### PR TITLE
debug: trace logging for app-exit freeze (#877)

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1215,6 +1215,7 @@ void DE1Device::writeMMR(uint32_t address, uint32_t value,
 }
 
 void DE1Device::writeMMRUrgent(uint32_t address, uint32_t value, const QString& reason) {
+    qDebug() << "[shutdown trace] writeMMRUrgent: enter reason=" << reason;
     if (!m_transport) return;
 
     if (dropIfFirmwareFlashInProgress(address, value, reason, "write urgent")) {
@@ -1232,7 +1233,9 @@ void DE1Device::writeMMRUrgent(uint32_t address, uint32_t value, const QString& 
     // the cache so a subsequent non-urgent writeMMR with the same value
     // correctly dedups against what we just sent.
     m_lastMMRValues.insert(address, value);
+    qDebug() << "[shutdown trace] writeMMRUrgent: before transport->writeUrgent";
     m_transport->writeUrgent(DE1::Characteristic::WRITE_TO_MMR, buildMMRPayload(address, value));
+    qDebug() << "[shutdown trace] writeMMRUrgent: after transport->writeUrgent";
 }
 
 // ----- Firmware update (A009 / A006) -------------------------------------
@@ -1370,6 +1373,7 @@ void DE1Device::setUsbChargerOn(bool on, bool force) {
 }
 
 void DE1Device::setUsbChargerOnUrgent(bool on) {
+    qDebug() << "[shutdown trace] setUsbChargerOnUrgent: enter, transport=" << (m_transport ? "ok" : "null");
     if (!m_transport) {
         qWarning() << "DE1Device::setUsbChargerOnUrgent: no transport, cannot set charger" << (on ? "ON" : "OFF");
         return;
@@ -1378,10 +1382,13 @@ void DE1Device::setUsbChargerOnUrgent(bool on) {
     if (stateChanged) {
         m_usbChargerOn = on;
     }
+    qDebug() << "[shutdown trace] setUsbChargerOnUrgent: before writeMMRUrgent";
     writeMMRUrgent(DE1::MMR::USB_CHARGER, on ? 1 : 0,
                    QStringLiteral("setUsbChargerOnUrgent"));
+    qDebug() << "[shutdown trace] setUsbChargerOnUrgent: after writeMMRUrgent, stateChanged=" << stateChanged;
     if (stateChanged) {
         emit usbChargerOnChanged();
+        qDebug() << "[shutdown trace] setUsbChargerOnUrgent: after emit usbChargerOnChanged";
     }
 }
 

--- a/src/core/batterymanager.cpp
+++ b/src/core/batterymanager.cpp
@@ -471,7 +471,11 @@ void BatteryManager::ensureChargerOn() {
         // Use the urgent (queue-bypassing) path so the BLE write goes out immediately.
         // On iOS, the normal 50ms command queue could race with app suspension — by the
         // time the queued write fires, CoreBluetooth may have already been suspended.
+        qDebug() << "[shutdown trace] BM: before setUsbChargerOnUrgent";
         m_device->setUsbChargerOnUrgent(true);
+        qDebug() << "[shutdown trace] BM: after setUsbChargerOnUrgent";
+    } else {
+        qDebug() << "[shutdown trace] BM: skipped — device null or not connected";
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2236,23 +2236,28 @@ int main(int argc, char *argv[])
                 qWarning() << "BLE queue drain timed out after" << timeoutMs << "ms — sleep command may not have been delivered.";
         }
 
+        qDebug() << "[shutdown trace] before ensureChargerOn";
         // IMPORTANT: Ensure charger is ON before exiting
         // This matches de1app's app_exit behavior - always leave charger ON for safety
         batteryManager.ensureChargerOn();
+        qDebug() << "[shutdown trace] after ensureChargerOn";
 
         // Disconnect DE1 signals FIRST — otherwise de1Device.disconnect() below
         // fires the disconnected signal, which triggers the auto-reconnect lambda
         // and schedules a 5s QTimer. That timer stays alive through stack unwinding
         // and hangs the event dispatcher on Android when it tries to fire after teardown.
         QObject::disconnect(&de1Device, nullptr, nullptr, nullptr);
+        qDebug() << "[shutdown trace] after de1 wildcard disconnect";
 
         // Explicitly disconnect BLE so the GATT connection is released cleanly.
         // Without this, if the app is force-killed (e.g. after a hang), Android's
         // Bluetooth stack keeps the stale GATT connection — on Samsung devices this
         // can prevent the app from reconnecting until the device is rebooted.
         de1Device.disconnect();
+        qDebug() << "[shutdown trace] after de1Device.disconnect()";
         if (physicalScale) {
             physicalScale->disconnectFromScale();
+            qDebug() << "[shutdown trace] after physicalScale.disconnectFromScale()";
         }
 
         // Note: No need to null context properties here. All C++ objects are
@@ -2263,10 +2268,12 @@ int main(int argc, char *argv[])
         // This prevents iOS crash (SIGBUS) where the accessibility system tries to
         // sync with already-destroyed QML items during app exit
         QAccessible::setActive(false);
+        qDebug() << "[shutdown trace] after QAccessible::setActive(false)";
 
         // Shutdown accessibility to stop TTS before any other cleanup
         // This prevents race conditions with Android's hwuiTask thread
         accessibilityManager.shutdown();
+        qDebug() << "[shutdown trace] after accessibilityManager.shutdown()";
     });
 
     int result = app.exec();


### PR DESCRIPTION
## Summary
- Adds `[shutdown trace]` qDebug markers around every step of the `aboutToQuit` shutdown path so the next reproduction of #877 pinpoints exactly which call hangs.
- Instruments three layers: `main.cpp` (aboutToQuit), `BatteryManager::ensureChargerOn`, and `DE1Device::setUsbChargerOnUrgent` / `writeMMRUrgent`.
- No behavior change — diagnostics only.

## Why
[#877](https://github.com/Kulitorum/Decenza/issues/877): long-press sleep hangs the app on build 3326 (worked cleanly on 3318). The reporter's `debug.log` shows the last logged line in every failing session is `BatteryManager: Ensuring charger is ON (app exit/suspend safety)`. In the working-build sessions the next line is `[MMR] write urgent: 0x803854 = 1 [setUsbChargerOnUrgent]`, then the wildcard-disconnect WARN, etc. The freeze sits inside that small window but it spans BLE writes, signal disconnects, and the QAccessible/AccessibilityManager teardown — narrow enough to be worth instrumenting rather than guessing.

## Expected trace order on success
```
[shutdown trace] before ensureChargerOn
[shutdown trace] BM: before setUsbChargerOnUrgent
[shutdown trace] setUsbChargerOnUrgent: enter, transport= ok
[shutdown trace] setUsbChargerOnUrgent: before writeMMRUrgent
[shutdown trace] writeMMRUrgent: enter reason= "setUsbChargerOnUrgent"
[MMR] write urgent: 0x803854 = 1 [setUsbChargerOnUrgent]
[shutdown trace] writeMMRUrgent: before transport->writeUrgent
[shutdown trace] writeMMRUrgent: after transport->writeUrgent
[shutdown trace] setUsbChargerOnUrgent: after writeMMRUrgent, stateChanged= ...
[shutdown trace] BM: after setUsbChargerOnUrgent
[shutdown trace] after ensureChargerOn
[shutdown trace] after de1 wildcard disconnect
[shutdown trace] after de1Device.disconnect()
[shutdown trace] after physicalScale.disconnectFromScale()
[shutdown trace] after QAccessible::setActive(false)
[shutdown trace] after accessibilityManager.shutdown()
```
The first missing line in a failing log is the blocking call.

## Test plan
- [ ] Build locally and reproduce the long-press-sleep freeze
- [ ] Capture debug.log and identify the last `[shutdown trace]` line printed
- [ ] Open follow-up PR with the actual fix; revert this trace logging once the root cause is in main

🤖 Generated with [Claude Code](https://claude.com/claude-code)