### PR TITLE
fix(ios): correct SafariViewHelper include path in settings_network

### DIFF
--- a/src/core/settings_network.cpp
+++ b/src/core/settings_network.cpp
@@ -7,7 +7,7 @@
 
 #ifdef Q_OS_IOS
 #include "../screensaver/iosbrightness.h"
-#include "../SafariViewHelper.h"
+#include "SafariViewHelper.h"
 #endif
 
 SettingsNetwork::SettingsNetwork(QObject* parent)


### PR DESCRIPTION
## Summary
- v1.7.2 iOS Archive failed with `'../SafariViewHelper.h' file not found` (run [24959991223](https://github.com/Kulitorum/Decenza/actions/runs/24959991223)).
- `SafariViewHelper.h` lives in `ios/`, which `CMakeLists.txt:609` adds to the iOS include path. `src/core/settings.cpp:31` already includes it correctly as `"SafariViewHelper.h"`. The stray `../` in `settings_network.cpp` was introduced in #855 (Settings split Tier 2) and resolves to the non-existent `src/SafariViewHelper.h`.
- Not caught in #855's review because iOS CI only runs on tag push, not on PRs (per `project_ci_pr_policy`).

## Test plan
- [ ] After merge, push a new tag (or trigger `ios-release.yml` via `workflow_dispatch`) and confirm the iOS Archive succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)