### PR TITLE
saw: extract shared expected-drip prediction helper (#873)

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -11,6 +11,7 @@
 #include "settings_network.h"
 #include "settings_app.h"
 #include "grinderaliases.h"
+#include "../machine/sawprediction.h"
 #include <algorithm>
 #include <QStandardPaths>
 #include <QDir>
@@ -840,39 +841,24 @@ double Settings::getExpectedDrip(double currentFlowRate) const {
         return qMin(currentFlowRate * (sensorLag(currentScale) + 0.1), 8.0);  // No entries for this scale type
     }
 
-    // Weighted average: weight by recency AND flow similarity
-    // Recency weight scales linearly from recencyMax (newest) to recencyMin (oldest)
-    // Flow similarity: closer flow = higher weight (gaussian-ish)
-    double weightedDripSum = 0;
-    double totalWeight = 0;
-
-    for (qsizetype i = 0; i < entries.size(); ++i) {
-        const Entry& e = entries[i];
-
-        // Recency weight: linear interpolation from max to min across entry count
-        double recencyWeight = recencyMax - i * (recencyMax - recencyMin) / qMax(qsizetype{1}, entries.size() - 1);
-
-        // Flow similarity weight: gaussian with sigma=0.25 ml/s
-        double flowDiff = qAbs(e.flow - currentFlowRate);
-        double flowWeight = qExp(-(flowDiff * flowDiff) / 0.125);  // sigma^2 * 2 = 0.125
-
-        double weight = recencyWeight * flowWeight;
-        weightedDripSum += e.drip * weight;
-        totalWeight += weight;
+    // Math is shared with WeightProcessor and getExpectedDripFor via
+    // SawPrediction::weightedDripPrediction so σ stays in lockstep.
+    QVector<double> drips, flows;
+    drips.reserve(entries.size());
+    flows.reserve(entries.size());
+    for (const Entry& e : std::as_const(entries)) {
+        drips.append(e.drip);
+        flows.append(e.flow);
     }
 
-    if (totalWeight < 0.01) {
+    const double prediction = SawPrediction::weightedDripPrediction(
+        drips, flows, currentFlowRate, recencyMax, recencyMin);
+
+    if (qIsNaN(prediction)) {
         // All entries have very different flow rates — fall back to sensor-lag default.
         return qMin(currentFlowRate * (sensorLag(currentScale) + 0.1), 8.0);
     }
-
-    double expectedDrip = weightedDripSum / totalWeight;
-
-    // Clamp to reasonable range (0.5 to 20 grams)
-    if (expectedDrip < 0.5) expectedDrip = 0.5;
-    if (expectedDrip > 20.0) expectedDrip = 20.0;
-
-    return expectedDrip;
+    return prediction;
 }
 
 QList<QPair<double, double>> Settings::sawLearningEntries(const QString& scaleType, int maxEntries) const {
@@ -1211,24 +1197,18 @@ double Settings::getExpectedDripFor(const QString& profileFilename,
                 if (obj.contains("drip")) entries.append({obj["drip"].toDouble(), obj["flow"].toDouble()});
             }
             if (!entries.isEmpty()) {
-                double weightedDripSum = 0;
-                double totalWeight = 0;
-                const double recencyMax = 10.0;
-                const double recencyMin = 3.0;
-                for (qsizetype i = 0; i < entries.size(); ++i) {
-                    const Entry& e = entries[i];
-                    double recencyWeight = recencyMax - i * (recencyMax - recencyMin)
-                                                       / qMax(qsizetype{1}, entries.size() - 1);
-                    double flowDiff = qAbs(e.flow - currentFlowRate);
-                    // Flow similarity weight: gaussian with sigma=0.25 ml/s
-                    double flowWeight = qExp(-(flowDiff * flowDiff) / 0.125);  // sigma^2 * 2 = 0.125
-                    double w = recencyWeight * flowWeight;
-                    weightedDripSum += e.drip * w;
-                    totalWeight += w;
+                QVector<double> drips, flows;
+                drips.reserve(entries.size());
+                flows.reserve(entries.size());
+                for (const Entry& e : std::as_const(entries)) {
+                    drips.append(e.drip);
+                    flows.append(e.flow);
                 }
-                if (totalWeight >= 0.01) {
-                    double expected = weightedDripSum / totalWeight;
-                    return qBound(0.5, expected, 20.0);
+                const double prediction = SawPrediction::weightedDripPrediction(
+                    drips, flows, currentFlowRate,
+                    /*recencyMax=*/10.0, /*recencyMin=*/3.0);
+                if (!qIsNaN(prediction)) {
+                    return prediction;
                 }
             }
         }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -814,7 +814,7 @@ double Settings::getExpectedDrip(double currentFlowRate) const {
 
     // Check convergence state to determine adaptive parameters
     bool converged = isSawConverged(currentScale);
-    int maxEntries = converged ? 12 : 8;
+    qsizetype maxEntries = converged ? 12 : 8;
     double recencyMax = 10.0;
     double recencyMin = converged ? 3.0 : 1.0;  // Steeper recency = faster adaptation
 
@@ -1187,9 +1187,12 @@ double Settings::getExpectedDripFor(const QString& profileFilename,
     if (!profileFilename.isEmpty()) {
         QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
         if (pairHistory.size() >= kSawMinMediansForGraduation) {
-            // Weighted average using the same recency + flow-similarity scheme as the
-            // global getExpectedDrip(). Uses up to 12 medians (pair history is capped at
-            // 10, so this just consumes the lot in practice).
+            // Same flow-similarity kernel as the global getExpectedDrip(), but
+            // recencyMin is fixed at 3.0 — per-pair history only kicks in after
+            // graduation (≥ kSawMinMediansForGraduation committed medians) and
+            // is small (capped at 10), so the pre-convergence steepening that
+            // the global path uses (recencyMin=1.0) doesn't apply here.
+            // Uses up to 12 medians (pair history caps at 10 in practice).
             struct Entry { double drip; double flow; };
             QVector<Entry> entries;
             for (qsizetype i = pairHistory.size() - 1; i >= 0 && entries.size() < 12; --i) {

--- a/src/machine/sawprediction.h
+++ b/src/machine/sawprediction.h
@@ -56,9 +56,8 @@ inline double weightedDripPrediction(const QVector<double>& drips,
                                      double recencyMax,
                                      double recencyMin)
 {
-    Q_ASSERT(drips.size() == flows.size());
     const qsizetype count = drips.size();
-    if (count == 0) {
+    if (count == 0 || flows.size() != count) {
         return qQNaN();
     }
 

--- a/src/machine/sawprediction.h
+++ b/src/machine/sawprediction.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <QtCore/QtMath>
+#include <QtCore/QVector>
+#include <QtCore/qnumeric.h>
+
+// Shared math for SAW expected-drip prediction.
+//
+// Three sites compute the same Gaussian-weighted average over recent
+// (drip, flow) entries: the live SAW threshold in WeightProcessor and the
+// post-shot prediction used for learning-pool feedback in Settings (global
+// pool + per-(profile, scale) pool). All three MUST stay in lockstep — drift
+// in σ between the live threshold and the learning feedback would silently
+// desync SAW behaviour. PR #870 narrowed σ from 1.5 → 0.25 ml/s; issue #873
+// flagged that the WeightProcessor copy carried no σ-specific test.
+//
+// Centralising the constant + math here lets all three sites share one σ
+// value and lets the math be unit-tested directly.
+
+namespace SawPrediction {
+
+// Gaussian flow-similarity σ (ml/s) used when weighting past entries by how
+// close their training flow was to the current flow rate.
+constexpr double kFlowSimilaritySigma = 0.25;
+
+// Pre-computed 2σ² used in the exp(-x²/(2σ²)) kernel.
+constexpr double kFlowSimilaritySigmaSq2 =
+    2.0 * kFlowSimilaritySigma * kFlowSimilaritySigma;
+
+// Floor below which the weighted sum is considered untrustworthy (all entries
+// far from currentFlowRate). Caller falls back to a sensor-lag default.
+constexpr double kMinTotalWeight = 0.01;
+
+// Output clamp range (grams). Predictions outside this band are not credible
+// and are pinned to the nearest edge.
+constexpr double kMinDripPrediction = 0.5;
+constexpr double kMaxDripPrediction = 20.0;
+
+// Predict expected drip from past (drip, flow) pairs using a Gaussian
+// flow-similarity kernel and a linear recency weight.
+//
+// Inputs:
+//   drips, flows      Parallel vectors, recency-ordered (index 0 = newest).
+//                     Sizes must match.
+//   currentFlowRate   Current flow at the moment of prediction (ml/s).
+//   recencyMax        Recency weight for the newest entry.
+//   recencyMin        Recency weight for the oldest entry.
+//
+// Returns the clamped weighted-average drip in grams, or qQNaN() when the
+// total weight falls below kMinTotalWeight (every entry's flow is far from
+// currentFlowRate). Callers handle the NaN case by falling back to their
+// own sensor-lag default — fallback chains differ between sites.
+inline double weightedDripPrediction(const QVector<double>& drips,
+                                     const QVector<double>& flows,
+                                     double currentFlowRate,
+                                     double recencyMax,
+                                     double recencyMin)
+{
+    Q_ASSERT(drips.size() == flows.size());
+    const qsizetype count = drips.size();
+    if (count == 0) {
+        return qQNaN();
+    }
+
+    const qsizetype denom = qMax(qsizetype{1}, count - 1);
+    double weightedDripSum = 0.0;
+    double totalWeight = 0.0;
+
+    for (qsizetype i = 0; i < count; ++i) {
+        const double recencyWeight =
+            recencyMax - i * (recencyMax - recencyMin) / denom;
+        const double flowDiff = qAbs(flows[i] - currentFlowRate);
+        const double flowWeight =
+            qExp(-(flowDiff * flowDiff) / kFlowSimilaritySigmaSq2);
+        const double w = recencyWeight * flowWeight;
+        weightedDripSum += drips[i] * w;
+        totalWeight += w;
+    }
+
+    if (totalWeight < kMinTotalWeight) {
+        return qQNaN();
+    }
+    return qBound(kMinDripPrediction,
+                  weightedDripSum / totalWeight,
+                  kMaxDripPrediction);
+}
+
+}  // namespace SawPrediction

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -1,4 +1,5 @@
 #include "weightprocessor.h"
+#include "sawprediction.h"
 #include <QtMath>
 #include <QDebug>
 #include <chrono>
@@ -414,41 +415,30 @@ double WeightProcessor::computeLSLR(int windowMs) const
 double WeightProcessor::getExpectedDrip(double currentFlowRate) const
 {
     // Uses snapshot of SAW learning data taken at configure() time.
-    // Algorithm matches Settings::getExpectedDrip — weighted average with
-    // recency and flow-similarity weights.
+    // Math is shared with Settings::getExpectedDrip[For] via SawPrediction::
+    // weightedDripPrediction so σ and the kernel stay in lockstep.
     if (m_learningDrips.isEmpty()) {
         // No learning data — use scale-specific sensor lag as first-shot default.
         // Matches de1app: flow × (sensor_lag + 0.1s DE1 machine lag), capped at 8g.
         return qMin(currentFlowRate * (m_sensorLagSeconds + 0.1), 8.0);
     }
 
-    int maxEntries = m_sawConverged ? 12 : 8;
-    double recencyMax = 10.0;
-    double recencyMin = m_sawConverged ? 3.0 : 1.0;
+    const int maxEntries = m_sawConverged ? 12 : 8;
+    const double recencyMax = 10.0;
+    const double recencyMin = m_sawConverged ? 3.0 : 1.0;
 
-    qsizetype count = qMin(m_learningDrips.size(), static_cast<qsizetype>(maxEntries));
-    double weightedDripSum = 0;
-    double totalWeight = 0;
+    const qsizetype count =
+        qMin(m_learningDrips.size(), static_cast<qsizetype>(maxEntries));
+    QVector<double> drips = m_learningDrips.mid(0, count);
+    QVector<double> flows = m_learningFlows.mid(0, count);
 
-    for (qsizetype i = 0; i < count; ++i) {
-        double drip = m_learningDrips[i];
-        double flow = m_learningFlows[i];
+    const double prediction = SawPrediction::weightedDripPrediction(
+        drips, flows, currentFlowRate, recencyMax, recencyMin);
 
-        // Recency weight: linear interpolation from max to min
-        double recencyWeight = recencyMax - i * (recencyMax - recencyMin) / qMax(qsizetype(1), count - 1);
-
-        // Flow similarity: gaussian with sigma=0.25 ml/s
-        double flowDiff = qAbs(flow - currentFlowRate);
-        double flowWeight = qExp(-(flowDiff * flowDiff) / 0.125);  // sigma^2 * 2 = 0.125
-
-        double w = recencyWeight * flowWeight;
-        weightedDripSum += drip * w;
-        totalWeight += w;
+    if (qIsNaN(prediction)) {
+        // Total weight under the kMinTotalWeight floor → every entry's flow is
+        // far from currentFlowRate. Fall back to the sensor-lag default.
+        return qMin(currentFlowRate * (m_sensorLagSeconds + 0.1), 8.0);
     }
-
-    if (totalWeight < 0.01) {
-        return qMin(currentFlowRate * (m_sensorLagSeconds + 0.1), 8.0);  // All entries have very different flow rates
-    }
-
-    return qBound(0.5, weightedDripSum / totalWeight, 20.0);
+    return prediction;
 }

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -423,12 +423,11 @@ double WeightProcessor::getExpectedDrip(double currentFlowRate) const
         return qMin(currentFlowRate * (m_sensorLagSeconds + 0.1), 8.0);
     }
 
-    const int maxEntries = m_sawConverged ? 12 : 8;
+    const qsizetype maxEntries = m_sawConverged ? 12 : 8;
     const double recencyMax = 10.0;
     const double recencyMin = m_sawConverged ? 3.0 : 1.0;
 
-    const qsizetype count =
-        qMin(m_learningDrips.size(), static_cast<qsizetype>(maxEntries));
+    const qsizetype count = qMin(m_learningDrips.size(), maxEntries);
     QVector<double> drips = m_learningDrips.mid(0, count);
     QVector<double> flows = m_learningFlows.mid(0, count);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -322,6 +322,11 @@ add_decenza_test(tst_weightprocessor
     ${CMAKE_SOURCE_DIR}/src/machine/weightprocessor.cpp
 )
 
+# --- tst_sawprediction: shared SAW expected-drip kernel (σ + Gaussian math) ---
+add_decenza_test(tst_sawprediction
+    tst_sawprediction.cpp
+)
+
 # --- tst_saw: WeightProcessor SAW tests (minimal deps) ---
 add_decenza_test(tst_saw
     tst_saw.cpp

--- a/tests/tst_sawprediction.cpp
+++ b/tests/tst_sawprediction.cpp
@@ -1,0 +1,169 @@
+#include <QtTest>
+#include <QVector>
+#include <QtMath>
+
+#include "machine/sawprediction.h"
+
+// Direct unit tests for SawPrediction::weightedDripPrediction.
+//
+// The σ flow-similarity constant lives in this header and is consumed by
+// three sites: WeightProcessor::getExpectedDrip (live SAW threshold) and
+// Settings::getExpectedDrip[For] (post-shot learning feedback). Those sites
+// are exercised through their own integration tests, but the math itself
+// has no direct test — issue #873 flagged the WeightProcessor copy as a
+// hand-carried snapshot of the σ math with no σ-specific signal. These
+// tests pin the behaviour of the kernel directly so a future regression
+// (e.g. resetting σ to 1.5, or zeroing it) is caught at the unit level.
+
+class tst_SawPrediction : public QObject {
+    Q_OBJECT
+
+private slots:
+
+    // ===== σ constant lock-in =====
+
+    void sigmaConstantMatchesNarrowedValue() {
+        // PR #870 narrowed σ from 1.5 to 0.25 ml/s. Pin the value here so a
+        // careless edit is caught even before any kernel test runs.
+        QCOMPARE(SawPrediction::kFlowSimilaritySigma, 0.25);
+        QCOMPARE(SawPrediction::kFlowSimilaritySigmaSq2, 0.125);
+    }
+
+    // ===== flowDiff = 0 baseline =====
+
+    void zeroFlowDiffCollapsesToTrainingDrip() {
+        // When every entry's flow matches currentFlowRate exactly, flowWeight=1
+        // and the result is the recency-weighted average of the drips. With a
+        // constant drip the answer is just that drip — σ is invisible here.
+        QVector<double> drips = {2.0, 2.0, 2.0};
+        QVector<double> flows = {1.5, 1.5, 1.5};
+        const double pred = SawPrediction::weightedDripPrediction(
+            drips, flows, 1.5, 10.0, 3.0);
+        QVERIFY2(qAbs(pred - 2.0) < 1e-9,
+                 qPrintable(QString("expected 2.0, got %1").arg(pred)));
+    }
+
+    // ===== σ-narrow attenuation =====
+
+    void farFlowAttenuatesToNaNFallback() {
+        // Single entry trained at flow=1.5, queried at flow=2.5. flowDiff=1.0,
+        // flowWeight = exp(-1.0/0.125) = exp(-8) ≈ 3.4e-4. recencyWeight = 10.
+        // totalWeight ≈ 3.4e-3, below the 0.01 floor → kernel returns NaN so
+        // the caller falls back. This is the σ=0.25 signature: at σ=1.5
+        // (regression) flowWeight ≈ 0.80 and the kernel would return 2.0.
+        QVector<double> drips = {2.0};
+        QVector<double> flows = {1.5};
+        const double pred = SawPrediction::weightedDripPrediction(
+            drips, flows, 2.5, 10.0, 3.0);
+        QVERIFY2(qIsNaN(pred),
+                 qPrintable(QString("expected NaN fallback, got %1").arg(pred)));
+    }
+
+    void wideFlowSpreadSeparatesPredictions() {
+        // Two entries straddling the query flow. With σ=0.25 the off-flow
+        // entry is attenuated to ~exp(-32) ≈ 0 and the kernel locks onto the
+        // matching entry. At σ=1.5 the two would blend to ~mid-range.
+        QVector<double> drips = {0.6, 1.8};
+        QVector<double> flows = {1.0, 3.0};
+
+        const double low = SawPrediction::weightedDripPrediction(
+            drips, flows, 1.0, 10.0, 3.0);
+        const double high = SawPrediction::weightedDripPrediction(
+            drips, flows, 3.0, 10.0, 3.0);
+
+        QVERIFY2(qAbs(low - 0.6) < 0.05,
+                 qPrintable(QString("low query expected ~0.6, got %1").arg(low)));
+        QVERIFY2(qAbs(high - 1.8) < 0.05,
+                 qPrintable(QString("high query expected ~1.8, got %1").arg(high)));
+    }
+
+    // ===== Recency weighting =====
+
+    void recencyWeightingFavoursNewest() {
+        // Three entries at the same flow but different drips. The weighted
+        // average should pull toward the newest entry (index 0) because
+        // recencyMax > recencyMin.
+        QVector<double> drips = {1.0, 2.0, 3.0};   // newest is 1.0
+        QVector<double> flows = {1.5, 1.5, 1.5};
+
+        const double pred = SawPrediction::weightedDripPrediction(
+            drips, flows, 1.5, /*recencyMax=*/10.0, /*recencyMin=*/1.0);
+
+        // Pure mean would be 2.0. Recency-weighted with max=10/min=1 puts
+        // more weight on 1.0, so the result should sit below 2.0.
+        QVERIFY2(pred < 2.0,
+                 qPrintable(QString("recency should pull below mean 2.0, got %1").arg(pred)));
+        QVERIFY2(pred > 1.0,
+                 qPrintable(QString("recency should not collapse to newest, got %1").arg(pred)));
+    }
+
+    void uniformRecencyCollapsesToFlowWeightedMean() {
+        // recencyMax == recencyMin → recency drops out and the kernel reduces
+        // to a pure flow-weighted average. With identical flows and uniform
+        // recency the result is the unweighted mean of the drips.
+        QVector<double> drips = {1.0, 2.0, 3.0};
+        QVector<double> flows = {1.5, 1.5, 1.5};
+        const double pred = SawPrediction::weightedDripPrediction(
+            drips, flows, 1.5, /*recencyMax=*/5.0, /*recencyMin=*/5.0);
+        QVERIFY2(qAbs(pred - 2.0) < 1e-9,
+                 qPrintable(QString("expected mean 2.0, got %1").arg(pred)));
+    }
+
+    // ===== Single-entry edge =====
+
+    void singleEntryWithMatchingFlowReturnsThatDrip() {
+        // count-1 == 0 → recency denominator is clamped to 1, recencyWeight =
+        // recencyMax. flowWeight = 1 → result is the entry's drip (clamped).
+        QVector<double> drips = {1.4};
+        QVector<double> flows = {2.0};
+        const double pred = SawPrediction::weightedDripPrediction(
+            drips, flows, 2.0, 10.0, 3.0);
+        QVERIFY2(qAbs(pred - 1.4) < 1e-9,
+                 qPrintable(QString("expected 1.4, got %1").arg(pred)));
+    }
+
+    // ===== Empty input =====
+
+    void emptyInputReturnsNaN() {
+        QVector<double> drips;
+        QVector<double> flows;
+        const double pred = SawPrediction::weightedDripPrediction(
+            drips, flows, 2.0, 10.0, 3.0);
+        QVERIFY(qIsNaN(pred));
+    }
+
+    // ===== Output clamping =====
+
+    void resultClampedToMinDrip() {
+        QVector<double> drips = {0.1, 0.2};   // below 0.5 floor
+        QVector<double> flows = {1.5, 1.5};
+        const double pred = SawPrediction::weightedDripPrediction(
+            drips, flows, 1.5, 10.0, 3.0);
+        QCOMPARE(pred, SawPrediction::kMinDripPrediction);
+    }
+
+    void resultClampedToMaxDrip() {
+        QVector<double> drips = {25.0, 30.0};   // above 20.0 ceiling
+        QVector<double> flows = {1.5, 1.5};
+        const double pred = SawPrediction::weightedDripPrediction(
+            drips, flows, 1.5, 10.0, 3.0);
+        QCOMPARE(pred, SawPrediction::kMaxDripPrediction);
+    }
+
+    // ===== totalWeight floor — all entries far from query flow =====
+
+    void allEntriesFarFromQueryFlowReturnNaN() {
+        // Multiple entries all 2 ml/s away from the query → each flowWeight ≈
+        // exp(-32). Even with recencyMax=10 the totalWeight stays well under
+        // the 0.01 floor.
+        QVector<double> drips = {1.0, 2.0, 3.0};
+        QVector<double> flows = {0.5, 0.5, 0.5};
+        const double pred = SawPrediction::weightedDripPrediction(
+            drips, flows, 2.5, 10.0, 3.0);
+        QVERIFY2(qIsNaN(pred),
+                 qPrintable(QString("expected NaN, got %1").arg(pred)));
+    }
+};
+
+QTEST_GUILESS_MAIN(tst_SawPrediction)
+#include "tst_sawprediction.moc"

--- a/tests/tst_sawprediction.cpp
+++ b/tests/tst_sawprediction.cpp
@@ -132,6 +132,20 @@ private slots:
         QVERIFY(qIsNaN(pred));
     }
 
+    // ===== Mismatched sizes are a contract violation =====
+
+    void mismatchedVectorSizesReturnNaN() {
+        // Callers construct drips and flows in lockstep, but a refactor that
+        // accidentally drops one append would be silently undefined without
+        // a guard. The kernel returns NaN so the call site lands on its
+        // sensor-lag fallback rather than reading past the end of `flows`.
+        QVector<double> drips = {1.0, 2.0, 3.0};
+        QVector<double> flows = {1.5, 1.5};   // one short
+        const double pred = SawPrediction::weightedDripPrediction(
+            drips, flows, 1.5, 10.0, 3.0);
+        QVERIFY(qIsNaN(pred));
+    }
+
     // ===== Output clamping =====
 
     void resultClampedToMinDrip() {


### PR DESCRIPTION
## Summary
- Pulls the Gaussian flow-similarity + recency-weighted-average inner loop out of `WeightProcessor::getExpectedDrip` and both `Settings::getExpectedDrip[For]` sites into a shared header `src/machine/sawprediction.h`. All three call sites now route through `SawPrediction::weightedDripPrediction`, so the σ constant lives in exactly one place and the live SAW threshold can no longer drift away from the post-shot learning feedback.
- Adds `tests/tst_sawprediction.cpp` with the σ-specific direct coverage that was missing for the WeightProcessor copy (#873): σ value lock-in, zero-`flowDiff` collapse, far-flow attenuation to the NaN fallback, two-sided flow separation, recency weighting, single-entry edge, empty input, the `[0.5 g, 20 g]` output clamp.

## Why
Closes #873. PR #870 narrowed σ from 1.5 → 0.25 at all three sites, but only the `Settings` versions had σ-specific tests in `tst_saw_settings`. `WeightProcessor::getExpectedDrip` carried a hand-copied snapshot of the same math with no direct test, so a future merge or copy-paste regression at that one site would have silently desynced the live SAW threshold from the learning pool feedback. Centralising the kernel addresses both the lockstep risk (option #1 in the issue) and the testability gap (option #2) in one move.

## Test plan
- [x] `tst_sawprediction` — 13 new tests, all pass
- [x] `tst_weightprocessor` — 24 pass (no regressions)
- [x] `tst_saw` — 14 pass (no regressions)
- [x] `tst_saw_settings` — 17 pass (no regressions)
- [x] `tst_settings`, `tst_settling` — pass
- [x] Full Qt Creator test sweep: 1720 passed, 0 failed, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)