### PR TITLE
ci(ios): unset MACOSX_DEPLOYMENT_TARGET on macos-26 to avoid clang env conflict

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -111,6 +111,13 @@ jobs:
 
       - name: Configure CMake
         run: |
+          # The macos-26 runner image sets MACOSX_DEPLOYMENT_TARGET=26.2 in
+          # the shell env. Xcode 26's clang refuses to compile when conflicting
+          # *_DEPLOYMENT_TARGET env vars are present (the iOS toolchain sets
+          # IPHONEOS_DEPLOYMENT_TARGET=17.0 for the iOS target, and the host's
+          # 26.2 leaks in alongside it). Unset before invoking qt-cmake so the
+          # compiler-ABI introspection it runs doesn't trip the new check.
+          unset MACOSX_DEPLOYMENT_TARGET
           mkdir -p build/ios
           cd build/ios
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
@@ -120,11 +127,16 @@ jobs:
             -DCMAKE_XCODE_ATTRIBUTE_CXX="$CCACHE_LAUNCH_CXX" \
             -DCMAKE_XCODE_ATTRIBUTE_LD="$CCACHE_LAUNCH_C" \
             -DCMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS="$CCACHE_LAUNCH_CXX"
-            
+
       - name: Build and Archive
         env:
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          # See the Configure CMake step for why this is needed. xcodebuild
+          # forks autogen scripts that re-invoke clang for CMake's ABI test;
+          # the host MACOSX_DEPLOYMENT_TARGET must be cleared so the iOS
+          # cross-compile target doesn't conflict.
+          unset MACOSX_DEPLOYMENT_TARGET
           cd build/ios
 
           # Build archive


### PR DESCRIPTION
## Summary

Follow-up to #923. After bumping the iOS workflow to `macos-26`, the build itself fails earlier than the upload step did before:

> clang++: error: conflicting deployment targets, both '26.2' and '17.0' are present in environment

The `macos-26` runner image sets `MACOSX_DEPLOYMENT_TARGET=26.2` in the shell env (the host macOS version). Xcode 26's clang has a new check (LLVM 17) that refuses to compile when multiple `*_DEPLOYMENT_TARGET` env vars are simultaneously present with different values — the iOS toolchain's `IPHONEOS_DEPLOYMENT_TARGET=17.0` collides with the host's `26.2`.

Fix: `unset MACOSX_DEPLOYMENT_TARGET` at the top of both:
- `Configure CMake` (qt-cmake invokes the compiler for ABI introspection)
- `Build and Archive` (xcodebuild forks autogen scripts that re-run CMake's `CMakeCXXCompilerABI.cpp` test)

Subprocesses inherit the parent shell's env, so a single `unset` in each step propagates correctly to all the clang invocations underneath.

## Why macos-15 didn't hit this

`macos-15` didn't set the host env var at all, so the conflict didn't exist. `macos-26` exports it as part of the runner image profile.

## Failure that prompted this

[ios-release.yml run #25121171646](https://github.com/Kulitorum/Decenza/actions/runs/25121171646) on the v1.7.2 prerelease tag (the `macos-26` first attempt).

## Test plan

- [ ] Re-tag v1.7.2 after merge, verify iOS build completes the Build and Archive step
- [ ] Verify upload step then succeeds (the original reason for the macos-26 bump)
- [ ] Verify final IPA still has `LC_BUILD_VERSION minos 17.0` so iOS 17/18 users still supported

🤖 Generated with [Claude Code](https://claude.ai/code)