### PR TITLE
chore(log): record simulation-mode state at startup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -462,6 +462,7 @@ int main(int argc, char *argv[])
 
     DE1Device de1Device;
     de1Device.setSettings(&settings);  // For water level auto-calibration
+    qDebug() << "Simulation mode:" << (settings.simulationMode() ? "ON" : "off");
     de1Device.setSimulationMode(settings.simulationMode());  // Restore simulation mode from settings
     std::unique_ptr<ScaleDevice> physicalScale;  // Physical BLE scale (when connected)
     FlowScale flowScale;  // Virtual scale using DE1 flow data (fallback when no BLE scale)


### PR DESCRIPTION
## Summary
- Log one line at startup (`Simulation mode: ON` / `off`) so debug.log shows the current state without needing a screenshot.

## Context
A user on Linux Mint 22.3 reported the Connections tab showing **Status: Connected** with firmware details while Bluetooth was powered off. The debug log they shared gave no indication that simulation mode was the cause — it only became obvious from a screenshot showing the hardcoded sim values (93.0 °C, 872 ml, `firmware=v1342`). This one-liner makes the state visible directly in the log.

## Test plan
- [ ] Start the app with simulation mode OFF → log contains `Simulation mode: off`
- [ ] Toggle simulation mode ON in Settings → Machine, restart → log contains `Simulation mode: ON`

🤖 Generated with [Claude Code](https://claude.com/claude-code)