### PR TITLE
fix: auto-recover expired MCP sessions instead of hard-failing

### DIFF
--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -181,10 +181,20 @@ void McpServer::handleHttpRequest(QTcpSocket* socket, const QString& method,
             if (!session && sessionHeader.isEmpty() && m_sessions.size() == 1) {
                 session = m_sessions.begin().value();
             }
+            // Auto-recover: if session expired or ID is stale, create a new one
+            // instead of hard-failing. mcp-remote can't re-initialize on its own,
+            // so rejecting here leaves the client permanently broken until restart.
             if (!session) {
-                sendJsonRpcError(socket, -32600, "Invalid session",
-                                 request["id"].toVariant(), sessionHeader);
-                return;
+                qDebug() << "McpServer: Session not found (expired or stale), auto-creating new session";
+                session = findOrCreateSession(QString());
+                if (!session) {
+                    sendJsonRpcError(socket, -32000, "Too many sessions",
+                                     request["id"].toVariant(), sessionHeader);
+                    return;
+                }
+                // Mark as initialized — the client already completed initialize
+                // in a prior session, so skip the handshake requirement
+                session->setInitialized(true);
             }
             if (!session->initialized() && rpcMethod != "notifications/initialized") {
                 sendJsonRpcError(socket, -32600, "Session not initialized",

--- a/src/mcp/mcpserver.h
+++ b/src/mcp/mcpserver.h
@@ -133,6 +133,6 @@ private:
     // Limits
     static constexpr int MaxSessions = 8;
     static constexpr int MaxSseConnections = 4;
-    static constexpr int SessionTimeoutMinutes = 30;
+    static constexpr int SessionTimeoutMinutes = 1440;  // 24 hours
     static constexpr int RateLimitPerMinute = 10;
 };


### PR DESCRIPTION
## Summary
- Session timeout increased from 30 min to 24 hours
- Auto-creates a new session when old one is expired/stale, instead of returning "Invalid session" error
- mcp-remote can't re-initialize on its own, so the server needs to be resilient

## Test plan
- [ ] Connect MCP, wait for session to be active, verify tools work
- [ ] Restart app, reconnect MCP, verify session auto-recovers without manual reconnection

🤖 Generated with [Claude Code](https://claude.ai/code)