### PR TITLE
ci(ios): bump runner to macos-26 for Xcode 26 / iOS 26 SDK

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build-ios:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Bumps `.github/workflows/ios-release.yml` from `runs-on: macos-15` to `runs-on: macos-26`
- Apple now rejects App Store Connect uploads built with anything older than the iOS 26 SDK (Xcode 26+); `macos-15` ships Xcode 16.4 (iOS 18.5 SDK), so every iOS upload from that image fails with HTTP 409 SDK validation
- `macos-26` is GA, same pricing tier (no premium), default Xcode 26.2 with 26.0.1 → 26.4.1 also installed

## Why this doesn't drop iOS 17/18 support

This is a **build SDK** bump, not a **deployment target** change. The deployment target (set via `qt-cmake` / `CMAKE_OSX_DEPLOYMENT_TARGET`, currently iOS 17.0+) controls minimum runtime support and is independent of the SDK the binary was compiled against. Existing iOS 17/18 users keep working — iOS 26-only APIs would simply not be reachable at runtime on their devices.

## Failure that prompted this

[ios-release.yml run #25118859278](https://github.com/Kulitorum/Decenza/actions/runs/25118859278) on the v1.7.2 prerelease tag — build itself succeeded (compile, sign, IPA export); only the App Store Connect upload step failed with:

> SDK version issue. This app was built with the iOS 18.5 SDK. All iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later, in order to be uploaded to App Store Connect or submitted for distribution. (ID: 4ed8b5c5-a419-4766-b511-c7861f990978)

## Why iOS only (not macOS)

The `macos-release.yml` workflow produces a notarized DMG for direct distribution, not Mac App Store submission, so it isn't subject to the same SDK gate. That build succeeded on the v1.7.2 tag run. Bump it independently if/when notarization tightens.

## Test plan

- [ ] Trigger a `workflow_dispatch` test build of the iOS workflow with `upload_to_appstore=false` to confirm `macos-26` builds Decenza cleanly
- [ ] Once green, re-tag v1.7.2 (or wait for next release) — App Store upload should succeed
- [ ] Confirm `xcrun otool -l Decenza.app/Decenza | grep -A 2 LC_BUILD_VERSION` on the resulting binary still shows `minos 17.0` (or current floor) — the SDK bump should not have moved the deployment target

🤖 Generated with [Claude Code](https://claude.ai/code)