### PR TITLE
fix: false "scale not tared" warning during espresso preheat

### DIFF
--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -188,7 +188,7 @@ void WeightProcessor::processWeight(double weight)
     }
     if (!m_stopTriggered && m_targetWeight > 0 && flowRateShort >= 0.5) {
         // Log once when flow becomes valid — confirms de-jitter is working
-        if (!m_flowBecameValidLogged) {
+        if (!m_flowBecameValidLogged && m_extractionStartTime > 0) {
             m_flowBecameValidLogged = true;
             double extractionTime = (wallClock - m_extractionStartTime) / 1000.0;
             qDebug() << "[SAW-Worker] Flow became valid: flowShort=" << QString::number(flowRateShort, 'f', 2)
@@ -275,6 +275,7 @@ void WeightProcessor::startExtraction()
 
 void WeightProcessor::markExtractionStart()
 {
+    if (!m_active || m_extractionStartTime != 0) return;
     m_extractionStartTime = QDateTime::currentMSecsSinceEpoch();
 }
 

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -36,7 +36,7 @@ public slots:
     void setCurrentFrame(int frameNumber);
     void setTareComplete(bool complete);
     void startExtraction();
-    void markExtractionStart();  // Called when extraction actually begins (preinfusion)
+    void markExtractionStart();  // Called when flow starts (idempotent, espresso-only)
     void stopExtraction();
     void resetForRetare();  // Clear LSLR buffer after auto-tare during preheat
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -604,7 +604,7 @@ int main(int argc, char *argv[])
                          }, Qt::QueuedConnection);
                      });
 
-    // Mark extraction start when flow actually begins (preinfusion), not at preheat.
+    // Mark extraction start when flow actually begins, not at preheat.
     // This ensures the untared-cup sanity check in WeightProcessor doesn't fire during
     // preheat while the BLE tare command is still in transit to the scale.
     QObject::connect(&machineState, &MachineState::shotStarted,


### PR DESCRIPTION
## Summary
- The untared-cup sanity check in WeightProcessor fired falsely because `m_extractionStartTime` was set at **preheat start**, before the BLE tare command had been processed by the scale
- Cup weight (>50g) within 3 seconds of preheat start triggered the red "Scale not tared — auto-stop disabled" warning, even though the tare would complete well before water flows
- Fix: defer `m_extractionStartTime` to when flow actually begins (`shotStarted` at preinfusion), giving the BLE tare the entire preheat phase to complete

## Test plan
- [ ] Start espresso with cup on scale → no false red warning
- [ ] SAW (stop-at-weight) still stops the shot correctly
- [ ] Genuinely untared scale at extraction start should still trigger the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)