### PR TITLE
Unify BLE health refresh setting and move toggle to Bluetooth tab

### DIFF
--- a/qml/pages/settings/SettingsBluetoothTab.qml
+++ b/qml/pages/settings/SettingsBluetoothTab.qml
@@ -297,6 +297,57 @@ Item {
                         }
                     }
                 }
+
+                // BLE health refresh
+                Rectangle {
+                    Layout.fillWidth: true
+                    implicitHeight: bleHealthContent.implicitHeight + Theme.scaled(16)
+                    color: Qt.darker(Theme.surfaceColor, 1.1)
+                    radius: Theme.scaled(6)
+                    border.color: Theme.borderColor
+                    border.width: 1
+
+                    ColumnLayout {
+                        id: bleHealthContent
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        anchors.margins: Theme.scaled(10)
+                        spacing: Theme.scaled(6)
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: Theme.scaled(8)
+
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: Theme.scaled(1)
+
+                                Tr {
+                                    key: "settings.preferences.bleHealthRefresh"
+                                    fallback: "BLE health refresh"
+                                    color: Theme.textColor
+                                    font.pixelSize: Theme.scaled(13)
+                                }
+
+                                Tr {
+                                    Layout.fillWidth: true
+                                    key: "settings.preferences.bleHealthRefreshDesc"
+                                    fallback: "Cycle all Bluetooth connections on wake and periodically to prevent long-uptime BLE degradation"
+                                    color: Theme.textSecondaryColor
+                                    font.pixelSize: Theme.scaled(11)
+                                    wrapMode: Text.WordWrap
+                                }
+                            }
+
+                            StyledSwitch {
+                                checked: Settings.bleHealthRefreshEnabled
+                                accessibleName: TranslationManager.translate("settings.preferences.bleHealthRefresh", "BLE health refresh")
+                                onToggled: Settings.bleHealthRefreshEnabled = checked
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -585,6 +636,7 @@ Item {
                         }
                     }
                 }
+
             }
         }
     }

--- a/qml/pages/settings/SettingsPreferencesTab.qml
+++ b/qml/pages/settings/SettingsPreferencesTab.qml
@@ -81,56 +81,6 @@ KeyboardAwareContainer {
                     }
                 }
 
-                // Reset BLE on wake
-                Rectangle {
-                    Layout.fillWidth: true
-                    implicitHeight: bleResetContent.implicitHeight + Theme.scaled(30)
-                    color: Theme.surfaceColor
-                    radius: Theme.cardRadius
-
-                    ColumnLayout {
-                        id: bleResetContent
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        anchors.top: parent.top
-                        anchors.margins: Theme.scaled(15)
-                        spacing: Theme.scaled(10)
-
-                        RowLayout {
-                            Layout.fillWidth: true
-                            spacing: Theme.scaled(8)
-
-                            ColumnLayout {
-                                spacing: Theme.scaled(1)
-
-                                Tr {
-                                    key: "settings.preferences.resetBleOnWake"
-                                    fallback: "Reset BLE connection on wake"
-                                    color: Theme.textColor
-                                    font.pixelSize: Theme.scaled(14)
-                                }
-
-                                Tr {
-                                    Layout.fillWidth: true
-                                    key: "settings.preferences.resetBleOnWakeDesc"
-                                    fallback: "Cycle all Bluetooth connections when the machine wakes from sleep"
-                                    color: Theme.textSecondaryColor
-                                    font.pixelSize: Theme.scaled(11)
-                                    wrapMode: Text.WordWrap
-                                }
-                            }
-
-                            Item { Layout.fillWidth: true }
-
-                            StyledSwitch {
-                                checked: Settings.resetBleOnWake
-                                accessibleName: TranslationManager.translate("settings.preferences.resetBleOnWake", "Reset BLE connection on wake")
-                                onToggled: Settings.resetBleOnWake = checked
-                            }
-                        }
-                    }
-                }
-
                 // Refill Kit
                 Rectangle {
                     Layout.fillWidth: true

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -2031,14 +2031,20 @@ void Settings::setAutoFavoritesMaxItems(int maxItems) {
     }
 }
 
-bool Settings::resetBleOnWake() const {
+bool Settings::bleHealthRefreshEnabled() const {
+    // Migration path: keep honoring legacy key if new key is not yet present.
+    if (m_settings.contains("ble/healthRefreshEnabled")) {
+        return m_settings.value("ble/healthRefreshEnabled", false).toBool();
+    }
     return m_settings.value("ble/resetOnWake", false).toBool();
 }
 
-void Settings::setResetBleOnWake(bool enabled) {
-    if (resetBleOnWake() != enabled) {
+void Settings::setBleHealthRefreshEnabled(bool enabled) {
+    if (bleHealthRefreshEnabled() != enabled) {
+        m_settings.setValue("ble/healthRefreshEnabled", enabled);
+        // Keep legacy key in sync for downgrade compatibility.
         m_settings.setValue("ble/resetOnWake", enabled);
-        emit resetBleOnWakeChanged();
+        emit bleHealthRefreshEnabledChanged();
     }
 }
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -136,7 +136,7 @@ class Settings : public QObject {
     Q_PROPERTY(bool autoFavoritesHideUnrated READ autoFavoritesHideUnrated WRITE setAutoFavoritesHideUnrated NOTIFY autoFavoritesHideUnratedChanged)
 
     // BLE settings
-    Q_PROPERTY(bool resetBleOnWake READ resetBleOnWake WRITE setResetBleOnWake NOTIFY resetBleOnWakeChanged)
+    Q_PROPERTY(bool bleHealthRefreshEnabled READ bleHealthRefreshEnabled WRITE setBleHealthRefreshEnabled NOTIFY bleHealthRefreshEnabledChanged)
 
     // Auto-update settings
     Q_PROPERTY(bool autoCheckUpdates READ autoCheckUpdates WRITE setAutoCheckUpdates NOTIFY autoCheckUpdatesChanged)
@@ -511,8 +511,8 @@ public:
     void setAutoFavoritesHideUnrated(bool hide);
 
     // BLE settings
-    bool resetBleOnWake() const;
-    void setResetBleOnWake(bool enabled);
+    bool bleHealthRefreshEnabled() const;
+    void setBleHealthRefreshEnabled(bool enabled);
 
     // Auto-update settings
     bool autoCheckUpdates() const;
@@ -712,7 +712,7 @@ signals:
     void shotServerPortChanged();
     void autoFavoritesGroupByChanged();
     void autoFavoritesMaxItemsChanged();
-    void resetBleOnWakeChanged();
+    void bleHealthRefreshEnabledChanged();
     void autoFavoritesOpenBrewSettingsChanged();
     void autoFavoritesHideUnratedChanged();
     void autoCheckUpdatesChanged();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -259,8 +259,8 @@ int main(int argc, char *argv[])
     });
     autoWakeManager.start();
 
-    // BLE health refresh - cycles BLE connections on wake from sleep (and every 5 hours)
-    // to prevent Android Bluetooth stack degradation over long uptimes
+    // BLE health refresh (settings-controlled) - cycles BLE connections on wake from
+    // sleep and every 5 hours to prevent long-uptime Android Bluetooth degradation.
     BleRefresher bleRefresher(&de1Device, &bleManager, &machineState, &settings);
     bleRefresher.startPeriodicRefresh(5);
 


### PR DESCRIPTION
## Summary
- rename BLE refresh setting to bleHealthRefreshEnabled
- gate both wake-triggered and periodic BLE refresh behind the same setting
- keep backward compatibility by reading/writing legacy ble/resetOnWake
- move the BLE health refresh toggle from Preferences to the Bluetooth page (machine side)

## Notes
- periodic refresh still avoids running while machine is sleeping to prevent unintended wake-ups
