### PR TITLE
fix(analysis): gate temperatureUnstable on the shot reaching real extraction

### DIFF
--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -185,6 +185,16 @@ virtual scale (dose-aware flow integration), so the arm fires headless too.
 The simplest of the four. `temperatureUnstable = true` when:
 
 - `temperature` and `temperatureGoal` both have > 10 samples, AND
+- `pourStart > 0` (a Pour / infus / Start phase marker was found — without
+  it, `avgTempDeviation` would average from t=0 and pull in the preheat
+  ramp), AND
+- `reachedExtractionPhase(phases, duration)` is true: at least one phase
+  marker with `frameNumber ≥ 1` exists `TEMP_MIN_EXTRACTION_SEC` (1.0 s)
+  before the shot's last sample. Aborted shots that died during
+  preinfusion-start would otherwise read the machine's preheat ramp as
+  drift; the firmware sometimes records the 0→1 transition in the final
+  ms before stop, so a marker-presence-only check is not enough — the
+  phase has to have actually lasted, AND
 - `hasIntentionalTempStepping(temperatureGoal)` is false (goal range ≤
   `TEMP_STEPPING_RANGE` = 5 °C — D-Flow 84 → 94 is intentional, ignore), AND
 - `avgTempDeviation(temperature, temperatureGoal, pourStart, pourEnd) >
@@ -192,6 +202,12 @@ The simplest of the four. `temperatureUnstable = true` when:
 
 `avgTempDeviation` is the average absolute deviation over the pour window
 where the goal is non-zero.
+
+The `pourStart > 0` and `reachedExtractionPhase` guards are applied at
+all three call sites (`generateSummary`, `saveShot`, `loadShotRecordStatic`)
+so live, save-time, and recompute-on-load all converge on the same flag
+value — important because `loadShotRecordStatic` writes drift back to the
+DB (see §4) and any asymmetry would silently flip flags between sessions.
 
 ### 2.4 Skip first frame
 

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -322,6 +322,23 @@ double ShotAnalysis::avgTempDeviation(const QVector<QPointF>& tempData,
     return count > 0 ? devSum / count : 0.0;
 }
 
+bool ShotAnalysis::reachedExtractionPhase(const QList<HistoryPhaseMarker>& phases,
+                                           double shotDuration)
+{
+    if (shotDuration <= 0.0) return false;
+    for (const auto& pm : phases) {
+        if (pm.frameNumber < 1) continue;
+        // Frame ≥ 1 marker found. The shot must have continued past it for
+        // long enough to actually run extraction. Aborted shots sometimes
+        // record the 0→1 transition in firmware in the final ms before the
+        // shot ends (frame marker present, but no samples land inside it),
+        // so a presence-only check would let those slip through.
+        if (shotDuration - pm.time >= TEMP_MIN_EXTRACTION_SEC)
+            return true;
+    }
+    return false;
+}
+
 double ShotAnalysis::findValueAtTime(const QVector<QPointF>& data, double time)
 {
     if (data.isEmpty()) return 0.0;
@@ -736,7 +753,10 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
     }
 
     // --- Temperature stability ---
-    if (temperature.size() > 10 && temperatureGoal.size() > 10 && pourStart > 0) {
+    // Gated on reachedExtractionPhase so aborted shots that died during
+    // preinfusion-start (frame 0 only) don't fire on the preheat ramp.
+    if (temperature.size() > 10 && temperatureGoal.size() > 10 && pourStart > 0
+        && reachedExtractionPhase(phases, duration)) {
         if (!hasIntentionalTempStepping(temperatureGoal)) {
             double avgDev = avgTempDeviation(temperature, temperatureGoal, pourStart, pourEnd);
             if (avgDev > TEMP_UNSTABLE_THRESHOLD) {

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -29,6 +29,7 @@ public:
     static constexpr double CHANNELING_MAX_AVG_FLOW = 3.0;        // mL/s — skip turbo/filter shots
     static constexpr double TEMP_UNSTABLE_THRESHOLD = 2.0;        // °C avg deviation from goal
     static constexpr double TEMP_STEPPING_RANGE = 5.0;            // °C goal range = intentional stepping
+    static constexpr double TEMP_MIN_EXTRACTION_SEC = 1.0;        // min seconds of extraction past frame 1 to score temp
 
     // Mode-aware detection window tuning. A sample counts toward channeling
     // detection only inside a window where the active control goal (pressure
@@ -134,6 +135,17 @@ public:
     static double avgTempDeviation(const QVector<QPointF>& tempData,
                                     const QVector<QPointF>& tempGoalData,
                                     double startTime, double endTime);
+
+    // Returns true when the shot reached actual extraction — at least one phase
+    // marker with frameNumber >= 1 sits more than TEMP_MIN_EXTRACTION_SEC before
+    // the shot's last sample. Used to gate the temperature-stability detector
+    // so that aborted shots which died during preinfusion-start don't get
+    // flagged for temp drift caused by the machine still preheating. Frame 1 is
+    // sometimes recorded in firmware in the final ms of an aborted shot
+    // (the marker exists but no samples land inside it), so checking marker
+    // presence alone is not sufficient — we require the phase to have lasted.
+    static bool reachedExtractionPhase(const QList<HistoryPhaseMarker>& phases,
+                                        double shotDuration);
 
     // --- Helpers ---
 

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -954,12 +954,15 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
 
         // Temperature stability using shared ShotAnalysis helpers. Gated on
         // reachedExtractionPhase so aborted shots that died during preinfusion-
-        // start (frame 0 only) don't get flagged for temp drift caused by the
-        // machine still preheating against an 82 °C goal.
+        // start don't get flagged for temp drift caused by the machine still
+        // preheating against an 82 °C goal. The pourStart > 0 conjunct
+        // matches generateSummary and prevents avgTempDeviation from averaging
+        // from t=0 (which would include the preheat ramp) when phase labels
+        // are unusual enough that no Pour/infus/Start marker was found.
         data.temperatureUnstable = false;
         const auto& tempPts = shotData->temperatureData();
         const auto& tempGoalPts = shotData->temperatureGoalData();
-        if (tempPts.size() > 10 && tempGoalPts.size() > 10
+        if (tempPts.size() > 10 && tempGoalPts.size() > 10 && pourStart > 0
             && ShotAnalysis::reachedExtractionPhase(tmpRecord.phases, duration)) {
             if (!ShotAnalysis::hasIntentionalTempStepping(tempGoalPts)) {
                 double avgDev = ShotAnalysis::avgTempDeviation(tempPts, tempGoalPts, pourStart, pourEnd);
@@ -2221,10 +2224,14 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
         }
 
         // Temperature stability. Gated on reachedExtractionPhase so aborted
-        // shots that died during preinfusion-start (frame 0 only) don't get
-        // flagged for temp drift caused by the machine still preheating.
+        // shots that died during preinfusion-start don't get flagged for
+        // temp drift caused by the machine still preheating. The pourStart
+        // > 0 conjunct matches generateSummary and prevents avgTempDeviation
+        // from averaging from t=0 (which would include the preheat ramp)
+        // when phase labels are unusual enough that no Pour/infus/Start
+        // marker was found.
         record.temperatureUnstable = false;
-        if (record.temperature.size() > 10 && record.temperatureGoal.size() > 10
+        if (record.temperature.size() > 10 && record.temperatureGoal.size() > 10 && pourStart > 0
             && ShotAnalysis::reachedExtractionPhase(record.phases, record.summary.duration)) {
             if (!ShotAnalysis::hasIntentionalTempStepping(record.temperatureGoal)) {
                 double avgDev = ShotAnalysis::avgTempDeviation(record.temperature, record.temperatureGoal, pourStart, pourEnd);

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -952,11 +952,15 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
             data.channelingDetected = (severity == ShotAnalysis::ChannelingSeverity::Sustained);
         }
 
-        // Temperature stability using shared ShotAnalysis helpers
+        // Temperature stability using shared ShotAnalysis helpers. Gated on
+        // reachedExtractionPhase so aborted shots that died during preinfusion-
+        // start (frame 0 only) don't get flagged for temp drift caused by the
+        // machine still preheating against an 82 °C goal.
         data.temperatureUnstable = false;
         const auto& tempPts = shotData->temperatureData();
         const auto& tempGoalPts = shotData->temperatureGoalData();
-        if (tempPts.size() > 10 && tempGoalPts.size() > 10) {
+        if (tempPts.size() > 10 && tempGoalPts.size() > 10
+            && ShotAnalysis::reachedExtractionPhase(tmpRecord.phases, duration)) {
             if (!ShotAnalysis::hasIntentionalTempStepping(tempGoalPts)) {
                 double avgDev = ShotAnalysis::avgTempDeviation(tempPts, tempGoalPts, pourStart, pourEnd);
                 data.temperatureUnstable = avgDev > ShotAnalysis::TEMP_UNSTABLE_THRESHOLD;
@@ -2216,9 +2220,12 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
             record.channelingDetected = (severity == ShotAnalysis::ChannelingSeverity::Sustained);
         }
 
-        // Temperature stability
+        // Temperature stability. Gated on reachedExtractionPhase so aborted
+        // shots that died during preinfusion-start (frame 0 only) don't get
+        // flagged for temp drift caused by the machine still preheating.
         record.temperatureUnstable = false;
-        if (record.temperature.size() > 10 && record.temperatureGoal.size() > 10) {
+        if (record.temperature.size() > 10 && record.temperatureGoal.size() > 10
+            && ShotAnalysis::reachedExtractionPhase(record.phases, record.summary.duration)) {
             if (!ShotAnalysis::hasIntentionalTempStepping(record.temperatureGoal)) {
                 double avgDev = ShotAnalysis::avgTempDeviation(record.temperature, record.temperatureGoal, pourStart, pourEnd);
                 record.temperatureUnstable = avgDev > ShotAnalysis::TEMP_UNSTABLE_THRESHOLD;


### PR DESCRIPTION
## Summary
- Live verification of v1.7.2 prerelease against shot history surfaced a clean false positive: shot 885 — a 2.3 s shot aborted during preinfusion-start — was firing `temperatureUnstable=true`. The detector was averaging the machine's preheat ramp (68 → 75 °C against an 82 °C goal) across an extraction that never actually started, producing ~9 °C average deviation and tripping the 2 °C threshold.
- Add `ShotAnalysis::reachedExtractionPhase(phases, shotDuration)` and gate all three temperature-unstable call sites on it. The function returns true only when at least one `frameNumber >= 1` marker sits more than `TEMP_MIN_EXTRACTION_SEC` (1.0 s) before the shot's last sample.
- The duration buffer matters: phase-marker presence alone is not enough, because the firmware sometimes records the 0 → 1 transition in the final ms of an aborted shot. Shot 885 is exactly that — a frame-1 marker exists at `time=2.5` but the shot ended at `2.284`, so no samples landed in frame 1. The gate now correctly excludes that case.

## Detection results

| Shot | Duration | Frame ≥ 1 entered at | Past frame 1 | New gate |
|------|----------|---------------------:|-------------:|----------|
| 885 (aborted preheat) | 2.284 s | 2.5 s | -0.216 s | **skip** |
| 891 (clean 80's, 36 g) | 20.189 s | 1.873 s | 18.316 s | run |
| 890 (puck failure, 1.1 g yield) | 59.554 s | ~2 s | ~58 s | run |

## Three call sites updated

- `ShotHistoryStorage::saveShotStatic` — save-time write of `temperatureUnstable` column.
- `ShotHistoryStorage::loadShotRecordStatic` — load-time recompute (the path that PR #896 made canonical).
- `ShotAnalysis::generateSummary` — the `Temperature drifted X°C from goal on average` observation in the Shot Summary dialog.

## Why not just \"don't save aborted shots\"

That's a separate, larger discussion (user-visible behavior change, settings toggle, threshold definitions, telemetry). Even if we add a save-time filter for future shots, legacy aborts already in the DB still need this gate. Issue forthcoming.

## Test plan
- [x] `mcp__qtcreator__build` — clean, 0 errors / 0 warnings.
- [x] `mcp__qtcreator__run_tests` — 1742 passed, 0 failed, 0 warnings.
- [x] `shot_corpus_regression` ctest — passes (no fixture verdict changed).
- [ ] On-device: open shot 885 in detail view, confirm chip no longer shows \"Temp unstable\".
- [ ] Confirm a normal shot with real temp drift still flags (next time we see one in history; nothing in the recent corpus has fired this badge legitimately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)