### PR TITLE
fix(ui): water refill warning fires at user's configured threshold (#916)

### DIFF
--- a/qml/components/layout/items/WaterLevelItem.qml
+++ b/qml/components/layout/items/WaterLevelItem.qml
@@ -10,19 +10,20 @@ Item {
 
     property bool showMl: Settings.app.waterLevelDisplayUnit === "ml"
 
-    // Margin = mm of water remaining before firmware halts the machine.
+    // Margin = mm of water above the user's configured refill threshold.
     // waterLevelMm = rawSensorMm + 5mm offset (sensor mounted above intake).
     // waterRefillPoint is in raw sensor mm (sent to firmware as-is).
     // So: margin = waterLevelMm - sensorOffset - waterRefillPoint = rawSensorMm - waterRefillPoint.
+    // "Refill" appears at margin <= 0, i.e. when raw water level reaches the user's setting.
     readonly property real sensorOffset: 5.0
     readonly property real margin: DE1Device.waterLevelMm - sensorOffset - Settings.app.waterRefillPoint
     readonly property string warningState: {
         // No warning when disconnected — waterLevelMm initializes to 0.0 which would
         // falsely trigger "critical" on every startup until the first BLE update arrives.
         if (!DE1Device.connected) return "ok"
-        if (margin > 7) return "ok"
-        if (margin > 5) return "caution"
-        if (margin > 3) return "low"
+        if (margin > 5) return "ok"
+        if (margin > 2) return "caution"
+        if (margin > 0) return "low"
         return "critical"
     }
     readonly property bool isPulsing: warningState !== "ok"


### PR DESCRIPTION
## Summary
- Fixes #916. Previously the warning bands in `WaterLevelItem.qml` were anchored at fixed `+7 / +5 / +3` mm offsets above `waterRefillPoint`, so a user setting "warn at 3 mm" would see the caution pulse start at raw 10 mm and the "Refill" word only appear at raw 6 mm — never at the value they typed.
- Rebase the bands so "Refill" appears exactly at the user's threshold (`margin <= 0`), with `low` (≤ 2 mm above) and `caution` (≤ 5 mm above) as shorter pre-warning bands.
- No firmware behavior change — `setWaterRefillLevel()` still sends `StartFillLevel` unchanged. This is purely a presentation fix in one QML file.

### Behavior comparison
| User setting | Before: caution → low → Refill | After: caution → low → Refill |
|---|---|---|
| 3 mm | raw 10 → 8 → 6 | raw 8 → 5 → 3 |
| 5 mm (default) | raw 12 → 10 → 8 | raw 10 → 7 → 5 |
| 10 mm | raw 17 → 15 → 13 | raw 15 → 12 → 10 |

Note: the auto-refill kit ignores `StartFillLevel` (it triggers on its own float switch), and the settings UI hides this threshold field when a kit is detected. So this fix only affects users without a kit, which is exactly the population for whom the warning matters.

## Test plan
- [ ] On a no-kit machine, set "Water Refill Threshold" to 3 mm and verify pulsing only starts at ~8 mm raw, with "Refill" appearing at 3 mm.
- [ ] Set the threshold to a higher value (e.g. 10 mm) and verify the bands track upward.
- [ ] Verify no warning shown when DE1 is disconnected (`waterLevelMm == 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)