### PR TITLE
feat(saw): drop per-profile graduation from 3 medians to 2

### DIFF
--- a/docs/CLAUDE_MD/SAW_LEARNING.md
+++ b/docs/CLAUDE_MD/SAW_LEARNING.md
@@ -37,7 +37,7 @@ The same architecture that fixed the analogous problem in flow calibration ([AUT
 2. **Batched median commits** — accumulate 5 shots' worth of pending entries before changing the model. The median is robust to single-shot outliers (channeling, scale glitches, cup interaction). 5 was chosen to match flow cal.
 3. **Batch-level dispersion check** — if the 5 lags within a batch are too spread out (IQR > 1.0 s, or any single lag > 1.5 s from the batch median), the whole batch is dropped. Dispersion that high indicates the user changed conditions mid-batch (different beans, different grinder, manual stop).
 4. **Global bootstrap** — the median lag across all graduated `(profile, scale)` pairs on the same scale is published as `saw/globalBootstrapLag/<scaleType>`. New pairs use this as their first-shot default instead of the scale's hardware-only `sensorLag()`.
-5. **Read-path fallback chain** — `perProfile` (≥ 3 committed batches) → `globalBootstrap` → `globalPool` (legacy entries) → `scaleDefault`. New users / new pairs degrade gracefully.
+5. **Read-path fallback chain** — `perProfile` (≥ `kSawMinMediansForGraduation` committed batches, currently 2 = 10 SAW shots) → `globalBootstrap` → `globalPool` (legacy entries) → `scaleDefault`. New users / new pairs degrade gracefully.
 
 ### Why this is the right shape
 
@@ -56,9 +56,9 @@ Three QSettings keys, each a JSON object keyed by `"<profileFilename>::<scaleTyp
 
 | Key | Shape | Trim | Purpose |
 |-----|-------|------|---------|
-| `saw/perProfileHistory` | array of committed batch-median entries `{drip, flow, overshoot, scale, profile, ts, batchSize}` | 10 medians (~50 shots-worth) | Source of truth for `sawLearnedLagFor` / `getExpectedDripFor` once the pair has graduated (≥ 3 medians). |
+| `saw/perProfileHistory` | array of committed batch-median entries `{drip, flow, overshoot, scale, profile, ts, batchSize}` | 10 medians (~50 shots-worth) | Source of truth for `sawLearnedLagFor` / `getExpectedDripFor` once the pair has graduated (≥ `kSawMinMediansForGraduation` medians, currently 2). |
 | `saw/perProfileBatch` | array of pending raw entries `{drip, flow, overshoot, scale, profile, ts}` (target size 5) | 5 (commit point) | Pending accumulator; flushed on commit or rejection. |
-| `saw/globalBootstrapLag/<scaleType>` | scalar `double` (seconds) | n/a | IQR-fenced median of last committed median lag from each pair on this scale with at least one committed batch-median. Used as first-shot default for new pairs. (Graduation for the per-profile *read* path is a stricter ≥ 3 medians; the bootstrap is a cold-start prior, so it accepts pairs with any committed history — IQR fencing handles the rest.) |
+| `saw/globalBootstrapLag/<scaleType>` | scalar `double` (seconds) | n/a | IQR-fenced median of last committed median lag from each pair on this scale with at least one committed batch-median. Used as first-shot default for new pairs. (Graduation for the per-profile *read* path is a stricter `kSawMinMediansForGraduation` medians; the bootstrap is a cold-start prior, so it accepts pairs with any committed history — IQR fencing handles the rest.) |
 
 The legacy `saw/learningHistory` key is preserved as a **global pool**: every committed batch-median is mirrored into it (trim 50). This keeps `isSawConverged()` and the legacy convergence-divergence detection working without changes, and provides a final read-path fallback for users with pre-update data.
 
@@ -70,7 +70,7 @@ The per-entry shape gains one optional field, `profile`. Old entries without it 
 
 ```
 sawLearnedLagFor(profile, scale):
-  if perProfileSawHistory(profile, scale).size ≥ 3:
+  if perProfileSawHistory(profile, scale).size ≥ kSawMinMediansForGraduation:
     return mean(drip / flow over last 5 medians)        ← perProfile
   if globalSawBootstrapLag(scale) > 0:
     return globalSawBootstrapLag(scale)                 ← globalBootstrap

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -683,7 +683,7 @@ void Settings::clearFlowCalPendingIdeals(const QString& profileFilename) {
 // legacy single-shot global pool it replaces. Trade-off: smaller = faster to
 // adapt to per-profile drip dynamics; larger = more stability against early
 // regime bias. See docs/CLAUDE_MD/SAW_LEARNING.md.
-static constexpr int kSawMinMediansForGraduation = 2;
+static constexpr qsizetype kSawMinMediansForGraduation = 2;
 
 // Returns average lag for display in QML settings (calculated from stored drip/flow)
 double Settings::sawLearnedLag() const {
@@ -1327,9 +1327,10 @@ void Settings::addSawPerPairEntry(double drip, double flowRate, const QString& s
 
     // 4. Auto-reset: 2nd consecutive batch with median overshoot < -6g → wipe pair history,
     //    let the new median be the sole baseline. The legacy single-shot path triggers on
-    //    2 consecutive bad shots; here, since each median represents 5 shots, the threshold
-    //    is effectively 10 consecutive bad shots — intentional debouncing for the batched
-    //    update model.
+    //    2 consecutive bad shots; here, since each median represents 5 shots, the
+    //    auto-reset trigger is effectively 10 consecutive bad shots — intentional
+    //    debouncing for the batched update model. (Distinct from the graduation
+    //    threshold defined at the top of this section.)
     QJsonObject historyMap = loadPerProfileSawHistoryMap();
     QJsonArray pairHistory = historyMap.value(key).toArray();
     if (medianOver < -6.0 && !pairHistory.isEmpty()) {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -676,6 +676,15 @@ void Settings::clearFlowCalPendingIdeals(const QString& profileFilename) {
 
 // SAW (Stop-at-Weight) learning
 
+// Minimum committed batch-medians before a (profile, scale) pair graduates from
+// the global fallbacks (globalBootstrap / globalPool / scaleDefault) to its own
+// per-pair model. Each median represents 5 SAW shots that survived the IQR
+// dispersion gate, so 2 medians = 10 shots — already a stronger signal than the
+// legacy single-shot global pool it replaces. Trade-off: smaller = faster to
+// adapt to per-profile drip dynamics; larger = more stability against early
+// regime bias. See docs/CLAUDE_MD/SAW_LEARNING.md.
+static constexpr int kSawMinMediansForGraduation = 2;
+
 // Returns average lag for display in QML settings (calculated from stored drip/flow)
 double Settings::sawLearnedLag() const {
     ensureSawCacheLoaded();
@@ -1134,7 +1143,7 @@ void Settings::setGlobalSawBootstrapLag(const QString& scaleType, double lag) {
 QString Settings::sawModelSource(const QString& profileFilename, const QString& scaleType) const {
     if (!profileFilename.isEmpty()) {
         QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
-        if (pairHistory.size() >= 3) return QStringLiteral("perProfile");
+        if (pairHistory.size() >= kSawMinMediansForGraduation) return QStringLiteral("perProfile");
     }
     if (globalSawBootstrapLag(scaleType) > 0.0) return QStringLiteral("globalBootstrap");
     ensureSawCacheLoaded();
@@ -1150,7 +1159,7 @@ QList<QPair<double, double>> Settings::sawLearningEntriesFor(const QString& prof
     QList<QPair<double, double>> result;
     if (!profileFilename.isEmpty()) {
         QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
-        if (pairHistory.size() >= 3) {
+        if (pairHistory.size() >= kSawMinMediansForGraduation) {
             for (qsizetype i = pairHistory.size() - 1; i >= 0 && result.size() < maxEntries; --i) {
                 QJsonObject obj = pairHistory[i].toObject();
                 if (obj.contains("drip")) {
@@ -1166,7 +1175,7 @@ QList<QPair<double, double>> Settings::sawLearningEntriesFor(const QString& prof
 double Settings::sawLearnedLagFor(const QString& profileFilename, const QString& scaleType) const {
     if (!profileFilename.isEmpty()) {
         QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
-        if (pairHistory.size() >= 3) {
+        if (pairHistory.size() >= kSawMinMediansForGraduation) {
             double sumLag = 0;
             qsizetype count = 0;
             for (qsizetype i = pairHistory.size() - 1; i >= 0 && count < 5; --i) {
@@ -1191,7 +1200,7 @@ double Settings::getExpectedDripFor(const QString& profileFilename,
                                     double currentFlowRate) const {
     if (!profileFilename.isEmpty()) {
         QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
-        if (pairHistory.size() >= 3) {
+        if (pairHistory.size() >= kSawMinMediansForGraduation) {
             // Weighted average using the same recency + flow-similarity scheme as the
             // global getExpectedDrip(). Uses up to 12 medians (pair history is capped at
             // 10, so this just consumes the lot in practice).
@@ -1382,8 +1391,9 @@ void Settings::recomputeGlobalSawBootstrap(const QString& scaleType) {
     // (5 real shots) is already more informative than the static sensorLag() constant,
     // so any pair with at least one committed median contributes. The IQR fence below
     // protects against under-trained outliers if many pairs accumulate. Pairs that have
-    // crossed the per-profile graduation threshold (>= 3 medians) for the read path
-    // are a stricter bar handled in sawLearnedLagFor / sawModelSource.
+    // crossed the per-profile graduation threshold (kSawMinMediansForGraduation
+    // medians) for the read path are a stricter bar handled in sawLearnedLagFor /
+    // sawModelSource.
     QJsonObject map = loadPerProfileSawHistoryMap();
     QVector<double> lags;
     for (auto it = map.begin(); it != map.end(); ++it) {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -182,7 +182,8 @@ public:
     double sawLearnedLag() const;  // Average lag for display in QML (calculated from drip/flow)
     double getExpectedDrip(double currentFlowRate) const;  // Predicts drip based on flow and history
     // Per-(profile, scale) variant of sawLearnedLag — falls back to global bootstrap /
-    // per-scale data when the pair has not yet graduated (< 3 committed batch-medians).
+    // per-scale data when the pair has not yet graduated (fewer than
+    // kSawMinMediansForGraduation committed batch-medians; see settings.cpp).
     // Pass empty profile for the legacy global-pool path. Returns the mean of drip/flow
     // over the last 5 committed batch-medians (same numeric units as sawLearnedLag).
     Q_INVOKABLE double sawLearnedLagFor(const QString& profileFilename, const QString& scaleType) const;

--- a/tests/tst_saw_settings.cpp
+++ b/tests/tst_saw_settings.cpp
@@ -40,13 +40,11 @@ private slots:
 
     void perPairIsolatesFromOtherProfile() {
         // A's batch commits a small drip; B's commits a large drip.
-        // After both have graduated, sawLearnedLagFor(A) and sawLearnedLagFor(B)
-        // should reflect their own batches, not the global average.
+        // After both have graduated (2 committed medians each), sawLearnedLagFor(A)
+        // and sawLearnedLagFor(B) should reflect their own batches, not the global average.
         commitBatch(kProfileA, 0.6, 1.5);   // lag 0.4s
-        commitBatch(kProfileA, 0.6, 1.5);
-        commitBatch(kProfileA, 0.6, 1.5);   // 3 medians → graduated
+        commitBatch(kProfileA, 0.6, 1.5);   // 2 medians → graduated
         commitBatch(kProfileB, 3.0, 1.5);   // lag 2.0s
-        commitBatch(kProfileB, 3.0, 1.5);
         commitBatch(kProfileB, 3.0, 1.5);
 
         const double lagA = m_settings.sawLearnedLagFor(kProfileA, kScale);
@@ -116,11 +114,26 @@ private slots:
         commitBatch(kProfileB, 0.9, 1.5);
         QCOMPARE(m_settings.sawModelSource(kProfileC, kScale), QString("globalBootstrap"));
 
-        // 3. C graduates (needs ≥ 3 committed medians) → uses its own data.
-        commitBatch(kProfileC, 1.2, 1.5);
+        // 3. C graduates (needs ≥ kSawMinMediansForGraduation committed medians,
+        //    currently 2) → uses its own data.
         commitBatch(kProfileC, 1.2, 1.5);
         commitBatch(kProfileC, 1.2, 1.5);
         QCOMPARE(m_settings.sawModelSource(kProfileC, kScale), QString("perProfile"));
+    }
+
+    // ===== One median is not enough to graduate =====
+
+    void singleMedianStillFallsBackToBootstrap() {
+        // After one committed median on C, the read path must still treat C as a
+        // cold-start pair and fall back to globalBootstrap (set up by A and B below).
+        // This guards the lower-bound boundary of the graduation gate.
+        commitBatch(kProfileA, 0.6, 1.5);
+        commitBatch(kProfileB, 0.9, 1.5);
+        QVERIFY(m_settings.globalSawBootstrapLag(kScale) > 0.0);
+
+        commitBatch(kProfileC, 1.2, 1.5);  // 1 median — below graduation threshold
+        QCOMPARE(m_settings.perProfileSawHistory(kProfileC, kScale).size(), 1);
+        QCOMPARE(m_settings.sawModelSource(kProfileC, kScale), QString("globalBootstrap"));
     }
 
     // ===== Reset for profile only =====
@@ -152,8 +165,7 @@ private slots:
     // ===== getExpectedDripFor returns per-pair after graduation =====
 
     void getExpectedDripForUsesPerPairAfterGraduation() {
-        // Three batches at consistent lag = 0.4s should yield expected drip ≈ flow * 0.4
-        commitBatch(kProfileA, 0.6, 1.5);
+        // Two batches at consistent lag = 0.4s should yield expected drip ≈ flow * 0.4
         commitBatch(kProfileA, 0.6, 1.5);
         commitBatch(kProfileA, 0.6, 1.5);
 


### PR DESCRIPTION
## Summary

Follow-up to #848. A (profile, scale) pair previously needed 3 committed batch-medians (15 SAW shots) before its own data took over from the global fallbacks. For users pulling 1–2 SAW shots/day on a given combo, that's 1–3 weeks per pair — exactly the slow-ramp pain that #847 was trying to address.

This drops the read-path graduation threshold to 2 batch-medians (10 SAW shots).

## Why 2 is enough

Each committed median already represents:
- 5 SAW shots that **survived the IQR dispersion gate** (IQR ≤ 1.0 s on lags, no single lag deviating > 1.5 s from the batch median).
- A median of 5, which is robust against single-shot outliers by construction.

Two such medians = 10 shots through that filter. That is a substantially stronger signal than the single-shot legacy \`globalPool\` entries we'd otherwise fall back to during the gap.

The auto-reset path (2 consecutive medians with overshoot < -6 g, \`settings.cpp:1326\`) is unchanged and still catches regime changes after graduation.

## Risk

Worst case is a "honeymoon" where the user's first 10 shots on a new bean land at similar-but-biased lag, the pair graduates, then real-world shots drift. In practice the recency-weighted average in \`getExpectedDripFor\` (line 1207) means each new median pushes the model — post-graduation it self-corrects within a few committed batches.

## Changes

| File | Change |
|------|--------|
| \`src/core/settings.cpp\` | Lift the magic \`3\` into \`kSawMinMediansForGraduation = 2\` with a doc comment; update the 4 read-path sites and the \`recomputeGlobalSawBootstrap\` comment |
| \`src/core/settings.h\` | Update the \`sawLearnedLagFor\` comment to reference the named constant |
| \`tests/tst_saw_settings.cpp\` | Existing tests drop from 3 batches to 2; add \`singleMedianStillFallsBackToBootstrap\` to guard the lower-bound boundary |
| \`docs/CLAUDE_MD/SAW_LEARNING.md\` | Reword graduation references to use the named constant |

## Test plan

- [x] \`ctest -R tst_saw_settings\` — all 10 cases pass (9 existing + 1 new)
- [x] \`ctest -R tst_saw\` — legacy SAW tests still pass
- [ ] Pull 10 SAW shots on a new (profile, scale) combo → log shows \`[SAW] model: source="perProfile"\` after the 2nd batch commits
- [ ] Existing pairs that had 1 or 2 committed medians under the old code immediately become \`perProfile\` after upgrade (data shape unchanged — same per-pair history is just read past a lower gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)