### PR TITLE
Rename debug page to Debugging Tools, reorder layout, remove unused AudioOutput

### DIFF
--- a/qml/pages/ScreensaverPage.qml
+++ b/qml/pages/ScreensaverPage.qml
@@ -183,7 +183,6 @@ Page {
 
     MediaPlayer {
         id: mediaPlayer
-        audioOutput: AudioOutput { volume: 0 }  // Muted
         videoOutput: videoOutput
 
         onMediaStatusChanged: {

--- a/src/network/shotserver_shots.cpp
+++ b/src/network/shotserver_shots.cpp
@@ -3098,7 +3098,7 @@ QString ShotServer::generateDebugPage() const
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Debug &amp; Dev Tools - Decenza DE1</title>
+    <title>Debugging Tools - Decenza DE1</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script>if (typeof Chart === "undefined") document.getElementById("memoryBody").innerHTML = "<p style='color:#8b949e;padding:1em'>Chart.js failed to load (no internet?). Memory data is still available via <code>/api/memory</code>.</p>";</script>
     <style>
@@ -3270,14 +3270,12 @@ QString ShotServer::generateDebugPage() const
             background: #000;
             border: 1px solid var(--border);
             border-radius: 8px;
-            height: calc(100vh - 500px);
+            height: calc(100vh - 280px);
             overflow-y: auto;
             font-family: "Consolas", "Monaco", "Courier New", monospace;
             font-size: 12px;
             padding: 0.5rem;
-        }
-        .log-container.expanded {
-            height: calc(100vh - 120px);
+            margin-bottom: 1rem;
         }
         .log-line {
             white-space: pre;
@@ -3295,7 +3293,7 @@ QString ShotServer::generateDebugPage() const
     <header class="header">
         <div class="header-content">
             <a href="/" class="back-btn">&#8592;</a>
-            <h1>Debug &amp; Dev Tools</h1>
+            <h1>Debugging Tools</h1>
             <div class="status">
                 <span class="status-dot"></span>
                 <span id="lineCount">0 lines</span>
@@ -3309,6 +3307,12 @@ QString ShotServer::generateDebugPage() const
         </div>
     </header>
     <main class="container">
+        <div style="margin-bottom:1rem;display:flex;gap:0.5rem;flex-wrap:wrap;">
+            <a href="/database.db" class="btn" style="text-decoration:none;">&#128190; Download Database</a>
+            <button class="btn" onclick="downloadLog()">&#128196; Download Log</button>
+            <a href="/upload" class="btn" style="text-decoration:none;">&#128230; Upload APK</a>
+        </div>
+        <div class="log-container" id="logContainer"></div>
         <div class="memory-section" id="memorySection">
             <div class="memory-header" onclick="toggleMemory()">
                 <h2>Memory</h2>
@@ -3355,12 +3359,6 @@ QString ShotServer::generateDebugPage() const
                 </div>
             </div>
         </div>
-        <div style="margin-bottom:1rem;display:flex;gap:0.5rem;flex-wrap:wrap;">
-            <a href="/database.db" class="btn" style="text-decoration:none;">&#128190; Download Database</a>
-            <button class="btn" onclick="downloadLog()">&#128196; Download Log</button>
-            <a href="/upload" class="btn" style="text-decoration:none;">&#128230; Upload APK</a>
-        </div>
-        <div class="log-container" id="logContainer"></div>
     </main>
     <script>
         /* --- Memory section --- */
@@ -3371,7 +3369,6 @@ QString ShotServer::generateDebugPage() const
             memoryCollapsed = !memoryCollapsed;
             document.getElementById("memoryBody").classList.toggle("collapsed", memoryCollapsed);
             document.getElementById("memoryToggle").textContent = memoryCollapsed ? "Expand" : "Collapse";
-            document.getElementById("logContainer").classList.toggle("expanded", memoryCollapsed);
         }
 
         function formatUptime(minutes) {

--- a/src/network/webtemplates/menu_html.h
+++ b/src/network/webtemplates/menu_html.h
@@ -13,7 +13,6 @@ inline QString generateMenuHtml(bool includeUploadApk = false)
                     <div class="menu-dropdown" id="menuDropdown">
                         <a href="#" class="menu-item" id="powerToggle" onclick="togglePower(); return false;">&#9889; Loading...</a>
                         <a href="/" class="menu-item">&#127866; Shot History</a>
-                        <a href="/debug" class="menu-item">&#128196; Live Debug Log</a>
                         <a href="/remote" class="menu-item">&#128421; Remote Control</a>
                         <a href="/settings" class="menu-item">&#128273; AI and Web Service Connections</a>)HTML";
 
@@ -34,6 +33,7 @@ inline QString generateMenuHtml(bool includeUploadApk = false)
                         <a href="/api/backup/full" class="menu-item">&#128230; Download Backup</a>
                         <a href="/restore" class="menu-item">&#128229; Restore Backup</a>
                         <a href="/ai-conversations" class="menu-item">&#129302; AI Conversations</a>
+                        <a href="/debug" class="menu-item">&#128296; Debugging Tools</a>
                     </div>
                 </div>)HTML";
 


### PR DESCRIPTION
## Summary

- Renames "Live Debug Log" menu item to "Debugging Tools" and moves it to the bottom of the nav menu
- Renames debug page title/h1 from "Debug & Dev Tools" to "Debugging Tools"
- Moves the log output window above the memory section so controls are logically adjacent to the log
- Removes unused `AudioOutput` from the screensaver `MediaPlayer` — suppresses "Low latency performance mode not set" Android warning on every startup

## Test plan

- [ ] Open web interface, verify "Debugging Tools" appears at the bottom of the nav menu
- [ ] Navigate to Debugging Tools page — log window appears first, memory section below
- [ ] Verify log auto-scroll, clear, download buttons work as before
- [ ] Verify memory section collapse/expand still works
- [ ] On Android, verify "Low latency performance mode not set" warning no longer appears in logs at startup
- [ ] Verify screensaver videos still play (muted) correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)