### PR TITLE
steam-health: require two low sessions for auto-reset; show establishing state

### DIFF
--- a/qml/pages/settings/SettingsCalibrationTab.qml
+++ b/qml/pages/settings/SettingsCalibrationTab.qml
@@ -381,12 +381,33 @@ Item {
                             Accessible.ignored: true
                         }
 
-                        // Status: no data yet
+                        // Status: establishing baseline (fresh install or post-reset).
+                        // SteamHealthTracker.baselineState drives the wording so the
+                        // user always sees what's happening — never a silent empty
+                        // panel. Covers the Empty / EstablishingInitial /
+                        // EstablishingAfterReset states; hidden once Ready.
                         Text {
                             visible: !SteamHealthTracker.hasData
                             Layout.fillWidth: true
-                            text: TranslationManager.translate("settings.calibration.steamHealthNoData",
-                                "Not enough data yet. At least 5 steam sessions with the same settings are needed to establish a baseline.")
+                            text: {
+                                var state = SteamHealthTracker.baselineState
+                                var count = SteamHealthTracker.sessionCount
+                                var total = SteamHealthTracker.minSessionsForTrend
+                                if (state === SteamHealthTrackerType.EstablishingAfterReset) {
+                                    return TranslationManager.translate("settings.calibration.steamHealthEstablishingAfterReset",
+                                        "Establishing new, improved baseline — we detected a significant pressure drop (likely a descale or steam-wand clean). Collecting %1 of %2 sessions to calibrate against your freshly-clean machine.")
+                                        .arg(count).arg(total)
+                                }
+                                if (state === SteamHealthTrackerType.EstablishingInitial) {
+                                    return TranslationManager.translate("settings.calibration.steamHealthEstablishingInitial",
+                                        "Establishing baseline — %1 of %2 sessions collected. Steam your next drink as normal; trends will appear once we have enough data.")
+                                        .arg(count).arg(total)
+                                }
+                                // Empty
+                                return TranslationManager.translate("settings.calibration.steamHealthEmpty",
+                                    "No steam sessions recorded yet. At least %1 sessions are needed before trend detection begins.")
+                                    .arg(total)
+                            }
                             color: Theme.textSecondaryColor
                             font.family: Theme.bodyFont.family
                             font.pixelSize: Theme.scaled(12)

--- a/src/machine/steamhealthtracker.cpp
+++ b/src/machine/steamhealthtracker.cpp
@@ -15,9 +15,24 @@ SteamHealthTracker::SteamHealthTracker(QObject* parent)
     m_lastWarnedSession = m_settings.value("steam/lastWarnedSession", -99).toInt();
     m_lastSteamFlow = m_settings.value("steam/lastTrackedFlow", 0).toInt();
     m_lastSteamTemp = m_settings.value("steam/lastTrackedTemp", 0).toInt();
+    m_pendingAutoReset = m_settings.value("steam/pendingAutoReset", false).toBool();
+    m_establishingAfterReset = m_settings.value("steam/establishingAfterReset", false).toBool();
+    // Safety: if session count has already accumulated past the threshold
+    // (e.g. user downgraded/upgraded across the feature), clear the stale
+    // "establishing after reset" flag so we don't lie about the state.
+    if (m_establishingAfterReset && m_sessionCount >= MIN_SESSIONS_FOR_TREND) {
+        m_establishingAfterReset = false;
+        m_settings.setValue("steam/establishingAfterReset", false);
+    }
     if (!history.isEmpty()) {
         updateCachedStats(history, m_lastSteamTemp);
     }
+}
+
+SteamHealthTracker::BaselineState SteamHealthTracker::baselineState() const {
+    if (m_sessionCount <= 0) return Empty;
+    if (m_sessionCount >= MIN_SESSIONS_FOR_TREND) return Ready;
+    return m_establishingAfterReset ? EstablishingAfterReset : EstablishingInitial;
 }
 
 double SteamHealthTracker::normalizePressure(double avgPressure, int steamFlow) const {
@@ -123,20 +138,31 @@ void SteamHealthTracker::onSessionComplete(SteamDataModel* model, int steamFlowS
     m_settings.setValue("steam/lastTrackedTemp", steamTempSetting);
     updateCachedStats(history, steamTempSetting);
 
+    // Once we're back to a full baseline window, drop the
+    // "establishing after reset" banner — trend detection is live again.
+    if (m_establishingAfterReset && m_sessionCount >= MIN_SESSIONS_FOR_TREND) {
+        m_establishingAfterReset = false;
+        m_settings.setValue("steam/establishingAfterReset", false);
+    }
+
     emit sessionHistoryChanged();
 }
 
 void SteamHealthTracker::clearHistory() {
     m_settings.remove("steam/sessionHistory");
     m_settings.remove("steam/lastWarnedSession");
+    m_settings.remove("steam/pendingAutoReset");
+    m_settings.remove("steam/establishingAfterReset");
     m_sessionCount = 0;
     m_lastWarnedSession = -99;
     m_baselinePressure = 0.0;
     m_baselineTemperature = 0.0;
     m_currentPressure = 0.0;
     m_currentTemperature = 0.0;
+    m_pendingAutoReset = false;
+    m_establishingAfterReset = false;
     emit sessionHistoryChanged();
-    qDebug() << "SteamHealth [reset] session history and warning cooldown cleared";
+    qDebug() << "SteamHealth [reset] session history, cooldown, and auto-reset flags cleared";
 }
 
 // --- Scale buildup trend detection ---
@@ -198,7 +224,11 @@ void SteamHealthTracker::checkTrend(QList<SteamSessionSummary>& history,
     // Only pressure is used for auto-reset detection. Temperature changes are
     // driven by the heater setpoint, not limescale — a user changing their steam
     // temperature setting would spuriously trigger a reset.
-    bool autoReset = false;
+    //
+    // Two-step confirmation: a single low session only *arms* m_pendingAutoReset.
+    // The trim fires when the next session also drops (real descales produce
+    // persistent low readings; a one-shot dip is an outlier, not a descale).
+    bool dropDetected = false;
     qsizetype recentCount = qMin(qsizetype(5), n - 1);
     if (recentCount > 0) {
         double recentPressureSum = 0;
@@ -213,24 +243,49 @@ void SteamHealthTracker::checkTrend(QList<SteamSessionSummary>& history,
         if (pressureRange > 0) {
             double drop = recentAvgPressure - currentPressure;
             if (drop >= pressureRange * AUTO_RESET_DROP_THRESHOLD) {
-                autoReset = true;
+                dropDetected = true;
             }
         }
     }
 
-    if (autoReset) {
-        qDebug() << "SteamHealth [auto-reset]"
-                 << "normalizedP:" << currentPressure << "bar"
-                 << "temp:" << currentTemp << "°C"
-                 << "trimmedTo:" << AUTO_RESET_KEEP_SESSIONS << "sessions";
+    if (dropDetected) {
+        if (m_pendingAutoReset) {
+            // Confirmed: two consecutive low sessions. Trim history to just
+            // those two — they describe the new (cleaner) machine state.
+            // Everything older is from before the descale/clean and would
+            // pollute the new baseline's rolling recent-average.
+            qDebug() << "SteamHealth [auto-reset]"
+                     << "confirmed drop — trimming to" << AUTO_RESET_KEEP_SESSIONS << "sessions"
+                     << "normalizedP:" << currentPressure << "bar"
+                     << "temp:" << currentTemp << "°C";
 
-        while (history.size() > AUTO_RESET_KEEP_SESSIONS) {
-            history.removeLast();
+            while (history.size() > AUTO_RESET_KEEP_SESSIONS) {
+                history.removeLast();
+            }
+            saveHistory(history);
+            m_pendingAutoReset = false;
+            m_establishingAfterReset = true;
+            m_lastWarnedSession = -99;
+            m_settings.setValue("steam/pendingAutoReset", false);
+            m_settings.setValue("steam/establishingAfterReset", true);
+            m_settings.setValue("steam/lastWarnedSession", m_lastWarnedSession);
+            return;
         }
-        saveHistory(history);
-        m_lastWarnedSession = -99;
-        m_settings.setValue("steam/lastWarnedSession", m_lastWarnedSession);
-        return;
+
+        // First low session: arm pending flag and wait for confirmation.
+        qDebug() << "SteamHealth [auto-reset-armed]"
+                 << "low session detected — waiting for next session to confirm"
+                 << "normalizedP:" << currentPressure << "bar";
+        m_pendingAutoReset = true;
+        m_settings.setValue("steam/pendingAutoReset", true);
+    } else if (m_pendingAutoReset) {
+        // Previous session was low but this one isn't — the drop didn't
+        // persist, so disarm. The armed session stays in history and
+        // contributes to the baseline like any other session.
+        qDebug() << "SteamHealth [auto-reset-disarmed]"
+                 << "low session not confirmed — pressure recovered";
+        m_pendingAutoReset = false;
+        m_settings.setValue("steam/pendingAutoReset", false);
     }
 
     // --- Compute progress toward thresholds ---

--- a/src/machine/steamhealthtracker.h
+++ b/src/machine/steamhealthtracker.h
@@ -20,6 +20,25 @@ struct SteamSessionSummary {
 class SteamHealthTracker : public QObject {
     Q_OBJECT
 
+public:
+    // Baseline lifecycle state surfaced to QML so the settings/calibration
+    // screen can show a meaningful message while trends are not yet
+    // available, instead of going silent.
+    //
+    //   Empty                   — no sessions recorded (fresh install / manual reset)
+    //   EstablishingInitial     — 1..4 sessions, collecting first baseline
+    //   EstablishingAfterReset  — 1..4 sessions since an auto-reset trimmed
+    //                             history after a detected pressure drop
+    //                             (likely descale / steam-wand clean)
+    //   Ready                   — 5+ sessions; trend detection is active
+    enum BaselineState {
+        Empty,
+        EstablishingInitial,
+        EstablishingAfterReset,
+        Ready,
+    };
+    Q_ENUM(BaselineState)
+
     Q_PROPERTY(int sessionCount READ sessionCount NOTIFY sessionHistoryChanged)
     Q_PROPERTY(double baselinePressure READ baselinePressure NOTIFY sessionHistoryChanged)
     Q_PROPERTY(double baselineTemperature READ baselineTemperature NOTIFY sessionHistoryChanged)
@@ -28,8 +47,10 @@ class SteamHealthTracker : public QObject {
     Q_PROPERTY(bool hasData READ hasData NOTIFY sessionHistoryChanged)
     Q_PROPERTY(double pressureThreshold READ pressureThreshold NOTIFY sessionHistoryChanged)
     Q_PROPERTY(double temperatureThreshold READ temperatureThreshold CONSTANT)
+    // Number of sessions required before hasData flips true.
+    Q_PROPERTY(int minSessionsForTrend READ minSessionsForTrend CONSTANT)
+    Q_PROPERTY(BaselineState baselineState READ baselineState NOTIFY sessionHistoryChanged)
 
-public:
     explicit SteamHealthTracker(QObject* parent = nullptr);
 
     int sessionCount() const { return m_sessionCount; }
@@ -41,6 +62,8 @@ public:
     double pressureThreshold() const { return m_baselinePressure > 0 ? qMin(m_baselinePressure * PRESSURE_WARN_MULTIPLIER, PRESSURE_HARD_LIMIT) : PRESSURE_HARD_LIMIT; }
     double temperatureThreshold() const { return TEMPERATURE_THRESHOLD; }
     double trendProgressThreshold() const { return TREND_PROGRESS_THRESHOLD; }
+    int minSessionsForTrend() const { return MIN_SESSIONS_FOR_TREND; }
+    BaselineState baselineState() const;
 
     // Called per BLE sample during steaming (live threshold checks)
     void onSample(double pressure, double temperature);
@@ -92,6 +115,17 @@ private:
     bool m_pressureWarningEmitted = false;
     bool m_temperatureWarningEmitted = false;
 
+    // Auto-reset two-step confirmation (persisted across restart).
+    // A single low-pressure session sets m_pendingAutoReset; the trim only
+    // fires when the *next* session also drops. Prevents one-off outliers
+    // (partial-full boiler, normalization edge cases) from wiping history.
+    bool m_pendingAutoReset = false;
+
+    // True after auto-reset has trimmed history, cleared once sessionCount
+    // reaches MIN_SESSIONS_FOR_TREND. Drives the "Establishing new, improved
+    // baseline" state so the UI can explain the transient empty state.
+    bool m_establishingAfterReset = false;
+
     // Thresholds
     static constexpr double PRESSURE_HARD_LIMIT = 8.0;      // bar — absolute safety net for live onSample() check
     static constexpr double PRESSURE_WARN_MULTIPLIER = 3.0;  // warn when pressure reaches this multiple of baseline
@@ -102,8 +136,8 @@ private:
     static constexpr int MIN_SESSIONS_FOR_TREND = 5;         // minimum comparable sessions
     static constexpr int MAX_HISTORY_SIZE = 150;             // sessions to keep
     static constexpr double TREND_PROGRESS_THRESHOLD = 0.6;   // warn at 60% of the way from baseline to warn level
-    static constexpr double AUTO_RESET_DROP_THRESHOLD = 0.3;  // auto-reset baseline if drop >= 30% of range (likely descale)
-    static constexpr int AUTO_RESET_KEEP_SESSIONS = 3;       // sessions to keep after auto-reset
+    static constexpr double AUTO_RESET_DROP_THRESHOLD = 0.3;  // auto-reset baseline if drop >= 30% of range (likely descale) — must persist across 2 consecutive sessions
+    static constexpr int AUTO_RESET_KEEP_SESSIONS = 2;       // sessions to keep after auto-reset (the two consecutive triggering sessions; older scaled-up sessions are discarded)
     static constexpr double TRIM_SECONDS = 2.0;              // skip first 2s of samples
     static constexpr int REFERENCE_FLOW = 150;               // 1.5 mL/s — normalization reference
     static constexpr double PRESSURE_PER_FLOW_UNIT = 0.012;  // bar per 0.01 mL/s (from RO-water baseline data)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1535,6 +1535,12 @@ int main(int argc, char *argv[])
         "MachineState is created in C++");
     qmlRegisterUncreatableType<AIConversation>("Decenza", 1, 0, "AIConversationType",
         "AIConversation is created in C++");
+    // Exposes SteamHealthTracker::BaselineState enum values to QML
+    // (e.g. SteamHealthTrackerType.EstablishingAfterReset). The tracker
+    // instance itself is available as the "SteamHealthTracker" context
+    // property — this type registration is only needed for enum access.
+    qmlRegisterUncreatableType<SteamHealthTracker>("Decenza", 1, 0, "SteamHealthTrackerType",
+        "SteamHealthTracker is created in C++");
 
     // Register strange attractor renderer (QQuickPaintedItem, no Quick3D dependency)
     qmlRegisterType<StrangeAttractorRenderer>("Decenza", 1, 0, "StrangeAttractorRenderer");

--- a/src/mcp/mcptools_machine.cpp
+++ b/src/mcp/mcptools_machine.cpp
@@ -38,8 +38,35 @@ static SteamHealthInfo computeSteamHealth(SteamHealthTracker* tracker)
     info.hasData = tracker->hasData();
 
     if (!info.hasData) {
-        info.status = QStringLiteral("insufficient_data");
-        info.recommendation = QStringLiteral("Need at least 5 steam sessions to establish baseline");
+        // Differentiate fresh-install, first-baseline-in-progress, and
+        // post-reset states so an AI agent asking "what's my steam health"
+        // can explain *why* there's no trend yet. Mirrors the QML
+        // settings screen's establishing-baseline messaging.
+        const int total = tracker->minSessionsForTrend();
+        switch (tracker->baselineState()) {
+        case SteamHealthTracker::EstablishingAfterReset:
+            info.status = QStringLiteral("establishing_after_reset");
+            info.recommendation = QStringLiteral(
+                "A significant pressure drop was detected (likely descale or steam-wand clean). "
+                "Collecting sessions to calibrate against the freshly-clean baseline. "
+                "%1 of %2 sessions logged.")
+                .arg(info.sessionCount).arg(total);
+            break;
+        case SteamHealthTracker::EstablishingInitial:
+            info.status = QStringLiteral("establishing_baseline");
+            info.recommendation = QStringLiteral(
+                "Establishing initial baseline. %1 of %2 sessions logged — "
+                "trend detection begins once the window is full.")
+                .arg(info.sessionCount).arg(total);
+            break;
+        case SteamHealthTracker::Empty:
+        default:
+            info.status = QStringLiteral("insufficient_data");
+            info.recommendation = QStringLiteral(
+                "No steam sessions recorded yet. At least %1 sessions are needed to establish a baseline.")
+                .arg(total);
+            break;
+        }
         return info;
     }
 

--- a/tests/tst_shotsettings.cpp
+++ b/tests/tst_shotsettings.cpp
@@ -1,5 +1,6 @@
 #include <QtTest>
 #include <QSignalSpy>
+#include <QRegularExpression>
 
 #include "ble/de1device.h"
 #include "ble/protocol/binarycodec.h"
@@ -210,6 +211,11 @@ private slots:
         // mis-parsing a stray 8-byte frame.
         TestFixture f;
         QSignalSpy spy(&f.device, &DE1Device::shotSettingsReported);
+
+        // Expected qWarning from parseShotSettings — silence so the test
+        // passes cleanly (otherwise QTest flags it as "passed with warning").
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("\\[BLE DE1\\] parseShotSettings: short payload"));
 
         QByteArray truncated(8, 0);
         emit f.transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, truncated);

--- a/tests/tst_steamhealth.cpp
+++ b/tests/tst_steamhealth.cpp
@@ -18,6 +18,8 @@ private:
     QVariant m_origLastWarned;
     QVariant m_origLastFlow;
     QVariant m_origLastTemp;
+    QVariant m_origPendingAutoReset;
+    QVariant m_origEstablishingAfterReset;
 
 private slots:
 
@@ -26,11 +28,15 @@ private slots:
         m_origLastWarned = m_settings.value("steam/lastWarnedSession");
         m_origLastFlow = m_settings.value("steam/lastTrackedFlow");
         m_origLastTemp = m_settings.value("steam/lastTrackedTemp");
+        m_origPendingAutoReset = m_settings.value("steam/pendingAutoReset");
+        m_origEstablishingAfterReset = m_settings.value("steam/establishingAfterReset");
         // Start each test with clean history
         m_settings.remove("steam/sessionHistory");
         m_settings.remove("steam/lastWarnedSession");
         m_settings.remove("steam/lastTrackedFlow");
         m_settings.remove("steam/lastTrackedTemp");
+        m_settings.remove("steam/pendingAutoReset");
+        m_settings.remove("steam/establishingAfterReset");
     }
 
     void cleanup() {
@@ -53,6 +59,26 @@ private slots:
             m_settings.remove("steam/lastTrackedTemp");
         else
             m_settings.setValue("steam/lastTrackedTemp", m_origLastTemp);
+
+        if (!m_origPendingAutoReset.isValid())
+            m_settings.remove("steam/pendingAutoReset");
+        else
+            m_settings.setValue("steam/pendingAutoReset", m_origPendingAutoReset);
+
+        if (!m_origEstablishingAfterReset.isValid())
+            m_settings.remove("steam/establishingAfterReset");
+        else
+            m_settings.setValue("steam/establishingAfterReset", m_origEstablishingAfterReset);
+    }
+
+    // Helper: feed the tracker a single session at given raw pressure / temp.
+    static void addSession(SteamHealthTracker& tracker, double rawPressure,
+                           int steamFlow = 150, int steamTemp = 160,
+                           double measuredTemp = 160.0) {
+        SteamDataModel model;
+        for (int j = 0; j < 40; ++j)
+            model.addSample(2.0 + j * 0.6, rawPressure, 1.0, measuredTemp);
+        tracker.onSessionComplete(&model, steamFlow, steamTemp);
     }
 
     // ==========================================
@@ -642,6 +668,168 @@ private slots:
         double range = tracker.pressureThreshold() - tracker.baselinePressure();
         double progress = (tracker.currentPressure() - tracker.baselinePressure()) / range;
         QCOMPARE(progress, 0.5);
+    }
+
+    // ==========================================
+    // Auto-reset two-step confirmation (issue #752)
+    // ==========================================
+    //
+    // A real descale/steam-wand clean produces a persistent pressure drop
+    // across multiple sessions. A single low reading (partial boiler,
+    // normalization edge case, etc.) is an outlier and must NOT trim
+    // history on its own. The trim only fires when two consecutive
+    // sessions both drop >= AUTO_RESET_DROP_THRESHOLD below the rolling
+    // recent average. After trimming, only the two triggering sessions
+    // are retained — older scaled-up sessions would pollute the new
+    // baseline's recent-average window.
+
+    void singleLowSessionArmsButDoesNotTrim() {
+        SteamHealthTracker tracker;
+
+        // Seed a scaled-up baseline: 6 sessions at 5.0 bar raw (normalized ~5.0).
+        for (int i = 0; i < 6; ++i)
+            addSession(tracker, 5.0);
+
+        int countBeforeDrop = tracker.sessionCount();
+        QCOMPARE(countBeforeDrop, 6);
+
+        // Single low session — raw 1.0 bar. Big drop, should arm but not trim.
+        addSession(tracker, 1.0);
+
+        QCOMPARE(tracker.sessionCount(), countBeforeDrop + 1);
+        QVERIFY2(tracker.baselineState() == SteamHealthTracker::Ready,
+                 "single low session must not trim history — trend detection stays live");
+    }
+
+    void twoConsecutiveLowSessionsTrimHistoryToJustThem() {
+        SteamHealthTracker tracker;
+
+        // Seed a scaled-up baseline.
+        for (int i = 0; i < 6; ++i)
+            addSession(tracker, 5.0);
+
+        // First low session — arms.
+        addSession(tracker, 1.0);
+        QCOMPARE(tracker.sessionCount(), 7);
+
+        // Second low session — confirms, triggers trim to exactly 2 sessions
+        // (the two triggering low ones; all older scaled-up sessions discarded).
+        addSession(tracker, 1.0);
+
+        QCOMPARE(tracker.sessionCount(), 2);
+        // State flips to EstablishingAfterReset (2 < MIN_SESSIONS_FOR_TREND=5)
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::EstablishingAfterReset);
+    }
+
+    void pressureRecoveryDisarmsPendingReset() {
+        SteamHealthTracker tracker;
+
+        // Use raw 5.0 / 3.0 so the baseline doesn't drop so far that the
+        // recovery session looks like massive scale buildup and fires a
+        // spurious scaleBuildupWarning after disarming.
+        //   baseline=3.0, warn=min(9,8)=8, range=5, threshold=1.5
+        //   arming drop = 5.0 - 3.0 = 2.0 (armed)
+        //   recovery drop = avg(3,5,5,5,5)=4.6 - 5.0 = -0.4 (disarm)
+        for (int i = 0; i < 6; ++i)
+            addSession(tracker, 5.0);
+
+        // Armed by a low session...
+        addSession(tracker, 3.0);
+        QCOMPARE(tracker.sessionCount(), 7);
+
+        // ...but next session recovers to the original range. No trim.
+        addSession(tracker, 5.0);
+
+        QCOMPARE(tracker.sessionCount(), 8);
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::Ready);
+    }
+
+    void establishingAfterResetClearsOnceFullWindow() {
+        SteamHealthTracker tracker;
+
+        // Seed, trigger reset, then refill past the 5-session threshold.
+        for (int i = 0; i < 6; ++i)
+            addSession(tracker, 5.0);
+        addSession(tracker, 1.0);  // arm
+        addSession(tracker, 1.0);  // confirm — trim
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::EstablishingAfterReset);
+
+        // 3 more sessions at the new (low) range — baseline state should
+        // flip back to Ready once sessionCount == 5.
+        addSession(tracker, 1.0);
+        addSession(tracker, 1.0);
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::EstablishingAfterReset);
+        addSession(tracker, 1.0);
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::Ready);
+    }
+
+    void pendingAutoResetSurvivesRestart() {
+        {
+            SteamHealthTracker tracker;
+            for (int i = 0; i < 6; ++i)
+                addSession(tracker, 5.0);
+            addSession(tracker, 1.0);  // arms — m_pendingAutoReset persisted to QSettings
+            QCOMPARE(tracker.sessionCount(), 7);
+        }
+
+        // Simulate app restart: a new tracker instance inherits persisted state.
+        SteamHealthTracker tracker2;
+        QCOMPARE(tracker2.sessionCount(), 7);
+
+        // Immediately trigger a confirming low session — if the pending flag
+        // wasn't persisted, this would merely arm again and NOT trim.
+        addSession(tracker2, 1.0);
+
+        QCOMPARE(tracker2.sessionCount(), 2);
+        QCOMPARE(tracker2.baselineState(), SteamHealthTracker::EstablishingAfterReset);
+    }
+
+    void establishingAfterResetSurvivesRestart() {
+        {
+            SteamHealthTracker tracker;
+            for (int i = 0; i < 6; ++i)
+                addSession(tracker, 5.0);
+            addSession(tracker, 1.0);
+            addSession(tracker, 1.0);  // trim fires
+            QCOMPARE(tracker.baselineState(), SteamHealthTracker::EstablishingAfterReset);
+        }
+
+        SteamHealthTracker tracker2;
+        QCOMPARE(tracker2.baselineState(), SteamHealthTracker::EstablishingAfterReset);
+        QCOMPARE(tracker2.sessionCount(), 2);
+    }
+
+    void baselineStateReflectsSessionCount() {
+        SteamHealthTracker tracker;
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::Empty);
+
+        addSession(tracker, 2.0);
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::EstablishingInitial);
+
+        for (int i = 0; i < 3; ++i)
+            addSession(tracker, 2.0);
+        QCOMPARE(tracker.sessionCount(), 4);
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::EstablishingInitial);
+
+        addSession(tracker, 2.0);
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::Ready);
+    }
+
+    void clearHistoryResetsAutoResetFlags() {
+        SteamHealthTracker tracker;
+        for (int i = 0; i < 6; ++i)
+            addSession(tracker, 5.0);
+        addSession(tracker, 1.0);  // arm
+        addSession(tracker, 1.0);  // confirm — trim fires
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::EstablishingAfterReset);
+
+        tracker.clearHistory();
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::Empty);
+
+        // After a manual clear, a fresh new run should behave like a
+        // clean install: initial establishing state, not after-reset.
+        addSession(tracker, 2.0);
+        QCOMPARE(tracker.baselineState(), SteamHealthTracker::EstablishingInitial);
     }
 
     void highBaselineWarningStillReachable() {


### PR DESCRIPTION
Closes #752.

## Summary

Fixes two issues with the steam-health scale-buildup tracker where a real descale or Rinza steam-wand clean leaves the feature silently degraded:

- **Two-step auto-reset confirmation.** A single anomalous low-pressure session no longer trims history on its own. The trim now requires two *consecutive* low sessions. \`m_pendingAutoReset\` is persisted to QSettings so the flag survives app restart.
- **Keep the two triggering sessions, not three.** On confirmed reset, history is now trimmed to exactly the two consecutive low sessions that triggered it. Previously the kept window was 3 (triggering + two pre-trigger scaled-up readings), which polluted the new baseline's rolling recent-average.
- **No more silent "no data" panel.** The settings/calibration screen now shows:
  - *"Establishing baseline — N of 5 sessions collected…"* for fresh installs
  - *"Establishing new, improved baseline — we detected a significant pressure drop (likely a descale or steam-wand clean). Collecting N of 5 sessions to calibrate against your freshly-clean machine."* after an auto-reset
- **MCP \`steam_get_health\`** returns \`establishing_after_reset\` / \`establishing_baseline\` / \`insufficient_data\` with progress-aware recommendations so AI agents can explain *why* there's no trend yet.

Also folds in a small test-hygiene fix to \`tst_ShotSettings::parseShotSettingsShortPayloadIgnored\` so the expected short-payload qWarning is silenced via \`QTest::ignoreMessage\` (was flagging the test as "passed with warning" in Qt Test output).

## Test plan

- [ ] Build clean
- [ ] \`ctest -R tst_steamhealth\` passes all new cases
- [ ] \`ctest -R tst_shotsettings\` — parseShotSettingsShortPayloadIgnored now shows clean PASS (no yellow icon)
- [ ] Fresh install: settings panel shows "Establishing baseline — 0 of 5 sessions collected"
- [ ] After 5 sessions: panel transitions to the normal baseline/pressure/temperature rows
- [ ] Simulate descale (steam session with normalized pressure well below recent average): first triggers armed-state log, second session confirms, panel shows "Establishing new, improved baseline"
- [ ] MCP \`steam_get_health\` returns \`establishing_after_reset\` status after a confirmed reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)