### PR TITLE
fix: ccache for Android/iOS/macOS builds

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -98,6 +98,24 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: android-arm64
+          max-size: 500M
+
+      - name: Wrap NDK compilers with ccache
+        run: |
+          # Qt's Android toolchain overrides CMAKE_*_COMPILER_LAUNCHER,
+          # so we wrap the actual NDK compiler binaries with ccache instead.
+          NDK_BIN="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          for COMP in clang clang++; do
+            if [ -f "$NDK_BIN/$COMP" ]; then
+              mv "$NDK_BIN/$COMP" "$NDK_BIN/$COMP.real"
+              cat > "$NDK_BIN/$COMP" <<'WRAPPER'
+          #!/bin/sh
+          exec ccache "$(dirname "$0")/$( basename "$0" ).real" "$@"
+          WRAPPER
+              chmod +x "$NDK_BIN/$COMP"
+              echo "Wrapped $NDK_BIN/$COMP with ccache"
+            fi
+          done
 
       - name: Decode Android keystore
         env:
@@ -112,9 +130,7 @@ jobs:
           cd build
           $QT_ROOT_DIR/bin/qt-cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
       - name: Build
         env:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -53,6 +53,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ios-arm64
+          max-size: 500M
 
       - name: Install Apple certificate and provisioning profile
         env:
@@ -93,9 +94,7 @@ jobs:
           cd build/ios
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
             
       - name: Build and Archive
         env:
@@ -103,12 +102,14 @@ jobs:
         run: |
           cd build/ios
 
-          # Build archive
+          # Build archive (CC/CXX inject ccache for Xcode builds)
           xcodebuild archive \
             -project Decenza.xcodeproj \
             -scheme Decenza \
             -destination "generic/platform=iOS" \
             -archivePath $RUNNER_TEMP/Decenza.xcarchive \
+            CC="ccache clang" \
+            CXX="ccache clang++" \
             CODE_SIGN_STYLE=Manual \
             DEVELOPMENT_TEAM=$TEAM_ID \
             CODE_SIGN_IDENTITY="iPhone Distribution" \

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -63,6 +63,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: macos-universal
+          max-size: 500M
 
       - name: Install Apple Developer ID certificate
         env:
@@ -136,8 +137,6 @@ jobs:
             -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
             -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DOPENSSL_ROOT_DIR="${OPENSSL_PREFIX}" \
             -DOPENSSL_INCLUDE_DIR="${OPENSSL_PREFIX}/include" \
             -DOPENSSL_CRYPTO_LIBRARY="${OPENSSL_PREFIX}/lib/libcrypto.a" \
@@ -146,7 +145,8 @@ jobs:
       - name: Build Release
         run: |
           cd build/macos
-          cmake --build . --config Release --parallel
+          # Inject ccache via Xcode CC/CXX build settings
+          cmake --build . --config Release --parallel -- CC="ccache clang" CXX="ccache clang++"
 
       - name: Bundle Qt frameworks
         run: |


### PR DESCRIPTION
## Summary
- **Android**: ccache had 0% hit rate because Qt's NDK toolchain overrides `CMAKE_CXX_COMPILER_LAUNCHER`. Fix: wrap NDK `clang`/`clang++` binaries with ccache shell scripts
- **iOS**: Same 0% — Xcode generator ignores compiler launchers. Fix: pass `CC="ccache clang"` as xcodebuild build settings
- **macOS**: Same 0% — also uses Xcode generator. Fix: pass CC/CXX via `cmake --build -- CC=... CXX=...`
- Linux workflows (88% hit rate) unchanged — Ninja/Make respect `CMAKE_*_COMPILER_LAUNCHER`

## Evidence
| Platform | Before | After (expected) |
|---|---|---|
| Android | 0/0 objects cached | ~260+ hits |
| iOS | 0/0 objects cached | ~260+ hits |
| macOS | 0/0 objects cached | ~300+ hits |
| Linux x64 | 264/300 (88%) | unchanged |
| Linux ARM64 | 261/297 (88%) | unchanged |

## Test plan
- [ ] Trigger Android build → verify ccache stats show >0 hits in "Post Set up ccache" step
- [ ] Trigger iOS build → verify ccache stats show >0 hits
- [ ] Trigger macOS build → verify ccache stats show >0 hits
- [ ] Verify all builds complete successfully (signing, upload, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)