### PR TITLE
chore: un-ignore .claude/{agents,commands,hooks} alongside skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,8 @@ logcat_*.txt
 -.zip
 .claude/*
 !.claude/skills/
+!.claude/agents/
+!.claude/commands/
+!.claude/hooks/
 .DS_Store
 /.codex_tmp


### PR DESCRIPTION
## Summary

Follow-up to #850. Broadens the negation list in [.gitignore](.gitignore) so future shared agents, slash commands, and hooks are tracked alongside skills. `.claude/settings.local.json` (personal state) remains ignored.

## Test plan

- [ ] `git check-ignore -v .claude/settings.local.json` — still ignored
- [ ] `git check-ignore -v .claude/agents/x.md .claude/commands/y.md .claude/hooks/z.json` — none ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)