### PR TITLE
fix: clean up orphaned MCP sessions on re-initialize

### DIFF
--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -82,8 +82,8 @@ void DecentScale::onServiceDiscovered(const QBluetoothUuid& uuid) {
 void DecentScale::onServicesDiscoveryFinished() {
     if (!m_serviceFound) {
         DECENT_WARN("Decent Scale service not found");
-        m_transport->disconnectFromDevice();
         emit errorOccurred("Decent Scale service not found");
+        m_transport->disconnectFromDevice();
         return;
     }
     m_transport->discoverCharacteristics(Scale::Decent::SERVICE);

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -688,11 +688,13 @@ McpSession* McpServer::findOrCreateSession(const QString& sessionHeader)
     // Clean up orphaned sessions before creating a new one.
     // When mcp-remote's SSE connection drops and it re-initializes (without
     // sending a session header), the old session stays around with no SSE
-    // socket. Over hours this fills the session quota. Remove sessions whose
-    // SSE transport is gone — the client has already moved on.
+    // socket. Over hours this fills the session quota. Remove initialized
+    // sessions whose SSE transport is gone — the client has already moved on.
+    // We check initialized() to avoid killing sessions that were just created
+    // by a concurrent initialize but haven't connected their SSE stream yet.
     QStringList orphaned;
     for (auto it = m_sessions.constBegin(); it != m_sessions.constEnd(); ++it) {
-        if (!it.value()->sseSocket())
+        if (!it.value()->sseSocket() && it.value()->initialized())
             orphaned.append(it.key());
     }
     for (const QString& id : orphaned) {

--- a/src/mcp/mcpserver.h
+++ b/src/mcp/mcpserver.h
@@ -155,6 +155,6 @@ private:
     // Limits
     static constexpr int MaxSessions = 8;
     static constexpr int MaxSseConnections = 4;
-    static constexpr int SessionTimeoutMinutes = 30;  // safety net — sessions are removed on SSE disconnect
+    static constexpr int SessionTimeoutMinutes = 30;  // safety net — orphan cleanup only runs during session creation
     static constexpr int RateLimitPerMinute = 10;
 };


### PR DESCRIPTION
## Summary
- When mcp-remote's SSE drops and it re-initializes (without sending `Mcp-Session` header), the old session stayed around with the 24-hour timeout, accumulating until hitting the 8-session cap and rejecting all new MCP connections
- `findOrCreateSession()` now removes sessions with no active SSE socket before creating a new one — these are orphaned sessions whose client has already moved on
- Reduced safety-net session timeout from 24 hours to 30 minutes

## Test plan
- [ ] Connect 1-2 MCP clients (e.g., Claude Desktop via mcp-remote)
- [ ] Let it run for several hours — SSE will drop/reconnect periodically
- [ ] Verify "Removing orphaned session" appears in logs on re-initialize
- [ ] Verify session count stays bounded (no "Too many sessions" warnings)
- [ ] Verify SSE-only reconnects (no re-initialize) still work — session should survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)