### PR TITLE
copy: mention milk residue in steam health description

### DIFF
--- a/qml/pages/settings/SettingsCalibrationTab.qml
+++ b/qml/pages/settings/SettingsCalibrationTab.qml
@@ -373,7 +373,7 @@ Item {
                         Text {
                             Layout.fillWidth: true
                             text: TranslationManager.translate("settings.calibration.steamHealthDesc",
-                                "Rising pressure or temperature over time can indicate scale buildup. The bars show how far your latest session has drifted from your clean-machine baseline toward the warning level.")
+                                "Rising pressure or temperature over time can indicate milk residue or scale buildup. Try cleaning your steam wand with a milk cleaner first; descale if the issue persists. The bars show drift from your clean-machine baseline toward the warning level.")
                             color: Theme.textSecondaryColor
                             font.family: Theme.bodyFont.family
                             font.pixelSize: Theme.scaled(12)


### PR DESCRIPTION
## Summary
- Updated the Steam Health panel description to mention milk residue alongside scale buildup as a cause for rising pressure/temperature
- Added actionable guidance: clean wand with milk cleaner first, descale if issue persists

## Test plan
- [ ] Open Settings > Calibration > Steam Health and verify updated description text renders correctly
- [ ] Confirm text wraps properly and doesn't overflow the card

🤖 Generated with [Claude Code](https://claude.ai/code)