### PR TITLE
fix: skip video screensaver on Android emulator

### DIFF
--- a/qml/pages/ScreensaverPage.qml
+++ b/qml/pages/ScreensaverPage.qml
@@ -32,6 +32,8 @@ Page {
     property string lastFailedSource: ""
     property string currentImageSource: ""
     property bool useFirstImage: true  // Toggle for cross-fade between two images
+    // No hardware video decoder (e.g. Android emulator) — skip all videos
+    property bool videoDecoderBroken: !ScreensaverManager.hasHardwareVideoDecoder
 
     Component.onCompleted: {
         console.log("[ScreensaverPage] Loaded, type:", screensaverType,
@@ -111,6 +113,8 @@ Page {
         }
     }
 
+    property int videoSkipCount: 0  // Guard against deep recursion when skipping broken videos
+
     function playNextMedia() {
         if (!ScreensaverManager.enabled) {
             return
@@ -124,6 +128,7 @@ Page {
                 // Display image with cross-fade transition
                 mediaPlayer.stop()
                 mediaPlaying = true
+                videoSkipCount = 0
 
                 // Load into the inactive image, then cross-fade
                 if (useFirstImage) {
@@ -133,6 +138,21 @@ Page {
                 }
                 currentImageSource = source
                 // Cross-fade will be triggered when image loads (onStatusChanged)
+            } else if (videoDecoderBroken) {
+                // No hardware decoder — skip videos, try next item (might be an image)
+                videoSkipCount++
+                if (videoSkipCount > ScreensaverManager.itemCount + 5) {
+                    // All catalog items are videos — no playable content, auto-wake
+                    console.warn("[Screensaver] No playable content (no hardware decoder) — auto-waking")
+                    videoSkipCount = 0
+                    mediaPlaying = false
+                    isCurrentItemImage = false
+                    wake()
+                    return
+                }
+                ScreensaverManager.markVideoPlayed(source)
+                playNextMedia()
+                return
             } else {
                 // Play video - reset image state
                 imageDisplayTimer.stop()
@@ -141,12 +161,17 @@ Page {
                 imageDisplay1.source = ""
                 imageDisplay2.source = ""
                 mediaPlaying = true
+                videoSkipCount = 0
                 mediaPlayer.source = source
                 mediaPlayer.play()
             }
         } else {
             mediaPlaying = false
             isCurrentItemImage = false
+            if (videoDecoderBroken) {
+                console.warn("[Screensaver] No content available (no hardware decoder) — auto-waking")
+                wake()
+            }
         }
     }
 
@@ -492,6 +517,10 @@ Page {
     Keys.onPressed: wake()
 
     function wake() {
+        mediaPlayer.stop()
+        mediaPlayer.source = ""
+        mediaPlaying = false
+
         // Wake up the DE1, or try to reconnect if disconnected
         if (DE1Device.connected) {
             DE1Device.wakeUp()
@@ -517,6 +546,8 @@ Page {
     StackView.onRemoved: {
         console.log("[Screensaver] Waking: restoring brightness and cleaning up")
         mediaPlayer.stop()
+        mediaPlayer.source = ""
+        mediaPlaying = false
         imageDisplayTimer.stop()
         dimTimer.stop()
         dimBehavior.enabled = false

--- a/src/screensaver/screensavervideomanager.cpp
+++ b/src/screensaver/screensavervideomanager.cpp
@@ -1065,6 +1065,77 @@ void ScreensaverVideoManager::clearCacheWithRateLimit()
     }
 }
 
+bool ScreensaverVideoManager::hasHardwareVideoDecoder() const
+{
+#ifdef Q_OS_ANDROID
+    QJniEnvironment env;
+
+    // Get MediaCodecList with ALL_CODECS
+    QJniObject codecList("android/media/MediaCodecList", "(I)V", 1); // ALL_CODECS = 1
+    if (!codecList.isValid()) {
+        qWarning() << "[Screensaver] Failed to create MediaCodecList";
+        return true; // Assume available if we can't check
+    }
+
+    QJniObject codecInfos = codecList.callObjectMethod(
+        "getCodecInfos", "()[Landroid/media/MediaCodecInfo;");
+    if (!codecInfos.isValid()) {
+        qWarning() << "[Screensaver] Failed to get codec infos";
+        return true;
+    }
+
+    auto infosArray = codecInfos.object<jobjectArray>();
+    jsize count = env->GetArrayLength(infosArray);
+
+    for (jsize i = 0; i < count; i++) {
+        QJniObject info = QJniObject::fromLocalRef(env->GetObjectArrayElement(infosArray, i));
+        if (!info.isValid()) continue;
+
+        // Skip encoders, we only care about decoders
+        if (info.callMethod<jboolean>("isEncoder")) continue;
+
+        QJniObject nameObj = info.callObjectMethod("getName", "()Ljava/lang/String;");
+        if (!nameObj.isValid()) continue;
+        QString name = nameObj.toString();
+
+        // Check if this decoder handles video/avc (H.264)
+        QJniObject types = info.callObjectMethod(
+            "getSupportedTypes", "()[Ljava/lang/String;");
+        if (!types.isValid()) continue;
+
+        auto typesArray = types.object<jobjectArray>();
+        jsize typeCount = env->GetArrayLength(typesArray);
+        bool handlesH264 = false;
+        for (jsize j = 0; j < typeCount; j++) {
+            QJniObject typeStr = QJniObject::fromLocalRef(env->GetObjectArrayElement(typesArray, j));
+            if (typeStr.isValid() && typeStr.toString().contains("avc", Qt::CaseInsensitive)) {
+                handlesH264 = true;
+                break;
+            }
+        }
+        if (!handlesH264) continue;
+
+        // isHardwareAccelerated() is unreliable — c2.goldfish.* (emulator) reports true.
+        // Filter by name: skip known software/emulator decoders.
+        bool isSoftware = name.startsWith("c2.goldfish.") ||
+                          name.startsWith("c2.android.") ||
+                          name.startsWith("OMX.google.");
+        qDebug() << "[Screensaver] H.264 decoder:" << name
+                 << "hwAccel:" << info.callMethod<jboolean>("isHardwareAccelerated")
+                 << "software:" << isSoftware;
+        if (!isSoftware) {
+            return true;
+        }
+    }
+
+    // No hardware H.264 decoder found — software-only (e.g. emulator)
+    qWarning() << "[Screensaver] No hardware H.264 decoder found — video playback disabled";
+    return false;
+#else
+    return true; // Desktop/iOS always have hardware decoders
+#endif
+}
+
 bool ScreensaverVideoManager::isRateLimited() const
 {
     if (!m_rateLimitedUntil.isValid()) {

--- a/src/screensaver/screensavervideomanager.h
+++ b/src/screensaver/screensavervideomanager.h
@@ -122,6 +122,9 @@ class ScreensaverVideoManager : public QObject {
     Q_PROPERTY(bool pipesShowClock READ pipesShowClock WRITE setPipesShowClock NOTIFY pipesShowClockChanged)
     Q_PROPERTY(bool attractorShowClock READ attractorShowClock WRITE setAttractorShowClock NOTIFY attractorShowClockChanged)
 
+    // Hardware video decoder availability (false when only emulator/software decoders found)
+    Q_PROPERTY(bool hasHardwareVideoDecoder READ hasHardwareVideoDecoder CONSTANT)
+
     // Rate limiting (after cache clear)
     Q_PROPERTY(bool isRateLimited READ isRateLimited NOTIFY rateLimitedChanged)
     Q_PROPERTY(int rateLimitMinutesRemaining READ rateLimitMinutesRemaining NOTIFY rateLimitedChanged)
@@ -179,6 +182,9 @@ public:
     QString shotMapTexture() const { return m_shotMapTexture; }
     bool shotMapShowClock() const { return m_shotMapShowClock; }
     bool shotMapShowProfiles() const { return m_shotMapShowProfiles; }
+
+    // Hardware video decoder detection
+    bool hasHardwareVideoDecoder() const;
 
     // Rate limiting
     bool isRateLimited() const;


### PR DESCRIPTION
## Summary
- Detect missing hardware H.264 decoder on Android via JNI `MediaCodecList` enumeration
- Skip known software/emulator decoders (`c2.goldfish.*`, `c2.android.*`, `OMX.google.*`) since `isHardwareAccelerated()` is unreliable (goldfish reports true)
- When no hardware decoder found, skip all videos in screensaver and auto-wake back to idle
- Clean up MediaPlayer state (stop + clear source) in `wake()` and `StackView.onRemoved`

## Test plan
- [ ] Android emulator: screensaver enters, skips videos, auto-wakes back to idle (no freeze)
- [ ] Android real device: video screensaver plays normally
- [ ] Desktop/iOS: video screensaver unaffected (always returns true)
- [ ] Image-only catalogs still work on emulator (shows images, no auto-wake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)