### PR TITLE
fix(update): prevent downgrade install; add settings crash debug logging

### DIFF
--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -222,6 +222,15 @@ Page {
                 asynchronous: !modelData.loadSync
                 source: modelData.source
 
+                onStatusChanged: {
+                    if (status === Loader.Loading)
+                        console.log("SettingsPage: async loading tab", tabId)
+                    else if (status === Loader.Ready)
+                        console.log("SettingsPage: tab ready", tabId)
+                    else if (status === Loader.Error)
+                        console.log("SettingsPage: tab load error", tabId)
+                }
+
                 onLoaded: {
                     // Themes tab emits a signal requesting the Save Theme dialog
                     if (tabId === "themes" && item) {

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -228,7 +228,7 @@ Page {
                     else if (status === Loader.Ready)
                         console.log("SettingsPage: tab ready", tabId)
                     else if (status === Loader.Error)
-                        console.log("SettingsPage: tab load error", tabId)
+                        console.warn("SettingsPage: tab load error", tabId)
                 }
 
                 onLoaded: {

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -204,6 +204,7 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
     QJsonDocument doc = QJsonDocument::fromJson(data);
     if (!doc.isArray()) {
         m_errorMessage = "Invalid response from GitHub";
+        qWarning() << "UpdateChecker:" << m_errorMessage << "- response:" << data.left(200);
         emit errorMessageChanged();
         return;
     }
@@ -289,6 +290,11 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
         }
 #endif
         // iOS doesn't download from GitHub - updates come from App Store
+    }
+
+    if (m_downloadUrl.isEmpty()) {
+        qWarning() << "UpdateChecker: release" << m_releaseTag
+                   << "found but no platform asset available";
     }
 
     // Check if update is available using display version comparison,
@@ -530,7 +536,7 @@ void UpdateChecker::onDownloadFinished()
     if (!m_currentReply || !m_downloadFile) {
         qWarning() << "UpdateChecker: onDownloadFinished called with null reply or file"
                     << "reply=" << m_currentReply << "file=" << m_downloadFile;
-        m_errorMessage = "Download failed unexpectedly";
+        m_errorMessage = "Download failed unexpectedly. Please try again.";
         emit errorMessageChanged();
         m_downloading = false;
         emit downloadingChanged();

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -313,9 +313,15 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
 #endif
 
     if (m_updateAvailable != wasAvailable) {
-        // If update is no longer available (e.g. user is now on a newer beta),
-        // invalidate any cached APK so it can't be installed accidentally.
-        if (!m_updateAvailable && !m_downloadedApkPath.isEmpty()) {
+        // If an update that was previously available is no longer available
+        // (e.g. user sideloaded a newer build, switched to a channel whose
+        // latest version is not newer, or a re-check finds they are now
+        // current), clear the cached APK path so it can't be installed
+        // accidentally. The file itself is left for OS cleanup — a
+        // PackageInstaller session may still hold it open.
+        // NOTE: dismissUpdate() and onInstallStatus() contain equivalent
+        // cleanup; all three must be kept consistent.
+        if (!m_updateAvailable && !m_downloading && !m_downloadedApkPath.isEmpty()) {
             m_downloadedApkPath.clear();
             m_expectedDownloadSize = 0;
             emit downloadReadyChanged();
@@ -387,7 +393,10 @@ void UpdateChecker::downloadAndInstall()
 {
     if (!m_updateAvailable) {
         qWarning() << "UpdateChecker: downloadAndInstall called but no update available (current:"
-                   << currentVersion() << "latest:" << m_latestVersion << ")";
+                   << currentVersion() << "latest:" << m_latestVersion
+                   << "downloadUrl:" << (m_downloadUrl.isEmpty() ? "<empty>" : m_downloadUrl) << ")";
+        m_errorMessage = "No update available";
+        emit errorMessageChanged();
         return;
     }
     if (m_downloading || m_checking) return;

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -292,10 +292,12 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
         // iOS doesn't download from GitHub - updates come from App Store
     }
 
+#if defined(Q_OS_ANDROID) || defined(Q_OS_MACOS)
     if (m_downloadUrl.isEmpty()) {
         qWarning() << "UpdateChecker: release" << m_releaseTag
                    << "found but no platform asset available";
     }
+#endif
 
     // Check if update is available using display version comparison,
     // falling back to build number if versions are equal
@@ -319,20 +321,21 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
 #endif
 
     if (m_updateAvailable != wasAvailable) {
-        // If an update that was previously available is no longer available
-        // (e.g. user sideloaded a newer build, switched to a channel whose
-        // latest version is not newer, or a re-check finds they are now
-        // current), clear the cached APK path so it can't be installed
-        // accidentally. The file itself is left for OS cleanup — a
-        // PackageInstaller session may still hold it open.
-        // NOTE: dismissUpdate() and onInstallStatus() contain equivalent
-        // cleanup; all three must be kept consistent.
-        if (!m_updateAvailable && !m_downloading && !m_downloadedApkPath.isEmpty()) {
-            m_downloadedApkPath.clear();
-            m_expectedDownloadSize = 0;
-            emit downloadReadyChanged();
-        }
         emit updateAvailableChanged();
+    }
+
+    // Clear any cached APK whenever no update is available and no operation is
+    // in flight, so a stale path can't be installed accidentally. Runs
+    // unconditionally (not only on transition) to cover the case where the path
+    // was set before a re-check that finds the running version already current.
+    // The file is left on disk for OS cleanup — a PackageInstaller session may
+    // still hold it open. (dismissUpdate() also clears the path but additionally
+    // removes the file; onInstallStatus() mirrors that behaviour. All three sites
+    // clear m_downloadedApkPath and emit downloadReadyChanged — keep in sync.)
+    if (!m_updateAvailable && !m_downloading && !m_installInFlight && !m_downloadedApkPath.isEmpty()) {
+        m_downloadedApkPath.clear();
+        m_expectedDownloadSize = 0;
+        emit downloadReadyChanged();
     }
     // canDownloadUpdate is derived from m_downloadUrl on desktop; fire when it
     // changes so QML re-evaluates the download-button visibility binding. On

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -313,6 +313,13 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
 #endif
 
     if (m_updateAvailable != wasAvailable) {
+        // If update is no longer available (e.g. user is now on a newer beta),
+        // invalidate any cached APK so it can't be installed accidentally.
+        if (!m_updateAvailable && !m_downloadedApkPath.isEmpty()) {
+            m_downloadedApkPath.clear();
+            m_expectedDownloadSize = 0;
+            emit downloadReadyChanged();
+        }
         emit updateAvailableChanged();
     }
     // canDownloadUpdate is derived from m_downloadUrl on desktop; fire when it
@@ -378,6 +385,11 @@ bool UpdateChecker::isNewerVersion(const QString& latest, const QString& current
 
 void UpdateChecker::downloadAndInstall()
 {
+    if (!m_updateAvailable) {
+        qWarning() << "UpdateChecker: downloadAndInstall called but no update available (current:"
+                   << currentVersion() << "latest:" << m_latestVersion << ")";
+        return;
+    }
     if (m_downloading || m_checking) return;
     if (m_installInFlight) {
         m_errorMessage = "Install already in progress. If no confirmation dialog is visible, "


### PR DESCRIPTION
## Summary

- **UpdateChecker downgrade fix**: `downloadAndInstall()` now returns early if `m_updateAvailable` is false, preventing a stale download URL (e.g. latest stable v1.6.3 while running v1.7.2 beta) from installing an older version. Also clears the cached APK path immediately when a version check flips `updateAvailable` to false.
- **Crash debug logging**: `SettingsPage` now logs which async tab starts loading, finishes, or errors. The next SIGSEGV in `QQmlConnections::connectSignalsToMethods()` (issue #844) will show the exact tab name as the last debug line before the crash.

## Context

Issue #844 crash report showed v1.7.2 (beta/prerelease) downloading and installing v1.6.3 (older stable) during a settings browsing session. The `downloadAndInstall()` function had no guard for `m_updateAvailable`, so a stale URL could be used even after the version check determined no update was needed. The crash itself (SIGSEGV during async QML incubation) requires another reproduction to identify the exact `Connections` block; the logging change makes that identification trivial.

## Test plan

- [ ] Run as a beta version with beta updates disabled — confirm update checker finds stable release, confirm `downloadAndInstall()` logs warning and does nothing
- [ ] Run as older version — confirm normal update flow still works (downloads and installs correctly)
- [ ] Browse all settings tabs — confirm `SettingsPage: async loading tab <id>` / `tab ready <id>` logs appear in debug output for each tab visited

🤖 Generated with [Claude Code](https://claude.com/claude-code)