### PR TITLE
Fix false temperature override after recipe editor changes

### DIFF
--- a/qml/components/layout/items/TemperatureItem.qml
+++ b/qml/components/layout/items/TemperatureItem.qml
@@ -11,6 +11,8 @@ Item {
     readonly property double effectiveTargetTemp: Settings.hasTemperatureOverride
         ? Settings.temperatureOverride
         : MainController.profileTargetTemperature
+    readonly property bool isRealOverride: Settings.hasTemperatureOverride &&
+        Math.abs(Settings.temperatureOverride - MainController.profileTargetTemperature) > 0.1
 
     implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
     implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
@@ -18,7 +20,7 @@ Item {
     Accessible.role: Accessible.StaticText
     Accessible.name: {
         var text = "Group temperature: " + DE1Device.temperature.toFixed(1) + " degrees, target: " + root.effectiveTargetTemp.toFixed(0) + " degrees"
-        if (Settings.hasTemperatureOverride) text += " (override active)"
+        if (root.isRealOverride) text += " (override active)"
         return text
     }
     Accessible.focusable: true
@@ -47,7 +49,7 @@ Item {
                 MachineState.tareScale()
                 if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
                     var announcement = "Group temperature: " + DE1Device.temperature.toFixed(1) + " degrees, target: " + root.effectiveTargetTemp.toFixed(0) + " degrees"
-                    if (Settings.hasTemperatureOverride) announcement += " (override active)"
+                    if (root.isRealOverride) announcement += " (override active)"
                     AccessibilityManager.announceLabel(announcement)
                 }
             }
@@ -79,7 +81,7 @@ Item {
                 Text {
                     anchors.baseline: parent.children[0].baseline
                     text: "/ " + root.effectiveTargetTemp.toFixed(1) + "\u00B0C"
-                    color: Settings.hasTemperatureOverride ? Theme.primaryColor : Theme.textSecondaryColor
+                    color: root.isRealOverride ? Theme.primaryColor : Theme.textSecondaryColor
                     font.family: Theme.valueFont.family
                     font.pixelSize: Theme.valueFont.pixelSize / 2
                     Accessible.ignored: true
@@ -97,7 +99,7 @@ Item {
                     Accessible.ignored: true
                 }
                 Text {
-                    visible: Settings.hasTemperatureOverride
+                    visible: root.isRealOverride
                     text: "(override)"
                     color: Theme.primaryColor
                     font: Theme.labelFont
@@ -111,7 +113,7 @@ Item {
             onClicked: {
                 if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
                     var announcement = "Group temperature: " + DE1Device.temperature.toFixed(1) + " degrees, target: " + root.effectiveTargetTemp.toFixed(0) + " degrees"
-                    if (Settings.hasTemperatureOverride) announcement += " (override active)"
+                    if (root.isRealOverride) announcement += " (override active)"
                     AccessibilityManager.announceLabel(announcement)
                 }
             }

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1535,6 +1535,12 @@ void MainController::uploadRecipeProfile(const QVariantMap& recipeParams) {
     m_currentProfile.setRecipeParams(recipe);
     m_currentProfile.regenerateFromRecipe();
 
+    // Sync temperature override so uploadCurrentProfile doesn't apply wrong delta
+    // and shot plan text shows correct temperature (not stale override)
+    if (m_settings) {
+        m_settings->setTemperatureOverride(m_currentProfile.espressoTemperature());
+    }
+
     // Mark as modified
     if (!m_profileModified) {
         m_profileModified = true;


### PR DESCRIPTION
## Summary
- Fix `uploadRecipeProfile()` missing `setTemperatureOverride()` sync — after changing temperature in the recipe editor, the stale override caused wrong delta applied to machine frames and the shot plan showing an incorrect arrow (e.g., "84 → 91°C")
- Fix `TemperatureItem` showing "(override)" label whenever `hasTemperatureOverride` is true, which is always true after any profile load. Now only shows when the override actually differs from the profile temperature (>0.1°C), matching `ShotPlanText`'s existing logic

## Test plan
- [ ] Change temperature in recipe editor, save profile → shot plan should show just the new temp (no arrow)
- [ ] Change temperature in recipe editor, save profile → idle screen should show "Group Temp" without "(override)"
- [ ] Set a real override via BrewDialog (different from profile temp) → "(override)" label and arrow should appear
- [ ] Clear overrides → "(override)" label and arrow should disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)