### PR TITLE
feat(mcp,ai): add ai_advisor_invoke MCP tool for prompt A/B testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,7 @@ set(SOURCES
     src/mcp/mcptools_devices.cpp
     src/mcp/mcptools_write.cpp
     src/mcp/mcptools_agent.cpp
+    src/mcp/mcptools_ai.cpp
     src/network/mqttclient.cpp
     src/network/webdebuglogger.cpp
     src/network/locationprovider.cpp

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -54,6 +54,7 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
 class MemoryMonitor;
 void registerDebugTools(McpToolRegistry* registry, MemoryMonitor* memoryMonitor);
 void registerAgentTools(McpToolRegistry* registry);
+void registerAITools(McpToolRegistry* registry, MainController* mainController);
 void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                           MachineState* machineState, ProfileManager* profileManager,
                           ShotHistoryStorage* shotHistory, MemoryMonitor* memoryMonitor,
@@ -160,6 +161,7 @@ void McpServer::registerAllTools()
     registerDeviceTools(m_toolRegistry, m_bleManager, m_device);
     registerDebugTools(m_toolRegistry, m_memoryMonitor);
     registerAgentTools(m_toolRegistry);
+    registerAITools(m_toolRegistry, m_mainController);
     qDebug() << "McpServer: Registered"
              << m_toolRegistry->listTools(2, QStringLiteral("2025-11-25")).size() << "tools";
 }

--- a/src/mcp/mcptools_ai.cpp
+++ b/src/mcp/mcptools_ai.cpp
@@ -21,27 +21,24 @@
 #include <QThread>
 #include <QTimer>
 
-// Hard cap on a single advisor call. Provider-side timeout is 60s
-// (AIProvider::ANALYSIS_TIMEOUT_MS). This adds a small buffer so the MCP
-// caller gets a clean "timeout" reply rather than a dangling promise if
-// the provider's own timeout fires.
-static constexpr int kAdvisorMcpTimeoutMs = 75 * 1000;
+// Hard cap on a single advisor call, sized to outlast the slowest
+// provider's own timeout so the MCP caller always gets a clean reply
+// from us rather than a dangling promise. Cloud providers cap at 60s
+// (AIProvider::ANALYSIS_TIMEOUT_MS); OllamaProvider caps at 120s
+// (LOCAL_ANALYSIS_TIMEOUT_MS). 135s adds a small buffer above the
+// Ollama path.
+static constexpr int kAdvisorMcpTimeoutMs = 135 * 1000;
 
 void registerAITools(McpToolRegistry* registry, MainController* mainController)
 {
-    // ai_advisor_invoke
-    //
-    // Tier: write — makes a paid outbound call to the configured AI
-    // provider. Side effects: emits `recommendationReceived` (which the
-    // in-app advisor's QML overlay listens to) and updates AIManager's
-    // `lastRecommendation`. Don't fire while the user is actively using
-    // the in-app advisor; the call is rejected if `isAnalyzing` is true.
-    //
-    // Always returns `systemPromptUsed` and `userPromptUsed` so the
-    // caller can verify exactly what the provider received — that
-    // visibility is the whole point for prompt A/B testing. Set
-    // `dryRun: true` to assemble the prompts without sending them
-    // anywhere (no network call, no side effects).
+    // ai_advisor_invoke — registered at "control" tier (matches the
+    // McpToolRegistry::categoryMinLevel taxonomy: read/control/settings;
+    // anything else is rejected as deny-all). Makes a paid outbound
+    // call to the configured AI provider and emits AIManager signals
+    // the in-app advisor's QML overlay listens to (lastRecommendation,
+    // recommendationReceived). The call is rejected when isAnalyzing
+    // is already true, both up-front and after the background DB load
+    // hops back to the main thread (race window).
     registry->registerAsyncTool(
         "ai_advisor_invoke",
         "Invoke the configured AI advisor with the dial-in context for a shot. "
@@ -51,7 +48,8 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
         "systemPromptUsed + userPromptUsed in the response so the caller can see exactly "
         "what was sent — useful for prompt A/B testing and end-to-end advisor validation. "
         "Pass dryRun: true to skip the network call and just return the assembled "
-        "prompts (no side effects, no token cost). "
+        "prompts (no network call, no token cost — but does still spawn a worker thread "
+        "and read the shot row from SQLite). "
         "Side effects (when not dry-run): the response also reaches the in-app "
         "conversation overlay (updates lastRecommendation, fires recommendationReceived). "
         "Returns an error if the advisor is already busy with another request. "
@@ -201,12 +199,17 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
                     // and invoke. `done` guards against double-fire (the
                     // provider's own timeout could fire alongside our
                     // wrapper's timeout in a race, though rare). The
-                    // QTimer is parented to AIManager so it's cleaned up
-                    // on shutdown.
+                    // The QTimer is parented to AIManager so it dies
+                    // alongside it on app shutdown — but during normal
+                    // operation finalize() owns its lifetime explicitly
+                    // (deleteLater) so per-call timers don't accumulate
+                    // as permanent AIManager children.
                     struct CallState {
                         bool done = false;
                         QMetaObject::Connection successConn;
                         QMetaObject::Connection errorConn;
+                        QMetaObject::Connection timeoutConn;
+                        QMetaObject::Connection destroyedConn;
                         QTimer* timeout = nullptr;
                         qint64 startMs = 0;
                     };
@@ -228,8 +231,16 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
                         if (aiPtrInner) {
                             QObject::disconnect(state->successConn);
                             QObject::disconnect(state->errorConn);
+                            QObject::disconnect(state->timeoutConn);
+                            QObject::disconnect(state->destroyedConn);
                         }
-                        if (state->timeout) state->timeout->stop();
+                        // The QTimer is parented to AIManager; deleteLater()
+                        // also runs when the parent is destroyed, so this is
+                        // safe in both lifecycles.
+                        if (state->timeout) {
+                            state->timeout->stop();
+                            state->timeout->deleteLater();
+                        }
                         const qint64 latencyMs = QDateTime::currentMSecsSinceEpoch() - state->startMs;
 
                         QJsonObject result = body;
@@ -252,9 +263,23 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
                         ai, [finalize](const QString& error) {
                             finalize(QJsonObject{{"error", error}});
                         });
-                    QObject::connect(state->timeout, &QTimer::timeout,
+                    state->timeoutConn = QObject::connect(state->timeout, &QTimer::timeout,
                         ai, [finalize]() {
-                            finalize(QJsonObject{{"error", "Advisor call timed out after 75s"}});
+                            finalize(QJsonObject{{"error",
+                                QString("Advisor call timed out after %1s")
+                                    .arg(kAdvisorMcpTimeoutMs / 1000)}});
+                        });
+                    // If AIManager dies before any of the above signals fire
+                    // (app shutdown with a live call in flight), Qt would
+                    // auto-disconnect those receiver-bound lambdas without
+                    // ever invoking finalize — leaking `state` and stranding
+                    // `respond()`. The destroyed-signal hook makes that a
+                    // clean error rather than a hang+leak. Receiver is
+                    // QCoreApplication::instance() — it outlives AIManager,
+                    // so this connection still fires.
+                    state->destroyedConn = QObject::connect(ai, &QObject::destroyed,
+                        QCoreApplication::instance(), [finalize]() {
+                            finalize(QJsonObject{{"error", "AI manager destroyed before advisor reply"}});
                         });
 
                     state->timeout->start();
@@ -265,5 +290,5 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
             QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
             thread->start();
         },
-        "write");
+        "control");
 }

--- a/src/mcp/mcptools_ai.cpp
+++ b/src/mcp/mcptools_ai.cpp
@@ -1,0 +1,269 @@
+#include "mcpserver.h"
+#include "mcptoolregistry.h"
+#include "../ai/aimanager.h"
+#include "../ai/shotsummarizer.h"
+#include "../ai/aiprovider.h"
+#include "../controllers/maincontroller.h"
+#include "../core/dbutils.h"
+#include "../history/shothistorystorage.h"
+#include "../history/shotprojection.h"
+#include "../profile/profile.h"
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMetaObject>
+#include <QPointer>
+#include <QSqlDatabase>
+#include <QSqlQuery>
+#include <QString>
+#include <QThread>
+#include <QTimer>
+
+// Hard cap on a single advisor call. Provider-side timeout is 60s
+// (AIProvider::ANALYSIS_TIMEOUT_MS). This adds a small buffer so the MCP
+// caller gets a clean "timeout" reply rather than a dangling promise if
+// the provider's own timeout fires.
+static constexpr int kAdvisorMcpTimeoutMs = 75 * 1000;
+
+void registerAITools(McpToolRegistry* registry, MainController* mainController)
+{
+    // ai_advisor_invoke
+    //
+    // Tier: write — makes a paid outbound call to the configured AI
+    // provider. Side effects: emits `recommendationReceived` (which the
+    // in-app advisor's QML overlay listens to) and updates AIManager's
+    // `lastRecommendation`. Don't fire while the user is actively using
+    // the in-app advisor; the call is rejected if `isAnalyzing` is true.
+    //
+    // Always returns `systemPromptUsed` and `userPromptUsed` so the
+    // caller can verify exactly what the provider received — that
+    // visibility is the whole point for prompt A/B testing. Set
+    // `dryRun: true` to assemble the prompts without sending them
+    // anywhere (no network call, no side effects).
+    registry->registerAsyncTool(
+        "ai_advisor_invoke",
+        "Invoke the configured AI advisor with the dial-in context for a shot. "
+        "Builds the same system prompt and user prompt the in-app advisor would build, "
+        "sends to the provider currently selected in settings (OpenAI/Anthropic/Gemini/"
+        "OpenRouter/Ollama), and returns the response. Always echoes the assembled "
+        "systemPromptUsed + userPromptUsed in the response so the caller can see exactly "
+        "what was sent — useful for prompt A/B testing and end-to-end advisor validation. "
+        "Pass dryRun: true to skip the network call and just return the assembled "
+        "prompts (no side effects, no token cost). "
+        "Side effects (when not dry-run): the response also reaches the in-app "
+        "conversation overlay (updates lastRecommendation, fires recommendationReceived). "
+        "Returns an error if the advisor is already busy with another request. "
+        "Optional overrides let the caller substitute custom system/user prompts to "
+        "test alternate prompt shapes against the same provider config.",
+        QJsonObject{
+            {"type", "object"},
+            {"properties", QJsonObject{
+                {"shot_id", QJsonObject{{"type", "integer"},
+                    {"description", "Shot ID to build context for. If omitted, uses the most recent shot."}}},
+                {"dryRun", QJsonObject{{"type", "boolean"},
+                    {"description", "If true, assemble the prompts and return them without sending to the provider. No network call, no token cost. Default false."}}},
+                {"userPromptOverride", QJsonObject{{"type", "string"},
+                    {"description", "Replace the auto-built user prompt with custom text. Useful for prompt A/B testing."}}},
+                {"systemPromptOverride", QJsonObject{{"type", "string"},
+                    {"description", "Replace the auto-built system prompt with custom text. When omitted, uses ShotSummarizer::shotAnalysisSystemPrompt for the resolved shot's profile."}}}
+            }}
+        },
+        [mainController](const QJsonObject& args, std::function<void(QJsonObject)> respond) {
+            if (!mainController || !mainController->aiManager()) {
+                respond(QJsonObject{{"error", "AI advisor not available"}});
+                return;
+            }
+            AIManager* ai = mainController->aiManager();
+            const bool dryRun = args.value("dryRun").toBool();
+
+            // Configuration / busy gates only matter for live calls;
+            // a dry run just assembles prompts.
+            if (!dryRun) {
+                if (!ai->isConfigured()) {
+                    respond(QJsonObject{{"error", "AI provider not configured. Set provider + API key in app settings first."}});
+                    return;
+                }
+                if (ai->isAnalyzing()) {
+                    respond(QJsonObject{{"error", "AI advisor busy with another request — try again in a moment."}});
+                    return;
+                }
+            }
+
+            ShotHistoryStorage* shotHistory = mainController->shotHistory();
+            if (!shotHistory || !shotHistory->isReady()) {
+                respond(QJsonObject{{"error", "Shot history not available"}});
+                return;
+            }
+
+            // Resolve shot ID on the main thread before spawning the worker.
+            qint64 shotId = args.value("shot_id").toInteger(0);
+            if (shotId <= 0) shotId = shotHistory->lastSavedShotId();
+
+            const QString dbPath = shotHistory->databasePath();
+            const QString userPromptOverride = args.value("userPromptOverride").toString();
+            const QString systemPromptOverride = args.value("systemPromptOverride").toString();
+            QPointer<AIManager> aiPtr(ai);
+
+            // Pattern matches dialing_get_context: SQL on a background
+            // thread, then hop back to the main thread for AIManager
+            // access (AIManager owns providers + ShotSummarizer and is
+            // not thread-safe).
+            QThread* thread = QThread::create(
+                [dbPath, shotId, dryRun, userPromptOverride, systemPromptOverride,
+                 aiPtr, respond]() {
+                ShotProjection shot;
+                qint64 resolvedShotId = shotId;
+
+                if (resolvedShotId <= 0) {
+                    withTempDb(dbPath, "mcp_advisor_latest", [&](QSqlDatabase& db) {
+                        QSqlQuery q(db);
+                        if (q.exec("SELECT id FROM shots ORDER BY timestamp DESC LIMIT 1") && q.next())
+                            resolvedShotId = q.value(0).toLongLong();
+                    });
+                }
+
+                if (resolvedShotId <= 0) {
+                    QMetaObject::invokeMethod(qApp, [respond]() {
+                        respond(QJsonObject{{"error", "No shots available — record a shot before invoking the advisor."}});
+                    }, Qt::QueuedConnection);
+                    return;
+                }
+
+                withTempDb(dbPath, "mcp_advisor", [&](QSqlDatabase& db) {
+                    ShotRecord record = ShotHistoryStorage::loadShotRecordStatic(db, resolvedShotId);
+                    shot = ShotHistoryStorage::convertShotRecord(record);
+                });
+
+                QMetaObject::invokeMethod(qApp,
+                    [aiPtr, shot, dryRun, userPromptOverride, systemPromptOverride,
+                     resolvedShotId, respond]() {
+                    if (!aiPtr) {
+                        respond(QJsonObject{{"error", "App shut down before advisor call could start"}});
+                        return;
+                    }
+                    if (!shot.isValid()) {
+                        respond(QJsonObject{{"error", QString("Shot not found: %1").arg(resolvedShotId)}});
+                        return;
+                    }
+                    AIManager* ai = aiPtr.data();
+
+                    // Re-check the busy gate on the main thread for live
+                    // calls — between the gate above and here, the user
+                    // may have triggered an in-app advisor call.
+                    if (!dryRun && ai->isAnalyzing()) {
+                        respond(QJsonObject{{"error", "AI advisor busy with another request — try again in a moment."}});
+                        return;
+                    }
+
+                    QString systemPrompt;
+                    if (!systemPromptOverride.isEmpty()) {
+                        systemPrompt = systemPromptOverride;
+                    } else {
+                        const QString bevType = shot.beverageType.isEmpty()
+                            ? QStringLiteral("espresso") : shot.beverageType;
+                        QString profileType;
+                        if (!shot.profileJson.isEmpty()) {
+                            const QJsonObject pj = QJsonDocument::fromJson(shot.profileJson.toUtf8()).object();
+                            profileType = pj.value("type").toString();
+                        }
+                        systemPrompt = ShotSummarizer::shotAnalysisSystemPrompt(
+                            bevType, shot.profileName, profileType, shot.profileKbId);
+                    }
+
+                    QString userPrompt;
+                    if (!userPromptOverride.isEmpty()) {
+                        userPrompt = userPromptOverride;
+                    } else {
+                        userPrompt = ai->generateHistoryShotSummary(shot);
+                        if (userPrompt.isEmpty()) {
+                            respond(QJsonObject{{"error", "Failed to assemble shot summary for shot " + QString::number(resolvedShotId)}});
+                            return;
+                        }
+                    }
+
+                    // Dry-run path: return the prompts without invoking
+                    // the provider. Cost-free preview for prompt design.
+                    if (dryRun) {
+                        respond(QJsonObject{
+                            {"shotId", static_cast<double>(resolvedShotId)},
+                            {"provider", ai->selectedProvider()},
+                            {"model", ai->currentModelName()},
+                            {"systemPromptUsed", systemPrompt},
+                            {"userPromptUsed", userPrompt},
+                            {"dryRun", true}
+                        });
+                        return;
+                    }
+
+                    // Live path: subscribe to AIManager's reply signals
+                    // and invoke. `done` guards against double-fire (the
+                    // provider's own timeout could fire alongside our
+                    // wrapper's timeout in a race, though rare). The
+                    // QTimer is parented to AIManager so it's cleaned up
+                    // on shutdown.
+                    struct CallState {
+                        bool done = false;
+                        QMetaObject::Connection successConn;
+                        QMetaObject::Connection errorConn;
+                        QTimer* timeout = nullptr;
+                        qint64 startMs = 0;
+                    };
+                    auto* state = new CallState();
+                    state->startMs = QDateTime::currentMSecsSinceEpoch();
+                    state->timeout = new QTimer(ai);
+                    state->timeout->setSingleShot(true);
+                    state->timeout->setInterval(kAdvisorMcpTimeoutMs);
+
+                    const QString providerId = ai->selectedProvider();
+                    const QString modelName = ai->currentModelName();
+                    QPointer<AIManager> aiPtrInner(ai);
+
+                    auto finalize = [state, aiPtrInner, providerId, modelName,
+                                     systemPrompt, userPrompt, resolvedShotId, respond](
+                                        const QJsonObject& body) {
+                        if (state->done) return;
+                        state->done = true;
+                        if (aiPtrInner) {
+                            QObject::disconnect(state->successConn);
+                            QObject::disconnect(state->errorConn);
+                        }
+                        if (state->timeout) state->timeout->stop();
+                        const qint64 latencyMs = QDateTime::currentMSecsSinceEpoch() - state->startMs;
+
+                        QJsonObject result = body;
+                        result["shotId"] = static_cast<double>(resolvedShotId);
+                        result["provider"] = providerId;
+                        result["model"] = modelName;
+                        result["latencyMs"] = static_cast<double>(latencyMs);
+                        result["systemPromptUsed"] = systemPrompt;
+                        result["userPromptUsed"] = userPrompt;
+                        respond(result);
+
+                        delete state;
+                    };
+
+                    state->successConn = QObject::connect(ai, &AIManager::recommendationReceived,
+                        ai, [finalize](const QString& response) {
+                            finalize(QJsonObject{{"response", response}});
+                        });
+                    state->errorConn = QObject::connect(ai, &AIManager::errorOccurred,
+                        ai, [finalize](const QString& error) {
+                            finalize(QJsonObject{{"error", error}});
+                        });
+                    QObject::connect(state->timeout, &QTimer::timeout,
+                        ai, [finalize]() {
+                            finalize(QJsonObject{{"error", "Advisor call timed out after 75s"}});
+                        });
+
+                    state->timeout->start();
+                    ai->analyze(systemPrompt, userPrompt);
+                }, Qt::QueuedConnection);
+            });
+
+            QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+            thread->start();
+        },
+        "write");
+}

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -47,6 +47,7 @@ void registerDeviceTools(McpToolRegistry*, BLEManager*, DE1Device*) {}
 void registerDebugTools(McpToolRegistry*, MemoryMonitor*) {}
 void registerMcpResources(McpResourceRegistry*, DE1Device*, MachineState*, ProfileManager*, ShotHistoryStorage*, MemoryMonitor*, Settings*) {}
 void registerAgentTools(McpToolRegistry*) {}
+void registerAITools(McpToolRegistry*, MainController*) {}
 
 class tst_McpServerProtocol : public QObject {
     Q_OBJECT

--- a/tests/tst_mcpserver_session.cpp
+++ b/tests/tst_mcpserver_session.cpp
@@ -37,6 +37,7 @@ void registerDeviceTools(McpToolRegistry*, BLEManager*, DE1Device*) {}
 void registerDebugTools(McpToolRegistry*, MemoryMonitor*) {}
 void registerMcpResources(McpResourceRegistry*, DE1Device*, MachineState*, ProfileManager*, ShotHistoryStorage*, MemoryMonitor*, Settings*) {}
 void registerAgentTools(McpToolRegistry*) {}
+void registerAITools(McpToolRegistry*, MainController*) {}
 
 // Test McpServer session management: findOrCreateSession, ping, subscribe/unsubscribe.
 // These tests exercise the server directly without full BLE/profile wiring.


### PR DESCRIPTION
## Summary

New write-tier MCP tool that exercises the configured AI advisor end-to-end. Useful for:
- **Prompt A/B testing** — capture before/after responses on the same shot to validate prompt-side changes (like the canonical-source separation in #1030) don't regress advice quality.
- **Cost-free prompt preview** — pass \`dryRun: true\` to assemble the system + user prompts and return them without sending anywhere.
- **End-to-end advisor validation** — verify the configured provider + model + system prompt actually round-trip cleanly.

Always echoes \`systemPromptUsed\` + \`userPromptUsed\` in the response so the caller sees exactly what reached the provider — not just the response.

## Tool shape

\`ai_advisor_invoke\`, write tier:

\`\`\`json
{
  "shot_id": 42,                    // optional; defaults to most recent shot
  "dryRun": false,                  // optional; default false
  "userPromptOverride": "...",      // optional; replaces auto-built user prompt
  "systemPromptOverride": "..."     // optional; replaces auto-built system prompt
}
\`\`\`

Response:

\`\`\`json
{
  "shotId": 42,
  "provider": "anthropic",
  "model": "claude-sonnet-4-6",
  "systemPromptUsed": "...",
  "userPromptUsed": "...",
  "response": "...",                // when not dryRun
  "latencyMs": 4231,                // when not dryRun
  "dryRun": true                    // when dryRun
}
\`\`\`

Errors as \`{"error": "..."}\` for: unconfigured provider, busy advisor, missing shot, timeout (75s wrapper around the provider's 60s).

## Implementation notes

- Routes through \`AIManager::analyze\`, so the response also reaches the in-app conversation overlay (\`lastRecommendation\` / \`recommendationReceived\`). This is documented in the tool description; users can switch to a non-default provider via settings if they want isolation, or fire \`dryRun: true\` calls that skip the provider entirely.
- Pattern matches \`dialing_get_context\`: SQL on a worker thread, main-thread hop for AIManager + ShotSummarizer access (neither is thread-safe).
- 75s wrapper timeout sits just above the provider's own 60s \`ANALYSIS_TIMEOUT_MS\` so callers always get a clean reply rather than a dangling promise.
- Re-checks the busy gate after the background DB load completes — the user might have triggered an in-app advisor call between the gate check and the main-thread hop.
- \`done\` flag on the call state guards against double-fire (provider's own timeout could in theory fire alongside our wrapper's; rare but harmless).

## Test plan

- [x] Build via Qt Creator MCP — succeeded with 0 errors, 0 warnings
- [x] \`tst_McpServerSession\` (16 tests) — pass
- [x] \`tst_McpServerProtocol\` (29 tests) — pass
- [ ] Manual smoke test: configure a provider, invoke \`ai_advisor_invoke\` with \`dryRun: true\`, confirm the assembled prompts match what the in-app advisor sees
- [ ] Manual smoke test: same with \`dryRun: false\`, confirm round-trip works and \`response\` is populated
- [ ] Verify the in-app overlay receives the response (intended side effect — documented)

🤖 Generated with [Claude Code](https://claude.ai/code)