### PR TITLE
fix: break ShotGraph.calculatedMax binding loop

### DIFF
--- a/qml/components/ShotGraph.qml
+++ b/qml/components/ShotGraph.qml
@@ -85,8 +85,8 @@ ChartView {
     ValueAxis {
         id: timeAxis
         min: 0
-        // Use calculated max (with 5px padding) or minimum 5 seconds
-        max: Math.max(minTime, calculatedMax)
+        // recalcMax() guarantees calculatedMax >= minTime
+        max: calculatedMax
         tickCount: Math.min(7, Math.max(3, Math.floor(max / 10) + 2))
         labelFormat: "%.0f"
         labelsColor: Theme.textSecondaryColor


### PR DESCRIPTION
## Summary
- Replace declarative binding on `calculatedMax` with imperative `recalcMax()` to eliminate QML binding loop warning
- The circular chain `calculatedMax → timeAxis.max → ChartView relayout → plotArea → cachedPlotWidth → calculatedMax` is broken by removing the declarative dependency
- `recalcMax()` is called from `onRawTimeChanged` (new data) and `onPlotAreaChanged` (layout change)

## Context
Debug logs showed this warning firing in pairs on every single shot (12+ occurrences across sessions):
```
WARN EspressoPage.qml:364:9: QML ShotGraph: Binding loop detected for property "calculatedMax"
```

## Test plan
- [ ] Run an espresso shot and verify the graph scales correctly as data arrives
- [ ] Check debug log for absence of `calculatedMax` binding loop warnings
- [ ] Verify graph padding at the right edge still works (5px gap)
- [ ] Rotate device / resize window and confirm graph redraws correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)