### PR TITLE
Fix 13 backup bugs: use-after-free, data integrity, UI

### DIFF
--- a/src/core/databasebackupmanager.h
+++ b/src/core/databasebackupmanager.h
@@ -5,6 +5,7 @@
 #include <QDateTime>
 #include <QThread>
 #include <QVector>
+#include <memory>
 
 class Settings;
 class ShotHistoryStorage;
@@ -123,4 +124,9 @@ private:
     bool m_restoreInProgress = false;  // Prevent concurrent restores
     QStringList m_cachedBackups;       // Cached result of getAvailableBackups()
     QVector<QThread*> m_activeThreads; // Track background threads for cleanup
+
+    // Shared flag: set to true in destructor so background-thread lambdas
+    // that captured `this` can detect the object is gone before invoking
+    // methods on it via QueuedConnection.
+    std::shared_ptr<bool> m_destroyed = std::make_shared<bool>(false);
 };


### PR DESCRIPTION
## Summary

- Fixes 13 bugs in the comprehensive backup feature that were identified in review but missed the PR #265 merge
- Covers use-after-free in background threads, data integrity during DB import, macOS ZIP extraction, and QML UI state issues

## Changes

### C++ — `databasebackupmanager.h/.cpp`
- **Use-after-free prevention**: Destructor waits indefinitely (not 5s) for background threads; added `shared_ptr<bool> m_destroyed` flag guarding all 8 `QMetaObject::invokeMethod` callbacks across 3 thread lambdas
- **macOS ZIP extraction**: `canonicalPath()` → `absolutePath()` to avoid `/tmp` → `/private/tmp` symlink mismatch breaking path traversal guard
- **ZIP write safety**: Check `QZipWriter::status()` before `close()` (not after); remove partial ZIP file on failure
- **Replace-mode media**: Clear existing media files before restoring (was only clearing profiles)

### C++ — `shothistorystorage.cpp`
- **WAL checkpoint race**: Move `QFile::copy` inside the DB connection scope so no other writer can modify between checkpoint and copy
- **Old-schema import**: Default `beverage_type` to `"espresso"` when source DB column is missing (NULL)
- **Backfill query**: Include `OR beverage_type IS NULL` so NULL values from old DBs are also backfilled
- **Backfill transaction**: Check `transaction()` and `commit()` return values with rollback on failure

### QML — `SettingsDataTab.qml`
- **Translated string comparison**: Replace `=== TranslationManager.translate(...)` with `searchPerformed` boolean flag driven by `onDiscoveryComplete` signal
- **Restore button guard**: Disable during active backup/restore operations
- **Binding safety**: Cache `hasStoragePermission()` as a property (method calls don't re-evaluate in QML bindings)
- **Auto-focus**: `onVisibleChanged` instead of `Component.onCompleted` for manual IP field

## Test plan
- [ ] Create a manual backup, verify ZIP is created successfully
- [ ] Restore a backup in both merge and replace mode
- [ ] Test replace-mode media restore (existing files should be cleared)
- [ ] Import from an old-schema DB without `beverage_type` column
- [ ] On Android, verify storage permission warning/button behavior
- [ ] Search for devices, verify "No devices found" hint appears after search completes
- [ ] Verify restore button is disabled during active backup/restore

🤖 Generated with [Claude Code](https://claude.ai/code)