### PR TITLE
docs(openspec): scaffold D/E/F follow-up proposals

### DIFF
--- a/openspec/changes/cache-analyzeshot-on-shotrecord/proposal.md
+++ b/openspec/changes/cache-analyzeshot-on-shotrecord/proposal.md
@@ -1,0 +1,24 @@
+# Change: Cache `analyzeShot` output on `ShotRecord` to eliminate the dual detail-load pass
+
+## Why
+
+`ShotHistoryStorage::loadShotRecordStatic` runs `ShotAnalysis::analyzeShot` once to recompute the badge boolean columns. Then `ShotHistoryStorage::convertShotRecord` (called immediately after, on the same `ShotRecord`, with the same inputs) runs `analyzeShot` *again* to populate `summaryLines` and the structured `detectorResults` JSON for MCP / dialog consumers. Two full detector passes per shot detail load on byte-identical inputs.
+
+The post-`unify-detector-cascade-save-load` design.md flagged this as the natural next step: "A future change can elevate `analyzeShot`'s output into `ShotRecord` so a single pipe through both functions reuses one pass." This is that change.
+
+The win is twofold: (1) detector work cuts in half on every shot detail load (the dominant CPU path on the post-shot review and history-detail pages), and (2) it eliminates one more "do the two `analyzeShot` calls agree?" contract — the answer becomes "they're literally the same call" by construction.
+
+## What Changes
+
+- **ADD** an optional `std::optional<ShotAnalysis::AnalysisResult> analysis` member on `ShotRecord` (or a small side struct cached alongside it). Populated by `loadShotRecordStatic` after the badge projection runs; consumed by `convertShotRecord` if present, otherwise `convertShotRecord` falls back to running `analyzeShot` itself.
+- **MODIFY** `loadShotRecordStatic` so it stashes the `AnalysisResult` it just computed into the field before returning.
+- **MODIFY** `convertShotRecord` to read from the cached field when present and skip the second `analyzeShot` call. When absent (e.g. callers that bypass `loadShotRecordStatic` and construct `ShotRecord` directly — `ShotHistoryExporter`, tests), fall back to the existing inline `analyzeShot` call so behavior stays correct end-to-end.
+- **NO change** to `analyzeShot`'s signature, the badge projection, the prose lines, or the JSON shape exposed via MCP. Pure caller-side dedup.
+
+## Impact
+
+- Affected specs: `shot-analysis-pipeline` — new requirement: shot detail loads SHALL run `analyzeShot` exactly once, with the result reused across the badge-recompute and the convert-to-QVariantMap stages.
+- Affected code: `src/history/shothistory_types.h` (new field), `src/history/shothistorystorage.cpp` (`loadShotRecordStatic` writes; `convertShotRecord` reads-or-fallbacks), tests covering the cached vs. fallback paths.
+- User-visible behavior: identical. Same prose lines, same badges, same MCP JSON. The cache hit is invisible.
+- Performance: ~50% reduction in detector CPU on the shot-detail-load path. Bounded but real on shots with long curves.
+- Risk surface: the cache must be invalidated if any input changes between `loadShotRecordStatic` and `convertShotRecord`. They run sequentially in `requestShot` with no mutation in between, so this is structurally safe today, but the new field's lifecycle should be documented to avoid future bugs (e.g. callers that mutate `ShotRecord.pressure` after load and expect `convertShotRecord` to reflect the change).

--- a/openspec/changes/cache-analyzeshot-on-shotrecord/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/changes/cache-analyzeshot-on-shotrecord/specs/shot-analysis-pipeline/spec.md
@@ -1,0 +1,33 @@
+# shot-analysis-pipeline
+
+## ADDED Requirements
+
+### Requirement: Shot detail loads SHALL run `analyzeShot` exactly once
+
+When a shot is loaded via `ShotHistoryStorage::loadShotRecordStatic` and immediately serialized via `ShotHistoryStorage::convertShotRecord` (the canonical detail-load path), the application SHALL invoke `ShotAnalysis::analyzeShot` exactly once for that shot. The `AnalysisResult` produced by `loadShotRecordStatic`'s recompute SHALL be cached on the returned `ShotRecord` (via an optional field), and `convertShotRecord` SHALL read from that cache when present instead of running `analyzeShot` a second time.
+
+When `convertShotRecord` is called on a `ShotRecord` that was NOT produced by `loadShotRecordStatic` — direct construction in `ShotHistoryExporter`, in tests, or any other path that bypasses the load helper — the cache MAY be absent. In that case, `convertShotRecord` SHALL fall back to running `analyzeShot` inline so behavior remains correct end-to-end.
+
+The cached `AnalysisResult` SHALL be invalidated (cleared / reset) if any input curve on the `ShotRecord` is mutated after load. Today no caller mutates `ShotRecord` between `loadShotRecordStatic` and `convertShotRecord`, but the field's docstring SHALL document this invariant so future callers don't introduce a stale-cache bug.
+
+`analyzeShot`'s signature, the badge column projection (`decenza::applyBadgesToTarget`), the prose `summaryLines`, and the structured `detectorResults` JSON SHALL all be unchanged. This is a pure caller-side dedup.
+
+#### Scenario: Standard detail-load path runs analyzeShot once
+
+- **GIVEN** a shot record loaded via `loadShotRecordStatic`
+- **WHEN** the same `ShotRecord` is then passed to `convertShotRecord`
+- **THEN** `loadShotRecordStatic` SHALL have populated `record.cachedAnalysis` with the `AnalysisResult` it computed
+- **AND** `convertShotRecord` SHALL read `summaryLines` and `detectorResults` from the cached struct without invoking `ShotAnalysis::analyzeShot` itself
+
+#### Scenario: Direct-construction caller falls back to inline analyzeShot
+
+- **GIVEN** a `ShotRecord` constructed directly (e.g. `ShotHistoryExporter`) without `cachedAnalysis`
+- **WHEN** `convertShotRecord(record)` is invoked
+- **THEN** `convertShotRecord` SHALL invoke `ShotAnalysis::analyzeShot` inline
+- **AND** the resulting `summaryLines` and `detectorResults` SHALL be identical to what the cached path would produce for the same input
+
+#### Scenario: Cached and fallback paths produce equivalent output
+
+- **GIVEN** two equivalent `ShotRecord`s for the same shot, `A` with `cachedAnalysis` populated and `B` without
+- **WHEN** `convertShotRecord(A)` and `convertShotRecord(B)` are both invoked
+- **THEN** the resulting QVariantMap's `summaryLines`, `detectorResults`, and all five badge boolean fields SHALL be byte-equal across the two calls

--- a/openspec/changes/cache-analyzeshot-on-shotrecord/tasks.md
+++ b/openspec/changes/cache-analyzeshot-on-shotrecord/tasks.md
@@ -1,0 +1,35 @@
+# Tasks
+
+## 1. Cache field on ShotRecord
+
+- [ ] 1.1 Add `std::optional<ShotAnalysis::AnalysisResult> cachedAnalysis;` to `ShotRecord` in `src/history/shothistory_types.h`. Document that it is populated by `loadShotRecordStatic` after the badge projection and consumed by `convertShotRecord`; reset to `std::nullopt` if any of the input curves are mutated after load.
+- [ ] 1.2 Confirm `<optional>` is included (or add to the header). `ShotAnalysis::AnalysisResult` is already public.
+
+## 2. Populate from loadShotRecordStatic
+
+- [ ] 2.1 In `loadShotRecordStatic`, after `decenza::applyBadgesToTarget(record, analysis.detectors);`, also `record.cachedAnalysis = std::move(analysis);` so the result survives the function return.
+- [ ] 2.2 Verify the lazy-persist write-back block (which only reads the projected booleans) still works correctly — it does, since `applyBadgesToTarget` already wrote the booleans onto `record`.
+
+## 3. Consume in convertShotRecord
+
+- [ ] 3.1 In `convertShotRecord`, gate the existing `analyzeShot` block on `record.cachedAnalysis.has_value()`:
+  - If present: read `summaryLines` and `detectorResults` from the cached struct.
+  - If absent: run `analyzeShot` inline as today (covers `ShotHistoryExporter`, direct test callers, etc. that didn't go through `loadShotRecordStatic`).
+- [ ] 3.2 Keep the surrounding `analysisFlags` / `frameInfo` extraction inside the fallback branch — the cached path doesn't need them.
+
+## 4. Tests
+
+- [ ] 4.1 Extend an existing `loadShotRecordStatic` round-trip test (or add one to a new `tst_shothistorystorage_cache.cpp`) that asserts `record.cachedAnalysis.has_value()` after load and that `convertShotRecord(record)["summaryLines"]` equals `cachedAnalysis->lines`.
+- [ ] 4.2 Add a fallback-path test: construct a `ShotRecord` directly (without `cachedAnalysis`), pass to `convertShotRecord`, assert `summaryLines` and `detectorResults` are still populated and identical to a fresh `analyzeShot` call. Locks in the legacy direct-construction path.
+- [ ] 4.3 Add an equivalence test: same shot data through both paths produces byte-equal `summaryLines` and `detectorResults`. Catches drift if either path is modified in isolation.
+
+## 5. Verify
+
+- [ ] 5.1 Build clean (Qt Creator MCP).
+- [ ] 5.2 All existing tests pass (currently 1793; this change should add 3, target 1796).
+- [ ] 5.3 Manual smoke: open a few shots from history, watch a profiler / log to confirm `analyzeShot` is invoked once per detail load, not twice.
+
+## 6. Documentation
+
+- [ ] 6.1 Update `docs/SHOT_REVIEW.md` §3 to note that `convertShotRecord` reads from `record.cachedAnalysis` when populated by `loadShotRecordStatic`, falling back to its own `analyzeShot` call only for direct-construction callers.
+- [ ] 6.2 Document the cache invalidation rule in the new field's docstring.

--- a/openspec/changes/remove-generateshotsummary-bridge/proposal.md
+++ b/openspec/changes/remove-generateshotsummary-bridge/proposal.md
@@ -1,0 +1,37 @@
+# Change: Remove `ShotHistoryStorage::generateShotSummary` Q_INVOKABLE
+
+## Why
+
+`ShotHistoryStorage::generateShotSummary(QVariantMap shotData)` is a Q_INVOKABLE bridge that converts a serialized shot back into typed inputs and runs `ShotAnalysis::generateSummary`. Before PR #934 (dialog dedup), it was the canonical path the in-app Shot Summary dialog took to compute prose lines.
+
+Post-#934, the dialog reads `shotData.summaryLines` directly from `ShotHistoryStorage::convertShotRecord`'s output. `generateShotSummary` is now only the *fallback* path the dialog hits when `summaryLines` is missing — a case that doesn't occur in production because every QVariantMap reaching the dialog flows through `convertShotRecord`, which always populates `summaryLines` (post-#933).
+
+Keeping a Q_INVOKABLE that has no live callers and no documented preconditions for "when is the fallback hit?" is implicit-drift surface: the bridge does its own `profileFrameInfoFromJson` parse, its own `getAnalysisFlags` lookup, and reconstructs `QList<HistoryPhaseMarker>` from the `QVariantMap` — three independent reconstruction paths that could subtly diverge from `convertShotRecord`'s.
+
+This change deletes the Q_INVOKABLE and simplifies the dialog binding to drop the fallback. If someone in the future legitimately needs to convert a serialized shot back to prose lines without going through `convertShotRecord`, they should add a more explicit helper at that time, not lean on a vestigial bridge.
+
+## What Changes
+
+- **REMOVE** `ShotHistoryStorage::generateShotSummary(const QVariantMap&)` from both the header and implementation.
+- **MODIFY** `qml/components/ShotAnalysisDialog.qml` `analysisLines` binding to drop the fallback branch:
+  ```qml
+  property var analysisLines: {
+      if (!analysisDialog.visible) return []
+      return Array.isArray(shotData?.summaryLines) ? shotData.summaryLines : []
+  }
+  ```
+  Empty-fallback (`[]`) preserves dialog correctness for the (now hypothetical) case where `shotData.summaryLines` is absent — the dialog renders a "Shot Summary" header with no observation lines, which is correct for a shot the analyzer couldn't process. Better than rendering wrong prose from a parallel reconstruction path.
+- **REMOVE** the corresponding test cases in `tst_shotanalysis.cpp` / `tst_shotsummarizer.cpp` that exercised the QVariantMap-roundtrip path through `generateShotSummary`. The remaining `analyzeShot` and `convertShotRecord` tests already cover the canonical pipeline.
+- **NO change** to `analyzeShot`, `convertShotRecord`, the badge projection, or the AI advisor's `summarizeFromHistory` path.
+
+## Impact
+
+- Affected specs: `shot-analysis-pipeline` — REMOVED requirement: the `generateShotSummary` Q_INVOKABLE bridge no longer exists; the dialog SHALL read `shotData.summaryLines` directly with an empty fallback.
+- Affected code: `src/history/shothistorystorage.{h,cpp}` (deletion), `qml/components/ShotAnalysisDialog.qml` (drop fallback branch), tests covering the deleted function.
+- User-visible behavior: identical for shots that flow through `convertShotRecord` (i.e. all production shots). Hypothetical legacy shots with empty `summaryLines` will see an empty dialog body instead of recomputed prose — preferable to risking divergent output.
+- Risk surface: low. Confirmed via `grep` that the only caller is `ShotAnalysisDialog.qml`'s fallback. If a third caller emerges during the change, surface it explicitly and consider keeping the bridge.
+
+## Out of scope
+
+- The fallback-empty case could optionally show a "couldn't analyze this shot" message instead of an empty body. UX decision; defer to a separate UI follow-up if anyone wants it.
+- `ShotAnalysis::generateSummary` (the `analyzeShot(...).lines` wrapper) is independent and stays. It's still used by `ShotSummarizer` and the slow path of `summarizeFromHistory`.

--- a/openspec/changes/remove-generateshotsummary-bridge/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/changes/remove-generateshotsummary-bridge/specs/shot-analysis-pipeline/spec.md
@@ -1,0 +1,37 @@
+# shot-analysis-pipeline
+
+## REMOVED Requirements
+
+### Requirement: ~~`ShotHistoryStorage::generateShotSummary` Q_INVOKABLE bridge~~
+
+**Reason for removal:** Post `dedup-shot-summary-dialog` (PR #934) the in-app Shot Summary dialog reads `shotData.summaryLines` directly from `convertShotRecord`'s output. The Q_INVOKABLE bridge `ShotHistoryStorage::generateShotSummary` is now only the dialog's *fallback* path, hit only when `shotData.summaryLines` is missing — a case that doesn't occur in production because every QVariantMap reaching the dialog flows through `convertShotRecord` (which always populates `summaryLines` post-PR #933).
+
+The bridge has no live production callers and represents implicit-drift surface: it does its own `profileFrameInfoFromJson` parse, its own `getAnalysisFlags` lookup, and reconstructs `QList<HistoryPhaseMarker>` from the QVariantMap — three reconstruction paths that could subtly diverge from `convertShotRecord`'s.
+
+**Migration:** External callers that need to convert a serialized shot back to prose lines should:
+1. Load the shot via `ShotHistoryStorage::requestShot` and let `convertShotRecord` populate `summaryLines` on the resulting QVariantMap, OR
+2. Construct a `ShotRecord`, call `ShotAnalysis::analyzeShot` directly, and read `.lines` from the result.
+
+The `ShotAnalysis::generateSummary` static method (the `analyzeShot(...).lines` wrapper) is unaffected and remains available for callers that have raw curve data.
+
+## ADDED Requirements
+
+### Requirement: Shot Summary dialog SHALL render `shotData.summaryLines` with an empty fallback
+
+After the bridge is removed, `ShotAnalysisDialog.qml` SHALL bind its `analysisLines` property to `shotData.summaryLines` directly when present, falling back to an empty list `[]` when absent. The dialog SHALL NOT invoke any C++ helper that recomputes prose from a serialized shot — the canonical computation site is `convertShotRecord`'s `analyzeShot` pass.
+
+When `shotData.summaryLines` is absent (a hypothetical edge case for shots that didn't flow through `convertShotRecord`), the dialog SHALL render its "Shot Summary" header with no observation lines, rather than risk a divergent reconstruction. This is preferable UX to risking subtly wrong prose; if a future product decision needs a "couldn't analyze this shot" message, it can be added at the dialog level without resurrecting the bridge.
+
+#### Scenario: Modern shotData renders directly
+
+- **GIVEN** a shotData QVariantMap produced by `convertShotRecord`, with `summaryLines` populated
+- **WHEN** the user opens the Shot Summary dialog
+- **THEN** the dialog SHALL render the prose lines from `shotData.summaryLines` directly
+- **AND** the dialog SHALL NOT invoke any Q_INVOKABLE method on `ShotHistoryStorage`
+
+#### Scenario: shotData without summaryLines renders empty
+
+- **GIVEN** a shotData QVariantMap whose `summaryLines` field is absent or not a non-empty list
+- **WHEN** the user opens the Shot Summary dialog
+- **THEN** the dialog SHALL render its "Shot Summary" header with no observation lines
+- **AND** the dialog SHALL NOT crash, fall back to recomputation, or display unrelated content

--- a/openspec/changes/remove-generateshotsummary-bridge/tasks.md
+++ b/openspec/changes/remove-generateshotsummary-bridge/tasks.md
@@ -1,0 +1,37 @@
+# Tasks
+
+## 1. Verify no other callers exist
+
+- [ ] 1.1 `git grep -n "generateShotSummary" src/ qml/` — confirm the only QML caller is `ShotAnalysisDialog.qml`'s fallback branch and the only C++ references are the declaration / definition / test cases. If any other caller surfaces, surface it explicitly and reconsider.
+
+## 2. Delete the Q_INVOKABLE
+
+- [ ] 2.1 Remove `Q_INVOKABLE QVariantList generateShotSummary(const QVariantMap&) const;` from `src/history/shothistorystorage.h`.
+- [ ] 2.2 Remove the `ShotHistoryStorage::generateShotSummary` definition from `src/history/shothistorystorage.cpp`.
+
+## 3. Simplify dialog binding
+
+- [ ] 3.1 In `qml/components/ShotAnalysisDialog.qml`, replace the multi-branch `analysisLines` property with the simpler:
+  ```qml
+  property var analysisLines: {
+      if (!analysisDialog.visible) return []
+      return Array.isArray(shotData?.summaryLines) ? shotData.summaryLines : []
+  }
+  ```
+- [ ] 3.2 Remove the multi-line comment block above the property — the simplified binding is self-explanatory.
+
+## 4. Tests
+
+- [ ] 4.1 Remove any tests in `tst_shotanalysis.cpp` or `tst_shotsummarizer.cpp` that exercised the `QVariantMap`-roundtrip path through `generateShotSummary`. Verify nothing else implicitly depended on the bridge.
+- [ ] 4.2 Confirm remaining tests still cover the canonical pipeline (`tst_shotanalysis::analyzeShot_*`, `tst_shotanalysis::badgeProjection_*`, `tst_shotsummarizer::*`).
+
+## 5. Verify
+
+- [ ] 5.1 Build clean (Qt Creator MCP).
+- [ ] 5.2 All tests pass.
+- [ ] 5.3 Manual smoke: open the Shot Summary dialog on a few shots — should render lines identically to pre-change behavior. Open one shot whose `shotData.summaryLines` happens to be empty (if such a shot exists in the test corpus) and confirm the dialog renders a "Shot Summary" header with no body, not a crash.
+
+## 6. Documentation
+
+- [ ] 6.1 Update `docs/SHOT_REVIEW.md` §3 to drop references to `generateShotSummary` as the bridge function. Replace with: "The dialog reads `shotData.summaryLines` directly from `convertShotRecord`'s output."
+- [ ] 6.2 Remove the stale "matches `ShotHistoryStorage::generateShotSummary`'s input for the dialog" reference in `src/ai/shotsummarizer.cpp` (if still present after #935 — verify).

--- a/openspec/changes/simplify-analysis-input-prep/proposal.md
+++ b/openspec/changes/simplify-analysis-input-prep/proposal.md
@@ -1,0 +1,29 @@
+# Change: Consolidate analyzeShot input preparation into a small helper
+
+## Why
+
+Three call sites of `ShotAnalysis::analyzeShot` (`saveShotData`, `loadShotRecordStatic`, `convertShotRecord`) each independently look up the same two helper values for the same shot:
+
+- `ShotSummarizer::getAnalysisFlags(profileKbId)` — reads from a static-cached profile knowledge map
+- `profileFrameInfoFromJson(profileJson)` — parses the profile JSON to extract `firstFrameSeconds` and `frameCount`
+
+Each call site has its own four-line inline preparation block. The lookups are independently cheap, but the duplication means any future addition to `analyzeShot`'s required inputs (e.g. a new `analysisFlags` flag, a new `ProfileFrameInfo` field) needs to be added in three places — exactly the kind of "you have to update N call sites identically" invariant the cascade-unification work was trying to eliminate.
+
+This change folds the preparation into a single `decenza::AnalysisInputs prepareAnalysisInputs(const ShotRecord&)` (or equivalent for the save-time `ShotSaveData` shape) so call sites become one line each, and adding a new input field is a one-place change.
+
+Same scope: stale comment in `tst_shotsummarizer.cpp`'s file-level header still references "the same call ShotHistoryStorage::generateShotSummary makes for the dialog" (post-`#933` and `#936` the canonical path is `analyzeShot`). Easy to update alongside the helper introduction.
+
+## What Changes
+
+- **ADD** `decenza::AnalysisInputs` struct (in `src/history/shotanalysisinputs.h` or similar) with fields for the analysis flags + frame info + first-frame seconds. Also export `prepareAnalysisInputs(const ShotRecord&)` and `prepareAnalysisInputs(const ShotSaveData&)` overloads (or one templated helper).
+- **MODIFY** the three call sites in `shothistorystorage.cpp` to use the helper instead of inline lookups. Reduces ~12 lines to ~3 each.
+- **UPDATE** the file-level header comment in `tests/tst_shotsummarizer.cpp` (lines 1-13) to reflect the post-#933 canonical pipeline.
+- **NO change** to behavior — the helper just consolidates lookups that were already happening per call site.
+
+## Impact
+
+- Affected specs: `shot-analysis-pipeline` — new requirement: analyzeShot input preparation lives in exactly one helper.
+- Affected code: `src/history/shotanalysisinputs.h` (new), `src/history/shothistorystorage.cpp` (three call sites simplified), `tests/tst_shotsummarizer.cpp` (header comment).
+- User-visible behavior: identical.
+- Performance: identical (the lookups are unchanged, just consolidated).
+- Risk: low. Pure refactor with no behavior change. Both saved and loaded `ShotRecord` shapes already have `profileKbId` and `profileJson` fields; the helper just reads those.

--- a/openspec/changes/simplify-analysis-input-prep/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/changes/simplify-analysis-input-prep/specs/shot-analysis-pipeline/spec.md
@@ -1,0 +1,27 @@
+# shot-analysis-pipeline
+
+## ADDED Requirements
+
+### Requirement: `analyzeShot` input preparation SHALL live in exactly one helper
+
+The two helper lookups required to populate `analyzeShot`'s arguments — `ShotSummarizer::getAnalysisFlags(profileKbId)` and `profileFrameInfoFromJson(profileJson)` — SHALL be consolidated into a single `decenza::prepareAnalysisInputs` helper (declared in `src/history/shotanalysisinputs.h`). The helper SHALL accept any `ShotRecord`-shaped or `ShotSaveData`-shaped source that exposes `profileKbId` and `profileJson` fields, and return a typed `AnalysisInputs` struct containing the `analysisFlags`, `firstFrameSeconds`, and `frameCount` values.
+
+The three storage-layer `analyzeShot` call sites (`saveShotData`, `loadShotRecordStatic`, `convertShotRecord`) SHALL each invoke `prepareAnalysisInputs` once and pass the resulting fields into `analyzeShot`. None of them SHALL retain inline calls to `getAnalysisFlags` or `profileFrameInfoFromJson` for the purpose of building `analyzeShot` arguments.
+
+`analyzeShot`'s signature, the badge column projection, the prose `summaryLines`, and the structured `detectorResults` JSON SHALL all remain unchanged. This is a pure refactor.
+
+A future addition to `analyzeShot`'s required inputs (e.g. a new `analysisFlags` flag, a new `ProfileFrameInfo` field) SHALL be made by extending `AnalysisInputs` and `prepareAnalysisInputs` once, with the three call sites picking up the new field automatically.
+
+#### Scenario: Save-time call site uses the helper
+
+- **GIVEN** a `ShotSaveData` with populated `profileKbId` and `profileJson`
+- **WHEN** `saveShotData` reaches the `analyzeShot` call
+- **THEN** `saveShotData` SHALL invoke `decenza::prepareAnalysisInputs(data)` exactly once
+- **AND** SHALL pass `inputs.analysisFlags`, `inputs.firstFrameSeconds`, and `inputs.frameCount` into `analyzeShot`
+- **AND** SHALL NOT have any inline `getAnalysisFlags` or `profileFrameInfoFromJson` call remaining
+
+#### Scenario: All three storage call sites produce equivalent inputs
+
+- **GIVEN** the same shot's data exposed via three lenses (the live `ShotSaveData` at save time, the loaded `ShotRecord` at load time, the same `ShotRecord` passed through `convertShotRecord`)
+- **WHEN** `prepareAnalysisInputs` is invoked in each
+- **THEN** the resulting `AnalysisInputs` SHALL be byte-equal across all three calls (same `analysisFlags`, same `firstFrameSeconds`, same `frameCount`)

--- a/openspec/changes/simplify-analysis-input-prep/tasks.md
+++ b/openspec/changes/simplify-analysis-input-prep/tasks.md
@@ -1,0 +1,28 @@
+# Tasks
+
+## 1. Helper
+
+- [ ] 1.1 Add `src/history/shotanalysisinputs.h` (header-only, namespace `decenza`) declaring `struct AnalysisInputs { QStringList analysisFlags; double firstFrameSeconds; int frameCount; };` plus a templated `inline AnalysisInputs prepareAnalysisInputs(const T& source)` that reads `source.profileKbId` and `source.profileJson` and assembles the struct via the existing helpers.
+- [ ] 1.2 The template MUST be header-only so unit tests can include it without linking the storage TU.
+
+## 2. Use the helper in storage call sites
+
+- [ ] 2.1 Replace the inline preparation block in `saveShotData` with `const auto inputs = decenza::prepareAnalysisInputs(data);` and pass `inputs.analysisFlags`, `inputs.firstFrameSeconds`, `inputs.frameCount` into `analyzeShot`.
+- [ ] 2.2 Same for `loadShotRecordStatic` (reads from `record`).
+- [ ] 2.3 Same for `convertShotRecord` (reads from `record`).
+- [ ] 2.4 Confirm the existing `firstFrameSec`-vs-`firstFrameSeconds` naming mismatch between save and load resolves consistently (rename whichever is inconsistent).
+
+## 3. Tests
+
+- [ ] 3.1 Add a unit test in `tst_shotanalysis.cpp` (or new file) that exercises `prepareAnalysisInputs` on a synthetic `ShotRecord` and asserts the three output fields match what direct calls to `getAnalysisFlags` and `profileFrameInfoFromJson` would produce.
+- [ ] 3.2 Add a regression test that all three call sites (save, load, convert) produce equivalent inputs for the same shot — locks in that the helper's invocation contract doesn't drift across sites.
+
+## 4. Cleanup tst_shotsummarizer.cpp header
+
+- [ ] 4.1 Update the file-level header comment in `tests/tst_shotsummarizer.cpp` (lines 1-13) to reference `analyzeShot` as the canonical pipeline entry point (post-#933) and `convertShotRecord`'s pre-population of `summaryLines` as the dedup mechanism (post-#935). The current text references "ShotHistoryStorage::generateShotSummary" and "the same call" patterns that pre-date the unification.
+
+## 5. Verify
+
+- [ ] 5.1 Build clean (Qt Creator MCP).
+- [ ] 5.2 All existing tests pass.
+- [ ] 5.3 Spot-check that the three call sites produce identical `analyzeShot` arguments for the same shot (via debug log or unit-test assertion).


### PR DESCRIPTION
Three follow-up OpenSpec proposals identified after A/B/C landed (PRs #934/#935/#936). Each is a proposal awaiting approval; implementation deferred.

## D — \`cache-analyzeshot-on-shotrecord\`
Eliminate the dual \`analyzeShot\` pass per shot detail load by caching the \`AnalysisResult\` on \`ShotRecord\`. \`loadShotRecordStatic\` populates it; \`convertShotRecord\` reads it (with inline-fallback for direct-construction callers). Halves detector CPU per detail load and turns "do the two calls agree?" into a non-question. Highest-value follow-up.

## E — \`simplify-analysis-input-prep\`
Consolidate the three independent \`getAnalysisFlags\` + \`profileFrameInfoFromJson\` lookups (one each in \`saveShotData\`, \`loadShotRecordStatic\`, \`convertShotRecord\`) into a single \`decenza::prepareAnalysisInputs\` helper. Pure refactor; future additions to \`analyzeShot\` inputs become a one-place change. Also updates the stale file-level header in \`tst_shotsummarizer.cpp\`.

## F — \`remove-generateshotsummary-bridge\`
Delete the now-vestigial \`ShotHistoryStorage::generateShotSummary\` Q_INVOKABLE. Post-#934 the dialog reads \`summaryLines\` directly from \`convertShotRecord\`; the bridge is only a fallback that never triggers in production and represents implicit-drift surface (independent JSON parse, separate \`getAnalysisFlags\` call, separate phase-marker reconstruction). Migration: external callers convert via \`requestShot\` or \`analyzeShot\` directly.

## Recommended order
1. **D** first — biggest CPU + structural win, low risk.
2. **F** next — eliminates a real implicit-drift surface; depends on grep confirming no remaining QML callers.
3. **E** last — trivial cleanup; nice-to-have, not load-bearing.

## Test plan
- [x] All three pass \`openspec validate --strict --no-interactive\`.
- Implementation per proposal will follow once approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)