### PR TITLE
fix(mcp): clean up shot tool surface (#983, #980, #979)

### DIFF
--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -52,9 +52,9 @@ Page {
                 editBarista = editShotData.barista || ""
                 editDoseWeight = editShotData.doseWeightG ?? 0
                 editDrinkWeight = editShotData.finalWeightG ?? 0
-                editDrinkTds = editShotData.drinkTds ?? 0
-                editDrinkEy = editShotData.drinkEy ?? 0
-                editEnjoyment = editShotData.enjoyment ?? 0
+                editDrinkTds = editShotData.drinkTdsPct ?? 0
+                editDrinkEy = editShotData.drinkEyPct ?? 0
+                editEnjoyment = editShotData.enjoyment0to100 ?? 0
                 editNotes = editShotData.espressoNotes || ""
             }
         }

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -135,9 +135,9 @@ Page {
                 // Preserve any live R2 reading that arrived before the async DB load;
                 // only take the DB value when no measurement has been received yet.
                 if (editDrinkTds === 0)
-                    editDrinkTds = editShotData.drinkTds ?? 0
-                editDrinkEy = editShotData.drinkEy ?? 0
-                editEnjoyment = editShotData.enjoyment ?? 0  // Use ?? to avoid treating 0 as falsy
+                    editDrinkTds = editShotData.drinkTdsPct ?? 0
+                editDrinkEy = editShotData.drinkEyPct ?? 0
+                editEnjoyment = editShotData.enjoyment0to100 ?? 0  // Use ?? to avoid treating 0 as falsy
                 editNotes = editShotData.espressoNotes || ""
                 editBeverageType = editShotData.beverageType || "espresso"
                 // Recompute EY now that dose/weight are loaded (covers the case where TDS
@@ -240,9 +240,9 @@ Page {
         editBarista !== (editShotData.barista || "") ||
         editDoseWeight !== ((editShotData.doseWeightG > 0) ? editShotData.doseWeightG : Settings.dye.dyeBeanWeight) ||
         editDrinkWeight !== (editShotData.finalWeightG ?? 0) ||
-        editDrinkTds !== (editShotData.drinkTds ?? 0) ||
-        editDrinkEy !== (editShotData.drinkEy ?? 0) ||
-        editEnjoyment !== (editShotData.enjoyment ?? 0) ||
+        editDrinkTds !== (editShotData.drinkTdsPct ?? 0) ||
+        editDrinkEy !== (editShotData.drinkEyPct ?? 0) ||
+        editEnjoyment !== (editShotData.enjoyment0to100 ?? 0) ||
         editNotes !== (editShotData.espressoNotes || "") ||
         editBeverageType !== (editShotData.beverageType || "espresso")
     )
@@ -1339,9 +1339,9 @@ Page {
                             "barista": editBarista,
                             "doseWeightG": editDoseWeight,
                             "finalWeightG": editDrinkWeight,
-                            "drinkTds": editDrinkTds,
-                            "drinkEy": editDrinkEy,
-                            "enjoyment": editEnjoyment,
+                            "drinkTdsPct": editDrinkTds,
+                            "drinkEyPct": editDrinkEy,
+                            "enjoyment0to100": editEnjoyment,
                             "espressoNotes": editNotes,
                             "profileName": editShotData.profileName || ""
                         }
@@ -1362,9 +1362,9 @@ Page {
                             "barista": editBarista,
                             "doseWeightG": editDoseWeight,
                             "finalWeightG": editDrinkWeight,
-                            "drinkTds": editDrinkTds,
-                            "drinkEy": editDrinkEy,
-                            "enjoyment": editEnjoyment,
+                            "drinkTdsPct": editDrinkTds,
+                            "drinkEyPct": editDrinkEy,
+                            "enjoyment0to100": editEnjoyment,
                             "espressoNotes": editNotes
                         })
                         MainController.visualizer.uploadShotFromHistory(uploadData)

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -667,7 +667,7 @@ Page {
                     spacing: Theme.scaled(2)
                     Accessible.role: Accessible.StaticText
                     Accessible.name: TranslationManager.translate("shotdetail.rating", "Rating") + ": " +
-                        ((shotData.enjoyment || 0) > 0 ? shotData.enjoyment + "%" : "-")
+                        ((shotData.enjoyment0to100 || 0) > 0 ? shotData.enjoyment0to100 + "%" : "-")
                     Tr {
                         key: "shotdetail.rating"
                         fallback: "Rating"
@@ -676,7 +676,7 @@ Page {
                         Accessible.ignored: true
                     }
                     Text {
-                        text: (shotData.enjoyment || 0) > 0 ? shotData.enjoyment + "%" : "-"
+                        text: (shotData.enjoyment0to100 || 0) > 0 ? shotData.enjoyment0to100 + "%" : "-"
                         font: Theme.subtitleFont
                         color: Theme.warningColor
                         Accessible.ignored: true
@@ -833,7 +833,7 @@ Page {
                 Layout.preferredHeight: analysisColumn.height + Theme.spacingLarge
                 color: Theme.surfaceColor
                 radius: Theme.cardRadius
-                visible: shotDetailPage.advancedMode && (shotData.drinkTds > 0 || shotData.drinkEy > 0)
+                visible: shotDetailPage.advancedMode && (shotData.drinkTdsPct > 0 || shotData.drinkEyPct > 0)
                 Accessible.role: Accessible.Grouping
                 Accessible.name: TranslationManager.translate("shotdetail.analysis", "Analysis")
 
@@ -859,13 +859,13 @@ Page {
                         ColumnLayout {
                             spacing: Theme.scaled(2)
                             Tr { key: "shotdetail.tds"; fallback: "TDS"; font: Theme.captionFont; color: Theme.textSecondaryColor }
-                            Text { text: (shotData.drinkTds || 0).toFixed(2) + "%"; font: Theme.bodyFont; color: Theme.dyeTdsColor }
+                            Text { text: (shotData.drinkTdsPct || 0).toFixed(2) + "%"; font: Theme.bodyFont; color: Theme.dyeTdsColor }
                         }
 
                         ColumnLayout {
                             spacing: Theme.scaled(2)
                             Tr { key: "shotdetail.ey"; fallback: "EY"; font: Theme.captionFont; color: Theme.textSecondaryColor }
-                            Text { text: (shotData.drinkEy || 0).toFixed(1) + "%"; font: Theme.bodyFont; color: Theme.dyeEyColor }
+                            Text { text: (shotData.drinkEyPct || 0).toFixed(1) + "%"; font: Theme.bodyFont; color: Theme.dyeEyColor }
                         }
                     }
                 }

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -587,7 +587,7 @@ Page {
                 border.color: isSelected(model.id) ? Theme.primaryColor : "transparent"
                 border.width: isSelected(model.id) ? 2 : 0
 
-                property int shotEnjoyment: model.enjoyment || 0
+                property int shotEnjoyment: model.enjoyment0to100 || 0
 
                 // Accessibility: row is a button whose primary action opens shot detail.
                 // Note: visual tap toggles selection (line 696); TalkBack double-tap opens detail

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -401,9 +401,9 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
     summary.grinderModel = shotData.grinderModel;
     summary.grinderBurrs = shotData.grinderBurrs;
     summary.grinderSetting = shotData.grinderSetting;
-    summary.drinkTds = shotData.drinkTds;
-    summary.drinkEy = shotData.drinkEy;
-    summary.enjoymentScore = shotData.enjoyment;
+    summary.drinkTds = shotData.drinkTdsPct;
+    summary.drinkEy = shotData.drinkEyPct;
+    summary.enjoymentScore = shotData.enjoyment0to100;
     summary.tastingNotes = shotData.espressoNotes;
 
     // Convert curve data
@@ -821,17 +821,17 @@ QString ShotSummarizer::buildHistoryContext(const QVariantList& recentShots)
         }
 
         // Extraction measurements
-        if (shot.drinkTds > 0 || shot.drinkEy > 0) {
+        if (shot.drinkTdsPct > 0 || shot.drinkEyPct > 0) {
             out << "- Extraction: ";
-            if (shot.drinkTds > 0) out << "TDS " << QString::number(shot.drinkTds, 'f', 2) << "%";
-            if (shot.drinkTds > 0 && shot.drinkEy > 0) out << ", ";
-            if (shot.drinkEy > 0) out << "EY " << QString::number(shot.drinkEy, 'f', 1) << "%";
+            if (shot.drinkTdsPct > 0) out << "TDS " << QString::number(shot.drinkTdsPct, 'f', 2) << "%";
+            if (shot.drinkTdsPct > 0 && shot.drinkEyPct > 0) out << ", ";
+            if (shot.drinkEyPct > 0) out << "EY " << QString::number(shot.drinkEyPct, 'f', 1) << "%";
             out << "\n";
         }
 
         // Score and tasting notes
-        if (shot.enjoyment > 0) {
-            out << "- Score: " << shot.enjoyment << "/100\n";
+        if (shot.enjoyment0to100 > 0) {
+            out << "- Score: " << shot.enjoyment0to100 << "/100\n";
         }
         if (!shot.espressoNotes.isEmpty()) {
             out << "- Notes: \"" << shot.espressoNotes << "\"\n";

--- a/src/history/shothistorystorage_queries.cpp
+++ b/src/history/shothistorystorage_queries.cpp
@@ -432,14 +432,14 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                             shot["doseWeightG"] = query.value(6).toDouble();
                             shot["beanBrand"] = query.value(7).toString();
                             shot["beanType"] = query.value(8).toString();
-                            shot["enjoyment"] = query.value(9).toInt();
+                            shot["enjoyment0to100"] = query.value(9).toInt();
                             shot["hasVisualizerUpload"] = !query.value(10).isNull();
                             shot["grinderSetting"] = query.value(11).toString();
                             shot["temperatureOverrideC"] = query.value(12).toDouble();
                             shot["targetWeightG"] = query.value(13).toDouble();
                             shot["beverageType"] = query.value(14).toString();
-                            shot["drinkTds"] = query.value(15).toDouble();
-                            shot["drinkEy"] = query.value(16).toDouble();
+                            shot["drinkTdsPct"] = query.value(15).toDouble();
+                            shot["drinkEyPct"] = query.value(16).toDouble();
                             shot["channelingDetected"] = query.value(17).toInt() != 0;
                             shot["temperatureUnstable"] = query.value(18).toInt() != 0;
                             shot["grindIssueDetected"] = query.value(19).toInt() != 0;
@@ -552,7 +552,7 @@ QVariantList ShotHistoryStorage::loadRecentShotsByKbIdStatic(QSqlDatabase& db, c
             shot["doseWeightG"] = query.value("dose_weight").toDouble();
             shot["finalWeightG"] = query.value("final_weight").toDouble();
             shot["durationSec"] = query.value("duration_seconds").toDouble();
-            shot["enjoyment"] = query.value("enjoyment").toInt();
+            shot["enjoyment0to100"] = query.value("enjoyment").toInt();
             shot["grinderSetting"] = query.value("grinder_setting").toString();
             shot["grinderModel"] = query.value("grinder_model").toString();
             shot["grinderBrand"] = query.value("grinder_brand").toString();
@@ -562,8 +562,8 @@ QVariantList ShotHistoryStorage::loadRecentShotsByKbIdStatic(QSqlDatabase& db, c
             shot["beanType"] = query.value("bean_type").toString();
             shot["roastLevel"] = query.value("roast_level").toString();
             shot["roastDate"] = query.value("roast_date").toString();
-            shot["drinkTds"] = query.value("drink_tds").toDouble();
-            shot["drinkEy"] = query.value("drink_ey").toDouble();
+            shot["drinkTdsPct"] = query.value("drink_tds").toDouble();
+            shot["drinkEyPct"] = query.value("drink_ey").toDouble();
             shot["temperatureOverrideC"] = query.value("temperature_override").toDouble();
             shot["targetWeightG"] = query.value("yield_override").toDouble();
             shot["profileJson"] = query.value("profile_json").toString();

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -52,7 +52,7 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.doseWeightG = record.summary.doseWeight;
     p.beanBrand = record.summary.beanBrand;
     p.beanType = record.summary.beanType;
-    p.enjoyment = record.summary.enjoyment;
+    p.enjoyment0to100 = record.summary.enjoyment;
     p.hasVisualizerUpload = record.summary.hasVisualizerUpload;
     p.beverageType = record.summary.beverageType;
     p.roastDate = record.roastDate;
@@ -61,8 +61,8 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.grinderModel = record.grinderModel;
     p.grinderBurrs = record.grinderBurrs;
     p.grinderSetting = record.grinderSetting;
-    p.drinkTds = record.drinkTds;
-    p.drinkEy = record.drinkEy;
+    p.drinkTdsPct = record.drinkTds;
+    p.drinkEyPct = record.drinkEy;
     p.espressoNotes = record.espressoNotes;
     p.beanNotes = record.beanNotes;
     p.barista = record.barista;

--- a/src/history/shotprojection.cpp
+++ b/src/history/shotprojection.cpp
@@ -16,7 +16,7 @@ QVariantMap ShotProjection::toVariantMap() const
     m["doseWeightG"] = doseWeightG;
     m["beanBrand"] = beanBrand;
     m["beanType"] = beanType;
-    m["enjoyment"] = enjoyment;
+    m["enjoyment0to100"] = enjoyment0to100;
     m["hasVisualizerUpload"] = hasVisualizerUpload;
     m["beverageType"] = beverageType;
     m["roastDate"] = roastDate;
@@ -25,8 +25,8 @@ QVariantMap ShotProjection::toVariantMap() const
     m["grinderModel"] = grinderModel;
     m["grinderBurrs"] = grinderBurrs;
     m["grinderSetting"] = grinderSetting;
-    m["drinkTds"] = drinkTds;
-    m["drinkEy"] = drinkEy;
+    m["drinkTdsPct"] = drinkTdsPct;
+    m["drinkEyPct"] = drinkEyPct;
     m["espressoNotes"] = espressoNotes;
     m["beanNotes"] = beanNotes;
     m["barista"] = barista;
@@ -65,7 +65,6 @@ QVariantMap ShotProjection::toVariantMap() const
     if (phaseSummaries.isValid())
         m["phaseSummaries"] = phaseSummaries;
     m["phases"] = phases;
-    m["dateTime"] = dateTime;
     return m;
 }
 
@@ -81,14 +80,13 @@ ShotProjection ShotProjection::fromVariantMap(const QVariantMap& m)
     p.uuid = m.value("uuid").toString();
     p.timestamp = m.value("timestamp").toLongLong();
     p.timestampIso = m.value("timestampIso").toString();
-    p.dateTime = m.value("dateTime").toString();
     p.profileName = m.value("profileName").toString();
     p.durationSec = m.value("durationSec").toDouble();
     p.finalWeightG = m.value("finalWeightG").toDouble();
     p.doseWeightG = m.value("doseWeightG").toDouble();
     p.beanBrand = m.value("beanBrand").toString();
     p.beanType = m.value("beanType").toString();
-    p.enjoyment = m.value("enjoyment").toInt();
+    p.enjoyment0to100 = m.value("enjoyment0to100").toInt();
     p.hasVisualizerUpload = m.value("hasVisualizerUpload").toBool();
     p.beverageType = m.value("beverageType").toString();
     p.roastDate = m.value("roastDate").toString();
@@ -97,8 +95,8 @@ ShotProjection ShotProjection::fromVariantMap(const QVariantMap& m)
     p.grinderModel = m.value("grinderModel").toString();
     p.grinderBurrs = m.value("grinderBurrs").toString();
     p.grinderSetting = m.value("grinderSetting").toString();
-    p.drinkTds = m.value("drinkTds").toDouble();
-    p.drinkEy = m.value("drinkEy").toDouble();
+    p.drinkTdsPct = m.value("drinkTdsPct").toDouble();
+    p.drinkEyPct = m.value("drinkEyPct").toDouble();
     p.espressoNotes = m.value("espressoNotes").toString();
     p.beanNotes = m.value("beanNotes").toString();
     p.barista = m.value("barista").toString();

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -38,7 +38,7 @@ class ShotProjection {
     Q_PROPERTY(double doseWeightG MEMBER doseWeightG)
     Q_PROPERTY(QString beanBrand MEMBER beanBrand)
     Q_PROPERTY(QString beanType MEMBER beanType)
-    Q_PROPERTY(int enjoyment MEMBER enjoyment)
+    Q_PROPERTY(int enjoyment0to100 MEMBER enjoyment0to100)
     Q_PROPERTY(bool hasVisualizerUpload MEMBER hasVisualizerUpload)
     Q_PROPERTY(QString beverageType MEMBER beverageType)
     Q_PROPERTY(QString roastDate MEMBER roastDate)
@@ -47,8 +47,8 @@ class ShotProjection {
     Q_PROPERTY(QString grinderModel MEMBER grinderModel)
     Q_PROPERTY(QString grinderBurrs MEMBER grinderBurrs)
     Q_PROPERTY(QString grinderSetting MEMBER grinderSetting)
-    Q_PROPERTY(double drinkTds MEMBER drinkTds)
-    Q_PROPERTY(double drinkEy MEMBER drinkEy)
+    Q_PROPERTY(double drinkTdsPct MEMBER drinkTdsPct)
+    Q_PROPERTY(double drinkEyPct MEMBER drinkEyPct)
     Q_PROPERTY(QString espressoNotes MEMBER espressoNotes)
     Q_PROPERTY(QString beanNotes MEMBER beanNotes)
     Q_PROPERTY(QString barista MEMBER barista)
@@ -104,7 +104,7 @@ public:
     double doseWeightG = 0.0;
     QString beanBrand;
     QString beanType;
-    int enjoyment = 0;
+    int enjoyment0to100 = 0;
     bool hasVisualizerUpload = false;
     QString beverageType;
     QString roastDate;
@@ -113,8 +113,8 @@ public:
     QString grinderModel;
     QString grinderBurrs;
     QString grinderSetting;
-    double drinkTds = 0.0;
-    double drinkEy = 0.0;
+    double drinkTdsPct = 0.0;
+    double drinkEyPct = 0.0;
     QString espressoNotes;
     QString beanNotes;
     QString barista;

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -107,7 +107,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                             h["doseG"] = shot.doseWeightG;
                             h["yieldG"] = shot.finalWeightG;
                             h["durationSec"] = shot.durationSec;
-                            h["enjoyment0to100"] = shot.enjoyment;
+                            h["enjoyment0to100"] = shot.enjoyment0to100;
                             h["grinderSetting"] = shot.grinderSetting;
                             h["grinderModel"] = shot.grinderModel;
                             h["grinderBrand"] = shot.grinderBrand;
@@ -188,7 +188,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     shotSummary["doseG"] = sd.doseWeightG;
                     shotSummary["yieldG"] = sd.finalWeightG;
                     shotSummary["durationSec"] = sd.durationSec;
-                    shotSummary["enjoyment0to100"] = sd.enjoyment;
+                    shotSummary["enjoyment0to100"] = sd.enjoyment0to100;
                     shotSummary["notes"] = sd.espressoNotes;
                     shotSummary["beanBrand"] = sd.beanBrand;
                     shotSummary["beanType"] = sd.beanType;

--- a/src/mcp/mcptools_profiles.cpp
+++ b/src/mcp/mcptools_profiles.cpp
@@ -423,6 +423,13 @@ void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileMana
                 return result;
             }
 
+            if (filename == profileManager->baseProfileName()) {
+                result["error"] = "Cannot delete the currently-active profile '" + filename +
+                    "'. Call profiles_set_active with a different profile first, then retry.";
+                result["filename"] = filename;
+                return result;
+            }
+
             bool deleted = profileManager->deleteProfile(filename);
             if (deleted) {
                 result["success"] = true;

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -14,6 +14,33 @@
 #include <QMetaObject>
 #include <QCoreApplication>
 
+// Drop heavy fields (time-series, debugLog, profileJson) from a shot projection
+// JSON object so it fits within typical LLM context windows. The full payload
+// for a single shot is ~85K chars (mostly time-series); the summary is ~3K and
+// covers every dialing/comparison use case (scalars, phaseSummaries,
+// summaryLines, detectorResults, ratings).
+static void stripTimeSeriesFields(QJsonObject& obj)
+{
+    static const char* heavyFields[] = {
+        "pressure", "flow", "temperature", "temperatureMix",
+        "resistance", "conductance", "darcyResistance", "conductanceDerivative",
+        "waterDispensed", "pressureGoal", "flowGoal", "temperatureGoal",
+        "weight", "weightFlowRate",
+        "debugLog", "profileJson"
+    };
+    for (const char* key : heavyFields)
+        obj.remove(QString::fromLatin1(key));
+}
+
+// Resolve the detail argument. Default "summary" — drops time-series, debugLog,
+// profileJson. "full" — return the complete projection. Unknown values fall
+// back to summary so the LLM gets a usable response rather than the 200K-char
+// firehose.
+static bool wantsFullDetail(const QJsonObject& args)
+{
+    return args.value("detail").toString() == QStringLiteral("full");
+}
+
 void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistory)
 {
     // shots_list
@@ -199,11 +226,19 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
     // shots_get_detail
     registry->registerAsyncTool(
         "shots_get_detail",
-        "Get full shot record including time-series data (pressure, flow, temperature, weight curves)",
+        "Get a shot record. Default detail='summary' returns scalars, phase summaries, "
+        "summary lines, detector results, and ratings (~3K chars). Pass detail='full' to "
+        "include time-series curves (pressure, flow, temperature, weight), debug log, "
+        "and embedded profile JSON (~85K chars — only useful for curve-aware analysis).",
         QJsonObject{
             {"type", "object"},
             {"properties", QJsonObject{
-                {"shotId", QJsonObject{{"type", "integer"}, {"description", "Shot ID"}}}
+                {"shotId", QJsonObject{{"type", "integer"}, {"description", "Shot ID"}}},
+                {"detail", QJsonObject{
+                    {"type", "string"},
+                    {"enum", QJsonArray{"summary", "full"}},
+                    {"description", "summary (default): omit time-series, debugLog, profileJson. full: include everything."}
+                }}
             }},
             {"required", QJsonArray{"shotId"}}
         },
@@ -219,9 +254,10 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                 return;
             }
 
+            const bool fullDetail = wantsFullDetail(args);
             const QString dbPath = shotHistory->databasePath();
 
-            QThread* thread = QThread::create([dbPath, shotId, respond]() {
+            QThread* thread = QThread::create([dbPath, shotId, fullDetail, respond]() {
                 QJsonObject result;
 
                 if (!withTempDb(dbPath, "mcp_shot_detail", [&](QSqlDatabase& db) {
@@ -229,6 +265,8 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                     ShotProjection shot = ShotHistoryStorage::convertShotRecord(record);
                     if (shot.isValid()) {
                         result = shot.toJsonObject();
+                        if (!fullDetail)
+                            stripTimeSeriesFields(result);
                     } else {
                         result["error"] = "Shot not found: " + QString::number(shotId);
                     }
@@ -257,7 +295,10 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
     // shots_compare
     registry->registerAsyncTool(
         "shots_compare",
-        "Side-by-side comparison of 2 or more shots. Returns summary data for each shot.",
+        "Side-by-side comparison of 2 or more shots. Default detail='summary' returns "
+        "scalars + phase summaries per shot plus a changes diff between consecutive shots "
+        "(~3K chars/shot). Pass detail='full' to include time-series curves and debug logs "
+        "(~85K chars/shot — exceeds typical LLM context with more than 1-2 shots).",
         QJsonObject{
             {"type", "object"},
             {"properties", QJsonObject{
@@ -265,6 +306,11 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                     {"type", "array"},
                     {"items", QJsonObject{{"type", "integer"}}},
                     {"description", "Array of shot IDs to compare (2-10)"}
+                }},
+                {"detail", QJsonObject{
+                    {"type", "string"},
+                    {"enum", QJsonArray{"summary", "full"}},
+                    {"description", "summary (default): omit time-series, debugLog, profileJson per shot. full: include everything."}
                 }}
             }},
             {"required", QJsonArray{"shotIds"}}
@@ -281,9 +327,10 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                 return;
             }
 
+            const bool fullDetail = wantsFullDetail(args);
             const QString dbPath = shotHistory->databasePath();
 
-            QThread* thread = QThread::create([dbPath, idArray, respond]() {
+            QThread* thread = QThread::create([dbPath, idArray, fullDetail, respond]() {
                 QJsonObject result;
                 QJsonArray shots;
                 QList<ShotProjection> projections;
@@ -294,7 +341,10 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         ShotRecord record = ShotHistoryStorage::loadShotRecordStatic(db, shotId);
                         ShotProjection shot = ShotHistoryStorage::convertShotRecord(record);
                         if (shot.isValid()) {
-                            shots.append(shot.toJsonObject());
+                            QJsonObject shotJson = shot.toJsonObject();
+                            if (!fullDetail)
+                                stripTimeSeriesFields(shotJson);
+                            shots.append(shotJson);
                             projections.append(std::move(shot));
                         }
                     }
@@ -341,7 +391,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         diffNum(prev.doseWeightG, curr.doseWeightG, "doseG", "g");
                         diffNum(prev.finalWeightG, curr.finalWeightG, "yieldG", "g");
                         diffNum(prev.durationSec, curr.durationSec, "durationSec", "s");
-                        diffNum(prev.enjoyment, curr.enjoyment, "enjoyment0to100", "");
+                        diffNum(prev.enjoyment0to100, curr.enjoyment0to100, "enjoyment0to100", "");
 
                         if (diff.size() > 2)
                             changes.append(diff);

--- a/src/network/shotserver_shots.cpp
+++ b/src/network/shotserver_shots.cpp
@@ -49,7 +49,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         // safety on every field name read below.
         const ShotProjection shot = ShotProjection::fromVariantMap(v.toMap());
 
-        int rating = qRound(static_cast<double>(shot.enjoyment));
+        int rating = qRound(static_cast<double>(shot.enjoyment0to100));
 
         double ratio = 0;
         if (shot.doseWeightG > 0) {
@@ -116,8 +116,8 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
             }
         }
 
-        const double drinkTds = shot.drinkTds;
-        const double drinkEy = shot.drinkEy;
+        const double drinkTds = shot.drinkTdsPct;
+        const double drinkEy = shot.drinkEyPct;
 
         rows += QString(R"HTML(
             <div class="shot-card" onclick="toggleSelect(%1, this)" data-id="%1"
@@ -1032,7 +1032,7 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
         ratio = shot.finalWeightG / shot.doseWeightG;
     }
 
-    int rating = qRound(static_cast<double>(shot.enjoyment) / 20.0);
+    int rating = qRound(static_cast<double>(shot.enjoyment0to100) / 20.0);
     QString stars;
     for (int i = 0; i < 5; i++) {
         stars += (i < rating) ? "&#9733;" : "&#9734;";
@@ -2118,13 +2118,13 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
     .arg(jsEscape(shot.espressoNotes))                                               // %31 espressoNotes
     .arg(shot.doseWeightG, 0, 'f', 1)                                                // %32 doseWeightG
     .arg(shot.finalWeightG, 0, 'f', 1)                                               // %33 finalWeightG
-    .arg(shot.enjoyment)                                                             // %34 enjoyment
+    .arg(shot.enjoyment0to100)                                                       // %34 enjoyment
     .arg(jsEscape(shot.barista))                                                     // %35 barista
     .arg(jsEscape(shot.beverageType.isEmpty()
                   ? QStringLiteral("espresso")
                   : shot.beverageType))                                              // %36 beverageType
-    .arg(shot.drinkTds, 0, 'f', 2)                                                   // %37 drinkTds
-    .arg(shot.drinkEy, 0, 'f', 1)                                                    // %38 drinkEy
+    .arg(shot.drinkTdsPct, 0, 'f', 2)                                                // %37 drinkTds
+    .arg(shot.drinkEyPct, 0, 'f', 1)                                                 // %38 drinkEy
     .arg(resistanceData)                                                             // %39 resistance
     .arg(jsEscape(shot.grinderBrand))                                                // %40 grinderBrand
     .arg(jsEscape(shot.grinderBurrs));                                               // %41 grinderBurrs

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -195,9 +195,9 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
         if (!combined.isEmpty()) shotObj["grinder_model"] = combined;
     }
     setStr("grinder_setting", &ShotProjection::grinderSetting);
-    setDouble("drink_tds", &ShotProjection::drinkTds);
-    setDouble("drink_ey", &ShotProjection::drinkEy);
-    setInt("espresso_enjoyment", &ShotProjection::enjoyment);
+    setDouble("drink_tds", &ShotProjection::drinkTdsPct);
+    setDouble("drink_ey", &ShotProjection::drinkEyPct);
+    setInt("espresso_enjoyment", &ShotProjection::enjoyment0to100);
     setStr("espresso_notes", &ShotProjection::espressoNotes);
     setStr("barista", &ShotProjection::barista);
     setStr("profile_title", &ShotProjection::profileName);
@@ -1136,10 +1136,10 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const ShotProjection& shotDa
 
     // Shot info
     QJsonObject shot;
-    if (shotData.enjoyment > 0) shot["enjoyment"] = shotData.enjoyment;
+    if (shotData.enjoyment0to100 > 0) shot["enjoyment"] = shotData.enjoyment0to100;
     if (!shotData.espressoNotes.isEmpty()) shot["notes"] = shotData.espressoNotes;
-    if (shotData.drinkTds > 0) shot["tds"] = shotData.drinkTds;
-    if (shotData.drinkEy > 0) shot["ey"] = shotData.drinkEy;
+    if (shotData.drinkTdsPct > 0) shot["tds"] = shotData.drinkTdsPct;
+    if (shotData.drinkEyPct > 0) shot["ey"] = shotData.drinkEyPct;
     meta["shot"] = shot;
 
     // Grinder info (combine brand+model for visualizer compatibility)
@@ -1173,9 +1173,9 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const ShotProjection& shotDa
     if (!shotData.grinderSetting.isEmpty()) settings["grinder_setting"] = shotData.grinderSetting;
     if (shotData.doseWeightG > 0) settings["grinder_dose_weight"] = shotData.doseWeightG;
     if (finalWeight > 0) settings["drink_weight"] = finalWeight;
-    if (shotData.drinkTds > 0) settings["drink_tds"] = shotData.drinkTds;
-    if (shotData.drinkEy > 0) settings["drink_ey"] = shotData.drinkEy;
-    if (shotData.enjoyment > 0) settings["espresso_enjoyment"] = shotData.enjoyment;
+    if (shotData.drinkTdsPct > 0) settings["drink_tds"] = shotData.drinkTdsPct;
+    if (shotData.drinkEyPct > 0) settings["drink_ey"] = shotData.drinkEyPct;
+    if (shotData.enjoyment0to100 > 0) settings["espresso_enjoyment"] = shotData.enjoyment0to100;
     if (!shotData.espressoNotes.isEmpty()) settings["espresso_notes"] = shotData.espressoNotes;
 
     if (!shotData.barista.isEmpty()) settings["barista"] = shotData.barista;


### PR DESCRIPTION
## Summary
- **#983** — `profiles_delete` returns an actionable error when the target is the currently-active profile (instead of the generic "Failed to delete" that LLMs couldn't recover from).
- **#980** — finishes the unit/scale suffix migration in `ShotProjection`: `enjoyment` → `enjoyment0to100`, `drinkTds` → `drinkTdsPct`, `drinkEy` → `drinkEyPct`. Drops the duplicate `dateTime` key from `toVariantMap` (`timestampIso` is canonical). All emitters and consumers are updated; no backward-compat fallback in `fromVariantMap` (MCP is stateless — no caller is reaching for old keys).
- **#979** — `shots_get_detail` and `shots_compare` get a `detail: \"summary\" | \"full\"` parameter. Default `\"summary\"` strips time-series, `debugLog`, and `profileJson` (~85K → ~3K chars per shot). `\"full\"` returns the complete projection.

## Test plan
- [ ] `profiles_delete` against the active profile → returns the new explicit error
- [ ] `profiles_delete` after switching active → succeeds
- [ ] `shots_get_detail` (no detail) → summary payload, no time-series, no `debugLog`/`profileJson`
- [ ] `shots_get_detail` with `detail: \"full\"` → full payload including curves
- [ ] `shots_compare` (no detail) → per-shot summaries + diff `changes` block
- [ ] `shots_compare` with `detail: \"full\"` → full per-shot payloads
- [ ] `shots_list`, `dialing_get_context` continue to render correctly
- [ ] ShotDetailPage / PostShotReviewPage / BeanInfoPage show TDS, EY, enjoyment correctly (read paths)
- [ ] Visualizer upload from PostShotReviewPage works (write path through `fromVariantMap`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)