### PR TITLE
Fix profile editor scroll reset on built-in profile star toggle

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -493,9 +493,6 @@ QVariantList MainController::selectedProfiles() const {
 QVariantList MainController::allBuiltInProfiles() const {
     QVariantList result;
 
-    // Get selected built-in profile names from settings
-    QStringList selectedBuiltIns = m_settings ? m_settings->selectedBuiltInProfiles() : QStringList();
-
     for (const ProfileInfo& info : m_allProfiles) {
         if (info.source == ProfileSource::BuiltIn) {
             QVariantMap profile;
@@ -503,7 +500,6 @@ QVariantList MainController::allBuiltInProfiles() const {
             profile["title"] = info.title;
             profile["beverageType"] = info.beverageType;
             profile["source"] = static_cast<int>(info.source);
-            profile["isSelected"] = selectedBuiltIns.contains(info.filename);
             profile["isRecipeMode"] = info.isRecipeMode;
             result.append(profile);
         }
@@ -1220,6 +1216,7 @@ void MainController::refreshProfiles() {
     }
 
     emit profilesChanged();
+    emit allBuiltInProfileListChanged();
 }
 
 void MainController::uploadCurrentProfile() {
@@ -1595,6 +1592,7 @@ void MainController::createNewProfileWithEditorType(EditorType type, const QStri
     emit profileModifiedChanged();
     emit targetWeightChanged();
     emit profilesChanged();
+    emit allBuiltInProfileListChanged();
 
     uploadCurrentProfile();
     qDebug() << "Created new" << editorTypeToString(type) << "profile:" << title;

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -60,7 +60,7 @@ class MainController : public QObject {
     Q_PROPERTY(double brewByRatio READ brewByRatio NOTIFY targetWeightChanged)
     Q_PROPERTY(QVariantList availableProfiles READ availableProfiles NOTIFY profilesChanged)
     Q_PROPERTY(QVariantList selectedProfiles READ selectedProfiles NOTIFY profilesChanged)
-    Q_PROPERTY(QVariantList allBuiltInProfiles READ allBuiltInProfiles NOTIFY profilesChanged)
+    Q_PROPERTY(QVariantList allBuiltInProfiles READ allBuiltInProfiles NOTIFY allBuiltInProfileListChanged)
     Q_PROPERTY(QVariantList cleaningProfiles READ cleaningProfiles NOTIFY profilesChanged)
     Q_PROPERTY(QVariantList downloadedProfiles READ downloadedProfiles NOTIFY profilesChanged)
     Q_PROPERTY(QVariantList userCreatedProfiles READ userCreatedProfiles NOTIFY profilesChanged)
@@ -239,6 +239,7 @@ signals:
     void profileModifiedChanged();
     void targetWeightChanged();
     void profilesChanged();
+    void allBuiltInProfileListChanged();
     void sawSettlingChanged();
 
     // Accessibility: emitted when extraction frame changes


### PR DESCRIPTION
## Summary
- Fix ListView scrolling to top when clicking select/unselect stars on the "Decent Built-in" page in the profile editor
- Root cause: `allBuiltInProfiles` shared the `profilesChanged` NOTIFY signal with `selectedProfiles`, so toggling selection reassigned the entire model
- Give `allBuiltInProfiles` its own `allBuiltInProfileListChanged` signal, emitted only when profiles are actually added/removed
- Remove unused `isSelected` field from model data (delegate already computes it via Settings binding)

## Test plan
- [ ] Open profile editor → "Decent Built-in" tab
- [ ] Scroll down and click a star to select/unselect a profile
- [ ] Verify the list stays at the same scroll position
- [ ] Verify the star visual updates correctly
- [ ] Switch to "Selected" tab and verify selected profiles still appear/disappear correctly
- [ ] Create a new profile and verify it appears in the built-in list

🤖 Generated with [Claude Code](https://claude.com/claude-code)