### PR TITLE
fix: scale auto-reconnect after scan discovery

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -906,6 +906,7 @@ int main(int argc, char *argv[])
         settings.setScaleAddress(getDeviceIdentifier(device));
         settings.setScaleType(type);
         settings.setScaleName(device.name());
+        bleManager.setSavedScaleAddress(getDeviceIdentifier(device), type, device.name());
 
         // Switch MachineState and TimingController to use physical scale instead of FlowScale
         machineState.setScale(physicalScale.get());


### PR DESCRIPTION
Fixes #378

## Summary
- Scale auto-reconnect fails every time after BLE scan discovery
- When a scale is discovered via scan, its address was saved to `Settings` (QSettings on disk) but not loaded into `BLEManager::m_savedScaleAddress` (runtime memory)
- All reconnect retries after disconnect fail immediately with "no saved scale address/type"
- Fix: add `bleManager.setSavedScaleAddress()` call alongside the existing `settings.setScaleAddress()` call

## Test plan
- [ ] Connect a BLE scale via Settings → Scan
- [ ] Power off the scale
- [ ] Verify log shows reconnect attempts with actual address (not "no saved scale address/type")
- [ ] Power on the scale within retry window → verify auto-reconnect
- [ ] If retry window expired, suspend/resume app → verify reconnect uses saved address

🤖 Generated with [Claude Code](https://claude.com/claude-code)