### PR TITLE
openspec: tighten-grind-yield-shortfall-arm (proposal)

### DIFF
--- a/openspec/changes/tighten-grind-yield-shortfall-arm/proposal.md
+++ b/openspec/changes/tighten-grind-yield-shortfall-arm/proposal.md
@@ -1,0 +1,95 @@
+# Change: Decouple grind yield-shortfall arm from the 15s pressurized-duration gate
+
+## Why
+
+The 500-shot audit (#963) found that the moderate-yield arm of the grind
+detector was hidden by a shared duration gate. Today's
+`analyzeFlowVsGoal` runs both the flow-choked arm and the yield-shortfall
+arm under one shared precondition:
+
+```cpp
+if (flowSamples >= 5 && pressurizedDuration >= CHOKED_DURATION_MIN_SEC) {
+    // ... both arms inside
+}
+```
+
+That 15s pressurized gate makes sense for the **flow-choked** arm — it
+needs sustained pressure to compute a meaningful mean flow. It does NOT
+make sense for the **yield-shortfall** arm, which is yield-ratio-based
+and doesn't read pressurized flow at all.
+
+Concrete miss: shot 745 (Adaptive v2): 35s pour, **yield 23.1g of 36g
+target = 0.64 ratio**, well below the 0.85 moderate-choke threshold.
+Pressurized duration was 8.76s, under the 15s gate — so the entire arm
+was silenced. Verdict reads "Clean shot. Puck held well." The user
+makes no change, repeats the underextraction next shot.
+
+Simulation against the 17 currently-silent under-target shots in the
+audit:
+
+| Approach | New fires |
+|---|---|
+| Drop duration gate from yield arm; keep ratio at 0.85 | 9 (includes borderline Adaptive v2 at 71-76%, likely FPs) |
+| Drop duration gate from yield arm; **tighten ratio to 0.70** | **5** (745, 752, 753, 754, 735 — all genuinely choked-shaped) |
+| Drop duration gate from yield arm; tighten ratio to 0.65 | 5 (same) |
+| Drop duration gate from yield arm; tighten ratio to 0.50 | 3 |
+
+The 0.70 threshold is the empirical sweet spot: catches the 5 genuinely
+choked shots, excludes the 4 borderline Adaptive v2 shots (71-76%
+yield, high flow rates) where flagging "puck choked" would likely be
+a false positive — those profiles may simply deliver less than target
+by design.
+
+The flow-choked arm keeps its existing 15s gate unchanged. The
+verified-clean signal also continues to require both gates (we can
+only strongly verify when the flow arm could speak).
+
+## What Changes
+
+- **Yield-shortfall arm decouples from the 15s pressurized-duration
+  gate.** It runs whenever `flowSamples >= 5` (i.e. the puck saw
+  meaningful pressure even briefly) AND the standard target/yield
+  preconditions hold. Eliminates shot 745's silent miss and the
+  similar Q3 short-pour-low-yield population.
+- **`CHOKED_YIELD_RATIO_MAX` tightens from 0.85 to 0.70.** Empirical:
+  the 0.85 threshold over-flagged Adaptive v2 fast-pour shots that
+  delivered 71-76% of target by design. 0.70 catches the genuine
+  choke shapes without those false positives.
+- **`hasData=true` semantics expand.** Previously set only when the
+  shared 15s+5-sample gate passed. Now also set when the yield arm
+  fires standalone. The verified-clean path still requires the strong
+  flow-arm gates.
+- **Flow-choked arm unchanged.** Still requires `flowSamples >= 5`,
+  `pressurizedDuration >= 15s`, mean pressurized flow `< 0.5 mL/s`.
+- **Badge projection unchanged.** `grindIssueDetected` still requires
+  `chokedPuck || yieldOvershoot || |delta| > FLOW_DEVIATION_THRESHOLD`.
+  The relaxed yield-arm trigger projects through cleanly because
+  yield-shortfall already sets `chokedPuck = true`.
+- **No new MCP fields.** Coverage signal continues to be `"verified"`
+  whenever `hasData=true`. (Future work in #964 to expose the
+  individual gate values.)
+
+## Impact
+
+- Affected specs: `shot-analysis-pipeline` (modify the existing grind
+  detector requirement to document the split gate semantics).
+- Affected code:
+  - `src/ai/shotanalysis.h` — change `CHOKED_YIELD_RATIO_MAX` from
+    0.85 to 0.70.
+  - `src/ai/shotanalysis.cpp` — restructure `analyzeFlowVsGoal`'s
+    outer gate into a flow-arm gate and a yield-arm gate.
+  - `tests/tst_shotanalysis.cpp` — 3 new tests (yield arm fires
+    without 15s pressurized; doesn't fire on 0.75 ratio; flow arm
+    still requires 15s).
+  - `tests/data/shots/manifest.json` + fixture — verify
+    `80s_choked_moderate.json` still passes (ratio is near 0.7
+    boundary).
+  - `docs/SHOT_REVIEW.md` §2.2 — update the moderate-yield threshold
+    and rationale.
+- No QML changes. No DB migration. No badge UI changes.
+
+Estimated population impact going forward: ~1% of espresso shots
+(based on 5/500 historical). Every future shot of any espresso
+profile that lands in the 50-70% yield ratio range with brief
+pressurized window now gets the actionable "grind too fine, coarsen"
+signal instead of a misleading "Clean shot."

--- a/openspec/changes/tighten-grind-yield-shortfall-arm/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/changes/tighten-grind-yield-shortfall-arm/specs/shot-analysis-pipeline/spec.md
@@ -1,0 +1,80 @@
+# shot-analysis-pipeline delta
+
+## MODIFIED Requirements
+
+### Requirement: Grind detector SHALL emit a coverage signal distinguishing verified-clean from not-analyzable
+
+The grind detector SHALL emit a `grindCoverage` signal taking one of three values (`"verified"`, `"notAnalyzable"`, `"skipped"`) so that the system can distinguish a positively-verified clean grind from the absence of analyzable data. When `ShotAnalysis::analyzeFlowVsGoal` runs against an espresso shot whose beverage type and analysis flags do not gate it out (`skipped == false`), the function SHALL evaluate the choked-puck arms with split gating: the **flow-choked arm** SHALL fire only when ALL of `flowSamples >= 5` AND `pressurizedDuration >= CHOKED_DURATION_MIN_SEC` (15.0 s) AND mean pressurized flow `< CHOKED_FLOW_MAX_MLPS` (0.5 mL/s) hold. The **yield-shortfall arm** SHALL fire when ALL of `flowSamples >= 5` AND `targetWeightG > 0.0` AND `finalWeightG > 0.0` AND `(finalWeightG / targetWeightG) < CHOKED_YIELD_RATIO_MAX` (0.70 — tightened from a prior 0.85 by audit) hold. The yield arm SHALL NOT require `pressurizedDuration >= 15.0 s` — its diagnosis is yield-based and does not read pressurized flow.
+
+The function SHALL set `GrindCheck::hasData = true` whenever EITHER arm could speak: when `flowSamples >= 5` AND (`pressurizedDuration >= 15.0 s` OR the yield-shortfall arm fired). The function SHALL set `GrindCheck::verifiedClean = true` only when `flowSamples >= 5` AND `pressurizedDuration >= 15.0 s` AND neither sub-arm fired AND `|delta| <= FLOW_DEVIATION_THRESHOLD` AND `yieldOvershoot == false`. The verified-clean signal still requires the strong flow-arm gates because it asserts a healthy sustained pressurized pour.
+
+`ShotAnalysis::analyzeShot` SHALL populate a `DetectorResults::grindCoverage` field with one of three string values:
+
+- `"verified"` — `GrindCheck.hasData == true`. The detector ran with enough data to produce a result. Set whether or not the result is healthy: a verified-clean pour AND a chokedPuck/yieldOvershoot/large-delta pour BOTH carry `coverage = "verified"`. Coverage signals data availability, not health outcome — read `grindVerifiedClean` / `grindDirection` / verdict for the diagnosis.
+- `"notAnalyzable"` — `GrindCheck.hasData == false && GrindCheck.skipped == false`, AND the espresso shot's pour window was non-degenerate (`pourEndSec > pourStartSec`), AND the beverage type is not in the non-espresso skip list.
+- `"skipped"` — `GrindCheck.skipped == true` (non-espresso beverages or profiles carrying the `grind_check_skip` analysis flag).
+
+When the pourTruncated cascade is active, the field SHALL be omitted entirely (consistent with how the channeling, flow-trend, temp, and grind blocks are already suppressed in that cascade).
+
+The five quality-badge boolean projections in `src/history/shotbadgeprojection.h` SHALL NOT change. Specifically: `grindIssueDetected` SHALL still require `grindHasData && (grindChokedPuck || grindYieldOvershoot || |grindFlowDeltaMlPerSec| > FLOW_DEVIATION_THRESHOLD)`. A verified-clean result SHALL project `grindIssueDetected = false`. A yield-shortfall-only result (yield arm fired, flow arm gates didn't pass) SHALL project `grindIssueDetected = true` because `chokedPuck` is set when either choke sub-arm fires.
+
+#### Scenario: Verified-clean shot emits a positive signal
+
+- **GIVEN** an espresso shot with beverage type `"espresso"` and a healthy pressurized pour (≥ 5 flow samples, ≥ 15 s sustained at ≥ 4 bar)
+- **AND** mean pressurized flow ≥ 0.5 mL/s
+- **AND** either `targetWeightG == 0` OR `finalWeightG / targetWeightG >= 0.70`
+- **WHEN** `analyzeShot` runs
+- **THEN** `DetectorResults.grindCoverage` SHALL equal `"verified"`
+- **AND** `summaryLines` SHALL contain one entry with `type = "good"` and text "Grind tracked goal during pour"
+- **AND** `grindIssueDetected` SHALL be `false`
+
+#### Scenario: Profile shape that defeats both arms emits an honest signal
+
+- **GIVEN** an espresso shot whose phase markers are exclusively flow-mode OR whose pressurized duration is below 15 s
+- **AND** the choked-puck arm produces no usable data (`flowSamples < 5` — i.e. no pressurized samples at all)
+- **AND** the flow-vs-goal arm produces no usable data (no flow-mode samples in the pour window with `goal >= 0.3 mL/s`)
+- **AND** the beverage type is `"espresso"`
+- **AND** the pour window is non-degenerate (`pourEndSec > pourStartSec`)
+- **WHEN** `analyzeShot` runs
+- **THEN** `DetectorResults.grindCoverage` SHALL equal `"notAnalyzable"`
+- **AND** `summaryLines` SHALL contain one entry with `type = "observation"` and text starting with "Could not analyze grind on this profile shape"
+- **AND** `grindIssueDetected` SHALL be `false`
+
+#### Scenario: Choked puck verdict is unchanged on the flow arm
+
+- **GIVEN** an espresso shot whose mean pressurized flow is below 0.5 mL/s AND the flow-choked arm gates pass (≥ 5 samples AND ≥ 15s pressurized)
+- **WHEN** `analyzeShot` runs
+- **THEN** `DetectorResults.grindCoverage` SHALL equal `"verified"` (the flow-arm gates passed)
+- **AND** `chokedPuck` SHALL be `true` and the existing "Puck choked" warning line and verdict SHALL fire identically to prior behavior
+- **AND** `verifiedClean` SHALL be `false`
+- **AND** `grindIssueDetected` SHALL be `true`
+
+#### Scenario: Yield-shortfall arm fires on a brief-pressurized shot
+
+- **GIVEN** an espresso shot with `flowSamples >= 5` (puck saw meaningful pressure briefly) AND `pressurizedDuration < 15 s` (flow-arm gate did NOT pass)
+- **AND** `targetWeightG > 0` AND `finalWeightG > 0`
+- **AND** `(finalWeightG / targetWeightG) < 0.70` (e.g. 23.1g of a 36g target = 0.64)
+- **WHEN** `analyzeShot` runs
+- **THEN** `chokedPuck` SHALL be `true` (yield arm fired)
+- **AND** `hasData` SHALL be `true`
+- **AND** `verifiedClean` SHALL be `false` (flow-arm gates required for verification)
+- **AND** `DetectorResults.grindCoverage` SHALL equal `"verified"` (an arm produced data)
+- **AND** `grindIssueDetected` SHALL be `true`
+- **AND** `summaryLines` SHALL include the existing "Pour produced near-zero flow while pressure held — puck choked" warning
+
+#### Scenario: Borderline yield ratio between 0.70 and 0.85 stays silent
+
+- **GIVEN** an espresso shot with `flowSamples >= 5` AND `pressurizedDuration < 15 s`
+- **AND** `(finalWeightG / targetWeightG) = 0.75` (above 0.70 threshold but below the prior 0.85)
+- **WHEN** `analyzeShot` runs
+- **THEN** `chokedPuck` SHALL be `false`
+- **AND** the audit-driven 0.70 threshold SHALL hold; no warning line about "Pour produced near-zero flow" SHALL fire
+- **AND** `grindIssueDetected` SHALL be `false`
+
+#### Scenario: Pour-truncated cascade suppresses the coverage signal
+
+- **GIVEN** an espresso shot where `pourTruncated == true` (peak pressure inside the pour window is below `PRESSURE_FLOOR_BAR`)
+- **WHEN** `analyzeShot` runs
+- **THEN** `DetectorResults.grindCoverage` SHALL be absent from the structured output
+- **AND** `summaryLines` SHALL NOT contain the new "Grind tracked goal" line NOR the new "Could not analyze grind" line
+- **AND** the existing pourTruncated cascade behavior SHALL apply unchanged

--- a/openspec/changes/tighten-grind-yield-shortfall-arm/tasks.md
+++ b/openspec/changes/tighten-grind-yield-shortfall-arm/tasks.md
@@ -1,0 +1,29 @@
+# Tasks
+
+## 1. Threshold + gate split
+
+- [ ] 1.1 Change `CHOKED_YIELD_RATIO_MAX` in `src/ai/shotanalysis.h` from `0.85` to `0.70`.
+- [ ] 1.2 Restructure `analyzeFlowVsGoal` in `src/ai/shotanalysis.cpp` so the outer gate is `flowSamples >= 5` (the loose precondition shared by both arms). The flow-choked arm's `pressurizedDuration >= CHOKED_DURATION_MIN_SEC` check moves inside the flow-arm-specific block.
+- [ ] 1.3 Set `result.hasData = true` whenever ANY arm could speak (flow-arm gates passed OR yield-shortfall fired). The verified-clean path still requires the flow-arm gates passed (preserves the strong "we saw a healthy pour" semantics).
+- [ ] 1.4 Update the existing `result.sampleCount = flowSamples` assignment so it sets when the choked path fires (any arm), keeping current consumer-visible semantics.
+
+## 2. Tests
+
+- [ ] 2.1 New test `grindCheck_yieldArm_firesWithoutSustainedPressurized` — synthesize a shot 745-shape: 35s pour, brief pressurized window (~6s above 4 bar), yield 0.64 ratio. Assert `chokedPuck=true`, `hasData=true`, `verifiedClean=false`, the warning line "Pour produced near-zero flow while pressure held" fires (or the appropriate yield-shortfall summary line), and `grindIssueDetected=true` projects.
+- [ ] 2.2 New test `grindCheck_yieldArm_doesNotFireOnBorderlineRatio` — synthesize 0.75 yield ratio. Assert it stays silent (boundary case for the 0.70 threshold). Verdict reads "Clean shot. Puck held well." (or "verified" coverage if Arm 1 ran).
+- [ ] 2.3 New test `grindCheck_flowArm_stillRequiresFifteenSeconds` — synthesize a shot with 0.5 mL/s mean flow but only 10s pressurized. Assert `chokedPuck=false` (flow arm gate not satisfied). Locks in that the flow-arm gate change is one-directional.
+- [ ] 2.4 Re-verify `analyzeShot_chokedPuck_structuredFieldsMatchProse` and `badgeProjection_*` tests still pass (ratios used are well under 0.5 in the existing fixtures).
+- [ ] 2.5 Re-validate `tests/data/shots/manifest.json` corpus regression. Specifically check `80s_choked_moderate.json` — its yield ratio is near the 0.7 boundary; if the expected outcome changes, update the manifest entry.
+
+## 3. Docs
+
+- [ ] 3.1 Update `docs/SHOT_REVIEW.md` §2.2 (grind detector internals): change the moderate-yield-arm threshold from `< 0.85` to `< 0.70` in both the prose and the example. Add a sentence explaining the audit-driven rationale ("0.85 over-flagged Adaptive v2 fast-pour profiles delivering 71-76% of target by design; 0.70 is the empirical sweet spot from the 500-shot audit").
+- [ ] 3.2 Update `docs/SHOT_REVIEW.md` §2.2 (grind detector internals): document the gate split — flow arm requires sustained 15s, yield arm runs as soon as any pressurized samples were seen.
+
+## 4. Validation
+
+- [ ] 4.1 `openspec validate tighten-grind-yield-shortfall-arm --strict --no-interactive` passes.
+- [ ] 4.2 Build (`mcp__qtcreator__build`) clean.
+- [ ] 4.3 `tst_shotanalysis` passes (existing + 3 new tests).
+- [ ] 4.4 `shot_corpus_regression` ctest target passes.
+- [ ] 4.5 Manual smoke: re-run the Gap A simulation against the live audit data after the build; confirm 5 newly-flagged shots match the expected list (745, 752, 753, 754, 735).


### PR DESCRIPTION
## Summary
OpenSpec proposal for #963 Gap A: decouple the yield-shortfall arm from the 15s pressurized-duration gate, and tighten \`CHOKED_YIELD_RATIO_MAX\` from 0.85 to 0.70. Forward-looking detector tuning — catches the actionable "grind too fine, coarsen" pattern on shots that today silently read "Clean shot. Puck held well."

## Motivation

Concrete miss: shot 745 (Adaptive v2, 35s pour, yield 23.1/36 = 0.64) — well below the 0.85 moderate-choke threshold, but its pressurized duration was only 8.76s. The shared 15s gate silenced both arms together. User makes no change, repeats the underextraction.

## Simulation

Against the 17 currently-silent under-target shots in the audit:

| Approach | New fires |
|---|---|
| Drop duration gate; keep 0.85 ratio | 9 (4 likely FPs on Adaptive v2 fast-pour profiles delivering 71-76% by design) |
| **Drop duration gate; tighten ratio to 0.70** | **5** (745, 752, 753, 754, 735 — all genuinely choked-shaped) |

The 0.70 threshold is the empirical sweet spot from the 500-shot audit.

## Scope

- One \`## MODIFIED Requirements\` block updating the existing grind-detector-coverage requirement to document split gating between the flow arm (still requires 15s sustained pressurized) and the yield arm (runs as soon as ≥ 5 pressurized samples).
- 6 scenarios — 4 keep prior semantics; 2 new ones cover the new yield-shortfall-fires-on-brief-pressurized case and the borderline (0.75 ratio) silence case.

## Tasks (high-level)

1. Threshold + gate split (3-4 line C++ change)
2. 3 new tests
3. Re-validate corpus
4. Update SHOT_REVIEW.md §2.2

## Validation
- [x] \`openspec validate tighten-grind-yield-shortfall-arm --strict --no-interactive\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)