### PR TITLE
fix: skip goToIdle on manual shot stop to avoid idle flash

### DIFF
--- a/qml/pages/EspressoPage.qml
+++ b/qml/pages/EspressoPage.qml
@@ -95,13 +95,19 @@ Page {
     Keys.onEscapePressed: {
         root.stopReason = "manual"
         DE1Device.stopOperation()
-        root.goToIdle()
+        // Don't navigate — main.qml's stop-overlay flow navigates to shot
+        // review (or idle if Edit After Shot is off) after the overlay times
+        // out. Navigating immediately caused a flash of the idle page before
+        // the shot review appeared.
     }
 
     Keys.onSpacePressed: {
         root.stopReason = "manual"
         DE1Device.stopOperation()
-        root.goToIdle()
+        // Don't navigate — main.qml's stop-overlay flow navigates to shot
+        // review (or idle if Edit After Shot is off) after the overlay times
+        // out. Navigating immediately caused a flash of the idle page before
+        // the shot review appeared.
     }
 
     // Additional keyboard navigation for accessibility
@@ -122,7 +128,7 @@ Page {
         if (event.key === Qt.Key_Backspace) {
             root.stopReason = "manual"
             DE1Device.stopOperation()
-            root.goToIdle()
+            // Don't navigate — main.qml's stop-overlay flow handles navigation
             event.accepted = true
         }
     }
@@ -632,13 +638,13 @@ Page {
         Keys.onReturnPressed: {
             root.stopReason = "manual"
             DE1Device.stopOperation()
-            root.goToIdle()
+            // Don't navigate — main.qml's stop-overlay flow handles navigation
             event.accepted = true
         }
         Keys.onSpacePressed: {
             root.stopReason = "manual"
             DE1Device.stopOperation()
-            root.goToIdle()
+            // Don't navigate — main.qml's stop-overlay flow handles navigation
             event.accepted = true
         }
 
@@ -659,7 +665,7 @@ Page {
             onAccessibleClicked: {
                 root.stopReason = "manual"
                 DE1Device.stopOperation()
-                root.goToIdle()
+                // Don't navigate — main.qml's stop-overlay flow handles navigation
             }
         }
     }
@@ -705,18 +711,18 @@ Page {
                 Accessible.onPressAction: {
                     root.stopReason = "manual"
                     DE1Device.stopOperation()
-                    root.goToIdle()
+                    // Don't navigate — main.qml's stop-overlay flow handles navigation
                 }
                 Keys.onReturnPressed: {
                     root.stopReason = "manual"
                     DE1Device.stopOperation()
-                    root.goToIdle()
+                    // Don't navigate — main.qml's stop-overlay flow handles navigation
                     event.accepted = true
                 }
                 Keys.onSpacePressed: {
                     root.stopReason = "manual"
                     DE1Device.stopOperation()
-                    root.goToIdle()
+                    // Don't navigate — main.qml's stop-overlay flow handles navigation
                     event.accepted = true
                 }
 
@@ -743,7 +749,7 @@ Page {
                     onAccessibleClicked: {
                         root.stopReason = "manual"
                         DE1Device.stopOperation()
-                        root.goToIdle()
+                        // Don't navigate — main.qml's stop-overlay flow handles navigation
                     }
                 }
             }

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -544,6 +544,24 @@ QString ShotSummarizer::buildUserPrompt(const ShotSummary& summary) const
         if (summary.drinkEy > 0) out << "EY " << QString::number(summary.drinkEy, 'f', 1) << "%";
         out << "\n";
     }
+
+    // Overall shot peaks across ALL phases — so the AI can compare against profile peak-pressure
+    // targets (e.g. D-Flow "grind for 6–9 bar peak") without conflating per-phase peaks.
+    {
+        double peakPressureVal = 0, peakPressureTime = 0;
+        for (const auto& pt : summary.pressureCurve) {
+            if (pt.y() > peakPressureVal) { peakPressureVal = pt.y(); peakPressureTime = pt.x(); }
+        }
+        double peakFlowVal = 0, peakFlowTime = 0;
+        for (const auto& pt : summary.flowCurve) {
+            if (pt.y() > peakFlowVal) { peakFlowVal = pt.y(); peakFlowTime = pt.x(); }
+        }
+        if (peakPressureVal > 0.1 || peakFlowVal > 0.1) {
+            out << "- **Overall shot peaks**: ";
+            out << "pressure " << QString::number(peakPressureVal, 'f', 2) << " bar @" << QString::number(peakPressureTime, 'f', 0) << "s, ";
+            out << "flow " << QString::number(peakFlowVal, 'f', 2) << " ml/s @" << QString::number(peakFlowTime, 'f', 0) << "s\n";
+        }
+    }
     out << "\n";
 
     // Profile recipe (frame sequence)
@@ -578,7 +596,7 @@ QString ShotSummarizer::buildUserPrompt(const ShotSummary& summary) const
                 if (pt.x() < phase.startTime || pt.x() > phase.endTime) continue;
                 if (pt.y() > peakFlowVal) { peakFlowVal = pt.y(); peakFlowTime = pt.x(); }
             }
-            out << "- Phase peaks: ";
+            out << "- Peak within this phase only: ";
             out << "pressure " << QString::number(peakPressureVal, 'f', 2) << " bar @" << QString::number(peakPressureTime, 'f', 0) << "s, ";
             out << "flow " << QString::number(peakFlowVal, 'f', 2) << " ml/s @" << QString::number(peakFlowTime, 'f', 0) << "s\n";
         }


### PR DESCRIPTION
## Summary

- When you tap Stop on EspressoPage, the screen briefly flashes to the idle page before the shot review page appears a few seconds later. The auto-end path (shot finishes on its own) doesn't have this bug.
- Root cause: manual-stop handlers in EspressoPage called goToIdle() immediately, then main.qml's stop-overlay timer (3s) pushed the shot review on top.
- Fix: remove the immediate goToIdle() from all 10 manual-stop handlers. Navigation is now handled uniformly by main.qml's stop-overlay flow for both manual and auto-end paths — the stop overlay renders on top of EspressoPage, then after the timer navigation goes directly to shot review (or idle if Edit After Shot is off).

Safe because EspressoPage is only reached during active espresso phases, so wasEspressoOperation is true when the shot-end flow fires, guaranteeing the overlay timer navigates correctly.

## Test plan

- [ ] Tap Stop during a shot with Edit After Shot ON → no idle flash, goes straight to shot review after the stop overlay
- [ ] Tap Stop with Edit After Shot OFF → no idle flash, goes to idle after the stop overlay
- [ ] Let a shot auto-end (SAW/SAV/profile) → unchanged behavior (straight to shot review after overlay)
- [ ] Keyboard Escape / Space / Backspace on EspressoPage all stop the shot and navigate correctly
- [ ] Physical STOP button (headless machines) and back button both stop cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)