### PR TITLE
docs: OpenSpec proposal for Qt Charts → Qt Graphs migration (deferred)

### DIFF
--- a/openspec/changes/migrate-charting-to-qt-graphs/design.md
+++ b/openspec/changes/migrate-charting-to-qt-graphs/design.md
@@ -1,0 +1,131 @@
+# Design: Charting Migration from Qt Charts to Qt Graphs
+
+## Upstream Dependencies
+
+This change is blocked on upstream Qt work. The gates are documented in `proposal.md` under "Gate Conditions"; this section documents the engineering impact of each open issue and how it shapes the design.
+
+### QTBUG-142046 — Axis range API returns stale values
+
+**Link**: [bugreports.qt.io/browse/QTBUG-142046](https://bugreports.qt.io/browse/QTBUG-142046)
+
+**Impact on Decenza**: `ShotGraph.qml` and `HistoryShotGraph.qml` implement a tap-to-inspect feature: the user taps the plot area and a crosshair snaps to the nearest data point, displaying the values at that x. Implementation requires reading the current `ValueAxis.min`/`max` to convert the tap's pixel coordinates into data coordinates. With the bug present, those properties return a constant garbage value (one forum user reported `25.626488705368423`) regardless of the actual visible range — meaning the crosshair would snap to wrong points on any zoomed or programmatically-range-set graph.
+
+**Why we can't work around it**: `GraphsView` does not (as of Qt 6.10–6.11) expose an alternative API that reports the effective axis range. We could track every programmatic range change ourselves in QML and mirror it into a side channel, but (a) that duplicates bookkeeping Qt should own, (b) it doesn't help if the range changes via user interaction (zoom/pan), and (c) maintaining it against a Qt version where the official API starts working again would cause divergence.
+
+**Status monitoring**: Watch the ticket's Fix Version field. A "6.11.x" or "6.12" designation opens the gate.
+
+### Missing bulk-update API on `XYSeries`
+
+**Forum reference**: [forum.qt.io/topic/158993/dynamically-add-point-to-lineseries-of-qml-qt-graphs](https://forum.qt.io/topic/158993)
+
+**Impact on Decenza**: `ShotDataModel` registers `QLineSeries` from QML and calls `replace(QList<QPointF>)` at ~5 Hz during live extraction to push the full updated dataset in one call. Per-point `append()` calls QML→C++ hundreds of times per second, which Qt forum users have flagged as a performance bottleneck.
+
+**Forum workarounds reported**:
+1. Pre-build data in C++ and call `QXYSeries::replace()` from a DataSource class that receives the `QLineSeries*` as a property. Qt users report this is "fast" — unclear if the QML `LineSeries` type exposes `replace()` via a slot (Qt has TODO comments in the source indicating this is planned but not done).
+2. `clear()` + append-in-loop. Forum consensus: works but not performant enough for real-time.
+
+**Design implication**: If by the time gates pass the QML `LineSeries.replace()` slot still isn't exposed, we either (a) keep the current C++-side registration pattern (which should continue to work with Qt Graphs' `QLineSeries` since it inherits from `QXYSeries`), or (b) write a small `SeriesUpdater` C++ class that wraps `QList<QPointF>` replacement. Option (a) is free; option (b) is ~30 lines. Neither is a blocker — just a style choice revealed at spike time.
+
+## Feature-Gap Analysis
+
+Four Qt Charts features used by Decenza have no direct Qt Graphs equivalent. Each needs a bridging strategy before any migration code is written.
+
+### 1. Axis auto-ranging (Charts auto-sizes, Graphs requires explicit `min`/`max`)
+
+**Charts behavior**: `ValueAxis` auto-computes `min`/`max` from attached series data and re-fits on series change.
+
+**Graphs behavior**: Axes have no auto-range; `min`/`max` must be set explicitly. If series data exceeds the range, points clip silently.
+
+**Bridge**: Build `qml/components/graphs/AutoRangingAxis.qml` — a `ValueAxis` subclass that binds `min`/`max` to computed expressions over attached series. Takes:
+- `series: var` — one or more `XYSeries` to track
+- `padding: real` — fraction above/below the data range (default 0.05)
+- `minFloor: real`, `maxCeiling: real` — optional hard clamps (used for temperature axes that should never dip below room temperature)
+
+Recomputes on `series.pointsChanged` and on series list changes. Used everywhere a Qt Charts `ValueAxis` currently relies on auto-range behavior.
+
+### 2. Legend (Charts built-in, Graphs has none)
+
+**Charts behavior**: `ChartView.legend` exposes a fully-themed legend with markers synced to series colors and visibility.
+
+**Graphs behavior**: No built-in legend. Must be built from QML primitives.
+
+**Bridge**: Build `qml/components/graphs/CustomLegend.qml` — a horizontal `Row` of colored-square + label pairs, driven by a list of `{ name, color, visible }` objects. Matches the existing `Theme.qml` styling and supports tap-to-toggle visibility (already used in `ShotGraph` for muting individual series).
+
+### 3. Dash/dot line styles (Charts has `Qt.DashLine`, Graphs does not)
+
+**Charts behavior**: `LineSeries.style: Qt.DashLine | Qt.DotLine | Qt.DashDotLine` renders the stroke pattern in the series itself.
+
+**Graphs behavior**: `LineSeries` is solid-stroke only. Qt Quick Shapes (which Graphs is built on) supports `ShapePath.strokeStyle: ShapePath.DashLine` but not through the `LineSeries` element.
+
+**Bridge**: Build `qml/components/graphs/DashedLineSeries.qml` — a reusable overlay that takes the same `points` binding as a `LineSeries` and draws a `ShapePath` with a `strokeStyle` pattern. Used for goal curves, frame-boundary markers, and phase-transition indicators.
+
+Axis alignment is the tricky part: the `ShapePath` is drawn in plot-area coordinates (pixels), not data coordinates. The component accepts `axisX` and `axisY` references and does the data→pixel mapping using `GraphsView.plotArea` dimensions.
+
+### 4. `plotArea` geometry exposure
+
+**Charts behavior**: `ChartView.plotArea` returns a `rect` usable for pixel↔data coordinate mapping (used by crosshairs and the "inspect this point" feature in `ShotGraph`).
+
+**Graphs behavior**: `GraphsView` exposes plot-area geometry via different properties — need to verify during Stage 0 whether `marginLeft`/`marginRight`/`marginTop`/`marginBottom` are sufficient or if a custom property binding is needed. If inadequate, file an upstream Qt bug; in the interim, compute geometry from `width`/`height` minus axis sizes.
+
+## Staged-Migration Rationale
+
+### Why 5 stages and not a big-bang rewrite?
+
+- **Each graph is isolated.** `ShotGraph` and `SteamGraph` do not share QML code; they can migrate independently.
+- **The app remains usable between stages.** At every stage boundary, both Charts and Graphs are linked and in use. A staged rollback of a single graph is cheap — just revert that graph's file.
+- **Feedback accumulates.** Lessons from Stage 1 (FlowCalibrationPage) materially shape Stages 2–3 design. A big-bang approach commits to decisions before validating them on even one graph.
+- **CI stays green throughout.** No long-lived migration branch; each stage is a regular PR to `main`.
+
+### Stage ordering justification
+
+| Stage | Target | Why this order |
+|---|---|---|
+| 0 | Infrastructure only | Defer all visible change until bridge components exist |
+| 1 | `FlowCalibrationPage` | Smallest surface (~272 lines, 40% chart) — validates the pattern with lowest blast radius |
+| 2 | `SteamGraph` + `SteamDataModel` | Simpler than espresso (fewer axes, no goal curves, no interactive crosshairs) — second-easiest win |
+| 3 | Espresso graphs (4 QML + 2 C++ models) | Hardest. By this point the bridge components are battle-tested and the migration pattern is well-understood |
+| 4 | Remove Charts dependency | Must be last: cannot remove the import until every graph has migrated |
+
+### Why not migrate C++ models first, QML last (or vice-versa)?
+
+Qt Charts and Qt Graphs both use `QLineSeries` at the C++ level but from different namespaces (`QtCharts::QLineSeries` vs `QtGraphs::QLineSeries`). They are not interchangeable — a `replaceSeries()` call into a QML-side `QtGraphs.LineSeries` from a C++ `QtCharts::QLineSeries` would fail at runtime. Each graph's QML and C++ sides must migrate together in a single stage.
+
+## Performance Measurement
+
+Before Stage 1 begins, capture baseline metrics so each stage can be evaluated against them:
+
+1. **Live shot FPS** — run a shot on the Decent tablet (Samsung SM-X210) with `QSG_RENDER_TIMING=1`, log min/median/max frame times during the 30-second pour. Expected baseline: ~16.7 ms median (60 fps).
+2. **History scroll smoothness** — scroll the shot history list with 200+ entries; measure scroll FPS via Qt Quick profiler.
+3. **Graph first-paint latency** — time from `Component.onCompleted` on a `ShotGraph` to first frame rendered. Baseline is whatever Charts currently delivers.
+4. **Memory footprint** — `QProcess::RssUsage` after opening the history view with 50 shots; Graphs is expected to be lower due to dropping the Graphics View framework.
+
+Record baselines in `docs/CLAUDE_MD/PERFORMANCE_BASELINE.md` (new file in Stage 0). Re-measure at each stage boundary and note regressions in the PR description.
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| **QTBUG-142046 regresses after initial fix** (axis range API) | Low | High (breaks crosshairs) | Stage 0 spike re-runs the regression test; hold Stage 1 if regressed |
+| Qt Graphs `plotArea` API insufficient for crosshairs | Medium | High (blocks ShotGraph migration) | Prototype in Stage 0 before committing to Stage 3 scope |
+| `DashedLineSeries` axis mapping is buggy at axis-range changes | Medium | Medium | Stage 1 pilot stress-tests this on flow-cal goal curves |
+| Visual fidelity diverges (anti-aliasing, line thickness) | High | Low | Acceptable — document divergence, don't chase pixel-perfect parity |
+| Live shot FPS regresses on lower-end Android tablets | Low | High | Measure in Stage 1 on the oldest supported hardware; abort migration if >10% regression |
+| Qt version with fixes has a *different* blocking bug | Medium | Medium | Stage 0 spike catches it before any migration code ships |
+| `QXYSeries::replace()` slot not exposed to QML | Medium | Low | C++-side registration continues to work; ~30 lines of bridge code as fallback |
+| Qt announces Qt 7 release date sooner than expected, compressing migration timeline | Low | Medium | Gates already include a Qt 7 escalation clause in `proposal.md` |
+
+## Open Questions
+
+- **Does Qt 6.10 Graphs support series `replace()` with a `QList<QPointF>`?** If not, `ShotDataModel::registerSeries()` needs an alternative bulk-update path (possibly `setPoints()` on each update). Must be answered in Stage 0.
+- **Does `GraphsView` respect the parent `QQuickItem` clip rect?** Current `ChartView`-based graphs rely on plot-area clipping when overlays draw out of range. Verify before Stage 1.
+- **Theme system compatibility.** Qt Graphs uses `GraphsTheme` (unified 2D/3D theme). Does it play nicely with Decenza's `Theme.qml` singleton, or does `Theme.qml` need new properties to feed `GraphsTheme`? Defer decision to Stage 0 spike.
+
+## Rollback Plan
+
+If any stage must be rolled back mid-migration:
+
+1. **Stage 0 rollback**: Remove `Qt6::Graphs` from `CMakeLists.txt`, delete `qml/components/graphs/`. No user impact — nothing was using it.
+2. **Stage 1–3 rollback**: `git revert` the stage's PR. Qt Charts path remains intact in every preceding commit. No data migration or setting reset needed.
+3. **Stage 4 rollback**: Re-add `Charts` to `CMakeLists.txt`. No QML code changes needed since Stage 4 only removes the dependency.
+
+All rollbacks are clean because Charts and Graphs coexist in the build from Stage 0 through Stage 3.

--- a/openspec/changes/migrate-charting-to-qt-graphs/proposal.md
+++ b/openspec/changes/migrate-charting-to-qt-graphs/proposal.md
@@ -1,0 +1,85 @@
+# Change: Migrate Charting from Qt Charts to Qt Graphs
+
+## Status: DEFERRED — MONITOR UPSTREAM
+
+**This change is not ready to start.** Qt Graphs (Decenza's intended successor to Qt Charts) has upstream blockers that prevent a clean migration today. This proposal captures the plan, the blocking conditions, and the monitoring cadence so the work isn't forgotten and can be picked up as soon as upstream gates pass.
+
+**Earliest re-evaluation: after Qt 6.11.1 is released.** See the "Gate Conditions" section below.
+
+## Why
+
+Qt Charts was deprecated in Qt 6.10 (the version Decenza targets) and is stuck on the Qt 4-era Graphics View Framework — software-rendered, Widgets-coupled, and not GPU-accelerated. Qt's successor is **Qt Graphs**, which renders via Qt Quick Shapes + Qt RHI, using each platform's native backend (Metal on macOS/iOS, Direct3D on Windows, Vulkan/OpenGL on Linux). Shot graphs are the most GPU-intensive surface in Decenza — running them on the modern pipeline is the right long-term direction.
+
+Qt Charts will not be removed imminently: per the Qt forum consensus it remains available for **the entire lifetime of Qt 6** (shipped late 2020, still the current major version), and is only removed in **Qt 7** (no announced release date). Qt staff have publicly stated *"for new projects it's recommended to start with Qt Graphs. But there's nothing wrong with using Qt Charts"* and *"if you can (i.e. no feature is missing) use Qt Graphs as Qt Charts will be phased out eventually."* The migration is a *when*, not *if* — but the "when" is gated on Qt Graphs closing its current feature gaps, not on internal Decenza timing.
+
+## Gate Conditions (required before Stage 0 starts)
+
+Stage 0 SHALL NOT begin until **all** of the following are true. Each condition is verifiable without ambiguity.
+
+1. **[QTBUG-142046](https://bugreports.qt.io/browse/QTBUG-142046)** — *Axis range properties on `GraphsView` return stale/constant values regardless of zoom/pan* — is closed as fixed in a released Qt version, AND that Qt version ships with the functionality fix verified via a 10-line QML reproducer (`ValueAxis.min` updates after programmatic range change). This bug is a **hard blocker** because `ShotGraph.qml`'s crosshair/inspect feature relies on reading the current axis range to map pixel↔data coordinates. Without a correct axis range API, the crosshair cannot be migrated.
+
+2. **Qt Graphs 2D migration guide** ([doc.qt.io/qt-6/qtgraphs-migration-guide-2d.html](https://doc.qt.io/qt-6/qtgraphs-migration-guide-2d.html)) no longer contains a "Missing features" or equivalent caveat section for the features Decenza uses: built-in legend (or a sanctioned bridge pattern), axis auto-ranging (or sanctioned bridge pattern), dash/dot line strokes, and an approved pixel↔data coordinate mapping API.
+
+3. **`QXYSeries::replace(QList<QPointF>)` or equivalent bulk-update API** is officially supported in Qt Graphs and documented. Decenza's C++ data models (`ShotDataModel`, `SteamDataModel`, `ShotComparisonModel`) rely on this for efficient series population at ~5 Hz during live extraction; per-point `append()` is not performant enough.
+
+4. **Qt 6.11.1 is released** (earliest re-evaluation window). 6.11.0 release notes are insufficient on their own — patch releases typically land the bug fixes that accumulate during the .0's stability period.
+
+### Re-evaluation cadence (until all gates pass)
+
+- Check Qt release notes at every Qt minor release (`6.11.0`, `6.11.1`, `6.12.0`, ...): search for "Graphs", "QTBUG-142046", and any mention of the missing features.
+- Skim the Qt forum Graphs category monthly for new gap reports or workaround patterns.
+- If Qt 7 gets an announced release date with a Charts-removal timeline, escalate priority even if gates aren't fully met.
+
+### If gates pass but new blockers emerge
+
+This proposal's Stage 0 includes a technical spike (`tasks.md` §0.2) that validates the gates on the actual Decenza codebase before any user-visible work begins. If the spike reveals new blockers (e.g., the bulk `replace()` API exists but has a performance regression at our data rates), those blockers go into a new "Gate Conditions" update to this proposal, and Stage 0 pauses until they clear too.
+
+## What Changes
+
+**Staged migration** across five phases. Each phase is independently shippable; the app remains fully functional at every stage boundary, with no flag-day cutover.
+
+- **Stage 0 — Foundation**: Add `Qt6::Graphs` to the build alongside `Qt6::Charts` (both import paths coexist). Build reusable QML components (`AutoRangingAxis`, `CustomLegend`, `DashedLineSeries`) that close the remaining feature gaps between Charts and Graphs.
+- **Stage 1 — Pilot**: Migrate `FlowCalibrationPage.qml` (smallest graph, ~40% chart code) as a proof of concept to validate the pattern end-to-end.
+- **Stage 2 — Steam graph**: Migrate `SteamGraph.qml` + `SteamDataModel` C++ backing (simpler than espresso graphs — fewer axes, no goal curves).
+- **Stage 3 — Espresso graphs**: Migrate the four espresso graph families (`ShotGraph`, `HistoryShotGraph`, `ComparisonGraph`, `ProfileGraph`) and their C++ backing (`ShotDataModel`, `ShotComparisonModel`).
+- **Stage 4 — Cleanup**: Remove `Qt6::Charts` from `CMakeLists.txt`, delete migration shim components, uninstall Qt Charts from dev machines, close the migration.
+
+**Intentionally out of scope**: visual redesign of any graph (migration is mechanical fidelity only), migration of `FastLineRenderer` (already bypasses Qt Charts — survives intact), migration of Canvas-based phase markers in `ComparisonGraph` (independent of Charts).
+
+## What Changes
+
+**Staged migration** across five phases. Each phase is independently shippable; the app remains fully functional at every stage boundary, with no flag-day cutover.
+
+- **Stage 0 — Foundation**: Add `Qt6::Graphs` to the build alongside `Qt6::Charts` (both import paths coexist). Build reusable QML components (`AutoRangingAxis`, `CustomLegend`, `DashedLineSeries`) that close the feature gaps between Charts and Graphs.
+- **Stage 1 — Pilot**: Migrate `FlowCalibrationPage.qml` (smallest graph, ~40% chart code) as a proof of concept to validate the pattern end-to-end.
+- **Stage 2 — Steam graph**: Migrate `SteamGraph.qml` + `SteamDataModel` C++ backing (simpler than espresso graphs — fewer axes, no goal curves).
+- **Stage 3 — Espresso graphs**: Migrate the four espresso graph families (`ShotGraph`, `HistoryShotGraph`, `ComparisonGraph`, `ProfileGraph`) and their C++ backing (`ShotDataModel`, `ShotComparisonModel`).
+- **Stage 4 — Cleanup**: Remove `Qt6::Charts` from `CMakeLists.txt`, delete migration shim components, uninstall Qt Charts from dev machines, close the migration.
+
+**Intentionally out of scope**: visual redesign of any graph (migration is mechanical fidelity only), migration of `FastLineRenderer` (already bypasses Qt Charts — survives intact), migration of Canvas-based phase markers in `ComparisonGraph` (independent of Charts).
+
+## Impact
+
+- **Affected specs**: `charting` (new capability — codifies Decenza's graphing contract so future rendering-backend swaps are cheaper)
+- **Affected code**:
+  - `CMakeLists.txt` — add `Graphs` component, drop `Charts` in Stage 4
+  - `qml/components/ShotGraph.qml`, `HistoryShotGraph.qml`, `ComparisonGraph.qml`, `SteamGraph.qml`, `ProfileGraph.qml` (~2 350 lines of QML)
+  - `qml/pages/FlowCalibrationPage.qml` (~272 lines)
+  - `src/models/shotdatamodel.{h,cpp}`, `src/models/steamdatamodel.{h,cpp}`, `src/models/shotcomparisonmodel.{h,cpp}` (~1 460 lines)
+  - New QML components under `qml/components/graphs/` — `AutoRangingAxis.qml`, `CustomLegend.qml`, `DashedLineSeries.qml`
+- **Performance target**: graphs render at ≥60 fps during live extraction on Decent tablet (Samsung SM-X210) — measured via `Qt Quick Scene Graph` profiler; no regression on existing frame-drop tests (currently frame drops <1% of extraction time).
+- **Risk**: mid-migration regressions are the largest hazard. Mitigation is the staged approach — each stage ships to `main` independently with the full test protocol (see `design.md`).
+
+## Success Criteria
+
+- Every graph in the app renders with visual fidelity matching the pre-migration baseline (side-by-side screenshot comparison on Windows, macOS, Android).
+- No user-visible feature regressions (crosshairs, axis toggling, dash-line goal curves, phase markers, zoom/pan if present, legend).
+- Shot-history list with 100+ entries opens and scrolls at the same speed or faster than the Qt Charts baseline.
+- Live shot graphing on the Decent tablet maintains ≥60 fps during the densest extraction phase (high-flow pour with scale updates at 20 Hz).
+- `CMakeLists.txt` contains no reference to `Qt6::Charts`; the Qt Charts library can be uninstalled with no build or runtime breakage.
+
+## Non-Goals
+
+- **No new graphing features** as part of the migration. Adding zoom, new series types, or theming changes is a separate future change after Stage 4 archives.
+- **No 3D graphs.** Qt Graphs supports 3D; Decenza has no 3D graph use case today.
+- **No QSGGeometryNode rewrite.** The existing `FastLineRenderer` pattern is faster than either Charts or Graphs for live data and stays as-is.

--- a/openspec/changes/migrate-charting-to-qt-graphs/specs/charting/spec.md
+++ b/openspec/changes/migrate-charting-to-qt-graphs/specs/charting/spec.md
@@ -1,0 +1,140 @@
+# Spec Delta: charting
+
+## ADDED Requirements
+
+### Requirement: Upstream Qt Graphs Readiness Gates
+
+Implementation of this capability SHALL NOT begin until every one of the following upstream conditions is satisfied and documented in `openspec/changes/migrate-charting-to-qt-graphs/tasks.md` under Pre-Stage 0.
+
+#### Scenario: QTBUG-142046 resolution verified
+- **WHEN** an engineer checks the axis-range API readiness gate
+- **THEN** [QTBUG-142046](https://bugreports.qt.io/browse/QTBUG-142046) (axis range properties return stale/constant values on `GraphsView`) SHALL be marked "Closed" with a Fix Version corresponding to a released Qt version
+- **AND** a 10-line QML reproducer SHALL demonstrate that programmatic axis range changes are readable via `ValueAxis.min`/`max` on that Qt version
+
+#### Scenario: Qt Graphs migration guide signals parity
+- **WHEN** an engineer checks the feature-parity gate
+- **THEN** Qt's published [Qt Graphs 2D migration guide](https://doc.qt.io/qt-6/qtgraphs-migration-guide-2d.html) SHALL either contain no "Missing features" caveat relevant to Decenza (built-in legend, axis auto-ranging, dashed/dotted line strokes, pixel↔data coordinate mapping), OR document sanctioned bridge patterns for each
+
+#### Scenario: Bulk series update API available
+- **WHEN** an engineer checks the bulk-update gate
+- **THEN** Qt Graphs SHALL expose a documented, supported bulk-update API equivalent to `QXYSeries::replace(QList<QPointF>)` suitable for ~5 Hz dataset replacement without measurable per-call overhead
+
+#### Scenario: Qt 6.11.1 released
+- **WHEN** an engineer checks the minimum-version gate
+- **THEN** Qt 6.11.1 or later SHALL have been released and available on all Decenza-supported platforms (Windows MSVC 2022, macOS, iOS, Android)
+
+### Requirement: Rendering Backend
+
+The charting subsystem SHALL use Qt Graphs (GPU-accelerated, Qt Quick Shapes-based) as its sole rendering backend. Qt Charts (Graphics View-based) SHALL NOT be present in the build.
+
+#### Scenario: Build configuration omits Qt Charts
+- **WHEN** a developer inspects `CMakeLists.txt`
+- **THEN** `find_package(Qt6 ...)` SHALL include `Graphs` but NOT `Charts`
+- **AND** no source file SHALL `#include <QtCharts/...>` or reference `QtCharts::` namespaces
+- **AND** no QML file SHALL `import QtCharts`
+
+#### Scenario: Live shot graph renders on GPU
+- **WHEN** a user starts an espresso shot on the Decent tablet (Samsung SM-X210)
+- **THEN** `ShotGraph.qml` SHALL render via `GraphsView`
+- **AND** the render loop SHALL maintain ≥60 fps during the densest extraction phase
+- **AND** no Qt Charts symbols SHALL be loaded at runtime
+
+### Requirement: Axis Ranging
+
+Axes on any Decenza graph SHALL have a defined visible range at all times, either explicitly configured or automatically computed from attached series data.
+
+#### Scenario: Auto-ranging axis tracks series data
+- **WHEN** an `AutoRangingAxis` is bound to one or more `XYSeries` with a non-empty point set
+- **THEN** its `min` SHALL equal the minimum y-value across all attached series minus `padding`
+- **AND** its `max` SHALL equal the maximum y-value across all attached series plus `padding`
+- **AND** it SHALL recompute on any `pointsChanged` signal from an attached series
+
+#### Scenario: Auto-ranging axis respects floor and ceiling clamps
+- **WHEN** an `AutoRangingAxis` has a non-null `minFloor` and the data minimum would be below it
+- **THEN** the axis `min` SHALL be clamped to `minFloor`
+- **AND** the same SHALL apply for `maxCeiling`
+
+#### Scenario: Explicit range overrides
+- **WHEN** a graph's axis has an explicit `min` and `max` set directly (not `AutoRangingAxis`)
+- **THEN** the axis SHALL use exactly those values regardless of series data
+
+### Requirement: Legend
+
+Any graph that displays two or more user-distinguishable series SHALL provide a legend identifying each series by name and color.
+
+#### Scenario: Legend displays all visible series
+- **WHEN** a graph has multiple visible series
+- **THEN** a `CustomLegend` SHALL render one entry per series
+- **AND** each entry SHALL show the series color and display name
+- **AND** entries SHALL match `Theme.qml`-defined fonts and spacing
+
+#### Scenario: Legend toggles series visibility
+- **WHEN** a user taps a legend entry
+- **THEN** the corresponding series `visible` property SHALL toggle
+- **AND** the legend entry SHALL visually indicate the muted state (reduced opacity)
+
+### Requirement: Dashed Line Overlays
+
+Goal curves, frame-boundary markers, and phase-transition indicators SHALL support dashed and dotted stroke patterns.
+
+#### Scenario: Dashed goal curve
+- **WHEN** a `DashedLineSeries` is configured with `stroke: DashedLineSeries.DashLine`, `axisX`, `axisY`, and a `points` array
+- **THEN** it SHALL render a `ShapePath` with `strokeStyle: ShapePath.DashLine`
+- **AND** each point SHALL map from data space to pixel space using the attached axes' current ranges and the parent `GraphsView.plotArea` geometry
+- **AND** the pattern SHALL re-map on axis range changes, series changes, and view resize
+
+### Requirement: Pixel-to-Data Coordinate Mapping
+
+Graphs that implement crosshair, tap-to-inspect, or overlay positioning features SHALL expose a deterministic mapping between pixel coordinates and data coordinates.
+
+#### Scenario: Crosshair aligns with underlying data point
+- **WHEN** a user taps a location within the plot area of a graph that supports inspection
+- **THEN** the crosshair SHALL position at the nearest data point's screen coordinates
+- **AND** the inspected data values SHALL be read directly from the series at that x-value
+- **AND** the mapping SHALL remain correct across window resizes and axis range changes
+
+### Requirement: Performance Parity
+
+The migration from Qt Charts to Qt Graphs SHALL NOT regress graph rendering performance.
+
+#### Scenario: Live shot FPS maintained
+- **WHEN** a shot is running on the Decent tablet with a physical BLE scale reporting at 20 Hz
+- **AND** the `ShotGraph` is displaying live pressure, flow, temperature, and weight traces
+- **THEN** the median frame time SHALL be ≤16.7 ms (60 fps)
+- **AND** the 99th-percentile frame time SHALL be ≤33.3 ms (30 fps)
+- **AND** these metrics SHALL meet or beat the documented Qt Charts baseline in `docs/CLAUDE_MD/PERFORMANCE_BASELINE.md`
+
+#### Scenario: History list scroll smoothness
+- **WHEN** a user scrolls the shot history list containing ≥200 entries
+- **AND** each row contains a `HistoryShotGraph`
+- **THEN** scroll FPS SHALL be ≥60 fps on the Decent tablet
+- **AND** SHALL meet or beat the Qt Charts baseline
+
+### Requirement: Live Series Rendering
+
+The existing `FastLineRenderer` pattern (custom `QSGGeometryNode` subclass for high-frequency live data) SHALL continue to function as a direct scene-graph renderer, bypassing the Qt Graphs series abstraction.
+
+#### Scenario: FastLineRenderer integration survives migration
+- **WHEN** the app is built and run post-migration
+- **THEN** live pressure/flow/temperature/weight traces on `ShotGraph` and `SteamGraph` SHALL render via `FastLineRenderer`
+- **AND** no measurable performance change SHALL occur in live-trace rendering vs the pre-migration state
+- **AND** goal curves and historical traces SHALL render via standard `QtGraphs.LineSeries` or `DashedLineSeries`
+
+### Requirement: Bridge Components Location
+
+Reusable QML components that close feature gaps between Qt Charts and Qt Graphs SHALL live under `qml/components/graphs/` and be registered in `CMakeLists.txt`'s `qt_add_qml_module` file list.
+
+#### Scenario: Bridge components discoverable
+- **WHEN** a developer opens `qml/components/graphs/`
+- **THEN** they SHALL find at minimum: `AutoRangingAxis.qml`, `CustomLegend.qml`, `DashedLineSeries.qml`
+- **AND** each SHALL be documented at the top of the file with usage notes and the Charts feature it replaces
+
+### Requirement: Rollback Safety Through Stages
+
+Each migration stage SHALL be independently revertable via a single `git revert` without requiring data migration, setting changes, or cross-stage coordination.
+
+#### Scenario: Mid-migration rollback
+- **WHEN** a regression is discovered after Stage N (1 ≤ N ≤ 3) has merged
+- **THEN** reverting Stage N's merge commit SHALL restore the pre-Stage-N graph behavior
+- **AND** all earlier stages' graphs SHALL continue to function
+- **AND** Qt Charts SHALL still be present in the build through Stage 3

--- a/openspec/changes/migrate-charting-to-qt-graphs/tasks.md
+++ b/openspec/changes/migrate-charting-to-qt-graphs/tasks.md
@@ -1,0 +1,165 @@
+# Tasks: Migrate Charting to Qt Graphs
+
+Each stage below is independently shippable as its own PR. Do not start a stage until the previous stage has been merged, tested on hardware, and its performance measurements recorded.
+
+**Stage 0 is currently GATED on upstream Qt work.** Complete the monitoring tasks in the "Pre-Stage 0 — Upstream Monitoring" section below before beginning any implementation work.
+
+## Pre-Stage 0 — Upstream Monitoring (active now)
+
+This section's tasks run until the gate conditions in `proposal.md` are satisfied. They are intentionally lightweight so they don't compete with other active work.
+
+### P.1 Set up monitoring
+- [ ] Subscribe to [QTBUG-142046](https://bugreports.qt.io/browse/QTBUG-142046) (click "Watch") to get notified on status changes
+- [ ] Bookmark the [Qt Graphs 2D migration guide](https://doc.qt.io/qt-6/qtgraphs-migration-guide-2d.html) for periodic re-read
+- [ ] Add a recurring reminder (calendar or task tracker) to re-check gates at each Qt release
+
+### P.2 Quarterly gate check (or at every Qt release, whichever comes first)
+- [ ] Read the Qt release notes for each new minor or patch version (`6.11.0`, `6.11.1`, `6.12.0`, …). Search for: `Graphs`, `QTBUG-142046`, `LineSeries`, `ValueAxis`
+- [ ] Review the migration guide for changes to its "Missing features" section
+- [ ] Scan the Qt forum's Graphs category for new gap reports or sanctioned workarounds
+- [ ] If any gate condition flips from open → closed, update this file, then notify whoever owns the migration decision
+
+### P.3 Earliest checkpoint: Qt 6.11.1 release
+- [ ] When Qt 6.11.1 ships, do a full gate-condition audit. If all four gates pass, write up findings and request approval to begin Stage 0. If gates remain open, document which ones and revise the "earliest re-evaluation" date in `proposal.md`
+
+## Stage 0 — Foundation
+
+**Precondition**: All four gate conditions in `proposal.md` satisfied and documented in a recent Pre-Stage 0 gate-check entry.
+
+### 0.1 Build system
+- [ ] Install Qt Graphs component via Qt Maintenance Tool (dev machines only at this stage)
+- [ ] Add `Graphs` to the `find_package(Qt6 REQUIRED COMPONENTS ...)` list in `CMakeLists.txt`
+- [ ] Add `Qt6::Graphs` to `target_link_libraries(Decenza PRIVATE ...)`
+- [ ] Verify clean build on Windows, macOS, iOS, Android with both `Charts` and `Graphs` linked
+- [ ] Update `openspec/project.md` Tech Stack section to list `Graphs` alongside `Charts`
+
+### 0.2 Spike — verify gate conditions on real Decenza code
+- [ ] **Re-verify QTBUG-142046 is fixed**: write a 10-line QML reproducer that programmatically changes an axis range and reads it back. If the readback lies, halt Stage 0 and reopen Pre-Stage 0 monitoring.
+- [ ] Confirm the released Qt version's `XYSeries::replace()` signature and data format; document in `design.md`. If QML `LineSeries.replace()` is still not exposed as a slot, prototype the 30-line `SeriesUpdater` bridge described in `design.md` §Upstream Dependencies.
+- [ ] Verify `GraphsView.plotArea` / margin properties are sufficient for crosshair pixel↔data mapping; if not, file a Qt upstream bug and document workaround
+- [ ] Test `GraphsView` clipping behavior with overlays drawn outside the plot area
+- [ ] Decide `GraphsTheme` integration strategy with Decenza's `Theme.qml` singleton
+
+### 0.3 Bridge components
+- [ ] Create `qml/components/graphs/AutoRangingAxis.qml` — wraps `ValueAxis` with auto-range behavior from attached series; supports `padding`, `minFloor`, `maxCeiling`
+- [ ] Create `qml/components/graphs/CustomLegend.qml` — themed horizontal legend with tap-to-toggle visibility; driven by `{ name, color, visible }` model
+- [ ] Create `qml/components/graphs/DashedLineSeries.qml` — `ShapePath`-based dashed-stroke overlay aligned to `axisX`/`axisY`; data→pixel mapping via `GraphsView.plotArea`
+- [ ] Register each component in `CMakeLists.txt` `qt_add_qml_module` file list
+
+### 0.4 Performance baseline
+- [ ] Create `docs/CLAUDE_MD/PERFORMANCE_BASELINE.md` documenting the measurement protocol
+- [ ] Record baseline metrics on Decent tablet (Samsung SM-X210):
+  - Live shot FPS during a 30-second pour (`QSG_RENDER_TIMING=1`)
+  - Shot history scroll FPS with 200+ entries
+  - Graph first-paint latency
+  - Memory footprint after opening history with 50 shots
+- [ ] Record baseline on Windows dev machine and macOS for comparison
+
+### 0.5 Stage 0 PR
+- [ ] Open PR with title `feat: add Qt Graphs alongside Qt Charts (migration Stage 0)`
+- [ ] PR description lists bridge components added, spike findings, baseline measurements
+- [ ] Merge after review; do not remove any Qt Charts usage yet
+
+## Stage 1 — Pilot: `FlowCalibrationPage.qml`
+
+### 1.1 Migrate QML
+- [ ] Replace `import QtCharts` with `import QtGraphs` in `qml/pages/FlowCalibrationPage.qml`
+- [ ] Replace `ChartView` with `GraphsView`
+- [ ] Replace built-in `ValueAxis` usages with `AutoRangingAxis` (or explicit `min`/`max` where appropriate)
+- [ ] Replace dashed goal-curve `LineSeries` with `DashedLineSeries` overlay
+- [ ] Replace `.legend` references with `CustomLegend` instance
+- [ ] Hook plot-area geometry to any overlay that used `plotArea`
+
+### 1.2 Validate
+- [ ] Side-by-side screenshot comparison with pre-migration state (Windows, macOS, Android)
+- [ ] Re-run all Flow Calibration user flows (run a calibration, view results, adjust settings)
+- [ ] Measure live FPS during calibration pour — must match or beat Stage 0 baseline
+- [ ] Verify crosshair/inspect behavior if present
+
+### 1.3 Stage 1 PR
+- [ ] Open PR: `feat: migrate FlowCalibrationPage to Qt Graphs (migration Stage 1)`
+- [ ] Include before/after screenshots and performance diff
+- [ ] Merge only after on-device sign-off by hardware owner
+
+## Stage 2 — Steam Graph
+
+### 2.1 Migrate C++ model
+- [ ] `src/models/steamdatamodel.h`: change `#include <QtCharts/QLineSeries>` to `#include <QtGraphs/QLineSeries>`
+- [ ] Update any `QtCharts::` namespace qualifications to `QtGraphs::`
+- [ ] Adjust `registerGoalSeries()` / `registerSeries()` to use the Graphs `replace()` API confirmed in Stage 0.2
+- [ ] Verify `FastLineRenderer` (live series) still registers and renders — it bypasses Charts anyway
+
+### 2.2 Migrate QML
+- [ ] `qml/components/SteamGraph.qml`: `import QtCharts` → `import QtGraphs`, `ChartView` → `GraphsView`
+- [ ] Replace axes with `AutoRangingAxis` or explicit ranges
+- [ ] Replace legend with `CustomLegend`
+- [ ] Convert dashed goal-temperature overlay to `DashedLineSeries`
+
+### 2.3 Validate
+- [ ] Live steam session on hardware — goal curve aligned, live temperature/pressure traces smooth
+- [ ] Steam history view — historical sessions render correctly
+- [ ] FPS meets baseline
+
+### 2.4 Stage 2 PR
+- [ ] Open PR: `feat: migrate SteamGraph and SteamDataModel to Qt Graphs (migration Stage 2)`
+- [ ] Merge after on-device sign-off
+
+## Stage 3 — Espresso Graphs
+
+Stage 3 is the largest. Split into sub-stages 3a–3d to keep PRs reviewable (one graph family per PR).
+
+### 3.1 Stage 3a — `ShotGraph.qml` + `ShotDataModel` (live extraction view)
+- [ ] C++: migrate `ShotDataModel` includes + namespaces; update series-registration API
+- [ ] QML: migrate `ShotGraph.qml` — GraphsView, AutoRangingAxis, CustomLegend, DashedLineSeries for goal curves, DashedLineSeries for frame markers
+- [ ] Preserve `FastLineRenderer` integration (live pressure/flow/temperature/weight traces)
+- [ ] Validate crosshair + inspect-point feature still works
+- [ ] Validate series visibility toggling via legend
+- [ ] Stage 3a PR: `feat: migrate ShotGraph to Qt Graphs (migration Stage 3a)`
+
+### 3.2 Stage 3b — `HistoryShotGraph.qml` (history detail view)
+- [ ] QML migration following Stage 3a pattern
+- [ ] Ensure scroll performance of the history list is not degraded (each list row contains a HistoryShotGraph)
+- [ ] Stage 3b PR: `feat: migrate HistoryShotGraph to Qt Graphs (migration Stage 3b)`
+
+### 3.3 Stage 3c — `ComparisonGraph.qml` + `ShotComparisonModel`
+- [ ] C++: migrate `ShotComparisonModel` includes + namespaces
+- [ ] QML: migrate; pay special attention to Canvas-based phase markers — these are Charts-independent and must continue to overlay correctly on GraphsView
+- [ ] Validate 2-shot and 3-shot comparisons render identically
+- [ ] Stage 3c PR: `feat: migrate ComparisonGraph to Qt Graphs (migration Stage 3c)`
+
+### 3.4 Stage 3d — `ProfileGraph.qml` (profile editor preview)
+- [ ] QML migration; the graph previews simulated extraction from profile frames
+- [ ] Verify profile-editing responsiveness (graph re-renders on frame edit)
+- [ ] Stage 3d PR: `feat: migrate ProfileGraph to Qt Graphs (migration Stage 3d)`
+
+## Stage 4 — Cleanup
+
+### 4.1 Remove Qt Charts
+- [ ] Audit codebase: `grep -r "QtCharts" src/ qml/` must return zero matches
+- [ ] Remove `Charts` from `find_package(Qt6 REQUIRED COMPONENTS ...)` in `CMakeLists.txt`
+- [ ] Remove any remaining `Qt6::Charts` link references
+- [ ] Build clean on all platforms; confirm app launches and all graphs render
+
+### 4.2 Bridge-component retention decision
+- [ ] Decide whether `AutoRangingAxis`, `CustomLegend`, and `DashedLineSeries` stay as project-owned components (likely yes — they're useful and Qt Graphs' gaps are real)
+- [ ] Update `CLAUDE.md` graph/QML conventions section to mention the bridge components as canonical
+
+### 4.3 Documentation and cleanup
+- [ ] Update `openspec/project.md` Tech Stack: remove `Charts`
+- [ ] Update `CLAUDE.md` if it mentions Qt Charts anywhere
+- [ ] Uninstall Qt Charts from dev machines' Qt installations
+- [ ] Uninstall Qt Data Visualization (unrelated to this migration but should be cleaned up at the same time — Decenza does not use it)
+
+### 4.4 Final PR and archive
+- [ ] Open PR: `chore: remove Qt Charts dependency (migration Stage 4)`
+- [ ] After merge, archive this change: `openspec archive migrate-charting-to-qt-graphs --yes`
+- [ ] Update `openspec/specs/charting/spec.md` with the final capability definition
+
+## Cross-stage acceptance criteria
+
+At each stage PR before merge:
+- [ ] Clean build on Windows, macOS, iOS, Android
+- [ ] On-device smoke test on Decent tablet (Samsung SM-X210)
+- [ ] Live FPS meets or beats Stage 0 baseline (documented in PR)
+- [ ] No new Qt log warnings/errors introduced
+- [ ] Side-by-side screenshots attached for any graph touched in that stage


### PR DESCRIPTION
## Summary

- Adds a complete OpenSpec change proposal at `openspec/changes/migrate-charting-to-qt-graphs/` for migrating Decenza's charting from Qt Charts (deprecated in Qt 6.10) to Qt Graphs
- Captures the migration as **deferred** with explicit upstream gate conditions — no implementation work starts yet
- Earliest re-evaluation target: **after Qt 6.11.1 is released**

## Why deferred, not just punted

Qt forum research turned up a hard upstream blocker:

- [QTBUG-142046](https://bugreports.qt.io/browse/QTBUG-142046) — `GraphsView` axis range properties return stale/constant values regardless of zoom/pan. Acknowledged by Qt staff, no fix timeline. This would break `ShotGraph.qml`'s crosshair inspect feature (which maps pixel→data via the current axis range).

Qt staff's own guidance on the forum: *"for new projects it's recommended to start with Qt Graphs. But there's nothing wrong with using Qt Charts"* and *"if you can (i.e. no feature is missing) use Qt Graphs as Qt Charts will be phased out eventually."* Qt Charts is removed in Qt 7, which has no announced release date.

Rather than lose the analysis, the proposal codifies it as a watch-list item with clear entry criteria.

## What's in the proposal

- **Gate Conditions** (four hard gates, all must pass before Stage 0):
  1. QTBUG-142046 fixed and verified
  2. Qt Graphs migration guide drops its "Missing features" section
  3. Bulk `XYSeries::replace()` API available
  4. Qt 6.11.1 released
- **Pre-Stage 0 — Upstream Monitoring** task list (active now): subscribe to the Qt bug, quarterly release-notes audit, forum scan, Qt 6.11.1 checkpoint
- **Staged migration plan** (when gates pass): Stage 0 foundation + bridge components → Stage 1 pilot (`FlowCalibrationPage`) → Stage 2 (`SteamGraph`) → Stage 3a–d (espresso graphs) → Stage 4 cleanup
- **Design doc** with feature-gap analysis (auto-ranging axis, legend, dashed lines, plotArea mapping), bridge-component design, performance measurement protocol, risk register, and rollback plan
- **Spec delta** defining the `charting` capability with `Upstream Qt Graphs Readiness Gates` as the first requirement

## Test plan

- [x] Ran `openspec validate migrate-charting-to-qt-graphs --strict --no-interactive` — passes
- [ ] Reviewers sanity-check the gate conditions and monitoring cadence are appropriate
- [ ] No code changes, so no build/runtime testing required

🤖 Generated with [Claude Code](https://claude.com/claude-code)