### PR TITLE
a11y: screen reader audit — Wave 1 + Wave 2 pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,7 +494,7 @@ KeyboardAwareContainer {
 }
 ```
 
-**Accessibility on interactive elements**: See `docs/CLAUDE_MD/ACCESSIBILITY.md` for the full rules, component table, common mistakes checklist, focus-order requirements, and anti-patterns. The short version: every interactive element needs `Accessible.role`, `Accessible.name`, `Accessible.focusable: true`, and `activeFocusOnTab: true`. Prefer `AccessibleButton` or `AccessibleMouseArea` over raw `Rectangle+MouseArea`.
+**Accessibility on interactive elements**: See `docs/CLAUDE_MD/ACCESSIBILITY.md` for the full rules, component table, common mistakes checklist, focus-order requirements, and anti-patterns. The short version: every interactive element needs `Accessible.role`, `Accessible.name`, `Accessible.focusable: true`, and `Accessible.onPressAction`. Prefer `AccessibleButton` or `AccessibleMouseArea` over raw `Rectangle+MouseArea`. (`activeFocusOnTab: true` is keyboard-only and low priority for this tablet app — see ACCESSIBILITY.md.)
 
 ### ShotServer Web UI (split across shotserver_*.cpp files)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ Detailed documentation lives in `docs/CLAUDE_MD/`. Read these when working in th
 | `STEAM_CALIBRATION.md` | Steam health tracking, calibration procedure |
 | `CUP_FILL_VIEW.md` | CupFillView layer stack, GPU shaders, updating cup images |
 | `EMOJI_SYSTEM.md` | Twemoji SVG rendering, adding/switching emoji sets |
+| `ACCESSIBILITY.md` | TalkBack/VoiceOver rules, focus order, anti-patterns, implementation plan |
 
 Also in `docs/`:
 - `MCP_SERVER.md` — full MCP tool list, access levels, architecture
@@ -493,64 +494,7 @@ KeyboardAwareContainer {
 }
 ```
 
-**Accessibility on interactive elements**: Every interactive element must have `Accessible.role`, `Accessible.name`, and `Accessible.focusable: true`. Without these, TalkBack/VoiceOver cannot discover or activate the element. Use the table below:
-
-| Element | Use instead | If raw, must set |
-|---------|-------------|------------------|
-| Button (Rectangle+MouseArea) | `AccessibleButton` or `AccessibleMouseArea` | `Accessible.role: Accessible.Button` + `name` + `focusable` + `onPressAction` |
-| Text input | `StyledTextField` | `Accessible.role: Accessible.EditableText` + `name` + `description: text` + `focusable` |
-| Autocomplete field | `SuggestionField` | (same as text input) |
-| Checkbox | Qt `CheckBox` | `Accessible.name` + `Accessible.checked: checked` + `focusable` |
-| Dropdown | `StyledComboBox` | `Accessible.role: Accessible.ComboBox` + `name` (use label, not displayText) + `focusable` |
-| List delegate | — | `Accessible.role: Accessible.Button` + `name` (summarize row content) + `focusable` + `onPressAction` |
-
-Common mistakes:
-- **Multi-action element missing `Accessible.description` hint**: Any interactive element with secondary actions (long-press, double-tap) **must** set `Accessible.description` (or `accessibleDescription` on `AccessibleTapHandler`) to announce those actions. TalkBack/VoiceOver reads this as a hint after the element name. Without it, blind users cannot discover secondary actions. Format: `"Double-tap or long-press to <action>."` For `AccessibleTapHandler` use the `accessibleDescription` property; for `ActionButton` and raw `Rectangle` use `Accessible.description` directly.
-- **Rectangle+MouseArea without accessibility**: TalkBack cannot see it. Use `AccessibleButton`, `AccessibleMouseArea`, or add all four properties (`role`, `name`, `focusable`, `onPressAction`).
-- **Accessibility on raw MouseArea instead of Rectangle**: Never put `Accessible.role`/`name`/`focusable` on a raw `MouseArea` child — put them on the parent Rectangle. MouseArea should only have an `id` so the Rectangle's `Accessible.onPressAction` can route to it. This does **not** apply to `AccessibleMouseArea`, which is a project component designed to handle accessibility on behalf of the parent via `accessibleItem`.
-- **Missing `Accessible.onPressAction`**: Every raw Rectangle+MouseArea button **must** have `Accessible.onPressAction: mouseAreaId.clicked(null)` (or `.tapped()` for TapHandler). Without it, TalkBack/VoiceOver double-tap does nothing. This applies even when the other three properties (`role`, `name`, `focusable`) are present. Not needed when using `AccessibleMouseArea` or `AccessibleButton`.
-- **Child Text inside accessible button missing `Accessible.ignored: true`**: When a Rectangle has `Accessible.name`, all child Text elements must set `Accessible.ignored: true`. Otherwise TalkBack announces the button name AND the text content, doubling the announcement.
-- **Text input missing `Accessible.description: text`**: Field sounds "Empty" even when it contains text. `StyledTextField` and `SuggestionField` set this automatically. Note: `Accessible.value` does not exist in Qt QML — use `Accessible.description` instead.
-- **ComboBox `Accessible.name` set to `displayText`**: Announces the selected value instead of the field label. Override with the label text.
-- **List row with no accessibility**: Only child elements (e.g. CheckBox) are discoverable; the row itself and its primary action are invisible.
-- **Decorative text without `Accessible.ignored: true`**: When a list delegate summarizes its content in `Accessible.name`, all child Text elements must set `Accessible.ignored: true`. Otherwise TalkBack announces the summary AND each text line individually, doubling every piece of information. Same applies to icon/label text inside buttons that already have `Accessible.name`.
-
-```qml
-// BAD - TalkBack can't see this button
-Rectangle {
-    MouseArea { onClicked: doSomething() }
-}
-
-// GOOD - use AccessibleButton (preferred for standard buttons)
-AccessibleButton {
-    text: "Save"
-    accessibleName: "Save changes"
-    onClicked: doSomething()
-}
-
-// GOOD - use AccessibleMouseArea (for custom-styled buttons, provides announce-first TalkBack behavior)
-Rectangle {
-    id: myButton
-    color: Theme.primaryColor
-    Accessible.ignored: true
-    Text { text: "Save"; Accessible.ignored: true }
-    AccessibleMouseArea {
-        anchors.fill: parent
-        accessibleName: "Save changes"
-        accessibleItem: myButton
-        onAccessibleClicked: doSomething()
-    }
-}
-
-// OK - add accessibility to Rectangle manually (last resort, loses announce-first behavior)
-Rectangle {
-    Accessible.role: Accessible.Button
-    Accessible.name: "Save changes"
-    Accessible.focusable: true
-    Accessible.onPressAction: area.clicked(null)
-    MouseArea { id: area; onClicked: doSomething() }
-}
-```
+**Accessibility on interactive elements**: See `docs/CLAUDE_MD/ACCESSIBILITY.md` for the full rules, component table, common mistakes checklist, focus-order requirements, and anti-patterns. The short version: every interactive element needs `Accessible.role`, `Accessible.name`, `Accessible.focusable: true`, and `activeFocusOnTab: true`. Prefer `AccessibleButton` or `AccessibleMouseArea` over raw `Rectangle+MouseArea`.
 
 ### ShotServer Web UI (split across shotserver_*.cpp files)
 
@@ -682,39 +626,6 @@ Each operation page (Steam, HotWater, Flush) has:
 
 ## Accessibility (TalkBack/VoiceOver)
 
-### Current Implementation
-The app has accessibility support via `AccessibilityManager` (C++) with:
-- Text-to-speech announcements via `AccessibilityManager.announce()`
-- Tick sounds for frame changes
-- `AccessibleTapHandler` and `AccessibleMouseArea` for touch handling
-- Extraction announcements (phase changes, weight milestones, periodic updates)
-- User-configurable settings in Settings → Accessibility
+See `docs/CLAUDE_MD/ACCESSIBILITY.md` for the full reference: component rules, focus-order requirements, anti-patterns, common mistakes checklist, and the page-by-page implementation plan for [Kulitorum/Decenza#736](https://github.com/Kulitorum/Decenza/issues/736).
 
-### Key Components
-- `src/core/accessibilitymanager.h/cpp` - TTS, tick sounds, settings persistence
-- `qml/components/AccessibleTapHandler.qml` - Touch handler that works with TalkBack
-- `qml/components/AccessibleMouseArea.qml` - Alternative touch handler with announce-first TalkBack behavior
-- `qml/components/AccessibleButton.qml` - Button with required accessibleName
-- `qml/components/AccessibleLabel.qml` - Tap-to-announce text
-
-### Accessibility Anti-patterns (Do NOT Use)
-
-1. **Parent-ignored / child-accessible**: Never set `Accessible.ignored: true` on a parent and put `Accessible.role` on a child occupying the same bounds. TalkBack can't reliably route activation to the child. Put accessibility properties on the interactive element itself. **Exception**: `AccessibleMouseArea` with `accessibleItem` is designed for this pattern — the parent Rectangle has `Accessible.ignored: true` and `AccessibleMouseArea` carries the accessibility properties. This is the established pattern for custom-styled buttons throughout the codebase.
-2. **Popup for selection lists**: Never use `Popup` for lists users must navigate. TalkBack can't trap focus inside Qt `Popup` elements. Use `Dialog { modal: true }` with `AccessibleButton` delegates instead.
-3. **Overlapping accessible elements**: Never position accessible buttons inside another accessible element's bounds (e.g., buttons inside a TextField's padding area). TalkBack will only discover one element. Use conditional layout to show buttons in separate bounds when accessibility is enabled.
-
-### Rules for New Components
-
-1. Every interactive element must have `Accessible.role`, `Accessible.name`, `Accessible.focusable`, `Accessible.onPressAction` **on itself** (not on a child). Exception: `AccessibleMouseArea` with `accessibleItem` carries accessibility for its parent — see anti-pattern #1 exception above.
-2. Every interactive element with secondary actions (long-press, double-tap) **must** also set `Accessible.description` (or `accessibleDescription` on `AccessibleTapHandler`) describing those actions. Format: `"Double-tap or long-press to <action>."` This is how TalkBack/VoiceOver announces hints — without it, blind users cannot discover secondary workflows.
-3. Never use `Popup` for selection lists — use `Dialog` with `AccessibleButton` delegates
-4. Never overlap accessible elements — separate bounds or use conditional layout (`_accessibilityMode` pattern)
-5. Test with TalkBack: double-tap to activate, swipe to navigate
-
-### Rules for Modifying Existing Components
-
-When touching existing code, **fix pre-existing bugs and violations in the file you're modifying** — do not dismiss them as "pre-existing". A bad bug is a bad bug regardless of when it was introduced. This applies to all issue types: real bugs, data loss, accessibility violations, missing i18n, incorrect MCP field names, etc. In code review, score pre-existing issues on the same scale as new issues. If you add properties to a Text element inside an `Accessible.name`-bearing parent and that Text is missing `Accessible.ignored: true`, add it. Issues compound over time and each modification is an opportunity to fix them.
-
-### TODO: Focus Order Improvements
-
-Tracked in https://github.com/Kulitorum/Decenza/issues/736 — KeyNavigation chains, FocusScope wrappers, and initial focus are missing from most pages.
+**Key rule for modifying existing components**: Fix pre-existing violations in any file you touch — do not dismiss them as "pre-existing". Issues compound over time and each change is an opportunity to fix them.

--- a/docs/CLAUDE_MD/ACCESSIBILITY.md
+++ b/docs/CLAUDE_MD/ACCESSIBILITY.md
@@ -1,0 +1,291 @@
+# Accessibility (TalkBack / VoiceOver)
+
+## Current Implementation
+
+The app has accessibility support via `AccessibilityManager` (C++) with:
+- Text-to-speech announcements via `AccessibilityManager.announce()`
+- Tick sounds for frame changes
+- `AccessibleTapHandler` and `AccessibleMouseArea` for touch handling
+- Extraction announcements (phase changes, weight milestones, periodic updates)
+- User-configurable settings in Settings → Accessibility
+
+### Key QML Components
+
+| Component | Purpose |
+|-----------|---------|
+| `qml/components/AccessibleButton.qml` | Standard button with required `accessibleName` |
+| `qml/components/AccessibleMouseArea.qml` | Custom-styled button with announce-first TalkBack behavior |
+| `qml/components/AccessibleTapHandler.qml` | TapHandler variant that works with TalkBack |
+| `qml/components/AccessibleLabel.qml` | Tap-to-announce text label |
+
+### Key C++ Component
+
+`src/core/accessibilitymanager.h/cpp` — TTS engine, tick sounds, settings persistence.
+
+---
+
+## Rule 1 — Every Interactive Element Must Be Discoverable
+
+Every interactive element must have `Accessible.role`, `Accessible.name`, and `Accessible.focusable: true`. Without these, TalkBack/VoiceOver cannot discover or activate the element.
+
+| Element | Preferred | If raw, must set |
+|---------|-----------|-----------------|
+| Button (Rectangle+MouseArea) | `AccessibleButton` or `AccessibleMouseArea` | `Accessible.role: Accessible.Button` + `Accessible.name` + `Accessible.focusable: true` + `Accessible.onPressAction` |
+| Text input | `StyledTextField` | `Accessible.role: Accessible.EditableText` + `Accessible.name` + `Accessible.description: text` + `Accessible.focusable: true` |
+| Autocomplete field | `SuggestionField` | (same as text input) |
+| Checkbox | Qt `CheckBox` | `Accessible.name` + `Accessible.checked: checked` + `Accessible.focusable: true` |
+| Dropdown | `StyledComboBox` | `Accessible.role: Accessible.ComboBox` + `Accessible.name` (use label, not displayText) + `Accessible.focusable: true` |
+| List delegate | — | `Accessible.role: Accessible.Button` + `Accessible.name` (summarize row content) + `Accessible.focusable: true` + `Accessible.onPressAction` |
+
+```qml
+// BAD - TalkBack can't see this button
+Rectangle {
+    MouseArea { onClicked: doSomething() }
+}
+
+// GOOD - use AccessibleButton (preferred for standard buttons)
+AccessibleButton {
+    text: "Save"
+    accessibleName: "Save changes"
+    onClicked: doSomething()
+}
+
+// GOOD - use AccessibleMouseArea (for custom-styled buttons, provides announce-first TalkBack behavior)
+Rectangle {
+    id: myButton
+    color: Theme.primaryColor
+    Accessible.ignored: true
+    Text { text: "Save"; Accessible.ignored: true }
+    AccessibleMouseArea {
+        anchors.fill: parent
+        accessibleName: "Save changes"
+        accessibleItem: myButton
+        onAccessibleClicked: doSomething()
+    }
+}
+
+// OK - add accessibility to Rectangle manually (last resort, loses announce-first behavior)
+Rectangle {
+    Accessible.role: Accessible.Button
+    Accessible.name: "Save changes"
+    Accessible.focusable: true
+    Accessible.onPressAction: area.clicked(null)
+    MouseArea { id: area; onClicked: doSomething() }
+}
+```
+
+---
+
+## Rule 2 — Secondary Actions Must Be Announced
+
+Any interactive element with secondary actions (long-press, double-tap) **must** set `Accessible.description` (or `accessibleDescription` on `AccessibleTapHandler`) describing those actions. TalkBack/VoiceOver reads this as a hint after the element name. Without it, blind users cannot discover secondary workflows.
+
+Format: `"Double-tap or long-press to <action>."` Where to set it depends on which component you're using:
+
+| Component | How to set hint |
+|-----------|----------------|
+| `AccessibleTapHandler` | `accessibleDescription` property (built into the component) |
+| `ActionButton` | `Accessible.description` on the button itself |
+| Raw `Rectangle` + `MouseArea` | `Accessible.description` on the Rectangle |
+| `AccessibleMouseArea` | `Accessible.description` on the **parent Rectangle** — `AccessibleMouseArea` does not expose an `accessibleDescription` property |
+
+---
+
+## Rule 3 — Every Page Must Have a Tab Chain (Focus Order)
+
+Screen reader users navigate by swiping, but keyboard users (and some switch-access users) rely on `Tab`/`Shift+Tab`. Both require a logical, complete focus chain.
+
+**Every page must:**
+
+1. Set `activeFocusOnTab: true` on every focusable control (alongside `Accessible.focusable: true`).
+2. Wire `KeyNavigation.tab` and `KeyNavigation.backtab` on all interactive controls in logical reading order, forming a **closed loop** (last element tabs back to first).
+3. Set initial focus when the page/dialog becomes visible:
+   - **Pages** (pushed onto `pageStack`): `Component.onCompleted: firstControl.forceActiveFocus()`
+   - **Dialogs/Popups**: `onOpened: firstControl.forceActiveFocus()` — `Component.onCompleted` fires before the dialog is open and is unreliable for focus.
+4. Wrap related groups of controls (e.g. a dialog's action buttons) in a `FocusScope`.
+
+```qml
+// Full pattern for a page
+Item {
+    Component.onCompleted: firstField.forceActiveFocus()
+
+    StyledTextField {
+        id: firstField
+        activeFocusOnTab: true
+        Accessible.focusable: true
+        KeyNavigation.tab: secondField
+        KeyNavigation.backtab: saveButton   // wraps around from last
+    }
+
+    StyledTextField {
+        id: secondField
+        activeFocusOnTab: true
+        Accessible.focusable: true
+        KeyNavigation.tab: saveButton
+        KeyNavigation.backtab: firstField
+    }
+
+    AccessibleButton {
+        id: saveButton
+        activeFocusOnTab: true
+        KeyNavigation.tab: firstField       // wraps back to start
+        KeyNavigation.backtab: secondField
+        onClicked: save()
+    }
+}
+
+// Group related controls with FocusScope
+FocusScope {
+    AccessibleButton { id: okButton;     KeyNavigation.tab: cancelButton }
+    AccessibleButton { id: cancelButton; KeyNavigation.tab: okButton }
+}
+
+// Repeater-based rows (e.g. preset pills) — KeyNavigation.tab can't reference
+// dynamic delegates statically. Instead:
+// 1. Expose focusTarget on the delegate Item
+// 2. Use Keys.onTabPressed with forceActiveFocus()
+// 3. Add Keys.onLeftPressed/RightPressed for arrow navigation within the row
+Repeater {
+    id: myRepeater
+    model: myModel
+
+    Item {
+        property Item focusTarget: myPill   // expose for external callers
+
+        Rectangle {
+            id: myPill
+            activeFocusOnTab: true
+            Accessible.role: Accessible.Button
+            Accessible.name: modelData.label
+            Accessible.focusable: true
+            Accessible.onPressAction: selectItem(index)
+
+            // Non-Button Rectangle: must handle Enter/Space manually
+            Keys.onReturnPressed: { selectItem(index); event.accepted = true }
+            Keys.onSpacePressed:  { selectItem(index); event.accepted = true }
+            Keys.onLeftPressed: {
+                if (index > 0) myRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
+                event.accepted = true
+            }
+            Keys.onRightPressed: {
+                if (index < myRepeater.count - 1) myRepeater.itemAt(index + 1).focusTarget.forceActiveFocus()
+                event.accepted = true
+            }
+            Keys.onTabPressed: {
+                if (index < myRepeater.count - 1)
+                    myRepeater.itemAt(index + 1).focusTarget.forceActiveFocus()
+                else
+                    nextControlAfterRow.forceActiveFocus()
+                event.accepted = true
+            }
+            Keys.onBacktabPressed: {
+                if (index > 0)
+                    myRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
+                else
+                    prevControlBeforeRow.forceActiveFocus()
+                event.accepted = true
+            }
+        }
+    }
+}
+```
+
+**Canonical reference**: `qml/pages/settings/SettingsCalibrationTab.qml` lines 710–783 — the only fully-implemented example. Note it is a `Dialog`, so initial focus uses `onOpened: heaterIdleTempSlider.forceActiveFocus()` (line 678), not `Component.onCompleted`.
+
+**Status**: Focus chains are missing from most pages. Work is tracked in
+[Kulitorum/Decenza#736](https://github.com/Kulitorum/Decenza/issues/736).
+
+> **Note on priority**: Decenza runs primarily on an Android tablet where users navigate by touch and TalkBack swipe. `KeyNavigation` and `activeFocusOnTab` have no effect on TalkBack — they only benefit desktop or physical-keyboard users. Keyboard chains are correct to add when already touching a page, but they are **low priority** compared to screen reader (Pass 1) work, which directly affects the tablet user base. See the [implementation plan](#screen-reader-audit-implementation-plan) below.
+
+---
+
+## Anti-Patterns (Do NOT Use)
+
+### 1. Parent-ignored / child-accessible
+Never set `Accessible.ignored: true` on a parent and put `Accessible.role` on a child occupying the same bounds. TalkBack can't reliably route activation to the child. Put accessibility properties on the interactive element itself.
+
+**Exception**: `AccessibleMouseArea` with `accessibleItem` is designed for this pattern — the parent Rectangle has `Accessible.ignored: true` and `AccessibleMouseArea` carries the accessibility properties. This is the established pattern for custom-styled buttons throughout the codebase.
+
+### 2. Popup for selection lists
+Never use `Popup` for lists users must navigate. TalkBack can't trap focus inside Qt `Popup` elements. Use `Dialog { modal: true }` with `AccessibleButton` delegates instead.
+
+### 3. Overlapping accessible elements
+Never position accessible buttons inside another accessible element's bounds (e.g., buttons inside a TextField's padding area). TalkBack will only discover one element. Use conditional layout to show buttons in separate bounds when accessibility is enabled. See `ShotHistoryPage.qml` for a real example: it checks `AccessibilityManager.accessibilityEnabled` to conditionally reposition elements that would otherwise overlap.
+
+---
+
+## Common Mistakes Checklist
+
+- **Rectangle+MouseArea without accessibility** — TalkBack cannot see it. Use `AccessibleButton`, `AccessibleMouseArea`, or add all four properties (`role`, `name`, `focusable`, `onPressAction`).
+- **Accessibility on raw MouseArea instead of Rectangle** — Never put `Accessible.role`/`name`/`focusable` on a raw `MouseArea` child — put them on the parent Rectangle. `AccessibleMouseArea` is the exception.
+- **Missing `Accessible.onPressAction`** — Every raw Rectangle+MouseArea button **must** have `Accessible.onPressAction: mouseAreaId.clicked(null)` (or `.tapped()` for TapHandler). Without it, TalkBack/VoiceOver double-tap does nothing. Not needed for `AccessibleMouseArea` or `AccessibleButton`.
+- **Child Text inside accessible button missing `Accessible.ignored: true`** — TalkBack announces button name AND text content, doubling the announcement.
+- **Text input missing `Accessible.description: text`** — Field sounds "Empty" even when it contains text. `StyledTextField` and `SuggestionField` set this automatically. Note: `Accessible.value` does not exist in Qt QML — use `Accessible.description` instead.
+- **ComboBox `Accessible.name` set to `displayText`** — Announces the selected value instead of the field label. Override with the label text.
+- **List row with no accessibility** — Only child elements (e.g. CheckBox) are discoverable; the row itself and its primary action are invisible.
+- **Decorative text without `Accessible.ignored: true`** — When a list delegate summarizes its content in `Accessible.name`, all child Text elements must set `Accessible.ignored: true`. Same applies to icon/label text inside buttons that already have `Accessible.name`.
+- **Multi-action element missing `Accessible.description` hint** — Secondary actions (long-press, double-tap) are invisible to screen reader users without a hint.
+- **`AccessibleTapHandler` with `accessibleItem`: child Text still needs `Accessible.ignored: true`** — When a Rectangle uses `AccessibleTapHandler` with `accessibleItem: myRect`, the TapHandler carries the accessible name on behalf of the Rectangle. Any `Text` children of that Rectangle still need `Accessible.ignored: true` — TalkBack will find both the TapHandler's name and the Text node and announce both. This applies even though the Rectangle itself has no `Accessible.name` property set directly.
+
+**Keyboard navigation (desktop/physical keyboard only — low priority for this tablet app):**
+- **Missing `activeFocusOnTab: true`** — Control is unreachable by keyboard Tab navigation even if it has `Accessible.focusable: true`. Both must be set together. Has no effect on TalkBack swipe navigation.
+- **Raw Rectangle with `activeFocusOnTab` missing `Keys.onReturnPressed/SpacePressed`** — `activeFocusOnTab` gets the element focused, but a raw Rectangle won't activate on Enter/Space without explicit key handlers. Qt's `Button`-based components (`AccessibleButton`, `ActionButton`) handle this internally; raw Rectangles do not.
+- **No `KeyNavigation` chain** — Focus jumps unpredictably or gets stuck for keyboard users. Has no effect on TalkBack swipe navigation.
+- **`KeyNavigation.tab` on a Repeater delegate** — `KeyNavigation.tab` requires a static Item reference and cannot point to dynamically-created delegate instances. Use the `focusTarget` pattern instead (see below).
+- **No initial focus** — First focusable control on a page should receive focus via `Component.onCompleted: firstControl.forceActiveFocus()`.
+
+---
+
+## Rules for New Components
+
+1. Every interactive element must have `Accessible.role`, `Accessible.name`, `Accessible.focusable: true`, and `Accessible.onPressAction` **on itself** (not on a child). Exception: `AccessibleMouseArea` with `accessibleItem`.
+2. Every interactive element with secondary actions must set `Accessible.description` describing those actions.
+3. Never use `Popup` for selection lists — use `Dialog` with `AccessibleButton` delegates.
+4. Never overlap accessible elements — separate bounds or check `AccessibilityManager.accessibilityEnabled` to conditionally reposition elements (see `ShotHistoryPage.qml` for an example).
+5. Test with TalkBack: double-tap to activate, swipe to navigate.
+6. *(Low priority for this tablet app)* Every focusable control should also set `activeFocusOnTab: true` for desktop/physical-keyboard users.
+
+## Rules for Modifying Existing Components
+
+When touching existing code, **fix pre-existing violations in the file you're modifying** — do not dismiss them as "pre-existing". Issues compound over time and each modification is an opportunity to fix them. If you add a `Text` element inside an `Accessible.name`-bearing parent and it's missing `Accessible.ignored: true`, add it.
+
+---
+
+## Screen Reader Audit Implementation Plan
+
+### Why screen reader only
+
+Decenza runs primarily on an Android tablet. Users with accessibility needs use TalkBack swipe navigation — `KeyNavigation`, `activeFocusOnTab`, and `forceActiveFocus` have no effect on TalkBack. The keyboard navigation work added to Wave 1 pages (FlushPage, HotWaterPage, SteamPage, IdlePage, EspressoPage) is harmless and correct for desktop users, but it is **not the focus of ongoing accessibility work**. Remaining waves audit screen reader properties only.
+
+The three things that have direct, immediate impact on tablet TalkBack users:
+1. **Missing `Accessible.onPressAction`** — element is announced but double-tap does nothing
+2. **Missing `Accessible.description`** — secondary actions (long-press, drag) are invisible
+3. **Missing `Accessible.ignored: true`** on child Text — element name is announced twice
+
+### Wave 1 — Core operation pages
+| Page | Status |
+|------|--------|
+| `FlushPage.qml` | **Done** |
+| `HotWaterPage.qml` | **Done** |
+| `SteamPage.qml` | **Done** |
+| `IdlePage.qml` | **Done** |
+| `EspressoPage.qml` | **Done** |
+
+### Wave 2 — Post-shot and review pages
+`PostShotReviewPage`, `ShotDetailPage`, `ShotHistoryPage`, `BeanInfoPage`
+
+### Wave 3 — Profile management pages
+`ProfileSelectorPage`, `RecipeEditorPage`, `SimpleProfileEditorPage`, `ProfileEditorPage`, `ProfileInfoPage`
+
+### Wave 4 — Settings tabs (one PR per tab)
+Priority: `SettingsMachineTab` → `SettingsConnectionsTab` → `SettingsPreferencesTab` → `SettingsAITab` → `SettingsAccessibilityTab` → remaining tabs.
+(`SettingsCalibrationTab` is already done — skip.)
+
+### Wave 5 — Secondary pages
+`CommunityBrowserPage`, `VisualizerBrowserPage`, `VisualizerMultiImportPage`, `ProfileImportPage`, `ShotComparisonPage`, `AutoFavoriteInfoPage`, `AutoFavoritesPage`, `DialingAssistantPage`, `FlowCalibrationPage`, `DescalingPage`
+
+### Definition of "done" for a page
+- All interactive elements have `Accessible.role`, `Accessible.name`, `Accessible.focusable: true`, `Accessible.onPressAction`
+- All secondary actions (long-press, drag, double-tap) have `Accessible.description` hints
+- All decorative `Text`/icons inside accessible parents have `Accessible.ignored: true`
+- No bare `Rectangle+MouseArea` without accessibility properties

--- a/docs/CLAUDE_MD/ACCESSIBILITY.md
+++ b/docs/CLAUDE_MD/ACCESSIBILITY.md
@@ -190,7 +190,7 @@ Repeater {
 }
 ```
 
-**Canonical reference**: `qml/pages/settings/SettingsCalibrationTab.qml` lines 710–783 — the only fully-implemented example. Note it is a `Dialog`, so initial focus uses `onOpened: heaterIdleTempSlider.forceActiveFocus()` (line 678), not `Component.onCompleted`.
+**Canonical references**: `qml/pages/settings/SettingsCalibrationTab.qml` lines 710–783 (Dialog — uses `onOpened: heaterIdleTempSlider.forceActiveFocus()`, not `Component.onCompleted`). For Repeater-based pill rows, see `qml/pages/FlushPage.qml` (settings preset section).
 
 **Status**: Focus chains are missing from most pages. Work is tracked in
 [Kulitorum/Decenza#736](https://github.com/Kulitorum/Decenza/issues/736).
@@ -210,7 +210,7 @@ Never set `Accessible.ignored: true` on a parent and put `Accessible.role` on a 
 Never use `Popup` for lists users must navigate. TalkBack can't trap focus inside Qt `Popup` elements. Use `Dialog { modal: true }` with `AccessibleButton` delegates instead.
 
 ### 3. Overlapping accessible elements
-Never position accessible buttons inside another accessible element's bounds (e.g., buttons inside a TextField's padding area). TalkBack will only discover one element. Use conditional layout to show buttons in separate bounds when accessibility is enabled. See `ShotHistoryPage.qml` for a real example: it checks `AccessibilityManager.accessibilityEnabled` to conditionally reposition elements that would otherwise overlap.
+Never position accessible buttons inside another accessible element's bounds (e.g., buttons inside a TextField's padding area). TalkBack will only discover one element. Use conditional layout to show buttons in separate bounds when accessibility is enabled. See `ShotHistoryPage.qml` for a real example: it checks `AccessibilityManager.enabled` to conditionally reposition elements that would otherwise overlap.
 
 ---
 
@@ -241,7 +241,7 @@ Never position accessible buttons inside another accessible element's bounds (e.
 1. Every interactive element must have `Accessible.role`, `Accessible.name`, `Accessible.focusable: true`, and `Accessible.onPressAction` **on itself** (not on a child). Exception: `AccessibleMouseArea` with `accessibleItem`.
 2. Every interactive element with secondary actions must set `Accessible.description` describing those actions.
 3. Never use `Popup` for selection lists — use `Dialog` with `AccessibleButton` delegates.
-4. Never overlap accessible elements — separate bounds or check `AccessibilityManager.accessibilityEnabled` to conditionally reposition elements (see `ShotHistoryPage.qml` for an example).
+4. Never overlap accessible elements — separate bounds or check `AccessibilityManager.enabled` to conditionally reposition elements (see `ShotHistoryPage.qml` for an example).
 5. Test with TalkBack: double-tap to activate, swipe to navigate.
 6. *(Low priority for this tablet app)* Every focusable control should also set `activeFocusOnTab: true` for desktop/physical-keyboard users.
 
@@ -272,7 +272,12 @@ The three things that have direct, immediate impact on tablet TalkBack users:
 | `EspressoPage.qml` | **Done** |
 
 ### Wave 2 — Post-shot and review pages
-`PostShotReviewPage`, `ShotDetailPage`, `ShotHistoryPage`, `BeanInfoPage`
+| Page | Status |
+|------|--------|
+| `PostShotReviewPage.qml` | **Done** |
+| `ShotDetailPage.qml` | **Done** |
+| `ShotHistoryPage.qml` | **Done** (was already correct) |
+| `BeanInfoPage.qml` | **Done** (was already correct) |
 
 ### Wave 3 — Profile management pages
 `ProfileSelectorPage`, `RecipeEditorPage`, `SimpleProfileEditorPage`, `ProfileEditorPage`, `ProfileInfoPage`

--- a/qml/pages/EspressoPage.qml
+++ b/qml/pages/EspressoPage.qml
@@ -28,9 +28,10 @@ Page {
 
     Component.onCompleted: {
         // Only set title if this page is actually in the StackView (not during preload)
-        if (StackView.status === StackView.Active)
+        if (StackView.status === StackView.Active) {
             root.currentPageTitle = ProfileManager.currentProfileName
-        viewModeMouseArea.forceActiveFocus()
+            viewModeMouseArea.forceActiveFocus()
+        }
     }
     StackView.onActivated: {
         root.currentPageTitle = ProfileManager.currentProfileName

--- a/qml/pages/EspressoPage.qml
+++ b/qml/pages/EspressoPage.qml
@@ -30,6 +30,7 @@ Page {
         // Only set title if this page is actually in the StackView (not during preload)
         if (StackView.status === StackView.Active)
             root.currentPageTitle = ProfileManager.currentProfileName
+        viewModeMouseArea.forceActiveFocus()
     }
     StackView.onActivated: {
         root.currentPageTitle = ProfileManager.currentProfileName
@@ -413,6 +414,7 @@ Page {
             source: "qrc:/icons/Graph.svg"
             sourceSize.width: Theme.scaled(22)
             sourceSize.height: Theme.scaled(22)
+            Accessible.ignored: true
 
             layer.enabled: true
             layer.smooth: true
@@ -423,9 +425,15 @@ Page {
         }
 
         AccessibleMouseArea {
+            id: viewModeMouseArea
             anchors.fill: parent
             accessibleName: TranslationManager.translate("espresso.viewMode.button", "Change extraction view")
             accessibleItem: viewModeButton
+            activeFocusOnTab: true
+            KeyNavigation.tab: espressoBackButton
+            KeyNavigation.backtab: skipFrameButton.visible ? skipFrameButton : espressoBackButton
+            Keys.onReturnPressed: { viewSelectorDialog.open(); event.accepted = true }
+            Keys.onSpacePressed:  { viewSelectorDialog.open(); event.accepted = true }
             onAccessibleClicked: viewSelectorDialog.open()
         }
     }
@@ -619,6 +627,20 @@ Page {
         border.color: Theme.primaryContrastColor
         border.width: Theme.scaled(2)
 
+        activeFocusOnTab: true
+        Keys.onReturnPressed: {
+            root.stopReason = "manual"
+            DE1Device.stopOperation()
+            root.goToIdle()
+            event.accepted = true
+        }
+        Keys.onSpacePressed: {
+            root.stopReason = "manual"
+            DE1Device.stopOperation()
+            root.goToIdle()
+            event.accepted = true
+        }
+
         Text {
             anchors.centerIn: parent
             text: TranslationManager.translate("espresso.button.stop", "STOP")
@@ -673,15 +695,36 @@ Page {
                 Layout.fillHeight: true
                 Layout.preferredWidth: height
 
+                activeFocusOnTab: true
+                KeyNavigation.tab: skipFrameButton.visible ? skipFrameButton : viewModeMouseArea
+                KeyNavigation.backtab: viewModeMouseArea
                 Accessible.role: Accessible.Button
                 Accessible.name: TranslationManager.translate("espresso.accessible.stop", "Stop and go back")
                 Accessible.focusable: true
+                Accessible.onPressAction: {
+                    root.stopReason = "manual"
+                    DE1Device.stopOperation()
+                    root.goToIdle()
+                }
+                Keys.onReturnPressed: {
+                    root.stopReason = "manual"
+                    DE1Device.stopOperation()
+                    root.goToIdle()
+                    event.accepted = true
+                }
+                Keys.onSpacePressed: {
+                    root.stopReason = "manual"
+                    DE1Device.stopOperation()
+                    root.goToIdle()
+                    event.accepted = true
+                }
 
                 Image {
                     anchors.centerIn: parent
                     source: "qrc:/icons/back.svg"
                     sourceSize.width: Theme.scaled(28)
                     sourceSize.height: Theme.scaled(28)
+                    Accessible.ignored: true
 
                     layer.enabled: true
                     layer.smooth: true
@@ -974,10 +1017,15 @@ Page {
                 visible: MachineState.phase === MachineStateType.Phase.Preinfusion ||
                          MachineState.phase === MachineStateType.Phase.Pouring
 
+                activeFocusOnTab: true
+                KeyNavigation.tab: viewModeMouseArea
+                KeyNavigation.backtab: espressoBackButton
                 Accessible.role: Accessible.Button
                 Accessible.name: TranslationManager.translate("espresso.accessible.skipFrame", "Skip to next frame")
                 Accessible.focusable: true
                 Accessible.onPressAction: skipFrameTapHandler.tapped(null)
+                Keys.onReturnPressed: { DE1Device.skipToNextFrame(); event.accepted = true }
+                Keys.onSpacePressed:  { DE1Device.skipToNextFrame(); event.accepted = true }
 
                 Text {
                     anchors.centerIn: parent

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -303,8 +303,24 @@ Page {
                                         MainController.applyFlushSettings()
                                     }
 
-                                    Keys.onReturnPressed: { Accessible.onPressAction(); event.accepted = true }
-                                    Keys.onSpacePressed:  { Accessible.onPressAction(); event.accepted = true }
+                                    Keys.onReturnPressed: {
+                                        Settings.selectedFlushPreset = presetDelegate.presetIndex
+                                        flowInput.value = modelData.flow
+                                        secondsInput.value = modelData.seconds
+                                        Settings.flushFlow = modelData.flow
+                                        Settings.flushSeconds = modelData.seconds
+                                        MainController.applyFlushSettings()
+                                        event.accepted = true
+                                    }
+                                    Keys.onSpacePressed: {
+                                        Settings.selectedFlushPreset = presetDelegate.presetIndex
+                                        flowInput.value = modelData.flow
+                                        secondsInput.value = modelData.seconds
+                                        Settings.flushFlow = modelData.flow
+                                        Settings.flushSeconds = modelData.seconds
+                                        MainController.applyFlushSettings()
+                                        event.accepted = true
+                                    }
                                     Keys.onLeftPressed: {
                                         if (index > 0) presetRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
                                         event.accepted = true

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -16,6 +16,7 @@ Page {
         Settings.flushFlow = getCurrentPresetFlow()
         Settings.flushSeconds = getCurrentPresetSeconds()
         MainController.applyFlushSettings()
+        if (!isFlushing) secondsInput.forceActiveFocus()
     }
     StackView.onActivated: root.currentPageTitle = pageTitle
 
@@ -73,6 +74,7 @@ Page {
                 spacing: Theme.scaled(8)
 
                 Repeater {
+                    id: livePresetRepeater
                     model: Settings.flushPresets
 
                     Rectangle {
@@ -83,11 +85,41 @@ Page {
                         border.color: index === Settings.selectedFlushPreset ? Theme.primaryColor : Theme.textSecondaryColor
                         border.width: 1
 
+                        activeFocusOnTab: true
                         Accessible.role: Accessible.Button
                         Accessible.name: modelData.name + " " + TranslationManager.translate("flush.accessibility.preset", "preset") +
                                          (index === Settings.selectedFlushPreset ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                         Accessible.focusable: true
                         Accessible.onPressAction: livePresetArea.clicked(null)
+
+                        Keys.onReturnPressed: { livePresetArea.clicked(null); event.accepted = true }
+                        Keys.onSpacePressed:  { livePresetArea.clicked(null); event.accepted = true }
+                        Keys.onLeftPressed: {
+                            if (index > 0) livePresetRepeater.itemAt(index - 1).forceActiveFocus()
+                            event.accepted = true
+                        }
+                        Keys.onRightPressed: {
+                            if (index < livePresetRepeater.count - 1) livePresetRepeater.itemAt(index + 1).forceActiveFocus()
+                            event.accepted = true
+                        }
+                        Keys.onTabPressed: {
+                            if (index < livePresetRepeater.count - 1)
+                                livePresetRepeater.itemAt(index + 1).forceActiveFocus()
+                            else if (flushStopButton.visible)
+                                flushStopButton.forceActiveFocus()
+                            else
+                                livePresetRepeater.itemAt(0).forceActiveFocus()
+                            event.accepted = true
+                        }
+                        Keys.onBacktabPressed: {
+                            if (index > 0)
+                                livePresetRepeater.itemAt(index - 1).forceActiveFocus()
+                            else if (flushStopButton.visible)
+                                flushStopButton.forceActiveFocus()
+                            else
+                                livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
+                            event.accepted = true
+                        }
 
                         Text {
                             id: livePresetText
@@ -163,12 +195,25 @@ Page {
                 border.color: Theme.primaryContrastColor
                 border.width: Theme.scaled(2)
 
+                activeFocusOnTab: true
+                Keys.onReturnPressed: { DE1Device.stopOperation(); root.goToIdle(); event.accepted = true }
+                Keys.onSpacePressed:  { DE1Device.stopOperation(); root.goToIdle(); event.accepted = true }
+                Keys.onTabPressed: {
+                    if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(0).forceActiveFocus()
+                    event.accepted = true
+                }
+                Keys.onBacktabPressed: {
+                    if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
+                    event.accepted = true
+                }
+
                 Text {
                     anchors.centerIn: parent
                     text: TranslationManager.translate("flush.button.stop", "STOP")
                     color: Theme.primaryContrastColor
                     font.pixelSize: Theme.scaled(24)
                     font.weight: Font.Bold
+                    Accessible.ignored: true
                 }
 
                 // Using TapHandler for better touch responsiveness
@@ -230,6 +275,7 @@ Page {
                                 height: Theme.scaled(36)
 
                                 property int presetIndex: index
+                                property Item focusTarget: presetPill
 
                                 Rectangle {
                                     id: presetPill
@@ -241,10 +287,12 @@ Page {
                                     border.width: 1
                                     opacity: dragArea.drag.active ? 0.8 : 1.0
 
+                                    activeFocusOnTab: true
                                     Accessible.role: Accessible.Button
                                     Accessible.name: modelData.name + " " + TranslationManager.translate("flush.accessibility.preset", "preset") +
                                                      (presetDelegate.presetIndex === Settings.selectedFlushPreset ?
                                                       ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
+                                    Accessible.description: TranslationManager.translate("flush.accessibility.presetHint", "Double-tap or long-press to rename.")
                                     Accessible.focusable: true
                                     Accessible.onPressAction: {
                                         Settings.selectedFlushPreset = presetDelegate.presetIndex
@@ -253,6 +301,31 @@ Page {
                                         Settings.flushFlow = modelData.flow
                                         Settings.flushSeconds = modelData.seconds
                                         MainController.applyFlushSettings()
+                                    }
+
+                                    Keys.onReturnPressed: { Accessible.onPressAction(); event.accepted = true }
+                                    Keys.onSpacePressed:  { Accessible.onPressAction(); event.accepted = true }
+                                    Keys.onLeftPressed: {
+                                        if (index > 0) presetRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
+                                        event.accepted = true
+                                    }
+                                    Keys.onRightPressed: {
+                                        if (index < presetRepeater.count - 1) presetRepeater.itemAt(index + 1).focusTarget.forceActiveFocus()
+                                        event.accepted = true
+                                    }
+                                    Keys.onTabPressed: {
+                                        if (index < presetRepeater.count - 1)
+                                            presetRepeater.itemAt(index + 1).focusTarget.forceActiveFocus()
+                                        else
+                                            addPresetButton.forceActiveFocus()
+                                        event.accepted = true
+                                    }
+                                    Keys.onBacktabPressed: {
+                                        if (index > 0)
+                                            presetRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
+                                        else
+                                            flowInput.forceActiveFocus()
+                                        event.accepted = true
                                     }
 
                                     Drag.active: dragArea.drag.active
@@ -272,6 +345,7 @@ Page {
                                         text: modelData.name
                                         color: presetDelegate.presetIndex === Settings.selectedFlushPreset ? Theme.primaryContrastColor : Theme.textColor
                                         font: Theme.bodyFont
+                                        Accessible.ignored: true
                                     }
 
                                     MouseArea {
@@ -357,11 +431,20 @@ Page {
                             border.color: Theme.textSecondaryColor
                             border.width: 1
 
+                            activeFocusOnTab: true
+                            KeyNavigation.tab: secondsInput
+                            KeyNavigation.backtab: presetRepeater.count > 0
+                                ? presetRepeater.itemAt(presetRepeater.count - 1).focusTarget
+                                : secondsInput
+                            Keys.onReturnPressed: { addPresetDialog.open(); event.accepted = true }
+                            Keys.onSpacePressed:  { addPresetDialog.open(); event.accepted = true }
+
                             Text {
                                 anchors.centerIn: parent
                                 text: "+"
                                 color: Theme.textColor
                                 font.pixelSize: Theme.scaled(20)
+                                Accessible.ignored: true
                             }
 
                             // Using TapHandler for better touch responsiveness
@@ -421,6 +504,8 @@ Page {
                             suffix: " s"
                             valueColor: Theme.primaryColor
                             accessibleName: TranslationManager.translate("flush.label.duration", "Duration")
+                            KeyNavigation.tab: flowInput
+                            KeyNavigation.backtab: addPresetButton
 
                             onValueModified: function(newValue) {
                                 secondsInput.value = newValue
@@ -457,6 +542,10 @@ Page {
                             suffix: " mL/s"
                             valueColor: Theme.flowColor
                             accessibleName: TranslationManager.translate("flush.label.flowRate", "Flow Rate")
+                            KeyNavigation.tab: presetRepeater.count > 0
+                                ? presetRepeater.itemAt(0).focusTarget
+                                : addPresetButton
+                            KeyNavigation.backtab: secondsInput
 
                             onValueModified: function(newValue) {
                                 flowInput.value = newValue
@@ -560,10 +649,13 @@ Page {
                     font: Theme.bodyFont
                     verticalAlignment: TextInput.AlignVCenter
                     inputMethodHints: Qt.ImhNoPredictiveText
+                    activeFocusOnTab: true
                     Accessible.role: Accessible.EditableText
                     Accessible.name: TranslationManager.translate("flush.accessible.renamePreset", "Rename flush preset")
                     Accessible.description: text
                     Accessible.focusable: true
+                    KeyNavigation.tab: deleteButton
+                    KeyNavigation.backtab: saveButton
 
                     Tr {
                         anchors.fill: parent
@@ -582,9 +674,12 @@ Page {
                 spacing: Theme.scaled(10)
 
                 AccessibleButton {
+                    id: deleteButton
                     text: TranslationManager.translate("flush.button.delete", "Delete")
                     accessibleName: TranslationManager.translate("flush.deletePreset", "Delete this flush preset")
                     destructive: true
+                    KeyNavigation.tab: cancelEditButton
+                    KeyNavigation.backtab: editPresetNameInput
                     onClicked: {
                         Settings.removeFlushPreset(editingPresetIndex)
                         editPresetPopup.close()
@@ -594,15 +689,21 @@ Page {
                 Item { Layout.fillWidth: true }
 
                 AccessibleButton {
+                    id: cancelEditButton
                     text: TranslationManager.translate("flush.button.cancel", "Cancel")
                     accessibleName: TranslationManager.translate("flush.cancelEditingPreset", "Cancel editing flush preset")
+                    KeyNavigation.tab: saveButton
+                    KeyNavigation.backtab: deleteButton
                     onClicked: editPresetPopup.close()
                 }
 
                 AccessibleButton {
+                    id: saveButton
                     primary: true
                     text: TranslationManager.translate("flush.button.save", "Save")
                     accessibleName: TranslationManager.translate("flush.savePresetChanges", "Save changes to flush preset")
+                    KeyNavigation.tab: editPresetNameInput
+                    KeyNavigation.backtab: cancelEditButton
                     onClicked: {
                         Qt.inputMethod.commit()
                         var preset = Settings.getFlushPreset(editingPresetIndex)
@@ -674,10 +775,13 @@ Page {
                     font: Theme.bodyFont
                     verticalAlignment: TextInput.AlignVCenter
                     inputMethodHints: Qt.ImhNoPredictiveText
+                    activeFocusOnTab: true
                     Accessible.role: Accessible.EditableText
                     Accessible.name: TranslationManager.translate("flush.accessible.newPresetName", "New flush preset name")
                     Accessible.description: text
                     Accessible.focusable: true
+                    KeyNavigation.tab: cancelAddButton
+                    KeyNavigation.backtab: addButton
 
                     Tr {
                         anchors.fill: parent
@@ -698,15 +802,21 @@ Page {
                 Item { Layout.fillWidth: true }
 
                 AccessibleButton {
+                    id: cancelAddButton
                     text: TranslationManager.translate("flush.button.cancel", "Cancel")
                     accessibleName: TranslationManager.translate("flush.cancelAddingPreset", "Cancel adding new flush preset")
+                    KeyNavigation.tab: addButton
+                    KeyNavigation.backtab: newPresetNameInput
                     onClicked: addPresetDialog.close()
                 }
 
                 AccessibleButton {
+                    id: addButton
                     primary: true
                     text: TranslationManager.translate("flush.button.add", "Add")
                     accessibleName: TranslationManager.translate("flush.addNewPreset", "Add new flush preset with entered name")
+                    KeyNavigation.tab: newPresetNameInput
+                    KeyNavigation.backtab: cancelAddButton
                     onClicked: {
                         Qt.inputMethod.commit()
                         if (newPresetNameInput.text.length > 0) {

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -356,8 +356,26 @@ Page {
                                         MainController.applyHotWaterSettings()
                                     }
 
-                                    Keys.onReturnPressed: { Accessible.onPressAction(); event.accepted = true }
-                                    Keys.onSpacePressed:  { Accessible.onPressAction(); event.accepted = true }
+                                    Keys.onReturnPressed: {
+                                        Settings.selectedWaterVessel = vesselDelegate.vesselIndex
+                                        volumeInput.value = modelData.volume
+                                        flowRateInput.value = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
+                                        Settings.waterVolume = modelData.volume
+                                        Settings.waterVolumeMode = (modelData.mode || "weight")
+                                        Settings.hotWaterFlowRate = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
+                                        MainController.applyHotWaterSettings()
+                                        event.accepted = true
+                                    }
+                                    Keys.onSpacePressed: {
+                                        Settings.selectedWaterVessel = vesselDelegate.vesselIndex
+                                        volumeInput.value = modelData.volume
+                                        flowRateInput.value = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
+                                        Settings.waterVolume = modelData.volume
+                                        Settings.waterVolumeMode = (modelData.mode || "weight")
+                                        Settings.hotWaterFlowRate = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
+                                        MainController.applyHotWaterSettings()
+                                        event.accepted = true
+                                    }
                                     Keys.onLeftPressed: {
                                         if (index > 0) vesselRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
                                         event.accepted = true

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -22,6 +22,7 @@ Page {
         if (!isVolumeMode && !isDispensing) {
             MachineState.tareScale()
         }
+        if (!isDispensing) volumeInput.forceActiveFocus()
     }
     StackView.onActivated: root.currentPageTitle = pageTitleText.text
 
@@ -82,6 +83,7 @@ Page {
                 spacing: Theme.scaled(8)
 
                 Repeater {
+                    id: liveVesselRepeater
                     model: Settings.waterVesselPresets
 
                     Rectangle {
@@ -92,11 +94,41 @@ Page {
                         border.color: index === Settings.selectedWaterVessel ? Theme.primaryColor : Theme.textSecondaryColor
                         border.width: 1
 
+                        activeFocusOnTab: true
                         Accessible.role: Accessible.Button
                         Accessible.name: modelData.name + " " + TranslationManager.translate("hotwater.accessibility.vessel", "vessel") +
                                          (index === Settings.selectedWaterVessel ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                         Accessible.focusable: true
                         Accessible.onPressAction: liveVesselArea.clicked(null)
+
+                        Keys.onReturnPressed: { liveVesselArea.clicked(null); event.accepted = true }
+                        Keys.onSpacePressed:  { liveVesselArea.clicked(null); event.accepted = true }
+                        Keys.onLeftPressed: {
+                            if (index > 0) liveVesselRepeater.itemAt(index - 1).forceActiveFocus()
+                            event.accepted = true
+                        }
+                        Keys.onRightPressed: {
+                            if (index < liveVesselRepeater.count - 1) liveVesselRepeater.itemAt(index + 1).forceActiveFocus()
+                            event.accepted = true
+                        }
+                        Keys.onTabPressed: {
+                            if (index < liveVesselRepeater.count - 1)
+                                liveVesselRepeater.itemAt(index + 1).forceActiveFocus()
+                            else if (hotWaterStopButton.visible)
+                                hotWaterStopButton.forceActiveFocus()
+                            else
+                                liveVesselRepeater.itemAt(0).forceActiveFocus()
+                            event.accepted = true
+                        }
+                        Keys.onBacktabPressed: {
+                            if (index > 0)
+                                liveVesselRepeater.itemAt(index - 1).forceActiveFocus()
+                            else if (hotWaterStopButton.visible)
+                                hotWaterStopButton.forceActiveFocus()
+                            else
+                                liveVesselRepeater.itemAt(liveVesselRepeater.count - 1).forceActiveFocus()
+                            event.accepted = true
+                        }
 
                         Text {
                             id: liveVesselText
@@ -193,6 +225,8 @@ Page {
                 displayText: (value / 10).toFixed(1) + " mL/s"
                 valueColor: Theme.flowColor
                 accessibleName: TranslationManager.translate("hotwater.label.flowRate", "Flow Rate")
+                KeyNavigation.tab: hotWaterStopButton.visible ? hotWaterStopButton : (liveVesselRepeater.count > 0 ? liveVesselRepeater.itemAt(0) : liveFlowRateInput)
+                KeyNavigation.backtab: liveVesselRepeater.count > 0 ? liveVesselRepeater.itemAt(liveVesselRepeater.count - 1) : liveFlowRateInput
 
                 onValueModified: function(newValue) {
                     MainController.setHotWaterFlowRateImmediate(Math.round(newValue))
@@ -213,12 +247,25 @@ Page {
                 border.color: Theme.primaryContrastColor
                 border.width: Theme.scaled(2)
 
+                activeFocusOnTab: true
+                Keys.onReturnPressed: { DE1Device.stopOperation(); root.goToIdle(); event.accepted = true }
+                Keys.onSpacePressed:  { DE1Device.stopOperation(); root.goToIdle(); event.accepted = true }
+                Keys.onTabPressed: {
+                    if (liveVesselRepeater.count > 0) liveVesselRepeater.itemAt(0).forceActiveFocus()
+                    event.accepted = true
+                }
+                Keys.onBacktabPressed: {
+                    if (liveVesselRepeater.count > 0) liveVesselRepeater.itemAt(liveVesselRepeater.count - 1).forceActiveFocus()
+                    event.accepted = true
+                }
+
                 Text {
                     anchors.centerIn: parent
                     text: TranslationManager.translate("hotwater.button.stop", "STOP")
                     color: Theme.primaryContrastColor
                     font.pixelSize: Theme.scaled(24)
                     font.weight: Font.Bold
+                    Accessible.ignored: true
                 }
 
                 // Using TapHandler for better touch responsiveness
@@ -280,6 +327,7 @@ Page {
                                 height: Theme.scaled(36)
 
                                 property int vesselIndex: index
+                                property Item focusTarget: vesselPill
 
                                 Rectangle {
                                     id: vesselPill
@@ -291,11 +339,47 @@ Page {
                                     border.width: 1
                                     opacity: dragArea.drag.active ? 0.8 : 1.0
 
+                                    activeFocusOnTab: true
                                     Accessible.role: Accessible.Button
                                     Accessible.name: modelData.name + " " + TranslationManager.translate("hotwater.accessibility.preset", "preset") +
                                                      (vesselDelegate.vesselIndex === Settings.selectedWaterVessel ?
                                                       ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
+                                    Accessible.description: TranslationManager.translate("hotwater.accessibility.presetHint", "Double-tap or long-press to rename.")
                                     Accessible.focusable: true
+                                    Accessible.onPressAction: {
+                                        Settings.selectedWaterVessel = vesselDelegate.vesselIndex
+                                        volumeInput.value = modelData.volume
+                                        flowRateInput.value = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
+                                        Settings.waterVolume = modelData.volume
+                                        Settings.waterVolumeMode = (modelData.mode || "weight")
+                                        Settings.hotWaterFlowRate = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
+                                        MainController.applyHotWaterSettings()
+                                    }
+
+                                    Keys.onReturnPressed: { Accessible.onPressAction(); event.accepted = true }
+                                    Keys.onSpacePressed:  { Accessible.onPressAction(); event.accepted = true }
+                                    Keys.onLeftPressed: {
+                                        if (index > 0) vesselRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
+                                        event.accepted = true
+                                    }
+                                    Keys.onRightPressed: {
+                                        if (index < vesselRepeater.count - 1) vesselRepeater.itemAt(index + 1).focusTarget.forceActiveFocus()
+                                        event.accepted = true
+                                    }
+                                    Keys.onTabPressed: {
+                                        if (index < vesselRepeater.count - 1)
+                                            vesselRepeater.itemAt(index + 1).focusTarget.forceActiveFocus()
+                                        else
+                                            addVesselButton.forceActiveFocus()
+                                        event.accepted = true
+                                    }
+                                    Keys.onBacktabPressed: {
+                                        if (index > 0)
+                                            vesselRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
+                                        else
+                                            flowRateInput.forceActiveFocus()
+                                        event.accepted = true
+                                    }
 
                                     Drag.active: dragArea.drag.active
                                     Drag.source: vesselDelegate
@@ -314,6 +398,7 @@ Page {
                                         text: modelData.name
                                         color: vesselDelegate.vesselIndex === Settings.selectedWaterVessel ? Theme.primaryContrastColor : Theme.textColor
                                         font: Theme.bodyFont
+                                        Accessible.ignored: true
                                     }
 
                                     MouseArea {
@@ -400,11 +485,20 @@ Page {
                             border.color: Theme.textSecondaryColor
                             border.width: 1
 
+                            activeFocusOnTab: true
+                            KeyNavigation.tab: volumeInput
+                            KeyNavigation.backtab: vesselRepeater.count > 0
+                                ? vesselRepeater.itemAt(vesselRepeater.count - 1).focusTarget
+                                : volumeInput
+                            Keys.onReturnPressed: { addVesselDialog.open(); event.accepted = true }
+                            Keys.onSpacePressed:  { addVesselDialog.open(); event.accepted = true }
+
                             Text {
                                 anchors.centerIn: parent
                                 text: "+"
                                 color: Theme.textColor
                                 font.pixelSize: Theme.scaled(20)
+                                Accessible.ignored: true
                             }
 
                             // Using TapHandler for better touch responsiveness
@@ -450,6 +544,7 @@ Page {
                             spacing: Theme.scaled(4)
 
                             Rectangle {
+                                id: weightModeButton
                                 width: weightModeText.implicitWidth + Theme.scaled(20)
                                 height: Theme.scaled(36)
                                 radius: Theme.scaled(18)
@@ -457,11 +552,16 @@ Page {
                                 border.color: !isVolumeMode ? Theme.primaryColor : Theme.textSecondaryColor
                                 border.width: 1
 
+                                activeFocusOnTab: true
                                 Accessible.role: Accessible.Button
                                 Accessible.name: TranslationManager.translate("hotwater.mode.weight", "Weight (g)") +
                                                  (!isVolumeMode ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                                 Accessible.focusable: true
                                 Accessible.onPressAction: weightModeArea.clicked(null)
+                                Keys.onReturnPressed: { weightModeArea.clicked(null); event.accepted = true }
+                                Keys.onSpacePressed:  { weightModeArea.clicked(null); event.accepted = true }
+                                KeyNavigation.tab: volumeModeButton
+                                KeyNavigation.backtab: temperatureInput
 
                                 Text {
                                     id: weightModeText
@@ -484,6 +584,7 @@ Page {
                             }
 
                             Rectangle {
+                                id: volumeModeButton
                                 width: volumeModeText.implicitWidth + Theme.scaled(20)
                                 height: Theme.scaled(36)
                                 radius: Theme.scaled(18)
@@ -491,11 +592,16 @@ Page {
                                 border.color: isVolumeMode ? Theme.primaryColor : Theme.textSecondaryColor
                                 border.width: 1
 
+                                activeFocusOnTab: true
                                 Accessible.role: Accessible.Button
                                 Accessible.name: TranslationManager.translate("hotwater.mode.volume", "Volume (ml)") +
                                                  (isVolumeMode ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                                 Accessible.focusable: true
                                 Accessible.onPressAction: volumeModeArea.clicked(null)
+                                Keys.onReturnPressed: { volumeModeArea.clicked(null); event.accepted = true }
+                                Keys.onSpacePressed:  { volumeModeArea.clicked(null); event.accepted = true }
+                                KeyNavigation.tab: volumeInput
+                                KeyNavigation.backtab: weightModeButton
 
                                 Text {
                                     id: volumeModeText
@@ -540,6 +646,8 @@ Page {
                             accessibleName: isVolumeMode
                                 ? TranslationManager.translate("hotwater.label.volume", "Volume")
                                 : TranslationManager.translate("hotwater.label.weight", "Weight")
+                            KeyNavigation.tab: temperatureInput
+                            KeyNavigation.backtab: volumeModeButton
 
                             onValueModified: function(newValue) {
                                 volumeInput.value = newValue
@@ -576,6 +684,8 @@ Page {
                             suffix: "°C"
                             valueColor: Theme.temperatureColor
                             accessibleName: TranslationManager.translate("hotwater.label.temperature", "Temperature")
+                            KeyNavigation.tab: flowRateInput
+                            KeyNavigation.backtab: volumeInput
 
                             onValueModified: function(newValue) {
                                 temperatureInput.value = newValue
@@ -611,6 +721,10 @@ Page {
                             displayText: (value / 10).toFixed(1) + " mL/s"
                             valueColor: Theme.flowColor
                             accessibleName: TranslationManager.translate("hotwater.label.flowRate", "Flow Rate")
+                            KeyNavigation.tab: vesselRepeater.count > 0
+                                ? vesselRepeater.itemAt(0).focusTarget
+                                : addVesselButton
+                            KeyNavigation.backtab: temperatureInput
 
                             onValueModified: function(newValue) {
                                 flowRateInput.value = Math.round(newValue)
@@ -718,10 +832,13 @@ Page {
                     font: Theme.bodyFont
                     verticalAlignment: TextInput.AlignVCenter
                     inputMethodHints: Qt.ImhNoPredictiveText
+                    activeFocusOnTab: true
                     Accessible.role: Accessible.EditableText
                     Accessible.name: TranslationManager.translate("hotwater.accessible.renameVessel", "Rename water vessel")
                     Accessible.description: text
                     Accessible.focusable: true
+                    KeyNavigation.tab: deleteVesselButton
+                    KeyNavigation.backtab: saveVesselButton
 
                     Tr {
                         anchors.fill: parent
@@ -740,9 +857,12 @@ Page {
                 spacing: Theme.scaled(10)
 
                 AccessibleButton {
+                    id: deleteVesselButton
                     text: TranslationManager.translate("hotwater.button.delete", "Delete")
                     accessibleName: TranslationManager.translate("hotWater.deleteVesselPreset", "Delete this water vessel preset")
                     destructive: true
+                    KeyNavigation.tab: cancelEditVesselButton
+                    KeyNavigation.backtab: editVesselNameInput
                     onClicked: {
                         Settings.removeWaterVesselPreset(editingVesselIndex)
                         editVesselPopup.close()
@@ -752,15 +872,21 @@ Page {
                 Item { Layout.fillWidth: true }
 
                 AccessibleButton {
+                    id: cancelEditVesselButton
                     text: TranslationManager.translate("hotwater.button.cancel", "Cancel")
                     accessibleName: TranslationManager.translate("hotWater.cancelEditingVessel", "Cancel editing water vessel")
+                    KeyNavigation.tab: saveVesselButton
+                    KeyNavigation.backtab: deleteVesselButton
                     onClicked: editVesselPopup.close()
                 }
 
                 AccessibleButton {
+                    id: saveVesselButton
                     primary: true
                     text: TranslationManager.translate("hotwater.button.save", "Save")
                     accessibleName: TranslationManager.translate("hotWater.saveVesselChanges", "Save changes to water vessel preset")
+                    KeyNavigation.tab: editVesselNameInput
+                    KeyNavigation.backtab: cancelEditVesselButton
                     onClicked: {
                         Qt.inputMethod.commit()
                         var preset = Settings.getWaterVesselPreset(editingVesselIndex)
@@ -832,10 +958,13 @@ Page {
                     font: Theme.bodyFont
                     verticalAlignment: TextInput.AlignVCenter
                     inputMethodHints: Qt.ImhNoPredictiveText
+                    activeFocusOnTab: true
                     Accessible.role: Accessible.EditableText
                     Accessible.name: TranslationManager.translate("hotwater.accessible.newVesselName", "New water vessel name")
                     Accessible.description: text
                     Accessible.focusable: true
+                    KeyNavigation.tab: cancelAddVesselButton
+                    KeyNavigation.backtab: addVesselConfirmButton
 
                     Tr {
                         anchors.fill: parent
@@ -856,15 +985,21 @@ Page {
                 Item { Layout.fillWidth: true }
 
                 AccessibleButton {
+                    id: cancelAddVesselButton
                     text: TranslationManager.translate("hotwater.button.cancel", "Cancel")
                     accessibleName: TranslationManager.translate("hotWater.cancelAddingVessel", "Cancel adding new water vessel")
+                    KeyNavigation.tab: addVesselConfirmButton
+                    KeyNavigation.backtab: newVesselNameInput
                     onClicked: addVesselDialog.close()
                 }
 
                 AccessibleButton {
+                    id: addVesselConfirmButton
                     primary: true
                     text: TranslationManager.translate("hotwater.button.add", "Add")
                     accessibleName: TranslationManager.translate("hotWater.addNewVessel", "Add new water vessel with entered name")
+                    KeyNavigation.tab: newVesselNameInput
+                    KeyNavigation.backtab: cancelAddVesselButton
                     onClicked: {
                         Qt.inputMethod.commit()
                         if (newVesselNameInput.text.length > 0) {

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -373,15 +373,19 @@ Page {
                         spacing: Theme.scaled(8)
 
                         Rectangle {
+                            id: nonFavoriteProfilePill
                             width: nonFavoriteProfileText.implicitWidth + Theme.scaled(40)
                             height: Theme.scaled(50)
                             radius: Theme.scaled(10)
                             color: Theme.successColor
 
+                            activeFocusOnTab: true
                             Accessible.role: Accessible.Button
                             Accessible.name: (ProfileManager.currentProfileName || "") + " " + TranslationManager.translate("idle.accessible.startespresso", "Start espresso")
                             Accessible.focusable: true
                             Accessible.onPressAction: idleNonFavMouseArea.clicked(null)
+                            Keys.onReturnPressed: { idleNonFavMouseArea.clicked(null); event.accepted = true }
+                            Keys.onSpacePressed:  { idleNonFavMouseArea.clicked(null); event.accepted = true }
 
                             Text {
                                 id: nonFavoriteProfileText

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -1124,6 +1124,7 @@ Page {
                             font.pixelSize: Theme.scaled(14)
                             verticalAlignment: Text.AlignVCenter
                             elide: Text.ElideRight
+                            Accessible.ignored: true
                         }
 
                         Accessible.role: Accessible.StaticText
@@ -1167,6 +1168,7 @@ Page {
                             font.pixelSize: Theme.scaled(14)
                             verticalAlignment: Text.AlignVCenter
                             elide: Text.ElideRight
+                            Accessible.ignored: true
                         }
 
                         Accessible.role: Accessible.StaticText

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -861,14 +861,14 @@ Page {
 
                         ColumnLayout {
                             spacing: Theme.scaled(2)
-                            Tr { key: "shotdetail.tds"; fallback: "TDS"; font: Theme.captionFont; color: Theme.textSecondaryColor; Accessible.ignored: true }
-                            Text { text: (shotData.drinkTds || 0).toFixed(2) + "%"; font: Theme.bodyFont; color: Theme.dyeTdsColor; Accessible.ignored: true }
+                            Tr { key: "shotdetail.tds"; fallback: "TDS"; font: Theme.captionFont; color: Theme.textSecondaryColor }
+                            Text { text: (shotData.drinkTds || 0).toFixed(2) + "%"; font: Theme.bodyFont; color: Theme.dyeTdsColor }
                         }
 
                         ColumnLayout {
                             spacing: Theme.scaled(2)
-                            Tr { key: "shotdetail.ey"; fallback: "EY"; font: Theme.captionFont; color: Theme.textSecondaryColor; Accessible.ignored: true }
-                            Text { text: (shotData.drinkEy || 0).toFixed(1) + "%"; font: Theme.bodyFont; color: Theme.dyeEyColor; Accessible.ignored: true }
+                            Tr { key: "shotdetail.ey"; fallback: "EY"; font: Theme.captionFont; color: Theme.textSecondaryColor }
+                            Text { text: (shotData.drinkEy || 0).toFixed(1) + "%"; font: Theme.bodyFont; color: Theme.dyeEyColor }
                         }
                     }
                 }

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -395,6 +395,7 @@ Page {
 
                 Accessible.role: Accessible.Graphic
                 Accessible.name: graphAccessibleDescription()
+                Accessible.description: TranslationManager.translate("shotdetail.accessible.graph.swipe", "Swipe left for older shot, swipe right for newer shot.")
                 Accessible.focusable: true
                 focus: true
 
@@ -537,8 +538,7 @@ Page {
                     font: Theme.labelFont
                     color: Theme.textSecondaryColor
                     horizontalAlignment: Text.AlignHCenter
-                    Accessible.name: TranslationManager.translate("shotdetail.accessible.position",
-                        "Shot %1 of %2").arg(currentIndex + 1).arg(shotIds.length)
+                    Accessible.ignored: true
                 }
 
                 AccessibleButton {
@@ -756,6 +756,7 @@ Page {
                             color: Theme.textColor
                             Layout.fillWidth: true
                             elide: Text.ElideRight
+                            Accessible.ignored: true
                         }
 
                         GridLayout {
@@ -804,6 +805,7 @@ Page {
                             fallback: "Grinder"
                             font: Theme.subtitleFont
                             color: Theme.textColor
+                            Accessible.ignored: true
                         }
 
                         GridLayout {
@@ -851,6 +853,7 @@ Page {
                         fallback: "Analysis"
                         font: Theme.subtitleFont
                         color: Theme.textColor
+                        Accessible.ignored: true
                     }
 
                     RowLayout {
@@ -858,14 +861,14 @@ Page {
 
                         ColumnLayout {
                             spacing: Theme.scaled(2)
-                            Tr { key: "shotdetail.tds"; fallback: "TDS"; font: Theme.captionFont; color: Theme.textSecondaryColor }
-                            Text { text: (shotData.drinkTds || 0).toFixed(2) + "%"; font: Theme.bodyFont; color: Theme.dyeTdsColor }
+                            Tr { key: "shotdetail.tds"; fallback: "TDS"; font: Theme.captionFont; color: Theme.textSecondaryColor; Accessible.ignored: true }
+                            Text { text: (shotData.drinkTds || 0).toFixed(2) + "%"; font: Theme.bodyFont; color: Theme.dyeTdsColor; Accessible.ignored: true }
                         }
 
                         ColumnLayout {
                             spacing: Theme.scaled(2)
-                            Tr { key: "shotdetail.ey"; fallback: "EY"; font: Theme.captionFont; color: Theme.textSecondaryColor }
-                            Text { text: (shotData.drinkEy || 0).toFixed(1) + "%"; font: Theme.bodyFont; color: Theme.dyeEyColor }
+                            Tr { key: "shotdetail.ey"; fallback: "EY"; font: Theme.captionFont; color: Theme.textSecondaryColor; Accessible.ignored: true }
+                            Text { text: (shotData.drinkEy || 0).toFixed(1) + "%"; font: Theme.bodyFont; color: Theme.dyeEyColor; Accessible.ignored: true }
                         }
                     }
                 }
@@ -953,6 +956,7 @@ Page {
                             sourceSize.width: Theme.labelFont.pixelSize
                             sourceSize.height: Theme.labelFont.pixelSize
                             anchors.verticalCenter: parent.verticalCenter
+                            Accessible.ignored: true
                         }
                         Tr {
                             key: "shotdetail.uploadedtovisualizer"

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -324,6 +324,8 @@ Page {
 
                     activeFocusOnTab: true
                     Accessible.ignored: true
+                    Keys.onReturnPressed: { viewToggleMa.accessibleClicked(); event.accepted = true }
+                    Keys.onSpacePressed:  { viewToggleMa.accessibleClicked(); event.accepted = true }
                     Keys.onTabPressed: {
                         if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(0).forceActiveFocus()
                         else if (steamStopButton.visible) steamStopButton.forceActiveFocus()
@@ -678,7 +680,7 @@ Page {
                 AccessibleTapHandler {
                     id: stopTapHandler
                     anchors.fill: parent
-                    accessibleName: steamSoftStopped ? "Purge steam wand" : "Stop steaming"
+                    accessibleName: steamSoftStopped ? TranslationManager.translate("steam.accessible.purge", "Purge steam wand") : TranslationManager.translate("steam.accessible.stop", "Stop steaming")
                     accessibleItem: steamStopButton
                     onAccessibleClicked: {
                         if (Settings.headlessSkipPurgeConfirm) {
@@ -847,8 +849,26 @@ Page {
                                         MainController.startSteamHeating()
                                     }
 
-                                    Keys.onReturnPressed: { Accessible.onPressAction(); event.accepted = true }
-                                    Keys.onSpacePressed:  { Accessible.onPressAction(); event.accepted = true }
+                                    Keys.onReturnPressed: {
+                                        Settings.selectedSteamPitcher = pitcherDelegate.pitcherIndex
+                                        var flow = modelData.flow !== undefined ? modelData.flow : 150
+                                        durationSlider.value = modelData.duration
+                                        flowSlider.value = flow
+                                        Settings.steamTimeout = modelData.duration
+                                        Settings.steamFlow = flow
+                                        MainController.startSteamHeating()
+                                        event.accepted = true
+                                    }
+                                    Keys.onSpacePressed: {
+                                        Settings.selectedSteamPitcher = pitcherDelegate.pitcherIndex
+                                        var flow = modelData.flow !== undefined ? modelData.flow : 150
+                                        durationSlider.value = modelData.duration
+                                        flowSlider.value = flow
+                                        Settings.steamTimeout = modelData.duration
+                                        Settings.steamFlow = flow
+                                        MainController.startSteamHeating()
+                                        event.accepted = true
+                                    }
                                     Keys.onLeftPressed: {
                                         if (index > 0) pitcherRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
                                         event.accepted = true

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -20,6 +20,7 @@ Page {
         // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
         // startSteamHeating clears steamDisabled flag automatically
         MainController.startSteamHeating()
+        if (!isSteaming) durationSlider.forceActiveFocus()
     }
     StackView.onActivated: root.currentPageTitle = pageTitle
 
@@ -169,9 +170,11 @@ Page {
         property string warningMessage: ""
         title: TranslationManager.translate("steam.warning.title", "Steam Warning")
         modal: true
+        focus: true
         anchors.centerIn: parent
         width: Math.min(parent.width * 0.85, Theme.scaled(360))
         padding: Theme.spacingMedium
+        onOpened: warningOkButton.forceActiveFocus()
 
         background: Rectangle {
             color: Theme.surfaceColor
@@ -193,6 +196,7 @@ Page {
             }
 
             AccessibleButton {
+                id: warningOkButton
                 text: TranslationManager.translate("common.button.ok", "OK")
                 accessibleName: TranslationManager.translate("common.button.ok", "OK")
                 Layout.alignment: Qt.AlignRight
@@ -229,6 +233,7 @@ Page {
                     spacing: Theme.scaled(8)
 
                     Repeater {
+                        id: livePresetRepeater
                         model: Settings.steamPitcherPresets
 
                         Rectangle {
@@ -239,6 +244,7 @@ Page {
                             border.color: index === Settings.selectedSteamPitcher ? Theme.primaryColor : Theme.textSecondaryColor
                             border.width: 1
 
+                            activeFocusOnTab: true
                             Accessible.role: Accessible.Button
                             Accessible.name: {
                                 var label = modelData.name + " " + TranslationManager.translate("steam.accessibility.preset", "preset")
@@ -251,6 +257,35 @@ Page {
                             }
                             Accessible.focusable: true
                             Accessible.onPressAction: livePitcherMa.clicked(null)
+
+                            Keys.onReturnPressed: { livePitcherMa.clicked(null); event.accepted = true }
+                            Keys.onSpacePressed:  { livePitcherMa.clicked(null); event.accepted = true }
+                            Keys.onLeftPressed: {
+                                if (index > 0) livePresetRepeater.itemAt(index - 1).forceActiveFocus()
+                                event.accepted = true
+                            }
+                            Keys.onRightPressed: {
+                                if (index < livePresetRepeater.count - 1) livePresetRepeater.itemAt(index + 1).forceActiveFocus()
+                                event.accepted = true
+                            }
+                            Keys.onTabPressed: {
+                                if (index < livePresetRepeater.count - 1)
+                                    livePresetRepeater.itemAt(index + 1).forceActiveFocus()
+                                else if (steamStopButton.visible)
+                                    steamStopButton.forceActiveFocus()
+                                else
+                                    livePresetRepeater.itemAt(0).forceActiveFocus()
+                                event.accepted = true
+                            }
+                            Keys.onBacktabPressed: {
+                                if (index > 0)
+                                    livePresetRepeater.itemAt(index - 1).forceActiveFocus()
+                                else if (steamStopButton.visible)
+                                    steamStopButton.forceActiveFocus()
+                                else
+                                    livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
+                                event.accepted = true
+                            }
 
                             Text {
                                 id: livePitcherText
@@ -281,12 +316,24 @@ Page {
 
                 // View toggle button (graph/timer)
                 Rectangle {
+                    id: viewToggleBtn
                     width: Theme.scaled(44)
                     height: Theme.scaled(44)
                     radius: Theme.cardRadius
                     color: viewToggleMa.containsMouse ? Qt.darker(Theme.surfaceColor, 1.2) : Theme.surfaceColor
 
+                    activeFocusOnTab: true
                     Accessible.ignored: true
+                    Keys.onTabPressed: {
+                        if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(0).forceActiveFocus()
+                        else if (steamStopButton.visible) steamStopButton.forceActiveFocus()
+                        event.accepted = true
+                    }
+                    Keys.onBacktabPressed: {
+                        if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
+                        else if (steamStopButton.visible) steamStopButton.forceActiveFocus()
+                        event.accepted = true
+                    }
 
                     Image {
                         anchors.centerIn: parent
@@ -372,10 +419,15 @@ Page {
                         border.color: Theme.borderColor
                         border.width: 1
 
+                        activeFocusOnTab: true
                         Accessible.role: Accessible.Button
                         Accessible.name: TranslationManager.translate("steam.decreaseTime", "Decrease steam time by 5 seconds")
                         Accessible.focusable: true
                         Accessible.onPressAction: decreaseMouseArea.clicked(null)
+                        Keys.onReturnPressed: { decreaseMouseArea.clicked(null); event.accepted = true }
+                        Keys.onSpacePressed:  { decreaseMouseArea.clicked(null); event.accepted = true }
+                        KeyNavigation.tab: increaseTimeBtn
+                        KeyNavigation.backtab: steamingFlowSlider
 
                         Text {
                             anchors.centerIn: parent
@@ -427,10 +479,15 @@ Page {
                         border.color: Theme.borderColor
                         border.width: 1
 
+                        activeFocusOnTab: true
                         Accessible.role: Accessible.Button
                         Accessible.name: TranslationManager.translate("steam.increaseTime", "Increase steam time by 5 seconds")
                         Accessible.focusable: true
                         Accessible.onPressAction: increaseMouseArea.clicked(null)
+                        Keys.onReturnPressed: { increaseMouseArea.clicked(null); event.accepted = true }
+                        Keys.onSpacePressed:  { increaseMouseArea.clicked(null); event.accepted = true }
+                        KeyNavigation.tab: steamingFlowSlider
+                        KeyNavigation.backtab: decreaseTimeBtn
 
                         Text {
                             anchors.centerIn: parent
@@ -510,6 +567,8 @@ Page {
                     value: Settings.steamFlow
                     displayText: flowToDisplay(value)
                     accessibleName: TranslationManager.translate("steam.label.steamFlow", "Steam Flow")
+                    KeyNavigation.tab: steamStopButton.visible ? steamStopButton : (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : steamingFlowSlider)
+                    KeyNavigation.backtab: increaseTimeBtn
                     onValueModified: function(newValue) {
                         steamingFlowSlider.value = newValue
                         MainController.setSteamFlowImmediate(newValue)
@@ -593,6 +652,18 @@ Page {
                 border.color: Theme.primaryContrastColor
                 border.width: Theme.scaled(2)
 
+                activeFocusOnTab: true
+                Keys.onReturnPressed: { stopTapHandler.accessibleClicked(); event.accepted = true }
+                Keys.onSpacePressed:  { stopTapHandler.accessibleClicked(); event.accepted = true }
+                Keys.onTabPressed: {
+                    if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(0).forceActiveFocus()
+                    event.accepted = true
+                }
+                Keys.onBacktabPressed: {
+                    if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
+                    event.accepted = true
+                }
+
                 Text {
                     id: stopButtonText
                     anchors.centerIn: parent
@@ -600,6 +671,7 @@ Page {
                     color: Theme.primaryContrastColor
                     font.pixelSize: Theme.scaled(24)
                     font.weight: Font.Bold
+                    Accessible.ignored: true
                 }
 
                 // Using TapHandler for better touch responsiveness
@@ -740,6 +812,7 @@ Page {
                                 height: Theme.scaled(36)
 
                                 property int pitcherIndex: index
+                                property Item focusTarget: pitcherPill
 
                                 Rectangle {
                                     id: pitcherPill
@@ -751,6 +824,7 @@ Page {
                                     border.width: 1
                                     opacity: dragArea.drag.active ? 0.8 : 1.0
 
+                                    activeFocusOnTab: true
                                     Accessible.role: Accessible.Button
                                     Accessible.name: {
                                         var label = modelData.name + " " + TranslationManager.translate("steam.accessibility.preset", "preset")
@@ -771,6 +845,33 @@ Page {
                                         Settings.steamTimeout = modelData.duration
                                         Settings.steamFlow = flow
                                         MainController.startSteamHeating()
+                                    }
+
+                                    Keys.onReturnPressed: { Accessible.onPressAction(); event.accepted = true }
+                                    Keys.onSpacePressed:  { Accessible.onPressAction(); event.accepted = true }
+                                    Keys.onLeftPressed: {
+                                        if (index > 0) pitcherRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
+                                        event.accepted = true
+                                    }
+                                    Keys.onRightPressed: {
+                                        if (index < pitcherRepeater.count - 1) pitcherRepeater.itemAt(index + 1).focusTarget.forceActiveFocus()
+                                        event.accepted = true
+                                    }
+                                    Keys.onTabPressed: {
+                                        if (index < pitcherRepeater.count - 1)
+                                            pitcherRepeater.itemAt(index + 1).focusTarget.forceActiveFocus()
+                                        else
+                                            addPitcherButton.forceActiveFocus()
+                                        event.accepted = true
+                                    }
+                                    Keys.onBacktabPressed: {
+                                        if (index > 0)
+                                            pitcherRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
+                                        else if (ScaleDevice.connected && !ScaleDevice.isFlowScale)
+                                            savePitcherWeightBtn.forceActiveFocus()
+                                        else
+                                            steamTempSlider.forceActiveFocus()
+                                        event.accepted = true
                                     }
 
                                     Drag.active: dragArea.drag.active
@@ -877,11 +978,20 @@ Page {
                             border.color: Theme.textSecondaryColor
                             border.width: 1
 
+                            activeFocusOnTab: true
+                            KeyNavigation.tab: durationSlider
+                            KeyNavigation.backtab: pitcherRepeater.count > 0
+                                ? pitcherRepeater.itemAt(pitcherRepeater.count - 1).focusTarget
+                                : durationSlider
+                            Keys.onReturnPressed: { addPitcherDialog.open(); event.accepted = true }
+                            Keys.onSpacePressed:  { addPitcherDialog.open(); event.accepted = true }
+
                             Text {
                                 anchors.centerIn: parent
                                 text: "+"
                                 color: Theme.textColor
                                 font.pixelSize: Theme.scaled(20)
+                                Accessible.ignored: true
                             }
 
                             // Using TapHandler for better touch responsiveness
@@ -942,6 +1052,8 @@ Page {
                             value: getCurrentPitcherDuration()
                             valueColor: Theme.primaryColor
                             accessibleName: TranslationManager.translate("steam.label.duration", "Duration")
+                            KeyNavigation.tab: flowSlider
+                            KeyNavigation.backtab: addPitcherButton
                             onValueModified: function(newValue) {
                                 durationSlider.value = newValue
                                 Settings.steamTimeout = newValue
@@ -985,6 +1097,8 @@ Page {
                             displayText: flowToDisplay(value)
                             valueColor: Theme.primaryColor
                             accessibleName: TranslationManager.translate("steam.label.steamFlow", "Steam Flow")
+                            KeyNavigation.tab: steamTempSlider
+                            KeyNavigation.backtab: durationSlider
                             onValueModified: function(newValue) {
                                 flowSlider.value = newValue
                                 MainController.setSteamFlowImmediate(newValue)
@@ -1028,6 +1142,8 @@ Page {
                             value: Settings.steamTemperature
                             valueColor: Theme.temperatureColor
                             accessibleName: TranslationManager.translate("steam.label.temperature", "Steam Temperature")
+                            KeyNavigation.tab: ScaleDevice.connected && !ScaleDevice.isFlowScale ? tareBtn : (pitcherRepeater.count > 0 ? pitcherRepeater.itemAt(0).focusTarget : addPitcherButton)
+                            KeyNavigation.backtab: flowSlider
                             onValueModified: function(newValue) {
                                 steamTempSlider.value = newValue
                                 MainController.setSteamTemperatureImmediate(newValue)
@@ -1091,10 +1207,15 @@ Page {
                                 border.color: Theme.borderColor
                                 border.width: 1
 
+                                activeFocusOnTab: true
                                 Accessible.role: Accessible.Button
                                 Accessible.name: TranslationManager.translate("steam.accessible.tare", "Tare scale")
                                 Accessible.focusable: true
                                 Accessible.onPressAction: tareBtnMa.clicked(null)
+                                Keys.onReturnPressed: { tareBtnMa.clicked(null); event.accepted = true }
+                                Keys.onSpacePressed:  { tareBtnMa.clicked(null); event.accepted = true }
+                                KeyNavigation.tab: savePitcherWeightBtn
+                                KeyNavigation.backtab: steamTempSlider
 
                                 Tr {
                                     anchors.centerIn: parent
@@ -1127,12 +1248,17 @@ Page {
                                 border.color: isClear ? Theme.borderColor : "transparent"
                                 border.width: isClear ? 1 : 0
 
+                                activeFocusOnTab: true
                                 Accessible.role: Accessible.Button
                                 Accessible.name: isClear
                                     ? TranslationManager.translate("steam.label.clearPitcherWeight", "Clear pitcher weight")
                                     : TranslationManager.translate("steam.label.savePitcherWeight", "Save pitcher weight")
                                 Accessible.focusable: true
                                 Accessible.onPressAction: savePitcherWtMa.clicked(null)
+                                Keys.onReturnPressed: { savePitcherWtMa.clicked(null); event.accepted = true }
+                                Keys.onSpacePressed:  { savePitcherWtMa.clicked(null); event.accepted = true }
+                                KeyNavigation.tab: pitcherRepeater.count > 0 ? pitcherRepeater.itemAt(0).focusTarget : addPitcherButton
+                                KeyNavigation.backtab: tareBtn
 
                                 Text {
                                     anchors.centerIn: parent
@@ -1311,10 +1437,13 @@ Page {
                     font: Theme.bodyFont
                     verticalAlignment: TextInput.AlignVCenter
                     inputMethodHints: Qt.ImhNoPredictiveText
+                    activeFocusOnTab: true
                     Accessible.role: Accessible.EditableText
                     Accessible.name: TranslationManager.translate("steam.accessible.renamePitcher", "Rename pitcher preset")
                     Accessible.description: text
                     Accessible.focusable: true
+                    KeyNavigation.tab: editDeleteButton
+                    KeyNavigation.backtab: editSaveButton
 
                     Text {
                         anchors.fill: parent
@@ -1336,9 +1465,12 @@ Page {
                 spacing: Theme.scaled(10)
 
                 AccessibleButton {
+                    id: editDeleteButton
                     text: deleteButtonText.text
                     accessibleName: TranslationManager.translate("steam.deletePitcherPreset", "Delete this pitcher preset")
                     destructive: true
+                    KeyNavigation.tab: editCancelButton
+                    KeyNavigation.backtab: editPitcherNameInput
                     onClicked: {
                         Settings.removeSteamPitcherPreset(editingPitcherIndex)
                         editPitcherPopup.close()
@@ -1348,15 +1480,21 @@ Page {
                 Item { Layout.fillWidth: true }
 
                 AccessibleButton {
+                    id: editCancelButton
                     text: cancelButtonText.text
                     accessibleName: TranslationManager.translate("steam.cancelEditingPitcher", "Cancel editing pitcher preset")
+                    KeyNavigation.tab: editSaveButton
+                    KeyNavigation.backtab: editDeleteButton
                     onClicked: editPitcherPopup.close()
                 }
 
                 AccessibleButton {
+                    id: editSaveButton
                     primary: true
                     text: saveButtonText.text
                     accessibleName: TranslationManager.translate("steam.savePitcherChanges", "Save changes to pitcher preset")
+                    KeyNavigation.tab: editPitcherNameInput
+                    KeyNavigation.backtab: editCancelButton
                     onClicked: {
                         Qt.inputMethod.commit()
                         var preset = Settings.getSteamPitcherPreset(editingPitcherIndex)
@@ -1432,10 +1570,13 @@ Page {
                     font: Theme.bodyFont
                     verticalAlignment: TextInput.AlignVCenter
                     inputMethodHints: Qt.ImhNoPredictiveText
+                    activeFocusOnTab: true
                     Accessible.role: Accessible.EditableText
                     Accessible.name: TranslationManager.translate("steam.accessible.newPitcherName", "New pitcher preset name")
                     Accessible.description: text
                     Accessible.focusable: true
+                    KeyNavigation.tab: addCancelPitcherButton
+                    KeyNavigation.backtab: addPitcherConfirmButton
 
                     Text {
                         anchors.fill: parent
@@ -1455,15 +1596,21 @@ Page {
                 Item { Layout.fillWidth: true }
 
                 AccessibleButton {
+                    id: addCancelPitcherButton
                     text: addCancelButtonText.text
                     accessibleName: TranslationManager.translate("steam.cancelAddingPitcher", "Cancel adding new pitcher preset")
+                    KeyNavigation.tab: addPitcherConfirmButton
+                    KeyNavigation.backtab: newPitcherName
                     onClicked: addPitcherDialog.close()
                 }
 
                 AccessibleButton {
+                    id: addPitcherConfirmButton
                     primary: true
                     text: addButtonText.text
                     accessibleName: TranslationManager.translate("steam.addNewPitcher", "Add new pitcher preset with entered name")
+                    KeyNavigation.tab: newPitcherName
+                    KeyNavigation.backtab: addCancelPitcherButton
                     onClicked: {
                         Qt.inputMethod.commit()
                         if (newPitcherName.text.trim() !== "") {


### PR DESCRIPTION
## Summary

Audits Wave 1 (operation pages) and Wave 2 (review pages) for TalkBack/VoiceOver correctness. The focus is on the three issues that directly affect tablet users — not keyboard navigation, which has no effect on TalkBack swipe users.

**The three things fixed on each page:**
- **Missing `Accessible.onPressAction`** — element was announced but double-tap did nothing
- **Missing `Accessible.description`** — secondary actions (long-press, drag) were invisible to screen reader users
- **Missing `Accessible.ignored: true` on child Text** — TalkBack was announcing both the accessible name and raw text content, doubling every announcement

### Wave 1 — Operation pages
| Page | Key fixes |
|------|-----------|
| `FlushPage` | `onPressAction` missing from preset pills; description hints for long-press rename; `Accessible.ignored` on child Text |
| `HotWaterPage` | `onPressAction` missing from vessel pills; description hints; `Accessible.ignored` fixes |
| `SteamPage` | `Accessible.ignored` on stop button Text and pitcher pill Text |
| `IdlePage` | Keyboard activation on non-favorite profile pill (minor) |
| `EspressoPage` | `Accessible.ignored` on icon children; `onPressAction` gap on back button |

### Wave 2 — Review pages
| Page | Key fixes |
|------|-----------|
| `PostShotReviewPage` | `Accessible.ignored` on two child Text elements |
| `ShotDetailPage` | `Accessible.description` for swipe gesture on graph card; `Accessible.ignored` on several child Text/Tr elements; suppressed broken accessible node on position counter |
| `ShotHistoryPage` | Already correct — no changes |
| `BeanInfoPage` | Already correct — no changes |

### Docs
- Extracts the CLAUDE.md accessibility section into `docs/CLAUDE_MD/ACCESSIBILITY.md` with full rules, patterns, common mistakes checklist, and Repeater `focusTarget` keyboard pattern
- Documents the rationale for why keyboard navigation (`KeyNavigation`, `activeFocusOnTab`) is **low priority** for this tablet-first app — those properties have no effect on TalkBack swipe navigation

Note: Wave 1 pages also received keyboard navigation chains (Pass 2) before we clarified the tablet-first priority. Those chains are harmless and have been left in place.

## Test plan
- [ ] Enable TalkBack on Android tablet
- [ ] On FlushPage: swipe to preset pills — double-tap should select preset; swipe to hear long-press hint
- [ ] On HotWaterPage: same for vessel pills
- [ ] On ShotDetailPage: swipe to graph card — should hear swipe gesture hint
- [ ] Verify no element announces its name twice (no doubled announcements)
- [ ] Smoke test normal touch usage on all pages — no behaviour changes expected

Closes #736 (partial — Waves 3–5 remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)