### PR TITLE
fix: remove hardcoded ShotSettings defaults write on connect

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1185,19 +1185,16 @@ void DE1Device::sendInitialSettings() {
     // Read refill kit status
     requestRefillKitStatus();
 
-    // Send shot settings
-    double steamTemp = 0.0;
-    int steamDuration = 120;
-    double hotWaterTemp = 80.0;
-    int hotWaterVolume = 200;
-    double groupTemp = 93.0;
+    // NOTE: de1app sends the user's steam/hotwater settings here
+    // (de1_send_steam_hotwater_settings). We skip it — the user's real
+    // settings are sent by MainController::applyAllSettings() which fires
+    // immediately after initialSettingsComplete via signal/slot. Writing
+    // hardcoded defaults here would briefly set wrong values on the DE1
+    // (steam=0, group=93) and pollute the drift detector's commanded state.
 
-    setShotSettings(steamTemp, steamDuration, hotWaterTemp, hotWaterVolume, groupTemp);
-
-    // Signal that initial settings are complete
-    // Use a write-complete counter to detect when all queued writes finish
-    // For simplicity, emit immediately — the transport queues ensure ordering,
-    // and MainController connects to this signal to apply user settings
+    // Signal that initial settings are complete. MainController connects
+    // to this to apply user settings (profile upload, steam/hotwater/flush
+    // settings, water refill level, flow calibration).
     emit initialSettingsComplete();
 }
 

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -695,11 +695,8 @@ void MainController::applyFlushSettings() {
 }
 
 void MainController::applyAllSettings() {
-    // Fresh connection / initial settings cycle — reset ShotSettings drift
-    // bookkeeping so a prior session's exhausted retry budget doesn't
-    // permanently disable auto-heal, and so the spurious drift from the
-    // initial-defaults write's indication crossing our user-value write
-    // doesn't burn the new session's retry slots.
+    // Fresh connection — reset ShotSettings drift bookkeeping so a prior
+    // session's exhausted retry budget doesn't permanently disable auto-heal.
     m_shotSettingsDriftResendCount = 0;
     m_shotSettingsResendInFlight = false;
 


### PR DESCRIPTION
## Summary
- Removes the hardcoded ShotSettings defaults write (`steam=0C, duration=120s, hotWater=80C, vol=200ml, group=93C`) from `sendInitialSettings()` on BLE connect
- The user's real settings are sent by `applyAllSettings()` which fires immediately after via `initialSettingsComplete` signal — matching what de1app does (`de1_send_steam_hotwater_settings` reads from user settings, never writes defaults)
- Eliminates one unnecessary BLE write per connect and removes the startup race where the DE1 briefly had wrong settings and the drift detector had stale commanded values

## Context
Found while investigating DE1 debug logs — four ShotSettings writes fire within 150ms at startup, with the second one containing hardcoded defaults that are immediately overwritten. This was identified as a pre-existing race from PR #751 that became more visible after PR #768 extended drift detection to all 5 ShotSettings fields.

## Test plan
- [ ] Connect to DE1, verify only user settings appear in `[ShotSettings] write:` logs at startup (no `steam=0.0C duration=120s` line)
- [ ] Verify steam heater, hot water, and group temp all work correctly after connect
- [ ] Verify no `[SettingsDrift]` warnings at startup
- [ ] Run `ctest -R tst_shotsettings` — existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)