### PR TITLE
fix(mcp): omit detectorResults.gates from shot reads (#993)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -331,7 +331,9 @@ Expect: count > 0, all returned shots have profileName containing "D-Flow"
 Call: shots_get_detail (shotId: SHOT_ID)
 Expect: id=SHOT_ID, scalars + phaseSummaries + summaryLines + detectorResults present.
         Time-series arrays (pressure, flow, temperature, etc.), debugLog, and
-        profileJson are OMITTED in summary mode. Payload ~3 KB.
+        profileJson are OMITTED in summary mode. Per-detector `gates` blocks
+        (implementation thresholds) are OMITTED in both summary and full mode.
+        Payload ~3 KB.
 ```
 
 ### 6.3a shots_get_detail — full

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -32,6 +32,30 @@ static void stripTimeSeriesFields(QJsonObject& obj)
         obj.remove(QString::fromLatin1(key));
 }
 
+// Strip per-detector implementation-detail blocks (currently `gates`) from
+// detectorResults so MCP responses only expose the user-facing scalars the
+// detectors commit to externally. Threshold values inside `gates` (e.g.
+// chokedFlowMaxMlPerSec) are scratch input/output for the detector and
+// invite the LLM to reason about them as if they were dialing parameters.
+static void stripDetectorInternals(QJsonObject& obj)
+{
+    if (!obj.contains("detectorResults"))
+        return;
+    QJsonObject detectorResults = obj.value("detectorResults").toObject();
+    static const char* detectorKeys[] = {
+        "grind", "channeling", "flowTrend", "tempStability", "preinfusion"
+    };
+    for (const char* key : detectorKeys) {
+        const QString k = QString::fromLatin1(key);
+        if (!detectorResults.contains(k))
+            continue;
+        QJsonObject d = detectorResults.value(k).toObject();
+        d.remove(QStringLiteral("gates"));
+        detectorResults[k] = d;
+    }
+    obj["detectorResults"] = detectorResults;
+}
+
 // Resolve the detail argument. Default "summary" — drops time-series, debugLog,
 // profileJson. "full" — return the complete projection. Unknown values fall
 // back to summary so the LLM gets a usable response rather than the 200K-char
@@ -267,6 +291,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         result = shot.toJsonObject();
                         if (!fullDetail)
                             stripTimeSeriesFields(result);
+                        stripDetectorInternals(result);
                     } else {
                         result["error"] = "Shot not found: " + QString::number(shotId);
                     }
@@ -344,6 +369,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                             QJsonObject shotJson = shot.toJsonObject();
                             if (!fullDetail)
                                 stripTimeSeriesFields(shotJson);
+                            stripDetectorInternals(shotJson);
                             shots.append(shotJson);
                             projections.append(std::move(shot));
                         }


### PR DESCRIPTION
## Summary
- Strip per-detector `gates` blocks from MCP `shots_get_detail` and `shots_compare` responses (both summary and full mode).
- The `gates` block is detector implementation detail — input thresholds (`chokedFlowMaxMlPerSec`, `chokedYieldRatioMax`, …) and intermediate computations — that an LLM can pattern-match on as if they were dialing parameters.
- Keeps the user-facing detector scalars: `checked`, `direction`, `hasData`, `verifiedClean`, `yieldRatio`, `yieldOvershoot`, `coverage`, `chokedPuck`, `sampleCount`, `deltaMlPerSec`.
- Updates MCP_TEST_PLAN.md §6.3 to note gates is omitted.

The data is still produced and persisted in `ShotProjection.detectorResults` (used by QML); only the MCP wire format is filtered. Available via `shots_get_debug_log` if needed.

Closes #993.

## Test plan
- [ ] `shots_get_detail (shotId: …)` returns `detectorResults.grind` without a `gates` field.
- [ ] `shots_get_detail (shotId: …, detail: \"full\")` also has no `gates`.
- [ ] `shots_compare` for shots with grind data has no `gates` per shot.
- [ ] QML post-shot review (which reads ShotProjection directly) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)