### PR TITLE
fix(issue-template): allow file attachments in debug log field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -92,8 +92,7 @@ body:
     id: logs
     attributes:
       label: Debug log / shot debug log
-      description: Attach the app debug log and (if relevant) the shot debug log here. Drag files in or paste text.
-      render: text
+      description: Attach the app debug log and (if relevant) the shot debug log here. Drag files in, paste text, or click the paperclip to upload.
     validations:
       required: false
 


### PR DESCRIPTION
## Summary
- Remove `render: text` from the debug log field in `bug_report.yml` so GitHub's "Paste, drop, or click to add files" affordance is shown — same as on the Screenshots field.
- Previously the field was a plain preformatted block, which stripped the attach toolbar. Reporters couldn't drop `.log` or `.zip` files.

## Test plan
- [ ] Open "New issue → Bug report" and confirm the Debug log field shows the attach paperclip and accepts file drops