### PR TITLE
feat: enrich AI grinder prompt with burr geometry

### DIFF
--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -2,6 +2,7 @@
 #include "../models/shotdatamodel.h"
 #include "../profile/profile.h"
 #include "../network/visualizeruploader.h"
+#include "../core/grinderaliases.h"
 
 #include <cmath>
 #include <algorithm>
@@ -440,6 +441,11 @@ QString ShotSummarizer::buildUserPrompt(const ShotSummary& summary) const
                : summary.grinderBrand + " " + summary.grinderModel);
         out << "- **Grinder**: " << grinderStr;
         if (!summary.grinderBurrs.isEmpty()) out << " with " << summary.grinderBurrs;
+        // Enrich with burr geometry (e.g. "83mm flat") from grinder database
+        QString geometry = GrinderAliases::burrGeometry(
+            summary.grinderBrand, summary.grinderModel, summary.grinderBurrs);
+        if (!geometry.isEmpty() && !summary.grinderBurrs.contains(geometry))
+            out << " (" << geometry << ")";
         if (!summary.grinderSetting.isEmpty()) out << " @ " << summary.grinderSetting;
         out << "\n";
     }

--- a/src/core/grinderaliases.h
+++ b/src/core/grinderaliases.h
@@ -3,6 +3,7 @@
 #include <QString>
 #include <QStringList>
 #include <QVector>
+#include <QRegularExpression>
 
 namespace GrinderAliases {
 
@@ -235,6 +236,58 @@ inline bool isBurrSwappable(const QString& brand, const QString& model)
         }
     }
     return false;
+}
+
+// Return a compact burr geometry string for AI enrichment (e.g. "83mm flat", "63mm conical").
+// Type (flat/conical) inferred from user's burrs string first, then stock burrs.
+// Size from database burrSizeMm first, then parsed from burrs strings.
+inline QString burrGeometry(const QString& brand, const QString& model, const QString& userBurrs = QString())
+{
+    // Infer burr type (flat/conical) from a descriptive string
+    auto inferType = [](const QString& s) -> QString {
+        QString lower = s.toLower();
+        if (lower.contains("conical")) return "conical";
+        if (lower.contains("flat")) return "flat";
+        return QString();
+    };
+
+    // Infer burr size from a descriptive string (e.g. "83mm flat steel" -> 83)
+    auto inferSize = [](const QString& s) -> int {
+        static const QRegularExpression rx("(\\d{2,3})\\s*mm");
+        auto match = rx.match(s);
+        return match.hasMatch() ? match.captured(1).toInt() : 0;
+    };
+
+    // Look up the grinder entry for burrSizeMm and stock burrs
+    const GrinderEntry* entry = nullptr;
+    const auto& grinders = allGrinders();
+    for (const auto& g : grinders) {
+        if (g.brand.compare(brand, Qt::CaseInsensitive) == 0 &&
+            g.model.compare(model, Qt::CaseInsensitive) == 0) {
+            entry = &g;
+            break;
+        }
+    }
+
+    // Determine burr type: prefer user burrs, fall back to stock burrs
+    QString type;
+    if (!userBurrs.isEmpty()) type = inferType(userBurrs);
+    if (type.isEmpty() && entry && !entry->stockBurrs.isEmpty())
+        type = inferType(entry->stockBurrs.first());
+
+    // Determine size: prefer entry's burrSizeMm, fall back to parsing strings
+    int size = (entry && entry->burrSizeMm > 0) ? entry->burrSizeMm : 0;
+    if (size == 0 && !userBurrs.isEmpty()) size = inferSize(userBurrs);
+    if (size == 0 && entry && !entry->stockBurrs.isEmpty())
+        size = inferSize(entry->stockBurrs.first());
+
+    if (size > 0 && !type.isEmpty())
+        return QString("%1mm %2").arg(size).arg(type);
+    if (size > 0)
+        return QString("%1mm").arg(size);
+    if (!type.isEmpty())
+        return type;
+    return QString();
 }
 
 // Get all known brands (unique, sorted)


### PR DESCRIPTION
## Summary
- Adds `burrGeometry()` to `grinderaliases.h` that returns a compact string like "83mm flat" or "63mm conical" by looking up the grinder entry and inferring burr type from stock/user burrs strings
- Enriches the AI shot prompt in `shotsummarizer.cpp` to append burr geometry after the grinder info
- Skips the parenthetical when the user's burrs string already contains the geometry text

Before: `Grinder: Turin DF83V @ 2.5`
After: `Grinder: Turin DF83V (83mm flat) @ 2.5`

This gives the AI direct knowledge of flat vs conical and burr size without relying on training data to identify the grinder.

## Test plan
- [ ] Known grinder with no burrs entered: geometry appended (e.g. "Niche Zero (63mm conical)")
- [ ] Known grinder with burrs that already contain geometry: no redundant parenthetical
- [ ] Known grinder with aftermarket burrs: geometry reflects user's burrs type + entry's size
- [ ] Unknown grinder: no geometry appended (graceful no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)