### PR TITLE
fix: limit SAW spike filter to active extraction only

### DIFF
--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -25,7 +25,12 @@ void WeightProcessor::processWeight(double weight)
     // false SAW stop. Any reading that jumps more than 100g from the previous
     // sample is rejected. Auto-resets after 3 consecutive rejections to handle
     // legitimate shifts (cup removal, tare, scale reconnect at different offset).
-    if (m_hasLastWeight && qAbs(weight - m_lastRawWeight) > 100.0) {
+    //
+    // Only active during extraction — between shots, cup placement/removal and
+    // tare drift produce legitimate 100g+ swings that the filter would reject,
+    // freezing the flow rate display and polluting the debug log. The filter is
+    // reset by startExtraction() before each shot.
+    if (m_active && m_hasLastWeight && qAbs(weight - m_lastRawWeight) > 100.0) {
         if (++m_consecutiveRejections < 3) {
             m_lastWallClockMs = wallClock;  // Keep de-jitter timing accurate
             qWarning() << "[SAW-Worker] Spike rejected: weight=" << weight

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -26,10 +26,11 @@ void WeightProcessor::processWeight(double weight)
     // sample is rejected. Auto-resets after 3 consecutive rejections to handle
     // legitimate shifts (cup removal, tare, scale reconnect at different offset).
     //
-    // Only active during extraction — between shots, cup placement/removal and
-    // tare drift produce legitimate 100g+ swings that the filter would reject,
-    // freezing the flow rate display and polluting the debug log. The filter is
-    // reset by startExtraction() before each shot.
+    // Only active during extraction — between shots, cup placement/removal,
+    // tare drift, and scale reconnect at different offset produce legitimate
+    // 100g+ swings that the filter would reject, freezing the flow rate display
+    // and polluting the debug log. The filter is reset by startExtraction()
+    // before each shot and by resetForRetare() on mid-preheat retare.
     if (m_active && m_hasLastWeight && qAbs(weight - m_lastRawWeight) > 100.0) {
         if (++m_consecutiveRejections < 3) {
             m_lastWallClockMs = wallClock;  // Keep de-jitter timing accurate
@@ -358,6 +359,7 @@ void WeightProcessor::resetForRetare()
     m_frameWeightSkipSent.clear();
     m_lastWallClockMs = 0;
     m_lastSampleTs = 0;
+    m_uncalibratedBatchWarned = false;  // Timestamps cleared — de-jitter needs recalibration
     m_lastTareWarnMs = 0;
     m_lastLowFlowLogMs = 0;
     m_flowBecameValidLogged = false;

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -74,6 +74,7 @@ private:
     QList<WeightSample> m_weightSamples;
 
     // Spike filter: rejects single-packet BLE corruption (issue #610).
+    // Scoped to active extractions via m_active — see processWeight().
     // Auto-resets after 3 consecutive rejections to handle legitimate shifts.
     double m_lastRawWeight = 0;
     bool m_hasLastWeight = false;

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -329,10 +329,11 @@ private slots:
 
     void consecutiveRejectionsAutoReset() {
         // After 3 consecutive rejections, the filter accepts the new baseline.
-        // This handles legitimate shifts (cup removal, scale reconnect).
+        // This handles legitimate shifts during extraction (e.g. scale reconnect).
         WeightProcessor wp;
         installFakeClock(wp);
         QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
+        wp.startExtraction();  // Spike filter only active during extraction
 
         // Establish baseline at ~10g
         feedRising(wp, 8.0, 2.0, 5);
@@ -356,6 +357,7 @@ private slots:
         WeightProcessor wp;
         installFakeClock(wp);
         QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
+        wp.startExtraction();  // Spike filter only active during extraction
 
         // Build stable 2 g/s flow
         feedRising(wp, 0.0, 2.0, 10);
@@ -378,6 +380,27 @@ private slots:
         QVERIFY2(qAbs(flowAfter - flowBefore) < 1.5,
                  qPrintable(QString("Flow should be stable after spike rejection: before=%1 after=%2")
                             .arg(flowBefore).arg(flowAfter)));
+    }
+
+    void spikeBypassedWhenInactive() {
+        // Outside extraction, 100g+ jumps should NOT be rejected — they're
+        // legitimate events (cup placement/removal, tare drift).
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
+        // Do NOT call startExtraction() — stay inactive
+
+        // Feed a baseline
+        wp.processWeight(0.0); m_fakeClock += 200;
+        QCOMPARE(flowSpy.count(), 1);
+
+        // 200g jump — would be rejected during extraction, but passes when inactive
+        wp.processWeight(200.0); m_fakeClock += 200;
+        QCOMPARE(flowSpy.count(), 2);  // Signal emitted, not rejected
+
+        // Jump back to 0 — also passes
+        wp.processWeight(0.0); m_fakeClock += 200;
+        QCOMPARE(flowSpy.count(), 3);
     }
 
     // ==========================================


### PR DESCRIPTION
## Summary
- Gates the SAW spike filter on `m_active` so it only rejects 100g+ jumps during extraction
- Between shots, cup placement/removal and tare drift legitimately exceed 100g — the filter was rejecting these, freezing the flow rate display and filling the debug log with warnings
- `startExtraction()` already resets all spike filter state before each shot, so extraction safety is unchanged

## Context
Found by analyzing DE1 debug logs: a -361g baseline from the previous session's cup removal persisted across app restart. Every near-zero reading was rejected as a "spike" for 67 minutes until the 3-rejection auto-reset kicked in. The filter was running outside extraction where it serves no purpose — SAW logic is already gated on `m_active` at line 134.

## Test plan
- [ ] Pull shot — SAW spike filter still protects during extraction (inject a 200g spike in simulator if possible)
- [ ] Between shots, place/remove cup — no spike rejection warnings in log, flow rate display updates immediately
- [ ] Run `ctest -R tst_` to verify no test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)