### PR TITLE
debug: Test A — remove destroyed/objectNameChanged disconnects (#877)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2278,13 +2278,10 @@ int main(int argc, char *argv[])
         SD_TRACE_DISCONNECT(&DE1Device::shotSettingsReported,    "shotSettingsReported");
         SD_TRACE_DISCONNECT(&DE1Device::logMessage,              "logMessage");
 
-        // Built-in QObject signals — last build's trace showed all 19 user
-        // signals disconnect cleanly and the wildcard tail hangs, so the
-        // offender is one of these (or some less-visible connection).
-        SD_TRACE_DISCONNECT(&QObject::destroyed,                 "destroyed");
-        SD_TRACE_DISCONNECT(&QObject::objectNameChanged,         "objectNameChanged");
-
-        // Final wildcard catch-all — anything not enumerated above.
+        // Test A (#877): remove the per-signal disconnects for destroyed/
+        // objectNameChanged that "fixed" the freeze in build 3329. If the
+        // wildcard tail freezes again here → those built-ins are the real
+        // culprit. If it stays clean → 3329's "fix" was timing/order luck.
         qDebug() << "[shutdown trace] before disconnect <wildcard tail>";
         QObject::disconnect(&de1Device, nullptr, nullptr, nullptr);
         qDebug() << "[shutdown trace] after disconnect <wildcard tail>";


### PR DESCRIPTION
## Summary
- Removes the explicit per-signal disconnects for `QObject::destroyed` and `QObject::objectNameChanged` added in PR #882.
- Leaves the 19 named signal disconnects and the trailing wildcard.
- Diagnostics only.

## Why
Build 3329 (PR #882) made the long-press-sleep freeze go away. Framed at the time as a "fix" but actually just a probe. Two equally consistent explanations remain on the table:

1. `destroyed` / `objectNameChanged` carried the connection that hangs the wildcard form (real cause).
2. The extra ~3ms of timing slack and two more log writes shifted the schedule enough to dodge a timing-sensitive deadlock (luck).

Test A removes the two built-in disconnects so the wildcard tail has to cover them again. Predicted outcomes:

- **Freeze returns at `before disconnect <wildcard tail>` →** confirms (1). Next step: enumerate connections on `destroyed` / `objectNameChanged` to find the offender.
- **Shutdown stays clean →** confirms (2). Next step: bisect by reordering or by adding/removing log lines to manipulate timing.

## Test plan
- [ ] Repro the long-press-sleep on Decent tablet, build 3330
- [ ] Check whether the wildcard tail completes
- [ ] Decide next probe based on outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)