### PR TITLE
debug: trace destroyed/objectNameChanged disconnects (#877)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2278,7 +2278,13 @@ int main(int argc, char *argv[])
         SD_TRACE_DISCONNECT(&DE1Device::shotSettingsReported,    "shotSettingsReported");
         SD_TRACE_DISCONNECT(&DE1Device::logMessage,              "logMessage");
 
-        // Catch-all for any signals not enumerated above (e.g. base-class signals)
+        // Built-in QObject signals — last build's trace showed all 19 user
+        // signals disconnect cleanly and the wildcard tail hangs, so the
+        // offender is one of these (or some less-visible connection).
+        SD_TRACE_DISCONNECT(&QObject::destroyed,                 "destroyed");
+        SD_TRACE_DISCONNECT(&QObject::objectNameChanged,         "objectNameChanged");
+
+        // Final wildcard catch-all — anything not enumerated above.
         qDebug() << "[shutdown trace] before disconnect <wildcard tail>";
         QObject::disconnect(&de1Device, nullptr, nullptr, nullptr);
         qDebug() << "[shutdown trace] after disconnect <wildcard tail>";


### PR DESCRIPTION
## Summary
- Adds explicit `[shutdown trace]` brackets around disconnects of `QObject::destroyed` and `QObject::objectNameChanged` ahead of the wildcard tail.
- The wildcard tail remains as a final catch-all.
- Diagnostics only.

## Why
Build 3328 (PR #881) showed all 19 user-defined `DE1Device` signals disconnect cleanly:
```
[7.181] after disconnect logMessage
[7.184] before disconnect <wildcard tail>   ← FREEZE
```
That narrows the offender to a Qt-built-in signal (`destroyed`, `objectNameChanged`) or some less-visible connection (string-form `connect(...)`, QML `Connections` element, etc.). Tracing the two built-ins explicitly will identify the culprit if it's one of those; if neither blocks, the freeze is in something the per-signal pointer-form disconnects don't reach.

## Test plan
- [ ] Reproduce long-press-sleep freeze on Decent tablet, build 3329
- [ ] Report the last `[shutdown trace] before disconnect <X>` line in debug.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)