### PR TITLE
feat(mcp): group dialInHistory into per-session iterations (#1009)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -35,6 +35,7 @@ If ORIGINAL_MODIFIED is true, warn the user — tests will modify the profile an
 | 2026-03-20 | 37 | 41 | 1 | 0 | Initial run, simulator mode |
 | 2026-04-30 | 33 | 56 | 1 | 0 | Simulator, MCP 2025-11-25 negotiated. Plan refreshed for PR #976 field renames, `profiles_save` readonly refusal, `profiles_create` empty-filename, removal of `preferences` category, and §4.10 active-delete behavior. |
 | 2026-05-01 | 33 | 56 | 1 | 0 | Plan refreshed for PR #984: `shots_get_detail`/`shots_compare` default to summary mode (#979); `enjoyment0to100`/`drinkTdsPct`/`drinkEyPct` everywhere on shot reads (#980); `profiles_delete` returns actionable error on active profile (#983). |
+| 2026-05-01 | 35 | — | — | 0 | Plan refreshed for PR #1014 (#1009): `dialing_get_context` now emits `dialInSessions` (sessions of shots within ~60 min on the same profile, with within-session `changeFromPrev` diffs) in place of the flat `dialInHistory` array. |
 | 2026-05-01 | 34 | — | — | 0 | Spot-check after merging PRs #996–#1005 (issues #985–#994). Validated: `app_get_info` returns platform block, `machine_get_state` no longer ships `stateString`/`platform`. `shots_list` returns `hasMore`/`nextOffset` (last-page → false/null). `shots_get_detail`/`shots_compare` strip `gates` from detector results, emit `null` for unrated `enjoyment0to100`/`drinkTdsPct`/`drinkEyPct`, and `shots_compare` hoists `profileNotes`/`profileKbId` to a top-level `sharedProfile` block when shots share a profile. `profiles_list` filters (`editorType`, `excludeCategories`, `nameContains`, `readOnly`) and the derived `category` field work; trim + case-insensitive match catches `D-Flow`/`A-Flow`. `profiles_get_params` emits both un-suffixed and `*Bar`/`*C`/`*MlPerSec`/`*Sec`/`*G`/`*Ml` aliases (incl. `preinfusionStopPressureBar`). `settings_get` keys filter accepts suffixed read names (`espressoTemperatureC` round-trips); unknown keys/categories return structured error with `validCategories`/`unknownKeys`. `dialing_get_context` default returns ~1 KB profile section only; `includeFullKnowledge: true` returns the full ~18 KB system prompt + reference tables + catalog. |
 | 2026-05-01 | 34 | 67 | 1 | 1 | Full plan run, simulator. All sections passed: §1 state/info/telemetry, §2 sleep/wake/stop/skip (start_* skipped per simulator note), §3.3-3.8 profile read for all editor types (with new aliases), §4 profile editing incl. frame preservation, save-as, built-in revert, active-profile delete protection, profiles_create. §5 settings get/set incl. unknown rejection. §6 shots list/detail/compare/update/delete (round-trip restored). §7 dialing default + full knowledge. §8 scale, §9 devices, §10 debug pagination, §11 settings parity for all 22 categories. **One failure**: §4.10 `profiles_delete` of `mcp_test_tmp` returned `Failed to delete profile` after switching active to `default` first — the user profile appears to vanish from the list when active is switched, even though `profiles_save` reported success and `profiles_get_active` confirmed it. Behavior may be a save-persistence quirk in the simulator path; worth a follow-up issue. Cleanup left no residue (default active, modified=false, DYE/system settings all back to ORIGINAL values). |
 | 2026-05-01 | 35 | 68 | 1 | 0 | Re-run §4.9–§4.10 + new §4.9a after merging PR #1007 (#1006). Root cause was the test plan's old `_mcp_test_tmp` filename — `ProfileStorage::listProfiles` filters underscore-prefixed files (reserved for internal files like `_current.json`), so the profile got persisted to disk but was invisible to `profiles_list` / `refreshProfiles`, which made `ProfileManager::deleteProfile` see `source=BuiltIn` and return false even when the file was successfully removed. PR #1007 rejects underscore-prefixed filenames upfront in `profiles_save`. Re-verified live after app restart: `profiles_save (filename: "_internal_thing", ...)` → clear error suggesting `internal_thing` instead; `profiles_save (filename: "mcp_test_tmp", ...)` → success → visible in `profiles_list (nameContains: "mcp")` (count=1) → `profiles_set_active default` → `profiles_delete (mcp_test_tmp)` → `Profile deleted: mcp_test_tmp` → list count=0. All 11 MCP issues from this session (#985–#994 + #1006) closed. |
@@ -475,11 +476,18 @@ Expect: error — tool not found (replaced by shots_update in phase 15)
 
 ### 7.1 dialing_get_context
 ```
-Call: dialing_get_context (history_limit: 2)
+Call: dialing_get_context (history_limit: 5)
 Expect: shotId > 0, shot object present, currentBean present, currentProfile present.
         profileKnowledge non-empty (if the profile has a KB entry) — small (~1 KB):
         only the current profile's curated section. No system prompt / reference
         tables / cross-profile catalog (per #987).
+        dialInSessions present when prior shots exist on the same profile —
+        an array of session objects { sessionStart, sessionEnd, shotCount, shots[] }.
+        Sessions are emitted newest-first; shots within a session are oldest-first.
+        Each shot after the first in a session carries `changeFromPrev` (a diff
+        in the same shape shots_compare emits: grinderSetting, doseG, yieldG,
+        durationSec, enjoyment0to100, beanBrand). Shots within ~60 minutes of
+        each other on the same profile are grouped into one session (per #1009).
 ```
 
 ### 7.1a dialing_get_context — full knowledge

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -1,5 +1,6 @@
 #include "mcpserver.h"
 #include "mcptoolregistry.h"
+#include "mcptools_dialing_helpers.h"
 #include "../history/shothistorystorage.h"
 #include "../controllers/maincontroller.h"
 #include "../controllers/profilemanager.h"
@@ -29,13 +30,6 @@ struct DialingDbResult {
     QJsonArray dialInSessions;
     QJsonObject grinderContext;
 };
-
-// A run of consecutive shots on the same profile counts as one dial-in
-// "session" when the gap between adjacent shots is small enough that the
-// user is plausibly still iterating. 60 minutes covers the realistic case
-// (pull, taste, adjust grinder, re-dose, pull again) without merging
-// unrelated morning/afternoon attempts.
-static constexpr qint64 kDialInSessionGapSec = 60 * 60;
 
 // Build the changeFromPrev diff between two adjacent shots in the same
 // session — same shape as `shots_compare` produces, computed inline so the
@@ -185,27 +179,21 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                             return h;
                         };
 
-                        // Walk the DESC list, breaking sessions when the
-                        // gap to the next-older shot exceeds the threshold.
-                        QList<QList<ShotProjection>> sessions;
-                        QList<ShotProjection> current;
-                        for (qsizetype i = 0; i < shots.size(); ++i) {
-                            current.append(shots[i]);
-                            const bool isLast = (i == shots.size() - 1);
-                            const bool gapTooLarge = !isLast &&
-                                qAbs(shots[i].timestamp - shots[i+1].timestamp) > kDialInSessionGapSec;
-                            if (isLast || gapTooLarge) {
-                                sessions.append(current);
-                                current.clear();
-                            }
-                        }
+                        // Group the DESC-ordered shots into sessions using
+                        // the pure helper (unit-tested separately).
+                        QList<qint64> timestamps;
+                        timestamps.reserve(shots.size());
+                        for (const auto& s : shots)
+                            timestamps.append(s.timestamp);
+                        const auto sessionIndices = McpDialingHelpers::groupSessions(timestamps);
 
-                        for (const auto& session : sessions) {
-                            // Reverse to ASC within the session.
+                        for (const auto& indices : sessionIndices) {
+                            // Reverse to ASC within the session so
+                            // changeFromPrev reads "older -> newer".
                             QList<ShotProjection> ordered;
-                            ordered.reserve(session.size());
-                            for (qsizetype i = session.size() - 1; i >= 0; --i)
-                                ordered.append(session[i]);
+                            ordered.reserve(indices.size());
+                            for (qsizetype i = indices.size() - 1; i >= 0; --i)
+                                ordered.append(shots[indices[i]]);
 
                             QJsonArray sessionShots;
                             for (qsizetype i = 0; i < ordered.size(); ++i) {

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -26,9 +26,41 @@
 struct DialingDbResult {
     ShotProjection shotData;
     QString profileKbId;
-    QJsonArray dialInHistory;
+    QJsonArray dialInSessions;
     QJsonObject grinderContext;
 };
+
+// A run of consecutive shots on the same profile counts as one dial-in
+// "session" when the gap between adjacent shots is small enough that the
+// user is plausibly still iterating. 60 minutes covers the realistic case
+// (pull, taste, adjust grinder, re-dose, pull again) without merging
+// unrelated morning/afternoon attempts.
+static constexpr qint64 kDialInSessionGapSec = 60 * 60;
+
+// Build the changeFromPrev diff between two adjacent shots in the same
+// session — same shape as `shots_compare` produces, computed inline so the
+// AI doesn't need a separate round-trip to see what moved.
+static QJsonObject changeFromPrev(const ShotProjection& prev, const ShotProjection& curr)
+{
+    QJsonObject diff;
+    auto diffStr = [&](const QString& a, const QString& b, const QString& key) {
+        if (!a.isEmpty() && !b.isEmpty() && a != b)
+            diff[key] = QString("%1 -> %2").arg(a, b);
+    };
+    auto diffNum = [&](double a, double b, const QString& key, const QString& unit) {
+        if (a != 0 && b != 0 && qAbs(a - b) > 0.01)
+            diff[key] = QString("%1 -> %2 %3 (%4%5)")
+                .arg(a, 0, 'f', 1).arg(b, 0, 'f', 1).arg(unit)
+                .arg(b > a ? "+" : "").arg(b - a, 0, 'f', 1);
+    };
+    diffStr(prev.grinderSetting, curr.grinderSetting, "grinderSetting");
+    diffStr(prev.beanBrand, curr.beanBrand, "beanBrand");
+    diffNum(prev.doseWeightG, curr.doseWeightG, "doseG", "g");
+    diffNum(prev.finalWeightG, curr.finalWeightG, "yieldG", "g");
+    diffNum(prev.durationSec, curr.durationSec, "durationSec", "s");
+    diffNum(prev.enjoyment0to100, curr.enjoyment0to100, "enjoyment0to100", "");
+    return diff;
+}
 
 void registerDialingTools(McpToolRegistry* registry, MainController* mainController,
                           ProfileManager* profileManager,
@@ -37,9 +69,10 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
     // dialing_get_context
     registry->registerAsyncTool(
         "dialing_get_context",
-        "Get dial-in context: recent shot summary, dial-in history (last N shots with same profile), "
-        "profile knowledge for the current shot's profile, bean/grinder metadata, and grinder context "
-        "(observed settings range, step size, and burr-swappable flag). "
+        "Get dial-in context: recent shot summary, dial-in history grouped into sessions (runs of "
+        "shots on the same profile within ~60 minutes of each other, with within-session "
+        "changeFromPrev diffs), profile knowledge for the current shot's profile, bean/grinder "
+        "metadata, and grinder context (observed settings range, step size, and burr-swappable flag). "
         "Primary read tool for dial-in conversations — a single call gives everything needed to analyze "
         "a shot and suggest changes. Default profileKnowledge contains only the current profile's "
         "curated KB entry (~1 KB); pass includeFullKnowledge: true to also receive the dial-in system "
@@ -100,11 +133,21 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     dbResult.shotData = ShotHistoryStorage::convertShotRecord(record);
                     dbResult.profileKbId = record.profileKbId;
 
-                    // --- Dial-in history (same profile family) ---
+                    // --- Dial-in history grouped into sessions (same profile family) ---
+                    // History returns DESC (newest first). Within a session
+                    // we want ASC order so changeFromPrev reads "older ->
+                    // newer" — matching how the user iterates. Sessions
+                    // themselves stay newest-first so the most relevant
+                    // recent iteration is at the top of the list.
                     if (!dbResult.profileKbId.isEmpty()) {
                         QVariantList history = ShotHistoryStorage::loadRecentShotsByKbIdStatic(db, dbResult.profileKbId, historyLimit, resolvedShotId);
-                        for (const auto& v : history) {
-                            const ShotProjection shot = ShotProjection::fromVariantMap(v.toMap());
+
+                        QList<ShotProjection> shots;
+                        shots.reserve(history.size());
+                        for (const auto& v : history)
+                            shots.append(ShotProjection::fromVariantMap(v.toMap()));
+
+                        auto shotToJson = [](const ShotProjection& shot) {
                             QJsonObject h;
                             h["id"] = shot.id;
                             h["timestamp"] = shot.timestampIso;
@@ -139,7 +182,49 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                                 if (twVal > 0)
                                     h["targetWeightG"] = twVal;
                             }
-                            dbResult.dialInHistory.append(h);
+                            return h;
+                        };
+
+                        // Walk the DESC list, breaking sessions when the
+                        // gap to the next-older shot exceeds the threshold.
+                        QList<QList<ShotProjection>> sessions;
+                        QList<ShotProjection> current;
+                        for (qsizetype i = 0; i < shots.size(); ++i) {
+                            current.append(shots[i]);
+                            const bool isLast = (i == shots.size() - 1);
+                            const bool gapTooLarge = !isLast &&
+                                qAbs(shots[i].timestamp - shots[i+1].timestamp) > kDialInSessionGapSec;
+                            if (isLast || gapTooLarge) {
+                                sessions.append(current);
+                                current.clear();
+                            }
+                        }
+
+                        for (const auto& session : sessions) {
+                            // Reverse to ASC within the session.
+                            QList<ShotProjection> ordered;
+                            ordered.reserve(session.size());
+                            for (qsizetype i = session.size() - 1; i >= 0; --i)
+                                ordered.append(session[i]);
+
+                            QJsonArray sessionShots;
+                            for (qsizetype i = 0; i < ordered.size(); ++i) {
+                                QJsonObject h = shotToJson(ordered[i]);
+                                if (i > 0) {
+                                    QJsonObject diff = changeFromPrev(ordered[i-1], ordered[i]);
+                                    h["changeFromPrev"] = diff.isEmpty() ? QJsonValue(QJsonValue::Null) : QJsonValue(diff);
+                                } else {
+                                    h["changeFromPrev"] = QJsonValue(QJsonValue::Null);
+                                }
+                                sessionShots.append(h);
+                            }
+
+                            QJsonObject sessionObj;
+                            sessionObj["sessionStart"] = ordered.first().timestampIso;
+                            sessionObj["sessionEnd"] = ordered.last().timestampIso;
+                            sessionObj["shotCount"] = static_cast<int>(ordered.size());
+                            sessionObj["shots"] = sessionShots;
+                            dbResult.dialInSessions.append(sessionObj);
                         }
                     }
 
@@ -183,8 +268,8 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     result["currentDateTime"] = now.toOffsetFromUtc(now.offsetFromUtc()).toString(Qt::ISODate);
                     result["shotId"] = resolvedShotId;
 
-                    if (!dbResult.dialInHistory.isEmpty())
-                        result["dialInHistory"] = dbResult.dialInHistory;
+                    if (!dbResult.dialInSessions.isEmpty())
+                        result["dialInSessions"] = dbResult.dialInSessions;
                     if (!dbResult.grinderContext.isEmpty())
                         result["grinderContext"] = dbResult.grinderContext;
 

--- a/src/mcp/mcptools_dialing_helpers.h
+++ b/src/mcp/mcptools_dialing_helpers.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QList>
+#include <QtGlobal>
+
+// Helpers extracted from mcptools_dialing.cpp so the pure-logic pieces can be
+// unit-tested without spinning up the full MCP / DB / thread stack.
+
+namespace McpDialingHelpers {
+
+// A run of consecutive shots on the same profile counts as one dial-in
+// "session" when the gap between adjacent shots is small enough that the
+// user is plausibly still iterating. 60 minutes covers the realistic case
+// (pull, taste, adjust grinder, re-dose, pull again) without merging
+// unrelated morning/afternoon attempts.
+constexpr qint64 kDialInSessionGapSec = 60 * 60;
+
+// Group an ordered (DESC by timestamp) list of timestamps into sessions.
+// Two adjacent timestamps belong to the same session iff their gap is
+// <= thresholdSec. Returns each session as a list of indices into the input
+// list, preserving the input's DESC order within each session. Sessions
+// themselves are emitted in input order (= newest session first).
+//
+// Pure function: no Qt object dependencies, easy to unit-test.
+inline QList<QList<qsizetype>> groupSessions(const QList<qint64>& timestampsDesc,
+                                              qint64 thresholdSec = kDialInSessionGapSec)
+{
+    QList<QList<qsizetype>> sessions;
+    if (timestampsDesc.isEmpty())
+        return sessions;
+
+    QList<qsizetype> current;
+    for (qsizetype i = 0; i < timestampsDesc.size(); ++i) {
+        current.append(i);
+        const bool isLast = (i == timestampsDesc.size() - 1);
+        const bool gapTooLarge = !isLast &&
+            qAbs(timestampsDesc[i] - timestampsDesc[i + 1]) > thresholdSec;
+        if (isLast || gapTooLarge) {
+            sessions.append(current);
+            current.clear();
+        }
+    }
+    return sessions;
+}
+
+} // namespace McpDialingHelpers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,11 @@ add_decenza_test(tst_aborted_shot_classifier
     tst_aborted_shot_classifier.cpp
 )
 
+# --- tst_mcptools_dialing_helpers: pure session-grouping algorithm (issue #1009) ---
+add_decenza_test(tst_mcptools_dialing_helpers
+    tst_mcptools_dialing_helpers.cpp
+)
+
 # --- tst_firmwarepackets: FWMapRequest + firmware chunk byte layout tests
 # (header-only target; no cpp dependency beyond the test itself) ---
 add_decenza_test(tst_firmwarepackets

--- a/tests/tst_mcptools_dialing_helpers.cpp
+++ b/tests/tst_mcptools_dialing_helpers.cpp
@@ -1,0 +1,98 @@
+#include <QTest>
+#include "mcp/mcptools_dialing_helpers.h"
+
+using namespace McpDialingHelpers;
+
+class TstMcpToolsDialingHelpers : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void emptyInput_returnsNoSessions();
+    void singleShot_returnsOneSessionOfOne();
+    void twoAdjacentShots_inSameSession();
+    void twoFarApartShots_inSeparateSessions();
+    void issueExample_threeShots_twoSessions();
+    void exactlyAtThreshold_groupsTogether();
+    void justOverThreshold_breaksSession();
+    void thresholdIsConfigurable();
+};
+
+void TstMcpToolsDialingHelpers::emptyInput_returnsNoSessions()
+{
+    QVERIFY(groupSessions({}).isEmpty());
+}
+
+void TstMcpToolsDialingHelpers::singleShot_returnsOneSessionOfOne()
+{
+    const auto sessions = groupSessions({1000});
+    QCOMPARE(sessions.size(), qsizetype(1));
+    QCOMPARE(sessions[0].size(), qsizetype(1));
+    QCOMPARE(sessions[0][0], qsizetype(0));
+}
+
+void TstMcpToolsDialingHelpers::twoAdjacentShots_inSameSession()
+{
+    // Two shots 7 minutes apart — well within the 60-min threshold.
+    const auto sessions = groupSessions({2000, 2000 - 7 * 60});
+    QCOMPARE(sessions.size(), qsizetype(1));
+    QCOMPARE(sessions[0].size(), qsizetype(2));
+    QCOMPARE(sessions[0][0], qsizetype(0));
+    QCOMPARE(sessions[0][1], qsizetype(1));
+}
+
+void TstMcpToolsDialingHelpers::twoFarApartShots_inSeparateSessions()
+{
+    // Two shots 24 hours apart.
+    const auto sessions = groupSessions({100000, 100000 - 24 * 3600});
+    QCOMPARE(sessions.size(), qsizetype(2));
+    QCOMPARE(sessions[0].size(), qsizetype(1));
+    QCOMPARE(sessions[1].size(), qsizetype(1));
+    QCOMPARE(sessions[0][0], qsizetype(0));
+    QCOMPARE(sessions[1][0], qsizetype(1));
+}
+
+void TstMcpToolsDialingHelpers::issueExample_threeShots_twoSessions()
+{
+    // Mirrors the issue #1009 example: shots 884 (today 9:36), 883 (today 9:29),
+    // 882 (yesterday 10:09). 884 and 883 are 7 min apart — same session.
+    // 883 and 882 are ~23 hours apart — separate sessions.
+    const qint64 t884 = 1000000;
+    const qint64 t883 = t884 - 7 * 60;
+    const qint64 t882 = t883 - 23 * 3600;
+    const auto sessions = groupSessions({t884, t883, t882});
+
+    QCOMPARE(sessions.size(), qsizetype(2));
+    QCOMPARE(sessions[0].size(), qsizetype(2));
+    QCOMPARE(sessions[1].size(), qsizetype(1));
+    // First session has indices [0, 1] (884 + 883), second has [2] (882).
+    QCOMPARE(sessions[0][0], qsizetype(0));
+    QCOMPARE(sessions[0][1], qsizetype(1));
+    QCOMPARE(sessions[1][0], qsizetype(2));
+}
+
+void TstMcpToolsDialingHelpers::exactlyAtThreshold_groupsTogether()
+{
+    // Exactly at the threshold (gap == threshold) → still same session.
+    const auto sessions = groupSessions({3600, 0}, /*thresholdSec=*/3600);
+    QCOMPARE(sessions.size(), qsizetype(1));
+    QCOMPARE(sessions[0].size(), qsizetype(2));
+}
+
+void TstMcpToolsDialingHelpers::justOverThreshold_breaksSession()
+{
+    // 1 second over the threshold → distinct sessions.
+    const auto sessions = groupSessions({3601, 0}, /*thresholdSec=*/3600);
+    QCOMPARE(sessions.size(), qsizetype(2));
+}
+
+void TstMcpToolsDialingHelpers::thresholdIsConfigurable()
+{
+    // With a 30-min threshold, a 45-min gap should split.
+    const auto sessions = groupSessions({3600, 3600 - 45 * 60}, /*thresholdSec=*/30 * 60);
+    QCOMPARE(sessions.size(), qsizetype(2));
+}
+
+QTEST_APPLESS_MAIN(TstMcpToolsDialingHelpers)
+
+#include "tst_mcptools_dialing_helpers.moc"


### PR DESCRIPTION
Closes #1009.

## Summary
- Replaces the flat `dialInHistory` array on `dialing_get_context` with `dialInSessions`, grouping consecutive shots on the same profile (≤ 60 min adjacent gap) into iteration sessions.
- Within each session, shots are ordered ASC and each non-first shot carries a `changeFromPrev` diff (same shape as `shots_compare`: grinderSetting, doseG, yieldG, durationSec, enjoyment0to100, beanBrand).
- Sessions themselves are emitted newest-first, so the most relevant recent iteration is at the top.

## Why
The AI's #1 question on every dial-in turn is "what changed since last shot?" The flat history forced it to either eyeball timestamps or call `shots_compare` separately. The session structure plus inline diff lets it pattern-match "finer + yield up + duration up = grind move worked" in one turn.

## Test plan
- [ ] `dialing_get_context` with several recent shots on one profile → see them grouped into one session, each with `changeFromPrev`.
- [ ] Pull a shot, wait > 60 min, pull another → see two sessions of 1 shot each.
- [ ] Profile with no prior shots → no `dialInSessions` key (omitted when empty, same as before for `dialInHistory`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)