### PR TITLE
fix: Android fresh install stuck on 'Bluetooth powered off' (#732)

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -61,10 +61,13 @@ bool BLEManager::isBluetoothAvailable() const
     // install, permission is Undetermined — if we bail out here, the scan flow never
     // gets a chance to call requestBluetoothPermission(), and the user is stuck with
     // "Bluetooth is powered off" even though the adapter is fine. Report available
-    // while permission is unknown so the scan proceeds and prompts the user.
+    // only while the status is Undetermined so the scan proceeds and prompts the
+    // user. If the user has explicitly denied, fall through to the real hostMode()
+    // check (which will report PoweredOff) so bluetoothAvailable accurately reflects
+    // that BLE is unusable.
     QBluetoothPermission perm;
     perm.setCommunicationModes(QBluetoothPermission::Access);
-    if (qApp->checkPermission(perm) != Qt::PermissionStatus::Granted) {
+    if (qApp->checkPermission(perm) == Qt::PermissionStatus::Undetermined) {
         return true;
     }
 #endif
@@ -235,9 +238,16 @@ void BLEManager::requestBluetoothPermission() {
         qApp->requestPermission(bluetoothPermission, this, [this](const QPermission& permission) {
             if (permission.status() == Qt::PermissionStatus::Granted) {
                 emit de1LogMessage("Bluetooth permission granted");
+                // isBluetoothAvailable() now switches from the Undetermined bypass
+                // to the real hostMode() check. Notify QML bindings so any "Bluetooth
+                // unavailable" UI re-evaluates immediately.
+                emit bluetoothAvailableChanged();
                 doStartScan();
             } else {
                 emit de1LogMessage("Bluetooth permission denied");
+                // Transition Undetermined → Denied also flips isBluetoothAvailable()
+                // from true to false (via the hostMode() fall-through).
+                emit bluetoothAvailableChanged();
                 emit errorOccurred("Bluetooth permission denied");
             }
         });

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -7,6 +7,7 @@
 #include <QBluetoothUuid>
 #include <QCoreApplication>
 #include <QDebug>
+#include <QBluetoothPermission>
 #include <QLocationPermission>
 #include <QStandardPaths>
 #include <QDir>
@@ -54,6 +55,19 @@ bool BLEManager::isBluetoothAvailable() const
 #ifdef Q_OS_IOS
     return true;  // CoreBluetooth manages state; QBluetoothLocalDevice not available on iOS
 #else
+#ifdef Q_OS_ANDROID
+    // On Android, QBluetoothLocalDevice::hostMode() returns HostPoweredOff until the
+    // BLUETOOTH_CONNECT runtime permission has been granted (Android 12+). On a fresh
+    // install, permission is Undetermined — if we bail out here, the scan flow never
+    // gets a chance to call requestBluetoothPermission(), and the user is stuck with
+    // "Bluetooth is powered off" even though the adapter is fine. Report available
+    // while permission is unknown so the scan proceeds and prompts the user.
+    QBluetoothPermission perm;
+    perm.setCommunicationModes(QBluetoothPermission::Access);
+    if (qApp->checkPermission(perm) != Qt::PermissionStatus::Granted) {
+        return true;
+    }
+#endif
     return m_localDevice->hostMode() != QBluetoothLocalDevice::HostPoweredOff;
 #endif
 }


### PR DESCRIPTION
## Summary
- Fixes Android 12+ fresh-install case where Decenza reports "Bluetooth is powered off" and never prompts for the runtime Bluetooth permission, blocking all device discovery.
- Regression introduced in v1.6.5 by #695, which added an `isBluetoothAvailable()` guard that runs *before* `requestBluetoothPermission()`. On Android, `QBluetoothLocalDevice::hostMode()` returns `HostPoweredOff` until `BLUETOOTH_CONNECT` is granted, so the guard silently short-circuited the permission prompt.
- On Android, treat the adapter as available while permission status is not yet `Granted` so the scan flow reaches `requestBluetoothPermission()` and prompts the user. Once granted the real `hostMode()` check runs normally.

## Evidence from the reporter's log (#732)
```
WARN  Permissions not authorized ... QBluetoothPermission::CommunicationMode(Access)
WARN  Local device initialize() failed due to missing permissions
DEBUG BLEManager: scanForDevices - Bluetooth is powered off, skipping
```
No "Requesting Bluetooth permission…" log ever appears on build 3267. Earlier sessions in the same log worked only because permissions were carried over from a prior install — after the uninstall/reinstall Android revoked them and there was no way to re-grant.

## Test plan
- [ ] `adb uninstall io.github.kulitorum.decenza_de1` on Android 12+, install this build, tap Scan for Devices → permission prompt appears, grant, devices discovered.
- [ ] Deny the Bluetooth permission → error surfaces, app doesn't hang.
- [ ] With Bluetooth actually turned off in system settings, tap scan → "Bluetooth is powered off" is reported (real adapter-off guard still works post-grant).
- [ ] Existing install with permission already granted still scans without re-prompting.
- [ ] iOS unaffected (Q_OS_IOS path unchanged).

Fixes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)