### PR TITLE
fix(history): move exported shot history dir out of profiles/ subdirectory

### DIFF
--- a/src/core/profilestorage.cpp
+++ b/src/core/profilestorage.cpp
@@ -27,7 +27,8 @@ ProfileStorage::ProfileStorage(QObject* parent)
         migrateProfilesToExternal();
     }
 
-    // One-time migration: history dir was incorrectly nested inside profiles/
+    // One-time migration: history dir was incorrectly nested inside profiles/ on desktop.
+    // No-op on Android with external storage (history was never written to AppDataLocation there).
     migrateHistoryToNewPath();
 }
 
@@ -126,7 +127,10 @@ QString ProfileStorage::downloadedProfilesPath() const {
 }
 
 QString ProfileStorage::userHistoryPath() const {
-    QString basePath = externalProfilesPath(); // non-empty only on Android
+    // Use externalProfilesPath only when storage permission is confirmed — unlike other
+    // path methods, the fallback here is AppDataLocation (not fallbackPath/profiles/) so
+    // that history lands alongside profiles/ rather than inside it.
+    QString basePath = isConfigured() ? externalProfilesPath() : QString();
     if (basePath.isEmpty()) {
         basePath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     }
@@ -139,7 +143,7 @@ QString ProfileStorage::userHistoryPath() const {
 }
 
 QString ProfileStorage::userHistoryPathIfExists() const {
-    QString basePath = externalProfilesPath(); // non-empty only on Android
+    QString basePath = isConfigured() ? externalProfilesPath() : QString();
     if (basePath.isEmpty()) {
         basePath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     }
@@ -155,6 +159,21 @@ void ProfileStorage::migrateHistoryToNewPath()
 
     QDir oldDir(oldPath);
     if (!oldDir.exists()) return;
+
+    if (QDir(newPath).exists()) {
+        // newPath exists: a prior migration ran or files were already written to the correct
+        // location. Move any remaining files individually (skipping conflicts) then clean up.
+        const QStringList files = oldDir.entryList(QDir::Files);
+        for (const QString& name : files) {
+            const QString dst = newPath + "/" + name;
+            if (!QFile::exists(dst)) {
+                QFile::rename(oldPath + "/" + name, dst);
+            }
+        }
+        QDir(oldPath).removeRecursively();
+        qDebug() << "[ProfileStorage] Cleaned up stale history directory" << oldPath;
+        return;
+    }
 
     if (!QDir().rename(oldPath, newPath)) {
         qWarning() << "[ProfileStorage] Failed to migrate history directory from"

--- a/src/core/profilestorage.cpp
+++ b/src/core/profilestorage.cpp
@@ -26,6 +26,9 @@ ProfileStorage::ProfileStorage(QObject* parent)
     if (isConfigured()) {
         migrateProfilesToExternal();
     }
+
+    // One-time migration: history dir was incorrectly nested inside profiles/
+    migrateHistoryToNewPath();
 }
 
 bool ProfileStorage::isConfigured() const {
@@ -123,9 +126,9 @@ QString ProfileStorage::downloadedProfilesPath() const {
 }
 
 QString ProfileStorage::userHistoryPath() const {
-    QString basePath = isConfigured() ? externalProfilesPath() : fallbackPath();
+    QString basePath = externalProfilesPath(); // non-empty only on Android
     if (basePath.isEmpty()) {
-        basePath = fallbackPath();
+        basePath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     }
     QString path = basePath + "/history";
     QDir dir(path);
@@ -136,12 +139,29 @@ QString ProfileStorage::userHistoryPath() const {
 }
 
 QString ProfileStorage::userHistoryPathIfExists() const {
-    QString basePath = isConfigured() ? externalProfilesPath() : fallbackPath();
+    QString basePath = externalProfilesPath(); // non-empty only on Android
     if (basePath.isEmpty()) {
-        basePath = fallbackPath();
+        basePath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     }
     QString path = basePath + "/history";
     return QDir(path).exists() ? path : QString();
+}
+
+void ProfileStorage::migrateHistoryToNewPath()
+{
+    const QString appData = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    const QString oldPath = appData + "/profiles/history";
+    const QString newPath = appData + "/history";
+
+    QDir oldDir(oldPath);
+    if (!oldDir.exists()) return;
+
+    if (!QDir().rename(oldPath, newPath)) {
+        qWarning() << "[ProfileStorage] Failed to migrate history directory from"
+                   << oldPath << "to" << newPath;
+        return;
+    }
+    qDebug() << "[ProfileStorage] Migrated history from" << oldPath << "to" << newPath;
 }
 
 QStringList ProfileStorage::listProfiles() const {

--- a/src/core/profilestorage.h
+++ b/src/core/profilestorage.h
@@ -70,6 +70,9 @@ public:
     // Migrate profiles from internal to external storage (call after permission granted)
     Q_INVOKABLE void migrateProfilesToExternal();
 
+    // One-time migration: moves history dir from inside profiles/ to a sibling location
+    void migrateHistoryToNewPath();
+
 signals:
     void configuredChanged();
     void folderSelected(bool success);

--- a/src/core/profilestorage.h
+++ b/src/core/profilestorage.h
@@ -58,8 +58,9 @@ public:
     // Get the downloaded profiles path (for profiles imported from Visualizer)
     QString downloadedProfilesPath() const;
 
-    // Get the user history path (sibling of the user profiles folder) for shot export.
-    // Creates the directory if it doesn't already exist.
+    // Get the path for shot history exports. On Android with storage permission it is
+    // a sibling of user/ under Documents/Decenza; on other platforms it is a sibling
+    // of profiles/ under AppDataLocation. Creates the directory if it doesn't already exist.
     QString userHistoryPath() const;
 
     // Like userHistoryPath(), but returns an empty string instead of creating the
@@ -70,13 +71,16 @@ public:
     // Migrate profiles from internal to external storage (call after permission granted)
     Q_INVOKABLE void migrateProfilesToExternal();
 
-    // One-time migration: moves history dir from inside profiles/ to a sibling location
-    void migrateHistoryToNewPath();
-
 signals:
     void configuredChanged();
     void folderSelected(bool success);
 
 private:
     bool m_setupSkipped = false;
+
+    // Moves history dir from AppDataLocation/profiles/history → AppDataLocation/history.
+    // Safe to call every startup — no-ops when the old path is absent (idempotent by design,
+    // no guard flag needed). Desktop-only: on Android with external storage the old broken
+    // path never existed under AppDataLocation.
+    void migrateHistoryToNewPath();
 };


### PR DESCRIPTION
## Summary

- `userHistoryPath()` and `userHistoryPathIfExists()` were computing their base from `fallbackPath()` (`AppDataLocation/profiles`), so exported JSON shot history files landed at `…/profiles/history` instead of `…/history` (a sibling of `profiles/`, not nested inside it)
- Fix uses `AppDataLocation` directly on Mac, Windows, Linux, and iOS; Android (which uses `externalProfilesPath()` → `Documents/Decenza/`) was already correct
- Adds a one-time startup migration that renames the old `profiles/history` directory into the correct location using `QDir::rename()` (atomic on the same filesystem); no-op if the old directory doesn't exist

## Test plan

- [ ] Build and run on Mac
- [ ] Enable "Export shots to file" in settings
- [ ] Confirm exported files appear at `~/Library/Application Support/DecentEspresso/Decenza/history/`
- [ ] Confirm `profiles/history/` does not exist
- [ ] Migration test: manually create `profiles/history/` with a dummy `.json`, restart app, verify file moved to `history/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)