### PR TITLE
fix(mcp): harden SSE socket lifetime to prevent macOS CFSocket UAF

### DIFF
--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -322,8 +322,15 @@ void McpServer::handleHttpRequest(QTcpSocket* socket, const QString& method,
             return;
         }
 
-        // SSE stream for server-initiated notifications
-        if (static_cast<int>(m_sseClients.size()) >= MaxSseConnections) {
+        // SSE stream for server-initiated notifications. Count only live entries —
+        // a QPointer that has gone null (socket destroyed before our disconnect
+        // lambda ran) still occupies a slot until probeSseKeepalives() GCs it on
+        // the next 30 s tick, and we don't want stale nulls to falsely trip the
+        // limit and reject a legitimate client.
+        int liveSseCount = 0;
+        for (const QPointer<QTcpSocket>& p : std::as_const(m_sseClients))
+            if (!p.isNull()) ++liveSseCount;
+        if (liveSseCount >= MaxSseConnections) {
             sendHttpResponse(socket, 429, "Too many SSE connections", "text/plain");
             return;
         }

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -146,10 +146,11 @@ void McpServer::broadcastSseNotification(const QString& resourceUri)
 
     // Send only to sessions that subscribed to this resource URI.
     // Sessions without any subscriptions receive all notifications (backward compat).
-    QList<QTcpSocket*> dead;
-    for (QTcpSocket* client : std::as_const(m_sseClients)) {
-        if (client->state() != QAbstractSocket::ConnectedState) {
-            dead.append(client);
+    QList<QPointer<QTcpSocket>> dead;
+    for (const QPointer<QTcpSocket>& clientPtr : std::as_const(m_sseClients)) {
+        QTcpSocket* client = clientPtr.data();
+        if (!client || client->state() != QAbstractSocket::ConnectedState) {
+            dead.append(clientPtr);
             continue;
         }
 
@@ -169,8 +170,37 @@ void McpServer::broadcastSseNotification(const QString& resourceUri)
             client->flush();
         }
     }
-    for (QTcpSocket* client : dead)
-        m_sseClients.remove(client);
+    for (const QPointer<QTcpSocket>& p : dead)
+        m_sseClients.removeAll(p);
+}
+
+bool McpServer::isSseClient(QTcpSocket* socket) const
+{
+    if (!socket) return false;
+    return m_sseClients.contains(QPointer<QTcpSocket>(socket));
+}
+
+void McpServer::probeSseKeepalives()
+{
+    QList<QPointer<QTcpSocket>> dead;
+    for (const QPointer<QTcpSocket>& clientPtr : std::as_const(m_sseClients)) {
+        QTcpSocket* client = clientPtr.data();
+        if (!client || client->state() != QAbstractSocket::ConnectedState
+                    || client->write(": keepalive\n\n") == -1) {
+            dead.append(clientPtr);
+            continue;
+        }
+        client->flush();
+    }
+    // ShotServer owns the QTcpSocket lifetime; we just unsubscribe and let
+    // its onDisconnected drive deleteLater. close() emits disconnected
+    // synchronously, which fires our own lambda and removes from m_sseClients
+    // again (no-op once removed).
+    for (const QPointer<QTcpSocket>& p : dead) {
+        m_sseClients.removeAll(p);
+        if (QTcpSocket* c = p.data())
+            c->close();
+    }
 }
 
 McpServer::~McpServer()
@@ -317,12 +347,12 @@ void McpServer::handleHttpRequest(QTcpSocket* socket, const QString& method,
         socket->write(response);
         socket->flush();
 
-        m_sseClients.insert(socket);
+        m_sseClients.append(QPointer<QTcpSocket>(socket));
         if (sseSession)
             sseSession->setSseSocket(socket);
 
         connect(socket, &QTcpSocket::disconnected, this, [this, socket]() {
-            m_sseClients.remove(socket);
+            m_sseClients.removeAll(QPointer<QTcpSocket>(socket));
             // Clear the session's SSE socket reference — the client may reconnect
             // SSE without re-initializing, so keep the session alive.
             for (auto* s : std::as_const(m_sessions)) {

--- a/src/mcp/mcpserver.h
+++ b/src/mcp/mcpserver.h
@@ -8,7 +8,7 @@
 #include <QTimer>
 #include <QPair>
 #include <QPointer>
-#include <QSet>
+#include <QList>
 #include <optional>
 
 class McpSession;
@@ -62,6 +62,12 @@ public:
     void handleHttpRequest(QTcpSocket* socket, const QString& method,
                            const QString& path, const QByteArray& headers,
                            const QByteArray& body);
+
+    // Called by ShotServer to keep SSE-aware code paths in sync with raw HTTP
+    // socket handling. ShotServer owns the QTcpSocket; McpServer just tracks
+    // which of those sockets are upgraded to SSE.
+    bool isSseClient(QTcpSocket* socket) const;
+    void probeSseKeepalives();
 
     int activeSessionCount() const { return static_cast<int>(m_sessions.size()); }
 
@@ -141,8 +147,14 @@ private:
     // Rate limiting
     QTimer* m_rateLimitTimer;
 
-    // SSE clients
-    QSet<QTcpSocket*> m_sseClients;
+    // SSE clients. Stored as QPointer so that if ShotServer destroys the
+    // underlying socket without us seeing the disconnected signal first
+    // (e.g. teardown ordering on macOS), iteration goes to nullptr instead
+    // of dangling — the macOS QCFSocketNotifier crash on shutdown was use-
+    // after-free of exactly this kind of raw socket pointer. QList rather
+    // than QSet because QPointer has no qHash overload and the list is
+    // bounded by MaxSseConnections (4) — linear scans are trivial.
+    QList<QPointer<QTcpSocket>> m_sseClients;
     void broadcastSseNotification(const QString& resourceUri);
 
     // In-app confirmation (machine_start_* tools)

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -354,13 +354,18 @@ void ShotServer::setSettings(Settings* settings)
 }
 
 // Precondition: no socket in `clients` has an entry in m_keepAliveTimers.
-// This is enforced at each SSE registration site by calling take() on the map:
-//   /api/theme/subscribe  — see handleRequest(), "m_sseThemeClients.insert"
-//   /api/layout/events    — see handleRequest(), "m_sseLayoutClients.insert"
-// If a new SSE endpoint is added WITHOUT calling take(), this function will call
-// deleteLater() on the socket while its timer lambda still holds a raw pointer to
-// it — causing use-after-free when the timer fires. This static function has no
-// access to m_keepAliveTimers, so callers must maintain the invariant.
+// This is enforced at each SSE registration site by either calling take() on
+// the map, or by routing the request such that sendResponse/resetKeepAliveTimer
+// is never called. Current sites:
+//   /api/theme/subscribe  — see handleRequest(), "m_sseThemeClients.insert" (calls take())
+//   /api/layout/events    — see handleRequest(), "m_sseLayoutClients.insert" (calls take())
+//   /mcp (SSE GET)        — bypasses sendResponse entirely; McpServer manages its own
+//                           m_sseClients list and ShotServer never inserts a timer
+// If a new SSE endpoint is added that goes through sendResponse without calling
+// take(), this function will call deleteLater() on the socket while its timer
+// lambda still holds a raw pointer to it — causing use-after-free when the timer
+// fires. This static function has no access to m_keepAliveTimers, so callers
+// must maintain the invariant.
 static void broadcastSseEvent(QSet<QTcpSocket*>& clients, const QByteArray& event)
 {
     QList<QTcpSocket*> dead;
@@ -936,7 +941,11 @@ void ShotServer::onCleanupTimerTick()
     // MCP SSE clients live in McpServer's set; have it run its own probe so
     // silently-dropped MCP connections are detected on the same 30 s cadence.
     // McpServer only close()s — ShotServer remains the sole destroyer via
-    // onDisconnected → deleteLater.
+    // onDisconnected → deleteLater. That contract relies on onNewConnection
+    // wiring `disconnected → onDisconnected` for every accepted socket; if
+    // that connect is ever removed, McpServer::probeSseKeepalives() will leak
+    // the socket because close() will fire disconnected with no slot to
+    // schedule deleteLater().
     if (m_mcpServer)
         m_mcpServer->probeSseKeepalives();
 }

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -558,9 +558,12 @@ void ShotServer::onReadyRead()
     // entry becomes dangling once deleteLater destroys the socket and its child timer.
     if (socket->state() != QAbstractSocket::ConnectedState) return;
 
-    // SSE clients keep connections open — ignore further data from them
+    // SSE clients keep connections open — ignore further data from them.
+    // MCP SSE sockets live in McpServer's set, not ours, so route the check
+    // through the accessor.
     if (m_sseLayoutClients.contains(socket)) return;
     if (m_sseThemeClients.contains(socket)) return;
+    if (m_mcpServer && m_mcpServer->isSseClient(socket)) return;
 
     // Stop keep-alive idle timer while processing incoming request data
     if (QTimer* t = m_keepAliveTimers.value(socket))
@@ -929,6 +932,13 @@ void ShotServer::onCleanupTimerTick()
             c->deleteLater();
         }
     }
+
+    // MCP SSE clients live in McpServer's set; have it run its own probe so
+    // silently-dropped MCP connections are detected on the same 30 s cadence.
+    // McpServer only close()s — ShotServer remains the sole destroyer via
+    // onDisconnected → deleteLater.
+    if (m_mcpServer)
+        m_mcpServer->probeSseKeepalives();
 }
 
 void ShotServer::onDiscoveryDatagram()


### PR DESCRIPTION
## Summary
- MCP SSE clients are now stored as `QList<QPointer<QTcpSocket>>` so a dropped socket reads as null instead of dangling on iteration — addresses the macOS `qt_mac_socket_callback` SIGSEGV observed after \"SSE client disconnected\" in the log.
- `McpServer::isSseClient()` lets `ShotServer::onReadyRead` skip MCP SSE sockets next to the existing layout/theme early-returns.
- `McpServer::probeSseKeepalives()` is invoked from `onCleanupTimerTick` so dead MCP connections are detected on the same 30 s cadence as the other SSE types. `ShotServer` remains the sole destroyer via `onDisconnected → deleteLater`.

## Why
A user-reported SIGSEGV on macOS crashed at:
```
__CFSocketPerformV0 → qt_mac_socket_callback → QCoreApplication::sendEvent → notifyInternal2
```
with `McpServer: SSE client disconnected, remaining: 0` as the last log line. Tracing showed three problems with how MCP SSE sockets were managed:
1. Raw `QTcpSocket*` storage in `m_sseClients` and a single signal-driven removal — no defense against teardown ordering races.
2. MCP SSE sockets were not in the SSE-aware early-return in `onReadyRead`, unlike layout/theme SSE clients.
3. No keepalive probe for MCP SSE clients — silently-broken connections sat until the OS surfaced the disconnect.

## Test plan
- [ ] Build cleanly on macOS (verified — `mcp__qtcreator__build` succeeded, 0 warnings)
- [ ] Connect an MCP client (e.g. `mcp-remote`), let it idle past the 30 s cleanup tick, confirm keepalive comments are visible on the wire
- [ ] Disconnect the MCP client and confirm `m_sseClients` empties without crash
- [ ] Run for an extended idle session on macOS (the original crash reproduced after several hours of idle SSE reconnects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)