### PR TITLE
Fix popups appearing above screensaver causing burn-in

### DIFF
--- a/src/core/updatechecker.h
+++ b/src/core/updatechecker.h
@@ -88,6 +88,7 @@ private:
     bool m_downloading = false;
     int m_downloadProgress = 0;
     bool m_updateAvailable = false;
+    bool m_updatePromptShown = false;  // Only emit updatePromptRequested once per update
     QString m_latestVersion;
     QString m_releaseNotes;
     QString m_downloadUrl;


### PR DESCRIPTION
## Summary
- Prevent popups (update dialog, BLE errors, etc.) from appearing above the screensaver, which could cause screen burn-in on tablets left idle for hours
- The periodic update check was emitting `updatePromptRequested` on every hourly check while `m_updateAvailable` was true, eventually opening the popup above the active screensaver

## Changes

**C++ (UpdateChecker):**
- Add `m_updatePromptShown` flag so `updatePromptRequested` emits only once per new version discovery, not on every periodic check
- Reset flag when a new release tag is detected in `parseReleaseInfo()`
- User dismiss ("Later") keeps flag set — no re-prompt for same version
- Screensaver dismiss bypasses the flag entirely (uses QML queue)

**QML (main.qml):**
- Add `screensaverActive` guard to `showNextPendingPopup()` as safety net
- Close any open popups in `goToScreensaver()` and re-queue them in `pendingPopups` for display after wake
- Preserve `bleErrorDialog` params (errorMessage, isLocationError, isBluetoothError) when re-queuing

## Test plan
- [ ] Leave app idle until screensaver activates, verify no popups appear above it
- [ ] If update is available: verify popup appears after waking from screensaver
- [ ] Dismiss update with "Later", verify it doesn't re-appear on next hourly check
- [ ] Trigger a BLE error, let screensaver activate, wake — verify error dialog shows with correct message
- [ ] Verify normal popup flow still works when screensaver is not active

🤖 Generated with [Claude Code](https://claude.com/claude-code)