### PR TITLE
saw: tune Gaussian flow-similarity sigma from 1.5 to 0.25

### DIFF
--- a/openspec/changes/tune-saw-old-prediction/proposal.md
+++ b/openspec/changes/tune-saw-old-prediction/proposal.md
@@ -50,4 +50,4 @@ The pre-graduation bootstrap path (`flow × globalSawBootstrapLag(scale)` capped
 - **Worst-case error (≈1.7 g for stall-recovery shots)** — that's a feature problem (e.g., puck-state proxy, flow-trajectory feature), not a tuning problem. Out of scope.
 - **Speed of personalization** (pair-specific predictions in <10 shots) — Phase 0 showed pending-batch warmup at any threshold loses to the existing cross-pair bootstrap on the corpus. Decoupled from this proposal.
 - **Smart bootstrap pool restructuring** — Phase 0 showed it fails the gate (helps high-flow but hurts the headline low-flow case). Decoupled and dropped.
-- **Generalization beyond the corpus** — 63 shots from one user, two profiles, one scale. The post-deploy shadow logging in Phase 2 is the actual generalization test.
+- **Generalization beyond the corpus** — 63 shots from one user, two profiles, one scale. There is no post-deploy telemetry that would pull SAW prediction data from a representative cohort, so the rollback gate (Phase 3) is qualitative (issue reports + Jeff's own observation), not metric-based. Shadow logging was considered and dropped — see Phase 2 of `tasks.md` for the rationale.

--- a/openspec/changes/tune-saw-old-prediction/tasks.md
+++ b/openspec/changes/tune-saw-old-prediction/tasks.md
@@ -23,39 +23,30 @@ Phase 0 has already been executed. Results are recorded in `analysis.md`. Summar
 - [ ] Build + run the full ctest suite. All green is a hard gate before any push.
 - [ ] Run `tools/saw_parity/` against the real Settings code (no env-var) and confirm overall MAE ≈ 0.348 g (matching the Phase 0 measurement) on the 63-shot corpus.
 
-## Phase 2 — Shadow logging (ships in same PR as Phase 1)
+## Phase 2 — Shadow logging (DROPPED 2026-04-26)
 
-- [ ] Extend the existing `[SAW] accuracy:` log line at `main.cpp:532` with two additional fields:
-  - `oldSigmaDrip=` — what σ=1.5 would have predicted at this shot's flow given the same pool. Compute via a private helper that runs the OLD math with the OLD constant. Allows post-deploy A/B comparison against the σ=0.25 prediction.
-  - `predictionSource=` — `perPair` | `globalBootstrap` | `scaleDefault`. Lets Phase 3 analysis split metrics by which path fired.
-- [ ] Confirm both new fields flow through the persistent debug logger so they survive past per-shot capture.
+Originally planned to add `oldSigmaDrip` and `predictionSource` to the `[SAW] accuracy:` log line so post-deploy MAE could be A/B'd against σ=1.5. Dropped because:
 
-## Phase 3 — Analysis (after deployment)
+- Detailed per-shot SAW data only reaches us when a user submits a system log, and users only submit logs when they hit a problem. That biases any "data we'd see" toward σ=0.25 *failures* rather than a clean A/B sample.
+- Without telemetry to pull `oldSigmaDrip` from a representative cohort, the field is effectively dead bytes on most users' devices.
+- The cost of adding it (extra qExp per shot end, 2 log fields, a new `SawPredictionDetail` API, ongoing maintenance until removed) outweighs its post-deploy value.
 
-- [ ] Wait until the persistent debug log has accumulated ≥ 30 SAW-triggering shots since the deploy date, across at least 3 distinct (profile, scale) pairs.
-- [ ] Pull the persistent log via `mcp__de1__debug_get_log` and extract `[SAW] accuracy:` lines.
-- [ ] Compute MAE for both `oldSigmaDrip` (σ=1.5) and `predictedDrip` (σ=0.25) against `actualDrip`:
-  - Overall and per (profile, scale) pair
-  - Per flow bucket (low / mid / high)
-  - Per `predictionSource` (perPair / globalBootstrap / scaleDefault)
-- [ ] Append all metrics to `analysis.md` alongside the Phase 0 pre-deploy baseline.
+If a richer post-deploy signal becomes desirable later (e.g., if shotmap/visualizer telemetry is extended to include SAW prediction fields), this can be re-added as a small, focused change.
 
-## Phase 4 — Decision point
+## Phase 3 — Decision (after deployment)
 
-Pre-committed criteria:
+Decision criteria are now qualitative, not metric-based:
 
-- [ ] **Decision A — Keep the σ change.** Pick this iff:
-  1. Overall post-deploy MAE for σ=0.25 ≤ Phase 0 baseline (0.348 g, within noise).
-  2. Low-flow post-deploy MAE has improved or held even vs the captured `oldSigmaDrip` field.
-  3. No (profile, scale) pair shows divergence: 3+ consecutive overshoots > 2 g in the same direction post-deploy.
+- [ ] **Decision A — Keep the σ change.** Default. Pick this iff:
+  1. No SAW-related issue reports (overshoot/undershoot complaints) in the GitHub Issues tracker in the 2 weeks following the deploy.
+  2. Jeff's own daily-driver pulls are not regressing visibly (subjective; based on his shot-by-shot observation).
 - [ ] **Decision B — Roll back the σ change.** Pick this iff:
-  1. Overall post-deploy MAE worsens vs the captured `oldSigmaDrip` field.
-  2. Low-flow worsens.
-  3. Any (profile, scale) pair diverges per the threshold above.
-  Rollback procedure: `git revert <Phase 1+2 squash commit SHA>`. Shadow-logging captures will remain in the persistent log for forensic analysis.
-- [ ] Record the decision and supporting numbers in `analysis.md` and update `proposal.md` with a final status line.
+  1. ≥1 user reports a SAW regression that didn't exist pre-deploy.
+  2. Jeff observes a clear regression on his own machine that the Phase 0 corpus didn't predict.
+  Rollback procedure: `git revert <Phase 1 commit SHA>`. No shadow data was captured, so the rollback decision is based on reports + observation, not metrics.
+- [ ] Record the decision in `analysis.md` and update `proposal.md` with a final status line.
 
-## Phase 5 — Archive
+## Phase 4 — Archive
 
 - [ ] After deployment is stable for ≥ 2 weeks (regardless of decision):
   - [ ] Run `openspec validate tune-saw-old-prediction --strict --no-interactive` to confirm consistency.

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -852,9 +852,9 @@ double Settings::getExpectedDrip(double currentFlowRate) const {
         // Recency weight: linear interpolation from max to min across entry count
         double recencyWeight = recencyMax - i * (recencyMax - recencyMin) / qMax(1, entries.size() - 1);
 
-        // Flow similarity weight: gaussian with sigma=1.5 ml/s
+        // Flow similarity weight: gaussian with sigma=0.25 ml/s
         double flowDiff = qAbs(e.flow - currentFlowRate);
-        double flowWeight = qExp(-(flowDiff * flowDiff) / 4.5);  // sigma^2 * 2 = 4.5
+        double flowWeight = qExp(-(flowDiff * flowDiff) / 0.125);  // sigma^2 * 2 = 0.125
 
         double weight = recencyWeight * flowWeight;
         weightedDripSum += e.drip * weight;
@@ -1220,7 +1220,8 @@ double Settings::getExpectedDripFor(const QString& profileFilename,
                     double recencyWeight = recencyMax - i * (recencyMax - recencyMin)
                                                        / qMax(qsizetype{1}, entries.size() - 1);
                     double flowDiff = qAbs(e.flow - currentFlowRate);
-                    double flowWeight = qExp(-(flowDiff * flowDiff) / 4.5);
+                    // Flow similarity weight: gaussian with sigma=0.25 ml/s
+                    double flowWeight = qExp(-(flowDiff * flowDiff) / 0.125);  // sigma^2 * 2 = 0.125
                     double w = recencyWeight * flowWeight;
                     weightedDripSum += e.drip * w;
                     totalWeight += w;

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -846,11 +846,11 @@ double Settings::getExpectedDrip(double currentFlowRate) const {
     double weightedDripSum = 0;
     double totalWeight = 0;
 
-    for (int i = 0; i < entries.size(); ++i) {
+    for (qsizetype i = 0; i < entries.size(); ++i) {
         const Entry& e = entries[i];
 
         // Recency weight: linear interpolation from max to min across entry count
-        double recencyWeight = recencyMax - i * (recencyMax - recencyMin) / qMax(1, entries.size() - 1);
+        double recencyWeight = recencyMax - i * (recencyMax - recencyMin) / qMax(qsizetype{1}, entries.size() - 1);
 
         // Flow similarity weight: gaussian with sigma=0.25 ml/s
         double flowDiff = qAbs(e.flow - currentFlowRate);

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -437,9 +437,9 @@ double WeightProcessor::getExpectedDrip(double currentFlowRate) const
         // Recency weight: linear interpolation from max to min
         double recencyWeight = recencyMax - i * (recencyMax - recencyMin) / qMax(qsizetype(1), count - 1);
 
-        // Flow similarity: gaussian with sigma=1.5 ml/s
+        // Flow similarity: gaussian with sigma=0.25 ml/s
         double flowDiff = qAbs(flow - currentFlowRate);
-        double flowWeight = qExp(-(flowDiff * flowDiff) / 4.5);  // sigma^2 * 2 = 4.5
+        double flowWeight = qExp(-(flowDiff * flowDiff) / 0.125);  // sigma^2 * 2 = 0.125
 
         double w = recencyWeight * flowWeight;
         weightedDripSum += drip * w;

--- a/tests/tst_saw_settings.cpp
+++ b/tests/tst_saw_settings.cpp
@@ -200,6 +200,65 @@ private slots:
         QCOMPARE(m_settings.globalSawBootstrapLag(kScale), before);
     }
 
+    // ===== σ flow-similarity behavior =====
+    //
+    // The other tests in this file train and query at the same flow value, so the
+    // gaussian flow-similarity weight is always 1.0 and σ is invisible to them.
+    // The three tests below probe σ explicitly so a future regression that widens
+    // it back out (or accidentally narrows it to zero) is caught.
+
+    void farQueryFlowFallsBackBecauseGaussianAttenuates() {
+        // Capture the cold-start scale-default fallback at the query flow. With no
+        // committed data and no bootstrap, getExpectedDripFor returns
+        // flow × (sensorLag + 0.1).
+        const double fallback = m_settings.getExpectedDripFor(kProfileA, kScale, 2.5);
+
+        // Train two batches at flow=1.5 so the per-pair history graduates with a
+        // training drip far from the fallback.
+        commitBatch(kProfileA, 2.0, 1.5);
+        commitBatch(kProfileA, 2.0, 1.5);
+
+        // Query 1.0 ml/s away from training. At σ=0.25, flowWeight=exp(-8)≈3e-4 and
+        // totalWeight drops below the 0.01 floor → branch falls through to the
+        // scale-default fallback. At σ=1.5 (regression) flowWeight≈0.80 and the
+        // prediction would lock to 2.0 g.
+        const double pred = m_settings.getExpectedDripFor(kProfileA, kScale, 2.5);
+
+        QVERIFY2(qAbs(pred - fallback) < qAbs(pred - 2.0),
+                 qPrintable(QString("pred=%1 not closer to fallback=%2 than to training=2.0")
+                                .arg(pred).arg(fallback)));
+    }
+
+    void sameFlowQueryReturnsTrainingDrip() {
+        // Locks in the no-flow-shift case: when query flow equals training flow,
+        // flowWeight=1 for every entry and the weighted average collapses to the
+        // (constant) training drip regardless of σ. Tolerance is tight so a σ
+        // regression doesn't hide here even though σ shouldn't matter at flowDiff=0.
+        commitBatch(kProfileA, 2.0, 1.5);
+        commitBatch(kProfileA, 2.0, 1.5);
+
+        const double pred = m_settings.getExpectedDripFor(kProfileA, kScale, 1.5);
+        QVERIFY2(qAbs(pred - 2.0) < 0.05,
+                 qPrintable(QString("expected ~2.0, got %1").arg(pred)));
+    }
+
+    void differentQueryFlowsProduceDifferentPredictions() {
+        // Two committed medians spanning a wide flow range. Querying at each end
+        // should return the corresponding training drip — under σ=0.25 the
+        // off-flow entry is attenuated to ~exp(-32) and contributes nothing. If σ
+        // were widened to dilute everything to a flat average the two predictions
+        // would converge.
+        commitBatch(kProfileA, 0.6, 1.0);   // lag 0.6s
+        commitBatch(kProfileA, 1.8, 3.0);   // lag 0.6s
+
+        const double low  = m_settings.getExpectedDripFor(kProfileA, kScale, 1.0);
+        const double high = m_settings.getExpectedDripFor(kProfileA, kScale, 3.0);
+
+        QVERIFY2(qAbs(high - low) > 0.5,
+                 qPrintable(QString("predictions did not separate by flow: low=%1 high=%2")
+                                .arg(low).arg(high)));
+    }
+
     // ===== Full reset clears bootstrap =====
 
     void fullResetClearsBootstrap() {

--- a/tests/tst_saw_settings.cpp
+++ b/tests/tst_saw_settings.cpp
@@ -204,8 +204,11 @@ private slots:
     //
     // The other tests in this file train and query at the same flow value, so the
     // gaussian flow-similarity weight is always 1.0 and σ is invisible to them.
-    // The three tests below probe σ explicitly so a future regression that widens
-    // it back out (or accidentally narrows it to zero) is caught.
+    // Two of the three tests below (farQueryFlow, differentQueryFlows) probe σ
+    // explicitly so a future regression that widens it back out (or accidentally
+    // narrows it to zero) is caught. The third (sameFlowQuery) is a flowDiff=0
+    // baseline lock-in — σ is invisible there too, but the test pins the no-flow-
+    // shift result so the surrounding weighted-average machinery can't silently break.
 
     void farQueryFlowFallsBackBecauseGaussianAttenuates() {
         // Capture the cold-start scale-default fallback at the query flow. With no
@@ -248,8 +251,8 @@ private slots:
         // off-flow entry is attenuated to ~exp(-32) and contributes nothing. If σ
         // were widened to dilute everything to a flat average the two predictions
         // would converge.
-        commitBatch(kProfileA, 0.6, 1.0);   // lag 0.6s
-        commitBatch(kProfileA, 1.8, 3.0);   // lag 0.6s
+        commitBatch(kProfileA, 0.6, 1.0);   // low-flow training: drip=0.6, flow=1.0
+        commitBatch(kProfileA, 1.8, 3.0);   // high-flow training: drip=1.8, flow=3.0
 
         const double low  = m_settings.getExpectedDripFor(kProfileA, kScale, 1.0);
         const double high = m_settings.getExpectedDripFor(kProfileA, kScale, 3.0);


### PR DESCRIPTION
## Summary

Phase 1 of [openspec/tune-saw-old-prediction](openspec/changes/tune-saw-old-prediction/proposal.md). Drops the SAW Gaussian flow-similarity σ from 1.5 → 0.25 ml/s at three call sites (`Settings::getExpectedDrip`, `Settings::getExpectedDripFor`, `WeightProcessor::getExpectedDrip`) — the only numeric change is `flowDiff² / 4.5` → `flowDiff² / 0.125`.

Phase 0 (recorded in `analysis.md`) measured this on a 63-shot real-shot corpus through real production code via `tools/saw_parity/`:
- Overall MAE: 0.370 → 0.348 g (−6%)
- High-flow MAE: 0.686 → 0.592 g (−14%)
- Shot 887 over-prediction: +0.90 → +0.57 g (−37%)

Pool data, clamps (`drip ∈ [0.5, 20]`), and fallback paths (lag-fallback when pool is degenerate) are unchanged. Migration: zero.

## What's included

- σ change at the 3 sites (single numeric constant + comment update each)
- 3 new σ-exercising tests in `tst_saw_settings.cpp` — the existing 52 SAW tests train and query at the same flow, leaving σ entirely uncovered. The new tests defend against future regressions in either direction (σ widened or narrowed).
- Phase 2 (shadow logging) explicitly dropped; Phase 3 reframed as a qualitative decision. Rationale documented in `tasks.md`.

## Test plan

- [x] Full ctest suite passes (1707 / 1707, no warnings)
- [x] `tools/saw_parity/` confirms overall MAE = 0.34811 g and shot 887 signed error = +0.573 g (matching Phase 0 baseline through real production code)
- [x] `openspec validate tune-saw-old-prediction --strict --no-interactive` — clean
- [ ] Daily-driver soak on Jeff's machine for 2 weeks per Phase 3 decision criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)