### PR TITLE
fix(ble): warn on Linux when CAP_NET_ADMIN is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ set(SOURCES
     src/core/translationmanager.cpp
     src/core/updatechecker.cpp
     src/ble/protocol/binarycodec.cpp
+    src/ble/blecapability.cpp
     src/ble/blemanager.cpp
     src/ble/de1device.cpp
     src/ble/bletransport.cpp
@@ -371,6 +372,7 @@ set(HEADERS
     src/ble/protocol/binarycodec.h
     src/ble/protocol/de1characteristics.h
     src/ble/protocol/decentscaleprotocol.h
+    src/ble/blecapability.h
     src/ble/blemanager.h
     src/ble/de1transport.h
     src/ble/de1device.h

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1925,6 +1925,7 @@ ApplicationWindow {
 
                 AccessibleButton {
                     text: trLinuxBleCapCopy.text
+                    accessibleName: trLinuxBleCapCopy.text
                     onClicked: {
                         cmdText.selectAll()
                         cmdText.copy()

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -466,6 +466,13 @@ ApplicationWindow {
             // On subsequent launches, still check if storage setup is needed
             // (e.g., after reinstall when QSettings was restored but SAF permission wasn't)
             checkStorageSetup()
+
+            // Linux-only: warn if the binary is missing CAP_NET_ADMIN, which
+            // causes BLE connections to the DE1 to fail silently. Only shown
+            // after first run so the welcome dialog isn't obscured.
+            if (BLEManager.linuxBleCapabilityMissing) {
+                Qt.callLater(function() { linuxBleCapabilityDialog.open() })
+            }
         }
 
         // Initialize sleep countdowns (fresh app start, not auto-woken)
@@ -1847,6 +1854,93 @@ ApplicationWindow {
         }
     }
 
+    // Linux BLE capability warning — shown on Linux when the binary lacks
+    // CAP_NET_ADMIN. Without it, BlueZ can't determine whether a BLE address
+    // is random or public and rejects connections to the DE1 (which uses a
+    // random static address) with UnknownRemoteDeviceError. The capability
+    // is granted via `sudo setcap` and is frequently cleared by OS updates.
+    Dialog {
+        id: linuxBleCapabilityDialog
+        modal: true
+        dim: true
+        anchors.centerIn: parent
+        width: Theme.dialogWidth + 2 * padding
+        closePolicy: Dialog.NoAutoClose
+        padding: Theme.dialogPadding
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
+            border.width: 2
+            border.color: Theme.errorColor
+        }
+
+        Tr { id: trLinuxBleCapTitle; key: "main.dialog.linuxBleCapability.title"; fallback: "Bluetooth permission missing"; visible: false }
+        Tr { id: trLinuxBleCapMessage; key: "main.dialog.linuxBleCapability.message"; fallback: "Decenza needs the CAP_NET_ADMIN Linux capability to connect to the DE1 over Bluetooth. Without it, the DE1 is discovered by scans but connections fail with \"Remote device not found\".\n\nThis often happens after a system update clears file capabilities.\n\nRun this command in a terminal, then restart Decenza:"; visible: false }
+        Tr { id: trLinuxBleCapCopy; key: "main.dialog.linuxBleCapability.copy"; fallback: "Copy command"; visible: false }
+
+        contentItem: Column {
+            spacing: Theme.spacingLarge
+
+            Text {
+                text: trLinuxBleCapTitle.text
+                font: Theme.subtitleFont
+                color: Theme.textColor
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            Text {
+                text: trLinuxBleCapMessage.text
+                wrapMode: Text.Wrap
+                width: parent.width
+                font: Theme.bodyFont
+                color: Theme.textColor
+            }
+
+            Rectangle {
+                width: parent.width
+                color: Theme.backgroundColor
+                radius: Theme.cardRadius / 2
+                border.width: 1
+                border.color: Theme.primaryContrastColor
+                height: cmdText.implicitHeight + 2 * Theme.spacingMedium
+
+                TextEdit {
+                    id: cmdText
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingMedium
+                    text: BLEManager.linuxBleSetcapCommand
+                    readOnly: true
+                    selectByMouse: true
+                    wrapMode: TextEdit.Wrap
+                    font.family: "monospace"
+                    font.pixelSize: Theme.bodyFont.pixelSize
+                    color: Theme.textColor
+                }
+            }
+
+            Row {
+                spacing: Theme.spacingMedium
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                AccessibleButton {
+                    text: trLinuxBleCapCopy.text
+                    onClicked: {
+                        cmdText.selectAll()
+                        cmdText.copy()
+                        cmdText.deselect()
+                    }
+                }
+
+                AccessibleButton {
+                    text: trCommonOk.text
+                    accessibleName: trCommonDismissDialog.text
+                    onClicked: linuxBleCapabilityDialog.close()
+                }
+            }
+        }
+    }
+
     // First-run welcome dialog
     Dialog {
         id: firstRunDialog
@@ -1894,6 +1988,9 @@ ApplicationWindow {
                     Settings.setValue("firstRunComplete", true)
                     firstRunDialog.close()
                     checkStorageSetup()
+                    if (BLEManager.linuxBleCapabilityMissing) {
+                        Qt.callLater(function() { linuxBleCapabilityDialog.open() })
+                    }
                 }
             }
         }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -372,6 +372,15 @@ ApplicationWindow {
         })
     }
 
+    // Shows the Linux CAP_NET_ADMIN warning when the binary is missing the
+    // capability. Suppressed in simulator mode (BLE disabled) to avoid a
+    // spurious startup modal for devs running the simulator on Linux.
+    function maybeShowLinuxBleCapabilityDialog() {
+        if (!BLEManager.disabled && BLEManager.linuxBleCapabilityMissing) {
+            Qt.callLater(function() { linuxBleCapabilityDialog.open() })
+        }
+    }
+
     // No timer needed — page transitions are instant (empty Transition{}),
     // so Qt.callLater suffices to let the event loop finish the replace().
 
@@ -467,11 +476,11 @@ ApplicationWindow {
             // (e.g., after reinstall when QSettings was restored but SAF permission wasn't)
             checkStorageSetup()
 
-            // Linux-only: warn if the binary is missing CAP_NET_ADMIN, which
-            // causes BLE connections to the DE1 to fail silently. Only shown
-            // after first run so the welcome dialog isn't obscured.
-            if (BLEManager.linuxBleCapabilityMissing) {
-                Qt.callLater(function() { linuxBleCapabilityDialog.open() })
+            // If a crash dialog is about to open, defer the capability
+            // warning until it's dismissed (see crashReportDialog handlers)
+            // so the two modals don't stack on the same frame.
+            if (!(PreviousCrashLog && PreviousCrashLog.length > 0)) {
+                maybeShowLinuxBleCapabilityDialog()
             }
         }
 
@@ -1802,10 +1811,12 @@ ApplicationWindow {
         onDismissed: {
             // Clear the crash log file
             MainController.clearCrashLog()
+            maybeShowLinuxBleCapabilityDialog()
         }
         onReported: {
             // Clear the crash log file after successful report
             MainController.clearCrashLog()
+            maybeShowLinuxBleCapabilityDialog()
         }
     }
 
@@ -1878,6 +1889,7 @@ ApplicationWindow {
         Tr { id: trLinuxBleCapTitle; key: "main.dialog.linuxBleCapability.title"; fallback: "Bluetooth permission missing"; visible: false }
         Tr { id: trLinuxBleCapMessage; key: "main.dialog.linuxBleCapability.message"; fallback: "Decenza needs the CAP_NET_ADMIN Linux capability to connect to the DE1 over Bluetooth. Without it, the DE1 is discovered by scans but connections fail with \"Remote device not found\".\n\nThis often happens after a system update clears file capabilities.\n\nRun this command in a terminal, then restart Decenza:"; visible: false }
         Tr { id: trLinuxBleCapCopy; key: "main.dialog.linuxBleCapability.copy"; fallback: "Copy command"; visible: false }
+        Tr { id: trLinuxBleCapCommandField; key: "main.dialog.linuxBleCapability.commandField"; fallback: "Setcap command"; visible: false }
 
         contentItem: Column {
             spacing: Theme.spacingLarge
@@ -1916,6 +1928,11 @@ ApplicationWindow {
                     font.family: "monospace"
                     font.pixelSize: Theme.bodyFont.pixelSize
                     color: Theme.textColor
+
+                    Accessible.role: Accessible.EditableText
+                    Accessible.name: trLinuxBleCapCommandField.text
+                    Accessible.readOnly: true
+                    Accessible.focusable: true
                 }
             }
 
@@ -1989,9 +2006,7 @@ ApplicationWindow {
                     Settings.setValue("firstRunComplete", true)
                     firstRunDialog.close()
                     checkStorageSetup()
-                    if (BLEManager.linuxBleCapabilityMissing) {
-                        Qt.callLater(function() { linuxBleCapabilityDialog.open() })
-                    }
+                    maybeShowLinuxBleCapabilityDialog()
                 }
             }
         }

--- a/src/ble/blecapability.cpp
+++ b/src/ble/blecapability.cpp
@@ -1,0 +1,61 @@
+#include "blecapability.h"
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <QFile>
+
+namespace {
+// Cached result of the /proc/self/status CAP_NET_ADMIN probe. BlueZ needs
+// CAP_NET_ADMIN to distinguish random from public BLE addresses; without it,
+// connects to random-address peripherals (the DE1) fail with
+// UnknownRemoteDeviceError. The capability is granted via
+// `sudo setcap 'cap_net_admin+eip' <binary>` and is often cleared by OS
+// package updates.
+bool g_checked = false;
+bool g_missing = false;
+QString g_setcapCommand;
+
+void ensureChecked()
+{
+    if (g_checked) return;
+    g_checked = true;
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    QFile f(QStringLiteral("/proc/self/status"));
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return;
+    while (!f.atEnd()) {
+        const QByteArray line = f.readLine();
+        if (!line.startsWith("CapEff:")) continue;
+        const QString hex = QString::fromUtf8(line.mid(7)).trimmed();
+        bool ok = false;
+        const quint64 capEff = hex.toULongLong(&ok, 16);
+        if (!ok) return;
+        constexpr quint64 CAP_NET_ADMIN_BIT = quint64(1) << 12;  // CAP_NET_ADMIN = 12
+        if ((capEff & CAP_NET_ADMIN_BIT) == 0) {
+            g_missing = true;
+            g_setcapCommand =
+                QStringLiteral("sudo setcap 'cap_net_admin+eip' %1")
+                    .arg(QCoreApplication::applicationFilePath());
+            qWarning().noquote() << "BleCapability: CAP_NET_ADMIN missing — BLE connects to random-address devices (including the DE1) will fail. Fix:"
+                                 << g_setcapCommand;
+        }
+        return;
+    }
+#endif
+}
+} // namespace
+
+namespace BleCapability {
+
+bool linuxMissing()
+{
+    ensureChecked();
+    return g_missing;
+}
+
+QString linuxSetcapCommand()
+{
+    ensureChecked();
+    return g_setcapCommand;
+}
+
+} // namespace BleCapability

--- a/src/ble/blecapability.h
+++ b/src/ble/blecapability.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QString>
+
+// Detection of the Linux CAP_NET_ADMIN capability required by BlueZ to
+// distinguish random from public BLE addresses. Without it, connects to
+// random-address peripherals like the DE1 fail with UnknownRemoteDeviceError.
+// Lives in its own TU so lightweight test binaries can link against it
+// without pulling in all of BLEManager's scale/refractometer dependencies.
+namespace BleCapability {
+
+// Returns true only on Linux (non-Android) when the current process lacks
+// effective CAP_NET_ADMIN. Cached after the first call.
+bool linuxMissing();
+
+// The exact `sudo setcap 'cap_net_admin+eip' <binary>` command that grants
+// the capability. Empty string on non-Linux or when the capability is
+// already present.
+QString linuxSetcapCommand();
+
+} // namespace BleCapability

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -1,4 +1,5 @@
 #include "blemanager.h"
+#include "blecapability.h"
 #include "scaledevice.h"
 #include "protocol/de1characteristics.h"
 #include "scales/scalefactory.h"
@@ -50,59 +51,7 @@ BLEManager::BLEManager(QObject* parent)
 
     // Eagerly run the Linux capability check so any qWarning lands early in
     // startup logs; subsequent calls hit the cached result.
-    (void) BLEManager::isLinuxBleCapabilityMissing();
-}
-
-namespace {
-// Cached result of the /proc/self/status CAP_NET_ADMIN probe. BlueZ needs
-// CAP_NET_ADMIN to distinguish random from public BLE addresses; without it,
-// connects to random-address peripherals (the DE1) fail with
-// UnknownRemoteDeviceError. The capability is granted via
-// `sudo setcap 'cap_net_admin+eip' <binary>` and is often cleared by OS
-// package updates.
-bool g_linuxCapChecked = false;
-bool g_linuxCapMissing = false;
-QString g_linuxSetcapCommand;
-
-void ensureLinuxCapChecked()
-{
-    if (g_linuxCapChecked) return;
-    g_linuxCapChecked = true;
-#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-    QFile f(QStringLiteral("/proc/self/status"));
-    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return;
-    while (!f.atEnd()) {
-        const QByteArray line = f.readLine();
-        if (!line.startsWith("CapEff:")) continue;
-        const QString hex = QString::fromUtf8(line.mid(7)).trimmed();
-        bool ok = false;
-        const quint64 capEff = hex.toULongLong(&ok, 16);
-        if (!ok) return;
-        constexpr quint64 CAP_NET_ADMIN_BIT = quint64(1) << 12;  // CAP_NET_ADMIN = 12
-        if ((capEff & CAP_NET_ADMIN_BIT) == 0) {
-            g_linuxCapMissing = true;
-            g_linuxSetcapCommand =
-                QStringLiteral("sudo setcap 'cap_net_admin+eip' %1")
-                    .arg(QCoreApplication::applicationFilePath());
-            qWarning().noquote() << "BLEManager: CAP_NET_ADMIN missing — BLE connects to random-address devices (including the DE1) will fail. Fix:"
-                                 << g_linuxSetcapCommand;
-        }
-        return;
-    }
-#endif
-}
-} // namespace
-
-bool BLEManager::isLinuxBleCapabilityMissing()
-{
-    ensureLinuxCapChecked();
-    return g_linuxCapMissing;
-}
-
-QString BLEManager::linuxBleSetcapCommandStatic()
-{
-    ensureLinuxCapChecked();
-    return g_linuxSetcapCommand;
+    (void) BleCapability::linuxMissing();
 }
 
 bool BLEManager::isBluetoothAvailable() const

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -48,17 +48,27 @@ BLEManager::BLEManager(QObject* parent)
     m_scaleConnectionTimer->setInterval(20000);
     connect(m_scaleConnectionTimer, &QTimer::timeout, this, &BLEManager::onScaleConnectionTimeout);
 
-    checkLinuxBleCapability();
+    // Eagerly run the Linux capability check so any qWarning lands early in
+    // startup logs; subsequent calls hit the cached result.
+    (void) BLEManager::isLinuxBleCapabilityMissing();
 }
 
-void BLEManager::checkLinuxBleCapability()
+namespace {
+// Cached result of the /proc/self/status CAP_NET_ADMIN probe. BlueZ needs
+// CAP_NET_ADMIN to distinguish random from public BLE addresses; without it,
+// connects to random-address peripherals (the DE1) fail with
+// UnknownRemoteDeviceError. The capability is granted via
+// `sudo setcap 'cap_net_admin+eip' <binary>` and is often cleared by OS
+// package updates.
+bool g_linuxCapChecked = false;
+bool g_linuxCapMissing = false;
+QString g_linuxSetcapCommand;
+
+void ensureLinuxCapChecked()
 {
+    if (g_linuxCapChecked) return;
+    g_linuxCapChecked = true;
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-    // BlueZ needs CAP_NET_ADMIN to determine whether a remote BLE address is
-    // random or public. Without it, connects to random-address peripherals
-    // (like the DE1) fail with UnknownRemoteDeviceError. The capability is
-    // granted via `sudo setcap 'cap_net_admin+eip' <binary>` and is often
-    // cleared by OS package updates, so detect and surface it.
     QFile f(QStringLiteral("/proc/self/status"));
     if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return;
     while (!f.atEnd()) {
@@ -70,16 +80,29 @@ void BLEManager::checkLinuxBleCapability()
         if (!ok) return;
         constexpr quint64 CAP_NET_ADMIN_BIT = quint64(1) << 12;  // CAP_NET_ADMIN = 12
         if ((capEff & CAP_NET_ADMIN_BIT) == 0) {
-            m_linuxBleCapabilityMissing = true;
-            m_linuxBleSetcapCommand =
+            g_linuxCapMissing = true;
+            g_linuxSetcapCommand =
                 QStringLiteral("sudo setcap 'cap_net_admin+eip' %1")
                     .arg(QCoreApplication::applicationFilePath());
             qWarning().noquote() << "BLEManager: CAP_NET_ADMIN missing — BLE connects to random-address devices (including the DE1) will fail. Fix:"
-                                 << m_linuxBleSetcapCommand;
+                                 << g_linuxSetcapCommand;
         }
         return;
     }
 #endif
+}
+} // namespace
+
+bool BLEManager::isLinuxBleCapabilityMissing()
+{
+    ensureLinuxCapChecked();
+    return g_linuxCapMissing;
+}
+
+QString BLEManager::linuxBleSetcapCommandStatic()
+{
+    ensureLinuxCapChecked();
+    return g_linuxSetcapCommand;
 }
 
 bool BLEManager::isBluetoothAvailable() const

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -47,6 +47,39 @@ BLEManager::BLEManager(QObject* parent)
     m_scaleConnectionTimer->setSingleShot(true);
     m_scaleConnectionTimer->setInterval(20000);
     connect(m_scaleConnectionTimer, &QTimer::timeout, this, &BLEManager::onScaleConnectionTimeout);
+
+    checkLinuxBleCapability();
+}
+
+void BLEManager::checkLinuxBleCapability()
+{
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    // BlueZ needs CAP_NET_ADMIN to determine whether a remote BLE address is
+    // random or public. Without it, connects to random-address peripherals
+    // (like the DE1) fail with UnknownRemoteDeviceError. The capability is
+    // granted via `sudo setcap 'cap_net_admin+eip' <binary>` and is often
+    // cleared by OS package updates, so detect and surface it.
+    QFile f(QStringLiteral("/proc/self/status"));
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return;
+    while (!f.atEnd()) {
+        const QByteArray line = f.readLine();
+        if (!line.startsWith("CapEff:")) continue;
+        const QString hex = QString::fromUtf8(line.mid(7)).trimmed();
+        bool ok = false;
+        const quint64 capEff = hex.toULongLong(&ok, 16);
+        if (!ok) return;
+        constexpr quint64 CAP_NET_ADMIN_BIT = quint64(1) << 12;  // CAP_NET_ADMIN = 12
+        if ((capEff & CAP_NET_ADMIN_BIT) == 0) {
+            m_linuxBleCapabilityMissing = true;
+            m_linuxBleSetcapCommand =
+                QStringLiteral("sudo setcap 'cap_net_admin+eip' %1")
+                    .arg(QCoreApplication::applicationFilePath());
+            qWarning().noquote() << "BLEManager: CAP_NET_ADMIN missing — BLE connects to random-address devices (including the DE1) will fail. Fix:"
+                                 << m_linuxBleSetcapCommand;
+        }
+        return;
+    }
+#endif
 }
 
 bool BLEManager::isBluetoothAvailable() const

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -11,6 +11,8 @@
 #include <QStringList>
 #include <QFile>
 
+#include "blecapability.h"
+
 class ScaleDevice;
 class DiFluidR2;
 
@@ -62,14 +64,8 @@ public:
     bool scaleConnectionFailed() const { return m_scaleConnectionFailed; }
     bool hasSavedScale() const { return !m_savedScaleAddress.isEmpty(); }
     bool hasSavedDE1() const { return !m_savedDE1Address.isEmpty(); }
-    bool linuxBleCapabilityMissing() const { return isLinuxBleCapabilityMissing(); }
-    QString linuxBleSetcapCommand() const { return linuxBleSetcapCommandStatic(); }
-
-    // Static accessors — usable by BLE transport classes that don't hold a
-    // BLEManager reference. Return false/empty on non-Linux (and cached after
-    // first call).
-    static bool isLinuxBleCapabilityMissing();
-    static QString linuxBleSetcapCommandStatic();
+    bool linuxBleCapabilityMissing() const { return BleCapability::linuxMissing(); }
+    QString linuxBleSetcapCommand() const { return BleCapability::linuxSetcapCommand(); }
 
     Q_INVOKABLE QBluetoothDeviceInfo getScaleDeviceInfo(const QString& address) const;
     Q_INVOKABLE QString getScaleType(const QString& address) const;

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -45,6 +45,8 @@ class BLEManager : public QObject {
     Q_PROPERTY(bool refractometerConnected READ isRefractometerConnected NOTIFY refractometerConnectedChanged)
     Q_PROPERTY(bool hasSavedDE1 READ hasSavedDE1 CONSTANT)
     Q_PROPERTY(bool disabled READ isDisabled WRITE setDisabled NOTIFY disabledChanged)
+    Q_PROPERTY(bool linuxBleCapabilityMissing READ linuxBleCapabilityMissing CONSTANT)
+    Q_PROPERTY(QString linuxBleSetcapCommand READ linuxBleSetcapCommand CONSTANT)
 
 public:
     explicit BLEManager(QObject* parent = nullptr);
@@ -60,6 +62,8 @@ public:
     bool scaleConnectionFailed() const { return m_scaleConnectionFailed; }
     bool hasSavedScale() const { return !m_savedScaleAddress.isEmpty(); }
     bool hasSavedDE1() const { return !m_savedDE1Address.isEmpty(); }
+    bool linuxBleCapabilityMissing() const { return m_linuxBleCapabilityMissing; }
+    QString linuxBleSetcapCommand() const { return m_linuxBleSetcapCommand; }
 
     Q_INVOKABLE QBluetoothDeviceInfo getScaleDeviceInfo(const QString& address) const;
     Q_INVOKABLE QString getScaleType(const QString& address) const;
@@ -142,6 +146,7 @@ private:
     void requestBluetoothPermission();
     void doStartScan();
     void ensureDiscoveryAgent();
+    void checkLinuxBleCapability();
 
 #ifndef Q_OS_IOS
     QBluetoothLocalDevice* m_localDevice = nullptr;
@@ -154,6 +159,8 @@ private:
     bool m_scanningForScales = false;  // True when scanning for scales (user or auto-reconnect)
     bool m_userInitiatedScaleScan = false;  // True only for user-initiated scan (show all scales)
     bool m_scaleConnectionFailed = false;
+    bool m_linuxBleCapabilityMissing = false;
+    QString m_linuxBleSetcapCommand;
     ScaleDevice* m_scaleDevice = nullptr;
     QTimer* m_scaleConnectionTimer = nullptr;
 

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -62,8 +62,14 @@ public:
     bool scaleConnectionFailed() const { return m_scaleConnectionFailed; }
     bool hasSavedScale() const { return !m_savedScaleAddress.isEmpty(); }
     bool hasSavedDE1() const { return !m_savedDE1Address.isEmpty(); }
-    bool linuxBleCapabilityMissing() const { return m_linuxBleCapabilityMissing; }
-    QString linuxBleSetcapCommand() const { return m_linuxBleSetcapCommand; }
+    bool linuxBleCapabilityMissing() const { return isLinuxBleCapabilityMissing(); }
+    QString linuxBleSetcapCommand() const { return linuxBleSetcapCommandStatic(); }
+
+    // Static accessors — usable by BLE transport classes that don't hold a
+    // BLEManager reference. Return false/empty on non-Linux (and cached after
+    // first call).
+    static bool isLinuxBleCapabilityMissing();
+    static QString linuxBleSetcapCommandStatic();
 
     Q_INVOKABLE QBluetoothDeviceInfo getScaleDeviceInfo(const QString& address) const;
     Q_INVOKABLE QString getScaleType(const QString& address) const;
@@ -146,7 +152,6 @@ private:
     void requestBluetoothPermission();
     void doStartScan();
     void ensureDiscoveryAgent();
-    void checkLinuxBleCapability();
 
 #ifndef Q_OS_IOS
     QBluetoothLocalDevice* m_localDevice = nullptr;
@@ -159,8 +164,6 @@ private:
     bool m_scanningForScales = false;  // True when scanning for scales (user or auto-reconnect)
     bool m_userInitiatedScaleScan = false;  // True only for user-initiated scan (show all scales)
     bool m_scaleConnectionFailed = false;
-    bool m_linuxBleCapabilityMissing = false;
-    QString m_linuxBleSetcapCommand;
     ScaleDevice* m_scaleDevice = nullptr;
     QTimer* m_scaleConnectionTimer = nullptr;
 

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -1,5 +1,5 @@
 #include "bletransport.h"
-#include "blemanager.h"
+#include "blecapability.h"
 #include "protocol/de1characteristics.h"
 
 #include <QBluetoothAddress>
@@ -397,10 +397,10 @@ void BleTransport::onControllerError(QLowEnergyController::Error error) {
     // setcap hint when we've actually detected the capability is missing —
     // otherwise we'd mislead users whose error has a different cause.
     if (error == QLowEnergyController::UnknownRemoteDeviceError
-        && BLEManager::isLinuxBleCapabilityMissing()) {
+        && BleCapability::linuxMissing()) {
         warn(QStringLiteral("Linux hint: run `%1` and restart the app "
                             "(capability is often cleared by OS updates).")
-                 .arg(BLEManager::linuxBleSetcapCommandStatic()));
+                 .arg(BleCapability::linuxSetcapCommand()));
     }
 }
 

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -2,12 +2,12 @@
 #include "protocol/de1characteristics.h"
 
 #include <QBluetoothAddress>
+#include <QCoreApplication>
 #include <QLowEnergyConnectionParameters>
 #include <QDebug>
 
 #ifdef Q_OS_ANDROID
 #include <QJniObject>
-#include <QCoreApplication>
 
 // Store DE1 address in Android SharedPreferences for shutdown service
 static void storeDE1AddressForShutdown(const QString& address) {
@@ -391,6 +391,21 @@ void BleTransport::onControllerError(QLowEnergyController::Error error) {
     }
     warn(QString("!!! CONTROLLER ERROR: %1 !!!").arg(errorName));
     emit errorOccurred(userMessage);
+
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    // On desktop Linux, BlueZ requires CAP_NET_ADMIN for the process to
+    // determine whether a remote BLE address is random or public. Without it,
+    // Qt guesses wrong and BlueZ rejects the connection with
+    // UnknownRemoteDeviceError. The DE1 uses a random static address, so this
+    // hits users whose binary lost its file capability (e.g. after an OS
+    // upgrade re-extracted the package).
+    if (error == QLowEnergyController::UnknownRemoteDeviceError) {
+        const QString exe = QCoreApplication::applicationFilePath();
+        warn(QStringLiteral("Linux hint: run `sudo setcap 'cap_net_admin+eip' %1` "
+                            "and restart the app (capability is often cleared by OS updates).")
+                 .arg(exe));
+    }
+#endif
 }
 
 void BleTransport::onServiceDiscovered(const QBluetoothUuid& uuid) {

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -1,8 +1,8 @@
 #include "bletransport.h"
+#include "blemanager.h"
 #include "protocol/de1characteristics.h"
 
 #include <QBluetoothAddress>
-#include <QCoreApplication>
 #include <QLowEnergyConnectionParameters>
 #include <QDebug>
 
@@ -392,20 +392,16 @@ void BleTransport::onControllerError(QLowEnergyController::Error error) {
     warn(QString("!!! CONTROLLER ERROR: %1 !!!").arg(errorName));
     emit errorOccurred(userMessage);
 
-#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-    // On desktop Linux, BlueZ requires CAP_NET_ADMIN for the process to
-    // determine whether a remote BLE address is random or public. Without it,
-    // Qt guesses wrong and BlueZ rejects the connection with
-    // UnknownRemoteDeviceError. The DE1 uses a random static address, so this
-    // hits users whose binary lost its file capability (e.g. after an OS
-    // upgrade re-extracted the package).
-    if (error == QLowEnergyController::UnknownRemoteDeviceError) {
-        const QString exe = QCoreApplication::applicationFilePath();
-        warn(QStringLiteral("Linux hint: run `sudo setcap 'cap_net_admin+eip' %1` "
-                            "and restart the app (capability is often cleared by OS updates).")
-                 .arg(exe));
+    // On Linux, UnknownRemoteDeviceError usually means the process lacks
+    // CAP_NET_ADMIN and BlueZ guessed the address type wrong. Only log the
+    // setcap hint when we've actually detected the capability is missing —
+    // otherwise we'd mislead users whose error has a different cause.
+    if (error == QLowEnergyController::UnknownRemoteDeviceError
+        && BLEManager::isLinuxBleCapabilityMissing()) {
+        warn(QStringLiteral("Linux hint: run `%1` and restart the app "
+                            "(capability is often cleared by OS updates).")
+                 .arg(BLEManager::linuxBleSetcapCommandStatic()));
     }
-#endif
 }
 
 void BleTransport::onServiceDiscovered(const QBluetoothUuid& uuid) {

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -1,5 +1,5 @@
 #include "qtscalebletransport.h"
-#include "../blemanager.h"
+#include "../blecapability.h"
 #include <QDebug>
 #include <QTimer>
 #include <QLowEnergyConnectionParameters>
@@ -286,10 +286,10 @@ void QtScaleBleTransport::onControllerError(QLowEnergyController::Error err) {
     // Only log the setcap hint when we've actually detected the missing
     // capability — the check is a no-op / always false on non-Linux.
     if (err == QLowEnergyController::UnknownRemoteDeviceError
-        && BLEManager::isLinuxBleCapabilityMissing()) {
+        && BleCapability::linuxMissing()) {
         QT_TRANSPORT_LOG(QStringLiteral("Linux hint: run `%1` and restart the app "
                                         "(capability is often cleared by OS updates).")
-                             .arg(BLEManager::linuxBleSetcapCommandStatic()));
+                             .arg(BleCapability::linuxSetcapCommand()));
     }
 }
 

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -1,5 +1,5 @@
 #include "qtscalebletransport.h"
-#include <QCoreApplication>
+#include "../blemanager.h"
 #include <QDebug>
 #include <QTimer>
 #include <QLowEnergyConnectionParameters>
@@ -283,17 +283,14 @@ void QtScaleBleTransport::onControllerError(QLowEnergyController::Error err) {
     QT_TRANSPORT_LOG(msg);
     emit error(msg);
 
-#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-    // See BleTransport::onControllerError for context. Without CAP_NET_ADMIN,
-    // BlueZ can't tell random vs public BLE addresses and rejects connects
-    // with UnknownRemoteDeviceError.
-    if (err == QLowEnergyController::UnknownRemoteDeviceError) {
-        const QString exe = QCoreApplication::applicationFilePath();
-        QT_TRANSPORT_LOG(QStringLiteral("Linux hint: run `sudo setcap 'cap_net_admin+eip' %1` "
-                                        "and restart the app (capability is often cleared by OS updates).")
-                             .arg(exe));
+    // Only log the setcap hint when we've actually detected the missing
+    // capability — the check is a no-op / always false on non-Linux.
+    if (err == QLowEnergyController::UnknownRemoteDeviceError
+        && BLEManager::isLinuxBleCapabilityMissing()) {
+        QT_TRANSPORT_LOG(QStringLiteral("Linux hint: run `%1` and restart the app "
+                                        "(capability is often cleared by OS updates).")
+                             .arg(BLEManager::linuxBleSetcapCommandStatic()));
     }
-#endif
 }
 
 void QtScaleBleTransport::onServiceDiscovered(const QBluetoothUuid& uuid) {

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -1,4 +1,5 @@
 #include "qtscalebletransport.h"
+#include <QCoreApplication>
 #include <QDebug>
 #include <QTimer>
 #include <QLowEnergyConnectionParameters>
@@ -281,6 +282,18 @@ void QtScaleBleTransport::onControllerError(QLowEnergyController::Error err) {
     QString msg = QString("!!! CONTROLLER ERROR: %1 !!!").arg(errorName);
     QT_TRANSPORT_LOG(msg);
     emit error(msg);
+
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    // See BleTransport::onControllerError for context. Without CAP_NET_ADMIN,
+    // BlueZ can't tell random vs public BLE addresses and rejects connects
+    // with UnknownRemoteDeviceError.
+    if (err == QLowEnergyController::UnknownRemoteDeviceError) {
+        const QString exe = QCoreApplication::applicationFilePath();
+        QT_TRANSPORT_LOG(QStringLiteral("Linux hint: run `sudo setcap 'cap_net_admin+eip' %1` "
+                                        "and restart the app (capability is often cleared by OS updates).")
+                             .arg(exe));
+    }
+#endif
 }
 
 void QtScaleBleTransport::onServiceDiscovered(const QBluetoothUuid& uuid) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(MACHINE_SOURCES
 set(BLE_SOURCES
     ${CMAKE_SOURCE_DIR}/src/ble/de1device.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/bletransport.cpp
+    ${CMAKE_SOURCE_DIR}/src/ble/blecapability.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/scaledevice.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/protocol/binarycodec.cpp
 )


### PR DESCRIPTION
## Summary
- Fixes [#804](https://github.com/Kulitorum/Decenza/issues/804): on Raspberry Pi OS (and other Linux), an OS update can strip the `CAP_NET_ADMIN` file capability from the Decenza binary. Without it, BlueZ can't tell random from public BLE addresses and rejects connects to the DE1 (random static address) with `UnknownRemoteDeviceError` — the DE1 is found by scans but never comes online.
- Detects a missing effective `CAP_NET_ADMIN` at `BLEManager` startup via `/proc/self/status` and exposes it to QML as a CONSTANT Q_PROPERTY along with the exact `sudo setcap 'cap_net_admin+eip' <binary>` command.
- Shows a prominent modal dialog (red border, non-dismissible-by-outside-click) at startup with the command in a selectable read-only field plus a Copy button. Dialog is deferred until after the first-run welcome on fresh installs.
- Adds a fallback actionable hint to the connection log when `UnknownRemoteDeviceError` fires (for DE1 and scale BLE transports), in case the user dismisses the dialog or the check somehow misses.

## Test plan
- [ ] On Linux without the capability: launch app → verify modal dialog appears with the exact command and binary path, Copy button puts it on the clipboard.
- [ ] Run the command, restart: dialog no longer appears, DE1 connects normally.
- [ ] On macOS/Windows/Android: no dialog, no regressions (the check is compiled out).
- [ ] On first-run (fresh install) Linux without cap: welcome dialog shows first, capability dialog appears after clicking Continue.
- [ ] Verify the log hint still fires on `UnknownRemoteDeviceError` (e.g. if the user dismissed the dialog) and surfaces in the connection log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)