### PR TITLE
fix(analysis): repair corpus regressions from #864

### DIFF
--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -87,14 +87,11 @@ ShotAnalysis::ChannelingSeverity ShotAnalysis::detectChannelingFromDerivative(
     // channel signature is positive (flow surges, pressure dips,
     // conductance jumps up), but the post-channel collapse — flow drops
     // toward zero while pressure stays roughly stable — produces sustained
-    // negative dC/dt of equal diagnostic value. Examples in the regression
-    // corpus: londinium_gusher (puck gave up at 3.4 bar, flow collapsed
-    // 7.5 → 0.5 ml/s, dC/dt strongly negative throughout the pour).
-    // Distinguishing this real signal from the lever pressure-rise
-    // pattern (also negative dC/dt, but caused by intentional pressure
-    // ramping rather than puck failure) is the window builder's job —
-    // see buildChannelingWindows, which masks out samples where pressure
-    // is rapidly climbing.
+    // negative dC/dt of equal diagnostic value. Distinguishing that real
+    // signal from the lever pressure-rise pattern (also negative dC/dt, but
+    // caused by intentional pressure ramping rather than puck failure) is
+    // the window builder's job: see buildChannelingWindows, which masks out
+    // samples where pressure is rapidly climbing.
     for (const auto& pt : conductanceDerivative) {
         if (pt.x() < analysisStart) continue;
         if (pt.x() > analysisEnd) break;
@@ -219,11 +216,11 @@ QVector<ShotAnalysis::DetectionWindow> ShotAnalysis::buildChannelingWindows(
         // channeling.
         //
         // Direction matters: real puck failures collapse flow under
-        // approximately stable pressure (londinium_gusher) so pressure
-        // stays in-window. Bloom transitions and pressure-mode → flow-mode
-        // handoffs see pressure FALL rapidly — those are legitimate
-        // channeling signals (or expected transients) and must not be
-        // masked, so we only fence on rises here.
+        // approximately stable pressure, so pressure stays in-window.
+        // Bloom transitions and pressure-mode → flow-mode handoffs see
+        // pressure FALL rapidly — those are legitimate channeling signals
+        // (or expected transients) and must not be masked, so we only
+        // fence on rises here.
         if (isFlowMode) {
             const double pressureNow = lookupOrNaN(pressure, t);
             const double pressureFut = lookupOrNaN(pressure, t + WINDOW_HALF_SEC);
@@ -382,12 +379,12 @@ ShotAnalysis::GrindCheck ShotAnalysis::analyzeFlowVsGoal(
         // actually belongs. The 0.1 s margin absorbs BLE timestamp jitter.
         //
         // Both trims are gated on the resulting range staying at least
-        // kMinPostTrimRangeSec long. On extreme puck-failure shots (e.g.
-        // puck_failure_short_gusher: 2.2 s total, firmware bailed out
-        // immediately) the first flow-mode phase can be a fraction of a
-        // second — trimming 0.5 s off the front would leave nothing to
-        // analyze and the detector would silently report no-data instead
-        // of catching the obvious gusher.
+        // kMinPostTrimRangeSec long. On extreme puck-failure shots —
+        // where the firmware bails out within a couple of seconds because
+        // the puck offers no resistance — the first flow-mode phase can
+        // be a fraction of a second. Trimming 0.5 s off the front of that
+        // phase would leave nothing to analyze and the detector would
+        // silently report no-data instead of catching the obvious gusher.
         constexpr double kMinPostTrimRangeSec = 1.0;
         bool firstFlowModeAtPourStartSeen = false;
         for (qsizetype i = 0; i < phases.size(); ++i) {

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -83,18 +83,23 @@ ShotAnalysis::ChannelingSeverity ShotAnalysis::detectChannelingFromDerivative(
         return false;
     };
 
-    // Channeling is a positive-dC/dt signature: a channel forms, flow surges
-    // and pressure dips, conductance (flow/pressure) jumps up. Negative dC/dt
-    // is the opposite — flow falling relative to pressure — which is the
-    // normal dynamic on lever pressure-rise frames (pressure climbs faster
-    // than flow follows) and on pressure-decline frames as the puck thins.
-    // Treating |dC/dt| as channeling false-flags every lever pour, so we
-    // count only signed positive excursions here.
+    // The detector counts BOTH signs of dC/dt as channeling. The textbook
+    // channel signature is positive (flow surges, pressure dips,
+    // conductance jumps up), but the post-channel collapse — flow drops
+    // toward zero while pressure stays roughly stable — produces sustained
+    // negative dC/dt of equal diagnostic value. Examples in the regression
+    // corpus: londinium_gusher (puck gave up at 3.4 bar, flow collapsed
+    // 7.5 → 0.5 ml/s, dC/dt strongly negative throughout the pour).
+    // Distinguishing this real signal from the lever pressure-rise
+    // pattern (also negative dC/dt, but caused by intentional pressure
+    // ramping rather than puck failure) is the window builder's job —
+    // see buildChannelingWindows, which masks out samples where pressure
+    // is rapidly climbing.
     for (const auto& pt : conductanceDerivative) {
         if (pt.x() < analysisStart) continue;
         if (pt.x() > analysisEnd) break;
         if (!inAnyWindow(pt.x())) continue;
-        const double v = pt.y();
+        const double v = std::abs(pt.y());
         if (v > maxSpike) {
             maxSpike = v;
             maxSpikeTime = pt.x();
@@ -204,6 +209,30 @@ QVector<ShotAnalysis::DetectionWindow> ShotAnalysis::buildChannelingWindows(
         if (convergenceErr > WINDOW_CONVERGED_REL) {
             flushCurrent();
             continue;
+        }
+
+        // Flow-mode phases: exclude samples where pressure is RISING fast.
+        // The flow goal can be steady (e.g. 7.5 ml/s preinfusion) while the
+        // puck builds pressure under a pressure-ceiling exit condition. The
+        // resulting rapid pressure rise drives conductance sharply down —
+        // sustained negative dC/dt that's the lever-rise dynamic, not
+        // channeling.
+        //
+        // Direction matters: real puck failures collapse flow under
+        // approximately stable pressure (londinium_gusher) so pressure
+        // stays in-window. Bloom transitions and pressure-mode → flow-mode
+        // handoffs see pressure FALL rapidly — those are legitimate
+        // channeling signals (or expected transients) and must not be
+        // masked, so we only fence on rises here.
+        if (isFlowMode) {
+            const double pressureNow = lookupOrNaN(pressure, t);
+            const double pressureFut = lookupOrNaN(pressure, t + WINDOW_HALF_SEC);
+            if (!std::isnan(pressureNow) && !std::isnan(pressureFut)
+                && pressureNow > 0.5
+                && pressureFut > pressureNow * (1.0 + WINDOW_STATIONARY_REL)) {
+                flushCurrent();
+                continue;
+            }
         }
 
         // Sample qualifies. Extend or start the current window.
@@ -351,6 +380,15 @@ ShotAnalysis::GrindCheck ShotAnalysis::analyzeFlowVsGoal(
         // out by the pour-window gate below anyway; consuming the
         // "first seen" flag on it would silently skip the trim where it
         // actually belongs. The 0.1 s margin absorbs BLE timestamp jitter.
+        //
+        // Both trims are gated on the resulting range staying at least
+        // kMinPostTrimRangeSec long. On extreme puck-failure shots (e.g.
+        // puck_failure_short_gusher: 2.2 s total, firmware bailed out
+        // immediately) the first flow-mode phase can be a fraction of a
+        // second — trimming 0.5 s off the front would leave nothing to
+        // analyze and the detector would silently report no-data instead
+        // of catching the obvious gusher.
+        constexpr double kMinPostTrimRangeSec = 1.0;
         bool firstFlowModeAtPourStartSeen = false;
         for (qsizetype i = 0; i < phases.size(); ++i) {
             if (!phases[i].isFlowMode) continue;
@@ -358,13 +396,17 @@ ShotAnalysis::GrindCheck ShotAnalysis::analyzeFlowVsGoal(
             double end = (i + 1 < phases.size()) ? phases[i + 1].time : pourEnd;
             if (!firstFlowModeAtPourStartSeen
                 && phases[i].time + 0.1 >= pourStart) {
-                start += GRIND_PUMP_RAMP_SKIP_SEC;
+                if ((end - start) - GRIND_PUMP_RAMP_SKIP_SEC >= kMinPostTrimRangeSec) {
+                    start += GRIND_PUMP_RAMP_SKIP_SEC;
+                }
                 firstFlowModeAtPourStartSeen = true;
             }
             if (i + 1 < phases.size()
                 && phases[i + 1].transitionReason.compare(
                        QStringLiteral("pressure"), Qt::CaseInsensitive) == 0) {
-                end -= GRIND_LIMITER_TAIL_SKIP_SEC;
+                if ((end - start) - GRIND_LIMITER_TAIL_SKIP_SEC >= kMinPostTrimRangeSec) {
+                    end -= GRIND_LIMITER_TAIL_SKIP_SEC;
+                }
             }
             if (end > start) flowModeRanges.append({start, end});
         }

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -73,7 +73,10 @@ public:
     //   * The active goal is stationary (|goal(t±WINDOW_HALF_SEC) - goal(t)|
     //     / goal(t) ≤ WINDOW_STATIONARY_REL), AND
     //   * Actual is converged onto goal (|actual - goal| / goal ≤
-    //     WINDOW_CONVERGED_REL).
+    //     WINDOW_CONVERGED_REL), AND
+    //   * For flow-mode phases only, actual pressure is not rising rapidly
+    //     in the next WINDOW_HALF_SEC — the lever pressure-rise pattern
+    //     would otherwise read as channeling. Falling pressure is allowed.
     // Contiguous included times collapse into DetectionWindow spans. Short
     // gaps (≤ WINDOW_GAP_MERGE_SEC) are merged.
     //

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -308,12 +308,14 @@ private slots:
             pressure, flow, /*pressureGoal=*/QVector<QPointF>{},
             flowGoal, phases, /*pourStart=*/0.0, /*pourEnd=*/10.0);
 
-        // The 2-4 s ramp must be excluded; the post-ramp plateau (4.1 s+)
-        // is in-window. Assert the first window starts AFTER the ramp,
-        // which is what the lever-rise gate is actually responsible for.
+        // The steep part of the ramp must be excluded; once the ±0.75 s
+        // lookup spans the post-ramp plateau the relative pressure rise
+        // drops below WINDOW_STATIONARY_REL and windows can re-open.
+        // Empirically that crossover lands near t = 3.3 s, so any window
+        // start before t = 3 indicates the gate stopped firing too early.
         QVERIFY2(!windows.isEmpty(), "expected at least one window during the plateau");
         QVERIFY2(windows.first().start >= 3.0,
-                 qPrintable(QString("expected first window to start after the ramp, got start=%1s")
+                 qPrintable(QString("expected first window past the steep ramp, got start=%1s")
                                 .arg(windows.first().start)));
     }
 
@@ -456,30 +458,31 @@ private slots:
                  false);
     }
 
-    // Extreme puck failure: 2 s shot, single very short flow-mode phase.
-    // The pump-ramp trim would consume nearly the whole range and leave
-    // the detector silent — instead it must back off so a clean gusher
-    // signal still surfaces. Mirrors the puck_failure_short_gusher
-    // corpus fixture.
+    // Extreme puck failure: a flow-mode phase shorter than
+    // (GRIND_PUMP_RAMP_SKIP_SEC + kMinPostTrimRangeSec) so the trim guard
+    // must take its bypass branch. Without the bypass, the pump-ramp trim
+    // (0.5 s) would push start past end (start=0.5, end=0.8 → 3 samples
+    // after time-window filter, < 5 → hasData=false → grind silent on a
+    // shot that's clearly a gusher). With the bypass, the full 0-0.8 s
+    // window stays and the detector fires.
     void flowVsGoal_shortShot_skipsTrimToPreserveSignal()
     {
         QList<HistoryPhaseMarker> phases{
             phase(0.0, "Fill", 0, /*isFlowMode=*/true),
+            phase(0.8, "Pour", 1, /*isFlowMode=*/false),
             phase(2.0, "End", -1, /*isFlowMode=*/false),
         };
-        // Flow gushes (avg ~6 ml/s) against goal 4 ml/s — clear coarse
-        // grind / puck-failure signal. With pump-ramp trim applied, the
-        // resulting range [0.5, 2.0] is 1.5 s — fine. With pump-ramp + a
-        // hypothetical pressure tail trim it would collapse, but here
-        // there's no pressure tail (next phase isn't "pressure"-exiting).
-        // The test below validates the bypass on the truly short case.
+        // Flow gushes (6 ml/s) against goal 4 ml/s during the 0.8 s
+        // flow-mode phase — clear coarse-grind signal. The phase length
+        // (0.8 s) minus the trim (0.5 s) equals 0.3 s, well below the
+        // 1.0 s post-trim minimum, so the bypass must engage.
         auto flow = flatSeries(0.0, 2.0, 6.0);
         auto flowGoal = flatSeries(0.0, 2.0, 4.0);
 
         const auto r = ShotAnalysis::analyzeFlowVsGoal(
             flow, flowGoal, phases, /*pourStart=*/0.0, /*pourEnd=*/2.0);
         QVERIFY2(r.hasData,
-                 "expected enough samples after trim guard");
+                 "expected the trim bypass to preserve enough samples");
         QVERIFY2(r.delta > ShotAnalysis::FLOW_DEVIATION_THRESHOLD,
                  qPrintable(QString("expected positive delta > %1, got %2")
                                 .arg(ShotAnalysis::FLOW_DEVIATION_THRESHOLD).arg(r.delta)));

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -280,24 +280,72 @@ private slots:
         }
     }
 
-    // Channeling is a positive-dC/dt signature. A sustained negative-dC/dt
-    // run (the lever pressure-rise / decline shape: pressure climbing or
-    // falling faster than flow can follow → conductance dropping) must not
-    // be flagged. The magnitudes here would all trip the |v| > 3 check that
-    // the legacy std::abs() loop used.
-    void channelingFromDerivative_negativeSpikeNotFlagged()
+    // Lever-style false-positive suppression: in a flow-mode phase whose
+    // flow goal is steady but actual pressure is rising fast (the pump is
+    // building toward a pressure-ceiling exit condition), the window
+    // builder must exclude those samples — the resulting dC/dt drop is the
+    // pressure-rise dynamic, not channeling. Falling pressure (bloom
+    // transitions, pump stops) must NOT be masked: those are legitimate
+    // channeling-like transients.
+    void channelingWindows_flowModeRisingPressure_isExcluded()
     {
-        QVector<QPointF> dcdt;
-        for (double t = 0.0; t <= 25.0; t += 0.1) {
-            double v = 0.2;
-            if (t >= 7.0 && t <= 12.0) v = -8.0;  // 50 samples at -8 (|v|=8)
-            dcdt.append(QPointF(t, v));
-        }
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "Preinfusion", 0, /*isFlowMode=*/true),
+            phase(10.0, "End", -1, /*isFlowMode=*/false),
+        };
 
-        QVector<ShotAnalysis::DetectionWindow> fullPour{{2.0, 25.0}};
-        auto severity = ShotAnalysis::detectChannelingFromDerivative(
-            dcdt, /*pourStart=*/2.0, /*pourEnd=*/25.0, fullPour);
-        QCOMPARE(severity, ShotAnalysis::ChannelingSeverity::None);
+        // Flow tracks goal cleanly, but pressure ramps from 2 → 10 bar over
+        // 4 s (≈ 2 bar/s — matches 80's Espresso preinfusion-late dynamic
+        // before the pressure-ceiling exit). After 4 s pressure stays flat
+        // at 10 bar so the test isolates the ramp effect.
+        const auto flow = flatSeries(0.0, 10.0, 7.5);
+        const auto flowGoal = flatSeries(0.0, 10.0, 7.5);
+        QVector<QPointF> pressure;
+        pressure.append(rampSeries(0.0, 4.0, 2.0, 10.0));
+        for (const auto& p : flatSeries(4.1, 10.0, 10.0)) pressure.append(p);
+
+        const auto windows = ShotAnalysis::buildChannelingWindows(
+            pressure, flow, /*pressureGoal=*/QVector<QPointF>{},
+            flowGoal, phases, /*pourStart=*/0.0, /*pourEnd=*/10.0);
+
+        // The 2-4 s ramp must be excluded; the post-ramp plateau (4.1 s+)
+        // is in-window. Assert the first window starts AFTER the ramp,
+        // which is what the lever-rise gate is actually responsible for.
+        QVERIFY2(!windows.isEmpty(), "expected at least one window during the plateau");
+        QVERIFY2(windows.first().start >= 3.0,
+                 qPrintable(QString("expected first window to start after the ramp, got start=%1s")
+                                .arg(windows.first().start)));
+    }
+
+    // Inverse: in a flow-mode phase with falling pressure (the bloom
+    // transition shape — pump stops while flow trails to zero), pressure
+    // is changing rapidly but in the negative direction, so the lever-rise
+    // gate must NOT engage. Validates that the directional rule preserves
+    // the legacy detector's coverage of bloom-transition spikes.
+    void channelingWindows_flowModeFallingPressure_isIncluded()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "Bloom", 0, /*isFlowMode=*/true),
+            phase(10.0, "End", -1, /*isFlowMode=*/false),
+        };
+
+        // Same setup but pressure falls from 8 → 2 bar.
+        const auto flow = flatSeries(0.0, 10.0, 1.5);
+        const auto flowGoal = flatSeries(0.0, 10.0, 1.5);
+        const auto pressure = rampSeries(0.0, 10.0, 8.0, 2.0);
+
+        const auto windows = ShotAnalysis::buildChannelingWindows(
+            pressure, flow, /*pressureGoal=*/QVector<QPointF>{},
+            flowGoal, phases, /*pourStart=*/0.0, /*pourEnd=*/10.0);
+
+        double totalMaskSec = 0.0;
+        for (const auto& w : windows) totalMaskSec += (w.end - w.start);
+        // Most of the analysis range should be in-window. CHANNELING_DC_POUR_SKIP_SEC
+        // (2 s) and CHANNELING_DC_POUR_SKIP_END_SEC (1.5 s) are trimmed by
+        // the window builder, leaving 10 - 2 - 1.5 = 6.5 s of analysis range.
+        QVERIFY2(totalMaskSec > 5.0,
+                 qPrintable(QString("expected ~6.5 s of windows during pressure fall, got %1s")
+                                .arg(totalMaskSec)));
     }
 
     // analyzeFlowVsGoal / detectGrindIssue ----------------------------------
@@ -406,6 +454,37 @@ private slots:
                                 .arg(r.delta)));
         QCOMPARE(ShotAnalysis::detectGrindIssue(flow, flowGoal, phases, 0.0, 11.0),
                  false);
+    }
+
+    // Extreme puck failure: 2 s shot, single very short flow-mode phase.
+    // The pump-ramp trim would consume nearly the whole range and leave
+    // the detector silent — instead it must back off so a clean gusher
+    // signal still surfaces. Mirrors the puck_failure_short_gusher
+    // corpus fixture.
+    void flowVsGoal_shortShot_skipsTrimToPreserveSignal()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "Fill", 0, /*isFlowMode=*/true),
+            phase(2.0, "End", -1, /*isFlowMode=*/false),
+        };
+        // Flow gushes (avg ~6 ml/s) against goal 4 ml/s — clear coarse
+        // grind / puck-failure signal. With pump-ramp trim applied, the
+        // resulting range [0.5, 2.0] is 1.5 s — fine. With pump-ramp + a
+        // hypothetical pressure tail trim it would collapse, but here
+        // there's no pressure tail (next phase isn't "pressure"-exiting).
+        // The test below validates the bypass on the truly short case.
+        auto flow = flatSeries(0.0, 2.0, 6.0);
+        auto flowGoal = flatSeries(0.0, 2.0, 4.0);
+
+        const auto r = ShotAnalysis::analyzeFlowVsGoal(
+            flow, flowGoal, phases, /*pourStart=*/0.0, /*pourEnd=*/2.0);
+        QVERIFY2(r.hasData,
+                 "expected enough samples after trim guard");
+        QVERIFY2(r.delta > ShotAnalysis::FLOW_DEVIATION_THRESHOLD,
+                 qPrintable(QString("expected positive delta > %1, got %2")
+                                .arg(ShotAnalysis::FLOW_DEVIATION_THRESHOLD).arg(r.delta)));
+        QCOMPARE(ShotAnalysis::detectGrindIssue(flow, flowGoal, phases, 0.0, 2.0),
+                 true);
     }
 
     // The limiter-tail trim is gated on transitionReason == "pressure".


### PR DESCRIPTION
## Summary
PR #864 was over-aggressive — it killed two real-positive cases in the regression corpus that I missed because the Qt Creator MCP `run_tests` only runs QTests, not the `shot_corpus_regression` ctest target. Linux CI caught it on the v1.7.2 retag. This PR repairs both.

## What broke

**londinium_gusher** — channeling went **Sustained → None**. The "signed positive only" rule from #864 silenced the post-channel collapse signature (flow drops 7.5 → 0.5 ml/s while pressure stays near 3 bar, conductance plummets, dC/dt strongly negative). The textbook channel is positive, but the corpus relies on the detector also catching the failure tail.

**puck_failure_short_gusher** — grindIssue went **true → false**. The new pump-ramp trim (0.5 s off the first flow-mode phase) consumed the entire ~0 s flow-mode range that this 2.2 s extreme puck-failure shot exposes after phase reconstruction. Zero samples → silent `no-data`.

## Three fixes

1. **Restore `std::abs()` in `detectChannelingFromDerivative`** so both signs of dC/dt count. Discriminating puck-failure (negative dC/dt under *stable* pressure) from lever-rise (negative dC/dt under *fast-rising* pressure) is now the window builder's job.

2. **`buildChannelingWindows`: fence flow-mode samples where pressure is rising fast** (> `WINDOW_STATIONARY_REL` across the ±0.75 s lookup). Direction matters — only **rises** are masked. Bloom transitions and pressure-mode → flow-mode handoffs (pressure falling) stay in-window because those are legitimate channeling-style transients.

3. **`analyzeFlowVsGoal`: both pump-ramp and limiter-tail trims now require ≥ 1 s of range left**. Trimming a fractional-second flow-mode phase down to nothing is strictly worse than leaving the raw samples — extreme puck-failure shots have just enough data in that short window to register a clear gusher delta.

## Tests
- Drop the obsolete `channelingFromDerivative_negativeSpikeNotFlagged` test (invalidated by the `abs` restore).
- Add `channelingWindows_flowModeRisingPressure_isExcluded` — rising pressure during flow-mode phase masks the samples.
- Add `channelingWindows_flowModeFallingPressure_isIncluded` — falling pressure (bloom/handoff) stays in-window.
- Add `flowVsGoal_shortShot_skipsTrimToPreserveSignal` — pump-ramp trim bypassed when range too short.

## Validation
- `shot_corpus_regression`: 10/12 → **12/12**
- `tst_ShotAnalysis`: 1701 → **1704** (3 new tests, no regressions)

## Process gap
Qt Creator MCP `run_tests` doesn't include `shot_corpus_regression` (separate ctest target driven by `shot_eval`). For analysis changes I should have run `ctest -R shot_corpus_regression` against the macOS-Debug build before pushing — added to my mental checklist for next time.

## Test plan
- [x] `tst_ShotAnalysis` full suite — 1704/1704
- [x] `shot_corpus_regression` — 12/12 in local Debug build
- [ ] Pull a fresh lever-style shot post-merge, confirm channeling badge silent on clean pours
- [ ] Pull a known-channeled flat-pressure shot, confirm Sustained still fires
- [ ] Pull a known fine-grind D-Flow shot, confirm grind issue still detected
- [ ] CI Linux build passes (currently failing on `dbe3ec49`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)