### PR TITLE
Fix back button not working on post-shot review page

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1579,7 +1579,8 @@ ApplicationWindow {
             // Return to saved page if set, otherwise go to idlePage
             if (root.returnToPageName === "postShotReviewPage") {
                 var shotId = root.returnToShotId > 0 ? root.returnToShotId : MainController.lastSavedShotId
-                pageStack.replace(postShotReviewPage, { editShotId: shotId })
+                pageStack.replace(idlePage)
+                pageStack.push(postShotReviewPage, { editShotId: shotId })
             } else {
                 if (pageStack.currentItem && pageStack.currentItem.objectName !== "idlePage") {
                     pageStack.replace(idlePage)
@@ -2138,7 +2139,8 @@ ApplicationWindow {
         if ((currentPage === "steamPage" || currentPage === "hotWaterPage" || currentPage === "flushPage") &&
             root.returnToPageName === "postShotReviewPage") {
             var shotId = root.returnToShotId > 0 ? root.returnToShotId : MainController.lastSavedShotId
-            pageStack.replace(postShotReviewPage, { editShotId: shotId })
+            pageStack.replace(idlePage)
+            pageStack.push(postShotReviewPage, { editShotId: shotId })
             root.returnToPageName = ""
             root.returnToShotId = 0
             return
@@ -2265,8 +2267,9 @@ ApplicationWindow {
 
     function goToShotMetadata(shotId) {
         if (!startNavigation()) return
-        // Replace EspressoPage so back button returns to home, not the mid-shot graph
-        pageStack.replace(postShotReviewPage, { editShotId: shotId || 0 })
+        // Put idlePage on the stack so back button returns to idle, not the mid-shot graph
+        pageStack.replace(idlePage)
+        pageStack.push(postShotReviewPage, { editShotId: shotId || 0 })
     }
 
     // Helper to announce arbitrary text for accessibility (used for non-page announcements)

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -714,12 +714,7 @@ Page {
             if (hasUnsavedChanges) {
                 unsavedChangesDialog.open()
             } else {
-                // If editing from history, pop back to history; otherwise go to idle
-                if (isEditMode) {
-                    pageStack.pop()
-                } else {
-                    goToIdle()
-                }
+                pageStack.pop()
             }
         }
 
@@ -1089,19 +1084,11 @@ Page {
         itemType: "shot"
         showSaveAs: false
         onDiscardClicked: {
-            if (isEditMode) {
-                pageStack.pop()
-            } else {
-                goToIdle()
-            }
+            pageStack.pop()
         }
         onSaveClicked: {
             saveEditedShot()
-            if (isEditMode) {
-                pageStack.pop()
-            } else {
-                goToIdle()
-            }
+            pageStack.pop()
         }
     }
 


### PR DESCRIPTION
## Summary

- After a shot, the back button on the post-shot review page did nothing — tapping it had no effect and users were stuck
- Root cause: `goToShotMetadata()` used `pageStack.replace()` which put PostShotReviewPage at the bottom of the stack with nothing to `pop()` to
- Fix: all navigation paths now put idlePage on the stack first (`replace(idlePage)` + `push(postShotReviewPage)`), so `pop()` always returns to the correct page
- Simplifies PostShotReviewPage by removing conditional back-button logic — `pop()` works in all cases (idle after a shot, history list when browsing)

## Test plan

- [ ] Pull a shot — after shot ends, verify back button on review page returns to idle
- [ ] Open a shot from shot history — verify back button returns to shot history list
- [ ] On review page with unsaved changes, verify discard and save both navigate back correctly
- [ ] Start steam/flush from review page — verify returning to review page still has working back button

🤖 Generated with [Claude Code](https://claude.com/claude-code)