### PR TITLE
fix(mcp): dedupe shared profile fields in shots_compare (#994)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -349,6 +349,10 @@ Call: shots_compare (shotIds: [SHOT_ID, SHOT_ID_2])
 Expect: response contains data for both shot IDs, plus a `changes` block diffing
         consecutive shots (durationSec, grinderSetting, doseG/yieldG, enjoyment0to100).
         ~3 KB per shot — no time-series, no debugLog, no profileJson.
+        If both shots share the same profile: top-level `sharedProfile` block
+        carries profileName/profileKbId/profileNotes once, and those fields are
+        omitted from each shot. When shots span multiple profiles, the per-shot
+        fields remain.
 ```
 
 ### 6.4a shots_compare — full

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -297,7 +297,9 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
         "shots_compare",
         "Side-by-side comparison of 2 or more shots. Default detail='summary' returns "
         "scalars + phase summaries per shot plus a changes diff between consecutive shots "
-        "(~3K chars/shot). Pass detail='full' to include time-series curves and debug logs "
+        "(~3K chars/shot). When all shots share a profile, profileName/profileKbId/"
+        "profileNotes are hoisted to a top-level `sharedProfile` block and omitted from "
+        "each shot. Pass detail='full' to include time-series curves and debug logs "
         "(~85K chars/shot — exceeds typical LLM context with more than 1-2 shots).",
         QJsonObject{
             {"type", "object"},
@@ -353,6 +355,45 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                 }
 
                 if (!result.contains("error")) {
+                    // Dedupe shared profile metadata. Comparing dial-in
+                    // iterations on a single recipe is the common case, and
+                    // profileNotes is ~700 chars per shot — hoisting it to
+                    // sharedProfile saves ~20% of payload at N=2 and scales
+                    // with N. When shots span multiple profiles, leave the
+                    // per-shot fields in place.
+                    if (shots.size() >= 2) {
+                        const QJsonObject first = shots.first().toObject();
+                        const QString sharedName = first.value("profileName").toString();
+                        const QString sharedKbId = first.value("profileKbId").toString();
+                        const QString sharedNotes = first.value("profileNotes").toString();
+                        bool allShare = !sharedName.isEmpty();
+                        for (const QJsonValue& v : std::as_const(shots)) {
+                            const QJsonObject s = v.toObject();
+                            if (s.value("profileName").toString() != sharedName ||
+                                s.value("profileKbId").toString() != sharedKbId ||
+                                s.value("profileNotes").toString() != sharedNotes) {
+                                allShare = false;
+                                break;
+                            }
+                        }
+                        if (allShare) {
+                            QJsonArray dedupedShots;
+                            for (const QJsonValue& v : std::as_const(shots)) {
+                                QJsonObject s = v.toObject();
+                                s.remove("profileNotes");
+                                s.remove("profileKbId");
+                                dedupedShots.append(s);
+                            }
+                            shots = dedupedShots;
+                            QJsonObject sharedProfile;
+                            sharedProfile["profileName"] = sharedName;
+                            if (!sharedKbId.isEmpty())
+                                sharedProfile["profileKbId"] = sharedKbId;
+                            if (!sharedNotes.isEmpty())
+                                sharedProfile["profileNotes"] = sharedNotes;
+                            result["sharedProfile"] = sharedProfile;
+                        }
+                    }
                     result["shots"] = shots;
                     result["count"] = shots.size();
                 }


### PR DESCRIPTION
## Summary
- When all shots in a `shots_compare` response share the same `profileName`/`profileKbId`/`profileNotes` (the common case — comparing dial-in iterations on one recipe), hoist those fields to a top-level `sharedProfile` block and omit them from each shot.
- Saves ~700 chars per shot beyond the first; ~7 KB at the 10-shot max.
- When shots span multiple profiles, the per-shot fields remain.
- Updates tool description and MCP_TEST_PLAN.md §6.4.

Closes #994.

## Test plan
- [ ] `shots_compare ([id1, id2])` where both shots use the same profile: response has `sharedProfile.profileName/profileKbId/profileNotes`, individual `shots[i]` entries have no `profileNotes` or `profileKbId`.
- [ ] `shots_compare ([id1, id2])` with different profiles: per-shot `profileNotes`/`profileKbId` retained, no `sharedProfile`.
- [ ] `profileName` still emitted per shot in the dedup case (it's also the diff key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)