### PR TITLE
refactor(history): replace shot projection map with ShotProjection Q_GADGET (#975)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,7 @@ set(SOURCES
     src/history/shothistorystorage_internal.cpp
     src/history/shothistorystorage_serialize.cpp
     src/history/shothistorystorage_queries.cpp
+    src/history/shotprojection.cpp
     src/history/shotdebuglogger.cpp
     src/history/shotfileparser.cpp
     src/history/shotimporter.cpp
@@ -458,6 +459,7 @@ set(HEADERS
     src/history/shothistory_types.h
     src/history/shothistorystorage.h
     src/history/shothistorystorage_internal.h
+    src/history/shotprojection.h
     src/history/shotdebuglogger.h
     src/history/shotfileparser.h
     src/history/shotimporter.h

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -353,7 +353,7 @@ QString AIManager::generateShotSummary(ShotDataModel* shotData,
     return m_summarizer->buildUserPrompt(summary);
 }
 
-QString AIManager::generateHistoryShotSummary(const QVariantMap& shotData)
+QString AIManager::generateHistoryShotSummary(const ShotProjection& shotData)
 {
     ShotSummary summary = m_summarizer->summarizeFromHistory(shotData);
     return m_summarizer->buildUserPrompt(summary);
@@ -368,12 +368,12 @@ void AIManager::setShotHistoryStorage(ShotHistoryStorage* storage)
 // Returns (timestamp, fullShot) pairs. Extracted from requestRecentShotContext
 // to reduce lambda nesting. NOT safe to call from the main thread (would conflict
 // with the primary DB connection).
-static QList<QPair<qint64, QVariantMap>> loadQualifiedShots(
+static QList<QPair<qint64, ShotProjection>> loadQualifiedShots(
     const QString& dbPath,
     const QString& beanBrand, const QString& beanType,
     const QString& profileName, int excludeShotId)
 {
-    QList<QPair<qint64, QVariantMap>> qualifiedShots;
+    QList<QPair<qint64, ShotProjection>> qualifiedShots;
 
     withTempDb(dbPath, "ai_context", [&](QSqlDatabase& db) {
         // 1. Look up the current shot's timestamp
@@ -444,7 +444,7 @@ static QList<QPair<qint64, QVariantMap>> loadQualifiedShots(
                 continue;
             }
 
-            QVariantMap fullShot;
+            ShotProjection fullShot;
             try {
                 ShotRecord record = ShotHistoryStorage::loadShotRecordStatic(db, c.id);
                 fullShot = ShotHistoryStorage::convertShotRecord(record);
@@ -452,14 +452,13 @@ static QList<QPair<qint64, QVariantMap>> loadQualifiedShots(
                 qWarning() << "  Shot id=" << c.id << "-> SKIPPED (exception:" << e.what() << ")";
                 continue;
             }
-            if (fullShot.isEmpty()) {
+            if (!fullShot.isValid()) {
                 qWarning() << "  Shot id=" << c.id << "-> SKIPPED (convertShotRecord returned empty)";
                 continue;
             }
 
             // Check targetWeight-based mistake filter (needs full record)
-            double targetWeight = fullShot.value("targetWeightG", 0.0).toDouble();
-            if (targetWeight > 0.0 && c.finalWeight < targetWeight / 3.0) {
+            if (fullShot.targetWeightG > 0.0 && c.finalWeight < fullShot.targetWeightG / 3.0) {
                 qDebug() << "  Shot id=" << c.id << "-> SKIPPED (mistake, weight < 1/3 target)";
                 continue;
             }
@@ -990,16 +989,11 @@ bool AIManager::isSupportedBeverageType(const QString& beverageType) const
     return bev.isEmpty() || bev == "espresso" || bev == "filter" || bev == "pourover";
 }
 
-bool AIManager::isMistakeShot(const QVariantMap& shotData) const
+bool AIManager::isMistakeShot(const ShotProjection& shotData) const
 {
-    double duration = shotData.value("durationSec", 0.0).toDouble();
-    double finalWeight = shotData.value("finalWeightG", 0.0).toDouble();
-    double targetWeight = shotData.value("targetWeightG", 0.0).toDouble();
-
-    if (duration < 10.0) return true;
-    if (finalWeight < 5.0) return true;
-    if (targetWeight > 0.0 && finalWeight < targetWeight / 3.0) return true;
-
+    if (shotData.durationSec < 10.0) return true;
+    if (shotData.finalWeightG < 5.0) return true;
+    if (shotData.targetWeightG > 0.0 && shotData.finalWeightG < shotData.targetWeightG / 3.0) return true;
     return false;
 }
 

--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -8,6 +8,8 @@
 #include <QVariantMap>
 #include <memory>
 
+#include "../history/shotprojection.h"
+
 class QNetworkAccessManager;
 class AIProvider;
 class AIConversation;
@@ -72,7 +74,7 @@ public:
     Q_INVOKABLE QString switchConversation(const QString& beanBrand, const QString& beanType, const QString& profileName);
     Q_INVOKABLE void loadMostRecentConversation();
     Q_INVOKABLE void clearCurrentConversation();
-    Q_INVOKABLE bool isMistakeShot(const QVariantMap& shotData) const;
+    Q_INVOKABLE bool isMistakeShot(const ShotProjection& shotData) const;
     Q_INVOKABLE bool isSupportedBeverageType(const QString& beverageType) const;
     static QString conversationKey(const QString& beanBrand, const QString& beanType, const QString& profileName);
 
@@ -115,7 +117,7 @@ public:
                                              const QVariantMap& metadata);
 
     // Generate shot summary from historical shot data (for ShotDetailPage)
-    Q_INVOKABLE QString generateHistoryShotSummary(const QVariantMap& shotData);
+    Q_INVOKABLE QString generateHistoryShotSummary(const ShotProjection& shotData);
 
     // Shot history access for contextual recommendations
     void setShotHistoryStorage(ShotHistoryStorage* storage);

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -481,12 +481,12 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
         return summary;
     }
 
-    // Slow path: legacy shotData (e.g. imported shots, direct test callers,
-    // any QVariantMap that didn't flow through convertShotRecord) lacks the
-    // pre-computed fields. Delegate detector orchestration to
-    // runShotAnalysisAndPopulate, the same helper summarize() uses on the
-    // live path — see summarize() for rationale. historyMarkers was already
-    // populated alongside the PhaseSummary list above (single pass).
+    // Slow path: shotData not produced by convertShotRecord (imported shots,
+    // direct test callers) has empty summaryLines and needs the full analysis
+    // pipeline. Delegate detector orchestration to runShotAnalysisAndPopulate,
+    // the same helper summarize() uses on the live path — see summarize() for
+    // rationale. historyMarkers was already populated alongside the
+    // PhaseSummary list above (single pass).
     const QStringList analysisFlags = getAnalysisFlags(summary.profileKbId);
 
     // First-frame seconds reuses the profileDoc parsed at the top of this
@@ -787,7 +787,7 @@ QString ShotSummarizer::buildHistoryContext(const QVariantList& recentShots)
 
         const double ratio = shot.doseWeightG > 0 ? shot.finalWeightG / shot.doseWeightG : 0;
 
-        out << "### Shot " << (i + 1) << " (" << shot.dateTime << ")\n";
+        out << "### Shot " << (i + 1) << " (" << shot.timestampIso << ")\n";
         out << "- Profile: " << shot.profileName << "\n";
         out << "- Dose: " << QString::number(shot.doseWeightG, 'f', 1) << "g → Yield: "
             << QString::number(shot.finalWeightG, 'f', 1) << "g (1:" << QString::number(ratio, 'f', 1) << ")\n";

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -341,20 +341,20 @@ static QVector<QPointF> variantListToPoints(const QVariantList& list)
     return points;
 }
 
-ShotSummary ShotSummarizer::summarizeFromHistory(const QVariantMap& shotData) const
+ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData) const
 {
     ShotSummary summary;
 
     // Profile info
-    summary.profileTitle = shotData.value("profileName", "Unknown").toString();
-    summary.beverageType = shotData.value("beverageType", "espresso").toString();
-    summary.profileNotes = shotData.value("profileNotes").toString();
-    summary.profileKbId = shotData.value("profileKbId").toString();
+    summary.profileTitle = shotData.profileName.isEmpty() ? QStringLiteral("Unknown") : shotData.profileName;
+    summary.beverageType = shotData.beverageType.isEmpty() ? QStringLiteral("espresso") : shotData.beverageType;
+    summary.profileNotes = shotData.profileNotes;
+    summary.profileKbId = shotData.profileKbId;
 
     // Parse stored profile JSON once and use it for: (1) editorType-derived
     // profile-style description, (2) frame description, (3) firstFrameSeconds
     // for skip-first-frame detection. Was three separate parses; now one.
-    const QString profileJson = shotData.value("profileJson").toString();
+    const QString profileJson = shotData.profileJson;
     QJsonDocument profileDoc;
     if (!profileJson.isEmpty()) {
         profileDoc = QJsonDocument::fromJson(profileJson.toUtf8());
@@ -387,33 +387,33 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const QVariantMap& shotData) co
     }
 
     // Overall metrics
-    summary.doseWeight = shotData.value("doseWeightG", 0.0).toDouble();
-    summary.finalWeight = shotData.value("finalWeightG", 0.0).toDouble();
-    summary.totalDuration = shotData.value("durationSec", 0.0).toDouble();
+    summary.doseWeight = shotData.doseWeightG;
+    summary.finalWeight = shotData.finalWeightG;
+    summary.totalDuration = shotData.durationSec;
     summary.ratio = summary.doseWeight > 0 ? summary.finalWeight / summary.doseWeight : 0;
 
     // DYE metadata
-    summary.beanBrand = shotData.value("beanBrand").toString();
-    summary.beanType = shotData.value("beanType").toString();
-    summary.roastDate = shotData.value("roastDate").toString();
-    summary.roastLevel = shotData.value("roastLevel").toString();
-    summary.grinderBrand = shotData.value("grinderBrand").toString();
-    summary.grinderModel = shotData.value("grinderModel").toString();
-    summary.grinderBurrs = shotData.value("grinderBurrs").toString();
-    summary.grinderSetting = shotData.value("grinderSetting").toString();
-    summary.drinkTds = shotData.value("drinkTds", 0.0).toDouble();
-    summary.drinkEy = shotData.value("drinkEy", 0.0).toDouble();
-    summary.enjoymentScore = shotData.value("enjoyment", 0).toInt();
-    summary.tastingNotes = shotData.value("espressoNotes").toString();
+    summary.beanBrand = shotData.beanBrand;
+    summary.beanType = shotData.beanType;
+    summary.roastDate = shotData.roastDate;
+    summary.roastLevel = shotData.roastLevel;
+    summary.grinderBrand = shotData.grinderBrand;
+    summary.grinderModel = shotData.grinderModel;
+    summary.grinderBurrs = shotData.grinderBurrs;
+    summary.grinderSetting = shotData.grinderSetting;
+    summary.drinkTds = shotData.drinkTds;
+    summary.drinkEy = shotData.drinkEy;
+    summary.enjoymentScore = shotData.enjoyment;
+    summary.tastingNotes = shotData.espressoNotes;
 
     // Convert curve data
-    summary.pressureCurve = variantListToPoints(shotData.value("pressure").toList());
-    summary.flowCurve = variantListToPoints(shotData.value("flow").toList());
-    summary.tempCurve = variantListToPoints(shotData.value("temperature").toList());
-    summary.weightCurve = variantListToPoints(shotData.value("weight").toList());
-    summary.pressureGoalCurve = variantListToPoints(shotData.value("pressureGoal").toList());
-    summary.flowGoalCurve = variantListToPoints(shotData.value("flowGoal").toList());
-    summary.tempGoalCurve = variantListToPoints(shotData.value("temperatureGoal").toList());
+    summary.pressureCurve = variantListToPoints(shotData.pressure);
+    summary.flowCurve = variantListToPoints(shotData.flow);
+    summary.tempCurve = variantListToPoints(shotData.temperature);
+    summary.weightCurve = variantListToPoints(shotData.weight);
+    summary.pressureGoalCurve = variantListToPoints(shotData.pressureGoal);
+    summary.flowGoalCurve = variantListToPoints(shotData.flowGoal);
+    summary.tempGoalCurve = variantListToPoints(shotData.temperatureGoal);
 
     if (summary.pressureCurve.isEmpty()) return summary;
 
@@ -423,7 +423,7 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const QVariantMap& shotData) co
     // contribute their HistoryPhaseMarker (frame transitions matter to
     // skip-first-frame detection even when their span is degenerate).
     QList<HistoryPhaseMarker> historyMarkers;
-    const QVariantList phases = shotData.value("phases").toList();
+    const QVariantList phases = shotData.phases;
     historyMarkers.reserve(phases.size());
 
     if (!phases.isEmpty()) {
@@ -472,11 +472,9 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const QVariantMap& shotData) co
     // If detectorResults is absent, .toBool() defaults to false, so a callsite
     // that stuffs only summaryLines could mis-suppress per-phase temp markers
     // on a truncated-pour shot. Today no such callsite exists.
-    const QVariantList preComputedLines = shotData.value("summaryLines").toList();
-    if (!preComputedLines.isEmpty()) {
-        summary.summaryLines = preComputedLines;
-        const QVariantMap preDetectors = shotData.value("detectorResults").toMap();
-        summary.pourTruncatedDetected = preDetectors.value("pourTruncated").toBool();
+    if (!shotData.summaryLines.isEmpty()) {
+        summary.summaryLines = shotData.summaryLines;
+        summary.pourTruncatedDetected = shotData.detectorResults.value("pourTruncated").toBool();
         if (!summary.pourTruncatedDetected
             && ShotAnalysis::reachedExtractionPhase(historyMarkers, summary.totalDuration))
             markPerPhaseTempInstability(summary, summary.tempCurve, summary.tempGoalCurve);
@@ -504,12 +502,12 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const QVariantMap& shotData) co
         frameCount = static_cast<int>(p.steps().size());
     }
 
-    const QVector<QPointF> derivCurve = variantListToPoints(shotData.value("conductanceDerivative").toList());
+    const QVector<QPointF> derivCurve = variantListToPoints(shotData.conductanceDerivative);
 
     // Per-shot targetWeight drives both arms of the grind-vs-yield check
     // (the choked-puck yield arm and the gusher arm added in PR #910) —
     // matches the input convertShotRecord passes to analyzeShot.
-    const double targetWeightG = shotData.value("targetWeightG").toDouble();
+    const double targetWeightG = shotData.targetWeightG;
 
     runShotAnalysisAndPopulate(summary,
         summary.pressureCurve, summary.flowCurve, summary.weightCurve,
@@ -776,85 +774,72 @@ QString ShotSummarizer::buildHistoryContext(const QVariantList& recentShots)
     out << "## Recent Shot History (same profile family, newest first)\n\n";
     out << "Use this to identify dial-in trends — what changed between shots and how it affected the result.\n\n";
 
+    // Convert each map entry to ShotProjection so the rest of this block reads
+    // fields with compile-time-checked names. The input is a QVariantList from
+    // ShotHistoryStorage::loadRecentShotsByKbIdStatic — that producer emits a
+    // map with the same keys as ShotProjection's Q_PROPERTYs, so the round-trip
+    // through fromVariantMap() is lossless for the fields read here.
     for (qsizetype i = 0; i < recentShots.size(); ++i) {
-        QVariantMap shot = recentShots[i].toMap();
-
-        QString dateTime = shot.value("dateTime").toString();
-        double dose = shot.value("doseWeightG", 0.0).toDouble();
-        double yield = shot.value("finalWeightG", 0.0).toDouble();
-        double duration = shot.value("durationSec", 0.0).toDouble();
+        const ShotProjection shot = ShotProjection::fromVariantMap(recentShots[i].toMap());
 
         // Skip entries with no meaningful data (corrupt or incomplete records)
-        if (dose <= 0 && yield <= 0 && duration <= 0) continue;
+        if (shot.doseWeightG <= 0 && shot.finalWeightG <= 0 && shot.durationSec <= 0) continue;
 
-        double ratio = dose > 0 ? yield / dose : 0;
-        int score = shot.value("enjoyment", 0).toInt();
+        const double ratio = shot.doseWeightG > 0 ? shot.finalWeightG / shot.doseWeightG : 0;
 
-        out << "### Shot " << (i + 1) << " (" << dateTime << ")\n";
-        out << "- Profile: " << shot.value("profileName").toString() << "\n";
-        out << "- Dose: " << QString::number(dose, 'f', 1) << "g → Yield: "
-            << QString::number(yield, 'f', 1) << "g (1:" << QString::number(ratio, 'f', 1) << ")\n";
-        out << "- Duration: " << QString::number(duration, 'f', 0) << "s\n";
+        out << "### Shot " << (i + 1) << " (" << shot.dateTime << ")\n";
+        out << "- Profile: " << shot.profileName << "\n";
+        out << "- Dose: " << QString::number(shot.doseWeightG, 'f', 1) << "g → Yield: "
+            << QString::number(shot.finalWeightG, 'f', 1) << "g (1:" << QString::number(ratio, 'f', 1) << ")\n";
+        out << "- Duration: " << QString::number(shot.durationSec, 'f', 0) << "s\n";
 
         // Grinder info
-        QString grinderBrand = shot.value("grinderBrand").toString();
-        QString grinderModel = shot.value("grinderModel").toString();
-        QString grinderBurrs = shot.value("grinderBurrs").toString();
-        QString grinderSetting = shot.value("grinderSetting").toString();
-        if (!grinderBrand.isEmpty() || !grinderModel.isEmpty() || !grinderSetting.isEmpty()) {
+        if (!shot.grinderBrand.isEmpty() || !shot.grinderModel.isEmpty() || !shot.grinderSetting.isEmpty()) {
             out << "- Grinder: ";
-            if (!grinderBrand.isEmpty()) out << grinderBrand;
-            if (!grinderModel.isEmpty()) {
-                if (!grinderBrand.isEmpty()) out << " ";
-                out << grinderModel;
+            if (!shot.grinderBrand.isEmpty()) out << shot.grinderBrand;
+            if (!shot.grinderModel.isEmpty()) {
+                if (!shot.grinderBrand.isEmpty()) out << " ";
+                out << shot.grinderModel;
             }
-            if (!grinderBurrs.isEmpty()) out << " with " << grinderBurrs;
-            if (!grinderSetting.isEmpty()) out << " @ " << grinderSetting;
+            if (!shot.grinderBurrs.isEmpty()) out << " with " << shot.grinderBurrs;
+            if (!shot.grinderSetting.isEmpty()) out << " @ " << shot.grinderSetting;
             out << "\n";
         }
 
         // Temperature override
-        double tempOverride = shot.value("temperatureOverrideC", 0.0).toDouble();
-        if (tempOverride > 0) {
-            out << "- Temperature override: " << QString::number(tempOverride, 'f', 1) << "°C\n";
+        if (shot.temperatureOverrideC > 0) {
+            out << "- Temperature override: " << QString::number(shot.temperatureOverrideC, 'f', 1) << "°C\n";
         }
 
         // Bean info
-        QString beanBrand = shot.value("beanBrand").toString();
-        QString beanType = shot.value("beanType").toString();
-        if (!beanBrand.isEmpty() || !beanType.isEmpty()) {
-            out << "- Beans: " << beanBrand;
-            if (!beanBrand.isEmpty() && !beanType.isEmpty()) out << " - ";
-            out << beanType;
-            QString roastLevel = shot.value("roastLevel").toString();
-            if (!roastLevel.isEmpty()) out << " (" << roastLevel << ")";
+        if (!shot.beanBrand.isEmpty() || !shot.beanType.isEmpty()) {
+            out << "- Beans: " << shot.beanBrand;
+            if (!shot.beanBrand.isEmpty() && !shot.beanType.isEmpty()) out << " - ";
+            out << shot.beanType;
+            if (!shot.roastLevel.isEmpty()) out << " (" << shot.roastLevel << ")";
             out << "\n";
         }
 
         // Extraction measurements
-        double tds = shot.value("drinkTds", 0.0).toDouble();
-        double ey = shot.value("drinkEy", 0.0).toDouble();
-        if (tds > 0 || ey > 0) {
+        if (shot.drinkTds > 0 || shot.drinkEy > 0) {
             out << "- Extraction: ";
-            if (tds > 0) out << "TDS " << QString::number(tds, 'f', 2) << "%";
-            if (tds > 0 && ey > 0) out << ", ";
-            if (ey > 0) out << "EY " << QString::number(ey, 'f', 1) << "%";
+            if (shot.drinkTds > 0) out << "TDS " << QString::number(shot.drinkTds, 'f', 2) << "%";
+            if (shot.drinkTds > 0 && shot.drinkEy > 0) out << ", ";
+            if (shot.drinkEy > 0) out << "EY " << QString::number(shot.drinkEy, 'f', 1) << "%";
             out << "\n";
         }
 
         // Score and tasting notes
-        if (score > 0) {
-            out << "- Score: " << score << "/100\n";
+        if (shot.enjoyment > 0) {
+            out << "- Score: " << shot.enjoyment << "/100\n";
         }
-        QString notes = shot.value("espressoNotes").toString();
-        if (!notes.isEmpty()) {
-            out << "- Notes: \"" << notes << "\"\n";
+        if (!shot.espressoNotes.isEmpty()) {
+            out << "- Notes: \"" << shot.espressoNotes << "\"\n";
         }
 
         // Profile recipe (from stored JSON)
-        QString profileJson = shot.value("profileJson").toString();
-        if (!profileJson.isEmpty()) {
-            QString recipe = Profile::describeFramesFromJson(profileJson);
+        if (!shot.profileJson.isEmpty()) {
+            QString recipe = Profile::describeFramesFromJson(shot.profileJson);
             if (!recipe.isEmpty()) {
                 out << "- Recipe: " << recipe << "\n";
             }

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -8,6 +8,8 @@
 #include <QPointF>
 #include <QVariant>
 
+#include "../history/shotprojection.h"
+
 class ShotDataModel;
 class Profile;
 struct ShotMetadata;
@@ -120,8 +122,8 @@ public:
                           double doseWeight,
                           double finalWeight) const;
 
-    // Summarize from historical shot data (QVariantMap from database)
-    ShotSummary summarizeFromHistory(const QVariantMap& shotData) const;
+    // Summarize from historical shot data (typed projection from database)
+    ShotSummary summarizeFromHistory(const ShotProjection& shotData) const;
 
     // Generate text prompt from summary
     QString buildUserPrompt(const ShotSummary& summary) const;

--- a/src/history/shothistoryexporter.cpp
+++ b/src/history/shothistoryexporter.cpp
@@ -127,7 +127,7 @@ bool writeShotJson(const QString& dbPath,
         return false;
     }
 
-    QVariantMap shotData = ShotHistoryStorage::convertShotRecord(record);
+    ShotProjection shotData = ShotHistoryStorage::convertShotRecord(record);
     QByteArray payload = VisualizerUploader::buildHistoryShotJson(shotData);
 
     const QString fullPath = exportedFilePath(historyDir, record.summary.timestamp, shotId);

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1197,7 +1197,7 @@ void ShotHistoryStorage::requestMostRecentShotId()
 void ShotHistoryStorage::requestShot(qint64 shotId)
 {
     if (!m_ready) {
-        emit shotReady(shotId, QVariantMap());
+        emit shotReady(shotId, ShotProjection());
         return;
     }
 

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "shothistory_types.h"
+#include "shotprojection.h"
 
 #include <QObject>
 #include <QSqlDatabase>
@@ -87,8 +88,11 @@ public:
     // Thread-safe: caller provides their own connection. Shared by MCP and in-app AI.
     static GrinderContext queryGrinderContext(QSqlDatabase& db, const QString& grinderModel, const QString& beverageType);
 
-    // Convert ShotRecord to QVariantMap (shared by requestShot, ShotServer, AIManager)
-    static QVariantMap convertShotRecord(const ShotRecord& record);
+    // Convert ShotRecord to a typed ShotProjection (shared by requestShot,
+    // ShotServer, AIManager, MCP). Returns a default-constructed ShotProjection
+    // (id == 0, isValid() == false) when the record is empty. Replaces the
+    // QVariantMap projection that lived here pre-#975 — see shotprojection.h.
+    static ShotProjection convertShotRecord(const ShotRecord& record);
 
     // Thread-safe shot save: opens a temporary connection, does all INSERTs + WAL checkpoint.
     // Safe to call from any thread (does not use m_db). Returns shotId or -1 on failure.
@@ -206,7 +210,7 @@ signals:
     void errorOccurred(const QString& message);
     void shotsFilteredReady(const QVariantList& results, bool isAppend, int totalCount);
     void loadingFilteredChanged();
-    void shotReady(qint64 shotId, const QVariantMap& shot);
+    void shotReady(qint64 shotId, const ShotProjection& shot);
     void recentShotsByKbIdReady(const QString& kbId, const QVariantList& shots);
     void importDatabaseFinished(bool success);
     void shotMetadataUpdated(qint64 shotId, bool success);

--- a/src/history/shothistorystorage_queries.cpp
+++ b/src/history/shothistorystorage_queries.cpp
@@ -569,9 +569,12 @@ QVariantList ShotHistoryStorage::loadRecentShotsByKbIdStatic(QSqlDatabase& db, c
             shot["profileJson"] = query.value("profile_json").toString();
             shot["beverageType"] = query.value("beverage_type").toString();
 
-            // ISO 8601 with timezone for API/AI consumption (CLAUDE.md convention)
+            // ISO 8601 with timezone for API/AI consumption (CLAUDE.md convention).
+            // Written into ShotProjection::timestampIso so it does not collide with
+            // dateTime, which convertShotRecord populates with a locale-formatted
+            // display string for QML.
             QDateTime dt = QDateTime::fromSecsSinceEpoch(ts);
-            shot["dateTime"] = dt.toOffsetFromUtc(dt.offsetFromUtc()).toString(Qt::ISODate);
+            shot["timestampIso"] = dt.toOffsetFromUtc(dt.offsetFromUtc()).toString(Qt::ISODate);
 
             results.append(shot);
         }

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -106,6 +106,11 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     // AnalysisResult is already cached on `record.cachedAnalysis` (populated
     // alongside the badge projection). Read from there to avoid running
     // analyzeShot a second time on identical inputs.
+    //
+    // Slow path: ShotRecords without a cached analysis (test fixtures, direct
+    // construction) own a fresh AnalysisResult in `analysisOwned`, and
+    // `analysisPtr` points at it — keeping the address stable across the
+    // dereference below.
     {
         ShotAnalysis::AnalysisResult analysisOwned;
         const ShotAnalysis::AnalysisResult* analysisPtr = nullptr;

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -1,99 +1,100 @@
-// ShotHistoryStorage::convertShotRecord — serialization of a fully-loaded
-// ShotRecord into the QVariantMap shape consumed by QML, MCP, and the
-// Visualizer/Decenza upload flows. Split out of the main TU because it
-// owns ~200 lines of mechanical key-value mapping plus the
-// analyzeShot-fast-path-vs-fallback branch — a separate concern from the
-// DB lifecycle / save / load code that lives in shothistorystorage.cpp.
-//
-// convertShotRecord is a static method (declared `static` in
-// shothistorystorage.h), so all state is reached through the `record`
-// argument with no `this` pointer involved — that's what makes the
-// file split mechanical. Behavior is identical to the pre-split
-// implementation.
+// ShotHistoryStorage::convertShotRecord — builds a typed ShotProjection from
+// a fully-loaded ShotRecord. The body sits next to shothistorystorage.cpp
+// rather than in shotprojection.cpp because it depends on the internal-detail
+// helpers in shothistorystorage_internal.cpp (prepareAnalysisInputs, use12h).
+// Co-locating the call sites means tests that pull in shotprojection.cpp
+// don't transitively need internal.cpp — the dependency edge stays inside
+// the history TU set that already pulls in internal.cpp anyway.
 
 #include "shothistorystorage.h"
 #include "shothistorystorage_internal.h"
+#include "shotprojection.h"
 
 #include "ai/shotanalysis.h"
 
 #include <QDateTime>
 #include <QJsonDocument>
 
-QVariantMap ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
+namespace {
+
+QVariantList pointsToVariant(const QVector<QPointF>& points)
+{
+    QVariantList list;
+    list.reserve(points.size());
+    for (const auto& pt : points) {
+        QVariantMap p;
+        p["x"] = pt.x();
+        p["y"] = pt.y();
+        list.append(p);
+    }
+    return list;
+}
+
+} // namespace
+
+ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
 {
     using decenza::storage::detail::AnalysisInputs;
     using decenza::storage::detail::prepareAnalysisInputs;
     using decenza::storage::detail::use12h;
 
-    QVariantMap result;
-    if (record.summary.id == 0) return result;
+    ShotProjection p;
+    if (record.summary.id == 0) return p;
 
-    result["id"] = record.summary.id;
-    result["uuid"] = record.summary.uuid;
-    result["timestamp"] = record.summary.timestamp;
-    // ISO 8601 with timezone for MCP consumers (CLAUDE.md: "Never return Unix timestamps")
+    p.id = record.summary.id;
+    p.uuid = record.summary.uuid;
+    p.timestamp = record.summary.timestamp;
     auto isodt = QDateTime::fromSecsSinceEpoch(record.summary.timestamp);
-    result["timestampIso"] = isodt.toOffsetFromUtc(isodt.offsetFromUtc()).toString(Qt::ISODate);
-    result["profileName"] = record.summary.profileName;
-    result["durationSec"] = record.summary.duration;
-    result["finalWeightG"] = record.summary.finalWeight;
-    result["doseWeightG"] = record.summary.doseWeight;
-    result["beanBrand"] = record.summary.beanBrand;
-    result["beanType"] = record.summary.beanType;
-    result["enjoyment"] = record.summary.enjoyment;
-    result["hasVisualizerUpload"] = record.summary.hasVisualizerUpload;
-    result["beverageType"] = record.summary.beverageType;
-    result["roastDate"] = record.roastDate;
-    result["roastLevel"] = record.roastLevel;
-    result["grinderBrand"] = record.grinderBrand;
-    result["grinderModel"] = record.grinderModel;
-    result["grinderBurrs"] = record.grinderBurrs;
-    result["grinderSetting"] = record.grinderSetting;
-    result["drinkTds"] = record.drinkTds;
-    result["drinkEy"] = record.drinkEy;
-    result["espressoNotes"] = record.espressoNotes;
-    result["beanNotes"] = record.beanNotes;
-    result["barista"] = record.barista;
-    result["profileNotes"] = record.profileNotes;
-    result["visualizerId"] = record.visualizerId;
-    result["visualizerUrl"] = record.visualizerUrl;
-    result["debugLog"] = record.debugLog;
-    result["temperatureOverrideC"] = record.temperatureOverride;
-    result["targetWeightG"] = record.targetWeight;
-    result["profileJson"] = record.profileJson;
-    result["profileKbId"] = record.profileKbId;
+    p.timestampIso = isodt.toOffsetFromUtc(isodt.offsetFromUtc()).toString(Qt::ISODate);
+    p.profileName = record.summary.profileName;
+    p.durationSec = record.summary.duration;
+    p.finalWeightG = record.summary.finalWeight;
+    p.doseWeightG = record.summary.doseWeight;
+    p.beanBrand = record.summary.beanBrand;
+    p.beanType = record.summary.beanType;
+    p.enjoyment = record.summary.enjoyment;
+    p.hasVisualizerUpload = record.summary.hasVisualizerUpload;
+    p.beverageType = record.summary.beverageType;
+    p.roastDate = record.roastDate;
+    p.roastLevel = record.roastLevel;
+    p.grinderBrand = record.grinderBrand;
+    p.grinderModel = record.grinderModel;
+    p.grinderBurrs = record.grinderBurrs;
+    p.grinderSetting = record.grinderSetting;
+    p.drinkTds = record.drinkTds;
+    p.drinkEy = record.drinkEy;
+    p.espressoNotes = record.espressoNotes;
+    p.beanNotes = record.beanNotes;
+    p.barista = record.barista;
+    p.profileNotes = record.profileNotes;
+    p.visualizerId = record.visualizerId;
+    p.visualizerUrl = record.visualizerUrl;
+    p.debugLog = record.debugLog;
+    p.temperatureOverrideC = record.temperatureOverride;
+    p.targetWeightG = record.targetWeight;
+    p.profileJson = record.profileJson;
+    p.profileKbId = record.profileKbId;
 
-    auto pointsToVariant = [](const QVector<QPointF>& points) {
-        QVariantList list;
-        for (const auto& pt : points) {
-            QVariantMap p;
-            p["x"] = pt.x();
-            p["y"] = pt.y();
-            list.append(p);
-        }
-        return list;
-    };
+    p.pressure = pointsToVariant(record.pressure);
+    p.flow = pointsToVariant(record.flow);
+    p.temperature = pointsToVariant(record.temperature);
+    p.temperatureMix = pointsToVariant(record.temperatureMix);
+    p.resistance = pointsToVariant(record.resistance);
+    p.conductance = pointsToVariant(record.conductance);
+    p.darcyResistance = pointsToVariant(record.darcyResistance);
+    p.conductanceDerivative = pointsToVariant(record.conductanceDerivative);
+    p.waterDispensed = pointsToVariant(record.waterDispensed);
+    p.pressureGoal = pointsToVariant(record.pressureGoal);
+    p.flowGoal = pointsToVariant(record.flowGoal);
+    p.temperatureGoal = pointsToVariant(record.temperatureGoal);
+    p.weight = pointsToVariant(record.weight);
+    p.weightFlowRate = pointsToVariant(record.weightFlowRate);
 
-    result["pressure"] = pointsToVariant(record.pressure);
-    result["flow"] = pointsToVariant(record.flow);
-    result["temperature"] = pointsToVariant(record.temperature);
-    result["temperatureMix"] = pointsToVariant(record.temperatureMix);
-    result["resistance"] = pointsToVariant(record.resistance);
-    result["conductance"] = pointsToVariant(record.conductance);
-    result["darcyResistance"] = pointsToVariant(record.darcyResistance);
-    result["conductanceDerivative"] = pointsToVariant(record.conductanceDerivative);
-    result["waterDispensed"] = pointsToVariant(record.waterDispensed);
-    result["pressureGoal"] = pointsToVariant(record.pressureGoal);
-    result["flowGoal"] = pointsToVariant(record.flowGoal);
-    result["temperatureGoal"] = pointsToVariant(record.temperatureGoal);
-    result["weight"] = pointsToVariant(record.weight);
-    result["weightFlowRate"] = pointsToVariant(record.weightFlowRate);
-
-    result["channelingDetected"] = record.channelingDetected;
-    result["temperatureUnstable"] = record.temperatureUnstable;
-    result["grindIssueDetected"] = record.grindIssueDetected;
-    result["skipFirstFrameDetected"] = record.skipFirstFrameDetected;
-    result["pourTruncatedDetected"] = record.pourTruncatedDetected;
+    p.channelingDetected = record.channelingDetected;
+    p.temperatureUnstable = record.temperatureUnstable;
+    p.grindIssueDetected = record.grindIssueDetected;
+    p.skipFirstFrameDetected = record.skipFirstFrameDetected;
+    p.pourTruncatedDetected = record.pourTruncatedDetected;
 
     // Run the full shot-summary detector pipeline once and expose both the
     // prose lines (rendered by the in-app dialog) and the structured detector
@@ -105,15 +106,8 @@ QVariantMap ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     // AnalysisResult is already cached on `record.cachedAnalysis` (populated
     // alongside the badge projection). Read from there to avoid running
     // analyzeShot a second time on identical inputs.
-    //
-    // Slow path: direct-construction callers (tests, any future path that
-    // bypasses loadShotRecordStatic) hand us a ShotRecord without
-    // `cachedAnalysis`. prepareAnalysisInputs bundles analysisFlags +
-    // firstFrameSeconds + frameCount so this call site stays in lock-step
-    // with saveShot and loadShotRecordStatic — same lookups, same args
-    // passed to analyzeShot.
     {
-        ShotAnalysis::AnalysisResult analysisOwned;  // storage if we need to compute
+        ShotAnalysis::AnalysisResult analysisOwned;
         const ShotAnalysis::AnalysisResult* analysisPtr = nullptr;
         if (record.cachedAnalysis.has_value()) {
             analysisPtr = &record.cachedAnalysis.value();
@@ -130,7 +124,7 @@ QVariantMap ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
             analysisPtr = &analysisOwned;
         }
         const ShotAnalysis::AnalysisResult& analysis = *analysisPtr;
-        result["summaryLines"] = analysis.lines;
+        p.summaryLines = analysis.lines;
 
         const auto& d = analysis.detectors;
         QVariantMap detectorResults;
@@ -178,10 +172,6 @@ QVariantMap ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
             grind["chokedPuck"] = d.grindChokedPuck;
             grind["yieldOvershoot"] = d.grindYieldOvershoot;
             grind["verifiedClean"] = d.grindVerifiedClean;
-            // yieldRatio is populated whenever Arm 2's gate ran with a known
-            // target+final pair. Lifted to the top of the grind object (in
-            // addition to gates.yieldRatio) so consumers can read the value
-            // both checks compare against without descending into gates.
             if (d.grindGateYieldRatio > 0.0) {
                 grind["yieldRatio"] = d.grindGateYieldRatio;
             }
@@ -189,11 +179,6 @@ QVariantMap ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
         if (!d.grindCoverage.isEmpty()) {
             grind["coverage"] = d.grindCoverage;
         }
-        // Gate diagnostics from the choked-puck arm. Always emitted when the
-        // arm ran (`gateRan == true`) — even on gate-fail paths — so MCP
-        // consumers can answer "why didn't this badge fire?" without parsing
-        // the cascade source. Thresholds are emitted alongside the inputs
-        // so consumers don't need to re-derive them from CHOKED_* constants.
         if (d.grindGateRan) {
             QVariantMap gates;
             gates["passed"] = d.grindGatePassed;
@@ -218,29 +203,29 @@ QVariantMap ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
         detectorResults["skipFirstFrame"] = d.skipFirstFrame;
         detectorResults["verdictCategory"] = d.verdictCategory;
 
-        result["detectorResults"] = detectorResults;
+        p.detectorResults = detectorResults;
     }
 
-    // Phase summaries for UI (computed at save time or on-the-fly for legacy shots)
     if (!record.phaseSummariesJson.isEmpty()) {
         QJsonDocument phaseSummariesDoc = QJsonDocument::fromJson(record.phaseSummariesJson.toUtf8());
-        result["phaseSummaries"] = phaseSummariesDoc.toVariant();
+        p.phaseSummaries = phaseSummariesDoc.toVariant();
     }
 
     QVariantList phases;
+    phases.reserve(record.phases.size());
     for (const auto& phase : record.phases) {
-        QVariantMap p;
-        p["time"] = phase.time;
-        p["label"] = phase.label;
-        p["frameNumber"] = phase.frameNumber;
-        p["isFlowMode"] = phase.isFlowMode;
-        p["transitionReason"] = phase.transitionReason;
-        phases.append(p);
+        QVariantMap phaseMap;
+        phaseMap["time"] = phase.time;
+        phaseMap["label"] = phase.label;
+        phaseMap["frameNumber"] = phase.frameNumber;
+        phaseMap["isFlowMode"] = phase.isFlowMode;
+        phaseMap["transitionReason"] = phase.transitionReason;
+        phases.append(phaseMap);
     }
-    result["phases"] = phases;
+    p.phases = phases;
 
     QDateTime dt = QDateTime::fromSecsSinceEpoch(record.summary.timestamp);
-    result["dateTime"] = dt.toString(use12h() ? "yyyy-MM-dd h:mm:ss AP" : "yyyy-MM-dd HH:mm:ss");
+    p.dateTime = dt.toString(use12h() ? "yyyy-MM-dd h:mm:ss AP" : "yyyy-MM-dd HH:mm:ss");
 
-    return result;
+    return p;
 }

--- a/src/history/shotprojection.cpp
+++ b/src/history/shotprojection.cpp
@@ -1,0 +1,149 @@
+#include "shotprojection.h"
+
+#include <QMetaType>
+
+QVariantMap ShotProjection::toVariantMap() const
+{
+    if (!isValid()) return {};
+
+    QVariantMap m;
+    m["id"] = id;
+    m["uuid"] = uuid;
+    m["timestamp"] = timestamp;
+    m["timestampIso"] = timestampIso;
+    m["profileName"] = profileName;
+    m["durationSec"] = durationSec;
+    m["finalWeightG"] = finalWeightG;
+    m["doseWeightG"] = doseWeightG;
+    m["beanBrand"] = beanBrand;
+    m["beanType"] = beanType;
+    m["enjoyment"] = enjoyment;
+    m["hasVisualizerUpload"] = hasVisualizerUpload;
+    m["beverageType"] = beverageType;
+    m["roastDate"] = roastDate;
+    m["roastLevel"] = roastLevel;
+    m["grinderBrand"] = grinderBrand;
+    m["grinderModel"] = grinderModel;
+    m["grinderBurrs"] = grinderBurrs;
+    m["grinderSetting"] = grinderSetting;
+    m["drinkTds"] = drinkTds;
+    m["drinkEy"] = drinkEy;
+    m["espressoNotes"] = espressoNotes;
+    m["beanNotes"] = beanNotes;
+    m["barista"] = barista;
+    m["profileNotes"] = profileNotes;
+    m["visualizerId"] = visualizerId;
+    m["visualizerUrl"] = visualizerUrl;
+    m["debugLog"] = debugLog;
+    m["temperatureOverrideC"] = temperatureOverrideC;
+    m["targetWeightG"] = targetWeightG;
+    m["profileJson"] = profileJson;
+    m["profileKbId"] = profileKbId;
+
+    m["pressure"] = pressure;
+    m["flow"] = flow;
+    m["temperature"] = temperature;
+    m["temperatureMix"] = temperatureMix;
+    m["resistance"] = resistance;
+    m["conductance"] = conductance;
+    m["darcyResistance"] = darcyResistance;
+    m["conductanceDerivative"] = conductanceDerivative;
+    m["waterDispensed"] = waterDispensed;
+    m["pressureGoal"] = pressureGoal;
+    m["flowGoal"] = flowGoal;
+    m["temperatureGoal"] = temperatureGoal;
+    m["weight"] = weight;
+    m["weightFlowRate"] = weightFlowRate;
+
+    m["channelingDetected"] = channelingDetected;
+    m["temperatureUnstable"] = temperatureUnstable;
+    m["grindIssueDetected"] = grindIssueDetected;
+    m["skipFirstFrameDetected"] = skipFirstFrameDetected;
+    m["pourTruncatedDetected"] = pourTruncatedDetected;
+
+    m["summaryLines"] = summaryLines;
+    m["detectorResults"] = detectorResults;
+    if (phaseSummaries.isValid())
+        m["phaseSummaries"] = phaseSummaries;
+    m["phases"] = phases;
+    m["dateTime"] = dateTime;
+    return m;
+}
+
+QJsonObject ShotProjection::toJsonObject() const
+{
+    return QJsonObject::fromVariantMap(toVariantMap());
+}
+
+ShotProjection ShotProjection::fromVariantMap(const QVariantMap& m)
+{
+    ShotProjection p;
+    p.id = m.value("id").toLongLong();
+    p.uuid = m.value("uuid").toString();
+    p.timestamp = m.value("timestamp").toLongLong();
+    p.timestampIso = m.value("timestampIso").toString();
+    p.dateTime = m.value("dateTime").toString();
+    p.profileName = m.value("profileName").toString();
+    p.durationSec = m.value("durationSec").toDouble();
+    p.finalWeightG = m.value("finalWeightG").toDouble();
+    p.doseWeightG = m.value("doseWeightG").toDouble();
+    p.beanBrand = m.value("beanBrand").toString();
+    p.beanType = m.value("beanType").toString();
+    p.enjoyment = m.value("enjoyment").toInt();
+    p.hasVisualizerUpload = m.value("hasVisualizerUpload").toBool();
+    p.beverageType = m.value("beverageType").toString();
+    p.roastDate = m.value("roastDate").toString();
+    p.roastLevel = m.value("roastLevel").toString();
+    p.grinderBrand = m.value("grinderBrand").toString();
+    p.grinderModel = m.value("grinderModel").toString();
+    p.grinderBurrs = m.value("grinderBurrs").toString();
+    p.grinderSetting = m.value("grinderSetting").toString();
+    p.drinkTds = m.value("drinkTds").toDouble();
+    p.drinkEy = m.value("drinkEy").toDouble();
+    p.espressoNotes = m.value("espressoNotes").toString();
+    p.beanNotes = m.value("beanNotes").toString();
+    p.barista = m.value("barista").toString();
+    p.profileNotes = m.value("profileNotes").toString();
+    p.visualizerId = m.value("visualizerId").toString();
+    p.visualizerUrl = m.value("visualizerUrl").toString();
+    p.debugLog = m.value("debugLog").toString();
+    p.temperatureOverrideC = m.value("temperatureOverrideC").toDouble();
+    p.targetWeightG = m.value("targetWeightG").toDouble();
+    p.profileJson = m.value("profileJson").toString();
+    p.profileKbId = m.value("profileKbId").toString();
+
+    p.channelingDetected = m.value("channelingDetected").toBool();
+    p.temperatureUnstable = m.value("temperatureUnstable").toBool();
+    p.grindIssueDetected = m.value("grindIssueDetected").toBool();
+    p.skipFirstFrameDetected = m.value("skipFirstFrameDetected").toBool();
+    p.pourTruncatedDetected = m.value("pourTruncatedDetected").toBool();
+
+    p.pressure = m.value("pressure").toList();
+    p.flow = m.value("flow").toList();
+    p.temperature = m.value("temperature").toList();
+    p.temperatureMix = m.value("temperatureMix").toList();
+    p.resistance = m.value("resistance").toList();
+    p.conductance = m.value("conductance").toList();
+    p.darcyResistance = m.value("darcyResistance").toList();
+    p.conductanceDerivative = m.value("conductanceDerivative").toList();
+    p.waterDispensed = m.value("waterDispensed").toList();
+    p.pressureGoal = m.value("pressureGoal").toList();
+    p.flowGoal = m.value("flowGoal").toList();
+    p.temperatureGoal = m.value("temperatureGoal").toList();
+    p.weight = m.value("weight").toList();
+    p.weightFlowRate = m.value("weightFlowRate").toList();
+
+    p.summaryLines = m.value("summaryLines").toList();
+    p.detectorResults = m.value("detectorResults").toMap();
+    p.phaseSummaries = m.value("phaseSummaries");
+    p.phases = m.value("phases").toList();
+    return p;
+}
+
+void ShotProjection::registerMetaTypeConverters()
+{
+    static bool registered = false;
+    if (registered) return;
+    registered = true;
+    QMetaType::registerConverter<QVariantMap, ShotProjection>(&ShotProjection::fromVariantMap);
+}

--- a/src/history/shotprojection.cpp
+++ b/src/history/shotprojection.cpp
@@ -9,7 +9,6 @@ QVariantMap ShotProjection::toVariantMap() const
     QVariantMap m;
     m["id"] = id;
     m["uuid"] = uuid;
-    m["timestamp"] = timestamp;
     m["timestampIso"] = timestampIso;
     m["profileName"] = profileName;
     m["durationSec"] = durationSec;

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -159,9 +159,10 @@ public:
     bool isValid() const { return id != 0; }
 
     // Build the legacy QVariantMap shape — same keys, same nested types as the
-    // pre-Q_GADGET convertShotRecord() return value. Used by callers that still
-    // serialise the projection wholesale (JSON for visualizer/exporter, the
-    // shot-list HTML page, and MCP `shots_get_detail` / `shots_compare`).
+    // pre-Q_GADGET convertShotRecord() return value. Today's only callers are
+    // toJsonObject() (delegates here) and tests. Direct C++ consumers in the
+    // shot-list HTML page and visualizer exporter read fields off the typed
+    // projection instead.
     QVariantMap toVariantMap() const;
 
     // QJsonObject form for MCP (shots_get_detail, shots_compare). Internally

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -1,0 +1,185 @@
+#pragma once
+
+// ShotProjection — typed value-type representation of a fully-loaded ShotRecord.
+//
+// Replaces the stringly-typed QVariantMap that ShotHistoryStorage::convertShotRecord
+// used to return. Field access through Q_PROPERTYs gives compile-time safety on the
+// C++ side (`shot.finalWeightG` instead of `shot["finalWeightG"].toDouble()`) while
+// QML continues to read fields by name (`shotData.finalWeightG`) because the QML
+// engine surfaces Q_PROPERTYs of a Q_GADGET as JS properties — the access syntax is
+// identical to the previous QVariantMap shape.
+//
+// Field names match the legacy QVariantMap keys exactly so QML, MCP JSON, and any
+// QVariantMap-flavoured consumers (Object.assign in QML, exporter pipeline) stay
+// compatible. toVariantMap()/toJsonObject() are provided for the few consumers
+// that still need a map (web HTML rendering, JSON serialisation for MCP, the
+// visualizer.coffee uploader's JSON builder).
+
+#include <QMetaType>
+#include <QString>
+#include <QStringList>
+#include <QVariantList>
+#include <QVariantMap>
+#include <QJsonObject>
+
+struct ShotRecord;
+
+class ShotProjection {
+    Q_GADGET
+
+    Q_PROPERTY(qint64 id MEMBER id)
+    Q_PROPERTY(QString uuid MEMBER uuid)
+    Q_PROPERTY(qint64 timestamp MEMBER timestamp)
+    Q_PROPERTY(QString timestampIso MEMBER timestampIso)
+    Q_PROPERTY(QString dateTime MEMBER dateTime)
+    Q_PROPERTY(QString profileName MEMBER profileName)
+    Q_PROPERTY(double durationSec MEMBER durationSec)
+    Q_PROPERTY(double finalWeightG MEMBER finalWeightG)
+    Q_PROPERTY(double doseWeightG MEMBER doseWeightG)
+    Q_PROPERTY(QString beanBrand MEMBER beanBrand)
+    Q_PROPERTY(QString beanType MEMBER beanType)
+    Q_PROPERTY(int enjoyment MEMBER enjoyment)
+    Q_PROPERTY(bool hasVisualizerUpload MEMBER hasVisualizerUpload)
+    Q_PROPERTY(QString beverageType MEMBER beverageType)
+    Q_PROPERTY(QString roastDate MEMBER roastDate)
+    Q_PROPERTY(QString roastLevel MEMBER roastLevel)
+    Q_PROPERTY(QString grinderBrand MEMBER grinderBrand)
+    Q_PROPERTY(QString grinderModel MEMBER grinderModel)
+    Q_PROPERTY(QString grinderBurrs MEMBER grinderBurrs)
+    Q_PROPERTY(QString grinderSetting MEMBER grinderSetting)
+    Q_PROPERTY(double drinkTds MEMBER drinkTds)
+    Q_PROPERTY(double drinkEy MEMBER drinkEy)
+    Q_PROPERTY(QString espressoNotes MEMBER espressoNotes)
+    Q_PROPERTY(QString beanNotes MEMBER beanNotes)
+    Q_PROPERTY(QString barista MEMBER barista)
+    Q_PROPERTY(QString profileNotes MEMBER profileNotes)
+    Q_PROPERTY(QString visualizerId MEMBER visualizerId)
+    Q_PROPERTY(QString visualizerUrl MEMBER visualizerUrl)
+    Q_PROPERTY(QString debugLog MEMBER debugLog)
+    Q_PROPERTY(double temperatureOverrideC MEMBER temperatureOverrideC)
+    Q_PROPERTY(double targetWeightG MEMBER targetWeightG)
+    Q_PROPERTY(QString profileJson MEMBER profileJson)
+    Q_PROPERTY(QString profileKbId MEMBER profileKbId)
+
+    Q_PROPERTY(bool channelingDetected MEMBER channelingDetected)
+    Q_PROPERTY(bool temperatureUnstable MEMBER temperatureUnstable)
+    Q_PROPERTY(bool grindIssueDetected MEMBER grindIssueDetected)
+    Q_PROPERTY(bool skipFirstFrameDetected MEMBER skipFirstFrameDetected)
+    Q_PROPERTY(bool pourTruncatedDetected MEMBER pourTruncatedDetected)
+
+    Q_PROPERTY(QVariantList pressure MEMBER pressure)
+    Q_PROPERTY(QVariantList flow MEMBER flow)
+    Q_PROPERTY(QVariantList temperature MEMBER temperature)
+    Q_PROPERTY(QVariantList temperatureMix MEMBER temperatureMix)
+    Q_PROPERTY(QVariantList resistance MEMBER resistance)
+    Q_PROPERTY(QVariantList conductance MEMBER conductance)
+    Q_PROPERTY(QVariantList darcyResistance MEMBER darcyResistance)
+    Q_PROPERTY(QVariantList conductanceDerivative MEMBER conductanceDerivative)
+    Q_PROPERTY(QVariantList waterDispensed MEMBER waterDispensed)
+    Q_PROPERTY(QVariantList pressureGoal MEMBER pressureGoal)
+    Q_PROPERTY(QVariantList flowGoal MEMBER flowGoal)
+    Q_PROPERTY(QVariantList temperatureGoal MEMBER temperatureGoal)
+    Q_PROPERTY(QVariantList weight MEMBER weight)
+    Q_PROPERTY(QVariantList weightFlowRate MEMBER weightFlowRate)
+
+    // summaryLines, detectorResults, phaseSummaries, phases stay loosely typed:
+    // they are nested structures or free-form lists that are themselves passed
+    // through to QML / MCP without per-field reads. Promoting them to sub-gadgets
+    // would multiply the migration surface without adding compile-time safety to
+    // any current consumer site.
+    Q_PROPERTY(QVariantList summaryLines MEMBER summaryLines)
+    Q_PROPERTY(QVariantMap detectorResults MEMBER detectorResults)
+    Q_PROPERTY(QVariant phaseSummaries MEMBER phaseSummaries)
+    Q_PROPERTY(QVariantList phases MEMBER phases)
+
+public:
+    qint64 id = 0;
+    QString uuid;
+    qint64 timestamp = 0;
+    QString timestampIso;
+    QString dateTime;
+    QString profileName;
+    double durationSec = 0.0;
+    double finalWeightG = 0.0;
+    double doseWeightG = 0.0;
+    QString beanBrand;
+    QString beanType;
+    int enjoyment = 0;
+    bool hasVisualizerUpload = false;
+    QString beverageType;
+    QString roastDate;
+    QString roastLevel;
+    QString grinderBrand;
+    QString grinderModel;
+    QString grinderBurrs;
+    QString grinderSetting;
+    double drinkTds = 0.0;
+    double drinkEy = 0.0;
+    QString espressoNotes;
+    QString beanNotes;
+    QString barista;
+    QString profileNotes;
+    QString visualizerId;
+    QString visualizerUrl;
+    QString debugLog;
+    double temperatureOverrideC = 0.0;
+    double targetWeightG = 0.0;
+    QString profileJson;
+    QString profileKbId;
+
+    bool channelingDetected = false;
+    bool temperatureUnstable = false;
+    bool grindIssueDetected = false;
+    bool skipFirstFrameDetected = false;
+    bool pourTruncatedDetected = false;
+
+    QVariantList pressure;
+    QVariantList flow;
+    QVariantList temperature;
+    QVariantList temperatureMix;
+    QVariantList resistance;
+    QVariantList conductance;
+    QVariantList darcyResistance;
+    QVariantList conductanceDerivative;
+    QVariantList waterDispensed;
+    QVariantList pressureGoal;
+    QVariantList flowGoal;
+    QVariantList temperatureGoal;
+    QVariantList weight;
+    QVariantList weightFlowRate;
+
+    QVariantList summaryLines;
+    QVariantMap detectorResults;
+    QVariant phaseSummaries;
+    QVariantList phases;
+
+    // True when this projection holds a real shot (id != 0). convertShotRecord()
+    // returns a default-constructed ShotProjection on lookup failure; isValid()
+    // is the cheapest reliable way to detect that.
+    bool isValid() const { return id != 0; }
+
+    // Build the legacy QVariantMap shape — same keys, same nested types as the
+    // pre-Q_GADGET convertShotRecord() return value. Used by callers that still
+    // serialise the projection wholesale (JSON for visualizer/exporter, the
+    // shot-list HTML page, and MCP `shots_get_detail` / `shots_compare`).
+    QVariantMap toVariantMap() const;
+
+    // QJsonObject form for MCP (shots_get_detail, shots_compare). Internally
+    // delegates to QJsonObject::fromVariantMap(toVariantMap()).
+    QJsonObject toJsonObject() const;
+
+    // Build a ShotProjection from the legacy QVariantMap shape (or any JS
+    // object QML hands across a Q_INVOKABLE boundary). Used by Q_INVOKABLE
+    // methods that take `const ShotProjection&`: a registered QMetaType
+    // converter (see registerMetaTypeConverters() called once at startup)
+    // routes QVariantMap → ShotProjection through this method, so QML callers
+    // passing a JS object — including the Object.assign-produced object in
+    // PostShotReviewPage's onShotBadgesUpdated — still satisfy the parameter.
+    static ShotProjection fromVariantMap(const QVariantMap& map);
+
+    // Register the QVariantMap → ShotProjection converter. Call once at
+    // application startup (main.cpp). Idempotent across calls.
+    static void registerMetaTypeConverters();
+};
+
+Q_DECLARE_METATYPE(ShotProjection)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,6 +96,7 @@
 #include "network/webdebuglogger.h"
 #include "core/widgetlibrary.h"
 #include "history/shothistoryexporter.h"
+#include "history/shotprojection.h"
 #include "mcp/mcpserver.h"
 #include "network/librarysharing.h"
 #include "network/relayclient.h"
@@ -1687,6 +1688,18 @@ int main(int argc, char *argv[])
         "SettingsNetwork is created in C++");
     qmlRegisterUncreatableType<SettingsApp>("Decenza", 1, 0, "SettingsAppType",
         "SettingsApp is created in C++");
+
+    // ShotProjection is a Q_GADGET value type used as the parameter of
+    // ShotHistoryStorage::shotReady. qmlRegisterUncreatableMetaObject registers
+    // its meta-object so QML signal handlers can read its Q_PROPERTYs by name
+    // (`shotData.finalWeightG`). qRegisterMetaType makes the type usable on
+    // Qt::QueuedConnection signal/slot connections (the connection threads
+    // serialize the QVariant<ShotProjection> across thread boundaries).
+    qRegisterMetaType<ShotProjection>("ShotProjection");
+    ShotProjection::registerMetaTypeConverters();
+    qmlRegisterUncreatableMetaObject(ShotProjection::staticMetaObject,
+        "Decenza", 1, 0, "ShotProjection",
+        "ShotProjection is a value type returned by ShotHistoryStorage signals");
 
     // Register strange attractor renderer (QQuickPaintedItem, no Quick3D dependency)
     qmlRegisterType<StrangeAttractorRenderer>("Decenza", 1, 0, "StrangeAttractorRenderer");

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -24,7 +24,7 @@
 
 // Data collected on the background thread (pure SQL results, no QObject access)
 struct DialingDbResult {
-    QVariantMap shotData;
+    ShotProjection shotData;
     QString profileKbId;
     QJsonArray dialInHistory;
     QJsonObject grinderContext;
@@ -99,53 +99,47 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     if (!dbResult.profileKbId.isEmpty()) {
                         QVariantList history = ShotHistoryStorage::loadRecentShotsByKbIdStatic(db, dbResult.profileKbId, historyLimit, resolvedShotId);
                         for (const auto& v : history) {
-                            QVariantMap shot = v.toMap();
+                            const ShotProjection shot = ShotProjection::fromVariantMap(v.toMap());
                             QJsonObject h;
-                            h["id"] = shot["id"].toLongLong();
-                            h["timestamp"] = shot["dateTime"].toString();
-                            h["profileName"] = shot["profileName"].toString();
-                            h["doseG"] = shot["doseWeightG"].toDouble();
-                            h["yieldG"] = shot["finalWeightG"].toDouble();
-                            h["durationSec"] = shot["durationSec"].toDouble();
-                            h["enjoyment0to100"] = shot["enjoyment"].toInt();
-                            h["grinderSetting"] = shot["grinderSetting"].toString();
-                            h["grinderModel"] = shot["grinderModel"].toString();
-                            h["grinderBrand"] = shot["grinderBrand"].toString();
-                            h["grinderBurrs"] = shot["grinderBurrs"].toString();
-                            h["notes"] = shot["espressoNotes"].toString();
-                            h["beanBrand"] = shot["beanBrand"].toString();
-                            h["beanType"] = shot["beanType"].toString();
-                            double tempOverride = shot["temperatureOverrideC"].toDouble();
-                            if (tempOverride > 0)
-                                h["temperatureOverrideC"] = tempOverride;
+                            h["id"] = shot.id;
+                            h["timestamp"] = shot.dateTime;
+                            h["profileName"] = shot.profileName;
+                            h["doseG"] = shot.doseWeightG;
+                            h["yieldG"] = shot.finalWeightG;
+                            h["durationSec"] = shot.durationSec;
+                            h["enjoyment0to100"] = shot.enjoyment;
+                            h["grinderSetting"] = shot.grinderSetting;
+                            h["grinderModel"] = shot.grinderModel;
+                            h["grinderBrand"] = shot.grinderBrand;
+                            h["grinderBurrs"] = shot.grinderBurrs;
+                            h["notes"] = shot.espressoNotes;
+                            h["beanBrand"] = shot.beanBrand;
+                            h["beanType"] = shot.beanType;
+                            if (shot.temperatureOverrideC > 0)
+                                h["temperatureOverrideC"] = shot.temperatureOverrideC;
 
                             // For shots saved by MainController, targetWeightG is always
                             // populated (user override → profile target_weight → finalWeight).
                             // The profile-JSON fallback below is defensive for shots imported
                             // from external formats (de1app, visualizer.coffee) where the
                             // shot importer leaves targetWeight at 0.
-                            double targetWeight = shot["targetWeightG"].toDouble();
-                            if (targetWeight > 0) {
-                                h["targetWeightG"] = targetWeight;
-                            } else {
-                                QString profileJson = shot["profileJson"].toString();
-                                if (!profileJson.isEmpty()) {
-                                    QJsonObject profileObj = QJsonDocument::fromJson(profileJson.toUtf8()).object();
-                                    QJsonValue tw = profileObj["target_weight"];
-                                    double twVal = tw.isString() ? tw.toString().toDouble() : tw.toDouble();
-                                    if (twVal > 0)
-                                        h["targetWeightG"] = twVal;
-                                }
+                            if (shot.targetWeightG > 0) {
+                                h["targetWeightG"] = shot.targetWeightG;
+                            } else if (!shot.profileJson.isEmpty()) {
+                                QJsonObject profileObj = QJsonDocument::fromJson(shot.profileJson.toUtf8()).object();
+                                QJsonValue tw = profileObj["target_weight"];
+                                double twVal = tw.isString() ? tw.toString().toDouble() : tw.toDouble();
+                                if (twVal > 0)
+                                    h["targetWeightG"] = twVal;
                             }
                             dbResult.dialInHistory.append(h);
                         }
                     }
 
                     // --- Grinder context (shared helper) ---
-                    QString grinderModel = dbResult.shotData.contains("grinderModel")
-                        ? dbResult.shotData["grinderModel"].toString() : QString();
-                    QString beverageType = dbResult.shotData.value("beverageType", "espresso").toString();
-                    if (beverageType.isEmpty()) beverageType = "espresso";
+                    QString grinderModel = dbResult.shotData.grinderModel;
+                    QString beverageType = dbResult.shotData.beverageType.isEmpty()
+                        ? QStringLiteral("espresso") : dbResult.shotData.beverageType;
                     if (!grinderModel.isEmpty()) {
                         GrinderContext ctx = ShotHistoryStorage::queryGrinderContext(db, grinderModel, beverageType);
                         if (!ctx.settingsObserved.isEmpty()) {
@@ -172,7 +166,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                 QMetaObject::invokeMethod(qApp,
                     [respond, dbResult, resolvedShotId, mainController, profileManager, settings]() {
 
-                    if (dbResult.shotData.isEmpty()) {
+                    if (!dbResult.shotData.isValid()) {
                         respond(QJsonObject{{"error", "Shot not found: " + QString::number(resolvedShotId)}});
                         return;
                     }
@@ -190,22 +184,20 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     // --- Shot summary ---
                     const auto& sd = dbResult.shotData;
                     QJsonObject shotSummary;
-                    shotSummary["profileName"] = sd["profileName"].toString();
-                    shotSummary["doseG"] = sd["doseWeightG"].toDouble();
-                    shotSummary["yieldG"] = sd["finalWeightG"].toDouble();
-                    shotSummary["durationSec"] = sd["durationSec"].toDouble();
-                    shotSummary["enjoyment0to100"] = sd["enjoyment"].toInt();
-                    shotSummary["notes"] = sd["espressoNotes"].toString();
-                    shotSummary["beanBrand"] = sd["beanBrand"].toString();
-                    shotSummary["beanType"] = sd["beanType"].toString();
-                    shotSummary["roastLevel"] = sd["roastLevel"].toString();
-                    shotSummary["grinderModel"] = sd["grinderModel"].toString();
-                    shotSummary["grinderSetting"] = sd["grinderSetting"].toString();
-                    shotSummary["grinderBurrs"] = sd["grinderBurrs"].toString();
-                    double dose = sd["doseWeightG"].toDouble();
-                    double yield = sd["finalWeightG"].toDouble();
-                    if (dose > 0)
-                        shotSummary["ratio"] = QString("1:%1").arg(yield / dose, 0, 'f', 2);
+                    shotSummary["profileName"] = sd.profileName;
+                    shotSummary["doseG"] = sd.doseWeightG;
+                    shotSummary["yieldG"] = sd.finalWeightG;
+                    shotSummary["durationSec"] = sd.durationSec;
+                    shotSummary["enjoyment0to100"] = sd.enjoyment;
+                    shotSummary["notes"] = sd.espressoNotes;
+                    shotSummary["beanBrand"] = sd.beanBrand;
+                    shotSummary["beanType"] = sd.beanType;
+                    shotSummary["roastLevel"] = sd.roastLevel;
+                    shotSummary["grinderModel"] = sd.grinderModel;
+                    shotSummary["grinderSetting"] = sd.grinderSetting;
+                    shotSummary["grinderBurrs"] = sd.grinderBurrs;
+                    if (sd.doseWeightG > 0)
+                        shotSummary["ratio"] = QString("1:%1").arg(sd.finalWeightG / sd.doseWeightG, 0, 'f', 2);
                     result["shot"] = shotSummary;
 
                     // --- AI-generated shot analysis ---
@@ -217,9 +209,8 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     }
 
                     // --- Profile knowledge ---
-                    QString profileTitle = sd["profileName"].toString();
-                    QString bevType = sd.value("beverageType", "espresso").toString();
-                    if (bevType.isEmpty()) bevType = "espresso";
+                    QString profileTitle = sd.profileName;
+                    QString bevType = sd.beverageType.isEmpty() ? QStringLiteral("espresso") : sd.beverageType;
                     QString profileKnowledge = ShotSummarizer::shotAnalysisSystemPrompt(
                         bevType, profileTitle, QString(), dbResult.profileKbId);
                     if (!profileKnowledge.isEmpty())

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -102,7 +102,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                             const ShotProjection shot = ShotProjection::fromVariantMap(v.toMap());
                             QJsonObject h;
                             h["id"] = shot.id;
-                            h["timestamp"] = shot.dateTime;
+                            h["timestamp"] = shot.timestampIso;
                             h["profileName"] = shot.profileName;
                             h["doseG"] = shot.doseWeightG;
                             h["yieldG"] = shot.finalWeightG;

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -226,9 +226,9 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
 
                 if (!withTempDb(dbPath, "mcp_shot_detail", [&](QSqlDatabase& db) {
                     ShotRecord record = ShotHistoryStorage::loadShotRecordStatic(db, shotId);
-                    QVariantMap shotMap = ShotHistoryStorage::convertShotRecord(record);
-                    if (!shotMap.isEmpty()) {
-                        result = QJsonObject::fromVariantMap(shotMap);
+                    ShotProjection shot = ShotHistoryStorage::convertShotRecord(record);
+                    if (shot.isValid()) {
+                        result = shot.toJsonObject();
                     } else {
                         result["error"] = "Shot not found: " + QString::number(shotId);
                     }
@@ -286,14 +286,17 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
             QThread* thread = QThread::create([dbPath, idArray, respond]() {
                 QJsonObject result;
                 QJsonArray shots;
+                QList<ShotProjection> projections;
 
                 if (!withTempDb(dbPath, "mcp_compare", [&](QSqlDatabase& db) {
                     for (const auto& idVal : idArray) {
                         qint64 shotId = idVal.toInteger();
                         ShotRecord record = ShotHistoryStorage::loadShotRecordStatic(db, shotId);
-                        QVariantMap shotMap = ShotHistoryStorage::convertShotRecord(record);
-                        if (!shotMap.isEmpty())
-                            shots.append(QJsonObject::fromVariantMap(shotMap));
+                        ShotProjection shot = ShotHistoryStorage::convertShotRecord(record);
+                        if (shot.isValid()) {
+                            shots.append(shot.toJsonObject());
+                            projections.append(std::move(shot));
+                        }
                     }
                 })) {
                     result["error"] = "Failed to open shot database";
@@ -304,36 +307,41 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                     result["count"] = shots.size();
                 }
 
-                // Compute changes between consecutive shots
-                if (shots.size() >= 2) {
+                // Compute changes between consecutive shots. Field-pointer
+                // accessors keep the diff loop compile-time-safe — renaming
+                // ShotProjection::doseWeightG turns the diffNum() call into a
+                // compile error rather than a silent missed-rename bug. The
+                // outKey strings are the MCP-facing schema (doseG, yieldG,
+                // enjoyment0to100), distinct from the projection's field names.
+                if (projections.size() >= 2) {
                     QJsonArray changes;
-                    for (qsizetype i = 1; i < shots.size(); ++i) {
-                        QJsonObject prev = shots[i-1].toObject();
-                        QJsonObject curr = shots[i].toObject();
+                    for (qsizetype i = 1; i < projections.size(); ++i) {
+                        const ShotProjection& prev = projections[i-1];
+                        const ShotProjection& curr = projections[i];
                         QJsonObject diff;
-                        diff["fromShotId"] = prev["id"];
-                        diff["toShotId"] = curr["id"];
+                        diff["fromShotId"] = prev.id;
+                        diff["toShotId"] = curr.id;
 
-                        auto diffStr = [&](const QString& key) {
-                            QString a = prev[key].toString(), b = curr[key].toString();
+                        auto diffStr = [&](QString ShotProjection::*field, const QString& outKey) {
+                            const QString& a = prev.*field;
+                            const QString& b = curr.*field;
                             if (!a.isEmpty() && !b.isEmpty() && a != b)
-                                diff[key] = QString("%1 -> %2").arg(a, b);
+                                diff[outKey] = QString("%1 -> %2").arg(a, b);
                         };
-                        auto diffNumUnit = [&](const QString& srcKey, const QString& outKey, const QString& unit) {
-                            double a = prev[srcKey].toDouble(), b = curr[srcKey].toDouble();
+                        auto diffNum = [&](double a, double b, const QString& outKey, const QString& unit) {
                             if (a != 0 && b != 0 && qAbs(a - b) > 0.01)
                                 diff[outKey] = QString("%1 -> %2 %3 (%4%5)")
                                     .arg(a, 0, 'f', 1).arg(b, 0, 'f', 1).arg(unit)
                                     .arg(b > a ? "+" : "").arg(b - a, 0, 'f', 1);
                         };
 
-                        diffStr("grinderSetting");
-                        diffStr("profileName");
-                        diffStr("beanBrand");
-                        diffNumUnit("doseWeightG", "doseG", "g");
-                        diffNumUnit("finalWeightG", "yieldG", "g");
-                        diffNumUnit("durationSec", "durationSec", "s");
-                        diffNumUnit("enjoyment", "enjoyment0to100", "");
+                        diffStr(&ShotProjection::grinderSetting, "grinderSetting");
+                        diffStr(&ShotProjection::profileName, "profileName");
+                        diffStr(&ShotProjection::beanBrand, "beanBrand");
+                        diffNum(prev.doseWeightG, curr.doseWeightG, "doseG", "g");
+                        diffNum(prev.finalWeightG, curr.finalWeightG, "yieldG", "g");
+                        diffNum(prev.durationSec, curr.durationSec, "durationSec", "s");
+                        diffNum(prev.enjoyment, curr.enjoyment, "enjoyment0to100", "");
 
                         if (diff.size() > 2)
                             changes.append(diff);

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -1708,7 +1708,7 @@ btn.textContent='Copied!';setTimeout(function(){btn.textContent='Copy'},2000);
         QString dbPath = m_storage->databasePath();
         auto destroyed = m_destroyed;
         QThread* thread = QThread::create([this, socketGuard, dbPath, shotId, destroyed]() {
-            QVariantMap shot;
+            ShotProjection shot;
             bool dbOpened = withTempDb(dbPath, "shs_web_det", [&](QSqlDatabase& db) {
                 ShotRecord record = ShotHistoryStorage::loadShotRecordStatic(db, shotId);
                 shot = ShotHistoryStorage::convertShotRecord(record);
@@ -1818,7 +1818,7 @@ btn.textContent='Copied!';setTimeout(function(){btn.textContent='Copy'},2000);
         QString dbPath = m_storage->databasePath();
         auto destroyed = m_destroyed;
         QThread* thread = QThread::create([this, socketGuard, dbPath, shotId, destroyed]() {
-            QVariantMap shot;
+            ShotProjection shot;
             bool dbOpened = withTempDb(dbPath, "shs_web_get", [&](QSqlDatabase& db) {
                 ShotRecord record = ShotHistoryStorage::loadShotRecordStatic(db, shotId);
                 shot = ShotHistoryStorage::convertShotRecord(record);
@@ -1831,7 +1831,7 @@ btn.textContent='Copied!';setTimeout(function(){btn.textContent='Copy'},2000);
                 if (!dbOpened) {
                     sendResponse(socketGuard, 500, "application/json", R"({"error":"Database unavailable"})");
                 } else {
-                    sendJson(socketGuard, QJsonDocument(QJsonObject::fromVariantMap(shot)).toJson());
+                    sendJson(socketGuard, QJsonDocument(shot.toJsonObject()).toJson());
                 }
             }, Qt::QueuedConnection);
         });

--- a/src/network/shotserver.h
+++ b/src/network/shotserver.h
@@ -18,6 +18,8 @@
 #include <QNetworkAccessManager>
 #include <QPointer>
 #include <memory>
+
+#include "../history/shotprojection.h"
 #ifdef Q_OS_ANDROID
 #include <QJniObject>
 #endif
@@ -145,7 +147,7 @@ private:
 
     QString getLocalIpAddress() const;
     QString generateShotListPage(const QVariantList& shots) const;
-    QString generateShotDetailPage(qint64 shotId, const QVariantMap& shot) const;
+    QString generateShotDetailPage(qint64 shotId, const ShotProjection& shot) const;
     QString generateComparisonPage(const QList<ShotRecord>& shots) const;
     QString generateDebugPage() const;
     QString generateUploadPage() const;

--- a/src/network/shotserver_shots.cpp
+++ b/src/network/shotserver_shots.cpp
@@ -44,25 +44,28 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
 {
     QString rows;
     for (const QVariant& v : std::as_const(shots)) {
-        QVariantMap shot = v.toMap();
+        // queryShotList() emits maps with ShotProjection-aligned keys; routing
+        // them through fromVariantMap() gives the rest of the loop compile-time
+        // safety on every field name read below.
+        const ShotProjection shot = ShotProjection::fromVariantMap(v.toMap());
 
-        int rating = qRound(shot["enjoyment"].toDouble());  // 0-100
+        int rating = qRound(static_cast<double>(shot.enjoyment));  // 0-100
 
         double ratio = 0;
-        if (shot["doseWeightG"].toDouble() > 0) {
-            ratio = shot["finalWeightG"].toDouble() / shot["doseWeightG"].toDouble();
+        if (shot.doseWeightG > 0) {
+            ratio = shot.finalWeightG / shot.doseWeightG;
         }
 
-        QString profileName = shot["profileName"].toString();
-        QString beanBrand = shot["beanBrand"].toString();
-        QString beanType = shot["beanType"].toString();
-        QString dateTime = shot["dateTime"].toString();
-        double doseWeight = shot["doseWeightG"].toDouble();
-        double finalWeight = shot["finalWeightG"].toDouble();
-        double duration = shot["durationSec"].toDouble();
-        QString grinderSetting = shot["grinderSetting"].toString();
-        double tempOverride = shot["temperatureOverrideC"].toDouble();  // Always has value
-        double targetWeight = shot["targetWeightG"].toDouble();  // Always has value
+        const QString& profileName = shot.profileName;
+        const QString& beanBrand = shot.beanBrand;
+        const QString& beanType = shot.beanType;
+        const QString& dateTime = shot.dateTime;
+        const double doseWeight = shot.doseWeightG;
+        const double finalWeight = shot.finalWeightG;
+        const double duration = shot.durationSec;
+        const QString& grinderSetting = shot.grinderSetting;
+        const double tempOverride = shot.temperatureOverrideC;  // Always has value
+        const double targetWeight = shot.targetWeightG;  // Always has value
 
         // Escape for JavaScript string (single quotes) and HTML attribute
         auto escapeForJs = [](const QString& s) -> QString {
@@ -113,8 +116,8 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
             }
         }
 
-        double drinkTds = shot["drinkTds"].toDouble();
-        double drinkEy = shot["drinkEy"].toDouble();
+        const double drinkTds = shot.drinkTds;
+        const double drinkEy = shot.drinkEy;
 
         rows += QString(R"HTML(
             <div class="shot-card" onclick="toggleSelect(%1, this)" data-id="%1"
@@ -157,7 +160,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
                 </a>
             </div>
         )HTML")
-        .arg(shot["id"].toLongLong())       // %1
+        .arg(shot.id)                       // %1
         .arg(profileHtml)                   // %2 (data attr, undecorated)
         .arg(brandHtml)                     // %3
         .arg(coffeeHtml)                    // %4
@@ -173,7 +176,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         .arg(beanDisplay)                   // %14 (beans with grind)
         .arg(drinkTds, 0, 'f', 2)           // %15
         .arg(drinkEy, 0, 'f', 2)            // %16
-        .arg(shot["timestamp"].toLongLong()); // %17 (epoch for sorting)
+        .arg(shot.timestamp); // %17 (epoch for sorting)
     }
 
     // Build HTML in chunks to avoid MSVC string literal size limit
@@ -1016,20 +1019,20 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
     return html;
 }
 
-QString ShotServer::generateShotDetailPage(qint64 shotId, const QVariantMap& shot) const
+QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& shot) const
 {
-    if (shot.isEmpty()) {
+    if (!shot.isValid()) {
         return QStringLiteral("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>Not Found</title></head>"
                   "<body style=\"background:#0d1117;color:#fff;font-family:sans-serif;padding:2rem;\">"
                   "<h1>Shot not found</h1><a href=\"/\" style=\"color:#c9a227;\">Back to list</a></body></html>");
     }
 
     double ratio = 0;
-    if (shot["doseWeightG"].toDouble() > 0) {
-        ratio = shot["finalWeightG"].toDouble() / shot["doseWeightG"].toDouble();
+    if (shot.doseWeightG > 0) {
+        ratio = shot.finalWeightG / shot.doseWeightG;
     }
 
-    int rating = qRound(shot["enjoyment"].toDouble() / 20.0);
+    int rating = qRound(static_cast<double>(shot.enjoyment) / 20.0);
     QString stars;
     for (int i = 0; i < 5; i++) {
         stars += (i < rating) ? "&#9733;" : "&#9734;";
@@ -1048,9 +1051,9 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const QVariantMap& sho
     };
 
     // Temperature and target weight (always have values)
-    double tempOverride = shot["temperatureOverrideC"].toDouble();
-    double targetWeight = shot["targetWeightG"].toDouble();
-    double finalWeight = shot["finalWeightG"].toDouble();
+    const double tempOverride = shot.temperatureOverrideC;
+    const double targetWeight = shot.targetWeightG;
+    const double finalWeight = shot.finalWeightG;
 
     // Build yield display with optional target
     QString yieldDisplay = QString("%1g").arg(finalWeight, 0, 'f', 1);
@@ -1086,14 +1089,14 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const QVariantMap& sho
         return "[" + items.join(",") + "]";
     };
 
-    QString pressureData = pointsToJson(shot["pressure"].toList());
-    QString flowData = pointsToJson(shot["flow"].toList());
-    QString tempData = pointsToJson(shot["temperature"].toList());
-    QString weightData = pointsToJson(shot["weight"].toList());
-    QString weightFlowRateData = pointsToJson(shot["weightFlowRate"].toList());
-    QString resistanceData = pointsToJson(shot["resistance"].toList());
-    QString pressureGoalData = goalPointsToJson(shot["pressureGoal"].toList());
-    QString flowGoalData = goalPointsToJson(shot["flowGoal"].toList());
+    QString pressureData = pointsToJson(shot.pressure);
+    QString flowData = pointsToJson(shot.flow);
+    QString tempData = pointsToJson(shot.temperature);
+    QString weightData = pointsToJson(shot.weight);
+    QString weightFlowRateData = pointsToJson(shot.weightFlowRate);
+    QString resistanceData = pointsToJson(shot.resistance);
+    QString pressureGoalData = goalPointsToJson(shot.pressureGoal);
+    QString flowGoalData = goalPointsToJson(shot.flowGoal);
 
     // Convert phase markers to JSON for Chart.js
     auto phasesToJson = [](const QVariantList& phases) -> QString {
@@ -1120,7 +1123,7 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const QVariantMap& sho
         }
         return "[" + items.join(",") + "]";
     };
-    QString phaseData = phasesToJson(shot["phases"].toList());
+    QString phaseData = phasesToJson(shot.phases);
 
     QString html = QString(R"HTML(
 <!DOCTYPE html>
@@ -2079,52 +2082,52 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const QVariantMap& sho
 )HTML";
     return html
     .arg(tempOverride > 0
-         ? shot["profileName"].toString().toHtmlEscaped() + QString(" (%1\u00B0C)").arg(tempOverride, 0, 'f', 0)
-         : shot["profileName"].toString().toHtmlEscaped())
-    .arg(shot["dateTime"].toString())
-    .arg(shot["doseWeightG"].toDouble(), 0, 'f', 1)
+         ? shot.profileName.toHtmlEscaped() + QString(" (%1\u00B0C)").arg(tempOverride, 0, 'f', 0)
+         : shot.profileName.toHtmlEscaped())
+    .arg(shot.dateTime)
+    .arg(shot.doseWeightG, 0, 'f', 1)
     .arg(yieldDisplay)
     .arg(ratio, 0, 'f', 1)
-    .arg(shot["durationSec"].toDouble(), 0, 'f', 1)
+    .arg(shot.durationSec, 0, 'f', 1)
     .arg(stars)
-    .arg(shot["beanBrand"].toString().isEmpty() ? "-" : shot["beanBrand"].toString().toHtmlEscaped())
-    .arg(shot["beanType"].toString().isEmpty() ? "-" : shot["beanType"].toString().toHtmlEscaped())
-    .arg(shot["roastDate"].toString().isEmpty() ? "-" : shot["roastDate"].toString().toHtmlEscaped())
-    .arg(shot["roastLevel"].toString().isEmpty() ? "-" : shot["roastLevel"].toString().toHtmlEscaped())
-    .arg(shot["grinderBrand"].toString().isEmpty() && shot["grinderModel"].toString().isEmpty()
-         ? "-" : (shot["grinderBrand"].toString() + " " + shot["grinderModel"].toString()).trimmed().toHtmlEscaped())
-    .arg(shot["grinderSetting"].toString().isEmpty() ? "-" : shot["grinderSetting"].toString().toHtmlEscaped())
-    .arg(shot["espressoNotes"].toString().isEmpty() ? "No notes" : shot["espressoNotes"].toString().toHtmlEscaped())
+    .arg(shot.beanBrand.isEmpty() ? "-" : shot.beanBrand.toHtmlEscaped())
+    .arg(shot.beanType.isEmpty() ? "-" : shot.beanType.toHtmlEscaped())
+    .arg(shot.roastDate.isEmpty() ? "-" : shot.roastDate.toHtmlEscaped())
+    .arg(shot.roastLevel.isEmpty() ? "-" : shot.roastLevel.toHtmlEscaped())
+    .arg(shot.grinderBrand.isEmpty() && shot.grinderModel.isEmpty()
+         ? "-" : (shot.grinderBrand + " " + shot.grinderModel).trimmed().toHtmlEscaped())
+    .arg(shot.grinderSetting.isEmpty() ? "-" : shot.grinderSetting.toHtmlEscaped())
+    .arg(shot.espressoNotes.isEmpty() ? "No notes" : shot.espressoNotes.toHtmlEscaped())
     .arg(pressureData)
     .arg(flowData)
     .arg(weightData)
     .arg(tempData)
     .arg(pressureGoalData)
     .arg(flowGoalData)
-    .arg(shot["debugLog"].toString().isEmpty() ? "No debug log available" : shot["debugLog"].toString().toHtmlEscaped())
+    .arg(shot.debugLog.isEmpty() ? "No debug log available" : shot.debugLog.toHtmlEscaped())
     .arg(phaseData)
     .arg(weightFlowRateData)
     // shotData JS object fields (%24-%38)
     .arg(shotId)                                                                     // %24 id
-    .arg(jsEscape(shot["beanBrand"].toString()))                                     // %25 beanBrand
-    .arg(jsEscape(shot["beanType"].toString()))                                      // %26 beanType
-    .arg(jsEscape(shot["roastDate"].toString()))                                     // %27 roastDate
-    .arg(jsEscape(shot["roastLevel"].toString()))                                    // %28 roastLevel
-    .arg(jsEscape(shot["grinderModel"].toString()))                                  // %29 grinderModel
-    .arg(jsEscape(shot["grinderSetting"].toString()))                                // %30 grinderSetting
-    .arg(jsEscape(shot["espressoNotes"].toString()))                                 // %31 espressoNotes
-    .arg(shot["doseWeightG"].toDouble(), 0, 'f', 1)                                 // %32 doseWeightG
-    .arg(shot["finalWeightG"].toDouble(), 0, 'f', 1)                                // %33 finalWeightG
-    .arg(qRound(shot["enjoyment"].toDouble()))                                       // %34 enjoyment
-    .arg(jsEscape(shot["barista"].toString()))                                       // %35 barista
-    .arg(jsEscape(shot["beverageType"].toString().isEmpty()
+    .arg(jsEscape(shot.beanBrand))                                                   // %25 beanBrand
+    .arg(jsEscape(shot.beanType))                                                    // %26 beanType
+    .arg(jsEscape(shot.roastDate))                                                   // %27 roastDate
+    .arg(jsEscape(shot.roastLevel))                                                  // %28 roastLevel
+    .arg(jsEscape(shot.grinderModel))                                                // %29 grinderModel
+    .arg(jsEscape(shot.grinderSetting))                                              // %30 grinderSetting
+    .arg(jsEscape(shot.espressoNotes))                                               // %31 espressoNotes
+    .arg(shot.doseWeightG, 0, 'f', 1)                                                // %32 doseWeightG
+    .arg(shot.finalWeightG, 0, 'f', 1)                                               // %33 finalWeightG
+    .arg(shot.enjoyment)                                                             // %34 enjoyment
+    .arg(jsEscape(shot.barista))                                                     // %35 barista
+    .arg(jsEscape(shot.beverageType.isEmpty()
                   ? QStringLiteral("espresso")
-                  : shot["beverageType"].toString()))                                // %36 beverageType
-    .arg(shot["drinkTds"].toDouble(), 0, 'f', 2)                                    // %37 drinkTds
-    .arg(shot["drinkEy"].toDouble(), 0, 'f', 1)                                     // %38 drinkEy
+                  : shot.beverageType))                                              // %36 beverageType
+    .arg(shot.drinkTds, 0, 'f', 2)                                                   // %37 drinkTds
+    .arg(shot.drinkEy, 0, 'f', 1)                                                    // %38 drinkEy
     .arg(resistanceData)                                                             // %39 resistance
-    .arg(jsEscape(shot["grinderBrand"].toString()))                                  // %40 grinderBrand
-    .arg(jsEscape(shot["grinderBurrs"].toString()));                                 // %41 grinderBurrs
+    .arg(jsEscape(shot.grinderBrand))                                                // %40 grinderBrand
+    .arg(jsEscape(shot.grinderBurrs));                                               // %41 grinderBurrs
 }
 
 QString ShotServer::generateComparisonPage(const QList<ShotRecord>& shots) const

--- a/src/network/shotserver_shots.cpp
+++ b/src/network/shotserver_shots.cpp
@@ -49,7 +49,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         // safety on every field name read below.
         const ShotProjection shot = ShotProjection::fromVariantMap(v.toMap());
 
-        int rating = qRound(static_cast<double>(shot.enjoyment));  // 0-100
+        int rating = qRound(static_cast<double>(shot.enjoyment));
 
         double ratio = 0;
         if (shot.doseWeightG > 0) {

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -119,32 +119,30 @@ void VisualizerUploader::uploadShot(ShotDataModel* shotData,
     sendUpload(jsonData);
 }
 
-void VisualizerUploader::uploadShotFromHistory(const QVariantMap& shotData)
+void VisualizerUploader::uploadShotFromHistory(const ShotProjection& shotData)
 {
-    if (shotData.isEmpty()) {
+    if (!shotData.isValid()) {
         emit uploadFailed("No shot data available");
         return;
     }
 
     // Extract beverage type from profile JSON
     QString beverageType;
-    QString profileJson = shotData["profileJson"].toString();
-    if (!profileJson.isEmpty()) {
-        QJsonDocument profileDoc = QJsonDocument::fromJson(profileJson.toUtf8());
+    if (!shotData.profileJson.isEmpty()) {
+        QJsonDocument profileDoc = QJsonDocument::fromJson(shotData.profileJson.toUtf8());
         if (!profileDoc.isNull()) {
             beverageType = profileDoc.object()["beverage_type"].toString();
         }
     }
 
-    double duration = shotData["durationSec"].toDouble();
-    if (!validateUpload(beverageType, duration))
+    if (!validateUpload(beverageType, shotData.durationSec))
         return;
 
     QByteArray jsonData = buildHistoryShotJson(shotData);
     sendUpload(jsonData);
 }
 
-void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, const QVariantMap& shotData)
+void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, const ShotProjection& shotData)
 {
     if (visualizerId.isEmpty()) {
         emit uploadFailed("No visualizer ID for update");
@@ -168,42 +166,41 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
     emit lastUploadStatusChanged();
 
     // Build JSON body: {"shot": {"bean_brand": "...", ...}}
+    // Field-pointer accessors give compile-time safety on the projection side;
+    // the API field strings are visualizer.coffee's external schema (snake_case)
+    // and intentionally distinct from the projection's field names.
     QJsonObject shotObj;
-    auto setField = [&](const QString& apiField, const QString& mapKey) {
-        if (!shotData.contains(mapKey)) return;
-        QVariant val = shotData[mapKey];
-        if (val.typeId() == QMetaType::Double) {
-            double d = val.toDouble();
-            if (d > 0) shotObj[apiField] = d;
-        } else if (val.typeId() == QMetaType::Int) {
-            int i = val.toInt();
-            if (i > 0) shotObj[apiField] = i;
-        } else {
-            QString s = val.toString();
-            if (!s.isEmpty()) shotObj[apiField] = s;
-        }
+    auto setStr = [&](const QString& apiField, QString ShotProjection::*field) {
+        const QString& s = shotData.*field;
+        if (!s.isEmpty()) shotObj[apiField] = s;
+    };
+    auto setDouble = [&](const QString& apiField, double ShotProjection::*field) {
+        const double v = shotData.*field;
+        if (v > 0) shotObj[apiField] = v;
+    };
+    auto setInt = [&](const QString& apiField, int ShotProjection::*field) {
+        const int v = shotData.*field;
+        if (v > 0) shotObj[apiField] = v;
     };
 
-    setField("bean_brand", "beanBrand");
-    setField("bean_type", "beanType");
-    setField("roast_level", "roastLevel");
-    setField("roast_date", "roastDate");
-    setField("bean_weight", "doseWeightG");
-    setField("drink_weight", "finalWeightG");
+    setStr("bean_brand", &ShotProjection::beanBrand);
+    setStr("bean_type", &ShotProjection::beanType);
+    setStr("roast_level", &ShotProjection::roastLevel);
+    setStr("roast_date", &ShotProjection::roastDate);
+    setDouble("bean_weight", &ShotProjection::doseWeightG);
+    setDouble("drink_weight", &ShotProjection::finalWeightG);
     // Combine brand + model for visualizer (no separate brand field in API)
     {
-        QString brand = shotData.value("grinderBrand").toString().trimmed();
-        QString model = shotData.value("grinderModel").toString().trimmed();
-        QString combined = (brand + " " + model).trimmed();
+        QString combined = (shotData.grinderBrand.trimmed() + " " + shotData.grinderModel.trimmed()).trimmed();
         if (!combined.isEmpty()) shotObj["grinder_model"] = combined;
     }
-    setField("grinder_setting", "grinderSetting");
-    setField("drink_tds", "drinkTds");
-    setField("drink_ey", "drinkEy");
-    setField("espresso_enjoyment", "enjoyment");
-    setField("espresso_notes", "espressoNotes");
-    setField("barista", "barista");
-    setField("profile_title", "profileName");
+    setStr("grinder_setting", &ShotProjection::grinderSetting);
+    setDouble("drink_tds", &ShotProjection::drinkTds);
+    setDouble("drink_ey", &ShotProjection::drinkEy);
+    setInt("espresso_enjoyment", &ShotProjection::enjoyment);
+    setStr("espresso_notes", &ShotProjection::espressoNotes);
+    setStr("barista", &ShotProjection::barista);
+    setStr("profile_title", &ShotProjection::profileName);
 
     QJsonObject root;
     root["shot"] = shotObj;
@@ -965,16 +962,15 @@ void VisualizerUploader::sendUpload(const QByteArray& jsonData)
 }
 
 // static
-QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
+QByteArray VisualizerUploader::buildHistoryShotJson(const ShotProjection& shotData)
 {
     QJsonObject root;
     root["version"] = 2;
 
     // Use original timestamp from the shot
-    qint64 timestamp = shotData["timestamp"].toLongLong();
-    root["clock"] = timestamp;
-    root["timestamp"] = timestamp;
-    root["date"] = QDateTime::fromSecsSinceEpoch(timestamp).toString(Qt::ISODate);
+    root["clock"] = shotData.timestamp;
+    root["timestamp"] = shotData.timestamp;
+    root["date"] = QDateTime::fromSecsSinceEpoch(shotData.timestamp).toString(Qt::ISODate);
 
     // Helper to convert QVariantList of {x,y} points to QVector<QPointF>
     auto toPointVector = [](const QVariantList& points) -> QVector<QPointF> {
@@ -1006,14 +1002,14 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
     };
 
     // Convert to point vectors for interpolation
-    QVector<QPointF> pressureData = toPointVector(shotData["pressure"].toList());
-    QVector<QPointF> flowData = toPointVector(shotData["flow"].toList());
-    QVector<QPointF> tempData = toPointVector(shotData["temperature"].toList());
-    QVector<QPointF> pressureGoalData = toPointVector(shotData["pressureGoal"].toList());
-    QVector<QPointF> flowGoalData = toPointVector(shotData["flowGoal"].toList());
-    QVector<QPointF> tempGoalData = toPointVector(shotData["temperatureGoal"].toList());
-    QVector<QPointF> weightData = toPointVector(shotData["weight"].toList());
-    QVector<QPointF> weightFlowRateData = toPointVector(shotData["weightFlowRate"].toList());
+    QVector<QPointF> pressureData = toPointVector(shotData.pressure);
+    QVector<QPointF> flowData = toPointVector(shotData.flow);
+    QVector<QPointF> tempData = toPointVector(shotData.temperature);
+    QVector<QPointF> pressureGoalData = toPointVector(shotData.pressureGoal);
+    QVector<QPointF> flowGoalData = toPointVector(shotData.flowGoal);
+    QVector<QPointF> tempGoalData = toPointVector(shotData.temperatureGoal);
+    QVector<QPointF> weightData = toPointVector(shotData.weight);
+    QVector<QPointF> weightFlowRateData = toPointVector(shotData.weightFlowRate);
 
     // Elapsed time array (from pressure data - the master timeline)
     root["elapsed"] = extractTimes(pressureData);
@@ -1046,7 +1042,7 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
         totals["weight"] = interpolateGoalData(weightData, pressureData);
     }
     // Water dispensed: scale by 0.1 to match de1app's espresso_water_dispensed convention
-    QVector<QPointF> waterDispensedData = toPointVector(shotData["waterDispensed"].toList());
+    QVector<QPointF> waterDispensedData = toPointVector(shotData.waterDispensed);
     if (!waterDispensedData.isEmpty()) {
         QJsonArray waterDispensedRaw = interpolateGoalData(waterDispensedData, pressureData);
         QJsonArray waterDispensedScaled;
@@ -1058,9 +1054,9 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
 
     // Resistance object: P/flow² (Darcy, matches de1app's espresso_resistance) and
     // P/flow_weight² (scale flow, de1app calls this espresso_resistance_weight → by_weight)
-    QVector<QPointF> histWeightFlowData = toPointVector(shotData["weightFlowRate"].toList());
+    QVector<QPointF> histWeightFlowData = toPointVector(shotData.weightFlowRate);
     {
-        QVector<QPointF> histResData = toPointVector(shotData["darcyResistance"].toList());
+        QVector<QPointF> histResData = toPointVector(shotData.darcyResistance);
         QJsonObject resistance;
         if (!histResData.isEmpty())
             resistance["resistance"] = interpolateGoalData(histResData, pressureData);
@@ -1083,7 +1079,7 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
     // Scale object: raw weight series at native sample times. Only emit if there is scale data.
     if (!weightData.isEmpty() || !histWeightFlowData.isEmpty()) {
         QJsonObject scale;
-        scale["espresso_start"] = shotData["timestamp"].toDouble();
+        scale["espresso_start"] = static_cast<double>(shotData.timestamp);
         if (!weightData.isEmpty()) {
             QJsonArray weights, arrivals;
             for (const auto& pt : weightData) {
@@ -1103,7 +1099,7 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
     }
 
     // State change array from history phase markers
-    QVariantList phases = shotData["phases"].toList();
+    const QVariantList& phases = shotData.phases;
     if (!phases.isEmpty() && !pressureData.isEmpty()) {
         // Collect times of real frame transitions only (skip Start/End markers)
         QVector<double> markerTimes;
@@ -1132,47 +1128,36 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
 
     // Bean info
     QJsonObject bean;
-    QString beanBrand = shotData["beanBrand"].toString();
-    QString beanType = shotData["beanType"].toString();
-    QString roastDate = shotData["roastDate"].toString();
-    QString roastLevel = shotData["roastLevel"].toString();
-    if (!beanBrand.isEmpty()) bean["brand"] = beanBrand;
-    if (!beanType.isEmpty()) bean["type"] = beanType;
-    if (!roastDate.isEmpty()) bean["roast_date"] = roastDate;
-    if (!roastLevel.isEmpty()) bean["roast_level"] = roastLevel;
+    if (!shotData.beanBrand.isEmpty()) bean["brand"] = shotData.beanBrand;
+    if (!shotData.beanType.isEmpty()) bean["type"] = shotData.beanType;
+    if (!shotData.roastDate.isEmpty()) bean["roast_date"] = shotData.roastDate;
+    if (!shotData.roastLevel.isEmpty()) bean["roast_level"] = shotData.roastLevel;
     meta["bean"] = bean;
 
     // Shot info
     QJsonObject shot;
-    int enjoyment = shotData["enjoyment"].toInt();
-    QString notes = shotData["espressoNotes"].toString();
-    double tds = shotData["drinkTds"].toDouble();
-    double ey = shotData["drinkEy"].toDouble();
-    if (enjoyment > 0) shot["enjoyment"] = enjoyment;
-    if (!notes.isEmpty()) shot["notes"] = notes;
-    if (tds > 0) shot["tds"] = tds;
-    if (ey > 0) shot["ey"] = ey;
+    if (shotData.enjoyment > 0) shot["enjoyment"] = shotData.enjoyment;
+    if (!shotData.espressoNotes.isEmpty()) shot["notes"] = shotData.espressoNotes;
+    if (shotData.drinkTds > 0) shot["tds"] = shotData.drinkTds;
+    if (shotData.drinkEy > 0) shot["ey"] = shotData.drinkEy;
     meta["shot"] = shot;
 
     // Grinder info (combine brand+model for visualizer compatibility)
     QJsonObject grinder;
-    QString grinderBrand = shotData["grinderBrand"].toString();
-    QString grinderModel = shotData["grinderModel"].toString();
-    QString grinderSetting = shotData["grinderSetting"].toString();
-    QString grinderDisplay2 = grinderBrand.isEmpty() ? grinderModel
-        : (grinderModel.isEmpty() ? grinderBrand : grinderBrand + " " + grinderModel);
+    QString grinderDisplay2 = shotData.grinderBrand.isEmpty() ? shotData.grinderModel
+        : (shotData.grinderModel.isEmpty() ? shotData.grinderBrand
+                                           : shotData.grinderBrand + " " + shotData.grinderModel);
     if (!grinderDisplay2.isEmpty()) grinder["model"] = grinderDisplay2;
-    if (!grinderSetting.isEmpty()) grinder["setting"] = grinderSetting;
+    if (!shotData.grinderSetting.isEmpty()) grinder["setting"] = shotData.grinderSetting;
     meta["grinder"] = grinder;
 
     // Weights: use stored final weight from history; fall back to flow-integrated volume if missing
-    double doseWeight = shotData["doseWeightG"].toDouble();
-    double finalWeight = shotData["finalWeightG"].toDouble();
+    double finalWeight = shotData.finalWeightG;
     if (finalWeight <= 0 && !waterDispensedData.isEmpty())
         finalWeight = waterDispensedData.last().y();  // actual ml (normalized at import)
-    if (doseWeight > 0) meta["in"] = doseWeight;
+    if (shotData.doseWeightG > 0) meta["in"] = shotData.doseWeightG;
     if (finalWeight > 0) meta["out"] = finalWeight;
-    meta["time"] = shotData["durationSec"].toDouble();
+    meta["time"] = shotData.durationSec;
 
     root["meta"] = meta;
 
@@ -1180,27 +1165,25 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
     QJsonObject app = buildAppInfoJson();
 
     QJsonObject settings;
-    if (!beanBrand.isEmpty()) settings["bean_brand"] = beanBrand;
-    if (!beanType.isEmpty()) settings["bean_type"] = beanType;
-    if (!roastDate.isEmpty()) settings["roast_date"] = roastDate;
-    if (!roastLevel.isEmpty()) settings["roast_level"] = roastLevel;
+    if (!shotData.beanBrand.isEmpty()) settings["bean_brand"] = shotData.beanBrand;
+    if (!shotData.beanType.isEmpty()) settings["bean_type"] = shotData.beanType;
+    if (!shotData.roastDate.isEmpty()) settings["roast_date"] = shotData.roastDate;
+    if (!shotData.roastLevel.isEmpty()) settings["roast_level"] = shotData.roastLevel;
     if (!grinderDisplay2.isEmpty()) settings["grinder_model"] = grinderDisplay2;
-    if (!grinderSetting.isEmpty()) settings["grinder_setting"] = grinderSetting;
-    if (doseWeight > 0) settings["grinder_dose_weight"] = doseWeight;
+    if (!shotData.grinderSetting.isEmpty()) settings["grinder_setting"] = shotData.grinderSetting;
+    if (shotData.doseWeightG > 0) settings["grinder_dose_weight"] = shotData.doseWeightG;
     if (finalWeight > 0) settings["drink_weight"] = finalWeight;
-    if (tds > 0) settings["drink_tds"] = tds;
-    if (ey > 0) settings["drink_ey"] = ey;
-    if (enjoyment > 0) settings["espresso_enjoyment"] = enjoyment;
-    if (!notes.isEmpty()) settings["espresso_notes"] = notes;
+    if (shotData.drinkTds > 0) settings["drink_tds"] = shotData.drinkTds;
+    if (shotData.drinkEy > 0) settings["drink_ey"] = shotData.drinkEy;
+    if (shotData.enjoyment > 0) settings["espresso_enjoyment"] = shotData.enjoyment;
+    if (!shotData.espressoNotes.isEmpty()) settings["espresso_notes"] = shotData.espressoNotes;
 
-    QString barista = shotData["barista"].toString();
-    if (!barista.isEmpty()) settings["barista"] = barista;
+    if (!shotData.barista.isEmpty()) settings["barista"] = shotData.barista;
 
     // Parse profile JSON and merge profile fields for Visualizer TCL extraction
-    QString profileJson = shotData["profileJson"].toString();
     QJsonObject profileJsonObj;
-    if (!profileJson.isEmpty()) {
-        QJsonDocument profileDoc = QJsonDocument::fromJson(profileJson.toUtf8());
+    if (!shotData.profileJson.isEmpty()) {
+        QJsonDocument profileDoc = QJsonDocument::fromJson(shotData.profileJson.toUtf8());
         if (!profileDoc.isNull()) {
             profileJsonObj = profileDoc.object();
             Profile profile = Profile::fromJson(profileDoc);
@@ -1213,22 +1196,20 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const QVariantMap& shotData)
     }
 
     // Also set profile_title from shot data (may differ from profile's own title)
-    QString profileName = shotData["profileName"].toString();
-    if (!profileName.isEmpty())
-        settings["profile_title"] = profileName;
+    if (!shotData.profileName.isEmpty())
+        settings["profile_title"] = shotData.profileName;
 
     QJsonObject data;
     data["settings"] = settings;
-    QString debugLog = shotData["debugLog"].toString();
-    if (!debugLog.isEmpty())
-        data["debug_log"] = debugLog;
+    if (!shotData.debugLog.isEmpty())
+        data["debug_log"] = shotData.debugLog;
     app["data"] = data;
 
     root["app"] = app;
 
     // Barista at root level (Visualizer may extract from here)
-    if (!barista.isEmpty())
-        root["barista"] = barista;
+    if (!shotData.barista.isEmpty())
+        root["barista"] = shotData.barista;
 
     // Profile JSON object for Visualizer's ?format=json download
     if (!profileJsonObj.isEmpty())

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -6,6 +6,8 @@
 #include <QVector>
 #include <QPointF>
 
+#include "../history/shotprojection.h"
+
 class ShotDataModel;
 class Settings;
 class Profile;
@@ -56,18 +58,22 @@ public:
                                  const QString& debugLog = QString(),
                                  qint64 shotEpoch = 0);
 
-    // Upload a shot from history (takes QVariantMap from ShotHistoryStorage::getShot())
-    Q_INVOKABLE void uploadShotFromHistory(const QVariantMap& shotData);
+    // Upload a shot from history (takes the typed projection from
+    // ShotHistoryStorage::convertShotRecord). QML callers can pass either a
+    // ShotProjection (from shotReady) or a JS object (post-Object.assign in
+    // PostShotReviewPage); the QVariantMap → ShotProjection meta-converter
+    // registered at startup handles both shapes.
+    Q_INVOKABLE void uploadShotFromHistory(const ShotProjection& shotData);
 
     // Update metadata on an already-uploaded shot (PATCH to visualizer.coffee)
-    Q_INVOKABLE void updateShotOnVisualizer(const QString& visualizerId, const QVariantMap& shotData);
+    Q_INVOKABLE void updateShotOnVisualizer(const QString& visualizerId, const ShotProjection& shotData);
 
     // Test connection with current credentials
     Q_INVOKABLE void testConnection();
 
-    // Build a visualizer-compatible JSON payload from a ShotHistoryStorage QVariantMap.
+    // Build a visualizer-compatible JSON payload from a ShotProjection.
     // Thread-safe; does not touch instance state. Reused by ShotHistoryExporter.
-    static QByteArray buildHistoryShotJson(const QVariantMap& shotData);
+    static QByteArray buildHistoryShotJson(const ShotProjection& shotData);
 
 signals:
     void uploadingChanged();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,6 +188,8 @@ add_decenza_test(tst_shotsummarizer
     ${CMAKE_SOURCE_DIR}/src/ai/shotsummarizer.cpp
     ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
     ${CMAKE_SOURCE_DIR}/src/ai/conductance.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
     ${CMAKE_SOURCE_DIR}/src/models/shotdatamodel.cpp
     ${CMAKE_SOURCE_DIR}/src/rendering/fastlinerenderer.cpp
     ${CMAKE_SOURCE_DIR}/src/network/visualizeruploader.cpp
@@ -296,6 +298,8 @@ set(PROFILEMANAGER_SOURCES
     ${CMAKE_SOURCE_DIR}/src/ai/conductance.cpp
     ${CMAKE_SOURCE_DIR}/src/ai/shotsummarizer.cpp
     ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
     ${CMAKE_SOURCE_DIR}/src/models/shotdatamodel.cpp
     ${CMAKE_SOURCE_DIR}/src/rendering/fastlinerenderer.cpp
     ${CMAKE_SOURCE_DIR}/src/network/visualizeruploader.cpp
@@ -303,11 +307,16 @@ set(PROFILEMANAGER_SOURCES
 )
 
 # History sources (ShotHistoryStorage + transitive deps)
+# shotprojection.h is listed explicitly so AUTOMOC generates the Q_GADGET
+# meta-object — without it, ShotProjection::staticMetaObject is undefined and
+# tests using the gadget fail to link.
 set(HISTORY_SOURCES
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_internal.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
     ${CMAKE_SOURCE_DIR}/src/ai/conductance.cpp
     ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
     ${CMAKE_SOURCE_DIR}/src/ai/shotsummarizer.cpp
@@ -480,6 +489,8 @@ add_decenza_test(tst_mcptools_write
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_internal.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
     ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
     ${BLE_SOURCES}
     ${PROFILE_SOURCES}
@@ -507,6 +518,8 @@ add_decenza_test(tst_mcpserver_session
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_internal.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
     ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
     ${BLE_SOURCES}
     ${PROFILE_SOURCES}
@@ -535,6 +548,8 @@ add_decenza_test(tst_mcpserver_protocol
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_internal.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
     ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
     ${BLE_SOURCES}
     ${PROFILE_SOURCES}

--- a/tests/tst_shotrecord_cache.cpp
+++ b/tests/tst_shotrecord_cache.cpp
@@ -113,7 +113,7 @@ private slots:
         cached.detectors.pourTruncated = false;
         record.cachedAnalysis = cached;
 
-        const QVariantMap result = ShotHistoryStorage::convertShotRecord(record);
+        const QVariantMap result = ShotHistoryStorage::convertShotRecord(record).toVariantMap();
         const QVariantList lines = result.value("summaryLines").toList();
 
         QVERIFY2(!lines.isEmpty(), "summaryLines must be populated from the cache");
@@ -133,7 +133,7 @@ private slots:
         ShotRecord record = buildHealthyRecord();
         // cachedAnalysis intentionally left at default (std::nullopt).
 
-        const QVariantMap result = ShotHistoryStorage::convertShotRecord(record);
+        const QVariantMap result = ShotHistoryStorage::convertShotRecord(record).toVariantMap();
         const QVariantList lines = result.value("summaryLines").toList();
         const QVariantMap detectors = result.value("detectorResults").toMap();
 
@@ -153,7 +153,7 @@ private slots:
     void cachedAndFallback_paths_produceEquivalentOutput()
     {
         ShotRecord recordFallback = buildHealthyRecord();
-        const QVariantMap fallbackResult = ShotHistoryStorage::convertShotRecord(recordFallback);
+        const QVariantMap fallbackResult = ShotHistoryStorage::convertShotRecord(recordFallback).toVariantMap();
 
         ShotRecord recordCached = buildHealthyRecord();
         // Run analyzeShot ourselves (matching what loadShotRecordStatic
@@ -168,7 +168,7 @@ private slots:
             /*analysisFlags=*/{}, /*firstFrameSec=*/-1.0,
             recordCached.targetWeight, recordCached.summary.finalWeight,
             /*expectedFrameCount=*/-1);
-        const QVariantMap cachedResult = ShotHistoryStorage::convertShotRecord(recordCached);
+        const QVariantMap cachedResult = ShotHistoryStorage::convertShotRecord(recordCached).toVariantMap();
 
         // summaryLines must match line-for-line.
         const QVariantList fbLines = fallbackResult.value("summaryLines").toList();
@@ -199,7 +199,7 @@ private slots:
         ShotRecord record = buildHealthyRecord();
         record.targetWeight = 36.5;
 
-        const QVariantMap result = ShotHistoryStorage::convertShotRecord(record);
+        const QVariantMap result = ShotHistoryStorage::convertShotRecord(record).toVariantMap();
 
         QVERIFY2(result.contains("targetWeightG"),
                  "shot detail must expose targetWeightG");
@@ -215,7 +215,7 @@ private slots:
         ShotRecord record = buildHealthyRecord();
         record.targetWeight = 36.0;
 
-        const QVariantMap result = ShotHistoryStorage::convertShotRecord(record);
+        const QVariantMap result = ShotHistoryStorage::convertShotRecord(record).toVariantMap();
         const QVariantMap detectors = result.value("detectorResults").toMap();
         const QVariantMap grind = detectors.value("grind").toMap();
 

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -24,6 +24,7 @@
 #include <QString>
 
 #include "ai/shotsummarizer.h"
+#include "history/shotprojection.h"
 #include "models/shotdatamodel.h"
 #include "network/visualizeruploader.h"
 
@@ -203,7 +204,7 @@ private slots:
         shot["flowGoal"] = QVariantList();
 
         ShotSummarizer summarizer;
-        ShotSummary summary = summarizer.summarizeFromHistory(shot);
+        ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
 
         QVERIFY2(summary.pourTruncatedDetected, "puck-failure shape must set pourTruncatedDetected");
         QVERIFY2(linesContain(summary.summaryLines, QStringLiteral("Pour never pressurized")),
@@ -285,7 +286,7 @@ private slots:
         shot["flowGoal"] = QVariantList();
 
         ShotSummarizer summarizer;
-        ShotSummary summary = summarizer.summarizeFromHistory(shot);
+        ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
 
         QVERIFY2(!summary.pourTruncatedDetected,
                  "test setup: pressure peaked above floor so pourTruncated should not fire");
@@ -341,7 +342,7 @@ private slots:
         shot["flowGoal"] = QVariantList();
 
         ShotSummarizer summarizer;
-        ShotSummary summary = summarizer.summarizeFromHistory(shot);
+        ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
 
         QVERIFY2(!summary.pourTruncatedDetected,
                  "healthy 9-bar shot must not be flagged as puck-failure");
@@ -433,7 +434,7 @@ private slots:
         shot["detectorResults"] = detectors;
 
         ShotSummarizer summarizer;
-        const ShotSummary summary = summarizer.summarizeFromHistory(shot);
+        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
 
         QCOMPARE(summary.summaryLines.size(), 2);
         QCOMPARE(summary.summaryLines[0].toMap().value("text").toString(),
@@ -453,7 +454,7 @@ private slots:
         // Deliberately omit summaryLines.
 
         ShotSummarizer summarizer;
-        const ShotSummary summary = summarizer.summarizeFromHistory(shot);
+        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
 
         QVERIFY2(!summary.summaryLines.isEmpty(),
                  "fallback inline detector path must populate summaryLines");
@@ -475,7 +476,7 @@ private slots:
     {
         QVariantMap slowShot = buildHealthyShotMap();
         ShotSummarizer summarizer;
-        const ShotSummary slowSummary = summarizer.summarizeFromHistory(slowShot);
+        const ShotSummary slowSummary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(slowShot));
 
         // Now build a fast-path shot by stuffing the slow-path's lines and
         // pourTruncated into a fresh map. summarizeFromHistory MUST produce
@@ -485,7 +486,7 @@ private slots:
         QVariantMap detectors;
         detectors["pourTruncated"] = slowSummary.pourTruncatedDetected;
         fastShot["detectorResults"] = detectors;
-        const ShotSummary fastSummary = summarizer.summarizeFromHistory(fastShot);
+        const ShotSummary fastSummary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(fastShot));
 
         QCOMPARE(fastSummary.summaryLines.size(), slowSummary.summaryLines.size());
         for (qsizetype i = 0; i < slowSummary.summaryLines.size(); ++i) {
@@ -652,7 +653,7 @@ private slots:
         shot["detectorResults"] = detectors;
 
         ShotSummarizer summarizer;
-        const ShotSummary summary = summarizer.summarizeFromHistory(shot);
+        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
 
         QVERIFY2(summary.pourTruncatedDetected,
                  "fast path must derive pourTruncatedDetected from detectorResults");
@@ -711,7 +712,7 @@ private slots:
         shot["flowGoal"] = QVariantList();
 
         ShotSummarizer summarizer;
-        const ShotSummary summary = summarizer.summarizeFromHistory(shot);
+        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
 
         // marker[0]: startTime=0, endTime=markers[1].time=0 → degenerate, skip.
         // marker[1]: startTime=0, endTime=markers[2].time=8 → 8s span.
@@ -770,7 +771,7 @@ private slots:
         shot["flowGoal"] = QVariantList();
 
         ShotSummarizer summarizer;
-        const ShotSummary summary = summarizer.summarizeFromHistory(shot);
+        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
 
         QCOMPARE(summary.phases.size(), 2);
         // Preinfusion (0–8s): pressure flat at 1.0, flow flat at 1.8,


### PR DESCRIPTION
Closes #975.

## Summary

- Adds [`ShotProjection`](src/history/shotprojection.h) — a Q_GADGET value type that replaces the stringly-typed `QVariantMap` returned by `ShotHistoryStorage::convertShotRecord`. Renames now fail to compile at every C++ consumer site instead of silently dropping data — the bug class that #969, #971, and #974 each had to chase through six readers.
- QML keeps reading fields by name (`shotData.finalWeightG`) via Q_PROPERTY reflection; field names match the legacy map keys exactly. A registered `QVariantMap → ShotProjection` meta-converter lets `Q_INVOKABLE` methods accept JS objects (e.g. `PostShotReviewPage`'s `Object.assign`'d `editShotData`) without QML changes.
- C++ consumers migrated to field access: `AIManager` (`isMistakeShot`, `loadQualifiedShots`, `generateHistoryShotSummary`), `ShotSummarizer` (`summarizeFromHistory`, recent-shot block), MCP (`shots_get_detail`, `shots_compare` with member-pointer `diffStr`/`diffNum` helpers, `dialing_get_context`), `VisualizerUploader` (`uploadShotFromHistory`, `updateShotOnVisualizer`, `buildHistoryShotJson`), `ShotServer` (list + detail HTML), and `ShotHistoryExporter`.
- The `shotReady` signal now emits `const ShotProjection&`. Registered as a metatype in [main.cpp](src/main.cpp) so QueuedConnection across thread boundaries works.

## Out of scope (per the issue)

Time-series fields stay as `QVariantList<{x,y}>`, the metadata write path through `requestUpdateShotMetadata` is a separate stringly-typed contract, and visualizer.coffee's external snake_case schema is unchanged.

## Test plan

- [x] Full build clean (Qt Creator, macOS Debug)
- [x] Full test suite green: 1843 passed / 0 failed
- [ ] Smoke test on device: open a shot from history (PostShotReviewPage / ShotDetailPage), edit metadata, upload to Visualizer
- [ ] Smoke test MCP: `shots_get_detail`, `shots_compare`, `dialing_get_context` against a live shot
- [ ] Spot-check QML graph rendering on `LastShotItem` (uses `shot.pressure`, `shot.flow`, etc. via Q_PROPERTY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)