### PR TITLE
suggestion-field: don't auto-open dropdown on focus

### DIFF
--- a/qml/components/SuggestionField.qml
+++ b/qml/components/SuggestionField.qml
@@ -120,8 +120,12 @@ Item {
             // Don't set root.text here - that breaks the parent binding!
             // Just emit the signal and let parent update via its binding
             root.textEdited(text)
-            // Show dropdown when typing if we have matching suggestions (but not after selection)
-            if (!justSelected && text.length > 0 && getFilteredSuggestions().length > 0) {
+            // Show dropdown when typing if we have matching suggestions (but not after selection).
+            // Close it when the field is empty — the popup is a filter-as-you-type affordance,
+            // not a browse-all list (that's what the arrow button's dialog is for).
+            if (text.length === 0) {
+                suggestionPopup.close()
+            } else if (!justSelected && getFilteredSuggestions().length > 0) {
                 suggestionPopup.open()
             }
         }
@@ -131,10 +135,10 @@ Item {
                 justSelected = false  // Reset so typing works again
                 isActivelyTyping = false  // Reset - show all suggestions initially
                 root.inputFocused(textInput)
-                // Show suggestions when focused (popup for typing, not dialog)
-                if (suggestions.length > 0 && !root._accessibilityMode) {
-                    suggestionPopup.open()
-                }
+                // Intentionally do NOT auto-open the popup on focus. The popup is a
+                // filter-as-you-type dropdown; it appears once the user starts typing.
+                // To browse all suggestions, the user taps the arrow button which opens
+                // the SelectionDialog.
             } else {
                 // Emit textEdited to ensure value is committed when losing focus
                 // Don't set root.text here - that breaks the parent binding!
@@ -212,9 +216,9 @@ Item {
                     isActivelyTyping = false
                     textInput.text = ""
                     root.textEdited("")
-                    if (suggestions.length > 0) {
-                        suggestionPopup.open()
-                    }
+                    // Don't re-open the popup — it's a type-to-filter dropdown,
+                    // and there's nothing to filter after clearing.
+                    suggestionPopup.close()
                 }
             }
         }

--- a/qml/components/SuggestionField.qml
+++ b/qml/components/SuggestionField.qml
@@ -208,10 +208,12 @@ Item {
                 Accessible.ignored: true
             }
 
-            MouseArea {
+            AccessibleMouseArea {
                 id: clearArea
                 anchors.fill: parent
-                onClicked: {
+                accessibleName: TranslationManager.translate("suggestionfield.clear", "Clear text")
+                accessibleItem: parent
+                onAccessibleClicked: {
                     justSelected = false
                     isActivelyTyping = false
                     textInput.text = ""
@@ -246,10 +248,12 @@ Item {
                 }
             }
 
-            MouseArea {
+            AccessibleMouseArea {
                 id: arrowArea
                 anchors.fill: parent
-                onClicked: {
+                accessibleName: TranslationManager.translate("suggestionfield.openDropdown", "Open suggestions")
+                accessibleItem: parent
+                onAccessibleClicked: {
                     if (suggestionPopup.visible) {
                         suggestionPopup.close()
                     } else {


### PR DESCRIPTION
## Summary
- Autocomplete fields (Roaster, Coffee, Grinder, Barista on Bean Info / Post-Shot Review / Brew Dialog) opened a dropdown on focus showing the full list — identical to the arrow-button's modal dialog. Two lists for the same purpose.
- Restrict the popup to filter-as-you-type: it appears only once the user types a non-empty string, narrows with each keystroke, and closes when the field goes empty.
- The arrow button on the right of the field remains the "browse all" entry point (opens `SelectionDialog`).

## Test plan
- [ ] On Bean Info, tap the Roaster field — keyboard opens, no dropdown.
- [ ] Type a letter — filtered dropdown appears and narrows as more letters are typed.
- [ ] Delete back to empty — dropdown closes.
- [ ] Tap the arrow button — modal dialog opens with the full list (unchanged).
- [ ] Tap the inline X — field clears, no dropdown reopens.
- [ ] Repeat on Coffee, Grinder, Barista fields.
- [ ] Repeat on the same fields in Post-Shot Review and Brew Dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)