### PR TITLE
debug: Test B — bisect destroyed vs objectNameChanged (#877)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2278,10 +2278,12 @@ int main(int argc, char *argv[])
         SD_TRACE_DISCONNECT(&DE1Device::shotSettingsReported,    "shotSettingsReported");
         SD_TRACE_DISCONNECT(&DE1Device::logMessage,              "logMessage");
 
-        // Test A (#877): remove the per-signal disconnects for destroyed/
-        // objectNameChanged that "fixed" the freeze in build 3329. If the
-        // wildcard tail freezes again here → those built-ins are the real
-        // culprit. If it stays clean → 3329's "fix" was timing/order luck.
+        // Test B (#877): Test A confirmed one of destroyed/objectNameChanged
+        // carries the offending connection. Bisect by adding back ONLY
+        // destroyed. If the wildcard tail still hangs → it's
+        // objectNameChanged. If it stays clean → it's destroyed.
+        SD_TRACE_DISCONNECT(&QObject::destroyed,                 "destroyed");
+
         qDebug() << "[shutdown trace] before disconnect <wildcard tail>";
         QObject::disconnect(&de1Device, nullptr, nullptr, nullptr);
         qDebug() << "[shutdown trace] after disconnect <wildcard tail>";


### PR DESCRIPTION
## Summary
- Adds back per-signal disconnect for `QObject::destroyed` only, keeps wildcard tail.
- Diagnostics only.

## Why
Test A confirmed: removing both `destroyed`/`objectNameChanged` disconnects brings the freeze back at the wildcard tail. So one of the two carries the offending connection. Test B bisects:

- **Wildcard tail still hangs →** `objectNameChanged` is the culprit.
- **Shutdown completes cleanly →** `destroyed` is the culprit.

Next step after this is grepping for whoever connects to that signal against `de1Device`, identifying the receiver, and shipping a targeted fix.

## Test plan
- [ ] Repro long-press-sleep on Decent tablet, build 3331
- [ ] Report whether the wildcard tail prints its `after` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)