### PR TITLE
Fix ColorEditor binding loop on color property

### DIFF
--- a/qml/components/ColorEditor.qml
+++ b/qml/components/ColorEditor.qml
@@ -5,10 +5,12 @@ import Decenza
 Item {
     id: root
 
-    // The current color being edited
-    property color color: _rgbMode
-        ? Qt.rgba(_r / 255, _g / 255, _b / 255, 1.0)
-        : Qt.hsla(_h / 360, _s / 100, _l / 100, 1.0)
+    // The current color being edited. Updated imperatively (not as a derived
+    // binding) to avoid a binding loop: setColor() writes the internal
+    // representations, and the consumer's onColorChanged handler can route
+    // back through setColor() — Qt's loop detector flags the synchronous
+    // re-evaluation chain even though the cycle is broken by external guards.
+    property color color: "#4682E6"
 
     // RGB components (0-255)
     property real _r: 70
@@ -26,6 +28,12 @@ Item {
     // Guard against feedback loops during setColor
     property bool _updating: false
 
+    function _recomputeColor() {
+        color = _rgbMode
+            ? Qt.rgba(_r / 255, _g / 255, _b / 255, 1.0)
+            : Qt.hsla(_h / 360, _s / 100, _l / 100, 1.0)
+    }
+
     function setColor(c) {
         if (typeof c === 'string') c = Qt.color(c)
         _updating = true
@@ -38,6 +46,7 @@ Item {
         _s = c.hslSaturation * 100
         _l = c.hslLightness * 100
         _updating = false
+        color = c
     }
 
     // Sync the other representation when sliders change
@@ -238,5 +247,6 @@ Item {
             else if (channelIndex === 1) _l = val
             else _s = val
         }
+        _recomputeColor()
     }
 }


### PR DESCRIPTION
Closes #853.

## Summary
- Convert `ColorEditor.color` from a derived binding to a plain property updated imperatively in `setColor()` and `_setChannel()`
- Eliminates ~100 `Binding loop detected for property "color"` warnings per theme-editor interaction

## Root cause
The derived binding `property color color: _rgbMode ? Qt.rgba(...) : Qt.hsla(...)` re-evaluates synchronously each time an internal channel (`_r`/`_g`/`_b`/`_h`/`_s`/`_l`) is written. Inside `setColor()` those writes happen one by one. Each write fires the binding, which fires `colorChanged`, which the consumer (`SettingsThemesTab.onColorChanged`) feeds back through `applyColorChange` → `setEditingPaletteColor` → `customThemeColorsChanged` → `selectColor` → `setColor`. The `_selecting` and `_updating` guards break the recursion functionally — colors apply correctly — but Qt's loop detector still flags the re-evaluation chain.

## Fix
- Drop the derived binding. `color` is now a plain property with a literal default.
- Add `_recomputeColor()` and call it in:
  - `setColor()` — after writing the internals
  - `_setChannel()` — after writing the channel
- The mirror-sync helpers (`_syncFromRgb`/`_syncFromHsl`) intentionally don't recompute `color`; they only keep the alternate representation up to date for slider gradients, while the canonical color was already set by `_setChannel`/`setColor`.

## Test plan
- [ ] Open Settings → Themes, click any color swatch — no `Binding loop detected` warnings in the log
- [ ] Drag RGB sliders — color preview, hex field, and saved palette update live
- [ ] Drag HSL sliders — same
- [ ] Toggle RGB ↔ HLS mode mid-edit — color stays the same, sliders show the right values
- [ ] Hex field paste applies correctly
- [ ] Switch active theme / palette mode — color editor refreshes to the newly selected color

🤖 Generated with [Claude Code](https://claude.com/claude-code)