### PR TITLE
fix: commit IME composing text before save/send

### DIFF
--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -465,6 +465,7 @@ Rectangle {
                         Keys.onEnterPressed: sendFollowUp()
 
                         function sendFollowUp() {
+                            Qt.inputMethod.commit()
                             if (text.length === 0) return
                             if (!MainController.aiManager || !MainController.aiManager.conversation) return
 

--- a/qml/components/ExpandableTextArea.qml
+++ b/qml/components/ExpandableTextArea.qml
@@ -318,6 +318,7 @@ Rectangle {
                     primary: !root.readOnly
                     visible: root.isMobile
                     onClicked: {
+                        Qt.inputMethod.commit()
                         if (!root.readOnly) {
                             root.text = dialogTextArea.text
                             root.editingFinished()
@@ -420,6 +421,7 @@ Rectangle {
                     accessibleName: root.readOnly ? TranslationManager.translate("common.close", "Close") : TranslationManager.translate("common.save", "Save")
                     primary: !root.readOnly
                     onClicked: {
+                        Qt.inputMethod.commit()
                         if (!root.readOnly) {
                             root.text = dialogTextArea.text
                             root.editingFinished()

--- a/qml/components/layout/CustomEditorPopup.qml
+++ b/qml/components/layout/CustomEditorPopup.qml
@@ -106,6 +106,7 @@ Dialog {
     }
 
     function doSave() {
+        Qt.inputMethod.commit()
         // Extract segments from document and compile to HTML
         var segments = formatter.toSegments()
         var html = formatter.segmentsToHtml(segments)

--- a/qml/components/layout/CustomEditorPopup.qml
+++ b/qml/components/layout/CustomEditorPopup.qml
@@ -733,6 +733,7 @@ Dialog {
                                 id: bgColorMa
                                 anchors.fill: parent
                                 onClicked: {
+                                    Qt.inputMethod.commit()
                                     colorPickerPopup.mode = "bg"
                                     colorPickerPopup.initialColor = popup.textBackgroundColor
                                         ? Qt.color(popup.textBackgroundColor) : Qt.color("#333333")

--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -181,6 +181,7 @@ Page {
 
     // Save edited shot back to history
     function saveEditedShot() {
+        Qt.inputMethod.commit()
         if (editShotId <= 0) return
         var metadata = {
             "beanBrand": editBeanBrand,

--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -237,6 +237,7 @@ Page {
     // Update the currently-selected preset's data with the current DYE field values.
     // Used by "Save" (not "Save As") when a preset was selected before editing.
     function saveToCurrentPreset(pendingPresetIndex, goBackAfter) {
+        Qt.inputMethod.commit()
         var idx = _snapSelectedPreset
         if (idx < 0) return
         var preset = Settings.getBeanPreset(idx)

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -772,7 +772,7 @@ Page {
                                 editDoseWeight = newValue
                                 calculateEy()
                             }
-                            onActiveFocusChanged: if (activeFocus) Qt.inputMethod.hide()
+                            onActiveFocusChanged: if (activeFocus) { Qt.inputMethod.commit(); Qt.inputMethod.hide() }
                         }
                     }
 
@@ -804,7 +804,7 @@ Page {
                                 editDrinkWeight = newValue
                                 calculateEy()
                             }
-                            onActiveFocusChanged: if (activeFocus) Qt.inputMethod.hide()
+                            onActiveFocusChanged: if (activeFocus) { Qt.inputMethod.commit(); Qt.inputMethod.hide() }
                         }
                     }
 
@@ -855,7 +855,7 @@ Page {
                                     editDrinkTds = newValue
                                     calculateEy()
                                 }
-                                onActiveFocusChanged: if (activeFocus) Qt.inputMethod.hide()
+                                onActiveFocusChanged: if (activeFocus) { Qt.inputMethod.commit(); Qt.inputMethod.hide() }
                             }
                         }
                     }
@@ -887,7 +887,7 @@ Page {
                             onValueModified: function(newValue) {
                                 editDrinkEy = newValue
                             }
-                            onActiveFocusChanged: if (activeFocus) Qt.inputMethod.hide()
+                            onActiveFocusChanged: if (activeFocus) { Qt.inputMethod.commit(); Qt.inputMethod.hide() }
                         }
                     }
                 }

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -238,6 +238,7 @@ Page {
 
     // Save edited shot back to history
     function saveEditedShot() {
+        Qt.inputMethod.commit()
         if (editShotId <= 0) return
         var metadata = {
             "beanBrand": editBeanBrand,

--- a/qml/pages/ProfileEditorPage.qml
+++ b/qml/pages/ProfileEditorPage.qml
@@ -1526,6 +1526,7 @@ Page {
         }
 
         function doSave() {
+            Qt.inputMethod.commit()
             if (profile && nameField.text.length > 0) {
                 profile.title = nameField.text
                 updatePageTitle()

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -477,6 +477,7 @@ Page {
                     accessibleName: TranslationManager.translate("settingsPage.saveThemeWithName", "Save current theme with entered name")
                     enabled: saveThemeDialog.themeName.trim().length > 0
                     onClicked: {
+                        Qt.inputMethod.commit()
                         var name = saveThemeDialog.themeName.trim()
                         if (name.length > 0 && name !== "Default") {
                             Settings.saveCurrentTheme(name)

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -451,6 +451,7 @@ Page {
                 accessibleName: TranslationManager.translate("settings.themes.themeNamePlaceholder", "Theme name")
                 onTextChanged: saveThemeDialog.themeName = text
                 onAccepted: {
+                    Qt.inputMethod.commit()
                     if (saveThemeDialog.themeName.trim().length > 0) {
                         Settings.saveCurrentTheme(saveThemeDialog.themeName.trim())
                         if (themesLoader.item) themesLoader.item.refreshPresets()


### PR DESCRIPTION
## Summary
- On Android/iOS virtual keyboards, the last typed word stays in a composing/pre-edit state and is **not** reflected in `TextField.text` until committed. Tapping a save/send button reads stale text, silently dropping the last word.
- Adds `Qt.inputMethod.commit()` at the top of every save/send function that reads text input, across 6 files:
  - **PostShotReviewPage** — shot notes save
  - **BeanInfoPage** — bean/grinder metadata save
  - **ProfileEditorPage** — profile rename dialog
  - **ConversationOverlay** — AI chat send
  - **SettingsPage** — theme name save dialog
  - **CustomEditorPopup** — layout custom text save
- No-op on desktop, so safe to always call

## Test plan
- [ ] On Android, type a note in PostShotReviewPage without trailing space, tap Save — last word should be preserved
- [ ] On Android, type in AI chat overlay and hit send — last word should be preserved
- [ ] Verify desktop behavior is unchanged (commit() is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)