### PR TITLE
openspec: add-grind-detector-coverage-signal (proposal)

### DIFF
--- a/openspec/changes/add-grind-detector-coverage-signal/proposal.md
+++ b/openspec/changes/add-grind-detector-coverage-signal/proposal.md
@@ -1,0 +1,101 @@
+# Change: Add grind-detector coverage signal — verified-clean vs not-analyzable
+
+## Why
+
+A 500-shot audit against the live shot history found that **~50% of espresso
+shots silently produce `det.grind.hasData = false`** while still showing the
+verdict "Clean shot. Puck held well." Affected profiles concentrate on
+two-marker (Preinfusion + Pour) shapes:
+
+| Profile                          | hasData=false rate |
+|----------------------------------|--------------------|
+| A-Flow / default-medium          | 100% (52/52)       |
+| D-Flow / La Pavoni / La Pavoni 80s | 100% (25/25)     |
+| D-Flow / Malabar                 | 99%  (107/108)     |
+| D-Flow / Luca's Italian Style    | 87%  (7/8)         |
+| D-Flow / Q                       | 30%  (55/182)      |
+
+Root cause (verified by reading `analyzeFlowVsGoal` against representative
+shots Malabar #459, La Pavoni #277, A-Flow #604):
+
+1. **Arm 1 (flow-vs-goal)** builds flow-mode time ranges from phase markers,
+   then skips every flow sample where `fp.x() < pourStart`. On a two-marker
+   profile (Preinfusion → Pour), the only flow-mode range is
+   `[0, pourStart]` — i.e. *entirely before* `pourStart`. Zero qualifying
+   samples, arm goes silent.
+
+2. **Arm 2 (choked-puck)** sets `result.hasData = true` only inside its
+   `if (flowChoked || yieldShortfall)` branch. When pressure is healthy and
+   yield is reasonable, the arm correctly says "no choke" but never sets
+   hasData. There is no positive "all clear" signal.
+
+3. **Yield-overshoot arm** requires `targetWeightG > 0`. Many of these
+   profiles save `targetWeightG = 0` (user uses SAW or eyeballs), silencing
+   the arm.
+
+The downstream effect is that the verdict text claims "Puck held well." on
+every shot from these profiles regardless of whether the puck actually held
+or the system simply could not analyze it. That's *integrity* harm — users
+learn the badge system is unreliable on lever / two-frame profiles, then
+either ignore badges or distrust them when a real detector eventually fires.
+
+## What Changes
+
+- **Arm 2 emits a positive "verified clean" signal.** When the choked-puck
+  loop sees `flowSamples >= 5 && pressurizedDuration >= 15s` AND neither
+  `flowChoked` nor `yieldShortfall` fires, set `result.hasData = true` AND
+  set a new `result.verifiedClean = true` flag (without setting
+  `chokedPuck`). The user-facing summary gains a `[good]` line acknowledging
+  the verification.
+
+- **A "could not analyze grind" signal replaces the misleading silent
+  pass.** When `analyzeFlowVsGoal` returns `hasData=false AND skipped=false`
+  on an espresso shot whose pour window was non-degenerate, expose the
+  result as a new `det.grind.coverage = "notAnalyzable"` value. The summary
+  emits an `[observation]` line "Could not analyze grind on this profile
+  shape." The verdict cascade replaces the bare "Clean shot. Puck held
+  well." with "Clean shot, but grind could not be evaluated for this
+  profile" when the only analytic absence is the grind detector.
+
+- **No badge changes.** The five quality-badge booleans (`grindIssueDetected`,
+  etc.) are untouched. `hasData=true && !chokedPuck && !yieldOvershoot &&
+  |delta| <= threshold` still does NOT set `grindIssueDetected`. The
+  proposed change adds positive UI signal in the summary dialog and
+  detector-results MCP payload without altering the cascade or projection.
+
+- **Simulation outcome on the 253 shot population that currently silences
+  the grind detector** (faithful port of Arm 2 against cached curves):
+
+  | Outcome | Count | What the user sees |
+  |---|---|---|
+  | Newly emits "verified clean" (Option 1) | **134 (53%)** | New `[good]` summary line backed by data |
+  | Newly emits "couldn't analyze" (Option 3) | **115 (45%)** | Honest `[observation]` line + adjusted verdict |
+  | Newly detected as choked (would be a false positive) | **0** | Safe — Arm 2's choke condition unchanged |
+  | Inverted-window (still silent) | 4 | Orthogonal — separate fix |
+
+  Total useful coverage: **249/253 (98%)** of formerly-silent shots gain
+  meaningful UI signal.
+
+## Impact
+
+- Affected specs: `shot-analysis-pipeline` (this change adds the coverage
+  signal contract).
+- Affected code:
+  - `src/ai/shotanalysis.{h,cpp}` — new `GrindCheck::verifiedClean` field;
+    Arm 2 sets `hasData=true` once gates pass; new
+    `DetectorResults.grindCoverage` enum-string field; new summary line in
+    `analyzeShot`; verdict-cascade prose adjustment.
+  - `src/history/shothistorystorage_serialize.cpp` — emit
+    `det.grind.coverage` in `convertShotRecord`'s structured output.
+  - `tests/tst_shotanalysis.cpp` — regression coverage for the four
+    transitions (verified-clean, not-analyzable, still-choked,
+    pourTruncated-suppressed).
+  - `tools/shot_eval/main.cpp` — already exercises `analyzeShot`'s line list
+    via `generateSummary`; manifest may need an updated golden line for
+    affected fixtures.
+- No QML changes required: `ShotAnalysisDialog.qml` already renders all
+  `[good]` / `[observation]` line types from `summaryLines`.
+- No DB migration: badge columns unchanged; summary lines are recomputed
+  on every load.
+- `docs/SHOT_REVIEW.md` — update §2.2 (grind detector internals) to
+  document the new positive-signal branch and the `grindCoverage` value.

--- a/openspec/changes/add-grind-detector-coverage-signal/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/changes/add-grind-detector-coverage-signal/specs/shot-analysis-pipeline/spec.md
@@ -1,0 +1,117 @@
+# shot-analysis-pipeline delta
+
+## ADDED Requirements
+
+### Requirement: Grind detector SHALL emit a coverage signal distinguishing verified-clean from not-analyzable
+
+The grind detector SHALL emit a `grindCoverage` signal taking one of three values (`"verified"`, `"notAnalyzable"`, `"skipped"`) so that the system can distinguish a positively-verified clean grind from the absence of analyzable data. When `ShotAnalysis::analyzeFlowVsGoal` runs against an espresso shot whose beverage type and analysis flags do not gate it out (`skipped == false`), the function SHALL set `GrindCheck::hasData = true` whenever its choked-puck loop sees BOTH `flowSamples >= 5` AND `pressurizedDuration >= 15.0 s` (the existing gate constants `CHOKED_PRESSURE_MIN_BAR = 4.0` and `CHOKED_DURATION_MIN_SEC = 15.0`), regardless of whether `flowChoked` or `yieldShortfall` fires. When neither sub-arm fires, the function SHALL ALSO set a new `GrindCheck::verifiedClean = true` flag.
+
+`ShotAnalysis::analyzeShot` SHALL populate a new `DetectorResults::grindCoverage`
+field with one of three string values:
+
+- `"verified"` — `GrindCheck.hasData == true && GrindCheck.verifiedClean == true`.
+- `"notAnalyzable"` — `GrindCheck.hasData == false && GrindCheck.skipped == false`,
+  AND the espresso shot's pour window was non-degenerate (`pourEndSec > pourStartSec`),
+  AND the beverage type is not in the non-espresso skip list.
+- `"skipped"` — `GrindCheck.skipped == true` (non-espresso beverages or profiles
+  carrying the `grind_check_skip` analysis flag).
+
+When the pourTruncated cascade is active, the field SHALL be omitted entirely
+(consistent with how the channeling, flow-trend, temp, and grind blocks are
+already suppressed in that cascade).
+
+The five quality-badge boolean projections in `src/history/shotbadgeprojection.h`
+SHALL NOT change. Specifically: `grindIssueDetected` SHALL still require
+`grindHasData && (grindChokedPuck || grindYieldOvershoot || |grindFlowDeltaMlPerSec| > FLOW_DEVIATION_THRESHOLD)`.
+A verified-clean result SHALL project `grindIssueDetected = false`.
+
+#### Scenario: Verified-clean shot emits a positive signal
+
+- **GIVEN** an espresso shot with beverage type `"espresso"` and a healthy
+  pressurized pour (≥ 5 flow samples, ≥ 15 s sustained at ≥ 4 bar)
+- **AND** mean pressurized flow ≥ 0.5 mL/s
+- **AND** either `targetWeightG == 0` OR `finalWeightG / targetWeightG >= 0.85`
+- **WHEN** `analyzeShot` runs
+- **THEN** `DetectorResults.grindCoverage` SHALL equal `"verified"`
+- **AND** `summaryLines` SHALL contain one entry with `type = "good"` and text
+  "Grind tracked goal during pour"
+- **AND** `grindIssueDetected` SHALL be `false`
+
+#### Scenario: Profile shape that defeats both arms emits an honest signal
+
+- **GIVEN** an espresso shot whose phase markers are exclusively flow-mode OR
+  whose pressurized duration is below 15 s
+- **AND** the choked-puck arm produces no usable data (`flowSamples < 5` OR
+  `pressurizedDuration < 15.0 s`)
+- **AND** the flow-vs-goal arm produces no usable data (no flow-mode samples
+  in the pour window with `goal >= 0.3 mL/s`)
+- **AND** the beverage type is `"espresso"`
+- **AND** the pour window is non-degenerate (`pourEndSec > pourStartSec`)
+- **WHEN** `analyzeShot` runs
+- **THEN** `DetectorResults.grindCoverage` SHALL equal `"notAnalyzable"`
+- **AND** `summaryLines` SHALL contain one entry with `type = "observation"`
+  and text starting with "Could not analyze grind on this profile shape"
+- **AND** `grindIssueDetected` SHALL be `false`
+
+#### Scenario: Choked puck verdict is unchanged
+
+- **GIVEN** an espresso shot whose mean pressurized flow is below 0.5 mL/s
+  AND the choked-puck arm gates pass
+- **WHEN** `analyzeShot` runs
+- **THEN** `DetectorResults.grindCoverage` SHALL equal `"verified"` (the gates
+  passed, so the loop has data) — but `chokedPuck` SHALL be `true` and the
+  existing "Puck choked" warning line and verdict SHALL fire identically to
+  prior behavior
+- **AND** `verifiedClean` SHALL be `false`
+- **AND** `grindIssueDetected` SHALL be `true`
+
+#### Scenario: Pour-truncated cascade suppresses the coverage signal
+
+- **GIVEN** an espresso shot where `pourTruncated == true` (peak pressure
+  inside the pour window is below `PRESSURE_FLOOR_BAR`)
+- **WHEN** `analyzeShot` runs
+- **THEN** `DetectorResults.grindCoverage` SHALL be absent from the structured
+  output
+- **AND** `summaryLines` SHALL NOT contain the new "Grind tracked goal" line
+  NOR the new "Could not analyze grind" line
+- **AND** the existing pourTruncated cascade behavior SHALL apply unchanged
+
+### Requirement: Verdict cascade SHALL acknowledge a not-analyzable grind result
+
+The verdict cascade SHALL distinguish "clean and verified" from "clean but grind not analyzable" so users on lever / two-frame profiles see honest UI text. When the verdict cascade in `analyzeShot` reaches the "Otherwise" terminal branch (no warnings, no cautions) AND `DetectorResults.grindCoverage == "notAnalyzable"`, the cascade SHALL emit the verdict text "Clean shot, but grind could not be evaluated for this profile shape." instead of the existing "Clean shot. Puck held well."
+
+When the cascade reaches the same terminal branch with `grindCoverage ==
+"verified"` or `grindCoverage` absent (e.g. non-espresso skipped path), the
+cascade SHALL emit the existing "Verdict: Clean shot. Puck held well." text
+unchanged.
+
+The `verdictCategory` enum string emitted on `DetectorResults` SHALL gain a
+new value `"cleanGrindNotAnalyzable"` for the new branch. The existing
+`"clean"` value SHALL continue to apply when grind was verified or skipped.
+
+#### Scenario: Verified-clean shot keeps the existing clean verdict
+
+- **GIVEN** an espresso shot with `grindCoverage == "verified"` AND no
+  warning/caution lines
+- **WHEN** the verdict cascade runs
+- **THEN** the verdict line SHALL read "Verdict: Clean shot. Puck held well."
+- **AND** `verdictCategory` SHALL equal `"clean"`
+
+#### Scenario: Not-analyzable shot gets the honest verdict
+
+- **GIVEN** an espresso shot with `grindCoverage == "notAnalyzable"` AND no
+  warning/caution lines
+- **WHEN** the verdict cascade runs
+- **THEN** the verdict line SHALL read "Verdict: Clean shot, but grind could
+  not be evaluated for this profile shape."
+- **AND** `verdictCategory` SHALL equal `"cleanGrindNotAnalyzable"`
+
+#### Scenario: Warnings or cautions take precedence over the new verdict
+
+- **GIVEN** an espresso shot with `grindCoverage == "notAnalyzable"` AND
+  any other detector emits a warning or caution line
+- **WHEN** the verdict cascade runs
+- **THEN** the verdict SHALL come from the existing precedence rules
+  (pourTruncated → skipFirstFrame → chokedPuck → "Puck integrity issue" →
+  caution-grind direction → "Decent shot with minor issues to watch"),
+  NOT from the new "grind could not be evaluated" branch

--- a/openspec/changes/add-grind-detector-coverage-signal/tasks.md
+++ b/openspec/changes/add-grind-detector-coverage-signal/tasks.md
@@ -1,0 +1,42 @@
+# Tasks
+
+## 1. Detector struct + Arm 2 signal
+
+- [ ] 1.1 Add `bool verifiedClean = false;` to `ShotAnalysis::GrindCheck` and a matching `bool grindVerifiedClean` to `DetectorResults`.
+- [ ] 1.2 In `analyzeFlowVsGoal`, after the existing `if (flowSamples >= 5 && pressurizedDuration >= CHOKED_DURATION_MIN_SEC) { ... }` block: when neither `flowChoked` nor `yieldShortfall` fires, set `result.hasData = true; result.verifiedClean = true; result.sampleCount = flowSamples;`.
+- [ ] 1.3 Confirm the projection in `src/history/shotbadgeprojection.h` does NOT change — the badge boolean still requires `chokedPuck || yieldOvershoot || |delta| > threshold`. Add a unit test that a verified-clean result projects to `grindIssueDetected = false`.
+
+## 2. Coverage enum
+
+- [ ] 2.1 Add a `grindCoverage` field on `DetectorResults` taking values `"verified"`, `"notAnalyzable"`, `"skipped"`, or absent (when not espresso). Populate inside `analyzeShot` from `GrindCheck.{hasData, verifiedClean, skipped}`.
+- [ ] 2.2 Emit `grindCoverage` in `ShotHistoryStorage::convertShotRecord`'s structured `detectorResults` output.
+- [ ] 2.3 Document the field in `docs/CLAUDE_MD/MCP_SERVER.md` "Shot Detector Outputs".
+
+## 3. Summary lines + verdict prose
+
+- [ ] 3.1 In `analyzeShot`, when the grind block does NOT fire any caution/warning AND `grind.verifiedClean == true`, append a `[good]` line with text "Grind tracked goal during pour" and severity `good`.
+- [ ] 3.2 When the grind block does NOT fire AND `grind.hasData == false && grind.skipped == false`, append an `[observation]` line "Could not analyze grind on this profile shape — check flow trend, channeling, and taste instead."
+- [ ] 3.3 In the verdict cascade, when the only deviation from a fully-clean read is `grindCoverage == "notAnalyzable"` and no warnings/cautions fire, replace `"Verdict: Clean shot. Puck held well."` with `"Verdict: Clean shot, but grind could not be evaluated for this profile shape."`. Otherwise verdict unchanged.
+
+## 4. Tests
+
+- [ ] 4.1 `tst_shotanalysis::grindCoverage_verifiedClean_passesPositive` — synthesize a healthy 30 s shot with steady pressure ≥ 4 bar, mean flow 2 mL/s, target_weight=36 g, final=36 g; assert `verifiedClean=true`, `hasData=true`, `chokedPuck=false`, line list contains `[good] Grind tracked goal during pour`.
+- [ ] 4.2 `tst_shotanalysis::grindCoverage_notAnalyzable_doesNotLieClean` — synthesize a 25 s pour with no pressure-mode phase markers and pressure that never sustains 4 bar; assert `hasData=false`, `verifiedClean=false`, line list contains `[observation] Could not analyze grind on this profile shape...`, verdict reads "...grind could not be evaluated for this profile shape."
+- [ ] 4.3 `tst_shotanalysis::grindCoverage_choked_unchanged` — re-run an existing choked-puck fixture; verify `chokedPuck=true`, `verifiedClean=false`, badge fires identically to before.
+- [ ] 4.4 `tst_shotanalysis::grindCoverage_pourTruncatedSuppresses` — verify the cascade: when `pourTruncated` fires, the grind block is skipped entirely (no verified-clean line, no notAnalyzable line, no grindCoverage emission).
+- [ ] 4.5 `tst_shotanalysis::grindCoverage_yieldOvershoot_unchanged` — verify yield-overshoot still fires the same way; `verifiedClean=false`.
+- [ ] 4.6 `tst_shotanalysis::badgeProjection_verifiedClean_doesNotFireGrindBadge` — `DetectorResults` with `grindHasData=true && grindVerifiedClean=true` must project `grindIssueDetected=false`.
+- [ ] 4.7 Update `tests/data/shots/manifest.json` for any fixture whose summary text changes from `"Clean shot. Puck held well."` to the new "verified" or "not analyzable" wording.
+
+## 5. Docs
+
+- [ ] 5.1 Update `docs/SHOT_REVIEW.md` §2.2 (grind detector internals) to describe the verified-clean branch on Arm 2 and the `grindCoverage` field.
+- [ ] 5.2 Update `docs/SHOT_REVIEW.md` §3 (Shot Summary dialog) to list the two new line types in the "Observations emitted" enumeration.
+- [ ] 5.3 Update `docs/SHOT_REVIEW.md` §4 (Persistence semantics) — note that `grindCoverage` is recomputed on every load just like the other detector outputs; no DB column.
+
+## 6. Validation
+
+- [ ] 6.1 `openspec validate add-grind-detector-coverage-signal --strict --no-interactive` passes.
+- [ ] 6.2 Build (`mcp__qtcreator__build`) clean.
+- [ ] 6.3 `tst_shotanalysis` and `shot_corpus_regression` ctest targets pass.
+- [ ] 6.4 Manual smoke: open a Malabar shot in Shot Detail, confirm the new `[good]` line appears; open an A-Flow short-pressurized shot, confirm the `[observation]` line + adjusted verdict appear.


### PR DESCRIPTION
## Summary
OpenSpec proposal to fix the largest finding from the 500-shot badge audit: ~50% of espresso shots silently produce `det.grind.hasData = false` while showing the verdict "Clean shot. Puck held well." This is an integrity issue — the system claims "Clean" on lever / two-frame profiles regardless of actual grind.

Proposal: Arm 2 gains a positive "verified clean" branch (Option 1); shots where neither arm produces data get a new `grindCoverage = "notAnalyzable"` signal and an honest verdict (Option 3).

## Audit data motivating the change

500 shots pulled live via MCP `shots_get_detail`. `hasData=false` rate:

| Profile | Rate |
|---|---|
| A-Flow / default-medium | 100% (52/52) |
| D-Flow / La Pavoni + 80s | 100% (25/25) |
| D-Flow / Malabar | 99% (107/108) |
| D-Flow / Luca's Italian Style | 87% (7/8) |
| D-Flow / Q | 30% (55/182) |

## Simulation outcome (faithful port of Arm 2 against cached curves on the 253 silent shots)

| Outcome | Count | What changes for the user |
|---|---|---|
| Newly emits "verified clean" | **134 (53%)** | New `[good]` line backed by data |
| Newly emits "couldn't analyze" | **115 (45%)** | Honest `[observation]` + adjusted verdict |
| Newly detected as choked | **0** | Safe — Arm 2's choke condition unchanged |
| Inverted-window (still silent) | 4 | Orthogonal — separate fix |

98% of formerly-silent shots gain meaningful UI signal. Zero new false-positive grind badges.

## What's in this PR

- `openspec/changes/add-grind-detector-coverage-signal/proposal.md` — full motivation + simulation results.
- `openspec/changes/add-grind-detector-coverage-signal/tasks.md` — implementation checklist.
- `openspec/changes/add-grind-detector-coverage-signal/specs/shot-analysis-pipeline/spec.md` — `## ADDED Requirements` delta covering both new behaviors with full scenarios.

## What's NOT in this PR

This PR only scaffolds the spec. Implementation lands separately after approval — per CLAUDE.md OpenSpec workflow:
> Stage 2: Implementing Changes — Do not start implementation until the proposal is reviewed and approved.

## Validation
- [x] `openspec validate add-grind-detector-coverage-signal --strict --no-interactive` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)