### PR TITLE
Fix BLE Health Refresh reconnection failures on low-end tablets

### DIFF
--- a/src/ble/blerefresher.h
+++ b/src/ble/blerefresher.h
@@ -35,7 +35,7 @@ signals:
     void refreshingChanged();
 
 private:
-    void scheduleRefresh();
+    void scheduleRefresh(bool isWakeTrigger = false);
     void executeRefresh();
     void onRefreshComplete();
 
@@ -51,14 +51,20 @@ private:
     bool m_de1WasConnected = false;
     bool m_scaleWasConnected = false;
     QElapsedTimer m_lastRefresh;
+    QElapsedTimer m_de1ConnectedSince;  // Tracks current connection uptime
+    bool m_de1ConnectedSinceValid = false;  // Whether m_de1ConnectedSince is running
     int m_periodicIntervalMs = 5 * 3600 * 1000;  // 5 hours default
+    int m_scanRetryCount = 0;
 
     // Temporary connections for event-driven sequencing
     QMetaObject::Connection m_phaseConn;
     QMetaObject::Connection m_de1ConnConn;
     QMetaObject::Connection m_scanConn;
+    QMetaObject::Connection m_de1UptimeConn;
 
     static constexpr int MIN_REFRESH_INTERVAL_MS = 60 * 60 * 1000;  // 60 minute debounce
+    static constexpr int WAKE_MIN_UPTIME_MS = 2 * 3600 * 1000;  // 2 hours
+    static constexpr int MAX_SCAN_RETRIES = 2;  // 3 total scans (initial + 2 retries)
 };
 
 #endif // BLEREFRESHER_H


### PR DESCRIPTION
## Summary

Fixes #269 — A7 Lite user reports app fails to reconnect to DE1 after waking with BLE Health Refresh enabled.

- **Wake trigger uptime gate**: Wake-from-sleep triggers now require 2+ hours of continuous DE1 connection before firing. Short connections don't suffer from BLE stack degradation and shouldn't be disrupted.
- **Scan retry logic**: Replaces fire-and-forget fallback scan (which immediately disconnected all listeners) with up to 3 total scans (~45s window), keeping reconnect listeners active through retries. Slow MediaTek BLE chipsets on tablets like the A7 Lite get enough time to rediscover the DE1.
- **Stale listener fix**: Successful reconnect now also disconnects `m_scanConn`, preventing a stale scan listener from firing after the DE1 has already reconnected.

## Test plan

- [ ] Build in Qt Creator (no CLI build needed)
- [ ] Verify `[BleRefresher]` debug logs for each scenario:
  - Wake after short uptime (<2h): logs "Wake trigger skipped: connection uptime Xs < minimum 7200s"
  - Wake after long uptime (>2h): proceeds with refresh
  - Periodic timer: always proceeds (no uptime check)
  - Scan retry on failure: logs retry count and continues scanning
  - All retries exhausted: logs "All 3 scans exhausted" and completes gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)