### PR TITLE
feat(settings): move DE1 firmware into About + fix Linux icon + Apple BT state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,7 @@ endif()
 if(APPLE)
     list(APPEND SOURCES
         src/ble/transport/corebluetooth/corebluetoothscalebletransport.mm
+        src/ble/applebtstate.mm
         src/screensaver/iosbrightness.mm
     )
 endif()
@@ -485,6 +486,7 @@ endif()
 if(APPLE)
     list(APPEND HEADERS
         src/ble/transport/corebluetooth/corebluetoothscalebletransport.h
+        src/ble/applebtstate.h
     )
 endif()
 

--- a/qml/components/SettingsSearchIndex.js
+++ b/qml/components/SettingsSearchIndex.js
@@ -104,6 +104,10 @@ function getSearchEntries(tr) {
           title: tr("settings.machine.simulationModeTitle", "Simulation Mode"),
           description: tr("settings.machine.simulationModeDesc", "Use the app without a connected DE1 machine"),
           keywords: ["offline", "simulation", "demo", "unlock", "gui", "disconnect"] },
+        { tabIndex: 1, cardId: "pocketIntegration",
+          title: tr("settings.machine.pocketIntegrationTitle", "Pocket Integration"),
+          description: tr("settings.machine.pocketIntegrationDesc", "Allow the Pocket app to view and control your screen remotely. Requires an active Pocket pairing."),
+          keywords: ["pocket", "remote", "pair", "control", "screen"] },
 
         // Tab 2: Calibration
         { tabIndex: 2, cardId: "flowCalibration",
@@ -156,6 +160,10 @@ function getSearchEntries(tr) {
           title: tr("settings.search.factoryResetTitle", "Factory Reset"),
           description: tr("settings.search.factoryResetDesc", "Remove all data and uninstall"),
           keywords: ["reset", "factory", "delete", "clear", "uninstall", "wipe"] },
+        { tabIndex: 3, cardId: "exportShotsCard",
+          title: tr("settings.data.exportshots", "Export Shots to File"),
+          description: tr("settings.search.exportShotsDesc", "Mirror shots to JSON files for external tools"),
+          keywords: ["export", "json", "shots", "mirror", "backup", "files"] },
 
         // Tab 4: Themes
         { tabIndex: 4, cardId: "themeColors",
@@ -224,6 +232,10 @@ function getSearchEntries(tr) {
           title: tr("settings.update.currentversion", "Current Version"),
           description: tr("settings.search.checkUpdatesDesc", "Auto-check and download app updates"),
           keywords: ["update", "version", "download", "beta", "release"] },
+        { tabIndex: 11, cardId: "firmwareUpdate",
+          title: tr("firmware.card.title", "DE1 Firmware"),
+          description: tr("settings.search.firmwareDesc", "Check, update, or downgrade the DE1 machine firmware"),
+          keywords: ["firmware", "de1", "update", "downgrade", "nightly", "stable", "flash"] },
         { tabIndex: 11, cardId: "releaseNotes",
           title: tr("settings.search.releaseNotesTitle", "Release Notes"),
           description: tr("settings.search.releaseNotesDesc", "What's new in this version"),

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -115,7 +115,6 @@ Page {
                     TranslationManager.translate("settings.tab.mqtt", "MQTT"),
                     TranslationManager.translate("settings.tab.languageAccess", "Language & Access")
                 ]
-                tabNames.push(TranslationManager.translate("settings.tab.firmware", "Firmware"))
                 tabNames.push(TranslationManager.translate("settings.tab.about", "About"))
                 if (Settings.isDebugBuild) tabNames.push(TranslationManager.translate("settings.tab.debug", "Debug"))
                 if (currentIndex >= 0 && currentIndex < tabNames.length) {
@@ -247,12 +246,6 @@ Page {
         }
 
         StyledTabButton {
-            id: firmwareTabButton
-            text: TranslationManager.translate("settings.tab.firmware", "Firmware")
-            tabLabel: TranslationManager.translate("settings.tab.firmware", "Firmware")
-        }
-
-        StyledTabButton {
             id: aboutTabButton
             text: TranslationManager.translate("settings.tab.about", "About")
             tabLabel: TranslationManager.translate("settings.tab.about", "About")
@@ -374,26 +367,18 @@ Page {
             source: "settings/SettingsLanguageTab.qml"
         }
 
-        // Tab 11: Firmware (DE1 firmware update) - lazy loaded on first visit
-        Loader {
-            id: firmwareLoader
-            active: 11 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsFirmwareTab.qml"
-        }
-
-        // Tab 12: About (merged Update + About) - lazy loaded on first visit
+        // Tab 11: About (Updates, Firmware, About) - lazy loaded on first visit
         Loader {
             id: aboutLoader
-            active: 12 in settingsPage.loadedTabs
+            active: 11 in settingsPage.loadedTabs
             asynchronous: true
             source: "settings/SettingsUpdateTab.qml"
         }
 
-        // Tab 13: Debug - only in debug builds, lazy loaded on first visit
+        // Tab 12: Debug - only in debug builds, lazy loaded on first visit
         Loader {
             id: debugLoader
-            active: Settings.isDebugBuild && (13 in settingsPage.loadedTabs)
+            active: Settings.isDebugBuild && (12 in settingsPage.loadedTabs)
             asynchronous: true
             source: "settings/SettingsDebugTab.qml"
         }

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -383,8 +383,14 @@ Item {
 
                             Image {
                                 source: "qrc:/icons/bluetooth.svg"
-                                width: Theme.scaled(18)
-                                height: Theme.scaled(18)
+                                // sourceSize is load-bearing here: bluetooth.svg has a
+                                // 649×649 viewBox, so without it the Image's implicit
+                                // size (what RowLayout uses) is 649×649, which on Linux
+                                // renders as a giant icon overflowing the banner (#830).
+                                sourceSize.width: Theme.scaled(18)
+                                sourceSize.height: Theme.scaled(18)
+                                Layout.preferredWidth: Theme.scaled(18)
+                                Layout.preferredHeight: Theme.scaled(18)
                                 fillMode: Image.PreserveAspectFit
                             }
 

--- a/qml/pages/settings/SettingsUpdateTab.qml
+++ b/qml/pages/settings/SettingsUpdateTab.qml
@@ -366,7 +366,9 @@ Item {
 
                     Item { Layout.fillWidth: true }
 
-                    // Hidden while the status area is showing its own progress UI
+                    // False while the status area shows its own progress UI, and
+                    // on platforms where canCheckForUpdates is false (e.g. iOS,
+                    // which handles app updates through the App Store).
                     readonly property bool idleState: MainController.updateChecker.canCheckForUpdates
                                                       && !MainController.updateChecker.checking
                                                       && !MainController.updateChecker.downloading
@@ -620,7 +622,13 @@ Item {
         modal: true
         dim: true
         padding: 0
-        closePolicy: Dialog.CloseOnEscape
+        // Block Escape while a flash is in progress — otherwise the user can
+        // dismiss the dialog and lose sight of the progress UI while the BLE
+        // upload keeps running in the background. The close (×) button is
+        // gated the same way below.
+        closePolicy: (firmwarePanelLoader.item && firmwarePanelLoader.item.isFlashing)
+                     ? Dialog.NoAutoClose
+                     : Dialog.CloseOnEscape
 
         // Latch: keep the panel loaded after the first open so state/progress
         // isn't lost when the user closes and reopens the dialog.

--- a/qml/pages/settings/SettingsUpdateTab.qml
+++ b/qml/pages/settings/SettingsUpdateTab.qml
@@ -12,6 +12,9 @@ Item {
     property int versionTapCount: 0
     property var lastTapTime: 0
 
+    readonly property var fw: typeof MainController !== "undefined" && MainController
+                              ? MainController.firmwareUpdater : null
+
     RowLayout {
         anchors.fill: parent
         spacing: Theme.scaled(15)
@@ -223,8 +226,120 @@ Item {
             }
         }
 
-        // Right column: Update status and actions
-        Rectangle {
+        // Right column: Firmware card + Software Updates
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: Theme.scaled(8)
+
+            // Firmware card (DE1 firmware update entry point)
+            Rectangle {
+                objectName: "firmwareUpdate"
+                Layout.fillWidth: true
+                Layout.preferredHeight: firmwareCardContent.implicitHeight + Theme.scaled(16)
+                color: Theme.surfaceColor
+                radius: Theme.cardRadius
+
+                ColumnLayout {
+                    id: firmwareCardContent
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.margins: Theme.scaled(10)
+                    spacing: Theme.scaled(4)
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(8)
+
+                        Tr {
+                            key: "firmware.card.title"
+                            fallback: "DE1 Firmware"
+                            color: Theme.textColor
+                            font.pixelSize: Theme.scaled(14)
+                            font.bold: true
+                        }
+
+                        Rectangle {
+                            width: Theme.scaled(10)
+                            height: Theme.scaled(10)
+                            radius: Theme.scaled(5)
+                            Layout.leftMargin: Theme.scaled(4)
+                            color: {
+                                if (!updateTab.fw) return Theme.textSecondaryColor
+                                if (updateTab.fw.updateAvailable)
+                                    return updateTab.fw.isDowngrade ? Theme.warningColor : Theme.primaryColor
+                                if (updateTab.fw.installedVersion > 0) return Theme.successColor
+                                return Theme.textSecondaryColor
+                            }
+                        }
+
+                        Text {
+                            Layout.fillWidth: true
+                            text: {
+                                if (!updateTab.fw) return ""
+                                if (updateTab.fw.updateAvailable) {
+                                    if (updateTab.fw.isDowngrade) {
+                                        return TranslationManager.translate(
+                                            "firmware.card.downgradeAvailable",
+                                            "Downgrade available: v%1 (installed v%2)")
+                                            .arg(updateTab.fw.availableVersion)
+                                            .arg(updateTab.fw.installedVersion > 0 ? updateTab.fw.installedVersion : "—")
+                                    }
+                                    return TranslationManager.translate(
+                                        "firmware.card.updateAvailable",
+                                        "Update available: v%1 (installed v%2)")
+                                        .arg(updateTab.fw.availableVersion)
+                                        .arg(updateTab.fw.installedVersion > 0 ? updateTab.fw.installedVersion : "—")
+                                }
+                                if (updateTab.fw.installedVersion > 0) {
+                                    return TranslationManager.translate(
+                                        "firmware.card.upToDate",
+                                        "Up to date — v%1")
+                                        .arg(updateTab.fw.installedVersion)
+                                }
+                                return TranslationManager.translate(
+                                    "firmware.card.unknown",
+                                    "Firmware version unknown — connect DE1 and check")
+                            }
+                            color: updateTab.fw && updateTab.fw.updateAvailable
+                                   ? (updateTab.fw.isDowngrade ? Theme.warningColor : Theme.textColor)
+                                   : Theme.textColor
+                            font.pixelSize: Theme.scaled(13)
+                            font.bold: updateTab.fw && updateTab.fw.updateAvailable
+                            elide: Text.ElideRight
+                        }
+
+                        Text {
+                            id: firmwareManageText
+                            text: TranslationManager.translate("firmware.card.manage", "Manage...")
+                            color: Theme.primaryColor
+                            font.pixelSize: Theme.scaled(13)
+                            Accessible.ignored: true
+                            AccessibleMouseArea {
+                                anchors.fill: parent
+                                anchors.margins: -Theme.scaled(6)
+                                accessibleName: TranslationManager.translate("firmware.card.manageAccessible", "Open DE1 firmware update")
+                                accessibleItem: firmwareManageText
+                                onAccessibleClicked: firmwareDialog.open()
+                            }
+                        }
+                    }
+
+                    Text {
+                        Layout.fillWidth: true
+                        text: TranslationManager.translate(
+                            "firmware.card.description",
+                            "Check, update, or downgrade the DE1 firmware.")
+                        color: Theme.textSecondaryColor
+                        font.pixelSize: Theme.scaled(12)
+                        wrapMode: Text.WordWrap
+                    }
+                }
+            }
+
+            // Software Updates card (app updates + release notes)
+            Rectangle {
             objectName: "releaseNotes"
             Layout.fillWidth: true
             Layout.fillHeight: true
@@ -233,21 +348,70 @@ Item {
 
             ColumnLayout {
                 anchors.fill: parent
-                anchors.margins: Theme.scaled(15)
-                spacing: Theme.scaled(10)
+                anchors.margins: Theme.scaled(10)
+                spacing: Theme.scaled(6)
 
-                Tr {
-                    key: "settings.update.softwareupdates"
-                    fallback: "Software Updates"
-                    color: Theme.textColor
-                    font.pixelSize: Theme.scaled(14)
-                    font.bold: true
+                // Title + inline action buttons
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.scaled(8)
+
+                    Tr {
+                        key: "settings.update.softwareupdates"
+                        fallback: "Software Updates"
+                        color: Theme.textColor
+                        font.pixelSize: Theme.scaled(14)
+                        font.bold: true
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    // Hidden while the status area is showing its own progress UI
+                    readonly property bool idleState: MainController.updateChecker.canCheckForUpdates
+                                                      && !MainController.updateChecker.checking
+                                                      && !MainController.updateChecker.downloading
+                                                      && !MainController.updateChecker.installing
+
+                    AccessibleButton {
+                        text: TranslationManager.translate("settings.update.checknow", "Check Now")
+                        accessibleName: TranslationManager.translate("settings.update.checkNowAccessible", "Check for app updates")
+                        visible: parent.idleState
+                        enabled: !MainController.updateChecker.checking
+                        onClicked: MainController.updateChecker.checkForUpdates()
+                    }
+
+                    AccessibleButton {
+                        primary: true
+                        text: MainController.updateChecker.downloadReady
+                              ? TranslationManager.translate("settings.update.install", "Install")
+                              : TranslationManager.translate("settings.update.downloadinstall", "Download & Install")
+                        accessibleName: MainController.updateChecker.downloadReady
+                              ? TranslationManager.translate("settings.update.installAccessible", "Install the downloaded update")
+                              : TranslationManager.translate("settings.update.downloadInstallAccessible", "Download and install the available update")
+                        visible: parent.idleState && MainController.updateChecker.updateAvailable && MainController.updateChecker.canDownloadUpdate
+                        onClicked: MainController.updateChecker.downloadAndInstall()
+                    }
+
+                    AccessibleButton {
+                        primary: true
+                        text: TranslationManager.translate("settings.update.viewongithub", "View on GitHub")
+                        accessibleName: TranslationManager.translate("settings.update.viewOnGithubAccessible", "Open the release page on GitHub")
+                        visible: parent.idleState && MainController.updateChecker.updateAvailable && !MainController.updateChecker.canDownloadUpdate
+                        onClicked: MainController.updateChecker.openReleasePage()
+                    }
+
+                    AccessibleButton {
+                        text: TranslationManager.translate("settings.update.whatsnew", "What's New?")
+                        accessibleName: TranslationManager.translate("settings.update.whatsNewAccessible", "View release notes for this update")
+                        visible: parent.idleState && MainController.updateChecker.releaseNotes !== ""
+                        onClicked: releaseNotesPopup.open()
+                    }
                 }
 
                 // Status area
                 Rectangle {
                     Layout.fillWidth: true
-                    Layout.preferredHeight: statusColumn.height + 20
+                    Layout.preferredHeight: statusColumn.height + Theme.scaled(12)
                     color: Theme.backgroundColor
                     radius: Theme.scaled(8)
 
@@ -256,8 +420,8 @@ Item {
                         anchors.left: parent.left
                         anchors.right: parent.right
                         anchors.top: parent.top
-                        anchors.margins: Theme.scaled(10)
-                        spacing: Theme.scaled(8)
+                        anchors.margins: Theme.scaled(8)
+                        spacing: Theme.scaled(4)
 
                         // Status row
                         RowLayout {
@@ -387,49 +551,6 @@ Item {
                     wrapMode: Text.WordWrap
                 }
 
-                // Action buttons row (not shown on iOS)
-                RowLayout {
-                    Layout.fillWidth: true
-                    spacing: Theme.scaled(10)
-                    visible: MainController.updateChecker.canCheckForUpdates && !MainController.updateChecker.checking && !MainController.updateChecker.downloading && !MainController.updateChecker.installing
-
-                    AccessibleButton {
-                        text: TranslationManager.translate("settings.update.checknow", "Check Now")
-                        accessibleName: TranslationManager.translate("settings.update.checkNowAccessible", "Check for app updates")
-                        enabled: !MainController.updateChecker.checking
-                        onClicked: MainController.updateChecker.checkForUpdates()
-                    }
-
-                    AccessibleButton {
-                        primary: true
-                        text: MainController.updateChecker.downloadReady
-                              ? TranslationManager.translate("settings.update.install", "Install")
-                              : TranslationManager.translate("settings.update.downloadinstall", "Download & Install")
-                        accessibleName: MainController.updateChecker.downloadReady
-                              ? TranslationManager.translate("settings.update.installAccessible", "Install the downloaded update")
-                              : TranslationManager.translate("settings.update.downloadInstallAccessible", "Download and install the available update")
-                        visible: MainController.updateChecker.updateAvailable && MainController.updateChecker.canDownloadUpdate
-                        onClicked: MainController.updateChecker.downloadAndInstall()
-                    }
-
-                    AccessibleButton {
-                        primary: true
-                        text: TranslationManager.translate("settings.update.viewongithub", "View on GitHub")
-                        accessibleName: TranslationManager.translate("settings.update.viewOnGithubAccessible", "Open the release page on GitHub")
-                        visible: MainController.updateChecker.updateAvailable && !MainController.updateChecker.canDownloadUpdate
-                        onClicked: MainController.updateChecker.openReleasePage()
-                    }
-
-                    AccessibleButton {
-                        text: TranslationManager.translate("settings.update.whatsnew", "What's New?")
-                        accessibleName: TranslationManager.translate("settings.update.whatsNewAccessible", "View release notes for this update")
-                        visible: MainController.updateChecker.releaseNotes !== ""
-                        onClicked: releaseNotesPopup.open()
-                    }
-
-                    Item { Layout.fillWidth: true }
-                }
-
                 // Inline release notes preview
                 Rectangle {
                     Layout.fillWidth: true
@@ -484,6 +605,88 @@ Item {
                     Layout.fillHeight: true
                     visible: MainController.updateChecker.releaseNotes === ""
                 }
+            }
+            }
+        }
+    }
+
+    // Firmware update dialog (full-screen) — hosts the SettingsFirmwareTab panel
+    Dialog {
+        id: firmwareDialog
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        width: parent ? parent.width - Theme.scaled(40) : Theme.scaled(800)
+        height: parent ? parent.height - Theme.scaled(40) : Theme.scaled(600)
+        modal: true
+        dim: true
+        padding: 0
+        closePolicy: Dialog.CloseOnEscape
+
+        // Latch: keep the panel loaded after the first open so state/progress
+        // isn't lost when the user closes and reopens the dialog.
+        property bool panelLoaded: false
+        onOpened: panelLoaded = true
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
+            border.width: 1
+            border.color: Theme.borderColor
+        }
+
+        contentItem: ColumnLayout {
+            spacing: 0
+
+            // Header bar with title + close button
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Theme.scaled(48)
+                color: Theme.backgroundColor
+                radius: Theme.cardRadius
+
+                // Square off bottom corners so header sits flush with content
+                Rectangle {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    height: Theme.cardRadius
+                    color: Theme.backgroundColor
+                }
+
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: Theme.scaled(16)
+                    anchors.rightMargin: Theme.scaled(10)
+                    spacing: Theme.scaled(8)
+
+                    Tr {
+                        key: "firmware.dialog.title"
+                        fallback: "DE1 Firmware Update"
+                        color: Theme.textColor
+                        font.pixelSize: Theme.scaled(15)
+                        font.bold: true
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    StyledIconButton {
+                        text: "×"
+                        accessibleName: TranslationManager.translate("firmware.dialog.close", "Close firmware dialog")
+                        enabled: !firmwarePanelLoader.item || !firmwarePanelLoader.item.isFlashing
+                        onClicked: firmwareDialog.close()
+                    }
+                }
+            }
+
+            // Firmware panel content (lazy-loaded on first open, stays loaded)
+            Loader {
+                id: firmwarePanelLoader
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.margins: Theme.scaled(8)
+                asynchronous: true
+                active: firmwareDialog.panelLoaded
+                source: "SettingsFirmwareTab.qml"
             }
         }
     }

--- a/src/ble/applebtstate.h
+++ b/src/ble/applebtstate.h
@@ -16,9 +16,12 @@
 // delegate fires whenever the state transitions (e.g. the user toggles
 // BT, revokes permission, or airplane mode flips).
 //
-// Header compiles everywhere so blemanager.h can forward-declare it
-// without platform guards; the implementation in applebtstate.mm is only
-// wired into the build on APPLE targets (see CMakeLists.txt).
+// This header is a plain QObject declaration and compiles on every
+// platform. The implementation in applebtstate.mm is Apple-only and is
+// only wired into the build on APPLE targets (see CMakeLists.txt); the
+// forward declaration in blemanager.h is correspondingly guarded so
+// non-Apple translation units don't reference a symbol that will never
+// link.
 class AppleBtState : public QObject {
     Q_OBJECT
 public:

--- a/src/ble/applebtstate.h
+++ b/src/ble/applebtstate.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QObject>
+
+// Apple-platform adapter for CoreBluetooth's CBCentralManager.state.
+//
+// Replaces two broken paths in BLEManager::isBluetoothAvailable():
+//   * macOS — QBluetoothLocalDevice::hostMode() reports HostConnectable
+//     even when the user has Bluetooth turned off (QTBUG-50838), so the
+//     "Bluetooth is powered off" banner never fires.
+//   * iOS — QBluetoothLocalDevice isn't available at all, and the current
+//     code unconditionally returns true, so the banner can't fire there
+//     either (including when the user has denied the Bluetooth permission).
+//
+// CBCentralManager is the native source of truth on both platforms. Its
+// delegate fires whenever the state transitions (e.g. the user toggles
+// BT, revokes permission, or airplane mode flips).
+//
+// Header compiles everywhere so blemanager.h can forward-declare it
+// without platform guards; the implementation in applebtstate.mm is only
+// wired into the build on APPLE targets (see CMakeLists.txt).
+class AppleBtState : public QObject {
+    Q_OBJECT
+public:
+    explicit AppleBtState(QObject* parent = nullptr);
+    ~AppleBtState() override;
+
+    // True when CoreBluetooth has reported PoweredOff, Unauthorized, or
+    // Unsupported. False in the Unknown / Resetting / PoweredOn states —
+    // the initial Unknown window (before the delegate first fires) keeps
+    // the banner hidden rather than flashing it on every app launch.
+    bool isUnavailable() const;
+
+signals:
+    void stateChanged();
+
+private:
+    void* m_observer = nullptr;  // DecenzaBtStateObserver* (Obj-C, type-erased)
+};

--- a/src/ble/applebtstate.mm
+++ b/src/ble/applebtstate.mm
@@ -1,0 +1,72 @@
+#include "applebtstate.h"
+
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+
+#import <CoreBluetooth/CoreBluetooth.h>
+#include <QDebug>
+
+@interface DecenzaBtStateObserver : NSObject <CBCentralManagerDelegate>
+@property(nonatomic, strong) CBCentralManager *manager;
+@property(nonatomic, assign) AppleBtState *owner;
+- (BOOL)isUnavailable;
+@end
+
+@implementation DecenzaBtStateObserver
+
+- (instancetype)initWithOwner:(AppleBtState *)owner {
+    if ((self = [super init])) {
+        _owner = owner;
+        // ShowPowerAlertKey=NO keeps CoreBluetooth from surfacing its own
+        // system alert when BT is off — we render our own in-app banner.
+        _manager = [[CBCentralManager alloc]
+                        initWithDelegate:self
+                                   queue:dispatch_get_main_queue()
+                                 options:@{CBCentralManagerOptionShowPowerAlertKey: @NO}];
+    }
+    return self;
+}
+
+- (void)centralManagerDidUpdateState:(CBCentralManager *)central {
+    Q_UNUSED(central);
+    if (_owner) {
+        emit _owner->stateChanged();
+    }
+}
+
+- (BOOL)isUnavailable {
+    switch (_manager.state) {
+        case CBManagerStatePoweredOff:
+        case CBManagerStateUnauthorized:
+        case CBManagerStateUnsupported:
+            return YES;
+        case CBManagerStateUnknown:
+        case CBManagerStateResetting:
+        case CBManagerStatePoweredOn:
+        default:
+            return NO;
+    }
+}
+
+@end
+
+AppleBtState::AppleBtState(QObject* parent) : QObject(parent) {
+    m_observer = (__bridge_retained void*)[[DecenzaBtStateObserver alloc] initWithOwner:this];
+}
+
+AppleBtState::~AppleBtState() {
+    if (m_observer) {
+        DecenzaBtStateObserver* obs = (__bridge_transfer DecenzaBtStateObserver*)m_observer;
+        obs.owner = nullptr;
+        obs.manager.delegate = nil;
+        obs = nil;
+        m_observer = nullptr;
+    }
+}
+
+bool AppleBtState::isUnavailable() const {
+    if (!m_observer) return false;
+    DecenzaBtStateObserver* obs = (__bridge DecenzaBtStateObserver*)m_observer;
+    return [obs isUnavailable];
+}
+
+#endif  // Apple targets only — Windows/Linux don't compile this TU.

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -28,6 +28,10 @@
 #include <QUrl>
 #endif
 
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+#include "applebtstate.h"
+#endif
+
 BLEManager* BLEManager::s_instance = nullptr;
 
 BLEManager::BLEManager(QObject* parent)
@@ -61,8 +65,21 @@ BLEManager::BLEManager(QObject* parent)
 bool BLEManager::isBluetoothAvailable() const
 {
     if (m_disabled) return true;  // simulator mode — always report available
-#ifdef Q_OS_IOS
-    return true;  // CoreBluetooth manages state; QBluetoothLocalDevice not available on iOS
+
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+    // On both Apple platforms QBluetoothLocalDevice is unreliable: it doesn't
+    // exist on iOS, and on macOS hostMode() always returns HostConnectable
+    // regardless of the real BT state (QTBUG-50838). CBCentralManager is the
+    // native source of truth, wrapped in AppleBtState. Created lazily here so
+    // simulator-mode launches don't pay the CoreBluetooth init / permission
+    // prompt cost (m_disabled is set before QML's first binding evaluation).
+    if (!m_appleBtState) {
+        auto* self = const_cast<BLEManager*>(this);
+        self->m_appleBtState = new AppleBtState(self);
+        connect(self->m_appleBtState, &AppleBtState::stateChanged,
+                self, &BLEManager::bluetoothAvailableChanged);
+    }
+    return !m_appleBtState->isUnavailable();
 #else
 #ifdef Q_OS_ANDROID
     // On Android, QBluetoothLocalDevice::hostMode() returns HostPoweredOff until the

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -15,6 +15,9 @@
 
 class ScaleDevice;
 class DiFluidR2;
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+class AppleBtState;
+#endif
 
 // Helper to get device identifier - iOS uses UUID, others use MAC address
 inline QString getDeviceIdentifier(const QBluetoothDeviceInfo& device) {
@@ -163,6 +166,12 @@ private:
 
 #ifndef Q_OS_IOS
     QBluetoothLocalDevice* m_localDevice = nullptr;
+#endif
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+    // Lazy — created on the first non-simulator isBluetoothAvailable()
+    // query so CoreBluetooth initialisation (and its permission prompt)
+    // doesn't fire at app launch when the user has simulator mode on.
+    mutable AppleBtState* m_appleBtState = nullptr;
 #endif
     QBluetoothDeviceDiscoveryAgent* m_discoveryAgent = nullptr;
     QList<QBluetoothDeviceInfo> m_de1Devices;


### PR DESCRIPTION
Closes #830.

## Summary

**Part 1 — Firmware moved into About (#830 item 1):**
- Removes the dedicated **Firmware** tab from Settings; DE1 firmware now lives as a card on the **About** tab above *Software Updates*, matching the Heater Calibration card pattern. A **Manage...** link opens the existing firmware panel in a full-screen dialog (close disabled while flashing; panel state survives close/reopen via a latched Loader).
- Firmware card header is one compact row: title · status dot · availability text · Manage, with a short description beneath. Status color reflects update-available / up-to-date / downgrade / unknown.
- Inlines *Check Now / Install / View on GitHub / What's New?* with the **Software Updates** title to reclaim vertical space for release notes. Tightened padding on both cards.
- Adds missing firmwareUpdate, exportShotsCard, and pocketIntegration entries to SettingsSearchIndex.js; fixes a stale \`11=About, 12=Debug\` comment that no longer matched runtime.
- Incidentally fixes the existing \`goToSettings(11)\` call in main.qml that was labelled \"About\" but landed on Firmware — after the reindex it goes where the comment said.

**Part 2 — Linux oversized BLE icon (#830 item 2):**
- bluetooth.svg has a 649×649 viewBox. The Image in the *Bluetooth is turned off* banner only set \`width\`/\`height\` — inside a RowLayout those are ignored for sizing, so the layout used the Image's implicit size (derived from the intrinsic 649×649) and rendered a giant icon on the Linux AppImage. Setting \`sourceSize\` + \`Layout.preferredWidth\`/\`Height\` constrains both the rasterization and the layout size to 18×18.

**Part 3 — macOS & iOS Bluetooth state detection (latent bug uncovered by #2):**
- While investigating why the banner never rendered on Mac, found that \`isBluetoothAvailable()\` was wrong on both Apple platforms: macOS fell through to \`QBluetoothLocalDevice::hostMode()\` which always returns HostConnectable (QTBUG-50838); iOS unconditionally returned \`true\` because \`QBluetoothLocalDevice\` isn't available there. Neither a powered-off adapter nor a denied permission could surface the banner.
- New \`AppleBtState\` helper (applebtstate.h/.mm) wraps \`CBCentralManager\` and observes its state via the CoreBluetooth delegate — the native source of truth on both platforms. Created lazily on the first non-simulator query so simulator-mode launches don't pay CoreBluetooth init (or trigger the iOS BT permission prompt). stateChanged is wired straight to \`BLEManager::bluetoothAvailableChanged\`.
- Linux, Windows, and Android paths unchanged.

## Test plan
- [ ] Settings tab bar no longer shows a Firmware tab; About is the last non-debug tab.
- [ ] On the About tab the Firmware card sits above Software Updates; status dot/text matches connection state.
- [ ] **Manage...** opens the full-screen firmware dialog; all existing firmware controls work (Check now, Update now, channel toggle, downgrade warning, error/retry, awaiting-reboot).
- [ ] Close button on the firmware dialog is disabled while flashing.
- [ ] Settings search for \"firmware\", \"export shots\", \"pocket\" surfaces the new entries.
- [ ] On Linux (AppImage), disable Bluetooth and open Settings → Connections; the banner icon is 18×18, not oversized.
- [ ] On macOS, disable Bluetooth from Control Center and open Settings → Connections; banner now renders.
- [ ] On macOS, re-enable Bluetooth; banner disappears without restarting the app.
- [ ] On iOS, toggle Bluetooth in Control Center and revoke the app's BT permission; banner renders in both cases.
- [ ] Launching with simulator mode enabled on macOS/iOS does not trigger a Bluetooth permission prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)