### PR TITLE
Improve Auto-Favorites with editable brew fields

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -19,6 +19,9 @@ ApplicationWindow {
     // Debug flag to force live view on operation pages (for development)
     property bool debugLiveView: false
 
+    // Flag to open BrewDialog when IdlePage becomes active (set by AutoFavoritesPage)
+    property bool pendingBrewDialog: false
+
     // True while the first-run restore dialog is active (prevents SettingsDataTab from also handling restore signals)
 
     // Global accessibility: find closest Text within radius of tap

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -12,6 +12,10 @@ Page {
 
     StackView.onActivated: {
         root.currentPageTitle = "Idle"
+        if (root.pendingBrewDialog) {
+            root.pendingBrewDialog = false
+            idleBrewDialog.open()
+        }
     }
 
     // Secret developer mode: hold top-right corner for 5 seconds to simulate a completed shot

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -2029,6 +2029,28 @@ void Settings::setAutoFavoritesMaxItems(int maxItems) {
     }
 }
 
+bool Settings::autoFavoritesOpenBrewSettings() const {
+    return m_settings.value("autoFavorites/openBrewSettings", false).toBool();
+}
+
+void Settings::setAutoFavoritesOpenBrewSettings(bool open) {
+    if (autoFavoritesOpenBrewSettings() != open) {
+        m_settings.setValue("autoFavorites/openBrewSettings", open);
+        emit autoFavoritesOpenBrewSettingsChanged();
+    }
+}
+
+bool Settings::autoFavoritesHideUnrated() const {
+    return m_settings.value("autoFavorites/hideUnrated", false).toBool();
+}
+
+void Settings::setAutoFavoritesHideUnrated(bool hide) {
+    if (autoFavoritesHideUnrated() != hide) {
+        m_settings.setValue("autoFavorites/hideUnrated", hide);
+        emit autoFavoritesHideUnratedChanged();
+    }
+}
+
 bool Settings::autoCheckUpdates() const {
     return m_settings.value("updates/autoCheck", true).toBool();
 }

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -132,6 +132,8 @@ class Settings : public QObject {
     // Auto-favorites settings
     Q_PROPERTY(QString autoFavoritesGroupBy READ autoFavoritesGroupBy WRITE setAutoFavoritesGroupBy NOTIFY autoFavoritesGroupByChanged)
     Q_PROPERTY(int autoFavoritesMaxItems READ autoFavoritesMaxItems WRITE setAutoFavoritesMaxItems NOTIFY autoFavoritesMaxItemsChanged)
+    Q_PROPERTY(bool autoFavoritesOpenBrewSettings READ autoFavoritesOpenBrewSettings WRITE setAutoFavoritesOpenBrewSettings NOTIFY autoFavoritesOpenBrewSettingsChanged)
+    Q_PROPERTY(bool autoFavoritesHideUnrated READ autoFavoritesHideUnrated WRITE setAutoFavoritesHideUnrated NOTIFY autoFavoritesHideUnratedChanged)
 
     // Auto-update settings
     Q_PROPERTY(bool autoCheckUpdates READ autoCheckUpdates WRITE setAutoCheckUpdates NOTIFY autoCheckUpdatesChanged)
@@ -500,6 +502,10 @@ public:
     void setAutoFavoritesGroupBy(const QString& groupBy);
     int autoFavoritesMaxItems() const;
     void setAutoFavoritesMaxItems(int maxItems);
+    bool autoFavoritesOpenBrewSettings() const;
+    void setAutoFavoritesOpenBrewSettings(bool open);
+    bool autoFavoritesHideUnrated() const;
+    void setAutoFavoritesHideUnrated(bool hide);
 
     // Auto-update settings
     bool autoCheckUpdates() const;
@@ -699,6 +705,8 @@ signals:
     void shotServerPortChanged();
     void autoFavoritesGroupByChanged();
     void autoFavoritesMaxItemsChanged();
+    void autoFavoritesOpenBrewSettingsChanged();
+    void autoFavoritesHideUnratedChanged();
     void autoCheckUpdatesChanged();
     void betaUpdatesEnabledChanged();
     void dailyBackupHourChanged();


### PR DESCRIPTION
## Summary
- **BrewDialog**: Replace static recipe info box with editable SuggestionFields for profile, bean brand, and bean type. Profile selection loads temperature and target weight. Bean info saved back to Settings on confirm.
- **AutoFavoritesPage**: Combine bean/profile/grinder into a single Flow row that wraps on small screens. Add "Hide unrated favorites" and "Open brew settings after load" toggle settings. Bump recipe summary fonts from caption to label size.
- **IdlePage**: Auto-open BrewDialog after loading a favorite (when setting enabled) via `pendingBrewDialog` flag

## Test plan
- [ ] Open BrewDialog → verify profile, bean brand, and bean type fields are editable with suggestions
- [ ] Change profile in BrewDialog → verify temperature and target weight update
- [ ] Confirm brew → verify bean brand/type saved to Settings
- [ ] Auto-Favorites → verify combined bean/profile/grinder row displays correctly
- [ ] Auto-Favorites on narrow screen → verify row wraps to second line
- [ ] Toggle "Hide unrated favorites" → verify unrated entries hidden/shown
- [ ] Toggle "Open brew settings after load" → verify BrewDialog opens after loading a favorite
- [ ] Load favorite without "Open brew settings" → verify no BrewDialog popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)