### PR TITLE
ci(ios): restore green iOS build on macos-26 / Xcode 26.4.1 with ccache

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -88,70 +88,39 @@ jobs:
       - name: Configure ccache for CI
         run: ccache --set-config=compiler_check=content
 
-      - name: Replace Xcode clang/clang++ with env-scrubbing shims
+      - name: Create env-scrubbing ccache compiler wrappers
         run: |
-          # Xcode 26.1+ clang has a strict check: if more than one platform's
-          # *_DEPLOYMENT_TARGET env var is set when clang runs, refuse to
-          # compile with "conflicting deployment targets". The macos-26
-          # runner image pre-exports MACOSX/IPHONESIMULATOR/MACCATALYST
-          # values; xcodebuild then layers IPHONEOS_DEPLOYMENT_TARGET=17.0
-          # from the iOS toolchain on top. Four platform vars in one
-          # subprocess env trips the check.
+          # Two roles in one wrapper:
           #
-          # Verified that Xcode 26.4.1 (the version we pin above for libc++
-          # ABI compatibility) carries the same strict check — see
-          # https://github.com/Kulitorum/Decenza/actions/runs/25129294929
-          # for the failure when the shim was removed as a test.
+          # 1. Env scrub. Xcode 26.1+ clang refuses to compile when more than
+          #    one platform's *_DEPLOYMENT_TARGET env var is set. The macos-26
+          #    runner image pre-exports MACOSX/IPHONESIMULATOR/MACCATALYST
+          #    values and xcodebuild adds IPHONEOS=17.0 from the iOS toolchain.
+          #    Without ccache wrappers in the loop, xcodebuild normalizes its
+          #    env before exec'ing clang and the conflict doesn't fire — but
+          #    once we wrap clang with launch-c (so ccache can cache), the
+          #    wrapper interposes between xcodebuild's normalization and
+          #    clang's check. Unset the host platform vars in the wrapper to
+          #    restore the same effect.
           #
-          # Earlier failed approaches in this PR's history:
-          #   - parent-shell unset: doesn't reach PhaseScriptExecution
-          #     subprocesses (xcodebuild re-injects from build settings)
-          #   - CMAKE_C/CXX_COMPILER override to a wrapper: qt-cmake's iOS
-          #     toolchain forces the variables back to absolute Xcode paths
-          #     after we set them, so the wrapper isn't called for CMake's
-          #     AUTOMOC compiler-ABI test (the actual failing call site)
-          #   - Pinning Xcode 26.0.1: lacks iOS platform on macos-26
-          #   - Pinning Xcode 26.1.1: still has the strict check
+          # 2. Preserve IPHONEOS_DEPLOYMENT_TARGET. The link step needs it
+          #    intact for libc++ symbol resolution; if it's unset alongside
+          #    the host vars, the linker can't find Qt's [abi:ue170006]
+          #    libc++ symbols. This was the failure mode in commit bf12ee6d.
           #
-          # Replacing the Xcode clang/clang++ binaries directly intercepts
-          # every invocation — CMake's ABI test, AUTOMOC predefs subprocess,
-          # the actual compile, ccache-wrapped calls. The runner is an
-          # ephemeral VM so modifying the Xcode bundle doesn't persist
-          # across jobs.
+          # 3. ccache caching. Standard chain: xcodebuild → launch-c → ccache
+          #    → real clang.
           #
-          # Long-term durable fix is upstream: CMake's AUTOMOC predefs
+          # Long-term durable fix is upstream — CMake's AUTOMOC predefs
           # script should pass -target explicitly so it doesn't depend on
           # env-var fallback. Tracked as #925.
-          set -e
-          XCODE_BIN="$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/bin"
-          for tool in clang clang++; do
-            if [ -f "$XCODE_BIN/$tool" ] && [ ! -f "$XCODE_BIN/$tool.real" ]; then
-              sudo mv "$XCODE_BIN/$tool" "$XCODE_BIN/$tool.real"
-              sudo tee "$XCODE_BIN/$tool" >/dev/null <<EOF
-          #!/bin/sh
-          # Strip ALL platform deployment-target env vars. The developer's
-          # local Mac has none of these set in the shell and Qt 6.10.3 +
-          # Xcode 26.4.1 builds cleanly there; we match that env. Target/SDK
-          # come in via -target / -isysroot flags on the actual link line.
-          unset MACOSX_DEPLOYMENT_TARGET IPHONEOS_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET
-          exec "$XCODE_BIN/$tool.real" "\$@"
-          EOF
-              sudo chmod +x "$XCODE_BIN/$tool"
-            fi
-          done
-
-      - name: Create ccache compiler wrappers
-        run: |
-          # Wraps clang/clang++ for ccache. The Xcode toolchain binaries are
-          # already replaced with env-scrubbing shims (step above), so the
-          # call chain at compile time is:
-          #   xcodebuild → launch-c → ccache → /…/clang (shim) → unset → clang.real
           WRAPPER_DIR="$RUNNER_TEMP/ccache-wrappers"
           mkdir -p "$WRAPPER_DIR"
           CLANG=$(xcrun -f clang)
           CLANGPP=$(xcrun -f clang++)
-          printf '#!/bin/sh\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$CLANG" "$CLANG" > "$WRAPPER_DIR/launch-c"
-          printf '#!/bin/sh\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$CLANGPP" "$CLANGPP" > "$WRAPPER_DIR/launch-cxx"
+          ENV_SCRUB='unset MACOSX_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET'
+          printf '#!/bin/sh\n%s\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$ENV_SCRUB" "$CLANG" "$CLANG" > "$WRAPPER_DIR/launch-c"
+          printf '#!/bin/sh\n%s\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$ENV_SCRUB" "$CLANGPP" "$CLANGPP" > "$WRAPPER_DIR/launch-cxx"
           chmod +x "$WRAPPER_DIR/launch-c" "$WRAPPER_DIR/launch-cxx"
           echo "CCACHE_LAUNCH_C=$WRAPPER_DIR/launch-c" >> $GITHUB_ENV
           echo "CCACHE_LAUNCH_CXX=$WRAPPER_DIR/launch-cxx" >> $GITHUB_ENV

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -174,13 +174,17 @@ jobs:
         run: |
           mkdir -p build/ios
           cd build/ios
+          # Only wrap CC/CXX with ccache. Wrapping LD/LDPLUSPLUS routes the
+          # link step through ccache (which doesn't cache link products) and
+          # — because LD points at launch-c — forces the C++ link through
+          # the clang driver instead of clang++, so -lc++ is never auto-
+          # added and the link fails with missing __cxa_*/__gxx_personality
+          # symbols. Leave LD/LDPLUSPLUS at Xcode defaults.
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_XCODE_ATTRIBUTE_CC="$CCACHE_LAUNCH_C" \
-            -DCMAKE_XCODE_ATTRIBUTE_CXX="$CCACHE_LAUNCH_CXX" \
-            -DCMAKE_XCODE_ATTRIBUTE_LD="$CCACHE_LAUNCH_C" \
-            -DCMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS="$CCACHE_LAUNCH_CXX"
+            -DCMAKE_XCODE_ATTRIBUTE_CXX="$CCACHE_LAUNCH_CXX"
 
       - name: Build and Archive
         env:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -88,39 +88,51 @@ jobs:
       - name: Configure ccache for CI
         run: ccache --set-config=compiler_check=content
 
-      - name: Create env-scrubbing ccache compiler wrappers
+      - name: Replace Xcode clang/clang++ with env-scrubbing shims
         run: |
-          # Two roles in one wrapper:
+          # The shim sits on the *active* Xcode (26.4.1, set by the pin step
+          # above) and intercepts ALL clang invocations — both xcodebuild's
+          # native compile path and the AUTOMOC PhaseScriptExecution that
+          # calls clang directly without going through CMAKE_XCODE_ATTRIBUTE
+          # _CC (which is why a wrapper-only approach can't catch it).
           #
-          # 1. Env scrub. Xcode 26.1+ clang refuses to compile when more than
-          #    one platform's *_DEPLOYMENT_TARGET env var is set. The macos-26
-          #    runner image pre-exports MACOSX/IPHONESIMULATOR/MACCATALYST
-          #    values and xcodebuild adds IPHONEOS=17.0 from the iOS toolchain.
-          #    Without ccache wrappers in the loop, xcodebuild normalizes its
-          #    env before exec'ing clang and the conflict doesn't fire — but
-          #    once we wrap clang with launch-c (so ccache can cache), the
-          #    wrapper interposes between xcodebuild's normalization and
-          #    clang's check. Unset the host platform vars in the wrapper to
-          #    restore the same effect.
+          # The shim unsets host-platform DEPLOYMENT_TARGET env vars (MACOSX,
+          # IPHONESIMULATOR, MACCATALYST, TVOS, WATCHOS, XROS, DRIVERKIT)
+          # but PRESERVES IPHONEOS_DEPLOYMENT_TARGET — the linker needs the
+          # latter to resolve libc++ correctly against Qt's prebuilt iOS
+          # binaries. An earlier attempt that unset IPHONEOS too (commit
+          # bf12ee6d) link-failed with undefined [abi:ue170006] symbols.
           #
-          # 2. Preserve IPHONEOS_DEPLOYMENT_TARGET. The link step needs it
-          #    intact for libc++ symbol resolution; if it's unset alongside
-          #    the host vars, the linker can't find Qt's [abi:ue170006]
-          #    libc++ symbols. This was the failure mode in commit bf12ee6d.
-          #
-          # 3. ccache caching. Standard chain: xcodebuild → launch-c → ccache
-          #    → real clang.
-          #
-          # Long-term durable fix is upstream — CMake's AUTOMOC predefs
+          # Long-term durable fix is upstream: CMake's AUTOMOC predefs
           # script should pass -target explicitly so it doesn't depend on
           # env-var fallback. Tracked as #925.
+          set -e
+          XCODE_BIN="$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+          for tool in clang clang++; do
+            if [ -f "$XCODE_BIN/$tool" ] && [ ! -f "$XCODE_BIN/$tool.real" ]; then
+              sudo mv "$XCODE_BIN/$tool" "$XCODE_BIN/$tool.real"
+              sudo tee "$XCODE_BIN/$tool" >/dev/null <<EOF
+          #!/bin/sh
+          unset MACOSX_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET
+          exec "$XCODE_BIN/$tool.real" "\$@"
+          EOF
+              sudo chmod +x "$XCODE_BIN/$tool"
+            fi
+          done
+
+      - name: Create ccache compiler wrappers
+        run: |
+          # Standard ccache plumbing. The Xcode toolchain binaries are already
+          # replaced with env-scrubbing shims (step above), so the call chain
+          # at compile time is:
+          #   xcodebuild → launch-c → ccache → /…/clang (shim) → clang.real
+          # The shim handles env scrub; the wrapper only adds ccache.
           WRAPPER_DIR="$RUNNER_TEMP/ccache-wrappers"
           mkdir -p "$WRAPPER_DIR"
           CLANG=$(xcrun -f clang)
           CLANGPP=$(xcrun -f clang++)
-          ENV_SCRUB='unset MACOSX_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET'
-          printf '#!/bin/sh\n%s\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$ENV_SCRUB" "$CLANG" "$CLANG" > "$WRAPPER_DIR/launch-c"
-          printf '#!/bin/sh\n%s\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$ENV_SCRUB" "$CLANGPP" "$CLANGPP" > "$WRAPPER_DIR/launch-cxx"
+          printf '#!/bin/sh\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$CLANG" "$CLANG" > "$WRAPPER_DIR/launch-c"
+          printf '#!/bin/sh\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$CLANGPP" "$CLANGPP" > "$WRAPPER_DIR/launch-cxx"
           chmod +x "$WRAPPER_DIR/launch-c" "$WRAPPER_DIR/launch-cxx"
           echo "CCACHE_LAUNCH_C=$WRAPPER_DIR/launch-c" >> $GITHUB_ENV
           echo "CCACHE_LAUNCH_CXX=$WRAPPER_DIR/launch-cxx" >> $GITHUB_ENV

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -43,35 +43,6 @@ jobs:
           echo "build_code=$NEXT" >> $GITHUB_OUTPUT
           echo "Version code bumped: $CURRENT -> $NEXT"
 
-      - name: Pin Xcode to 26.1.1
-        run: |
-          # macos-26 default is Xcode 26.2, whose clang adds a strict check
-          # that refuses to compile when more than one *_DEPLOYMENT_TARGET
-          # env var is set. The runner image exports MACOSX, IPHONESIMULATOR,
-          # and MACCATALYST values (all from the macOS 26 host); the iOS
-          # cross-compile adds IPHONEOS=17.0 — four platform vars in one env,
-          # which trips the check inside Xcode's PhaseScriptExecution
-          # subprocesses where we can't easily scrub them.
-          #
-          # We pin to Xcode 26.1.1 because:
-          #   - It satisfies App Store Connect's iOS 26 SDK requirement
-          #     (paired with the iOS 26.1 SDK, also in the Xcode 26 family).
-          #   - macos-26 only has iOS platform support installed for the
-          #     iOS 26.1 / 26.2 / 26.4 runtimes (see runner image readme).
-          #     Xcode 26.0.1 lacks the iOS platform component on this image,
-          #     so xcodebuild errors with "iOS 26.0 is not installed" before
-          #     it gets anywhere near a compile.
-          #   - 26.1.1's clang predates the strict deployment-target env
-          #     check (introduced in 26.2), so the conflicting platform env
-          #     vars from the runner image don't trip it.
-          #
-          # The durable fix is upstream — CMake's automoc compiler-ABI test
-          # should be passing -target explicitly so it doesn't depend on
-          # env-var fallback. Tracked as #925.
-          sudo xcode-select -s /Applications/Xcode_26.1.1.app/Contents/Developer
-          xcodebuild -version
-          echo "DEVELOPER_DIR=/Applications/Xcode_26.1.1.app/Contents/Developer" >> $GITHUB_ENV
-
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
@@ -91,19 +62,48 @@ jobs:
       - name: Configure ccache for CI
         run: ccache --set-config=compiler_check=content
 
-      - name: Create ccache compiler wrappers
+      - name: Create compiler wrappers (ccache + DEPLOYMENT_TARGET env scrub)
         run: |
-          # Use CMAKE_XCODE_ATTRIBUTE_CC/CXX approach (same as macOS).
-          # CMake configure uses the real compiler; only xcodebuild uses wrappers.
+          # Two roles for these wrappers:
+          #
+          # 1. ccache cache hits — same as on macOS.
+          # 2. Scrub host platform DEPLOYMENT_TARGET env vars so Xcode 26.1+
+          #    clang's strict env-conflict check doesn't trip when CMake's
+          #    AUTOMOC ABI test (CMakeCXXCompilerABI.cpp) re-invokes clang
+          #    inside an xcodebuild PhaseScriptExecution subprocess. The
+          #    macos-26 runner image pre-exports MACOSX_DEPLOYMENT_TARGET=26.2,
+          #    IPHONESIMULATOR_DEPLOYMENT_TARGET=26.2, MACCATALYST_DEPLOYMENT
+          #    _TARGET=25.2 (and probably others); xcodebuild then layers
+          #    IPHONEOS_DEPLOYMENT_TARGET=17.0 from the iOS toolchain on top.
+          #    With four platform vars set at once, clang refuses with:
+          #      "conflicting deployment targets, both '26.2' and '17.0'"
+          #    Unsetting in the parent shell doesn't reach
+          #    PhaseScriptExecution subprocesses (xcodebuild re-injects
+          #    them). Doing it inside the wrapper is the durable fix —
+          #    every clang invocation, however nested, gets a clean env.
+          #
+          # The wrapper is wired in two places below:
+          #   - CMAKE_XCODE_ATTRIBUTE_CC/CXX → real compile (Xcode generator).
+          #   - CMAKE_C/CXX_COMPILER         → CMake's own ABI tests, which
+          #                                    is the failing call site.
+          # Both paths now go through the env-scrub.
           WRAPPER_DIR="$RUNNER_TEMP/ccache-wrappers"
           mkdir -p "$WRAPPER_DIR"
           CLANG=$(xcrun -f clang)
           CLANGPP=$(xcrun -f clang++)
-          printf '#!/bin/sh\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$CLANG" "$CLANG" > "$WRAPPER_DIR/launch-c"
-          printf '#!/bin/sh\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$CLANGPP" "$CLANGPP" > "$WRAPPER_DIR/launch-cxx"
+          # Note: leading-arg trim handles the case where Xcode passes the
+          # absolute compiler path as $1; we drop it and exec the real one.
+          ENV_SCRUB='unset MACOSX_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET'
+          printf '#!/bin/sh\n%s\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$ENV_SCRUB" "$CLANG" "$CLANG" > "$WRAPPER_DIR/launch-c"
+          printf '#!/bin/sh\n%s\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$ENV_SCRUB" "$CLANGPP" "$CLANGPP" > "$WRAPPER_DIR/launch-cxx"
           chmod +x "$WRAPPER_DIR/launch-c" "$WRAPPER_DIR/launch-cxx"
           echo "CCACHE_LAUNCH_C=$WRAPPER_DIR/launch-c" >> $GITHUB_ENV
           echo "CCACHE_LAUNCH_CXX=$WRAPPER_DIR/launch-cxx" >> $GITHUB_ENV
+          # Print contents for log-debugging
+          echo "--- launch-c ---"
+          cat "$WRAPPER_DIR/launch-c"
+          echo "--- launch-cxx ---"
+          cat "$WRAPPER_DIR/launch-cxx"
 
       - name: Install Apple certificate and provisioning profile
         env:
@@ -140,18 +140,22 @@ jobs:
 
       - name: Configure CMake
         run: |
-          # The macos-26 runner image sets MACOSX_DEPLOYMENT_TARGET=26.2 in
-          # the shell env. Xcode 26's clang refuses to compile when conflicting
-          # *_DEPLOYMENT_TARGET env vars are present (the iOS toolchain sets
-          # IPHONEOS_DEPLOYMENT_TARGET=17.0 for the iOS target, and the host's
-          # 26.2 leaks in alongside it). Unset before invoking qt-cmake so the
-          # compiler-ABI introspection it runs doesn't trip the new check.
-          unset MACOSX_DEPLOYMENT_TARGET
+          # The wrappers built above ensure every clang invocation — including
+          # the AUTOMOC compiler-ABI test that runs inside xcodebuild's
+          # PhaseScriptExecution — has the host platform DEPLOYMENT_TARGET
+          # env vars unset before exec'ing the real compiler. Wire them in
+          # via:
+          #   - CMAKE_C/CXX_COMPILER         → CMake's own ABI tests
+          #     (CMakeCXXCompilerABI.cpp, used by AUTOMOC predefs). This is
+          #     the actual failing call site.
+          #   - CMAKE_XCODE_ATTRIBUTE_CC/CXX → real Xcode-driven compile.
           mkdir -p build/ios
           cd build/ios
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DCMAKE_C_COMPILER="$CCACHE_LAUNCH_C" \
+            -DCMAKE_CXX_COMPILER="$CCACHE_LAUNCH_CXX" \
             -DCMAKE_XCODE_ATTRIBUTE_CC="$CCACHE_LAUNCH_C" \
             -DCMAKE_XCODE_ATTRIBUTE_CXX="$CCACHE_LAUNCH_CXX" \
             -DCMAKE_XCODE_ATTRIBUTE_LD="$CCACHE_LAUNCH_C" \
@@ -161,11 +165,6 @@ jobs:
         env:
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          # See the Configure CMake step for why this is needed. xcodebuild
-          # forks autogen scripts that re-invoke clang for CMake's ABI test;
-          # the host MACOSX_DEPLOYMENT_TARGET must be cleared so the iOS
-          # cross-compile target doesn't conflict.
-          unset MACOSX_DEPLOYMENT_TARGET
           cd build/ios
 
           # Build archive

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -53,57 +53,59 @@ jobs:
           cache: true
           cache-key-prefix: 'qt-ios-v4'
 
-      - name: Set up ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          key: ios-arm64
-          max-size: 500M
-
-      - name: Configure ccache for CI
-        run: ccache --set-config=compiler_check=content
-
-      - name: Create compiler wrappers (ccache + DEPLOYMENT_TARGET env scrub)
+      - name: Replace Xcode clang/clang++ with env-scrubbing shims
         run: |
-          # Two roles for these wrappers:
+          # Why this is here, not just CMake variable overrides:
           #
-          # 1. ccache cache hits — same as on macOS.
-          # 2. Scrub host platform DEPLOYMENT_TARGET env vars so Xcode 26.1+
-          #    clang's strict env-conflict check doesn't trip when CMake's
-          #    AUTOMOC ABI test (CMakeCXXCompilerABI.cpp) re-invokes clang
-          #    inside an xcodebuild PhaseScriptExecution subprocess. The
-          #    macos-26 runner image pre-exports MACOSX_DEPLOYMENT_TARGET=26.2,
-          #    IPHONESIMULATOR_DEPLOYMENT_TARGET=26.2, MACCATALYST_DEPLOYMENT
-          #    _TARGET=25.2 (and probably others); xcodebuild then layers
-          #    IPHONEOS_DEPLOYMENT_TARGET=17.0 from the iOS toolchain on top.
-          #    With four platform vars set at once, clang refuses with:
-          #      "conflicting deployment targets, both '26.2' and '17.0'"
-          #    Unsetting in the parent shell doesn't reach
-          #    PhaseScriptExecution subprocesses (xcodebuild re-injects
-          #    them). Doing it inside the wrapper is the durable fix —
-          #    every clang invocation, however nested, gets a clean env.
+          # Xcode 26.1+ clang has a new check: if more than one platform's
+          # *_DEPLOYMENT_TARGET env var is set at compile time, refuse the
+          # build with "conflicting deployment targets". The macos-26 runner
+          # image pre-exports MACOSX_DEPLOYMENT_TARGET=26.2,
+          # IPHONESIMULATOR_DEPLOYMENT_TARGET=26.2, MACCATALYST_DEPLOYMENT
+          # _TARGET=25.2; xcodebuild layers IPHONEOS_DEPLOYMENT_TARGET=17.0
+          # from the iOS toolchain on top. Four platform vars in one
+          # subprocess env trips the check.
           #
-          # The wrapper is wired in two places below:
-          #   - CMAKE_XCODE_ATTRIBUTE_CC/CXX → real compile (Xcode generator).
-          #   - CMAKE_C/CXX_COMPILER         → CMake's own ABI tests, which
-          #                                    is the failing call site.
-          # Both paths now go through the env-scrub.
-          WRAPPER_DIR="$RUNNER_TEMP/ccache-wrappers"
-          mkdir -p "$WRAPPER_DIR"
-          CLANG=$(xcrun -f clang)
-          CLANGPP=$(xcrun -f clang++)
-          # Note: leading-arg trim handles the case where Xcode passes the
-          # absolute compiler path as $1; we drop it and exec the real one.
-          ENV_SCRUB='unset MACOSX_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET'
-          printf '#!/bin/sh\n%s\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$ENV_SCRUB" "$CLANG" "$CLANG" > "$WRAPPER_DIR/launch-c"
-          printf '#!/bin/sh\n%s\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$ENV_SCRUB" "$CLANGPP" "$CLANGPP" > "$WRAPPER_DIR/launch-cxx"
-          chmod +x "$WRAPPER_DIR/launch-c" "$WRAPPER_DIR/launch-cxx"
-          echo "CCACHE_LAUNCH_C=$WRAPPER_DIR/launch-c" >> $GITHUB_ENV
-          echo "CCACHE_LAUNCH_CXX=$WRAPPER_DIR/launch-cxx" >> $GITHUB_ENV
-          # Print contents for log-debugging
-          echo "--- launch-c ---"
-          cat "$WRAPPER_DIR/launch-c"
-          echo "--- launch-cxx ---"
-          cat "$WRAPPER_DIR/launch-cxx"
+          # Earlier attempts (this PR's history shows them all):
+          #   - parent-shell unset: doesn't reach PhaseScriptExecution
+          #     subprocesses (xcodebuild re-injects from build settings)
+          #   - CMAKE_C/CXX_COMPILER override to a wrapper: qt-cmake's iOS
+          #     toolchain forces the variables back to absolute Xcode
+          #     paths after we set them, so the wrapper isn't called for
+          #     CMake's AUTOMOC compiler-ABI test (the actual failing site)
+          #   - Pinning Xcode 26.0.1: lacks iOS platform on macos-26
+          #   - Pinning Xcode 26.1.1: still has the strict check
+          #
+          # Replacing the Xcode clang/clang++ binaries with shims at their
+          # canonical paths is guaranteed to intercept every invocation —
+          # CMake's ABI test, AUTOMOC predefs subprocesses, the actual
+          # compile, ccache-wrapped calls, all of them. The runner is an
+          # ephemeral VM so modifying the Xcode bundle doesn't persist.
+          #
+          # The shim:
+          #   - unsets all host platform DEPLOYMENT_TARGET env vars
+          #   - leaves IPHONEOS_DEPLOYMENT_TARGET intact (the one we want)
+          #   - execs the real compiler (renamed to .real alongside)
+          #
+          # Long-term durable fix is upstream — CMake's AUTOMOC predefs
+          # script should pass -target explicitly. Tracked as #925.
+          set -e
+          XCODE_BIN="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+          for tool in clang clang++; do
+            if [ -f "$XCODE_BIN/$tool" ] && [ ! -f "$XCODE_BIN/$tool.real" ]; then
+              sudo mv "$XCODE_BIN/$tool" "$XCODE_BIN/$tool.real"
+              sudo tee "$XCODE_BIN/$tool" >/dev/null <<EOF
+          #!/bin/sh
+          unset MACOSX_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET
+          exec "$XCODE_BIN/$tool.real" "\$@"
+          EOF
+              sudo chmod +x "$XCODE_BIN/$tool"
+            fi
+          done
+          echo "--- shim contents ---"
+          cat "$XCODE_BIN/clang"
+          echo "--- shim verifies it execs the real clang ---"
+          "$XCODE_BIN/clang" --version
 
       - name: Install Apple certificate and provisioning profile
         env:
@@ -140,26 +142,16 @@ jobs:
 
       - name: Configure CMake
         run: |
-          # The wrappers built above ensure every clang invocation — including
-          # the AUTOMOC compiler-ABI test that runs inside xcodebuild's
-          # PhaseScriptExecution — has the host platform DEPLOYMENT_TARGET
-          # env vars unset before exec'ing the real compiler. Wire them in
-          # via:
-          #   - CMAKE_C/CXX_COMPILER         → CMake's own ABI tests
-          #     (CMakeCXXCompilerABI.cpp, used by AUTOMOC predefs). This is
-          #     the actual failing call site.
-          #   - CMAKE_XCODE_ATTRIBUTE_CC/CXX → real Xcode-driven compile.
+          # ccache is intentionally NOT used on this workflow (test isolating
+          # whether ccache wrapping the Xcode-26 link step on macos-26 is
+          # responsible for libc++ symbol-resolution failures). The shim
+          # installed above handles env scrub on its own; clang/clang++ go
+          # through it directly without an intermediate ccache layer.
           mkdir -p build/ios
           cd build/ios
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-            -DCMAKE_C_COMPILER="$CCACHE_LAUNCH_C" \
-            -DCMAKE_CXX_COMPILER="$CCACHE_LAUNCH_CXX" \
-            -DCMAKE_XCODE_ATTRIBUTE_CC="$CCACHE_LAUNCH_C" \
-            -DCMAKE_XCODE_ATTRIBUTE_CXX="$CCACHE_LAUNCH_CXX" \
-            -DCMAKE_XCODE_ATTRIBUTE_LD="$CCACHE_LAUNCH_C" \
-            -DCMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS="$CCACHE_LAUNCH_CXX"
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
       - name: Build and Archive
         env:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -82,11 +82,21 @@ jobs:
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
-          key: ios-arm64
+          # Key bumped to xcode26.4.1: the prior `ios-arm64` cache holds
+          # objects compiled against an older Xcode/libc++ revision. With
+          # the env-scrubbing shim in place, compiler_check=content hashed
+          # the (unchanging) shim script instead of the real compiler, so
+          # those stale objects were being served on Xcode 26.4.1 runs and
+          # link-failed against the newer libc++ ABI.
+          key: ios-arm64-xcode26.4.1
           max-size: 500M
 
       - name: Configure ccache for CI
-        run: ccache --set-config=compiler_check=content
+        # Run %compiler% -v so the hash captures the real compiler the shim
+        # execs (clang.real), not just the shim shell script. Without this,
+        # an Xcode bump leaves cached objects orphaned to the old SDK's
+        # libc++ symbol set and the link fails with undefined std symbols.
+        run: ccache --set-config=compiler_check='%compiler% -v'
 
       - name: Replace Xcode clang/clang++ with env-scrubbing shims
         run: |

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -96,7 +96,12 @@ jobs:
               sudo mv "$XCODE_BIN/$tool" "$XCODE_BIN/$tool.real"
               sudo tee "$XCODE_BIN/$tool" >/dev/null <<EOF
           #!/bin/sh
-          unset MACOSX_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET
+          # Strip ALL platform deployment-target env vars (including IPHONEOS).
+          # The user's local Mac has none of these set in the shell and Qt
+          # 6.10.3 + Xcode 26 builds fine; we match that env. Target/SDK come
+          # in via -target / -isysroot flags on the actual link line, so iOS
+          # is still correctly identified without IPHONEOS_DEPLOYMENT_TARGET.
+          unset MACOSX_DEPLOYMENT_TARGET IPHONEOS_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET
           exec "$XCODE_BIN/$tool.real" "\$@"
           EOF
               sudo chmod +x "$XCODE_BIN/$tool"

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -43,6 +43,32 @@ jobs:
           echo "build_code=$NEXT" >> $GITHUB_OUTPUT
           echo "Version code bumped: $CURRENT -> $NEXT"
 
+      - name: Pin Xcode to 26.4.1 (matches developer's local libc++ ABI)
+        run: |
+          # macos-26's default Xcode (26.2) ships a libc++ revision that
+          # doesn't include the [abi:ue170006] unstable-ABI symbols Qt
+          # 6.10.3's prebuilt iOS binaries reference (qtshadertools,
+          # libQt6BundledSpirv_Cross). Result: link fails with
+          #   Undefined symbols: std::length_error::length_error[abi:ue170006]
+          #   ... vtable for spirv_cross::CompilerError ...
+          #
+          # Xcode 26.4.1 (Apple clang 21.0.0 build 2100.0.123.102) ships the
+          # matching libc++ revision and is the version the developer builds
+          # with locally on macOS 26.4 — same Qt 6.10.3 binaries link cleanly
+          # there. The macos-26 runner image has 26.4.1 installed alongside
+          # the default 26.2 with full iOS platform support (iOS 26.4 SDK +
+          # simulator runtimes per the runner readme).
+          #
+          # The deployment-target shim installed below is still needed:
+          # 26.4.1's clang carries the same strict env-conflict check from
+          # 26.1+, and the runner image still pre-exports MACOSX/IPHONESIMU-
+          # LATOR/MACCATALYST values. Pin + shim are complementary, not
+          # redundant.
+          sudo xcode-select -s /Applications/Xcode_26.4.1.app/Contents/Developer
+          xcodebuild -version
+          xcrun --sdk iphoneos clang --version | head -3
+          echo "DEVELOPER_DIR=/Applications/Xcode_26.4.1.app/Contents/Developer" >> $GITHUB_ENV
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -192,11 +192,19 @@ jobs:
           # the clang driver instead of clang++, so -lc++ is never auto-
           # added and the link fails with missing __cxa_*/__gxx_personality
           # symbols. Leave LD/LDPLUSPLUS at Xcode defaults.
+          #
+          # Force -lc++ -lc++abi explicitly: when CC/CXX point at a non-
+          # Apple wrapper, Xcode also strips its "auto add C++ runtime"
+          # logic from the link step, producing undefined std::* symbols
+          # (run 25133536323 etc.). The diff against the green non-ccache
+          # build was the absence of -ivfsstatcache (SDK statcache) and
+          # the auto C++ runtime link.
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_XCODE_ATTRIBUTE_CC="$CCACHE_LAUNCH_C" \
-            -DCMAKE_XCODE_ATTRIBUTE_CXX="$CCACHE_LAUNCH_CXX"
+            -DCMAKE_XCODE_ATTRIBUTE_CXX="$CCACHE_LAUNCH_CXX" \
+            -DCMAKE_XCODE_ATTRIBUTE_OTHER_LDFLAGS="-lc++ -lc++abi"
 
       - name: Build and Archive
         env:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -79,64 +79,34 @@ jobs:
           cache: true
           cache-key-prefix: 'qt-ios-v4'
 
-      - name: Replace Xcode clang/clang++ with env-scrubbing shims
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          key: ios-arm64
+          max-size: 500M
+
+      - name: Configure ccache for CI
+        run: ccache --set-config=compiler_check=content
+
+      - name: Create ccache compiler wrappers
         run: |
-          # Why this is here, not just CMake variable overrides:
-          #
-          # Xcode 26.1+ clang has a new check: if more than one platform's
-          # *_DEPLOYMENT_TARGET env var is set at compile time, refuse the
-          # build with "conflicting deployment targets". The macos-26 runner
-          # image pre-exports MACOSX_DEPLOYMENT_TARGET=26.2,
-          # IPHONESIMULATOR_DEPLOYMENT_TARGET=26.2, MACCATALYST_DEPLOYMENT
-          # _TARGET=25.2; xcodebuild layers IPHONEOS_DEPLOYMENT_TARGET=17.0
-          # from the iOS toolchain on top. Four platform vars in one
-          # subprocess env trips the check.
-          #
-          # Earlier attempts (this PR's history shows them all):
-          #   - parent-shell unset: doesn't reach PhaseScriptExecution
-          #     subprocesses (xcodebuild re-injects from build settings)
-          #   - CMAKE_C/CXX_COMPILER override to a wrapper: qt-cmake's iOS
-          #     toolchain forces the variables back to absolute Xcode
-          #     paths after we set them, so the wrapper isn't called for
-          #     CMake's AUTOMOC compiler-ABI test (the actual failing site)
-          #   - Pinning Xcode 26.0.1: lacks iOS platform on macos-26
-          #   - Pinning Xcode 26.1.1: still has the strict check
-          #
-          # Replacing the Xcode clang/clang++ binaries with shims at their
-          # canonical paths is guaranteed to intercept every invocation —
-          # CMake's ABI test, AUTOMOC predefs subprocesses, the actual
-          # compile, ccache-wrapped calls, all of them. The runner is an
-          # ephemeral VM so modifying the Xcode bundle doesn't persist.
-          #
-          # The shim:
-          #   - unsets all host platform DEPLOYMENT_TARGET env vars
-          #   - leaves IPHONEOS_DEPLOYMENT_TARGET intact (the one we want)
-          #   - execs the real compiler (renamed to .real alongside)
-          #
-          # Long-term durable fix is upstream — CMake's AUTOMOC predefs
-          # script should pass -target explicitly. Tracked as #925.
-          set -e
-          XCODE_BIN="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"
-          for tool in clang clang++; do
-            if [ -f "$XCODE_BIN/$tool" ] && [ ! -f "$XCODE_BIN/$tool.real" ]; then
-              sudo mv "$XCODE_BIN/$tool" "$XCODE_BIN/$tool.real"
-              sudo tee "$XCODE_BIN/$tool" >/dev/null <<EOF
-          #!/bin/sh
-          # Strip ALL platform deployment-target env vars (including IPHONEOS).
-          # The user's local Mac has none of these set in the shell and Qt
-          # 6.10.3 + Xcode 26 builds fine; we match that env. Target/SDK come
-          # in via -target / -isysroot flags on the actual link line, so iOS
-          # is still correctly identified without IPHONEOS_DEPLOYMENT_TARGET.
-          unset MACOSX_DEPLOYMENT_TARGET IPHONEOS_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET
-          exec "$XCODE_BIN/$tool.real" "\$@"
-          EOF
-              sudo chmod +x "$XCODE_BIN/$tool"
-            fi
-          done
-          echo "--- shim contents ---"
-          cat "$XCODE_BIN/clang"
-          echo "--- shim verifies it execs the real clang ---"
-          "$XCODE_BIN/clang" --version
+          # Standard ccache plumbing — wraps clang/clang++ so xcodebuild's
+          # CMAKE_XCODE_ATTRIBUTE_CC/CXX/LD/LDPLUSPLUS path runs through ccache.
+          # NOTE: this run intentionally has NO env-scrubbing shim on the Xcode
+          # toolchain binaries — testing whether Xcode 26.4.1's clang carries
+          # the strict deployment-target conflict check from 26.1+. If the
+          # build succeeds, the shim is unnecessary and can stay removed; if
+          # it fails with "conflicting deployment targets", we restore the
+          # shim and the cleaner workflow becomes shim+ccache, both needed.
+          WRAPPER_DIR="$RUNNER_TEMP/ccache-wrappers"
+          mkdir -p "$WRAPPER_DIR"
+          CLANG=$(xcrun -f clang)
+          CLANGPP=$(xcrun -f clang++)
+          printf '#!/bin/sh\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$CLANG" "$CLANG" > "$WRAPPER_DIR/launch-c"
+          printf '#!/bin/sh\nif [ "$1" = "%s" ]; then shift; fi\nexec ccache "%s" "$@"\n' "$CLANGPP" "$CLANGPP" > "$WRAPPER_DIR/launch-cxx"
+          chmod +x "$WRAPPER_DIR/launch-c" "$WRAPPER_DIR/launch-cxx"
+          echo "CCACHE_LAUNCH_C=$WRAPPER_DIR/launch-c" >> $GITHUB_ENV
+          echo "CCACHE_LAUNCH_CXX=$WRAPPER_DIR/launch-cxx" >> $GITHUB_ENV
 
       - name: Install Apple certificate and provisioning profile
         env:
@@ -173,16 +143,15 @@ jobs:
 
       - name: Configure CMake
         run: |
-          # ccache is intentionally NOT used on this workflow (test isolating
-          # whether ccache wrapping the Xcode-26 link step on macos-26 is
-          # responsible for libc++ symbol-resolution failures). The shim
-          # installed above handles env scrub on its own; clang/clang++ go
-          # through it directly without an intermediate ccache layer.
           mkdir -p build/ios
           cd build/ios
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+            -DCMAKE_XCODE_ATTRIBUTE_CC="$CCACHE_LAUNCH_C" \
+            -DCMAKE_XCODE_ATTRIBUTE_CXX="$CCACHE_LAUNCH_CXX" \
+            -DCMAKE_XCODE_ATTRIBUTE_LD="$CCACHE_LAUNCH_C" \
+            -DCMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS="$CCACHE_LAUNCH_CXX"
 
       - name: Build and Archive
         env:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -82,20 +82,21 @@ jobs:
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
-          # Key bumped to xcode26.4.1: the prior `ios-arm64` cache holds
-          # objects compiled against an older Xcode/libc++ revision. With
-          # the env-scrubbing shim in place, compiler_check=content hashed
-          # the (unchanging) shim script instead of the real compiler, so
-          # those stale objects were being served on Xcode 26.4.1 runs and
-          # link-failed against the newer libc++ ABI.
-          key: ios-arm64-xcode26.4.1
+          # Key includes a shim-revision tag (s2 = "shim revision 2: also
+          # unsets IPHONEOS_DEPLOYMENT_TARGET"). Bump this whenever the
+          # shim's env-scrub list changes — the shim's behavior affects
+          # compile output, but ccache's compiler_check (even with
+          # %compiler% -v) sees the same banner from clang.real regardless
+          # of which env vars the shim drops, so a key bump is the only
+          # reliable way to invalidate.
+          key: ios-arm64-xcode26.4.1-s2
           max-size: 500M
 
       - name: Configure ccache for CI
         # Run %compiler% -v so the hash captures the real compiler the shim
-        # execs (clang.real), not just the shim shell script. Without this,
-        # an Xcode bump leaves cached objects orphaned to the old SDK's
-        # libc++ symbol set and the link fails with undefined std symbols.
+        # execs (clang.real), not just the shim shell script. This catches
+        # underlying Xcode upgrades automatically. (Shim-script changes
+        # still need a manual cache-key bump above — see comment there.)
         run: ccache --set-config=compiler_check='%compiler% -v'
 
       - name: Replace Xcode clang/clang++ with env-scrubbing shims

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -88,16 +88,64 @@ jobs:
       - name: Configure ccache for CI
         run: ccache --set-config=compiler_check=content
 
+      - name: Replace Xcode clang/clang++ with env-scrubbing shims
+        run: |
+          # Xcode 26.1+ clang has a strict check: if more than one platform's
+          # *_DEPLOYMENT_TARGET env var is set when clang runs, refuse to
+          # compile with "conflicting deployment targets". The macos-26
+          # runner image pre-exports MACOSX/IPHONESIMULATOR/MACCATALYST
+          # values; xcodebuild then layers IPHONEOS_DEPLOYMENT_TARGET=17.0
+          # from the iOS toolchain on top. Four platform vars in one
+          # subprocess env trips the check.
+          #
+          # Verified that Xcode 26.4.1 (the version we pin above for libc++
+          # ABI compatibility) carries the same strict check — see
+          # https://github.com/Kulitorum/Decenza/actions/runs/25129294929
+          # for the failure when the shim was removed as a test.
+          #
+          # Earlier failed approaches in this PR's history:
+          #   - parent-shell unset: doesn't reach PhaseScriptExecution
+          #     subprocesses (xcodebuild re-injects from build settings)
+          #   - CMAKE_C/CXX_COMPILER override to a wrapper: qt-cmake's iOS
+          #     toolchain forces the variables back to absolute Xcode paths
+          #     after we set them, so the wrapper isn't called for CMake's
+          #     AUTOMOC compiler-ABI test (the actual failing call site)
+          #   - Pinning Xcode 26.0.1: lacks iOS platform on macos-26
+          #   - Pinning Xcode 26.1.1: still has the strict check
+          #
+          # Replacing the Xcode clang/clang++ binaries directly intercepts
+          # every invocation — CMake's ABI test, AUTOMOC predefs subprocess,
+          # the actual compile, ccache-wrapped calls. The runner is an
+          # ephemeral VM so modifying the Xcode bundle doesn't persist
+          # across jobs.
+          #
+          # Long-term durable fix is upstream: CMake's AUTOMOC predefs
+          # script should pass -target explicitly so it doesn't depend on
+          # env-var fallback. Tracked as #925.
+          set -e
+          XCODE_BIN="$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+          for tool in clang clang++; do
+            if [ -f "$XCODE_BIN/$tool" ] && [ ! -f "$XCODE_BIN/$tool.real" ]; then
+              sudo mv "$XCODE_BIN/$tool" "$XCODE_BIN/$tool.real"
+              sudo tee "$XCODE_BIN/$tool" >/dev/null <<EOF
+          #!/bin/sh
+          # Strip ALL platform deployment-target env vars. The developer's
+          # local Mac has none of these set in the shell and Qt 6.10.3 +
+          # Xcode 26.4.1 builds cleanly there; we match that env. Target/SDK
+          # come in via -target / -isysroot flags on the actual link line.
+          unset MACOSX_DEPLOYMENT_TARGET IPHONEOS_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET
+          exec "$XCODE_BIN/$tool.real" "\$@"
+          EOF
+              sudo chmod +x "$XCODE_BIN/$tool"
+            fi
+          done
+
       - name: Create ccache compiler wrappers
         run: |
-          # Standard ccache plumbing — wraps clang/clang++ so xcodebuild's
-          # CMAKE_XCODE_ATTRIBUTE_CC/CXX/LD/LDPLUSPLUS path runs through ccache.
-          # NOTE: this run intentionally has NO env-scrubbing shim on the Xcode
-          # toolchain binaries — testing whether Xcode 26.4.1's clang carries
-          # the strict deployment-target conflict check from 26.1+. If the
-          # build succeeds, the shim is unnecessary and can stay removed; if
-          # it fails with "conflicting deployment targets", we restore the
-          # shim and the cleaner workflow becomes shim+ccache, both needed.
+          # Wraps clang/clang++ for ccache. The Xcode toolchain binaries are
+          # already replaced with env-scrubbing shims (step above), so the
+          # call chain at compile time is:
+          #   xcodebuild → launch-c → ccache → /…/clang (shim) → unset → clang.real
           WRAPPER_DIR="$RUNNER_TEMP/ccache-wrappers"
           mkdir -p "$WRAPPER_DIR"
           CLANG=$(xcrun -f clang)

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -112,8 +112,7 @@ jobs:
           # -isysroot flags on the actual command line, so iOS is still
           # correctly identified. With IPHONEOS preserved in the env,
           # clang++'s implicit libc++ resolution at link time goes wrong
-          # and the link fails with undefined std::* symbols (run
-          # 25132542710). Matches the previously-green config (27c0551f).
+          # and the link fails with undefined std::* symbols.
           #
           # Long-term durable fix is upstream: CMake's AUTOMOC predefs
           # script should pass -target explicitly so it doesn't depend on
@@ -186,19 +185,15 @@ jobs:
         run: |
           mkdir -p build/ios
           cd build/ios
-          # Only wrap CC/CXX with ccache. Wrapping LD/LDPLUSPLUS routes the
-          # link step through ccache (which doesn't cache link products) and
-          # — because LD points at launch-c — forces the C++ link through
-          # the clang driver instead of clang++, so -lc++ is never auto-
-          # added and the link fails with missing __cxa_*/__gxx_personality
-          # symbols. Leave LD/LDPLUSPLUS at Xcode defaults.
+          # Wrap only CC/CXX with ccache (not LD/LDPLUSPLUS): ccache
+          # doesn't cache link products, and pointing LD at launch-c forces
+          # the C++ link through the `clang` driver instead of `clang++`,
+          # which drops the implicit -lc++ and breaks the link.
           #
-          # Force -lc++ -lc++abi explicitly: when CC/CXX point at a non-
-          # Apple wrapper, Xcode also strips its "auto add C++ runtime"
-          # logic from the link step, producing undefined std::* symbols
-          # (run 25133536323 etc.). The diff against the green non-ccache
-          # build was the absence of -ivfsstatcache (SDK statcache) and
-          # the auto C++ runtime link.
+          # Once CC/CXX point at a non-Apple wrapper, Xcode also stops
+          # auto-adding the C++ runtime libraries to the Ld phase (and
+          # drops -ivfsstatcache and other Apple-internal flags). Compen-
+          # sate by setting -lc++ -lc++abi in OTHER_LDFLAGS explicitly.
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -106,12 +106,13 @@ jobs:
           # calls clang directly without going through CMAKE_XCODE_ATTRIBUTE
           # _CC (which is why a wrapper-only approach can't catch it).
           #
-          # The shim unsets host-platform DEPLOYMENT_TARGET env vars (MACOSX,
-          # IPHONESIMULATOR, MACCATALYST, TVOS, WATCHOS, XROS, DRIVERKIT)
-          # but PRESERVES IPHONEOS_DEPLOYMENT_TARGET — the linker needs the
-          # latter to resolve libc++ correctly against Qt's prebuilt iOS
-          # binaries. An earlier attempt that unset IPHONEOS too (commit
-          # bf12ee6d) link-failed with undefined [abi:ue170006] symbols.
+          # Unset ALL platform DEPLOYMENT_TARGET env vars including
+          # IPHONEOS_DEPLOYMENT_TARGET. Target/SDK come in via -target /
+          # -isysroot flags on the actual command line, so iOS is still
+          # correctly identified. With IPHONEOS preserved in the env,
+          # clang++'s implicit libc++ resolution at link time goes wrong
+          # and the link fails with undefined std::* symbols (run
+          # 25132542710). Matches the previously-green config (27c0551f).
           #
           # Long-term durable fix is upstream: CMake's AUTOMOC predefs
           # script should pass -target explicitly so it doesn't depend on
@@ -123,7 +124,7 @@ jobs:
               sudo mv "$XCODE_BIN/$tool" "$XCODE_BIN/$tool.real"
               sudo tee "$XCODE_BIN/$tool" >/dev/null <<EOF
           #!/bin/sh
-          unset MACOSX_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET
+          unset MACOSX_DEPLOYMENT_TARGET IPHONEOS_DEPLOYMENT_TARGET IPHONESIMULATOR_DEPLOYMENT_TARGET MACCATALYST_DEPLOYMENT_TARGET TVOS_DEPLOYMENT_TARGET WATCHOS_DEPLOYMENT_TARGET XROS_DEPLOYMENT_TARGET DRIVERKIT_DEPLOYMENT_TARGET
           exec "$XCODE_BIN/$tool.real" "\$@"
           EOF
               sudo chmod +x "$XCODE_BIN/$tool"


### PR DESCRIPTION
## Summary
- Bumps the iOS workflow runner from `macos-15` to `macos-26` and pins Xcode to **26.4.1** (matches the developer's local libc++ ABI for Qt 6.10.3 prebuilt iOS binaries — default `26.2` ships a libc++ revision missing the `[abi:ue170006]` symbols Qt references).
- Installs an env-scrubbing shim on the active toolchain's `clang`/`clang++` to dodge Xcode 26.1+'s strict deployment-target conflict check (the `macos-26` runner image pre-exports `MACOSX/IPHONESIMULATOR/MACCATALYST_DEPLOYMENT_TARGET`, and xcodebuild adds `IPHONEOS_DEPLOYMENT_TARGET` on top — four platform vars in one env trips the check).
- Restores ccache, but wraps **only CC/CXX** (not LD/LDPLUSPLUS) — wrapping LD routes the link through `clang` instead of `clang++` and drops the implicit `-lc++`. To compensate for Xcode also dropping its auto C++ runtime link when CC is a non-Apple wrapper, force `-lc++ -lc++abi` in `OTHER_LDFLAGS`.
- ccache cache key includes a shim-revision tag (`-s2`); bump it whenever the shim's env-scrub list changes. `compiler_check='%compiler% -v'` captures the underlying `clang.real` version so Xcode upgrades invalidate the cache automatically.

## Test plan
- [x] iOS App Store Build workflow run on this branch (run 25134184526) — green, 5m13s, IPA + dSYMs uploaded
- [ ] Confirm next tag-driven release builds and uploads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)