### PR TITLE
fix(steam): persist live steam warning banner until dismissed

### DIFF
--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -182,13 +182,16 @@ Page {
         }
     }
 
-    // Warning banner (auto-dismiss after 5 seconds — allowed per CLAUDE.md for UI auto-dismiss)
+    // Live safety warning banner. Persists until the user taps it — this is a
+    // one-shot per-session alert (latched in SteamHealthTracker), so if it
+    // auto-dismissed the user could easily miss it while focused on the pitcher.
     property string warningText: ""
     property bool warningVisible: false
-    Timer {
-        id: warningDismissTimer
-        interval: 5000
-        onTriggered: warningVisible = false
+
+    // Clear any stale warning when a new steam session starts.
+    onIsSteamingChanged: {
+        if (isSteaming)
+            warningVisible = false
     }
 
     // Warning connections
@@ -199,13 +202,11 @@ Page {
             warningText = TranslationManager.translate("steam.warning.pressureHigh",
                 "Warning: steam pressure is too high")
             warningVisible = true
-            warningDismissTimer.restart()
         }
         function onTemperatureTooHigh() {
             warningText = TranslationManager.translate("steam.warning.temperatureHigh",
                 "Warning: steam temperature is too high")
             warningVisible = true
-            warningDismissTimer.restart()
         }
         function onDescaleWarning() {
             steamWarningDialog.warningMessage = TranslationManager.translate("steam.warning.descale",
@@ -461,8 +462,9 @@ Page {
                 }
             }
 
-            // Warning banner (live warnings during steaming)
+            // Warning banner (live warnings during steaming). Tap to dismiss.
             Rectangle {
+                id: warningBanner
                 Layout.fillWidth: true
                 Layout.preferredHeight: warningBannerText.implicitHeight + Theme.spacingSmall * 2
                 visible: warningVisible
@@ -473,7 +475,7 @@ Page {
                     id: warningBannerText
                     anchors.centerIn: parent
                     width: parent.width - Theme.spacingMedium * 2
-                    text: warningText
+                    text: warningText + "  " + TranslationManager.translate("steam.warning.tapToDismiss", "(tap to dismiss)")
                     color: Theme.primaryContrastColor
                     font: Theme.bodyFont
                     horizontalAlignment: Text.AlignHCenter
@@ -481,9 +483,12 @@ Page {
                     Accessible.ignored: true
                 }
 
-                Accessible.role: Accessible.StaticText
-                Accessible.name: warningText
-                Accessible.focusable: true
+                AccessibleMouseArea {
+                    anchors.fill: parent
+                    accessibleItem: warningBanner
+                    accessibleName: warningText
+                    onAccessibleClicked: warningVisible = false
+                }
             }
 
             // === TIMER VIEW (default) ===

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -94,6 +94,11 @@ Page {
             wasSteaming = true
             steamSoftStopped = false
             _lastAnnouncedSteamWeight = 0
+            // Drop any banner left over from a prior session so it doesn't
+            // carry into the new one. SteamHealthTracker re-arms its per-session
+            // latch at the first sample of the new session, so if the new
+            // session also trips a threshold, the banner will re-show.
+            warningVisible = false
             // Preset reset runs in the else branch (at session end), not here.
             // Resetting at session start meant Settings was stale during the
             // window between state=Steam (when main.qml's onStateChanged fires
@@ -182,17 +187,14 @@ Page {
         }
     }
 
-    // Live safety warning banner. Persists until the user taps it — this is a
-    // one-shot per-session alert (latched in SteamHealthTracker), so if it
-    // auto-dismissed the user could easily miss it while focused on the pitcher.
+    // Live safety warning banner. Persists until the user taps it. The two
+    // signals that drive it (pressureTooHigh / temperatureTooHigh) are each
+    // latched to fire at most once per session in SteamHealthTracker, so an
+    // auto-dismiss would risk the user missing the only alert they get.
+    // (The three other SteamHealthTracker signals handled below are
+    // post-session modal dialogs, not this banner.)
     property string warningText: ""
     property bool warningVisible: false
-
-    // Clear any stale warning when a new steam session starts.
-    onIsSteamingChanged: {
-        if (isSteaming)
-            warningVisible = false
-    }
 
     // Warning connections
     Connections {
@@ -471,11 +473,16 @@ Page {
                 radius: Theme.cardRadius
                 color: Theme.errorColor
 
+                // Composed banner text — a single translatable template so
+                // translators control word order relative to the warning.
+                readonly property string composedText: TranslationManager.translate(
+                    "steam.warning.withTapHint", "%1  (tap to dismiss)").arg(warningText)
+
                 Text {
                     id: warningBannerText
                     anchors.centerIn: parent
                     width: parent.width - Theme.spacingMedium * 2
-                    text: warningText + "  " + TranslationManager.translate("steam.warning.tapToDismiss", "(tap to dismiss)")
+                    text: warningBanner.composedText
                     color: Theme.primaryContrastColor
                     font: Theme.bodyFont
                     horizontalAlignment: Text.AlignHCenter
@@ -486,7 +493,7 @@ Page {
                 AccessibleMouseArea {
                     anchors.fill: parent
                     accessibleItem: warningBanner
-                    accessibleName: warningText
+                    accessibleName: warningBanner.composedText
                     onAccessibleClicked: warningVisible = false
                 }
             }


### PR DESCRIPTION
## Summary
- The live steam pressure/temperature warning banner on `SteamPage` auto-dismissed after 5 seconds. Users focused on their pitcher routinely missed it — and since the underlying signal is latched per session in `SteamHealthTracker`, a missed warning was gone for the rest of the session.
- Banner now persists until the user taps it. Text appends "(tap to dismiss)" as a visible affordance, and an `AccessibleMouseArea` handles screen reader activation (first-tap-announce / second-tap-activate via TalkBack/VoiceOver).
- Any stale warning is cleared on the rising edge of `isSteaming` so it doesn't linger into the next steam session.

Only affects the live-session banner (pressure > 8.0 bar / temp > 180 °C hard limits). The post-session `Dialog` alerts (`onDescaleWarning`, `onTemperatureWarning`, `onScaleBuildupWarning`) were already modal with an OK button and are unchanged.

## Test plan
- [ ] Trigger a live pressure warning (steam pressure > 8 bar) — banner appears and stays until tapped.
- [ ] Tap the banner — it dismisses.
- [ ] Start a new steam session while a warning from a previous session is still visible — banner clears automatically.
- [ ] TalkBack/VoiceOver: first tap announces "Warning: steam pressure is too high", second tap dismisses.
- [ ] Temperature variant: same behavior with the "steam temperature is too high" text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)