### PR TITLE
Simplify web shot history sort UI with inline dropdown

### DIFF
--- a/src/network/shotserver_shots.cpp
+++ b/src/network/shotserver_shots.cpp
@@ -422,7 +422,6 @@ QString ShotServer::generateShotListPage() const
 
     // Part 6: Sort dropdown CSS
     html += R"HTML(
-        .sort-field-btn { position: relative; }
         .sort-dir-btn { min-width: 2.2rem; padding-left: 0.5rem; padding-right: 0.5rem; text-align: center; }
         .sort-dropdown {
             position: absolute;
@@ -611,8 +610,8 @@ QString ShotServer::generateShotListPage() const
                     <div class="sort-option" data-sort="dose" data-default-dir="desc" onclick="selectSort('dose')">Dose <span class="sort-check">&#10003;</span></div>
                     <div class="sort-option" data-sort="yield" data-default-dir="desc" onclick="selectSort('yield')">Yield <span class="sort-check">&#10003;</span></div>
                 </div>
+                <button class="search-action-btn sort-dir-btn" id="sortDirBtn" onclick="toggleSortDir()">&#9660;</button>
             </span>
-            <button class="search-action-btn sort-dir-btn" id="sortDirBtn" onclick="toggleSortDir()">&#9660;</button>
         </div>
         <div class="search-panels-anchor">
         <div class="saved-searches-panel" id="savedPanel">


### PR DESCRIPTION
## Summary

- Replace the collapsible sort section (9 buttons in an expandable panel) with two compact inline buttons in the search toolbar: a sort field dropdown and a direction toggle
- Matches the native QML app's sort pattern (dropdown picker + direction button)
- Reduces vertical space usage and makes sorting more discoverable

## Test plan

- [ ] Open web interface → shot history page
- [ ] Verify sort buttons appear inline after the Saved button in the search bar
- [ ] Click sort field button → dropdown shows 9 options with checkmark on active
- [ ] Select a different sort field → cards re-sort, button text updates, default direction applied
- [ ] Click direction arrow → toggles ASC/DESC, cards re-sort
- [ ] Click outside dropdown → closes
- [ ] Test on mobile viewport (600px) → buttons wrap correctly with search row

🤖 Generated with [Claude Code](https://claude.com/claude-code)