### PR TITLE
fix: break ShotGraph calculatedMax binding loop

### DIFF
--- a/qml/components/ShotGraph.qml
+++ b/qml/components/ShotGraph.qml
@@ -59,7 +59,7 @@ ChartView {
     property double minTime: 5.0
     property double paddingPixels: Theme.scaled(5)
     property double cachedPlotWidth: 1
-    property double calculatedMax: minTime
+    property double calculatedMax: 5.0  // initial value; updated imperatively by recalcMax()
 
     function recalcMax() {
         var raw = ShotDataModel.rawTime * cachedPlotWidth / Math.max(1, cachedPlotWidth - paddingPixels)


### PR DESCRIPTION
## Summary
- Replace `calculatedMax: minTime` declarative binding with literal `5.0` initial value
- Eliminates QML binding loop warning that fired 6-12 times during every extraction

Closes #438

## Test plan
- [ ] Run an espresso extraction — no "Binding loop detected for property calculatedMax" warnings
- [ ] Graph still auto-expands time axis as extraction progresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)