### PR TITLE
feat(espresso): +10g button to extend SAW mid-shot (#792)

### DIFF
--- a/qml/components/AccessibleButton.qml
+++ b/qml/components/AccessibleButton.qml
@@ -21,6 +21,10 @@ Button {
     // For external reference
     property Item accessibleItem: root
 
+    // Live press state — Button.down stays false because touchArea below accepts
+    // the press. Bind custom background visuals to this instead of `down`.
+    readonly property alias isPressed: touchArea.pressed
+
     // Optional font overrides (0/-1 = use defaults)
     property int _customFontSize: 0
     property int _customFontWeight: -1

--- a/qml/components/ShotGraph.qml
+++ b/qml/components/ShotGraph.qml
@@ -140,8 +140,13 @@ ChartView {
         id: weightAxis
         min: 0
         // Live shots may bump SAW past the configured target (#792 +10g button), so
-        // take the larger of profile target and current MachineState target.
-        max: Math.max(10, Math.max(ProfileManager.targetWeight || 0, MachineState.targetWeight || 0, 36) * 1.1)
+        // take the larger of profile target and current MachineState target. Each
+        // source uses an explicit > 0 check because targetWeight == 0 means SAW
+        // disabled, and JS `||` would conflate that with "no data".
+        max: Math.max(10, Math.max(
+            ProfileManager.targetWeight > 0 ? ProfileManager.targetWeight : 0,
+            MachineState.targetWeight > 0 ? MachineState.targetWeight : 0,
+            36) * 1.1)
         tickCount: 5
         visible: false
     }

--- a/qml/components/ShotGraph.qml
+++ b/qml/components/ShotGraph.qml
@@ -139,7 +139,9 @@ ChartView {
     ValueAxis {
         id: weightAxis
         min: 0
-        max: Math.max(10, (ProfileManager.targetWeight || 36) * 1.1)
+        // Live shots may bump SAW past the configured target (#792 +10g button), so
+        // take the larger of profile target and current MachineState target.
+        max: Math.max(10, Math.max(ProfileManager.targetWeight || 0, MachineState.targetWeight || 0, 36) * 1.1)
         tickCount: 5
         visible: false
     }

--- a/qml/pages/EspressoPage.qml
+++ b/qml/pages/EspressoPage.qml
@@ -1001,8 +1001,9 @@ Page {
                 onClicked: MainController.bumpTargetWeight(10.0)
 
                 background: Rectangle {
+                    implicitWidth: Theme.scaled(56)
                     implicitHeight: Theme.scaled(24)
-                    color: addTenButton.down ? Qt.darker(Theme.accentColor, 1.3) : Theme.accentColor
+                    color: addTenButton.isPressed ? Qt.darker(Theme.accentColor, 1.3) : Theme.accentColor
                     radius: Theme.scaled(12)
                 }
                 contentItem: Text {
@@ -1036,8 +1037,9 @@ Page {
                 onClicked: DE1Device.skipToNextFrame()
 
                 background: Rectangle {
+                    implicitWidth: Theme.scaled(56)
                     implicitHeight: Theme.scaled(24)
-                    color: skipFrameButton.down ? Qt.darker(Theme.accentColor, 1.3) : Theme.accentColor
+                    color: skipFrameButton.isPressed ? Qt.darker(Theme.accentColor, 1.3) : Theme.accentColor
                     radius: Theme.scaled(12)
                 }
                 contentItem: Text {

--- a/qml/pages/EspressoPage.qml
+++ b/qml/pages/EspressoPage.qml
@@ -981,13 +981,15 @@ Page {
             }
 
             // Bump SAW target by +10g (issue #792 — "salvage" a too-fast shot)
-            Rectangle {
+            AccessibleButton {
                 id: addTenButton
                 Layout.preferredWidth: Theme.scaled(56)
                 Layout.preferredHeight: Theme.scaled(24)
                 Layout.alignment: Qt.AlignVCenter
-                radius: Theme.scaled(12)
-                color: addTenTapHandler.pressed ? Qt.darker(Theme.accentColor, 1.3) : Theme.accentColor
+                leftPadding: 0
+                rightPadding: 0
+                text: TranslationManager.translate("espresso.button.add10", "+10 g")
+                accessibleName: TranslationManager.translate("espresso.accessible.add10", "Add 10 grams to weight target")
                 visible: MachineState.targetWeight > 0 &&
                          (MachineState.phase === MachineStateType.Phase.Preinfusion ||
                           MachineState.phase === MachineStateType.Phase.Pouring)
@@ -995,61 +997,57 @@ Page {
                 activeFocusOnTab: true
                 KeyNavigation.tab: skipFrameButton
                 KeyNavigation.backtab: espressoBackButton
-                Accessible.role: Accessible.Button
-                Accessible.name: TranslationManager.translate("espresso.accessible.add10", "Add 10 grams to weight target")
-                Accessible.focusable: true
-                Accessible.onPressAction: addTenTapHandler.tapped(null)
-                Keys.onReturnPressed: { MainController.bumpTargetWeight(10.0); event.accepted = true }
-                Keys.onSpacePressed:  { MainController.bumpTargetWeight(10.0); event.accepted = true }
 
-                Text {
-                    anchors.centerIn: parent
-                    text: TranslationManager.translate("espresso.button.add10", "+10 g")
+                onClicked: MainController.bumpTargetWeight(10.0)
+
+                background: Rectangle {
+                    implicitHeight: Theme.scaled(24)
+                    color: addTenButton.down ? Qt.darker(Theme.accentColor, 1.3) : Theme.accentColor
+                    radius: Theme.scaled(12)
+                }
+                contentItem: Text {
+                    text: addTenButton.text
                     color: Theme.textColor
                     font.pixelSize: Theme.scaled(11)
                     font.weight: Font.Medium
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
                     Accessible.ignored: true
-                }
-
-                TapHandler {
-                    id: addTenTapHandler
-                    onTapped: MainController.bumpTargetWeight(10.0)
                 }
             }
 
             // Skip to next profile frame
-            Rectangle {
+            AccessibleButton {
                 id: skipFrameButton
                 Layout.preferredWidth: Theme.scaled(56)
                 Layout.preferredHeight: Theme.scaled(24)
                 Layout.alignment: Qt.AlignVCenter
-                radius: Theme.scaled(12)
-                color: skipFrameTapHandler.pressed ? Qt.darker(Theme.accentColor, 1.3) : Theme.accentColor
+                leftPadding: 0
+                rightPadding: 0
+                text: TranslationManager.translate("espresso.button.skip", "Skip")
+                accessibleName: TranslationManager.translate("espresso.accessible.skipFrame", "Skip to next frame")
                 visible: MachineState.phase === MachineStateType.Phase.Preinfusion ||
                          MachineState.phase === MachineStateType.Phase.Pouring
 
                 activeFocusOnTab: true
                 KeyNavigation.tab: viewModeMouseArea
-                KeyNavigation.backtab: addTenButton
-                Accessible.role: Accessible.Button
-                Accessible.name: TranslationManager.translate("espresso.accessible.skipFrame", "Skip to next frame")
-                Accessible.focusable: true
-                Accessible.onPressAction: skipFrameTapHandler.tapped(null)
-                Keys.onReturnPressed: { DE1Device.skipToNextFrame(); event.accepted = true }
-                Keys.onSpacePressed:  { DE1Device.skipToNextFrame(); event.accepted = true }
+                KeyNavigation.backtab: addTenButton.visible ? addTenButton : espressoBackButton
 
-                Text {
-                    anchors.centerIn: parent
-                    text: TranslationManager.translate("espresso.button.skip", "Skip")
+                onClicked: DE1Device.skipToNextFrame()
+
+                background: Rectangle {
+                    implicitHeight: Theme.scaled(24)
+                    color: skipFrameButton.down ? Qt.darker(Theme.accentColor, 1.3) : Theme.accentColor
+                    radius: Theme.scaled(12)
+                }
+                contentItem: Text {
+                    text: skipFrameButton.text
                     color: Theme.textColor
                     font.pixelSize: Theme.scaled(11)
                     font.weight: Font.Medium
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
                     Accessible.ignored: true
-                }
-
-                TapHandler {
-                    id: skipFrameTapHandler
-                    onTapped: DE1Device.skipToNextFrame()
                 }
             }
         }

--- a/qml/pages/EspressoPage.qml
+++ b/qml/pages/EspressoPage.qml
@@ -44,7 +44,7 @@ Page {
                 return "Temperature: " + DE1Device.temperature.toFixed(1) + " degrees"
             case 5: // Weight and/or Volume
                 var parts = []
-                if (MachineState.targetWeight > 0) parts.push(TranslationManager.translate("espresso.accessible.weight", "Weight:") + " " + espressoPage.currentWeight.toFixed(1) + " " + TranslationManager.translate("espresso.accessible.of", "of") + " " + ProfileManager.targetWeight.toFixed(0) + " " + TranslationManager.translate("espresso.accessible.grams", "grams"))
+                if (MachineState.targetWeight > 0) parts.push(TranslationManager.translate("espresso.accessible.weight", "Weight:") + " " + espressoPage.currentWeight.toFixed(1) + " " + TranslationManager.translate("espresso.accessible.of", "of") + " " + MachineState.targetWeight.toFixed(0) + " " + TranslationManager.translate("espresso.accessible.grams", "grams"))
                 if (MachineState.targetVolume > 0) parts.push(TranslationManager.translate("espresso.accessible.volume", "Volume:") + " " + MachineState.pourVolume.toFixed(1) + " " + TranslationManager.translate("espresso.accessible.of", "of") + " " + MachineState.targetVolume.toFixed(0) + " " + TranslationManager.translate("espresso.accessible.milliliters", "milliliters"))
                 return parts.join(", ") || TranslationManager.translate("espresso.noStopTarget", "No stop target")
             default:
@@ -356,7 +356,7 @@ Page {
         id: cupFillComponent
         CupFillView {
             currentWeight: espressoPage.currentWeight
-            targetWeight: ProfileManager.targetWeight
+            targetWeight: MachineState.targetWeight
             currentFlow: DE1Device.flow
             currentPressure: DE1Device.pressure
             goalPressure: MainController.filteredGoalPressure
@@ -913,7 +913,7 @@ Page {
                 // Show volume display when only volume target is set (no weight target)
                 readonly property bool isVolumeMode: MachineState.targetVolume > 0 && MachineState.targetWeight <= 0
                 readonly property double currentValue: isVolumeMode ? MachineState.pourVolume : espressoPage.currentWeight
-                readonly property double targetValue: isVolumeMode ? MachineState.targetVolume : ProfileManager.targetWeight
+                readonly property double targetValue: isVolumeMode ? MachineState.targetVolume : MachineState.targetWeight
                 readonly property string unit: isVolumeMode ? "ml" : "g"
                 readonly property color displayColor: isVolumeMode ? Theme.flowColor : Theme.weightColor
 
@@ -921,7 +921,7 @@ Page {
                 Accessible.name: {
                     var parts = []
                     if (MachineState.targetWeight > 0)
-                        parts.push(TranslationManager.translate("espresso.accessible.weight", "Weight:") + " " + espressoPage.currentWeight.toFixed(1) + " " + TranslationManager.translate("espresso.accessible.of", "of") + " " + ProfileManager.targetWeight.toFixed(0) + " " + TranslationManager.translate("espresso.accessible.grams", "grams"))
+                        parts.push(TranslationManager.translate("espresso.accessible.weight", "Weight:") + " " + espressoPage.currentWeight.toFixed(1) + " " + TranslationManager.translate("espresso.accessible.of", "of") + " " + MachineState.targetWeight.toFixed(0) + " " + TranslationManager.translate("espresso.accessible.grams", "grams"))
                     if (MachineState.targetVolume > 0)
                         parts.push(TranslationManager.translate("espresso.accessible.volume", "Volume:") + " " + MachineState.pourVolume.toFixed(1) + " " + TranslationManager.translate("espresso.accessible.of", "of") + " " + MachineState.targetVolume.toFixed(0) + " " + TranslationManager.translate("espresso.accessible.milliliters", "milliliters"))
                     return parts.join(", ") || TranslationManager.translate("espresso.noStopTarget", "No stop target")
@@ -941,7 +941,7 @@ Page {
                     }
                     Text {
                         text: ProfileManager.brewByRatioActive && !weightVolumeColumn.isVolumeMode
-                            ? "1:" + ProfileManager.brewByRatio.toFixed(1) + " (" + ProfileManager.targetWeight.toFixed(0) + "g)"
+                            ? "1:" + ProfileManager.brewByRatio.toFixed(1) + " (" + MachineState.targetWeight.toFixed(0) + "g)"
                             : "/ " + weightVolumeColumn.targetValue.toFixed(0) + " " + weightVolumeColumn.unit
                         color: Theme.textSecondaryColor
                         font.pixelSize: Theme.scaled(18)
@@ -980,6 +980,43 @@ Page {
                 }
             }
 
+            // Bump SAW target by +10g (issue #792 — "salvage" a too-fast shot)
+            Rectangle {
+                id: addTenButton
+                Layout.preferredWidth: Theme.scaled(56)
+                Layout.preferredHeight: Theme.scaled(24)
+                Layout.alignment: Qt.AlignVCenter
+                radius: Theme.scaled(12)
+                color: addTenTapHandler.pressed ? Qt.darker(Theme.accentColor, 1.3) : Theme.accentColor
+                visible: MachineState.targetWeight > 0 &&
+                         (MachineState.phase === MachineStateType.Phase.Preinfusion ||
+                          MachineState.phase === MachineStateType.Phase.Pouring)
+
+                activeFocusOnTab: true
+                KeyNavigation.tab: skipFrameButton
+                KeyNavigation.backtab: espressoBackButton
+                Accessible.role: Accessible.Button
+                Accessible.name: TranslationManager.translate("espresso.accessible.add10", "Add 10 grams to weight target")
+                Accessible.focusable: true
+                Accessible.onPressAction: addTenTapHandler.tapped(null)
+                Keys.onReturnPressed: { MainController.bumpTargetWeight(10.0); event.accepted = true }
+                Keys.onSpacePressed:  { MainController.bumpTargetWeight(10.0); event.accepted = true }
+
+                Text {
+                    anchors.centerIn: parent
+                    text: TranslationManager.translate("espresso.button.add10", "+10 g")
+                    color: Theme.textColor
+                    font.pixelSize: Theme.scaled(11)
+                    font.weight: Font.Medium
+                    Accessible.ignored: true
+                }
+
+                TapHandler {
+                    id: addTenTapHandler
+                    onTapped: MainController.bumpTargetWeight(10.0)
+                }
+            }
+
             // Skip to next profile frame
             Rectangle {
                 id: skipFrameButton
@@ -993,7 +1030,7 @@ Page {
 
                 activeFocusOnTab: true
                 KeyNavigation.tab: viewModeMouseArea
-                KeyNavigation.backtab: espressoBackButton
+                KeyNavigation.backtab: addTenButton
                 Accessible.role: Accessible.Button
                 Accessible.name: TranslationManager.translate("espresso.accessible.skipFrame", "Skip to next frame")
                 Accessible.focusable: true

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -717,6 +717,9 @@ void DE1Device::requestState(DE1::State state) {
         case DE1::State::Clean:
             m_simulator->startClean();
             break;
+        case DE1::State::SkipToNext:
+            m_simulator->skipFrame();
+            break;
         default:
             break;
         }

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2043,6 +2043,23 @@ void MainController::factoryResetAndQuit()
     QCoreApplication::quit();
 }
 
+void MainController::bumpTargetWeight(double deltaG)
+{
+    if (!m_machineState) return;
+    const double current = m_machineState->targetWeight();
+    if (current <= 0.0) return;
+
+    const auto phase = m_machineState->phase();
+    if (phase != MachineState::Phase::Preinfusion && phase != MachineState::Phase::Pouring) {
+        return;
+    }
+
+    const double newTarget = current + deltaG;
+    qInfo().noquote() << "MainController::bumpTargetWeight: targetWeight"
+                      << current << "->" << newTarget << "g (delta=" << deltaG << ")";
+    m_machineState->setTargetWeight(newTarget);
+}
+
 void MainController::onShotSampleReceived(const ShotSample& sample) {
     if (!m_shotDataModel || !m_machineState) {
         return;

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -167,6 +167,11 @@ public slots:
 
     Q_INVOKABLE void factoryResetAndQuit();
 
+    // Mid-shot SAW adjustment (e.g. user pressed +10g to "salvage" a too-fast shot).
+    // No-op outside Preinfusion/Pouring or when no SAW target is set.
+    // Updates MachineState only — does NOT mutate the persisted profile/setting.
+    Q_INVOKABLE void bumpTargetWeight(double deltaG);
+
 signals:
     void sawSettlingChanged();
 

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -168,8 +168,8 @@ public slots:
     Q_INVOKABLE void factoryResetAndQuit();
 
     // Mid-shot SAW adjustment (e.g. user pressed +10g to "salvage" a too-fast shot).
-    // No-op outside Preinfusion/Pouring or when no SAW target is set.
-    // Updates MachineState only — does NOT mutate the persisted profile/setting.
+    // Intentionally only mutates MachineState — leaving the persisted profile/setting
+    // untouched so the next shot reverts to the user's normal target.
     Q_INVOKABLE void bumpTargetWeight(double deltaG);
 
 signals:

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -168,8 +168,9 @@ public slots:
     Q_INVOKABLE void factoryResetAndQuit();
 
     // Mid-shot SAW adjustment (e.g. user pressed +10g to "salvage" a too-fast shot).
-    // Intentionally only mutates MachineState — leaving the persisted profile/setting
-    // untouched so the next shot reverts to the user's normal target.
+    // No-op outside Preinfusion/Pouring or when no SAW target is set. Intentionally
+    // only mutates MachineState — leaving the persisted profile/setting untouched so
+    // the next shot reverts to the user's normal target.
     Q_INVOKABLE void bumpTargetWeight(double deltaG);
 
 signals:

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -278,6 +278,14 @@ void WeightProcessor::configure(double targetWeight, int preinfuseFrameCount,
     m_sensorLagSeconds = sensorLagSeconds;
 }
 
+void WeightProcessor::setTargetWeight(double weight)
+{
+    if (m_targetWeight == weight) return;
+    qInfo().noquote() << "WeightProcessor: targetWeight" << m_targetWeight << "->" << weight
+                      << "(active=" << m_active << ")";
+    m_targetWeight = weight;
+}
+
 void WeightProcessor::setCurrentFrame(int frameNumber)
 {
     m_currentFrame = frameNumber;

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -15,6 +15,7 @@
 // Input (via QueuedConnection from main thread):
 //   - processWeight(): called at ~5Hz with each scale reading
 //   - configure(): called once at shot start with targets and learning data
+//   - setTargetWeight(): may update SAW target mid-shot (e.g. user +10g bump)
 //   - setCurrentFrame(): called at ~5Hz from DE1 shot samples
 //
 // Output (via QueuedConnection back to main thread):
@@ -36,8 +37,8 @@ public slots:
                    QVector<double> frameExitWeights,
                    QVector<double> learningDrips, QVector<double> learningFlows,
                    bool sawConverged, double sensorLagSeconds = 0.38);
-    // Live SAW target update (e.g. user pressed +10g mid-shot). Safe to call any time;
-    // single-writer on the worker thread, invoked from main thread via QueuedConnection.
+    // Live SAW target update (e.g. user pressed +10g mid-shot). Writes are serialized
+    // on the worker thread via QueuedConnection from main thread, so no extra locking.
     void setTargetWeight(double weight);
     void setCurrentFrame(int frameNumber);
     void setTareComplete(bool complete);

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -36,6 +36,9 @@ public slots:
                    QVector<double> frameExitWeights,
                    QVector<double> learningDrips, QVector<double> learningFlows,
                    bool sawConverged, double sensorLagSeconds = 0.38);
+    // Live SAW target update (e.g. user pressed +10g mid-shot). Safe to call any time;
+    // single-writer on the worker thread, invoked from main thread via QueuedConnection.
+    void setTargetWeight(double weight);
     void setCurrentFrame(int frameNumber);
     void setTareComplete(bool complete);
     void startExtraction();
@@ -103,7 +106,7 @@ private:
     bool m_flowBecameValidLogged = false;  // Log once when flowShort transitions 0→valid
     bool m_untaredCupSignalled = false;   // Fire untaredCupDetected only once per extraction
 
-    // Configuration (set once at shot start, read-only during extraction)
+    // Configuration (set at shot start; m_targetWeight may be updated mid-shot via setTargetWeight)
     double m_targetWeight = 0;
     int m_preinfuseFrameCount = 0;  // SAW suppressed until m_currentFrame >= this
     QVector<double> m_frameExitWeights;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -679,6 +679,18 @@ int main(int argc, char *argv[])
                          }, Qt::QueuedConnection);
                      });
 
+    // Forward live SAW target changes (e.g. user pressed +10g mid-shot) to the worker.
+    // Pre-shot callers (profile activation, recipe save) set the target before
+    // configure() runs, so this is a no-op for them; only mid-shot bumps actually
+    // move the worker's target.
+    QObject::connect(&machineState, &MachineState::targetWeightChanged,
+                     [&weightProcessor, &machineState]() {
+                         const double w = machineState.targetWeight();
+                         QMetaObject::invokeMethod(&weightProcessor, [&weightProcessor, w]() {
+                             weightProcessor.setTargetWeight(w);
+                         }, Qt::QueuedConnection);
+                     });
+
 #ifdef Q_OS_ANDROID
     // GC management: defer Android GC during flowing operations (espresso, hot water, etc.)
     // to reduce stop-the-world pause impact on BLE delivery and SAW latency.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -680,9 +680,9 @@ int main(int argc, char *argv[])
                      });
 
     // Forward live SAW target changes (e.g. user pressed +10g mid-shot) to the worker.
-    // Pre-shot callers (profile activation, recipe save) set the target before
-    // configure() runs, so this is a no-op for them; only mid-shot bumps actually
-    // move the worker's target.
+    // Pre-shot callers (profile activation, recipe save) also fire this signal, but
+    // configure() overwrites m_targetWeight at shot start, so any pre-shot forwarding
+    // is harmless. Only mid-shot bumps observably move the worker's target.
     QObject::connect(&machineState, &MachineState::targetWeightChanged,
                      [&weightProcessor, &machineState]() {
                          const double w = machineState.targetWeight();

--- a/src/simulator/de1simulator.cpp
+++ b/src/simulator/de1simulator.cpp
@@ -278,6 +278,18 @@ void DE1Simulator::stop()
     stopOperation();
 }
 
+void DE1Simulator::skipFrame()
+{
+    if (m_state != DE1::State::Espresso ||
+        (m_subState != DE1::SubState::Preinfusion && m_subState != DE1::SubState::Pouring)) {
+        qDebug() << "DE1Simulator: skipFrame ignored (state=" << static_cast<int>(m_state)
+                 << "subState=" << static_cast<int>(m_subState) << ")";
+        return;
+    }
+    qDebug() << "DE1Simulator: skipFrame requested at frame" << m_currentFrameIndex;
+    advanceToNextFrame();
+}
+
 void DE1Simulator::goToSleep()
 {
     stopOperation();

--- a/src/simulator/de1simulator.h
+++ b/src/simulator/de1simulator.h
@@ -53,6 +53,9 @@ public slots:
     void stop();
     void goToSleep();
     void wakeUp();
+    // Skip to next profile frame (mirrors DE1::State::SkipToNext from the real machine).
+    // No-op outside espresso (Preinfusion/Pouring substates).
+    void skipFrame();
 
     // Target steam temperature from the app's ShotSettings write. A target of 0
     // means "heater off" (Off preset / steamDisabled). The sim doesn't model a


### PR DESCRIPTION
Closes #792 (manual variant — AI/auto-detect and UGS branches deferred).

## Summary
- Adds a **+10 g** button next to **Skip** on EspressoPage. Each press extends the live stop-at-weight target by 10 g, so a too-fast shot can be salvaged as a "spontaneous allonge" instead of binned.
- Wires `MachineState::targetWeightChanged` → `WeightProcessor` on its worker thread so mid-shot target changes actually move the SAW trigger. Previously `m_targetWeight` was set once in `configure()` and documented as read-only during extraction.
- `MainController::bumpTargetWeight()` updates `MachineState` only — the persisted profile/setting is **not** mutated, so the next shot starts at the user's normal target. Button is hidden when `targetWeight == 0` (e.g. basic profile without SAW).
- Display bindings on the weight column, brew-by-ratio label, CupFillView, and accessibility readouts switched from `ProfileManager.targetWeight` to `MachineState.targetWeight` so the bumped target shows live (progress bar, "/ 46 g", cup fill ceiling).

## Drive-by: Skip button fixed in simulator
While exploring I noticed Skip does nothing in simulator mode. `DE1Device::requestState()`'s simulator switch had no case for `DE1::State::SkipToNext` and was silently falling into `default: break;`. Added `DE1Simulator::skipFrame()` (calls existing `advanceToNextFrame()`, no-op outside Preinfusion/Pouring) and the missing switch case. Bundled here because it's tiny and was blocking simulator testing of +10 alongside Skip.

## Files
- `qml/pages/EspressoPage.qml` — new button + display bindings + tab order (Back → +10 → Skip → view-mode)
- `src/controllers/maincontroller.{h,cpp}` — `bumpTargetWeight(deltaG)`
- `src/machine/weightprocessor.{h,cpp}` — `setTargetWeight()` slot
- `src/main.cpp` — connect `targetWeightChanged` → worker via `Qt::QueuedConnection`
- `src/ble/de1device.cpp`, `src/simulator/de1simulator.{h,cpp}` — simulator Skip fix

## Test plan
- [ ] **Simulator — Skip regression**: start espresso, press Skip mid-shot, confirm logs show frame advance.
- [ ] **Simulator — +10 button**: start espresso with SAW set, press **+10** during Preinfusion/Pouring; confirm progress-bar label "/ X g" increments by 10 each press, CupFillView ceiling updates, qInfo log shows old → new target on both MainController and WeightProcessor.
- [ ] **Visibility gating**: button hidden in Idle/Heating/Ready and when targetWeight === 0 (basic profile with no SAW).
- [ ] **Real DE1**: SAW = 36 g, start shot, press **+10** twice → shot stops at ≈56 g (not 36).
- [ ] **No persistence**: subsequent shot still uses the persisted 36 g target (profile/Settings untouched).
- [ ] **Brew-by-ratio**: ratio label "1:2.0 (36g)" updates the parenthetical to reflect bumped target.
- [ ] **Accessibility**: TalkBack/VoiceOver — focus order Back → +10 → Skip → view-mode; +10 announces "Add 10 grams to weight target".
- [ ] **Existing tests**: ctest -R weight and ctest -R machinestate pass with -DBUILD_TESTS=ON.

## Out of scope (per #792, deferred)
- AUTO branch: AI/flow-detection auto-extends SAW.
- UGS grind correction suggestions.
- Configurable bump amount (+5/+10/+20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)