### PR TITLE
feat(idle): show yield override arrow in shot plan, matching temperature

### DIFF
--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -27,6 +27,7 @@ Text {
     property string roastDate: Settings.dyeRoastDate
     property string grindSize: Settings.dyeGrinderSetting
     property double dose: Settings.dyeBeanWeight
+    property double profileYield: ProfileManager.profileTargetWeight
     property double targetWeight: ProfileManager.targetWeight
 
     text: {
@@ -52,7 +53,14 @@ Text {
         if (showDoseYield && (dose > 0 || targetWeight > 0)) {
             var yieldParts = []
             if (dose > 0) yieldParts.push(dose.toFixed(1) + "g in")
-            if (targetWeight > 0) yieldParts.push(targetWeight.toFixed(1) + "g out")
+            if (targetWeight > 0) {
+                var yieldStr = targetWeight.toFixed(1) + "g out"
+                if (Settings.hasBrewYieldOverride && profileYield > 0
+                        && Math.abs(targetWeight - profileYield) > 0.1) {
+                    yieldStr = profileYield.toFixed(1) + " → " + targetWeight.toFixed(1) + "g out"
+                }
+                yieldParts.push(yieldStr)
+            }
             parts.push(yieldParts.join(", "))
         }
         return parts.length > 0 ? parts.join(" \u00B7 ") : ""


### PR DESCRIPTION
## Summary
- The shot plan chip on the Idle page already renders `93 → 85°C` when `Settings.hasTemperatureOverride` is true. Yield had no equivalent indicator — it just showed the effective value (`40.0g out`), so users couldn't tell from the chip that an override was active.
- Mirror the temperature pattern for yield: when `Settings.hasBrewYieldOverride` is true and the override differs from the profile default by more than 0.1 g, render `36.0 → 40.0g out` instead of just `40.0g out`.
- `ProfileManager.profileTargetWeight` is already a `Q_PROPERTY` backed by `currentProfileChanged`, so the new `profileYield` binding re-evaluates correctly when the profile changes or the override is cleared.

## Test plan
- [ ] Load a shot from Shot History or Auto-Favorites whose saved `yield_override` differs from the profile's `target_weight` — chip should read e.g. `Profile · Bean · 18.0g in, 36.0 → 40.0g out`.
- [ ] Change the yield in Brew Settings manually to something different from the profile default — chip should update to show the arrow.
- [ ] Clear overrides via Brew Settings → chip drops back to single value `40.0g out`.
- [ ] Verify the temperature arrow still works the same way — both arrows should appear together when both are active.
- [ ] Profile with `target_weight == 0` (volumetric / timer-based profiles): chip should still show single value without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)