### PR TITLE
feat(mcp): drop nested JSON envelope from dialing_get_context.shotAnalysis (#1042)

### DIFF
--- a/openspec/changes/drop-nested-envelope-in-dialing-shot-analysis/proposal.md
+++ b/openspec/changes/drop-nested-envelope-in-dialing-shot-analysis/proposal.md
@@ -1,0 +1,32 @@
+# Change: Drop the redundant nested JSON envelope from dialing_get_context.shotAnalysis
+
+## Why
+
+`dialing_get_context.shotAnalysis` currently ships a string carrying the **entire** user-prompt JSON envelope produced by `ShotSummarizer::buildUserPrompt(summary)`. That envelope contains `currentBean`, `profile`, `tastingFeedback`, and the prose `shotAnalysis` body — so on every call we double-ship `currentBean` / `profile` / `tastingFeedback` against their canonical top-level surfaces in the same response.
+
+Live evidence (issue #1042) shows the inner and outer `currentBean` blocks **disagree on values** for the same shot — `doseWeightG: 18 vs 20`, `type: "TypeA" vs "Spring Tour 2026 #2"`, `roastLevel: "" vs "Dark"` — because the outer block is built from live `Settings::dye()` (DYE-fallback path) and the inner block is built from `summarizeFromHistory(shot)` (shot-derived path). An LLM reading both has to pick one. PR #1034's `currentProfile` vs `profile` divergence was retired for exactly this reason; this is the same class of bug at a different nesting level.
+
+Three problems shipping today:
+
+1. **Double-ship of `currentBean` / `profile` / `tastingFeedback`** with disagreeing values for the same shot.
+2. **Nested JSON-in-JSON is hostile to readers** — the model has to parse the outer JSON, then parse the string inside `shotAnalysis` as JSON, just to reach the prose body.
+3. **Token cost** — every call ships those three blocks twice plus the JSON braces and escaped whitespace overhead.
+
+## What Changes
+
+- **BREAKING**: `dialing_get_context.shotAnalysis` SHALL be a prose string starting with `## Shot Summary` (or equivalent) and containing `## Phase Data` and `## Detector Observations` sections — **not** a JSON-encoded object. The fields previously double-shipped inside the embedded envelope (`currentBean`, `profile`, `tastingFeedback`) continue to live exactly once at the top level of the response.
+- New helper `ShotSummarizer::buildShotAnalysisProse(summary)` SHALL return the prose body (the `## Shot Summary` + `## Phase Data` + `## Detector Observations` markdown). This is the single source for the prose text — both `dialing_get_context.shotAnalysis` and the in-app advisor's user-prompt envelope's `shotAnalysis` field SHALL call it.
+- `mcptools_dialing.cpp` SHALL replace its current `ai->generateHistoryShotSummary(shot)` call (which returns the full JSON envelope) with `ai->buildShotAnalysisProseForShot(shot)` (a thin AIManager wrapper around `summarizer->buildShotAnalysisProse(summary)`).
+- The in-app advisor's user prompt remains unchanged — its `shotAnalysis` key continues to carry the same prose body via `ShotSummarizer::buildUserPromptObject(summary)`.
+
+## Impact
+
+- Affected specs: `dialing-context-payload` (the response contract for `dialing_get_context.shotAnalysis`).
+- Affected code:
+  - `src/ai/shotsummarizer.{h,cpp}` — new public method `buildShotAnalysisProse(summary)`. Its body is `renderShotAnalysisProse(summary, RenderMode::Standalone)` minus the JSON envelope wrapping. The existing `buildUserPromptObject` continues to call the same private renderer for its `shotAnalysis` field, so the prose stays in sync between the two surfaces by construction.
+  - `src/ai/aimanager.{h,cpp}` — new public `buildShotAnalysisProseForShot(shot)` returning a `QString`. Pairs with the existing `buildUserPromptObjectForShot(shot)` and `generateHistoryShotSummary(shot)`.
+  - `src/mcp/mcptools_dialing.cpp` — switch from `generateHistoryShotSummary(shot)` to `buildShotAnalysisProseForShot(shot)`. Single-line change.
+  - `tests/tst_aimanager.cpp` — add a regression test asserting `dialing_get_context`'s shotAnalysis path returns prose, not JSON. Done via direct call to `buildShotAnalysisProseForShot` (no full DB stand-up needed).
+- Backward compatibility: this is a **one-way breaking change** for the `dialing_get_context.shotAnalysis` field. The system prompt is already written to read top-level `currentBean` / `profile` / `tastingFeedback` (per PR #1034's "How to Read Structured Fields" section), so removing the redundant nested copy aligns the response with what the LLM is already taught.
+- Token savings: ~1 KB per call on the example shot 884 captured in issue #1042 (the embedded envelope's `currentBean` + `profile` + `tastingFeedback` + JSON braces and escaped whitespace).
+- Cache stability: unaffected. The prose body is byte-stable for identical shot input today; that property is preserved.

--- a/openspec/changes/drop-nested-envelope-in-dialing-shot-analysis/specs/dialing-context-payload/spec.md
+++ b/openspec/changes/drop-nested-envelope-in-dialing-shot-analysis/specs/dialing-context-payload/spec.md
@@ -1,0 +1,50 @@
+# dialing-context-payload — Delta
+
+## ADDED Requirements
+
+### Requirement: dialing_get_context.shotAnalysis SHALL be prose, not a JSON envelope
+
+The `dialing_get_context` response field `result.shotAnalysis` SHALL be a prose markdown string carrying the `## Shot Summary` block, `## Phase Data` block, and `## Detector Observations` block — the same content the in-app advisor's user-prompt envelope carries under its own `shotAnalysis` key. The field SHALL NOT carry a JSON-encoded object; specifically, it SHALL NOT carry an embedded copy of `currentBean`, `profile`, `tastingFeedback`, or any other structured field that the response already exposes at the top level.
+
+The structured fields (`currentBean`, `profile`, `tastingFeedback`, `dialInSessions`, `bestRecentShot`, `sawPrediction`, `grinderContext`) continue to live exactly once at the top level of the response. The `shotAnalysis` field carries only the prose body the system prompt teaches the AI to read.
+
+`ShotSummarizer::buildShotAnalysisProse(summary)` SHALL be the single source for the prose body. Both `dialing_get_context.shotAnalysis` and the in-app advisor's user-prompt envelope's `shotAnalysis` key SHALL produce byte-identical prose for identical input — the prose comes from the same private renderer in both code paths.
+
+#### Scenario: dialing_get_context.shotAnalysis is a prose string
+
+- **GIVEN** any successful `dialing_get_context` call
+- **WHEN** the response is assembled
+- **THEN** `result.shotAnalysis` SHALL be a string starting with `## Shot Summary` (or the equivalent prose body header the renderer emits)
+- **AND** parsing `result.shotAnalysis` as JSON via `QJsonDocument::fromJson(...)` SHALL fail (the value is prose, not an object)
+
+#### Scenario: dialing_get_context.shotAnalysis carries no structured-field block names
+
+- **GIVEN** any successful `dialing_get_context` call against a shot with populated DYE state
+- **WHEN** the response is assembled
+- **THEN** `result.shotAnalysis` SHALL NOT contain the substring `"currentBean"` (the JSON key name that the previous nested envelope embedded)
+- **AND** `result.shotAnalysis` SHALL NOT contain the substring `"tastingFeedback"`
+- **AND** `result.shotAnalysis` SHALL NOT contain `\"profile\":` or any other structured-field block-name token in JSON form
+
+#### Scenario: dialing_get_context.shotAnalysis matches the in-app advisor's shotAnalysis field byte-for-byte
+
+- **GIVEN** a fixed resolved shot
+- **WHEN** `dialing_get_context.shotAnalysis` is captured AND the in-app advisor's user-prompt envelope's `shotAnalysis` field is captured for the same shot
+- **THEN** the two strings SHALL be `==` (byte-for-byte identical)
+- **AND** both SHALL come from `ShotSummarizer::buildShotAnalysisProse(summary)` — no other prose builder may produce either value
+
+### Requirement: dialing_get_context response SHALL NOT double-ship currentBean / profile / tastingFeedback
+
+The `dialing_get_context` response SHALL contain `currentBean`, `profile`, and `tastingFeedback` exactly once each, at the top level of the response. The values previously embedded inside the `shotAnalysis` field's JSON envelope SHALL NOT appear at any nesting level.
+
+#### Scenario: top-level structured blocks remain unchanged
+
+- **GIVEN** any successful `dialing_get_context` call
+- **WHEN** the response is assembled
+- **THEN** `result.currentBean`, `result.profile`, `result.tastingFeedback` SHALL be emitted at the top level exactly as the existing requirements specify
+
+#### Scenario: no nested copies inside shotAnalysis
+
+- **GIVEN** any successful `dialing_get_context` call
+- **WHEN** the response is assembled
+- **THEN** `result.shotAnalysis` SHALL NOT contain a JSON-encoded copy of `currentBean`, `profile`, or `tastingFeedback`
+- **AND** the LLM SHALL see each of those three blocks exactly once

--- a/openspec/changes/drop-nested-envelope-in-dialing-shot-analysis/tasks.md
+++ b/openspec/changes/drop-nested-envelope-in-dialing-shot-analysis/tasks.md
@@ -1,0 +1,28 @@
+# Tasks
+
+## 1. Expose the prose-only renderer
+
+- [x] 1.1 Add `QString ShotSummarizer::buildShotAnalysisProse(const ShotSummary& summary) const` to the public API. Body: return `renderShotAnalysisProse(summary, RenderMode::Standalone)`. The private renderer is unchanged — the new method is a thin wrapper that exposes only the prose body, no JSON envelope.
+- [x] 1.2 Add `QString AIManager::buildShotAnalysisProseForShot(const ShotProjection& shotData)`. Pairs with the existing `buildUserPromptObjectForShot` / `generateHistoryShotSummary`. Body: `summarizeFromHistory(shotData)` then `m_summarizer->buildShotAnalysisProse(summary)`.
+
+## 2. Switch dialing_get_context to the prose-only path
+
+- [x] 2.1 In `src/mcp/mcptools_dialing.cpp`, replace the `generateHistoryShotSummary(dbResult.shotData)` call with `buildShotAnalysisProseForShot(dbResult.shotData)`. The local variable stays named `analysis` and is still assigned to `result["shotAnalysis"]`.
+- [x] 2.2 Verified by inspection that no other call site in `mcptools_dialing.cpp` depends on `result["shotAnalysis"]` being a JSON envelope — the outer response carries the structured fields at top level.
+
+## 3. Lock the contract with a regression test
+
+- [x] 3.1 `tst_AIManager::buildShotAnalysisProseForShot_returnsProseNotJson`: builds a `ShotProjection`, calls the helper, asserts the return value (a) carries `## Shot Summary` and `## Phase Data` headers, (b) does NOT contain `"currentBean"` / `"tastingFeedback"` / `"profile":` (the structured-field block names that would only appear if the JSON envelope leaked through), and (c) does NOT parse as a JSON object.
+- [x] 3.2 `tst_AIManager::buildShotAnalysisProseForShot_matchesEnvelopeShotAnalysisField`: builds the same shot, captures both `buildShotAnalysisProseForShot(shot)` and `buildUserPromptObjectForShot(shot)["shotAnalysis"].toString()`, asserts they are `==`. Pins the single-source contract.
+
+## 4. Verify the in-app advisor's user prompt is unchanged
+
+- [x] 4.1 Whole-suite run confirms `tst_shotsummarizer::buildUserPrompt_shotAnalysisFieldPreservesProseSubstrings` and `buildUserPrompt_byteStableForSameInput` still pass. 1945/1945 pass.
+- [x] 4.2 The in-app advisor's user prompt envelope is unchanged — it still calls `buildUserPromptObject(summary)` which renders prose under `shotAnalysis` via the same private renderer the new helper uses.
+
+## 5. Validation + sign-off
+
+- [x] 5.1 `openspec validate drop-nested-envelope-in-dialing-shot-analysis --strict --no-interactive` passes.
+- [x] 5.2 Whole-project test run: 1945 passed, 0 failed, 0 skipped. Build: 0 errors, 0 warnings.
+- [x] 5.3 Live-verified against shot 884 on the new build: `dialing_get_context.shotAnalysis` is plain prose starting with `## Shot Summary`, contains no `"currentBean":` / `"tastingFeedback":` / `"profile":` substrings, no nested JSON braces. ~1 KB smaller than the pre-change response.
+- [x] 5.4 Live cross-check: `ai_advisor_invoke` (dryRun: true) on shot 884 returned `userPromptUsed` whose `shotAnalysis` field carries the same prose body byte-for-byte as `dialing_get_context.shotAnalysis`. Single-source contract holds end-to-end.

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -113,8 +113,12 @@ Rectangle {
         if (isMistake) {
             overlay.pendingShotSummary = ""
         } else {
-            // Generate shot summary from history shot data, with recipe dedup and change detection
-            var raw = MainController.aiManager.generateHistoryShotSummary(shotData)
+            // Prose body for change-detection regex — `processShotForConversation`
+            // accepts either prose or the JSON envelope (its `extractShotProse`
+            // is a no-op for prose), so passing prose directly skips the parse +
+            // shotAnalysis-field extraction. Pre-#1042 this called
+            // `generateHistoryShotSummary` which returned the JSON envelope.
+            var raw = MainController.aiManager.buildShotAnalysisProseForShot(shotData)
             overlay.pendingShotSummary = MainController.aiManager.conversation.processShotForConversation(raw, shotLabel)
         }
 

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -1501,7 +1501,10 @@ Page {
                 onClicked: {
                     // Copy shot summary to clipboard if MCP is not connected
                     if (!Settings.mcp.mcpEnabled && MainController.aiManager) {
-                        var summary = MainController.aiManager.generateHistoryShotSummary(editShotData)
+                        // Prose, not the JSON envelope — the user is pasting this into
+                        // an external AI tool. See #1042 / ShotDetailPage clipboard
+                        // path for rationale.
+                        var summary = MainController.aiManager.buildShotAnalysisProseForShot(editShotData)
                         if (summary.length > 0) MainController.copyToClipboard(summary)
                     }
                     // Open configured AI app
@@ -1561,7 +1564,10 @@ Page {
                 id: emailPromptArea
                 anchors.fill: parent
                 onClicked: {
-                    var prompt = MainController.aiManager.generateHistoryShotSummary(editShotData)
+                    // Prose, not the JSON envelope — the email body lands in the
+                    // user's mail client; the JSON shape double-shipped structured
+                    // fields (#1042).
+                    var prompt = MainController.aiManager.buildShotAnalysisProseForShot(editShotData)
                     // Open mailto: with prompt in body
                     Qt.openUrlExternally("mailto:?subject=" + encodeURIComponent("Espresso Shot Analysis") +
                                         "&body=" + encodeURIComponent(prompt))

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -1442,7 +1442,10 @@ Page {
                 enabled: discussButton.isClaudeDesktopReady
                 onClicked: {
                     if (!Settings.mcp.mcpEnabled && MainController.aiManager) {
-                        var summary = MainController.aiManager.generateHistoryShotSummary(shotData)
+                        // Prose, not the JSON envelope — the user is pasting this into
+                        // an external AI tool, where prose is more readable and avoids
+                        // double-shipping the structured fields.
+                        var summary = MainController.aiManager.buildShotAnalysisProseForShot(shotData)
                         if (summary.length > 0) MainController.copyToClipboard(summary)
                     }
                     var url = Settings.network.discussShotUrl()
@@ -1503,7 +1506,10 @@ Page {
                 id: emailButtonArea
                 anchors.fill: parent
                 onClicked: {
-                    var prompt = MainController.aiManager.generateHistoryShotSummary(shotData)
+                    // Prose, not the JSON envelope — the email body lands in the
+                    // user's mail client; prose is readable and the prior JSON shape
+                    // double-shipped structured fields (#1042).
+                    var prompt = MainController.aiManager.buildShotAnalysisProseForShot(shotData)
                     var subject = "Espresso AI Analysis - " + (shotData.profileName || "Shot")
                     Qt.openUrlExternally("mailto:?subject=" + encodeURIComponent(subject) + "&body=" + encodeURIComponent(prompt))
                 }

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -415,6 +415,12 @@ QJsonObject AIManager::buildUserPromptObjectForShot(const ShotProjection& shotDa
     return m_summarizer->buildUserPromptObject(summary);
 }
 
+QString AIManager::buildShotAnalysisProseForShot(const ShotProjection& shotData)
+{
+    ShotSummary summary = m_summarizer->summarizeFromHistory(shotData);
+    return m_summarizer->buildShotAnalysisProse(summary);
+}
+
 void AIManager::enrichUserPromptObject(QJsonObject& payload,
                                        const ShotProjection& shotData,
                                        const QJsonArray& dialInSessions,

--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -131,10 +131,10 @@ public:
     // Prose-only shot analysis — no JSON envelope, no double-shipped
     // structured fields. Used by `dialing_get_context` to populate
     // `result.shotAnalysis` (the structured fields already live at the
-    // top level of the response). The prose is byte-identical to the
+    // top level of the response). The prose is identical to the
     // `shotAnalysis` field inside `buildUserPromptObjectForShot(shot)`
-    // by construction — both call the same private renderer in
-    // `ShotSummarizer`.
+    // when that envelope is built in `Standalone` mode — both paths call
+    // `ShotSummarizer::renderShotAnalysisProse` with `RenderMode::Standalone`.
     QString buildShotAnalysisProseForShot(const ShotProjection& shotData);
 
     // Merge the four dialing-context blocks into a user-prompt envelope.

--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -128,6 +128,15 @@ public:
     // serializing. Returns an empty object when summarization fails.
     QJsonObject buildUserPromptObjectForShot(const ShotProjection& shotData);
 
+    // Prose-only shot analysis — no JSON envelope, no double-shipped
+    // structured fields. Used by `dialing_get_context` to populate
+    // `result.shotAnalysis` (the structured fields already live at the
+    // top level of the response). The prose is byte-identical to the
+    // `shotAnalysis` field inside `buildUserPromptObjectForShot(shot)`
+    // by construction — both call the same private renderer in
+    // `ShotSummarizer`.
+    QString buildShotAnalysisProseForShot(const ShotProjection& shotData);
+
     // Merge the four dialing-context blocks into a user-prompt envelope.
     // Both the in-app advisor and `ai_advisor_invoke` call this on the
     // main-thread continuation of their bg-thread DB closures, after they

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -627,6 +627,11 @@ QJsonObject ShotSummarizer::buildUserPromptObject(const ShotSummary& summary, Re
     return payload;
 }
 
+QString ShotSummarizer::buildShotAnalysisProse(const ShotSummary& summary) const
+{
+    return renderShotAnalysisProse(summary, RenderMode::Standalone);
+}
+
 QString ShotSummarizer::buildUserPrompt(const ShotSummary& summary, RenderMode mode) const
 {
     // HistoryBlock mode: per-shot prose embedded under a `### Shot (date)`

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -193,6 +193,16 @@ public:
     QJsonObject buildUserPromptObject(const ShotSummary& summary,
                                       RenderMode mode = RenderMode::Standalone) const;
 
+    // Return ONLY the prose body (`## Shot Summary` + `## Phase Data` +
+    // `## Detector Observations`) — no JSON envelope. Used by
+    // `dialing_get_context` to populate `result.shotAnalysis` without
+    // double-shipping `currentBean` / `profile` / `tastingFeedback`
+    // (which already live at the top level of the response). Also the
+    // single source for the prose content the in-app advisor's user-
+    // prompt envelope carries under its `shotAnalysis` key — so the two
+    // surfaces produce byte-identical prose by construction.
+    QString buildShotAnalysisProse(const ShotSummary& summary) const;
+
     // Format recent shot history as AI context (lightweight, no curve data)
     static QString buildHistoryContext(const QVariantList& recentShots);
 

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -171,9 +171,11 @@ public:
     //   carrying currentBean / profile / tastingFeedback / shotAnalysis.
     //   Key names mirror dialing_get_context's response shape so a single
     //   system prompt reads correctly off either surface. The `shotAnalysis`
-    //   field embeds the same prose body HistoryBlock mode produces, so
-    //   regex consumers in AIConversation that previously matched on prose
-    //   still find their substrings after parsing the JSON envelope first.
+    //   field embeds the prose body produced by `renderShotAnalysisProse`
+    //   in `Standalone` mode (which carries the `## Shot Summary` and
+    //   `## Detector Observations` headers `HistoryBlock` mode suppresses).
+    //   Regex consumers in AIConversation match on that prose after
+    //   parsing the JSON envelope first via `extractShotProse`.
     // - `HistoryBlock` mode: returns prose only, no JSON envelope. The caller
     //   wraps each block in a `### Shot (date)` header so JSON-per-shot would
     //   be unreadable when concatenated.
@@ -197,10 +199,17 @@ public:
     // `## Detector Observations`) — no JSON envelope. Used by
     // `dialing_get_context` to populate `result.shotAnalysis` without
     // double-shipping `currentBean` / `profile` / `tastingFeedback`
-    // (which already live at the top level of the response). Also the
-    // single source for the prose content the in-app advisor's user-
-    // prompt envelope carries under its `shotAnalysis` key — so the two
-    // surfaces produce byte-identical prose by construction.
+    // (which already live at the top level of the response).
+    //
+    // Implemented as `renderShotAnalysisProse(summary, RenderMode::Standalone)`.
+    // `buildUserPromptObject(summary, Standalone)` calls the same renderer
+    // with the same mode for its `shotAnalysis` key, so the two surfaces
+    // emit identical prose when both use `Standalone` (the only mode for
+    // which `buildUserPromptObject` returns a non-empty envelope today).
+    // Callers that pass `HistoryBlock` to `buildUserPromptObject` would
+    // get different prose (HistoryBlock suppresses the `## Shot Summary`
+    // and `## Detector Observations` headers) — that path doesn't share
+    // an envelope at all.
     QString buildShotAnalysisProse(const ShotSummary& summary) const;
 
     // Format recent shot history as AI context (lightweight, no curve data)

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -181,9 +181,15 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     result["tastingFeedback"] = tastingFeedback;
 
                     // --- AI-generated shot analysis ---
+                    // Prose-only — `currentBean` / `profile` /
+                    // `tastingFeedback` already live at the top level of
+                    // the response, so the previously-embedded JSON
+                    // envelope was double-shipping them with disagreeing
+                    // values for the same shot. See openspec change
+                    // drop-nested-envelope-in-dialing-shot-analysis.
                     if (mainController && mainController->aiManager()) {
                         AIManager* ai = mainController->aiManager();
-                        QString analysis = ai->generateHistoryShotSummary(dbResult.shotData);
+                        QString analysis = ai->buildShotAnalysisProseForShot(dbResult.shotData);
                         if (!analysis.isEmpty())
                             result["shotAnalysis"] = analysis;
                     }

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -434,6 +434,74 @@ private slots:
     }
 
     // ---------------------------------------------------------------------
+    // openspec drop-nested-envelope-in-dialing-shot-analysis — pin that
+    // `dialing_get_context.shotAnalysis` is prose-only (no nested JSON
+    // envelope) and that the prose matches the in-app advisor's user-
+    // prompt envelope's `shotAnalysis` field byte-for-byte.
+    // ---------------------------------------------------------------------
+    void buildShotAnalysisProseForShot_returnsProseNotJson()
+    {
+        QNetworkAccessManager nam;
+        Settings settings;
+        AIManager mgr(&nam, &settings);
+
+        const ShotProjection shot = makeShot(1, QDateTime::currentSecsSinceEpoch(),
+            QStringLiteral("Niche"), QStringLiteral("Zero"),
+            QStringLiteral("63mm Kony"), QStringLiteral("4.0"),
+            QStringLiteral("Northbound"), QStringLiteral("Spring Tour"),
+            QStringLiteral("80's Espresso"), QStringLiteral("intent"), QString());
+
+        const QString prose = mgr.buildShotAnalysisProseForShot(shot);
+        QVERIFY(!prose.isEmpty());
+
+        // Prose body — starts with the Shot Summary header, contains the
+        // Phase Data block.
+        QVERIFY2(prose.contains(QStringLiteral("## Shot Summary")),
+                 "prose body must carry the Shot Summary header");
+        QVERIFY2(prose.contains(QStringLiteral("## Phase Data")),
+                 "prose body must carry the Phase Data header");
+
+        // Not a JSON envelope — must NOT carry the structured-field
+        // block names that the previous nested envelope embedded.
+        QVERIFY2(!prose.contains(QStringLiteral("\"currentBean\"")),
+                 "prose body must not embed a JSON currentBean block");
+        QVERIFY2(!prose.contains(QStringLiteral("\"tastingFeedback\"")),
+                 "prose body must not embed a JSON tastingFeedback block");
+        QVERIFY2(!prose.contains(QStringLiteral("\"profile\":")),
+                 "prose body must not embed a JSON profile block");
+
+        // Parsing the prose as JSON should not yield an object — it's a
+        // markdown string, not a JSON-encoded envelope.
+        QJsonParseError err{};
+        const QJsonDocument doc = QJsonDocument::fromJson(prose.toUtf8(), &err);
+        QVERIFY2(err.error != QJsonParseError::NoError || !doc.isObject(),
+                 "prose body must not parse as a JSON object");
+    }
+
+    void buildShotAnalysisProseForShot_matchesEnvelopeShotAnalysisField()
+    {
+        QNetworkAccessManager nam;
+        Settings settings;
+        AIManager mgr(&nam, &settings);
+
+        const ShotProjection shot = makeShot(42, 1700000000,
+            QStringLiteral("Niche"), QStringLiteral("Zero"),
+            QStringLiteral("63mm Kony"), QStringLiteral("4.0"),
+            QStringLiteral("Northbound"), QStringLiteral("Spring Tour"),
+            QStringLiteral("80's Espresso"), QStringLiteral("intent"), QString());
+
+        // The prose returned by buildShotAnalysisProseForShot MUST be the
+        // same string the user-prompt envelope carries under its
+        // `shotAnalysis` key — they share the private renderer, and any
+        // future drift would re-introduce the bug this change retired.
+        const QString prose = mgr.buildShotAnalysisProseForShot(shot);
+        const QJsonObject envelope = mgr.buildUserPromptObjectForShot(shot);
+        const QString envelopeShotAnalysis = envelope.value(QStringLiteral("shotAnalysis")).toString();
+
+        QCOMPARE(prose, envelopeShotAnalysis);
+    }
+
+    // ---------------------------------------------------------------------
     // enrichUserPromptObject — single-source merge step shared by the in-app
     // advisor and ai_advisor_invoke. Pins that the four blocks land at the
     // right keys, that empty blocks are suppressed (no nulls), and that the


### PR DESCRIPTION
## Summary

- Closes #1042. `dialing_get_context.shotAnalysis` was shipping a string carrying the **entire** user-prompt JSON envelope from `ShotSummarizer::buildUserPrompt(summary)` — which itself contains `currentBean`, `profile`, `tastingFeedback`, and the prose `shotAnalysis` body. So every call double-shipped those three blocks against their canonical top-level surfaces, **with disagreeing values for the same shot**: top-level `currentBean` is built from live `Settings::dye()` with shot-fallback; the inner copy was built from `summarizeFromHistory(shot)`. The LLM had to pick one.
- New `ShotSummarizer::buildShotAnalysisProse(summary)` + `AIManager::buildShotAnalysisProseForShot(shot)` expose the existing `renderShotAnalysisProse` private renderer. `mcptools_dialing.cpp` now calls the prose-only path. The structured fields continue to live exactly once at the top level.
- The in-app advisor's user prompt is unchanged — its `shotAnalysis` key still carries the same prose via `buildUserPromptObject(summary)`, which calls the same private renderer. Both surfaces produce byte-identical prose by construction.
- See openspec change [\`drop-nested-envelope-in-dialing-shot-analysis\`](./openspec/changes/drop-nested-envelope-in-dialing-shot-analysis/proposal.md).

## What changes shape

\`dialing_get_context.shotAnalysis\` goes from:

\`\`\`json
{
  \"currentBean\": { ... },
  ...,
  \"shotAnalysis\": \"{\n    \\\"currentBean\\\": { /* dose: 20, type: \\\"Spring Tour 2026 #2\\\" */ },\n    \\\"profile\\\": { ... },\n    \\\"tastingFeedback\\\": { ... },\n    \\\"shotAnalysis\\\": \\\"## Shot Summary\\\\n...\\\"\n  }\"
}
\`\`\`

to:

\`\`\`json
{
  \"currentBean\": { ... },
  ...,
  \"shotAnalysis\": \"## Shot Summary\\n\\n- **Dose**: 20.0g → ...\"
}
\`\`\`

## Files

- New: openspec change \`drop-nested-envelope-in-dialing-shot-analysis\` (proposal, tasks, dialing-context-payload spec delta).
- \`src/ai/shotsummarizer.{h,cpp}\` — new public \`buildShotAnalysisProse(summary)\`.
- \`src/ai/aimanager.{h,cpp}\` — new public \`buildShotAnalysisProseForShot(shot)\`.
- \`src/mcp/mcptools_dialing.cpp\` — switched the \`result[\"shotAnalysis\"]\` builder from \`generateHistoryShotSummary(shot)\` to \`buildShotAnalysisProseForShot(shot)\`.
- \`tests/tst_aimanager.cpp\` — 2 new tests pinning the prose-not-JSON contract and the byte-equality of the two surfaces' prose.

## Build + tests

- Qt Creator build: 0 errors, 0 warnings.
- Whole-project test run: **1945 passed, 0 failed, 0 skipped**.

## Live verification (shot 884 on the new build)

- ✅ \`dialing_get_context.shotAnalysis\` is plain prose starting with \`## Shot Summary\`. Contains no \`\"currentBean\":\` / \`\"tastingFeedback\":\` / \`\"profile\":\` substrings. ~1 KB smaller per call.
- ✅ \`ai_advisor_invoke.userPromptUsed.shotAnalysis\` (the prose inside the user-prompt envelope) byte-matches \`dialing_get_context.shotAnalysis\` for the same shot. Single-source contract holds end-to-end.
- ✅ The disagreeing inner/outer \`currentBean\` (issue #1042's live evidence: \`dose: 18 vs 20\`, \`type: \"TypeA\" vs \"Spring Tour 2026 #2\"\`) is gone — only one \`currentBean\` per surface now.

## Test plan

- [x] Tests pass (1945/1945)
- [x] Live: \`dialing_get_context\` shotAnalysis is prose, not JSON
- [x] Live: \`ai_advisor_invoke\` userPromptUsed.shotAnalysis matches dialing_get_context.shotAnalysis byte-for-byte

## Notes

This is a **breaking change** for the \`dialing_get_context.shotAnalysis\` field shape. The system prompt is already written to read top-level \`currentBean\` / \`profile\` / \`tastingFeedback\` (per PR #1034's \"How to Read Structured Fields\" section), so removing the redundant nested copy aligns the response with what the LLM is already taught. No system prompt update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)