### PR TITLE
fix(migration): make device discovery reliable on Wi-Fi

### DIFF
--- a/android/AndroidManifest.xml.in
+++ b/android/AndroidManifest.xml.in
@@ -13,6 +13,9 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Allows us to hold a WifiManager.MulticastLock so incoming UDP broadcast
+         discovery datagrams aren't filtered by the OS on Wi-Fi. -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <!-- Storage permissions -->
     <!-- Android 9 (SDK 28): needs WRITE_EXTERNAL_STORAGE -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />

--- a/src/core/datamigrationclient.cpp
+++ b/src/core/datamigrationclient.cpp
@@ -34,6 +34,7 @@ DataMigrationClient::DataMigrationClient(QNetworkAccessManager* networkManager, 
 DataMigrationClient::~DataMigrationClient()
 {
     *m_destroyed = true;
+    stopDiscovery();
     cancel();
     delete m_tempDir;
 }

--- a/src/core/datamigrationclient.cpp
+++ b/src/core/datamigrationclient.cpp
@@ -1054,22 +1054,52 @@ void DataMigrationClient::startDiscovery()
 
     connect(m_discoverySocket, &QUdpSocket::readyRead, this, &DataMigrationClient::onDiscoveryDatagram);
 
-    // Send broadcast discovery message
-    QByteArray discoveryMessage = "DECENZA_DISCOVER";
+    // Send the first broadcast burst immediately, then retransmit a few times
+    // during the discovery window to cover UDP packet loss.
+    m_discoveryRetransmitIndex = 0;
+    sendDiscoveryBroadcasts();
+    m_discoveryRetransmitIndex = 1;
 
-    // Send to broadcast address
+    if (!m_discoveryRetransmitTimer) {
+        m_discoveryRetransmitTimer = new QTimer(this);
+        m_discoveryRetransmitTimer->setSingleShot(true);
+        connect(m_discoveryRetransmitTimer, &QTimer::timeout, this, &DataMigrationClient::onDiscoveryRetransmit);
+    }
+    constexpr int retransmitCount = sizeof(DISCOVERY_RETRANSMIT_SCHEDULE_MS) / sizeof(DISCOVERY_RETRANSMIT_SCHEDULE_MS[0]);
+    if (m_discoveryRetransmitIndex < retransmitCount) {
+        m_discoveryRetransmitTimer->start(DISCOVERY_RETRANSMIT_SCHEDULE_MS[m_discoveryRetransmitIndex]);
+    }
+
+    // Set up overall timeout timer
+    if (!m_discoveryTimer) {
+        m_discoveryTimer = new QTimer(this);
+        m_discoveryTimer->setSingleShot(true);
+        connect(m_discoveryTimer, &QTimer::timeout, this, &DataMigrationClient::onDiscoveryTimeout);
+    }
+    m_discoveryTimer->start(DISCOVERY_TIMEOUT_MS);
+}
+
+void DataMigrationClient::sendDiscoveryBroadcasts()
+{
+    if (!m_discoverySocket) {
+        return;
+    }
+
+    QByteArray discoveryMessage = "DECENZA_DISCOVER";
+    const int burst = m_discoveryRetransmitIndex;
+
+    // Send to global broadcast address
     qint64 sent = m_discoverySocket->writeDatagram(discoveryMessage, QHostAddress::Broadcast, DISCOVERY_PORT);
     if (sent == -1) {
-        qWarning() << "DataMigrationClient: Failed to send broadcast:" << m_discoverySocket->errorString();
+        qWarning() << "DataMigrationClient: Failed to send broadcast (burst" << burst << "):" << m_discoverySocket->errorString();
         qWarning() << "DataMigrationClient: This may be due to firewall, network configuration, or missing permissions";
     } else {
         qDebug() << "DataMigrationClient: Sent discovery broadcast to 255.255.255.255"
-                 << "port" << DISCOVERY_PORT << "(" << sent << "bytes)";
+                 << "port" << DISCOVERY_PORT << "(burst" << burst << "," << sent << "bytes)";
     }
 
-    // Also try sending to common subnet broadcast addresses (255.255.255.255 may not work on all networks)
-    // Get local addresses and compute their broadcast addresses
-    qDebug() << "DataMigrationClient: Scanning network interfaces for subnet broadcast addresses...";
+    // Also send to directed subnet broadcast addresses for every up interface —
+    // 255.255.255.255 is filtered on many networks, but 192.168.x.255 usually gets through.
     int interfaceCount = 0;
     for (const QNetworkInterface& interface : QNetworkInterface::allInterfaces()) {
         if (!(interface.flags() & QNetworkInterface::IsUp) ||
@@ -1079,41 +1109,60 @@ void DataMigrationClient::startDiscovery()
         }
 
         interfaceCount++;
-        qDebug() << "DataMigrationClient: Interface" << interface.name() << "is up";
+        if (burst == 0) {
+            qDebug() << "DataMigrationClient: Interface" << interface.name() << "is up";
+        }
 
         for (const QNetworkAddressEntry& entry : interface.addressEntries()) {
             if (entry.ip().protocol() == QAbstractSocket::IPv4Protocol) {
                 QHostAddress broadcast = entry.broadcast();
-                qDebug() << "DataMigrationClient:   Local IP:" << entry.ip().toString()
-                         << "Broadcast:" << (broadcast.isNull() ? "none" : broadcast.toString());
+                if (burst == 0) {
+                    qDebug() << "DataMigrationClient:   Local IP:" << entry.ip().toString()
+                             << "Broadcast:" << (broadcast.isNull() ? "none" : broadcast.toString());
+                }
                 if (!broadcast.isNull() && broadcast != QHostAddress::Broadcast) {
                     qint64 sent = m_discoverySocket->writeDatagram(discoveryMessage, broadcast, DISCOVERY_PORT);
                     if (sent > 0) {
-                        qDebug() << "DataMigrationClient:   Sent discovery to" << broadcast.toString() << "(" << sent << "bytes)";
+                        qDebug() << "DataMigrationClient:   Sent discovery to" << broadcast.toString()
+                                 << "(burst" << burst << "," << sent << "bytes)";
                     } else {
-                        qWarning() << "DataMigrationClient:   Failed to send to" << broadcast.toString() << ":" << m_discoverySocket->errorString();
+                        qWarning() << "DataMigrationClient:   Failed to send to" << broadcast.toString()
+                                   << "(burst" << burst << "):" << m_discoverySocket->errorString();
                     }
                 }
             }
         }
     }
-    if (interfaceCount == 0) {
+    if (interfaceCount == 0 && burst == 0) {
         qWarning() << "DataMigrationClient: No active network interfaces found!";
     }
+}
 
-    // Set up timeout timer
-    if (!m_discoveryTimer) {
-        m_discoveryTimer = new QTimer(this);
-        m_discoveryTimer->setSingleShot(true);
-        connect(m_discoveryTimer, &QTimer::timeout, this, &DataMigrationClient::onDiscoveryTimeout);
+void DataMigrationClient::onDiscoveryRetransmit()
+{
+    if (!m_searching) {
+        return;
     }
-    m_discoveryTimer->start(DISCOVERY_TIMEOUT_MS);
+
+    sendDiscoveryBroadcasts();
+    m_discoveryRetransmitIndex++;
+
+    constexpr int retransmitCount = sizeof(DISCOVERY_RETRANSMIT_SCHEDULE_MS) / sizeof(DISCOVERY_RETRANSMIT_SCHEDULE_MS[0]);
+    if (m_discoveryRetransmitIndex < retransmitCount) {
+        const int delay = DISCOVERY_RETRANSMIT_SCHEDULE_MS[m_discoveryRetransmitIndex]
+                          - DISCOVERY_RETRANSMIT_SCHEDULE_MS[m_discoveryRetransmitIndex - 1];
+        m_discoveryRetransmitTimer->start(delay);
+    }
 }
 
 void DataMigrationClient::stopDiscovery()
 {
     if (m_discoveryTimer) {
         m_discoveryTimer->stop();
+    }
+
+    if (m_discoveryRetransmitTimer) {
+        m_discoveryRetransmitTimer->stop();
     }
 
     if (m_discoverySocket) {

--- a/src/core/datamigrationclient.h
+++ b/src/core/datamigrationclient.h
@@ -120,6 +120,7 @@ private slots:
     void onDownloadProgress(qint64 received, qint64 total);
     void onDiscoveryDatagram();
     void onDiscoveryTimeout();
+    void onDiscoveryRetransmit();
     void onAuthReply();
 
 private:
@@ -192,10 +193,17 @@ private:
     // Device discovery
     QUdpSocket* m_discoverySocket = nullptr;
     QTimer* m_discoveryTimer = nullptr;
+    QTimer* m_discoveryRetransmitTimer = nullptr;
     QVariantList m_discoveredDevices;
     bool m_searching = false;
+    int m_discoveryRetransmitIndex = 0;
+    void sendDiscoveryBroadcasts();
     static constexpr int DISCOVERY_PORT = 8889;
-    static constexpr int DISCOVERY_TIMEOUT_MS = 3000;  // Search for 3 seconds
+    static constexpr int DISCOVERY_TIMEOUT_MS = 5000;  // Search for 5 seconds
+    // Retransmit schedule in ms from the start of discovery. First entry must be 0.
+    // UDP broadcasts can be dropped silently, especially on Wi-Fi, so we repeat a few
+    // times to improve the chance every responder gets at least one request.
+    static constexpr int DISCOVERY_RETRANSMIT_SCHEDULE_MS[] = {0, 500, 1200, 2500};
 
     // Authentication
     bool m_needsAuthentication = false;

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -470,6 +470,7 @@ bool ShotServer::start()
     if (m_discoverySocket->bind(QHostAddress::Any, DISCOVERY_PORT, QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint)) {
         connect(m_discoverySocket, &QUdpSocket::readyRead, this, &ShotServer::onDiscoveryDatagram);
         qDebug() << "ShotServer: Discovery listener started on UDP port" << DISCOVERY_PORT;
+        acquireDiscoveryMulticastLock();
     } else {
         qWarning() << "ShotServer: Failed to bind discovery socket on port" << DISCOVERY_PORT << m_discoverySocket->errorString();
         delete m_discoverySocket;
@@ -493,6 +494,7 @@ void ShotServer::stop()
         delete m_discoverySocket;
         m_discoverySocket = nullptr;
     }
+    releaseDiscoveryMulticastLock();
 
     if (m_server) {
         m_cleanupTimer->stop();
@@ -953,6 +955,62 @@ void ShotServer::onDiscoveryDatagram()
             qDebug() << "ShotServer: Sent discovery response to" << senderAddress.toString();
         }
     }
+}
+
+void ShotServer::acquireDiscoveryMulticastLock()
+{
+#ifdef Q_OS_ANDROID
+    if (m_multicastLock.isValid()) {
+        return;
+    }
+
+    QJniObject context = QJniObject::callStaticObjectMethod(
+        "org/qtproject/qt/android/QtNative",
+        "activity",
+        "()Landroid/app/Activity;");
+    if (!context.isValid()) {
+        qWarning() << "ShotServer: Cannot acquire MulticastLock - no Android activity";
+        return;
+    }
+
+    QJniObject service = QJniObject::fromString("wifi");
+    QJniObject wifiManager = context.callObjectMethod(
+        "getSystemService",
+        "(Ljava/lang/String;)Ljava/lang/Object;",
+        service.object<jstring>());
+    if (!wifiManager.isValid()) {
+        qWarning() << "ShotServer: Cannot acquire MulticastLock - WifiManager unavailable";
+        return;
+    }
+
+    QJniObject tag = QJniObject::fromString("DecenzaDiscovery");
+    m_multicastLock = wifiManager.callObjectMethod(
+        "createMulticastLock",
+        "(Ljava/lang/String;)Landroid/net/wifi/WifiManager$MulticastLock;",
+        tag.object<jstring>());
+    if (!m_multicastLock.isValid()) {
+        qWarning() << "ShotServer: Failed to create MulticastLock";
+        return;
+    }
+
+    m_multicastLock.callMethod<void>("setReferenceCounted", "(Z)V", jboolean(false));
+    m_multicastLock.callMethod<void>("acquire");
+    qDebug() << "ShotServer: Acquired Wi-Fi MulticastLock for discovery";
+#endif
+}
+
+void ShotServer::releaseDiscoveryMulticastLock()
+{
+#ifdef Q_OS_ANDROID
+    if (!m_multicastLock.isValid()) {
+        return;
+    }
+    if (m_multicastLock.callMethod<jboolean>("isHeld")) {
+        m_multicastLock.callMethod<void>("release");
+        qDebug() << "ShotServer: Released Wi-Fi MulticastLock";
+    }
+    m_multicastLock = QJniObject();
+#endif
 }
 
 void ShotServer::handleRequest(QTcpSocket* socket, const QByteArray& request)

--- a/src/network/shotserver.h
+++ b/src/network/shotserver.h
@@ -18,6 +18,9 @@
 #include <QNetworkAccessManager>
 #include <QPointer>
 #include <memory>
+#ifdef Q_OS_ANDROID
+#include <QJniObject>
+#endif
 
 class ShotHistoryStorage;
 struct ShotRecord;
@@ -121,6 +124,13 @@ private slots:
     void onThemeChanged();
 
 private:
+    // On Android, Wi-Fi filters incoming UDP broadcast and multicast frames
+    // unless the app holds a WifiManager.MulticastLock. Without this, discovery
+    // requests silently fail to reach us — see DataMigrationClient retransmit
+    // logic in src/core/datamigrationclient.cpp. No-op on other platforms.
+    void acquireDiscoveryMulticastLock();
+    void releaseDiscoveryMulticastLock();
+
     void handleRequest(QTcpSocket* socket, const QByteArray& request);
     void sendResponse(QTcpSocket* socket, int statusCode, const QString& contentType,
                       const QByteArray& body, const QByteArray& extraHeaders = QByteArray());
@@ -225,6 +235,9 @@ private:
 
     QTcpServer* m_server = nullptr;
     QUdpSocket* m_discoverySocket = nullptr;
+#ifdef Q_OS_ANDROID
+    QJniObject m_multicastLock;
+#endif
     ShotHistoryStorage* m_storage = nullptr;
     DE1Device* m_device = nullptr;
     ScreensaverVideoManager* m_screensaverManager = nullptr;

--- a/src/network/shotserver.h
+++ b/src/network/shotserver.h
@@ -124,10 +124,9 @@ private slots:
     void onThemeChanged();
 
 private:
-    // On Android, Wi-Fi filters incoming UDP broadcast and multicast frames
-    // unless the app holds a WifiManager.MulticastLock. Without this, discovery
-    // requests silently fail to reach us — see DataMigrationClient retransmit
-    // logic in src/core/datamigrationclient.cpp. No-op on other platforms.
+    // On Android, Wi-Fi filters incoming UDP broadcast/multicast frames unless
+    // the app holds a WifiManager.MulticastLock. Without this, discovery
+    // requests silently never reach us. No-op on other platforms.
     void acquireDiscoveryMulticastLock();
     void releaseDiscoveryMulticastLock();
 


### PR DESCRIPTION
## Summary
- **Root cause**: Data-migration device discovery was intermittent (~50% of the time on the Decent tablet). Logs from the 192.168.10.163 tablet showed zero `Discovery request from …` lines for the whole session — the Android OS was silently dropping UDP broadcasts because the app didn't hold a `WifiManager.MulticastLock`. Compounding that, the client only sent one broadcast at the start of a 3-second window with no retries, so any packet loss anywhere was fatal.
- **Client (`DataMigrationClient`)**: send the discovery broadcast in 4 bursts at `t = 0 / 500 / 1200 / 2500 ms` across a `5 s` window (up from a single burst / 3 s). Each log line now tags the burst number, so the log tells you which send the responder actually heard.
- **Server (`ShotServer`, Android only)**: acquire a non-reference-counted `MulticastLock` while the discovery listener is bound; release it when the server stops. Adds `CHANGE_WIFI_MULTICAST_STATE` to the manifest (normal permission, granted at install).
- **Multi-device**: existing dedup-by-`serverUrl` already supports listing multiple servers; retransmission materially improves the odds that every responder on the LAN is seen in a single scan.

## Test plan
- [ ] Build both tablet and desktop from this branch; fresh-install the APK on the tablet (normal permission requires install, not upgrade).
- [ ] From desktop, run the data-migration "search for devices" flow with the tablet powered and Wi-Fi awake — confirm the tablet appears on every (or near-every) scan, and that the tablet log shows `ShotServer: Discovery request from …` for each scan.
- [ ] Verify tablet log shows `ShotServer: Acquired Wi-Fi MulticastLock for discovery` on start and `Released Wi-Fi MulticastLock` on stop.
- [ ] With two Decenza instances on the LAN, confirm both appear in the discovery list (dedup still works, no duplicate rows per device).
- [ ] On macOS/iOS/Windows/Linux builds, confirm the JNI block compiles out and discovery still works.
- [ ] Verify `stopDiscovery()` cancels the retransmit timer mid-burst (cancel a search quickly from the UI and confirm no stray broadcasts after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)