### PR TITLE
ai: add overall shot peaks to summarizer

### DIFF
--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -544,6 +544,24 @@ QString ShotSummarizer::buildUserPrompt(const ShotSummary& summary) const
         if (summary.drinkEy > 0) out << "EY " << QString::number(summary.drinkEy, 'f', 1) << "%";
         out << "\n";
     }
+
+    // Overall shot peaks across ALL phases — so the AI can compare against profile peak-pressure
+    // targets (e.g. D-Flow "grind for 6–9 bar peak") without conflating per-phase peaks.
+    {
+        double peakPressureVal = 0, peakPressureTime = 0;
+        for (const auto& pt : summary.pressureCurve) {
+            if (pt.y() > peakPressureVal) { peakPressureVal = pt.y(); peakPressureTime = pt.x(); }
+        }
+        double peakFlowVal = 0, peakFlowTime = 0;
+        for (const auto& pt : summary.flowCurve) {
+            if (pt.y() > peakFlowVal) { peakFlowVal = pt.y(); peakFlowTime = pt.x(); }
+        }
+        if (peakPressureVal > 0.1 || peakFlowVal > 0.1) {
+            out << "- **Overall shot peaks**: ";
+            out << "pressure " << QString::number(peakPressureVal, 'f', 2) << " bar @" << QString::number(peakPressureTime, 'f', 0) << "s, ";
+            out << "flow " << QString::number(peakFlowVal, 'f', 2) << " ml/s @" << QString::number(peakFlowTime, 'f', 0) << "s\n";
+        }
+    }
     out << "\n";
 
     // Profile recipe (frame sequence)
@@ -578,7 +596,7 @@ QString ShotSummarizer::buildUserPrompt(const ShotSummary& summary) const
                 if (pt.x() < phase.startTime || pt.x() > phase.endTime) continue;
                 if (pt.y() > peakFlowVal) { peakFlowVal = pt.y(); peakFlowTime = pt.x(); }
             }
-            out << "- Phase peaks: ";
+            out << "- Peak within this phase only: ";
             out << "pressure " << QString::number(peakPressureVal, 'f', 2) << " bar @" << QString::number(peakPressureTime, 'f', 0) << "s, ";
             out << "flow " << QString::number(peakFlowVal, 'f', 2) << " ml/s @" << QString::number(peakFlowTime, 'f', 0) << "s\n";
         }


### PR DESCRIPTION
## Summary

- The AI shot summarizer emitted per-phase "Phase peaks" lines but no shot-wide peak, which caused the advisor to cite a pour-phase peak as "the" peak pressure on profiles where pressure peaks before the pour (D-Flow, Londinium, lever, blooming). On shot #854 the advisor reported a 3.9 bar peak, while the graph clearly showed ~5 bar — the actual 5.01 bar peak occurred during the Infusing phase.
- Adds an "Overall shot peaks" line to the top summary bullets so the AI can compare against profile peak-pressure targets (e.g. D-Flow / Q's stated "grind for 6–9 bar peak") and make concrete grind recommendations.
- Renames the per-phase label from "Phase peaks:" to "Peak within this phase only:" so the AI can't conflate it with the shot peak.

## Test plan

- [ ] Build succeeds in Qt Creator
- [ ] Run an AI analysis on a D-Flow shot and confirm the "Overall shot peaks" line appears in the prompt and the advisor no longer quotes the pour-only peak as the overall peak

🤖 Generated with [Claude Code](https://claude.com/claude-code)