### PR TITLE
fix: keep Qt event loop running on Android when backgrounded

### DIFF
--- a/android/AndroidManifest.xml.in
+++ b/android/AndroidManifest.xml.in
@@ -55,6 +55,12 @@
             </intent-filter>
 
             <meta-data android:name="android.app.lib_name" android:value="Decenza" />
+            <!-- Keep Qt event loop running when app is backgrounded. Without this,
+                 Qt freezes the event loop when the activity is suspended (no EGL surface),
+                 which kills the HTTP/MCP server. Users switch to Claude for remote control
+                 and need the server to stay responsive. The render thread safely handles
+                 the missing EGL surface (non-fatal "makeCurrent: no EGLSurface" warnings). -->
+            <meta-data android:name="android.app.background_running" android:value="true"/>
             <meta-data
                 android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
                 android:resource="@xml/device_filter" />

--- a/android/AndroidManifest.xml.in
+++ b/android/AndroidManifest.xml.in
@@ -58,8 +58,14 @@
             <!-- Keep Qt event loop running when app is backgrounded. Without this,
                  Qt freezes the event loop when the activity is suspended (no EGL surface),
                  which kills the HTTP/MCP server. Users switch to Claude for remote control
-                 and need the server to stay responsive. The render thread safely handles
-                 the missing EGL surface (non-fatal "makeCurrent: no EGLSurface" warnings). -->
+                 and need the server to stay responsive.
+                 Safety requires the QAccessible::setActive(false) call in main.cpp's
+                 ApplicationSuspended handler — it disables the accessibility bridge
+                 before the EGL surface is destroyed, preventing a SIGABRT deadlock
+                 between QtAndroidAccessibility and the render thread's eglSurface()
+                 swap. With that guard in place, the "makeCurrent: no EGLSurface"
+                 warnings from the render thread are non-fatal. Do NOT remove this
+                 flag without also reconsidering that guard, and vice versa. -->
             <meta-data android:name="android.app.background_running" android:value="true"/>
             <meta-data
                 android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"

--- a/android/src/io/github/kulitorum/decenza_de1/BleConnectionService.java
+++ b/android/src/io/github/kulitorum/decenza_de1/BleConnectionService.java
@@ -51,13 +51,19 @@ public class BleConnectionService extends Service {
         ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, foregroundServiceType);
 
         // Acquire a partial wake lock to keep the CPU alive while the screen is off.
-        // Without this, Android suspends the Qt event loop when the display sleeps,
-        // freezing all QTimers — including BatteryManager's 60-second USB charger
-        // keepalive. The DE1 has a 10-minute timeout that re-enables/resets its USB
-        // port if it receives no BLE writes. On battery-free tablets (Teclast P85Pro
-        // etc.) this causes an instant power cut and the tablet dies. The wake lock
-        // ensures BatteryManager keeps sending "charger ON" every 60s, matching
-        // de1app's behavior where Tcl timers never pause.
+        // This complements the android.app.background_running=true manifest flag:
+        //   - background_running keeps the Qt event loop alive when the activity is
+        //     backgrounded (screen on, another app in front).
+        //   - This wake lock keeps the CPU from suspending when the display turns
+        //     off entirely. Without it, Android suspends the Qt event loop,
+        //     freezing all QTimers — including BatteryManager's 60-second USB
+        //     charger keepalive.
+        // Both are required for the DE1's 10-minute USB port reset timeout: if the
+        // tablet misses the keepalive, the DE1 re-enables/resets its USB port, and
+        // on battery-free tablets (Teclast P85Pro etc.) this causes an instant
+        // power cut and the tablet dies. The wake lock ensures BatteryManager
+        // keeps sending "charger ON" every 60s, matching de1app's behavior where
+        // Tcl timers never pause.
         //
         // The wake lock is held only while the DE1 is connected (service lifecycle),
         // so it has zero impact when the machine is off or disconnected.


### PR DESCRIPTION
## Summary

- Adds `android.app.background_running=true` meta-data to the Decenza activity so the Qt event loop continues processing while the app is in the background
- Fixes the MCP server (and all QTimers, BLE heartbeats) freezing when the user switches away from Decenza — e.g., to the Claude app for remote DE1 control
- Eliminates the session-storm on resume (log showed 5+ new MCP sessions created in 43ms when clients reconnected after a 5-minute background period)

## Background

Diagnosing the on-device log showed a 310-second gap with zero event loop activity between suspend and resume — no memory snapshots, no BLE heartbeats, no HTTP requests served. Qt for Android's default is to freeze the main event loop on `ApplicationSuspended` because the EGL surface is gone and painting would crash. The `background_running` meta-data opts out of that freeze; the render thread's missing-EGL-surface warnings are already non-fatal in our log.

The BLE foreground service + wake lock keeps the *process* alive (so DE1/scale connections survive), but without this flag the Qt event loop itself is paused, making the HTTP/MCP server unreachable.

## iOS

iOS has no equivalent flag. `bluetooth-central` (already present) only wakes the app for BLE events, not arbitrary TCP. The realistic workarounds there are split view or an in-app web view — out of scope for this PR.

## Test plan

- [ ] Build Android release, connect DE1
- [ ] Connect Claude Code MCP client, issue a few tool calls
- [ ] Switch to Claude app (or any other app) for >60 seconds
- [ ] Verify log shows continued memory snapshots, BLE heartbeats, and MCP requests being served while backgrounded
- [ ] Verify returning to Decenza does not produce a burst of "Session not found, auto-creating new session" entries
- [ ] Sanity: no new crashes or EGL-related SIGABRTs

🤖 Generated with [Claude Code](https://claude.com/claude-code)