### PR TITLE
Improve offline mode restart warning

### DIFF
--- a/qml/pages/settings/SettingsOptionsTab.qml
+++ b/qml/pages/settings/SettingsOptionsTab.qml
@@ -93,15 +93,15 @@ KeyboardAwareContainer {
                             onToggled: {
                                 // Save to persistent Settings — takes effect on next launch
                                 Settings.simulationMode = checked
-                                restartRequiredText.visible = true
                             }
                         }
                     }
 
-                    Text {
+                    Tr {
                         id: restartRequiredText
-                        visible: false
-                        text: "Restart required for this change to take effect"
+                        visible: Settings.simulationMode !== DE1Device.simulationMode
+                        key: "settings.preferences.restartRequired"
+                        fallback: "Restart required for this change to take effect"
                         color: Theme.warningColor
                         font.pixelSize: Theme.scaled(12)
                         Layout.leftMargin: Theme.scaled(15)

--- a/qml/pages/settings/SettingsPreferencesTab.qml
+++ b/qml/pages/settings/SettingsPreferencesTab.qml
@@ -309,15 +309,15 @@ KeyboardAwareContainer {
                                 onToggled: {
                                     // Save to persistent Settings — takes effect on next launch
                                     Settings.simulationMode = checked
-                                    restartRequiredText.visible = true
                                 }
                             }
                         }
 
-                        Text {
+                        Tr {
                             id: restartRequiredText
-                            visible: false
-                            text: "Restart required for this change to take effect"
+                            visible: Settings.simulationMode !== DE1Device.simulationMode
+                            key: "settings.preferences.restartRequired"
+                            fallback: "Restart required for this change to take effect"
                             color: Theme.warningColor
                             font.pixelSize: Theme.scaled(12)
                             Layout.leftMargin: Theme.scaled(15)


### PR DESCRIPTION
## Summary
- Replace imperative `visible = true` with declarative binding (`Settings.simulationMode !== DE1Device.simulationMode`) so the restart warning persists across page navigation and hides when toggled back to match runtime state
- Switch from `Text` to `Tr` for translatability
- Applied to both `SettingsOptionsTab.qml` and `SettingsPreferencesTab.qml`

## Test plan
- [ ] Toggle offline mode ON when it's OFF at runtime — warning appears
- [ ] Toggle offline mode OFF when it's ON at runtime — warning appears
- [ ] Toggle it back to match runtime state — warning disappears
- [ ] Navigate away from settings and back — warning still visible if mismatch exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)