### PR TITLE
fix: rename Dialog message property to avoid Qt 6.10 FINAL conflict

### DIFF
--- a/qml/pages/settings/SettingsDebugTab.qml
+++ b/qml/pages/settings/SettingsDebugTab.qml
@@ -275,13 +275,13 @@ Item {
                     if (errors > 0) {
                         msg += "\nErrors: " + errors
                     }
-                    profileConvertResultDialog.message = msg
+                    profileConvertResultDialog.resultMessage = msg
                     profileConvertResultDialog.isError = errors > 0
                     profileConvertResultDialog.open()
                 }
                 function onConversionError(message) {
                     profileConvertResultDialog.title = "Conversion Failed"
-                    profileConvertResultDialog.message = message
+                    profileConvertResultDialog.resultMessage = message
                     profileConvertResultDialog.isError = true
                     profileConvertResultDialog.open()
                 }
@@ -296,7 +296,7 @@ Item {
                 anchors.centerIn: Overlay.overlay
                 padding: Theme.scaled(24)
 
-                property string message: ""
+                property string resultMessage: ""
                 property bool isError: false
 
                 background: Rectangle {
@@ -318,7 +318,7 @@ Item {
                     }
 
                     Text {
-                        text: profileConvertResultDialog.message
+                        text: profileConvertResultDialog.resultMessage
                         wrapMode: Text.Wrap
                         width: parent.width
                         font: Theme.bodyFont
@@ -425,7 +425,7 @@ Item {
                     if (success) {
                         console.log("Database import successful")
                         importResultDialog.title = "Import Successful"
-                        importResultDialog.message = "Database imported successfully.\nTotal shots: " + MainController.shotHistory.totalShots
+                        importResultDialog.resultMessage = "Database imported successfully.\nTotal shots: " + MainController.shotHistory.totalShots
                         importResultDialog.isError = false
                         importResultDialog.open()
                     }
@@ -442,7 +442,7 @@ Item {
                 anchors.centerIn: Overlay.overlay
                 padding: Theme.scaled(24)
 
-                property string message: ""
+                property string resultMessage: ""
                 property bool isError: false
 
                 background: Rectangle {
@@ -464,7 +464,7 @@ Item {
                     }
 
                     Text {
-                        text: importResultDialog.message
+                        text: importResultDialog.resultMessage
                         wrapMode: Text.Wrap
                         width: parent.width
                         font: Theme.bodyFont
@@ -485,7 +485,7 @@ Item {
                 target: MainController.shotHistory
                 function onErrorOccurred(message) {
                     importResultDialog.title = "Import Failed"
-                    importResultDialog.message = message
+                    importResultDialog.resultMessage = message
                     importResultDialog.isError = true
                     importResultDialog.open()
                 }

--- a/qml/pages/settings/SettingsLanguageTab.qml
+++ b/qml/pages/settings/SettingsLanguageTab.qml
@@ -18,7 +18,7 @@ Item {
         target: TranslationManager
         function onTranslationSubmitted(success, message) {
             submitResultPopup.isSuccess = success
-            submitResultPopup.message = message
+            submitResultPopup.resultMessage = message
             submitResultPopup.open()
         }
         function onLanguageDownloaded(langCode, success, error) {
@@ -445,7 +445,7 @@ Item {
         closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
 
         property bool isSuccess: false
-        property string message: ""
+        property string resultMessage: ""
 
         background: Rectangle {
             color: Theme.surfaceColor
@@ -467,7 +467,7 @@ Item {
 
             Text {
                 width: parent.width
-                text: submitResultPopup.message
+                text: submitResultPopup.resultMessage
                 font: Theme.bodyFont
                 color: Theme.textColor
                 wrapMode: Text.Wrap

--- a/qml/pages/settings/SettingsShotHistoryTab.qml
+++ b/qml/pages/settings/SettingsShotHistoryTab.qml
@@ -294,7 +294,7 @@ KeyboardAwareContainer {
             anchors.centerIn: Overlay.overlay
             padding: Theme.scaled(24)
 
-            property string message: ""
+            property string resultMessage: ""
             property bool isError: false
 
             background: Rectangle {
@@ -316,7 +316,7 @@ KeyboardAwareContainer {
                 }
 
                 Text {
-                    text: importResultDialog.message
+                    text: importResultDialog.resultMessage
                     wrapMode: Text.Wrap
                     width: parent.width
                     font: Theme.bodyFont
@@ -337,7 +337,7 @@ KeyboardAwareContainer {
             target: MainController.shotImporter
             function onImportComplete(imported, skipped, failed) {
                 importResultDialog.title = "Import Complete"
-                importResultDialog.message = "Imported: " + imported + " shots\n" +
+                importResultDialog.resultMessage = "Imported: " + imported + " shots\n" +
                                              "Skipped (duplicates): " + skipped + "\n" +
                                              "Failed: " + failed + "\n\n" +
                                              "Total shots: " + (MainController.shotHistory ? MainController.shotHistory.totalShots : "?")
@@ -346,7 +346,7 @@ KeyboardAwareContainer {
             }
             function onImportError(message) {
                 importResultDialog.title = "Import Failed"
-                importResultDialog.message = message
+                importResultDialog.resultMessage = message
                 importResultDialog.isError = true
                 importResultDialog.open()
             }


### PR DESCRIPTION
## Summary
- Related to #376 — fixes the "Cannot override FINAL property" warning in Settings tabs
- Qt 6.10 marks `Popup.message` as FINAL, so declaring `property string message` on a `Dialog` causes the warning and may prevent the component from loading
- Renamed to `resultMessage` in all 4 affected Dialog instances across 3 files

## Test plan
- [ ] Open Settings > History tab — check if it's no longer blank
- [ ] Open Settings > Debug tab — profile conversion and DB import dialogs should work
- [ ] Open Settings > Language tab — translation submit result dialog should work
- [ ] Verify no "Cannot override FINAL property" warnings in debug log

🤖 Generated with [Claude Code](https://claude.ai/code)