### PR TITLE
fix: convert ValueInput scrubberPopup from Popup to Dialog for accessibility

### DIFF
--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -416,8 +416,8 @@ Item {
         }
     }
 
-    // Full-width popup with blur - same as compact but bigger
-    Popup {
+    // Full-width dialog with blur - same as compact but bigger
+    Dialog {
         id: scrubberPopup
         parent: Overlay.overlay
         anchors.centerIn: parent
@@ -425,7 +425,10 @@ Item {
         height: parent.height
         modal: true
         dim: false
-        closePolicy: Popup.CloseOnPressOutside
+        closePolicy: Dialog.CloseOnPressOutside
+        header: null
+        footer: null
+        padding: 0
 
         onOpened: {
             popupValueContainer.forceActiveFocus()
@@ -447,7 +450,6 @@ Item {
             anchors.fill: parent
             property int currentGear: 0
 
-            Accessible.role: Accessible.Dialog
             Accessible.name: TranslationManager.translate("valueinput.editor.title", "Value editor")
 
             // Tap outside to close


### PR DESCRIPTION
## Summary
- Convert `scrubberPopup` in `ValueInput.qml` from `Popup` to `Dialog` for native TalkBack/VoiceOver focus trapping
- Add `header: null`, `footer: null`, `padding: 0` to suppress Dialog's default chrome (no visual change)
- Remove redundant `Accessible.role: Accessible.Dialog` from inner content (Dialog provides this natively)

Closes #349

## Test plan
- [ ] TalkBack (Android): open scrubber, verify focus stays trapped inside — swipe navigation should not escape to background
- [ ] VoiceOver (iOS): same focus trapping verification
- [ ] Drag-to-adjust interaction still works in the scrubber overlay
- [ ] Keyboard navigation (Escape to close, arrows to adjust) still works
- [ ] Test in ProfileEditorPage and BrewDialog where ValueInput is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)