### PR TITLE
fix: make bean presets immutable favorites

### DIFF
--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -103,6 +103,7 @@ Page {
             if (matchIndex >= 0) {
                 // Auto-select the matching preset instead of showing the dialog
                 Settings.selectedBeanPreset = matchIndex
+                _snapSelectedPreset = matchIndex
             } else {
                 guestBeanDialog.open()
             }
@@ -694,7 +695,7 @@ Page {
                     DatePickerDialog {
                         id: beanDatePicker
                         onDateSelected: function(dateString) {
-                            if (isEditMode) editRoastDate = dateString; else Settings.dyeRoastDate = dateString;
+                            if (isEditMode) editRoastDate = dateString; else { Settings.dyeRoastDate = dateString; deselectPresetOnEdit(); }
                         }
                     }
                 }
@@ -1150,6 +1151,15 @@ Page {
                             }
                             // Update snapshot so handleBack() doesn't show spurious unsaved changes dialog
                             _snapSelectedPreset = Settings.selectedBeanPreset
+                            _snapBrand = Settings.dyeBeanBrand
+                            _snapType = Settings.dyeBeanType
+                            _snapRoastDate = Settings.dyeRoastDate
+                            _snapRoastLevel = Settings.dyeRoastLevel
+                            _snapGrinderBrand = Settings.dyeGrinderBrand
+                            _snapGrinderModel = Settings.dyeGrinderModel
+                            _snapGrinderBurrs = Settings.dyeGrinderBurrs
+                            _snapGrinderSetting = Settings.dyeGrinderSetting
+                            _snapBarista = Settings.dyeBarista
                             var shouldGoBack = savePresetDialog.goBackAfterSave
                             newBeanNameInput.text = ""
                             savePresetDialog.goBackAfterSave = false


### PR DESCRIPTION
## Summary
- Bean presets were silently corrupted when editing DYE fields on BeanInfoPage — auto-save-back wrote field values into the selected preset while keeping the old name, causing name/data mismatch
- Removed auto-save-back behavior: presets are now immutable favorites that only change via explicit save
- Editing any DYE field while a preset is selected now deselects the preset (visual feedback)
- Added "Save Favorite" as third option in the unsaved changes dialog (Discard / Keep / Save Favorite)
- Pre-fills preset name with "Brand Coffee" when clicking + or Save Favorite

## Test plan
- [ ] Select a bean preset on IdlePage — verify shot plan updates correctly
- [ ] Open BeanInfoPage with a preset selected, edit a field — verify preset deselects
- [ ] Hit back after editing — verify 3-button dialog (Discard / Keep / Save Favorite)
- [ ] Test Discard: changes reverted, preset restored
- [ ] Test Keep: DYE changes kept, preset deselected, no preset data corrupted
- [ ] Test Save Favorite: name dialog opens pre-filled, saves preset, navigates back
- [ ] Click + to add preset — verify name pre-filled with brand+type
- [ ] Save with same name as existing preset — verify it updates (no duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)