### PR TITLE
fix: restore firmware-handled steam timeout for GHC purge puff

### DIFF
--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -839,7 +839,14 @@ void MachineState::checkStopAtTime() {
 
     double target = 0;
     if (m_phase == Phase::Steaming) {
-        target = m_settings->steamTimeout();
+        // Steam timeout is handled by DE1 firmware via ShotSettings.steamTimeout.
+        // The firmware stops steam flow but keeps the machine in Steaming state so
+        // pressing GHC Stop triggers a final cleaning purge puff. App-side stop
+        // exits steaming entirely, killing the GHC light and purge opportunity.
+        // Only use app-side stop for the simulator (which has no firmware timer).
+        if (m_device && m_device->simulationMode()) {
+            target = m_settings->steamTimeout();
+        }
     } else if (m_phase == Phase::Flushing) {
         target = m_settings->flushSeconds();
     } else {


### PR DESCRIPTION
## Summary

- Commit e7c33f6c ("enable app-side stop-on-time for steam on real hardware") removed a simulator-only guard, causing the app to call `stopOperation()` when the steam timer expired. This exits steaming entirely — GHC red light goes off, no purge opportunity.
- The DE1 firmware intentionally handles steam timeout differently from flush: it stops steam flow but keeps the machine in Steaming state so pressing GHC Stop triggers a final cleaning purge puff.
- Restores the simulator-only guard with an expanded comment explaining why steam and flush are handled differently.

Reported by a user: "When the steam timer finishes, the machine gives 3 or 4 short puffs and then stops, and the red steam button on the GHC is no longer illuminated. Previously I could press Stop for one final large purge."

## Test plan

- [ ] Steam with a timer set — when timer expires, GHC red light should stay on and machine should remain in Steaming state (steam flow stops)
- [ ] Press GHC Stop after timer expires — should trigger the final purge puff
- [ ] Simulator still auto-stops steam when timer expires
- [ ] Flush timer still works as before (app-side stop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)