### PR TITLE
fix(firmware): prompt for power-cycle immediately after verify

### DIFF
--- a/docs/CLAUDE_MD/FIRMWARE_UPDATE.md
+++ b/docs/CLAUDE_MD/FIRMWARE_UPDATE.md
@@ -24,7 +24,7 @@ Two buttons:
 - **Phase 1 — Erase**: `FWMapRequest(erase=1, map=1)` sent on characteristic `A009`. DE1 erases the inactive flash bank. Modern firmware sends a single erase-complete notification (`fwToErase=0`). We then wait a fixed 10 s (Android) / 1 s (elsewhere) per de1app's convention before starting the chunk pump.
 - **Phase 2 — Upload**: 28,992 sequential 20-byte packets streamed to characteristic `A006`. Each packet is `[len=16][addr24 BE][16-byte payload]`. Length byte is 16 (`0x10`) — same format as MMR writes which use length 4. Address is 24-bit **big-endian**. ACK-driven progress so the bar tracks bytes on the wire, not bytes in the BLE queue.
 - **Phase 3 — Verify**: `FWMapRequest(erase=0, map=1, FirstError=FF,FF,FF)` on `A009`. DE1 verifies the inactive bank and replies with a 3-byte `FirstError`. `{0xFF, 0xFF, 0xFD}` = success; anything else = the byte offset of the first corrupt block.
-- On success, the DE1 remaps the inactive bank as active and auto-reboots. Decenza's auto-reconnect logic re-establishes BLE.
+- On success, the DE1 remaps the inactive bank as active. It does **not** auto-reboot in practice — on every captured flash (upgrade and downgrade) the machine keeps running the old firmware until the user flips its power switch. Decenza prompts for a power-cycle immediately after verify (see `FirmwareUpdater::AwaitingReboot`) and its auto-reconnect logic re-establishes BLE once the DE1 comes back up on the new firmware.
 
 ### BLE subscription timing (matters)
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -218,7 +218,7 @@ ApplicationWindow {
     }
 
     // Firmware power-cycle prompt. Opens globally (not just on the Firmware
-    // tab) when the auto-reboot grace window expires or the DE1 reconnects
+    // tab) as soon as the flash verifies, and also if the DE1 reconnects
     // still running the old firmware after a flash. Auto-dismisses once the
     // updater transitions out of AwaitingReboot (success or failure).
     Connections {
@@ -256,7 +256,7 @@ ApplicationWindow {
         }
 
         Tr { id: trFwRebootTitle; key: "main.dialog.firmwareRebootRequired.title"; fallback: "Power-cycle the DE1"; visible: false }
-        Tr { id: trFwRebootMessage; key: "main.dialog.firmwareRebootRequired.message"; fallback: "The firmware is flashed but the DE1 didn't restart on its own. Switch the DE1 off (back-panel switch or unplug), wait a few seconds, then switch it back on. Decenza will finish the update automatically once the DE1 reconnects."; visible: false }
+        Tr { id: trFwRebootMessage; key: "main.dialog.firmwareRebootRequired.message"; fallback: "The new firmware is flashed and verified. Switch the DE1 off (back-panel switch or unplug), wait a few seconds, then switch it back on to load the new firmware. Decenza will finish the update automatically once the DE1 reconnects."; visible: false }
         Tr { id: trFwRebootAck; key: "main.dialog.firmwareRebootRequired.ack"; fallback: "OK, I'll do it"; visible: false }
 
         onOpened: {

--- a/qml/pages/settings/SettingsFirmwareTab.qml
+++ b/qml/pages/settings/SettingsFirmwareTab.qml
@@ -325,10 +325,8 @@ Item {
         }
 
         // ----- Awaiting-reboot strip ------------------------------
-        // Shown after verify succeeds, while we wait for the DE1 to
-        // actually boot into the new firmware. Text escalates from
-        // "restarting" to "please power-cycle" once the auto-reboot
-        // grace window expires.
+        // Shown after verify succeeds, while we wait for the user to
+        // power-cycle the DE1 so it boots into the new firmware.
 
         Rectangle {
             Layout.fillWidth: true
@@ -336,19 +334,15 @@ Item {
             visible: fw && fw.state === firmwareTab.stateAwaitingReboot
             color: Theme.surfaceColor
             radius: Theme.cardRadius
-            border.color: fw && fw.needsManualReboot ? Theme.warningColor : Theme.accentColor
+            border.color: Theme.warningColor
             border.width: 1
 
             Text {
                 anchors.fill: parent
                 anchors.margins: Theme.spacingMedium
-                text: fw && fw.needsManualReboot
-                          ? TranslationManager.translate(
-                                "firmware.tab.awaitingManualReboot",
-                                "Firmware flashed — please power-cycle the DE1 to boot into the new version.")
-                          : TranslationManager.translate(
-                                "firmware.tab.awaitingAutoReboot",
-                                "Firmware flashed — waiting for the DE1 to restart.")
+                text: TranslationManager.translate(
+                          "firmware.tab.awaitingManualReboot",
+                          "Firmware flashed — please power-cycle the DE1 to boot into the new version.")
                 color: Theme.textColor
                 font.pixelSize: Theme.scaled(14)
                 wrapMode: Text.Wrap

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -295,9 +295,9 @@ public slots:
     // Subscribe to FW_MAP_REQUEST notifications. Done on demand at the
     // start of a firmware update rather than always-on, because A009 is
     // silent during normal operation and leaving a handler active adds
-    // nothing. There is no unsubscribe on the transport; BLE disconnect
-    // and/or the DE1 auto-reboot at the end of verify implicitly
-    // terminate the subscription.
+    // nothing. There is no unsubscribe on the transport; the user power-
+    // cycling the DE1 at the end of verify disconnects BLE and implicitly
+    // terminates the subscription.
     void subscribeFirmwareNotifications();
 
 signals:

--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -70,7 +70,6 @@ FirmwareUpdater::FirmwareUpdater(DE1Device* device, FirmwareAssetCache* cache,
     m_eraseTimeoutTimer.setSingleShot(true);
     m_verifyTimeoutTimer.setSingleShot(true);
     m_verifyDisconnectGrace.setSingleShot(true);
-    m_autoRebootWaitTimer.setSingleShot(true);
     m_chunkPumpTimer.setInterval(m_chunkPumpIntervalMs);
 
     connect(&m_postEraseWaitTimer, &QTimer::timeout,
@@ -83,8 +82,6 @@ FirmwareUpdater::FirmwareUpdater(DE1Device* device, FirmwareAssetCache* cache,
             this, &FirmwareUpdater::onVerifyTimeout);
     connect(&m_verifyDisconnectGrace, &QTimer::timeout,
             this, &FirmwareUpdater::onVerifyDisconnectGrace);
-    connect(&m_autoRebootWaitTimer, &QTimer::timeout,
-            this, &FirmwareUpdater::onAutoRebootWaitTimeout);
 
     if (m_cache) {
         connect(m_cache, &FirmwareAssetCache::checkFinished,
@@ -166,7 +163,6 @@ void FirmwareUpdater::onDeviceFirmwareVersionChanged() {
             // failure. Covers upgrades stuck on old (v < target) AND
             // downgrades stuck on old (v > target).
             m_verifyDisconnectGrace.stop();
-            m_autoRebootWaitTimer.stop();
             if (m_state != State::AwaitingReboot) {
                 setProgress(1.0);
                 setState(State::AwaitingReboot);
@@ -234,7 +230,6 @@ void FirmwareUpdater::onDeviceConnectionChanged() {
             // away / comes back with the old version (genuine failure).
             m_verifyingAmbiguous = true;
             m_verifyTimeoutTimer.stop();
-            m_autoRebootWaitTimer.stop();
             m_verifyDisconnectGrace.start(m_verifyDisconnectGraceMs);
             break;
         default:
@@ -291,7 +286,6 @@ void FirmwareUpdater::setEraseTimeoutMs(int ms)            { m_eraseTimeoutMs   
 void FirmwareUpdater::setVerifyTimeoutMs(int ms)           { m_verifyTimeoutMs           = ms; }
 void FirmwareUpdater::setVerifyDisconnectGraceMs(int ms)   { m_verifyDisconnectGraceMs   = ms; }
 void FirmwareUpdater::setPostUploadSettleMs(int ms)        { m_postUploadSettleMs        = ms; }
-void FirmwareUpdater::setAutoRebootWaitMs(int ms)          { m_autoRebootWaitMs          = ms; }
 
 // ---- Read-only state helpers -------------------------------------------
 
@@ -425,7 +419,6 @@ void FirmwareUpdater::startUpdate() {
     m_verifyingAmbiguous = false;
     m_flashCompleted = false;
     m_verifyDisconnectGrace.stop();
-    m_autoRebootWaitTimer.stop();
     if (m_needsManualReboot) {
         m_needsManualReboot = false;
         emit needsManualRebootChanged();
@@ -784,11 +777,12 @@ void FirmwareUpdater::onFwMapResponse(uint8_t fwToErase, uint8_t fwToMap,
         const QByteArray expected = QByteArray::fromHex("FFFFFD");
         if (firstError == expected) {
             // Don't claim success yet. The bootloader says the new bank
-            // verifies, but modern firmware only auto-reboots on upgrades —
-            // downgrades (and possibly other edge cases) stay on the old
-            // firmware until the user power-cycles. Enter AwaitingReboot
-            // and wait for an actual disconnect + reconnect with the
-            // expected version before calling completeSuccess().
+            // verifies, but in practice the DE1 doesn't auto-reboot — on
+            // every captured flash (both upgrade and downgrade) the
+            // machine stays on the old firmware until the user power-
+            // cycles. Prompt immediately; we still wait for an actual
+            // disconnect + reconnect with the expected version before
+            // calling completeSuccess().
             //
             // m_flashCompleted persists through a spurious Failed if the
             // grace window times out mid-boot — lets us retroactively
@@ -796,7 +790,11 @@ void FirmwareUpdater::onFwMapResponse(uint8_t fwToErase, uint8_t fwToMap,
             // firmware (vs. forcing the user to re-flash via Retry).
             m_verifyingAmbiguous = true;
             m_flashCompleted = true;
-            m_autoRebootWaitTimer.start(m_autoRebootWaitMs);
+            m_needsManualReboot = true;
+            emit needsManualRebootChanged();
+            qCDebug(firmwareLog).noquote()
+                << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
+                << "[firmware] verify OK — prompting user to power-cycle";
             setProgress(1.0);
             setState(State::AwaitingReboot);
         } else {
@@ -811,20 +809,6 @@ void FirmwareUpdater::onFwMapResponse(uint8_t fwToErase, uint8_t fwToMap,
     }
 }
 
-void FirmwareUpdater::onAutoRebootWaitTimeout() {
-    // We're still connected after the auto-reboot window. The DE1 isn't
-    // going to reboot on its own — tell the user to power-cycle. When they
-    // do, the disconnect handler picks it up via the same
-    // verifyingAmbiguous path as a clean auto-reboot.
-    if (m_state != State::AwaitingReboot) return;
-    if (m_needsManualReboot) return;
-    m_needsManualReboot = true;
-    emit needsManualRebootChanged();
-    qCWarning(firmwareLog).noquote()
-        << formatElapsed(m_updateTimer.isValid() ? m_updateTimer.elapsed() : -1)
-        << "[firmware] auto-reboot window expired — prompting user to power-cycle";
-}
-
 void FirmwareUpdater::onPostEraseWaitComplete() {
     if (m_state != State::Erasing) return;
     beginUploadPhase();
@@ -832,7 +816,6 @@ void FirmwareUpdater::onPostEraseWaitComplete() {
 
 void FirmwareUpdater::completeSuccess() {
     if (m_device) m_device->setFirmwareFlashInProgress(false);
-    m_autoRebootWaitTimer.stop();
     m_verifyDisconnectGrace.stop();
     m_verifyingAmbiguous = false;
     m_flashCompleted = false;
@@ -862,7 +845,6 @@ void FirmwareUpdater::failWith(const QString& reason, bool retryable) {
     m_verifyTimeoutTimer.stop();
     m_postEraseWaitTimer.stop();
     m_chunkPumpTimer.stop();
-    m_autoRebootWaitTimer.stop();
     m_verifyDisconnectGrace.stop();
     m_verifyingAmbiguous = false;
     if (m_needsManualReboot) {

--- a/src/controllers/firmwareupdater.cpp
+++ b/src/controllers/firmwareupdater.cpp
@@ -226,8 +226,8 @@ void FirmwareUpdater::onDeviceConnectionChanged() {
         case State::AwaitingReboot:
             // Ambiguous — don't classify yet. Open the grace window to see
             // whether the device comes back reporting the new version
-            // (successful reboot, either auto or user-initiated) or stays
-            // away / comes back with the old version (genuine failure).
+            // (user power-cycled) or stays away / comes back with the old
+            // version (genuine failure).
             m_verifyingAmbiguous = true;
             m_verifyTimeoutTimer.stop();
             m_verifyDisconnectGrace.start(m_verifyDisconnectGraceMs);
@@ -308,7 +308,7 @@ QString FirmwareUpdater::stateText() const {
         case State::Verifying:      return QStringLiteral("Verifying");
         case State::Succeeded:      return QStringLiteral("Update complete");
         case State::Failed:         return QStringLiteral("Update failed");
-        case State::AwaitingReboot: return QStringLiteral("Waiting for DE1 to restart");
+        case State::AwaitingReboot: return QStringLiteral("Power-cycle the DE1 to load new firmware");
     }
     return QString();
 }

--- a/src/controllers/firmwareupdater.h
+++ b/src/controllers/firmwareupdater.h
@@ -46,9 +46,10 @@ class FirmwareUpdater : public QObject {
     Q_PROPERTY(double progress READ progress NOTIFY progressChanged)
     Q_PROPERTY(QString errorMessage READ errorMessage NOTIFY stateChanged)
     Q_PROPERTY(bool retryAvailable READ retryAvailable NOTIFY stateChanged)
-    // True when we're in AwaitingReboot and the auto-reboot grace window
-    // has expired without the DE1 disconnecting. The UI surfaces a
-    // "power-cycle the DE1" instruction when this is true.
+    // True while we need the user to flip the DE1's power switch for the
+    // new firmware to take effect. Set as soon as we enter AwaitingReboot
+    // (verify succeeded) and cleared on Succeeded/Failed. The UI surfaces
+    // a "power-cycle the DE1" instruction when this is true.
     Q_PROPERTY(bool needsManualReboot READ needsManualReboot NOTIFY needsManualRebootChanged)
 
 public:
@@ -62,13 +63,13 @@ public:
         Verifying,
         Succeeded,
         Failed,
-        // The bootloader confirmed the new bank verifies, but the DE1 hasn't
-        // actually booted into it yet. Modern firmware auto-reboots on
-        // upgrade; downgrades (and possibly other edge cases) don't, and
-        // require the user to power-cycle the machine. We stay in this state
-        // until the DE1 disconnects + reconnects reporting the expected
-        // version. Added after #822 — appending rather than inserting so
-        // existing numeric values are stable for QML/tests.
+        // The bootloader confirmed the new bank verifies, but the DE1 is
+        // still running the old firmware. In practice the DE1 never auto-
+        // reboots (captured on every flash we've instrumented), so we
+        // prompt the user to power-cycle immediately and stay in this
+        // state until the DE1 disconnects + reconnects reporting the
+        // expected version. Added after #822 — appending rather than
+        // inserting so existing numeric values are stable for QML/tests.
         AwaitingReboot
     };
     Q_ENUM(State)
@@ -99,7 +100,6 @@ public:
     void setVerifyTimeoutMs(int ms);          // default 60000
     void setVerifyDisconnectGraceMs(int ms);  // default 180000 (3 min)
     void setPostUploadSettleMs(int ms);       // default 1500
-    void setAutoRebootWaitMs(int ms);         // default 30000
 
     // Read-only state -----------------------------------------------
 
@@ -160,7 +160,6 @@ private slots:
     void onEraseTimeout();
     void onVerifyTimeout();
     void onVerifyDisconnectGrace();
-    void onAutoRebootWaitTimeout();
 
 private:
     void setState(State newState);
@@ -231,12 +230,8 @@ private:
     // Retry.
     bool        m_flashCompleted       = false;
 
-    // Auto-reboot wait: after verify succeeds, we wait this long for the
-    // DE1 to disconnect on its own (signalling auto-reboot). If it stays
-    // connected past the window, needsManualReboot flips true so the UI
-    // prompts the user to power-cycle.
-    QTimer      m_autoRebootWaitTimer;
-    int         m_autoRebootWaitMs     = 30000;
+    // Set the moment verify succeeds so the UI prompts the user to
+    // power-cycle immediately. Cleared on Succeeded/Failed.
     bool        m_needsManualReboot    = false;
 
     QTimer      m_postEraseWaitTimer;

--- a/src/controllers/firmwareupdater.h
+++ b/src/controllers/firmwareupdater.h
@@ -209,12 +209,15 @@ private:
     uint32_t    m_dismissedVersion = 0;
 
     // Verify-disconnect grace window: when the DE1 disconnects during
-    // Verifying (which commonly means a successful reboot rather than a
-    // failure), we wait briefly to see if the post-reboot version matches
-    // what we just flashed before classifying the outcome.
+    // Verifying or AwaitingReboot, we wait briefly to see if the
+    // post-reconnect version matches what we just flashed before
+    // classifying the outcome. This is the primary success path under
+    // the current model — the DE1 doesn't auto-reboot, so completion
+    // runs through a user power-cycle + reconnect, not a direct
+    // verify → Succeeded transition.
     bool        m_verifyingAmbiguous    = false;
     QTimer      m_verifyDisconnectGrace;
-    // Generous default so a manual power-cycle (user sees prompt, walks to
+    // Generous default so a user power-cycle (sees prompt, walks to the
     // machine, flips switch, waits for DE1 BLE stack to come back) doesn't
     // trip a spurious "did not reconnect after verify" failure. Real-world
     // DE1 boot + BLE rediscovery is typically 30–60 s; 180 s leaves room


### PR DESCRIPTION
## Summary
- Captured two real flashes (upgrade 1333→1352 and downgrade 1352→1333 on the same DE1/firmware pair); on both, the \`auto-reboot window expired — prompting user to power-cycle\` log line fired at exactly +30 s because the DE1 kept running the old firmware. The 30 s wait added nothing and the prompt's wording implied something had gone wrong.
- Set \`m_needsManualReboot = true\` the moment the A009 verify notification confirms the new bank. Drop \`m_autoRebootWaitTimer\`, \`m_autoRebootWaitMs\`, and the \`onAutoRebootWaitTimeout\` handler.
- Reword the root-level power-cycle dialog and the Settings → Firmware awaiting-reboot strip to describe the next step plainly (flip the switch to load the new firmware) instead of describing a failure to auto-reboot.
- The disconnect + reconnect + version-match success path is untouched, so a DE1 that does auto-reboot (none observed) would still complete cleanly.

## Test plan
- [ ] Tap \"Update now\" on an available firmware → verify the power-cycle dialog appears within ~1 s of the verify-success notification, not 30 s later
- [ ] Power-cycle the DE1 → reconnect handshake completes, dialog closes, Settings → Firmware shows \"Update complete — DE1 is on v…\"
- [ ] Do nothing (don't power-cycle) → dialog stays up until the 180 s verify-disconnect grace expires and we fall back to the standard \"DE1 did not reconnect after verify\" failure (existing path, unchanged)
- [ ] Start a flash, let it verify, swipe the dialog-ack button → the Firmware tab strip still says \"please power-cycle the DE1\" with a warning-coloured border
- [ ] Unit tests: \`ctest -R tst_firmwareupdater\` (no test calls \`setAutoRebootWaitMs\`, so no test updates needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)