### PR TITLE
fix: recover from Android DeadSystemException killing BLE thread (#538)

### DIFF
--- a/android/src/io/github/kulitorum/decenza_de1/DecenzaActivity.java
+++ b/android/src/io/github/kulitorum/decenza_de1/DecenzaActivity.java
@@ -80,15 +80,17 @@ public class DecenzaActivity extends QtActivity {
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
             // DeadSystemException means Android's Bluetooth system service died
             // (deep sleep, OEM power management, system_server crash).
-            // If it happened on the BLE thread, write a flag file so the C++ side
-            // can detect it and trigger BLE recovery (disconnect + reconnect).
+            // Create a flag file so the C++ side can detect it and trigger BLE
+            // recovery (disconnect + reconnect). This fires on any thread — we
+            // don't filter by thread name since DeadSystemException only occurs
+            // when Android system services die, which always affects BLE.
             // Don't crash the app — the rest of the app is fine, only BLE is dead.
             if (isDeadSystemException(throwable)) {
                 Log.w(TAG, "DeadSystemException on thread " + thread.getName()
                         + " — Bluetooth system died, signaling BLE recovery");
                 try {
                     File flagFile = new File(getFilesDir(), "ble_dead_system");
-                    new FileWriter(flagFile).close();
+                    flagFile.createNewFile();
                     Log.w(TAG, "Wrote BLE recovery flag: " + flagFile.getAbsolutePath());
                 } catch (Exception e) {
                     Log.e(TAG, "Failed to write BLE recovery flag: " + e.getMessage());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -707,9 +707,8 @@ int main(int argc, char *argv[])
     auto* bleRecoveryTimer = new QTimer();
     bleRecoveryTimer->setInterval(10000);
     QObject::connect(bleRecoveryTimer, &QTimer::timeout,
-                     [&bleManager, &de1Device, &settings]() {
-        // Java getFilesDir() = /data/data/<pkg>/files/ on Android
-        // QStandardPaths::AppDataLocation = /data/data/<pkg>/files/ on Android
+                     [&bleManager, &de1Device]() {
+        // Use same path as CrashHandler (proven to match Java getFilesDir())
         QString flagPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
                          + "/ble_dead_system";
         QFile flagFile(flagPath);


### PR DESCRIPTION
## Summary
- Android's Bluetooth system service can die during deep sleep or OEM power management, throwing `DeadSystemRuntimeException` from `BluetoothGatt.writeCharacteristic()` inside Qt's BLE handler thread
- Previously the crash was suppressed but BLE stayed dead with no recovery
- Now: Java writes a flag file, C++ checks every 10s, forces disconnect, waits 3s, reconnects

## How it works
1. `DecenzaActivity.java`: on `DeadSystemException`, write `ble_dead_system` flag to app files dir
2. `main.cpp`: 10-second timer checks for flag, deletes it, calls `de1Device.disconnect()` + `bleManager.resetScaleConnectionState()`, then reconnects after 3s delay

## Test plan
- [ ] Build succeeds on Android
- [ ] Normal BLE operation unaffected (flag file never created)
- [ ] If BLE thread dies (simulated or real), app continues running and attempts reconnection
- [ ] Flag file is cleaned up after recovery

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)