### PR TITLE
fix: suppress BLE writes when adjusting settings during active operation

### DIFF
--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -105,8 +105,7 @@ Page {
                                 Settings.selectedFlushPreset = index
                                 Settings.flushFlow = modelData.flow
                                 Settings.flushSeconds = modelData.seconds
-                                if (!isFlushing)
-                                    MainController.applyFlushSettings()
+                                MainController.applyFlushSettings()
                             }
                         }
                     }

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -105,7 +105,8 @@ Page {
                                 Settings.selectedFlushPreset = index
                                 Settings.flushFlow = modelData.flow
                                 Settings.flushSeconds = modelData.seconds
-                                MainController.applyFlushSettings()
+                                if (!isFlushing)
+                                    MainController.applyFlushSettings()
                             }
                         }
                     }

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -113,10 +113,9 @@ Page {
                             onClicked: {
                                 Settings.selectedWaterVessel = index
                                 Settings.waterVolume = modelData.volume
-                                Settings.waterVolumeMode = (modelData.mode || "weight")
+                                Settings.waterVolumeMode = (modelData.mode ?? "weight")
                                 Settings.hotWaterFlowRate = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
-                                if (!isDispensing)
-                                    MainController.applyHotWaterSettings()
+                                MainController.applyHotWaterSettings()
                             }
                         }
                     }

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -115,7 +115,8 @@ Page {
                                 Settings.waterVolume = modelData.volume
                                 Settings.waterVolumeMode = (modelData.mode || "weight")
                                 Settings.hotWaterFlowRate = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
-                                MainController.applyHotWaterSettings()
+                                if (!isDispensing)
+                                    MainController.applyHotWaterSettings()
                             }
                         }
                     }

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -381,7 +381,8 @@ Page {
                             onClicked: {
                                 var newTime = Math.max(5, Settings.steamTimeout - 5)
                                 Settings.steamTimeout = newTime
-                                MainController.startSteamHeating()
+                                if (!root.isSteaming)
+                                    MainController.startSteamHeating()
                             }
                         }
                     }
@@ -433,7 +434,8 @@ Page {
                             onClicked: {
                                 var newTime = Math.min(120, Settings.steamTimeout + 5)
                                 Settings.steamTimeout = newTime
-                                MainController.startSteamHeating()
+                                if (!root.isSteaming)
+                                    MainController.startSteamHeating()
                             }
                         }
                     }

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -260,7 +260,8 @@ Page {
                                     var flow = modelData.flow !== undefined ? modelData.flow : 150
                                     Settings.steamTimeout = modelData.duration
                                     Settings.steamFlow = flow
-                                    MainController.startSteamHeating()
+                                    if (!isSteaming)
+                                        MainController.startSteamHeating()
                                 }
                             }
                         }
@@ -381,7 +382,7 @@ Page {
                             onClicked: {
                                 var newTime = Math.max(5, Settings.steamTimeout - 5)
                                 Settings.steamTimeout = newTime
-                                if (!root.isSteaming)
+                                if (!isSteaming)
                                     MainController.startSteamHeating()
                             }
                         }
@@ -434,7 +435,7 @@ Page {
                             onClicked: {
                                 var newTime = Math.min(120, Settings.steamTimeout + 5)
                                 Settings.steamTimeout = newTime
-                                if (!root.isSteaming)
+                                if (!isSteaming)
                                     MainController.startSteamHeating()
                             }
                         }


### PR DESCRIPTION
## Summary

Fixes UI freeze on iPadOS 26.4 when pressing ±5s during steaming. Calling `startSteamHeating()` mid-steam was sending `setShotSettings` + `writeMMR` BLE commands to the DE1 while it was already running, causing the app to become unresponsive.

- **Steam ±5s buttons**: guard with `!isSteaming` — display updates immediately, BLE send suppressed during active steam
- **Steam pitcher pills**: same guard added (was an identical unguarded path in the same steaming view)
- **Hot water / flush live preset pills**: these are designed for mid-operation switching and are only reachable during the active operation, so the BLE send is kept unconditional (original behavior restored)
- Live steam flow control (`setSteamFlowImmediate`) is unaffected — it uses a separate single-MMR path
- Fix `waterVolumeMode || "weight"` → `?? "weight"` (empty string was being coerced to `"weight"`)

## Test plan

- [ ] Steam: press ±5s during steaming — display updates, no freeze
- [ ] Steam: press ±5s during heat-up (before steaming) — `startSteamHeating()` fires, updated timeout sent to machine
- [ ] Steam: switch pitcher preset during steaming — display updates, no freeze
- [ ] Hot water: tap a different vessel preset during dispensing — updates machine settings live
- [ ] Flush: tap a different preset during flushing — updates machine settings live
- [ ] Steam: adjust flow slider during steaming — still works (live flow path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)