### PR TITLE
ci(macos): bump ccache max-size 500M → 2G to fit universal binaries

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -64,7 +64,13 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: macos-universal
-          max-size: 500M
+          # macOS builds universal binaries (arm64 + x86_64), so each cache
+          # entry holds a fat object ~2x the size of a single-arch entry.
+          # At 500M, the cache sat at 99% full and evicted ~150 LRU entries
+          # between consecutive builds, causing ~20% miss rate even when
+          # nothing changed source-wise. Linux's single-arch builds fit at
+          # 75% of 500M and don't show the problem.
+          max-size: 2G
 
       - name: Configure ccache for CI
         run: ccache --set-config=compiler_check=content


### PR DESCRIPTION
## Summary
The macOS ccache was hitting the 500 MB cap at 99% full and LRU-evicting ~150 entries between consecutive runs. The next build then re-compiled those evicted files even when nothing changed source-wise, giving a ~20% miss rate on no-change builds.

Linux uses the same 500 MB cap but its single-arch x86_64 cache fits at 75%, so eviction never happens — 98.6% hit rate, 1.4% miss.

macOS universal binaries (arm64 + x86_64) store fat objects per cache entry, roughly doubling the per-file footprint. 2 GB gives ~4× the working set headroom.

## Empirical baseline (run 25206462388, no source changes vs prior build)
\`\`\`
Cacheable calls:   802 / 812 (98.77%)
  Hits:            645 / 802 (80.42%)
  Misses:          157 / 802 (19.58%)
  Cache size (GB): 0.5 / 0.5 (99.33%)  ← cache at cap, evicting LRU
\`\`\`

vs Linux at the same commit:
\`\`\`
Cacheable calls:  1073 / 1073 (100.0%)
  Hits:           1058 / 1073 (98.60%)
  Misses:           15 / 1073 ( 1.40%)
  Cache size (GB):  0.4 /  0.5 (75.09%)  ← headroom, no eviction
\`\`\`

## Cost
None. Cap raised to 2 GB; Decenza's combined cache usage across all 6 platform workflows stays well under the 10 GB free GitHub Actions cache limit per repo.

## Test plan
- [ ] After this lands and a build runs, the next no-change rebuild should show > 95% hit rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)