### PR TITLE
fix: prevent dangling keep-alive timer crash after sleep/wake

### DIFF
--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -529,10 +529,10 @@ void ShotServer::onReadyRead()
     if (!socket) return;
 
     // After sleep/wake or network changes, readyRead can fire for sockets that
-    // onDisconnected() already scheduled for deleteLater(). Processing such a
-    // socket would create a new keep-alive timer (via sendResponse →
-    // resetKeepAliveTimer) that becomes a dangling pointer once deleteLater runs.
-    if (socket->state() == QAbstractSocket::UnconnectedState) return;
+    // are closing or already disconnected. Processing such a socket would create
+    // a new keep-alive timer (via sendResponse → resetKeepAliveTimer) whose map
+    // entry becomes dangling once deleteLater destroys the socket and its child timer.
+    if (socket->state() != QAbstractSocket::ConnectedState) return;
 
     // SSE clients keep connections open — ignore further data from them
     if (m_sseLayoutClients.contains(socket)) return;


### PR DESCRIPTION
## Summary
- Fixes SIGSEGV in `QTimer::stop()` at `shotserver.cpp:537` triggered after macOS sleep/wake
- After wake, `readyRead` can fire for sockets already scheduled for `deleteLater()` by `onDisconnected()`. Processing such a socket creates a new keep-alive timer that becomes a dangling pointer once `deleteLater` destroys the socket and its child timer
- Adds state check in `onReadyRead()` to skip `UnconnectedState` sockets, and in `resetKeepAliveTimer()` to prevent creating timers for non-connected sockets

## Test plan
- [ ] Run app with web UI open, sleep/wake the Mac, verify no crash
- [ ] Open layout editor SSE connection, sleep/wake, verify graceful reconnect
- [ ] Verify keep-alive connections still work normally (multiple requests on same connection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)