### PR TITLE
test(aimanager): use de1app-shape exit object in profile JSON fixture

### DIFF
--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -98,7 +98,7 @@ private slots:
             "type": "advanced",
             "version": 2,
             "steps": [
-                {"name":"preinfusion","temperature":92,"seconds":8,"flow":4.0,"transition":"fast","exit":{"type":"pressure_over","value":4.0}},
+                {"name":"preinfusion","temperature":92,"seconds":8,"flow":4.0,"transition":"fast","exit":{"type":"pressure","condition":"over","value":4.0}},
                 {"name":"pour","temperature":92,"seconds":22,"pressure":9.0,"transition":"smooth"}
             ]
         })");


### PR DESCRIPTION
## Summary

- The preinfusion frame in `tst_AIManager::emitRecentShotContext_hoistsProfileAndSetupOnce`'s profile JSON fixture stuffed the legacy flat `exitType` name (`pressure_over`) into the de1app-shaped nested envelope.
- `ProfileFrame::fromJson`'s nested branch only recognizes `type ∈ {pressure, flow, weight}` with a separate `condition ∈ {over, under}` — it logged the warning and ignored the exit condition.
- Updated the fixture to the proper de1app shape: `{"type":"pressure","condition":"over","value":4.0}`.

## Why

Test passed (assertions don't depend on the parsed exit) but every run leaked a real `qWarning` into the test log. The QtC test runner flagged it under `tests_with_warnings`.

## Test plan

- [x] `tst_AIManager::emitRecentShotContext_hoistsProfileAndSetupOnce` — no longer emits the warning.
- [x] Full suite: 1916 passed, 0 failed, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)