### PR TITLE
fix(shotserver): replace stray `%%` literals in raw CSS/HTML with `%`

### DIFF
--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -1426,7 +1426,7 @@ a{color:#6c8cff}
 <p>The MCP server runs inside Decenza on <strong>any platform</strong> (Android tablet, iOS, Windows, macOS, Linux). Claude Desktop on your computer connects to it over your local WiFi network.</p>
 
 <h2>Platform Compatibility</h2>
-<table style="width:100%%;border-collapse:collapse;margin:12px 0">
+<table style="width:100%;border-collapse:collapse;margin:12px 0">
 <tr style="border-bottom:1px solid #333"><td style="padding:8px"><strong>Decenza runs on</strong></td><td style="padding:8px">Any platform &mdash; tablet, phone, or desktop</td></tr>
 <tr style="border-bottom:1px solid #333"><td style="padding:8px"><strong>Claude Desktop connects from</strong></td><td style="padding:8px">macOS or Windows (same WiFi network)</td></tr>
 )HTML"

--- a/src/network/shotserver_backup.cpp
+++ b/src/network/shotserver_backup.cpp
@@ -628,9 +628,9 @@ QString ShotServer::generateRestorePage() const
             overflow: hidden;
         }
         .progress-fill {
-            height: 100%%;
+            height: 100%;
             background: var(--accent);
-            width: 0%%;
+            width: 0%;
             transition: width 0.3s;
         }
         .status-message {

--- a/src/network/shotserver_shots.cpp
+++ b/src/network/shotserver_shots.cpp
@@ -319,7 +319,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         .shot-metric .metric-label { font-size: 0.625rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; }
         .shot-arrow { color: var(--text-secondary); font-size: 1rem; }
         .shot-footer { display: flex; justify-content: space-between; align-items: center; }
-        .shot-beans { font-size: 0.8125rem; color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 60%%; }
+        .shot-beans { font-size: 0.8125rem; color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 60%; }
         .shot-rating { color: var(--accent); font-size: 0.875rem; }
         .shot-temp { color: var(--text-secondary); font-weight: normal; }
         .shot-grind { color: var(--text-secondary); font-weight: normal; }
@@ -424,7 +424,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         .menu-btn:hover { color: var(--accent); }
         .menu-dropdown {
             position: absolute;
-            top: 100%%;
+            top: 100%;
             right: 0;
             margin-top: 0.5rem;
             background: var(--surface);
@@ -458,7 +458,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         .sort-dir-btn { min-width: 2.2rem; padding-left: 0.5rem; padding-right: 0.5rem; text-align: center; }
         .sort-dropdown {
             position: absolute;
-            top: 100%%;
+            top: 100%;
             right: 0;
             margin-top: 0.25rem;
             background: var(--surface);
@@ -564,7 +564,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
         }
         .saved-search-delete:hover { color: #c0392b; }
         .help-table {
-            width: 100%%;
+            width: 100%;
             border-collapse: collapse;
             font-size: 0.8rem;
         }
@@ -659,7 +659,7 @@ QString ShotServer::generateShotListPage(const QVariantList& shots) const
                 <tr><td><span class="help-keyword" onclick="insertSearchKeyword('yield:')">yield:</span></td><td>Yield weight (g)</td><td><span class="help-syntax">yield:30-40</span></td></tr>
                 <tr><td><span class="help-keyword" onclick="insertSearchKeyword('time:')">time:</span></td><td>Duration (seconds)</td><td><span class="help-syntax">time:25-35</span></td></tr>
                 <tr><td><span class="help-keyword" onclick="insertSearchKeyword('tds:')">tds:</span></td><td>TDS</td><td><span class="help-syntax">tds:1.3-1.5</span></td></tr>
-                <tr><td><span class="help-keyword" onclick="insertSearchKeyword('ey:')">ey:</span></td><td>Extraction yield (%%)</td><td><span class="help-syntax">ey:18-22</span></td></tr>
+                <tr><td><span class="help-keyword" onclick="insertSearchKeyword('ey:')">ey:</span></td><td>Extraction yield (%)</td><td><span class="help-syntax">ey:18-22</span></td></tr>
             </table>
             <p style="margin-top:0.5rem;font-size:0.75rem;color:var(--text-secondary);">Syntax: <span class="help-syntax">N</span> (exact), <span class="help-syntax">N-M</span> (range), <span class="help-syntax">N+</span> (minimum)<br>Combine keywords with text: <span class="help-syntax">ethiopia dose:18 rating:70+</span></p>
         </div>

--- a/src/network/webtemplates/menu_css.h
+++ b/src/network/webtemplates/menu_css.h
@@ -17,7 +17,7 @@ inline constexpr const char* WEB_CSS_MENU = R"CSS(
         .menu-btn:hover { color: var(--accent); }
         .menu-dropdown {
             position: absolute;
-            top: 100%%;
+            top: 100%;
             right: 0;
             margin-top: 0.5rem;
             background: var(--surface);


### PR DESCRIPTION
## Summary
Follow-up to #1027. Several CSS rules in the web shotserver shipped to browsers with `100%%`, `60%%`, `0%%`, and one cell with text `(%%)`, because the source had `%%` written for a literal `%` that was never going through `QString::arg()` (or, in the MCP setup page, was going through arg() — but Qt's arg() does NOT reduce `%%` back to `%`, so the doubling is wrong in both paths). Browsers reject `100%%` as an invalid CSS value and silently fall back to `auto`, so these rules were quietly broken:

- `.menu-dropdown { top: 100% }` (shot list page + shared `webtemplates/menu_css.h`)
- `.sort-dropdown { top: 100% }`
- `.help-table { width: 100% }`
- `.shot-beans { max-width: 60% }`
- `.progress-fill { height: 100%; width: 0% }` (restore page progress bar)
- MCP setup page table `width:100%`
- Search-help cell `Extraction yield (%)` (was rendering "(%%)")

Empirical Qt 6.10 behavior (minimal repro):

```
QString("width: 100%%").arg("X")     → "width: 100%%"
QString("width: 100%%; %1").arg("X") → "width: 100%%; X"
```

`%%` is preserved verbatim — the "double the percent" convention was cargo-cult and produced wrong output. The two `% → %%` doubling lambdas (`escapeForJs`, `jsEscape`) were already fixed in #1027; this PR cleans up the remaining literal occurrences in the source.

## Test plan
- [ ] Open the shot list — `.shot-beans` truncates beans column at 60% (was unbounded), and the burger-menu / sort dropdowns position directly below their buttons (was floating at `top: auto`)
- [ ] Open the restore-backup page — uploading a backup shows the progress bar fill with non-zero height (was rendering as a 0-height div)
- [ ] Open the MCP setup page — table fills the full width
- [ ] Open the search help on the shot list — "Extraction yield (%)" reads with one percent sign

🤖 Generated with [Claude Code](https://claude.com/claude-code)