### PR TITLE
fix(mcp): add suffixed aliases to profiles_get_params (#992)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -121,7 +121,8 @@ Call: profiles_get_params
 Expect: editorType="pressure"
 Expect present: espressoPressure, pressureEnd, preinfusionTime, holdTime, simpleDeclineTime, tempStart, tempHold, limiterValue
 Expect also present (suffixed aliases per #992): espressoPressureBar, pressureEndBar,
-        preinfusionTimeSec, holdTimeSec, simpleDeclineTimeSec, tempStartC, tempHoldC.
+        preinfusionStopPressureBar, preinfusionTimeSec, holdTimeSec, simpleDeclineTimeSec,
+        tempStartC, tempHoldC.
         Each alias has the same value as its un-suffixed sibling — both forms round-trip.
 Expect absent: fillTemperature, pourFlow, rampTime, steps
 ```
@@ -132,6 +133,8 @@ Call: profiles_set_active (filename: "flow_profile_for_straight_espresso", confi
 Call: profiles_get_params
 Expect: editorType="flow"
 Expect present: holdFlow, flowEnd, preinfusionTime, holdTime, simpleDeclineTime, tempStart, limiterValue
+Expect also present (suffixed aliases per #992): holdFlowMlPerSec, flowEndMlPerSec,
+        preinfusionTimeSec, holdTimeSec, simpleDeclineTimeSec, tempStartC.
 Expect absent: espressoPressure, pressureEnd, fillTemperature, pourFlow, rampTime, steps
 ```
 
@@ -141,6 +144,9 @@ Call: profiles_set_active (filename: "d_flow_q", confirmed: true)
 Call: profiles_get_params
 Expect: editorType="dflow"
 Expect present: fillTemperature, fillPressure, fillFlow, infusePressure, infuseTime, pourTemperature, pourFlow, pourPressure
+Expect also present (suffixed aliases per #992): fillTemperatureC, fillPressureBar,
+        fillFlowMlPerSec, infusePressureBar, infuseTimeSec, pourTemperatureC,
+        pourFlowMlPerSec, pourPressureBar.
 Expect absent: preinfusionTime, espressoPressure, holdFlow, rampTime, steps
 ```
 
@@ -150,6 +156,7 @@ Call: profiles_set_active (filename: "a_flow_default_medium", confirmed: true)
 Call: profiles_get_params
 Expect: editorType="aflow"
 Expect present: (all dflow fields) + rampTime, rampDownEnabled, flowExtractionUp, secondFillEnabled
+Expect also present (suffixed aliases per #992): rampTimeSec, plus all dflow aliases above.
 Expect absent: preinfusionTime, espressoPressure, steps
 ```
 

--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -120,6 +120,9 @@ Call: profiles_set_active (filename: "default", confirmed: true)
 Call: profiles_get_params
 Expect: editorType="pressure"
 Expect present: espressoPressure, pressureEnd, preinfusionTime, holdTime, simpleDeclineTime, tempStart, tempHold, limiterValue
+Expect also present (suffixed aliases per #992): espressoPressureBar, pressureEndBar,
+        preinfusionTimeSec, holdTimeSec, simpleDeclineTimeSec, tempStartC, tempHoldC.
+        Each alias has the same value as its un-suffixed sibling — both forms round-trip.
 Expect absent: fillTemperature, pourFlow, rampTime, steps
 ```
 

--- a/src/mcp/mcptools_profiles.cpp
+++ b/src/mcp/mcptools_profiles.cpp
@@ -228,6 +228,7 @@ void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileMana
                 {"pourPressure", "pourPressureBar"},
                 {"espressoPressure", "espressoPressureBar"},
                 {"pressureEnd", "pressureEndBar"},
+                {"preinfusionStopPressure", "preinfusionStopPressureBar"},
                 // mL/s
                 {"fillFlow", "fillFlowMlPerSec"},
                 {"pourFlow", "pourFlowMlPerSec"},

--- a/src/mcp/mcptools_profiles.cpp
+++ b/src/mcp/mcptools_profiles.cpp
@@ -209,6 +209,52 @@ void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileMana
                 }
             }
 
+            // Per #992: also emit unit/scale-suffixed aliases so AI agents
+            // see the same convention as profiles_get_active and other read
+            // tools (per CLAUDE.md MCP convention). The un-suffixed names
+            // are kept because they are also the write keys for
+            // profiles_edit_params — both forms now round-trip.
+            static const QPair<const char*, const char*> suffixAliases[] = {
+                // °C
+                {"tempStart", "tempStartC"},
+                {"tempPreinfuse", "tempPreinfuseC"},
+                {"tempHold", "tempHoldC"},
+                {"tempDecline", "tempDeclineC"},
+                {"fillTemperature", "fillTemperatureC"},
+                {"pourTemperature", "pourTemperatureC"},
+                // bar
+                {"fillPressure", "fillPressureBar"},
+                {"infusePressure", "infusePressureBar"},
+                {"pourPressure", "pourPressureBar"},
+                {"espressoPressure", "espressoPressureBar"},
+                {"pressureEnd", "pressureEndBar"},
+                // mL/s
+                {"fillFlow", "fillFlowMlPerSec"},
+                {"pourFlow", "pourFlowMlPerSec"},
+                {"holdFlow", "holdFlowMlPerSec"},
+                {"flowEnd", "flowEndMlPerSec"},
+                {"preinfusionFlowRate", "preinfusionFlowRateMlPerSec"},
+                // s
+                {"fillTimeout", "fillTimeoutSec"},
+                {"infuseTime", "infuseTimeSec"},
+                {"preinfusionTime", "preinfusionTimeSec"},
+                {"holdTime", "holdTimeSec"},
+                {"simpleDeclineTime", "simpleDeclineTimeSec"},
+                {"rampTime", "rampTimeSec"},
+                // g
+                {"infuseWeight", "infuseWeightG"},
+                {"targetWeight", "targetWeightG"},
+                {"dose", "doseG"},
+                // mL
+                {"infuseVolume", "infuseVolumeMl"},
+                {"targetVolume", "targetVolumeMl"},
+            };
+            for (const auto& pair : suffixAliases) {
+                const QString src = QString::fromLatin1(pair.first);
+                if (result.contains(src))
+                    result[QString::fromLatin1(pair.second)] = result.value(src);
+            }
+
             return result;
         },
         "read");


### PR DESCRIPTION
## Summary
\`profiles_get_active\` emits unit/scale-suffixed names (\`targetWeightG\`, \`targetTemperatureC\`) per the CLAUDE.md MCP convention, while \`profiles_get_params\` returned un-suffixed names because those double as \`profiles_edit_params\` write keys. AI agents reading both tools had to learn two vocabularies.

This PR takes option A from the issue: add suffixed aliases to the \`profiles_get_params\` response for every field that has a unit/scale. Both names round-trip; the un-suffixed forms remain for backward compat with existing write keys.

Affected fields:
- °C: tempStart[C], tempPreinfuse[C], tempHold[C], tempDecline[C], fillTemperature[C], pourTemperature[C]
- bar: fillPressure[Bar], infusePressure[Bar], pourPressure[Bar], espressoPressure[Bar], pressureEnd[Bar]
- mL/s: fillFlow[MlPerSec], pourFlow[MlPerSec], holdFlow[MlPerSec], flowEnd[MlPerSec], preinfusionFlowRate[MlPerSec]
- s: fillTimeout[Sec], infuseTime[Sec], preinfusionTime[Sec], holdTime[Sec], simpleDeclineTime[Sec], rampTime[Sec]
- g: infuseWeight[G], targetWeight[G], dose[G]
- mL: infuseVolume[Ml], targetVolume[Ml]

Closes #992.

## Test plan
- [ ] \`profiles_get_params\` on a pressure profile returns both \`tempStart\` and \`tempStartC\` with the same value, both \`espressoPressure\` and \`espressoPressureBar\`, etc.
- [ ] \`profiles_get_params\` on an aflow profile returns \`rampTime\` and \`rampTimeSec\`.
- [ ] \`profiles_get_params\` on an advanced profile is unchanged (advanced returns the raw frame data; aliases only apply to recipe params).
- [ ] \`profiles_edit_params (tempStart: 92, ...)\` still works (un-suffixed write keys preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)