### PR TITLE
fix(firmware): guard all DE1 command paths during firmware flash

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -738,6 +738,7 @@ void DE1Device::requestState(DE1::State state) {
 #endif
 
     if (!m_transport) return;
+    if (dropDeviceWriteIfFirmwareFlash("requestState")) return;
     QByteArray data(1, static_cast<char>(state));
     m_transport->write(DE1::Characteristic::REQUESTED_STATE, data);
 }
@@ -809,6 +810,7 @@ void DE1Device::stopOperationUrgent(qint64 sawTriggerMs) {
     }
 #endif
     if (!m_transport) return;
+    if (dropDeviceWriteIfFirmwareFlash("stopOperationUrgent")) return;
     clearCommandQueue();
     if (sawTriggerMs > 0) {
         m_lastSawTriggerMs = sawTriggerMs;
@@ -906,6 +908,7 @@ void DE1Device::uploadProfile(const Profile& profile) {
 #endif
 
     if (!m_transport) return;
+    if (dropDeviceWriteIfFirmwareFlash("uploadProfile")) return;
 
     // Attach the ACK listener BEFORE queuing writes so we observe every
     // writeComplete for this upload.
@@ -926,6 +929,7 @@ void DE1Device::uploadProfileAndStartEspresso(const Profile& profile) {
 #endif
 
     if (!m_transport) return;
+    if (dropDeviceWriteIfFirmwareFlash("uploadProfileAndStartEspresso")) return;
 
     QList<QByteArray> frames = profile.toFrameBytes();
     startProfileUploadTracking(profile.title(), frames, /*expectEspressoStart=*/true);
@@ -1106,11 +1110,13 @@ void DE1Device::finishProfileUpload(bool success, const QString& reason)
 
 void DE1Device::writeHeader(const QByteArray& headerData) {
     if (!m_transport) return;
+    if (dropDeviceWriteIfFirmwareFlash("writeHeader")) return;
     m_transport->write(DE1::Characteristic::HEADER_WRITE, headerData);
 }
 
 void DE1Device::writeFrame(const QByteArray& frameData) {
     if (!m_transport) return;
+    if (dropDeviceWriteIfFirmwareFlash("writeFrame")) return;
     m_transport->write(DE1::Characteristic::FRAME_WRITE, frameData);
 }
 
@@ -1137,6 +1143,13 @@ void DE1Device::setFirmwareFlashInProgress(bool inProgress) {
     m_firmwareFlashInProgress = inProgress;
     qDebug() << "[firmware] DE1Device MMR-write guard"
              << (inProgress ? "ENGAGED" : "cleared");
+}
+
+bool DE1Device::dropDeviceWriteIfFirmwareFlash(const char* label) const {
+    if (!m_firmwareFlashInProgress) return false;
+    qWarning().noquote() << QString("[DE1] %1 DROPPED (firmware flash in progress)")
+        .arg(QString::fromLatin1(label));
+    return true;
 }
 
 bool DE1Device::dropIfFirmwareFlashInProgress(uint32_t address, uint32_t value,
@@ -1374,6 +1387,7 @@ void DE1Device::setUsbChargerOnUrgent(bool on) {
 
 void DE1Device::setWaterRefillLevel(int refillPointMm) {
     if (!m_transport) return;
+    if (dropDeviceWriteIfFirmwareFlash("setWaterRefillLevel")) return;
     QByteArray data;
     data.append(BinaryCodec::encodeShortBE(BinaryCodec::encodeU16P8(0)));
     data.append(BinaryCodec::encodeShortBE(BinaryCodec::encodeU16P8(static_cast<double>(refillPointMm))));
@@ -1509,6 +1523,7 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     }
 #endif
     if (!m_transport) return;
+    if (dropDeviceWriteIfFirmwareFlash("setShotSettings")) return;
     QByteArray data(9, 0);
     data[0] = 0;  // SteamSettings flags
     data[1] = BinaryCodec::encodeU8P0(steamTemp);
@@ -1626,6 +1641,7 @@ void DE1Device::parseShotSettings(const QByteArray& data) {
 
 void DE1Device::resendLastShotSettings() {
     if (!m_transport || m_lastShotSettingsPayload.isEmpty()) return;
+    if (dropDeviceWriteIfFirmwareFlash("resendLastShotSettings")) return;
     qDebug().noquote() << QString(
         "[ShotSettings] resend: repeating last payload (steam=%1C duration=%2s hotWater=%3C vol=%4ml group=%5C)")
         .arg(m_commandedSteamTargetC, 0, 'f', 1)

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -354,6 +354,12 @@ private:
                                        const QString& reason,
                                        const char* label) const;
 
+    // Generic "drop this DE1 write mid-flash" guard for command paths that
+    // don't go through writeMMR (state changes, profile upload, shot
+    // settings, water levels, etc.). Returns true (and logs a qWarning)
+    // when a flash is in progress so the caller should bail.
+    bool dropDeviceWriteIfFirmwareFlash(const char* label) const;
+
     // Transport signal handlers
     void onTransportConnected();
     void onTransportDisconnected();


### PR DESCRIPTION
## Summary

Follow-up to #822. The existing firmware-flash guard only covered MMR writes via `writeMMR()` (and `goToSleep()`). Everything else that writes to the DE1 over BLE — state commands, profile uploads, shot settings, water levels — was unguarded, so a QML/MCP/web-UI caller could poke the DE1 mid-flash through characteristics the MMR guard doesn't cover. Interleaving non-chunk writes with chunk writes on the shared BLE queue risks corrupting the flash.

## Changes

Added a generic `dropDeviceWriteIfFirmwareFlash()` helper (parallel to the existing MMR-specific one) and applied it at every command entry point:

- **State commands**: `requestState()` (covers `startEspresso`/`startSteam`/`startHotWater`/`startFlush`/`stop`/`wake`/`skipToNextFrame` via centralized routing) and `stopOperationUrgent()` (SAW stop that writes `REQUESTED_STATE` directly via `writeUrgent`, bypassing `requestState`)
- **Profile upload**: `uploadProfile()`, `uploadProfileAndStartEspresso()`, `writeHeader()`, `writeFrame()`
- **Shot settings**: `setShotSettings()`, `resendLastShotSettings()`
- **Water levels**: `setWaterRefillLevel()`

The firmware chunk pump itself (`writeFirmwareChunk`, `writeFWMapRequest`) is intentionally **not** guarded — that's the operation we're protecting.

## Test plan

- [ ] Trigger firmware flash, then attempt to start a shot / upload a profile / change steam temp via QML or MCP — all should drop with `[DE1] <label> DROPPED (firmware flash in progress)` log lines
- [ ] Normal operation (no flash): all of the above still work exactly as before
- [ ] Existing MMR guard behavior unchanged
- [ ] BLE-chunk pump throughput unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)