### PR TITLE
docs: replace SHOT_REVIEW_IMPROVEMENTS.md with SHOT_REVIEW.md (current-state badge + summary reference)

### DIFF
--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -1,10 +1,11 @@
 # Shot Review: Current State
 
 This is a snapshot of how the post-shot review and shot detail pages work today,
-focused on the quality-badge / detector system that has accumulated several rounds
-of refinement. It is the source of truth for anyone modifying detectors, persistence,
-or the badge UI; the `git log` for `docs/SHOT_REVIEW_IMPROVEMENTS.md` is the source
-of truth for the path that got us here.
+focused on the quality-badge / detector system and the Shot Summary dialog that
+share the same underlying analysis. It is the source of truth for anyone modifying
+detectors, persistence, the badge UI, or the summary text; the `git log` for
+`docs/SHOT_REVIEW.md` (and its prior name `SHOT_REVIEW_IMPROVEMENTS.md`) is the
+source of truth for the path that got us here.
 
 The detectors are still under active iteration — expect this doc to drift, and
 prefer reading the code (`src/ai/shotanalysis.h` is heavily commented) when in
@@ -43,7 +44,9 @@ shared `shotReview/advancedMode` setting toggles information density on both.
 
 Four independent flags, surfaced via `qml/components/QualityBadges.qml`. When
 any fire, those chips show; when none fire, a single green "Clean extraction"
-chip shows. None of the chips suppress the others.
+chip shows. None of the chips suppress the others. A non-clickable "Shot
+Summary" chip always sits at the end of the row — that's the entry point to
+the analysis dialog described in §3.
 
 | Flag                       | Color  | Label                  | Source                       |
 | -------------------------- | ------ | ---------------------- | ---------------------------- |
@@ -52,7 +55,7 @@ chip shows. None of the chips suppress the others.
 | `grindIssueDetected`       | orange | "Grind issue"          | `detectGrindIssue` (`analyzeFlowVsGoal`) |
 | `skipFirstFrameDetected`   | orange | "First step skipped"   | `detectSkipFirstFrame`       |
 
-The badges are recomputed on every shot load (see §3) so detector improvements
+The badges are recomputed on every shot load (see §4) so detector improvements
 take effect on existing shots without a manual re-analyze.
 
 ---
@@ -229,7 +232,120 @@ wired to a separate badge column.
 
 ---
 
-## 3. Persistence semantics
+## 3. Shot Summary dialog
+
+The "Shot Summary" chip at the end of the badge row opens
+`qml/components/ShotAnalysisDialog.qml` — a non-AI, non-modal-blocking
+analysis pane that surfaces a list of observations plus a single verdict
+line. The text is computed entirely in C++ from the captured curves; the
+QML side is a thin display layer.
+
+### Pipeline
+
+`ShotAnalysisDialog` (visible) →
+`MainController.shotHistory.generateShotSummary(shotData)` (Q_INVOKABLE on
+`ShotHistoryStorage`) →
+`ShotAnalysis::generateSummary(...)` →
+`QVariantList` of `{ text, type }` lines →
+`Repeater` in the dialog with a colored dot per line.
+
+`generateShotSummary` is the bridge that converts the QML `shotData` map
+into the typed vectors `generateSummary` expects (pressure, flow, weight,
+temperature + goals, conductance derivative, phases, beverage type, profile
+JSON for first-frame seconds, yield override + final weight for the choked-
+puck yield arm). Empty / missing fields are tolerated where the underlying
+detector tolerates them.
+
+### Line types and rendering
+
+Each line carries a `type`:
+
+| Type          | Dot color                     | Used for                                   |
+| ------------- | ----------------------------- | ------------------------------------------ |
+| `good`        | success (green)               | "Puck stable", happy-path observations     |
+| `caution`     | warning (orange)              | flow drift, temp drift, grind direction    |
+| `warning`     | error (red)                   | sustained channeling, choked puck, frame skip, pour truncated |
+| `observation` | text-secondary (neutral grey) | preinfusion drip mass / duration           |
+| `verdict`     | no dot, larger font           | always exactly one, last in the list       |
+
+The dialog renders the verdict in subtitle font with no dot to set it apart
+from the observation lines.
+
+### Observations emitted
+
+Order follows `generateSummary` top-to-bottom:
+
+1. **Channeling status** — uses the same `buildChannelingWindows` +
+   `detectChannelingFromDerivative` path as the badge. Emits **Sustained**
+   ("warning"), **Transient** ("caution") with the spike timestamp, or a
+   "Puck stable" ("good") line. Skipped for filter / pourover / tea /
+   steam / cleaning beverages, turbo shots, and profiles with the
+   `channeling_expected` analysis flag.
+2. **Flow trend** — compares mean flow in the first 30% of the pour
+   against the last 30%. ±0.5 mL/s thresholds emit "Flow rose … (puck
+   erosion)" or "Flow dropped … (fines migration or clogging)" as
+   "caution". Suppressed for profiles with the `flow_trend_ok` analysis
+   flag (Cremina lever and similar where declining/rising flow is by
+   design).
+3. **Preinfusion drip** — when preinfusion lasted > 1 s and at least 0.5 g
+   landed during it, emits "Preinfusion: Xg in Ys" as an "observation".
+4. **Temperature stability** — when `hasIntentionalTempStepping` is false
+   and `avgTempDeviation` exceeds 2 °C, emits "Temperature drifted X °C
+   from goal on average" as "caution".
+5. **Grind direction** — uses the same `analyzeFlowVsGoal` path as the
+   badge. Emits one of: "Pour produced near-zero flow while pressure
+   held — puck choked" ("warning") when `chokedPuck` fires, "Flow
+   averaged X mL/s below target — grind may be too fine" ("caution"),
+   "Flow averaged X mL/s above target — grind may be too coarse"
+   ("caution"), or nothing when within tolerance.
+6. **Pour truncated** — `detectPourTruncated`. Emits "Pour never
+   pressurized — puck failed" as "warning" when peak pressure stayed
+   under 2.5 bar.
+7. **Skip first frame** — `detectSkipFirstFrame`. Emits "First profile
+   step skipped — likely a DE1 firmware bug…" as "warning".
+
+### Verdict precedence
+
+Exactly one verdict line is appended to every summary. The cascade picks
+the first match (more specific failures take precedence over generic
+puck-integrity advice):
+
+1. **Pour truncated** → "Puck failed — pour never pressurized." Dominates
+   over channeling / grind / temperature, since the puck never built any
+   resistance worth analyzing.
+2. **Skip first frame** → "First profile step was skipped — power-cycle…"
+   Pre-empts choked-puck because a frame-skip can synthesise extraction
+   dynamics that resemble a choke; fix the machine first, then re-evaluate.
+3. **Choked puck** → "Puck choked — grind way too fine. Coarsen
+   significantly." Pre-empts the generic "Puck integrity issue" verdict
+   below.
+4. **Has any "warning"** → "Puck integrity issue — improve distribution."
+   When a directional grind signal is present alongside, it appends
+   "Grind is running fine — try coarser." or "Grind is running coarse —
+   try finer." as a modifier (since channeling alone doesn't tell you
+   which direction grind is off).
+5. **Has any "caution"** → If the only caution is a grind direction,
+   names the direction ("Grind appears too fine — try coarser." /
+   "…too coarse — try finer."). Otherwise: "Decent shot with minor
+   issues to watch."
+6. **Otherwise** → "Clean shot. Puck held well."
+
+### Triggering and lifecycle
+
+The dialog is instantiated declaratively inside `ShotDetailPage.qml` and
+`PostShotReviewPage.qml`. The `Shot Summary` chip in `QualityBadges.qml`
+emits `summaryRequested()` on tap, which the host page handles by calling
+`open()` on its `ShotAnalysisDialog` instance. Analysis lines are
+recomputed each time the dialog becomes visible (the
+`MainController.shotHistory.generateShotSummary(shotData)` binding only
+fires while `analysisDialog.visible` is true), so detector improvements
+take effect on summary text the same way they do on badges — no save-time
+freeze. There is no DB persistence for summary lines; they're regenerated
+on demand.
+
+---
+
+## 4. Persistence semantics
 
 ### Save-time: stored columns
 
@@ -285,7 +401,7 @@ require another sweep.
 
 ---
 
-## 4. Code map
+## 5. Code map
 
 ### Detector logic
 
@@ -293,7 +409,8 @@ require another sweep.
   `buildChannelingWindows`, `detectChannelingFromDerivative`,
   `detectGrindIssue`, `detectSkipFirstFrame`, `detectPourTruncated`,
   `hasIntentionalTempStepping`, `avgTempDeviation`, `shouldSkipChannelingCheck`,
-  `generateSummary` (used by the Shot Analysis dialog), all tuning constants.
+  `generateSummary` (the Shot Summary dialog text — see §3), all tuning
+  constants.
 
 ### Persistence
 
@@ -303,11 +420,13 @@ require another sweep.
   - `requestReanalyzeBadges` — lazy-persist worker.
   - `requestShotsFiltered` + `buildFilterQuery` — history-list filter that
     reads the stored columns.
+  - `generateShotSummary` — Q_INVOKABLE bridge that converts a QML
+    `shotData` map into the typed inputs for `ShotAnalysis::generateSummary`.
   - DB migration for the four flag columns.
   - `computeDerivedCurves` — fills conductance / dC/dt for legacy shots that
     predate migration 10.
   - `profileFrameInfoFromJson` — extracts `frameCount` and
-    `firstFrameSeconds` for `detectSkipFirstFrame`.
+    `firstFrameSeconds` for `detectSkipFirstFrame` and the summary path.
 
 ### Profile-level analysis flags
 
@@ -320,11 +439,16 @@ require another sweep.
 ### UI
 
 - `qml/components/QualityBadges.qml` — chip rendering. One chip per active
-  flag; when none active, a single "Clean extraction" chip.
+  flag; when none active, a single "Clean extraction" chip; always a
+  trailing "Shot Summary" chip that emits `summaryRequested()`.
+- `qml/components/ShotAnalysisDialog.qml` — Shot Summary dialog. Calls
+  `MainController.shotHistory.generateShotSummary(shotData)` while
+  visible and renders the resulting `{ text, type }` lines.
 - `qml/pages/ShotDetailPage.qml` and `qml/pages/PostShotReviewPage.qml` —
   consume `shotData.channelingDetected` / `temperatureUnstable` /
   `grindIssueDetected` / `skipFirstFrameDetected`, listen for
-  `shotBadgesUpdated`, call `requestReanalyzeBadges` on load.
+  `shotBadgesUpdated`, call `requestReanalyzeBadges` on load, host the
+  `ShotAnalysisDialog` instance and wire `summaryRequested` to `open()`.
 - `qml/pages/ShotHistoryPage.qml` — filter chips that consume the stored
   columns.
 
@@ -336,7 +460,7 @@ require another sweep.
 
 ---
 
-## 5. Regression corpus
+## 6. Regression corpus
 
 `tools/shot_eval/` is a CLI harness that runs the live detectors against a
 curated corpus of shot fixtures and prints (or validates) the verdicts.
@@ -361,7 +485,7 @@ To add a fixture:
 
 ---
 
-## 6. References
+## 7. References
 
 - PR #649 — original Tier 1 diagnostics (badges, dC/dt, phase summary, mix
   temperature, basic/advanced toggle).

--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -44,8 +44,8 @@ shared `shotReview/advancedMode` setting toggles information density on both.
 
 Four independent flags, surfaced via `qml/components/QualityBadges.qml`. When
 any fire, those chips show; when none fire, a single green "Clean extraction"
-chip shows. None of the chips suppress the others. A non-clickable "Shot
-Summary" chip always sits at the end of the row — that's the entry point to
+chip shows. None of the chips suppress the others. A tappable "Shot
+Summary" chip always sits at the end of the row — it's the entry point to
 the analysis dialog described in §3.
 
 | Flag                       | Color  | Label                  | Source                       |
@@ -53,7 +53,7 @@ the analysis dialog described in §3.
 | `channelingDetected`       | red    | "Channeling detected"  | `detectChannelingFromDerivative` |
 | `temperatureUnstable`      | orange | "Temp unstable"        | `avgTempDeviation` + threshold |
 | `grindIssueDetected`       | orange | "Grind issue"          | `detectGrindIssue` (`analyzeFlowVsGoal`) |
-| `skipFirstFrameDetected`   | orange | "First step skipped"   | `detectSkipFirstFrame`       |
+| `skipFirstFrameDetected`   | red    | "First step skipped"   | `detectSkipFirstFrame`       |
 
 The badges are recomputed on every shot load (see §4) so detector improvements
 take effect on existing shots without a manual re-analyze.
@@ -91,10 +91,13 @@ included only when, at that time:
    / goal(t) ≤ 0.15` on both sides.
 2. The actual value has **converged** onto the goal: `|actual − goal| / goal ≤
    0.15`.
-3. For **flow-mode phases only**, pressure is not rising fast (`pressureFut >
-   pressureNow * 1.15` over 0.75 s ahead disqualifies the sample). Falling
-   pressure is allowed — bloom transitions and pressure-mode → flow-mode
-   handoffs are legitimate channeling signals.
+3. For **flow-mode phases only**, pressure is not rising fast: when
+   `pressureNow > 0.5` bar AND `pressureFut > pressureNow * 1.15` over 0.75 s
+   ahead, the sample is disqualified. Falling pressure is allowed — bloom
+   transitions and pressure-mode → flow-mode handoffs are legitimate
+   channeling signals. The 0.5 bar precondition gates out the
+   near-atmospheric window where small absolute jitter would otherwise read
+   as a 15 % relative rise.
 
 Contiguous qualifying times collapse into windows; gaps ≤
 `WINDOW_GAP_MERGE_SEC` (0.3 s) are merged.
@@ -324,10 +327,14 @@ puck-integrity advice):
    "Grind is running fine — try coarser." or "Grind is running coarse —
    try finer." as a modifier (since channeling alone doesn't tell you
    which direction grind is off).
-5. **Has any "caution"** → If the only caution is a grind direction,
-   names the direction ("Grind appears too fine — try coarser." /
-   "…too coarse — try finer."). Otherwise: "Decent shot with minor
-   issues to watch."
+5. **Has any "caution"** → If grind data is directional (`|delta| >
+   FLOW_DEVIATION_THRESHOLD`), names the direction ("Grind appears too
+   fine — try coarser." / "…too coarse — try finer.") regardless of any
+   other cautions also present. Otherwise: "Decent shot with minor
+   issues to watch." (The in-source comment phrases this as "if the
+   only caution is a grind direction," but the implementation does not
+   actually check for uniqueness — a directional grind delta wins over
+   a co-occurring temperature or flow-trend caution.)
 6. **Otherwise** → "Clean shot. Puck held well."
 
 ### Triggering and lifecycle
@@ -372,9 +379,11 @@ when the shot predates migration 10 (the `conductance` column).
 
 When a shot is opened in `ShotDetailPage` or `PostShotReviewPage`, QML calls
 `MainController.shotHistory.requestReanalyzeBadges(id)`. That method runs on
-the DB worker thread, recomputes the four flags, and issues an `UPDATE` if
-any flag differs from the stored value. It then emits `shotBadgesUpdated` so
-the UI can refresh without a full reload.
+the DB worker thread and recomputes the four flags. If at least one flag
+differs from the stored value, it issues an `UPDATE` *and* emits
+`shotBadgesUpdated` so the UI can refresh without a full reload. If every
+flag already matches the stored value, the worker exits silently — no
+`UPDATE`, no signal, no UI refresh.
 
 The wiring lives at `qml/pages/ShotDetailPage.qml` (in `onShotReady`) and
 `qml/pages/PostShotReviewPage.qml`. The visualizer-update reload path

--- a/docs/SHOT_REVIEW_IMPROVEMENTS.md
+++ b/docs/SHOT_REVIEW_IMPROVEMENTS.md
@@ -1,501 +1,391 @@
-# Shot Review Page Improvements
+# Shot Review: Current State
 
-## Status: Tier 1 Implemented
+This is a snapshot of how the post-shot review and shot detail pages work today,
+focused on the quality-badge / detector system that has accumulated several rounds
+of refinement. It is the source of truth for anyone modifying detectors, persistence,
+or the badge UI; the `git log` for `docs/SHOT_REVIEW_IMPROVEMENTS.md` is the source
+of truth for the path that got us here.
 
-This document identifies improvements to the post-shot review and shot detail pages
-that help users understand shot quality without AI interaction. Prioritized by impact
-and implementation effort.
-
----
-
-## 0. Implementation Summary (Tier 1)
-
-All Tier 1 items (1.1--1.4) are implemented on both PostShotReviewPage and
-ShotDetailPage. A Basic/Advanced mode toggle controls information density.
-
-### Basic/Advanced Mode
-
-A pill-style toggle (persisted to `shotReview/advancedMode`) sits below the graph
-legend on both pages. The same setting syncs between pages.
-
-**Basic mode** (default):
-- Graph: pressure, flow, temperature, weight, weight flow (5 curves)
-- Quality badge (single status chip)
-- Metrics: duration, dose, output, ratio, rating
-- Notes, bean info, grinder info, barista
-
-**Advanced mode** adds:
-- Graph legend: resistance (P/F), conductance (F²/P), dC/dt, Darcy resistance
-  (P/F²), mix temperature
-- Phase marker labels on graph (frame boundary labels with transition reasons)
-- Phase summary panel (collapsible table with per-phase metrics)
-- TDS/EY fields (review page) and analysis card (detail page)
-- Debug log button (detail page)
-
-### What Was Built
-
-| Item | Status | Notes |
-|------|--------|-------|
-| 1.1 Conductance + dC/dt curves | Done | 3 new curves + existing resistance moved to advanced legend |
-| 1.2 Quality badges | Done | Single chip: green/red/orange. Both modes. |
-| 1.3 Phase summary panel | Done | Collapsible, advanced only. Computed at save, backfilled for legacy. |
-| 1.4 Mix temperature curve | Done | Already stored, now displayed. Advanced legend. |
-
-### Additional Changes
-
-- **Unified channeling detection (dC/dt)**: `channelingDetected` now comes from
-  the conductance derivative, matching the Shot Summary popup's signal. Previously
-  the badge used a flow-spike heuristic (flow-mode phases only) while the popup
-  used dC/dt, so they could disagree — especially on pressure-profile shots where
-  the badge could never fire. `ShotAnalysis::detectChannelingFromDerivative()` is
-  now the single source of truth, used by the badge, the AI prompt observations,
-  and `ShotAnalysisDialog`. The badge fires on Sustained events (>10 samples with
-  `|dC/dt| > 3.0`); transient self-healed channels surface only in the popup.
-- **Detail page layout**: Bean and grinder info cards display side by side.
-- **Auto-close timer**: Only runs on post-shot auto-open. User-initiated opens
-  (history E button) do not auto-close.
-- **DB migration 10**: Added `channeling_detected` and `temperature_unstable`
-  columns to `shots` table.
-- **Legacy shot backfill**: Conductance, Darcy resistance, conductance derivative,
-  phase summaries, and quality flags are computed on-the-fly when loading shots
-  saved before this feature.
-- **Theme colors**: 4 new chart colors (conductanceColor, conductanceDerivativeColor,
-  darcyResistanceColor, temperatureMixColor).
-
-### Files Changed
-
-- `src/models/shotdatamodel.h/cpp` --- conductance, Darcy resistance, dC/dt vectors
-- `src/history/shothistorystorage.h/cpp` --- migration, compress/decompress, derived
-  curve backfill, phase summary computation
-- `qml/Theme.qml` --- 4 new chart colors
-- `qml/components/GraphLegend.qml` --- Row→Flow, 4 entries, advancedMode filtering
-- `qml/components/HistoryShotGraph.qml` --- 4 new LineSeries
-- `qml/components/ShotGraph.qml` --- 3 new FastLineRenderers
-- `qml/components/QualityBadges.qml` --- new component
-- `qml/components/PhaseSummaryPanel.qml` --- new component
-- `qml/pages/PostShotReviewPage.qml` --- data bindings, badges, toggle, phase panel,
-  TDS/EY advanced-only, auto-close fix
-- `qml/pages/ShotDetailPage.qml` --- data bindings, badges, toggle, phase panel,
-  side-by-side cards, analysis/debug advanced-only
-- `qml/pages/ShotHistoryPage.qml` --- pass autoClose: false on manual open
-- `CMakeLists.txt` --- 2 new QML files
+The detectors are still under active iteration — expect this doc to drift, and
+prefer reading the code (`src/ai/shotanalysis.h` is heavily commented) when in
+doubt.
 
 ---
 
-## 1. Current State
+## 1. What the user sees
 
-### What the Shot Review Page Shows Today
+### Pages
 
-**Graph curves** (6 total, via `GraphLegend.qml`):
-1. Pressure (bar) --- on by default
-2. Flow (mL/s) --- on by default
-3. Temperature (°C) --- on by default
-4. Weight (g) --- on by default
-5. Weight flow rate (g/s) --- on by default
-6. Resistance (P/F) --- **off by default**
+Both **PostShotReviewPage** (auto-opens when a shot ends) and **ShotDetailPage**
+(opened from history) render the same shot data with the same components. A
+shared `shotReview/advancedMode` setting toggles information density on both.
 
-**Goal overlays** (dashed lines): pressure goal, flow goal, temperature goal.
+### Basic mode (default)
 
-**Phase markers**: Frame boundaries with transition reason labels ([W]eight, [P]ressure,
-[F]low, [T]ime). Pump mode indicators (flow vs. pressure mode) as color-coded bars.
+- Graph: pressure, flow, temperature, weight, weight flow rate.
+- Goal overlays for pressure / flow / temperature (dashed).
+- Phase markers (frame boundaries) without label text.
+- Quality badges (one or more chips below the graph).
+- Metrics: duration, dose, output, ratio, rating.
+- Notes, bean / grinder info, barista.
 
-**Metrics**: Duration, Dose, Output (with optional target yield), Ratio (1:X), Rating
-(0--100%).
+### Advanced mode adds
 
-**Metadata**: Notes, TDS, EY, bean info (brand, type, roast date, roast level), grinder
-info (brand, model, burrs, setting), barista, beverage type.
+- Resistance (P/F), Darcy resistance (P/F²), conductance (F²/P), dC/dt, mix
+  temperature curves (toggleable in the legend).
+- Phase marker label text (frame boundaries with transition reasons —
+  `[W]` weight, `[P]` pressure, `[F]` flow, `[T]` time).
+- Phase summary panel — collapsible per-phase metrics table.
+- TDS / EY fields (review page) and analysis card + debug log button (detail
+  page).
 
-**Interactive elements**: Resizable graph, tap/drag crosshair inspection
-(`GraphInspectBar`), right-axis toggle (Weight vs. Temperature), legend toggles,
-shot navigation (swipe), rating slider, refractometer TDS reading.
+### Quality badges
 
-### What's Computed But Not Shown
+Four independent flags, surfaced via `qml/components/QualityBadges.qml`. When
+any fire, those chips show; when none fire, a single green "Clean extraction"
+chip shows. None of the chips suppress the others.
 
-`ShotSummarizer` (`src/ai/shotsummarizer.h`) computes extensive per-shot metrics that
-are only used for AI prompt generation, never displayed to the user:
+| Flag                       | Color  | Label                  | Source                       |
+| -------------------------- | ------ | ---------------------- | ---------------------------- |
+| `channelingDetected`       | red    | "Channeling detected"  | `detectChannelingFromDerivative` |
+| `temperatureUnstable`      | orange | "Temp unstable"        | `avgTempDeviation` + threshold |
+| `grindIssueDetected`       | orange | "Grind issue"          | `detectGrindIssue` (`analyzeFlowVsGoal`) |
+| `skipFirstFrameDetected`   | orange | "First step skipped"   | `detectSkipFirstFrame`       |
 
-**Per-phase metrics** (preinfusion, extraction, decline, etc.):
-- `avgPressure`, `maxPressure`, `minPressure`
-- `avgFlow`, `maxFlow`, `minFlow`
-- `avgTemperature`, `tempStability` (std deviation from goal)
-- `weightGained` (grams during this phase)
-- `pressureAtStart`, `pressureAtMiddle`, `pressureAtEnd`
-- `flowAtStart`, `flowAtMiddle`, `flowAtEnd`
-
-**Anomaly flags**:
-- `channelingDetected` --- sustained dC/dt elevation (>10 samples with
-  `|dC/dt| > 3.0`) — puck integrity loss, works across all frame modes
-- `temperatureUnstable` --- avg deviation from goal > 2°C
-
-**Stored data series not displayed**:
-- `m_temperatureMixPoints` --- mix temperature (group head thermal stability)
-- `m_waterDispensedPoints` --- cumulative water volume (mL)
-- `m_weightFlowRateRawPoints` --- pre-smoothing weight flow rate
+The badges are recomputed on every shot load (see §3) so detector improvements
+take effect on existing shots without a manual re-analyze.
 
 ---
 
-## 2. What Visualizer.coffee and Peer Tools Show
+## 2. Detector internals
 
-### Visualizer.coffee
+All four detectors live in `src/ai/shotanalysis.{h,cpp}` as static methods on
+`ShotAnalysis`. Tuning constants are defined at the top of the header so they
+can be tweaked in one place. The header is heavily commented — read it
+alongside this section.
 
-Source: [github.com/miharekar/visualizer](https://github.com/miharekar/visualizer)
+### 2.1 Channeling
 
-**Additional graph curves** (hidden by default, toggled via legend):
-- Resistance: `R = P / F²` (Darcy's law, not `P / F`)
-- Conductance: `C = F² / P` (inverse of resistance)
-- Conductance derivative: `dC/dt`, Gaussian smoothed --- the most diagnostic curve
-- Mix temperature (alongside basket temperature)
-- Water dispensed
+Single source of truth for channeling severity is `detectChannelingFromDerivative`,
+operating on the Gaussian-smoothed conductance derivative `dC/dt`. The badge
+fires on the **Sustained** severity tier; the **Transient** tier surfaces only
+in the Shot Analysis dialog popup.
 
-**Exact formulas** (from `app/models/shot_chart/additional_charts.rb`):
+**Severity tiers** (`ChannelingSeverity`):
 
-```ruby
-# Resistance: pressure / flow^2, clamped to 19
-r = pressure / (flow ** 2)
-v = r > 19 ? nil : r
+- **None** — no sample's `|dC/dt|` exceeds `CHANNELING_DC_TRANSIENT_PEAK` (5.0).
+- **Transient** — a single peak above 5.0 (a self-healed channel).
+- **Sustained** — more than `CHANNELING_DC_SUSTAINED_COUNT` (10) samples above
+  `CHANNELING_DC_ELEVATED` (3.0) **inside the inclusion windows**.
 
-# Conductance: flow^2 / pressure, clamped to 19
-c = (flow ** 2) / pressure
-v = c > 19 ? nil : c
+**Inclusion windows** are built by `buildChannelingWindows`. Without windowing
+the detector flags every lever-style preinfusion as channeling because the
+natural pressure-rise dynamic drives `dC/dt` strongly negative. A sample is
+included only when, at that time:
 
-# Conductance derivative: rate of change, scaled x10, Gaussian smoothed
-derivative = ((c2 - c1) / ((t2 - t1) / 1000)) * 10
-# Then 9-point Gaussian kernel:
-GAUSSIAN_MULTIPLIERS = [0.048297, 0.08393, 0.124548, 0.157829, 0.170793,
-                        0.157829, 0.124548, 0.08393, 0.048297]
-# Clamped to [-5, 19]
+1. The active control goal (flow goal during flow-mode phases, pressure goal
+   during pressure-mode phases) is **stationary**: `|goal(t±0.75 s) − goal(t)|
+   / goal(t) ≤ 0.15` on both sides.
+2. The actual value has **converged** onto the goal: `|actual − goal| / goal ≤
+   0.15`.
+3. For **flow-mode phases only**, pressure is not rising fast (`pressureFut >
+   pressureNow * 1.15` over 0.75 s ahead disqualifies the sample). Falling
+   pressure is allowed — bloom transitions and pressure-mode → flow-mode
+   handoffs are legitimate channeling signals.
+
+Contiguous qualifying times collapse into windows; gaps ≤
+`WINDOW_GAP_MERGE_SEC` (0.3 s) are merged.
+
+**Fallback semantics** are deliberate:
+
+- Empty `phases` → emits a single whole-pour window (legacy shots predating
+  phase markers run unrestricted, preserving coverage).
+- Non-empty `phases` but no qualifying window → returns empty, and
+  `detectChannelingFromDerivative` reports `None` (not unrestricted). This is
+  the "all-ramp shot, nothing reliable to analyze" path; better to be silent
+  than to false-positive.
+
+**Pour-window trim**: the first `CHANNELING_DC_POUR_SKIP_SEC` (2.0 s) and last
+`CHANNELING_DC_POUR_SKIP_END_SEC` (1.5 s) of the pour are excluded from the
+detector's time grid — they cover the pressure-ramp / flow-catchup transient
+at start and the natural tail acceleration at end. `buildChannelingWindows`
+applies the same trim to its output bounds.
+
+**Hard skips** (`shouldSkipChannelingCheck` returns true → `channelingDetected`
+forced to false):
+
+- Beverage type is `filter`, `pourover`, `tea`, `steam`, or `cleaning`.
+- Average flow during the pour exceeds `CHANNELING_MAX_AVG_FLOW` (3.0 mL/s) —
+  turbo / very-coarse shots have no diagnostic dC/dt signal.
+
+**Profile-level skip**: a `channeling_expected` flag in `ProfileKnowledge`
+(reached via `ShotSummarizer::getAnalysisFlags(profileKbId)`) suppresses
+channeling detection for profiles where channeling-shaped curves are intentional.
+
+### 2.2 Grind issue
+
+Implemented by `detectGrindIssue`, which delegates to `analyzeFlowVsGoal` and
+returns true when either arm fires. Two arms run **additively**, not as
+fallback — a clean flow-mode preinfusion can hide a pressure-mode choke and
+vice versa.
+
+**Arm 1: flow-vs-goal averaging** (the "primary" path).
+
+For each flow-mode phase, builds an inclusive time range:
+
+- Skip the first `GRIND_PUMP_RAMP_SKIP_SEC` (0.5 s) of the first flow-mode
+  phase that coincides with `pourStart` — pump-ramp lag, not a grind signal.
+- If the phase exits via `transitionReason == "pressure"`, skip the trailing
+  `GRIND_LIMITER_TAIL_SKIP_SEC` (1.5 s) — the firmware's pressure ceiling has
+  engaged and the controller is no longer tracking flow goal.
+- Both trims are gated on the resulting range remaining ≥ 1 s long. Extreme
+  puck-failure shots with sub-second flow-mode phases would otherwise have
+  their entire data trimmed away.
+
+Within those ranges, average actual flow vs. flow goal across all samples
+where `goal ≥ FLOW_GOAL_MIN_AVG` (0.3 mL/s — gates out preinfusion sentinel
+goals). Requires ≥ 5 qualifying samples to yield a result. The check fires
+when `|delta| > FLOW_DEVIATION_THRESHOLD` (0.4 mL/s); positive delta = coarse,
+negative = fine.
+
+**Arm 2: choked-puck check** (pressure-mode only).
+
+For each pressure-mode phase (or the whole pour window if all phases are
+flow-mode-labeled), accumulate samples where `pressure ≥
+CHOKED_PRESSURE_MIN_BAR` (4.0). Requires `flowSamples ≥ 5` and
+`pressurizedDuration ≥ CHOKED_DURATION_MIN_SEC` (15 s) to fire. Two
+sub-arms feed `chokedPuck`:
+
+- **Severe (flow arm)**: mean pressurized flow `< CHOKED_FLOW_MAX_MLPS` (0.5
+  mL/s). Catches the obvious failures (e.g., 80's Espresso with 1.1 g yield
+  and ~0.3 mL/s mean).
+- **Moderate (yield arm)**: `finalWeightG / targetWeightG < CHOKED_YIELD_RATIO_MAX`
+  (0.85). Catches narrowly-above-flow-threshold cases where the puck still
+  failed (e.g., 25 g of a 36 g target, ~0.6 mL/s mean).
+
+The yield arm requires both `targetWeightG > 0` and `finalWeightG > 0` —
+imported shots without target metadata correctly stay silent.
+`finalWeightG` works on either a real BLE scale or Decenza's `FlowScale`
+virtual scale (dose-aware flow integration), so the arm fires headless too.
+
+**Hard skips** (`skipped = true`, both arms suppressed):
+
+- Beverage type is `filter`, `pourover`, `tea`, `steam`, or `cleaning`.
+- `analysisFlags` contains `grind_check_skip`.
+- Pressure data is empty (the arm-2 path early-returns).
+
+### 2.3 Temperature unstable
+
+The simplest of the four. `temperatureUnstable = true` when:
+
+- `temperature` and `temperatureGoal` both have > 10 samples, AND
+- `hasIntentionalTempStepping(temperatureGoal)` is false (goal range ≤
+  `TEMP_STEPPING_RANGE` = 5 °C — D-Flow 84 → 94 is intentional, ignore), AND
+- `avgTempDeviation(temperature, temperatureGoal, pourStart, pourEnd) >
+  TEMP_UNSTABLE_THRESHOLD` (2.0 °C).
+
+`avgTempDeviation` is the average absolute deviation over the pour window
+where the goal is non-zero.
+
+### 2.4 Skip first frame
+
+`detectSkipFirstFrame` operates on phase markers only — no curves needed. Two
+distinct branches inside one function, picked from the marker stream:
+
+**FW-bug branch** — frame 0 was never observed before a non-zero frame:
+returns `phase.time < 2.0`. The 2-second window matches the de1app Tcl
+plugin's polling cadence (it can only catch this before t = 2 s), so we use
+the same hard window for parity. This case requires a power-cycle to fix.
+
+**Short-first-step branch** — frame 0 was observed but ended early:
+returns `phase.time < cutoff` where:
+
+```
+cutoff = (firstFrameConfiguredSeconds > 0)
+       ? min(2.0, 0.5 * firstFrameConfiguredSeconds)
+       : 2.0
 ```
 
-**Additional features**:
-- Weight at transition points (preinfusion dripping weight)
-- Enjoyment over time chart (trend across shots)
-- Tasting spider/radar chart (8 SCA dimensions, Premium 2026)
-- Shot comparison with curve overlay
-- Custom metadata fields (key-value, Premium)
-- Shot tags for organization
+The configured-aware path avoids false positives on profiles whose first
+frame is configured for 2 seconds — BLE notification jitter routinely lands
+the frame-1 marker a few hundred ms early, and a 1.87 s actual on a 2 s
+configured frame should not flag.
 
-### Smart Espresso Profiler (SEP)
+`expectedFrameCount` is honored when known: values < 2 suppress detection
+(no second frame to skip to), and out-of-range frame numbers are skipped as
+malformed.
 
-- **Profile Drift Indicator (PDI)** --- single-number deviation from target profile
-- **Reference shot overlay** --- display a previous shot's curves behind the current
-  shot for visual replication
-- Movable time cursor for precise value inspection
+`firstFrameConfiguredSeconds` is fed in by callers from `ProfileFrameInfo`
+(parsed from the stored profile JSON via `profileFrameInfoFromJson`).
 
-### GaggiMate MCP
+### 2.5 Pour truncated (used by the summary path, not a badge)
 
-- Resistance using `P / F²` (Darcy's law)
-- Channeling risk scoring
-- Per-phase profile compliance metrics with human-readable bands
-  (MODERATE, STABLE, SLIGHT_OVERSHOOT)
-- Physics-informed diagnostic heuristics
-
-### Beanconqueror
-
-- Average flow quantity as a summary metric
-- Cupping by aromatics or flavors
-- 30+ customizable brew parameters
-
-### Key Diagnostic Patterns (Community Knowledge)
-
-| Graph Pattern | Meaning | Adjustment |
-|---------------|---------|------------|
-| Smooth pressure ramp, stable plateau, gentle taper | Good extraction | None |
-| Sudden flow spike + pressure dip | Channeling | Improve puck prep / WDT |
-| Erratic pressure during extraction | Multiple channels | Grind finer, better distribution |
-| Consistently high flow | Grind too coarse | Grind finer |
-| Very low, trickling flow | Choked / too fine | Grind coarser |
-| Flow increasing over time | Puck erosion (rate matters) | Monitor --- fast increase = problem |
-| Conductance derivative spike then return | Transient channel (self-healed) | Minor issue |
-| Conductance derivative sustained elevation | Persistent channeling | Major puck prep issue |
-
-**Core insight**: "The pressure line reveals the machine's intent; the flow line shows
-the coffee's response." The conductance derivative shows puck integrity.
+`detectPourTruncated` returns true when peak pressure inside the pour window
+stays below `PRESSURE_FLOOR_BAR` (2.5). It catches the failure mode where
+conductance saturates at its clamp, `dC/dt` is flat, and flow tracks the
+preinfusion goal perfectly — every other detector goes silent. Currently used
+inside `ShotAnalysis::generateSummary` (the user-facing observation list); not
+wired to a separate badge column.
 
 ---
 
-## 3. Proposed Improvements
+## 3. Persistence semantics
 
-### Tier 1: High Impact, Data Already Exists
+### Save-time: stored columns
 
-#### 1.1 Conductance and Conductance Derivative Curves ✅
+The `shots` table has four flag columns: `channeling_detected`,
+`temperature_unstable`, `grind_issue_detected`, `skip_first_frame_detected`.
+At shot save (or import), the badges are computed once from the captured
+curves and written into these columns alongside the rest of the shot record.
 
-**What**: Add three new toggleable curves to the graph legend: Conductance (`F²/P`),
-Conductance Derivative (`dC/dt`), and optionally Darcy Resistance (`P/F²`).
+### Load-time: always recompute (PR #893)
 
-**Why**: The conductance derivative is the single most diagnostic visual for puck
-integrity. It reveals transient channeling events --- spikes where channels form and
-heal --- that are invisible in the pressure, flow, and resistance curves. Visualizer
-shows all three; the DE1 community considers `dC/dt` the most valuable diagnostic
-metric available. Adding it to the on-device app means users get this feedback
-immediately after pulling a shot, without uploading to Visualizer.
+`ShotHistoryStorage::loadShotRecordStatic` reads the stored columns, then
+**unconditionally recomputes all four badges** from the loaded curve data
+before returning. This means the in-memory `ShotRecord` always reflects the
+current detector logic, regardless of when the shot was saved or under which
+detector version. The recompute block lives in `loadShotRecordStatic` (around
+the comment "Always recompute every quality badge from the loaded curve
+data").
 
-**Implementation**:
-- Add `conductancePoints`, `conductanceDerivativePoints`, `darcyResistancePoints` to
-  `ShotDataModel` as computed `QVector<QPointF>` series
-- Compute in the existing `addSample()` loop (conductance/resistance) and a post-shot
-  smoothing pass (derivative with 9-point Gaussian kernel)
-- Persist in `shot_samples` compressed blob alongside existing resistance
-- Add three entries to `GraphLegend.qml` (hidden by default):
-  - "Conduct(F²/P)" --- conductance
-  - "dC/dt" --- conductance derivative
-  - "Resist(P/F²)" --- Darcy resistance (alternative to existing P/F)
-- Add corresponding `FastLineRenderer` entries in `ShotGraph.qml` and
-  `HistoryShotGraph.qml`
-- Keep existing "Resist(P/F)" toggle for backward compatibility
+The recompute uses on-the-fly derived curves for legacy shots that lack them:
+`computeDerivedCurves` fills `conductanceDerivative` from `pressure`/`flow`
+when the shot predates migration 10 (the `conductance` column).
 
-**Resistance formula note**: Decenza currently uses `P / F` (Ohm's law analogy).
-Visualizer and GaggiMate use `P / F²` (Darcy's law for laminar flow through porous
-media). Neither is definitively "correct" --- they emphasize different aspects of
-puck behavior. Offer both as toggleable curves rather than switching, so users
-familiar with either convention can use what they know.
+### Lazy persist on view (PR #893)
 
-#### 1.2 Channeling and Quality Badges ✅
+When a shot is opened in `ShotDetailPage` or `PostShotReviewPage`, QML calls
+`MainController.shotHistory.requestReanalyzeBadges(id)`. That method runs on
+the DB worker thread, recomputes the four flags, and issues an `UPDATE` if
+any flag differs from the stored value. It then emits `shotBadgesUpdated` so
+the UI can refresh without a full reload.
 
-**What**: Show small visual indicators on the post-shot review and shot detail pages
-when `ShotSummarizer` detects issues.
+The wiring lives at `qml/pages/ShotDetailPage.qml` (in `onShotReady`) and
+`qml/pages/PostShotReviewPage.qml`. The visualizer-update reload path
+suppresses it (badges didn't change, and the visualizer flow already
+triggers a second `onShotReady`).
 
-**Why**: `channelingDetected` and `temperatureUnstable` are already computed but only
-sent to the AI. Surfacing them as visible badges gives users immediate feedback
-without needing to ask the AI or interpret raw curves.
+### Residual gap (Issue #894)
 
-**Implementation**:
-- Expose `ShotSummary` fields to QML (either via new Q_PROPERTY on a summary object,
-  or by storing flags in shot metadata at save time)
-- Display as colored chips below the graph or in the metrics row:
-  - Red: "Channeling detected" (sustained dC/dt elevation — puck integrity loss)
-  - Orange: "Temp unstable" (avg deviation > 2°C from goal)
-  - Green: "Clean extraction" (neither flag triggered)
-- On the shot detail page, show the same badges from stored flags
-- Consider adding: "Pressure hit wall" (pressure at max limiter for > N seconds)
-  and "Choked" (flow < 0.5 mL/s for > N seconds during extraction)
+`requestShotsFiltered` → `buildFilterQuery()` (around
+`shothistorystorage.cpp:1463-1474`) builds badge filters against the **stored
+columns**, not the recomputed values. The MCP `shots_list` tool reads the
+same stored columns. So a shot whose recomputed badges no longer match the
+stored values is consistent in the detail view (after one open, lazy persist
+catches up) but inconsistent in:
 
-**Caution**: The current `temperatureUnstable` flag triggers on profiles with
-intentional temperature stepping (e.g., D-Flow's 84°C→94°C). Before surfacing it,
-make the flag recipe-aware: only flag instability when the temperature deviates from
-the *goal curve*, not from a flat average. This is listed as Phase 0 item 4 in
-`docs/CLAUDE_MD/AI_ADVISOR.md`.
+- The history-list filter chips ("Show only channeling shots") for shots not
+  yet viewed under the current detectors.
+- `shots_list` MCP responses for the same.
 
-#### 1.3 Phase Summary Panel ✅
-
-**What**: Collapsible panel below the graph showing per-phase metrics in a compact
-table.
-
-**Why**: `ShotSummarizer` computes detailed per-phase statistics (avg pressure, flow,
-temp, weight gained, duration) but none are shown. These metrics answer the questions
-users most often ask: "How much dripped during preinfusion?" "What was my average
-extraction pressure?" "How long was each phase?"
-
-**Design**:
-```
-▼ Phase Summary
-┌──────────────┬──────────┬───────────┬──────────┬─────────────┐
-│ Phase        │ Duration │ Avg Press │ Avg Flow │ Weight      │
-├──────────────┼──────────┼───────────┼──────────┼─────────────┤
-│ Preinfusion  │ 8.2s     │ 3.1 bar   │ 1.2 mL/s │ 6.4g       │
-│ Extraction   │ 22.1s    │ 7.8 bar   │ 1.7 mL/s │ 28.3g      │
-│ Decline      │ 5.4s     │ 5.2 bar   │ 2.1 mL/s │ 8.9g       │
-└──────────────┴──────────┴───────────┴──────────┴─────────────┘
-```
-
-The preinfusion weight gained is particularly important --- the Profile Knowledge Base
-frequently references "X grams dripping before pressure rise" as the primary dial-in
-signal for Blooming and lever profiles. Making this visible without AI transforms a
-hidden diagnostic into an actionable metric.
-
-**Implementation**:
-- Compute phase summary at shot save time (extend `ShotSummarizer` or add a separate
-  lightweight computation)
-- Store as JSON in the shot record (or compute on-the-fly from phase markers + curves)
-- QML: `Repeater` over phases, collapsed by default, expandable via tap
-
-#### 1.4 Mix Temperature Curve ✅
-
-**What**: Add mix temperature as a toggleable curve in the graph legend.
-
-**Why**: Stored as `m_temperatureMixPoints` but never displayed. Mix temperature shows
-the actual water temperature reaching the puck (vs. basket/thermocouple temperature).
-The difference between basket and mix temp reveals thermal stability of the group
-head. Visualizer shows both.
-
-**Implementation**:
-- Add "Mix temp" entry to `GraphLegend.qml` (hidden by default)
-- Add `FastLineRenderer` entry sharing the right Y axis with existing temperature
-- Use a distinct color (e.g., lighter shade of temperature color)
+Tracked in #894. Options on the table: a one-shot bulk resweep (option 1),
+adding a manual "Re-analyze all shots" button (option 2), or both (hybrid).
+Held until the detectors stabilize — the next round of fixes would just
+require another sweep.
 
 ---
 
-### Tier 2: Medium Impact, Small New Computation
+## 4. Code map
 
-#### 2.1 Shot-to-Shot Delta Card
+### Detector logic
 
-**What**: When viewing a shot in history, show the delta from the previous shot on the
-same profile.
+- `src/ai/shotanalysis.{h,cpp}` — all four detectors, `analyzeFlowVsGoal`,
+  `buildChannelingWindows`, `detectChannelingFromDerivative`,
+  `detectGrindIssue`, `detectSkipFirstFrame`, `detectPourTruncated`,
+  `hasIntentionalTempStepping`, `avgTempDeviation`, `shouldSkipChannelingCheck`,
+  `generateSummary` (used by the Shot Analysis dialog), all tuning constants.
 
-**Why**: Users dial in iteratively --- change grind, pull a shot, evaluate. The most
-valuable feedback is "what changed vs. last time." Currently users must mentally
-compare two shots or navigate to the comparison page. A compact delta card makes
-cause-and-effect visible at a glance.
+### Persistence
 
-**Design**:
-```
-vs. previous (10 min ago):
-  Grind: 12 → 11 (-1)
-  Pressure: +0.8 bar avg
-  Flow: -0.3 mL/s avg
-  Duration: +4.1s
-  Enjoyment: +12%
-```
+- `src/history/shothistorystorage.{h,cpp}`:
+  - `loadShotRecordStatic` — load + recompute block (the "always recompute
+    every quality badge" comment marks the section).
+  - `requestReanalyzeBadges` — lazy-persist worker.
+  - `requestShotsFiltered` + `buildFilterQuery` — history-list filter that
+    reads the stored columns.
+  - DB migration for the four flag columns.
+  - `computeDerivedCurves` — fills conductance / dC/dt for legacy shots that
+    predate migration 10.
+  - `profileFrameInfoFromJson` — extracts `frameCount` and
+    `firstFrameSeconds` for `detectSkipFirstFrame`.
 
-**Implementation**:
-- Query previous shot with same `profile_kb_id` from `ShotHistoryStorage`
-- Compute deltas for key metrics (already done in `shots_compare` MCP tool)
-- Display as a compact card below the metrics row, collapsed by default
-- Color-code deltas (green = improvement direction, based on whether metric moved
-  toward the profile's target)
+### Profile-level analysis flags
 
-#### 2.2 Goal Deviation Highlighting
+- `src/profile/profileknowledge.{h,cpp}` — KB entries that carry per-profile
+  `analysisFlags` (`channeling_expected`, `grind_check_skip`,
+  `bloom_self_heal`, etc.).
+- `ShotSummarizer::getAnalysisFlags(profileKbId)` is the canonical lookup
+  used by both detector callers and `loadShotRecordStatic`.
 
-**What**: Shade the region between actual and goal curves with a translucent fill when
-deviation exceeds a threshold.
+### UI
 
-**Why**: The graph already draws goal lines (dashed), but users must mentally compare
-two lines to spot deviations. Shading makes it visually obvious *where* and *how much*
-the shot departed from the profile's intent. More informative than a single deviation
-number (like SEP's Profile Drift Indicator) because it shows spatial context.
+- `qml/components/QualityBadges.qml` — chip rendering. One chip per active
+  flag; when none active, a single "Clean extraction" chip.
+- `qml/pages/ShotDetailPage.qml` and `qml/pages/PostShotReviewPage.qml` —
+  consume `shotData.channelingDetected` / `temperatureUnstable` /
+  `grindIssueDetected` / `skipFirstFrameDetected`, listen for
+  `shotBadgesUpdated`, call `requestReanalyzeBadges` on load.
+- `qml/pages/ShotHistoryPage.qml` — filter chips that consume the stored
+  columns.
 
-**Implementation**:
-- For each controlled variable (pressure or flow, depending on the frame's mode),
-  compute the difference between actual and goal at each sample point
-- Where `|actual - goal| > threshold` (e.g., 0.5 bar for pressure, 0.3 mL/s for flow),
-  draw a translucent polygon between the two curves
-- Use warm color (red/orange) for over-target, cool color (blue) for under-target
-- This requires a new `ShaderEffect` or Canvas element in the graph components
+### MCP
 
-#### 2.3 Reference Shot Overlay
-
-**What**: Let users pin a "reference" shot and overlay its curves as faint background
-traces on the current shot's graph.
-
-**Why**: Smart Espresso Profiler's most-praised feature. Users want to replicate their
-best shots. Overlaying the reference shot's curves gives a visual target beyond the
-profile's goal lines (which represent machine targets, not the user's best actual
-performance). The comparison page already supports multi-shot overlay --- this extends
-it to the single-shot view.
-
-**Implementation**:
-- Add a "Compare to..." button on the shot detail page
-- Default reference: the user's highest-rated shot on the same profile
-- Load reference shot data from `ShotHistoryStorage` into a second `ShotDataModel`
-- Draw reference curves as faint (20--30% opacity), thinner lines behind the primary
-  curves
-- Store the reference shot ID as a user preference per profile
-
-#### 2.4 Enjoyment Trend Sparkline
-
-**What**: Small inline chart showing recent enjoyment ratings for this profile.
-
-**Why**: Shows whether the user is improving, regressing, or stable. Visualizer has a
-dedicated `EnjoymentChart` for this. On a mobile device, a compact sparkline
-(last 10--20 shots) provides this at a glance without navigating to a separate page.
-
-**Implementation**:
-- Query recent shots with same `profile_kb_id`, extract enjoyment values
-- Render as a minimal sparkline (no axes, just the trend line + current value dot)
-- Place near the enjoyment rating on the post-shot review page
-- Color the line based on trend direction (improving = green, declining = red)
+- `src/mcp/mcptools_shots.cpp` — `shots_list` reads stored columns;
+  `shots_get_detail` runs through `loadShotRecordStatic` and so reflects
+  recomputed badges.
 
 ---
 
-### Tier 3: Nice-to-Have, More Work
+## 5. Regression corpus
 
-#### 3.1 Puck Resistance Shape Classification
+`tools/shot_eval/` is a CLI harness that runs the live detectors against a
+curated corpus of shot fixtures and prints (or validates) the verdicts.
 
-**What**: Classify the resistance curve shape and display a label: "Smooth decline"
-(good), "Erratic" (channeling), "Flat then crash" (puck failure), "Rising" (fines
-migration).
+- **Fixtures**: `tests/data/shots/*.json` — curated real shots covering
+  lever-clean (Cremina, E61, Damian LRv3, classic Italian), lever / E61
+  failure modes (80's Espresso choked moderate / puck failure, classic
+  Italian fast, Londinium gusher, blooming aborted / choker, puck-failure
+  short gusher), grind-fine (Malabar D-Flow), and Adaptive v2 cases (Gagne).
+- **Manifest**: `tests/data/shots/manifest.json` — golden verdicts per
+  fixture.
+- **CTest target**: `shot_corpus_regression` (declared in
+  `tests/CMakeLists.txt`) runs `shot_eval --validate manifest.json`. Linux
+  CI catches detector regressions before merge.
 
-**Why**: Helps users who can't yet read resistance curves. But with the conductance
-derivative (1.1) showing channeling visually, and the quality badges (1.2) flagging
-detected issues, this becomes less necessary.
+To add a fixture:
 
-**Implementation**: Heuristics on the resistance time-series slope, variance, and
-sudden changes. Low confidence in classification accuracy without community validation.
-
-#### 3.2 Profile Compliance Score
-
-**What**: Single percentage representing how closely the actual shot tracked the
-profile's intended curves.
-
-**Why**: GaggiMate MCP computes this. Gives an at-a-glance quality signal.
-
-**Caution**: Misleading for deliberately adjusted shots (user changed temperature
-mid-shot, or profile has wide tolerances). A "low compliance" shot may taste excellent.
-Consider showing only when deviation is large enough to be meaningful.
-
-#### 3.3 Tasting Radar Chart
-
-**What**: Spider chart across sensory dimensions (fragrance, aroma, flavor, aftertaste,
-acidity, bitterness, sweetness, mouthfeel).
-
-**Why**: Visualizer Premium added this in 2026 using SCA CVA Descriptive methodology.
-Enables rich shot-to-shot taste comparison.
-
-**Caution**: Requires significant UI work, user education, and most users don't have
-the vocabulary or training to rate 8 dimensions consistently. The simpler enjoyment
-rating + free-form notes covers most use cases. Consider this only if there's
-demonstrated user demand.
-
-#### 3.4 Water Dispensed Curve
-
-**What**: Add cumulative water volume (mL) as a toggleable curve.
-
-**Why**: Stored as `m_waterDispensedPoints` but not displayed. Useful for understanding
-dispersion and pre-wetting phases, but overlaps significantly with the weight curve
-for most users.
-
----
-
-## 4. What NOT to Adopt
-
-- **Profile Drift Indicator as a single number (SEP)** --- A percentage deviation
-  hides *where* the deviation occurred. Goal deviation highlighting (2.2) provides
-  more useful spatial context.
-
-- **Cupping-by-aromatics (Beanconqueror)** --- Too niche for a general-purpose app.
-  The enjoyment rating + notes covers this.
-
-- **Replacing `P/F` resistance with `P/F²`** --- The formula debate is unresolved in
-  the community. Offer both as toggleable curves rather than switching and breaking
-  existing users' expectations.
-
-- **Custom metadata fields** --- Decenza already has comprehensive structured metadata
-  (bean, grinder, notes, TDS, EY). Free-form key-value pairs add complexity without
-  proportional value.
-
----
-
-## 5. Implementation Priority
-
-If doing only three things:
-
-1. **Conductance derivative** (1.1) --- highest-value diagnostic curve, data exists,
-   differentiates Decenza from every other on-device espresso app
-2. **Quality badges** (1.2) --- surface existing `ShotSummarizer` flags, near-zero
-   new computation
-3. **Phase summary panel** (1.3) --- expose per-phase metrics that are already computed
-
-These three give users the most shot-quality understanding for the least effort, and
-none require AI interaction.
+1. Drop the captured shot JSON in `tests/data/shots/`.
+2. Add an entry to `manifest.json` with the expected badge / verdict.
+3. Run `shot_eval --validate` locally (or via the ctest target) to confirm.
+4. Commit both files together so the manifest documents the new golden.
 
 ---
 
 ## 6. References
 
-1. Visualizer.coffee source: https://github.com/miharekar/visualizer
-2. Visualizer conductance/resistance: https://visualizer.coffee/updates/conductance-and-resistance
-3. GaggiMate MCP: https://github.com/julianleopold/gaggimate-mcp
-4. Smart Espresso Profiler: https://apps.apple.com/us/app/smart-espresso-profiler/id1391707089
-5. Beanconqueror: https://beanconqueror.com/
-6. Coffee ad Astra puck resistance study:
-   https://coffeeadastra.com/2021/01/16/a-study-of-espresso-puck-resistance-and-how-puck-preparation-affects-it/
-7. Espresso Compass (Barista Hustle): https://www.baristahustle.com/the-espresso-compass/
+- PR #649 — original Tier 1 diagnostics (badges, dC/dt, phase summary, mix
+  temperature, basic/advanced toggle).
+- PR #699 — bloom/soak channeling suppression via per-profile flags.
+- PR #811 — mode-aware shot analysis (`buildChannelingWindows` +
+  flow-mode-only `analyzeFlowVsGoal`) plus the `shot_eval` corpus.
+- PR #864 — first attempt at lever false-positive suppression
+  (over-aggressive).
+- PR #866 — corpus-regression repair (rising-pressure gate in flow-mode
+  windows, ≥ 1 s post-trim guard on grind ranges).
+- PR #890 — skip-first-frame uses the configured first-frame seconds, not
+  a hard 2 s constant.
+- PR #891 — choked-puck arm on pressure-mode pours.
+- PR #892 — moderate grind-too-fine via yield/target ratio.
+- PR #893 — recompute every quality badge on shot load + lazy persist on
+  view.
+- Issue #894 — residual stored-column drift (history-list filter and
+  `shots_list` MCP read stored, not recomputed values).
+
+External resources that informed the diagnostic patterns:
+
+- Visualizer.coffee: <https://github.com/miharekar/visualizer> (conductance /
+  resistance formulas, dC/dt smoothing kernel).
+- GaggiMate MCP: <https://github.com/julianleopold/gaggimate-mcp> (Darcy
+  resistance, channeling risk scoring, profile compliance).
+- Coffee ad Astra puck resistance study: <https://coffeeadastra.com/2021/01/16/a-study-of-espresso-puck-resistance-and-how-puck-preparation-affects-it/>.
+- Espresso Compass (Barista Hustle): <https://www.baristahustle.com/the-espresso-compass/>.


### PR DESCRIPTION
## Summary
- Renames `docs/SHOT_REVIEW_IMPROVEMENTS.md` → `docs/SHOT_REVIEW.md` and rewrites it in place as a single canonical reference for the badge / detector system and the Shot Summary dialog as they work today, replacing the Tier 1 plan + addenda structure.
- Captures the changes from the last couple of weeks (#811, #864, #866, #890, #891, #892, #893) so Claude and human contributors have a current source of truth instead of patching addenda onto a stale plan.
- Acknowledges that detectors are still under active iteration; the doc is explicitly framed as a snapshot and points readers at the well-commented `src/ai/shotanalysis.h` when in doubt.

## What the new doc covers
- §1 Basic vs Advanced mode (what each gates), the four quality badges (color / label / source), and the trailing "Shot Summary" chip.
- §2 Detector internals: channeling windowing rules + dC/dt thresholds, two-arm grind detector (flow-vs-goal trims + pressure-mode choked-puck flow/yield arms), temperature stability, skip-first-frame FW-bug vs short-first-step branches, pour-truncated.
- §3 **Shot Summary dialog**: the pipeline (QualityBadges → ShotAnalysisDialog → `generateShotSummary` → `generateSummary`), line types and rendering, the seven observation kinds emitted in order, verdict precedence cascade, lifecycle (regenerated on every open).
- §4 Persistence: save-time stored columns, always-recompute on load (#893), lazy persist via `requestReanalyzeBadges`, residual gap on history-list filter / `shots_list` MCP (#894).
- §5 Code map for detector logic, persistence (incl. `generateShotSummary`), profile-level analysis flags, QML components (incl. `ShotAnalysisDialog`), MCP.
- §6 Regression corpus: `tools/shot_eval/`, `tests/data/shots/manifest.json`, `shot_corpus_regression` ctest target.
- §7 Updated reference list covering #649 → #893 plus #894.

Closes #867.

## Test plan
- [ ] Render the new file on GitHub and confirm formatting (tables, fenced blocks, links, section numbering).
- [ ] Spot-check the constants in §2 (`CHANNELING_DC_*`, `WINDOW_*`, `GRIND_*`, `CHOKED_*`, `TEMP_*`) against `src/ai/shotanalysis.h`.
- [ ] Spot-check the verdict precedence in §3 against the cascade in `ShotAnalysis::generateSummary`.
- [ ] Spot-check the file/function references in §5 still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)