### PR TITLE
fix(saw): +10g bump persisting across shots (#806)

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1501,14 +1501,6 @@ void MainController::onEspressoCycleStarted() {
         }
     }
 
-    // Reset MachineState::targetWeight to the profile's current value so any +10g
-    // bump from the previous shot doesn't carry over. main.cpp reads
-    // machineState.targetWeight() in its espressoCycleStarted lambda to configure
-    // WeightProcessor, and MainController's handler runs first (connected earlier).
-    if (m_machineState && m_profileManager) {
-        m_machineState->setTargetWeight(m_profileManager->targetWeight());
-    }
-
     // Save previous shot if settling is still in progress — startShot() emits
     // shotProcessingReady synchronously, which triggers onShotEnded(). This must
     // happen BEFORE clearing the model or resetting m_extractionStarted, otherwise
@@ -1567,6 +1559,13 @@ void MainController::onEspressoCycleStarted() {
 }
 
 void MainController::onShotEnded() {
+    // Clear any +10g bump applied via bumpTargetWeight() so MachineState::targetWeight
+    // matches the profile again before the next shot. Doing this at shot end (rather
+    // than at next-shot start) avoids depending on signal-handler connection order.
+    if (m_machineState && m_profileManager) {
+        m_machineState->setTargetWeight(m_profileManager->targetWeight());
+    }
+
     // Clear filtered goals so CupFillView doesn't show stale tracking colors
     if (m_filteredGoalPressure != 0 || m_filteredGoalFlow != 0) {
         m_filteredGoalPressure = 0;

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1501,6 +1501,14 @@ void MainController::onEspressoCycleStarted() {
         }
     }
 
+    // Reset MachineState::targetWeight to the profile's current value so any +10g
+    // bump from the previous shot doesn't carry over. main.cpp reads
+    // machineState.targetWeight() in its espressoCycleStarted lambda to configure
+    // WeightProcessor, and MainController's handler runs first (connected earlier).
+    if (m_machineState && m_profileManager) {
+        m_machineState->setTargetWeight(m_profileManager->targetWeight());
+    }
+
     // Save previous shot if settling is still in progress — startShot() emits
     // shotProcessingReady synchronously, which triggers onShotEnded(). This must
     // happen BEFORE clearing the model or resetting m_extractionStarted, otherwise


### PR DESCRIPTION
## Summary
- The +10g button was intended to bump SAW only for the in-progress shot, but the bump was persisting into the next shot (build 3290, issue #806).
- Root cause: `bumpTargetWeight()` writes to `MachineState::m_targetWeight`, which is only rewritten on profile load or brew-yield override change. At shot 2 start, [main.cpp:615](https://github.com/Kulitorum/Decenza/blob/main/src/main.cpp#L615) reads `machineState.targetWeight()` (still bumped) and configures `WeightProcessor` with the stale value — SAW fires 10g late.
- Fix: at the top of `MainController::onEspressoCycleStarted`, reset `MachineState::targetWeight` to `ProfileManager::targetWeight()` (which already reflects the DYE brew-yield override). `MainController`'s handler is connected before the `main.cpp` lambda, so the reset lands before `WeightProcessor` reads it.

Fixes #806

## Test plan
- [ ] Start a shot, press +10g mid-pour — confirm the in-progress shot's SAW target is +10g above recipe.
- [ ] Without pressing +10g, start a second shot on the same profile — confirm SAW target matches the recipe (no carry-over).
- [ ] With a brew-yield override active (DYE ratio), repeat the above — confirm the override is still honored on shot 2.
- [ ] Verify no regression on Android (the reported platform) and desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)