### PR TITLE
fix: commit IME composition before reading text fields on mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,21 @@ Repeater {
 
 Other reserved names to avoid in model data: `parent`, `children`, `data`, `state`, `enabled`, `visible`, `width`, `height`, `x`, `y`, `z`, `focus`, `clip`.
 
+**IME last-word drop on mobile**: On Android/iOS virtual keyboards, the last typed word is held in a composing/pre-edit state and is NOT reflected in `TextField.text` until committed. When a button's `onClicked` reads a text field's `.text` directly (to send, save, or pass to a C++ method), always call `Qt.inputMethod.commit()` first — otherwise the last word is silently dropped. This is a no-op on desktop so it is safe to always include.
+```qml
+// BAD - last word may be missing on mobile
+onClicked: {
+    doSomething(myField.text)
+}
+
+// GOOD - commit pending IME composition first
+onClicked: {
+    Qt.inputMethod.commit()
+    doSomething(myField.text)
+}
+```
+This applies to every button/action that reads and immediately uses text input — save dialogs, send buttons, preset name dialogs, TOTP code fields, search/import fields, etc. For `doSave()` helper functions called from both buttons and `Keys.onReturnPressed`, put the commit at the top of the function.
+
 **Keyboard handling for text inputs**: Always wrap pages with text input fields in `KeyboardAwareContainer` to shift content above the keyboard on mobile:
 ```qml
 KeyboardAwareContainer {

--- a/qml/components/AIConversationPanel.qml
+++ b/qml/components/AIConversationPanel.qml
@@ -105,6 +105,11 @@ Item {
                 onClicked: {
                     if (!conversation) return
 
+                    // Commit any pending IME composition before reading text.
+                    // On mobile keyboards the last typed word stays in a "pre-edit"
+                    // composing state until committed, so it won't appear in .text yet.
+                    Qt.inputMethod.commit()
+
                     var prompt = followUpInput.visible && followUpInput.text
                         ? followUpInput.text
                         : root.userPrompt

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -878,6 +878,7 @@ Dialog {
                 text: TranslationManager.translate("brewDialog.ok", "OK")
                 accessibleName: TranslationManager.translate("brewDialog.confirmBrewSettings", "Confirm brew settings")
                 onClicked: {
+                    Qt.inputMethod.commit()
                     Settings.lastUsedRatio = root.ratio
                     Settings.dyeBeanBrand = root.beanBrand
                     Settings.dyeBeanType = root.beanType

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -646,6 +646,7 @@ Rectangle {
                     primary: true
                     enabled: inputDialogTextArea.text.length > 0 && inputRow.canSend
                     onClicked: {
+                        Qt.inputMethod.commit()
                         // Route through conversationInput.sendFollowUp() to reuse
                         // context-prepending and ask()/followUp() branching logic
                         conversationInput.text = inputDialogTextArea.text

--- a/qml/components/CrashReportDialog.qml
+++ b/qml/components/CrashReportDialog.qml
@@ -264,6 +264,7 @@ Dialog {
                     accessibleName: TranslationManager.translate("crashReport.sendReportAccessible", "Send crash report")
                     enabled: !CrashReporter.submitting
                     onClicked: {
+                        Qt.inputMethod.commit()
                         root.dialogState = "submitting"
                         CrashReporter.submitReport(crashLog, userNotesInput.text, debugLogTail)
                     }
@@ -509,6 +510,7 @@ Dialog {
                     accessibleName: TranslationManager.translate("crashReport.retryAccessible", "Retry sending crash report")
                     enabled: !CrashReporter.submitting
                     onClicked: {
+                        Qt.inputMethod.commit()
                         root.dialogState = "submitting"
                         CrashReporter.submitReport(crashLog, userNotesInput.text, debugLogTail)
                     }

--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -1255,6 +1255,7 @@ Page {
                     text: TranslationManager.translate("common.add", "Add")
                     accessibleName: TranslationManager.translate("beanInfo.addNewPreset", "Add new bean preset with current settings")
                     onClicked: {
+                        Qt.inputMethod.commit()
                         if (newBeanNameInput.text.trim().length > 0) {
                             var presetName = newBeanNameInput.text.trim()
                             Settings.saveBeanPresetFromCurrent(presetName)
@@ -1370,6 +1371,7 @@ Page {
                     text: TranslationManager.translate("common.save", "Save")
                     accessibleName: TranslationManager.translate("beanInfo.saveChangesToPreset", "Save changes to bean preset")
                     onClicked: {
+                        Qt.inputMethod.commit()
                         if (editBeanNameInput.text.trim().length > 0 && editPresetIndex >= 0) {
                             var preset = Settings.getBeanPreset(editPresetIndex)
                             Settings.updateBeanPreset(editPresetIndex,

--- a/qml/pages/DialingAssistantPage.qml
+++ b/qml/pages/DialingAssistantPage.qml
@@ -205,6 +205,7 @@ Page {
                              !MainController.aiManager.conversation.busy
                     onClicked: {
                         if (!MainController.aiManager || !MainController.aiManager.conversation) return
+                        Qt.inputMethod.commit()
                         if (followUpInput.text.length === 0) return
 
                         MainController.aiManager.conversation.followUp(followUpInput.text)

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -604,6 +604,7 @@ Page {
                     text: TranslationManager.translate("flush.button.save", "Save")
                     accessibleName: TranslationManager.translate("flush.savePresetChanges", "Save changes to flush preset")
                     onClicked: {
+                        Qt.inputMethod.commit()
                         var preset = Settings.getFlushPreset(editingPresetIndex)
                         Settings.updateFlushPreset(editingPresetIndex, editPresetNameInput.text, preset.flow, preset.seconds)
                         editPresetPopup.close()
@@ -707,6 +708,7 @@ Page {
                     text: TranslationManager.translate("flush.button.add", "Add")
                     accessibleName: TranslationManager.translate("flush.addNewPreset", "Add new flush preset with entered name")
                     onClicked: {
+                        Qt.inputMethod.commit()
                         if (newPresetNameInput.text.length > 0) {
                             Settings.addFlushPreset(newPresetNameInput.text, 6.0, 5.0)
                             newPresetNameInput.text = ""

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -762,6 +762,7 @@ Page {
                     text: TranslationManager.translate("hotwater.button.save", "Save")
                     accessibleName: TranslationManager.translate("hotWater.saveVesselChanges", "Save changes to water vessel preset")
                     onClicked: {
+                        Qt.inputMethod.commit()
                         var preset = Settings.getWaterVesselPreset(editingVesselIndex)
                         Settings.updateWaterVesselPreset(editingVesselIndex, editVesselNameInput.text, preset.volume, preset.mode || "weight", (preset.flowRate !== undefined) ? preset.flowRate : 40)
                         editVesselPopup.close()
@@ -865,6 +866,7 @@ Page {
                     text: TranslationManager.translate("hotwater.button.add", "Add")
                     accessibleName: TranslationManager.translate("hotWater.addNewVessel", "Add new water vessel with entered name")
                     onClicked: {
+                        Qt.inputMethod.commit()
                         if (newVesselNameInput.text.length > 0) {
                             Settings.addWaterVesselPreset(newVesselNameInput.text, 200, "weight", 40)
                             newVesselNameInput.text = ""

--- a/qml/pages/ProfileEditorPage.qml
+++ b/qml/pages/ProfileEditorPage.qml
@@ -895,6 +895,7 @@ Page {
         }
 
         function doSave() {
+            Qt.inputMethod.commit()
             if (saveAsTitleField.text.length > 0) {
                 var filename = ProfileManager.titleToFilename(saveAsTitleField.text)
                 if (ProfileManager.isBuiltInFilename(filename)) {

--- a/qml/pages/ProfileImportPage.qml
+++ b/qml/pages/ProfileImportPage.qml
@@ -469,6 +469,7 @@ Page {
                     primary: true
                     enabled: newNameInput.text.trim().length > 0
                     onClicked: {
+                        Qt.inputMethod.commit()
                         duplicateDialog.actionTaken = true
                         MainController.profileImporter.saveWithNewName(newNameInput.text.trim())
                         duplicateDialog.close()

--- a/qml/pages/RecipeEditorPage.qml
+++ b/qml/pages/RecipeEditorPage.qml
@@ -833,6 +833,7 @@ Page {
         }
 
         function doSave() {
+            Qt.inputMethod.commit()
             if (saveAsTitleField.text.length > 0) {
                 var fullTitle = editorPrefix() + saveAsTitleField.text
                 var filename = ProfileManager.titleToFilename(fullTitle)

--- a/qml/pages/SimpleProfileEditorPage.qml
+++ b/qml/pages/SimpleProfileEditorPage.qml
@@ -1047,6 +1047,7 @@ Page {
         }
 
         function doSave() {
+            Qt.inputMethod.commit()
             if (saveAsTitleField.text.length > 0) {
                 var filename = ProfileManager.titleToFilename(saveAsTitleField.text)
                 if (ProfileManager.isBuiltInFilename(filename)) {

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -1358,6 +1358,7 @@ Page {
                     text: saveButtonText.text
                     accessibleName: TranslationManager.translate("steam.savePitcherChanges", "Save changes to pitcher preset")
                     onClicked: {
+                        Qt.inputMethod.commit()
                         var preset = Settings.getSteamPitcherPreset(editingPitcherIndex)
                         Settings.updateSteamPitcherPreset(editingPitcherIndex, editPitcherNameInput.text, preset.duration, preset.flow)
                         editPitcherPopup.close()
@@ -1464,6 +1465,7 @@ Page {
                     text: addButtonText.text
                     accessibleName: TranslationManager.translate("steam.addNewPitcher", "Add new pitcher preset with entered name")
                     onClicked: {
+                        Qt.inputMethod.commit()
                         if (newPitcherName.text.trim() !== "") {
                             var presetCount = Settings.steamPitcherPresets.length
                             Settings.addSteamPitcherPreset(newPitcherName.text.trim(), 30, 150)

--- a/qml/pages/VisualizerBrowserPage.qml
+++ b/qml/pages/VisualizerBrowserPage.qml
@@ -180,6 +180,7 @@ Page {
                                 ? TranslationManager.translate("visualizerBrowser.importingPleaseWait", "Importing profile, please wait")
                                 : TranslationManager.translate("visualizerBrowser.importUsingShareCode", "Import profile using the 4-character share code")
                             onClicked: {
+                                Qt.inputMethod.commit()
                                 MainController.visualizerImporter.importFromShareCode(shareCodeInput.text)
                             }
                         }
@@ -406,6 +407,7 @@ Page {
                             text: TranslationManager.translate("visualizer.button.save", "Save")
                             accessibleName: TranslationManager.translate("visualizerBrowser.saveWithNewName", "Save profile with the new name")
                             onClicked: {
+                                Qt.inputMethod.commit()
                                 MainController.visualizerImporter.saveWithNewName(newNameInput.text.trim())
                                 hideDuplicateDialog()
                             }

--- a/qml/pages/VisualizerMultiImportPage.qml
+++ b/qml/pages/VisualizerMultiImportPage.qml
@@ -297,6 +297,7 @@ Page {
                         enabled: codeInput.text.length === 4
 
                         onClicked: {
+                            Qt.inputMethod.commit()
                             MainController.visualizerImporter.importFromShareCode(codeInput.text)
                             showCodeInput = false
                         }
@@ -879,6 +880,7 @@ Page {
                 enabled: renameInput.text.trim().length > 0
 
                 onClicked: {
+                    Qt.inputMethod.commit()
                     Qt.inputMethod.hide()
                     renameInput.focus = false
                     MainController.visualizerImporter.importFromShotIdWithName(renameProfileId, renameInput.text.trim())

--- a/qml/pages/settings/DeviceMigrationDialog.qml
+++ b/qml/pages/settings/DeviceMigrationDialog.qml
@@ -301,6 +301,7 @@ Dialog {
                         primary: true
                         enabled: manualIpField.text.trim().length > 0
                         onClicked: {
+                            Qt.inputMethod.commit()
                             var address = manualIpField.text.trim()
                             // If user didn't include http://, add it
                             if (!address.startsWith("http://") && !address.startsWith("https://")) {
@@ -397,6 +398,7 @@ Dialog {
                         "Submit authenticator code to connect to remote device")
                     enabled: migrationTotpField.text.length === 6 && !MainController.dataMigration.isConnecting
                     onClicked: {
+                        Qt.inputMethod.commit()
                         MainController.dataMigration.authenticate(migrationTotpField.text)
                     }
                 }

--- a/qml/pages/settings/SettingsAITab.qml
+++ b/qml/pages/settings/SettingsAITab.qml
@@ -1149,6 +1149,7 @@ KeyboardAwareContainer {
                         Keys.onEnterPressed: sendMsg()
 
                         function sendMsg() {
+                            Qt.inputMethod.commit()
                             if (text.length === 0) return
                             MainController.aiManager?.conversation?.followUp(text)
                             text = ""

--- a/qml/pages/settings/SettingsHistoryDataTab.qml
+++ b/qml/pages/settings/SettingsHistoryDataTab.qml
@@ -1663,6 +1663,7 @@ KeyboardAwareContainer {
                                 "Verify authenticator code to complete setup")
                             enabled: totpCodeField.text.length === 6 && !totpSetupDialog.verifying
                             onClicked: {
+                                Qt.inputMethod.commit()
                                 totpSetupDialog.verifying = true;
                                 var success = MainController.shotServer.completeTotpSetup(
                                     totpSetupDialog.totpSecret, totpCodeField.text);


### PR DESCRIPTION
## Summary

- On Android/iOS virtual keyboards, the last typed word stays in a composing (pre-edit) state and is **not** reflected in `TextField.text` until explicitly committed
- Tapping a Send/Save button while the last word is uncommitted silently drops it
- Added `Qt.inputMethod.commit()` at the top of every `onClicked` handler (and `doSave()` helper) that reads a text field and sends/saves the value
- Also documented the pattern in CLAUDE.md's QML Gotchas section so it doesn't regress

## Affected locations (17 files)

| File | Context |
|------|---------|
| `AIConversationPanel.qml` | AI follow-up send button |
| `ConversationOverlay.qml` | Conversation input send button |
| `CrashReportDialog.qml` | Send/Retry crash report (user notes field) |
| `DialingAssistantPage.qml` | AI dialing assistant follow-up |
| `BeanInfoPage.qml` | Add/edit bean preset name |
| `FlushPage.qml` | Add/edit flush preset name |
| `HotWaterPage.qml` | Add/edit water vessel name |
| `SteamPage.qml` | Add/edit pitcher preset name |
| `ProfileEditorPage.qml` | Save As dialog (`doSave()`) |
| `RecipeEditorPage.qml` | Save As dialog (`doSave()`) |
| `SimpleProfileEditorPage.qml` | Save As dialog (`doSave()`) |
| `ProfileImportPage.qml` | Save with new name on duplicate |
| `VisualizerBrowserPage.qml` | Import by share code, save with new name |
| `VisualizerMultiImportPage.qml` | Import by share code, rename on import |
| `DeviceMigrationDialog.qml` | Manual IP connect, TOTP verify |
| `SettingsHistoryDataTab.qml` | TOTP setup verification |
| `CLAUDE.md` | Documents the pattern in QML Gotchas |

## Test plan

- [ ] On Android: type a multi-word question in the AI advisor and tap Ask — verify last word is included
- [ ] On Android: create a preset with a multi-word name and tap Save — verify full name is saved
- [ ] On Android: use a Save As dialog in any profile editor — verify the full title is saved
- [ ] On desktop: verify no regression (commit() is a no-op when no IME is active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)