### PR TITLE
fix: reject BLE weight spikes that cause false SAW stops

### DIFF
--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -23,11 +23,21 @@ void WeightProcessor::processWeight(double weight)
     // Spike filter (issue #610): reject single-packet BLE corruption.
     // A Felicita scale was observed sending 1649g instead of ~10g, causing a
     // false SAW stop. Any reading that jumps more than 100g from the previous
-    // sample is clearly corrupted — espresso never changes that fast.
+    // sample is rejected. Auto-resets after 3 consecutive rejections to handle
+    // legitimate shifts (cup removal, tare, scale reconnect at different offset).
     if (m_hasLastWeight && qAbs(weight - m_lastRawWeight) > 100.0) {
-        qWarning() << "[SAW-Worker] Spike rejected: weight=" << weight
-                   << "last=" << m_lastRawWeight;
-        return;
+        if (++m_consecutiveRejections < 3) {
+            m_lastWallClockMs = wallClock;  // Keep de-jitter timing accurate
+            qWarning() << "[SAW-Worker] Spike rejected: weight=" << weight
+                       << "last=" << m_lastRawWeight;
+            return;
+        }
+        qWarning() << "[SAW-Worker] Spike filter reset after"
+                   << m_consecutiveRejections << "consecutive rejections"
+                   << "— accepting new baseline:" << weight;
+        m_consecutiveRejections = 0;
+    } else {
+        m_consecutiveRejections = 0;
     }
     m_hasLastWeight = true;
     m_lastRawWeight = weight;
@@ -150,7 +160,6 @@ void WeightProcessor::processWeight(double weight)
                 m_oscillationDetected = false;
                 m_settleCount = 0;
                 m_weightSamples.clear();  // Fresh LSLR baseline from post-settle readings
-        
                 m_hasLastWeight = false;  // Accept first reading at any weight after recovery
                 qDebug() << "[SAW-Worker] Scale settled after oscillation, SAW re-armed";
             }
@@ -276,6 +285,7 @@ void WeightProcessor::setTareComplete(bool complete)
         // re-armed if called mid-shot (e.g. physical scale reconnects after a BLE drop).
         m_oscillationDetected = false;
         m_settleCount = 0;
+        m_hasLastWeight = false;  // Tare shifts weight baseline — accept first post-tare reading
     }
 }
 
@@ -289,6 +299,7 @@ void WeightProcessor::startExtraction()
 
     m_lastRawWeight = 0;
     m_hasLastWeight = false;
+    m_consecutiveRejections = 0;
     m_currentFrame = -1;
     m_tareComplete = false;
     m_oscillationDetected = false;
@@ -336,6 +347,7 @@ void WeightProcessor::resetForRetare()
 
     m_lastRawWeight = 0;
     m_hasLastWeight = false;
+    m_consecutiveRejections = 0;
     m_extractionStartTime = 0;  // Will be set when extraction actually starts
     m_stopTriggered = false;
     m_frameWeightSkipSent.clear();

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -74,8 +74,10 @@ private:
     QList<WeightSample> m_weightSamples;
 
     // Spike filter: rejects single-packet BLE corruption (issue #610).
+    // Auto-resets after 3 consecutive rejections to handle legitimate shifts.
     double m_lastRawWeight = 0;
     bool m_hasLastWeight = false;
+    int m_consecutiveRejections = 0;
 
     // State
     bool m_active = false;

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -327,6 +327,30 @@ private slots:
         QCOMPARE(stopSpy.count(), 0);
     }
 
+    void consecutiveRejectionsAutoReset() {
+        // After 3 consecutive rejections, the filter accepts the new baseline.
+        // This handles legitimate shifts (cup removal, scale reconnect).
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
+
+        // Establish baseline at ~10g
+        feedRising(wp, 8.0, 2.0, 5);
+        QVERIFY(flowSpy.count() >= 4);
+
+        // Inject 3 readings at 500g — first 2 rejected, 3rd accepted as new baseline
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected.*500"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected.*500"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike filter reset"));
+        int countBefore = flowSpy.count();
+        wp.processWeight(500.0); m_fakeClock += 200;
+        wp.processWeight(500.0); m_fakeClock += 200;
+        wp.processWeight(500.0); m_fakeClock += 200;
+
+        // 3rd reading should have been accepted — flowRatesReady emitted
+        QCOMPARE(flowSpy.count(), countBefore + 1);
+    }
+
     void spikeDoesNotCorruptFlowRate() {
         // A rejected spike should not affect LSLR flow computation
         WeightProcessor wp;


### PR DESCRIPTION
## Summary
- Fixes #610 — Felicita scale sends corrupted BLE packet (~1649g instead of ~10g), causing SAW to immediately stop the shot at 13.9g
- Adds a simple spike filter in `WeightProcessor::processWeight()`: reject any reading that jumps >100g from the previous sample
- Same issue confirmed on de1app via [visualizer data](https://visualizer.coffee/shots/8f7245a2-0b40-494f-a517-5b50adf0d3a6) — de1app's median filter is off by default (`high_vibration_scale_filtering`)

## Changes
- **`weightprocessor.h/cpp`**: Added `m_lastRawWeight`/`m_hasLastWeight` spike filter with resets on extraction start, retare, and oscillation recovery
- **`tst_weightprocessor.cpp`**: Added `singleSpikeRejectedByRateFilter` (reproduces #610) and `spikeDoesNotCorruptFlowRate` tests

## Test plan
- [x] Existing `tst_weightprocessor` and `tst_saw` tests pass cleanly (no warnings)
- [ ] Test with Felicita scale — normal shots should be unaffected
- [ ] Verify spike rejection warning appears in debug log if corruption recurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)