### PR TITLE
fix(history): log query failure in queryGrinderContext (#1045)

### DIFF
--- a/src/history/shothistorystorage_queries.cpp
+++ b/src/history/shothistorystorage_queries.cpp
@@ -616,7 +616,14 @@ GrinderContext ShotHistoryStorage::queryGrinderContext(QSqlDatabase& db,
     if (!beanBrand.isEmpty()) {
         q.bindValue(":brand", beanBrand);
     }
-    if (!q.exec()) return ctx;
+    if (!q.exec()) {
+        qWarning() << "ShotHistoryStorage::queryGrinderContext: query failed:"
+                   << q.lastError().text()
+                   << "grinderModel=" << grinderModel
+                   << "beverageType=" << ctx.beverageType
+                   << "beanBrand=" << beanBrand;
+        return ctx;
+    }
 
     QSet<double> numericSet;
     ctx.allNumeric = true;


### PR DESCRIPTION
## Summary
- Replace silent `if (!q.exec()) return ctx;` in `ShotHistoryStorage::queryGrinderContext` with a `qWarning` that captures the SQL error plus `grinderModel` / `beverageType` / `beanBrand` so a real DB error stops being indistinguishable from a benign "no matching shots" result.
- Matches the existing house-style precedent in the same file (`loadShotRecordStatic`, `loadRecentShotsByKbIdStatic`).
- Pure telemetry: the empty-`ctx` return shape on failure is unchanged, so callers (`McpDialingBlocks::buildGrinderContextBlock`, used by both `dialing_get_context` and the in-app advisor enrichment via #1041) and tests keep working.

Closes #1045.

## Test plan
- [x] Local build (Qt Creator) clean — 0 errors, 0 warnings.
- [ ] No new tests required: failure-branch logging is non-functional for callers (return shape unchanged); existing `tst_aimanager` / dialing-context tests continue to assert the omission contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)