### PR TITLE
fix(mcp): reject unknown keys/categories in settings_get/set (#986)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -304,10 +304,26 @@ Call: settings_get (keys: ["espressoTemperature"])
 Expect: response contains espressoTemperatureC (un-suffixed write name still works).
 ```
 
+### 5.1b settings_get — unknown category / keys reject
+```
+Call: settings_get (category: "preferences")
+Expect: error="Unknown category 'preferences'", validCategories array present.
+Call: settings_get (keys: ["nonexistentKey"])
+Expect: error="Unknown settings key(s)", unknownKeys=["nonexistentKey"].
+Call: settings_get (keys: ["dyeBeanBrand", "typoo"])
+Expect: error, unknownKeys=["typoo"] (mixed valid+invalid is still an error).
+```
+
 ### 5.2 settings_set — DYE metadata
 ```
 Call: settings_set (dyeBeanBrand: "MCP Test Brand", dyeGrinderSetting: "99", confirmed: true)
 Expect: success=true, updated includes "dyeBeanBrand" and "dyeGrinderSetting"
+```
+
+### 5.2a settings_set — unknown key reject
+```
+Call: settings_set (nonexistentKey: 42, confirmed: true)
+Expect: error="Unknown settings key(s)", unknownKeys=["nonexistentKey"]. No setters fire.
 ```
 
 ### 5.3 Cleanup: restore DYE

--- a/src/mcp/mcptools_settings.cpp
+++ b/src/mcp/mcptools_settings.cpp
@@ -20,6 +20,7 @@
 
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QSet>
 
 void registerSettingsReadTools(McpToolRegistry* registry, Settings* settings,
                                AccessibilityManager* accessibility,
@@ -59,6 +60,15 @@ void registerSettingsReadTools(McpToolRegistry* registry, Settings* settings,
             QString category = args["category"].toString();
             bool hasKeys = !keys.isEmpty();
 
+            // Track which keys and categories the iteration considers, so
+            // that requested keys/categories that don't match anything can
+            // be reported as errors rather than returning {} silently
+            // (#986). Typos and outdated category names ("preferences" was
+            // removed in phase 16) are the worst kind of failure mode for
+            // an LLM agent — indistinguishable from "the value is empty."
+            QSet<QString> knownCategories;
+            QSet<QString> matchedKeys;
+
             // If keys are specified, return those regardless of category.
             // If category is specified, return all settings in that category.
             // If neither, return all settings.
@@ -70,11 +80,14 @@ void registerSettingsReadTools(McpToolRegistry* registry, Settings* settings,
             // again must round-trip — see #985.
             auto include = [&](const QString& key, const QString& cat,
                                const QString& alias = QString()) -> bool {
+                knownCategories.insert(cat);
                 if (hasKeys) {
                     for (const auto& k : keys) {
                         const QString s = k.toString();
-                        if (s == key || (!alias.isEmpty() && s == alias))
+                        if (s == key || (!alias.isEmpty() && s == alias)) {
+                            matchedKeys.insert(s);
                             return true;
+                        }
                     }
                     return false;
                 }
@@ -278,6 +291,34 @@ void registerSettingsReadTools(McpToolRegistry* registry, Settings* settings,
             if (include("autoFavoritesMaxItems", "autofavorites")) result["autoFavoritesMaxItems"] = settings->network()->autoFavoritesMaxItems();
             if (include("autoFavoritesOpenBrewSettings", "autofavorites")) result["autoFavoritesOpenBrewSettings"] = settings->network()->autoFavoritesOpenBrewSettings();
             if (include("autoFavoritesHideUnrated", "autofavorites")) result["autoFavoritesHideUnrated"] = settings->network()->autoFavoritesHideUnrated();
+
+            // Reject unknown category. Empty category is "no filter" — fine.
+            if (!category.isEmpty() && !knownCategories.contains(category)) {
+                QStringList sorted = knownCategories.values();
+                sorted.sort();
+                QJsonArray validCategories;
+                for (const QString& c : std::as_const(sorted)) validCategories.append(c);
+                return QJsonObject{
+                    {"error", QString("Unknown category '%1'").arg(category)},
+                    {"validCategories", validCategories}
+                };
+            }
+
+            // Report keys that were requested but matched no known field.
+            // (Empty `keys` array means "all settings" — nothing to validate.)
+            if (hasKeys) {
+                QJsonArray unknown;
+                for (const auto& k : keys) {
+                    const QString s = k.toString();
+                    if (!matchedKeys.contains(s)) unknown.append(s);
+                }
+                if (!unknown.isEmpty()) {
+                    return QJsonObject{
+                        {"error", "Unknown settings key(s)"},
+                        {"unknownKeys", unknown}
+                    };
+                }
+            }
 
             return result;
         },

--- a/src/mcp/mcptools_settings.cpp
+++ b/src/mcp/mcptools_settings.cpp
@@ -66,7 +66,26 @@ void registerSettingsReadTools(McpToolRegistry* registry, Settings* settings,
             // (#986). Typos and outdated category names ("preferences" was
             // removed in phase 16) are the worst kind of failure mode for
             // an LLM agent — indistinguishable from "the value is empty."
-            QSet<QString> knownCategories;
+            //
+            // Pre-seed with the full static category list. The include()
+            // helper also inserts as it iterates, but several categories
+            // ("screensaver", "accessibility", "battery", "language") only
+            // get an include() call from inside null-guarded service blocks
+            // — if the matching service is null at registration time, those
+            // categories would otherwise be falsely reported as unknown.
+            QSet<QString> knownCategories = {
+                QStringLiteral("machine"), QStringLiteral("calibration"),
+                QStringLiteral("connections"), QStringLiteral("screensaver"),
+                QStringLiteral("accessibility"), QStringLiteral("ai"),
+                QStringLiteral("espresso"), QStringLiteral("steam"),
+                QStringLiteral("water"), QStringLiteral("flush"),
+                QStringLiteral("dye"), QStringLiteral("mqtt"),
+                QStringLiteral("themes"), QStringLiteral("visualizer"),
+                QStringLiteral("update"), QStringLiteral("data"),
+                QStringLiteral("history"), QStringLiteral("language"),
+                QStringLiteral("debug"), QStringLiteral("battery"),
+                QStringLiteral("heater"), QStringLiteral("autofavorites")
+            };
             QSet<QString> matchedKeys;
 
             // If keys are specified, return those regardless of category.

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -23,6 +23,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QJsonDocument>
+#include <QSet>
 #include <QSqlDatabase>
 #include <QSqlQuery>
 #include <QThread>
@@ -224,19 +225,13 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
         "settings");
 
     // settings_set
-    registry->registerAsyncTool(
-        "settings_set",
-        "Update any app setting on the device. This is the tool to use when the user asks to change "
-        "grind size (dyeGrinderSetting), dose weight (dyeBeanWeight), drink/yield weight (targetWeight), "
-        "brew temperature (espressoTemperature), or any other setting. "
-        "Covers all QML settings tabs: machine, calibration, connections, screensaver, accessibility, AI, "
-        "espresso, steam, water, flush, DYE metadata, MQTT, themes, visualizer, update, data, "
-        "history, language, debug, battery, heater, auto-favorites. "
-        "API keys and passwords are excluded (sensitive). "
-        "For temperature and weight changes on the active profile, this tool handles the profile update automatically. "
-        "IMPORTANT: Only call this when the user explicitly asks to change settings on the machine. "
-        "For discussion and recommendations, respond in chat instead.",
-        QJsonObject{
+    //
+    // Schema is built into a local variable so the property names can be
+    // extracted into validSettingsKeys (one pass at registration time).
+    // The lambda then rejects any args key that's not in the schema instead
+    // of silently ignoring it (#986). Without this, typos like
+    // `setings_set(dyeBenBrand: ...)` succeed with `{updated: []}` errors.
+    QJsonObject settingsSetSchema = QJsonObject{
             {"type", "object"},
             {"properties", QJsonObject{
                 // Espresso / profile
@@ -381,10 +376,45 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 // Confirmation
                 {"confirmed", QJsonObject{{"type", "boolean"}, {"description", "Set to true after user confirms this action in chat"}}}
             }}
-        },
-        [profileManager, settings, accessibility, screensaver, translation, battery](const QJsonObject& args, std::function<void(QJsonObject)> respond) {
+        };
+    QSet<QString> validSettingsKeys;
+    {
+        const QJsonObject props = settingsSetSchema.value("properties").toObject();
+        for (auto it = props.constBegin(); it != props.constEnd(); ++it)
+            validSettingsKeys.insert(it.key());
+    }
+    registry->registerAsyncTool(
+        "settings_set",
+        "Update any app setting on the device. This is the tool to use when the user asks to change "
+        "grind size (dyeGrinderSetting), dose weight (dyeBeanWeight), drink/yield weight (targetWeight), "
+        "brew temperature (espressoTemperature), or any other setting. "
+        "Covers all QML settings tabs: machine, calibration, connections, screensaver, accessibility, AI, "
+        "espresso, steam, water, flush, DYE metadata, MQTT, themes, visualizer, update, data, "
+        "history, language, debug, battery, heater, auto-favorites. "
+        "API keys and passwords are excluded (sensitive). "
+        "For temperature and weight changes on the active profile, this tool handles the profile update automatically. "
+        "IMPORTANT: Only call this when the user explicitly asks to change settings on the machine. "
+        "For discussion and recommendations, respond in chat instead.",
+        settingsSetSchema,
+        [profileManager, settings, accessibility, screensaver, translation, battery, validSettingsKeys](const QJsonObject& args, std::function<void(QJsonObject)> respond) {
             if (!settings) {
                 respond(QJsonObject{{"error", "Settings not available"}});
+                return;
+            }
+
+            // Reject unknown keys before applying any setters. Catches typos
+            // and outdated names that would otherwise return {updated: []}
+            // and look like a server-side problem to an LLM.
+            QStringList unknownKeys;
+            for (auto it = args.constBegin(); it != args.constEnd(); ++it) {
+                if (!validSettingsKeys.contains(it.key()))
+                    unknownKeys.append(it.key());
+            }
+            if (!unknownKeys.isEmpty()) {
+                respond(QJsonObject{
+                    {"error", "Unknown settings key(s)"},
+                    {"unknownKeys", QJsonArray::fromStringList(unknownKeys)}
+                });
                 return;
             }
 


### PR DESCRIPTION
## Summary
- `settings_get` rejects unknown `category` values (e.g. `preferences`, removed in phase 16) and any `keys` entries that don't match a known field. Previous behavior was silent `{}`.
- `settings_set` extracts the schema property names into a `validSettingsKeys` set at registration time and rejects any args key that's not in it. Previous behavior was silent `{updated: []}`.
- Schema declaration for `settings_set` was hoisted into a local `settingsSetSchema` variable; no schema content changed.
- MCP_TEST_PLAN.md §5.1b/§5.2a cover the reject paths.

Closes #986.

## Test plan
- [ ] `settings_get (category: \"preferences\")` returns `error` + `validCategories` array.
- [ ] `settings_get (keys: [\"nonexistentKey\"])` returns `error` + `unknownKeys`.
- [ ] `settings_get (keys: [\"espressoTemperatureC\", \"typoo\"])` returns `error` listing only `typoo` (still rejects when mixed).
- [ ] `settings_set (nonexistentKey: 42, confirmed: true)` returns `error` + `unknownKeys`. No real setting changes.
- [ ] `settings_set (dyeBeanBrand: \"X\", confirmed: true)` still succeeds (regression check).
- [ ] `settings_get` (no args) still returns the full settings dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)