### PR TITLE
fix: dSYM not included in iOS xcarchive for crash symbolication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,7 +804,6 @@ if(IOS)
         XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT[variant=Debug] "dwarf"
         XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT[variant=MinSizeRel] "dwarf-with-dsym"
         XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT[variant=RelWithDebInfo] "dwarf-with-dsym"
-        XCODE_ATTRIBUTE_DWARF_DSYM_FOLDER_PATH "$(CONFIGURATION_BUILD_DIR)"
         XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS "${CMAKE_CURRENT_SOURCE_DIR}/ios/Decenza.entitlements"
     )
     # Only override Xcode's signing team when explicitly provided


### PR DESCRIPTION
## Summary
- `DWARF_DSYM_FOLDER_PATH` was overridden to `$(CONFIGURATION_BUILD_DIR)`, redirecting dSYMs to the build directory instead of inside the `.xcarchive`
- The CI dSYM upload step was silently failing on **every build** with "No files were found"
- This is why we have no dSYMs for v1.5.8 (or any other version) — the artifact was never produced
- Fix: remove the override so Xcode uses the default archive path

## Test plan
- [ ] iOS CI build produces a `Decenza-iOS-dSYMs` artifact
- [ ] The artifact contains `Decenza.app.dSYM`
- [ ] Local Xcode archive still builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)