### PR TITLE
fix: unify ShotSettings volume-mode gate and attribute BLE writes

### DIFF
--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -334,7 +334,7 @@ Item {
                 case "tempToggleSteam":
                     if (typeof Settings !== "undefined" && typeof MainController !== "undefined") {
                         if (Settings.steamDisabled)
-                            MainController.startSteamHeating()
+                            MainController.startSteamHeating("custom-widget-toggle")
                         else
                             MainController.turnOffSteamHeater()
                     }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -215,7 +215,7 @@ ApplicationWindow {
             // DE1::State::Steam = 5
             if (DE1Device.state === 5) {
                 console.log("DE1 entered Steam state - starting heater, navigating to SteamPage")
-                MainController.startSteamHeating()  // This clears steamDisabled flag
+                MainController.startSteamHeating("de1-state-steam")  // This clears steamDisabled flag
                 // Navigate to SteamPage immediately so user sees heating progress
                 var currentPage = pageStack.currentItem ? pageStack.currentItem.objectName : ""
                 if (currentPage !== "steamPage" && !pageStack.busy) {
@@ -2080,7 +2080,7 @@ ApplicationWindow {
             if (phase === MachineStateType.Phase.Steaming && wasIdle) {
                 // Start steam heating when entering steam (from GHC button)
                 // startSteamHeating clears steamDisabled flag and forces heater on regardless of keepSteamHeaterOn
-                MainController.startSteamHeating()
+                MainController.startSteamHeating("phase-steaming")
                 console.log("Started steam heating on phase change to Steaming")
                 // Stop any pending auto-flush timer when starting new steam
                 steamAutoFlushTimer.stop()

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -26,7 +26,7 @@ Page {
             Settings.steamFlow = getCurrentPitcherFlow()
             // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
             // startSteamHeating clears steamDisabled flag automatically
-            MainController.startSteamHeating()
+            MainController.startSteamHeating("steampage-activated")
             durationSlider.forceActiveFocus()
         }
     }
@@ -76,7 +76,7 @@ Page {
             // Reset to preset value (discard any +5s/-5s adjustments from previous session)
             Settings.steamTimeout = getCurrentPitcherDuration()
             Settings.steamFlow = getCurrentPitcherFlow()
-            MainController.startSteamHeating()
+            MainController.startSteamHeating("is-steaming-changed")
         } else {
             console.log("SteamPage: Settings view now visible (isSteaming=false)")
             // Turn off steam heater after steaming if keepSteamHeaterOn is false
@@ -312,7 +312,7 @@ Page {
                                     Settings.steamTimeout = modelData.duration
                                     Settings.steamFlow = flow
                                     if (!isSteaming)
-                                        MainController.startSteamHeating()
+                                        MainController.startSteamHeating("live-pitcher-click")
                                 }
                             }
                         }
@@ -455,7 +455,7 @@ Page {
                                 if (isSteaming)
                                     MainController.setSteamTimeoutImmediate(newTime)
                                 else
-                                    MainController.startSteamHeating()
+                                    MainController.startSteamHeating("decrease-5s")
                             }
                         }
                     }
@@ -515,7 +515,7 @@ Page {
                                 if (isSteaming)
                                     MainController.setSteamTimeoutImmediate(newTime)
                                 else
-                                    MainController.startSteamHeating()
+                                    MainController.startSteamHeating("increase-5s")
                             }
                         }
                     }
@@ -854,7 +854,7 @@ Page {
                                         flowSlider.value = flow
                                         Settings.steamTimeout = modelData.duration
                                         Settings.steamFlow = flow
-                                        MainController.startSteamHeating()
+                                        MainController.startSteamHeating("pitcher-a11y")
                                     }
 
                                     Keys.onReturnPressed: {
@@ -864,7 +864,7 @@ Page {
                                         flowSlider.value = flow
                                         Settings.steamTimeout = modelData.duration
                                         Settings.steamFlow = flow
-                                        MainController.startSteamHeating()
+                                        MainController.startSteamHeating("pitcher-return")
                                         event.accepted = true
                                     }
                                     Keys.onSpacePressed: {
@@ -874,7 +874,7 @@ Page {
                                         flowSlider.value = flow
                                         Settings.steamTimeout = modelData.duration
                                         Settings.steamFlow = flow
-                                        MainController.startSteamHeating()
+                                        MainController.startSteamHeating("pitcher-space")
                                         event.accepted = true
                                     }
                                     Keys.onLeftPressed: {
@@ -947,7 +947,7 @@ Page {
                                                 flowSlider.value = flow
                                                 Settings.steamTimeout = modelData.duration
                                                 Settings.steamFlow = flow
-                                                MainController.startSteamHeating()
+                                                MainController.startSteamHeating("pitcher-click")
                                             }
                                             pitcherPill.Drag.drop()
                                             pitcherPresetsRow.draggedIndex = -1

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1199,7 +1199,8 @@ void DE1Device::sendInitialSettings() {
 
 void DE1Device::setShotSettings(double steamTemp, int steamDuration,
                                 double hotWaterTemp, int hotWaterVolume,
-                                double groupTemp) {
+                                double groupTemp,
+                                const QString& reason) {
     if (!m_transport) return;
     QByteArray data(9, 0);
     data[0] = 0;  // SteamSettings flags
@@ -1214,21 +1215,26 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     data[7] = (groupTempEncoded >> 8) & 0xFF;
     data[8] = groupTempEncoded & 0xFF;
 
+    const QString reasonSuffix = reason.isEmpty()
+        ? QString() : QStringLiteral(" [%1]").arg(reason);
+
     // Dedupe: skip writes whose payload exactly matches the last one sent.
     // Multiple QML signals (state change, phase change, page open, isSteaming
     // change) all fire startSteamHeating() with the same values, producing
     // 4-5 identical BLE writes per steam session. Resends from the drift
     // auto-heal path go through resendLastShotSettings() and bypass this
-    // function, so they're unaffected.
+    // function, so they're unaffected. The `[reason]` suffix attributes the
+    // elided call to its origin so we can see which convergent signal fired.
     if (data == m_lastShotSettingsPayload) {
         qDebug().noquote() << QString(
             "[ShotSettings] write skipped: payload unchanged "
-            "(steam=%1C duration=%2s hotWater=%3C vol=%4ml groupTemp=%5C)")
+            "(steam=%1C duration=%2s hotWater=%3C vol=%4ml groupTemp=%5C)%6")
             .arg(steamTemp, 0, 'f', 1)
             .arg(steamDuration)
             .arg(hotWaterTemp, 0, 'f', 1)
             .arg(hotWaterVolume)
-            .arg(groupTemp, 0, 'f', 2);
+            .arg(groupTemp, 0, 'f', 2)
+            .arg(reasonSuffix);
         return;
     }
 
@@ -1248,12 +1254,13 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     // This is what lets us tell apart "we never wrote it" vs "we wrote it and
     // the DE1 ignored us" vs "stale indication crossed our new write".
     qDebug().noquote() << QString(
-        "[ShotSettings] write: steam=%1C duration=%2s hotWater=%3C vol=%4ml groupTemp=%5C")
+        "[ShotSettings] write: steam=%1C duration=%2s hotWater=%3C vol=%4ml groupTemp=%5C%6")
         .arg(steamTemp, 0, 'f', 1)
         .arg(steamDuration)
         .arg(hotWaterTemp, 0, 'f', 1)
         .arg(hotWaterVolume)
-        .arg(groupTemp, 0, 'f', 2);
+        .arg(groupTemp, 0, 'f', 2)
+        .arg(reasonSuffix);
 
     m_transport->write(DE1::Characteristic::SHOT_SETTINGS, data);
 

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -183,10 +183,13 @@ public slots:
     void writeHeader(const QByteArray& headerData);
     void writeFrame(const QByteArray& frameData);
 
-    // Settings
+    // Settings. `reason` is an optional caller tag that appears in the
+    // [ShotSettings] write: / write skipped: log lines, so redundant calls
+    // from convergent signals can be attributed to their origin.
     void setShotSettings(double steamTemp, int steamDuration,
                         double hotWaterTemp, int hotWaterVolume,
-                        double groupTemp);
+                        double groupTemp,
+                        const QString& reason = QString());
 
     // Re-send the last ShotSettings payload exactly as last commanded. Used
     // by the drift auto-heal path to re-assert what we intended WITHOUT

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -631,13 +631,6 @@ void MainController::sendMachineSettings() {
     double groupTemp = getGroupTemperature();
     qDebug() << "sendMachineSettings: steam=" << steamTemp << "°C, groupTemp=" << groupTemp << "°C";
 
-    // Hot water volume: only send actual ml in volume mode (machine auto-stops via flowmeter).
-    // In weight mode send 0 so the app controls stop via scale instead.
-    int hotWaterVolume = 0;
-    if (m_settings->waterVolumeMode() == "volume") {
-        hotWaterVolume = qMin(m_settings->waterVolume(), 255);  // BLE uint8 max
-    }
-
     // 1. ShotSettings (single write with all temperatures).
     // DE1Device::setShotSettings() internally records the commanded values
     // so onShotSettingsReported() can compare reported against commanded.
@@ -645,7 +638,7 @@ void MainController::sendMachineSettings() {
         steamTemp,
         m_settings->steamTimeout(),
         m_settings->waterTemperature(),
-        hotWaterVolume,
+        m_settings->effectiveHotWaterVolume(),
         groupTemp
     );
 
@@ -1267,7 +1260,7 @@ void MainController::setSteamTemperatureImmediate(double temp) {
         temp,
         m_settings->steamTimeout(),
         m_settings->waterTemperature(),
-        m_settings->waterVolume(),
+        m_settings->effectiveHotWaterVolume(),
         groupTemp
     );
 
@@ -1314,7 +1307,7 @@ void MainController::sendSteamTemperature(double temp) {
               .arg(temp)
               .arg(m_settings->steamTimeout())
               .arg(m_settings->waterTemperature())
-              .arg(m_settings->waterVolume())
+              .arg(m_settings->effectiveHotWaterVolume())
               .arg(groupTemp));
 
     // Send to machine without saving to settings (for enable/disable toggle)
@@ -1322,7 +1315,7 @@ void MainController::sendSteamTemperature(double temp) {
         temp,
         m_settings->steamTimeout(),
         m_settings->waterTemperature(),
-        m_settings->waterVolume(),
+        m_settings->effectiveHotWaterVolume(),
         groupTemp
     );
 
@@ -1344,7 +1337,7 @@ void MainController::startSteamHeating() {
         steamTemp,
         m_settings->steamTimeout(),
         m_settings->waterTemperature(),
-        m_settings->waterVolume(),
+        m_settings->effectiveHotWaterVolume(),
         groupTemp
     );
 
@@ -1367,7 +1360,7 @@ void MainController::turnOffSteamHeater() {
         0.0,
         m_settings->steamTimeout(),
         m_settings->waterTemperature(),
-        m_settings->waterVolume(),
+        m_settings->effectiveHotWaterVolume(),
         groupTemp
     );
 
@@ -1407,7 +1400,7 @@ void MainController::setSteamTimeoutImmediate(int timeout) {
         m_settings->steamTemperature(),
         timeout,
         m_settings->waterTemperature(),
-        m_settings->waterVolume(),
+        m_settings->effectiveHotWaterVolume(),
         groupTemp
     );
 
@@ -1426,7 +1419,7 @@ void MainController::softStopSteam() {
         m_settings->steamTemperature(),
         1,  // 1 second - any elapsed time > 1 will trigger stop
         m_settings->waterTemperature(),
-        m_settings->waterVolume(),
+        m_settings->effectiveHotWaterVolume(),
         groupTemp
     );
 

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -258,7 +258,7 @@ MainController::MainController(QNetworkAccessManager* networkManager,
 
     // Steam on/off commands
     connect(m_mqttClient, &MqttClient::steamOnRequested, this, [this]() {
-        startSteamHeating();
+        startSteamHeating(QStringLiteral("mqtt-steam-on"));
     });
     connect(m_mqttClient, &MqttClient::steamOffRequested, this, [this]() {
         turnOffSteamHeater();
@@ -612,7 +612,7 @@ void MainController::onShotSettingsReported(double deviceSteamTargetC, int devic
     m_device->resendLastShotSettings();
 }
 
-void MainController::sendMachineSettings() {
+void MainController::sendMachineSettings(const QString& reason) {
     if (!m_device || !m_device->isConnected() || !m_settings) return;
 
     // Determine steam temperature to send:
@@ -639,7 +639,8 @@ void MainController::sendMachineSettings() {
         m_settings->steamTimeout(),
         m_settings->waterTemperature(),
         m_settings->effectiveHotWaterVolume(),
-        groupTemp
+        groupTemp,
+        reason.isEmpty() ? QStringLiteral("sendMachineSettings") : reason
     );
 
     // 2. Steam flow MMR
@@ -655,17 +656,17 @@ void MainController::sendMachineSettings() {
 }
 
 void MainController::applySteamSettings() {
-    sendMachineSettings();
+    sendMachineSettings(QStringLiteral("applySteamSettings"));
 }
 
 void MainController::applyHotWaterSettings() {
-    sendMachineSettings();
+    sendMachineSettings(QStringLiteral("applyHotWaterSettings"));
     if (m_device && m_device->isConnected())
         m_device->writeMMR(DE1::MMR::HOT_WATER_FLOW_RATE, m_settings->hotWaterFlowRate());
 }
 
 void MainController::applyFlushSettings() {
-    sendMachineSettings();
+    sendMachineSettings(QStringLiteral("applyFlushSettings"));
 }
 
 void MainController::applyAllSettings() {
@@ -680,7 +681,7 @@ void MainController::applyAllSettings() {
     }
 
     // 2. Apply steam/hot water/flush settings (unified)
-    sendMachineSettings();
+    sendMachineSettings(QStringLiteral("applyAllSettings"));
 
     // 3. Apply water refill level
     applyWaterRefillLevel();
@@ -1261,7 +1262,8 @@ void MainController::setSteamTemperatureImmediate(double temp) {
         m_settings->steamTimeout(),
         m_settings->waterTemperature(),
         m_settings->effectiveHotWaterVolume(),
-        groupTemp
+        groupTemp,
+        QStringLiteral("setSteamTemperatureImmediate")
     );
 
     qDebug() << "Steam temperature set to:" << temp;
@@ -1316,13 +1318,14 @@ void MainController::sendSteamTemperature(double temp) {
         m_settings->steamTimeout(),
         m_settings->waterTemperature(),
         m_settings->effectiveHotWaterVolume(),
-        groupTemp
+        groupTemp,
+        QStringLiteral("sendSteamTemperature")
     );
 
     logToFile("Command queued successfully");
 }
 
-void MainController::startSteamHeating() {
+void MainController::startSteamHeating(const QString& reason) {
     if (!m_device || !m_device->isConnected() || !m_settings) return;
 
     // Clear steamDisabled flag - we're explicitly starting steam heating
@@ -1338,13 +1341,15 @@ void MainController::startSteamHeating() {
         m_settings->steamTimeout(),
         m_settings->waterTemperature(),
         m_settings->effectiveHotWaterVolume(),
-        groupTemp
+        groupTemp,
+        reason.isEmpty() ? QStringLiteral("startSteamHeating") : reason
     );
 
     // Also send steam flow via MMR
     m_device->writeMMR(0x803828, m_settings->steamFlow());
 
-    qDebug() << "Started steam heating to" << steamTemp << "°C";
+    qDebug() << "Started steam heating to" << steamTemp << "°C"
+             << "from" << (reason.isEmpty() ? QStringLiteral("<unspecified>") : reason);
 }
 
 void MainController::turnOffSteamHeater() {
@@ -1361,7 +1366,8 @@ void MainController::turnOffSteamHeater() {
         m_settings->steamTimeout(),
         m_settings->waterTemperature(),
         m_settings->effectiveHotWaterVolume(),
-        groupTemp
+        groupTemp,
+        QStringLiteral("turnOffSteamHeater")
     );
 
     qDebug() << "Turned off steam heater (steamDisabled=true)";
@@ -1401,7 +1407,8 @@ void MainController::setSteamTimeoutImmediate(int timeout) {
         timeout,
         m_settings->waterTemperature(),
         m_settings->effectiveHotWaterVolume(),
-        groupTemp
+        groupTemp,
+        QStringLiteral("setSteamTimeoutImmediate")
     );
 
     qDebug() << "Steam timeout set to:" << timeout;
@@ -1420,7 +1427,8 @@ void MainController::softStopSteam() {
         1,  // 1 second - any elapsed time > 1 will trigger stop
         m_settings->waterTemperature(),
         m_settings->effectiveHotWaterVolume(),
-        groupTemp
+        groupTemp,
+        QStringLiteral("softStopSteam")
     );
 
     qDebug() << "Soft stop steam: sent 1-second timeout to trigger natural stop";

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -143,8 +143,11 @@ public slots:
     // Send steam temperature to machine without saving to settings (for enable/disable toggle)
     Q_INVOKABLE void sendSteamTemperature(double temp);
 
-    // Start heating steam heater (ignores keepSteamHeaterOn - for when user wants to steam)
-    Q_INVOKABLE void startSteamHeating();
+    // Start heating steam heater (ignores keepSteamHeaterOn - for when user wants to steam).
+    // `reason` is a caller-identifying tag that flows into the [ShotSettings] BLE log
+    // so redundant calls (convergent QML signals, state/phase/isSteaming transitions)
+    // can be attributed. Pass a short kebab-case string like "steampage-activated".
+    Q_INVOKABLE void startSteamHeating(const QString& reason = QString());
 
     // Turn off steam heater (sends 0 C)
     Q_INVOKABLE void turnOffSteamHeater();
@@ -211,7 +214,8 @@ private:
     void computeAutoFlowCalibration();
     void updateGlobalFromPerProfileMedian();
     double getGroupTemperature() const;
-    void sendMachineSettings();
+    // `reason` is a caller tag that flows into the [ShotSettings] BLE log.
+    void sendMachineSettings(const QString& reason = QString());
 
     ProfileManager* m_profileManager = nullptr;
 

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -1478,7 +1478,8 @@ void ProfileManager::uploadCurrentProfile() {
                 m_settings->steamTimeout(),
                 m_settings->waterTemperature(),
                 m_settings->effectiveHotWaterVolume(),
-                groupTemp
+                groupTemp,
+                QStringLiteral("uploadCurrentProfile")
             );
             qDebug() << "Set group temp to" << groupTemp << "C for profile" << m_currentProfile.title();
         }

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -1473,21 +1473,11 @@ void ProfileManager::uploadCurrentProfile() {
         // This controls what temperature the machine heats to in Ready state
         if (m_settings) {
             double steamTemp = (m_settings->steamDisabled() || !m_settings->keepSteamHeaterOn()) ? 0.0 : m_settings->steamTemperature();
-            // Hot water volume must match MainController::sendMachineSettings:
-            // in weight mode the app stops hot water via the scale, so we
-            // send 0 to disable the DE1's flowmeter auto-stop. If the two
-            // call sites disagree, two back-to-back writes with different
-            // volumes race at the BLE layer and falsely trip the
-            // ShotSettings drift detector.
-            int hotWaterVolume = 0;
-            if (m_settings->waterVolumeMode() == "volume") {
-                hotWaterVolume = qMin(m_settings->waterVolume(), 255);
-            }
             m_device->setShotSettings(
                 steamTemp,
                 m_settings->steamTimeout(),
                 m_settings->waterTemperature(),
-                hotWaterVolume,
+                m_settings->effectiveHotWaterVolume(),
                 groupTemp
             );
             qDebug() << "Set group temp to" << groupTemp << "C for profile" << m_currentProfile.title();

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -1473,11 +1473,21 @@ void ProfileManager::uploadCurrentProfile() {
         // This controls what temperature the machine heats to in Ready state
         if (m_settings) {
             double steamTemp = (m_settings->steamDisabled() || !m_settings->keepSteamHeaterOn()) ? 0.0 : m_settings->steamTemperature();
+            // Hot water volume must match MainController::sendMachineSettings:
+            // in weight mode the app stops hot water via the scale, so we
+            // send 0 to disable the DE1's flowmeter auto-stop. If the two
+            // call sites disagree, two back-to-back writes with different
+            // volumes race at the BLE layer and falsely trip the
+            // ShotSettings drift detector.
+            int hotWaterVolume = 0;
+            if (m_settings->waterVolumeMode() == "volume") {
+                hotWaterVolume = qMin(m_settings->waterVolume(), 255);
+            }
             m_device->setShotSettings(
                 steamTemp,
                 m_settings->steamTimeout(),
                 m_settings->waterTemperature(),
-                m_settings->waterVolume(),
+                hotWaterVolume,
                 groupTemp
             );
             qDebug() << "Set group temp to" << groupTemp << "C for profile" << m_currentProfile.title();

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1200,6 +1200,11 @@ void Settings::setWaterVolumeMode(const QString& mode) {
     }
 }
 
+int Settings::effectiveHotWaterVolume() const {
+    if (waterVolumeMode() != "volume") return 0;
+    return qBound(0, waterVolume(), 255);  // BLE uint8 range
+}
+
 // Hot water SAW learning
 double Settings::hotWaterSawOffset() const {
     return m_settings.value("water/sawOffset", 2.0).toDouble();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -418,6 +418,14 @@ public:
     QString waterVolumeMode() const;  // "weight" or "volume"
     void setWaterVolumeMode(const QString& mode);
 
+    // Hot water volume byte to send in DE1 ShotSettings. In "weight" mode the
+    // app stops hot water via the scale and sends 0 so the DE1 flowmeter
+    // auto-stop is disabled; in "volume" mode it returns the clamped
+    // waterVolume(). All setShotSettings() call sites must use this to keep
+    // payloads consistent — otherwise the ShotSettings drift detector trips
+    // on BLE echo reordering.
+    int effectiveHotWaterVolume() const;
+
     double hotWaterSawOffset() const;
     void setHotWaterSawOffset(double offset);
     int hotWaterSawSampleCount() const;

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -240,6 +240,49 @@ private slots:
         QCOMPARE(targetEspressoVol, static_cast<uint8_t>(200));
     }
 
+    void uploadCurrentProfileRespectsWaterVolumeMode() {
+        // Regression: profile upload must match MainController::sendMachineSettings
+        // on hot water volume, otherwise two back-to-back writes with different
+        // `vol` values race at the BLE layer and falsely trip the drift detector.
+        // Byte 4 of the ShotSettings payload is TargetHotWaterVol (U8P0 ml).
+
+        // --- Weight mode: vol byte must be 0 ---
+        {
+            McpTestFixture f;
+            loadDFlowProfile(f);
+            f.settings.setWaterVolumeMode("weight");
+            f.settings.setWaterVolume(65);
+            f.transport.clearWrites();
+            f.device.m_lastShotSettingsPayload.clear();
+
+            f.profileManager.uploadCurrentProfile();
+
+            auto settingsWrites = f.writesTo(SHOT_SETTINGS);
+            QVERIFY(!settingsWrites.isEmpty());
+            QByteArray data = settingsWrites.last();
+            QVERIFY(data.size() >= 5);
+            QCOMPARE(static_cast<uint8_t>(data[4]), static_cast<uint8_t>(0));
+        }
+
+        // --- Volume mode: vol byte must echo settings.waterVolume() ---
+        {
+            McpTestFixture f;
+            loadDFlowProfile(f);
+            f.settings.setWaterVolumeMode("volume");
+            f.settings.setWaterVolume(65);
+            f.transport.clearWrites();
+            f.device.m_lastShotSettingsPayload.clear();
+
+            f.profileManager.uploadCurrentProfile();
+
+            auto settingsWrites = f.writesTo(SHOT_SETTINGS);
+            QVERIFY(!settingsWrites.isEmpty());
+            QByteArray data = settingsWrites.last();
+            QVERIFY(data.size() >= 5);
+            QCOMPARE(static_cast<uint8_t>(data[4]), static_cast<uint8_t>(65));
+        }
+    }
+
     void uploadBlockedDuringActivePhase() {
         McpTestFixture f;
         loadDFlowProfile(f);

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -122,6 +122,40 @@ private slots:
         m_settings.setScaleAddress("");
         QCOMPARE(m_settings.scaleAddress(), QString(""));
     }
+
+    // ==========================================
+    // Derived: effectiveHotWaterVolume
+    // ==========================================
+
+    void effectiveHotWaterVolumeRespectsMode() {
+        QString origMode = m_settings.waterVolumeMode();
+        int origVol = m_settings.waterVolume();
+
+        m_settings.setWaterVolume(65);
+
+        m_settings.setWaterVolumeMode("weight");
+        QCOMPARE(m_settings.effectiveHotWaterVolume(), 0);
+
+        m_settings.setWaterVolumeMode("volume");
+        QCOMPARE(m_settings.effectiveHotWaterVolume(), 65);
+
+        // Anything other than "volume" is treated as weight mode.
+        m_settings.setWaterVolumeMode("something-else");
+        QCOMPARE(m_settings.effectiveHotWaterVolume(), 0);
+
+        // Lower bound: negative values from corrupted storage must clamp to 0,
+        // not wrap to 255 after uint8 cast.
+        m_settings.setWaterVolumeMode("volume");
+        m_settings.setWaterVolume(-1);
+        QCOMPARE(m_settings.effectiveHotWaterVolume(), 0);
+
+        // Upper bound: values above 255 clamp to the BLE uint8 max.
+        m_settings.setWaterVolume(500);
+        QCOMPARE(m_settings.effectiveHotWaterVolume(), 255);
+
+        m_settings.setWaterVolumeMode(origMode);
+        m_settings.setWaterVolume(origVol);
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_Settings)


### PR DESCRIPTION
## Summary

Started as a fix for a false-positive ShotSettings drift warning on startup; grew into a small audit of every code path that writes the DE1's ShotSettings characteristic.

### The original bug
\`ProfileManager::uploadCurrentProfile()\` unconditionally passed \`Settings::waterVolume()\` as \`TargetHotWaterVol\`. \`MainController::sendMachineSettings()\` gates this on \`waterVolumeMode\` — sending 0 in weight mode so the app stops hot water via the scale instead of the DE1's flowmeter. \`applyAllSettings\` called both back-to-back; in weight mode the two produced different payloads (65 → 0), the DE1's echo notifications arrived out of order, and the drift detector from #773 falsely flagged \"DE1-dropped-write\" and resent.

Live log evidence:
\`\`\`
[5.347] [ShotSettings] write: ... vol=65ml ...    # ProfileManager (unconditional)
[5.356] [ShotSettings] write: ... vol=0ml ...     # MainController (weight mode)
[5.429] reported: ... vol=0ml ...                 # echo of 2nd arrives first
[6.254] reported: ... vol=65ml ...                # echo of 1st arrives late
[6.263] WARN DE1-dropped-write
[6.348] resolved after 1 resend(s)
\`\`\`

### What the PR does

**1. Single source of truth for the volume-mode gate.** Adds \`Settings::effectiveHotWaterVolume()\` that returns 0 in weight mode and \`qBound(0, waterVolume(), 255)\` in volume mode. All eight \`setShotSettings\` call sites now use it — one in \`ProfileManager\`, seven in \`MainController\` (\`sendMachineSettings\`, plus the six steam paths \`setSteamTemperatureImmediate\`, \`sendSteamTemperature\`, \`startSteamHeating\`, \`turnOffSteamHeater\`, \`setSteamTimeoutImmediate\`, \`softStopSteam\`). Those six were passing \`waterVolume()\` raw before, which would have kept the same race latent on every user steam-action in weight mode.

**2. Lower-bound clamp.** The previous \`qMin(..., 255)\` let a negative \`waterVolume()\` (corrupted \`QSettings\`) slip through and wrap to 255 via the downstream \`uint8_t\` cast. \`qBound(0, v, 255)\` in the helper fixes it at the source. \`BinaryCodec::encodeU8P0\` also clamps, so the DE1 payload was already safe — this is defense at the right layer.

**3. Attribute ShotSettings BLE writes to their originator.** The existing session log showed four \`startSteamHeating\` calls per steam session (all elided by #773's dedup) without identifying which QML signal fired each one. Added an optional \`reason\` tag that flows from every \`startSteamHeating\` / \`sendMachineSettings\` / \`uploadCurrentProfile\` callsite into \`DE1Device::setShotSettings\`, where it's appended to both \`[ShotSettings] write:\` and \`write skipped: payload unchanged\` log lines. Every QML and C++ entry point now passes a tag (\`de1-state-steam\`, \`phase-steaming\`, \`steampage-activated\`, \`is-steaming-changed\`, \`live-pitcher-click\`, \`decrease-5s\`, \`increase-5s\`, \`pitcher-a11y/return/space/click\`, \`custom-widget-toggle\`, \`mqtt-steam-on\`, \`applySteamSettings\`, \`applyHotWaterSettings\`, \`applyFlushSettings\`, \`applyAllSettings\`, etc.). Future redundancy audits become self-service.

### Tests

- \`tst_profilemanager::uploadCurrentProfileRespectsWaterVolumeMode\` — byte-4 assertion in both modes.
- \`tst_settings::effectiveHotWaterVolumeRespectsMode\` — helper round-trip including negative lower-bound clamp and >255 upper-bound clamp.

### Test plan
- [x] \`ctest -R tst_profilemanager\` passes locally
- [x] \`ctest -R tst_settings\` passes locally
- [x] Two on-device steam sessions on the prior build confirmed steam control healthy (pre-fix; the race is latent outside the startup path)
- [ ] Post-merge: verify next session log shows \`[reason]\` suffix on every \`[ShotSettings]\` line and no \`DE1-dropped-write\` warning at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)