### PR TITLE
fix: improve Visualizer upload parity with de1app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ logcat_*.txt
 -.zip
 .claude/
 .DS_Store
+/.codex_tmp

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1261,6 +1261,9 @@ void MainController::onShotEnded() {
     // Must run before stopCapture() so its debug output is included in the shot log.
     computeAutoFlowCalibration();
 
+    // Capture shot-end epoch now so uploads (including deferred pending uploads) use consistent time
+    m_pendingShotEpoch = QDateTime::currentSecsSinceEpoch();
+
     // Stop debug logging and get the captured log
     QString debugLog;
     if (m_shotDebugLogger) {
@@ -1390,7 +1393,7 @@ void MainController::onShotEnded() {
     // Auto-upload if enabled (do this first, before showing metadata page)
     if (m_settings->visualizerAutoUpload() && m_visualizer) {
         qDebug() << "  -> Auto-uploading to visualizer";
-        m_visualizer->uploadShot(m_shotDataModel, m_profileManager->currentProfilePtr(), duration, finalWeight, doseWeight, metadata, debugLog);
+        m_visualizer->uploadShot(m_shotDataModel, m_profileManager->currentProfilePtr(), duration, finalWeight, doseWeight, metadata, debugLog, m_pendingShotEpoch);
     }
 
     // Store pending shot data for later upload (user can re-upload with updated metadata)
@@ -1457,9 +1460,10 @@ void MainController::uploadPendingShot() {
 
     m_visualizer->uploadShot(m_shotDataModel, m_profileManager->currentProfilePtr(),
                              m_pendingShotDuration, m_pendingShotFinalWeight,
-                             m_pendingShotDoseWeight, metadata, m_pendingDebugLog);
+                             m_pendingShotDoseWeight, metadata, m_pendingDebugLog, m_pendingShotEpoch);
 
     m_hasPendingShot = false;
+    m_pendingDebugLog.clear();
 }
 
 void MainController::generateFakeShotData() {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1267,6 +1267,7 @@ void MainController::onShotEnded() {
         m_shotDebugLogger->stopCapture();
         debugLog = m_shotDebugLogger->getCapturedLog();
     }
+    m_pendingDebugLog = debugLog;
 
     // Build metadata for history
     ShotMetadata metadata;
@@ -1389,7 +1390,7 @@ void MainController::onShotEnded() {
     // Auto-upload if enabled (do this first, before showing metadata page)
     if (m_settings->visualizerAutoUpload() && m_visualizer) {
         qDebug() << "  -> Auto-uploading to visualizer";
-        m_visualizer->uploadShot(m_shotDataModel, m_profileManager->currentProfilePtr(), duration, finalWeight, doseWeight, metadata);
+        m_visualizer->uploadShot(m_shotDataModel, m_profileManager->currentProfilePtr(), duration, finalWeight, doseWeight, metadata, debugLog);
     }
 
     // Store pending shot data for later upload (user can re-upload with updated metadata)
@@ -1456,7 +1457,7 @@ void MainController::uploadPendingShot() {
 
     m_visualizer->uploadShot(m_shotDataModel, m_profileManager->currentProfilePtr(),
                              m_pendingShotDuration, m_pendingShotFinalWeight,
-                             m_pendingShotDoseWeight, metadata);
+                             m_pendingShotDoseWeight, metadata, m_pendingDebugLog);
 
     m_hasPendingShot = false;
 }

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -260,6 +260,7 @@ private:
     double m_pendingShotDuration = 0;
     double m_pendingShotFinalWeight = 0;
     double m_pendingShotDoseWeight = 0;
+    qint64 m_pendingShotEpoch = 0;
     QString m_pendingDebugLog;
     qint64 m_lastSavedShotId = 0;  // ID of most recently saved shot (for post-shot review)
     bool m_savingShot = false;     // Guard against overlapping async saves

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -260,6 +260,7 @@ private:
     double m_pendingShotDuration = 0;
     double m_pendingShotFinalWeight = 0;
     double m_pendingShotDoseWeight = 0;
+    QString m_pendingDebugLog;
     qint64 m_lastSavedShotId = 0;  // ID of most recently saved shot (for post-shot review)
     bool m_savingShot = false;     // Guard against overlapping async saves
 

--- a/src/history/shotfileparser.cpp
+++ b/src/history/shotfileparser.cpp
@@ -79,8 +79,13 @@ ShotFileParser::ParseResult ShotFileParser::parse(const QByteArray& fileContents
         result.record.temperatureMix = toPointVector(elapsed, tempMix);
     if (!resistance.isEmpty())
         result.record.resistance = toPointVector(elapsed, resistance);
-    if (!waterDispensed.isEmpty())
+    if (!waterDispensed.isEmpty()) {
+        // de1app stores espresso_water_dispensed at 0.1× scale (tenths of ml); normalize to actual ml
+        // so that all shots in the DB use the same unit regardless of import source.
+        for (auto& v : waterDispensed)
+            v *= 10.0;
         result.record.waterDispensed = toPointVector(elapsed, waterDispensed);
+    }
     if (!flowWeight.isEmpty())
         result.record.weightFlowRate = toPointVector(elapsed, flowWeight);
 

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -101,7 +101,8 @@ void VisualizerUploader::uploadShot(ShotDataModel* shotData,
                                      double duration,
                                      double finalWeight,
                                      double doseWeight,
-                                     const ShotMetadata& metadata)
+                                     const ShotMetadata& metadata,
+                                     const QString& debugLog)
 {
     if (!shotData) {
         emit uploadFailed("No shot data available");
@@ -112,7 +113,7 @@ void VisualizerUploader::uploadShot(ShotDataModel* shotData,
     if (!validateUpload(beverageType, duration))
         return;
 
-    QByteArray jsonData = buildShotJson(shotData, profile, finalWeight, doseWeight, metadata);
+    QByteArray jsonData = buildShotJson(shotData, profile, finalWeight, doseWeight, metadata, debugLog);
     sendUpload(jsonData);
 }
 
@@ -380,7 +381,8 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
                                               const Profile* profile,
                                               double finalWeight,
                                               double doseWeight,
-                                              const ShotMetadata& metadata)
+                                              const ShotMetadata& metadata,
+                                              const QString& debugLog)
 {
     QJsonObject root;
 
@@ -463,19 +465,39 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
         // Interpolate cumulative weight to match elapsed timestamps
         totals["weight"] = interpolateGoalData(cumulativeWeightData, pressureData);
     }
-    // Water dispensed (cumulative flow volume in ml)
+    // Water dispensed: de1app stores espresso_water_dispensed at 0.1× scale (tenths of ml),
+    // so Visualizer expects values ~4.0 for a 40ml shot, not 40.0. Apply the same scaling.
     const auto& waterDispensedData = shotData->waterDispensedData();
     if (!waterDispensedData.isEmpty()) {
-        totals["water_dispensed"] = interpolateGoalData(waterDispensedData, pressureData);
+        QJsonArray waterDispensedRaw = interpolateGoalData(waterDispensedData, pressureData);
+        QJsonArray waterDispensedScaled;
+        for (const auto& v : waterDispensedRaw)
+            waterDispensedScaled.append(v.toDouble() * 0.1);
+        totals["water_dispensed"] = waterDispensedScaled;
     }
     root["totals"] = totals;
 
-    // Resistance object (pressure / flow²)
+    // Resistance object: P/flow² (DE1 flow) and P/flow_weight² (scale flow, de1app calls this by_weight)
     const auto& resistanceData = shotData->resistanceData();
-    if (!resistanceData.isEmpty()) {
+    const auto& weightFlowRateData = shotData->weightFlowRateData();
+    {
         QJsonObject resistance;
-        resistance["resistance"] = interpolateGoalData(resistanceData, pressureData);
-        root["resistance"] = resistance;
+        if (!resistanceData.isEmpty())
+            resistance["resistance"] = interpolateGoalData(resistanceData, pressureData);
+        if (!weightFlowRateData.isEmpty() && !pressureData.isEmpty()) {
+            QJsonArray fwInterp = interpolateGoalData(weightFlowRateData, pressureData);
+            QJsonArray resByWeight;
+            for (qsizetype i = 0; i < pressureData.size(); ++i) {
+                double fw = fwInterp[i].toDouble();
+                double res = 0.0;
+                if (fw > 0.05)
+                    res = qMin(pressureData[i].y() / (fw * fw), 19.0);
+                resByWeight.append(res);
+            }
+            resistance["by_weight"] = resByWeight;
+        }
+        if (!resistance.isEmpty())
+            root["resistance"] = resistance;
     }
 
     // State change array (de1app format: alternating sign value at each frame transition)
@@ -499,6 +521,30 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
             stateChange.append(stateVal);
         }
         root["state_change"] = stateChange;
+    }
+
+    // Scale object: raw weight series at native sample times (for connectivity debugging)
+    // de1app sends scale_raw_weight/arrival; we send what we have (cumulative weight + flow rate)
+    {
+        QJsonObject scale;
+        scale["espresso_start"] = root["clock"].toDouble();
+        const auto& rawWeightData = shotData->cumulativeWeightData();
+        if (!rawWeightData.isEmpty()) {
+            QJsonArray weights, arrivals;
+            for (const auto& pt : rawWeightData) {
+                arrivals.append(pt.x());
+                weights.append(pt.y());
+            }
+            scale["weight_arrival"] = arrivals;
+            scale["weight"] = weights;
+        }
+        if (!weightFlowRateData.isEmpty()) {
+            QJsonArray flows;
+            for (const auto& pt : weightFlowRateData)
+                flows.append(pt.y());
+            scale["weight_flow"] = flows;
+        }
+        root["scale"] = scale;
     }
 
     // Meta object (de1app format)
@@ -541,7 +587,13 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
 
     // Weights
     double beanWeight = metadata.beanWeight > 0 ? metadata.beanWeight : doseWeight;
+    // Use user-entered weight first, then scale weight, then firmware volume (ml ≈ g for espresso)
     double drinkWeight = metadata.drinkWeight > 0 ? metadata.drinkWeight : finalWeight;
+    if (drinkWeight <= 0) {
+        const auto& wdData = shotData->waterDispensedData();
+        if (!wdData.isEmpty())
+            drinkWeight = wdData.last().y();  // ml from flow integration
+    }
     if (beanWeight > 0)
         meta["in"] = beanWeight;
     if (drinkWeight > 0)
@@ -605,6 +657,8 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
         machineState["headless"] = m_device->isHeadless() ? 1 : 0;
         data["machine_state"] = machineState;
     }
+    if (!debugLog.isEmpty())
+        data["debug_log"] = debugLog;
     app["data"] = data;
 
     root["app"] = app;
@@ -981,12 +1035,66 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
     temperature["goal"] = interpolateGoalData(tempGoalData, pressureData);
     root["temperature"] = temperature;
 
-    // Totals object (weight)
+    // Totals object
     QJsonObject totals;
     if (!weightData.isEmpty()) {
         totals["weight"] = interpolateGoalData(weightData, pressureData);
     }
+    // Water dispensed: scale by 0.1 to match de1app's espresso_water_dispensed convention
+    QVector<QPointF> waterDispensedData = toPointVector(shotData["waterDispensed"].toList());
+    if (!waterDispensedData.isEmpty()) {
+        QJsonArray waterDispensedRaw = interpolateGoalData(waterDispensedData, pressureData);
+        QJsonArray waterDispensedScaled;
+        for (const auto& v : waterDispensedRaw)
+            waterDispensedScaled.append(v.toDouble() * 0.1);
+        totals["water_dispensed"] = waterDispensedScaled;
+    }
     root["totals"] = totals;
+
+    // Resistance object: P/flow² (DE1) and P/flow_weight² (scale)
+    QVector<QPointF> histWeightFlowData = toPointVector(shotData["weightFlowRate"].toList());
+    {
+        QVector<QPointF> histResData = toPointVector(shotData["resistance"].toList());
+        QJsonObject resistance;
+        if (!histResData.isEmpty())
+            resistance["resistance"] = interpolateGoalData(histResData, pressureData);
+        if (!histWeightFlowData.isEmpty() && !pressureData.isEmpty()) {
+            QJsonArray fwInterp = interpolateGoalData(histWeightFlowData, pressureData);
+            QJsonArray resByWeight;
+            for (qsizetype i = 0; i < pressureData.size(); ++i) {
+                double fw = fwInterp[i].toDouble();
+                double res = 0.0;
+                if (fw > 0.05)
+                    res = qMin(pressureData[i].y() / (fw * fw), 19.0);
+                resByWeight.append(res);
+            }
+            resistance["by_weight"] = resByWeight;
+        }
+        if (!resistance.isEmpty())
+            root["resistance"] = resistance;
+    }
+
+    // Scale object: raw weight series at native sample times
+    {
+        QJsonObject scale;
+        scale["espresso_start"] = shotData["timestamp"].toDouble();
+        if (!weightData.isEmpty()) {
+            QJsonArray weights, arrivals;
+            for (const auto& pt : weightData) {
+                arrivals.append(pt.x());
+                weights.append(pt.y());
+            }
+            scale["weight_arrival"] = arrivals;
+            scale["weight"] = weights;
+        }
+        if (!histWeightFlowData.isEmpty()) {
+            QJsonArray flows;
+            for (const auto& pt : histWeightFlowData)
+                flows.append(pt.y());
+            scale["weight_flow"] = flows;
+        }
+        root["scale"] = scale;
+    }
 
     // State change array from history phase markers
     QVariantList phases = shotData["phases"].toList();
@@ -1051,9 +1159,11 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
     if (!grinderSetting.isEmpty()) grinder["setting"] = grinderSetting;
     meta["grinder"] = grinder;
 
-    // Weights
+    // Weights: user-entered first, then scale, then firmware volume fallback
     double doseWeight = shotData["doseWeight"].toDouble();
     double finalWeight = shotData["finalWeight"].toDouble();
+    if (finalWeight <= 0 && !waterDispensedData.isEmpty())
+        finalWeight = waterDispensedData.last().y();  // ml from flow integration
     if (doseWeight > 0) meta["in"] = doseWeight;
     if (finalWeight > 0) meta["out"] = finalWeight;
     meta["time"] = shotData["duration"].toDouble();
@@ -1103,6 +1213,9 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
 
     QJsonObject data;
     data["settings"] = settings;
+    QString debugLog = shotData["debugLog"].toString();
+    if (!debugLog.isEmpty())
+        data["debug_log"] = debugLog;
     app["data"] = data;
 
     root["app"] = app;

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -102,7 +102,8 @@ void VisualizerUploader::uploadShot(ShotDataModel* shotData,
                                      double finalWeight,
                                      double doseWeight,
                                      const ShotMetadata& metadata,
-                                     const QString& debugLog)
+                                     const QString& debugLog,
+                                     qint64 shotEpoch)
 {
     if (!shotData) {
         emit uploadFailed("No shot data available");
@@ -113,7 +114,7 @@ void VisualizerUploader::uploadShot(ShotDataModel* shotData,
     if (!validateUpload(beverageType, duration))
         return;
 
-    QByteArray jsonData = buildShotJson(shotData, profile, finalWeight, doseWeight, metadata, debugLog);
+    QByteArray jsonData = buildShotJson(shotData, profile, finalWeight, doseWeight, metadata, debugLog, shotEpoch);
     sendUpload(jsonData);
 }
 
@@ -382,7 +383,8 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
                                               double finalWeight,
                                               double doseWeight,
                                               const ShotMetadata& metadata,
-                                              const QString& debugLog)
+                                              const QString& debugLog,
+                                              qint64 shotEpoch)
 {
     QJsonObject root;
 
@@ -393,14 +395,15 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
     const auto& pressureGoalData = shotData->pressureGoalData();
     const auto& flowGoalData = shotData->flowGoalData();
     const auto& temperatureGoalData = shotData->temperatureGoalData();
-    const auto& weightFlowRateData = shotData->weightFlowRateData();  // Flow rate from scale (g/s)
-    const auto& cumulativeWeightData = shotData->cumulativeWeightData();  // Cumulative weight (g)
+    const auto& weightFlowRateData = shotData->weightFlowRateData();   // Scale flow rate (g/s)
+    const auto& darcyResistanceData = shotData->darcyResistanceData(); // P/flow² (Darcy formula, matches de1app)
+    const auto& cumulativeWeightData = shotData->cumulativeWeightData(); // Cumulative weight (g)
 
     // Use de1app version 2 format
     root["version"] = 2;
 
-    // Timestamps
-    qint64 clockTime = QDateTime::currentSecsSinceEpoch();
+    // Timestamps — use the caller-supplied shot epoch so pending uploads don't use upload time
+    qint64 clockTime = shotEpoch > 0 ? shotEpoch : QDateTime::currentSecsSinceEpoch();
     root["clock"] = clockTime;
     root["timestamp"] = clockTime;
     root["date"] = QDateTime::currentDateTime().toString(Qt::ISODate);
@@ -477,9 +480,9 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
     }
     root["totals"] = totals;
 
-    // Resistance object: P/flow² (DE1 flow) and P/flow_weight² (scale flow, de1app calls this by_weight)
-    const auto& resistanceData = shotData->resistanceData();
-    const auto& weightFlowRateData = shotData->weightFlowRateData();
+    // Resistance object: P/flow² (Darcy formula, matches de1app's espresso_resistance) and
+    // P/flow_weight² (scale flow, de1app calls this espresso_resistance_weight → by_weight)
+    const auto& resistanceData = darcyResistanceData;  // use Darcy P/flow² to match de1app
     {
         QJsonObject resistance;
         if (!resistanceData.isEmpty())
@@ -524,14 +527,14 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
     }
 
     // Scale object: raw weight series at native sample times (for connectivity debugging)
-    // de1app sends scale_raw_weight/arrival; we send what we have (cumulative weight + flow rate)
-    {
+    // de1app sends scale_raw_weight/arrival (raw BLE readings); we send processed cumulative weight.
+    // Only emit if there is actual scale data.
+    if (!cumulativeWeightData.isEmpty() || !weightFlowRateData.isEmpty()) {
         QJsonObject scale;
-        scale["espresso_start"] = root["clock"].toDouble();
-        const auto& rawWeightData = shotData->cumulativeWeightData();
-        if (!rawWeightData.isEmpty()) {
+        scale["espresso_start"] = clockTime;  // shot-end epoch (consistent with history path)
+        if (!cumulativeWeightData.isEmpty()) {
             QJsonArray weights, arrivals;
-            for (const auto& pt : rawWeightData) {
+            for (const auto& pt : cumulativeWeightData) {
                 arrivals.append(pt.x());
                 weights.append(pt.y());
             }
@@ -587,12 +590,12 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
 
     // Weights
     double beanWeight = metadata.beanWeight > 0 ? metadata.beanWeight : doseWeight;
-    // Use user-entered weight first, then scale weight, then firmware volume (ml ≈ g for espresso)
+    // Use user-entered weight first, then scale weight, then app's flow-integrated volume (ml ≈ g for espresso)
     double drinkWeight = metadata.drinkWeight > 0 ? metadata.drinkWeight : finalWeight;
     if (drinkWeight <= 0) {
         const auto& wdData = shotData->waterDispensedData();
         if (!wdData.isEmpty())
-            drinkWeight = wdData.last().y();  // ml from flow integration
+            drinkWeight = wdData.last().y();  // actual ml from flow integration, not scaled
     }
     if (beanWeight > 0)
         meta["in"] = beanWeight;
@@ -1051,10 +1054,11 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
     }
     root["totals"] = totals;
 
-    // Resistance object: P/flow² (DE1) and P/flow_weight² (scale)
+    // Resistance object: P/flow² (Darcy, matches de1app's espresso_resistance) and
+    // P/flow_weight² (scale flow, de1app calls this espresso_resistance_weight → by_weight)
     QVector<QPointF> histWeightFlowData = toPointVector(shotData["weightFlowRate"].toList());
     {
-        QVector<QPointF> histResData = toPointVector(shotData["resistance"].toList());
+        QVector<QPointF> histResData = toPointVector(shotData["darcyResistance"].toList());
         QJsonObject resistance;
         if (!histResData.isEmpty())
             resistance["resistance"] = interpolateGoalData(histResData, pressureData);
@@ -1074,8 +1078,8 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
             root["resistance"] = resistance;
     }
 
-    // Scale object: raw weight series at native sample times
-    {
+    // Scale object: raw weight series at native sample times. Only emit if there is scale data.
+    if (!weightData.isEmpty() || !histWeightFlowData.isEmpty()) {
         QJsonObject scale;
         scale["espresso_start"] = shotData["timestamp"].toDouble();
         if (!weightData.isEmpty()) {
@@ -1159,11 +1163,11 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
     if (!grinderSetting.isEmpty()) grinder["setting"] = grinderSetting;
     meta["grinder"] = grinder;
 
-    // Weights: user-entered first, then scale, then firmware volume fallback
+    // Weights: use stored final weight from history; fall back to flow-integrated volume if missing
     double doseWeight = shotData["doseWeight"].toDouble();
     double finalWeight = shotData["finalWeight"].toDouble();
     if (finalWeight <= 0 && !waterDispensedData.isEmpty())
-        finalWeight = waterDispensedData.last().y();  // ml from flow integration
+        finalWeight = waterDispensedData.last().y();  // actual ml (normalized at import)
     if (doseWeight > 0) meta["in"] = doseWeight;
     if (finalWeight > 0) meta["out"] = finalWeight;
     meta["time"] = shotData["duration"].toDouble();

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -52,7 +52,8 @@ public:
                                  double duration,
                                  double finalWeight = 0,
                                  double doseWeight = 0,
-                                 const ShotMetadata& metadata = ShotMetadata());
+                                 const ShotMetadata& metadata = ShotMetadata(),
+                                 const QString& debugLog = QString());
 
     // Upload a shot from history (takes QVariantMap from ShotHistoryStorage::getShot())
     Q_INVOKABLE void uploadShotFromHistory(const QVariantMap& shotData);
@@ -82,7 +83,8 @@ private:
                              const Profile* profile,
                              double finalWeight,
                              double doseWeight,
-                             const ShotMetadata& metadata);
+                             const ShotMetadata& metadata,
+                             const QString& debugLog);
 
     QJsonObject buildVisualizerProfileJson(const Profile* profile);
     QByteArray buildMultipartData(const QByteArray& jsonData, const QString& boundary);

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -53,7 +53,8 @@ public:
                                  double finalWeight = 0,
                                  double doseWeight = 0,
                                  const ShotMetadata& metadata = ShotMetadata(),
-                                 const QString& debugLog = QString());
+                                 const QString& debugLog = QString(),
+                                 qint64 shotEpoch = 0);
 
     // Upload a shot from history (takes QVariantMap from ShotHistoryStorage::getShot())
     Q_INVOKABLE void uploadShotFromHistory(const QVariantMap& shotData);
@@ -84,7 +85,8 @@ private:
                              double finalWeight,
                              double doseWeight,
                              const ShotMetadata& metadata,
-                             const QString& debugLog);
+                             const QString& debugLog,
+                             qint64 shotEpoch = 0);
 
     QJsonObject buildVisualizerProfileJson(const Profile* profile);
     QByteArray buildMultipartData(const QByteArray& jsonData, const QString& boundary);


### PR DESCRIPTION
## Summary

- **Fix `water_dispensed` 10× scaling bug**: de1app stores `espresso_water_dispensed` at 0.1× scale (tenths of ml); apply same scaling before upload so Visualizer displays the correct volume
- **Add `water_dispensed` to history re-uploads**: was previously missing from `buildHistoryShotJson`
- **Add `resistance.by_weight`**: P/flow_weight² using scale-derived flow rate (g/s), matching de1app's `resistance_weight` field — both live and history paths
- **Add `scale` object**: raw weight series at native scale sample times (`weight`, `weight_arrival`, `weight_flow`, `espresso_start`), matching de1app format — both paths
- **Add `meta.out` firmware volume fallback**: when scale weight is 0/missing (e.g. scale disconnects mid-shot), fall back to `waterDispensed` integration volume — both paths
- **Embed `debug_log` in `app.data`**: shot debug log is now uploaded with every shot so support investigations don't require manually retrieving logs — both paths
- **Store `m_pendingDebugLog`** in `MainController` so the debug log is available for deferred (post-metadata) re-uploads

## Test plan
- [ ] Pull down branch and do a live shot — confirm Visualizer shows `resistance.by_weight` curve and correct `water_dispensed` volume
- [ ] Re-upload a shot from history — confirm same fields present and `debugLog` from DB is included
- [ ] Shot with scale disconnect mid-shot — confirm `meta.out` falls back to firmware volume instead of 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)