### PR TITLE
fix: add EMA smoothing to auto flow calibration

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2588,18 +2588,22 @@ void MainController::computeAutoFlowCalibration() {
 
     ideal = qBound(kCalibrationMin, ideal, kCalibrationMax);
 
-    // EMA smoothing: blend ideal toward current to dampen shot-to-shot oscillation.
-    // alpha=0.3 moves 30% toward the ideal each shot, converging in ~5-7 shots while
-    // preventing a single noisy shot from dominating (vs. jumping straight to ideal).
-    constexpr double kEmaAlpha = 0.3;
-    double computed = kEmaAlpha * ideal + (1.0 - kEmaAlpha) * currentEffective;
-
-    // Only update if relative change > 2%. The > 0.01 guard avoids division by zero
-    // on first use (before any calibration is set).
-    if (currentEffective > 0.01 && qAbs(computed - currentEffective) / currentEffective < kChangeThreshold) {
-        qDebug() << "Auto flow cal: computed" << computed << "≈ current" << currentEffective << "(< 2% change, skipping)";
+    // Only update if the ideal itself differs enough from current. Checking ideal (not the
+    // EMA output) preserves the original 2% deadband regardless of alpha. The > 0.01 guard
+    // avoids division by zero on first use (before any calibration is set).
+    if (currentEffective > 0.01 && qAbs(ideal - currentEffective) / currentEffective < kChangeThreshold) {
+        qDebug() << "Auto flow cal: ideal" << ideal << "≈ current" << currentEffective << "(< 2% change, skipping)";
         return;
     }
+
+    // EMA smoothing: blend current toward ideal to dampen shot-to-shot oscillation.
+    // alpha=0.3 moves 30% toward the ideal each shot, converging in ~5-7 shots while
+    // preventing a single noisy shot from dominating (vs. jumping straight to ideal).
+    // Skip EMA on the first shot for this profile — no oscillation history to dampen yet.
+    constexpr double kEmaAlpha = 0.3;
+    double computed = m_settings->hasProfileFlowCalibration(m_baseProfileName)
+        ? kEmaAlpha * ideal + (1.0 - kEmaAlpha) * currentEffective
+        : ideal;
 
     double oldValue = currentEffective;
     if (!m_settings->setProfileFlowCalibration(m_baseProfileName, computed)) {


### PR DESCRIPTION
## Summary

- Adds exponential moving average smoothing (alpha=0.3) to per-profile flow calibration updates
- Instead of jumping straight to the per-shot ideal multiplier, blends 30% toward it each shot
- Converges in ~5-7 shots while preventing a single noisy shot from dominating

## Motivation

Recent shots showed the multiplier oscillating between 0.78–0.97 shot-to-shot:
```
Shot 780: 1.000 → 0.799  (ratio 1.30)
Shot 781: 0.799 → 0.880  (ratio 0.94)
Shot 782: 0.880 → 0.969  (ratio 0.94)
Shot 783: 0.969 → 0.824  (ratio 1.22)
```
With EMA at alpha=0.3, the same sequence converges smoothly to ~0.88 with no large swings.

## Test plan

- Pull a few shots with a profile that has auto flow calibration enabled
- Verify the multiplier converges smoothly rather than bouncing each shot
- Check logcat for `Auto flow cal: updated ... (ideal: ... EMA alpha: 0.3 ...)`

🤖 Generated with [Claude Code](https://claude.ai/code)