### PR TITLE
feat: PostShotReview header improvements + skip-first-frame quality badge

### DIFF
--- a/qml/components/QualityBadges.qml
+++ b/qml/components/QualityBadges.qml
@@ -13,6 +13,7 @@ Item {
     required property bool channelingDetected
     required property bool temperatureUnstable
     required property bool grindIssueDetected
+    required property bool skipFirstFrameDetected
 
     signal summaryRequested()
 
@@ -129,9 +130,44 @@ Item {
             }
         }
 
+        // Skip-first-frame badge (red) — DE1 firmware bug or very short first step
+        Rectangle {
+            visible: root.skipFirstFrameDetected
+            width: skipFrameRow.width + Theme.spacingMedium * 2
+            height: Theme.scaled(28)
+            radius: Theme.scaled(14)
+            color: Qt.rgba(Theme.errorColor.r, Theme.errorColor.g, Theme.errorColor.b, 0.15)
+            border.color: Theme.errorColor
+            border.width: Theme.scaled(1)
+
+            Accessible.role: Accessible.StaticText
+            Accessible.name: skipFrameText.text
+            Accessible.focusable: true
+
+            Row {
+                id: skipFrameRow
+                anchors.centerIn: parent
+                spacing: Theme.scaled(4)
+                Rectangle {
+                    width: Theme.scaled(8); height: Theme.scaled(8); radius: Theme.scaled(4)
+                    color: Theme.errorColor; anchors.verticalCenter: parent.verticalCenter
+                    Accessible.ignored: true
+                }
+                Tr {
+                    id: skipFrameText
+                    key: "badges.skipFirstFrame"
+                    fallback: "First step skipped"
+                    font: Theme.captionFont
+                    color: Theme.errorColor
+                    anchors.verticalCenter: parent.verticalCenter
+                    Accessible.ignored: true
+                }
+            }
+        }
+
         // Clean extraction badge (green) — only shown when no flags are set
         Rectangle {
-            visible: !root.channelingDetected && !root.temperatureUnstable && !root.grindIssueDetected
+            visible: !root.channelingDetected && !root.temperatureUnstable && !root.grindIssueDetected && !root.skipFirstFrameDetected
             width: cleanRow.width + Theme.spacingMedium * 2
             height: Theme.scaled(28)
             radius: Theme.scaled(14)

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -227,7 +227,7 @@ Page {
         editGrinderBurrs !== (editShotData.grinderBurrs || "") ||
         editGrinderSetting !== (editShotData.grinderSetting || "") ||
         editBarista !== (editShotData.barista || "") ||
-        editDoseWeight !== (editShotData.doseWeight ?? 0) ||
+        editDoseWeight !== ((editShotData.doseWeight > 0) ? editShotData.doseWeight : Settings.dyeBeanWeight) ||
         editDrinkWeight !== (editShotData.finalWeight ?? 0) ||
         editDrinkTds !== (editShotData.drinkTds ?? 0) ||
         editDrinkEy !== (editShotData.drinkEy ?? 0) ||

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -270,10 +270,10 @@ Page {
         Settings.dyeGrinderBurrs = editGrinderBurrs
         Settings.dyeGrinderSetting = editGrinderSetting
         Settings.dyeBarista = editBarista
-        Settings.dyeBeanWeight = editDoseWeight
-        Settings.dyeDrinkWeight = editDrinkWeight
-        Settings.dyeDrinkTds = editDrinkTds
-        Settings.dyeDrinkEy = editDrinkEy
+        if (editDoseWeight > 0) Settings.dyeBeanWeight = editDoseWeight
+        if (editDrinkWeight > 0) Settings.dyeDrinkWeight = editDrinkWeight
+        if (editDrinkTds > 0) Settings.dyeDrinkTds = editDrinkTds
+        if (editDrinkEy > 0) Settings.dyeDrinkEy = editDrinkEy
         // Note: enjoyment and notes are NOT synced back - they're shot-specific
         // Note: reload deferred to onShotMetadataUpdated to avoid race with async write
     }

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -465,7 +465,7 @@ Page {
                                 if (typeof Refractometer !== "undefined" && Refractometer)
                                     Refractometer.requestMeasurement()
                             } else {
-                                BLEManager.tryDirectConnectToRefractometer()
+                                BLEManager.scanForDevices()
                             }
                         }
                     }

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -131,12 +131,13 @@ Page {
                 MainController.shotHistory.requestReanalyzeBadges(shotId)
             }
         }
-        function onShotBadgesUpdated(shotId, channeling, tempUnstable, grindIssue) {
+        function onShotBadgesUpdated(shotId, channeling, tempUnstable, grindIssue, skipFirstFrame) {
             if (shotId !== postShotReviewPage.editShotId) return
             var updated = Object.assign({}, editShotData)
             updated.channelingDetected = channeling
             updated.temperatureUnstable = tempUnstable
             updated.grindIssueDetected = grindIssue
+            updated.skipFirstFrameDetected = skipFirstFrame
             editShotData = updated
         }
         function onShotMetadataUpdated(shotId, success) {
@@ -327,7 +328,7 @@ Page {
             width: parent.width
             spacing: Theme.scaled(6)
 
-            // Header: Profile (Temp) + Basic/Advanced toggle
+            // Header: Profile (Temp) + date + quality badges + sparkle + Read TDS + Basic/Advanced toggle
             RowLayout {
                 Layout.fillWidth: true
                 spacing: Theme.spacingMedium
@@ -337,29 +338,132 @@ Page {
                     Layout.fillWidth: true
                     spacing: Theme.scaled(2)
 
-                    Text {
-                        textFormat: Text.RichText
-                        text: {
-                            var name = editShotData.profileName || ""
-                            var t = editShotData.temperatureOverride
-                            var result
-                            if (t !== undefined && t !== null && t > 0) {
-                                result = name + " (" + Math.round(t) + "\u00B0C)"
-                            } else {
-                                result = name
-                            }
-                            return Theme.replaceEmojiWithImg(result, Theme.titleFont.pixelSize)
-                        }
-                        font: Theme.titleFont
-                        color: Theme.textColor
+                    RowLayout {
                         Layout.fillWidth: true
-                        elide: Text.ElideRight
+                        spacing: Theme.spacingSmall
+
+                        Text {
+                            textFormat: Text.RichText
+                            text: {
+                                var name = editShotData.profileName || ""
+                                var t = editShotData.temperatureOverride
+                                var result
+                                if (t !== undefined && t !== null && t > 0) {
+                                    result = name + " (" + Math.round(t) + "\u00B0C)"
+                                } else {
+                                    result = name
+                                }
+                                return Theme.replaceEmojiWithImg(result, Theme.titleFont.pixelSize)
+                            }
+                            font: Theme.titleFont
+                            color: Theme.textColor
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                        }
+
+                        Text {
+                            text: editShotData.dateTime || ""
+                            font: Theme.labelFont
+                            color: Theme.textSecondaryColor
+                            elide: Text.ElideRight
+                            Layout.maximumWidth: postShotReviewPage.width * 0.35
+                        }
+
+                        QualityBadges {
+                            visible: !!(editShotData.profileKbId)
+                            Layout.fillWidth: false
+                            Layout.maximumWidth: postShotReviewPage.width * 0.5
+                            channelingDetected: editShotData.channelingDetected ?? false
+                            temperatureUnstable: editShotData.temperatureUnstable ?? false
+                            grindIssueDetected: editShotData.grindIssueDetected ?? false
+                            skipFirstFrameDetected: editShotData.skipFirstFrameDetected ?? false
+                            onSummaryRequested: reviewAnalysisDialog.open()
+                        }
+
+                        ShotAnalysisDialog {
+                            id: reviewAnalysisDialog
+                            shotData: editShotData
+                        }
+                    }
+                }
+
+                // KB sparkle button — opens the profile knowledge base
+                Image {
+                    id: headerSparkle
+                    visible: !!(editShotData.profileKbId)
+                    source: "qrc:/icons/sparkle.svg"
+                    sourceSize.width: Theme.scaled(18)
+                    sourceSize.height: Theme.scaled(18)
+                    Layout.alignment: Qt.AlignVCenter
+                    opacity: headerSparkleArea.containsMouse ? 1.0 : 0.6
+                    Accessible.ignored: true
+
+                    layer.enabled: true
+                    layer.smooth: true
+                    layer.effect: MultiEffect {
+                        colorization: 1.0
+                        colorizationColor: Theme.textSecondaryColor
                     }
 
+                    AccessibleMouseArea {
+                        id: headerSparkleArea
+                        anchors.fill: parent
+                        anchors.margins: Theme.scaled(-8)
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        accessibleName: TranslationManager.translate("profileselector.accessible.view_knowledge", "View AI knowledge base")
+                        accessibleItem: headerSparkle
+                        onAccessibleClicked: {
+                            shotKnowledgeDialog.profileTitle = editShotData.profileName || ""
+                            shotKnowledgeDialog.content = ProfileManager.profileKnowledgeContent(editShotData.profileName)
+                            shotKnowledgeDialog.open()
+                        }
+                    }
+                }
+
+                // Read TDS button (R2 refractometer)
+                Rectangle {
+                    id: readTdsButton
+                    property bool refConnected: BLEManager.refractometerConnected
+                    property bool refMeasuring: refConnected && typeof Refractometer !== "undefined" && Refractometer && Refractometer.measuring
+                    visible: Settings.savedRefractometerAddress !== ""
+                    Layout.preferredWidth: Theme.scaled(80)
+                    Layout.preferredHeight: Theme.scaled(36)
+                    Layout.alignment: Qt.AlignVCenter
+                    radius: Theme.scaled(12)
+                    color: Theme.surfaceColor
+                    border.width: 1
+                    border.color: Theme.textSecondaryColor
+                    opacity: refMeasuring ? 0.5 : 1.0
+                    Accessible.ignored: true
+
                     Text {
-                        text: editShotData.dateTime || ""
-                        font: Theme.labelFont
-                        color: Theme.textSecondaryColor
+                        anchors.centerIn: parent
+                        text: {
+                            if (!readTdsButton.refConnected) return TranslationManager.translate("postshotreview.refractometer.off", "R2 Off")
+                            if (readTdsButton.refMeasuring) return TranslationManager.translate("postshotreview.refractometer.measuring", "...")
+                            return TranslationManager.translate("postshotreview.refractometer.readTds", "Read TDS")
+                        }
+                        color: Theme.textColor
+                        font.pixelSize: Theme.scaled(13)
+                        Accessible.ignored: true
+                    }
+
+                    AccessibleMouseArea {
+                        anchors.fill: parent
+                        accessibleName: readTdsButton.refConnected
+                            ? TranslationManager.translate("postshotreview.readTdsFromRefractometer", "Read TDS from refractometer")
+                            : TranslationManager.translate("postshotreview.reconnectRefractometer", "Reconnect refractometer")
+                        accessibleItem: readTdsButton
+                        enabled: !readTdsButton.refMeasuring
+                        onAccessibleClicked: {
+                            if (readTdsButton.refConnected) {
+                                if (typeof Refractometer !== "undefined" && Refractometer)
+                                    Refractometer.requestMeasurement()
+                            } else {
+                                BLEManager.tryDirectConnectToRefractometer()
+                            }
+                        }
                     }
                 }
 
@@ -529,20 +633,6 @@ Page {
                 visible: !!(editShotData.pressure && editShotData.pressure.length > 0)
             }
 
-            QualityBadges {
-                Layout.fillWidth: true
-                visible: !!(editShotData.pressure && editShotData.pressure.length > 0) && !!(editShotData.profileKbId)
-                channelingDetected: editShotData.channelingDetected ?? false
-                temperatureUnstable: editShotData.temperatureUnstable ?? false
-                grindIssueDetected: editShotData.grindIssueDetected ?? false
-                onSummaryRequested: reviewAnalysisDialog.open()
-            }
-
-            ShotAnalysisDialog {
-                id: reviewAnalysisDialog
-                shotData: editShotData
-            }
-
             // Phase summary panel (advanced mode only)
             PhaseSummaryPanel {
                 Layout.fillWidth: true
@@ -550,12 +640,10 @@ Page {
                 visible: postShotReviewPage.advancedMode && (editShotData.phaseSummaries || []).length > 0
             }
 
-            // Rating (moved to top, right after graph) + Read TDS button when R2 configured
+            // Rating (moved to top, right after graph)
             Item {
                 Layout.fillWidth: true
                 Layout.preferredHeight: ratingLabel.height + ratingBox.height + Theme.scaled(2)
-
-                property bool hasRefractometer: Settings.savedRefractometerAddress !== ""
 
                 Tr {
                     id: ratingLabel
@@ -571,8 +659,7 @@ Page {
                 Rectangle {
                     id: ratingBox
                     anchors.left: parent.left
-                    anchors.right: readTdsButton.visible ? readTdsButton.left : parent.right
-                    anchors.rightMargin: readTdsButton.visible ? Theme.scaled(8) : 0
+                    anchors.right: parent.right
                     anchors.top: ratingLabel.bottom
                     anchors.topMargin: Theme.scaled(2)
                     height: Theme.scaled(44)
@@ -589,52 +676,6 @@ Page {
                         accessibleName: TranslationManager.translate("postshotreview.label.rating", "Rating") + " " + value + " " + TranslationManager.translate("postshotreview.unit.percent", "percent")
                         onValueModified: function(newValue) {
                             editEnjoyment = newValue
-                        }
-                    }
-                }
-
-                Rectangle {
-                    id: readTdsButton
-                    property bool refConnected: BLEManager.refractometerConnected
-                    property bool refMeasuring: refConnected && typeof Refractometer !== "undefined" && Refractometer && Refractometer.measuring
-                    visible: parent.hasRefractometer && postShotReviewPage.advancedMode
-                    anchors.right: parent.right
-                    anchors.top: ratingBox.top
-                    anchors.bottom: ratingBox.bottom
-                    width: Theme.scaled(80)
-                    radius: Theme.scaled(12)
-                    color: Theme.surfaceColor
-                    border.width: 1
-                    border.color: Theme.textSecondaryColor
-                    opacity: refMeasuring ? 0.5 : 1.0
-                    Accessible.ignored: true
-
-                    Text {
-                        anchors.centerIn: parent
-                        text: {
-                            if (!readTdsButton.refConnected) return TranslationManager.translate("postshotreview.refractometer.off", "R2 Off")
-                            if (readTdsButton.refMeasuring) return TranslationManager.translate("postshotreview.refractometer.measuring", "...")
-                            return TranslationManager.translate("postshotreview.refractometer.readTds", "Read TDS")
-                        }
-                        color: Theme.textColor
-                        font.pixelSize: Theme.scaled(13)
-                        Accessible.ignored: true
-                    }
-
-                    AccessibleMouseArea {
-                        anchors.fill: parent
-                        accessibleName: readTdsButton.refConnected
-                            ? TranslationManager.translate("postshotreview.readTdsFromRefractometer", "Read TDS from refractometer")
-                            : TranslationManager.translate("postshotreview.reconnectRefractometer", "Reconnect refractometer")
-                        accessibleItem: readTdsButton
-                        enabled: !readTdsButton.refMeasuring
-                        onAccessibleClicked: {
-                            if (readTdsButton.refConnected) {
-                                if (typeof Refractometer !== "undefined" && Refractometer)
-                                    Refractometer.requestMeasurement()
-                            } else {
-                                BLEManager.tryDirectConnectToRefractometer()
-                            }
                         }
                     }
                 }
@@ -1132,6 +1173,34 @@ Page {
     BottomBar {
         onBackClicked: handleBack()
 
+        // Profile name + date remain visible while the user scrolls,
+        // providing context when the header is off-screen.
+        ColumnLayout {
+            visible: !!(editShotData.profileName)
+            spacing: 0
+            Layout.alignment: Qt.AlignVCenter
+            Accessible.role: Accessible.StaticText
+            Accessible.name: (editShotData.profileName || "") + (editShotData.dateTime ? ", " + editShotData.dateTime : "")
+            Accessible.focusable: true
+
+            Text {
+                text: editShotData.profileName || ""
+                font: Theme.labelFont
+                color: Theme.textColor
+                elide: Text.ElideRight
+                Layout.maximumWidth: postShotReviewPage.width * 0.3
+                Accessible.ignored: true
+            }
+            Text {
+                text: editShotData.dateTime || ""
+                font: Theme.captionFont
+                color: Theme.textSecondaryColor
+                elide: Text.ElideRight
+                Layout.maximumWidth: postShotReviewPage.width * 0.3
+                Accessible.ignored: true
+            }
+        }
+
         // Save button - only visible when there are unsaved changes
         Rectangle {
             id: saveButton
@@ -1582,6 +1651,124 @@ Page {
             }
 
             onActivated: function(index) { parent.valueChanged(currentText) }
+        }
+    }
+
+    // Profile AI knowledge base dialog
+    Dialog {
+        id: shotKnowledgeDialog
+        anchors.centerIn: parent
+        width: Math.min(Theme.scaled(500), parent.width - Theme.scaled(40))
+        height: Math.min(shotKbContent.implicitHeight + Theme.scaled(120), parent.height - Theme.scaled(80))
+        padding: 0
+        modal: true
+
+        property string profileTitle: ""
+        property string content: ""
+
+        function formatContent(raw) {
+            var lines = raw.split('\n')
+            var parts = []
+            for (var i = 0; i < lines.length; i++) {
+                var line = lines[i]
+                if (!line.trim()) continue
+                if (line.startsWith('Also matches:') || line.startsWith('AnalysisFlags:')) continue
+                var colonIdx = line.indexOf(': ')
+                if (colonIdx > 0 && colonIdx <= 35 && !line.startsWith('DO NOT') && !line.startsWith('-')) {
+                    var label = line.substring(0, colonIdx).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                    var value = line.substring(colonIdx + 2).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                    parts.push('<b>' + label + ':</b> ' + value)
+                } else if (line.startsWith('DO NOT')) {
+                    parts.push('<i>' + line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</i>')
+                } else {
+                    parts.push(line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'))
+                }
+            }
+            return parts.join('<br>')
+        }
+
+        header: Item {
+            implicitHeight: Theme.scaled(50)
+
+            Row {
+                anchors.left: parent.left
+                anchors.leftMargin: Theme.scaled(20)
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Theme.scaled(8)
+
+                Image {
+                    source: "qrc:/icons/sparkle.svg"
+                    sourceSize.width: Theme.scaled(18)
+                    sourceSize.height: Theme.scaled(18)
+                    anchors.verticalCenter: parent.verticalCenter
+                    layer.enabled: true
+                    layer.smooth: true
+                    layer.effect: MultiEffect {
+                        colorization: 1.0
+                        colorizationColor: Theme.primaryColor
+                    }
+                }
+
+                Text {
+                    text: shotKnowledgeDialog.profileTitle
+                    font: Theme.titleFont
+                    color: Theme.textColor
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 1
+                color: Theme.borderColor
+            }
+        }
+
+        contentItem: Flickable {
+            clip: true
+            contentHeight: shotKbContent.implicitHeight + Theme.scaled(30)
+            flickableDirection: Flickable.VerticalFlick
+            boundsBehavior: Flickable.StopAtBounds
+
+            Text {
+                id: shotKbContent
+                width: parent.width - Theme.scaled(40)
+                x: Theme.scaled(20)
+                y: Theme.scaled(15)
+                text: shotKnowledgeDialog.formatContent(shotKnowledgeDialog.content)
+                textFormat: Text.RichText
+                color: Theme.textColor
+                font: Theme.bodyFont
+                wrapMode: Text.WordWrap
+                lineHeight: 1.5
+            }
+        }
+
+        footer: Item {
+            implicitHeight: Theme.scaled(55)
+
+            Rectangle {
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 1
+                color: Theme.borderColor
+            }
+
+            AccessibleButton {
+                anchors.centerIn: parent
+                width: Theme.scaled(100)
+                text: TranslationManager.translate("common.button.ok", "OK")
+                accessibleName: TranslationManager.translate("common.accessibility.dismissDialog", "Dismiss dialog")
+                onClicked: shotKnowledgeDialog.close()
+            }
+        }
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
         }
     }
 

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -122,11 +122,18 @@ Page {
                 editBarista = editShotData.barista || ""
                 editDoseWeight = editShotData.doseWeight ?? 0
                 editDrinkWeight = editShotData.finalWeight ?? 0
-                editDrinkTds = editShotData.drinkTds ?? 0
+                // Preserve any live R2 reading that arrived before the async DB load;
+                // only take the DB value when no measurement has been received yet.
+                if (editDrinkTds === 0)
+                    editDrinkTds = editShotData.drinkTds ?? 0
                 editDrinkEy = editShotData.drinkEy ?? 0
                 editEnjoyment = editShotData.enjoyment ?? 0  // Use ?? to avoid treating 0 as falsy
                 editNotes = editShotData.espressoNotes || ""
                 editBeverageType = editShotData.beverageType || "espresso"
+                // Recompute EY now that dose/weight are loaded (covers the case where TDS
+                // arrived via R2 before the shot data was ready, or where the DB already
+                // has a non-zero TDS from a previous session).
+                calculateEy()
                 // Recompute quality badges in background (handles stale values after KB updates)
                 MainController.shotHistory.requestReanalyzeBadges(shotId)
             }

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -370,7 +370,11 @@ Page {
                         }
 
                         QualityBadges {
-                            visible: !!(editShotData.profileKbId)
+                            visible: !!(editShotData.profileKbId
+                                        || editShotData.channelingDetected
+                                        || editShotData.temperatureUnstable
+                                        || editShotData.grindIssueDetected
+                                        || editShotData.skipFirstFrameDetected)
                             Layout.fillWidth: false
                             Layout.maximumWidth: postShotReviewPage.width * 0.5
                             channelingDetected: editShotData.channelingDetected ?? false

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -120,7 +120,9 @@ Page {
                 editGrinderBurrs = editShotData.grinderBurrs || ""
                 editGrinderSetting = editShotData.grinderSetting || ""
                 editBarista = editShotData.barista || ""
-                editDoseWeight = editShotData.doseWeight ?? 0
+                // Fall back to last-used DYE dose when the shot has no stored dose,
+                // so EY can be computed immediately when TDS arrives.
+                editDoseWeight = (editShotData.doseWeight > 0) ? editShotData.doseWeight : Settings.dyeBeanWeight
                 editDrinkWeight = editShotData.finalWeight ?? 0
                 // Preserve any live R2 reading that arrived before the async DB load;
                 // only take the DB value when no measurement has been received yet.

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -247,7 +247,11 @@ Page {
                         }
 
                         QualityBadges {
-                            visible: !!(shotData.profileKbId)
+                            visible: !!(shotData.profileKbId
+                                        || shotData.channelingDetected
+                                        || shotData.temperatureUnstable
+                                        || shotData.grindIssueDetected
+                                        || shotData.skipFirstFrameDetected)
                             Layout.fillWidth: false
                             Layout.maximumWidth: shotDetailPage.width * 0.5
                             channelingDetected: shotData.channelingDetected ?? false

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -84,12 +84,13 @@ Page {
                 console.warn("ShotDetailPage: Failed to save visualizer info for shot", id)
             }
         }
-        function onShotBadgesUpdated(id, channeling, tempUnstable, grindIssue) {
+        function onShotBadgesUpdated(id, channeling, tempUnstable, grindIssue, skipFirstFrame) {
             if (id !== shotDetailPage.shotId) return
             var updated = Object.assign({}, shotData)
             updated.channelingDetected = channeling
             updated.temperatureUnstable = tempUnstable
             updated.grindIssueDetected = grindIssue
+            updated.skipFirstFrameDetected = skipFirstFrame
             shotData = updated
         }
     }
@@ -252,6 +253,7 @@ Page {
                             channelingDetected: shotData.channelingDetected ?? false
                             temperatureUnstable: shotData.temperatureUnstable ?? false
                             grindIssueDetected: shotData.grindIssueDetected ?? false
+                            skipFirstFrameDetected: shotData.skipFirstFrameDetected ?? false
                             onSummaryRequested: detailAnalysisDialog.open()
                         }
 

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -1332,12 +1332,27 @@ Page {
                 }
                 Text { text: TranslationManager.translate("shothistory.helpgrind", "Grind issue"); font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
                 Text { text: "grind:yes"; font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
+
+                Rectangle {
+                    color: skipFrameArea.pressed ? Theme.surfaceColor : "transparent"
+                    radius: Theme.scaled(4)
+                    implicitWidth: skipFrameLabel.implicitWidth + Theme.scaled(8)
+                    implicitHeight: skipFrameLabel.implicitHeight + Theme.scaled(4)
+                    Accessible.role: Accessible.Button
+                    Accessible.name: TranslationManager.translate("shothistory.insertKeyword", "Insert %1").arg("skipframe:yes")
+                    Accessible.focusable: true
+                    Accessible.onPressAction: skipFrameArea.clicked(null)
+                    Text { id: skipFrameLabel; text: "skipframe:yes"; anchors.centerIn: parent; font.pixelSize: Theme.labelFont.pixelSize; color: Theme.primaryColor; font.bold: true; Accessible.ignored: true }
+                    MouseArea { id: skipFrameArea; anchors.fill: parent; onClicked: insertSearchKeyword("skipframe:yes") }
+                }
+                Text { text: TranslationManager.translate("shothistory.helpskipframe", "First step skipped"); font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
+                Text { text: "skipframe:yes"; font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
             }
 
             // Syntax explanation
             Text {
                 text: TranslationManager.translate("shothistory.searchhelpsyntax",
-                    "Syntax: N (exact), N-M (range), N+ (minimum)\nQuality flags: channeling:yes, temp:yes, grind:yes\nCombine keywords with text: ethiopia dose:18 channeling:yes")
+                    "Syntax: N (exact), N-M (range), N+ (minimum)\nQuality flags: channeling:yes, temp:yes, grind:yes, skipframe:yes\nCombine keywords with text: ethiopia dose:18 channeling:yes")
                 font: Theme.captionFont
                 color: Theme.textSecondaryColor
                 wrapMode: Text.Wrap

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -194,11 +194,12 @@ Page {
                 }
             }
 
-            // Parse quality flag keywords (channeling:yes, temp:yes, grind:yes)
+            // Parse quality flag keywords (channeling:yes, temp:yes, grind:yes, skipframe:yes)
             var flagKeywords = [
                 { pattern: /\bchanneling:yes\b/gi, filterKey: "filterChanneling" },
                 { pattern: /\btemp:yes\b/gi, filterKey: "filterTemperatureUnstable" },
-                { pattern: /\bgrind:yes\b/gi, filterKey: "filterGrindIssue" }
+                { pattern: /\bgrind:yes\b/gi, filterKey: "filterGrindIssue" },
+                { pattern: /\bskipframe:yes\b/gi, filterKey: "filterSkipFirstFrame" }
             ]
             for (var j = 0; j < flagKeywords.length; j++) {
                 var fk = flagKeywords[j]
@@ -210,7 +211,7 @@ Page {
 
             // Strip any remaining keyword tokens (e.g. duplicate dose:18 dose:20)
             searchText = searchText.replace(/\b(rating|dose|yield|time|tds|ey):\d+(?:\.\d+)?(?:-\d+(?:\.\d+)?|\+)?/g, "")
-            searchText = searchText.replace(/\b(channeling|temp|grind):yes\b/gi, "")
+            searchText = searchText.replace(/\b(channeling|temp|grind|skipframe):yes\b/gi, "")
 
             // Pass remaining text as FTS search (skipped when exact initialFilter is active)
             searchText = searchText.trim().replace(/\s+/g, " ")
@@ -591,6 +592,7 @@ Page {
                     if (model.channelingDetected) issues.push("channeling")
                     if (model.temperatureUnstable) issues.push("temp unstable")
                     if (model.grindIssueDetected) issues.push("grind issue")
+                    if (model.skipFirstFrameDetected) issues.push("first step skipped")
                     if (issues.length > 0) parts.push(issues.join(", "))
                     return parts.join(", ")
                 }
@@ -739,6 +741,12 @@ Page {
                                 width: Theme.scaled(8); height: Theme.scaled(8); radius: Theme.scaled(4)
                                 color: Theme.warningColor
                                 visible: model.grindIssueDetected ?? false
+                                Accessible.ignored: true
+                            }
+                            Rectangle {
+                                width: Theme.scaled(8); height: Theme.scaled(8); radius: Theme.scaled(4)
+                                color: Theme.errorColor
+                                visible: model.skipFirstFrameDetected ?? false
                                 Accessible.ignored: true
                             }
                         }

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -335,6 +335,20 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
         }
     }
 
+    // --- Skip-first-frame ---
+    // Re-derive from phase markers (already available) so generateSummary() does not
+    // need a separate skipFirstFrameDetected parameter. Mirrors the Tcl plugin: FW bug
+    // (machine never executed frame 0) or profile first step too short (< 2 s).
+    const bool skipFirstFrame = detectSkipFirstFrame(phases);
+    if (skipFirstFrame) {
+        QVariantMap line;
+        line["text"] = QStringLiteral("First profile step skipped \u2014 "
+            "likely a DE1 firmware bug (power-cycle machine to fix) "
+            "or first step too short (check profile settings)");
+        line["type"] = QStringLiteral("warning");
+        lines.append(line);
+    }
+
     // --- Verdict ---
     bool hasWarning = false, hasCaution = false;
     for (const auto& lineVar : lines) {
@@ -344,7 +358,13 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
     }
 
     QVariantMap verdict;
-    if (hasWarning) {
+    if (skipFirstFrame) {
+        // Skip-first-frame is a machine/profile issue, not puck integrity — give specific advice
+        // so the user isn't told to adjust grind when the real fix is a power-cycle.
+        verdict["text"] = QStringLiteral("Verdict: First profile step was skipped \u2014 "
+            "power-cycle the machine to fix a firmware bug, "
+            "or review the profile's first step settings.");
+    } else if (hasWarning) {
         // Channeling detected — direction depends on whether flow was running slow or fast.
         // Too-fine grind can cause puck collapse and channeling just as much as too-coarse.
         if (hasFlowGoalData && flowGrindDelta < -FLOW_DEVIATION_THRESHOLD) {

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -139,6 +139,16 @@ bool ShotAnalysis::detectGrindIssue(const QVector<QPointF>& flow,
     return std::abs(delta) > FLOW_DEVIATION_THRESHOLD;
 }
 
+bool ShotAnalysis::detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases)
+{
+    if (phases.isEmpty()) return false;
+    // FW bug: machine never executed frame 0 — jumped directly to frame 1 or higher
+    if (phases[0].frameNumber != 0) return true;
+    // Profile issue: frame 0 executed but transitioned in under 2 seconds
+    if (phases.size() > 1 && phases[1].time < 2.0) return true;
+    return false;
+}
+
 QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
                                              const QVector<QPointF>& flow,
                                              const QVector<QPointF>& weight,

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -139,13 +139,48 @@ bool ShotAnalysis::detectGrindIssue(const QVector<QPointF>& flow,
     return std::abs(delta) > FLOW_DEVIATION_THRESHOLD;
 }
 
-bool ShotAnalysis::detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases)
+bool ShotAnalysis::detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
+                                        int expectedFrameCount)
 {
-    if (phases.isEmpty()) return false;
-    // FW bug: machine never executed frame 0 — jumped directly to frame 1 or higher
-    if (phases[0].frameNumber != 0) return true;
-    // Profile issue: frame 0 executed but transitioned in under 2 seconds
-    if (phases.size() > 1 && phases[1].time < 2.0) return true;
+    if (phases.isEmpty())
+        return false;
+
+    if (expectedFrameCount >= 0 && expectedFrameCount < 2)
+        return false;
+
+    // Decenza inserts a synthetic "Start" marker at extraction start before any
+    // real frame-change markers. Ignore it so we can mirror the de1app plugin's
+    // "did we ever see frame 0 before a non-zero frame in the first 2 seconds?"
+    // behavior against saved history.
+    qsizetype firstRealMarker = 0;
+    if (phases.first().label == QStringLiteral("Start") && phases.first().frameNumber == 0)
+        firstRealMarker = 1;
+
+    bool sawRealFrameZero = false;
+    for (qsizetype i = firstRealMarker; i < phases.size(); ++i) {
+        const HistoryPhaseMarker& phase = phases[i];
+        if (phase.frameNumber < 0)
+            continue;
+        if (expectedFrameCount >= 0 && phase.frameNumber >= expectedFrameCount)
+            continue;
+
+        if (phase.frameNumber == 0) {
+            sawRealFrameZero = true;
+            continue;
+        }
+
+        // Match the Tcl plugin's detection window: only classify transitions that
+        // happen in the first 2 seconds of extraction.
+        if (phase.time >= 2.0)
+            return false;
+
+        // At this point we've seen a real non-zero frame inside the 2-second
+        // window. If frame 0 was never observed first, it's the firmware bug;
+        // otherwise it's the "first step too short" profile case. The badge is
+        // intentionally shared for both conditions.
+        return true;
+    }
+
     return false;
 }
 

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -156,7 +156,6 @@ bool ShotAnalysis::detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
     if (phases.first().label == QStringLiteral("Start") && phases.first().frameNumber == 0)
         firstRealMarker = 1;
 
-    bool sawRealFrameZero = false;
     for (qsizetype i = firstRealMarker; i < phases.size(); ++i) {
         const HistoryPhaseMarker& phase = phases[i];
         if (phase.frameNumber < 0)
@@ -164,20 +163,17 @@ bool ShotAnalysis::detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
         if (expectedFrameCount >= 0 && phase.frameNumber >= expectedFrameCount)
             continue;
 
-        if (phase.frameNumber == 0) {
-            sawRealFrameZero = true;
+        if (phase.frameNumber == 0)
             continue;
-        }
 
         // Match the Tcl plugin's detection window: only classify transitions that
         // happen in the first 2 seconds of extraction.
         if (phase.time >= 2.0)
             return false;
 
-        // At this point we've seen a real non-zero frame inside the 2-second
-        // window. If frame 0 was never observed first, it's the firmware bug;
-        // otherwise it's the "first step too short" profile case. The badge is
-        // intentionally shared for both conditions.
+        // Non-zero frame inside the 2-second window — flag the shot. Both the
+        // firmware bug (frame 0 never seen) and the short-first-step case
+        // (frame 0 briefly seen, then jumped away) share this badge intentionally.
         return true;
     }
 

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -97,9 +97,15 @@ public:
     // Returns true if the shot appears to have skipped profile frame 0, indicating
     // either a known DE1 firmware bug (machine started at frame 1+) or a profile
     // whose first step is so short (< 2 s) it was never meaningfully executed.
+    // Mirrors the de1app plugin semantics against Decenza's saved phase markers:
+    // ignore the synthetic "Start" marker, then inspect real frame markers only
+    // within the first 2 seconds of extraction. expectedFrameCount is optional;
+    // when known, values less than 2 suppress detection (there is no second frame
+    // to skip to), and out-of-range frame numbers are ignored as malformed data.
     // The firmware bug requires a full power-cycle of the machine to fix.
     // Returns false when phases is empty (insufficient data).
-    static bool detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases);
+    static bool detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
+                                     int expectedFrameCount = -1);
 
     // Generate a concise shot summary from curve data. Returns a list of
     // noteworthy observations + a verdict. Used by ShotAnalysisDialog.qml.

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -94,6 +94,13 @@ public:
                                   const QVector<QPointF>& flowGoal,
                                   double pourStart, double pourEnd);
 
+    // Returns true if the shot appears to have skipped profile frame 0, indicating
+    // either a known DE1 firmware bug (machine started at frame 1+) or a profile
+    // whose first step is so short (< 2 s) it was never meaningfully executed.
+    // The firmware bug requires a full power-cycle of the machine to fix.
+    // Returns false when phases is empty (insufficient data).
+    static bool detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases);
+
     // Generate a concise shot summary from curve data. Returns a list of
     // noteworthy observations + a verdict. Used by ShotAnalysisDialog.qml.
     // flowGoal is the profile's target flow curve and drives grind-direction analysis (may be empty).

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -2285,7 +2285,9 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     // Like grind detection, this needs no derived curves, so it covers all shot
     // eras including shots predating migration 12 that have skip_first_frame_detected = 0 (DEFAULT).
     if (!record.phases.isEmpty()) {
-        record.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(record.phases);
+        record.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(
+            record.phases,
+            expectedFrameCountFromProfileJson(record.profileJson));
     }
 
     return record;

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -698,6 +698,19 @@ bool ShotHistoryStorage::runMigrations()
         currentVersion = 11;
     }
 
+    // Migration 12: Add skip_first_frame_detected flag.
+    // Detects DE1 firmware bug where the machine skips profile frame 0.
+    if (currentVersion < 12) {
+        qDebug() << "ShotHistoryStorage: Running migration to version 12 (skip_first_frame_detected)";
+
+        if (!hasColumn("shots", "skip_first_frame_detected"))
+            query.exec("ALTER TABLE shots ADD COLUMN skip_first_frame_detected INTEGER DEFAULT 0");
+
+        query.exec("DELETE FROM schema_version");
+        query.exec("INSERT INTO schema_version (version) VALUES (12)");
+        currentVersion = 12;
+    }
+
     m_schemaVersion = currentVersion;
     return true;
 }
@@ -925,6 +938,10 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
             data.grindIssueDetected = ShotAnalysis::detectGrindIssue(
                 flowPts, shotData->flowGoalData(), pourStart, pourEnd);
         }
+
+        // Skip-first-frame detection: check whether frame 0 was absent or very short,
+        // indicating a known DE1 firmware bug or a misconfigured profile first step.
+        data.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(tmpRecord.phases);
     }
 
     // Compress sample data on main thread (reads QObject data vectors)
@@ -1014,7 +1031,8 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
                     profile_notes, debug_log,
                     temperature_override, yield_override, profile_kb_id,
-                    channeling_detected, temperature_unstable, grind_issue_detected
+                    channeling_detected, temperature_unstable, grind_issue_detected,
+                    skip_first_frame_detected
                 ) VALUES (
                     :uuid, :timestamp, :profile_name, :profile_json, :beverage_type,
                     :duration, :final_weight, :dose_weight,
@@ -1023,7 +1041,8 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     :drink_tds, :drink_ey, :enjoyment, :espresso_notes, :bean_notes, :barista,
                     :profile_notes, :debug_log,
                     :temperature_override, :yield_override, :profile_kb_id,
-                    :channeling_detected, :temperature_unstable, :grind_issue_detected
+                    :channeling_detected, :temperature_unstable, :grind_issue_detected,
+                    :skip_first_frame_detected
                 )
             )");
 
@@ -1057,6 +1076,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
             query.bindValue(":channeling_detected", data.channelingDetected ? 1 : 0);
             query.bindValue(":temperature_unstable", data.temperatureUnstable ? 1 : 0);
             query.bindValue(":grind_issue_detected", data.grindIssueDetected ? 1 : 0);
+            query.bindValue(":skip_first_frame_detected", data.skipFirstFrameDetected ? 1 : 0);
 
             if (!query.exec()) {
                 qWarning() << "ShotHistoryStorage: Failed to insert shot:" << query.lastError().text();
@@ -1321,6 +1341,7 @@ ShotFilter ShotHistoryStorage::parseFilterMap(const QVariantMap& filterMap)
     filter.filterChanneling = filterMap.value("filterChanneling", false).toBool();
     filter.filterTemperatureUnstable = filterMap.value("filterTemperatureUnstable", false).toBool();
     filter.filterGrindIssue = filterMap.value("filterGrindIssue", false).toBool();
+    filter.filterSkipFirstFrame = filterMap.value("filterSkipFirstFrame", false).toBool();
     filter.sortColumn = filterMap.value("sortField", "timestamp").toString();
     filter.sortDirection = filterMap.value("sortDirection", "DESC").toString();
     return filter;
@@ -1399,6 +1420,9 @@ QString ShotHistoryStorage::buildFilterQuery(const ShotFilter& filter, QVariantL
     }
     if (filter.filterGrindIssue) {
         conditions << "grind_issue_detected = 1";
+    }
+    if (filter.filterSkipFirstFrame) {
+        conditions << "skip_first_frame_detected = 1";
     }
 
     if (conditions.isEmpty()) {
@@ -1493,7 +1517,8 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                    enjoyment, visualizer_id, grinder_setting,
                    temperature_override, yield_override, beverage_type,
                    drink_tds, drink_ey,
-                   channeling_detected, temperature_unstable, grind_issue_detected
+                   channeling_detected, temperature_unstable, grind_issue_detected,
+                   skip_first_frame_detected
             FROM shots
             WHERE id IN (SELECT rowid FROM shots_fts WHERE shots_fts MATCH '%1')
             %2
@@ -1507,7 +1532,8 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                    enjoyment, visualizer_id, grinder_setting,
                    temperature_override, yield_override, beverage_type,
                    drink_tds, drink_ey,
-                   channeling_detected, temperature_unstable, grind_issue_detected
+                   channeling_detected, temperature_unstable, grind_issue_detected,
+                   skip_first_frame_detected
             FROM shots
             %1
             %2
@@ -1575,6 +1601,7 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                             shot["channelingDetected"] = query.value(17).toInt() != 0;
                             shot["temperatureUnstable"] = query.value(18).toInt() != 0;
                             shot["grindIssueDetected"] = query.value(19).toInt() != 0;
+                            shot["skipFirstFrameDetected"] = query.value(20).toInt() != 0;
 
                             QDateTime dt = QDateTime::fromSecsSinceEpoch(
                                 query.value(2).toLongLong());
@@ -1654,6 +1681,7 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
     auto destroyed = m_destroyed;
     QThread* thread = QThread::create([this, dbPath, shotId, destroyed]() {
         bool newChanneling = false, newTempUnstable = false, newGrindIssue = false;
+        bool newSkipFirstFrame = false;
         bool recordFound = false, flagsChanged = false;
 
         withTempDb(dbPath, "shs_badges", [&](QSqlDatabase& db) {
@@ -1705,17 +1733,23 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
                     record.flow, record.flowGoal, pourStart, pourEnd);
             }
 
+            // Skip-first-frame detection from phase markers
+            newSkipFirstFrame = ShotAnalysis::detectSkipFirstFrame(record.phases);
+
             // Update DB only if any flag changed
             flagsChanged = (newChanneling != record.channelingDetected
                 || newTempUnstable != record.temperatureUnstable
-                || newGrindIssue != record.grindIssueDetected);
+                || newGrindIssue != record.grindIssueDetected
+                || newSkipFirstFrame != record.skipFirstFrameDetected);
             if (flagsChanged) {
                 QSqlQuery q(db);
                 q.prepare("UPDATE shots SET channeling_detected=:c,"
-                          " temperature_unstable=:t, grind_issue_detected=:g WHERE id=:id");
+                          " temperature_unstable=:t, grind_issue_detected=:g,"
+                          " skip_first_frame_detected=:s WHERE id=:id");
                 q.bindValue(":c", newChanneling ? 1 : 0);
                 q.bindValue(":t", newTempUnstable ? 1 : 0);
                 q.bindValue(":g", newGrindIssue ? 1 : 0);
+                q.bindValue(":s", newSkipFirstFrame ? 1 : 0);
                 q.bindValue(":id", shotId);
                 if (!q.exec())
                     qWarning() << "ShotHistoryStorage: badge update failed for shot"
@@ -1726,10 +1760,10 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
         if (!recordFound || *destroyed) return;
         QMetaObject::invokeMethod(
             this,
-            [this, shotId, newChanneling, newTempUnstable, newGrindIssue, flagsChanged, destroyed]() {
+            [this, shotId, newChanneling, newTempUnstable, newGrindIssue, newSkipFirstFrame, flagsChanged, destroyed]() {
                 if (*destroyed) return;
                 if (!flagsChanged) return;
-                emit shotBadgesUpdated(shotId, newChanneling, newTempUnstable, newGrindIssue);
+                emit shotBadgesUpdated(shotId, newChanneling, newTempUnstable, newGrindIssue, newSkipFirstFrame);
             },
             Qt::QueuedConnection);
     });
@@ -1902,6 +1936,7 @@ QVariantMap ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     result["channelingDetected"] = record.channelingDetected;
     result["temperatureUnstable"] = record.temperatureUnstable;
     result["grindIssueDetected"] = record.grindIssueDetected;
+    result["skipFirstFrameDetected"] = record.skipFirstFrameDetected;
 
     // Phase summaries for UI (computed at save time or on-the-fly for legacy shots)
     if (!record.phaseSummariesJson.isEmpty()) {
@@ -2073,7 +2108,8 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
                drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
                profile_notes, visualizer_id, visualizer_url, debug_log,
                temperature_override, yield_override, beverage_type, profile_kb_id,
-               channeling_detected, temperature_unstable, grind_issue_detected
+               channeling_detected, temperature_unstable, grind_issue_detected,
+               skip_first_frame_detected
         FROM shots WHERE id = ?
     )")) {
         qWarning() << "ShotHistoryStorage::loadShotRecordStatic: prepare failed:" << query.lastError().text();
@@ -2119,6 +2155,7 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     record.channelingDetected = query.value(30).toInt() != 0;
     record.temperatureUnstable = query.value(31).toInt() != 0;
     record.grindIssueDetected = query.value(32).toInt() != 0;
+    record.skipFirstFrameDetected = query.value(33).toInt() != 0;
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     if (query.prepare("SELECT data_blob FROM shot_samples WHERE shot_id = ?")) {
@@ -3242,8 +3279,9 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                         enjoyment, espresso_notes, bean_notes, barista,
                         profile_notes, visualizer_id, visualizer_url, debug_log,
                         temperature_override, yield_override, profile_kb_id,
-                        channeling_detected, temperature_unstable, grind_issue_detected)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        channeling_detected, temperature_unstable, grind_issue_detected,
+                        skip_first_frame_detected)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 )");
 
                 insert.addBindValue(uuid);
@@ -3283,6 +3321,8 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                 insert.addBindValue((tu.isValid() && !tu.isNull()) ? tu : QVariant(0));
                 QVariant gi = srcShots.value("grind_issue_detected");
                 insert.addBindValue((gi.isValid() && !gi.isNull()) ? gi : QVariant(0));
+                QVariant sf = srcShots.value("skip_first_frame_detected");
+                insert.addBindValue((sf.isValid() && !sf.isNull()) ? sf : QVariant(0));
 
                 if (!insert.exec()) {
                     qWarning() << "ShotHistoryStorage::importDatabaseStatic: Failed to import shot:" << insert.lastError().text();
@@ -3462,7 +3502,8 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
             drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
             profile_notes, debug_log,
             temperature_override, yield_override, profile_kb_id,
-            channeling_detected, temperature_unstable, grind_issue_detected
+            channeling_detected, temperature_unstable, grind_issue_detected,
+            skip_first_frame_detected
         ) VALUES (
             :uuid, :timestamp, :profile_name, :profile_json, :beverage_type,
             :duration, :final_weight, :dose_weight,
@@ -3471,7 +3512,8 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
             :drink_tds, :drink_ey, :enjoyment, :espresso_notes, :bean_notes, :barista,
             :profile_notes, :debug_log,
             :temperature_override, :yield_override, :profile_kb_id,
-            :channeling_detected, :temperature_unstable, :grind_issue_detected
+            :channeling_detected, :temperature_unstable, :grind_issue_detected,
+            :skip_first_frame_detected
         )
     )");
 
@@ -3507,6 +3549,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
     query.bindValue(":channeling_detected", record.channelingDetected ? 1 : 0);
     query.bindValue(":temperature_unstable", record.temperatureUnstable ? 1 : 0);
     query.bindValue(":grind_issue_detected", record.grindIssueDetected ? 1 : 0);
+    query.bindValue(":skip_first_frame_detected", record.skipFirstFrameDetected ? 1 : 0);
 
     if (!query.exec()) {
         qWarning() << "ShotHistoryStorage: Failed to import shot:" << query.lastError().text();

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -2281,6 +2281,13 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
         }
     }
 
+    // Skip-first-frame: always recompute from phase markers when available.
+    // Like grind detection, this needs no derived curves, so it covers all shot
+    // eras including shots predating migration 12 that have skip_first_frame_detected = 0 (DEFAULT).
+    if (!record.phases.isEmpty()) {
+        record.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(record.phases);
+    }
+
     return record;
 }
 

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -31,6 +31,20 @@ static bool use12h() {
     return val;
 }
 
+static int expectedFrameCountFromProfileJson(const QString& profileJson)
+{
+    if (profileJson.isEmpty())
+        return -1;
+
+    QJsonParseError parseError;
+    const QJsonDocument doc = QJsonDocument::fromJson(profileJson.toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject())
+        return -1;
+
+    const Profile profile = Profile::fromJson(doc);
+    return static_cast<int>(profile.steps().size());
+}
+
 const QString ShotHistoryStorage::DB_CONNECTION_NAME = "ShotHistoryConnection";
 
 ShotHistoryStorage::ShotHistoryStorage(QObject* parent)
@@ -941,7 +955,9 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
 
         // Skip-first-frame detection: check whether frame 0 was absent or very short,
         // indicating a known DE1 firmware bug or a misconfigured profile first step.
-        data.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(tmpRecord.phases);
+        data.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(
+            tmpRecord.phases,
+            profile ? static_cast<int>(profile->steps().size()) : -1);
     }
 
     // Compress sample data on main thread (reads QObject data vectors)
@@ -1734,7 +1750,9 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
             }
 
             // Skip-first-frame detection from phase markers
-            newSkipFirstFrame = ShotAnalysis::detectSkipFirstFrame(record.phases);
+            newSkipFirstFrame = ShotAnalysis::detectSkipFirstFrame(
+                record.phases,
+                expectedFrameCountFromProfileJson(record.profileJson));
 
             // Update DB only if any flag changed
             flagsChanged = (newChanneling != record.channelingDetected

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -98,6 +98,7 @@ struct ShotRecord {
     bool channelingDetected = false;
     bool temperatureUnstable = false;
     bool grindIssueDetected = false;
+    bool skipFirstFrameDetected = false;
 
     // Phase summaries JSON (per-phase metrics: duration, avgPressure, avgFlow, weightGained, etc.)
     QString phaseSummariesJson;
@@ -143,6 +144,7 @@ struct ShotFilter {
     bool filterChanneling = false;
     bool filterTemperatureUnstable = false;
     bool filterGrindIssue = false;
+    bool filterSkipFirstFrame = false;
     QString sortColumn = "timestamp";
     QString sortDirection = "DESC";
 };
@@ -184,6 +186,7 @@ struct ShotSaveData {
     bool channelingDetected = false;
     bool temperatureUnstable = false;
     bool grindIssueDetected = false;
+    bool skipFirstFrameDetected = false;
 
     // Phase summaries JSON (per-phase metrics for UI display)
     QString phaseSummariesJson;
@@ -386,7 +389,7 @@ signals:
     void mostRecentShotIdReady(qint64 shotId);
     void distinctCacheReady();
     void grinderFieldsUpdated(int updatedCount);
-    void shotBadgesUpdated(qint64 shotId, bool channelingDetected, bool temperatureUnstable, bool grindIssueDetected);
+    void shotBadgesUpdated(qint64 shotId, bool channelingDetected, bool temperatureUnstable, bool grindIssueDetected, bool skipFirstFrameDetected);
 
 private:
     bool createTables();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,6 +119,12 @@ add_decenza_test(tst_recipegenerator
     ${CODEC_SOURCES}
 )
 
+# --- tst_shotanalysis: ShotAnalysis quality heuristics ---
+add_decenza_test(tst_shotanalysis
+    tst_shotanalysis.cpp
+    ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
+)
+
 # --- tst_shotsettings: ShotSettings BLE wire format ---
 add_decenza_test(tst_shotsettings
     tst_shotsettings.cpp

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -10,7 +10,7 @@
 
 #include "history/shothistorystorage.h"
 
-// Test the ShotHistoryStorage schema creation and migration chain (v1->v11).
+// Test the ShotHistoryStorage schema creation and migration chain (v1->v12).
 //
 // Strategy: create a temp DB with an old schema (missing columns),
 // set schema_version to an old value, then call initialize() which runs
@@ -151,7 +151,7 @@ private slots:
     }
 
     // ==========================================
-    // Fresh DB: full schema at v11
+    // Fresh DB: full schema at v12
     // ==========================================
 
     void freshDbCreatesSchema() {
@@ -164,7 +164,7 @@ private slots:
             QVERIFY(hasTable(db, "shot_samples"));
             QVERIFY(hasTable(db, "shot_phases"));
             QVERIFY(hasTable(db, "schema_version"));
-            QCOMPARE(getSchemaVersion(db), 11);
+            QCOMPARE(getSchemaVersion(db), 12);
         });
     }
 
@@ -185,6 +185,7 @@ private slots:
             QVERIFY(hasColumn(db, "shots", "channeling_detected"));
             QVERIFY(hasColumn(db, "shots", "temperature_unstable"));
             QVERIFY(hasColumn(db, "shots", "grind_issue_detected"));
+            QVERIFY(hasColumn(db, "shots", "skip_first_frame_detected"));
             QVERIFY(hasColumn(db, "shot_phases", "transition_reason"));
         });
     }
@@ -224,7 +225,7 @@ private slots:
         initAndClose(path, storage);
 
         withRawDb(path, "v1_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 11);
+            QCOMPARE(getSchemaVersion(db), 12);
             QVERIFY(hasColumn(db, "shots", "temperature_override"));
             QVERIFY(hasColumn(db, "shots", "yield_override"));
             QVERIFY(hasColumn(db, "shots", "beverage_type"));
@@ -234,6 +235,7 @@ private slots:
             QVERIFY(hasColumn(db, "shots", "channeling_detected"));
             QVERIFY(hasColumn(db, "shots", "temperature_unstable"));
             QVERIFY(hasColumn(db, "shots", "grind_issue_detected"));
+            QVERIFY(hasColumn(db, "shots", "skip_first_frame_detected"));
             QVERIFY(hasColumn(db, "shot_phases", "transition_reason"));
         });
     }
@@ -334,7 +336,7 @@ private slots:
         withRawDb(path, "v9_verify", [](QSqlDatabase& db) {
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasIndex(db, "idx_shots_profile_kb_id"));
-            QCOMPARE(getSchemaVersion(db), 11);
+            QCOMPARE(getSchemaVersion(db), 12);
         });
     }
 
@@ -348,7 +350,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "idempotent", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 11);
+            QCOMPARE(getSchemaVersion(db), 12);
         });
     }
 
@@ -368,7 +370,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "empty_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 11);
+            QCOMPARE(getSchemaVersion(db), 12);
         });
     }
 
@@ -391,7 +393,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "null_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 11);
+            QCOMPARE(getSchemaVersion(db), 12);
             QSqlQuery q(db);
             q.exec("SELECT grinder_brand FROM shots WHERE uuid = 'test-null'");
             QVERIFY(q.next());
@@ -444,7 +446,7 @@ private slots:
     }
 
     // ==========================================
-    // Full chain v1->v11 preserves existing data
+    // Full chain v1->v12 preserves existing data
     // ==========================================
 
     void fullChainPreservesData() {

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -54,6 +54,24 @@ private slots:
             phase(0.0, "Start", 0),
             phase(0.2, "Pour", 1),
         }, 1, false);
+
+        // expectedFrameCount == 0: also suppresses (< 2 frames, no skip possible)
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.2, "Pour", 1),
+        }, 0, false);
+
+        // FW bug: machine never executed frame 0 — first marker arrives directly at frame 1.
+        // No "Start" or frame-0 entry at all. Mirrors the Tcl plugin's skipped_first_step_FW
+        // case where step1_registered is never set before a non-zero frame is seen.
+        expectSkipDetection({
+            phase(0.0, "Pour", 1),
+        }, 3, true);
+
+        // FW bug with no expectedFrameCount (default -1, unknown profile)
+        expectSkipDetection({
+            phase(0.0, "Pour", 1),
+        }, -1, true);
     }
 };
 

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -1,0 +1,61 @@
+#include <QtTest>
+
+#include "ai/shotanalysis.h"
+#include "history/shothistorystorage.h"
+
+class tst_ShotAnalysis : public QObject {
+    Q_OBJECT
+
+private:
+    static HistoryPhaseMarker phase(double time, const QString& label, int frameNumber)
+    {
+        HistoryPhaseMarker marker;
+        marker.time = time;
+        marker.label = label;
+        marker.frameNumber = frameNumber;
+        return marker;
+    }
+
+    static void expectSkipDetection(const QList<HistoryPhaseMarker>& phases,
+                                    int expectedFrameCount,
+                                    bool expected)
+    {
+        QCOMPARE(ShotAnalysis::detectSkipFirstFrame(phases, expectedFrameCount), expected);
+    }
+
+private slots:
+    void skipFirstFrameDetection()
+    {
+        expectSkipDetection({}, -1, false);
+
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "Fill", 0),
+            phase(2.3, "Pour", 1),
+        }, 3, false);
+
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "Fill", 0),
+            phase(1.4, "Pour", 1),
+        }, 3, true);
+
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.2, "Pour", 1),
+        }, 3, true);
+
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(2.0, "Pour", 1),
+        }, 3, false);
+
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.2, "Pour", 1),
+        }, 1, false);
+    }
+};
+
+QTEST_MAIN(tst_ShotAnalysis)
+#include "tst_shotanalysis.moc"


### PR DESCRIPTION
## Summary

- **PostShotReviewPage header** now matches the layout introduced for ShotDetailPage in cdcf4de: date inline with title, QualityBadges + ShotAnalysisDialog ("Shot Summary") in the header row, sparkle KB button, and profile name/date in the bottom bar while scrolling
- **Read TDS button** moved from the rating row to the header — visible whenever an R2 refractometer is configured, regardless of advanced mode
- **New "First step skipped" quality badge** (red) detects the known DE1 firmware bug where the machine skips profile frame 0, and the secondary case where the first step is under 2 seconds
- **Several R2/EY bug fixes** discovered during review and testing

## New badge details

Ported from the `skip_first_step_notice` de1app plugin by Damian. Detection uses phase markers stored in `shot_phases`:
- **FW bug**: first phase marker has `frameNumber != 0` → machine never executed frame 0, requires power-cycle to fix
- **Profile issue**: frame 0 present but next frame arrived in < 2 s → first step too short

Fully integrated into the quality badge pipeline:
- `ShotAnalysis::detectSkipFirstFrame()` — detection logic
- DB migration 12 adds `skip_first_frame_detected` column
- `requestReanalyzeBadges()` recomputes on shot open
- `shotBadgesUpdated` signal gains 4th bool param
- Filterable: `ShotFilter::filterSkipFirstFrame`
- Keyword search: `skipframe:yes` in history search bar (including help popover entry)
- `loadShotRecordStatic` always recomputes from phase markers (covers pre-migration-12 shots)
- ShotHistoryPage indicator dot + accessible label

## R2 / EY bug fixes

- **R2 reconnect button used wrong BLE call**: was calling `tryDirectConnectToRefractometer()` which silently does nothing if a scan is already in progress (from `onCompleted`). Now calls `scanForDevices()` (introduced in #717) which stops any current scan and restarts fresh.
- **EY not computed when TDS arrived before shot data loaded**: `onTdsChanged` could fire before `onShotReady` completed (async DB load), then `onShotReady` would overwrite `editDrinkTds` back to 0. Fixed by preserving the live R2 reading and calling `calculateEy()` at the end of `onShotReady`.
- **`dyeBeanWeight` silently zeroed by saving without a dose**: `saveCurrentValues()` unconditionally wrote `editDoseWeight` (potentially 0) back to `Settings.dyeBeanWeight`, causing every subsequent shot to be saved with `doseWeight=0`. Fixed with `> 0` guards on all four numeric DYE fields (dose, drink weight, TDS, EY).
- **Dose pre-fill**: when the shot has no stored dose, `editDoseWeight` now defaults to `Settings.dyeBeanWeight` so EY can be computed immediately when the TDS reading arrives.

## Test plan

- [ ] Open a shot in PostShotReview — confirm date is inline, QualityBadges appear in header when `profileKbId` is set, sparkle button opens KB dialog
- [ ] With R2 configured: confirm Read TDS button appears at top in both basic and advanced mode
- [ ] With R2 disconnected: tap "R2 Off" — confirm it triggers a fresh scan and reconnects
- [ ] Read TDS with R2 — confirm EY is computed immediately (even if dose wasn't previously stored)
- [ ] Confirm rating bar now fills full width
- [ ] Confirm profile name + date visible in bottom bar while scrolling
- [ ] On a shot from a machine with the skip-first-frame FW bug: confirm red "First step skipped" badge appears
- [ ] Type `skipframe:yes` in shot history search — confirm only flagged shots appear; confirm `skipframe:yes` is visible in the search help popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)