### PR TITLE
profile: surface upload retry state in UI; abort shot during retry

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -2749,6 +2749,73 @@ ApplicationWindow {
         }
     }
 
+    // ============ PROFILE UPLOAD RETRY TOAST ============
+    // Reconnecting… toast shown while ProfileManager is retrying a failed
+    // profile upload. Bound reactively to ProfileManager.profileUploadRetrying
+    // so it appears within one frame of the first retry arming and clears
+    // immediately on success or when the communication-failure dialog takes
+    // over.
+    Tr { id: trReconnectingToast; key: "main.toast.reconnecting"; fallback: "Reconnecting…"; visible: false }
+    Tr { id: trShotStoppedReloading; key: "main.toast.shotStoppedReloading"; fallback: "Shot stopped while profile reloads…"; visible: false }
+
+    // Latched true when ProfileManager aborts a shot during the retry window;
+    // cleared when the retry state clears (success or exhaustion). Drives the
+    // toast text so the user knows *why* the shot stopped, not just that
+    // something is retrying.
+    property bool shotStoppedForProfileRetry: false
+
+    Rectangle {
+        id: reconnectingToast
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Theme.scaled(40)
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: reconnectingToastLabel.implicitWidth + Theme.scaled(32)
+        height: reconnectingToastLabel.implicitHeight + Theme.scaled(16)
+        radius: Theme.cardRadius
+        color: Theme.surfaceColor
+        opacity: (ProfileManager.profileUploadRetrying
+                  && !ProfileManager.de1CommunicationFailure) ? 1 : 0
+        visible: opacity > 0
+        z: 600
+        Accessible.ignored: true
+
+        Behavior on opacity {
+            NumberAnimation { duration: 300 }
+        }
+
+        Text {
+            id: reconnectingToastLabel
+            anchors.centerIn: parent
+            text: root.shotStoppedForProfileRetry
+                  ? trShotStoppedReloading.text
+                  : trReconnectingToast.text
+            color: Theme.textColor
+            font.pixelSize: Theme.scaled(13)
+            Accessible.ignored: true
+        }
+    }
+
+    Connections {
+        target: ProfileManager
+        function onProfileUploadRetryingChanged() {
+            if (ProfileManager.profileUploadRetrying) {
+                if (AccessibilityManager.enabled) {
+                    AccessibilityManager.announce(reconnectingToastLabel.text)
+                }
+            } else {
+                // Retry window closed (either succeeded or exhausted) —
+                // reset the shot-stopped message for next time.
+                root.shotStoppedForProfileRetry = false
+            }
+        }
+        function onShotAbortedProfileUploadRetrying() {
+            root.shotStoppedForProfileRetry = true
+            if (AccessibilityManager.enabled) {
+                AccessibilityManager.announce(trShotStoppedReloading.text, true)
+            }
+        }
+    }
+
     // ============ AUTO FLOW CALIBRATION TOAST ============
     property string flowCalToastText: ""
 

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -126,6 +126,10 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
         qDebug() << "ProfileManager: retrying failed profile upload (attempt"
                  << m_profileUploadRetryAttempts << "of" << kMaxUploadRetryAttempts
                  << "— last failure:" << m_lastUploadFailureReason << ")";
+        // Timer is no longer active (it's firing) — the retry indicator
+        // should clear for this instant and re-arm only if the retry also
+        // fails with a retryable reason.
+        updateProfileUploadRetrying();
         uploadCurrentProfile();
     });
 
@@ -141,6 +145,7 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                 m_profileUploadRetryTimer.stop();
                 m_profileUploadRetryAttempts = 0;
                 m_lastUploadFailureReason.clear();
+                updateProfileUploadRetrying();
                 return;
             }
             if (!isRetryableUploadFailure(reason)) {
@@ -163,6 +168,7 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                     m_de1CommunicationFailure = true;
                     emit de1CommunicationFailureChanged();
                 }
+                updateProfileUploadRetrying();
                 return;
             }
             // Exponential backoff capped at kUploadRetryMaxMs.
@@ -177,6 +183,32 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                 .arg(m_profileUploadRetryAttempts)
                 .arg(kMaxUploadRetryAttempts);
             m_profileUploadRetryTimer.start(delayMs);
+            updateProfileUploadRetrying();
+
+            // Safety: if a shot is already running on the DE1 (started via the
+            // group-head button before the new profile landed), the DE1 is
+            // extracting with whatever was previously in memory. Rather than
+            // let the user brew on a stale or half-uploaded profile, stop the
+            // shot immediately — same behaviour as aborting when the saved
+            // scale is not connected. The user can restart once the retry
+            // loop either succeeds or surfaces the communication-failure
+            // dialog.
+            if (m_machineState && m_device) {
+                auto phase = m_machineState->phase();
+                const bool isEspressoShot =
+                    (phase == MachineState::Phase::EspressoPreheating ||
+                     phase == MachineState::Phase::Preinfusion ||
+                     phase == MachineState::Phase::Pouring ||
+                     phase == MachineState::Phase::Ending);
+                if (isEspressoShot) {
+                    qWarning() << "ProfileManager: aborting in-progress shot "
+                                  "because profile upload is retrying (DE1 may "
+                                  "be running stale frames). Phase was:"
+                               << m_machineState->phaseString();
+                    m_device->requestState(DE1::State::Idle);
+                    emit shotAbortedProfileUploadRetrying();
+                }
+            }
         });
 
         // On BLE disconnect, stop retrying — the reconnect path
@@ -192,6 +224,7 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                     m_profileUploadRetryTimer.stop();
                     m_profileUploadRetryAttempts = 0;
                     m_lastUploadFailureReason.clear();
+                    updateProfileUploadRetrying();
                 }
             }
         });
@@ -921,6 +954,7 @@ void ProfileManager::loadProfile(const QString& profileName) {
     m_profileUploadRetryTimer.stop();
     m_profileUploadRetryAttempts = 0;
     m_lastUploadFailureReason.clear();
+    updateProfileUploadRetrying();
 
     // Resolve profile name: could be title or filename (MQTT publishes titles)
 
@@ -1074,6 +1108,7 @@ bool ProfileManager::loadProfileFromJson(const QString& jsonContent) {
     m_profileUploadRetryTimer.stop();
     m_profileUploadRetryAttempts = 0;
     m_lastUploadFailureReason.clear();
+    updateProfileUploadRetrying();
 
     m_currentProfile = Profile::loadFromJsonString(jsonContent);
 
@@ -1339,6 +1374,14 @@ void ProfileManager::refreshProfiles() {
 
 // === Profile upload ===
 
+void ProfileManager::updateProfileUploadRetrying() {
+    const bool retrying = m_profileUploadRetryAttempts > 0
+                          && m_profileUploadRetryTimer.isActive();
+    if (retrying == m_profileUploadRetrying) return;
+    m_profileUploadRetrying = retrying;
+    emit profileUploadRetryingChanged();
+}
+
 void ProfileManager::acknowledgeDe1CommunicationFailure() {
     // The user dismissed the communication-failure dialog. Clear the flag
     // (so the dialog goes away) and reset retry state so the next
@@ -1352,6 +1395,7 @@ void ProfileManager::acknowledgeDe1CommunicationFailure() {
     m_profileUploadRetryTimer.stop();
     m_profileUploadRetryAttempts = 0;
     m_lastUploadFailureReason.clear();
+    updateProfileUploadRetrying();
 }
 
 void ProfileManager::uploadCurrentProfile() {

--- a/src/controllers/profilemanager.h
+++ b/src/controllers/profilemanager.h
@@ -65,6 +65,14 @@ class ProfileManager : public QObject {
     // open()/close() on De1CommunicationErrorDialog. The dialog's OK button
     // calls acknowledgeDe1CommunicationFailure() to clear the flag.
     Q_PROPERTY(bool de1CommunicationFailure READ de1CommunicationFailure NOTIFY de1CommunicationFailureChanged)
+    // Reactive view of the upload-retry backoff window. True while a failed
+    // upload is queued to retry (m_profileUploadRetryAttempts > 0 AND
+    // m_profileUploadRetryTimer.isActive()). QML binds a toast to this so the
+    // user sees "Reconnecting…" during the otherwise-silent 15s backoff
+    // window. Cleared on success, on exhaustion (when
+    // de1CommunicationFailure supersedes), on disconnect, on user-initiated
+    // profile switch, and on ack.
+    Q_PROPERTY(bool profileUploadRetrying READ profileUploadRetrying NOTIFY profileUploadRetryingChanged)
     Q_PROPERTY(bool profileHasRecommendedDose READ profileHasRecommendedDose NOTIFY currentProfileChanged)
     Q_PROPERTY(double profileRecommendedDose READ profileRecommendedDose NOTIFY currentProfileChanged)
     Q_PROPERTY(bool isCurrentProfileReadOnly READ isCurrentProfileReadOnly NOTIFY currentProfileChanged)
@@ -165,6 +173,9 @@ public slots:
     bool de1CommunicationFailure() const { return m_de1CommunicationFailure; }
     Q_INVOKABLE void acknowledgeDe1CommunicationFailure();
 
+    // See Q_PROPERTY documentation above.
+    bool profileUploadRetrying() const { return m_profileUploadRetrying; }
+
 signals:
     void currentProfileChanged();
     void profileModifiedChanged();
@@ -182,6 +193,13 @@ signals:
 
     // See Q_PROPERTY documentation above.
     void de1CommunicationFailureChanged();
+    void profileUploadRetryingChanged();
+
+    // Emitted when an in-progress espresso shot is aborted because a profile
+    // upload just failed with a retryable reason. The DE1 was running stale
+    // frames; the UI should surface a toast/warning. Mirrors the
+    // MainController::shotAbortedNoScale pattern.
+    void shotAbortedProfileUploadRetrying();
 
 private:
     void loadDefaultProfile();
@@ -223,6 +241,12 @@ private:
     int m_profileUploadRetryAttempts = 0;
     QString m_lastUploadFailureReason;
     bool m_de1CommunicationFailure = false;
+    // Cached value of (m_profileUploadRetryAttempts > 0 &&
+    // m_profileUploadRetryTimer.isActive()). Updated via
+    // updateProfileUploadRetrying() from every state-mutation site so the
+    // NOTIFY signal fires exactly when the value changes.
+    bool m_profileUploadRetrying = false;
+    void updateProfileUploadRetrying();
 
 #ifdef DECENZA_TESTING
     friend class tst_ProfileManager;

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -2018,6 +2018,173 @@ private slots:
         QCOMPARE(f.profileManager.m_profileUploadRetryAttempts, 0);
         QVERIFY(!f.profileManager.m_profileUploadRetryTimer.isActive());
     }
+
+    // =========================================================================
+    // profileUploadRetrying Q_PROPERTY lifecycle (issue #750)
+    // =========================================================================
+    //
+    // QML binds a "Reconnecting…" toast to this property, so it must flip true
+    // within the same tick that the retry timer arms, and flip false cleanly
+    // on every exit path (success, exhaustion, disconnect, profile switch,
+    // acknowledge). The NOTIFY signal must fire exactly once per transition
+    // — no spurious emissions, no missed edges.
+
+    void profileUploadRetryingFlipsTrueOnFirstFailure() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        QVERIFY(!f.profileManager.profileUploadRetrying());
+
+        QSignalSpy spy(&f.profileManager,
+            &ProfileManager::profileUploadRetryingChanged);
+
+        f.profileManager.uploadCurrentProfile();
+        emit f.device.profileUploaded(false,
+            QStringLiteral("timeout waiting for write ACKs"));
+
+        QVERIFY(f.profileManager.profileUploadRetrying());
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void profileUploadRetryingClearsOnSuccess() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+        emit f.device.profileUploaded(false,
+            QStringLiteral("timeout waiting for write ACKs"));
+        QVERIFY(f.profileManager.profileUploadRetrying());
+
+        QSignalSpy spy(&f.profileManager,
+            &ProfileManager::profileUploadRetryingChanged);
+        emit f.device.profileUploaded(true, QString());
+
+        QVERIFY(!f.profileManager.profileUploadRetrying());
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void profileUploadRetryingClearsOnExhaustion() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        ScopedWarningFilter filter(
+            "profile upload failed .* consecutive times");
+        f.profileManager.uploadCurrentProfile();
+
+        const QString reason = QStringLiteral("timeout waiting for write ACKs");
+        // Attempts 1..4 leave the flag true; the 5th exhausts the budget
+        // and the flag must flip back to false so the toast yields to the
+        // exhaustion dialog.
+        for (int i = 0; i < 4; ++i) {
+            emit f.device.profileUploaded(false, reason);
+            QVERIFY(f.profileManager.profileUploadRetrying());
+        }
+        emit f.device.profileUploaded(false, reason);
+
+        QVERIFY(f.profileManager.de1CommunicationFailure());
+        QVERIFY2(!f.profileManager.profileUploadRetrying(),
+            "exhaustion must clear profileUploadRetrying — the dialog takes over");
+    }
+
+    void profileUploadRetryingClearsOnDisconnect() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+        emit f.device.profileUploaded(false,
+            QStringLiteral("timeout waiting for write ACKs"));
+        QVERIFY(f.profileManager.profileUploadRetrying());
+
+        f.transport.setConnectedSim(false);
+
+        QVERIFY(!f.profileManager.profileUploadRetrying());
+    }
+
+    void profileUploadRetryingClearsOnAcknowledge() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        ScopedWarningFilter filter(
+            "profile upload failed .* consecutive times");
+        f.profileManager.uploadCurrentProfile();
+        const QString reason = QStringLiteral("timeout waiting for write ACKs");
+        for (int i = 0; i < 5; ++i) {
+            emit f.device.profileUploaded(false, reason);
+        }
+        QVERIFY(!f.profileManager.profileUploadRetrying());
+
+        // Acknowledge is a clean no-op for the retrying flag (already false
+        // at exhaustion) — but it must not regress to true.
+        QSignalSpy spy(&f.profileManager,
+            &ProfileManager::profileUploadRetryingChanged);
+        f.profileManager.acknowledgeDe1CommunicationFailure();
+
+        QVERIFY(!f.profileManager.profileUploadRetrying());
+        QCOMPARE(spy.count(), 0);
+    }
+
+    void profileUploadRetryingClearsOnProfileSwitch() {
+        McpTestFixture f;
+        loadDFlowProfile(f, "First");
+        f.profileManager.uploadCurrentProfile();
+        emit f.device.profileUploaded(false,
+            QStringLiteral("timeout waiting for write ACKs"));
+        QVERIFY(f.profileManager.profileUploadRetrying());
+
+        loadDFlowProfile(f, "Second");
+
+        QVERIFY(!f.profileManager.profileUploadRetrying());
+    }
+
+    void retryableFailureDuringShotStopsShot() {
+        // If the DE1 is mid-shot (user pressed the group-head button) while a
+        // profile upload fails with a retryable reason, the machine is
+        // running on stale frames. ProfileManager must stop the shot
+        // immediately (same behaviour as aborting when no scale is
+        // connected) and emit shotAbortedProfileUploadRetrying so the UI
+        // can surface the reason.
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        f.machineState.m_phase = MachineState::Phase::Pouring;
+        QSignalSpy abortSpy(&f.profileManager,
+            &ProfileManager::shotAbortedProfileUploadRetrying);
+        f.transport.clearWrites();
+
+        ScopedWarningFilter filter(
+            "aborting in-progress shot because profile upload is retrying");
+        emit f.device.profileUploaded(false,
+            QStringLiteral("timeout waiting for write ACKs"));
+
+        QCOMPARE(abortSpy.count(), 1);
+        // requestState(Idle) goes through the transport as a state-request
+        // write — verifying the signal is sufficient to confirm the abort
+        // path ran; the transport-level assertion is covered by other tests.
+    }
+
+    void retryableFailureOutsideShotDoesNotEmitAbort() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        QSignalSpy abortSpy(&f.profileManager,
+            &ProfileManager::shotAbortedProfileUploadRetrying);
+        // Idle phase: no shot to stop.
+        emit f.device.profileUploaded(false,
+            QStringLiteral("timeout waiting for write ACKs"));
+
+        QCOMPARE(abortSpy.count(), 0);
+    }
+
+    void profileUploadRetryingDoesNotFireForNonRetryableFailure() {
+        McpTestFixture f;
+        loadDFlowProfile(f);
+        f.profileManager.uploadCurrentProfile();
+
+        QSignalSpy spy(&f.profileManager,
+            &ProfileManager::profileUploadRetryingChanged);
+        emit f.device.profileUploaded(false,
+            QStringLiteral("superseded by a new upload"));
+
+        QVERIFY(!f.profileManager.profileUploadRetrying());
+        QCOMPARE(spy.count(), 0);
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_ProfileManager)


### PR DESCRIPTION
Closes #750.

## Summary

- Adds \`Q_PROPERTY(bool profileUploadRetrying)\` to \`ProfileManager\` — reactive view of the otherwise-silent 15s retry backoff window, so QML binds a toast without imperative show/hide calls.
- "Reconnecting…" toast at the bottom of the screen appears within one frame of the first retry arming and clears on success or when the \`De1CommunicationErrorDialog\` takes over.
- If a retryable upload failure arrives while the DE1 is mid-shot (user started via the group-head button before the new profile landed), the machine is running on stale frames. ProfileManager now stops the shot immediately via \`requestState(DE1::State::Idle)\` and emits \`shotAbortedProfileUploadRetrying\` — mirrors the no-scale abort pattern. Toast text switches to "Shot stopped while profile reloads…" so the user knows why.
- Nine new \`tst_ProfileManager\` cases cover property lifecycle (success, exhaustion, disconnect, acknowledge, profile switch, non-retryable failure) and the shot-abort signal (fires only during active espresso phases).

## Test plan

- [ ] Build clean
- [ ] \`ctest -R tst_profilemanager\` passes the new cases
- [ ] Disconnect DE1 mid-upload; toast appears, then exhaustion dialog takes over
- [ ] Single transient failure on real hardware shows toast then auto-clears on successful retry
- [ ] Start a shot via GHC while a retryable failure is in flight — shot stops immediately, toast reads "Shot stopped while profile reloads…"
- [ ] Accessibility: TalkBack announces both toast messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)