### PR TITLE
fix(ios): defer focus shift to dodge QIOSTapRecognizer dispatch_async race

### DIFF
--- a/qml/components/SuggestionField.qml
+++ b/qml/components/SuggestionField.qml
@@ -45,12 +45,21 @@ Item {
         // Don't set root.text directly - emit signal and let parent update via binding
         root.textEdited(selectedText)
         root.suggestionSelected(selectedText)
-        // forceActiveFocus on the container rather than just setting textInput.focus = false.
-        // Setting focus = false lets QML traverse the focus chain to the next item (another
-        // text field), which shows the keyboard again. Explicitly taking focus to the
-        // non-keyboard root Item stops that traversal.
-        root.forceActiveFocus()
-        Qt.inputMethod.hide()
+        // Defer focus shift + IME hide. Synchronously moving focus off a text
+        // field while a tap is mid-dispatch crashes on iOS — Qt's
+        // QIOSTapRecognizer.touchesEnded queues a dispatch_async block that
+        // reads _focusView on the next runloop pass; nil'ing it via
+        // setEnabled:NO between dispatch and execution segfaults inside
+        // showEditMenu(). See qtbase 6.10.3
+        // src/plugins/platforms/ios/qiostextinputoverlay.mm:982.
+        // Deferring lets the queued block run first against a still-valid view.
+        Qt.callLater(function() {
+            // forceActiveFocus on the container (a plain Item) instead of
+            // clearing textInput.focus, otherwise QML traverses to the next
+            // text field and the keyboard reappears.
+            root.forceActiveFocus()
+            Qt.inputMethod.hide()
+        })
     }
 
     // Close dialog when field becomes invisible (page popped, tab switched)
@@ -60,14 +69,17 @@ Item {
     function openSuggestionsDialog() {
         isActivelyTyping = false  // Show all suggestions
         suggestionPopup.close()   // Close typing popup before opening modal dialog
-        // Give focus to the non-keyboard container before the dialog opens.
-        // The Dialog saves the current activeFocusItem and restores it on close.
-        // If textInput still has focus here, the dialog would restore focus to it
-        // on close (showing the keyboard again). Moving focus to root (a plain Item)
-        // makes the dialog restore to a non-keyboard element instead.
-        root.forceActiveFocus()
-        Qt.inputMethod.hide()
-        suggestionsDialog.open()
+        // Defer focus shift + IME hide + dialog open. See selectSuggestion()
+        // for the iOS QIOSTapRecognizer race this works around.
+        Qt.callLater(function() {
+            // Give focus to the non-keyboard container before the dialog
+            // opens — Dialog restores activeFocusItem on close, and we don't
+            // want it to restore to textInput (which would re-show the
+            // keyboard).
+            root.forceActiveFocus()
+            Qt.inputMethod.hide()
+            suggestionsDialog.open()
+        })
     }
 
     // Track if user is actively typing (vs just focusing with existing text)

--- a/qml/components/SuggestionField.qml
+++ b/qml/components/SuggestionField.qml
@@ -50,7 +50,7 @@ Item {
         // QIOSTapRecognizer.touchesEnded queues a dispatch_async block that
         // reads _focusView on the next runloop pass; nil'ing it via
         // setEnabled:NO between dispatch and execution segfaults inside
-        // showEditMenu(). See qtbase 6.10.3
+        // showEditMenu(). See QTBUG-146020 and qtbase 6.10.3
         // src/plugins/platforms/ios/qiostextinputoverlay.mm:982.
         // Deferring lets the queued block run first against a still-valid view.
         Qt.callLater(function() {


### PR DESCRIPTION
## Summary

Fix iOS SIGSEGV crash inside Qt's `QIOSTapRecognizer` tap-dispatch block by deferring the focus-shift work in `SuggestionField.qml` with `Qt.callLater()`. Closes #871. Tracked upstream as [QTBUG-146020](https://bugreports.qt.io/browse/QTBUG-146020).

## What's going on

After symbolicating crashes #871 and #872 against the v1.7.1 dSYM, frame 3 was always `__-[QIOSTapRecognizer touchesEnded:withEvent:]_block_invoke`. Reading `qtbase/src/plugins/platforms/ios/qiostextinputoverlay.mm` (Qt 6.10.3) shows why:

`QIOSTapRecognizer::touchesEnded` (line 965) queues a block via `dispatch_async(dispatch_get_main_queue(), ^{ ... })` to show the iOS edit menu on the next runloop pass:
```objc
dispatch_async(dispatch_get_main_queue(), ^{
    if (_menuShouldBeVisible)
        showEditMenu(_focusView, touchPos.toPoint());   // ← reads self->_focusView lazily
    ...
});
```

But `setEnabled:NO` (line 915), called when focus leaves a text-editable item, **releases `_focusView` and sets it to nil**. And `showEditMenu`'s first line dereferences it without a nil check:
```objc
QWindow *qtWindow = quiview_cast(focusView).platformWindow->window();   // null deref → SIGSEGV
```

So the race is: user taps inside our QQuickWindow → `touchesEnded` queues the block → our QML tap handler synchronously calls `forceActiveFocus()` + `Qt.inputMethod.hide()`, moving focus off the text field → `_focusView = nil` → next runloop pass, the block fires and crashes.

This matches both user notes on the issue: "changing grinders / filling out shot information" and "pressing the up arrow next to coffee/grinder" both involve `SuggestionField` chevron taps that synchronously shift focus.

## What this PR does

Wraps the focus-shift work in `selectSuggestion()` and `openSuggestionsDialog()` in `Qt.callLater(...)` so the dispatch_async block runs first against a still-valid `_focusView`. Costs one event-loop tick per chevron tap or suggestion pick — imperceptible to users.

If Qt ships a fix for [QTBUG-146020](https://bugreports.qt.io/browse/QTBUG-146020) later, we'd just be redundantly deferring; no harm. Once the workaround can be removed, the comment in `SuggestionField.qml` points at the upstream bug.

## Test plan

- [ ] Build iOS release locally
- [ ] Sideload to an iOS 26.x device
- [ ] In `PostShotReviewPage`, repeatedly tap the chevron next to grinder/coffee fields, type, pick from the dropdown — confirm no crash
- [ ] Same flow with VoiceOver on (the `AccessibleMouseArea` path) — confirm no crash and announcements still fire
- [ ] Desktop / Android sanity: keyboard still hides correctly after picking a suggestion (Qt.callLater is a one-tick deferral, not a behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)