### PR TITLE
fix: favorite profile click only selects, no longer opens editor

### DIFF
--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -773,14 +773,12 @@ Page {
                     onRowSelected: function(index) {
                         var fav = Settings.favoriteProfiles[index]
                         if (!fav) return
-                        ProfileManager.loadProfile(fav.filename)
-                        if (index === Settings.selectedFavoriteProfile) {
-                            root.goToProfileEditor()
-                        } else {
+                        if (index !== Settings.selectedFavoriteProfile) {
+                            ProfileManager.loadProfile(fav.filename)
+                            Settings.selectedFavoriteProfile = index
                             if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
                                 AccessibilityManager.announce(root.cleanForSpeech(fav.name) + " " + TranslationManager.translate("profileSelector.selected", "selected"))
                             }
-                            Settings.selectedFavoriteProfile = index
                         }
                     }
                     onRowMoved: function(from, to) { Settings.moveFavoriteProfile(from, to) }


### PR DESCRIPTION
## Summary
- Clicking a favorite profile pill on ProfileSelectorPage now only selects it (loads profile + updates selected index)
- Previously, clicking an already-selected favorite opened the profile editor
- Editor remains accessible via the edit icon button on the pill or long-press

## Test plan
- [ ] Click an unselected favorite — should select it without opening editor
- [ ] Click the already-selected favorite — should do nothing (no editor navigation)
- [ ] Click the edit icon on a favorite pill — should open editor
- [ ] Long-press a favorite pill — should open editor
- [ ] With TalkBack: double-tap a favorite — should select only

🤖 Generated with [Claude Code](https://claude.com/claude-code)