### PR TITLE
fix(AI): keep conversation reply visible on mobile after inputDialog close

### DIFF
--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -47,15 +47,23 @@ Rectangle {
 
     onVisibleChanged: {
         if (!visible && inputDialog.visible) {
+            // Drop any staged Send so inputDialog.onClosed doesn't fire a
+            // followUp() against this now-hidden overlay. The user explicitly
+            // dismissed the conversation; honour that and don't ship the
+            // message in the background.
+            inputDialog._pendingMessage = ""
             inputDialog.close()
         }
     }
 
     function open() {
         visible = true
-        Qt.callLater(function() {
-            conversationFlickable.contentY = Math.max(0, conversationFlickable.contentHeight - conversationFlickable.height)
-        })
+        // Scroll synchronously now that the overlay is visible. The TextArea
+        // bound `text` to getConversationText() at creation, so contentHeight
+        // is already current — no need to defer through Qt.callLater (which
+        // would race against any pending Markdown reflow).
+        conversationFlickable.contentY = Math.max(0,
+            conversationFlickable.contentHeight - conversationFlickable.height)
     }
 
     /**
@@ -239,6 +247,15 @@ Rectangle {
                             onClicked: {
                                 if (MainController.aiManager) {
                                     MainController.aiManager.clearCurrentConversation()
+                                    // Reset the scroll state machine. clearHistory() emits
+                                    // historyChanged but never responseReceived/errorOccurred,
+                                    // so without this the next user-send onHistoryChanged would
+                                    // see _waitingForResponse left at true and treat the send
+                                    // as a response — scrolling to a stale _preResponseHeight
+                                    // instead of the bottom.
+                                    overlay._waitingForResponse = false
+                                    overlay._pendingScrollKind = ""
+                                    overlay._preResponseHeight = 0
                                     // Re-fetch historical context on background thread
                                     if (overlay.shotId > 0) {
                                         overlay.historicalContext = ""
@@ -774,9 +791,13 @@ Rectangle {
         function onResponseReceived(response) {
             overlay._waitingForResponse = false
             // Scroll target was staged by onHistoryChanged (which aiconversation.cpp
-            // emits immediately before responseReceived). The TextArea's
-            // onContentHeightChanged handler ran the scroll + update() inside
-            // that text= assignment, so there's nothing left to do here.
+            // emits immediately before responseReceived). In the common case the
+            // text= assignment changed contentHeight, so onContentHeightChanged
+            // already ran the scroll and consumed _pendingScrollKind. Clear it
+            // defensively here in case contentHeight didn't change (e.g. response
+            // produced an identical height) — otherwise the stale "preResponse"
+            // sentinel would be consumed by the next unrelated layout pass.
+            overlay._pendingScrollKind = ""
         }
         function onErrorOccurred(error) {
             // Reset flag so the next send captures scroll position correctly

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -307,6 +307,32 @@ Rectangle {
                                 selectionScrollTimer.stop()
                             }
                         }
+
+                        // Apply any pending scroll target the moment the new
+                        // Markdown layout is reflected in contentHeight, then
+                        // wake the render thread. Driving the scroll off the
+                        // layout-completion signal (rather than Qt.callLater,
+                        // which fires before the layout pass settles) is what
+                        // keeps the response visible on mobile without needing
+                        // a tap to wake the render loop.
+                        onContentHeightChanged: {
+                            var kind = overlay._pendingScrollKind
+                            if (kind === "bottom") {
+                                conversationFlickable.contentY = Math.max(0,
+                                    conversationFlickable.contentHeight - conversationFlickable.height)
+                                overlay._pendingScrollKind = ""
+                            } else if (kind === "preResponse") {
+                                conversationFlickable.contentY = Math.max(0, overlay._preResponseHeight)
+                                overlay._pendingScrollKind = ""
+                            }
+                            // Force a scene graph repaint on every layout pass.
+                            // The render thread on mobile can stay asleep through
+                            // property changes that originate from network reply
+                            // signals; this catches any async layout finalization
+                            // (e.g. Markdown reflow) that happens after the scroll.
+                            conversationText.update()
+                            conversationFlickable.update()
+                        }
                     }
 
                     Timer {
@@ -598,6 +624,21 @@ Rectangle {
         closePolicy: Dialog.CloseOnEscape
         onOpened: inputDialogTextArea.forceActiveFocus()
 
+        // Send button stages the message here, then closes. The actual send
+        // runs in onClosed so conversation.followUp() / ask() — which emit
+        // historyChanged synchronously — only mutate the overlay once the
+        // dialog has fully animated away and the keyboard has finished hiding.
+        // Sending during the close transition leaves the render thread on
+        // mobile in a stale-paint state and the response flashes-then-vanishes
+        // until the user taps the screen.
+        property string _pendingMessage: ""
+        onClosed: {
+            if (_pendingMessage.length === 0) return
+            conversationInput.text = _pendingMessage
+            _pendingMessage = ""
+            conversationInput.sendFollowUp()
+        }
+
         // Keyboard height for iOS shrink-above-keyboard layout.
         // Android uses adjustPan (window shifts), so always full height.
         property real keyboardHeight: {
@@ -654,11 +695,12 @@ Rectangle {
                     enabled: inputDialogTextArea.text.length > 0 && inputRow.canSend
                     onClicked: {
                         Qt.inputMethod.commit()
-                        // Route through conversationInput.sendFollowUp() to reuse
-                        // context-prepending and ask()/followUp() branching logic
-                        conversationInput.text = inputDialogTextArea.text
+                        // Stage the message and close; inputDialog.onClosed runs
+                        // sendFollowUp() once the dialog + keyboard transitions
+                        // are complete, so the overlay isn't being mutated on
+                        // an obscured/animating surface.
+                        inputDialog._pendingMessage = inputDialogTextArea.text
                         inputDialog.close()
-                        conversationInput.sendFollowUp()
                     }
                 }
 
@@ -718,43 +760,45 @@ Rectangle {
         }
     }
 
-    // Scroll management for conversation updates
+    // Scroll management for conversation updates.
+    // Scroll targets are staged here and applied by conversationText.onContentHeightChanged
+    // once the new Markdown has fully laid out — driving the scroll + repaint
+    // off the layout-completion event (instead of Qt.callLater, which fires
+    // before the layout pass settles) is what keeps the response visible on
+    // mobile without needing a tap to wake the render loop.
     property real _preResponseHeight: 0
     property bool _waitingForResponse: false
+    property string _pendingScrollKind: ""  // "" | "bottom" | "preResponse"
     Connections {
         target: MainController.aiManager ? MainController.aiManager.conversation : null
         function onResponseReceived(response) {
             overlay._waitingForResponse = false
-            // Refresh text with the response, then scroll to top of new response
-            conversationText.text = MainController.aiManager.conversation.getConversationText()
-            Qt.callLater(function() {
-                conversationFlickable.contentY = Math.max(0, overlay._preResponseHeight)
-                // Mobile render thread can stay asleep when a property changes from
-                // a network reply. Force a scene graph repaint so the reply appears
-                // without requiring a touch to wake the render loop.
-                conversationText.update()
-                conversationFlickable.update()
-            })
+            // Scroll target was staged by onHistoryChanged (which aiconversation.cpp
+            // emits immediately before responseReceived). The TextArea's
+            // onContentHeightChanged handler ran the scroll + update() inside
+            // that text= assignment, so there's nothing left to do here.
         }
         function onErrorOccurred(error) {
             // Reset flag so the next send captures scroll position correctly
             overlay._waitingForResponse = false
+            overlay._pendingScrollKind = ""
         }
         function onHistoryChanged() {
+            var isResponse = overlay._waitingForResponse
             // Only save the scroll target when the user sends (before response arrives).
-            // The response triggers historyChanged too, but we handle that in onResponseReceived.
-            if (!overlay._waitingForResponse) {
+            // The response triggers historyChanged too — its scroll target is
+            // _preResponseHeight, captured below on the user-send path.
+            if (!isResponse) {
                 overlay._preResponseHeight = conversationText.contentHeight
                 overlay._waitingForResponse = true
             }
-            // Refresh conversation text
+            // Stage the scroll target before mutating text. The text= assignment
+            // updates contentHeight synchronously, which fires
+            // conversationText.onContentHeightChanged in the same JS turn —
+            // that handler reads _pendingScrollKind, performs the scroll, and
+            // wakes the render thread.
+            overlay._pendingScrollKind = isResponse ? "preResponse" : "bottom"
             conversationText.text = MainController.aiManager.conversation.getConversationText()
-            // Scroll to bottom to show the user's message / thinking indicator
-            Qt.callLater(function() {
-                conversationFlickable.contentY = Math.max(0, conversationFlickable.contentHeight - conversationFlickable.height)
-                conversationText.update()
-                conversationFlickable.update()
-            })
         }
     }
 


### PR DESCRIPTION
## Summary

The shot-review AI conversation would render the reply for ~1/8 sec and then appear blank until the user tapped the screen. Two race conditions combined to leave the render thread on a stale paint after returning from the half-screen input dialog.

- **Defer the send to `inputDialog.onClosed`.** The Send button used to call `conversationInput.sendFollowUp()` synchronously right after `inputDialog.close()`, so `conversation.followUp()` emitted `historyChanged` while the dialog was still animating away and the keyboard was still hiding — the overlay was being mutated on an obscured surface. The Send button now stages the message in `inputDialog._pendingMessage`, closes, and `onClosed` runs `sendFollowUp()` against a stable overlay.
- **Drive the scroll + repaint off `conversationText.onContentHeightChanged`.** The previous fix used `Qt.callLater`, which fires *before* the new Markdown layout pass settles, so `update()` was painting a pre-final-layout frame. Moving scroll/`update()` into `onContentHeightChanged` runs them after layout — and re-firing on async Markdown reflow keeps the render thread awake without a polling timer (per the CLAUDE.md "no timers as workarounds" rule).
- **Drop the redundant `conversationText.text = …` in `onResponseReceived`.** `aiconversation.cpp` emits `historyChanged` immediately before `responseReceived`, so `onHistoryChanged` already set the text. The second assignment just forced an extra layout pass on the new Markdown.

## Test plan

- [ ] iOS: open shot-review AI assistant, ask a follow-up via the input dialog, confirm the response appears and stays visible without tapping
- [ ] Android: same as above
- [ ] Desktop: confirm inline send (no inputDialog) still works and scrolls correctly
- [ ] Cancel / Escape from inputDialog: confirm `_pendingMessage` stays empty and no spurious send fires
- [ ] Multi-turn conversation: confirm `_preResponseHeight` scroll target lands at the top of the new response on each turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)