### PR TITLE
ci(ios): pin Xcode to 26.0.1 to avoid LLVM-17 strict deployment-target check

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -43,6 +43,25 @@ jobs:
           echo "build_code=$NEXT" >> $GITHUB_OUTPUT
           echo "Version code bumped: $CURRENT -> $NEXT"
 
+      - name: Pin Xcode to 26.0.1
+        run: |
+          # macos-26 default is Xcode 26.2, whose clang adds a strict check
+          # that refuses to compile when more than one *_DEPLOYMENT_TARGET
+          # env var is set. The runner image exports MACOSX, IPHONESIMULATOR,
+          # and MACCATALYST values (all from the macOS 26 host); the iOS
+          # cross-compile adds IPHONEOS=17.0 — four platform vars in one env,
+          # which trips the check inside Xcode's PhaseScriptExecution
+          # subprocesses where we can't easily scrub them.
+          #
+          # Xcode 26.0.1 ships an earlier clang from the same Xcode 26 family,
+          # so it satisfies App Store Connect's iOS 26 SDK requirement, but
+          # without the new env-conflict check. Pinning here keeps the SDK
+          # gate satisfied while sidestepping the build failure on macos-26.
+          # Tracked separately as a Qt-toolchain follow-up.
+          sudo xcode-select -s /Applications/Xcode_26.0.1.app/Contents/Developer
+          xcodebuild -version
+          echo "DEVELOPER_DIR=/Applications/Xcode_26.0.1.app/Contents/Developer" >> $GITHUB_ENV
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:


### PR DESCRIPTION
## Summary

Band-aid for v1.7.2: pin iOS workflow to Xcode 26.0.1, which is in the same Xcode 26 family (satisfies App Store Connect's iOS 26 SDK requirement) but doesn't carry LLVM 17's strict env-conflict check that's blocking us on Xcode 26.2.

## Why pin instead of fix

The actual fix is upstream — see [#925](https://github.com/Kulitorum/Decenza/issues/925) for the full analysis. Short version: when xcodebuild forks `PhaseScriptExecution` autogen subprocesses to populate `moc_predefs_Release.h`, CMake's compiler-ABI test calls clang **without `-target arm64-apple-ios17.0`**, relying entirely on env-var fallback to determine the platform. With Xcode 26.1+, when `MACOSX/IPHONESIMULATOR/MACCATALYST/IPHONEOS` deployment-target env vars are simultaneously present (which the macos-26 runner image guarantees), clang refuses to compile.

The durable fix is to inject an explicit `-target` into CMake's compiler invocations (likely via `-DCMAKE_CXX_COMPILER_TARGET=arm64-apple-ios17.0`); tracked in [#925](https://github.com/Kulitorum/Decenza/issues/925). This PR unblocks v1.7.2 while that's investigated.

## Why this works

- Apple's iOS 26 SDK gate applies to the **build SDK**, not the clang version's check behavior. Xcode 26.0.1 ships the iOS 26.0 SDK; same family, satisfies the gate.
- Xcode 26.0.1 predates the strict deployment-target env check (which appears to be Xcode 26.1 or 26.2).
- Deployment target stays at iOS 17.0 — no change to who can install/run the app.

## Failures that prompted this

- [run #25121620721](https://github.com/Kulitorum/Decenza/actions/runs/25121620721) — Build and Archive on macos-26 default Xcode 26.2: clang env conflict in AUTOMOC predefs subprocess
- Earlier macos-15 attempt: SDK rejected at App Store Connect upload ("must be built with iOS 26 SDK")

## Test plan

- [ ] After merge, re-tag v1.7.2 and verify iOS build completes Build, Archive, Export, and App Store Upload steps
- [ ] Verify `LC_BUILD_VERSION minos 17.0` on the resulting binary (no deployment-target drift)

🤖 Generated with [Claude Code](https://claude.ai/code)