### PR TITLE
test(ai): add direct unit tests for ShotSummarizer::summarize() (K)

### DIFF
--- a/openspec/changes/add-shotsummarizer-live-path-test/tasks.md
+++ b/openspec/changes/add-shotsummarizer-live-path-test/tasks.md
@@ -2,25 +2,22 @@
 
 ## 1. Mock ShotDataModel
 
-- [ ] 1.1 Add a minimal `MockShotDataModel` (file-scope class in `tests/tst_shotsummarizer.cpp` or a `tests/mock_shotdatamodel.h` header) that subclasses or duck-types the accessor methods `ShotSummarizer::summarize` reads:
-  - `pressureData()`, `flowData()`, `cumulativeWeightData()`, `temperatureData()`, `temperatureGoalData()`, `conductanceDerivativeData()`
-  - `phaseMarkersList()`, `pressureGoalData()`, `flowGoalData()`
-- [ ] 1.2 The mock exposes setters/init helpers so test fixtures can stuff curve data: `mock.setPressure(QVector<QPointF>{...})` etc.
-- [ ] 1.3 Decide between subclass vs. full QObject mock. Subclass is simpler if `ShotDataModel`'s accessors are virtual; otherwise a minimal duck-typed class works (since `summarize` takes `const ShotDataModel*` we'd need a real subclass). Pick whichever has lower friction.
+- [x] 1.1 The proposal contemplated either a subclass mock or a duck-typed mock; in practice the simplest path was to construct a real `ShotDataModel` and feed test data through its existing public ingestion API (`addSample`, `addWeightSample`, `addPhaseMarker`, `computeConductanceDerivative`). No production-code change, no friend declaration, no MockShotDataModel header — just a small `populateLiveShot()` builder helper colocated with the tests.
+- [x] 1.2 Builder helper: `populateLiveShot(model, samples, phases, weightSamples)` accepts a flat `LiveSample` vector (`t/pressure/flow/temperature/pressureGoal/flowGoal/temperatureGoal/isFlowMode`) plus a phase-marker tuple list, calls the corresponding `ShotDataModel` setters, and finishes with `computeConductanceDerivative()` so the dC/dt curve is in place.
+- [x] 1.3 No subclass needed — a real `ShotDataModel` instance is small enough to construct per-test and disposes via QObject parent ownership when the test method returns.
 
 ## 2. Live-path tests
 
-- [ ] 2.1 `summarize_pourTruncated_suppressesChannelingAndTempLines`: build a `MockShotDataModel` with the same puck-failure shape as the existing `pourTruncatedSuppressesChannelingAndTempLines` history test. Call `summarize(mock, profile, metadata, 18, 36)`. Assert the same line-suppression contract.
-- [ ] 2.2 `summarize_abortedPreinfusion_doesNotFlagPerPhaseTemp`: mirrors the existing aborted-preinfusion history test. Asserts the per-phase temp gate.
-- [ ] 2.3 `summarize_healthyShot_keepsObservations`: mirrors the existing healthy-shot history test.
+- [x] 2.1 `summarize_pourTruncated_suppressesChannelingAndTempLines_live` — mirrors the history-path puck-failure test. Asserts `pourTruncatedDetected` fires and the cascade suppresses both channeling and temperature-drift lines on the live path.
+- [x] 2.2 `summarize_abortedPreinfusion_doesNotFlagPerPhaseTemp_live` — mirrors the aborted-preinfusion history test. Asserts the `reachedExtractionPhase` gate suppresses per-phase temperature markers on the live path.
+- [x] 2.3 `summarize_healthyShot_keepsObservations_live` — mirrors the healthy-shot history test. Asserts the live path doesn't over-suppress observations on a clean 9-bar shot and emits a verdict line.
 
 ## 3. Optional parity test
 
-- [ ] 3.1 `summarize_andHistory_producesEquivalentSummary`: build the same shot data once. Run through `summarize(mock, profile, ...)` and `summarizeFromHistory(equivalentQVariantMap)`. Assert `summary.summaryLines`, `summary.pourTruncatedDetected`, and `summary.phases` are byte-equal across the two paths.
-- [ ] 3.2 Skip if the mock setup is awkward — the three direct tests above already cover the live-path surface; parity is a nice-to-have, not a contract this change needs to lock in.
+- [ ] 3.1 Live ↔ history equivalence test (`summarize` and `summarizeFromHistory` produce byte-equal `ShotSummary` for the same data). Skipped per proposal note ("nice-to-have, not a contract this change needs to lock in"). The three direct live-path tests above cover the live-path adapter surface; an equivalence test would primarily protect against post-helper drift, which `runShotAnalysisAndPopulate` (PR #945, I) structurally prevents by funneling both paths through one orchestration call.
 
 ## 4. Verify
 
-- [ ] 4.1 Build clean (Qt Creator MCP).
-- [ ] 4.2 All existing `tst_shotsummarizer` tests pass + 3 (or 4) new ones.
-- [ ] 4.3 Re-run with `-DCMAKE_BUILD_TYPE=Debug` to catch any QObject signal-emission warnings the mock triggers.
+- [x] 4.1 Build clean (Qt Creator MCP, 0 errors / 0 warnings).
+- [x] 4.2 All existing tests pass + 3 new live-path tests (1809 total, up from 1806).
+- [ ] 4.3 Re-run with Debug build for QObject signal-emission warnings — deferred. The MCP run reports 0 warnings; `addSample` does not emit signals (the production code defers signaling to the 33 ms flush timer that doesn't run in tests).

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -73,9 +73,14 @@ bool linesContainType(const QVariantList& lines, const QString& type)
     return false;
 }
 
-// Time-series sample for the live-path builder. addSample() takes a flat
-// argument list, but the tests want declarative shapes. Using a struct
-// keeps the call sites readable when there are 8+ values per sample.
+// Time-series sample for the live-path builder. ShotDataModel::addSample
+// takes 10 positional args (time, pressure, flow, temperature, mixTemp,
+// pressureGoal, flowGoal, temperatureGoal, frameNumber, isFlowMode); this
+// struct elides mixTemp (aliased to temperature inside the builder) and
+// frameNumber (production code's addSample marks frameNumber Q_UNUSED, so
+// the value never lands anywhere — only the phase markers carry frame
+// information). Tests should declare per-sample shapes here and let the
+// builder fan them out.
 struct LiveSample {
     double t;
     double pressure;
@@ -87,32 +92,47 @@ struct LiveSample {
     bool isFlowMode;
 };
 
-// Builds a real ShotDataModel from a flat list of LiveSample structs and a
-// matching set of phase markers. Live-path tests need a ShotDataModel*
-// (not a QVariantMap), so we exercise the same public ingestion API the
-// production code uses (addSample, addWeightSample, addPhaseMarker), then
-// run computeConductanceDerivative() to populate the dC/dt series.
+// Builds a real ShotDataModel from a flat list of LiveSample structs plus
+// matching phase markers. Live-path tests need a ShotDataModel* (not a
+// QVariantMap), so we exercise the same public ingestion API the production
+// code uses (addSample, addWeightSample, addPhaseMarker), then run
+// computeConductanceDerivative() to populate the dC/dt series.
 //
-// Lives in test scope rather than as a generic test fixture so the
-// ShotDataModel parent (the QObject* arg) stays explicit at the call
-// site — every test method owns its model and disposes via QObject parent
-// ownership.
+// `finalWeight` lets the caller anchor the synthesized cumulative weight
+// curve to the same final weight passed to summarize() — without it, the
+// curve and the summarize() finalWeight argument disagree, and any future
+// test extension that asserts on weight-derived detector output (yield
+// arms, weight gained) would silently read inconsistent data. When
+// `weightSamples` is supplied explicitly the synthetic curve is skipped.
+//
+// The ShotDataModel is owned by the caller's stack frame; destruction
+// happens at scope exit via RAII, no QObject parent involved.
 void populateLiveShot(ShotDataModel* model,
                       const std::vector<LiveSample>& samples,
                       const QList<std::tuple<double, QString, int, bool>>& phases,
+                      double finalWeight,
                       const std::vector<QPointF>& weightSamples = {})
 {
     for (const auto& [t, label, frameNumber, isFlowMode] : phases) {
         model->addPhaseMarker(t, label, frameNumber, isFlowMode);
     }
+    const double totalDuration = samples.empty() ? 0.0 : samples.back().t;
     for (const LiveSample& s : samples) {
         model->addSample(s.t, s.pressure, s.flow, s.temperature, s.temperature,
                          s.pressureGoal, s.flowGoal, s.temperatureGoal,
                          /*frameNumber=*/-1, s.isFlowMode);
-        // Synthesise a default cumulative weight sample if the caller didn't
-        // supply one — enough to give findValueAtTime something to interpolate.
-        if (weightSamples.empty()) {
-            model->addWeightSample(s.t, /*weight=*/s.t * 1.2);
+        // Synthesize a linear cumulative weight ramp from 0 to finalWeight
+        // when the caller didn't supply explicit weight samples. Using
+        // finalWeight as the endpoint keeps the curve consistent with the
+        // summarize() finalWeight argument so weight-dependent detectors
+        // see matching data on both sides.
+        if (weightSamples.empty() && totalDuration > 0.0) {
+            const double w = (s.t / totalDuration) * finalWeight;
+            // ShotDataModel::addWeightSample drops samples below 0.1 g, so
+            // skip the start-of-shot 0 g sample explicitly.
+            if (w >= 0.1) {
+                model->addWeightSample(s.t, w);
+            }
         }
     }
     for (const QPointF& w : weightSamples) {
@@ -477,10 +497,6 @@ private slots:
         QCOMPARE(fastSummary.pourTruncatedDetected, slowSummary.pourTruncatedDetected);
     }
 
-    // Cascade integrity through the fast path: when shotData carries a
-    // detectorResults.pourTruncated == true, summarizeFromHistory MUST set
-    // summary.pourTruncatedDetected = true AND skip the per-phase temp
-    // instability marking, exactly like the slow path's cascade.
     // ---- Live-path tests (summarize via ShotDataModel*) ----
     //
     // The history-path tests above feed QVariantMap shapes into
@@ -493,20 +509,36 @@ private slots:
 
     // Live-path puck-failure: same shape as
     // pourTruncatedSuppressesChannelingAndTempLines but the input is a
-    // real ShotDataModel rather than a QVariantMap.
+    // real ShotDataModel rather than a QVariantMap. Sets pressureGoal=9.0
+    // throughout the pour-mode phase so buildChannelingWindows produces
+    // a real inclusion window — without that, channeling would stay
+    // silent because no flow/pressure goal exists, and the assertion
+    // !"Sustained channeling" would pass for the wrong reason.
     void summarize_pourTruncated_suppressesChannelingAndTempLines_live()
     {
         ShotDataModel model;
         std::vector<LiveSample> samples;
-        for (double t = 0.0; t <= 30.0 + 1e-9; t += 0.1) {
+        // Preinfusion 0–8 s: flow-mode, flowGoal 1.5.
+        for (double t = 0.0; t <= 8.0; t += 0.1) {
             samples.push_back({
                 /*t=*/t, /*pressure=*/1.0, /*flow=*/1.5,
-                /*temperature=*/88.0, /*pressureGoal=*/0.0, /*flowGoal=*/0.0,
+                /*temperature=*/88.0, /*pressureGoal=*/0.0, /*flowGoal=*/1.5,
+                /*temperatureGoal=*/93.0, /*isFlowMode=*/true});
+        }
+        // Pour 8–30 s: pressure-mode, pressureGoal 9.0. Actual pressure
+        // stays at 1.0 bar to trip pourTruncated; the steady pressureGoal
+        // gives buildChannelingWindows a non-empty window, so the cascade
+        // actually has something to suppress.
+        for (double t = 8.0 + 0.1; t <= 30.0 + 1e-9; t += 0.1) {
+            samples.push_back({
+                /*t=*/t, /*pressure=*/1.0, /*flow=*/1.5,
+                /*temperature=*/88.0, /*pressureGoal=*/9.0, /*flowGoal=*/0.0,
                 /*temperatureGoal=*/93.0, /*isFlowMode=*/false});
         }
         populateLiveShot(&model, samples,
             {{0.0, QStringLiteral("Preinfusion"), 0, true},
-             {8.0, QStringLiteral("Pour"), 1, false}});
+             {8.0, QStringLiteral("Pour"), 1, false}},
+            /*finalWeight=*/36.0);
 
         ShotMetadata metadata;
         ShotSummarizer summarizer;
@@ -514,17 +546,21 @@ private slots:
             metadata, /*doseWeight=*/18.0, /*finalWeight=*/36.0);
 
         QVERIFY2(summary.pourTruncatedDetected,
-                 "live-path puck-failure shape must set pourTruncatedDetected");
+                 "puck-failure shape must set pourTruncatedDetected");
         QVERIFY2(linesContain(summary.summaryLines, QStringLiteral("Pour never pressurized")),
-                 "live-path summaryLines must contain the puck-failed warning");
+                 "summaryLines must contain the puck-failed warning");
         QVERIFY2(!linesContain(summary.summaryLines, QStringLiteral("Sustained channeling")),
-                 "live-path channeling line must be suppressed by the cascade");
+                 "channeling line must be suppressed by the cascade");
         QVERIFY2(!linesContain(summary.summaryLines, QStringLiteral("Temperature drifted")),
-                 "live-path temperature drift line must be suppressed by the cascade");
+                 "temperature drift line must be suppressed by the cascade");
+        QVERIFY2(linesContainType(summary.summaryLines, QStringLiteral("verdict")),
+                 "every shot must end with a verdict line");
     }
 
     // Live-path aborted-preinfusion: pin the reachedExtractionPhase gate on
-    // the live path. Mirrors abortedPreinfusionDoesNotFlagPerPhaseTemp.
+    // the live path. Mirrors abortedPreinfusionDoesNotFlagPerPhaseTemp;
+    // sample isFlowMode and the marker isFlowMode are both `false` to
+    // match the history-path mirror exactly.
     void summarize_abortedPreinfusion_doesNotFlagPerPhaseTemp_live()
     {
         ShotDataModel model;
@@ -535,11 +571,13 @@ private slots:
             samples.push_back({
                 /*t=*/t, /*pressure=*/4.0, /*flow=*/0.5,
                 /*temperature=*/88.0, /*pressureGoal=*/0.0, /*flowGoal=*/0.0,
-                /*temperatureGoal=*/93.0, /*isFlowMode=*/true});
+                /*temperatureGoal=*/93.0, /*isFlowMode=*/false});
         }
-        // Frame 0 only — reachedExtractionPhase must return false.
+        // Frame 0 only, isFlowMode=false to mirror the history-path test —
+        // reachedExtractionPhase must return false.
         populateLiveShot(&model, samples,
-            {{0.0, QStringLiteral("Preinfusion"), 0, true}});
+            {{0.0, QStringLiteral("Preinfusion"), 0, false}},
+            /*finalWeight=*/0.5);
 
         ShotMetadata metadata;
         ShotSummarizer summarizer;
@@ -550,8 +588,10 @@ private slots:
                  "test setup: 4-bar peak should not trip pourTruncated");
         for (const PhaseSummary& phase : summary.phases) {
             QVERIFY2(!phase.temperatureUnstable,
-                     "live-path per-phase temp markers must stay false on aborted-preinfusion shots");
+                     "per-phase temp markers must stay false on aborted-preinfusion shots");
         }
+        QVERIFY2(linesContainType(summary.summaryLines, QStringLiteral("verdict")),
+                 "every shot must end with a verdict line");
     }
 
     // Live-path healthy shot: sanity check that the live adapter doesn't
@@ -576,7 +616,8 @@ private slots:
         }
         populateLiveShot(&model, samples,
             {{0.0, QStringLiteral("Preinfusion"), 0, true},
-             {8.0, QStringLiteral("Pour"), 1, false}});
+             {8.0, QStringLiteral("Pour"), 1, false}},
+            /*finalWeight=*/36.0);
 
         ShotMetadata metadata;
         ShotSummarizer summarizer;
@@ -584,13 +625,17 @@ private slots:
             metadata, /*doseWeight=*/18.0, /*finalWeight=*/36.0);
 
         QVERIFY2(!summary.pourTruncatedDetected,
-                 "healthy 9-bar shot must not be flagged as puck-failure on the live path");
+                 "healthy 9-bar shot must not be flagged as puck-failure");
         QVERIFY2(!linesContain(summary.summaryLines, QStringLiteral("Pour never pressurized")),
-                 "live-path puck-failed warning must be absent on a healthy shot");
+                 "puck-failed warning must be absent on a healthy shot");
         QVERIFY2(linesContainType(summary.summaryLines, QStringLiteral("verdict")),
-                 "every live-path shot must end with a verdict line");
+                 "every shot must end with a verdict line");
     }
 
+    // Cascade integrity through the fast path: when shotData carries a
+    // detectorResults.pourTruncated == true, summarizeFromHistory MUST set
+    // summary.pourTruncatedDetected = true AND skip the per-phase temp
+    // instability marking, exactly like the slow path's cascade.
     void summarizeFromHistory_fastPathPreservesPourTruncatedCascade()
     {
         QVariantMap shot = buildHealthyShotMap();

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -24,6 +24,8 @@
 #include <QString>
 
 #include "ai/shotsummarizer.h"
+#include "models/shotdatamodel.h"
+#include "network/visualizeruploader.h"
 
 namespace {
 
@@ -69,6 +71,54 @@ bool linesContainType(const QVariantList& lines, const QString& type)
         if (v.toMap().value("type").toString() == type) return true;
     }
     return false;
+}
+
+// Time-series sample for the live-path builder. addSample() takes a flat
+// argument list, but the tests want declarative shapes. Using a struct
+// keeps the call sites readable when there are 8+ values per sample.
+struct LiveSample {
+    double t;
+    double pressure;
+    double flow;
+    double temperature;
+    double pressureGoal;
+    double flowGoal;
+    double temperatureGoal;
+    bool isFlowMode;
+};
+
+// Builds a real ShotDataModel from a flat list of LiveSample structs and a
+// matching set of phase markers. Live-path tests need a ShotDataModel*
+// (not a QVariantMap), so we exercise the same public ingestion API the
+// production code uses (addSample, addWeightSample, addPhaseMarker), then
+// run computeConductanceDerivative() to populate the dC/dt series.
+//
+// Lives in test scope rather than as a generic test fixture so the
+// ShotDataModel parent (the QObject* arg) stays explicit at the call
+// site — every test method owns its model and disposes via QObject parent
+// ownership.
+void populateLiveShot(ShotDataModel* model,
+                      const std::vector<LiveSample>& samples,
+                      const QList<std::tuple<double, QString, int, bool>>& phases,
+                      const std::vector<QPointF>& weightSamples = {})
+{
+    for (const auto& [t, label, frameNumber, isFlowMode] : phases) {
+        model->addPhaseMarker(t, label, frameNumber, isFlowMode);
+    }
+    for (const LiveSample& s : samples) {
+        model->addSample(s.t, s.pressure, s.flow, s.temperature, s.temperature,
+                         s.pressureGoal, s.flowGoal, s.temperatureGoal,
+                         /*frameNumber=*/-1, s.isFlowMode);
+        // Synthesise a default cumulative weight sample if the caller didn't
+        // supply one — enough to give findValueAtTime something to interpolate.
+        if (weightSamples.empty()) {
+            model->addWeightSample(s.t, /*weight=*/s.t * 1.2);
+        }
+    }
+    for (const QPointF& w : weightSamples) {
+        model->addWeightSample(w.x(), w.y());
+    }
+    model->computeConductanceDerivative();
 }
 
 } // namespace
@@ -431,6 +481,116 @@ private slots:
     // detectorResults.pourTruncated == true, summarizeFromHistory MUST set
     // summary.pourTruncatedDetected = true AND skip the per-phase temp
     // instability marking, exactly like the slow path's cascade.
+    // ---- Live-path tests (summarize via ShotDataModel*) ----
+    //
+    // The history-path tests above feed QVariantMap shapes into
+    // summarizeFromHistory(); these mirror them on the live path so the
+    // ShotDataModel input adapter doesn't regress. After PR #945 (I) both
+    // paths share runShotAnalysisAndPopulate() — so a divergence here
+    // would mean the live-path adapter built different inputs (curves,
+    // markers, frame info, target weight) than the history adapter for
+    // the same shot, not a detector-orchestration drift.
+
+    // Live-path puck-failure: same shape as
+    // pourTruncatedSuppressesChannelingAndTempLines but the input is a
+    // real ShotDataModel rather than a QVariantMap.
+    void summarize_pourTruncated_suppressesChannelingAndTempLines_live()
+    {
+        ShotDataModel model;
+        std::vector<LiveSample> samples;
+        for (double t = 0.0; t <= 30.0 + 1e-9; t += 0.1) {
+            samples.push_back({
+                /*t=*/t, /*pressure=*/1.0, /*flow=*/1.5,
+                /*temperature=*/88.0, /*pressureGoal=*/0.0, /*flowGoal=*/0.0,
+                /*temperatureGoal=*/93.0, /*isFlowMode=*/false});
+        }
+        populateLiveShot(&model, samples,
+            {{0.0, QStringLiteral("Preinfusion"), 0, true},
+             {8.0, QStringLiteral("Pour"), 1, false}});
+
+        ShotMetadata metadata;
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarize(&model, /*profile=*/nullptr,
+            metadata, /*doseWeight=*/18.0, /*finalWeight=*/36.0);
+
+        QVERIFY2(summary.pourTruncatedDetected,
+                 "live-path puck-failure shape must set pourTruncatedDetected");
+        QVERIFY2(linesContain(summary.summaryLines, QStringLiteral("Pour never pressurized")),
+                 "live-path summaryLines must contain the puck-failed warning");
+        QVERIFY2(!linesContain(summary.summaryLines, QStringLiteral("Sustained channeling")),
+                 "live-path channeling line must be suppressed by the cascade");
+        QVERIFY2(!linesContain(summary.summaryLines, QStringLiteral("Temperature drifted")),
+                 "live-path temperature drift line must be suppressed by the cascade");
+    }
+
+    // Live-path aborted-preinfusion: pin the reachedExtractionPhase gate on
+    // the live path. Mirrors abortedPreinfusionDoesNotFlagPerPhaseTemp.
+    void summarize_abortedPreinfusion_doesNotFlagPerPhaseTemp_live()
+    {
+        ShotDataModel model;
+        std::vector<LiveSample> samples;
+        // Pressure peaks at 4 bar so pourTruncated does NOT fire — we want to
+        // isolate the per-phase temp gate, not the puck-failure cascade.
+        for (double t = 0.0; t <= 3.0 + 1e-9; t += 0.1) {
+            samples.push_back({
+                /*t=*/t, /*pressure=*/4.0, /*flow=*/0.5,
+                /*temperature=*/88.0, /*pressureGoal=*/0.0, /*flowGoal=*/0.0,
+                /*temperatureGoal=*/93.0, /*isFlowMode=*/true});
+        }
+        // Frame 0 only — reachedExtractionPhase must return false.
+        populateLiveShot(&model, samples,
+            {{0.0, QStringLiteral("Preinfusion"), 0, true}});
+
+        ShotMetadata metadata;
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarize(&model, /*profile=*/nullptr,
+            metadata, /*doseWeight=*/18.0, /*finalWeight=*/0.5);
+
+        QVERIFY2(!summary.pourTruncatedDetected,
+                 "test setup: 4-bar peak should not trip pourTruncated");
+        for (const PhaseSummary& phase : summary.phases) {
+            QVERIFY2(!phase.temperatureUnstable,
+                     "live-path per-phase temp markers must stay false on aborted-preinfusion shots");
+        }
+    }
+
+    // Live-path healthy shot: sanity check that the live adapter doesn't
+    // over-suppress observations on a clean 9-bar shot. Mirrors
+    // healthyShotKeepsObservationsAndDoesNotTruncate.
+    void summarize_healthyShot_keepsObservations_live()
+    {
+        ShotDataModel model;
+        std::vector<LiveSample> samples;
+        // Preinfusion 0–8 s @ 2 bar, pour 8–30 s @ 9 bar.
+        for (double t = 0.0; t <= 8.0; t += 0.1) {
+            samples.push_back({
+                /*t=*/t, /*pressure=*/2.0, /*flow=*/2.0,
+                /*temperature=*/93.0, /*pressureGoal=*/0.0, /*flowGoal=*/2.0,
+                /*temperatureGoal=*/93.0, /*isFlowMode=*/true});
+        }
+        for (double t = 8.0 + 0.1; t <= 30.0 + 1e-9; t += 0.1) {
+            samples.push_back({
+                /*t=*/t, /*pressure=*/9.0, /*flow=*/2.0,
+                /*temperature=*/93.0, /*pressureGoal=*/9.0, /*flowGoal=*/0.0,
+                /*temperatureGoal=*/93.0, /*isFlowMode=*/false});
+        }
+        populateLiveShot(&model, samples,
+            {{0.0, QStringLiteral("Preinfusion"), 0, true},
+             {8.0, QStringLiteral("Pour"), 1, false}});
+
+        ShotMetadata metadata;
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarize(&model, /*profile=*/nullptr,
+            metadata, /*doseWeight=*/18.0, /*finalWeight=*/36.0);
+
+        QVERIFY2(!summary.pourTruncatedDetected,
+                 "healthy 9-bar shot must not be flagged as puck-failure on the live path");
+        QVERIFY2(!linesContain(summary.summaryLines, QStringLiteral("Pour never pressurized")),
+                 "live-path puck-failed warning must be absent on a healthy shot");
+        QVERIFY2(linesContainType(summary.summaryLines, QStringLiteral("verdict")),
+                 "every live-path shot must end with a verdict line");
+    }
+
     void summarizeFromHistory_fastPathPreservesPourTruncatedCascade()
     {
         QVariantMap shot = buildHealthyShotMap();


### PR DESCRIPTION
## Summary

- Adds three live-path tests to `tst_shotsummarizer` that mirror the existing saved-shot tests: puck-failure cascade, aborted-preinfusion gate, healthy-shot sanity.
- Constructs real `ShotDataModel` instances through their public ingestion API; no `MockShotDataModel` or production-code friend declaration needed.
- Implements OpenSpec proposal `add-shotsummarizer-live-path-test` (proposal K, the final piece of the G–K series).

(This PR replaces #946, which was auto-closed when its base branch was merged. Same content, rebased on main.)

## Why

The history-path tests covered `summarizeFromHistory` thoroughly, but the live path (`summarize(ShotDataModel*, ...)`) had no regression lock — bugs in the curve-extraction adapter from `ShotDataModel*` could regress without surfacing in CI.

After PR #949 (I) both paths share `runShotAnalysisAndPopulate`, so a divergence here would mean the live-path adapter built different inputs (curves, markers, frame info, target weight) for the same shot — not a detector-orchestration drift.

## Test plan

- [x] Three new live-path tests added: `summarize_pourTruncated_suppressesChannelingAndTempLines_live`, `summarize_abortedPreinfusion_doesNotFlagPerPhaseTemp_live`, `summarize_healthyShot_keepsObservations_live`.
- [x] The puck-failure live test feeds `pressureGoal=9.0` across pour-mode samples so `buildChannelingWindows` produces a real inclusion window — without that, the channeling-suppression assertion would pass for the wrong reason (no window → detector silent regardless of cascade).
- [x] `populateLiveShot` synthesises a cumulative weight curve consistent with the `finalWeight` argument passed to `summarize()`.
- [x] Existing 11 tests still pass; suite up to 14.
- [x] Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)