### PR TITLE
Match de1app BLE header values for MinimumPressure and MaximumFlow

### DIFF
--- a/src/profile/profile.cpp
+++ b/src/profile/profile.cpp
@@ -696,6 +696,9 @@ Profile Profile::loadFromTclString(const QString& content) {
     val = extractValue("maximum_pressure");
     if (!val.isEmpty()) profile.m_maximumPressure = val.toDouble();
 
+    val = extractValue("flow_profile_minimum_pressure");
+    if (!val.isEmpty()) profile.m_minimumPressure = val.toDouble();
+
     val = extractValue("tank_desired_water_temperature");
     if (!val.isEmpty()) profile.m_tankDesiredWaterTemperature = val.toDouble();
 
@@ -1018,8 +1021,10 @@ QByteArray Profile::toHeaderBytes() const {
     header[0] = 1;  // HeaderV
     header[1] = static_cast<char>(m_steps.size());  // NumberOfFrames
     header[2] = static_cast<char>(m_preinfuseFrameCount);  // NumberOfPreinfuseFrames
-    header[3] = BinaryCodec::encodeU8P4(m_minimumPressure);  // MinimumPressure
-    header[4] = BinaryCodec::encodeU8P4(m_maximumFlow);  // MaximumFlow
+    // De1app defaults to IgnoreLimit, so MinimumPressure and MaximumFlow are not
+    // used as constraints. Hardcode to match de1app (binary.tcl:867-868).
+    header[3] = 0;  // MinimumPressure
+    header[4] = BinaryCodec::encodeU8P4(6.0);  // MaximumFlow
 
     return header;
 }


### PR DESCRIPTION
## Summary
- Hardcode `MinimumPressure=0` and `MaximumFlow=6` in BLE profile header to match de1app (`binary.tcl:867-868`)
- Every frame sets `IgnoreLimit`, so these header-level limits are never used by the machine — de1app knows this and hardcodes them
- Read `flow_profile_minimum_pressure` from TCL profiles for data fidelity (stored in JSON, never sent to machine)

## Context
Found during TCL vs JSON parser comparison while verifying PR #324. De1app stores `flow_profile_minimum_pressure` in profile files but never uses it for BLE control — it's a vestigial setting.

## Test plan
- [ ] Import TCL profile with `flow_profile_minimum_pressure 4`, verify value preserved in saved JSON
- [ ] Verify BLE header sends MinimumPressure=0 and MaximumFlow=6 (check debug log during profile upload)
- [ ] No behavioral change expected (IgnoreLimit flag already made these values unused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)