### PR TITLE
docs(claude-md): split CLAUDE.md into focused reference docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,23 +137,27 @@ Detailed documentation lives in `docs/CLAUDE_MD/`. Read these when working in th
 
 | Document | When to read |
 |----------|-------------|
+| `PROJECT_STRUCTURE.md` | Map of `src/`, `qml/`, `resources/`, signal/slot flow, profile pipeline |
 | `CI_CD.md` | Release process, GitHub Actions workflows, version bumping |
-| `RECIPE_PROFILES.md` | Recipe Editor, D-Flow/A-Flow/Pressure/Flow types, frame generation |
+| `PLATFORM_BUILD.md` | CLI build commands (Windows/macOS/iOS), Windows installer, Android signing, tablet quirks |
+| `RECIPE_PROFILES.md` | Recipe Editor, D-Flow/A-Flow/Pressure/Flow types, frame generation, JSON format, stop limits, profile_sync tool |
 | `TESTING.md` | Test framework, mock strategy, adding new tests, **`shot_eval` harness + regression corpus** |
 | `BLE_PROTOCOL.md` | BLE UUIDs, retry mechanism, shot debug logging, battery/steam control |
 | `VISUALIZER.md` | DYE metadata, profile import/export, ProfileSaveHelper, filename generation |
 | `DATA_MIGRATION.md` | Device-to-device transfer architecture and REST endpoints |
-| `PLATFORM_BUILD.md` | Windows installer, Android signing, Decent tablet quirks |
-| `STEAM_CALIBRATION.md` | Postmortem on the removed steam calibration feature — why it didn't work, what held up, future directions |
+| `STEAM_CALIBRATION.md` | Postmortem on the removed steam calibration feature |
 | `CUP_FILL_VIEW.md` | CupFillView layer stack, GPU shaders, updating cup images |
 | `EMOJI_SYSTEM.md` | Twemoji SVG rendering, adding/switching emoji sets |
 | `ACCESSIBILITY.md` | TalkBack/VoiceOver rules, focus order, anti-patterns, implementation plan |
 | `AUTO_FLOW_CALIBRATION.md` | Auto flow calibration algorithm, batched median updates, windowing, convergence |
-| `SAW_LEARNING.md` | Per-(profile, scale) stop-at-weight learning — analysis, batched median commits, IQR dispersion rejection, global bootstrap |
-| `FIRMWARE_UPDATE.md` | DE1 firmware update flow, source URL, validation rules, failure modes, simulator behaviour |
+| `SAW_LEARNING.md` | Per-(profile, scale) stop-at-weight learning |
+| `FIRMWARE_UPDATE.md` | DE1 firmware update flow, source URL, validation rules, failure modes |
 | `MCP_SERVER.md` | Full MCP tool list, access levels, architecture, data conventions |
 | `AI_ADVISOR.md` | AI dialing assistant design |
 | `SETTINGS.md` | Settings architecture: 7 domain sub-objects, how to add properties/domains, QML access pattern, build-blast rules |
+| `QML_GOTCHAS.md` | QML bug-prone patterns with code samples (font conflict, reserved names, IME drop, etc.) |
+| `QML_NAVIGATION.md` | StackView page navigation, phase-change handler, operation-page conventions |
+| `SHOTSERVER.md` | ShotServer file split, async community endpoints, JS `fetch()` rules |
 
 Read [`docs/SHOT_REVIEW.md`](https://github.com/Kulitorum/Decenza/blob/main/docs/SHOT_REVIEW.md) when working on the post-shot review / shot detail pages, the five quality-badge detectors (pour truncated, channeling, grind issue, temperature unstable, skip-first-frame), the Shot Summary dialog, badge persistence, or `src/ai/shotanalysis.{h,cpp}`. It is the source of truth for detector internals, gate semantics, and the recompute-on-load contract; keep it in sync when changing any of the above.
 
@@ -168,245 +172,13 @@ Read [`docs/SHOT_REVIEW.md`](https://github.com/Kulitorum/Decenza/blob/main/docs
 - **de1app source**: `C:\code\de1app` (Windows) or `/Users/jeffreyh/Development/GitHub/de1app` (macOS) — original Tcl/Tk DE1 app for reference
 - **IMPORTANT**: Use relative paths (e.g., `src/main.cpp`) instead of absolute paths (e.g., `C:\CODE\de1-qt\src\main.cpp`) to avoid "Error: UNKNOWN: unknown error, open" when editing files
 
-## Command Line Build (for Claude sessions)
+## Building
 
-**IMPORTANT**: Don't build automatically - let the user build in Qt Creator, which is ~50x faster than command-line builds. Only use these commands if the user explicitly asks for a CLI build.
-
-MSVC environment variables (INCLUDE, LIB) are set permanently. Use Visual Studio generator (Ninja not in PATH).
-
-**Configure Release:**
-```bash
-rm -rf build/Release && mkdir -p build/Release && cd build/Release && cmake ../.. -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="C:/Qt/6.10.3/msvc2022_64"
-```
-
-**Build Release (parallel):**
-```bash
-cd build/Release && unset CMAKE_BUILD_PARALLEL_LEVEL && MSYS_NO_PATHCONV=1 cmake --build . --config Release -- /m
-```
-
-**Configure Debug:**
-```bash
-rm -rf build/Debug && mkdir -p build/Debug && cd build/Debug && cmake ../.. -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="C:/Qt/6.10.3/msvc2022_64" -DCMAKE_BUILD_TYPE=Debug
-```
-
-**Build Debug (parallel):**
-```bash
-cd build/Debug && unset CMAKE_BUILD_PARALLEL_LEVEL && MSYS_NO_PATHCONV=1 cmake --build . --config Debug -- /m
-```
-
-Note: `unset CMAKE_BUILD_PARALLEL_LEVEL` avoids conflicts with `/m`. `MSYS_NO_PATHCONV=1` prevents bash from converting `/m` to `M:/`. The `/m` flag enables MSBuild parallel compilation.
-
-**Output locations:**
-- Release: `build/Release/Release/Decenza.exe`
-- Debug: `build/Debug/Debug/Decenza.exe`
-
-## macOS/iOS Build (on Mac)
-
-Use Qt's `qt-cmake` wrapper which handles cross-compilation correctly.
-
-**Finding Qt paths:** Qt is installed at `~/Qt/`. Discover paths dynamically:
-```bash
-# Find qt-cmake for macOS
-find ~/Qt -name "qt-cmake" -path "*/macos/*"
-# Find Ninja (bundled with Qt)
-find ~/Qt/Tools -name "ninja"
-```
-
-**Configure iOS (generates Xcode project):**
-```bash
-rm -rf build/Qt_6_10_3_for_iOS && mkdir -p build/Qt_6_10_3_for_iOS && cd build/Qt_6_10_3_for_iOS && /Users/mic/Qt/6.10.3/ios/bin/qt-cmake ../.. -G Xcode
-```
-
-**Configure macOS (generates Xcode project):**
-```bash
-rm -rf build/Qt_6_10_3_for_macOS && mkdir -p build/Qt_6_10_3_for_macOS && cd build/Qt_6_10_3_for_macOS && /Users/mic/Qt/6.10.3/macos/bin/qt-cmake ../.. -G Xcode
-```
-
-**Open in Xcode:**
-```bash
-open build/Qt_6_10_3_for_iOS/Decenza.xcodeproj
-# or
-open build/Qt_6_10_3_for_macOS/Decenza.xcodeproj
-```
-
-Then in Xcode: Product → Archive for App Store submission.
-
-## CI/CD (GitHub Actions)
-
-See `docs/CLAUDE_MD/CI_CD.md` for workflows, secrets, quick commands, and platform notes.
+**Don't build automatically** — let the user build in Qt Creator (~50× faster than CLI). Only run CLI builds when the user explicitly asks. CLI commands for Windows/macOS/iOS live in `docs/CLAUDE_MD/PLATFORM_BUILD.md`.
 
 ## Project Structure
 
-```
-src/
-├── ai/                     # AI assistant integration
-│   ├── aimanager.*         # Provider config, test connection, conversation lifecycle
-│   ├── aiprovider.*        # HTTP calls to OpenAI/Anthropic/Ollama/OpenRouter
-│   ├── aiconversation.*    # Multi-turn conversation state + history persistence
-│   ├── shotanalysis.*      # Shot analysis prompts and structured response parsing
-│   └── shotsummarizer.*    # Summarise shot data into AI-readable text
-├── ble/                    # Bluetooth LE layer
-│   ├── de1device.*         # DE1 machine protocol
-│   ├── blemanager.*        # Device discovery
-│   ├── scaledevice.*       # Abstract scale interface
-│   ├── protocol/           # BLE UUIDs, binary codec
-│   ├── scales/             # Scale implementations (13 types)
-│   └── transport/          # BLE transport abstraction
-├── controllers/
-│   ├── maincontroller.*    # App logic, profiles, shot processing
-│   ├── directcontroller.*  # Direct frame control mode
-│   ├── profilemanager.*    # Profile CRUD, activation, built-in management
-│   └── shottimingcontroller.* # Shot timing, tare management, weight processing
-├── core/
-│   ├── settings.*          # QSettings persistence
-│   ├── batterymanager.*    # Smart charging control
-│   ├── accessibilitymanager.* # TTS announcements, tick sounds, a11y settings
-│   ├── asynclogger.*       # Background-thread file logger
-│   ├── autowakemanager.*   # Scheduled DE1 auto-wake (time-based)
-│   ├── crashhandler.*      # Signal handler → writes crash log on crash
-│   ├── databasebackupmanager.* # Daily automatic backup of shots/settings/profiles
-│   ├── datamigrationclient.*   # Device-to-device data transfer (REST client)
-│   ├── dbutils.h           # withTempDb() helper for background-thread DB connections
-│   ├── documentformatter.* # Formats shot/profile data as Markdown for AI context
-│   ├── grinderaliases.h    # Grinder brand/model normalisation table
-│   ├── memorymonitor.*     # RSS/heap tracking, low-memory warnings
-│   ├── profilestorage.*    # Low-level profile file I/O (JSON read/write, enumeration)
-│   ├── settingsserializer.* # Export/import settings as JSON
-│   ├── translationmanager.* # Runtime i18n — loads locale JSON, exposes translate()
-│   ├── updatechecker.*     # GitHub Releases polling for app updates
-│   └── widgetlibrary.*     # Local library for layout items, zones, layouts, themes
-├── history/                # Shot history storage and queries
-│   ├── shothistorystorage.* # SQLite CRUD, background-thread query helpers
-│   ├── shotimporter.*      # Import shots from JSON files / migration
-│   ├── shotdebuglogger.*   # Per-shot BLE frame debug log writer
-│   └── shotfileparser.*    # Parse legacy shot file formats
-├── machine/
-│   ├── machinestate.*      # Phase tracking, stop-at-weight, stop-at-volume
-│   ├── steamcalibrator.*   # Steam flow calibration procedure
-│   ├── steamhealthtracker.* # Tracks steam health metrics over time
-│   └── weightprocessor.*   # Centralised weight filtering and smoothing
-├── mcp/                    # Model Context Protocol server (AI agent tools)
-│   ├── mcpserver.*         # WebSocket server, session management
-│   ├── mcpsession.h        # Per-connection session state
-│   ├── mcptoolregistry.h   # Tool registration and dispatch
-│   ├── mcpresourceregistry.h # Resource registration
-│   ├── mcptools_shots.*    # Shot history tools
-│   ├── mcptools_profiles.* # Profile read/write tools
-│   ├── mcptools_machine.*  # Machine state tools
-│   ├── mcptools_control.*  # Shot control tools
-│   ├── mcptools_devices.*  # BLE device tools
-│   ├── mcptools_scale.*    # Scale tools
-│   ├── mcptools_settings.* # Settings tools
-│   ├── mcptools_dialing.*  # Dialing assistant tools
-│   ├── mcptools_write.*    # Write/update tools
-│   └── mcptools_agent.*    # Agent coordination tools
-├── models/
-│   ├── shotdatamodel.*     # Shot data for graphing (live + history)
-│   ├── shotcomparisonmodel.* # Side-by-side shot comparison data
-│   ├── flowcalibrationmodel.* # Flow calibration data model
-│   └── steamdatamodel.*    # Steam session data for graphing
-├── network/
-│   ├── shotserver.cpp      # HTTP server core + route dispatch
-│   ├── shotserver_backup.cpp   # Backup/restore endpoints
-│   ├── shotserver_layout.cpp   # Layout editor web UI
-│   ├── shotserver_shots.cpp    # Shot history endpoints
-│   ├── shotserver_settings.cpp # Settings endpoints
-│   ├── shotserver_ai.cpp       # AI assistant endpoints
-│   ├── shotserver_auth.cpp     # Authentication
-│   ├── shotserver_theme.cpp    # Theme endpoints
-│   ├── shotserver_upload.cpp   # File upload handling
-│   ├── visualizeruploader.*    # Upload shots to visualizer.coffee
-│   ├── visualizerimporter.*    # Import profiles from visualizer.coffee
-│   ├── librarysharing.*    # Community profile library (browse/download/upload)
-│   ├── mqttclient.*        # MQTT connectivity for remote monitoring
-│   ├── relayclient.*       # WebSocket relay for remote DE1 control
-│   ├── crashreporter.*     # Crash report submission to backend
-│   ├── shotreporter.*      # Automatic shot reporting / webhooks
-│   ├── locationprovider.*  # City + coordinates for shot metadata
-│   ├── screencaptureservice.* # Screenshot capture for sharing
-│   └── webdebuglogger.*    # Web-accessible debug log endpoint
-├── profile/
-│   ├── profile.*           # Profile container, JSON/TCL formats
-│   ├── profileframe.*      # Single extraction step
-│   ├── profilesavehelper.* # Shared save/compare/deduplicate logic for importers
-│   ├── profileconverter.*  # Convert between profile formats
-│   ├── profileimporter.*   # Import profiles from files / visualizer
-│   ├── recipeanalyzer.*    # Extract RecipeParams from frame-based profiles
-│   ├── recipegenerator.*   # Generate frame profiles from RecipeParams
-│   └── recipeparams.*      # Typed recipe parameter container
-├── rendering/              # Custom rendering (shot graphs, etc.)
-├── screensaver/            # Screensaver implementation
-├── simulator/              # DE1 machine simulator
-├── usb/                    # USB scale connectivity (Decent USB scale, serial)
-├── weather/                # Weather data for shot metadata
-└── main.cpp                # Entry point, object wiring
-
-qml/
-├── pages/                  # Full-screen pages (EspressoPage, ShotDetailPage, etc.)
-│   └── settings/           # Settings tab pages
-├── components/             # Reusable components (ShotGraph, StatusBar, etc.)
-├── simulator/              # Simulator UI (GHCSimulatorWindow)
-└── Theme.qml               # Singleton styling (+ emojiToImage())
-
-resources/
-├── CoffeeCup/              # 3D-rendered cup images for CupFillView
-│   ├── BackGround.png      # Cup back, interior, handle (701x432)
-│   ├── Mask.png            # Black = coffee area, white = no coffee
-│   ├── Overlay.png         # Rim, front highlights (lighten blend)
-│   └── FullRes.7z          # Source PSD archive
-├── emoji/                  # ~750 Twemoji SVGs (CC-BY 4.0)
-├── emoji.qrc               # Qt resource file for emoji SVGs
-└── resources.qrc           # Icons, fonts, other assets
-
-shaders/
-├── crt.frag                # CRT/retro display effect
-├── cup_mask.frag           # Masks coffee to cup interior (inverts Mask.png)
-└── cup_lighten.frag        # Lighten (MAX) blend + brightness-to-alpha
-
-scripts/
-└── download_emoji.py       # Download emoji SVGs from various sources
-```
-
-## Key Architecture
-
-### Signal/Slot Flow
-```
-DE1Device (BLE) → signals → MainController → ShotDataModel → QML graphs
-                          → ShotTimingController (timing, tare, weight)
-ScaleDevice     → signals → MachineState (stop-at-weight)
-                          → MainController (graph data)
-MachineState    → signals → MainController → QML page navigation
-AIManager       → signals → QML AI panels (conversation responses)
-MqttClient      → signals → MainController (remote monitoring)
-RelayClient     ←→ DE1Device (remote control over WebSocket relay)
-MCPServer       → tool calls → MainController / ProfileManager / ShotHistoryStorage
-```
-
-### Scale System
-- **ScaleDevice**: Abstract base class
-- **FlowScale**: Virtual scale from DE1 flow data (fallback when no physical scale)
-- **Physical scales**: DecentScale, AcaiaScale, FelicitaScale, etc. (factory pattern)
-
-### Machine Phases
-```
-Disconnected → Sleep → Idle → Heating → Ready
-Ready → EspressoPreheating → Preinfusion → Pouring → Ending
-Also: Steaming, HotWater, Flushing, Refill, Descaling, Cleaning
-```
-
-### AI & MCP
-- **AIManager**: Manages provider config and conversation lifecycle; exposes `conversation` to QML
-- **AIConversation**: Multi-turn conversation with history; used by AI panels across the app
-- **MCPServer**: WebSocket server exposing machine control and data as MCP tools for external AI agents
-- **ShotAnalysis / ShotSummarizer**: Format shot data as text context for AI prompts
-
-### Profile Pipeline
-```
-TCL/JSON file → ProfileImporter → ProfileConverter → Profile (in memory)
-RecipeParams  → RecipeGenerator → Profile frames → DE1 upload
-Profile frames ← RecipeAnalyzer ← existing frame-based profile (reverse)
-ProfileManager: CRUD, activation, built-in management, ProfileStorage I/O
-```
+See `docs/CLAUDE_MD/PROJECT_STRUCTURE.md` for the full source tree, signal/slot flow, scale system, machine phases, AI/MCP overview, and profile pipeline. Top-level: `src/` (C++), `qml/` (UI), `resources/`, `shaders/`, `tests/`, `docs/`, `openspec/`, `android/`, `installer/`.
 
 ## Conventions
 
@@ -416,10 +188,7 @@ ProfileManager: CRUD, activation, built-in management, ProfileStorage I/O
 - **Settings go in their domain sub-object, not on `Settings` directly.** `Settings` is a façade that owns 7 domain classes (`SettingsMqtt`, `SettingsTheme`, etc.). Add new properties to the matching `Settings<Domain>` class, or create a new sub-object if none fits. Never add a property back to `Settings` itself, and never `#include "settings_<domain>.h"` in `settings.h` — both undo the recompile-blast win the split was built for. New sub-objects also require `qmlRegisterUncreatableType<Settings<Domain>>(...)` in `main.cpp` or QML resolves `Settings.<domain>.<prop>` to `undefined` at runtime. QML access is **always** `Settings.<domain>.<prop>`, never the flat `Settings.<prop>`. See `docs/CLAUDE_MD/SETTINGS.md` for the full checklist.
 
 ### C++
-- Classes: `PascalCase`
-- Methods/variables: `camelCase`
-- Members: `m_` prefix
-- Slots: `onEventName()`
+- Classes: `PascalCase`; methods/variables: `camelCase`; members: `m_` prefix; slots: `onEventName()`
 - Use `Q_PROPERTY` with `NOTIFY` for bindable properties
 - Use `qsizetype` (not `int`) for container sizes — `QVector::size()`, `QList::size()`, `QString::size()` etc. return `qsizetype` (64-bit on iOS/macOS). Assigning to `int` causes `-Wshorten-64-to-32` warnings.
 
@@ -431,97 +200,20 @@ ProfileManager: CRUD, activation, built-in management, ProfileStorage I/O
 - All user-visible text must be internationalized. Use `TranslationManager.translate("section.key", "Fallback text")` for property bindings and inline expressions. Use the `Tr` component for standalone visible text (`Tr { key: "section.name"; fallback: "English text" }`). For text used in properties via `Tr`, use a hidden instance: `Tr { id: trMyLabel; key: "my.key"; fallback: "Label"; visible: false }` then `text: trMyLabel.text`. Reuse existing keys like `common.button.ok` and `common.accessibility.dismissDialog` where applicable.
 - Use `StyledTextField` instead of `TextField` to avoid Material floating label
 - `ActionButton` dims icon (50% opacity) and text (secondary color) when disabled
-- `native` is a reserved JavaScript keyword - use `nativeName` instead
-- **Never use Unicode symbols as icons in text** (e.g., `"\u270E"`, `"\u2717"`, `"\u2630"`). These render as tofu squares on devices without the right font glyphs. Use SVG icons from `qrc:/icons/` with `Image` instead. For buttons/menu items, use a `Row { Image {} Text {} }` contentItem. Safe Unicode characters (°, ·, —, →, ×) that are in standard fonts are OK.
-- **Never override FINAL properties on Qt types.** Qt 6.10+ marks some `Popup`/`Dialog` properties as FINAL (e.g., `message`, `title`). Declaring `property string message` on a Dialog will prevent the component from loading. Use a different name (e.g., `resultMessage`), or use the inherited property directly if it already exists on the base type.
-- **Use `??` not `||` for numeric defaults where 0 is valid.** JavaScript `||` treats `0` as falsy, so `value || 0.6` returns `0.6` when `value` is `0`. Use `value ?? 0.6` (nullish coalescing) which only falls back for `null`/`undefined`. Only use `||` when `0` genuinely means "no data" (e.g., unrated enjoyment, unmeasured TDS).
 
-### QML Gotchas
+### QML Gotchas (one-liners — full samples in `docs/CLAUDE_MD/QML_GOTCHAS.md`)
 
-**Font property conflict**: Cannot use `font: Theme.bodyFont` and then override sub-properties like `font.bold: true`. QML treats this as assigning the property twice.
-```qml
-// BAD - causes "Property has already been assigned a value" error
-Text {
-    font: Theme.bodyFont
-    font.bold: true  // Error!
-}
+- **Font property conflict**: don't mix `font: Theme.bodyFont` with `font.bold: true` — assign sub-properties individually.
+- **Reserved names in JS model data**: `name`, `parent`, `children`, `data`, `state`, `enabled`, `visible`, `width`, `height`, `x`, `y`, `z`, `focus`, `clip` collide with QML properties — use `label` etc.
+- **IME last-word drop**: call `Qt.inputMethod.commit()` before reading any `TextField.text` from a button handler — otherwise the in-progress word is lost on mobile.
+- **Keyboard handling**: wrap pages with text inputs in `KeyboardAwareContainer { textFields: [...] }`.
+- **FINAL Qt properties**: don't redeclare `message`/`title` etc. on `Popup`/`Dialog` (Qt 6.10+) — pick a different name like `resultMessage`.
+- **Numeric defaults**: use `value ?? 0.6`, not `value || 0.6` — `||` treats `0` as falsy.
+- **`native` is reserved**: use `nativeName`.
+- **No Unicode glyphs as icons** (`"✎"`, `"☰"`): use SVG `Image` from `qrc:/icons/`. Safe: `°`, `·`, `—`, `→`, `×`.
+- **Accessibility on interactive elements**: every interactive element needs `Accessible.role`, `Accessible.name`, `Accessible.focusable: true`, and `Accessible.onPressAction`. Prefer `AccessibleButton` / `AccessibleMouseArea` over raw `Rectangle+MouseArea`. Full rules in `docs/CLAUDE_MD/ACCESSIBILITY.md`.
 
-// GOOD - use individual properties
-Text {
-    font.family: Theme.bodyFont.family
-    font.pixelSize: Theme.bodyFont.pixelSize
-    font.bold: true
-}
-```
-
-**Reserved property names in JS model data**: `name` is a reserved QML property (`QObject::objectName`). When a JS array of objects is used as a Repeater model, `modelData.name` resolves to the QML object name (empty string), not the JS property. Use a different key like `label`.
-```qml
-// BAD - modelData.name resolves to empty string
-readonly property var items: [{ name: "Foo" }]
-Repeater {
-    model: items
-    delegate: Text { text: modelData.name }  // Shows nothing!
-}
-
-// GOOD - use a non-reserved key
-readonly property var items: [{ label: "Foo" }]
-Repeater {
-    model: items
-    delegate: Text { text: modelData.label }  // Works correctly
-}
-```
-
-Other reserved names to avoid in model data: `parent`, `children`, `data`, `state`, `enabled`, `visible`, `width`, `height`, `x`, `y`, `z`, `focus`, `clip`.
-
-**IME last-word drop on mobile**: On Android/iOS virtual keyboards, the last typed word is held in a composing/pre-edit state and is NOT reflected in `TextField.text` until committed. When a button's `onClicked` reads a text field's `.text` directly (to send, save, or pass to a C++ method), always call `Qt.inputMethod.commit()` first — otherwise the last word is silently dropped. This is a no-op on desktop so it is safe to always include.
-```qml
-// BAD - last word may be missing on mobile
-onClicked: {
-    doSomething(myField.text)
-}
-
-// GOOD - commit pending IME composition first
-onClicked: {
-    Qt.inputMethod.commit()
-    doSomething(myField.text)
-}
-```
-This applies to every button/action that reads and immediately uses text input — save dialogs, send buttons, preset name dialogs, TOTP code fields, search/import fields, etc. For `doSave()` helper functions called from both buttons and `Keys.onReturnPressed`, put the commit at the top of the function.
-
-**Keyboard handling for text inputs**: Always wrap pages with text input fields in `KeyboardAwareContainer` to shift content above the keyboard on mobile:
-```qml
-KeyboardAwareContainer {
-    id: keyboardContainer
-    anchors.fill: parent
-    textFields: [myTextField1, myTextField2]  // Register all text inputs
-
-    // Your page content here
-    ColumnLayout {
-        StyledTextField { id: myTextField1 }
-        StyledTextField { id: myTextField2 }
-    }
-}
-```
-
-**Accessibility on interactive elements**: See `docs/CLAUDE_MD/ACCESSIBILITY.md` for the full rules, component table, common mistakes checklist, focus-order requirements, and anti-patterns. The short version: every interactive element needs `Accessible.role`, `Accessible.name`, `Accessible.focusable: true`, and `Accessible.onPressAction`. Prefer `AccessibleButton` or `AccessibleMouseArea` over raw `Rectangle+MouseArea`. (`activeFocusOnTab: true` is keyboard-only and low priority for this tablet app — see ACCESSIBILITY.md.)
-
-### ShotServer Web UI (split across shotserver_*.cpp files)
-
-The ShotServer is split into multiple files: `shotserver.cpp` (core + routing), `shotserver_layout.cpp` (layout editor), `shotserver_shots.cpp`, `shotserver_backup.cpp`, `shotserver_settings.cpp`, `shotserver_ai.cpp`, `shotserver_auth.cpp`, `shotserver_theme.cpp`, `shotserver_upload.cpp`. The layout editor web UI is served as inline HTML/JS from `shotserver_layout.cpp`. Follow these conventions:
-
-**Async community endpoints (signal-based):**
-- Community API calls (`browse`, `download`, `upload`, `delete`) are async — they connect to `LibrarySharing` signals and wait for a callback. Use the established pattern: `QPointer<QTcpSocket>` + `std::shared_ptr<bool>` fired guard + `QTimer` timeout + `PendingLibraryRequest` tracking.
-- **Always verify the operation was accepted** after calling `LibrarySharing` methods. Methods like `browseCommunity()` and `downloadEntry()` silently return if already busy (`m_browsing`/`m_downloading`). Check `isBrowsing()`/`isDownloading()` after the call and send an immediate error response if rejected — otherwise the request hangs until the 60s timeout.
-- **Always log timeout and cleanup events.** Use `qWarning()` when a timeout fires, `qDebug()` when a response is dropped (socket disconnected) or when a duplicate callback is blocked by the fired guard.
-- **Only one request per type** is allowed at a time (`hasInFlightLibraryRequest`), because `LibrarySharing` is a singleton that emits one signal consumed by whichever handler is connected.
-
-**JavaScript `fetch()` calls:**
-- **Every `fetch()` must have a `.catch()` handler.** Never leave a fetch chain without error handling — silent failures leave the UI in a broken state (spinner stuck, editor blank, no feedback).
-- **Check `r.ok` before `r.json()`** in fetch chains. Non-2xx responses with non-JSON bodies will throw on `.json()` and produce a misleading "Network error" instead of "Server error (500)".
-- **Use `AbortController` with a timeout** for community API calls (client-side 45s, server-side 60s safety net).
-- **Don't mutate state before async success.** For example, increment a page counter only after the fetch succeeds, not before — otherwise failed requests skip pages permanently.
-
-### MCP Tool Responses (src/mcp/)
+### MCP Tool Responses (`src/mcp/`)
 
 MCP tool responses are consumed by LLMs which cannot reliably interpret raw numbers. Follow these conventions:
 
@@ -532,92 +224,25 @@ MCP tool responses are consumed by LLMs which cannot reliably interpret raw numb
 
 See `docs/CLAUDE_MD/MCP_SERVER.md` for the full data conventions section.
 
-## Emoji System
+## Subsystem Pointers
 
-See `docs/CLAUDE_MD/EMOJI_SYSTEM.md`. Key rule: always use `Image { source: Theme.emojiToImage(value) }` — never `Text` for emojis.
-
-## Cup Fill View
-
-See `docs/CLAUDE_MD/CUP_FILL_VIEW.md` for layer stack, GPU shaders, and how to update cup images.
-
-## Profile System
-
-See `docs/CLAUDE_MD/RECIPE_PROFILES.md` for the Recipe Editor, D-Flow/A-Flow/Pressure/Flow editor types, frame generation details, and recipe parameters.
-
-- **FrameBased mode**: Upload to machine, executes autonomously
-- **DirectControl mode**: App sends setpoints frame-by-frame
-- Formats: JSON (unified with de1app v2), TCL (de1app import)
-- Tare happens when frame 0 starts (after machine preheat)
-- **Stop limits**: `target_weight` (SAW) and `target_volume` (SAV) are checked independently — whichever triggers first stops the shot. A value of 0 means disabled. Volume bucketing uses **DE1 substate** splitting (matching de1app): flow during Preinfusion substate → preinfusion volume, flow during Pouring substate → pour volume. Other substates (heating, stabilising) are excluded. SAV uses a raw `pourVolume >= target` comparison with no lag compensation (matching de1app). SAW ignores the first 5 seconds of extraction and only fires after the current frame reaches `number_of_preinfuse_frames` (matching de1app). For **basic profiles** (`settings_2a`/`settings_2b`) with a BLE scale *configured* (not just connected), SAV is skipped (matching de1app's `skip_sav_check` / `expecting_present`). The DE1 firmware also has a `TargetEspressoVol` safety limit (200 ml, matching de1app's `espresso_typical_volume`) sent via `setShotSettings`.
-- **Profile comparison/sync**: Use the `profile_sync` C++ tool (built with the main project, no extra flags). `profile_sync <de1app_profiles_dir> <builtin_profiles_dir>` compares TCL sources against built-in JSONs. Pass `de1plus/profiles/` as the first arg — the tool also scans `de1plus/plugins/*/profiles/` and a plugin copy overrides a base copy with the same output filename (canonical source wins, e.g. the 9-frame `A_Flow` plugin profiles beat the stale 6-frame copies in `de1plus/profiles/`). Simple profiles (`settings_2a`/`settings_2b`) ship with `"steps": []` and have their frames regenerated in-memory before comparison so the equality check is like-for-like. Add `--sync` to overwrite stale JSONs and create missing ones (**modifies `resources/profiles/` in-place** — review changes before committing).
-- **Profile import test**: Run `ctest -R tst_tclimport` (requires `-DBUILD_TESTS=ON`). The `compareWithBuiltin` test loads all TCL files from `tests/data/de1app_profiles/` through the C++ parser and verifies they match their built-in JSON counterparts field-by-field.
-
-### JSON Format (unified with de1app)
-
-Decenza and de1app share the same JSON profile format. The writer (`toJson()`) outputs de1app v2 format with JSON numbers (not strings): nested `exit`/`limiter` objects, `version`, `legacy_profile_type`, `notes`, `number_of_preinfuse_frames`. The reader (`fromJson()`) accepts both de1app nested and legacy Decenza flat fields (for old profiles in shot history), with `jsonToDouble()` handling de1app's string-encoded numbers.
-
-- **Writer keys**: `notes` (not `profile_notes`), `legacy_profile_type` (not `profile_type`), `number_of_preinfuse_frames` (not `preinfuse_frame_count`), nested `exit`/`limiter`/`weight` (no flat exit fields)
-- **Reader fallbacks**: Accepts old flat fields (`exit_if`, `exit_type`, `exit_pressure_over`, `max_flow_or_pressure`, `profile_notes`, `profile_type`, `preinfuse_frame_count`) for backward compat with shot history snapshots
-- **Decenza extensions**: `recipe`, `mode`, `has_recommended_dose`, `temperature_presets`, simple profile params — de1app ignores these. (`is_recipe_mode` was removed; editor type is now derived at runtime from title + `legacy_profile_type`)
-- **No separate reader**: There is no `loadFromDE1AppJson()` — `fromJson()` handles all variants
-
-## Data Migration (Device-to-Device Transfer)
-
-See `docs/CLAUDE_MD/DATA_MIGRATION.md` for architecture, REST endpoints, and import options.
-
-## Visualizer Integration
-
-See `docs/CLAUDE_MD/VISUALIZER.md` for DYE metadata, profile import, visualizer format, ProfileSaveHelper, and filename generation.
-
-## Unit Testing
-
-See `docs/CLAUDE_MD/TESTING.md` for the test framework, architecture, mock strategy, and how to add new tests. Tests use Qt Test (QTest) with `friend class` access behind `#ifdef DECENZA_TESTING`. Build with `-DBUILD_TESTS=ON`. The `shot_eval` CLI harness and `tests/data/shots/` regression corpus are also documented there.
-
-## BLE Protocol Notes
-
-See `docs/CLAUDE_MD/BLE_PROTOCOL.md` for UUIDs, retry mechanism, shot debug logging, battery management, and steam heater control.
+- **Profiles, JSON format, stop limits, profile_sync**: `docs/CLAUDE_MD/RECIPE_PROFILES.md`
+- **QML page navigation, operation pages, phase-change handler**: `docs/CLAUDE_MD/QML_NAVIGATION.md`
+- **ShotServer (split files, async community endpoints, fetch rules)**: `docs/CLAUDE_MD/SHOTSERVER.md`
+- **Emoji**: always `Image { source: Theme.emojiToImage(value) }` — never `Text` for emojis. See `EMOJI_SYSTEM.md`.
+- **Cup Fill View**: `docs/CLAUDE_MD/CUP_FILL_VIEW.md`
+- **Data migration (device-to-device)**: `docs/CLAUDE_MD/DATA_MIGRATION.md`
+- **Visualizer integration**: `docs/CLAUDE_MD/VISUALIZER.md`
+- **Unit testing** (Qt Test, `friend class` access behind `#ifdef DECENZA_TESTING`, build with `-DBUILD_TESTS=ON`, `shot_eval` harness, `tests/data/shots/` regression corpus): `docs/CLAUDE_MD/TESTING.md`
+- **BLE protocol**: `docs/CLAUDE_MD/BLE_PROTOCOL.md`
+- **CI/CD, releases, auto-update**: `docs/CLAUDE_MD/CI_CD.md`
+- **Windows installer / Android build / tablet quirks**: `docs/CLAUDE_MD/PLATFORM_BUILD.md`
 
 ## Platforms
 
 - Desktop: Windows, macOS, Linux
 - Mobile: Android (API 28+), iOS (17.0+)
 - Android needs Location permission for BLE scanning
-
-## Windows Installer / Android Build / Tablet Troubleshooting
-
-See `docs/CLAUDE_MD/PLATFORM_BUILD.md` for Windows Inno Setup, Android signing, and Decent tablet quirks.
-
-## Publishing Releases
-
-See `docs/CLAUDE_MD/CI_CD.md` for the full release process, updating pre-releases, auto-update system, and release notes guidelines.
-
-## QML Navigation System
-
-### Page Navigation (main.qml)
-- **StackView**: `pageStack` manages page navigation
-- **Auto-navigation**: `MachineState.phaseChanged` signal triggers automatic page transitions
-- **Operation pages**: SteamPage, HotWaterPage, FlushPage, EspressoPage
-- **Completion flow**: When operations end, show 1.5-second completion overlay, then navigate to IdlePage
-
-### Phase Change Handler Pattern
-```qml
-// In main.qml onPhaseChanged handler:
-// 1. Check pageStack.busy ONLY for navigation calls, not completion handling
-// 2. Navigation TO operation pages: check !pageStack.busy before replace()
-// 3. Completion handling (Idle/Ready): NEVER skip - always show completion overlay
-```
-
-### Operation Page Structure
-Each operation page (Steam, HotWater, Flush) has:
-- `objectName`: Must be set for navigation detection (e.g., `objectName: "steamPage"`)
-- `isOperating` property: Binds to `MachineState.phase === <phase>`
-- **Live view**: Shown during operation (timer, progress, stop button)
-- **Settings view**: Shown when idle (presets, configuration)
-- **Stop button**: Only visible on headless machines (`DE1Device.isHeadless`)
-
-### Common Bug Pattern
-**Problem**: Early `return` in `onPhaseChanged` can skip completion handling
-**Solution**: Only check `pageStack.busy` before `replace()` calls, not at handler start
 
 ## Versioning
 
@@ -626,7 +251,7 @@ Each operation page (Steam, HotWater, Flush) has:
 - **version.h**: Auto-generated from `src/version.h.in` with VERSION_STRING macro
 - **AndroidManifest.xml**: Auto-generated from `android/AndroidManifest.xml.in` by CMake at build time (gitignored). Both `versionCode` and `versionName` come from `versioncode.txt` and `CMakeLists.txt` respectively.
 - **installer/version.iss**: Auto-generated from `installer/version.iss.in` by CMake at build time (gitignored).
-- To release a new version: Update VERSION in CMakeLists.txt, commit, then follow the "Publishing Releases" process (create release first, then push tag)
+- To release a new version: Update VERSION in CMakeLists.txt, commit, then follow the "Publishing Releases" process in `docs/CLAUDE_MD/CI_CD.md` (create release first, then push tag)
 
 ## Git Workflow
 

--- a/docs/CLAUDE_MD/PLATFORM_BUILD.md
+++ b/docs/CLAUDE_MD/PLATFORM_BUILD.md
@@ -1,3 +1,68 @@
+## Command Line Build (for Claude sessions)
+
+> **Don't build automatically** — let the user build in Qt Creator (~50× faster than CLI). Only use these commands if the user explicitly asks for a CLI build.
+
+### Windows (MSVC)
+
+MSVC environment variables (INCLUDE, LIB) are set permanently. Use Visual Studio generator (Ninja not in PATH).
+
+**Configure Release:**
+```bash
+rm -rf build/Release && mkdir -p build/Release && cd build/Release && cmake ../.. -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="C:/Qt/6.10.3/msvc2022_64"
+```
+
+**Build Release (parallel):**
+```bash
+cd build/Release && unset CMAKE_BUILD_PARALLEL_LEVEL && MSYS_NO_PATHCONV=1 cmake --build . --config Release -- /m
+```
+
+**Configure Debug:**
+```bash
+rm -rf build/Debug && mkdir -p build/Debug && cd build/Debug && cmake ../.. -G "Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH="C:/Qt/6.10.3/msvc2022_64" -DCMAKE_BUILD_TYPE=Debug
+```
+
+**Build Debug (parallel):**
+```bash
+cd build/Debug && unset CMAKE_BUILD_PARALLEL_LEVEL && MSYS_NO_PATHCONV=1 cmake --build . --config Debug -- /m
+```
+
+Notes: `unset CMAKE_BUILD_PARALLEL_LEVEL` avoids conflicts with `/m`. `MSYS_NO_PATHCONV=1` prevents bash from converting `/m` to `M:/`. The `/m` flag enables MSBuild parallel compilation.
+
+**Output locations:**
+- Release: `build/Release/Release/Decenza.exe`
+- Debug: `build/Debug/Debug/Decenza.exe`
+
+### macOS / iOS (on Mac)
+
+Use Qt's `qt-cmake` wrapper which handles cross-compilation correctly.
+
+**Finding Qt paths.** Qt is installed at `~/Qt/`. Discover paths dynamically:
+```bash
+# Find qt-cmake for macOS
+find ~/Qt -name "qt-cmake" -path "*/macos/*"
+# Find Ninja (bundled with Qt)
+find ~/Qt/Tools -name "ninja"
+```
+
+**Configure iOS (generates Xcode project):**
+```bash
+rm -rf build/Qt_6_10_3_for_iOS && mkdir -p build/Qt_6_10_3_for_iOS && cd build/Qt_6_10_3_for_iOS && /Users/mic/Qt/6.10.3/ios/bin/qt-cmake ../.. -G Xcode
+```
+
+**Configure macOS (generates Xcode project):**
+```bash
+rm -rf build/Qt_6_10_3_for_macOS && mkdir -p build/Qt_6_10_3_for_macOS && cd build/Qt_6_10_3_for_macOS && /Users/mic/Qt/6.10.3/macos/bin/qt-cmake ../.. -G Xcode
+```
+
+**Open in Xcode:**
+```bash
+open build/Qt_6_10_3_for_iOS/Decenza.xcodeproj
+# or
+open build/Qt_6_10_3_for_macOS/Decenza.xcodeproj
+```
+
+Then in Xcode: Product → Archive for App Store submission.
+
 ## Windows Installer
 
 The Windows installer is built with Inno Setup (`installer/setup.iss`). It uses a local config file `installer/setupvars.iss` (gitignored) to define machine-specific paths.

--- a/docs/CLAUDE_MD/PROJECT_STRUCTURE.md
+++ b/docs/CLAUDE_MD/PROJECT_STRUCTURE.md
@@ -1,0 +1,201 @@
+# Project Structure
+
+Top-level layout of the Decenza source tree. Use this as a map when locating subsystems; the actual file list is authoritative — run `ls`/`tree` if you suspect drift.
+
+## Top-level
+
+```
+src/        # C++ sources (see breakdown below)
+qml/        # QML UI (pages/, components/, simulator/, Theme.qml)
+resources/  # CoffeeCup/, emoji/, .qrc files, icons, fonts
+shaders/    # crt.frag, cup_mask.frag, cup_lighten.frag
+scripts/    # download_emoji.py and other helpers
+tests/      # Qt Test sources (gated behind -DBUILD_TESTS=ON)
+docs/       # Documentation (this directory: docs/CLAUDE_MD/)
+openspec/   # OpenSpec change proposals and capability specs
+android/    # AndroidManifest.xml.in, build.gradle
+installer/  # Inno Setup script + setupvars template
+```
+
+## src/ subsystems
+
+```
+src/
+├── ai/                     # AI assistant integration
+│   ├── aimanager.*         # Provider config, test connection, conversation lifecycle
+│   ├── aiprovider.*        # HTTP calls to OpenAI/Anthropic/Ollama/OpenRouter
+│   ├── aiconversation.*    # Multi-turn conversation state + history persistence
+│   ├── shotanalysis.*      # Shot analysis prompts and structured response parsing
+│   └── shotsummarizer.*    # Summarise shot data into AI-readable text
+├── ble/                    # Bluetooth LE layer
+│   ├── de1device.*         # DE1 machine protocol
+│   ├── blemanager.*        # Device discovery
+│   ├── scaledevice.*       # Abstract scale interface
+│   ├── protocol/           # BLE UUIDs, binary codec
+│   ├── scales/             # Scale implementations (13 types)
+│   └── transport/          # BLE transport abstraction
+├── controllers/
+│   ├── maincontroller.*    # App logic, profiles, shot processing
+│   ├── directcontroller.*  # Direct frame control mode
+│   ├── profilemanager.*    # Profile CRUD, activation, built-in management
+│   └── shottimingcontroller.* # Shot timing, tare management, weight processing
+├── core/
+│   ├── settings.*          # QSettings persistence (façade — see SETTINGS.md)
+│   ├── batterymanager.*    # Smart charging control
+│   ├── accessibilitymanager.* # TTS announcements, tick sounds, a11y settings
+│   ├── asynclogger.*       # Background-thread file logger
+│   ├── autowakemanager.*   # Scheduled DE1 auto-wake (time-based)
+│   ├── crashhandler.*      # Signal handler → writes crash log on crash
+│   ├── databasebackupmanager.* # Daily automatic backup of shots/settings/profiles
+│   ├── datamigrationclient.*   # Device-to-device data transfer (REST client)
+│   ├── dbutils.h           # withTempDb() helper for background-thread DB connections
+│   ├── documentformatter.* # Formats shot/profile data as Markdown for AI context
+│   ├── grinderaliases.h    # Grinder brand/model normalisation table
+│   ├── memorymonitor.*     # RSS/heap tracking, low-memory warnings
+│   ├── profilestorage.*    # Low-level profile file I/O (JSON read/write, enumeration)
+│   ├── settingsserializer.* # Export/import settings as JSON
+│   ├── translationmanager.* # Runtime i18n — loads locale JSON, exposes translate()
+│   ├── updatechecker.*     # GitHub Releases polling for app updates
+│   └── widgetlibrary.*     # Local library for layout items, zones, layouts, themes
+├── history/                # Shot history storage and queries
+│   ├── shothistorystorage.* # SQLite CRUD, background-thread query helpers
+│   ├── shotimporter.*      # Import shots from JSON files / migration
+│   ├── shotdebuglogger.*   # Per-shot BLE frame debug log writer
+│   ├── shotfileparser.*    # Parse legacy shot file formats
+│   └── shotprojection.*    # Projected/derived shot fields
+├── machine/
+│   ├── machinestate.*      # Phase tracking, stop-at-weight, stop-at-volume
+│   ├── steamcalibrator.*   # Steam flow calibration procedure
+│   ├── steamhealthtracker.* # Tracks steam health metrics over time
+│   └── weightprocessor.*   # Centralised weight filtering and smoothing
+├── mcp/                    # Model Context Protocol server (AI agent tools)
+│   ├── mcpserver.*         # WebSocket server, session management
+│   ├── mcpsession.h        # Per-connection session state
+│   ├── mcptoolregistry.h   # Tool registration and dispatch
+│   ├── mcpresourceregistry.h # Resource registration
+│   ├── mcptools_shots.*    # Shot history tools
+│   ├── mcptools_profiles.* # Profile read/write tools
+│   ├── mcptools_machine.*  # Machine state tools
+│   ├── mcptools_control.*  # Shot control tools
+│   ├── mcptools_devices.*  # BLE device tools
+│   ├── mcptools_scale.*    # Scale tools
+│   ├── mcptools_settings.* # Settings tools
+│   ├── mcptools_dialing.*  # Dialing assistant tools
+│   ├── mcptools_write.*    # Write/update tools
+│   └── mcptools_agent.*    # Agent coordination tools
+├── models/
+│   ├── shotdatamodel.*     # Shot data for graphing (live + history)
+│   ├── shotcomparisonmodel.* # Side-by-side shot comparison data
+│   ├── flowcalibrationmodel.* # Flow calibration data model
+│   └── steamdatamodel.*    # Steam session data for graphing
+├── network/
+│   ├── shotserver.cpp      # HTTP server core + route dispatch
+│   ├── shotserver_backup.cpp   # Backup/restore endpoints
+│   ├── shotserver_layout.cpp   # Layout editor web UI
+│   ├── shotserver_shots.cpp    # Shot history endpoints
+│   ├── shotserver_settings.cpp # Settings endpoints
+│   ├── shotserver_ai.cpp       # AI assistant endpoints
+│   ├── shotserver_auth.cpp     # Authentication
+│   ├── shotserver_theme.cpp    # Theme endpoints
+│   ├── shotserver_upload.cpp   # File upload handling
+│   ├── visualizeruploader.*    # Upload shots to visualizer.coffee
+│   ├── visualizerimporter.*    # Import profiles from visualizer.coffee
+│   ├── librarysharing.*    # Community profile library (browse/download/upload)
+│   ├── mqttclient.*        # MQTT connectivity for remote monitoring
+│   ├── relayclient.*       # WebSocket relay for remote DE1 control
+│   ├── crashreporter.*     # Crash report submission to backend
+│   ├── shotreporter.*      # Automatic shot reporting / webhooks
+│   ├── locationprovider.*  # City + coordinates for shot metadata
+│   ├── screencaptureservice.* # Screenshot capture for sharing
+│   └── webdebuglogger.*    # Web-accessible debug log endpoint
+├── profile/
+│   ├── profile.*           # Profile container, JSON/TCL formats
+│   ├── profileframe.*      # Single extraction step
+│   ├── profilesavehelper.* # Shared save/compare/deduplicate logic for importers
+│   ├── profileconverter.*  # Convert between profile formats
+│   ├── profileimporter.*   # Import profiles from files / visualizer
+│   ├── recipeanalyzer.*    # Extract RecipeParams from frame-based profiles
+│   ├── recipegenerator.*   # Generate frame profiles from RecipeParams
+│   └── recipeparams.*      # Typed recipe parameter container
+├── rendering/              # Custom rendering (shot graphs, etc.)
+├── screensaver/            # Screensaver implementation
+├── simulator/              # DE1 machine simulator
+├── usb/                    # USB scale connectivity (Decent USB scale, serial)
+├── weather/                # Weather data for shot metadata
+└── main.cpp                # Entry point, object wiring
+```
+
+## qml/
+
+```
+qml/
+├── pages/                  # Full-screen pages (EspressoPage, ShotDetailPage, etc.)
+│   └── settings/           # Settings tab pages
+├── components/             # Reusable components (ShotGraph, StatusBar, etc.)
+├── simulator/              # Simulator UI (GHCSimulatorWindow)
+└── Theme.qml               # Singleton styling (+ emojiToImage())
+```
+
+## resources/
+
+```
+resources/
+├── CoffeeCup/              # 3D-rendered cup images for CupFillView
+│   ├── BackGround.png      # Cup back, interior, handle (701x432)
+│   ├── Mask.png            # Black = coffee area, white = no coffee
+│   ├── Overlay.png         # Rim, front highlights (lighten blend)
+│   └── FullRes.7z          # Source PSD archive
+├── emoji/                  # ~750 Twemoji SVGs (CC-BY 4.0)
+├── emoji.qrc               # Qt resource file for emoji SVGs
+└── resources.qrc           # Icons, fonts, other assets
+```
+
+## shaders/
+
+```
+shaders/
+├── crt.frag                # CRT/retro display effect
+├── cup_mask.frag           # Masks coffee to cup interior (inverts Mask.png)
+└── cup_lighten.frag        # Lighten (MAX) blend + brightness-to-alpha
+```
+
+## Key Architecture
+
+### Signal/Slot Flow
+```
+DE1Device (BLE) → signals → MainController → ShotDataModel → QML graphs
+                          → ShotTimingController (timing, tare, weight)
+ScaleDevice     → signals → MachineState (stop-at-weight)
+                          → MainController (graph data)
+MachineState    → signals → MainController → QML page navigation
+AIManager       → signals → QML AI panels (conversation responses)
+MqttClient      → signals → MainController (remote monitoring)
+RelayClient     ←→ DE1Device (remote control over WebSocket relay)
+MCPServer       → tool calls → MainController / ProfileManager / ShotHistoryStorage
+```
+
+### Scale System
+- **ScaleDevice**: Abstract base class
+- **FlowScale**: Virtual scale from DE1 flow data (fallback when no physical scale)
+- **Physical scales**: DecentScale, AcaiaScale, FelicitaScale, etc. (factory pattern)
+
+### Machine Phases
+```
+Disconnected → Sleep → Idle → Heating → Ready
+Ready → EspressoPreheating → Preinfusion → Pouring → Ending
+Also: Steaming, HotWater, Flushing, Refill, Descaling, Cleaning
+```
+
+### AI & MCP
+- **AIManager**: Manages provider config and conversation lifecycle; exposes `conversation` to QML
+- **AIConversation**: Multi-turn conversation with history; used by AI panels across the app
+- **MCPServer**: WebSocket server exposing machine control and data as MCP tools for external AI agents
+- **ShotAnalysis / ShotSummarizer**: Format shot data as text context for AI prompts
+
+### Profile Pipeline
+```
+TCL/JSON file → ProfileImporter → ProfileConverter → Profile (in memory)
+RecipeParams  → RecipeGenerator → Profile frames → DE1 upload
+Profile frames ← RecipeAnalyzer ← existing frame-based profile (reverse)
+ProfileManager: CRUD, activation, built-in management, ProfileStorage I/O
+```

--- a/docs/CLAUDE_MD/QML_GOTCHAS.md
+++ b/docs/CLAUDE_MD/QML_GOTCHAS.md
@@ -1,0 +1,97 @@
+# QML Gotchas
+
+Bug-prone QML patterns discovered the hard way. The corresponding one-liners in `CLAUDE.md` point here for the full code samples and rationale.
+
+## Font property conflict
+
+Cannot use `font: Theme.bodyFont` and then override sub-properties like `font.bold: true`. QML treats this as assigning the property twice.
+
+```qml
+// BAD - causes "Property has already been assigned a value" error
+Text {
+    font: Theme.bodyFont
+    font.bold: true  // Error!
+}
+
+// GOOD - use individual properties
+Text {
+    font.family: Theme.bodyFont.family
+    font.pixelSize: Theme.bodyFont.pixelSize
+    font.bold: true
+}
+```
+
+## Reserved property names in JS model data
+
+`name` is a reserved QML property (`QObject::objectName`). When a JS array of objects is used as a Repeater model, `modelData.name` resolves to the QML object name (empty string), not the JS property. Use a different key like `label`.
+
+```qml
+// BAD - modelData.name resolves to empty string
+readonly property var items: [{ name: "Foo" }]
+Repeater {
+    model: items
+    delegate: Text { text: modelData.name }  // Shows nothing!
+}
+
+// GOOD - use a non-reserved key
+readonly property var items: [{ label: "Foo" }]
+Repeater {
+    model: items
+    delegate: Text { text: modelData.label }  // Works correctly
+}
+```
+
+Other reserved names to avoid in model data: `parent`, `children`, `data`, `state`, `enabled`, `visible`, `width`, `height`, `x`, `y`, `z`, `focus`, `clip`.
+
+## IME last-word drop on mobile
+
+On Android/iOS virtual keyboards, the last typed word is held in a composing/pre-edit state and is NOT reflected in `TextField.text` until committed. When a button's `onClicked` reads a text field's `.text` directly (to send, save, or pass to a C++ method), always call `Qt.inputMethod.commit()` first — otherwise the last word is silently dropped. This is a no-op on desktop so it is safe to always include.
+
+```qml
+// BAD - last word may be missing on mobile
+onClicked: {
+    doSomething(myField.text)
+}
+
+// GOOD - commit pending IME composition first
+onClicked: {
+    Qt.inputMethod.commit()
+    doSomething(myField.text)
+}
+```
+
+This applies to every button/action that reads and immediately uses text input — save dialogs, send buttons, preset name dialogs, TOTP code fields, search/import fields, etc. For `doSave()` helper functions called from both buttons and `Keys.onReturnPressed`, put the commit at the top of the function.
+
+## Keyboard handling for text inputs
+
+Always wrap pages with text input fields in `KeyboardAwareContainer` to shift content above the keyboard on mobile:
+
+```qml
+KeyboardAwareContainer {
+    id: keyboardContainer
+    anchors.fill: parent
+    textFields: [myTextField1, myTextField2]  // Register all text inputs
+
+    // Your page content here
+    ColumnLayout {
+        StyledTextField { id: myTextField1 }
+        StyledTextField { id: myTextField2 }
+    }
+}
+```
+
+## FINAL properties on Qt types
+
+Never override FINAL properties on Qt types. Qt 6.10+ marks some `Popup`/`Dialog` properties as FINAL (e.g., `message`, `title`). Declaring `property string message` on a Dialog will prevent the component from loading. Use a different name (e.g., `resultMessage`), or use the inherited property directly if it already exists on the base type.
+
+## Numeric defaults with `??` not `||`
+
+JavaScript `||` treats `0` as falsy, so `value || 0.6` returns `0.6` when `value` is `0`. Use `value ?? 0.6` (nullish coalescing) which only falls back for `null`/`undefined`. Only use `||` when `0` genuinely means "no data" (e.g., unrated enjoyment, unmeasured TDS).
+
+## `native` is reserved
+
+`native` is a reserved JavaScript keyword — use `nativeName` instead.
+
+## No Unicode symbols as icons
+
+Never use Unicode symbols as icons in text (e.g., `"✎"`, `"✗"`, `"☰"`). These render as tofu squares on devices without the right font glyphs. Use SVG icons from `qrc:/icons/` with `Image` instead. For buttons/menu items, use a `Row { Image {} Text {} }` contentItem. Safe Unicode characters (°, ·, —, →, ×) that are in standard fonts are OK.

--- a/docs/CLAUDE_MD/QML_NAVIGATION.md
+++ b/docs/CLAUDE_MD/QML_NAVIGATION.md
@@ -1,0 +1,35 @@
+# QML Navigation System
+
+How page navigation works in `main.qml` and the conventions every operation page (Steam, HotWater, Flush, Espresso) must follow.
+
+## Page Navigation (main.qml)
+
+- **StackView**: `pageStack` manages page navigation
+- **Auto-navigation**: `MachineState.phaseChanged` signal triggers automatic page transitions
+- **Operation pages**: SteamPage, HotWaterPage, FlushPage, EspressoPage
+- **Completion flow**: When operations end, show 1.5-second completion overlay, then navigate to IdlePage
+
+## Phase Change Handler Pattern
+
+```qml
+// In main.qml onPhaseChanged handler:
+// 1. Check pageStack.busy ONLY for navigation calls, not completion handling
+// 2. Navigation TO operation pages: check !pageStack.busy before replace()
+// 3. Completion handling (Idle/Ready): NEVER skip - always show completion overlay
+```
+
+## Operation Page Structure
+
+Each operation page (Steam, HotWater, Flush) has:
+
+- `objectName`: Must be set for navigation detection (e.g., `objectName: "steamPage"`)
+- `isOperating` property: Binds to `MachineState.phase === <phase>`
+- **Live view**: Shown during operation (timer, progress, stop button)
+- **Settings view**: Shown when idle (presets, configuration)
+- **Stop button**: Only visible on headless machines (`DE1Device.isHeadless`)
+
+## Common Bug Pattern
+
+**Problem**: Early `return` in `onPhaseChanged` can skip completion handling.
+
+**Solution**: Only check `pageStack.busy` before `replace()` calls, not at handler start.

--- a/docs/CLAUDE_MD/RECIPE_PROFILES.md
+++ b/docs/CLAUDE_MD/RECIPE_PROFILES.md
@@ -543,6 +543,28 @@ qml/components/
 └── PresetButton.qml        # Preset selector
 ```
 
+## Profile Modes & Stop Limits
+
+- **FrameBased mode**: Upload to machine, executes autonomously
+- **DirectControl mode**: App sends setpoints frame-by-frame
+- Formats: JSON (unified with de1app v2), TCL (de1app import)
+- Tare happens when frame 0 starts (after machine preheat)
+- **Stop limits**: `target_weight` (SAW) and `target_volume` (SAV) are checked independently — whichever triggers first stops the shot. A value of 0 means disabled. Volume bucketing uses **DE1 substate** splitting (matching de1app): flow during Preinfusion substate → preinfusion volume, flow during Pouring substate → pour volume. Other substates (heating, stabilising) are excluded. SAV uses a raw `pourVolume >= target` comparison with no lag compensation (matching de1app). SAW ignores the first 5 seconds of extraction and only fires after the current frame reaches `number_of_preinfuse_frames` (matching de1app). For **basic profiles** (`settings_2a`/`settings_2b`) with a BLE scale *configured* (not just connected), SAV is skipped (matching de1app's `skip_sav_check` / `expecting_present`). The DE1 firmware also has a `TargetEspressoVol` safety limit (200 ml, matching de1app's `espresso_typical_volume`) sent via `setShotSettings`.
+
+## JSON Format (unified with de1app)
+
+Decenza and de1app share the same JSON profile format. The writer (`toJson()`) outputs de1app v2 format with JSON numbers (not strings): nested `exit`/`limiter` objects, `version`, `legacy_profile_type`, `notes`, `number_of_preinfuse_frames`. The reader (`fromJson()`) accepts both de1app nested and legacy Decenza flat fields (for old profiles in shot history), with `jsonToDouble()` handling de1app's string-encoded numbers.
+
+- **Writer keys**: `notes` (not `profile_notes`), `legacy_profile_type` (not `profile_type`), `number_of_preinfuse_frames` (not `preinfuse_frame_count`), nested `exit`/`limiter`/`weight` (no flat exit fields)
+- **Reader fallbacks**: Accepts old flat fields (`exit_if`, `exit_type`, `exit_pressure_over`, `max_flow_or_pressure`, `profile_notes`, `profile_type`, `preinfuse_frame_count`) for backward compat with shot history snapshots
+- **Decenza extensions**: `recipe`, `mode`, `has_recommended_dose`, `temperature_presets`, simple profile params — de1app ignores these. (`is_recipe_mode` was removed; editor type is now derived at runtime from title + `legacy_profile_type`)
+- **No separate reader**: There is no `loadFromDE1AppJson()` — `fromJson()` handles all variants
+
+## Profile Comparison / Sync Tools
+
+- **Profile comparison/sync**: Use the `profile_sync` C++ tool (built with the main project, no extra flags). `profile_sync <de1app_profiles_dir> <builtin_profiles_dir>` compares TCL sources against built-in JSONs. Pass `de1plus/profiles/` as the first arg — the tool also scans `de1plus/plugins/*/profiles/` and a plugin copy overrides a base copy with the same output filename (canonical source wins, e.g. the 9-frame `A_Flow` plugin profiles beat the stale 6-frame copies in `de1plus/profiles/`). Simple profiles (`settings_2a`/`settings_2b`) ship with `"steps": []` and have their frames regenerated in-memory before comparison so the equality check is like-for-like. Add `--sync` to overwrite stale JSONs and create missing ones (**modifies `resources/profiles/` in-place** — review changes before committing).
+- **Profile import test**: Run `ctest -R tst_tclimport` (requires `-DBUILD_TESTS=ON`). The `compareWithBuiltin` test loads all TCL files from `tests/data/de1app_profiles/` through the C++ parser and verifies they match their built-in JSON counterparts field-by-field.
+
 ## References
 
 - [D-Flow GitHub Repository](https://github.com/Damian-AU/D_Flow_Espresso_Profile)

--- a/docs/CLAUDE_MD/SHOTSERVER.md
+++ b/docs/CLAUDE_MD/SHOTSERVER.md
@@ -1,0 +1,31 @@
+# ShotServer Web UI
+
+The ShotServer is the in-app HTTP server that exposes shot history, settings, layout editor, and AI endpoints to the browser. It is split across multiple files; this doc captures the conventions that the routing layer and the embedded JavaScript must follow.
+
+## File layout
+
+- `shotserver.cpp` — core server + route dispatch
+- `shotserver_layout.cpp` — layout editor web UI (inline HTML/JS)
+- `shotserver_shots.cpp` — shot history endpoints
+- `shotserver_backup.cpp` — backup/restore endpoints
+- `shotserver_settings.cpp` — settings endpoints
+- `shotserver_ai.cpp` — AI assistant endpoints
+- `shotserver_auth.cpp` — authentication
+- `shotserver_theme.cpp` — theme endpoints
+- `shotserver_upload.cpp` — file upload handling
+
+The layout editor web UI is served as inline HTML/JS from `shotserver_layout.cpp`.
+
+## Async community endpoints (signal-based)
+
+- Community API calls (`browse`, `download`, `upload`, `delete`) are async — they connect to `LibrarySharing` signals and wait for a callback. Use the established pattern: `QPointer<QTcpSocket>` + `std::shared_ptr<bool>` fired guard + `QTimer` timeout + `PendingLibraryRequest` tracking.
+- **Always verify the operation was accepted** after calling `LibrarySharing` methods. Methods like `browseCommunity()` and `downloadEntry()` silently return if already busy (`m_browsing`/`m_downloading`). Check `isBrowsing()`/`isDownloading()` after the call and send an immediate error response if rejected — otherwise the request hangs until the 60s timeout.
+- **Always log timeout and cleanup events.** Use `qWarning()` when a timeout fires, `qDebug()` when a response is dropped (socket disconnected) or when a duplicate callback is blocked by the fired guard.
+- **Only one request per type** is allowed at a time (`hasInFlightLibraryRequest`), because `LibrarySharing` is a singleton that emits one signal consumed by whichever handler is connected.
+
+## JavaScript `fetch()` calls
+
+- **Every `fetch()` must have a `.catch()` handler.** Never leave a fetch chain without error handling — silent failures leave the UI in a broken state (spinner stuck, editor blank, no feedback).
+- **Check `r.ok` before `r.json()`** in fetch chains. Non-2xx responses with non-JSON bodies will throw on `.json()` and produce a misleading "Network error" instead of "Server error (500)".
+- **Use `AbortController` with a timeout** for community API calls (client-side 45s, server-side 60s safety net).
+- **Don't mutate state before async success.** For example, increment a page counter only after the fetch succeeds, not before — otherwise failed requests skip pages permanently.


### PR DESCRIPTION
## Summary
- Trim `CLAUDE.md` from 641 → 266 lines (~58% reduction) by moving domain-specific content into `docs/CLAUDE_MD/` files. The always-loaded context now keeps only cross-cutting rules (Design Principles, C++/QML conventions, MCP response shape, Versioning, Git Workflow) plus a pointer index.
- **New docs**: `PROJECT_STRUCTURE.md` (full src tree + signal/slot flow), `QML_GOTCHAS.md` (font conflict, reserved names, IME drop, FINAL props — with code samples), `QML_NAVIGATION.md` (StackView/phase-change conventions), `SHOTSERVER.md` (split-file layout, async community endpoint pattern, `fetch()` rules).
- **Extended**: `PLATFORM_BUILD.md` (CLI build commands for Windows/macOS/iOS), `RECIPE_PROFILES.md` (stop limits, JSON format, `profile_sync`).
- QML gotchas remain in `CLAUDE.md` as one-liner bullets pointing to `QML_GOTCHAS.md`, so the rules are still discoverable at a glance.

## Test plan
- [ ] Skim the new `CLAUDE.md` and confirm the Reference Documents table covers every doc you expect to find.
- [ ] Spot-check one moved section (e.g. QML Gotchas) to confirm the new doc reads cleanly standalone.
- [ ] Confirm the OpenSpec block (lines 1–124) is byte-identical to before so `openspec` tooling won't rewrite it on next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)