### PR TITLE
fix: validate favorites/currentProfile at startup, remove stale profile references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,6 +621,7 @@ set(QML_FILES
 	qml/components/BrewDialog.qml
     qml/components/CircularGauge.qml
     qml/components/ConnectionIndicator.qml
+    qml/components/FavoritesListView.qml
     qml/components/PresetPillRow.qml
     qml/components/TouchSlider.qml
     qml/components/StepSlider.qml

--- a/qml/components/FavoritesListView.qml
+++ b/qml/components/FavoritesListView.qml
@@ -16,9 +16,14 @@ import Decenza
 //  - On release, emits rowMoved(startIndex, endIndex) once; consumer persists to its
 //    own store (Settings) and the resulting NOTIFY rebuilds the DelegateModel to match.
 //
-// Consumer API (identical to previous version):
-//   model, selectedIndex, displayTextFn, accessibleNameFn, deleteAccessibleNameFn,
-//   removeConfirmFn, trailingActionDelegate, showDeleteButton
+// Consumer API:
+//   model: QVariantList of row objects
+//   selectedIndex: external index of the selected row (or -1)
+//   displayTextFn(row, index), accessibleNameFn(row, index), deleteAccessibleNameFn(row, index)
+//   removeConfirmFn(row, index): return false to cancel delete
+//   trailingActionDelegate: Component whose loaded root sees `parent.row`, `parent.rowIndex`, `parent.selected`
+//   showDeleteButton: toggles the X button column
+//   rowAccessibleDescription: TalkBack/VoiceOver hint describing the long-press/double-tap action
 //
 // Signals: rowSelected(int), rowLongPressed(int), rowMoved(int from, int to), rowDeleted(int)
 Item {
@@ -36,6 +41,12 @@ Item {
                (row && row.name ? row.name : "")
     }
     property var removeConfirmFn: function(row, index) { return true }
+
+    // TalkBack/VoiceOver hint for the row's secondary (long-press/double-tap) action.
+    // Consumers should override with context-specific text (e.g. "rename preset", "edit profile").
+    property string rowAccessibleDescription: TranslationManager.translate(
+        "favorites.accessible.secondary_hint",
+        "Double-tap or long-press for more options.")
 
     signal rowSelected(int index)
     signal rowLongPressed(int index)
@@ -98,7 +109,7 @@ Item {
                 layer.smooth: true
                 layer.effect: MultiEffect {
                     shadowEnabled: true
-                    shadowColor: "#80000000"
+                    shadowColor: Theme.shadowColor
                     shadowBlur: 0.8
                     shadowVerticalOffset: 4
                 }
@@ -146,16 +157,25 @@ Item {
                                 autoScrollTimer.stop()
                                 autoScrollTimer.vy = 0
                                 var endIndex = rowDelegate.liveIndex
-                                root._dragging = false
                                 if (_startIndex >= 0 && endIndex !== _startIndex) {
+                                    // Emit before clearing _dragging so the selection-highlight
+                                    // binding doesn't re-evaluate against a stale selectedIndex
+                                    // for one frame before the consumer's Settings update lands.
                                     root.rowMoved(_startIndex, endIndex)
                                 }
+                                root._dragging = false
                                 _startIndex = -1
                             }
 
                             onCanceled: {
                                 autoScrollTimer.stop()
                                 autoScrollTimer.vy = 0
+                                // Roll back any live swaps performed during this drag so the
+                                // DelegateModel order stays in sync with the backing Settings list.
+                                var currentIndex = rowDelegate.liveIndex
+                                if (_startIndex >= 0 && currentIndex !== _startIndex) {
+                                    visualModel.items.move(currentIndex, _startIndex, 1)
+                                }
                                 root._dragging = false
                                 _startIndex = -1
                             }
@@ -184,7 +204,7 @@ Item {
                     Text {
                         Layout.fillWidth: true
                         text: root.displayTextFn(rowDelegate.rowData, rowDelegate.liveIndex)
-                        color: rowDelegate.selected ? "white" : Theme.textColor
+                        color: rowDelegate.selected ? Theme.primaryContrastColor : Theme.textColor
                         font: Theme.bodyFont
                         elide: Text.ElideRight
                         Accessible.ignored: true
@@ -226,6 +246,7 @@ Item {
                     z: -1
                     accessibleName: rowDelegate.rowData
                         ? root.accessibleNameFn(rowDelegate.rowData, rowDelegate.liveIndex) : ""
+                    accessibleDescription: root.rowAccessibleDescription
                     accessibleItem: rowPill
                     supportLongPress: true
                     supportDoubleClick: true

--- a/qml/components/FavoritesListView.qml
+++ b/qml/components/FavoritesListView.qml
@@ -34,6 +34,8 @@ Item {
     property Component trailingActionDelegate: null
     property bool showDeleteButton: true
 
+    // Note: `row` here is always a QVariantMap JS object (not a QML QObject), so `row.name`
+    // safely reads the map key — it does NOT resolve to QObject::objectName.
     property var displayTextFn: function(row, index) { return row && row.name ? row.name : "" }
     property var accessibleNameFn: function(row, index) { return row && row.name ? row.name : "" }
     property var deleteAccessibleNameFn: function(row, index) {
@@ -46,7 +48,7 @@ Item {
     // Consumers should override with context-specific text (e.g. "rename preset", "edit profile").
     property string rowAccessibleDescription: TranslationManager.translate(
         "favorites.accessible.secondary_hint",
-        "Double-tap or long-press for more options.")
+        "Double-tap or long-press to rename or reorder.")
 
     signal rowSelected(int index)
     signal rowLongPressed(int index)
@@ -119,10 +121,13 @@ Item {
                     anchors.margins: Theme.scaled(10)
                     spacing: Theme.scaled(8)
 
-                    // Drag handle (expanded touch target)
+                    // Drag handle (expanded touch target).
+                    // Drag-to-reorder is a pointer gesture with no TalkBack equivalent;
+                    // consumers expose rename/reorder via the row's long-press action instead.
                     Item {
                         Layout.preferredWidth: Theme.scaled(24)
                         Layout.preferredHeight: Theme.scaled(24)
+                        Accessible.ignored: true
 
                         Image {
                             anchors.centerIn: parent

--- a/qml/components/FavoritesListView.qml
+++ b/qml/components/FavoritesListView.qml
@@ -1,0 +1,286 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Effects
+import QtQml.Models
+import Decenza
+
+// Reusable vertical reorderable list with live drag-and-drop.
+// Used by Profile favorites and Bean presets — edits here improve both.
+//
+// Drag UX:
+//  - Grab the drag handle at the left of any row.
+//  - Hovering over another row performs a live swap; other rows slide out of the way
+//    via ListView.moveDisplaced animation.
+//  - Edge autoscroll triggers near the top/bottom of the list.
+//  - On release, emits rowMoved(startIndex, endIndex) once; consumer persists to its
+//    own store (Settings) and the resulting NOTIFY rebuilds the DelegateModel to match.
+//
+// Consumer API (identical to previous version):
+//   model, selectedIndex, displayTextFn, accessibleNameFn, deleteAccessibleNameFn,
+//   removeConfirmFn, trailingActionDelegate, showDeleteButton
+//
+// Signals: rowSelected(int), rowLongPressed(int), rowMoved(int from, int to), rowDeleted(int)
+Item {
+    id: root
+
+    property var model: []
+    property int selectedIndex: -1
+    property Component trailingActionDelegate: null
+    property bool showDeleteButton: true
+
+    property var displayTextFn: function(row, index) { return row && row.name ? row.name : "" }
+    property var accessibleNameFn: function(row, index) { return row && row.name ? row.name : "" }
+    property var deleteAccessibleNameFn: function(row, index) {
+        return TranslationManager.translate("favorites.accessible.remove", "Remove") + " " +
+               (row && row.name ? row.name : "")
+    }
+    property var removeConfirmFn: function(row, index) { return true }
+
+    signal rowSelected(int index)
+    signal rowLongPressed(int index)
+    signal rowMoved(int from, int to)
+    signal rowDeleted(int index)
+
+    readonly property int rowHeight: Theme.scaled(60)
+    readonly property int rowSpacing: Theme.scaled(8)
+
+    implicitHeight: {
+        var n = root.model ? root.model.length : 0
+        if (n <= 0) return 0
+        return n * rowHeight + (n - 1) * rowSpacing
+    }
+
+    property bool _dragging: false
+
+    DelegateModel {
+        id: visualModel
+        model: root.model
+
+        delegate: Item {
+            id: rowDelegate
+            width: listView.width
+            height: root.rowHeight
+
+            // itemsIndex reflects live position after reorder via visualModel.items.move()
+            readonly property int liveIndex: DelegateModel.itemsIndex
+            readonly property var rowData: modelData
+            // Highlight suppressed during drag (selected index refers to the external
+            // model; live swaps would make the highlight jump mid-drag).
+            readonly property bool selected: !root._dragging && (liveIndex === root.selectedIndex)
+
+            Rectangle {
+                id: rowPill
+                width: rowDelegate.width
+                height: rowDelegate.height
+                radius: Theme.scaled(8)
+                color: rowDelegate.selected ? Theme.primaryColor : Theme.backgroundColor
+                border.color: dragArea.drag.active ? Theme.primaryColor : Theme.textSecondaryColor
+                border.width: dragArea.drag.active ? 2 : 1
+                scale: dragArea.drag.active ? 1.03 : 1.0
+                z: dragArea.drag.active ? 10 : 1
+                opacity: dragArea.drag.active ? 0.95 : 1.0
+
+                Behavior on scale { NumberAnimation { duration: 120; easing.type: Easing.OutQuad } }
+
+                Drag.active: dragArea.drag.active
+                Drag.source: rowDelegate
+                Drag.hotSpot.x: width / 2
+                Drag.hotSpot.y: height / 2
+
+                states: State {
+                    when: dragArea.drag.active
+                    ParentChange { target: rowPill; parent: listView }
+                    AnchorChanges { target: rowPill; anchors.horizontalCenter: undefined; anchors.verticalCenter: undefined }
+                }
+
+                layer.enabled: dragArea.drag.active
+                layer.smooth: true
+                layer.effect: MultiEffect {
+                    shadowEnabled: true
+                    shadowColor: "#80000000"
+                    shadowBlur: 0.8
+                    shadowVerticalOffset: 4
+                }
+
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.margins: Theme.scaled(10)
+                    spacing: Theme.scaled(8)
+
+                    // Drag handle (expanded touch target)
+                    Item {
+                        Layout.preferredWidth: Theme.scaled(24)
+                        Layout.preferredHeight: Theme.scaled(24)
+
+                        Image {
+                            anchors.centerIn: parent
+                            source: "qrc:/icons/list.svg"
+                            sourceSize.width: Theme.scaled(18)
+                            sourceSize.height: Theme.scaled(18)
+                            opacity: rowDelegate.selected ? 1.0 : 0.5
+                            layer.enabled: !rowDelegate.selected
+                            layer.smooth: true
+                            layer.effect: MultiEffect {
+                                colorization: 1.0
+                                colorizationColor: Theme.textSecondaryColor
+                            }
+                        }
+
+                        MouseArea {
+                            id: dragArea
+                            anchors.fill: parent
+                            anchors.margins: -Theme.scaled(6)
+                            preventStealing: true
+                            drag.target: rowPill
+                            drag.axis: Drag.YAxis
+
+                            property int _startIndex: -1
+
+                            onPressed: {
+                                _startIndex = rowDelegate.liveIndex
+                                root._dragging = true
+                            }
+
+                            onReleased: {
+                                autoScrollTimer.stop()
+                                autoScrollTimer.vy = 0
+                                var endIndex = rowDelegate.liveIndex
+                                root._dragging = false
+                                if (_startIndex >= 0 && endIndex !== _startIndex) {
+                                    root.rowMoved(_startIndex, endIndex)
+                                }
+                                _startIndex = -1
+                            }
+
+                            onCanceled: {
+                                autoScrollTimer.stop()
+                                autoScrollTimer.vy = 0
+                                root._dragging = false
+                                _startIndex = -1
+                            }
+
+                            onPositionChanged: {
+                                if (!drag.active) return
+                                // Edge autoscroll
+                                var centerInList = rowPill.y + rowPill.height / 2 - listView.contentY
+                                var band = Theme.scaled(50)
+                                var maxVy = Theme.scaled(12)
+                                if (centerInList < band) {
+                                    autoScrollTimer.vy = -Math.min(maxVy, (band - centerInList) / 3)
+                                    if (!autoScrollTimer.running) autoScrollTimer.start()
+                                } else if (centerInList > listView.height - band) {
+                                    autoScrollTimer.vy = Math.min(maxVy, (centerInList - (listView.height - band)) / 3)
+                                    if (!autoScrollTimer.running) autoScrollTimer.start()
+                                } else {
+                                    autoScrollTimer.stop()
+                                    autoScrollTimer.vy = 0
+                                }
+                            }
+                        }
+                    }
+
+                    // Row label
+                    Text {
+                        Layout.fillWidth: true
+                        text: root.displayTextFn(rowDelegate.rowData, rowDelegate.liveIndex)
+                        color: rowDelegate.selected ? "white" : Theme.textColor
+                        font: Theme.bodyFont
+                        elide: Text.ElideRight
+                        Accessible.ignored: true
+                    }
+
+                    // Trailing action slot
+                    Loader {
+                        active: root.trailingActionDelegate !== null
+                        visible: active
+                        sourceComponent: root.trailingActionDelegate
+                        Layout.preferredWidth: Theme.scaled(36)
+                        Layout.preferredHeight: Theme.scaled(36)
+                        property var row: rowDelegate.rowData
+                        property int rowIndex: rowDelegate.liveIndex
+                        property bool selected: rowDelegate.selected
+                    }
+
+                    // Delete button
+                    StyledIconButton {
+                        Layout.preferredWidth: Theme.scaled(36)
+                        Layout.preferredHeight: Theme.scaled(36)
+                        visible: root.showDeleteButton
+                        icon.source: "qrc:/icons/cross.svg"
+                        inactiveColor: Theme.errorColor
+                        accessibleName: rowDelegate.rowData
+                            ? root.deleteAccessibleNameFn(rowDelegate.rowData, rowDelegate.liveIndex) : ""
+
+                        onClicked: {
+                            if (!rowDelegate.rowData) return
+                            if (root.removeConfirmFn(rowDelegate.rowData, rowDelegate.liveIndex)) {
+                                root.rowDeleted(rowDelegate.liveIndex)
+                            }
+                        }
+                    }
+                }
+
+                AccessibleTapHandler {
+                    anchors.fill: parent
+                    z: -1
+                    accessibleName: rowDelegate.rowData
+                        ? root.accessibleNameFn(rowDelegate.rowData, rowDelegate.liveIndex) : ""
+                    accessibleItem: rowPill
+                    supportLongPress: true
+                    supportDoubleClick: true
+                    onAccessibleClicked: {
+                        if (!rowDelegate.rowData) return
+                        root.rowSelected(rowDelegate.liveIndex)
+                    }
+                    onAccessibleDoubleClicked: {
+                        if (!rowDelegate.rowData) return
+                        root.rowLongPressed(rowDelegate.liveIndex)
+                    }
+                    onAccessibleLongPressed: {
+                        if (!rowDelegate.rowData) return
+                        root.rowLongPressed(rowDelegate.liveIndex)
+                    }
+                }
+            }
+
+            // Live swap: as the dragged pill enters this row, shuffle the DelegateModel
+            // so other rows animate out of the way in real time.
+            DropArea {
+                anchors.fill: parent
+                onEntered: function(drag) {
+                    var src = drag.source
+                    if (!src) return
+                    var from = src.liveIndex
+                    var to = rowDelegate.liveIndex
+                    if (from !== to) visualModel.items.move(from, to, 1)
+                }
+            }
+        }
+    }
+
+    ListView {
+        id: listView
+        anchors.fill: parent
+        clip: true
+        model: visualModel
+        spacing: root.rowSpacing
+        boundsBehavior: Flickable.StopAtBounds
+        interactive: !root._dragging
+
+        moveDisplaced: Transition {
+            NumberAnimation { properties: "x,y"; duration: 180; easing.type: Easing.OutQuad }
+        }
+
+        Timer {
+            id: autoScrollTimer
+            interval: 16
+            repeat: true
+            property real vy: 0
+            onTriggered: {
+                var maxY = Math.max(0, listView.contentHeight - listView.height)
+                listView.contentY = Math.max(0, Math.min(maxY, listView.contentY + vy))
+            }
+        }
+    }
+}

--- a/qml/components/layout/items/BeansItem.qml
+++ b/qml/components/layout/items/BeansItem.qml
@@ -160,13 +160,24 @@ Item {
         }
 
         contentItem: PresetPillRow {
+            id: beansPillRow
             maxWidth: Theme.scaled(600)
-            presets: Settings.beanPresets
-            selectedIndex: Settings.selectedBeanPreset
+            presets: Settings.idleBeanPresets
+            // selectedIndex refers to position within the filtered list
+            selectedIndex: {
+                var list = Settings.idleBeanPresets
+                for (var i = 0; i < list.length; ++i) {
+                    if (list[i].originalIndex === Settings.selectedBeanPreset) return i
+                }
+                return -1
+            }
 
             onPresetSelected: function(index) {
-                Settings.selectedBeanPreset = index
-                Settings.applyBeanPreset(index)
+                var row = beansPillRow.presets[index]
+                if (!row) return
+                var originalIndex = row.originalIndex !== undefined ? row.originalIndex : index
+                Settings.selectedBeanPreset = originalIndex
+                Settings.applyBeanPreset(originalIndex)
                 presetPopup.close()
             }
         }

--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -492,6 +492,10 @@ Page {
                         wrapMode: Text.Wrap
                     }
 
+                    // This list is bound to the FULL `beanPresets` (unfiltered), so the
+                    // `index` passed to row callbacks is already an external index —
+                    // no `originalIndex` translation needed here. BeansItem / IdlePage
+                    // bind to the filtered `idleBeanPresets` view and map via originalIndex.
                     FavoritesListView {
                         id: beanPresetsList
                         Layout.fillWidth: true
@@ -499,6 +503,9 @@ Page {
                         visible: Settings.beanPresets.length > 0
                         model: Settings.beanPresets
                         selectedIndex: Settings.selectedBeanPreset
+                        rowAccessibleDescription: TranslationManager.translate(
+                            "beaninfo.accessible.row_hint",
+                            "Double-tap or long-press to rename preset.")
 
                         displayTextFn: function(row, index) {
                             return row && row.name ? row.name : ""
@@ -519,8 +526,10 @@ Page {
                             StyledIconButton {
                                 anchors.fill: parent
                                 active: parent.row ? (parent.row.showOnIdle !== false) : false
-                                activeColor: parent.selected ? "white" : Theme.primaryColor
-                                inactiveColor: parent.selected ? Qt.rgba(1, 1, 1, 0.5) : Theme.textSecondaryColor
+                                activeColor: parent.selected ? Theme.primaryContrastColor : Theme.primaryColor
+                                inactiveColor: parent.selected
+                                    ? Qt.rgba(Theme.primaryContrastColor.r, Theme.primaryContrastColor.g, Theme.primaryContrastColor.b, 0.5)
+                                    : Theme.textSecondaryColor
                                 icon.source: active ? "qrc:/icons/star.svg" : "qrc:/icons/star-outline.svg"
                                 icon.width: Theme.scaled(18)
                                 icon.height: Theme.scaled(18)
@@ -556,14 +565,26 @@ Page {
                         onRowMoved: function(from, to) {
                             // Shift the "unsaved-changes" snapshot so a pure reorder
                             // of the selected item doesn't trip the back-button dialog.
-                            // Mirrors the shift logic in Settings::moveBeanPreset.
+                            // Mirrors the shift logic in Settings::moveBeanPreset
+                            // (src/core/settings.cpp, Settings::moveBeanPreset).
                             var s = _snapSelectedPreset
                             if (s === from) _snapSelectedPreset = to
                             else if (from < s && to >= s) _snapSelectedPreset = s - 1
                             else if (from > s && to <= s) _snapSelectedPreset = s + 1
                             Settings.moveBeanPreset(from, to)
                         }
-                        onRowDeleted: function(index) { Settings.removeBeanPreset(index) }
+                        onRowDeleted: function(index) {
+                            // Mirror Settings::removeBeanPreset's selection adjustment
+                            // (src/core/settings.cpp, Settings::removeBeanPreset) on the
+                            // snapshot so deleting an unrelated preset doesn't trip the
+                            // back-button unsaved-changes dialog.
+                            var s = _snapSelectedPreset
+                            var newLen = Settings.beanPresets.length - 1
+                            if (newLen <= 0) _snapSelectedPreset = -1
+                            else if (s >= newLen) _snapSelectedPreset = newLen - 1
+                            else if (s > index) _snapSelectedPreset = s - 1
+                            Settings.removeBeanPreset(index)
+                        }
                     }
                 }
             }
@@ -582,7 +603,6 @@ Page {
                 Tr {
                     Layout.columnSpan: 2
                     Layout.fillWidth: true
-                    Layout.topMargin: Theme.scaled(0)
                     key: "beaninfo.section.bean"
                     fallback: "Bean"
                     color: Theme.textSecondaryColor

--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -117,6 +117,22 @@ Page {
         }
     }
 
+    // Re-capture the unsaved-changes baseline from current Settings. Called after
+    // "choose" actions (selecting a preset, saving a preset) that alter Settings but
+    // aren't user-typed edits the back-button should prompt about.
+    function refreshSnapshot() {
+        _snapBrand = Settings.dyeBeanBrand
+        _snapType = Settings.dyeBeanType
+        _snapRoastDate = Settings.dyeRoastDate
+        _snapRoastLevel = Settings.dyeRoastLevel
+        _snapGrinderBrand = Settings.dyeGrinderBrand
+        _snapGrinderModel = Settings.dyeGrinderModel
+        _snapGrinderBurrs = Settings.dyeGrinderBurrs
+        _snapGrinderSetting = Settings.dyeGrinderSetting
+        _snapBarista = Settings.dyeBarista
+        _snapSelectedPreset = Settings.selectedBeanPreset
+    }
+
     // Check if there's actual bean data loaded (not just empty)
     function hasGuestBeanData() {
         return Settings.dyeBeanBrand.length > 0 || Settings.dyeBeanType.length > 0
@@ -527,6 +543,9 @@ Page {
                             shotMetadataPage.forceActiveFocus()
                             Settings.selectedBeanPreset = index
                             Settings.applyBeanPreset(index)
+                            // Picking a preset is a choice, not an edit — reset the baseline
+                            // so back-button doesn't prompt about the applied field values.
+                            refreshSnapshot()
                         }
                         onRowLongPressed: function(index) {
                             editPresetIndex = index
@@ -1132,16 +1151,7 @@ Page {
                                 Settings.selectedBeanPreset = savedIndex
                             }
                             // Update snapshot so handleBack() doesn't show spurious unsaved changes dialog
-                            _snapSelectedPreset = Settings.selectedBeanPreset
-                            _snapBrand = Settings.dyeBeanBrand
-                            _snapType = Settings.dyeBeanType
-                            _snapRoastDate = Settings.dyeRoastDate
-                            _snapRoastLevel = Settings.dyeRoastLevel
-                            _snapGrinderBrand = Settings.dyeGrinderBrand
-                            _snapGrinderModel = Settings.dyeGrinderModel
-                            _snapGrinderBurrs = Settings.dyeGrinderBurrs
-                            _snapGrinderSetting = Settings.dyeGrinderSetting
-                            _snapBarista = Settings.dyeBarista
+                            refreshSnapshot()
                             var shouldGoBack = savePresetDialog.goBackAfterSave
                             newBeanNameInput.text = ""
                             savePresetDialog.goBackAfterSave = false

--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -534,7 +534,16 @@ Page {
                             editPresetName = preset.name || ""
                             editPresetDialog.open()
                         }
-                        onRowMoved: function(from, to) { Settings.moveBeanPreset(from, to) }
+                        onRowMoved: function(from, to) {
+                            // Shift the "unsaved-changes" snapshot so a pure reorder
+                            // of the selected item doesn't trip the back-button dialog.
+                            // Mirrors the shift logic in Settings::moveBeanPreset.
+                            var s = _snapSelectedPreset
+                            if (s === from) _snapSelectedPreset = to
+                            else if (from < s && to >= s) _snapSelectedPreset = s - 1
+                            else if (from > s && to <= s) _snapSelectedPreset = s + 1
+                            Settings.moveBeanPreset(from, to)
+                        }
                         onRowDeleted: function(index) { Settings.removeBeanPreset(index) }
                     }
                 }

--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -49,10 +49,10 @@ Page {
                 editGrinderBurrs = editShotData.grinderBurrs || ""
                 editGrinderSetting = editShotData.grinderSetting || ""
                 editBarista = editShotData.barista || ""
-                editDoseWeight = editShotData.doseWeight || 0
-                editDrinkWeight = editShotData.finalWeight || 0
-                editDrinkTds = editShotData.drinkTds || 0
-                editDrinkEy = editShotData.drinkEy || 0
+                editDoseWeight = editShotData.doseWeight ?? 0
+                editDrinkWeight = editShotData.finalWeight ?? 0
+                editDrinkTds = editShotData.drinkTds ?? 0
+                editDrinkEy = editShotData.drinkEy ?? 0
                 editEnjoyment = editShotData.enjoyment ?? 0
                 editNotes = editShotData.espressoNotes || ""
             }
@@ -447,7 +447,7 @@ Page {
                         Text {
                             text: "(" + Settings.beanPresets.length + ")"
                             color: Theme.textColor
-                            font.pixelSize: Theme.scaled(18)
+                            font.pixelSize: Theme.bodyFont.pixelSize
                         }
 
                         Item { Layout.fillWidth: true }

--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -392,183 +392,55 @@ Page {
                 }
             }
 
+            // Bean presets + data-entry grid laid out side-by-side in non-edit mode.
+            // In edit mode the presets card is hidden and the grid takes full width.
+            RowLayout {
+                id: beanEntryRow
+                Layout.fillWidth: true
+                Layout.preferredHeight: Math.max(
+                    fieldsGrid.implicitHeight,
+                    isEditMode ? 0 : (presetsCardColumn.implicitHeight + Theme.scaled(24)))
+                spacing: Theme.scaled(12)
+
             // Bean presets section (only in non-edit mode)
             Rectangle {
                 id: presetsCard
-                Layout.fillWidth: true
-                Layout.preferredHeight: Theme.scaled(90)
+                Layout.preferredWidth: Theme.scaled(380)
+                Layout.fillHeight: true
                 color: Theme.surfaceColor
                 radius: Theme.cardRadius
                 visible: !isEditMode
 
-                RowLayout {
+                ColumnLayout {
+                    id: presetsCardColumn
                     anchors.fill: parent
                     anchors.margins: Theme.scaled(12)
-                    spacing: Theme.scaled(20)
+                    spacing: Theme.scaled(8)
 
-                    Tr {
-                        key: "beaninfo.presets.title"
-                        fallback: "Bean Preset"
-                        color: Theme.textColor
-                        font.pixelSize: Theme.scaled(24)
-                    }
-
-                    // Bean preset pills with drag-and-drop (scrollable)
-                    Flickable {
-                        id: pillsFlickable
+                    RowLayout {
                         Layout.fillWidth: true
-                        Layout.fillHeight: true
-                        contentWidth: beanPresetsRow.width
-                        contentHeight: height
-                        clip: true
-                        flickableDirection: Flickable.HorizontalFlick
-                        boundsBehavior: Flickable.StopAtBounds
-                        pressDelay: 150
-                        interactive: beanPresetsRow.draggedIndex < 0
-
-                    Row {
-                        id: beanPresetsRow
                         spacing: Theme.scaled(8)
-                        y: Math.round((pillsFlickable.height - height) / 2)
 
-                        property int draggedIndex: -1
-                        // Store reference to Settings for use in deeply nested delegates
-                        property var settings: Settings
-
-                        Repeater {
-                            id: beanRepeater
-                            model: Settings.beanPresets
-
-                            Item {
-                                id: beanDelegate
-                                width: beanPill.width
-                                height: Theme.scaled(36)
-
-                                property int beanIndex: index
-
-                                Rectangle {
-                                    id: beanPill
-                                    width: beanText.implicitWidth + 24
-                                    height: Theme.scaled(36)
-                                    radius: Theme.scaled(18)
-                                    color: beanDelegate.beanIndex === Settings.selectedBeanPreset ? Theme.primaryColor : Theme.backgroundColor
-                                    border.color: beanDelegate.beanIndex === Settings.selectedBeanPreset ? Theme.primaryColor : Theme.textSecondaryColor
-                                    border.width: 1
-                                    opacity: beanDragArea.drag.active ? 0.8 : 1.0
-
-                                    Accessible.role: Accessible.Button
-                                    Accessible.name: modelData.name + " " + TranslationManager.translate("beaninfo.accessibility.preset", "preset") +
-                                                     (beanDelegate.beanIndex === Settings.selectedBeanPreset ?
-                                                      ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
-                                    Accessible.focusable: true
-                                    Accessible.description: TranslationManager.translate("beaninfo.accessible.preset.hint", "Long-press to rename or delete this preset.")
-                                    Accessible.onPressAction: {
-                                        var s = beanPresetsRow.settings
-                                        var targetIndex = beanDelegate.beanIndex
-                                        s.selectedBeanPreset = targetIndex
-                                        s.applyBeanPreset(targetIndex)
-                                    }
-
-                                    Drag.active: beanDragArea.drag.active
-                                    Drag.source: beanDelegate
-                                    Drag.hotSpot.x: width / 2
-                                    Drag.hotSpot.y: height / 2
-
-                                    states: State {
-                                        when: beanDragArea.drag.active
-                                        ParentChange { target: beanPill; parent: beanPresetsRow }
-                                        AnchorChanges { target: beanPill; anchors.verticalCenter: undefined }
-                                    }
-
-                                    Text {
-                                        id: beanText
-                                        anchors.centerIn: parent
-                                        text: modelData.name
-                                        color: beanDelegate.beanIndex === Settings.selectedBeanPreset ? Theme.primaryContrastColor : Theme.textColor
-                                        font: Theme.bodyFont
-                                        Accessible.ignored: true
-                                    }
-
-                                    MouseArea {
-                                        id: beanDragArea
-                                        anchors.fill: parent
-                                        drag.target: beanPill
-                                        drag.axis: Drag.XAxis
-
-                                        property bool held: false
-                                        property bool moved: false
-
-                                        onPressed: {
-                                            held = false
-                                            moved = false
-                                            beanHoldTimer.start()
-                                        }
-
-                                        onReleased: {
-                                            beanHoldTimer.stop()
-                                            var s = beanPresetsRow.settings
-                                            if (!moved && !held) {
-                                                // Remove focus from any text fields first to ensure clean state
-                                                shotMetadataPage.forceActiveFocus()
-
-                                                var targetIndex = beanDelegate.beanIndex
-                                                s.selectedBeanPreset = targetIndex
-                                                s.applyBeanPreset(targetIndex)
-                                            }
-                                            beanPill.Drag.drop()
-                                            if (beanPresetsRow) beanPresetsRow.draggedIndex = -1
-                                        }
-
-                                        onPositionChanged: {
-                                            if (drag.active) {
-                                                moved = true
-                                                if (beanPresetsRow) beanPresetsRow.draggedIndex = beanDelegate.beanIndex
-                                            }
-                                        }
-
-                                        onDoubleClicked: {
-                                            beanHoldTimer.stop()
-                                            held = true  // Prevent single-click selection on release
-                                            editPresetIndex = beanDelegate.beanIndex
-                                            var preset = beanPresetsRow.settings.getBeanPreset(beanDelegate.beanIndex)
-                                            editPresetName = preset.name || ""
-                                            editPresetDialog.open()
-                                        }
-
-                                        Timer {
-                                            id: beanHoldTimer
-                                            interval: 500
-                                            onTriggered: {
-                                                if (!beanDragArea.moved) {
-                                                    beanDragArea.held = true
-                                                    editPresetIndex = beanDelegate.beanIndex
-                                                    var preset = beanPresetsRow.settings.getBeanPreset(beanDelegate.beanIndex)
-                                                    editPresetName = preset.name || ""
-                                                    editPresetDialog.open()
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                DropArea {
-                                    anchors.fill: parent
-                                    onEntered: function(drag) {
-                                        var fromIndex = drag.source.beanIndex
-                                        var toIndex = beanDelegate.beanIndex
-                                        if (fromIndex !== toIndex) {
-                                            beanPresetsRow.settings.moveBeanPreset(fromIndex, toIndex)
-                                        }
-                                    }
-                                }
-                            }
+                        Tr {
+                            key: "beaninfo.presets.title"
+                            fallback: "Bean Preset"
+                            color: Theme.textColor
+                            font.pixelSize: Theme.scaled(22)
                         }
+
+                        Text {
+                            text: "(" + Settings.beanPresets.length + ")"
+                            color: Theme.textColor
+                            font.pixelSize: Theme.scaled(18)
+                        }
+
+                        Item { Layout.fillWidth: true }
 
                         // Add button
                         Rectangle {
                             id: addBeanButton
-                            width: Theme.scaled(36)
-                            height: Theme.scaled(36)
+                            Layout.preferredWidth: Theme.scaled(36)
+                            Layout.preferredHeight: Theme.scaled(36)
                             radius: Theme.scaled(18)
                             color: Theme.backgroundColor
                             border.color: Theme.textSecondaryColor
@@ -593,25 +465,103 @@ Page {
                             }
                         }
                     }
-                    }
 
                     Tr {
-                        key: "beaninfo.hint.reorder"
-                        fallback: "Drag to reorder, hold or double-click to edit"
+                        Layout.fillWidth: true
+                        visible: Settings.beanPresets.length > 0
+                        key: "beaninfo.hint.reorder_vertical"
+                        fallback: "Drag to reorder, double-click to rename, click star to show on home screen"
                         color: Theme.textSecondaryColor
-                        font: Theme.labelFont
+                        font: Theme.captionFont
+                        wrapMode: Text.Wrap
+                    }
+
+                    FavoritesListView {
+                        id: beanPresetsList
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        visible: Settings.beanPresets.length > 0
+                        model: Settings.beanPresets
+                        selectedIndex: Settings.selectedBeanPreset
+
+                        displayTextFn: function(row, index) {
+                            return row && row.name ? row.name : ""
+                        }
+                        accessibleNameFn: function(row, index) {
+                            if (!row) return ""
+                            var status = index === Settings.selectedBeanPreset
+                                ? ", " + TranslationManager.translate("accessibility.selected", "selected") : ""
+                            return row.name + " " + TranslationManager.translate("beaninfo.accessibility.preset", "preset") + status
+                        }
+                        deleteAccessibleNameFn: function(row, index) {
+                            return TranslationManager.translate("beaninfo.accessibility.removepreset", "Remove preset") +
+                                   (row && row.name ? " " + row.name : "")
+                        }
+
+                        // "Show on idle" star toggle in place of profiles' edit button
+                        trailingActionDelegate: Component {
+                            StyledIconButton {
+                                anchors.fill: parent
+                                active: parent.row ? (parent.row.showOnIdle !== false) : false
+                                activeColor: parent.selected ? "white" : Theme.primaryColor
+                                inactiveColor: parent.selected ? Qt.rgba(1, 1, 1, 0.5) : Theme.textSecondaryColor
+                                icon.source: active ? "qrc:/icons/star.svg" : "qrc:/icons/star-outline.svg"
+                                icon.width: Theme.scaled(18)
+                                icon.height: Theme.scaled(18)
+                                accessibleName: parent.row
+                                    ? ((parent.row.showOnIdle !== false
+                                        ? TranslationManager.translate("beaninfo.accessible.hide_from_idle", "Hide from idle page")
+                                        : TranslationManager.translate("beaninfo.accessible.show_on_idle", "Show on idle page"))
+                                        + " " + parent.row.name)
+                                    : ""
+
+                                onClicked: {
+                                    if (!parent.row) return
+                                    var currently = parent.row.showOnIdle !== false
+                                    Settings.setBeanPresetShowOnIdle(parent.rowIndex, !currently)
+                                }
+                            }
+                        }
+
+                        onRowSelected: function(index) {
+                            shotMetadataPage.forceActiveFocus()
+                            Settings.selectedBeanPreset = index
+                            Settings.applyBeanPreset(index)
+                        }
+                        onRowLongPressed: function(index) {
+                            editPresetIndex = index
+                            var preset = Settings.getBeanPreset(index)
+                            editPresetName = preset.name || ""
+                            editPresetDialog.open()
+                        }
+                        onRowMoved: function(from, to) { Settings.moveBeanPreset(from, to) }
+                        onRowDeleted: function(index) { Settings.removeBeanPreset(index) }
                     }
                 }
             }
 
-            // 3-column grid for all fields
+            // 2-column grid grouped into Bean / Grinder / Barista sections.
+            // Wider fields, better use of vertical space, less text cropping.
             GridLayout {
+                id: fieldsGrid
                 Layout.fillWidth: true
-                columns: 3
-                columnSpacing: 8
-                rowSpacing: 6
+                Layout.alignment: Qt.AlignTop
+                columns: 2
+                columnSpacing: Theme.scaled(10)
+                rowSpacing: Theme.scaled(2)
 
-                // === ROW 1: Bean info ===
+                // === BEAN SECTION ===
+                Tr {
+                    Layout.columnSpan: 2
+                    Layout.fillWidth: true
+                    Layout.topMargin: Theme.scaled(0)
+                    key: "beaninfo.section.bean"
+                    fallback: "Bean"
+                    color: Theme.textSecondaryColor
+                    font.pixelSize: Theme.scaled(14)
+                    font.bold: true
+                }
+
                 SuggestionField {
                     Layout.fillWidth: true
                     label: TranslationManager.translate("shotmetadata.label.roaster", "Roaster")
@@ -696,7 +646,31 @@ Page {
                     }
                 }
 
-                // === ROW 2: Grinder brand, Model, Burrs ===
+                LabeledComboBox {
+                    Layout.fillWidth: true
+                    label: TranslationManager.translate("shotmetadata.label.roastlevel", "Roast level")
+                    model: ["",
+                        TranslationManager.translate("shotmetadata.roastlevel.light", "Light"),
+                        TranslationManager.translate("shotmetadata.roastlevel.mediumlight", "Medium-Light"),
+                        TranslationManager.translate("shotmetadata.roastlevel.medium", "Medium"),
+                        TranslationManager.translate("shotmetadata.roastlevel.mediumdark", "Medium-Dark"),
+                        TranslationManager.translate("shotmetadata.roastlevel.dark", "Dark")]
+                    currentValue: isEditMode ? editRoastLevel : Settings.dyeRoastLevel
+                    onValueChanged: function(v) { if (isEditMode) editRoastLevel = v; else { Settings.dyeRoastLevel = v; deselectPresetOnEdit(); } }
+                }
+
+                // === GRINDER SECTION ===
+                Tr {
+                    Layout.columnSpan: 2
+                    Layout.fillWidth: true
+                    Layout.topMargin: Theme.scaled(6)
+                    key: "beaninfo.section.grinder"
+                    fallback: "Grinder"
+                    color: Theme.textSecondaryColor
+                    font.pixelSize: Theme.scaled(14)
+                    font.bold: true
+                }
+
                 SuggestionField {
                     id: grinderBrandField
                     Layout.fillWidth: true
@@ -784,20 +758,6 @@ Page {
                     onInputBlurred: Qt.callLater(checkFocusReset)
                 }
 
-                // === ROW 3: Roast level, Setting, Barista ===
-                LabeledComboBox {
-                    Layout.fillWidth: true
-                    label: TranslationManager.translate("shotmetadata.label.roastlevel", "Roast level")
-                    model: ["",
-                        TranslationManager.translate("shotmetadata.roastlevel.light", "Light"),
-                        TranslationManager.translate("shotmetadata.roastlevel.mediumlight", "Medium-Light"),
-                        TranslationManager.translate("shotmetadata.roastlevel.medium", "Medium"),
-                        TranslationManager.translate("shotmetadata.roastlevel.mediumdark", "Medium-Dark"),
-                        TranslationManager.translate("shotmetadata.roastlevel.dark", "Dark")]
-                    currentValue: isEditMode ? editRoastLevel : Settings.dyeRoastLevel
-                    onValueChanged: function(v) { if (isEditMode) editRoastLevel = v; else { Settings.dyeRoastLevel = v; deselectPresetOnEdit(); } }
-                }
-
                 SuggestionField {
                     Layout.fillWidth: true
                     label: TranslationManager.translate("shotmetadata.label.setting", "Setting")
@@ -814,7 +774,19 @@ Page {
                     onInputBlurred: Qt.callLater(checkFocusReset)
                 }
 
+                Tr {
+                    Layout.columnSpan: 2
+                    Layout.fillWidth: true
+                    Layout.topMargin: Theme.scaled(6)
+                    key: "beaninfo.section.barista"
+                    fallback: "Barista"
+                    color: Theme.textSecondaryColor
+                    font.pixelSize: Theme.scaled(14)
+                    font.bold: true
+                }
+
                 SuggestionField {
+                    Layout.columnSpan: 2
                     Layout.fillWidth: true
                     label: TranslationManager.translate("shotmetadata.label.barista", "Barista")
                     text: isEditMode ? editBarista : Settings.dyeBarista
@@ -829,6 +801,7 @@ Page {
                     onInputBlurred: Qt.callLater(checkFocusReset)
                 }
             }
+            }  // end beanEntryRow
 
             Item { Layout.preferredHeight: 10 }
         }
@@ -1245,16 +1218,6 @@ Page {
 
             RowLayout {
                 spacing: Theme.scaled(10)
-
-                AccessibleButton {
-                    text: TranslationManager.translate("common.delete", "Delete")
-                    accessibleName: TranslationManager.translate("beanInfo.deletePreset", "Delete this bean preset")
-                    destructive: true
-                    onClicked: {
-                        Settings.removeBeanPreset(editPresetIndex)
-                        editPresetDialog.close()
-                    }
-                }
 
                 Item { Layout.fillWidth: true }
 

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -126,9 +126,12 @@ Page {
                     }
                     break
                 case "beans":
-                    presets = Settings.beanPresets
-                    if (Settings.selectedBeanPreset >= 0 && Settings.selectedBeanPreset < presets.length) {
-                        selectedName = presets[Settings.selectedBeanPreset].name
+                    presets = Settings.idleBeanPresets
+                    for (var bi = 0; bi < presets.length; ++bi) {
+                        if (presets[bi].originalIndex === Settings.selectedBeanPreset) {
+                            selectedName = presets[bi].name
+                            break
+                        }
                     }
                     break
             }
@@ -465,13 +468,23 @@ Page {
                 active: activePresetFunction === "beans"
                 visible: active
                 sourceComponent: PresetPillRow {
+                    id: inlineBeanPresetRow
                     maxWidth: beanPresetLoader.width
-                    presets: Settings.beanPresets
-                    selectedIndex: Settings.selectedBeanPreset
+                    presets: Settings.idleBeanPresets
+                    selectedIndex: {
+                        var list = Settings.idleBeanPresets
+                        for (var i = 0; i < list.length; ++i) {
+                            if (list[i].originalIndex === Settings.selectedBeanPreset) return i
+                        }
+                        return -1
+                    }
 
                     onPresetSelected: function(index) {
-                        Settings.selectedBeanPreset = index
-                        Settings.applyBeanPreset(index)
+                        var row = inlineBeanPresetRow.presets[index]
+                        if (!row) return
+                        var originalIndex = row.originalIndex !== undefined ? row.originalIndex : index
+                        Settings.selectedBeanPreset = originalIndex
+                        Settings.applyBeanPreset(originalIndex)
                     }
                 }
             }

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -709,166 +709,77 @@ Page {
                     }
                 }
 
-                ListView {
+                FavoritesListView {
                     id: favoritesList
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    clip: true
                     visible: Settings.favoriteProfiles.length > 0
                     model: Settings.favoriteProfiles
-                    spacing: Theme.scaled(8)
+                    selectedIndex: Settings.selectedFavoriteProfile
 
-                    delegate: Item {
-                        id: favoriteDelegate
-                        width: favoritesList.width
-                        height: Math.max(Theme.scaled(60), favContentRow.implicitHeight + Theme.scaled(10) * 2)
+                    displayTextFn: function(row, index) {
+                        if (!row) return ""
+                        var name = row.name
+                        if (index === Settings.selectedFavoriteProfile && ProfileManager.profileModified) {
+                            return ProfileManager.isCurrentProfileReadOnly
+                                ? name + " (modified)" : "*" + name
+                        }
+                        return name
+                    }
+                    accessibleNameFn: function(row, index) {
+                        if (!row) return ""
+                        var modified = (index === Settings.selectedFavoriteProfile && ProfileManager.profileModified)
+                            ? ", " + TranslationManager.translate("presets.unsaved", "unsaved changes") : ""
+                        var status = index === Settings.selectedFavoriteProfile
+                            ? ", " + TranslationManager.translate("profileselector.accessible.selected_favorite", "selected favorite")
+                            : ", " + TranslationManager.translate("profileselector.accessible.favorite", "favorite")
+                        return root.cleanForSpeech(row.name) + modified + status
+                    }
+                    deleteAccessibleNameFn: function(row, index) {
+                        if (!row) return ""
+                        return TranslationManager.translate("profileselector.accessible.remove", "Remove") + " " +
+                               root.cleanForSpeech(row.name) + " " +
+                               TranslationManager.translate("profileselector.accessible.from_favorites", "from favorites")
+                    }
 
-                        property int favoriteIndex: index
-
-                        Rectangle {
-                            id: favoritePill
+                    trailingActionDelegate: Component {
+                        StyledIconButton {
                             anchors.fill: parent
-                            radius: Theme.scaled(8)
-                            color: index === Settings.selectedFavoriteProfile ?
-                                   Theme.primaryColor : Theme.backgroundColor
-                            border.color: Theme.textSecondaryColor
-                            border.width: 1
+                            icon.source: "qrc:/icons/edit.svg"
+                            icon.width: Theme.scaled(18)
+                            icon.height: Theme.scaled(18)
+                            icon.color: parent.selected ? "white" : Theme.textColor
+                            accessibleName: parent.row ? (TranslationManager.translate("profileselector.accessible.edit", "Edit") + " " + root.cleanForSpeech(parent.row.name)) : ""
 
-                            RowLayout {
-                                id: favContentRow
-                                anchors.fill: parent
-                                anchors.margins: Theme.scaled(10)
-                                spacing: Theme.scaled(8)
-
-                                // Drag handle
-                                Image {
-                                    source: "qrc:/icons/list.svg"
-                                    sourceSize.width: Theme.scaled(18)
-                                    sourceSize.height: Theme.scaled(18)
-                                    opacity: index === Settings.selectedFavoriteProfile ? 1.0 : 0.5
-
-                                    layer.enabled: index !== Settings.selectedFavoriteProfile
-                                    layer.smooth: true
-                                    layer.effect: MultiEffect {
-                                        colorization: 1.0
-                                        colorizationColor: Theme.textSecondaryColor
-                                    }
-
-                                    MouseArea {
-                                        id: dragArea
-                                        anchors.fill: parent
-                                        preventStealing: true
-                                        drag.target: favoritePill
-                                        drag.axis: Drag.YAxis
-
-                                        property int startIndex: -1
-
-                                        onPressed: {
-                                            startIndex = favoriteDelegate.favoriteIndex
-                                            favoritePill.anchors.fill = undefined
-                                        }
-
-                                        onReleased: {
-                                            // Read position BEFORE restoring anchors (anchors.fill resets y to 0)
-                                            var contentPos = favoriteDelegate.y + favoritePill.y
-                                            var newIndex = Math.floor((contentPos + favoritePill.height/2) / (favoriteDelegate.height + favoritesList.spacing))
-                                            newIndex = Math.max(0, Math.min(newIndex, Settings.favoriteProfiles.length - 1))
-                                            favoritePill.anchors.fill = favoriteDelegate
-                                            if (newIndex !== startIndex && startIndex >= 0) {
-                                                Settings.moveFavoriteProfile(startIndex, newIndex)
-                                            }
-                                        }
-
-                                        onCanceled: {
-                                            favoritePill.anchors.fill = favoriteDelegate
-                                        }
-                                    }
-                                }
-
-                                // Profile name
-                                Text {
-                                    Layout.fillWidth: true
-                                    text: {
-                                        var name = modelData.name
-                                        if (index === Settings.selectedFavoriteProfile && ProfileManager.profileModified) {
-                                            return ProfileManager.isCurrentProfileReadOnly
-                                                ? name + " (modified)" : "*" + name
-                                        }
-                                        return name
-                                    }
-                                    color: index === Settings.selectedFavoriteProfile ?
-                                           "white" : Theme.textColor
-                                    font: Theme.bodyFont
-                                    elide: Text.ElideRight
-                                    Accessible.ignored: true
-                                }
-
-                                // Edit button
-                                StyledIconButton {
-                                    id: editFavoriteButton
-                                    Layout.preferredWidth: Theme.scaled(36)
-                                    Layout.preferredHeight: Theme.scaled(36)
-                                    icon.source: "qrc:/icons/edit.svg"
-                                    icon.width: Theme.scaled(18)
-                                    icon.height: Theme.scaled(18)
-                                    icon.color: index === Settings.selectedFavoriteProfile ? "white" : Theme.textColor
-                                    accessibleName: modelData ? (TranslationManager.translate("profileselector.accessible.edit", "Edit") + " " + root.cleanForSpeech(modelData.name)) : ""
-
-                                    onClicked: {
-                                        if (!modelData) return
-                                        Settings.selectedFavoriteProfile = index
-                                        ProfileManager.loadProfile(modelData.filename)
-                                        root.goToProfileEditor()
-                                    }
-                                }
-
-                                // Remove button
-                                StyledIconButton {
-                                    id: removeFavoriteButton
-                                    Layout.preferredWidth: Theme.scaled(36)
-                                    Layout.preferredHeight: Theme.scaled(36)
-                                    icon.source: "qrc:/icons/cross.svg"
-                                    inactiveColor: Theme.errorColor
-                                    accessibleName: modelData ? (TranslationManager.translate("profileselector.accessible.remove", "Remove") + " " + root.cleanForSpeech(modelData.name) + " " + TranslationManager.translate("profileselector.accessible.from_favorites", "from favorites")) : ""
-
-                                    onClicked: {
-                                        if (!modelData) return
-                                        var name = root.cleanForSpeech(modelData.name)
-                                        Settings.removeFavoriteProfile(index)
-                                        if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
-                                            AccessibilityManager.announce(name + " " + TranslationManager.translate("profileselector.accessible.removed_from_favorites", "removed from favorites"))
-                                        }
-                                    }
-                                }
+                            onClicked: {
+                                if (!parent.row) return
+                                Settings.selectedFavoriteProfile = parent.rowIndex
+                                ProfileManager.loadProfile(parent.row.filename)
+                                root.goToProfileEditor()
                             }
+                        }
+                    }
 
-                            // Using TapHandler for better touch responsiveness
-                            AccessibleTapHandler {
-                                anchors.fill: parent
-                                z: -1
-                                accessibleName: {
-                                    if (!modelData) return ""
-                                    var modified = (index === Settings.selectedFavoriteProfile && ProfileManager.profileModified) ? ", " + TranslationManager.translate("presets.unsaved", "unsaved changes") : ""
-                                    var status = index === Settings.selectedFavoriteProfile ? ", " + TranslationManager.translate("profileselector.accessible.selected_favorite", "selected favorite") : ", " + TranslationManager.translate("profileselector.accessible.favorite", "favorite")
-                                    return root.cleanForSpeech(modelData.name) + modified + status
-                                }
-                                accessibleItem: favoritePill
-                                onAccessibleClicked: {
-                                    if (!modelData) return
-                                    // Always load the profile when clicking
-                                    ProfileManager.loadProfile(modelData.filename)
-                                    if (index === Settings.selectedFavoriteProfile) {
-                                        // Already selected - open editor
-                                        root.goToProfileEditor()
-                                    } else {
-                                        // Select it (first click)
-                                        if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
-                                            AccessibilityManager.announce(root.cleanForSpeech(modelData.name) + " " + TranslationManager.translate("profileSelector.selected", "selected"))
-                                        }
-                                        Settings.selectedFavoriteProfile = index
-                                    }
-                                }
+                    onRowSelected: function(index) {
+                        var fav = Settings.favoriteProfiles[index]
+                        if (!fav) return
+                        ProfileManager.loadProfile(fav.filename)
+                        if (index === Settings.selectedFavoriteProfile) {
+                            root.goToProfileEditor()
+                        } else {
+                            if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
+                                AccessibilityManager.announce(root.cleanForSpeech(fav.name) + " " + TranslationManager.translate("profileSelector.selected", "selected"))
                             }
+                            Settings.selectedFavoriteProfile = index
+                        }
+                    }
+                    onRowMoved: function(from, to) { Settings.moveFavoriteProfile(from, to) }
+                    onRowDeleted: function(index) {
+                        var fav = Settings.favoriteProfiles[index]
+                        var name = fav ? root.cleanForSpeech(fav.name) : ""
+                        Settings.removeFavoriteProfile(index)
+                        if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
+                            AccessibilityManager.announce(name + " " + TranslationManager.translate("profileselector.accessible.removed_from_favorites", "removed from favorites"))
                         }
                     }
                 }

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -281,7 +281,7 @@ Page {
                                         var name = modelData.title
                                         if (isCurrentProfile && ProfileManager.profileModified) {
                                             return ProfileManager.isCurrentProfileReadOnly
-                                                ? name + " (modified)" : "*" + name
+                                                ? name + " " + TranslationManager.translate("profileselector.modified_suffix", "(modified)") : "*" + name
                                         }
                                         return name
                                     }
@@ -725,7 +725,7 @@ Page {
                         var name = row.name
                         if (index === Settings.selectedFavoriteProfile && ProfileManager.profileModified) {
                             return ProfileManager.isCurrentProfileReadOnly
-                                ? name + " (modified)" : "*" + name
+                                ? name + " " + TranslationManager.translate("profileselector.modified_suffix", "(modified)") : "*" + name
                         }
                         return name
                     }
@@ -751,7 +751,7 @@ Page {
                             icon.source: "qrc:/icons/edit.svg"
                             icon.width: Theme.scaled(18)
                             icon.height: Theme.scaled(18)
-                            icon.color: parent.selected ? "white" : Theme.textColor
+                            icon.color: parent.selected ? Theme.primaryContrastColor : Theme.textColor
                             accessibleName: parent.row ? (TranslationManager.translate("profileselector.accessible.edit", "Edit") + " " + root.cleanForSpeech(parent.row.name)) : ""
 
                             onClicked: {
@@ -763,6 +763,13 @@ Page {
                         }
                     }
 
+                    onRowLongPressed: function(index) {
+                        var fav = Settings.favoriteProfiles[index]
+                        if (!fav) return
+                        Settings.selectedFavoriteProfile = index
+                        ProfileManager.loadProfile(fav.filename)
+                        root.goToProfileEditor()
+                    }
                     onRowSelected: function(index) {
                         var fav = Settings.favoriteProfiles[index]
                         if (!fav) return

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -636,7 +636,7 @@ Page {
 
                 // Empty state
                 Tr {
-                    visible: Settings.favoriteProfiles.length === 0 && Settings.selectedFavoriteProfile !== -1
+                    visible: Settings.favoriteProfiles.length === 0
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     key: "profileselector.favorites.empty"

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -716,6 +716,9 @@ Page {
                     visible: Settings.favoriteProfiles.length > 0
                     model: Settings.favoriteProfiles
                     selectedIndex: Settings.selectedFavoriteProfile
+                    rowAccessibleDescription: TranslationManager.translate(
+                        "profileselector.accessible.row_hint",
+                        "Double-tap or long-press to open profile editor.")
 
                     displayTextFn: function(row, index) {
                         if (!row) return ""

--- a/resources/profiles/a_flow_default_dark.json
+++ b/resources/profiles/a_flow_default_dark.json
@@ -27,7 +27,6 @@
         "pourPressure": 9,
         "pourTemperature": 88,
         "rampTime": 5,
-        "editorType": "aflow",
         "targetWeight": 36,
         "rampDownEnabled": false,
         "flowExtractionUp": false

--- a/resources/profiles/a_flow_default_like_dflow.json
+++ b/resources/profiles/a_flow_default_like_dflow.json
@@ -27,7 +27,6 @@
         "pourPressure": 10,
         "pourTemperature": 93,
         "rampTime": 0,
-        "editorType": "aflow",
         "targetWeight": 36,
         "rampDownEnabled": false,
         "flowExtractionUp": true

--- a/resources/profiles/a_flow_default_medium.json
+++ b/resources/profiles/a_flow_default_medium.json
@@ -27,7 +27,6 @@
         "pourPressure": 10,
         "pourTemperature": 95,
         "rampTime": 10,
-        "editorType": "aflow",
         "targetWeight": 36,
         "rampDownEnabled": false,
         "flowExtractionUp": true

--- a/resources/profiles/a_flow_default_very_dark.json
+++ b/resources/profiles/a_flow_default_very_dark.json
@@ -27,7 +27,6 @@
         "pourPressure": 10,
         "pourTemperature": 95,
         "rampTime": 6,
-        "editorType": "aflow",
         "targetWeight": 32,
         "rampDownEnabled": true,
         "flowExtractionUp": true

--- a/resources/profiles/d_flow_default.json
+++ b/resources/profiles/d_flow_default.json
@@ -14,7 +14,6 @@
     "target_volume": 0,
     "recipe": {
         "dose": 18,
-        "editorType": "dflow",
         "fillFlow": 8,
         "fillPressure": 3,
         "fillTemperature": 88,

--- a/resources/profiles/d_flow_la_pavoni.json
+++ b/resources/profiles/d_flow_la_pavoni.json
@@ -14,7 +14,6 @@
     "target_volume": 0,
     "recipe": {
         "dose": 18,
-        "editorType": "dflow",
         "fillFlow": 8,
         "fillPressure": 1.2,
         "fillTemperature": 84,

--- a/resources/profiles/d_flow_q.json
+++ b/resources/profiles/d_flow_q.json
@@ -14,7 +14,6 @@
     "target_volume": 0,
     "recipe": {
         "dose": 18,
-        "editorType": "dflow",
         "fillFlow": 8,
         "fillPressure": 6,
         "fillTemperature": 84,

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -792,8 +792,12 @@ void ProfileManager::loadProfile(const QString& profileName) {
     QString path;
     bool found = false;
 
-    // Resolve profile name: could be title or filename (MQTT publishes titles)
+    // Normalize: strip .json extension if present (legacy settings entries may include it)
     QString resolvedName = profileName;
+    if (resolvedName.endsWith(QLatin1String(".json"), Qt::CaseInsensitive))
+        resolvedName = resolvedName.chopped(5);
+
+    // Resolve profile name: could be title or filename (MQTT publishes titles)
 
     // First, check if it's a title (most common case from MQTT)
     for (auto it = m_profileTitles.begin(); it != m_profileTitles.end(); ++it) {
@@ -847,10 +851,14 @@ void ProfileManager::loadProfile(const QString& profileName) {
         }
     }
 
-    // 5. Fall back to default
+    // 5. Fall back to real default — this should not happen in normal operation after
+    // startup validation removes stale references from favorites and currentProfile.
     if (!found) {
-        qWarning() << "ProfileManager::loadProfile: Profile not found:" << profileName << "(resolved:" << resolvedName << ") — loading default";
+        qWarning() << "ProfileManager::loadProfile: Profile not found:" << profileName
+                   << "(resolved:" << resolvedName << ")";
+        emit profileLoadFailed(resolvedName);
         loadDefaultProfile();
+        resolvedName = QStringLiteral("default");  // Track real default, not stale name
     }
 
     // Backfill empty notes from built-in profile (handles imported copies from before notes were added)
@@ -1149,6 +1157,36 @@ void ProfileManager::refreshProfiles() {
 
         m_availableProfiles.append(name);
         m_profileTitles[name] = info.title;
+    }
+
+    // Validate favorites and currentProfile against the known profile set.
+    // Removes favorites that reference profiles not found in any directory, and resets
+    // a stale currentProfile to the first remaining valid favorite (or "default").
+    // Runs every time refreshProfiles() is called so stale references are cleaned up at startup.
+    if (m_settings) {
+        QSet<QString> known(m_availableProfiles.begin(), m_availableProfiles.end());
+
+        QVariantList favorites = m_settings->favoriteProfiles();
+        for (int i = static_cast<int>(favorites.size()) - 1; i >= 0; --i) {
+            QString fn = favorites.at(i).toMap()[QStringLiteral("filename")].toString();
+            if (!known.contains(fn)) {
+                qWarning() << "refreshProfiles: removing stale favorite" << fn << "(profile not found)";
+                m_settings->removeFavoriteProfile(i);
+            }
+        }
+
+        QString cp = m_settings->currentProfile();
+        if (cp.endsWith(QLatin1String(".json"), Qt::CaseInsensitive))
+            cp = cp.chopped(5);
+        if (!cp.isEmpty() && !known.contains(cp)) {
+            QString replacement = QStringLiteral("default");
+            QVariantList updatedFavs = m_settings->favoriteProfiles();
+            if (!updatedFavs.isEmpty())
+                replacement = updatedFavs.first().toMap()[QStringLiteral("filename")].toString();
+            qWarning() << "refreshProfiles: stale currentProfile" << cp
+                       << "-> replacing with" << replacement;
+            m_settings->setCurrentProfile(replacement);
+        }
     }
 
     emit profilesChanged();
@@ -2042,38 +2080,9 @@ void ProfileManager::applyFlowCalibration() {
 // === Private helpers ===
 
 void ProfileManager::loadDefaultProfile() {
-    m_currentProfile = Profile();
-    m_currentProfile.setTitle("Default");
-    m_currentProfile.setTargetWeight(36.0);
-
-    // Create a simple default profile
-    ProfileFrame preinfusion;
-    preinfusion.name = "Preinfusion";
-    preinfusion.pump = "pressure";
-    preinfusion.pressure = 4.0;
-    preinfusion.temperature = 93.0;
-    preinfusion.seconds = 10.0;
-    preinfusion.exitIf = true;
-    preinfusion.exitType = "pressure_over";
-    preinfusion.exitPressureOver = 3.0;
-
-    ProfileFrame extraction;
-    extraction.name = "Extraction";
-    extraction.pump = "pressure";
-    extraction.pressure = 9.0;
-    extraction.temperature = 93.0;
-    extraction.seconds = 30.0;
-
-    if (!m_currentProfile.addStep(preinfusion)) {
-        qWarning() << "loadDefaultProfile: failed to add preinfusion frame";
-    }
-    if (!m_currentProfile.addStep(extraction)) {
-        qWarning() << "loadDefaultProfile: failed to add extraction frame";
-    }
-    m_currentProfile.setPreinfuseFrameCount(1);
-
+    m_currentProfile = Profile::loadFromFile(QStringLiteral(":/profiles/default.json"));
     if (m_settings) {
-        m_settings->setSelectedFavoriteProfile(-1);  // Default profile, not in favorites
+        m_settings->setSelectedFavoriteProfile(-1);
         if (m_startupLoadDone || !m_settings->hasBrewYieldOverride())
             m_settings->setBrewYieldOverride(m_currentProfile.targetWeight());
         m_settings->setTemperatureOverride(m_currentProfile.espressoTemperature());

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -1167,7 +1167,7 @@ void ProfileManager::refreshProfiles() {
         QSet<QString> known(m_availableProfiles.begin(), m_availableProfiles.end());
 
         QVariantList favorites = m_settings->favoriteProfiles();
-        for (int i = static_cast<int>(favorites.size()) - 1; i >= 0; --i) {
+        for (qsizetype i = favorites.size() - 1; i >= 0; --i) {
             QString fn = favorites.at(i).toMap()[QStringLiteral("filename")].toString();
             if (!known.contains(fn)) {
                 qWarning() << "refreshProfiles: removing stale favorite" << fn << "(profile not found)";

--- a/src/controllers/profilemanager.h
+++ b/src/controllers/profilemanager.h
@@ -164,6 +164,10 @@ signals:
     // Connect to ShotDebugLogger for diagnostics.
     void profileUploadBlocked(const QString& phaseString, const QString& stackTrace);
 
+    // Emitted when loadProfile() cannot find the requested profile file.
+    // The UI should show an error and prompt the user to select another profile.
+    void profileLoadFailed(const QString& filename);
+
 private:
     void loadDefaultProfile();
     void updateProfileKnowledgeBaseId();

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1370,7 +1370,12 @@ QVariantList Settings::beanPresets() const {
 
     QVariantList result;
     for (const QJsonValue& v : arr) {
-        result.append(v.toObject().toVariantMap());
+        QVariantMap row = v.toObject().toVariantMap();
+        // Backfill legacy presets (no showOnIdle field) — default true to preserve behavior
+        if (!row.contains("showOnIdle")) {
+            row["showOnIdle"] = true;
+        }
+        result.append(row);
     }
     return result;
 }
@@ -1402,6 +1407,7 @@ void Settings::addBeanPreset(const QString& name, const QString& brand, const QS
     preset["grinderModel"] = grinderModel;
     preset["grinderBurrs"] = grinderBurrs;
     preset["grinderSetting"] = grinderSetting;
+    preset["showOnIdle"] = true;
     arr.append(preset);
 
     m_settings.setValue("bean/presets", QJsonDocument(arr).toJson());
@@ -1416,6 +1422,10 @@ void Settings::updateBeanPreset(int index, const QString& name, const QString& b
     QJsonArray arr = getBeanPresetsArray();
 
     if (index >= 0 && index < arr.size()) {
+        // Preserve showOnIdle from existing entry (default true for legacy)
+        QJsonObject existing = arr[index].toObject();
+        bool showOnIdle = existing.contains("showOnIdle") ? existing["showOnIdle"].toBool() : true;
+
         QJsonObject preset;
         preset["name"] = name;
         preset["brand"] = brand;
@@ -1426,6 +1436,7 @@ void Settings::updateBeanPreset(int index, const QString& name, const QString& b
         preset["grinderModel"] = grinderModel;
         preset["grinderBurrs"] = grinderBurrs;
         preset["grinderSetting"] = grinderSetting;
+        preset["showOnIdle"] = showOnIdle;
         arr[index] = preset;
 
         m_settings.setValue("bean/presets", QJsonDocument(arr).toJson());
@@ -1477,11 +1488,45 @@ void Settings::moveBeanPreset(int from, int to) {
     }
 }
 
+void Settings::setBeanPresetShowOnIdle(int index, bool show) {
+    QJsonArray arr = getBeanPresetsArray();
+
+    if (index >= 0 && index < arr.size()) {
+        QJsonObject preset = arr[index].toObject();
+        if (preset["showOnIdle"].toBool(true) != show) {
+            preset["showOnIdle"] = show;
+            arr[index] = preset;
+            m_settings.setValue("bean/presets", QJsonDocument(arr).toJson());
+            emit beanPresetsChanged();
+        }
+    }
+}
+
+QVariantList Settings::idleBeanPresets() const {
+    QJsonArray arr = getBeanPresetsArray();
+
+    QVariantList result;
+    for (qsizetype i = 0; i < arr.size(); ++i) {
+        QJsonObject obj = arr[i].toObject();
+        bool showOnIdle = obj.contains("showOnIdle") ? obj["showOnIdle"].toBool() : true;
+        if (!showOnIdle) continue;
+        QVariantMap row = obj.toVariantMap();
+        row["showOnIdle"] = true;
+        row["originalIndex"] = static_cast<int>(i);
+        result.append(row);
+    }
+    return result;
+}
+
 QVariantMap Settings::getBeanPreset(int index) const {
     QJsonArray arr = getBeanPresetsArray();
 
     if (index >= 0 && index < arr.size()) {
-        return arr[index].toObject().toVariantMap();
+        QVariantMap row = arr[index].toObject().toVariantMap();
+        if (!row.contains("showOnIdle")) {
+            row["showOnIdle"] = true;
+        }
+        return row;
     }
     return QVariantMap();
 }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -763,7 +763,7 @@ QVariantList Settings::favoriteProfiles() const {
 }
 
 int Settings::selectedFavoriteProfile() const {
-    return m_settings.value("profile/selectedFavorite", 0).toInt();
+    return m_settings.value("profile/selectedFavorite", -1).toInt();
 }
 
 void Settings::setSelectedFavoriteProfile(int index) {
@@ -818,7 +818,7 @@ void Settings::removeFavoriteProfile(int index) {
         if (selected >= arr.size() && arr.size() > 0) {
             setSelectedFavoriteProfile(static_cast<int>(arr.size()) - 1);
         } else if (arr.size() == 0) {
-            setSelectedFavoriteProfile(0);
+            setSelectedFavoriteProfile(-1);
         }
 
         emit favoriteProfilesChanged();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -94,6 +94,7 @@ class Settings : public QObject {
 
     // Bean presets
     Q_PROPERTY(QVariantList beanPresets READ beanPresets NOTIFY beanPresetsChanged)
+    Q_PROPERTY(QVariantList idleBeanPresets READ idleBeanPresets NOTIFY beanPresetsChanged)
     Q_PROPERTY(int selectedBeanPreset READ selectedBeanPreset WRITE setSelectedBeanPreset NOTIFY selectedBeanPresetChanged)
 
     // UI settings
@@ -452,6 +453,8 @@ public:
                                       const QString& grinderSetting);
     Q_INVOKABLE void removeBeanPreset(int index);
     Q_INVOKABLE void moveBeanPreset(int from, int to);
+    Q_INVOKABLE void setBeanPresetShowOnIdle(int index, bool show);
+    Q_INVOKABLE QVariantList idleBeanPresets() const;  // Filtered subset with originalIndex field
     Q_INVOKABLE QVariantMap getBeanPreset(int index) const;
     Q_INVOKABLE void applyBeanPreset(int index);       // Sets all DYE fields from preset
     Q_INVOKABLE void saveBeanPresetFromCurrent(const QString& name);  // Creates or updates preset from current DYE

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -94,6 +94,8 @@ class Settings : public QObject {
 
     // Bean presets
     Q_PROPERTY(QVariantList beanPresets READ beanPresets NOTIFY beanPresetsChanged)
+    // Filtered view of beanPresets: only rows where showOnIdle == true. Each row gains
+    // an `originalIndex` field mapping back into beanPresets for selection/apply calls.
     Q_PROPERTY(QVariantList idleBeanPresets READ idleBeanPresets NOTIFY beanPresetsChanged)
     Q_PROPERTY(int selectedBeanPreset READ selectedBeanPreset WRITE setSelectedBeanPreset NOTIFY selectedBeanPresetChanged)
 
@@ -454,7 +456,7 @@ public:
     Q_INVOKABLE void removeBeanPreset(int index);
     Q_INVOKABLE void moveBeanPreset(int from, int to);
     Q_INVOKABLE void setBeanPresetShowOnIdle(int index, bool show);
-    Q_INVOKABLE QVariantList idleBeanPresets() const;  // Filtered subset with originalIndex field
+    QVariantList idleBeanPresets() const;              // see Q_PROPERTY above
     Q_INVOKABLE QVariantMap getBeanPreset(int index) const;
     Q_INVOKABLE void applyBeanPreset(int index);       // Sets all DYE fields from preset
     Q_INVOKABLE void saveBeanPresetFromCurrent(const QString& name);  // Creates or updates preset from current DYE

--- a/src/profile/recipeparams.cpp
+++ b/src/profile/recipeparams.cpp
@@ -253,9 +253,6 @@ QJsonObject RecipeParams::toJson() const {
     obj["tempHold"] = tempHold;
     obj["tempDecline"] = tempDecline;
 
-    // Editor type
-    obj["editorType"] = editorTypeToString(editorType);
-
     // BLE header
     if (preinfuseFrameCount >= 0)
         obj["preinfuseFrameCount"] = preinfuseFrameCount;

--- a/tests/mocks/McpTestFixture.h
+++ b/tests/mocks/McpTestFixture.h
@@ -59,9 +59,10 @@ struct McpTestFixture {
     DE1Device device;
     MachineState machineState;
     // Suppress expected warnings during ProfileManager construction — test env has
-    // no saved profile (falls back to default) and no ai.qrc (knowledge base missing).
+    // no saved profile (falls back to default), no ai.qrc (knowledge base missing),
+    // and may have stale favorites/currentProfile in real QSettings from the dev machine.
     // Filter must be declared before profileManager so it is constructed first and destroyed last.
-    ScopedWarningFilter constructionFilter{"Profile not found|Failed to load profile knowledge"};
+    ScopedWarningFilter constructionFilter{"Profile not found|Failed to load profile knowledge|refreshProfiles: .*stale"};
     ProfileManager profileManager;
     McpToolRegistry registry;
 

--- a/tests/tst_recipeparams.cpp
+++ b/tests/tst_recipeparams.cpp
@@ -60,7 +60,8 @@ private slots:
         QVERIFY(parsed.rampDownEnabled);
         QVERIFY(!parsed.flowExtractionUp);
         QVERIFY(parsed.secondFillEnabled);
-        QCOMPARE(parsed.editorType, EditorType::AFlow);
+        // editorType is intentionally not serialized to JSON (derived from profile title at load time)
+        QCOMPARE(parsed.editorType, EditorType::DFlow);  // default when absent from JSON
         QCOMPARE(parsed.preinfuseFrameCount, 3);
     }
 


### PR DESCRIPTION
## Summary

- **Root cause of #654**: Settings stored `currentProfile = "a_flow_medium.json"` (a filename that no longer exists). `loadProfile()` fell back to a hardcoded in-memory `loadDefaultProfile()` that created a profile titled "Default" with no type — opening the advanced editor instead of the correct recipe editor. The stale name was re-persisted to settings every restart.
- `refreshProfiles()` now validates all favorites and `currentProfile` against the known profile set at startup, removing stale entries and resetting `currentProfile` to the first valid favorite (or `"default"`)
- `loadProfile()` strips `.json` extension to prevent double-extension lookups when settings stored the filename with extension
- `loadProfile()` `!found` branch now emits a `profileLoadFailed` signal and resolves to `"default"` so the stale filename is not re-written to settings
- `loadDefaultProfile()` loads the real `:/profiles/default.json` instead of building a hardcoded in-memory profile that shadowed it
- Removed `recipe.editorType` from `RecipeParams::toJson()` — editor type is derived at runtime from filename/title; existing profiles lose the field on next save
- Removed `recipe.editorType` from all 7 built-in `d_flow_*` / `a_flow_*` JSON files

## Test plan

- [ ] Build and run on Mac
- [ ] Open Profiles page — stale "A-Flow Medium" / "D-Flow Default" favorites are gone after startup
- [ ] `mcp__decenza__settings_get` — `currentProfile` is no longer `"a_flow_medium.json"`
- [ ] Add a D-Flow or A-Flow profile as favorite, restart — it survives validation and opens the recipe editor
- [ ] Verify `d_flow_default.json` no longer contains `recipe.editorType` in its `recipe` block

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)