### PR TITLE
fix(steam): mid-session pitcher preset switch updates duration

### DIFF
--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -398,10 +398,15 @@ Page {
                                         // restores reactivity without falling back to a bare
                                         // imperative assignment.
                                         steamingFlowSlider.value = Qt.binding(function() { return Settings.brew.steamFlow })
-                                        // Push the new flow over BLE. Don't push timeout — the
-                                        // DE1's session timer is already running on the prior
-                                        // value and a mid-session timeout change risks an
-                                        // immediate stop if the new value is < elapsed.
+                                        // Push both the new duration (via ShotSettings) and the
+                                        // new flow (via MMR) so a mid-session preset switch
+                                        // actually changes when steaming stops — matching the
+                                        // hot water page's vessel-pill behaviour and the
+                                        // existing +5s/-5s buttons. If the new duration is less
+                                        // than elapsed, the DE1 firmware will end the session,
+                                        // which is the user's intent when picking a smaller
+                                        // preset.
+                                        MainController.setSteamTimeoutImmediate(modelData.duration)
                                         MainController.setSteamFlowImmediate(flow)
                                     }
                                 }


### PR DESCRIPTION
## Summary
- Tapping a different pitcher preset while steaming was only pushing the new flow to the DE1; the duration stayed at the previous preset's value because the live-pitcher tap handler intentionally skipped \`setSteamTimeoutImmediate\`.
- Result: switching from a 24s preset to a 34s preset mid-steam did not extend the session.
- Now push both the new duration (via ShotSettings) and the new flow (via MMR), matching the hot water page's vessel-pill behaviour and the existing +5s/-5s buttons.

The "could cause an immediate stop if new value < elapsed" concern that originally guarded this path doesn't apply when extending; when shortening, the firmware ending the session is the user's intent.

Fixes #915

## Test plan
- [ ] Start steaming with a small-pitcher preset (e.g. 20s).
- [ ] Mid-session, tap a larger preset (e.g. 35s) — verify steam continues to the new duration.
- [ ] Start steaming with a large-pitcher preset (e.g. 35s); mid-session tap a smaller preset (e.g. 15s) — verify session stops promptly.
- [ ] Confirm flow still updates on preset switch (existing behaviour preserved).
- [ ] Confirm +5s/-5s buttons still work mid-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)