### PR TITLE
fix(firmware): refuse background update check while flash is in progress

### DIFF
--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -328,6 +328,29 @@ void FirmwareUpdater::setState(State newState) {
             const QString s = stateText(); m_state = old;
             return s;
         }();
+
+    // Defense in depth: the MMR-write guard on DE1Device is engaged by
+    // beginErasePhase() and cleared by completeSuccess()/failWith(). If
+    // anything else ever transitions out of an active-flash state (e.g.
+    // a future code path, test harness, or new caller), make sure the
+    // guard follows. Otherwise the guard stays engaged after the flash
+    // dies and every MMR write is silently dropped for the rest of the
+    // session.
+    const bool wasActiveFlash =
+        m_state == State::Erasing || m_state == State::Uploading ||
+        m_state == State::Verifying || m_state == State::AwaitingReboot;
+    const bool nowActiveFlash =
+        newState == State::Erasing || newState == State::Uploading ||
+        newState == State::Verifying || newState == State::AwaitingReboot;
+    if (wasActiveFlash && !nowActiveFlash && m_device &&
+        m_device->firmwareFlashInProgress()) {
+        qCWarning(firmwareLog).noquote()
+            << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
+            << "[firmware] leaving active-flash state without completeSuccess/"
+               "failWith — clearing MMR guard as a safety net";
+        m_device->setFirmwareFlashInProgress(false);
+    }
+
     m_state = newState;
     emit stateChanged();
 }
@@ -378,6 +401,21 @@ void FirmwareUpdater::checkForUpdate() {
 
 void FirmwareUpdater::startUpdate() {
     if (!m_cache || !m_device) return;
+
+    // Refuse to re-enter while a flash is already running. Same reasoning as
+    // checkForUpdate() — a stray invocation (MCP, double-tapped UI button,
+    // remote control) would reset the flags, setState(Downloading), and
+    // bulldoze the in-flight state machine without cleanly tearing down
+    // the BLE chunk pump or clearing DE1Device's MMR-write guard.
+    if (m_state == State::Erasing || m_state == State::Uploading ||
+        m_state == State::Verifying || m_state == State::AwaitingReboot ||
+        m_state == State::Downloading) {
+        qCWarning(firmwareLog).noquote()
+            << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
+            << "[firmware] startUpdate ignored (flash already in progress, state="
+            << stateText() << ")";
+        return;
+    }
 
     // Reset carry-over state from any prior attempt (e.g. a previous
     // verify-disconnect-grace failure) so residual flags don't corrupt the

--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -348,6 +348,23 @@ void FirmwareUpdater::checkForUpdate() {
     // versions, channel state). Only the actual flash is blocked — see
     // startUpdate().
     if (m_state == State::Checking) return;
+    // Refuse while a flash is actually running. The periodic check fires
+    // 30 s after app launch — if the user tapped "Update now" within that
+    // window (as happens on first use after an app self-update), the check
+    // would setState(Checking), blow away the in-flight Erasing/Uploading/
+    // Verifying/AwaitingReboot state machine, leave the DE1Device
+    // firmware-flash MMR guard stuck engaged, and silently stall the flash
+    // while the user thinks it's running. Skip the check — the user will
+    // see fresh installed/available numbers on the next tick after the
+    // flash completes.
+    if (m_state == State::Erasing || m_state == State::Uploading ||
+        m_state == State::Verifying || m_state == State::AwaitingReboot) {
+        qCDebug(firmwareLog).noquote()
+            << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
+            << "[firmware] check skipped (flash in progress, state="
+            << stateText() << ")";
+        return;
+    }
     if (!m_updateTimer.isValid()) m_updateTimer.start();  // reset for a fresh check
     const uint32_t installed = m_installedVersionProvider
         ? m_installedVersionProvider() : m_installedVersion;

--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -371,9 +371,11 @@ void FirmwareUpdater::checkForUpdate() {
     // versions, channel state). Only the actual flash is blocked — see
     // startUpdate().
     if (m_state == State::Checking) return;
-    // Refuse while a flash is actually running. The periodic check fires
-    // 30 s after app launch — if the user tapped "Update now" within that
-    // window (as happens on first use after an app self-update), the check
+    // Refuse while a flash is actually running. The periodic check schedule
+    // (see MainController::MainController: 30 s after first launch, then
+    // once per week) can fire at any point — including mid-flash if the
+    // user started an update after the tablet had been idle long enough
+    // for the weekly cadence to elapse. Without this guard, the check
     // would setState(Checking), blow away the in-flight Erasing/Uploading/
     // Verifying/AwaitingReboot state machine, leave the DE1Device
     // firmware-flash MMR guard stuck engaged, and silently stall the flash


### PR DESCRIPTION
## Bug

Reported in a real user session. User tapped \"Update now\" ~15 s after app launch; flash entered Uploading at +26 s; at +30 s the periodic firmware update check fired (30 s-after-launch heuristic from \`FIRMWARE_UPDATE.md\`) and **bulldozed the in-flight flash**:

\`\`\`
[15.558] state: Idle -> Downloading firmware    <- user tapped Update now
[15.827] state: Ready to install -> Erasing flash
[26.263] state: Erasing flash -> Uploading firmware
[30.274] UpdateChecker: Periodic update check
[30.277] [firmware] check started, installed= 1333
[30.280] state: Uploading firmware -> Checking for update   <- KILLED
[30.338] state: Checking for update -> Idle
\`\`\`

\`checkForUpdate()\` only guarded against already being \`State::Checking\`. From any other state (including the active-flash phases) it called \`setState(Checking)\`, which aborted the state machine. But \`DE1Device::m_firmwareFlashInProgress\` was **never cleared** (only \`completeSuccess\`/\`failWith\` do that), so every subsequent MMR write got dropped for the rest of the session. With \`isFlashing=false\`, the screensaver activated 30 min later when AutoSleep fired.

The user came back to a sleeping tablet, still-old firmware, and no hint anything had failed.

## Fix

\`checkForUpdate()\` now refuses when state is \`Erasing\`/\`Uploading\`/\`Verifying\`/\`AwaitingReboot\`. Logs a skip note so the behavior is visible in debug logs. The Firmware tab's Installed/Available numbers will refresh on the next tick after the flash completes — they're already showing pre-flash values during the flash anyway, so no user-visible regression.

## Test plan

- [ ] Trigger a flash. Wait 30 s. Confirm the periodic check does NOT interrupt the flash (debug log shows \`[firmware] check skipped (flash in progress, state= Uploading)\`).
- [ ] Normal path: after a flash completes, periodic check runs as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)