### PR TITLE
fix: stop leaking TDS/EY into next shot metadata

### DIFF
--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -260,8 +260,10 @@ Page {
         }
         MainController.shotHistory.requestUpdateShotMetadata(editShotId, metadata)
 
-        // Sync sticky metadata back to Settings (bean/grinder info) for the next shot
-        // but NOT enjoyment/notes which are shot-specific
+        // Sync sticky metadata back to Settings (bean/grinder info) for the next shot.
+        // Per-shot fields (enjoyment, notes, TDS, EY) are NOT synced — otherwise they
+        // would leak into the next shot's metadata, since MainController builds shot
+        // metadata from these Settings values at shot end.
         Settings.dyeBeanBrand = editBeanBrand
         Settings.dyeBeanType = editBeanType
         Settings.dyeRoastDate = editRoastDate
@@ -273,9 +275,6 @@ Page {
         Settings.dyeBarista = editBarista
         if (editDoseWeight > 0) Settings.dyeBeanWeight = editDoseWeight
         if (editDrinkWeight > 0) Settings.dyeDrinkWeight = editDrinkWeight
-        if (editDrinkTds > 0) Settings.dyeDrinkTds = editDrinkTds
-        if (editDrinkEy > 0) Settings.dyeDrinkEy = editDrinkEy
-        // Note: enjoyment and notes are NOT synced back - they're shot-specific
         // Note: reload deferred to onShotMetadataUpdated to avoid race with async write
     }
 


### PR DESCRIPTION
## Summary

- `PostShotReviewPage.saveEditedShot()` was syncing the edited TDS and EY back to `Settings.dyeDrinkTds` / `Settings.dyeDrinkEy`.
- `MainController::onShotEnded` (`src/controllers/maincontroller.cpp:1681-1682`) builds every new shot's metadata from those same Settings values, and correctly resets them to 0 after saving — but the post-shot review handler was immediately un-resetting them.
- Result: shot N's TDS/EY would silently appear on shot N+1 until the user typed new numbers.

Fix: drop the two sticky-sync assignments. TDS and EY are per-shot values, same as enjoyment and notes (which were already excluded). Updated the surrounding comment to document the rule and why it matters.

## Test plan

- [ ] Record a shot, open post-shot review, enter a TDS value (EY auto-calculates), save.
- [ ] Pull a second shot, open post-shot review: TDS and EY fields should be empty, not carrying shot 1's values.
- [ ] Confirm bean/grinder/dose/drink weight still persist across shots as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)