### PR TITLE
feat(mcp): ai_advisor_invoke writes through to AIConversation (#1055 follow-up)

### DIFF
--- a/src/ai/aiconversation.cpp
+++ b/src/ai/aiconversation.cpp
@@ -2,6 +2,7 @@
 #include "aimanager.h"
 #include "shotsummarizer.h"
 
+#include <QDateTime>
 #include <QDebug>
 #include <QSettings>
 #include <QJsonArray>
@@ -315,6 +316,56 @@ AIConversation::loadRecentAssistantTurnsForKey(const QString& storageKey, qsizet
         });
     }
     return out;
+}
+
+void AIConversation::appendAssistantTurnForKey(
+    const QString& storageKey,
+    qint64 shotId,
+    const QString& userPrompt,
+    const QString& assistantResponse,
+    const std::optional<QJsonObject>& structuredNext)
+{
+    if (storageKey.isEmpty()) return;
+    QSettings settings;
+    const QString prefix = QStringLiteral("ai/conversations/") + storageKey + QStringLiteral("/");
+
+    // Pull the existing messages array (if any) so we append rather than
+    // overwrite. New conversations produce an empty array.
+    QJsonArray messages;
+    const QByteArray raw = settings.value(prefix + "messages").toByteArray();
+    if (!raw.isEmpty()) {
+        QJsonParseError err{};
+        const QJsonDocument doc = QJsonDocument::fromJson(raw, &err);
+        if (err.error == QJsonParseError::NoError && doc.isArray()) {
+            messages = doc.array();
+        } else {
+            qWarning() << "AIConversation::appendAssistantTurnForKey: existing messages "
+                          "for key" << storageKey << "did not parse as JSON array — "
+                          "appending to empty;" << err.errorString();
+        }
+    }
+
+    QJsonObject userMsg;
+    userMsg["role"] = QStringLiteral("user");
+    userMsg["content"] = userPrompt;
+    if (shotId != 0) userMsg["shotId"] = static_cast<double>(shotId);
+    messages.append(userMsg);
+
+    QJsonObject assistantMsg;
+    assistantMsg["role"] = QStringLiteral("assistant");
+    assistantMsg["content"] = assistantResponse;
+    if (shotId != 0) assistantMsg["shotId"] = static_cast<double>(shotId);
+    if (structuredNext.has_value()) assistantMsg["structuredNext"] = *structuredNext;
+    messages.append(assistantMsg);
+
+    settings.setValue(prefix + "messages",
+        QJsonDocument(messages).toJson(QJsonDocument::Compact));
+    settings.setValue(prefix + "timestamp",
+        QDateTime::currentDateTime().toString(Qt::ISODate));
+    // Note: systemPrompt is not written here. The in-app advisor sets it
+    // via ask(); the MCP path uses analyze(systemPrompt, userPrompt) and
+    // doesn't carry an AIConversation. For recentAdvice purposes the
+    // system prompt isn't needed — only `messages` is read.
 }
 
 void AIConversation::sendRequest()

--- a/src/ai/aiconversation.h
+++ b/src/ai/aiconversation.h
@@ -198,6 +198,32 @@ public:
     static QList<HistoricalAssistantTurn> loadRecentAssistantTurnsForKey(
         const QString& storageKey, qsizetype max);
 
+    /**
+     * Persist a user/assistant turn pair into the conversation at
+     * `storageKey` without going through a live AIConversation. Used by
+     * `ai_advisor_invoke` (MCP) so its turns participate in
+     * `recentAdvice` attribution on subsequent calls — the in-app
+     * advisor writes via `ask()` + `addAssistantMessage`; this helper
+     * gives the MCP path the same write-through without needing to
+     * mutate the user's currently-active in-app conversation object.
+     *
+     * Layout: same `ai/conversations/<key>/messages` shape as
+     * `saveToStorage`. The user turn carries `shotId`; the assistant
+     * turn carries `shotId` + optional `structuredNext`.
+     *
+     * Concurrency: when the live in-app `AIConversation` has the same
+     * `storageKey()` loaded, the caller is responsible for refreshing
+     * its in-memory state via `loadFromStorage()` after this returns —
+     * otherwise the in-app's next `saveToStorage` will overwrite the
+     * just-written turn.
+     */
+    static void appendAssistantTurnForKey(
+        const QString& storageKey,
+        qint64 shotId,
+        const QString& userPrompt,
+        const QString& assistantResponse,
+        const std::optional<QJsonObject>& structuredNext);
+
 signals:
     void responseReceived(const QString& response);
     void errorOccurred(const QString& error);

--- a/src/mcp/mcptools_ai.cpp
+++ b/src/mcp/mcptools_ai.cpp
@@ -314,7 +314,8 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
                     };
 
                     state->successConn = QObject::connect(ai, &AIManager::recommendationReceived,
-                        ai, [finalize](const QString& response) {
+                        ai, [finalize, aiPtrInner, shot, resolvedShotId, userPrompt](
+                                const QString& response) {
                             // Surface the trailing structured `nextShot`
                             // block (issue #1054) as a top-level field
                             // alongside the prose response, so MCP
@@ -326,6 +327,35 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
                             const auto structured = AIManager::parseStructuredNext(response);
                             if (structured.has_value()) {
                                 body.insert(QStringLiteral("structuredNext"), *structured);
+                            }
+
+                            // Persist the turn into the conversation key
+                            // so future ai_advisor_invoke / in-app advisor
+                            // calls on the same bean+profile see this
+                            // turn in their recentAdvice block. Without
+                            // this, the MCP path was effectively silent
+                            // — AIConversation was only written by the
+                            // in-app advisor flow.
+                            //
+                            // Skip when shot identity is incomplete (no
+                            // bean or no profile name): conversationKey
+                            // would still hash to something, but using
+                            // it as an attribution anchor is unsafe.
+                            if (!shot.beanBrand.isEmpty()
+                                && !shot.profileName.isEmpty()) {
+                                const QString convKey = AIManager::conversationKey(
+                                    shot.beanBrand, shot.beanType, shot.profileName);
+                                AIConversation::appendAssistantTurnForKey(
+                                    convKey, resolvedShotId,
+                                    userPrompt, response, structured);
+                                // Keep the live in-app conversation in
+                                // sync if it has the same key loaded —
+                                // otherwise its next saveToStorage will
+                                // overwrite the just-written turn.
+                                if (aiPtrInner && aiPtrInner->conversation()
+                                    && aiPtrInner->conversation()->storageKey() == convKey) {
+                                    aiPtrInner->conversation()->loadFromStorage();
+                                }
                             }
                             finalize(body);
                         });

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -1774,6 +1774,127 @@ private slots:
         QVERIFY(true);
     }
 
+    // -------------------------------------------------------------
+    // Static appendAssistantTurnForKey (#1055 follow-up: MCP
+    // ai_advisor_invoke write-through). Lets surfaces persist a
+    // user/assistant pair into the conversation at `storageKey`
+    // without going through a live AIConversation. Subsequent
+    // recentAdvice loads see the turn.
+    // -------------------------------------------------------------
+
+    void appendAssistantTurnForKey_writesUserAndAssistantWithShotId()
+    {
+        QSettings s;
+        s.clear();
+        const QString key = "test_append_static";
+
+        QJsonObject sn{
+            {"grinderSetting", "4.75"},
+            {"expectedDurationSec", QJsonArray{32, 38}},
+            {"expectedFlowMlPerSec", QJsonArray{1.0, 1.5}},
+            {"successCondition", "OK"},
+            {"reasoning", "slow flow toward target"}
+        };
+
+        AIConversation::appendAssistantTurnForKey(
+            key, /*shotId=*/8473,
+            QStringLiteral("user prompt content"),
+            QStringLiteral("Try grinder 4.75."),
+            sn);
+
+        // Verify via the static loader that the assistant turn qualifies.
+        const auto turns = AIConversation::loadRecentAssistantTurnsForKey(key, 3);
+        QCOMPARE(turns.size(), 1);
+        QCOMPARE(turns.first().shotId, qint64(8473));
+        QCOMPARE(turns.first().structuredNext.value("grinderSetting").toString(),
+                 QStringLiteral("4.75"));
+
+        // Verify the persisted bytes contain a user message with shotId.
+        const QByteArray raw = QSettings().value(
+            QStringLiteral("ai/conversations/") + key + QStringLiteral("/messages"))
+            .toByteArray();
+        const QJsonArray arr = QJsonDocument::fromJson(raw).array();
+        QCOMPARE(arr.size(), 2);
+        QCOMPARE(arr.at(0).toObject().value("role").toString(), QStringLiteral("user"));
+        QCOMPARE(static_cast<qint64>(arr.at(0).toObject().value("shotId").toDouble()),
+                 qint64(8473));
+        QCOMPARE(arr.at(1).toObject().value("role").toString(), QStringLiteral("assistant"));
+
+        s.clear();
+    }
+
+    void appendAssistantTurnForKey_appendsRatherThanOverwrites()
+    {
+        QSettings s;
+        s.clear();
+        const QString key = "test_append_grows";
+
+        const QJsonObject sn{
+            {"grinderSetting", "4.75"},
+            {"expectedDurationSec", QJsonArray{32, 38}},
+            {"expectedFlowMlPerSec", QJsonArray{1.0, 1.5}},
+            {"successCondition", "OK"},
+            {"reasoning", "r"}
+        };
+
+        AIConversation::appendAssistantTurnForKey(
+            key, 100, "u1", "a1", sn);
+        AIConversation::appendAssistantTurnForKey(
+            key, 105, "u2", "a2", sn);
+
+        // Two pairs => 4 messages.
+        const QByteArray raw = QSettings().value(
+            QStringLiteral("ai/conversations/") + key + QStringLiteral("/messages"))
+            .toByteArray();
+        const QJsonArray arr = QJsonDocument::fromJson(raw).array();
+        QCOMPARE(arr.size(), 4);
+
+        // Static loader returns most-recent-first, capped.
+        const auto turns = AIConversation::loadRecentAssistantTurnsForKey(key, 3);
+        QCOMPARE(turns.size(), 2);
+        QCOMPARE(turns.at(0).shotId, qint64(105));
+        QCOMPARE(turns.at(1).shotId, qint64(100));
+
+        s.clear();
+    }
+
+    void appendAssistantTurnForKey_omitsStructuredNextWhenAbsent()
+    {
+        QSettings s;
+        s.clear();
+        const QString key = "test_append_no_sn";
+
+        AIConversation::appendAssistantTurnForKey(
+            key, 200, "u", "clarifying question, no rec",
+            std::nullopt);
+
+        const QByteArray raw = QSettings().value(
+            QStringLiteral("ai/conversations/") + key + QStringLiteral("/messages"))
+            .toByteArray();
+        QVERIFY2(!raw.contains("structuredNext"),
+                 "absent structuredNext must not be persisted as a key");
+
+        // Loader skips assistant turns missing structuredNext, so this
+        // turn does not qualify for recentAdvice — exactly the MCP
+        // behaviour for a clarifying-question reply.
+        const auto turns = AIConversation::loadRecentAssistantTurnsForKey(key, 3);
+        QVERIFY(turns.isEmpty());
+
+        s.clear();
+    }
+
+    void appendAssistantTurnForKey_emptyKeyIsNoOp()
+    {
+        QSettings s;
+        s.clear();
+        AIConversation::appendAssistantTurnForKey(
+            QString(), 100, "u", "a", std::nullopt);
+        // No assertion needed: this just must not crash and must not
+        // create any settings keys.
+        QVERIFY(true);
+        s.clear();
+    }
+
     void aiConversation_setShotIdForCurrentTurn_legacyConversationHasZeroShotId()
     {
         // A pre-#1053 conversation has no shotId on any entry; reader


### PR DESCRIPTION
## Summary

Closes the gap surfaced when testing #1055's `recentAdvice` block end-to-end: two consecutive `ai_advisor_invoke` MCP calls couldn't populate `recentAdvice` because the MCP path **never wrote to AIConversation**. Only the in-app advisor (QML overlay) was producing turns the closed-loop builder could read back.

This change:

- Adds `AIConversation::appendAssistantTurnForKey` — a static appender that persists a user/assistant turn pair into the conversation at a given storage key without going through a live AIConversation. Same QSettings layout as `saveToStorage`; user turn carries `shotId`, assistant turn carries `shotId` + optional `structuredNext` (matching the schema #1053 / #1054 pinned).
- Wires `ai_advisor_invoke`'s success-path lambda to call it after every recommendation.
- Concurrency: when the in-app `m_conversation` has the same `storageKey()` loaded, the MCP path calls `loadFromStorage()` to refresh in-memory state — otherwise the in-app's next save would overwrite the just-written turn.

End-to-end demonstration on a real two-shot sequence (shots 880 → 881 on the same profile, no synthetic data):

1. `ai_advisor_invoke shot_id=880` (the choked Apr 27 60s shot at grind 4): advisor returns prose plus a structured `nextShot` recommending `grinderSetting: \"5.25\"`. The new appender persists this turn into `ai/conversations/<key>/messages` with `shotId=880`.
2. `ai_advisor_invoke shot_id=884` (a later shot on the same bean+profile, dryRun): the envelope now contains:
   ```json
   \"recentAdvice\": [{
     \"turnsAgo\": 1,
     \"structuredNext\": { \"grinderSetting\": \"5.25\", \"expectedDurationSec\": [33,42], ... },
     \"userResponse\": {
       \"actualNextShotId\": 881,
       \"adherence\": \"followed\",
       \"grinderSetting\": \"5\",
       \"outcomeInPredictedRange\": { \"duration\": false, \"flow\": false }
     }
   }]
   ```
3. The system prompt's rule kicks in: `\"followed\" + outcome out of predicted range ⇒ REVISE direction`.

## Test plan

- [x] 4 new tests in `tst_aimanager.cpp`:
  - `appendAssistantTurnForKey_writesUserAndAssistantWithShotId` — basic write + verifies static loader sees the turn
  - `appendAssistantTurnForKey_appendsRatherThanOverwrites` — two writes produce 4 messages, loader returns most-recent-first
  - `appendAssistantTurnForKey_omitsStructuredNextWhenAbsent` — clarifying-question turns persist without the key, don't qualify for recentAdvice
  - `appendAssistantTurnForKey_emptyKeyIsNoOp` — defensive guard
- [x] All 2013 tests pass clean, zero warnings
- [x] Manual end-to-end: real shots 880 → 884 produce a populated `recentAdvice` block in the envelope (verified above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)