### PR TITLE
fix(mcp): emit null for unrated enjoyment / unmeasured TDS / EY (#991)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -693,7 +693,9 @@ un-suffixed writer names. Quick lookup:
 
 PR #984 (#980) extended the suffixed-read convention through `ShotProjection`, so
 `shots_get_detail` and `shots_compare` now match `shots_list` for `enjoyment0to100`,
-`drinkTdsPct`, and `drinkEyPct`. Remaining read/write asymmetries (dose, yield, notes)
+`drinkTdsPct`, and `drinkEyPct`. Per #991, all three fields are emitted as `null`
+(not `0`) on shots that lack a rating or refractometer measurement, so callers can
+distinguish unrated/unmeasured from a deliberate zero. Remaining read/write asymmetries (dose, yield, notes)
 are tracked separately — read names use the projection's full member name (`doseWeightG`,
 `finalWeightG`, `espressoNotes`) while write names use the legacy short form for
 `shots_update`/`settings_set` schemas.

--- a/src/mcp/mcpresources.cpp
+++ b/src/mcp/mcpresources.cpp
@@ -121,7 +121,8 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                             shot["doseG"] = query.value("dose_weight").toDouble();
                             shot["yieldG"] = query.value("final_weight").toDouble();
                             shot["durationSec"] = query.value("duration_seconds").toDouble();
-                            shot["enjoyment0to100"] = query.value("enjoyment").toInt();
+                            const int enjoyment = query.value("enjoyment").toInt();
+                            shot["enjoyment0to100"] = enjoyment > 0 ? QJsonValue(enjoyment) : QJsonValue(QJsonValue::Null);
                             shot["beanBrand"] = query.value("bean_brand").toString();
                             shot["beanType"] = query.value("bean_type").toString();
                             shots.append(shot);

--- a/src/mcp/mcpresources.cpp
+++ b/src/mcp/mcpresources.cpp
@@ -208,8 +208,10 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                             shot["doseG"] = query.value("dose_weight").toDouble();
                             shot["yieldG"] = query.value("final_weight").toDouble();
                             shot["durationSec"] = query.value("duration_seconds").toDouble();
-                            shot["tdsPercent"] = query.value("drink_tds").toDouble();
-                            shot["extractionYieldPercent"] = query.value("drink_ey").toDouble();
+                            const double tds = query.value("drink_tds").toDouble();
+                            const double ey = query.value("drink_ey").toDouble();
+                            shot["tdsPercent"] = tds > 0.0 ? QJsonValue(tds) : QJsonValue(QJsonValue::Null);
+                            shot["extractionYieldPercent"] = ey > 0.0 ? QJsonValue(ey) : QJsonValue(QJsonValue::Null);
                             shots.append(shot);
                         }
                     }

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -107,7 +107,9 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                             h["doseG"] = shot.doseWeightG;
                             h["yieldG"] = shot.finalWeightG;
                             h["durationSec"] = shot.durationSec;
-                            h["enjoyment0to100"] = shot.enjoyment0to100;
+                            h["enjoyment0to100"] = shot.enjoyment0to100 > 0
+                                ? QJsonValue(shot.enjoyment0to100)
+                                : QJsonValue(QJsonValue::Null);
                             h["grinderSetting"] = shot.grinderSetting;
                             h["grinderModel"] = shot.grinderModel;
                             h["grinderBrand"] = shot.grinderBrand;
@@ -188,7 +190,9 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     shotSummary["doseG"] = sd.doseWeightG;
                     shotSummary["yieldG"] = sd.finalWeightG;
                     shotSummary["durationSec"] = sd.durationSec;
-                    shotSummary["enjoyment0to100"] = sd.enjoyment0to100;
+                    shotSummary["enjoyment0to100"] = sd.enjoyment0to100 > 0
+                        ? QJsonValue(sd.enjoyment0to100)
+                        : QJsonValue(QJsonValue::Null);
                     shotSummary["notes"] = sd.espressoNotes;
                     shotSummary["beanBrand"] = sd.beanBrand;
                     shotSummary["beanType"] = sd.beanType;

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -65,6 +65,26 @@ static bool wantsFullDetail(const QJsonObject& args)
     return args.value("detail").toString() == QStringLiteral("full");
 }
 
+// Replace 0 with null for enjoyment0to100/drinkTdsPct/drinkEyPct so MCP
+// consumers can distinguish unrated shots (and shots without TDS/EY
+// measurements) from a deliberate zero. The QML UI already does this
+// implicitly with `(value || 0) > 0 ? value : "-"` on display; this gives
+// the LLM the same signal.
+static void nullifyUnratedFields(QJsonObject& obj)
+{
+    static const char* ratingFields[] = {
+        "enjoyment0to100", "drinkTdsPct", "drinkEyPct"
+    };
+    for (const char* key : ratingFields) {
+        const QString k = QString::fromLatin1(key);
+        if (!obj.contains(k))
+            continue;
+        const double v = obj.value(k).toDouble();
+        if (v <= 0.0)
+            obj[k] = QJsonValue(QJsonValue::Null);
+    }
+}
+
 void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistory)
 {
     // shots_list
@@ -169,7 +189,8 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                             shot["doseG"] = query.value("dose_weight").toDouble();
                             shot["yieldG"] = query.value("final_weight").toDouble();
                             shot["durationSec"] = query.value("duration_seconds").toDouble();
-                            shot["enjoyment0to100"] = query.value("enjoyment").toInt();
+                            const int enjoyment = query.value("enjoyment").toInt();
+                            shot["enjoyment0to100"] = enjoyment > 0 ? QJsonValue(enjoyment) : QJsonValue(QJsonValue::Null);
                             shot["grinderSetting"] = query.value("grinder_setting").toString();
                             shot["grinderModel"] = query.value("grinder_model").toString();
                             shot["notes"] = query.value("espresso_notes").toString();
@@ -298,6 +319,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         if (!fullDetail)
                             stripTimeSeriesFields(result);
                         stripDetectorInternals(result);
+                        nullifyUnratedFields(result);
                     } else {
                         result["error"] = "Shot not found: " + QString::number(shotId);
                     }
@@ -378,6 +400,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                             if (!fullDetail)
                                 stripTimeSeriesFields(shotJson);
                             stripDetectorInternals(shotJson);
+                            nullifyUnratedFields(shotJson);
                             shots.append(shotJson);
                             projections.append(std::move(shot));
                         }


### PR DESCRIPTION
## Summary
- Shots without a user rating or refractometer reading now emit `enjoyment0to100`/`drinkTdsPct`/`drinkEyPct` as **null** (instead of 0) on all MCP shot reads.
- Applied at four sites: `shots_list`, `shots_get_detail`, `shots_compare`, `dialing_get_context` (history + current shot), and the `decenza://shots/recent` resource.
- Mirrors the existing QML display guard (`(value || 0) > 0 ? value : \"-\"`) used by `ShotDetailPage` and `PostShotReviewPage`.
- Updates MCP_TEST_PLAN.md to document the convention.

LLMs scanning shots no longer mis-read \"this user dislikes everything\" from a DB full of unrated shots.

Closes #991.

## Test plan
- [ ] `shots_list` against a DB with unrated shots: those entries have `enjoyment0to100: null`.
- [ ] A shot with `enjoyment=75` returns `enjoyment0to100: 75` unchanged.
- [ ] `shots_get_detail` on an unrated, no-refractometer shot: all three fields are `null`.
- [ ] `dialing_get_context` history block: unrated history shots show `enjoyment0to100: null`.
- [ ] `shots_list (minEnjoyment: 1)` still returns only rated shots (filter unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)