### PR TITLE
Fix de1app JSON format detection in loadFromJsonString()

### DIFF
--- a/src/profile/profile.cpp
+++ b/src/profile/profile.cpp
@@ -571,6 +571,12 @@ Profile Profile::loadFromJsonString(const QString& jsonContent) {
                    << "at offset" << parseError.offset;
         return Profile();
     }
+    // Detect de1app v2 JSON format (same check as loadFromFile)
+    QJsonObject obj = doc.object();
+    if (obj.contains("version") || obj.contains("legacy_profile_type")) {
+        return loadFromDE1AppJson(jsonContent);
+    }
+
     return fromJson(doc);
 }
 


### PR DESCRIPTION
## Summary

- `loadFromJsonString()` was missing de1app format detection, causing all numeric fields to silently default (pressure=9, flow=2, temp=93, seconds=30) when loading de1app/D-Flow profiles from shot history, visualizer import, or any other string-based path
- Added the same `"version"`/`"legacy_profile_type"` key check that `loadFromFile()` already uses, routing de1app format JSON to `loadFromDE1AppJson()` which handles string-encoded numbers and nested exit/limiter objects correctly

Fixes #320

## Root Cause

De1app JSON encodes numbers as strings (`"3.0"` instead of `3.0`). `QJsonValue::toDouble(default)` returns the **default** for string-typed values, so every numeric field silently got its default value. The profile still parsed with a valid title and steps, so the fallback to `loadFromDE1AppJson()` never triggered.

`loadFromFile()` already had the correct detection (checking for `"version"` or `"legacy_profile_type"` keys), but `loadFromJsonString()` was never updated with the same check. This affected all 6 call sites: shot history, profile storage, visualizer import, profile import, data migration, and frame description.

## Test plan

- [ ] Load a de1app format D-Flow profile from shot history — values should match the original (pressure=3.0, flow=8, temp=88, not the defaults 9/2/93)
- [ ] Import a de1app format profile from visualizer — should parse correctly
- [ ] Verify native Decenza format profiles still load correctly (no regression)
- [ ] Verify exit conditions and limiter values are preserved on de1app profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)