### PR TITLE
de1device: drop stub profile from sendInitialSettings

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1145,34 +1145,15 @@ void DE1Device::sendInitialSettings() {
         writeMMR(DE1::MMR::TANK_TEMP_THRESHOLD, 0);
     }
 
-    // Send a basic profile header (5 bytes)
-    QByteArray header(5, 0);
-    header[0] = 1;   // HeaderV
-    header[1] = 1;   // NumberOfFrames
-    header[2] = 0;   // NumberOfPreinfuseFrames
-    header[3] = 0;   // MinimumPressure (U8P4)
-    header[4] = 96;  // MaximumFlow (U8P4) = 6.0 * 16
-
-    m_transport->write(DE1::Characteristic::HEADER_WRITE, header);
-
-    // Send a basic profile frame (8 bytes)
-    QByteArray frame(8, 0);
-    frame[0] = 0;    // FrameToWrite = 0
-    frame[1] = 0;    // Flag
-    frame[2] = static_cast<char>(144);  // SetVal (U8P4) = 9.0 * 16 = 144
-    frame[3] = static_cast<char>(186);  // Temp (U8P1) = 93.0 * 2 = 186
-    frame[4] = 62;   // FrameLen (F8_1_7)
-    frame[5] = 0;    // TriggerVal
-    frame[6] = 0;    // MaxVol high byte
-    frame[7] = 0;    // MaxVol low byte
-
-    m_transport->write(DE1::Characteristic::FRAME_WRITE, frame);
-
-    // Send tail frame
-    QByteArray tailFrame(8, 0);
-    tailFrame[0] = 1;    // FrameToWrite = NumberOfFrames
-
-    m_transport->write(DE1::Characteristic::FRAME_WRITE, tailFrame);
+    // NOTE: de1app's equivalent (later_new_de1_connection_setup →
+    // de1_send_shot_frames) writes the user's current profile here, not a
+    // stub. We used to write a hardcoded 1-frame 9-bar profile ("to trigger
+    // wake-up response") — it served no purpose beyond being overwritten by
+    // MainController::applyAllSettings() ~500 ms later, and its leftover
+    // FRAME_WRITE acks leaked into the next profile-upload tracker (see
+    // onProfileUploadWriteComplete's HEADER_WRITE barrier). The user's real
+    // profile is sent after `initialSettingsComplete` fires, so there's
+    // nothing to send here.
 
     // Read GHC info via MMR
     QByteArray mmrRead(20, 0);

--- a/tests/tst_profileupload.cpp
+++ b/tests/tst_profileupload.cpp
@@ -223,19 +223,18 @@ private slots:
 
     // ===== Regression: leftover FRAME_WRITE acks from a prior batch ignored =====
     //
-    // Reproduces the first-connect profile-upload failure documented in the
-    // logs: sendInitialSettings() writes a basic profile (1 HEADER + 2 FRAMEs)
-    // to the DE1 before the user profile is uploaded. Those writes sit in the
-    // transport's queue when startProfileUploadTracking() attaches to
-    // writeComplete. As they drain, their FRAME_WRITE acks leak into the new
-    // tracker, so the first three "seen" frame bytes are [0x00, 0x01, ...]
-    // from the basic frames instead of the user profile's real frames, and
-    // the sequence check fails. The retry fires 1s later, by which time the
-    // queue is drained, and succeeds.
-    //
-    // Fix: treat HEADER_WRITE completion as a barrier — clear any frame bytes
-    // accumulated before our header lands, and ignore FRAME_WRITE acks that
-    // arrive before the header. This test asserts both behaviours.
+    // Historical context: sendInitialSettings() used to write a stub profile
+    // (1 HEADER + 2 FRAMEs) on every (re)connect before the user profile was
+    // uploaded. Those writes sat in the transport queue when the tracker
+    // attached to writeComplete, and their FRAME_WRITE acks leaked into the
+    // new tracker — the first two "seen" frame bytes were always [0x00, 0x01]
+    // from the stub, and the sequence check failed until a 1-second retry.
+    // The stub was subsequently removed, but the tracker still needs to be
+    // robust against any future code path that leaves writes pending at
+    // attach time (e.g. a shot-settings retry, or a refill-kit probe). These
+    // tests lock in the two defenses that prevent the leak:
+    //   (1) FRAME_WRITE acks before our HEADER_WRITE are ignored
+    //   (2) every HEADER_WRITE ack clears accumulated frame bytes
 
     void leakedFrameAcksBeforeOurHeaderAreIgnored() {
         MockTransport transport;


### PR DESCRIPTION
## Summary
Follow-up to #761. Removes the stub profile (1 header + 2 frames, hardcoded 9-bar / 93 °C / 30 s) that \`DE1Device::sendInitialSettings()\` used to write at every BLE (re)connect.

## Why the stub was useless
- **\`de1app\` doesn't do this.** Its equivalent (\`later_new_de1_connection_setup\` → \`de1_send_shot_frames\` in \`bluetooth.tcl\`/\`de1_comms.tcl\`) writes the **user's current profile**, not a stub. Decenza's implementer lifted the structure but hardcoded a placeholder because \`DE1Device\` can't easily reach the user profile from inside the BLE layer.
- **It's immediately overwritten.** \`sendInitialSettings\` emits \`initialSettingsComplete\`, which \`MainController::applyAllSettings()\` handles by calling \`ProfileManager::uploadCurrentProfile()\` ~500 ms later. The stub lives on the DE1 for less than a second before being replaced.
- **It doesn't "wake" anything.** The state/temperature/water-level notifications fire from their own characteristic subscriptions as soon as those are enabled — no profile required.
- **It was the source of #761's bug.** Its leftover \`FRAME_WRITE\` acks leaked into the next profile-upload tracker. #761 added the HEADER_WRITE barrier as a defense in depth; this PR removes the leak itself.

## Side benefit
Between the stub upload and the user's real upload, the DE1 would be running a random 9-bar profile. If the user somehow triggered a shot in that window (via relay, MCP, or direct button press on a headless machine), they'd get the wrong profile. Now the DE1 keeps whatever profile it already had (typically from the last session) until the user's real profile arrives.

## Test plan
- [ ] Build succeeds; all existing tests still pass (the regression tests in \`tst_profileupload.cpp\` don't depend on \`sendInitialSettings\` — they simulate the leak pattern directly with \`MockTransport\`).
- [ ] Android: install, verify BLE connect still works and the user's profile uploads successfully on first connect.
- [ ] Pull a shot to confirm the user's profile actually runs (not some stale cached profile on the DE1).
- [ ] Check \`adb logcat\` on connect — should see only one \`Uploading profile\` + one \`profile upload verified\` line, with no \`profile upload FAILED\` warning and no retry.

## Net
3 fewer BLE writes on every (re)connect. No behavior change for the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)