### PR TITLE
fix: unify recent-shots-by-KB-ID queries (#641)

### DIFF
--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -176,71 +176,6 @@ ShotMetadata AIManager::buildMetadata(const QString& beanBrand,
     return metadata;
 }
 
-// File-scope helper: runs on a background thread with its own SQLite connection.
-// Returns recent shots matching the given knowledge base ID, for AI dial-in history.
-static QVariantList loadRecentShotsByKbId(
-    const QString& dbPath, const QString& profileKbId, int limit, qint64 excludeShotId)
-{
-    QVariantList results;
-    withTempDb(dbPath, "ai_recent", [&](QSqlDatabase& db) {
-        QString sql = QStringLiteral(R"(
-            SELECT id, timestamp, profile_name, duration_seconds,
-                   final_weight, dose_weight, bean_brand, bean_type, roast_level,
-                   grinder_brand, grinder_model, grinder_burrs, grinder_setting,
-                   drink_tds, drink_ey, enjoyment, espresso_notes,
-                   temperature_override, profile_json
-            FROM shots
-            WHERE profile_kb_id = ?
-        )");
-        if (excludeShotId >= 0)
-            sql += QStringLiteral(" AND id != ?");
-        sql += QStringLiteral(" ORDER BY timestamp DESC LIMIT ?");
-
-        QSqlQuery query(db);
-        if (!query.prepare(sql)) {
-            qWarning() << "AIManager::loadRecentShotsByKbId: prepare failed:" << query.lastError().text();
-            return;
-        }
-        int idx = 0;
-        query.bindValue(idx++, profileKbId);
-        if (excludeShotId >= 0)
-            query.bindValue(idx++, excludeShotId);
-        query.bindValue(idx, limit);
-
-        if (!query.exec()) {
-            qWarning() << "AIManager::loadRecentShotsByKbId: failed:" << query.lastError().text();
-            return;
-        }
-        while (query.next()) {
-            QVariantMap shot;
-            shot["id"] = query.value(0).toLongLong();
-            shot["timestamp"] = query.value(1).toLongLong();
-            shot["profileName"] = query.value(2).toString();
-            shot["duration"] = query.value(3).toDouble();
-            shot["finalWeight"] = query.value(4).toDouble();
-            shot["doseWeight"] = query.value(5).toDouble();
-            shot["beanBrand"] = query.value(6).toString();
-            shot["beanType"] = query.value(7).toString();
-            shot["roastLevel"] = query.value(8).toString();
-            shot["grinderBrand"] = query.value(9).toString();
-            shot["grinderModel"] = query.value(10).toString();
-            shot["grinderBurrs"] = query.value(11).toString();
-            shot["grinderSetting"] = query.value(12).toString();
-            shot["drinkTds"] = query.value(13).toDouble();
-            shot["drinkEy"] = query.value(14).toDouble();
-            shot["enjoyment"] = query.value(15).toInt();
-            shot["espressoNotes"] = query.value(16).toString();
-            shot["temperatureOverride"] = query.value(17).toDouble();
-            shot["profileJson"] = query.value(18).toString();
-            QDateTime dt = QDateTime::fromSecsSinceEpoch(query.value(1).toLongLong());
-            // ISO 8601 with timezone for AI consumption (CLAUDE.md MCP convention)
-            shot["dateTime"] = dt.toOffsetFromUtc(dt.offsetFromUtc()).toString(Qt::ISODate);
-            results.append(shot);
-        }
-    });
-    return results;
-}
-
 void AIManager::analyzeShot(ShotDataModel* shotData,
                              Profile* profile,
                              double doseWeight,
@@ -319,7 +254,10 @@ void AIManager::analyzeShotWithMetadata(ShotDataModel* shotData,
         QPointer<AIManager> self(this);
 
         QThread* thread = QThread::create([self, dbPath, kbId, excludeId, systemPrompt, userPrompt]() {
-            QVariantList recentShots = loadRecentShotsByKbId(dbPath, kbId, 5, excludeId);
+            QVariantList recentShots;
+            withTempDb(dbPath, "ai_recent", [&](QSqlDatabase& db) {
+                recentShots = ShotHistoryStorage::loadRecentShotsByKbIdStatic(db, kbId, 5, excludeId);
+            });
 
             QMetaObject::invokeMethod(qApp, [self, systemPrompt, userPrompt, recentShots = std::move(recentShots)]() {
                 if (!self) return;

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1503,41 +1503,11 @@ void ShotHistoryStorage::requestRecentShotsByKbId(const QString& kbId, int limit
     }
 
     const QString dbPath = m_dbPath;
-
     auto destroyed = m_destroyed;
     QThread* thread = QThread::create([this, dbPath, kbId, limit, destroyed]() {
         QVariantList results;
         withTempDb(dbPath, "shs_kbid", [&](QSqlDatabase& db) {
-            QSqlQuery query(db);
-            query.prepare(QStringLiteral(
-                "SELECT id, timestamp, profile_name, dose_weight, final_weight, "
-                "duration_seconds, enjoyment, grinder_setting, grinder_model, "
-                "espresso_notes, bean_brand, bean_type, profile_kb_id "
-                "FROM shots WHERE profile_kb_id = :kbId "
-                "ORDER BY timestamp DESC LIMIT :limit"));
-            query.bindValue(":kbId", kbId);
-            query.bindValue(":limit", limit);
-
-            if (query.exec()) {
-                while (query.next()) {
-                    QVariantMap shot;
-                    shot["id"] = query.value("id").toLongLong();
-                    shot["timestamp"] = query.value("timestamp").toLongLong();
-                    shot["profileName"] = query.value("profile_name").toString();
-                    shot["dose"] = query.value("dose_weight").toDouble();
-                    shot["yield"] = query.value("final_weight").toDouble();
-                    shot["duration"] = query.value("duration_seconds").toDouble();
-                    shot["enjoyment"] = query.value("enjoyment").toInt();
-                    shot["grinderSetting"] = query.value("grinder_setting").toString();
-                    shot["grinderModel"] = query.value("grinder_model").toString();
-                    shot["notes"] = query.value("espresso_notes").toString();
-                    shot["beanBrand"] = query.value("bean_brand").toString();
-                    shot["beanType"] = query.value("bean_type").toString();
-                    results.append(shot);
-                }
-            } else {
-                qWarning() << "ShotHistoryStorage: recentShotsByKbId query failed:" << query.lastError().text();
-            }
+            results = loadRecentShotsByKbIdStatic(db, kbId, limit);
         });
 
         if (*destroyed) return;
@@ -1552,6 +1522,72 @@ void ShotHistoryStorage::requestRecentShotsByKbId(const QString& kbId, int limit
 
     connect(thread, &QThread::finished, thread, &QObject::deleteLater);
     thread->start();
+}
+
+QVariantList ShotHistoryStorage::loadRecentShotsByKbIdStatic(QSqlDatabase& db, const QString& kbId, int limit, qint64 excludeShotId)
+{
+    QVariantList results;
+    QString sql = QStringLiteral(R"(
+        SELECT id, timestamp, profile_name, duration_seconds, final_weight, dose_weight,
+               bean_brand, bean_type, roast_level, grinder_brand, grinder_model,
+               grinder_burrs, grinder_setting, drink_tds, drink_ey, enjoyment,
+               espresso_notes, roast_date, temperature_override, yield_override, profile_json, beverage_type
+        FROM shots
+        WHERE profile_kb_id = ?
+    )");
+    if (excludeShotId >= 0)
+        sql += QStringLiteral(" AND id != ?");
+    sql += QStringLiteral(" ORDER BY timestamp DESC LIMIT ?");
+
+    QSqlQuery query(db);
+    if (!query.prepare(sql)) {
+        qWarning() << "ShotHistoryStorage::loadRecentShotsByKbIdStatic: prepare failed:" << query.lastError().text();
+        return results;
+    }
+
+    int idx = 0;
+    query.bindValue(idx++, kbId);
+    if (excludeShotId >= 0)
+        query.bindValue(idx++, excludeShotId);
+    query.bindValue(idx, limit);
+
+    if (query.exec()) {
+        while (query.next()) {
+            QVariantMap shot;
+            shot["id"] = query.value("id").toLongLong();
+            qint64 ts = query.value("timestamp").toLongLong();
+            shot["timestamp"] = ts;
+            shot["profileName"] = query.value("profile_name").toString();
+            shot["doseWeight"] = query.value("dose_weight").toDouble();
+            shot["finalWeight"] = query.value("final_weight").toDouble();
+            shot["duration"] = query.value("duration_seconds").toDouble();
+            shot["enjoyment"] = query.value("enjoyment").toInt();
+            shot["grinderSetting"] = query.value("grinder_setting").toString();
+            shot["grinderModel"] = query.value("grinder_model").toString();
+            shot["grinderBrand"] = query.value("grinder_brand").toString();
+            shot["grinderBurrs"] = query.value("grinder_burrs").toString();
+            shot["espressoNotes"] = query.value("espresso_notes").toString();
+            shot["beanBrand"] = query.value("bean_brand").toString();
+            shot["beanType"] = query.value("bean_type").toString();
+            shot["roastLevel"] = query.value("roast_level").toString();
+            shot["roastDate"] = query.value("roast_date").toString();
+            shot["drinkTds"] = query.value("drink_tds").toDouble();
+            shot["drinkEy"] = query.value("drink_ey").toDouble();
+            shot["temperatureOverride"] = query.value("temperature_override").toDouble();
+            shot["yieldOverride"] = query.value("yield_override").toDouble();
+            shot["profileJson"] = query.value("profile_json").toString();
+            shot["beverageType"] = query.value("beverage_type").toString();
+
+            // ISO 8601 with timezone for API/AI consumption (CLAUDE.md convention)
+            QDateTime dt = QDateTime::fromSecsSinceEpoch(ts);
+            shot["dateTime"] = dt.toOffsetFromUtc(dt.offsetFromUtc()).toString(Qt::ISODate);
+
+            results.append(shot);
+        }
+    } else {
+        qWarning() << "ShotHistoryStorage::loadRecentShotsByKbIdStatic: query failed:" << query.lastError().text();
+    }
+    return results;
 }
 
 QVariantMap ShotHistoryStorage::convertShotRecord(const ShotRecord& record)

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -219,6 +219,10 @@ public:
     // Returns summary data (not full time-series) for dial-in history queries.
     Q_INVOKABLE void requestRecentShotsByKbId(const QString& kbId, int limit = 10);
 
+    // Query recent shots by KB ID (summary data, no time-series).
+    // Thread-safe: caller provides their own connection. Shared by MCP and in-app AI.
+    static QVariantList loadRecentShotsByKbIdStatic(QSqlDatabase& db, const QString& kbId, int limit, qint64 excludeShotId = -1);
+
     // Static version for background-thread use — caller provides their own connection.
     static ShotRecord loadShotRecordStatic(QSqlDatabase& db, qint64 shotId);
 

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -96,48 +96,43 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
 
                     // --- Dial-in history (same profile family) ---
                     if (!dbResult.profileKbId.isEmpty()) {
-                        QSqlQuery hQuery(db);
-                        hQuery.prepare("SELECT id, timestamp, profile_name, dose_weight, final_weight, "
-                                       "duration_seconds, enjoyment, grinder_setting, grinder_model, "
-                                       "espresso_notes, bean_brand, bean_type, yield_override, profile_json "
-                                       "FROM shots WHERE profile_kb_id = ? "
-                                       "AND id != ? "
-                                       "ORDER BY timestamp DESC LIMIT ?");
-                        hQuery.bindValue(0, dbResult.profileKbId);
-                        hQuery.bindValue(1, resolvedShotId);
-                        hQuery.bindValue(2, historyLimit);
-                        if (hQuery.exec()) {
-                            while (hQuery.next()) {
-                                QJsonObject h;
-                                h["id"] = hQuery.value("id").toLongLong();
-                                auto dt = QDateTime::fromSecsSinceEpoch(hQuery.value("timestamp").toLongLong());
-                                h["timestamp"] = dt.toOffsetFromUtc(dt.offsetFromUtc()).toString(Qt::ISODate);
-                                h["profileName"] = hQuery.value("profile_name").toString();
-                                h["doseG"] = hQuery.value("dose_weight").toDouble();
-                                h["yieldG"] = hQuery.value("final_weight").toDouble();
-                                h["durationSec"] = hQuery.value("duration_seconds").toDouble();
-                                h["enjoyment0to100"] = hQuery.value("enjoyment").toInt();
-                                h["grinderSetting"] = hQuery.value("grinder_setting").toString();
-                                h["grinderModel"] = hQuery.value("grinder_model").toString();
-                                h["notes"] = hQuery.value("espresso_notes").toString();
-                                h["beanBrand"] = hQuery.value("bean_brand").toString();
-                                h["beanType"] = hQuery.value("bean_type").toString();
-                                // Use yield_override (brew-by-ratio target) if set, else profile's target_weight
-                                double yieldOverride = hQuery.value("yield_override").toDouble();
-                                if (yieldOverride > 0) {
-                                    h["targetWeightG"] = yieldOverride;
-                                } else {
-                                    QString profileJson = hQuery.value("profile_json").toString();
-                                    if (!profileJson.isEmpty()) {
-                                        QJsonObject profileObj = QJsonDocument::fromJson(profileJson.toUtf8()).object();
-                                        QJsonValue tw = profileObj["target_weight"];
-                                        double twVal = tw.isString() ? tw.toString().toDouble() : tw.toDouble();
-                                        if (twVal > 0)
-                                            h["targetWeightG"] = twVal;
-                                    }
+                        QVariantList history = ShotHistoryStorage::loadRecentShotsByKbIdStatic(db, dbResult.profileKbId, historyLimit, resolvedShotId);
+                        for (const auto& v : history) {
+                            QVariantMap shot = v.toMap();
+                            QJsonObject h;
+                            h["id"] = shot["id"].toLongLong();
+                            h["timestamp"] = shot["dateTime"].toString();
+                            h["profileName"] = shot["profileName"].toString();
+                            h["doseG"] = shot["doseWeight"].toDouble();
+                            h["yieldG"] = shot["finalWeight"].toDouble();
+                            h["durationSec"] = shot["duration"].toDouble();
+                            h["enjoyment0to100"] = shot["enjoyment"].toInt();
+                            h["grinderSetting"] = shot["grinderSetting"].toString();
+                            h["grinderModel"] = shot["grinderModel"].toString();
+                            h["grinderBrand"] = shot["grinderBrand"].toString();
+                            h["grinderBurrs"] = shot["grinderBurrs"].toString();
+                            h["notes"] = shot["espressoNotes"].toString();
+                            h["beanBrand"] = shot["beanBrand"].toString();
+                            h["beanType"] = shot["beanType"].toString();
+                            double tempOverride = shot["temperatureOverride"].toDouble();
+                            if (tempOverride > 0)
+                                h["temperatureOverrideC"] = tempOverride;
+
+                            // Use yieldOverride (brew-by-ratio target) if set, else profile's target_weight
+                            double yieldOverride = shot["yieldOverride"].toDouble();
+                            if (yieldOverride > 0) {
+                                h["targetWeightG"] = yieldOverride;
+                            } else {
+                                QString profileJson = shot["profileJson"].toString();
+                                if (!profileJson.isEmpty()) {
+                                    QJsonObject profileObj = QJsonDocument::fromJson(profileJson.toUtf8()).object();
+                                    QJsonValue tw = profileObj["target_weight"];
+                                    double twVal = tw.isString() ? tw.toString().toDouble() : tw.toDouble();
+                                    if (twVal > 0)
+                                        h["targetWeightG"] = twVal;
                                 }
-                                dbResult.dialInHistory.append(h);
                             }
+                            dbResult.dialInHistory.append(h);
                         }
                     }
 


### PR DESCRIPTION
## Summary
- Consolidated three duplicate "recent shots by KB ID" queries (ShotHistoryStorage, AIManager, MCP inline SQL) into a single `ShotHistoryStorage::loadRecentShotsByKbIdStatic()` method
- Eliminates silent zero-value bugs from field name mismatches (`dose`/`yield` vs `doseWeight`/`finalWeight` vs `doseG`/`yieldG`)
- Added `roast_date` to the shared SELECT for completeness
- Added `grinderBrand`, `grinderBurrs`, and `temperatureOverrideC` to MCP dial-in history output to match in-app AI parity

Closes #641

## Test plan
- [ ] Pull a shot and open AI advisor — verify dial-in history context includes all fields
- [ ] Use MCP `dialing_get_context` tool — verify history objects include `grinderBrand`, `grinderBurrs`, `temperatureOverrideC`
- [ ] Verify no field name mismatches by checking AI summary mentions grinder and temperature data from history

🤖 Generated with [Claude Code](https://claude.com/claude-code)