### PR TITLE
Prevent SAW auto-tuning regression after convergence

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -568,7 +568,7 @@ public:
     // SAW (Stop-at-Weight) learning
     double sawLearnedLag() const;  // Average lag for display in QML (calculated from drip/flow)
     double getExpectedDrip(double currentFlowRate) const;  // Predicts drip based on flow and history
-    void addSawLearningPoint(double drip, double flowRate, const QString& scaleType);
+    void addSawLearningPoint(double drip, double flowRate, const QString& scaleType, double overshoot);
     Q_INVOKABLE void resetSawLearning();
 
     // Layout configuration (dynamic IdlePage layout)
@@ -707,6 +707,9 @@ private:
     QJsonObject getLayoutObject() const;
     void saveLayoutObject(const QJsonObject& layout);
     QString generateItemId(const QString& type) const;
+
+    // SAW convergence detection helper
+    bool isSawConverged(const QString& scaleType) const;
 
     QSettings m_settings;
     mutable QJsonObject m_layoutCache;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
     QObject::connect(&timingController, &ShotTimingController::sawLearningComplete,
                      [&settings](double drip, double flowAtStop, double overshoot) {
                          QString scaleType = settings.scaleType();
-                         settings.addSawLearningPoint(drip, flowAtStop, scaleType);
+                         settings.addSawLearningPoint(drip, flowAtStop, scaleType, overshoot);
                          qDebug() << "[SAW] Learning point saved: drip=" << drip
                                   << "flow=" << flowAtStop << "overshoot=" << overshoot
                                   << "scale=" << scaleType;


### PR DESCRIPTION
## Summary

- Store overshoot value with each SAW learning point (enables convergence detection)
- Adaptive learning rate: use 20 entries with flat recency weights (10→5) when converged vs 10 entries with steep weights (10→1) when adapting — reduces single-shot impact from ~19% to ~5%
- Outlier rejection: skip learning points that deviate too far from prediction when converged (`|drip - expected| > max(3.0, expected)`)
- Validate drip/flow values to reject scale glitches (negative values)

## Test plan

- [ ] Build in Qt Creator
- [ ] Pull shots and check `[SAW]` debug logs for overshoot values in learning points
- [ ] After convergence (3+ shots with low overshoot), verify outlier rejection logs for bad shots
- [ ] Reset SAW learning, verify system converges normally with steep weights
- [ ] After convergence, verify expected drip remains stable despite occasional bad shots

🤖 Generated with [Claude Code](https://claude.com/claude-code)