### PR TITLE
ui(settings): move keepScaleOn toggle below alerts, gate on saved scale

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -777,47 +777,6 @@ Item {
                         }
                     }
 
-                    // Keep scale connected when DE1 sleeps
-                    ColumnLayout {
-                        Layout.fillWidth: true
-                        spacing: Theme.scaled(4)
-
-                        RowLayout {
-                            Layout.fillWidth: true
-
-                            Text {
-                                text: TranslationManager.translate("settings.bluetooth.keepScaleOn",
-                                                                   "Keep scale connected when DE1 sleeps")
-                                color: Theme.textColor
-                                font.family: Theme.bodyFont.family
-                                font.pixelSize: Theme.scaled(14)
-                                Accessible.ignored: true
-                            }
-
-                            Item { Layout.fillWidth: true }
-
-                            StyledSwitch {
-                                id: keepScaleOnSwitch
-                                checked: Settings.keepScaleOn
-                                accessibleName: TranslationManager.translate(
-                                    "settings.bluetooth.keepScaleOn",
-                                    "Keep scale connected when DE1 sleeps")
-                                onToggled: Settings.keepScaleOn = checked
-                            }
-                        }
-
-                        Text {
-                            Layout.fillWidth: true
-                            text: TranslationManager.translate(
-                                "settings.bluetooth.keepScaleOnDesc",
-                                "Turn off to power down and disconnect the scale when the DE1 sleeps. Recommended for battery-only scales; reconnects automatically when the DE1 wakes.")
-                            color: Theme.textSecondaryColor
-                            font.pixelSize: Theme.scaled(12)
-                            wrapMode: Text.WordWrap
-                            Accessible.ignored: true
-                        }
-                    }
-
                     // Connected BLE scale name + battery
                     RowLayout {
                         Layout.fillWidth: true
@@ -1168,6 +1127,46 @@ Item {
                             checked: Settings.showScaleDialogs
                             accessibleName: TranslationManager.translate("connections.scaleConnectionAlerts", "Scale connection alerts")
                             onToggled: Settings.showScaleDialogs = checked
+                        }
+                    }
+
+                    // Keep scale connected when DE1 sleeps
+                    RowLayout {
+                        Layout.fillWidth: true
+                        visible: Settings.knownScales.length > 0
+                        spacing: Theme.scaled(15)
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 0
+                            Text {
+                                text: TranslationManager.translate("settings.bluetooth.keepScaleOn",
+                                                                   "Keep scale connected when DE1 sleeps")
+                                font.pixelSize: Theme.scaled(14)
+                                color: Theme.textColor
+                                Accessible.ignored: true
+                            }
+                            Text {
+                                Layout.fillWidth: true
+                                text: TranslationManager.translate(
+                                    "settings.bluetooth.keepScaleOnDesc",
+                                    "Turn off to power down and disconnect the scale when the DE1 sleeps. Recommended for battery-only scales; reconnects automatically when the DE1 wakes.")
+                                color: Theme.textSecondaryColor
+                                font.pixelSize: Theme.scaled(12)
+                                wrapMode: Text.WordWrap
+                                Accessible.ignored: true
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        StyledSwitch {
+                            id: keepScaleOnSwitch
+                            checked: Settings.keepScaleOn
+                            accessibleName: TranslationManager.translate(
+                                "settings.bluetooth.keepScaleOn",
+                                "Keep scale connected when DE1 sleeps")
+                            onToggled: Settings.keepScaleOn = checked
                         }
                     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1693,6 +1693,20 @@ int main(int argc, char *argv[])
         timingController.setScale(&simulatedScale);
         context->setContextProperty("ScaleDevice", &simulatedScale);
 
+        // Register as a known scale so UI gated on Settings.knownScales (keepScaleOn
+        // toggle, alerts toggle, known-devices picker) is reachable in simulation.
+        // Idempotent: addKnownScale dedupes by address. Removed on non-sim startup below.
+        const QString kSimulatedScaleAddress = QStringLiteral("sim:00:00:00:00:00:00");
+        settings.addKnownScale(kSimulatedScaleAddress,
+                               QStringLiteral("simulated"),
+                               QStringLiteral("Simulated Scale"));
+        // Promote to primary only if no real scale is paired, so the Known Devices
+        // picker shows "Simulated Scale" instead of "No scale selected" without
+        // clobbering a user's real scale pairing.
+        if (settings.primaryScaleAddress().isEmpty()) {
+            settings.setPrimaryScale(kSimulatedScaleAddress);
+        }
+
         // Reconnect WeightProcessor from FlowScale to SimulatedScale for espresso SAW
         QObject::disconnect(&flowScale, &ScaleDevice::weightChanged,
                             &weightProcessor, &WeightProcessor::processWeight);
@@ -1751,6 +1765,12 @@ int main(int argc, char *argv[])
 #endif // desktop GHC window
     }
 #endif // QT_DEBUG
+
+    // Purge the simulated-scale entry when not running in simulation mode, so a
+    // prior debug session's placeholder doesn't leak into the real connection UI.
+    if (!settings.simulationMode()) {
+        settings.removeKnownScale(QStringLiteral("sim:00:00:00:00:00:00"));
+    }
 
 #ifdef Q_OS_ANDROID
     // Set landscape orientation on Android (after QML is loaded)


### PR DESCRIPTION
## Summary

Follow-up to [#793](https://github.com/Kulitorum/Decenza/pull/793). Two small UI tweaks to the new **Keep scale connected when DE1 sleeps** toggle on Settings → Connections, plus a debug-only simulator-mode tweak to make the toggle testable without real hardware.

### UI changes (`SettingsConnectionsTab.qml`)
- Moved the toggle below the **Scale connection alerts** toggle (previously sat above the connected-scale/battery row).
- Only renders when a scale is saved (\`Settings.knownScales.length > 0\`), matching the alerts toggle's gating — no point showing a scale-behavior preference before any scale has been paired.
- Restructured the toggle's QML to match the alerts toggle's \`RowLayout\` + \`ColumnLayout { title, desc }\` pattern so the two sit visually consistent.

### Debug-only sim change (`main.cpp`)
- In \`QT_DEBUG\` simulation mode, registers a \"Simulated Scale\" entry in \`Settings.knownScales\` so UI gated on a known scale (the new toggle, alerts toggle, known-devices picker, \"Forget\" button) is reachable when testing without real hardware.
- Promoted to primary only if no real scale is already paired, to avoid clobbering a user's real pairing.
- Non-sim startup purges the entry, so prior debug state doesn't leak into production connection UI.

## Test plan

- [ ] Fresh install / no saved scale: neither toggle is visible on Settings → Connections.
- [ ] After pairing a scale (or running in sim mode): both toggles appear, in order — Scale connection alerts, then Keep scale connected.
- [ ] Toggle still reads/writes \`Settings.keepScaleOn\` and persists across restarts.
- [ ] Forget scale → both toggles hide again.
- [ ] Sim mode: Known Devices picker shows \"Simulated Scale\" as primary (not \"No scale selected\").
- [ ] Switching from sim mode back to normal mode on next launch: simulated-scale entry is gone from Known Devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)