### PR TITLE
feat: flow-cal cap bump + firmware-gated auto-cal ceiling

### DIFF
--- a/docs/AUTO_FLOW_CALIBRATION.md
+++ b/docs/AUTO_FLOW_CALIBRATION.md
@@ -24,7 +24,7 @@ Automatic per-profile flow calibration using scale data as ground truth. After e
 5. **Compute calibration** (formula depends on profile type):
    - **Flow profiles**: `mean(weight_flow) / (target_flow * 0.963)` — uses the profile's known target flow, independent of current calibration
    - **Pressure profiles**: `current_multiplier * mean(weight_flow) / (mean(machine_flow) * 0.963)` — divides out current calibration from reported flow
-6. **Sanity check**: Clamp to [0.5, 1.8] — cap extreme values that likely indicate measurement errors
+6. **Sanity check**: Clamp to `[0.5, kCalibrationMax]` — cap extreme values that likely indicate measurement errors. The upper bound tracks DE1 firmware (1.8 on pre-v1337 firmware, 2.7 on v1337+)
 7. **Store & apply**: If the computed value differs from current by > 2%, EMA-smooth toward it (alpha=0.3) and send to the machine
 
 ## Algorithm Details
@@ -79,7 +79,14 @@ The multiplier is only updated when the computed value differs from the current 
 
 ### Sanity Bounds
 
-The computed multiplier is clamped to [0.5, 1.8]. Values outside this range indicate measurement errors (e.g., scale drift, splash, evaporation) rather than genuine calibration offsets.
+The computed multiplier is clamped to `[0.5, kCalibrationMax]`, where `kCalibrationMax` is firmware-dependent:
+
+- **Pre-v1337 firmware** (classic pumps): 1.8 — matches the historical upper bound; values this high on older pumps almost always indicate measurement errors (scale drift, splash, evaporation) rather than genuine offsets.
+- **v1337+ firmware** (newer pump hardware): 2.7 — the firmware-side cap was raised from 2.0 to 3.0, and auto-cal keeps ~10% headroom below that (same 0.9× ratio the old pair used).
+
+Values above the classic 1.8 ceiling (but under the new 2.7 one) are legitimate on v1337+ firmware but are logged via `qWarning` and surfaced in the Profile Info page with an amber color and an "unusually high — verify scale accuracy" screen-reader description, so the user can sanity-check their scale before trusting the new value.
+
+Per-profile persistence (`Settings::setProfileFlowCalibration`) and the settings importer (`SettingsSerializer`) both accept `[0.5, 2.7]` regardless of the currently-connected firmware — the runtime compute-time gate is what enforces the stricter 1.8 cap on older firmware, so stored values from a v1337+ session remain readable if the user later downgrades firmware. The window-ratio guard `[0.75, 1.35]` (see above) remains the primary protection against bad scale data across both firmware ranges.
 
 ## User Experience
 

--- a/qml/pages/FlowCalibrationPage.qml
+++ b/qml/pages/FlowCalibrationPage.qml
@@ -179,8 +179,8 @@ Page {
                     AccessibleButton {
                         text: "+0.01"
                         accessibleName: TranslationManager.translate("flowCalibration.increase", "Increase multiplier")
-                        enabled: FlowCalibrationModel.hasData && FlowCalibrationModel.multiplier < 1.99
-                        onClicked: FlowCalibrationModel.multiplier = Math.min(2.0, FlowCalibrationModel.multiplier + 0.01)
+                        enabled: FlowCalibrationModel.hasData && FlowCalibrationModel.multiplier < 2.99
+                        onClicked: FlowCalibrationModel.multiplier = Math.min(3.0, FlowCalibrationModel.multiplier + 0.01)
                     }
                 }
 
@@ -189,7 +189,7 @@ Page {
                     Layout.fillWidth: true
                     Layout.preferredHeight: Theme.scaled(40)
                     from: 0.35
-                    to: 2.0
+                    to: 3.0
                     stepSize: 0.01
                     value: FlowCalibrationModel.multiplier
                     enabled: FlowCalibrationModel.hasData

--- a/qml/pages/ProfileInfoPage.qml
+++ b/qml/pages/ProfileInfoPage.qml
@@ -207,12 +207,23 @@ Page {
                                 void(Settings.flowCalibrationMultiplier);
                                 return profileFilename ? Settings.hasProfileFlowCalibration(profileFilename) : false;
                             }
+                            // Multipliers above this were historically out-of-range; on newer firmware
+                            // they can be legitimate but are worth flagging so the user can sanity-check
+                            // scale accuracy before trusting them.
+                            readonly property double classicCeiling: 1.8
+                            property bool isUnusuallyHigh: effectiveCal > classicCeiling
                             property string calLabel: isAuto
                                 ? TranslationManager.translate("profileinfo.flowCalAuto", "(auto)")
                                 : TranslationManager.translate("profileinfo.flowCalGlobal", "(global)")
                             text: effectiveCal.toFixed(2) + " " + calLabel
                             font: Theme.bodyFont
-                            color: Theme.textColor
+                            // Amber when above the classic 1.8 ceiling — genuine on newer firmware but
+                            // worth a visual nudge so the user double-checks scale accuracy.
+                            color: isUnusuallyHigh ? Theme.warningColor : Theme.textColor
+                            Accessible.description: isUnusuallyHigh
+                                ? TranslationManager.translate("profileinfo.flowCalHigh",
+                                    "Unusually high — verify scale accuracy")
+                                : ""
                         }
                     }
                 }

--- a/qml/pages/ProfileInfoPage.qml
+++ b/qml/pages/ProfileInfoPage.qml
@@ -220,10 +220,18 @@ Page {
                             // Amber when above the classic 1.8 ceiling — genuine on newer firmware but
                             // worth a visual nudge so the user double-checks scale accuracy.
                             color: isUnusuallyHigh ? Theme.warningColor : Theme.textColor
-                            Accessible.description: isUnusuallyHigh
-                                ? TranslationManager.translate("profileinfo.flowCalHigh",
-                                    "Unusually high — verify scale accuracy")
-                                : ""
+                            // Make the value discoverable by TalkBack/VoiceOver. The warning is folded
+                            // into Accessible.name (not Accessible.description) because a bare Text
+                            // element without a role is invisible to the accessibility tree — the
+                            // description would be silently dropped. Name covers both the value and
+                            // the warning so the entire piece of information reaches screen-reader
+                            // users in one announcement.
+                            Accessible.role: Accessible.StaticText
+                            Accessible.name: isUnusuallyHigh
+                                ? text + " — " + TranslationManager.translate(
+                                    "profileinfo.flowCalHigh",
+                                    "Unusually high, verify scale accuracy")
+                                : text
                         }
                     }
                 }

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -107,6 +107,7 @@ public:
     Q_INVOKABLE void setIsHeadless(bool headless);  // Debug toggle
     int refillKitDetected() const { return m_refillKitDetected; }  // -1=unknown, 0=not detected, 1=detected
     int machineModel() const { return m_machineModel; }  // 0=unknown, 1=DE1, 2=DE1+, 3=PRO, 4=XL, 5=CAFE, 6=XXL, 7=XXXL
+    int firmwareBuildNumber() const { return m_firmwareBuildNumber; }  // 0 = unknown, otherwise build number (e.g. 1347)
     int heaterVoltage() const { return m_heaterVoltage; }  // 0=unknown, otherwise volts (e.g. 110, 220)
 
     // Transport abstraction

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -618,11 +618,11 @@ void MainController::computeAutoFlowCalibration() {
     // We track the best (longest) qualifying window found across the entire shot.
     double bestStart = -1, bestEnd = -1;
     double bestSumMF = 0, bestSumWF = 0;
-    int bestCount = 0;
+    qsizetype bestCount = 0;
 
     double winStart = -1;
     double winSumMF = 0, winSumWF = 0;
-    int winCount = 0;
+    qsizetype winCount = 0;
     double winLastT = -1;
 
     // Finish the current window: save as best if longest, then reset for next window
@@ -641,11 +641,11 @@ void MainController::computeAutoFlowCalibration() {
     };
 
     // Cursors for nearest-point/interpolation search (both arrays are time-sorted)
-    int wfCursor = 0;
-    int mfCursor = 1;
+    qsizetype wfCursor = 0;
+    qsizetype mfCursor = 1;
     int mfMissCount = 0;  // Tracks flow interpolation misses for diagnostics
 
-    for (int i = 1; i < pressureData.size(); ++i) {
+    for (qsizetype i = 1; i < pressureData.size(); ++i) {
         double dt = pressureData[i].x() - pressureData[i - 1].x();
         if (dt <= 0) continue;
         double dpdt = qAbs(pressureData[i].y() - pressureData[i - 1].y()) / dt;
@@ -670,7 +670,7 @@ void MainController::computeAutoFlowCalibration() {
         // Find weight flow at this time (nearest point, using cursor since t increases monotonically)
         double wf = 0;
         double nearestDist = 1e9;
-        for (int k = wfCursor; k < weightFlowData.size(); ++k) {
+        for (qsizetype k = wfCursor; k < weightFlowData.size(); ++k) {
             double dist = qAbs(weightFlowData[k].x() - t);
             if (dist < nearestDist) {
                 nearestDist = dist;
@@ -688,7 +688,7 @@ void MainController::computeAutoFlowCalibration() {
 
         // Find machine flow at this time (linear interpolation, using cursor)
         double mf = 0;
-        for (int j = mfCursor; j < flowData.size(); ++j) {
+        for (qsizetype j = mfCursor; j < flowData.size(); ++j) {
             if (flowData[j].x() >= t) {
                 double t0 = flowData[j - 1].x();
                 double t1 = flowData[j].x();
@@ -878,6 +878,13 @@ void MainController::computeAutoFlowCalibration() {
     double computed = m_settings->hasProfileFlowCalibration(m_profileManager->baseProfileName())
         ? kEmaAlpha * ideal + (1.0 - kEmaAlpha) * currentEffective
         : ideal;
+
+    // Re-clamp after EMA. When the user has manually set the global multiplier above
+    // kCalibrationMax (e.g. 3.0 via the manual UI vs. kCalibrationMax=2.7), currentEffective
+    // falls back to that global for profiles without a per-profile value, and EMA can then
+    // land outside [kCalibrationMin, kCalibrationMax]. Without this, setProfileFlowCalibration
+    // would silently reject the write and auto-cal would stop converging for that profile.
+    computed = qBound(kCalibrationMin, computed, kCalibrationMax);
 
     double oldValue = currentEffective;
     if (!m_settings->setProfileFlowCalibration(m_profileManager->baseProfileName(), computed)) {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -597,7 +597,15 @@ void MainController::computeAutoFlowCalibration() {
     constexpr int    kMinWindowSamples = 7;          // ~1.5s at 5Hz pressure sampling
     constexpr double kWaterDensity93C = 0.963;       // g/ml - density correction for water at ~93°C
     constexpr double kCalibrationMin = 0.5;          // sanity lower bound
-    constexpr double kCalibrationMax = 1.8;          // sanity upper bound
+    // Sanity upper bound. Keeps auto-cal ~10% below the firmware-side cap so the algorithm
+    // has headroom before hitting the hard firmware limit:
+    //   - Pre-v1337 firmware: 1.8 (firmware cap 2.0 × 0.9)
+    //   - v1337+ firmware:    2.7 (firmware cap 3.0 × 0.9, newer pump hardware)
+    // Values above the old 1.8 ceiling are legitimate on newer firmware but worth flagging
+    // to the user; on older firmware they almost always indicate scale artefacts.
+    const int kFirmwareCapBumped = 1337;
+    const int fwBuild = m_device ? m_device->firmwareBuildNumber() : 0;
+    const double kCalibrationMax = (fwBuild >= kFirmwareCapBumped) ? 2.7 : 1.8;
     constexpr double kChangeThreshold = 0.02;        // 2% relative change required to update
     constexpr double kMaxSampleRatio = 2.5;          // per-sample machine/weight ratio — break window on extreme outliers
     constexpr double kMinSampleRatio = 0.4;          // (generous bounds: window-level check is tighter)
@@ -842,6 +850,17 @@ void MainController::computeAutoFlowCalibration() {
     }
 
     ideal = qBound(kCalibrationMin, ideal, kCalibrationMax);
+
+    // On v1337+ firmware, legitimate multipliers can exceed the classic 1.8 ceiling
+    // (better pumps → higher genuine ratios). Warn so telemetry / user-visible UI can
+    // flag shots where the computed value looks unusually high — helps catch scale bias
+    // before it walks the calibration to absurd values.
+    constexpr double kClassicCeiling = 1.8;
+    if (ideal > kClassicCeiling) {
+        qWarning() << "Auto flow cal: computed multiplier" << ideal
+                   << "exceeds classic ceiling" << kClassicCeiling
+                   << "— verify scale accuracy (firmware build:" << fwBuild << ")";
+    }
 
     // Only update if the ideal itself differs enough from current. Checking ideal (not the
     // EMA output) preserves the original 2% deadband regardless of alpha. The > 0.01 guard

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -3940,11 +3940,14 @@ bool Settings::setProfileFlowCalibration(const QString& profileFilename, double 
         qWarning() << "Settings: setProfileFlowCalibration called with empty profile filename";
         return false;
     }
-    // Sanity bounds — same range [0.5, 1.8] as computeAutoFlowCalibration(),
-    // but we reject (don't clamp) to prevent stale/corrupt values from persisting
-    if (multiplier < 0.5 || multiplier > 1.8) {
+    // Sanity bounds — persistence accepts [0.5, 2.7] to match the highest value the
+    // runtime auto-cal algorithm can produce (kCalibrationMax on v1337+ firmware).
+    // MainController::computeAutoFlowCalibration applies a tighter firmware-version-
+    // dependent ceiling (1.8 on older firmware, 2.7 on v1337+). Persistence just
+    // prevents obviously-corrupt values.
+    if (multiplier < 0.5 || multiplier > 2.7) {
         qWarning() << "Settings: rejecting per-profile flow calibration"
-                   << multiplier << "for" << profileFilename << "(outside [0.5, 1.8])";
+                   << multiplier << "for" << profileFilename << "(outside [0.5, 2.7])";
         return false;
     }
     QJsonObject map = allProfileFlowCalibrations();

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -3895,7 +3895,8 @@ double Settings::flowCalibrationMultiplier() const {
 }
 
 void Settings::setFlowCalibrationMultiplier(double multiplier) {
-    multiplier = qBound(0.35, multiplier, 2.0);
+    // Upper bound bumped 2.0 → 3.0 to match DE1 firmware v1337 (de1app parity).
+    multiplier = qBound(0.35, multiplier, 3.0);
     if (qAbs(flowCalibrationMultiplier() - multiplier) > 0.001) {
         m_settings.setValue("calibration/flowMultiplier", multiplier);
         emit flowCalibrationMultiplierChanged();

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -788,12 +788,12 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
                     continue;
                 }
                 double val = it.value().toDouble();
-                if (val >= 0.5 && val <= 1.8) {
+                if (val >= 0.5 && val <= 2.7) {
                     settings->setProfileFlowCalibration(it.key(), val);
                     imported++;
                 } else {
                     qWarning() << "Settings import: flow calibration out of bounds for"
-                               << it.key() << ":" << val << "(expected [0.5, 1.8])";
+                               << it.key() << ":" << val << "(expected [0.5, 2.7])";
                     rejected++;
                 }
             }

--- a/src/models/flowcalibrationmodel.cpp
+++ b/src/models/flowcalibrationmodel.cpp
@@ -34,7 +34,7 @@ void FlowCalibrationModel::setDevice(DE1Device* device) {
 }
 
 void FlowCalibrationModel::setMultiplier(double m) {
-    m = qBound(0.35, m, 2.0);
+    m = qBound(0.35, m, 3.0);
     if (qAbs(m_multiplier - m) > 0.001) {
         m_multiplier = m;
         recalculateFlow();


### PR DESCRIPTION
## Summary
Two coordinated changes motivated by DE1 firmware v1337 raising the machine-side flow-calibration cap from 2.0 to 3.0 (to match newer pump hardware).

### Manual cap
Bumped the user-controlled multiplier cap 2.0 → 3.0 in all three sites:
- `Settings::setFlowCalibrationMultiplier` `qBound` upper
- `FlowCalibrationModel::setMultiplier` `qBound` upper
- `FlowCalibrationPage` \"+0.01\" enable threshold + `Math.min` + slider `to`

### Auto-cal ceiling (firmware-gated)
Auto-cal keeps ~10% headroom below the firmware cap, mirroring the old 2.0→1.8 pair (0.9× ratio):
- Pre-v1337 firmware: `kCalibrationMax = 1.8` (unchanged)
- v1337+ firmware: `kCalibrationMax = 2.7`

`DE1Device::firmwareBuildNumber()` is now exposed so `MainController::computeAutoFlowCalibration` can branch at runtime.

### Warning (option 3 from the ceiling discussion)
- `qWarning` logged whenever the post-clamp computed value exceeds the classic 1.8 ceiling (scale-bias telemetry).
- `ProfileInfoPage` colors the multiplier in `Theme.warningColor` and sets `Accessible.description` to \"Unusually high — verify scale accuracy\" when > 1.8. No Unicode icon — per CLAUDE.md.

### Persistence loosening
`Settings::setProfileFlowCalibration` and `SettingsSerializer` both accept `[0.5, 2.7]` now. Persistence just prevents corrupt values; the firmware-aware clamp at compute time is the correctness gate. This also keeps values computed on v1337+ readable if a user later downgrades firmware.

The window-ratio guard `[0.75, 1.35]` stays as the primary protection against bad scale data.

## Test plan
- [ ] Old firmware (< v1337): auto-cal still clamps per-profile values at 1.8; slider/UI still allows 3.0 manually.
- [ ] New firmware (≥ v1337): auto-cal can converge up to 2.7; values > 1.8 appear amber in Profile Info with \"Unusually high — verify scale accuracy\" TalkBack hint; `qWarning` fires.
- [ ] Import a settings backup containing per-profile cal values > 1.8 and ≤ 2.7 — accepted; values > 2.7 rejected.
- [ ] No reference to the new-machine codename in any commit message, comment, or doc.

Identified via `/de1app_review` 60-day scan. Reference: de1app commit `d2b0180c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)