### PR TITLE
refactor: move dialing helpers from src/mcp/ to src/ai/ (#1040)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ set(SOURCES
     src/mcp/mcptools_profiles.cpp
     src/mcp/mcptools_settings.cpp
     src/mcp/mcptools_dialing.cpp
-    src/mcp/mcptools_dialing_blocks.cpp
+    src/ai/dialing_blocks.cpp
     src/mcp/mcptools_control.cpp
     src/mcp/mcpresources.cpp
     src/mcp/mcptools_scale.cpp

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -6,7 +6,7 @@
 #include "../core/settings_ai.h"
 #include "../core/grinderaliases.h"
 #include "../controllers/profilemanager.h"
-#include "../mcp/mcptools_dialing_blocks.h"
+#include "dialing_blocks.h"
 #include "../models/shotdatamodel.h"
 #include "../profile/profile.h"
 #include "../network/visualizeruploader.h"
@@ -284,12 +284,12 @@ void AIManager::analyzeShotWithMetadata(ShotDataModel* shotData,
                     resolvedShot = ShotHistoryStorage::convertShotRecord(rec);
                 }
 
-                dialInSessions = McpDialingBlocks::buildDialInSessionsBlock(
+                dialInSessions = DialingBlocks::buildDialInSessionsBlock(
                     db, kbId, excludeId, 5);
                 if (resolvedShot.isValid()) {
-                    bestRecentShot = McpDialingBlocks::buildBestRecentShotBlock(
+                    bestRecentShot = DialingBlocks::buildBestRecentShotBlock(
                         db, kbId, excludeId, resolvedShot);
-                    grinderContext = McpDialingBlocks::buildGrinderContextBlock(
+                    grinderContext = DialingBlocks::buildGrinderContextBlock(
                         db, resolvedShot.grinderModel,
                         resolvedShot.beverageType, resolvedShot.beanBrand);
                 }
@@ -434,7 +434,7 @@ void AIManager::enrichUserPromptObject(QJsonObject& payload,
     if (!grinderContext.isEmpty())
         payload["grinderContext"] = grinderContext;
     if (shotData.isValid()) {
-        const QJsonObject sawPrediction = McpDialingBlocks::buildSawPredictionBlock(
+        const QJsonObject sawPrediction = DialingBlocks::buildSawPredictionBlock(
             m_settings, m_profileManager, shotData);
         if (!sawPrediction.isEmpty())
             payload["sawPrediction"] = sawPrediction;

--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -1,5 +1,5 @@
-#include "mcptools_dialing_blocks.h"
-#include "mcptools_dialing_helpers.h"
+#include "dialing_blocks.h"
+#include "dialing_helpers.h"
 
 #include "../history/shothistorystorage.h"
 #include "../history/shotprojection.h"
@@ -23,9 +23,9 @@
 
 namespace {
 
-McpDialingHelpers::ShotDiffInputs toDiffInputs(const ShotProjection& s)
+DialingHelpers::ShotDiffInputs toDiffInputs(const ShotProjection& s)
 {
-    McpDialingHelpers::ShotDiffInputs d;
+    DialingHelpers::ShotDiffInputs d;
     d.grinderSetting = s.grinderSetting;
     d.beanBrand = s.beanBrand;
     d.doseWeightG = s.doseWeightG;
@@ -37,7 +37,7 @@ McpDialingHelpers::ShotDiffInputs toDiffInputs(const ShotProjection& s)
 
 QJsonObject changeFromPrev(const ShotProjection& prev, const ShotProjection& curr)
 {
-    return McpDialingHelpers::buildShotChangeDiff(toDiffInputs(prev), toDiffInputs(curr));
+    return DialingHelpers::buildShotChangeDiff(toDiffInputs(prev), toDiffInputs(curr));
 }
 
 // Per-shot serializer for dialInSessions. Identity overrides come from
@@ -45,7 +45,7 @@ QJsonObject changeFromPrev(const ShotProjection& prev, const ShotProjection& cur
 // the five identity fields only when they differ from the session
 // context (otherwise the field is hoisted and absent here).
 QJsonObject shotToJson(const ShotProjection& shot,
-                       const McpDialingHelpers::ShotIdentity& override)
+                       const DialingHelpers::ShotIdentity& override)
 {
     QJsonObject h;
     h["id"] = shot.id;
@@ -97,7 +97,7 @@ QJsonObject shotToJson(const ShotProjection& shot,
 
 } // namespace
 
-namespace McpDialingBlocks {
+namespace DialingBlocks {
 
 QJsonArray buildDialInSessionsBlock(QSqlDatabase& db,
                                     const QString& profileKbId,
@@ -119,7 +119,7 @@ QJsonArray buildDialInSessionsBlock(QSqlDatabase& db,
     timestamps.reserve(shots.size());
     for (const auto& s : shots)
         timestamps.append(s.timestamp);
-    const auto sessionIndices = McpDialingHelpers::groupSessions(timestamps);
+    const auto sessionIndices = DialingHelpers::groupSessions(timestamps);
 
     for (const auto& indices : sessionIndices) {
         // Reverse indices to ASC within the session so changeFromPrev
@@ -129,10 +129,10 @@ QJsonArray buildDialInSessionsBlock(QSqlDatabase& db,
         for (qsizetype i = indices.size() - 1; i >= 0; --i)
             ordered.append(shots[indices[i]]);
 
-        QList<McpDialingHelpers::ShotIdentity> identities;
+        QList<DialingHelpers::ShotIdentity> identities;
         identities.reserve(ordered.size());
         for (const ShotProjection& s : ordered) {
-            McpDialingHelpers::ShotIdentity id;
+            DialingHelpers::ShotIdentity id;
             id.grinderBrand = s.grinderBrand;
             id.grinderModel = s.grinderModel;
             id.grinderBurrs = s.grinderBurrs;
@@ -140,8 +140,8 @@ QJsonArray buildDialInSessionsBlock(QSqlDatabase& db,
             id.beanType = s.beanType;
             identities.append(id);
         }
-        const McpDialingHelpers::HoistedSession hoisted =
-            McpDialingHelpers::hoistSessionContext(identities);
+        const DialingHelpers::HoistedSession hoisted =
+            DialingHelpers::hoistSessionContext(identities);
 
         QJsonArray sessionShots;
         for (qsizetype i = 0; i < ordered.size(); ++i) {
@@ -299,7 +299,7 @@ QJsonObject buildSawPredictionBlock(Settings* settings,
     if (bevType.compare(QStringLiteral("espresso"), Qt::CaseInsensitive) != 0)
         return QJsonObject();
 
-    const double flowAtCutoff = McpDialingHelpers::estimateFlowAtCutoff(
+    const double flowAtCutoff = DialingHelpers::estimateFlowAtCutoff(
         currentShot.flow, currentShot.durationSec);
     if (flowAtCutoff <= 0) return QJsonObject();
 
@@ -343,4 +343,4 @@ QJsonObject buildSawPredictionBlock(Settings* settings,
 // that link only `shotsummarizer.cpp` don't drag in this TU's DB-dependent
 // block builders (loadShotRecordStatic et al.).
 
-} // namespace McpDialingBlocks
+} // namespace DialingBlocks

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "mcptools_dialing_helpers.h"  // buildBeanFreshness — composed inside buildCurrentBeanBlock
+#include "dialing_helpers.h"  // buildBeanFreshness — composed inside buildCurrentBeanBlock
 
 #include <QJsonArray>
 #include <QJsonObject>
@@ -31,7 +31,7 @@ class ShotProjection;
 // (or empty `QJsonArray`) when its preconditions don't hold, so callers
 // can suppress the corresponding key entirely (no `null` placeholders).
 
-namespace McpDialingBlocks {
+namespace DialingBlocks {
 
 // Window for the "best recent shot on this profile" anchor. Bounded
 // so the anchor reflects the user's *current* setup era — same grinder
@@ -73,7 +73,7 @@ QJsonObject buildGrinderContextBlock(QSqlDatabase& db,
 // `currentBean` build through this helper so the two surfaces produce
 // byte-equivalent JSON for the same shot. Composes
 // `currentBean.beanFreshness` from the shot's `roastDate` via
-// `McpDialingHelpers::buildBeanFreshness`. Pure: no Qt object
+// `DialingHelpers::buildBeanFreshness`. Pure: no Qt object
 // dependencies beyond the projection and JSON value types.
 //
 // Inputs that capture every field this block reads from the shot. Kept
@@ -94,7 +94,7 @@ struct CurrentBeanBlockInputs {
 };
 
 // Defined inline so test binaries that link only `shotsummarizer.cpp`
-// (and not the rest of `mcptools_dialing_blocks.cpp`'s DB-dependent
+// (and not the rest of `dialing_blocks.cpp`'s DB-dependent
 // builders) can pick up this single helper without pulling in
 // `loadShotRecordStatic` / `loadRecentShotsByKbIdStatic` symbols.
 inline QJsonObject buildCurrentBeanBlock(const CurrentBeanBlockInputs& in)
@@ -109,7 +109,7 @@ inline QJsonObject buildCurrentBeanBlock(const CurrentBeanBlockInputs& in)
     bean["grinderSetting"] = in.grinderSetting;
     bean["doseWeightG"] = in.doseWeightG;
 
-    const QJsonObject freshness = McpDialingHelpers::buildBeanFreshness(in.roastDate);
+    const QJsonObject freshness = DialingHelpers::buildBeanFreshness(in.roastDate);
     if (!freshness.isEmpty())
         bean["beanFreshness"] = freshness;
 
@@ -134,4 +134,4 @@ QJsonObject buildSawPredictionBlock(Settings* settings,
                                     ProfileManager* profileManager,
                                     const ShotProjection& currentShot);
 
-} // namespace McpDialingBlocks
+} // namespace DialingBlocks

--- a/src/ai/dialing_helpers.h
+++ b/src/ai/dialing_helpers.h
@@ -8,10 +8,12 @@
 #include <QVariantMap>
 #include <QtGlobal>
 
-// Helpers extracted from mcptools_dialing.cpp so the pure-logic pieces can be
-// unit-tested without spinning up the full MCP / DB / thread stack.
+// Pure-logic helpers shared by both the MCP `dialing_get_context` tool and
+// the in-app advisor enrichment path. Lives under src/ai/ (the consumer
+// that owns the dialing-context concept) rather than src/mcp/, so the AI
+// subsystem does not reverse-include from MCP. Issue #1040.
 
-namespace McpDialingHelpers {
+namespace DialingHelpers {
 
 // A run of consecutive shots on the same profile counts as one dial-in
 // "session" when the gap between adjacent shots is small enough that the
@@ -240,4 +242,4 @@ inline double estimateFlowAtCutoff(const QVariantList& flowSamples,
     return count > 0 ? sum / count : 0.0;
 }
 
-} // namespace McpDialingHelpers
+} // namespace DialingHelpers

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -5,8 +5,8 @@
 #include "../profile/profile.h"
 #include "../network/visualizeruploader.h"  // ShotMetadata struct (lives in this header for historical reasons)
 #include "../core/grinderaliases.h"
-#include "../mcp/mcptools_dialing_helpers.h"  // shared buildBeanFreshness — same shape on both surfaces
-#include "../mcp/mcptools_dialing_blocks.h"   // shared buildCurrentBeanBlock — single source of truth for currentBean
+#include "dialing_helpers.h"  // shared buildBeanFreshness — same shape on both surfaces
+#include "dialing_blocks.h"   // shared buildCurrentBeanBlock — single source of truth for currentBean
 
 #include <cmath>
 #include <algorithm>
@@ -549,7 +549,7 @@ static QJsonObject buildCurrentBeanBlock(const ShotSummary& summary)
     // Delegates to the shared helper so this surface and
     // `dialing_get_context.currentBean` produce byte-equivalent JSON for
     // the same resolved shot.
-    McpDialingBlocks::CurrentBeanBlockInputs in;
+    DialingBlocks::CurrentBeanBlockInputs in;
     in.beanBrand = summary.beanBrand;
     in.beanType = summary.beanType;
     in.roastLevel = summary.roastLevel;
@@ -559,7 +559,7 @@ static QJsonObject buildCurrentBeanBlock(const ShotSummary& summary)
     in.grinderBurrs = summary.grinderBurrs;
     in.grinderSetting = summary.grinderSetting;
     in.doseWeightG = summary.doseWeight;
-    return McpDialingBlocks::buildCurrentBeanBlock(in);
+    return DialingBlocks::buildCurrentBeanBlock(in);
 }
 
 static QJsonObject buildCurrentProfileBlock(const ShotSummary& summary)

--- a/src/mcp/mcptools_ai.cpp
+++ b/src/mcp/mcptools_ai.cpp
@@ -1,6 +1,6 @@
 #include "mcpserver.h"
 #include "mcptoolregistry.h"
-#include "mcptools_dialing_blocks.h"
+#include "../ai/dialing_blocks.h"
 #include "../ai/aimanager.h"
 #include "../ai/shotsummarizer.h"
 #include "../ai/aiprovider.h"
@@ -146,11 +146,11 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
                         // the userPromptUsed echo is byte-equivalent
                         // across surfaces. See openspec
                         // add-dialing-blocks-to-advisor.
-                        dialInSessions = McpDialingBlocks::buildDialInSessionsBlock(
+                        dialInSessions = DialingBlocks::buildDialInSessionsBlock(
                             db, shot.profileKbId, resolvedShotId, 5);
-                        bestRecentShot = McpDialingBlocks::buildBestRecentShotBlock(
+                        bestRecentShot = DialingBlocks::buildBestRecentShotBlock(
                             db, shot.profileKbId, resolvedShotId, shot);
-                        grinderContext = McpDialingBlocks::buildGrinderContextBlock(
+                        grinderContext = DialingBlocks::buildGrinderContextBlock(
                             db, shot.grinderModel, shot.beverageType, shot.beanBrand);
                     }
                 });
@@ -202,7 +202,7 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
                         // grinderContext from bg thread; sawPrediction
                         // built here on the main thread). Same shape the
                         // in-app advisor produces — both surfaces call
-                        // the same helpers in McpDialingBlocks.
+                        // the same helpers in DialingBlocks.
                         QJsonObject userPromptObj = ai->buildUserPromptObjectForShot(shot);
                         if (userPromptObj.isEmpty()) {
                             respond(QJsonObject{{"error", "Failed to assemble shot summary for shot " + QString::number(resolvedShotId)}});

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -1,7 +1,7 @@
 #include "mcpserver.h"
 #include "mcptoolregistry.h"
-#include "mcptools_dialing_helpers.h"
-#include "mcptools_dialing_blocks.h"
+#include "../ai/dialing_helpers.h"
+#include "../ai/dialing_blocks.h"
 #include "../history/shothistorystorage.h"
 #include "../controllers/maincontroller.h"
 #include "../controllers/profilemanager.h"
@@ -118,16 +118,16 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     dbResult.profileKbId = record.profileKbId;
 
                     // The four DB-backed dialing-context blocks are produced
-                    // by shared helpers in mcptools_dialing_blocks. Both
+                    // by shared helpers in dialing_blocks. Both
                     // dialing_get_context and the in-app advisor's
                     // user-prompt enrichment path call the same builders so
                     // the two surfaces cannot drift. See openspec
                     // add-dialing-blocks-to-advisor.
-                    dbResult.dialInSessions = McpDialingBlocks::buildDialInSessionsBlock(
+                    dbResult.dialInSessions = DialingBlocks::buildDialInSessionsBlock(
                         db, dbResult.profileKbId, resolvedShotId, historyLimit);
-                    dbResult.bestRecentShot = McpDialingBlocks::buildBestRecentShotBlock(
+                    dbResult.bestRecentShot = DialingBlocks::buildBestRecentShotBlock(
                         db, dbResult.profileKbId, resolvedShotId, dbResult.shotData);
-                    dbResult.grinderContext = McpDialingBlocks::buildGrinderContextBlock(
+                    dbResult.grinderContext = DialingBlocks::buildGrinderContextBlock(
                         db, dbResult.shotData.grinderModel,
                         dbResult.shotData.beverageType, dbResult.shotData.beanBrand);
                 });
@@ -232,7 +232,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     // same helper so a single system-prompt reading lands
                     // on byte-equivalent JSON.
                     {
-                        McpDialingBlocks::CurrentBeanBlockInputs in;
+                        DialingBlocks::CurrentBeanBlockInputs in;
                         in.beanBrand = sd.beanBrand;
                         in.beanType = sd.beanType;
                         in.roastLevel = sd.roastLevel;
@@ -242,7 +242,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         in.grinderBurrs = sd.grinderBurrs;
                         in.grinderSetting = sd.grinderSetting;
                         in.doseWeightG = sd.doseWeightG;
-                        result["currentBean"] = McpDialingBlocks::buildCurrentBeanBlock(in);
+                        result["currentBean"] = DialingBlocks::buildCurrentBeanBlock(in);
                     }
 
                     // --- Profile (single canonical block) ---
@@ -282,7 +282,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                     // ProfileManager::baseProfileName(). Body lives in the
                     // shared helper so the in-app advisor and MCP advisor
                     // ship the same shape.
-                    const QJsonObject sawPrediction = McpDialingBlocks::buildSawPredictionBlock(
+                    const QJsonObject sawPrediction = DialingBlocks::buildSawPredictionBlock(
                         settings, profileManager, dbResult.shotData);
                     if (!sawPrediction.isEmpty())
                         result["sawPrediction"] = sawPrediction;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,9 +81,9 @@ add_decenza_test(tst_aborted_shot_classifier
     tst_aborted_shot_classifier.cpp
 )
 
-# --- tst_mcptools_dialing_helpers: pure session-grouping algorithm (issue #1009) ---
-add_decenza_test(tst_mcptools_dialing_helpers
-    tst_mcptools_dialing_helpers.cpp
+# --- tst_dialing_helpers: pure session-grouping algorithm (issue #1009) ---
+add_decenza_test(tst_dialing_helpers
+    tst_dialing_helpers.cpp
 )
 
 # --- tst_mcptools_shots_helpers: detectorResults envelope reshape (issue #1012) ---
@@ -238,7 +238,7 @@ add_decenza_test(tst_aimanager
     ${CMAKE_SOURCE_DIR}/src/ai/conductance.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
-    ${CMAKE_SOURCE_DIR}/src/mcp/mcptools_dialing_blocks.cpp
+    ${CMAKE_SOURCE_DIR}/src/ai/dialing_blocks.cpp
     ${CMAKE_SOURCE_DIR}/src/models/shotdatamodel.cpp
     ${CMAKE_SOURCE_DIR}/src/rendering/fastlinerenderer.cpp
     ${CMAKE_SOURCE_DIR}/src/network/visualizeruploader.cpp

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -32,7 +32,7 @@
 #include "core/settings_dye.h"
 #include "history/shotprojection.h"
 #include "history/shothistory_types.h"
-#include "mcp/mcptools_dialing_blocks.h"
+#include "ai/dialing_blocks.h"
 
 namespace {
 
@@ -441,7 +441,7 @@ private slots:
     // user-prompt path
     // (`AIManager::buildUserPromptObjectForShot(...)["currentBean"]`)
     // build through the shared
-    // `McpDialingBlocks::buildCurrentBeanBlock`, sourced solely from the
+    // `DialingBlocks::buildCurrentBeanBlock`, sourced solely from the
     // resolved shot. Pinned end-to-end so future drift between the two
     // builders fails the test rather than confusing the LLM with two
     // disagreeing views of the same shot.
@@ -489,7 +489,7 @@ private slots:
         // `mcptools_dialing.cpp:200`-block exactly — same field-by-field
         // mapping from `sd` (the resolved shot) into
         // `CurrentBeanBlockInputs`).
-        McpDialingBlocks::CurrentBeanBlockInputs in;
+        DialingBlocks::CurrentBeanBlockInputs in;
         in.beanBrand = shot.beanBrand;
         in.beanType = shot.beanType;
         in.roastLevel = shot.roastLevel;
@@ -499,7 +499,7 @@ private slots:
         in.grinderBurrs = shot.grinderBurrs;
         in.grinderSetting = shot.grinderSetting;
         in.doseWeightG = shot.doseWeightG;
-        const QJsonObject mcpCurrentBean = McpDialingBlocks::buildCurrentBeanBlock(in);
+        const QJsonObject mcpCurrentBean = DialingBlocks::buildCurrentBeanBlock(in);
 
         // The contract: byte-equivalent JSON for the same shot.
         QCOMPARE(inAppCurrentBean, mcpCurrentBean);
@@ -705,7 +705,7 @@ private slots:
     }
 
     // ---------------------------------------------------------------------
-    // McpDialingBlocks gating — preconditions that short-circuit before
+    // DialingBlocks gating — preconditions that short-circuit before
     // touching the DB / Settings / ProfileManager. These cases ship the
     // omission contract (empty QJsonObject so callers suppress the key)
     // without needing real DB infrastructure.
@@ -723,7 +723,7 @@ private slots:
             QVariantMap{{"x", 28.0}, {"y", 1.8}},
             QVariantMap{{"x", 29.0}, {"y", 2.0}},
             QVariantMap{{"x", 30.0}, {"y", 2.1}}};
-        const QJsonObject sp = McpDialingBlocks::buildSawPredictionBlock(nullptr, nullptr, shot);
+        const QJsonObject sp = DialingBlocks::buildSawPredictionBlock(nullptr, nullptr, shot);
         QVERIFY(sp.isEmpty());
     }
 
@@ -742,7 +742,7 @@ private slots:
             QVariantMap{{"x", 29.0}, {"y", 4.2}},
             QVariantMap{{"x", 30.0}, {"y", 4.1}}};
         Settings settings;
-        const QJsonObject sp = McpDialingBlocks::buildSawPredictionBlock(&settings, nullptr, shot);
+        const QJsonObject sp = DialingBlocks::buildSawPredictionBlock(&settings, nullptr, shot);
         QVERIFY(sp.isEmpty());
     }
 
@@ -757,7 +757,7 @@ private slots:
             QStringLiteral("Bean"), QStringLiteral("Type"),
             QStringLiteral("Profile"), QString(), QString());
         Settings settings;
-        const QJsonObject sp = McpDialingBlocks::buildSawPredictionBlock(&settings, nullptr, shot);
+        const QJsonObject sp = DialingBlocks::buildSawPredictionBlock(&settings, nullptr, shot);
         QVERIFY(sp.isEmpty());
     }
 
@@ -767,7 +767,7 @@ private slots:
         // before any DB access. (We can't easily stand up a real DB here;
         // this test pins the gating, not the DB query path.)
         QSqlDatabase db; // default-constructed: invalid, never used
-        const QJsonArray arr = McpDialingBlocks::buildDialInSessionsBlock(
+        const QJsonArray arr = DialingBlocks::buildDialInSessionsBlock(
             db, QString(), 1, 5);
         QVERIFY(arr.isEmpty());
     }
@@ -776,7 +776,7 @@ private slots:
     {
         QSqlDatabase db;
         ShotProjection shot;
-        const QJsonObject obj = McpDialingBlocks::buildBestRecentShotBlock(
+        const QJsonObject obj = DialingBlocks::buildBestRecentShotBlock(
             db, QString(), 1, shot);
         QVERIFY(obj.isEmpty());
     }
@@ -784,7 +784,7 @@ private slots:
     void grinderContextBlock_returnsEmpty_whenGrinderModelEmpty()
     {
         QSqlDatabase db;
-        const QJsonObject obj = McpDialingBlocks::buildGrinderContextBlock(
+        const QJsonObject obj = DialingBlocks::buildGrinderContextBlock(
             db, QString(), QStringLiteral("espresso"), QString());
         QVERIFY(obj.isEmpty());
     }

--- a/tests/tst_dialing_helpers.cpp
+++ b/tests/tst_dialing_helpers.cpp
@@ -1,9 +1,9 @@
 #include <QTest>
-#include "mcp/mcptools_dialing_helpers.h"
+#include "ai/dialing_helpers.h"
 
-using namespace McpDialingHelpers;
+using namespace DialingHelpers;
 
-class TstMcpToolsDialingHelpers : public QObject
+class TstDialingHelpers : public QObject
 {
     Q_OBJECT
 
@@ -46,12 +46,12 @@ private slots:
     void estimateFlowAtCutoff_customWindow();
 };
 
-void TstMcpToolsDialingHelpers::emptyInput_returnsNoSessions()
+void TstDialingHelpers::emptyInput_returnsNoSessions()
 {
     QVERIFY(groupSessions({}).isEmpty());
 }
 
-void TstMcpToolsDialingHelpers::singleShot_returnsOneSessionOfOne()
+void TstDialingHelpers::singleShot_returnsOneSessionOfOne()
 {
     const auto sessions = groupSessions({1000});
     QCOMPARE(sessions.size(), qsizetype(1));
@@ -59,7 +59,7 @@ void TstMcpToolsDialingHelpers::singleShot_returnsOneSessionOfOne()
     QCOMPARE(sessions[0][0], qsizetype(0));
 }
 
-void TstMcpToolsDialingHelpers::twoAdjacentShots_inSameSession()
+void TstDialingHelpers::twoAdjacentShots_inSameSession()
 {
     // Two shots 7 minutes apart — well within the 60-min threshold.
     const auto sessions = groupSessions({2000, 2000 - 7 * 60});
@@ -69,7 +69,7 @@ void TstMcpToolsDialingHelpers::twoAdjacentShots_inSameSession()
     QCOMPARE(sessions[0][1], qsizetype(1));
 }
 
-void TstMcpToolsDialingHelpers::twoFarApartShots_inSeparateSessions()
+void TstDialingHelpers::twoFarApartShots_inSeparateSessions()
 {
     // Two shots 24 hours apart.
     const auto sessions = groupSessions({100000, 100000 - 24 * 3600});
@@ -80,7 +80,7 @@ void TstMcpToolsDialingHelpers::twoFarApartShots_inSeparateSessions()
     QCOMPARE(sessions[1][0], qsizetype(1));
 }
 
-void TstMcpToolsDialingHelpers::issueExample_threeShots_twoSessions()
+void TstDialingHelpers::issueExample_threeShots_twoSessions()
 {
     // Mirrors the issue #1009 example: shots 884 (today 9:36), 883 (today 9:29),
     // 882 (yesterday 10:09). 884 and 883 are 7 min apart — same session.
@@ -99,7 +99,7 @@ void TstMcpToolsDialingHelpers::issueExample_threeShots_twoSessions()
     QCOMPARE(sessions[1][0], qsizetype(2));
 }
 
-void TstMcpToolsDialingHelpers::exactlyAtThreshold_groupsTogether()
+void TstDialingHelpers::exactlyAtThreshold_groupsTogether()
 {
     // Exactly at the threshold (gap == threshold) → still same session.
     const auto sessions = groupSessions({3600, 0}, /*thresholdSec=*/3600);
@@ -107,14 +107,14 @@ void TstMcpToolsDialingHelpers::exactlyAtThreshold_groupsTogether()
     QCOMPARE(sessions[0].size(), qsizetype(2));
 }
 
-void TstMcpToolsDialingHelpers::justOverThreshold_breaksSession()
+void TstDialingHelpers::justOverThreshold_breaksSession()
 {
     // 1 second over the threshold → distinct sessions.
     const auto sessions = groupSessions({3601, 0}, /*thresholdSec=*/3600);
     QCOMPARE(sessions.size(), qsizetype(2));
 }
 
-void TstMcpToolsDialingHelpers::thresholdIsConfigurable()
+void TstDialingHelpers::thresholdIsConfigurable()
 {
     // With a 30-min threshold, a 45-min gap should split.
     const auto sessions = groupSessions({3600, 3600 - 45 * 60}, /*thresholdSec=*/30 * 60);
@@ -129,13 +129,13 @@ void TstMcpToolsDialingHelpers::thresholdIsConfigurable()
 // vacuum-sealed) is misleading data dressed as precise data — many users
 // freeze beans, and the previous advisory note was demonstrably skimmed.
 
-void TstMcpToolsDialingHelpers::buildBeanFreshness_emptyRoastDate_returnsEmptyObject()
+void TstDialingHelpers::buildBeanFreshness_emptyRoastDate_returnsEmptyObject()
 {
     QCOMPARE(buildBeanFreshness(QString()), QJsonObject());
     QCOMPARE(buildBeanFreshness(QStringLiteral("")), QJsonObject());
 }
 
-void TstMcpToolsDialingHelpers::buildBeanFreshness_populatedRoastDate_carriesFreshnessKnownAndInstruction()
+void TstDialingHelpers::buildBeanFreshness_populatedRoastDate_carriesFreshnessKnownAndInstruction()
 {
     const QJsonObject block = buildBeanFreshness(QStringLiteral("2026-04-15"));
     QCOMPARE(block["roastDate"].toString(), QStringLiteral("2026-04-15"));
@@ -152,7 +152,7 @@ void TstMcpToolsDialingHelpers::buildBeanFreshness_populatedRoastDate_carriesFre
              "instruction must surface the freezing pattern that breaks calendar-age reasoning");
 }
 
-void TstMcpToolsDialingHelpers::buildBeanFreshness_neverEmitsAnyDayCountField()
+void TstDialingHelpers::buildBeanFreshness_neverEmitsAnyDayCountField()
 {
     // The block intentionally contains NO precomputed day count under any
     // field name. This is the load-bearing contract — adding back any
@@ -187,13 +187,13 @@ void TstMcpToolsDialingHelpers::buildBeanFreshness_neverEmitsAnyDayCountField()
 // surface once on `session.context` and zero times on per-shot entries.
 
 namespace {
-McpDialingHelpers::ShotIdentity makeIdentity(const QString& gBrand,
+DialingHelpers::ShotIdentity makeIdentity(const QString& gBrand,
                                               const QString& gModel,
                                               const QString& gBurrs,
                                               const QString& bBrand,
                                               const QString& bType)
 {
-    McpDialingHelpers::ShotIdentity id;
+    DialingHelpers::ShotIdentity id;
     id.grinderBrand = gBrand;
     id.grinderModel = gModel;
     id.grinderBurrs = gBurrs;
@@ -203,7 +203,7 @@ McpDialingHelpers::ShotIdentity makeIdentity(const QString& gBrand,
 }
 } // namespace
 
-void TstMcpToolsDialingHelpers::hoistSessionContext_emptySession_returnsEmpty()
+void TstDialingHelpers::hoistSessionContext_emptySession_returnsEmpty()
 {
     const auto out = hoistSessionContext({});
     QVERIFY(out.context.grinderBrand.isEmpty());
@@ -211,7 +211,7 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_emptySession_returnsEmpty()
     QVERIFY(out.perShotOverrides.isEmpty());
 }
 
-void TstMcpToolsDialingHelpers::hoistSessionContext_allShotsShareIdentity_contextHasAllOverridesEmpty()
+void TstDialingHelpers::hoistSessionContext_allShotsShareIdentity_contextHasAllOverridesEmpty()
 {
     // Mirrors the Northbound 80's Espresso 4-shot iteration session.
     const auto shot = makeIdentity(
@@ -219,7 +219,7 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_allShotsShareIdentity_contex
         QStringLiteral("63mm Mazzer Kony conical"),
         QStringLiteral("Northbound Coffee Roasters"),
         QStringLiteral("Spring Tour 2026 #2"));
-    const QList<McpDialingHelpers::ShotIdentity> shots{shot, shot, shot, shot};
+    const QList<DialingHelpers::ShotIdentity> shots{shot, shot, shot, shot};
 
     const auto out = hoistSessionContext(shots);
 
@@ -239,7 +239,7 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_allShotsShareIdentity_contex
     }
 }
 
-void TstMcpToolsDialingHelpers::hoistSessionContext_oneShotDiffersOnBeanBrand_onlyThatShotOverrides()
+void TstDialingHelpers::hoistSessionContext_oneShotDiffersOnBeanBrand_onlyThatShotOverrides()
 {
     const auto a = makeIdentity(
         QStringLiteral("Niche"), QStringLiteral("Zero"),
@@ -249,7 +249,7 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_oneShotDiffersOnBeanBrand_on
         QStringLiteral("Niche"), QStringLiteral("Zero"),
         QStringLiteral("63mm conical"),
         QStringLiteral("Prodigal"), QStringLiteral("Buenos Aires"));
-    const QList<McpDialingHelpers::ShotIdentity> shots{a, b, a};
+    const QList<DialingHelpers::ShotIdentity> shots{a, b, a};
 
     const auto out = hoistSessionContext(shots);
 
@@ -274,7 +274,7 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_oneShotDiffersOnBeanBrand_on
     QVERIFY(out.perShotOverrides[2].beanBrand.isEmpty());
 }
 
-void TstMcpToolsDialingHelpers::hoistSessionContext_singleShotSession_contextCarriesIdentity()
+void TstDialingHelpers::hoistSessionContext_singleShotSession_contextCarriesIdentity()
 {
     const auto only = makeIdentity(
         QStringLiteral("Niche"), QStringLiteral("Zero"),
@@ -289,7 +289,7 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_singleShotSession_contextCar
     QVERIFY(out.perShotOverrides[0].beanBrand.isEmpty());
 }
 
-void TstMcpToolsDialingHelpers::hoistSessionContext_firstShotEmptyForField_fallsBackToFirstNonEmpty()
+void TstDialingHelpers::hoistSessionContext_firstShotEmptyForField_fallsBackToFirstNonEmpty()
 {
     // Shot[0] has no recorded grinderBurrs (legacy import); shots[1+] do.
     // Context should pick the first non-empty value rather than leave it
@@ -303,7 +303,7 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_firstShotEmptyForField_falls
         QStringLiteral("Niche"), QStringLiteral("Zero"),
         QStringLiteral("63mm conical"),
         QStringLiteral("Northbound"), QStringLiteral("Spring Tour"));
-    const QList<McpDialingHelpers::ShotIdentity> shots{a, b, b};
+    const QList<DialingHelpers::ShotIdentity> shots{a, b, b};
 
     const auto out = hoistSessionContext(shots);
 
@@ -319,7 +319,7 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_firstShotEmptyForField_falls
     QVERIFY(out.perShotOverrides[2].grinderBurrs.isEmpty());
 }
 
-void TstMcpToolsDialingHelpers::hoistSessionContext_allShotsEmptyForField_contextOmitsField()
+void TstDialingHelpers::hoistSessionContext_allShotsEmptyForField_contextOmitsField()
 {
     // No shot has a recorded grinderBurrs — context.grinderBurrs stays
     // empty, and the JSON serializer omits the field from `context`.
@@ -327,7 +327,7 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_allShotsEmptyForField_contex
         QStringLiteral("Niche"), QStringLiteral("Zero"),
         QString(),
         QStringLiteral("Northbound"), QStringLiteral("Spring Tour"));
-    const QList<McpDialingHelpers::ShotIdentity> shots{a, a, a};
+    const QList<DialingHelpers::ShotIdentity> shots{a, a, a};
 
     const auto out = hoistSessionContext(shots);
 
@@ -344,7 +344,7 @@ void TstMcpToolsDialingHelpers::hoistSessionContext_allShotsEmptyForField_contex
 // (current vs best-rated past shot). Direction is `from -> to`; pin that
 // here so the AI's "what moved" envelope reads consistently.
 
-void TstMcpToolsDialingHelpers::buildShotChangeDiff_identicalShots_emptyDiff()
+void TstDialingHelpers::buildShotChangeDiff_identicalShots_emptyDiff()
 {
     ShotDiffInputs s;
     s.grinderSetting = QStringLiteral("4.5");
@@ -359,7 +359,7 @@ void TstMcpToolsDialingHelpers::buildShotChangeDiff_identicalShots_emptyDiff()
              "two shots with identical fields must produce no diff");
 }
 
-void TstMcpToolsDialingHelpers::buildShotChangeDiff_directionIsFromTo()
+void TstDialingHelpers::buildShotChangeDiff_directionIsFromTo()
 {
     // changeFromBest example from #1020 issue: best=18g/9-grind, current=20g/4.5-grind
     ShotDiffInputs best;
@@ -380,7 +380,7 @@ void TstMcpToolsDialingHelpers::buildShotChangeDiff_directionIsFromTo()
     QCOMPARE(diff["yieldG"].toString(), QStringLiteral("40.2 -> 35.9 g (-4.3)"));
 }
 
-void TstMcpToolsDialingHelpers::buildShotChangeDiff_zeroFieldsSkipped()
+void TstDialingHelpers::buildShotChangeDiff_zeroFieldsSkipped()
 {
     // When either side has 0 for a numeric field, skip the diff — there's
     // no meaningful comparison to be made (e.g. legacy shots without TDS).
@@ -401,7 +401,7 @@ void TstMcpToolsDialingHelpers::buildShotChangeDiff_zeroFieldsSkipped()
     QVERIFY(diff.contains("durationSec"));
 }
 
-void TstMcpToolsDialingHelpers::buildShotChangeDiff_emptyStringsSkipped()
+void TstDialingHelpers::buildShotChangeDiff_emptyStringsSkipped()
 {
     // Same rule for strings: blank on either side = no diff.
     ShotDiffInputs from;
@@ -419,7 +419,7 @@ void TstMcpToolsDialingHelpers::buildShotChangeDiff_emptyStringsSkipped()
              "identical strings must not produce a diff entry");
 }
 
-void TstMcpToolsDialingHelpers::buildShotChangeDiff_changeFromBestExample()
+void TstDialingHelpers::buildShotChangeDiff_changeFromBestExample()
 {
     // Mirrors the issue #1020 example: best is shot 802 on Prodigal Buenos
     // Aires at grind 9 / 18g / 40.2g, current is shot 884 on Northbound at
@@ -459,12 +459,12 @@ QVariantMap makeSample(double t, double y)
 }
 } // namespace
 
-void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_emptySamples_returnsZero()
+void TstDialingHelpers::estimateFlowAtCutoff_emptySamples_returnsZero()
 {
     QCOMPARE(estimateFlowAtCutoff({}, 30.0), 0.0);
 }
 
-void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_zeroDuration_returnsZero()
+void TstDialingHelpers::estimateFlowAtCutoff_zeroDuration_returnsZero()
 {
     // No duration → no window. Defensive: legacy shots with bogus durations.
     QVariantList samples;
@@ -472,7 +472,7 @@ void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_zeroDuration_returnsZero()
     QCOMPARE(estimateFlowAtCutoff(samples, 0.0), 0.0);
 }
 
-void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_averagesLastTwoSeconds()
+void TstDialingHelpers::estimateFlowAtCutoff_averagesLastTwoSeconds()
 {
     // Shot duration = 30s; default window = 2s → samples in [28, 30] count.
     QVariantList samples;
@@ -487,7 +487,7 @@ void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_averagesLastTwoSeconds()
     QVERIFY(qFuzzyCompare(avg, 1.8));
 }
 
-void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_skipsZeroFlowSamples()
+void TstDialingHelpers::estimateFlowAtCutoff_skipsZeroFlowSamples()
 {
     // y == 0 (drip detected as zero, scale rounding) shouldn't drag the avg
     // down — the SAW prediction wants the flow regime that drove pour
@@ -501,7 +501,7 @@ void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_skipsZeroFlowSamples()
     QVERIFY(qFuzzyCompare(avg, 1.5));
 }
 
-void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_shortShot_clampsWindowToZero()
+void TstDialingHelpers::estimateFlowAtCutoff_shortShot_clampsWindowToZero()
 {
     // Shot shorter than the window — window must clamp to t >= 0 so we
     // average the whole shot rather than emit garbage.
@@ -514,7 +514,7 @@ void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_shortShot_clampsWindowToZer
     QVERIFY(qFuzzyCompare(avg, 1.5));  // (1.0 + 2.0) / 2
 }
 
-void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_customWindow()
+void TstDialingHelpers::estimateFlowAtCutoff_customWindow()
 {
     QVariantList samples;
     samples.append(makeSample(25.0, 1.0));
@@ -527,6 +527,6 @@ void TstMcpToolsDialingHelpers::estimateFlowAtCutoff_customWindow()
     QVERIFY(qFuzzyCompare(estimateFlowAtCutoff(samples, 30.0, 1.0), 3.0));
 }
 
-QTEST_APPLESS_MAIN(TstMcpToolsDialingHelpers)
+QTEST_APPLESS_MAIN(TstDialingHelpers)
 
-#include "tst_mcptools_dialing_helpers.moc"
+#include "tst_dialing_helpers.moc"


### PR DESCRIPTION
## Summary

- Eliminates the reverse architectural dependency where `src/ai/shotsummarizer.cpp` and `src/ai/aimanager.cpp` included headers from `src/mcp/`
- Renames the helpers and namespaces to drop the misleading `Mcp` / `mcptools_` prefix
- Both surfaces (`dialing_get_context` and the in-app advisor) still call the same shared helpers; the move is rename-only

## Changes

- `src/mcp/mcptools_dialing_helpers.h` -> `src/ai/dialing_helpers.h`
- `src/mcp/mcptools_dialing_blocks.{h,cpp}` -> `src/ai/dialing_blocks.{h,cpp}`
- `tests/tst_mcptools_dialing_helpers.cpp` -> `tests/tst_dialing_helpers.cpp`
- Namespaces: `McpDialingHelpers` -> `DialingHelpers`, `McpDialingBlocks` -> `DialingBlocks`
- All include sites and `CMakeLists.txt` files updated

## Test plan

- [x] Build via Qt Creator MCP — 0 errors, 0 warnings
- [x] Full test suite — 1939 passed, 0 failed, 0 skipped

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)