### PR TITLE
Fix SIGSEGV when DiFluid R2 refractometer reconnects

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -523,6 +523,9 @@ void BLEManager::clearSavedRefractometer() {
 }
 
 void BLEManager::setRefractometerDevice(DiFluidR2* device) {
+    if (m_refractometerDevice) {
+        disconnect(m_refractometerDevice, nullptr, this, nullptr);
+    }
     m_refractometerDevice = device;
     if (m_refractometerDevice) {
         connect(m_refractometerDevice, &DiFluidR2::connectedChanged,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1148,13 +1148,13 @@ int main(int argc, char *argv[])
             return;  // Already connected
         }
 
-        // Clean up old refractometer before replacing — the raw pointers in
-        // MainController/BLEManager/QML would dangle when unique_ptr destroys the old object
+        // Clean up old refractometer before replacing — disconnect first (emits
+        // signals while pointers are still valid), then clear raw pointer holders
         if (refractometer) {
+            refractometer->disconnectFromDevice();
             mainController.setRefractometer(nullptr);
             bleManager.setRefractometerDevice(nullptr);
             engine.rootContext()->setContextProperty("Refractometer", nullptr);
-            refractometer->disconnectFromDevice();
         }
 
         // Create transport using the same platform selection as scales
@@ -1189,11 +1189,12 @@ int main(int argc, char *argv[])
 
     // Handle Forget Refractometer — disconnect and clean up
     QObject::connect(&bleManager, &BLEManager::disconnectRefractometerRequested,
-                     [&refractometer, &mainController, &engine]() {
+                     [&refractometer, &mainController, &engine, &bleManager]() {
         if (refractometer) {
             qDebug() << "[Refractometer] Forget requested, disconnecting";
             refractometer->disconnectFromDevice();
             mainController.setRefractometer(nullptr);
+            bleManager.setRefractometerDevice(nullptr);
             engine.rootContext()->setContextProperty("Refractometer", nullptr);
             refractometer.reset();
         }


### PR DESCRIPTION
## Summary
- Fixes #569 — crash (SIGSEGV) when a disconnected DiFluid R2 refractometer is rediscovered during BLE scanning
- When the R2 disconnected and was rediscovered, `refractometer = std::make_unique<DiFluidR2>(...)` destroyed the old object while `MainController`, `BLEManager`, and QML still held raw pointers to it. The subsequent `setRefractometer()` tried to `disconnect()` on freed memory.
- Clears all raw pointer holders before replacing the `unique_ptr`, matching the existing "Forget Refractometer" cleanup pattern

## Test plan
- [ ] Connect DiFluid R2 refractometer via BLE
- [ ] Walk out of BLE range (or toggle Bluetooth) so R2 disconnects
- [ ] Return to range and let auto-reconnect trigger — should reconnect without crash
- [ ] Verify TDS readings still flow through after reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)