### PR TITLE
fix(profile): stop overriding espresso_temperature on every parse (#958)

### DIFF
--- a/src/profile/profile.cpp
+++ b/src/profile/profile.cpp
@@ -556,21 +556,12 @@ Profile Profile::fromJson(const QJsonDocument& doc) {
         }
     }
 
-    // Sync espresso_temperature from first frame for advanced profiles only.
-    // Simple profiles (settings_2a/2b) have explicit espresso_temperature that is
-    // authoritative — their frames may be stale from a prior conversion.
-    bool isSimpleProfile = (profile.m_profileType == "settings_2a" || profile.m_profileType == "settings_2b");
-    if (!isSimpleProfile && !profile.m_steps.isEmpty()) {
-        if (!obj.contains("espresso_temperature")) {
-            profile.m_espressoTemperature = profile.m_steps.first().temperature;
-        } else {
-            double firstFrameTemp = profile.m_steps.first().temperature;
-            if (qAbs(profile.m_espressoTemperature - firstFrameTemp) > 0.1) {
-                qDebug() << "Syncing espresso_temperature from" << profile.m_espressoTemperature
-                         << "to first frame temp" << firstFrameTemp;
-                profile.m_espressoTemperature = firstFrameTemp;
-            }
-        }
+    // Default espresso_temperature from first frame only when the JSON omits it,
+    // so we never store NaN/0. Otherwise the top-level value is authoritative —
+    // it can legitimately differ from steps[0].temperature (e.g. a cooler group
+    // preheat target paired with a hotter preinfusion ramp).
+    if (!obj.contains("espresso_temperature") && !profile.m_steps.isEmpty()) {
+        profile.m_espressoTemperature = profile.m_steps.first().temperature;
     }
 
     // De1app defaults NumberOfPreinfuseFrames to 0 when the field is missing

--- a/src/profile/profile.cpp
+++ b/src/profile/profile.cpp
@@ -557,9 +557,10 @@ Profile Profile::fromJson(const QJsonDocument& doc) {
     }
 
     // Default espresso_temperature from first frame only when the JSON omits it,
-    // so we never store NaN/0. Otherwise the top-level value is authoritative —
-    // it can legitimately differ from steps[0].temperature (e.g. a cooler group
-    // preheat target paired with a hotter preinfusion ramp).
+    // so we never store NaN/0. Otherwise the top-level value is authoritative at
+    // load time — it can legitimately differ from steps[0].temperature (e.g. a
+    // cooler group preheat target paired with a hotter preinfusion ramp).
+    // (regenerateFromRecipe resyncs it from frames after recipe regeneration.)
     if (!obj.contains("espresso_temperature") && !profile.m_steps.isEmpty()) {
         profile.m_espressoTemperature = profile.m_steps.first().temperature;
     }
@@ -1189,8 +1190,7 @@ void Profile::regenerateSimpleFrames() {
     // The caller (applyRecipeToScalarFields) already set it from tempStart.
     // Syncing from the first frame is wrong when preinfusionTime=0 and
     // tempStepsEnabled=true — the first frame would be the hold frame at
-    // temp2, not temp0. Simple profiles have authoritative scalar temperature
-    // (see fromJson guard at line ~548).
+    // temp2, not temp0.
 }
 
 void Profile::regenerateFromRecipe() {


### PR DESCRIPTION
## Summary

- `Profile::fromJson` was healing the top-level `espresso_temperature` to `steps[0].temperature` on every parse — and logging `Syncing espresso_temperature…` each time.
- Mismatched top-level vs. frame[0] is **intentional** on many profiles (D-Flow / A-Flow built-ins ship with a cooler group preheat paired with a hotter preinfusion ramp). The heal silently overrode authored values.
- `fromJson` is on every read path (Shot Detail, MCP `shots_get_detail`, profile listing), so the log noise was constant under normal use and produced ~500 lines during a 500-shot MCP audit.
- de1app does no auto-sync on profile load, so removing the heal matches its behavior. The "All temps" slider in Decenza's editor already matches de1app's `change_espresso_temperature` (shifts all frames by delta, sets top-level to the new absolute frame[0]) — no change needed there.
- The defaulting branch (`if !contains("espresso_temperature")`) is kept so malformed JSON that omits the field doesn't end up with NaN/0.

Fixes #958.

## Test plan

- [x] Builds cleanly (Qt Creator MSVC, 0 errors / 0 warnings)
- [ ] Open Shot Detail on a historical shot — confirm no `Syncing espresso_temperature…` log lines
- [ ] Activate a D-Flow / A-Flow built-in (e.g. `a_flow_default_dark`) — confirm the profile-level temp shown matches the JSON (92°C, not 93°C) and the heater preheats to that value

🤖 Generated with [Claude Code](https://claude.com/claude-code)