### PR TITLE
fix: use cumulative weight for AI weightCurve (#640)

### DIFF
--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -169,7 +169,6 @@ ShotSummary ShotSummarizer::summarize(const ShotDataModel* shotData,
     const auto& pressureData = shotData->pressureData();
     const auto& flowData = shotData->flowData();
     const auto& tempData = shotData->temperatureData();
-    const auto& weightFlowData = shotData->weightFlowRateData();  // Flow rate from scale (g/s)
     const auto& cumulativeWeightData = shotData->cumulativeWeightData();  // Cumulative weight (g)
 
     if (pressureData.isEmpty()) {
@@ -180,7 +179,7 @@ ShotSummary ShotSummarizer::summarize(const ShotDataModel* shotData,
     summary.pressureCurve = pressureData;
     summary.flowCurve = flowData;
     summary.tempCurve = tempData;
-    summary.weightCurve = weightFlowData;  // Flow rate useful for AI analysis (detecting channeling spikes)
+    summary.weightCurve = cumulativeWeightData;  // Cumulative weight (g) — matches history path
 
     // Store target/goal curves (what the profile intended)
     summary.pressureGoalCurve = shotData->pressureGoalData();


### PR DESCRIPTION
## Summary
- Live path stored weight flow rate (g/s) in `weightCurve` while history path stored cumulative weight (g)
- Both paths feed into `buildUserPrompt()` which labels values as `Xg` and computes per-phase `weightGained` via `endWeight - startWeight` — both only make sense with cumulative weight
- One-line fix: use `cumulativeWeightData()` instead of `weightFlowRateData()` in `summarize()`

Closes #640

## Test plan
- [ ] Pull a shot and open AI advisor — verify weight values in phase snapshots show cumulative grams (e.g. 23.7g), not flow rate (e.g. 1.4g)
- [ ] Load a historical shot's AI review — verify weight values are consistent with live shots

🤖 Generated with [Claude Code](https://claude.com/claude-code)