### PR TITLE
docs(claude): point CLAUDE.md at docs/SHOT_REVIEW.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,8 @@ Detailed documentation lives in `docs/CLAUDE_MD/`. Read these when working in th
 | `AI_ADVISOR.md` | AI dialing assistant design |
 | `SETTINGS.md` | Settings architecture: 7 domain sub-objects, how to add properties/domains, QML access pattern, build-blast rules |
 
+Read [`docs/SHOT_REVIEW.md`](https://github.com/Kulitorum/Decenza/blob/main/docs/SHOT_REVIEW.md) when working on the post-shot review / shot detail pages, the four quality-badge detectors (channeling, grind issue, temperature unstable, skip-first-frame), the Shot Summary dialog, badge persistence, or `src/ai/shotanalysis.{h,cpp}`. It is the source of truth for detector internals, gate semantics, and the recompute-on-load contract; keep it in sync when changing any of the above.
+
 ## Development Environment
 
 - **ADB path**: `/c/Users/Micro/AppData/Local/Android/Sdk/platform-tools/adb.exe`


### PR DESCRIPTION
## Summary
- Adds an explicit reference paragraph in `CLAUDE.md` pointing at [`docs/SHOT_REVIEW.md`](https://github.com/Kulitorum/Decenza/blob/main/docs/SHOT_REVIEW.md) so AI assistants know it's the source of truth for the post-shot review pages, the four quality-badge detectors, the Shot Summary dialog, badge persistence, and `src/ai/shotanalysis.{h,cpp}`.
- Notes that the doc must be kept in sync when those areas change.

## Test plan
- [x] `CLAUDE.md` renders correctly (markdown link + paragraph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)