### PR TITLE
fix(mcp): fall back to last shot for blank currentBean grinder/dose (#1019)

### DIFF
--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -434,24 +434,34 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         result["profileKnowledge"] = profileKnowledge;
 
                     // --- Bean/grinder metadata (current DYE settings) ---
-                    // The `beanFreshness` block replaces the previous
-                    // `roastDate` + `daysSinceRoast` + `daysSinceRoastNote`
-                    // shape. The precomputed day count is intentionally
-                    // absent — calendar age without storage context (frozen
-                    // vs counter, days-since-thawed) is misleading data
-                    // dressed as precise data, and the AI was skimming past
-                    // the advisory note. The new `instruction` reads
-                    // imperative: ASK about storage before quoting age.
+                    // DYE wins per-field; for grinder + dose, fall back to
+                    // the resolved shot's value when DYE is blank so the AI
+                    // doesn't lose its highest-leverage signal (burr
+                    // geometry, grinder brand, current setting) when the
+                    // user hasn't filled out DYE recently. Bean fields
+                    // (brand/type/roastLevel) and roastDate are *not*
+                    // inferred — beans rotate per hopper and roastDate
+                    // lives only inside `beanFreshness` to keep the
+                    // freshness surface in one place. Merge logic lives in
+                    // McpDialingHelpers::buildCurrentBean (pure,
+                    // unit-tested).
                     if (settings) {
-                        QJsonObject bean;
-                        bean["brand"] = settings->dye()->dyeBeanBrand();
-                        bean["type"] = settings->dye()->dyeBeanType();
-                        bean["roastLevel"] = settings->dye()->dyeRoastLevel();
-                        bean["grinderBrand"] = settings->dye()->dyeGrinderBrand();
-                        bean["grinderModel"] = settings->dye()->dyeGrinderModel();
-                        bean["grinderBurrs"] = settings->dye()->dyeGrinderBurrs();
-                        bean["grinderSetting"] = settings->dye()->dyeGrinderSetting();
-                        bean["doseWeightG"] = settings->dye()->dyeBeanWeight();
+                        McpDialingHelpers::CurrentBeanInputs in;
+                        in.dyeBeanBrand = settings->dye()->dyeBeanBrand();
+                        in.dyeBeanType = settings->dye()->dyeBeanType();
+                        in.dyeRoastLevel = settings->dye()->dyeRoastLevel();
+                        in.dyeGrinderBrand = settings->dye()->dyeGrinderBrand();
+                        in.dyeGrinderModel = settings->dye()->dyeGrinderModel();
+                        in.dyeGrinderBurrs = settings->dye()->dyeGrinderBurrs();
+                        in.dyeGrinderSetting = settings->dye()->dyeGrinderSetting();
+                        in.dyeDoseWeightG = settings->dye()->dyeBeanWeight();
+                        in.fallbackGrinderBrand = sd.grinderBrand;
+                        in.fallbackGrinderModel = sd.grinderModel;
+                        in.fallbackGrinderBurrs = sd.grinderBurrs;
+                        in.fallbackGrinderSetting = sd.grinderSetting;
+                        in.fallbackDoseWeightG = sd.doseWeightG;
+                        in.fallbackShotId = resolvedShotId;
+                        QJsonObject bean = McpDialingHelpers::buildCurrentBean(in);
                         const QJsonObject freshness = McpDialingHelpers::buildBeanFreshness(
                             settings->dye()->dyeRoastDate());
                         if (!freshness.isEmpty())

--- a/src/mcp/mcptools_dialing_helpers.h
+++ b/src/mcp/mcptools_dialing_helpers.h
@@ -238,8 +238,9 @@ inline QJsonObject buildCurrentBean(const CurrentBeanInputs& in)
         bean["inferredFromShotId"] = in.fallbackShotId;
         bean["inferredFields"] = inferredFields;
         bean["inferredNote"] = QStringLiteral(
-            "Listed fields are inferred from the most recent shot, not entered "
-            "by the user. Confirm before recommending a change.");
+            "Listed fields are inferred from the resolved shot (id "
+            "above), not entered by the user. Confirm before recommending "
+            "a change.");
     }
 
     return bean;

--- a/src/mcp/mcptools_dialing_helpers.h
+++ b/src/mcp/mcptools_dialing_helpers.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QJsonArray>
 #include <QJsonObject>
 #include <QList>
 #include <QString>
@@ -154,6 +155,94 @@ inline QJsonObject buildBeanFreshness(const QString& roastDate)
     block["freshnessKnown"] = false;
     block["instruction"] = QString::fromUtf8(kBeanFreshnessInstruction);
     return block;
+}
+
+// Per-field inputs the currentBean block synthesizes from. The caller fills
+// the `dye*` half from `Settings::dye()` (live, user-entered) and the
+// `fallback*` half from the resolved shot's grinder/dose metadata. The
+// helper picks per field: DYE if non-empty, otherwise the fallback shot's
+// value, and tracks which fields ended up inferred.
+//
+// Bean fields (brand/type/roastLevel) are intentionally not inferred —
+// those rotate per hopper and a stale-shot value could mislead the AI
+// into reasoning about the wrong bean. roastDate is also un-inferred and
+// surfaced separately via `buildBeanFreshness` — calendar age without
+// storage context is misleading regardless of source. Grinder + dose are
+// stable across shots within an iteration session, so falling back is
+// safe.
+struct CurrentBeanInputs {
+    // Live DYE values from Settings::dye() (the "currently loaded" snapshot).
+    QString dyeBeanBrand;
+    QString dyeBeanType;
+    QString dyeRoastLevel;
+    QString dyeGrinderBrand;
+    QString dyeGrinderModel;
+    QString dyeGrinderBurrs;
+    QString dyeGrinderSetting;
+    double dyeDoseWeightG = 0;
+
+    // Resolved shot's grinder/dose snapshot (used as fallback when the DYE
+    // counterpart is blank/zero). Bean fields aren't carried here — see
+    // rationale above.
+    QString fallbackGrinderBrand;
+    QString fallbackGrinderModel;
+    QString fallbackGrinderBurrs;
+    QString fallbackGrinderSetting;
+    double fallbackDoseWeightG = 0;
+    qint64 fallbackShotId = 0;
+};
+
+// Build the `currentBean` JSON object with grinder/dose fallback to the
+// resolved shot's values when the DYE field is empty/zero. Inferred fields
+// are listed in `inferredFields`, with `inferredFromShotId` and an
+// inferredNote pointing the AI to confirm before recommending a change.
+// roastDate / beanFreshness are *not* set here — the caller composes
+// `bean["beanFreshness"]` via `buildBeanFreshness(...)` so the freshness
+// surface stays in one place.
+//
+// Pure function: no Qt object dependencies beyond JSON value types, easy to
+// unit-test.
+inline QJsonObject buildCurrentBean(const CurrentBeanInputs& in)
+{
+    QJsonObject bean;
+    bean["brand"] = in.dyeBeanBrand;
+    bean["type"] = in.dyeBeanType;
+    bean["roastLevel"] = in.dyeRoastLevel;
+
+    QJsonArray inferredFields;
+    auto pickStr = [&](const QString& dye, const QString& fallback,
+                        const QString& key) -> QString {
+        if (dye.isEmpty() && !fallback.isEmpty()) {
+            inferredFields.append(key);
+            return fallback;
+        }
+        return dye;
+    };
+    bean["grinderBrand"] = pickStr(in.dyeGrinderBrand, in.fallbackGrinderBrand,
+        QStringLiteral("grinderBrand"));
+    bean["grinderModel"] = pickStr(in.dyeGrinderModel, in.fallbackGrinderModel,
+        QStringLiteral("grinderModel"));
+    bean["grinderBurrs"] = pickStr(in.dyeGrinderBurrs, in.fallbackGrinderBurrs,
+        QStringLiteral("grinderBurrs"));
+    bean["grinderSetting"] = pickStr(in.dyeGrinderSetting, in.fallbackGrinderSetting,
+        QStringLiteral("grinderSetting"));
+
+    if (in.dyeDoseWeightG <= 0 && in.fallbackDoseWeightG > 0) {
+        bean["doseWeightG"] = in.fallbackDoseWeightG;
+        inferredFields.append(QStringLiteral("doseWeightG"));
+    } else {
+        bean["doseWeightG"] = in.dyeDoseWeightG;
+    }
+
+    if (!inferredFields.isEmpty() && in.fallbackShotId > 0) {
+        bean["inferredFromShotId"] = in.fallbackShotId;
+        bean["inferredFields"] = inferredFields;
+        bean["inferredNote"] = QStringLiteral(
+            "Listed fields are inferred from the most recent shot, not entered "
+            "by the user. Confirm before recommending a change.");
+    }
+
+    return bean;
 }
 
 } // namespace McpDialingHelpers

--- a/tests/tst_mcptools_dialing_helpers.cpp
+++ b/tests/tst_mcptools_dialing_helpers.cpp
@@ -29,6 +29,15 @@ private slots:
     void hoistSessionContext_singleShotSession_contextCarriesIdentity();
     void hoistSessionContext_firstShotEmptyForField_fallsBackToFirstNonEmpty();
     void hoistSessionContext_allShotsEmptyForField_contextOmitsField();
+
+    // buildCurrentBean (issue #1019)
+    void buildCurrentBean_dyePopulated_noInference();
+    void buildCurrentBean_grinderBlank_inferredFromShot();
+    void buildCurrentBean_doseBlank_inferredFromShot();
+    void buildCurrentBean_partialFallback_listsOnlyInferredFields();
+    void buildCurrentBean_beanFieldsNeverInferred();
+    void buildCurrentBean_bothBlank_omitsInferredMeta();
+    void buildCurrentBean_dyeWins_overShotValues();
 };
 
 void TstMcpToolsDialingHelpers::emptyInput_returnsNoSessions()
@@ -321,6 +330,160 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_allShotsEmptyForField_contex
     for (const auto& override : out.perShotOverrides) {
         QVERIFY(override.grinderBurrs.isEmpty());
     }
+}
+
+// ---- buildCurrentBean (issue #1019) ----
+//
+// The DYE block represents what's currently in the grinder/hopper. When
+// grinder/dose fields are blank but the resolved shot has them populated,
+// fall back to the shot's values and tag them as inferred so the AI knows
+// to confirm before recommending a change. Bean fields (brand/type/
+// roastLevel) are *never* inferred — those rotate per hopper. roastDate
+// is intentionally absent from the helper output; it lives in
+// `currentBean.beanFreshness` (composed by the caller) so the freshness
+// surface stays in one place.
+
+namespace {
+CurrentBeanInputs sampleInputs()
+{
+    CurrentBeanInputs in;
+    in.dyeBeanBrand = QStringLiteral("Northbound");
+    in.dyeBeanType = QStringLiteral("Single Origin");
+    in.dyeRoastLevel = QStringLiteral("Light");
+    in.dyeGrinderBrand = QStringLiteral("Niche");
+    in.dyeGrinderModel = QStringLiteral("Zero");
+    in.dyeGrinderBurrs = QStringLiteral("63mm Mazzer Kony conical");
+    in.dyeGrinderSetting = QStringLiteral("4.5");
+    in.dyeDoseWeightG = 18.0;
+    in.fallbackGrinderBrand = QStringLiteral("Eureka");
+    in.fallbackGrinderModel = QStringLiteral("Mignon");
+    in.fallbackGrinderBurrs = QStringLiteral("55mm flat");
+    in.fallbackGrinderSetting = QStringLiteral("12");
+    in.fallbackDoseWeightG = 20.0;
+    in.fallbackShotId = 884;
+    return in;
+}
+} // namespace
+
+void TstMcpToolsDialingHelpers::buildCurrentBean_dyePopulated_noInference()
+{
+    const QJsonObject bean = buildCurrentBean(sampleInputs());
+
+    QCOMPARE(bean["grinderBrand"].toString(), QStringLiteral("Niche"));
+    QCOMPARE(bean["grinderModel"].toString(), QStringLiteral("Zero"));
+    QCOMPARE(bean["grinderSetting"].toString(), QStringLiteral("4.5"));
+    QCOMPARE(bean["doseWeightG"].toDouble(), 18.0);
+    QVERIFY2(!bean.contains("inferredFromShotId"),
+             "DYE fully populated must not surface inferredFromShotId");
+    QVERIFY2(!bean.contains("inferredFields"),
+             "DYE fully populated must not surface inferredFields");
+}
+
+void TstMcpToolsDialingHelpers::buildCurrentBean_grinderBlank_inferredFromShot()
+{
+    CurrentBeanInputs in = sampleInputs();
+    in.dyeGrinderBrand.clear();
+    in.dyeGrinderModel.clear();
+    in.dyeGrinderBurrs.clear();
+    in.dyeGrinderSetting.clear();
+
+    const QJsonObject bean = buildCurrentBean(in);
+
+    QCOMPARE(bean["grinderBrand"].toString(), QStringLiteral("Eureka"));
+    QCOMPARE(bean["grinderModel"].toString(), QStringLiteral("Mignon"));
+    QCOMPARE(bean["grinderBurrs"].toString(), QStringLiteral("55mm flat"));
+    QCOMPARE(bean["grinderSetting"].toString(), QStringLiteral("12"));
+    QCOMPARE(bean["inferredFromShotId"].toInteger(), qint64(884));
+
+    const QJsonArray inferred = bean["inferredFields"].toArray();
+    QCOMPARE(inferred.size(), 4);
+    QVERIFY(inferred.contains(QStringLiteral("grinderBrand")));
+    QVERIFY(inferred.contains(QStringLiteral("grinderModel")));
+    QVERIFY(inferred.contains(QStringLiteral("grinderBurrs")));
+    QVERIFY(inferred.contains(QStringLiteral("grinderSetting")));
+    QVERIFY2(bean.contains("inferredNote"),
+             "inferred fields must come with an explanatory note");
+}
+
+void TstMcpToolsDialingHelpers::buildCurrentBean_doseBlank_inferredFromShot()
+{
+    CurrentBeanInputs in = sampleInputs();
+    in.dyeDoseWeightG = 0;
+
+    const QJsonObject bean = buildCurrentBean(in);
+
+    QCOMPARE(bean["doseWeightG"].toDouble(), 20.0);
+    const QJsonArray inferred = bean["inferredFields"].toArray();
+    QCOMPARE(inferred.size(), 1);
+    QVERIFY(inferred.contains(QStringLiteral("doseWeightG")));
+}
+
+void TstMcpToolsDialingHelpers::buildCurrentBean_partialFallback_listsOnlyInferredFields()
+{
+    CurrentBeanInputs in = sampleInputs();
+    in.dyeGrinderSetting.clear();   // only this one is blank
+
+    const QJsonObject bean = buildCurrentBean(in);
+
+    const QJsonArray inferred = bean["inferredFields"].toArray();
+    QCOMPARE(inferred.size(), 1);
+    QCOMPARE(inferred[0].toString(), QStringLiteral("grinderSetting"));
+    // Other grinder fields stayed on DYE values
+    QCOMPARE(bean["grinderBrand"].toString(), QStringLiteral("Niche"));
+}
+
+void TstMcpToolsDialingHelpers::buildCurrentBean_beanFieldsNeverInferred()
+{
+    // Bean brand/type/roastLevel rotate per hopper — falling back to a
+    // stale shot would mislead the AI. Even when DYE is fully empty,
+    // these stay blank rather than inheriting the shot's bean. roastDate
+    // is owned by `buildBeanFreshness` (composed by the caller) and is
+    // intentionally absent from the helper's output.
+    CurrentBeanInputs in = sampleInputs();
+    in.dyeBeanBrand.clear();
+    in.dyeBeanType.clear();
+    in.dyeRoastLevel.clear();
+
+    const QJsonObject bean = buildCurrentBean(in);
+
+    QVERIFY2(bean["brand"].toString().isEmpty(),
+             "bean brand must never be inferred from shot");
+    QVERIFY2(bean["type"].toString().isEmpty(),
+             "bean type must never be inferred from shot");
+    QVERIFY2(bean["roastLevel"].toString().isEmpty(),
+             "roast level must never be inferred from shot");
+    QVERIFY2(!bean.contains("roastDate"),
+             "roastDate must not appear at currentBean top level — owned by beanFreshness");
+    // No grinder/dose blanks → no inferredFields surfaced.
+    QVERIFY(!bean.contains("inferredFields"));
+}
+
+void TstMcpToolsDialingHelpers::buildCurrentBean_bothBlank_omitsInferredMeta()
+{
+    // Both DYE and shot grinder are blank — no inference possible.
+    CurrentBeanInputs in;
+    in.fallbackShotId = 884;
+    const QJsonObject bean = buildCurrentBean(in);
+
+    QVERIFY2(!bean.contains("inferredFromShotId"),
+             "no fallback data → no inferred meta");
+    QVERIFY2(!bean.contains("inferredFields"),
+             "no fallback data → no inferred meta");
+}
+
+void TstMcpToolsDialingHelpers::buildCurrentBean_dyeWins_overShotValues()
+{
+    // Sanity: when DYE is populated and the shot has different values, DYE
+    // wins. This pins the precedence direction — production code never
+    // overrides user-entered DYE with shot data.
+    CurrentBeanInputs in = sampleInputs();
+    // DYE says Niche, shot says Eureka — Niche must surface.
+    QCOMPARE(in.dyeGrinderBrand, QStringLiteral("Niche"));
+    QCOMPARE(in.fallbackGrinderBrand, QStringLiteral("Eureka"));
+
+    const QJsonObject bean = buildCurrentBean(in);
+    QCOMPARE(bean["grinderBrand"].toString(), QStringLiteral("Niche"));
+    QVERIFY(!bean.contains("inferredFields"));
 }
 
 QTEST_APPLESS_MAIN(TstMcpToolsDialingHelpers)


### PR DESCRIPTION
## Summary

- Add `McpDialingHelpers::buildCurrentBean` (pure helper) that picks each grinder/dose field per-cell: DYE wins when non-empty, otherwise the resolved shot's value, with the inferred field names listed in `inferredFields` and an `inferredFromShotId` + `inferredNote` so the AI can confirm with the user before recommending a change.
- Wire it into `dialing_get_context` instead of the inline DYE-only block.
- Bean fields (brand/type/roastDate/roastLevel) stay un-inferred — they rotate per hopper and inheriting them from a stale shot would mislead the AI.

## Why

When the user hadn't filled out DYE recently, `currentBean` showed every grinder field blank even though the most recent shot had brand/model/burrs/setting populated — neutering the system prompt's grinder-geometry reasoning section. The data was right there in `dialInSessions[0].shots[0]` but invisible to the AI's mental model of "what's currently loaded."

Closes #1019.

## Test plan

- [x] `TstMcpToolsDialingHelpers` — 17 passed (added 7 cases: DYE-populated no-inference, grinder blank → inferred, dose blank → inferred, partial fallback lists only blank fields, bean fields never inferred, both-blank omits meta, DYE wins over shot).
- [ ] Live verification: clear DYE grinder fields in app, save a shot with grinder set, then call `dialing_get_context` and confirm the response carries `inferredFields: [grinderBrand, grinderModel, grinderBurrs, grinderSetting]` with the shot's values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)