### PR TITLE
profile: auto-retry failed uploads, show dialog on exhaustion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -692,6 +692,7 @@ set(QML_FILES
     qml/components/SwipeableArea.qml
     qml/components/CrashReportDialog.qml
     qml/components/McpConfirmDialog.qml
+    qml/components/De1CommunicationErrorDialog.qml
     qml/components/ColoredIcon.qml
     qml/components/CrtOverlay.qml
     qml/components/CrtShaderEffect.qml

--- a/qml/components/De1CommunicationErrorDialog.qml
+++ b/qml/components/De1CommunicationErrorDialog.qml
@@ -1,0 +1,137 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Decenza
+
+// Shown when ProfileManager has exhausted its retry budget for BLE profile
+// uploads. Means a transient BLE issue (frame-ACK mismatch, write-ACK
+// timeout) didn't resolve on its own after 5 attempts spanning ~15 seconds,
+// and the DE1 almost certainly needs to be power-cycled.
+//
+// Bound to ProfileManager.de1CommunicationFailure. The single OK button
+// calls acknowledgeDe1CommunicationFailure() to clear the flag.
+Dialog {
+    id: root
+    anchors.centerIn: parent
+    width: Theme.dialogWidth + 2 * padding
+    modal: true
+    dim: true
+    padding: Theme.dialogPadding
+    closePolicy: Dialog.NoAutoClose
+
+    background: Rectangle {
+        color: Theme.surfaceColor
+        radius: Theme.cardRadius
+        border.width: 2
+        border.color: Theme.errorColor
+    }
+
+    onOpened: {
+        if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
+            AccessibilityManager.announce(
+                TranslationManager.translate("de1CommError.announce",
+                    "DE1 communication issue. The current profile could not be loaded. Please power-cycle the DE1 and reconnect."))
+        }
+    }
+
+    contentItem: ColumnLayout {
+        spacing: 0
+
+        // Header (icon + title)
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredHeight: Theme.scaled(50)
+            Layout.topMargin: Theme.scaled(10)
+
+            RowLayout {
+                anchors.left: parent.left
+                anchors.leftMargin: Theme.scaled(20)
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: Theme.scaled(12)
+
+                Rectangle {
+                    width: Theme.scaled(32)
+                    height: Theme.scaled(32)
+                    radius: Theme.scaled(16)
+                    color: Theme.errorColor
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "!"
+                        font.pixelSize: Theme.scaled(18)
+                        font.bold: true
+                        color: Theme.primaryContrastColor
+                        Accessible.ignored: true
+                    }
+                }
+
+                Text {
+                    text: TranslationManager.translate("de1CommError.title",
+                        "DE1 Communication Issue")
+                    font: Theme.titleFont
+                    color: Theme.textColor
+                    Accessible.ignored: true
+                }
+            }
+
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 1
+                color: Theme.borderColor
+            }
+        }
+
+        // Message body
+        Text {
+            text: TranslationManager.translate("de1CommError.body",
+                "The app couldn't load the current profile onto the DE1 after several attempts. " +
+                "This usually means the DE1 needs a quick power cycle.\n\n" +
+                "1. Turn the DE1 off at its back switch.\n" +
+                "2. Wait a few seconds.\n" +
+                "3. Turn it back on — Decenza will reconnect automatically.")
+            font: Theme.bodyFont
+            color: Theme.textColor
+            wrapMode: Text.Wrap
+            Layout.fillWidth: true
+            Layout.margins: Theme.scaled(20)
+            Accessible.ignored: true
+        }
+
+        // Single OK button
+        Item {
+            Layout.fillWidth: true
+            Layout.leftMargin: Theme.scaled(20)
+            Layout.rightMargin: Theme.scaled(20)
+            Layout.bottomMargin: Theme.scaled(20)
+            Layout.preferredHeight: Theme.scaled(50)
+
+            AccessibleButton {
+                anchors.right: parent.right
+                width: Theme.scaled(140)
+                height: Theme.scaled(50)
+                text: TranslationManager.translate("common.button.ok", "OK")
+                accessibleName: TranslationManager.translate("de1CommError.acknowledgeAccessible",
+                    "Acknowledge DE1 communication issue")
+                onClicked: {
+                    ProfileManager.acknowledgeDe1CommunicationFailure()
+                    root.close()
+                }
+                background: Rectangle {
+                    implicitHeight: Theme.scaled(50)
+                    radius: Theme.buttonRadius
+                    color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                }
+                contentItem: Text {
+                    text: parent.text
+                    font: Theme.bodyFont
+                    color: Theme.primaryContrastColor
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    Accessible.ignored: true
+                }
+            }
+        }
+    }
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1874,6 +1874,26 @@ ApplicationWindow {
         }
     }
 
+    // DE1 communication-failure dialog — shown when ProfileManager has
+    // exhausted its retry budget for BLE profile uploads. Opens/closes
+    // purely from ProfileManager.de1CommunicationFailure so there's no
+    // imperative showDialog()/hideDialog() coupling to maintain.
+    De1CommunicationErrorDialog {
+        id: de1CommunicationErrorDialog
+    }
+    Connections {
+        target: ProfileManager
+        function onDe1CommunicationFailureChanged() {
+            if (ProfileManager.de1CommunicationFailure) {
+                if (!de1CommunicationErrorDialog.visible)
+                    de1CommunicationErrorDialog.open()
+            } else {
+                if (de1CommunicationErrorDialog.visible)
+                    de1CommunicationErrorDialog.close()
+            }
+        }
+    }
+
     // MCP confirmation dialog — shown when an AI assistant triggers a machine start operation
     McpConfirmDialog {
         id: mcpConfirmDialog

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -95,6 +95,20 @@ void DE1Device::onTransportDisconnected() {
     m_lastSawTriggerMs = 0;
     m_lastSawWriteMs = 0;
 
+    // If an upload was in flight when the transport dropped, surface it as
+    // a non-retryable "BLE disconnect during upload" failure *now* rather
+    // than letting the 10 s m_uploadTimeoutTimer eventually fire with a
+    // "timeout waiting for write ACKs" reason. The timeout path is
+    // classified retryable, which would incorrectly bump ProfileManager's
+    // retry counter after the disconnect has already reset it — leading to
+    // the communication-failure dialog appearing after 4 post-reconnect
+    // failures instead of 5. The reconnect path (initialSettingsComplete
+    // -> applyAllSettings -> uploadCurrentProfile) re-uploads on its own,
+    // so we don't need to retry from here.
+    if (m_profileUploadInProgress) {
+        finishProfileUpload(false, QStringLiteral("BLE disconnect during upload"));
+    }
+
     m_connecting = false;
     emit connectingChanged();
     emit connectedChanged();
@@ -954,7 +968,7 @@ void DE1Device::finishProfileUpload(bool success, const QString& reason)
     m_uploadExpectEspressoStart = false;
     m_uploadProfileTitle.clear();
 
-    emit profileUploaded(success);
+    emit profileUploaded(success, reason);
 
     // Deferred sleep only applies on a successful upload; on failure we drop
     // the pending sleep instead of trying to put a DE1 to sleep whose profile

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -201,7 +201,12 @@ signals:
     void shotSampleReceived(const ShotSample& sample);
     void waterLevelChanged();
     void firmwareVersionChanged();
-    void profileUploaded(bool success);
+    // Emitted when a profile upload attempt completes. On failure, `reason`
+    // carries a short human-readable string explaining why (matching the text
+    // in the qWarning log line) so listeners can distinguish retryable
+    // transients (frame sequence mismatch, ACK timeout) from non-retryable
+    // events (supersede, queue clear, BLE disconnect). Empty on success.
+    void profileUploaded(bool success, const QString& reason = QString());
     void initialSettingsComplete();
     void errorOccurred(const QString& error);
     void simulationModeChanged();

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -50,6 +50,41 @@ static size_t captureBacktrace(void** buffer, size_t maxFrames) {
 }
 #endif
 
+// Auto-retry constants for failed profile uploads (see profilemanager.h for
+// the full design note). The backoff is 1s, 2s, 4s, 8s between the 4 retries,
+// then give up after the 5th total attempt and surface the communication
+// failure to the user. The cap of 8s keeps the total wall-clock before the
+// dialog shows down to ~15s of transient BLE trouble; past that, the DE1
+// very likely needs to be power-cycled.
+static constexpr int kUploadRetryBaseMs = 1000;
+static constexpr int kUploadRetryMaxMs = 8000;
+static constexpr int kMaxUploadRetryAttempts = 5;
+
+// Reasons returned by DE1Device::profileUploaded(false, reason) that should
+// NOT trigger an auto-retry. The rest (frame sequence mismatch, ACK timeout)
+// are treated as retryable.
+//
+// We use startsWith() rather than exact equality so DE1Device can include
+// variable details after a stable prefix — for example "frame sequence
+// mismatch (expected [0x00, 0x01], got [0x00, 0x00])" carries the hex
+// payload in the same string. The exact retryable/non-retryable prefix
+// text is locked down by tst_profileupload.cpp's `.at(1).toString()`
+// assertions, so any future rename of a reason string in
+// finishProfileUpload() will break those tests loudly before it can
+// silently flip classification here.
+static bool isRetryableUploadFailure(const QString& reason) {
+    // Superseded: a newer upload is already in flight — let it own the outcome.
+    if (reason.startsWith(QStringLiteral("superseded"))) return false;
+    // Queue cleared: a shot/steam/hot-water just started, clearing the queue
+    // intentionally. The next uploadCurrentProfile() will re-arm.
+    if (reason.startsWith(QStringLiteral("command queue cleared"))) return false;
+    // BLE disconnect: the reconnect path (initialSettingsComplete ->
+    // applyAllSettings -> uploadCurrentProfile) already re-uploads when the
+    // link comes back. Retrying on a timer would race with that.
+    if (reason.startsWith(QStringLiteral("BLE disconnect"))) return false;
+    return true;
+}
+
 
 ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                                MachineState* machineState,
@@ -76,6 +111,88 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                 phase == MachineState::Phase::Sleep || phase == MachineState::Phase::Heating) {
                 qDebug() << "Retrying pending profile upload now that phase is" << m_machineState->phaseString();
                 uploadCurrentProfile();
+            }
+        });
+    }
+
+    // Auto-retry on failed profile uploads. When DE1Device emits a failure
+    // with a retryable reason, arm m_profileUploadRetryTimer with exponential
+    // backoff (capped at 8s). After kMaxUploadRetryAttempts consecutive
+    // failures, give up and set m_de1CommunicationFailure so the UI surfaces
+    // a "power-cycle the DE1" dialog. Success — or any non-retryable reason
+    // like "superseded" — resets the counter.
+    m_profileUploadRetryTimer.setSingleShot(true);
+    connect(&m_profileUploadRetryTimer, &QTimer::timeout, this, [this]() {
+        qDebug() << "ProfileManager: retrying failed profile upload (attempt"
+                 << m_profileUploadRetryAttempts << "of" << kMaxUploadRetryAttempts
+                 << "— last failure:" << m_lastUploadFailureReason << ")";
+        uploadCurrentProfile();
+    });
+
+    if (m_device) {
+        connect(m_device, &DE1Device::profileUploaded, this,
+                [this](bool success, const QString& reason) {
+            if (success) {
+                // A successful upload clears all retry state. If a prior
+                // communication-failure dialog is still up, leave it — the
+                // user needs to explicitly acknowledge — but restore the
+                // ability to arm a fresh retry if this succeeding upload is
+                // followed by another failure.
+                m_profileUploadRetryTimer.stop();
+                m_profileUploadRetryAttempts = 0;
+                m_lastUploadFailureReason.clear();
+                return;
+            }
+            if (!isRetryableUploadFailure(reason)) {
+                // Not a retry condition — don't bump the counter. The
+                // existing m_profileUploadPending / phaseChanged machinery
+                // handles queue-clear and supersede cases on its own.
+                return;
+            }
+            m_lastUploadFailureReason = reason;
+            m_profileUploadRetryAttempts++;
+            if (m_profileUploadRetryAttempts >= kMaxUploadRetryAttempts) {
+                qWarning().noquote() << QStringLiteral(
+                    "ProfileManager: profile upload failed %1 consecutive times — "
+                    "giving up and asking the user to power-cycle the DE1. "
+                    "Last reason: %2")
+                    .arg(m_profileUploadRetryAttempts)
+                    .arg(m_lastUploadFailureReason);
+                m_profileUploadRetryTimer.stop();
+                if (!m_de1CommunicationFailure) {
+                    m_de1CommunicationFailure = true;
+                    emit de1CommunicationFailureChanged();
+                }
+                return;
+            }
+            // Exponential backoff capped at kUploadRetryMaxMs.
+            // attempts=1 -> 1000ms, 2 -> 2000ms, 3 -> 4000ms, 4 -> 8000ms.
+            const int shift = qMin(m_profileUploadRetryAttempts - 1, 20);
+            const int delayMs = qMin(kUploadRetryBaseMs * (1 << shift), kUploadRetryMaxMs);
+            qDebug().noquote() << QStringLiteral(
+                "ProfileManager: profile upload failed (%1); retrying in %2 ms "
+                "(attempt %3 of %4)")
+                .arg(reason)
+                .arg(delayMs)
+                .arg(m_profileUploadRetryAttempts)
+                .arg(kMaxUploadRetryAttempts);
+            m_profileUploadRetryTimer.start(delayMs);
+        });
+
+        // On BLE disconnect, stop retrying — the reconnect path
+        // (initialSettingsComplete -> applyAllSettings -> uploadCurrentProfile)
+        // will re-upload once the link is back, and that fresh upload should
+        // start from attempt 1.
+        connect(m_device, &DE1Device::connectedChanged, this, [this]() {
+            if (m_device && !m_device->isConnected()) {
+                if (m_profileUploadRetryTimer.isActive()
+                    || m_profileUploadRetryAttempts > 0) {
+                    qDebug() << "ProfileManager: resetting upload-retry state "
+                                "because DE1 disconnected";
+                    m_profileUploadRetryTimer.stop();
+                    m_profileUploadRetryAttempts = 0;
+                    m_lastUploadFailureReason.clear();
+                }
             }
         });
     }
@@ -796,6 +913,15 @@ void ProfileManager::loadProfile(const QString& profileName) {
     if (resolvedName.endsWith(QLatin1String(".json"), Qt::CaseInsensitive))
         resolvedName = resolvedName.chopped(5);
 
+    // User-initiated profile switch: reset any in-flight retry state so a
+    // stale retry from the previous profile doesn't count toward the new
+    // profile's attempt budget. We do NOT reset in uploadCurrentProfile()
+    // itself because the retry timer calls that function — resetting there
+    // would make kMaxUploadRetryAttempts unreachable.
+    m_profileUploadRetryTimer.stop();
+    m_profileUploadRetryAttempts = 0;
+    m_lastUploadFailureReason.clear();
+
     // Resolve profile name: could be title or filename (MQTT publishes titles)
 
     // First, check if it's a title (most common case from MQTT)
@@ -942,6 +1068,12 @@ bool ProfileManager::loadProfileFromJson(const QString& jsonContent) {
         qWarning() << "loadProfileFromJson: Empty JSON content";
         return false;
     }
+
+    // Fresh profile load = fresh retry budget (see loadProfile() for the
+    // full rationale).
+    m_profileUploadRetryTimer.stop();
+    m_profileUploadRetryAttempts = 0;
+    m_lastUploadFailureReason.clear();
 
     m_currentProfile = Profile::loadFromJsonString(jsonContent);
 
@@ -1206,6 +1338,21 @@ void ProfileManager::refreshProfiles() {
 
 
 // === Profile upload ===
+
+void ProfileManager::acknowledgeDe1CommunicationFailure() {
+    // The user dismissed the communication-failure dialog. Clear the flag
+    // (so the dialog goes away) and reset retry state so the next
+    // uploadCurrentProfile() starts from a clean attempt counter. We do NOT
+    // auto-trigger a new upload here; the user is expected to power-cycle
+    // the DE1, after which the normal reconnect path re-uploads.
+    if (m_de1CommunicationFailure) {
+        m_de1CommunicationFailure = false;
+        emit de1CommunicationFailureChanged();
+    }
+    m_profileUploadRetryTimer.stop();
+    m_profileUploadRetryAttempts = 0;
+    m_lastUploadFailureReason.clear();
+}
 
 void ProfileManager::uploadCurrentProfile() {
     // Guard: Don't upload profile during active operations - this corrupts the running shot!

--- a/src/controllers/profilemanager.h
+++ b/src/controllers/profilemanager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QTimer>
 #include <QVariantList>
 #include <QMap>
 #include "../profile/profile.h"
@@ -58,6 +59,12 @@ class ProfileManager : public QObject {
     Q_PROPERTY(QString currentEditorType READ currentEditorType NOTIFY currentProfileChanged)
     Q_PROPERTY(double profileTargetTemperature READ profileTargetTemperature NOTIFY currentProfileChanged)
     Q_PROPERTY(double profileTargetWeight READ profileTargetWeight NOTIFY currentProfileChanged)
+    // Set to true after kMaxUploadRetryAttempts consecutive profile uploads
+    // have failed with retryable reasons. qml/main.qml watches this property
+    // via a Connections handler (onDe1CommunicationFailureChanged) and calls
+    // open()/close() on De1CommunicationErrorDialog. The dialog's OK button
+    // calls acknowledgeDe1CommunicationFailure() to clear the flag.
+    Q_PROPERTY(bool de1CommunicationFailure READ de1CommunicationFailure NOTIFY de1CommunicationFailureChanged)
     Q_PROPERTY(bool profileHasRecommendedDose READ profileHasRecommendedDose NOTIFY currentProfileChanged)
     Q_PROPERTY(double profileRecommendedDose READ profileRecommendedDose NOTIFY currentProfileChanged)
     Q_PROPERTY(bool isCurrentProfileReadOnly READ isCurrentProfileReadOnly NOTIFY currentProfileChanged)
@@ -154,6 +161,10 @@ public slots:
     Q_INVOKABLE bool saveProfile(const QString& filename);
     Q_INVOKABLE bool saveProfileAs(const QString& filename, const QString& title);
 
+    // Communication-failure dialog support.
+    bool de1CommunicationFailure() const { return m_de1CommunicationFailure; }
+    Q_INVOKABLE void acknowledgeDe1CommunicationFailure();
+
 signals:
     void currentProfileChanged();
     void profileModifiedChanged();
@@ -168,6 +179,9 @@ signals:
     // Emitted when loadProfile() cannot find the requested profile file.
     // The UI should show an error and prompt the user to select another profile.
     void profileLoadFailed(const QString& filename);
+
+    // See Q_PROPERTY documentation above.
+    void de1CommunicationFailureChanged();
 
 private:
     void loadDefaultProfile();
@@ -197,6 +211,18 @@ private:
     bool m_profileModified = false;
     bool m_profileUploadPending = false;
     bool m_startupLoadDone = false;
+
+    // Auto-retry state for failed profile uploads. A failure with a retryable
+    // reason (frame sequence mismatch, ACK timeout) arms
+    // m_profileUploadRetryTimer with exponential backoff, capped per the
+    // constants in profilemanager.cpp. On success, disconnect, or
+    // supersede/queue-clear, the counter resets. After
+    // kMaxUploadRetryAttempts consecutive failures, m_de1CommunicationFailure
+    // flips to true so the UI can surface a "power-cycle the DE1" dialog.
+    QTimer m_profileUploadRetryTimer;
+    int m_profileUploadRetryAttempts = 0;
+    QString m_lastUploadFailureReason;
+    bool m_de1CommunicationFailure = false;
 
 #ifdef DECENZA_TESTING
     friend class tst_ProfileManager;

--- a/tests/mocks/MockTransport.h
+++ b/tests/mocks/MockTransport.h
@@ -6,8 +6,12 @@
 #include <QList>
 #include <QPair>
 
-// Mock transport that captures BLE writes instead of sending them.
-// Used by tst_shotsettings to verify exact wire format.
+// Mock transport that captures BLE writes instead of sending them. Shared
+// across the BLE-facing test suite: tst_shotsettings (wire format),
+// tst_profileupload (frame-ACK verification), tst_profilemanager (upload
+// retry state machine), tst_mcptools_* (MCP tool integration). Tests that
+// need to simulate ACKs can either call ackAllWritesInOrder() or emit
+// writeComplete() directly.
 
 class MockTransport : public DE1Transport {
     Q_OBJECT
@@ -17,6 +21,12 @@ public:
     // Captured writes
     QList<QPair<QBluetoothUuid, QByteArray>> writes;
 
+    // Simulated connection state. Default true so tests that never touch it
+    // behave as if the transport is always up (existing behaviour). Tests
+    // that exercise disconnect/reconnect flip it via setConnectedSim(), which
+    // also emits the matching DE1Transport::connected/disconnected signal.
+    bool m_connected = true;
+
     // DE1Transport interface
     void write(const QBluetoothUuid& uuid, const QByteArray& data) override {
         writes.append({uuid, data});
@@ -24,13 +34,27 @@ public:
     void read(const QBluetoothUuid&) override {}
     void subscribe(const QBluetoothUuid&) override {}
     void subscribeAll() override {}
-    void disconnect() override {}
-    bool isConnected() const override { return true; }
+    void disconnect() override {
+        if (m_connected) {
+            m_connected = false;
+            emit disconnected();
+        }
+    }
+    bool isConnected() const override { return m_connected; }
     QString transportName() const override { return QStringLiteral("Mock"); }
 
     // Test helpers
     QByteArray lastWriteData() const { return writes.isEmpty() ? QByteArray() : writes.last().second; }
     void clearWrites() { writes.clear(); }
+
+    // Flip simulated connection state and emit the matching transport signal.
+    // Used by tests that verify behaviour across a disconnect/reconnect cycle.
+    void setConnectedSim(bool newState) {
+        if (m_connected == newState) return;
+        m_connected = newState;
+        if (newState) emit connected();
+        else emit disconnected();
+    }
 
     // Simulate the BLE stack ACKing every captured write in order, mirroring
     // what BleTransport::onCharacteristicWritten does on the real device.

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -1773,6 +1773,251 @@ private slots:
         f.profileManager.createNewProfile("Advanced");
         QVERIFY(!f.profileManager.isCurrentProfileRecipe());
     }
+
+    // =========================================================================
+    // Auto-retry on failed profile uploads
+    // =========================================================================
+    //
+    // Covers the retry state machine added to ProfileManager: a failed
+    // DE1Device::profileUploaded(false, reason) signal arms
+    // m_profileUploadRetryTimer with exponential backoff (1s, 2s, 4s, 8s),
+    // gives up after 5 consecutive failures, and sets the
+    // de1CommunicationFailure flag so QML can surface the
+    // power-cycle-the-DE1 dialog. See profilemanager.cpp kMax*Retry constants.
+    //
+    // Tests drive the state machine by calling uploadCurrentProfile() (which
+    // emits the BLE writes through MockTransport) and then synthesising the
+    // failure outcome via `emit f.device.profileUploaded(false, reason)` —
+    // we don't need to plumb through the real DE1Device::finishProfileUpload
+    // path because it's exercised in tst_profileupload.
+    //
+    // The retry timer is inspected via friend access rather than waiting for
+    // real elapsed time (which would be 15s of dead air to exercise all 4
+    // retries).
+
+    void failedUploadWithRetryableReasonArmsTimer() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        QVERIFY(!f.profileManager.m_profileUploadRetryTimer.isActive());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
+
+        f.profileManager.uploadCurrentProfile();
+
+        // First failure with a retryable reason.
+        emit f.device.profileUploaded(false,
+            QStringLiteral("frame sequence mismatch (expected [0x00], got [0x01])"));
+
+        QVERIFY(f.profileManager.m_profileUploadRetryTimer.isActive());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 1);
+        QCOMPARE(f.profileManager.m_profileUploadRetryTimer.interval(), 1000);
+        QVERIFY(!f.profileManager.de1CommunicationFailure());
+    }
+
+    void retryBacksOffExponentiallyCappedAt8s() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        const QString reason =
+            QStringLiteral("timeout waiting for write ACKs");
+
+        // Attempts 1..4 arm the timer with delays 1s, 2s, 4s, 8s.
+        const int expectedDelays[4] = {1000, 2000, 4000, 8000};
+        for (int i = 0; i < 4; ++i) {
+            emit f.device.profileUploaded(false, reason);
+            QVERIFY2(f.profileManager.m_profileUploadRetryTimer.isActive(),
+                qPrintable(QString("timer must be armed after failure %1").arg(i + 1)));
+            QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, i + 1);
+            QCOMPARE(f.profileManager.m_profileUploadRetryTimer.interval(), expectedDelays[i]);
+        }
+    }
+
+    void retryResetsOnSuccess() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        emit f.device.profileUploaded(false,
+            QStringLiteral("frame sequence mismatch (expected [0x00], got [0x01])"));
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 1);
+        QVERIFY(f.profileManager.m_profileUploadRetryTimer.isActive());
+
+        emit f.device.profileUploaded(true, QString());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
+        QVERIFY(!f.profileManager.m_profileUploadRetryTimer.isActive());
+        QVERIFY(f.profileManager.m_lastUploadFailureReason.isEmpty());
+    }
+
+    void fiveConsecutiveFailuresSetCommunicationFailureFlag() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        // The 5th failure logs a qWarning — expected in this test.
+        ScopedWarningFilter filter(
+            "profile upload failed .* consecutive times");
+        f.profileManager.uploadCurrentProfile();
+
+        QSignalSpy flagSpy(&f.profileManager,
+            &ProfileManager::de1CommunicationFailureChanged);
+
+        const QString reason = QStringLiteral("timeout waiting for write ACKs");
+        for (int i = 0; i < 5; ++i) {
+            emit f.device.profileUploaded(false, reason);
+        }
+
+        QVERIFY2(f.profileManager.de1CommunicationFailure(),
+            "de1CommunicationFailure must flip true after 5 retryable failures");
+        QCOMPARE(flagSpy.count(), 1);
+        // Timer must NOT still be running — there's no retry #6.
+        QVERIFY(!f.profileManager.m_profileUploadRetryTimer.isActive());
+    }
+
+    void acknowledgeClearsCommunicationFailureAndResetsRetry() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        ScopedWarningFilter filter(
+            "profile upload failed .* consecutive times");
+        f.profileManager.uploadCurrentProfile();
+
+        const QString reason = QStringLiteral("timeout waiting for write ACKs");
+        for (int i = 0; i < 5; ++i) {
+            emit f.device.profileUploaded(false, reason);
+        }
+        QVERIFY(f.profileManager.de1CommunicationFailure());
+
+        QSignalSpy flagSpy(&f.profileManager,
+            &ProfileManager::de1CommunicationFailureChanged);
+        f.profileManager.acknowledgeDe1CommunicationFailure();
+
+        QVERIFY(!f.profileManager.de1CommunicationFailure());
+        QCOMPARE(flagSpy.count(), 1);
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
+        QVERIFY(f.profileManager.m_lastUploadFailureReason.isEmpty());
+    }
+
+    void supersededFailureDoesNotArmRetry() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        emit f.device.profileUploaded(false,
+            QStringLiteral("superseded by a new upload"));
+
+        QVERIFY(!f.profileManager.m_profileUploadRetryTimer.isActive());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
+    }
+
+    void bleDisconnectFailureDoesNotArmRetry() {
+        // The reconnect path (initialSettingsComplete -> applyAllSettings ->
+        // uploadCurrentProfile) handles this; the retry timer must not race
+        // with it.
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        emit f.device.profileUploaded(false,
+            QStringLiteral("BLE disconnect during upload"));
+
+        QVERIFY(!f.profileManager.m_profileUploadRetryTimer.isActive());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
+    }
+
+    void queueClearFailureDoesNotArmRetry() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        emit f.device.profileUploaded(false,
+            QStringLiteral("command queue cleared during upload"));
+
+        QVERIFY(!f.profileManager.m_profileUploadRetryTimer.isActive());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
+    }
+
+    void transportDisconnectResetsRetryState() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        // Arm the retry via a retryable failure.
+        emit f.device.profileUploaded(false,
+            QStringLiteral("timeout waiting for write ACKs"));
+        QVERIFY(f.profileManager.m_profileUploadRetryTimer.isActive());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 1);
+
+        // Simulate the transport dropping — DE1Device::onTransportDisconnected
+        // fires, which emits connectedChanged. ProfileManager's handler must
+        // clear the retry state so the reconnect path starts from attempt 0.
+        f.transport.setConnectedSim(false);
+
+        QVERIFY(!f.profileManager.m_profileUploadRetryTimer.isActive());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
+    }
+
+    void loadProfileResetsRetryState() {
+        McpTestFixture f;
+        loadDFlowProfile(f, "First");
+
+        f.profileManager.uploadCurrentProfile();
+        emit f.device.profileUploaded(false,
+            QStringLiteral("timeout waiting for write ACKs"));
+        QVERIFY(f.profileManager.m_profileUploadRetryTimer.isActive());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 1);
+
+        // User switches profiles — attempt counter must reset so the new
+        // profile gets its own fresh 5-attempt budget.
+        loadDFlowProfile(f, "Second");
+
+        QVERIFY(!f.profileManager.m_profileUploadRetryTimer.isActive());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
+    }
+
+    void retryTimerFiringDuringActivePhaseDefersToPendingFlag() {
+        // If the retry timer fires while the machine is in an active phase
+        // (shot in progress), uploadCurrentProfile() hits the active-phase
+        // guard, sets m_profileUploadPending = true, and returns without
+        // attempting a BLE write. The phaseChanged handler must resume the
+        // upload once the phase becomes Idle/Ready — and the retry counter
+        // must stay intact so the 5-attempt budget carries across the
+        // active-phase gap.
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        ScopedWarningFilter filter("BLOCKED during active phase|^  #");
+
+        // Prime: one retryable failure arms the retry timer and sets
+        // attempts=1.
+        f.profileManager.uploadCurrentProfile();
+        emit f.device.profileUploaded(false,
+            QStringLiteral("timeout waiting for write ACKs"));
+        QVERIFY(f.profileManager.m_profileUploadRetryTimer.isActive());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 1);
+
+        // Simulate the machine entering an active phase, then directly
+        // invoke the retry timer's uploadCurrentProfile() call (rather than
+        // waiting 1000 ms of real time).
+        f.machineState.m_phase = MachineState::Phase::Pouring;
+        f.transport.clearWrites();
+        f.profileManager.uploadCurrentProfile();
+
+        // The attempt was blocked: no BLE writes, pending flag set,
+        // retry counter unchanged (blocked attempts don't consume budget).
+        QVERIFY2(f.writesTo(HEADER_WRITE).isEmpty(),
+            "Blocked attempt must not write profile header to BLE");
+        QVERIFY(f.profileManager.m_profileUploadPending);
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 1);
+
+        // Phase returns to Idle — the pending handler resumes the upload.
+        f.machineState.m_phase = MachineState::Phase::Idle;
+        emit f.machineState.phaseChanged();
+
+        QVERIFY2(!f.writesTo(HEADER_WRITE).isEmpty(),
+            "phaseChanged must resume the pending upload");
+        QVERIFY(!f.profileManager.m_profileUploadPending);
+
+        // If the resumed upload now succeeds, the retry state resets cleanly.
+        emit f.device.profileUploaded(true, QString());
+        QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
+        QVERIFY(!f.profileManager.m_profileUploadRetryTimer.isActive());
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_ProfileManager)

--- a/tests/tst_profileupload.cpp
+++ b/tests/tst_profileupload.cpp
@@ -115,7 +115,12 @@ private slots:
                                      transport.writes.at(1).second);
 
         QCOMPARE(spy.count(), 1);
-        QCOMPARE(spy.takeFirst().at(0).toBool(), false);
+        auto args = spy.takeFirst();
+        QCOMPARE(args.at(0).toBool(), false);
+        // The reason argument (index 1) carries the same text the qWarning
+        // logs. Listeners (e.g. ProfileManager's retry loop) pattern-match on
+        // it to decide whether to retry — lock it down.
+        QVERIFY(args.at(1).toString().startsWith("frame sequence mismatch"));
     }
 
     // ===== Failure path: frames ACKed out of order =====
@@ -145,7 +150,9 @@ private slots:
                                      transport.writes.at(1).second);
 
         QCOMPARE(spy.count(), 1);
-        QCOMPARE(spy.takeFirst().at(0).toBool(), false);
+        auto args = spy.takeFirst();
+        QCOMPARE(args.at(0).toBool(), false);
+        QVERIFY(args.at(1).toString().startsWith("frame sequence mismatch"));
     }
 
     // ===== Unrelated writes don't satisfy the tracker =====
@@ -234,7 +241,44 @@ private slots:
         device.disconnect();
 
         QCOMPARE(spy.count(), 1);
-        QCOMPARE(spy.takeFirst().at(0).toBool(), false);
+        auto args = spy.takeFirst();
+        QCOMPARE(args.at(0).toBool(), false);
+        QCOMPARE(args.at(1).toString(), QStringLiteral("BLE disconnect during upload"));
+    }
+
+    // ===== Unexpected transport drop surfaces the same non-retryable reason =====
+
+    void unexpectedTransportDropReportsBleDisconnect() {
+        // Unlike disconnectMidUploadReportsFailure() (which drives the
+        // app-initiated DE1Device::disconnect() path), this test simulates
+        // the transport layer firing disconnected() on its own — e.g. the
+        // DE1 powered off, or BLE link-loss. DE1Device::onTransportDisconnected
+        // must finish the in-flight upload with the "BLE disconnect during
+        // upload" reason so it's classified non-retryable. Without this,
+        // the 10-second upload-timeout timer would eventually fire with
+        // "timeout waiting for write ACKs" (retryable) and poison any
+        // downstream retry counter across the reconnect.
+        MockTransport transport;
+        DE1Device device;
+        device.setTransport(&transport);
+
+        QSignalSpy spy(&device, &DE1Device::profileUploaded);
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("profile upload FAILED — BLE disconnect during upload"));
+
+        device.uploadProfile(makeSimpleProfile());
+        // Ack header to get the tracker past its first write, then simulate
+        // the transport going away. Note this bypasses DE1Device::disconnect
+        // and only fires DE1Transport::disconnected, which is the path
+        // that onTransportDisconnected handles.
+        emit transport.writeComplete(DE1::Characteristic::HEADER_WRITE,
+                                     transport.writes.at(0).second);
+        transport.setConnectedSim(false);
+
+        QCOMPARE(spy.count(), 1);
+        auto args = spy.takeFirst();
+        QCOMPARE(args.at(0).toBool(), false);
+        QCOMPARE(args.at(1).toString(), QStringLiteral("BLE disconnect during upload"));
     }
 };
 


### PR DESCRIPTION
## Summary

Stacks on top of #744. When a BLE profile upload fails with a transient reason (frame-ACK mismatch, write-ACK timeout), ProfileManager now auto-retries with exponential backoff (1s, 2s, 4s, 8s) up to 5 total attempts. If all 5 fail, a new \`de1CommunicationFailure\` Q_PROPERTY flips true and QML shows a dialog asking the user to power-cycle the DE1.

Motivation: most users trigger shots via the GHC hardware button, which bypasses the app entirely. If the initial BLE profile upload silently failed at startup, every subsequent shot would use a stale/missing profile — wasted coffee until the user noticed. Before #744, those failures were invisible (the old counter-based check lied about success); #744 made them visible in the debug log; this PR makes the app self-heal for transient issues and surface the rest to the user.

## Design highlights

- **Retryable reasons**: \`frame sequence mismatch\`, \`timeout waiting for write ACKs\`
- **Non-retryable reasons** (and why):
  - \`superseded by a new upload\` — newer upload in flight
  - \`command queue cleared during upload\` — intentional teardown (shot/steam started)
  - \`BLE disconnect during upload\` — the \`initialSettingsComplete\` → \`applyAllSettings\` → \`uploadCurrentProfile\` chain already re-uploads on reconnect; the timer would race with it
- **Reset points**: success, BLE disconnect, \`loadProfile\` / \`loadProfileFromJson\` (user profile switch), \`acknowledgeDe1CommunicationFailure\` (user OK'd dialog). **Not** at the top of \`uploadCurrentProfile\` — the retry timer calls that function, so resetting there would make the 5-attempt cap unreachable.
- Signal signature change: \`DE1Device::profileUploaded(bool)\` → \`profileUploaded(bool success, const QString& reason)\`. Only listeners today are QSignalSpy in tests; confirmed safe.

## Files

| File | What changed |
|------|-------------|
| \`src/ble/de1device.h\` / \`.cpp\` | Signal gets \`reason\` param; emit passes \`reason\` through |
| \`src/controllers/profilemanager.h\` | New \`QTimer m_profileUploadRetryTimer\`, attempt counter, \`de1CommunicationFailure\` Q_PROPERTY + signal + invokable acknowledgement |
| \`src/controllers/profilemanager.cpp\` | Constructor wires the \`profileUploaded\` / \`connectedChanged\` / timer handlers; \`loadProfile\` / \`loadProfileFromJson\` / \`acknowledgeDe1CommunicationFailure\` reset retry state |
| \`qml/components/De1CommunicationErrorDialog.qml\` (NEW) | Modelled on \`McpConfirmDialog.qml\`; single OK button |
| \`qml/main.qml\` | Instantiate dialog, bind open/close to \`ProfileManager.de1CommunicationFailure\` |
| \`CMakeLists.txt\` | Register new QML file |
| \`tests/mocks/MockTransport.h\` | New \`setConnectedSim()\` test helper — needed to drive transport disconnect in the retry-reset test |
| \`tests/tst_profilemanager.cpp\` | 9 new cases covering the full retry state machine |
| \`tests/tst_profileupload.cpp\` | Verify the reason string on failure paths |

## Test plan

- [x] \`ctest -R tst_profilemanager\` — 9 new cases
- [x] \`ctest -R tst_profileupload\` — extended signal signature
- [ ] Manual: force a bad upload (yank BLE mid-header); confirm retry logs show attempt counter and backoff intervals; confirm 5 failures trigger the dialog
- [ ] Manual GHC workflow: upload fails, ~15s silence, dialog appears, user power-cycles, next shot uses correct profile
- [ ] Verify dialog i18n wiring with \`TranslationManager.translate()\` and English fallbacks

## Explicit non-goals (follow-up work)

- Spinner/banner during the 15-second retry window (failures are silent to the user; only exhaustion is surfaced)
- Routing app-initiated \`startEspresso\` through \`uploadProfileAndStartEspresso\` — touches every start-espresso call site, deserves its own PR
- Translation keys — add with the rest of the i18n pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)