### PR TITLE
fix: navigate directly to shot review when SAW settling outlasts overlay

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1802,8 +1802,10 @@ ApplicationWindow {
                     goToIdle()
                 }
             } else {
-                // pendingMetadataNavigation is only set by onShotEndedShowMetadata (Edit After
-                // Shot ON). If false here, post-shot review is disabled — go straight to idle.
+                // pendingMetadataNavigation is set by onShotEndedShowMetadata only when
+                // the overlay was still visible at signal time. False here means either
+                // Edit After Shot is OFF, or the shot save arrived after the overlay
+                // expired (SAW settling outlasted 3s) and was handled directly.
                 goToIdle()
             }
         }
@@ -2713,11 +2715,22 @@ ApplicationWindow {
                 stopOverlayTimer.restart()
             } else {
                 // Stop overlay already expired (e.g. SAW settling outlasted the
-                // 3s overlay timer and goToIdle already ran). Navigate directly
-                // to shot review instead of restarting the timer for another 3s.
+                // 3s overlay timer). Navigate directly to shot review instead of
+                // restarting the timer for another 3s.
+
+                // Guard: if a new shot started while the old one was still saving,
+                // onShotStarted cleared the overlay but this stale signal arrived
+                // late. Don't interrupt the active shot.
+                var currentPage = pageStack.currentItem ? pageStack.currentItem.objectName : ""
+                if (currentPage === "espressoPage") {
+                    console.log("Post-shot navigation: new shot in progress, skipping stale review")
+                    return
+                }
+
                 var timeout = Number(Settings.value("postShotReviewTimeout", 31))
                 if (timeout === 0) {
-                    console.log("Post-shot review: Instant timeout, staying on idle")
+                    console.log("Post-shot review: Instant timeout, going to idle")
+                    goToIdle()
                 } else if (root.pendingShotId > 0) {
                     goToShotMetadata(root.pendingShotId)
                 } else {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -2704,10 +2704,26 @@ ApplicationWindow {
 
         function onShotEndedShowMetadata() {
             root.pendingShotId = MainController.lastSavedShotId
-            root.pendingMetadataNavigation = true
-            console.log("Shot ended, will navigate after stop overlay. shotId:", root.pendingShotId)
-            // Restart stop overlay timer to ensure it survives the page change
-            stopOverlayTimer.restart()
+            console.log("Shot ended, navigate to review. shotId:", root.pendingShotId,
+                        "overlayVisible:", root.stopOverlayVisible)
+
+            if (root.stopOverlayVisible) {
+                // Stop overlay still showing — defer navigation to when it expires
+                root.pendingMetadataNavigation = true
+                stopOverlayTimer.restart()
+            } else {
+                // Stop overlay already expired (e.g. SAW settling outlasted the
+                // 3s overlay timer and goToIdle already ran). Navigate directly
+                // to shot review instead of restarting the timer for another 3s.
+                var timeout = Number(Settings.value("postShotReviewTimeout", 31))
+                if (timeout === 0) {
+                    console.log("Post-shot review: Instant timeout, staying on idle")
+                } else if (root.pendingShotId > 0) {
+                    goToShotMetadata(root.pendingShotId)
+                } else {
+                    console.warn("Post-shot navigation: no valid pendingShotId after overlay expired")
+                }
+            }
         }
     }
 

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -386,9 +386,16 @@ void ShotTimingController::onDisplayTimerTick()
                 avg += m_settlingWindow[i];
             if (m_settlingWindowCount > 0)
                 avg /= m_settlingWindowCount;
-            if (m_settlingWindowCount > 0 && m_weight > avg + SETTLING_ABOVE_AVG_MARGIN) {
-                // BLE silence during active drip: weight is still above rolling avg.
-                // Don't declare stable — reset stable clock and wait for more samples.
+            if (stableMs >= SETTLING_SILENCE_OVERRIDE_MS) {
+                // Weight hasn't changed by 0.1g in 2+ seconds — definitely stable.
+                // The rolling avg is polluted by early rising samples and can't
+                // catch up without new readings, so bypass the avg margin check.
+                qDebug() << "[SAW] Weight stabilized at" << m_weight << "g (no change for" << stableMs << "ms, detected by timer)";
+                m_settlingTimer.stop();
+                onSettlingComplete();
+            } else if (m_settlingWindowCount > 0 && m_weight > avg + SETTLING_ABOVE_AVG_MARGIN) {
+                // BLE silence during potential active drip (1-2s): weight above
+                // rolling avg. Wait for more samples before declaring stable.
                 qDebug() << "[SAW] Timer: silent but weight" << QString::number(m_weight, 'f', 1)
                          << "g still above avg" << QString::number(avg, 'f', 1)
                          << "g - drip may still be ongoing";

--- a/src/controllers/shottimingcontroller.h
+++ b/src/controllers/shottimingcontroller.h
@@ -152,6 +152,7 @@ private:
     static constexpr double SETTLING_AVG_THRESHOLD = 0.3;  // Max avg drift to declare stable (g)
     static constexpr int SETTLING_STABLE_MS = 1000;        // How long avg must be stable (ms)
     static constexpr double SETTLING_ABOVE_AVG_MARGIN = 0.2; // Current weight must be within this of avg to declare stable (g)
+    static constexpr int SETTLING_SILENCE_OVERRIDE_MS = 2000; // If weight unchanged for this long, declare stable regardless of avg margin
     double m_settlingWindow[SETTLING_WINDOW_SIZE] = {};
     int m_settlingWindowCount = 0;
     int m_settlingWindowIndex = 0;


### PR DESCRIPTION
## Summary

- After a SAW-triggered shot end, the app briefly shows the idle page before navigating to the shot review page. This happens because SAW weight settling (4–8s on the last two shots) outlasts the 3-second stop overlay timer.
- Root cause: `stopOverlayTimer` fires at 3s, sees `pendingMetadataNavigation == false` (shot not saved yet — still settling), runs `goToIdle()`. When the shot finally saves and `shotEndedShowMetadata` fires, it just restarts the timer for another 3 seconds on idle.
- Fix: in `onShotEndedShowMetadata`, check `stopOverlayVisible`. If the overlay is still showing, use the existing deferred path. If it already expired (settling took too long), navigate directly to shot review — no timer restart, no idle flash.

Evidence from app log (shot 854):
- `[7558.487]` stop overlay shown, 3s timer starts
- `[7561.5]` timer fires, `pendingMetadataNavigation == false` → `goToIdle()`
- `[7562.463]` shot saved, `shotEndedShowMetadata` fires, restarts timer for 3 more seconds
- `[7565.5]` timer fires again → finally navigates to shot review

Shot 853 was even worse — settling took 8 seconds.

## Test plan

- [ ] Pull a SAW-triggered shot → should go directly from espresso (with overlay) to shot review, no idle flash
- [ ] If settling is fast (<3s), the overlay path should work unchanged
- [ ] With Edit After Shot OFF, should still go to idle normally after overlay
- [ ] With postShotReviewTimeout = 0 (Instant), should stay on idle even after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)