### PR TITLE
fix(ai): mark buildShotAnalysisProseForShot Q_INVOKABLE so QML can call it

### DIFF
--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -132,11 +132,14 @@ public:
     // Prose-only shot analysis — no JSON envelope, no double-shipped
     // structured fields. Used by `dialing_get_context` to populate
     // `result.shotAnalysis` (the structured fields already live at the
-    // top level of the response). The prose is identical to the
-    // `shotAnalysis` field inside `buildUserPromptObjectForShot(shot)`
-    // when that envelope is built in `Standalone` mode — both paths call
+    // top level of the response), and by the in-app conversation
+    // overlay's QML to seed change-detection prose for the AI Advice
+    // button (qml/components/ConversationOverlay.qml). The prose is
+    // identical to the `shotAnalysis` field inside
+    // `buildUserPromptObjectForShot(shot)` when that envelope is built
+    // in `Standalone` mode — both paths call
     // `ShotSummarizer::renderShotAnalysisProse` with `RenderMode::Standalone`.
-    QString buildShotAnalysisProseForShot(const ShotProjection& shotData);
+    Q_INVOKABLE QString buildShotAnalysisProseForShot(const ShotProjection& shotData);
 
     // Merge the four dialing-context blocks into a user-prompt envelope.
     // Both the in-app advisor and `ai_advisor_invoke` call this on the


### PR DESCRIPTION
## Summary

The in-app AI advisor button on `PostShotReviewPage` silently failed with:

```
qrc:/qt/qml/Decenza/qml/components/ConversationOverlay.qml:121: TypeError:
Property 'buildShotAnalysisProseForShot' of object AIManager(...) is not a function
```

`buildShotAnalysisProseForShot` was added by #1046 (drop nested envelope) to replace the previous QML call to `generateHistoryShotSummary`, but the new method was never marked `Q_INVOKABLE`. QML's meta-object lookup returned undefined and the advisor stayed dark on every shot tap.

The fix is the missing `Q_INVOKABLE`. Doc-comment expanded to call out the QML caller (`qml/components/ConversationOverlay.qml`) so the next refactor doesn't lose the marker again.

## Test plan

- [x] Local build clean
- [ ] Manual: open PostShotReviewPage on a shot, tap "Discuss with AI" — overlay opens with the shot summary populated. (Pending user verification on the live app.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)