### PR TITLE
fix(ble): follow-up Linux BLE diagnostics after #805

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ set(SOURCES
     src/ble/scales/flowscale.cpp
     src/ble/transport/qtscalebletransport.cpp
     src/core/asynclogger.cpp
+    src/core/btlogfilter.cpp
     src/machine/machinestate.cpp
     src/machine/weightprocessor.cpp
     src/profile/profile.cpp
@@ -396,6 +397,7 @@ set(HEADERS
     src/ble/transport/scalebletransport.h
     src/ble/transport/qtscalebletransport.h
     src/core/asynclogger.h
+    src/core/btlogfilter.h
     src/machine/machinestate.h
     src/machine/weightprocessor.h
     src/profile/profile.h

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1959,6 +1959,113 @@ ApplicationWindow {
         }
     }
 
+    // Linux BLE BlueZ-cache recovery hint — shown when UnknownRemoteDeviceError
+    // fires on a DE1 connection attempt while CAP_NET_ADMIN is effective. That
+    // combination almost always means the host-side BlueZ state is stale
+    // (cached address type, expired pairing) after an OS upgrade or similar.
+    // Gated to Linux + caps-OK; the setcap dialog above covers the caps-missing
+    // case.
+    Connections {
+        target: BLEManager
+        function onLinuxBlueZCacheHintNeeded() {
+            if (BLEManager.disabled) return
+            if (BLEManager.linuxBleCapabilityMissing) return  // setcap dialog takes precedence
+            Qt.callLater(function() { linuxBleBluezCacheDialog.open() })
+        }
+    }
+
+    Dialog {
+        id: linuxBleBluezCacheDialog
+        modal: true
+        dim: true
+        anchors.centerIn: parent
+        width: Theme.dialogWidth + 2 * padding
+        closePolicy: Dialog.NoAutoClose
+        padding: Theme.dialogPadding
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
+            border.width: 2
+            border.color: Theme.errorColor
+        }
+
+        Tr { id: trBluezCacheTitle; key: "main.dialog.linuxBleBluezCache.title"; fallback: "Can't connect to DE1 — try clearing the Bluetooth cache"; visible: false }
+        Tr { id: trBluezCacheMessage; key: "main.dialog.linuxBleBluezCache.message"; fallback: "The DE1 was discovered but the Bluetooth stack rejected the connection (\"Remote device not found\"). This usually means BlueZ cached stale pairing or address information after an OS update.\n\nIn a terminal, remove the cached entry and restart the Bluetooth service, then power-cycle the DE1 and try again:"; visible: false }
+        Tr { id: trBluezCacheCopy; key: "main.dialog.linuxBleBluezCache.copy"; fallback: "Copy commands"; visible: false }
+        Tr { id: trBluezCacheCommandField; key: "main.dialog.linuxBleBluezCache.commandField"; fallback: "BlueZ recovery commands"; visible: false }
+
+        contentItem: Column {
+            spacing: Theme.spacingLarge
+
+            Text {
+                text: trBluezCacheTitle.text
+                font: Theme.subtitleFont
+                color: Theme.textColor
+                anchors.horizontalCenter: parent.horizontalCenter
+                wrapMode: Text.Wrap
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            Text {
+                text: trBluezCacheMessage.text
+                wrapMode: Text.Wrap
+                width: parent.width
+                font: Theme.bodyFont
+                color: Theme.textColor
+            }
+
+            Rectangle {
+                width: parent.width
+                color: Theme.backgroundColor
+                radius: Theme.cardRadius / 2
+                border.width: 1
+                border.color: Theme.primaryContrastColor
+                height: bluezCmdText.implicitHeight + 2 * Theme.spacingMedium
+
+                TextEdit {
+                    id: bluezCmdText
+                    anchors.fill: parent
+                    anchors.margins: Theme.spacingMedium
+                    text: "MAC=$(bluetoothctl devices | awk '/DE1/ {print $2; exit}')\nbluetoothctl remove \"$MAC\"\nsudo systemctl restart bluetooth"
+                    readOnly: true
+                    selectByMouse: true
+                    wrapMode: TextEdit.Wrap
+                    font.family: "monospace"
+                    font.pixelSize: Theme.bodyFont.pixelSize
+                    color: Theme.textColor
+
+                    Accessible.role: Accessible.EditableText
+                    Accessible.name: trBluezCacheCommandField.text
+                    Accessible.readOnly: true
+                    Accessible.focusable: true
+                }
+            }
+
+            Row {
+                spacing: Theme.spacingMedium
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                AccessibleButton {
+                    text: trBluezCacheCopy.text
+                    accessibleName: trBluezCacheCopy.text
+                    onClicked: {
+                        bluezCmdText.selectAll()
+                        bluezCmdText.copy()
+                        bluezCmdText.deselect()
+                    }
+                }
+
+                AccessibleButton {
+                    text: trCommonOk.text
+                    accessibleName: trCommonDismissDialog.text
+                    onClicked: linuxBleBluezCacheDialog.close()
+                }
+            }
+        }
+    }
+
     // First-run welcome dialog
     Dialog {
         id: firstRunDialog

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1960,11 +1960,11 @@ ApplicationWindow {
     }
 
     // Linux BLE BlueZ-cache recovery hint — shown when UnknownRemoteDeviceError
-    // fires on a DE1 connection attempt while CAP_NET_ADMIN is effective. That
-    // combination almost always means the host-side BlueZ state is stale
-    // (cached address type, expired pairing) after an OS upgrade or similar.
-    // Gated to Linux + caps-OK; the setcap dialog above covers the caps-missing
-    // case.
+    // fires on a DE1 or scale connection attempt while CAP_NET_ADMIN is
+    // effective. That combination almost always means the host-side BlueZ
+    // state is stale (cached address type, expired pairing) after an OS
+    // upgrade. Gated to Linux + caps-OK; the setcap dialog above covers the
+    // caps-missing case.
     Connections {
         target: BLEManager
         function onLinuxBlueZCacheHintNeeded() {

--- a/src/ble/blecapability.cpp
+++ b/src/ble/blecapability.cpp
@@ -3,6 +3,10 @@
 #include <QCoreApplication>
 #include <QDebug>
 #include <QFile>
+#include <QProcess>
+#include <QStandardPaths>
+#include <atomic>
+#include <mutex>
 
 namespace {
 // Cached result of the /proc/self/status CAP_NET_ADMIN probe. BlueZ needs
@@ -42,6 +46,41 @@ void ensureChecked()
     }
 #endif
 }
+
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+// Run a short-lived external command and return its stdout (trimmed).
+// Returns an empty string if the binary isn't installed or the command
+// exceeded the 2-second budget. Stays on the caller's thread — only
+// invoked from the one-shot diagnostics dump, which runs off the BLE
+// error handler path.
+QString runBriefly(const QString& program, const QStringList& args)
+{
+    const QString resolved = QStandardPaths::findExecutable(program);
+    if (resolved.isEmpty()) return QString();
+    QProcess p;
+    p.setProcessChannelMode(QProcess::MergedChannels);
+    p.start(resolved, args);
+    if (!p.waitForFinished(2000)) {
+        p.kill();
+        p.waitForFinished(250);
+        return QString();
+    }
+    return QString::fromUtf8(p.readAllStandardOutput()).trimmed();
+}
+
+void logProcStatusCaps()
+{
+    QFile f(QStringLiteral("/proc/self/status"));
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return;
+    while (!f.atEnd()) {
+        const QByteArray line = f.readLine();
+        if (line.startsWith("CapEff:") || line.startsWith("CapBnd:")
+            || line.startsWith("CapInh:") || line.startsWith("CapAmb:")) {
+            qInfo().noquote() << "BtDiagnostics:" << QString::fromUtf8(line).trimmed();
+        }
+    }
+}
+#endif
 } // namespace
 
 namespace BleCapability {
@@ -56,6 +95,42 @@ QString linuxSetcapCommand()
 {
     ensureChecked();
     return g_setcapCommand;
+}
+
+void logLinuxBtDiagnosticsOnce()
+{
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    static std::once_flag flag;
+    std::call_once(flag, [] {
+        qInfo().noquote() << "BtDiagnostics: ---- Linux BT diagnostics (one-shot) ----";
+        qInfo().noquote() << "BtDiagnostics: binary =" << QCoreApplication::applicationFilePath();
+        logProcStatusCaps();
+
+        const QString getcap = runBriefly(QStringLiteral("getcap"),
+                                          {QCoreApplication::applicationFilePath()});
+        if (!getcap.isEmpty())
+            qInfo().noquote() << "BtDiagnostics: getcap =" << getcap;
+
+        const QString bluezVersion = runBriefly(QStringLiteral("bluetoothctl"),
+                                                {QStringLiteral("--version")});
+        if (!bluezVersion.isEmpty())
+            qInfo().noquote() << "BtDiagnostics: bluetoothctl =" << bluezVersion;
+
+        const QString hci = runBriefly(QStringLiteral("hciconfig"), {QStringLiteral("-a")});
+        if (!hci.isEmpty()) {
+            const auto lines = hci.split(u'\n');
+            for (const QString& l : lines)
+                qInfo().noquote() << "BtDiagnostics: hciconfig:" << l;
+        }
+        qInfo().noquote() << "BtDiagnostics: ---- end ----";
+    });
+#endif
+}
+
+bool takeBluezCacheHintToken()
+{
+    static std::atomic_bool fired{false};
+    return !fired.exchange(true);
 }
 
 } // namespace BleCapability

--- a/src/ble/blecapability.cpp
+++ b/src/ble/blecapability.cpp
@@ -5,54 +5,44 @@
 #include <QFile>
 #include <QProcess>
 #include <QStandardPaths>
+#include <QThread>
 #include <atomic>
 #include <mutex>
 
 namespace {
-// Cached result of the /proc/self/status CAP_NET_ADMIN probe. BlueZ needs
-// CAP_NET_ADMIN to distinguish random from public BLE addresses; without it,
-// connects to random-address peripherals (the DE1) fail with
-// UnknownRemoteDeviceError. The capability is granted via
-// `sudo setcap 'cap_net_admin+eip' <binary>` and is often cleared by OS
-// package updates.
-bool g_checked = false;
+std::once_flag g_checkFlag;
 bool g_missing = false;
 QString g_setcapCommand;
 
 void ensureChecked()
 {
-    if (g_checked) return;
-    g_checked = true;
+    std::call_once(g_checkFlag, [] {
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-    QFile f(QStringLiteral("/proc/self/status"));
-    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return;
-    while (!f.atEnd()) {
-        const QByteArray line = f.readLine();
-        if (!line.startsWith("CapEff:")) continue;
-        const QString hex = QString::fromUtf8(line.mid(7)).trimmed();
-        bool ok = false;
-        const quint64 capEff = hex.toULongLong(&ok, 16);
-        if (!ok) return;
-        constexpr quint64 CAP_NET_ADMIN_BIT = quint64(1) << 12;  // CAP_NET_ADMIN = 12
-        if ((capEff & CAP_NET_ADMIN_BIT) == 0) {
-            g_missing = true;
-            g_setcapCommand =
-                QStringLiteral("sudo setcap 'cap_net_admin+eip' %1")
-                    .arg(QCoreApplication::applicationFilePath());
-            qWarning().noquote() << "BleCapability: CAP_NET_ADMIN missing — BLE connects to random-address devices (including the DE1) will fail. Fix:"
-                                 << g_setcapCommand;
+        QFile f(QStringLiteral("/proc/self/status"));
+        if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return;
+        while (!f.atEnd()) {
+            const QByteArray line = f.readLine();
+            if (!line.startsWith("CapEff:")) continue;
+            const QString hex = QString::fromUtf8(line.mid(7)).trimmed();
+            bool ok = false;
+            const quint64 capEff = hex.toULongLong(&ok, 16);
+            if (!ok) return;
+            constexpr quint64 CAP_NET_ADMIN_BIT = quint64(1) << 12;
+            if ((capEff & CAP_NET_ADMIN_BIT) == 0) {
+                g_missing = true;
+                g_setcapCommand =
+                    QStringLiteral("sudo setcap 'cap_net_admin+eip' %1")
+                        .arg(QCoreApplication::applicationFilePath());
+                qWarning().noquote() << "BleCapability: CAP_NET_ADMIN missing — BLE connects to random-address devices (including the DE1) will fail. Fix:"
+                                     << g_setcapCommand;
+            }
+            return;
         }
-        return;
-    }
 #endif
+    });
 }
 
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-// Run a short-lived external command and return its stdout (trimmed).
-// Returns an empty string if the binary isn't installed or the command
-// exceeded the 2-second budget. Stays on the caller's thread — only
-// invoked from the one-shot diagnostics dump, which runs off the BLE
-// error handler path.
 QString runBriefly(const QString& program, const QStringList& args)
 {
     const QString resolved = QStandardPaths::findExecutable(program);
@@ -80,6 +70,31 @@ void logProcStatusCaps()
         }
     }
 }
+
+void collectAndLogDiagnostics()
+{
+    qInfo().noquote() << "BtDiagnostics: ---- Linux BT diagnostics (one-shot) ----";
+    qInfo().noquote() << "BtDiagnostics: binary =" << QCoreApplication::applicationFilePath();
+    logProcStatusCaps();
+
+    const QString getcap = runBriefly(QStringLiteral("getcap"),
+                                      {QCoreApplication::applicationFilePath()});
+    if (!getcap.isEmpty())
+        qInfo().noquote() << "BtDiagnostics: getcap =" << getcap;
+
+    const QString bluezVersion = runBriefly(QStringLiteral("bluetoothctl"),
+                                            {QStringLiteral("--version")});
+    if (!bluezVersion.isEmpty())
+        qInfo().noquote() << "BtDiagnostics: bluetoothctl =" << bluezVersion;
+
+    const QString hci = runBriefly(QStringLiteral("hciconfig"), {QStringLiteral("-a")});
+    if (!hci.isEmpty()) {
+        const auto lines = hci.split(u'\n');
+        for (const QString& l : lines)
+            qInfo().noquote() << "BtDiagnostics: hciconfig:" << l;
+    }
+    qInfo().noquote() << "BtDiagnostics: ---- end ----";
+}
 #endif
 } // namespace
 
@@ -102,27 +117,12 @@ void logLinuxBtDiagnosticsOnce()
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     static std::once_flag flag;
     std::call_once(flag, [] {
-        qInfo().noquote() << "BtDiagnostics: ---- Linux BT diagnostics (one-shot) ----";
-        qInfo().noquote() << "BtDiagnostics: binary =" << QCoreApplication::applicationFilePath();
-        logProcStatusCaps();
-
-        const QString getcap = runBriefly(QStringLiteral("getcap"),
-                                          {QCoreApplication::applicationFilePath()});
-        if (!getcap.isEmpty())
-            qInfo().noquote() << "BtDiagnostics: getcap =" << getcap;
-
-        const QString bluezVersion = runBriefly(QStringLiteral("bluetoothctl"),
-                                                {QStringLiteral("--version")});
-        if (!bluezVersion.isEmpty())
-            qInfo().noquote() << "BtDiagnostics: bluetoothctl =" << bluezVersion;
-
-        const QString hci = runBriefly(QStringLiteral("hciconfig"), {QStringLiteral("-a")});
-        if (!hci.isEmpty()) {
-            const auto lines = hci.split(u'\n');
-            for (const QString& l : lines)
-                qInfo().noquote() << "BtDiagnostics: hciconfig:" << l;
-        }
-        qInfo().noquote() << "BtDiagnostics: ---- end ----";
+        // QProcess::waitForFinished() blocks up to 2 s per subprocess; spawn
+        // a worker thread so the BLE error handler (main thread) returns
+        // immediately.
+        QThread* t = QThread::create([] { collectAndLogDiagnostics(); });
+        QObject::connect(t, &QThread::finished, t, &QObject::deleteLater);
+        t->start();
     });
 #endif
 }

--- a/src/ble/blecapability.h
+++ b/src/ble/blecapability.h
@@ -18,4 +18,16 @@ bool linuxMissing();
 // already present.
 QString linuxSetcapCommand();
 
+// Dump a one-shot block of Linux BT diagnostics (CapEff/CapBnd, getcap,
+// BlueZ version, hciconfig -a) to the debug log via qInfo(). Safe to call
+// from any BLE error path; fires at most once per process and is a no-op
+// on non-Linux. Designed to flow into the debug log that the issue
+// template attaches to bug reports.
+void logLinuxBtDiagnosticsOnce();
+
+// One-shot latch for the BlueZ-cache recovery hint. Returns true the
+// first time it is called in a process, false thereafter. Used by
+// transport error paths to emit the hint signal only once per session.
+bool takeBluezCacheHintToken();
+
 } // namespace BleCapability

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -113,6 +113,7 @@ BLEManager::~BLEManager() {
 
 void BLEManager::requestBluezCacheHint()
 {
+    if (m_disabled) return;  // don't burn the one-shot token in simulator mode
     if (BleCapability::takeBluezCacheHintToken()) {
         emit linuxBlueZCacheHintNeeded();
     }

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -28,9 +28,13 @@
 #include <QUrl>
 #endif
 
+BLEManager* BLEManager::s_instance = nullptr;
+
 BLEManager::BLEManager(QObject* parent)
     : QObject(parent)
 {
+    s_instance = this;
+
     // Discovery agent is created lazily in ensureDiscoveryAgent() to avoid
     // initializing CoreBluetooth (and triggering TCC privacy checks) when
     // BLE is disabled (e.g. simulation mode on Mac debug builds).
@@ -103,6 +107,14 @@ void BLEManager::ensureDiscoveryAgent() {
 BLEManager::~BLEManager() {
     if (m_scanning) {
         stopScan();
+    }
+    if (s_instance == this) s_instance = nullptr;
+}
+
+void BLEManager::requestBluezCacheHint()
+{
+    if (BleCapability::takeBluezCacheHintToken()) {
+        emit linuxBlueZCacheHintNeeded();
     }
 }
 

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -67,6 +67,17 @@ public:
     bool linuxBleCapabilityMissing() const { return BleCapability::linuxMissing(); }
     QString linuxBleSetcapCommand() const { return BleCapability::linuxSetcapCommand(); }
 
+    // Singleton accessor so the transport layer can surface the BlueZ-cache
+    // hint without plumbing a BLEManager* through every constructor. Only
+    // one BLEManager is ever constructed (see main.cpp).
+    static BLEManager* instance() { return s_instance; }
+
+    // Emit linuxBlueZCacheHintNeeded at most once per session. Invoked from
+    // the transport layer when UnknownRemoteDeviceError fires and the
+    // capability check indicates caps are effective (so the cause is
+    // almost certainly a stale BlueZ cache or similar host-side state).
+    void requestBluezCacheHint();
+
     Q_INVOKABLE QBluetoothDeviceInfo getScaleDeviceInfo(const QString& address) const;
     Q_INVOKABLE QString getScaleType(const QString& address) const;
     Q_INVOKABLE void connectToScale(const QString& address);  // Manual scale selection
@@ -132,6 +143,7 @@ signals:
     void refractometerConnectedChanged();
     void refractometerDiscovered(const QBluetoothDeviceInfo& device);
     void disconnectRefractometerRequested();
+    void linuxBlueZCacheHintNeeded();  // Request the BlueZ-cache recovery dialog (Linux, caps OK).
 
 
 private slots:
@@ -192,4 +204,6 @@ private:
     QStringList m_scaleLogMessages;
     QString m_scaleLogFilePath;
     void writeScaleLogToFile();
+
+    static BLEManager* s_instance;
 };

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -1,5 +1,6 @@
 #include "bletransport.h"
 #include "blecapability.h"
+#include "blemanager.h"
 #include "protocol/de1characteristics.h"
 
 #include <QBluetoothAddress>
@@ -392,6 +393,12 @@ void BleTransport::onControllerError(QLowEnergyController::Error error) {
     warn(QString("!!! CONTROLLER ERROR: %1 !!!").arg(errorName));
     emit errorOccurred(userMessage);
 
+    // Dump a one-shot Linux BT diagnostics block into the debug log the
+    // first time any transport error fires. The issue template attaches
+    // the debug log to every bug report, so this flows to maintainers
+    // automatically. No-op on non-Linux.
+    BleCapability::logLinuxBtDiagnosticsOnce();
+
     // On Linux, UnknownRemoteDeviceError usually means the process lacks
     // CAP_NET_ADMIN and BlueZ guessed the address type wrong. Only log the
     // setcap hint when we've actually detected the capability is missing —
@@ -401,6 +408,15 @@ void BleTransport::onControllerError(QLowEnergyController::Error error) {
         warn(QStringLiteral("Linux hint: run `%1` and restart the app "
                             "(capability is often cleared by OS updates).")
                  .arg(BleCapability::linuxSetcapCommand()));
+    }
+
+    // Caps are fine but the DE1 still couldn't be resolved — almost always
+    // a stale BlueZ cache after an OS upgrade. Ask BLEManager to surface
+    // the recovery dialog (it de-dupes; only the first call per session
+    // fires the signal).
+    if (error == QLowEnergyController::UnknownRemoteDeviceError
+        && !BleCapability::linuxMissing()) {
+        if (auto* m = BLEManager::instance()) m->requestBluezCacheHint();
     }
 }
 

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -1,5 +1,6 @@
 #include "qtscalebletransport.h"
 #include "../blecapability.h"
+#include "../blemanager.h"
 #include <QDebug>
 #include <QTimer>
 #include <QLowEnergyConnectionParameters>
@@ -283,6 +284,10 @@ void QtScaleBleTransport::onControllerError(QLowEnergyController::Error err) {
     QT_TRANSPORT_LOG(msg);
     emit error(msg);
 
+    // Same one-shot Linux BT diagnostics dump as the DE1 transport —
+    // whichever transport hits an error first triggers it.
+    BleCapability::logLinuxBtDiagnosticsOnce();
+
     // Only log the setcap hint when we've actually detected the missing
     // capability — the check is a no-op / always false on non-Linux.
     if (err == QLowEnergyController::UnknownRemoteDeviceError
@@ -290,6 +295,13 @@ void QtScaleBleTransport::onControllerError(QLowEnergyController::Error err) {
         QT_TRANSPORT_LOG(QStringLiteral("Linux hint: run `%1` and restart the app "
                                         "(capability is often cleared by OS updates).")
                              .arg(BleCapability::linuxSetcapCommand()));
+    }
+
+    // Caps OK but still UnknownRemoteDeviceError — surface the BlueZ cache
+    // recovery dialog via BLEManager.
+    if (err == QLowEnergyController::UnknownRemoteDeviceError
+        && !BleCapability::linuxMissing()) {
+        if (auto* m = BLEManager::instance()) m->requestBluezCacheHint();
     }
 }
 

--- a/src/core/btlogfilter.cpp
+++ b/src/core/btlogfilter.cpp
@@ -1,0 +1,33 @@
+#include "btlogfilter.h"
+
+#include "../ble/blecapability.h"
+
+#include <QString>
+
+namespace {
+QtMessageHandler g_previousHandler = nullptr;
+
+void messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg)
+{
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    if (type == QtWarningMsg
+        && !BleCapability::linuxMissing()
+        && msg.contains(QStringLiteral("Missing CAP_NET_ADMIN permission"))) {
+        return;  // our independent probe says caps are effective; drop the false alarm
+    }
+#endif
+    if (g_previousHandler) g_previousHandler(type, context, msg);
+}
+} // namespace
+
+namespace BtLogFilter {
+
+void install()
+{
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    if (g_previousHandler) return;
+    g_previousHandler = qInstallMessageHandler(messageHandler);
+#endif
+}
+
+} // namespace BtLogFilter

--- a/src/core/btlogfilter.h
+++ b/src/core/btlogfilter.h
@@ -4,13 +4,13 @@
 
 // Chains into qInstallMessageHandler to drop Qt's "Missing CAP_NET_ADMIN
 // permission..." bluetooth warning when BleCapability::linuxMissing() is
-// false. Qt prints that warning under conditions where it isn't actually
-// caused by missing caps (see issue #804 follow-up) which misleads users
-// into running setcap despite caps already being effective.
+// false — Qt prints the warning under conditions that don't always mean
+// caps are missing, and the false alarm misleads users who have already
+// granted the capability.
 //
-// Installation order matters — install AFTER AsyncLogger so we sit above
-// it in the handler chain and reach messages before they're enqueued:
-//   qDebug() → ShotDebugLogger → WebDebugLogger → CrashHandler → BtLogFilter → AsyncLogger
+// Install AFTER AsyncLogger, CrashHandler, and WebDebugLogger so this
+// filter sits at the top of the static chain and can suppress the false
+// warning before it reaches any other handler.
 //
 // No-op on non-Linux.
 namespace BtLogFilter {

--- a/src/core/btlogfilter.h
+++ b/src/core/btlogfilter.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QtGlobal>
+
+// Chains into qInstallMessageHandler to drop Qt's "Missing CAP_NET_ADMIN
+// permission..." bluetooth warning when BleCapability::linuxMissing() is
+// false. Qt prints that warning under conditions where it isn't actually
+// caused by missing caps (see issue #804 follow-up) which misleads users
+// into running setcap despite caps already being effective.
+//
+// Installation order matters — install AFTER AsyncLogger so we sit above
+// it in the handler chain and reach messages before they're enqueued:
+//   qDebug() → ShotDebugLogger → WebDebugLogger → CrashHandler → BtLogFilter → AsyncLogger
+//
+// No-op on non-Linux.
+namespace BtLogFilter {
+
+void install();
+
+} // namespace BtLogFilter

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@
 
 
 #include "core/asynclogger.h"
+#include "core/btlogfilter.h"
 #include "core/settings.h"
 #include "core/translationmanager.h"
 #include "core/batterymanager.h"
@@ -327,6 +328,10 @@ int main(int argc, char *argv[])
 
     // Install web debug logger early to capture all output
     WebDebugLogger::install();
+
+    // Install BLE log filter before Qt's Bluetooth module fires its
+    // spurious "Missing CAP_NET_ADMIN" warning (issue #804 follow-up).
+    BtLogFilter::install();
 
     QApplication app(argc, argv);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,8 +329,9 @@ int main(int argc, char *argv[])
     // Install web debug logger early to capture all output
     WebDebugLogger::install();
 
-    // Install BLE log filter before Qt's Bluetooth module fires its
-    // spurious "Missing CAP_NET_ADMIN" warning (issue #804 follow-up).
+    // Suppress Qt's spurious "Missing CAP_NET_ADMIN" bluetooth warning
+    // when our own probe says caps are effective. Must run before Qt
+    // Bluetooth classes are constructed.
     BtLogFilter::install();
 
     QApplication app(argc, argv);


### PR DESCRIPTION
## Summary

Follow-up to #805 covering the case where CAP_NET_ADMIN is effective but BLE still fails — the exact situation reported in #804, where Qt's misleading `"Missing CAP_NET_ADMIN permission"` warning sent the user down the setcap rabbit hole while the real cause was a stale BlueZ cache.

Three changes, all Linux-only (no-op on macOS/Windows/Android):

### 1. `BtLogFilter` — suppress Qt's false cap warning
New chained `qInstallMessageHandler` in `src/core/btlogfilter.{h,cpp}`. When `BleCapability::linuxMissing()` is false and the incoming message is Qt's `"Missing CAP_NET_ADMIN permission"` warning, drop it on the floor. Installed in `main.cpp` right after `WebDebugLogger` so it sees Bluetooth warnings before they propagate.

### 2. BlueZ-cache recovery dialog
When `UnknownRemoteDeviceError` fires on a DE1 or scale connect attempt **and** caps are effective, the host BlueZ state is almost always stale. A new modal surfaces the recovery commands:

```
MAC=$(bluetoothctl devices | awk '/DE1/ {print $2; exit}')
bluetoothctl remove "$MAC"
sudo systemctl restart bluetooth
```

with a Copy button. Plumbed via a new `BLEManager::linuxBlueZCacheHintNeeded()` signal, a public `requestBluezCacheHint()` method (de-dupes via `BleCapability::takeBluezCacheHintToken()`), and a new static `BLEManager::instance()` so the transport layer can reach it without a constructor change. Dialog modeled on the setcap dialog from #805 and gated on `!disabled && !linuxBleCapabilityMissing` so it never stacks with it.

### 3. One-shot BT diagnostics dump
First time any BLE transport error fires in a session, `BleCapability::logLinuxBtDiagnosticsOnce()` writes a block to the debug log via `qInfo()`:

- `CapEff`/`CapBnd`/`CapInh`/`CapAmb` from `/proc/self/status`
- `getcap` on the binary
- `bluetoothctl --version`
- `hciconfig -a` (if installed)

Guarded by `std::once_flag`. Since #802/#803 wired the issue template to attach the debug log, these diagnostics flow into every future Linux BLE bug report for free — no UI surface needed, no support round-trips.

## Test plan
- [ ] **Caps missing (existing #805 behavior unchanged):** `sudo setcap -r` → launch → confirm setcap dialog still opens
- [ ] **Caps present + Qt false-alarm suppressed:** `sudo setcap 'cap_net_admin+eip' Decenza_DE1` → launch with `QT_LOGGING_RULES="qt.bluetooth.warning=true"` → scan → confirm the `"Missing CAP_NET_ADMIN"` line does **not** appear in stdout/debug log
- [ ] **BlueZ-cache dialog:** caps present, power off DE1 to force `UnknownRemoteDeviceError` → confirm new dialog opens with recovery commands; Copy works; fires once per session; does not stack with setcap dialog
- [ ] **Diagnostics dump:** trigger any transport error → confirm single `BtDiagnostics:` block in debug log with all four sections; second error does **not** re-dump
- [ ] **Non-Linux no-op:** build/run on macOS — confirm no new code paths run, no new log lines, and the new QML connection is silent (signal never emitted)

Closes #804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)