### PR TITLE
fix(BLE): only invalidate MMR cache when clearQueue actually drops a write

### DIFF
--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -271,7 +271,11 @@ void BleTransport::disconnect() {
 }
 
 qsizetype BleTransport::clearQueue() {
-    qsizetype cleared = m_commandQueue.size();
+    // processCommandQueue dequeues a command before dispatching it, so the
+    // currently-in-flight write is no longer in m_commandQueue but is still
+    // live (m_writePending=true). Count it too — otherwise an aborted MMR
+    // write would leave m_lastMMRValues claiming the DE1 has the value.
+    qsizetype cleared = m_commandQueue.size() + (m_writePending ? 1 : 0);
     m_commandQueue.clear();
     m_writePending = false;
     m_writeTimeoutTimer.stop();

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -270,7 +270,7 @@ void BleTransport::disconnect() {
     m_disconnectedEmittedForAttempt = false;
 }
 
-void BleTransport::clearQueue() {
+qsizetype BleTransport::clearQueue() {
     qsizetype cleared = m_commandQueue.size();
     m_commandQueue.clear();
     m_writePending = false;
@@ -279,7 +279,7 @@ void BleTransport::clearQueue() {
     m_writeRetryCount = 0;
     m_lastWriteUuid.clear();
     m_lastWriteData.clear();
-    Q_UNUSED(cleared);
+    return cleared;
 }
 
 bool BleTransport::isConnected() const {

--- a/src/ble/bletransport.h
+++ b/src/ble/bletransport.h
@@ -39,7 +39,7 @@ public:
     void subscribe(const QBluetoothUuid& uuid) override;
     void subscribeAll() override;
     void disconnect() override;
-    void clearQueue() override;
+    qsizetype clearQueue() override;
     bool isConnected() const override;
     QString transportName() const override { return QStringLiteral("BLE"); }
 

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -789,11 +789,15 @@ void DE1Device::goToSleep() {
     }
 
     if (!m_transport) return;
-    // Clear pending commands - sleep takes priority. Also drop the MMR cache
-    // so any MMR writes queued-then-dropped don't leave the cache claiming
-    // the DE1 already holds those values (see clearCommandQueue).
-    m_lastMMRValues.clear();
-    m_transport->clearQueue();
+    // Clear pending commands - sleep takes priority. Only drop the MMR
+    // cache if something was actually queued — an empty queue means the
+    // cache still matches what we've sent. Avoids a spurious re-send of
+    // steam/flush MMR on every steam end (where flow-begin defensively
+    // calls us through clearCommandQueue but nothing is pending).
+    const qsizetype dropped = m_transport->clearQueue();
+    if (dropped > 0) {
+        m_lastMMRValues.clear();
+    }
 
     // Send sleep command directly (don't queue it)
     QByteArray data(1, static_cast<char>(DE1::State::Sleep));
@@ -813,12 +817,17 @@ void DE1Device::clearCommandQueue() {
     m_lastSawTriggerMs = 0;
     m_lastSawWriteMs = 0;
     // Dropping the transport queue discards pending MMR writes whose values
-    // are already recorded in m_lastMMRValues — those writes never reach the
-    // DE1, so the cache would silently elide the next retry. Clearing it
-    // forces the next writeMMR to actually hit the wire.
-    m_lastMMRValues.clear();
+    // are already recorded in m_lastMMRValues, so the cache would silently
+    // elide the next retry. Only invalidate the cache if something was
+    // actually dropped — the call sites here (flow-begin, onShotStarted,
+    // stopOperationUrgent) fire defensively whether or not writes are
+    // pending, and clearing on every call would cost 3 spurious MMR writes
+    // per steam/hot-water session.
     if (m_transport) {
-        m_transport->clearQueue();
+        const qsizetype dropped = m_transport->clearQueue();
+        if (dropped > 0) {
+            m_lastMMRValues.clear();
+        }
     }
 }
 

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -819,10 +819,10 @@ void DE1Device::clearCommandQueue() {
     // Dropping the transport queue discards pending MMR writes whose values
     // are already recorded in m_lastMMRValues, so the cache would silently
     // elide the next retry. Only invalidate the cache if something was
-    // actually dropped — the call sites here (flow-begin, onShotStarted,
-    // stopOperationUrgent) fire defensively whether or not writes are
-    // pending, and clearing on every call would cost 3 spurious MMR writes
-    // per steam/hot-water session.
+    // actually dropped — the call sites here (flow-begin,
+    // onEspressoCycleStarted, stopOperationUrgent) fire defensively whether
+    // or not writes are pending, and clearing on every call would cost 3
+    // spurious MMR writes per steam/hot-water session.
     if (m_transport) {
         const qsizetype dropped = m_transport->clearQueue();
         if (dropped > 0) {

--- a/src/ble/de1transport.h
+++ b/src/ble/de1transport.h
@@ -69,11 +69,14 @@ public:
     virtual void disconnect() = 0;
 
     /**
-     * Clear any pending command queue.
-     * Called before urgent operations (SAW stop, sleep) to prevent stale
-     * commands from interfering. No-op for transports without queuing.
+     * Clear any pending command queue and return the number of commands
+     * that were dropped. Called before urgent operations (SAW stop, sleep)
+     * to prevent stale commands from interfering. Transports without
+     * queuing return 0. The count lets DE1Device skip invalidating its
+     * per-register MMR dedup cache when nothing was actually dropped (the
+     * cache is only at risk when a queued write never reached the wire).
      */
-    virtual void clearQueue() {}
+    virtual qsizetype clearQueue() { return 0; }
 
     /**
      * Check if the transport is currently connected.

--- a/tests/mocks/MockTransport.h
+++ b/tests/mocks/MockTransport.h
@@ -27,6 +27,12 @@ public:
     // also emits the matching DE1Transport::connected/disconnected signal.
     bool m_connected = true;
 
+    // Simulated queue depth for clearQueue() accounting. Tests that
+    // exercise the "queue drop → MMR cache invalidated" path bump this
+    // before calling clearCommandQueue(); the default of 0 models an
+    // idle transport where clearQueue is a no-op drop.
+    qsizetype pendingQueueSize = 0;
+
     // DE1Transport interface
     void write(const QBluetoothUuid& uuid, const QByteArray& data) override {
         writes.append({uuid, data});
@@ -39,6 +45,11 @@ public:
             m_connected = false;
             emit disconnected();
         }
+    }
+    qsizetype clearQueue() override {
+        const qsizetype dropped = pendingQueueSize;
+        pendingQueueSize = 0;
+        return dropped;
     }
     bool isConnected() const override { return m_connected; }
     QString transportName() const override { return QStringLiteral("Mock"); }

--- a/tests/tst_mmrwrite.cpp
+++ b/tests/tst_mmrwrite.cpp
@@ -174,9 +174,9 @@ private slots:
         // writes never reached the DE1 — but m_lastMMRValues already
         // recorded their values. If the cache survived, the next identical
         // writeMMR would dedup and the DE1 would never see the dropped
-        // value. Callers: MainController::onShotStarted at every espresso
-        // start, DE1Device::stopOperationUrgent on SAW trigger, MachineState
-        // on non-espresso flow-begin.
+        // value. Callers: MainController::onEspressoCycleStarted at every
+        // espresso start, DE1Device::stopOperationUrgent on SAW trigger,
+        // MachineState on non-espresso flow-begin.
         TestFixture f;
         f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);
 
@@ -195,9 +195,11 @@ private slots:
         // when nothing is pending (guarding against stale profile-upload
         // frames that in practice aren't there). If we invalidated the
         // MMR cache on every such call, every steam/hot-water session
-        // would end with three spurious re-sends of STEAM_FLOW / FLUSH_FLOW
-        // / FLUSH_TIMEOUT. When clearQueue reports nothing dropped, the
-        // cache is still in sync with what reached the wire — preserve it.
+        // would end with three spurious re-sends of the three MMR writes
+        // sendMachineSettings emits (steam flow 0x803828, flush flow
+        // 0x803840, flush timeout 0x803848). When clearQueue reports
+        // nothing dropped, the cache is still in sync with what reached
+        // the wire — preserve it.
         TestFixture f;
         QTest::ignoreMessage(QtDebugMsg,
             QRegularExpression("\\[MMR\\] write skipped"));
@@ -206,6 +208,42 @@ private slots:
 
         // pendingQueueSize defaults to 0 — clearQueue is a no-op drop.
         f.device.clearCommandQueue();
+
+        f.transport.clearWrites();
+        f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);  // same value
+
+        QCOMPARE(f.transport.writes.size(), 0);  // deduped — cache held
+    }
+
+    // ===== goToSleep: same conditional-invalidation contract =====
+
+    void goToSleepDropsInvalidateCache() {
+        // goToSleep bypasses DE1Device::clearCommandQueue() and calls
+        // m_transport->clearQueue() directly. Same invariant applies: if
+        // a queued write was dropped, the cache might be ahead of the DE1
+        // and must be invalidated.
+        TestFixture f;
+        f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);
+
+        f.transport.pendingQueueSize = 1;
+        f.device.goToSleep();
+
+        f.transport.clearWrites();
+        f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);  // same value
+
+        QCOMPARE(f.transport.writes.size(), 1);  // fired despite same value
+    }
+
+    void goToSleepWithEmptyQueuePreservesCache() {
+        // Symmetric to clearCommandQueueWithEmptyQueuePreservesCache — if
+        // nothing was queued, the cache is still in sync and must survive.
+        TestFixture f;
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression("\\[MMR\\] write skipped"));
+
+        f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);
+
+        f.device.goToSleep();  // pendingQueueSize defaults to 0
 
         f.transport.clearWrites();
         f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);  // same value

--- a/tests/tst_mmrwrite.cpp
+++ b/tests/tst_mmrwrite.cpp
@@ -169,23 +169,48 @@ private slots:
 
     // ===== Command queue clear invalidates cache =====
 
-    void clearCommandQueueClearsCache() {
-        // clearCommandQueue drops every pending transport write — including
-        // MMR writes whose values were just recorded in m_lastMMRValues. If
-        // the cache survived, the next identical writeMMR would dedup and
-        // the DE1 would never receive the value that was dropped on the
-        // floor. Callers: MainController::onShotStarted at every espresso
+    void clearCommandQueueDropsInvalidateCache() {
+        // When clearCommandQueue actually drops pending writes, those
+        // writes never reached the DE1 — but m_lastMMRValues already
+        // recorded their values. If the cache survived, the next identical
+        // writeMMR would dedup and the DE1 would never see the dropped
+        // value. Callers: MainController::onShotStarted at every espresso
         // start, DE1Device::stopOperationUrgent on SAW trigger, MachineState
-        // on preinfusion phase entry.
+        // on non-espresso flow-begin.
         TestFixture f;
         f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);
 
+        // Simulate a non-empty transport queue — clearQueue reports >0.
+        f.transport.pendingQueueSize = 1;
         f.device.clearCommandQueue();
 
         f.transport.clearWrites();
         f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);  // same value
 
         QCOMPARE(f.transport.writes.size(), 1);  // fired despite same value
+    }
+
+    void clearCommandQueueWithEmptyQueuePreservesCache() {
+        // Non-espresso flow-begin defensively calls clearCommandQueue even
+        // when nothing is pending (guarding against stale profile-upload
+        // frames that in practice aren't there). If we invalidated the
+        // MMR cache on every such call, every steam/hot-water session
+        // would end with three spurious re-sends of STEAM_FLOW / FLUSH_FLOW
+        // / FLUSH_TIMEOUT. When clearQueue reports nothing dropped, the
+        // cache is still in sync with what reached the wire — preserve it.
+        TestFixture f;
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression("\\[MMR\\] write skipped"));
+
+        f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);
+
+        // pendingQueueSize defaults to 0 — clearQueue is a no-op drop.
+        f.device.clearCommandQueue();
+
+        f.transport.clearWrites();
+        f.device.writeMMR(DE1::MMR::STEAM_FLOW, 150);  // same value
+
+        QCOMPARE(f.transport.writes.size(), 0);  // deduped — cache held
     }
 
     // ===== Disconnect invalidates cache =====


### PR DESCRIPTION
## Summary
Follow-up to #784. Every non-espresso flow-begin (steam Pouring, hot water Pouring) defensively calls `DE1Device::clearCommandQueue()` via [machinestate.cpp:350](https://github.com/Kulitorum/Decenza/blob/977e159b/src/machine/machinestate.cpp#L350) to guard against stale queued profile-upload frames. In practice nothing is queued, but #784 wired the MMR-cache clear into that same path, so every steam/hot-water cycle ended with three spurious re-sends of `STEAM_FLOW` / `FLUSH_FLOW` / `FLUSH_TIMEOUT` as `applySteamSettings` repopulated the cache. Visible in the tablet debug log at every steam-stop.

Make `DE1Transport::clearQueue()` return the number of commands it actually dropped. `DE1Device::clearCommandQueue()` and `goToSleep()` only invalidate `m_lastMMRValues` when the count is >0. Preserves the safety fix for the real race (BLE write queued → `clearQueue` drops it → cache claims DE1 has the value) while eliminating the nuisance burst on every steam stop.

## Test plan
- [x] `tst_mmrwrite::clearCommandQueueDropsInvalidateCache` — bumps `MockTransport::pendingQueueSize` before the call; confirms cache is invalidated (1 BLE write on same-value retry).
- [x] `tst_mmrwrite::clearCommandQueueWithEmptyQueuePreservesCache` (new) — leaves `pendingQueueSize=0`; confirms cache survives (0 BLE writes on same-value retry).
- [x] `tst_shotsettings`, `tst_machinestate`, `tst_profileupload`, `tst_sav`, `tst_saw` still pass after the `clearQueue()` signature change.
- [x] Main Decenza app links clean on macOS.
- [ ] On-device: verify steam-end no longer shows the 3-MMR burst in the debug log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)