### PR TITLE
fix: keyboard and scroll issues in AI conversation views

### DIFF
--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -244,9 +244,10 @@ Rectangle {
                     }
 
                     // Spacer to avoid overlap with global hide-keyboard button on mobile
+                    // (button is scaled(36) wide + standardMargin from edge)
                     Item {
                         visible: (Qt.platform.os === "android" || Qt.platform.os === "ios")
-                        width: Theme.scaled(40)
+                        width: Theme.scaled(52)
                         height: 1
                     }
                 }
@@ -553,6 +554,10 @@ Rectangle {
             Qt.callLater(function() {
                 conversationFlickable.contentY = Math.max(0, overlay._preResponseHeight)
             })
+        }
+        function onErrorOccurred(error) {
+            // Reset flag so the next send captures scroll position correctly
+            overlay._waitingForResponse = false
         }
         function onHistoryChanged() {
             // Only save the scroll target when the user sends (before response arrives).

--- a/qml/components/KeyboardAwareContainer.qml
+++ b/qml/components/KeyboardAwareContainer.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Window
 import Decenza
 
 // Container that shifts content up when a text field has focus.
@@ -94,17 +95,12 @@ Item {
         var fieldPos = field.mapToItem(targetFlickable.contentItem, 0, 0)
         var fieldBottom = fieldPos.y + field.height
 
-        // On Android, adjustPan already shifts the window above the keyboard.
-        // Only subtract keyboard height on other platforms to avoid double-shifting.
-        var visibleHeight
-        if (Qt.platform.os === "android") {
-            visibleHeight = targetFlickable.height
-        } else {
-            var kbHeight = Qt.inputMethod.keyboardRectangle.height / Screen.devicePixelRatio
-            if (kbHeight <= 0) kbHeight = root.height * 0.5
-            visibleHeight = targetFlickable.height - kbHeight
-            if (visibleHeight <= 0) visibleHeight = targetFlickable.height * 0.5
-        }
+        // adjustPan shifts the window but not the Flickable's coordinate space,
+        // so we still need to subtract keyboard height to know the truly visible area.
+        var kbHeight = Qt.inputMethod.keyboardRectangle.height / Screen.devicePixelRatio
+        if (kbHeight <= 0) kbHeight = root.height * 0.45
+        var visibleHeight = targetFlickable.height - kbHeight
+        if (visibleHeight <= 0) visibleHeight = targetFlickable.height * 0.5
 
         var margin = 20
         var maxContentY = Math.max(0, targetFlickable.contentHeight - targetFlickable.height)

--- a/qml/pages/DialingAssistantPage.qml
+++ b/qml/pages/DialingAssistantPage.qml
@@ -322,18 +322,25 @@ Page {
 
     // Handle conversation updates (follow-ups)
     property real _preResponseHeight: 0
+    property bool _waitingForResponse: false
     Connections {
         target: MainController.aiManager ? MainController.aiManager.conversation : null
         function onResponseReceived(response) {
+            _waitingForResponse = false
             // Scroll to top of the new response so it's readable from the start
             Qt.callLater(function() {
                 recommendationFlickable.contentY = Math.max(0, _preResponseHeight)
             })
         }
+        function onErrorOccurred(error) {
+            _waitingForResponse = false
+        }
         function onHistoryChanged() {
-            // Save scroll target before the response text is added
-            if (MainController.aiManager.conversation.busy) {
+            // Only save the scroll target when the user sends (before response arrives).
+            // The response triggers historyChanged too, but we handle that in onResponseReceived.
+            if (!_waitingForResponse) {
                 _preResponseHeight = recommendationText.contentHeight
+                _waitingForResponse = true
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fix keyboard not dismissing after sending messages in AI conversation overlay and dialing assistant
- Fix AI response scrolling past the top of screen — now scrolls to the start of the new response so it's readable
- Fix input field hidden behind keyboard on Android in conversation overlay (adjustPan can't help full-window overlays)
- Fix hide-keyboard button overlapping Clear/Report buttons on mobile
- Fix KeyboardAwareContainer Flickable scrolling on Android — subtract keyboard height from visible area since adjustPan shifts the window, not the Flickable coordinate space
- Reset scroll tracking flag on AI request errors so retry scrolling works correctly
- Use consistent `_waitingForResponse` flag pattern across ConversationOverlay and DialingAssistantPage

## Test plan
- [ ] Open AI conversation, type a message, hit Send — keyboard should dismiss
- [ ] After AI response arrives, verify it shows from the start (not scrolled past top)
- [ ] Trigger an AI error (e.g. network off), then retry — verify scroll still works correctly
- [ ] On Android: verify input field stays visible above keyboard when typing
- [ ] On Android: verify text fields in PostShotReviewPage scroll above keyboard when focused
- [ ] On Android/iOS: verify hide-keyboard button doesn't overlap Clear/Report buttons
- [ ] On pages using KeyboardAwareContainer with targetFlickable: verify fields scroll into view on Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)