### PR TITLE
fix: break binding loop on ShotGraph time axis max property

### DIFF
--- a/qml/components/ShotGraph.qml
+++ b/qml/components/ShotGraph.qml
@@ -87,7 +87,7 @@ ChartView {
         min: 0
         // recalcMax() guarantees calculatedMax >= minTime
         max: calculatedMax
-        tickCount: Math.min(7, Math.max(3, Math.floor(max / 10) + 2))
+        tickCount: Math.min(7, Math.max(3, Math.floor(calculatedMax / 10) + 2))
         labelFormat: "%.0f"
         labelsColor: Theme.textSecondaryColor
         gridLineColor: Qt.rgba(255, 255, 255, 0.1)


### PR DESCRIPTION
## Summary
- `tickCount` binding referenced `max`, which could trigger a re-layout emitting `maxChanged`, creating a binding loop
- Changed to reference `calculatedMax` directly, breaking the circular dependency

Closes #515

## Test plan
- [ ] Run espresso — verify no "Binding loop detected" warning in log for ShotGraph
- [ ] Verify time axis tick spacing still looks correct

🤖 Generated with [Claude Code](https://claude.ai/code)