### PR TITLE
fix: normalize steam pressure across flow settings

### DIFF
--- a/src/machine/steamhealthtracker.cpp
+++ b/src/machine/steamhealthtracker.cpp
@@ -149,15 +149,17 @@ void SteamHealthTracker::clearHistory() {
 //
 // Baselines:
 //   Pressure: lowest normalized avgPressure across all sessions.
-//   Temperature: the current session's steamTemperature setting (target).
+//   Temperature: lowest measured avgTemperature across all sessions.
 //
 // Warning fires when current value has moved 60% of the way from baseline
 // toward the warn threshold (baseline x 3.0 for pressure, capped at 8 bar / 180°C
 // for temperature). Re-warns at most every 5 sessions.
 //
-// Auto-reset: If the newest session drops >= 30% of the range (relative to the
-// rolling average of recent sessions) toward the threshold, we assume a descale
-// happened and trim old sessions.
+// Auto-reset: Pressure only. If the newest session's normalized pressure drops
+// >= 30% of the range (relative to the rolling average of recent sessions),
+// we assume a descale happened and trim old sessions. Temperature is excluded
+// from auto-reset because temperature changes are driven by the heater setpoint,
+// not limescale — changing the steam temperature setting would spuriously trigger.
 
 void SteamHealthTracker::checkTrend(QList<SteamSessionSummary>& history,
                                      int steamFlow, int steamTemp) {
@@ -174,37 +176,38 @@ void SteamHealthTracker::checkTrend(QList<SteamSessionSummary>& history,
         baselinePressure = qMin(baselinePressure, normalizePressure(s.avgPressure, s.steamFlow));
     }
 
-    // Temperature baseline: the current session's target setting
-    double baselineTemp = static_cast<double>(steamTemp);
+    // Temperature baseline: lowest measured temperature across all sessions.
+    // This tracks real multi-session trends (scale buildup causes overshoot)
+    // rather than comparing against the current setting (which changes when
+    // the user adjusts their steam temperature preference).
+    double baselineTemp = history.first().avgTemperature;
+    for (const auto& s : history) {
+        baselineTemp = qMin(baselineTemp, s.avgTemperature);
+    }
 
     // Current: most recent session (normalized)
     double currentPressure = normalizePressure(history.first().avgPressure, history.first().steamFlow);
     double currentTemp = history.first().avgTemperature;
 
-    // --- Auto-reset on meaningful drop (likely descale) ---
+    // --- Auto-reset on meaningful pressure drop (likely descale) ---
+    // Only pressure is used for auto-reset detection. Temperature changes are
+    // driven by the heater setpoint, not limescale — a user changing their steam
+    // temperature setting would spuriously trigger a reset.
     bool autoReset = false;
     qsizetype recentCount = qMin(qsizetype(5), n - 1);
     if (recentCount > 0) {
-        double recentPressureSum = 0, recentTempSum = 0;
+        double recentPressureSum = 0;
         for (qsizetype i = 1; i <= recentCount; ++i) {
             recentPressureSum += normalizePressure(history[i].avgPressure, history[i].steamFlow);
-            recentTempSum += history[i].avgTemperature;
         }
         double recentAvgPressure = recentPressureSum / recentCount;
-        double recentAvgTemp = recentTempSum / recentCount;
 
         double pressureWarnLevel = qMin(baselinePressure * PRESSURE_WARN_MULTIPLIER, PRESSURE_HARD_LIMIT);
+        // Use baseline range so auto-reset fires even when recentAvg exceeds warn level
         double pressureRange = pressureWarnLevel - baselinePressure;
         if (pressureRange > 0) {
             double drop = recentAvgPressure - currentPressure;
             if (drop >= pressureRange * AUTO_RESET_DROP_THRESHOLD) {
-                autoReset = true;
-            }
-        }
-        double tempRange = TEMPERATURE_THRESHOLD - recentAvgTemp;
-        if (!autoReset && tempRange > 0) {
-            double drop = recentAvgTemp - currentTemp;
-            if (drop >= tempRange * AUTO_RESET_DROP_THRESHOLD) {
                 autoReset = true;
             }
         }
@@ -308,8 +311,11 @@ void SteamHealthTracker::updateCachedStats(const QList<SteamSessionSummary>& his
         m_baselinePressure = qMin(m_baselinePressure, normalizePressure(s.avgPressure, s.steamFlow));
     }
 
-    // Temperature baseline = current session's target setting
-    m_baselineTemperature = static_cast<double>(steamTemp);
+    // Temperature baseline = lowest measured temperature across all sessions
+    m_baselineTemperature = m_currentTemperature;
+    for (const auto& s : history) {
+        m_baselineTemperature = qMin(m_baselineTemperature, s.avgTemperature);
+    }
 }
 
 // --- QSettings JSON persistence ---

--- a/src/machine/steamhealthtracker.h
+++ b/src/machine/steamhealthtracker.h
@@ -101,7 +101,7 @@ private:
     static constexpr int MIN_DURATION_FOR_ANALYSIS = 20;     // minimum seconds — filters aborted cycles
     static constexpr int MIN_SESSIONS_FOR_TREND = 5;         // minimum comparable sessions
     static constexpr int MAX_HISTORY_SIZE = 150;             // sessions to keep
-    static constexpr double TREND_PROGRESS_THRESHOLD = 0.6;   // warn at 60% of the way from baseline to flow-relative threshold
+    static constexpr double TREND_PROGRESS_THRESHOLD = 0.6;   // warn at 60% of the way from baseline to warn level
     static constexpr double AUTO_RESET_DROP_THRESHOLD = 0.3;  // auto-reset baseline if drop >= 30% of range (likely descale)
     static constexpr int AUTO_RESET_KEEP_SESSIONS = 3;       // sessions to keep after auto-reset
     static constexpr double TRIM_SECONDS = 2.0;              // skip first 2s of samples

--- a/tests/tst_steamhealth.cpp
+++ b/tests/tst_steamhealth.cpp
@@ -349,21 +349,38 @@ private slots:
         QCOMPARE(tracker.currentPressure(), 3.2);
     }
 
-    void temperatureBaselineIsUserTarget() {
+    void temperatureBaselineIsLowestMeasured() {
         SteamHealthTracker tracker;
 
-        // Session with temp setting = 160
-        SteamDataModel model;
-        for (int j = 0; j < 40; ++j)
-            model.addSample(2.0 + j * 0.6, 2.0, 1.0, 165.0);  // actual 165, target 160
-
-        // Need 5 sessions for hasData
-        for (int i = 0; i < 5; ++i)
+        // Sessions with varying measured temperatures
+        // Session 1-3: measured 165°C
+        for (int i = 0; i < 3; ++i) {
+            SteamDataModel model;
+            for (int j = 0; j < 40; ++j)
+                model.addSample(2.0 + j * 0.6, 2.0, 1.0, 165.0);
             tracker.onSessionComplete(&model, 150, 160);
+        }
 
-        // Baseline temp should be the target setting (160), not the measured value (165)
-        QCOMPARE(tracker.baselineTemperature(), 160.0);
-        QCOMPARE(tracker.currentTemperature(), 165.0);
+        // Session 4: measured 158°C (lowest)
+        {
+            SteamDataModel model;
+            for (int j = 0; j < 40; ++j)
+                model.addSample(2.0 + j * 0.6, 2.0, 1.0, 158.0);
+            tracker.onSessionComplete(&model, 150, 160);
+        }
+
+        // Session 5: measured 162°C
+        {
+            SteamDataModel model;
+            for (int j = 0; j < 40; ++j)
+                model.addSample(2.0 + j * 0.6, 2.0, 1.0, 162.0);
+            tracker.onSessionComplete(&model, 150, 160);
+        }
+
+        QVERIFY(tracker.hasData());
+        // Baseline temp = lowest measured (158), not user setting (160)
+        QCOMPARE(tracker.baselineTemperature(), 158.0);
+        QCOMPARE(tracker.currentTemperature(), 162.0);
     }
 
     // ==========================================


### PR DESCRIPTION
## Summary
- Replace the `isComparable` flow/temperature filter with pressure normalization to a reference flow rate
- All sessions now contribute to trend detection regardless of steam flow setting changes
- Existing session history is preserved and reinterpreted with normalization (raw values stored, normalized at read time)

## Problem
Changing steam flow settings (e.g., from 0.8 to 1.5 mL/s) made all prior sessions "non-comparable," effectively resetting the health tracker history. Users who experiment with flow settings lost months of data.

## Solution
Linear normalization model derived from RO-water baseline data:
- `normalizedPressure = measuredPressure - 0.012 * (steamFlow - 150)`
- Flow 75 at 1.4 bar → normalizes to 2.3 bar (at reference flow 150)
- Flow 120 at 2.0 bar → normalizes to 2.36 bar
- Flow 150 at 2.4 bar → stays 2.4 bar (reference)

## Test plan
- [ ] Run `tst_steamhealth` — all tests pass
- [ ] On device: steam at different flow settings, verify normalized pressures are consistent in logs
- [ ] Verify existing session history is preserved after update
- [ ] MCP `steam_get_health` returns data even after flow setting changes

🤖 Generated with [Claude Code](https://claude.ai/code)