### PR TITLE
fix(build): link the post-J history TUs into tst_mcpserver_protocol

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -532,6 +532,9 @@ add_decenza_test(tst_mcpserver_protocol
     ${CMAKE_SOURCE_DIR}/src/mcp/mcpsession.h
     ${PROFILEMANAGER_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_internal.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
     ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
     ${BLE_SOURCES}
     ${PROFILE_SOURCES}


### PR DESCRIPTION
## Summary

`tst_mcpserver_protocol` was added by [#953](https://github.com/Kulitorum/Decenza/pull/953) (MCP spec 2025-11-25) and pulls `src/history/shothistorystorage.cpp` directly. The target's source list is set up against the pre-J single-TU layout — after PRs [#951](https://github.com/Kulitorum/Decenza/pull/951) and [#952](https://github.com/Kulitorum/Decenza/pull/952), `shothistorystorage.cpp` is one of four TUs that contribute member definitions to `ShotHistoryStorage`.

Result: linker fails with ~17 undefined-symbol errors covering `convertShotRecord` (now in `_serialize.cpp`), `prepareAnalysisInputs` (now in `_internal.cpp`), and the entire query / distinct-cache / auto-favorite / grinder-context surface (now in `_queries.cpp`).

The two existing direct-pull test targets — `tst_mcptools_write` and `tst_mcpserver_session` — already include the three split TUs (added in J's CMake updates). This PR brings `tst_mcpserver_protocol` to parity.

## Test plan

- [x] Build clean via Qt Creator MCP — 0 errors. The 2 warnings are the pre-existing OpenSSL link-version mismatches.
- [x] Full test suite via Qt Creator MCP: 1834 passed, 0 failed, 0 with warnings (up from 1811 — #953 added 23 new MCP-protocol tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)