### PR TITLE
Fix layout warning in SettingsHistoryDataTab

### DIFF
--- a/qml/pages/settings/SettingsHistoryDataTab.qml
+++ b/qml/pages/settings/SettingsHistoryDataTab.qml
@@ -1056,9 +1056,10 @@ KeyboardAwareContainer {
         }
     }
 
-    // Status message for backup operations
+    // Status message for backup operations (reparented to avoid layout warnings)
     Rectangle {
         id: backupStatusBackground
+        parent: Overlay.overlay
         visible: false
         anchors.bottom: parent.bottom
         anchors.horizontalCenter: parent.horizontalCenter


### PR DESCRIPTION
## Summary
- Reparent backup status toast Rectangle to `Overlay.overlay` to avoid "anchors on an item managed by a layout" QML warning

## Test plan
- [ ] Verify no QML layout warnings in console on History & Data tab
- [ ] Verify backup status toast still appears correctly after backup operations

🤖 Generated with [Claude Code](https://claude.ai/code)