### PR TITLE
feat(mcp): add hasNotes/hasTds/hasRating filters to shots_list (#1011)

### DIFF
--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -37,6 +37,7 @@ If ORIGINAL_MODIFIED is true, warn the user — tests will modify the profile an
 | 2026-05-01 | 33 | 56 | 1 | 0 | Plan refreshed for PR #984: `shots_get_detail`/`shots_compare` default to summary mode (#979); `enjoyment0to100`/`drinkTdsPct`/`drinkEyPct` everywhere on shot reads (#980); `profiles_delete` returns actionable error on active profile (#983). |
 | 2026-05-01 | 35 | — | — | 0 | Plan refreshed for PR #1014 (#1009): `dialing_get_context` now emits `dialInSessions` (sessions of shots within ~60 min on the same profile, with within-session `changeFromPrev` diffs) in place of the flat `dialInHistory` array. |
 | 2026-05-01 | 35 | — | — | 0 | Plan refreshed for PR #1015 (#1010): `dialing_get_context` now emits a `tastingFeedback` block (`hasEnjoymentScore` / `hasNotes` / `hasRefractometer`, plus a conditional `recommendation` when any are missing). |
+| 2026-05-01 | 35 | — | — | 0 | Plan refreshed for PR #1016 (#1011): `shots_list` accepts `hasRating` / `hasNotes` / `hasTds` boolean filters, composable with existing filters. New §6.2a covers them. |
 | 2026-05-01 | 34 | — | — | 0 | Spot-check after merging PRs #996–#1005 (issues #985–#994). Validated: `app_get_info` returns platform block, `machine_get_state` no longer ships `stateString`/`platform`. `shots_list` returns `hasMore`/`nextOffset` (last-page → false/null). `shots_get_detail`/`shots_compare` strip `gates` from detector results, emit `null` for unrated `enjoyment0to100`/`drinkTdsPct`/`drinkEyPct`, and `shots_compare` hoists `profileNotes`/`profileKbId` to a top-level `sharedProfile` block when shots share a profile. `profiles_list` filters (`editorType`, `excludeCategories`, `nameContains`, `readOnly`) and the derived `category` field work; trim + case-insensitive match catches `D-Flow`/`A-Flow`. `profiles_get_params` emits both un-suffixed and `*Bar`/`*C`/`*MlPerSec`/`*Sec`/`*G`/`*Ml` aliases (incl. `preinfusionStopPressureBar`). `settings_get` keys filter accepts suffixed read names (`espressoTemperatureC` round-trips); unknown keys/categories return structured error with `validCategories`/`unknownKeys`. `dialing_get_context` default returns ~1 KB profile section only; `includeFullKnowledge: true` returns the full ~18 KB system prompt + reference tables + catalog. |
 | 2026-05-01 | 34 | 67 | 1 | 1 | Full plan run, simulator. All sections passed: §1 state/info/telemetry, §2 sleep/wake/stop/skip (start_* skipped per simulator note), §3.3-3.8 profile read for all editor types (with new aliases), §4 profile editing incl. frame preservation, save-as, built-in revert, active-profile delete protection, profiles_create. §5 settings get/set incl. unknown rejection. §6 shots list/detail/compare/update/delete (round-trip restored). §7 dialing default + full knowledge. §8 scale, §9 devices, §10 debug pagination, §11 settings parity for all 22 categories. **One failure**: §4.10 `profiles_delete` of `mcp_test_tmp` returned `Failed to delete profile` after switching active to `default` first — the user profile appears to vanish from the list when active is switched, even though `profiles_save` reported success and `profiles_get_active` confirmed it. Behavior may be a save-persistence quirk in the simulator path; worth a follow-up issue. Cleanup left no residue (default active, modified=false, DYE/system settings all back to ORIGINAL values). |
 | 2026-05-01 | 35 | 68 | 1 | 0 | Re-run §4.9–§4.10 + new §4.9a after merging PR #1007 (#1006). Root cause was the test plan's old `_mcp_test_tmp` filename — `ProfileStorage::listProfiles` filters underscore-prefixed files (reserved for internal files like `_current.json`), so the profile got persisted to disk but was invisible to `profiles_list` / `refreshProfiles`, which made `ProfileManager::deleteProfile` see `source=BuiltIn` and return false even when the file was successfully removed. PR #1007 rejects underscore-prefixed filenames upfront in `profiles_save`. Re-verified live after app restart: `profiles_save (filename: "_internal_thing", ...)` → clear error suggesting `internal_thing` instead; `profiles_save (filename: "mcp_test_tmp", ...)` → success → visible in `profiles_list (nameContains: "mcp")` (count=1) → `profiles_set_active default` → `profiles_delete (mcp_test_tmp)` → `Profile deleted: mcp_test_tmp` → list count=0. All 11 MCP issues from this session (#985–#994 + #1006) closed. |
@@ -396,6 +397,18 @@ suffixed names (`enjoyment0to100`, `drinkTdsPct`, `drinkEyPct`, `doseWeightG`,
 ```
 Call: shots_list (profileName: "D-Flow", limit: 3)
 Expect: count > 0, all returned shots have profileName containing "D-Flow"
+```
+
+### 6.2a shots_list — feedback filters (#1011)
+```
+Call: shots_list (hasRating: true, limit: 5)
+Expect: every returned shot has enjoyment0to100 != null (and > 0).
+Call: shots_list (hasNotes: true, limit: 5)
+Expect: every returned shot has non-empty `notes`.
+Call: shots_list (hasTds: true, limit: 5)
+Expect: every returned shot has drinkTdsPct > 0 (verify by spot-checking via shots_get_detail).
+Call: shots_list (hasRating: true, hasNotes: true, beanBrand: "<known brand>", limit: 5)
+Expect: filters compose; total / hasMore / nextOffset reflect the filtered subset.
 ```
 
 ### 6.3 shots_get_detail — summary (default)

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -99,6 +99,9 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                 {"profileName", QJsonObject{{"type", "string"}, {"description", "Filter by profile name (substring match)"}}},
                 {"beanBrand", QJsonObject{{"type", "string"}, {"description", "Filter by bean brand"}}},
                 {"minEnjoyment", QJsonObject{{"type", "integer"}, {"description", "Minimum enjoyment rating (1-100, 0 or omit means no filter)"}}},
+                {"hasRating", QJsonObject{{"type", "boolean"}, {"description", "Only shots with an enjoyment score (>0). Composable with other filters; equivalent to minEnjoyment: 1."}}},
+                {"hasNotes", QJsonObject{{"type", "boolean"}, {"description", "Only shots with non-empty espresso notes."}}},
+                {"hasTds", QJsonObject{{"type", "boolean"}, {"description", "Only shots with a refractometer reading (drinkTdsPct > 0)."}}},
                 {"after", QJsonObject{{"type", "string"}, {"description", "Only shots after this ISO timestamp (e.g. 2026-03-15T00:00:00)"}}},
                 {"before", QJsonObject{{"type", "string"}, {"description", "Only shots before this ISO timestamp (e.g. 2026-03-21T23:59:59)"}}}
             }}
@@ -118,6 +121,9 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
             QString profileFilter = args["profileName"].toString();
             QString beanFilter = args["beanBrand"].toString();
             int minEnjoyment = args["minEnjoyment"].toInt(-1);
+            const bool hasRating = args.value("hasRating").toBool();
+            const bool hasNotes = args.value("hasNotes").toBool();
+            const bool hasTds = args.value("hasTds").toBool();
             qint64 afterEpoch = 0, beforeEpoch = 0;
             if (args.contains("after")) {
                 QDateTime dt = QDateTime::fromString(args["after"].toString(), Qt::ISODate);
@@ -132,7 +138,8 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
 
             QThread* thread = QThread::create(
                 [dbPath, limit, offset, profileFilter, beanFilter,
-                 minEnjoyment, afterEpoch, beforeEpoch, currentDateTime, respond]() {
+                 minEnjoyment, hasRating, hasNotes, hasTds,
+                 afterEpoch, beforeEpoch, currentDateTime, respond]() {
                 QJsonObject result;
                 QJsonArray shots;
                 qint64 totalCount = 0;
@@ -155,6 +162,18 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                     if (minEnjoyment > 0) {
                         sql += " AND enjoyment >= :minEnjoyment";
                         countSql += " AND enjoyment >= :minEnjoyment";
+                    }
+                    if (hasRating) {
+                        sql += " AND enjoyment > 0";
+                        countSql += " AND enjoyment > 0";
+                    }
+                    if (hasNotes) {
+                        sql += " AND TRIM(COALESCE(espresso_notes, '')) <> ''";
+                        countSql += " AND TRIM(COALESCE(espresso_notes, '')) <> ''";
+                    }
+                    if (hasTds) {
+                        sql += " AND drink_tds > 0";
+                        countSql += " AND drink_tds > 0";
                     }
                     if (afterEpoch > 0) {
                         sql += " AND timestamp >= :after";


### PR DESCRIPTION
Closes #1011.

## Summary
- Adds three boolean filters to `shots_list`: `hasRating` (enjoyment > 0), `hasNotes` (trimmed espresso notes non-empty), `hasTds` (drink_tds > 0).
- Composable with existing `profileName` / `beanBrand` / `minEnjoyment` / `after` / `before` filters.
- All applied as SQL `WHERE` clauses, so the count + paging stay correct.

## Why
Previously the only feedback-aware filter was `minEnjoyment`. To find shots with *any* notes or refractometer data, an AI had to list, then `shots_get_detail` every result — expensive and prone to truncating before finding the rated subset. Companion to PR #999 (#991) which made unrated/unmeasured fields emit `null`.

## Test plan
- [ ] `shots_list { hasRating: true }` → only shots with enjoyment > 0.
- [ ] `shots_list { hasNotes: true }` → only shots with non-whitespace notes.
- [ ] `shots_list { hasTds: true }` → only shots with TDS > 0.
- [ ] Combined with `beanBrand` → composes correctly, total/hasMore counts align.

🤖 Generated with [Claude Code](https://claude.com/claude-code)