### PR TITLE
feat(badges): add puckFailed chip + suppression cascade (#903)

### DIFF
--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -42,18 +42,30 @@ shared `shotReview/advancedMode` setting toggles information density on both.
 
 ### Quality badges
 
-Four independent flags, surfaced via `qml/components/QualityBadges.qml`. When
-any fire, those chips show; when none fire, a single green "Clean extraction"
-chip shows. None of the chips suppress the others. A tappable "Shot
-Summary" chip always sits at the end of the row — it's the entry point to
-the analysis dialog described in §3.
+Five flags, surfaced via `qml/components/QualityBadges.qml`. When any fire,
+those chips show; when none fire, a single green "Clean extraction" chip
+shows. A tappable "Shot Summary" chip always sits at the end of the row —
+it's the entry point to the analysis dialog described in §3.
 
 | Flag                       | Color  | Label                  | Source                       |
 | -------------------------- | ------ | ---------------------- | ---------------------------- |
+| `pourTruncatedDetected`    | red    | "Puck failed"          | `detectPourTruncated`        |
 | `channelingDetected`       | red    | "Channeling detected"  | `detectChannelingFromDerivative` |
 | `temperatureUnstable`      | orange | "Temp unstable"        | `avgTempDeviation` + threshold |
 | `grindIssueDetected`       | orange | "Grind issue"          | `detectGrindIssue` (`analyzeFlowVsGoal`) |
 | `skipFirstFrameDetected`   | red    | "First step skipped"   | `detectSkipFirstFrame`       |
+
+**Suppression cascade.** `pourTruncatedDetected` is dominant: when it fires,
+`channelingDetected` / `temperatureUnstable` / `grindIssueDetected` are
+forced to false at save time, in the load-time recompute, and inside
+`generateSummary`. The puck failed to build pressure, so the curves the
+other three detectors read off don't mean what they normally mean
+(conductance saturates → derivative flat, flow tracks preinfusion goal →
+grind delta ≈ 0, temp drift measured against a pour that didn't really
+happen). `skipFirstFrameDetected` is **not** suppressed — it's a
+machine/profile issue orthogonal to puck integrity. The clean-extraction
+green chip's visibility gate also includes `!pourTruncatedDetected` so a
+suppressed puck-failure shot can't fall through to the wrong all-clear.
 
 The badges are recomputed on every shot load (see §4) so detector improvements
 take effect on existing shots without a manual re-analyze.
@@ -62,7 +74,7 @@ take effect on existing shots without a manual re-analyze.
 
 ## 2. Detector internals
 
-All four detectors live in `src/ai/shotanalysis.{h,cpp}` as static methods on
+All five detectors live in `src/ai/shotanalysis.{h,cpp}` as static methods on
 `ShotAnalysis`. Tuning constants are defined at the top of the header so they
 can be tweaked in one place. The header is heavily commented — read it
 alongside this section.
@@ -194,7 +206,7 @@ virtual scale (dose-aware flow integration), so the arm fires headless too.
 
 ### 2.3 Temperature unstable
 
-The simplest of the four. `temperatureUnstable = true` when:
+The simplest of the five. `temperatureUnstable = true` when:
 
 - `temperature` and `temperatureGoal` both have > 10 samples, AND
 - `pourStart > 0` (a Pour / infus / Start phase marker was found — without
@@ -252,14 +264,28 @@ malformed.
 `firstFrameConfiguredSeconds` is fed in by callers from `ProfileFrameInfo`
 (parsed from the stored profile JSON via `profileFrameInfoFromJson`).
 
-### 2.5 Pour truncated (used by the summary path, not a badge)
+### 2.5 Pour truncated (puck failed)
 
 `detectPourTruncated` returns true when peak pressure inside the pour window
 stays below `PRESSURE_FLOOR_BAR` (2.5). It catches the failure mode where
 conductance saturates at its clamp, `dC/dt` is flat, and flow tracks the
-preinfusion goal perfectly — every other detector goes silent. Currently used
-inside `ShotAnalysis::generateSummary` (the user-facing observation list); not
-wired to a separate badge column.
+preinfusion goal perfectly — every other detector goes silent or fires the
+wrong diagnosis. Skipped for filter / pourover / tea / steam / cleaning
+beverages where low pressure is expected.
+
+**Suppression cascade.** When this detector fires, the save block, the
+load-time recompute, and `generateSummary` all force `channelingDetected`
+/ `temperatureUnstable` / `grindIssueDetected` to false. See §1 for the
+rationale; see §4 for where it's enforced.
+
+**Population the badge catches.** A puck-failure shot can come from any of:
+grind way too coarse, distribution failure (massive channel), no/loose
+puck or missing basket, severe underdose, profile misconfigured (high
+flow goal with no pressure cap), or an early abort. The user can't
+discriminate among these from the curve, so the verdict text leads with
+the meta-action ("Don't tune off this shot — peak pressure never built,
+so the other quality signals are unreliable") rather than naming a
+specific fix.
 
 ---
 
@@ -304,36 +330,48 @@ from the observation lines.
 
 ### Observations emitted
 
-Order follows `generateSummary` top-to-bottom:
+`generateSummary` computes `pourTruncated` first; when it fires, the
+channeling / flow-trend / temperature / grind blocks below all skip
+emission entirely. The list collapses to a single warning + the
+puck-failed verdict. Order otherwise follows `generateSummary`
+top-to-bottom:
 
 1. **Channeling status** — uses the same `buildChannelingWindows` +
    `detectChannelingFromDerivative` path as the badge. Emits **Sustained**
    ("warning"), **Transient** ("caution") with the spike timestamp, or a
    "Puck stable" ("good") line. Skipped for filter / pourover / tea /
-   steam / cleaning beverages, turbo shots, and profiles with the
-   `channeling_expected` analysis flag.
+   steam / cleaning beverages, turbo shots, profiles with the
+   `channeling_expected` analysis flag, **and when `pourTruncated`
+   fires**.
 2. **Flow trend** — compares mean flow in the first 30% of the pour
    against the last 30%. ±0.5 mL/s thresholds emit "Flow rose … (puck
    erosion)" or "Flow dropped … (fines migration or clogging)" as
    "caution". Suppressed for profiles with the `flow_trend_ok` analysis
    flag (Cremina lever and similar where declining/rising flow is by
-   design).
+   design), **and when `pourTruncated` fires**.
 3. **Preinfusion drip** — when preinfusion lasted > 1 s and at least 0.5 g
    landed during it, emits "Preinfusion: Xg in Ys" as an "observation".
+   Not gated on `pourTruncated` — drip mass is a fact, not a diagnosis.
 4. **Temperature stability** — when `hasIntentionalTempStepping` is false
    and `avgTempDeviation` exceeds 2 °C, emits "Temperature drifted X °C
-   from goal on average" as "caution".
+   from goal on average" as "caution". **Suppressed when `pourTruncated`
+   fires.**
 5. **Grind direction** — uses the same `analyzeFlowVsGoal` path as the
    badge. Emits one of: "Pour produced near-zero flow while pressure
    held — puck choked" ("warning") when `chokedPuck` fires, "Flow
    averaged X mL/s below target — grind may be too fine" ("caution"),
    "Flow averaged X mL/s above target — grind may be too coarse"
-   ("caution"), or nothing when within tolerance.
+   ("caution"), or nothing when within tolerance. **Suppressed when
+   `pourTruncated` fires.**
 6. **Pour truncated** — `detectPourTruncated`. Emits "Pour never
-   pressurized — puck failed" as "warning" when peak pressure stayed
-   under 2.5 bar.
+   pressurized (peak X bar) — puck offered no resistance. Likely
+   causes: grind way too coarse, distribution failure, no/loose puck,
+   severe underdose, or profile without a pressure cap." as "warning"
+   when peak pressure stayed under 2.5 bar. The actual peak value is
+   substituted into the line.
 7. **Skip first frame** — `detectSkipFirstFrame`. Emits "First profile
-   step skipped — likely a DE1 firmware bug…" as "warning".
+   step skipped — likely a DE1 firmware bug…" as "warning". Not gated
+   on `pourTruncated` — frame-skip is orthogonal to puck integrity.
 
 ### Verdict precedence
 
@@ -341,9 +379,12 @@ Exactly one verdict line is appended to every summary. The cascade picks
 the first match (more specific failures take precedence over generic
 puck-integrity advice):
 
-1. **Pour truncated** → "Puck failed — pour never pressurized." Dominates
-   over channeling / grind / temperature, since the puck never built any
-   resistance worth analyzing.
+1. **Pour truncated** → "Don't tune off this shot — peak pressure never
+   built, so the other quality signals (channeling, grind direction,
+   temp) are unreliable. Check prep (dose, distribution, basket, grind)
+   and pull another." Dominates over channeling / grind / temperature
+   since the puck never built any resistance worth analyzing; leads with
+   the meta-action because the shot has no useful tuning signal.
 2. **Skip first frame** → "First profile step was skipped — power-cycle…"
    Pre-empts choked-puck because a frame-skip can synthesise extraction
    dynamics that resemble a choke; fix the machine first, then re-evaluate.
@@ -384,20 +425,28 @@ on demand.
 
 ### Save-time: stored columns
 
-The `shots` table has four flag columns: `channeling_detected`,
-`temperature_unstable`, `grind_issue_detected`, `skip_first_frame_detected`.
-At shot save (or import), the badges are computed once from the captured
-curves and written into these columns alongside the rest of the shot record.
+The `shots` table has five flag columns: `pour_truncated_detected`,
+`channeling_detected`, `temperature_unstable`, `grind_issue_detected`,
+`skip_first_frame_detected`. At shot save (or import), the badges are
+computed once from the captured curves and written into these columns
+alongside the rest of the shot record.
 
-### Load-time: always recompute (PR #893)
+`pour_truncated_detected` is computed **first** at save time. When it's
+true, `channeling_detected` / `temperature_unstable` / `grind_issue_detected`
+are forced to false (their gates check `!data.pourTruncatedDetected`).
+`skip_first_frame_detected` is not gated.
+
+### Load-time: always recompute (PR #893, extended for the 5th badge in PR #922)
 
 `ShotHistoryStorage::loadShotRecordStatic` reads the stored columns, then
-**unconditionally recomputes all four badges** from the loaded curve data
-before returning. This means the in-memory `ShotRecord` always reflects the
-current detector logic, regardless of when the shot was saved or under which
-detector version. The recompute block lives in `loadShotRecordStatic` (around
-the comment "Always recompute every quality badge from the loaded curve
-data").
+**unconditionally recomputes all five badges** from the loaded curve data
+before returning. The same suppression cascade runs here: `pourTruncated`
+is computed first and the channeling / temp / grind blocks are gated on
+`!record.pourTruncatedDetected`. This means the in-memory `ShotRecord`
+always reflects the current detector logic and the cascade is consistent
+between save and load. The recompute block lives in `loadShotRecordStatic`
+(around the comment "Always recompute every quality badge from the loaded
+curve data").
 
 The recompute uses on-the-fly derived curves for legacy shots that lack them:
 `computeDerivedCurves` fills `conductanceDerivative` from `pressure`/`flow`
@@ -407,11 +456,13 @@ when the shot predates migration 10 (the `conductance` column).
 
 When a shot is opened in `ShotDetailPage` or `PostShotReviewPage`, QML calls
 `MainController.shotHistory.requestReanalyzeBadges(id)`. That method runs on
-the DB worker thread and recomputes the four flags. If at least one flag
+the DB worker thread and recomputes the five flags. If at least one flag
 differs from the stored value, it issues an `UPDATE` *and* emits
-`shotBadgesUpdated` so the UI can refresh without a full reload. If every
-flag already matches the stored value, the worker exits silently — no
-`UPDATE`, no signal, no UI refresh.
+`shotBadgesUpdated(shotId, channeling, tempUnstable, grindIssue,
+skipFirstFrame, pourTruncated)` (six args; the puck-failure flag was added
+in PR #922) so the UI can refresh without a full reload. If every flag
+already matches the stored value, the worker exits silently — no `UPDATE`,
+no signal, no UI refresh.
 
 The wiring lives at `qml/pages/ShotDetailPage.qml` (in `onShotReady`) and
 `qml/pages/PostShotReviewPage.qml`. The visualizer-update reload path
@@ -442,7 +493,7 @@ require another sweep.
 
 ### Detector logic
 
-- `src/ai/shotanalysis.{h,cpp}` — all four detectors, `analyzeFlowVsGoal`,
+- `src/ai/shotanalysis.{h,cpp}` — all five detectors, `analyzeFlowVsGoal`,
   `buildChannelingWindows`, `detectChannelingFromDerivative`,
   `detectGrindIssue`, `detectSkipFirstFrame`, `detectPourTruncated`,
   `hasIntentionalTempStepping`, `avgTempDeviation`, `shouldSkipChannelingCheck`,
@@ -459,7 +510,8 @@ require another sweep.
     reads the stored columns.
   - `generateShotSummary` — Q_INVOKABLE bridge that converts a QML
     `shotData` map into the typed inputs for `ShotAnalysis::generateSummary`.
-  - DB migration for the four flag columns.
+  - DB migrations for the five flag columns (10–13; migration 13 adds
+    `pour_truncated_detected`).
   - `computeDerivedCurves` — fills conductance / dC/dt for legacy shots that
     predate migration 10.
   - `profileFrameInfoFromJson` — extracts `frameCount` and
@@ -483,9 +535,10 @@ require another sweep.
   visible and renders the resulting `{ text, type }` lines.
 - `qml/pages/ShotDetailPage.qml` and `qml/pages/PostShotReviewPage.qml` —
   consume `shotData.channelingDetected` / `temperatureUnstable` /
-  `grindIssueDetected` / `skipFirstFrameDetected`, listen for
-  `shotBadgesUpdated`, call `requestReanalyzeBadges` on load, host the
-  `ShotAnalysisDialog` instance and wire `summaryRequested` to `open()`.
+  `grindIssueDetected` / `skipFirstFrameDetected` / `pourTruncatedDetected`,
+  listen for `shotBadgesUpdated`, call `requestReanalyzeBadges` on load,
+  host the `ShotAnalysisDialog` instance and wire `summaryRequested` to
+  `open()`.
 - `qml/pages/ShotHistoryPage.qml` — filter chips that consume the stored
   columns.
 
@@ -541,6 +594,14 @@ To add a fixture:
   view.
 - Issue #894 — residual stored-column drift (history-list filter and
   `shots_list` MCP read stored, not recomputed values).
+- PR #898 — `temperatureUnstable` gating fix (`reachedExtractionPhase`).
+- PR #901 — flow/pressure-mode rising-pressure gate fix.
+- PR #910 — yield-overshoot ("gusher") arm in `analyzeFlowVsGoal`.
+- PR #922 / Issue #903 — fifth badge `pourTruncatedDetected` ("Puck failed"),
+  suppression cascade across save / load / `generateSummary`,
+  meta-action verdict ("Don't tune off this shot"), migration 13.
+- Issue #921 — `ShotSummarizer` (AI advisor prompt path) does not yet
+  share the suppression cascade; tracked as a follow-up to PR #922.
 
 External resources that informed the diagnostic patterns:
 

--- a/qml/components/QualityBadges.qml
+++ b/qml/components/QualityBadges.qml
@@ -14,6 +14,12 @@ Item {
     required property bool temperatureUnstable
     required property bool grindIssueDetected
     required property bool skipFirstFrameDetected
+    // Puck-failure flag (peak pressure < PRESSURE_FLOOR_BAR). Dominant: when
+    // true the C++ detector path forces the other four flags to false so this
+    // chip stands alone. The clean-extraction green chip below also gates on
+    // this — without that, a suppressed puck-failure shot would render the
+    // wrong all-clear.
+    required property bool pourTruncatedDetected
 
     signal summaryRequested()
 
@@ -130,6 +136,42 @@ Item {
             }
         }
 
+        // Puck-failed badge (red) — peak pressure stayed below PRESSURE_FLOOR_BAR.
+        // Sits before skipFirstFrame so it reads first when both fire.
+        Rectangle {
+            visible: root.pourTruncatedDetected
+            width: puckFailedRow.width + Theme.spacingMedium * 2
+            height: Theme.scaled(28)
+            radius: Theme.scaled(14)
+            color: Qt.rgba(Theme.errorColor.r, Theme.errorColor.g, Theme.errorColor.b, 0.15)
+            border.color: Theme.errorColor
+            border.width: Theme.scaled(1)
+
+            Accessible.role: Accessible.StaticText
+            Accessible.name: puckFailedText.text
+            Accessible.focusable: true
+
+            Row {
+                id: puckFailedRow
+                anchors.centerIn: parent
+                spacing: Theme.scaled(4)
+                Rectangle {
+                    width: Theme.scaled(8); height: Theme.scaled(8); radius: Theme.scaled(4)
+                    color: Theme.errorColor; anchors.verticalCenter: parent.verticalCenter
+                    Accessible.ignored: true
+                }
+                Tr {
+                    id: puckFailedText
+                    key: "badges.puckFailed"
+                    fallback: "Puck failed"
+                    font: Theme.captionFont
+                    color: Theme.errorColor
+                    anchors.verticalCenter: parent.verticalCenter
+                    Accessible.ignored: true
+                }
+            }
+        }
+
         // Skip-first-frame badge (red) — DE1 firmware bug or very short first step
         Rectangle {
             visible: root.skipFirstFrameDetected
@@ -167,7 +209,7 @@ Item {
 
         // Clean extraction badge (green) — only shown when no flags are set
         Rectangle {
-            visible: !root.channelingDetected && !root.temperatureUnstable && !root.grindIssueDetected && !root.skipFirstFrameDetected
+            visible: !root.channelingDetected && !root.temperatureUnstable && !root.grindIssueDetected && !root.skipFirstFrameDetected && !root.pourTruncatedDetected
             width: cleanRow.width + Theme.spacingMedium * 2
             height: Theme.scaled(28)
             radius: Theme.scaled(14)

--- a/qml/components/QualityBadges.qml
+++ b/qml/components/QualityBadges.qml
@@ -15,10 +15,12 @@ Item {
     required property bool grindIssueDetected
     required property bool skipFirstFrameDetected
     // Puck-failure flag (peak pressure < PRESSURE_FLOOR_BAR). Dominant: when
-    // true the C++ detector path forces the other four flags to false so this
-    // chip stands alone. The clean-extraction green chip below also gates on
-    // this — without that, a suppressed puck-failure shot would render the
-    // wrong all-clear.
+    // true the C++ detector path forces channeling/temp/grind to false so
+    // this chip stands alone. (skipFirstFrameDetected is intentionally NOT
+    // suppressed — it's a machine/profile issue orthogonal to puck integrity
+    // and can co-fire with this chip.) The clean-extraction green chip
+    // below also gates on this — without that, a suppressed puck-failure
+    // shot would render the wrong all-clear.
     required property bool pourTruncatedDetected
 
     signal summaryRequested()

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -150,13 +150,14 @@ Page {
                 // below catches the persist event.
             }
         }
-        function onShotBadgesUpdated(shotId, channeling, tempUnstable, grindIssue, skipFirstFrame) {
+        function onShotBadgesUpdated(shotId, channeling, tempUnstable, grindIssue, skipFirstFrame, pourTruncated) {
             if (shotId !== postShotReviewPage.editShotId) return
             var updated = Object.assign({}, editShotData)
             updated.channelingDetected = channeling
             updated.temperatureUnstable = tempUnstable
             updated.grindIssueDetected = grindIssue
             updated.skipFirstFrameDetected = skipFirstFrame
+            updated.pourTruncatedDetected = pourTruncated
             editShotData = updated
         }
         function onShotMetadataUpdated(shotId, success) {
@@ -393,13 +394,15 @@ Page {
                                         || editShotData.channelingDetected
                                         || editShotData.temperatureUnstable
                                         || editShotData.grindIssueDetected
-                                        || editShotData.skipFirstFrameDetected)
+                                        || editShotData.skipFirstFrameDetected
+                                        || editShotData.pourTruncatedDetected)
                             Layout.fillWidth: false
                             Layout.maximumWidth: postShotReviewPage.width * 0.5
                             channelingDetected: editShotData.channelingDetected ?? false
                             temperatureUnstable: editShotData.temperatureUnstable ?? false
                             grindIssueDetected: editShotData.grindIssueDetected ?? false
                             skipFirstFrameDetected: editShotData.skipFirstFrameDetected ?? false
+                            pourTruncatedDetected: editShotData.pourTruncatedDetected ?? false
                             onSummaryRequested: reviewAnalysisDialog.open()
                         }
 

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -80,13 +80,14 @@ Page {
                 console.warn("ShotDetailPage: Failed to save visualizer info for shot", id)
             }
         }
-        function onShotBadgesUpdated(id, channeling, tempUnstable, grindIssue, skipFirstFrame) {
+        function onShotBadgesUpdated(id, channeling, tempUnstable, grindIssue, skipFirstFrame, pourTruncated) {
             if (id !== shotDetailPage.shotId) return
             var updated = Object.assign({}, shotData)
             updated.channelingDetected = channeling
             updated.temperatureUnstable = tempUnstable
             updated.grindIssueDetected = grindIssue
             updated.skipFirstFrameDetected = skipFirstFrame
+            updated.pourTruncatedDetected = pourTruncated
             shotData = updated
         }
     }
@@ -245,13 +246,15 @@ Page {
                                         || shotData.channelingDetected
                                         || shotData.temperatureUnstable
                                         || shotData.grindIssueDetected
-                                        || shotData.skipFirstFrameDetected)
+                                        || shotData.skipFirstFrameDetected
+                                        || shotData.pourTruncatedDetected)
                             Layout.fillWidth: false
                             Layout.maximumWidth: shotDetailPage.width * 0.5
                             channelingDetected: shotData.channelingDetected ?? false
                             temperatureUnstable: shotData.temperatureUnstable ?? false
                             grindIssueDetected: shotData.grindIssueDetected ?? false
                             skipFirstFrameDetected: shotData.skipFirstFrameDetected ?? false
+                            pourTruncatedDetected: shotData.pourTruncatedDetected ?? false
                             onSummaryRequested: detailAnalysisDialog.open()
                         }
 

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -194,12 +194,13 @@ Page {
                 }
             }
 
-            // Parse quality flag keywords (channeling:yes, temp:yes, grind:yes, skipframe:yes)
+            // Parse quality flag keywords (channeling:yes, temp:yes, grind:yes, skipframe:yes, puckfailed:yes)
             var flagKeywords = [
                 { pattern: /\bchanneling:yes\b/gi, filterKey: "filterChanneling" },
                 { pattern: /\btemp:yes\b/gi, filterKey: "filterTemperatureUnstable" },
                 { pattern: /\bgrind:yes\b/gi, filterKey: "filterGrindIssue" },
-                { pattern: /\bskipframe:yes\b/gi, filterKey: "filterSkipFirstFrame" }
+                { pattern: /\bskipframe:yes\b/gi, filterKey: "filterSkipFirstFrame" },
+                { pattern: /\bpuckfailed:yes\b/gi, filterKey: "filterPourTruncated" }
             ]
             for (var j = 0; j < flagKeywords.length; j++) {
                 var fk = flagKeywords[j]
@@ -211,7 +212,7 @@ Page {
 
             // Strip any remaining keyword tokens (e.g. duplicate dose:18 dose:20)
             searchText = searchText.replace(/\b(rating|dose|yield|time|tds|ey):\d+(?:\.\d+)?(?:-\d+(?:\.\d+)?|\+)?/g, "")
-            searchText = searchText.replace(/\b(channeling|temp|grind|skipframe):yes\b/gi, "")
+            searchText = searchText.replace(/\b(channeling|temp|grind|skipframe|puckfailed):yes\b/gi, "")
 
             // Pass remaining text as FTS search (skipped when exact initialFilter is active)
             searchText = searchText.trim().replace(/\s+/g, " ")
@@ -604,6 +605,7 @@ Page {
                         parts.push(doseVal.toFixed(1) + "g to " + yieldVal.toFixed(1) + "g")
                     if (shotDelegate.shotEnjoyment > 0) parts.push(shotDelegate.shotEnjoyment + "%")
                     var issues = []
+                    if (model.pourTruncatedDetected) issues.push("puck failed")
                     if (model.channelingDetected) issues.push("channeling")
                     if (model.temperatureUnstable) issues.push("temp unstable")
                     if (model.grindIssueDetected) issues.push("grind issue")
@@ -739,7 +741,15 @@ Page {
                                 Accessible.ignored: true
                             }
 
-                            // Quality issue indicator dots
+                            // Quality issue indicator dots. Order: red puckFailed first
+                            // (most severe — shot has no tuning signal), then channeling
+                            // (red), temp/grind (orange), skipFirstFrame (red).
+                            Rectangle {
+                                width: Theme.scaled(8); height: Theme.scaled(8); radius: Theme.scaled(4)
+                                color: Theme.errorColor
+                                visible: model.pourTruncatedDetected ?? false
+                                Accessible.ignored: true
+                            }
                             Rectangle {
                                 width: Theme.scaled(8); height: Theme.scaled(8); radius: Theme.scaled(4)
                                 color: Theme.errorColor

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -703,8 +703,27 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
     }
     if (pourStart == 0 && preinfEnd > 0) pourStart = preinfEnd;
 
+    // --- Pour-truncated detection (runs first; dominates the cascade) ---
+    // When peak pressure stayed below PRESSURE_FLOOR_BAR the puck never built,
+    // so channeling / flow-trend / temp-stability / grind blocks are all
+    // reading off curves the failed puck didn't produce. Skip those blocks
+    // entirely when this fires, and emit a single "Puck failed" warning +
+    // verdict that names the meta-action ("don't tune off this shot"). Peak
+    // pressure is computed locally for the warning text — detectPourTruncated
+    // doesn't return it.
+    const bool pourTruncated = detectPourTruncated(pressure, pourStart, pourEnd, beverageType);
+    double peakPressureBar = 0.0;
+    if (pourTruncated) {
+        for (const auto& pt : pressure) {
+            if (pt.x() < pourStart) continue;
+            if (pt.x() > pourEnd) break;
+            if (pt.y() > peakPressureBar) peakPressureBar = pt.y();
+        }
+    }
+
     // --- dC/dt analysis (channeling) ---
-    bool skipChanneling = shouldSkipChannelingCheck(beverageType, flow, pourStart, pourEnd)
+    bool skipChanneling = pourTruncated
+        || shouldSkipChannelingCheck(beverageType, flow, pourStart, pourEnd)
         || analysisFlags.contains(QStringLiteral("channeling_expected"));
 
     if (!skipChanneling && !conductanceDerivative.isEmpty()) {
@@ -738,8 +757,10 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
 
     // --- Flow trend during extraction ---
     // Skipped for profiles where declining/rising flow is intentional (e.g. Cremina lever).
+    // Suppressed when pourTruncated fires — rising/falling flow is meaningless on a puck
+    // that never built pressure.
     const bool flowTrendOk = analysisFlags.contains(QStringLiteral("flow_trend_ok"));
-    if (!flowTrendOk && pourStart > 0 && pourEnd > pourStart && flow.size() > 10) {
+    if (!pourTruncated && !flowTrendOk && pourStart > 0 && pourEnd > pourStart && flow.size() > 10) {
         double flowStartSum = 0, flowEndSum = 0;
         int flowStartCount = 0, flowEndCount = 0;
         const double pourSpan = pourEnd - pourStart;
@@ -785,7 +806,10 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
     // --- Temperature stability ---
     // Gated on reachedExtractionPhase so aborted shots that died during
     // preinfusion-start (frame 0 only) don't fire on the preheat ramp.
-    if (temperature.size() > 10 && temperatureGoal.size() > 10 && pourStart > 0
+    // Suppressed when pourTruncated fires — temp drift on a puck that never
+    // built is a downstream symptom, not a useful diagnosis.
+    if (!pourTruncated
+        && temperature.size() > 10 && temperatureGoal.size() > 10 && pourStart > 0
         && reachedExtractionPhase(phases, duration)) {
         if (!hasIntentionalTempStepping(temperatureGoal)) {
             double avgDev = avgTempDeviation(temperature, temperatureGoal, pourStart, pourEnd);
@@ -805,11 +829,19 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
     // analyzeFlowVsGoal() also runs additively on pressure-mode portions of
     // the pour, so a shot with a healthy flow-mode preinfusion AND a choked
     // pressure-mode tail can have both delta near zero and chokedPuck true.
-    const GrindCheck grind = analyzeFlowVsGoal(flow, flowGoal, phases,
-                                                pourStart, pourEnd,
-                                                beverageType, analysisFlags,
-                                                pressure,
-                                                targetWeightG, finalWeightG);
+    //
+    // Suppressed when pourTruncated fires: with peak < 2.5 bar the flow-mode
+    // phases tracked the preinfusion goal perfectly (puck wasn't holding
+    // water back) so delta sits at ~0, and the pressure-mode arms can never
+    // satisfy their 4 bar / 15 s gate. The detector reads "no signal," which
+    // would FP a "Clean shot" verdict on a puck failure.
+    const GrindCheck grind = pourTruncated
+        ? GrindCheck{}
+        : analyzeFlowVsGoal(flow, flowGoal, phases,
+                            pourStart, pourEnd,
+                            beverageType, analysisFlags,
+                            pressure,
+                            targetWeightG, finalWeightG);
     if (grind.hasData) {
         if (grind.yieldOvershoot) {
             // Gusher: yield blew past target by > 20%. The puck offered too
@@ -849,16 +881,20 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
     }
 
     // --- Pour truncated (puck failure) ---
-    // Catches shots that the channeling + grind detectors miss: pressure
-    // never builds, conductance saturates, flow tracks preinfusion goal, so
-    // every normal detector stays silent. Looking straight at peak pressure
-    // exposes the failure. Emits its own warning line (not a verdict — the
-    // existing verdict machinery covers that below).
-    const bool pourTruncated = detectPourTruncated(pressure, pourStart, pourEnd, beverageType);
+    // Detection ran at the top of the function; this block emits the
+    // user-facing warning line. The cause list spans the full population:
+    // grind way too coarse, distribution failure (massive channel), no/loose
+    // puck or missing basket, severe underdose, or a profile that doesn't
+    // enforce a pressure cap (high flow goal with no ceiling). The user
+    // can't discriminate among those from the curve — verdict below tells
+    // them to fix prep and pull again rather than tune off this shot.
     if (pourTruncated) {
         QVariantMap line;
-        line["text"] = QStringLiteral("Pour never pressurized \u2014 puck failed "
-            "(massive channel, missing puck, or grind radically too coarse)");
+        line["text"] = QStringLiteral("Pour never pressurized (peak %1 bar) \u2014 "
+            "puck offered no resistance. Likely causes: grind way too coarse, "
+            "distribution failure, no/loose puck, severe underdose, or profile "
+            "without a pressure cap.")
+            .arg(peakPressureBar, 0, 'f', 1);
         line["type"] = QStringLiteral("warning");
         lines.append(line);
     }
@@ -890,11 +926,18 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
 
     QVariantMap verdict;
     if (pourTruncated) {
-        // Dominates over every other signal — if the puck failed to build
-        // pressure, channeling / grind direction / temperature advice are
-        // all irrelevant. User needs to know the puck failed.
-        verdict["text"] = QStringLiteral("Verdict: Puck failed \u2014 pour never "
-            "pressurized. Check dose, distribution, and whether grind is drastically too coarse.");
+        // Dominates over every other signal. Lead with the meta-action
+        // ("don't tune off this shot") because peak pressure never built —
+        // the channeling / grind / temp detectors are reading off curves the
+        // failed puck didn't produce, so their silence (or any drift they
+        // happen to flag) is not a tuning signal. Naming the unreliable
+        // detectors explicitly is important: a user who sees no Channeling
+        // chip might otherwise assume "OK at least no channeling," which is
+        // wrong on a puck failure.
+        verdict["text"] = QStringLiteral("Verdict: Don't tune off this shot \u2014 "
+            "peak pressure never built, so the other quality signals "
+            "(channeling, grind direction, temp) are unreliable. Check prep "
+            "(dose, distribution, basket, grind) and pull another.");
     } else if (skipFirstFrame) {
         // Skip-first-frame is a machine/profile issue, not puck integrity — give specific advice
         // so the user isn't told to adjust grind when the real fix is a power-cycle.

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -96,10 +96,13 @@ struct ShotRecord {
     //
     // pourTruncatedDetected is the dominant flag — when it fires, the puck never
     // built pressure, so channeling / temp / grind signals are unreliable readings
-    // off curves the failed puck didn't produce. The save and load paths suppress
-    // the other three flags to false in that case so the UI doesn't show
-    // contradictory "Temp unstable" or "Clean extraction" chips on top of a puck
-    // failure. See ShotAnalysis::detectPourTruncated for the underlying detector.
+    // off curves the failed puck didn't produce. The save and load paths force
+    // those three (channelingDetected, temperatureUnstable, grindIssueDetected) to
+    // false in that case so the UI doesn't show contradictory "Temp unstable" or
+    // "Clean extraction" chips on top of a puck failure. skipFirstFrameDetected
+    // is NOT suppressed — it's a machine/profile issue orthogonal to puck
+    // integrity and can co-fire with pourTruncatedDetected.
+    // See ShotAnalysis::detectPourTruncated for the underlying detector.
     bool channelingDetected = false;
     bool temperatureUnstable = false;
     bool grindIssueDetected = false;
@@ -191,8 +194,9 @@ struct ShotSaveData {
     QString profileKbId;
 
     // Quality flags (computed at save time using ShotAnalysis helpers). When
-    // pourTruncatedDetected fires the other three are forced to false — see the
-    // matching comment on ShotRecord.
+    // pourTruncatedDetected fires, channelingDetected / temperatureUnstable /
+    // grindIssueDetected are forced to false; skipFirstFrameDetected is not.
+    // See the matching comment on ShotRecord.
     bool channelingDetected = false;
     bool temperatureUnstable = false;
     bool grindIssueDetected = false;

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -92,11 +92,19 @@ struct ShotRecord {
     // AI knowledge base ID (e.g. "d-flow", "blooming espresso") for profile-aware analysis
     QString profileKbId;
 
-    // Quality flags (computed at save time, recomputed on-the-fly for legacy shots)
+    // Quality flags (computed at save time, recomputed on-the-fly for legacy shots).
+    //
+    // pourTruncatedDetected is the dominant flag — when it fires, the puck never
+    // built pressure, so channeling / temp / grind signals are unreliable readings
+    // off curves the failed puck didn't produce. The save and load paths suppress
+    // the other three flags to false in that case so the UI doesn't show
+    // contradictory "Temp unstable" or "Clean extraction" chips on top of a puck
+    // failure. See ShotAnalysis::detectPourTruncated for the underlying detector.
     bool channelingDetected = false;
     bool temperatureUnstable = false;
     bool grindIssueDetected = false;
     bool skipFirstFrameDetected = false;
+    bool pourTruncatedDetected = false;
 
     // Phase summaries JSON (per-phase metrics: duration, avgPressure, avgFlow, weightGained, etc.)
     QString phaseSummariesJson;
@@ -144,6 +152,7 @@ struct ShotFilter {
     bool filterTemperatureUnstable = false;
     bool filterGrindIssue = false;
     bool filterSkipFirstFrame = false;
+    bool filterPourTruncated = false;
     QString sortColumn = "timestamp";
     QString sortDirection = "DESC";
 };
@@ -181,11 +190,14 @@ struct ShotSaveData {
     // AI knowledge base ID (e.g. "d-flow", "blooming espresso") — computed at save time
     QString profileKbId;
 
-    // Quality flags (computed at save time using ShotAnalysis helpers)
+    // Quality flags (computed at save time using ShotAnalysis helpers). When
+    // pourTruncatedDetected fires the other three are forced to false — see the
+    // matching comment on ShotRecord.
     bool channelingDetected = false;
     bool temperatureUnstable = false;
     bool grindIssueDetected = false;
     bool skipFirstFrameDetected = false;
+    bool pourTruncatedDetected = false;
 
     // Phase summaries JSON (per-phase metrics for UI display)
     QString phaseSummariesJson;

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -736,6 +736,24 @@ bool ShotHistoryStorage::runMigrations()
         currentVersion = 12;
     }
 
+    // Migration 13: Add pour_truncated_detected flag.
+    // Catches puck failures where peak pressure stayed below PRESSURE_FLOOR_BAR
+    // (puck offered no resistance — channeling/temp/grind detectors stay silent
+    // or fire wrong because the curves they read off never built). When this
+    // flag is true the other three quality flags are forced to false both at
+    // save time and via drift-on-load, so the UI shows a single red "Puck
+    // failed" chip rather than a contradictory mix.
+    if (currentVersion < 13) {
+        qDebug() << "ShotHistoryStorage: Running migration to version 13 (pour_truncated_detected)";
+
+        if (!hasColumn("shots", "pour_truncated_detected"))
+            query.exec("ALTER TABLE shots ADD COLUMN pour_truncated_detected INTEGER DEFAULT 0");
+
+        query.exec("DELETE FROM schema_version");
+        query.exec("INSERT INTO schema_version (version) VALUES (13)");
+        currentVersion = 13;
+    }
+
     m_schemaVersion = currentVersion;
     return true;
 }
@@ -931,6 +949,17 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
             }
         }
 
+        // Pour-truncated detection runs first because it dominates: when peak
+        // pressure stayed below PRESSURE_FLOOR_BAR the puck never built, so
+        // the channeling/temp/grind signals are read off curves that don't
+        // mean what they normally mean (conductance saturated → derivative
+        // flat, flow tracked preinfusion goal → grind delta ≈ 0, temp drift
+        // measured against a pour that didn't really happen). When this fires
+        // we force the other three flags to false below so the UI shows a
+        // single red "Puck failed" chip rather than a contradictory mix.
+        data.pourTruncatedDetected = ShotAnalysis::detectPourTruncated(
+            tmpRecord.pressure, pourStart, pourEnd, data.beverageType);
+
         // Channeling detection uses dC/dt (the Gaussian-smoothed conductance
         // derivative) — it catches channels invisible to flow/pressure alone
         // and works regardless of frame mode. computeConductanceDerivative()
@@ -940,7 +969,8 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
         // onto it yet — suppresses false positives on lever, D-Flow decline,
         // and pressure ramps.
         data.channelingDetected = false;
-        if (!ShotAnalysis::shouldSkipChannelingCheck(data.beverageType, flowPts, pourStart, pourEnd)
+        if (!data.pourTruncatedDetected
+            && !ShotAnalysis::shouldSkipChannelingCheck(data.beverageType, flowPts, pourStart, pourEnd)
             && !ShotSummarizer::getAnalysisFlags(data.profileKbId).contains(QStringLiteral("channeling_expected"))) {
             const auto channelWindows = ShotAnalysis::buildChannelingWindows(
                 tmpRecord.pressure, flowPts,
@@ -959,10 +989,12 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
         // matches generateSummary and prevents avgTempDeviation from averaging
         // from t=0 (which would include the preheat ramp) when phase labels
         // are unusual enough that no Pour/infus/Start marker was found.
+        // Suppressed when pourTruncated fires — see the comment above.
         data.temperatureUnstable = false;
         const auto& tempPts = shotData->temperatureData();
         const auto& tempGoalPts = shotData->temperatureGoalData();
-        if (tempPts.size() > 10 && tempGoalPts.size() > 10 && pourStart > 0
+        if (!data.pourTruncatedDetected
+            && tempPts.size() > 10 && tempGoalPts.size() > 10 && pourStart > 0
             && ShotAnalysis::reachedExtractionPhase(tmpRecord.phases, duration)) {
             if (!ShotAnalysis::hasIntentionalTempStepping(tempGoalPts)) {
                 double avgDev = ShotAnalysis::avgTempDeviation(tempPts, tempGoalPts, pourStart, pourEnd);
@@ -976,7 +1008,10 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
         // mode aware — restricts averaging to flow-controlled phases so the
         // check no longer compares actual flow against a pressure-mode
         // profile's flow limiter (80's Espresso, Cremina, Londinium pour).
-        if (!ShotAnalysis::shouldSkipChannelingCheck(data.beverageType, flowPts, pourStart, pourEnd)) {
+        // Suppressed when pourTruncated fires — see the comment above.
+        data.grindIssueDetected = false;
+        if (!data.pourTruncatedDetected
+            && !ShotAnalysis::shouldSkipChannelingCheck(data.beverageType, flowPts, pourStart, pourEnd)) {
             data.grindIssueDetected = ShotAnalysis::detectGrindIssue(
                 flowPts, shotData->flowGoalData(), tmpRecord.phases,
                 pourStart, pourEnd, data.beverageType,
@@ -1085,7 +1120,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     profile_notes, debug_log,
                     temperature_override, yield_override, profile_kb_id,
                     channeling_detected, temperature_unstable, grind_issue_detected,
-                    skip_first_frame_detected
+                    skip_first_frame_detected, pour_truncated_detected
                 ) VALUES (
                     :uuid, :timestamp, :profile_name, :profile_json, :beverage_type,
                     :duration, :final_weight, :dose_weight,
@@ -1095,7 +1130,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     :profile_notes, :debug_log,
                     :temperature_override, :yield_override, :profile_kb_id,
                     :channeling_detected, :temperature_unstable, :grind_issue_detected,
-                    :skip_first_frame_detected
+                    :skip_first_frame_detected, :pour_truncated_detected
                 )
             )");
 
@@ -1130,6 +1165,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
             query.bindValue(":temperature_unstable", data.temperatureUnstable ? 1 : 0);
             query.bindValue(":grind_issue_detected", data.grindIssueDetected ? 1 : 0);
             query.bindValue(":skip_first_frame_detected", data.skipFirstFrameDetected ? 1 : 0);
+            query.bindValue(":pour_truncated_detected", data.pourTruncatedDetected ? 1 : 0);
 
             if (!query.exec()) {
                 qWarning() << "ShotHistoryStorage: Failed to insert shot:" << query.lastError().text();
@@ -1396,6 +1432,7 @@ ShotFilter ShotHistoryStorage::parseFilterMap(const QVariantMap& filterMap)
     filter.filterTemperatureUnstable = filterMap.value("filterTemperatureUnstable", false).toBool();
     filter.filterGrindIssue = filterMap.value("filterGrindIssue", false).toBool();
     filter.filterSkipFirstFrame = filterMap.value("filterSkipFirstFrame", false).toBool();
+    filter.filterPourTruncated = filterMap.value("filterPourTruncated", false).toBool();
     filter.sortColumn = filterMap.value("sortField", "timestamp").toString();
     filter.sortDirection = filterMap.value("sortDirection", "DESC").toString();
     return filter;
@@ -1478,6 +1515,9 @@ QString ShotHistoryStorage::buildFilterQuery(const ShotFilter& filter, QVariantL
     }
     if (filter.filterSkipFirstFrame) {
         conditions << "skip_first_frame_detected = 1";
+    }
+    if (filter.filterPourTruncated) {
+        conditions << "pour_truncated_detected = 1";
     }
 
     if (conditions.isEmpty()) {
@@ -1573,7 +1613,7 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                    temperature_override, yield_override, beverage_type,
                    drink_tds, drink_ey,
                    channeling_detected, temperature_unstable, grind_issue_detected,
-                   skip_first_frame_detected
+                   skip_first_frame_detected, pour_truncated_detected
             FROM shots
             WHERE id IN (SELECT rowid FROM shots_fts WHERE shots_fts MATCH '%1')
             %2
@@ -1588,7 +1628,7 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                    temperature_override, yield_override, beverage_type,
                    drink_tds, drink_ey,
                    channeling_detected, temperature_unstable, grind_issue_detected,
-                   skip_first_frame_detected
+                   skip_first_frame_detected, pour_truncated_detected
             FROM shots
             %1
             %2
@@ -1657,6 +1697,7 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                             shot["temperatureUnstable"] = query.value(18).toInt() != 0;
                             shot["grindIssueDetected"] = query.value(19).toInt() != 0;
                             shot["skipFirstFrameDetected"] = query.value(20).toInt() != 0;
+                            shot["pourTruncatedDetected"] = query.value(21).toInt() != 0;
 
                             QDateTime dt = QDateTime::fromSecsSinceEpoch(
                                 query.value(2).toLongLong());
@@ -1732,7 +1773,8 @@ void ShotHistoryStorage::requestShot(qint64 shotId)
                     record.channelingDetected,
                     record.temperatureUnstable,
                     record.grindIssueDetected,
-                    record.skipFirstFrameDetected);
+                    record.skipFirstFrameDetected,
+                    record.pourTruncatedDetected);
             }
         }, Qt::QueuedConnection);
     });
@@ -1757,7 +1799,7 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
         bool recordFound = false;
         bool badgesPersisted = false;
         bool newChanneling = false, newTempUnstable = false;
-        bool newGrindIssue = false, newSkipFirstFrame = false;
+        bool newGrindIssue = false, newSkipFirstFrame = false, newPourTruncated = false;
 
         withTempDb(dbPath, "shs_badges", [&](QSqlDatabase& db) {
             ShotRecord record = loadShotRecordStatic(db, shotId, &badgesPersisted);
@@ -1767,14 +1809,15 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
             newTempUnstable = record.temperatureUnstable;
             newGrindIssue = record.grindIssueDetected;
             newSkipFirstFrame = record.skipFirstFrameDetected;
+            newPourTruncated = record.pourTruncatedDetected;
         });
 
         if (!recordFound || !badgesPersisted || *destroyed) return;
         QMetaObject::invokeMethod(
             this,
-            [this, shotId, newChanneling, newTempUnstable, newGrindIssue, newSkipFirstFrame, destroyed]() {
+            [this, shotId, newChanneling, newTempUnstable, newGrindIssue, newSkipFirstFrame, newPourTruncated, destroyed]() {
                 if (*destroyed) return;
-                emit shotBadgesUpdated(shotId, newChanneling, newTempUnstable, newGrindIssue, newSkipFirstFrame);
+                emit shotBadgesUpdated(shotId, newChanneling, newTempUnstable, newGrindIssue, newSkipFirstFrame, newPourTruncated);
             },
             Qt::QueuedConnection);
     });
@@ -1948,6 +1991,7 @@ QVariantMap ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     result["temperatureUnstable"] = record.temperatureUnstable;
     result["grindIssueDetected"] = record.grindIssueDetected;
     result["skipFirstFrameDetected"] = record.skipFirstFrameDetected;
+    result["pourTruncatedDetected"] = record.pourTruncatedDetected;
 
     // Phase summaries for UI (computed at save time or on-the-fly for legacy shots)
     if (!record.phaseSummariesJson.isEmpty()) {
@@ -2084,7 +2128,7 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
                profile_notes, visualizer_id, visualizer_url, debug_log,
                temperature_override, yield_override, beverage_type, profile_kb_id,
                channeling_detected, temperature_unstable, grind_issue_detected,
-               skip_first_frame_detected
+               skip_first_frame_detected, pour_truncated_detected
         FROM shots WHERE id = ?
     )")) {
         qWarning() << "ShotHistoryStorage::loadShotRecordStatic: prepare failed:" << query.lastError().text();
@@ -2131,6 +2175,7 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     record.temperatureUnstable = query.value(31).toInt() != 0;
     record.grindIssueDetected = query.value(32).toInt() != 0;
     record.skipFirstFrameDetected = query.value(33).toInt() != 0;
+    record.pourTruncatedDetected = query.value(34).toInt() != 0;
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     // Snapshot stored badge values before the recompute block overwrites them, so
@@ -2139,6 +2184,7 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     const bool storedTempUnstable = record.temperatureUnstable;
     const bool storedGrindIssue = record.grindIssueDetected;
     const bool storedSkipFirstFrame = record.skipFirstFrameDetected;
+    const bool storedPourTruncated = record.pourTruncatedDetected;
 
     if (query.prepare("SELECT data_blob FROM shot_samples WHERE shot_id = ?")) {
         query.bindValue(0, shotId);
@@ -2198,6 +2244,7 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     // (post-migration-10) or filled by computeDerivedCurves() above (legacy).
     // The grind and skip-first-frame sub-blocks need only flow / flowGoal /
     // pressure / phases, which are always available.
+    record.pourTruncatedDetected = false;
     if (!record.pressure.isEmpty()) {
         double pourStart = 0, pourEnd = record.pressure.last().x();
         for (const auto& pm : record.phases) {
@@ -2210,9 +2257,18 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
             }
         }
 
+        // Pour-truncated runs first because it dominates the badge cascade —
+        // see the matching comment in saveShotData. When this fires the
+        // channeling / temp / grind blocks are gated off so the UI shows a
+        // single red "Puck failed" chip rather than wrong-diagnosis chips
+        // read off curves the failed puck didn't produce.
+        record.pourTruncatedDetected = ShotAnalysis::detectPourTruncated(
+            record.pressure, pourStart, pourEnd, record.summary.beverageType);
+
         // Channeling (dC/dt with mode-aware windowing)
         record.channelingDetected = false;
-        if (!ShotAnalysis::shouldSkipChannelingCheck(record.summary.beverageType, record.flow, pourStart, pourEnd)
+        if (!record.pourTruncatedDetected
+            && !ShotAnalysis::shouldSkipChannelingCheck(record.summary.beverageType, record.flow, pourStart, pourEnd)
             && !ShotSummarizer::getAnalysisFlags(record.profileKbId).contains(QStringLiteral("channeling_expected"))) {
             const auto windows = ShotAnalysis::buildChannelingWindows(
                 record.pressure, record.flow,
@@ -2229,9 +2285,10 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
         // > 0 conjunct matches generateSummary and prevents avgTempDeviation
         // from averaging from t=0 (which would include the preheat ramp)
         // when phase labels are unusual enough that no Pour/infus/Start
-        // marker was found.
+        // marker was found. Suppressed when pourTruncated fires.
         record.temperatureUnstable = false;
-        if (record.temperature.size() > 10 && record.temperatureGoal.size() > 10 && pourStart > 0
+        if (!record.pourTruncatedDetected
+            && record.temperature.size() > 10 && record.temperatureGoal.size() > 10 && pourStart > 0
             && ShotAnalysis::reachedExtractionPhase(record.phases, record.summary.duration)) {
             if (!ShotAnalysis::hasIntentionalTempStepping(record.temperatureGoal)) {
                 double avgDev = ShotAnalysis::avgTempDeviation(record.temperature, record.temperatureGoal, pourStart, pourEnd);
@@ -2242,9 +2299,10 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
         // Grind direction (flow-vs-goal + choked-puck arms). Reset before the
         // skip-check so filter/pourover/tea/steam/cleaning shots clear any
         // stale stored value (the channeling/temp resets above are the same
-        // pattern).
+        // pattern). Suppressed when pourTruncated fires.
         record.grindIssueDetected = false;
-        if (!ShotAnalysis::shouldSkipChannelingCheck(record.summary.beverageType, record.flow, pourStart, pourEnd)) {
+        if (!record.pourTruncatedDetected
+            && !ShotAnalysis::shouldSkipChannelingCheck(record.summary.beverageType, record.flow, pourStart, pourEnd)) {
             record.grindIssueDetected = ShotAnalysis::detectGrindIssue(
                 record.flow, record.flowGoal, record.phases,
                 pourStart, pourEnd, record.summary.beverageType,
@@ -2270,17 +2328,20 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     const bool flagsChanged = (storedChanneling != record.channelingDetected
         || storedTempUnstable != record.temperatureUnstable
         || storedGrindIssue != record.grindIssueDetected
-        || storedSkipFirstFrame != record.skipFirstFrameDetected);
+        || storedSkipFirstFrame != record.skipFirstFrameDetected
+        || storedPourTruncated != record.pourTruncatedDetected);
     if (flagsChanged) {
         QSqlQuery upd(db);
         upd.prepare("UPDATE shots SET channeling_detected=:c,"
                     " temperature_unstable=:t, grind_issue_detected=:g,"
                     " skip_first_frame_detected=:s,"
+                    " pour_truncated_detected=:p,"
                     " updated_at = strftime('%s', 'now') WHERE id=:id");
         upd.bindValue(":c", record.channelingDetected ? 1 : 0);
         upd.bindValue(":t", record.temperatureUnstable ? 1 : 0);
         upd.bindValue(":g", record.grindIssueDetected ? 1 : 0);
         upd.bindValue(":s", record.skipFirstFrameDetected ? 1 : 0);
+        upd.bindValue(":p", record.pourTruncatedDetected ? 1 : 0);
         upd.bindValue(":id", shotId);
         if (upd.exec()) {
             if (outBadgesPersisted) *outBadgesPersisted = true;

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1002,16 +1002,27 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
             }
         }
 
-        // Grind issue detection: flow persistently above or below goal during
-        // pour. Skip for turbo/filter shots (high-flow profiles have wide
-        // natural flow variation that would cause false positives). Phase-
-        // mode aware — restricts averaging to flow-controlled phases so the
-        // check no longer compares actual flow against a pressure-mode
-        // profile's flow limiter (80's Espresso, Cremina, Londinium pour).
-        // Suppressed when pourTruncated fires — see the comment above.
+        // Grind issue detection. Phase-mode aware — restricts flow-vs-goal
+        // averaging to flow-controlled phases so the check no longer compares
+        // actual flow against a pressure-mode profile's flow limiter (80's
+        // Espresso, Cremina, Londinium pour). Suppressed when pourTruncated
+        // fires — see the comment above.
+        //
+        // Note: we deliberately do NOT gate this on shouldSkipChannelingCheck
+        // (the turbo / non-espresso skip used by the dC/dt detector). The
+        // yield-overshoot arm in analyzeFlowVsGoal is documented to fire
+        // independently of any flow-rate window because a gusher often has
+        // high avg flow that would trigger the turbo skip; gating with
+        // shouldSkipChannelingCheck would mask that arm on exactly the
+        // population it was designed to catch (turbo gushers with peak
+        // pressure just above PRESSURE_FLOOR_BAR). analyzeFlowVsGoal already
+        // handles non-espresso beverages and intentionally-skipped profiles
+        // via its internal `bevSkip` and `grind_check_skip` checks; the
+        // pressure-mode choke arms have their own 4 bar × 15 s gate that
+        // turbo shots can't satisfy; the flow-vs-goal averaging is gated on
+        // flow-mode phase windows that turbo profiles handle correctly.
         data.grindIssueDetected = false;
-        if (!data.pourTruncatedDetected
-            && !ShotAnalysis::shouldSkipChannelingCheck(data.beverageType, flowPts, pourStart, pourEnd)) {
+        if (!data.pourTruncatedDetected) {
             data.grindIssueDetected = ShotAnalysis::detectGrindIssue(
                 flowPts, shotData->flowGoalData(), tmpRecord.phases,
                 pourStart, pourEnd, data.beverageType,
@@ -2296,13 +2307,18 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
             }
         }
 
-        // Grind direction (flow-vs-goal + choked-puck arms). Reset before the
-        // skip-check so filter/pourover/tea/steam/cleaning shots clear any
-        // stale stored value (the channeling/temp resets above are the same
-        // pattern). Suppressed when pourTruncated fires.
+        // Grind direction (flow-vs-goal + choked-puck + yield-overshoot arms).
+        // Reset before the gate so filter/pourover/tea/steam/cleaning shots
+        // clear any stale stored value via analyzeFlowVsGoal's internal skip
+        // (the channeling/temp resets above are the same pattern). Suppressed
+        // when pourTruncated fires.
+        //
+        // No outer shouldSkipChannelingCheck gate — see the matching comment
+        // in saveShotData. Skipping turbo here would mask the yield-overshoot
+        // arm on turbo gushers, which contradicts the arm's documented
+        // independence from flow-rate windows.
         record.grindIssueDetected = false;
-        if (!record.pourTruncatedDetected
-            && !ShotAnalysis::shouldSkipChannelingCheck(record.summary.beverageType, record.flow, pourStart, pourEnd)) {
+        if (!record.pourTruncatedDetected) {
             record.grindIssueDetected = ShotAnalysis::detectGrindIssue(
                 record.flow, record.flowGoal, record.phases,
                 pourStart, pourEnd, record.summary.beverageType,

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -221,7 +221,7 @@ signals:
     void mostRecentShotIdReady(qint64 shotId);
     void distinctCacheReady();
     void grinderFieldsUpdated(int updatedCount);
-    void shotBadgesUpdated(qint64 shotId, bool channelingDetected, bool temperatureUnstable, bool grindIssueDetected, bool skipFirstFrameDetected);
+    void shotBadgesUpdated(qint64 shotId, bool channelingDetected, bool temperatureUnstable, bool grindIssueDetected, bool skipFirstFrameDetected, bool pourTruncatedDetected);
 
 private:
     bool createTables();

--- a/tests/data/shots/manifest.json
+++ b/tests/data/shots/manifest.json
@@ -4,10 +4,11 @@
   "shots": [
     {
       "file": "80s_puck_failure.json",
-      "description": "Shot 868 — catastrophic puck failure. 80's Espresso, 0.6 bar peak, 37g in 7s. Puck offered no resistance; channeling + grind detectors are blind to this because conductance saturates and flow tracks preinfusion goal perfectly. detectPourTruncated must catch it.",
+      "description": "Shot 868 — catastrophic puck failure. 80's Espresso, 0.6 bar peak, 37g in 7s. Puck offered no resistance; channeling + grind detectors are blind to this because conductance saturates and flow tracks preinfusion goal perfectly. detectPourTruncated must catch it. PR #922 promoted this to a red 'Puck failed' badge; the verdict text leads with the meta-action (don't tune off the shot) since the user can't discriminate among the prep failures from the curve.",
       "expect": {
         "channeling": "None",
-        "pourTruncated": true
+        "pourTruncated": true,
+        "summaryVerdictContains": "Don't tune off this shot"
       }
     },
     {
@@ -21,11 +22,12 @@
     },
     {
       "file": "puck_failure_short_gusher.json",
-      "description": "Extreme puck failure — 2.2s total, 0g yield. Extracted nothing because the machine bailed out immediately. Redundantly caught by both pourTruncated and grindIssue.",
+      "description": "Extreme puck failure — 2.2s total, 0g yield. Extracted nothing because the machine bailed out immediately. shot_eval reports both pourTruncated and grindIssue at the detector level (they fire independently); the production storage path applies PR #922's suppression cascade so only the puckFailed badge appears in the UI.",
       "expect": {
         "channeling": "None",
         "grindIssue": true,
-        "pourTruncated": true
+        "pourTruncated": true,
+        "summaryVerdictContains": "Don't tune off this shot"
       }
     },
     {

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -164,7 +164,7 @@ private slots:
             QVERIFY(hasTable(db, "shot_samples"));
             QVERIFY(hasTable(db, "shot_phases"));
             QVERIFY(hasTable(db, "schema_version"));
-            QCOMPARE(getSchemaVersion(db), 12);
+            QCOMPARE(getSchemaVersion(db), 13);
         });
     }
 
@@ -186,6 +186,7 @@ private slots:
             QVERIFY(hasColumn(db, "shots", "temperature_unstable"));
             QVERIFY(hasColumn(db, "shots", "grind_issue_detected"));
             QVERIFY(hasColumn(db, "shots", "skip_first_frame_detected"));
+            QVERIFY(hasColumn(db, "shots", "pour_truncated_detected"));
             QVERIFY(hasColumn(db, "shot_phases", "transition_reason"));
         });
     }
@@ -225,7 +226,7 @@ private slots:
         initAndClose(path, storage);
 
         withRawDb(path, "v1_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 12);
+            QCOMPARE(getSchemaVersion(db), 13);
             QVERIFY(hasColumn(db, "shots", "temperature_override"));
             QVERIFY(hasColumn(db, "shots", "yield_override"));
             QVERIFY(hasColumn(db, "shots", "beverage_type"));
@@ -236,6 +237,7 @@ private slots:
             QVERIFY(hasColumn(db, "shots", "temperature_unstable"));
             QVERIFY(hasColumn(db, "shots", "grind_issue_detected"));
             QVERIFY(hasColumn(db, "shots", "skip_first_frame_detected"));
+            QVERIFY(hasColumn(db, "shots", "pour_truncated_detected"));
             QVERIFY(hasColumn(db, "shot_phases", "transition_reason"));
         });
     }
@@ -336,7 +338,7 @@ private slots:
         withRawDb(path, "v9_verify", [](QSqlDatabase& db) {
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasIndex(db, "idx_shots_profile_kb_id"));
-            QCOMPARE(getSchemaVersion(db), 12);
+            QCOMPARE(getSchemaVersion(db), 13);
         });
     }
 
@@ -350,7 +352,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "idempotent", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 12);
+            QCOMPARE(getSchemaVersion(db), 13);
         });
     }
 
@@ -370,7 +372,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "empty_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 12);
+            QCOMPARE(getSchemaVersion(db), 13);
         });
     }
 
@@ -393,7 +395,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "null_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 12);
+            QCOMPARE(getSchemaVersion(db), 13);
             QSqlQuery q(db);
             q.exec("SELECT grinder_brand FROM shots WHERE uuid = 'test-null'");
             QVERIFY(q.next());

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -1093,6 +1093,135 @@ private slots:
         // Pour window starts at 2 s — misses the fill spike.
         QCOMPARE(ShotAnalysis::detectPourTruncated(pressure, 2.0, 8.0), true);
     }
+
+    // ---- Suppression cascade in generateSummary ----
+    //
+    // When pourTruncated fires, the channeling / flow-trend / temp-stability /
+    // grind blocks all read off curves the failed puck didn't produce, so
+    // their output is unreliable. The summary path suppresses those blocks
+    // entirely and emits a single "Pour never pressurized" warning + the
+    // "Don't tune off this shot" verdict instead. These tests lock in that
+    // behaviour so a future tweak to one of the suppressed blocks can't
+    // accidentally re-introduce a wrong-diagnosis line on a puck-failure
+    // shot. Mirror of issue #903 — see the issue for the user-visible bug
+    // (shot 868 firing "Temp unstable" while the actual signal was a 0.63
+    // bar peak puck failure).
+
+    // Warning line must include the actual peak pressure inside the pour
+    // window (the value the user looks at) and the verdict must lead with
+    // "Don't tune off this shot" rather than the old "Puck failed" wording.
+    void pourTruncated_summary_warningIncludesPeakAndVerdictNamesMetaAction()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "preinfusion start", 0, /*isFlowMode=*/true),
+            phase(2.0, "pour",              1, /*isFlowMode=*/true),
+        };
+        // Flat 0.6 bar across the pour — well below PRESSURE_FLOOR_BAR (2.5).
+        QVector<QPointF> pressure = flatSeries(0.0, 7.0, 0.6);
+        QVector<QPointF> flow = flatSeries(0.0, 7.0, 7.0);
+        QVector<QPointF> flowGoal = flatSeries(0.0, 7.0, 7.5);
+        QVector<QPointF> temperature = flatSeries(0.0, 7.0, 80.0);
+        QVector<QPointF> temperatureGoal = flatSeries(0.0, 7.0, 82.0);
+        QVector<QPointF> dCdt = flatSeries(0.0, 7.0, 0.0);
+        QVector<QPointF> weight;
+
+        const QVariantList lines = ShotAnalysis::generateSummary(
+            pressure, flow, weight, temperature, temperatureGoal,
+            dCdt, phases, /*beverageType=*/"espresso", /*duration=*/7.0,
+            /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
+
+        bool sawTruncatedWarning = false;
+        QString warningText;
+        QString verdictText;
+        for (const QVariant& v : lines) {
+            const QVariantMap m = v.toMap();
+            const QString type = m["type"].toString();
+            const QString text = m["text"].toString();
+            if (type == "warning" && text.contains("never pressurized", Qt::CaseInsensitive)) {
+                sawTruncatedWarning = true;
+                warningText = text;
+            }
+            if (type == "verdict")
+                verdictText = text;
+        }
+        QVERIFY2(sawTruncatedWarning, "expected the pour-truncated warning line");
+        QVERIFY2(warningText.contains("peak 0.6 bar"),
+                 qPrintable("warning was: " + warningText));
+        QVERIFY2(verdictText.contains("Don't tune off this shot", Qt::CaseInsensitive),
+                 qPrintable("verdict was: " + verdictText));
+        QVERIFY2(verdictText.contains("unreliable", Qt::CaseInsensitive),
+                 qPrintable("verdict should name the unreliable signals: " + verdictText));
+    }
+
+    // Temperature drift well above the 2°C threshold must NOT produce a
+    // "Temperature drifted" caution line when pourTruncated fires. This is
+    // the exact misdiagnosis from shot 868 — fix is the suppression gate in
+    // generateSummary.
+    void pourTruncated_summary_suppressesTempDriftLine()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "preinfusion start", 0, /*isFlowMode=*/true),
+            phase(2.0, "pour",              1, /*isFlowMode=*/true),
+        };
+        QVector<QPointF> pressure = flatSeries(0.0, 7.0, 0.6);  // puck failure
+        QVector<QPointF> flow = flatSeries(0.0, 7.0, 7.0);
+        QVector<QPointF> flowGoal = flatSeries(0.0, 7.0, 7.5);
+        // 5°C below goal — would normally trip the temp-unstable detector.
+        QVector<QPointF> temperature = flatSeries(0.0, 7.0, 77.0);
+        QVector<QPointF> temperatureGoal = flatSeries(0.0, 7.0, 82.0);
+        QVector<QPointF> dCdt = flatSeries(0.0, 7.0, 0.0);
+        QVector<QPointF> weight;
+
+        const QVariantList lines = ShotAnalysis::generateSummary(
+            pressure, flow, weight, temperature, temperatureGoal,
+            dCdt, phases, /*beverageType=*/"espresso", /*duration=*/7.0,
+            /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
+
+        for (const QVariant& v : lines) {
+            const QVariantMap m = v.toMap();
+            const QString text = m["text"].toString();
+            QVERIFY2(!text.contains("Temperature drifted", Qt::CaseInsensitive),
+                     qPrintable("temp-drift line leaked through suppression: " + text));
+        }
+    }
+
+    // Sustained dC/dt elevation must NOT produce a channeling line (or its
+    // green "Puck stable — no channeling spikes" companion) when
+    // pourTruncated fires — the conductance signal is unreliable when peak
+    // pressure stayed below floor.
+    void pourTruncated_summary_suppressesChannelingLines()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "preinfusion start", 0, /*isFlowMode=*/true),
+            phase(2.0, "pour",              1, /*isFlowMode=*/true),
+        };
+        QVector<QPointF> pressure = flatSeries(0.0, 7.0, 0.6);  // puck failure
+        QVector<QPointF> flow = flatSeries(0.0, 7.0, 7.0);
+        QVector<QPointF> flowGoal = flatSeries(0.0, 7.0, 7.5);
+        QVector<QPointF> temperature = flatSeries(0.0, 7.0, 82.0);
+        QVector<QPointF> temperatureGoal = flatSeries(0.0, 7.0, 82.0);
+        // Synthetic dC/dt with a sustained run above the elevated threshold.
+        QVector<QPointF> dCdt;
+        for (double t = 2.0; t <= 7.0; t += 0.05)
+            dCdt.append(QPointF(t, 4.5));  // > CHANNELING_DC_ELEVATED (3.0)
+        QVector<QPointF> weight;
+
+        const QVariantList lines = ShotAnalysis::generateSummary(
+            pressure, flow, weight, temperature, temperatureGoal,
+            dCdt, phases, /*beverageType=*/"espresso", /*duration=*/7.0,
+            /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
+
+        for (const QVariant& v : lines) {
+            const QVariantMap m = v.toMap();
+            const QString text = m["text"].toString();
+            QVERIFY2(!text.contains("channeling", Qt::CaseInsensitive)
+                     || text.contains("never pressurized", Qt::CaseInsensitive)
+                     || text.contains("Don't tune off", Qt::CaseInsensitive),
+                     qPrintable("channeling line leaked through suppression: " + text));
+            QVERIFY2(!text.contains("Puck stable", Qt::CaseInsensitive),
+                     qPrintable("green puck-stable line leaked through suppression: " + text));
+        }
+    }
 };
 
 QTEST_MAIN(tst_ShotAnalysis)

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -367,7 +367,8 @@ struct EvaluatedShot {
     bool grindSkipped = false;
     bool skippedInProd = false;  // production-path short-circuit (cleaning/filter/etc)
     bool pourTruncated = false;  // peak pressure never reached PRESSURE_FLOOR_BAR
-    QString verdict;
+    QString verdict;             // channeling-severity label for the table view (NOT the user-facing verdict)
+    QString summaryVerdict;      // user-facing verdict text from ShotAnalysis::generateSummary; populated lazily for --validate
 };
 
 // Count elevated samples + find max spike in a dC/dt series across a time
@@ -469,6 +470,30 @@ EvaluatedShot evaluate(const LoadedShot& s)
     // because the puck never built pressure at all.
     ev.pourTruncated = ShotAnalysis::detectPourTruncated(
         s.pressure, s.pourStart, s.pourEnd, s.beverageType);
+
+    // User-facing verdict text. Calls into the same generateSummary() that the
+    // Shot Summary popup uses, so the manifest can lock in the verdict-cascade
+    // wording and catch regressions to the suppression rules (e.g. PR #922's
+    // pourTruncated → "Don't tune off this shot" verdict). Pass empty vectors
+    // for weight / temperature / temperatureGoal — the function tolerates
+    // missing curves and skips the corresponding observation lines, but the
+    // verdict cascade still picks the right branch from pressure / flow / dC/dt
+    // and the phase markers, which is what the manifest gates check.
+    {
+        const QVariantList lines = ShotAnalysis::generateSummary(
+            s.pressure, s.flow, /*weight=*/{}, /*temperature=*/{},
+            /*temperatureGoal=*/{}, s.conductanceDerivative, s.phases,
+            s.beverageType, s.durationSec, s.pressureGoal, s.flowGoal,
+            /*analysisFlags=*/{}, /*firstFrameConfiguredSeconds=*/-1.0,
+            s.targetWeightG, s.yieldG);
+        for (const QVariant& v : lines) {
+            const QVariantMap m = v.toMap();
+            if (m.value(QStringLiteral("type")).toString() == QStringLiteral("verdict")) {
+                ev.summaryVerdict = m.value(QStringLiteral("text")).toString();
+                break;
+            }
+        }
+    }
 
     // Short verdict for the table: report any direction the two detectors
     // disagree on — that's what the user cares about when evaluating a
@@ -689,6 +714,17 @@ int main(int argc, char** argv)
                     mismatches << QStringLiteral("pourTruncated: want=%1 got=%2")
                                       .arg(want ? "true" : "false",
                                            ev.pourTruncated ? "true" : "false");
+            }
+            // Substring match against the user-facing verdict text — guards
+            // wording regressions in the verdict cascade (e.g. the puck-failed
+            // "Don't tune off this shot" lead-in from PR #922). Substring
+            // rather than exact so manifest authors can lock in the
+            // diagnostic phrase without freezing the entire sentence.
+            if (expect.contains("summaryVerdictContains")) {
+                const QString want = expect.value("summaryVerdictContains").toString();
+                if (!ev.summaryVerdict.contains(want, Qt::CaseInsensitive))
+                    mismatches << QStringLiteral("summaryVerdictContains: want=%1 got=%2")
+                                      .arg(want, ev.summaryVerdict);
             }
 
             if (mismatches.isEmpty()) {


### PR DESCRIPTION
## Summary

Closes the chip half of [#903](https://github.com/Kulitorum/Decenza/issues/903): low-pressure shots get a dedicated red **Puck failed** chip and the channeling/temp/grind flags are suppressed under it, so users no longer see contradictory \"Temp unstable\" or \"Clean extraction\" badges on what's actually a puck failure.

- New \`pour_truncated_detected\` column (migration 13), drift-on-load fixes 15 historical shots automatically on next read (8 of which currently fire wrong-diagnosis \"Temp unstable\")
- Suppression cascade applied in three places: save block, \`loadShotRecordStatic\` recompute, and \`ShotAnalysis::generateSummary\`
- New chip in \`QualityBadges.qml\`, gated against \"Clean extraction\" so a suppressed shot can't fall through to the green chip
- Summary verdict reworded to lead with the meta-action (\"Don't tune off this shot — peak pressure never built, so the other quality signals are unreliable\") and the warning line includes actual peak pressure

## Why this shape

Discussion on the issue landed on combining what was originally PR A (suppression) and PR B (badge column) — suppression alone would let the green \"Clean extraction\" chip fire on puck-failure shots, which is worse than the wrong-orange-chip status quo. The two halves are a single design.

Gap 2 from the issue (the 2.5–5 bar underpressurized band, ~4 shots / 0.4 % incidence) is intentionally **not** in this PR. See the issue thread for the rationale.

## Test plan

- [x] \`ctest\` — all 1769 pass (1766 pre-existing + 3 new \`pourTruncated_summary_*\` cascade tests)
- [x] \`tst_dbmigration\` — schema version bump 12→13 + new column-presence assertion
- [x] Existing \`shot_corpus_regression\` — both puck-failure fixtures (\`80s_puck_failure.json\`, \`puck_failure_short_gusher.json\`) still pass; \`londinium_gusher.json\` peak-9-bar fixture still shows channeling (suppression doesn't fire when \`pourTruncated\` is false)
- [ ] Manual smoke: open shot 1052 in history (the canonical puck-failure case from the issue: 80's Espresso, 18.1g → 37.4g in 7.27s, peak 0.63 bar) — should now show red \"Puck failed\" instead of orange \"Temp unstable.\" Confirm \`pour_truncated_detected\` flipped via SQLite.
- [ ] Manual smoke: open a clean shot (e.g. anything peaking at 9 bar) — should still show green \"Clean extraction\" with no regressions

## Out of scope

- \`ShotSummarizer\` (AI advisor prompt context path) computes its own \`channelingDetected\` / \`temperatureUnstable\` flags via an independent pipeline. Same suppression logic should apply there — tracked as [#921](https://github.com/Kulitorum/Decenza/issues/921) for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)