### PR TITLE
feat(mcp): add filtering to profiles_list (#989)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -95,8 +95,19 @@ On real headless DE1:
 ### 3.1 profiles_list
 ```
 Call: profiles_list
-Expect: count > 0, each profile has filename, title, editorType
+Expect: count > 0, each profile has filename, title, editorType, readOnly, category
+        (category is the title's slash prefix or null for espresso recipes).
 Verify: editorType values include at least "pressure", "flow", "dflow", "aflow", "advanced"
+```
+
+### 3.1a profiles_list — filtered
+```
+Call: profiles_list (editorType: "dflow")
+Expect: every returned profile has editorType="dflow", count smaller than unfiltered.
+Call: profiles_list (excludeCategories: ["Tea", "Cleaning", "Pour over basket", "Test", "Visualizer"])
+Expect: count is the espresso-only subset (significantly smaller than unfiltered).
+Call: profiles_list (nameContains: "espresso", readOnly: false)
+Expect: only user-writable profiles whose title or filename contains "espresso".
 ```
 
 ### 3.2 profiles_get_active

--- a/src/mcp/mcptools_profiles.cpp
+++ b/src/mcp/mcptools_profiles.cpp
@@ -12,34 +12,88 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QJsonDocument>
+#include <QSet>
 
 void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileManager)
 {
     // profiles_list
     registry->registerTool(
         "profiles_list",
-        "List all available profiles with their names and filenames",
-        QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
-        [profileManager](const QJsonObject&) -> QJsonObject {
+        "List available profiles with optional filters. Returns filename, title, editorType, "
+        "readOnly, and category (parsed from the title's slash prefix — Tea, Cleaning, "
+        "Pour over basket, Test, Visualizer, or null for espresso recipes).",
+        QJsonObject{
+            {"type", "object"},
+            {"properties", QJsonObject{
+                {"editorType", QJsonObject{
+                    {"type", "string"},
+                    {"enum", QJsonArray{"pressure", "flow", "dflow", "aflow", "advanced"}},
+                    {"description", "Filter by editor type."}
+                }},
+                {"nameContains", QJsonObject{
+                    {"type", "string"},
+                    {"description", "Substring match against title or filename (case-insensitive)."}
+                }},
+                {"excludeCategories", QJsonObject{
+                    {"type", "array"},
+                    {"items", QJsonObject{{"type", "string"}}},
+                    {"description", "Title-prefix categories to skip, e.g. [\"Tea\", \"Cleaning\", \"Pour over basket\", \"Test\", \"Visualizer\"]."}
+                }},
+                {"readOnly", QJsonObject{
+                    {"type", "boolean"},
+                    {"description", "true: only built-in (read-only) profiles. false: only user-writable."}
+                }}
+            }}
+        },
+        [profileManager](const QJsonObject& args) -> QJsonObject {
             QJsonObject result;
             if (!profileManager) return result;
+
+            const QString editorTypeFilter = args.value("editorType").toString();
+            const QString nameContains = args.value("nameContains").toString().toLower();
+            const QJsonArray excludeArr = args.value("excludeCategories").toArray();
+            QSet<QString> excludeCategories;
+            for (const auto& v : excludeArr) excludeCategories.insert(v.toString());
+            const bool hasReadOnlyFilter = args.contains("readOnly");
+            const bool readOnlyFilter = args.value("readOnly").toBool();
+
+            // Derive the slash-prefix category from the title. Profiles
+            // titled "Tea/Some Variant" map to category "Tea"; titles
+            // without a slash get null (treated as Espresso recipes).
+            auto categoryOf = [](const QString& title) -> QString {
+                const int slash = title.indexOf('/');
+                return slash > 0 ? title.left(slash) : QString();
+            };
 
             QJsonArray profiles;
             QJsonArray links;
             QVariantList all = profileManager->availableProfiles();
             for (const QVariant& v : all) {
                 QVariantMap pm = v.toMap();
-                QJsonObject p;
                 const QString filename = pm["name"].toString();
+                const QString title = pm["title"].toString();
+                const QString editorType = pm["editorType"].toString();
+                const bool readOnly = pm["readOnly"].toBool();
+                const QString category = categoryOf(title);
+
+                if (!editorTypeFilter.isEmpty() && editorType != editorTypeFilter) continue;
+                if (!nameContains.isEmpty() &&
+                    !title.toLower().contains(nameContains) &&
+                    !filename.toLower().contains(nameContains)) continue;
+                if (!excludeCategories.isEmpty() && excludeCategories.contains(category)) continue;
+                if (hasReadOnlyFilter && readOnly != readOnlyFilter) continue;
+
+                QJsonObject p;
                 p["filename"] = filename;
-                p["title"] = pm["title"].toString();
-                p["editorType"] = pm["editorType"].toString();
-                p["readOnly"] = pm["readOnly"].toBool();
+                p["title"] = title;
+                p["editorType"] = editorType;
+                p["readOnly"] = readOnly;
+                p["category"] = category.isEmpty() ? QJsonValue(QJsonValue::Null) : QJsonValue(category);
                 profiles.append(p);
 
                 QJsonObject link;
                 link["uri"] = QStringLiteral("decenza://profiles/") + filename;
-                link["title"] = pm["title"].toString();
+                link["title"] = title;
                 link["mimeType"] = "application/json";
                 links.append(link);
             }

--- a/src/mcp/mcptools_profiles.cpp
+++ b/src/mcp/mcptools_profiles.cpp
@@ -52,8 +52,11 @@ void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileMana
             const QString editorTypeFilter = args.value("editorType").toString();
             const QString nameContains = args.value("nameContains").toString().toLower();
             const QJsonArray excludeArr = args.value("excludeCategories").toArray();
-            QSet<QString> excludeCategories;
-            for (const auto& v : excludeArr) excludeCategories.insert(v.toString());
+            // Lowercase exclusion set so "tea"/"Tea"/"TEA" all match — LLMs
+            // don't always reproduce capitalization from documented examples
+            // verbatim, and the cost of a permissive match here is nil.
+            QSet<QString> excludeCategoriesLower;
+            for (const auto& v : excludeArr) excludeCategoriesLower.insert(v.toString().toLower());
             const bool hasReadOnlyFilter = args.contains("readOnly");
             const bool readOnlyFilter = args.value("readOnly").toBool();
 
@@ -62,7 +65,11 @@ void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileMana
             // without a slash get null (treated as Espresso recipes).
             auto categoryOf = [](const QString& title) -> QString {
                 const int slash = title.indexOf('/');
-                return slash > 0 ? title.left(slash) : QString();
+                // Built-in profile titles use "Foo / Bar" with whitespace
+                // around the slash ("D-Flow / default", "A-Flow / ...",
+                // also produced by profiles_create), so trim to keep
+                // callers matching bare "Tea", "D-Flow", etc.
+                return slash > 0 ? title.left(slash).trimmed() : QString();
             };
 
             QJsonArray profiles;
@@ -80,7 +87,7 @@ void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileMana
                 if (!nameContains.isEmpty() &&
                     !title.toLower().contains(nameContains) &&
                     !filename.toLower().contains(nameContains)) continue;
-                if (!excludeCategories.isEmpty() && excludeCategories.contains(category)) continue;
+                if (!excludeCategoriesLower.isEmpty() && excludeCategoriesLower.contains(category.toLower())) continue;
                 if (hasReadOnlyFilter && readOnly != readOnlyFilter) continue;
 
                 QJsonObject p;


### PR DESCRIPTION
## Summary
Adds four optional filter params and a derived \`category\` field to \`profiles_list\` so AI agents picking or comparing espresso profiles don't have to scan past the ~40 tea / cleaning / pour-over / test / visualizer entries every call.

- \`editorType\`: pressure | flow | dflow | aflow | advanced
- \`nameContains\`: case-insensitive substring against title or filename
- \`excludeCategories\`: title-prefix categories to skip
- \`readOnly\`: filter built-ins vs user-writable

Each profile entry also gets a \`category\` field parsed from the title's slash prefix (\`Tea\`, \`Cleaning\`, \`Pour over basket\`, \`Test\`, \`Visualizer\`, or null for espresso recipes) — making the existing categorization machine-readable.

No filter args returns the full list (backward compatible).

Closes #989.

## Test plan
- [ ] \`profiles_list\` (no args) still returns the full list, plus a \`category\` field per entry.
- [ ] \`profiles_list (editorType: \"dflow\")\` returns only D-Flow profiles.
- [ ] \`profiles_list (excludeCategories: [\"Tea\", \"Cleaning\", \"Pour over basket\", \"Test\", \"Visualizer\"])\` returns the espresso subset only.
- [ ] \`profiles_list (nameContains: \"espresso\", readOnly: false)\` returns only user-writable matches.
- [ ] \`profiles_list (readOnly: true)\` returns only built-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)