### PR TITLE
fix: exclude MQTT password from backup and device migration

### DIFF
--- a/src/core/datamigrationclient.cpp
+++ b/src/core/datamigrationclient.cpp
@@ -531,7 +531,9 @@ void DataMigrationClient::onSettingsReply()
 
         QJsonDocument doc = QJsonDocument::fromJson(data);
         if (doc.isObject() && m_settings) {
-            // Exclude machine-specific calibration and sensitive credentials
+            // Exclude machine-specific calibration and broker-specific MQTT password.
+            // Other sensitive keys (API keys, visualizer password) are intentionally
+            // transferred — they belong to the user, not the machine.
             SettingsSerializer::importFromJson(m_settings, doc.object(), {"flowCalibration", "mqttPassword"});
             m_settingsImported = 1;
             qDebug() << "DataMigrationClient: Settings imported successfully";

--- a/src/network/shotserver_backup.cpp
+++ b/src/network/shotserver_backup.cpp
@@ -954,6 +954,8 @@ void ShotServer::handleBackupRestore(QTcpSocket* socket, const QString& tempFile
             if (m_settings) {
                 QJsonDocument doc = QJsonDocument::fromJson(entryData);
                 if (!doc.isNull() && doc.isObject()) {
+                    // Filter sensitive keys on import — older backups may contain
+                    // passwords/API keys that were exported before this fix
                     SettingsSerializer::importFromJson(m_settings, doc.object(), SettingsSerializer::sensitiveKeys());
                     settingsRestored = true;
                     qDebug() << "ShotServer: Restored settings";


### PR DESCRIPTION
## Summary
- Backup zip export no longer includes sensitive keys (MQTT password, API keys) — changed `includeSensitive` from `true` to `false`
- Backup restore now skips all `sensitiveKeys()` on import, protecting against old backups that included passwords
- Device-to-device migration excludes `mqttPassword` on settings import (alongside existing `flowCalibration` exclusion)

The local settings web UI still reads/writes the MQTT password since it's the device configuring its own connection.

## Test plan
- [ ] Create a full backup and verify `settings.json` inside the zip does not contain `password`, API keys, or other sensitive fields
- [ ] Restore an old backup that contains a password field — verify it is not imported
- [ ] Migrate settings from another device — verify MQTT password is not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)