### PR TITLE
test(profile): refresh tst_profile fixtures after #961 dropped temp auto-sync (#968)

### DIFF
--- a/tests/tst_profile.cpp
+++ b/tests/tst_profile.cpp
@@ -33,10 +33,12 @@ private:
         obj["minimum_pressure"] = 0.0;
         obj["number_of_preinfuse_frames"] = 1;
 
-        // One simple frame with nested exit
+        // One simple frame with nested exit. Frame temp matches top-level so the
+        // round-trip test asserts genuine preservation; mismatch behavior is
+        // covered by espressoTempNotSyncedFromFirstFrame.
         QJsonObject frame;
         frame["name"] = "preinfusion";
-        frame["temperature"] = 88.0;
+        frame["temperature"] = 93.0;
         frame["sensor"] = "coffee";
         frame["pump"] = "flow";
         frame["transition"] = "fast";
@@ -105,7 +107,7 @@ private slots:
         QCOMPARE(p2.profileType(), QString("settings_2c"));
         QCOMPARE(p2.targetWeight(), 36.0);
         QCOMPARE(p2.targetVolume(), 0.0);
-        QCOMPARE(p2.espressoTemperature(), 88.0);  // Synced from first frame for advanced profiles
+        QCOMPARE(p2.espressoTemperature(), 93.0);
         QCOMPARE(p2.steps().size(), 1);
         QCOMPARE(p2.preinfuseFrameCount(), 1);  // Explicit value from makeAdvancedProfileJson()
     }
@@ -158,7 +160,7 @@ private slots:
 
         QJsonObject frame;
         frame["name"] = "test";
-        frame["temperature"] = QString("88.0");
+        frame["temperature"] = QString("93.5");
         frame["pressure"] = QString("9.0");
         frame["flow"] = QString("2.0");
         frame["seconds"] = QString("30.0");
@@ -169,9 +171,9 @@ private slots:
         Profile p = Profile::fromJson(QJsonDocument(obj));
         QCOMPARE(p.targetWeight(), 36.0);
         QCOMPARE(p.targetVolume(), 100.0);
-        QCOMPARE(p.espressoTemperature(), 88.0);  // Synced from first frame
+        QCOMPARE(p.espressoTemperature(), 93.5);
         QCOMPARE(p.preinfuseFrameCount(), 2);
-        QCOMPARE(p.steps()[0].temperature, 88.0);
+        QCOMPARE(p.steps()[0].temperature, 93.5);
         QCOMPARE(p.steps()[0].pressure, 9.0);
     }
 
@@ -655,13 +657,22 @@ private slots:
 
     // ===== Espresso temperature sync =====
 
-    void espressoTempSyncFromFirstFrame() {
-        // For advanced profiles, espresso_temperature syncs from first frame
+    void espressoTempNotSyncedFromFirstFrame() {
+        // Regression guard for #968 / PR #961: fromJson must NOT rewrite the
+        // top-level espresso_temperature from steps[0].temperature when both
+        // are present. The mismatch is intentional on D-Flow/A-Flow profiles
+        // (cooler group preheat target paired with a hotter preinfusion ramp).
         QJsonObject obj = makeAdvancedProfileJson();
         obj["espresso_temperature"] = 90.0;
-        // First frame has temp 88.0
+        QJsonArray steps = obj["steps"].toArray();
+        QJsonObject frame = steps[0].toObject();
+        frame["temperature"] = 88.0;
+        steps.replace(0, frame);
+        obj["steps"] = steps;
+
         Profile p = Profile::fromJson(QJsonDocument(obj));
-        QCOMPARE(p.espressoTemperature(), 88.0);  // Synced from first frame
+        QCOMPARE(p.espressoTemperature(), 90.0);  // top-level preserved
+        QCOMPARE(p.steps()[0].temperature, 88.0); // frame preserved
     }
 
     void espressoTempNoSyncForSimple() {


### PR DESCRIPTION
Closes #968.

## Summary
- PR #961 (commit `c4f4f9b1`) stopped `Profile::fromJson` from force-syncing the top-level `espresso_temperature` to `steps[0].temperature` on every parse. Three fixtures in `tests/tst_profile.cpp` had encoded the now-removed side-effect and were failing on `main`.
- `jsonRoundTripAdvanced` (`tests/tst_profile.cpp:94`) and `jsonStringEncodedNumbers` (`tests/tst_profile.cpp:149`) used a deliberate top-level/frame mismatch (93 vs 88) and asserted the post-sync value. With the heal correctly removed, round-trip preserves 93. Aligned the fixtures so the test verifies what it always meant to: parse → serialize → parse is stable.
- `espressoTempSyncFromFirstFrame` was the literal "the auto-sync feature works" test. Inverted to `espressoTempNotSyncedFromFirstFrame` (asserts top-level 90 and frame 88 both survive `fromJson`) — turns lost coverage into a forward-looking regression guard against the heal sneaking back in.

Other 1837 tests continue to pass; the 3 previously failing tests are now green.

## Test plan
- [x] `tst_profile` runs locally — 88 pass, 0 fail
- [x] Manual review: assertions match #961's intent (top-level authoritative at load time, frame values preserved as-authored)
- [ ] CI on this PR (none expected — test-only change, platform workflows run on tag push per project policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)