### PR TITLE
fix: back button on shot review returns to home instead of mid-shot graph

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -2265,8 +2265,8 @@ ApplicationWindow {
 
     function goToShotMetadata(shotId) {
         if (!startNavigation()) return
-        // Pass editShotId to edit the just-saved shot (always use edit mode now)
-        pageStack.push(postShotReviewPage, { editShotId: shotId || 0 })
+        // Replace EspressoPage so back button returns to home, not the mid-shot graph
+        pageStack.replace(postShotReviewPage, { editShotId: shotId || 0 })
     }
 
     // Helper to announce arbitrary text for accessibility (used for non-page announcements)


### PR DESCRIPTION
## Summary

- `goToShotMetadata()` was using `pageStack.push()` to navigate to `PostShotReviewPage`, leaving `EspressoPage` in the stack underneath
- Pressing back on the shot review page would pop back to the mid-shot graph (EspressoPage) instead of the home screen
- Fixed by using `pageStack.replace()` so `EspressoPage` is replaced and back navigates correctly to idle

## Test plan
- [ ] Pull an espresso shot
- [ ] When shot review page appears, press back
- [ ] Verify it returns to the home/idle screen, not the mid-shot graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)