### PR TITLE
fix: guard USBManager references on iOS

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -257,17 +257,17 @@ Item {
 
                     // Port info
                     Text {
-                        text: TranslationManager.translate("settings.connections.port", "Port:") + " " + USBManager.portName
+                        text: TranslationManager.translate("settings.connections.port", "Port:") + " " + (typeof USBManager !== "undefined" ? USBManager.portName : "")
                         color: Theme.textSecondaryColor
                         font.pixelSize: Theme.scaled(13)
                     }
 
                     // Serial number
                     Text {
-                        text: TranslationManager.translate("settings.connections.serial", "Serial:") + " " + USBManager.serialNumber
+                        text: TranslationManager.translate("settings.connections.serial", "Serial:") + " " + (typeof USBManager !== "undefined" ? USBManager.serialNumber : "")
                         color: Theme.textSecondaryColor
                         font.pixelSize: Theme.scaled(13)
-                        visible: USBManager.serialNumber !== ""
+                        visible: typeof USBManager !== "undefined" && USBManager.serialNumber !== ""
                     }
 
                     // Firmware version


### PR DESCRIPTION
## Summary
- Guard three unprotected `USBManager` references in `SettingsConnectionsTab.qml` with `typeof USBManager !== "undefined"` checks
- Eliminates QML `ReferenceError` warnings on iOS where `USBManager` is not registered (USB/serial is desktop/Android only)

Closes #439

## Test plan
- [ ] Open Settings → Connections tab on iOS — no QML warnings in console
- [ ] Open Settings → Connections tab on desktop/Android with USB connected — port/serial info still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)