### PR TITLE
ci(android): use Ninja generator instead of Make

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -57,7 +57,7 @@ jobs:
           java-version: '17'
 
       - name: Install minimal host dependencies
-        run: sudo apt-get install -y --no-install-recommends libegl1 libgl1
+        run: sudo apt-get install -y --no-install-recommends libegl1 libgl1 ninja-build
 
       - name: Install Qt for Android
         uses: jurplel/install-qt-action@v4
@@ -152,7 +152,7 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          $QT_ROOT_DIR/bin/qt-cmake .. \
+          $QT_ROOT_DIR/bin/qt-cmake .. -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 


### PR DESCRIPTION
## Summary
- The Android release workflow was calling `qt-cmake` without a `-G` flag, so it defaulted to **Unix Makefiles**. Linux x64, Linux ARM64, and Windows already use Ninja; this brings Android in line.
- Adds `ninja-build` to the apt install and passes `-G Ninja` to qt-cmake.
- macOS and iOS intentionally stay on `-G Xcode` (needed for the Archive / codesigning flow).

## Test plan
- [ ] Push a `v*` tag (or run the workflow via `workflow_dispatch`) and confirm the Android APK build succeeds with Ninja.
- [ ] Compare build duration against the previous Makefiles-based run ([24935872515](https://github.com/Kulitorum/Decenza/actions/runs/24935872515)) to confirm the expected speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)