### PR TITLE
ux: water level opacity pulse + text swap

### DIFF
--- a/qml/components/layout/items/WaterLevelItem.qml
+++ b/qml/components/layout/items/WaterLevelItem.qml
@@ -25,26 +25,45 @@ Item {
         if (margin > 3) return "warning"
         return "critical"
     }
-    readonly property bool isBlinking: warningState !== "ok"
-    readonly property color stateWarningColor: warningState === "critical" ? Theme.errorColor : Theme.warningColor
-    readonly property color displayColor: {
-        if (!isBlinking) return Theme.waterLevelColor
-        return blinkTimer.blinkOn ? stateWarningColor : Theme.waterLevelColor
+    readonly property bool isPulsing: warningState !== "ok"
+    readonly property real pulseMinOpacity: {
+        if (warningState === "low") return 0.4
+        if (warningState === "warning") return 0.3
+        return 0.2  // critical
+    }
+    readonly property int pulseDuration: {
+        if (warningState === "low") return 2000
+        if (warningState === "warning") return 1000
+        return 500  // critical
+    }
+    readonly property string displayText: {
+        if (warningState === "critical")
+            return TranslationManager.translate("waterlevel.warning.refill", "Refill")
+        if (warningState === "warning")
+            return TranslationManager.translate("waterlevel.warning.low", "Low")
+        return root.showMl ? DE1Device.waterLevelMl + " ml" : DE1Device.waterLevel.toFixed(0) + "%"
     }
 
-    // Progressive blink animation — rate increases as water approaches halt threshold
-    Timer {
-        id: blinkTimer
-        running: root.isBlinking && root.visible
-        repeat: true
-        interval: root.warningState === "low" ? 2000
-                : root.warningState === "warning" ? 1000 : 500  // critical
-        property bool blinkOn: true
-        onTriggered: blinkOn = !blinkOn
-        onRunningChanged: if (!running) blinkOn = true
+    // Smooth sine-wave opacity pulse — rate and depth increase with urgency
+    property real pulseOpacity: 1.0
+    SequentialAnimation {
+        id: pulseAnimation
+        running: root.isPulsing && root.visible
+        loops: Animation.Infinite
+        NumberAnimation {
+            target: root; property: "pulseOpacity"
+            from: 1.0; to: root.pulseMinOpacity
+            duration: root.pulseDuration / 2
+            easing.type: Easing.InOutSine
+        }
+        NumberAnimation {
+            target: root; property: "pulseOpacity"
+            from: root.pulseMinOpacity; to: 1.0
+            duration: root.pulseDuration / 2
+            easing.type: Easing.InOutSine
+        }
+        onRunningChanged: if (!running) root.pulseOpacity = 1.0
     }
-
-    onWarningStateChanged: if (isBlinking) blinkTimer.blinkOn = true
 
     implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
     implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
@@ -75,8 +94,9 @@ Item {
         Text {
             id: compactWater
             anchors.centerIn: parent
-            text: root.showMl ? DE1Device.waterLevelMl + " ml" : DE1Device.waterLevel.toFixed(0) + "%"
-            color: root.displayColor
+            text: root.displayText
+            color: Theme.waterLevelColor
+            opacity: root.pulseOpacity
             font: Theme.bodyFont
             Accessible.ignored: true
         }
@@ -97,10 +117,9 @@ Item {
 
             Text {
                 Layout.alignment: Qt.AlignHCenter
-                text: root.showMl
-                    ? DE1Device.waterLevelMl + " ml"
-                    : DE1Device.waterLevel.toFixed(0) + "%"
-                color: root.displayColor
+                text: root.displayText
+                color: Theme.waterLevelColor
+                opacity: root.pulseOpacity
                 font: Theme.valueFont
                 Accessible.ignored: true
             }

--- a/qml/components/layout/items/WaterLevelItem.qml
+++ b/qml/components/layout/items/WaterLevelItem.qml
@@ -21,27 +21,29 @@ Item {
         // falsely trigger "critical" on every startup until the first BLE update arrives.
         if (!DE1Device.connected) return "ok"
         if (margin > 7) return "ok"
-        if (margin > 5) return "low"
-        if (margin > 3) return "warning"
+        if (margin > 5) return "caution"
+        if (margin > 3) return "low"
         return "critical"
     }
     readonly property bool isPulsing: warningState !== "ok"
     readonly property real pulseMinOpacity: {
-        if (warningState === "low") return 0.4
-        if (warningState === "warning") return 0.3
+        if (warningState === "caution") return 0.4
+        if (warningState === "low") return 0.3
         return 0.2  // critical
     }
     readonly property int pulseDuration: {
-        if (warningState === "low") return 2000
-        if (warningState === "warning") return 1000
+        if (warningState === "caution") return 2000
+        if (warningState === "low") return 1000
         return 500  // critical
     }
     readonly property string displayText: {
         if (warningState === "critical")
             return TranslationManager.translate("waterlevel.warning.refill", "Refill")
-        if (warningState === "warning")
+        if (warningState === "low")
             return TranslationManager.translate("waterlevel.warning.low", "Low")
-        return root.showMl ? DE1Device.waterLevelMl + " ml" : DE1Device.waterLevel.toFixed(0) + "%"
+        return root.showMl
+            ? DE1Device.waterLevelMl + " " + TranslationManager.translate("waterlevel.unit.ml", "ml")
+            : DE1Device.waterLevel.toFixed(0) + TranslationManager.translate("waterlevel.unit.percent", "%")
     }
 
     // Smooth sine-wave opacity pulse — rate and depth increase with urgency
@@ -65,20 +67,30 @@ Item {
         onRunningChanged: if (!running) root.pulseOpacity = 1.0
     }
 
+    onWarningStateChanged: {
+        if (isPulsing) {
+            pulseAnimation.stop()
+            pulseOpacity = 1.0
+            pulseAnimation.start()
+        }
+    }
+
     implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
     implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
 
     Accessible.role: Accessible.StaticText
     Accessible.name: {
-        var level = root.showMl
+        var label = TranslationManager.translate("waterlevel.accessible.label", "Water level:")
+        var numericLevel = root.showMl
             ? DE1Device.waterLevelMl + " " + TranslationManager.translate("waterlevel.accessible.milliliters", "milliliters")
             : DE1Device.waterLevel.toFixed(0) + " " + TranslationManager.translate("waterlevel.accessible.percent", "percent")
-        var warning = root.warningState === "critical"
-            ? ". " + TranslationManager.translate("waterlevel.accessible.warning.critical", "Warning: water level critically low, refill soon")
-            : root.warningState !== "ok"
-            ? ". " + TranslationManager.translate("waterlevel.accessible.warning.low", "Warning: water level is low")
-            : ""
-        return TranslationManager.translate("waterlevel.accessible.label", "Water level:") + " " + level + warning
+        if (root.warningState === "critical")
+            return label + " " + root.displayText + ", " + numericLevel + ". " + TranslationManager.translate("waterlevel.accessible.warning.critical", "Warning: water level critically low, refill soon")
+        if (root.warningState === "low")
+            return label + " " + root.displayText + ", " + numericLevel + ". " + TranslationManager.translate("waterlevel.accessible.warning.low", "Warning: water level is low")
+        if (root.warningState === "caution")
+            return label + " " + numericLevel + ". " + TranslationManager.translate("waterlevel.accessible.warning.low", "Warning: water level is low")
+        return label + " " + numericLevel
     }
     Accessible.focusable: true
     Accessible.onPressAction: fullMouseArea.clicked(null)
@@ -138,17 +150,7 @@ Item {
             anchors.fill: parent
             onClicked: {
                 if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
-                    var warning = root.warningState === "critical"
-                        ? ". " + TranslationManager.translate("waterlevel.accessible.warning.critical", "Warning: water level critically low, refill soon")
-                        : root.warningState !== "ok"
-                        ? ". " + TranslationManager.translate("waterlevel.accessible.warning.low", "Warning: water level is low")
-                        : ""
-                    var label = TranslationManager.translate("waterlevel.accessible.label", "Water level:")
-                    if (root.showMl) {
-                        AccessibilityManager.announceLabel(label + " " + DE1Device.waterLevelMl + " " + TranslationManager.translate("waterlevel.accessible.milliliters", "milliliters") + warning)
-                    } else {
-                        AccessibilityManager.announceLabel(label + " " + DE1Device.waterLevel.toFixed(0) + " " + TranslationManager.translate("waterlevel.accessible.percent", "percent") + warning)
-                    }
+                    AccessibilityManager.announceLabel(root.Accessible.name)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Replace color blink (blue ↔ yellow/red) with smooth sine-wave opacity pulse that stays blue — avoids confusion with nearby temperature display which also uses red
- Swap numeric value for descriptive text at higher warning levels: "Low" at warning, "Refill" at critical
- Progressive urgency: ok = solid number, low = gentle pulsing number (2s), warning = medium pulsing "Low" (1s), critical = rapid pulsing "Refill" (0.5s)

## Test plan
- [ ] Verify normal water level shows solid blue number (% or ml)
- [ ] Simulate low water: number pulses gently (opacity 1.0 → 0.4, 2s cycle)
- [ ] Simulate warning water: text changes to "Low", pulse speeds up (1s cycle)
- [ ] Simulate critical water: text changes to "Refill", rapid pulse (0.5s cycle)
- [ ] Verify compact mode shows same behavior
- [ ] Verify pulse stops and text returns to number when water level recovers
- [ ] Verify no animation when disconnected (warningState stays "ok")
- [ ] Test with screen reader — accessible name still reports numeric level + warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)