### PR TITLE
fix: update phase pill name on every frame change (#791)

### DIFF
--- a/qml/pages/EspressoPage.qml
+++ b/qml/pages/EspressoPage.qml
@@ -13,11 +13,8 @@ Page {
     // Local weight property - updated directly in signal handler for immediate display
     property real currentWeight: 0.0
 
-    // Frame name display — only updates when the same frame name is seen on
-    // consecutive frame-change events, filtering out short transitional frames.
+    // Frame name shown in the phase pill; updated on every frame change.
     property string displayedFrameName: ""
-    property string pendingFrameName: ""
-    property int pendingFrameCount: 0
 
     // Accessibility: value announcement cycling (swipe left/right)
     property int accessibilityValueIndex: 0
@@ -172,8 +169,6 @@ Page {
         function onShotStarted() {
             // Reset frame name so previous shot's last frame doesn't linger
             espressoPage.displayedFrameName = ""
-            espressoPage.pendingFrameName = ""
-            espressoPage.pendingFrameCount = 0
 
             if (!accessibilityEnabled()) return
             lastAnnouncedWeight = 0
@@ -261,23 +256,8 @@ Page {
     Connections {
         target: MainController
         function onFrameChanged(frameIndex, frameName, transitionReason) {
-            // Frame name filtering: show immediately if it matches the pending name
-            // (confirming it's a real phase, not a brief transition), or queue it.
             if (frameName !== "") {
-                if (frameName === espressoPage.pendingFrameName) {
-                    espressoPage.pendingFrameCount++
-                    // Second consecutive event with same name — it's stable, show it
-                    if (espressoPage.pendingFrameCount >= 2 && espressoPage.displayedFrameName !== frameName) {
-                        espressoPage.displayedFrameName = frameName
-                    }
-                } else {
-                    // New frame name — if it's the first frame or display is empty, show immediately
-                    espressoPage.pendingFrameName = frameName
-                    espressoPage.pendingFrameCount = 1
-                    if (espressoPage.displayedFrameName === "") {
-                        espressoPage.displayedFrameName = frameName
-                    }
-                }
+                espressoPage.displayedFrameName = frameName
             }
 
             if (transitionReason === "" || frameName === "") return


### PR DESCRIPTION
## Summary
- Fixes [#791](https://github.com/Kulitorum/Decenza/issues/791): the phase-info pill on EspressoPage stayed on the first frame name (e.g. "preinfusion start") for the whole shot on the Cremina profile.
- Root cause: the filter in `onFrameChanged` required two consecutive `frameChanged` events with the same `frameName` before updating `displayedFrameName`. Since `MainController::frameChanged` only emits when the frame *number* changes, two same-name events almost never occur — so any profile with unique names per frame got stuck on frame 0.
- Fix: drop the filter and the unused `pendingFrameName` / `pendingFrameCount` state; update `displayedFrameName` on every frame change.

Affected profiles: every advanced profile with unique names per step, including Cremina, Blooming Espresso, Extractamundo Dos, I Got Your Back, TurboBloom, 80s Espresso. D-Flow and A-Flow masked the bug because they repeat some frame names.

## Test plan
- [ ] Run a Cremina shot and confirm the phase pill advances through "preinfusion start" → "preinfusion" → "soak" → "ramp" → "ramp-down".
- [ ] Run a D-Flow shot and confirm the pill still shows Filling/Infusing/Pouring correctly.
- [ ] Confirm the pill resets between shots (no stale name from the previous extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)