### PR TITLE
Fix startup double-read, duplicate LCD disable, and BLE settings UI

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -2119,9 +2119,7 @@ ApplicationWindow {
                 // Sleep before the wake command takes effect)
                 if (!screensaverActive && !root.startupGracePeriod && !root.shuttingDown) {
                     console.log("Machine entered Sleep - showing screensaver")
-                    if (ScaleDevice && ScaleDevice.connected) {
-                        ScaleDevice.disableLcd()
-                    }
+                    // Scale LCD disable is handled by C++ phaseChanged handler in main.cpp
                     goToScreensaver()
                 }
             } else if (phase === MachineStateType.Phase.Idle || phase === MachineStateType.Phase.Ready) {

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -391,6 +391,7 @@ Item {
                         Layout.fillWidth: true
                         Layout.preferredHeight: Theme.scaled(60)
                         clip: true
+                        visible: !DE1Device.connected
                         model: BLEManager.discoveredDevices
 
                         delegate: ItemDelegate {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -356,6 +356,7 @@ MainController::MainController(QNetworkAccessManager* networkManager,
     } else {
         loadDefaultProfile();
     }
+    m_profileJsonCache.clear();  // Free cached JSON after startup profile load
 
     // Keep MachineState in sync when yield override changes in Settings
     if (m_settings) {
@@ -901,7 +902,11 @@ void MainController::loadProfile(const QString& profileName) {
 
     // 1. Check ProfileStorage first (SAF folder on Android)
     if (m_profileStorage && m_profileStorage->isConfigured()) {
-        QString jsonContent = m_profileStorage->readProfile(resolvedName);
+        // Use cached JSON from refreshProfiles() if available (avoids double-read at startup)
+        QString jsonContent = m_profileJsonCache.take(resolvedName);
+        if (jsonContent.isEmpty()) {
+            jsonContent = m_profileStorage->readProfile(resolvedName);
+        }
         if (!jsonContent.isEmpty()) {
             m_currentProfile = Profile::loadFromJsonString(jsonContent);
             found = true;
@@ -1159,6 +1164,7 @@ void MainController::refreshProfiles() {
     m_availableProfiles.clear();
     m_profileTitles.clear();
     m_allProfiles.clear();
+    m_profileJsonCache.clear();
 
     // Helper to load profile metadata from file path
     auto loadProfileMeta = [](const QString& path) -> std::tuple<QString, QString, bool> {
@@ -1210,6 +1216,9 @@ void MainController::refreshProfiles() {
             if (jsonContent.isEmpty()) {
                 continue;
             }
+
+            // Cache for loadProfile() to avoid re-reading from storage
+            m_profileJsonCache[name] = jsonContent;
 
             auto [title, beverageType, isRecipeMode] = loadProfileMetaFromJson(jsonContent);
 

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -308,6 +308,7 @@ private:
     Profile m_currentProfile;
     QStringList m_availableProfiles;
     QMap<QString, QString> m_profileTitles;  // filename -> display title
+    QMap<QString, QString> m_profileJsonCache;  // filename -> JSON (populated by refreshProfiles, consumed by loadProfile)
     QList<ProfileInfo> m_allProfiles;  // Complete list with metadata
     double m_shotStartTime = 0;
     double m_lastSampleTime = 0;  // For delta time calculation (DE1's raw timer)


### PR DESCRIPTION
## Summary
- **Profile double-read**: `refreshProfiles()` reads all profiles from external storage for metadata, then `loadProfile()` reads the current profile again. Added a JSON cache so the startup profile load reuses the already-read content instead of hitting disk twice.
- **Duplicate scale LCD disable**: Both a QML handler and a C++ handler called `disableLcd()` on the same Sleep phase change, sending the BLE command twice. Removed the QML one since the C++ handler in `main.cpp` already covers it.
- **"No devices found" while connected**: The machine device list on the Bluetooth settings tab was always visible, so when connected (scan stopped, list empty) it showed "No devices found". Hidden when `DE1Device.connected` is true.

## Test plan
- [ ] Launch app with a profile in external storage — verify only one "Read from external" log line for the startup profile
- [ ] Connect DE1, let it go to sleep — verify only one "Disabling LCD" log line (not two)
- [ ] Open Settings → Connections with DE1 connected — verify no "No devices found" text shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)