### PR TITLE
fix: skip early extraction in auto flow calibration window

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2494,6 +2494,8 @@ void MainController::computeAutoFlowCalibration() {
     constexpr double kMinSampleRatio = 0.4;          // (generous bounds: window-level check is tighter)
     constexpr double kMaxWindowRatio = 1.35;         // window-mean machine/weight ratio — reject if scale data is suspect
     constexpr double kMinWindowRatio = 0.75;         // (de1app GFC users get ~0.9-1.1 ratios on good data)
+    constexpr double kMinWindowStartTime = 10.0;     // seconds — skip early extraction where LSLR weight flow
+                                                     // lags behind actual flow, producing inflated ratios
 
     // Find the best steady-pour window: stable pressure above minimum + meaningful weight flow.
     // We track the best (longest) qualifying window found across the entire shot.
@@ -2532,6 +2534,13 @@ void MainController::computeAutoFlowCalibration() {
         double dpdt = qAbs(pressureData[i].y() - pressureData[i - 1].y()) / dt;
         double pressure = pressureData[i].y();
         double t = pressureData[i].x();
+
+        // Skip early extraction where LSLR weight flow hasn't converged yet.
+        // The rolling regression lags behind actual flow for the first ~10-12s,
+        // producing artificially low weight flow and inflated machine/weight ratios.
+        if (t < kMinWindowStartTime) {
+            continue;
+        }
 
         // Require stable pressure AND minimum pressure.
         // The minimum pressure rejects empty-portafilter / no-coffee shots where


### PR DESCRIPTION
## Summary
The auto flow calibration steady-window algorithm was selecting windows during the first ~10s of extraction, where the LSLR weight flow rate hasn't converged yet. This produced inflated machine/weight ratios (1.35-1.54) that were rejected by the bounds check, preventing calibration from ever converging.

Added `kMinWindowStartTime = 10.0` seconds to skip the LSLR ramp-up period. The algorithm now only considers windows starting after 10s into extraction, where weight flow has stabilized.

## Verification
Analyzed 19 calibration events across 5 users with different scales and profiles:

| Scale | Profile | Events | Affected | Impact |
|-------|---------|--------|----------|--------|
| Decent Scale 10Hz | D-Flow / Q | 2 rejected | 2 | Fixes — finds valid later window |
| Eureka Precisa 6Hz | Damian's LRv3 | 1 rejected | 1 | Helps — skips bad early window |
| Acaia | Adaptive v2 | 2 accepted | 0 | No change (windows already >25s) |
| Flow Scale | D-Flow variants | 14 events | 1 | Shorter window, same result |

No regressions across any user or profile type.

## Test plan
- [ ] Pull a shot with auto flow calibration enabled — verify calibration window starts at t>=10s in debug log
- [ ] Verify calibration converges (ratio within [0.75, 1.35] bounds)
- [ ] Short profiles (<20s) should still find valid windows in the later extraction phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)