### PR TITLE
fix: measure SteamHealth against actual flow time, not state time

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -138,7 +138,10 @@ MainController::MainController(QNetworkAccessManager* networkManager,
                 m_settings->setSteamDisabled(false);
             }
 
-            // Steam session ended — run post-session analysis
+            // Steam session ended — run post-session analysis. m_steamStartTime
+            // is only set when isFlowing() was true (Steaming/Pouring substates),
+            // so this fires after all flowing samples have been collected even
+            // though the Steaming phase persists through Puffing/Ending substates.
             if (phase != MachineState::Phase::Steaming && m_steamStartTime > 0) {
                 if (m_steamHealthTracker && m_steamDataModel) {
                     m_steamHealthTracker->onSessionComplete(
@@ -2057,12 +2060,13 @@ void MainController::onShotSampleReceived(const ShotSample& sample) {
     }
     m_lastSampleTime = sample.timer;
 
-    // Record steam data only while steam is actually flowing (Steaming/Pouring
-    // substates), not during the GHC purge puff (Puffing) or wind-down (Ending).
-    // Without this gate, ~10s of post-flow purge time inflates rawTime() and
-    // skews SteamHealth's avg/peak metrics with non-steaming samples.
+    // Record steam data only while steam is actually flowing. isFlowing()
+    // returns true only for SubState::Steaming or SubState::Pouring (whitelist);
+    // all other Steaming-phase substates (Puffing, Ending, FinalHeating, etc.)
+    // are excluded. Without this gate, post-flow purge/wind-down samples inflate
+    // rawTime() and skew SteamHealth's avg/peak metrics with non-steaming data.
     bool steamFlowing = (phase == MachineState::Phase::Steaming
-                         && m_machineState && m_machineState->isFlowing());
+                         && m_machineState->isFlowing());
     if (steamFlowing && m_steamDataModel) {
         if (m_steamStartTime == 0) {
             m_steamStartTime = sample.timer;

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2057,8 +2057,13 @@ void MainController::onShotSampleReceived(const ShotSample& sample) {
     }
     m_lastSampleTime = sample.timer;
 
-    // Record steam data during Steaming phase
-    if (phase == MachineState::Phase::Steaming && m_steamDataModel) {
+    // Record steam data only while steam is actually flowing (Steaming/Pouring
+    // substates), not during the GHC purge puff (Puffing) or wind-down (Ending).
+    // Without this gate, ~10s of post-flow purge time inflates rawTime() and
+    // skews SteamHealth's avg/peak metrics with non-steaming samples.
+    bool steamFlowing = (phase == MachineState::Phase::Steaming
+                         && m_machineState && m_machineState->isFlowing());
+    if (steamFlowing && m_steamDataModel) {
         if (m_steamStartTime == 0) {
             m_steamStartTime = sample.timer;
             m_steamDataModel->clear();

--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -49,7 +49,10 @@ MachineState::MachineState(DE1Device* device, QObject* parent)
 }
 
 bool MachineState::isFlowing() const {
-    // For steam, only count as flowing if actually steaming (not purging/ending)
+    // For steam, only count as flowing during SubState::Steaming or
+    // SubState::Pouring (whitelist). All other substates that map to
+    // Phase::Steaming — Puffing, Ending, FinalHeating, PausedSteam, etc. —
+    // return false.
     if (m_phase == Phase::Steaming && m_device) {
         DE1::SubState subState = m_device->subState();
         return subState == DE1::SubState::Steaming ||


### PR DESCRIPTION
## Summary
- Gate steam sample recording on `m_machineState->isFlowing()` so only true flow time (Steaming/Pouring substates) counts toward SteamHealth metrics
- Excludes Puffing (GHC purge puff) and Ending substates which previously inflated `rawTime()` by ~10s per session
- Restores the `MIN_DURATION_FOR_ANALYSIS=20s` filter so brief steaming tests (under 20s of actual flow) are correctly skipped

## Context
A 10-second steam test session was recording ~30s of samples (17s actual flow + 13s purge/wind-down), so the 20s minimum filter never triggered. Worse, the post-flow samples (during Puffing/Ending where pressure and temperature behave differently) were polluting the avg pressure/peak temperature metrics that drive SteamHealth's drift detection and auto-reset.

`MachineState::isFlowing()` already correctly distinguishes flow from purge for steam:
```cpp
if (m_phase == Phase::Steaming && m_device) {
    DE1::SubState subState = m_device->subState();
    return subState == DE1::SubState::Steaming || subState == DE1::SubState::Pouring;
}
```

## Test plan
- [ ] Steam for less than 20s — verify the session is skipped with `SteamHealth [skip] N samples Ms` log
- [ ] Steam for over 20s of actual flow — verify session is recorded and `duration` matches actual flow time
- [ ] Verify `SteamHealth [session] ... duration: Ns` no longer includes purge/ending time
- [ ] Verify session-end logic still triggers (`onSessionComplete` called when phase leaves Steaming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)