### PR TITLE
fix: balance AVAudioSession on iOS screensaver wake

### DIFF
--- a/src/screensaver/iosbrightness.h
+++ b/src/screensaver/iosbrightness.h
@@ -14,6 +14,8 @@ void ios_restoreScreenBrightness();                // Restore to pre-dim value
 void ios_checkAndRestoreBrightness();              // Call at startup to recover from crash while dimmed
 void ios_setIdleTimerDisabled(bool disabled);      // Prevent iOS auto-lock (equivalent of FLAG_KEEP_SCREEN_ON)
 void ios_setStatusBarStyle(bool isDarkTheme);      // Set status bar icons light (dark theme) or dark (light theme)
+void ios_activateAudioSession();                    // Balance AVAudioSession before video playback
+void ios_deactivateAudioSession();                  // Deactivate audio session after video stops
 
 #ifdef __cplusplus
 }

--- a/src/screensaver/iosbrightness.mm
+++ b/src/screensaver/iosbrightness.mm
@@ -5,6 +5,7 @@
 #if TARGET_OS_IOS
 
 #import <UIKit/UIKit.h>
+#import <AVFoundation/AVAudioSession.h>
 #include <QDebug>
 
 static NSString * const kSavedBrightnessKey = @"DecenzaSavedBrightness";
@@ -81,6 +82,27 @@ void ios_setStatusBarStyle(bool isDarkTheme)
     });
 }
 
+void ios_activateAudioSession()
+{
+    NSError *error = nil;
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&error];
+    if (error) {
+        NSLog(@"[Screensaver] iOS: failed to set audio session category: %@", error);
+    }
+    error = nil;
+    [[AVAudioSession sharedInstance] setActive:YES error:&error];
+    if (error) {
+        NSLog(@"[Screensaver] iOS: failed to activate audio session: %@", error);
+    }
+}
+
+void ios_deactivateAudioSession()
+{
+    [[AVAudioSession sharedInstance] setActive:NO
+                                  withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+                                        error:nil];
+}
+
 #else
 // macOS — no UIScreen API, brightness control not available
 void ios_setScreenBrightness(float) {}
@@ -88,5 +110,7 @@ void ios_restoreScreenBrightness() {}
 void ios_checkAndRestoreBrightness() {}
 void ios_setIdleTimerDisabled(bool) {}
 void ios_setStatusBarStyle(bool) {}
+void ios_activateAudioSession() {}
+void ios_deactivateAudioSession() {}
 #endif
 #endif

--- a/src/screensaver/screensavervideomanager.cpp
+++ b/src/screensaver/screensavervideomanager.cpp
@@ -152,6 +152,9 @@ void ScreensaverVideoManager::setKeepScreenOn(bool on)
     // via brightness control, so the system idle timer is redundant. Without this, iOS
     // will lock the screen and suspend the app, breaking smart charging and BLE comms.
     ios_setIdleTimerDisabled(on);
+    if (on) {
+        ios_activateAudioSession();
+    }
 #else
     Q_UNUSED(on)
 #endif
@@ -194,6 +197,7 @@ void ScreensaverVideoManager::restoreScreenBrightness()
     });
 #elif defined(Q_OS_IOS)
     ios_restoreScreenBrightness();
+    ios_deactivateAudioSession();
 #endif
 }
 


### PR DESCRIPTION
## Summary
- Adds `ios_activateAudioSession()` / `ios_deactivateAudioSession()` to `iosbrightness.mm`
- Calls activate when screensaver enters video mode, deactivate when it exits
- Balances Qt's internal `setActive:NO` call so iOS no longer logs "Unbalanced audio session deactivation" warnings

Closes #443

## Test plan
- [ ] Build with iOS kit, deploy to iPad
- [ ] Enable screensaver with video mode
- [ ] Let screensaver activate, then wake it
- [ ] Check debug log — "Unbalanced audio session deactivation" warning should no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)