### PR TITLE
perf(ai): dedup AI advisor's historical-shot detector pass (B)

### DIFF
--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -441,9 +441,14 @@ Observations` section with a preamble framing the lines as detector
 evidence (severity tags `[warning]` / `[caution]` / `[good]` /
 `[observation]`). The `verdict` line is filtered out so the AI reasons
 from the same observations the verdict was built from rather than
-anchoring on the dialog's pre-cooked conclusion. The suppression cascade
-is enforced in exactly one place — `analyzeShot` — so the badge UI,
-the dialog, and the AI advisor cannot drift.
+anchoring on the dialog's pre-cooked conclusion. On historical shots,
+`ShotSummarizer::summarizeFromHistory` prefers the pre-computed
+`shotData.summaryLines` (populated by `convertShotRecord`'s `analyzeShot`
+pass) and only falls back to running the inline detector orchestration
+when that field is absent — same fast/fallback pattern the dialog uses,
+same correctness guarantee. The suppression cascade is enforced in
+exactly one place — `analyzeShot` — so the badge UI, the dialog, and
+the AI advisor cannot drift.
 
 ### External MCP agents see structured detectors (PR #933, resolved Issue #931)
 

--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -445,8 +445,8 @@ anchoring on the dialog's pre-cooked conclusion. On historical shots,
 `ShotSummarizer::summarizeFromHistory` prefers the pre-computed
 `shotData.summaryLines` (populated by `convertShotRecord`'s `analyzeShot`
 pass) and only falls back to running the inline detector orchestration
-when that field is absent — same fast/fallback pattern the dialog uses,
-same correctness guarantee. The suppression cascade is enforced in
+when that field is absent. Both paths invoke the same `analyzeShot` body,
+so they produce equivalent observation lines. The suppression cascade is enforced in
 exactly one place — `analyzeShot` — so the badge UI, the dialog, and
 the AI advisor cannot drift.
 

--- a/openspec/changes/dedup-ai-advisor-history-path/proposal.md
+++ b/openspec/changes/dedup-ai-advisor-history-path/proposal.md
@@ -1,0 +1,23 @@
+# Change: Dedup AI advisor's historical-shot path by reading pre-computed `summaryLines`
+
+## Why
+
+`ShotSummarizer::summarizeFromHistory(shotData)` builds the AI advisor prompt for a historical shot. It calls `ShotAnalysis::generateSummary(...)` (the wrapper around `analyzeShot`) inline, even though the input `shotData` map came out of `ShotHistoryStorage::convertShotRecord` and already carries `summaryLines` populated by `analyzeShot`. Result: every time the AI advisor is asked about a saved shot, the detector pipeline runs twice for the same data — once inside `convertShotRecord` and once inside `summarizeFromHistory` — and the answers must always be identical because both paths run the same code with the same inputs.
+
+This is the historical-shot mirror of the dialog dedup (change `dedup-shot-summary-dialog`). The live-path `ShotSummarizer::summarize(ShotDataModel*)` still needs to compute, because no `convertShotRecord` runs for an in-progress shot.
+
+## What Changes
+
+- **MODIFY** `src/ai/shotsummarizer.cpp` `summarizeFromHistory` so that when `shotData["summaryLines"]` is a non-empty list, the function reuses those lines directly and skips the `ShotAnalysis::generateSummary(...)` invocation.
+  - When the fast path triggers, derive `summary.pourTruncatedDetected` from `shotData["detectorResults"]["pourTruncated"]` (also pre-computed by `convertShotRecord`).
+  - The per-phase temperature instability markers (`markPerPhaseTempInstability`) remain conditional on `!summary.pourTruncatedDetected` and `ShotAnalysis::reachedExtractionPhase(historyMarkers, summary.totalDuration)`, identical to today.
+- **PRESERVE** the existing inline path as a fallback for legacy `shotData` maps that don't carry `summaryLines` / `detectorResults` (direct callers, imported shots without the new fields, tests).
+- **NO change** to `summarize(ShotDataModel*)` (live path), `analyzeShot`, or `generateSummary`.
+
+## Impact
+
+- Affected specs: `shot-analysis-pipeline` (new requirement: AI advisor SHALL prefer pre-computed `summaryLines`/`detectorResults` when present in historical `shotData`).
+- Affected code: `src/ai/shotsummarizer.cpp` (`summarizeFromHistory` only).
+- User-visible behavior: identical AI prompts. Same lines, same severity tags, same verdict-line filtering before emission.
+- Performance: one fewer `analyzeShot` pass per AI advisor invocation on a saved shot.
+- Risk surface: the fast path must populate everything `summarizeFromHistory` currently sets on `summary` — `summaryLines`, `pourTruncatedDetected`, and the per-phase `temperatureUnstable` flags via `markPerPhaseTempInstability`. The bypass is around the *detector orchestration block* only, not around the curve-data and DYE-metadata population earlier in the function.

--- a/openspec/changes/dedup-ai-advisor-history-path/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/changes/dedup-ai-advisor-history-path/specs/shot-analysis-pipeline/spec.md
@@ -1,0 +1,41 @@
+# shot-analysis-pipeline
+
+## ADDED Requirements
+
+### Requirement: AI advisor's historical-shot path SHALL reuse pre-computed `summaryLines` when present
+
+When `ShotSummarizer::summarizeFromHistory(shotData)` is invoked with a `shotData` map whose `summaryLines` field is a non-empty list, the function SHALL populate `ShotSummary::summaryLines` from that field directly AND SHALL skip its inline `ShotAnalysis::generateSummary(...)` invocation. The function SHALL also derive `ShotSummary::pourTruncatedDetected` from `shotData["detectorResults"]["pourTruncated"]` when the `detectorResults` field is present.
+
+When `summaryLines` is absent or empty (legacy shots, direct test callers, imported shots without the new fields), the function SHALL fall back to the existing inline detector orchestration path. The fast and fallback paths SHALL produce equivalent `ShotSummary::summaryLines` for identical shot data — they cannot drift because both ultimately rely on the same `ShotAnalysis::analyzeShot` body.
+
+The per-phase temperature instability markers (`markPerPhaseTempInstability`) SHALL remain gated on `!summary.pourTruncatedDetected AND ShotAnalysis::reachedExtractionPhase(historyMarkers, summary.totalDuration)` regardless of which path produced the summary lines.
+
+The live-path entry point `ShotSummarizer::summarize(ShotDataModel*)` is OUT OF SCOPE — it operates on an in-progress shot for which no `convertShotRecord` has run, and SHALL continue to call `analyzeShot` (via `generateSummary`) inline.
+
+#### Scenario: Modern shotData with pre-computed lines bypasses recomputation
+
+- **GIVEN** a `shotData` map produced by `ShotHistoryStorage::convertShotRecord`, with `summaryLines` containing a known list and `detectorResults.pourTruncated == true`
+- **WHEN** the AI advisor invokes `summarizeFromHistory(shotData)`
+- **THEN** the resulting `ShotSummary.summaryLines` SHALL equal the input `shotData.summaryLines`
+- **AND** `ShotSummary.pourTruncatedDetected` SHALL be `true`
+- **AND** `ShotAnalysis::generateSummary(...)` SHALL NOT be invoked by `summarizeFromHistory` for this call
+
+#### Scenario: Legacy shotData without summaryLines uses the inline path
+
+- **GIVEN** a `shotData` map whose `summaryLines` field is missing or empty
+- **WHEN** the AI advisor invokes `summarizeFromHistory(shotData)`
+- **THEN** the function SHALL invoke `ShotAnalysis::generateSummary(...)` inline
+- **AND** the resulting `ShotSummary.summaryLines` SHALL be non-empty for shots with sufficient curve data
+
+#### Scenario: Fast and fallback paths produce equivalent results
+
+- **GIVEN** two equivalent `shotData` maps for the same shot, `A` with `summaryLines` pre-populated and `B` without
+- **WHEN** `summarizeFromHistory(A)` and `summarizeFromHistory(B)` are both invoked
+- **THEN** the resulting `ShotSummary::summaryLines` from each call SHALL contain the same lines in the same order with the same `text` and `type` values
+
+#### Scenario: Fast path preserves the pour-truncated cascade
+
+- **GIVEN** a `shotData` map with non-empty `summaryLines` and `detectorResults.pourTruncated == true`
+- **WHEN** the AI advisor invokes `summarizeFromHistory(shotData)`
+- **THEN** `ShotSummary::pourTruncatedDetected` SHALL be `true`
+- **AND** no `PhaseSummary::temperatureUnstable` markers SHALL be set on the summary's phase list (the cascade gates the per-phase pass identically to the slow path)

--- a/openspec/changes/dedup-ai-advisor-history-path/tasks.md
+++ b/openspec/changes/dedup-ai-advisor-history-path/tasks.md
@@ -1,0 +1,35 @@
+# Tasks
+
+## 1. Fast-path implementation
+
+- [x] 1.1 In `src/ai/shotsummarizer.cpp` `summarizeFromHistory`, after the existing curve-data and DYE-metadata population (everything before the detector orchestration block), check for the pre-computed fields and short-circuit:
+  ```cpp
+  const QVariantList preComputedLines = shotData.value("summaryLines").toList();
+  if (!preComputedLines.isEmpty()) {
+      summary.summaryLines = preComputedLines;
+      const QVariantMap preDetectors = shotData.value("detectorResults").toMap();
+      summary.pourTruncatedDetected = preDetectors.value("pourTruncated").toBool();
+      if (!summary.pourTruncatedDetected
+          && ShotAnalysis::reachedExtractionPhase(historyMarkers, summary.totalDuration))
+          markPerPhaseTempInstability(summary, summary.tempCurve, summary.tempGoalCurve);
+      return summary;
+  }
+  ```
+- [x] 1.2 Confirmed `historyMarkers` and `summary.totalDuration` are populated *before* the fast-path branch — the existing function ordering puts both ahead of the detector orchestration block, so the fast path has all the inputs it needs for `reachedExtractionPhase` and per-phase marker gating.
+- [x] 1.3 Added inline comments explaining why the fast path is safe (the slow path eventually runs the same analyzeShot body) and that the bypass is around the detector orchestration block only — not around curve-data or DYE-metadata population.
+
+## 2. Tests
+
+- [x] 2.1 `summarizeFromHistory_usesPreComputedLines` — feeds a sentinel `summaryLines` list and asserts it comes back unchanged. Also stashes `detectorResults.pourTruncated = false` and asserts `pourTruncatedDetected` is derived from there, not recomputed.
+- [x] 2.2 `summarizeFromHistory_fallsBackWhenNoSummaryLines` — omits `summaryLines` from `shotData` and asserts the inline detector path still produces non-empty `summaryLines` and a verdict line.
+- [x] 2.3 `summarizeFromHistory_fastAndSlowPathsAgree` — runs the slow path first to capture real lines, feeds them into the fast path on a fresh map, asserts byte-equal output. Catches drift if either path is later modified in isolation.
+- [x] 2.4 `summarizeFromHistory_fastPathPreservesPourTruncatedCascade` — exercises the cascade through the fast path: stashes `detectorResults.pourTruncated = true`, asserts `summary.pourTruncatedDetected == true` and per-phase temperature markers are NOT set. Locks in the cascade integrity through the fast path.
+
+## 3. Verify
+
+- [x] 3.1 Build clean (Qt Creator MCP, 0 errors / 0 warnings).
+- [x] 3.2 1782 tests pass (1778 prior + 4 new). No regressions.
+
+## 4. Docs
+
+- [x] 4.1 Updated `docs/SHOT_REVIEW.md` §3 "AI advisor consumes the same line list" to document the fast/fallback pattern matching the dialog dedup.

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -466,6 +466,27 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const QVariantMap& shotData) co
                                                  summary.totalDuration));
     }
 
+    // Fast path: when shotData came out of ShotHistoryStorage::convertShotRecord
+    // it already carries `summaryLines` (from convertShotRecord's analyzeShot
+    // pass) and `detectorResults.pourTruncated`. Reuse those directly instead
+    // of running analyzeShot a second time on the same data — the two paths
+    // are byte-identical by construction (same code, same inputs). Per-phase
+    // temperature markers are still gated on the same conditions as the
+    // slow path; only the detector orchestration block is bypassed.
+    const QVariantList preComputedLines = shotData.value("summaryLines").toList();
+    if (!preComputedLines.isEmpty()) {
+        summary.summaryLines = preComputedLines;
+        const QVariantMap preDetectors = shotData.value("detectorResults").toMap();
+        summary.pourTruncatedDetected = preDetectors.value("pourTruncated").toBool();
+        if (!summary.pourTruncatedDetected
+            && ShotAnalysis::reachedExtractionPhase(historyMarkers, summary.totalDuration))
+            markPerPhaseTempInstability(summary, summary.tempCurve, summary.tempGoalCurve);
+        return summary;
+    }
+
+    // Slow path: legacy shotData (e.g. imported shots, direct test callers,
+    // any QVariantMap that didn't flow through convertShotRecord) lacks the
+    // pre-computed fields. Fall through to the inline detector orchestration.
     // Detector orchestration delegated to ShotAnalysis::analyzeShot (via the
     // generateSummary wrapper) — see summarize() for rationale. historyMarkers
     // was already populated alongside the PhaseSummary list above (single pass).

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -469,10 +469,18 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const QVariantMap& shotData) co
     // Fast path: when shotData came out of ShotHistoryStorage::convertShotRecord
     // it already carries `summaryLines` (from convertShotRecord's analyzeShot
     // pass) and `detectorResults.pourTruncated`. Reuse those directly instead
-    // of running analyzeShot a second time on the same data — the two paths
-    // are byte-identical by construction (same code, same inputs). Per-phase
-    // temperature markers are still gated on the same conditions as the
-    // slow path; only the detector orchestration block is bypassed.
+    // of running analyzeShot a second time on the same data — both the fast
+    // path's pre-computed lines and the slow path's recomputation invoke the
+    // same analyzeShot body on equivalent inputs, so the two paths produce
+    // matching observation lines. Per-phase temperature markers are still
+    // gated on the same conditions as the slow path; only the detector
+    // orchestration block is bypassed.
+    //
+    // Precondition: callers populating `summaryLines` MUST also populate
+    // `detectorResults.pourTruncated` (convertShotRecord does both, atomically).
+    // If detectorResults is absent, .toBool() defaults to false, so a callsite
+    // that stuffs only summaryLines could mis-suppress per-phase temp markers
+    // on a truncated-pour shot. Today no such callsite exists.
     const QVariantList preComputedLines = shotData.value("summaryLines").toList();
     if (!preComputedLines.isEmpty()) {
         summary.summaryLines = preComputedLines;
@@ -507,7 +515,7 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const QVariantMap& shotData) co
 
     // Per-shot yieldOverride drives both arms of the grind-vs-yield check
     // (the choked-puck yield arm and the gusher arm added in PR #910) —
-    // matches ShotHistoryStorage::generateShotSummary's input for the dialog.
+    // matches the input convertShotRecord passes to analyzeShot.
     const double targetWeightG = shotData.value("yieldOverride").toDouble();
 
     summary.summaryLines = ShotAnalysis::generateSummary(

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -413,7 +413,7 @@ private slots:
         const ShotSummary fastSummary = summarizer.summarizeFromHistory(fastShot);
 
         QCOMPARE(fastSummary.summaryLines.size(), slowSummary.summaryLines.size());
-        for (int i = 0; i < slowSummary.summaryLines.size(); ++i) {
+        for (qsizetype i = 0; i < slowSummary.summaryLines.size(); ++i) {
             QCOMPARE(fastSummary.summaryLines[i].toMap().value("text").toString(),
                      slowSummary.summaryLines[i].toMap().value("text").toString());
             QCOMPARE(fastSummary.summaryLines[i].toMap().value("type").toString(),

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -283,6 +283,175 @@ private slots:
         QVERIFY2(!prompt.contains(QStringLiteral("## Dialog Verdict")),
                  "verdict section is never emitted to the AI prompt");
     }
+    // ---- Fast path: pre-computed summaryLines from convertShotRecord ----
+    //
+    // PR #933 made ShotHistoryStorage::convertShotRecord run analyzeShot per
+    // shot conversion and stash the prose in shotData["summaryLines"]. The
+    // historical-shot AI advisor path used to call generateSummary inline
+    // anyway — running the full detector pipeline a second time on the same
+    // data. summarizeFromHistory now reuses the pre-computed lines when
+    // present, falling back to the inline computation only for legacy
+    // shotData maps that didn't flow through convertShotRecord.
+
+    // Helper: build a healthy-shot QVariantMap (peak pressure ~9 bar, normal
+    // flow, no drift). Used by the fast/slow path equivalence tests below.
+    static QVariantMap buildHealthyShotMap()
+    {
+        QVariantMap shot;
+        shot["beverageType"] = QStringLiteral("espresso");
+        shot["duration"] = 30.0;
+        shot["doseWeight"] = 18.0;
+        shot["finalWeight"] = 36.0;
+        shot["yieldOverride"] = 36.0;
+
+        QVariantList pressure, flow, temperature, temperatureGoal, derivative, weight;
+        appendFlat(pressure, 0.0, 8.0, 1.0);
+        appendFlat(pressure, 8.0, 30.0, 9.0);
+        appendFlat(flow, 0.0, 30.0, 1.8);
+        appendFlat(temperature, 0.0, 30.0, 92.0);
+        appendFlat(temperatureGoal, 0.0, 30.0, 92.0);
+        appendFlat(derivative, 0.0, 30.0, 0.0);
+        appendFlat(weight, 0.0, 30.0, 36.0);
+
+        QVariantList phases;
+        appendPhase(phases, 0.0, QStringLiteral("Preinfusion"), 0);
+        appendPhase(phases, 8.0, QStringLiteral("Pour"), 1);
+
+        shot["pressure"] = pressure;
+        shot["flow"] = flow;
+        shot["temperature"] = temperature;
+        shot["temperatureGoal"] = temperatureGoal;
+        shot["conductanceDerivative"] = derivative;
+        shot["weight"] = weight;
+        shot["phases"] = phases;
+        shot["pressureGoal"] = QVariantList();
+        shot["flowGoal"] = QVariantList();
+        return shot;
+    }
+
+    // Sentinel test: when shotData carries a non-empty summaryLines field,
+    // summarizeFromHistory MUST return those exact lines without recomputing.
+    // Achieved by stuffing a clearly-fake sentinel into summaryLines that no
+    // real detector would produce — if recomputation ran, the sentinel would
+    // be replaced with the real (non-sentinel) line list.
+    void summarizeFromHistory_usesPreComputedLines()
+    {
+        QVariantMap shot = buildHealthyShotMap();
+
+        // Sentinel that no real analyzer would emit.
+        QVariantMap sentinel;
+        sentinel["text"] = QStringLiteral("__SENTINEL__ pre-computed line");
+        sentinel["type"] = QStringLiteral("good");
+        QVariantMap sentinelVerdict;
+        sentinelVerdict["text"] = QStringLiteral("Verdict: __SENTINEL__");
+        sentinelVerdict["type"] = QStringLiteral("verdict");
+
+        QVariantList preLines;
+        preLines.append(sentinel);
+        preLines.append(sentinelVerdict);
+        shot["summaryLines"] = preLines;
+
+        // Also stash a detectorResults map so pourTruncatedDetected gets
+        // derived from there rather than computed.
+        QVariantMap detectors;
+        detectors["pourTruncated"] = false;
+        shot["detectorResults"] = detectors;
+
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarizeFromHistory(shot);
+
+        QCOMPARE(summary.summaryLines.size(), 2);
+        QCOMPARE(summary.summaryLines[0].toMap().value("text").toString(),
+                 QStringLiteral("__SENTINEL__ pre-computed line"));
+        QCOMPARE(summary.summaryLines[1].toMap().value("text").toString(),
+                 QStringLiteral("Verdict: __SENTINEL__"));
+        QVERIFY2(!summary.pourTruncatedDetected,
+                 "pourTruncatedDetected must be derived from detectorResults.pourTruncated");
+    }
+
+    // Fallback test: when summaryLines is missing/empty, the inline detector
+    // path still runs and produces real (non-sentinel) lines. Locks in that
+    // legacy callers (imported shots, direct test invocations) keep working.
+    void summarizeFromHistory_fallsBackWhenNoSummaryLines()
+    {
+        QVariantMap shot = buildHealthyShotMap();
+        // Deliberately omit summaryLines.
+
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarizeFromHistory(shot);
+
+        QVERIFY2(!summary.summaryLines.isEmpty(),
+                 "fallback inline detector path must populate summaryLines");
+        QVERIFY2(linesContainType(summary.summaryLines, QStringLiteral("verdict")),
+                 "every shot must end with a verdict line");
+        // Healthy shot: should NOT be flagged as truncated.
+        QVERIFY2(!summary.pourTruncatedDetected,
+                 "healthy shot must not flag pourTruncatedDetected");
+    }
+
+    // Equivalence test: a shotData with pre-computed summaryLines AND a
+    // shotData without must produce identical summary.summaryLines (modulo
+    // the fact that the pre-computed path uses whatever was passed in). To
+    // make this meaningful, run the slow path FIRST to get the real lines,
+    // then feed those into the fast path and confirm the result matches.
+    // This catches drift if the fast-path branch is ever modified to do
+    // something different than just reading the pre-computed field.
+    void summarizeFromHistory_fastAndSlowPathsAgree()
+    {
+        QVariantMap slowShot = buildHealthyShotMap();
+        ShotSummarizer summarizer;
+        const ShotSummary slowSummary = summarizer.summarizeFromHistory(slowShot);
+
+        // Now build a fast-path shot by stuffing the slow-path's lines and
+        // pourTruncated into a fresh map. summarizeFromHistory MUST produce
+        // an equivalent summary.
+        QVariantMap fastShot = buildHealthyShotMap();
+        fastShot["summaryLines"] = slowSummary.summaryLines;
+        QVariantMap detectors;
+        detectors["pourTruncated"] = slowSummary.pourTruncatedDetected;
+        fastShot["detectorResults"] = detectors;
+        const ShotSummary fastSummary = summarizer.summarizeFromHistory(fastShot);
+
+        QCOMPARE(fastSummary.summaryLines.size(), slowSummary.summaryLines.size());
+        for (int i = 0; i < slowSummary.summaryLines.size(); ++i) {
+            QCOMPARE(fastSummary.summaryLines[i].toMap().value("text").toString(),
+                     slowSummary.summaryLines[i].toMap().value("text").toString());
+            QCOMPARE(fastSummary.summaryLines[i].toMap().value("type").toString(),
+                     slowSummary.summaryLines[i].toMap().value("type").toString());
+        }
+        QCOMPARE(fastSummary.pourTruncatedDetected, slowSummary.pourTruncatedDetected);
+    }
+
+    // Cascade integrity through the fast path: when shotData carries a
+    // detectorResults.pourTruncated == true, summarizeFromHistory MUST set
+    // summary.pourTruncatedDetected = true AND skip the per-phase temp
+    // instability marking, exactly like the slow path's cascade.
+    void summarizeFromHistory_fastPathPreservesPourTruncatedCascade()
+    {
+        QVariantMap shot = buildHealthyShotMap();
+        // Stash any non-empty summaryLines (content irrelevant for this assertion).
+        QVariantMap line;
+        line["text"] = QStringLiteral("dummy");
+        line["type"] = QStringLiteral("good");
+        QVariantList lines;
+        lines.append(line);
+        shot["summaryLines"] = lines;
+
+        QVariantMap detectors;
+        detectors["pourTruncated"] = true;
+        shot["detectorResults"] = detectors;
+
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarizeFromHistory(shot);
+
+        QVERIFY2(summary.pourTruncatedDetected,
+                 "fast path must derive pourTruncatedDetected from detectorResults");
+        // Per-phase temperature markers must NOT be set when pourTruncated fires.
+        for (const PhaseSummary& phase : summary.phases) {
+            QVERIFY2(!phase.temperatureUnstable,
+                     "pourTruncated cascade must suppress per-phase temp markers in fast path");
+        }
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_ShotSummarizer)


### PR DESCRIPTION
Implements OpenSpec change [`dedup-ai-advisor-history-path`](https://github.com/Kulitorum/Decenza/blob/2f999d7c/openspec/changes/dedup-ai-advisor-history-path/proposal.md). Second of three follow-ups (A/B/C) from the parity audit on PR #933.

Depends on PR #934 conceptually but not technically — the two are independent and can land in either order. PR #934 deduped the dialog path; this PR dedups the AI advisor's historical-shot path with the same fast/fallback pattern.

## Summary
- `ShotSummarizer::summarizeFromHistory` now short-circuits when `shotData.summaryLines` is non-empty, deriving `pourTruncatedDetected` from `shotData.detectorResults.pourTruncated`.
- Per-phase temperature markers are still gated on the same conditions as the slow path, so the cascade integrity is preserved.
- Slow path (existing inline detector orchestration) remains as the fallback for legacy `shotData` maps that didn't flow through `convertShotRecord`.
- Live-path `summarize(ShotDataModel*)` is unchanged — there's no `convertShotRecord` upstream of an in-progress shot.

## Test plan
- [x] Build clean (Qt Creator MCP, 0 errors / 0 warnings)
- [x] 1782 tests pass (1778 prior + 4 new for B)
- [x] `summarizeFromHistory_usesPreComputedLines` — sentinel-based, locks in that pre-computed lines come back unchanged
- [x] `summarizeFromHistory_fallsBackWhenNoSummaryLines` — legacy path still works
- [x] `summarizeFromHistory_fastAndSlowPathsAgree` — byte-equal output across paths
- [x] `summarizeFromHistory_fastPathPreservesPourTruncatedCascade` — cascade integrity through fast path

🤖 Generated with [Claude Code](https://claude.com/claude-code)