### PR TITLE
Add HTTPS and TOTP authenticator security for web access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,12 @@ if(IOS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x objective-c++")
 endif()
 
+# OpenSSL for HTTPS/TLS and WebAuthn signature verification
+# Android uses KDAB android_openssl (fetched above), other platforms use system OpenSSL
+if(NOT ANDROID)
+    find_package(OpenSSL REQUIRED)
+endif()
+
 # Address Sanitizer - enabled for single-config Debug builds (Makefiles, Ninja).
 # Multi-config generators (Visual Studio, Xcode) don't set CMAKE_BUILD_TYPE at
 # configure time, so flags would leak into Release builds. Android requires special
@@ -218,6 +224,7 @@ set(SOURCES
     src/network/shotserver_layout.cpp
     src/network/shotserver_theme.cpp
     src/network/shotserver_settings.cpp
+    src/network/shotserver_auth.cpp
     src/network/mqttclient.cpp
     src/network/webdebuglogger.cpp
     src/network/locationprovider.cpp
@@ -366,6 +373,11 @@ target_link_libraries(Decenza_DE1 PRIVATE
     paho-mqtt3a-static
 )
 
+# Link OpenSSL (non-Android; Android uses add_android_openssl_libraries below)
+if(NOT ANDROID)
+    target_link_libraries(Decenza_DE1 PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+endif()
+
 # Optionally link Quick3D and add 3D screensaver sources
 if(ENABLE_QUICK3D AND Qt6Quick3D_FOUND)
     target_link_libraries(Decenza_DE1 PRIVATE Qt6::Quick3D)
@@ -498,6 +510,8 @@ set(QML_FILES
     qml/components/CrtOverlay.qml
     qml/components/CrtShaderEffect.qml
     qml/components/ReportAdviceDialog.qml
+    qml/components/QrCode.qml
+    qml/components/qrcode.js
 
     qml/components/layout/LayoutItemDelegate.qml
     qml/components/layout/LayoutBarZone.qml

--- a/qml/components/QrCode.qml
+++ b/qml/components/QrCode.qml
@@ -1,0 +1,75 @@
+import QtQuick
+import "qrcode.js" as QR
+
+Item {
+    id: root
+
+    property string value: ""
+    property color foreground: "#000000"
+    property color background: "#ffffff"
+    property int quietZone: 4
+
+    // Internal: computed QR matrix
+    property var _matrix: null
+    property int _modules: 0
+
+    onValueChanged: _rebuild()
+    Component.onCompleted: _rebuild()
+
+    function _rebuild() {
+        if (!value) {
+            _matrix = null;
+            _modules = 0;
+            return;
+        }
+        var m = QR.generate(value);
+        if (!m) {
+            _matrix = null;
+            _modules = 0;
+            return;
+        }
+        _modules = m.length;
+        // Flatten to a simple array for the Repeater
+        var flat = [];
+        for (var y = 0; y < m.length; y++)
+            for (var x = 0; x < m.length; x++)
+                flat.push(m[y][x] ? 1 : 0);
+        _matrix = flat;
+    }
+
+    // White background with quiet zone
+    Rectangle {
+        anchors.fill: parent
+        color: root.background
+    }
+
+    // Grid of modules
+    Grid {
+        id: qrGrid
+        anchors.centerIn: parent
+        columns: root._modules
+        visible: root._matrix !== null && root._modules > 0
+
+        // Cell size: integer pixels for sharp edges
+        property int cellSize: {
+            if (root._modules <= 0) return 1;
+            var total = root._modules + root.quietZone * 2;
+            var s = Math.floor(Math.min(root.width, root.height) / total);
+            return Math.max(s, 1);
+        }
+
+        width: root._modules * cellSize
+        height: root._modules * cellSize
+
+        Repeater {
+            model: root._matrix ? root._matrix.length : 0
+
+            Rectangle {
+                required property int index
+                width: qrGrid.cellSize
+                height: qrGrid.cellSize
+                color: root._matrix[index] ? root.foreground : root.background
+            }
+        }
+    }
+}

--- a/qml/components/ReportAdviceDialog.qml
+++ b/qml/components/ReportAdviceDialog.qml
@@ -105,11 +105,11 @@ Dialog {
                         color: Theme.warningColor
                         Accessible.ignored: true
 
-                        Text {
+                        Image {
                             anchors.centerIn: parent
-                            text: "\u26A0"
-                            font.pixelSize: Theme.scaled(18)
-                            color: "white"
+                            source: "qrc:/emoji/26a0.svg"  // Warning sign
+                            sourceSize.width: Theme.scaled(18)
+                            sourceSize.height: Theme.scaled(18)
                             Accessible.ignored: true
                         }
                     }

--- a/qml/components/library/LibraryPanel.qml
+++ b/qml/components/library/LibraryPanel.qml
@@ -324,10 +324,11 @@ Rectangle {
                 border.width: 1
                 opacity: canDeleteSelected ? 1.0 : 0.4
 
-                Text {
+                Image {
                     anchors.centerIn: parent
-                    text: "\uD83D\uDDD1"  // Wastebasket
-                    font.pixelSize: Theme.scaled(14)
+                    source: "qrc:/icons/cross-filled.svg"  // Delete
+                    sourceSize.width: Theme.scaled(14)
+                    sourceSize.height: Theme.scaled(14)
                 }
 
                 MouseArea {

--- a/qml/components/qrcode.js
+++ b/qml/components/qrcode.js
@@ -1,0 +1,601 @@
+.pragma library
+
+// QR Code Generator for QML
+// Ported from Project Nayuki's QR Code Generator (MIT License)
+// https://www.nayuki.io/page/qr-code-generator-library
+// Copyright (c) Project Nayuki. (MIT License)
+
+// Returns a 2D boolean matrix (true=dark, false=light) or null on error.
+// Usage: var matrix = generate("Hello World");
+//        if (matrix) { /* matrix[y][x] is true for dark modules */ }
+
+function generate(text) {
+    if (!text) return null;
+    try {
+        var segs = QrSegment_makeSegments(text);
+        var qr = encodeSegments(segs, 1); // EC Level LOW
+        if (!qr) return null;
+        // Convert to simple 2D boolean array
+        var result = [];
+        for (var y = 0; y < qr.size; y++) {
+            var row = [];
+            for (var x = 0; x < qr.size; x++)
+                row.push(qr.modules[y][x]);
+            result.push(row);
+        }
+        return result;
+    } catch (e) {
+        console.log("QR generate error: " + e);
+        return null;
+    }
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+var PENALTY_N1 = 3;
+var PENALTY_N2 = 3;
+var PENALTY_N3 = 40;
+var PENALTY_N4 = 10;
+
+var ECC_CODEWORDS_PER_BLOCK = [
+    // Index 0 = LOW, 1 = MEDIUM, 2 = QUARTILE, 3 = HIGH
+    [-1,  7, 10, 15, 20, 26, 18, 20, 24, 30, 18, 20, 24, 26, 30, 22, 24, 28, 30, 28, 28, 28, 28, 30, 30, 26, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
+    [-1, 10, 16, 26, 18, 24, 16, 18, 22, 22, 26, 30, 22, 22, 24, 24, 28, 28, 26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28],
+    [-1, 13, 22, 18, 26, 18, 24, 18, 22, 20, 24, 28, 26, 24, 20, 30, 24, 28, 28, 26, 30, 28, 30, 30, 30, 30, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
+    [-1, 17, 28, 22, 16, 22, 28, 26, 26, 24, 28, 24, 28, 22, 24, 24, 30, 28, 28, 26, 28, 30, 24, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30]
+];
+
+var NUM_ERROR_CORRECTION_BLOCKS = [
+    [-1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4,  4,  4,  4,  4,  6,  6,  6,  6,  7,  8,  8,  9,  9, 10, 12, 12, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 24, 25],
+    [-1, 1, 1, 1, 2, 2, 4, 4, 4, 5, 5,  5,  8,  9,  9, 10, 10, 11, 13, 14, 16, 17, 17, 18, 20, 21, 23, 25, 26, 28, 29, 31, 33, 35, 37, 38, 40, 43, 45, 47, 49],
+    [-1, 1, 1, 2, 2, 4, 4, 6, 6, 8, 8,  8, 10, 12, 16, 12, 17, 16, 18, 21, 20, 23, 23, 25, 27, 29, 34, 34, 35, 38, 40, 43, 45, 48, 51, 53, 56, 59, 62, 65, 68],
+    [-1, 1, 1, 2, 4, 4, 4, 5, 6, 8, 8, 11, 11, 16, 16, 18, 16, 19, 21, 25, 25, 25, 34, 30, 32, 35, 37, 40, 42, 45, 48, 51, 54, 57, 60, 63, 66, 70, 74, 77, 81]
+];
+
+// ECL format bits: LOW=1, MEDIUM=0, QUARTILE=3, HIGH=2
+var ECL_FORMAT_BITS = [1, 0, 3, 2];
+
+// ── Utility functions ──────────────────────────────────────────────────────
+
+function getBit(x, i) {
+    return ((x >>> i) & 1) !== 0;
+}
+
+function appendBits(val, len, bb) {
+    for (var i = len - 1; i >= 0; i--)
+        bb.push((val >>> i) & 1);
+}
+
+// ── Reed-Solomon ───────────────────────────────────────────────────────────
+
+function reedSolomonMultiply(x, y) {
+    var z = 0;
+    for (var i = 7; i >= 0; i--) {
+        z = (z << 1) ^ ((z >>> 7) * 0x11D);
+        z ^= ((y >>> i) & 1) * x;
+    }
+    return z;
+}
+
+function reedSolomonComputeDivisor(degree) {
+    var result = [];
+    for (var i = 0; i < degree - 1; i++)
+        result.push(0);
+    result.push(1);
+
+    var root = 1;
+    for (var i = 0; i < degree; i++) {
+        for (var j = 0; j < result.length; j++) {
+            result[j] = reedSolomonMultiply(result[j], root);
+            if (j + 1 < result.length)
+                result[j] ^= result[j + 1];
+        }
+        root = reedSolomonMultiply(root, 0x02);
+    }
+    return result;
+}
+
+function reedSolomonComputeRemainder(data, divisor) {
+    var result = [];
+    for (var i = 0; i < divisor.length; i++)
+        result.push(0);
+
+    for (var i = 0; i < data.length; i++) {
+        var factor = data[i] ^ result.shift();
+        result.push(0);
+        for (var j = 0; j < divisor.length; j++)
+            result[j] ^= reedSolomonMultiply(divisor[j], factor);
+    }
+    return result;
+}
+
+// ── QR Code number of raw data modules ─────────────────────────────────────
+
+function getNumRawDataModules(ver) {
+    var result = (16 * ver + 128) * ver + 64;
+    if (ver >= 2) {
+        var numAlign = Math.floor(ver / 7) + 2;
+        result -= (25 * numAlign - 10) * numAlign - 55;
+        if (ver >= 7)
+            result -= 36;
+    }
+    return result;
+}
+
+function getNumDataCodewords(ver, eclOrdinal) {
+    return Math.floor(getNumRawDataModules(ver) / 8) -
+        ECC_CODEWORDS_PER_BLOCK[eclOrdinal][ver] *
+        NUM_ERROR_CORRECTION_BLOCKS[eclOrdinal][ver];
+}
+
+// ── QR Segment encoding ───────────────────────────────────────────────────
+
+var NUMERIC_REGEX = /^[0-9]*$/;
+var ALPHANUMERIC_REGEX = /^[A-Z0-9 $%*+.\/:=]*$/;
+var ALPHANUMERIC_CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+
+// Mode: [modeBits, [charCountBits for version ranges]]
+var MODE_NUMERIC      = { modeBits: 0x1, ccBits: [10, 12, 14] };
+var MODE_ALPHANUMERIC = { modeBits: 0x2, ccBits: [ 9, 11, 13] };
+var MODE_BYTE         = { modeBits: 0x4, ccBits: [ 8, 16, 16] };
+
+function numCharCountBits(mode, ver) {
+    return mode.ccBits[Math.floor((ver + 7) / 17)];
+}
+
+function toUtf8ByteArray(str) {
+    var s = encodeURI(str);
+    var result = [];
+    for (var i = 0; i < s.length; i++) {
+        if (s.charAt(i) !== "%")
+            result.push(s.charCodeAt(i));
+        else {
+            result.push(parseInt(s.substring(i + 1, i + 3), 16));
+            i += 2;
+        }
+    }
+    return result;
+}
+
+function QrSegment_makeBytes(data) {
+    var bb = [];
+    for (var i = 0; i < data.length; i++)
+        appendBits(data[i], 8, bb);
+    return { mode: MODE_BYTE, numChars: data.length, bitData: bb };
+}
+
+function QrSegment_makeNumeric(digits) {
+    var bb = [];
+    for (var i = 0; i < digits.length; ) {
+        var n = Math.min(digits.length - i, 3);
+        appendBits(parseInt(digits.substring(i, i + n), 10), n * 3 + 1, bb);
+        i += n;
+    }
+    return { mode: MODE_NUMERIC, numChars: digits.length, bitData: bb };
+}
+
+function QrSegment_makeAlphanumeric(text) {
+    var bb = [];
+    var i;
+    for (i = 0; i + 2 <= text.length; i += 2) {
+        var temp = ALPHANUMERIC_CHARSET.indexOf(text.charAt(i)) * 45;
+        temp += ALPHANUMERIC_CHARSET.indexOf(text.charAt(i + 1));
+        appendBits(temp, 11, bb);
+    }
+    if (i < text.length)
+        appendBits(ALPHANUMERIC_CHARSET.indexOf(text.charAt(i)), 6, bb);
+    return { mode: MODE_ALPHANUMERIC, numChars: text.length, bitData: bb };
+}
+
+function QrSegment_makeSegments(text) {
+    if (text === "")
+        return [];
+    else if (NUMERIC_REGEX.test(text))
+        return [QrSegment_makeNumeric(text)];
+    else if (ALPHANUMERIC_REGEX.test(text))
+        return [QrSegment_makeAlphanumeric(text)];
+    else
+        return [QrSegment_makeBytes(toUtf8ByteArray(text))];
+}
+
+function getTotalBits(segs, version) {
+    var result = 0;
+    for (var i = 0; i < segs.length; i++) {
+        var seg = segs[i];
+        var ccbits = numCharCountBits(seg.mode, version);
+        if (seg.numChars >= (1 << ccbits))
+            return Infinity;
+        result += 4 + ccbits + seg.bitData.length;
+    }
+    return result;
+}
+
+// ── Main encode function ──────────────────────────────────────────────────
+
+function encodeSegments(segs, eclOrdinal) {
+    var minVersion = 1;
+    var maxVersion = 40;
+
+    // Find minimal version
+    var version, dataUsedBits;
+    for (version = minVersion; ; version++) {
+        var dataCapacityBits = getNumDataCodewords(version, eclOrdinal) * 8;
+        var usedBits = getTotalBits(segs, version);
+        if (usedBits <= dataCapacityBits) {
+            dataUsedBits = usedBits;
+            break;
+        }
+        if (version >= maxVersion)
+            return null; // Data too long
+    }
+
+    // Boost ECL if data still fits
+    var eclOrder = [1, 2, 3]; // MEDIUM, QUARTILE, HIGH
+    for (var i = 0; i < eclOrder.length; i++) {
+        if (dataUsedBits <= getNumDataCodewords(version, eclOrder[i]) * 8)
+            eclOrdinal = eclOrder[i];
+    }
+
+    // Build bit stream
+    var bb = [];
+    for (var i = 0; i < segs.length; i++) {
+        var seg = segs[i];
+        appendBits(seg.mode.modeBits, 4, bb);
+        appendBits(seg.numChars, numCharCountBits(seg.mode, version), bb);
+        for (var j = 0; j < seg.bitData.length; j++)
+            bb.push(seg.bitData[j]);
+    }
+
+    // Pad
+    var dataCapacityBits = getNumDataCodewords(version, eclOrdinal) * 8;
+    appendBits(0, Math.min(4, dataCapacityBits - bb.length), bb);
+    appendBits(0, (8 - bb.length % 8) % 8, bb);
+    for (var padByte = 0xEC; bb.length < dataCapacityBits; padByte ^= 0xEC ^ 0x11)
+        appendBits(padByte, 8, bb);
+
+    // Pack into bytes
+    var dataCodewords = [];
+    for (var i = 0; i < bb.length; i += 8)
+        dataCodewords.push(0);
+    for (var i = 0; i < bb.length; i++)
+        dataCodewords[i >>> 3] |= bb[i] << (7 - (i & 7));
+
+    // Build QR code
+    return buildQrCode(version, eclOrdinal, dataCodewords);
+}
+
+// ── QR Code construction ──────────────────────────────────────────────────
+
+function buildQrCode(version, eclOrdinal, dataCodewords) {
+    var size = version * 4 + 17;
+
+    // Initialize modules and isFunction grids
+    var modules = [];
+    var isFunction = [];
+    for (var y = 0; y < size; y++) {
+        modules.push([]);
+        isFunction.push([]);
+        for (var x = 0; x < size; x++) {
+            modules[y].push(false);
+            isFunction[y].push(false);
+        }
+    }
+
+    var qr = { size: size, version: version, modules: modules, isFunction: isFunction };
+
+    // Draw function patterns
+    drawFunctionPatterns(qr);
+
+    // Add ECC and interleave
+    var allCodewords = addEccAndInterleave(qr, dataCodewords, eclOrdinal);
+
+    // Draw codewords
+    drawCodewords(qr, allCodewords);
+
+    // Find best mask
+    var bestMask = -1;
+    var bestPenalty = Infinity;
+    for (var mask = 0; mask < 8; mask++) {
+        applyMask(qr, mask);
+        drawFormatBits(qr, eclOrdinal, mask);
+        var penalty = getPenaltyScore(qr);
+        if (penalty < bestPenalty) {
+            bestMask = mask;
+            bestPenalty = penalty;
+        }
+        applyMask(qr, mask); // Undo
+    }
+
+    // Apply best mask
+    applyMask(qr, bestMask);
+    drawFormatBits(qr, eclOrdinal, bestMask);
+
+    return qr;
+}
+
+// ── Drawing function patterns ─────────────────────────────────────────────
+
+function setFunctionModule(qr, x, y, isDark) {
+    qr.modules[y][x] = isDark;
+    qr.isFunction[y][x] = true;
+}
+
+function drawFunctionPatterns(qr) {
+    var size = qr.size;
+    var version = qr.version;
+
+    // Timing patterns
+    for (var i = 0; i < size; i++) {
+        setFunctionModule(qr, 6, i, i % 2 === 0);
+        setFunctionModule(qr, i, 6, i % 2 === 0);
+    }
+
+    // Finder patterns
+    drawFinderPattern(qr, 3, 3);
+    drawFinderPattern(qr, size - 4, 3);
+    drawFinderPattern(qr, 3, size - 4);
+
+    // Alignment patterns
+    var alignPos = getAlignmentPatternPositions(version, size);
+    var numAlign = alignPos.length;
+    for (var i = 0; i < numAlign; i++) {
+        for (var j = 0; j < numAlign; j++) {
+            if (!(i === 0 && j === 0 || i === 0 && j === numAlign - 1 || i === numAlign - 1 && j === 0))
+                drawAlignmentPattern(qr, alignPos[i], alignPos[j]);
+        }
+    }
+
+    // Format bits (dummy, overwritten later)
+    drawFormatBits(qr, 0, 0);
+    drawVersion(qr);
+}
+
+function drawFinderPattern(qr, x, y) {
+    var size = qr.size;
+    for (var dy = -4; dy <= 4; dy++) {
+        for (var dx = -4; dx <= 4; dx++) {
+            var dist = Math.max(Math.abs(dx), Math.abs(dy));
+            var xx = x + dx;
+            var yy = y + dy;
+            if (0 <= xx && xx < size && 0 <= yy && yy < size)
+                setFunctionModule(qr, xx, yy, dist !== 2 && dist !== 4);
+        }
+    }
+}
+
+function drawAlignmentPattern(qr, x, y) {
+    for (var dy = -2; dy <= 2; dy++)
+        for (var dx = -2; dx <= 2; dx++)
+            setFunctionModule(qr, x + dx, y + dy, Math.max(Math.abs(dx), Math.abs(dy)) !== 1);
+}
+
+function getAlignmentPatternPositions(version, size) {
+    if (version === 1)
+        return [];
+    var numAlign = Math.floor(version / 7) + 2;
+    var step = Math.floor((version * 8 + numAlign * 3 + 5) / (numAlign * 4 - 4)) * 2;
+    var result = [6];
+    for (var pos = size - 7; result.length < numAlign; pos -= step)
+        result.splice(1, 0, pos);
+    return result;
+}
+
+function drawFormatBits(qr, eclOrdinal, mask) {
+    var size = qr.size;
+    var data = ECL_FORMAT_BITS[eclOrdinal] << 3 | mask;
+    var rem = data;
+    for (var i = 0; i < 10; i++)
+        rem = (rem << 1) ^ ((rem >>> 9) * 0x537);
+    var bits = (data << 10 | rem) ^ 0x5412;
+
+    // First copy
+    for (var i = 0; i <= 5; i++)
+        setFunctionModule(qr, 8, i, getBit(bits, i));
+    setFunctionModule(qr, 8, 7, getBit(bits, 6));
+    setFunctionModule(qr, 8, 8, getBit(bits, 7));
+    setFunctionModule(qr, 7, 8, getBit(bits, 8));
+    for (var i = 9; i < 15; i++)
+        setFunctionModule(qr, 14 - i, 8, getBit(bits, i));
+
+    // Second copy
+    for (var i = 0; i < 8; i++)
+        setFunctionModule(qr, size - 1 - i, 8, getBit(bits, i));
+    for (var i = 8; i < 15; i++)
+        setFunctionModule(qr, 8, size - 15 + i, getBit(bits, i));
+    setFunctionModule(qr, 8, size - 8, true);
+}
+
+function drawVersion(qr) {
+    if (qr.version < 7)
+        return;
+    var rem = qr.version;
+    for (var i = 0; i < 12; i++)
+        rem = (rem << 1) ^ ((rem >>> 11) * 0x1F25);
+    var bits = qr.version << 12 | rem;
+
+    for (var i = 0; i < 18; i++) {
+        var color = getBit(bits, i);
+        var a = qr.size - 11 + i % 3;
+        var b = Math.floor(i / 3);
+        setFunctionModule(qr, a, b, color);
+        setFunctionModule(qr, b, a, color);
+    }
+}
+
+// ── ECC and interleave ────────────────────────────────────────────────────
+
+function addEccAndInterleave(qr, data, eclOrdinal) {
+    var ver = qr.version;
+    var numBlocks = NUM_ERROR_CORRECTION_BLOCKS[eclOrdinal][ver];
+    var blockEccLen = ECC_CODEWORDS_PER_BLOCK[eclOrdinal][ver];
+    var rawCodewords = Math.floor(getNumRawDataModules(ver) / 8);
+    var numShortBlocks = numBlocks - rawCodewords % numBlocks;
+    var shortBlockLen = Math.floor(rawCodewords / numBlocks);
+
+    var blocks = [];
+    var rsDiv = reedSolomonComputeDivisor(blockEccLen);
+    for (var i = 0, k = 0; i < numBlocks; i++) {
+        var datLen = shortBlockLen - blockEccLen + (i < numShortBlocks ? 0 : 1);
+        var dat = data.slice(k, k + datLen);
+        k += datLen;
+        var ecc = reedSolomonComputeRemainder(dat, rsDiv);
+        if (i < numShortBlocks)
+            dat.push(0);
+        blocks.push(dat.concat(ecc));
+    }
+
+    var result = [];
+    for (var i = 0; i < blocks[0].length; i++) {
+        for (var j = 0; j < blocks.length; j++) {
+            if (i !== shortBlockLen - blockEccLen || j >= numShortBlocks)
+                result.push(blocks[j][i]);
+        }
+    }
+    return result;
+}
+
+// ── Draw codewords ────────────────────────────────────────────────────────
+
+function drawCodewords(qr, data) {
+    var size = qr.size;
+    var i = 0;
+    for (var right = size - 1; right >= 1; right -= 2) {
+        if (right === 6)
+            right = 5;
+        for (var vert = 0; vert < size; vert++) {
+            for (var j = 0; j < 2; j++) {
+                var x = right - j;
+                var upward = ((right + 1) & 2) === 0;
+                var y = upward ? size - 1 - vert : vert;
+                if (!qr.isFunction[y][x] && i < data.length * 8) {
+                    qr.modules[y][x] = getBit(data[i >>> 3], 7 - (i & 7));
+                    i++;
+                }
+            }
+        }
+    }
+}
+
+// ── Masking ───────────────────────────────────────────────────────────────
+
+function applyMask(qr, mask) {
+    var size = qr.size;
+    for (var y = 0; y < size; y++) {
+        for (var x = 0; x < size; x++) {
+            var invert;
+            switch (mask) {
+                case 0: invert = (x + y) % 2 === 0;                                  break;
+                case 1: invert = y % 2 === 0;                                        break;
+                case 2: invert = x % 3 === 0;                                        break;
+                case 3: invert = (x + y) % 3 === 0;                                  break;
+                case 4: invert = (Math.floor(x / 3) + Math.floor(y / 2)) % 2 === 0;  break;
+                case 5: invert = x * y % 2 + x * y % 3 === 0;                        break;
+                case 6: invert = (x * y % 2 + x * y % 3) % 2 === 0;                  break;
+                case 7: invert = ((x + y) % 2 + x * y % 3) % 2 === 0;                break;
+            }
+            if (!qr.isFunction[y][x] && invert)
+                qr.modules[y][x] = !qr.modules[y][x];
+        }
+    }
+}
+
+// ── Penalty scoring ───────────────────────────────────────────────────────
+
+function finderPenaltyCountPatterns(runHistory, size) {
+    var n = runHistory[1];
+    var core = n > 0 && runHistory[2] === n && runHistory[3] === n * 3 &&
+               runHistory[4] === n && runHistory[5] === n;
+    return (core && runHistory[0] >= n * 4 && runHistory[6] >= n ? 1 : 0)
+         + (core && runHistory[6] >= n * 4 && runHistory[0] >= n ? 1 : 0);
+}
+
+function finderPenaltyAddHistory(currentRunLength, runHistory, size) {
+    if (runHistory[0] === 0)
+        currentRunLength += size;
+    runHistory.pop();
+    runHistory.unshift(currentRunLength);
+}
+
+function finderPenaltyTerminateAndCount(currentRunColor, currentRunLength, runHistory, size) {
+    if (currentRunColor) {
+        finderPenaltyAddHistory(currentRunLength, runHistory, size);
+        currentRunLength = 0;
+    }
+    currentRunLength += size;
+    finderPenaltyAddHistory(currentRunLength, runHistory, size);
+    return finderPenaltyCountPatterns(runHistory, size);
+}
+
+function getPenaltyScore(qr) {
+    var size = qr.size;
+    var modules = qr.modules;
+    var result = 0;
+
+    // Rule 1 & 3: Adjacent modules in rows having same color, and finder-like patterns
+    for (var y = 0; y < size; y++) {
+        var runColor = false;
+        var runX = 0;
+        var runHistory = [0, 0, 0, 0, 0, 0, 0];
+        for (var x = 0; x < size; x++) {
+            if (modules[y][x] === runColor) {
+                runX++;
+                if (runX === 5)
+                    result += PENALTY_N1;
+                else if (runX > 5)
+                    result++;
+            } else {
+                finderPenaltyAddHistory(runX, runHistory, size);
+                if (!runColor)
+                    result += finderPenaltyCountPatterns(runHistory, size) * PENALTY_N3;
+                runColor = modules[y][x];
+                runX = 1;
+            }
+        }
+        result += finderPenaltyTerminateAndCount(runColor, runX, runHistory, size) * PENALTY_N3;
+    }
+
+    // Rule 1 & 3: Adjacent modules in columns
+    for (var x = 0; x < size; x++) {
+        var runColor = false;
+        var runY = 0;
+        var runHistory = [0, 0, 0, 0, 0, 0, 0];
+        for (var y = 0; y < size; y++) {
+            if (modules[y][x] === runColor) {
+                runY++;
+                if (runY === 5)
+                    result += PENALTY_N1;
+                else if (runY > 5)
+                    result++;
+            } else {
+                finderPenaltyAddHistory(runY, runHistory, size);
+                if (!runColor)
+                    result += finderPenaltyCountPatterns(runHistory, size) * PENALTY_N3;
+                runColor = modules[y][x];
+                runY = 1;
+            }
+        }
+        result += finderPenaltyTerminateAndCount(runColor, runY, runHistory, size) * PENALTY_N3;
+    }
+
+    // Rule 2: 2x2 blocks of same color
+    for (var y = 0; y < size - 1; y++) {
+        for (var x = 0; x < size - 1; x++) {
+            var color = modules[y][x];
+            if (color === modules[y][x + 1] &&
+                color === modules[y + 1][x] &&
+                color === modules[y + 1][x + 1])
+                result += PENALTY_N2;
+        }
+    }
+
+    // Rule 4: Balance of dark and light modules
+    var dark = 0;
+    for (var y = 0; y < size; y++)
+        for (var x = 0; x < size; x++)
+            if (modules[y][x]) dark++;
+    var total = size * size;
+    var k = Math.ceil(Math.abs(dark * 20 - total * 10) / total) - 1;
+    result += k * PENALTY_N4;
+
+    return result;
+}

--- a/qml/pages/DescalingPage.qml
+++ b/qml/pages/DescalingPage.qml
@@ -208,9 +208,10 @@ Page {
                             Layout.fillWidth: true
                             spacing: Theme.scaled(8)
 
-                            Text {
-                                text: "\u2705"  // Checkmark
-                                font.pixelSize: Theme.scaled(24)
+                            Image {
+                                source: "qrc:/emoji/2705.svg"  // Checkmark
+                                sourceSize.width: Theme.scaled(24)
+                                sourceSize.height: Theme.scaled(24)
                             }
 
                             Tr {

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -780,10 +780,10 @@ Page {
                 anchors.centerIn: parent
                 spacing: Theme.scaled(6)
 
-                Text {
-                    text: "\u2601"  // Cloud icon
-                    font.pixelSize: Theme.scaled(16)
-                    color: "white"
+                Image {
+                    source: "qrc:/emoji/2601.svg"  // Cloud icon
+                    sourceSize.width: Theme.scaled(16)
+                    sourceSize.height: Theme.scaled(16)
                     anchors.verticalCenter: parent.verticalCenter
                     Accessible.ignored: true
                 }

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -654,11 +654,20 @@ Page {
                     anchors.fill: parent
                     anchors.margins: Theme.spacingMedium
 
-                    Tr {
-                        key: "shotdetail.uploadedtovisualizer"
-                        fallback: "\u2601 Uploaded to Visualizer"
-                        font: Theme.labelFont
-                        color: Theme.successColor
+                    Row {
+                        spacing: Theme.scaled(4)
+                        Image {
+                            source: "qrc:/emoji/2601.svg"
+                            sourceSize.width: Theme.labelFont.pixelSize
+                            sourceSize.height: Theme.labelFont.pixelSize
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        Tr {
+                            key: "shotdetail.uploadedtovisualizer"
+                            fallback: "Uploaded to Visualizer"
+                            font: Theme.labelFont
+                            color: Theme.successColor
+                        }
                     }
 
                     Item { Layout.fillWidth: true }
@@ -774,10 +783,10 @@ Page {
                 anchors.centerIn: parent
                 spacing: Theme.scaled(6)
 
-                Text {
-                    text: "\u2601"  // Cloud icon
-                    font.pixelSize: Theme.scaled(16)
-                    color: "white"
+                Image {
+                    source: "qrc:/emoji/2601.svg"  // Cloud icon
+                    sourceSize.width: Theme.scaled(16)
+                    sourceSize.height: Theme.scaled(16)
                     anchors.verticalCenter: parent.verticalCenter
                     Accessible.ignored: true
                 }

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -558,10 +558,10 @@ Page {
                                 Accessible.ignored: true
                             }
 
-                            Text {
-                                text: model.hasVisualizerUpload ? "\u2601" : ""
-                                font.pixelSize: Theme.scaled(16)
-                                color: Theme.successColor
+                            Image {
+                                source: "qrc:/emoji/2601.svg"  // Cloud icon
+                                sourceSize.width: Theme.scaled(16)
+                                sourceSize.height: Theme.scaled(16)
                                 visible: model.hasVisualizerUpload
                                 Accessible.ignored: true
                             }

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -199,6 +199,15 @@ MainController::MainController(Settings* settings, DE1Device* device,
                 m_shotServer->start();
             }
         });
+        connect(m_settings, &Settings::webSecurityEnabledChanged, this, [this]() {
+            bool wasRunning = m_shotServer->isRunning();
+            if (wasRunning) {
+                m_shotServer->stop();
+            }
+            if (wasRunning || m_settings->shotServerEnabled()) {
+                m_shotServer->start();
+            }
+        });
     }
 
     // Set MachineState on ShotServer for home automation API

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -2301,6 +2301,17 @@ void Settings::setShotServerPort(int port) {
     }
 }
 
+bool Settings::webSecurityEnabled() const {
+    return m_settings.value("shotServer/webSecurityEnabled", false).toBool();
+}
+
+void Settings::setWebSecurityEnabled(bool enabled) {
+    if (webSecurityEnabled() != enabled) {
+        m_settings.setValue("shotServer/webSecurityEnabled", enabled);
+        emit webSecurityEnabledChanged();
+    }
+}
+
 // Auto-favorites settings
 QString Settings::autoFavoritesGroupBy() const {
     return m_settings.value("autoFavorites/groupBy", "bean_profile").toString();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -146,6 +146,7 @@ class Settings : public QObject {
     Q_PROPERTY(bool shotServerEnabled READ shotServerEnabled WRITE setShotServerEnabled NOTIFY shotServerEnabledChanged)
     Q_PROPERTY(QString shotServerHostname READ shotServerHostname WRITE setShotServerHostname NOTIFY shotServerHostnameChanged)
     Q_PROPERTY(int shotServerPort READ shotServerPort WRITE setShotServerPort NOTIFY shotServerPortChanged)
+    Q_PROPERTY(bool webSecurityEnabled READ webSecurityEnabled WRITE setWebSecurityEnabled NOTIFY webSecurityEnabledChanged)
 
     // Auto-favorites settings
     Q_PROPERTY(QString autoFavoritesGroupBy READ autoFavoritesGroupBy WRITE setAutoFavoritesGroupBy NOTIFY autoFavoritesGroupByChanged)
@@ -555,6 +556,8 @@ public:
     void setShotServerHostname(const QString& hostname);
     int shotServerPort() const;
     void setShotServerPort(int port);
+    bool webSecurityEnabled() const;
+    void setWebSecurityEnabled(bool enabled);
 
     // Auto-favorites settings
     QString autoFavoritesGroupBy() const;
@@ -782,6 +785,7 @@ signals:
     void shotServerEnabledChanged();
     void shotServerHostnameChanged();
     void shotServerPortChanged();
+    void webSecurityEnabledChanged();
     void autoFavoritesGroupByChanged();
     void autoFavoritesMaxItemsChanged();
     void bleHealthRefreshEnabledChanged();

--- a/src/network/shotserver_auth.cpp
+++ b/src/network/shotserver_auth.cpp
@@ -1,0 +1,373 @@
+#include "shotserver.h"
+#include "webtemplates/auth_page.h"
+#include "../core/settings.h"
+
+#include <QCryptographicHash>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMessageAuthenticationCode>
+#include <QRandomGenerator>
+#include <QSettings>
+#include <QDateTime>
+
+// ─── Base32 encoding/decoding ───────────────────────────────────────────────
+
+static const char BASE32_ALPHABET[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+static QString toBase32(const QByteArray& data)
+{
+    QString result;
+    int bits = 0;
+    int buffer = 0;
+    for (int i = 0; i < data.size(); i++) {
+        buffer = (buffer << 8) | static_cast<unsigned char>(data[i]);
+        bits += 8;
+        while (bits >= 5) {
+            result.append(QLatin1Char(BASE32_ALPHABET[(buffer >> (bits - 5)) & 0x1F]));
+            bits -= 5;
+        }
+    }
+    if (bits > 0) {
+        result.append(QLatin1Char(BASE32_ALPHABET[(buffer << (5 - bits)) & 0x1F]));
+    }
+    return result;
+}
+
+static QByteArray fromBase32(const QString& encoded)
+{
+    QByteArray result;
+    int bits = 0;
+    int buffer = 0;
+    for (QChar c : encoded) {
+        int val;
+        char ch = c.toUpper().toLatin1();
+        if (ch >= 'A' && ch <= 'Z') val = ch - 'A';
+        else if (ch >= '2' && ch <= '7') val = ch - '2' + 26;
+        else continue;
+        buffer = (buffer << 5) | val;
+        bits += 5;
+        if (bits >= 8) {
+            result.append(static_cast<char>((buffer >> (bits - 8)) & 0xFF));
+            bits -= 8;
+        }
+    }
+    return result;
+}
+
+// ─── TOTP computation (RFC 6238) ────────────────────────────────────────────
+
+static QString computeTotp(const QByteArray& secret, qint64 counter)
+{
+    // Convert counter to 8-byte big-endian
+    QByteArray counterBytes(8, 0);
+    for (int i = 7; i >= 0; i--) {
+        counterBytes[i] = static_cast<char>(counter & 0xFF);
+        counter >>= 8;
+    }
+
+    // HMAC-SHA1 using Qt
+    QByteArray hmac = QMessageAuthenticationCode::hash(counterBytes, secret, QCryptographicHash::Sha1);
+
+    // Dynamic truncation
+    int offset = hmac[hmac.size() - 1] & 0x0F;
+    quint32 code = (static_cast<quint32>(static_cast<unsigned char>(hmac[offset]) & 0x7F) << 24) |
+                   (static_cast<quint32>(static_cast<unsigned char>(hmac[offset + 1]) & 0xFF) << 16) |
+                   (static_cast<quint32>(static_cast<unsigned char>(hmac[offset + 2]) & 0xFF) << 8) |
+                   static_cast<quint32>(static_cast<unsigned char>(hmac[offset + 3]) & 0xFF);
+
+    code = code % 1000000;
+    return QString("%1").arg(code, 6, 10, QChar('0'));
+}
+
+static bool validateTotp(const QByteArray& secret, const QString& code)
+{
+    qint64 now = QDateTime::currentSecsSinceEpoch();
+    qint64 counter = now / 30;
+
+    // Check current + ±2 time steps (150-second window for clock drift)
+    for (int i = -2; i <= 2; i++) {
+        if (computeTotp(secret, counter + i) == code) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// ─── Helper: extract User-Agent from request ────────────────────────────────
+
+static QString extractUserAgent(const QByteArray& request)
+{
+    QString requestStr = QString::fromUtf8(request);
+    QStringList lines = requestStr.split("\r\n");
+    for (const QString& line : lines) {
+        if (line.startsWith("User-Agent:", Qt::CaseInsensitive)) {
+            return line.mid(11).trimmed();
+        }
+    }
+    return QString();
+}
+
+// ─── Rate limiting ──────────────────────────────────────────────────────────
+
+bool ShotServer::checkRateLimit(const QString& ip)
+{
+    auto now = QDateTime::currentDateTimeUtc();
+    auto it = m_loginAttempts.find(ip);
+    if (it != m_loginAttempts.end()) {
+        // Reset window if older than 60 seconds
+        if (it->second.secsTo(now) > 60) {
+            it->first = 0;
+            it->second = now;
+        }
+        if (it->first >= 5) {
+            return false;  // Rate limited
+        }
+        it->first++;
+    } else {
+        m_loginAttempts[ip] = {1, now};
+    }
+    return true;
+}
+
+// ─── QML-callable TOTP setup methods ────────────────────────────────────────
+
+QVariantMap ShotServer::generateTotpSetup()
+{
+    // Generate random 20-byte secret
+    QByteArray secretBytes(20, 0);
+    QRandomGenerator::global()->fillRange(
+        reinterpret_cast<quint32*>(secretBytes.data()),
+        secretBytes.size() / static_cast<int>(sizeof(quint32)));
+
+    QString base32Secret = toBase32(secretBytes);
+    QString uri = QString("otpauth://totp/Decenza:DE1?secret=%1&issuer=Decenza&algorithm=SHA1&digits=6&period=30")
+                      .arg(base32Secret);
+
+    QVariantMap result;
+    result["secret"] = base32Secret;
+    result["uri"] = uri;
+    return result;
+}
+
+bool ShotServer::completeTotpSetup(const QString& secret, const QString& code)
+{
+    QByteArray secretBytes = fromBase32(secret);
+    if (secretBytes.isEmpty()) {
+        return false;
+    }
+
+    if (!validateTotp(secretBytes, code)) {
+        qDebug() << "ShotServer: TOTP setup verification failed";
+        return false;
+    }
+
+    // Store the verified secret
+    if (m_settings) {
+        m_settings->setValue("webAuth/totpSecret", secret);
+        m_settings->setValue("webAuth/credentialId", QVariant());
+        m_settings->setValue("webAuth/credentialPublicKey", QVariant());
+        m_settings->sync();
+    }
+
+    emit hasTotpSecretChanged();
+    return true;
+}
+
+void ShotServer::resetTotpSecret()
+{
+    if (m_settings) {
+        m_settings->setValue("webAuth/totpSecret", QVariant());
+        m_settings->sync();
+    }
+    m_sessions.clear();
+    saveSessions();
+    qDebug() << "ShotServer: TOTP secret and all sessions cleared";
+    emit hasTotpSecretChanged();
+}
+
+// ─── Web auth route handler ─────────────────────────────────────────────────
+
+void ShotServer::handleAuthRoute(QTcpSocket* socket, const QString& method, const QString& path, const QByteArray& body)
+{
+    if (path == "/auth/login" && method == "GET") {
+        if (hasStoredTotpSecret()) {
+            sendResponse(socket, 200, "text/html; charset=utf-8", QByteArray(WEB_AUTH_LOGIN_PAGE));
+        } else {
+            sendResponse(socket, 200, "text/html; charset=utf-8", QByteArray(WEB_AUTH_SETUP_REQUIRED_PAGE));
+        }
+    }
+    else if (path == "/auth/setup-required" && method == "GET") {
+        sendResponse(socket, 200, "text/html; charset=utf-8", QByteArray(WEB_AUTH_SETUP_REQUIRED_PAGE));
+    }
+    else if (path == "/api/auth/login" && method == "POST") {
+        handleTotpLogin(socket, body);
+    }
+    else if (path == "/api/auth/reset" && method == "POST") {
+        // Require valid session to reset
+        QByteArray fullRequest = socket->property("fullRequest").toByteArray();
+        if (!checkSession(fullRequest)) {
+            sendResponse(socket, 401, "application/json", R"({"error":"Unauthorized"})");
+            return;
+        }
+        resetTotpSecret();
+        sendJson(socket, R"({"success":true})");
+    }
+    else {
+        sendResponse(socket, 404, "text/plain", "Not Found");
+    }
+}
+
+// ─── TOTP login handler ─────────────────────────────────────────────────────
+
+void ShotServer::handleTotpLogin(QTcpSocket* socket, const QByteArray& body)
+{
+    // Rate limiting by IP
+    QString clientIp = (socket->state() != QAbstractSocket::UnconnectedState)
+        ? socket->peerAddress().toString() : "unknown";
+    if (!checkRateLimit(clientIp)) {
+        sendResponse(socket, 429, "application/json",
+                     R"({"error":"Too many attempts. Please wait 60 seconds."})");
+        return;
+    }
+
+    if (!hasStoredTotpSecret()) {
+        sendResponse(socket, 400, "application/json",
+                     R"({"error":"TOTP not configured. Set up in the Decenza app first."})");
+        return;
+    }
+
+    QJsonDocument doc = QJsonDocument::fromJson(body);
+    if (!doc.isObject()) {
+        sendResponse(socket, 400, "application/json", R"({"error":"Invalid JSON"})");
+        return;
+    }
+
+    QString code = doc.object()["code"].toString().trimmed();
+    if (code.length() != 6) {
+        sendResponse(socket, 400, "application/json", R"({"error":"Code must be 6 digits"})");
+        return;
+    }
+
+    // Validate TOTP
+    QString storedSecret = m_settings->value("webAuth/totpSecret").toString();
+    QByteArray secretBytes = fromBase32(storedSecret);
+
+    if (!validateTotp(secretBytes, code)) {
+        sendResponse(socket, 401, "application/json", R"({"error":"Invalid code"})");
+        return;
+    }
+
+    // Reset rate limit on success
+    m_loginAttempts.remove(clientIp);
+
+    // Create session
+    QByteArray fullRequest = socket->property("fullRequest").toByteArray();
+    QString userAgent = extractUserAgent(fullRequest);
+    QString token = createSession(userAgent);
+
+    int maxAge = SESSION_LIFETIME_DAYS * 24 * 60 * 60;
+    QString cookie = QString("decenza_session=%1; Max-Age=%2; Path=/; Secure; HttpOnly; SameSite=Strict")
+                         .arg(token).arg(maxAge);
+
+    QByteArray responseBody = R"({"success":true})";
+    QByteArray extraHeaders = QString("Set-Cookie: %1\r\n").arg(cookie).toUtf8();
+    sendResponse(socket, 200, "application/json", responseBody, extraHeaders);
+}
+
+// ─── Session management (unchanged from WebAuthn version) ───────────────────
+
+QString ShotServer::extractCookie(const QByteArray& request, const QString& cookieName) const
+{
+    QString requestStr = QString::fromUtf8(request);
+    QStringList lines = requestStr.split("\r\n");
+    for (const QString& line : lines) {
+        if (line.startsWith("Cookie:", Qt::CaseInsensitive)) {
+            QString cookieStr = line.mid(7).trimmed();
+            QStringList cookies = cookieStr.split(";");
+            for (const QString& cookie : cookies) {
+                QString trimmed = cookie.trimmed();
+                if (trimmed.startsWith(cookieName + "=")) {
+                    return trimmed.mid(cookieName.length() + 1);
+                }
+            }
+        }
+    }
+    return QString();
+}
+
+bool ShotServer::checkSession(const QByteArray& request) const
+{
+    QString token = extractCookie(request, "decenza_session");
+    if (token.isEmpty()) return false;
+
+    auto it = m_sessions.find(token);
+    if (it == m_sessions.end()) return false;
+
+    return it->expiry > QDateTime::currentDateTimeUtc();
+}
+
+QString ShotServer::createSession(const QString& userAgent)
+{
+    QByteArray tokenBytes(32, 0);
+    for (int i = 0; i < 32; i++) {
+        tokenBytes[i] = static_cast<char>(QRandomGenerator::global()->bounded(256));
+    }
+    QString token = tokenBytes.toHex();
+
+    SessionInfo info;
+    info.expiry = QDateTime::currentDateTimeUtc().addDays(SESSION_LIFETIME_DAYS);
+    info.userAgent = userAgent;
+    m_sessions[token] = info;
+
+    saveSessions();
+    return token;
+}
+
+bool ShotServer::hasStoredTotpSecret() const
+{
+    if (!m_settings) return false;
+    QVariant secret = m_settings->value("webAuth/totpSecret");
+    return secret.isValid() && !secret.toString().isEmpty();
+}
+
+void ShotServer::loadSessions()
+{
+    if (!m_settings) return;
+    QSettings settings;
+    int count = settings.beginReadArray("webAuth/sessions");
+    for (int i = 0; i < count; i++) {
+        settings.setArrayIndex(i);
+        QString token = settings.value("token").toString();
+        SessionInfo info;
+        info.expiry = settings.value("expiry").toDateTime();
+        info.userAgent = settings.value("userAgent").toString();
+        if (info.expiry > QDateTime::currentDateTimeUtc()) {
+            m_sessions[token] = info;
+        }
+    }
+    settings.endArray();
+    qDebug() << "ShotServer: Loaded" << m_sessions.size() << "active sessions";
+}
+
+void ShotServer::saveSessions()
+{
+    QSettings settings;
+    // Clear expired sessions first
+    QMutableHashIterator<QString, SessionInfo> it(m_sessions);
+    while (it.hasNext()) {
+        it.next();
+        if (it.value().expiry <= QDateTime::currentDateTimeUtc()) {
+            it.remove();
+        }
+    }
+
+    settings.beginWriteArray("webAuth/sessions", m_sessions.size());
+    int i = 0;
+    for (auto sit = m_sessions.constBegin(); sit != m_sessions.constEnd(); ++sit, ++i) {
+        settings.setArrayIndex(i);
+        settings.setValue("token", sit.key());
+        settings.setValue("expiry", sit.value().expiry);
+        settings.setValue("userAgent", sit.value().userAgent);
+    }
+    settings.endArray();
+}

--- a/src/network/webtemplates/auth_page.h
+++ b/src/network/webtemplates/auth_page.h
@@ -1,0 +1,265 @@
+#pragma once
+
+// TOTP Login page - 6-digit code input
+inline constexpr const char* WEB_AUTH_LOGIN_PAGE = R"HTML(
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sign In - Decenza DE1</title>
+    <style>
+        :root {
+            --bg: #0d1117;
+            --surface: #161b22;
+            --border: #30363d;
+            --text: #e6edf3;
+            --text-secondary: #8b949e;
+            --accent: #c9a227;
+            --accent-hover: #d4ad2e;
+            --error: #f85149;
+            --success: #3fb950;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .container {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 40px;
+            max-width: 380px;
+            width: 90%;
+            text-align: center;
+        }
+        .logo { font-size: 48px; margin-bottom: 16px; }
+        h1 { font-size: 22px; margin-bottom: 8px; }
+        .desc {
+            color: var(--text-secondary);
+            font-size: 14px;
+            line-height: 1.5;
+            margin-bottom: 24px;
+        }
+        .code-input {
+            display: flex;
+            justify-content: center;
+            gap: 8px;
+            margin-bottom: 20px;
+        }
+        .code-input input {
+            width: 44px;
+            height: 56px;
+            background: var(--bg);
+            border: 2px solid var(--border);
+            border-radius: 8px;
+            color: var(--text);
+            font-size: 24px;
+            font-weight: 600;
+            text-align: center;
+            outline: none;
+            transition: border-color 0.2s;
+        }
+        .code-input input:focus {
+            border-color: var(--accent);
+        }
+        .btn {
+            background: var(--accent);
+            color: #000;
+            border: none;
+            border-radius: 8px;
+            padding: 14px 28px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            width: 100%;
+            transition: background 0.2s;
+        }
+        .btn:hover { background: var(--accent-hover); }
+        .btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+        .status {
+            margin-top: 16px;
+            font-size: 13px;
+            min-height: 20px;
+        }
+        .status.error { color: var(--error); }
+        .status.success { color: var(--success); }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="logo">&#9749;</div>
+        <h1>Sign In</h1>
+        <p class="desc">
+            Enter the 6-digit code from your authenticator app.
+        </p>
+        <div class="code-input" id="codeInputs">
+            <input type="text" inputmode="numeric" maxlength="1" autocomplete="one-time-code" autofocus>
+            <input type="text" inputmode="numeric" maxlength="1">
+            <input type="text" inputmode="numeric" maxlength="1">
+            <input type="text" inputmode="numeric" maxlength="1">
+            <input type="text" inputmode="numeric" maxlength="1">
+            <input type="text" inputmode="numeric" maxlength="1">
+        </div>
+        <button class="btn" id="loginBtn" onclick="doLogin()">Sign In</button>
+        <div class="status" id="status"></div>
+    </div>
+    <script>
+        var inputs = document.querySelectorAll('.code-input input');
+        inputs.forEach(function(inp, i) {
+            inp.addEventListener('input', function() {
+                if (inp.value.length === 1 && i < 5) inputs[i + 1].focus();
+                if (getCode().length === 6) doLogin();
+            });
+            inp.addEventListener('keydown', function(e) {
+                if (e.key === 'Backspace' && !inp.value && i > 0) {
+                    inputs[i - 1].focus();
+                    inputs[i - 1].value = '';
+                }
+            });
+            inp.addEventListener('paste', function(e) {
+                e.preventDefault();
+                var text = (e.clipboardData || window.clipboardData).getData('text').replace(/\D/g, '');
+                for (var j = 0; j < 6 && j < text.length; j++) {
+                    inputs[j].value = text[j];
+                }
+                if (text.length >= 6) doLogin();
+                else if (text.length > 0) inputs[Math.min(text.length, 5)].focus();
+            });
+        });
+
+        function getCode() {
+            var code = '';
+            inputs.forEach(function(inp) { code += inp.value; });
+            return code;
+        }
+
+        async function doLogin() {
+            var code = getCode();
+            if (code.length !== 6 || !/^\d{6}$/.test(code)) return;
+
+            var btn = document.getElementById('loginBtn');
+            var status = document.getElementById('status');
+            btn.disabled = true;
+            status.textContent = 'Verifying...';
+            status.className = 'status';
+
+            try {
+                var res = await fetch('/api/auth/login', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ code: code })
+                });
+                var data = await res.json();
+                if (res.ok) {
+                    status.textContent = 'Authenticated! Redirecting...';
+                    status.className = 'status success';
+                    setTimeout(function() { window.location.href = '/'; }, 500);
+                } else {
+                    status.textContent = data.error || 'Invalid code';
+                    status.className = 'status error';
+                    btn.disabled = false;
+                    inputs.forEach(function(inp) { inp.value = ''; });
+                    inputs[0].focus();
+                }
+            } catch (e) {
+                status.textContent = 'Connection error';
+                status.className = 'status error';
+                btn.disabled = false;
+            }
+        }
+    </script>
+</body>
+</html>
+)HTML";
+
+// Setup Required page - shown when no TOTP secret is configured
+inline constexpr const char* WEB_AUTH_SETUP_REQUIRED_PAGE = R"HTML(
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Setup Required - Decenza DE1</title>
+    <style>
+        :root {
+            --bg: #0d1117;
+            --surface: #161b22;
+            --border: #30363d;
+            --text: #e6edf3;
+            --text-secondary: #8b949e;
+            --accent: #c9a227;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .container {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 40px;
+            max-width: 420px;
+            width: 90%;
+            text-align: center;
+        }
+        .logo { font-size: 48px; margin-bottom: 16px; }
+        h1 { font-size: 22px; margin-bottom: 8px; }
+        .desc {
+            color: var(--text-secondary);
+            font-size: 14px;
+            line-height: 1.6;
+            margin-bottom: 16px;
+        }
+        .steps {
+            text-align: left;
+            margin: 20px 0;
+            padding: 16px;
+            background: rgba(201, 162, 39, 0.08);
+            border: 1px solid rgba(201, 162, 39, 0.2);
+            border-radius: 8px;
+        }
+        .steps ol {
+            padding-left: 20px;
+            color: var(--text-secondary);
+            font-size: 13px;
+            line-height: 1.8;
+        }
+        .steps li { margin-bottom: 4px; }
+        .steps strong { color: var(--text); }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="logo">&#128274;</div>
+        <h1>Security Setup Required</h1>
+        <p class="desc">
+            Authenticator app verification needs to be configured in the Decenza app before you can access the web interface.
+        </p>
+        <div class="steps">
+            <ol>
+                <li>Open the <strong>Decenza DE1</strong> app on your device</li>
+                <li>Go to <strong>Settings</strong> &rarr; <strong>Data</strong> tab</li>
+                <li>Enable <strong>Security</strong> and follow the setup steps</li>
+                <li>Come back here and <a href="/auth/login" style="color: #c9a227;">sign in</a></li>
+            </ol>
+        </div>
+    </div>
+</body>
+</html>
+)HTML";


### PR DESCRIPTION
## Summary

- Replace WebAuthn (broken on LAN IPs) with TOTP authentication compatible with Apple Passwords, Google Authenticator, 1Password, etc.
- Add HTTPS with self-signed TLS certificates (auto-generated with SANs for all local IPs)
- TOTP setup via QR code or manual secret entry in Settings, 6-digit code login with rate limiting, 90-day session cookies
- Fix crash in `cleanupStaleConnections()` when accessing stale socket peer address
- Fix QSslServer using wrong signal (`pendingConnectionAvailable` instead of `newConnection`)
- macOS Tahoe workaround: use QtTextRendering to avoid PNGReadPlugin emoji crash
- Replace Unicode emoji text with SVG images in several QML pages

## Test plan

- [ ] Enable "Remote Access" + "Enable Security" in Settings → Data tab
- [ ] Open `https://<ip>:8888` in browser → accept self-signed cert → see Setup page
- [ ] Scan QR code with authenticator app, enter 6-digit code → verify succeeds
- [ ] Close browser, reopen → see Login page → enter code → access granted
- [ ] Session persists across page refreshes (90-day cookie)
- [ ] Reset Security button clears TOTP and all sessions
- [ ] Rate limiting: 5 failed attempts within 60s → 429 response
- [ ] Stale connection cleanup does not crash on disconnected sockets

🤖 Generated with [Claude Code](https://claude.com/claude-code)