### PR TITLE
fix(mcp): steam health covers milk fouling, not just scale

### DIFF
--- a/src/machine/steamhealthtracker.cpp
+++ b/src/machine/steamhealthtracker.cpp
@@ -330,7 +330,9 @@ void SteamHealthTracker::checkTrend(QList<SteamSessionSummary>& history,
         m_settings.setValue("steam/lastWarnedSession", m_lastWarnedSession);
         emit scaleBuildupWarning(
             tr("Steam pressure has increased from %1 to %2 bar over %3 sessions. "
-               "This may indicate scale buildup. Consider descaling your machine.")
+               "This may be caused by milk residue in the steam tip or scale buildup. "
+               "Try a steam-tip soak in a milk cleaner (Rinza/Cafiza) first; "
+               "if the issue persists, consider descaling your machine.")
             .arg(baselinePressure, 0, 'f', 1)
             .arg(currentPressure, 0, 'f', 1)
             .arg(n));
@@ -344,7 +346,9 @@ void SteamHealthTracker::checkTrend(QList<SteamSessionSummary>& history,
         m_settings.setValue("steam/lastWarnedSession", m_lastWarnedSession);
         emit scaleBuildupWarning(
             tr("Steam temperature has increased from %1 to %2 °C over %3 sessions. "
-               "This may indicate scale buildup. Consider descaling your machine.")
+               "This may be caused by milk residue in the steam tip or scale buildup. "
+               "Try a steam-tip soak in a milk cleaner (Rinza/Cafiza) first; "
+               "if the issue persists, consider descaling your machine.")
             .arg(baselineTemp, 0, 'f', 1)
             .arg(currentTemp, 0, 'f', 1)
             .arg(n));

--- a/src/mcp/mcptools_machine.cpp
+++ b/src/mcp/mcptools_machine.cpp
@@ -83,13 +83,17 @@ static SteamHealthInfo computeSteamHealth(SteamHealthTracker* tracker)
     double maxProgress = qMax(info.pressureProgress, info.temperatureProgress);
     if (maxProgress >= warnThreshold) {
         info.status = QStringLiteral("warning");
-        info.recommendation = QStringLiteral("Significant scale buildup detected — descaling recommended soon");
+        info.recommendation = QStringLiteral(
+            "Significant steam-flow restriction detected — likely milk residue in the steam tip or scale buildup. "
+            "Start with a steam-tip soak in a milk cleaner (Rinza/Cafiza); if pressure doesn't recover, descaling is likely needed.");
     } else if (maxProgress >= monitorThreshold) {
         info.status = QStringLiteral("monitor");
-        info.recommendation = QStringLiteral("Scale buildup is progressing — consider descaling in the coming weeks");
+        info.recommendation = QStringLiteral(
+            "Steam pressure or temperature is rising — likely milk residue in the steam tip or scale buildup. "
+            "Try a steam-tip soak in a milk cleaner first; if the trend persists, consider descaling.");
     } else {
         info.status = QStringLiteral("healthy");
-        info.recommendation = QStringLiteral("Steam system is clean — no scale buildup detected");
+        info.recommendation = QStringLiteral("Steam system is clean — no flow restriction detected");
     }
     return info;
 }
@@ -178,8 +182,8 @@ void registerMachineTools(McpToolRegistry* registry, DE1Device* device,
                 if (info.hasData && info.status != QStringLiteral("healthy")) {
                     QJsonObject sh;
                     sh["sessionCount"] = info.sessionCount;
-                    sh["pressureScaleBuildupProgress0to1"] = info.pressureProgress;
-                    sh["temperatureScaleBuildupProgress0to1"] = info.temperatureProgress;
+                    sh["pressureRestrictionProgress0to1"] = info.pressureProgress;
+                    sh["temperatureRestrictionProgress0to1"] = info.temperatureProgress;
                     sh["status"] = info.status;
                     sh["recommendation"] = info.recommendation;
                     result["steamHealth"] = sh;
@@ -241,8 +245,10 @@ void registerMachineTools(McpToolRegistry* registry, DE1Device* device,
     registry->registerTool(
         "steam_get_health",
         "Get detailed steam system health: baseline and current pressure/temperature, "
-        "scale buildup progress toward warn thresholds, status, and recommendation. "
-        "Use this when the user asks about steam health, descaling, or scale buildup.",
+        "flow-restriction progress toward warn thresholds, status, and recommendation. "
+        "Rising pressure/temperature can indicate milk residue in the steam tip or scale buildup "
+        "(the tool cannot distinguish the two — recommendations cover both). "
+        "Use this when the user asks about steam health, steam wand cleaning, or descaling.",
         QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
         [mainController](const QJsonObject&) -> QJsonObject {
             QJsonObject result;
@@ -264,8 +270,8 @@ void registerMachineTools(McpToolRegistry* registry, DE1Device* device,
             }
 
             if (info.hasData) {
-                result["pressureScaleBuildupProgress0to1"] = info.pressureProgress;
-                result["temperatureScaleBuildupProgress0to1"] = info.temperatureProgress;
+                result["pressureRestrictionProgress0to1"] = info.pressureProgress;
+                result["temperatureRestrictionProgress0to1"] = info.temperatureProgress;
                 result["warnThresholdProgress0to1"] = tracker->trendProgressThreshold();
             }
 


### PR DESCRIPTION
## Summary

- Rewrites the `steam_get_health` MCP tool recommendations to list both likely causes of rising steam pressure/temperature (milk residue in the steam tip *or* scale buildup), with tip-soak suggested first and descaling as the follow-up.
- Renames the output fields from `pressure/temperatureScaleBuildupProgress0to1` → `pressure/temperatureRestrictionProgress0to1` so the schema no longer implies scale is the only cause.
- Updates the tool description to explicitly acknowledge the tool can't distinguish the two causes.

No change to `SteamHealthTracker` math or to the settings page text (which already covered both causes correctly).

Closes #799.

## Test plan

- [ ] Build — expect no compile warnings (string + field renames only)
- [ ] Run `mcp de1 steam_get_health` and confirm:
  - [ ] Response contains `pressureRestrictionProgress0to1` / `temperatureRestrictionProgress0to1` (no `ScaleBuildup` field names)
  - [ ] Recommendation text mentions both milk residue and scale buildup, suggests tip-soak first
  - [ ] `status: monitor` / `warning` / `healthy` still fires at the correct thresholds
- [ ] Spot-check `machine_get_state` embedded `steamHealth` block uses the renamed fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)