### PR TITLE
fix(analysis): detect puck failure on shots aborted before first pour marker

### DIFF
--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -597,16 +597,25 @@ bool ShotAnalysis::detectPourTruncated(const QVector<QPointF>& pressure,
         || bev == QStringLiteral("cleaning"))
         return false;
 
-    if (pressure.size() < 10 || pourEnd <= pourStart) return false;
+    if (pressure.size() < 10) return false;
 
-    // Scan the pour window for peak pressure. We look only inside the pour
-    // (not the entire sample range) because some profiles briefly spike
-    // during fill before the puck is engaged — that's not diagnostic of
-    // whether extraction actually built pressure.
+    // Scan the pour window for peak pressure. We normally look only inside
+    // the pour (not the entire sample range) because some profiles briefly
+    // spike during fill before the puck is engaged — that's not diagnostic
+    // of whether extraction actually built pressure. But when the window is
+    // degenerate (pourEnd <= pourStart, which happens on shots that aborted
+    // before the first pour-class phase marker landed) the marker-derived
+    // window is unusable: in that case, scan the whole series. The 2.5 bar
+    // floor is conservative enough that any shot that built real extraction
+    // pressure crosses it somewhere — if no sample reaches the floor across
+    // the entire series, the puck demonstrably never built.
+    const bool windowValid = (pourEnd > pourStart);
     double peakBar = 0.0;
     for (const auto& pt : pressure) {
-        if (pt.x() < pourStart) continue;
-        if (pt.x() > pourEnd) break;
+        if (windowValid) {
+            if (pt.x() < pourStart) continue;
+            if (pt.x() > pourEnd) break;
+        }
         if (pt.y() > peakBar) peakBar = pt.y();
     }
     return peakBar < PRESSURE_FLOOR_BAR;

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -1080,6 +1080,24 @@ private slots:
         QCOMPARE(ShotAnalysis::detectPourTruncated(pressure, 0.0, 10.0, ""), true);
     }
 
+    // Inverted pour window (pourEnd < pourStart) happens when a shot is
+    // stopped before the first pour-class phase marker lands — e.g.
+    // a 2.3 s abort whose "Pour" marker timestamp is 2.5 s. Bailing out
+    // there hides genuine puck-failure shots (peak pressure under 2.5 bar
+    // across the entire series). Fall back to scanning the whole series
+    // when the marker-derived window is unusable. Regression for shot 875.
+    void pourTruncated_invertedWindow_scansFullSeries()
+    {
+        // Mirrors shot 875: 12 samples, peak ~0.35 bar, pourStart > pourEnd.
+        QVector<QPointF> pressure;
+        const double peaks[] = {0.04, 0.06, 0.08, 0.10, 0.12, 0.14,
+                                 0.16, 0.18, 0.20, 0.26, 0.32, 0.35};
+        double t = 0.0;
+        for (double p : peaks) { pressure.append(QPointF(t, p)); t += 0.21; }
+        // pourStart (2.5) > pourEnd (2.28) — degenerate window.
+        QCOMPARE(ShotAnalysis::detectPourTruncated(pressure, 2.5, 2.28), true);
+    }
+
     // Peak happening outside the pour window (e.g. during fill) should not
     // count — we're diagnosing extraction pressure.
     void pourTruncated_peakOutsidePourWindow_fires()


### PR DESCRIPTION
## Summary
- `detectPourTruncated` early-returned when `pourEnd <= pourStart`, hiding puck-failure shots whose first pour-class phase marker landed after the shot was already aborted. Verified against shot 875 (80's Espresso, 2.28 s, 1.1 g, peak 0.35 bar): `pourStart=2.5 > pourEnd=2.28` — production gave the "Clean shot. Puck held well." verdict instead of the puck-failure cascade.
- Fall back to scanning the whole pressure series when the marker-derived window is degenerate. The 2.5 bar floor is conservative enough that any shot that built real extraction pressure crosses it somewhere; if nothing in the entire series reaches the floor, the puck demonstrably never built.
- New regression test `pourTruncated_invertedWindow_scansFullSeries` mirrors shot 875's series (12 samples, 0.35 bar peak, inverted window).

## Context
Surfaced while reviewing badge classifications across the last 100 shots in local history via the live Decenza MCP server. Of 100 shots, only one fell into this trap — but the failure mode (very-short aborts) is real and silent.

The non-espresso skip-list (filter / pourover / tea / steam / cleaning) still runs first, so legitimate low-pressure modes are unaffected. The `pressure.size() < 10` guard is preserved for truly empty shots.

## Test plan
- [x] `tst_shotanalysis` — 1835 passed, 0 failed
- [x] `shot_corpus_regression` ctest passes (no existing fixture regresses)
- [x] New unit test covers the inverted-window case
- [ ] Manual: re-load shot 875 in Shot Detail; confirm "Pour never pressurized" warning + "Don't tune off this shot" verdict (relies on lazy-recompute on detail open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)