### PR TITLE
fix(autosleep): arm stay-awake window when tablet is already awake

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -2666,14 +2666,18 @@ ApplicationWindow {
         target: MainController
 
         function onAutoWakeTriggered() {
-            console.log("[Main] Auto-wake triggered, exiting screensaver")
+            console.log("[Main] Auto-wake triggered")
             if (screensaverActive) {
                 goToIdleFromScreensaver()
-                // Set stay-awake countdown if enabled (after goToIdleFromScreensaver sets normal)
-                if (Settings.autoWakeStayAwakeEnabled && Settings.autoWakeStayAwakeMinutes > 0) {
-                    root.sleepCountdownStayAwake = Settings.autoWakeStayAwakeMinutes
-                    console.log("Auto-wake: stayAwake countdown=" + root.sleepCountdownStayAwake)
-                }
+            }
+            // Arm the stay-awake window on every auto-wake, regardless of whether
+            // the tablet was in screensaver. Otherwise, if the app was already
+            // awake at the scheduled time (user touched the tablet, screensaver
+            // disabled, or app just launched), the window is silently skipped
+            // and the machine sleeps ~autoSleepMinutes after the next shot.
+            if (Settings.autoWakeStayAwakeEnabled && Settings.autoWakeStayAwakeMinutes > 0) {
+                root.sleepCountdownStayAwake = Settings.autoWakeStayAwakeMinutes
+                console.log("Auto-wake: stayAwake countdown=" + root.sleepCountdownStayAwake)
             }
         }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -2670,14 +2670,15 @@ ApplicationWindow {
             if (screensaverActive) {
                 goToIdleFromScreensaver()
             }
-            // Arm the stay-awake window on every auto-wake, regardless of whether
-            // the tablet was in screensaver. Otherwise, if the app was already
-            // awake at the scheduled time (user touched the tablet, screensaver
-            // disabled, or app just launched), the window is silently skipped
-            // and the machine sleeps ~autoSleepMinutes after the next shot.
+            // Arm on every auto-wake, not only when exiting screensaver — the app
+            // may already be awake at the scheduled time, and skipping would let
+            // the machine auto-sleep before the stay-awake window applies.
             if (Settings.autoWakeStayAwakeEnabled && Settings.autoWakeStayAwakeMinutes > 0) {
                 root.sleepCountdownStayAwake = Settings.autoWakeStayAwakeMinutes
                 console.log("Auto-wake: stayAwake countdown=" + root.sleepCountdownStayAwake)
+            } else {
+                console.log("Auto-wake: stayAwake not armed (enabled=" + Settings.autoWakeStayAwakeEnabled +
+                            ", minutes=" + Settings.autoWakeStayAwakeMinutes + ")")
             }
         }
 


### PR DESCRIPTION
## Summary
- If scheduled auto-wake fires while the tablet is already awake (`screensaverActive=false`), `sleepCountdownStayAwake` is never set, and the machine sleeps ~30 min after the first shot instead of honoring the stay-awake window.
- Move the stay-awake counter assignment out of the `if (screensaverActive)` block so the window is armed on every auto-wake trigger.
- `goToIdleFromScreensaver()` still only runs when the tablet actually needs to exit screensaver.

## Why
User report: DE1 programmed to wake at 5:30 AM and stay awake until 7:30 AM. Works as expected **until** a shot is pulled during the window — then the machine reverts to the 30-minute auto-sleep and goes to sleep before the next cup.

Root cause is the `if (screensaverActive)` guard around the stay-awake assignment in the `onAutoWakeTriggered` handler ([qml/main.qml:2670-2677](qml/main.qml:2670)). The two-counter design ("sleep when both normal and stayAwake expire") was correct, but the stayAwake counter was only populated when the tablet happened to be in screensaver at the scheduled wake time.

The fix preserves the existing "sleep at the later of (last shot + autoSleepMinutes) or (wake window end)" behavior — it just ensures the window actually gets armed in all cases.

## Test plan
- [ ] DE1 asleep, tablet in screensaver, scheduled wake at time T with stayAwake=120 min, no shot → DE1 stays awake until T+120.
- [ ] DE1 asleep, tablet **awake** (user touched screen), scheduled wake fires → `Auto-wake: stayAwake countdown=120` appears in logs; DE1 stays awake until T+120.
- [ ] Same as above, pull a shot 15 min into the window → DE1 stays awake until T+120 (not shot+30).
- [ ] Pull a shot near end of window (e.g. T+110 with 30 min normal timeout) → DE1 sleeps at shot+30, not T+120.
- [ ] Stay-awake toggle **off** → behavior unchanged (normal 30-min countdown only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)