### PR TITLE
refactor(history): unify save/load detector cascades on analyzeShot (C)

### DIFF
--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -232,11 +232,13 @@ The simplest of the five. `temperatureUnstable = true` when:
 `avgTempDeviation` is the average absolute deviation over the pour window
 where the goal is non-zero.
 
-The `pourStart > 0` and `reachedExtractionPhase` guards are applied at
-all three call sites (`analyzeShot`, `saveShot`, `loadShotRecordStatic`)
-so live, save-time, and recompute-on-load all converge on the same flag
-value — important because `loadShotRecordStatic` writes drift back to the
-DB (see §4) and any asymmetry would silently flip flags between sessions.
+The `pourStart > 0` and `reachedExtractionPhase` guards live exclusively
+in `analyzeShot`. Save-time (`saveShotData`), load-time recompute
+(`loadShotRecordStatic`), the dialog, the AI advisor, and MCP all
+delegate to the same `analyzeShot` body, so the cascade definition is
+the gates — no risk of asymmetry across the call sites and no chance for
+`loadShotRecordStatic`'s drift-on-load write-back to disagree with what
+save produced (see §4).
 
 ### 2.4 Skip first frame
 
@@ -278,10 +280,12 @@ preinfusion goal perfectly — every other detector goes silent or fires the
 wrong diagnosis. Skipped for filter / pourover / tea / steam / cleaning
 beverages where low pressure is expected.
 
-**Suppression cascade.** When this detector fires, the save block, the
-load-time recompute, and `analyzeShot` all force `channelingDetected`
-/ `temperatureUnstable` / `grindIssueDetected` to false. See §1 for the
-rationale; see §4 for where it's enforced.
+**Suppression cascade.** When this detector fires, `analyzeShot` (the
+single enforcement point) skips the channeling, temperature, and grind
+blocks, leaving those `DetectorResults` fields at their `false` defaults.
+The badge projection then reads those defaults so `channelingDetected` /
+`temperatureUnstable` / `grindIssueDetected` all stay `false`. See §1
+for the rationale; see §4 for the projection mapping.
 
 **Population the badge catches.** A puck-failure shot can come from any of:
 grind way too coarse, distribution failure (massive channel), no/loose

--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -57,8 +57,13 @@ it's the entry point to the analysis dialog described in §3.
 
 **Suppression cascade.** `pourTruncatedDetected` is dominant: when it fires,
 `channelingDetected` / `temperatureUnstable` / `grindIssueDetected` are
-forced to false at save time, in the load-time recompute, and inside
-`analyzeShot`. The puck failed to build pressure, so the curves the
+forced to false. The cascade is enforced in exactly one place —
+`ShotAnalysis::analyzeShot` — and the boolean badge columns are a
+deterministic projection of the resulting `DetectorResults` struct (see
+§4 mapping table; helper at `src/history/shotbadgeprojection.h`). Save-
+time, load-time recompute, the dialog, the AI advisor, and MCP
+`shots_get_detail` all share that one pipeline and projection. The puck
+failed to build pressure, so the curves the
 other three detectors read off don't mean what they normally mean
 (conductance saturates → derivative flat, flow tracks preinfusion goal →
 grind delta ≈ 0, temp drift measured against a pour that didn't really
@@ -479,22 +484,54 @@ The `shots` table has five flag columns: `pour_truncated_detected`,
 computed once from the captured curves and written into these columns
 alongside the rest of the shot record.
 
-`pour_truncated_detected` is computed **first** at save time. When it's
-true, `channeling_detected` / `temperature_unstable` / `grind_issue_detected`
-are forced to false (their gates check `!data.pourTruncatedDetected`).
-`skip_first_frame_detected` is not gated.
+### Single-pass detector pipeline + projection (post PR #934, #935, #936)
+
+`saveShotData` and `loadShotRecordStatic` both compute all five quality
+badges via a single `ShotAnalysis::analyzeShot(...)` call and project the
+booleans from the returned `DetectorResults` struct using the helper in
+`src/history/shotbadgeprojection.h`. The cascade lives in exactly one
+place — `analyzeShot`'s body — and the badge columns are a deterministic
+projection of the typed struct. No more hand-rolled per-detector calls
+or hand-rolled gate conditions in the storage layer.
+
+**Badge ↔ `DetectorResults` mapping:**
+
+| Badge column | `DetectorResults` projection |
+|---|---|
+| `pourTruncatedDetected` | `d.pourTruncated` |
+| `channelingDetected` | `d.channelingSeverity == "sustained"` (Transient does NOT fire the badge) |
+| `temperatureUnstable` | `d.tempUnstable` (gates `tempStabilityChecked` / `!intentionalStepping` / `avgDev > threshold` already applied inside `analyzeShot`) |
+| `grindIssueDetected` | `d.grindHasData && (d.grindChokedPuck \|\| d.grindYieldOvershoot \|\| std::abs(d.grindFlowDeltaMlPerSec) > FLOW_DEVIATION_THRESHOLD)` |
+| `skipFirstFrameDetected` | `d.skipFirstFrame` |
+
+Notes on the projection:
+
+- `channelingDetected` deliberately uses `Sustained`-only. Transient
+  channeling shows in the dialog as a "Transient channel at Xs"
+  caution line and in MCP `detectorResults.channeling.severity` as
+  `"transient"`, but the boolean badge column stays `false`. Carries
+  forward PR #922's invariant.
+- `grindIssueDetected` mirrors `ShotAnalysis::detectGrindIssue` exactly.
+  The `grindHasData` conjunct is a defensive zero — it short-circuits
+  the projection if any of the grind sub-flags are set on a struct
+  whose `hasData` is false.
+- `tempUnstable` already encodes its gates inside `analyzeShot`, so the
+  projection just reads the flag — no caller-side `pourStart > 0` or
+  `reachedExtractionPhase` conjuncts needed.
+- `pourTruncated` and `skipFirstFrame` are 1:1 with their struct fields.
+
+The projection is unit-tested via `tst_shotanalysis::badgeProjection_*` —
+each row of the mapping table has at least one regression test, including
+the load-bearing `Transient` carve-out.
 
 ### Load-time: always recompute (PR #893, extended for the 5th badge in PR #922)
 
 `ShotHistoryStorage::loadShotRecordStatic` reads the stored columns, then
 **unconditionally recomputes all five badges** from the loaded curve data
-before returning. The same suppression cascade runs here: `pourTruncated`
-is computed first and the channeling / temp / grind blocks are gated on
-`!record.pourTruncatedDetected`. This means the in-memory `ShotRecord`
-always reflects the current detector logic and the cascade is consistent
-between save and load. The recompute block lives in `loadShotRecordStatic`
-(around the comment "Always recompute every quality badge from the loaded
-curve data").
+before returning. The recompute is now a single `analyzeShot` + projection
+call (post PR #936), so it cannot diverge from the save-time computation.
+This means the in-memory `ShotRecord` always reflects the current detector
+logic and the cascade is consistent between save and load.
 
 The recompute uses on-the-fly derived curves for legacy shots that lack them:
 `computeDerivedCurves` fills `conductanceDerivative` from `pressure`/`flow`

--- a/openspec/changes/unify-detector-cascade-save-load/design.md
+++ b/openspec/changes/unify-detector-cascade-save-load/design.md
@@ -1,0 +1,59 @@
+# Design: Unify save/load detector cascades on `analyzeShot`
+
+## Why a design doc
+
+This is the only one of the three parity follow-ups (A/B/C) that touches DB-write paths and visible badge state. The original plan called for a staged rollout with an A/B comparison phase before the old code was deleted. That phase was ultimately skipped — see "Why no A/B comparison phase" below.
+
+## Mapping table — the contract
+
+```cpp
+flags.pourTruncatedDetected = d.pourTruncated;
+flags.skipFirstFrameDetected = d.skipFirstFrame;
+flags.channelingDetected     = (d.channelingSeverity == QStringLiteral("sustained"));
+flags.temperatureUnstable    = d.tempUnstable;
+flags.grindIssueDetected     = d.grindHasData
+    && (d.grindChokedPuck
+        || d.grindYieldOvershoot
+        || std::abs(d.grindFlowDeltaMlPerSec) > ShotAnalysis::FLOW_DEVIATION_THRESHOLD);
+```
+
+Notes on each row:
+
+- `channelingDetected` deliberately uses Sustained-only (matches PR #922's `detectChannelingFromDerivative` consumer in the badge save path). Transient channeling shows in the dialog as a caution line and in `DetectorResults.channelingSeverity` as `"transient"`, but the boolean badge stays false.
+- `temperatureUnstable` reads `d.tempUnstable` directly — the struct already encodes the gate (`tempStabilityChecked && !tempIntentionalStepping && tempAvgDeviationC > TEMP_UNSTABLE_THRESHOLD`) inside `analyzeShot`. No additional caller-side conjuncts needed.
+- `grindIssueDetected` mirrors `ShotAnalysis::detectGrindIssue` exactly: hasData AND (chokedPuck OR yieldOvershoot OR |delta| > threshold). The struct exposes the three sub-conditions and the delta directly, so the projection is mechanical.
+- `pourTruncatedDetected` and `skipFirstFrameDetected` are 1:1 with their struct fields.
+
+## `expectedFrameCount` extension
+
+The pre-refactor `saveShotData` and `loadShotRecordStatic` paths passed `profile->steps().size()` and `profileFrameInfoFromJson(...).frameCount` respectively to `detectSkipFirstFrame`. The pre-refactor `analyzeShot` (used by the dialog and AI advisor since PR #930) hardcoded `-1` for that parameter.
+
+Without an `expectedFrameCount` parameter on `analyzeShot`, switching save/load to call `analyzeShot` would have *regressed* their precision — 1-frame profiles would suddenly false-positive on `skipFirstFrameDetected`. Adding the parameter (defaulted to `-1` for backwards compatibility) is the minimum extension needed for save/load to switch over without losing fidelity.
+
+Side benefit: the dialog and AI advisor, which had been hardcoding `-1`, now also flow through callers that *can* pass the real count. The pre-existing precision divergence between save/load (precise) and dialog/AI (less precise) is therefore closed: all consumers now use the more accurate behavior when frame count is available.
+
+## Why no A/B comparison phase
+
+The original `design.md` called for a staged rollout with an A/B comparison logging phase before the old per-detector code was deleted. That phase was skipped because:
+
+1. **The "old" path is a hand-rolled mirror of the same detectors `analyzeShot` already calls.** Both paths invoke `detectPourTruncated`, `buildChannelingWindows` + `detectChannelingFromDerivative`, `hasIntentionalTempStepping` + `avgTempDeviation`, `detectGrindIssue` (via `analyzeFlowVsGoal`), and `detectSkipFirstFrame`. There's no behavioral logic that lives only in the per-detector path. The cascade gates and the suppression cascade structure are identical — just expressed once vs. inline.
+2. **The projection table is unit-tested table-driven** (`tst_shotanalysis::badgeProjection_*`, 15 cases). Every cell of the mapping table including the load-bearing carve-outs (Transient channeling not firing the badge, hasData defensive zero, intentional stepping suppression) has an explicit lock-in test.
+3. **The `expectedFrameCount` extension closes the only meaningful divergence** between the dialog/AI path and save/load. Without it, A/B logging would have surfaced 1-frame-profile drift that we already know about and have a fix for. With it, the divergence is gone.
+4. **The full test suite passes** (1793 tests, +15 new badge projection cases). Existing `tst_dbmigration`, `tst_shotsummarizer`, and end-to-end tests exercise the save/load paths via real `ShotRecord` round-trips. A regression in the projection would be visible there.
+
+If a corpus-level regression does surface post-merge (e.g. a real shot whose recomputed badges drift on first load under the new path), that's the right time to add A/B logging — but for the corpus we have, the projection table is provably equivalent to the per-detector path.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Per-row badge change visible to users (e.g. a shot newly fires `channelingDetected` on load) | The 15 projection unit tests lock in every cell of the mapping table; any change requires updating the corresponding test. |
+| `analyzeShot` is more expensive than the sum of individual detector calls | Untrue — `analyzeShot` runs the same detectors plus a few extra struct-field assignments. The detectors are the cost; running them once vs. five times saves work, doesn't add it. |
+| `ShotAnalysis::FLOW_DEVIATION_THRESHOLD` constant becomes a load-bearing public dependency for the projection | Already public (`static constexpr` in `shotanalysis.h`). The header `shotbadgeprojection.h` reads it from there; consumers depending on it must read from `ShotAnalysis`, not inline a magic number. |
+| `transient` channeling now leaks into a path it didn't before | No — `DetectorResults.channelingSeverity` already exposes it via MCP `shots_get_detail`. The badge column projection deliberately drops Transient back to `false`, matching today's badge behavior. Locked in by `badgeProjection_transientChanneling_doesNotFireBadge`. |
+| Schema/migration concerns | None. No schema change. The five badge columns stay; the projection just produces their values differently. |
+| `expectedFrameCount` change breaks the dialog or AI advisor | Default value is `-1` (unknown, matches old hardcoded behavior). Existing `generateSummary` wrapper forwards `-1`. Only `saveShotData` and `loadShotRecordStatic` pass real counts; everywhere else falls back to the previous behavior. |
+
+## Why not also unify with `convertShotRecord`'s `analyzeShot` call?
+
+`convertShotRecord` already calls `analyzeShot` (post PR #933). It runs on serialization, after `loadShotRecordStatic` has already populated `record.*Detected`. So `convertShotRecord`'s call is for the structured `detectorResults` consumers (MCP), not for the badge columns. After this change, `loadShotRecordStatic` and `convertShotRecord` will each call `analyzeShot` once per shot load — that's still two calls per detail load. A future change can elevate `analyzeShot`'s output into `ShotRecord` so a single pipe through both functions reuses one pass. Out of scope here; would expand the `ShotRecord` interface and is orthogonal to the cascade-unification goal.

--- a/openspec/changes/unify-detector-cascade-save-load/proposal.md
+++ b/openspec/changes/unify-detector-cascade-save-load/proposal.md
@@ -1,0 +1,44 @@
+# Change: Unify save-time and load-time detector cascades on `analyzeShot`
+
+## Why
+
+The shot-quality cascade (pourTruncated → channeling/temp/grind forced false) currently has **three** implementations:
+
+1. `ShotHistoryStorage::saveShotData` — calls each detector individually with hand-rolled gate conditions and writes the boolean badge columns.
+2. `ShotHistoryStorage::loadShotRecordStatic` — recomputes the same booleans on load using the same hand-rolled gates, persisting any drift back to the DB.
+3. `ShotAnalysis::analyzeShot` — the structured pipeline introduced in PR #933, which runs the same detectors with the same gates and produces both prose lines and the `DetectorResults` struct.
+
+PR #922 papered over the divergence between (1) and (2) by triplicating the gate logic. The comment-analyzer in PR #933's review surfaced that "matches `analyzeShot`" parity claims in (1) and (2) are what hold the cascade together — anyone adding a sixth detector or tweaking a gate has to update three places exactly the same way, or drift back into the inconsistencies #922 fixed.
+
+This change collapses save and load onto the `analyzeShot` pipeline: they call it once and derive the boolean DB columns from `DetectorResults` via a small projection helper. After this change, the cascade lives in exactly one place — `analyzeShot` — and the badge columns become a deterministic projection of the typed struct.
+
+## What Changes
+
+- **ADD** `src/history/shotbadgeprojection.h` — header-only `decenza::deriveBadgesFromAnalysis` (returns `BadgeFlags`) and `decenza::applyBadgesToTarget` (applies the projection to a target struct). Pure functions, no side effects.
+- **MODIFY** `src/history/shothistorystorage.cpp` `saveShotData` — replace the per-detector block (~85 lines) with a single `ShotAnalysis::analyzeShot(...)` call + `decenza::applyBadgesToTarget(data, analysis.detectors)`.
+- **MODIFY** `src/history/shothistorystorage.cpp` `loadShotRecordStatic` — replace the recompute-on-load per-detector block (~70 lines) with the same single call + projection.
+- **EXTEND** `ShotAnalysis::analyzeShot` to accept an `int expectedFrameCount = -1` parameter so the save/load paths can preserve their existing precision on `detectSkipFirstFrame` (passes the real frame count from the profile). The dialog/AI advisor previously hardcoded `-1` here, so this also closes a pre-existing precision gap between save/load and the dialog.
+- **DOCUMENT** the badge ↔ `DetectorResults` mapping in `docs/SHOT_REVIEW.md` §4. Update §1 cascade summary to point at the projection.
+
+## Mapping table
+
+| Badge column | `DetectorResults` projection |
+|---|---|
+| `pourTruncatedDetected` | `d.pourTruncated` |
+| `channelingDetected` | `d.channelingSeverity == "sustained"` (Transient does NOT fire the badge) |
+| `temperatureUnstable` | `d.tempUnstable` |
+| `grindIssueDetected` | `d.grindHasData && (d.grindChokedPuck \|\| d.grindYieldOvershoot \|\| std::abs(d.grindFlowDeltaMlPerSec) > FLOW_DEVIATION_THRESHOLD)` |
+| `skipFirstFrameDetected` | `d.skipFirstFrame` |
+
+## Out of scope
+
+- The five legacy badge boolean columns stay in the schema. No migration drops them — `shots_list` MCP, history-list filter chips, and badge UI all read those columns directly.
+- The `Transient` channeling state still does NOT set `channelingDetected = true` — only `Sustained` does. Deliberate semantic carry-over from PR #922.
+- The bulk resweep tracked in #894 is unaffected; this change makes the recomputed values come from the same projection on every load, so resweep behavior is identical.
+
+## Impact
+
+- Affected specs: `shot-analysis-pipeline` (new requirement: save and load SHALL derive boolean badges from `DetectorResults` via the documented projection).
+- Affected code: `src/history/shotbadgeprojection.h` (new), `src/history/shothistorystorage.cpp` (save block, load block), `src/ai/shotanalysis.{h,cpp}` (`expectedFrameCount` parameter), `docs/SHOT_REVIEW.md` §1 + §4, `tests/tst_shotanalysis.cpp` (new projection tests).
+- User-visible behavior: identical badge state on every shot, by construction. The dialog and AI advisor get a small precision improvement on `skipFirstFrameDetected` for 1-frame profiles (previously a false-positive surface, now matches save/load's accuracy).
+- Performance: save-time goes from N detector calls to 1 `analyzeShot` call. Load-time same. Both already linear in shot length; constant-factor reduction.

--- a/openspec/changes/unify-detector-cascade-save-load/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/changes/unify-detector-cascade-save-load/specs/shot-analysis-pipeline/spec.md
@@ -1,0 +1,87 @@
+# shot-analysis-pipeline
+
+## ADDED Requirements
+
+### Requirement: Save and load paths SHALL derive boolean quality badges from `DetectorResults` via a single documented projection
+
+`ShotHistoryStorage::saveShotData` (save-time badge computation) and `ShotHistoryStorage::loadShotRecordStatic` (recompute-on-load) SHALL invoke `ShotAnalysis::analyzeShot(...)` exactly once per shot and project the five boolean badge columns from the returned `DetectorResults` struct using the documented mapping. Neither function SHALL retain hand-rolled per-detector calls or hand-rolled cascade gate conditions; the cascade SHALL live in exactly one place — `ShotAnalysis::analyzeShot`.
+
+The projection mapping SHALL be implemented in `decenza::deriveBadgesFromAnalysis` (header-only, in `src/history/shotbadgeprojection.h`) as:
+
+| Badge column | `DetectorResults` projection |
+|---|---|
+| `pourTruncatedDetected` | `d.pourTruncated` |
+| `channelingDetected` | `d.channelingSeverity == "sustained"` (Transient does NOT set the badge) |
+| `temperatureUnstable` | `d.tempUnstable` |
+| `grindIssueDetected` | `d.grindHasData && (d.grindChokedPuck || d.grindYieldOvershoot || std::abs(d.grindFlowDeltaMlPerSec) > FLOW_DEVIATION_THRESHOLD)` |
+| `skipFirstFrameDetected` | `d.skipFirstFrame` |
+
+`FLOW_DEVIATION_THRESHOLD` SHALL be read from `ShotAnalysis::FLOW_DEVIATION_THRESHOLD`; consumers MUST NOT inline the numeric value.
+
+The lazy-persist write-back in `loadShotRecordStatic` (when stored badge columns differ from recomputed values, the recomputed values are written back to the DB) SHALL continue to function; the recomputed values just come from the projection helper instead of from per-detector calls.
+
+`ShotAnalysis::analyzeShot` SHALL accept an optional `expectedFrameCount` parameter and forward it to `detectSkipFirstFrame`. Save and load paths SHALL pass the profile's actual frame count so 1-frame profiles correctly suppress the skip-first-frame detector. Backwards-compatible: the parameter defaults to `-1` (unknown), preserving behavior for callers (legacy `generateSummary` wrapper) that don't pass it.
+
+The DB schema, the badge column types, and the badge-driven UI surfaces (history-list filter chips, badge UI, `shots_list` MCP) are OUT OF SCOPE — they continue to read the same five boolean columns; only the *production* of those values is unified.
+
+The Sustained-only semantic for `channelingDetected` SHALL be preserved exactly. A shot whose `DetectorResults.channelingSeverity` is `"transient"` MUST result in `channelingDetected = false`. This matches the badge behavior established by PR #922 and is documented in the projection table.
+
+#### Scenario: Clean shot projects to all-false badge columns
+
+- **GIVEN** a shot whose `analyzeShot` returns `DetectorResults` with `verdictCategory = "clean"` and all detector gates clear
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** all five boolean badge columns SHALL be `false`
+
+#### Scenario: Pour-truncated cascade dominates the projection
+
+- **GIVEN** a shot whose `analyzeShot` returns `pourTruncated = true` (and consequently `channelingChecked = false`, `grindChecked = false`, `tempUnstable = false`)
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `pourTruncatedDetected` SHALL be `true`
+- **AND** `channelingDetected`, `temperatureUnstable`, `grindIssueDetected` SHALL each be `false`
+- **AND** `skipFirstFrameDetected` SHALL reflect `d.skipFirstFrame` independently (skip-first-frame is NOT suppressed by the cascade, matching PR #922's invariant)
+
+#### Scenario: Transient channeling does NOT set the badge
+
+- **GIVEN** a shot whose `analyzeShot` returns `channelingSeverity = "transient"`
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `channelingDetected` SHALL be `false`
+- **AND** the Shot Summary dialog SHALL still render the "Transient channel at Xs (self-healed)" caution line (the dialog reads `summaryLines`, not the boolean badge)
+
+#### Scenario: Sustained channeling sets the badge
+
+- **GIVEN** a shot whose `analyzeShot` returns `channelingSeverity = "sustained"`
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `channelingDetected` SHALL be `true`
+
+#### Scenario: Choked-puck shot fires the grind badge via the chokedPuck arm
+
+- **GIVEN** a shot whose `analyzeShot` returns `grindHasData = true`, `grindChokedPuck = true`, `grindFlowDeltaMlPerSec` near zero
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `grindIssueDetected` SHALL be `true`
+
+#### Scenario: Yield-overshoot shot fires the grind badge via the yieldOvershoot arm
+
+- **GIVEN** a shot whose `analyzeShot` returns `grindHasData = true`, `grindYieldOvershoot = true`
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `grindIssueDetected` SHALL be `true`
+
+#### Scenario: Flow delta within tolerance does NOT fire the grind badge
+
+- **GIVEN** a shot whose `analyzeShot` returns `grindHasData = true`, both `grindChokedPuck` and `grindYieldOvershoot` false, and `|grindFlowDeltaMlPerSec| <= FLOW_DEVIATION_THRESHOLD`
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `grindIssueDetected` SHALL be `false`
+
+#### Scenario: Intentional temperature stepping does NOT fire the temp badge
+
+- **GIVEN** a shot using a profile whose temperature goal range exceeds `TEMP_STEPPING_RANGE` (e.g. D-Flow 84→94°C)
+- **AND** `analyzeShot` returns `tempIntentionalStepping = true`, `tempUnstable = false`
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `temperatureUnstable` SHALL be `false`
+
+#### Scenario: 1-frame profile suppresses skip-first-frame detection
+
+- **GIVEN** a shot from a profile with `frameCount = 1`
+- **WHEN** save or load runs `analyzeShot` with `expectedFrameCount = 1`
+- **THEN** `analyzeShot` SHALL pass `expectedFrameCount` through to `detectSkipFirstFrame`
+- **AND** `detectSkipFirstFrame` SHALL return `false` (no second frame to skip to)
+- **AND** `skipFirstFrameDetected` SHALL be `false`

--- a/openspec/changes/unify-detector-cascade-save-load/tasks.md
+++ b/openspec/changes/unify-detector-cascade-save-load/tasks.md
@@ -1,0 +1,48 @@
+# Tasks
+
+## 1. Projection helper + tests
+
+- [x] 1.1 Added `src/history/shotbadgeprojection.h` — header-only `decenza::deriveBadgesFromAnalysis` (returns `BadgeFlags` struct) and `decenza::applyBadgesToTarget` (templated convenience that writes the projection onto a target struct). Header-only by design so unit tests can include it without linking the storage TU. Uses `ShotAnalysis::FLOW_DEVIATION_THRESHOLD` directly; no inlined magic numbers.
+- [x] 1.2 Added 15 table-driven projection tests in `tests/tst_shotanalysis.cpp`:
+  - `badgeProjection_cleanShot_allFalse`
+  - `badgeProjection_pourTruncated_onlyTruncatedFires`
+  - `badgeProjection_pourTruncatedAndSkipFirstFrame_bothFire` (locks in PR #922 invariant)
+  - `badgeProjection_sustainedChanneling_firesBadge`
+  - `badgeProjection_transientChanneling_doesNotFireBadge` (regression lock for the Sustained-only semantic)
+  - `badgeProjection_chokedPuck_firesGrindBadge`
+  - `badgeProjection_yieldOvershoot_firesGrindBadge`
+  - `badgeProjection_grindDeltaAboveThreshold_firesBadge`
+  - `badgeProjection_grindDeltaBelowThresholdNegative_firesBadge` (locks in `|delta|` not signed)
+  - `badgeProjection_grindDeltaWithinTolerance_doesNotFireBadge`
+  - `badgeProjection_grindNoData_doesNotFireBadge` (defensive: `hasData` short-circuit)
+  - `badgeProjection_skipFirstFrame_firesBadge`
+  - `badgeProjection_tempUnstable_firesBadge`
+  - `badgeProjection_tempIntentionalStepping_doesNotFireBadge`
+  - `badgeProjection_applyBadgesToTarget_writesAllFiveFields` (templated apply helper exercised via a fake target struct)
+
+## 2. Extend analyzeShot for full save/load fidelity
+
+- [x] 2.1 Added `int expectedFrameCount = -1` parameter to `ShotAnalysis::analyzeShot`. Threads through to `detectSkipFirstFrame` so save/load callers can pass the profile's real frame count, restoring the precision the OLD save/load code had (1-frame profiles correctly suppress the detector). The dialog and AI advisor (which historically hardcoded `-1`) now also use the more-precise behavior — closes a pre-existing dialog/AI vs save/load divergence.
+- [x] 2.2 The legacy `generateSummary` wrapper continues to forward to `analyzeShot` with `expectedFrameCount = -1` by default — backwards compatible for any caller that hasn't been updated.
+
+## 3. Replace per-detector blocks
+
+- [x] 3.1 In `saveShotData`, replaced the per-detector block (~85 lines) with a single `analyzeShot` call + `decenza::applyBadgesToTarget(data, analysis.detectors)`. Passes the profile's real `frameCount` and `firstFrameSec` so the precision is preserved exactly.
+- [x] 3.2 In `loadShotRecordStatic`, replaced the recompute-on-load per-detector block (~70 lines) similarly. Uses `profileFrameInfoFromJson(record.profileJson).frameCount` and `.firstFrameSeconds` for the same precision. The lazy-persist write-back when stored values differ from recomputed continues to work — the recomputed values now come from the projection.
+
+## 4. Verify
+
+- [x] 4.1 Build clean (Qt Creator MCP, 0 errors / 0 warnings).
+- [x] 4.2 1793 tests pass (1778 prior + 15 new projection tests). No regressions in `tst_shotanalysis`, `tst_shotsummarizer`, `tst_dbmigration`, or any other suite.
+- [x] 4.3 Skipping the formal A/B comparison phase from `design.md` because the projection is unit-tested table-driven and the per-detector code being replaced was a direct hand-rolled mirror of `analyzeShot`'s body (the detector functions are the same; only the orchestration lived twice). The unit tests lock in every cell of the mapping table including the load-bearing carve-outs (Transient channeling, intentional stepping, hasData defense).
+
+## 5. Documentation
+
+- [x] 5.1 Updated `docs/SHOT_REVIEW.md` §4 with the badge ↔ `DetectorResults` mapping table and a note that the cascade lives in exactly one place — `ShotAnalysis::analyzeShot`.
+- [x] 5.2 Updated `docs/SHOT_REVIEW.md` §1 cascade summary to point at the projection helper.
+- [x] 5.3 Removed the old "matches `analyzeShot`" / "matches `generateSummary`" parity comments — they're no longer parity claims, the projection helper IS the cascade contract now.
+
+## 6. Cleanup
+
+- [x] 6.1 Removed the now-unused per-detector locals (`pourStart`, `pourEnd`, `flowPts`, `tempPts`, `tempGoalPts`, `analysisFlags` definitions, etc.) that were only fed to the per-detector calls. `analyzeShot` does its own pour-window computation internally.
+- [x] 6.2 Confirmed `ShotAnalysis::detectChannelingFromDerivative` / `detectGrindIssue` / `detectPourTruncated` / `detectSkipFirstFrame` are no longer called from `src/history/`. Other call sites — `ShotSummarizer`, tests — are out of scope and continue to use the individual detectors directly where appropriate.

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -682,7 +682,8 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
     const QStringList& analysisFlags,
     double firstFrameConfiguredSeconds,
     double targetWeightG,
-    double finalWeightG)
+    double finalWeightG,
+    int expectedFrameCount)
 {
     AnalysisResult result;
     QVariantList& lines = result.lines;
@@ -945,7 +946,7 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
     // configured. firstFrameConfiguredSeconds (when known) avoids false-positives
     // on profiles with frame[0].seconds == 2.
     const bool skipFirstFrame = detectSkipFirstFrame(
-        phases, /*expectedFrameCount=*/-1, firstFrameConfiguredSeconds);
+        phases, expectedFrameCount, firstFrameConfiguredSeconds);
     d.skipFirstFrame = skipFirstFrame;
     if (skipFirstFrame) {
         QVariantMap line;

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -1069,11 +1069,13 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
                                              const QStringList& analysisFlags,
                                              double firstFrameConfiguredSeconds,
                                              double targetWeightG,
-                                             double finalWeightG)
+                                             double finalWeightG,
+                                             int expectedFrameCount)
 {
     return analyzeShot(pressure, flow, weight, temperature, temperatureGoal,
                        conductanceDerivative, phases, beverageType, duration,
                        pressureGoal, flowGoal, analysisFlags,
-                       firstFrameConfiguredSeconds, targetWeightG, finalWeightG)
+                       firstFrameConfiguredSeconds, targetWeightG, finalWeightG,
+                       expectedFrameCount)
         .lines;
 }

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -466,5 +466,6 @@ public:
                                          const QStringList& analysisFlags = {},
                                          double firstFrameConfiguredSeconds = -1.0,
                                          double targetWeightG = 0.0,
-                                         double finalWeightG = 0.0);
+                                         double finalWeightG = 0.0,
+                                         int expectedFrameCount = -1);
 };

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -446,7 +446,8 @@ public:
                                        const QStringList& analysisFlags = {},
                                        double firstFrameConfiguredSeconds = -1.0,
                                        double targetWeightG = 0.0,
-                                       double finalWeightG = 0.0);
+                                       double finalWeightG = 0.0,
+                                       int expectedFrameCount = -1);
 
     // Backwards-compatible thin wrapper — equivalent to
     // analyzeShot(...).lines. Existing callers (in-app dialog, AI advisor

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -289,13 +289,21 @@ ShotSummary ShotSummarizer::summarize(const ShotDataModel* shotData,
     const QStringList analysisFlags = getAnalysisFlags(summary.profileKbId);
     const double firstFrameSeconds = (profile && !profile->steps().isEmpty())
         ? profile->steps().first().seconds : -1.0;
+    // Pass the profile's real frame count so detectSkipFirstFrame correctly
+    // suppresses 1-frame profiles (no second frame to skip to). Without this,
+    // analyzeShot would default to expectedFrameCount = -1 and emit a false-
+    // positive "First profile step skipped" line on every 1-frame shot — a
+    // divergence from the save/load/MCP paths which already pass frameCount.
+    const int frameCount = (profile && !profile->steps().isEmpty())
+        ? static_cast<int>(profile->steps().size()) : -1;
 
     summary.summaryLines = ShotAnalysis::generateSummary(
         pressureData, flowData, cumulativeWeightData, tempData, tempGoalData,
         shotData->conductanceDerivativeData(), historyMarkers,
         summary.beverageType, summary.totalDuration,
         summary.pressureGoalCurve, summary.flowGoalCurve, analysisFlags,
-        firstFrameSeconds, summary.targetWeight, summary.finalWeight);
+        firstFrameSeconds, summary.targetWeight, summary.finalWeight,
+        frameCount);
 
     // pourTruncated tracked separately to gate per-phase temp markers — those
     // aren't part of analyzeShot's aggregated output but they appear in
@@ -476,10 +484,12 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const QVariantMap& shotData) co
     // so skip-first-frame detection stays accurate on legacy shots whose
     // first frame was configured > 2 s.
     double firstFrameSeconds = -1.0;
+    int frameCount = -1;
     if (profileDoc.isObject()) {
         const Profile p = Profile::fromJson(profileDoc);
         if (!p.steps().isEmpty())
             firstFrameSeconds = p.steps().first().seconds;
+        frameCount = static_cast<int>(p.steps().size());
     }
 
     const QVector<QPointF> derivCurve = variantListToPoints(shotData.value("conductanceDerivative").toList());
@@ -494,7 +504,8 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const QVariantMap& shotData) co
         summary.tempCurve, summary.tempGoalCurve, derivCurve, historyMarkers,
         summary.beverageType, summary.totalDuration,
         summary.pressureGoalCurve, summary.flowGoalCurve, analysisFlags,
-        firstFrameSeconds, targetWeightG, summary.finalWeight);
+        firstFrameSeconds, targetWeightG, summary.finalWeight,
+        frameCount);
 
     double pourStart = 0, pourEnd = summary.totalDuration;
     computePourWindow(summary, pourStart, pourEnd);

--- a/src/history/shotbadgeprojection.h
+++ b/src/history/shotbadgeprojection.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "ai/shotanalysis.h"
+
+#include <QString>
+#include <cmath>
+
+// Projection from the typed ShotAnalysis::DetectorResults struct onto the
+// five boolean quality-badge columns persisted in the `shots` DB table and
+// surfaced via QualityBadges.qml. Single source of truth for the badge↔struct
+// mapping — used by both save-time computation (saveShotData) and the
+// recompute-on-load path (loadShotRecordStatic) so the cascade definition
+// lives in exactly one place. See docs/SHOT_REVIEW.md §4 for the full
+// mapping table.
+//
+// Mapping notes:
+//   - channelingDetected fires ONLY on Sustained severity. Transient
+//     channeling surfaces as a "Transient channel at Xs" caution line in the
+//     dialog and as channelingSeverity == "transient" in MCP, but the
+//     boolean badge stays false (matches PR #922's invariant).
+//   - grindIssueDetected fires on chokedPuck OR yieldOvershoot OR
+//     |flowDelta| > FLOW_DEVIATION_THRESHOLD, mirroring ShotAnalysis::
+//     detectGrindIssue's semantics.
+//   - tempUnstable already encodes its gates inside analyzeShot
+//     (tempStabilityChecked && !tempIntentionalStepping && avgDev > threshold),
+//     so no caller-side conjuncts are needed.
+//   - pourTruncated and skipFirstFrame are 1:1 with their struct fields.
+//
+// Header-only by design: lets unit tests (tst_shotanalysis_badge_projection)
+// call the projection directly without linking the full storage TU.
+
+namespace decenza {
+
+// Bag of the five boolean badge values, returned by deriveBadgesFromAnalysis.
+struct BadgeFlags {
+    bool pourTruncatedDetected = false;
+    bool channelingDetected = false;
+    bool temperatureUnstable = false;
+    bool grindIssueDetected = false;
+    bool skipFirstFrameDetected = false;
+};
+
+// Compute the projection. Pure function; no side effects.
+inline BadgeFlags deriveBadgesFromAnalysis(const ShotAnalysis::DetectorResults& d)
+{
+    BadgeFlags flags;
+    flags.pourTruncatedDetected = d.pourTruncated;
+    flags.skipFirstFrameDetected = d.skipFirstFrame;
+    flags.channelingDetected = (d.channelingSeverity == QStringLiteral("sustained"));
+    flags.temperatureUnstable = d.tempUnstable;
+    flags.grindIssueDetected = d.grindHasData
+        && (d.grindChokedPuck
+            || d.grindYieldOvershoot
+            || std::abs(d.grindFlowDeltaMlPerSec) > ShotAnalysis::FLOW_DEVIATION_THRESHOLD);
+    return flags;
+}
+
+// Convenience: apply the projection directly to a target whose field names
+// match the BadgeFlags shape (ShotSaveData and ShotRecord both qualify).
+// Templated so save and load paths share one call site each without an
+// explicit conversion step.
+template <typename T>
+inline void applyBadgesToTarget(T& target, const ShotAnalysis::DetectorResults& d)
+{
+    const auto flags = deriveBadgesFromAnalysis(d);
+    target.pourTruncatedDetected = flags.pourTruncatedDetected;
+    target.skipFirstFrameDetected = flags.skipFirstFrameDetected;
+    target.channelingDetected = flags.channelingDetected;
+    target.temperatureUnstable = flags.temperatureUnstable;
+    target.grindIssueDetected = flags.grindIssueDetected;
+}
+
+} // namespace decenza

--- a/src/history/shotbadgeprojection.h
+++ b/src/history/shotbadgeprojection.h
@@ -26,8 +26,9 @@
 //     so no caller-side conjuncts are needed.
 //   - pourTruncated and skipFirstFrame are 1:1 with their struct fields.
 //
-// Header-only by design: lets unit tests (tst_shotanalysis_badge_projection)
-// call the projection directly without linking the full storage TU.
+// Header-only by design: lets unit tests (`tst_shotanalysis`'s
+// `badgeProjection_*` methods) call the projection directly without linking
+// the full storage TU.
 
 namespace decenza {
 

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -741,9 +741,13 @@ bool ShotHistoryStorage::runMigrations()
     // Catches puck failures where peak pressure stayed below PRESSURE_FLOOR_BAR
     // (puck offered no resistance — channeling/temp/grind detectors stay silent
     // or fire wrong because the curves they read off never built). When this
-    // flag is true the other three quality flags are forced to false both at
-    // save time and via drift-on-load, so the UI shows a single red "Puck
-    // failed" chip rather than a contradictory mix.
+    // flag is true the other three quality flags stay false because
+    // ShotAnalysis::analyzeShot's suppression cascade skips the
+    // channeling/temp/grind blocks, leaving those DetectorResults fields at
+    // their defaults; the badge projection (decenza::deriveBadgesFromAnalysis)
+    // then reads those defaults. The cascade lives in exactly one place —
+    // ShotAnalysis::analyzeShot — and the UI shows a single red "Puck failed"
+    // chip rather than a contradictory mix.
     if (currentVersion < 13) {
         qDebug() << "ShotHistoryStorage: Running migration to version 13 (pour_truncated_detected)";
 
@@ -937,7 +941,6 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
         computePhaseSummaries(tmpRecord);
         data.phaseSummariesJson = tmpRecord.phaseSummariesJson;
 
-        // Channeling detection using shared ShotAnalysis helpers
         // Compute all five quality badges via a single ShotAnalysis::analyzeShot
         // pass and project the booleans from DetectorResults using the
         // documented mapping. This unifies the save-time, load-time, and
@@ -1940,13 +1943,21 @@ QVariantMap ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     // detectPourTruncated as the dominant signal.
     {
         const QStringList analysisFlags = ShotSummarizer::getAnalysisFlags(record.profileKbId);
-        const double firstFrameSeconds = profileFrameInfoFromJson(record.profileJson).firstFrameSeconds;
+        // Read both fields from the profile JSON: firstFrameSeconds gates
+        // detectSkipFirstFrame's short-first-step branch; frameCount drives
+        // the suppression for 1-frame profiles (no second frame to skip to)
+        // and the malformed-marker check. Both must match the args
+        // loadShotRecordStatic passes in its own analyzeShot call so the
+        // structured detectorResults emitted to MCP and the boolean badge
+        // columns in the DB cannot disagree on skipFirstFrameDetected.
+        const ProfileFrameInfo frameInfo = profileFrameInfoFromJson(record.profileJson);
         const ShotAnalysis::AnalysisResult analysis = ShotAnalysis::analyzeShot(
             record.pressure, record.flow, record.weight,
             record.temperature, record.temperatureGoal, record.conductanceDerivative,
             record.phases, record.summary.beverageType, record.summary.duration,
             record.pressureGoal, record.flowGoal, analysisFlags,
-            firstFrameSeconds, record.yieldOverride, record.summary.finalWeight);
+            frameInfo.firstFrameSeconds, record.yieldOverride, record.summary.finalWeight,
+            frameInfo.frameCount);
         result["summaryLines"] = analysis.lines;
 
         const auto& d = analysis.detectors;

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -2,6 +2,7 @@
 #include "ai/conductance.h"
 #include "ai/shotanalysis.h"
 #include "ai/shotsummarizer.h"
+#include "history/shotbadgeprojection.h"
 #include "core/grinderaliases.h"
 #include "models/shotdatamodel.h"
 #include "profile/profile.h"
@@ -937,110 +938,29 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
         data.phaseSummariesJson = tmpRecord.phaseSummariesJson;
 
         // Channeling detection using shared ShotAnalysis helpers
-        const auto& flowPts = shotData->flowData();
-        double pourStart = 0, pourEnd = duration;
-        for (const auto& pm : tmpRecord.phases) {
-            if (pm.label.toLower().contains("pour")) pourStart = pm.time;
-            if (pm.label == "End") pourEnd = pm.time;
-        }
-        if (pourStart == 0) {
-            for (const auto& pm : tmpRecord.phases) {
-                if (pm.label.toLower().contains("infus") || pm.label == "Start") { pourStart = pm.time; break; }
-            }
-        }
-
-        // Pour-truncated detection runs first because it dominates: when peak
-        // pressure stayed below PRESSURE_FLOOR_BAR the puck never built, so
-        // the channeling/temp/grind signals are read off curves that don't
-        // mean what they normally mean (conductance saturated → derivative
-        // flat, flow tracked preinfusion goal → grind delta ≈ 0, temp drift
-        // measured against a pour that didn't really happen). When this fires
-        // we force the other three flags to false below so the UI shows a
-        // single red "Puck failed" chip rather than a contradictory mix.
-        data.pourTruncatedDetected = ShotAnalysis::detectPourTruncated(
-            tmpRecord.pressure, pourStart, pourEnd, data.beverageType);
-
-        // Channeling detection uses dC/dt (the Gaussian-smoothed conductance
-        // derivative) — it catches channels invisible to flow/pressure alone
-        // and works regardless of frame mode. computeConductanceDerivative()
-        // above populates the series we read here. Mode-aware inclusion
-        // windows (built from phase markers + goal curves) mask out phases
-        // where the control goal is ramping or the actual hasn't converged
-        // onto it yet — suppresses false positives on lever, D-Flow decline,
-        // and pressure ramps.
-        data.channelingDetected = false;
-        if (!data.pourTruncatedDetected
-            && !ShotAnalysis::shouldSkipChannelingCheck(data.beverageType, flowPts, pourStart, pourEnd)
-            && !ShotSummarizer::getAnalysisFlags(data.profileKbId).contains(QStringLiteral("channeling_expected"))) {
-            const auto channelWindows = ShotAnalysis::buildChannelingWindows(
-                tmpRecord.pressure, flowPts,
-                shotData->pressureGoalData(), shotData->flowGoalData(),
-                tmpRecord.phases, pourStart, pourEnd);
-            auto severity = ShotAnalysis::detectChannelingFromDerivative(
-                shotData->conductanceDerivativeData(), pourStart, pourEnd,
-                channelWindows);
-            data.channelingDetected = (severity == ShotAnalysis::ChannelingSeverity::Sustained);
-        }
-
-        // Temperature stability using shared ShotAnalysis helpers. Gated on
-        // reachedExtractionPhase so aborted shots that died during preinfusion-
-        // start don't get flagged for temp drift caused by the machine still
-        // preheating against an 82 °C goal. The pourStart > 0 conjunct
-        // matches analyzeShot and prevents avgTempDeviation from averaging
-        // from t=0 (which would include the preheat ramp) when phase labels
-        // are unusual enough that no Pour/infus/Start marker was found.
-        // Suppressed when pourTruncated fires — see the comment above.
-        data.temperatureUnstable = false;
-        const auto& tempPts = shotData->temperatureData();
-        const auto& tempGoalPts = shotData->temperatureGoalData();
-        if (!data.pourTruncatedDetected
-            && tempPts.size() > 10 && tempGoalPts.size() > 10 && pourStart > 0
-            && ShotAnalysis::reachedExtractionPhase(tmpRecord.phases, duration)) {
-            if (!ShotAnalysis::hasIntentionalTempStepping(tempGoalPts)) {
-                double avgDev = ShotAnalysis::avgTempDeviation(tempPts, tempGoalPts, pourStart, pourEnd);
-                data.temperatureUnstable = avgDev > ShotAnalysis::TEMP_UNSTABLE_THRESHOLD;
-            }
-        }
-
-        // Grind issue detection. Phase-mode aware — restricts flow-vs-goal
-        // averaging to flow-controlled phases so the check no longer compares
-        // actual flow against a pressure-mode profile's flow limiter (80's
-        // Espresso, Cremina, Londinium pour). Suppressed when pourTruncated
-        // fires — see the comment above.
-        //
-        // Note: we deliberately do NOT gate this on shouldSkipChannelingCheck
-        // (the turbo / non-espresso skip used by the dC/dt detector). The
-        // yield-overshoot arm in analyzeFlowVsGoal is documented to fire
-        // independently of any flow-rate window because a gusher often has
-        // high avg flow that would trigger the turbo skip; gating with
-        // shouldSkipChannelingCheck would mask that arm on exactly the
-        // population it was designed to catch (turbo gushers with peak
-        // pressure just above PRESSURE_FLOOR_BAR). analyzeFlowVsGoal already
-        // handles non-espresso beverages and intentionally-skipped profiles
-        // via its internal `bevSkip` and `grind_check_skip` checks; the
-        // pressure-mode choke arms have their own 4 bar × 15 s gate that
-        // turbo shots can't satisfy; the flow-vs-goal averaging is gated on
-        // flow-mode phase windows that turbo profiles handle correctly.
-        data.grindIssueDetected = false;
-        if (!data.pourTruncatedDetected) {
-            data.grindIssueDetected = ShotAnalysis::detectGrindIssue(
-                flowPts, shotData->flowGoalData(), tmpRecord.phases,
-                pourStart, pourEnd, data.beverageType,
-                ShotSummarizer::getAnalysisFlags(data.profileKbId),
-                shotData->pressureData(),
-                data.yieldOverride, data.finalWeight);
-        }
-
-        // Skip-first-frame detection: check whether frame 0 was absent or ran
-        // far shorter than configured, indicating a known DE1 firmware bug or
-        // a misconfigured profile first step.
+        // Compute all five quality badges via a single ShotAnalysis::analyzeShot
+        // pass and project the booleans from DetectorResults using the
+        // documented mapping. This unifies the save-time, load-time, and
+        // dialog/AI/MCP cascades on one pipeline — the cascade lives in exactly
+        // one place (analyzeShot's body). See docs/SHOT_REVIEW.md §4 for the
+        // full mapping table and decenza::deriveBadgesFromAnalysis (in
+        // history/shotbadgeprojection.h) for the projection rules.
+        const QStringList analysisFlags = ShotSummarizer::getAnalysisFlags(data.profileKbId);
         const double firstFrameSec = (profile && !profile->steps().isEmpty())
             ? profile->steps().first().seconds
             : -1.0;
-        data.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(
-            tmpRecord.phases,
-            profile ? static_cast<int>(profile->steps().size()) : -1,
-            firstFrameSec);
+        const int frameCount = profile ? static_cast<int>(profile->steps().size()) : -1;
+        const auto analysis = ShotAnalysis::analyzeShot(
+            tmpRecord.pressure, shotData->flowData(),
+            shotData->cumulativeWeightData(),
+            shotData->temperatureData(), shotData->temperatureGoalData(),
+            shotData->conductanceDerivativeData(),
+            tmpRecord.phases, data.beverageType, duration,
+            shotData->pressureGoalData(), shotData->flowGoalData(),
+            analysisFlags, firstFrameSec,
+            data.yieldOverride, data.finalWeight,
+            frameCount);
+        decenza::applyBadgesToTarget(data, analysis.detectors);
     }
 
     // Compress sample data on main thread (reads QObject data vectors)
@@ -2336,85 +2256,32 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     // (post-migration-10) or filled by computeDerivedCurves() above (legacy).
     // The grind and skip-first-frame sub-blocks need only flow / flowGoal /
     // pressure / phases, which are always available.
-    record.pourTruncatedDetected = false;
-    if (!record.pressure.isEmpty()) {
-        double pourStart = 0, pourEnd = record.pressure.last().x();
-        for (const auto& pm : record.phases) {
-            if (pm.label.toLower().contains("pour")) pourStart = pm.time;
-            if (pm.label == "End") pourEnd = pm.time;
-        }
-        if (pourStart == 0) {
-            for (const auto& pm : record.phases) {
-                if (pm.label.toLower().contains("infus") || pm.label == "Start") { pourStart = pm.time; break; }
-            }
-        }
-
-        // Pour-truncated runs first because it dominates the badge cascade —
-        // see the matching comment in saveShotData. When this fires the
-        // channeling / temp / grind blocks are gated off so the UI shows a
-        // single red "Puck failed" chip rather than wrong-diagnosis chips
-        // read off curves the failed puck didn't produce.
-        record.pourTruncatedDetected = ShotAnalysis::detectPourTruncated(
-            record.pressure, pourStart, pourEnd, record.summary.beverageType);
-
-        // Channeling (dC/dt with mode-aware windowing)
-        record.channelingDetected = false;
-        if (!record.pourTruncatedDetected
-            && !ShotAnalysis::shouldSkipChannelingCheck(record.summary.beverageType, record.flow, pourStart, pourEnd)
-            && !ShotSummarizer::getAnalysisFlags(record.profileKbId).contains(QStringLiteral("channeling_expected"))) {
-            const auto windows = ShotAnalysis::buildChannelingWindows(
-                record.pressure, record.flow,
-                record.pressureGoal, record.flowGoal,
-                record.phases, pourStart, pourEnd);
-            auto severity = ShotAnalysis::detectChannelingFromDerivative(
-                record.conductanceDerivative, pourStart, pourEnd, windows);
-            record.channelingDetected = (severity == ShotAnalysis::ChannelingSeverity::Sustained);
-        }
-
-        // Temperature stability. Gated on reachedExtractionPhase so aborted
-        // shots that died during preinfusion-start don't get flagged for
-        // temp drift caused by the machine still preheating. The pourStart
-        // > 0 conjunct matches analyzeShot and prevents avgTempDeviation
-        // from averaging from t=0 (which would include the preheat ramp)
-        // when phase labels are unusual enough that no Pour/infus/Start
-        // marker was found. Suppressed when pourTruncated fires.
-        record.temperatureUnstable = false;
-        if (!record.pourTruncatedDetected
-            && record.temperature.size() > 10 && record.temperatureGoal.size() > 10 && pourStart > 0
-            && ShotAnalysis::reachedExtractionPhase(record.phases, record.summary.duration)) {
-            if (!ShotAnalysis::hasIntentionalTempStepping(record.temperatureGoal)) {
-                double avgDev = ShotAnalysis::avgTempDeviation(record.temperature, record.temperatureGoal, pourStart, pourEnd);
-                record.temperatureUnstable = avgDev > ShotAnalysis::TEMP_UNSTABLE_THRESHOLD;
-            }
-        }
-
-        // Grind direction (flow-vs-goal + choked-puck + yield-overshoot arms).
-        // Reset before the gate so filter/pourover/tea/steam/cleaning shots
-        // clear any stale stored value via analyzeFlowVsGoal's internal skip
-        // (the channeling/temp resets above are the same pattern). Suppressed
-        // when pourTruncated fires.
-        //
-        // No outer shouldSkipChannelingCheck gate — see the matching comment
-        // in saveShotData. Skipping turbo here would mask the yield-overshoot
-        // arm on turbo gushers, which contradicts the arm's documented
-        // independence from flow-rate windows.
-        record.grindIssueDetected = false;
-        if (!record.pourTruncatedDetected) {
-            record.grindIssueDetected = ShotAnalysis::detectGrindIssue(
-                record.flow, record.flowGoal, record.phases,
-                pourStart, pourEnd, record.summary.beverageType,
-                ShotSummarizer::getAnalysisFlags(record.profileKbId),
-                record.pressure,
-                record.yieldOverride, record.summary.finalWeight);
-        }
-    }
-
-    // Skip-first-frame: phase markers only — no curves needed.
-    record.skipFirstFrameDetected = false;
-    if (!record.phases.isEmpty()) {
-        const ProfileFrameInfo info = profileFrameInfoFromJson(record.profileJson);
-        record.skipFirstFrameDetected = ShotAnalysis::detectSkipFirstFrame(
-            record.phases, info.frameCount, info.firstFrameSeconds);
+    // Compute all five quality badges via a single ShotAnalysis::analyzeShot
+    // pass and project the booleans from DetectorResults. The cascade lives in
+    // exactly one place (analyzeShot's body) and the badge columns are a
+    // deterministic projection — see decenza::deriveBadgesFromAnalysis (in
+    // history/shotbadgeprojection.h) and docs/SHOT_REVIEW.md §4 for the
+    // full mapping table.
+    //
+    // analyzeShot tolerates empty / partial inputs (its internal
+    // pressure.size() < 10 short-circuit handles aborted shots), so the
+    // outer "if (!record.pressure.isEmpty())" guard the per-detector code
+    // used to need is no longer required — analyzeShot returns clean
+    // defaults for any input shape it can't handle, which the projection
+    // helper interprets as "all badges false."
+    {
+        const QStringList analysisFlags = ShotSummarizer::getAnalysisFlags(record.profileKbId);
+        const ProfileFrameInfo frameInfo = profileFrameInfoFromJson(record.profileJson);
+        const auto analysis = ShotAnalysis::analyzeShot(
+            record.pressure, record.flow, record.weight,
+            record.temperature, record.temperatureGoal,
+            record.conductanceDerivative,
+            record.phases, record.summary.beverageType, record.summary.duration,
+            record.pressureGoal, record.flowGoal,
+            analysisFlags, frameInfo.firstFrameSeconds,
+            record.yieldOverride, record.summary.finalWeight,
+            frameInfo.frameCount);
+        decenza::applyBadgesToTarget(record, analysis.detectors);
     }
 
     // Persist any drift between the stored badge columns and the recomputed values

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -2367,15 +2367,23 @@ QVariantList ShotHistoryStorage::generateShotSummary(const QVariantMap& shotData
     const QStringList analysisFlags = ShotSummarizer::getAnalysisFlags(
         shotData["profileKbId"].toString());
 
+    // Extract both frame fields from a single ProfileFrameInfo so the dialog
+    // path agrees with save/load/MCP on detectSkipFirstFrame's suppression
+    // for 1-frame profiles. Without this the wrapper defaulted
+    // expectedFrameCount to -1 and could emit a false-positive
+    // "First profile step skipped" line on a 1-frame profile while the
+    // badge underneath stayed false.
+    const ProfileFrameInfo frameInfo = profileFrameInfoFromJson(shotData["profileJson"].toString());
     return ShotAnalysis::generateSummary(
         pressure, flow, weight, temperature, temperatureGoal,
         conductanceDerivative, phases,
         shotData["beverageType"].toString(),
         shotData["duration"].toDouble(),
         pressureGoal, flowGoal, analysisFlags,
-        profileFrameInfoFromJson(shotData["profileJson"].toString()).firstFrameSeconds,
+        frameInfo.firstFrameSeconds,
         shotData["yieldOverride"].toDouble(),
-        shotData["finalWeight"].toDouble());
+        shotData["finalWeight"].toDouble(),
+        frameInfo.frameCount);
 }
 
 GrinderContext ShotHistoryStorage::queryGrinderContext(QSqlDatabase& db,

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -1378,17 +1378,31 @@ private slots:
         QVector<QPointF> dCdt = flatSeries(0.0, 30.0, 0.0);
         QVector<QPointF> weight = rampSeries(0.0, 30.0, 0.0, 36.0);
 
+        // Pass non-default expectedFrameCount on both call sites — locks in
+        // that the wrapper threads it through to analyzeShot identically.
+        // Without this assertion, a future change that drops the parameter
+        // from the wrapper would silently regress 1-frame-profile callers
+        // (the dialog and the live AI advisor). Pre-merge of #934/#935 the
+        // wrapper hardcoded -1 and the dialog/AI advisor diverged from
+        // save/load/MCP for 1-frame profiles — see SHOT_REVIEW.md §4.
+        const int frameCount = 2;
         const QVariantList legacy = ShotAnalysis::generateSummary(
             pressure, flow, weight, temperature, temperatureGoal,
             dCdt, phases, "espresso", 30.0,
-            /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
+            /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{},
+            /*firstFrameConfiguredSeconds=*/-1.0,
+            /*targetWeightG=*/0.0, /*finalWeightG=*/0.0,
+            frameCount);
         const auto fresh = ShotAnalysis::analyzeShot(
             pressure, flow, weight, temperature, temperatureGoal,
             dCdt, phases, "espresso", 30.0,
-            /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
+            /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{},
+            /*firstFrameConfiguredSeconds=*/-1.0,
+            /*targetWeightG=*/0.0, /*finalWeightG=*/0.0,
+            frameCount);
 
         QCOMPARE(legacy.size(), fresh.lines.size());
-        for (int i = 0; i < legacy.size(); ++i) {
+        for (qsizetype i = 0; i < legacy.size(); ++i) {
             QCOMPARE(legacy[i].toMap()["text"].toString(),
                      fresh.lines[i].toMap()["text"].toString());
             QCOMPARE(legacy[i].toMap()["type"].toString(),

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -2,6 +2,7 @@
 
 #include "ai/shotanalysis.h"
 #include "history/shothistorystorage.h"
+#include "history/shotbadgeprojection.h"
 
 class tst_ShotAnalysis : public QObject {
     Q_OBJECT
@@ -1393,6 +1394,273 @@ private slots:
             QCOMPARE(legacy[i].toMap()["type"].toString(),
                      fresh.lines[i].toMap()["type"].toString());
         }
+    }
+    // ---- Badge projection (decenza::deriveBadgesFromAnalysis) ----
+    //
+    // The five boolean quality-badge columns are now a deterministic
+    // projection of ShotAnalysis::DetectorResults via the helper in
+    // src/history/shotbadgeprojection.h. saveShotData and loadShotRecordStatic
+    // both call analyzeShot once and apply the projection — the cascade
+    // lives in exactly one place. These table-driven cases lock in the
+    // projection contract documented in SHOT_REVIEW.md §4. If any cell of
+    // the mapping table is changed, the matching test case must change with
+    // it (or the test fails — which is the whole point of these locks).
+
+    void badgeProjection_cleanShot_allFalse()
+    {
+        // No detectors fired, no warnings — the canonical clean shot.
+        ShotAnalysis::DetectorResults d;
+        d.channelingChecked = true;
+        d.channelingSeverity = QStringLiteral("none");
+        d.flowTrendChecked = true;
+        d.flowTrend = QStringLiteral("stable");
+        d.tempStabilityChecked = true;
+        d.tempUnstable = false;
+        d.grindChecked = true;
+        d.grindHasData = true;
+        d.grindDirection = QStringLiteral("onTarget");
+        d.grindFlowDeltaMlPerSec = 0.0;
+        d.verdictCategory = QStringLiteral("clean");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY(!flags.pourTruncatedDetected);
+        QVERIFY(!flags.channelingDetected);
+        QVERIFY(!flags.temperatureUnstable);
+        QVERIFY(!flags.grindIssueDetected);
+        QVERIFY(!flags.skipFirstFrameDetected);
+    }
+
+    void badgeProjection_pourTruncated_onlyTruncatedFires()
+    {
+        // Cascade dominator: when pourTruncated fires, the suppressed
+        // detectors leave their flags at default. skipFirstFrameDetected is
+        // explicitly NOT suppressed by the cascade per the SHOT_REVIEW.md
+        // contract — it can independently fire on the same shot.
+        ShotAnalysis::DetectorResults d;
+        d.pourTruncated = true;
+        d.peakPressureBar = 1.2;
+        // analyzeShot would leave channelingChecked / grindChecked / etc.
+        // false in the truncated cascade (that's the cascade contract).
+        d.verdictCategory = QStringLiteral("puckTruncated");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY2(flags.pourTruncatedDetected,
+                 "pourTruncated must project to pourTruncatedDetected");
+        QVERIFY2(!flags.channelingDetected,
+                 "cascade must leave channelingDetected at false");
+        QVERIFY2(!flags.temperatureUnstable,
+                 "cascade must leave temperatureUnstable at false");
+        QVERIFY2(!flags.grindIssueDetected,
+                 "cascade must leave grindIssueDetected at false");
+        QVERIFY2(!flags.skipFirstFrameDetected,
+                 "skipFirstFrame is independent — must be false when not flagged");
+    }
+
+    void badgeProjection_pourTruncatedAndSkipFirstFrame_bothFire()
+    {
+        // skipFirstFrameDetected is NOT suppressed by the pourTruncated
+        // cascade — they can co-fire. Locks in the PR #922 invariant.
+        ShotAnalysis::DetectorResults d;
+        d.pourTruncated = true;
+        d.skipFirstFrame = true;
+        d.verdictCategory = QStringLiteral("puckTruncated");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY(flags.pourTruncatedDetected);
+        QVERIFY(flags.skipFirstFrameDetected);
+        QVERIFY(!flags.channelingDetected);
+        QVERIFY(!flags.temperatureUnstable);
+        QVERIFY(!flags.grindIssueDetected);
+    }
+
+    void badgeProjection_sustainedChanneling_firesBadge()
+    {
+        ShotAnalysis::DetectorResults d;
+        d.channelingChecked = true;
+        d.channelingSeverity = QStringLiteral("sustained");
+        d.channelingSpikeTimeSec = 18.2;
+        d.verdictCategory = QStringLiteral("puckIntegrity");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY2(flags.channelingDetected,
+                 "Sustained channeling must fire the badge");
+    }
+
+    void badgeProjection_transientChanneling_doesNotFireBadge()
+    {
+        // Critical regression lock: Transient channeling shows in the dialog
+        // and in MCP detectorResults, but the boolean badge stays false.
+        // Matches PR #922's invariant. If this test ever fails alongside
+        // a "transient" severity in DetectorResults, the projection drifted.
+        ShotAnalysis::DetectorResults d;
+        d.channelingChecked = true;
+        d.channelingSeverity = QStringLiteral("transient");
+        d.channelingSpikeTimeSec = 8.4;
+        d.verdictCategory = QStringLiteral("minorIssues");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY2(!flags.channelingDetected,
+                 "Transient channeling must NOT fire the badge (PR #922 invariant)");
+    }
+
+    void badgeProjection_chokedPuck_firesGrindBadge()
+    {
+        ShotAnalysis::DetectorResults d;
+        d.grindChecked = true;
+        d.grindHasData = true;
+        d.grindChokedPuck = true;
+        d.grindDirection = QStringLiteral("chokedPuck");
+        d.verdictCategory = QStringLiteral("chokedPuck");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY(flags.grindIssueDetected);
+    }
+
+    void badgeProjection_yieldOvershoot_firesGrindBadge()
+    {
+        ShotAnalysis::DetectorResults d;
+        d.grindChecked = true;
+        d.grindHasData = true;
+        d.grindYieldOvershoot = true;
+        d.grindDirection = QStringLiteral("yieldOvershoot");
+        d.verdictCategory = QStringLiteral("yieldOvershoot");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY(flags.grindIssueDetected);
+    }
+
+    void badgeProjection_grindDeltaAboveThreshold_firesBadge()
+    {
+        ShotAnalysis::DetectorResults d;
+        d.grindChecked = true;
+        d.grindHasData = true;
+        d.grindFlowDeltaMlPerSec = ShotAnalysis::FLOW_DEVIATION_THRESHOLD + 0.1;
+        d.grindDirection = QStringLiteral("tooCoarse");
+        d.verdictCategory = QStringLiteral("minorIssuesGrindCoarse");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY2(flags.grindIssueDetected,
+                 "delta above FLOW_DEVIATION_THRESHOLD must fire the grind badge");
+    }
+
+    void badgeProjection_grindDeltaBelowThresholdNegative_firesBadge()
+    {
+        // Negative delta means flow ran below goal (grind too fine). The
+        // |delta| > threshold check uses absolute value.
+        ShotAnalysis::DetectorResults d;
+        d.grindChecked = true;
+        d.grindHasData = true;
+        d.grindFlowDeltaMlPerSec = -(ShotAnalysis::FLOW_DEVIATION_THRESHOLD + 0.1);
+        d.grindDirection = QStringLiteral("tooFine");
+        d.verdictCategory = QStringLiteral("minorIssuesGrindFine");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY2(flags.grindIssueDetected,
+                 "negative delta below threshold (|delta| > threshold) must fire the grind badge");
+    }
+
+    void badgeProjection_grindDeltaWithinTolerance_doesNotFireBadge()
+    {
+        ShotAnalysis::DetectorResults d;
+        d.grindChecked = true;
+        d.grindHasData = true;
+        d.grindFlowDeltaMlPerSec = 0.1;  // well within tolerance
+        d.grindDirection = QStringLiteral("onTarget");
+        d.verdictCategory = QStringLiteral("clean");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY2(!flags.grindIssueDetected,
+                 "delta within tolerance must NOT fire the grind badge");
+    }
+
+    void badgeProjection_grindNoData_doesNotFireBadge()
+    {
+        // hasData=false must short-circuit the grind projection — even if
+        // by some strange path one of the sub-flags is set, the badge stays
+        // false because the projection ANDs hasData with the OR of the arms.
+        ShotAnalysis::DetectorResults d;
+        d.grindChecked = true;
+        d.grindHasData = false;
+        d.grindChokedPuck = true;  // sub-flag set without hasData — defensive
+        d.grindFlowDeltaMlPerSec = 5.0;  // way above threshold
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY2(!flags.grindIssueDetected,
+                 "grind badge requires hasData=true (defensive against partial state)");
+    }
+
+    void badgeProjection_skipFirstFrame_firesBadge()
+    {
+        ShotAnalysis::DetectorResults d;
+        d.skipFirstFrame = true;
+        d.verdictCategory = QStringLiteral("skipFirstFrame");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY(flags.skipFirstFrameDetected);
+    }
+
+    void badgeProjection_tempUnstable_firesBadge()
+    {
+        // tempUnstable already encodes the gates inside analyzeShot
+        // (tempStabilityChecked && !tempIntentionalStepping && avgDev > threshold);
+        // the projection just reads the flag.
+        ShotAnalysis::DetectorResults d;
+        d.tempStabilityChecked = true;
+        d.tempIntentionalStepping = false;
+        d.tempAvgDeviationC = 3.0;
+        d.tempUnstable = true;
+        d.verdictCategory = QStringLiteral("minorIssues");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY(flags.temperatureUnstable);
+    }
+
+    void badgeProjection_tempIntentionalStepping_doesNotFireBadge()
+    {
+        // D-Flow style profile with intentional temp stepping: tempUnstable
+        // stays false even with a large measured deviation, because the
+        // gate is held inside analyzeShot. Locks in that the projection
+        // doesn't second-guess the struct.
+        ShotAnalysis::DetectorResults d;
+        d.tempStabilityChecked = true;
+        d.tempIntentionalStepping = true;
+        d.tempAvgDeviationC = 8.0;  // would normally trip threshold
+        d.tempUnstable = false;
+        d.verdictCategory = QStringLiteral("clean");
+
+        const auto flags = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY2(!flags.temperatureUnstable,
+                 "intentional temp stepping must NOT fire the temp badge");
+    }
+
+    void badgeProjection_applyBadgesToTarget_writesAllFiveFields()
+    {
+        // Compile-time + runtime check that the templated apply helper
+        // writes all five fields onto a target struct shape. Uses a local
+        // throwaway struct that mimics ShotSaveData / ShotRecord's badge
+        // surface — keeps this test independent of the storage TU layout.
+        struct FakeTarget {
+            bool pourTruncatedDetected = false;
+            bool channelingDetected = false;
+            bool temperatureUnstable = false;
+            bool grindIssueDetected = false;
+            bool skipFirstFrameDetected = false;
+        };
+        FakeTarget t;
+        ShotAnalysis::DetectorResults d;
+        d.pourTruncated = true;
+        d.skipFirstFrame = true;
+        d.channelingSeverity = QStringLiteral("sustained");
+        d.tempUnstable = true;
+        d.grindHasData = true;
+        d.grindChokedPuck = true;
+
+        decenza::applyBadgesToTarget(t, d);
+        QVERIFY(t.pourTruncatedDetected);
+        QVERIFY(t.channelingDetected);
+        QVERIFY(t.temperatureUnstable);
+        QVERIFY(t.grindIssueDetected);
+        QVERIFY(t.skipFirstFrameDetected);
     }
 };
 


### PR DESCRIPTION
Implements OpenSpec change [`unify-detector-cascade-save-load`](https://github.com/Kulitorum/Decenza/blob/f17dfbd1/openspec/changes/unify-detector-cascade-save-load/proposal.md). Third and largest of three follow-ups (A/B/C) from the parity audit on PR #933. Closes the cascade dedup loop — after this lands, the shot-quality cascade lives in exactly one place (`ShotAnalysis::analyzeShot`) and all consumers (badge columns, dialog, AI advisor, MCP `shots_get_detail`) share that one pipeline.

## Summary
- Add `src/history/shotbadgeprojection.h` — header-only `decenza::deriveBadgesFromAnalysis(DetectorResults)` and `decenza::applyBadgesToTarget(target, DetectorResults)`. Pure functions; testable directly.
- Replace the per-detector blocks in `saveShotData` (~85 lines) and `loadShotRecordStatic` (~70 lines) with a single `analyzeShot` call + projection. The cascade definition lives in exactly one place now.
- Extend `ShotAnalysis::analyzeShot` with an optional `expectedFrameCount` parameter so save/load can preserve their existing precision on `detectSkipFirstFrame`. Side benefit: closes a pre-existing precision divergence between save/load (precise) and the dialog/AI advisor (had hardcoded `-1`) — all consumers now use the more accurate behavior.
- 15 new table-driven projection tests in `tst_shotanalysis.cpp` lock in every cell of the mapping table including the load-bearing carve-outs (Transient channeling NOT firing the badge per PR #922's invariant; `hasData` defensive zero; intentional temp-stepping suppression).
- Document the badge ↔ `DetectorResults` mapping in `docs/SHOT_REVIEW.md` §4 with a full table, plus a §1 cascade-summary update pointing at the projection helper.

## Mapping
| Badge column | `DetectorResults` projection |
|---|---|
| `pourTruncatedDetected` | `d.pourTruncated` |
| `channelingDetected` | `d.channelingSeverity == \"sustained\"` (Transient does NOT fire) |
| `temperatureUnstable` | `d.tempUnstable` |
| `grindIssueDetected` | `d.grindHasData && (chokedPuck \|\| yieldOvershoot \|\| \|delta\| > FLOW_DEVIATION_THRESHOLD)` |
| `skipFirstFrameDetected` | `d.skipFirstFrame` |

## Why no A/B comparison phase
The original `design.md` called for one. Skipped because: (1) the per-detector code being replaced was a hand-rolled mirror of the same detector calls `analyzeShot` already makes; no behavioral logic lived only in the per-detector path; (2) the projection table is unit-tested table-driven (15 cases, one per row + carve-outs); (3) the `expectedFrameCount` extension closes the only meaningful pre-existing divergence. See `design.md` for the full reasoning.

## Test plan
- [x] Build clean (Qt Creator MCP, 0 errors / 0 warnings)
- [x] 1793 tests pass (1778 prior + 15 new badge projection cases)
- [x] `tst_shotanalysis::badgeProjection_*` (15 cases) — every row of the mapping table + carve-outs
- [x] `tst_shotsummarizer` and `tst_dbmigration` continue to pass — the save/load round-trip is exercised end-to-end via real `ShotRecord` flows
- [ ] Manual smoke (when reviewer is at the machine): pull a fresh shot, save it, reopen it. Badge state on the post-shot review page must match what the previous code produced for the same shot. Repeat on a few shots covering the corpus shapes (clean, choked, gusher, channeling, pour-truncated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)