### PR TITLE
fix: auto-disable checksum for original Decent Scale (non-HDS)

### DIFF
--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -64,6 +64,9 @@ void DecentScale::onTransportDisconnected() {
     DECENT_WARN("Transport disconnected");
     stopWatchdog();
     stopHeartbeat();
+    if (m_checksumDisabled) {
+        DECENT_LOG("Checksum validation re-enabled on disconnect");
+    }
     m_consecutiveChecksumFailures = 0;
     m_checksumDisabled = false;
     setConnected(false);
@@ -173,7 +176,7 @@ void DecentScale::parseWeightData(const QByteArray& data) {
     // Validate XOR checksum on all packet types except LED response (0x0A),
     // which uses all 7 bytes for data and has no room for a checksum.
     // See: https://github.com/Kulitorum/Decenza/issues/560
-    // Original Decent Scale (v1) may not compute checksums correctly — auto-disable
+    // Original Decent Scale (v1) does not compute checksums correctly — auto-disable
     // after consecutive failures. See: https://github.com/Kulitorum/Decenza/issues/630
     if (command != 0x0A && !m_checksumDisabled) {
         uint8_t expected = DecentScaleProtocol::calculateXor(data);

--- a/src/ble/scales/decentscale.h
+++ b/src/ble/scales/decentscale.h
@@ -54,7 +54,7 @@ private:
     static constexpr int kWatchdogFirstTimeoutMs = 1000;   // Initial: 1s to verify data flowing
     static constexpr int kWatchdogTickleTimeoutMs = 2000;   // Subsequent: 2s after each update
     static constexpr int kWatchdogMaxRetries = 10;          // Re-enable notifications up to 10 times
-    static constexpr int kChecksumFailureThreshold = 5;     // Disable checksum after N consecutive failures
+    static constexpr int kChecksumFailureThreshold = 5;     // Disable checksum on the Nth consecutive failure (Nth packet is accepted)
 
     ScaleBleTransport* m_transport = nullptr;
     QString m_name = "Decent Scale";

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -249,8 +249,8 @@ private slots:
     }
 
     void decentChecksumAutoDisableAfterConsecutiveFailures() {
-        // Original Decent Scale (v1) sends invalid checksums — after 5 consecutive
-        // failures, checksum validation should be disabled and weight data accepted.
+        // Original Decent Scale (v1) sends invalid checksums — on the 5th consecutive
+        // failure, checksum validation is disabled and the triggering packet is accepted.
         // See: https://github.com/Kulitorum/Decenza/issues/630
         DecentScale scale(nullptr);
         QSignalSpy spy(&scale, &ScaleDevice::weightChanged);


### PR DESCRIPTION
## Summary
- Original Decent Scale (v1) sends weight packets with invalid XOR checksums, causing all data to be dropped and weight stuck at 0.0g (#630)
- After 5 consecutive checksum failures, automatically disable validation for the remainder of the connection
- Valid checksums reset the failure counter, so HDS scales with occasional corruption still benefit from validation
- State resets on disconnect so each connection starts fresh

## Test plan
- [ ] Verify existing `decentBadChecksumDropped` test still passes (single bad packet is still dropped)
- [ ] Verify new `decentChecksumAutoDisableAfterConsecutiveFailures` test passes (5th bad packet triggers auto-disable)
- [ ] Verify new `decentChecksumResetOnGoodPacket` test passes (valid packet resets counter)
- [ ] If available, test with original Decent Scale v1 hardware — weight should display after ~5 initial dropped packets

Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)