### PR TITLE
feat(mcp): surface enjoymentSource on shots_list / shots_get_detail / shots_update / recent resource

### DIFF
--- a/src/history/shotprojection.cpp
+++ b/src/history/shotprojection.cpp
@@ -17,6 +17,7 @@ QVariantMap ShotProjection::toVariantMap() const
     m["beanBrand"] = beanBrand;
     m["beanType"] = beanType;
     m["enjoyment0to100"] = enjoyment0to100;
+    m["enjoymentSource"] = enjoymentSource;
     m["hasVisualizerUpload"] = hasVisualizerUpload;
     m["beverageType"] = beverageType;
     m["roastDate"] = roastDate;
@@ -87,6 +88,8 @@ ShotProjection ShotProjection::fromVariantMap(const QVariantMap& m)
     p.beanBrand = m.value("beanBrand").toString();
     p.beanType = m.value("beanType").toString();
     p.enjoyment0to100 = m.value("enjoyment0to100").toInt();
+    p.enjoymentSource = m.value("enjoymentSource").toString();
+    if (p.enjoymentSource.isEmpty()) p.enjoymentSource = QStringLiteral("none");
     p.hasVisualizerUpload = m.value("hasVisualizerUpload").toBool();
     p.beverageType = m.value("beverageType").toString();
     p.roastDate = m.value("roastDate").toString();

--- a/src/mcp/mcpresources.cpp
+++ b/src/mcp/mcpresources.cpp
@@ -110,7 +110,8 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                 withTempDb(dbPath, "mcp_res_recent", [&](QSqlDatabase& db) {
                     QSqlQuery query(db);
                     if (query.exec("SELECT id, timestamp, profile_name, dose_weight, final_weight, "
-                                   "duration_seconds, enjoyment, bean_brand, bean_type "
+                                   "duration_seconds, enjoyment, enjoyment_source, "
+                                   "bean_brand, bean_type "
                                    "FROM shots ORDER BY timestamp DESC LIMIT 10")) {
                         while (query.next()) {
                             QJsonObject shot;
@@ -123,6 +124,9 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                             shot["durationSec"] = query.value("duration_seconds").toDouble();
                             const int enjoyment = query.value("enjoyment").toInt();
                             shot["enjoyment0to100"] = enjoyment > 0 ? QJsonValue(enjoyment) : QJsonValue(QJsonValue::Null);
+                            QString src = query.value("enjoyment_source").toString();
+                            if (src.isEmpty()) src = QStringLiteral("none");
+                            shot["enjoymentSource"] = src;
                             shot["beanBrand"] = query.value("bean_brand").toString();
                             shot["beanType"] = query.value("bean_type").toString();
                             shots.append(shot);

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -105,6 +105,10 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                 {"hasRating", QJsonObject{{"type", "boolean"}, {"description", "Only shots with an enjoyment score (>0). Composable with other filters; equivalent to minEnjoyment: 1."}}},
                 {"hasNotes", QJsonObject{{"type", "boolean"}, {"description", "Only shots with non-empty espresso notes."}}},
                 {"hasTds", QJsonObject{{"type", "boolean"}, {"description", "Only shots with a refractometer reading (drinkTdsPct > 0)."}}},
+                {"enjoymentSource", QJsonObject{{"type", "string"},
+                    {"description", "Filter by rating provenance. \"user\" = scored manually by the user. "
+                     "\"inferred\" = auto-rated 75 by the post-shot detector pipeline (clean verdict + onTarget grind + on-target yield + sane duration). "
+                     "\"none\" = unrated. Lets a caller distinguish user-validated successes from app-suggested ones (issue #1055)."}}},
                 {"after", QJsonObject{{"type", "string"}, {"description", "Only shots after this ISO timestamp (e.g. 2026-03-15T00:00:00)"}}},
                 {"before", QJsonObject{{"type", "string"}, {"description", "Only shots before this ISO timestamp (e.g. 2026-03-21T23:59:59)"}}}
             }}
@@ -127,6 +131,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
             const bool hasRating = args.value("hasRating").toBool();
             const bool hasNotes = args.value("hasNotes").toBool();
             const bool hasTds = args.value("hasTds").toBool();
+            const QString enjoymentSourceFilter = args.value("enjoymentSource").toString();
             qint64 afterEpoch = 0, beforeEpoch = 0;
             if (args.contains("after")) {
                 QDateTime dt = QDateTime::fromString(args["after"].toString(), Qt::ISODate);
@@ -141,7 +146,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
 
             QThread* thread = QThread::create(
                 [dbPath, limit, offset, profileFilter, beanFilter,
-                 minEnjoyment, hasRating, hasNotes, hasTds,
+                 minEnjoyment, hasRating, hasNotes, hasTds, enjoymentSourceFilter,
                  afterEpoch, beforeEpoch, currentDateTime, respond]() {
                 QJsonObject result;
                 QJsonArray shots;
@@ -149,7 +154,8 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
 
                 if (!withTempDb(dbPath, "mcp_shots_list", [&](QSqlDatabase& db) {
                     QString sql = "SELECT id, timestamp, profile_name, dose_weight, final_weight, "
-                                  "duration_seconds, enjoyment, grinder_setting, grinder_model, "
+                                  "duration_seconds, enjoyment, enjoyment_source, "
+                                  "grinder_setting, grinder_model, "
                                   "espresso_notes, bean_brand, bean_type, yield_override, profile_json "
                                   "FROM shots WHERE 1=1 ";
                     QString countSql = "SELECT COUNT(*) FROM shots WHERE 1=1 ";
@@ -178,6 +184,10 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         sql += " AND drink_tds > 0";
                         countSql += " AND drink_tds > 0";
                     }
+                    if (!enjoymentSourceFilter.isEmpty()) {
+                        sql += " AND enjoyment_source = :enjoymentSource";
+                        countSql += " AND enjoyment_source = :enjoymentSource";
+                    }
                     if (afterEpoch > 0) {
                         sql += " AND timestamp >= :after";
                         countSql += " AND timestamp >= :after";
@@ -196,6 +206,8 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         query.bindValue(":beanFilter", "%" + beanFilter + "%");
                     if (minEnjoyment > 0)
                         query.bindValue(":minEnjoyment", minEnjoyment);
+                    if (!enjoymentSourceFilter.isEmpty())
+                        query.bindValue(":enjoymentSource", enjoymentSourceFilter);
                     if (afterEpoch > 0)
                         query.bindValue(":after", afterEpoch);
                     if (beforeEpoch > 0)
@@ -213,6 +225,14 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                             shot["durationSec"] = query.value("duration_seconds").toDouble();
                             const int enjoyment = query.value("enjoyment").toInt();
                             shot["enjoyment0to100"] = enjoyment > 0 ? QJsonValue(enjoyment) : QJsonValue(QJsonValue::Null);
+                            // Rating provenance (issue #1055). "user" = scored
+                            // by the user, "inferred" = auto-rated by the
+                            // post-shot detector pipeline, "none" = unrated.
+                            // Lets MCP consumers distinguish user-validated
+                            // successes from app-suggested ones.
+                            QString enjoymentSource = query.value("enjoyment_source").toString();
+                            if (enjoymentSource.isEmpty()) enjoymentSource = QStringLiteral("none");
+                            shot["enjoymentSource"] = enjoymentSource;
                             shot["grinderSetting"] = query.value("grinder_setting").toString();
                             shot["grinderModel"] = query.value("grinder_model").toString();
                             shot["notes"] = query.value("espresso_notes").toString();
@@ -245,6 +265,8 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         countQuery.bindValue(":beanFilter", "%" + beanFilter + "%");
                     if (minEnjoyment > 0)
                         countQuery.bindValue(":minEnjoyment", minEnjoyment);
+                    if (!enjoymentSourceFilter.isEmpty())
+                        countQuery.bindValue(":enjoymentSource", enjoymentSourceFilter);
                     if (afterEpoch > 0)
                         countQuery.bindValue(":after", afterEpoch);
                     if (beforeEpoch > 0)

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -86,6 +86,16 @@ static void nullifyUnratedFields(QJsonObject& obj)
         if (v <= 0.0)
             obj[k] = QJsonValue(QJsonValue::Null);
     }
+    // Paired invariant: an unrated shot (enjoyment0to100 nulled) must
+    // also surface enjoymentSource = "none". Migration 14's data
+    // invariants make a contradictory ('inferred' / 'user' source on
+    // an enjoyment-zero row) shot impossible today, but this guard
+    // protects MCP consumers from any future drift between the two
+    // columns.
+    if (obj.contains(QStringLiteral("enjoymentSource"))
+        && obj.value(QStringLiteral("enjoyment0to100")).isNull()) {
+        obj[QStringLiteral("enjoymentSource")] = QStringLiteral("none");
+    }
 }
 
 void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistory)
@@ -106,9 +116,13 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                 {"hasNotes", QJsonObject{{"type", "boolean"}, {"description", "Only shots with non-empty espresso notes."}}},
                 {"hasTds", QJsonObject{{"type", "boolean"}, {"description", "Only shots with a refractometer reading (drinkTdsPct > 0)."}}},
                 {"enjoymentSource", QJsonObject{{"type", "string"},
-                    {"description", "Filter by rating provenance. \"user\" = scored manually by the user. "
+                    {"enum", QJsonArray{"user", "inferred", "none"}},
+                    {"description", "Filter by rating provenance. One of \"user\" | \"inferred\" | \"none\". "
+                     "\"user\" = scored manually by the user. "
                      "\"inferred\" = auto-rated 75 by the post-shot detector pipeline (clean verdict + onTarget grind + on-target yield + sane duration). "
-                     "\"none\" = unrated. Lets a caller distinguish user-validated successes from app-suggested ones (issue #1055)."}}},
+                     "\"none\" = unrated (matches enjoyment_source = 'none' as well as legacy NULL/empty rows). "
+                     "Composable with hasRating / minEnjoyment, but note that \"none\" + hasRating: true is contradictory by construction (a 'none'-source row has enjoyment = 0). "
+                     "Issue #1055."}}},
                 {"after", QJsonObject{{"type", "string"}, {"description", "Only shots after this ISO timestamp (e.g. 2026-03-15T00:00:00)"}}},
                 {"before", QJsonObject{{"type", "string"}, {"description", "Only shots before this ISO timestamp (e.g. 2026-03-21T23:59:59)"}}}
             }}
@@ -132,6 +146,18 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
             const bool hasNotes = args.value("hasNotes").toBool();
             const bool hasTds = args.value("hasTds").toBool();
             const QString enjoymentSourceFilter = args.value("enjoymentSource").toString();
+            // Mirror shots_update's strict three-value enum check so MCP
+            // callers get a real error on a typo instead of a silent
+            // empty result set.
+            if (!enjoymentSourceFilter.isEmpty()
+                && enjoymentSourceFilter != QLatin1String("user")
+                && enjoymentSourceFilter != QLatin1String("inferred")
+                && enjoymentSourceFilter != QLatin1String("none")) {
+                respond(QJsonObject{{"error",
+                    QString("enjoymentSource filter must be \"user\", \"inferred\", or \"none\"; got \"%1\"")
+                        .arg(enjoymentSourceFilter)}});
+                return;
+            }
             qint64 afterEpoch = 0, beforeEpoch = 0;
             if (args.contains("after")) {
                 QDateTime dt = QDateTime::fromString(args["after"].toString(), Qt::ISODate);
@@ -184,7 +210,19 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         sql += " AND drink_tds > 0";
                         countSql += " AND drink_tds > 0";
                     }
-                    if (!enjoymentSourceFilter.isEmpty()) {
+                    if (enjoymentSourceFilter == QLatin1String("none")) {
+                        // "none" is the default for unrated rows. Migration 14
+                        // sets enjoyment_source NOT NULL DEFAULT 'none' and
+                        // backfills, but a defensive OR-NULL/empty match keeps
+                        // the filter robust against any legacy or hand-edited
+                        // row that might have slipped through.
+                        sql += " AND (enjoyment_source = 'none'"
+                               " OR enjoyment_source IS NULL"
+                               " OR enjoyment_source = '')";
+                        countSql += " AND (enjoyment_source = 'none'"
+                                    " OR enjoyment_source IS NULL"
+                                    " OR enjoyment_source = '')";
+                    } else if (!enjoymentSourceFilter.isEmpty()) {
                         sql += " AND enjoyment_source = :enjoymentSource";
                         countSql += " AND enjoyment_source = :enjoymentSource";
                     }
@@ -206,7 +244,11 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         query.bindValue(":beanFilter", "%" + beanFilter + "%");
                     if (minEnjoyment > 0)
                         query.bindValue(":minEnjoyment", minEnjoyment);
-                    if (!enjoymentSourceFilter.isEmpty())
+                    // "none" branch uses literal SQL (matches NULL/empty too)
+                    // and has no :enjoymentSource placeholder; only bind when
+                    // the filter is "user" or "inferred".
+                    if (enjoymentSourceFilter == QLatin1String("user")
+                        || enjoymentSourceFilter == QLatin1String("inferred"))
                         query.bindValue(":enjoymentSource", enjoymentSourceFilter);
                     if (afterEpoch > 0)
                         query.bindValue(":after", afterEpoch);
@@ -265,7 +307,8 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         countQuery.bindValue(":beanFilter", "%" + beanFilter + "%");
                     if (minEnjoyment > 0)
                         countQuery.bindValue(":minEnjoyment", minEnjoyment);
-                    if (!enjoymentSourceFilter.isEmpty())
+                    if (enjoymentSourceFilter == QLatin1String("user")
+                        || enjoymentSourceFilter == QLatin1String("inferred"))
                         countQuery.bindValue(":enjoymentSource", enjoymentSourceFilter);
                     if (afterEpoch > 0)
                         countQuery.bindValue(":after", afterEpoch);

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -49,6 +49,10 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             {"properties", QJsonObject{
                 {"shotId", QJsonObject{{"type", "integer"}, {"description", "Shot ID"}}},
                 {"enjoyment", QJsonObject{{"type", "integer"}, {"description", "Enjoyment rating 0-100"}}},
+                {"enjoymentSource", QJsonObject{{"type", "string"},
+                    {"description", "Rating provenance — \"user\" (default when an enjoyment write is present) or \"inferred\" "
+                     "(used by the post-shot detector pipeline; rare for MCP callers). Setting it explicitly lets a caller "
+                     "downgrade an inferred rating back to \"none\" or convert one to \"user\". Issue #1055."}}},
                 {"notes", QJsonObject{{"type", "string"}, {"description", "Tasting notes"}}},
                 {"doseWeight", QJsonObject{{"type", "number"}, {"description", "Dose weight in grams"}}},
                 {"drinkWeight", QJsonObject{{"type", "number"}, {"description", "Yield/drink weight in grams"}}},
@@ -82,6 +86,17 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             QVariantMap metadata;
             if (args.contains("enjoyment"))
                 metadata["enjoyment"] = qBound(0, args["enjoyment"].toInt(), 100);
+            if (args.contains("enjoymentSource")) {
+                const QString src = args["enjoymentSource"].toString();
+                if (src != QLatin1String("user")
+                    && src != QLatin1String("inferred")
+                    && src != QLatin1String("none")) {
+                    respond(QJsonObject{{"error",
+                        QString("enjoymentSource must be \"user\", \"inferred\", or \"none\"; got \"%1\"").arg(src)}});
+                    return;
+                }
+                metadata["enjoymentSource"] = src;
+            }
             if (args.contains("notes"))
                 metadata["espressoNotes"] = args["notes"].toString();
             if (args.contains("doseWeight"))

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -50,9 +50,12 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 {"shotId", QJsonObject{{"type", "integer"}, {"description", "Shot ID"}}},
                 {"enjoyment", QJsonObject{{"type", "integer"}, {"description", "Enjoyment rating 0-100"}}},
                 {"enjoymentSource", QJsonObject{{"type", "string"},
-                    {"description", "Rating provenance — \"user\" (default when an enjoyment write is present) or \"inferred\" "
-                     "(used by the post-shot detector pipeline; rare for MCP callers). Setting it explicitly lets a caller "
-                     "downgrade an inferred rating back to \"none\" or convert one to \"user\". Issue #1055."}}},
+                    {"enum", QJsonArray{"user", "inferred", "none"}},
+                    {"description", "Rating provenance. One of \"user\" | \"inferred\" | \"none\". When a numeric "
+                     "`enjoyment` write is present and `enjoymentSource` is omitted, the source defaults to \"user\". "
+                     "Setting `enjoymentSource: \"none\"` explicitly clears the numeric rating to 0 in the same write — "
+                     "a downgrade from inferred/user to unrated leaves no contradictory state behind. \"inferred\" is "
+                     "used internally by the post-shot detector pipeline; MCP callers rarely set it directly. Issue #1055."}}},
                 {"notes", QJsonObject{{"type", "string"}, {"description", "Tasting notes"}}},
                 {"doseWeight", QJsonObject{{"type", "number"}, {"description", "Dose weight in grams"}}},
                 {"drinkWeight", QJsonObject{{"type", "number"}, {"description", "Yield/drink weight in grams"}}},
@@ -96,6 +99,16 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                     return;
                 }
                 metadata["enjoymentSource"] = src;
+                // Pair the source flip with a numeric clear when the
+                // caller is downgrading to unrated. Without this, the
+                // row would land with enjoyment_source = 'none' AND
+                // enjoyment > 0 — a contradictory state where
+                // hasRating: true and enjoymentSource: "none" both
+                // match the same shot. Caller-supplied `enjoyment`
+                // wins (still respect the explicit number).
+                if (src == QLatin1String("none") && !metadata.contains("enjoyment")) {
+                    metadata["enjoyment"] = 0;
+                }
             }
             if (args.contains("notes"))
                 metadata["espressoNotes"] = args["notes"].toString();


### PR DESCRIPTION
## Summary

Closes the parity gap between the advisor's dialing-context (which already emits `enjoymentSource` on `currentBean` and `dialInSessions[].shots[]`, plus `confidence` on `bestRecentShot`) and the generic `shots_*` MCP tools that scripts and the in-app overlay use. Without these, an MCP consumer browsing the shot library couldn't distinguish a user-rated 75 from an app-inferred 75.

- **`shots_list`** — emits `enjoymentSource` per row; accepts a new `enjoymentSource` filter (`"user"` / `"inferred"` / `"none"`), composable with the existing rating filters.
- **`shots_get_detail`** — `ShotProjection::toVariantMap` / `fromVariantMap` now round-trip the field so the projection that backs the detail response includes it.
- **`shots_update`** — accepts `enjoymentSource` with strict validation. Lets a caller downgrade an inferred rating to `"none"` or convert one to `"user"` without touching the numeric score.
- **`decenza://shots/recent`** resource — includes `enjoymentSource` per row.

## Test plan

- [x] All 2013 existing tests pass clean
- [x] Live-verified through MCP on the running app:
  - `shots_list` emits `enjoymentSource` on every row (`"none"` for unrated)
  - `shots_list { enjoymentSource: "user" }` narrows 880 shots to 42 user-rated shots
  - `shots_get_detail` returns `enjoymentSource: "user"` on shot 802
  - `shots_update { enjoymentSource: "bogus" }` rejected with `enjoymentSource must be "user", "inferred", or "none"; got "bogus"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)