### PR TITLE
suggestion-field: fix Android filter lag by disabling predictive text

### DIFF
--- a/qml/components/SuggestionField.qml
+++ b/qml/components/SuggestionField.qml
@@ -110,6 +110,11 @@ Item {
         text: root.text
         placeholder: root.label
         EnterKey.type: Qt.EnterKeyDone
+        // Disable predictive text / autocorrect on virtual keyboards (Android) so each
+        // keystroke commits to `text` immediately. Without this, the IME holds composing
+        // text and `onTextEdited` only fires on space/punctuation/backspace, so the
+        // filter-as-you-type dropdown appears to lag behind the user's typing.
+        inputMethodHints: Qt.ImhNoPredictiveText
 
         // Make room for buttons on the right (only in normal mode)
         rightPadding: root._accessibilityMode ? Theme.scaled(12) : Theme.scaled(84)


### PR DESCRIPTION
## Summary
- Follow-up to #756. On Android, users reported that typing in Roaster / Coffee / Grinder / Barista autocomplete fields showed no suggestions until they pressed **space** or **delete**.
- Root cause: the Android soft keyboard holds each character in an IME pre-edit composition state, so `TextField.text` is not updated (and `onTextEdited` does not fire) until the composition commits on space/punctuation/backspace. Before #756 this was hidden because the dropdown was already open from focus; now that the dropdown is strictly filter-as-you-type, the delay is visible.
- Fix: add `inputMethodHints: Qt.ImhNoPredictiveText` to the internal text field in `SuggestionField.qml` so each keystroke commits immediately. Mirrors the existing fix in `qml/pages/ShotHistoryPage.qml:361-364` (shot search field), and the IME behavior documented in `CLAUDE.md` under "IME last-word drop on mobile".
- One-line change + explanatory comment. Desktop/macOS behavior is unchanged (hint is a no-op where there is no soft keyboard composition).

## Test plan
- [ ] Android: open **Bean Info**, tap the **Roaster** field — keyboard opens, no dropdown (preserves #756 behavior).
- [ ] Android: type a single letter — filtered dropdown appears **immediately**, narrows with each additional letter (no need to press space first).
- [ ] Android: delete back to empty — dropdown closes.
- [ ] Android: tap the arrow button — `SelectionDialog` opens with full list (unchanged).
- [ ] Android: repeat on **Coffee**, **Grinder**, **Barista** on Bean Info, Post-Shot Review, and Brew Dialog.
- [ ] macOS desktop: typing still opens the dropdown (regression sanity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)