### PR TITLE
fix: scope the preset "modified" indicator and track beans-modified state

### DIFF
--- a/qml/components/PresetPillRow.qml
+++ b/qml/components/PresetPillRow.qml
@@ -13,6 +13,9 @@ FocusScope {
     property var pillSuffixFn: null  // Optional: function(index) => string suffix appended to pill text (e.g. " (125g)")
     property int pillSuffixVersion: 0  // Increment from outside to force pill text refresh without full layout recalc
     property real pillSuffixMaxWidth: 0  // Reserve extra horizontal space per pill for the suffix
+    property bool showProfileModified: false  // Only the espresso row reflects ProfileManager.profileModified;
+                                               // steam/flush/hot-water/bean rows share this component but are
+                                               // unrelated to the espresso profile's dirty state.
 
     // Effective max width - ensures we never exceed parent width even if maxWidth is larger
     readonly property real effectiveMaxWidth: {
@@ -53,7 +56,7 @@ FocusScope {
     function announceCurrentPill() {
         if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled && presets.length > 0) {
             var name = presets[focusedIndex].name || ""
-            var modified = (focusedIndex === selectedIndex && ProfileManager.profileModified) ? ", " + TranslationManager.translate("presets.unsaved", "unsaved changes") : ""
+            var modified = (showProfileModified && focusedIndex === selectedIndex && ProfileManager.profileModified) ? ", " + TranslationManager.translate("presets.unsaved", "unsaved changes") : ""
             var status = focusedIndex === selectedIndex ? ", " + TranslationManager.translate("presets.selected", "selected") : ""
             AccessibilityManager.announce(name + modified + status)
         }
@@ -62,7 +65,7 @@ FocusScope {
     // Base name for layout calculation (no live suffix — avoids layout recalc on every scale tick)
     function pillLayoutName(index) {
         var name = presets[index] ? (presets[index].name || "") : ""
-        if (index === selectedIndex && ProfileManager.profileModified) {
+        if (showProfileModified && index === selectedIndex && ProfileManager.profileModified) {
             name = ProfileManager.isCurrentProfileReadOnly ? name + " (modified)" : "*" + name
         }
         return name
@@ -106,6 +109,7 @@ FocusScope {
     onPillSuffixFnChanged: recalcTimer.restart()
     Connections {
         target: ProfileManager
+        enabled: root.showProfileModified
         function onProfileModifiedChanged() { recalcTimer.restart() }
     }
 
@@ -276,7 +280,7 @@ FocusScope {
                             accessibleName: {
                                 if (!modelData || !modelData.preset) return ""
                                 var name = pillDisplayName(modelData.index)
-                                var modified = (modelData.index === root.selectedIndex && ProfileManager.profileModified) ? ", " + TranslationManager.translate("presets.unsaved", "unsaved changes") : ""
+                                var modified = (root.showProfileModified && modelData.index === root.selectedIndex && ProfileManager.profileModified) ? ", " + TranslationManager.translate("presets.unsaved", "unsaved changes") : ""
                                 var status = modelData.index === root.selectedIndex ? ", " + TranslationManager.translate("presets.selected", "selected") : ""
                                 return name + modified + status
                             }

--- a/qml/components/PresetPillRow.qml
+++ b/qml/components/PresetPillRow.qml
@@ -70,7 +70,9 @@ FocusScope {
     function pillLayoutName(index) {
         var name = presets[index] ? (presets[index].name || "") : ""
         if (modified && index === selectedIndex) {
-            name = modifiedIsReadOnly ? name + " (modified)" : "*" + name
+            name = modifiedIsReadOnly
+                ? name + " " + TranslationManager.translate("presets.modified", "(modified)")
+                : "*" + name
         }
         return name
     }
@@ -106,7 +108,7 @@ FocusScope {
         return textMetrics.width
     }
 
-    // Recalculate when presets, width, profile modified state, or suffix changes (deferred
+    // Recalculate when presets, width, modified state, or suffix changes (deferred
     // via timer to avoid destroying Repeater delegates during signal handler chains)
     onPresetsChanged: recalcTimer.restart()
     onEffectiveMaxWidthChanged: recalcTimer.restart()

--- a/qml/components/PresetPillRow.qml
+++ b/qml/components/PresetPillRow.qml
@@ -13,9 +13,13 @@ FocusScope {
     property var pillSuffixFn: null  // Optional: function(index) => string suffix appended to pill text (e.g. " (125g)")
     property int pillSuffixVersion: 0  // Increment from outside to force pill text refresh without full layout recalc
     property real pillSuffixMaxWidth: 0  // Reserve extra horizontal space per pill for the suffix
-    property bool showProfileModified: false  // Only the espresso row reflects ProfileManager.profileModified;
-                                               // steam/flush/hot-water/bean rows share this component but are
-                                               // unrelated to the espresso profile's dirty state.
+    // When true AND a pill is selected, append an "unsaved" marker to that pill.
+    // Callers opt in by binding this to their own dirty state — e.g. ProfileManager.profileModified
+    // for the espresso row or Settings.beansModified for the beans row. Rows that have no
+    // dirty-state concept (steam / flush / hot water) leave this at the default false.
+    property bool modified: false
+    // When modified, format as "Name (modified)" for read-only presets; otherwise "*Name".
+    property bool modifiedIsReadOnly: false
 
     // Effective max width - ensures we never exceed parent width even if maxWidth is larger
     readonly property real effectiveMaxWidth: {
@@ -56,17 +60,17 @@ FocusScope {
     function announceCurrentPill() {
         if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled && presets.length > 0) {
             var name = presets[focusedIndex].name || ""
-            var modified = (showProfileModified && focusedIndex === selectedIndex && ProfileManager.profileModified) ? ", " + TranslationManager.translate("presets.unsaved", "unsaved changes") : ""
+            var modifiedText = (root.modified && focusedIndex === selectedIndex) ? ", " + TranslationManager.translate("presets.unsaved", "unsaved changes") : ""
             var status = focusedIndex === selectedIndex ? ", " + TranslationManager.translate("presets.selected", "selected") : ""
-            AccessibilityManager.announce(name + modified + status)
+            AccessibilityManager.announce(name + modifiedText + status)
         }
     }
 
     // Base name for layout calculation (no live suffix — avoids layout recalc on every scale tick)
     function pillLayoutName(index) {
         var name = presets[index] ? (presets[index].name || "") : ""
-        if (showProfileModified && index === selectedIndex && ProfileManager.profileModified) {
-            name = ProfileManager.isCurrentProfileReadOnly ? name + " (modified)" : "*" + name
+        if (modified && index === selectedIndex) {
+            name = modifiedIsReadOnly ? name + " (modified)" : "*" + name
         }
         return name
     }
@@ -107,11 +111,12 @@ FocusScope {
     onPresetsChanged: recalcTimer.restart()
     onEffectiveMaxWidthChanged: recalcTimer.restart()
     onPillSuffixFnChanged: recalcTimer.restart()
-    Connections {
-        target: ProfileManager
-        enabled: root.showProfileModified
-        function onProfileModifiedChanged() { recalcTimer.restart() }
-    }
+    // Dirty-state changes alter pill widths ("*Name" / " (modified)") so they trigger a
+    // layout recalc. Because `modified` is a bindable property, we get changes from any
+    // upstream source (ProfileManager, Settings, etc.) via the QML binding system without
+    // a direct signal subscription here.
+    onModifiedChanged: recalcTimer.restart()
+    onModifiedIsReadOnlyChanged: recalcTimer.restart()
 
     // All model recalculations go through this timer to coalesce rapid changes
     // and ensure delegates aren't destroyed while their signal handlers run
@@ -280,9 +285,9 @@ FocusScope {
                             accessibleName: {
                                 if (!modelData || !modelData.preset) return ""
                                 var name = pillDisplayName(modelData.index)
-                                var modified = (root.showProfileModified && modelData.index === root.selectedIndex && ProfileManager.profileModified) ? ", " + TranslationManager.translate("presets.unsaved", "unsaved changes") : ""
+                                var modifiedText = (root.modified && modelData.index === root.selectedIndex) ? ", " + TranslationManager.translate("presets.unsaved", "unsaved changes") : ""
                                 var status = modelData.index === root.selectedIndex ? ", " + TranslationManager.translate("presets.selected", "selected") : ""
-                                return name + modified + status
+                                return name + modifiedText + status
                             }
                             accessibleItem: pill
 

--- a/qml/components/layout/items/BeansItem.qml
+++ b/qml/components/layout/items/BeansItem.qml
@@ -121,6 +121,26 @@ Item {
         padding: Theme.spacingMedium
         closePolicy: Popup.CloseOnPressOutside
 
+        // Full-mode beans path runs IdlePage.onActivePresetFunctionChanged which announces
+        // the preset list to TalkBack. The compact-mode popup bypasses that path, so
+        // announce here directly to keep feature parity for screen-reader users.
+        onOpened: {
+            if (typeof AccessibilityManager === "undefined" || !AccessibilityManager.enabled) return
+            var presets = Settings.idleBeanPresets
+            if (presets.length === 0) return
+            var names = []
+            var selectedName = ""
+            for (var i = 0; i < presets.length; ++i) {
+                names.push(presets[i].name)
+                if (presets[i].originalIndex === Settings.selectedBeanPreset) selectedName = presets[i].name
+            }
+            var announcement = presets.length + " " + TranslationManager.translate("idle.accessible.presets", "presets") + ": " + names.join(", ")
+            if (selectedName !== "") {
+                announcement += ". " + selectedName + " " + TranslationManager.translate("idle.accessible.isSelected", "is selected")
+            }
+            AccessibilityManager.announce(announcement)
+        }
+
         width: {
             var win = root.Window.window
             var w = Theme.scaled(600) + 2 * padding

--- a/qml/components/layout/items/BeansItem.qml
+++ b/qml/components/layout/items/BeansItem.qml
@@ -166,6 +166,7 @@ Item {
             id: beansPillRow
             maxWidth: Theme.scaled(600)
             presets: Settings.idleBeanPresets
+            modified: Settings.beansModified
             // selectedIndex refers to position within the filtered list
             selectedIndex: {
                 var list = Settings.idleBeanPresets

--- a/qml/components/layout/items/EspressoItem.qml
+++ b/qml/components/layout/items/EspressoItem.qml
@@ -170,6 +170,7 @@ Item {
                 presets: Settings.favoriteProfiles
                 selectedIndex: Settings.selectedFavoriteProfile
                 supportLongPress: true
+                showProfileModified: true
 
                 onPresetSelected: function(index) {
                     var wasAlreadySelected = (index === Settings.selectedFavoriteProfile)

--- a/qml/components/layout/items/EspressoItem.qml
+++ b/qml/components/layout/items/EspressoItem.qml
@@ -170,7 +170,8 @@ Item {
                 presets: Settings.favoriteProfiles
                 selectedIndex: Settings.selectedFavoriteProfile
                 supportLongPress: true
-                showProfileModified: true
+                modified: ProfileManager.profileModified
+                modifiedIsReadOnly: ProfileManager.isCurrentProfileReadOnly
 
                 onPresetSelected: function(index) {
                     var wasAlreadySelected = (index === Settings.selectedFavoriteProfile)

--- a/qml/components/layout/items/FlushItem.qml
+++ b/qml/components/layout/items/FlushItem.qml
@@ -116,6 +116,28 @@ Item {
         padding: Theme.spacingMedium
         closePolicy: Popup.CloseOnPressOutside
 
+        // Full-mode flush path runs IdlePage.onActivePresetFunctionChanged which
+        // announces the preset list to TalkBack. The compact-mode popup bypasses that
+        // path, so announce here directly to keep feature parity for screen-reader users.
+        onOpened: {
+            if (typeof AccessibilityManager === "undefined" || !AccessibilityManager.enabled) return
+            var presets = Settings.flushPresets
+            if (presets.length === 0) return
+            var names = []
+            var selectedName = ""
+            for (var i = 0; i < presets.length; ++i) {
+                names.push(presets[i].name)
+            }
+            if (Settings.selectedFlushPreset >= 0 && Settings.selectedFlushPreset < presets.length) {
+                selectedName = presets[Settings.selectedFlushPreset].name
+            }
+            var announcement = presets.length + " " + TranslationManager.translate("idle.accessible.presets", "presets") + ": " + names.join(", ")
+            if (selectedName !== "") {
+                announcement += ". " + selectedName + " " + TranslationManager.translate("idle.accessible.isSelected", "is selected")
+            }
+            AccessibilityManager.announce(announcement)
+        }
+
         width: {
             var win = root.Window.window
             var w = Theme.scaled(600) + 2 * padding

--- a/qml/components/layout/items/HotWaterItem.qml
+++ b/qml/components/layout/items/HotWaterItem.qml
@@ -116,6 +116,28 @@ Item {
         padding: Theme.spacingMedium
         closePolicy: Popup.CloseOnPressOutside
 
+        // Full-mode hot-water path runs IdlePage.onActivePresetFunctionChanged which
+        // announces the preset list to TalkBack. The compact-mode popup bypasses that
+        // path, so announce here directly to keep feature parity for screen-reader users.
+        onOpened: {
+            if (typeof AccessibilityManager === "undefined" || !AccessibilityManager.enabled) return
+            var presets = Settings.waterVesselPresets
+            if (presets.length === 0) return
+            var names = []
+            var selectedName = ""
+            for (var i = 0; i < presets.length; ++i) {
+                names.push(presets[i].name)
+            }
+            if (Settings.selectedWaterVessel >= 0 && Settings.selectedWaterVessel < presets.length) {
+                selectedName = presets[Settings.selectedWaterVessel].name
+            }
+            var announcement = presets.length + " " + TranslationManager.translate("idle.accessible.presets", "presets") + ": " + names.join(", ")
+            if (selectedName !== "") {
+                announcement += ". " + selectedName + " " + TranslationManager.translate("idle.accessible.isSelected", "is selected")
+            }
+            AccessibilityManager.announce(announcement)
+        }
+
         width: {
             var win = root.Window.window
             var w = Theme.scaled(600) + 2 * padding

--- a/qml/components/layout/items/SteamItem.qml
+++ b/qml/components/layout/items/SteamItem.qml
@@ -118,6 +118,26 @@ Item {
 
         onOpened: {
             if (typeof MachineState !== "undefined") MachineState.tareScale()
+
+            // Full-mode steam path runs IdlePage.onActivePresetFunctionChanged which
+            // announces the preset list to TalkBack. The compact-mode popup bypasses
+            // that path, so announce here directly to keep feature parity.
+            if (typeof AccessibilityManager === "undefined" || !AccessibilityManager.enabled) return
+            var presets = Settings.steamPitcherPresets
+            if (presets.length === 0) return
+            var names = []
+            var selectedName = ""
+            for (var i = 0; i < presets.length; ++i) {
+                names.push(presets[i].name)
+            }
+            if (Settings.selectedSteamPitcher >= 0 && Settings.selectedSteamPitcher < presets.length) {
+                selectedName = presets[Settings.selectedSteamPitcher].name
+            }
+            var announcement = presets.length + " " + TranslationManager.translate("idle.accessible.presets", "presets") + ": " + names.join(", ")
+            if (selectedName !== "") {
+                announcement += ". " + selectedName + " " + TranslationManager.translate("idle.accessible.isSelected", "is selected")
+            }
+            AccessibilityManager.announce(announcement)
         }
 
         width: {

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -329,6 +329,7 @@ Page {
                         presets: Settings.favoriteProfiles
                         selectedIndex: Settings.selectedFavoriteProfile
                         supportLongPress: true
+                        showProfileModified: true
 
                         onPresetSelected: function(index) {
                             var wasAlreadySelected = (index === Settings.selectedFavoriteProfile)

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -329,7 +329,8 @@ Page {
                         presets: Settings.favoriteProfiles
                         selectedIndex: Settings.selectedFavoriteProfile
                         supportLongPress: true
-                        showProfileModified: true
+                        modified: ProfileManager.profileModified
+                        modifiedIsReadOnly: ProfileManager.isCurrentProfileReadOnly
 
                         onPresetSelected: function(index) {
                             var wasAlreadySelected = (index === Settings.selectedFavoriteProfile)
@@ -500,6 +501,7 @@ Page {
                     id: inlineBeanPresetRow
                     maxWidth: beanPresetLoader.width
                     presets: Settings.idleBeanPresets
+                    modified: Settings.beansModified
                     selectedIndex: {
                         var list = Settings.idleBeanPresets
                         for (var i = 0; i < list.length; ++i) {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -284,6 +284,22 @@ Settings::Settings(QObject* parent)
     if (m_settings.value("mcp/apiKey", "").toString().isEmpty()) {
         m_settings.setValue("mcp/apiKey", QUuid::createUuid().toString(QUuid::WithoutBraces));
     }
+
+    // Beans-modified tracking: recompute whenever any DYE bean/grinder field or the
+    // selected preset / preset list changes. Fields tracked here must stay in sync
+    // with those compared in recomputeBeansModified() and written by applyBeanPreset().
+    connect(this, &Settings::dyeBeanBrandChanged,     this, &Settings::recomputeBeansModified);
+    connect(this, &Settings::dyeBeanTypeChanged,      this, &Settings::recomputeBeansModified);
+    connect(this, &Settings::dyeRoastDateChanged,     this, &Settings::recomputeBeansModified);
+    connect(this, &Settings::dyeRoastLevelChanged,    this, &Settings::recomputeBeansModified);
+    connect(this, &Settings::dyeGrinderBrandChanged,  this, &Settings::recomputeBeansModified);
+    connect(this, &Settings::dyeGrinderModelChanged,  this, &Settings::recomputeBeansModified);
+    connect(this, &Settings::dyeGrinderBurrsChanged,  this, &Settings::recomputeBeansModified);
+    connect(this, &Settings::dyeGrinderSettingChanged, this, &Settings::recomputeBeansModified);
+    connect(this, &Settings::dyeBaristaChanged,       this, &Settings::recomputeBeansModified);
+    connect(this, &Settings::selectedBeanPresetChanged, this, &Settings::recomputeBeansModified);
+    connect(this, &Settings::beanPresetsChanged,      this, &Settings::recomputeBeansModified);
+    recomputeBeansModified();  // Seed initial state from persisted values
 }
 
 // Machine settings
@@ -1636,6 +1652,29 @@ void Settings::applyBeanPreset(int index) {
     setDyeGrinderBurrs(burrs);
     setDyeGrinderSetting(preset.value("grinderSetting").toString());
     setDyeBarista(preset.value("barista").toString());
+}
+
+void Settings::recomputeBeansModified() {
+    bool modified = false;
+    const int idx = selectedBeanPreset();
+    if (idx >= 0) {
+        const QVariantMap preset = getBeanPreset(idx);
+        if (!preset.isEmpty()) {
+            modified = dyeBeanBrand()      != preset.value("brand").toString()
+                    || dyeBeanType()       != preset.value("type").toString()
+                    || dyeRoastDate()      != preset.value("roastDate").toString()
+                    || dyeRoastLevel()     != preset.value("roastLevel").toString()
+                    || dyeGrinderBrand()   != preset.value("grinderBrand").toString()
+                    || dyeGrinderModel()   != preset.value("grinderModel").toString()
+                    || dyeGrinderBurrs()   != preset.value("grinderBurrs").toString()
+                    || dyeGrinderSetting() != preset.value("grinderSetting").toString()
+                    || dyeBarista()        != preset.value("barista").toString();
+        }
+    }
+    if (modified != m_beansModified) {
+        m_beansModified = modified;
+        emit beansModifiedChanged();
+    }
 }
 
 void Settings::saveBeanPresetFromCurrent(const QString& name) {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1505,7 +1505,7 @@ void Settings::updateBeanPreset(int index, const QString& name, const QString& b
                                 const QString& grinderSetting, const QString& barista) {
     QJsonArray arr = getBeanPresetsArray();
 
-    if (index >= 0 && index < arr.size()) {
+    if (index >= 0 && index < static_cast<int>(arr.size())) {
         // Preserve showOnIdle from existing entry (default true for legacy)
         QJsonObject existing = arr[index].toObject();
         bool showOnIdle = existing.contains("showOnIdle") ? existing["showOnIdle"].toBool() : true;
@@ -1532,13 +1532,13 @@ void Settings::updateBeanPreset(int index, const QString& name, const QString& b
 void Settings::removeBeanPreset(int index) {
     QJsonArray arr = getBeanPresetsArray();
 
-    if (index >= 0 && index < arr.size()) {
+    if (index >= 0 && index < static_cast<int>(arr.size())) {
         arr.removeAt(index);
         m_settings.setValue("bean/presets", QJsonDocument(arr).toJson());
 
         // Adjust selected if needed
         int selected = selectedBeanPreset();
-        if (selected >= arr.size() && arr.size() > 0) {
+        if (selected >= static_cast<int>(arr.size()) && arr.size() > 0) {
             setSelectedBeanPreset(static_cast<int>(arr.size()) - 1);
         } else if (arr.size() == 0) {
             setSelectedBeanPreset(-1);
@@ -1553,7 +1553,7 @@ void Settings::removeBeanPreset(int index) {
 void Settings::moveBeanPreset(int from, int to) {
     QJsonArray arr = getBeanPresetsArray();
 
-    if (from >= 0 && from < arr.size() && to >= 0 && to < arr.size() && from != to) {
+    if (from >= 0 && from < static_cast<int>(arr.size()) && to >= 0 && to < static_cast<int>(arr.size()) && from != to) {
         QJsonValue item = arr[from];
         arr.removeAt(from);
         arr.insert(to, item);
@@ -1576,7 +1576,7 @@ void Settings::moveBeanPreset(int from, int to) {
 void Settings::setBeanPresetShowOnIdle(int index, bool show) {
     QJsonArray arr = getBeanPresetsArray();
 
-    if (index >= 0 && index < arr.size()) {
+    if (index >= 0 && index < static_cast<int>(arr.size())) {
         QJsonObject preset = arr[index].toObject();
         if (preset["showOnIdle"].toBool(true) != show) {
             preset["showOnIdle"] = show;
@@ -1693,8 +1693,9 @@ void Settings::saveBeanPresetFromCurrent(const QString& name) {
                         dyeGrinderBurrs(),
                         dyeGrinderSetting(),
                         dyeBarista());
+        setSelectedBeanPreset(existingIndex);
     } else {
-        // Add new preset
+        // Add new preset (appends to the end)
         addBeanPreset(name,
                      dyeBeanBrand(),
                      dyeBeanType(),
@@ -1705,6 +1706,7 @@ void Settings::saveBeanPresetFromCurrent(const QString& name) {
                      dyeGrinderBurrs(),
                      dyeGrinderSetting(),
                      dyeBarista());
+        setSelectedBeanPreset(static_cast<int>(getBeanPresetsArray().size()) - 1);
     }
 }
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -101,6 +101,9 @@ class Settings : public QObject {
     // an `originalIndex` field mapping back into beanPresets for selection/apply calls.
     Q_PROPERTY(QVariantList idleBeanPresets READ idleBeanPresets NOTIFY beanPresetsChanged)
     Q_PROPERTY(int selectedBeanPreset READ selectedBeanPreset WRITE setSelectedBeanPreset NOTIFY selectedBeanPresetChanged)
+    // True when selectedBeanPreset >= 0 AND any DYE bean/grinder field diverges from the preset's stored value.
+    // Mirrors the ProfileManager.profileModified concept so the beans pill can show an "unsaved" indicator.
+    Q_PROPERTY(bool beansModified READ beansModified NOTIFY beansModifiedChanged)
 
     // UI settings
     Q_PROPERTY(QString skin READ skin WRITE setSkin NOTIFY skinChanged)
@@ -479,6 +482,8 @@ public:
     Q_INVOKABLE void saveBeanPresetFromCurrent(const QString& name);  // Creates or updates preset from current DYE
     Q_INVOKABLE int findBeanPresetByContent(const QString& brand, const QString& type) const;  // Returns index or -1 (simple match)
     Q_INVOKABLE int findBeanPresetByName(const QString& name) const;  // Returns index or -1
+
+    bool beansModified() const { return m_beansModified; }
 
     // UI settings
     QString skin() const;
@@ -921,6 +926,7 @@ signals:
     void flushSecondsChanged();
     void beanPresetsChanged();
     void selectedBeanPresetChanged();
+    void beansModifiedChanged();
     void skinChanged();
     void currentProfileChanged();
     void customThemeColorsChanged();
@@ -1039,6 +1045,12 @@ private:
 
     void ensureSawCacheLoaded() const;
     void writeKnownScales(const QVariantList& scales);
+
+    // Recompute m_beansModified from current DYE values vs the selected preset and emit
+    // beansModifiedChanged() if the cached state flipped. Wired to the relevant NOTIFY
+    // signals in the constructor.
+    void recomputeBeansModified();
+    bool m_beansModified = false;
 
     mutable QSettings m_settings;
     bool m_use12HourTime = false;


### PR DESCRIPTION
## Summary
Two related fixes so that the preset pill \"modified\" indicator behaves correctly for every preset type:

1. **Stop the espresso dirty flag from leaking onto other rows.** `PresetPillRow` is shared across Espresso, Steam, HotWater, Flush, and Beans rows, but read `ProfileManager.profileModified` unconditionally — so editing an espresso profile (e.g. brew temp) tagged the selected steam/flush/hot-water preset as modified too.

2. **Actually track modified state for beans.** Previously there was no equivalent for beans. If you modified bean/grinder fields in the Beans window and came back without saving (or used \"Use as entered\"), the live DYE values could diverge from the selected preset but the pill never showed it. Adds `Settings::beansModified` that compares current DYE fields to the selected preset.

### API change on `PresetPillRow`
Generalized the opt-in so any preset row can expose its own dirty state:
- `property bool modified` (bindable)
- `property bool modifiedIsReadOnly` — prefix `*` vs. suffix `(modified)`

Callers:
- Espresso → `modified: ProfileManager.profileModified; modifiedIsReadOnly: ProfileManager.isCurrentProfileReadOnly`
- Beans → `modified: Settings.beansModified`
- Steam / Hot Water / Flush → unset (default `false`)

Fixes #728

## Test plan
- [ ] Change brew temp without saving → only selected espresso pill shows `*Name` / `(modified)` (read-only); Steam, HotWater, Flush, Beans pills are clean
- [ ] Select a bean preset, then open beans window, change grinder setting, back out without saving → selected beans pill shows `*Name`
- [ ] Apply beans preset fully (fields match) → beans pill clean
- [ ] \"Use as entered\" clears `selectedBeanPreset` to -1 → no beans pill is selected, so no asterisk (expected)
- [ ] TalkBack: swipe to the dirty pill announces \"unsaved changes\" (espresso and beans); other preset rows do not

🤖 Generated with [Claude Code](https://claude.com/claude-code)