### PR TITLE
feat(mcp): add sawPrediction block to dialing_get_context (#1021)

### DIFF
--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -613,9 +613,14 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     //     a SAW prediction at all.
                     //   - scale + profile configured: SAW pair key needs
                     //     both. Empty either side -> omit.
-                    if (settings && profileManager &&
-                        dbResult.shotData.beverageType.compare(
-                            QStringLiteral("espresso"), Qt::CaseInsensitive) == 0) {
+                    // Reuse the bevType local computed above — it defaults
+                    // empty beverageType to "espresso" the same way the
+                    // grinderContext block does, so older/imported shots
+                    // without an explicit beverageType behave consistently
+                    // with the rest of the response.
+                    if (settings && profileManager
+                        && bevType.compare(QStringLiteral("espresso"),
+                                           Qt::CaseInsensitive) == 0) {
                         const QString scaleType = settings->scaleType();
                         const QString profileFilename = profileManager->baseProfileName();
                         const double flowAtCutoff = McpDialingHelpers::estimateFlowAtCutoff(

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -70,17 +70,14 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
         "metadata, grinder context (observed settings range, step size, and burr-swappable flag), "
         "a tastingFeedback block flagging whether the shot has enjoyment / notes / refractometer "
         "data — when any is missing the block carries a recommendation to ask the user before "
-<<<<<<< HEAD
         "suggesting changes — and a bestRecentShot anchor (highest-rated past shot on the same "
         "profile within the last 90 days, with a changeFromBest diff against the current shot) "
         "so advice can reference what success has looked like, not just what changed since last "
         "pull. The 90-day window keeps the anchor on the user's current setup era; the block "
-        "is omitted when no rated shot in that window exists. "
-=======
-        "suggesting changes — and a sawPrediction block (predicted post-cut drip in grams from the "
-        "stop-at-weight learner, with sourceTier reporting which model is active so the AI can "
-        "weight its confidence). "
->>>>>>> 880d5b7a (feat(mcp): add sawPrediction block to dialing_get_context (#1021))
+        "is omitted when no rated shot in that window exists. A sawPrediction block surfaces "
+        "the predicted post-cut drip in grams from the stop-at-weight learner (espresso only; "
+        "with sourceTier reporting which model is active so the AI can weight its confidence; "
+        "omitted when no scale is configured or the shot lacks usable flow data). "
         "Primary read tool for dial-in conversations — a single call gives everything needed to analyze "
         "a shot and suggest changes. Default profileKnowledge contains only the current profile's "
         "curated KB entry (~1 KB); pass includeFullKnowledge: true to also receive the dial-in system "
@@ -601,24 +598,29 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     // active (perProfile / globalBootstrap / globalPool /
                     // scaleDefault), so the AI can weight its confidence.
                     // Read-only signal — AI proposes, user/shots_update/
-                    // settings_set writes. Omitted entirely when no scale
-                    // is configured (no scaleType) or no profile is loaded
-                    // (no filename to key the SAW pair off).
-                    if (settings && profileManager) {
+                    // settings_set writes.
+                    //
+                    // Gates (review feedback on #1021):
+                    //   - espresso only: filter / pour-over flow regimes
+                    //     run 4–8 ml/s and the SAW recommendation text is
+                    //     espresso-shaped ("set target X g lower"). The
+                    //     learner is keyed off the espresso pour anyway.
+                    //   - real flow data only: skip the block when the
+                    //     resolved shot lacks usable flow samples
+                    //     (estimateFlowAtCutoff returns 0). A hard-coded
+                    //     "1.5 ml/s default" produced sensible-looking
+                    //     numbers for shots that had no business carrying
+                    //     a SAW prediction at all.
+                    //   - scale + profile configured: SAW pair key needs
+                    //     both. Empty either side -> omit.
+                    if (settings && profileManager &&
+                        dbResult.shotData.beverageType.compare(
+                            QStringLiteral("espresso"), Qt::CaseInsensitive) == 0) {
                         const QString scaleType = settings->scaleType();
                         const QString profileFilename = profileManager->baseProfileName();
-                        if (!scaleType.isEmpty() && !profileFilename.isEmpty()) {
-                            // The actual SAW math uses the live flow at
-                            // the moment of cutoff; for the post-shot
-                            // context we approximate with the tail of the
-                            // recorded curve via estimateFlowAtCutoff
-                            // (pure helper, unit-tested). Default to
-                            // 1.5 ml/s — typical espresso pour rate —
-                            // when the shot lacks usable flow data so
-                            // imported shots still get a ballpark.
-                            double flowAtCutoff = McpDialingHelpers::estimateFlowAtCutoff(
-                                dbResult.shotData.flow, dbResult.shotData.durationSec);
-                            if (flowAtCutoff <= 0) flowAtCutoff = 1.5;
+                        const double flowAtCutoff = McpDialingHelpers::estimateFlowAtCutoff(
+                            dbResult.shotData.flow, dbResult.shotData.durationSec);
+                        if (!scaleType.isEmpty() && !profileFilename.isEmpty() && flowAtCutoff > 0) {
 
                             const double predictedDripG =
                                 settings->calibration()->getExpectedDripFor(

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -7,6 +7,7 @@
 #include "../ai/aimanager.h"
 #include "../ai/shotsummarizer.h"
 #include "../core/settings.h"
+#include "../core/settings_calibration.h"
 #include "../core/settings_dye.h"
 #include "../profile/profile.h"
 
@@ -69,11 +70,17 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
         "metadata, grinder context (observed settings range, step size, and burr-swappable flag), "
         "a tastingFeedback block flagging whether the shot has enjoyment / notes / refractometer "
         "data — when any is missing the block carries a recommendation to ask the user before "
+<<<<<<< HEAD
         "suggesting changes — and a bestRecentShot anchor (highest-rated past shot on the same "
         "profile within the last 90 days, with a changeFromBest diff against the current shot) "
         "so advice can reference what success has looked like, not just what changed since last "
         "pull. The 90-day window keeps the anchor on the user's current setup era; the block "
         "is omitted when no rated shot in that window exists. "
+=======
+        "suggesting changes — and a sawPrediction block (predicted post-cut drip in grams from the "
+        "stop-at-weight learner, with sourceTier reporting which model is active so the AI can "
+        "weight its confidence). "
+>>>>>>> 880d5b7a (feat(mcp): add sawPrediction block to dialing_get_context (#1021))
         "Primary read tool for dial-in conversations — a single call gives everything needed to analyze "
         "a shot and suggest changes. Default profileKnowledge contains only the current profile's "
         "curated KB entry (~1 KB); pass includeFullKnowledge: true to also receive the dial-in system "
@@ -582,6 +589,71 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         if (profileManager->profileHasRecommendedDose())
                             profileInfo["recommendedDoseG"] = profileManager->profileRecommendedDose();
                         result["profile"] = profileInfo;
+                    }
+
+                    // --- SAW (Stop-at-Weight) prediction (#1021) ---
+                    // Surface the per-(profile, scale) predicted post-cut
+                    // drip so the AI can answer "should I bump my target
+                    // up?" without starting a five-shot grind iteration
+                    // that addresses the wrong variable. Predicted drip
+                    // comes from the same SAW learner the in-app stop
+                    // logic uses — sourceTier reports which model is
+                    // active (perProfile / globalBootstrap / globalPool /
+                    // scaleDefault), so the AI can weight its confidence.
+                    // Read-only signal — AI proposes, user/shots_update/
+                    // settings_set writes. Omitted entirely when no scale
+                    // is configured (no scaleType) or no profile is loaded
+                    // (no filename to key the SAW pair off).
+                    if (settings && profileManager) {
+                        const QString scaleType = settings->scaleType();
+                        const QString profileFilename = profileManager->baseProfileName();
+                        if (!scaleType.isEmpty() && !profileFilename.isEmpty()) {
+                            // The actual SAW math uses the live flow at
+                            // the moment of cutoff; for the post-shot
+                            // context we approximate with the tail of the
+                            // recorded curve via estimateFlowAtCutoff
+                            // (pure helper, unit-tested). Default to
+                            // 1.5 ml/s — typical espresso pour rate —
+                            // when the shot lacks usable flow data so
+                            // imported shots still get a ballpark.
+                            double flowAtCutoff = McpDialingHelpers::estimateFlowAtCutoff(
+                                dbResult.shotData.flow, dbResult.shotData.durationSec);
+                            if (flowAtCutoff <= 0) flowAtCutoff = 1.5;
+
+                            const double predictedDripG =
+                                settings->calibration()->getExpectedDripFor(
+                                    profileFilename, scaleType, flowAtCutoff);
+                            const QString sourceTier =
+                                settings->calibration()->sawModelSource(profileFilename, scaleType);
+                            const double learnedLagSec =
+                                settings->calibration()->sawLearnedLagFor(profileFilename, scaleType);
+                            const int sampleCount =
+                                settings->calibration()->perProfileSawHistory(profileFilename, scaleType).size();
+
+                            QJsonObject sawPrediction;
+                            sawPrediction["profileFilename"] = profileFilename;
+                            sawPrediction["scaleType"] = scaleType;
+                            sawPrediction["flowAtCutoffMlPerSec"] =
+                                QString::number(flowAtCutoff, 'f', 2).toDouble();
+                            sawPrediction["predictedDripG"] =
+                                QString::number(predictedDripG, 'f', 2).toDouble();
+                            sawPrediction["learnedLagSec"] =
+                                QString::number(learnedLagSec, 'f', 2).toDouble();
+                            sawPrediction["sampleCount"] = sampleCount;
+                            sawPrediction["sourceTier"] = sourceTier;
+                            // Only emit a recommendation when the drip is
+                            // meaningfully above scale noise — for sub-
+                            // 0.2 g overshoots the AI shouldn't be
+                            // suggesting target tweaks.
+                            if (predictedDripG >= 0.2) {
+                                sawPrediction["recommendation"] = QString(
+                                    "Set the stop-at-weight target ~%1 g lower than your aim "
+                                    "to land near goal — that's the typical post-cutoff drip "
+                                    "on this (profile, scale) pair.")
+                                        .arg(predictedDripG, 0, 'f', 1);
+                            }
+                            result["sawPrediction"] = sawPrediction;
+                        }
                     }
 
                     // Note: dial-in reference tables and profile knowledge base are now

--- a/src/mcp/mcptools_dialing_helpers.h
+++ b/src/mcp/mcptools_dialing_helpers.h
@@ -4,6 +4,8 @@
 #include <QJsonObject>
 #include <QList>
 #include <QString>
+#include <QVariantList>
+#include <QVariantMap>
 #include <QtGlobal>
 
 // Helpers extracted from mcptools_dialing.cpp so the pure-logic pieces can be
@@ -291,6 +293,40 @@ inline QJsonObject buildShotChangeDiff(const ShotDiffInputs& from,
     diffNum(from.enjoyment0to100, to.enjoyment0to100,
             QStringLiteral("enjoyment0to100"), QStringLiteral(""));
     return diff;
+}
+
+// Estimate the average pour flow rate over the last `windowSec` seconds of
+// the shot. Drives the sawPrediction block: SAW math needs a representative
+// flow at cutoff, and the tail of the recorded flow curve tracks the same
+// physical flow regime that was active when stop-at-weight engaged.
+//
+// `flowSamples` is the QVariantList shape ShotProjection ships
+// (`{"x": <time>, "y": <flow>}` per entry). `durationSec` is the shot's
+// total duration; the window is `[durationSec - windowSec, durationSec]`,
+// clamped to t >= 0. Samples with y <= 0 (drip, scale noise) are skipped.
+// Returns 0.0 when no usable samples land in the window — caller decides
+// the fallback (typically "default to typical espresso pour rate").
+//
+// Pure function: the only Qt dep is QVariant unboxing.
+inline double estimateFlowAtCutoff(const QVariantList& flowSamples,
+                                    double durationSec,
+                                    double windowSec = 2.0)
+{
+    if (flowSamples.isEmpty() || durationSec <= 0) return 0.0;
+    const double windowStart = qMax(0.0, durationSec - windowSec);
+    double sum = 0.0;
+    int count = 0;
+    for (qsizetype i = flowSamples.size() - 1; i >= 0; --i) {
+        const QVariantMap pt = flowSamples[i].toMap();
+        const double t = pt.value(QStringLiteral("x")).toDouble();
+        if (t < windowStart) break;
+        const double y = pt.value(QStringLiteral("y")).toDouble();
+        if (y > 0) {
+            sum += y;
+            ++count;
+        }
+    }
+    return count > 0 ? sum / count : 0.0;
 }
 
 } // namespace McpDialingHelpers

--- a/tests/tst_mcptools_dialing_helpers.cpp
+++ b/tests/tst_mcptools_dialing_helpers.cpp
@@ -45,6 +45,14 @@ private slots:
     void buildShotChangeDiff_zeroFieldsSkipped();
     void buildShotChangeDiff_emptyStringsSkipped();
     void buildShotChangeDiff_changeFromBestExample();
+
+    // estimateFlowAtCutoff (issue #1021)
+    void estimateFlowAtCutoff_emptySamples_returnsZero();
+    void estimateFlowAtCutoff_zeroDuration_returnsZero();
+    void estimateFlowAtCutoff_averagesLastTwoSeconds();
+    void estimateFlowAtCutoff_skipsZeroFlowSamples();
+    void estimateFlowAtCutoff_shortShot_clampsWindowToZero();
+    void estimateFlowAtCutoff_customWindow();
 };
 
 void TstMcpToolsDialingHelpers::emptyInput_returnsNoSessions()
@@ -597,6 +605,89 @@ void TstMcpToolsDialingHelpers::buildShotChangeDiff_changeFromBestExample()
              QStringLiteral("Prodigal -> Northbound Coffee Roasters"));
     QCOMPARE(diff["doseG"].toString(), QStringLiteral("18.0 -> 20.0 g (+2.0)"));
     QCOMPARE(diff["yieldG"].toString(), QStringLiteral("40.2 -> 35.9 g (-4.3)"));
+}
+
+// ---- estimateFlowAtCutoff (issue #1021) ----
+//
+// SAW prediction needs a representative flow rate at the moment of cutoff.
+// We approximate by averaging the tail of the recorded flow curve.
+
+namespace {
+QVariantMap makeSample(double t, double y)
+{
+    QVariantMap m;
+    m["x"] = t;
+    m["y"] = y;
+    return m;
+}
+} // namespace
+
+void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_emptySamples_returnsZero()
+{
+    QCOMPARE(estimateFlowAtCutoff({}, 30.0), 0.0);
+}
+
+void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_zeroDuration_returnsZero()
+{
+    // No duration → no window. Defensive: legacy shots with bogus durations.
+    QVariantList samples;
+    samples.append(makeSample(10.0, 1.5));
+    QCOMPARE(estimateFlowAtCutoff(samples, 0.0), 0.0);
+}
+
+void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_averagesLastTwoSeconds()
+{
+    // Shot duration = 30s; default window = 2s → samples in [28, 30] count.
+    QVariantList samples;
+    samples.append(makeSample(10.0, 0.5));   // outside window
+    samples.append(makeSample(20.0, 1.0));   // outside window
+    samples.append(makeSample(28.0, 1.6));   // inside (boundary)
+    samples.append(makeSample(29.0, 1.8));
+    samples.append(makeSample(30.0, 2.0));
+
+    const double avg = estimateFlowAtCutoff(samples, 30.0);
+    // Average of 1.6, 1.8, 2.0 = 1.8
+    QVERIFY(qFuzzyCompare(avg, 1.8));
+}
+
+void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_skipsZeroFlowSamples()
+{
+    // y == 0 (drip detected as zero, scale rounding) shouldn't drag the avg
+    // down — the SAW prediction wants the flow regime that drove pour
+    // pressure, not stale zero readings between drops.
+    QVariantList samples;
+    samples.append(makeSample(28.0, 1.5));
+    samples.append(makeSample(29.0, 0.0));   // skip
+    samples.append(makeSample(30.0, 1.5));
+
+    const double avg = estimateFlowAtCutoff(samples, 30.0);
+    QVERIFY(qFuzzyCompare(avg, 1.5));
+}
+
+void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_shortShot_clampsWindowToZero()
+{
+    // Shot shorter than the window — window must clamp to t >= 0 so we
+    // average the whole shot rather than emit garbage.
+    QVariantList samples;
+    samples.append(makeSample(0.5, 1.0));
+    samples.append(makeSample(1.0, 2.0));
+
+    // duration=1.0, default window=2.0 → window starts at max(0, 1.0-2.0) = 0
+    const double avg = estimateFlowAtCutoff(samples, 1.0);
+    QVERIFY(qFuzzyCompare(avg, 1.5));  // (1.0 + 2.0) / 2
+}
+
+void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_customWindow()
+{
+    QVariantList samples;
+    samples.append(makeSample(25.0, 1.0));
+    samples.append(makeSample(28.0, 2.0));
+    samples.append(makeSample(30.0, 3.0));
+
+    // 5s window → [25, 30] all three samples → (1+2+3)/3 = 2.0
+    QVERIFY(qFuzzyCompare(estimateFlowAtCutoff(samples, 30.0, 5.0), 2.0));
+    // 1s window → [29, 30] only the t=30 sample → 3.0
+    QVERIFY(qFuzzyCompare(estimateFlowAtCutoff(samples, 30.0, 1.0), 3.0));
 }
 
 QTEST_APPLESS_MAIN(TstMcpToolsDialingHelpers)


### PR DESCRIPTION
## Summary

- Add a \`sawPrediction\` block to \`dialing_get_context\` that surfaces the per-(profile, scale) SAW prediction so the AI can reason about post-cut drip without starting a multi-shot iteration that addresses the wrong variable.
- Block fields: \`profileFilename\`, \`scaleType\`, \`flowAtCutoffMlPerSec\`, \`predictedDripG\`, \`learnedLagSec\`, \`sampleCount\`, \`sourceTier\` (\`perProfile\` / \`globalBootstrap\` / \`globalPool\` / \`scaleDefault\` — same tiers \`SettingsCalibration::sawModelSource\` exposes). \`recommendation\` is added only when \`predictedDripG >= 0.2 g\` (below that, the overshoot is in scale-noise territory).
- Omitted entirely when no scaleType is configured or no profile is loaded.
- Extract the flow-at-cutoff estimator into \`McpDialingHelpers::estimateFlowAtCutoff\` (pure helper, unit-tested).

## Why

Yield is one of the most common \"why didn't this taste right\" complaints, and SAW overshoot is invisible to the user — they set 36 g, got 35.9, and don't know whether to nudge target up, change grind, or accept that's noise. With \`sawPrediction.predictedDripG\` the AI can give a 30-second answer (\"you're consistently 0.6 g shy because of post-cut drip — bump target to 36.6 g\") instead of starting a five-shot grind chase.

Closes #1021.

## Test plan

- [x] \`TstMcpToolsDialingHelpers\` — 14 tests pass (8 existing groupSessions + 6 new estimateFlowAtCutoff: empty samples, zero duration, last-2-seconds average, skips zero-flow samples, short shot clamps window to zero, custom window).
- [ ] Live verification: pull a few shots on a profile with a connected scale, call \`dialing_get_context\`, and confirm \`sawPrediction\` appears with a sensible \`predictedDripG\` and tier (\`scaleDefault\` for first shot, \`perProfile\` after ≥5 graduated shots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)