### PR TITLE
fix(firmware): set upload-time expectation to less than 30 minutes

### DIFF
--- a/qml/pages/settings/SettingsFirmwareTab.qml
+++ b/qml/pages/settings/SettingsFirmwareTab.qml
@@ -405,9 +405,9 @@ Item {
                       "firmware.tab.sourceNote",
                       "Firmware is fetched from Decent's update CDN " +
                       "(fast.decentespresso.com). Auto-checks run weekly. " +
-                      "The upload takes several minutes over Bluetooth — " +
-                      "keep the app open and the DE1 connected until the " +
-                      "update completes.")
+                      "The upload usually takes less than 30 minutes over " +
+                      "Bluetooth — keep the app open and the DE1 connected " +
+                      "until the update completes.")
             color: Theme.textSecondaryColor
             font.pixelSize: Theme.scaled(11)
             wrapMode: Text.Wrap


### PR DESCRIPTION
## Summary
The source note on Settings → Firmware said the upload \"takes several minutes over Bluetooth\". In practice the flash takes ~18 minutes on Android and ~30 minutes on macOS, so users who trust the copy will assume the progress bar is stuck. Reword to \"usually takes less than 30 minutes\".

## Test plan
- [ ] Open Settings → Firmware and confirm the source note reads \"The upload usually takes less than 30 minutes over Bluetooth — keep the app open and the DE1 connected until the update completes.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)