### PR TITLE
feat(ValueInput): add valueCommitted signal, defer BLE writes to end of interaction

### DIFF
--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -80,7 +80,11 @@ Item {
     Accessible.description: TranslationManager.translate("valueinput.accessibility.description", "Use plus and minus buttons to adjust. Tap center for full-screen editor. Double-tap value to type a number.")
     Accessible.focusable: true
 
-    // Keyboard handling
+    // Keyboard handling. Press fires adjustValue per key-press (including
+    // auto-repeat while held); release fires commitValue once when the
+    // physical key lifts — same contract as the +/- button MouseAreas, so
+    // BLE-bound consumers that migrated to onValueCommitted don't miss
+    // hardware-keyboard adjustments.
     Keys.onUpPressed: adjustValue(1)
     Keys.onDownPressed: adjustValue(-1)
     Keys.onLeftPressed: adjustValue(-1)
@@ -98,6 +102,17 @@ Item {
         } else if (event.key === Qt.Key_PageDown) {
             adjustValue(-10)
             event.accepted = true
+        }
+    }
+
+    Keys.onReleased: function(event) {
+        if (event.isAutoRepeat) return
+        switch (event.key) {
+            case Qt.Key_Up: case Qt.Key_Down: case Qt.Key_Left: case Qt.Key_Right:
+            case Qt.Key_PageUp: case Qt.Key_PageDown:
+                commitValue()
+                event.accepted = true
+                break
         }
     }
 
@@ -532,13 +547,15 @@ Item {
 
             Accessible.name: TranslationManager.translate("valueinput.editor.title", "Value editor")
 
-            // Tap outside to close (exit edit mode first)
+            // Tap outside to close (exit edit mode first). When the TextInput
+            // is in edit mode, commit the typed value instead of silently
+            // discarding it — tapping elsewhere is a common tablet "done"
+            // gesture. Escape in the TextInput remains an explicit discard.
             MouseArea {
                 anchors.fill: parent
                 onClicked: {
                     if (popupContent.editMode) {
-                        popupContent.editMode = false
-                        popupValueContainer.forceActiveFocus()
+                        popupTextInput.commitText()
                     } else {
                         scrubberPopup.close()
                     }
@@ -616,7 +633,9 @@ Item {
                         Accessible.description: TranslationManager.translate("valueinput.popup.hint", "Double-tap to type a number.")
                         Accessible.focusable: true
 
-                        // Keyboard navigation — honors the selected gear
+                        // Keyboard navigation — honors the selected gear.
+                        // Release fires commitValue once when the key lifts,
+                        // mirroring the +/- button contract.
                         Keys.onEscapePressed: scrubberPopup.close()
                         Keys.onUpPressed: popupAdjust(1)
                         Keys.onDownPressed: popupAdjust(-1)
@@ -624,6 +643,15 @@ Item {
                         Keys.onRightPressed: popupAdjust(1)
                         Keys.onReturnPressed: scrubberPopup.close()
                         Keys.onEnterPressed: scrubberPopup.close()
+                        Keys.onReleased: function(event) {
+                            if (event.isAutoRepeat) return
+                            switch (event.key) {
+                                case Qt.Key_Up: case Qt.Key_Down: case Qt.Key_Left: case Qt.Key_Right:
+                                    root.commitValue()
+                                    event.accepted = true
+                                    break
+                            }
+                        }
 
                         Text {
                             anchors.centerIn: parent

--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -45,11 +45,28 @@ Item {
     signal valueModified(real newValue)
     signal valueCommitted(real newValue)
 
-    // Helper: emit valueCommitted with the current value. Used by all
-    // release/click handlers so a single tap, a hold release, a drag release,
-    // and a keyboard arrow all produce one commit.
+    // Internal dirty flag: set when valueModified is emitted, cleared by
+    // commitValue(). Ensures valueCommitted only fires when the interaction
+    // actually changed the value (e.g. tapping + when already at max emits
+    // neither signal, rather than firing an expensive BLE-write commit for a
+    // no-op adjustment).
+    property bool _dirtySinceCommit: false
+
+    // Internal helper used in place of raw root.valueModified() emission so
+    // the dirty flag is kept consistent.
+    function _emitValueModified(newVal) {
+        root.valueModified(newVal)
+        _dirtySinceCommit = true
+    }
+
+    // Emit valueCommitted if the interaction changed the value. Called by
+    // every release/click/drag-end/text-entry handler. No-op when nothing
+    // changed (e.g. a tap on a pinned-at-max button).
     function commitValue() {
-        root.valueCommitted(root.value)
+        if (_dirtySinceCommit) {
+            _dirtySinceCommit = false
+            root.valueCommitted(root.value)
+        }
     }
 
     // Enable keyboard focus
@@ -639,12 +656,13 @@ Item {
                                     var roundTo = root.hasFineGear ? root.fineStepSize : root.stepSize
                                     parsed = Math.round(parsed / roundTo) * roundTo
                                     if (parsed !== root.value) {
-                                        root.valueModified(parsed)
+                                        root._emitValueModified(parsed)
                                     }
-                                    // Typing a number is a deliberate, final adjustment —
-                                    // always commit on Enter so BLE-bound consumers fire
-                                    // exactly once per typed edit.
-                                    root.valueCommitted(parsed)
+                                    // Typing a number is a deliberate, final adjustment.
+                                    // commitValue() only fires valueCommitted if the
+                                    // typed value differed from the prior value — typing
+                                    // the same number back is a no-op.
+                                    root.commitValue()
                                     if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
                                         AccessibilityManager.announce(root.displayText || (parsed.toFixed(root.decimals) + (root.suffix.trim() ? " " + root.suffix.trim() : "")))
                                     }
@@ -1015,7 +1033,7 @@ Item {
         var roundTo = root.hasFineGear ? root.fineStepSize : root.stepSize
         newVal = Math.round(newVal / roundTo) * roundTo
         if (newVal !== root.value) {
-            root.valueModified(newVal)
+            _emitValueModified(newVal)
             if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
                 AccessibilityManager.announce(root.displayText || (newVal.toFixed(root.decimals) + (root.suffix.trim() ? " " + root.suffix.trim() : "")))
             }

--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -31,8 +31,26 @@ Item {
         return useBaseScale ? Theme.scaledBase(value) : Theme.scaled(value)
     }
 
-    // Signals - emits the new value for parent to apply
+    // Signals
+    //
+    // valueModified fires on every adjustment step — every +/- click, every
+    // hold-timer tick, every drag pixel-step. Use for cheap reactions
+    // (updating local state, saving to Settings).
+    //
+    // valueCommitted fires at the END of a user interaction — release of a
+    // hold, end of a drag, single click, text-entry commit. Use for expensive
+    // actions (BLE writes, file saves) that shouldn't fire on every tick.
+    // A single tap emits both signals; a held adjustment emits valueModified
+    // per tick and valueCommitted once on release.
     signal valueModified(real newValue)
+    signal valueCommitted(real newValue)
+
+    // Helper: emit valueCommitted with the current value. Used by all
+    // release/click handlers so a single tap, a hold release, a drag release,
+    // and a keyboard arrow all produce one commit.
+    function commitValue() {
+        root.valueCommitted(root.value)
+    }
 
     // Enable keyboard focus
     activeFocusOnTab: true
@@ -137,9 +155,18 @@ Item {
                 MouseArea {
                     id: minusArea
                     anchors.fill: parent
-                    onClicked: adjustValue(-1)
+                    // Tap: adjust once and commit. Hold: pressAndHold starts the
+                    // repeat timer; on release we stop the timer and commit.
+                    // onCanceled means user dragged off the button — stop without
+                    // committing since the hold repeats are what they wanted to cancel.
+                    onClicked: { adjustValue(-1); root.commitValue() }
                     onPressAndHold: decrementTimer.start()
-                    onReleased: decrementTimer.stop()
+                    onReleased: {
+                        if (decrementTimer.running) {
+                            decrementTimer.stop()
+                            root.commitValue()
+                        }
+                    }
                     onCanceled: decrementTimer.stop()
                 }
 
@@ -428,9 +455,14 @@ Item {
                 MouseArea {
                     id: plusArea
                     anchors.fill: parent
-                    onClicked: adjustValue(1)
+                    onClicked: { adjustValue(1); root.commitValue() }
                     onPressAndHold: incrementTimer.start()
-                    onReleased: incrementTimer.stop()
+                    onReleased: {
+                        if (incrementTimer.running) {
+                            incrementTimer.stop()
+                            root.commitValue()
+                        }
+                    }
                     onCanceled: incrementTimer.stop()
                 }
 
@@ -536,9 +568,14 @@ Item {
                         MouseArea {
                             id: popupMinusArea
                             anchors.fill: parent
-                            onClicked: popupAdjust(-1)
+                            onClicked: { popupAdjust(-1); root.commitValue() }
                             onPressAndHold: popupDecrementTimer.start()
-                            onReleased: popupDecrementTimer.stop()
+                            onReleased: {
+                                if (popupDecrementTimer.running) {
+                                    popupDecrementTimer.stop()
+                                    root.commitValue()
+                                }
+                            }
                             onCanceled: popupDecrementTimer.stop()
                         }
 
@@ -593,7 +630,9 @@ Item {
                             inputMethodHints: Qt.ImhFormattedNumbersOnly
                             selectByMouse: true
 
-                            function commitValue() {
+                            // Rename from commitValue to commitText to avoid clashing
+                            // with root.commitValue() used by release handlers above.
+                            function commitText() {
                                 var parsed = parseFloat(text)
                                 if (!isNaN(parsed)) {
                                     parsed = Math.max(root.from, Math.min(root.to, parsed))
@@ -602,6 +641,10 @@ Item {
                                     if (parsed !== root.value) {
                                         root.valueModified(parsed)
                                     }
+                                    // Typing a number is a deliberate, final adjustment —
+                                    // always commit on Enter so BLE-bound consumers fire
+                                    // exactly once per typed edit.
+                                    root.valueCommitted(parsed)
                                     if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
                                         AccessibilityManager.announce(root.displayText || (parsed.toFixed(root.decimals) + (root.suffix.trim() ? " " + root.suffix.trim() : "")))
                                     }
@@ -610,8 +653,8 @@ Item {
                                 popupValueContainer.forceActiveFocus()
                             }
 
-                            Keys.onReturnPressed: commitValue()
-                            Keys.onEnterPressed: commitValue()
+                            Keys.onReturnPressed: commitText()
+                            Keys.onEnterPressed: commitText()
                             Keys.onEscapePressed: {
                                 popupContent.editMode = false
                                 popupValueContainer.forceActiveFocus()
@@ -693,6 +736,8 @@ Item {
                                 isDragging = false
                                 // Keep currentGear — it persists so +/- buttons
                                 // and subsequent drags use the selected gear.
+                                // Drag is always a real adjustment, so always commit.
+                                root.commitValue()
                             }
 
                             onCanceled: {
@@ -820,9 +865,14 @@ Item {
                         MouseArea {
                             id: popupPlusArea
                             anchors.fill: parent
-                            onClicked: popupAdjust(1)
+                            onClicked: { popupAdjust(1); root.commitValue() }
                             onPressAndHold: popupIncrementTimer.start()
-                            onReleased: popupIncrementTimer.stop()
+                            onReleased: {
+                                if (popupIncrementTimer.running) {
+                                    popupIncrementTimer.stop()
+                                    root.commitValue()
+                                }
+                            }
                             onCanceled: popupIncrementTimer.stop()
                         }
 

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -529,12 +529,15 @@ Page {
                             KeyNavigation.tab: flowInput
                             KeyNavigation.backtab: addPresetButton
 
+                            // onValueModified fires on every +/- tick during hold (up to
+                            // 12 Hz). Do cheap bookkeeping here, and defer the BLE write
+                            // to onValueCommitted which fires once on release.
                             onValueModified: function(newValue) {
                                 secondsInput.value = newValue
                                 Settings.flushSeconds = newValue
                                 saveCurrentPreset(flowInput.value, newValue)
-                                MainController.applyFlushSettings()
                             }
+                            onValueCommitted: MainController.applyFlushSettings()
                         }
                     }
 
@@ -569,12 +572,14 @@ Page {
                                 : addPresetButton
                             KeyNavigation.backtab: secondsInput
 
+                            // onValueModified: cheap bookkeeping per tick.
+                            // onValueCommitted: BLE write once at interaction end.
                             onValueModified: function(newValue) {
                                 flowInput.value = newValue
                                 Settings.flushFlow = newValue
                                 saveCurrentPreset(newValue, secondsInput.value)
-                                MainController.applyFlushSettings()
                             }
+                            onValueCommitted: MainController.applyFlushSettings()
                         }
                     }
 

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -231,6 +231,14 @@ Page {
                 KeyNavigation.tab: hotWaterStopButton.visible ? hotWaterStopButton : (liveVesselRepeater.count > 0 ? liveVesselRepeater.itemAt(0) : liveFlowRateInput)
                 KeyNavigation.backtab: liveVesselRepeater.count > 0 ? liveVesselRepeater.itemAt(liveVesselRepeater.count - 1) : liveFlowRateInput
 
+                // Cheap Settings write per tick so the slider's `value:`
+                // binding re-evaluates and the displayed number tracks the
+                // user's adjustment live during a hold. ValueInput doesn't
+                // self-mutate root.value — without a consumer writing the
+                // bound source, the displayed value stays pinned.
+                onValueModified: function(newValue) {
+                    Settings.hotWaterFlowRate = Math.round(newValue)
+                }
                 // BLE write deferred to commit so holding +/- doesn't
                 // spam the flow-rate MMR register every 80 ms.
                 onValueCommitted: function(newValue) {

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -231,7 +231,9 @@ Page {
                 KeyNavigation.tab: hotWaterStopButton.visible ? hotWaterStopButton : (liveVesselRepeater.count > 0 ? liveVesselRepeater.itemAt(0) : liveFlowRateInput)
                 KeyNavigation.backtab: liveVesselRepeater.count > 0 ? liveVesselRepeater.itemAt(liveVesselRepeater.count - 1) : liveFlowRateInput
 
-                onValueModified: function(newValue) {
+                // BLE write deferred to commit so holding +/- doesn't
+                // spam the flow-rate MMR register every 80 ms.
+                onValueCommitted: function(newValue) {
                     MainController.setHotWaterFlowRateImmediate(Math.round(newValue))
                 }
             }
@@ -674,8 +676,8 @@ Page {
                                 volumeInput.value = newValue
                                 Settings.waterVolume = newValue
                                 saveCurrentVessel(newValue, flowRateInput.value)
-                                MainController.applyHotWaterSettings()
                             }
+                            onValueCommitted: MainController.applyHotWaterSettings()
                         }
                     }
 
@@ -711,8 +713,8 @@ Page {
                             onValueModified: function(newValue) {
                                 temperatureInput.value = newValue
                                 Settings.waterTemperature = newValue
-                                MainController.applyHotWaterSettings()
                             }
+                            onValueCommitted: MainController.applyHotWaterSettings()
                         }
                     }
 

--- a/qml/pages/ProfileEditorPage.qml
+++ b/qml/pages/ProfileEditorPage.qml
@@ -526,7 +526,7 @@ Page {
                     ValueInput {
                         Layout.fillWidth: true; valueColor: Theme.weightColor
                         accessibleName: TranslationManager.translate("profileEditor.recommendedDose", "Recommended dose"); from: 5; to: 100; stepSize: 0.1; suffix: " g"
-                        value: { stepVersion; return profile ? (profile.recommended_dose || 18) : 18 }
+                        value: { stepVersion; return profile ? (profile.recommended_dose ?? 18) : 18 }
                         onValueModified: function(newValue) { if (profile) { profile.recommended_dose = Math.round(newValue * 10) / 10 } }
                         onValueCommitted: uploadProfile()
                     }
@@ -592,7 +592,7 @@ Page {
                     Layout.preferredWidth: Theme.scaled(160); valueColor: Theme.temperatureColor
                     accessibleName: TranslationManager.translate("profileEditor.preheatTankAccessible", "Preheat water tank temperature")
                     from: 0; to: 45; stepSize: 1; suffix: " °C"
-                    value: { stepVersion; return profile ? (profile.tank_desired_water_temperature || 0) : 0 }
+                    value: { stepVersion; return profile ? (profile.tank_desired_water_temperature ?? 0) : 0 }
                     onValueModified: function(newValue) {
                         if (profile) {
                             profile.tank_desired_water_temperature = Math.round(newValue)
@@ -611,7 +611,7 @@ Page {
                     Layout.preferredWidth: Theme.scaled(160)
                     accessibleName: TranslationManager.translate("profileEditor.preinfusionEndsAccessible", "Preinfusion ends after step")
                     from: 0; to: profile ? profile.steps.length : 0; stepSize: 1
-                    value: { stepVersion; return profile ? (profile.preinfuse_frame_count || 0) : 0 }
+                    value: { stepVersion; return profile ? (profile.preinfuse_frame_count ?? 0) : 0 }
                     onValueModified: function(newValue) {
                         if (profile) {
                             profile.preinfuse_frame_count = Math.round(newValue)

--- a/qml/pages/ProfileEditorPage.qml
+++ b/qml/pages/ProfileEditorPage.qml
@@ -486,6 +486,9 @@ Page {
                     Layout.fillWidth: true; valueColor: Theme.temperatureColor
                     accessibleName: TranslationManager.translate("profileEditor.globalTemperature", "Global temperature"); from: 70; to: 100; stepSize: 0.1; suffix: " °C"
                     value: { stepVersion; return profile && profile.steps.length > 0 ? profile.steps[0].temperature : 93 }
+                    // onValueModified mutates the profile per adjustment tick so the UI
+                    // reflects the change live; onValueCommitted fires the BLE upload
+                    // once on release instead of per tick.
                     onValueModified: function(newValue) {
                         if (profile && profile.steps.length > 0) {
                             var rounded = Math.round(newValue * 10) / 10
@@ -494,9 +497,9 @@ Page {
                                 profile.steps[i].temperature += delta
                             }
                             profile.espresso_temperature = rounded
-                            uploadProfile()
                         }
                     }
+                    onValueCommitted: uploadProfile()
                 }
             }
 
@@ -524,7 +527,8 @@ Page {
                         Layout.fillWidth: true; valueColor: Theme.weightColor
                         accessibleName: TranslationManager.translate("profileEditor.recommendedDose", "Recommended dose"); from: 5; to: 100; stepSize: 0.1; suffix: " g"
                         value: { stepVersion; return profile ? (profile.recommended_dose || 18) : 18 }
-                        onValueModified: function(newValue) { if (profile) { profile.recommended_dose = Math.round(newValue * 10) / 10; uploadProfile() } }
+                        onValueModified: function(newValue) { if (profile) { profile.recommended_dose = Math.round(newValue * 10) / 10 } }
+                        onValueCommitted: uploadProfile()
                     }
                 }
             }
@@ -592,9 +596,9 @@ Page {
                     onValueModified: function(newValue) {
                         if (profile) {
                             profile.tank_desired_water_temperature = Math.round(newValue)
-                            uploadProfile()
                         }
                     }
+                    onValueCommitted: uploadProfile()
                 }
             }
 
@@ -611,9 +615,9 @@ Page {
                     onValueModified: function(newValue) {
                         if (profile) {
                             profile.preinfuse_frame_count = Math.round(newValue)
-                            uploadProfile()
                         }
                     }
+                    onValueCommitted: uploadProfile()
                 }
             }
 
@@ -637,9 +641,9 @@ Page {
                         if (profile) {
                             profile.target_volume = Math.round(newValue)
                             stepVersion++
-                            uploadProfile()
                         }
                     }
+                    onValueCommitted: uploadProfile()
                 }
             }
 
@@ -663,9 +667,9 @@ Page {
                         if (profile) {
                             profile.target_weight = Math.round(newValue * 10) / 10
                             stepVersion++
-                            uploadProfile()
                         }
                     }
+                    onValueCommitted: uploadProfile()
                 }
             }
 
@@ -684,9 +688,9 @@ Page {
                             var newRange = Math.round(newValue * 100) / 100
                             profile.maximum_flow_range_advanced = newRange
                             applyRangeToAllSteps()
-                            uploadProfile()
                         }
                     }
+                    onValueCommitted: uploadProfile()
                 }
             }
 
@@ -705,9 +709,9 @@ Page {
                             var newRange = Math.round(newValue * 100) / 100
                             profile.maximum_pressure_range_advanced = newRange
                             applyRangeToAllSteps()
-                            uploadProfile()
                         }
                     }
+                    onValueCommitted: uploadProfile()
                 }
             }
 
@@ -1217,7 +1221,7 @@ Page {
                 }
 
                 // Temperature
-                ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("profileEditor.stepTemperature", "Step temperature"); from: 70; to: 100; stepSize: 0.1; suffix: " °C"; value: stepVersion >= 0 && step ? step.temperature : 93; onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].temperature = Math.round(newValue * 10) / 10; uploadProfile() } } }
+                ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("profileEditor.stepTemperature", "Step temperature"); from: 70; to: 100; stepSize: 0.1; suffix: " °C"; value: stepVersion >= 0 && step ? step.temperature : 93; onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].temperature = Math.round(newValue * 10) / 10 } }; onValueCommitted: uploadProfile() }
 
                 // Sensor toggle
                 Text { text: TranslationManager.translate("profileEditor.sensor", "Sensor"); font: Theme.captionFont; color: Theme.textSecondaryColor }
@@ -1298,9 +1302,9 @@ Page {
                             } else {
                                 profile.steps[selectedStepIndex].pressure = val
                             }
-                            uploadProfile()
                         }
                     }
+                    onValueCommitted: uploadProfile()
                 }
 
                 // Transition toggle
@@ -1342,15 +1346,15 @@ Page {
 
                 // Max duration
                 Text { text: TranslationManager.translate("profileEditor.maxDuration", "Max duration"); font: Theme.captionFont; color: Theme.textSecondaryColor }
-                ValueInput { Layout.fillWidth: true; accessibleName: TranslationManager.translate("profileEditor.maxDuration", "Max duration"); from: 0; to: 120; stepSize: 1; suffix: " s"; displayText: stepVersion >= 0 && step && step.seconds === 0 ? TranslationManager.translate("profileEditor.off", "off") : ""; value: stepVersion >= 0 && step ? step.seconds : 30; onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].seconds = Math.round(newValue); uploadProfile() } } }
+                ValueInput { Layout.fillWidth: true; accessibleName: TranslationManager.translate("profileEditor.maxDuration", "Max duration"); from: 0; to: 120; stepSize: 1; suffix: " s"; displayText: stepVersion >= 0 && step && step.seconds === 0 ? TranslationManager.translate("profileEditor.off", "off") : ""; value: stepVersion >= 0 && step ? step.seconds : 30; onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].seconds = Math.round(newValue) } }; onValueCommitted: uploadProfile() }
 
                 // Max volume
                 Text { text: TranslationManager.translate("profileEditor.maxVolume", "Volume"); font: Theme.captionFont; color: Theme.flowColor }
-                ValueInput { Layout.fillWidth: true; valueColor: Theme.flowColor; accessibleName: TranslationManager.translate("profileEditor.maxVolume", "Max volume"); from: 0; to: 500; stepSize: 1; suffix: " mL"; displayText: stepVersion >= 0 && step && (step.volume || 0) === 0 ? TranslationManager.translate("profileEditor.off", "off") : ""; value: stepVersion >= 0 && step ? (step.volume || 0) : 0; onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].volume = Math.round(newValue); uploadProfile() } } }
+                ValueInput { Layout.fillWidth: true; valueColor: Theme.flowColor; accessibleName: TranslationManager.translate("profileEditor.maxVolume", "Max volume"); from: 0; to: 500; stepSize: 1; suffix: " mL"; displayText: stepVersion >= 0 && step && (step.volume || 0) === 0 ? TranslationManager.translate("profileEditor.off", "off") : ""; value: stepVersion >= 0 && step ? (step.volume || 0) : 0; onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].volume = Math.round(newValue) } }; onValueCommitted: uploadProfile() }
 
                 // Max weight (independent, app-side exit)
                 Text { text: TranslationManager.translate("profileEditor.maxWeight", "Weight"); font: Theme.captionFont; color: Theme.weightColor }
-                ValueInput { Layout.fillWidth: true; valueColor: Theme.weightColor; accessibleName: TranslationManager.translate("profileEditor.maxWeight", "Max weight"); from: 0; to: 500; stepSize: 0.1; suffix: " g"; displayText: stepVersion >= 0 && step && (step.exit_weight || 0) === 0 ? TranslationManager.translate("profileEditor.off", "off") : ""; value: stepVersion >= 0 && step ? (step.exit_weight || 0) : 0; onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].exit_weight = Math.round(newValue * 10) / 10; uploadProfile() } } }
+                ValueInput { Layout.fillWidth: true; valueColor: Theme.weightColor; accessibleName: TranslationManager.translate("profileEditor.maxWeight", "Max weight"); from: 0; to: 500; stepSize: 0.1; suffix: " g"; displayText: stepVersion >= 0 && step && (step.exit_weight || 0) === 0 ? TranslationManager.translate("profileEditor.off", "off") : ""; value: stepVersion >= 0 && step ? (step.exit_weight || 0) : 0; onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].exit_weight = Math.round(newValue * 10) / 10 } }; onValueCommitted: uploadProfile() }
 
                 // Flow/Pressure limit (opposite of goal in section 2)
                 Text { text: step && step.pump === "pressure" ? TranslationManager.translate("profileEditor.maxFlow", "Flow limit") : TranslationManager.translate("profileEditor.maxPressure", "Pressure limit"); font: Theme.captionFont; color: step && step.pump === "pressure" ? Theme.flowColor : Theme.pressureColor }
@@ -1362,7 +1366,8 @@ Page {
                     suffix: step && step.pump === "pressure" ? " mL/s" : " bar"
                     displayText: { var v = stepVersion; var val = step ? (step.max_flow_or_pressure || 0) : 0; return val === 0 ? TranslationManager.translate("profileEditor.off", "off") : "" }
                     value: { var v = stepVersion; return step ? (step.max_flow_or_pressure || 0) : 0 }
-                    onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].max_flow_or_pressure = Math.round(newValue * 100) / 100; uploadProfile() } }
+                    onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].max_flow_or_pressure = Math.round(newValue * 100) / 100 } }
+                    onValueCommitted: uploadProfile()
                 }
 
                 Rectangle { Layout.fillWidth: true; height: 1; color: Theme.borderColor }
@@ -1418,8 +1423,8 @@ Page {
                                 case "flow_over": profile.steps[selectedStepIndex].exit_flow_over = val; break
                                 case "flow_under": profile.steps[selectedStepIndex].exit_flow_under = val; break
                             }
-                            uploadProfile()
                         }
+                        onValueCommitted: uploadProfile()
                     }
                 }
 

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -578,10 +578,14 @@ Page {
                     accessibleName: TranslationManager.translate("steam.label.steamFlow", "Steam Flow")
                     KeyNavigation.tab: steamStopButton.visible ? steamStopButton : (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : steamingFlowSlider)
                     KeyNavigation.backtab: increaseTimeBtn
+                    // Defer BLE writes to commit: onValueModified fires per
+                    // adjustment tick; BLE should only fire on release.
                     onValueModified: function(newValue) {
                         steamingFlowSlider.value = newValue
-                        MainController.setSteamFlowImmediate(newValue)
                         saveCurrentPitcher(getCurrentPitcherDuration(), newValue)
+                    }
+                    onValueCommitted: function(newValue) {
+                        MainController.setSteamFlowImmediate(newValue)
                     }
                 }
 
@@ -1129,8 +1133,10 @@ Page {
                             KeyNavigation.backtab: durationSlider
                             onValueModified: function(newValue) {
                                 flowSlider.value = newValue
-                                MainController.setSteamFlowImmediate(newValue)
                                 saveCurrentPitcher(durationSlider.value, newValue)
+                            }
+                            onValueCommitted: function(newValue) {
+                                MainController.setSteamFlowImmediate(newValue)
                             }
                         }
                     }
@@ -1174,6 +1180,8 @@ Page {
                             KeyNavigation.backtab: flowSlider
                             onValueModified: function(newValue) {
                                 steamTempSlider.value = newValue
+                            }
+                            onValueCommitted: function(newValue) {
                                 MainController.setSteamTemperatureImmediate(newValue)
                             }
                         }


### PR DESCRIPTION
## Summary
The reason-tag logging from #780 exposed two classes of BLE over-writes driven by \`ValueInput\`:

1. **Flush page storm (observed in session log):** 30+ \`[applyFlushSettings]\` calls in 2.5 s while holding +/-. \`setShotSettings\` dedups but \`sendMachineSettings\` also writes three MMR registers that are **not deduped**, producing ~90 BLE writes in under 3 s.
2. **Profile editor (latent, worse):** 13 sliders each call \`uploadProfile()\` from \`onValueModified\`. Holding a slider for 2 s re-uploads the entire profile ~25 times — ~150 BLE writes per 2 s of adjustment.

CLAUDE.md forbids timer-based debounce (\"including debounce — should use event-based flags\"), so the fix is an event-based signal.

## Change

### ValueInput contract
Adds \`signal valueCommitted(real newValue)\` alongside the existing \`valueModified\`. Fires exactly once at the end of a user interaction (hold release, drag end, single tap, text commit). A private dirty flag ensures it only fires when the interaction actually modified the value — tapping + at max emits neither signal. The internal \`commitText()\` function was renamed to avoid shadowing the new root-level \`commitValue()\`.

| Interaction | valueModified | valueCommitted |
|-------------|---------------|----------------|
| Single tap on +/- (value changed) | 1× | 1× |
| Single tap on +/- (no change — e.g. pinned at max) | 0 | 0 |
| Hold +/- (N ticks) | N× | 1× on release |
| Drag scrubber (M pixels) | M× | 1× on release |
| Type a value + Enter | 1× | 1× |
| Type same value + Enter | 0 | 0 |
| User drags off the button (cancel) | varies | 0 |

### Migrations (all keep cheap bookkeeping in \`onValueModified\`, move BLE writes to \`onValueCommitted\`)

- **\`FlushPage.qml\`**: secondsInput, flowInput — \`applyFlushSettings()\`.
- **\`ProfileEditorPage.qml\`** (13 handlers): global temp, recommended dose, preheat tank, preinfusion ends, stop-at-volume, stop-at-weight, flow/pressure range limits, step temp, pressure/flow goal, max duration/volume/weight/flow-or-pressure, exit value — all now call \`uploadProfile()\` only on commit.
- **\`SteamPage.qml\`** (3 handlers): steamingFlowSlider, flowSlider — \`setSteamFlowImmediate\`; steamTempSlider — \`setSteamTemperatureImmediate\`.
- **\`HotWaterPage.qml\`** (3 handlers): live flowRateInput — \`setHotWaterFlowRateImmediate\`; settings volumeInput + temperatureInput — \`applyHotWaterSettings\`.

### Intentionally NOT migrated (no BLE cost per tick)
- \`SettingsMachineTab.qml\`: pure QSettings persistence.
- \`BrewDialog.qml\`: local state (\`doseValue\`, \`ratio\`, \`targetValue\`).
- \`AutoFavoritesPage\`, \`RecipeEditorPage\`, \`SimpleProfileEditorPage\`, \`PostShotReviewPage\`, other settings tabs: in-memory or QSettings only.

## Evidence (pre-fix, from post-#780 session log)
\`\`\`
[4141.996] [ShotSettings] write skipped ... [applyFlushSettings]
[4142.026] ... [applyFlushSettings]
...  (30 more, every ~25–80 ms for 2.5 s)
[4144.503] ... [applyFlushSettings]
\`\`\`
Each iteration also fired three un-deduped MMR writes (0x803828 / 0x803840 / 0x803848). Issue #783 tracks adding per-register dedup to \`writeMMR\` as belt-and-suspenders.

## Test plan
- [ ] On-device: hold duration +/- on FlushPage; log should show \`[applyFlushSettings]\` dedup-skips during hold, then the final real BLE payload once on release.
- [ ] On-device: hold a temperature or pressure slider on ProfileEditorPage; log should show no \`uploadProfile\` activity until release, then exactly one profile upload.
- [ ] On-device: hold steam temperature + on SteamPage; log should show one \`setSteamTemperatureImmediate\` on release, not ~12 Hz.
- [ ] On-device: hold hot-water volume in HotWaterPage settings view; log should show one \`applyHotWaterSettings\` on release.
- [ ] Single taps, popup drags, and text entry still commit correctly.
- [ ] Tapping + when pinned at max does nothing (no valueModified, no valueCommitted — verify by placing a log line in either handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)