### PR TITLE
feat(shotserver): add quality badges + shot summary, switch ratings to N%

### DIFF
--- a/src/network/shotserver_shots.cpp
+++ b/src/network/shotserver_shots.cpp
@@ -131,7 +131,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         const double drinkTds = shot.drinkTdsPct;
         const double drinkEy = shot.drinkEyPct;
 
-        rows += QString(R"HTML(
+        QString row = QString(R"HTML(
             <div class="shot-card" onclick="toggleSelect(%1, this)" data-id="%1"
                  data-profile="%2" data-brand="%3" data-coffee="%4" data-rating="%5"
                  data-ratio="%6" data-duration="%7" data-date="%17" data-dose="%9" data-yield="%10"
@@ -167,7 +167,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
                     </div>
                     <div class="shot-footer">
                         <span class="shot-beans">%14</span>
-                        %18
+                        __RATING_CHIP__
                     </div>
                 </a>
             </div>
@@ -188,8 +188,18 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         .arg(beanDisplay)                   // %14 (beans with grind)
         .arg(drinkTds, 0, 'f', 2)           // %15
         .arg(drinkEy, 0, 'f', 2)            // %16
-        .arg(shot.timestamp)                // %17 (epoch for sorting)
-        .arg(ratingChip);                   // %18 (rating chip HTML — empty when unrated)
+        .arg(shot.timestamp);               // %17 (epoch for sorting)
+
+        // Inject ratingChip via replace() AFTER the .arg() chain so the
+        // literal `%</span>` (and any future user-derived content) cannot
+        // shadow numbered placeholders. Doubling `%` to `%%` is the file's
+        // older convention but doesn't actually work — Qt's QString::arg()
+        // never reduces `%%` back to `%` (see qtbase qstring.cpp
+        // findArgEscapes/replaceArgEscapes), so doubling either leaks `%%`
+        // to the rendered output or still shadows ("%5" → "%%5" still
+        // parses as a %5 placeholder via continue + re-scan).
+        row.replace(QStringLiteral("__RATING_CHIP__"), ratingChip);
+        rows += row;
     }
 
     // Build HTML in chunks to avoid MSVC string literal size limit
@@ -1139,10 +1149,16 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
     QString phaseData = phasesToJson(shot.phases);
 
     // Build quality-badge chips and the Shot Summary modal contents from the
-    // analyzeShot() outputs that already arrived on the projection. Mirrors the
-    // in-app QualityBadges + ShotAnalysisDialog. Inserted as the last two args
-    // (%42, %43) in the .arg() chain below, so any stray `%` in summary text
-    // can't shadow a later placeholder.
+    // analyzeShot() outputs that already arrived on the projection. Mirrors
+    // the in-app QualityBadges + ShotAnalysisDialog. Both blobs contain
+    // detector-generated text that may include literal `%` (e.g. "75% of
+    // goal"), so they are NOT passed through .arg() — they are injected via
+    // replace() AFTER the .arg() chain below into __BADGES_HTML__ /
+    // __SUMMARY_LINES_HTML__ markers in the template. That sidesteps the
+    // QString::arg() placeholder-shadowing trap entirely; doubling `%` to
+    // `%%` doesn't actually escape (Qt's arg never reduces `%%` back to
+    // `%`, and "%5"→"%%5" still parses as a %5 placeholder via the
+    // continue+rescan in qstring.cpp).
     auto badgeChip = [](const QString& kind, const QString& text) -> QString {
         return QString("<span class=\"badge %1\"><span class=\"dot\"></span>%2</span>")
             .arg(kind, text);
@@ -1623,7 +1639,7 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
                 <div class="value rating">%7</div>
                 <div class="label">Rating</div>
             </div>
-            %42
+            __BADGES_HTML__
         </div>
 
         <div class="chart-container">
@@ -1720,7 +1736,7 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
     <div class="summary-modal" id="summaryModal" onclick="if(event.target===this)closeSummaryDialog()">
         <div class="summary-modal-content">
             <h2>Shot Summary</h2>
-            %43
+            __SUMMARY_LINES_HTML__
             <button class="summary-modal-close" onclick="closeSummaryDialog()">OK</button>
         </div>
     </div>
@@ -2247,7 +2263,7 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
 </body>
 </html>
 )HTML";
-    return html
+    QString rendered = html
     .arg(tempOverride > 0
          ? shot.profileName.toHtmlEscaped() + QString(" (%1\u00B0C)").arg(tempOverride, 0, 'f', 0)
          : shot.profileName.toHtmlEscaped())
@@ -2294,9 +2310,15 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
     .arg(shot.drinkEyPct, 0, 'f', 1)                                                 // %38 drinkEy
     .arg(resistanceData)                                                             // %39 resistance
     .arg(jsEscape(shot.grinderBrand))                                                // %40 grinderBrand
-    .arg(jsEscape(shot.grinderBurrs))                                                // %41 grinderBurrs
-    .arg(badgesHtml)                                                                 // %42 quality badges + summary button
-    .arg(summaryLinesHtml);                                                          // %43 shot summary modal lines
+    .arg(jsEscape(shot.grinderBurrs));                                               // %41 grinderBurrs
+
+    // badgesHtml / summaryLinesHtml carry detector-generated text and CSS that
+    // can contain literal `%`. Inject AFTER the .arg() chain via replace() so
+    // they can never feed Qt's placeholder scanner. See the build-site comment
+    // above for why doubling `%` doesn't actually escape.
+    rendered.replace(QStringLiteral("__BADGES_HTML__"), badgesHtml);
+    rendered.replace(QStringLiteral("__SUMMARY_LINES_HTML__"), summaryLinesHtml);
+    return rendered;
 }
 
 QString ShotServer::generateComparisonPage(const QList<ShotRecord>& shots) const

--- a/src/network/shotserver_shots.cpp
+++ b/src/network/shotserver_shots.cpp
@@ -79,10 +79,21 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         const double tempOverride = shot.temperatureOverrideC;  // Always has value
         const double targetWeight = shot.targetWeightG;  // Always has value
 
-        // Escape for JavaScript string (single quotes) and HTML attribute
+        // Escape for JavaScript string (single quotes) and HTML attribute.
+        //
+        // Does NOT double `%` → `%%`: that pattern looks like an arg-placeholder
+        // escape but isn't one — Qt's QString::arg() never reduces `%%` back to
+        // `%` (verified in qtbase qstring.cpp findArgEscapes/replaceArgEscapes),
+        // so doubling caused user-visible `%%` whenever a profile/bean name
+        // contained a `%` followed by a non-digit (the common case, e.g.
+        // "50% off" rendered as "50%% off"). It also failed to escape the
+        // shadow case it was meant to prevent — "%12" would still parse as a
+        // %12 placeholder after doubling because the parser rescans after
+        // each non-match. The residual shadow risk (user typing the literal
+        // text of an unfilled placeholder number into a name) is real but
+        // rare; the rendering bug was always-on and visible.
         auto escapeForJs = [](const QString& s) -> QString {
             QString escaped = s;
-            escaped.replace("%", "%%");      // Must be first — protect QString::arg() placeholders
             escaped.replace("\\", "\\\\");
             escaped.replace("'", "\\'");
             escaped.replace("\"", "&quot;");
@@ -1061,10 +1072,14 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
         ? (QString::number(shot.enjoyment0to100) + QStringLiteral("%"))
         : QStringLiteral("-");
 
-    // Escape for embedding in JavaScript string literals (inside double quotes)
+    // Escape for embedding in JavaScript string literals (inside double quotes).
+    // Does NOT double `%` → `%%` — see escapeForJs in generateShotListPage above
+    // for the full rationale. Short version: the doubling was visible-output
+    // wrong (Qt's arg() never reduces `%%` back to `%`) and didn't actually
+    // prevent placeholder shadowing either ("%12" still parses as %12 after
+    // doubling).
     auto jsEscape = [](const QString& s) -> QString {
         QString r = s;
-        r.replace(QLatin1String("%"), QLatin1String("%%"));    // Must be first: prevent %1-%99 arg placeholders
         r.replace(QLatin1String("\\"), QLatin1String("\\\\"));
         r.replace(QLatin1String("\""), QLatin1String("\\\""));
         r.replace(QLatin1String("\n"), QLatin1String("\\n"));

--- a/src/network/shotserver_shots.cpp
+++ b/src/network/shotserver_shots.cpp
@@ -51,6 +51,18 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
 
         int rating = qRound(static_cast<double>(shot.enjoyment0to100));
 
+        // Rating chip (matches in-app ShotHistoryPage: "N%" when rated, hidden
+        // when unrated). data-rating= and the rating:N+ search syntax keep using
+        // the numeric value above.
+        QString ratingChip;
+        if (rating > 0) {
+            const QString r = QString::number(rating);
+            ratingChip = QStringLiteral(
+                "<span class=\"shot-rating clickable\" "
+                "onclick=\"event.preventDefault(); event.stopPropagation(); setSearch('rating:") + r + QStringLiteral("+')\">")
+                + r + QStringLiteral("%</span>");
+        }
+
         double ratio = 0;
         if (shot.doseWeightG > 0) {
             ratio = shot.finalWeightG / shot.doseWeightG;
@@ -155,7 +167,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
                     </div>
                     <div class="shot-footer">
                         <span class="shot-beans">%14</span>
-                        <span class="shot-rating clickable" onclick="event.preventDefault(); event.stopPropagation(); setSearch('rating:%5+')">rating: %5</span>
+                        %18
                     </div>
                 </a>
             </div>
@@ -176,7 +188,8 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         .arg(beanDisplay)                   // %14 (beans with grind)
         .arg(drinkTds, 0, 'f', 2)           // %15
         .arg(drinkEy, 0, 'f', 2)            // %16
-        .arg(shot.timestamp); // %17 (epoch for sorting)
+        .arg(shot.timestamp)                // %17 (epoch for sorting)
+        .arg(ratingChip);                   // %18 (rating chip HTML — empty when unrated)
     }
 
     // Build HTML in chunks to avoid MSVC string literal size limit
@@ -1032,11 +1045,11 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
         ratio = shot.finalWeightG / shot.doseWeightG;
     }
 
-    int rating = qRound(static_cast<double>(shot.enjoyment0to100) / 20.0);
-    QString stars;
-    for (int i = 0; i < 5; i++) {
-        stars += (i < rating) ? "&#9733;" : "&#9734;";
-    }
+    // Rating display: "N%" when rated, "-" when unrated. Mirrors ShotDetailPage.qml
+    // ("rating: N%" / "-"). 0-100 enjoyment is the canonical scale across the app.
+    QString ratingText = (shot.enjoyment0to100 > 0)
+        ? (QString::number(shot.enjoyment0to100) + QStringLiteral("%"))
+        : QStringLiteral("-");
 
     // Escape for embedding in JavaScript string literals (inside double quotes)
     auto jsEscape = [](const QString& s) -> QString {
@@ -1124,6 +1137,44 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
         return "[" + items.join(",") + "]";
     };
     QString phaseData = phasesToJson(shot.phases);
+
+    // Build quality-badge chips and the Shot Summary modal contents from the
+    // analyzeShot() outputs that already arrived on the projection. Mirrors the
+    // in-app QualityBadges + ShotAnalysisDialog. Inserted as the last two args
+    // (%42, %43) in the .arg() chain below, so any stray `%` in summary text
+    // can't shadow a later placeholder.
+    auto badgeChip = [](const QString& kind, const QString& text) -> QString {
+        return QString("<span class=\"badge %1\"><span class=\"dot\"></span>%2</span>")
+            .arg(kind, text);
+    };
+    QString badgesHtml = QStringLiteral("<div class=\"shot-quality\">");
+    const bool hasFlag = shot.channelingDetected || shot.temperatureUnstable
+                       || shot.grindIssueDetected || shot.pourTruncatedDetected
+                       || shot.skipFirstFrameDetected;
+    if (shot.channelingDetected)     badgesHtml += badgeChip("danger",  "Channeling detected");
+    if (shot.temperatureUnstable)    badgesHtml += badgeChip("warning", "Temp unstable");
+    if (shot.grindIssueDetected)     badgesHtml += badgeChip("warning", "Grind issue");
+    if (shot.pourTruncatedDetected)  badgesHtml += badgeChip("danger",  "Puck failed");
+    if (shot.skipFirstFrameDetected) badgesHtml += badgeChip("danger",  "First step skipped");
+    if (!hasFlag)                    badgesHtml += badgeChip("success", "Clean extraction");
+    if (!shot.summaryLines.isEmpty()) {
+        badgesHtml += QStringLiteral(
+            "<button class=\"summary-btn\" onclick=\"openSummaryDialog()\">"
+            "&#128202; Shot Summary</button>");
+    }
+    badgesHtml += QStringLiteral("</div>");
+
+    QString summaryLinesHtml;
+    for (const QVariant& line : shot.summaryLines) {
+        const QVariantMap m = line.toMap();
+        const QString type = m.value("type").toString();
+        const QString text = m.value("text").toString().toHtmlEscaped();
+        summaryLinesHtml += QString("<div class=\"summary-line %1\"><span class=\"line-dot\"></span><span>%2</span></div>")
+            .arg(type, text);
+    }
+    if (summaryLinesHtml.isEmpty()) {
+        summaryLinesHtml = QStringLiteral("<div class=\"summary-line\"><span>No summary available.</span></div>");
+    }
 
     QString html = QString(R"HTML(
 <!DOCTYPE html>
@@ -1225,6 +1276,124 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
             text-transform: uppercase;
             letter-spacing: 0.05em;
         }
+        .shot-quality {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 0.5rem;
+            flex: 1;
+            min-width: 0;
+            padding: 0 0.5rem;
+        }
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.375rem;
+            padding: 0 0.75rem;
+            height: 28px;
+            border-radius: 14px;
+            border: 1px solid;
+            font-size: 0.75rem;
+            line-height: 1;
+            white-space: nowrap;
+        }
+        .badge .dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+        }
+        .badge.danger { color: #e73249; border-color: #e73249; background: rgba(231,50,73,0.15); }
+        .badge.danger .dot { background: #e73249; }
+        .badge.warning { color: #f0a020; border-color: #f0a020; background: rgba(240,160,32,0.15); }
+        .badge.warning .dot { background: #f0a020; }
+        .badge.success { color: #18c37e; border-color: #18c37e; background: rgba(24,195,126,0.15); }
+        .badge.success .dot { background: #18c37e; }
+        .summary-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.375rem;
+            padding: 0 0.75rem;
+            height: 28px;
+            border-radius: 14px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            color: var(--text-secondary);
+            font-size: 0.75rem;
+            cursor: pointer;
+            font-family: inherit;
+            line-height: 1;
+            white-space: nowrap;
+        }
+        .summary-btn:hover { color: var(--accent); border-color: var(--accent); }
+        .summary-modal {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.6);
+            z-index: 300;
+            align-items: center;
+            justify-content: center;
+            padding: 1rem;
+        }
+        .summary-modal.open { display: flex; }
+        .summary-modal-content {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 1.5rem;
+            max-width: 450px;
+            width: 100%;
+            max-height: 80vh;
+            overflow-y: auto;
+        }
+        .summary-modal-content h2 {
+            text-align: center;
+            font-size: 1rem;
+            font-weight: 600;
+            margin-bottom: 1rem;
+        }
+        .summary-line {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.5rem;
+            padding: 0.375rem 0;
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+            line-height: 1.4;
+        }
+        .summary-line .line-dot {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            margin-top: 0.5rem;
+            flex-shrink: 0;
+        }
+        .summary-line.good .line-dot { background: #18c37e; }
+        .summary-line.caution .line-dot { background: #f0a020; }
+        .summary-line.warning .line-dot { background: #e73249; }
+        .summary-line.observation .line-dot { background: var(--text-secondary); }
+        .summary-line.verdict {
+            color: var(--text);
+            font-weight: 500;
+            padding-top: 0.75rem;
+            margin-top: 0.5rem;
+            border-top: 1px solid var(--border);
+        }
+        .summary-line.verdict .line-dot { display: none; }
+        .summary-modal-close {
+            width: 100%;
+            margin-top: 1rem;
+            padding: 0.625rem;
+            background: var(--accent);
+            border: none;
+            border-radius: 8px;
+            color: #000;
+            font-weight: 500;
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 0.875rem;
+        }
+        .summary-modal-close:hover { opacity: 0.9; }
         .chart-container {
             background: var(--surface);
             border: 1px solid var(--border);
@@ -1379,10 +1548,6 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
         .edit-row .label { color: var(--text-secondary); white-space: nowrap; min-width: 80px; }
         .edit-row .edit-field { flex: 1; text-align: right; }
         .edit-row .edit-input, .edit-row .edit-select { text-align: right; }
-        .star-input { display: inline-flex; gap: 0.25rem; cursor: pointer; font-size: 1.5rem; }
-        .star-input .star { color: var(--border); transition: color 0.1s; user-select: none; }
-        .star-input .star.active { color: var(--accent); }
-        .star-input .star:hover { color: var(--accent); }
         .metric-card .edit-input { text-align: center; width: 80px; }
         .menu-wrapper { position: relative; margin-left: auto; }
         .menu-btn {
@@ -1458,6 +1623,7 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
                 <div class="value rating">%7</div>
                 <div class="label">Rating</div>
             </div>
+            %42
         </div>
 
         <div class="chart-container">
@@ -1551,6 +1717,14 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
         <button class="cancel-btn" onclick="cancelEdit()">Cancel</button>
     </div>
 
+    <div class="summary-modal" id="summaryModal" onclick="if(event.target===this)closeSummaryDialog()">
+        <div class="summary-modal-content">
+            <h2>Shot Summary</h2>
+            %43
+            <button class="summary-modal-close" onclick="closeSummaryDialog()">OK</button>
+        </div>
+    </div>
+
     <script>
         var shotData = {
             id: %24,
@@ -1623,18 +1797,13 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
             originalInfoGridHTML = infoGrid.innerHTML;
             originalActionsDisplay = actionsBar.style.display;
 
-            var stars = shotData.enjoyment > 0 ? Math.round(shotData.enjoyment / 20) : 0;
-            var starHtml = '';
-            for (var i = 1; i <= 5; i++) {
-                starHtml += '<span class="star ' + (i <= stars ? 'active' : '') + '" data-value="' + i + '" onclick="setStarRating(' + i + ')">&#9733;</span>';
-            }
-
             // Build edit form for metrics bar using DOM
             // Note: shotData values are server-escaped and trusted (from our own database)
+            var ratingValue = shotData.enjoyment > 0 ? shotData.enjoyment : 0;
             var metricsHtml =
                 '<div class="metric-card"><input type="number" class="edit-input" id="editDose" step="0.1" value="' + shotData.doseWeightG + '" oninput="autoCalcEY()"><div class="label">Dose (g)</div></div>' +
                 '<div class="metric-card"><input type="number" class="edit-input" id="editYield" step="0.1" value="' + shotData.finalWeightG + '" oninput="autoCalcEY()"><div class="label">Yield (g)</div></div>' +
-                '<div class="metric-card"><div class="star-input" id="starRating" data-value="' + stars + '">' + starHtml + '</div><div class="label">Rating</div></div>';
+                '<div class="metric-card"><input type="number" class="edit-input" id="editRating" min="0" max="100" step="1" value="' + ratingValue + '"><div class="label">Rating (%)</div></div>';
             metricsBar.innerHTML = metricsHtml;
 
             var roastLevels = ['', 'Light', 'Medium-Light', 'Medium', 'Medium-Dark', 'Dark'];
@@ -1698,15 +1867,6 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
             if (debugContainer) debugContainer.style.display = originalDebugDisplay;
         }
 
-        function setStarRating(value) {
-            var stars = document.querySelectorAll('#starRating .star');
-            for (var i = 0; i < stars.length; i++) {
-                if (i < value) stars[i].classList.add('active');
-                else stars[i].classList.remove('active');
-            }
-            document.getElementById('starRating').dataset.value = value;
-        }
-
         function autoCalcEY() {
             var dose = parseFloat(document.getElementById('editDose').value) || 0;
             var yieldVal = parseFloat(document.getElementById('editYield').value) || 0;
@@ -1718,8 +1878,8 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
         }
 
         function saveChanges() {
-            var starEl = document.getElementById('starRating');
-            var starValue = parseInt(starEl.dataset.value) || 0;
+            var ratingValue = parseInt(document.getElementById('editRating').value) || 0;
+            ratingValue = Math.max(0, Math.min(100, ratingValue));
 
             var data = {
                 beanBrand: document.getElementById('editBrand').value,
@@ -1733,7 +1893,7 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
                 espressoNotes: document.getElementById('editNotes').value,
                 doseWeight: parseFloat(document.getElementById('editDose').value) || 0,
                 finalWeight: parseFloat(document.getElementById('editYield').value) || 0,
-                enjoyment: starValue * 20,
+                enjoyment: ratingValue,
                 barista: document.getElementById('editBarista').value,
                 beverageType: document.getElementById('editBeverageType').value,
                 drinkTds: parseFloat(document.getElementById('editTds').value) || 0,
@@ -2064,6 +2224,13 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
             menu.classList.toggle("open");
         }
 
+        function openSummaryDialog() {
+            document.getElementById("summaryModal").classList.add("open");
+        }
+        function closeSummaryDialog() {
+            document.getElementById("summaryModal").classList.remove("open");
+        }
+
         document.addEventListener("click", function(e) {
             var menu = document.getElementById("menuDropdown");
             var btn = e.target.closest(".menu-btn");
@@ -2089,7 +2256,7 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
     .arg(yieldDisplay)
     .arg(ratio, 0, 'f', 1)
     .arg(shot.durationSec, 0, 'f', 1)
-    .arg(stars)
+    .arg(ratingText)
     .arg(shot.beanBrand.isEmpty() ? "-" : shot.beanBrand.toHtmlEscaped())
     .arg(shot.beanType.isEmpty() ? "-" : shot.beanType.toHtmlEscaped())
     .arg(shot.roastDate.isEmpty() ? "-" : shot.roastDate.toHtmlEscaped())
@@ -2127,7 +2294,9 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
     .arg(shot.drinkEyPct, 0, 'f', 1)                                                 // %38 drinkEy
     .arg(resistanceData)                                                             // %39 resistance
     .arg(jsEscape(shot.grinderBrand))                                                // %40 grinderBrand
-    .arg(jsEscape(shot.grinderBurrs));                                               // %41 grinderBurrs
+    .arg(jsEscape(shot.grinderBurrs))                                                // %41 grinderBurrs
+    .arg(badgesHtml)                                                                 // %42 quality badges + summary button
+    .arg(summaryLinesHtml);                                                          // %43 shot summary modal lines
 }
 
 QString ShotServer::generateComparisonPage(const QList<ShotRecord>& shots) const


### PR DESCRIPTION
## Summary
- Adds the quality-badge chips and Shot Summary modal to the web shot detail page, mirroring the in-app `QualityBadges` + `ShotAnalysisDialog`. Channeling, temp-unstable, grind-issue, puck-failed, first-step-skipped, or a green "Clean extraction" chip render alongside the Rating; the Shot Summary button opens a modal listing the analyzeShot() observations and verdict.
- Switches shot ratings from 5-star UI to numeric `N%` everywhere — detail page (`85%` / `-`), list page chip (hidden when unrated), and edit-mode 0-100 number input — matching `ShotDetailPage.qml`, `ShotHistoryPage.qml`, and `RatingInput.qml`. `data-rating` and the `rating:N+` search syntax keep using the numeric value.

Data flows through the existing `ShotProjection` (no backend changes) — `summaryLines` and detector flags are already populated by `convertShotRecord`.

## Test plan
- [ ] Open the shot list — rating chips show `N%` and disappear for unrated shots; clicking a chip filters with `rating:N+`
- [ ] Open a shot detail page — Rating reads `85%` (or `-`) instead of stars
- [ ] Verify badge chips appear next to Rating and reflect the same flags as the in-app shot detail
- [ ] Click Shot Summary — modal opens with the same observation lines + verdict as the in-app dialog
- [ ] Edit a shot — Rating field is a 0-100 number input, save persists the value, list/detail re-render with the new percentage
- [ ] Confirm the modal closes via OK, backdrop click, and survives edit-mode cancel/restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)