### PR TITLE
fix: MCP setup script writes to wrong path on Windows MSIX installs

### DIFF
--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -1066,6 +1066,9 @@ if ($isAdmin) {
     Write-Host ""
 }
 
+# Refresh PATH from registry (picks up Node.js installed in a prior run)
+$env:PATH = [System.Environment]::GetEnvironmentVariable("PATH","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("PATH","User")
+
 # Check for Node.js (needed for npx/mcp-remote)
 if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
     Write-Host "Node.js is required but not installed." -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- Claude Desktop on Windows uses MSIX packaging (even direct downloads), which virtualizes the filesystem — config lives under `%LOCALAPPDATA%\Packages\Claude_*\` not `%APPDATA%\Claude\`
- Install and uninstall PowerShell scripts now auto-detect the correct config path by checking for a `Claude_*` package folder first
- Install script cleans up stale `decenza` entries from `%APPDATA%\Claude\` left by previous runs

## Test plan
- [ ] Run `install.ps1` on Windows with MSIX-installed Claude Desktop — verify config written to `%LOCALAPPDATA%\Packages\Claude_*\LocalCache\Roaming\Claude\`
- [ ] Run `install.ps1` on Windows with non-MSIX Claude Desktop — verify config written to `%APPDATA%\Claude\`
- [ ] If stale config exists at `%APPDATA%\Claude\`, verify it gets cleaned up
- [ ] Run `uninstall.ps1` — verify it finds and removes from the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)