### PR TITLE
fix: extraction view selector text truncation and unstyled checkboxes

### DIFF
--- a/qml/components/AccessibleMouseArea.qml
+++ b/qml/components/AccessibleMouseArea.qml
@@ -15,9 +15,16 @@ MouseArea {
     // The item to track for "tap again to activate" (defaults to parent)
     property var accessibleItem: parent
 
-    // Accessibility: Make this a proper button for screen readers
-    Accessible.role: Accessible.Button
+    // Optional: override accessible role (default Button, set to Accessible.CheckBox for toggles)
+    property int accessibleRole: Accessible.Button
+
+    // Optional: checked state for CheckBox role
+    property bool accessibleChecked: false
+
+    // Accessibility: Make this a proper interactive element for screen readers
+    Accessible.role: root.accessibleRole
     Accessible.name: root.accessibleName
+    Accessible.checked: root.accessibleChecked
     Accessible.focusable: true
 
     // Handle TalkBack/VoiceOver activation via accessibility press action

--- a/qml/components/ExtractionViewSelector.qml
+++ b/qml/components/ExtractionViewSelector.qml
@@ -22,8 +22,6 @@ Dialog {
     width: Math.min(parent.width * 0.85, Theme.scaled(360))
     // Let the Dialog auto-size vertically from content
     padding: 0
-    topPadding: 0
-    bottomPadding: 0
 
     background: Rectangle {
         color: Theme.surfaceColor
@@ -46,6 +44,7 @@ Dialog {
             text: selectorDialog.title
             color: Theme.textColor
             font: Theme.subtitleFont
+            Accessible.ignored: true  // Dialog.title already announces this
         }
 
         Repeater {
@@ -177,14 +176,9 @@ Dialog {
             Layout.topMargin: Theme.spacingSmall
             radius: Theme.cardRadius
             color: Theme.backgroundColor
+            Accessible.ignored: true
 
             property bool isChecked: selectorDialog.showPhaseIndicator
-
-            Accessible.role: Accessible.CheckBox
-            Accessible.name: TranslationManager.translate("espresso.viewSelector.showPhaseIndicator", "Show Phase Indicator")
-            Accessible.checked: isChecked
-            Accessible.focusable: true
-            Accessible.onPressAction: phaseToggleArea.clicked(null)
 
             RowLayout {
                 anchors.fill: parent
@@ -227,10 +221,13 @@ Dialog {
                 }
             }
 
-            MouseArea {
-                id: phaseToggleArea
+            AccessibleMouseArea {
                 anchors.fill: parent
-                onClicked: selectorDialog.phaseIndicatorToggled(!phaseToggleCard.isChecked)
+                accessibleName: TranslationManager.translate("espresso.viewSelector.showPhaseIndicator", "Show Phase Indicator")
+                accessibleItem: phaseToggleCard
+                accessibleRole: Accessible.CheckBox
+                accessibleChecked: phaseToggleCard.isChecked
+                onAccessibleClicked: selectorDialog.phaseIndicatorToggled(!phaseToggleCard.isChecked)
             }
         }
 
@@ -243,14 +240,9 @@ Dialog {
             Layout.bottomMargin: Theme.spacingMedium
             radius: Theme.cardRadius
             color: Theme.backgroundColor
+            Accessible.ignored: true
 
             property bool isChecked: selectorDialog.showStats
-
-            Accessible.role: Accessible.CheckBox
-            Accessible.name: TranslationManager.translate("espresso.viewSelector.showStats", "Show Stats")
-            Accessible.checked: isChecked
-            Accessible.focusable: true
-            Accessible.onPressAction: statsToggleArea.clicked(null)
 
             RowLayout {
                 anchors.fill: parent
@@ -293,10 +285,13 @@ Dialog {
                 }
             }
 
-            MouseArea {
-                id: statsToggleArea
+            AccessibleMouseArea {
                 anchors.fill: parent
-                onClicked: selectorDialog.statsToggled(!statsToggleCard.isChecked)
+                accessibleName: TranslationManager.translate("espresso.viewSelector.showStats", "Show Stats")
+                accessibleItem: statsToggleCard
+                accessibleRole: Accessible.CheckBox
+                accessibleChecked: statsToggleCard.isChecked
+                onAccessibleClicked: selectorDialog.statsToggled(!statsToggleCard.isChecked)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Description text wraps instead of truncating with ellipsis
- Option cards auto-size to fit wrapped content instead of fixed height
- Dialog no longer clips content at the bottom (title moved into content layout)
- Checkboxes replaced with plain themed Rectangle indicators matching the radio buttons
- SVG tick icon instead of Unicode checkmark (cross-device safe)
- Proper accessibility on toggle rows (role, name, checked, onPressAction)

## Test plan
- [ ] Open extraction view selector on espresso page
- [ ] Verify description text is fully visible (no ellipsis)
- [ ] Verify checkboxes align with radio buttons and match theme color
- [ ] Verify dialog fits all content without clipping (both dark and light mode)
- [ ] Tap "Show Phase Indicator" and "Show Stats" rows to toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)