### PR TITLE
fix(saw): capture per-shot log lines for SAW learning

### DIFF
--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -4,6 +4,7 @@
 #include "../core/settings.h"
 #include "../machine/machinestate.h"
 #include <QDebug>
+#include <QScopeGuard>
 
 ShotTimingController::ShotTimingController(DE1Device* device, QObject* parent)
     : QObject(parent)
@@ -491,7 +492,13 @@ void ShotTimingController::onSettlingComplete()
     // Settling is done - stop display timer and notify UI
     m_displayTimer.stop();
     emit sawSettlingChanged();
-    emit shotProcessingReady();
+
+    // Defer shotProcessingReady until after sawLearningComplete fires. onShotEnded()
+    // calls ShotDebugLogger::stopCapture(), so any qDebug emitted after that point is
+    // dropped from the per-shot log. SAW_LEARNING.md requires the [SAW] accuracy /
+    // accumulated / committed lines to land in the per-shot log, so we run the SAW
+    // path first and emit shotProcessingReady on scope exit.
+    auto deferProcessing = qScopeGuard([this] { emit shotProcessingReady(); });
 
     // Check scale is still connected
     if (!m_scale || !m_scale->isConnected()) {

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -493,11 +493,11 @@ void ShotTimingController::onSettlingComplete()
     m_displayTimer.stop();
     emit sawSettlingChanged();
 
-    // Defer shotProcessingReady until after sawLearningComplete fires. onShotEnded()
-    // calls ShotDebugLogger::stopCapture(), so any qDebug emitted after that point is
-    // dropped from the per-shot log. SAW_LEARNING.md requires the [SAW] accuracy /
-    // accumulated / committed lines to land in the per-shot log, so we run the SAW
-    // path first and emit shotProcessingReady on scope exit.
+    // Emit shotProcessingReady on scope exit so qDebug from the SAW path lands in
+    // the per-shot log before the downstream slot closes the capture window.
+    // SAW_LEARNING.md requires those lines in the per-shot log. Relies on direct
+    // (same-thread) connections — a queued connection on either signal would defeat
+    // the ordering.
     auto deferProcessing = qScopeGuard([this] { emit shotProcessingReady(); });
 
     // Check scale is still connected

--- a/src/controllers/shottimingcontroller.h
+++ b/src/controllers/shottimingcontroller.h
@@ -167,4 +167,8 @@ private:
     // Display timer (for smooth UI updates between BLE samples)
     QTimer m_displayTimer;
     qint64 m_displayTimeBase = 0;  // Wall clock when shot started
+
+#ifdef DECENZA_TESTING
+    friend class tst_Settling;
+#endif
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -337,6 +337,7 @@ add_decenza_test(tst_saw
 find_package(Qt6 REQUIRED COMPONENTS Charts Quick)
 add_decenza_test(tst_settling
     tst_settling.cpp
+    mocks/MockScaleDevice.h
     ${CMAKE_SOURCE_DIR}/src/ai/conductance.cpp
     ${CMAKE_SOURCE_DIR}/src/models/shotdatamodel.cpp
     ${CMAKE_SOURCE_DIR}/src/rendering/fastlinerenderer.cpp

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -202,6 +202,10 @@ private slots:
         scale.mockSetConnected(true);
         tc.setScale(&scale);
 
+        // ScaleDevice's destructor emits a DISCONNECTED warning as the mock goes out
+        // of scope at test end; mark it expected per docs/CLAUDE_MD/TESTING.md.
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("DISCONNECTED"));
+
         // Populate state so onSettlingComplete passes every guard and reaches the
         // sawLearningComplete emit: drip=1.5g, flow=1.5ml/s, overshoot=0.5g.
         tc.m_weightAtStop = 35.0;

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -1,10 +1,12 @@
 #include <QtTest>
 #include <QSignalSpy>
 #include <QRegularExpression>
+#include <QStringList>
 
 #include "models/shotdatamodel.h"
 #include "controllers/shottimingcontroller.h"
 #include "ble/de1device.h"
+#include "mocks/MockScaleDevice.h"
 
 // Test SAW settling behavior: trimSettlingData(), m_sawSettling flag lifecycle,
 // and the interaction between settling completion and shot save ordering.
@@ -187,6 +189,55 @@ private slots:
         // Settlement depends on the timer, so just verify settling is still active
         // (not prematurely cancelled by the guard itself).
         QVERIFY(tc.isSawSettling());
+    }
+
+    void sawLearningCompleteFiresBeforeShotProcessingReady() {
+        // SAW_LEARNING.md requires the [SAW] accuracy / accumulated / committed lines
+        // to land in the per-shot debug log. shotProcessingReady triggers stopCapture
+        // downstream, so sawLearningComplete (and the qDebug it drives) must fire first.
+        DE1Device device;
+        ShotTimingController tc(&device);
+
+        MockScaleDevice scale;
+        scale.mockSetConnected(true);
+        tc.setScale(&scale);
+
+        // Populate state so onSettlingComplete passes every guard and reaches the
+        // sawLearningComplete emit: drip=1.5g, flow=1.5ml/s, overshoot=0.5g.
+        tc.m_weightAtStop = 35.0;
+        tc.m_flowRateAtStop = 1.5;
+        tc.m_targetWeightAtStop = 36.0;
+        tc.m_weight = 36.5;
+        tc.m_sawSettling = true;
+
+        QStringList order;
+        QObject::connect(&tc, &ShotTimingController::sawLearningComplete,
+                         [&order](double, double, double) { order << "sawLearningComplete"; });
+        QObject::connect(&tc, &ShotTimingController::shotProcessingReady,
+                         [&order]() { order << "shotProcessingReady"; });
+
+        tc.onSettlingComplete();
+
+        QCOMPARE(order, (QStringList{"sawLearningComplete", "shotProcessingReady"}));
+    }
+
+    void shotProcessingReadyEmittedOnEarlyReturnFromSettling() {
+        // Even when SAW learning is skipped (e.g. scale disconnected at settling),
+        // shotProcessingReady must still fire — the QScopeGuard in onSettlingComplete
+        // is what guarantees this on every code path.
+        DE1Device device;
+        ShotTimingController tc(&device);
+        // No scale set → onSettlingComplete takes the "scale disconnected" early return.
+        tc.m_sawSettling = true;
+
+        QSignalSpy sawSpy(&tc, &ShotTimingController::sawLearningComplete);
+        QSignalSpy readySpy(&tc, &ShotTimingController::shotProcessingReady);
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Scale disconnected"));
+        tc.onSettlingComplete();
+
+        QCOMPARE(sawSpy.count(), 0);   // learning skipped
+        QCOMPARE(readySpy.count(), 1); // but shot still saves
     }
 
     void startShotCancelsSettlingAndEmitsReady() {


### PR DESCRIPTION
## Summary
- `ShotTimingController::onSettlingComplete` emitted `shotProcessingReady` before `sawLearningComplete`. Because `shotProcessingReady` synchronously runs `MainController::onShotEnded`, which calls `ShotDebugLogger::stopCapture()`, the `[SAW] accuracy` / `accumulated` / `committed` `qDebug` lines that fire afterward were dropped from the per-shot log (system log only) — violating the contract in [`docs/CLAUDE_MD/SAW_LEARNING.md`](https://github.com/Kulitorum/Decenza/blob/main/docs/CLAUDE_MD/SAW_LEARNING.md).
- Wrap `shotProcessingReady` in a `QScopeGuard` so it always fires exactly once on function exit, after `sawLearningComplete` and the early-return `qWarning` paths. Auto flow cal already follows the same "log before stopCapture" ordering ([`maincontroller.cpp:1768`](https://github.com/Kulitorum/Decenza/blob/main/src/controllers/maincontroller.cpp#L1768)); SAW just took a different signal path and missed it.

Confirmed empirically on this machine: shots 891/892 logged `[SAW] accumulated drip=… (n/5)` to the persisted system log, but the per-shot debug logs only showed the `[SAW] model:` line (which fires at extraction *start*, before `stopCapture()`).

## Test plan
- [x] Existing `tests/tst_settling.cpp` still asserts exactly one `shotProcessingReady` emission per shot — `QScopeGuard` preserves that.
- [ ] Build via Qt Creator and pull a SAW shot; verify the saved shot's debug log now contains both `[SAW] accuracy: predictedDrip=…` and `[SAW] accumulated drip=…` (or `committed median lag=…` on every 5th shot).
- [ ] Verify a skipped-learning path (e.g., disconnect scale before settling completes) still saves the shot — `shotProcessingReady` must still fire on the early-return path. The scope guard guarantees this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)