### PR TITLE
chore(main): tighten main.cpp includes and fix clazy Qt-container warnings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,9 +59,10 @@
 #include "ble/scales/scalefactory.h"
 #include "ble/scales/flowscale.h"
 #include "ble/refractometers/difluidr2.h"
-#include "ble/transport/qtscalebletransport.h"
 #if defined(Q_OS_IOS) || defined(Q_OS_MACOS)
-#include "ble/transport/corebluetooth/corebluetoothscalebletransport.h"
+#include "ble/transport/corebluetooth/corebluetoothscalebletransport.h" // IWYU pragma: keep
+#else
+#include "ble/transport/qtscalebletransport.h" // IWYU pragma: keep
 #endif
 #include "machine/machinestate.h"
 #include "machine/weightprocessor.h"
@@ -623,7 +624,7 @@ int main(int argc, char *argv[])
                          QString scaleType = settings.scaleType();
                          bool converged = settings.isSawConverged(scaleType);
                          int maxEntries = converged ? 12 : 8;
-                         auto entries = settings.sawLearningEntries(scaleType, maxEntries);
+                         const auto entries = settings.sawLearningEntries(scaleType, maxEntries);
                          QVector<double> drips, flows;
                          drips.reserve(entries.size());
                          flows.reserve(entries.size());
@@ -1619,7 +1620,7 @@ int main(int argc, char *argv[])
 
     // Give RelayClient a handle to the main window for screen capture
     if (!engine.rootObjects().isEmpty()) {
-        QQuickWindow* window = qobject_cast<QQuickWindow*>(engine.rootObjects().first());
+        QQuickWindow* window = qobject_cast<QQuickWindow*>(engine.rootObjects().constFirst());
         if (window) {
             relayClient.setWindow(window);
         }
@@ -2119,7 +2120,7 @@ int main(int argc, char *argv[])
         // Qt.quit() does NOT trigger ApplicationWindow.onClosing, so the QML-side
         // shuttingDown flag may not be set. Setting it here covers all exit paths.
         if (!engine.rootObjects().isEmpty()) {
-            engine.rootObjects().first()->setProperty("shuttingDown", true);
+            engine.rootObjects().constFirst()->setProperty("shuttingDown", true);
         }
 
         // Stop weight processor thread first (before BLE shutdown).


### PR DESCRIPTION
## Summary
Four cleanups to quiet clang-tidy / clazy noise in `src/main.cpp`:

1. **Platform-scope `qtscalebletransport.h`** — moved the include into the same `#if/#else` block that already guards `corebluetoothscalebletransport.h`, so iOS/macOS builds (which use CoreBluetooth at `main.cpp:1360`) no longer pull in a header only referenced inside the `#else` branch at `main.cpp:1363`. Added `// IWYU pragma: keep` on both branches so clangd's include-cleaner doesn't re-flag either side when analysis runs on the "off" platform.
2. **`const auto entries`** at the SAW learning lookup (line 624) — silences `clazy-range-loop-detach`. The subsequent `for (const auto& e : entries)` was iterating a non-const lvalue, hitting `QList::begin()`'s non-const overload and forcing a COW detach.
3. **`engine.rootObjects().constFirst()`** at lines 1620 and 2120 — fixes `clazy-detaching-temporary`. `rootObjects()` returns a fresh `QList` and calling `.first()` on it returns a non-const reference into a temporary; `constFirst()` returns a const reference without triggering detach.

No behavioural change — the `#else`-branch QtScaleBleTransport use at line 1363 and the CoreBluetooth use at line 1360 were already platform-gated; only the include was un-gated.

## Test plan
- [ ] Build Debug + Release on both macOS and Windows, confirm no new warnings.
- [ ] iOS/macOS: QtScaleBleTransport is no longer compiled (already was effectively dead code, just less noisy now).
- [ ] Non-Apple platforms (Linux / Android / Windows): `QtScaleBleTransport` is instantiated at `main.cpp:1363` exactly as before.
- [ ] Shot save flow still records SAW learning entries (the range-loop at line 630 still runs, just without the COW detach).
- [ ] App startup and shutdown still work — `RelayClient::setWindow()` and the `shuttingDown` QML property still get set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)