### PR TITLE
debug: per-signal disconnect tracing for #877

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2246,8 +2246,43 @@ int main(int argc, char *argv[])
         // fires the disconnected signal, which triggers the auto-reconnect lambda
         // and schedules a 5s QTimer. That timer stays alive through stack unwinding
         // and hangs the event dispatcher on Android when it tries to fire after teardown.
+        //
+        // TEMP: split into per-signal disconnects to bisect a quit-time freeze (#877).
+        // Whichever signal name appears as the LAST "before" without an "after" is the
+        // one whose connection cleanup blocks. Once located, restore the wildcard or
+        // make a targeted fix.
+#define SD_TRACE_DISCONNECT(SIGNAL_PTR, NAME) \
+        do { \
+            qDebug() << "[shutdown trace] before disconnect" << NAME; \
+            QObject::disconnect(&de1Device, SIGNAL_PTR, nullptr, nullptr); \
+            qDebug() << "[shutdown trace] after disconnect" << NAME; \
+        } while (0)
+
+        SD_TRACE_DISCONNECT(&DE1Device::connectedChanged,        "connectedChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::connectingChanged,       "connectingChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::stateChanged,            "stateChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::subStateChanged,         "subStateChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::shotSampleReceived,      "shotSampleReceived");
+        SD_TRACE_DISCONNECT(&DE1Device::waterLevelChanged,       "waterLevelChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::firmwareVersionChanged,  "firmwareVersionChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::profileUploaded,         "profileUploaded");
+        SD_TRACE_DISCONNECT(&DE1Device::initialSettingsComplete, "initialSettingsComplete");
+        SD_TRACE_DISCONNECT(&DE1Device::errorOccurred,           "errorOccurred");
+        SD_TRACE_DISCONNECT(&DE1Device::simulationModeChanged,   "simulationModeChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::guiEnabledChanged,       "guiEnabledChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::usbChargerOnChanged,     "usbChargerOnChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::isHeadlessChanged,       "isHeadlessChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::refillKitDetectedChanged,"refillKitDetectedChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::heaterVoltageChanged,    "heaterVoltageChanged");
+        SD_TRACE_DISCONNECT(&DE1Device::fwMapResponse,           "fwMapResponse");
+        SD_TRACE_DISCONNECT(&DE1Device::shotSettingsReported,    "shotSettingsReported");
+        SD_TRACE_DISCONNECT(&DE1Device::logMessage,              "logMessage");
+
+        // Catch-all for any signals not enumerated above (e.g. base-class signals)
+        qDebug() << "[shutdown trace] before disconnect <wildcard tail>";
         QObject::disconnect(&de1Device, nullptr, nullptr, nullptr);
-        qDebug() << "[shutdown trace] after de1 wildcard disconnect";
+        qDebug() << "[shutdown trace] after disconnect <wildcard tail>";
+#undef SD_TRACE_DISCONNECT
 
         // Explicitly disconnect BLE so the GATT connection is released cleanly.
         // Without this, if the app is force-killed (e.g. after a hang), Android's


### PR DESCRIPTION
## Summary
- Replaces `QObject::disconnect(&de1Device, nullptr, nullptr, nullptr)` at main.cpp:2247 with one disconnect per signal, bracketed by `[shutdown trace] before/after disconnect <name>`.
- Adds a wildcard catch-all at the end for base-class / NOTIFY signals not enumerated.
- Diagnostics only — no behavior change unless the wildcard itself is the blocker (in which case we'll see exactly which signal hangs).

## Why
Prior trace (PR #879, build 3327) narrowed the #877 quit-freeze to that single wildcard call. Persisted log shows `[shutdown trace] after ensureChargerOn` at 10.273s then silence. `WebDebugLogger::handleMessage` writes to disk synchronously on the main thread, so the line ahead of the disconnect definitively returned. Reporter additionally confirms the freeze is hard — swiping the app does not kill it — which is consistent with the main thread blocked in connection cleanup against another thread (binder-backed BLE/Java slot is the prime suspect).

## Expected output
On success every "before disconnect <X>" gets a matching "after disconnect <X>". On reproduction, the **last "before" without a matching "after"** identifies the offending signal. The wildcard catch-all at the end covers anything not enumerated.

## Test plan
- [ ] Build locally and reproduce the long-press-sleep freeze on Decent tablet
- [ ] Capture debug.log and report the last-printed `[shutdown trace]` line
- [ ] Open targeted-fix PR once the offending signal is identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)