### PR TITLE
fix: fetch shot map data once on screensaver start

### DIFF
--- a/qml/components/ShotMapScreensaver.qml
+++ b/qml/components/ShotMapScreensaver.qml
@@ -42,15 +42,6 @@ Item {
         fetchShots()
     }
 
-    // Poll API every 30 seconds
-    Timer {
-        id: pollTimer
-        interval: 30000
-        running: root.running && root.visible
-        repeat: true
-        onTriggered: fetchShots()
-    }
-
     // Globe rotation animation
     NumberAnimation on globeRotation {
         running: root.running && root.visible && mapShape === "globe"


### PR DESCRIPTION
## Summary
- Remove 30-second polling timer from `ShotMapScreensaver`
- Shots are fetched once on `Component.onCompleted` — no new shots can occur while screensaver is active
- Eliminates unnecessary CPU/disk/network activity during idle

Closes #442

## Test plan
- [ ] Enable shot map screensaver, let it activate
- [ ] Verify map loads with shot dots
- [ ] Confirm no repeated `[ShotMapScreensaver] Loaded` log lines after initial load

🤖 Generated with [Claude Code](https://claude.com/claude-code)