### PR TITLE
fix(steam): restore mid-session SteamFlow control + verify-and-retry MMR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ Also in `docs/`:
 
 - **ADB path**: `/c/Users/Micro/AppData/Local/Android/Sdk/platform-tools/adb.exe`
 - **Uninstall app**: `adb uninstall io.github.kulitorum.decenza_de1`
-- **WiFi debugging**: `192.168.1.208:5555` (reconnect: `adb connect 192.168.1.208:5555`)
+- **WiFi debugging**: `192.168.1.212:5555` (reconnect: `adb connect 192.168.1.212:5555`). The DHCP lease can rotate — if reconnect fails, plug in USB and run `adb shell ip route | grep wlan` to read the current IP, then `adb tcpip 5555` + `adb connect <ip>:5555`.
 - **Qt version**: 6.10.3
 - **Qt path**: `C:/Qt/6.10.3/msvc2022_64`
 - **C++ standard**: C++17

--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -320,12 +320,26 @@ Item {
                         if (!isDragging && !hasMoved) {
                             scrubberPopup.open()
                         }
+                        // Commit on drag release. PR #782 added the
+                        // valueCommitted contract for the +/- buttons but
+                        // missed this MouseArea, so drags were updating
+                        // _dirtySinceCommit during onPositionChanged
+                        // (via _emitValueModified) without ever firing
+                        // commitValue() — silently dropping the BLE write
+                        // for every consumer that migrated to onValueCommitted.
+                        if (isDragging) {
+                            root.commitValue()
+                        }
                         isDragging = false
                         dragReady = false
                         hasMoved = false
                     }
 
                     onCanceled: {
+                        // Drag canceled (e.g. finger left the screen edge,
+                        // or another gesture stole focus). Don't commit —
+                        // this matches the +/- button onCanceled semantics
+                        // (treat cancel as "user changed their mind").
                         isDragging = false
                         dragReady = false
                         hasMoved = false

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -386,18 +386,19 @@ Page {
                                     if (!isSteaming) {
                                         MainController.startSteamHeating("live-pitcher-click")
                                     } else {
-                                        // Sync the live slider imperatively. Its binding to
-                                        // Settings.steamFlow gets broken the first time the
-                                        // user drags it (onValueModified writes value=newVal),
-                                        // so a Settings update from this preset tap won't
-                                        // reach the slider on its own.
-                                        steamingFlowSlider.value = flow
-                                        // Settings assignment alone only updates QSettings; the BLE
-                                        // MMR write to 0x803828 lives in MainController. Push the
-                                        // new flow immediately so the DE1 picks it up mid-session.
-                                        // Don't push timeout — the DE1's session timer is already
-                                        // running on the prior value and a mid-session timeout
-                                        // change risks an immediate stop if the new value is < elapsed.
+                                        // Re-bind the live slider to Settings.steamFlow using
+                                        // Qt.binding. The user's first drag on the slider
+                                        // imperatively writes value=newVal in onValueModified,
+                                        // which permanently destroys the original declarative
+                                        // binding — any later Settings.steamFlow change (like
+                                        // this preset tap) won't reach the slider. Qt.binding
+                                        // restores reactivity without falling back to a bare
+                                        // imperative assignment.
+                                        steamingFlowSlider.value = Qt.binding(function() { return Settings.steamFlow })
+                                        // Push the new flow over BLE. Don't push timeout — the
+                                        // DE1's session timer is already running on the prior
+                                        // value and a mid-session timeout change risks an
+                                        // immediate stop if the new value is < elapsed.
                                         MainController.setSteamFlowImmediate(flow)
                                     }
                                 }

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -383,8 +383,23 @@ Page {
                                     var flow = modelData.flow !== undefined ? modelData.flow : 150
                                     Settings.steamTimeout = modelData.duration
                                     Settings.steamFlow = flow
-                                    if (!isSteaming)
+                                    if (!isSteaming) {
                                         MainController.startSteamHeating("live-pitcher-click")
+                                    } else {
+                                        // Sync the live slider imperatively. Its binding to
+                                        // Settings.steamFlow gets broken the first time the
+                                        // user drags it (onValueModified writes value=newVal),
+                                        // so a Settings update from this preset tap won't
+                                        // reach the slider on its own.
+                                        steamingFlowSlider.value = flow
+                                        // Settings assignment alone only updates QSettings; the BLE
+                                        // MMR write to 0x803828 lives in MainController. Push the
+                                        // new flow immediately so the DE1 picks it up mid-session.
+                                        // Don't push timeout — the DE1's session timer is already
+                                        // running on the prior value and a mid-session timeout
+                                        // change risks an immediate stop if the new value is < elapsed.
+                                        MainController.setSteamFlowImmediate(flow)
+                                    }
                                 }
                             }
                         }
@@ -650,8 +665,11 @@ Page {
                     accessibleName: TranslationManager.translate("steam.label.steamFlow", "Steam Flow")
                     KeyNavigation.tab: steamStopButton.visible ? steamStopButton : (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : steamingFlowSlider)
                     KeyNavigation.backtab: increaseTimeBtn
-                    // Defer BLE writes to commit: onValueModified fires per
-                    // adjustment tick; BLE should only fire on release.
+                    // BLE write deferred to commit (PR #782 pattern). The single
+                    // commit-time MMR write is reliable because setSteamFlowImmediate
+                    // routes through writeMMRVerified — write, read-back, retry on
+                    // mismatch — so a single caller-side call is enough even when
+                    // the firmware's sample-tick loop misses the first write.
                     onValueModified: function(newValue) {
                         steamingFlowSlider.value = newValue
                         saveCurrentPitcher(getCurrentPitcherDuration(), newValue)

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -110,6 +110,7 @@ void DE1Device::onTransportDisconnected() {
     // than trusting cached values from the previous session (the DE1 may have
     // power-cycled or had its firmware state reset between sessions).
     m_lastMMRValues.clear();
+    m_pendingMMRVerifies.clear();
     m_deviceSteamTargetC = -1.0;
     m_deviceSteamDurationSec = -1;
     m_deviceHotWaterTempC = -1.0;
@@ -655,6 +656,31 @@ void DE1Device::parseMMRResponse(const QByteArray& data) {
             emit refillKitDetectedChanged();
         }
     }
+
+    // writeMMRVerified read-back: if this address has a pending verify,
+    // compare what the DE1 reports against what we wrote. Match → done.
+    // Mismatch → retry until the budget is exhausted. This sits below the
+    // address-specific handlers above so they still see the read response
+    // (no early return) — verifications and address handlers are independent.
+    auto verifyIt = m_pendingMMRVerifies.constFind(address);
+    if (verifyIt != m_pendingMMRVerifies.constEnd() && data.size() >= 8) {
+        uint32_t actualValue =
+            (static_cast<uint32_t>(static_cast<uint8_t>(d[7])) << 24) |
+            (static_cast<uint32_t>(static_cast<uint8_t>(d[6])) << 16) |
+            (static_cast<uint32_t>(static_cast<uint8_t>(d[5])) << 8) |
+            static_cast<uint32_t>(static_cast<uint8_t>(d[4]));
+
+        if (actualValue == verifyIt.value().expectedValue) {
+            qDebug().noquote() << QString("[MMR] verify ok: 0x%1 = %2 [%3]")
+                .arg(address, 6, 16, QLatin1Char('0'))
+                .arg(actualValue)
+                .arg(verifyIt.value().reason);
+            m_pendingMMRVerifies.remove(address);
+        } else {
+            retryMMRVerify(address,
+                QString("read-mismatch got=%1").arg(actualValue));
+        }
+    }
 }
 
 // -- Machine control methods (delegate through transport) --
@@ -1134,6 +1160,76 @@ void DE1Device::writeMMRUrgent(uint32_t address, uint32_t value, const QString& 
     // correctly dedups against what we just sent.
     m_lastMMRValues.insert(address, value);
     m_transport->writeUrgent(DE1::Characteristic::WRITE_TO_MMR, buildMMRPayload(address, value));
+}
+
+void DE1Device::writeMMRVerified(uint32_t address, uint32_t value,
+                                  const QString& reason, int maxRetries) {
+    if (!m_transport) return;
+
+    // Replace any prior verification for this address — newest write wins.
+    // (Mid-drag the user can replace the value many times before the first
+    // read-back lands; we only care about reaching the latest value.)
+    m_pendingMMRVerifies.insert(address, PendingMMRVerify{value, maxRetries, reason});
+
+    // Initial write. force=true bypasses dedup so a retry that re-writes the
+    // same value actually reaches the wire (otherwise the cache would elide).
+    writeMMR(address, value, reason, /*force=*/true);
+
+    // Schedule the read-back. 50ms gives the BLE queue's 50ms inter-write
+    // spacing time to dispatch the write and the DE1 a tick to process it.
+    QTimer::singleShot(50, this, [this, address]() {
+        scheduleMMRVerifyRead(address);
+    });
+}
+
+void DE1Device::scheduleMMRVerifyRead(uint32_t address) {
+    if (!m_pendingMMRVerifies.contains(address)) return;
+    if (!m_transport) {
+        m_pendingMMRVerifies.remove(address);
+        return;
+    }
+
+    // Request a read. Response arrives via READ_FROM_MMR notification and is
+    // dispatched by parseMMRResponse, which checks m_pendingMMRVerifies.
+    QByteArray req(20, 0);
+    req[0] = 0x00;  // Len = 0 means "read 4 bytes"
+    req[1] = (address >> 16) & 0xFF;
+    req[2] = (address >> 8) & 0xFF;
+    req[3] = address & 0xFF;
+    m_transport->write(DE1::Characteristic::READ_FROM_MMR, req);
+}
+
+void DE1Device::retryMMRVerify(uint32_t address, const QString& cause) {
+    auto it = m_pendingMMRVerifies.find(address);
+    if (it == m_pendingMMRVerifies.end()) return;
+
+    it.value().attemptsRemaining--;
+
+    if (it.value().attemptsRemaining <= 0) {
+        qWarning().noquote() << QString(
+            "[MMR] verify FAILED for 0x%1 expected=%2 [%3 / %4]")
+            .arg(address, 6, 16, QLatin1Char('0'))
+            .arg(it.value().expectedValue)
+            .arg(it.value().reason)
+            .arg(cause);
+        m_pendingMMRVerifies.remove(address);
+        return;
+    }
+
+    qDebug().noquote() << QString(
+        "[MMR] verify retry for 0x%1 expected=%2 attempts_left=%3 [%4 / %5]")
+        .arg(address, 6, 16, QLatin1Char('0'))
+        .arg(it.value().expectedValue)
+        .arg(it.value().attemptsRemaining)
+        .arg(it.value().reason)
+        .arg(cause);
+
+    writeMMR(address, it.value().expectedValue,
+             it.value().reason + QStringLiteral("-retry"), /*force=*/true);
+
+    QTimer::singleShot(50, this, [this, address]() {
+        scheduleMMRVerifyRead(address);
+    });
 }
 
 void DE1Device::setUsbChargerOn(bool on, bool force) {

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -227,11 +227,12 @@ public slots:
 
     // MMR write with read-back verification: write, then read the register
     // back ~50ms later, retry up to maxRetries times if the read doesn't
-    // return the value we wrote. Used for SteamFlow during steaming where a
-    // single MMR write isn't reliably picked up by the firmware's sample-tick
-    // loop — verify-and-retry replaces blind spam with confirmed delivery.
-    // A subsequent call for the same address replaces (cancels) the prior
-    // verification — newest write wins.
+    // return the value we wrote. Used for SteamFlow during steaming as
+    // defensive insurance — on-device testing showed zero retries needed
+    // in practice, but verify-and-retry catches any silent drop (e.g. a
+    // BLE write lost during high traffic) without costing a retry budget
+    // on the happy path. A subsequent call for the same address replaces
+    // (cancels) the prior verification — newest write wins.
     void writeMMRVerified(uint32_t address, uint32_t value,
                           const QString& reason = QString(),
                           int maxRetries = 5);

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -225,6 +225,17 @@ public slots:
     void writeMMRUrgent(uint32_t address, uint32_t value,
                         const QString& reason = QString());
 
+    // MMR write with read-back verification: write, then read the register
+    // back ~50ms later, retry up to maxRetries times if the read doesn't
+    // return the value we wrote. Used for SteamFlow during steaming where a
+    // single MMR write isn't reliably picked up by the firmware's sample-tick
+    // loop — verify-and-retry replaces blind spam with confirmed delivery.
+    // A subsequent call for the same address replaces (cancels) the prior
+    // verification — newest write wins.
+    void writeMMRVerified(uint32_t address, uint32_t value,
+                          const QString& reason = QString(),
+                          int maxRetries = 5);
+
     // USB charger control (force=true to resend even if state unchanged, needed for DE1's 10-min timeout)
     void setUsbChargerOn(bool on, bool force = false);
 
@@ -296,6 +307,10 @@ private:
     void rebuildVersionLine3();
     void requestGHCStatus();
 
+    // writeMMRVerified helpers
+    void scheduleMMRVerifyRead(uint32_t address);
+    void retryMMRVerify(uint32_t address, const QString& cause);
+
     void sendInitialSettings();
 
     // Profile upload tracking (frame-ACK verification, modeled on de1app's
@@ -352,6 +367,15 @@ private:
     // changes fan out into the same MMR). Cleared on transport disconnect so
     // a reconnect re-writes real values rather than trusting stale ones.
     QHash<uint32_t, uint32_t> m_lastMMRValues;
+    // Pending writeMMRVerified() entries keyed by address. Each tracks the
+    // expected value and remaining retry budget; cleared when a read-back
+    // matches or retries are exhausted, and on transport disconnect.
+    struct PendingMMRVerify {
+        uint32_t expectedValue;
+        int attemptsRemaining;
+        QString reason;
+    };
+    QHash<uint32_t, PendingMMRVerify> m_pendingMMRVerifies;
     double m_waterLevel = 0.0;
     double m_waterLevelMm = 0.0;  // Raw mm value (with sensor offset applied)
     int m_waterLevelMl = 0;       // Volume in ml (from CAD lookup table)

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1413,8 +1413,12 @@ void MainController::setSteamFlowImmediate(int flow) {
 
     m_settings->setSteamFlow(flow);
 
-    // Send steam flow via MMR (can be changed in real-time)
-    m_device->writeMMR(0x803828, flow, QStringLiteral("setSteamFlowImmediate"));
+    // Verify-and-retry: a single MMR write to 0x803828 isn't reliably picked
+    // up by the steam controller's sample-tick loop mid-Pouring. Read the
+    // register back and retry until the DE1 confirms the new value, so a
+    // single caller-side call (slider release, preset tap) is enough.
+    m_device->writeMMRVerified(0x803828, flow,
+                               QStringLiteral("setSteamFlowImmediate"));
 
     qDebug() << "Steam flow set to:" << flow;
 }

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1413,10 +1413,11 @@ void MainController::setSteamFlowImmediate(int flow) {
 
     m_settings->setSteamFlow(flow);
 
-    // Verify-and-retry: a single MMR write to 0x803828 isn't reliably picked
-    // up by the steam controller's sample-tick loop mid-Pouring. Read the
-    // register back and retry until the DE1 confirms the new value, so a
-    // single caller-side call (slider release, preset tap) is enough.
+    // Verify-and-retry as defensive insurance: a single MMR write should be
+    // enough (on-device testing showed zero retries needed across many slider
+    // drags), but steam flow is user-visible enough that we read the register
+    // back and retry on mismatch rather than relying on the write alone. One
+    // caller-side call (slider release, preset tap) stays one logical command.
     m_device->writeMMRVerified(0x803828, flow,
                                QStringLiteral("setSteamFlowImmediate"));
 


### PR DESCRIPTION
## Summary

- Restores mid-session steam flow control — drag-on-value-text now actually reaches the DE1
- Adds `writeMMRVerified()` (write + read-back + retry) for confirmed-delivery MMR writes; `setSteamFlowImmediate` routes through it
- Live preset row now writes the new flow to the DE1 mid-session and syncs the slider
- Doc commit: refresh the WiFi debug IP that DHCP rotated and add a USB-recovery hint

## Root cause

PR #782 split BLE writes from `onValueModified` to `onValueCommitted` in `ValueInput`, but missed the `valueDragArea.onReleased` handler (`ValueInput.qml:315`). The +/- button MouseAreas got the new `commitValue()` call; the value-text drag MouseArea did not.

So horizontal drags fired `_emitValueModified` per ~20 px (setting `_dirtySinceCommit=true`) but `commitValue()` never ran — for every consumer that migrated to `onValueCommitted` (SteamPage, FlushPage, HotWaterPage, SettingsMachineTab) drag-to-write became a silent no-op.

For SteamPage's mid-session flow slider this was visible as "the steam intensity doesn't react when I drag the slider mid-session". The displayed value updated, `Settings.steamFlow` persisted, but no BLE packet ever reached the DE1.

## Why verify-and-retry too

While hunting the regression I built `writeMMRVerified()` thinking the firmware needed multiple writes to land — a wrong theory the on-device test debunked (zero retries needed across many drags). Kept it anyway as defensive engineering: writes the value, reads `0x803828` back via `READ_FROM_MMR` after ~50 ms, retries up to 5× with `force=true` on mismatch. Costs one extra read per change, makes future BLE drops or firmware quirks self-healing on this register, and self-documents that `SteamFlow` is a confirmed-delivery setting.

## Files

| File | Purpose |
|------|---------|
| `qml/components/ValueInput.qml` | **Root-cause fix** — `valueDragArea.onReleased` calls `commitValue()`. Affects every page that wired BLE to `onValueCommitted`. |
| `qml/pages/SteamPage.qml` | Live preset row: mid-session taps push `setSteamFlowImmediate(flow)` and imperatively sync `steamingFlowSlider.value` (binding gets broken by the first drag). |
| `src/ble/de1device.{h,cpp}` | New `writeMMRVerified()` + `PendingMMRVerify` state + `parseMMRResponse` hook + clear on disconnect. |
| `src/controllers/maincontroller.cpp` | `setSteamFlowImmediate()` routes through `writeMMRVerified()`. |
| `CLAUDE.md` | Refresh stale WiFi debug IP, add USB-fallback hint for next DHCP rotation. |

## Test plan

- [x] On-device (DE1Pro v1333, Galaxy Tab A9): drag steam flow 40 → 145 → 40 mid-Pouring; every commit shows `[MMR] verify ok: 0x803828 = N` on the first read-back; steam intensity visibly tracks.
- [x] No retries needed across multiple sessions — firmware honors mid-session writes when they actually arrive.
- [ ] Sanity-check that drag-to-write also works on FlushPage and HotWaterPage (same `ValueInput` change benefits them).
- [ ] Verify the +/- button paths still commit correctly (unchanged by this PR but co-tenant of the same component).
- [ ] Verify nothing broke when a drag is canceled (drag-off-screen) — should not commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)