### PR TITLE
fix(analysis): compare frame-0 actual to configured seconds, not hard 2 s

### DIFF
--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -484,7 +484,8 @@ bool ShotAnalysis::detectPourTruncated(const QVector<QPointF>& pressure,
 }
 
 bool ShotAnalysis::detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
-                                        int expectedFrameCount)
+                                        int expectedFrameCount,
+                                        double firstFrameConfiguredSeconds)
 {
     if (phases.isEmpty())
         return false;
@@ -493,13 +494,13 @@ bool ShotAnalysis::detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
         return false;
 
     // Decenza inserts a synthetic "Start" marker at extraction start before any
-    // real frame-change markers. Ignore it so we can mirror the de1app plugin's
-    // "did we ever see frame 0 before a non-zero frame in the first 2 seconds?"
-    // behavior against saved history.
+    // real frame-change markers. Ignore it so we can track "did we ever see
+    // frame 0 before a non-zero frame?" against saved history.
     qsizetype firstRealMarker = 0;
     if (phases.first().label == QStringLiteral("Start") && phases.first().frameNumber == 0)
         firstRealMarker = 1;
 
+    bool sawFrameZero = false;
     for (qsizetype i = firstRealMarker; i < phases.size(); ++i) {
         const HistoryPhaseMarker& phase = phases[i];
         if (phase.frameNumber < 0)
@@ -507,18 +508,31 @@ bool ShotAnalysis::detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
         if (expectedFrameCount >= 0 && phase.frameNumber >= expectedFrameCount)
             continue;
 
-        if (phase.frameNumber == 0)
+        if (phase.frameNumber == 0) {
+            sawFrameZero = true;
             continue;
+        }
 
-        // Match the Tcl plugin's detection window: only classify transitions that
-        // happen in the first 2 seconds of extraction.
-        if (phase.time >= 2.0)
-            return false;
+        // FW-bug branch: frame 0 was never observed before a non-zero frame.
+        // Mirror the de1app Tcl plugin's hard 2 s window — that plugin polls
+        // during extraction and can only catch it before t=2 s, so for parity
+        // we only flag here within that same window.
+        if (!sawFrameZero)
+            return phase.time < 2.0;
 
-        // Non-zero frame inside the 2-second window — flag the shot. Both the
-        // firmware bug (frame 0 never seen) and the short-first-step case
-        // (frame 0 briefly seen, then jumped away) share this badge intentionally.
-        return true;
+        // Short-first-step branch: frame 0 was observed; judge whether it
+        // ran long enough. The de1app Tcl plugin uses a hard 2 s wall, which
+        // false-positives on profiles configured with frame[0].seconds == 2
+        // because BLE notification jitter routinely lands the frame-1 marker
+        // a few hundred ms early. When the configured first-frame duration
+        // is known, compare against half of configured (capped at 2 s) so a
+        // 1.87 s actual on a 2 s configured frame — 94 % of plan — does not
+        // flag.
+        double cutoff = 2.0;
+        if (firstFrameConfiguredSeconds > 0.0)
+            cutoff = std::min(2.0, 0.5 * firstFrameConfiguredSeconds);
+
+        return phase.time < cutoff;
     }
 
     return false;
@@ -535,7 +549,8 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
                                              double duration,
                                              const QVector<QPointF>& pressureGoal,
                                              const QVector<QPointF>& flowGoal,
-                                             const QStringList& analysisFlags)
+                                             const QStringList& analysisFlags,
+                                             double firstFrameConfiguredSeconds)
 {
     QVariantList lines;
 
@@ -689,9 +704,12 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
 
     // --- Skip-first-frame ---
     // Re-derive from phase markers (already available) so generateSummary() does not
-    // need a separate skipFirstFrameDetected parameter. Mirrors the Tcl plugin: FW bug
-    // (machine never executed frame 0) or profile first step too short (< 2 s).
-    const bool skipFirstFrame = detectSkipFirstFrame(phases);
+    // need a separate skipFirstFrameDetected parameter. Catches FW bug (machine
+    // never executed frame 0) or profile first step running far shorter than
+    // configured. firstFrameConfiguredSeconds (when known) avoids false-positives
+    // on profiles with frame[0].seconds == 2.
+    const bool skipFirstFrame = detectSkipFirstFrame(
+        phases, /*expectedFrameCount=*/-1, firstFrameConfiguredSeconds);
     if (skipFirstFrame) {
         QVariantMap line;
         line["text"] = QStringLiteral("First profile step skipped \u2014 "

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -217,19 +217,22 @@ public:
                                      double pourStart, double pourEnd,
                                      const QString& beverageType = {});
 
-    // Returns true if the shot appears to have skipped profile frame 0, indicating
-    // either a known DE1 firmware bug (machine started at frame 1+) or a profile
-    // whose first step ran far shorter than configured. Ignores the synthetic
-    // "Start" marker, then inspects real frame markers. expectedFrameCount is
-    // optional; when known, values less than 2 suppress detection (no second
-    // frame to skip to), and out-of-range frame numbers are ignored as malformed
-    // data. firstFrameConfiguredSeconds is the value of profile.steps[0].seconds;
-    // when known (> 0) the actual frame-0 duration is judged against half of
-    // configured (capped at 2 s) so profiles with frame[0].seconds == 2 do not
-    // false-positive on normal sub-frame BLE jitter. When unknown (<= 0 or -1)
-    // falls back to the de1app plugin's hard 2 s window. The firmware bug
-    // requires a full power-cycle of the machine to fix. Returns false when
-    // phases is empty (insufficient data).
+    // Returns true if the shot appears to have skipped profile frame 0. Two
+    // distinct branches:
+    //   - FW-bug: frame 0 was never observed before a non-zero frame. Always
+    //     uses the de1app plugin's hard 2 s window (parity with the polling
+    //     Tcl plugin); firstFrameConfiguredSeconds is ignored here because the
+    //     machine never executed frame 0 at all, so the configured duration
+    //     is irrelevant.
+    //   - Short-first-step: frame 0 was observed but ended early. Cutoff is
+    //     min(2.0, 0.5 * firstFrameConfiguredSeconds) when configured > 0, else
+    //     a hard 2 s window. The configured-aware path avoids false-positives
+    //     on profiles with frame[0].seconds == 2 where normal sub-frame BLE
+    //     jitter routinely lands the frame-1 marker just under 2 s.
+    // expectedFrameCount is optional; when known, values < 2 suppress detection
+    // (no second frame to skip to) and out-of-range frame numbers are treated
+    // as malformed data. The FW-bug case requires a full power-cycle to fix.
+    // Returns false when phases is empty.
     static bool detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
                                      int expectedFrameCount = -1,
                                      double firstFrameConfiguredSeconds = -1.0);

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -219,16 +219,20 @@ public:
 
     // Returns true if the shot appears to have skipped profile frame 0, indicating
     // either a known DE1 firmware bug (machine started at frame 1+) or a profile
-    // whose first step is so short (< 2 s) it was never meaningfully executed.
-    // Mirrors the de1app plugin semantics against Decenza's saved phase markers:
-    // ignore the synthetic "Start" marker, then inspect real frame markers only
-    // within the first 2 seconds of extraction. expectedFrameCount is optional;
-    // when known, values less than 2 suppress detection (there is no second frame
-    // to skip to), and out-of-range frame numbers are ignored as malformed data.
-    // The firmware bug requires a full power-cycle of the machine to fix.
-    // Returns false when phases is empty (insufficient data).
+    // whose first step ran far shorter than configured. Ignores the synthetic
+    // "Start" marker, then inspects real frame markers. expectedFrameCount is
+    // optional; when known, values less than 2 suppress detection (no second
+    // frame to skip to), and out-of-range frame numbers are ignored as malformed
+    // data. firstFrameConfiguredSeconds is the value of profile.steps[0].seconds;
+    // when known (> 0) the actual frame-0 duration is judged against half of
+    // configured (capped at 2 s) so profiles with frame[0].seconds == 2 do not
+    // false-positive on normal sub-frame BLE jitter. When unknown (<= 0 or -1)
+    // falls back to the de1app plugin's hard 2 s window. The firmware bug
+    // requires a full power-cycle of the machine to fix. Returns false when
+    // phases is empty (insufficient data).
     static bool detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
-                                     int expectedFrameCount = -1);
+                                     int expectedFrameCount = -1,
+                                     double firstFrameConfiguredSeconds = -1.0);
 
     // Generate a concise shot summary from curve data. Returns a list of
     // noteworthy observations + a verdict. Used by ShotAnalysisDialog.qml.
@@ -247,5 +251,6 @@ public:
                                          double duration,
                                          const QVector<QPointF>& pressureGoal = {},
                                          const QVector<QPointF>& flowGoal = {},
-                                         const QStringList& analysisFlags = {});
+                                         const QStringList& analysisFlags = {},
+                                         double firstFrameConfiguredSeconds = -1.0);
 };

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -32,34 +32,27 @@ static bool use12h() {
     return val;
 }
 
-static int expectedFrameCountFromProfileJson(const QString& profileJson)
+struct ProfileFrameInfo {
+    int frameCount = -1;
+    double firstFrameSeconds = -1.0;
+};
+
+static ProfileFrameInfo profileFrameInfoFromJson(const QString& profileJson)
 {
     if (profileJson.isEmpty())
-        return -1;
+        return {};
 
     QJsonParseError parseError;
     const QJsonDocument doc = QJsonDocument::fromJson(profileJson.toUtf8(), &parseError);
     if (parseError.error != QJsonParseError::NoError || !doc.isObject())
-        return -1;
+        return {};
 
     const Profile profile = Profile::fromJson(doc);
-    return static_cast<int>(profile.steps().size());
-}
-
-static double firstFrameSecondsFromProfileJson(const QString& profileJson)
-{
-    if (profileJson.isEmpty())
-        return -1.0;
-
-    QJsonParseError parseError;
-    const QJsonDocument doc = QJsonDocument::fromJson(profileJson.toUtf8(), &parseError);
-    if (parseError.error != QJsonParseError::NoError || !doc.isObject())
-        return -1.0;
-
-    const Profile profile = Profile::fromJson(doc);
-    if (profile.steps().isEmpty())
-        return -1.0;
-    return profile.steps().first().seconds;
+    ProfileFrameInfo info;
+    info.frameCount = static_cast<int>(profile.steps().size());
+    if (!profile.steps().isEmpty())
+        info.firstFrameSeconds = profile.steps().first().seconds;
+    return info;
 }
 
 const QString ShotHistoryStorage::DB_CONNECTION_NAME = "ShotHistoryConnection";
@@ -1791,10 +1784,9 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
             }
 
             // Skip-first-frame detection from phase markers
+            const ProfileFrameInfo info = profileFrameInfoFromJson(record.profileJson);
             newSkipFirstFrame = ShotAnalysis::detectSkipFirstFrame(
-                record.phases,
-                expectedFrameCountFromProfileJson(record.profileJson),
-                firstFrameSecondsFromProfileJson(record.profileJson));
+                record.phases, info.frameCount, info.firstFrameSeconds);
 
             // Update DB only if any flag changed
             flagsChanged = (newChanneling != record.channelingDetected
@@ -2295,10 +2287,9 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     // Like grind detection, this needs no derived curves, so it covers all shot
     // eras including shots predating migration 12 that have skip_first_frame_detected = 0 (DEFAULT).
     if (!record.phases.isEmpty()) {
+        const ProfileFrameInfo info = profileFrameInfoFromJson(record.profileJson);
         record.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(
-            record.phases,
-            expectedFrameCountFromProfileJson(record.profileJson),
-            firstFrameSecondsFromProfileJson(record.profileJson));
+            record.phases, info.frameCount, info.firstFrameSeconds);
     }
 
     return record;
@@ -2348,7 +2339,7 @@ QVariantList ShotHistoryStorage::generateShotSummary(const QVariantMap& shotData
         shotData["beverageType"].toString(),
         shotData["duration"].toDouble(),
         pressureGoal, flowGoal, analysisFlags,
-        firstFrameSecondsFromProfileJson(shotData["profileJson"].toString()));
+        profileFrameInfoFromJson(shotData["profileJson"].toString()).firstFrameSeconds);
 }
 
 GrinderContext ShotHistoryStorage::queryGrinderContext(QSqlDatabase& db,

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -46,6 +46,22 @@ static int expectedFrameCountFromProfileJson(const QString& profileJson)
     return static_cast<int>(profile.steps().size());
 }
 
+static double firstFrameSecondsFromProfileJson(const QString& profileJson)
+{
+    if (profileJson.isEmpty())
+        return -1.0;
+
+    QJsonParseError parseError;
+    const QJsonDocument doc = QJsonDocument::fromJson(profileJson.toUtf8(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject())
+        return -1.0;
+
+    const Profile profile = Profile::fromJson(doc);
+    if (profile.steps().isEmpty())
+        return -1.0;
+    return profile.steps().first().seconds;
+}
+
 const QString ShotHistoryStorage::DB_CONNECTION_NAME = "ShotHistoryConnection";
 
 ShotHistoryStorage::ShotHistoryStorage(QObject* parent)
@@ -967,11 +983,16 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
                 ShotSummarizer::getAnalysisFlags(data.profileKbId));
         }
 
-        // Skip-first-frame detection: check whether frame 0 was absent or very short,
-        // indicating a known DE1 firmware bug or a misconfigured profile first step.
+        // Skip-first-frame detection: check whether frame 0 was absent or ran
+        // far shorter than configured, indicating a known DE1 firmware bug or
+        // a misconfigured profile first step.
+        const double firstFrameSec = (profile && !profile->steps().isEmpty())
+            ? profile->steps().first().seconds
+            : -1.0;
         data.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(
             tmpRecord.phases,
-            profile ? static_cast<int>(profile->steps().size()) : -1);
+            profile ? static_cast<int>(profile->steps().size()) : -1,
+            firstFrameSec);
     }
 
     // Compress sample data on main thread (reads QObject data vectors)
@@ -1772,7 +1793,8 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
             // Skip-first-frame detection from phase markers
             newSkipFirstFrame = ShotAnalysis::detectSkipFirstFrame(
                 record.phases,
-                expectedFrameCountFromProfileJson(record.profileJson));
+                expectedFrameCountFromProfileJson(record.profileJson),
+                firstFrameSecondsFromProfileJson(record.profileJson));
 
             // Update DB only if any flag changed
             flagsChanged = (newChanneling != record.channelingDetected
@@ -2275,7 +2297,8 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     if (!record.phases.isEmpty()) {
         record.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(
             record.phases,
-            expectedFrameCountFromProfileJson(record.profileJson));
+            expectedFrameCountFromProfileJson(record.profileJson),
+            firstFrameSecondsFromProfileJson(record.profileJson));
     }
 
     return record;
@@ -2324,7 +2347,8 @@ QVariantList ShotHistoryStorage::generateShotSummary(const QVariantMap& shotData
         conductanceDerivative, phases,
         shotData["beverageType"].toString(),
         shotData["duration"].toDouble(),
-        pressureGoal, flowGoal, analysisFlags);
+        pressureGoal, flowGoal, analysisFlags,
+        firstFrameSecondsFromProfileJson(shotData["profileJson"].toString()));
 }
 
 GrinderContext ShotHistoryStorage::queryGrinderContext(QSqlDatabase& db,

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -58,6 +58,16 @@ private:
         QCOMPARE(ShotAnalysis::detectSkipFirstFrame(phases, expectedFrameCount), expected);
     }
 
+    static void expectSkipDetection(const QList<HistoryPhaseMarker>& phases,
+                                    int expectedFrameCount,
+                                    double firstFrameConfiguredSeconds,
+                                    bool expected)
+    {
+        QCOMPARE(ShotAnalysis::detectSkipFirstFrame(phases, expectedFrameCount,
+                                                     firstFrameConfiguredSeconds),
+                 expected);
+    }
+
 private slots:
     void skipFirstFrameDetection()
     {
@@ -107,6 +117,63 @@ private slots:
         expectSkipDetection({
             phase(0.0, "Pour", 1),
         }, -1, true);
+
+        // --- Configured-first-frame-seconds path (option 1 fix) ---
+
+        // 80's Espresso shot 889 regression: profile configures frame[0].seconds = 2,
+        // BLE jitter delivers the frame-1 marker at 1.872 s (94 % of plan). The
+        // legacy hard 2 s window flagged this; with configured seconds known
+        // the cutoff is min(2.0, 0.5*2.0) = 1.0 s, so 1.872 must NOT flag.
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "preinfusion start", 0),
+            phase(1.872, "preinfusion", 1),
+        }, 4, /*firstFrameConfiguredSeconds=*/2.0, false);
+
+        // Same profile, frame 0 actually skipped (e.g., transition at 0.3 s):
+        // 0.3 < 1.0 s cutoff → flag.
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "preinfusion start", 0),
+            phase(0.3, "preinfusion", 1),
+        }, 4, /*firstFrameConfiguredSeconds=*/2.0, true);
+
+        // Profile with a deliberately short first step (0.5 s configured): a
+        // 0.4 s actual is 80 % of plan, not "skipped" — must NOT flag.
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "Fill", 0),
+            phase(0.4, "Pour", 1),
+        }, 3, /*firstFrameConfiguredSeconds=*/0.5, false);
+
+        // Same short-first-step profile but actual is even shorter (0.2 s on
+        // a 0.5 s plan = 40 %): cutoff = 0.25 s, 0.2 < 0.25 → flag.
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "Fill", 0),
+            phase(0.2, "Pour", 1),
+        }, 3, /*firstFrameConfiguredSeconds=*/0.5, true);
+
+        // Long configured first frame (4 s): cutoff capped at 2 s. A 2.5 s
+        // actual (early exit, e.g., pressure-over) → no flag.
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "Fill", 0),
+            phase(2.5, "Pour", 1),
+        }, 3, /*firstFrameConfiguredSeconds=*/4.0, false);
+
+        // Long configured first frame, actual under the 2 s cap → flag.
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "Fill", 0),
+            phase(1.5, "Pour", 1),
+        }, 3, /*firstFrameConfiguredSeconds=*/4.0, true);
+
+        // Firmware bug (no frame 0 marker) still flags regardless of
+        // configured seconds — frame 0 was genuinely never executed.
+        expectSkipDetection({
+            phase(0.0, "Pour", 1),
+        }, 3, /*firstFrameConfiguredSeconds=*/2.0, true);
     }
 
     // buildChannelingWindows ---------------------------------------------


### PR DESCRIPTION
## Summary
- The `skipFirstFrame` detector mirrored the de1app Tcl plugin's hard `< 2 s` window, which false-positives on every profile that configures `frame[0].seconds = 2` (e.g. **80's Espresso**) — normal sub-frame BLE jitter routinely lands the frame-1 marker around 1.85–1.95 s, well within the legacy window.
- When the profile is known, judge actual frame-0 duration against `min(2.0, 0.5 * configuredSeconds)`. A 1.87 s actual on a 2 s plan (94 % of configured) no longer flags; an honest skip on the same profile (e.g. 0.3 s actual) still does.
- The FW-bug branch (frame 0 never observed) keeps the hard 2 s window for de1app parity.
- Existing badges are re-derived from phase markers on record load, so false flags on legacy shots drop off automatically.

## Test plan
- [x] `tst_ShotAnalysis::skipFirstFrameDetection` — extended with 6 new cases covering the configured-seconds path (regression case 1.872 s on 2 s plan, real skip on same profile, deliberately short profile both directions, long-frame cap above and below, FW bug with known profile)
- [x] Full test suite green (1735 passed, 0 failed, 0 warnings)
- [ ] Spot-check on Jeff's machine: shot 889 should drop the "First profile step skipped" verdict next time the analysis dialog re-derives badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)