### PR TITLE
Add right axis toggle to live shot graph

### DIFF
--- a/qml/components/HistoryShotGraph.qml
+++ b/qml/components/HistoryShotGraph.qml
@@ -435,8 +435,8 @@ ChartView {
         height: chart.plotArea.height
 
         Accessible.role: Accessible.Button
-        Accessible.name: chart.showWeightAxis ? "Right axis: Weight. Tap to show Temperature"
-                                              : "Right axis: Temperature. Tap to show Weight"
+        Accessible.name: chart.showWeightAxis ? TranslationManager.translate("graph.rightAxisWeight", "Right axis: Weight. Tap for Temperature")
+                                              : TranslationManager.translate("graph.rightAxisTemp", "Right axis: Temperature. Tap for Weight")
         Accessible.focusable: true
         Accessible.onPressAction: chart.toggleRightAxis()
 

--- a/qml/components/ShotGraph.qml
+++ b/qml/components/ShotGraph.qml
@@ -372,8 +372,8 @@ ChartView {
         height: chart.plotArea.height
 
         Accessible.role: Accessible.Button
-        Accessible.name: chart.showWeightAxis ? "Right axis: Weight. Tap for Temperature"
-                                              : "Right axis: Temperature. Tap for Weight"
+        Accessible.name: chart.showWeightAxis ? TranslationManager.translate("graph.rightAxisWeight", "Right axis: Weight. Tap for Temperature")
+                                              : TranslationManager.translate("graph.rightAxisTemp", "Right axis: Temperature. Tap for Weight")
         Accessible.focusable: true
         Accessible.onPressAction: axisToggleArea.clicked(null)
 


### PR DESCRIPTION
## Summary
- Tap the right axis labels on the live shot graph to toggle between weight and temperature axes
- Uses manual fixed-position labels (same approach as HistoryShotGraph) to prevent layout shift when toggling
- Shared `showWeightAxis` setting stays in sync between live and history graphs

## Test plan
- [ ] During a live shot, tap the right axis labels — should toggle between weight (g) and temp (°C)
- [ ] Verify no layout shift when toggling
- [ ] Verify the setting persists across app restarts
- [ ] Verify history graphs still toggle correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)