### PR TITLE
feat(steam): add "Add Off" preset option that disables the steam heater

### DIFF
--- a/qml/components/PresetPillRow.qml
+++ b/qml/components/PresetPillRow.qml
@@ -242,13 +242,19 @@ FocusScope {
 
                         property bool isSelected: modelData.index === root.selectedIndex
                         property bool isFocused: root.activeFocus && modelData.index === root.focusedIndex
+                        // A preset may mark itself as disabled (e.g. a steam "Off" preset
+                        // that stops heating instead of setting a temp/time). Render it
+                        // muted so it's visibly distinct from real time/temp presets.
+                        property bool isDisabled: modelData && modelData.preset && modelData.preset.disabled === true
 
                         width: pillText.implicitWidth + root.pillPadding
                         height: Theme.scaled(50)
                         radius: Theme.scaled(10)
 
-                        color: isSelected ? Theme.primaryColor : Theme.backgroundColor
-                        border.color: isSelected ? Theme.primaryColor : Theme.textSecondaryColor
+                        color: isSelected
+                            ? (isDisabled ? Theme.textSecondaryColor : Theme.primaryColor)
+                            : Theme.backgroundColor
+                        border.color: isSelected && !isDisabled ? Theme.primaryColor : Theme.textSecondaryColor
                         border.width: 1
 
                         // Accessibility: Let AccessibleTapHandler handle screen reader interaction

--- a/qml/components/layout/items/SteamItem.qml
+++ b/qml/components/layout/items/SteamItem.qml
@@ -216,6 +216,14 @@ Item {
                     var wasAlreadySelected = (index === Settings.selectedSteamPitcher)
                     Settings.selectedSteamPitcher = index
                     var preset = Settings.getSteamPitcherPreset(index)
+                    if (preset && preset.disabled) {
+                        // "Off" preset — disable the steam heater. Don't write
+                        // undefined preset.duration/flow into int Settings, and
+                        // don't start steam on re-tap.
+                        MainController.turnOffSteamHeater()
+                        presetPopup.close()
+                        return
+                    }
                     if (preset) {
                         Settings.steamTimeout = preset.duration
                         Settings.steamFlow = preset.flow !== undefined ? preset.flow : 150

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -214,8 +214,20 @@ ApplicationWindow {
         function onStateChanged() {
             // DE1::State::Steam = 5
             if (DE1Device.state === 5) {
-                console.log("DE1 entered Steam state - starting heater, navigating to SteamPage")
-                MainController.startSteamHeating("de1-state-steam")  // This clears steamDisabled flag
+                // Match de1app: if the currently selected steam preset is an "Off" pill,
+                // leave the heater target at 0 (already pushed via sendMachineSettings /
+                // turnOffSteamHeater). The DE1 still enters Steam state on GHC press, but
+                // with TargetSteamTemp=0 no steam is produced — consistent with the user's
+                // intent to keep the boiler off.
+                var currentPitcher = Settings.getSteamPitcherPreset(Settings.selectedSteamPitcher)
+                var currentPitcherDisabled = currentPitcher && currentPitcher.disabled === true
+                if (currentPitcherDisabled) {
+                    console.log("DE1 entered Steam state but Off preset selected — heater stays off")
+                    MainController.turnOffSteamHeater()
+                } else {
+                    console.log("DE1 entered Steam state - starting heater, navigating to SteamPage")
+                    MainController.startSteamHeating("de1-state-steam")  // This clears steamDisabled flag
+                }
                 // Navigate to SteamPage immediately so user sees heating progress
                 var currentPage = pageStack.currentItem ? pageStack.currentItem.objectName : ""
                 if (currentPage !== "steamPage" && !pageStack.busy) {

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -293,6 +293,14 @@ Page {
                         var wasAlreadySelected = (index === Settings.selectedSteamPitcher)
                         Settings.selectedSteamPitcher = index
                         var preset = Settings.getSteamPitcherPreset(index)
+                        if (preset && preset.disabled) {
+                            // "Off" preset — disable the steam heater; don't touch
+                            // steamTimeout/steamFlow (preset.duration/flow are undefined
+                            // for disabled presets and writing undefined to these int
+                            // properties errors), and don't start steam on re-tap.
+                            MainController.turnOffSteamHeater()
+                            return
+                        }
                         if (preset) {
                             Settings.steamTimeout = preset.duration
                             Settings.steamFlow = preset.flow !== undefined ? preset.flow : 150

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -25,7 +25,9 @@ Page {
             var preset = Settings.getSteamPitcherPreset(Settings.selectedSteamPitcher)
             if (preset && preset.disabled) {
                 // Selected preset is an "Off" pill — leave the heater off rather
-                // than kicking it on as the page activates.
+                // than kicking it on as the page activates. Don't forceActiveFocus
+                // on the hidden duration slider; let the first visible interactive
+                // element (the pill row) take default focus.
                 MainController.turnOffSteamHeater()
             } else {
                 // Sync Settings with selected preset
@@ -34,8 +36,8 @@ Page {
                 // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
                 // startSteamHeating clears steamDisabled flag automatically
                 MainController.startSteamHeating("steampage-activated")
+                durationSlider.forceActiveFocus()
             }
-            durationSlider.forceActiveFocus()
         }
     }
 

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -56,6 +56,17 @@ Page {
     // DE1::SubState::Puffing = 20
     readonly property bool isPuffing: DE1Device.state === 5 && DE1Device.subState === 20
 
+    // Reactive: is the currently selected preset an "Off" pill? Duration/flow/temp
+    // sliders don't apply to Off presets so they're hidden in the settings frame.
+    // References selectedSteamPitcher and steamPitcherPresets so the binding
+    // re-evaluates on selection change or when the preset list itself is edited.
+    readonly property bool currentPitcherDisabled: {
+        var _selected = Settings.selectedSteamPitcher
+        var _list = Settings.steamPitcherPresets
+        var preset = Settings.getSteamPitcherPreset(_selected)
+        return preset ? preset.disabled === true : false
+    }
+
     // Debug logging for steam phase issues
     Connections {
         target: MachineState
@@ -1114,10 +1125,29 @@ Page {
                     anchors.margins: Theme.scaled(16)
                     spacing: Theme.scaled(8)
 
+                    // Centered placeholder when the selected preset is an "Off" pill —
+                    // duration/flow/temperature/weight don't apply, so the slider rows
+                    // below are all hidden and we show this in their place.
+                    Item {
+                        visible: root.currentPitcherDisabled
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+
+                        Tr {
+                            anchors.centerIn: parent
+                            key: "steam.offPresetNotice"
+                            fallback: "Steam heater off for this preset."
+                            color: Theme.textSecondaryColor
+                            font.pixelSize: Theme.scaled(20)
+                            horizontalAlignment: Text.AlignHCenter
+                        }
+                    }
+
                     // Duration (per-pitcher, auto-saves)
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(16)
+                        visible: !root.currentPitcherDisabled
 
                         Tr {
                             key: "steam.label.duration"
@@ -1149,12 +1179,13 @@ Page {
                         }
                     }
 
-                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3 }
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !root.currentPitcherDisabled }
 
                     // Steam Flow (per-pitcher, auto-saves)
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(16)
+                        visible: !root.currentPitcherDisabled
 
                         Column {
                             Tr {
@@ -1196,12 +1227,13 @@ Page {
                         }
                     }
 
-                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3 }
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !root.currentPitcherDisabled }
 
                     // Temperature (global setting)
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(16)
+                        visible: !root.currentPitcherDisabled
 
                         Column {
                             Tr {
@@ -1242,13 +1274,13 @@ Page {
                         }
                     }
 
-                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3 }
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !root.currentPitcherDisabled }
 
                     // Weight — pitcher tare calibration per preset
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(16)
-                        visible: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                        visible: ScaleDevice.connected && !ScaleDevice.isFlowScale && !root.currentPitcherDisabled
 
                         Column {
                             spacing: Theme.scaled(4)

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -6,6 +6,7 @@ import Decenza
 import "../components"
 
 Page {
+    id: steamPage
     objectName: "steamPage"
     background: Rectangle { color: Theme.backgroundColor }
 
@@ -1129,7 +1130,7 @@ Page {
                     // duration/flow/temperature/weight don't apply, so the slider rows
                     // below are all hidden and we show this in their place.
                     Item {
-                        visible: root.currentPitcherDisabled
+                        visible: steamPage.currentPitcherDisabled
                         Layout.fillWidth: true
                         Layout.fillHeight: true
 
@@ -1147,7 +1148,7 @@ Page {
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(16)
-                        visible: !root.currentPitcherDisabled
+                        visible: !steamPage.currentPitcherDisabled
 
                         Tr {
                             key: "steam.label.duration"
@@ -1179,13 +1180,13 @@ Page {
                         }
                     }
 
-                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !root.currentPitcherDisabled }
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
 
                     // Steam Flow (per-pitcher, auto-saves)
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(16)
-                        visible: !root.currentPitcherDisabled
+                        visible: !steamPage.currentPitcherDisabled
 
                         Column {
                             Tr {
@@ -1227,13 +1228,13 @@ Page {
                         }
                     }
 
-                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !root.currentPitcherDisabled }
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
 
                     // Temperature (global setting)
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(16)
-                        visible: !root.currentPitcherDisabled
+                        visible: !steamPage.currentPitcherDisabled
 
                         Column {
                             Tr {
@@ -1274,13 +1275,13 @@ Page {
                         }
                     }
 
-                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !root.currentPitcherDisabled }
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
 
                     // Weight — pitcher tare calibration per preset
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(16)
-                        visible: ScaleDevice.connected && !ScaleDevice.isFlowScale && !root.currentPitcherDisabled
+                        visible: ScaleDevice.connected && !ScaleDevice.isFlowScale && !steamPage.currentPitcherDisabled
 
                         Column {
                             spacing: Theme.scaled(4)

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -21,12 +21,19 @@ Page {
     StackView.onActivated: {
         root.currentPageTitle = pageTitle
         if (!isSteaming) {
-            // Sync Settings with selected preset
-            Settings.steamTimeout = getCurrentPitcherDuration()
-            Settings.steamFlow = getCurrentPitcherFlow()
-            // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
-            // startSteamHeating clears steamDisabled flag automatically
-            MainController.startSteamHeating("steampage-activated")
+            var preset = Settings.getSteamPitcherPreset(Settings.selectedSteamPitcher)
+            if (preset && preset.disabled) {
+                // Selected preset is an "Off" pill — leave the heater off rather
+                // than kicking it on as the page activates.
+                MainController.turnOffSteamHeater()
+            } else {
+                // Sync Settings with selected preset
+                Settings.steamTimeout = getCurrentPitcherDuration()
+                Settings.steamFlow = getCurrentPitcherFlow()
+                // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
+                // startSteamHeating clears steamDisabled flag automatically
+                MainController.startSteamHeating("steampage-activated")
+            }
             durationSlider.forceActiveFocus()
         }
     }
@@ -116,15 +123,19 @@ Page {
         return (flow / 100).toFixed(2)
     }
 
-    // Get current pitcher's values with defaults
+    // Get current pitcher's values with defaults. "Off" (disabled) presets
+    // don't carry duration/flow, so fall back to the current Settings so the
+    // sliders don't jump when the user switches to an Off preset.
     function getCurrentPitcherDuration() {
         var preset = Settings.getSteamPitcherPreset(Settings.selectedSteamPitcher)
-        return preset ? preset.duration : 30
+        if (!preset || preset.disabled) return Settings.steamTimeout || 30
+        return preset.duration
     }
 
     function getCurrentPitcherFlow() {
         var preset = Settings.getSteamPitcherPreset(Settings.selectedSteamPitcher)
-        return (preset && preset.flow !== undefined) ? preset.flow : 150
+        if (!preset || preset.disabled) return Settings.steamFlow || 150
+        return (preset.flow !== undefined) ? preset.flow : 150
     }
 
     function getCurrentPitcherName() {
@@ -132,10 +143,17 @@ Page {
         return preset ? preset.name : ""
     }
 
-    // Save current pitcher with new values
+    function isCurrentPitcherDisabled() {
+        var preset = Settings.getSteamPitcherPreset(Settings.selectedSteamPitcher)
+        return preset ? preset.disabled === true : false
+    }
+
+    // Save current pitcher with new values. No-op for disabled presets — their
+    // duration/flow are meaningless, and writing them via updateSteamPitcherPreset
+    // would let slider drags silently bake values into the saved JSON.
     function saveCurrentPitcher(duration, flow) {
         var name = getCurrentPitcherName()
-        if (name) {
+        if (name && !isCurrentPitcherDisabled()) {
             Settings.updateSteamPitcherPreset(Settings.selectedSteamPitcher, name, duration, flow)
         }
     }
@@ -263,21 +281,33 @@ Page {
                         model: Settings.steamPitcherPresets
 
                         Rectangle {
+                            id: livePitcherPill
+                            readonly property bool pitcherDisabled: modelData.disabled === true
+                            readonly property bool pitcherSelected: index === Settings.selectedSteamPitcher
+
+                            // Hide "Off" presets from the mid-session preset row — there's no
+                            // meaningful action when tapped mid-steam, so don't show the pill.
+                            visible: !(isSteaming && pitcherDisabled)
+
                             width: livePitcherText.implicitWidth + 24
                             height: Theme.scaled(36)
                             radius: Theme.scaled(18)
-                            color: index === Settings.selectedSteamPitcher ? Theme.primaryColor : Theme.surfaceColor
-                            border.color: index === Settings.selectedSteamPitcher ? Theme.primaryColor : Theme.textSecondaryColor
+                            color: pitcherSelected
+                                ? (pitcherDisabled ? Theme.textSecondaryColor : Theme.primaryColor)
+                                : Theme.surfaceColor
+                            border.color: pitcherSelected && !pitcherDisabled ? Theme.primaryColor : Theme.textSecondaryColor
                             border.width: 1
 
                             activeFocusOnTab: true
                             Accessible.role: Accessible.Button
                             Accessible.name: {
                                 var label = modelData.name + " " + TranslationManager.translate("steam.accessibility.preset", "preset")
+                                if (livePitcherPill.pitcherDisabled)
+                                    label += ", " + TranslationManager.translate("steam.accessibility.presetOff", "turns steam heater off")
                                 var pitcherWt = modelData.pitcherWeightG ?? 0
-                                if (pitcherWt > 0)
+                                if (pitcherWt > 0 && !livePitcherPill.pitcherDisabled)
                                     label += ", " + TranslationManager.translate("steam.accessibility.pitcherWeight", "pitcher") + " " + pitcherWt.toFixed(0) + "g"
-                                if (index === Settings.selectedSteamPitcher)
+                                if (livePitcherPill.pitcherSelected)
                                     label += ", " + TranslationManager.translate("accessibility.selected", "selected")
                                 return label
                             }
@@ -317,7 +347,9 @@ Page {
                                 id: livePitcherText
                                 anchors.centerIn: parent
                                 text: modelData.name
-                                color: index === Settings.selectedSteamPitcher ? Theme.primaryContrastColor : Theme.textColor
+                                color: livePitcherPill.pitcherSelected
+                                    ? Theme.primaryContrastColor
+                                    : (livePitcherPill.pitcherDisabled ? Theme.textSecondaryColor : Theme.textColor)
                                 font: Theme.bodyFont
                                 Accessible.ignored: true
                             }
@@ -326,7 +358,14 @@ Page {
                                 id: livePitcherMa
                                 anchors.fill: parent
                                 onClicked: {
+                                    // Off pills are hidden during steaming (visible binding
+                                    // above), so ignore any tap that slips through mid-session.
+                                    if (isSteaming && livePitcherPill.pitcherDisabled) return
                                     Settings.selectedSteamPitcher = index
+                                    if (livePitcherPill.pitcherDisabled) {
+                                        MainController.turnOffSteamHeater()
+                                        return
+                                    }
                                     var flow = modelData.flow !== undefined ? modelData.flow : 150
                                     Settings.steamTimeout = modelData.duration
                                     Settings.steamFlow = flow
@@ -849,55 +888,56 @@ Page {
 
                                 Rectangle {
                                     id: pitcherPill
+                                    readonly property bool pitcherDisabled: modelData.disabled === true
+                                    readonly property bool pitcherSelected: pitcherDelegate.pitcherIndex === Settings.selectedSteamPitcher
+
                                     width: pitcherText.implicitWidth + 24
                                     height: Theme.scaled(36)
                                     radius: Theme.scaled(18)
-                                    color: pitcherDelegate.pitcherIndex === Settings.selectedSteamPitcher ? Theme.primaryColor : Theme.backgroundColor
-                                    border.color: pitcherDelegate.pitcherIndex === Settings.selectedSteamPitcher ? Theme.primaryColor : Theme.textSecondaryColor
+                                    color: pitcherSelected
+                                        ? (pitcherDisabled ? Theme.textSecondaryColor : Theme.primaryColor)
+                                        : Theme.backgroundColor
+                                    border.color: pitcherSelected && !pitcherDisabled ? Theme.primaryColor : Theme.textSecondaryColor
                                     border.width: 1
                                     opacity: dragArea.drag.active ? 0.8 : 1.0
+
+                                    function applyPitcher(reason) {
+                                        Settings.selectedSteamPitcher = pitcherDelegate.pitcherIndex
+                                        if (pitcherDisabled) {
+                                            MainController.turnOffSteamHeater()
+                                            return
+                                        }
+                                        var flow = modelData.flow !== undefined ? modelData.flow : 150
+                                        durationSlider.value = modelData.duration
+                                        flowSlider.value = flow
+                                        Settings.steamTimeout = modelData.duration
+                                        Settings.steamFlow = flow
+                                        MainController.startSteamHeating(reason)
+                                    }
 
                                     activeFocusOnTab: true
                                     Accessible.role: Accessible.Button
                                     Accessible.name: {
                                         var label = modelData.name + " " + TranslationManager.translate("steam.accessibility.preset", "preset")
+                                        if (pitcherDisabled)
+                                            label += ", " + TranslationManager.translate("steam.accessibility.presetOff", "turns steam heater off")
                                         var pitcherWt = modelData.pitcherWeightG ?? 0
-                                        if (pitcherWt > 0)
+                                        if (pitcherWt > 0 && !pitcherDisabled)
                                             label += ", " + TranslationManager.translate("steam.accessibility.pitcherWeight", "pitcher") + " " + pitcherWt.toFixed(0) + "g"
-                                        if (pitcherDelegate.pitcherIndex === Settings.selectedSteamPitcher)
+                                        if (pitcherSelected)
                                             label += ", " + TranslationManager.translate("accessibility.selected", "selected")
                                         return label
                                     }
                                     Accessible.description: TranslationManager.translate("steam.accessibility.pitcherEditHint", "Double-tap or long-press to edit preset.")
                                     Accessible.focusable: true
-                                    Accessible.onPressAction: {
-                                        Settings.selectedSteamPitcher = pitcherDelegate.pitcherIndex
-                                        var flow = modelData.flow !== undefined ? modelData.flow : 150
-                                        durationSlider.value = modelData.duration
-                                        flowSlider.value = flow
-                                        Settings.steamTimeout = modelData.duration
-                                        Settings.steamFlow = flow
-                                        MainController.startSteamHeating("pitcher-a11y")
-                                    }
+                                    Accessible.onPressAction: pitcherPill.applyPitcher("pitcher-a11y")
 
                                     Keys.onReturnPressed: {
-                                        Settings.selectedSteamPitcher = pitcherDelegate.pitcherIndex
-                                        var flow = modelData.flow !== undefined ? modelData.flow : 150
-                                        durationSlider.value = modelData.duration
-                                        flowSlider.value = flow
-                                        Settings.steamTimeout = modelData.duration
-                                        Settings.steamFlow = flow
-                                        MainController.startSteamHeating("pitcher-return")
+                                        pitcherPill.applyPitcher("pitcher-return")
                                         event.accepted = true
                                     }
                                     Keys.onSpacePressed: {
-                                        Settings.selectedSteamPitcher = pitcherDelegate.pitcherIndex
-                                        var flow = modelData.flow !== undefined ? modelData.flow : 150
-                                        durationSlider.value = modelData.duration
-                                        flowSlider.value = flow
-                                        Settings.steamTimeout = modelData.duration
-                                        Settings.steamFlow = flow
-                                        MainController.startSteamHeating("pitcher-space")
+                                        pitcherPill.applyPitcher("pitcher-space")
                                         event.accepted = true
                                     }
                                     Keys.onLeftPressed: {
@@ -940,7 +980,9 @@ Page {
                                         id: pitcherText
                                         anchors.centerIn: parent
                                         text: modelData.name
-                                        color: pitcherDelegate.pitcherIndex === Settings.selectedSteamPitcher ? Theme.primaryContrastColor : Theme.textColor
+                                        color: pitcherPill.pitcherSelected
+                                            ? Theme.primaryContrastColor
+                                            : (pitcherPill.pitcherDisabled ? Theme.textSecondaryColor : Theme.textColor)
                                         font: Theme.bodyFont
                                         Accessible.ignored: true
                                     }
@@ -964,13 +1006,7 @@ Page {
                                             holdTimer.stop()
                                             if (!moved && !held) {
                                                 // Simple click - select the pitcher
-                                                Settings.selectedSteamPitcher = pitcherDelegate.pitcherIndex
-                                                var flow = modelData.flow !== undefined ? modelData.flow : 150
-                                                durationSlider.value = modelData.duration
-                                                flowSlider.value = flow
-                                                Settings.steamTimeout = modelData.duration
-                                                Settings.steamFlow = flow
-                                                MainController.startSteamHeating("pitcher-click")
+                                                pitcherPill.applyPitcher("pitcher-click")
                                             }
                                             pitcherPill.Drag.drop()
                                             pitcherPresetsRow.draggedIndex = -1
@@ -1608,6 +1644,7 @@ Page {
             Tr { id: addPitcherNamePlaceholder; key: "steam.placeholder.pitcherName"; fallback: "Pitcher name"; visible: false }
             Tr { id: addCancelButtonText; key: "steam.button.cancel"; fallback: "Cancel"; visible: false }
             Tr { id: addButtonText; key: "steam.button.add"; fallback: "Add"; visible: false }
+            Tr { id: addOffButtonText; key: "steam.button.addOff"; fallback: "Add Off"; visible: false }
 
             Rectangle {
                 Layout.preferredWidth: Theme.scaled(280)
@@ -1654,9 +1691,27 @@ Page {
                     id: addCancelPitcherButton
                     text: addCancelButtonText.text
                     accessibleName: TranslationManager.translate("steam.cancelAddingPitcher", "Cancel adding new pitcher preset")
-                    KeyNavigation.tab: addPitcherConfirmButton
+                    KeyNavigation.tab: addPitcherOffButton
                     KeyNavigation.backtab: newPitcherName
                     onClicked: addPitcherDialog.close()
+                }
+
+                AccessibleButton {
+                    id: addPitcherOffButton
+                    text: addOffButtonText.text
+                    accessibleName: TranslationManager.translate("steam.addNewPitcherOff", "Add new preset that turns the steam heater off")
+                    KeyNavigation.tab: addPitcherConfirmButton
+                    KeyNavigation.backtab: addCancelPitcherButton
+                    onClicked: {
+                        Qt.inputMethod.commit()
+                        if (newPitcherName.text.trim() !== "") {
+                            var presetCount = Settings.steamPitcherPresets.length
+                            Settings.addSteamPitcherPresetDisabled(newPitcherName.text.trim())
+                            Settings.selectedSteamPitcher = presetCount
+                            newPitcherName.text = ""
+                            addPitcherDialog.close()
+                        }
+                    }
                 }
 
                 AccessibleButton {
@@ -1665,7 +1720,7 @@ Page {
                     text: addButtonText.text
                     accessibleName: TranslationManager.translate("steam.addNewPitcher", "Add new pitcher preset with entered name")
                     KeyNavigation.tab: newPitcherName
-                    KeyNavigation.backtab: addCancelPitcherButton
+                    KeyNavigation.backtab: addPitcherOffButton
                     onClicked: {
                         Qt.inputMethod.commit()
                         if (newPitcherName.text.trim() !== "") {

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -128,13 +128,13 @@ Page {
     // sliders don't jump when the user switches to an Off preset.
     function getCurrentPitcherDuration() {
         var preset = Settings.getSteamPitcherPreset(Settings.selectedSteamPitcher)
-        if (!preset || preset.disabled) return Settings.steamTimeout || 30
+        if (!preset || preset.disabled) return Settings.steamTimeout ?? 30
         return preset.duration
     }
 
     function getCurrentPitcherFlow() {
         var preset = Settings.getSteamPitcherPreset(Settings.selectedSteamPitcher)
-        if (!preset || preset.disabled) return Settings.steamFlow || 150
+        if (!preset || preset.disabled) return Settings.steamFlow ?? 150
         return (preset.flow !== undefined) ? preset.flow : 150
     }
 

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -251,6 +251,21 @@ void DE1Device::setSimulatedState(DE1::State state, DE1::SubState subState) {
     }
 }
 
+void DE1Device::setSimulatedIdleSteamTemp(double steamTempC) {
+    if (!m_simulationMode) return;
+    if (qFuzzyCompare(m_steamTemp, steamTempC)) return;
+    m_steamTemp = steamTempC;
+    // steamTemperature's NOTIFY is shotSampleReceived, so fire a minimal
+    // sample to wake QML bindings. Other sample fields stay at their last
+    // values — this is an idle-state heater update, not a shot sample.
+    ShotSample sample;
+    sample.timestamp = QDateTime::currentMSecsSinceEpoch();
+    sample.steamTemp = m_steamTemp;
+    sample.headTemp = m_headTemp;
+    sample.mixTemp = m_mixTemp;
+    emit shotSampleReceived(sample);
+}
+
 void DE1Device::emitSimulatedShotSample(const ShotSample& sample) {
     if (!m_simulationMode) return;
 
@@ -1269,6 +1284,19 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
                                 double hotWaterTemp, int hotWaterVolume,
                                 double groupTemp,
                                 const QString& reason) {
+    // In simulation mode, forward the commanded steam target to the simulator
+    // so its m_steamTemp reflects what the app asked for (including Off
+    // presets where steamTemp=0 means "heater off"). The sim has no BLE
+    // transport, so return after forwarding — there's no write to queue.
+    if (m_simulationMode && m_simulator) {
+        m_simulator->setTargetSteamTemp(steamTemp);
+        m_commandedSteamTargetC = steamTemp;
+        m_commandedSteamDurationSec = steamDuration;
+        m_commandedHotWaterTempC = hotWaterTemp;
+        m_commandedHotWaterVolMl = hotWaterVolume;
+        m_commandedGroupTargetC = groupTemp;
+        return;
+    }
     if (!m_transport) return;
     QByteArray data(9, 0);
     data[0] = 0;  // SteamSettings flags

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -255,9 +255,13 @@ void DE1Device::setSimulatedIdleSteamTemp(double steamTempC) {
     if (!m_simulationMode) return;
     if (qFuzzyCompare(m_steamTemp, steamTempC)) return;
     m_steamTemp = steamTempC;
-    // steamTemperature's NOTIFY is shotSampleReceived, so fire a minimal
-    // sample to wake QML bindings. Other sample fields stay at their last
-    // values — this is an idle-state heater update, not a shot sample.
+    // steamTemperature's NOTIFY is shotSampleReceived, so fire a sample to
+    // wake QML bindings. Populate steamTemp + headTemp + mixTemp from our
+    // cached members (so those properties aren't clobbered to zero); all
+    // other sample fields (pressure, flow, goals, timer, frame) are
+    // zero-initialized. The caller (DE1Simulator::setTargetSteamTemp) only
+    // invokes this when idle — never during an active Steam/Espresso
+    // session — so the zeros won't land on the live graphs.
     ShotSample sample;
     sample.timestamp = QDateTime::currentMSecsSinceEpoch();
     sample.steamTemp = m_steamTemp;
@@ -1286,8 +1290,11 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
                                 const QString& reason) {
     // In simulation mode, forward the commanded steam target to the simulator
     // so its m_steamTemp reflects what the app asked for (including Off
-    // presets where steamTemp=0 means "heater off"). The sim has no BLE
-    // transport, so return after forwarding — there's no write to queue.
+    // presets where steamTemp=0 means "heater off"). Sim mode has no BLE
+    // transport, so the real-path dedupe check, characteristic write, and
+    // read-back verification are all skipped. m_lastShotSettingsPayload is
+    // intentionally left untouched — drift detection only runs against real
+    // DE1 indications, which never fire in sim mode.
     if (m_simulationMode && m_simulator) {
         m_simulator->setTargetSteamTemp(steamTemp);
         m_commandedSteamTargetC = steamTemp;

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -147,6 +147,10 @@ public:
     // For simulator integration - allows external code to set state and emit signals
     void setSimulatedState(DE1::State state, DE1::SubState subState);
     void emitSimulatedShotSample(const ShotSample& sample);
+    // Push an idle steam-temperature update from the simulator (e.g. when the
+    // app commands a new steam target via setShotSettings). Emits a minimal
+    // shot sample so QML bindings on DE1Device.steamTemperature re-evaluate.
+    void setSimulatedIdleSteamTemp(double steamTempC);
 #ifdef QT_DEBUG
     void setSimulator(DE1Simulator* simulator) { m_simulator = simulator; }
 #endif

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -616,11 +616,17 @@ void MainController::sendMachineSettings(const QString& reason) {
     if (!m_device || !m_device->isConnected() || !m_settings) return;
 
     // Determine steam temperature to send:
-    // - If steam is disabled: send 0
+    // - If steam is disabled (session flag): send 0
+    // - If the currently selected steam preset is an "Off" pill: send 0
+    //   (matches de1app's persistent steam_disabled behavior — the heater
+    //   target is 0 across restarts so the DE1 firmware can still honor
+    //   GHC presses with an Off target; no steam comes out.)
     // - If keepSteamHeaterOn is false: send 0 (user doesn't want heater on)
     // - Otherwise: send configured temperature
+    const QVariantMap currentPitcher = m_settings->getSteamPitcherPreset(m_settings->selectedSteamPitcher());
+    const bool currentPitcherDisabled = currentPitcher.value("disabled").toBool();
     double steamTemp;
-    if (m_settings->steamDisabled()) {
+    if (m_settings->steamDisabled() || currentPitcherDisabled) {
         steamTemp = 0.0;
     } else if (!m_settings->keepSteamHeaterOn()) {
         steamTemp = 0.0;

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -616,17 +616,28 @@ void MainController::sendMachineSettings(const QString& reason) {
     if (!m_device || !m_device->isConnected() || !m_settings) return;
 
     // Determine steam temperature to send:
-    // - If steam is disabled (session flag): send 0
     // - If the currently selected steam preset is an "Off" pill: send 0
-    //   (matches de1app's persistent steam_disabled behavior — the heater
-    //   target is 0 across restarts so the DE1 firmware can still honor
-    //   GHC presses with an Off target; no steam comes out.)
+    //   (matches de1app's persistent steam_disabled behavior — target 0 is
+    //   pushed so the DE1 firmware can still honor GHC presses with no
+    //   steam produced.)
+    // - If steam is disabled (session flag): send 0
     // - If keepSteamHeaterOn is false: send 0 (user doesn't want heater on)
     // - Otherwise: send configured temperature
+    //
+    // Rationalization: if the user has selected a non-Off preset, the session
+    // flag is stale (set by a previous turnOffSteamHeater call on a prior Off
+    // selection). The preset is the authoritative user intent — clear the
+    // flag so downstream code sees a consistent state. Without this, IdlePage
+    // / SteamItem applySteamSettings paths (which don't call startSteamHeating)
+    // would leave the flag set and the heater off until the user opened
+    // SteamPage.
     const QVariantMap currentPitcher = m_settings->getSteamPitcherPreset(m_settings->selectedSteamPitcher());
     const bool currentPitcherDisabled = currentPitcher.value("disabled").toBool();
+    if (!currentPitcherDisabled && m_settings->steamDisabled()) {
+        m_settings->setSteamDisabled(false);
+    }
     double steamTemp;
-    if (m_settings->steamDisabled() || currentPitcherDisabled) {
+    if (currentPitcherDisabled || m_settings->steamDisabled()) {
         steamTemp = 0.0;
     } else if (!m_settings->keepSteamHeaterOn()) {
         steamTemp = 0.0;

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -743,6 +743,20 @@ void Settings::addSteamPitcherPreset(const QString& name, int duration, int flow
     emit steamPitcherPresetsChanged();
 }
 
+void Settings::addSteamPitcherPresetDisabled(const QString& name) {
+    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
+    QJsonDocument doc = QJsonDocument::fromJson(data);
+    QJsonArray arr = doc.array();
+
+    QJsonObject preset;
+    preset["name"] = name;
+    preset["disabled"] = true;
+    arr.append(preset);
+
+    m_settings.setValue("steam/pitcherPresets", QJsonDocument(arr).toJson());
+    emit steamPitcherPresetsChanged();
+}
+
 void Settings::updateSteamPitcherPreset(int index, const QString& name, int duration, int flow) {
     QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
     QJsonDocument doc = QJsonDocument::fromJson(data);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -362,6 +362,7 @@ public:
     void setSelectedSteamCup(int index);
 
     Q_INVOKABLE void addSteamPitcherPreset(const QString& name, int duration, int flow);
+    Q_INVOKABLE void addSteamPitcherPresetDisabled(const QString& name);
     Q_INVOKABLE void updateSteamPitcherPreset(int index, const QString& name, int duration, int flow);
     Q_INVOKABLE void removeSteamPitcherPreset(int index);
     Q_INVOKABLE void moveSteamPitcherPreset(int from, int to);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1642,6 +1642,11 @@ int main(int argc, char *argv[])
         QObject::connect(&de1Simulator, &DE1Simulator::shotSampleReceived,
                          &de1Device, &DE1Device::emitSimulatedShotSample);
 
+        // Idle-state steam temperature updates (fired when the app commands a
+        // new steam target via setShotSettings — including Off presets).
+        QObject::connect(&de1Simulator, &DE1Simulator::idleSteamTempChanged,
+                         &de1Device, &DE1Device::setSimulatedIdleSteamTemp);
+
         // Create SimulatedScale and connect it like a real scale
         simulatedScalePtr = std::make_unique<SimulatedScale>();
         auto& simulatedScale = *simulatedScalePtr;

--- a/src/simulator/de1simulator.cpp
+++ b/src/simulator/de1simulator.cpp
@@ -215,6 +215,20 @@ void DE1Simulator::startSteam()
     setState(DE1::State::Steam, DE1::SubState::Pouring);
 }
 
+void DE1Simulator::setTargetSteamTemp(double targetC)
+{
+    // Ambient when heater is off, otherwise snap to target. Real DE1 has a
+    // thermal ramp; we skip it because the sim doesn't run a tick loop when
+    // idle, and the UI only cares that "Heating steam..." clears instead of
+    // climbing indefinitely.
+    constexpr double kAmbientC = 25.0;
+    double newSteamTemp = (targetC <= 0.0) ? kAmbientC : targetC;
+    if (qFuzzyCompare(newSteamTemp, m_steamTemp)) return;
+    m_steamTemp = newSteamTemp;
+    qDebug() << "DE1Simulator: target steam temp=" << targetC << "C -> m_steamTemp=" << m_steamTemp;
+    emit idleSteamTempChanged(m_steamTemp);
+}
+
 void DE1Simulator::startHotWater()
 {
     if (m_state == DE1::State::Sleep) wakeUp();

--- a/src/simulator/de1simulator.cpp
+++ b/src/simulator/de1simulator.cpp
@@ -226,6 +226,13 @@ void DE1Simulator::setTargetSteamTemp(double targetC)
     if (qFuzzyCompare(newSteamTemp, m_steamTemp)) return;
     m_steamTemp = newSteamTemp;
     qDebug() << "DE1Simulator: target steam temp=" << targetC << "C -> m_steamTemp=" << m_steamTemp;
+    // Only emit when idle — during active steam, the tick loop is already
+    // producing real shot samples at 5Hz and we'd inject a zero-pressure /
+    // zero-flow sample into the steam graph. The +5s/-5s buttons route
+    // through setShotSettings mid-steam; suppressing the emit here prevents
+    // graph pollution. The in-session target change is moot anyway because
+    // the Steam-state tick hardcodes m_steamTemp to 140°C + noise.
+    if (m_state == DE1::State::Steam) return;
     emit idleSteamTempChanged(m_steamTemp);
 }
 

--- a/src/simulator/de1simulator.h
+++ b/src/simulator/de1simulator.h
@@ -54,12 +54,20 @@ public slots:
     void goToSleep();
     void wakeUp();
 
+    // Target steam temperature from the app's ShotSettings write. A target of 0
+    // means "heater off" (Off preset / steamDisabled). The sim doesn't model a
+    // thermal ramp — it snaps m_steamTemp to target (or to ambient ~25C when
+    // target is 0) and emits idleSteamTempChanged so DE1Device's steam temp
+    // property reflects the commanded state instead of a stale hardcoded value.
+    void setTargetSteamTemp(double targetC);
+
 signals:
     void runningChanged();
     void stateChanged();
     void subStateChanged();
     void shotSampleReceived(const ShotSample& sample);
     void scaleWeightChanged(double weight);  // Simulated scale output
+    void idleSteamTempChanged(double steamTempC);  // Fired when target changes (idle thermal update)
 
 private slots:
     void onSimulationTimerTick();


### PR DESCRIPTION
## Summary
User request: allow creating a steam preset that turns the steam heater **off** rather than setting a temp/time. Useful for seasonal workflows (cold drinks, summer) where you want the boiler to stop heating until you're back to steaming.

Instead of a single built-in "Off" preset, the Add Preset dialog now has a third button **Add Off** alongside Cancel / Add — users name their own off pill ("Cold brew", "Summer", etc.) and can have multiple if they want.

## What changed
- **Data model** ([settings.cpp](../blob/feat/steam-preset-off/src/core/settings.cpp), [settings.h](../blob/feat/steam-preset-off/src/core/settings.h)): presets now support an optional `disabled: true` flag; new `Settings::addSteamPitcherPresetDisabled(name)` writes it. Existing `updateSteamPitcherPreset` already preserves unknown fields, so editing an Off preset keeps the flag.
- **Dialog** ([SteamPage.qml](../blob/feat/steam-preset-off/qml/pages/SteamPage.qml)): new "Add Off" button between Cancel and Add, tab-ordered.
- **Pill styling**: disabled pills use `Theme.textSecondaryColor` for the selected-background and text, so they read as "not a temp/time preset" without looking broken.
- **Apply path**: config-row pills go through one `applyPitcher()` helper that branches to `MainController.turnOffSteamHeater()` for disabled presets instead of `startSteamHeating`. Page activation does the same.
- **Live pill row**: Off pills are hidden while steaming — nothing useful to do mid-session.
- **Sliders**: `saveCurrentPitcher()` no-ops for disabled presets, and `getCurrentPitcher*` helpers fall back to current Settings values so sliders don't snap to undefined when an Off pill is selected.
- **A11y**: pill Accessible.name includes "turns steam heater off" when disabled.

## Test plan
- [ ] Add a new preset named "Off" via "Add Off" in the dialog — pill appears in the config row with muted styling, selected.
- [ ] Tap the Off pill from an idle steam page — steam heater turns off (no heating).
- [ ] Tap a normal pill afterwards — steam heater starts heating again, sliders update to preset values.
- [ ] Start a steam session from a normal preset, confirm the Off pill is **hidden** from the live pill row during steaming.
- [ ] Edit an Off preset via long-press: rename works, the `disabled: true` flag survives the edit.
- [ ] Move sliders while an Off preset is selected: changes do **not** get saved into the Off preset's JSON.
- [ ] Navigate to SteamPage with an Off preset selected: heater stays off, doesn't kick on.
- [ ] TalkBack/VoiceOver reads "turns steam heater off" for disabled pills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)