### PR TITLE
ble: verify profile upload frames via FrameToWrite ACKs

### DIFF
--- a/docs/CLAUDE_MD/BLE_PROTOCOL.md
+++ b/docs/CLAUDE_MD/BLE_PROTOCOL.md
@@ -48,6 +48,36 @@ Qt's `QLowEnergyController::disconnected()` signal only fires on a Connected→D
 
 Symptom if this is broken: DE1 reboot drops BLE, app attempts one reconnect, the attempt fails, then app stays silent forever until restarted. The Scan Devices button also appears dead because the `de1Discovered` handler's `!isConnecting()` guard never clears.
 
+### Profile Upload Frame-ACK Verification
+
+`DE1Device::uploadProfile()` and `uploadProfileAndStartEspresso()` don't just count write completions — they verify that each `FRAME_WRITE` ACK's leading byte (the `FrameToWrite` field) matches the sequence we queued, in order. Modeled on de1app's `confirm_de1_send_shot_frames_worked` in `de1_comms.tcl`.
+
+**Why:** Counting `characteristicWritten` signals alone can falsely report success when frames are silently dropped, reordered, or a stale profile remains loaded on the DE1 (e.g., if the original upload was never re-sent after a connection hiccup). Verifying the frame-number sequence surfaces these cases as real failures instead of mysterious early shot endings.
+
+**Tracked state (per in-flight upload):**
+- `m_uploadProfileTitle` — echoed into success/failure logs so operators can tell which profile the verdict refers to
+- `m_uploadExpectedFrameBytes` — leading byte of every frame we queued (regular: `0..N-1`, extension: `i+32`, tail: `N`)
+- `m_uploadSeenFrameBytes` — leading byte captured from each `FRAME_WRITE` ACK
+- `m_uploadHeaderAcked` / `m_uploadEspressoStartAcked` — one-shot flags
+- `m_uploadExpectEspressoStart` — set true by `uploadProfileAndStartEspresso()` so the tracker also waits for the `REQUESTED_STATE(Espresso)` ACK before calling the upload complete
+- `m_uploadConnection` — stored `QMetaObject::Connection` for the `writeComplete` listener so `finishProfileUpload()` can disconnect it deterministically
+- `m_uploadTimeoutTimer` — 10-second single-shot timer that surfaces stuck uploads as failures instead of hanging forever
+
+**Failure paths all emit `profileUploaded(false)` with a `qWarning()` whose reason text matches exactly what appears in the log:**
+- `frame sequence mismatch (expected vs seen byte list printed in hex)`
+- `timeout waiting for write ACKs`
+- `BLE disconnect during upload`
+- `command queue cleared during upload`
+- `superseded by a new upload`
+
+**Log format** (both paths emit via `.noquote()`, so the profile title appears without surrounding quotes; the failure message's own inline `"%3"` quoting of the title is preserved because it's part of the reason string):
+```
+DE1Device: profile upload verified — 5 frame(s) ACKed in order for profile D-Flow / Q
+DE1Device: profile upload FAILED — frame sequence mismatch (expected [0x00, 0x01, 0x02, 0x22, 0x03], got [0x00, 0x01, 0x02]). Profile "D-Flow / Q" was likely NOT correctly loaded on the DE1.
+```
+
+Regression coverage lives in `tests/tst_profileupload.cpp` (uses `MockTransport::ackAllWritesInOrder()` to simulate ACK sequences).
+
 ### Shot Debug Logging
 
 `ShotDebugLogger` captures all `qDebug()`/`qWarning()` messages during shots:

--- a/docs/CLAUDE_MD/TESTING.md
+++ b/docs/CLAUDE_MD/TESTING.md
@@ -208,6 +208,64 @@ Run this after any changes to `src/mcp/`, `src/controllers/profilemanager.cpp`, 
 3. If accessing private members, add `friend class tst_YourTest;` behind `#ifdef DECENZA_TESTING` in the production header
 4. Run `ctest` to verify
 
+## Handling Warnings
+
+**Every `qWarning()` emitted during a test run must either be fixed at the source or explicitly marked as expected.** A noisy test suite hides real regressions: once you get used to seeing 50 WARN lines in green output, the 51st one — which is actually a new bug — blends in. Treat warnings as failures-in-waiting.
+
+There are three legitimate outcomes for any warning fired during a test:
+
+### 1. It's the behaviour under test — mark it expected per-test
+
+Use `QTest::ignoreMessage()` at the top of the test function, **before** the action that triggers the warning. The test fails if the warning doesn't fire or if any other warning fires.
+
+```cpp
+void uploadFailsWhenFrameAckIsDropped() {
+    // ... setup ...
+
+    // The failure path emits a qWarning describing the mismatch — that's the
+    // behaviour we want to verify is still happening, so mark it as expected
+    // rather than letting it show up as noise.
+    QTest::ignoreMessage(QtWarningMsg,
+        QRegularExpression("profile upload FAILED — frame sequence mismatch"));
+
+    device.uploadProfile(makeSimpleProfile());
+    // ... rest of test ...
+}
+```
+
+Prefer `QRegularExpression` over exact-match strings so the test isn't brittle against formatting tweaks.
+
+### 2. It's a test-harness artifact across many tests — filter at fixture scope
+
+Use the `ScopedWarningFilter` RAII guard declared in `tests/mocks/McpTestFixture.h` for warnings that fire during fixture construction/destruction (e.g. `~DE1Device` surfacing an in-flight upload as failed when `MockTransport` never ACKed the writes). Declare the filter **before** the member whose destructor emits the warning so the filter outlives it:
+
+```cpp
+struct McpTestFixture {
+    // ... earlier members ...
+    // Declared before `device` so the filter outlives ~DE1Device.
+    ScopedWarningFilter uploadFilter{"profile upload FAILED — (BLE disconnect during upload|superseded by a new upload|command queue cleared during upload)"};
+    DE1Device device;
+    // ... later members ...
+};
+```
+
+Keep the regex **narrow** — list only the specific reasons that are expected. If the pattern is too broad, it will swallow genuinely unexpected warnings too. Add a comment explaining why each suppressed variant is expected.
+
+### 3. It's a real bug in the code or test — fix it
+
+Examples of "fix it" outcomes:
+- The code emits a warning for a state the test didn't intend to exercise → fix the test setup
+- The warning reveals a real race/order-of-operations bug in production code → fix the production code
+- The warning message is wrong or misleading → fix the log text
+
+When in doubt, fix it rather than suppress it. The goal of a passing test run is silence on stderr.
+
+### What not to do
+
+- **Do not globally suppress warnings** (e.g. a `qInstallMessageHandler` that drops everything at `QtWarningMsg`). That defeats the purpose.
+- **Do not suppress by substring-matching `"failed"` or `"error"`** — that's too broad and will hide genuine regressions.
+- **Do not amend an existing `ScopedWarningFilter` regex to make a new warning go away without adding a comment explaining the scenario.**
+
 ## Conventions
 
 - Test class names: `tst_FeatureName` (Qt convention)

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -11,6 +11,7 @@
 #include <QBluetoothAddress>
 #include <QDateTime>
 #include <QDebug>
+#include <QStringList>
 #include <chrono>
 #include <memory>
 
@@ -25,6 +26,14 @@ qint64 monotonicMsNow()
 DE1Device::DE1Device(QObject* parent)
     : QObject(parent)
 {
+    // 10 s is plenty: a full upload is header + ~5–10 frames, each a single
+    // write-with-response. If we pass this cap, the BLE link is almost
+    // certainly wedged and we should surface a failure rather than hang.
+    m_uploadTimeoutTimer.setSingleShot(true);
+    m_uploadTimeoutTimer.setInterval(10000);
+    connect(&m_uploadTimeoutTimer, &QTimer::timeout, this, [this]() {
+        finishProfileUpload(false, QStringLiteral("timeout waiting for write ACKs"));
+    });
 }
 
 DE1Device::~DE1Device() {
@@ -250,7 +259,12 @@ void DE1Device::connectToDevice(const QBluetoothDeviceInfo& device) {
 }
 
 void DE1Device::disconnect() {
-    m_profileUploadInProgress = false;
+    // Surface any in-flight profile upload as a failure before we tear down
+    // the transport — otherwise listeners (ProfileManager, QML) would never
+    // see a resolution for this attempt.
+    if (m_profileUploadInProgress) {
+        finishProfileUpload(false, QStringLiteral("BLE disconnect during upload"));
+    }
     m_sleepPendingAfterUpload = false;
     m_sawStopWritePending = false;
     m_lastSawTriggerMs = 0;
@@ -747,7 +761,9 @@ void DE1Device::wakeUp() {
 }
 
 void DE1Device::clearCommandQueue() {
-    m_profileUploadInProgress = false;
+    if (m_profileUploadInProgress) {
+        finishProfileUpload(false, QStringLiteral("command queue cleared during upload"));
+    }
     m_sleepPendingAfterUpload = false;
     m_sawStopWritePending = false;
     m_lastSawTriggerMs = 0;
@@ -766,41 +782,15 @@ void DE1Device::uploadProfile(const Profile& profile) {
 
     if (!m_transport) return;
 
-    m_profileUploadInProgress = true;
-
-    // Queue header write
-    QByteArray header = profile.toHeaderBytes();
-    m_transport->write(DE1::Characteristic::HEADER_WRITE, header);
-
-    // Queue each frame
+    // Attach the ACK listener BEFORE queuing writes so we observe every
+    // writeComplete for this upload.
     QList<QByteArray> frames = profile.toFrameBytes();
+    startProfileUploadTracking(profile.title(), frames, /*expectEspressoStart=*/false);
+
+    m_transport->write(DE1::Characteristic::HEADER_WRITE, profile.toHeaderBytes());
     for (const QByteArray& frame : frames) {
         m_transport->write(DE1::Characteristic::FRAME_WRITE, frame);
     }
-
-    // Track completion by counting writeComplete signals for profile-related UUIDs.
-    // Only count HEADER_WRITE and FRAME_WRITE completions to avoid interference
-    // from concurrent writes (e.g., MMR writes from other code paths).
-    qsizetype totalWrites = 1 + frames.size();  // header + frames
-    auto* counter = new qsizetype(0);
-    auto conn = std::make_shared<QMetaObject::Connection>();
-    *conn = connect(m_transport, &DE1Transport::writeComplete, this,
-        [this, totalWrites, counter, conn](const QBluetoothUuid& uuid, const QByteArray& /*data*/) {
-            if (uuid == DE1::Characteristic::HEADER_WRITE || uuid == DE1::Characteristic::FRAME_WRITE) {
-                (*counter)++;
-                if (*counter >= totalWrites) {
-                    QObject::disconnect(*conn);
-                    delete counter;
-                    m_profileUploadInProgress = false;
-                    emit profileUploaded(true);
-                    if (m_sleepPendingAfterUpload) {
-                        m_sleepPendingAfterUpload = false;
-                        qDebug() << "DE1Device: Profile upload complete, now sending deferred sleep";
-                        goToSleep();
-                    }
-                }
-            }
-        });
 }
 
 void DE1Device::uploadProfileAndStartEspresso(const Profile& profile) {
@@ -812,46 +802,170 @@ void DE1Device::uploadProfileAndStartEspresso(const Profile& profile) {
 
     if (!m_transport) return;
 
-    m_profileUploadInProgress = true;
-
-    // Queue header write
-    QByteArray header = profile.toHeaderBytes();
-    m_transport->write(DE1::Characteristic::HEADER_WRITE, header);
-
-    // Queue each frame
     QList<QByteArray> frames = profile.toFrameBytes();
+    startProfileUploadTracking(profile.title(), frames, /*expectEspressoStart=*/true);
+
+    m_transport->write(DE1::Characteristic::HEADER_WRITE, profile.toHeaderBytes());
     for (const QByteArray& frame : frames) {
         m_transport->write(DE1::Characteristic::FRAME_WRITE, frame);
     }
-
     // Queue espresso start AFTER all profile frames
     m_transport->write(DE1::Characteristic::REQUESTED_STATE,
                        QByteArray(1, static_cast<char>(DE1::State::Espresso)));
+}
 
-    // Track completion: header + frames + espresso start command.
-    // Count only profile-related UUIDs and the REQUESTED_STATE for espresso start.
-    qsizetype totalWrites = 1 + frames.size() + 1;
-    auto* counter = new qsizetype(0);
-    auto conn = std::make_shared<QMetaObject::Connection>();
-    *conn = connect(m_transport, &DE1Transport::writeComplete, this,
-        [this, totalWrites, counter, conn](const QBluetoothUuid& uuid, const QByteArray& /*data*/) {
-            if (uuid == DE1::Characteristic::HEADER_WRITE ||
-                uuid == DE1::Characteristic::FRAME_WRITE ||
-                uuid == DE1::Characteristic::REQUESTED_STATE) {
-                (*counter)++;
-                if (*counter >= totalWrites) {
-                    QObject::disconnect(*conn);
-                    delete counter;
-                    m_profileUploadInProgress = false;
-                    emit profileUploaded(true);
-                    if (m_sleepPendingAfterUpload) {
-                        m_sleepPendingAfterUpload = false;
-                        qDebug() << "DE1Device: Profile upload complete, now sending deferred sleep";
-                        goToSleep();
-                    }
-                }
+// -- Profile upload frame-ACK verification --
+//
+// The DE1's write-with-response ACK for FRAME_WRITE echoes the leading byte
+// (FrameToWrite) of the frame that was accepted. de1app uses that echo to
+// verify frames were not silently dropped or reordered — see
+// confirm_de1_send_shot_frames_worked in de1app's de1_comms.tcl. We mirror
+// that here: record the expected leading bytes, collect them from each ACK,
+// and on completion verify the two lists match exactly.
+
+void DE1Device::startProfileUploadTracking(const QString& profileTitle,
+                                           const QList<QByteArray>& frames,
+                                           bool expectEspressoStart)
+{
+    // Cancel any still-in-flight tracker. This should be rare (the guard is
+    // primarily for defensive coding against callers that re-issue an upload
+    // before the previous one drained), but if it happens we want to surface
+    // the earlier attempt as a failure rather than silently drop it.
+    if (m_profileUploadInProgress) {
+        finishProfileUpload(false, QStringLiteral("superseded by a new upload"));
+    }
+
+    m_uploadProfileTitle = profileTitle;
+    m_uploadExpectedFrameBytes.clear();
+    m_uploadExpectedFrameBytes.reserve(frames.size());
+    for (const QByteArray& frame : frames) {
+        m_uploadExpectedFrameBytes.append(frame.isEmpty()
+                                              ? 0
+                                              : static_cast<uint8_t>(frame.at(0)));
+    }
+    m_uploadSeenFrameBytes.clear();
+    m_uploadSeenFrameBytes.reserve(frames.size());
+    m_uploadHeaderAcked = false;
+    m_uploadEspressoStartAcked = false;
+    m_uploadExpectEspressoStart = expectEspressoStart;
+
+    m_profileUploadInProgress = true;
+
+    m_uploadConnection = connect(m_transport, &DE1Transport::writeComplete, this,
+                                 &DE1Device::onProfileUploadWriteComplete);
+
+    m_uploadTimeoutTimer.start();
+}
+
+void DE1Device::onProfileUploadWriteComplete(const QBluetoothUuid& uuid,
+                                             const QByteArray& data)
+{
+    if (uuid == DE1::Characteristic::HEADER_WRITE) {
+        m_uploadHeaderAcked = true;
+    } else if (uuid == DE1::Characteristic::FRAME_WRITE) {
+        m_uploadSeenFrameBytes.append(data.isEmpty()
+                                          ? 0
+                                          : static_cast<uint8_t>(data.at(0)));
+    } else if (m_uploadExpectEspressoStart
+               && uuid == DE1::Characteristic::REQUESTED_STATE) {
+        // Only count the Espresso-start write; other REQUESTED_STATE writes
+        // (e.g. a concurrent sleep request) must not satisfy this slot.
+        if (data.size() == 1
+            && static_cast<uint8_t>(data.at(0))
+                   == static_cast<uint8_t>(DE1::State::Espresso)) {
+            m_uploadEspressoStartAcked = true;
+        }
+    } else {
+        return;  // Unrelated write (MMR, ShotSettings, etc.)
+    }
+
+    const bool allFrames =
+        m_uploadSeenFrameBytes.size() >= m_uploadExpectedFrameBytes.size();
+    const bool allRequired = m_uploadHeaderAcked && allFrames
+                             && (!m_uploadExpectEspressoStart
+                                 || m_uploadEspressoStartAcked);
+    if (!allRequired) return;
+
+    // All the writes we expected have been ACKed by the BLE stack — now
+    // verify the frame sequence came back in order.
+    bool sequenceMatches =
+        (m_uploadSeenFrameBytes.size() == m_uploadExpectedFrameBytes.size());
+    if (sequenceMatches) {
+        for (qsizetype i = 0; i < m_uploadExpectedFrameBytes.size(); ++i) {
+            if (m_uploadSeenFrameBytes[i] != m_uploadExpectedFrameBytes[i]) {
+                sequenceMatches = false;
+                break;
             }
-        });
+        }
+    }
+
+    if (!sequenceMatches) {
+        auto formatSeq = [](const QList<uint8_t>& seq) {
+            QStringList parts;
+            parts.reserve(seq.size());
+            for (uint8_t b : seq) {
+                parts.append(QString::asprintf("0x%02X", b));
+            }
+            return QStringLiteral("[") + parts.join(QStringLiteral(", "))
+                   + QStringLiteral("]");
+        };
+        finishProfileUpload(
+            false,
+            QStringLiteral(
+                "frame sequence mismatch (expected %1, got %2). Profile \"%3\" "
+                "was likely NOT correctly loaded on the DE1.")
+                .arg(formatSeq(m_uploadExpectedFrameBytes))
+                .arg(formatSeq(m_uploadSeenFrameBytes))
+                .arg(m_uploadProfileTitle));
+        return;
+    }
+
+    finishProfileUpload(true);
+}
+
+void DE1Device::finishProfileUpload(bool success, const QString& reason)
+{
+    if (!m_profileUploadInProgress) return;
+
+    m_uploadTimeoutTimer.stop();
+    if (m_uploadConnection) {
+        QObject::disconnect(m_uploadConnection);
+        m_uploadConnection = {};
+    }
+    m_profileUploadInProgress = false;
+
+    // Use .noquote() so QString reasons/titles land as plain text (no
+    // surrounding quotes), making the messages scannable in the debug log
+    // and stable for test-harness filters to match against.
+    if (success) {
+        qDebug().noquote() << QStringLiteral("DE1Device: profile upload verified — %1 frame(s) ACKed in order for profile %2")
+                                 .arg(m_uploadExpectedFrameBytes.size())
+                                 .arg(m_uploadProfileTitle);
+    } else {
+        qWarning().noquote() << QStringLiteral("DE1Device: profile upload FAILED — %1")
+                                    .arg(reason.isEmpty() ? QStringLiteral("unknown reason") : reason);
+    }
+
+    // Clear accumulated tracking state so a subsequent upload starts clean.
+    m_uploadExpectedFrameBytes.clear();
+    m_uploadSeenFrameBytes.clear();
+    m_uploadHeaderAcked = false;
+    m_uploadEspressoStartAcked = false;
+    m_uploadExpectEspressoStart = false;
+    m_uploadProfileTitle.clear();
+
+    emit profileUploaded(success);
+
+    // Deferred sleep only applies on a successful upload; on failure we drop
+    // the pending sleep instead of trying to put a DE1 to sleep whose profile
+    // state we can't vouch for. The caller can re-issue goToSleep() if needed.
+    if (m_sleepPendingAfterUpload) {
+        m_sleepPendingAfterUpload = false;
+        if (success) {
+            qDebug() << "DE1Device: Profile upload complete, now sending deferred sleep";
+            goToSleep();
+        }
+    }
 }
 
 void DE1Device::writeHeader(const QByteArray& headerData) {

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -3,7 +3,11 @@
 #include <QObject>
 #include <QBluetoothDeviceInfo>
 #include <QBluetoothUuid>
+#include <QByteArray>
 #include <QEvent>
+#include <QList>
+#include <QString>
+#include <QTimer>
 
 #include "protocol/de1characteristics.h"
 
@@ -232,6 +236,17 @@ private:
 
     void sendInitialSettings();
 
+    // Profile upload tracking (frame-ACK verification, modeled on de1app's
+    // confirm_de1_send_shot_frames_worked). startProfileUploadTracking() must
+    // be called BEFORE queuing the header/frame writes so the listener is
+    // attached in time to observe every writeComplete.
+    void startProfileUploadTracking(const QString& profileTitle,
+                                    const QList<QByteArray>& frames,
+                                    bool expectEspressoStart);
+    void onProfileUploadWriteComplete(const QBluetoothUuid& uuid,
+                                      const QByteArray& data);
+    void finishProfileUpload(bool success, const QString& reason = QString());
+
     // Owned when created internally via connectToDevice(); set externally via setTransport() for USB
     DE1Transport* m_transport = nullptr;
     bool m_ownsTransport = false;  // True when DE1Device created the transport (connectToDevice)
@@ -265,6 +280,20 @@ private:
     Settings* m_settings = nullptr;       // For water level calibration persistence
     bool m_profileUploadInProgress = false;  // True while profile header+frames are being sent
     bool m_sleepPendingAfterUpload = false;  // Sleep requested during profile upload
+
+    // Frame-ACK verification state for the in-flight profile upload (cleared
+    // by finishProfileUpload()). m_uploadExpectedFrameBytes is the leading
+    // byte of every frame we queued to FRAME_WRITE, in queue order; each
+    // FRAME_WRITE ACK appends its leading byte to m_uploadSeenFrameBytes, and
+    // we compare the two sequences when all expected ACKs have arrived.
+    QString m_uploadProfileTitle;
+    QList<uint8_t> m_uploadExpectedFrameBytes;
+    QList<uint8_t> m_uploadSeenFrameBytes;
+    bool m_uploadHeaderAcked = false;
+    bool m_uploadEspressoStartAcked = false;
+    bool m_uploadExpectEspressoStart = false;
+    QMetaObject::Connection m_uploadConnection;
+    QTimer m_uploadTimeoutTimer;
     bool m_usbChargerOn = true;  // Default on (safe default like de1app)
     bool m_isHeadless = false;   // True if app can start operations (GHC not installed or inactive)
     int m_refillKitDetected = -1;  // -1=unknown, 0=not detected, 1=detected

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,18 @@ add_decenza_test(tst_shotsettings
     ${SIMULATOR_SOURCES}
 )
 
+# --- tst_profileupload: Profile upload frame-ACK verification ---
+add_decenza_test(tst_profileupload
+    tst_profileupload.cpp
+    mocks/MockTransport.h
+    ${CMAKE_SOURCE_DIR}/src/ble/de1transport.h
+    ${BLE_SOURCES}
+    ${PROFILE_SOURCES}
+    ${CORE_SOURCES}
+    ${CONTROLLER_SOURCES}
+    ${SIMULATOR_SOURCES}
+)
+
 # --- tst_blefidelity: BLE encode round-trip for all built-in profiles ---
 add_decenza_test(tst_blefidelity
     tst_blefidelity.cpp

--- a/tests/mocks/McpTestFixture.h
+++ b/tests/mocks/McpTestFixture.h
@@ -56,6 +56,20 @@ struct McpTestFixture {
     QTemporaryDir tempDir;   // isolated profile storage
     Settings settings;
     MockTransport transport;
+    // Profile upload verification (DE1Device::finishProfileUpload) emits qWarning
+    // when an upload doesn't complete cleanly. In tests, MockTransport never ACKs
+    // writes, so every uploadProfile() call that's followed by fixture teardown
+    // (BLE disconnect — fires from ~DE1Device), a rapid second uploadProfile()
+    // (supersede), or an explicit clearCommandQueue() ends up as a "FAILED"
+    // verdict. These are expected test-harness artifacts, not real failures —
+    // silence them. Unexpected reasons (frame sequence mismatch, ACK timeout)
+    // are intentionally NOT suppressed so they still surface if a test exposes
+    // one. tst_profileupload.cpp exercises the verification path directly and
+    // doesn't use this fixture, so its assertions are unaffected.
+    //
+    // Declared before `device` so the filter outlives ~DE1Device (members are
+    // destroyed in reverse declaration order).
+    ScopedWarningFilter uploadFilter{"profile upload FAILED — (BLE disconnect during upload|superseded by a new upload|command queue cleared during upload)"};
     DE1Device device;
     MachineState machineState;
     // Suppress expected warnings during ProfileManager construction — test env has

--- a/tests/mocks/MockTransport.h
+++ b/tests/mocks/MockTransport.h
@@ -31,4 +31,14 @@ public:
     // Test helpers
     QByteArray lastWriteData() const { return writes.isEmpty() ? QByteArray() : writes.last().second; }
     void clearWrites() { writes.clear(); }
+
+    // Simulate the BLE stack ACKing every captured write in order, mirroring
+    // what BleTransport::onCharacteristicWritten does on the real device.
+    // Tests that need to simulate dropped, reordered, or partial ACKs should
+    // emit writeComplete() directly instead.
+    void ackAllWritesInOrder() {
+        for (const auto& w : writes) {
+            emit writeComplete(w.first, w.second);
+        }
+    }
 };

--- a/tests/tst_profileupload.cpp
+++ b/tests/tst_profileupload.cpp
@@ -1,0 +1,242 @@
+#include <QtTest>
+#include <QRegularExpression>
+#include <QSignalSpy>
+
+#include "ble/de1device.h"
+#include "ble/protocol/de1characteristics.h"
+#include "profile/profile.h"
+#include "profile/profileframe.h"
+#include "mocks/MockTransport.h"
+
+// Verifies DE1Device::uploadProfile()'s frame-ACK verification (modeled on
+// de1app's confirm_de1_send_shot_frames_worked). Regression test for the
+// "shot ended early, DE1 was running a stale/mismatched profile" bug where
+// the per-write counter said "success" but the frames hadn't actually landed
+// in the right order on the DE1. After this change, the profileUploaded()
+// signal carries a real verdict: true iff the FRAME_WRITE ACKs' leading
+// FrameToWrite bytes matched the sequence we queued, in order.
+
+class tst_ProfileUpload : public QObject {
+    Q_OBJECT
+
+private:
+    // Build a minimal frame-based profile with two steps — enough to exercise
+    // regular frames + tail frame without pulling in extension frames.
+    static Profile makeSimpleProfile() {
+        Profile p;
+        p.setTitle(QStringLiteral("test-profile"));
+        p.setMode(Profile::Mode::FrameBased);
+
+        QList<ProfileFrame> steps;
+
+        ProfileFrame fill;
+        fill.name = QStringLiteral("fill");
+        fill.pump = QStringLiteral("pressure");
+        fill.pressure = 4.0;
+        fill.flow = 6.0;
+        fill.temperature = 93.0;
+        fill.seconds = 8.0;
+        fill.volume = 60;
+        steps.append(fill);
+
+        ProfileFrame pour;
+        pour.name = QStringLiteral("pour");
+        pour.pump = QStringLiteral("flow");
+        pour.pressure = 9.0;
+        pour.flow = 2.0;
+        pour.temperature = 93.0;
+        pour.seconds = 30.0;
+        pour.volume = 100;
+        steps.append(pour);
+
+        p.setSteps(steps);
+        return p;
+    }
+
+private slots:
+
+    // ===== Happy path: all ACKs arrive, in order =====
+
+    void uploadSucceedsWhenAcksMatchQueueOrder() {
+        MockTransport transport;
+        DE1Device device;
+        device.setTransport(&transport);
+
+        QSignalSpy spy(&device, &DE1Device::profileUploaded);
+
+        Profile p = makeSimpleProfile();
+        device.uploadProfile(p);
+
+        // Sanity: 1 header + N frames (2 steps → 2 regular + 1 tail = 3 frames)
+        QCOMPARE(transport.writes.size(), 4);
+        QCOMPARE(transport.writes.first().first, DE1::Characteristic::HEADER_WRITE);
+        QCOMPARE(transport.writes.at(1).first, DE1::Characteristic::FRAME_WRITE);
+        QCOMPARE(transport.writes.at(2).first, DE1::Characteristic::FRAME_WRITE);
+        QCOMPARE(transport.writes.at(3).first, DE1::Characteristic::FRAME_WRITE);
+
+        // Replay ACKs in queue order and confirm the upload resolves as success.
+        transport.ackAllWritesInOrder();
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.takeFirst().at(0).toBool(), true);
+    }
+
+    // ===== Failure path: a frame ACK goes missing =====
+
+    void uploadFailsWhenFrameAckIsDropped() {
+        MockTransport transport;
+        DE1Device device;
+        device.setTransport(&transport);
+
+        QSignalSpy spy(&device, &DE1Device::profileUploaded);
+
+        // The failure path emits a qWarning describing the mismatch —
+        // that's the behaviour we want to verify is still happening, so mark
+        // it as expected rather than letting it show up as noise.
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("profile upload FAILED — frame sequence mismatch"));
+
+        device.uploadProfile(makeSimpleProfile());
+
+        // Ack the header, then emit the first frame's ACK three times in a
+        // row (never ACKing the later frames at all). The count satisfies
+        // the tracker (three FRAME_WRITE ACKs == three queued frames), but
+        // the observed sequence is [frame0, frame0, frame0] instead of the
+        // expected [frame0, frame1, tail], so the sequence check fires.
+        // In a well-behaved stack duplicate ACKs shouldn't happen, but it's
+        // the cheapest way to trip the sequence check without waiting out
+        // the 10-second timeout.
+        emit transport.writeComplete(DE1::Characteristic::HEADER_WRITE,
+                                     transport.writes.at(0).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(1).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(1).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(1).second);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.takeFirst().at(0).toBool(), false);
+    }
+
+    // ===== Failure path: frames ACKed out of order =====
+
+    void uploadFailsWhenFramesAckedOutOfOrder() {
+        MockTransport transport;
+        DE1Device device;
+        device.setTransport(&transport);
+
+        QSignalSpy spy(&device, &DE1Device::profileUploaded);
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("profile upload FAILED — frame sequence mismatch"));
+
+        device.uploadProfile(makeSimpleProfile());
+
+        // Header first, then frames in reversed order. Count matches, but the
+        // FrameToWrite bytes will arrive as [tail, frame1, frame0] instead of
+        // [frame0, frame1, tail] — the sequence check must catch this.
+        emit transport.writeComplete(DE1::Characteristic::HEADER_WRITE,
+                                     transport.writes.at(0).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(3).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(2).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(1).second);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.takeFirst().at(0).toBool(), false);
+    }
+
+    // ===== Unrelated writes don't satisfy the tracker =====
+
+    void unrelatedWritesDoNotCountTowardUploadCompletion() {
+        MockTransport transport;
+        DE1Device device;
+        device.setTransport(&transport);
+
+        QSignalSpy spy(&device, &DE1Device::profileUploaded);
+
+        device.uploadProfile(makeSimpleProfile());
+
+        // An MMR or ShotSettings write completing mid-upload must not bump
+        // the counter into a false "success" verdict.
+        emit transport.writeComplete(DE1::Characteristic::HEADER_WRITE,
+                                     transport.writes.at(0).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(1).second);
+        // Bogus unrelated write — should be ignored.
+        emit transport.writeComplete(DE1::Characteristic::SHOT_SETTINGS,
+                                     QByteArray(9, 0));
+
+        // No profileUploaded signal yet — upload still in flight.
+        QCOMPARE(spy.count(), 0);
+
+        // Now finish with the remaining legit ACKs.
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(2).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(3).second);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.takeFirst().at(0).toBool(), true);
+    }
+
+    // ===== Espresso-start variant: requires REQUESTED_STATE(Espresso) ACK =====
+
+    void uploadAndStartEspressoRequiresEspressoAck() {
+        MockTransport transport;
+        DE1Device device;
+        device.setTransport(&transport);
+
+        QSignalSpy spy(&device, &DE1Device::profileUploaded);
+
+        device.uploadProfileAndStartEspresso(makeSimpleProfile());
+
+        // 1 header + 3 frames + 1 requested-state = 5 writes
+        QCOMPARE(transport.writes.size(), 5);
+        QCOMPARE(transport.writes.last().first, DE1::Characteristic::REQUESTED_STATE);
+
+        // Ack everything except the espresso-start write. Upload must NOT
+        // resolve yet.
+        emit transport.writeComplete(DE1::Characteristic::HEADER_WRITE,
+                                     transport.writes.at(0).second);
+        for (qsizetype i = 1; i <= 3; ++i) {
+            emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                         transport.writes.at(i).second);
+        }
+        QCOMPARE(spy.count(), 0);
+
+        // Now ack the espresso-start write — upload resolves as success.
+        emit transport.writeComplete(DE1::Characteristic::REQUESTED_STATE,
+                                     transport.writes.at(4).second);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.takeFirst().at(0).toBool(), true);
+    }
+
+    // ===== Disconnect mid-upload surfaces a failure =====
+
+    void disconnectMidUploadReportsFailure() {
+        MockTransport transport;
+        DE1Device device;
+        device.setTransport(&transport);
+
+        QSignalSpy spy(&device, &DE1Device::profileUploaded);
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("profile upload FAILED — BLE disconnect during upload"));
+
+        device.uploadProfile(makeSimpleProfile());
+        // Ack header, then tear down — the listener must see a failure
+        // verdict rather than hanging indefinitely.
+        emit transport.writeComplete(DE1::Characteristic::HEADER_WRITE,
+                                     transport.writes.at(0).second);
+        device.disconnect();
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.takeFirst().at(0).toBool(), false);
+    }
+};
+
+QTEST_GUILESS_MAIN(tst_ProfileUpload)
+#include "tst_profileupload.moc"


### PR DESCRIPTION
## Summary
- `DE1Device::uploadProfile()` / `uploadProfileAndStartEspresso()` now verify each `FRAME_WRITE` ACK's leading byte against the expected `FrameToWrite` sequence, modelled on de1app's `confirm_de1_send_shot_frames_worked`
- On mismatch, timeout (10 s), disconnect mid-upload, or queue-clear mid-upload, the upload now surfaces as `profileUploaded(false)` with a `qWarning()` that includes expected vs seen frame numbers and the profile title
- Previous behaviour just counted `writeComplete` signals and trusted them — silently-dropped or reordered frames reported success anyway

## Why
Shot 850 ended after 6 s because the DE1 was running a stale single-frame 9-bar setpoint instead of the D-Flow / Q profile we'd uploaded 14 h earlier. The old count-only check said "upload succeeded" so the bug was invisible until the shot failed with no obvious cause. The new verification would have logged exactly what went wrong the moment it happened.

## What a mismatch looks like in the log
\`\`\`
DE1Device: profile upload FAILED — frame sequence mismatch (expected [0x00, 0x01, 0x02, 0x22, 0x03], got [0x00, 0x01, 0x02]). Profile "D-Flow / Q" was likely NOT correctly loaded on the DE1.
\`\`\`

A successful upload now logs:
\`\`\`
DE1Device: profile upload verified — 5 frame(s) ACKed in order for profile "D-Flow / Q"
\`\`\`

## Test plan
- [x] New \`tst_profileupload\` covers: happy path, dropped frame ACK, out-of-order ACKs, unrelated writes ignored, \`uploadProfileAndStartEspresso\` requiring the \`REQUESTED_STATE(Espresso)\` ACK, and disconnect mid-upload reports failure
- [ ] Build + \`ctest\` clean locally
- [ ] Pull a real shot on an actual DE1 and confirm the "upload verified" log line appears; confirm no regressions in normal shot flow

## Docs
- Updated \`docs/CLAUDE_MD/BLE_PROTOCOL.md\` with a new "Profile Upload Frame-ACK Verification" section (tracked state, failure paths, example log lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)