### PR TITLE
chore(skills): add merge-pr skill and document squash-merge as standard

### DIFF
--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: merge-pr
+description: Squash-merge a GitHub PR and delete the branch. Use when the user says "merge", "merge the PR", "squash merge", or otherwise asks to land an open PR. This is the project-standard merge for Decenza.
+---
+
+# merge-pr
+
+Project-standard PR merge for Decenza: **squash + delete branch**. Every merged PR lands as a single commit on `main` with the PR title as the commit subject and the PR description as the body. Feature branches are deleted on both the remote and locally.
+
+## Steps
+
+1. **Resolve the target PR.**
+   - If the user gave a number, use it.
+   - Otherwise, get the PR for the current branch:
+     ```bash
+     gh pr view --repo Kulitorum/Decenza --json number,headRefName,state,isDraft,mergeable,mergeStateStatus
+     ```
+   - If no PR exists for the current branch and no number was given, stop and tell the user.
+
+2. **Pre-flight checks.**
+   - State must be `OPEN`, `isDraft` must be `false`, `mergeable` must be `MERGEABLE`. If any fails, stop and report why.
+   - Check CI: `gh pr checks <num> --repo Kulitorum/Decenza`. If checks are failing, stop and report. If checks are still running, ask the user whether to wait or merge anyway.
+   - If the PR was opened in this session, no extra approval is needed. If the user is asking to merge a PR they did not open in this conversation, confirm first ("Merge PR #N now?").
+
+3. **Merge.**
+   ```bash
+   gh pr merge <num> --repo Kulitorum/Decenza --squash --delete-branch
+   ```
+   Always pass both `--squash` and `--delete-branch`. Never use `--merge` or `--rebase` — Decenza standardizes on squash.
+
+4. **Verify and report.**
+   ```bash
+   gh pr view <num> --repo Kulitorum/Decenza --json state,mergedAt,mergeCommit
+   ```
+   Report the merge commit SHA as a clickable link: `[<short-sha>](https://github.com/Kulitorum/Decenza/commit/<full-sha>)`. Mention any auto-closed issues from the PR description.
+
+5. **Local cleanup (if the user is on the merged branch).**
+   - If the current branch matches the PR's `headRefName`, switch back to `main`, pull, and delete the local branch:
+     ```bash
+     git checkout main && git pull && git branch -D <branch>
+     ```
+   - Otherwise leave the local working copy alone.
+
+## When NOT to use
+
+- PR is a draft, has failing required checks, or has unresolved review threads — surface the blocker, don't merge.
+- PR targets a non-`main` branch (release branch, hotfix branch) — confirm with the user before squashing.
+- User explicitly asked for a different merge strategy (`--merge` for a true merge commit, `--rebase` for rebase) — follow the user's instruction and note that it deviates from project standard.

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ screenshot.png
 # Debug/temp files
 logcat_*.txt
 -.zip
-.claude/
+.claude/*
+!.claude/skills/
 .DS_Store
 /.codex_tmp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -622,6 +622,7 @@ Each operation page (Steam, HotWater, Flush) has:
 
 ## Git Workflow
 
+- **Standard merge: squash + delete branch.** Every PR lands on `main` as a single squashed commit, and the feature branch is deleted on the remote (and locally if you're on it). The `merge-pr` skill (`.claude/skills/merge-pr/SKILL.md`) automates this — invoke it via `/merge-pr` or whenever the user says "merge". Equivalent CLI: `gh pr merge <num> --repo Kulitorum/Decenza --squash --delete-branch`. Do not use `--merge` (true merge commit) or `--rebase` unless the user explicitly asks for them.
 - **Version codes are managed by CI** — local builds use `versioncode.txt` as-is (no auto-increment). All 6 CI workflows bump the code identically on tag push. The Android workflow commits the bumped value back to `main`.
 - You do **not** need to manually commit version code files — only `versioncode.txt` is tracked. `android/AndroidManifest.xml` and `installer/version.iss` are generated from `.in` templates by CMake at build time and are gitignored.
 


### PR DESCRIPTION
## Summary

- Adds [`.claude/skills/merge-pr/SKILL.md`](.claude/skills/merge-pr/SKILL.md) so Claude has a standardized procedure for landing a PR: pre-flight checks (open, not draft, mergeable, CI), then `gh pr merge --squash --delete-branch`, then local cleanup if you're on the merged branch.
- Documents squash + delete-branch as the project-standard merge in [CLAUDE.md](CLAUDE.md) under Git Workflow.
- Loosens `.gitignore` from `.claude/` to `.claude/*` with a negation for `.claude/skills/`, so shared project skills are tracked while `settings.local.json` and personal Claude state stay private.

## Why

When asked to "merge" a PR earlier today, Claude had to invent the merge command from scratch. Capturing the convention as a skill keeps the behavior consistent across sessions and contributors, and the CLAUDE.md bullet means even sessions without the skill loaded follow the same pattern.

## Test plan

- [ ] In a fresh Claude Code session, type `/merge-pr` (or "merge this PR") on an open PR — skill should run pre-flight checks, squash-merge, and delete the branch.
- [ ] Verify `.claude/settings.local.json` is still ignored: `git check-ignore -v .claude/settings.local.json`.
- [ ] Verify `.claude/skills/` is tracked: `git ls-files .claude/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)