### PR TITLE
fix(shutdown): targeted disconnect to dodge Qt wildcard-disconnect deadlock (#877)

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1215,7 +1215,6 @@ void DE1Device::writeMMR(uint32_t address, uint32_t value,
 }
 
 void DE1Device::writeMMRUrgent(uint32_t address, uint32_t value, const QString& reason) {
-    qDebug() << "[shutdown trace] writeMMRUrgent: enter reason=" << reason;
     if (!m_transport) return;
 
     if (dropIfFirmwareFlashInProgress(address, value, reason, "write urgent")) {
@@ -1233,9 +1232,7 @@ void DE1Device::writeMMRUrgent(uint32_t address, uint32_t value, const QString& 
     // the cache so a subsequent non-urgent writeMMR with the same value
     // correctly dedups against what we just sent.
     m_lastMMRValues.insert(address, value);
-    qDebug() << "[shutdown trace] writeMMRUrgent: before transport->writeUrgent";
     m_transport->writeUrgent(DE1::Characteristic::WRITE_TO_MMR, buildMMRPayload(address, value));
-    qDebug() << "[shutdown trace] writeMMRUrgent: after transport->writeUrgent";
 }
 
 // ----- Firmware update (A009 / A006) -------------------------------------
@@ -1373,7 +1370,6 @@ void DE1Device::setUsbChargerOn(bool on, bool force) {
 }
 
 void DE1Device::setUsbChargerOnUrgent(bool on) {
-    qDebug() << "[shutdown trace] setUsbChargerOnUrgent: enter, transport=" << (m_transport ? "ok" : "null");
     if (!m_transport) {
         qWarning() << "DE1Device::setUsbChargerOnUrgent: no transport, cannot set charger" << (on ? "ON" : "OFF");
         return;
@@ -1382,13 +1378,10 @@ void DE1Device::setUsbChargerOnUrgent(bool on) {
     if (stateChanged) {
         m_usbChargerOn = on;
     }
-    qDebug() << "[shutdown trace] setUsbChargerOnUrgent: before writeMMRUrgent";
     writeMMRUrgent(DE1::MMR::USB_CHARGER, on ? 1 : 0,
                    QStringLiteral("setUsbChargerOnUrgent"));
-    qDebug() << "[shutdown trace] setUsbChargerOnUrgent: after writeMMRUrgent, stateChanged=" << stateChanged;
     if (stateChanged) {
         emit usbChargerOnChanged();
-        qDebug() << "[shutdown trace] setUsbChargerOnUrgent: after emit usbChargerOnChanged";
     }
 }
 

--- a/src/core/batterymanager.cpp
+++ b/src/core/batterymanager.cpp
@@ -471,11 +471,7 @@ void BatteryManager::ensureChargerOn() {
         // Use the urgent (queue-bypassing) path so the BLE write goes out immediately.
         // On iOS, the normal 50ms command queue could race with app suspension — by the
         // time the queued write fires, CoreBluetooth may have already been suspended.
-        qDebug() << "[shutdown trace] BM: before setUsbChargerOnUrgent";
         m_device->setUsbChargerOnUrgent(true);
-        qDebug() << "[shutdown trace] BM: after setUsbChargerOnUrgent";
-    } else {
-        qDebug() << "[shutdown trace] BM: skipped — device null or not connected";
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2166,7 +2166,7 @@ int main(int argc, char *argv[])
     });
 
     // Cleanup on exit
-    QObject::connect(&app, &QCoreApplication::aboutToQuit, [&accessibilityManager, &batteryManager, &de1Device, &physicalScale, &engine, &weightThread, &relayClient]() {
+    QObject::connect(&app, &QCoreApplication::aboutToQuit, [&accessibilityManager, &batteryManager, &de1Device, &de1ReconnectTimer, &physicalScale, &engine, &weightThread, &relayClient]() {
         qDebug() << "Application exiting - shutting down devices";
 
         // Stop relay client and screen capture FIRST — the capture timer grabs
@@ -2236,68 +2236,35 @@ int main(int argc, char *argv[])
                 qWarning() << "BLE queue drain timed out after" << timeoutMs << "ms — sleep command may not have been delivered.";
         }
 
-        qDebug() << "[shutdown trace] before ensureChargerOn";
         // IMPORTANT: Ensure charger is ON before exiting
         // This matches de1app's app_exit behavior - always leave charger ON for safety
         batteryManager.ensureChargerOn();
-        qDebug() << "[shutdown trace] after ensureChargerOn";
 
-        // Disconnect DE1 signals FIRST — otherwise de1Device.disconnect() below
-        // fires the disconnected signal, which triggers the auto-reconnect lambda
-        // and schedules a 5s QTimer. That timer stays alive through stack unwinding
-        // and hangs the event dispatcher on Android when it tries to fire after teardown.
+        // Neutralize the auto-reconnect path before BLE disconnect, otherwise
+        // de1Device.disconnect() below fires connectedChanged, which triggers
+        // the auto-reconnect lambda and schedules a 5s QTimer. That timer
+        // stays alive through stack unwinding and hangs the event dispatcher
+        // on Android when it tries to fire after teardown.
         //
-        // TEMP: split into per-signal disconnects to bisect a quit-time freeze (#877).
-        // Whichever signal name appears as the LAST "before" without an "after" is the
-        // one whose connection cleanup blocks. Once located, restore the wildcard or
-        // make a targeted fix.
-#define SD_TRACE_DISCONNECT(SIGNAL_PTR, NAME) \
-        do { \
-            qDebug() << "[shutdown trace] before disconnect" << NAME; \
-            QObject::disconnect(&de1Device, SIGNAL_PTR, nullptr, nullptr); \
-            qDebug() << "[shutdown trace] after disconnect" << NAME; \
-        } while (0)
-
-        SD_TRACE_DISCONNECT(&DE1Device::connectedChanged,        "connectedChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::connectingChanged,       "connectingChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::stateChanged,            "stateChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::subStateChanged,         "subStateChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::shotSampleReceived,      "shotSampleReceived");
-        SD_TRACE_DISCONNECT(&DE1Device::waterLevelChanged,       "waterLevelChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::firmwareVersionChanged,  "firmwareVersionChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::profileUploaded,         "profileUploaded");
-        SD_TRACE_DISCONNECT(&DE1Device::initialSettingsComplete, "initialSettingsComplete");
-        SD_TRACE_DISCONNECT(&DE1Device::errorOccurred,           "errorOccurred");
-        SD_TRACE_DISCONNECT(&DE1Device::simulationModeChanged,   "simulationModeChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::guiEnabledChanged,       "guiEnabledChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::usbChargerOnChanged,     "usbChargerOnChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::isHeadlessChanged,       "isHeadlessChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::refillKitDetectedChanged,"refillKitDetectedChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::heaterVoltageChanged,    "heaterVoltageChanged");
-        SD_TRACE_DISCONNECT(&DE1Device::fwMapResponse,           "fwMapResponse");
-        SD_TRACE_DISCONNECT(&DE1Device::shotSettingsReported,    "shotSettingsReported");
-        SD_TRACE_DISCONNECT(&DE1Device::logMessage,              "logMessage");
-
-        // Test B (#877): Test A confirmed one of destroyed/objectNameChanged
-        // carries the offending connection. Bisect by adding back ONLY
-        // destroyed. If the wildcard tail still hangs → it's
-        // objectNameChanged. If it stays clean → it's destroyed.
-        SD_TRACE_DISCONNECT(&QObject::destroyed,                 "destroyed");
-
-        qDebug() << "[shutdown trace] before disconnect <wildcard tail>";
-        QObject::disconnect(&de1Device, nullptr, nullptr, nullptr);
-        qDebug() << "[shutdown trace] after disconnect <wildcard tail>";
-#undef SD_TRACE_DISCONNECT
+        // Stop the timer first (belt) and disconnect only connectedChanged
+        // (suspenders). Do NOT use the wildcard form
+        // QObject::disconnect(&de1Device, nullptr, nullptr, nullptr) here:
+        // de1Device is exposed to QML via setContextProperty, so QQmlEngine
+        // holds an internal connection on de1Device::destroyed for lifetime
+        // tracking. The wildcard disconnect form acquires receiver locks in
+        // a different order than the per-signal pointer form, and on Android
+        // shutdown that contends with the QML engine and hard-deadlocks the
+        // main thread (#877). The per-signal form has no such problem.
+        de1ReconnectTimer.stop();
+        QObject::disconnect(&de1Device, &DE1Device::connectedChanged, nullptr, nullptr);
 
         // Explicitly disconnect BLE so the GATT connection is released cleanly.
         // Without this, if the app is force-killed (e.g. after a hang), Android's
         // Bluetooth stack keeps the stale GATT connection — on Samsung devices this
         // can prevent the app from reconnecting until the device is rebooted.
         de1Device.disconnect();
-        qDebug() << "[shutdown trace] after de1Device.disconnect()";
         if (physicalScale) {
             physicalScale->disconnectFromScale();
-            qDebug() << "[shutdown trace] after physicalScale.disconnectFromScale()";
         }
 
         // Note: No need to null context properties here. All C++ objects are
@@ -2308,12 +2275,10 @@ int main(int argc, char *argv[])
         // This prevents iOS crash (SIGBUS) where the accessibility system tries to
         // sync with already-destroyed QML items during app exit
         QAccessible::setActive(false);
-        qDebug() << "[shutdown trace] after QAccessible::setActive(false)";
 
         // Shutdown accessibility to stop TTS before any other cleanup
         // This prevents race conditions with Android's hwuiTask thread
         accessibilityManager.shutdown();
-        qDebug() << "[shutdown trace] after accessibilityManager.shutdown()";
     });
 
     int result = app.exec();


### PR DESCRIPTION
## Summary
- Replaces the wildcard `QObject::disconnect(&de1Device, nullptr, nullptr, nullptr)` in the `aboutToQuit` handler with a targeted disconnect of just `DE1Device::connectedChanged`.
- Adds `de1ReconnectTimer.stop()` for belt-and-suspenders so the lambda can't restart the reconnect timer even if it runs during teardown.
- Removes all the trace logging added across builds 3327–3331 while bisecting this.

## Root cause
`de1Device` is exposed to QML via `setContextProperty("DE1Device", &de1Device)` (main.cpp:1559, 1820). `QQmlEngine` internally connects to a QObject's `destroyed()` signal for lifetime tracking on context-property bindings.

The wildcard `QObject::disconnect(sender, nullptr, nullptr, nullptr)` walks every connection on the sender and acquires each receiver's mutex while doing so. On Android shutdown that walk contends with the QQmlEngine's internal locking and hard-deadlocks the main thread (process unkillable by swipe). The per-signal pointer-form disconnect walks the same connection through a different lock-acquisition order and doesn't deadlock.

## How we got here (bisect via trace logging)
| Build | Change | Result |
|-------|--------|--------|
| 3326 (v1.7.2) | original | freezes |
| 3327 | trace before/after each shutdown step | freeze inside `QObject::disconnect(...)` wildcard |
| 3328 | split wildcard into 19 per-signal disconnects + tail wildcard | 19 clean, tail wildcard freezes |
| 3329 | added per-signal `destroyed` + `objectNameChanged` before tail | clean |
| 3330 (Test A) | removed those two | freeze returns at tail wildcard |
| 3331 (Test B) | added back only `destroyed` | clean ⇒ `destroyed` is the offending signal (the QQmlEngine connection) |

## What we don't know
Why this started reproducing between v1.7.1 (build 3318, worked) and v1.7.2 (3326+, broke). Nothing in that diff obviously changed how `de1Device` is exposed to QML or how shutdown runs. Most likely something increased the frequency of QML-internal activity at quit-time, tipping a previously-rare race into reliable repro. Not load-bearing for the fix.

## Test plan
- [ ] Repro long-press-sleep with this build on Decent tablet — must complete without freeze
- [ ] Quit via task switcher — must complete without freeze
- [ ] After quit, verify charger remains ON (no charger-off regression)
- [ ] Reopen app — DE1 reconnects normally (no reconnect-timer regression)

Closes #877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)