### PR TITLE
Fix location permissions on macOS and iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,10 +372,11 @@ if(ENABLE_QUICK3D AND Qt6Quick3D_FOUND)
     )
 endif()
 
-# iOS/macOS: Use Darwin multimedia plugin (AVFoundation-based)
+# iOS/macOS: Use Darwin multimedia and location permission plugins
 if(IOS OR APPLE)
     qt_import_plugins(Decenza_DE1
         INCLUDE_BY_TYPE multimedia Qt6::QDarwinMediaPlugin
+        INCLUDE_BY_TYPE permissions Qt6::QDarwinLocationPermissionPlugin
     )
 endif()
 

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -42,6 +42,10 @@
     </array>
     <key>NSBluetoothAlwaysUsageDescription</key>
     <string>This app uses Bluetooth to connect to your DE1 espresso machine and scales.</string>
+    <key>NSLocationUsageDescription</key>
+    <string>This app uses your location to show where your espresso shots were made on the shot map.</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>This app uses your location to show where your espresso shots were made on the shot map.</string>
     <key>NSBluetoothPeripheralUsageDescription</key>
     <string>This app uses Bluetooth to connect to your DE1 espresso machine and scales.</string>
     <key>NSCameraUsageDescription</key>

--- a/macos/Decenza_DE1.entitlements
+++ b/macos/Decenza_DE1.entitlements
@@ -4,5 +4,7 @@
 <dict>
     <key>com.apple.security.device.bluetooth</key>
     <true/>
+    <key>com.apple.security.personal-information.location</key>
+    <true/>
 </dict>
 </plist>

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -20,6 +20,8 @@
     <string>1</string>
     <key>NSBluetoothAlwaysUsageDescription</key>
     <string>This app uses Bluetooth to connect to your DE1 espresso machine and scales.</string>
+    <key>NSLocationUsageDescription</key>
+    <string>This app uses your location to show where your espresso shots were made on the shot map.</string>
     <key>NSHighResolutionCapable</key>
     <true/>
 </dict>

--- a/qml/pages/settings/SettingsPreferencesTab.qml
+++ b/qml/pages/settings/SettingsPreferencesTab.qml
@@ -402,21 +402,48 @@ KeyboardAwareContainer {
 
                         // Location status (only when enabled)
                         Text {
+                            Layout.fillWidth: true
                             visible: MainController.shotReporter && MainController.shotReporter.enabled
+                                 && MainController.shotReporter.hasLocation
                             text: {
                                 if (!MainController.shotReporter) return ""
-                                if (MainController.shotReporter.hasLocation) {
-                                    var city = MainController.shotReporter.currentCity()
-                                    var country = MainController.shotReporter.currentCountryCode()
-                                    var prefix = MainController.shotReporter.usingManualCity ? "Manual: " : "GPS: "
-                                    var lat = MainController.shotReporter.latitude.toFixed(1)
-                                    var lon = MainController.shotReporter.longitude.toFixed(1)
-                                    return prefix + city + (country ? ", " + country : "") + " (" + lat + ", " + lon + ")"
-                                }
-                                return "GPS disabled - enable in Android Settings"
+                                var city = MainController.shotReporter.currentCity()
+                                var country = MainController.shotReporter.currentCountryCode()
+                                var prefix = MainController.shotReporter.usingManualCity ? "Manual: " : "GPS: "
+                                var lat = MainController.shotReporter.latitude.toFixed(1)
+                                var lon = MainController.shotReporter.longitude.toFixed(1)
+                                return prefix + city + (country ? ", " + country : "") + " (" + lat + ", " + lon + ")"
                             }
-                            color: MainController.shotReporter && MainController.shotReporter.hasLocation ? Theme.textColor : Theme.textSecondaryColor
+                            color: Theme.textColor
                             font.pixelSize: Theme.scaled(12)
+                            wrapMode: Text.WordWrap
+                        }
+
+                        // Location unavailable - clickable to request permission / open settings
+                        Text {
+                            Layout.fillWidth: true
+                            visible: MainController.shotReporter && MainController.shotReporter.enabled
+                                 && !MainController.shotReporter.hasLocation
+                            text: Qt.platform.os === "android"
+                                  ? "GPS disabled - tap to open Settings"
+                                  : "No location - tap to enable"
+                            color: Theme.primaryColor
+                            font.pixelSize: Theme.scaled(12)
+                            font.underline: true
+                            wrapMode: Text.WordWrap
+
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    if (!MainController.shotReporter) return
+                                    // refreshLocation() handles the permission prompt on macOS/iOS;
+                                    // openLocationSettings() is for Android (GPS system toggle)
+                                    MainController.shotReporter.refreshLocation()
+                                    if (Qt.platform.os === "android")
+                                        MainController.shotReporter.openLocationSettings()
+                                }
+                            }
                         }
 
                         // Manual city input (shown when enabled)
@@ -448,10 +475,17 @@ KeyboardAwareContainer {
                                 }
 
                                 AccessibleButton {
-                                    text: "Test"
-                                    accessibleName: TranslationManager.translate("settings.options.testLocation", "Test location on shot map")
-                                    enabled: MainController.shotReporter && MainController.shotReporter.hasLocation
-                                    onClicked: mapTestPopup.open()
+                                    text: MainController.shotReporter && MainController.shotReporter.hasLocation ? "Test" : "Retry"
+                                    accessibleName: MainController.shotReporter && MainController.shotReporter.hasLocation
+                                        ? TranslationManager.translate("settings.options.testLocation", "Test location on shot map")
+                                        : "Retry location request"
+                                    onClicked: {
+                                        if (MainController.shotReporter && MainController.shotReporter.hasLocation) {
+                                            mapTestPopup.open()
+                                        } else if (MainController.shotReporter) {
+                                            MainController.shotReporter.refreshLocation()
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/network/locationprovider.h
+++ b/src/network/locationprovider.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QGeoPositionInfoSource>
+#include <QGuiApplication>
 #include <QNetworkAccessManager>
 #include <QTimer>
 
@@ -66,6 +67,7 @@ private slots:
     void onPositionUpdated(const QGeoPositionInfo& info);
     void onPositionError(QGeoPositionInfoSource::Error error);
     void onReverseGeocodeFinished(QNetworkReply* reply);
+    void onAppStateChanged(Qt::ApplicationState state);
 
 private:
     void reverseGeocode(double lat, double lon);


### PR DESCRIPTION
## Summary

- Fix location/GPS never working on macOS and iOS — showed "GPS disabled, enable in Android Settings" on all platforms
- Add proper Qt 6 permission flow (plist keys, entitlements, permission plugin, requestPermission() API)
- Improve UX with clickable "tap to enable" link and Retry button

## Changes

- **Info.plist** (macOS + iOS): Add `NSLocationUsageDescription` (required by Qt 6 permission plugin)
- **Entitlements** (macOS): Add `com.apple.security.personal-information.location` for sandbox
- **CMakeLists.txt**: Link `Qt6::QDarwinLocationPermissionPlugin` static plugin
- **LocationProvider**: Request `QLocationPermission` before using CoreLocation; auto-retry on app resume
- **QML**: Platform-appropriate status text, clickable link to trigger permission, Retry/Test button
- **openLocationSettings()**: Now opens System Settings on macOS, app settings on iOS

## Test plan
- [x] macOS: tap "No location - tap to enable" → permission prompt appears → location acquired
- [x] macOS: Retry button triggers location request after granting permission in System Settings
- [ ] iOS: same flow with permission prompt
- [ ] Android: existing GPS flow unchanged
- [ ] Verify layout doesn't overflow on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)