### PR TITLE
fix(mcp): trim dialing_get_context profileKnowledge by default (#987)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -400,8 +400,19 @@ Expect: error — tool not found (replaced by shots_update in phase 15)
 ### 7.1 dialing_get_context
 ```
 Call: dialing_get_context (history_limit: 2)
-Expect: shotId > 0, shot object present, currentBean present, currentProfile present
-Expect: profileKnowledge non-empty (if profile has knowledge base)
+Expect: shotId > 0, shot object present, currentBean present, currentProfile present.
+        profileKnowledge non-empty (if the profile has a KB entry) — small (~1 KB):
+        only the current profile's curated section. No system prompt / reference
+        tables / cross-profile catalog (per #987).
+```
+
+### 7.1a dialing_get_context — full knowledge
+```
+Call: dialing_get_context (history_limit: 2, includeFullKnowledge: true)
+Expect: profileKnowledge ~18 KB — includes the dial-in system prompt, espresso
+        reference tables, profile catalog, and the current profile's section.
+        Use this on the first turn of a dial-in conversation; subsequent turns can
+        rely on the default (small) form.
 ```
 
 ### 7.2 settings_set — DYE metadata (replaces dialing_apply_change)

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -923,7 +923,6 @@ void ShotSummarizer::loadProfileKnowledge()
         qWarning() << "ShotSummarizer: Failed to load profile knowledge resource";
         return;
     }
-    s_knowledgeLoaded = true;
 
     QString content = QTextStream(&file).readAll();
     file.close();
@@ -995,6 +994,13 @@ void ShotSummarizer::loadProfileKnowledge()
              << "profile knowledge entries";
 
     buildProfileCatalog();
+
+    // Mark loaded only after parse + catalog build complete. The
+    // double-checked-locking pattern at the top of this function depends
+    // on the flag indicating "data ready to read", not "we got far enough
+    // to open the file". Setting it earlier let a second thread that won
+    // the outer race read an empty s_profileKnowledge.
+    s_knowledgeLoaded = true;
 }
 
 void ShotSummarizer::buildProfileCatalog()

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -1137,6 +1137,15 @@ QString ShotSummarizer::findProfileSection(const QString& profileTitle, const QS
     return QString();
 }
 
+QString ShotSummarizer::profileKnowledgeForKbId(const QString& profileKbId)
+{
+    if (profileKbId.isEmpty()) return QString();
+    loadProfileKnowledge();
+    if (s_profileKnowledge.contains(profileKbId))
+        return s_profileKnowledge.value(profileKbId).content;
+    return QString();
+}
+
 QStringList ShotSummarizer::getAnalysisFlags(const QString& kbId)
 {
     if (kbId.isEmpty()) return {};

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -151,6 +151,12 @@ public:
     // Get the knowledge base content for a profile by title/type. Returns empty string if no match.
     static QString findProfileSection(const QString& profileTitle, const QString& profileType = QString());
 
+    // Direct KB lookup by ID — bypasses fuzzy title matching. Returns empty string
+    // if the ID isn't in the knowledge base. Used by MCP to ship just the current
+    // profile's KB entry without the surrounding system prompt + reference tables
+    // + cross-profile catalog (#987).
+    static QString profileKnowledgeForKbId(const QString& profileKbId);
+
     // Get structured analysis flags for a KB entry by its ID.
     // Returns empty list if kbId is not found. Flags are parsed from "AnalysisFlags:" lines
     // in profile_knowledge.md and control which checks analyzeShot() suppresses.

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -222,14 +222,24 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     // conversation. See #987.
                     QString profileTitle = sd.profileName;
                     QString bevType = sd.beverageType.isEmpty() ? QStringLiteral("espresso") : sd.beverageType;
+                    // Extract the editor type from the embedded profile JSON
+                    // so the fuzzy-match fallback can find a section for
+                    // custom-titled D-Flow / A-Flow profiles whose stored
+                    // profileKbId is stale or absent. Without this, the
+                    // fallback only matches on title alone.
+                    QString profileType;
+                    if (!sd.profileJson.isEmpty()) {
+                        const QJsonObject pj = QJsonDocument::fromJson(sd.profileJson.toUtf8()).object();
+                        profileType = pj.value("type").toString();
+                    }
                     QString profileKnowledge;
                     if (includeFullKnowledge) {
                         profileKnowledge = ShotSummarizer::shotAnalysisSystemPrompt(
-                            bevType, profileTitle, QString(), dbResult.profileKbId);
+                            bevType, profileTitle, profileType, dbResult.profileKbId);
                     } else {
                         profileKnowledge = ShotSummarizer::profileKnowledgeForKbId(dbResult.profileKbId);
                         if (profileKnowledge.isEmpty())
-                            profileKnowledge = ShotSummarizer::findProfileSection(profileTitle, QString());
+                            profileKnowledge = ShotSummarizer::findProfileSection(profileTitle, profileType);
                     }
                     if (!profileKnowledge.isEmpty())
                         result["profileKnowledge"] = profileKnowledge;

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -37,19 +37,23 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
     // dialing_get_context
     registry->registerAsyncTool(
         "dialing_get_context",
-        "Get full dial-in context: recent shot summary, dial-in history (last N shots with same profile), "
-        "profile knowledge (includes system prompt, dial-in reference tables, profile catalog with cross-profile recommendation guidance, and profile-specific KB), "
-        "bean/grinder metadata, and grinder context (observed settings range, step size, and burr-swappable flag). "
-        "This is the primary read tool for dial-in conversations — a single call gives "
-        "everything needed to analyze a shot and suggest changes. Grinder settings are shown as the user "
-        "entered them — may be numbers, letters, click counts, or grinder-specific notation like Eureka "
-        "multi-turn (1+4 = 1 rotation + position 4). The grinderContext block shows the range and step "
-        "size observed in the user's own shot history.",
+        "Get dial-in context: recent shot summary, dial-in history (last N shots with same profile), "
+        "profile knowledge for the current shot's profile, bean/grinder metadata, and grinder context "
+        "(observed settings range, step size, and burr-swappable flag). "
+        "Primary read tool for dial-in conversations — a single call gives everything needed to analyze "
+        "a shot and suggest changes. Default profileKnowledge contains only the current profile's "
+        "curated KB entry (~1 KB); pass includeFullKnowledge: true to also receive the dial-in system "
+        "prompt, reference tables, and the cross-profile catalog (~18 KB total — useful at session start "
+        "but redundant on later turns). "
+        "Grinder settings are shown as the user entered them — may be numbers, letters, click counts, or "
+        "grinder-specific notation like Eureka multi-turn (1+4 = 1 rotation + position 4). The "
+        "grinderContext block shows the range and step size observed in the user's own shot history.",
         QJsonObject{
             {"type", "object"},
             {"properties", QJsonObject{
                 {"shot_id", QJsonObject{{"type", "integer"}, {"description", "Specific shot ID to analyze. If omitted, uses most recent shot."}}},
-                {"history_limit", QJsonObject{{"type", "integer"}, {"description", "Number of prior shots with same profile to include (default 5, max 20)"}}}
+                {"history_limit", QJsonObject{{"type", "integer"}, {"description", "Number of prior shots with same profile to include (default 5, max 20)"}}},
+                {"includeFullKnowledge", QJsonObject{{"type", "boolean"}, {"description", "Include the full dial-in system prompt, reference tables, and profile catalog in profileKnowledge. Default false — return only the current profile's KB entry. Useful at session start; redundant per call."}}}
             }}
         },
         [mainController, profileManager, shotHistory, settings](const QJsonObject& args, std::function<void(QJsonObject)> respond) {
@@ -59,6 +63,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
             }
 
             int historyLimit = qBound(1, args["history_limit"].toInt(5), 20);
+            const bool includeFullKnowledge = args.value("includeFullKnowledge").toBool();
 
             // Resolve shot ID on the main thread (lastSavedShotId is a simple getter)
             qint64 shotId = args["shot_id"].toInteger(0);
@@ -68,7 +73,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
             const QString dbPath = shotHistory->databasePath();
 
             QThread* thread = QThread::create(
-                [dbPath, shotId, historyLimit, mainController, profileManager, settings, respond]() {
+                [dbPath, shotId, historyLimit, includeFullKnowledge, mainController, profileManager, settings, respond]() {
                 // --- All SQL runs on this background thread ---
                 DialingDbResult dbResult;
 
@@ -164,7 +169,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                 // --- Deliver results to main thread for final assembly ---
                 // Main-thread work: settings access, AI analysis, profile info
                 QMetaObject::invokeMethod(qApp,
-                    [respond, dbResult, resolvedShotId, mainController, profileManager, settings]() {
+                    [respond, dbResult, resolvedShotId, includeFullKnowledge, mainController, profileManager, settings]() {
 
                     if (!dbResult.shotData.isValid()) {
                         respond(QJsonObject{{"error", "Shot not found: " + QString::number(resolvedShotId)}});
@@ -209,10 +214,23 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     }
 
                     // --- Profile knowledge ---
+                    // Default: ship only the current profile's KB section
+                    // (~1 KB). The full system prompt + reference tables +
+                    // profile catalog (~18 KB total) is opt-in via
+                    // includeFullKnowledge — useful at session start, but
+                    // redundant on later turns of a multi-call dial-in
+                    // conversation. See #987.
                     QString profileTitle = sd.profileName;
                     QString bevType = sd.beverageType.isEmpty() ? QStringLiteral("espresso") : sd.beverageType;
-                    QString profileKnowledge = ShotSummarizer::shotAnalysisSystemPrompt(
-                        bevType, profileTitle, QString(), dbResult.profileKbId);
+                    QString profileKnowledge;
+                    if (includeFullKnowledge) {
+                        profileKnowledge = ShotSummarizer::shotAnalysisSystemPrompt(
+                            bevType, profileTitle, QString(), dbResult.profileKbId);
+                    } else {
+                        profileKnowledge = ShotSummarizer::profileKnowledgeForKbId(dbResult.profileKbId);
+                        if (profileKnowledge.isEmpty())
+                            profileKnowledge = ShotSummarizer::findProfileSection(profileTitle, QString());
+                    }
                     if (!profileKnowledge.isEmpty())
                         result["profileKnowledge"] = profileKnowledge;
 


### PR DESCRIPTION
## Summary
\`dialing_get_context\`'s \`profileKnowledge\` field used to ship ~18 KB on every call: dial-in system prompt, espresso reference tables, cross-profile catalog, and the current profile's KB entry — ~82% of the response payload, mostly static reference material that a multi-turn dial-in conversation doesn't need every turn.

- Default behavior now returns only the current profile's KB section (~1 KB) via a new \`ShotSummarizer::profileKnowledgeForKbId\` helper.
- Pass \`includeFullKnowledge: true\` to get the full system prompt + reference tables + profile catalog + current profile section (~18 KB), as before.
- Falls back to fuzzy title match when no \`profileKbId\` is stored on the shot (matches the existing \`shotAnalysisSystemPrompt\` behavior).

Recommendation B+C combined from the issue. Resource-link split (option A) deferred.

Closes #987.

## Test plan
- [ ] \`dialing_get_context\` (default) returns \`profileKnowledge\` of ~1 KB containing only the current profile's section. No \"## Espresso Dial-In Reference Tables\", no \"## Available Profiles with Curated Knowledge\".
- [ ] \`dialing_get_context (includeFullKnowledge: true)\` returns ~18 KB profileKnowledge including the system prompt + reference tables + catalog + current profile section.
- [ ] When the shot's profile has no KB entry, \`profileKnowledge\` is omitted (default mode).
- [ ] All other fields (shot, currentBean, currentProfile, dialInHistory, grinderContext, shotAnalysis) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)