### PR TITLE
refactor(scale): expose isSimulated property instead of name match

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -732,7 +732,7 @@ Item {
                         QtObject {
                             id: scaleStatusHelper
                             property bool isFlowScale: ScaleDevice && ScaleDevice.isFlowScale && Settings.useFlowScale
-                            property bool isSimulated: ScaleDevice && ScaleDevice.name === "Simulated Scale"
+                            property bool isSimulated: ScaleDevice && ScaleDevice.isSimulated
                             // FlowScale fallback after physical disconnect — treat as disconnected
                             property bool isDisconnectedFallback: ScaleDevice && ScaleDevice.isFlowScale && !Settings.useFlowScale
                             property bool isConnected: ScaleDevice && ScaleDevice.connected && !isDisconnectedFallback
@@ -865,7 +865,7 @@ Item {
                         color: Qt.rgba(Theme.warningColor.r, Theme.warningColor.g, Theme.warningColor.b, 0.15)
                         border.color: Theme.warningColor
                         border.width: 1
-                        visible: ScaleDevice && ScaleDevice.name === "Simulated Scale"
+                        visible: ScaleDevice && ScaleDevice.isSimulated
 
                         Text {
                             id: simScaleNotice

--- a/src/ble/scaledevice.h
+++ b/src/ble/scaledevice.h
@@ -16,6 +16,7 @@ class ScaleDevice : public QObject {
     Q_PROPERTY(int batteryLevel READ batteryLevel NOTIFY batteryLevelChanged)
     Q_PROPERTY(QString name READ name CONSTANT)
     Q_PROPERTY(bool isFlowScale READ isFlowScale CONSTANT)
+    Q_PROPERTY(bool isSimulated READ isSimulated CONSTANT)
 
 public:
     explicit ScaleDevice(QObject* parent = nullptr);
@@ -30,6 +31,7 @@ public:
     virtual QString name() const { return QString(); }
     virtual QString type() const { return QString(); }
     virtual bool isFlowScale() const { return false; }
+    virtual bool isSimulated() const { return false; }
 
     bool simulationMode() const { return m_simulationMode; }
     void setSimulationMode(bool enabled);

--- a/src/simulator/simulatedscale.h
+++ b/src/simulator/simulatedscale.h
@@ -18,6 +18,7 @@ public:
     void connectToDevice(const QBluetoothDeviceInfo& device) override;
     QString name() const override { return "Simulated Scale"; }
     QString type() const override { return "simulated"; }
+    bool isSimulated() const override { return true; }
 
 public slots:
     void tare() override;


### PR DESCRIPTION
## Summary
- Add virtual `bool isSimulated()` on `ScaleDevice` (Q_PROPERTY, CONSTANT), defaulting to `false`; override to `true` in `SimulatedScale`.
- Swap the two QML call sites in `SettingsConnectionsTab.qml` from `ScaleDevice.name === \"Simulated Scale\"` to `ScaleDevice.isSimulated`.

## Context
Flagged during review of [#836](https://github.com/Kulitorum/Decenza/pull/836). The DE1 side detects simulation via a proper `DE1Device.simulationMode` property, but the scale side was matching against the display-name string. Renaming the scale's display name for i18n or UX would silently break the \"Simulated\" status label and the simulator notice banner. Mirrors the existing `isFlowScale` pattern.

## Test plan
- [ ] Launch with Simulation Mode ON → Scale card shows **Simulated** status + simulator notice banner
- [ ] Launch without sim mode, connect a real scale → status shows **Connected**, no notice
- [ ] Launch without sim mode, no scale → FlowScale fallback still works (shows **Virtual Scale** when enabled, **Disconnected** otherwise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)