### PR TITLE
fix(mcp): add hasMore/nextOffset to shots_list (#990)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -312,7 +312,9 @@ Expect: success=true
 ```
 Call: shots_list (limit: 3)
 Expect: count=3, each shot has id, profileName, durationSec, enjoyment0to100,
-        doseG, yieldG, targetWeightG, timestamp (ISO 8601)
+        doseG, yieldG, targetWeightG, timestamp (ISO 8601).
+        Top-level fields: total, offset=0, hasMore=true (if total > 3),
+        nextOffset=3 (or null when hasMore=false).
 Save: note first shot id as SHOT_ID, second shot id as SHOT_ID_2
 ```
 Note: list summaries use unit/scale-suffixed field names (`durationSec`, `doseG`,

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -91,7 +91,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                  minEnjoyment, afterEpoch, beforeEpoch, currentDateTime, respond]() {
                 QJsonObject result;
                 QJsonArray shots;
-                int totalCount = 0;
+                qint64 totalCount = 0;
 
                 if (!withTempDb(dbPath, "mcp_shots_list", [&](QSqlDatabase& db) {
                     QString sql = "SELECT id, timestamp, profile_name, dose_weight, final_weight, "
@@ -183,7 +183,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                     if (beforeEpoch > 0)
                         countQuery.bindValue(":before", beforeEpoch);
                     if (countQuery.exec() && countQuery.next())
-                        totalCount = countQuery.value(0).toInt();
+                        totalCount = countQuery.value(0).toLongLong();
                 })) {
                     result["error"] = "Failed to open shot database";
                 }
@@ -194,10 +194,12 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                     result["count"] = shots.size();
                     result["total"] = totalCount;
                     result["offset"] = offset;
-                    const int returned = shots.size();
-                    const bool hasMore = (offset + returned) < totalCount;
+                    const qint64 returned = shots.size();
+                    const bool hasMore = (static_cast<qint64>(offset) + returned) < totalCount;
                     result["hasMore"] = hasMore;
-                    result["nextOffset"] = hasMore ? QJsonValue(offset + returned) : QJsonValue(QJsonValue::Null);
+                    result["nextOffset"] = hasMore
+                        ? QJsonValue(static_cast<qint64>(offset) + returned)
+                        : QJsonValue(QJsonValue::Null);
 
                     // Per MCP 2025-06-18: emit a resource_link block per shot
                     // pointing at decenza://shots/{id} so subscribing clients

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -194,6 +194,10 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                     result["count"] = shots.size();
                     result["total"] = totalCount;
                     result["offset"] = offset;
+                    const int returned = shots.size();
+                    const bool hasMore = (offset + returned) < totalCount;
+                    result["hasMore"] = hasMore;
+                    result["nextOffset"] = hasMore ? QJsonValue(offset + returned) : QJsonValue(QJsonValue::Null);
 
                     // Per MCP 2025-06-18: emit a resource_link block per shot
                     // pointing at decenza://shots/{id} so subscribing clients


### PR DESCRIPTION
## Summary
- Adds `hasMore` (bool) and `nextOffset` (int|null) to the `shots_list` response so paginating agents don't have to compute `(offset + count) < total` themselves.
- Matches the convention already used by `shots_get_debug_log`.
- Updates MCP_TEST_PLAN.md §6.1 to reference the new fields.

Closes #990.

## Test plan
- [ ] `shots_list (limit: 3)` against a DB with > 3 shots returns `hasMore=true` and `nextOffset=3`.
- [ ] `shots_list (limit: 3, offset: total-2)` (last page) returns `hasMore=false` and `nextOffset=null`.
- [ ] Existing `count`, `total`, `offset` fields unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)