### PR TITLE
fix(mcp): suppress per-phase temp instability prose on intentional stepping (#1018)

### DIFF
--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -476,11 +476,9 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
     if (!shotData.summaryLines.isEmpty()) {
         summary.summaryLines = shotData.summaryLines;
         summary.pourTruncatedDetected = shotData.detectorResults.value("pourTruncated").toBool();
-        // detectorResults["tempStability"] is the standardized envelope shape
-        // (see shothistorystorage_serialize.cpp): { checked, intentionalStepping,
-        // avgDeviationC, unstable }. .toMap() on a missing key returns an empty
-        // map, .value("intentionalStepping").toBool() then defaults to false —
-        // the same null-safe pattern as the pourTruncated read above.
+        // .toMap() on a missing tempStability key returns an empty map and
+        // .toBool() then defaults to false — a row without the envelope
+        // reads as !intentionalStepping (correct fallback).
         summary.tempIntentionalStepping = shotData.detectorResults
             .value("tempStability").toMap()
             .value("intentionalStepping").toBool();
@@ -704,13 +702,8 @@ QString ShotSummarizer::buildUserPrompt(const ShotSummary& summary) const
         }
         // Suppress per-phase temp instability when the puck never built \u2014
         // temp drift on a failed pour is a downstream symptom, not signal.
-        // Also suppress when the profile is intentionally stepping the
-        // temperature goal across the shot: per-phase deviation is by design
-        // and the global detector (and detectorResults envelope) already
-        // treats the shot as stable for the same reason. Without this gate
-        // the structured envelope and the prose disagree on stepping
-        // profiles, contradicting the system prompt's own "DO NOT flag low
-        // temperature on a stepping profile" guidance.
+        // Also suppress on intentionally-stepping profiles: per-phase
+        // deviation against a stepped goal is by design, not instability.
         if (phase.temperatureUnstable
             && !summary.pourTruncatedDetected
             && !summary.tempIntentionalStepping)

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -190,6 +190,7 @@ void ShotSummarizer::runShotAnalysisAndPopulate(ShotSummary& summary,
         frameCount);
     summary.summaryLines = analysis.lines;
     summary.pourTruncatedDetected = analysis.detectors.pourTruncated;
+    summary.tempIntentionalStepping = analysis.detectors.tempIntentionalStepping;
     if (!summary.pourTruncatedDetected
         && ShotAnalysis::reachedExtractionPhase(markers, summary.totalDuration))
         markPerPhaseTempInstability(summary, temperature, temperatureGoal);
@@ -475,6 +476,14 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
     if (!shotData.summaryLines.isEmpty()) {
         summary.summaryLines = shotData.summaryLines;
         summary.pourTruncatedDetected = shotData.detectorResults.value("pourTruncated").toBool();
+        // detectorResults["tempStability"] is the standardized envelope shape
+        // (see shothistorystorage_serialize.cpp): { checked, intentionalStepping,
+        // avgDeviationC, unstable }. .toMap() on a missing key returns an empty
+        // map, .value("intentionalStepping").toBool() then defaults to false —
+        // the same null-safe pattern as the pourTruncated read above.
+        summary.tempIntentionalStepping = shotData.detectorResults
+            .value("tempStability").toMap()
+            .value("intentionalStepping").toBool();
         if (!summary.pourTruncatedDetected
             && ShotAnalysis::reachedExtractionPhase(historyMarkers, summary.totalDuration))
             markPerPhaseTempInstability(summary, summary.tempCurve, summary.tempGoalCurve);
@@ -695,7 +704,16 @@ QString ShotSummarizer::buildUserPrompt(const ShotSummary& summary) const
         }
         // Suppress per-phase temp instability when the puck never built \u2014
         // temp drift on a failed pour is a downstream symptom, not signal.
-        if (phase.temperatureUnstable && !summary.pourTruncatedDetected)
+        // Also suppress when the profile is intentionally stepping the
+        // temperature goal across the shot: per-phase deviation is by design
+        // and the global detector (and detectorResults envelope) already
+        // treats the shot as stable for the same reason. Without this gate
+        // the structured envelope and the prose disagree on stepping
+        // profiles, contradicting the system prompt's own "DO NOT flag low
+        // temperature on a stepping profile" guidance.
+        if (phase.temperatureUnstable
+            && !summary.pourTruncatedDetected
+            && !summary.tempIntentionalStepping)
             out << "- **Temperature instability**: Average temperature deviated from target by >2\u00B0C during this phase\n";
         out << "\n";
     }

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -94,17 +94,10 @@ struct ShotSummary {
     // (which analyzeShot's aggregate output doesn't surface).
     bool pourTruncatedDetected = false;
 
-    // Intentional temperature stepping flag — when the profile steps the
-    // temperature goal across the shot (e.g. 82→72°C decline), per-phase
-    // average deviation is by design, not instability. The global detector
-    // already suppresses the aggregate "Temperature unstable" line on this
-    // basis (`ShotAnalysis::AnalysisResult::detectors.tempIntentionalStepping`);
-    // mirror that suppression for the per-phase prose so the AI advisor sees
-    // a consistent story between the structured detectorResults envelope and
-    // the prose shotAnalysis. The per-phase variant of
-    // `hasIntentionalTempStepping` only sees stepping within a single phase,
-    // so a profile that steps *across* phases (flat goal per phase, different
-    // goal each phase) needs the global flag to suppress the per-phase prose.
+    // True when the profile goal steps temperature across the shot (e.g.
+    // 82→72°C). markPerPhaseTempInstability only checks for stepping within
+    // a single phase, so cross-phase stepping (flat goal per phase, different
+    // goal each phase) needs this global flag to suppress per-phase prose.
     bool tempIntentionalStepping = false;
 
     // DYE metadata (from user input)

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -94,6 +94,19 @@ struct ShotSummary {
     // (which analyzeShot's aggregate output doesn't surface).
     bool pourTruncatedDetected = false;
 
+    // Intentional temperature stepping flag — when the profile steps the
+    // temperature goal across the shot (e.g. 82→72°C decline), per-phase
+    // average deviation is by design, not instability. The global detector
+    // already suppresses the aggregate "Temperature unstable" line on this
+    // basis (`ShotAnalysis::AnalysisResult::detectors.tempIntentionalStepping`);
+    // mirror that suppression for the per-phase prose so the AI advisor sees
+    // a consistent story between the structured detectorResults envelope and
+    // the prose shotAnalysis. The per-phase variant of
+    // `hasIntentionalTempStepping` only sees stepping within a single phase,
+    // so a profile that steps *across* phases (flat goal per phase, different
+    // goal each phase) needs the global flag to suppress the per-phase prose.
+    bool tempIntentionalStepping = false;
+
     // DYE metadata (from user input)
     QString beanBrand;
     QString beanType;

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -299,16 +299,12 @@ private slots:
                  "preheat-ramp drift must not surface in the prompt for aborted-preinfusion shots");
     }
 
-    // Issue #1018: when the profile goal steps temperature *across* phases
-    // (e.g. 80's Espresso 82→72°C — flat-per-phase, different goal each
-    // phase), the per-phase variant of hasIntentionalTempStepping returns
-    // false (no stepping within a single phase) but the global detector
-    // returns true and treats the shot as stable. Without the global
-    // suppression, the prose blocks emit "Temperature instability" on
-    // every phase whose avg deviation > 2°C, contradicting the
-    // detectorResults envelope (`tempStability.intentionalStepping: true,
-    // unstable: false`) and the system prompt's own "DO NOT flag low temp
-    // on a stepping profile" guidance.
+    // When the profile goal steps temperature across phases (flat goal
+    // within each phase, different goal each phase — e.g. 82→72°C), the
+    // per-phase hasIntentionalTempStepping check returns false but the
+    // global detector flags the shot as stepping. The per-phase prose
+    // gate must use the global flag, not the per-phase signal, or the
+    // prose contradicts the detectorResults envelope.
     void intentionalCrossPhaseSteppingSuppressesPerPhaseTempProse()
     {
         QVariantMap shot;
@@ -368,12 +364,10 @@ private slots:
                  "per-phase Temperature instability prose must be suppressed when the profile is intentionally stepping");
     }
 
-    // Defensive: when a legacy fast-path shotData carries no `tempStability`
-    // envelope (pre-#1017 history rows that flowed through the earlier
-    // convertShotRecord pass), the .toMap().value(...).toBool() chain in
-    // summarizeFromHistory must default to false rather than crashing or
-    // guessing. Without this, per-phase suppression on legacy rows would
-    // silently de-couple from the live path on the affected population.
+    // Defensive: when a fast-path shotData carries no `tempStability`
+    // envelope, the .toMap().value(...).toBool() chain must default to
+    // false rather than crashing. Without this, suppression on rows
+    // without the envelope would silently de-couple from the live path.
     void summarizeFromHistory_fastPathMissingTempStabilityEnvelopeDefaultsFalse()
     {
         QVariantMap shot = buildHealthyShotMap();
@@ -384,8 +378,8 @@ private slots:
         lines.append(line);
         shot["summaryLines"] = lines;
 
-        // Detector envelope present but no tempStability key — the legacy
-        // shape before #1017's standardization. pourTruncated stays false.
+        // Detector envelope present but no tempStability key.
+        // pourTruncated stays false.
         QVariantMap detectors;
         detectors["pourTruncated"] = false;
         shot["detectorResults"] = detectors;
@@ -397,18 +391,27 @@ private slots:
                  "missing tempStability envelope must default to !intentionalStepping (legacy rows)");
     }
 
-    // Cascade integrity through the fast path: when shotData carries
-    // detectorResults.tempStability.intentionalStepping == true, the per-phase
-    // prose must be suppressed even though the per-phase
-    // hasIntentionalTempStepping check might still return false (cross-phase
-    // stepping). Mirror of the slow-path check above through the
-    // pre-computed-summaryLines path.
-    void summarizeFromHistory_fastPathPropagatesIntentionalStepping()
+    // Fast path end-to-end: with non-empty summaryLines (skips analyzeShot)
+    // and a tempStability envelope flagging intentionalStepping, the per-phase
+    // markPerPhaseTempInstability still marks phases unstable (per-phase goal
+    // is flat, avg deviation > 2°C) but the gate in buildUserPrompt must
+    // suppress the prose because of the global flag. Asserts the prompt
+    // string itself, not just the bool — without that, a future refactor
+    // that breaks the gate while leaving propagation intact would slip past.
+    void summarizeFromHistory_fastPathSuppressesProseWhenSteppingFlagSet()
     {
         QVariantMap shot = buildHealthyShotMap();
-        // Force tempIntentionalStepping=true via the detector envelope; the
-        // detail of summaryLines doesn't matter — any non-empty list takes
-        // the fast path.
+        // Override temp curves so each phase has avg deviation ~3°C against
+        // a flat-per-phase goal — phase.temperatureUnstable will be set
+        // unless the gate suppresses it.
+        QVariantList temperature, temperatureGoal;
+        appendFlat(temperature, 0.0, 8.0, 79.0);
+        appendFlat(temperature, 8.0 + 0.1, 30.0, 69.0);
+        appendFlat(temperatureGoal, 0.0, 8.0, 82.0);
+        appendFlat(temperatureGoal, 8.0 + 0.1, 30.0, 72.0);
+        shot["temperature"] = temperature;
+        shot["temperatureGoal"] = temperatureGoal;
+
         QVariantMap line;
         line["text"] = QStringLiteral("dummy");
         line["type"] = QStringLiteral("good");
@@ -431,6 +434,53 @@ private slots:
 
         QVERIFY2(summary.tempIntentionalStepping,
                  "fast path must derive tempIntentionalStepping from detectorResults.tempStability");
+        const QString prompt = summarizer.buildUserPrompt(summary);
+        QVERIFY2(!prompt.contains(QStringLiteral("Temperature instability")),
+                 "fast path must suppress per-phase prose when the envelope flags intentional stepping");
+    }
+
+    // Negative control for the gate: same temp deviation as the test above,
+    // but the envelope explicitly says !intentionalStepping. The per-phase
+    // "Temperature instability" prose must still emit. Without this control,
+    // an over-aggressive gate (default-true, inverted condition) would
+    // silently swallow legitimate warnings on every shot and every other
+    // test would still pass.
+    void summarizeFromHistory_fastPathEmitsProseWhenNotStepping()
+    {
+        QVariantMap shot = buildHealthyShotMap();
+        QVariantList temperature, temperatureGoal;
+        appendFlat(temperature, 0.0, 8.0, 79.0);
+        appendFlat(temperature, 8.0 + 0.1, 30.0, 69.0);
+        appendFlat(temperatureGoal, 0.0, 8.0, 82.0);
+        appendFlat(temperatureGoal, 8.0 + 0.1, 30.0, 72.0);
+        shot["temperature"] = temperature;
+        shot["temperatureGoal"] = temperatureGoal;
+
+        QVariantMap line;
+        line["text"] = QStringLiteral("dummy");
+        line["type"] = QStringLiteral("good");
+        QVariantList lines;
+        lines.append(line);
+        shot["summaryLines"] = lines;
+
+        QVariantMap tempStability;
+        tempStability["checked"] = true;
+        tempStability["intentionalStepping"] = false;
+        tempStability["avgDeviationC"] = 3.0;
+        tempStability["unstable"] = true;
+        QVariantMap detectors;
+        detectors["pourTruncated"] = false;
+        detectors["tempStability"] = tempStability;
+        shot["detectorResults"] = detectors;
+
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
+
+        QVERIFY2(!summary.tempIntentionalStepping,
+                 "control: explicit !intentionalStepping must not flip the flag");
+        const QString prompt = summarizer.buildUserPrompt(summary);
+        QVERIFY2(prompt.contains(QStringLiteral("Temperature instability")),
+                 "without the stepping flag the per-phase instability prose must still surface");
     }
 
     // Sanity: a healthy shot (peak pressure ~9 bar) flows through the same

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -368,6 +368,35 @@ private slots:
                  "per-phase Temperature instability prose must be suppressed when the profile is intentionally stepping");
     }
 
+    // Defensive: when a legacy fast-path shotData carries no `tempStability`
+    // envelope (pre-#1017 history rows that flowed through the earlier
+    // convertShotRecord pass), the .toMap().value(...).toBool() chain in
+    // summarizeFromHistory must default to false rather than crashing or
+    // guessing. Without this, per-phase suppression on legacy rows would
+    // silently de-couple from the live path on the affected population.
+    void summarizeFromHistory_fastPathMissingTempStabilityEnvelopeDefaultsFalse()
+    {
+        QVariantMap shot = buildHealthyShotMap();
+        QVariantMap line;
+        line["text"] = QStringLiteral("dummy");
+        line["type"] = QStringLiteral("good");
+        QVariantList lines;
+        lines.append(line);
+        shot["summaryLines"] = lines;
+
+        // Detector envelope present but no tempStability key — the legacy
+        // shape before #1017's standardization. pourTruncated stays false.
+        QVariantMap detectors;
+        detectors["pourTruncated"] = false;
+        shot["detectorResults"] = detectors;
+
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
+
+        QVERIFY2(!summary.tempIntentionalStepping,
+                 "missing tempStability envelope must default to !intentionalStepping (legacy rows)");
+    }
+
     // Cascade integrity through the fast path: when shotData carries
     // detectorResults.tempStability.intentionalStepping == true, the per-phase
     // prose must be suppressed even though the per-phase

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -299,6 +299,111 @@ private slots:
                  "preheat-ramp drift must not surface in the prompt for aborted-preinfusion shots");
     }
 
+    // Issue #1018: when the profile goal steps temperature *across* phases
+    // (e.g. 80's Espresso 82→72°C — flat-per-phase, different goal each
+    // phase), the per-phase variant of hasIntentionalTempStepping returns
+    // false (no stepping within a single phase) but the global detector
+    // returns true and treats the shot as stable. Without the global
+    // suppression, the prose blocks emit "Temperature instability" on
+    // every phase whose avg deviation > 2°C, contradicting the
+    // detectorResults envelope (`tempStability.intentionalStepping: true,
+    // unstable: false`) and the system prompt's own "DO NOT flag low temp
+    // on a stepping profile" guidance.
+    void intentionalCrossPhaseSteppingSuppressesPerPhaseTempProse()
+    {
+        QVariantMap shot;
+        shot["beverageType"] = QStringLiteral("espresso");
+        shot["durationSec"] = 30.0;
+        shot["doseWeightG"] = 18.0;
+        shot["finalWeightG"] = 36.0;
+
+        QVariantList pressure;
+        appendFlat(pressure, 0.0, 8.0, 2.0);
+        appendFlat(pressure, 8.0, 30.0, 9.0);
+
+        QVariantList flow;
+        appendFlat(flow, 0.0, 30.0, 1.8);
+
+        // Per-phase the goal is flat (82 in preinfusion, 72 in pour). The
+        // bounded hasIntentionalTempStepping returns false for both phases
+        // (no per-phase range). Globally the goal spans 82→72 = 10°C, well
+        // above TEMP_STEPPING_RANGE — the global detector flags the shot as
+        // intentionally stepping.
+        QVariantList temperature, temperatureGoal;
+        appendFlat(temperature, 0.0, 8.0, 79.0);   // 3°C below goal in preinfusion
+        appendFlat(temperature, 8.0 + 0.1, 30.0, 69.0);  // 3°C below goal in pour
+        appendFlat(temperatureGoal, 0.0, 8.0, 82.0);
+        appendFlat(temperatureGoal, 8.0 + 0.1, 30.0, 72.0);
+
+        QVariantList derivative;
+        appendFlat(derivative, 0.0, 30.0, 0.0);
+
+        QVariantList weight;
+        appendFlat(weight, 0.0, 30.0, 36.0);
+
+        QVariantList phases;
+        appendPhase(phases, 0.0, QStringLiteral("Preinfusion"), 0);
+        appendPhase(phases, 8.0, QStringLiteral("Pour"), 1);
+
+        shot["pressure"] = pressure;
+        shot["flow"] = flow;
+        shot["temperature"] = temperature;
+        shot["temperatureGoal"] = temperatureGoal;
+        shot["conductanceDerivative"] = derivative;
+        shot["weight"] = weight;
+        shot["phases"] = phases;
+        shot["pressureGoal"] = QVariantList();
+        shot["flowGoal"] = QVariantList();
+
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
+
+        QVERIFY2(summary.tempIntentionalStepping,
+                 "82->72 cross-phase goal must set tempIntentionalStepping (matches detectorResults envelope)");
+        QVERIFY2(!summary.pourTruncatedDetected,
+                 "test setup: 9-bar peak should not trip pourTruncated");
+
+        const QString prompt = summarizer.buildUserPrompt(summary);
+        QVERIFY2(!prompt.contains(QStringLiteral("Temperature instability")),
+                 "per-phase Temperature instability prose must be suppressed when the profile is intentionally stepping");
+    }
+
+    // Cascade integrity through the fast path: when shotData carries
+    // detectorResults.tempStability.intentionalStepping == true, the per-phase
+    // prose must be suppressed even though the per-phase
+    // hasIntentionalTempStepping check might still return false (cross-phase
+    // stepping). Mirror of the slow-path check above through the
+    // pre-computed-summaryLines path.
+    void summarizeFromHistory_fastPathPropagatesIntentionalStepping()
+    {
+        QVariantMap shot = buildHealthyShotMap();
+        // Force tempIntentionalStepping=true via the detector envelope; the
+        // detail of summaryLines doesn't matter — any non-empty list takes
+        // the fast path.
+        QVariantMap line;
+        line["text"] = QStringLiteral("dummy");
+        line["type"] = QStringLiteral("good");
+        QVariantList lines;
+        lines.append(line);
+        shot["summaryLines"] = lines;
+
+        QVariantMap tempStability;
+        tempStability["checked"] = true;
+        tempStability["intentionalStepping"] = true;
+        tempStability["avgDeviationC"] = 3.0;
+        tempStability["unstable"] = false;
+        QVariantMap detectors;
+        detectors["pourTruncated"] = false;
+        detectors["tempStability"] = tempStability;
+        shot["detectorResults"] = detectors;
+
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
+
+        QVERIFY2(summary.tempIntentionalStepping,
+                 "fast path must derive tempIntentionalStepping from detectorResults.tempStability");
+    }
+
     // Sanity: a healthy shot (peak pressure ~9 bar) flows through the same
     // path but pourTruncatedDetected stays false and the cascade does not
     // suppress observations. This guards against an over-aggressive gate.


### PR DESCRIPTION
## Summary

- Adds `ShotSummary::tempIntentionalStepping` and propagates it from both the slow path (live shots / analyzeShot) and the fast path (pre-computed `detectorResults.tempStability.intentionalStepping` envelope from `convertShotRecord`).
- Gates the per-phase "Temperature instability" line in `buildUserPrompt` on `!tempIntentionalStepping`, matching the existing pourTruncated suppression pattern at the same callsite.

## Why

`detectorResults.tempStability` correctly reports `{intentionalStepping: true, unstable: false}` on stepping profiles like 80's Espresso (82→72°C decline), but the prose `shotAnalysis` was tagging two phases with "Temperature instability" anyway. The per-phase variant of `hasIntentionalTempStepping` returns false when each phase's goal is flat (the goal *across* phases is what's stepping), so the prose never saw the stepping signal the global detector already raised.

Closes #1018.

## Test plan

- [x] `tst_ShotSummarizer` — 16 passed (added `intentionalCrossPhaseSteppingSuppressesPerPhaseTempProse` for the slow path and `summarizeFromHistory_fastPathPropagatesIntentionalStepping` for the detectorResults envelope).
- [x] `tst_ShotAnalysis` — 71 passed (no regressions).
- [ ] Live verification on a stepping profile shot (80's Espresso) to confirm the prompt no longer contains "Temperature instability" in per-phase blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)