### PR TITLE
fix: keep scale connected when app backgrounded, fix flow cal feedback loop

### DIFF
--- a/docs/AUTO_FLOW_CALIBRATION.md
+++ b/docs/AUTO_FLOW_CALIBRATION.md
@@ -19,10 +19,13 @@ Automatic per-profile flow calibration using scale data as ground truth. After e
    - Scale data is recent (nearest weight flow point within 1 second)
    - Per-sample machine/weight flow ratio is within [0.4, 2.5] (rejects scale data glitches)
    - Window lasts at least 1.5 seconds with at least 7 samples
-3. **Ratio guard**: Window-mean machine/weight flow ratio must be within [0.75, 1.35] — rejects windows where scale data is systematically unreliable
-4. **Compute ratio**: `current_multiplier * mean(weight_flow) / (mean(machine_flow) * 0.963)` over the steady window
-5. **Sanity check**: Clamp to [0.5, 1.8] — cap extreme values that likely indicate measurement errors
-6. **Store & apply**: If the computed value differs from current by > 2%, save it per-profile and send to the machine
+3. **Profile classification**: Checks whether the profile's extraction frames (post-preinfusion) use flow control or pressure control — this determines which formula is used
+4. **Ratio guard**: Rejects windows where flow and weight diverge too much ([0.75, 1.35]). For flow profiles, compares `(target_flow * 0.963) / weight_flow`. For pressure profiles, compares `machine_flow / weight_flow`.
+5. **Compute calibration** (formula depends on profile type):
+   - **Flow profiles**: `mean(weight_flow) / (target_flow * 0.963)` — uses the profile's known target flow, independent of current calibration
+   - **Pressure profiles**: `current_multiplier * mean(weight_flow) / (mean(machine_flow) * 0.963)` — divides out current calibration from reported flow
+6. **Sanity check**: Clamp to [0.5, 1.8] — cap extreme values that likely indicate measurement errors
+7. **Store & apply**: If the computed value differs from current by > 2%, EMA-smooth toward it (alpha=0.3) and send to the machine
 
 ## Algorithm Details
 
@@ -48,13 +51,27 @@ Without this guard, shots with poor scale data quality can produce calibration v
 
 Before running calibration, the algorithm checks whether the settled weight dropped significantly below the weight at pump stop (> 3g drop). This indicates the stream of water hitting the cup was adding downward force to the scale during extraction, inflating the weight readings. Calibrating against these inflated readings would produce a multiplier that's too high, so the shot is skipped. This typically occurs with high-flow profiles where the stream has significant momentum.
 
-### Density Correction
+### Flow Profile vs Pressure Profile
 
-The machine flow sensor measures volumetric flow (ml/s), while the scale measures mass (g/s). Water at ~93°C has a density of ~0.963 g/ml, so the correction factor accounts for this difference. The formula is:
+The calibration formula depends on whether the profile's extraction frames use flow control or pressure control. Only extraction frames are considered (preinfusion frames are skipped, since they are almost always flow-controlled even in pressure profiles, and the steady window at t > 10s is always past preinfusion).
+
+**Flow profiles** (e.g., D-Flow, Filter): The DE1's PID servo holds the reported flow at the profile's target flow regardless of the calibration factor. Using the reported flow in the formula creates a feedback loop: lowering the factor → less pumping → lower weight flow → factor keeps drifting down, never converging. Instead, the formula uses the profile's target flow directly:
+
+```
+calibration = mean(weight_flow) / (target_flow * 0.963)
+```
+
+This is independent of the current calibration factor and converges correctly.
+
+**Pressure profiles** (e.g., Classic Italian): The machine controls pressure, not flow, so the reported flow reflects actual sensor readings (already multiplied by the calibration factor). The formula divides out the current factor to recover raw sensor flow:
 
 ```
 calibration = current_multiplier * mean(weight_flow) / (mean(machine_flow) * 0.963)
 ```
+
+### Density Correction
+
+The machine flow sensor measures volumetric flow (ml/s), while the scale measures mass (g/s). Water at ~93°C has a density of ~0.963 g/ml, so the correction factor accounts for this difference.
 
 ### Convergence
 
@@ -104,6 +121,10 @@ The calibration multiplier is written to the DE1 via the existing `DE1Device::se
 ## v2 Migration (Ratio Guard Reset)
 
 A one-time migration resets all per-profile flow calibrations and the global multiplier to 1.0. This is necessary because the pre-v2 algorithm had no ratio guards, allowing shots with poor scale data to drag calibrations down to ~0.6. The corrupted values then spread via the global median to new profiles (bootstrap problem). After the reset, the improved algorithm re-converges to correct values (~0.9-1.0) within a few shots per profile.
+
+## v3 Migration (Flow Profile Feedback Loop Fix)
+
+A one-time migration resets all per-profile flow calibrations and the global multiplier to 1.0. The v2 algorithm had a feedback loop for flow-controlled profiles: the DE1's PID holds reported flow at the target regardless of calibration, so the formula `ideal = factor * weightFlow / (reportedFlow * density)` made the ideal proportional to the current factor — it could only decrease, never converge. Over 30 shots a user's factor drifted from 1.0 to 0.59. The v3 algorithm uses the profile's target flow directly for flow profiles, breaking the loop. The reset clears all calibrations (including pressure profiles) since the global median may have been contaminated by drifted flow-profile values.
 
 ## Limitations
 

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -764,13 +764,15 @@ void MainController::computeAutoFlowCalibration() {
     bool isFlowProfile = false;
     {
         const auto& steps = m_profileManager->currentProfile().steps();
+        int preinfuseCount = m_profileManager->currentProfile().preinfuseFrameCount();
+
+        // Only check extraction frames (skip preinfusion). Preinfusion frames
+        // are almost always flow-controlled even in pressure profiles, and the
+        // steady window (t > 10s) is always past preinfusion anyway.
         int flowFrameCount = 0;
-        double flowSum = 0;
-        for (const auto& frame : steps) {
-            if (frame.isFlowControl() && frame.flow > 0.1) {
+        for (qsizetype i = preinfuseCount; i < steps.size(); ++i) {
+            if (steps[i].isFlowControl() && steps[i].flow > 0.1)
                 flowFrameCount++;
-                flowSum += frame.flow;
-            }
         }
         // Consider it a flow profile if any extraction frame uses flow control
         if (flowFrameCount > 0) {
@@ -778,7 +780,8 @@ void MainController::computeAutoFlowCalibration() {
             // Use the flow target closest to what the machine reported during
             // the window — this handles profiles with multiple flow targets
             double bestDist = 1e9;
-            for (const auto& frame : steps) {
+            for (qsizetype i = preinfuseCount; i < steps.size(); ++i) {
+                const auto& frame = steps[i];
                 if (frame.isFlowControl() && frame.flow > 0.1) {
                     double dist = qAbs(frame.flow - meanMachineFlow);
                     if (dist < bestDist) {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -743,7 +743,8 @@ void MainController::computeAutoFlowCalibration() {
              << bestCount << "samples)"
              << "meanMachineFlow=" << meanMachineFlow
              << "meanWeightFlow=" << meanWeightFlow
-             << "ratio=" << windowRatio;
+             << "ratio=" << windowRatio
+             << "currentFactor=" << m_settings->effectiveFlowCalibration(m_profileManager->baseProfileName());
 
     // Guard against division by zero. Should be impossible since every sample
     // in the window passed the kMinWeightFlow (0.5 g/s) check.
@@ -753,26 +754,82 @@ void MainController::computeAutoFlowCalibration() {
         return;
     }
 
-    // Window-level ratio sanity check. Reject windows where machine flow and
-    // scale-derived weight flow diverge too much. A healthy ratio is ~0.9-1.1
-    // (matching what de1app GFC users see when the curves overlap). Ratios
-    // outside [0.75, 1.35] indicate scale data quality problems: smoothing
-    // lag, stale weight readings, or the scale capturing a non-representative
-    // period. Without this check, bad windows drag the per-profile calibration
-    // down to ~0.6 when the correct value is ~0.9.
-    if (windowRatio > kMaxWindowRatio || windowRatio < kMinWindowRatio) {
+    // Check if the profile's extraction frames are flow-controlled.
+    // For flow profiles the DE1's PID locks reported flow to the target regardless
+    // of the calibration factor, which creates a feedback loop if we use reported
+    // flow in the calibration formula (each adjustment changes how much the machine
+    // pumps, but the reported flow stays the same → factor keeps drifting down).
+    // For these profiles, use the profile's target flow directly.
+    double profileTargetFlow = 0;
+    bool isFlowProfile = false;
+    {
+        const auto& steps = m_profileManager->currentProfile().steps();
+        int flowFrameCount = 0;
+        double flowSum = 0;
+        for (const auto& frame : steps) {
+            if (frame.isFlowControl() && frame.flow > 0.1) {
+                flowFrameCount++;
+                flowSum += frame.flow;
+            }
+        }
+        // Consider it a flow profile if any extraction frame uses flow control
+        if (flowFrameCount > 0) {
+            isFlowProfile = true;
+            // Use the flow target closest to what the machine reported during
+            // the window — this handles profiles with multiple flow targets
+            double bestDist = 1e9;
+            for (const auto& frame : steps) {
+                if (frame.isFlowControl() && frame.flow > 0.1) {
+                    double dist = qAbs(frame.flow - meanMachineFlow);
+                    if (dist < bestDist) {
+                        bestDist = dist;
+                        profileTargetFlow = frame.flow;
+                    }
+                }
+            }
+        }
+    }
+
+    // Window-level ratio sanity check. For flow profiles, compare weight flow
+    // against the profile's known target flow (density-adjusted) instead of
+    // the machine's reported flow (which is PID-locked to target and useless
+    // for ratio checking). For pressure profiles, compare machine vs weight flow.
+    // Reject windows where the ratio is outside [0.75, 1.35] — indicates
+    // channeling, scale issues, or other extraction anomalies.
+    if (isFlowProfile) {
+        double flowProfileRatio = (profileTargetFlow * kWaterDensity93C) / meanWeightFlow;
+        if (flowProfileRatio > kMaxWindowRatio || flowProfileRatio < kMinWindowRatio) {
+            qDebug() << "Auto flow cal: flow profile ratio" << flowProfileRatio
+                     << "(target" << profileTargetFlow << "vs weight" << meanWeightFlow << ")"
+                     << "outside bounds [" << kMinWindowRatio << "," << kMaxWindowRatio << "]"
+                     << "- skipping (extraction anomaly)";
+            return;
+        }
+    } else if (windowRatio > kMaxWindowRatio || windowRatio < kMinWindowRatio) {
         qDebug() << "Auto flow cal: window ratio" << windowRatio
                  << "outside bounds [" << kMinWindowRatio << "," << kMaxWindowRatio << "]"
                  << "- skipping (scale data suspect)";
         return;
     }
 
-    // The machine's reported flow includes the active calibration multiplier.
-    // To find the ideal multiplier: ideal = weight_flow / (raw_flow * density).
-    // Since raw = reported / current_multiplier, this simplifies to:
-    // ideal = current_multiplier * weight_flow / (reported_flow * density)
     double currentEffective = m_settings->effectiveFlowCalibration(m_profileManager->baseProfileName());
-    double ideal = currentEffective * meanWeightFlow / (meanMachineFlow * kWaterDensity93C);
+    double ideal;
+    if (isFlowProfile) {
+        // Flow profile: use the profile's target flow (independent of calibration).
+        // ideal = weightFlow / (targetFlow * density)
+        // This has no dependency on the current calibration factor, preventing
+        // the feedback loop where lowering the factor → less pumping → lower
+        // weight flow → factor keeps drifting down.
+        ideal = meanWeightFlow / (profileTargetFlow * kWaterDensity93C);
+        qDebug() << "Auto flow cal: flow profile — using target flow"
+                 << profileTargetFlow << "ml/s (reported:" << meanMachineFlow << ")";
+    } else {
+        // Pressure profile: the machine doesn't control flow, so reported flow
+        // reflects actual sensor readings (already multiplied by the calibration
+        // factor). Divide out the current factor to get raw sensor flow.
+        // ideal = currentFactor * weightFlow / (reportedFlow * density)
+        ideal = currentEffective * meanWeightFlow / (meanMachineFlow * kWaterDensity93C);
+    }
 
     if (!std::isfinite(ideal)) {
         qWarning() << "Auto flow cal: computed non-finite value" << ideal
@@ -811,7 +868,8 @@ void MainController::computeAutoFlowCalibration() {
     qDebug() << "Auto flow cal: updated" << m_profileManager->baseProfileName()
              << "from" << oldValue << "to" << computed
              << "(ideal:" << ideal << "EMA alpha:" << kEmaAlpha
-             << "window:" << windowDuration << "s," << bestCount << "samples)";
+             << "window:" << windowDuration << "s," << bestCount << "samples"
+             << "mode:" << (isFlowProfile ? "flow" : "pressure") << ")";
 
     emit flowCalibrationAutoUpdated(m_profileManager->currentProfile().title(), oldValue, computed);
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -191,6 +191,20 @@ Settings::Settings(QObject* parent)
         qDebug() << "Settings: Reset all flow calibrations to 1.0 (v2 ratio guard migration)";
     }
 
+    // One-time reset: clear all per-profile flow calibrations and reset global to 1.0.
+    // The v2 algorithm had a feedback loop for flow-controlled profiles: the DE1's PID
+    // holds reported flow at the target regardless of calibration, so the formula
+    // ideal = factor * weightFlow / (reportedFlow * density) made ideal proportional
+    // to the current factor — it could only decrease, never converge. The v3 algorithm
+    // uses the profile's target flow directly for flow profiles, breaking the loop.
+    // Users who ran v2 may have factors drifted to ~0.6-0.8 instead of ~0.9-1.0.
+    if (!m_settings.contains("calibration/v3FlowProfileReset")) {
+        savePerProfileFlowCalMap(QJsonObject());
+        setFlowCalibrationMultiplier(1.0);
+        m_settings.setValue("calibration/v3FlowProfileReset", true);
+        qDebug() << "Settings: Reset all flow calibrations to 1.0 (v3 flow profile feedback loop fix)";
+    }
+
     // Migrate legacy DYE grinder field: split combined model into brand/model/burrs
     if (!m_settings.contains("dye/grinderBrand") || m_settings.value("dye/grinderBrand").toString().isEmpty()) {
         QString oldModel = m_settings.value("dye/grinderModel").toString();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1862,8 +1862,6 @@ int main(int argc, char *argv[])
         static bool wasSuspended = false;
 
         if (state == Qt::ApplicationSuspended) {
-            // App is being suspended (mobile) - sleep scale to save battery
-            qDebug() << "App suspended - sleeping scale (DE1 stays awake)";
             wasSuspended = true;
 
 #ifdef Q_OS_ANDROID
@@ -1875,17 +1873,11 @@ int main(int argc, char *argv[])
             QAccessible::setActive(false);
 #endif
 
-            if (physicalScale && physicalScale->isConnected()) {
-                QEventLoop waitLoop;
-                bool scaleDone = false;
-                QObject::connect(physicalScale.get(), &ScaleDevice::sleepCompleted,
-                                 &waitLoop, [&]() { scaleDone = true; waitLoop.quit(); });
-                physicalScale->sleep();
-                if (!scaleDone) {
-                    QTimer::singleShot(1500, &waitLoop, &QEventLoop::quit);
-                    waitLoop.exec();
-                }
-            }
+            // Scale is NOT put to sleep when the app is backgrounded — scale sleep
+            // is tied to the machine going to sleep, not the app lifecycle. Users
+            // frequently switch to other apps (e.g., Claude) and expect the scale
+            // to remain connected when they return.
+
             // DE1 intentionally NOT put to sleep - user may be checking other apps
             // while machine heats up
 
@@ -1899,8 +1891,7 @@ int main(int argc, char *argv[])
             batteryManager.ensureChargerOn();
         }
         else if (state == Qt::ApplicationActive && wasSuspended) {
-            // App resumed from suspended state - wake scale
-            qDebug() << "App resumed - waking scale";
+            qDebug() << "App resumed from suspended state";
             wasSuspended = false;
 
 #ifdef Q_OS_ANDROID
@@ -1921,9 +1912,10 @@ int main(int argc, char *argv[])
                 }
             }
 
-            // Try to reconnect/wake scale
+            // Scale was not put to sleep on suspend, so it should still be connected.
+            // If the OS dropped the BLE connection anyway, start the reconnect sequence.
             if (physicalScale && physicalScale->isConnected()) {
-                physicalScale->wake();
+                qDebug() << "App resumed - scale still connected";
             } else if (!settings.scaleAddress().isEmpty() && !scaleReconnectTimer.isActive()) {
                 // Scale disconnected while suspended - restart reconnect sequence
                 scaleReconnectAttempt = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1854,9 +1854,9 @@ int main(int argc, char *argv[])
     settings.setLauncherMode(settings.launcherMode());
 #endif
 
-    // Cross-platform lifecycle handling: manage scale when app is suspended/resumed
-    // Note: DE1 is NOT put to sleep when backgrounded - users may switch apps while
-    // the machine is heating up and expect it to continue (e.g., checking Visualizer)
+    // Cross-platform lifecycle handling: manage BLE connections and system state
+    // when app is suspended/resumed. Neither DE1 nor scale are put to sleep when
+    // backgrounded — users may switch apps while the machine heats up.
     QObject::connect(&app, &QGuiApplication::applicationStateChanged,
                      [&physicalScale, &bleManager, &settings, &batteryManager, &de1Device, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &de1ReconnectTimer, &de1ReconnectAttempt](Qt::ApplicationState state) {
         static bool wasSuspended = false;
@@ -1876,7 +1876,11 @@ int main(int argc, char *argv[])
             // Scale is NOT put to sleep when the app is backgrounded — scale sleep
             // is tied to the machine going to sleep, not the app lifecycle. Users
             // frequently switch to other apps (e.g., Claude) and expect the scale
-            // to remain connected when they return.
+            // to remain connected when they return. On Android, the scale BLE
+            // connection stays alive only while the DE1 foreground service is
+            // running (provides the wake lock); without it the OS may freeze
+            // the event loop and drop the scale. The reconnect-on-resume path
+            // below handles that case.
 
             // DE1 intentionally NOT put to sleep - user may be checking other apps
             // while machine heats up


### PR DESCRIPTION
## Summary
- **Scale stays connected when backgrounding the app.** Previously `scale.sleep()` was called on app suspend, powering off the scale and dropping BLE. Now scale sleep is only tied to the machine sleeping. On Android the scale BLE stays alive while the DE1 foreground service is running (wake lock); on iOS the `bluetooth-central` background mode keeps CoreBluetooth alive. If the OS does drop the connection, the reconnect-on-resume path handles it.
- **Fixed auto flow calibration feedback loop for flow profiles.** The DE1's PID locks reported flow to the target regardless of calibration factor, so the old formula `ideal = factor × weightFlow / (reportedFlow × density)` made ideal proportional to the current factor — it could only decrease, never converge. Over 30 shots the factor drifted from 1.0 down to 0.59. Fixed by using the profile's target flow directly: `ideal = weightFlow / (targetFlow × density)`. Only extraction frames are checked (preinfusion frames are skipped since they are always flow-controlled even in pressure profiles). Pressure profiles keep the existing formula (which works correctly since the machine doesn't control flow).
- **One-time migration resets all calibrations** so users don't have to wait for the EMA to slowly recover from drifted values.
- **Updated `docs/AUTO_FLOW_CALIBRATION.md`** with the v3 algorithm: flow vs pressure profile distinction, both formulas, feedback loop explanation, and v3 migration section.

## Test plan
- [ ] Background the app on Android (switch to Claude), confirm scale stays connected when returning (DE1 must be connected for wake lock)
- [ ] Background the app on iOS, confirm scale stays connected
- [ ] Run an espresso with a flow profile (D-Flow) and check debug log for `Auto flow cal: flow profile — using target flow`
- [ ] Verify the ideal factor is reasonable (~0.9-1.1) and doesn't systematically decrease over multiple shots
- [ ] Run an espresso with a pressure profile (e.g., Classic Italian with flow preinfusion) and verify it is NOT classified as a flow profile (`mode: pressure` in log)
- [ ] Confirm calibration values are reset to 1.0 on first launch after upgrade (check for `v3 flow profile feedback loop fix` in log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)