### PR TITLE
fix: lower LSLR gate from 80% to 65% so SAW works on 5Hz scales

### DIFF
--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -186,7 +186,7 @@ void WeightProcessor::processWeight(double weight)
                      << "samples=" << m_weightSamples.size()
                      << "shortWindow=" << shortWindowMs << "ms"
                      << "shortDt=" << QString::number(shortDt, 'f', 3) << "s"
-                     << "gate=" << QString::number(shortWindowMs * 0.8 / 1000.0, 'f', 3) << "s";
+                     << "gate=" << QString::number(shortWindowMs * 0.65 / 1000.0, 'f', 3) << "s";
             m_lastLowFlowLogMs = wallClock;
         }
     }
@@ -337,7 +337,7 @@ double WeightProcessor::computeLSLR(int windowMs) const
     if (n < 2) return 0.0;
 
     double dt = (m_weightSamples.last().timestamp - m_weightSamples[startIdx].timestamp) / 1000.0;
-    if (dt < (windowMs * 0.8 / 1000.0)) return 0.0;  // Wait until window is ~80% full
+    if (dt < (windowMs * 0.65 / 1000.0)) return 0.0;  // Wait until window is ~65% full
 
     // Least-squares linear regression: fits w = slope*t + intercept
     // slope = flow rate in g/s. Uses all samples in the window, averaging


### PR DESCRIPTION
## Summary
- LSLR gate threshold lowered from 80% to 65% in `computeLSLR()`
- Fixes SAW never arming on 5Hz scales (Skale) where 3 samples span ~400ms and the 80% gate (400ms) is borderline
- Also updates the diagnostic log line to print the correct gate value

Closes #514

## Test plan
- [ ] Run espresso with Skale — verify SAW triggers reliably (no more "Flow too low" for entire shot)
- [ ] Verify debug log shows `gate= "0.325"` instead of `gate= "0.400"` for 500ms window
- [ ] If available, test with 2Hz scale (Bookoo) — should be unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)