### PR TITLE
refactor(settings): replace magic-number tab indexes with symbolic ids (#833)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -586,8 +586,9 @@ if(IOS)
     target_include_directories(Decenza PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ios)
 endif()
 
-# QML module - mark Theme.qml as singleton
+# QML module - mark singletons
 set_source_files_properties(qml/Theme.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
+set_source_files_properties(qml/components/SettingsTabs.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
 
 # Define QML files list for dependency tracking
 set(QML_FILES
@@ -711,6 +712,7 @@ set(QML_FILES
     qml/components/DateUtils.js
     qml/components/qrcode.js
     qml/components/SettingsSearchIndex.js
+    qml/components/SettingsTabs.qml
 
     qml/components/layout/LayoutItemDelegate.qml
     qml/components/layout/LayoutBarZone.qml

--- a/qml/components/SettingsSearchIndex.js
+++ b/qml/components/SettingsSearchIndex.js
@@ -23,7 +23,11 @@ function getSearchEntries(tr) {
           description: tr("settings.search.scaleConnectionDesc", "Pair a Bluetooth scale or refractometer"),
           keywords: ["scale", "acaia", "decent", "felicita", "weight", "pair", "tds", "refractometer", "atago"] },
 
-        // Screensaver (auto-sleep and auto-wake moved from Machine tab)
+        // Screensaver — auto-sleep and auto-wake also live on the Screensaver tab
+        { tabId: "screensaver", cardId: "screensaver",
+          title: tr("settings.screensaver.settings", "Screensaver Settings"),
+          description: tr("settings.search.screensaverDesc", "Choose screensaver type and settings"),
+          keywords: ["screensaver", "attractor", "pipes", "clock", "video", "image", "dim"] },
         { tabId: "screensaver", cardId: "autoSleep",
           title: tr("settings.preferences.autoSleep", "Auto-Sleep"),
           description: tr("settings.preferences.autoSleepDesc", "Put the machine to sleep after inactivity"),
@@ -162,12 +166,6 @@ function getSearchEntries(tr) {
           title: tr("settings.layout.title", "Home Screen Layout"),
           description: tr("settings.search.layoutDesc", "Customize idle screen widgets and zones"),
           keywords: ["layout", "widget", "zone", "customize", "idle", "home", "editor"] },
-
-        // Screensaver
-        { tabId: "screensaver", cardId: "screensaver",
-          title: tr("settings.screensaver.settings", "Screensaver Settings"),
-          description: tr("settings.search.screensaverDesc", "Choose screensaver type and settings"),
-          keywords: ["screensaver", "attractor", "pipes", "clock", "video", "image", "dim"] },
 
         // Visualizer
         { tabId: "visualizer", cardId: "visualizer",

--- a/qml/components/SettingsSearchIndex.js
+++ b/qml/components/SettingsSearchIndex.js
@@ -1,31 +1,11 @@
-// Settings search index — maps setting cards to tab indices for search navigation
-// Each entry: { tabIndex, cardId, title, description, keywords }
-// tabIndex matches the tab order in SettingsPage.qml:
-//   0=Connections, 1=Machine, 2=Calibration, 3=History & Data,
-//   4=Themes, 5=Layout, 6=Screensaver, 7=Visualizer, 8=AI,
-//   9=MQTT, 10=Language & Access, 11=About, 12=Debug (debug builds only, no search entries)
-// cardId matches the objectName on the card Rectangle in the tab QML
-// title/description are translated; keywords are English fallbacks for cross-language search
-
-function getTabName(index, tr) {
-    if (!tr) tr = function(key, fallback) { return fallback }
-    var names = [
-        tr("settings.tab.connections", "Connections"),
-        tr("settings.tab.machine", "Machine"),
-        tr("settings.tab.calibration", "Calibration"),
-        tr("settings.tab.historyData", "History & Data"),
-        tr("settings.tab.themes", "Themes"),
-        tr("settings.tab.layout", "Layout"),
-        tr("settings.tab.screensaver", "Screensaver"),
-        tr("settings.tab.visualizer", "Visualizer"),
-        tr("settings.tab.ai", "AI"),
-        tr("settings.tab.mqtt", "MQTT"),
-        tr("settings.tab.languageAccess", "Language & Access"),
-        tr("settings.tab.about", "About"),
-        tr("settings.tab.debug", "Debug")
-    ]
-    return index < names.length ? names[index] : ""
-}
+// Settings search index — maps setting cards to tabs for search navigation.
+// Each entry: { tabId, cardId, title, description, keywords }
+//   tabId    matches an id in SettingsTabs.qml (e.g. "connections", "machine", "about")
+//   cardId   matches the objectName on the card Rectangle in the tab QML
+//   title / description are translated; keywords are English fallbacks for cross-language search
+//
+// Tab ordering and localized names are resolved via the SettingsTabs singleton —
+// this file does not need to know anything about tab indexes.
 
 function getSearchEntries(tr) {
     // tr = TranslationManager.translate function
@@ -33,214 +13,216 @@ function getSearchEntries(tr) {
     if (!tr) tr = function(key, fallback) { return fallback }
 
     return [
-        // Tab 0: Connections
-        { tabIndex: 0, cardId: "machineConnection",
+        // Connections
+        { tabId: "connections", cardId: "machineConnection",
           title: tr("settings.bluetooth.machine", "Machine"),
           description: tr("settings.search.machineConnectionDesc", "Connect to DE1 via Bluetooth or USB"),
           keywords: ["ble", "bluetooth", "usb", "pair", "connect", "device", "machine"] },
-        { tabIndex: 0, cardId: "scaleConnection",
+        { tabId: "connections", cardId: "scaleConnection",
           title: tr("settings.bluetooth.scalesRefractometer", "Scales / Refractometer"),
           description: tr("settings.search.scaleConnectionDesc", "Pair a Bluetooth scale or refractometer"),
           keywords: ["scale", "acaia", "decent", "felicita", "weight", "pair", "tds", "refractometer", "atago"] },
 
-        // Tab 6: Screensaver (auto-sleep and auto-wake moved from Machine tab)
-        { tabIndex: 6, cardId: "autoSleep",
+        // Screensaver (auto-sleep and auto-wake moved from Machine tab)
+        { tabId: "screensaver", cardId: "autoSleep",
           title: tr("settings.preferences.autoSleep", "Auto-Sleep"),
           description: tr("settings.preferences.autoSleepDesc", "Put the machine to sleep after inactivity"),
           keywords: ["sleep", "timeout", "power", "idle", "standby"] },
-        { tabIndex: 6, cardId: "screensaverDim",
+        { tabId: "screensaver", cardId: "screensaverDim",
           title: tr("settings.screensaver.screensaver", "Screensaver"),
           description: tr("settings.search.screensaverDimDesc", "Dim the screen after inactivity"),
           keywords: ["dim", "brightness", "screensaver", "display", "darkness"] },
-        { tabIndex: 6, cardId: "autoWake",
+        { tabId: "screensaver", cardId: "autoWake",
           title: tr("settings.options.autoWake", "Auto-Wake Timer"),
           description: tr("settings.search.autoWakeDesc", "Schedule automatic wake-up times"),
           keywords: ["wake", "schedule", "alarm", "morning", "timer", "power"] },
-        { tabIndex: 1, cardId: "batteryCharging",
+
+        // Machine
+        { tabId: "machine", cardId: "batteryCharging",
           title: tr("settings.preferences.batteryCharging", "Battery Charging"),
           description: tr("settings.search.batteryDesc", "Smart charging mode for battery health"),
           keywords: ["battery", "charge", "usb", "power", "smart charging"] },
-        { tabIndex: 1, cardId: "shotMap",
+        { tabId: "machine", cardId: "shotMap",
           title: tr("settings.shotmap.title", "Shot Map"),
           description: tr("settings.shotmap.description", "Share your shots on the global map at decenza.coffee"),
           keywords: ["map", "location", "gps", "share", "global"] },
-        { tabIndex: 1, cardId: "themeMode",
+        { tabId: "machine", cardId: "themeMode",
           title: tr("settings.preferences.themeMode", "Theme Mode"),
           description: tr("settings.search.themeModeDesc", "Dark mode, light mode, follow system"),
           keywords: ["dark", "light", "theme", "mode", "appearance", "system"] },
-        { tabIndex: 1, cardId: "extractionView",
+        { tabId: "machine", cardId: "extractionView",
           title: tr("settings.preferences.extractionView", "Extraction View"),
           description: tr("settings.preferences.extractionViewDesc", "Visualization during espresso extraction"),
           keywords: ["chart", "cup", "graph", "extraction", "view"] },
-        { tabIndex: 1, cardId: "shotReviewTimer",
+        { tabId: "machine", cardId: "shotReviewTimer",
           title: tr("settings.machine.shotReviewTimer", "Shot Review Timer"),
           description: tr("settings.machine.shotReviewTimerDesc", "Return to idle after reviewing shot"),
           keywords: ["review", "post-shot", "timeout", "close", "auto"] },
-        { tabIndex: 1, cardId: "screenZoom",
+        { tabId: "machine", cardId: "screenZoom",
           title: tr("settings.machine.screenZoom", "Screen Zoom"),
           description: tr("settings.machine.screenZoomDesc", "Adjust UI scale individually for each screen to optimize readability."),
           keywords: ["zoom", "scale", "size", "ui", "display", "dpi"] },
-        { tabIndex: 1, cardId: "launcherMode",
+        { tabId: "machine", cardId: "launcherMode",
           title: tr("settings.options.launcherMode", "Launcher Mode"),
           description: tr("settings.options.launcherModeDesc", "Set Decenza as the Android home screen. Press Home to return here instead of the default launcher."),
           keywords: ["launcher", "home", "android", "kiosk"] },
-        { tabIndex: 1, cardId: "waterLevel",
+        { tabId: "machine", cardId: "waterLevel",
           title: tr("settings.options.waterLevel", "Water Level"),
           description: tr("settings.search.waterLevelDesc", "Water tank level and refill threshold"),
           keywords: ["water", "tank", "level", "refill"] },
-        { tabIndex: 1, cardId: "waterRefillThreshold",
+        { tabId: "machine", cardId: "waterRefillThreshold",
           title: tr("settings.options.waterRefillLevel", "Water Refill Threshold"),
           description: tr("settings.options.waterRefillLevelDesc", "Water level at which the machine warns you to refill"),
           keywords: ["water", "refill", "threshold", "warning"] },
-        { tabIndex: 1, cardId: "refillKit",
+        { tabId: "machine", cardId: "refillKit",
           title: tr("settings.preferences.refillKit", "Refill Kit"),
           description: tr("settings.preferences.refillKitDesc", "Control whether the machine uses an automatic water refill kit"),
           keywords: ["refill", "kit", "plumb", "water", "auto"] },
-        { tabIndex: 1, cardId: "steamHeater",
+        { tabId: "machine", cardId: "steamHeater",
           title: tr("settings.preferences.steamHeater", "Steam Heater"),
           description: tr("settings.preferences.steamHeaterDesc", "Pre-heat for faster steaming"),
           keywords: ["steam", "heater", "flush", "auto", "temperature", "two-tap", "two tap", "purge", "stop", "headless"] },
-        { tabIndex: 1, cardId: "simulationMode",
+        { tabId: "machine", cardId: "simulationMode",
           title: tr("settings.machine.simulationModeTitle", "Simulation Mode"),
           description: tr("settings.machine.simulationModeDesc", "Use the app without a connected DE1 machine"),
           keywords: ["offline", "simulation", "demo", "unlock", "gui", "disconnect"] },
-        { tabIndex: 1, cardId: "pocketIntegration",
+        { tabId: "machine", cardId: "pocketIntegration",
           title: tr("settings.machine.pocketIntegrationTitle", "Pocket Integration"),
           description: tr("settings.machine.pocketIntegrationDesc", "Allow the Pocket app to view and control your screen remotely. Requires an active Pocket pairing."),
           keywords: ["pocket", "remote", "pair", "control", "screen"] },
 
-        // Tab 2: Calibration
-        { tabIndex: 2, cardId: "flowCalibration",
+        // Calibration
+        { tabId: "calibration", cardId: "flowCalibration",
           title: tr("settings.preferences.flowCalibration", "Flow Calibration"),
           description: tr("settings.search.flowCalDesc", "Calibrate flow sensor accuracy"),
           keywords: ["flow", "calibration", "sensor", "auto", "multiplier"] },
-        { tabIndex: 2, cardId: "weightStopTiming",
+        { tabId: "calibration", cardId: "weightStopTiming",
           title: tr("settings.calibration.weightStopTiming", "Weight Stop Timing"),
           description: tr("settings.search.weightStopDesc", "Auto-learned stop-at-weight lag timing"),
           keywords: ["weight", "stop", "saw", "lag", "timing", "scale"] },
-        { tabIndex: 2, cardId: "heaterCalibration",
+        { tabId: "calibration", cardId: "heaterCalibration",
           title: tr("settings.calibration.title", "Heater Calibration"),
           description: tr("settings.search.heaterCalDesc", "Idle temp, warmup flow rates, timeout"),
           keywords: ["heater", "temperature", "warmup", "calibrate", "idle"] },
-        { tabIndex: 2, cardId: "virtualScale",
+        { tabId: "calibration", cardId: "virtualScale",
           title: tr("settings.preferences.virtualScale", "Virtual Scale"),
           description: tr("settings.search.virtualScaleDesc", "Estimate weight from flow sensor"),
           keywords: ["virtual", "scale", "flow", "weight", "estimate", "fallback"] },
-        { tabIndex: 2, cardId: "preferWeight",
+        { tabId: "calibration", cardId: "preferWeight",
           title: tr("settings.calibration.preferWeightOverVolume", "Prefer Weight over Volume"),
           description: tr("settings.search.preferWeightDesc", "Ignore volume limit when scale is paired"),
           keywords: ["weight", "volume", "sav", "ignore", "scale", "stop"] },
 
-        // Tab 3: History & Data
-        { tabIndex: 3, cardId: "shotHistory",
+        // History & Data
+        { tabId: "historyData", cardId: "shotHistory",
           title: tr("settings.search.shotHistoryTitle", "Shot History"),
           description: tr("settings.search.shotHistoryDesc", "View and manage shot history"),
           keywords: ["history", "shots", "past", "records"] },
-        { tabIndex: 3, cardId: "shotHistory",
+        { tabId: "historyData", cardId: "shotHistory",
           title: tr("settings.history.importFromDE1", "Import from DE1 App"),
           description: tr("settings.search.importDE1Desc", "Import shot history from DE1 tablet app"),
           keywords: ["import", "de1", "migrate", "transfer"] },
-        { tabIndex: 3, cardId: "dailyBackup",
+        { tabId: "historyData", cardId: "dailyBackup",
           title: tr("settings.data.dailybackup", "Daily Backup"),
           description: tr("settings.search.dailyBackupDesc", "Auto-backup shots, settings, profiles daily"),
           keywords: ["backup", "restore", "save", "data", "auto"] },
-        { tabIndex: 3, cardId: "enableServer",
+        { tabId: "historyData", cardId: "enableServer",
           title: tr("settings.history.enableserver", "Enable Server"),
           description: tr("settings.data.enableserverdesc", "Access shot data, layout editor, and AI from your browser"),
           keywords: ["server", "http", "web", "remote", "network", "share"] },
-        { tabIndex: 3, cardId: "enableServer",
+        { tabId: "historyData", cardId: "enableServer",
           title: tr("settings.data.enablesecurity", "Enable Security"),
           description: tr("settings.data.enablesecuritydesc", "Encrypt connections and require a code from your authenticator app"),
           keywords: ["security", "https", "totp", "authenticator", "password", "encryption"] },
-        { tabIndex: 3, cardId: "shotHistory",
+        { tabId: "historyData", cardId: "shotHistory",
           title: tr("settings.data.importfrom", "Import from Another Device"),
           description: tr("settings.search.deviceMigrationDesc", "Import from another Decenza device on WiFi"),
           keywords: ["migration", "transfer", "device", "import", "wifi", "sync"] },
-        { tabIndex: 3, cardId: "enableServer",
+        { tabId: "historyData", cardId: "enableServer",
           title: tr("settings.search.factoryResetTitle", "Factory Reset"),
           description: tr("settings.search.factoryResetDesc", "Remove all data and uninstall"),
           keywords: ["reset", "factory", "delete", "clear", "uninstall", "wipe"] },
-        { tabIndex: 3, cardId: "exportShotsCard",
+        { tabId: "historyData", cardId: "exportShotsCard",
           title: tr("settings.data.exportshots", "Export Shots to File"),
           description: tr("settings.search.exportShotsDesc", "Mirror shots to JSON files for external tools"),
           keywords: ["export", "json", "shots", "mirror", "backup", "files"] },
 
-        // Tab 4: Themes
-        { tabIndex: 4, cardId: "themeColors",
+        // Themes
+        { tabId: "themes", cardId: "themeColors",
           title: tr("settings.search.themeColorsTitle", "Theme Colors"),
           description: tr("settings.search.themeColorsDesc", "Customize app color palette"),
           keywords: ["color", "theme", "palette", "customize", "dark", "light"] },
-        { tabIndex: 4, cardId: "saveTheme",
+        { tabId: "themes", cardId: "saveTheme",
           title: tr("settings.search.saveThemeTitle", "Save Theme"),
           description: tr("settings.search.saveThemeDesc", "Save current color scheme as named theme"),
           keywords: ["save", "theme", "preset", "custom"] },
 
-        // Tab 5: Layout
-        { tabIndex: 5, cardId: "layoutEditor",
+        // Layout
+        { tabId: "layout", cardId: "layoutEditor",
           title: tr("settings.layout.title", "Home Screen Layout"),
           description: tr("settings.search.layoutDesc", "Customize idle screen widgets and zones"),
           keywords: ["layout", "widget", "zone", "customize", "idle", "home", "editor"] },
 
-        // Tab 6: Screensaver
-        { tabIndex: 6, cardId: "screensaver",
+        // Screensaver
+        { tabId: "screensaver", cardId: "screensaver",
           title: tr("settings.screensaver.settings", "Screensaver Settings"),
           description: tr("settings.search.screensaverDesc", "Choose screensaver type and settings"),
           keywords: ["screensaver", "attractor", "pipes", "clock", "video", "image", "dim"] },
 
-        // Tab 7: Visualizer
-        { tabIndex: 7, cardId: "visualizer",
+        // Visualizer
+        { tabId: "visualizer", cardId: "visualizer",
           title: tr("settings.visualizer.account", "Visualizer.coffee Account"),
           description: tr("settings.search.visualizerDesc", "Connect to visualizer.coffee for shot sharing"),
           keywords: ["visualizer", "coffee", "upload", "share", "account"] },
 
-        // Tab 8: AI
-        { tabIndex: 8, cardId: "aiProvider",
+        // AI
+        { tabId: "ai", cardId: "aiProvider",
           title: tr("settings.ai.section.provider", "AI Provider"),
           description: tr("settings.search.aiProviderDesc", "Configure AI for shot analysis"),
           keywords: ["ai", "openai", "anthropic", "gemini", "ollama", "api", "key", "model"] },
-        { tabIndex: 8, cardId: "mcpServer",
+        { tabId: "ai", cardId: "mcpServer",
           title: tr("settings.ai.mcp.enable", "Enable MCP Server"),
           description: tr("settings.search.mcpDesc", "Model Context Protocol server for Claude"),
           keywords: ["mcp", "claude", "server", "protocol", "discuss"] },
 
-        // Tab 9: MQTT
-        { tabIndex: 9, cardId: "mqtt",
+        // MQTT
+        { tabId: "mqtt", cardId: "mqtt",
           title: tr("mqtt.title", "MQTT"),
           description: tr("settings.search.mqttDesc", "Home automation broker connection"),
           keywords: ["mqtt", "home", "assistant", "automation", "broker", "ha"] },
 
-        // Tab 10: Language & Access
-        { tabIndex: 10, cardId: "language",
+        // Language & Access
+        { tabId: "languageAccess", cardId: "language",
           title: tr("language.languages", "Languages"),
           description: tr("settings.search.languageDesc", "Select app language"),
           keywords: ["language", "translate", "locale", "i18n"] },
-        { tabIndex: 10, cardId: "accessibility",
+        { tabId: "languageAccess", cardId: "accessibility",
           title: tr("settings.accessibility.title", "Accessibility"),
           description: tr("settings.accessibility.desc", "Screen reader support and audio feedback for blind and visually impaired users"),
           keywords: ["accessibility", "talkback", "voiceover", "screen reader", "tts", "blind"] },
-        { tabIndex: 10, cardId: "accessibility",
+        { tabId: "languageAccess", cardId: "accessibility",
           title: tr("settings.accessibility.voiceAnnouncements", "Voice Announcements"),
           description: tr("settings.accessibility.voiceAnnouncementsDesc", "Speak shot progress aloud"),
           keywords: ["voice", "speech", "tts", "announce", "talk"] },
-        { tabIndex: 10, cardId: "accessibility",
+        { tabId: "languageAccess", cardId: "accessibility",
           title: tr("settings.accessibility.frameTick", "Frame Tick Sound"),
           description: tr("settings.accessibility.frameTickDesc", "Play a tick when the machine moves to the next extraction step"),
           keywords: ["tick", "sound", "audio", "frame", "beep"] },
 
-        // Tab 11: About
-        { tabIndex: 11, cardId: "checkUpdates",
+        // About
+        { tabId: "about", cardId: "checkUpdates",
           title: tr("settings.update.currentversion", "Current Version"),
           description: tr("settings.search.checkUpdatesDesc", "Auto-check and download app updates"),
           keywords: ["update", "version", "download", "beta", "release"] },
-        { tabIndex: 11, cardId: "firmwareUpdate",
+        { tabId: "about", cardId: "firmwareUpdate",
           title: tr("firmware.card.title", "DE1 Firmware"),
           description: tr("settings.search.firmwareDesc", "Check, update, or downgrade the DE1 machine firmware"),
           keywords: ["firmware", "de1", "update", "downgrade", "nightly", "stable", "flash"] },
-        { tabIndex: 11, cardId: "releaseNotes",
+        { tabId: "about", cardId: "releaseNotes",
           title: tr("settings.search.releaseNotesTitle", "Release Notes"),
           description: tr("settings.search.releaseNotesDesc", "What's new in this version"),
           keywords: ["release", "notes", "changelog", "new", "version"] },
-        { tabIndex: 11, cardId: "checkUpdates",
+        { tabId: "about", cardId: "checkUpdates",
           title: tr("about.supportProject", "Support This Project"),
           description: tr("settings.search.donateDesc", "Support Decenza development via PayPal"),
           keywords: ["donate", "paypal", "support", "money", "tip"] },

--- a/qml/components/SettingsTabs.qml
+++ b/qml/components/SettingsTabs.qml
@@ -1,0 +1,79 @@
+pragma Singleton
+import QtQuick
+import Decenza
+
+// Single source of truth for Settings tab order, ids, and sources.
+// Adding or reordering a tab only requires editing the `tabs` list below.
+QtObject {
+    id: registry
+
+    // Order here defines the visible tab order in SettingsPage.
+    // id        — symbolic name used by navigation callers and the search index
+    // key       — TranslationManager key for the localized tab label
+    // fallback  — English fallback used when no translation is available
+    // source    — QML source loaded into the tab's StackLayout page
+    // loadSync  — if true, the Loader loads synchronously on startup (first tab only)
+    // debugOnly — if true, the tab is hidden unless Settings.isDebugBuild is set
+    readonly property var tabs: [
+        { id: "connections",    key: "settings.tab.connections",    fallback: "Connections",       source: "settings/SettingsConnectionsTab.qml",     loadSync: true,  debugOnly: false },
+        { id: "machine",        key: "settings.tab.machine",        fallback: "Machine",           source: "settings/SettingsMachineTab.qml",         loadSync: false, debugOnly: false },
+        { id: "calibration",    key: "settings.tab.calibration",    fallback: "Calibration",       source: "settings/SettingsCalibrationTab.qml",     loadSync: false, debugOnly: false },
+        { id: "historyData",    key: "settings.tab.historyData",    fallback: "History & Data",    source: "settings/SettingsHistoryDataTab.qml",     loadSync: false, debugOnly: false },
+        { id: "themes",         key: "settings.tab.themes",         fallback: "Themes",            source: "settings/SettingsThemesTab.qml",          loadSync: false, debugOnly: false },
+        { id: "layout",         key: "settings.tab.layout",         fallback: "Layout",            source: "settings/SettingsLayoutTab.qml",          loadSync: false, debugOnly: false },
+        { id: "screensaver",    key: "settings.tab.screensaver",    fallback: "Screensaver",       source: "settings/SettingsScreensaverTab.qml",     loadSync: false, debugOnly: false },
+        { id: "visualizer",     key: "settings.tab.visualizer",     fallback: "Visualizer",        source: "settings/SettingsVisualizerTab.qml",      loadSync: false, debugOnly: false },
+        { id: "ai",             key: "settings.tab.ai",             fallback: "AI",                source: "settings/SettingsAITab.qml",              loadSync: false, debugOnly: false },
+        { id: "mqtt",           key: "settings.tab.mqtt",           fallback: "MQTT",              source: "settings/SettingsHomeAutomationTab.qml",  loadSync: false, debugOnly: false },
+        { id: "languageAccess", key: "settings.tab.languageAccess", fallback: "Language & Access", source: "settings/SettingsLanguageTab.qml",        loadSync: false, debugOnly: false },
+        { id: "about",          key: "settings.tab.about",          fallback: "About",             source: "settings/SettingsUpdateTab.qml",          loadSync: false, debugOnly: false },
+        { id: "debug",          key: "settings.tab.debug",          fallback: "Debug",             source: "settings/SettingsDebugTab.qml",           loadSync: false, debugOnly: true  }
+    ]
+
+    // Map of id -> localized tab name. Rebuilt whenever the translation set
+    // changes so that bindings using `SettingsTabs.tabLabels[id]` re-evaluate.
+    readonly property var tabLabels: {
+        // Read translationVersion to establish a binding dependency on the
+        // current language — TranslationManager.translate() is a function and
+        // would not create a dependency on its own.
+        var _ = TranslationManager.translationVersion
+        var out = {}
+        for (var i = 0; i < tabs.length; i++) {
+            out[tabs[i].id] = TranslationManager.translate(tabs[i].key, tabs[i].fallback)
+        }
+        return out
+    }
+
+    function visibleTabs() {
+        var out = []
+        for (var i = 0; i < tabs.length; i++) {
+            var t = tabs[i]
+            if (!t.debugOnly || Settings.isDebugBuild) out.push(t)
+        }
+        return out
+    }
+
+    // Returns the index into visibleTabs() for the given id, or -1 if unknown/hidden.
+    function indexOf(id) {
+        var vis = visibleTabs()
+        for (var i = 0; i < vis.length; i++) {
+            if (vis[i].id === id) return i
+        }
+        return -1
+    }
+
+    // Returns the localized name for a tab id, or "" if unknown.
+    function tabName(id) {
+        return tabLabels[id] || ""
+    }
+
+    // Ordered localized names for visible tabs (for the accessibility announcer).
+    function visibleTabNames() {
+        var vis = visibleTabs()
+        var names = []
+        for (var i = 0; i < vis.length; i++) {
+            names.push(tabLabels[vis[i].id])
+        }
+        return names
+    }
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1637,7 +1637,7 @@ ApplicationWindow {
                             MainController.updateChecker.downloadAndInstall()
                         }
                         updateDialog.close()
-                        goToSettings(11)  // Navigate to About tab (has update controls)
+                        goToSettings("about")  // About tab has the update controls
 
                     }
                 }
@@ -2677,10 +2677,10 @@ ApplicationWindow {
         }
     }
 
-    function goToSettings(tabIndex) {
+    function goToSettings(tabId) {
         if (!startNavigation()) return
-        if (tabIndex !== undefined && tabIndex >= 0) {
-            pageStack.push(settingsPage, {requestedTabIndex: tabIndex})
+        if (tabId !== undefined && tabId !== "" && SettingsTabs.indexOf(tabId) >= 0) {
+            pageStack.push(settingsPage, {requestedTabId: tabId})
         } else {
             pageStack.push(settingsPage)
         }
@@ -3647,7 +3647,7 @@ ApplicationWindow {
                     onClicked: {
                         emptyDatabaseDialog.close();
                         startBluetoothScan();
-                        goToSettings(3);  // Navigate to History & Data tab
+                        goToSettings("historyData");  // History & Data tab has restore
                     }
                 }
             }

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -194,7 +194,6 @@ Page {
         }
     }
 
-    // Tab content area - all tabs preload in background
     StackLayout {
         id: tabContent
         anchors.top: tabBar.bottom
@@ -283,6 +282,15 @@ Page {
             keyboardOffset = 0
         }
 
+        function doSave(name) {
+            Settings.saveCurrentTheme(name)
+            var themesLoader = tabLoaders.itemAt(SettingsTabs.indexOf("themes"))
+            if (themesLoader && themesLoader.item && themesLoader.item.refreshPresets) {
+                themesLoader.item.refreshPresets()
+            }
+            saveThemeDialog.close()
+        }
+
         ColumnLayout {
             anchors.fill: parent
             spacing: Theme.spacingMedium
@@ -303,10 +311,9 @@ Page {
                 onTextChanged: saveThemeDialog.themeName = text
                 onAccepted: {
                     Qt.inputMethod.commit()
-                    if (saveThemeDialog.themeName.trim().length > 0) {
-                        Settings.saveCurrentTheme(saveThemeDialog.themeName.trim())
-                        if (themesLoader.item) themesLoader.item.refreshPresets()
-                        saveThemeDialog.close()
+                    var name = saveThemeDialog.themeName.trim()
+                    if (name.length > 0 && name !== "Default") {
+                        saveThemeDialog.doSave(name)
                     }
                 }
             }
@@ -332,9 +339,7 @@ Page {
                         Qt.inputMethod.commit()
                         var name = saveThemeDialog.themeName.trim()
                         if (name.length > 0 && name !== "Default") {
-                            Settings.saveCurrentTheme(name)
-                            if (themesLoader.item) themesLoader.item.refreshPresets()
-                            saveThemeDialog.close()
+                            saveThemeDialog.doSave(name)
                         }
                     }
                 }

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -12,8 +12,8 @@ Page {
 
     Component.onCompleted: root.currentPageTitle = TranslationManager.translate("settings.title", "Settings")
 
-    // Requested tab to switch to (set before pushing page)
-    property int requestedTabIndex: -1
+    // Requested tab to switch to (set before pushing page). Symbolic id from SettingsTabs.
+    property string requestedTabId: ""
 
     // Card to highlight after search navigation (cleared after use)
     property string highlightCardId: ""
@@ -32,19 +32,19 @@ Page {
     }
 
     StackView.onActivating: {
-        if (requestedTabIndex >= 0) {
-            markTabLoaded(requestedTabIndex)
-        }
+        var idx = requestedTabId.length > 0 ? SettingsTabs.indexOf(requestedTabId) : -1
+        if (idx >= 0) markTabLoaded(idx)
     }
 
     // Switch to requested tab after page transition completes (page is fully laid out)
     StackView.onActivated: {
         root.currentPageTitle = TranslationManager.translate("settings.title", "Settings")
-        if (requestedTabIndex >= 0) {
-            markTabLoaded(requestedTabIndex)
-            tabBar.currentIndex = requestedTabIndex
-            requestedTabIndex = -1
+        var idx = requestedTabId.length > 0 ? SettingsTabs.indexOf(requestedTabId) : -1
+        if (idx >= 0) {
+            markTabLoaded(idx)
+            tabBar.currentIndex = idx
         }
+        requestedTabId = ""
     }
 
     // Search button (left end of tab bar)
@@ -101,22 +101,7 @@ Page {
             settingsPage.markTabLoaded(currentIndex)
 
             if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
-                // Build tab names based on which tabs are visible
-                var tabNames = [
-                    TranslationManager.translate("settings.tab.connections", "Connections"),
-                    TranslationManager.translate("settings.tab.machine", "Machine"),
-                    TranslationManager.translate("settings.tab.calibration", "Calibration"),
-                    TranslationManager.translate("settings.tab.historyData", "History & Data"),
-                    TranslationManager.translate("settings.tab.themes", "Themes"),
-                    TranslationManager.translate("settings.tab.layout", "Layout"),
-                    TranslationManager.translate("settings.tab.screensaver", "Screensaver"),
-                    TranslationManager.translate("settings.tab.visualizer", "Visualizer"),
-                    TranslationManager.translate("settings.tab.ai", "AI"),
-                    TranslationManager.translate("settings.tab.mqtt", "MQTT"),
-                    TranslationManager.translate("settings.tab.languageAccess", "Language & Access")
-                ]
-                tabNames.push(TranslationManager.translate("settings.tab.about", "About"))
-                if (Settings.isDebugBuild) tabNames.push(TranslationManager.translate("settings.tab.debug", "Debug"))
+                var tabNames = SettingsTabs.visibleTabNames()
                 if (currentIndex >= 0 && currentIndex < tabNames.length) {
                     AccessibilityManager.announce(TranslationManager.translate("settings.accessible.tabAnnounce", "%1 tab").arg(tabNames[currentIndex]))
                 }
@@ -148,115 +133,64 @@ Page {
             }
         }
 
-        StyledTabButton {
-            id: connectionsTab
-            text: TranslationManager.translate("settings.tab.connections", "Connections")
-            tabLabel: TranslationManager.translate("settings.tab.connections", "Connections")
-        }
+        Repeater {
+            model: SettingsTabs.visibleTabs()
 
-        StyledTabButton {
-            id: machineTabButton
-            text: TranslationManager.translate("settings.tab.machine", "Machine")
-            tabLabel: TranslationManager.translate("settings.tab.machine", "Machine")
-        }
+            StyledTabButton {
+                id: tabBtn
+                required property var modelData
+                readonly property string tabId: modelData.id
+                readonly property bool isLanguageTab: modelData.id === "languageAccess"
 
-        StyledTabButton {
-            id: calibrationTabButton
-            text: TranslationManager.translate("settings.tab.calibration", "Calibration")
-            tabLabel: TranslationManager.translate("settings.tab.calibration", "Calibration")
-        }
-
-        StyledTabButton {
-            id: historyDataTabButton
-            text: TranslationManager.translate("settings.tab.historyData", "History & Data")
-            tabLabel: TranslationManager.translate("settings.tab.historyData", "History & Data")
-        }
-
-        StyledTabButton {
-            id: themesTabButton
-            text: TranslationManager.translate("settings.tab.themes", "Themes")
-            tabLabel: TranslationManager.translate("settings.tab.themes", "Themes")
-        }
-
-        StyledTabButton {
-            id: layoutTabButton
-            text: TranslationManager.translate("settings.tab.layout", "Layout")
-            tabLabel: TranslationManager.translate("settings.tab.layout", "Layout")
-        }
-
-        StyledTabButton {
-            id: screensaverTab
-            text: TranslationManager.translate("settings.tab.screensaver", "Screensaver")
-            tabLabel: TranslationManager.translate("settings.tab.screensaver", "Screensaver")
-        }
-
-        StyledTabButton {
-            id: visualizerTabButton
-            text: TranslationManager.translate("settings.tab.visualizer", "Visualizer")
-            tabLabel: TranslationManager.translate("settings.tab.visualizer", "Visualizer")
-        }
-
-        StyledTabButton {
-            id: aiTabButton
-            text: TranslationManager.translate("settings.tab.ai", "AI")
-            tabLabel: TranslationManager.translate("settings.tab.ai", "AI")
-        }
-
-        StyledTabButton {
-            id: mqttTabButton
-            text: TranslationManager.translate("settings.tab.mqtt", "MQTT")
-            tabLabel: TranslationManager.translate("settings.tab.mqtt", "MQTT")
-        }
-
-        // Language & Access tab with badge for untranslated strings
-        StyledTabButton {
-            id: languageTabButton
-            text: TranslationManager.translate("settings.tab.languageAccess", "Lang & Access")
-            tabLabel: TranslationManager.translate("settings.tab.languageAccess.full", "Language & Access")
-
-            // Override contentItem to add badge
-            contentItem: Row {
-                spacing: Theme.scaled(4)
-                Text {
-                    text: languageTabButton.text
-                    font: languageTabButton.font
-                    color: languageTabButton.checked ? Theme.textColor : Theme.textSecondaryColor
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                    anchors.verticalCenter: parent.verticalCenter
+                // Referencing translationVersion forces the language-tab branch below to re-
+                // evaluate on language change (the other branch goes through tabLabels, which
+                // already depends on translationVersion).
+                text: {
+                    var v = TranslationManager.translationVersion
+                    return isLanguageTab
+                        ? TranslationManager.translate("settings.tab.languageAccess", "Lang & Access")
+                        : SettingsTabs.tabLabels[tabId]
                 }
-                Rectangle {
-                    visible: TranslationManager.currentLanguage !== "en" && TranslationManager.untranslatedCount > 0
-                    width: badgeText.width + 8
-                    height: Theme.scaled(16)
-                    radius: Theme.scaled(8)
-                    color: Theme.warningColor
-                    anchors.verticalCenter: parent.verticalCenter
+                tabLabel: {
+                    var v = TranslationManager.translationVersion
+                    return isLanguageTab
+                        ? TranslationManager.translate("settings.tab.languageAccess.full", "Language & Access")
+                        : SettingsTabs.tabLabels[tabId]
+                }
 
+                // Shared Row contentItem: the badge is only visible on the Language & Access tab
+                // (Row ignores invisible children in its layout, so width matches plain-text tabs).
+                contentItem: Row {
+                    spacing: Theme.scaled(4)
                     Text {
-                        id: badgeText
-                        anchors.centerIn: parent
-                        text: TranslationManager.untranslatedCount > 99 ? "99+" : TranslationManager.untranslatedCount
-                        font.pixelSize: Theme.scaled(10)
-                        font.bold: true
-                        color: Theme.primaryContrastColor
+                        text: tabBtn.text
+                        font: tabBtn.font
+                        color: tabBtn.checked ? Theme.textColor : Theme.textSecondaryColor
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+                    Rectangle {
+                        visible: tabBtn.isLanguageTab
+                                 && TranslationManager.currentLanguage !== "en"
+                                 && TranslationManager.untranslatedCount > 0
+                        width: badgeText.width + 8
+                        height: Theme.scaled(16)
+                        radius: Theme.scaled(8)
+                        color: Theme.warningColor
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        Text {
+                            id: badgeText
+                            anchors.centerIn: parent
+                            text: TranslationManager.untranslatedCount > 99 ? "99+" : TranslationManager.untranslatedCount
+                            font.pixelSize: Theme.scaled(10)
+                            font.bold: true
+                            color: Theme.primaryContrastColor
+                        }
                     }
                 }
             }
-        }
-
-        StyledTabButton {
-            id: aboutTabButton
-            text: TranslationManager.translate("settings.tab.about", "About")
-            tabLabel: TranslationManager.translate("settings.tab.about", "About")
-        }
-
-        StyledTabButton {
-            id: debugTabButton
-            visible: Settings.isDebugBuild
-            text: TranslationManager.translate("settings.tab.debug", "Debug")
-            tabLabel: TranslationManager.translate("settings.tab.debug", "Debug")
-            width: visible ? implicitWidth : 0
         }
     }
 
@@ -274,113 +208,30 @@ Page {
 
         currentIndex: tabBar.currentIndex
 
-        // Tab 0: Connections - loads synchronously (first tab appears instantly)
-        Loader {
-            id: connectionsLoader
-            active: true
-            asynchronous: false
-            source: "settings/SettingsConnectionsTab.qml"
-        }
+        // One Loader per visible tab, in SettingsTabs order.
+        // Tabs with loadSync=true are loaded eagerly; others lazy-load on first visit.
+        Repeater {
+            id: tabLoaders
+            model: SettingsTabs.visibleTabs()
 
-        // Tab 1: Machine - lazy loaded on first visit
-        Loader {
-            id: machineLoader
-            active: 1 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsMachineTab.qml"
-        }
+            Loader {
+                required property var modelData
+                required property int index
+                readonly property string tabId: modelData.id
 
-        // Tab 2: Calibration - lazy loaded on first visit
-        Loader {
-            id: calibrationLoader
-            active: 2 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsCalibrationTab.qml"
-        }
+                active: modelData.loadSync || (index in settingsPage.loadedTabs)
+                asynchronous: !modelData.loadSync
+                source: modelData.source
 
-        // Tab 3: History & Data - lazy loaded on first visit
-        Loader {
-            id: historyDataLoader
-            active: 3 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsHistoryDataTab.qml"
-        }
-
-        // Tab 4: Themes - lazy loaded on first visit
-        Loader {
-            id: themesLoader
-            active: 4 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsThemesTab.qml"
-            onLoaded: {
-                item.openSaveThemeDialog.connect(function() {
-                    saveThemeDialog.open()
-                })
+                onLoaded: {
+                    // Themes tab emits a signal requesting the Save Theme dialog
+                    if (tabId === "themes" && item) {
+                        item.openSaveThemeDialog.connect(function() {
+                            saveThemeDialog.open()
+                        })
+                    }
+                }
             }
-        }
-
-        // Tab 5: Layout - lazy loaded on first visit
-        Loader {
-            id: layoutLoader
-            active: 5 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsLayoutTab.qml"
-        }
-
-        // Tab 6: Screensaver - lazy loaded on first visit
-        Loader {
-            id: screensaverLoader
-            active: 6 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsScreensaverTab.qml"
-        }
-
-        // Tab 7: Visualizer - lazy loaded on first visit
-        Loader {
-            id: visualizerLoader
-            active: 7 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsVisualizerTab.qml"
-        }
-
-        // Tab 8: AI - lazy loaded on first visit
-        Loader {
-            id: aiLoader
-            active: 8 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsAITab.qml"
-        }
-
-        // Tab 9: MQTT / Home Automation - lazy loaded on first visit
-        Loader {
-            id: homeAutomationLoader
-            active: 9 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsHomeAutomationTab.qml"
-        }
-
-        // Tab 10: Language & Access - lazy loaded on first visit
-        Loader {
-            id: languageLoader
-            active: 10 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsLanguageTab.qml"
-        }
-
-        // Tab 11: About (Updates, Firmware, About) - lazy loaded on first visit
-        Loader {
-            id: aboutLoader
-            active: 11 in settingsPage.loadedTabs
-            asynchronous: true
-            source: "settings/SettingsUpdateTab.qml"
-        }
-
-        // Tab 12: Debug - only in debug builds, lazy loaded on first visit
-        Loader {
-            id: debugLoader
-            active: Settings.isDebugBuild && (12 in settingsPage.loadedTabs)
-            asynchronous: true
-            source: "settings/SettingsDebugTab.qml"
         }
     }
 
@@ -494,7 +345,9 @@ Page {
     // Settings search dialog
     SettingsSearchDialog {
         id: settingsSearchDialog
-        onResultSelected: function(tabIndex, cardId) {
+        onResultSelected: function(tabId, cardId) {
+            var tabIndex = SettingsTabs.indexOf(tabId)
+            if (tabIndex < 0) return
             settingsPage.highlightCardId = cardId || ""
             settingsPage.markTabLoaded(tabIndex)
             tabBar.currentIndex = tabIndex
@@ -504,7 +357,7 @@ Page {
 
     // Scroll-to-card after search navigation (event-based, no timer)
     function scrollToCard(tabIndex, cardId) {
-        var loader = tabContent.children[tabIndex]
+        var loader = tabLoaders.itemAt(tabIndex)
         if (!loader) return
 
         if (loader.item) {

--- a/qml/pages/settings/SettingsSearchDialog.qml
+++ b/qml/pages/settings/SettingsSearchDialog.qml
@@ -16,7 +16,7 @@ Dialog {
     padding: Theme.scaled(16)
     closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
 
-    signal resultSelected(int tabIndex, string cardId)
+    signal resultSelected(string tabId, string cardId)
 
     background: Rectangle {
         color: Theme.surfaceColor
@@ -169,7 +169,7 @@ Dialog {
                 radius: Theme.scaled(6)
 
                 Accessible.role: Accessible.Button
-                Accessible.name: modelData.title + ", " + SearchIndex.getTabName(modelData.tabIndex, TranslationManager.translate.bind(TranslationManager)) + " tab"
+                Accessible.name: modelData.title + ", " + SettingsTabs.tabName(modelData.tabId) + " tab"
                 Accessible.focusable: true
                 Accessible.onPressAction: resultMouseArea.clicked(null)
 
@@ -214,7 +214,7 @@ Dialog {
                         Text {
                             id: tabBadgeText
                             anchors.centerIn: parent
-                            text: SearchIndex.getTabName(modelData.tabIndex, TranslationManager.translate.bind(TranslationManager))
+                            text: SettingsTabs.tabName(modelData.tabId)
                             color: Theme.primaryColor
                             font.pixelSize: Theme.scaled(10)
                             font.bold: true
@@ -229,7 +229,7 @@ Dialog {
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
                     onClicked: {
-                        searchDialog.resultSelected(modelData.tabIndex, modelData.cardId || "")
+                        searchDialog.resultSelected(modelData.tabId, modelData.cardId || "")
                         searchDialog.close()
                     }
                 }


### PR DESCRIPTION
Closes #833.

## Summary
- Adds a `SettingsTabs` QML singleton that owns the ordered tab definitions (id, translation key, fallback, Loader source, `loadSync`, `debugOnly`) plus `indexOf(id)`, `tabName(id)`, `tabLabels`, `visibleTabs()`, and `visibleTabNames()` helpers.
- `SettingsPage.qml` now drives both the `TabBar` buttons and the `StackLayout` Loaders from Repeaters keyed to `SettingsTabs.visibleTabs()`. The per-tab magic numbers in `active: N in loadedTabs` are gone, along with the hand-maintained `tabNames[]` announcer array.
- Navigation uses symbolic ids: `goToSettings(\"about\")`, `goToSettings(\"historyData\")`. `SettingsPage.requestedTabIndex` became `requestedTabId` (string).
- `SettingsSearchIndex.js` entries use `tabId` strings instead of `tabIndex` integers; `SettingsSearchDialog` emits `resultSelected(tabId, cardId)` and reads localized names via `SettingsTabs.tabName(tabId)`. The old `getTabName(index, tr)` helper is gone.
- Bonus fix: language-tab label branch now picks up language changes (reads `translationVersion`).

## Why it matters
The tab order used to live in ~5 places kept in lockstep by convention. #817 inserted a new Firmware tab and the \`goToSettings(11)\` caller in \`main.qml\` silently routed \"Update Now\" to the wrong tab — exactly the failure mode the issue describes. Adding or reordering a tab now only requires editing \`SettingsTabs.qml\`.

## Test plan
- [ ] Build & launch; open Settings, confirm all 12 (or 13 in debug builds) tabs render in the same order and localized labels match.
- [ ] Tap every tab; confirm lazy-loading still works (first visit loads content, subsequent visits are instant).
- [ ] From idle, trigger the update-available dialog → \"Update Now\" → lands on the **About** tab.
- [ ] Trigger the empty-database dialog → \"Restore\" → lands on **History & Data**.
- [ ] Open Settings search; pick a result in each tab and confirm navigation + scroll-to-card still works; verify the badge on the Language tab still appears for non-English locales with untranslated strings.
- [ ] TalkBack/VoiceOver: announce each tab on selection reports the correct localized name.
- [ ] Switch language; confirm all tab labels update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)