### PR TITLE
feat(history): add Export Shots to File toggle (#778)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,7 @@ set(SOURCES
     src/history/shotdebuglogger.cpp
     src/history/shotfileparser.cpp
     src/history/shotimporter.cpp
+    src/history/shothistoryexporter.cpp
     src/models/shotcomparisonmodel.cpp
     src/models/flowcalibrationmodel.cpp
     src/network/shotserver.cpp
@@ -424,6 +425,7 @@ set(HEADERS
     src/history/shotdebuglogger.h
     src/history/shotfileparser.h
     src/history/shotimporter.h
+    src/history/shothistoryexporter.h
     src/models/shotcomparisonmodel.h
     src/models/flowcalibrationmodel.h
     src/network/shotserver.h

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -2795,6 +2795,67 @@ ApplicationWindow {
         onTriggered: flowCalToast.opacity = 0
     }
 
+    // ============ SHOT EXPORT BULK COMPLETION TOAST ============
+    // Shown once the initial "export all shots" pass triggered by enabling
+    // Settings.exportShotsToFile has finished writing files to the user
+    // history folder. Silent-until-done so the toggle behaves like a plain
+    // boolean preference.
+    property string shotExportToastText: ""
+
+    Rectangle {
+        id: shotExportToast
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Theme.scaled(40)
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: shotExportToastLabel.implicitWidth + Theme.scaled(32)
+        height: shotExportToastLabel.implicitHeight + Theme.scaled(16)
+        radius: Theme.cardRadius
+        color: Theme.surfaceColor
+        opacity: 0
+        visible: opacity > 0
+        z: 600
+        Accessible.ignored: true
+
+        Behavior on opacity {
+            NumberAnimation { duration: 300 }
+        }
+
+        Text {
+            id: shotExportToastLabel
+            anchors.centerIn: parent
+            text: shotExportToastText
+            color: Theme.textColor
+            font.pixelSize: Theme.scaled(13)
+            Accessible.ignored: true
+        }
+    }
+
+    Timer {
+        id: shotExportToastTimer
+        interval: 4000
+        onTriggered: shotExportToast.opacity = 0
+    }
+
+    Connections {
+        target: ShotHistoryExporter
+        function onBulkExportFinished(ok, failed) {
+            if (failed > 0) {
+                shotExportToastText = TranslationManager.translate(
+                    "main.toast.exportShotsPartial",
+                    "Exported %1 shots; %2 failed").arg(ok).arg(failed)
+            } else {
+                shotExportToastText = TranslationManager.translate(
+                    "main.toast.exportShotsDone",
+                    "Exported %1 shots").arg(ok)
+            }
+            shotExportToast.opacity = 1
+            shotExportToastTimer.restart()
+            if (AccessibilityManager.enabled) {
+                AccessibilityManager.announce(shotExportToastText)
+            }
+        }
+    }
+
     // ============ ACCESSIBILITY: Machine State Announcements ============
     // Translatable accessibility announcements for machine state
     Tr { id: trAnnounceDisconnected; key: "main.accessibility.machineDisconnected"; fallback: "Machine disconnected"; visible: false }

--- a/qml/pages/settings/SettingsHistoryDataTab.qml
+++ b/qml/pages/settings/SettingsHistoryDataTab.qml
@@ -492,10 +492,15 @@ KeyboardAwareContainer {
             }
         }
 
-        // Right column: Server & Security
+        // Right column: Share Data card, plus Export Shots card below it
+        ColumnLayout {
+            Layout.preferredWidth: Theme.scaled(280)
+            Layout.fillHeight: true
+            spacing: Theme.scaled(15)
+
         Rectangle {
             objectName: "enableServer"
-            Layout.preferredWidth: Theme.scaled(280)
+            Layout.fillWidth: true
             Layout.fillHeight: true
             color: Theme.surfaceColor
             radius: Theme.cardRadius
@@ -718,6 +723,66 @@ KeyboardAwareContainer {
                 }
             }
     }
+
+        // Export Shots card — writes each shot as visualizer-format JSON to
+        // the user history folder alongside the user profiles folder. Off by
+        // default; toggling on bulk-exports the entire shot history.
+        Rectangle {
+            objectName: "exportShotsCard"
+            Layout.fillWidth: true
+            Layout.preferredHeight: exportShotsLayout.implicitHeight + Theme.scaled(30)
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
+
+            ColumnLayout {
+                id: exportShotsLayout
+                anchors.fill: parent
+                anchors.margins: Theme.scaled(15)
+                spacing: Theme.scaled(8)
+
+                Tr {
+                    key: "settings.data.exportshots"
+                    fallback: "Export Shots to File"
+                    color: Theme.textColor
+                    font.pixelSize: Theme.scaled(14)
+                    font.bold: true
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.scaled(8)
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(2)
+
+                        Tr {
+                            key: "settings.data.exportshotsrow"
+                            fallback: "Mirror shots to JSON files"
+                            color: Theme.textColor
+                            font.pixelSize: Theme.scaled(12)
+                        }
+
+                        Tr {
+                            key: "settings.data.exportshotsdesc"
+                            fallback: "Writes each shot as visualizer-format JSON to the history folder alongside your profiles. Files are for your archive only — the app never reads them back."
+                            color: Theme.textSecondaryColor
+                            font.pixelSize: Theme.scaled(9)
+                            Layout.fillWidth: true
+                            wrapMode: Text.WordWrap
+                        }
+                    }
+
+                    StyledSwitch {
+                        checked: Settings.exportShotsToFile
+                        accessibleName: TranslationManager.translate(
+                            "settings.data.exportshots", "Export Shots to File")
+                        onToggled: Settings.exportShotsToFile = checked
+                    }
+                }
+            }
+        }
+        }
 
     // Device Migration Dialog
     DeviceMigrationDialog {

--- a/src/core/profilestorage.cpp
+++ b/src/core/profilestorage.cpp
@@ -122,6 +122,19 @@ QString ProfileStorage::downloadedProfilesPath() const {
     return path;
 }
 
+QString ProfileStorage::userHistoryPath() const {
+    QString basePath = isConfigured() ? externalProfilesPath() : fallbackPath();
+    if (basePath.isEmpty()) {
+        basePath = fallbackPath();
+    }
+    QString path = basePath + "/history";
+    QDir dir(path);
+    if (!dir.exists()) {
+        dir.mkpath(".");
+    }
+    return path;
+}
+
 QStringList ProfileStorage::listProfiles() const {
     QStringList profiles;
     QStringList filters;

--- a/src/core/profilestorage.cpp
+++ b/src/core/profilestorage.cpp
@@ -135,6 +135,15 @@ QString ProfileStorage::userHistoryPath() const {
     return path;
 }
 
+QString ProfileStorage::userHistoryPathIfExists() const {
+    QString basePath = isConfigured() ? externalProfilesPath() : fallbackPath();
+    if (basePath.isEmpty()) {
+        basePath = fallbackPath();
+    }
+    QString path = basePath + "/history";
+    return QDir(path).exists() ? path : QString();
+}
+
 QStringList ProfileStorage::listProfiles() const {
     QStringList profiles;
     QStringList filters;

--- a/src/core/profilestorage.h
+++ b/src/core/profilestorage.h
@@ -58,8 +58,14 @@ public:
     // Get the downloaded profiles path (for profiles imported from Visualizer)
     QString downloadedProfilesPath() const;
 
-    // Get the user history path (sibling of the user profiles folder) for shot export
+    // Get the user history path (sibling of the user profiles folder) for shot export.
+    // Creates the directory if it doesn't already exist.
     QString userHistoryPath() const;
+
+    // Like userHistoryPath(), but returns an empty string instead of creating the
+    // directory when it doesn't exist — use from cleanup paths that should be
+    // no-ops when the feature has never been used.
+    QString userHistoryPathIfExists() const;
 
     // Migrate profiles from internal to external storage (call after permission granted)
     Q_INVOKABLE void migrateProfilesToExternal();

--- a/src/core/profilestorage.h
+++ b/src/core/profilestorage.h
@@ -58,6 +58,9 @@ public:
     // Get the downloaded profiles path (for profiles imported from Visualizer)
     QString downloadedProfilesPath() const;
 
+    // Get the user history path (sibling of the user profiles folder) for shot export
+    QString userHistoryPath() const;
+
     // Migrate profiles from internal to external storage (call after permission granted)
     Q_INVOKABLE void migrateProfilesToExternal();
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -3347,6 +3347,17 @@ void Settings::setDailyBackupHour(int hour) {
     }
 }
 
+bool Settings::exportShotsToFile() const {
+    return m_settings.value("export/shotsToFile", false).toBool();
+}
+
+void Settings::setExportShotsToFile(bool enabled) {
+    if (exportShotsToFile() != enabled) {
+        m_settings.setValue("export/shotsToFile", enabled);
+        emit exportShotsToFileChanged();
+    }
+}
+
 QString Settings::waterLevelDisplayUnit() const {
     return m_settings.value("display/waterLevelUnit", "percent").toString();
 }

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -193,6 +193,9 @@ class Settings : public QObject {
     // Daily backup settings
     Q_PROPERTY(int dailyBackupHour READ dailyBackupHour WRITE setDailyBackupHour NOTIFY dailyBackupHourChanged)
 
+    // Shot export settings
+    Q_PROPERTY(bool exportShotsToFile READ exportShotsToFile WRITE setExportShotsToFile NOTIFY exportShotsToFileChanged)
+
     // Water level display setting
     Q_PROPERTY(QString waterLevelDisplayUnit READ waterLevelDisplayUnit WRITE setWaterLevelDisplayUnit NOTIFY waterLevelDisplayUnitChanged)
 
@@ -709,6 +712,10 @@ public:
     int dailyBackupHour() const;
     void setDailyBackupHour(int hour);
 
+    // Shot export to file
+    bool exportShotsToFile() const;
+    void setExportShotsToFile(bool enabled);
+
     // Water level display
     QString waterLevelDisplayUnit() const;
     void setWaterLevelDisplayUnit(const QString& unit);
@@ -994,6 +1001,7 @@ signals:
     void autoCheckUpdatesChanged();
     void betaUpdatesEnabledChanged();
     void dailyBackupHourChanged();
+    void exportShotsToFileChanged();
     void waterLevelDisplayUnitChanged();
     void waterRefillPointChanged();
     void refillKitOverrideChanged();

--- a/src/history/shothistoryexporter.cpp
+++ b/src/history/shothistoryexporter.cpp
@@ -1,0 +1,200 @@
+#include "shothistoryexporter.h"
+
+#include "shothistorystorage.h"
+#include "../core/profilestorage.h"
+#include "../core/settings.h"
+#include "../core/dbutils.h"
+#include "../network/visualizeruploader.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QSaveFile>
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QThread>
+
+ShotHistoryExporter::ShotHistoryExporter(Settings* settings,
+                                         ProfileStorage* profileStorage,
+                                         ShotHistoryStorage* storage,
+                                         QObject* parent)
+    : QObject(parent)
+    , m_settings(settings)
+    , m_profileStorage(profileStorage)
+    , m_storage(storage)
+    , m_destroyed(std::make_shared<std::atomic<bool>>(false))
+{
+    Q_ASSERT(m_settings);
+    Q_ASSERT(m_profileStorage);
+    Q_ASSERT(m_storage);
+
+    connect(m_settings, &Settings::exportShotsToFileChanged,
+            this, &ShotHistoryExporter::onExportToggleChanged);
+    connect(m_storage, &ShotHistoryStorage::shotSaved,
+            this, &ShotHistoryExporter::onShotSaved);
+    connect(m_storage, &ShotHistoryStorage::shotMetadataUpdated,
+            this, &ShotHistoryExporter::onShotMetadataUpdated);
+    connect(m_storage, &ShotHistoryStorage::shotDeleted,
+            this, &ShotHistoryExporter::onShotDeleted);
+    connect(m_storage, &ShotHistoryStorage::shotsDeleted,
+            this, &ShotHistoryExporter::onShotsDeleted);
+}
+
+ShotHistoryExporter::~ShotHistoryExporter()
+{
+    *m_destroyed = true;
+}
+
+void ShotHistoryExporter::onExportToggleChanged()
+{
+    if (m_settings->exportShotsToFile()) {
+        startBulkExport();
+    }
+}
+
+void ShotHistoryExporter::onShotSaved(qint64 shotId)
+{
+    if (!m_settings->exportShotsToFile()) return;
+    if (m_bulkRunning.load()) return;
+    exportSingleShot(shotId);
+}
+
+void ShotHistoryExporter::onShotMetadataUpdated(qint64 shotId, bool success)
+{
+    if (!success) return;
+    if (!m_settings->exportShotsToFile()) return;
+    if (m_bulkRunning.load()) return;
+    exportSingleShot(shotId);
+}
+
+void ShotHistoryExporter::onShotDeleted(qint64 shotId)
+{
+    deleteExportedFiles({shotId});
+}
+
+void ShotHistoryExporter::onShotsDeleted(const QVariantList& shotIds)
+{
+    QList<qint64> ids;
+    ids.reserve(shotIds.size());
+    for (const auto& v : shotIds) ids.append(v.toLongLong());
+    deleteExportedFiles(ids);
+}
+
+namespace {
+
+bool writeShotJson(const QString& dbPath,
+                   const QString& historyDir,
+                   qint64 shotId)
+{
+    ShotRecord record;
+    bool opened = withTempDb(dbPath, "she_shot", [&](QSqlDatabase& db) {
+        record = ShotHistoryStorage::loadShotRecordStatic(db, shotId);
+    });
+    if (!opened || record.summary.id == 0) {
+        qWarning() << "ShotHistoryExporter: failed to load shot" << shotId;
+        return false;
+    }
+
+    QVariantMap shotData = ShotHistoryStorage::convertShotRecord(record);
+    QByteArray payload = VisualizerUploader::buildHistoryShotJson(shotData);
+
+    const QDateTime dt = QDateTime::fromSecsSinceEpoch(record.summary.timestamp);
+    const QString filename = QString("%1_%2.json")
+        .arg(dt.toString("yyyyMMddTHHmmss"))
+        .arg(shotId);
+    const QString fullPath = historyDir + "/" + filename;
+
+    QSaveFile file(fullPath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qWarning() << "ShotHistoryExporter: open failed for" << fullPath << ":" << file.errorString();
+        return false;
+    }
+    file.write(payload);
+    if (!file.commit()) {
+        qWarning() << "ShotHistoryExporter: commit failed for" << fullPath << ":" << file.errorString();
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+void ShotHistoryExporter::startBulkExport()
+{
+    bool expected = false;
+    if (!m_bulkRunning.compare_exchange_strong(expected, true)) {
+        qDebug() << "ShotHistoryExporter: bulk export already running";
+        return;
+    }
+
+    const QString dbPath = m_storage->databasePath();
+    const QString historyDir = m_profileStorage->userHistoryPath();
+    auto destroyed = m_destroyed;
+
+    QThread* thread = QThread::create([this, dbPath, historyDir, destroyed]() {
+        QList<qint64> ids;
+        withTempDb(dbPath, "she_ids", [&](QSqlDatabase& db) {
+            QSqlQuery q(db);
+            if (!q.exec(QStringLiteral("SELECT id FROM shots ORDER BY id ASC"))) {
+                qWarning() << "ShotHistoryExporter: id enumeration failed:" << q.lastError().text();
+                return;
+            }
+            while (q.next()) ids.append(q.value(0).toLongLong());
+        });
+
+        int ok = 0, failed = 0;
+        for (qint64 id : ids) {
+            if (*destroyed) return;
+            if (writeShotJson(dbPath, historyDir, id)) ok++;
+            else failed++;
+        }
+
+        if (*destroyed) return;
+        QMetaObject::invokeMethod(this, [this, ok, failed, destroyed]() {
+            if (*destroyed) return;
+            m_bulkRunning.store(false);
+            emit bulkExportFinished(ok, failed);
+        }, Qt::QueuedConnection);
+    });
+    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+    thread->start();
+}
+
+void ShotHistoryExporter::exportSingleShot(qint64 shotId)
+{
+    const QString dbPath = m_storage->databasePath();
+    const QString historyDir = m_profileStorage->userHistoryPath();
+    auto destroyed = m_destroyed;
+
+    QThread* thread = QThread::create([dbPath, historyDir, shotId, destroyed]() {
+        if (*destroyed) return;
+        writeShotJson(dbPath, historyDir, shotId);
+    });
+    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+    thread->start();
+}
+
+void ShotHistoryExporter::deleteExportedFiles(const QList<qint64>& shotIds)
+{
+    if (shotIds.isEmpty()) return;
+    const QString historyDir = m_profileStorage->userHistoryPath();
+    auto destroyed = m_destroyed;
+
+    QThread* thread = QThread::create([historyDir, shotIds, destroyed]() {
+        if (*destroyed) return;
+        QDir dir(historyDir);
+        if (!dir.exists()) return;
+        for (qint64 id : shotIds) {
+            const QStringList matches = dir.entryList(
+                {QString("*_%1.json").arg(id)}, QDir::Files);
+            for (const QString& name : matches) {
+                if (!QFile::remove(dir.filePath(name))) {
+                    qWarning() << "ShotHistoryExporter: remove failed for" << name;
+                }
+            }
+        }
+    });
+    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+    thread->start();
+}

--- a/src/history/shothistoryexporter.cpp
+++ b/src/history/shothistoryexporter.cpp
@@ -9,8 +9,8 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFile>
-#include <QFileInfo>
 #include <QSaveFile>
+#include <QSet>
 #include <QSqlQuery>
 #include <QSqlError>
 #include <QThread>
@@ -35,10 +35,18 @@ ShotHistoryExporter::ShotHistoryExporter(Settings* settings,
             this, &ShotHistoryExporter::onShotSaved);
     connect(m_storage, &ShotHistoryStorage::shotMetadataUpdated,
             this, &ShotHistoryExporter::onShotMetadataUpdated);
+    // shotsDeleted fires in addition to per-id shotDeleted for batch deletes,
+    // so we intentionally subscribe only to shotDeleted to avoid N+1 racing
+    // threads trying to remove the same files.
     connect(m_storage, &ShotHistoryStorage::shotDeleted,
             this, &ShotHistoryExporter::onShotDeleted);
-    connect(m_storage, &ShotHistoryStorage::shotsDeleted,
-            this, &ShotHistoryExporter::onShotsDeleted);
+
+    // If the toggle was already on from a previous session, re-export on
+    // startup so files are self-healed even if the user cleared the folder
+    // while the app was closed.
+    if (m_settings->exportShotsToFile()) {
+        startBulkExport();
+    }
 }
 
 ShotHistoryExporter::~ShotHistoryExporter()
@@ -55,7 +63,11 @@ void ShotHistoryExporter::onExportToggleChanged()
 
 void ShotHistoryExporter::onShotSaved(qint64 shotId)
 {
+    // ShotHistoryStorage emits shotSaved(-1) on precondition failures.
+    if (shotId <= 0) return;
     if (!m_settings->exportShotsToFile()) return;
+    // Bulk export will pick up any IDs that arrive during its run via its
+    // own post-loop catch-up query, so skip the live handler to avoid races.
     if (m_bulkRunning.load()) return;
     exportSingleShot(shotId);
 }
@@ -63,6 +75,7 @@ void ShotHistoryExporter::onShotSaved(qint64 shotId)
 void ShotHistoryExporter::onShotMetadataUpdated(qint64 shotId, bool success)
 {
     if (!success) return;
+    if (shotId <= 0) return;
     if (!m_settings->exportShotsToFile()) return;
     if (m_bulkRunning.load()) return;
     exportSingleShot(shotId);
@@ -70,15 +83,8 @@ void ShotHistoryExporter::onShotMetadataUpdated(qint64 shotId, bool success)
 
 void ShotHistoryExporter::onShotDeleted(qint64 shotId)
 {
-    deleteExportedFiles({shotId});
-}
-
-void ShotHistoryExporter::onShotsDeleted(const QVariantList& shotIds)
-{
-    QList<qint64> ids;
-    ids.reserve(shotIds.size());
-    for (const auto& v : shotIds) ids.append(v.toLongLong());
-    deleteExportedFiles(ids);
+    if (shotId <= 0) return;
+    deleteExportedShot(shotId);
 }
 
 namespace {
@@ -133,19 +139,38 @@ void ShotHistoryExporter::startBulkExport()
     auto destroyed = m_destroyed;
 
     QThread* thread = QThread::create([this, dbPath, historyDir, destroyed]() {
-        QList<qint64> ids;
-        withTempDb(dbPath, "she_ids", [&](QSqlDatabase& db) {
-            QSqlQuery q(db);
-            if (!q.exec(QStringLiteral("SELECT id FROM shots ORDER BY id ASC"))) {
-                qWarning() << "ShotHistoryExporter: id enumeration failed:" << q.lastError().text();
-                return;
-            }
-            while (q.next()) ids.append(q.value(0).toLongLong());
-        });
+        auto selectAllIds = [&dbPath](QList<qint64>& out) {
+            withTempDb(dbPath, "she_ids", [&](QSqlDatabase& db) {
+                QSqlQuery q(db);
+                if (!q.exec(QStringLiteral("SELECT id FROM shots ORDER BY id ASC"))) {
+                    qWarning() << "ShotHistoryExporter: id enumeration failed:" << q.lastError().text();
+                    return;
+                }
+                while (q.next()) out.append(q.value(0).toLongLong());
+            });
+        };
 
+        QList<qint64> ids;
+        selectAllIds(ids);
+
+        QSet<qint64> seen;
         int ok = 0, failed = 0;
         for (qint64 id : ids) {
             if (*destroyed) return;
+            seen.insert(id);
+            if (writeShotJson(dbPath, historyDir, id)) ok++;
+            else failed++;
+        }
+
+        // Catch-up pass: shots saved after the initial SELECT but before we
+        // flip m_bulkRunning to false are ignored by onShotSaved (which
+        // early-returns while bulk is running). Re-query and process any
+        // that landed during this run so they still end up on disk.
+        QList<qint64> latest;
+        selectAllIds(latest);
+        for (qint64 id : latest) {
+            if (*destroyed) return;
+            if (seen.contains(id)) continue;
             if (writeShotJson(dbPath, historyDir, id)) ok++;
             else failed++;
         }
@@ -175,23 +200,22 @@ void ShotHistoryExporter::exportSingleShot(qint64 shotId)
     thread->start();
 }
 
-void ShotHistoryExporter::deleteExportedFiles(const QList<qint64>& shotIds)
+void ShotHistoryExporter::deleteExportedShot(qint64 shotId)
 {
-    if (shotIds.isEmpty()) return;
-    const QString historyDir = m_profileStorage->userHistoryPath();
+    // Skip entirely if the feature was never used — avoids creating an empty
+    // history folder as a side effect of a deletion.
+    const QString historyDir = m_profileStorage->userHistoryPathIfExists();
+    if (historyDir.isEmpty()) return;
     auto destroyed = m_destroyed;
 
-    QThread* thread = QThread::create([historyDir, shotIds, destroyed]() {
+    QThread* thread = QThread::create([historyDir, shotId, destroyed]() {
         if (*destroyed) return;
         QDir dir(historyDir);
-        if (!dir.exists()) return;
-        for (qint64 id : shotIds) {
-            const QStringList matches = dir.entryList(
-                {QString("*_%1.json").arg(id)}, QDir::Files);
-            for (const QString& name : matches) {
-                if (!QFile::remove(dir.filePath(name))) {
-                    qWarning() << "ShotHistoryExporter: remove failed for" << name;
-                }
+        const QStringList matches = dir.entryList(
+            {QString("*_%1.json").arg(shotId)}, QDir::Files);
+        for (const QString& name : matches) {
+            if (!QFile::remove(dir.filePath(name))) {
+                qWarning() << "ShotHistoryExporter: remove failed for" << name;
             }
         }
     });

--- a/src/history/shothistoryexporter.h
+++ b/src/history/shothistoryexporter.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QVariantList>
+#include <atomic>
+#include <memory>
+
+class Settings;
+class ProfileStorage;
+class ShotHistoryStorage;
+
+// ShotHistoryExporter mirrors shots from the SQLite DB into individual
+// visualizer-format JSON files under ProfileStorage::userHistoryPath(),
+// driven by Settings::exportShotsToFile.
+//
+// Design:
+//  * Stateless when off: no tracking of "which shots have been exported."
+//  * Toggle off -> on: full re-export overwriting whatever is on disk.
+//  * Toggle on: incrementally export each new shot when shotSaved fires,
+//               refresh on metadata updates, and delete files when shots
+//               are deleted from the DB.
+//  * All disk and DB I/O runs on background threads.
+class ShotHistoryExporter : public QObject {
+    Q_OBJECT
+public:
+    explicit ShotHistoryExporter(Settings* settings,
+                                 ProfileStorage* profileStorage,
+                                 ShotHistoryStorage* storage,
+                                 QObject* parent = nullptr);
+    ~ShotHistoryExporter() override;
+
+signals:
+    // Emitted on the main thread after the initial bulk export finishes.
+    // ok + failed together equal the total shots attempted.
+    void bulkExportFinished(int ok, int failed);
+
+private slots:
+    void onExportToggleChanged();
+    void onShotSaved(qint64 shotId);
+    void onShotMetadataUpdated(qint64 shotId, bool success);
+    void onShotDeleted(qint64 shotId);
+    void onShotsDeleted(const QVariantList& shotIds);
+
+private:
+    void startBulkExport();
+    void exportSingleShot(qint64 shotId);
+    void deleteExportedFiles(const QList<qint64>& shotIds);
+
+    Settings* m_settings;
+    ProfileStorage* m_profileStorage;
+    ShotHistoryStorage* m_storage;
+
+    std::shared_ptr<std::atomic<bool>> m_destroyed;
+    std::atomic<bool> m_bulkRunning{false};
+};

--- a/src/history/shothistoryexporter.h
+++ b/src/history/shothistoryexporter.h
@@ -2,7 +2,6 @@
 
 #include <QObject>
 #include <QString>
-#include <QVariantList>
 #include <atomic>
 #include <memory>
 
@@ -16,10 +15,13 @@ class ShotHistoryStorage;
 //
 // Design:
 //  * Stateless when off: no tracking of "which shots have been exported."
-//  * Toggle off -> on: full re-export overwriting whatever is on disk.
+//  * Toggle off -> on, and app startup with the toggle already on:
+//    full re-export overwriting whatever is on disk.
 //  * Toggle on: incrementally export each new shot when shotSaved fires,
-//               refresh on metadata updates, and delete files when shots
-//               are deleted from the DB.
+//               refresh on metadata updates.
+//  * Shot deletions always remove matching exported files regardless of the
+//    toggle state, so files don't become orphaned if the user turns the
+//    toggle off and later deletes shots from the DB.
 //  * All disk and DB I/O runs on background threads.
 class ShotHistoryExporter : public QObject {
     Q_OBJECT
@@ -40,12 +42,11 @@ private slots:
     void onShotSaved(qint64 shotId);
     void onShotMetadataUpdated(qint64 shotId, bool success);
     void onShotDeleted(qint64 shotId);
-    void onShotsDeleted(const QVariantList& shotIds);
 
 private:
     void startBulkExport();
     void exportSingleShot(qint64 shotId);
-    void deleteExportedFiles(const QList<qint64>& shotIds);
+    void deleteExportedShot(qint64 shotId);
 
     Settings* m_settings;
     ProfileStorage* m_profileStorage;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,7 @@
 #endif
 #include "network/webdebuglogger.h"
 #include "core/widgetlibrary.h"
+#include "history/shothistoryexporter.h"
 #include "mcp/mcpserver.h"
 #include "network/librarysharing.h"
 #include "network/relayclient.h"
@@ -808,6 +809,11 @@ int main(int argc, char *argv[])
     // Connect screensaver manager to data migration client for media import
     mainController.dataMigration()->setScreensaverVideoManager(&screensaverManager);
 
+    // Shot-history-to-file exporter: mirrors the shots DB into individual
+    // visualizer-format JSON files under ProfileStorage::userHistoryPath()
+    // whenever Settings::exportShotsToFile is on.
+    ShotHistoryExporter shotHistoryExporter(&settings, &profileStorage, mainController.shotHistory());
+
     BatteryManager batteryManager;
     batteryManager.setDE1Device(&de1Device);
     batteryManager.setSettings(&settings);
@@ -1498,6 +1504,7 @@ int main(int argc, char *argv[])
     context->setContextProperty("WidgetLibrary", &widgetLibrary);
     context->setContextProperty("McpServer", &mcpServer);
     context->setContextProperty("LibrarySharing", &librarySharing);
+    context->setContextProperty("ShotHistoryExporter", &shotHistoryExporter);
 #ifndef Q_OS_IOS
     context->setContextProperty("USBManager", &usbManager);
     context->setContextProperty("UsbScaleManager", &usbScaleManager);

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -963,6 +963,7 @@ void VisualizerUploader::sendUpload(const QByteArray& jsonData)
     qDebug() << "Visualizer: Uploading shot...";
 }
 
+// static
 QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
 {
     QJsonObject root;

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -65,6 +65,10 @@ public:
     // Test connection with current credentials
     Q_INVOKABLE void testConnection();
 
+    // Build a visualizer-compatible JSON payload from a ShotHistoryStorage QVariantMap.
+    // Thread-safe; does not touch instance state. Reused by ShotHistoryExporter.
+    static QByteArray buildHistoryShotJson(const QVariantMap& shotData);
+
 signals:
     void uploadingChanged();
     void lastUploadStatusChanged();
@@ -96,7 +100,6 @@ private:
     static QJsonObject buildProfileSettings(const Profile* profile);
     bool validateUpload(const QString& beverageType, double duration);
     void sendUpload(const QByteArray& jsonData);
-    QByteArray buildHistoryShotJson(const QVariantMap& shotData);
 
     Settings* m_settings;
     QNetworkAccessManager* m_networkManager;


### PR DESCRIPTION
Closes #778.

## Summary
- New **Export Shots to File** toggle on Settings → History & Data (below the Share Data card). Off by default.
- When enabled, each shot in the DB is mirrored as a visualizer-format JSON file into `profiles/history/` alongside the user profiles folder. Files are for customer archive/analysis only — the app never reads them back.
- Reuses `VisualizerUploader::buildHistoryShotJson` (promoted to public static since it had no instance state) so the files are byte-identical to visualizer.coffee uploads.

## Stateless behaviour
| Action | Effect |
| --- | --- |
| Toggle off → on | Bulk-exports every shot, overwriting anything in the folder |
| Toggle on → off | Stops; leaves files alone |
| New shot saved (`shotSaved`) | Single JSON written |
| Metadata edited (`shotMetadataUpdated`, success=true) | JSON refreshed |
| Shot deleted (`shotDeleted` / `shotsDeleted`) | Matching `*_<id>.json` removed |
| Bulk export finished | Toast: `Exported N shots` (or `Exported N shots; M failed`) |

Nothing is persisted about what's been exported, so toggle-off + toggle-on = clean full re-export.

## Filename scheme
`YYYYMMDDTHHmmss_<shotId>.json` — timestamp matches the legacy `.shot` convention; shot ID guarantees uniqueness and enables glob-based deletion without a DB lookup.

## Threading
All DB reads and disk I/O run on background threads via `QThread::create` + `withTempDb`, following the existing `ShotHistoryStorage::requestCreateBackup` pattern. A `std::shared_ptr<std::atomic<bool>>` destroyed-flag guards callback delivery, and a `compare_exchange_strong` on `m_bulkRunning` prevents overlapping bulk passes.

## Files
- **New**: `src/history/shothistoryexporter.{h,cpp}` — exporter class
- **Modified**:
  - `src/core/settings.{h,cpp}` — new `exportShotsToFile` Q_PROPERTY (default false, QSettings key `export/shotsToFile`)
  - `src/core/profilestorage.{h,cpp}` — new `userHistoryPath()` helper
  - `src/network/visualizeruploader.{h,cpp}` — promoted `buildHistoryShotJson` to public `static`
  - `src/main.cpp` — constructs the exporter and registers it as a QML context property
  - `qml/pages/settings/SettingsHistoryDataTab.qml` — new Export Shots card below the Share Data card (i18n via new `settings.data.exportshots*` keys, `StyledSwitch` with `accessibleName`)
  - `qml/main.qml` — toast wired to `ShotHistoryExporter.bulkExportFinished` (new `main.toast.exportShots*` keys)
  - `CMakeLists.txt` — registered the new sources/headers

## Test plan
Verified end-to-end on macOS (fresh app, 1002 existing shots in the DB):
- [x] Toggle defaults to off
- [x] Enabling toggle creates `profiles/history/` and writes 992 files (matches DB, 10 gaps are deleted shots) — naming follows `YYYYMMDDTHHmmss_<id>.json`, no duplicates, average ~28 KB/shot
- [x] One file inspected: valid visualizer v2 JSON (`version: 2`), aligned time-series, full `meta`, embedded `profile`, populated `app.data.settings`
- [x] Pulling a new shot appended a fresh `*_1003.json` within seconds
- [x] Editing that shot's enjoyment/TDS/EY refreshed the file (mtime updated, new fields appear in `meta.shot` and `app.data.settings`)
- [x] Deleting that shot removed the file (folder back to 992)
- [ ] Android device: confirm files land under `Documents/Decenza/history/` with permission, internal fallback otherwise
- [ ] Windows device

🤖 Generated with [Claude Code](https://claude.com/claude-code)