### PR TITLE
fix(AI): force scene graph repaint when AI reply arrives on mobile

### DIFF
--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -729,7 +729,7 @@ Rectangle {
             conversationText.text = MainController.aiManager.conversation.getConversationText()
             Qt.callLater(function() {
                 conversationFlickable.contentY = Math.max(0, overlay._preResponseHeight)
-                // Android's render thread can stay asleep when a property changes from
+                // Mobile render thread can stay asleep when a property changes from
                 // a network reply. Force a scene graph repaint so the reply appears
                 // without requiring a touch to wake the render loop.
                 conversationText.update()

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -729,6 +729,11 @@ Rectangle {
             conversationText.text = MainController.aiManager.conversation.getConversationText()
             Qt.callLater(function() {
                 conversationFlickable.contentY = Math.max(0, overlay._preResponseHeight)
+                // Android's render thread can stay asleep when a property changes from
+                // a network reply. Force a scene graph repaint so the reply appears
+                // without requiring a touch to wake the render loop.
+                conversationText.update()
+                conversationFlickable.update()
             })
         }
         function onErrorOccurred(error) {
@@ -747,6 +752,8 @@ Rectangle {
             // Scroll to bottom to show the user's message / thinking indicator
             Qt.callLater(function() {
                 conversationFlickable.contentY = Math.max(0, conversationFlickable.contentHeight - conversationFlickable.height)
+                conversationText.update()
+                conversationFlickable.update()
             })
         }
     }

--- a/qml/pages/DialingAssistantPage.qml
+++ b/qml/pages/DialingAssistantPage.qml
@@ -131,28 +131,6 @@ Page {
             // Reset scroll position when visible
             onVisibleChanged: if (visible) contentY = 0
 
-            // Mobile render thread can stay asleep when text updates from a
-            // network reply — force a scene graph repaint so the reply appears
-            // without requiring a touch to wake the render loop.
-            Connections {
-                target: MainController.aiManager ? MainController.aiManager.conversation : null
-                function onResponseReceived() {
-                    Qt.callLater(function() {
-                        recommendationText.update()
-                        recommendationFlickable.update()
-                    })
-                }
-            }
-            Connections {
-                target: MainController.aiManager
-                function onRecommendationReceived() {
-                    Qt.callLater(function() {
-                        recommendationText.update()
-                        recommendationFlickable.update()
-                    })
-                }
-            }
-
             TextArea {
                 id: recommendationText
                 width: parent.width
@@ -343,6 +321,13 @@ Page {
         function onRecommendationReceived(recommendation) {
             // Reset scroll to top when new recommendation arrives
             recommendationFlickable.contentY = 0
+            // Mobile render thread can stay asleep when a property changes from a
+            // network reply — force a scene graph repaint so the reply appears
+            // without requiring a touch to wake the render loop.
+            Qt.callLater(function() {
+                recommendationText.update()
+                recommendationFlickable.update()
+            })
         }
         function onErrorOccurred(error) {
             // Stay on this page to show the error
@@ -359,6 +344,9 @@ Page {
             // Scroll to top of the new response so it's readable from the start
             Qt.callLater(function() {
                 recommendationFlickable.contentY = Math.max(0, _preResponseHeight)
+                // See onRecommendationReceived for render-thread wakeup rationale.
+                recommendationText.update()
+                recommendationFlickable.update()
             })
         }
         function onErrorOccurred(error) {

--- a/qml/pages/DialingAssistantPage.qml
+++ b/qml/pages/DialingAssistantPage.qml
@@ -131,6 +131,28 @@ Page {
             // Reset scroll position when visible
             onVisibleChanged: if (visible) contentY = 0
 
+            // Mobile render thread can stay asleep when text updates from a
+            // network reply — force a scene graph repaint so the reply appears
+            // without requiring a touch to wake the render loop.
+            Connections {
+                target: MainController.aiManager ? MainController.aiManager.conversation : null
+                function onResponseReceived() {
+                    Qt.callLater(function() {
+                        recommendationText.update()
+                        recommendationFlickable.update()
+                    })
+                }
+            }
+            Connections {
+                target: MainController.aiManager
+                function onRecommendationReceived() {
+                    Qt.callLater(function() {
+                        recommendationText.update()
+                        recommendationFlickable.update()
+                    })
+                }
+            }
+
             TextArea {
                 id: recommendationText
                 width: parent.width

--- a/qml/pages/settings/SettingsAITab.qml
+++ b/qml/pages/settings/SettingsAITab.qml
@@ -1174,9 +1174,11 @@ KeyboardAwareContainer {
         }
 
         property real _preResponseHeight: 0
+        property bool _waitingForResponse: false
         Connections {
             target: MainController.aiManager?.conversation ?? null
             function onResponseReceived() {
+                conversationOverlay._waitingForResponse = false
                 // Scroll to top of the new response
                 Qt.callLater(function() {
                     conversationFlickable.contentY = Math.max(0, conversationOverlay._preResponseHeight)
@@ -1187,9 +1189,16 @@ KeyboardAwareContainer {
                     conversationFlickable.update()
                 })
             }
+            function onErrorOccurred() {
+                conversationOverlay._waitingForResponse = false
+            }
             function onHistoryChanged() {
-                // Save height before updating — this is where the new response will start
-                conversationOverlay._preResponseHeight = conversationText.contentHeight
+                // Only save the scroll target when the user sends (before response arrives).
+                // The response also triggers historyChanged, but we handle that in onResponseReceived.
+                if (!conversationOverlay._waitingForResponse) {
+                    conversationOverlay._preResponseHeight = conversationText.contentHeight
+                    conversationOverlay._waitingForResponse = true
+                }
                 conversationText.text = MainController.aiManager?.conversation?.getConversationText() ?? ""
                 // Scroll to bottom to show user's message / thinking indicator
                 Qt.callLater(function() {

--- a/qml/pages/settings/SettingsAITab.qml
+++ b/qml/pages/settings/SettingsAITab.qml
@@ -1180,6 +1180,11 @@ KeyboardAwareContainer {
                 // Scroll to top of the new response
                 Qt.callLater(function() {
                     conversationFlickable.contentY = Math.max(0, conversationOverlay._preResponseHeight)
+                    // Mobile render thread can stay asleep when text updates from a
+                    // network reply — force a scene graph repaint so the reply
+                    // appears without requiring a touch to wake the render loop.
+                    conversationText.update()
+                    conversationFlickable.update()
                 })
             }
             function onHistoryChanged() {
@@ -1189,6 +1194,8 @@ KeyboardAwareContainer {
                 // Scroll to bottom to show user's message / thinking indicator
                 Qt.callLater(function() {
                     conversationFlickable.contentY = Math.max(0, conversationFlickable.contentHeight - conversationFlickable.height)
+                    conversationText.update()
+                    conversationFlickable.update()
                 })
             }
         }


### PR DESCRIPTION
## Summary
- On iOS and Android, AI replies frequently don't appear until the user taps the screen. The signal flow and imperative text update work correctly — only the repaint is missing because the Qt Quick render thread stays asleep when a property changes from a network reply.
- Fix: call `update()` on the TextArea and enclosing Flickable inside the existing `Qt.callLater` scroll handlers, for `responseReceived` / `historyChanged` / `recommendationReceived` across the three AI surfaces.
- Item-level `update()` is a no-op on desktop (render loop already wakes on binding changes), so no behavior change there.

Files:
- `qml/components/ConversationOverlay.qml` — shot-detail + post-shot AI conversation
- `qml/pages/settings/SettingsAITab.qml` — settings AI conversation panel
- `qml/pages/DialingAssistantPage.qml` — dial-in recommendation page

## Test plan
- [ ] Android: open AI conversation from a shot, send a message, wait for reply — confirm it appears without touching the screen.
- [ ] iOS: same flow.
- [ ] Settings → AI → in-panel conversation: send a message, confirm reply appears automatically.
- [ ] Dialing Assistant page: trigger a recommendation, confirm text appears without tapping.
- [ ] Desktop (macOS/Windows): regression check — conversation still flows normally, scroll positions still behave, no flicker.

Confidence: moderate (~50%) — diagnosis of render-thread suspension matches the "appears on tap" symptom, but unreproduced locally. If the item-level `update()` isn't enough, next step is escalating to `Window.window.update()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)