### PR TITLE
fix: restore state_class on MQTT espresso_count for HA long-term stats

### DIFF
--- a/src/network/mqttclient.cpp
+++ b/src/network/mqttclient.cpp
@@ -1129,13 +1129,14 @@ void MqttClient::publishHomeAssistantDiscovery()
     }
 
     // Espresso count sensor
-    // No state_class — count can decrease when shots are deleted from history,
-    // which is incompatible with "total_increasing" (HA would treat decreases as resets)
+    // total_increasing: HA treats value decreases (e.g. history cleared) as meter resets
+    // and continues accumulating from the new value — no inflation.
     {
         QJsonObject config;
         config["name"] = "DE1 Espresso Count";
         config["state_topic"] = baseTopic + "/espresso_count";
         config["icon"] = "mdi:counter";
+        config["state_class"] = "total_increasing";
         config["unique_id"] = QString("de1_%1_espresso_count").arg(m_clientId);
         config["availability_topic"] = baseTopic + "/availability";
         config["device"] = device;


### PR DESCRIPTION
## Summary
- Restores `state_class: "total_increasing"` on the `espresso_count` MQTT sensor
- It was removed in #359 over concern that shot deletions would inflate HA statistics, but `total_increasing` handles decreases correctly by treating them as meter resets
- Without `state_class`, HA cannot track long-term statistics at all

Closes #481

## Test plan
- [ ] Verify HA discovers the sensor with `state_class: total_increasing`
- [ ] Verify long-term statistics tracking resumes
- [ ] Verify clearing shot history does not inflate the statistics (HA treats decrease as reset)

🤖 Generated with [Claude Code](https://claude.ai/code)