### PR TITLE
de1device: treat HEADER_WRITE as barrier in profile-upload tracker

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -893,8 +893,19 @@ void DE1Device::onProfileUploadWriteComplete(const QBluetoothUuid& uuid,
                                              const QByteArray& data)
 {
     if (uuid == DE1::Characteristic::HEADER_WRITE) {
+        // Treat every HEADER_WRITE completion as a barrier. Any FRAME_WRITE
+        // acks observed before this point were leftovers from a write batch
+        // queued before our upload (notably the basic-profile header+frames
+        // in sendInitialSettings(), which run on every BLE (re)connect and
+        // drain between when our tracker attaches and when our own header
+        // is ACKed). Clearing on the header ensures the seen-sequence only
+        // reflects frames that followed our own header.
+        m_uploadSeenFrameBytes.clear();
         m_uploadHeaderAcked = true;
     } else if (uuid == DE1::Characteristic::FRAME_WRITE) {
+        // Ignore any FRAME_WRITE acks that arrive before the header barrier —
+        // those belong to a prior (non-tracked) write batch.
+        if (!m_uploadHeaderAcked) return;
         m_uploadSeenFrameBytes.append(data.isEmpty()
                                           ? 0
                                           : static_cast<uint8_t>(data.at(0)));

--- a/tests/tst_profileupload.cpp
+++ b/tests/tst_profileupload.cpp
@@ -221,6 +221,99 @@ private slots:
         QCOMPARE(spy.takeFirst().at(0).toBool(), true);
     }
 
+    // ===== Regression: leftover FRAME_WRITE acks from a prior batch ignored =====
+    //
+    // Reproduces the first-connect profile-upload failure documented in the
+    // logs: sendInitialSettings() writes a basic profile (1 HEADER + 2 FRAMEs)
+    // to the DE1 before the user profile is uploaded. Those writes sit in the
+    // transport's queue when startProfileUploadTracking() attaches to
+    // writeComplete. As they drain, their FRAME_WRITE acks leak into the new
+    // tracker, so the first three "seen" frame bytes are [0x00, 0x01, ...]
+    // from the basic frames instead of the user profile's real frames, and
+    // the sequence check fails. The retry fires 1s later, by which time the
+    // queue is drained, and succeeds.
+    //
+    // Fix: treat HEADER_WRITE completion as a barrier — clear any frame bytes
+    // accumulated before our header lands, and ignore FRAME_WRITE acks that
+    // arrive before the header. This test asserts both behaviours.
+
+    void leakedFrameAcksBeforeOurHeaderAreIgnored() {
+        MockTransport transport;
+        DE1Device device;
+        device.setTransport(&transport);
+
+        QSignalSpy spy(&device, &DE1Device::profileUploaded);
+
+        device.uploadProfile(makeSimpleProfile());
+
+        // Simulate the two basic-profile FRAME_WRITE acks from a prior
+        // (non-tracked) batch landing AFTER our tracker attaches but BEFORE
+        // our own HEADER_WRITE is acked. Our gate should drop them.
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     QByteArray(1, char(0x00)));  // basic frame 0
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     QByteArray(1, char(0x01)));  // basic tail frame
+
+        // No verdict yet — leaked frames are ignored, header still pending.
+        QCOMPARE(spy.count(), 0);
+
+        // Now our actual acks flow through in order.
+        emit transport.writeComplete(DE1::Characteristic::HEADER_WRITE,
+                                     transport.writes.at(0).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(1).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(2).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(3).second);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.takeFirst().at(0).toBool(), true);
+    }
+
+    // Variant of the above: the prior batch's HEADER_WRITE ack ALSO arrives
+    // after tracker attach (plausible when the tracker attaches between the
+    // prior header's queueing and its completion). That header would flip
+    // m_uploadHeaderAcked = true and the subsequent leaked frame acks would
+    // pass the gate. The fix additionally clears accumulated frame bytes on
+    // every HEADER_WRITE — so when our own header lands, the leaked frames
+    // are wiped out before our real frames accumulate.
+
+    void leakedHeaderAndFrameAcksAreWipedByOurHeader() {
+        MockTransport transport;
+        DE1Device device;
+        device.setTransport(&transport);
+
+        QSignalSpy spy(&device, &DE1Device::profileUploaded);
+
+        device.uploadProfile(makeSimpleProfile());
+
+        // Simulate the full prior batch (HEADER + 2 FRAMEs) landing after
+        // tracker attach. The leaked frames would be appended, but our own
+        // HEADER_WRITE ack must wipe them.
+        emit transport.writeComplete(DE1::Characteristic::HEADER_WRITE,
+                                     QByteArray(5, 0));           // prior header
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     QByteArray(1, char(0x00)));  // prior frame 0
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     QByteArray(1, char(0x01)));  // prior tail frame
+
+        QCOMPARE(spy.count(), 0);
+
+        // Our own header lands — wipes the leaked frames.
+        emit transport.writeComplete(DE1::Characteristic::HEADER_WRITE,
+                                     transport.writes.at(0).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(1).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(2).second);
+        emit transport.writeComplete(DE1::Characteristic::FRAME_WRITE,
+                                     transport.writes.at(3).second);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.takeFirst().at(0).toBool(), true);
+    }
+
     // ===== Disconnect mid-upload surfaces a failure =====
 
     void disconnectMidUploadReportsFailure() {


### PR DESCRIPTION
## Summary
Every BLE (re)connect, \`DE1Device::sendInitialSettings()\` writes a basic "stub" profile (1 header + 2 frames) to the DE1 before \`MainController\` uploads the user's real profile. \`startProfileUploadTracking()\` attaches to \`DE1Transport::writeComplete\` when \`uploadProfile()\` runs, but the stub's writes are still draining from the transport queue at that point. Their \`FRAME_WRITE\` acks leak into the new tracker, so the first two entries of \`m_uploadSeenFrameBytes\` are always \`[0x00, 0x01]\` — the stub's leading frame bytes — and the tracker fills up after only 3 of the user profile's real frame acks arrive.

This is exactly what we've been seeing on every session's first connect:
\`\`\`
expected [0x00, 0x01, 0x02, 0x22, 0x03]   (D-Flow/Q's 5 writes)
got      [0x00, 0x01, 0x00, 0x01, 0x02]   (2 leaked + 3 of user's)
\`\`\`

The ProfileManager's 1-second retry succeeds every time because the transport queue is fully drained by then — which is why this surfaced as "retry always succeeds on attempt 1 of 5" chatter rather than a user-visible failure.

## Fix
Two small changes in \`onProfileUploadWriteComplete()\` (src/ble/de1device.cpp):
1. **Clear \`m_uploadSeenFrameBytes\` whenever a \`HEADER_WRITE\` completes** — wipes any leaked frames accumulated before our own header lands.
2. **Ignore \`FRAME_WRITE\` acks that arrive before any \`HEADER_WRITE\` has been acked** — drops leaked frames whose prior header completed before the tracker even attached.

## Tests
Adds two regression cases to \`tests/tst_profileupload.cpp\`:
- \`leakedFrameAcksBeforeOurHeaderAreIgnored\` — leaked frames land before our header; must be dropped.
- \`leakedHeaderAndFrameAcksAreWipedByOurHeader\` — full prior batch (header + frames) leaks in; our own header must wipe them.

All existing tests still pass — the new semantics don't change any pre-existing behavior.

## Follow-up (separate PR)
The root cause of the leak is the stub profile in \`sendInitialSettings()\`. \`de1app\`'s equivalent (\`later_new_de1_connection_setup\` → \`de1_send_shot_frames\`) actually sends the user's current profile, not a stub, so the stub has no purpose here beyond being immediately overwritten by \`applyAllSettings\`. Worth removing in a follow-up — this PR handles the tracker's robustness regardless.

## Test plan
- [ ] Build succeeds; \`tst_profileupload\` passes on CI.
- [ ] Android: install APK, observe \`adb logcat\` on fresh connect — the \`profile upload FAILED — frame sequence mismatch\` warning should no longer fire at startup, and no \`ProfileManager: retrying failed profile upload\` line either.
- [ ] Pull a shot to confirm profile still uploads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)