### PR TITLE
tweak(flush): raise max duration from 30 s to 45 s

### DIFF
--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -521,7 +521,7 @@ Page {
                             Layout.preferredWidth: Theme.scaled(180)
                             value: getCurrentPresetSeconds()
                             from: 1
-                            to: 30
+                            to: 45
                             stepSize: 0.5
                             suffix: " s"
                             valueColor: Theme.primaryColor


### PR DESCRIPTION
## Summary

- Raise `ValueInput to` on the Flush preset Duration from 30 s → 45 s in `qml/pages/FlushPage.qml`.
- Single-line change; no C++ / protocol impact.

## Test plan

- [ ] Open Flush page → tap + on a preset's Duration → confirm it now accepts up to 45 s (not clamped at 30).
- [ ] Run a 45 s flush against the simulator / real DE1 → completes without premature stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)