### PR TITLE
ble: extend ShotSettings drift detection to all fields + steam diagnostics

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1312,6 +1312,7 @@ void DE1Device::parseShotSettings(const QByteArray& data) {
         && std::abs(hotWaterTempC - m_commandedHotWaterTempC) <= kTempTolerance
         && m_commandedHotWaterVolMl >= 0
         && hotWaterVolMl == m_commandedHotWaterVolMl
+        && m_commandedGroupTargetC >= 0.0
         && std::abs(groupTargetC - m_commandedGroupTargetC) <= kTempTolerance) {
         m_shotSettingsIndicationPending = false;
     }

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1300,8 +1300,9 @@ void DE1Device::parseShotSettings(const QByteArray& data) {
     // indication (leave pending set — the real post-write one will arrive
     // next) or a genuine dropped-write (MainController will detect it and
     // trigger a resend, which itself sets pending). Either way we wait.
-    // All 5 variable fields must match — a partial match (e.g. temp OK but
-    // duration wrong) still counts as unacknowledged.
+    // All 5 tracked fields must match — bytes 5-6 (TargetHotWaterLength,
+    // TargetEspressoVol) are hardcoded in every write and excluded. A partial
+    // match (e.g. temp OK but duration wrong) still counts as unacknowledged.
     constexpr double kTempTolerance = 0.5;  // u8p0 encoding rounding
     if (m_commandedSteamTargetC >= 0.0
         && std::abs(steamTargetC - m_commandedSteamTargetC) <= kTempTolerance

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -100,16 +100,22 @@ void DE1Device::onTransportDisconnected() {
     // post-reconnect indication against a stale commanded value from the
     // previous session (which would log a spurious drift).
     m_commandedSteamTargetC = -1.0;
+    m_commandedSteamDurationSec = -1;
+    m_commandedHotWaterTempC = -1.0;
+    m_commandedHotWaterVolMl = -1;
     m_commandedGroupTargetC = -1.0;
     m_lastShotSettingsWriteMs = 0;
     m_lastShotSettingsPayload.clear();
     m_shotSettingsIndicationPending = false;
     m_deviceSteamTargetC = -1.0;
+    m_deviceSteamDurationSec = -1;
+    m_deviceHotWaterTempC = -1.0;
+    m_deviceHotWaterVolMl = -1;
     m_deviceGroupTargetC = -1.0;
     // Emit the NOTIFY signal so any QML binding on deviceSteamTargetC /
     // deviceGroupTargetC sees the reset and doesn't keep displaying the
     // previous session's values until a fresh indication arrives.
-    emit shotSettingsReported(-1.0, -1.0);
+    emit shotSettingsReported(-1.0, -1, -1.0, -1, -1.0);
 
     // If an upload was in flight when the transport dropped, surface it as
     // a non-retryable "BLE disconnect during upload" failure *now* rather
@@ -1216,6 +1222,9 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     // controller, profile manager, steam calibrator, …) contributes to the
     // drift detector without each one having to remember.
     m_commandedSteamTargetC = steamTemp;
+    m_commandedSteamDurationSec = steamDuration;
+    m_commandedHotWaterTempC = hotWaterTemp;
+    m_commandedHotWaterVolMl = hotWaterVolume;
     m_commandedGroupTargetC = groupTemp;
     m_lastShotSettingsWriteMs = QDateTime::currentMSecsSinceEpoch();
     m_lastShotSettingsPayload = data;
@@ -1262,19 +1271,28 @@ void DE1Device::parseShotSettings(const QByteArray& data) {
     }
     const auto d = reinterpret_cast<const uint8_t*>(data.constData());
     const double steamTargetC = BinaryCodec::decodeU8P0(d[1]);
+    const int steamDurationSec = static_cast<int>(BinaryCodec::decodeU8P0(d[2]));
+    const double hotWaterTempC = BinaryCodec::decodeU8P0(d[3]);
+    const int hotWaterVolMl = static_cast<int>(BinaryCodec::decodeU8P0(d[4]));
     const uint16_t groupRaw = BinaryCodec::decodeShortBE(data, 7);
     const double groupTargetC = BinaryCodec::decodeU16P8(groupRaw);
 
     // Trace every DE1-reported value. Pair with the [ShotSettings] write:
     // lines above to reconstruct the request/response timeline when
-    // diagnosing "heater didn't heat" reports (e.g. issue #746).
+    // diagnosing "heater didn't heat" or "steam didn't stop" reports.
     qDebug().noquote() << QString(
-        "[ShotSettings] reported: steam=%1C group=%2C (%3 bytes)")
+        "[ShotSettings] reported: steam=%1C duration=%2s hotWater=%3C vol=%4ml group=%5C (%6 bytes)")
         .arg(steamTargetC, 0, 'f', 1)
+        .arg(steamDurationSec)
+        .arg(hotWaterTempC, 0, 'f', 1)
+        .arg(hotWaterVolMl)
         .arg(groupTargetC, 0, 'f', 2)
         .arg(data.size());
 
     m_deviceSteamTargetC = steamTargetC;
+    m_deviceSteamDurationSec = steamDurationSec;
+    m_deviceHotWaterTempC = hotWaterTempC;
+    m_deviceHotWaterVolMl = hotWaterVolMl;
     m_deviceGroupTargetC = groupTargetC;
 
     // Clear the indication-pending flag only when the report matches our
@@ -1282,20 +1300,32 @@ void DE1Device::parseShotSettings(const QByteArray& data) {
     // indication (leave pending set — the real post-write one will arrive
     // next) or a genuine dropped-write (MainController will detect it and
     // trigger a resend, which itself sets pending). Either way we wait.
+    // All 5 variable fields must match — a partial match (e.g. temp OK but
+    // duration wrong) still counts as unacknowledged.
+    constexpr double kTempTolerance = 0.5;  // u8p0 encoding rounding
     if (m_commandedSteamTargetC >= 0.0
-        && std::abs(steamTargetC - m_commandedSteamTargetC) <= 0.5
-        && std::abs(groupTargetC - m_commandedGroupTargetC) <= 0.5) {
+        && std::abs(steamTargetC - m_commandedSteamTargetC) <= kTempTolerance
+        && m_commandedSteamDurationSec >= 0
+        && steamDurationSec == m_commandedSteamDurationSec
+        && m_commandedHotWaterTempC >= 0.0
+        && std::abs(hotWaterTempC - m_commandedHotWaterTempC) <= kTempTolerance
+        && m_commandedHotWaterVolMl >= 0
+        && hotWaterVolMl == m_commandedHotWaterVolMl
+        && std::abs(groupTargetC - m_commandedGroupTargetC) <= kTempTolerance) {
         m_shotSettingsIndicationPending = false;
     }
 
-    emit shotSettingsReported(steamTargetC, groupTargetC);
+    emit shotSettingsReported(steamTargetC, steamDurationSec, hotWaterTempC, hotWaterVolMl, groupTargetC);
 }
 
 void DE1Device::resendLastShotSettings() {
     if (!m_transport || m_lastShotSettingsPayload.isEmpty()) return;
     qDebug().noquote() << QString(
-        "[ShotSettings] resend: repeating last payload (steam=%1C group=%2C)")
+        "[ShotSettings] resend: repeating last payload (steam=%1C duration=%2s hotWater=%3C vol=%4ml group=%5C)")
         .arg(m_commandedSteamTargetC, 0, 'f', 1)
+        .arg(m_commandedSteamDurationSec)
+        .arg(m_commandedHotWaterTempC, 0, 'f', 1)
+        .arg(m_commandedHotWaterVolMl)
         .arg(m_commandedGroupTargetC, 0, 'f', 2);
     m_lastShotSettingsWriteMs = QDateTime::currentMSecsSinceEpoch();
     m_shotSettingsIndicationPending = true;

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -68,10 +68,10 @@ class DE1Device : public QObject {
     Q_PROPERTY(double goalFlow READ goalFlow NOTIFY shotSampleReceived)
     Q_PROPERTY(double goalTemperature READ goalTemperature NOTIFY shotSampleReceived)
     Q_PROPERTY(double steamTemperature READ steamTemperature NOTIFY shotSampleReceived)
-    // DE1-reported ShotSettings target temperatures (from indications/reads of
-    // the SHOT_SETTINGS characteristic). -1.0 until first report. Used by
-    // MainController to detect drift between what we commanded and what the
-    // DE1 actually stored.
+    // DE1-reported ShotSettings targets (from indications/reads of the
+    // SHOT_SETTINGS characteristic). -1.0 (double) or -1 (int) until first
+    // report. Used by MainController to detect drift between what we
+    // commanded and what the DE1 actually stored.
     Q_PROPERTY(double deviceSteamTargetC READ deviceSteamTargetC NOTIFY shotSettingsReported)
     Q_PROPERTY(double deviceGroupTargetC READ deviceGroupTargetC NOTIFY shotSettingsReported)
     Q_PROPERTY(double waterLevel READ waterLevel NOTIFY waterLevelChanged)

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -327,9 +327,10 @@ private:
     double m_commandedGroupTargetC = -1.0;
     qint64 m_lastShotSettingsWriteMs = 0;
     // Raw 9-byte payload of the most recent ShotSettings write, used by
-    // resendLastShotSettings() to re-assert the exact value we commanded
-    // (including steamDuration/hotWater/etc. fields that aren't covered by
-    // the commanded-target pair above).
+    // resendLastShotSettings() to re-emit the exact bytes we originally sent.
+    // This is the only way to resend bytes 5-6 (TargetHotWaterLength,
+    // TargetEspressoVol) which are hardcoded in setShotSettings() and have
+    // no corresponding commanded-value members.
     QByteArray m_lastShotSettingsPayload;
     // See shotSettingsIndicationPending() — event-based "is a write currently
     // unacknowledged?" flag.

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -109,11 +109,17 @@ public:
     double mixTemperature() const { return m_mixTemp; }
     double steamTemperature() const { return m_steamTemp; }
     double deviceSteamTargetC() const { return m_deviceSteamTargetC; }
+    int deviceSteamDurationSec() const { return m_deviceSteamDurationSec; }
+    double deviceHotWaterTempC() const { return m_deviceHotWaterTempC; }
+    int deviceHotWaterVolMl() const { return m_deviceHotWaterVolMl; }
     double deviceGroupTargetC() const { return m_deviceGroupTargetC; }
-    // Last ShotSettings values we actually wrote over BLE (-1.0 if none yet).
+    // Last ShotSettings values we actually wrote over BLE (-1 if none yet).
     // Used by MainController's drift check to distinguish "DE1 dropped the
     // write" from "DE1 reported its power-on state before we wrote anything".
     double commandedSteamTargetC() const { return m_commandedSteamTargetC; }
+    int commandedSteamDurationSec() const { return m_commandedSteamDurationSec; }
+    double commandedHotWaterTempC() const { return m_commandedHotWaterTempC; }
+    int commandedHotWaterVolMl() const { return m_commandedHotWaterVolMl; }
     double commandedGroupTargetC() const { return m_commandedGroupTargetC; }
     qint64 lastShotSettingsWriteMs() const { return m_lastShotSettingsWriteMs; }
     // True between issuing a setShotSettings() write and receiving an
@@ -247,8 +253,10 @@ signals:
     void heaterVoltageChanged();
     // Emitted after the DE1 reports its stored ShotSettings (either from our
     // initial read on connect or from an indication after a write). Values
-    // are the DE1's current targets in Celsius; 0 means the heater is off.
-    void shotSettingsReported(double deviceSteamTargetC, double deviceGroupTargetC);
+    // are the DE1's current targets; 0 means the heater/setting is off.
+    void shotSettingsReported(double deviceSteamTargetC, int deviceSteamDurationSec,
+                              double deviceHotWaterTempC, int deviceHotWaterVolMl,
+                              double deviceGroupTargetC);
     void logMessage(const QString& message);
 
 protected:
@@ -302,14 +310,20 @@ private:
     double m_goalTemperature = 0.0;
     double m_steamTemp = 0.0;
     // DE1-reported ShotSettings targets (from SHOT_SETTINGS indications/reads).
-    // -1.0 until first report so MainController can distinguish "never heard
+    // -1 until first report so MainController can distinguish "never heard
     // back" from "DE1 says target is 0".
     double m_deviceSteamTargetC = -1.0;
+    int m_deviceSteamDurationSec = -1;
+    double m_deviceHotWaterTempC = -1.0;
+    int m_deviceHotWaterVolMl = -1;
     double m_deviceGroupTargetC = -1.0;
     // Last ShotSettings values we wrote (tracked here so every setShotSettings
     // caller — MainController, ProfileManager, etc. — is covered without each
-    // one having to remember). -1.0 until first write.
+    // one having to remember). -1 until first write.
     double m_commandedSteamTargetC = -1.0;
+    int m_commandedSteamDurationSec = -1;
+    double m_commandedHotWaterTempC = -1.0;
+    int m_commandedHotWaterVolMl = -1;
     double m_commandedGroupTargetC = -1.0;
     qint64 m_lastShotSettingsWriteMs = 0;
     // Raw 9-byte payload of the most recent ShotSettings write, used by

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -454,7 +454,8 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
     // Sentinel values emitted by DE1Device on disconnect — skip, there's
     // nothing to compare against.
     if (deviceSteamTargetC < 0.0 || deviceGroupTargetC < 0.0
-        || deviceSteamDurationSec < 0 || deviceHotWaterVolMl < 0) {
+        || deviceSteamDurationSec < 0 || deviceHotWaterTempC < 0.0
+        || deviceHotWaterVolMl < 0) {
         return;
     }
 

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -563,8 +563,8 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
     }
     if (hotWaterTempDrift) {
         QString note = QStringLiteral("hot water temp %1C but we commanded %2C")
-                           .arg(deviceHotWaterTempC, 0, 'f', 0)
-                           .arg(commandedHotWaterTemp, 0, 'f', 0);
+                           .arg(deviceHotWaterTempC, 0, 'f', 1)
+                           .arg(commandedHotWaterTemp, 0, 'f', 1);
         summary = summary.isEmpty() ? note : summary + QStringLiteral("; ") + note;
     }
     if (hotWaterVolDrift) {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -437,23 +437,31 @@ QString MainController::pasteFromClipboard() const {
     return text;
 }
 
-void MainController::onShotSettingsReported(double deviceSteamTargetC, double deviceGroupTargetC) {
+void MainController::onShotSettingsReported(double deviceSteamTargetC, int deviceSteamDurationSec,
+                                             double deviceHotWaterTempC, int deviceHotWaterVolMl,
+                                             double deviceGroupTargetC) {
     if (!m_device || !m_device->isConnected() || !m_settings) return;
 
     const double commandedSteam = m_device->commandedSteamTargetC();
+    const int commandedDuration = m_device->commandedSteamDurationSec();
+    const double commandedHotWaterTemp = m_device->commandedHotWaterTempC();
+    const int commandedHotWaterVol = m_device->commandedHotWaterVolMl();
     const double commandedGroup = m_device->commandedGroupTargetC();
-    const bool haveCommanded = (commandedSteam >= 0.0 && commandedGroup >= 0.0);
+    const bool haveCommanded = (commandedSteam >= 0.0 && commandedDuration >= 0
+                                && commandedHotWaterTemp >= 0.0 && commandedHotWaterVol >= 0
+                                && commandedGroup >= 0.0);
 
     // Sentinel values emitted by DE1Device on disconnect — skip, there's
     // nothing to compare against.
-    if (deviceSteamTargetC < 0.0 || deviceGroupTargetC < 0.0) {
+    if (deviceSteamTargetC < 0.0 || deviceGroupTargetC < 0.0
+        || deviceSteamDurationSec < 0 || deviceHotWaterVolMl < 0) {
         return;
     }
 
-    // Tolerances cover BLE encoding rounding. Steam is u8p0 (1°C quantum);
-    // group is u16p8 (far finer but we allow 0.5°C to absorb any FP noise).
-    constexpr double kSteamToleranceC = 0.5;
-    constexpr double kGroupToleranceC = 0.5;
+    // Tolerances cover BLE encoding rounding. Temperatures use u8p0 (1°C
+    // quantum) or u16p8; 0.5°C absorbs FP noise. Integer fields (duration,
+    // volume) must match exactly.
+    constexpr double kTempToleranceC = 0.5;
 
     // Compare reported against COMMANDED — "did the DE1 honor our last
     // write?" This is the authoritative question for #746, and it correctly
@@ -463,28 +471,42 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, double de
     // Settings-derived "expected" would make the drift handler clobber
     // those writes.
     const bool steamDrift = haveCommanded &&
-        std::abs(deviceSteamTargetC - commandedSteam) > kSteamToleranceC;
+        std::abs(deviceSteamTargetC - commandedSteam) > kTempToleranceC;
+    const bool durationDrift = haveCommanded &&
+        deviceSteamDurationSec != commandedDuration;
+    const bool hotWaterTempDrift = haveCommanded &&
+        std::abs(deviceHotWaterTempC - commandedHotWaterTemp) > kTempToleranceC;
+    const bool hotWaterVolDrift = haveCommanded &&
+        deviceHotWaterVolMl != commandedHotWaterVol;
     const bool groupDrift = haveCommanded &&
-        std::abs(deviceGroupTargetC - commandedGroup) > kGroupToleranceC;
+        std::abs(deviceGroupTargetC - commandedGroup) > kTempToleranceC;
 
     // Skip before we've ever written — DE1's initial indication on subscribe
     // reflects its power-on state, not ours, and racing against that would
     // log a bogus drift on every connect.
     if (!haveCommanded) {
         qDebug().noquote() << QString(
-            "[SettingsDrift] pre-commanded report ignored: reported steam=%1C group=%2C — waiting for first write")
+            "[SettingsDrift] pre-commanded report ignored: "
+            "reported(steam=%1C dur=%2s hw=%3C vol=%4ml group=%5C) — waiting for first write")
             .arg(deviceSteamTargetC, 0, 'f', 1)
+            .arg(deviceSteamDurationSec)
+            .arg(deviceHotWaterTempC, 0, 'f', 1)
+            .arg(deviceHotWaterVolMl)
             .arg(deviceGroupTargetC, 0, 'f', 2);
         return;
     }
 
-    if (!steamDrift && !groupDrift) {
+    if (!steamDrift && !durationDrift && !hotWaterTempDrift && !hotWaterVolDrift && !groupDrift) {
         // DE1 stored what we sent. Reset retry bookkeeping.
         if (m_shotSettingsDriftResendCount > 0) {
             qDebug().noquote() << QString(
-                "[SettingsDrift] resolved after %1 resend(s) — DE1 stored steam=%2C group=%3C")
+                "[SettingsDrift] resolved after %1 resend(s) — DE1 stored "
+                "steam=%2C dur=%3s hw=%4C vol=%5ml group=%6C")
                 .arg(m_shotSettingsDriftResendCount)
                 .arg(deviceSteamTargetC, 0, 'f', 1)
+                .arg(deviceSteamDurationSec)
+                .arg(deviceHotWaterTempC, 0, 'f', 1)
+                .arg(deviceHotWaterVolMl)
                 .arg(deviceGroupTargetC, 0, 'f', 2);
             m_shotSettingsDriftResendCount = 0;
         }
@@ -502,23 +524,23 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, double de
     if (m_device->shotSettingsIndicationPending()) {
         qDebug().noquote() << QString(
             "[SettingsDrift] stale-indication ignored (write unacknowledged): "
-            "reported(steam=%1C group=%2C) commanded(steam=%3C group=%4C)")
+            "reported(steam=%1C dur=%2s hw=%3C vol=%4ml group=%5C) "
+            "commanded(steam=%6C dur=%7s hw=%8C vol=%9ml group=%10C)")
             .arg(deviceSteamTargetC, 0, 'f', 1)
+            .arg(deviceSteamDurationSec)
+            .arg(deviceHotWaterTempC, 0, 'f', 1)
+            .arg(deviceHotWaterVolMl)
             .arg(deviceGroupTargetC, 0, 'f', 2)
             .arg(commandedSteam, 0, 'f', 1)
+            .arg(commandedDuration)
+            .arg(commandedHotWaterTemp, 0, 'f', 1)
+            .arg(commandedHotWaterVol)
             .arg(commandedGroup, 0, 'f', 2);
         return;
     }
 
     // Classify for the log so we can scan `grep SettingsDrift` in bug
-    // reports and immediately see what happened. Also compute expected
-    // (from Settings) for context — if it differs from commanded it means
-    // the user changed a setting between our last write and now.
-    const double expectedSteamC = m_settings->steamDisabled() ||
-                                  !m_settings->keepSteamHeaterOn()
-                                      ? 0.0
-                                      : m_settings->steamTemperature();
-    const double expectedGroupC = getGroupTemperature();
+    // reports and immediately see what happened.
     QString summary;
     if (steamDrift) {
         if (commandedSteam == 0.0 && deviceSteamTargetC > 0.0) {
@@ -533,23 +555,44 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, double de
                           .arg(commandedSteam, 0, 'f', 0);
         }
     }
+    if (durationDrift) {
+        QString note = QStringLiteral("steam duration %1s but we commanded %2s")
+                           .arg(deviceSteamDurationSec).arg(commandedDuration);
+        summary = summary.isEmpty() ? note : summary + QStringLiteral("; ") + note;
+    }
+    if (hotWaterTempDrift) {
+        QString note = QStringLiteral("hot water temp %1C but we commanded %2C")
+                           .arg(deviceHotWaterTempC, 0, 'f', 0)
+                           .arg(commandedHotWaterTemp, 0, 'f', 0);
+        summary = summary.isEmpty() ? note : summary + QStringLiteral("; ") + note;
+    }
+    if (hotWaterVolDrift) {
+        QString note = QStringLiteral("hot water vol %1ml but we commanded %2ml")
+                           .arg(deviceHotWaterVolMl).arg(commandedHotWaterVol);
+        summary = summary.isEmpty() ? note : summary + QStringLiteral("; ") + note;
+    }
     if (groupDrift) {
-        QString groupNote = QStringLiteral("group target %1C but we commanded %2C")
-                                .arg(deviceGroupTargetC, 0, 'f', 2)
-                                .arg(commandedGroup, 0, 'f', 2);
-        summary = summary.isEmpty() ? groupNote : summary + QStringLiteral("; ") + groupNote;
+        QString note = QStringLiteral("group target %1C but we commanded %2C")
+                           .arg(deviceGroupTargetC, 0, 'f', 2)
+                           .arg(commandedGroup, 0, 'f', 2);
+        summary = summary.isEmpty() ? note : summary + QStringLiteral("; ") + note;
     }
 
     qWarning().noquote() << QString(
-        "[SettingsDrift] DE1-dropped-write: %1 | reported(steam=%2C group=%3C) "
-        "commanded(steam=%4C group=%5C) expected(steam=%6C group=%7C)")
+        "[SettingsDrift] DE1-dropped-write: %1 | "
+        "reported(steam=%2C dur=%3s hw=%4C vol=%5ml group=%6C) "
+        "commanded(steam=%7C dur=%8s hw=%9C vol=%10ml group=%11C)")
         .arg(summary)
         .arg(deviceSteamTargetC, 0, 'f', 1)
+        .arg(deviceSteamDurationSec)
+        .arg(deviceHotWaterTempC, 0, 'f', 1)
+        .arg(deviceHotWaterVolMl)
         .arg(deviceGroupTargetC, 0, 'f', 2)
         .arg(commandedSteam, 0, 'f', 1)
-        .arg(commandedGroup, 0, 'f', 2)
-        .arg(expectedSteamC, 0, 'f', 1)
-        .arg(expectedGroupC, 0, 'f', 2);
+        .arg(commandedDuration)
+        .arg(commandedHotWaterTemp, 0, 'f', 1)
+        .arg(commandedHotWaterVol)
+        .arg(commandedGroup, 0, 'f', 2);
 
     // If a resend is already in flight (we sent one and haven't yet received
     // its indication), wait for that to resolve before firing another. This

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -194,10 +194,12 @@ signals:
 
 private slots:
     void onShotSampleReceived(const ShotSample& sample);
-    // Verify that the DE1's stored steam/group targets match what we've
-    // commanded. Logs drift and auto-heals by re-sending ShotSettings, with
-    // a retry budget to avoid infinite loops when the DE1 refuses the value.
-    void onShotSettingsReported(double deviceSteamTargetC, double deviceGroupTargetC);
+    // Verify that the DE1's stored ShotSettings match what we've commanded.
+    // Logs drift and auto-heals by re-sending ShotSettings, with a retry
+    // budget to avoid infinite loops when the DE1 refuses the value.
+    void onShotSettingsReported(double deviceSteamTargetC, int deviceSteamDurationSec,
+                                double deviceHotWaterTempC, int deviceHotWaterVolMl,
+                                double deviceGroupTargetC);
 
 private:
     void applyAllSettings();

--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -197,10 +197,12 @@ void MachineState::updatePhase() {
     DE1::SubState previousSubState = m_previousSubState;
     m_previousSubState = subState;
 
-    // Log steam substate transitions for diagnostics (#766 follow-up).
-    // Reconstructs the full Steaming->Puffing->Ending->Idle sequence from
-    // logs when diagnosing "steam didn't stop" reports.
-    if (state == DE1::State::Steam && subState != previousSubState) {
+    // Log steam substate transitions to reconstruct the full
+    // Steaming->Puffing->Ending->Idle sequence in bug reports.
+    // Gate on oldPhase==Steaming so the first entry into Steam doesn't log
+    // a spurious transition from m_previousSubState's init value.
+    if (state == DE1::State::Steam && oldPhase == Phase::Steaming
+        && subState != previousSubState) {
         qDebug().noquote() << QString("[Steam] substate: %1 -> %2")
             .arg(DE1::subStateToString(previousSubState),
                  DE1::subStateToString(subState));

--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -194,6 +194,17 @@ void MachineState::updatePhase() {
     Phase oldPhase = m_phase;
     DE1::State state = m_device->state();
     DE1::SubState subState = m_device->subState();
+    DE1::SubState previousSubState = m_previousSubState;
+    m_previousSubState = subState;
+
+    // Log steam substate transitions for diagnostics (#766 follow-up).
+    // Reconstructs the full Steaming->Puffing->Ending->Idle sequence from
+    // logs when diagnosing "steam didn't stop" reports.
+    if (state == DE1::State::Steam && subState != previousSubState) {
+        qDebug().noquote() << QString("[Steam] substate: %1 -> %2")
+            .arg(DE1::subStateToString(previousSubState),
+                 DE1::subStateToString(subState));
+    }
 
     switch (state) {
         case DE1::State::Sleep:
@@ -500,12 +511,16 @@ void MachineState::updatePhase() {
         // Defer other signal emissions to allow pending BLE notifications to process first.
         // This prevents QML binding updates from blocking the event loop during the BLE callback chain.
         // Note: espressoCycleStarted is emitted immediately above to avoid race conditions.
-        QMetaObject::invokeMethod(this, [this, wasInEspresso, isInEspresso, wasFlowing]() {
+        QMetaObject::invokeMethod(this, [this, wasInEspresso, isInEspresso, wasFlowing, oldPhase]() {
             emit phaseChanged();
 
             if (isFlowing() && !wasFlowing) {
+                if (m_phase == Phase::Steaming)
+                    qDebug().noquote() << "[Steam] flow started (phase entered Steaming)";
                 emit shotStarted();
             } else if (!isFlowing() && wasFlowing) {
+                if (oldPhase == Phase::Steaming)
+                    qDebug().noquote() << "[Steam] flow stopped (phase left Steaming)";
                 emit shotEnded();
             }
         }, Qt::QueuedConnection);
@@ -515,6 +530,10 @@ void MachineState::updatePhase() {
     // This handles steam stopping (Puffing/Ending substates) where phase stays Steaming
     if (!isFlowing() && m_shotTimer->isActive()) {
         qDebug() << "=== TIMER STOP: isFlowing() became false (substate change) ===";
+        if (m_device && m_device->state() == DE1::State::Steam) {
+            qDebug().noquote() << QString("[Steam] flow stopped via substate change (substate=%1)")
+                .arg(DE1::subStateToString(m_device->subState()));
+        }
         stopShotTimer();
         if (m_scale) {
             m_scale->stopTimer();

--- a/src/machine/machinestate.h
+++ b/src/machine/machinestate.h
@@ -123,6 +123,7 @@ private:
     ShotTimingController* m_timingController = nullptr;
 
     Phase m_phase = Phase::Disconnected;
+    DE1::SubState m_previousSubState = DE1::SubState::Ready;
     double m_shotTime = 0.0;
     double m_targetWeight = 36.0;
     double m_targetVolume = 0.0;

--- a/tests/tst_shotsettings.cpp
+++ b/tests/tst_shotsettings.cpp
@@ -154,11 +154,14 @@ private slots:
     // ===== Commanded-value tracking (issue #746 drift detection) =====
 
     void commandedValuesInitiallyUnset() {
-        // Before any write, commanded values report -1.0 so MainController's
+        // Before any write, commanded values report -1 so MainController's
         // drift check can ignore pre-commanded indications (DE1's power-on
         // state isn't something we should "fix").
         TestFixture f;
         QCOMPARE(f.device.commandedSteamTargetC(), -1.0);
+        QCOMPARE(f.device.commandedSteamDurationSec(), -1);
+        QCOMPARE(f.device.commandedHotWaterTempC(), -1.0);
+        QCOMPARE(f.device.commandedHotWaterVolMl(), -1);
         QCOMPARE(f.device.commandedGroupTargetC(), -1.0);
         QCOMPARE(f.device.lastShotSettingsWriteMs(), qint64(0));
     }
@@ -167,12 +170,18 @@ private slots:
         TestFixture f;
         f.device.setShotSettings(160, 120, 80, 200, 93.0);
         QCOMPARE(f.device.commandedSteamTargetC(), 160.0);
+        QCOMPARE(f.device.commandedSteamDurationSec(), 120);
+        QCOMPARE(f.device.commandedHotWaterTempC(), 80.0);
+        QCOMPARE(f.device.commandedHotWaterVolMl(), 200);
         QCOMPARE(f.device.commandedGroupTargetC(), 93.0);
         QVERIFY(f.device.lastShotSettingsWriteMs() > 0);
 
         // Subsequent write overwrites — latest command wins.
-        f.device.setShotSettings(0, 120, 80, 200, 88.0);
+        f.device.setShotSettings(0, 60, 90, 150, 88.0);
         QCOMPARE(f.device.commandedSteamTargetC(), 0.0);
+        QCOMPARE(f.device.commandedSteamDurationSec(), 60);
+        QCOMPARE(f.device.commandedHotWaterTempC(), 90.0);
+        QCOMPARE(f.device.commandedHotWaterVolMl(), 150);
         QCOMPARE(f.device.commandedGroupTargetC(), 88.0);
     }
 
@@ -199,9 +208,15 @@ private slots:
         emit f.transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, payload);
 
         QCOMPARE(spy.count(), 1);
-        QCOMPARE(spy.at(0).at(0).toDouble(), 145.0);
-        QCOMPARE(spy.at(0).at(1).toDouble(), 90.25);
+        QCOMPARE(spy.at(0).at(0).toDouble(), 145.0);   // steam temp
+        QCOMPARE(spy.at(0).at(1).toInt(), 120);          // steam duration
+        QCOMPARE(spy.at(0).at(2).toDouble(), 80.0);      // hot water temp
+        QCOMPARE(spy.at(0).at(3).toInt(), 200);           // hot water vol
+        QCOMPARE(spy.at(0).at(4).toDouble(), 90.25);     // group temp
         QCOMPARE(f.device.deviceSteamTargetC(), 145.0);
+        QCOMPARE(f.device.deviceSteamDurationSec(), 120);
+        QCOMPARE(f.device.deviceHotWaterTempC(), 80.0);
+        QCOMPARE(f.device.deviceHotWaterVolMl(), 200);
         QCOMPARE(f.device.deviceGroupTargetC(), 90.25);
     }
 
@@ -242,7 +257,10 @@ private slots:
         emit f.transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, payload);
 
         QCOMPARE(spy.count(), 1);
-        QCOMPARE(spy.at(0).at(0).toDouble(), 0.0);
+        QCOMPARE(spy.at(0).at(0).toDouble(), 0.0);   // steam temp off
+        QCOMPARE(spy.at(0).at(1).toInt(), 0);          // duration
+        QCOMPARE(spy.at(0).at(2).toDouble(), 0.0);     // hot water temp
+        QCOMPARE(spy.at(0).at(3).toInt(), 0);           // hot water vol
     }
 
     void disconnectResetsCommanded() {
@@ -256,9 +274,15 @@ private slots:
         f.transport.setConnectedSim(false);
 
         QCOMPARE(f.device.commandedSteamTargetC(), -1.0);
+        QCOMPARE(f.device.commandedSteamDurationSec(), -1);
+        QCOMPARE(f.device.commandedHotWaterTempC(), -1.0);
+        QCOMPARE(f.device.commandedHotWaterVolMl(), -1);
         QCOMPARE(f.device.commandedGroupTargetC(), -1.0);
         QCOMPARE(f.device.lastShotSettingsWriteMs(), qint64(0));
         QCOMPARE(f.device.deviceSteamTargetC(), -1.0);
+        QCOMPARE(f.device.deviceSteamDurationSec(), -1);
+        QCOMPARE(f.device.deviceHotWaterTempC(), -1.0);
+        QCOMPARE(f.device.deviceHotWaterVolMl(), -1);
         QCOMPARE(f.device.deviceGroupTargetC(), -1.0);
     }
 
@@ -274,8 +298,11 @@ private slots:
         f.transport.setConnectedSim(false);
 
         QCOMPARE(spy.count(), 1);
-        QCOMPARE(spy.at(0).at(0).toDouble(), -1.0);
-        QCOMPARE(spy.at(0).at(1).toDouble(), -1.0);
+        QCOMPARE(spy.at(0).at(0).toDouble(), -1.0);   // steam temp
+        QCOMPARE(spy.at(0).at(1).toInt(), -1);          // duration
+        QCOMPARE(spy.at(0).at(2).toDouble(), -1.0);     // hot water temp
+        QCOMPARE(spy.at(0).at(3).toInt(), -1);           // hot water vol
+        QCOMPARE(spy.at(0).at(4).toDouble(), -1.0);     // group temp
     }
 
     // ===== Indication-pending flag (event-based stale-indication detection) =====
@@ -345,6 +372,54 @@ private slots:
         f.transport.clearWrites();
         f.device.resendLastShotSettings();
         QCOMPARE(f.transport.writes.size(), 0);
+    }
+
+    // ===== Partial-match: pending flag stays set if only some fields match =====
+
+    void indicationPendingPartialMatchStaysPending() {
+        // Validates the "lost steam timeout" scenario: steam temp matches but
+        // duration doesn't. The pending flag must stay set so MainController
+        // detects drift and triggers a resend.
+        TestFixture f;
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);
+        QVERIFY(f.device.shotSettingsIndicationPending());
+
+        // Build indication that matches steam+group temp but has wrong duration.
+        QByteArray payload(9, 0);
+        payload[1] = char(160);   // steam temp matches
+        payload[2] = char(60);    // duration MISMATCHES (120 commanded)
+        payload[3] = char(80);    // hot water temp matches
+        payload[4] = char(200);   // hot water vol matches
+        payload[5] = char(60);
+        payload[6] = char(200);
+        uint16_t groupRaw = BinaryCodec::encodeU16P8(93.0);
+        payload[7] = char((groupRaw >> 8) & 0xFF);
+        payload[8] = char(groupRaw & 0xFF);
+        emit f.transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, payload);
+
+        // Pending should stay set because duration doesn't match.
+        QVERIFY(f.device.shotSettingsIndicationPending());
+    }
+
+    void indicationPendingPartialMatchHotWaterStaysPending() {
+        // Hot water volume mismatch: everything else matches but vol doesn't.
+        TestFixture f;
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);
+        QVERIFY(f.device.shotSettingsIndicationPending());
+
+        QByteArray payload(9, 0);
+        payload[1] = char(160);   // steam temp matches
+        payload[2] = char(120);   // duration matches
+        payload[3] = char(80);    // hot water temp matches
+        payload[4] = char(150);   // hot water vol MISMATCHES (200 commanded)
+        payload[5] = char(60);
+        payload[6] = char(200);
+        uint16_t groupRaw = BinaryCodec::encodeU16P8(93.0);
+        payload[7] = char((groupRaw >> 8) & 0xFF);
+        payload[8] = char(groupRaw & 0xFF);
+        emit f.transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, payload);
+
+        QVERIFY(f.device.shotSettingsIndicationPending());
     }
 };
 


### PR DESCRIPTION
## Summary
- Extends ShotSettings drift detection from 2 fields (steam temp, group temp) to all 5 variable fields: adds steam duration, hot water temp, and hot water volume verification
- The indication-pending flag now requires ALL 5 fields to match before clearing — a partial match (e.g. temp OK but duration byte dropped) stays pending and triggers auto-resend
- Adds `[Steam]` substate transition logging (`Steaming -> Puffing -> Ending`) and flow start/stop logging for diagnosing "steam didn't stop" reports
- All `[SettingsDrift]` log lines expanded to include all 5 fields in both reported and commanded sections

## Context
PR #751 added drift detection but only covered steam temp and group temp. The 9-byte ShotSettings payload has 3 more variable fields (steam duration, hot water temp, hot water volume) that were written but never verified from the DE1's indication. This means a dropped steam timeout byte would go undetected — the DE1 might heat to the right temperature but run with a wrong or zero timeout.

PR #766 fixed a steam timeout bug, and this follow-up ensures we have the logging to diagnose any recurrence without BLE sniffing.

## Test plan
- [ ] Build with `-DBUILD_TESTS=ON` and run `ctest -R tst_shotsettings` — all tests pass including 2 new partial-match tests
- [ ] Connect to DE1, observe `[ShotSettings] write:` and `[ShotSettings] reported:` logs include all 5 fields
- [ ] Start steam, observe `[Steam] substate:` transition logs
- [ ] Verify `[Steam] flow started` / `[Steam] flow stopped` appear in logs
- [ ] If drift occurs, verify `[SettingsDrift]` includes duration + hot water fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)