### PR TITLE
Bundle OpenSSL DLLs in Windows installer

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -50,6 +50,18 @@ jobs:
         with:
           arch: x64
 
+      - name: Install OpenSSL
+        shell: powershell
+        run: |
+          choco install openssl -y --no-progress
+          $opensslBin = "C:\Program Files\OpenSSL-Win64\bin"
+          if (Test-Path "$opensslBin\libssl-3-x64.dll") {
+            Write-Host "OpenSSL 3 found at: $opensslBin"
+          } else {
+            Write-Error "libssl-3-x64.dll not found in $opensslBin"
+            exit 1
+          }
+
       - name: Configure CMake
         run: |
           mkdir build
@@ -98,6 +110,7 @@ jobs:
           #define QtDir "$QT_DIR"
           #define VcRedistDir "$WORKSPACE\vcredist"
           #define VcRedistFile "vc_redist.x64.exe"
+          #define OpenSslDir "C:\Program Files\OpenSSL-Win64\bin"
           "@ | Out-File -FilePath "installer\setupvars.iss" -Encoding ASCII
 
           Write-Host "=== version.iss ==="

--- a/claude.md
+++ b/claude.md
@@ -582,6 +582,25 @@ The tablet lacks Google certification, so:
 - Some Google apps may prompt to install Play Services
 - GPS-only location works once enabled (see above)
 
+## Windows Installer
+
+The Windows installer is built with Inno Setup (`installer/setup.iss`). It uses a local config file `installer/setupvars.iss` (gitignored) to define machine-specific paths.
+
+### Local setupvars.iss
+Create `installer/setupvars.iss` with paths for your machine:
+```iss
+#define SourceDir "C:\CODE\de1-qt"
+#define AppBuildDir "C:\CODE\de1-qt\build\Release"
+#define AppDeployDir "C:\CODE\de1-qt\installer\deploy"
+#define QtDir "C:\Qt\6.10.2\msvc2022_64"
+#define VcRedistDir "C:\CODE\de1-qt\vcredist"
+#define VcRedistFile "vc_redist.x64.exe"
+#define OpenSslDir "C:\Program Files\OpenSSL-Win64\bin"
+```
+
+### OpenSSL Dependency
+The app links OpenSSL directly (for TLS certificate generation in Remote Access). The installer must bundle `libssl-3-x64.dll` and `libcrypto-3-x64.dll`. If `OpenSslDir` is defined in `setupvars.iss`, the installer copies them automatically. Install OpenSSL for Windows from https://slproweb.com/products/Win32OpenSSL.html if you don't have it.
+
 ## Android Build & Signing
 
 ### Build Process

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -9,6 +9,12 @@
 #expr Exec(QtDir + "\bin\windeployqt.exe", """" + AppDeployDir + "\" + TargetName + ".exe"" --qmldir """ + SourceDir + "\qml"" --no-translations --no-system-d3d-compiler --no-opengl-sw", , , SW_SHOW)
 #expr Exec("cmd.exe", "/c copy /y """ + SourcePath + "\qt.conf"" """ + AppDeployDir + "\""", , , SW_HIDE)
 
+; Copy OpenSSL DLLs (required for TLS in Remote Access)
+#ifdef OpenSslDir
+#expr Exec("cmd.exe", "/c copy /y """ + OpenSslDir + "\libssl-3-x64.dll"" """ + AppDeployDir + "\""", , , SW_HIDE)
+#expr Exec("cmd.exe", "/c copy /y """ + OpenSslDir + "\libcrypto-3-x64.dll"" """ + AppDeployDir + "\""", , , SW_HIDE)
+#endif
+
 [Setup]
 ; Application identity
 AppId={{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}


### PR DESCRIPTION
## Summary
- Install OpenSSL via choco in Windows CI workflow and copy `libssl-3-x64.dll` + `libcrypto-3-x64.dll` into the installer deploy directory
- Add `#ifdef OpenSslDir` guard in `setup.iss` so local builds can opt in by defining the path in their `setupvars.iss`
- Document Windows installer setup and OpenSSL dependency in CLAUDE.md

Fixes #253

## Test plan
- [ ] Trigger Windows CI build (`gh workflow run windows-release.yml`) and verify the installer includes the OpenSSL DLLs
- [ ] Install on a clean Windows machine (no OpenSSL installed) and confirm the app launches without the `libssl-3-x64.dll` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)