### PR TITLE
Fix SAW stop latency on slow devices via high-priority event delivery

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -564,6 +564,13 @@ void DE1Device::stopOperationUrgent() {
     stopOperationUrgent(0);
 }
 
+void DE1Device::customEvent(QEvent* event) {
+    if (event->type() == SawStopEvent::eventType()) {
+        auto* e = static_cast<SawStopEvent*>(event);
+        stopOperationUrgent(e->sawTriggerMs());
+    }
+}
+
 void DE1Device::stopOperationUrgent(qint64 sawTriggerMs) {
 #if (defined(Q_OS_WIN) || defined(Q_OS_MACOS)) && defined(QT_DEBUG)
     if (m_simulationMode && m_simulator) {

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -3,8 +3,25 @@
 #include <QObject>
 #include <QBluetoothDeviceInfo>
 #include <QBluetoothUuid>
+#include <QEvent>
 
 #include "protocol/de1characteristics.h"
+
+// High-priority custom event posted by WeightProcessor to bypass the normal
+// QueuedConnection queue on slow devices. Delivered via Qt::HighEventPriority
+// so it jumps ahead of pending D-Flow setpoint events on the main thread.
+class SawStopEvent : public QEvent {
+public:
+    static QEvent::Type eventType() {
+        static int type = QEvent::registerEventType();
+        return static_cast<QEvent::Type>(type);
+    }
+    explicit SawStopEvent(qint64 sawTriggerMs)
+        : QEvent(eventType()), m_sawTriggerMs(sawTriggerMs) {}
+    qint64 sawTriggerMs() const { return m_sawTriggerMs; }
+private:
+    qint64 m_sawTriggerMs;
+};
 
 class Profile;
 class Settings;
@@ -169,6 +186,9 @@ signals:
     void isHeadlessChanged();
     void refillKitDetectedChanged();
     void logMessage(const QString& message);
+
+protected:
+    void customEvent(QEvent* event) override;
 
 private:
     // Transport signal handlers

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -239,16 +239,24 @@ int main(int argc, char *argv[])
     QThread weightThread;
     weightThread.setObjectName(QStringLiteral("WeightProcessor"));
     weightProcessor.moveToThread(&weightThread);
-    weightThread.start(QThread::HighPriority);
+    weightThread.start();
 
     // Scale → WeightProcessor (main → worker, auto QueuedConnection)
     // Initially connected to FlowScale; reconnected when physical scale is found
     QObject::connect(&flowScale, &ScaleDevice::weightChanged,
                      &weightProcessor, &WeightProcessor::processWeight);
 
-    // WeightProcessor → DE1Device: stop-at-weight (auto QueuedConnection back to main thread)
+    // WeightProcessor → DE1Device: stop-at-weight.
+    // Use DirectConnection so the lambda runs immediately on the WeightProcessor's HighPriority
+    // thread, then post a Qt::HighEventPriority event to DE1Device. This makes the SAW stop
+    // jump ahead of any normal-priority events already queued on the main thread (e.g. D-Flow
+    // setpoint writes), preventing the 4+ second delivery delay seen on slow devices.
     QObject::connect(&weightProcessor, &WeightProcessor::stopNow,
-                     &de1Device, qOverload<qint64>(&DE1Device::stopOperationUrgent));
+                     &weightProcessor, [&de1Device](qint64 sawTriggerMs) {
+                         QCoreApplication::postEvent(&de1Device,
+                             new SawStopEvent(sawTriggerMs),
+                             Qt::HighEventPriority);
+                     }, Qt::DirectConnection);
 
     // WeightProcessor → MachineState: forward SAW trigger for QML "Target reached" display
     QObject::connect(&weightProcessor, &WeightProcessor::stopNow,


### PR DESCRIPTION
## Summary

- On slow Android devices (e.g. Samsung A7 Lite), stop-at-weight was arriving 4+ seconds late because the `stopNow` signal was delivered via a normal-priority `QueuedConnection`, queuing behind D-Flow setpoint events on the main thread
- Replaces the `QueuedConnection` with a `DirectConnection` lambda that posts a `SawStopEvent` at `Qt::HighEventPriority`, so the SAW stop jumps the queue and fires immediately when the main thread is next scheduled
- Drops WeightProcessor thread from `HighPriority` to normal — the priority boost was intended to help SAW latency but is no longer needed (and could starve the main thread on slow devices)

## Root cause

`WeightProcessor` runs on a dedicated thread and emits `stopNow` when the target weight is hit. The auto `QueuedConnection` to `DE1Device::stopOperationUrgent` posts to the **back** of the main thread's normal-priority event queue. In D-Flow mode, continuous setpoint writes fill that queue, causing the SAW stop to wait 4+ seconds before reaching the BLE layer — confirmed in a shot debug log from a Samsung A7 Lite user.

## Test plan

- [ ] Verify stop-at-weight fires promptly on a normal device (no regression)
- [ ] Verify stop-at-weight fires promptly in D-Flow mode
- [ ] Confirm no SAW-related log anomalies in shot debug output
- [ ] If possible, test on a lower-end Android device

🤖 Generated with [Claude Code](https://claude.com/claude-code)