### PR TITLE
fix(ble): recover DE1 connect after cold BlueZ cache / direct-wake error

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -336,6 +336,7 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
         }
         m_de1Devices.append(device);
         emit devicesChanged();
+        qDebug() << "[BLE] Found DE1:" << device.name() << "at" << getDeviceIdentifier(device);
         emit de1LogMessage(QString("Found DE1: %1 (%2)").arg(device.name()).arg(getDeviceIdentifier(device)));
         emit de1Discovered(device);
         return;

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -425,6 +425,21 @@ void BleTransport::onControllerError(QLowEnergyController::Error error) {
         if (auto* m = BLEManager::instance()) m->requestBluezCacheHint();
     }
 #endif
+
+    // Synthesize disconnected() so the upper layer treats the attempt as
+    // terminated. Without this, DE1Device::m_connecting stays true forever
+    // after a connect-time error like UnknownRemoteDeviceError, and the
+    // !isConnecting() guard in the de1Discovered handler (main.cpp) silently
+    // drops every subsequent scan-triggered retry. Qt's stateChanged →
+    // UnconnectedState synthesis at setupController() handles the common
+    // case, but BlueZ does not reliably transition to Unconnected after
+    // UnknownRemoteDeviceError when the device isn't in the adapter cache.
+    // The m_disconnectedEmittedForAttempt guard de-dupes if Qt fires later.
+    if (!m_disconnectedEmittedForAttempt) {
+        m_disconnectedEmittedForAttempt = true;
+        log("Controller error — synthesizing disconnected() so retry path can fire");
+        emit disconnected();
+    }
 }
 
 void BleTransport::onServiceDiscovered(const QBluetoothUuid& uuid) {


### PR DESCRIPTION
## Summary
- `BleTransport::onControllerError` now synthesizes `disconnected()` (de-duped by the existing `m_disconnectedEmittedForAttempt` flag) so `DE1Device::m_connecting` clears after a connect-time error like `UnknownRemoteDeviceError`. Without this, the `!isConnecting()` guard in the `de1Discovered` handler silently dropped every scan-triggered retry, leaving the DE1 stuck in "Found but never Online" forever.
- Add a `qDebug()` for DE1 discoveries in `BLEManager::onDeviceDiscovered`, symmetric with the existing scale/refractometer logging. Future Linux BLE bug reports will actually show "Found DE1:" in the attached stdout.

## Why
Reported in [#804](https://github.com/Kulitorum/Decenza/issues/804). Linux user running Decenza on a Pi with BlueZ. After wiping the BlueZ cache, the direct-wake path errors immediately with `UnknownRemoteDeviceError` (BlueZ has no record of the DE1's random static address type). Qt does not reliably transition the controller to `UnconnectedState` after that error on BlueZ, so the existing `stateChanged → UnconnectedState` synthesis at `setupController()` doesn't fire either. `m_connecting` stayed `true` forever; every subsequent scan-discovered retry bailed silently.

The Skale path in the same log recovered cleanly from the same error because scales get a fresh `QtScaleBleTransport` per retry attempt. The DE1Device is a persistent singleton, so its flag needed explicit clearing.

de1app has equivalent explicit recovery at `bluetooth.tcl:check_if_initial_connect_didnt_happen_quickly` (a 4s watchdog that tears down a stuck direct-connect and clears `currently_connecting_de1_handle`). Since CLAUDE.md forbids timers as guards, this PR does the event-based equivalent on the error signal instead.

## Test plan
- [ ] Verify existing connect/reconnect flows still work on Windows, macOS, Android (no regressions from the synthetic `disconnected()` — the de-dup flag ensures we never double-emit if Qt also fires the real signal).
- [ ] On Linux with BlueZ, reproduce the cold-cache scenario (`bluetoothctl remove <DE1-MAC>; sudo systemctl restart bluetooth`) and confirm Decenza recovers once the scan rediscovers the DE1, instead of staying "Found, never Online."
- [ ] Confirm the new `[BLE] Found DE1:` log line appears in terminal output when the DE1 is discovered during a scan.
- [ ] Ask pbrena to run the new build against his setup and attach a fresh log to #804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)