### PR TITLE
fix(mcp): gate spec-versioned tool fields on negotiated protocol version

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -33,6 +33,7 @@ If ORIGINAL_MODIFIED is true, warn the user — tests will modify the profile an
 | Date | Tools | Passed | Skipped | Failed | Notes |
 |------|-------|--------|---------|--------|-------|
 | 2026-03-20 | 37 | 41 | 1 | 0 | Initial run, simulator mode |
+| 2026-04-30 | 33 | 56 | 1 | 0 | Simulator, MCP 2025-11-25 negotiated. Plan refreshed for PR #976 field renames, `profiles_save` readonly refusal, `profiles_create` empty-filename, removal of `preferences` category, and §4.10 active-delete behavior. |
 
 ---
 
@@ -100,9 +101,11 @@ Verify: editorType values include at least "pressure", "flow", "dflow", "aflow",
 ### 3.2 profiles_get_active
 ```
 Call: profiles_get_active
-Expect: filename non-empty, editorType non-empty, modified is boolean, targetWeightG > 0
+Expect: filename non-empty, editorType non-empty, modified is boolean,
+        targetWeightG > 0, targetTemperatureC > 0, readOnly is boolean
 Save: note the filename and editorType as ORIGINAL_PROFILE and ORIGINAL_EDITOR
 ```
+Note: target temperature field is `targetTemperatureC` (suffix), not `targetTemperature`.
 
 ### 3.3 profiles_get_detail
 ```
@@ -168,7 +171,7 @@ Save: note tempStart as ORIGINAL_TEMP
 ```
 Call: profiles_edit_params (tempStart: ORIGINAL_TEMP+2, tempPreinfuse: ORIGINAL_TEMP+2, tempHold: ORIGINAL_TEMP+2, tempDecline: ORIGINAL_TEMP+2, confirmed: true)
 Expect: success=true, editorType="pressure", modified=true
-Verify: profiles_get_active → targetTemperature = ORIGINAL_TEMP+2, modified=true
+Verify: profiles_get_active → targetTemperatureC = ORIGINAL_TEMP+2, modified=true
 ```
 
 ### 4.2 Restore temperature
@@ -181,8 +184,9 @@ Expect: success=true
 ```
 Call: settings_set (espressoTemperature: ORIGINAL_TEMP+2, confirmed: true)
 Expect: success=true, updated includes "espressoTemperature"
-Verify: profiles_get_active → targetTemperature = ORIGINAL_TEMP+2
+Verify: profiles_get_active → targetTemperatureC = ORIGINAL_TEMP+2
 ```
+Note: writing `espressoTemperature` mutates the active profile (creates a user override on a built-in). This matches the QML behavior — the brew temperature lives on the profile.
 
 ### 4.4 Restore temperature
 ```
@@ -210,40 +214,47 @@ Verify: profiles_get_params → steps still has FRAME_COUNT elements, espresso_t
 ```
 Call: settings_set (espressoTemperature: ADV_TEMP, confirmed: true)
 Expect: updated includes "espressoTemperature"
-Verify: profiles_get_active → editorType="advanced", targetTemperature = ADV_TEMP
+Verify: profiles_get_active → editorType="advanced", targetTemperatureC = ADV_TEMP
 ```
 
-### 4.8 profiles_save — save in place
+### 4.8 profiles_save — refusal on read-only built-in
 ```
 Call: profiles_set_active (filename: "default", confirmed: true)
 Call: profiles_edit_params (tempStart: 91, tempPreinfuse: 91, tempHold: 91, tempDecline: 91, confirmed: true)
-Verify: profiles_get_active → modified=true
-Call: profiles_save (confirmed: true)
-Expect: success=true, filename="default"
-Verify: profiles_get_active → modified=false
-Note: this creates a user override of the built-in "default" — cleaned up in 4.11
+Verify: profiles_get_active → modified=true, readOnly=true
+Call: profiles_save (confirmed: true)   # no filename/title → in-place
+Expect: error containing "read-only" — built-in profiles cannot be saved in place;
+        Save As is required to create a user copy.
+Note: §4.3 (espressoTemperature setter) is the path that *does* persist edits on a
+      built-in by creating a user override automatically. profiles_save in-place is
+      reserved for already-user-owned profiles.
 ```
 
 ### 4.9 profiles_save — Save As
 ```
 Call: profiles_save (filename: "_mcp_test_tmp", title: "MCP Test Temp", confirmed: true)
 Expect: success=true, filename="_mcp_test_tmp"
-Note: this creates a temporary profile — cleaned up immediately in 4.10
+Verify: profiles_get_active → filename="_mcp_test_tmp", modified=false, readOnly=false
+Note: Save As makes the new copy active. Cleaned up in 4.10.
 ```
 
-### 4.10 profiles_delete — user profile
+### 4.10 profiles_delete — user profile (must switch active first)
 ```
+Call: profiles_set_active (filename: "default", confirmed: true)   # leave _mcp_test_tmp
 Call: profiles_delete (filename: "_mcp_test_tmp", confirmed: true)
 Expect: success=true, message contains "deleted"
 Verify: profiles_list → no profile with filename "_mcp_test_tmp"
+Note: deleting the currently-active profile is rejected with a misleading generic
+      "Failed to delete profile" message. Always switch active to a different profile
+      before delete.
 ```
 
 ### 4.11 profiles_delete — built-in revert
 ```
 Call: profiles_delete (filename: "default", confirmed: true)
-Expect: success=true (either "deleted" for user copy or "reverted" for built-in)
+Expect: success=true, "reverted":true (or "deleted":true if a user override existed)
 Verify: profiles_set_active (filename: "default", confirmed: true) → success (built-in still exists)
-Note: this cleans up the user override created in 4.8, restoring "default" to built-in state
+Note: succeeds even when no user override exists — reports "reverted" no-op.
 ```
 
 ### 4.12 profiles_set_active — built-in profile
@@ -257,10 +268,12 @@ Verify: profiles_get_active → title="Blooming Espresso"
 ```
 For each type in [dflow, aflow, pressure, flow, advanced]:
   Call: profiles_create (editorType: type, title: "_MCP Test " + type, confirmed: true)
-  Expect: success=true, editorType=type
+  Expect: success=true, editorType=type, filename="" (in-memory only — not yet saved)
   Verify: profiles_get_params → editorType matches type
-  Cleanup: profiles_delete (filename from create response, confirmed: true)
+  Cleanup: profiles_set_active (filename: "default", confirmed: true)  # discards unsaved
 ```
+Note: `profiles_create` only creates the profile in memory — call `profiles_save` with
+filename/title to persist. Switching active profile discards the unsaved draft.
 
 ### 4.14 Verify removed tool — dialing_apply_change
 ```
@@ -276,6 +289,8 @@ Call: settings_get
 Expect: espressoTemperatureC, targetWeightG, steamTemperatureC, waterTemperatureC, dyeBeanBrand all present
 Save: note dyeBeanBrand as ORIGINAL_BRAND, dyeGrinderSetting as ORIGINAL_GRIND
 ```
+Note: read fields are unit/scale-suffixed (`espressoTemperatureC`, `targetWeightG`),
+write fields drop the suffix (`espressoTemperature`, `targetWeight`).
 
 ### 5.2 settings_set — DYE metadata
 ```
@@ -294,9 +309,14 @@ Expect: success=true
 ### 6.1 shots_list
 ```
 Call: shots_list (limit: 3)
-Expect: count=3, each shot has id, profileName, duration, enjoyment
+Expect: count=3, each shot has id, profileName, durationSec, enjoyment0to100,
+        doseG, yieldG, targetWeightG, timestamp (ISO 8601)
 Save: note first shot id as SHOT_ID, second shot id as SHOT_ID_2
 ```
+Note: list summaries use unit/scale-suffixed field names (`durationSec`, `doseG`,
+`yieldG`, `enjoyment0to100`) per PR #976. **Detail responses below still use legacy
+names** (`enjoyment`, `doseWeightG`, `finalWeightG`, `espressoNotes`) — the rename
+hasn't been extended to `shots_get_detail` yet.
 
 ### 6.2 shots_list — filtered
 ```
@@ -308,12 +328,15 @@ Expect: count > 0, all returned shots have profileName containing "D-Flow"
 ```
 Call: shots_get_detail (shotId: SHOT_ID)
 Expect: id=SHOT_ID, pressure array non-empty, flow array non-empty, temperature array non-empty
+Caveat: response is large (50–80 KB for a typical shot) and may overflow the LLM
+        context window. Tracked in #979 — proposes opt-in `detail` parameter.
 ```
 
 ### 6.4 shots_compare
 ```
 Call: shots_compare (shotIds: [SHOT_ID, SHOT_ID_2])
 Expect: response contains data for both shot IDs
+Caveat: same payload-size issue as 6.3 (~130 KB for two shots). See #979.
 ```
 
 ### 6.5 shots_update — enjoyment and notes
@@ -321,19 +344,21 @@ Expect: response contains data for both shot IDs
 Call: shots_get_detail (shotId: SHOT_ID)
 Save: ORIGINAL_ENJOYMENT = enjoyment, ORIGINAL_NOTES = espressoNotes
 Call: shots_update (shotId: SHOT_ID, enjoyment: 85, notes: "MCP test run")
-Expect: success=true, message contains shot ID
+Expect: success=true, message contains shot ID, updated includes "enjoyment" and "espressoNotes"
 Cleanup: shots_update (shotId: SHOT_ID, enjoyment: ORIGINAL_ENJOYMENT, notes: ORIGINAL_NOTES)
 ```
 
 ### 6.6 shots_update — full metadata
 ```
 Call: shots_get_detail (shotId: SHOT_ID)
-Save: ORIGINAL_DOSE = doseWeight, ORIGINAL_BARISTA = barista
+Save: ORIGINAL_DOSE = doseWeightG, ORIGINAL_BARISTA = barista
 Call: shots_update (shotId: SHOT_ID, doseWeight: 18.5, barista: "MCP Test")
-Expect: success=true, updated includes "dose_weight" and "barista"
-Verify: shots_get_detail (shotId: SHOT_ID) → doseWeight=18.5
+Expect: success=true, updated includes "doseWeight" and "barista"
+Verify: shots_get_detail (shotId: SHOT_ID) → doseWeightG=18.5
 Cleanup: shots_update (shotId: SHOT_ID, doseWeight: ORIGINAL_DOSE, barista: ORIGINAL_BARISTA)
 ```
+Note: `shots_update` writers use un-suffixed names (`doseWeight`, `drinkWeight`),
+detail readers return suffixed names (`doseWeightG`, `finalWeightG`).
 
 ### 6.7 shots_delete — invalid ID (safe test)
 ```
@@ -448,10 +473,51 @@ Step 4 — Verify clean state:
 
 ## 11. Settings Parity (Phase 16)
 
+Valid categories per the `settings_get` schema:
+`machine, calibration, connections, screensaver, accessibility, ai, espresso, steam,
+water, flush, dye, mqtt, themes, visualizer, update, data, history, language, debug,
+battery, heater, autofavorites`. There is **no** `preferences` category — what used
+to live there has been split. Most landed in `machine` (sleep, theme, brightness,
+auto-wake, refill kit, post-shot review, default rating, …) but not all: tick/TTS
+moved to `accessibility`, screensaver-only keys to `screensaver`, update-channel
+keys to `update`, language to `language`. Use the table below to find a key's home,
+or pass `keys:["…"]` to bypass categories entirely.
+
+### Where do the common settings live? (verified 2026-04-30)
+
+| Category | Notable keys |
+|---|---|
+| `machine` | `autoSleepMinutes`, `keepSteamHeaterOn`, `themeMode`, `darkThemeName`, `lightThemeName`, `screenBrightness`, `autoWakeEnabled`, `autoWakeStayAwakeEnabled`, `autoWakeStayAwakeMinutes`, `defaultShotRating`, `launcherMode`, `postShotReviewTimeout`, `refillKitOverride`, `steamAutoFlushSeconds`, `steamTwoTapStop`, `waterLevelDisplayUnit`, `waterRefillPoint` |
+| `calibration` | `autoFlowCalibration`, `flowCalibrationMultiplier`, `ignoreVolumeWithScale`, `useFlowScale` |
+| `connections` | `machineAddress`, `scaleAddress`, `scaleName`, `scaleType`, `showScaleDialogs`, `usbSerialEnabled` |
+| `screensaver` | `screensaverType`, `dimDelayMinutes`, `dimPercent`, `cacheEnabled`, `flipClockUse3D`, `imageDisplayDuration`, `pipesSpeed`, `pipesCameraSpeed`, `pipesShowClock`, `videosShowClock`, `attractorShowClock`, `showDateOnPersonal`, `shotMapShape`, `shotMapTexture`, `shotMapShowClock`, `shotMapShowProfiles`, `shotMapShowTerminator` |
+| `accessibility` | `accessibilityEnabled`, `ttsEnabled`, `tickEnabled`, `tickSoundIndex`, `tickVolume`, `extractionAnnouncementsEnabled`, `extractionAnnouncementMode`, `extractionAnnouncementInterval` |
+| `ai` | `aiProvider`, `discussShotApp`, `discussShotCustomUrl`, `mcpAccessLevel`, `mcpConfirmationLevel`, `mcpEnabled`, `ollamaEndpoint`, `ollamaModel`, `openrouterModel` |
+| `espresso` | `currentProfile`, `espressoTemperatureC`, `lastUsedRatio`, `targetWeightG` |
+| `steam` | `steamDisabled`, `steamFlowMlPerSec`, `steamTemperatureC`, `steamTimeoutSec` |
+| `water` | `hotWaterFlowRateMlPerSec`, `waterTemperatureC`, `waterVolumeMl`, `waterVolumeMode` |
+| `flush` | `flushFlowMlPerSec`, `flushSeconds` |
+| `dye` | `dyeBarista`, `dyeBeanBrand`, `dyeBeanType`, `dyeBeanWeight`, `dyeDrinkEy`, `dyeDrinkTds`, `dyeDrinkWeight`, `dyeEspressoEnjoyment`, `dyeGrinderBrand`, `dyeGrinderBurrs`, `dyeGrinderModel`, `dyeGrinderSetting`, `dyeRoastDate`, `dyeRoastLevel`, `dyeShotNotes` |
+| `mqtt` | `mqttEnabled`, `mqttBaseTopic`, `mqttBrokerHost`, `mqttBrokerPort`, `mqttClientId`, `mqttHomeAssistantDiscovery`, `mqttPublishInterval`, `mqttRetainMessages`, `mqttUsername` |
+| `themes` | `activeShader`, `activeThemeName`, `isDarkMode`, `themeNames` (mostly read-only metadata; write via `machine.themeMode`/`darkThemeName`/`lightThemeName`) |
+| `visualizer` | `visualizerAutoUpload`, `visualizerClearNotesOnStart`, `visualizerExtendedMetadata`, `visualizerMinDuration`, `visualizerShowAfterShot` |
+| `update` | `autoCheckUpdates`, `betaUpdatesEnabled` |
+| `data` | `dailyBackupHour`, `shotServerEnabled`, `shotServerPort`, `webSecurityEnabled` |
+| `history` | `shotHistorySortDirection`, `shotHistorySortField` |
+| `language` | `currentLanguage` |
+| `debug` | `hideGhcSimulator`, `simulationMode` |
+| `battery` | `batteryPercent` (read-only), `chargingMode`, `isCharging` (read-only) |
+| `heater` | `heaterIdleTempC`, `heaterTestFlowMlPerSec`, `heaterWarmupFlowMlPerSec`, `heaterWarmupTimeoutSec` |
+| `autofavorites` | `autoFavoritesGroupBy`, `autoFavoritesHideUnrated`, `autoFavoritesMaxItems`, `autoFavoritesOpenBrewSettings` |
+
+Sensitive fields (API keys, passwords, TOTP secrets) are excluded from both
+`settings_get` *and* `settings_set` schemas — they cannot be read or written via MCP.
+
 ### State Capture
 ```
-Call: settings_get (category: "preferences")
-Save: ORIGINAL_AUTO_SLEEP = autoSleepMinutes, ORIGINAL_KEEP_STEAM = keepSteamHeaterOn
+Call: settings_get (category: "machine")
+Save: ORIGINAL_AUTO_SLEEP = autoSleepMinutes, ORIGINAL_KEEP_STEAM = keepSteamHeaterOn,
+      ORIGINAL_THEME_MODE = themeMode
 
 Call: settings_get (category: "accessibility")
 Save: ORIGINAL_A11Y_ENABLED = accessibilityEnabled, ORIGINAL_TICK_VOLUME = tickVolume
@@ -466,11 +532,14 @@ Call: settings_get (category: "update")
 Save: ORIGINAL_AUTO_CHECK = autoCheckUpdates
 ```
 
-### 11.1 settings_get — category filter
+### 11.1 settings_get — category filter (machine)
 ```
-Call: settings_get (category: "preferences")
-Expect: autoSleepMinutes present, keepSteamHeaterOn present, themeMode present
-Expect absent: mqttEnabled, screensaverType, accessibilityEnabled (wrong category)
+Call: settings_get (category: "machine")
+Expect: autoSleepMinutes, keepSteamHeaterOn, themeMode, darkThemeName, lightThemeName,
+        screenBrightness all present
+Expect absent: mqttEnabled, screensaverType, accessibilityEnabled (different categories)
+Note: an unknown category (e.g. "preferences") returns {} silently — server should
+      probably reject it with an error, but currently does not.
 ```
 
 ### 11.2 settings_get — all categories
@@ -500,7 +569,7 @@ Expect: screensaverType, dimDelayMinutes, dimPercent, pipesSpeed, pipesCameraSpe
         pipesShowClock, flipClockUse3D, videosShowClock, cacheEnabled present
 ```
 
-### 11.6 settings_set — preferences
+### 11.6 settings_set — auto-sleep and steam heater
 ```
 Call: settings_set (autoSleepMinutes: 30, keepSteamHeaterOn: false, confirmed: true)
 Expect: success=true, updated includes "autoSleepMinutes" and "keepSteamHeaterOn"
@@ -569,5 +638,27 @@ Cleanup: settings_set (currentLanguage: ORIGINAL_LANG, confirmed: true)
 | Scale | 3 | |
 | Devices | 3 | |
 | Debug | 1 | |
-| Settings Parity | 12 | Category filter, all categories, write+verify+restore |
+| Settings Parity | 12 | `keys:[…]` filter (no `preferences` category), categories, write+verify+restore |
 | **Total** | **62** | |
+
+## Field-name reference (PR #976 / #975)
+
+Settings, profile, and shot responses use unit/scale-suffixed reader names but
+un-suffixed writer names. Quick lookup:
+
+| Concept | Read field (responses) | Write field (settings_set / shots_update) |
+|---|---|---|
+| Espresso temp | `espressoTemperatureC` | `espressoTemperature` |
+| Steam temp | `steamTemperatureC` | `steamTemperature` |
+| Water temp | `waterTemperatureC` | `waterTemperature` |
+| Profile target temp | `targetTemperatureC` | (via `tempStart`/`espresso_temperature` on `profiles_edit_params`) |
+| Target weight | `targetWeightG` | `targetWeight` |
+| Shot duration | `durationSec` (list) | n/a (computed) |
+| Shot enjoyment | `enjoyment0to100` (list) / `enjoyment` (detail — legacy) | `enjoyment` (`shots_update`) |
+| Shot dose | `doseG` (list) / `doseWeightG` (detail) | `doseWeight` (`shots_update`) |
+| Shot yield | `yieldG` (list) / `finalWeightG` (detail) | `drinkWeight` (`shots_update`) |
+| Shot notes | `notes` (list) / `espressoNotes` (detail) | `notes` (`shots_update`) |
+
+Inconsistency to be filed: `shots_get_detail` should adopt the suffixed names so it
+matches `shots_list`. Currently the projection used by list summaries is the only
+surface that's been migrated.

--- a/src/mcp/mcpresourceregistry.h
+++ b/src/mcp/mcpresourceregistry.h
@@ -54,27 +54,36 @@ public:
         m_resources[uri] = res;
     }
 
-    QJsonArray listResources() const
+    // protocolVersion gates spec-versioned optional fields. Strict clients
+    // reject resources/list responses containing fields from a newer spec
+    // than was negotiated (matching the same hazard fixed for tools/list).
+    QJsonArray listResources(const QString& protocolVersion) const
     {
+        const bool emitTitle = protocolVersion >= QStringLiteral("2025-06-18");
+        const bool emitIcons = protocolVersion >= QStringLiteral("2025-11-25");
+
         QJsonArray result;
         for (auto it = m_resources.constBegin(); it != m_resources.constEnd(); ++it) {
             const auto& res = it.value();
             QJsonObject resJson;
             resJson["uri"] = res.uri;
             resJson["name"] = res.name;
-            // MCP 2025-06-18: separate human-readable `title` from `name`.
-            // Existing registrations already use a display-name-y string in
-            // `name` (e.g. "Machine State"), so reuse it here. New code
-            // should treat `name` as the programmatic identifier.
-            resJson["title"] = res.name;
+            if (emitTitle) {
+                // MCP 2025-06-18: separate human-readable `title` from `name`.
+                // Existing registrations already use a display-name-y string in
+                // `name` (e.g. "Machine State"), so reuse it here.
+                resJson["title"] = res.name;
+            }
             resJson["description"] = res.description;
             resJson["mimeType"] = res.mimeType;
 
-            // MCP 2025-11-25: icons array — derived from URI prefix.
-            QJsonArray icons = McpRegistryHelpers::iconsArrayFromQrc(
-                McpRegistryHelpers::iconQrcForResource(res.uri));
-            if (!icons.isEmpty())
-                resJson["icons"] = icons;
+            if (emitIcons) {
+                // MCP 2025-11-25: icons array — derived from URI prefix.
+                QJsonArray icons = McpRegistryHelpers::iconsArrayFromQrc(
+                    McpRegistryHelpers::iconQrcForResource(res.uri));
+                if (!icons.isEmpty())
+                    resJson["icons"] = icons;
+            }
 
             result.append(resJson);
         }

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -145,7 +145,8 @@ void McpServer::registerAllTools()
     registerDeviceTools(m_toolRegistry, m_bleManager, m_device);
     registerDebugTools(m_toolRegistry, m_memoryMonitor);
     registerAgentTools(m_toolRegistry);
-    qDebug() << "McpServer: Registered" << m_toolRegistry->listTools(2).size() << "tools";
+    qDebug() << "McpServer: Registered"
+             << m_toolRegistry->listTools(2, QStringLiteral("2025-11-25")).size() << "tools";
 }
 
 void McpServer::registerAllResources()
@@ -616,12 +617,13 @@ QJsonObject McpServer::handleInitialize(const QJsonObject& params, McpSession* s
 QJsonObject McpServer::handleToolsList(const QJsonObject& params, McpSession* session)
 {
     Q_UNUSED(params)
-    Q_UNUSED(session)
 
     int accessLevel = m_settings ? m_settings->mcp()->mcpAccessLevel() : 0;
+    const QString protocolVersion = session ? session->protocolVersion()
+                                            : QStringLiteral("2024-11-05");
 
     QJsonObject result;
-    result["tools"] = m_toolRegistry->listTools(accessLevel);
+    result["tools"] = m_toolRegistry->listTools(accessLevel, protocolVersion);
     return result;
 }
 

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -152,7 +152,8 @@ void McpServer::registerAllTools()
 void McpServer::registerAllResources()
 {
     registerMcpResources(m_resourceRegistry, m_device, m_machineState, m_profileManager, m_shotHistory, m_memoryMonitor, m_settings);
-    qDebug() << "McpServer: Registered" << m_resourceRegistry->listResources().size() << "resources";
+    qDebug() << "McpServer: Registered"
+             << m_resourceRegistry->listResources(QStringLiteral("2025-11-25")).size() << "resources";
 }
 
 void McpServer::connectSseNotifications()
@@ -260,8 +261,15 @@ McpServer::~McpServer()
     qDeleteAll(m_sessions);
 }
 
-QJsonObject McpServer::buildToolCallResponse(const QJsonObject& toolResult) const
+QJsonObject McpServer::buildToolCallResponse(const QJsonObject& toolResult,
+                                              const QString& protocolVersion) const
 {
+    // `structuredContent` and the `resource_link` content block type were
+    // introduced in 2025-06-18. Strict 2024-11-05 clients reject the response
+    // when either appears, so both are gated on the negotiated version.
+    const bool emitStructured = protocolVersion >= QStringLiteral("2025-06-18");
+    const bool emitResourceLinks = protocolVersion >= QStringLiteral("2025-06-18");
+
     // Pull out optional `_resourceLinks` array — tools that want to attach
     // resource_link content blocks declare them as a side-channel here so the
     // structured payload itself stays clean. Each entry is
@@ -271,25 +279,25 @@ QJsonObject McpServer::buildToolCallResponse(const QJsonObject& toolResult) cons
 
     QJsonArray content;
 
-    // Resource link blocks first — they're cheap to render and let clients
-    // that subscribe to resource updates correlate the result with a URI.
-    for (const QJsonValue& v : std::as_const(resourceLinks)) {
-        QJsonObject src = v.toObject();
-        QJsonObject block;
-        block["type"] = "resource_link";
-        block["uri"] = src.value("uri").toString();
-        const QString lt = src.value("title").toString();
-        if (!lt.isEmpty()) block["title"] = lt;
-        const QString mt = src.value("mimeType").toString();
-        block["mimeType"] = mt.isEmpty() ? QStringLiteral("application/json") : mt;
-        const QString ld = src.value("description").toString();
-        if (!ld.isEmpty()) block["description"] = ld;
-        content.append(block);
+    if (emitResourceLinks) {
+        // Resource link blocks first — they're cheap to render and let clients
+        // that subscribe to resource updates correlate the result with a URI.
+        for (const QJsonValue& v : std::as_const(resourceLinks)) {
+            QJsonObject src = v.toObject();
+            QJsonObject block;
+            block["type"] = "resource_link";
+            block["uri"] = src.value("uri").toString();
+            const QString lt = src.value("title").toString();
+            if (!lt.isEmpty()) block["title"] = lt;
+            const QString mt = src.value("mimeType").toString();
+            block["mimeType"] = mt.isEmpty() ? QStringLiteral("application/json") : mt;
+            const QString ld = src.value("description").toString();
+            if (!ld.isEmpty()) block["description"] = ld;
+            content.append(block);
+        }
     }
 
-    // Text content block — kept for backward compatibility with 2025-03-26
-    // clients that don't read structuredContent. Newer clients still see it
-    // and ignore it once they consume structuredContent.
+    // Text content block — universal across every supported protocol version.
     QJsonObject textBlock;
     textBlock["type"] = "text";
     textBlock["text"] = QString::fromUtf8(QJsonDocument(sanitized).toJson(QJsonDocument::Compact));
@@ -297,7 +305,8 @@ QJsonObject McpServer::buildToolCallResponse(const QJsonObject& toolResult) cons
 
     QJsonObject result;
     result["content"] = content;
-    result["structuredContent"] = sanitized;
+    if (emitStructured)
+        result["structuredContent"] = sanitized;
     return result;
 }
 
@@ -634,6 +643,8 @@ QJsonObject McpServer::handleToolsCall(const QJsonObject& params, McpSession* se
     QJsonObject arguments = params["arguments"].toObject();
 
     int accessLevel = m_settings ? m_settings->mcp()->mcpAccessLevel() : 0;
+    const QString protocolVersion = session ? session->protocolVersion()
+                                            : QStringLiteral("2024-11-05");
 
     // Rate limiting for control + settings tools
     QString category = m_toolRegistry->toolCategory(toolName);
@@ -659,7 +670,7 @@ QJsonObject McpServer::handleToolsCall(const QJsonObject& params, McpSession* se
         confirmPayload["action"] = toolName;
         confirmPayload["description"] = confirmationDescription(toolName);
         confirmPayload["parameters"] = arguments;
-        return buildToolCallResponse(confirmPayload);
+        return buildToolCallResponse(confirmPayload, protocolVersion);
     }
 
     // Strip the confirmed key before passing to tool handler
@@ -686,6 +697,7 @@ QJsonObject McpServer::handleToolsCall(const QJsonObject& params, McpSession* se
         pending.toolName = toolName;
         pending.arguments = arguments;
         pending.accessLevel = accessLevel;
+        pending.protocolVersion = protocolVersion;
         m_pendingConfirmation = pending;
 
         QString description = confirmationDescription(toolName);
@@ -701,12 +713,13 @@ QJsonObject McpServer::handleToolsCall(const QJsonObject& params, McpSession* se
         QPointer<QTcpSocket> socketPtr(socket);
         QVariant reqId = requestId;
         QString sessId = session->id();
+        QString protoVer = protocolVersion;
 
         QString error;
         bool dispatched = m_toolRegistry->callAsyncTool(
             toolName, arguments, accessLevel, error,
-            [this, socketPtr, reqId, sessId](QJsonObject toolResult) {
-                sendAsyncToolResponse(socketPtr, reqId, sessId, toolResult);
+            [this, socketPtr, reqId, sessId, protoVer](QJsonObject toolResult) {
+                sendAsyncToolResponse(socketPtr, reqId, sessId, protoVer, toolResult);
             });
 
         if (!dispatched) {
@@ -736,25 +749,32 @@ QJsonObject McpServer::handleToolsCall(const QJsonObject& params, McpSession* se
         return result;
     }
 
-    return buildToolCallResponse(toolResult);
+    return buildToolCallResponse(toolResult, protocolVersion);
 }
 
 QJsonObject McpServer::handleResourcesList(const QJsonObject& params, McpSession* session)
 {
     Q_UNUSED(params)
-    Q_UNUSED(session)
+
+    const QString protocolVersion = session ? session->protocolVersion()
+                                            : QStringLiteral("2024-11-05");
 
     QJsonObject result;
-    result["resources"] = m_resourceRegistry->listResources();
+    result["resources"] = m_resourceRegistry->listResources(protocolVersion);
     return result;
 }
 
 QJsonObject McpServer::handleResourcesRead(const QJsonObject& params, McpSession* session,
                                             QTcpSocket* socket, const QVariant& requestId)
 {
-    Q_UNUSED(session)
-
     QString uri = params["uri"].toString();
+
+    // `structuredContent` is a 2025-06-18 field; older clients see only the
+    // legacy `text` payload. Capture the negotiated version up-front so async
+    // dispatches honour it after the session pointer may have changed.
+    const QString protocolVersion = session ? session->protocolVersion()
+                                            : QStringLiteral("2024-11-05");
+    const bool emitStructured = protocolVersion >= QStringLiteral("2025-06-18");
 
     // Async resources: dispatch to background, send response later
     if (m_resourceRegistry->isAsyncResource(uri)) {
@@ -764,7 +784,7 @@ QJsonObject McpServer::handleResourcesRead(const QJsonObject& params, McpSession
 
         QString error;
         bool dispatched = m_resourceRegistry->readAsyncResource(uri, error,
-            [this, socketPtr, reqId, sessId, uri](QJsonObject resourceData) {
+            [this, socketPtr, reqId, sessId, uri, emitStructured](QJsonObject resourceData) {
                 if (!socketPtr || socketPtr->state() != QAbstractSocket::ConnectedState) {
                     qDebug() << "McpServer: async resource response dropped (socket disconnected)";
                     return;
@@ -776,7 +796,8 @@ QJsonObject McpServer::handleResourcesRead(const QJsonObject& params, McpSession
                 content["uri"] = uri;
                 content["mimeType"] = "application/json";
                 content["text"] = QString::fromUtf8(QJsonDocument(resourceData).toJson(QJsonDocument::Compact));
-                content["structuredContent"] = resourceData;
+                if (emitStructured)
+                    content["structuredContent"] = resourceData;
                 contents.append(content);
                 result["contents"] = contents;
                 sendJsonRpcResponse(socketPtr, result, reqId, sessId);
@@ -814,7 +835,8 @@ QJsonObject McpServer::handleResourcesRead(const QJsonObject& params, McpSession
     content["uri"] = uri;
     content["mimeType"] = "application/json";
     content["text"] = QString::fromUtf8(QJsonDocument(resourceData).toJson(QJsonDocument::Compact));
-    content["structuredContent"] = resourceData;
+    if (emitStructured)
+        content["structuredContent"] = resourceData;
     contents.append(content);
     result["contents"] = contents;
     return result;
@@ -869,20 +891,35 @@ McpSession* McpServer::findOrCreateSession(const QString& sessionHeader)
     }
 
     // Clean up orphaned sessions before creating a new one.
-    // When mcp-remote's SSE connection drops and it re-initializes (without
-    // sending a session header), the old session stays around with no SSE
-    // socket. Over hours this fills the session quota. Remove sessions whose
-    // SSE transport was established and then lost — the client has moved on.
-    // We check hadSseSocket() to avoid killing freshly-created sessions that
-    // haven't connected their SSE stream yet (window between POST initialize
-    // and GET /mcp).
+    // Two transports leak slots and need different signals:
+    //
+    //   1. SSE clients (mcp-remote, etc.) — their SSE stream drops and they
+    //      re-initialize without sending a session header. The old session
+    //      stays around with no SSE socket. Detect via hadSseSocket() so we
+    //      don't kill freshly-created sessions still in the window between
+    //      POST initialize and GET /mcp.
+    //
+    //   2. Pure-HTTP clients (Claude Code's `type: "http"` transport) — they
+    //      never establish an SSE stream, so hadSseSocket() is always false
+    //      and the SSE rule above never fires. Each reconnect leaks a slot
+    //      until the 30-min idle timeout, wedging the pool at MaxSessions.
+    //      Use idle time as the signal: an HTTP MCP client that hasn't sent
+    //      a request in OrphanIdleSeconds is presumed gone.
+    QDateTime now = QDateTime::currentDateTimeUtc();
+    constexpr int OrphanIdleSeconds = 60;
     QStringList orphaned;
     for (auto it = m_sessions.constBegin(); it != m_sessions.constEnd(); ++it) {
-        if (!it.value()->sseSocket() && it.value()->hadSseSocket())
+        const auto* s = it.value();
+        if (s->sseSocket())
+            continue;
+        if (s->hadSseSocket()) {
             orphaned.append(it.key());
+        } else if (s->lastActivity().secsTo(now) > OrphanIdleSeconds) {
+            orphaned.append(it.key());
+        }
     }
     for (const QString& id : orphaned) {
-        qDebug() << "McpServer: Removing orphaned session (no SSE socket)" << id;
+        qDebug() << "McpServer: Removing orphaned session" << id;
         if (m_pendingConfirmation.has_value() && m_pendingConfirmation->sessionId == id)
             m_pendingConfirmation.reset();
         delete m_sessions.take(id);
@@ -962,7 +999,7 @@ void McpServer::confirmationResolved(const QString& sessionId, bool accepted)
         QJsonObject deniedPayload;
         deniedPayload["error"] = "User denied confirmation for " + pending.toolName;
 
-        QJsonObject result = buildToolCallResponse(deniedPayload);
+        QJsonObject result = buildToolCallResponse(deniedPayload, pending.protocolVersion);
         result["isError"] = true;
         sendJsonRpcResponse(pending.socket, result, pending.requestId, pending.sessionId);
         return;
@@ -976,8 +1013,9 @@ void McpServer::confirmationResolved(const QString& sessionId, bool accepted)
         QString error;
         bool dispatched = m_toolRegistry->callAsyncTool(
             pending.toolName, pending.arguments, pending.accessLevel, error,
-            [this, socketPtr, reqId = pending.requestId, sessId = pending.sessionId](QJsonObject toolResult) {
-                sendAsyncToolResponse(socketPtr, reqId, sessId, toolResult);
+            [this, socketPtr, reqId = pending.requestId, sessId = pending.sessionId,
+             protoVer = pending.protocolVersion](QJsonObject toolResult) {
+                sendAsyncToolResponse(socketPtr, reqId, sessId, protoVer, toolResult);
             });
         if (!dispatched) {
             QJsonObject errorObj;
@@ -1005,19 +1043,22 @@ void McpServer::confirmationResolved(const QString& sessionId, bool accepted)
         return;
     }
 
-    sendJsonRpcResponse(pending.socket, buildToolCallResponse(toolResult),
+    sendJsonRpcResponse(pending.socket,
+                        buildToolCallResponse(toolResult, pending.protocolVersion),
                         pending.requestId, pending.sessionId);
 }
 
 void McpServer::sendAsyncToolResponse(QPointer<QTcpSocket> socket, const QVariant& requestId,
-                                       const QString& sessionId, const QJsonObject& toolResult)
+                                       const QString& sessionId, const QString& protocolVersion,
+                                       const QJsonObject& toolResult)
 {
     if (!socket || socket->state() != QAbstractSocket::ConnectedState) {
         qDebug() << "McpServer: async tool response dropped (socket disconnected)";
         return;
     }
 
-    sendJsonRpcResponse(socket, buildToolCallResponse(toolResult), requestId, sessionId);
+    sendJsonRpcResponse(socket, buildToolCallResponse(toolResult, protocolVersion),
+                        requestId, sessionId);
 }
 
 bool McpServer::needsInAppConfirmation(const QString& toolName) const

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -286,7 +286,23 @@ QJsonObject McpServer::buildToolCallResponse(const QJsonObject& toolResult,
             QJsonObject src = v.toObject();
             QJsonObject block;
             block["type"] = "resource_link";
-            block["uri"] = src.value("uri").toString();
+            const QString uri = src.value("uri").toString();
+            block["uri"] = uri;
+            // MCP 2025-06-18: `resource_link` carries the same shape as a
+            // `Resource`, where `name` is REQUIRED. Strict clients reject the
+            // whole content[] entry when it's missing. Prefer a side-channel
+            // `name` when the emitter supplied one; otherwise fall back to the
+            // uri's last path segment (e.g. decenza://shots/884 → "884",
+            // decenza://machine/state → "state") so we never ship an entry
+            // without `name`.
+            const QString providedName = src.value("name").toString();
+            if (!providedName.isEmpty()) {
+                block["name"] = providedName;
+            } else {
+                const qsizetype slash = uri.lastIndexOf('/');
+                const QString tail = slash >= 0 ? uri.mid(slash + 1) : uri;
+                block["name"] = tail.isEmpty() ? uri : tail;
+            }
             const QString lt = src.value("title").toString();
             if (!lt.isEmpty()) block["title"] = lt;
             const QString mt = src.value("mimeType").toString();

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -105,6 +105,21 @@ McpServer::McpServer(QObject* parent)
     }
 }
 
+// Authoritative list of MCP protocol versions this server will accept. First
+// entry is also the preferred version returned when a client requests an
+// unrecognized one. Order matters: keep newest first so `supportedVersions.first()`
+// is the latest spec.
+const QStringList& McpServer::supportedProtocolVersions()
+{
+    static const QStringList versions = {
+        QStringLiteral("2025-11-25"),
+        QStringLiteral("2025-06-18"),
+        QStringLiteral("2025-03-26"),
+        QStringLiteral("2024-11-05"),
+    };
+    return versions;
+}
+
 bool McpServer::isOriginAllowed(const QString& origin) const
 {
     // Empty Origin (CLI clients, mcp-remote, MCP Inspector CLI) is always allowed.
@@ -295,14 +310,20 @@ QJsonObject McpServer::buildToolCallResponse(const QJsonObject& toolResult,
             // uri's last path segment (e.g. decenza://shots/884 → "884",
             // decenza://machine/state → "state") so we never ship an entry
             // without `name`.
-            const QString providedName = src.value("name").toString();
-            if (!providedName.isEmpty()) {
-                block["name"] = providedName;
-            } else {
+            QString name = src.value("name").toString();
+            if (name.isEmpty() && !uri.isEmpty()) {
                 const qsizetype slash = uri.lastIndexOf('/');
                 const QString tail = slash >= 0 ? uri.mid(slash + 1) : uri;
-                block["name"] = tail.isEmpty() ? uri : tail;
+                name = tail.isEmpty() ? uri : tail;
             }
+            if (name.isEmpty()) {
+                // Empty uri AND no provided name — emitter bug. Skip the block
+                // entirely rather than ship a payload that fails strict zod
+                // validation downstream.
+                qWarning() << "McpServer: dropping resource_link with empty name and uri";
+                continue;
+            }
+            block["name"] = name;
             const QString lt = src.value("title").toString();
             if (!lt.isEmpty()) block["title"] = lt;
             const QString mt = src.value("mimeType").toString();
@@ -313,7 +334,9 @@ QJsonObject McpServer::buildToolCallResponse(const QJsonObject& toolResult,
         }
     }
 
-    // Text content block — universal across every supported protocol version.
+    // Text content block is always emitted: it's the only payload that
+    // 2024-11-05 / 2025-03-26 clients read, and 2025-06-18+ clients ignore it
+    // once they consume `structuredContent` below.
     QJsonObject textBlock;
     textBlock["type"] = "text";
     textBlock["text"] = QString::fromUtf8(QJsonDocument(sanitized).toJson(QJsonDocument::Compact));
@@ -403,6 +426,15 @@ void McpServer::handleHttpRequest(QTcpSocket* socket, const QString& method,
                     // to it. Reuse it to avoid leaking a new session on every request.
                     session = m_sessions.begin().value();
                     qDebug() << "McpServer: Stale session header, reusing sole session" << session->id();
+                    // Adopt the client's MCP-Protocol-Version (when present and
+                    // supported) so the mismatch check below doesn't 400 a
+                    // recovered client whose prior negotiation differed from the
+                    // session's. Mirrors the auto-create branch.
+                    if (!protocolHeader.isEmpty()
+                        && supportedProtocolVersions().contains(protocolHeader)
+                        && protocolHeader != session->protocolVersion()) {
+                        session->setProtocolVersion(protocolHeader);
+                    }
                 } else {
                     qDebug() << "McpServer: Session not found (expired or stale), auto-creating new session";
                     session = findOrCreateSession(QString());
@@ -413,12 +445,16 @@ void McpServer::handleHttpRequest(QTcpSocket* socket, const QString& method,
                     }
                     // Mark as initialized — the client already completed initialize
                     // in a prior session, so skip the handshake requirement.
-                    // Adopt the client's MCP-Protocol-Version when present so the
-                    // mismatch check below doesn't immediately 400 a recovered
-                    // client whose prior negotiation was newer than our default.
+                    // Adopt the client's MCP-Protocol-Version when present and
+                    // supported so the mismatch check below doesn't immediately
+                    // 400 a recovered client whose prior negotiation was newer
+                    // than our default. Reject unrecognized headers so an
+                    // attacker can't push the gate into an unspec'd state.
                     session->setInitialized(true);
-                    if (!protocolHeader.isEmpty())
+                    if (!protocolHeader.isEmpty()
+                        && supportedProtocolVersions().contains(protocolHeader)) {
                         session->setProtocolVersion(protocolHeader);
+                    }
                 }
             }
             // MCP-Protocol-Version header check (required by 2025-06-18 for
@@ -623,9 +659,7 @@ QJsonObject McpServer::handleInitialize(const QJsonObject& params, McpSession* s
     // Negotiate protocol version — accept what the client requests if we support it,
     // otherwise return our preferred version (the first entry).
     QString clientVersion = params["protocolVersion"].toString();
-    static const QStringList supportedVersions = {
-        "2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"
-    };
+    const QStringList& supportedVersions = supportedProtocolVersions();
     QString negotiatedVersion = supportedVersions.contains(clientVersion)
         ? clientVersion : supportedVersions.first();
 
@@ -633,10 +667,18 @@ QJsonObject McpServer::handleInitialize(const QJsonObject& params, McpSession* s
         session->setProtocolVersion(negotiatedVersion);
 
     const QJsonObject clientInfo = params["clientInfo"].toObject();
+    auto sanitizeForLog = [](QString s) {
+        // Untrusted strings from the network — cap length and strip newlines so
+        // a hostile or buggy client can't forge log lines or DoS log volume.
+        if (s.size() > 64) s.truncate(64);
+        s.replace(QChar('\n'), QChar(' '));
+        s.replace(QChar('\r'), QChar(' '));
+        return s;
+    };
     qInfo().nospace()
-        << "McpServer: initialize — client=" << clientInfo["name"].toString()
-        << " v" << clientInfo["version"].toString()
-        << " requested=" << clientVersion
+        << "McpServer: initialize — client=" << sanitizeForLog(clientInfo["name"].toString())
+        << " v" << sanitizeForLog(clientInfo["version"].toString())
+        << " requested=" << sanitizeForLog(clientVersion)
         << " negotiated=" << negotiatedVersion
         << " session=" << (session ? session->id() : QStringLiteral("(none)"));
 
@@ -810,7 +852,7 @@ QJsonObject McpServer::handleResourcesRead(const QJsonObject& params, McpSession
         bool dispatched = m_resourceRegistry->readAsyncResource(uri, error,
             [this, socketPtr, reqId, sessId, uri, emitStructured](QJsonObject resourceData) {
                 if (!socketPtr || socketPtr->state() != QAbstractSocket::ConnectedState) {
-                    qDebug() << "McpServer: async resource response dropped (socket disconnected)";
+                    qWarning() << "McpServer: async resource response dropped (socket disconnected)";
                     return;
                 }
 
@@ -930,7 +972,12 @@ McpSession* McpServer::findOrCreateSession(const QString& sessionHeader)
     //      Use idle time as the signal: an HTTP MCP client that hasn't sent
     //      a request in OrphanIdleSeconds is presumed gone.
     QDateTime now = QDateTime::currentDateTimeUtc();
-    constexpr int OrphanIdleSeconds = 60;
+    // 5 min: well above any reasonable client keep-alive cadence (Claude Code
+    // pings far more often, mcp-remote reconnects within seconds), and well
+    // above the longest expected synchronous tool runtime, so we don't reap a
+    // session whose async tool call is still in flight. Long enough to not
+    // misfire, short enough to keep the pool from wedging at MaxSessions.
+    constexpr int OrphanIdleSeconds = 300;
     QStringList orphaned;
     for (auto it = m_sessions.constBegin(); it != m_sessions.constEnd(); ++it) {
         const auto* s = it.value();
@@ -1077,7 +1124,7 @@ void McpServer::sendAsyncToolResponse(QPointer<QTcpSocket> socket, const QVarian
                                        const QJsonObject& toolResult)
 {
     if (!socket || socket->state() != QAbstractSocket::ConnectedState) {
-        qDebug() << "McpServer: async tool response dropped (socket disconnected)";
+        qWarning() << "McpServer: async tool response dropped (socket disconnected)";
         return;
     }
 

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -632,6 +632,14 @@ QJsonObject McpServer::handleInitialize(const QJsonObject& params, McpSession* s
     if (session)
         session->setProtocolVersion(negotiatedVersion);
 
+    const QJsonObject clientInfo = params["clientInfo"].toObject();
+    qInfo().nospace()
+        << "McpServer: initialize — client=" << clientInfo["name"].toString()
+        << " v" << clientInfo["version"].toString()
+        << " requested=" << clientVersion
+        << " negotiated=" << negotiatedVersion
+        << " session=" << (session ? session->id() : QStringLiteral("(none)"));
+
     QJsonObject result;
     result["protocolVersion"] = negotiatedVersion;
     result["capabilities"] = serverCapabilities;

--- a/src/mcp/mcpserver.h
+++ b/src/mcp/mcpserver.h
@@ -35,6 +35,7 @@ struct PendingConfirmation {
     QString toolName;
     QJsonObject arguments;
     int accessLevel;
+    QString protocolVersion;  // captured at request time so the held response gates spec-versioned fields correctly
 };
 
 class McpServer : public QObject {
@@ -123,12 +124,15 @@ private:
                           const QString& sessionId = QString(),
                           const QList<QPair<QByteArray, QByteArray>>& extraHeaders = {});
 
-    // Tool result construction — emits both `content[]` text (for legacy
-    // 2025-03-26 clients) and `structuredContent` (for 2025-06-18+ clients).
-    // If the tool result carries a `_resourceLinks` array, those entries are
-    // converted into `resource_link` content blocks and stripped from
-    // `structuredContent`.
-    QJsonObject buildToolCallResponse(const QJsonObject& toolResult) const;
+    // Tool result construction. Always emits a `content[]` text block (works
+    // for every protocol version). Spec-versioned additions are gated on the
+    // negotiated protocol version: `structuredContent` and `resource_link`
+    // content blocks are 2025-06-18 features, so 2024-11-05 clients see only
+    // the text block. If the tool result carries a `_resourceLinks` array,
+    // those entries are stripped from `structuredContent` and (when the
+    // version permits) emitted as `resource_link` blocks.
+    QJsonObject buildToolCallResponse(const QJsonObject& toolResult,
+                                       const QString& protocolVersion) const;
 
     // Origin allowlist. Empty Origin header is always accepted; loopback and
     // the host's own LAN IPs (computed from QNetworkInterface at construction)
@@ -179,9 +183,12 @@ private:
     // In-app confirmation (machine_start_* tools)
     std::optional<PendingConfirmation> m_pendingConfirmation;
 
-    // Async tool response helper — sends the tool result back on the held HTTP connection
+    // Async tool response helper — sends the tool result back on the held HTTP connection.
+    // protocolVersion is captured at dispatch time so the deferred response
+    // matches the originating session's negotiated spec.
     void sendAsyncToolResponse(QPointer<QTcpSocket> socket, const QVariant& requestId,
-                               const QString& sessionId, const QJsonObject& toolResult);
+                               const QString& sessionId, const QString& protocolVersion,
+                               const QJsonObject& toolResult);
 
     // Limits
     static constexpr int MaxSessions = 8;

--- a/src/mcp/mcpserver.h
+++ b/src/mcp/mcpserver.h
@@ -35,7 +35,7 @@ struct PendingConfirmation {
     QString toolName;
     QJsonObject arguments;
     int accessLevel;
-    QString protocolVersion;  // captured at request time so the held response gates spec-versioned fields correctly
+    QString protocolVersion = QStringLiteral("2024-11-05");  // captured at request time; default to legacy gating so a missed assignment never silently emits 2025-spec fields
 };
 
 class McpServer : public QObject {
@@ -81,6 +81,9 @@ public:
     // Registries (accessible for tool/resource registration in later phases)
     McpToolRegistry* toolRegistry() const { return m_toolRegistry; }
     McpResourceRegistry* resourceRegistry() const { return m_resourceRegistry; }
+
+    // Protocol versions this server can negotiate. First entry is preferred.
+    static const QStringList& supportedProtocolVersions();
 
 signals:
     void activeSessionCountChanged();

--- a/src/mcp/mcptoolregistry.h
+++ b/src/mcp/mcptoolregistry.h
@@ -135,9 +135,16 @@ public:
     // (so the AI knows they exist) but their descriptions note the required level.
     // Access is enforced in callTool — restricted tools return an error when called.
     // 0 = Monitor (read only), 1 = Control (read + control), 2 = Full (all)
-    QJsonArray listTools(int accessLevel) const
+    //
+    // protocolVersion gates spec-versioned optional fields. Strict clients reject
+    // tools/list responses containing fields from a newer spec than was negotiated,
+    // which surfaces as the server connecting with zero tools.
+    QJsonArray listTools(int accessLevel, const QString& protocolVersion) const
     {
         static const char* levelNames[] = {"Monitor", "Control", "Full"};
+        const bool emitTitle = protocolVersion >= QStringLiteral("2025-06-18");
+        const bool emitIcons = protocolVersion >= QStringLiteral("2025-11-25");
+
         QJsonArray result;
         for (auto it = m_tools.constBegin(); it != m_tools.constEnd(); ++it) {
             const auto& tool = it.value();
@@ -145,10 +152,11 @@ public:
 
             QJsonObject toolJson;
             toolJson["name"] = tool.name;
-            // MCP 2025-06-18: human-readable display name distinct from the
-            // programmatic `name`. Auto-derived from snake_case so existing
-            // registrations get a sensible default without per-tool churn.
-            toolJson["title"] = McpRegistryHelpers::deriveTitle(tool.name);
+            if (emitTitle) {
+                // MCP 2025-06-18: human-readable display name distinct from the
+                // programmatic `name`. Auto-derived from snake_case.
+                toolJson["title"] = McpRegistryHelpers::deriveTitle(tool.name);
+            }
             if (required > accessLevel) {
                 int reqClamped = qBound(0, required, 2);
                 toolJson["description"] = QString("[DISABLED — requires '%1' access level in Settings > AI > MCP] ")
@@ -158,13 +166,15 @@ public:
             }
             toolJson["inputSchema"] = tool.inputSchema;
 
-            // MCP 2025-11-25: optional icons for client UIs. Derived from the
-            // tool's name prefix so each tool gets a category-appropriate SVG
-            // without having to thread icons through every registration site.
-            QJsonArray icons = McpRegistryHelpers::iconsArrayFromQrc(
-                McpRegistryHelpers::iconQrcForTool(tool.name));
-            if (!icons.isEmpty())
-                toolJson["icons"] = icons;
+            if (emitIcons) {
+                // MCP 2025-11-25: optional icons for client UIs. Derived from the
+                // tool's name prefix so each tool gets a category-appropriate SVG
+                // without having to thread icons through every registration site.
+                QJsonArray icons = McpRegistryHelpers::iconsArrayFromQrc(
+                    McpRegistryHelpers::iconQrcForTool(tool.name));
+                if (!icons.isEmpty())
+                    toolJson["icons"] = icons;
+            }
 
             result.append(toolJson);
         }

--- a/src/mcp/mcptoolregistry.h
+++ b/src/mcp/mcptoolregistry.h
@@ -86,7 +86,7 @@ namespace McpRegistryHelpers {
         QJsonObject icon;
         icon["src"] = uri;
         icon["mimeType"] = "image/svg+xml";
-        icon["sizes"] = "any";  // SVG scales freely
+        icon["sizes"] = QJsonArray{ QStringLiteral("any") };  // SVG scales freely; MCP schema requires string[]
         return QJsonArray{ icon };
     }
 

--- a/src/mcp/mcptoolregistry.h
+++ b/src/mcp/mcptoolregistry.h
@@ -104,6 +104,9 @@ class McpToolRegistry : public QObject {
 public:
     explicit McpToolRegistry(QObject* parent = nullptr) : QObject(parent) {}
 
+    // Tool input schemas are stored in their registered form. The 2025-11-25
+    // `$schema` dialect declaration is stamped per-request in listTools() so
+    // it can be gated on the negotiated protocol version.
     void registerTool(const QString& name, const QString& description,
                       const QJsonObject& inputSchema, McpToolHandler handler,
                       const QString& category)
@@ -111,7 +114,7 @@ public:
         McpToolDefinition tool;
         tool.name = name;
         tool.description = description;
-        tool.inputSchema = McpRegistryHelpers::withJsonSchemaDialect(inputSchema);
+        tool.inputSchema = inputSchema;
         tool.handler = handler;
         tool.category = category;
         m_tools[name] = tool;
@@ -124,7 +127,7 @@ public:
         McpToolDefinition tool;
         tool.name = name;
         tool.description = description;
-        tool.inputSchema = McpRegistryHelpers::withJsonSchemaDialect(inputSchema);
+        tool.inputSchema = inputSchema;
         tool.asyncHandler = handler;
         tool.isAsync = true;
         tool.category = category;
@@ -144,6 +147,7 @@ public:
         static const char* levelNames[] = {"Monitor", "Control", "Full"};
         const bool emitTitle = protocolVersion >= QStringLiteral("2025-06-18");
         const bool emitIcons = protocolVersion >= QStringLiteral("2025-11-25");
+        const bool emitSchemaDialect = protocolVersion >= QStringLiteral("2025-11-25");
 
         QJsonArray result;
         for (auto it = m_tools.constBegin(); it != m_tools.constEnd(); ++it) {
@@ -164,7 +168,9 @@ public:
             } else {
                 toolJson["description"] = tool.description;
             }
-            toolJson["inputSchema"] = tool.inputSchema;
+            toolJson["inputSchema"] = emitSchemaDialect
+                ? McpRegistryHelpers::withJsonSchemaDialect(tool.inputSchema)
+                : tool.inputSchema;
 
             if (emitIcons) {
                 // MCP 2025-11-25: optional icons for client UIs. Derived from the

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -1568,7 +1568,9 @@ btn.textContent='Copied!';setTimeout(function(){btn.textContent='Copy'},2000);
 </body></html>)HTML");
 
             bool mcpOn = m_settings && m_settings->mcp()->mcpEnabled();
-            qsizetype toolCount = m_mcpServer ? m_mcpServer->toolRegistry()->listTools(2).size() : 0;
+            qsizetype toolCount = m_mcpServer
+                ? m_mcpServer->toolRegistry()->listTools(2, QStringLiteral("2025-11-25")).size()
+                : 0;
 
             html = html.arg(mcpOn ? "enabled" : "disabled",
                            mcpOn ? "Enabled" : "Disabled",

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -449,6 +449,16 @@ private slots:
         QCOMPARE(firstLink["uri"].toString(), QString("decenza://shots/42"));
         QCOMPARE(firstLink["title"].toString(), QString("Shot #42"));
         QCOMPARE(firstLink["mimeType"].toString(), QString("application/json"));
+        // MCP 2025-06-18: `name` is REQUIRED on resource_link blocks. Strict
+        // clients drop the entire content[] entry when it's missing. When the
+        // emitter doesn't provide one, the wrapper derives it from the uri's
+        // last path segment ("42" for decenza://shots/42).
+        QVERIFY2(firstLink.contains("name"),
+                 "resource_link blocks must always include `name` (MCP 2025-06-18)");
+        QCOMPARE(firstLink["name"].toString(), QString("42"));
+        // The second link similarly derives its name from the path segment.
+        const QJsonObject secondLink = content[1].toObject();
+        QCOMPARE(secondLink["name"].toString(), QString("foo"));
 
         // structuredContent must NOT carry the side-channel field — it's
         // consumed by the wrapper and stripped from the structured payload.

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -450,6 +450,129 @@ private slots:
         QVERIFY(structured.contains("items"));
     }
 
+    // ─── Spec-version gating: 2024-11-05 clients see only legacy fields ───
+    //
+    // Strict 2024-11-05 validators reject responses carrying fields introduced
+    // in newer specs. The server must omit those fields when the negotiated
+    // protocol version pre-dates their introduction. Each test below pins the
+    // exact field contract for the legacy version so a future spec bump can't
+    // silently re-leak a newer field.
+
+    void toolsListAt2024_11_05OmitsNewerSpecFields()
+    {
+        McpServer server;
+        server.toolRegistry()->registerTool(
+            "shots_get_detail",
+            "Test tool",
+            QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
+            [](const QJsonObject&) -> QJsonObject { return QJsonObject{}; },
+            "read");
+
+        const QString sid = openSession(server, "2024-11-05");
+        auto resp = sendHttp(server, "POST", rpcBody("tools/list", {}, 2), sid);
+        QCOMPARE(resp.statusCode, 200);
+
+        const QJsonArray tools = resp.jsonBody["result"].toObject()["tools"].toArray();
+        QCOMPARE(tools.size(), 1);
+        const QJsonObject t = tools[0].toObject();
+
+        // 2025-06-18 fields must NOT appear.
+        QVERIFY2(!t.contains("title"), "tools/list at 2024-11-05 must omit title");
+        // 2025-11-25 fields must NOT appear.
+        QVERIFY2(!t.contains("icons"), "tools/list at 2024-11-05 must omit icons");
+        QVERIFY2(!t["inputSchema"].toObject().contains("$schema"),
+                 "tools/list at 2024-11-05 must omit $schema dialect");
+
+        // Universal fields must still be present.
+        QCOMPARE(t["name"].toString(), QString("shots_get_detail"));
+        QVERIFY(t.contains("description"));
+        QVERIFY(t["inputSchema"].toObject().contains("type"));
+    }
+
+    void resourcesListAt2024_11_05OmitsNewerSpecFields()
+    {
+        McpServer server;
+        server.resourceRegistry()->registerResource(
+            "decenza://shots/42", "Shot 42", "A test shot", "application/json",
+            []() -> QJsonObject { return QJsonObject{{"id", 42}}; });
+
+        const QString sid = openSession(server, "2024-11-05");
+        auto resp = sendHttp(server, "POST", rpcBody("resources/list", {}, 2), sid);
+        QCOMPARE(resp.statusCode, 200);
+
+        const QJsonArray resources = resp.jsonBody["result"].toObject()["resources"].toArray();
+        QCOMPARE(resources.size(), 1);
+        const QJsonObject r = resources[0].toObject();
+
+        QVERIFY2(!r.contains("title"), "resources/list at 2024-11-05 must omit title");
+        QVERIFY2(!r.contains("icons"), "resources/list at 2024-11-05 must omit icons");
+        QCOMPARE(r["name"].toString(), QString("Shot 42"));
+        QCOMPARE(r["uri"].toString(), QString("decenza://shots/42"));
+    }
+
+    void toolsCallAt2024_11_05OmitsStructuredContentAndResourceLinks()
+    {
+        McpServer server;
+        server.toolRegistry()->registerTool(
+            "stub_listy_tool",
+            "Returns _resourceLinks side-channel",
+            QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
+            [](const QJsonObject&) -> QJsonObject {
+                QJsonObject link{{"uri", "decenza://shots/42"}, {"title", "#42"}};
+                return QJsonObject{{"items", QJsonArray{42}},
+                                   {"_resourceLinks", QJsonArray{link}}};
+            },
+            "read");
+
+        const QString sid = openSession(server, "2024-11-05");
+        QJsonObject params;
+        params["name"] = "stub_listy_tool";
+        params["arguments"] = QJsonObject{};
+        auto resp = sendHttp(server, "POST", rpcBody("tools/call", params, 2), sid);
+        QCOMPARE(resp.statusCode, 200);
+
+        const QJsonObject result = resp.jsonBody["result"].toObject();
+
+        // 2025-06-18 fields must NOT appear at 2024-11-05.
+        QVERIFY2(!result.contains("structuredContent"),
+                 "tools/call at 2024-11-05 must omit structuredContent");
+
+        // content[] must still carry the text block, but no resource_link blocks.
+        const QJsonArray content = result["content"].toArray();
+        QVERIFY2(!content.isEmpty(), "content[] must always be present");
+        bool hasText = false;
+        for (const QJsonValue& v : content) {
+            const QString type = v.toObject()["type"].toString();
+            QVERIFY2(type != "resource_link",
+                     "tools/call at 2024-11-05 must not emit resource_link blocks");
+            if (type == "text") hasText = true;
+        }
+        QVERIFY(hasText);
+    }
+
+    void resourcesReadAt2024_11_05OmitsStructuredContent()
+    {
+        McpServer server;
+        server.resourceRegistry()->registerResource(
+            "decenza://shots/42", "Shot 42", "A test shot", "application/json",
+            []() -> QJsonObject { return QJsonObject{{"id", 42}, {"label", "ok"}}; });
+
+        const QString sid = openSession(server, "2024-11-05");
+        QJsonObject params;
+        params["uri"] = "decenza://shots/42";
+        auto resp = sendHttp(server, "POST", rpcBody("resources/read", params, 2), sid);
+        QCOMPARE(resp.statusCode, 200);
+
+        const QJsonArray contents = resp.jsonBody["result"].toObject()["contents"].toArray();
+        QCOMPARE(contents.size(), 1);
+        const QJsonObject content = contents[0].toObject();
+
+        QVERIFY2(!content.contains("structuredContent"),
+                 "resources/read at 2024-11-05 must omit structuredContent");
+        QVERIFY(content.contains("text"));
+        QCOMPARE(content["uri"].toString(), QString("decenza://shots/42"));
+    }
+
     // ─── Pure helpers ──────────────────────────────────────────────────────
 
     void deriveTitleProducesTitleCaseFromSnakeCase()

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -355,6 +355,14 @@ private slots:
         const QJsonObject icon = icons[0].toObject();
         QCOMPARE(icon["mimeType"].toString(), QString("image/svg+xml"));
         QVERIFY(icon["src"].toString().startsWith("data:image/svg+xml;base64,"));
+        // MCP icon schema (HTML-style): `sizes` must be string[], not a bare
+        // string. Strict clients (e.g. Claude Code's zod validator) drop every
+        // tool entry that ships `"sizes":"any"`, surfacing zero tools despite
+        // a successful initialize handshake.
+        const QJsonValue sizes = icon["sizes"];
+        QVERIFY2(sizes.isArray(), "icon.sizes must be an array (string[])");
+        QVERIFY(!sizes.toArray().isEmpty());
+        QVERIFY(sizes.toArray()[0].isString());
 
         // 2025-11-25: JSON Schema 2020-12 dialect declared.
         QCOMPARE(t["inputSchema"].toObject()["$schema"].toString(),

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -568,6 +568,75 @@ private slots:
         QVERIFY(hasText);
     }
 
+    // Symmetric presence at 2025-06-18: structuredContent and resource_link
+    // were introduced in this revision. If the threshold ever drifts up to
+    // 2025-11-25 (e.g. someone "matches the icons gate"), 2025-06-18 clients
+    // would silently lose both. This test pins them at exactly 2025-06-18.
+    void toolsCallAt2025_06_18EmitsStructuredContentAndResourceLinks()
+    {
+        McpServer server;
+        server.toolRegistry()->registerTool(
+            "stub_listy_tool",
+            "Returns _resourceLinks side-channel",
+            QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
+            [](const QJsonObject&) -> QJsonObject {
+                QJsonObject link{{"uri", "decenza://shots/42"}, {"title", "#42"}};
+                return QJsonObject{{"items", QJsonArray{42}},
+                                   {"_resourceLinks", QJsonArray{link}}};
+            },
+            "read");
+
+        const QString sid = openSession(server, "2025-06-18");
+        QJsonObject params;
+        params["name"] = "stub_listy_tool";
+        params["arguments"] = QJsonObject{};
+        auto resp = sendHttp(server, "POST", rpcBody("tools/call", params, 2), sid);
+        QCOMPARE(resp.statusCode, 200);
+
+        const QJsonObject result = resp.jsonBody["result"].toObject();
+        QVERIFY2(result.contains("structuredContent"),
+                 "tools/call at 2025-06-18 must emit structuredContent");
+        const QJsonArray content = result["content"].toArray();
+        bool hasResourceLink = false;
+        for (const QJsonValue& v : content)
+            if (v.toObject()["type"].toString() == "resource_link") { hasResourceLink = true; break; }
+        QVERIFY2(hasResourceLink,
+                 "tools/call at 2025-06-18 must emit resource_link blocks");
+    }
+
+    // Mirror toolsListIncludesTitleAndIcons for resources/list. Without a
+    // 2025-11-25 presence test on the resource side, a regression that re-
+    // introduced `"sizes":"any"` (bare string) on resource icons would be
+    // invisible to CI even though it would zero-out resources for strict
+    // clients exactly the way the tools-side bug did.
+    void resourcesListAt2025_11_25EmitsTitleAndIcons()
+    {
+        McpServer server;
+        server.resourceRegistry()->registerResource(
+            "decenza://shots/recent", "Recent Shots", "Test resource",
+            "application/json", []() -> QJsonObject { return QJsonObject{}; });
+
+        const QString sid = openSession(server, "2025-11-25");
+        auto resp = sendHttp(server, "POST", rpcBody("resources/list", {}, 2), sid);
+        QCOMPARE(resp.statusCode, 200);
+
+        const QJsonArray resources = resp.jsonBody["result"].toObject()["resources"].toArray();
+        QCOMPARE(resources.size(), 1);
+        const QJsonObject r = resources[0].toObject();
+
+        QVERIFY2(r.contains("title"),
+                 "resources/list at 2025-06-18+ must include title");
+        const QJsonArray icons = r["icons"].toArray();
+        QVERIFY2(!icons.isEmpty(),
+                 "resources/list at 2025-11-25 must include at least one icon");
+        const QJsonObject icon = icons[0].toObject();
+        // Same icon.sizes shape pin as the tools-side test.
+        const QJsonValue sizes = icon["sizes"];
+        QVERIFY2(sizes.isArray(), "resource icon.sizes must be an array (string[])");
+        QVERIFY(!sizes.toArray().isEmpty());
+        QVERIFY(sizes.toArray()[0].isString());
+    }
+
     void resourcesReadAt2024_11_05OmitsStructuredContent()
     {
         McpServer server;


### PR DESCRIPTION
## Summary
Closes the entire #953 spec-version blast radius and a related HTTP-session leak that was wedging the session pool.

### Spec-version gating
`McpToolRegistry::listTools()` and four other surfaces unconditionally emitted spec-versioned fields, so strict 2024-11-05 validators (Claude Code) rejected the responses and surfaced zero tools.

| Surface | Field | Spec | Status |
|---|---|---|---|
| `tools/list` | `title` | 2025-06-18 | gated on `>= 2025-06-18` |
| `tools/list` | `icons` | 2025-11-25 | gated on `>= 2025-11-25` |
| `tools/list` | `inputSchema.$schema` | 2025-11-25 | moved from registration to `listTools()`, gated on `>= 2025-11-25` |
| `resources/list` | `title` | 2025-06-18 | gated on `>= 2025-06-18` |
| `resources/list` | `icons` | 2025-11-25 | gated on `>= 2025-11-25` |
| `tools/call` | `structuredContent` | 2025-06-18 | gated on `>= 2025-06-18` |
| `tools/call` | `resource_link` content blocks | 2025-06-18 | gated on `>= 2025-06-18` |
| `resources/read` | `structuredContent` | 2025-06-18 | gated on `>= 2025-06-18` |

Deferred response paths (chat confirmation, in-app confirmation, async tool dispatch, async resource read) capture the negotiated protocol version at request time so held responses honour the originating session's spec even after the session pointer may have changed.

### Session leak (HTTP transport)
`findOrCreateSession()` previously only purged sessions that had established *and lost* an SSE socket. Pure-HTTP transports (Claude Code's `"type": "http"`) never establish SSE, so each reconnect leaked a slot until the 30-min idle timeout, wedging the pool at `MaxSessions=8` with `Too many sessions` errors. Now also reaps non-SSE sessions whose `lastActivity` is older than 60s — matching the equivalent SSE-loss heuristic without double-tapping live clients.

### Regression introduced by
#953 ("Adopt MCP spec 2025-11-25") — added every field above without conditional emission.

## Test plan
- [x] Qt Creator build succeeds with 0 errors / 0 warnings
- [x] All 27 `tst_McpServerProtocol` tests pass (including 4 new pinning tests for 2024-11-05 contract)
- [x] `curl localhost:8888/mcp` with `protocolVersion: "2024-11-05"` returns tools with only `name`/`description`/`inputSchema` (no `title`, no `icons`, no `$schema`)
- [x] Same probe with `protocolVersion: "2025-11-25"` returns all fields
- [ ] After merge + rebuild + Claude Code restart, `mcp__decenza__*` tools surface in Claude Code's deferred-tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)