### PR TITLE
fix(history): skip bulk shot export when on-disk file is already current

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -3067,15 +3067,21 @@ ApplicationWindow {
 
     Connections {
         target: ShotHistoryExporter
-        function onBulkExportFinished(ok, failed) {
+        function onBulkExportFinished(written, skipped, failed) {
+            // Suppress the toast when nothing was actually written — a warm
+            // startup where every file is already current is the common case
+            // and a silent no-op is the honest signal there.
+            if (written === 0 && failed === 0) {
+                return
+            }
             if (failed > 0) {
                 shotExportToastText = TranslationManager.translate(
                     "main.toast.exportShotsPartial",
-                    "Exported %1 shots; %2 failed").arg(ok).arg(failed)
+                    "Exported %1 shots; %2 failed").arg(written).arg(failed)
             } else {
                 shotExportToastText = TranslationManager.translate(
                     "main.toast.exportShotsDone",
-                    "Exported %1 shots").arg(ok)
+                    "Exported %1 shots").arg(written)
             }
             shotExportToast.opacity = 1
             shotExportToastTimer.restart()

--- a/src/history/shothistoryexporter.cpp
+++ b/src/history/shothistoryexporter.cpp
@@ -9,6 +9,7 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QSaveFile>
 #include <QSet>
 #include <QSqlQuery>
@@ -89,6 +90,29 @@ void ShotHistoryExporter::onShotDeleted(qint64 shotId)
 
 namespace {
 
+struct ShotRefreshInfo {
+    qint64 id = 0;
+    qint64 timestamp = 0;
+    qint64 updatedAt = 0;
+};
+
+QString exportedFilePath(const QString& historyDir, qint64 timestamp, qint64 shotId)
+{
+    const QDateTime dt = QDateTime::fromSecsSinceEpoch(timestamp);
+    return historyDir + "/" + QString("%1_%2.json")
+        .arg(dt.toString("yyyyMMddTHHmmss"))
+        .arg(shotId);
+}
+
+// Returns true if the exported file is present and was written after the
+// shot's last DB update (so its contents are known to be current).
+bool exportedFileIsFresh(const QString& historyDir, const ShotRefreshInfo& info)
+{
+    const QFileInfo fi(exportedFilePath(historyDir, info.timestamp, info.id));
+    if (!fi.exists() || fi.size() <= 0) return false;
+    return fi.lastModified().toSecsSinceEpoch() >= info.updatedAt;
+}
+
 bool writeShotJson(const QString& dbPath,
                    const QString& historyDir,
                    qint64 shotId)
@@ -105,11 +129,7 @@ bool writeShotJson(const QString& dbPath,
     QVariantMap shotData = ShotHistoryStorage::convertShotRecord(record);
     QByteArray payload = VisualizerUploader::buildHistoryShotJson(shotData);
 
-    const QDateTime dt = QDateTime::fromSecsSinceEpoch(record.summary.timestamp);
-    const QString filename = QString("%1_%2.json")
-        .arg(dt.toString("yyyyMMddTHHmmss"))
-        .arg(shotId);
-    const QString fullPath = historyDir + "/" + filename;
+    const QString fullPath = exportedFilePath(historyDir, record.summary.timestamp, shotId);
 
     QSaveFile file(fullPath);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
@@ -139,26 +159,38 @@ void ShotHistoryExporter::startBulkExport()
     auto destroyed = m_destroyed;
 
     QThread* thread = QThread::create([this, dbPath, historyDir, destroyed]() {
-        auto selectAllIds = [&dbPath](QList<qint64>& out) {
+        auto selectAllShots = [&dbPath](QList<ShotRefreshInfo>& out) {
             withTempDb(dbPath, "she_ids", [&](QSqlDatabase& db) {
                 QSqlQuery q(db);
-                if (!q.exec(QStringLiteral("SELECT id FROM shots ORDER BY id ASC"))) {
+                if (!q.exec(QStringLiteral(
+                        "SELECT id, timestamp, COALESCE(updated_at, 0) "
+                        "FROM shots ORDER BY id ASC"))) {
                     qWarning() << "ShotHistoryExporter: id enumeration failed:" << q.lastError().text();
                     return;
                 }
-                while (q.next()) out.append(q.value(0).toLongLong());
+                while (q.next()) {
+                    ShotRefreshInfo info;
+                    info.id = q.value(0).toLongLong();
+                    info.timestamp = q.value(1).toLongLong();
+                    info.updatedAt = q.value(2).toLongLong();
+                    out.append(info);
+                }
             });
         };
 
-        QList<qint64> ids;
-        selectAllIds(ids);
+        QList<ShotRefreshInfo> shots;
+        selectAllShots(shots);
 
         QSet<qint64> seen;
-        int ok = 0, failed = 0;
-        for (qint64 id : ids) {
+        int written = 0, skipped = 0, failed = 0;
+        for (const ShotRefreshInfo& info : shots) {
             if (*destroyed) return;
-            seen.insert(id);
-            if (writeShotJson(dbPath, historyDir, id)) ok++;
+            seen.insert(info.id);
+            if (exportedFileIsFresh(historyDir, info)) {
+                skipped++;
+                continue;
+            }
+            if (writeShotJson(dbPath, historyDir, info.id)) written++;
             else failed++;
         }
 
@@ -166,20 +198,24 @@ void ShotHistoryExporter::startBulkExport()
         // flip m_bulkRunning to false are ignored by onShotSaved (which
         // early-returns while bulk is running). Re-query and process any
         // that landed during this run so they still end up on disk.
-        QList<qint64> latest;
-        selectAllIds(latest);
-        for (qint64 id : latest) {
+        QList<ShotRefreshInfo> latest;
+        selectAllShots(latest);
+        for (const ShotRefreshInfo& info : latest) {
             if (*destroyed) return;
-            if (seen.contains(id)) continue;
-            if (writeShotJson(dbPath, historyDir, id)) ok++;
+            if (seen.contains(info.id)) continue;
+            if (exportedFileIsFresh(historyDir, info)) {
+                skipped++;
+                continue;
+            }
+            if (writeShotJson(dbPath, historyDir, info.id)) written++;
             else failed++;
         }
 
         if (*destroyed) return;
-        QMetaObject::invokeMethod(this, [this, ok, failed, destroyed]() {
+        QMetaObject::invokeMethod(this, [this, written, skipped, failed, destroyed]() {
             if (*destroyed) return;
             m_bulkRunning.store(false);
-            emit bulkExportFinished(ok, failed);
+            emit bulkExportFinished(written, skipped, failed);
         }, Qt::QueuedConnection);
     });
     connect(thread, &QThread::finished, thread, &QObject::deleteLater);

--- a/src/history/shothistoryexporter.h
+++ b/src/history/shothistoryexporter.h
@@ -16,7 +16,10 @@ class ShotHistoryStorage;
 // Design:
 //  * Stateless when off: no tracking of "which shots have been exported."
 //  * Toggle off -> on, and app startup with the toggle already on:
-//    full re-export overwriting whatever is on disk.
+//    bulk pass that self-heals anything missing or out of date. Each shot's
+//    existing file is kept if its mtime is >= the shot's updated_at column,
+//    so a warm run with no DB changes performs no writes (and no shot-record
+//    load / JSON parse, which is where the real cost lived).
 //  * Toggle on: incrementally export each new shot when shotSaved fires,
 //               refresh on metadata updates.
 //  * Shot deletions always remove matching exported files regardless of the
@@ -34,8 +37,10 @@ public:
 
 signals:
     // Emitted on the main thread after the initial bulk export finishes.
-    // ok + failed together equal the total shots attempted.
-    void bulkExportFinished(int ok, int failed);
+    // written + skipped + failed together equal the total shots attempted.
+    // "skipped" counts shots whose on-disk export was already current
+    // (file mtime >= shot updated_at), so no write was performed.
+    void bulkExportFinished(int written, int skipped, int failed);
 
 private slots:
     void onExportToggleChanged();

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -552,7 +552,8 @@ bool ShotHistoryStorage::runMigrations()
                 readQuery.prepare("SELECT id, grinder_model FROM shots WHERE grinder_model IS NOT NULL AND grinder_model != ''");
                 if (readQuery.exec()) {
                     QSqlQuery updateQuery(m_db);
-                    updateQuery.prepare("UPDATE shots SET grinder_brand = ?, grinder_model = ?, grinder_burrs = ? WHERE id = ?");
+                    updateQuery.prepare("UPDATE shots SET grinder_brand = ?, grinder_model = ?, grinder_burrs = ?, "
+                                        "updated_at = strftime('%s', 'now') WHERE id = ?");
                     int backfillCount = 0;
 
                     while (readQuery.next()) {
@@ -1763,7 +1764,8 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
                 QSqlQuery q(db);
                 q.prepare("UPDATE shots SET channeling_detected=:c,"
                           " temperature_unstable=:t, grind_issue_detected=:g,"
-                          " skip_first_frame_detected=:s WHERE id=:id");
+                          " skip_first_frame_detected=:s,"
+                          " updated_at = strftime('%s', 'now') WHERE id=:id");
                 q.bindValue(":c", newChanneling ? 1 : 0);
                 q.bindValue(":t", newTempUnstable ? 1 : 0);
                 q.bindValue(":g", newGrindIssue ? 1 : 0);
@@ -3440,7 +3442,8 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                     QString type = doc.object().value("beverage_type").toString();
                     if (!type.isEmpty() && type != "espresso") {
                         QSqlQuery update(destDb);
-                        update.prepare("UPDATE shots SET beverage_type = ? WHERE id = ?");
+                        update.prepare("UPDATE shots SET beverage_type = ?, "
+                                       "updated_at = strftime('%s', 'now') WHERE id = ?");
                         update.addBindValue(type);
                         update.addBindValue(id);
                         update.exec();
@@ -3761,7 +3764,8 @@ void ShotHistoryStorage::backfillBeverageType()
         QString type = doc.object().value("beverage_type").toString();
         if (!type.isEmpty() && type != "espresso") {
             QSqlQuery update(m_db);
-            update.prepare("UPDATE shots SET beverage_type = ? WHERE id = ?");
+            update.prepare("UPDATE shots SET beverage_type = ?, "
+                           "updated_at = strftime('%s', 'now') WHERE id = ?");
             update.bindValue(0, type);
             update.bindValue(1, id);
             update.exec();
@@ -3819,7 +3823,8 @@ void ShotHistoryStorage::requestUpdateGrinderFields(const QString& oldBrand, con
         int count = 0;
         withTempDb(dbPath, "shs_grinder_update", [&](QSqlDatabase& db) {
             QSqlQuery query(db);
-            query.prepare("UPDATE shots SET grinder_brand = ?, grinder_model = ?, grinder_burrs = ? "
+            query.prepare("UPDATE shots SET grinder_brand = ?, grinder_model = ?, grinder_burrs = ?, "
+                          "updated_at = strftime('%s', 'now') "
                           "WHERE grinder_brand = ? AND grinder_model = ?");
             query.bindValue(0, newBrand);
             query.bindValue(1, newModel);


### PR DESCRIPTION
## Summary
- Addresses fix option **#3** from #812: ShotHistoryExporter now skips rewriting an exported shot file when the on-disk copy is already current (file exists, non-empty, `mtime >= shots.updated_at`). On a warm start no shot records are loaded and no profile JSON is parsed, so the ~1,365-line "Syncing espresso_temperature..." debug spam and the ~5 s of redundant disk work during startup both go away for users with large libraries.
- Bulk enumeration query now selects `(id, timestamp, COALESCE(updated_at, 0))` so the worker can make the freshness decision without hitting `loadShotRecordStatic()` unless a write is actually needed.
- `bulkExportFinished` signal widened to `(int written, int skipped, int failed)` — no external subscribers today. Header comment updated to describe the self-heal behaviour.

## Test plan
- [ ] Build Release in Qt Creator (macOS/Windows).
- [ ] With `exportShotsToFile` enabled and a populated history folder, launch the app and confirm no "Syncing espresso_temperature..." lines and no `jsonToDouble: failed to parse string ""` warnings in the log.
- [ ] Delete one exported JSON, relaunch, confirm it reappears and the rest are still skipped.
- [ ] Edit a shot's metadata (e.g. enjoyment / notes) while running, confirm the single-shot exporter still rewrites that file.
- [ ] Toggle `exportShotsToFile` off then on, confirm files that already exist are kept and nothing is rewritten if unchanged.
- [ ] Manually set the mtime of one exported file to the epoch, relaunch, confirm only that one is rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)