### PR TITLE
Fix BLE refresh overlay stuck forever

### DIFF
--- a/src/ble/blerefresher.h
+++ b/src/ble/blerefresher.h
@@ -56,11 +56,9 @@ private:
     // Temporary connections for event-driven sequencing
     QMetaObject::Connection m_phaseConn;
     QMetaObject::Connection m_de1ConnConn;
-
-    QTimer m_refreshTimeout;
+    QMetaObject::Connection m_scanConn;
 
     static constexpr int MIN_REFRESH_INTERVAL_MS = 60 * 60 * 1000;  // 60 minute debounce
-    static constexpr int REFRESH_TIMEOUT_MS = 30000;  // 30s safety timeout for reconnection
 };
 
 #endif // BLEREFRESHER_H


### PR DESCRIPTION
## Summary
- Skip BLE refresh entirely in simulation mode — no real BLE stack to reset, and `isConnected()` always returns `true` so the disconnect/reconnect sequence can never complete
- Add 30-second safety timeout for real DE1 reconnection failures (out of range, powered off, BLE stack crash) so the "Refreshing Bluetooth..." overlay doesn't stay stuck forever

## Test plan
- [ ] In simulation mode: trigger a BLE refresh (wake from sleep with `resetBleOnWake` enabled) — should log "Skipping refresh" and not show overlay
- [ ] With real DE1: trigger refresh, turn off DE1 during refresh — overlay should disappear after 30s
- [ ] With real DE1: normal refresh (DE1 stays on) — should complete quickly, timeout never fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)