### PR TITLE
fix: prevent BLE writes before DE1 characteristics are discovered

### DIFF
--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -326,6 +326,7 @@ void BleTransport::onControllerDisconnected() {
     m_writePending = false;
     m_writeTimeoutTimer.stop();
     m_commandTimer.stop();
+    m_characteristicsReady = false;
 
     emit disconnected();
 }

--- a/src/ble/bletransport.h
+++ b/src/ble/bletransport.h
@@ -21,7 +21,8 @@
  *   2. Call connectToDevice(deviceInfo)
  *   3. BleTransport handles service discovery, subscribes to notifications,
  *      reads initial values, and requests Idle state
- *   4. Emits connected() when ready for I/O
+ *   4. Emits connected() when ready for I/O (isConnected() returns false until
+ *      characteristic discovery completes, even if the BLE link is up)
  *   5. Call disconnect() or delete to tear down
  */
 class BleTransport : public DE1Transport {


### PR DESCRIPTION
## Summary

- `BleTransport::isConnected()` previously returned `true` as soon as the service object was created, but `m_characteristics` wasn't populated until characteristic discovery finished (~1s later)
- Commands arriving in that window (e.g. MQTT `steam_on`) passed the `isConnected()` guard in `startSteamHeating()` and similar methods, then were silently dropped with `"writeCharacteristic skipped - unknown characteristic"`
- Adds a `m_characteristicsReady` flag set only after `setupService()` completes, and includes it in `isConnected()` so all existing guards work correctly

## Root cause (from live log)

```
[3.867] DE1 service object created → isConnected() = true (but m_characteristics empty)
[4.074] MQTT steam_on → startSteamHeating() passes isConnected() guard
[4.140] writeCharacteristic(0000a00b) skipped - unknown characteristic  ← BUG
[4.290] writeCharacteristic(0000a006) skipped - unknown characteristic
[4.898] Characteristics ready: 18 registered  ← should have waited for this
```

## Test plan

- [ ] Connect DE1 via BLE — verify no "unknown characteristic" warnings in log at startup
- [ ] Trigger MQTT `steam_on` command immediately after app launch (before DE1 fully connects) — verify it is cleanly rejected by the `isConnected()` guard rather than silently dropped
- [ ] Normal espresso/steam/hot water flows unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)