### PR TITLE
fix: suppress DeadSystemException crash reports on Android

### DIFF
--- a/android/src/io/github/kulitorum/decenza_de1/DecenzaActivity.java
+++ b/android/src/io/github/kulitorum/decenza_de1/DecenzaActivity.java
@@ -64,10 +64,28 @@ public class DecenzaActivity extends QtActivity {
         super.onDestroy();
     }
 
+    private static boolean isDeadSystemException(Throwable t) {
+        while (t != null) {
+            if (t.getClass().getName().contains("DeadSystem")) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
+    }
+
     private void installJavaCrashHandler() {
         defaultHandler = Thread.getDefaultUncaughtExceptionHandler();
 
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+            // DeadSystemException means Android's system_server crashed or the device
+            // is rebooting. Nothing we can do — skip the crash report to avoid noise.
+            if (isDeadSystemException(throwable)) {
+                Log.w(TAG, "DeadSystemException on thread " + thread.getName()
+                        + " — Android system is dying, suppressing crash report");
+                return;
+            }
+
             try {
                 // Get crash log path (same as C++ crash handler)
                 File filesDir = getFilesDir();


### PR DESCRIPTION
## Summary
- Detect `DeadSystemException` in the Java uncaught exception handler and log a warning instead of writing a crash report
- Only suppresses this specific exception — all other Java crashes still get full reports
- The exception occurs when Android's system_server dies/reboots and our shutdown handler tries to send BLE commands to a dead Bluetooth stack

Closes #521

## Test plan
- [ ] Verify other Java exceptions still produce crash reports (e.g. force a NullPointerException in dev build)
- [ ] Verify the app builds for Android without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)