### PR TITLE
qml: fan out Android IME preedit fix to remaining search bars

### DIFF
--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -88,7 +88,12 @@ Page {
                         Layout.preferredHeight: Theme.scaled(44)
                         placeholder: TranslationManager.translate("profileselector.search.placeholder", "Search profiles...")
                         font.pixelSize: Theme.scaled(16)
-                        onTextChanged: allProfilesList.searchFilter = text.toLowerCase()
+                        // Hint the Android IME away from autocorrect (reduces surprise corrections
+                        // on profile names); some IMEs ignore this, so we still filter via displayText.
+                        inputMethodHints: Qt.ImhNoPredictiveText
+                        // Drive filter from displayText (includes IME preedit) so suggestions
+                        // update on every keystroke on Android. See SuggestionField.qml.
+                        onDisplayTextChanged: allProfilesList.searchFilter = displayText.toLowerCase()
                     }
 
                     Item { Layout.fillWidth: true; visible: viewFilter.currentIndex !== 5 }

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -358,13 +358,14 @@ Page {
                 Layout.fillWidth: true
                 placeholder: TranslationManager.translate("shothistory.searchplaceholder", "Search shots...")
                 rightPadding: searchClearButton.visible ? Theme.scaled(36) : Theme.scaled(12)
-                // Disable predictive text / autocorrect — forces IME to commit each
-                // character individually. Without this, the IME holds composing text
-                // and commits the entire word at once on space, which triggers a blank screen.
+                // Hint the Android IME away from autocorrect. Some IMEs (notably Gboard)
+                // ignore this, so we also drive the filter from `displayText` below —
+                // displayText includes the IME preedit composing text, so the filter
+                // updates per keystroke instead of waiting for a word commit.
                 inputMethodHints: Qt.ImhNoPredictiveText
                 property string lastTriggeredText: ""
-                onTextChanged: {
-                    var trimmed = text.trim()
+                onDisplayTextChanged: {
+                    var trimmed = displayText.trim()
                     if (trimmed !== lastTriggeredText) {
                         lastTriggeredText = trimmed
                         // User edited the search field — drop exact-match filter, use FTS
@@ -380,7 +381,7 @@ Page {
                     id: searchClearButton
                     width: Theme.scaled(20)
                     height: Theme.scaled(20)
-                    visible: searchField.text.length > 0 && !(typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled)
+                    visible: searchField.displayText.length > 0 && !(typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled)
                     anchors.right: parent.right
                     anchors.rightMargin: Theme.scaled(10)
                     anchors.verticalCenter: parent.verticalCenter
@@ -406,7 +407,7 @@ Page {
 
             // Accessible clear button (outside TextField bounds for TalkBack discoverability)
             AccessibleButton {
-                visible: searchField.text.length > 0 && typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled
+                visible: searchField.displayText.length > 0 && typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled
                 accessibleName: TranslationManager.translate("shothistory.clearsearch", "Clear search")
                 icon.source: "qrc:/icons/cross.svg"
                 onClicked: {

--- a/qml/pages/settings/SettingsSearchDialog.qml
+++ b/qml/pages/settings/SettingsSearchDialog.qml
@@ -79,7 +79,9 @@ Dialog {
         return SearchIndex.getSearchEntries(TranslationManager.translate.bind(TranslationManager))
     }
     property var filteredEntries: {
-        var query = searchField.text.trim().toLowerCase()
+        // Read `displayText` (not `text`) so the filter binding re-evaluates on every
+        // IME preedit change on Android, not just after the IME commits the word.
+        var query = searchField.displayText.trim().toLowerCase()
         if (query.length === 0) return allEntries
 
         var results = []
@@ -135,6 +137,9 @@ Dialog {
                 Layout.fillWidth: true
                 placeholder: TranslationManager.translate("settings.search.placeholder", "Search settings...")
                 accessibleName: TranslationManager.translate("settings.search.placeholder", "Search settings")
+                // Hint the Android IME away from autocorrect; some IMEs ignore this,
+                // so the filter above also reads displayText rather than text.
+                inputMethodHints: Qt.ImhNoPredictiveText
             }
         }
 

--- a/qml/pages/settings/StringBrowserPage.qml
+++ b/qml/pages/settings/StringBrowserPage.qml
@@ -266,6 +266,9 @@ Page {
                             font: Theme.bodyFont
                             color: Theme.textColor
                             clip: true
+                            // Hint the Android IME away from autocorrect; some IMEs ignore
+                            // this, so we also filter via displayText (see below).
+                            inputMethodHints: Qt.ImhNoPredictiveText
 
                             Accessible.role: Accessible.EditableText
                             Accessible.name: TranslationManager.translate("stringBrowser.accessible.searchStrings", "Search strings")
@@ -277,11 +280,13 @@ Page {
                                 text: TranslationManager.translate("stringBrowser.searchPlaceholder", "Search strings...")
                                 font: parent.font
                                 color: Theme.textSecondaryColor
-                                visible: !parent.text && !parent.activeFocus
+                                visible: !parent.displayText && !parent.activeFocus
                                 verticalAlignment: Text.AlignVCenter
                             }
 
-                            onTextChanged: stringModel.searchFilter = text
+                            // Drive filter from displayText (includes IME preedit) so results
+                            // update on every keystroke on Android. See SuggestionField.qml.
+                            onDisplayTextChanged: stringModel.searchFilter = displayText
                         }
 
                         Text {
@@ -290,7 +295,7 @@ Page {
                             text: "\u{2715}"
                             font.pixelSize: Theme.scaled(14)
                             color: Theme.textSecondaryColor
-                            visible: searchField.text !== ""
+                            visible: searchField.displayText !== ""
 
                             Accessible.role: Accessible.Button
                             Accessible.name: TranslationManager.translate("stringBrowser.accessible.clearSearch", "Clear search")


### PR DESCRIPTION
## Summary
Follow-up to #758 (SuggestionField). The same Android IME preedit bug affects every filter-as-you-type search bar in the app: while Gboard holds a word in composition, \`text\` / \`onTextChanged\` don't fire per keystroke, so the filter only updates after the user presses space, punctuation, or delete.

Applies the same mechanical fix (read \`displayText\` instead of \`text\`, trigger off \`onDisplayTextChanged\`) to:

- **Profile selector** — \`qml/pages/ProfileSelectorPage.qml\` (All Profiles search)
- **Settings search dialog** — \`qml/pages/settings/SettingsSearchDialog.qml\`
- **Shot history search** — \`qml/pages/ShotHistoryPage.qml\` (previously had \`Qt.ImhNoPredictiveText\` alone; that's not reliable on Gboard)
- **String browser** — \`qml/pages/settings/StringBrowserPage.qml\` (translation debug page)

\`Qt.ImhNoPredictiveText\` is kept / added everywhere as a best-effort autocorrect suppressor on IMEs that honor it. The displayText driver is what actually fixes the filter.

Desktop/macOS is unchanged — \`displayText === text\` on platforms without IME preedit.

## Test plan
On Android with Gboard (or the stock IME):
- [ ] **Profile selector** → *All Profiles* tab, search field: type one letter → list filters immediately.
- [ ] **Settings search** (gear icon → search): type one letter → results filter immediately.
- [ ] **Shot history**: search field filters per keystroke (no delay until space).
- [ ] **Settings → String browser**: type to filter translation strings — filters per keystroke.
- [ ] Each search's clear (X) button appears once any character is typed, even during preedit.

On macOS (regression check): all four search bars still filter normally as you type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)