### PR TITLE
fix(ble): suppress BlueZ cache recovery dialog on non-Linux platforms

### DIFF
--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -415,8 +415,11 @@ void BleTransport::onControllerError(QLowEnergyController::Error error) {
     // Caps are fine but the DE1 still couldn't be resolved — almost always
     // a stale BlueZ cache after an OS upgrade. Ask BLEManager to surface
     // the recovery dialog (it de-dupes; only the first call per session
-    // fires the signal).
-#ifndef DECENZA_TESTING
+    // fires the signal). Linux-only: macOS/iOS/Android surface
+    // UnknownRemoteDeviceError for unrelated reasons (Core Bluetooth cache,
+    // Android scan-restart races) where the bluetoothctl/systemctl recovery
+    // steps are irrelevant and confusing.
+#if !defined(DECENZA_TESTING) && defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Guarded out of test builds: test targets link bletransport.cpp
     // without blemanager.cpp, and pulling blemanager.cpp in would drag in
     // most of the BLE stack (scales, refractometers, permissions).

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -298,11 +298,15 @@ void QtScaleBleTransport::onControllerError(QLowEnergyController::Error err) {
     }
 
     // Caps OK but still UnknownRemoteDeviceError — surface the BlueZ cache
-    // recovery dialog via BLEManager.
+    // recovery dialog via BLEManager. Linux-only: the recovery commands
+    // (bluetoothctl/systemctl) do not apply on macOS/iOS/Android, where
+    // UnknownRemoteDeviceError surfaces for unrelated reasons.
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     if (err == QLowEnergyController::UnknownRemoteDeviceError
         && !BleCapability::linuxMissing()) {
         if (auto* m = BLEManager::instance()) m->requestBluezCacheHint();
     }
+#endif
 }
 
 void QtScaleBleTransport::onServiceDiscovered(const QBluetoothUuid& uuid) {


### PR DESCRIPTION
## Summary

On macOS, an incorrect popup appeared offering to fix Bluetooth problems by running Linux commands (`bluetoothctl`, `sudo systemctl restart bluetooth`). Repro in Jeff's debug log at line 23777:

```
[1.680] WARN  [BLE DE1] !!! CONTROLLER ERROR: UnknownRemoteDeviceError !!!
```

### Root cause

`BleCapability::linuxMissing()` only flips `g_missing = true` inside a `#ifdef Q_OS_LINUX` block (`src/ble/blecapability.cpp:14-45`). On macOS/iOS, it returns `false`, making the `!linuxMissing()` guard true. When Qt's Core Bluetooth layer reports `UnknownRemoteDeviceError` for unrelated cache reasons, the code asks `BLEManager` to surface the Linux-only BlueZ cache recovery dialog (`qml/main.qml:1972-2099`), which is useless and confusing on macOS.

### Fix

Gate the two `requestBluezCacheHint()` call sites in `src/ble/bletransport.cpp` and `src/ble/transport/qtscalebletransport.cpp` on `Q_OS_LINUX && !Q_OS_ANDROID`, matching the pattern used elsewhere in `blecapability.cpp` for the same distinction.

## Test plan

- [ ] On macOS, disconnect DE1 mid-session and verify no BlueZ dialog appears on subsequent reconnect errors
- [ ] On Linux, after a stale-pairing scenario (the original target), the BlueZ recovery dialog still appears
- [ ] Build passes on macOS/iOS/Linux/Android/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)