### PR TITLE
cal: batched median updates + pressure smoothing for auto flow cal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ Detailed documentation lives in `docs/CLAUDE_MD/`. Read these when working in th
 | `CUP_FILL_VIEW.md` | CupFillView layer stack, GPU shaders, updating cup images |
 | `EMOJI_SYSTEM.md` | Twemoji SVG rendering, adding/switching emoji sets |
 | `ACCESSIBILITY.md` | TalkBack/VoiceOver rules, focus order, anti-patterns, implementation plan |
+| `AUTO_FLOW_CALIBRATION.md` | Auto flow calibration algorithm, batched median updates, windowing, convergence |
 
 Also in `docs/`:
 - `MCP_SERVER.md` — full MCP tool list, access levels, architecture

--- a/docs/CLAUDE_MD/AUTO_FLOW_CALIBRATION.md
+++ b/docs/CLAUDE_MD/AUTO_FLOW_CALIBRATION.md
@@ -12,7 +12,7 @@ Automatic per-profile flow calibration using scale data as ground truth. After e
 
 1. **Shot completes** with a Bluetooth scale connected
 2. **Steady-state detection**: The algorithm scans the shot data for a window where:
-   - Pressure is stable (change <= 0.5 bar/sec)
+   - Pressure is stable (3-sample smoothed change <= 0.5 bar/sec)
    - Pressure is above 1.5 bar (rejects empty-portafilter shots)
    - Weight flow is meaningful (> 0.5 g/s)
    - Machine flow is meaningful (> 0.1 ml/s)
@@ -25,19 +25,21 @@ Automatic per-profile flow calibration using scale data as ground truth. After e
    - **Flow profiles**: `mean(weight_flow) / (target_flow * 0.963)` — uses the profile's known target flow, independent of current calibration
    - **Pressure profiles**: `current_multiplier * mean(weight_flow) / (mean(machine_flow) * 0.963)` — divides out current calibration from reported flow
 6. **Sanity check**: Clamp to `[0.5, kCalibrationMax]` — cap extreme values that likely indicate measurement errors. The upper bound tracks DE1 firmware (1.8 on pre-v1337 firmware, 2.7 on v1337+)
-7. **Store & apply**: If the computed value differs from current by > 2%, EMA-smooth toward it (alpha=0.3) and send to the machine
+7. **Batch accumulate**: Add the ideal to a per-profile batch (persisted in settings). After 5 shots, compute the batch median and update C using `0.5 * median + 0.5 * current`. Only apply if the change exceeds 3%.
 
 ## Algorithm Details
 
 ### Steady-State Window Detection
 
 The algorithm iterates through the shot's pressure data looking for the longest contiguous segment where:
-- Pressure is stable (change <= 0.5 bar/sec)
+- Pressure is stable (3-sample moving average change <= 0.5 bar/sec — smoothing filters PID jitter on flow profiles)
 - Pressure is above 1.5 bar (rejects no-coffee/empty-portafilter shots where water flows freely with near-zero back-pressure)
 - Weight flow > 0.5 g/s (excludes dripping/dead time)
 - Machine flow > 0.1 ml/s (excludes stalled flow)
 - Nearest scale data point within 1 second (ensures weight flow data alignment)
 - Per-sample machine/weight flow ratio within [0.4, 2.5] (rejects individual scale data glitches — generous bounds since single samples are noisy)
+
+Pressure is smoothed with a 3-sample centered moving average before computing dpdt. This filters the DE1's PID pressure corrections (~0.1-0.2 bar every ~0.2s) that would otherwise break the window on flow profiles. The original (unsmoothed) pressure is used for the minimum pressure check. Analysis of 13 D-Flow shots showed this increases average window duration from 10.7s to 16.3s.
 
 Any sample that fails these criteria breaks the current window, and the algorithm picks the longest qualifying window from the entire shot. The window must span at least 1.5 seconds with at least 7 samples to provide a reliable average.
 
@@ -73,9 +75,22 @@ calibration = current_multiplier * mean(weight_flow) / (mean(machine_flow) * 0.9
 
 The machine flow sensor measures volumetric flow (ml/s), while the scale measures mass (g/s). Water at ~93°C has a density of ~0.963 g/ml, so the correction factor accounts for this difference.
 
-### Convergence
+### Batched Median Updates
 
-The multiplier is only updated when the computed value differs from the current effective multiplier by more than 2%. This prevents unnecessary writes and oscillation from measurement noise.
+Instead of updating the calibration factor after every shot (which changes pump behavior and creates a feedback loop), the algorithm accumulates ideal values across 5 shots at a constant calibration, then updates once using the batch median.
+
+**Why batching?** Each calibration update changes the pump's flow setpoint, which changes puck extraction dynamics. Two identical pucks pulled at different C values produce different weight flows. Per-shot updates cause the algorithm to partially chase its own tail — each update changes the conditions for the next shot. Batching ensures 5 shots are pulled under identical pump conditions, producing truly comparable data.
+
+**Why median?** The median provides natural outlier rejection. Runaway shots, channeling anomalies, and other one-off events are automatically ignored without needing explicit detection logic.
+
+**Update rule:**
+- Accumulate 5 ideals per profile (persisted in settings across app restarts)
+- Compute median of the batch
+- Blend: `new_C = 0.5 * median + 0.5 * current_C` (alpha=0.5 is safe because the median of 5 shots is more reliable than a single ideal)
+- First calibration for a profile uses the median directly (no history to blend with)
+- Only apply if the change exceeds 3% — prevents unnecessary pump changes when the factor is already close
+
+After the update, the batch resets and accumulation begins again at the new C value. The algorithm continues monitoring indefinitely but only changes C when the shift is meaningful.
 
 ### Sanity Bounds
 
@@ -104,8 +119,10 @@ Per-profile persistence (`Settings::setProfileFlowCalibration`) and the settings
 
 - `autoFlowCalibration` (bool, default `true`): Master toggle
 - `calibration/perProfileFlow` (JSON object): Maps profile filename → multiplier
+- `calibration/flowCalBatch` (JSON object): Maps profile filename → array of pending ideal values (accumulator for batched updates)
 - `flowCalibrationMultiplier` (double, default 1.0): Global multiplier, auto-updated to espresso median
 - Effective multiplier: per-profile if auto-cal is on and one exists, otherwise falls back to global `flowCalibrationMultiplier`
+- Clearing a profile's calibration (via MCP or settings UI) also clears its pending batch
 
 ### Profile Load Hook
 
@@ -140,3 +157,5 @@ A one-time migration resets all per-profile flow calibrations and the global mul
 - **Density is approximated**: Uses a fixed 0.963 factor; actual density varies slightly with temperature
 - **One multiplier per profile**: Does not calibrate different flow rate ranges within a single profile
 - **Not retroactive**: Only applies to shots made after enabling the feature
+- **5-shot batch delay**: First calibration update requires 5 qualifying shots on a profile. The pump runs at the global multiplier (or 1.0 on fresh install) until then.
+- **Bean/grind changes within a batch**: If beans or grinder setting change within a 5-shot batch, the median blends data from different conditions. The median's outlier rejection mitigates this for small numbers of changed shots.

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -885,7 +885,7 @@ void MainController::computeAutoFlowCalibration() {
     // C update changes pump behavior, which changes puck dynamics, which changes the next
     // ideal — producing oscillation instead of convergence. The median also provides
     // natural outlier rejection (runaway shots, channeling anomalies).
-    constexpr int kBatchSize = 5;
+    constexpr qsizetype kBatchSize = 5;
     constexpr double kBatchEmaAlpha = 0.5;  // Higher alpha is safe because median of N shots is more reliable
 
     QString profileName = m_profileManager->baseProfileName();
@@ -911,10 +911,7 @@ void MainController::computeAutoFlowCalibration() {
     // Clear the batch now that we've consumed it
     m_settings->clearFlowCalPendingIdeals(profileName);
 
-    // Scale alpha proportionally for remainder batches (< kBatchSize shots).
-    // For full batches this gives kBatchEmaAlpha; for a batch of 1 it gives
-    // kBatchEmaAlpha / kBatchSize (very conservative single-shot update).
-    double alpha = kBatchEmaAlpha * qMin(1.0, static_cast<double>(n) / kBatchSize);
+    double alpha = kBatchEmaAlpha;
 
     // On first calibration for this profile, use median directly (no history to blend with)
     double computed = m_settings->hasProfileFlowCalibration(profileName)
@@ -928,7 +925,7 @@ void MainController::computeAutoFlowCalibration() {
     // would silently reject the write and auto-cal would stop converging for that profile.
     computed = qBound(kCalibrationMin, computed, kCalibrationMax);
 
-    // Only update if meaningfully different (> 2% change)
+    // Only update if meaningfully different (> 3% change)
     if (currentEffective > 0.01 && qAbs(computed - currentEffective) / currentEffective < kChangeThreshold) {
         qDebug() << "Auto flow cal: batch median" << median << "≈ current" << currentEffective
                  << "(computed" << computed << "< 3% change, skipping)";

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -606,13 +606,29 @@ void MainController::computeAutoFlowCalibration() {
     const int kFirmwareCapBumped = 1337;
     const int fwBuild = m_device ? m_device->firmwareBuildNumber() : 0;
     const double kCalibrationMax = (fwBuild >= kFirmwareCapBumped) ? 2.7 : 1.8;
-    constexpr double kChangeThreshold = 0.02;        // 2% relative change required to update
+    constexpr double kChangeThreshold = 0.03;        // 3% relative change required to update
     constexpr double kMaxSampleRatio = 2.5;          // per-sample machine/weight ratio — break window on extreme outliers
     constexpr double kMinSampleRatio = 0.4;          // (generous bounds: window-level check is tighter)
     constexpr double kMaxWindowRatio = 1.35;         // window-mean machine/weight ratio — reject if scale data is suspect
     constexpr double kMinWindowRatio = 0.75;         // (de1app GFC users get ~0.9-1.1 ratios on good data)
     constexpr double kMinWindowStartTime = 10.0;     // seconds — skip early extraction where LSLR weight flow
                                                      // lags behind actual flow, producing inflated ratios
+
+    // 3-sample centered moving average on pressure for dpdt computation.
+    // The DE1's PID causes rapid small pressure corrections (~0.1-0.2 bar per sample)
+    // that exceed the dpdt threshold on flow profiles, producing artificially short
+    // steady windows. Smoothing filters this PID jitter while preserving genuine
+    // pressure transitions (frame changes, preinfusion→pour).
+    QVector<double> smoothedPressure(pressureData.size());
+    for (qsizetype i = 0; i < pressureData.size(); ++i) {
+        if (i == 0 || i == pressureData.size() - 1) {
+            smoothedPressure[i] = pressureData[i].y();
+        } else {
+            smoothedPressure[i] = (pressureData[i - 1].y()
+                                   + pressureData[i].y()
+                                   + pressureData[i + 1].y()) / 3.0;
+        }
+    }
 
     // Find the best steady-pour window: stable pressure above minimum + meaningful weight flow.
     // We track the best (longest) qualifying window found across the entire shot.
@@ -648,7 +664,9 @@ void MainController::computeAutoFlowCalibration() {
     for (qsizetype i = 1; i < pressureData.size(); ++i) {
         double dt = pressureData[i].x() - pressureData[i - 1].x();
         if (dt <= 0) continue;
-        double dpdt = qAbs(pressureData[i].y() - pressureData[i - 1].y()) / dt;
+        // Use smoothed pressure for dpdt to filter PID jitter
+        double dpdt = qAbs(smoothedPressure[i] - smoothedPressure[i - 1]) / dt;
+        // Use original pressure for minimum pressure check (smoothing could mask real drops)
         double pressure = pressureData[i].y();
         double t = pressureData[i].x();
 
@@ -862,22 +880,46 @@ void MainController::computeAutoFlowCalibration() {
                    << "— verify scale accuracy (firmware build:" << fwBuild << ")";
     }
 
-    // Only update if the ideal itself differs enough from current. Checking ideal (not the
-    // EMA output) preserves the original 2% deadband regardless of alpha. The > 0.01 guard
-    // avoids division by zero on first use (before any calibration is set).
-    if (currentEffective > 0.01 && qAbs(ideal - currentEffective) / currentEffective < kChangeThreshold) {
-        qDebug() << "Auto flow cal: ideal" << ideal << "≈ current" << currentEffective << "(< 2% change, skipping)";
-        return;
+    // Batched median accumulator: collect ideals across multiple shots at a constant C,
+    // then update C using the batch median. This prevents the feedback loop where each
+    // C update changes pump behavior, which changes puck dynamics, which changes the next
+    // ideal — producing oscillation instead of convergence. The median also provides
+    // natural outlier rejection (runaway shots, channeling anomalies).
+    constexpr int kBatchSize = 5;
+    constexpr double kBatchEmaAlpha = 0.5;  // Higher alpha is safe because median of N shots is more reliable
+
+    QString profileName = m_profileManager->baseProfileName();
+    m_settings->appendFlowCalPendingIdeal(profileName, ideal);
+    QVector<double> pending = m_settings->flowCalPendingIdeals(profileName);
+
+    qDebug() << "Auto flow cal: accumulated ideal" << ideal
+             << "for" << profileName << "(" << pending.size() << "/" << kBatchSize << ")"
+             << "window:" << windowDuration << "s," << bestCount << "samples"
+             << "mode:" << (isFlowProfile ? "flow" : "pressure");
+
+    if (pending.size() < kBatchSize) {
+        return;  // Keep accumulating — don't update C yet
     }
 
-    // EMA smoothing: blend current toward ideal to dampen shot-to-shot oscillation.
-    // alpha=0.3 moves 30% toward the ideal each shot, converging in ~5-7 shots while
-    // preventing a single noisy shot from dominating (vs. jumping straight to ideal).
-    // Skip EMA on the first shot for this profile — no oscillation history to dampen yet.
-    constexpr double kEmaAlpha = 0.3;
-    double computed = m_settings->hasProfileFlowCalibration(m_profileManager->baseProfileName())
-        ? kEmaAlpha * ideal + (1.0 - kEmaAlpha) * currentEffective
-        : ideal;
+    // Batch complete — compute median
+    std::sort(pending.begin(), pending.end());
+    qsizetype n = pending.size();
+    double median = (n % 2 == 0)
+        ? (pending[n / 2 - 1] + pending[n / 2]) / 2.0
+        : pending[n / 2];
+
+    // Clear the batch now that we've consumed it
+    m_settings->clearFlowCalPendingIdeals(profileName);
+
+    // Scale alpha proportionally for remainder batches (< kBatchSize shots).
+    // For full batches this gives kBatchEmaAlpha; for a batch of 1 it gives
+    // kBatchEmaAlpha / kBatchSize (very conservative single-shot update).
+    double alpha = kBatchEmaAlpha * qMin(1.0, static_cast<double>(n) / kBatchSize);
+
+    // On first calibration for this profile, use median directly (no history to blend with)
+    double computed = m_settings->hasProfileFlowCalibration(profileName)
+        ? alpha * median + (1.0 - alpha) * currentEffective
+        : median;
 
     // Re-clamp after EMA. When the user has manually set the global multiplier above
     // kCalibrationMax (e.g. 3.0 via the manual UI vs. kCalibrationMax=2.7), currentEffective
@@ -886,18 +928,25 @@ void MainController::computeAutoFlowCalibration() {
     // would silently reject the write and auto-cal would stop converging for that profile.
     computed = qBound(kCalibrationMin, computed, kCalibrationMax);
 
+    // Only update if meaningfully different (> 2% change)
+    if (currentEffective > 0.01 && qAbs(computed - currentEffective) / currentEffective < kChangeThreshold) {
+        qDebug() << "Auto flow cal: batch median" << median << "≈ current" << currentEffective
+                 << "(computed" << computed << "< 3% change, skipping)";
+        return;
+    }
+
     double oldValue = currentEffective;
-    if (!m_settings->setProfileFlowCalibration(m_profileManager->baseProfileName(), computed)) {
+    if (!m_settings->setProfileFlowCalibration(profileName, computed)) {
         qWarning() << "Auto flow cal: computed value" << computed
-                   << "was rejected by settings for" << m_profileManager->baseProfileName();
+                   << "was rejected by settings for" << profileName;
         return;
     }
     applyFlowCalibration();
 
-    qDebug() << "Auto flow cal: updated" << m_profileManager->baseProfileName()
+    qDebug() << "Auto flow cal: updated" << profileName
              << "from" << oldValue << "to" << computed
-             << "(ideal:" << ideal << "EMA alpha:" << kEmaAlpha
-             << "window:" << windowDuration << "s," << bestCount << "samples"
+             << "(batch median:" << median << "from" << n << "ideals"
+             << "alpha:" << alpha
              << "mode:" << (isFlowProfile ? "flow" : "pressure") << ")";
 
     emit flowCalibrationAutoUpdated(m_profileManager->currentProfile().title(), oldValue, computed);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -4018,9 +4018,21 @@ void Settings::savePerProfileFlowCalMap(const QJsonObject& map) {
 
 // Auto flow calibration batch accumulator
 
-QVector<double> Settings::flowCalPendingIdeals(const QString& profileFilename) const {
+static QJsonObject parseFlowCalBatch(const QSettings& settings) {
+    QJsonParseError parseError;
     QJsonObject map = QJsonDocument::fromJson(
-        m_settings.value("calibration/flowCalBatch", "{}").toByteArray()).object();
+        settings.value("calibration/flowCalBatch", "{}").toByteArray(),
+        &parseError).object();
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning() << "Settings: corrupt flowCalBatch JSON:" << parseError.errorString();
+        const_cast<QSettings&>(settings).setValue("calibration/flowCalBatch", "{}");
+        return QJsonObject();
+    }
+    return map;
+}
+
+QVector<double> Settings::flowCalPendingIdeals(const QString& profileFilename) const {
+    QJsonObject map = parseFlowCalBatch(m_settings);
     QVector<double> result;
     QJsonArray arr = map.value(profileFilename).toArray();
     for (const auto& v : arr)
@@ -4029,8 +4041,7 @@ QVector<double> Settings::flowCalPendingIdeals(const QString& profileFilename) c
 }
 
 void Settings::appendFlowCalPendingIdeal(const QString& profileFilename, double ideal) {
-    QJsonObject map = QJsonDocument::fromJson(
-        m_settings.value("calibration/flowCalBatch", "{}").toByteArray()).object();
+    QJsonObject map = parseFlowCalBatch(m_settings);
     QJsonArray arr = map.value(profileFilename).toArray();
     arr.append(ideal);
     map[profileFilename] = arr;
@@ -4038,8 +4049,7 @@ void Settings::appendFlowCalPendingIdeal(const QString& profileFilename, double 
 }
 
 void Settings::clearFlowCalPendingIdeals(const QString& profileFilename) {
-    QJsonObject map = QJsonDocument::fromJson(
-        m_settings.value("calibration/flowCalBatch", "{}").toByteArray()).object();
+    QJsonObject map = parseFlowCalBatch(m_settings);
     map.remove(profileFilename);
     m_settings.setValue("calibration/flowCalBatch", QJsonDocument(map).toJson(QJsonDocument::Compact));
 }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -3964,6 +3964,8 @@ void Settings::clearProfileFlowCalibration(const QString& profileFilename) {
     QJsonObject map = allProfileFlowCalibrations();
     map.remove(profileFilename);
     savePerProfileFlowCalMap(map);
+    // Clear any pending batch ideals — they were computed at the old C value
+    clearFlowCalPendingIdeals(profileFilename);
 }
 
 double Settings::effectiveFlowCalibration(const QString& profileFilename) const {
@@ -4012,6 +4014,34 @@ void Settings::savePerProfileFlowCalMap(const QJsonObject& map) {
     m_perProfileFlowCalCacheValid = true;
     m_perProfileFlowCalVersion++;
     emit perProfileFlowCalibrationChanged();
+}
+
+// Auto flow calibration batch accumulator
+
+QVector<double> Settings::flowCalPendingIdeals(const QString& profileFilename) const {
+    QJsonObject map = QJsonDocument::fromJson(
+        m_settings.value("calibration/flowCalBatch", "{}").toByteArray()).object();
+    QVector<double> result;
+    QJsonArray arr = map.value(profileFilename).toArray();
+    for (const auto& v : arr)
+        result.append(v.toDouble());
+    return result;
+}
+
+void Settings::appendFlowCalPendingIdeal(const QString& profileFilename, double ideal) {
+    QJsonObject map = QJsonDocument::fromJson(
+        m_settings.value("calibration/flowCalBatch", "{}").toByteArray()).object();
+    QJsonArray arr = map.value(profileFilename).toArray();
+    arr.append(ideal);
+    map[profileFilename] = arr;
+    m_settings.setValue("calibration/flowCalBatch", QJsonDocument(map).toJson(QJsonDocument::Compact));
+}
+
+void Settings::clearFlowCalPendingIdeals(const QString& profileFilename) {
+    QJsonObject map = QJsonDocument::fromJson(
+        m_settings.value("calibration/flowCalBatch", "{}").toByteArray()).object();
+    map.remove(profileFilename);
+    m_settings.setValue("calibration/flowCalBatch", QJsonDocument(map).toJson(QJsonDocument::Compact));
 }
 
 // SAW (Stop-at-Weight) learning

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -832,6 +832,12 @@ public:
     QJsonObject allProfileFlowCalibrations() const;
     int perProfileFlowCalVersion() const { return m_perProfileFlowCalVersion; }
 
+    // Auto flow calibration batch accumulator: stores pending ideal values per profile
+    // until a full batch (5 shots) is collected, then the median is used to update C.
+    QVector<double> flowCalPendingIdeals(const QString& profileFilename) const;
+    void appendFlowCalPendingIdeal(const QString& profileFilename, double ideal);
+    void clearFlowCalPendingIdeals(const QString& profileFilename);
+
     // SAW (Stop-at-Weight) learning
     double sawLearnedLag() const;  // Average lag for display in QML (calculated from drip/flow)
     double getExpectedDrip(double currentFlowRate) const;  // Predicts drip based on flow and history


### PR DESCRIPTION
## Summary
- **3-sample MA pressure smoothing**: Filters PID jitter in dpdt computation, increasing average steady window from 10.7s to 16.3s across 13 D-Flow shots
- **Batched median accumulator**: Collects 5 ideals at constant C before updating, breaking the pump-behavior feedback loop and providing natural outlier rejection
- **3% change threshold**: Only updates calibration when the shift is meaningful, reducing unnecessary pump changes
- Moves `AUTO_FLOW_CALIBRATION.md` into `docs/CLAUDE_MD/` and references it from `CLAUDE.md`

## Context

Analysis in #739 found two issues with the v3 auto flow calibration:

1. **dpdt threshold too strict for flow profiles**: The DE1's PID causes 0.1-0.2 bar corrections every ~0.2s that exceed the 0.5 bar/s threshold, producing artificially short windows (2.5-5s instead of 18-21s). A 3-sample moving average on pressure filters this jitter while preserving genuine transitions.

2. **Per-shot EMA creates feedback loop**: Each C update changes pump behavior → changes puck dynamics → changes weight flow → changes the next ideal. Simulation across 11 same-bean/same-grind shots showed neither the current algorithm nor smoothing alone produces convergence. Batching 5 shots at constant C breaks the loop — the pump stays stable for 5 shots, producing truly comparable data, then the median update rejects outliers automatically.

Simulation results (Pumphouse Beach Entry @ grinder 11, 11 shots):
| Strategy | Updates | Final C | Distance from true mean (0.815) |
|----------|---------|---------|-------------------------------|
| Current (per-shot EMA α=0.3) | 11 | 0.839 | 0.024 |
| **Batched N=5, median, α=0.5** | **3** | **0.836** | **0.021** |

## Test plan
- [ ] Pull 5+ D-Flow shots with BLE scale — verify batch accumulation logs (`Auto flow cal: accumulated ideal ... (N/5)`)
- [ ] Verify C updates only after 5th shot with correct median/alpha in log
- [ ] Verify clearing calibration (MCP `clear_flow_calibration`) also clears pending batch
- [ ] Verify first calibration for a new profile uses median directly (no EMA blend)
- [ ] Monitor convergence per #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)