### PR TITLE
feat(scale): add keepScaleOn toggle for disconnect on DE1 sleep

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -777,6 +777,47 @@ Item {
                         }
                     }
 
+                    // Keep scale connected when DE1 sleeps
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(4)
+
+                        RowLayout {
+                            Layout.fillWidth: true
+
+                            Text {
+                                text: TranslationManager.translate("settings.bluetooth.keepScaleOn",
+                                                                   "Keep scale connected when DE1 sleeps")
+                                color: Theme.textColor
+                                font.family: Theme.bodyFont.family
+                                font.pixelSize: Theme.scaled(14)
+                                Accessible.ignored: true
+                            }
+
+                            Item { Layout.fillWidth: true }
+
+                            StyledSwitch {
+                                id: keepScaleOnSwitch
+                                checked: Settings.keepScaleOn
+                                accessibleName: TranslationManager.translate(
+                                    "settings.bluetooth.keepScaleOn",
+                                    "Keep scale connected when DE1 sleeps")
+                                onToggled: Settings.keepScaleOn = checked
+                            }
+                        }
+
+                        Text {
+                            Layout.fillWidth: true
+                            text: TranslationManager.translate(
+                                "settings.bluetooth.keepScaleOnDesc",
+                                "Turn off to power down and disconnect the scale when the DE1 sleeps. Recommended for battery-only scales; reconnects automatically when the DE1 wakes.")
+                            color: Theme.textSecondaryColor
+                            font.pixelSize: Theme.scaled(12)
+                            wrapMode: Text.WordWrap
+                            Accessible.ignored: true
+                        }
+                    }
+
                     // Connected BLE scale name + battery
                     RowLayout {
                         Layout.fillWidth: true

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -375,6 +375,20 @@ void Settings::setScaleType(const QString& type) {
     }
 }
 
+bool Settings::keepScaleOn() const {
+    // Default true preserves legacy Decenza behaviour (scale stays BLE-connected
+    // when the DE1 sleeps). Set to false to mirror de1app's default of powering
+    // off and disconnecting the scale — useful for battery-only scales.
+    return m_settings.value("scale/keepOn", true).toBool();
+}
+
+void Settings::setKeepScaleOn(bool keep) {
+    if (keepScaleOn() != keep) {
+        m_settings.setValue("scale/keepOn", keep);
+        emit keepScaleOnChanged();
+    }
+}
+
 QString Settings::scaleName() const {
     return m_settings.value("scale/name", "").toString();
 }

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -19,6 +19,7 @@ class Settings : public QObject {
     Q_PROPERTY(QString machineAddress READ machineAddress WRITE setMachineAddress NOTIFY machineAddressChanged)
     Q_PROPERTY(QString scaleAddress READ scaleAddress WRITE setScaleAddress NOTIFY scaleAddressChanged)
     Q_PROPERTY(QString scaleType READ scaleType WRITE setScaleType NOTIFY scaleTypeChanged)
+    Q_PROPERTY(bool keepScaleOn READ keepScaleOn WRITE setKeepScaleOn NOTIFY keepScaleOnChanged)
     Q_PROPERTY(QString scaleName READ scaleName WRITE setScaleName NOTIFY scaleNameChanged)
 
     // Multi-scale management
@@ -296,6 +297,9 @@ public:
 
     QString scaleAddress() const;
     void setScaleAddress(const QString& address);
+
+    bool keepScaleOn() const;
+    void setKeepScaleOn(bool keep);
 
     QString scaleType() const;
     void setScaleType(const QString& type);
@@ -903,6 +907,7 @@ signals:
     void machineAddressChanged();
     void scaleAddressChanged();
     void scaleTypeChanged();
+    void keepScaleOnChanged();
     void scaleNameChanged();
     void knownScalesChanged();
     void useFlowScaleChanged();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1987,14 +1987,31 @@ int main(int argc, char *argv[])
     // so MachineState transitions Disconnected→Sleep before the real state arrives)
     bool de1EverAwake = false;
     QObject::connect(&machineState, &MachineState::phaseChanged,
-                     [&physicalScale, &machineState, &de1EverAwake]() {
+                     [&physicalScale, &machineState, &settings, &de1EverAwake]() {
         auto phase = machineState.phase();
         if (phase == MachineState::Phase::Disconnected) {
             de1EverAwake = false;
         } else if (phase == MachineState::Phase::Sleep) {
             if (de1EverAwake && physicalScale && physicalScale->isConnected()) {
-                qDebug() << "DE1 going to sleep - disabling scale LCD";
-                physicalScale->disableLcd();
+                if (settings.keepScaleOn()) {
+                    qDebug() << "DE1 going to sleep - disabling scale LCD (keepScaleOn=true)";
+                    physicalScale->disableLcd();
+                } else {
+                    // Match de1app's default behaviour for battery-only scales:
+                    // send the scale's power-off command (no-op for scales that
+                    // don't implement sleep()), then drop the BLE link once the
+                    // sleep write completes. The saved scale address stays in
+                    // Settings, so the existing reconnect-on-resume / DE1-wake
+                    // flows reconnect automatically.
+                    qDebug() << "DE1 going to sleep - putting scale to sleep and disconnecting (keepScaleOn=false)";
+                    QObject::connect(physicalScale.get(), &ScaleDevice::sleepCompleted,
+                                     physicalScale.get(),
+                                     [scale = physicalScale.get()]() {
+                                         if (scale) scale->disconnectFromScale();
+                                     },
+                                     Qt::SingleShotConnection);
+                    physicalScale->sleep();
+                }
             }
         } else if (phase == MachineState::Phase::Idle) {
             if (physicalScale && physicalScale->isConnected()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1022,6 +1022,13 @@ int main(int argc, char *argv[])
     scaleReconnectTimer.setSingleShot(true);
     const std::vector<int> reconnectDelays = {5000, 30000, 60000};
 
+    // When Settings.keepScaleOn is false we deliberately disconnect the scale
+    // on DE1 sleep. The connectedChanged handler below normally schedules an
+    // auto-reconnect 5 s after any disconnect — this flag suppresses that for
+    // our deliberate path. Cleared on DE1 wake (Idle), app resume, and user-
+    // initiated scan so normal reconnect behaviour resumes.
+    bool scaleAutoReconnectSuppressed = false;
+
     QObject::connect(&scaleReconnectTimer, &QTimer::timeout,
                      [&bleManager, &settings, &scaleReconnectAttempt, &scaleReconnectTimer, &reconnectDelays]() {
         if (settings.scaleAddress().isEmpty()) {
@@ -1197,11 +1204,15 @@ int main(int argc, char *argv[])
 
         // When physical scale connects/disconnects, switch between physical and FlowScale
         QObject::connect(physicalScale.get(), &ScaleDevice::connectedChanged,
-                         [&physicalScale, &flowScale, &machineState, &engine, &bleManager, &mainController, &timingController, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &settings]() {
+                         [&physicalScale, &flowScale, &machineState, &engine, &bleManager, &mainController, &timingController, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &settings, &scaleAutoReconnectSuppressed]() {
             if (physicalScale && physicalScale->isConnected()) {
                 // Scale connected - stop any pending reconnect attempts
                 scaleReconnectTimer.stop();
                 scaleReconnectAttempt = 0;
+                // A fresh successful connect clears any deliberate-disconnect
+                // suppression (e.g. scale reconnected during DE1 sleep via a
+                // manual scan).
+                scaleAutoReconnectSuppressed = false;
                 // Scale connected - use physical scale
                 machineState.setScale(physicalScale.get());
                 timingController.setScale(physicalScale.get());
@@ -1239,8 +1250,13 @@ int main(int argc, char *argv[])
                 }
                 emit bleManager.scaleDisconnected();
                 qDebug() << "Scale disconnected - switched to FlowScale";
-                // Start auto-reconnect if we have a saved scale address
-                if (!settings.scaleAddress().isEmpty()) {
+                // Start auto-reconnect if we have a saved scale address, unless
+                // the disconnect was a deliberate one from the DE1-sleep path
+                // (keepScaleOn=false). In that case the DE1-wake handler
+                // re-arms the reconnect.
+                if (scaleAutoReconnectSuppressed) {
+                    qDebug() << "Scale disconnect was deliberate (keepScaleOn=false) - auto-reconnect suppressed until DE1 wakes";
+                } else if (!settings.scaleAddress().isEmpty()) {
                     scaleReconnectAttempt = 0;
                     scaleReconnectTimer.start(reconnectDelays[0]);
                     qDebug() << "Scale reconnect: scheduled first retry in" << reconnectDelays[0] << "ms";
@@ -1258,9 +1274,12 @@ int main(int argc, char *argv[])
 
     // Handle disconnect request when starting a new scan
     QObject::connect(&bleManager, &BLEManager::disconnectScaleRequested,
-                     [&physicalScale, &flowScale, &machineState, &engine, &mainController, &bleManager, &timingController, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt]() {
+                     [&physicalScale, &flowScale, &machineState, &engine, &mainController, &bleManager, &timingController, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &scaleAutoReconnectSuppressed]() {
         // Stop any pending auto-reconnect (user is deliberately scanning for a different scale)
         scaleReconnectTimer.stop();
+        // User is selecting a new scale — clear any sleep-deliberate suppression
+        // so the new scale's normal reconnect behaviour applies.
+        scaleAutoReconnectSuppressed = false;
         scaleReconnectAttempt = 0;
         if (physicalScale) {
             qDebug() << "Disconnecting scale before scan";
@@ -1891,7 +1910,7 @@ int main(int argc, char *argv[])
     // when app is suspended/resumed. Neither DE1 nor scale are put to sleep when
     // backgrounded — users may switch apps while the machine heats up.
     QObject::connect(&app, &QGuiApplication::applicationStateChanged,
-                     [&physicalScale, &bleManager, &settings, &batteryManager, &de1Device, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &de1ReconnectTimer, &de1ReconnectAttempt](Qt::ApplicationState state) {
+                     [&physicalScale, &bleManager, &settings, &batteryManager, &de1Device, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &de1ReconnectTimer, &de1ReconnectAttempt, &scaleAutoReconnectSuppressed](Qt::ApplicationState state) {
         static bool wasSuspended = false;
 
         if (state == Qt::ApplicationSuspended) {
@@ -1951,6 +1970,10 @@ int main(int argc, char *argv[])
 
             // Scale was not put to sleep on suspend, so it should still be connected.
             // If the OS dropped the BLE connection anyway, start the reconnect sequence.
+            // If the scale was deliberately disconnected on DE1 sleep, the user
+            // returning to the app is a signal that they want it back — clear the
+            // suppression flag so the normal reconnect runs.
+            scaleAutoReconnectSuppressed = false;
             if (physicalScale && physicalScale->isConnected()) {
                 qDebug() << "App resumed - scale still connected";
             } else if (!settings.scaleAddress().isEmpty() && !scaleReconnectTimer.isActive()) {
@@ -1981,13 +2004,21 @@ int main(int argc, char *argv[])
         }
     });
 
-    // Turn off scale LCD when DE1 sleeps, wake when DE1 wakes (like de1app's decentscale_off plugin)
-    // Uses disableLcd() instead of sleep() to keep BLE connected - no reconnection needed on wake
-    // de1EverAwake: suppress Sleep reaction on initial connect (DE1's default state is Sleep,
-    // so MachineState transitions Disconnected→Sleep before the real state arrives)
+    // Manage scale power state when the DE1 sleeps/wakes.
+    //   keepScaleOn=true  (default): send disableLcd() only — BLE stays connected,
+    //                                LCD re-enables via wake() on resume.
+    //   keepScaleOn=false: send sleep() then drop the BLE link once the write
+    //                      completes. Matches de1app's default for battery-only
+    //                      scales. Auto-reconnect is suppressed via
+    //                      scaleAutoReconnectSuppressed until the DE1 wakes.
+    // de1EverAwake: suppress Sleep reaction on initial connect (DE1's default
+    // BLE state is Sleep, so MachineState transitions Disconnected→Sleep before
+    // the real state arrives).
     bool de1EverAwake = false;
     QObject::connect(&machineState, &MachineState::phaseChanged,
-                     [&physicalScale, &machineState, &settings, &de1EverAwake]() {
+                     [&physicalScale, &machineState, &settings, &de1EverAwake,
+                      &scaleAutoReconnectSuppressed, &scaleReconnectTimer,
+                      &scaleReconnectAttempt, &reconnectDelays]() {
         auto phase = machineState.phase();
         if (phase == MachineState::Phase::Disconnected) {
             de1EverAwake = false;
@@ -1997,13 +2028,10 @@ int main(int argc, char *argv[])
                     qDebug() << "DE1 going to sleep - disabling scale LCD (keepScaleOn=true)";
                     physicalScale->disableLcd();
                 } else {
-                    // Match de1app's default behaviour for battery-only scales:
-                    // send the scale's power-off command (no-op for scales that
-                    // don't implement sleep()), then drop the BLE link once the
-                    // sleep write completes. The saved scale address stays in
-                    // Settings, so the existing reconnect-on-resume / DE1-wake
-                    // flows reconnect automatically.
                     qDebug() << "DE1 going to sleep - putting scale to sleep and disconnecting (keepScaleOn=false)";
+                    // Suppress the reconnect timer that connectedChanged would
+                    // otherwise schedule when disconnectFromScale() fires.
+                    scaleAutoReconnectSuppressed = true;
                     QObject::connect(physicalScale.get(), &ScaleDevice::sleepCompleted,
                                      physicalScale.get(),
                                      [scale = physicalScale.get()]() {
@@ -2017,6 +2045,17 @@ int main(int argc, char *argv[])
             if (physicalScale && physicalScale->isConnected()) {
                 qDebug() << "DE1 woke up - waking scale LCD";
                 physicalScale->wake();
+            } else if (scaleAutoReconnectSuppressed
+                       && !settings.scaleAddress().isEmpty()) {
+                // keepScaleOn=false path: we deliberately disconnected on DE1
+                // sleep and suppressed the auto-reconnect. Re-arm the reconnect
+                // sequence now that the DE1 is back.
+                qDebug() << "DE1 woke up - re-arming scale reconnect (keepScaleOn=false)";
+                scaleAutoReconnectSuppressed = false;
+                if (!scaleReconnectTimer.isActive()) {
+                    scaleReconnectAttempt = 0;
+                    scaleReconnectTimer.start(reconnectDelays[0]);
+                }
             }
             de1EverAwake = true;
         } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1130,7 +1130,7 @@ int main(int argc, char *argv[])
 
     // Connect to any supported scale when discovered
     QObject::connect(&bleManager, &BLEManager::scaleDiscovered,
-                     [&physicalScale, &flowScale, &machineState, &mainController, &engine, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays](const QBluetoothDeviceInfo& device, const QString& type) {
+                     [&physicalScale, &flowScale, &machineState, &mainController, &engine, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &scaleAutoReconnectSuppressed](const QBluetoothDeviceInfo& device, const QString& type) {
         // Don't connect if we already have a connected scale
         if (physicalScale && physicalScale->isConnected()) {
             return;


### PR DESCRIPTION
## Summary

Adds a new **Settings.keepScaleOn** toggle on the Connections settings page (below the Scan for Devices button). When enabled (default), behaviour is unchanged: the scale stays BLE-connected when the DE1 sleeps and only its LCD is disabled. When disabled, the scale is powered off via its native BLE sleep command and the BLE link is dropped, matching de1app's default behaviour.

Motivated by a user report: a Decent HDS scale left on battery overnight drained fully because Decenza kept the BLE connection alive. This toggle lets users with battery-only scales avoid that drain while preserving the current fast-wake behaviour for everyone else.

## Default

**True** — preserves current Decenza behaviour on upgrade. Users with battery-only scales can flip the toggle in Settings → Connections.

## How it works

- On DE1 phase → Sleep, with \`keepScaleOn=false\`:
  1. Call \`physicalScale->sleep()\` — sends the scale's power-off command.
  2. On \`ScaleDevice::sleepCompleted\`, call \`physicalScale->disconnectFromScale()\` to drop the BLE link.
  3. Saved scale address stays in Settings; existing reconnect-on-resume and DE1-wake paths reconnect automatically.
- Event-driven (no wall-clock timer) per CLAUDE.md's no-timers-as-guards rule.

## Scale coverage

| Scale | Native sleep command | Benefit |
|-------|:-:|-------|
| Decent (HDS) | Yes (\`0A 02 00\`) | Explicit power-off + BLE disconnect |
| Skale | Yes | Explicit power-off + BLE disconnect |
| Eureka Precisa | Yes | Explicit power-off + BLE disconnect |
| Acaia / Bookoo / DiFluid / Felicita / Hiroia / SmartChef / SoloBarista / Timemore / VariaAku / AtomheartEclair | No (inherits no-op base) | BLE disconnect only — still lets most peripherals drop into low-power advertising |

## Test plan

- [ ] With \`keepScaleOn=true\` (default): DE1 → Sleep still sends LCD-off only; scale stays connected. No regression.
- [ ] With \`keepScaleOn=false\` on a Decent scale: DE1 → Sleep sends \`0A 02\`, BLE disconnects within ~1 s. Scale powers off.
- [ ] DE1 wake (Idle phase): existing reconnect path restores the scale connection.
- [ ] Non-Decent scale (e.g. Acaia): toggle still causes BLE disconnect on DE1 sleep; scale enters low-power mode on peripheral side.
- [ ] Toggle UI on Settings → Connections page, directly under Scan for Devices, reads/writes \`Settings.keepScaleOn\`.
- [ ] Setting persists across app restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)