### PR TITLE
fix(location): suppress transient CoreLocation errors during permission-granted state

### DIFF
--- a/src/network/locationprovider.cpp
+++ b/src/network/locationprovider.cpp
@@ -196,14 +196,13 @@ void LocationProvider::onPositionError(QGeoPositionInfoSource::Error error)
     switch (error) {
     case QGeoPositionInfoSource::AccessError:
 #if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
-        // Qt's CoreLocation backend maps every CLLocationManager error to
-        // AccessError, including the transient kCLErrorLocationUnknown that
-        // fires while a fix is still being acquired (e.g. Wi-Fi geolocation
-        // cache miss). Only treat this as a real permission denial when the
-        // OS actually says permission isn't granted; otherwise let the 60 s
-        // UpdateTimeoutError path decide.
+        // Qt's CoreLocation backend collapses every CLLocationManager failure
+        // to AccessError (see qgeopositioninfosource_cl.mm), so this fires for
+        // transient errors too. Only treat it as a real denial when the OS
+        // confirms it; otherwise let the UpdateTimeoutError path decide.
         if (qApp->checkPermission(QLocationPermission{}) == Qt::PermissionStatus::Granted) {
-            qDebug() << "LocationProvider: Transient CoreLocation error while permission is granted, ignoring";
+            qWarning() << "LocationProvider: Swallowing CoreLocation AccessError while permission is Granted "
+                          "(treating as transient); awaiting timeout or fresh fix";
             return;
         }
 #endif

--- a/src/network/locationprovider.cpp
+++ b/src/network/locationprovider.cpp
@@ -195,6 +195,18 @@ void LocationProvider::onPositionError(QGeoPositionInfoSource::Error error)
     QString errorStr;
     switch (error) {
     case QGeoPositionInfoSource::AccessError:
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+        // Qt's CoreLocation backend maps every CLLocationManager error to
+        // AccessError, including the transient kCLErrorLocationUnknown that
+        // fires while a fix is still being acquired (e.g. Wi-Fi geolocation
+        // cache miss). Only treat this as a real permission denial when the
+        // OS actually says permission isn't granted; otherwise let the 60 s
+        // UpdateTimeoutError path decide.
+        if (qApp->checkPermission(QLocationPermission{}) == Qt::PermissionStatus::Granted) {
+            qDebug() << "LocationProvider: Transient CoreLocation error while permission is granted, ignoring";
+            return;
+        }
+#endif
         errorStr = "Location permission denied";
         break;
     case QGeoPositionInfoSource::ClosedError:


### PR DESCRIPTION
## Summary
- Qt's CoreLocation backend maps every \`CLLocationManager didFailWithError\` to \`QGeoPositionInfoSource::AccessError\`, including the transient \`kCLErrorLocationUnknown\` (error 0) that fires while a fix is still being acquired (Wi-Fi geolocation cache miss, slow network, etc.).
- Our \`onPositionError\` switch dutifully mapped \`AccessError\` → \`"Location permission denied"\`, which produced the granted-then-denied 8 ms apart log sequence in #907 and meant shots got saved without GPS metadata for the rest of the session.
- On macOS/iOS, re-check the actual OS permission status when \`AccessError\` fires; if the OS still reports \`Granted\`, swallow the transient error and let the 60 s \`UpdateTimeoutError\` path decide.

Fixes #907.

## Test plan
- [ ] Cold-start on a Mac with no recent CL fix and confirm the log no longer reports "Location permission denied" right after "Location permission granted"
- [ ] Confirm shots still get GPS metadata once a real fix arrives (or fall back through \`UpdateTimeoutError\` after 60 s)
- [ ] Sanity: revoke Location Services in System Settings, restart, confirm we still surface the genuine "Location permission denied" path

🤖 Generated with [Claude Code](https://claude.com/claude-code)