### PR TITLE
[codex] Avoid async settings tab incubation

### DIFF
--- a/qml/components/SettingsTabs.qml
+++ b/qml/components/SettingsTabs.qml
@@ -12,7 +12,7 @@ QtObject {
     // key       — TranslationManager key for the localized tab label
     // fallback  — English fallback used when no translation is available
     // source    — QML source loaded into the tab's StackLayout page
-    // loadSync  — if true, the Loader loads synchronously on startup (first tab only)
+    // loadSync  — if true, the Loader loads eagerly on startup (first tab only)
     // debugOnly — if true, the tab is hidden unless Settings.isDebugBuild is set
     readonly property var tabs: [
         { id: "connections",    key: "settings.tab.connections",    fallback: "Connections",       source: "settings/SettingsConnectionsTab.qml",     loadSync: true,  debugOnly: false },

--- a/qml/components/SettingsTabs.qml
+++ b/qml/components/SettingsTabs.qml
@@ -12,7 +12,7 @@ QtObject {
     // key       — TranslationManager key for the localized tab label
     // fallback  — English fallback used when no translation is available
     // source    — QML source loaded into the tab's StackLayout page
-    // loadSync  — if true, the Loader loads eagerly on startup (first tab only)
+    // loadSync  — if true, the tab is activated immediately when the page opens rather than on first visit (asynchronous: false is enforced globally in SettingsPage.qml)
     // debugOnly — if true, the tab is hidden unless Settings.isDebugBuild is set
     readonly property var tabs: [
         { id: "connections",    key: "settings.tab.connections",    fallback: "Connections",       source: "settings/SettingsConnectionsTab.qml",     loadSync: true,  debugOnly: false },

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -219,12 +219,16 @@ Page {
                 readonly property string tabId: modelData.id
 
                 active: modelData.loadSync || (index in settingsPage.loadedTabs)
-                asynchronous: !modelData.loadSync
+                // Keep settings tabs lazy-loaded, but instantiate them synchronously.
+                // Android crash reports have shown QQmlConnections crashing inside
+                // QQmlIncubationController while browsing settings; avoiding async
+                // incubation keeps Connections setup on the tab-switch event.
+                asynchronous: false
                 source: modelData.source
 
                 onStatusChanged: {
                     if (status === Loader.Loading)
-                        console.log("SettingsPage: async loading tab", tabId)
+                        console.log("SettingsPage: loading tab", tabId)
                     else if (status === Loader.Ready)
                         console.log("SettingsPage: tab ready", tabId)
                     else if (status === Loader.Error)

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -219,18 +219,19 @@ Page {
                 readonly property string tabId: modelData.id
 
                 active: modelData.loadSync || (index in settingsPage.loadedTabs)
-                // Keep settings tabs lazy-loaded, but instantiate them synchronously.
-                // Android crash reports have shown QQmlConnections crashing inside
-                // QQmlIncubationController while browsing settings; avoiding async
-                // incubation keeps Connections setup on the tab-switch event.
+                // Synchronous instantiation: Android crash reports showed QQmlConnections
+                // crashing inside QQmlIncubationController while browsing settings. Forcing
+                // asynchronous: false eliminates the incubation path entirely. Tabs remain
+                // lazy-loaded (active is gated by loadedTabs); loadSync only controls whether
+                // a tab is pre-activated on page open vs. activated on first visit.
                 asynchronous: false
                 source: modelData.source
 
                 onStatusChanged: {
                     if (status === Loader.Loading)
-                        console.log("SettingsPage: loading tab", tabId)
+                        console.log("SettingsPage: loading tab", tabId)  // TODO: remove after #844 confirmed resolved
                     else if (status === Loader.Ready)
-                        console.log("SettingsPage: tab ready", tabId)
+                        console.log("SettingsPage: tab ready", tabId)  // TODO: remove after #844 confirmed resolved
                     else if (status === Loader.Error)
                         console.warn("SettingsPage: tab load error", tabId)
                 }
@@ -382,7 +383,10 @@ Page {
             // Tab already loaded — scroll immediately
             doScrollAndHighlight(loader.item, cardId)
         } else {
-            // Wait for async Loader to finish via statusChanged signal
+            // Tab not yet instantiated — connect statusChanged; with asynchronous: false
+            // loading is synchronous but item is only valid after active flips, so
+            // statusChanged is still the correct hook when scrollToCard is called
+            // before the loader's active binding has re-evaluated
             var conn = function() {
                 if (loader.status === Loader.Ready && loader.item) {
                     loader.statusChanged.disconnect(conn)


### PR DESCRIPTION
## Summary

- Keep Settings tabs lazy-loaded, but instantiate visited tabs synchronously instead of through async QML incubation.
- Update the SettingsTabs comment so `loadSync` describes eager startup loading rather than async behavior.

## Why

Issue #844 still has an unknown crash after the downgrade fix. The crash stack dies in `QQmlConnections::connectSignalsToMethods()` under `QQmlIncubationController::incubateFor()` while the user was browsing settings. Settings tabs were the main place where we lazily created many `Connections` objects through async loaders, and this repo already has a documented workaround for the same Qt crash class by avoiding signal activity during QML incubation.

This change preserves lazy loading, but removes async incubation from Settings tab creation.

## Validation

- `git diff --check`