### PR TITLE
fix: increase BLE write retry delay and max retries (#428)

### DIFF
--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -100,7 +100,7 @@ BleTransport::BleTransport(QObject* parent)
                 m_writeRetryCount++;
                 log(QString("Write timeout, retrying %1/%2 (uuid=%3)")
                     .arg(m_writeRetryCount).arg(MAX_WRITE_RETRIES).arg(m_lastWriteUuid));
-                QTimer::singleShot(100, this, [this]() {
+                QTimer::singleShot(WRITE_RETRY_DELAY_MS, this, [this]() {
                     if (m_lastCommand) {
                         m_lastCommand();
                     }
@@ -387,7 +387,7 @@ void BleTransport::onServiceDiscovered(const QBluetoothUuid& uuid) {
                             m_writeRetryCount++;
                             log(QString("CharacteristicWriteError, retrying %1/%2 (uuid=%3)")
                                 .arg(m_writeRetryCount).arg(MAX_WRITE_RETRIES).arg(m_lastWriteUuid));
-                            QTimer::singleShot(100, this, [this]() {
+                            QTimer::singleShot(WRITE_RETRY_DELAY_MS, this, [this]() {
                                 if (m_lastCommand) {
                                     m_lastCommand();
                                 }

--- a/src/ble/bletransport.h
+++ b/src/ble/bletransport.h
@@ -83,9 +83,10 @@ private:
     // Write retry logic (like de1app)
     std::function<void()> m_lastCommand;
     int m_writeRetryCount = 0;
-    static constexpr int MAX_WRITE_RETRIES = 3;
+    static constexpr int MAX_WRITE_RETRIES = 10;
     QTimer m_writeTimeoutTimer;
     static constexpr int WRITE_TIMEOUT_MS = 5000;
+    static constexpr int WRITE_RETRY_DELAY_MS = 500;
     QString m_lastWriteUuid;
     QByteArray m_lastWriteData;
 


### PR DESCRIPTION
## Summary
- Increase retry delay from 100ms to **500ms** to match de1app's `after 500` timing, giving the BLE stack time to recover
- Increase max retries from 3 to **10** to match de1app's more persistent retry behavior for critical writes
- Extract hardcoded delay into `WRITE_RETRY_DELAY_MS` constant

## Test plan
- [ ] Verify normal BLE writes still succeed on first attempt
- [ ] If a write timeout or CharacteristicWriteError occurs, confirm retries use 500ms spacing in logs
- [ ] Confirm the DE1 stays connected through transient write failures that previously caused disconnects

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)