### PR TITLE
fix(ai): unify currentBean shape to a single shot-derived block (#1043)

### DIFF
--- a/openspec/changes/unify-current-bean-shape/proposal.md
+++ b/openspec/changes/unify-current-bean-shape/proposal.md
@@ -8,21 +8,23 @@ For the same resolved shot, `dialing_get_context.currentBean` and the in-app adv
 
 - **BREAKING** (LLM contract): `dialing_get_context.currentBean` now describes "the setup that produced the resolved shot," not "the live DYE setup with shot fallback." All bean / grinder / dose / roastDate fields are read from the resolved shot's saved metadata.
 - The `inferredFromShotId`, `inferredFields`, and (already-omitted-per-#977) `inferredNote` mechanism is **removed** from `currentBean`. Once the shot is the canonical source, nothing is "inferred" — every field originates from one place. Fields the shot did not record render as empty strings (or as omissions for `doseWeightG <= 0`).
-- A shared `McpDialingBlocks::buildCurrentBeanBlock(const ShotProjection&)` helper produces the JSON for both surfaces, so they cannot drift again.
+- A shared `McpDialingBlocks::buildCurrentBeanBlock(const CurrentBeanBlockInputs&)` helper produces the JSON for both surfaces, so they cannot drift again. Inputs are a small adapter struct so the in-app advisor's `ShotSummary` path can call it without round-tripping through the heavyweight `ShotProjection` type.
 - `currentBean.beanFreshness` is built off the resolved shot's `roastDate` on both surfaces (it was DYE-sourced in the MCP path; both now agree).
 - The `shotAnalysisSystemPrompt` "How to read structured fields" section drops the `inferredFields` clause (the field no longer ships) and tightens the `currentBean` description to "the setup that produced the resolved shot."
 - A new equivalence test in `tst_aimanager` drives both surfaces with a fixed shot + a deliberately divergent live DYE state and asserts the resulting `currentBean` JSON is equal under `==`.
 
 Live-DYE-vs-shot drift (the user changed DYE since the shot was pulled) is no longer surfaced in `currentBean` — that is a deliberate scope reduction. If a future change needs it, a separate `liveSetup` block can be added without renegotiating `currentBean`'s meaning.
 
+This deliberately supersedes the earlier guard from commit 704bc4e ("fall back to last shot for blank currentBean grinder/dose"), which forbade inferring bean fields (`brand` / `type` / `roastLevel`) from a shot on the grounds that "beans rotate per hopper." That guard was correct under the *old* semantics, where `currentBean` meant "the live setup" and a shot value was a fallback that could be stale relative to live DYE. Under the new semantics, `currentBean` means "the setup that produced the resolved shot" — the shot's bean fields *are* that shot's beans by definition, so within the shot's own context they cannot be stale. Reading bean fields from the shot is no longer inference; it is the canonical source. The "beans rotate per hopper" concern still matters when the user has changed beans between the resolved shot and the current dial-in iteration, but that is now visible via the absence of any value claiming to be "live": the AI sees only the shot's setup, has no contradicting live-DYE block to harmonize with, and falls back to asking the user about hopper changes.
+
 ## Impact
 
 - **Affected specs**: `dialing-context-payload` (modifies the static-framing-strings requirement and the beanFreshness empty-roastDate scenario; adds a new requirement pinning the canonical source).
 - **Affected code**:
-  - `src/mcp/mcptools_dialing_blocks.{h,cpp}` — new `buildCurrentBeanBlock(ShotProjection)` helper.
+  - `src/mcp/mcptools_dialing_blocks.{h,cpp}` — new `buildCurrentBeanBlock(CurrentBeanBlockInputs)` helper, defined inline in the header so test binaries that link only `shotsummarizer.cpp` do not pull in the DB-dependent block builders from the `.cpp`.
   - `src/mcp/mcptools_dialing.cpp` — drops the `Settings::dye()` reads + `McpDialingHelpers::buildCurrentBean` + DYE-sourced `buildBeanFreshness` and calls the new shared helper instead.
   - `src/mcp/mcptools_dialing_helpers.h` — `buildCurrentBean` and `CurrentBeanInputs` are removed (no callers remain).
-  - `src/ai/shotsummarizer.cpp` — `buildCurrentBeanBlock(ShotSummary)` becomes a thin adapter that maps summary fields onto a `ShotProjection`-shaped struct and delegates; the `inferredFields` branch is removed.
+  - `src/ai/shotsummarizer.cpp` — `buildCurrentBeanBlock(ShotSummary)` becomes a thin adapter that maps summary fields onto `CurrentBeanBlockInputs` and delegates; the `inferredFields` branch is removed.
   - `src/ai/shotsummarizer.h` — `ShotSummary::inferredFields` and `inferredFromShotId` are removed (unused after this change).
   - `src/ai/shotsummarizer.cpp` system-prompt builder — drops the `inferredFields` reference from the "How to read structured fields" section.
   - `tests/aimanager_tests/tst_aimanager.cpp` — new equivalence test.

--- a/openspec/changes/unify-current-bean-shape/proposal.md
+++ b/openspec/changes/unify-current-bean-shape/proposal.md
@@ -1,0 +1,29 @@
+# Change: Unify `currentBean` to a single shot-derived shape
+
+## Why
+
+For the same resolved shot, `dialing_get_context.currentBean` and the in-app advisor's user-prompt `currentBean` ship different shapes and disagree on values: dose, bean type, roast level, and the presence of `inferredFields` / `beanFreshness` all differ because one path reads from `Settings::dye()` (the live machine setup) while the other reads from the shot's saved metadata. The system prompt's "How to read structured fields" section teaches a single meaning for `currentBean`; the LLM today sees two. This is the same class of bug PR #1034 retired for `currentProfile` vs `profile`. See issue #1043.
+
+## What Changes
+
+- **BREAKING** (LLM contract): `dialing_get_context.currentBean` now describes "the setup that produced the resolved shot," not "the live DYE setup with shot fallback." All bean / grinder / dose / roastDate fields are read from the resolved shot's saved metadata.
+- The `inferredFromShotId`, `inferredFields`, and (already-omitted-per-#977) `inferredNote` mechanism is **removed** from `currentBean`. Once the shot is the canonical source, nothing is "inferred" — every field originates from one place. Fields the shot did not record render as empty strings (or as omissions for `doseWeightG <= 0`).
+- A shared `McpDialingBlocks::buildCurrentBeanBlock(const ShotProjection&)` helper produces the JSON for both surfaces, so they cannot drift again.
+- `currentBean.beanFreshness` is built off the resolved shot's `roastDate` on both surfaces (it was DYE-sourced in the MCP path; both now agree).
+- The `shotAnalysisSystemPrompt` "How to read structured fields" section drops the `inferredFields` clause (the field no longer ships) and tightens the `currentBean` description to "the setup that produced the resolved shot."
+- A new equivalence test in `tst_aimanager` drives both surfaces with a fixed shot + a deliberately divergent live DYE state and asserts the resulting `currentBean` JSON is equal under `==`.
+
+Live-DYE-vs-shot drift (the user changed DYE since the shot was pulled) is no longer surfaced in `currentBean` — that is a deliberate scope reduction. If a future change needs it, a separate `liveSetup` block can be added without renegotiating `currentBean`'s meaning.
+
+## Impact
+
+- **Affected specs**: `dialing-context-payload` (modifies the static-framing-strings requirement and the beanFreshness empty-roastDate scenario; adds a new requirement pinning the canonical source).
+- **Affected code**:
+  - `src/mcp/mcptools_dialing_blocks.{h,cpp}` — new `buildCurrentBeanBlock(ShotProjection)` helper.
+  - `src/mcp/mcptools_dialing.cpp` — drops the `Settings::dye()` reads + `McpDialingHelpers::buildCurrentBean` + DYE-sourced `buildBeanFreshness` and calls the new shared helper instead.
+  - `src/mcp/mcptools_dialing_helpers.h` — `buildCurrentBean` and `CurrentBeanInputs` are removed (no callers remain).
+  - `src/ai/shotsummarizer.cpp` — `buildCurrentBeanBlock(ShotSummary)` becomes a thin adapter that maps summary fields onto a `ShotProjection`-shaped struct and delegates; the `inferredFields` branch is removed.
+  - `src/ai/shotsummarizer.h` — `ShotSummary::inferredFields` and `inferredFromShotId` are removed (unused after this change).
+  - `src/ai/shotsummarizer.cpp` system-prompt builder — drops the `inferredFields` reference from the "How to read structured fields" section.
+  - `tests/aimanager_tests/tst_aimanager.cpp` — new equivalence test.
+- **Affected callers / consumers**: every LLM-facing consumer of `dialing_get_context` and the in-app advisor user prompt. The system prompt update lands in the same change so the prompt and payload move together.

--- a/openspec/changes/unify-current-bean-shape/specs/dialing-context-payload/spec.md
+++ b/openspec/changes/unify-current-bean-shape/specs/dialing-context-payload/spec.md
@@ -38,7 +38,7 @@ The response SHALL NOT include the static framing strings `currentBean.inferredN
 
 The `currentBean.inferredFromShotId` and `currentBean.inferredFields` fields SHALL NOT appear in the response. The DYE-with-shot-fallback machinery they qualified is removed; `currentBean` is now sourced solely from the resolved shot (see "currentBean SHALL describe the resolved shot's setup, not live DYE").
 
-The `shotAnalysisSystemPrompt` SHALL include a "How to read structured fields" section covering: (a) `tastingFeedback` gating (when all `has*` booleans are false, ASK the user about taste before suggesting changes), and (b) `beanFreshness` gating (never quote calendar age until `freshnessKnown == true`). The `inferredFields` clause that previously appeared in this section SHALL be removed.
+The `shotAnalysisSystemPrompt` SHALL include a "How to read structured fields" section covering: (a) `tastingFeedback` gating (when all `has*` booleans are false, ASK the user about taste before suggesting changes), (b) `beanFreshness` gating (never quote calendar age until `freshnessKnown == true`), and (c) the meaning of empty-string fields on `currentBean` — an empty value means the shot did not record that field (common on legacy shots), NOT that the user has no grinder / bean / etc.; the AI must ask before recommending a change to a blank field. The `inferredFields` clause that previously appeared in this section SHALL be removed.
 
 The `currentBean.daysSinceRoastNote` field is replaced by the `beanFreshness.instruction` field defined in the next requirement, NOT by a system-prompt entry — the freshness instruction is bean-state-specific and benefits from sitting next to the `roastDate` field.
 
@@ -64,6 +64,7 @@ The `currentBean.daysSinceRoastNote` field is replaced by the `beanFreshness.ins
 - **WHEN** rendered
 - **THEN** the output SHALL contain guidance for `tastingFeedback` (when all `has*` are false, ask first)
 - **AND** SHALL contain guidance for `beanFreshness` (never quote age until `freshnessKnown == true`)
+- **AND** SHALL contain guidance teaching that an empty-string `currentBean` field means "the shot did not record that field" (not "the user has no grinder / bean")
 - **AND** SHALL NOT contain a section describing `inferredFields` semantics
 
 ### Requirement: currentBean SHALL expose a beanFreshness block instead of precomputed days-since-roast

--- a/openspec/changes/unify-current-bean-shape/specs/dialing-context-payload/spec.md
+++ b/openspec/changes/unify-current-bean-shape/specs/dialing-context-payload/spec.md
@@ -1,0 +1,104 @@
+# dialing-context-payload — `currentBean` source unification
+
+## ADDED Requirements
+
+### Requirement: currentBean SHALL describe the resolved shot's setup, not live DYE
+
+`currentBean` SHALL be built from the resolved shot's saved bean / grinder / dose / roastDate metadata on every surface that emits it. The two surfaces — `dialing_get_context.currentBean` (the MCP read tool's top-level block) and the in-app advisor's user-prompt `currentBean` (rendered by `ShotSummarizer::buildUserPromptObject` from `summarizeFromHistory(shot)`) — SHALL produce byte-equivalent JSON for the same resolved shot.
+
+The block SHALL contain `brand`, `type`, `roastLevel`, `grinderBrand`, `grinderModel`, `grinderBurrs`, `grinderSetting`, `doseWeightG` keys with values read directly from the shot's saved fields. The block SHALL NOT read from `Settings::dye()` or any other "live machine state" source on either surface. When a shot string field is empty, its value SHALL be the empty string; `doseWeightG` SHALL be the shot's saved numeric value (which may be `0` when the shot has no recorded dose). The block SHALL NOT fall back to a different shot or to live DYE.
+
+The system prompt's "How to read structured fields" section SHALL describe `currentBean` as "the setup that produced the resolved shot." The prompt SHALL NOT teach an `inferredFields` reading.
+
+#### Scenario: Both surfaces produce equal currentBean for the same shot under divergent live DYE
+
+- **GIVEN** a saved shot with `beanType = "Spring Tour 2026 #2"`, `roastLevel = "Dark"`, `doseWeightG = 20`, `roastDate = "2026-03-30"`
+- **AND** a live `Settings::dye()` state with `dyeBeanType = "TypeA"`, `dyeRoastLevel = ""`, `dyeBeanWeight = 18`, `dyeRoastDate = ""` (the user changed DYE since the shot was pulled)
+- **WHEN** `dialing_get_context` builds `result["currentBean"]` for that shot
+- **AND** `ShotSummarizer::buildUserPromptObject(summarizeFromHistory(shot))` builds `payload["currentBean"]` for the same shot
+- **THEN** the two `currentBean` `QJsonObject`s SHALL be equal under `==`
+- **AND** both SHALL carry `type = "Spring Tour 2026 #2"`, `roastLevel = "Dark"`, `doseWeightG = 20`
+- **AND** both SHALL carry a `beanFreshness` block with `roastDate = "2026-03-30"`
+- **AND** neither SHALL contain `inferredFields`, `inferredFromShotId`, or `inferredNote`
+
+#### Scenario: Empty shot fields render as empty strings, not DYE fallback
+
+- **GIVEN** a saved shot with `grinderBrand = ""`, `grinderModel = ""`, `grinderBurrs = ""`, `grinderSetting = ""`
+- **AND** a live `Settings::dye()` state with `dyeGrinderBrand = "Niche"`, `dyeGrinderModel = "Zero"`, `dyeGrinderBurrs = "63mm Kony"`, `dyeGrinderSetting = "4.5"`
+- **WHEN** `dialing_get_context` builds `result["currentBean"]` for that shot
+- **THEN** `currentBean.grinderBrand`, `.grinderModel`, `.grinderBurrs`, `.grinderSetting` SHALL all be the empty string `""`
+- **AND** `currentBean.inferredFields` SHALL be absent
+- **AND** `currentBean.inferredFromShotId` SHALL be absent
+
+## MODIFIED Requirements
+
+### Requirement: dialing_get_context response SHALL move static framing strings to the system prompt
+
+The response SHALL NOT include the static framing strings `currentBean.inferredNote`, `currentBean.daysSinceRoastNote`, or `tastingFeedback.recommendation`. These are taught once in the system prompt rather than shipped on every call. The structural fields they previously qualified — `currentBean.beanFreshness`, `tastingFeedback.hasEnjoymentScore` / `.hasNotes` / `.hasRefractometer` — SHALL remain.
+
+The `currentBean.inferredFromShotId` and `currentBean.inferredFields` fields SHALL NOT appear in the response. The DYE-with-shot-fallback machinery they qualified is removed; `currentBean` is now sourced solely from the resolved shot (see "currentBean SHALL describe the resolved shot's setup, not live DYE").
+
+The `shotAnalysisSystemPrompt` SHALL include a "How to read structured fields" section covering: (a) `tastingFeedback` gating (when all `has*` booleans are false, ASK the user about taste before suggesting changes), and (b) `beanFreshness` gating (never quote calendar age until `freshnessKnown == true`). The `inferredFields` clause that previously appeared in this section SHALL be removed.
+
+The `currentBean.daysSinceRoastNote` field is replaced by the `beanFreshness.instruction` field defined in the next requirement, NOT by a system-prompt entry — the freshness instruction is bean-state-specific and benefits from sitting next to the `roastDate` field.
+
+#### Scenario: currentBean ships without inferred-field fallback machinery
+
+- **GIVEN** a `dialing_get_context` call where the resolved shot's grinder fields are populated but live DYE is blank, OR vice versa
+- **WHEN** the response is built
+- **THEN** `currentBean.inferredFromShotId` SHALL NOT be present
+- **AND** `currentBean.inferredFields` SHALL NOT be present
+- **AND** `currentBean.inferredNote` SHALL NOT be present
+- **AND** `currentBean`'s grinder / bean / dose values SHALL be those of the resolved shot
+
+#### Scenario: Tasting feedback ships booleans only
+
+- **GIVEN** a shot with no enjoyment score, no notes, and no TDS
+- **WHEN** the response is built
+- **THEN** `tastingFeedback.hasEnjoymentScore`, `.hasNotes`, `.hasRefractometer` SHALL all be `false`
+- **AND** `tastingFeedback.recommendation` SHALL NOT be present
+
+#### Scenario: System prompt teaches the field semantics
+
+- **GIVEN** the espresso `shotAnalysisSystemPrompt` output
+- **WHEN** rendered
+- **THEN** the output SHALL contain guidance for `tastingFeedback` (when all `has*` are false, ask first)
+- **AND** SHALL contain guidance for `beanFreshness` (never quote age until `freshnessKnown == true`)
+- **AND** SHALL NOT contain a section describing `inferredFields` semantics
+
+### Requirement: currentBean SHALL expose a beanFreshness block instead of precomputed days-since-roast
+
+`currentBean.daysSinceRoast` and `currentBean.daysSinceRoastNote` SHALL NOT be present in the response. They are replaced by `currentBean.beanFreshness`, a structured block with three fields:
+
+- `roastDate` — the resolved shot's saved `roastDate` string, surfaced verbatim.
+- `freshnessKnown` — boolean. Until a separate change introduces storage-mode tracking, this SHALL always be `false`.
+- `instruction` — a fixed imperative string: `"Calendar age from roastDate is NOT freshness — many users freeze and thaw weekly. ASK the user about storage before applying any bean-aging guidance."`
+
+The block SHALL be omitted entirely when the resolved shot's `roastDate` is empty. The block SHALL NOT contain a precomputed day count under any field name; the AI MUST do the subtraction itself, in front of the user, to make the assumption visible.
+
+The `shotAnalysis` prose SHALL NOT contain the parenthetical "(N days since roast, not necessarily freshness — ask about storage)" that previously rendered next to the bean name. It is replaced by the lighter "(roasted YYYY-MM-DD; ask user about storage before reasoning about age)" — same caveat, no day count.
+
+#### Scenario: beanFreshness emits with freshnessKnown false and the imperative instruction
+
+- **GIVEN** a resolved shot with `roastDate = "2026-04-15"` and no storage-mode information
+- **WHEN** the response is built
+- **THEN** `currentBean.beanFreshness.roastDate` SHALL be `"2026-04-15"`
+- **AND** `currentBean.beanFreshness.freshnessKnown` SHALL be `false`
+- **AND** `currentBean.beanFreshness.instruction` SHALL match the fixed imperative string verbatim
+- **AND** `currentBean` SHALL NOT contain `daysSinceRoast` or `daysSinceRoastNote` under any spelling
+- **AND** `currentBean.beanFreshness` SHALL NOT contain a `daysSinceRoast`, `calendarDaysSinceRoast`, `effectiveAgeDays`, or any other precomputed-day-count field
+
+#### Scenario: Empty shot roastDate omits the block entirely
+
+- **GIVEN** a resolved shot with no `roastDate` (the shot's saved `roastDate` field is empty)
+- **WHEN** the response is built
+- **THEN** `currentBean.beanFreshness` SHALL be absent
+- **AND** the block SHALL be absent regardless of whether live DYE has a `dyeRoastDate` value
+
+#### Scenario: shotAnalysis prose mirrors the no-day-count contract
+
+- **GIVEN** a shot whose bean has a populated `roastDate`
+- **WHEN** `shotAnalysis` prose is rendered
+- **THEN** the prose SHALL contain `"roasted YYYY-MM-DD"` for the date itself
+- **AND** SHALL contain a phrase pointing at storage uncertainty (e.g., `"ask user about storage"`)
+- **AND** SHALL NOT contain any phrase of the form `"N days since roast"` or `"N days post-roast"` or any standalone integer adjacent to a roast-date string

--- a/openspec/changes/unify-current-bean-shape/tasks.md
+++ b/openspec/changes/unify-current-bean-shape/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: Unify `currentBean` to a single shot-derived shape
+
+## Implementation
+
+- [x] 1. Add `McpDialingBlocks::buildCurrentBeanBlock(const ShotProjection& shot)` to `src/mcp/mcptools_dialing_blocks.{h,cpp}` — pure function, builds the canonical JSON from the shot's bean / grinder / dose / roastDate fields; composes `beanFreshness` via the existing `McpDialingHelpers::buildBeanFreshness` helper using the shot's `roastDate`.
+- [x] 2. Switch `src/mcp/mcptools_dialing.cpp` to call the new helper. Remove the `if (settings) { … McpDialingHelpers::buildCurrentBean(in) … }` block and the now-unused `Settings::dye()` reads for the bean payload.
+- [x] 3. Remove `McpDialingHelpers::CurrentBeanInputs` and `McpDialingHelpers::buildCurrentBean` from `src/mcp/mcptools_dialing_helpers.h` (no callers remain). Keep `buildBeanFreshness`.
+- [x] 4. Update `src/ai/shotsummarizer.cpp::buildCurrentBeanBlock(const ShotSummary&)` to delegate to `McpDialingBlocks::buildCurrentBeanBlock` by mapping the summary fields into a temporary `ShotProjection`-shaped input. Remove the `inferredFields` / `inferredFromShotId` branch.
+- [x] 5. Remove `inferredFields` and `inferredFromShotId` from `src/ai/shotsummarizer.h::ShotSummary` (now unused).
+- [x] 6. Update the espresso `shotAnalysisSystemPrompt` builder in `src/ai/shotsummarizer.cpp` to drop the `inferredFields` clause from the "How to read structured fields" section, and reword the `currentBean` description to "the setup that produced the resolved shot."
+- [x] 7. Add a `currentBean equivalence` test in `tests/aimanager_tests/tst_aimanager.cpp`: build a fixed `ShotProjection` (id, bean fields, grinder fields, dose, roastDate), set a deliberately divergent live DYE state, drive both surfaces (the MCP `dialing_get_context` path and `ShotSummarizer::buildUserPromptObject(summarizeFromHistory(shot))`), assert the resulting `currentBean` JSON objects are equal under `==`.
+- [x] 8. Run `openspec validate unify-current-bean-shape --strict --no-interactive` and resolve any issues.
+- [x] 9. Build via Qt Creator (clean) and confirm the existing dialing-context test in `tst_aimanager` passes.

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -548,8 +548,7 @@ static QJsonObject buildCurrentBeanBlock(const ShotSummary& summary)
 {
     // Delegates to the shared helper so this surface and
     // `dialing_get_context.currentBean` produce byte-equivalent JSON for
-    // the same resolved shot. See openspec change unify-current-bean-shape
-    // (issue #1043).
+    // the same resolved shot.
     McpDialingBlocks::CurrentBeanBlockInputs in;
     in.beanBrand = summary.beanBrand;
     in.beanType = summary.beanType;
@@ -995,7 +994,11 @@ QString ShotSummarizer::shotAnalysisSystemPrompt(const QString& beverageType, co
         "`.roastLevel` carry bean identity; `currentBean.grinderBrand` /\n"
         "`.grinderModel` / `.grinderBurrs` carry grinder identity. Every field\n"
         "in `currentBean` describes THE SETUP THAT PRODUCED THE RESOLVED SHOT —\n"
-        "not whatever the user has loaded on the machine right now. The\n"
+        "not whatever the user has loaded on the machine right now. An empty\n"
+        "string for any of these fields means the shot did NOT record that field\n"
+        "(common on legacy shots saved before the field was tracked); it does\n"
+        "NOT mean the user has no grinder / bean / etc. Ask the user before\n"
+        "recommending a change to any field that came back blank. The\n"
         "`shotAnalysis` prose carries neither bean nor grinder identity — it\n"
         "never carries a `Coffee:` / `Beans:` line nor a `Grinder:` line with\n"
         "brand/model/burrs. Only the per-shot variable `Grind setting:`\n"

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -6,6 +6,7 @@
 #include "../network/visualizeruploader.h"  // ShotMetadata struct (lives in this header for historical reasons)
 #include "../core/grinderaliases.h"
 #include "../mcp/mcptools_dialing_helpers.h"  // shared buildBeanFreshness — same shape on both surfaces
+#include "../mcp/mcptools_dialing_blocks.h"   // shared buildCurrentBeanBlock — single source of truth for currentBean
 
 #include <cmath>
 #include <algorithm>
@@ -545,31 +546,21 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
 
 static QJsonObject buildCurrentBeanBlock(const ShotSummary& summary)
 {
-    QJsonObject bean;
-    bean["brand"] = summary.beanBrand;
-    bean["type"] = summary.beanType;
-    bean["roastLevel"] = summary.roastLevel;
-    bean["grinderBrand"] = summary.grinderBrand;
-    bean["grinderModel"] = summary.grinderModel;
-    bean["grinderBurrs"] = summary.grinderBurrs;
-    bean["grinderSetting"] = summary.grinderSetting;
-    bean["doseWeightG"] = summary.doseWeight;
-
-    const QJsonObject freshness = McpDialingHelpers::buildBeanFreshness(summary.roastDate);
-    if (!freshness.isEmpty())
-        bean["beanFreshness"] = freshness;
-
-    if (!summary.inferredFields.isEmpty() && summary.inferredFromShotId > 0) {
-        QJsonArray inferred;
-        for (const QString& f : summary.inferredFields) inferred.append(f);
-        bean["inferredFields"] = inferred;
-        bean["inferredFromShotId"] = summary.inferredFromShotId;
-        bean["inferredNote"] = QStringLiteral(
-            "Listed fields are inferred from the resolved shot (id "
-            "above), not entered by the user. Confirm before recommending "
-            "a change.");
-    }
-    return bean;
+    // Delegates to the shared helper so this surface and
+    // `dialing_get_context.currentBean` produce byte-equivalent JSON for
+    // the same resolved shot. See openspec change unify-current-bean-shape
+    // (issue #1043).
+    McpDialingBlocks::CurrentBeanBlockInputs in;
+    in.beanBrand = summary.beanBrand;
+    in.beanType = summary.beanType;
+    in.roastLevel = summary.roastLevel;
+    in.roastDate = summary.roastDate;
+    in.grinderBrand = summary.grinderBrand;
+    in.grinderModel = summary.grinderModel;
+    in.grinderBurrs = summary.grinderBurrs;
+    in.grinderSetting = summary.grinderSetting;
+    in.doseWeightG = summary.doseWeight;
+    return McpDialingBlocks::buildCurrentBeanBlock(in);
 }
 
 static QJsonObject buildCurrentProfileBlock(const ShotSummary& summary)
@@ -1000,12 +991,15 @@ QString ShotSummarizer::shotAnalysisSystemPrompt(const QString& beverageType, co
         "extraction, peaks, phase data, detector observations) — it never\n"
         "carries `Profile:`, `Profile intent:`, or `## Profile Recipe`.\n\n"
         "**`currentBean`** + **`dialInSessions[].context`**: shot-INVARIANT\n"
-        "identity. `currentBean.brand` / `.type` / `.roastLevel` carry bean\n"
-        "identity; `currentBean.grinderBrand` / `.grinderModel` / `.grinderBurrs`\n"
-        "carry grinder identity for the live setup. The `shotAnalysis` prose\n"
-        "carries neither — it never carries a `Coffee:` / `Beans:` line nor a\n"
-        "`Grinder:` line with brand/model/burrs. Only the per-shot variable\n"
-        "`Grind setting:` appears in prose.\n\n"
+        "identity for the resolved shot. `currentBean.brand` / `.type` /\n"
+        "`.roastLevel` carry bean identity; `currentBean.grinderBrand` /\n"
+        "`.grinderModel` / `.grinderBurrs` carry grinder identity. Every field\n"
+        "in `currentBean` describes THE SETUP THAT PRODUCED THE RESOLVED SHOT —\n"
+        "not whatever the user has loaded on the machine right now. The\n"
+        "`shotAnalysis` prose carries neither bean nor grinder identity — it\n"
+        "never carries a `Coffee:` / `Beans:` line nor a `Grinder:` line with\n"
+        "brand/model/burrs. Only the per-shot variable `Grind setting:`\n"
+        "appears in prose.\n\n"
         "**`tastingFeedback`**: carries booleans `hasEnjoymentScore`, `hasNotes`,\n"
         "`hasRefractometer`. When ALL three are false, ASK the user how the shot\n"
         "tasted (score 1–100, 1–2 lines of flavor notes, TDS reading if available)\n"
@@ -1018,10 +1012,6 @@ QString ShotSummarizer::shotAnalysisSystemPrompt(const QString& beverageType, co
         "calendar days from `roastDate` are not freshness without storage context.\n"
         "ASK the user about storage before applying any bean-aging guidance from\n"
         "the dial-in reference tables.\n\n"
-        "**`currentBean.inferredFields`**: when present, lists field names that\n"
-        "were inferred from the most recent shot (because the user's DYE settings\n"
-        "were blank), not entered by the user. Confirm with the user before\n"
-        "recommending a change to any inferred field.\n\n"
         "**`dialInSessions[].context`**: hoists shot-identity fields shared across\n"
         "an iteration session (`grinderBrand`, `grinderModel`, `grinderBurrs`,\n"
         "`beanBrand`, `beanType`). When a per-shot entry under `shots[]` omits\n"

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -111,13 +111,6 @@ struct ShotSummary {
     // currentProfile.recommendedDoseG field shipped by dialing_get_context).
     double recommendedDoseG = 0;
 
-    // Fields whose value was inferred from a fallback shot rather than
-    // entered by the user. Empty when no inference happened. The advisor's
-    // user prompt only emits inferredFields/inferredFromShotId when this
-    // list is non-empty AND the id is > 0.
-    QStringList inferredFields;
-    qint64 inferredFromShotId = 0;
-
     // DYE metadata (from user input)
     QString beanBrand;
     QString beanType;

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -111,7 +111,11 @@ struct ShotSummary {
     // currentProfile.recommendedDoseG field shipped by dialing_get_context).
     double recommendedDoseG = 0;
 
-    // DYE metadata (from user input)
+    // Bean / grinder / tasting metadata. Source depends on the path:
+    // `summarize()` (live) reads from the just-collected `ShotMetadata`;
+    // `summarizeFromHistory()` reads from the shot's saved database
+    // record. The fields named here mirror the columns under those two
+    // sources — this struct is not itself a live-DYE snapshot.
     QString beanBrand;
     QString beanType;
     QString roastDate;
@@ -164,14 +168,15 @@ public:
     //   carrying currentBean / profile / tastingFeedback / shotAnalysis.
     //   Key names mirror dialing_get_context's response shape so a single
     //   system prompt reads correctly off either surface. The `shotAnalysis`
-    //   field embeds the prose body produced by `renderShotAnalysisProse`
-    //   in `Standalone` mode (which carries the `## Shot Summary` and
-    //   `## Detector Observations` headers `HistoryBlock` mode suppresses).
-    //   Regex consumers in AIConversation match on that prose after
-    //   parsing the JSON envelope first via `extractShotProse`.
-    // - `HistoryBlock` mode: returns prose only, no JSON envelope. The caller
-    //   wraps each block in a `### Shot (date)` header so JSON-per-shot would
-    //   be unreadable when concatenated.
+    //   field embeds prose rendered by `renderShotAnalysisProse(..., Standalone)`
+    //   — that prose carries the `## Shot Summary` and `## Detector
+    //   Observations` headers, which `HistoryBlock` mode strips. Regex
+    //   consumers in AIConversation match on that prose after parsing the
+    //   JSON envelope first via `extractShotProse`.
+    // - `HistoryBlock` mode: returns prose only, no JSON envelope, with
+    //   the two top-level headers stripped. The caller wraps each block
+    //   in a `### Shot (date)` header so JSON-per-shot would be unreadable
+    //   when concatenated.
     //
     // Output is byte-stable for identical input — no wall-clock or per-call
     // values appear in the payload, so prompt caching keeps hitting.

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -230,8 +230,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     // resolved shot, not live DYE. Both this surface and
                     // the in-app advisor's user prompt build through the
                     // same helper so a single system-prompt reading lands
-                    // on byte-equivalent JSON. See openspec change
-                    // unify-current-bean-shape (issue #1043).
+                    // on byte-equivalent JSON.
                     {
                         McpDialingBlocks::CurrentBeanBlockInputs in;
                         in.beanBrand = sd.beanBrand;

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -225,40 +225,25 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     if (!profileKnowledge.isEmpty())
                         result["profileKnowledge"] = profileKnowledge;
 
-                    // --- Bean/grinder metadata (current DYE settings) ---
-                    // DYE wins per-field; for grinder + dose, fall back to
-                    // the resolved shot's value when DYE is blank so the AI
-                    // doesn't lose its highest-leverage signal (burr
-                    // geometry, grinder brand, current setting) when the
-                    // user hasn't filled out DYE recently. Bean fields
-                    // (brand/type/roastLevel) and roastDate are *not*
-                    // inferred — beans rotate per hopper and roastDate
-                    // lives only inside `beanFreshness` to keep the
-                    // freshness surface in one place. Merge logic lives in
-                    // McpDialingHelpers::buildCurrentBean (pure,
-                    // unit-tested).
-                    if (settings) {
-                        McpDialingHelpers::CurrentBeanInputs in;
-                        in.dyeBeanBrand = settings->dye()->dyeBeanBrand();
-                        in.dyeBeanType = settings->dye()->dyeBeanType();
-                        in.dyeRoastLevel = settings->dye()->dyeRoastLevel();
-                        in.dyeGrinderBrand = settings->dye()->dyeGrinderBrand();
-                        in.dyeGrinderModel = settings->dye()->dyeGrinderModel();
-                        in.dyeGrinderBurrs = settings->dye()->dyeGrinderBurrs();
-                        in.dyeGrinderSetting = settings->dye()->dyeGrinderSetting();
-                        in.dyeDoseWeightG = settings->dye()->dyeBeanWeight();
-                        in.fallbackGrinderBrand = sd.grinderBrand;
-                        in.fallbackGrinderModel = sd.grinderModel;
-                        in.fallbackGrinderBurrs = sd.grinderBurrs;
-                        in.fallbackGrinderSetting = sd.grinderSetting;
-                        in.fallbackDoseWeightG = sd.doseWeightG;
-                        in.fallbackShotId = resolvedShotId;
-                        QJsonObject bean = McpDialingHelpers::buildCurrentBean(in);
-                        const QJsonObject freshness = McpDialingHelpers::buildBeanFreshness(
-                            settings->dye()->dyeRoastDate());
-                        if (!freshness.isEmpty())
-                            bean["beanFreshness"] = freshness;
-                        result["currentBean"] = bean;
+                    // --- Bean/grinder metadata (resolved shot's setup) ---
+                    // currentBean describes the setup that produced the
+                    // resolved shot, not live DYE. Both this surface and
+                    // the in-app advisor's user prompt build through the
+                    // same helper so a single system-prompt reading lands
+                    // on byte-equivalent JSON. See openspec change
+                    // unify-current-bean-shape (issue #1043).
+                    {
+                        McpDialingBlocks::CurrentBeanBlockInputs in;
+                        in.beanBrand = sd.beanBrand;
+                        in.beanType = sd.beanType;
+                        in.roastLevel = sd.roastLevel;
+                        in.roastDate = sd.roastDate;
+                        in.grinderBrand = sd.grinderBrand;
+                        in.grinderModel = sd.grinderModel;
+                        in.grinderBurrs = sd.grinderBurrs;
+                        in.grinderSetting = sd.grinderSetting;
+                        in.doseWeightG = sd.doseWeightG;
+                        result["currentBean"] = McpDialingBlocks::buildCurrentBeanBlock(in);
                     }
 
                     // --- Profile (single canonical block) ---

--- a/src/mcp/mcptools_dialing_blocks.cpp
+++ b/src/mcp/mcptools_dialing_blocks.cpp
@@ -339,4 +339,8 @@ QJsonObject buildSawPredictionBlock(Settings* settings,
     return sawPrediction;
 }
 
+// buildCurrentBeanBlock is defined inline in the header so test binaries
+// that link only `shotsummarizer.cpp` don't drag in this TU's DB-dependent
+// block builders (loadShotRecordStatic et al.).
+
 } // namespace McpDialingBlocks

--- a/src/mcp/mcptools_dialing_blocks.h
+++ b/src/mcp/mcptools_dialing_blocks.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "mcptools_dialing_helpers.h"  // buildBeanFreshness — composed inside buildCurrentBeanBlock
+
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QString>
@@ -63,6 +65,56 @@ QJsonObject buildGrinderContextBlock(QSqlDatabase& db,
                                      const QString& grinderModel,
                                      const QString& beverageType,
                                      const QString& beanBrand);
+
+// `currentBean` block for the resolved shot. Bean / grinder / dose /
+// roastDate fields come from the shot's saved metadata only — never
+// from `Settings::dye()` or any other live-machine-state source. Both
+// `dialing_get_context.currentBean` and the in-app advisor's user-prompt
+// `currentBean` build through this helper so the two surfaces produce
+// byte-equivalent JSON for the same shot. Composes
+// `currentBean.beanFreshness` from the shot's `roastDate` via
+// `McpDialingHelpers::buildBeanFreshness`. Pure: no Qt object
+// dependencies beyond the projection and JSON value types.
+//
+// Inputs that capture every field this block reads from the shot. Kept
+// as a small struct (not the full `ShotProjection`) so the in-app
+// advisor — which carries a `ShotSummary`, not a `ShotProjection` —
+// can call the helper without round-tripping through the heavyweight
+// projection type.
+struct CurrentBeanBlockInputs {
+    QString beanBrand;
+    QString beanType;
+    QString roastLevel;
+    QString roastDate;
+    QString grinderBrand;
+    QString grinderModel;
+    QString grinderBurrs;
+    QString grinderSetting;
+    double doseWeightG = 0;
+};
+
+// Defined inline so test binaries that link only `shotsummarizer.cpp`
+// (and not the rest of `mcptools_dialing_blocks.cpp`'s DB-dependent
+// builders) can pick up this single helper without pulling in
+// `loadShotRecordStatic` / `loadRecentShotsByKbIdStatic` symbols.
+inline QJsonObject buildCurrentBeanBlock(const CurrentBeanBlockInputs& in)
+{
+    QJsonObject bean;
+    bean["brand"] = in.beanBrand;
+    bean["type"] = in.beanType;
+    bean["roastLevel"] = in.roastLevel;
+    bean["grinderBrand"] = in.grinderBrand;
+    bean["grinderModel"] = in.grinderModel;
+    bean["grinderBurrs"] = in.grinderBurrs;
+    bean["grinderSetting"] = in.grinderSetting;
+    bean["doseWeightG"] = in.doseWeightG;
+
+    const QJsonObject freshness = McpDialingHelpers::buildBeanFreshness(in.roastDate);
+    if (!freshness.isEmpty())
+        bean["beanFreshness"] = freshness;
+
+    return bean;
+}
 
 // SAW (Stop-at-Weight) prediction for the resolved shot. Returns an
 // empty `QJsonObject` when any of the following hold:

--- a/src/mcp/mcptools_dialing_helpers.h
+++ b/src/mcp/mcptools_dialing_helpers.h
@@ -159,15 +159,6 @@ inline QJsonObject buildBeanFreshness(const QString& roastDate)
     return block;
 }
 
-// `CurrentBeanInputs` and `buildCurrentBean` were retired in
-// unify-current-bean-shape (issue #1043). The DYE-with-shot-fallback
-// helper produced a `currentBean` whose meaning ("the live setup with
-// shot fallback") disagreed with the in-app advisor's `currentBean`
-// ("the setup that produced the shot") for the same shot, including
-// when DYE drifted from the shot between pulls. Both surfaces now build
-// `currentBean` from the resolved shot only, via the shared
-// `McpDialingBlocks::buildCurrentBeanBlock(CurrentBeanBlockInputs&)`.
-
 // Inputs for the per-shot diff that drives both `changeFromPrev` (within a
 // dial-in session) and `changeFromBest` (current vs best-recent). Carries
 // just the fields that change between adjacent shots in a dial-in flow —

--- a/src/mcp/mcptools_dialing_helpers.h
+++ b/src/mcp/mcptools_dialing_helpers.h
@@ -159,94 +159,14 @@ inline QJsonObject buildBeanFreshness(const QString& roastDate)
     return block;
 }
 
-// Per-field inputs the currentBean block synthesizes from. The caller fills
-// the `dye*` half from `Settings::dye()` (live, user-entered) and the
-// `fallback*` half from the resolved shot's grinder/dose metadata. The
-// helper picks per field: DYE if non-empty, otherwise the fallback shot's
-// value, and tracks which fields ended up inferred.
-//
-// Bean fields (brand/type/roastLevel) are intentionally not inferred —
-// those rotate per hopper and a stale-shot value could mislead the AI
-// into reasoning about the wrong bean. roastDate is also un-inferred and
-// surfaced separately via `buildBeanFreshness` — calendar age without
-// storage context is misleading regardless of source. Grinder + dose are
-// stable across shots within an iteration session, so falling back is
-// safe.
-struct CurrentBeanInputs {
-    // Live DYE values from Settings::dye() (the "currently loaded" snapshot).
-    QString dyeBeanBrand;
-    QString dyeBeanType;
-    QString dyeRoastLevel;
-    QString dyeGrinderBrand;
-    QString dyeGrinderModel;
-    QString dyeGrinderBurrs;
-    QString dyeGrinderSetting;
-    double dyeDoseWeightG = 0;
-
-    // Resolved shot's grinder/dose snapshot (used as fallback when the DYE
-    // counterpart is blank/zero). Bean fields aren't carried here — see
-    // rationale above.
-    QString fallbackGrinderBrand;
-    QString fallbackGrinderModel;
-    QString fallbackGrinderBurrs;
-    QString fallbackGrinderSetting;
-    double fallbackDoseWeightG = 0;
-    qint64 fallbackShotId = 0;
-};
-
-// Build the `currentBean` JSON object with grinder/dose fallback to the
-// resolved shot's values when the DYE field is empty/zero. Inferred fields
-// are listed in `inferredFields`, with `inferredFromShotId` and an
-// inferredNote pointing the AI to confirm before recommending a change.
-// roastDate / beanFreshness are *not* set here — the caller composes
-// `bean["beanFreshness"]` via `buildBeanFreshness(...)` so the freshness
-// surface stays in one place.
-//
-// Pure function: no Qt object dependencies beyond JSON value types, easy to
-// unit-test.
-inline QJsonObject buildCurrentBean(const CurrentBeanInputs& in)
-{
-    QJsonObject bean;
-    bean["brand"] = in.dyeBeanBrand;
-    bean["type"] = in.dyeBeanType;
-    bean["roastLevel"] = in.dyeRoastLevel;
-
-    QJsonArray inferredFields;
-    auto pickStr = [&](const QString& dye, const QString& fallback,
-                        const QString& key) -> QString {
-        if (dye.isEmpty() && !fallback.isEmpty()) {
-            inferredFields.append(key);
-            return fallback;
-        }
-        return dye;
-    };
-    bean["grinderBrand"] = pickStr(in.dyeGrinderBrand, in.fallbackGrinderBrand,
-        QStringLiteral("grinderBrand"));
-    bean["grinderModel"] = pickStr(in.dyeGrinderModel, in.fallbackGrinderModel,
-        QStringLiteral("grinderModel"));
-    bean["grinderBurrs"] = pickStr(in.dyeGrinderBurrs, in.fallbackGrinderBurrs,
-        QStringLiteral("grinderBurrs"));
-    bean["grinderSetting"] = pickStr(in.dyeGrinderSetting, in.fallbackGrinderSetting,
-        QStringLiteral("grinderSetting"));
-
-    if (in.dyeDoseWeightG <= 0 && in.fallbackDoseWeightG > 0) {
-        bean["doseWeightG"] = in.fallbackDoseWeightG;
-        inferredFields.append(QStringLiteral("doseWeightG"));
-    } else {
-        bean["doseWeightG"] = in.dyeDoseWeightG;
-    }
-
-    if (!inferredFields.isEmpty() && in.fallbackShotId > 0) {
-        bean["inferredFromShotId"] = in.fallbackShotId;
-        bean["inferredFields"] = inferredFields;
-        bean["inferredNote"] = QStringLiteral(
-            "Listed fields are inferred from the resolved shot (id "
-            "above), not entered by the user. Confirm before recommending "
-            "a change.");
-    }
-
-    return bean;
-}
+// `CurrentBeanInputs` and `buildCurrentBean` were retired in
+// unify-current-bean-shape (issue #1043). The DYE-with-shot-fallback
+// helper produced a `currentBean` whose meaning ("the live setup with
+// shot fallback") disagreed with the in-app advisor's `currentBean`
+// ("the setup that produced the shot") for the same shot, including
+// when DYE drifted from the shot between pulls. Both surfaces now build
+// `currentBean` from the resolved shot only, via the shared
+// `McpDialingBlocks::buildCurrentBeanBlock(CurrentBeanBlockInputs&)`.
 
 // Inputs for the per-shot diff that drives both `changeFromPrev` (within a
 // dial-in session) and `changeFromBest` (current vs best-recent). Carries

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -29,6 +29,7 @@
 
 #include "ai/aimanager.h"
 #include "core/settings.h"
+#include "core/settings_dye.h"
 #include "history/shotprojection.h"
 #include "history/shothistory_types.h"
 #include "mcp/mcptools_dialing_blocks.h"
@@ -431,6 +432,96 @@ private slots:
         const QString b = QString::fromUtf8(
             QJsonDocument(mgr.buildUserPromptObjectForShot(shot)).toJson(QJsonDocument::Indented));
         QCOMPARE(a, b);
+    }
+
+    // ---------------------------------------------------------------------
+    // openspec unify-current-bean-shape (issue #1043) — both surfaces
+    // produce byte-equivalent `currentBean` JSON for the same resolved
+    // shot. The MCP path (`dialing_get_context.currentBean`) and the
+    // in-app advisor's user-prompt path
+    // (`AIManager::buildUserPromptObjectForShot(...)["currentBean"]`)
+    // build through the shared `McpDialingBlocks::buildCurrentBeanBlock`,
+    // sourced solely from the resolved shot.
+    // ---------------------------------------------------------------------
+    void currentBean_equivalenceAcrossSurfaces()
+    {
+        QNetworkAccessManager nam;
+        // Live DYE state is deliberately divergent from the shot's saved
+        // metadata to model the issue #1043 scenario: the user changed
+        // DYE between pulling the shot and asking the AI about it.
+        // currentBean must NOT pick up the live DYE values on either
+        // surface — the shot is the source of truth.
+        Settings settings;
+        settings.dye()->setDyeBeanBrand(QStringLiteral("Live DYE Brand"));
+        settings.dye()->setDyeBeanType(QStringLiteral("Live DYE Type"));
+        settings.dye()->setDyeRoastLevel(QStringLiteral("Light"));
+        settings.dye()->setDyeGrinderBrand(QStringLiteral("Live DYE Grinder"));
+        settings.dye()->setDyeGrinderModel(QStringLiteral("Live DYE Model"));
+        settings.dye()->setDyeGrinderBurrs(QStringLiteral("Live DYE Burrs"));
+        settings.dye()->setDyeGrinderSetting(QStringLiteral("99"));
+        settings.dye()->setDyeBeanWeight(99.0);
+        settings.dye()->setDyeRoastDate(QStringLiteral("2025-01-01"));
+
+        AIManager mgr(&nam, &settings);
+
+        // Shot has its own bean / grinder / dose / roastDate that
+        // currentBean must echo on every surface.
+        ShotProjection shot = makeShot(884, 1700000000,
+            QStringLiteral("Niche"), QStringLiteral("Zero"),
+            QStringLiteral("63mm Kony"), QStringLiteral("4.5"),
+            QStringLiteral("Northbound"), QStringLiteral("Spring Tour 2026 #2"),
+            QStringLiteral("80's Espresso"), QStringLiteral("intent"), QString());
+        shot.doseWeightG = 20.0;
+        shot.roastLevel = QStringLiteral("Dark");
+        shot.roastDate = QStringLiteral("2026-03-30");
+
+        // In-app advisor surface: through ShotSummarizer::buildUserPromptObject
+        // off summarizeFromHistory(shot).
+        const QJsonObject inAppEnvelope = mgr.buildUserPromptObjectForShot(shot);
+        QVERIFY(inAppEnvelope.contains(QStringLiteral("currentBean")));
+        const QJsonObject inAppCurrentBean = inAppEnvelope.value(QStringLiteral("currentBean")).toObject();
+
+        // MCP surface: the same shared helper that mcptools_dialing.cpp
+        // calls on the resolved shot (mirrors the
+        // `mcptools_dialing.cpp:200`-block exactly — same field-by-field
+        // mapping from `sd` (the resolved shot) into
+        // `CurrentBeanBlockInputs`).
+        McpDialingBlocks::CurrentBeanBlockInputs in;
+        in.beanBrand = shot.beanBrand;
+        in.beanType = shot.beanType;
+        in.roastLevel = shot.roastLevel;
+        in.roastDate = shot.roastDate;
+        in.grinderBrand = shot.grinderBrand;
+        in.grinderModel = shot.grinderModel;
+        in.grinderBurrs = shot.grinderBurrs;
+        in.grinderSetting = shot.grinderSetting;
+        in.doseWeightG = shot.doseWeightG;
+        const QJsonObject mcpCurrentBean = McpDialingBlocks::buildCurrentBeanBlock(in);
+
+        // The contract: byte-equivalent JSON for the same shot.
+        QCOMPARE(inAppCurrentBean, mcpCurrentBean);
+
+        // Spot-check the shot values won the source-of-truth contest
+        // against the live DYE values, on both surfaces.
+        QCOMPARE(inAppCurrentBean.value(QStringLiteral("type")).toString(),
+                 QStringLiteral("Spring Tour 2026 #2"));
+        QCOMPARE(inAppCurrentBean.value(QStringLiteral("roastLevel")).toString(),
+                 QStringLiteral("Dark"));
+        QCOMPARE(inAppCurrentBean.value(QStringLiteral("doseWeightG")).toDouble(), 20.0);
+
+        // Inferred-field machinery is gone on both surfaces.
+        QVERIFY(!inAppCurrentBean.contains(QStringLiteral("inferredFields")));
+        QVERIFY(!inAppCurrentBean.contains(QStringLiteral("inferredFromShotId")));
+        QVERIFY(!inAppCurrentBean.contains(QStringLiteral("inferredNote")));
+        QVERIFY(!mcpCurrentBean.contains(QStringLiteral("inferredFields")));
+        QVERIFY(!mcpCurrentBean.contains(QStringLiteral("inferredFromShotId")));
+
+        // beanFreshness reads from the shot's roastDate, not live DYE's.
+        QVERIFY(inAppCurrentBean.contains(QStringLiteral("beanFreshness")));
+        const QJsonObject freshness =
+            inAppCurrentBean.value(QStringLiteral("beanFreshness")).toObject();
+        QCOMPARE(freshness.value(QStringLiteral("roastDate")).toString(),
+                 QStringLiteral("2026-03-30"));
     }
 
     // ---------------------------------------------------------------------

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -435,22 +435,25 @@ private slots:
     }
 
     // ---------------------------------------------------------------------
-    // openspec unify-current-bean-shape (issue #1043) — both surfaces
-    // produce byte-equivalent `currentBean` JSON for the same resolved
-    // shot. The MCP path (`dialing_get_context.currentBean`) and the
-    // in-app advisor's user-prompt path
+    // Both surfaces produce byte-equivalent `currentBean` JSON for the
+    // same resolved shot. The MCP path
+    // (`dialing_get_context.currentBean`) and the in-app advisor's
+    // user-prompt path
     // (`AIManager::buildUserPromptObjectForShot(...)["currentBean"]`)
-    // build through the shared `McpDialingBlocks::buildCurrentBeanBlock`,
-    // sourced solely from the resolved shot.
+    // build through the shared
+    // `McpDialingBlocks::buildCurrentBeanBlock`, sourced solely from the
+    // resolved shot. Pinned end-to-end so future drift between the two
+    // builders fails the test rather than confusing the LLM with two
+    // disagreeing views of the same shot.
     // ---------------------------------------------------------------------
     void currentBean_equivalenceAcrossSurfaces()
     {
         QNetworkAccessManager nam;
         // Live DYE state is deliberately divergent from the shot's saved
-        // metadata to model the issue #1043 scenario: the user changed
-        // DYE between pulling the shot and asking the AI about it.
-        // currentBean must NOT pick up the live DYE values on either
-        // surface — the shot is the source of truth.
+        // metadata to model the case where the user changed DYE between
+        // pulling the shot and asking the AI about it. currentBean must
+        // NOT pick up the live DYE values on either surface — the shot is
+        // the source of truth.
         Settings settings;
         settings.dye()->setDyeBeanBrand(QStringLiteral("Live DYE Brand"));
         settings.dye()->setDyeBeanType(QStringLiteral("Live DYE Type"));

--- a/tests/tst_mcptools_dialing_helpers.cpp
+++ b/tests/tst_mcptools_dialing_helpers.cpp
@@ -30,14 +30,12 @@ private slots:
     void hoistSessionContext_firstShotEmptyForField_fallsBackToFirstNonEmpty();
     void hoistSessionContext_allShotsEmptyForField_contextOmitsField();
 
-    // buildCurrentBean (issue #1019)
-    void buildCurrentBean_dyePopulated_noInference();
-    void buildCurrentBean_grinderBlank_inferredFromShot();
-    void buildCurrentBean_doseBlank_inferredFromShot();
-    void buildCurrentBean_partialFallback_listsOnlyInferredFields();
-    void buildCurrentBean_beanFieldsNeverInferred();
-    void buildCurrentBean_bothBlank_omitsInferredMeta();
-    void buildCurrentBean_dyeWins_overShotValues();
+    // buildCurrentBean: removed in unify-current-bean-shape (issue #1043).
+    // The MCP-only DYE-with-fallback helper was retired in favor of the
+    // shared `McpDialingBlocks::buildCurrentBeanBlock(ShotProjection)` —
+    // both the MCP path and the in-app advisor user prompt build through
+    // it, sourced solely from the resolved shot. Equivalence is exercised
+    // in `tst_aimanager`'s currentBean equivalence test.
 
     // buildShotChangeDiff (issue #1020 — also drives changeFromPrev)
     void buildShotChangeDiff_identicalShots_emptyDiff();
@@ -345,160 +343,6 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_allShotsEmptyForField_contex
     for (const auto& override : out.perShotOverrides) {
         QVERIFY(override.grinderBurrs.isEmpty());
     }
-}
-
-// ---- buildCurrentBean (issue #1019) ----
-//
-// The DYE block represents what's currently in the grinder/hopper. When
-// grinder/dose fields are blank but the resolved shot has them populated,
-// fall back to the shot's values and tag them as inferred so the AI knows
-// to confirm before recommending a change. Bean fields (brand/type/
-// roastLevel) are *never* inferred — those rotate per hopper. roastDate
-// is intentionally absent from the helper output; it lives in
-// `currentBean.beanFreshness` (composed by the caller) so the freshness
-// surface stays in one place.
-
-namespace {
-CurrentBeanInputs sampleInputs()
-{
-    CurrentBeanInputs in;
-    in.dyeBeanBrand = QStringLiteral("Northbound");
-    in.dyeBeanType = QStringLiteral("Single Origin");
-    in.dyeRoastLevel = QStringLiteral("Light");
-    in.dyeGrinderBrand = QStringLiteral("Niche");
-    in.dyeGrinderModel = QStringLiteral("Zero");
-    in.dyeGrinderBurrs = QStringLiteral("63mm Mazzer Kony conical");
-    in.dyeGrinderSetting = QStringLiteral("4.5");
-    in.dyeDoseWeightG = 18.0;
-    in.fallbackGrinderBrand = QStringLiteral("Eureka");
-    in.fallbackGrinderModel = QStringLiteral("Mignon");
-    in.fallbackGrinderBurrs = QStringLiteral("55mm flat");
-    in.fallbackGrinderSetting = QStringLiteral("12");
-    in.fallbackDoseWeightG = 20.0;
-    in.fallbackShotId = 884;
-    return in;
-}
-} // namespace
-
-void TstMcpToolsDialingHelpers::buildCurrentBean_dyePopulated_noInference()
-{
-    const QJsonObject bean = buildCurrentBean(sampleInputs());
-
-    QCOMPARE(bean["grinderBrand"].toString(), QStringLiteral("Niche"));
-    QCOMPARE(bean["grinderModel"].toString(), QStringLiteral("Zero"));
-    QCOMPARE(bean["grinderSetting"].toString(), QStringLiteral("4.5"));
-    QCOMPARE(bean["doseWeightG"].toDouble(), 18.0);
-    QVERIFY2(!bean.contains("inferredFromShotId"),
-             "DYE fully populated must not surface inferredFromShotId");
-    QVERIFY2(!bean.contains("inferredFields"),
-             "DYE fully populated must not surface inferredFields");
-}
-
-void TstMcpToolsDialingHelpers::buildCurrentBean_grinderBlank_inferredFromShot()
-{
-    CurrentBeanInputs in = sampleInputs();
-    in.dyeGrinderBrand.clear();
-    in.dyeGrinderModel.clear();
-    in.dyeGrinderBurrs.clear();
-    in.dyeGrinderSetting.clear();
-
-    const QJsonObject bean = buildCurrentBean(in);
-
-    QCOMPARE(bean["grinderBrand"].toString(), QStringLiteral("Eureka"));
-    QCOMPARE(bean["grinderModel"].toString(), QStringLiteral("Mignon"));
-    QCOMPARE(bean["grinderBurrs"].toString(), QStringLiteral("55mm flat"));
-    QCOMPARE(bean["grinderSetting"].toString(), QStringLiteral("12"));
-    QCOMPARE(bean["inferredFromShotId"].toInteger(), qint64(884));
-
-    const QJsonArray inferred = bean["inferredFields"].toArray();
-    QCOMPARE(inferred.size(), 4);
-    QVERIFY(inferred.contains(QStringLiteral("grinderBrand")));
-    QVERIFY(inferred.contains(QStringLiteral("grinderModel")));
-    QVERIFY(inferred.contains(QStringLiteral("grinderBurrs")));
-    QVERIFY(inferred.contains(QStringLiteral("grinderSetting")));
-    QVERIFY2(bean.contains("inferredNote"),
-             "inferred fields must come with an explanatory note");
-}
-
-void TstMcpToolsDialingHelpers::buildCurrentBean_doseBlank_inferredFromShot()
-{
-    CurrentBeanInputs in = sampleInputs();
-    in.dyeDoseWeightG = 0;
-
-    const QJsonObject bean = buildCurrentBean(in);
-
-    QCOMPARE(bean["doseWeightG"].toDouble(), 20.0);
-    const QJsonArray inferred = bean["inferredFields"].toArray();
-    QCOMPARE(inferred.size(), 1);
-    QVERIFY(inferred.contains(QStringLiteral("doseWeightG")));
-}
-
-void TstMcpToolsDialingHelpers::buildCurrentBean_partialFallback_listsOnlyInferredFields()
-{
-    CurrentBeanInputs in = sampleInputs();
-    in.dyeGrinderSetting.clear();   // only this one is blank
-
-    const QJsonObject bean = buildCurrentBean(in);
-
-    const QJsonArray inferred = bean["inferredFields"].toArray();
-    QCOMPARE(inferred.size(), 1);
-    QCOMPARE(inferred[0].toString(), QStringLiteral("grinderSetting"));
-    // Other grinder fields stayed on DYE values
-    QCOMPARE(bean["grinderBrand"].toString(), QStringLiteral("Niche"));
-}
-
-void TstMcpToolsDialingHelpers::buildCurrentBean_beanFieldsNeverInferred()
-{
-    // Bean brand/type/roastLevel rotate per hopper — falling back to a
-    // stale shot would mislead the AI. Even when DYE is fully empty,
-    // these stay blank rather than inheriting the shot's bean. roastDate
-    // is owned by `buildBeanFreshness` (composed by the caller) and is
-    // intentionally absent from the helper's output.
-    CurrentBeanInputs in = sampleInputs();
-    in.dyeBeanBrand.clear();
-    in.dyeBeanType.clear();
-    in.dyeRoastLevel.clear();
-
-    const QJsonObject bean = buildCurrentBean(in);
-
-    QVERIFY2(bean["brand"].toString().isEmpty(),
-             "bean brand must never be inferred from shot");
-    QVERIFY2(bean["type"].toString().isEmpty(),
-             "bean type must never be inferred from shot");
-    QVERIFY2(bean["roastLevel"].toString().isEmpty(),
-             "roast level must never be inferred from shot");
-    QVERIFY2(!bean.contains("roastDate"),
-             "roastDate must not appear at currentBean top level — owned by beanFreshness");
-    // No grinder/dose blanks → no inferredFields surfaced.
-    QVERIFY(!bean.contains("inferredFields"));
-}
-
-void TstMcpToolsDialingHelpers::buildCurrentBean_bothBlank_omitsInferredMeta()
-{
-    // Both DYE and shot grinder are blank — no inference possible.
-    CurrentBeanInputs in;
-    in.fallbackShotId = 884;
-    const QJsonObject bean = buildCurrentBean(in);
-
-    QVERIFY2(!bean.contains("inferredFromShotId"),
-             "no fallback data → no inferred meta");
-    QVERIFY2(!bean.contains("inferredFields"),
-             "no fallback data → no inferred meta");
-}
-
-void TstMcpToolsDialingHelpers::buildCurrentBean_dyeWins_overShotValues()
-{
-    // Sanity: when DYE is populated and the shot has different values, DYE
-    // wins. This pins the precedence direction — production code never
-    // overrides user-entered DYE with shot data.
-    CurrentBeanInputs in = sampleInputs();
-    // DYE says Niche, shot says Eureka — Niche must surface.
-    QCOMPARE(in.dyeGrinderBrand, QStringLiteral("Niche"));
-    QCOMPARE(in.fallbackGrinderBrand, QStringLiteral("Eureka"));
-
-    const QJsonObject bean = buildCurrentBean(in);
-    QCOMPARE(bean["grinderBrand"].toString(), QStringLiteral("Niche"));
-    QVERIFY(!bean.contains("inferredFields"));
 }
 
 // ---- buildShotChangeDiff (issue #1020) ----

--- a/tests/tst_mcptools_dialing_helpers.cpp
+++ b/tests/tst_mcptools_dialing_helpers.cpp
@@ -30,13 +30,6 @@ private slots:
     void hoistSessionContext_firstShotEmptyForField_fallsBackToFirstNonEmpty();
     void hoistSessionContext_allShotsEmptyForField_contextOmitsField();
 
-    // buildCurrentBean: removed in unify-current-bean-shape (issue #1043).
-    // The MCP-only DYE-with-fallback helper was retired in favor of the
-    // shared `McpDialingBlocks::buildCurrentBeanBlock(ShotProjection)` —
-    // both the MCP path and the in-app advisor user prompt build through
-    // it, sourced solely from the resolved shot. Equivalence is exercised
-    // in `tst_aimanager`'s currentBean equivalence test.
-
     // buildShotChangeDiff (issue #1020 — also drives changeFromPrev)
     void buildShotChangeDiff_identicalShots_emptyDiff();
     void buildShotChangeDiff_directionIsFromTo();

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -1083,9 +1083,12 @@ private slots:
                  "system prompt must reference the freshnessKnown gate");
         QVERIFY2(prompt.contains(QStringLiteral("freeze")),
                  "system prompt must mention freezing as the storage variable that breaks calendar age");
-        // inferredFields gating
-        QVERIFY2(prompt.contains(QStringLiteral("inferredFields")),
-                 "system prompt must teach inferredFields gating");
+        // inferredFields gating: removed in unify-current-bean-shape
+        // (issue #1043). currentBean is now sourced solely from the
+        // resolved shot, so no fields are "inferred" — the system prompt
+        // SHALL NOT carry that clause.
+        QVERIFY2(!prompt.contains(QStringLiteral("inferredFields")),
+                 "system prompt must NOT teach a removed inferredFields field");
     }
 
     // Openspec optimize-dialing-context-payload, tasks 8 + 9: the prose

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -1083,12 +1083,17 @@ private slots:
                  "system prompt must reference the freshnessKnown gate");
         QVERIFY2(prompt.contains(QStringLiteral("freeze")),
                  "system prompt must mention freezing as the storage variable that breaks calendar age");
-        // inferredFields gating: removed in unify-current-bean-shape
-        // (issue #1043). currentBean is now sourced solely from the
-        // resolved shot, so no fields are "inferred" — the system prompt
-        // SHALL NOT carry that clause.
+        // currentBean is sourced solely from the resolved shot, so no
+        // fields are "inferred" — the system prompt SHALL NOT carry an
+        // inferredFields clause.
         QVERIFY2(!prompt.contains(QStringLiteral("inferredFields")),
                  "system prompt must NOT teach a removed inferredFields field");
+        // Empty-string semantics: an empty currentBean field means the
+        // shot did not record it, not that the user has no grinder/bean.
+        // The prompt MUST teach this so the LLM doesn't read a blank as a
+        // negation. Match on a stable phrase from the prompt body.
+        QVERIFY2(prompt.contains(QStringLiteral("did NOT record")),
+                 "system prompt must teach empty-string semantics for currentBean fields");
     }
 
     // Openspec optimize-dialing-context-payload, tasks 8 + 9: the prose


### PR DESCRIPTION
## Summary

For the same resolved shot, `dialing_get_context.currentBean` and the in-app advisor's user-prompt `currentBean` shipped different shapes and disagreed on values: the MCP path read live DYE with shot fallback (populating `inferredFields` / `inferredFromShotId`), while the in-app path read the shot's saved metadata. The LLM saw two `currentBean` blocks describing the same shot whenever the user changed DYE between pulling and asking. Same class of bug PR #1034 retired for `currentProfile` vs `profile`.

This PR implements **Option A** from issue #1043: bind `currentBean` to "the setup that produced the resolved shot" on every surface.

- New shared helper `McpDialingBlocks::buildCurrentBeanBlock(CurrentBeanBlockInputs)` builds the JSON from the resolved shot's bean / grinder / dose / roastDate fields only. Both `dialing_get_context.currentBean` and `ShotSummarizer::buildUserPromptObject(...)["currentBean"]` build through it. Defined inline in the header so test binaries that link only `shotsummarizer.cpp` don't drag in the DB-dependent block-builder TU.
- The DYE-with-fallback machinery is removed: `McpDialingHelpers::CurrentBeanInputs` / `buildCurrentBean` are gone, as are `ShotSummary::inferredFields` / `inferredFromShotId`. Once the shot is the canonical source, nothing is "inferred."
- `currentBean.beanFreshness` reads from the shot's `roastDate` on both surfaces (it was DYE-sourced in the MCP path).
- The espresso `shotAnalysisSystemPrompt` "How to read structured fields" section drops the `inferredFields` clause and tightens the `currentBean` description to "describes the setup that produced the resolved shot."
- OpenSpec change `unify-current-bean-shape` MODIFIES the existing static-framing-strings and beanFreshness requirements in `dialing-context-payload`, ADDS a canonical-source-pin requirement, and validates strict.

Live-DYE-vs-shot drift is no longer surfaced in `currentBean` — that is a deliberate scope reduction. If a future change needs it, a separate `liveSetup` block can be added without renegotiating `currentBean`'s meaning. See proposal.md for the rationale.

Closes #1043.

## Test plan
- [x] Local Qt Creator build clean — 0 errors, 0 warnings.
- [x] `tst_AIManager`, `TstMcpToolsDialingHelpers`, `tst_ShotSummarizer` all pass (92/92).
- [x] New `tst_AIManager::currentBean_equivalenceAcrossSurfaces` drives both surfaces with a fixed shot under deliberately divergent live DYE (different bean type, roast level, dose, roast date), asserts byte-equivalent `currentBean` JSON, and pins:
  - shot values win over live DYE (no `Live DYE Brand` / `99`g leak),
  - no `inferredFields` / `inferredFromShotId` / `inferredNote` on either surface,
  - `beanFreshness.roastDate` reads from the shot.
- [x] Seven obsolete `buildCurrentBean_*` unit tests in `tst_mcptools_dialing_helpers.cpp` deleted; equivalence test replaces them.
- [x] `tst_shotsummarizer`'s `inferredFields` system-prompt assertion flipped from "must contain" to "must NOT contain" to match the prompt update.
- [x] `openspec validate unify-current-bean-shape --strict --no-interactive` → valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)