### PR TITLE
fix(analysis): kill lever-style false positives in channeling and grind detectors

### DIFF
--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -335,13 +335,29 @@ ShotAnalysis::GrindCheck ShotAnalysis::analyzeFlowVsGoal(
     // safety limiter (80's Espresso rise+decline, Cremina lever, Londinium
     // pour, etc.) — comparing actual flow against that ceiling is the
     // canonical false-positive source.
+    //
+    // Two boundary trims (see GRIND_*_SKIP_SEC in shotanalysis.h) apply
+    // within each flow-mode range so we don't average pump-ramp lag or the
+    // post-limiter-engaged tail. Without them the lever preinfusion shape
+    // (pump-ramp at start + pressure ceiling activates at end) reads as a
+    // sustained "too fine" delta even on clean shots.
     struct Range { double start; double end; };
     QVector<Range> flowModeRanges;
     if (!phases.isEmpty()) {
+        bool firstFlowModeSeen = false;
         for (qsizetype i = 0; i < phases.size(); ++i) {
             if (!phases[i].isFlowMode) continue;
-            const double start = phases[i].time;
-            const double end = (i + 1 < phases.size()) ? phases[i + 1].time : pourEnd;
+            double start = phases[i].time;
+            double end = (i + 1 < phases.size()) ? phases[i + 1].time : pourEnd;
+            if (!firstFlowModeSeen) {
+                start += GRIND_PUMP_RAMP_SKIP_SEC;
+                firstFlowModeSeen = true;
+            }
+            if (i + 1 < phases.size()
+                && phases[i + 1].transitionReason.compare(
+                       QStringLiteral("pressure"), Qt::CaseInsensitive) == 0) {
+                end -= GRIND_LIMITER_TAIL_SKIP_SEC;
+            }
             if (end > start) flowModeRanges.append({start, end});
         }
     }

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -83,11 +83,18 @@ ShotAnalysis::ChannelingSeverity ShotAnalysis::detectChannelingFromDerivative(
         return false;
     };
 
+    // Channeling is a positive-dC/dt signature: a channel forms, flow surges
+    // and pressure dips, conductance (flow/pressure) jumps up. Negative dC/dt
+    // is the opposite — flow falling relative to pressure — which is the
+    // normal dynamic on lever pressure-rise frames (pressure climbs faster
+    // than flow follows) and on pressure-decline frames as the puck thins.
+    // Treating |dC/dt| as channeling false-flags every lever pour, so we
+    // count only signed positive excursions here.
     for (const auto& pt : conductanceDerivative) {
         if (pt.x() < analysisStart) continue;
         if (pt.x() > analysisEnd) break;
         if (!inAnyWindow(pt.x())) continue;
-        const double v = std::abs(pt.y());
+        const double v = pt.y();
         if (v > maxSpike) {
             maxSpike = v;
             maxSpikeTime = pt.x();

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -344,14 +344,22 @@ ShotAnalysis::GrindCheck ShotAnalysis::analyzeFlowVsGoal(
     struct Range { double start; double end; };
     QVector<Range> flowModeRanges;
     if (!phases.isEmpty()) {
-        bool firstFlowModeSeen = false;
+        // Pump-ramp trim applies to the first flow-mode phase that
+        // coincides with pourStart — that's the one where the pump goes
+        // from idle to commanded flow. A flow-mode phase that starts
+        // before pourStart (e.g. a fill phase) has its samples filtered
+        // out by the pour-window gate below anyway; consuming the
+        // "first seen" flag on it would silently skip the trim where it
+        // actually belongs. The 0.1 s margin absorbs BLE timestamp jitter.
+        bool firstFlowModeAtPourStartSeen = false;
         for (qsizetype i = 0; i < phases.size(); ++i) {
             if (!phases[i].isFlowMode) continue;
             double start = phases[i].time;
             double end = (i + 1 < phases.size()) ? phases[i + 1].time : pourEnd;
-            if (!firstFlowModeSeen) {
+            if (!firstFlowModeAtPourStartSeen
+                && phases[i].time + 0.1 >= pourStart) {
                 start += GRIND_PUMP_RAMP_SKIP_SEC;
-                firstFlowModeSeen = true;
+                firstFlowModeAtPourStartSeen = true;
             }
             if (i + 1 < phases.size()
                 && phases[i + 1].transitionReason.compare(

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -148,6 +148,18 @@ public:
     static constexpr double FLOW_GOAL_MIN_AVG = 0.3;    // ml/s — ignore goal periods with very low target (preinfusion)
     static constexpr double FLOW_DEVIATION_THRESHOLD = 0.4;  // ml/s avg deviation to flag grind issue
 
+    // Trim two boundary windows where flow naturally diverges from goal even
+    // on well-extracted shots, otherwise the grind detector false-flags every
+    // lever-style preinfusion (80's Espresso et al.):
+    //   - The first 0.5 s of the first flow-mode phase: pump ramp-up from
+    //     idle, mechanical lag rather than a grind signal.
+    //   - The last 1.5 s before any flow-mode phase that exits via the
+    //     "pressure" transition: once the firmware's pressure ceiling
+    //     engages, the controller stops tracking flow goal and switches to
+    //     limiting pressure, so the trailing flow undershoot is by design.
+    static constexpr double GRIND_PUMP_RAMP_SKIP_SEC = 0.5;
+    static constexpr double GRIND_LIMITER_TAIL_SKIP_SEC = 1.5;
+
     // Result of the flow-vs-goal grind direction check.
     struct GrindCheck {
         double delta = 0.0;          // (avg actual flow) - (avg goal flow). Positive = coarse, negative = fine.

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -150,10 +150,10 @@ public:
 
     // Trim two boundary windows where flow naturally diverges from goal even
     // on well-extracted shots, otherwise the grind detector false-flags every
-    // lever-style preinfusion (80's Espresso et al.):
-    //   - The first 0.5 s of the first flow-mode phase: pump ramp-up from
+    // lever-style preinfusion:
+    //   - Leading window of the first flow-mode phase: pump ramp-up from
     //     idle, mechanical lag rather than a grind signal.
-    //   - The last 1.5 s before any flow-mode phase that exits via the
+    //   - Trailing window of any flow-mode phase that exits via the
     //     "pressure" transition: once the firmware's pressure ceiling
     //     engages, the controller stops tracking flow goal and switches to
     //     limiting pressure, so the trailing flow undershoot is by design.

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -8,13 +8,15 @@ class tst_ShotAnalysis : public QObject {
 
 private:
     static HistoryPhaseMarker phase(double time, const QString& label, int frameNumber,
-                                     bool isFlowMode = false)
+                                     bool isFlowMode = false,
+                                     const QString& transitionReason = QString())
     {
         HistoryPhaseMarker marker;
         marker.time = time;
         marker.label = label;
         marker.frameNumber = frameNumber;
         marker.isFlowMode = isFlowMode;
+        marker.transitionReason = transitionReason;
         return marker;
     }
 
@@ -362,6 +364,47 @@ private slots:
 
         QCOMPARE(ShotAnalysis::detectGrindIssue(flow, flowGoal, phases,
                                                  10.0, 30.0, "", {"grind_check_skip"}),
+                 false);
+    }
+
+    // 80's Espresso style: preinfusion is flow-mode 7.5 ml/s with a pressure
+    // ceiling that exits the frame on "pressure" transition once the puck
+    // builds. The trailing samples (pressure limiter engaged → controller
+    // stops tracking flow goal) and the pump-ramp at the very start must be
+    // excluded so the averaged flow matches the actual tracking window.
+    void flowVsGoal_flowModeExitingOnPressure_trimsLimiterTailAndPumpRamp()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "Preinfusion", 0, /*isFlowMode=*/true),
+            phase(7.0, "Rise", 1, /*isFlowMode=*/false, /*tr=*/"pressure"),
+            phase(11.0, "End", -1, /*isFlowMode=*/false),
+        };
+
+        // Synthesize the lever preinfusion shape. Without the boundary trims
+        // the average pulls under goal by ~0.6 ml/s and FIRES grind issue.
+        // With both trims (skip 0-0.5 s ramp, skip 5.5-7 s limiter tail),
+        // the steady tracking window from 0.5-5.5 s reads ~7.5 ml/s and
+        // the check passes.
+        QVector<QPointF> flow;
+        QVector<QPointF> flowGoal;
+        for (double t = 0.0; t <= 11.0; t += 0.1) {
+            double f;
+            if (t < 0.5)        f = 4.0 + (7.5 - 4.0) * (t / 0.5);  // pump ramp 4 → 7.5
+            else if (t < 5.5)   f = 7.5;                             // steady tracking
+            else if (t < 7.0)   f = 6.0;                             // pressure limiter engaging
+            else                f = 4.5;                             // pressure-mode pour (excluded by isFlowMode)
+            flow.append(QPointF(t, f));
+            flowGoal.append(QPointF(t, 7.5));
+        }
+
+        const auto r = ShotAnalysis::analyzeFlowVsGoal(
+            flow, flowGoal, phases, /*pourStart=*/0.0, /*pourEnd=*/11.0);
+        QVERIFY(r.hasData);
+        QVERIFY2(std::abs(r.delta) < ShotAnalysis::FLOW_DEVIATION_THRESHOLD,
+                 qPrintable(QString("expected |delta| < %1, got %2")
+                                .arg(ShotAnalysis::FLOW_DEVIATION_THRESHOLD)
+                                .arg(r.delta)));
+        QCOMPARE(ShotAnalysis::detectGrindIssue(flow, flowGoal, phases, 0.0, 11.0),
                  false);
     }
 

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -408,6 +408,48 @@ private slots:
                  false);
     }
 
+    // The limiter-tail trim is gated on transitionReason == "pressure".
+    // Same flow shape as the lever test but with the next phase exiting on
+    // "time" — the trailing undershoot must remain in the average and the
+    // badge must still fire. Without this gate, a copy-paste regression
+    // that applied the trim unconditionally would silently suppress real
+    // grind signals on D-Flow / A-Flow profiles whose pour phases exit on
+    // time.
+    void flowVsGoal_flowModeExitingOnTime_keepsTrailingWindow_andFires()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "Preinfusion", 0, /*isFlowMode=*/true),
+            phase(7.0, "Rise", 1, /*isFlowMode=*/false, /*tr=*/"time"),
+            phase(11.0, "End", -1, /*isFlowMode=*/false),
+        };
+
+        // Pump ramp 0-0.5 s, steady tracking 0.5-5.5 s, sustained dip
+        // 5.5-7.0 s. Under "pressure" exit the dip is trimmed and the
+        // average is clean; under "time" exit the dip stays in and pulls
+        // the average ~0.9 ml/s under goal.
+        QVector<QPointF> flow;
+        QVector<QPointF> flowGoal;
+        for (double t = 0.0; t <= 11.0; t += 0.1) {
+            double f;
+            if (t < 0.5)        f = 4.0 + (7.5 - 4.0) * (t / 0.5);
+            else if (t < 5.5)   f = 7.5;
+            else if (t < 7.0)   f = 3.5;
+            else                f = 4.5;
+            flow.append(QPointF(t, f));
+            flowGoal.append(QPointF(t, 7.5));
+        }
+
+        const auto r = ShotAnalysis::analyzeFlowVsGoal(
+            flow, flowGoal, phases, /*pourStart=*/0.0, /*pourEnd=*/11.0);
+        QVERIFY(r.hasData);
+        QVERIFY2(r.delta < -ShotAnalysis::FLOW_DEVIATION_THRESHOLD,
+                 qPrintable(QString("expected delta < -%1, got %2")
+                                .arg(ShotAnalysis::FLOW_DEVIATION_THRESHOLD)
+                                .arg(r.delta)));
+        QCOMPARE(ShotAnalysis::detectGrindIssue(flow, flowGoal, phases, 0.0, 11.0),
+                 true);
+    }
+
     // Filter beverage type also short-circuits.
     void flowVsGoal_filterBeverage_skips()
     {

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -278,6 +278,26 @@ private slots:
         }
     }
 
+    // Channeling is a positive-dC/dt signature. A sustained negative-dC/dt
+    // run (the lever pressure-rise / decline shape: pressure climbing or
+    // falling faster than flow can follow → conductance dropping) must not
+    // be flagged. The magnitudes here would all trip the |v| > 3 check that
+    // the legacy std::abs() loop used.
+    void channelingFromDerivative_negativeSpikeNotFlagged()
+    {
+        QVector<QPointF> dcdt;
+        for (double t = 0.0; t <= 25.0; t += 0.1) {
+            double v = 0.2;
+            if (t >= 7.0 && t <= 12.0) v = -8.0;  // 50 samples at -8 (|v|=8)
+            dcdt.append(QPointF(t, v));
+        }
+
+        QVector<ShotAnalysis::DetectionWindow> fullPour{{2.0, 25.0}};
+        auto severity = ShotAnalysis::detectChannelingFromDerivative(
+            dcdt, /*pourStart=*/2.0, /*pourEnd=*/25.0, fullPour);
+        QCOMPARE(severity, ShotAnalysis::ChannelingSeverity::None);
+    }
+
     // analyzeFlowVsGoal / detectGrindIssue ----------------------------------
 
     // 80's Espresso style: pour frames are all pressure-controlled. No


### PR DESCRIPTION
## Summary
Both quality badges fired false positives on lever-style profiles (80's Espresso et al.) for the same structural reason: the detectors compared a measured curve against a target the controller had stopped tracking. Two independent fixes:

### 1. Channeling badge — drop `std::abs()` on dC/dt
- Detector at `shotanalysis.cpp:90` compared **|dC/dt|** against the elevated threshold, so lever pressure-rise/decline frames (pressure climbing or falling faster than flow follows → conductance dropping fast) tripped Sustained
- On shot 886 (80's Espresso, 20→35.5g, 32.25s) the stored derivative had **0 samples > 3**, **23 samples < -3** clamped at -5 — enough for `channelingDetected = true`
- Real channeling = channel forms → flow surges → pressure dips → conductance jumps **up**. Negative dC/dt is the opposite, normal puck dynamic
- Fix: count only signed positive excursions

### 2. Grind badge — trim pump-ramp and pressure-limiter windows
- `analyzeFlowVsGoal` averages actual flow vs goal during flow-mode phases. On 80's preinfusion (flow goal 7.5 ml/s, pressure exit ceiling 3.8 bar), two windows produce design-baked undershoot that pulled the average below threshold
  - First ~0.5 s: pump ramps from idle; mechanical lag
  - Last ~1.5 s before a `transitionReason == "pressure"` exit: pressure ceiling engaged, controller stopped tracking flow goal
- Fix: trim `GRIND_PUMP_RAMP_SKIP_SEC` from start of first flow-mode phase and `GRIND_LIMITER_TAIL_SKIP_SEC` before flow-mode phases that exit on pressure

## Empirical validation
Re-ran current vs proposed grind detector against ~1100 real shots in the local `shots.db` covering 11 profile classes:

| Profile | Shots | Verdict changes |
|---|---|---|
| 80's Espresso | 15 | **9 FIRE → pass** (target false positives) |
| Adaptive v2 | 37 | 1 FIRE → pass (pump-ramp FP) |
| D-Flow / Q | 329 | 0 |
| D-Flow / Luca's | 186 | 0 |
| D-Flow / Malabar | 137 | 0 |
| D-Flow / La Pavoni | 108 | 0 |
| Default | 53 | 0 |
| A-Flow / default-medium | 53 | 0 |
| D-Flow / Q3 | 30 | 0 |
| Blooming Espresso | 7 | 0 |
| Londonium | 3 | 0 |

No `pass → FIRE` flips in any profile, so the trims never enable detection where it's currently silent.

## Test plan
- [x] `tst_shotanalysis` — full suite green via Qt Creator (1701 passed, 0 failed)
- [x] Empirical validation across 11 profile classes (~1100 shots) showing only target false positives change verdict
- [ ] Pull a fresh lever-style shot post-merge, confirm both badges silent
- [ ] Pull a known-channeled flat-pressure shot post-merge, confirm channeling Sustained still fires
- [ ] Pull a known fine-grind D-Flow shot post-merge, confirm grind issue still detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)