### PR TITLE
feat(saw): per-(profile, scale) batched SAW learning (#847)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ Detailed documentation lives in `docs/CLAUDE_MD/`. Read these when working in th
 | `EMOJI_SYSTEM.md` | Twemoji SVG rendering, adding/switching emoji sets |
 | `ACCESSIBILITY.md` | TalkBack/VoiceOver rules, focus order, anti-patterns, implementation plan |
 | `AUTO_FLOW_CALIBRATION.md` | Auto flow calibration algorithm, batched median updates, windowing, convergence |
+| `SAW_LEARNING.md` | Per-(profile, scale) stop-at-weight learning — analysis, batched median commits, IQR dispersion rejection, global bootstrap |
 | `FIRMWARE_UPDATE.md` | DE1 firmware update flow, source URL, validation rules, failure modes, simulator behaviour |
 
 Also in `docs/`:

--- a/docs/CLAUDE_MD/SAW_LEARNING.md
+++ b/docs/CLAUDE_MD/SAW_LEARNING.md
@@ -58,7 +58,7 @@ Three QSettings keys, each a JSON object keyed by `"<profileFilename>::<scaleTyp
 |-----|-------|------|---------|
 | `saw/perProfileHistory` | array of committed batch-median entries `{drip, flow, overshoot, scale, profile, ts, batchSize}` | 10 medians (~50 shots-worth) | Source of truth for `sawLearnedLagFor` / `getExpectedDripFor` once the pair has graduated (≥ 3 medians). |
 | `saw/perProfileBatch` | array of pending raw entries `{drip, flow, overshoot, scale, profile, ts}` (target size 5) | 5 (commit point) | Pending accumulator; flushed on commit or rejection. |
-| `saw/globalBootstrapLag/<scaleType>` | scalar `double` (seconds) | n/a | IQR-fenced median of last committed median lag from each graduated pair on this scale. Used as first-shot default for new pairs. |
+| `saw/globalBootstrapLag/<scaleType>` | scalar `double` (seconds) | n/a | IQR-fenced median of last committed median lag from each pair on this scale with at least one committed batch-median. Used as first-shot default for new pairs. (Graduation for the per-profile *read* path is a stricter ≥ 3 medians; the bootstrap is a cold-start prior, so it accepts pairs with any committed history — IQR fencing handles the rest.) |
 
 The legacy `saw/learningHistory` key is preserved as a **global pool**: every committed batch-median is mirrored into it (trim 50). This keeps `isSawConverged()` and the legacy convergence-divergence detection working without changes, and provides a final read-path fallback for users with pre-update data.
 

--- a/docs/CLAUDE_MD/SAW_LEARNING.md
+++ b/docs/CLAUDE_MD/SAW_LEARNING.md
@@ -1,0 +1,183 @@
+# SAW (Stop-At-Weight) Learning
+
+## Problem
+
+The DE1's stop-at-weight feature has to send the stop command *before* the target weight is reached, because there is unavoidable lag between the command and pump shutdown:
+
+```
+total drip ≈ flow_at_stop × (BLE_round_trip_lag + DE1_machine_lag) + post_shutoff_drip
+```
+
+The two hardware lags are scale-specific (`Settings::sensorLag()` documents them; e.g., Decent Scale 0.38 s, Acaia 0.69 s, Bookoo 0.50 s) and the post-shutoff drip is profile- and portafilter-specific. Together they yield a total "drip after stop trigger" the controller has to predict in advance, then trigger the stop when `current_weight + predicted_drip ≥ target`.
+
+For years the predictor learned a single drip-vs-flow curve per scale type, stored as a rolling history of `{drip, flow, scale, overshoot}` records in QSettings (`saw/learningHistory`). That model worked for users on a single profile but gradually accumulated systematic error for users who alternate between profiles with different drip dynamics.
+
+[Issue #847](https://github.com/Kulitorum/Decenza/issues/847) reported the failure mode in unambiguous terms: a user alternating between an open-spout portafilter with one profile and a double-spout portafilter with another saw the model overshoot for the dominant pairing and undershoot for the secondary pairing. The learning was being pulled by whichever profile-portafilter combo the user pulled most often, contaminating the prediction for the rarer one.
+
+## Empirical evidence (this device, Apr 2026)
+
+Pulling SAW debug logs from real shots on a Decent Scale showed the contamination directly:
+
+| Shot | Profile | Trigger flow | expectedDrip | Settled drip | Result |
+|------|---------|--------------|--------------|--------------|--------|
+| 1056 | 80's Espresso | 1.99 g/s | 1.04 g | ~0.9 g | close |
+| 1059 | 80's Espresso | 2.04 g/s | 1.13 g | 1.1 g | accurate |
+| 1054 | 80's Espresso (short shot, fast end-flow) | 5.20 g/s | 1.27 g | ~2.5 g | **2× under-predicted** |
+| 1047 | **D-Flow / Q** | 2.30 g/s | 1.24 g | ~0.8 g | **0.4 g over-predicted** |
+
+Shot 1047 is the smoking gun. D-Flow / Q's actual drip is consistently ~0.8 g but the global model predicted 1.24 g — a systematic 0.4 g undershoot per shot, exactly the issue #847 pattern. The model was being pulled toward 80's Espresso's drip dynamics because that is the user's more frequent profile. D-Flow's lower drip rate never got a chance to teach the model its own signature.
+
+Shot 1054 is a separate point: even within a single profile, end-of-shot flow can vary 2.5×. The drip-vs-flow regression already in place handles that, so we kept it.
+
+## Solution: per-(profile, scale) batched learning
+
+The same architecture that fixed the analogous problem in flow calibration ([AUTO_FLOW_CALIBRATION.md](AUTO_FLOW_CALIBRATION.md), issue [#739](https://github.com/Kulitorum/Decenza/issues/739)) applies cleanly to SAW:
+
+1. **Per-(profile, scale) history** — each pair learns its own drip dynamics. Switching profiles or scales does not contaminate the active pair's data.
+2. **Batched median commits** — accumulate 5 shots' worth of pending entries before changing the model. The median is robust to single-shot outliers (channeling, scale glitches, cup interaction). 5 was chosen to match flow cal.
+3. **Batch-level dispersion check** — if the 5 lags within a batch are too spread out (IQR > 1.0 s, or any single lag > 1.5 s from the batch median), the whole batch is dropped. Dispersion that high indicates the user changed conditions mid-batch (different beans, different grinder, manual stop).
+4. **Global bootstrap** — the median lag across all graduated `(profile, scale)` pairs on the same scale is published as `saw/globalBootstrapLag/<scaleType>`. New pairs use this as their first-shot default instead of the scale's hardware-only `sensorLag()`.
+5. **Read-path fallback chain** — `perProfile` (≥ 3 committed batches) → `globalBootstrap` → `globalPool` (legacy entries) → `scaleDefault`. New users / new pairs degrade gracefully.
+
+### Why this is the right shape
+
+The two systems (flow cal and SAW) are learning the same kind of correction: a per-shot scalar that depends on (profile dynamics × hardware quirks), where the hardware quirk has a known prior (sensor lag for SAW, density correction for flow cal) and the profile contribution is what we have to learn from data. Both benefit from:
+
+- **Isolation by profile** — to eliminate cross-profile bias.
+- **Median over mean** — to absorb single-shot anomalies without explicit outlier detection.
+- **Batched updates** — to break the feedback loop where each model change alters the conditions for the next shot.
+- **Global fallback** — to cold-start new profiles from the system's collective experience instead of from a constant.
+
+Reusing flow cal's design for SAW reduces risk because the patterns are already in production and have a year of operational evidence behind them.
+
+## Storage schema
+
+Three QSettings keys, each a JSON object keyed by `"<profileFilename>::<scaleType>"`:
+
+| Key | Shape | Trim | Purpose |
+|-----|-------|------|---------|
+| `saw/perProfileHistory` | array of committed batch-median entries `{drip, flow, overshoot, scale, profile, ts, batchSize}` | 10 medians (~50 shots-worth) | Source of truth for `sawLearnedLagFor` / `getExpectedDripFor` once the pair has graduated (≥ 3 medians). |
+| `saw/perProfileBatch` | array of pending raw entries `{drip, flow, overshoot, scale, profile, ts}` (target size 5) | 5 (commit point) | Pending accumulator; flushed on commit or rejection. |
+| `saw/globalBootstrapLag/<scaleType>` | scalar `double` (seconds) | n/a | IQR-fenced median of last committed median lag from each graduated pair on this scale. Used as first-shot default for new pairs. |
+
+The legacy `saw/learningHistory` key is preserved as a **global pool**: every committed batch-median is mirrored into it (trim 50). This keeps `isSawConverged()` and the legacy convergence-divergence detection working without changes, and provides a final read-path fallback for users with pre-update data.
+
+The per-entry shape gains one optional field, `profile`. Old entries without it are still readable.
+
+## Algorithm Details
+
+### Read path
+
+```
+sawLearnedLagFor(profile, scale):
+  if perProfileSawHistory(profile, scale).size ≥ 3:
+    return mean(drip / flow over last 5 medians)        ← perProfile
+  if globalSawBootstrapLag(scale) > 0:
+    return globalSawBootstrapLag(scale)                 ← globalBootstrap
+  return sawLearnedLag()                                ← globalPool / scaleDefault
+
+sawModelSource(profile, scale):
+  → "perProfile" | "globalBootstrap" | "globalPool" | "scaleDefault"
+```
+
+`getExpectedDripFor` mirrors `getExpectedDrip`'s recency- and flow-similarity-weighted regression, but on the per-pair history when available. The flow-similarity weighting is what handles within-profile flow variation (e.g. shot 1054's 2.5× end-flow): the predictor weights past shots whose flow rate is close to the current shot's flow rate.
+
+### Write path
+
+```
+addSawLearningPoint(drip, flow, scale, overshoot, profile):
+  apply existing entry-level guards:                ← unchanged
+    drip < 0 or flow < 0       → reject
+    drip / flow > 4 s          → reject (implausible BLE lag)
+    converged + |drip - expected| > max(3, expected)  → reject
+
+  if profile is empty:                              ← legacy path preserved
+    append to global pool, trim 50, save
+    return
+
+  append entry to perProfileBatch[profile::scale]
+  if pending.size < 5:
+    log "[SAW] accumulated drip=… flow=… (n/5) lag=…"
+    return
+
+  compute median drip, flow, overshoot, lag, IQR(lags)
+  if IQR > 1.0 s or any |lag - median_lag| > 1.5 s:
+    log "[SAW] batch rejected — high dispersion …"
+    drop pending, return
+
+  if median_overshoot < -6 g and last committed median for pair was also < -6 g:
+    log "[SAW] 2nd consecutive overshoot<-6g … clearing committed history"
+    perProfileSawHistory[pair] := []                ← per-pair auto-reset
+
+  append median entry to perProfileSawHistory[pair], trim 10
+  append same median to global pool, trim 50
+  clear pending
+  recomputeGlobalSawBootstrap(scale)
+  emit sawLearnedLagChanged()
+```
+
+### Why batched, with median
+
+Per-shot updates create a feedback loop: each update changes the predicted-drip threshold, which changes when the stop command fires, which changes the observed drip. The model partially chases its own tail.
+
+Batching to N=5 holds the model constant for 5 shots, so the 5 ideals are pulled under identical conditions and are directly comparable. Taking the **median** of those 5 ideals is a built-in outlier filter: a single bad shot (channeling, scale glitch, manual stop, runaway) cannot move the model. This same logic, with the same numerical constants, has held up well in flow calibration since #739 closed.
+
+### Why dispersion guards on top of the median
+
+Median rejects single outliers but does not detect the case where the user changed conditions mid-batch (new beans, new grind setting). In that case all 5 ideals have shifted, and committing the median would lock in a half-changed model. The IQR-and-deviation gate (`IQR > 1 s` or `|lag - median| > 1.5 s`) drops the batch entirely in that case, forcing the user to start a fresh batch under stable conditions.
+
+### Why a global bootstrap median instead of just the scale default
+
+A new profile starting from `sensorLag(scaleType) + 0.1 s` will be off until 5 shots populate its history. With `globalSawBootstrapLag`, it starts from "what we have learned about this user's machine on this scale across their other profiles" — a much closer prior. Flow cal uses the same idea (median of espresso per-profile multipliers) and it noticeably reduces the cold-start error.
+
+## User Experience
+
+- **Default ON, automatic** — there is no setting; SAW learning is always on.
+- **Calibration tab** ([qml/pages/settings/SettingsCalibrationTab.qml](../../qml/pages/settings/SettingsCalibrationTab.qml)) shows the current effective lag for the active `(profile, scale)` pair and a source suffix: `(per-profile)`, `(global bootstrap)`, `(global)`, or `(default)`.
+- Two reset actions in the same card:
+  - **Reset this profile** — visible only when the source is `(per-profile)`. Clears just the active pair's history and pending batch.
+  - **Reset all** — clears every SAW key (global pool, all per-pair history + batch, all bootstrap values, hot-water SAW offset).
+- MCP tools: `reset_saw_learning` (existing, now clears the new keys too) and `reset_saw_learning_for_profile` (new, takes optional `profileFilename` and `scaleType` arguments).
+
+## Logging
+
+Two audiences. **System log** (qDebug/qWarning) for live debugging. **Per-shot debug log** ([src/history/shotdebuglogger.cpp](../../src/history/shotdebuglogger.cpp)), which captures qDebug output via Qt's message handler hook so any single shot's debug log is self-contained for accuracy analysis.
+
+System log lines:
+
+| Event | Format |
+|-------|--------|
+| Entry accepted into batch | `[SAW] accumulated drip=… flow=… for <profile>::<scale> (n/5) lag=…` |
+| Batch rejected (dispersion) | `[SAW] batch rejected — high dispersion median_lag=… iqr=… for <pair> — dropping batch` |
+| Batch committed | `[SAW] committed median lag=… (drip=… flow=…) for <pair> — n_medians=k` |
+| Auto-reset | `[SAW] 2nd consecutive overshoot<-6g for <pair> — clearing committed history` |
+| Bootstrap recompute | `[SAW] global bootstrap lag for <scale> updated to … (median of n graduated pairs)` |
+| Reset (per-pair / all) | `[SAW] reset perProfileHistory for <pair>` / `[SAW] reset all SAW learning` |
+
+Per-shot debug log adds two key lines (and the system log lines above are also captured here, since the shot debug logger hooks the global message handler):
+
+- `[SAW] model: source=<…> lag=… profile=<…> scale=<…> historyN=k` — emitted at extraction start when WeightProcessor's snapshot is taken. Records which model is driving the prediction for *this* shot.
+- `[SAW] accuracy: predictedDrip=… actualDrip=… delta=… overshoot=… flow=… scale=… profile=…` — emitted at settling completion. Headline number for "did SAW work for this shot."
+
+Together, opening any saved shot via the Shot Detail page or the `shots_get_debug_log` MCP tool is enough to reconstruct what model the controller used, how accurate it was, and whether this shot fed the model.
+
+## Storage Migration
+
+No explicit migration. The new keys are written lazily as users pull shots; the legacy `saw/learningHistory` continues to be read as the fallback global pool. Existing users do not lose any data and do not need to re-learn — they just gradually accumulate per-pair history alongside the global pool.
+
+A user who hits "Reset all" gets a clean slate (legacy + new keys both wiped) and starts fresh with the new architecture.
+
+## Files
+
+- [src/core/settings.h](../../src/core/settings.h) / [src/core/settings.cpp](../../src/core/settings.cpp) — schema, batch accumulator, read-path fallback chain, bootstrap recompute. The new public API mirrors flow cal: `sawLearnedLagFor`, `getExpectedDripFor`, `sawLearningEntriesFor`, `sawModelSource`, `resetSawLearningForProfile`, `globalSawBootstrapLag`, `addSawLearningPoint(…, profileFilename)`.
+- [src/main.cpp](../../src/main.cpp) — wires `ProfileManager::baseProfileName()` into the WeightProcessor snapshot path and the `sawLearningComplete` handler, and emits the per-shot `model:` / `accuracy:` log lines.
+- [qml/pages/settings/SettingsCalibrationTab.qml](../../qml/pages/settings/SettingsCalibrationTab.qml) — Calibration tab UI changes (source suffix, per-profile reset).
+- [src/mcp/mcptools_control.cpp](../../src/mcp/mcptools_control.cpp) — `reset_saw_learning_for_profile` tool.
+- [tests/tst_saw_settings.cpp](../../tests/tst_saw_settings.cpp) — per-pair isolation, batch commit at N=5, dispersion-rejection, bootstrap recompute, fallback chain, reset behaviour, legacy-path preservation.
+
+## Related
+
+- [AUTO_FLOW_CALIBRATION.md](AUTO_FLOW_CALIBRATION.md) — the architectural template this design copies from.
+- [BLE_PROTOCOL.md](BLE_PROTOCOL.md) — BLE round-trip lag context for `Settings::sensorLag()`.
+- Issue [#847](https://github.com/Kulitorum/Decenza/issues/847) — the bug report this addresses.
+- Issue [#739](https://github.com/Kulitorum/Decenza/issues/739) — auto flow calibration evolution thread; the data and reasoning there directly informed this design.

--- a/qml/pages/settings/SettingsCalibrationTab.qml
+++ b/qml/pages/settings/SettingsCalibrationTab.qml
@@ -164,6 +164,7 @@ Item {
                         }
 
                         RowLayout {
+                            id: sawSourceRow
                             Layout.fillWidth: true
                             property double _modelDep: Settings.sawLearnedLag  // dep tracker for rebind
                             property string _modelSource: { void(_modelDep);
@@ -180,7 +181,7 @@ Item {
 
                             Text {
                                 text: (Settings.scaleType || TranslationManager.translate("settings.options.none", "none"))
-                                      + parent._sourceSuffix
+                                      + sawSourceRow._sourceSuffix
                                       + " · "
                                       + TranslationManager.translate("settings.options.autoLearns", "learns when to stop so your cup hits target weight")
                                 color: Theme.textSecondaryColor
@@ -193,7 +194,7 @@ Item {
 
                             Text {
                                 id: resetThisProfileText
-                                visible: parent._modelSource === "perProfile"
+                                visible: sawSourceRow._modelSource === "perProfile"
                                 text: TranslationManager.translate("settings.options.resetThisProfile", "Reset this profile")
                                 color: Theme.primaryColor
                                 font.pixelSize: Theme.scaled(12)

--- a/qml/pages/settings/SettingsCalibrationTab.qml
+++ b/qml/pages/settings/SettingsCalibrationTab.qml
@@ -146,7 +146,17 @@ Item {
                             Item { Layout.fillWidth: true }
 
                             Text {
-                                text: Settings.sawLearnedLag.toFixed(2) + TranslationManager.translate("common.unit.seconds", "s")
+                                // sawLearnedLagFor() picks per-(profile, scale) data when the
+                                // pair has graduated, otherwise falls back to global bootstrap
+                                // / global pool / scale default. void(Settings.sawLearnedLag)
+                                // makes the binding depend on sawLearnedLagChanged so that
+                                // commits/rejects/resets trigger a re-evaluation.
+                                property string _profile: ProfileManager.baseProfileName
+                                property string _scale: Settings.scaleType
+                                property double _lagDep: Settings.sawLearnedLag
+                                text: { void(_lagDep);
+                                    return Settings.sawLearnedLagFor(_profile, _scale).toFixed(2)
+                                      + TranslationManager.translate("common.unit.seconds", "s"); }
                                 color: Theme.primaryColor
                                 font.pixelSize: Theme.scaled(14)
                                 font.bold: true
@@ -155,26 +165,59 @@ Item {
 
                         RowLayout {
                             Layout.fillWidth: true
+                            property double _modelDep: Settings.sawLearnedLag  // dep tracker for rebind
+                            property string _modelSource: { void(_modelDep);
+                                return Settings.sawModelSource(ProfileManager.baseProfileName, Settings.scaleType); }
+                            property string _sourceSuffix: {
+                                if (_modelSource === "perProfile")
+                                    return " " + TranslationManager.translate("settings.preferences.sawPerProfile", "(per-profile)");
+                                if (_modelSource === "globalBootstrap")
+                                    return " " + TranslationManager.translate("settings.preferences.sawBootstrap", "(global bootstrap)");
+                                if (_modelSource === "globalPool")
+                                    return " " + TranslationManager.translate("settings.preferences.sawGlobal", "(global)");
+                                return " " + TranslationManager.translate("settings.preferences.sawDefault", "(default)");
+                            }
 
                             Text {
-                                text: (Settings.scaleType || TranslationManager.translate("settings.options.none", "none")) + " · " + TranslationManager.translate("settings.options.autoLearns", "learns when to stop so your cup hits target weight")
+                                text: (Settings.scaleType || TranslationManager.translate("settings.options.none", "none"))
+                                      + parent._sourceSuffix
+                                      + " · "
+                                      + TranslationManager.translate("settings.options.autoLearns", "learns when to stop so your cup hits target weight")
                                 color: Theme.textSecondaryColor
                                 font.pixelSize: Theme.scaled(12)
+                                Layout.fillWidth: true
+                                wrapMode: Text.WordWrap
                             }
 
                             Item { Layout.fillWidth: true }
 
                             Text {
-                                id: resetText
-                                text: TranslationManager.translate("settings.options.reset", "Reset")
+                                id: resetThisProfileText
+                                visible: parent._modelSource === "perProfile"
+                                text: TranslationManager.translate("settings.options.resetThisProfile", "Reset this profile")
                                 color: Theme.primaryColor
                                 font.pixelSize: Theme.scaled(12)
                                 Accessible.ignored: true
                                 AccessibleMouseArea {
                                     anchors.fill: parent
                                     anchors.margins: -Theme.scaled(4)
-                                    accessibleName: TranslationManager.translate("settings.calibration.resetWeightStopTiming", "Reset weight stop timing")
-                                    accessibleItem: resetText
+                                    accessibleName: TranslationManager.translate("settings.calibration.resetWeightStopTimingProfile", "Reset weight stop timing for current profile")
+                                    accessibleItem: resetThisProfileText
+                                    onAccessibleClicked: Settings.resetSawLearningForProfile(ProfileManager.baseProfileName, Settings.scaleType)
+                                }
+                            }
+
+                            Text {
+                                id: resetAllText
+                                text: TranslationManager.translate("settings.options.resetAll", "Reset all")
+                                color: Theme.primaryColor
+                                font.pixelSize: Theme.scaled(12)
+                                Accessible.ignored: true
+                                AccessibleMouseArea {
+                                    anchors.fill: parent
+                                    anchors.margins: -Theme.scaled(4)
+                                    accessibleName: TranslationManager.translate("settings.calibration.resetWeightStopTimingAll", "Reset all weight stop timing")
+                                    accessibleItem: resetAllText
                                     onAccessibleClicked: Settings.resetSawLearning()
                                 }
                             }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -4630,7 +4630,7 @@ double Settings::sawLearnedLagFor(const QString& profileFilename, const QString&
         QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
         if (pairHistory.size() >= 3) {
             double sumLag = 0;
-            int count = 0;
+            qsizetype count = 0;
             for (qsizetype i = pairHistory.size() - 1; i >= 0 && count < 5; --i) {
                 QJsonObject obj = pairHistory[i].toObject();
                 double drip = obj.value("drip").toDouble();
@@ -4668,10 +4668,10 @@ double Settings::getExpectedDripFor(const QString& profileFilename,
                 double totalWeight = 0;
                 const double recencyMax = 10.0;
                 const double recencyMin = 3.0;
-                for (int i = 0; i < entries.size(); ++i) {
+                for (qsizetype i = 0; i < entries.size(); ++i) {
                     const Entry& e = entries[i];
                     double recencyWeight = recencyMax - i * (recencyMax - recencyMin)
-                                                       / qMax(1, entries.size() - 1);
+                                                       / qMax(qsizetype{1}, entries.size() - 1);
                     double flowDiff = qAbs(e.flow - currentFlowRate);
                     double flowWeight = qExp(-(flowDiff * flowDiff) / 4.5);
                     double w = recencyWeight * flowWeight;
@@ -4759,7 +4759,7 @@ void Settings::addSawPerPairEntry(double drip, double flowRate, const QString& s
     // 3. Outlier check on the batch as a whole.
     bool dispersionTooHigh = (lagIqr > kBatchMaxIqr);
     if (!dispersionTooHigh) {
-        for (double l : lags) {
+        for (double l : std::as_const(lags)) {
             if (qAbs(l - medianLag) > kBatchMaxDeviation) { dispersionTooHigh = true; break; }
         }
     }
@@ -4772,8 +4772,10 @@ void Settings::addSawPerPairEntry(double drip, double flowRate, const QString& s
     }
 
     // 4. Auto-reset: 2nd consecutive batch with median overshoot < -6g → wipe pair history,
-    //    let the new median be the sole baseline. Mirrors the single-shot auto-reset in the
-    //    legacy path, scoped per (profile, scale).
+    //    let the new median be the sole baseline. The legacy single-shot path triggers on
+    //    2 consecutive bad shots; here, since each median represents 5 shots, the threshold
+    //    is effectively 10 consecutive bad shots — intentional debouncing for the batched
+    //    update model.
     QJsonObject historyMap = loadPerProfileSawHistoryMap();
     QJsonArray pairHistory = historyMap.value(key).toArray();
     if (medianOver < -6.0 && !pairHistory.isEmpty()) {
@@ -4824,13 +4826,19 @@ void Settings::addSawPerPairEntry(double drip, double flowRate, const QString& s
              << "— n_medians=" << pairHistory.size();
 
     // 8. Recompute global bootstrap lag for this scale type so other (profile, scale)
-    //    pairs with no graduated history can use it as their first-shot default.
+    //    pairs with no per-pair history can use it as their first-shot default.
     recomputeGlobalSawBootstrap(scaleType);
 
     emit sawLearnedLagChanged();
 }
 
 void Settings::recomputeGlobalSawBootstrap(const QString& scaleType) {
+    // Bootstrap is a cold-start prior for *new* pairs: a single committed batch median
+    // (5 real shots) is already more informative than the static sensorLag() constant,
+    // so any pair with at least one committed median contributes. The IQR fence below
+    // protects against under-trained outliers if many pairs accumulate. Pairs that have
+    // crossed the per-profile graduation threshold (>= 3 medians) for the read path
+    // are a stricter bar handled in sawLearnedLagFor / sawModelSource.
     QJsonObject map = loadPerProfileSawHistoryMap();
     QVector<double> lags;
     for (auto it = map.begin(); it != map.end(); ++it) {
@@ -4845,7 +4853,7 @@ void Settings::recomputeGlobalSawBootstrap(const QString& scaleType) {
         if (flow > 0.5) lags.append(drip / flow);
     }
     if (lags.size() < 2) {
-        // Need at least 2 graduated pairs to compute a useful bootstrap median.
+        // Need at least 2 contributing pairs to compute a useful bootstrap median.
         return;
     }
     std::sort(lags.begin(), lags.end());
@@ -4858,14 +4866,14 @@ void Settings::recomputeGlobalSawBootstrap(const QString& scaleType) {
         const double lower = q1 - 1.5 * iqr;
         const double upper = q3 + 1.5 * iqr;
         QVector<double> filtered;
-        for (double v : lags) if (v >= lower && v <= upper) filtered.append(v);
+        for (double v : std::as_const(lags)) if (v >= lower && v <= upper) filtered.append(v);
         if (filtered.size() >= 2) lags = filtered;
     }
     const qsizetype n = lags.size();
     const double median = (n % 2 == 0) ? (lags[n / 2 - 1] + lags[n / 2]) / 2.0 : lags[n / 2];
     setGlobalSawBootstrapLag(scaleType, median);
     qDebug() << "[SAW] global bootstrap lag for" << scaleType
-             << "updated to" << median << "(median of" << n << "graduated pairs)";
+             << "updated to" << median << "(median of" << n << "pairs with committed history)";
 }
 
 // ============================================================

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -4365,7 +4365,8 @@ double Settings::sensorLag(const QString& scaleType)
     return 0.38;  // de1app default for unknown/unlisted scales
 }
 
-void Settings::addSawLearningPoint(double drip, double flowRate, const QString& scaleType, double overshoot) {
+void Settings::addSawLearningPoint(double drip, double flowRate, const QString& scaleType,
+                                   double overshoot, const QString& profileFilename) {
     // Validate physical constraints (scale glitches can produce negative values)
     if (drip < 0 || flowRate < 0) {
         qWarning() << "[SAW] Invalid learning point rejected: drip=" << drip << "flow=" << flowRate;
@@ -4398,6 +4399,18 @@ void Settings::addSawLearningPoint(double drip, double flowRate, const QString& 
         }
     }
 
+    // When called with a profile filename, route through the per-(profile, scale) batch
+    // accumulator. The pending batch holds 5 shots before committing the median to the
+    // per-pair history AND the global pool — this reduces churn from individual shots
+    // and provides outlier rejection via the median + IQR check. See AUTO_FLOW_CALIBRATION
+    // for the same pattern applied to flow cal.
+    if (!profileFilename.isEmpty()) {
+        addSawPerPairEntry(drip, flowRate, scaleType, overshoot, profileFilename);
+        return;
+    }
+
+    // Legacy path (profile unknown): append directly to the global pool. Preserves
+    // existing behaviour for callers that have not been updated to pass a profile.
     QByteArray data = m_settings.value("saw/learningHistory").toByteArray();
     QJsonArray arr;
     if (!data.isEmpty()) {
@@ -4463,13 +4476,396 @@ void Settings::addSawLearningPoint(double drip, double flowRate, const QString& 
 
 void Settings::resetSawLearning() {
     m_settings.remove("saw/learningHistory");
+    m_settings.remove("saw/perProfileHistory");
+    m_settings.remove("saw/perProfileBatch");
+    m_settings.remove("saw/globalBootstrapLag");
     m_sawHistoryCacheDirty = true;
     m_sawConvergedCache = -1;
+    m_perProfileSawHistoryCacheValid = false;
+    m_perProfileSawBatchCacheValid = false;
+    qDebug() << "[SAW] reset all SAW learning";
     emit sawLearnedLagChanged();
 
     // Also reset hot water SAW learning
     setHotWaterSawOffset(2.0);  // Back to default
     setHotWaterSawSampleCount(0);
+}
+
+void Settings::resetSawLearningForProfile(const QString& profileFilename, const QString& scaleType) {
+    if (profileFilename.isEmpty()) {
+        qWarning() << "[SAW] resetSawLearningForProfile called with empty profile";
+        return;
+    }
+    const QString key = sawPairKey(profileFilename, scaleType);
+    QJsonObject historyMap = loadPerProfileSawHistoryMap();
+    QJsonObject batchMap = loadPerProfileSawBatchMap();
+    bool changed = false;
+    if (historyMap.contains(key)) {
+        historyMap.remove(key);
+        savePerProfileSawHistoryMap(historyMap);
+        changed = true;
+    }
+    if (batchMap.contains(key)) {
+        batchMap.remove(key);
+        savePerProfileSawBatchMap(batchMap);
+        changed = true;
+    }
+    if (changed) {
+        qDebug() << "[SAW] reset perProfileHistory for" << key;
+        emit sawLearnedLagChanged();
+    }
+}
+
+// ---- per-(profile, scale) helpers ----
+
+QString Settings::sawPairKey(const QString& profileFilename, const QString& scaleType) {
+    return profileFilename + QStringLiteral("::") + scaleType;
+}
+
+QJsonObject Settings::loadPerProfileSawHistoryMap() const {
+    if (m_perProfileSawHistoryCacheValid) return m_perProfileSawHistoryCache;
+    QJsonParseError parseError;
+    QJsonObject map = QJsonDocument::fromJson(
+        m_settings.value("saw/perProfileHistory", "{}").toByteArray(),
+        &parseError).object();
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning() << "[SAW] corrupt perProfileHistory JSON:" << parseError.errorString()
+                   << "- per-profile SAW history lost";
+        const_cast<QSettings&>(m_settings).setValue("saw/perProfileHistory", "{}");
+        map = QJsonObject();
+    }
+    m_perProfileSawHistoryCache = map;
+    m_perProfileSawHistoryCacheValid = true;
+    return m_perProfileSawHistoryCache;
+}
+
+void Settings::savePerProfileSawHistoryMap(const QJsonObject& map) {
+    m_settings.setValue("saw/perProfileHistory",
+                        QJsonDocument(map).toJson(QJsonDocument::Compact));
+    m_perProfileSawHistoryCache = map;
+    m_perProfileSawHistoryCacheValid = true;
+}
+
+QJsonObject Settings::loadPerProfileSawBatchMap() const {
+    if (m_perProfileSawBatchCacheValid) return m_perProfileSawBatchCache;
+    QJsonParseError parseError;
+    QJsonObject map = QJsonDocument::fromJson(
+        m_settings.value("saw/perProfileBatch", "{}").toByteArray(),
+        &parseError).object();
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning() << "[SAW] corrupt perProfileBatch JSON:" << parseError.errorString();
+        const_cast<QSettings&>(m_settings).setValue("saw/perProfileBatch", "{}");
+        map = QJsonObject();
+    }
+    m_perProfileSawBatchCache = map;
+    m_perProfileSawBatchCacheValid = true;
+    return m_perProfileSawBatchCache;
+}
+
+void Settings::savePerProfileSawBatchMap(const QJsonObject& map) {
+    m_settings.setValue("saw/perProfileBatch",
+                        QJsonDocument(map).toJson(QJsonDocument::Compact));
+    m_perProfileSawBatchCache = map;
+    m_perProfileSawBatchCacheValid = true;
+}
+
+QJsonArray Settings::perProfileSawHistory(const QString& profileFilename, const QString& scaleType) const {
+    return loadPerProfileSawHistoryMap().value(sawPairKey(profileFilename, scaleType)).toArray();
+}
+
+QJsonObject Settings::allPerProfileSawHistory() const {
+    return loadPerProfileSawHistoryMap();
+}
+
+QJsonArray Settings::sawPendingBatch(const QString& profileFilename, const QString& scaleType) const {
+    return loadPerProfileSawBatchMap().value(sawPairKey(profileFilename, scaleType)).toArray();
+}
+
+double Settings::globalSawBootstrapLag(const QString& scaleType) const {
+    const QString key = QStringLiteral("saw/globalBootstrapLag/") + scaleType;
+    return m_settings.value(key, 0.0).toDouble();
+}
+
+void Settings::setGlobalSawBootstrapLag(const QString& scaleType, double lag) {
+    const QString key = QStringLiteral("saw/globalBootstrapLag/") + scaleType;
+    m_settings.setValue(key, lag);
+}
+
+// ---- per-(profile, scale) read path ----
+
+QString Settings::sawModelSource(const QString& profileFilename, const QString& scaleType) const {
+    if (!profileFilename.isEmpty()) {
+        QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
+        if (pairHistory.size() >= 3) return QStringLiteral("perProfile");
+    }
+    if (globalSawBootstrapLag(scaleType) > 0.0) return QStringLiteral("globalBootstrap");
+    ensureSawCacheLoaded();
+    for (const auto& v : std::as_const(m_sawHistoryCache)) {
+        if (v.toObject().value("scale").toString() == scaleType) return QStringLiteral("globalPool");
+    }
+    return QStringLiteral("scaleDefault");
+}
+
+QList<QPair<double, double>> Settings::sawLearningEntriesFor(const QString& profileFilename,
+                                                             const QString& scaleType,
+                                                             int maxEntries) const {
+    QList<QPair<double, double>> result;
+    if (!profileFilename.isEmpty()) {
+        QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
+        if (pairHistory.size() >= 3) {
+            for (qsizetype i = pairHistory.size() - 1; i >= 0 && result.size() < maxEntries; --i) {
+                QJsonObject obj = pairHistory[i].toObject();
+                if (obj.contains("drip")) {
+                    result.append({obj["drip"].toDouble(), obj["flow"].toDouble()});
+                }
+            }
+            if (!result.isEmpty()) return result;
+        }
+    }
+    return sawLearningEntries(scaleType, maxEntries);
+}
+
+double Settings::sawLearnedLagFor(const QString& profileFilename, const QString& scaleType) const {
+    if (!profileFilename.isEmpty()) {
+        QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
+        if (pairHistory.size() >= 3) {
+            double sumLag = 0;
+            int count = 0;
+            for (qsizetype i = pairHistory.size() - 1; i >= 0 && count < 5; --i) {
+                QJsonObject obj = pairHistory[i].toObject();
+                double drip = obj.value("drip").toDouble();
+                double flow = obj.value("flow").toDouble();
+                if (flow > 0.5) {
+                    sumLag += drip / flow;
+                    ++count;
+                }
+            }
+            if (count > 0) return sumLag / count;
+        }
+    }
+    double bootstrap = globalSawBootstrapLag(scaleType);
+    if (bootstrap > 0.0) return bootstrap;
+    return sawLearnedLag();
+}
+
+double Settings::getExpectedDripFor(const QString& profileFilename,
+                                    const QString& scaleType,
+                                    double currentFlowRate) const {
+    if (!profileFilename.isEmpty()) {
+        QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
+        if (pairHistory.size() >= 3) {
+            // Weighted average using the same recency + flow-similarity scheme as the
+            // global getExpectedDrip(). Uses up to 12 medians (pair history is capped at
+            // 10, so this just consumes the lot in practice).
+            struct Entry { double drip; double flow; };
+            QVector<Entry> entries;
+            for (qsizetype i = pairHistory.size() - 1; i >= 0 && entries.size() < 12; --i) {
+                QJsonObject obj = pairHistory[i].toObject();
+                if (obj.contains("drip")) entries.append({obj["drip"].toDouble(), obj["flow"].toDouble()});
+            }
+            if (!entries.isEmpty()) {
+                double weightedDripSum = 0;
+                double totalWeight = 0;
+                const double recencyMax = 10.0;
+                const double recencyMin = 3.0;
+                for (int i = 0; i < entries.size(); ++i) {
+                    const Entry& e = entries[i];
+                    double recencyWeight = recencyMax - i * (recencyMax - recencyMin)
+                                                       / qMax(1, entries.size() - 1);
+                    double flowDiff = qAbs(e.flow - currentFlowRate);
+                    double flowWeight = qExp(-(flowDiff * flowDiff) / 4.5);
+                    double w = recencyWeight * flowWeight;
+                    weightedDripSum += e.drip * w;
+                    totalWeight += w;
+                }
+                if (totalWeight >= 0.01) {
+                    double expected = weightedDripSum / totalWeight;
+                    return qBound(0.5, expected, 20.0);
+                }
+            }
+        }
+    }
+    double bootstrap = globalSawBootstrapLag(scaleType);
+    if (bootstrap > 0.0) {
+        return qMin(currentFlowRate * bootstrap, 8.0);
+    }
+    return getExpectedDrip(currentFlowRate);
+}
+
+// ---- per-pair batch accumulator + commit ----
+
+void Settings::addSawPerPairEntry(double drip, double flowRate, const QString& scaleType,
+                                  double overshoot, const QString& profileFilename) {
+    constexpr int kBatchSize = 5;
+    constexpr int kMaxPairHistory = 10;
+    constexpr double kBatchMaxIqr = 1.0;          // seconds — IQR of lags within a batch
+    constexpr double kBatchMaxDeviation = 1.5;    // seconds — single lag from batch median
+
+    const QString key = sawPairKey(profileFilename, scaleType);
+
+    // 1. Append entry to pending batch
+    QJsonObject batchMap = loadPerProfileSawBatchMap();
+    QJsonArray batch = batchMap.value(key).toArray();
+    QJsonObject entry;
+    entry["drip"] = drip;
+    entry["flow"] = flowRate;
+    entry["overshoot"] = overshoot;
+    entry["scale"] = scaleType;
+    entry["profile"] = profileFilename;
+    entry["ts"] = QDateTime::currentSecsSinceEpoch();
+    batch.append(entry);
+
+    if (batch.size() < kBatchSize) {
+        batchMap[key] = batch;
+        savePerProfileSawBatchMap(batchMap);
+        const double lag = (flowRate > 0.5) ? drip / flowRate : 0.0;
+        qDebug() << "[SAW] accumulated drip=" << drip << "flow=" << flowRate
+                 << "for" << key
+                 << "(" << batch.size() << "/" << kBatchSize << ") lag=" << lag;
+        return;
+    }
+
+    // 2. Batch full — compute medians of drip / flow / overshoot, plus IQR of lags.
+    QVector<double> drips, flows, overs, lags;
+    drips.reserve(batch.size()); flows.reserve(batch.size());
+    overs.reserve(batch.size()); lags.reserve(batch.size());
+    for (const auto& v : std::as_const(batch)) {
+        QJsonObject o = v.toObject();
+        drips.append(o["drip"].toDouble());
+        flows.append(o["flow"].toDouble());
+        overs.append(o["overshoot"].toDouble());
+        if (o["flow"].toDouble() > 0.5) lags.append(o["drip"].toDouble() / o["flow"].toDouble());
+    }
+
+    auto medianOf = [](QVector<double> v) -> double {
+        if (v.isEmpty()) return 0.0;
+        std::sort(v.begin(), v.end());
+        const qsizetype n = v.size();
+        return (n % 2 == 0) ? (v[n / 2 - 1] + v[n / 2]) / 2.0 : v[n / 2];
+    };
+    auto iqrOf = [](QVector<double> v) -> double {
+        if (v.size() < 4) return 0.0;
+        std::sort(v.begin(), v.end());
+        const qsizetype n = v.size();
+        return v[3 * n / 4] - v[n / 4];
+    };
+
+    const double medianDrip = medianOf(drips);
+    const double medianFlow = medianOf(flows);
+    const double medianOver = medianOf(overs);
+    const double medianLag = (medianFlow > 0.5) ? medianDrip / medianFlow : 0.0;
+    const double lagIqr = iqrOf(lags);
+
+    // 3. Outlier check on the batch as a whole.
+    bool dispersionTooHigh = (lagIqr > kBatchMaxIqr);
+    if (!dispersionTooHigh) {
+        for (double l : lags) {
+            if (qAbs(l - medianLag) > kBatchMaxDeviation) { dispersionTooHigh = true; break; }
+        }
+    }
+    if (dispersionTooHigh) {
+        qWarning() << "[SAW] batch rejected — high dispersion median_lag=" << medianLag
+                   << "iqr=" << lagIqr << "for" << key << "— dropping batch";
+        batchMap.remove(key);
+        savePerProfileSawBatchMap(batchMap);
+        return;
+    }
+
+    // 4. Auto-reset: 2nd consecutive batch with median overshoot < -6g → wipe pair history,
+    //    let the new median be the sole baseline. Mirrors the single-shot auto-reset in the
+    //    legacy path, scoped per (profile, scale).
+    QJsonObject historyMap = loadPerProfileSawHistoryMap();
+    QJsonArray pairHistory = historyMap.value(key).toArray();
+    if (medianOver < -6.0 && !pairHistory.isEmpty()) {
+        QJsonObject lastMedian = pairHistory.last().toObject();
+        if (lastMedian["overshoot"].toDouble() < -6.0) {
+            qWarning() << "[SAW] 2nd consecutive overshoot<-6g for" << key
+                       << "— clearing committed history";
+            pairHistory = QJsonArray();
+        }
+    }
+
+    // 5. Commit median to per-pair history.
+    QJsonObject medianEntry;
+    medianEntry["drip"] = medianDrip;
+    medianEntry["flow"] = medianFlow;
+    medianEntry["overshoot"] = medianOver;
+    medianEntry["scale"] = scaleType;
+    medianEntry["profile"] = profileFilename;
+    medianEntry["ts"] = QDateTime::currentSecsSinceEpoch();
+    medianEntry["batchSize"] = batch.size();
+    pairHistory.append(medianEntry);
+    while (pairHistory.size() > kMaxPairHistory) pairHistory.removeFirst();
+    historyMap[key] = pairHistory;
+    savePerProfileSawHistoryMap(historyMap);
+
+    // 6. Mirror the median into the global pool so isSawConverged + the legacy
+    //    bootstrap path keep working. Trim to 50 (existing cap).
+    QByteArray data = m_settings.value("saw/learningHistory").toByteArray();
+    QJsonArray pool;
+    if (!data.isEmpty()) {
+        QJsonParseError parseError;
+        QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
+        if (doc.isArray()) pool = doc.array();
+    }
+    pool.append(medianEntry);
+    while (pool.size() > 50) pool.removeFirst();
+    m_settings.setValue("saw/learningHistory", QJsonDocument(pool).toJson());
+    m_sawHistoryCacheDirty = true;
+    m_sawConvergedCache = -1;
+
+    // 7. Clear pending batch.
+    batchMap.remove(key);
+    savePerProfileSawBatchMap(batchMap);
+
+    qDebug() << "[SAW] committed median lag=" << medianLag
+             << "(drip=" << medianDrip << "flow=" << medianFlow << ")"
+             << "for" << key
+             << "— n_medians=" << pairHistory.size();
+
+    // 8. Recompute global bootstrap lag for this scale type so other (profile, scale)
+    //    pairs with no graduated history can use it as their first-shot default.
+    recomputeGlobalSawBootstrap(scaleType);
+
+    emit sawLearnedLagChanged();
+}
+
+void Settings::recomputeGlobalSawBootstrap(const QString& scaleType) {
+    QJsonObject map = loadPerProfileSawHistoryMap();
+    QVector<double> lags;
+    for (auto it = map.begin(); it != map.end(); ++it) {
+        QJsonArray pairHistory = it.value().toArray();
+        if (pairHistory.isEmpty()) continue;
+        // Median entries record their scale; only include this scale's pairs.
+        if (pairHistory.last().toObject().value("scale").toString() != scaleType) continue;
+        // Use the last committed median lag as that pair's representative.
+        QJsonObject last = pairHistory.last().toObject();
+        double drip = last.value("drip").toDouble();
+        double flow = last.value("flow").toDouble();
+        if (flow > 0.5) lags.append(drip / flow);
+    }
+    if (lags.size() < 2) {
+        // Need at least 2 graduated pairs to compute a useful bootstrap median.
+        return;
+    }
+    std::sort(lags.begin(), lags.end());
+    // IQR fence (1.5x IQR from Q1/Q3) — same outlier-removal as flow cal's global median.
+    if (lags.size() >= 4) {
+        const qsizetype n = lags.size();
+        const double q1 = lags[n / 4];
+        const double q3 = lags[3 * n / 4];
+        const double iqr = q3 - q1;
+        const double lower = q1 - 1.5 * iqr;
+        const double upper = q3 + 1.5 * iqr;
+        QVector<double> filtered;
+        for (double v : lags) if (v >= lower && v <= upper) filtered.append(v);
+        if (filtered.size() >= 2) lags = filtered;
+    }
+    const qsizetype n = lags.size();
+    const double median = (n % 2 == 0) ? (lags[n / 2 - 1] + lags[n / 2]) / 2.0 : lags[n / 2];
+    setGlobalSawBootstrapLag(scaleType, median);
+    qDebug() << "[SAW] global bootstrap lag for" << scaleType
+             << "updated to" << median << "(median of" << n << "graduated pairs)";
 }
 
 // ============================================================

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -862,9 +862,10 @@ public:
     // SAW (Stop-at-Weight) learning
     double sawLearnedLag() const;  // Average lag for display in QML (calculated from drip/flow)
     double getExpectedDrip(double currentFlowRate) const;  // Predicts drip based on flow and history
-    // Per-(profile, scale) overload — falls back to per-scale data when the pair has not
-    // yet graduated (< 3 committed batches). Pass empty profile for the legacy global-pool
-    // path. Returns the same numeric units as sawLearnedLag/getExpectedDrip.
+    // Per-(profile, scale) variant of sawLearnedLag — falls back to global bootstrap /
+    // per-scale data when the pair has not yet graduated (< 3 committed batch-medians).
+    // Pass empty profile for the legacy global-pool path. Returns the mean of drip/flow
+    // over the last 5 committed batch-medians (same numeric units as sawLearnedLag).
     Q_INVOKABLE double sawLearnedLagFor(const QString& profileFilename, const QString& scaleType) const;
     double getExpectedDripFor(const QString& profileFilename, const QString& scaleType, double currentFlowRate) const;
     QList<QPair<double, double>> sawLearningEntriesFor(const QString& profileFilename, const QString& scaleType, int maxEntries) const;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -862,8 +862,34 @@ public:
     // SAW (Stop-at-Weight) learning
     double sawLearnedLag() const;  // Average lag for display in QML (calculated from drip/flow)
     double getExpectedDrip(double currentFlowRate) const;  // Predicts drip based on flow and history
-    void addSawLearningPoint(double drip, double flowRate, const QString& scaleType, double overshoot);
+    // Per-(profile, scale) overload — falls back to per-scale data when the pair has not
+    // yet graduated (< 3 committed batches). Pass empty profile for the legacy global-pool
+    // path. Returns the same numeric units as sawLearnedLag/getExpectedDrip.
+    Q_INVOKABLE double sawLearnedLagFor(const QString& profileFilename, const QString& scaleType) const;
+    double getExpectedDripFor(const QString& profileFilename, const QString& scaleType, double currentFlowRate) const;
+    QList<QPair<double, double>> sawLearningEntriesFor(const QString& profileFilename, const QString& scaleType, int maxEntries) const;
+
+    // Reports which model the read path uses for (profile, scale). Strings:
+    // "perProfile" | "globalBootstrap" | "globalPool" | "scaleDefault". Used for logging.
+    Q_INVOKABLE QString sawModelSource(const QString& profileFilename, const QString& scaleType) const;
+
+    void addSawLearningPoint(double drip, double flowRate, const QString& scaleType, double overshoot,
+                             const QString& profileFilename = QString());
     Q_INVOKABLE void resetSawLearning();
+    Q_INVOKABLE void resetSawLearningForProfile(const QString& profileFilename, const QString& scaleType);
+
+    // Per-pair committed history (storage helpers; mostly for tests + bootstrap recompute).
+    // Each entry is a batch median {drip, flow, overshoot, ts}.
+    QJsonArray perProfileSawHistory(const QString& profileFilename, const QString& scaleType) const;
+    QJsonObject allPerProfileSawHistory() const;
+
+    // Per-pair pending batch accumulator (5 entries before committing the batch median).
+    QJsonArray sawPendingBatch(const QString& profileFilename, const QString& scaleType) const;
+
+    // Global bootstrap lag for new (profile, scale) pairs without graduated history.
+    // Returns 0.0 if no bootstrap exists (caller should fall through to global pool).
+    double globalSawBootstrapLag(const QString& scaleType) const;
+    void setGlobalSawBootstrapLag(const QString& scaleType, double lag);
 
     // Per-scale BLE sensor lag (seconds). Used as first-shot SAW default before learning kicks in.
     // Values empirically derived from de1app device_scale.tcl.
@@ -1116,6 +1142,22 @@ private:
     mutable QJsonObject m_perProfileFlowCalCache;  // Cached per-profile flow calibration map
     mutable bool m_perProfileFlowCalCacheValid = false;
     void savePerProfileFlowCalMap(const QJsonObject& map);
+
+    // Per-(profile, scale) SAW history cache. INVARIANT: all writes route through
+    // savePerProfileSawHistoryMap() / savePerProfileSawBatchMap() to keep the cache
+    // and QSettings in sync (mirrors the perProfileFlowCal cache pattern).
+    mutable QJsonObject m_perProfileSawHistoryCache;
+    mutable bool m_perProfileSawHistoryCacheValid = false;
+    mutable QJsonObject m_perProfileSawBatchCache;
+    mutable bool m_perProfileSawBatchCacheValid = false;
+    QJsonObject loadPerProfileSawHistoryMap() const;
+    void savePerProfileSawHistoryMap(const QJsonObject& map);
+    QJsonObject loadPerProfileSawBatchMap() const;
+    void savePerProfileSawBatchMap(const QJsonObject& map);
+    static QString sawPairKey(const QString& profileFilename, const QString& scaleType);
+    void addSawPerPairEntry(double drip, double flowRate, const QString& scaleType,
+                            double overshoot, const QString& profileFilename);
+    void recomputeGlobalSawBootstrap(const QString& scaleType);
     bool m_steamDisabled = false;  // Session-only, not persisted (for descaling)
     double m_temperatureOverride = 0;  // Session-only, for next shot
     bool m_hasTemperatureOverride = false;  // Session-only

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -508,14 +508,24 @@ int main(int argc, char *argv[])
     // WeightProcessor signals (stopNow, skipFrame) wired below.
     // ShotTimingController::stopAtWeightReached and perFrameWeightReached are no longer emitted.
 
-    // Connect SAW learning signal to settings persistence
+    // Connect SAW learning signal to settings persistence.
+    // Logs the predicted-vs-actual drip ("accuracy" line) before persisting, so any single
+    // shot's debug log records whether SAW hit its target. addSawLearningPoint then routes
+    // the entry through the per-(profile, scale) batch accumulator and emits the
+    // "accumulated"/"committed"/"batch rejected" qDebug line that ShotDebugLogger captures.
     QObject::connect(&timingController, &ShotTimingController::sawLearningComplete,
-                     [&settings](double drip, double flowAtStop, double overshoot) {
-                         QString scaleType = settings.scaleType();
-                         settings.addSawLearningPoint(drip, flowAtStop, scaleType, overshoot);
-                         qDebug() << "[SAW] Learning point saved: drip=" << drip
-                                  << "flow=" << flowAtStop << "overshoot=" << overshoot
-                                  << "scale=" << scaleType;
+                     [&settings, &mainController](double drip, double flowAtStop, double overshoot) {
+                         const QString scaleType = settings.scaleType();
+                         const QString profileFilename = mainController.profileManager()->baseProfileName();
+                         const double predictedDrip = settings.getExpectedDripFor(profileFilename, scaleType, flowAtStop);
+                         qDebug() << "[SAW] accuracy: predictedDrip=" << predictedDrip
+                                  << "actualDrip=" << drip
+                                  << "delta=" << (drip - predictedDrip)
+                                  << "overshoot=" << overshoot
+                                  << "flow=" << flowAtStop
+                                  << "scale=" << scaleType
+                                  << "profile=" << profileFilename;
+                         settings.addSawLearningPoint(drip, flowAtStop, scaleType, overshoot, profileFilename);
                      });
 
     // Forward sawSettling state to MainController for QML binding
@@ -619,12 +629,24 @@ int main(int argc, char *argv[])
     // startExtraction() (which resets m_tareComplete=false), causing tare to be lost.
     QObject::connect(&machineState, &MachineState::espressoCycleStarted,
                      [&weightProcessor, &machineState, &settings, &mainController, &timingController]() {
-                         // Build snapshot of learning data and configuration
+                         // Build snapshot of learning data and configuration.
+                         // Per-(profile, scale) lookup falls back to the global pool / scale
+                         // default automatically when the pair has not yet graduated (< 3
+                         // committed batches). The "model:" log line records which source
+                         // is driving this shot's predictions for later accuracy analysis.
                          double targetWeight = machineState.targetWeight();
                          QString scaleType = settings.scaleType();
+                         QString profileFilename = mainController.profileManager()->baseProfileName();
                          bool converged = settings.isSawConverged(scaleType);
                          int maxEntries = converged ? 12 : 8;
-                         const auto entries = settings.sawLearningEntries(scaleType, maxEntries);
+                         const auto entries = settings.sawLearningEntriesFor(profileFilename, scaleType, maxEntries);
+                         const QString modelSource = settings.sawModelSource(profileFilename, scaleType);
+                         const double currentLag = settings.sawLearnedLagFor(profileFilename, scaleType);
+                         qDebug() << "[SAW] model: source=" << modelSource
+                                  << "lag=" << currentLag
+                                  << "profile=" << profileFilename
+                                  << "scale=" << scaleType
+                                  << "historyN=" << entries.size();
                          QVector<double> drips, flows;
                          drips.reserve(entries.size());
                          flows.reserve(entries.size());

--- a/src/mcp/mcptools_control.cpp
+++ b/src/mcp/mcptools_control.cpp
@@ -259,8 +259,9 @@ void registerControlTools(McpToolRegistry* registry, DE1Device* device, MachineS
     // reset_saw_learning
     registry->registerTool(
         "reset_saw_learning",
-        "Reset stop-at-weight learning data. Useful when switching beans or grind settings, "
-        "as the learned flow deceleration curve may not apply to the new setup.",
+        "Reset stop-at-weight learning data. Clears the global pool, all per-(profile, scale) "
+        "histories and pending batches, and the global bootstrap. Useful when switching beans "
+        "or grind settings, as the learned flow deceleration curve may not apply to the new setup.",
         QJsonObject{{"type", "object"}, {"properties", QJsonObject{
             {"confirmed", QJsonObject{{"type", "boolean"}, {"description", "Set to true after user confirms this action in chat"}}}
         }}},
@@ -273,6 +274,42 @@ void registerControlTools(McpToolRegistry* registry, DE1Device* device, MachineS
             settings->resetSawLearning();
             result["success"] = true;
             result["message"] = "SAW learning data reset";
+            return result;
+        },
+        "settings");
+
+    // reset_saw_learning_for_profile
+    registry->registerTool(
+        "reset_saw_learning_for_profile",
+        "Reset stop-at-weight learning for a single (profile, scale) pair only. Other pairs "
+        "and the global bootstrap are preserved. Defaults to the active profile and the "
+        "configured scale type when arguments are omitted.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{
+            {"profileFilename", QJsonObject{{"type", "string"}, {"description", "Profile filename (defaults to active profile)"}}},
+            {"scaleType", QJsonObject{{"type", "string"}, {"description", "Scale type (defaults to configured scaleType)"}}},
+            {"confirmed", QJsonObject{{"type", "boolean"}, {"description", "Set to true after user confirms this action in chat"}}}
+        }}},
+        [settings, profileManager](const QJsonObject& args) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) {
+                result["error"] = "Settings not available";
+                return result;
+            }
+            QString filename = args["profileFilename"].toString();
+            if (filename.isEmpty() && profileManager) {
+                filename = profileManager->baseProfileName();
+            }
+            if (filename.isEmpty()) {
+                result["error"] = "No profile filename specified and no active profile";
+                return result;
+            }
+            QString scale = args["scaleType"].toString();
+            if (scale.isEmpty()) scale = settings->scaleType();
+            settings->resetSawLearningForProfile(filename, scale);
+            result["success"] = true;
+            result["profileFilename"] = filename;
+            result["scaleType"] = scale;
+            result["message"] = QString("SAW learning reset for %1 on %2").arg(filename, scale);
             return result;
         },
         "settings");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,6 +130,12 @@ add_decenza_test(tst_settings
     ${CORE_SOURCES}
 )
 
+# --- tst_saw_settings: per-(profile, scale) SAW learning + batch + bootstrap ---
+add_decenza_test(tst_saw_settings
+    tst_saw_settings.cpp
+    ${CORE_SOURCES}
+)
+
 # --- tst_tclimport: TCL profile import round-trip against de1app profiles ---
 add_decenza_test(tst_tclimport
     tst_tclimport.cpp

--- a/tests/tst_saw_settings.cpp
+++ b/tests/tst_saw_settings.cpp
@@ -1,0 +1,201 @@
+#include <QtTest>
+#include <QSignalSpy>
+#include <QJsonArray>
+#include <QJsonObject>
+
+#include "core/settings.h"
+
+// Tests for per-(profile, scale) SAW learning in Settings.
+// Each test wipes SAW data in init/cleanup so QSettings state from a prior run
+// or another test cannot leak in.
+
+class tst_SawSettings : public QObject {
+    Q_OBJECT
+
+private:
+    Settings m_settings;
+
+    static constexpr const char* kScale = "Decent Scale";
+    static constexpr const char* kProfileA = "profile_a";
+    static constexpr const char* kProfileB = "profile_b";
+    static constexpr const char* kProfileC = "profile_c";
+
+    // Drive a full 5-shot batch with consistent (drip, flow, overshoot).
+    void commitBatch(const QString& profile, double drip, double flow, double overshoot = 0.0) {
+        for (int i = 0; i < 5; ++i)
+            m_settings.addSawLearningPoint(drip, flow, kScale, overshoot, profile);
+    }
+
+private slots:
+
+    void init() {
+        m_settings.resetSawLearning();
+    }
+
+    void cleanup() {
+        m_settings.resetSawLearning();
+    }
+
+    // ===== Per-pair isolation =====
+
+    void perPairIsolatesFromOtherProfile() {
+        // A's batch commits a small drip; B's commits a large drip.
+        // After both have graduated, sawLearnedLagFor(A) and sawLearnedLagFor(B)
+        // should reflect their own batches, not the global average.
+        commitBatch(kProfileA, 0.6, 1.5);   // lag 0.4s
+        commitBatch(kProfileA, 0.6, 1.5);
+        commitBatch(kProfileA, 0.6, 1.5);   // 3 medians → graduated
+        commitBatch(kProfileB, 3.0, 1.5);   // lag 2.0s
+        commitBatch(kProfileB, 3.0, 1.5);
+        commitBatch(kProfileB, 3.0, 1.5);
+
+        const double lagA = m_settings.sawLearnedLagFor(kProfileA, kScale);
+        const double lagB = m_settings.sawLearnedLagFor(kProfileB, kScale);
+        QVERIFY2(lagA < 0.5, qPrintable(QString("A lag %1 not isolated").arg(lagA)));
+        QVERIFY2(lagB > 1.8, qPrintable(QString("B lag %1 not isolated").arg(lagB)));
+    }
+
+    // ===== Batch commit at N=5 =====
+
+    void batchAccumulatesUntilFiveThenCommits() {
+        // Before 5 shots: pending batch grows, no committed history.
+        for (int i = 0; i < 4; ++i) {
+            m_settings.addSawLearningPoint(1.0, 2.0, kScale, 0.0, kProfileA);
+            QCOMPARE(m_settings.sawPendingBatch(kProfileA, kScale).size(), i + 1);
+            QCOMPARE(m_settings.perProfileSawHistory(kProfileA, kScale).size(), 0);
+        }
+
+        // 5th shot triggers commit: pending cleared, history gains one median.
+        m_settings.addSawLearningPoint(1.0, 2.0, kScale, 0.0, kProfileA);
+        QCOMPARE(m_settings.sawPendingBatch(kProfileA, kScale).size(), 0);
+        QCOMPARE(m_settings.perProfileSawHistory(kProfileA, kScale).size(), 1);
+    }
+
+    // ===== Batch rejection on high IQR =====
+
+    void batchRejectedWhenDispersionTooHigh() {
+        // 4 tight entries at lag=0.4s and 1 wild outlier at lag=2.5s. Median lag = 0.4s,
+        // deviation of the outlier = 2.1s > 1.5s threshold → batch rejected and dropped.
+        // All lags remain ≤ 4s so they pass the entry-level lag-too-high guard.
+        m_settings.addSawLearningPoint(0.6, 1.5, kScale, 0.0, kProfileA);   // lag 0.40
+        m_settings.addSawLearningPoint(0.6, 1.5, kScale, 0.0, kProfileA);   // lag 0.40
+        m_settings.addSawLearningPoint(0.6, 1.5, kScale, 0.0, kProfileA);   // lag 0.40
+        m_settings.addSawLearningPoint(0.6, 1.5, kScale, 0.0, kProfileA);   // lag 0.40
+        m_settings.addSawLearningPoint(3.75, 1.5, kScale, 0.0, kProfileA);  // lag 2.50 → reject
+
+        // Batch dropped → pending cleared, no commit, no history.
+        QCOMPARE(m_settings.sawPendingBatch(kProfileA, kScale).size(), 0);
+        QCOMPARE(m_settings.perProfileSawHistory(kProfileA, kScale).size(), 0);
+    }
+
+    // ===== Global bootstrap recompute =====
+
+    void globalBootstrapUpdatedAfterMultiplePairsGraduate() {
+        // Bootstrap requires ≥ 2 graduated pairs on the same scale to update.
+        commitBatch(kProfileA, 0.6, 1.5);  // batches → 1 median
+        QCOMPARE(m_settings.globalSawBootstrapLag(kScale), 0.0); // only 1 pair
+
+        commitBatch(kProfileB, 0.9, 1.5);  // 2nd pair graduates → bootstrap updates
+        const double bootstrap = m_settings.globalSawBootstrapLag(kScale);
+        QVERIFY2(bootstrap > 0.0, "bootstrap not set after 2 graduated pairs");
+        // Median of A's 0.4s and B's 0.6s → 0.5s.
+        QVERIFY2(qAbs(bootstrap - 0.5) < 0.05,
+                 qPrintable(QString("expected ~0.5s, got %1").arg(bootstrap)));
+    }
+
+    // ===== Cold-start fallback chain =====
+
+    void coldStartFallsBackToScaleDefaultThenBootstrapThenPerProfile() {
+        // 1. No data anywhere → "scaleDefault" source.
+        QCOMPARE(m_settings.sawModelSource(kProfileA, kScale), QString("scaleDefault"));
+
+        // 2. Two other pairs graduate → bootstrap exists → C uses "globalBootstrap".
+        commitBatch(kProfileA, 0.6, 1.5);
+        commitBatch(kProfileB, 0.9, 1.5);
+        QCOMPARE(m_settings.sawModelSource(kProfileC, kScale), QString("globalBootstrap"));
+
+        // 3. C graduates → uses its own data.
+        commitBatch(kProfileC, 1.2, 1.5);
+        QCOMPARE(m_settings.sawModelSource(kProfileC, kScale), QString("perProfile"));
+    }
+
+    // ===== Reset for profile only =====
+
+    void resetForProfileLeavesOtherPairsIntact() {
+        commitBatch(kProfileA, 0.6, 1.5);
+        commitBatch(kProfileB, 0.9, 1.5);
+        QVERIFY(m_settings.perProfileSawHistory(kProfileA, kScale).size() > 0);
+        QVERIFY(m_settings.perProfileSawHistory(kProfileB, kScale).size() > 0);
+
+        m_settings.resetSawLearningForProfile(kProfileA, kScale);
+
+        QCOMPARE(m_settings.perProfileSawHistory(kProfileA, kScale).size(), 0);
+        QVERIFY(m_settings.perProfileSawHistory(kProfileB, kScale).size() > 0);
+    }
+
+    // ===== Reset for profile clears pending batch =====
+
+    void resetForProfileClearsPendingBatch() {
+        m_settings.addSawLearningPoint(1.0, 2.0, kScale, 0.0, kProfileA);
+        m_settings.addSawLearningPoint(1.0, 2.0, kScale, 0.0, kProfileA);
+        QCOMPARE(m_settings.sawPendingBatch(kProfileA, kScale).size(), 2);
+
+        m_settings.resetSawLearningForProfile(kProfileA, kScale);
+
+        QCOMPARE(m_settings.sawPendingBatch(kProfileA, kScale).size(), 0);
+    }
+
+    // ===== getExpectedDripFor returns per-pair after graduation =====
+
+    void getExpectedDripForUsesPerPairAfterGraduation() {
+        // Three batches at consistent lag = 0.4s should yield expected drip ≈ flow * 0.4
+        commitBatch(kProfileA, 0.6, 1.5);
+        commitBatch(kProfileA, 0.6, 1.5);
+        commitBatch(kProfileA, 0.6, 1.5);
+
+        const double drip = m_settings.getExpectedDripFor(kProfileA, kScale, 1.5);
+        QVERIFY2(qAbs(drip - 0.6) < 0.15,
+                 qPrintable(QString("expected ~0.6, got %1").arg(drip)));
+    }
+
+    // ===== Legacy call site (no profile) still works =====
+
+    void legacyAddSawLearningPointStillAppendsToGlobalPool() {
+        // Calling without a profile uses the legacy single-shot append. Verify
+        // the global pool grows by 1 and isSawConverged respects scale type.
+        m_settings.addSawLearningPoint(1.0, 2.0, kScale, 0.0);
+        m_settings.addSawLearningPoint(1.0, 2.0, kScale, 0.0);
+        m_settings.addSawLearningPoint(1.0, 2.0, kScale, 0.0);
+        QCOMPARE(m_settings.sawLearningEntries(kScale, 10).size(), 3);
+    }
+
+    // ===== Bootstrap survives a single profile reset =====
+
+    void bootstrapPersistsWhenOneProfileResets() {
+        commitBatch(kProfileA, 0.6, 1.5);
+        commitBatch(kProfileB, 0.9, 1.5);
+        const double before = m_settings.globalSawBootstrapLag(kScale);
+        QVERIFY(before > 0.0);
+
+        m_settings.resetSawLearningForProfile(kProfileA, kScale);
+
+        // Bootstrap is recomputed only on commits, so it stays at the previous
+        // value (still useful as a fallback for new profiles) — verify.
+        QCOMPARE(m_settings.globalSawBootstrapLag(kScale), before);
+    }
+
+    // ===== Full reset clears bootstrap =====
+
+    void fullResetClearsBootstrap() {
+        commitBatch(kProfileA, 0.6, 1.5);
+        commitBatch(kProfileB, 0.9, 1.5);
+        QVERIFY(m_settings.globalSawBootstrapLag(kScale) > 0.0);
+
+        m_settings.resetSawLearning();
+
+        QCOMPARE(m_settings.globalSawBootstrapLag(kScale), 0.0);
+    }
+};
+
+QTEST_GUILESS_MAIN(tst_SawSettings)
+#include "tst_saw_settings.moc"


### PR DESCRIPTION
## Summary

Fixes #847: users alternating between profiles paired with different portafilters (open spout vs. double spout) experience systematic SAW overshoot/undershoot because the global model is pulled toward the dominant profile's drip dynamics.

**Root cause (from real device data, Apr 2026):**

| Shot | Profile | expectedDrip | Actual drip | Result |
|------|---------|-------------|-------------|--------|
| 1047 | D-Flow / Q | 1.24 g | ~0.8 g | **0.4 g over-predicted** |
| 1059 | 80's Espresso | 1.13 g | 1.1 g | accurate |

Shot 1047 is the smoking gun — D-Flow/Q's lag is consistently ~0.8 g but the global model predicts 1.24 g because 80's Espresso (the more frequent profile) dominates the shared history.

## What Changes

- **Per-(profile, scale) history** keyed by `"<profileFilename>::<scaleType>"` — each combo learns its own drip dynamics in isolation
- **Batched median commits (N=5)**: model only updates after 5 shots, same as flow cal (#739). Median is outlier-resistant by construction
- **IQR dispersion gate**: batch dropped if IQR > 1.0 s or any lag deviates > 1.5 s from batch median — catches mid-batch condition changes (new beans, grind)
- **Global bootstrap lag**: IQR-fenced median of graduated pairs on the same scale; new profile/scale combos cold-start from this instead of the static `sensorLag()` constant
- **Fallback chain**: `perProfile` (≥3 medians) → `globalBootstrap` → `globalPool` (legacy) → `scaleDefault`
- **Legacy pool preserved**: every committed batch median is mirrored into `saw/learningHistory` so `isSawConverged()` and pre-update data keep working — no migration needed
- **Per-shot debug log**: two new lines per shot — `[SAW] model: source=… lag=… profile=… scale=… historyN=k` at extraction start and `[SAW] accuracy: predictedDrip=… actualDrip=… delta=…` at settling — so any historic shot retrieved via `shots_get_debug_log` tells the SAW accuracy story end-to-end
- **Calibration tab**: source suffix `(per-profile)` / `(global bootstrap)` / `(global)` / `(default)` + per-profile reset action alongside the existing reset-all
- **MCP tool**: `reset_saw_learning_for_profile` clears one pair's history and pending batch, leaves other pairs intact

## Architecture

This mirrors the auto flow calibration design from #739 exactly: per-profile storage, batched median commits, global bootstrap from the pool of graduated pairs, and a graceful fallback chain. Reusing the same patterns reduces risk — they have a year of production evidence behind them. See `docs/CLAUDE_MD/SAW_LEARNING.md` for full analysis including the empirical data that motivated the design.

## Files

| File | Change |
|------|--------|
| `src/core/settings.h` / `.cpp` | New per-pair API, batch accumulator, IQR check, bootstrap recompute, fallback chain |
| `src/main.cpp` | Profile keyed into WeightProcessor snapshot + `addSawLearningPoint`; new per-shot debug lines |
| `src/mcp/mcptools_control.cpp` | `reset_saw_learning_for_profile` tool |
| `qml/pages/settings/SettingsCalibrationTab.qml` | Source suffix + per-profile reset |
| `tests/tst_saw_settings.cpp` | 9 new unit tests (isolation, batch, IQR, bootstrap, fallback chain, resets) |
| `tests/CMakeLists.txt` | `tst_saw_settings` target |
| `docs/CLAUDE_MD/SAW_LEARNING.md` | Design doc with empirical evidence and rationale |

## Test plan

- [ ] `ctest -R tst_saw_settings` — all 9 cases pass
- [ ] Pull 5 shots on profile A → system log shows `[SAW] accumulated drip=… (n/5)` then `committed median lag=…`
- [ ] Switch to profile B → log shows `globalBootstrap` or `scaleDefault` fallback (not A's lag)
- [ ] Pull 5 shots on B → B graduates with its own lag
- [ ] Switch back to A → A's lag unchanged from before B shots (**this is the issue #847 fix**)
- [ ] Calibration tab shows correct source suffix for active profile
- [ ] "Reset this profile" clears only the active pair; other pairs intact
- [ ] `reset_saw_learning_for_profile` MCP tool works via wscat

🤖 Generated with [Claude Code](https://claude.com/claude-code)