### PR TITLE
fix: disable Qt 6.9+ safe area padding to use full screen (#582)

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -15,7 +15,17 @@ ApplicationWindow {
     width: 960
     height: 600
     title: "Decenza"
-    color: screensaverActive ? "black" : Theme.backgroundColor
+    color: Theme.backgroundColor
+
+    // Override Qt 6.9+ automatic safe area padding on ApplicationWindow.
+    // Qt reads Android system bar insets and offsets contentItem, even in
+    // fullscreen immersive mode. This causes a gap on some tablets (e.g.
+    // Lenovo Tab One #582). Since we run fullscreen with system bars hidden,
+    // there is nothing to protect content from — use the full window.
+    topPadding: 0
+    bottomPadding: 0
+    leftPadding: 0
+    rightPadding: 0
 
     // Debug flag to force live view on operation pages (for development)
     property bool debugLiveView: false


### PR DESCRIPTION
## Summary
- Override `ApplicationWindow` automatic safe area padding (`topPadding: 0` etc.) so `contentItem` fills the entire window
- Reverts the conditional screensaver background color (Fix #2) since the gap no longer exists

## Root Cause
Qt 6.9+ auto-binds `ApplicationWindow.topPadding` to `SafeArea.margins.top`. On the Lenovo Tab One (Android 15, SDK 35), the system reports `systemBars insets: top=44` even in fullscreen immersive mode. Qt converts this to 39 logical px (44 / 1.125 DPR) and offsets `contentItem` — creating the visible strip at the top.

The three prior fixes addressed the **Android native layer** (windowBackground color, ApplicationWindow.color, WindowInsetsController API), but the native ContentView was already at pos 0,0 full size. The offset was Qt's own framework applying safe area padding internally.

Debug log proof:
```
[#582 diag] Window size: 1191 x 711
[#582 diag] grandparent (contentItem) size: 1191 x 672 pos: 0 39  ← 39px gap
```

## Fix
Setting `topPadding: 0` / `bottomPadding: 0` / `leftPadding: 0` / `rightPadding: 0` overrides the automatic bindings. This is the [officially documented approach](https://doc.qt.io/qt-6/qml-qtquick-controls-applicationwindow.html) for apps that handle safe areas manually.

## Test plan
- [ ] Verify no strip/gap at top of screensaver on Lenovo Tab One (all screensaver types)
- [ ] Verify `[#582 diag]` log shows `contentItem pos: 0 0` and `size: 1191 x 711`
- [ ] Verify screensaver and all pages use full screen on Samsung A8 (regression check)
- [ ] Verify no visual issues on desktop (Windows/macOS)

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)