### PR TITLE
fix: remove QML page preload + defer page side effects to onActivated

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -596,97 +596,13 @@ ApplicationWindow {
         }
     }
 
-    // Pre-compile pages at startup by loading them once (warms QML cache)
-    // These are NOT used for navigation - StackView uses Components below
-    // The Loaders just ensure QML is parsed/compiled before first navigation
-    Loader {
-        id: preloadIdle
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { IdlePage {} }
-        onLoaded: active = false  // Unload after compilation (Loader owns the item)
-    }
-    Loader {
-        id: preloadEspresso
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { EspressoPage {} }
-        onLoaded: active = false
-    }
-    Loader {
-        id: preloadSteam
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { SteamPage {} }
-        onLoaded: active = false
-    }
-    Loader {
-        id: preloadHotWater
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { HotWaterPage {} }
-        onLoaded: active = false
-    }
-    Loader {
-        id: preloadFlush
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { FlushPage {} }
-        onLoaded: active = false
-    }
-    Loader {
-        id: preloadSettings
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { SettingsPage {} }
-        onLoaded: active = false
-    }
-    Loader {
-        id: preloadProfileSelector
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { ProfileSelectorPage {} }
-        onLoaded: active = false
-    }
-    Loader {
-        id: preloadProfileEditor
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { ProfileEditorPage {} }
-        onLoaded: active = false
-    }
-    Loader {
-        id: preloadRecipeEditor
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { RecipeEditorPage {} }
-        onLoaded: active = false
-    }
-    Loader {
-        id: preloadPressureEditor
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { PressureEditorPage {} }
-        onLoaded: active = false
-    }
-    Loader {
-        id: preloadFlowEditor
-        active: true
-        asynchronous: true
-        visible: false
-        sourceComponent: Component { FlowEditorPage {} }
-        onLoaded: active = false
-    }
+    // QML compilation is cached at build time by qmlcachegen (enabled by
+    // default in qt_add_qml_module since Qt 6.5), so the previous "preload
+    // every page in a hidden Loader" pattern no longer warmed anything
+    // useful — it just instantiated the full QML object tree, ran every
+    // page's Component.onCompleted (firing real BLE/scale side effects
+    // before the user opened the page), then destroyed it. Removed.
+
 
     // Navigation guard to prevent double-taps during page transitions
     property bool navigationInProgress: false

--- a/qml/pages/EspressoPage.qml
+++ b/qml/pages/EspressoPage.qml
@@ -26,13 +26,6 @@ Page {
     // Enable keyboard focus for the page
     focus: true
 
-    Component.onCompleted: {
-        // Only set title if this page is actually in the StackView (not during preload)
-        if (StackView.status === StackView.Active) {
-            root.currentPageTitle = ProfileManager.currentProfileName
-            viewModeMouseArea.forceActiveFocus()
-        }
-    }
     StackView.onActivated: {
         root.currentPageTitle = ProfileManager.currentProfileName
         espressoPage.forceActiveFocus()  // Ensure keyboard focus

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -10,7 +10,10 @@ Page {
 
     property string pageTitle: TranslationManager.translate("flush.title", "Flush")
 
-    Component.onCompleted: {
+    // No side effects here — this fires during the StackView preload Loader
+    // in main.qml and would apply flush settings before the user has even
+    // opened the page. Side effects belong in StackView.onActivated.
+    StackView.onActivated: {
         root.currentPageTitle = pageTitle
         // Sync Settings with selected preset
         Settings.flushFlow = getCurrentPresetFlow()
@@ -18,7 +21,6 @@ Page {
         MainController.applyFlushSettings()
         if (!isFlushing) secondsInput.forceActiveFocus()
     }
-    StackView.onActivated: root.currentPageTitle = pageTitle
 
     property bool isFlushing: MachineState.phase === MachineStateType.Phase.Flushing || root.debugLiveView
     property int editingPresetIndex: -1

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -10,16 +10,20 @@ Page {
 
     property string pageTitle: TranslationManager.translate("flush.title", "Flush")
 
-    // No side effects here — this fires during the StackView preload Loader
-    // in main.qml and would apply flush settings before the user has even
-    // opened the page. Side effects belong in StackView.onActivated.
+    // Use StackView.onActivated (not Component.onCompleted) so side effects
+    // run when the page is actually shown, not during construction. This
+    // also re-fires on pop-back if the page is ever pushed below another.
+    // Skip the preset-reset and settings push while flushing so a
+    // re-activation mid-session doesn't clobber in-progress state.
     StackView.onActivated: {
         root.currentPageTitle = pageTitle
-        // Sync Settings with selected preset
-        Settings.flushFlow = getCurrentPresetFlow()
-        Settings.flushSeconds = getCurrentPresetSeconds()
-        MainController.applyFlushSettings()
-        if (!isFlushing) secondsInput.forceActiveFocus()
+        if (!isFlushing) {
+            // Sync Settings with selected preset
+            Settings.flushFlow = getCurrentPresetFlow()
+            Settings.flushSeconds = getCurrentPresetSeconds()
+            MainController.applyFlushSettings()
+            secondsInput.forceActiveFocus()
+        }
     }
 
     property bool isFlushing: MachineState.phase === MachineStateType.Phase.Flushing || root.debugLiveView

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -8,7 +8,11 @@ Page {
     objectName: "hotWaterPage"
     background: Rectangle { color: Theme.backgroundColor }
 
-    Component.onCompleted: {
+    // No side effects here — this fires during the StackView preload Loader
+    // in main.qml and would tare the scale and apply hot water settings before
+    // the user has even opened the page. Side effects belong in
+    // StackView.onActivated.
+    StackView.onActivated: {
         root.currentPageTitle = pageTitleText.text
         // Sync Settings with selected preset
         Settings.waterVolume = getCurrentVesselVolume()
@@ -24,7 +28,6 @@ Page {
         }
         if (!isDispensing) volumeInput.forceActiveFocus()
     }
-    StackView.onActivated: root.currentPageTitle = pageTitleText.text
 
     // Hidden Tr component for page title (used by root.currentPageTitle)
     Tr { id: pageTitleText; key: "hotwater.title"; fallback: "Hot Water"; visible: false }

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -8,25 +8,25 @@ Page {
     objectName: "hotWaterPage"
     background: Rectangle { color: Theme.backgroundColor }
 
-    // No side effects here — this fires during the StackView preload Loader
-    // in main.qml and would tare the scale and apply hot water settings before
-    // the user has even opened the page. Side effects belong in
-    // StackView.onActivated.
+    // Use StackView.onActivated (not Component.onCompleted) so side effects
+    // run when the page is actually shown, not during construction. This
+    // also re-fires on pop-back if the page is ever pushed below another.
+    // Skip the preset-reset, settings push, and tare while dispensing so a
+    // re-activation mid-session doesn't clobber in-progress state.
     StackView.onActivated: {
         root.currentPageTitle = pageTitleText.text
-        // Sync Settings with selected preset
-        Settings.waterVolume = getCurrentVesselVolume()
-        Settings.waterVolumeMode = getCurrentVesselMode()
-        Settings.hotWaterFlowRate = getCurrentVesselFlowRate()
-        MainController.applyHotWaterSettings()
-        // Tare immediately so display shows 0g instead of current scale weight.
-        // Skip if already dispensing — the C++ flow-start handler tares with a
-        // 200ms delay to avoid BLE command contention; a duplicate tare here
-        // would overwrite the baseline and risk BLE packet drops.
-        if (!isVolumeMode && !isDispensing) {
-            MachineState.tareScale()
+        if (!isDispensing) {
+            // Sync Settings with selected preset
+            Settings.waterVolume = getCurrentVesselVolume()
+            Settings.waterVolumeMode = getCurrentVesselMode()
+            Settings.hotWaterFlowRate = getCurrentVesselFlowRate()
+            MainController.applyHotWaterSettings()
+            // Tare immediately so display shows 0g instead of current scale weight.
+            if (!isVolumeMode) {
+                MachineState.tareScale()
+            }
+            volumeInput.forceActiveFocus()
         }
-        if (!isDispensing) volumeInput.forceActiveFocus()
     }
 
     // Hidden Tr component for page title (used by root.currentPageTitle)

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -12,18 +12,23 @@ Page {
     property string pageTitle: steamPageTitle.text
     Tr { id: steamPageTitle; key: "steam.title"; fallback: "Steam"; visible: false }
 
-    // No side effects here — this fires during the StackView preload Loader
-    // in main.qml and would call startSteamHeating() before the user has
-    // even opened the page. Side effects belong in StackView.onActivated.
+    // Use StackView.onActivated (not Component.onCompleted) so side effects
+    // run when the page is actually shown, not during construction. This
+    // also re-fires on pop-back if the page is ever pushed below another.
+    // Gate the preset-reset and heater-start on !isSteaming so a re-activation
+    // mid-session doesn't clobber the user's in-progress settings or re-issue
+    // a redundant BLE write.
     StackView.onActivated: {
         root.currentPageTitle = pageTitle
-        // Sync Settings with selected preset
-        Settings.steamTimeout = getCurrentPitcherDuration()
-        Settings.steamFlow = getCurrentPitcherFlow()
-        // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
-        // startSteamHeating clears steamDisabled flag automatically
-        MainController.startSteamHeating()
-        if (!isSteaming) durationSlider.forceActiveFocus()
+        if (!isSteaming) {
+            // Sync Settings with selected preset
+            Settings.steamTimeout = getCurrentPitcherDuration()
+            Settings.steamFlow = getCurrentPitcherFlow()
+            // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
+            // startSteamHeating clears steamDisabled flag automatically
+            MainController.startSteamHeating()
+            durationSlider.forceActiveFocus()
+        }
     }
 
     property bool isSteaming: MachineState.phase === MachineStateType.Phase.Steaming || root.debugLiveView

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -12,7 +12,10 @@ Page {
     property string pageTitle: steamPageTitle.text
     Tr { id: steamPageTitle; key: "steam.title"; fallback: "Steam"; visible: false }
 
-    Component.onCompleted: {
+    // No side effects here — this fires during the StackView preload Loader
+    // in main.qml and would call startSteamHeating() before the user has
+    // even opened the page. Side effects belong in StackView.onActivated.
+    StackView.onActivated: {
         root.currentPageTitle = pageTitle
         // Sync Settings with selected preset
         Settings.steamTimeout = getCurrentPitcherDuration()
@@ -22,7 +25,6 @@ Page {
         MainController.startSteamHeating()
         if (!isSteaming) durationSlider.forceActiveFocus()
     }
-    StackView.onActivated: root.currentPageTitle = pageTitle
 
     property bool isSteaming: MachineState.phase === MachineStateType.Phase.Steaming || root.debugLiveView
     property int editingPitcherIndex: -1  // For the edit popup


### PR DESCRIPTION
## Summary
Two related fixes:

1. **Remove the QML page preload Loaders** in `main.qml`. Qt 6.5+'s `qt_add_qml_module` enables `qmlcachegen` by default, which compiles QML to bytecode at build time. The hidden-Loader preload pattern predated that and no longer warms anything useful — it just instantiated 11 page object trees, ran every `Component.onCompleted` (firing real BLE/scale side effects), then destroyed them.

2. **Defer SteamPage/HotWaterPage/FlushPage side effects to `StackView.onActivated`** so they only run when the user actually opens the page, not whenever the QML object is instantiated. Matches the pattern EspressoPage already uses.

## Context
Production logs (build 3278) show SteamPage's `MainController.startSteamHeating()` firing at app startup, producing a `[ShotSettings] write: steam=160.0C ...` BLE write before the user did anything. It also overwrote `Settings.steamTimeout` and `Settings.steamFlow` with the pitcher preset defaults.

HotWaterPage was sending `MachineState.tareScale()` at startup. FlushPage was overwriting `Settings.flushFlow`/`flushSeconds`.

Tracing back, both issues had the same root cause: `Component.onCompleted` ran during the preload Loader's instantiation. Removing the preload eliminates the entire class of "side effects fire before user interaction" bugs, plus it speeds up cold start by skipping 11 unnecessary instantiations.

## Test plan
- [ ] Cold launch app — verify NO `[ShotSettings] write: steam=160.0C ...` from `startSteamHeating()` before opening Steam page
- [ ] Open Steam page — verify settings sync, heater turns on, focus moves to slider
- [ ] Open Hot Water page — verify tare fires (when not dispensing), volume/flow reset to preset
- [ ] Open Flush page — verify flow/seconds reset to preset
- [ ] Navigate between pages — verify navigation doesn't feel noticeably slower than before
- [ ] Cold launch should be faster (one fewer pass of QML instantiation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)