### PR TITLE
test: fix tst_ProfileManager upload tests against ShotSettings dedup

### DIFF
--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -370,5 +370,6 @@ private:
 #ifdef DECENZA_TESTING
     friend class tst_SAV;
     friend class tst_MachineState;
+    friend class tst_ProfileManager;
 #endif
 };

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -375,6 +375,7 @@ private slots:
         // Set a temperature override
         f.settings.setTemperatureOverride(95.0);
         f.transport.clearWrites();
+        f.device.m_lastShotSettingsPayload.clear();
         f.profileManager.uploadCurrentProfile();
 
         // Shot settings should reflect the override, not the profile default

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -185,6 +185,10 @@ private slots:
         McpTestFixture f;
         loadDFlowProfile(f);
         f.transport.clearWrites();
+        // loadProfileFromJson already uploaded (same payload), so the next
+        // setShotSettings would be deduped. Clear the cache so this test can
+        // observe the SHOT_SETTINGS write.
+        f.device.m_lastShotSettingsPayload.clear();
 
         f.profileManager.uploadCurrentProfile();
 
@@ -202,6 +206,7 @@ private slots:
         McpTestFixture f;
         loadDFlowProfile(f, "Test", 36.0, 91.0);
         f.transport.clearWrites();
+        f.device.m_lastShotSettingsPayload.clear();
 
         f.profileManager.uploadCurrentProfile();
 
@@ -222,6 +227,7 @@ private slots:
         McpTestFixture f;
         loadDFlowProfile(f);
         f.transport.clearWrites();
+        f.device.m_lastShotSettingsPayload.clear();
 
         f.profileManager.uploadCurrentProfile();
 


### PR DESCRIPTION
## Summary
- PR #773 added payload-based dedup in `DE1Device::setShotSettings`. Three `tst_ProfileManager` tests (`uploadCurrentProfileWritesBLE`, `uploadCurrentProfileSendsCorrectTemperature`, `uploadCurrentProfileSends200mlSafetyLimit`) silently started failing because `loadDFlowProfile()` calls `uploadCurrentProfile()` internally via `loadProfileFromJson` (profilemanager.cpp:1142). That first upload wrote SHOT_SETTINGS; `clearWrites()` dropped the captured write; the explicit second `uploadCurrentProfile()` produced the same payload and was skipped by dedup → `writesTo(SHOT_SETTINGS)` came back empty.
- App behavior is correct (the dedup is the whole point of #773). Fix the test harness: clear `f.device.m_lastShotSettingsPayload` between the load and the explicit upload so the tested call actually fires.
- Added `tst_ProfileManager` to the `friend class` list in `src/ble/de1device.h` under `DECENZA_TESTING`, matching the existing `tst_SAV` / `tst_MachineState` pattern.

## Test plan
- [x] `tst_profilemanager` — 135 pass, 0 fail (was 132 pass, 3 fail on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)