### PR TITLE
fix: add roast date to Brew Settings dialog and improve layout

### DIFF
--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -365,12 +365,12 @@ Dialog {
             StyledTextField {
                 id: roastDateInput
                 Layout.fillWidth: true
-                placeholder: "yyyy-mm-dd"
+                placeholder: TranslationManager.translate("brewDialog.roastDatePlaceholder", "yyyy-mm-dd")
                 accessibleName: TranslationManager.translate("brewDialog.roastDate", "Roast date")
                 text: root.roastDate
                 inputMethodHints: Qt.ImhDate
                 inputMask: "9999-99-99"
-                onTextEdited: root.roastDate = text
+                onTextEdited: root.roastDate = text.replace(/_/g, "")
             }
 
             AccessibleButton {

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -41,9 +41,9 @@ Text {
             if (roastDate) beanLine += " \u00B7 " + roastDate
             parts.push(beanLine)
         } else if (grindSize) {
-            parts.push("Grind: " + grindSize)
+            parts.push(TranslationManager.translate("shotplantext.grind", "Grind: ") + grindSize)
         } else if (roastDate) {
-            parts.push(roastDate)
+            parts.push(TranslationManager.translate("shotplantext.roastedOn", "Roasted: ") + roastDate)
         }
         if (dose > 0 || targetWeight > 0) {
             var yieldParts = []

--- a/qml/components/SuggestionField.qml
+++ b/qml/components/SuggestionField.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Effects
 import Decenza
 
 // Autocomplete text field that shows filtered suggestions as you type
@@ -215,12 +216,19 @@ Item {
             color: arrowArea.pressed ? Theme.surfaceColor : "transparent"
             Accessible.ignored: true
 
-            Text {
+            Image {
                 anchors.centerIn: parent
-                text: suggestionPopup.visible ? "\u25B2" : "\u25BC"
-                color: Theme.textSecondaryColor
-                font.pixelSize: Theme.scaled(18)
+                source: "qrc:/icons/ArrowLeft.svg"
+                sourceSize.width: Theme.scaled(14)
+                sourceSize.height: Theme.scaled(14)
+                rotation: suggestionPopup.visible ? -90 : 90
                 Accessible.ignored: true
+                layer.enabled: true
+                layer.smooth: true
+                layer.effect: MultiEffect {
+                    colorization: 1.0
+                    colorizationColor: Theme.textSecondaryColor
+                }
             }
 
             MouseArea {


### PR DESCRIPTION
## Summary
- Adds a **Roast date** field with calendar date picker to the Brew Settings dialog (same UI as the Beans page), synced to `Settings.dyeRoastDate`
- Roast date is also shown in the shot plan text under the bean/coffee line
- Evens out spacing between Roaster/Coffee/Roast date rows (all 8px top margin)
- Reduces "Update Profile" and "Get from scale" button heights from 56→44 to match the row height
- Shortens "Stop at weight:" label to "Stop at:" to prevent truncation in the fixed-width label column
- Resets `SuggestionField` cursor to position 0 on external text update so long values (e.g. burr names) show from the start instead of the end

Closes #606

## Test plan
- [ ] Open Brew Settings dialog — roast date field appears below Coffee with a calendar button
- [ ] Tap calendar button — date picker opens and selection populates the field
- [ ] Confirm OK — `Settings.dyeRoastDate` is updated and visible in shot plan text
- [ ] Roaster/Coffee/Roast date rows have even spacing
- [ ] Update Profile and Get from Scale buttons are same height as adjacent inputs
- [ ] "Stop at:" label is not truncated
- [ ] Long burr names show from the beginning of the text

🤖 Generated with [Claude Code](https://claude.com/claude-code)