### PR TITLE
Restore does and grinder settings from the existing shot data

### DIFF
--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -50,10 +50,9 @@ Dialog {
         profileTargetWeight = MainController.targetWeight
         temperatureValue = Settings.hasTemperatureOverride ? Settings.temperatureOverride : profileTemperature
 
-        // Use active overrides if set, otherwise fall back to DYE/defaults
-        doseValue = Settings.hasBrewDoseOverride ? Settings.brewDoseOverride
-                  : (Settings.dyeBeanWeight > 0 ? Settings.dyeBeanWeight : 18.0)
-        grindSetting = Settings.hasBrewGrindOverride ? Settings.brewGrindOverride : Settings.dyeGrinderSetting
+        // Use DYE fields for dose and grind (source of truth)
+        doseValue = Settings.dyeBeanWeight > 0 ? Settings.dyeBeanWeight : 18.0
+        grindSetting = Settings.dyeGrinderSetting
         showScaleWarning = false
 
         // Yield: use override if set, otherwise use profile target weight
@@ -497,9 +496,7 @@ Dialog {
                 accessibleName: qsTr("Confirm brew settings")
                 onClicked: {
                     Settings.lastUsedRatio = root.ratio
-                    // Set grind setting and make it a guest bean (golden color)
                     Settings.dyeGrinderSetting = root.grindSetting
-                    Settings.selectedBeanPreset = -1  // Guest bean mode
                     // Use the new activateBrewWithOverrides method
                     MainController.activateBrewWithOverrides(
                         root.doseValue,

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -21,10 +21,8 @@ Text {
             return [Settings.dyeBeanBrand, Settings.dyeBeanType].filter(Boolean).join(" ")
         return ""
     }
-    property string grindSize: Settings.visualizerExtendedMetadata
-        ? (Settings.hasBrewGrindOverride ? Settings.brewGrindOverride : Settings.dyeGrinderSetting)
-        : ""
-    property double dose: Settings.hasBrewDoseOverride ? Settings.brewDoseOverride : Settings.dyeBeanWeight
+    property string grindSize: Settings.visualizerExtendedMetadata ? Settings.dyeGrinderSetting : ""
+    property double dose: Settings.dyeBeanWeight
     property double targetWeight: Settings.hasBrewYieldOverride ? Settings.brewYieldOverride : MainController.targetWeight
 
     text: {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -274,6 +274,7 @@ void MainController::setTargetWeight(double weight) {
 void MainController::activateBrewWithOverrides(double dose, double yield, double temperature, const QString& grind) {
     if (m_settings) {
         m_settings->setBrewDoseOverride(dose);
+        // Store dose and grind in DYE fields (source of truth)
         m_settings->setBrewYieldOverride(yield);
         m_settings->setBrewGrindOverride(grind);
         if (qAbs(temperature - m_currentProfile.espressoTemperature()) > 0.1) {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1014,24 +1014,10 @@ void Settings::applyBeanPreset(int index) {
     setDyeGrinderModel(preset.value("grinderModel").toString());
     setDyeGrinderSetting(preset.value("grinderSetting").toString());
 
-    // Clear all brew overrides - bean preset values take precedence
-    bool changed = false;
-    if (m_hasBrewGrindOverride) {
-        m_hasBrewGrindOverride = false;
-        m_brewGrindOverride.clear();
-        changed = true;
-    }
-    if (m_hasBrewDoseOverride) {
-        m_hasBrewDoseOverride = false;
-        m_brewDoseOverride = 0;
-        changed = true;
-    }
+    // Clear yield override - bean preset values take precedence for dose/grind
     if (m_hasBrewYieldOverride) {
         m_hasBrewYieldOverride = false;
         m_brewYieldOverride = 0;
-        changed = true;
-    }
-    if (changed) {
         emit brewOverridesChanged();
     }
 }
@@ -1964,20 +1950,6 @@ void Settings::clearTemperatureOverride() {
 }
 
 // Brew parameter overrides (session-only)
-double Settings::brewDoseOverride() const {
-    return m_brewDoseOverride;
-}
-
-void Settings::setBrewDoseOverride(double dose) {
-    m_brewDoseOverride = dose;
-    m_hasBrewDoseOverride = true;
-    emit brewOverridesChanged();
-}
-
-bool Settings::hasBrewDoseOverride() const {
-    return m_hasBrewDoseOverride;
-}
-
 double Settings::brewYieldOverride() const {
     return m_brewYieldOverride;
 }
@@ -1997,28 +1969,10 @@ bool Settings::hasBrewYieldOverride() const {
     return m_hasBrewYieldOverride;
 }
 
-QString Settings::brewGrindOverride() const {
-    return m_brewGrindOverride;
-}
-
-void Settings::setBrewGrindOverride(const QString& grind) {
-    m_brewGrindOverride = grind;
-    m_hasBrewGrindOverride = !grind.isEmpty();
-    emit brewOverridesChanged();
-}
-
-bool Settings::hasBrewGrindOverride() const {
-    return m_hasBrewGrindOverride;
-}
-
 void Settings::clearAllBrewOverrides() {
-    bool changed = m_hasBrewDoseOverride || m_hasBrewYieldOverride || m_hasBrewGrindOverride;
-    m_hasBrewDoseOverride = false;
-    m_brewDoseOverride = 0;
+    bool changed = m_hasBrewYieldOverride;
     m_hasBrewYieldOverride = false;
     m_brewYieldOverride = 0;
-    m_hasBrewGrindOverride = false;
-    m_brewGrindOverride.clear();
     if (changed) {
         emit brewOverridesChanged();
     }
@@ -2029,14 +1983,8 @@ QString Settings::brewOverridesToJson() const {
     if (m_hasTemperatureOverride) {
         obj["temperature"] = m_temperatureOverride;
     }
-    if (m_hasBrewDoseOverride) {
-        obj["dose"] = m_brewDoseOverride;
-    }
     if (m_hasBrewYieldOverride) {
         obj["yield"] = m_brewYieldOverride;
-    }
-    if (m_hasBrewGrindOverride) {
-        obj["grind"] = m_brewGrindOverride;
     }
     if (obj.isEmpty()) {
         return QString();
@@ -2051,14 +1999,8 @@ void Settings::applyBrewOverridesFromJson(const QString& json) {
     if (!doc.isObject()) return;
 
     QJsonObject obj = doc.object();
-    if (obj.contains("dose")) {
-        setBrewDoseOverride(obj["dose"].toDouble());
-    }
     if (obj.contains("yield")) {
         setBrewYieldOverride(obj["yield"].toDouble());
-    }
-    if (obj.contains("grind")) {
-        setBrewGrindOverride(obj["grind"].toString());
     }
     if (obj.contains("temperature")) {
         setTemperatureOverride(obj["temperature"].toDouble());

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -143,12 +143,8 @@ class Settings : public QObject {
     Q_PROPERTY(bool hasTemperatureOverride READ hasTemperatureOverride NOTIFY temperatureOverrideChanged)
 
     // Brew parameter overrides (session-only, for next shot)
-    Q_PROPERTY(double brewDoseOverride READ brewDoseOverride WRITE setBrewDoseOverride NOTIFY brewOverridesChanged)
-    Q_PROPERTY(bool hasBrewDoseOverride READ hasBrewDoseOverride NOTIFY brewOverridesChanged)
     Q_PROPERTY(double brewYieldOverride READ brewYieldOverride WRITE setBrewYieldOverride NOTIFY brewOverridesChanged)
     Q_PROPERTY(bool hasBrewYieldOverride READ hasBrewYieldOverride NOTIFY brewOverridesChanged)
-    Q_PROPERTY(QString brewGrindOverride READ brewGrindOverride WRITE setBrewGrindOverride NOTIFY brewOverridesChanged)
-    Q_PROPERTY(bool hasBrewGrindOverride READ hasBrewGrindOverride NOTIFY brewOverridesChanged)
 
     // Shot plan display settings
     Q_PROPERTY(bool showShotPlan READ showShotPlan WRITE setShowShotPlan NOTIFY showShotPlanChanged)
@@ -484,15 +480,9 @@ public:
     Q_INVOKABLE void clearTemperatureOverride();
 
     // Brew parameter overrides (session-only)
-    double brewDoseOverride() const;
-    void setBrewDoseOverride(double dose);
-    bool hasBrewDoseOverride() const;
     double brewYieldOverride() const;
     void setBrewYieldOverride(double yield);
     bool hasBrewYieldOverride() const;
-    QString brewGrindOverride() const;
-    void setBrewGrindOverride(const QString& grind);
-    bool hasBrewGrindOverride() const;
     void applyBrewOverridesFromJson(const QString& json);
     Q_INVOKABLE void clearAllBrewOverrides();
     Q_INVOKABLE QString brewOverridesToJson() const;
@@ -644,10 +634,6 @@ private:
     bool m_hasTemperatureOverride = false;  // Session-only
 
     // Brew parameter overrides (session-only)
-    double m_brewDoseOverride = 0;
-    bool m_hasBrewDoseOverride = false;
     double m_brewYieldOverride = 0;
     bool m_hasBrewYieldOverride = false;
-    QString m_brewGrindOverride;
-    bool m_hasBrewGrindOverride = false;
 };


### PR DESCRIPTION
This fixes a issue when restoring the shot plan from history where the does and grind settings where not properly loaded