### PR TITLE
ci: add sccache to Windows build, switch to Ninja

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -15,6 +15,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/linux-arm64-release.yml
+++ b/.github/workflows/linux-arm64-release.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -58,6 +59,7 @@ jobs:
           target: 'desktop'
           arch: 'win64_msvc2022_64'
           modules: 'qtquick3d qtshadertools qtcharts qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtserialport'
+          tools: 'tools_ninja'
           cache: true
           cache-key-prefix: 'qt-windows-v2'
 


### PR DESCRIPTION
Closes #385

## Changes

- Find Qt's bundled `ninja.exe` dynamically and add to PATH (no `choco install ninja`)
- Add `hendrikmuhs/ccache-action@v1` with `variant: sccache`, 500MB cache, keyed on Qt version
- Switch CMake generator from `Visual Studio 17 2022` to `Ninja`
- Pass `-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache`
- Remove `--config Release` from build step (set at configure time with Ninja)
- Fix `AppBuildDir` in installer config from `build\Release` → `build` (Ninja outputs flat)

## Expected impact

| | Before | After (warm cache) |
|---|---|---|
| Build time | ~18-20 min | ~5-7 min |
| Savings | — | ~65-70% |

Cold cache (first run, or after 7-day eviction) remains ~18-20 min.

## Test plan

- Trigger a manual `workflow_dispatch` build and confirm it succeeds end-to-end
- Check that the installer is produced and the sccache stats show a miss rate (expected on first run)
- Trigger a second build and confirm the sccache hit rate is high and build time is reduced

🤖 Generated with [Claude Code](https://claude.ai/code)