### PR TITLE
fix(firmware): don't claim success until DE1 actually boots into new firmware

### DIFF
--- a/qml/pages/settings/SettingsFirmwareTab.qml
+++ b/qml/pages/settings/SettingsFirmwareTab.qml
@@ -20,24 +20,27 @@ Item {
 
     // FirmwareUpdater::State enum values (kept in sync with the C++ side
     // — Q_ENUM exposes them but using the integer is the simplest binding)
-    readonly property int stateIdle:        0
-    readonly property int stateChecking:    1
-    readonly property int stateDownloading: 2
-    readonly property int stateReady:       3
-    readonly property int stateErasing:     4
-    readonly property int stateUploading:   5
-    readonly property int stateVerifying:   6
-    readonly property int stateSucceeded:   7
-    readonly property int stateFailed:      8
+    readonly property int stateIdle:           0
+    readonly property int stateChecking:       1
+    readonly property int stateDownloading:    2
+    readonly property int stateReady:          3
+    readonly property int stateErasing:        4
+    readonly property int stateUploading:      5
+    readonly property int stateVerifying:      6
+    readonly property int stateSucceeded:      7
+    readonly property int stateFailed:         8
+    readonly property int stateAwaitingReboot: 9
 
     readonly property bool isWorking: fw && (fw.state === stateChecking ||
                                              fw.state === stateDownloading ||
                                              fw.state === stateErasing ||
                                              fw.state === stateUploading ||
-                                             fw.state === stateVerifying)
+                                             fw.state === stateVerifying ||
+                                             fw.state === stateAwaitingReboot)
     readonly property bool isFlashing: fw && (fw.state === stateErasing ||
                                               fw.state === stateUploading ||
-                                              fw.state === stateVerifying)
+                                              fw.state === stateVerifying ||
+                                              fw.state === stateAwaitingReboot)
 
     ColumnLayout {
         anchors.fill: parent
@@ -318,6 +321,39 @@ Item {
                       .arg(fw ? fw.installedVersion : "")
                 color: Theme.textColor
                 font.pixelSize: Theme.scaled(14)
+            }
+        }
+
+        // ----- Awaiting-reboot strip ------------------------------
+        // Shown after verify succeeds, while we wait for the DE1 to
+        // actually boot into the new firmware. Text escalates from
+        // "restarting" to "please power-cycle" once the auto-reboot
+        // grace window expires.
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: Theme.scaled(80)
+            visible: fw && fw.state === firmwareTab.stateAwaitingReboot
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
+            border.color: fw && fw.needsManualReboot ? Theme.warningColor : Theme.accentColor
+            border.width: 1
+
+            Text {
+                anchors.fill: parent
+                anchors.margins: Theme.spacingMedium
+                text: fw && fw.needsManualReboot
+                          ? TranslationManager.translate(
+                                "firmware.tab.awaitingManualReboot",
+                                "Firmware flashed — please power-cycle the DE1 to boot into the new version.")
+                          : TranslationManager.translate(
+                                "firmware.tab.awaitingAutoReboot",
+                                "Firmware flashed — waiting for the DE1 to restart.")
+                color: Theme.textColor
+                font.pixelSize: Theme.scaled(14)
+                wrapMode: Text.Wrap
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
             }
         }
 

--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -129,17 +129,36 @@ void FirmwareUpdater::onDeviceFirmwareVersionChanged() {
         emit installedVersionChanged();
     }
 
-    // Post-reboot version confirms AwaitingReboot/verify-reconnect success.
-    // onDeviceConnectionChanged runs at BLE connect, but on a real DE1 the
-    // MMR 0x800010 read that feeds this version number lands after the
-    // connect signal, so the connect-time check misses it. Catch the
-    // version arrival here too so we don't time out the grace window while
-    // the DE1 is actually running the new firmware.
-    if (m_verifyingAmbiguous && v >= m_availableVersion && v > 0) {
-        m_verifyingAmbiguous = false;
-        m_verifyDisconnectGrace.stop();
-        m_autoRebootWaitTimer.stop();
-        completeSuccess();
+    // Post-reboot version arrival confirms AwaitingReboot/verify-reconnect
+    // outcome. onDeviceConnectionChanged runs at BLE connect, but on a real
+    // DE1 the MMR 0x800010 read that feeds this version number lands after
+    // the connect signal, so the connect-time check misses it. Catch the
+    // version arrival here so we don't time out the grace window while the
+    // DE1 is actually running the new firmware — or while it's running the
+    // old firmware and we should tell the user to power-cycle.
+    if (m_verifyingAmbiguous && v > 0) {
+        if (v >= m_availableVersion) {
+            completeSuccess();  // clears flags + timers
+        } else {
+            // DE1 booted into the old firmware. Escalate to power-cycle
+            // prompt rather than waiting for the grace-timeout failure.
+            m_verifyDisconnectGrace.stop();
+            m_autoRebootWaitTimer.stop();
+            if (m_state != State::AwaitingReboot) {
+                setProgress(1.0);
+                setState(State::AwaitingReboot);
+            }
+            if (!m_needsManualReboot) {
+                m_needsManualReboot = true;
+                emit needsManualRebootChanged();
+                qCWarning(firmwareLog).noquote()
+                    << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
+                    << "[firmware] DE1 reports old version" << v
+                    << "after flash — prompting user to power-cycle";
+            }
+            // Leave m_verifyingAmbiguous=true so a later disconnect+
+            // reconnect after the user power-cycles re-runs the check.
+        }
     }
 }
 
@@ -149,18 +168,45 @@ void FirmwareUpdater::onDeviceConnectionChanged() {
     // Reconnect path. If we were in ambiguous-verify (disconnected during
     // the verify phase, which commonly means a successful post-flash
     // reboot rather than a real failure), re-read the installed version
-    // and decide: match → retroactive success; mismatch → keep waiting
-    // for more version updates; timeout → fail.
+    // and decide: match → retroactive success; still old version →
+    // escalate to "please power-cycle" rather than failing silently. The
+    // installed version here may lag by a few hundred ms while the
+    // post-reconnect MMR 0x800010 read completes; onDeviceFirmwareVersionChanged
+    // provides the later confirmation path for the racy case.
     if (m_device->isConnected()) {
         if (m_verifyingAmbiguous) {
             const uint32_t installed = m_installedVersionProvider
                 ? m_installedVersionProvider() : m_installedVersion;
             m_installedVersion = installed;
-            if (installed >= m_availableVersion) {
-                m_verifyingAmbiguous = false;
+            if (installed >= m_availableVersion && installed > 0) {
+                completeSuccess();  // clears m_verifyingAmbiguous + timers
+            } else if (installed > 0 && installed < m_availableVersion) {
+                // Flash succeeded at the protocol level (verify returned
+                // FFFFFD), DE1 disconnected and reconnected — but it's
+                // running the old firmware. Common for downgrades where
+                // the bootloader won't auto-swap. Don't fail: tell the
+                // user to power-cycle and wait for the next disconnect.
                 m_verifyDisconnectGrace.stop();
-                completeSuccess();
+                m_autoRebootWaitTimer.stop();
+                if (m_state != State::AwaitingReboot) {
+                    setProgress(1.0);
+                    setState(State::AwaitingReboot);
+                }
+                if (!m_needsManualReboot) {
+                    m_needsManualReboot = true;
+                    emit needsManualRebootChanged();
+                    qCWarning(firmwareLog).noquote()
+                        << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
+                        << "[firmware] reconnected with old version"
+                        << installed << "— prompting user to power-cycle";
+                }
+                // Leave m_verifyingAmbiguous=true so the next disconnect+
+                // reconnect (after the user power-cycles) runs the check
+                // again via this same path.
             }
+            // installed == 0: MMR not yet read. Wait for
+            // onDeviceFirmwareVersionChanged or verifyDisconnectGrace
+            // to decide.
         }
         return;
     }

--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -128,6 +128,19 @@ void FirmwareUpdater::onDeviceFirmwareVersionChanged() {
         qCDebug(firmwareLog) << "[firmware] installed version refreshed:" << v;
         emit installedVersionChanged();
     }
+
+    // Post-reboot version confirms AwaitingReboot/verify-reconnect success.
+    // onDeviceConnectionChanged runs at BLE connect, but on a real DE1 the
+    // MMR 0x800010 read that feeds this version number lands after the
+    // connect signal, so the connect-time check misses it. Catch the
+    // version arrival here too so we don't time out the grace window while
+    // the DE1 is actually running the new firmware.
+    if (m_verifyingAmbiguous && v >= m_availableVersion && v > 0) {
+        m_verifyingAmbiguous = false;
+        m_verifyDisconnectGrace.stop();
+        m_autoRebootWaitTimer.stop();
+        completeSuccess();
+    }
 }
 
 void FirmwareUpdater::onDeviceConnectionChanged() {
@@ -295,6 +308,17 @@ void FirmwareUpdater::checkForUpdate() {
 
 void FirmwareUpdater::startUpdate() {
     if (!m_cache || !m_device) return;
+
+    // Reset carry-over state from any prior attempt (e.g. a previous
+    // verify-disconnect-grace failure) so residual flags don't corrupt the
+    // next cycle's ambiguous-verify/AwaitingReboot logic.
+    m_verifyingAmbiguous = false;
+    m_verifyDisconnectGrace.stop();
+    m_autoRebootWaitTimer.stop();
+    if (m_needsManualReboot) {
+        m_needsManualReboot = false;
+        emit needsManualRebootChanged();
+    }
 
     // Simulator: refuse any flash so we don't stream fake bytes onto a
     // pretend BLE channel and confuse the state machine. The QML gates
@@ -692,6 +716,8 @@ void FirmwareUpdater::onPostEraseWaitComplete() {
 void FirmwareUpdater::completeSuccess() {
     if (m_device) m_device->setFirmwareFlashInProgress(false);
     m_autoRebootWaitTimer.stop();
+    m_verifyDisconnectGrace.stop();
+    m_verifyingAmbiguous = false;
     if (m_needsManualReboot) {
         m_needsManualReboot = false;
         emit needsManualRebootChanged();
@@ -719,6 +745,8 @@ void FirmwareUpdater::failWith(const QString& reason, bool retryable) {
     m_postEraseWaitTimer.stop();
     m_chunkPumpTimer.stop();
     m_autoRebootWaitTimer.stop();
+    m_verifyDisconnectGrace.stop();
+    m_verifyingAmbiguous = false;
     if (m_needsManualReboot) {
         m_needsManualReboot = false;
         emit needsManualRebootChanged();

--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -70,6 +70,7 @@ FirmwareUpdater::FirmwareUpdater(DE1Device* device, FirmwareAssetCache* cache,
     m_eraseTimeoutTimer.setSingleShot(true);
     m_verifyTimeoutTimer.setSingleShot(true);
     m_verifyDisconnectGrace.setSingleShot(true);
+    m_autoRebootWaitTimer.setSingleShot(true);
     m_chunkPumpTimer.setInterval(m_chunkPumpIntervalMs);
 
     connect(&m_postEraseWaitTimer, &QTimer::timeout,
@@ -82,6 +83,8 @@ FirmwareUpdater::FirmwareUpdater(DE1Device* device, FirmwareAssetCache* cache,
             this, &FirmwareUpdater::onVerifyTimeout);
     connect(&m_verifyDisconnectGrace, &QTimer::timeout,
             this, &FirmwareUpdater::onVerifyDisconnectGrace);
+    connect(&m_autoRebootWaitTimer, &QTimer::timeout,
+            this, &FirmwareUpdater::onAutoRebootWaitTimeout);
 
     if (m_cache) {
         connect(m_cache, &FirmwareAssetCache::checkFinished,
@@ -158,12 +161,14 @@ void FirmwareUpdater::onDeviceConnectionChanged() {
                      /*retryable*/ true);
             break;
         case State::Verifying:
-            // Ambiguous — don't classify yet. Open a 15 s grace window to
-            // see whether the device comes back reporting the new version
-            // (successful reboot) or stays away / comes back with the old
-            // version (genuine failure).
+        case State::AwaitingReboot:
+            // Ambiguous — don't classify yet. Open the grace window to see
+            // whether the device comes back reporting the new version
+            // (successful reboot, either auto or user-initiated) or stays
+            // away / comes back with the old version (genuine failure).
             m_verifyingAmbiguous = true;
             m_verifyTimeoutTimer.stop();
+            m_autoRebootWaitTimer.stop();
             m_verifyDisconnectGrace.start(m_verifyDisconnectGraceMs);
             break;
         default:
@@ -220,6 +225,7 @@ void FirmwareUpdater::setEraseTimeoutMs(int ms)            { m_eraseTimeoutMs   
 void FirmwareUpdater::setVerifyTimeoutMs(int ms)           { m_verifyTimeoutMs           = ms; }
 void FirmwareUpdater::setVerifyDisconnectGraceMs(int ms)   { m_verifyDisconnectGraceMs   = ms; }
 void FirmwareUpdater::setPostUploadSettleMs(int ms)        { m_postUploadSettleMs        = ms; }
+void FirmwareUpdater::setAutoRebootWaitMs(int ms)          { m_autoRebootWaitMs          = ms; }
 
 // ---- Read-only state helpers -------------------------------------------
 
@@ -233,15 +239,16 @@ bool FirmwareUpdater::isSimulated() const {
 
 QString FirmwareUpdater::stateText() const {
     switch (m_state) {
-        case State::Idle:        return QStringLiteral("Idle");
-        case State::Checking:    return QStringLiteral("Checking for update");
-        case State::Downloading: return QStringLiteral("Downloading firmware");
-        case State::Ready:       return QStringLiteral("Ready to install");
-        case State::Erasing:     return QStringLiteral("Erasing flash");
-        case State::Uploading:   return QStringLiteral("Uploading firmware");
-        case State::Verifying:   return QStringLiteral("Verifying");
-        case State::Succeeded:   return QStringLiteral("Update complete");
-        case State::Failed:      return QStringLiteral("Update failed");
+        case State::Idle:           return QStringLiteral("Idle");
+        case State::Checking:       return QStringLiteral("Checking for update");
+        case State::Downloading:    return QStringLiteral("Downloading firmware");
+        case State::Ready:           return QStringLiteral("Ready to install");
+        case State::Erasing:        return QStringLiteral("Erasing flash");
+        case State::Uploading:      return QStringLiteral("Uploading firmware");
+        case State::Verifying:      return QStringLiteral("Verifying");
+        case State::Succeeded:      return QStringLiteral("Update complete");
+        case State::Failed:         return QStringLiteral("Update failed");
+        case State::AwaitingReboot: return QStringLiteral("Waiting for DE1 to restart");
     }
     return QString();
 }
@@ -641,7 +648,16 @@ void FirmwareUpdater::onFwMapResponse(uint8_t fwToErase, uint8_t fwToMap,
         m_verifyTimeoutTimer.stop();
         const QByteArray expected = QByteArray::fromHex("FFFFFD");
         if (firstError == expected) {
-            completeSuccess();
+            // Don't claim success yet. The bootloader says the new bank
+            // verifies, but modern firmware only auto-reboots on upgrades —
+            // downgrades (and possibly other edge cases) stay on the old
+            // firmware until the user power-cycles. Enter AwaitingReboot
+            // and wait for an actual disconnect + reconnect with the
+            // expected version before calling completeSuccess().
+            m_verifyingAmbiguous = true;
+            m_autoRebootWaitTimer.start(m_autoRebootWaitMs);
+            setProgress(1.0);
+            setState(State::AwaitingReboot);
         } else {
             const QString detail = QStringLiteral(
                 "Verification failed at block %1.%2.%3"
@@ -654,6 +670,20 @@ void FirmwareUpdater::onFwMapResponse(uint8_t fwToErase, uint8_t fwToMap,
     }
 }
 
+void FirmwareUpdater::onAutoRebootWaitTimeout() {
+    // We're still connected after the auto-reboot window. The DE1 isn't
+    // going to reboot on its own — tell the user to power-cycle. When they
+    // do, the disconnect handler picks it up via the same
+    // verifyingAmbiguous path as a clean auto-reboot.
+    if (m_state != State::AwaitingReboot) return;
+    if (m_needsManualReboot) return;
+    m_needsManualReboot = true;
+    emit needsManualRebootChanged();
+    qCWarning(firmwareLog).noquote()
+        << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
+        << "[firmware] auto-reboot window expired — prompting user to power-cycle";
+}
+
 void FirmwareUpdater::onPostEraseWaitComplete() {
     if (m_state != State::Erasing) return;
     beginUploadPhase();
@@ -661,6 +691,11 @@ void FirmwareUpdater::onPostEraseWaitComplete() {
 
 void FirmwareUpdater::completeSuccess() {
     if (m_device) m_device->setFirmwareFlashInProgress(false);
+    m_autoRebootWaitTimer.stop();
+    if (m_needsManualReboot) {
+        m_needsManualReboot = false;
+        emit needsManualRebootChanged();
+    }
     setProgress(1.0);
     setState(State::Succeeded);
     m_updateAvailable = false;
@@ -683,6 +718,11 @@ void FirmwareUpdater::failWith(const QString& reason, bool retryable) {
     m_verifyTimeoutTimer.stop();
     m_postEraseWaitTimer.stop();
     m_chunkPumpTimer.stop();
+    m_autoRebootWaitTimer.stop();
+    if (m_needsManualReboot) {
+        m_needsManualReboot = false;
+        emit needsManualRebootChanged();
+    }
     m_errorMessage   = reason;
     m_retryAvailable = retryable;
     setState(State::Failed);

--- a/src/controllers/firmwareupdater.h
+++ b/src/controllers/firmwareupdater.h
@@ -46,6 +46,10 @@ class FirmwareUpdater : public QObject {
     Q_PROPERTY(double progress READ progress NOTIFY progressChanged)
     Q_PROPERTY(QString errorMessage READ errorMessage NOTIFY stateChanged)
     Q_PROPERTY(bool retryAvailable READ retryAvailable NOTIFY stateChanged)
+    // True when we're in AwaitingReboot and the auto-reboot grace window
+    // has expired without the DE1 disconnecting. The UI surfaces a
+    // "power-cycle the DE1" instruction when this is true.
+    Q_PROPERTY(bool needsManualReboot READ needsManualReboot NOTIFY needsManualRebootChanged)
 
 public:
     enum class State {
@@ -57,7 +61,15 @@ public:
         Uploading,
         Verifying,
         Succeeded,
-        Failed
+        Failed,
+        // The bootloader confirmed the new bank verifies, but the DE1 hasn't
+        // actually booted into it yet. Modern firmware auto-reboots on
+        // upgrade; downgrades (and possibly other edge cases) don't, and
+        // require the user to power-cycle the machine. We stay in this state
+        // until the DE1 disconnects + reconnects reporting the expected
+        // version. Added after #822 — appending rather than inserting so
+        // existing numeric values are stable for QML/tests.
+        AwaitingReboot
     };
     Q_ENUM(State)
 
@@ -87,6 +99,7 @@ public:
     void setVerifyTimeoutMs(int ms);          // default 60000
     void setVerifyDisconnectGraceMs(int ms);  // default 15000
     void setPostUploadSettleMs(int ms);       // default 1500
+    void setAutoRebootWaitMs(int ms);         // default 30000
 
     // Read-only state -----------------------------------------------
 
@@ -101,8 +114,10 @@ public:
     bool isFlashing() const {
         return m_state == State::Erasing ||
                m_state == State::Uploading ||
-               m_state == State::Verifying;
+               m_state == State::Verifying ||
+               m_state == State::AwaitingReboot;
     }
+    bool needsManualReboot() const { return m_needsManualReboot; }
     int availableVersion() const { return static_cast<int>(m_availableVersion); }
     int installedVersion() const;  // logs [firmware] getter call so we can verify QML reads it
     double progress() const { return m_progress; }
@@ -129,6 +144,7 @@ signals:
     void progressChanged();
     void installedVersionChanged();
     void isSimulatedChanged();
+    void needsManualRebootChanged();
 
 private slots:
     void onCheckFinished(DE1::Firmware::FirmwareAssetCache::CheckResult result);
@@ -144,6 +160,7 @@ private slots:
     void onEraseTimeout();
     void onVerifyTimeout();
     void onVerifyDisconnectGrace();
+    void onAutoRebootWaitTimeout();
 
 private:
     void setState(State newState);
@@ -199,6 +216,14 @@ private:
     bool        m_verifyingAmbiguous    = false;
     QTimer      m_verifyDisconnectGrace;
     int         m_verifyDisconnectGraceMs = 15000;
+
+    // Auto-reboot wait: after verify succeeds, we wait this long for the
+    // DE1 to disconnect on its own (signalling auto-reboot). If it stays
+    // connected past the window, needsManualReboot flips true so the UI
+    // prompts the user to power-cycle.
+    QTimer      m_autoRebootWaitTimer;
+    int         m_autoRebootWaitMs     = 30000;
+    bool        m_needsManualReboot    = false;
 
     QTimer      m_postEraseWaitTimer;
     QTimer      m_chunkPumpTimer;

--- a/tests/tst_firmwareupdater.cpp
+++ b/tests/tst_firmwareupdater.cpp
@@ -207,6 +207,8 @@ private slots:
 
     void firmwareGuard_engagedDuringFlash_andClearedOnSuccess() {
         Fixture f;
+        auto installed = std::make_shared<uint32_t>(1200);
+        f.updater.setInstalledVersionProvider([installed]{ return *installed; });
         const QByteArray blob = makeFirmwareBlob(/*version*/ 1352);
         writeCachedBlob(&f.updater, &f.cache, blob);
 
@@ -226,7 +228,20 @@ private slots:
         QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Verifying);
         emit f.transport.dataReceived(DE1::Characteristic::FW_MAP_REQUEST,
                                       QByteArray::fromHex("00000001FFFFFD"));
-        QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::Succeeded);
+
+        // Verify-success no longer jumps straight to Succeeded; it enters
+        // AwaitingReboot until the DE1 actually comes back on the new
+        // firmware. Guard stays engaged through the wait.
+        QTRY_COMPARE(f.updater.state(), FirmwareUpdater::State::AwaitingReboot);
+        QVERIFY(f.device.firmwareFlashInProgress());
+
+        // Simulate auto-reboot: DE1 disconnects, reconnects with new version.
+        f.transport.setConnectedSim(false);
+        *installed = 1352;
+        f.transport.setConnectedSim(true);
+
+        QTRY_COMPARE_WITH_TIMEOUT(f.updater.state(),
+                                  FirmwareUpdater::State::Succeeded, 2000);
 
         // Guard must be cleared once we reach Succeeded — otherwise every
         // subsequent MMR write would be silently dropped.
@@ -449,6 +464,8 @@ private slots:
 
     void happyPath_endToEnd() {
         Fixture f;
+        auto installed = std::make_shared<uint32_t>(1200);
+        f.updater.setInstalledVersionProvider([installed]{ return *installed; });
         const QByteArray blob = makeFirmwareBlob(/*version*/ 1352);
         writeCachedBlob(&f.updater, &f.cache, blob);
 
@@ -513,9 +530,19 @@ private slots:
         QCOMPARE(chunkCount, expectedChunks);
         QVERIFY2(sawVerifyReq, "verify FWMapRequest was not written to A009");
 
-        // Simulate Phase 3 success notification.
+        // Simulate Phase 3 success notification. State should transition to
+        // AwaitingReboot first; Succeeded only lands once the DE1 actually
+        // reconnects reporting the new firmware version.
         emit f.transport.dataReceived(DE1::Characteristic::FW_MAP_REQUEST,
                                       QByteArray::fromHex("00000001FFFFFD"));
+
+        QTRY_COMPARE_WITH_TIMEOUT(f.updater.state(),
+                                  FirmwareUpdater::State::AwaitingReboot, 2000);
+
+        // Simulate auto-reboot: disconnect → reconnect with new version.
+        f.transport.setConnectedSim(false);
+        *installed = 1352;
+        f.transport.setConnectedSim(true);
 
         QTRY_COMPARE_WITH_TIMEOUT(f.updater.state(), FirmwareUpdater::State::Succeeded, 2000);
         QCOMPARE(f.updater.progress(), 1.0);


### PR DESCRIPTION
## Problem

A user reported the firmware downgrade path showed "Update complete" but the installed version stayed on the old firmware until they manually power-cycled the DE1.

Log showed:

\`\`\`
[+29:36.061] [firmware] state: Uploading firmware -> Verifying
[firmware] A009 notify: 00 00 00 01 ff ff fd     # verify success
[+29:37.401] [firmware] state: Verifying -> Update complete
[+34:59.539] [firmware] check started, installed= 1352  # still old!
\`\`\`

## Root cause

\`completeSuccess()\` was called synchronously from the verify-success handler. The bootloader's \`FFFFFD\` response confirms the new bank is valid, **not** that the DE1 has actually swapped banks and booted into it. Modern firmware auto-reboots on upgrades, but downgrades (and possibly other edge cases) stay on the old firmware until the user power-cycles. The old code optimistically set \`installedVersion = availableVersion\`, which was a lie for the downgrade case.

## Fix

Add a new \`State::AwaitingReboot\` between \`Verifying\` and \`Succeeded\`:

1. Verify-success transitions to \`AwaitingReboot\` and starts a 30s auto-reboot grace timer (\`setAutoRebootWaitMs\` for tests).
2. Within the window: if the DE1 disconnects (auto-reboot or user power-cycle), the existing \`verifyingAmbiguous\` path takes over — wait for reconnect, compare version against expected, call \`completeSuccess\` on match or fail on mismatch.
3. Grace expiry without disconnect: sets \`needsManualReboot\` (new Q_PROPERTY) so the UI prompts the user to power-cycle. When they do, disconnect fires and the ambiguous path runs.
4. \`isFlashing\` now includes \`AwaitingReboot\` so the sleep-timer/close-blocker dialog (#822) stays active through the reboot window.
5. MMR-write guard stays engaged until \`completeSuccess\`/\`failWith\`.

UI adds a new strip during \`AwaitingReboot\`:
- "Firmware flashed — waiting for the DE1 to restart." (first 30s)
- "Firmware flashed — please power-cycle the DE1 to boot into the new version." (after grace expires; warning-colored border)

\`AwaitingReboot\` is appended after \`Failed\` in the enum so numeric values for existing QML bindings and tests remain stable.

## Test plan

- [ ] **Upgrade path** (auto-reboot): Trigger update, watch state go Verify → AwaitingReboot → DE1 auto-disconnects → reconnects with new version → Succeeded. Grace timer never fires.
- [ ] **Downgrade path** (manual reboot required): Trigger downgrade, watch state stay in AwaitingReboot. Grace timer fires after 30s, "power-cycle" strip appears. Manually power-cycle DE1 → reconnects with new version → Succeeded.
- [ ] **Close dialog still fires during AwaitingReboot**: Cmd+Q while in AwaitingReboot → confirmation dialog appears (isFlashing is true).
- [ ] **Reconnect with stale version**: If DE1 somehow reconnects without rebooting (shouldn't happen but defensive), grace timer eventually fires \"did not reconnect\" failure with retry available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)