### PR TITLE
fix(mcp): accept suffixed read names in settings_get keys filter (#985)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -292,7 +292,17 @@ Expect: espressoTemperatureC, targetWeightG, steamTemperatureC, waterTemperature
 Save: note dyeBeanBrand as ORIGINAL_BRAND, dyeGrinderSetting as ORIGINAL_GRIND
 ```
 Note: read fields are unit/scale-suffixed (`espressoTemperatureC`, `targetWeightG`),
-write fields drop the suffix (`espressoTemperature`, `targetWeight`).
+write fields drop the suffix (`espressoTemperature`, `targetWeight`). The `keys`
+filter on `settings_get` accepts both forms — passing the suffixed read name an
+LLM saw in a previous response round-trips correctly.
+
+### 5.1a settings_get — keys filter round-trip
+```
+Call: settings_get (keys: ["espressoTemperatureC", "targetWeightG"])
+Expect: both fields present in response (suffixed alias accepted).
+Call: settings_get (keys: ["espressoTemperature"])
+Expect: response contains espressoTemperatureC (un-suffixed write name still works).
+```
 
 ### 5.2 settings_set — DYE metadata
 ```

--- a/src/mcp/mcptools_settings.cpp
+++ b/src/mcp/mcptools_settings.cpp
@@ -62,10 +62,20 @@ void registerSettingsReadTools(McpToolRegistry* registry, Settings* settings,
             // If keys are specified, return those regardless of category.
             // If category is specified, return all settings in that category.
             // If neither, return all settings.
-            auto include = [&](const QString& key, const QString& cat) -> bool {
+            //
+            // The keys filter accepts both the canonical write name (e.g.
+            // "espressoTemperature") and the suffixed read name returned in
+            // the response (e.g. "espressoTemperatureC"). An LLM that reads
+            // a value, stores the field name it received, and asks for it
+            // again must round-trip — see #985.
+            auto include = [&](const QString& key, const QString& cat,
+                               const QString& alias = QString()) -> bool {
                 if (hasKeys) {
-                    for (const auto& k : keys)
-                        if (k.toString() == key) return true;
+                    for (const auto& k : keys) {
+                        const QString s = k.toString();
+                        if (s == key || (!alias.isEmpty() && s == alias))
+                            return true;
+                    }
                     return false;
                 }
                 if (!category.isEmpty()) return category == cat;
@@ -157,25 +167,25 @@ void registerSettingsReadTools(McpToolRegistry* registry, Settings* settings,
             // API keys excluded — sensitive
 
             // === Espresso ===
-            if (include("espressoTemperature", "espresso")) result["espressoTemperatureC"] = settings->brew()->espressoTemperature();
-            if (include("targetWeight", "espresso")) result["targetWeightG"] = settings->brew()->targetWeight();
+            if (include("espressoTemperature", "espresso", "espressoTemperatureC")) result["espressoTemperatureC"] = settings->brew()->espressoTemperature();
+            if (include("targetWeight", "espresso", "targetWeightG")) result["targetWeightG"] = settings->brew()->targetWeight();
             if (include("lastUsedRatio", "espresso")) result["lastUsedRatio"] = settings->brew()->lastUsedRatio();
             if (include("currentProfile", "espresso")) result["currentProfile"] = settings->app()->currentProfile();
 
             // === Steam ===
-            if (include("steamTemperature", "steam")) result["steamTemperatureC"] = settings->brew()->steamTemperature();
-            if (include("steamTimeout", "steam")) result["steamTimeoutSec"] = settings->brew()->steamTimeout();
-            if (include("steamFlow", "steam")) result["steamFlowMlPerSec"] = settings->brew()->steamFlow() / 100.0;
+            if (include("steamTemperature", "steam", "steamTemperatureC")) result["steamTemperatureC"] = settings->brew()->steamTemperature();
+            if (include("steamTimeout", "steam", "steamTimeoutSec")) result["steamTimeoutSec"] = settings->brew()->steamTimeout();
+            if (include("steamFlow", "steam", "steamFlowMlPerSec")) result["steamFlowMlPerSec"] = settings->brew()->steamFlow() / 100.0;
             if (include("steamDisabled", "steam")) result["steamDisabled"] = settings->brew()->steamDisabled();
 
             // === Hot Water ===
-            if (include("waterTemperature", "water")) result["waterTemperatureC"] = settings->brew()->waterTemperature();
-            if (include("waterVolume", "water")) result["waterVolumeMl"] = settings->brew()->waterVolume();
+            if (include("waterTemperature", "water", "waterTemperatureC")) result["waterTemperatureC"] = settings->brew()->waterTemperature();
+            if (include("waterVolume", "water", "waterVolumeMl")) result["waterVolumeMl"] = settings->brew()->waterVolume();
             if (include("waterVolumeMode", "water")) result["waterVolumeMode"] = settings->brew()->waterVolumeMode();
-            if (include("hotWaterFlowRate", "water")) result["hotWaterFlowRateMlPerSec"] = settings->hardware()->hotWaterFlowRate() / 10.0;
+            if (include("hotWaterFlowRate", "water", "hotWaterFlowRateMlPerSec")) result["hotWaterFlowRateMlPerSec"] = settings->hardware()->hotWaterFlowRate() / 10.0;
 
             // === Flush ===
-            if (include("flushFlow", "flush")) result["flushFlowMlPerSec"] = settings->brew()->flushFlow();
+            if (include("flushFlow", "flush", "flushFlowMlPerSec")) result["flushFlowMlPerSec"] = settings->brew()->flushFlow();
             if (include("flushSeconds", "flush")) result["flushSeconds"] = settings->brew()->flushSeconds();
 
             // === DYE (bean/grinder metadata) ===
@@ -257,10 +267,10 @@ void registerSettingsReadTools(McpToolRegistry* registry, Settings* settings,
             // === Heater calibration (stored as tenths internally — divide by 10 to match QML display) ===
             {
                 auto* hw = settings->hardware();
-                if (include("heaterIdleTemp", "heater")) result["heaterIdleTempC"] = hw->heaterIdleTemp() / 10.0;
-                if (include("heaterWarmupFlow", "heater")) result["heaterWarmupFlowMlPerSec"] = hw->heaterWarmupFlow() / 10.0;
-                if (include("heaterTestFlow", "heater")) result["heaterTestFlowMlPerSec"] = hw->heaterTestFlow() / 10.0;
-                if (include("heaterWarmupTimeout", "heater")) result["heaterWarmupTimeoutSec"] = hw->heaterWarmupTimeout() / 10.0;
+                if (include("heaterIdleTemp", "heater", "heaterIdleTempC")) result["heaterIdleTempC"] = hw->heaterIdleTemp() / 10.0;
+                if (include("heaterWarmupFlow", "heater", "heaterWarmupFlowMlPerSec")) result["heaterWarmupFlowMlPerSec"] = hw->heaterWarmupFlow() / 10.0;
+                if (include("heaterTestFlow", "heater", "heaterTestFlowMlPerSec")) result["heaterTestFlowMlPerSec"] = hw->heaterTestFlow() / 10.0;
+                if (include("heaterWarmupTimeout", "heater", "heaterWarmupTimeoutSec")) result["heaterWarmupTimeoutSec"] = hw->heaterWarmupTimeout() / 10.0;
             }
 
             // === Auto-favorites ===


### PR DESCRIPTION
## Summary
- The `keys: [...]` filter on `settings_get` now accepts both the canonical write name and the suffixed read name returned in the response. Previously, asking for `espressoTemperatureC` (the field name the response uses) returned `{}` silently while `espressoTemperature` (the un-suffixed write name) worked.
- The `include()` helper grows an optional `alias` argument; only the ~13 fields where read/write names differ pass an alias.
- Updates MCP_TEST_PLAN.md §5.1a to verify the round-trip.

Closes #985.

## Test plan
- [ ] `settings_get (keys: [\"espressoTemperatureC\"])` returns `{espressoTemperatureC: <number>}`.
- [ ] `settings_get (keys: [\"espressoTemperature\"])` still works (un-suffixed write name).
- [ ] `settings_get (keys: [\"targetWeightG\"])` returns the value.
- [ ] `settings_get (keys: [\"unknownThing\"])` still returns `{}` (unknown-key handling is #986).

🤖 Generated with [Claude Code](https://claude.com/claude-code)