### PR TITLE
fix(ble+firmware): non-Linux BlueZ popup + block app close during flash

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -102,6 +102,17 @@ ApplicationWindow {
 
     // Handle app close: save position, put devices to sleep
     onClosing: function(close) {
+        // Block close during firmware flash — quitting mid-flash can brick
+        // the DE1. Show a confirmation dialog instead and let the user
+        // decide. If they confirm, the dialog calls Qt.quit() directly
+        // without the normal sleep sequence (which would try to talk to
+        // the DE1 mid-bootloader anyway).
+        if (MainController.firmwareUpdater && MainController.firmwareUpdater.isFlashing) {
+            close.accepted = false
+            firmwareFlashExitDialog.open()
+            return
+        }
+
         // Save window position on desktop (not size - keep default to match real device)
         if (Qt.platform.os !== "android" && Qt.platform.os !== "ios") {
             Settings.setValue("mainWindow/x", root.x)
@@ -120,6 +131,74 @@ ApplicationWindow {
         // Small delay before sending DE1 sleep to let scale command go through
         close.accepted = false
         scaleSleepTimer.start()
+    }
+
+    Dialog {
+        id: firmwareFlashExitDialog
+        modal: true
+        dim: true
+        anchors.centerIn: parent
+        width: Theme.dialogWidth + 2 * padding
+        closePolicy: Dialog.NoAutoClose
+        padding: Theme.dialogPadding
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
+            border.width: 2
+            border.color: Theme.errorColor
+        }
+
+        Tr { id: trFwExitTitle; key: "main.dialog.firmwareFlashExit.title"; fallback: "Firmware update in progress"; visible: false }
+        Tr { id: trFwExitMessage; key: "main.dialog.firmwareFlashExit.message"; fallback: "Quitting now can leave the DE1 in a partially flashed state and may require manual bootloader recovery. Wait for the update to finish before closing the app."; visible: false }
+        Tr { id: trFwExitKeepOpen; key: "main.dialog.firmwareFlashExit.keepOpen"; fallback: "Keep app open"; visible: false }
+        Tr { id: trFwExitQuitAnyway; key: "main.dialog.firmwareFlashExit.quitAnyway"; fallback: "Quit anyway"; visible: false }
+
+        contentItem: Column {
+            spacing: Theme.spacingLarge
+
+            Text {
+                text: trFwExitTitle.text
+                font: Theme.subtitleFont
+                color: Theme.textColor
+                anchors.horizontalCenter: parent.horizontalCenter
+                wrapMode: Text.Wrap
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            Text {
+                text: trFwExitMessage.text
+                wrapMode: Text.Wrap
+                width: parent.width
+                font: Theme.bodyFont
+                color: Theme.textColor
+            }
+
+            Row {
+                spacing: Theme.spacingMedium
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                AccessibleButton {
+                    text: trFwExitKeepOpen.text
+                    accessibleName: trFwExitKeepOpen.text
+                    onClicked: firmwareFlashExitDialog.close()
+                }
+
+                AccessibleButton {
+                    text: trFwExitQuitAnyway.text
+                    accessibleName: trFwExitQuitAnyway.text
+                    onClicked: {
+                        firmwareFlashExitDialog.close()
+                        // Skip the normal sleep-and-quit sequence — sleep is
+                        // already blocked in C++ mid-flash, and we don't want
+                        // any further BLE traffic either. Just exit.
+                        root.shuttingDown = true
+                        Qt.quit()
+                    }
+                }
+            }
+        }
     }
 
     Timer {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -154,6 +154,15 @@ ApplicationWindow {
         Tr { id: trFwExitKeepOpen; key: "main.dialog.firmwareFlashExit.keepOpen"; fallback: "Keep app open"; visible: false }
         Tr { id: trFwExitQuitAnyway; key: "main.dialog.firmwareFlashExit.quitAnyway"; fallback: "Quit anyway"; visible: false }
 
+        onOpened: {
+            // Park focus on the safe default so a stray screen-reader tap
+            // can't trigger "Quit anyway" — which would brick mid-flash.
+            fwExitKeepOpenButton.forceActiveFocus()
+            if (AccessibilityManager.enabled) {
+                AccessibilityManager.announce(trFwExitTitle.text + ". " + trFwExitMessage.text, true)
+            }
+        }
+
         contentItem: Column {
             spacing: Theme.spacingLarge
 
@@ -180,6 +189,7 @@ ApplicationWindow {
                 anchors.horizontalCenter: parent.horizontalCenter
 
                 AccessibleButton {
+                    id: fwExitKeepOpenButton
                     text: trFwExitKeepOpen.text
                     accessibleName: trFwExitKeepOpen.text
                     onClicked: firmwareFlashExitDialog.close()

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -415,8 +415,11 @@ void BleTransport::onControllerError(QLowEnergyController::Error error) {
     // Caps are fine but the DE1 still couldn't be resolved — almost always
     // a stale BlueZ cache after an OS upgrade. Ask BLEManager to surface
     // the recovery dialog (it de-dupes; only the first call per session
-    // fires the signal).
-#ifndef DECENZA_TESTING
+    // fires the signal). Linux-only: macOS/iOS/Android surface
+    // UnknownRemoteDeviceError for unrelated reasons (Core Bluetooth cache,
+    // Android scan-restart races) where the bluetoothctl/systemctl recovery
+    // steps are irrelevant and confusing.
+#if !defined(DECENZA_TESTING) && defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Guarded out of test builds: test targets link bletransport.cpp
     // without blemanager.cpp, and pulling blemanager.cpp in would drag in
     // most of the BLE stack (scales, refractometers, permissions).

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -839,6 +839,15 @@ void DE1Device::goToSleep() {
     }
 #endif
 
+    // Never send sleep during a firmware flash: writing to REQUESTED_STATE
+    // mid-flash can disrupt the bootloader and risk bricking. The MMR-write
+    // guard catches MMR traffic but sleep uses a direct writeUrgent on
+    // REQUESTED_STATE and would otherwise bypass it.
+    if (m_firmwareFlashInProgress) {
+        qWarning() << "DE1Device: Sleep requested during firmware flash, dropping";
+        return;
+    }
+
     // If a profile upload is in progress, defer sleep until it completes.
     if (m_profileUploadInProgress) {
         qDebug() << "DE1Device: Sleep requested during profile upload, deferring until upload completes";

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -298,11 +298,15 @@ void QtScaleBleTransport::onControllerError(QLowEnergyController::Error err) {
     }
 
     // Caps OK but still UnknownRemoteDeviceError — surface the BlueZ cache
-    // recovery dialog via BLEManager.
+    // recovery dialog via BLEManager. Linux-only: the recovery commands
+    // (bluetoothctl/systemctl) do not apply on macOS/iOS/Android, where
+    // UnknownRemoteDeviceError surfaces for unrelated reasons.
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     if (err == QLowEnergyController::UnknownRemoteDeviceError
         && !BleCapability::linuxMissing()) {
         if (auto* m = BLEManager::instance()) m->requestBluezCacheHint();
     }
+#endif
 }
 
 void QtScaleBleTransport::onServiceDiscovered(const QBluetoothUuid& uuid) {


### PR DESCRIPTION
Two related Bluetooth safety fixes (combined — previously split as #821 + #822).

## 1. Suppress BlueZ cache recovery dialog on non-Linux

### Problem
On macOS, an incorrect popup appeared offering to fix Bluetooth problems by running Linux commands (`bluetoothctl`, `sudo systemctl restart bluetooth`). Repro in Jeff's debug log:

```
[1.680] WARN  [BLE DE1] !!! CONTROLLER ERROR: UnknownRemoteDeviceError !!!
```

### Root cause
`BleCapability::linuxMissing()` only flips `g_missing = true` inside `#ifdef Q_OS_LINUX` in `src/ble/blecapability.cpp:14-45`. On macOS/iOS it returns `false`, making the `!linuxMissing()` guard true. When Core Bluetooth reports `UnknownRemoteDeviceError` for unrelated cache reasons, the code fired the Linux-only BlueZ cache recovery dialog (`qml/main.qml:1972-2099`).

### Fix
Gate `requestBluezCacheHint()` call sites in `bletransport.cpp` and `qtscalebletransport.cpp` on `Q_OS_LINUX && !Q_OS_ANDROID`.

## 2. Block app close and DE1 sleep during firmware flash

### Problem
Closing the app mid-firmware-update silently terminated the process and left the DE1 partially flashed. Jeff's log shows a Cmd+Q during a downgrade flash at 5% upload fired the normal `onClosing` sequence: scale sleep → `DE1::goToSleep()` → `Qt.quit()` 300ms later. The MMR-write guard caught routine traffic, but `goToSleep()` bypassed it by writing `REQUESTED_STATE` via `writeUrgent`, which can disrupt the bootloader and risk bricking.

### Fix
- **`src/ble/de1device.cpp`**: `goToSleep()` early-returns with a `qWarning` when `firmwareFlashInProgress` is set. Mirrors the existing "defer during profile upload" pattern.
- **`qml/main.qml`**: `onClosing` checks `MainController.firmwareUpdater.isFlashing`. If true, close is rejected and a new confirmation dialog opens warning about the bricking risk. Offers "Keep app open" (default) or "Quit anyway" — the latter sets `shuttingDown = true` and calls `Qt.quit()` directly (no further BLE traffic). Uses existing `FirmwareUpdater.isFlashing` property.

## Test plan

- [ ] On macOS, disconnect DE1 mid-session — no BlueZ dialog appears on reconnect errors
- [ ] On Linux, stale-pairing scenario still surfaces the BlueZ recovery dialog
- [ ] Start firmware update on macOS, Cmd+Q mid-flash → confirmation dialog appears, app stays open
- [ ] "Quit anyway" exits without sending DE1 sleep (verify via debug log)
- [ ] Close with no firmware in progress → normal sleep-and-quit sequence unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)