### PR TITLE
fix(mcp): dedupe phase, split platform info from machine_get_state (#988)

### DIFF
--- a/docs/CLAUDE_MD/MCP_SERVER.md
+++ b/docs/CLAUDE_MD/MCP_SERVER.md
@@ -86,7 +86,7 @@ Each tool has a `category` that determines the minimum access level required:
 
 | Category | Min Access Level | Tools |
 |----------|-----------------|-------|
-| `read` | 0 (Monitor) | machine_get_state, machine_get_telemetry, shots_list, shots_get_detail, shots_get_debug_log, shots_compare, profiles_list, profiles_get_active, profiles_get_detail, profiles_get_params, settings_get, dialing_get_context |
+| `read` | 0 (Monitor) | machine_get_state, app_get_info, machine_get_telemetry, shots_list, shots_get_detail, shots_get_debug_log, shots_compare, profiles_list, profiles_get_active, profiles_get_detail, profiles_get_params, settings_get, dialing_get_context |
 | `control` | 1 (Control) | machine_wake, machine_sleep, machine_start_espresso, machine_start_steam, machine_start_hot_water, machine_start_flush, machine_stop, machine_skip_frame, shots_update, backup_now, mqtt_connect, mqtt_disconnect, mqtt_publish_discovery, devices_connect_de1, devices_disconnect_scale |
 | `settings` | 2 (Full) | profiles_set_active, profiles_edit_params, profiles_save, profiles_delete, profiles_create, shots_delete, settings_set, reset_saw_learning, clear_flow_calibration, apply_theme |
 
@@ -162,7 +162,8 @@ This avoids holding HTTP connections and works naturally with the conversational
 ### Machine State
 | Tool | Description | Category |
 |------|-------------|----------|
-| `machine_get_state` | Phase, connection, readiness, heating status, water level (ml + mm), firmware version, active profile name | read |
+| `machine_get_state` | Phase, connection, readiness, heating status, water level (ml + mm), firmware version, active profile name. Platform/OS info has moved to `app_get_info` (#988) to keep tight polling responses small. | read |
+| `app_get_info` | App and device info: appVersion, qtVersion, OS, kernel, architecture, deviceModel, screen size/DPI, devicePixelRatio. Diagnostics-grade — call once per session. | read |
 | `machine_get_telemetry` | Live pressure, flow, temp, weight, goal values. During a shot, also returns the current shot's time-series data so far (not just the latest sample) so the AI can detect channeling or stalling mid-shot. | read |
 | `steam_get_health` | Detailed steam-system health: baseline + current pressure/temperature, flow-restriction progress toward warn thresholds, status, and recommendation. Used for steam-wand cleaning / descaling guidance. | read |
 

--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -43,7 +43,16 @@ If ORIGINAL_MODIFIED is true, warn the user — tests will modify the profile an
 ### 1.1 machine_get_state
 ```
 Call: machine_get_state
-Expect: phase exists, connected=true, waterLevelMl > 0, firmwareVersion non-empty, activeProfile non-empty
+Expect: phase exists, connected=true, waterLevelMl > 0, firmwareVersion non-empty, activeProfile non-empty.
+        No `stateString` field (deprecated — use `phase`).
+        No `platform` block (moved to app_get_info).
+```
+
+### 1.1a app_get_info
+```
+Call: app_get_info
+Expect: appVersion, qtVersion, os, osType, osVersion, kernelType, architecture,
+        deviceModel, screen* fields all present. Used once per session for diagnostics.
 ```
 
 ### 1.2 machine_get_telemetry

--- a/src/mcp/mcptools_machine.cpp
+++ b/src/mcp/mcptools_machine.cpp
@@ -105,7 +105,11 @@ void registerMachineTools(McpToolRegistry* registry, DE1Device* device,
     // machine_get_state
     registry->registerTool(
         "machine_get_state",
-        "Get current machine state: phase, connection status, readiness, heating, water level, firmware version, and platform/OS info (Android SDK version, device model, screen size)",
+        "Get current machine state: phase, connection status, readiness, heating, water level, "
+        "firmware version, and live shot scalars. `phase` is the canonical state field — one of "
+        "Disconnected | Sleep | Idle | Heating | Ready | EspressoPreheating | Preinfusion | "
+        "Pouring | Ending | Steaming | HotWater | Flushing | Refill | Descaling | Cleaning. "
+        "Platform/OS info has moved to app_get_info to keep poll responses small.",
         QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
         [device, machineState, profileManager, mainController](const QJsonObject&) -> QJsonObject {
             QJsonObject result;
@@ -127,7 +131,6 @@ void registerMachineTools(McpToolRegistry* registry, DE1Device* device,
             }
             if (device) {
                 result["connected"] = device->isConnected();
-                result["stateString"] = device->stateString();
                 result["waterLevelMl"] = device->waterLevelMl();
                 result["waterLevelMm"] = device->waterLevelMm();
                 result["firmwareVersion"] = device->firmwareVersion();
@@ -136,45 +139,6 @@ void registerMachineTools(McpToolRegistry* registry, DE1Device* device,
                 result["temperatureC"] = device->temperature();
                 result["steamTemperatureC"] = device->steamTemperature();
             }
-
-            // Platform / OS info
-            QJsonObject platform;
-            platform["appVersion"] = QString(VERSION_STRING);
-            platform["qtVersion"] = QString(qVersion());
-            platform["os"] = QSysInfo::prettyProductName().simplified();
-            platform["osType"] = QSysInfo::productType();
-            platform["osVersion"] = QSysInfo::productVersion();
-            platform["kernelType"] = QSysInfo::kernelType();
-            platform["kernelVersion"] = QSysInfo::kernelVersion();
-            platform["architecture"] = QSysInfo::currentCpuArchitecture();
-            platform["deviceModel"] = QSysInfo::machineHostName();
-#ifdef Q_OS_ANDROID
-            // Android SDK version (API level)
-            platform["androidSdkVersion"] = QJniObject::getStaticField<jint>(
-                "android/os/Build$VERSION", "SDK_INT");
-            QJniObject model = QJniObject::getStaticObjectField<jstring>(
-                "android/os/Build", "MODEL");
-            if (model.isValid())
-                platform["deviceModel"] = model.toString();
-            QJniObject manufacturer = QJniObject::getStaticObjectField<jstring>(
-                "android/os/Build", "MANUFACTURER");
-            if (manufacturer.isValid())
-                platform["manufacturer"] = manufacturer.toString();
-#endif
-#ifdef Q_OS_IOS
-            platform["osType"] = "ios";
-#endif
-            // Screen info
-            if (auto* screen = QGuiApplication::primaryScreen()) {
-                platform["screenSize"] = QString("%1x%2")
-                    .arg(screen->size().width()).arg(screen->size().height());
-                platform["screenPhysicalSize"] = QString("%1x%2")
-                    .arg(screen->physicalSize().width(), 0, 'f', 1)
-                    .arg(screen->physicalSize().height(), 0, 'f', 1);
-                platform["screenDpi"] = screen->physicalDotsPerInch();
-                platform["devicePixelRatio"] = screen->devicePixelRatio();
-            }
-            result["platform"] = platform;
 
             // Per MCP 2025-06-18: link the result to the canonical resource so
             // subscribing clients see updates flow through decenza://machine/state.
@@ -199,6 +163,54 @@ void registerMachineTools(McpToolRegistry* registry, DE1Device* device,
             }
 
             return result;
+        },
+        "read");
+
+    // app_get_info — diagnostics block previously embedded in machine_get_state.
+    // Split out so tight polling loops (monitoring a shot) don't re-ship ~10
+    // unchanging fields per response (#988).
+    registry->registerTool(
+        "app_get_info",
+        "Get app and device info: appVersion, qtVersion, OS, kernel, architecture, "
+        "deviceModel, screen size/DPI, devicePixelRatio. Diagnostics-grade — call once "
+        "per session, not every poll. machine_get_state used to embed this block.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
+        [](const QJsonObject&) -> QJsonObject {
+            QJsonObject platform;
+            platform["appVersion"] = QString(VERSION_STRING);
+            platform["qtVersion"] = QString(qVersion());
+            platform["os"] = QSysInfo::prettyProductName().simplified();
+            platform["osType"] = QSysInfo::productType();
+            platform["osVersion"] = QSysInfo::productVersion();
+            platform["kernelType"] = QSysInfo::kernelType();
+            platform["kernelVersion"] = QSysInfo::kernelVersion();
+            platform["architecture"] = QSysInfo::currentCpuArchitecture();
+            platform["deviceModel"] = QSysInfo::machineHostName();
+#ifdef Q_OS_ANDROID
+            platform["androidSdkVersion"] = QJniObject::getStaticField<jint>(
+                "android/os/Build$VERSION", "SDK_INT");
+            QJniObject model = QJniObject::getStaticObjectField<jstring>(
+                "android/os/Build", "MODEL");
+            if (model.isValid())
+                platform["deviceModel"] = model.toString();
+            QJniObject manufacturer = QJniObject::getStaticObjectField<jstring>(
+                "android/os/Build", "MANUFACTURER");
+            if (manufacturer.isValid())
+                platform["manufacturer"] = manufacturer.toString();
+#endif
+#ifdef Q_OS_IOS
+            platform["osType"] = "ios";
+#endif
+            if (auto* screen = QGuiApplication::primaryScreen()) {
+                platform["screenSize"] = QString("%1x%2")
+                    .arg(screen->size().width()).arg(screen->size().height());
+                platform["screenPhysicalSize"] = QString("%1x%2")
+                    .arg(screen->physicalSize().width(), 0, 'f', 1)
+                    .arg(screen->physicalSize().height(), 0, 'f', 1);
+                platform["screenDpi"] = screen->physicalDotsPerInch();
+                platform["devicePixelRatio"] = screen->devicePixelRatio();
+            }
+            return platform;
         },
         "read");
 


### PR DESCRIPTION
## Summary
Two AI-friendliness fixes for \`machine_get_state\`:

1. **Drop \`stateString\`.** The response previously emitted both \`phase\` (\"Ready\") and \`stateString\` (\"Idle\") from different sources; AI agents had no way to know which was canonical. \`phase\` is the QML enum and the documented one — keep that, drop \`stateString\`.

2. **Move platform info to a new \`app_get_info\` tool.** The ~10-field \`platform\` block (appVersion, qtVersion, OS, screen dimensions, etc.) is useful once per session for diagnostics, pure overhead in tight polling loops monitoring a shot.

\`machine_get_state\` still carries \`firmwareVersion\` and \`activeProfile\` — those are machine state, not platform info.

Closes #988.

## Test plan
- [ ] \`machine_get_state\` returns \`phase\` but not \`stateString\` and not \`platform\`.
- [ ] \`machine_get_state\` still returns \`firmwareVersion\`, \`activeProfile\`, all the live shot scalars.
- [ ] \`app_get_info\` returns the platform block (appVersion, qtVersion, deviceModel, screen*, etc.).
- [ ] On Android, \`app_get_info\` returns \`androidSdkVersion\`, \`manufacturer\`.
- [ ] On iOS, \`app_get_info\` returns \`osType: \"ios\"\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)