### PR TITLE
Improve flow calibration accuracy and reduce BLE log noise

### DIFF
--- a/docs/AUTO_FLOW_CALIBRATION.md
+++ b/docs/AUTO_FLOW_CALIBRATION.md
@@ -34,7 +34,11 @@ The algorithm iterates through the shot's pressure data looking for the longest 
 - Machine flow > 0.1 ml/s (excludes stalled flow)
 - Nearest scale data point within 1 second (ensures weight flow data alignment)
 
-Any sample that fails these criteria breaks the current window, and the algorithm picks the longest qualifying window from the entire shot. The window must span at least 5 seconds with at least 5 samples to provide a reliable average.
+Any sample that fails these criteria breaks the current window, and the algorithm picks the longest qualifying window from the entire shot. The window must span at least 4 seconds with at least 5 samples to provide a reliable average.
+
+### Stream Force Rejection
+
+Before running calibration, the algorithm checks whether the settled weight dropped significantly below the weight at pump stop (> 3g drop). This indicates the stream of water hitting the cup was adding downward force to the scale during extraction, inflating the weight readings. Calibrating against these inflated readings would produce a multiplier that's too high, so the shot is skipped. This typically occurs with high-flow profiles where the stream has significant momentum.
 
 ### Density Correction
 

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -158,7 +158,10 @@ void QtScaleBleTransport::discoverCharacteristics(const QBluetoothUuid& serviceU
 
 void QtScaleBleTransport::enableNotifications(const QBluetoothUuid& serviceUuid,
                                               const QBluetoothUuid& characteristicUuid) {
-    QT_TRANSPORT_LOG(QString("Enabling notifications for %1").arg(characteristicUuid.toString()));
+    const bool firstEnable = !m_notificationsEnabledOnce;
+    if (firstEnable) {
+        QT_TRANSPORT_LOG(QString("Enabling notifications for %1").arg(characteristicUuid.toString()));
+    }
 
     QLowEnergyService* service = m_services.value(serviceUuid);
     if (!service) {
@@ -178,11 +181,15 @@ void QtScaleBleTransport::enableNotifications(const QBluetoothUuid& serviceUuid,
         QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration);
 
     if (cccd.isValid()) {
-        QT_TRANSPORT_LOG("Writing CCCD to enable notifications");
+        if (firstEnable) {
+            QT_TRANSPORT_LOG("Writing CCCD to enable notifications");
+        }
         service->writeDescriptor(cccd, QByteArray::fromHex("0100"));
     } else {
         QT_TRANSPORT_LOG("CCCD descriptor not found - scale may still send notifications");
     }
+
+    m_notificationsEnabledOnce = true;
 
     // Emit immediately (fire-and-forget) - don't wait for CCCD write response.
     // Some scales (e.g. Bookoo) reject CCCD writes but still send notifications.
@@ -244,6 +251,7 @@ void QtScaleBleTransport::onControllerConnected() {
 void QtScaleBleTransport::onControllerDisconnected() {
     QT_TRANSPORT_LOG("Controller disconnected");
     m_connected = false;
+    m_notificationsEnabledOnce = false;
     emit disconnected();
 }
 
@@ -363,9 +371,8 @@ void QtScaleBleTransport::onCharacteristicWritten(const QLowEnergyCharacteristic
 
 void QtScaleBleTransport::onDescriptorWritten(const QLowEnergyDescriptor& d, const QByteArray& value) {
     Q_UNUSED(value);
-    if (d.type() == QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration) {
-        QT_TRANSPORT_LOG("CCCD write confirmed by remote device");
-    }
+    // CCCD confirmations are expected and frequent (keep-alive re-enables every ~5 min) - don't log
+    Q_UNUSED(d);
 }
 
 void QtScaleBleTransport::onServiceError(QLowEnergyService::ServiceError err) {

--- a/src/ble/transport/qtscalebletransport.h
+++ b/src/ble/transport/qtscalebletransport.h
@@ -58,4 +58,5 @@ private:
     QString m_deviceName;
     QString m_deviceId;  // UUID on iOS, address on other platforms - for duplicate detection
     bool m_connected = false;
+    bool m_notificationsEnabledOnce = false;  // Suppress routine CCCD logging after first enable
 };

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2253,6 +2253,18 @@ void MainController::computeAutoFlowCalibration() {
         return;
     }
 
+    // Reject shots where settled weight dropped significantly below the weight at SAW stop.
+    // This indicates stream impact force was inflating scale readings during extraction,
+    // which would produce an unreliable (too high) calibration multiplier.
+    double weightAtStop = m_shotDataModel->weightAtStop();
+    double finalWeight = m_shotDataModel->finalWeight();
+    if (weightAtStop > 5.0 && finalWeight > 0 && finalWeight < weightAtStop - 3.0) {
+        qDebug() << "Auto flow cal: skipped (weight dropped after stop:"
+                 << weightAtStop << "g ->" << finalWeight << "g,"
+                 << "delta:" << (weightAtStop - finalWeight) << "g — likely stream force artifact)";
+        return;
+    }
+
     const auto& flowData = m_shotDataModel->flowData();
     const auto& pressureData = m_shotDataModel->pressureData();
     if (flowData.size() < 10 || pressureData.size() < 10) {
@@ -2267,7 +2279,7 @@ void MainController::computeAutoFlowCalibration() {
     constexpr double kMinWeightFlow = 0.5;           // g/s - excludes dripping/dead time
     constexpr double kMinMachineFlow = 0.1;          // ml/s - excludes stalled flow
     constexpr double kMaxScaleDataGap = 1.0;         // seconds - max distance to nearest weight flow point
-    constexpr double kMinWindowDuration = 5.0;       // seconds
+    constexpr double kMinWindowDuration = 4.0;       // seconds (4s is enough for ~20 samples at 5Hz)
     constexpr int    kMinWindowSamples = 5;
     constexpr double kWaterDensity93C = 0.963;       // g/ml - density correction for water at ~93°C
     constexpr double kCalibrationMin = 0.5;          // sanity lower bound


### PR DESCRIPTION
## Summary
- **Stream force rejection**: Skip auto flow calibration when settled weight drops >3g below weight at SAW stop — this indicates stream impact force was inflating scale readings, producing unreliable multipliers
- **Lower minimum window**: Reduce calibration window threshold from 5s to 4s (still ~20 samples at 5Hz), allowing more shots to qualify
- **Reduce BLE log noise**: Suppress repetitive CCCD notification logging after first enable (keep-alive re-enables every ~5 min were flooding debug logs)

## Test plan
- [ ] Run a shot with a high-flow profile and verify calibration is skipped when weight drops after stop (check debug log for "stream force artifact" message)
- [ ] Run a normal shot and verify calibration still runs with the 4s window
- [ ] Check debug log during scale connection — CCCD messages should appear once, not repeatedly

🤖 Generated with [Claude Code](https://claude.com/claude-code)