### PR TITLE
fix(settings): label Machine card as "Simulated" when sim mode is on

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -426,8 +426,15 @@ Item {
                         Tr {
                             key: "settings.bluetooth.connected"
                             fallback: "Connected"
-                            visible: DE1Device.connected
+                            visible: DE1Device.connected && !DE1Device.simulationMode
                             color: Theme.successColor
+                        }
+
+                        Tr {
+                            key: "settings.bluetooth.simulated"
+                            fallback: "Simulated"
+                            visible: DE1Device.connected && DE1Device.simulationMode
+                            color: Theme.warningColor
                         }
 
                         Tr {
@@ -442,7 +449,7 @@ Item {
                     Text {
                         text: TranslationManager.translate("settings.bluetooth.firmware", "Firmware:") + " " + (DE1Device.firmwareVersion || TranslationManager.translate("settings.bluetooth.unknown", "Unknown"))
                         color: Theme.textSecondaryColor
-                        visible: DE1Device.connected
+                        visible: DE1Device.connected && !DE1Device.simulationMode
                     }
 
                     ListView {


### PR DESCRIPTION
## Summary
- The Connections tab's Machine card showed **Status: Connected** (green) with firmware details any time `DE1Device.connected` was true, including when simulation mode was the reason.
- Now shows **Simulated** (warning color) when `DE1Device.simulationMode` is true, and hides the firmware line (which was displaying the hardcoded sim string, not real firmware).
- Mirrors the pattern already used in the scale section of the same tab.

## Context
Reported by a Linux Mint user whose Bluetooth was powered off — the banner warned about BT being off, but right next to it the Machine card said **Status: Connected** with `firmware=v1342`, which is simulator output. They reasonably assumed the DE1 was actually connected. Companion to #835 (which surfaces simulation state in the debug log).

## Test plan
- [ ] Toggle simulation mode on → Connections tab Machine card shows **Simulated** (warning color), no firmware line
- [ ] Toggle off, connect DE1 → shows **Connected** (green) + real firmware
- [ ] Disconnect → shows **Disconnected** (error color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)