### PR TITLE
fix: verify ShotSettings via read-after-write, dedupe duplicates

### DIFF
--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -216,12 +216,10 @@ void BleTransport::subscribeAll() {
     subscribe(DE1::Characteristic::WATER_LEVELS);
     subscribe(DE1::Characteristic::READ_FROM_MMR);
     subscribe(DE1::Characteristic::TEMPERATURES);
-    // SHOT_SETTINGS: the DE1 firmware does not push notifications on this
-    // characteristic when we write to it (de1app confirms this — it doesn't
-    // subscribe). Verification happens via explicit read() after each write
-    // in DE1Device::setShotSettings(). We still subscribe in case the firmware
-    // ever starts pushing — costs nothing extra.
-    subscribe(DE1::Characteristic::SHOT_SETTINGS);
+    // SHOT_SETTINGS is intentionally NOT subscribed: the DE1 firmware does
+    // not push notifications on writes (confirmed in de1app's de1_comms.tcl).
+    // Verification happens via explicit read() after each write in
+    // DE1Device::setShotSettings().
 
     // Read initial values
     read(DE1::Characteristic::VERSION);

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -180,11 +180,16 @@ void BleTransport::writeUrgent(const QBluetoothUuid& uuid, const QByteArray& dat
 }
 
 void BleTransport::read(const QBluetoothUuid& uuid) {
-    if (!m_service || !m_characteristics.contains(uuid)) {
-        log(QString("read(%1) skipped - %2").arg(uuid.toString().mid(1, 8), !m_service ? "no service" : "unknown characteristic"));
-        return;
-    }
-    m_service->readCharacteristic(m_characteristics[uuid]);
+    // Queue the read so it runs after any pending writes complete. Without
+    // queueing, a read issued right after a write executes immediately and
+    // returns the pre-write value, defeating any read-after-write verification.
+    queueCommand([this, uuid]() {
+        if (!m_service || !m_characteristics.contains(uuid)) {
+            log(QString("read(%1) skipped - %2").arg(uuid.toString().mid(1, 8), !m_service ? "no service" : "unknown characteristic"));
+            return;
+        }
+        m_service->readCharacteristic(m_characteristics[uuid]);
+    });
 }
 
 void BleTransport::subscribe(const QBluetoothUuid& uuid) {
@@ -211,8 +216,11 @@ void BleTransport::subscribeAll() {
     subscribe(DE1::Characteristic::WATER_LEVELS);
     subscribe(DE1::Characteristic::READ_FROM_MMR);
     subscribe(DE1::Characteristic::TEMPERATURES);
-    // SHOT_SETTINGS is indicate-capable — subscribing lets us observe the
-    // DE1's stored steam/group targets and verify that our writes stuck.
+    // SHOT_SETTINGS: the DE1 firmware does not push notifications on this
+    // characteristic when we write to it (de1app confirms this — it doesn't
+    // subscribe). Verification happens via explicit read() after each write
+    // in DE1Device::setShotSettings(). We still subscribe in case the firmware
+    // ever starts pushing — costs nothing extra.
     subscribe(DE1::Characteristic::SHOT_SETTINGS);
 
     // Read initial values

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -623,4 +623,12 @@ void BleTransport::processCommandQueue() {
     auto command = m_commandQueue.dequeue();
     m_lastCommand = command;  // Store for potential retry
     command();
+
+    // Reads don't set m_writePending and don't re-enter via
+    // onCharacteristicWritten, so the queue would otherwise stall after a
+    // dispatched read until some other queueCommand() call. Re-arm the timer
+    // here so subsequent queued items continue draining.
+    if (!m_writePending && !m_commandQueue.isEmpty() && !m_commandTimer.isActive()) {
+        m_commandTimer.start();
+    }
 }

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1310,25 +1310,13 @@ void DE1Device::parseShotSettings(const QByteArray& data) {
     m_deviceHotWaterVolMl = hotWaterVolMl;
     m_deviceGroupTargetC = groupTargetC;
 
-    // Clear the indication-pending flag only when the report matches our
-    // last commanded value. A mismatch here is either a stale pre-write
-    // indication (leave pending set — the real post-write one will arrive
-    // next) or a genuine dropped-write (MainController will detect it and
-    // trigger a resend, which itself sets pending). Either way we wait.
-    // All 5 tracked fields must match — bytes 5-6 (TargetHotWaterLength,
-    // TargetEspressoVol) are hardcoded in every write and excluded. A partial
-    // match (e.g. temp OK but duration wrong) still counts as unacknowledged.
-    constexpr double kTempTolerance = 0.5;  // u8p0 encoding rounding
-    if (m_commandedSteamTargetC >= 0.0
-        && std::abs(steamTargetC - m_commandedSteamTargetC) <= kTempTolerance
-        && m_commandedSteamDurationSec >= 0
-        && steamDurationSec == m_commandedSteamDurationSec
-        && m_commandedHotWaterTempC >= 0.0
-        && std::abs(hotWaterTempC - m_commandedHotWaterTempC) <= kTempTolerance
-        && m_commandedHotWaterVolMl >= 0
-        && hotWaterVolMl == m_commandedHotWaterVolMl
-        && m_commandedGroupTargetC >= 0.0
-        && std::abs(groupTargetC - m_commandedGroupTargetC) <= kTempTolerance) {
+    // Clear the indication-pending flag on every received indication. Under
+    // the read-after-write model (the read is queued behind the write so it
+    // executes on the post-write state), there is no "stale pre-write
+    // indication" race to filter out — every received report IS the actual
+    // post-write state. If it doesn't match commanded, that's real drift,
+    // and MainController must act on it (not suppress as stale).
+    if (m_commandedSteamTargetC >= 0.0) {
         m_shotSettingsIndicationPending = false;
     }
 

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1243,13 +1243,13 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
 
     m_transport->write(DE1::Characteristic::SHOT_SETTINGS, data);
 
-    // SHOT_SETTINGS is subscribed in BleTransport::subscribeAll() and the DE1
-    // indicates the stored value back whenever it changes — including after
-    // our writes. MainController::onShotSettingsReported() compares that
-    // reported value against its commanded value and re-sends on drift.
-    // (A read-after-write here would race with our queued write, since
-    // BleTransport::read() bypasses the command queue; subscription gives us
-    // the same guarantee without the race.)
+    // Verify the write by reading back. The DE1 firmware does NOT push
+    // notifications on the SHOT_SETTINGS characteristic when written (de1app
+    // doesn't subscribe to it either — confirmed by inspecting de1_comms.tcl).
+    // BleTransport::read() queues the read so it executes after this write
+    // completes, returning the actual stored value to parseShotSettings()
+    // which feeds MainController::onShotSettingsReported() for drift detection.
+    m_transport->read(DE1::Characteristic::SHOT_SETTINGS);
 }
 
 void DE1Device::parseShotSettings(const QByteArray& data) {

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1215,6 +1215,24 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     data[7] = (groupTempEncoded >> 8) & 0xFF;
     data[8] = groupTempEncoded & 0xFF;
 
+    // Dedupe: skip writes whose payload exactly matches the last one sent.
+    // Multiple QML signals (state change, phase change, page open, isSteaming
+    // change) all fire startSteamHeating() with the same values, producing
+    // 4-5 identical BLE writes per steam session. Resends from the drift
+    // auto-heal path go through resendLastShotSettings() and bypass this
+    // function, so they're unaffected.
+    if (data == m_lastShotSettingsPayload) {
+        qDebug().noquote() << QString(
+            "[ShotSettings] write skipped: payload unchanged "
+            "(steam=%1C duration=%2s hotWater=%3C vol=%4ml groupTemp=%5C)")
+            .arg(steamTemp, 0, 'f', 1)
+            .arg(steamDuration)
+            .arg(hotWaterTemp, 0, 'f', 1)
+            .arg(hotWaterVolume)
+            .arg(groupTemp, 0, 'f', 2);
+        return;
+    }
+
     // Record what we're commanding so any setShotSettings() call site (main
     // controller, profile manager, steam calibrator, …) contributes to the
     // drift detector without each one having to remember.

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -106,7 +106,6 @@ void DE1Device::onTransportDisconnected() {
     m_commandedGroupTargetC = -1.0;
     m_lastShotSettingsWriteMs = 0;
     m_lastShotSettingsPayload.clear();
-    m_shotSettingsIndicationPending = false;
     m_deviceSteamTargetC = -1.0;
     m_deviceSteamDurationSec = -1;
     m_deviceHotWaterTempC = -1.0;
@@ -1243,9 +1242,6 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     m_commandedGroupTargetC = groupTemp;
     m_lastShotSettingsWriteMs = QDateTime::currentMSecsSinceEpoch();
     m_lastShotSettingsPayload = data;
-    // An indication for this write is now outstanding. Cleared in
-    // parseShotSettings() when the DE1 reports a matching value.
-    m_shotSettingsIndicationPending = true;
 
     // Trace every write so the timeline of commanded values is visible in the
     // debug log alongside the DE1-reported values from parseShotSettings().
@@ -1310,16 +1306,6 @@ void DE1Device::parseShotSettings(const QByteArray& data) {
     m_deviceHotWaterVolMl = hotWaterVolMl;
     m_deviceGroupTargetC = groupTargetC;
 
-    // Clear the indication-pending flag on every received indication. Under
-    // the read-after-write model (the read is queued behind the write so it
-    // executes on the post-write state), there is no "stale pre-write
-    // indication" race to filter out — every received report IS the actual
-    // post-write state. If it doesn't match commanded, that's real drift,
-    // and MainController must act on it (not suppress as stale).
-    if (m_commandedSteamTargetC >= 0.0) {
-        m_shotSettingsIndicationPending = false;
-    }
-
     emit shotSettingsReported(steamTargetC, steamDurationSec, hotWaterTempC, hotWaterVolMl, groupTargetC);
 }
 
@@ -1333,6 +1319,5 @@ void DE1Device::resendLastShotSettings() {
         .arg(m_commandedHotWaterVolMl)
         .arg(m_commandedGroupTargetC, 0, 'f', 2);
     m_lastShotSettingsWriteMs = QDateTime::currentMSecsSinceEpoch();
-    m_shotSettingsIndicationPending = true;
     m_transport->write(DE1::Characteristic::SHOT_SETTINGS, m_lastShotSettingsPayload);
 }

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -122,13 +122,6 @@ public:
     int commandedHotWaterVolMl() const { return m_commandedHotWaterVolMl; }
     double commandedGroupTargetC() const { return m_commandedGroupTargetC; }
     qint64 lastShotSettingsWriteMs() const { return m_lastShotSettingsWriteMs; }
-    // True between issuing a setShotSettings() write and receiving an
-    // indication that matches the commanded value. While true, any mismatch
-    // indication is presumed to be a stale pre-write value still in flight,
-    // and the drift check ignores it rather than triggering a spurious
-    // resend. Event-based replacement for a wall-clock "was the write
-    // recent?" heuristic.
-    bool shotSettingsIndicationPending() const { return m_shotSettingsIndicationPending; }
     double waterLevel() const { return m_waterLevel; }
     double waterLevelMm() const { return m_waterLevelMm; }
     int waterLevelMl() const { return m_waterLevelMl; }
@@ -332,9 +325,6 @@ private:
     // TargetEspressoVol) which are hardcoded in setShotSettings() and have
     // no corresponding commanded-value members.
     QByteArray m_lastShotSettingsPayload;
-    // See shotSettingsIndicationPending() — event-based "is a write currently
-    // unacknowledged?" flag.
-    bool m_shotSettingsIndicationPending = false;
     double m_waterLevel = 0.0;
     double m_waterLevelMm = 0.0;  // Raw mm value (with sensor offset applied)
     int m_waterLevelMl = 0;       // Volume in ml (from CAD lookup table)

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -138,7 +138,10 @@ MainController::MainController(QNetworkAccessManager* networkManager,
                 m_settings->setSteamDisabled(false);
             }
 
-            // Steam session ended — run post-session analysis
+            // Steam session ended — run post-session analysis. m_steamStartTime
+            // is only set when isFlowing() was true (Steaming/Pouring substates),
+            // so this fires after all flowing samples have been collected even
+            // though the Steaming phase persists through Puffing/Ending substates.
             if (phase != MachineState::Phase::Steaming && m_steamStartTime > 0) {
                 if (m_steamHealthTracker && m_steamDataModel) {
                     m_steamHealthTracker->onSessionComplete(
@@ -2057,12 +2060,13 @@ void MainController::onShotSampleReceived(const ShotSample& sample) {
     }
     m_lastSampleTime = sample.timer;
 
-    // Record steam data only while steam is actually flowing (Steaming/Pouring
-    // substates), not during the GHC purge puff (Puffing) or wind-down (Ending).
-    // Without this gate, ~10s of post-flow purge time inflates rawTime() and
-    // skews SteamHealth's avg/peak metrics with non-steaming samples.
+    // Record steam data only while steam is actually flowing. isFlowing()
+    // returns true only for SubState::Steaming or SubState::Pouring (whitelist);
+    // all other Steaming-phase substates (Puffing, Ending, FinalHeating, etc.)
+    // are excluded. Without this gate, post-flow purge/wind-down samples inflate
+    // rawTime() and skew SteamHealth's avg/peak metrics with non-steaming data.
     bool steamFlowing = (phase == MachineState::Phase::Steaming
-                         && m_machineState && m_machineState->isFlowing());
+                         && m_machineState->isFlowing());
     if (steamFlowing && m_steamDataModel) {
         if (m_steamStartTime == 0) {
             m_steamStartTime = sample.timer;

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -518,30 +518,12 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
         return;
     }
 
-    // Drift detected. If a write is still in flight (DE1Device clears the
-    // flag only when an indication matches commanded), this mismatch is
-    // almost certainly a stale pre-write indication still arriving —
-    // ignore it and wait for the real post-write indication. This is the
-    // event-based replacement for a wall-clock "msSinceLastWrite < 1500"
-    // guard, which CLAUDE.md's "never timers as guards" rule warned
-    // against.
-    if (m_device->shotSettingsIndicationPending()) {
-        qDebug().noquote() << QString(
-            "[SettingsDrift] stale-indication ignored (write unacknowledged): "
-            "reported(steam=%1C dur=%2s hw=%3C vol=%4ml group=%5C) "
-            "commanded(steam=%6C dur=%7s hw=%8C vol=%9ml group=%10C)")
-            .arg(deviceSteamTargetC, 0, 'f', 1)
-            .arg(deviceSteamDurationSec)
-            .arg(deviceHotWaterTempC, 0, 'f', 1)
-            .arg(deviceHotWaterVolMl)
-            .arg(deviceGroupTargetC, 0, 'f', 2)
-            .arg(commandedSteam, 0, 'f', 1)
-            .arg(commandedDuration)
-            .arg(commandedHotWaterTemp, 0, 'f', 1)
-            .arg(commandedHotWaterVol)
-            .arg(commandedGroup, 0, 'f', 2);
-        return;
-    }
+    // Drift detected. Under read-after-write, the received indication is the
+    // post-write state — if it doesn't match commanded, that's real drift.
+    // (Previously this branch had a stale-indication filter that suppressed
+    // mismatches while indicationPending was true, but that was needed only
+    // for the subscription-based design where pre-write indications could
+    // race ahead. The queued read happens after the write completes.)
 
     // Classify for the log so we can scan `grep SettingsDrift` in bug
     // reports and immediately see what happened.

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2057,8 +2057,13 @@ void MainController::onShotSampleReceived(const ShotSample& sample) {
     }
     m_lastSampleTime = sample.timer;
 
-    // Record steam data during Steaming phase
-    if (phase == MachineState::Phase::Steaming && m_steamDataModel) {
+    // Record steam data only while steam is actually flowing (Steaming/Pouring
+    // substates), not during the GHC purge puff (Puffing) or wind-down (Ending).
+    // Without this gate, ~10s of post-flow purge time inflates rawTime() and
+    // skews SteamHealth's avg/peak metrics with non-steaming samples.
+    bool steamFlowing = (phase == MachineState::Phase::Steaming
+                         && m_machineState && m_machineState->isFlowing());
+    if (steamFlowing && m_steamDataModel) {
         if (m_steamStartTime == 0) {
             m_steamStartTime = sample.timer;
             m_steamDataModel->clear();

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -518,12 +518,8 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
         return;
     }
 
-    // Drift detected. Under read-after-write, the received indication is the
-    // post-write state — if it doesn't match commanded, that's real drift.
-    // (Previously this branch had a stale-indication filter that suppressed
-    // mismatches while indicationPending was true, but that was needed only
-    // for the subscription-based design where pre-write indications could
-    // race ahead. The queued read happens after the write completes.)
+    // Drift detected. The received indication is the post-write state
+    // (read is queued after the write), so any mismatch is real drift.
 
     // Classify for the log so we can scan `grep SettingsDrift` in bug
     // reports and immediately see what happened.

--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -49,7 +49,10 @@ MachineState::MachineState(DE1Device* device, QObject* parent)
 }
 
 bool MachineState::isFlowing() const {
-    // For steam, only count as flowing if actually steaming (not purging/ending)
+    // For steam, only count as flowing during SubState::Steaming or
+    // SubState::Pouring (whitelist). All other substates that map to
+    // Phase::Steaming — Puffing, Ending, FinalHeating, PausedSteam, etc. —
+    // return false.
     if (m_phase == Phase::Steaming && m_device) {
         DE1::SubState subState = m_device->subState();
         return subState == DE1::SubState::Steaming ||

--- a/tests/tst_shotsettings.cpp
+++ b/tests/tst_shotsettings.cpp
@@ -305,31 +305,6 @@ private slots:
         QCOMPARE(spy.at(0).at(4).toDouble(), -1.0);     // group temp
     }
 
-    // ===== Indication-pending flag =====
-
-    void indicationPendingSetOnWriteClearedOnAnyIndication() {
-        // Under read-after-write, the queued read always returns the
-        // post-write state. The flag clears on ANY indication received after
-        // the first write, since there are no pre-write stale indications to
-        // filter out (the read happens after the write completes).
-        TestFixture f;
-        QVERIFY(!f.device.shotSettingsIndicationPending());
-
-        f.device.setShotSettings(160, 120, 80, 200, 93.0);
-        QVERIFY(f.device.shotSettingsIndicationPending());
-
-        // Any indication clears the flag — match or mismatch. Drift is
-        // detected by MainController comparing reported vs commanded values,
-        // not by inspecting the pending flag.
-        QByteArray payload(9, 0);
-        uint16_t groupRaw = BinaryCodec::encodeU16P8(90.0);  // mismatching
-        payload[7] = char((groupRaw >> 8) & 0xFF);
-        payload[8] = char(groupRaw & 0xFF);
-        emit f.transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, payload);
-
-        QVERIFY(!f.device.shotSettingsIndicationPending());
-    }
-
     // ===== resendLastShotSettings: repeats the last payload exactly =====
 
     void resendLastShotSettingsRepeatsPayload() {
@@ -342,9 +317,6 @@ private slots:
 
         QCOMPARE(f.transport.writes.size(), 1);
         QCOMPARE(f.transport.lastWriteData(), originalWrite);
-        // Resend should arm the pending flag too — we're waiting for a new
-        // confirming indication.
-        QVERIFY(f.device.shotSettingsIndicationPending());
     }
 
     void resendLastShotSettingsNoOpBeforeFirstWrite() {

--- a/tests/tst_shotsettings.cpp
+++ b/tests/tst_shotsettings.cpp
@@ -305,48 +305,29 @@ private slots:
         QCOMPARE(spy.at(0).at(4).toDouble(), -1.0);     // group temp
     }
 
-    // ===== Indication-pending flag (event-based stale-indication detection) =====
+    // ===== Indication-pending flag =====
 
-    void indicationPendingSetOnWriteClearedOnMatch() {
+    void indicationPendingSetOnWriteClearedOnAnyIndication() {
+        // Under read-after-write, the queued read always returns the
+        // post-write state. The flag clears on ANY indication received after
+        // the first write, since there are no pre-write stale indications to
+        // filter out (the read happens after the write completes).
         TestFixture f;
         QVERIFY(!f.device.shotSettingsIndicationPending());
 
         f.device.setShotSettings(160, 120, 80, 200, 93.0);
         QVERIFY(f.device.shotSettingsIndicationPending());
 
-        // A matching indication arrives — flag clears.
+        // Any indication clears the flag — match or mismatch. Drift is
+        // detected by MainController comparing reported vs commanded values,
+        // not by inspecting the pending flag.
         QByteArray payload(9, 0);
-        payload[1] = char(160);
-        payload[2] = char(120);
-        payload[3] = char(80);
-        payload[4] = char(200);
-        payload[5] = char(60);
-        payload[6] = char(200);
-        uint16_t groupRaw = BinaryCodec::encodeU16P8(93.0);
+        uint16_t groupRaw = BinaryCodec::encodeU16P8(90.0);  // mismatching
         payload[7] = char((groupRaw >> 8) & 0xFF);
         payload[8] = char(groupRaw & 0xFF);
         emit f.transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, payload);
 
         QVERIFY(!f.device.shotSettingsIndicationPending());
-    }
-
-    void indicationPendingStaysOnMismatch() {
-        // A stale indication (non-matching value arrives before the DE1 has
-        // processed our write) must NOT clear the flag — otherwise a
-        // subsequent matching indication would be misinterpreted, and the
-        // drift handler would incorrectly treat the stale one as real drift.
-        TestFixture f;
-        f.device.setShotSettings(160, 120, 80, 200, 93.0);
-        QVERIFY(f.device.shotSettingsIndicationPending());
-
-        // Stale indication with the previous (0) value.
-        QByteArray payload(9, 0);
-        uint16_t groupRaw = BinaryCodec::encodeU16P8(90.0);
-        payload[7] = char((groupRaw >> 8) & 0xFF);
-        payload[8] = char(groupRaw & 0xFF);
-        emit f.transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, payload);
-
-        QVERIFY(f.device.shotSettingsIndicationPending());
     }
 
     // ===== resendLastShotSettings: repeats the last payload exactly =====
@@ -372,54 +353,6 @@ private slots:
         f.transport.clearWrites();
         f.device.resendLastShotSettings();
         QCOMPARE(f.transport.writes.size(), 0);
-    }
-
-    // ===== Partial-match: pending flag stays set if only some fields match =====
-
-    void indicationPendingPartialMatchStaysPending() {
-        // Validates the "lost steam timeout" scenario: steam temp matches but
-        // duration doesn't. The pending flag must stay set so MainController
-        // detects drift and triggers a resend.
-        TestFixture f;
-        f.device.setShotSettings(160, 120, 80, 200, 93.0);
-        QVERIFY(f.device.shotSettingsIndicationPending());
-
-        // Build indication that matches steam+group temp but has wrong duration.
-        QByteArray payload(9, 0);
-        payload[1] = char(160);   // steam temp matches
-        payload[2] = char(60);    // duration MISMATCHES (120 commanded)
-        payload[3] = char(80);    // hot water temp matches
-        payload[4] = char(200);   // hot water vol matches
-        payload[5] = char(60);
-        payload[6] = char(200);
-        uint16_t groupRaw = BinaryCodec::encodeU16P8(93.0);
-        payload[7] = char((groupRaw >> 8) & 0xFF);
-        payload[8] = char(groupRaw & 0xFF);
-        emit f.transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, payload);
-
-        // Pending should stay set because duration doesn't match.
-        QVERIFY(f.device.shotSettingsIndicationPending());
-    }
-
-    void indicationPendingPartialMatchHotWaterStaysPending() {
-        // Hot water volume mismatch: everything else matches but vol doesn't.
-        TestFixture f;
-        f.device.setShotSettings(160, 120, 80, 200, 93.0);
-        QVERIFY(f.device.shotSettingsIndicationPending());
-
-        QByteArray payload(9, 0);
-        payload[1] = char(160);   // steam temp matches
-        payload[2] = char(120);   // duration matches
-        payload[3] = char(80);    // hot water temp matches
-        payload[4] = char(150);   // hot water vol MISMATCHES (200 commanded)
-        payload[5] = char(60);
-        payload[6] = char(200);
-        uint16_t groupRaw = BinaryCodec::encodeU16P8(93.0);
-        payload[7] = char((groupRaw >> 8) & 0xFF);
-        payload[8] = char(groupRaw & 0xFF);
-        emit f.transport.dataReceived(DE1::Characteristic::SHOT_SETTINGS, payload);
-
-        QVERIFY(f.device.shotSettingsIndicationPending());
     }
 
     // ===== Dedup: identical writes are skipped =====

--- a/tests/tst_shotsettings.cpp
+++ b/tests/tst_shotsettings.cpp
@@ -421,6 +421,53 @@ private slots:
 
         QVERIFY(f.device.shotSettingsIndicationPending());
     }
+
+    // ===== Dedup: identical writes are skipped =====
+
+    void duplicateWriteSkipped() {
+        // Multiple QML signals (state change, phase change, page open, isSteaming
+        // change) all fire startSteamHeating() with the same values. The second
+        // identical write should be skipped to avoid wasted BLE traffic.
+        TestFixture f;
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression("\\[ShotSettings\\] write skipped"));
+
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);
+        f.transport.clearWrites();
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);  // identical
+
+        QCOMPARE(f.transport.writes.size(), 0);
+    }
+
+    void changedWriteFiresAfterDuplicate() {
+        // After a duplicate is skipped, a genuinely different write must still
+        // fire. Dedup compares against the LAST sent payload, not historical.
+        TestFixture f;
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression("\\[ShotSettings\\] write skipped"));
+
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);  // skipped
+        f.transport.clearWrites();
+        f.device.setShotSettings(160, 60, 80, 200, 93.0);   // different duration
+
+        QCOMPARE(f.transport.writes.size(), 1);
+    }
+
+    void duplicateWriteAfterDisconnectFires() {
+        // Disconnect clears m_lastShotSettingsPayload. A subsequent identical
+        // write after reconnect must not be deduped against the pre-disconnect
+        // value.
+        TestFixture f;
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);
+
+        f.transport.setConnectedSim(false);
+        f.transport.setConnectedSim(true);
+
+        f.transport.clearWrites();
+        f.device.setShotSettings(160, 120, 80, 200, 93.0);  // same values
+        QCOMPARE(f.transport.writes.size(), 1);  // fired despite same values
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_ShotSettings)


### PR DESCRIPTION
## Summary
Three fixes that work together to make ShotSettings drift detection actually function:

1. **Read-after-write verification** — adds `read(SHOT_SETTINGS)` after every `setShotSettings()` write so the drift detector receives the DE1's stored value
2. **Queue-aware reads** — `BleTransport::read()` now goes through the command queue instead of bypassing it, so reads after writes don't race ahead and return stale values
3. **Dedupe identical writes** — skip writes whose payload exactly matches the last one sent, eliminating the 4-5 duplicate BLE writes per steam session
4. **Remove unused subscription** — drop `subscribe(SHOT_SETTINGS)` since the DE1 firmware never pushes notifications on this characteristic

## Context
The drift detector added in PR #768 was built on a false premise: that the DE1 firmware pushes notifications on the `SHOT_SETTINGS` characteristic when written. Inspection of de1app's `de1_comms.tcl` confirms it does NOT — de1app doesn't subscribe to `SHOT_SETTINGS`, only reads it on demand.

Production logs from build 3278 show this clearly: 12 ShotSettings writes in a 20-minute session, but only **one** `[ShotSettings] reported:` line (from the explicit startup read). Every steam timeout change, every group temp change — none of them got verified.

The duplicate writes came from multiple QML signals (state change, phase change, page open, isSteaming change) all firing `startSteamHeating()` with the same values within milliseconds. With read-after-write added, these duplicates would also produce duplicate reads — so deduping at the write site eliminates both at once.

## Test plan
- [ ] Connect to DE1 — verify a single `[ShotSettings] reported:` from startup read
- [ ] Change steam timeout in Settings — verify a `[ShotSettings] reported:` follows the `write:` line within ~50-100ms with the new value
- [ ] Run a steam session — verify ONE write per actual change (no `[ShotSettings] write skipped:` spam, but a few skips per session is expected from the QML signal cascade)
- [ ] Run `ctest -R tst_shotsettings` to verify existing tests pass + 3 new dedup tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)