### PR TITLE
Fix launcher mode crash on Android

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -61,6 +61,7 @@
                 <category android:name="android.intent.category.HOME" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <meta-data android:name="android.app.lib_name" android:value="Decenza_DE1" />
         </activity-alias>
 
         <!-- Service for handling device shutdown when app is swiped away -->


### PR DESCRIPTION
## Summary
- Fix crash when app is launched via HOME intent after enabling "Launcher Mode" in Settings
- The `LauncherAlias` activity-alias was missing `android.app.lib_name` metadata, causing Qt's `QtLoader` to construct an invalid library name (`lib_arm64-v8a.so` instead of `libDecenza_DE1_arm64-v8a.so`)

## Root Cause
When Android launches the app through the `LauncherAlias`, Qt reads `android.app.lib_name` from the launching component's metadata. Activity-aliases do **not** inherit metadata from their target activity. With no metadata on the alias, Qt got an empty library name, appended only the ABI suffix, and crashed trying to load a nonexistent `lib_arm64-v8a.so`.

## Fix
Add `<meta-data android:name="android.app.lib_name" android:value="Decenza_DE1" />` to the `LauncherAlias` element in `AndroidManifest.xml`.

Fixes #246, fixes #247, fixes #254

## Test plan
- [ ] Enable "Launcher Mode" in Settings → Preferences on Android
- [ ] Select Decenza as default home app when prompted
- [ ] Press HOME button — app should launch without crash
- [ ] Disable launcher mode and verify normal launch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)