### PR TITLE
Fix shot detail graph not visible on Android

### DIFF
--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -14,6 +14,8 @@ Page {
     // Shot navigation - list of shot IDs to swipe through
     property var shotIds: []  // Array of shot IDs (chronological order)
     property int currentIndex: -1  // Current position in shotIds
+    // Persisted graph height (like PostShotReviewPage)
+    property real graphHeight: Settings.value("shotDetail/graphHeight", Theme.scaled(250))
 
     Component.onCompleted: {
         root.currentPageTitle = TranslationManager.translate("shotdetail.title", "Shot Detail")
@@ -124,9 +126,6 @@ Page {
             }
 
             // Resizable graph with swipe navigation
-            // Persisted graph height (like PostShotReviewPage)
-            property real graphHeight: Settings.value("shotDetail/graphHeight", Theme.scaled(250))
-
             Rectangle {
                 id: graphCard
                 Layout.fillWidth: true


### PR DESCRIPTION
## Summary
- The `graphHeight` property was defined on the inner `ColumnLayout` but referenced as `shotDetailPage.graphHeight` (the `Page`), resolving to `undefined` and making the graph card height `NaN`/0
- Moved the property to the Page scope to match how `PostShotReviewPage` does it

## Test plan
- [ ] Open a shot from shot history on Android
- [ ] Verify the graph is visible between the date and navigation buttons
- [ ] Verify graph resize drag handle still works
- [ ] Verify swipe navigation between shots still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)