### PR TITLE
Preserve volume/exitWeight passthrough fields on recipe regeneration

### DIFF
--- a/src/profile/profile.cpp
+++ b/src/profile/profile.cpp
@@ -1089,12 +1089,34 @@ void Profile::regenerateFromRecipe() {
         return;
     }
 
+    // Save old frames so we can preserve passthrough fields after regeneration
+    QList<ProfileFrame> oldSteps = m_steps;
+
     // Regenerate frames from recipe parameters
     m_steps = RecipeGenerator::generateFrames(m_recipeParams);
 
     if (m_steps.size() == 1 && m_steps[0].name == "empty") {
         qWarning() << "regenerateFromRecipe: recipe produced fallback empty frame"
                    << "- check recipe parameters for" << m_title;
+    }
+
+    // Preserve passthrough fields (volume cap, fill weight safety exit) from old frames.
+    // RecipeParams controls volume/exitWeight only on infuse frames ("Infusing"/"Infuse");
+    // for all other frames these fields are hardcoded defaults in RecipeGenerator, so we
+    // restore the stored values to avoid silently dropping them on each save (issue #331).
+    if (!oldSteps.isEmpty()) {
+        for (ProfileFrame& newFrame : m_steps) {
+            // Skip infuse frames — RecipeParams is authoritative for their volume/exitWeight
+            if (newFrame.name == "Infusing" || newFrame.name == "Infuse")
+                continue;
+            for (const ProfileFrame& oldFrame : oldSteps) {
+                if (oldFrame.name == newFrame.name) {
+                    newFrame.volume = oldFrame.volume;
+                    newFrame.exitWeight = oldFrame.exitWeight;
+                    break;
+                }
+            }
+        }
     }
 
     // Update profile metadata from recipe


### PR DESCRIPTION
## Summary

Fixes #331

- `regenerateFromRecipe()` was rebuilding all frames from scratch via `RecipeGenerator`, silently dropping per-frame fields not represented in `RecipeParams`
- Fields lost: fill weight safety exit (`exitWeight=5.0g` on Filling), volume caps (`volume=60ml` on Filling, `volume=100ml` on Pouring) for D-Flow La Pavoni/Q profiles
- Fix: save existing frames before regeneration, then restore `volume` and `exitWeight` from the matching old frame (by name) for all frames **except** infuse frames (`"Infusing"`/`"Infuse"`), where `RecipeParams` is authoritative via `infuseVolume`/`infuseWeight`

This matches de1app's partial-edit-in-place approach. Since this ships in the same release as `migrateRecipeFrames()`, the migration will run for the first time with the fixed code — correctly preserving passthrough fields from the (already correct) stored JSON files.

## Test plan

- [ ] Load D-Flow La Pavoni or D-Flow default profile
- [ ] Edit a recipe parameter (e.g. pour flow) and save
- [ ] Verify Filling frame retains `exitWeight=5.0` and `volume=60` (La Pavoni) after save
- [ ] Verify Pouring frame retains `volume=100` (La Pavoni) after save
- [ ] Verify Infusing frame still uses `infuseVolume`/`infuseWeight` from RecipeParams (not preserved from old frame)

🤖 Generated with [Claude Code](https://claude.com/claude-code)