### PR TITLE
fix: improve MCP install scripts for Windows and macOS

### DIFF
--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -996,7 +996,7 @@ if ! command -v npx &>/dev/null; then
     echo "Node.js is required but not installed."
     if command -v brew &>/dev/null; then
         printf "Install Node.js via Homebrew? (Y/n) "
-        read choice < /dev/tty
+        read choice < /dev/tty || true
         choice=${choice:-Y}
         if [[ "$choice" =~ ^[Yy]$ ]]; then
             echo "Installing Node.js..."
@@ -1154,9 +1154,13 @@ try {
 "
 elif command -v python3 &>/dev/null; then
     python3 -c "
-import json
-with open('$CONFIG') as f:
-    config = json.load(f)
+import json, sys
+try:
+    with open('$CONFIG') as f:
+        config = json.load(f)
+except Exception as e:
+    print('Error reading config:', e, file=sys.stderr)
+    sys.exit(1)
 if 'mcpServers' in config and 'decenza' in config['mcpServers']:
     del config['mcpServers']['decenza']
     if not config['mcpServers']:


### PR DESCRIPTION
## Summary
- **Config directory**: Create it instead of erroring when missing (fixes Windows "directory not found" issue)
- **Python dependency removed**: Bash scripts now use `node -e` instead of `python3` for JSON manipulation (Node.js is already required for `npx mcp-remote`)
- **Node.js auto-install**: Offers `winget install` on Windows, `brew install` on macOS when Node.js is missing
- **Admin detection**: Warns Windows users if running PowerShell as Administrator (wrong AppData path)
- **Pipe-safe prompts**: `read` uses `/dev/tty` so prompts work in `curl | bash` pipelines
- **Bash uninstall**: Falls back to `python3` if `node` unavailable, with manual instructions as last resort

## Test plan
- [ ] Browse to `http://<ip>:8888/mcp/install.ps1` — verify admin warning, winget offer, config dir creation with path shown
- [ ] Browse to `http://<ip>:8888/mcp/install.sh` — verify `node -e` (no python3), brew offer, `/dev/tty` read, config dir creation
- [ ] Browse to `http://<ip>:8888/mcp/uninstall.sh` — verify node→python3 fallback chain
- [ ] Test Windows install on machine without Node.js
- [ ] Test macOS install on machine without Node.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)