### PR TITLE
fix(relay): tear down screen capture when phone goes silent

### DIFF
--- a/src/network/relayclient.cpp
+++ b/src/network/relayclient.cpp
@@ -14,6 +14,11 @@ static constexpr int kReconnectBaseMs = 5000;
 static constexpr int kReconnectMaxMs = 60000;
 static constexpr int kPingIntervalMs = 5 * 60 * 1000;  // 5 minutes
 static constexpr int kStatusPushIntervalMs = 5000;      // 5 seconds
+// Tear down screen capture if the phone goes silent for this long. The phone
+// is expected to send a "keepalive" relay_command at a faster cadence (~10s)
+// while the remote-control screen is foregrounded; explicit touches and
+// other commands also count as activity.
+static constexpr int kRemoteActivityTimeoutMs = 30000;
 static const QString kRelayUrl = QStringLiteral("wss://ws.decenza.coffee");
 
 RelayClient::RelayClient(DE1Device* device, MachineState* machineState,
@@ -34,6 +39,10 @@ RelayClient::RelayClient(DE1Device* device, MachineState* machineState,
     connect(&m_pingTimer, &QTimer::timeout, this, &RelayClient::onPingTimer);
 
     connect(&m_statusPushTimer, &QTimer::timeout, this, &RelayClient::pushStatus);
+
+    m_remoteActivityTimer.setSingleShot(true);
+    connect(&m_remoteActivityTimer, &QTimer::timeout,
+            this, &RelayClient::onRemoteActivityTimeout);
 
     // Trigger immediate status push on state changes
     if (m_device) {
@@ -70,6 +79,7 @@ void RelayClient::setEnabled(bool enabled)
         m_reconnectTimer.stop();
         m_pingTimer.stop();
         m_statusPushTimer.stop();
+        m_remoteActivityTimer.stop();
         m_reconnectAttempts = 0;
         // Destroy capture service synchronously BEFORE closing the socket.
         // m_socket.close() is async — onDisconnected() fires later, but by then
@@ -93,6 +103,7 @@ void RelayClient::shutdown()
     m_reconnectTimer.stop();
     m_pingTimer.stop();
     m_statusPushTimer.stop();
+    m_remoteActivityTimer.stop();
     m_enabled = false;
     m_socket.abort();
 }
@@ -141,9 +152,11 @@ void RelayClient::onConnected()
 
 void RelayClient::onDisconnected()
 {
-    qDebug() << "RelayClient: WebSocket disconnected";
+    qDebug() << "RelayClient: WebSocket disconnected — wasCapturing="
+             << static_cast<bool>(m_captureService);
     m_pingTimer.stop();
     m_statusPushTimer.stop();
+    m_remoteActivityTimer.stop();
     m_captureService.reset();
     emit connectedChanged();
 
@@ -168,11 +181,18 @@ void RelayClient::onTextMessageReceived(const QString& message)
     if (type == "relay_command") {
         QString commandId = obj["command_id"].toString();
         QString command = obj["command"].toString();
+        qDebug() << "RelayClient: relay_command received:" << command
+                 << "id:" << commandId;
+        // Treat any phone-originated command as activity. Reset BEFORE running
+        // the handler so that handlers which start the timer (start_remote)
+        // overwrite this value with a fresh full-window restart.
+        noteRemoteActivity();
         handleCommand(commandId, command);
     } else if (type == "registered") {
         qDebug() << "RelayClient: Successfully registered with relay";
     } else if (type == "binary_relay") {
-        // Decode base64 data and handle as binary
+        // Decode base64 data and handle as binary. noteRemoteActivity() runs
+        // inside onBinaryMessageReceived after the type byte is checked.
         QByteArray binaryData = QByteArray::fromBase64(obj["data"].toString().toLatin1());
         onBinaryMessageReceived(binaryData);
     } else {
@@ -218,12 +238,26 @@ void RelayClient::handleCommand(const QString& commandId, const QString& command
         m_lastStatusJson.clear();
         pushStatus();
     } else if (command == "start_remote") {
-        if (m_window && !m_captureService) {
+        if (!m_window) {
+            qWarning() << "RelayClient: start_remote ignored — window not yet wired";
+        } else if (m_captureService) {
+            qDebug() << "RelayClient: start_remote ignored — capture already active";
+            m_remoteActivityTimer.start(kRemoteActivityTimeoutMs);
+        } else {
+            qDebug() << "RelayClient: start_remote — creating ScreenCaptureService";
             double scale = 0.5;
             m_captureService = std::make_unique<ScreenCaptureService>(m_window, &m_socket, scale);
+            m_remoteActivityTimer.start(kRemoteActivityTimeoutMs);
         }
     } else if (command == "stop_remote") {
+        const bool wasActive = static_cast<bool>(m_captureService);
+        qDebug() << "RelayClient: stop_remote — wasActive=" << wasActive;
         m_captureService.reset();
+        m_remoteActivityTimer.stop();
+    } else if (command == "keepalive") {
+        // No-op. The activity bump already happened in onTextMessageReceived.
+        // Skip the command_response below to keep the channel quiet.
+        return;
     } else {
         qDebug() << "RelayClient: Unknown command:" << command;
     }
@@ -289,6 +323,22 @@ void RelayClient::onBinaryMessageReceived(const QByteArray& data)
     if (data.isEmpty()) return;
     quint8 type = static_cast<quint8>(data[0]);
     if (type == 0x02 && m_captureService) {
+        noteRemoteActivity();
         m_captureService->handleTouchEvent(data);
     }
+}
+
+void RelayClient::noteRemoteActivity()
+{
+    if (m_captureService) {
+        // Restarts the single-shot timer if already running.
+        m_remoteActivityTimer.start(kRemoteActivityTimeoutMs);
+    }
+}
+
+void RelayClient::onRemoteActivityTimeout()
+{
+    qWarning() << "RelayClient: no remote activity for" << kRemoteActivityTimeoutMs
+               << "ms — tearing down ScreenCaptureService";
+    m_captureService.reset();
 }

--- a/src/network/relayclient.cpp
+++ b/src/network/relayclient.cpp
@@ -14,10 +14,10 @@ static constexpr int kReconnectBaseMs = 5000;
 static constexpr int kReconnectMaxMs = 60000;
 static constexpr int kPingIntervalMs = 5 * 60 * 1000;  // 5 minutes
 static constexpr int kStatusPushIntervalMs = 5000;      // 5 seconds
-// Tear down screen capture if the phone goes silent for this long. The phone
-// is expected to send a "keepalive" relay_command at a faster cadence (~10s)
-// while the remote-control screen is foregrounded; explicit touches and
-// other commands also count as activity.
+// Tear down screen capture if the phone goes silent for this long. Explicit
+// touches and relay commands count as activity. The phone will eventually send
+// a "keepalive" relay_command at ~10s cadence once DecenzaPocket implements it;
+// until then, idle viewing without touches is cut off at 30 s.
 static constexpr int kRemoteActivityTimeoutMs = 30000;
 static const QString kRelayUrl = QStringLiteral("wss://ws.decenza.coffee");
 
@@ -192,7 +192,7 @@ void RelayClient::onTextMessageReceived(const QString& message)
         qDebug() << "RelayClient: Successfully registered with relay";
     } else if (type == "binary_relay") {
         // Decode base64 data and handle as binary. noteRemoteActivity() runs
-        // inside onBinaryMessageReceived after the type byte is checked.
+        // inside onBinaryMessageReceived only for type 0x02 when capture is active.
         QByteArray binaryData = QByteArray::fromBase64(obj["data"].toString().toLatin1());
         onBinaryMessageReceived(binaryData);
     } else {
@@ -226,8 +226,6 @@ void RelayClient::onPingTimer()
 
 void RelayClient::handleCommand(const QString& commandId, const QString& command)
 {
-    qDebug() << "RelayClient: Handling command:" << command << "id:" << commandId;
-
     if (command == "wake") {
         if (m_device) m_device->wakeUp();
     } else if (command == "sleep") {

--- a/src/network/relayclient.h
+++ b/src/network/relayclient.h
@@ -47,9 +47,12 @@ private:
     void handleCommand(const QString& commandId, const QString& command);
     void pushStatus();
     QJsonObject buildStatusJson() const;
-    // Restart the watchdog whenever inbound traffic from the phone arrives.
-    // Without this, an OS-killed phone leaves the capture loop running forever
-    // because the tablet's own WS to AWS stays alive (5-min ping keeps it open).
+    // Restart the inactivity watchdog whenever the phone sends any traffic.
+    // The tablet uses a time-based fallback here because the AWS relay proxy
+    // keeps the tablet↔AWS socket alive (5-min ping) after the phone dies, so
+    // onDisconnected() never fires for the phone's disconnection. The correct
+    // long-term fix is a relay-server peer_disconnected event; until that
+    // exists, the watchdog timer is the only available signal.
     void noteRemoteActivity();
 
     QWebSocket m_socket;

--- a/src/network/relayclient.h
+++ b/src/network/relayclient.h
@@ -40,17 +40,23 @@ private slots:
     void onReconnectTimer();
     void onPingTimer();
     void onBinaryMessageReceived(const QByteArray& data);
+    void onRemoteActivityTimeout();
 
 private:
     void connectToRelay();
     void handleCommand(const QString& commandId, const QString& command);
     void pushStatus();
     QJsonObject buildStatusJson() const;
+    // Restart the watchdog whenever inbound traffic from the phone arrives.
+    // Without this, an OS-killed phone leaves the capture loop running forever
+    // because the tablet's own WS to AWS stays alive (5-min ping keeps it open).
+    void noteRemoteActivity();
 
     QWebSocket m_socket;
     QTimer m_reconnectTimer;
     QTimer m_pingTimer;
     QTimer m_statusPushTimer;
+    QTimer m_remoteActivityTimer;
     DE1Device* m_device;
     MachineState* m_machineState;
     Settings* m_settings;


### PR DESCRIPTION
## Summary
- Adds a 30s activity watchdog in `RelayClient` so that `ScreenCaptureService` is torn down when the phone is OS-killed or loses network — the existing teardown paths (`stop_remote` and `onDisconnected`) are unreachable in that scenario because the tablet's own WS to AWS stays alive (5-min ping prevents idle timeout).
- Recognizes a `keepalive` relay_command as a no-op so DecenzaPocket can hold the session open while the user is just viewing without touching.
- Adds layered logs (`relay_command received: <cmd>`, `start_remote — creating ScreenCaptureService` / `…ignored — capture already active` / `…ignored — window not yet wired`, `stop_remote — wasActive=…`, `WebSocket disconnected — wasCapturing=…`) so the full message path is observable if this ever regresses.

## Why
Tablet logs showed `ScreenCaptureService: sent 1 tiles, 441 bytes` continuously after DecenzaPocket was backgrounded or killed. Root cause: tablet ↔ AWS WebSocket stays open independently of phone ↔ AWS, so neither `stop_remote` (phone may be killed before sending) nor `onDisconnected` (tablet's own WS still alive) fires.

The watchdog is a defense-in-depth backstop — `stop_remote` and `onDisconnected` still tear down capture immediately when reachable; the watchdog only fires when both paths fail.

## Phone-side contract
DecenzaPocket should send `relay_command: "keepalive"` at <30s cadence while the remote-control screen is foregrounded. Until that lands, idle viewing without touches will be cut off after 30s. Tunable at `relayclient.cpp:21` (`kRemoteActivityTimeoutMs`).

## Test plan
- [x] Pair phone, start remote, then graceful background → tablet logs `stop_remote — wasActive= true` immediately, `ScreenCaptureService: stopped`, no further `sent N tiles`. (Confirmed on device.)
- [ ] Pair phone, start remote, then **force-stop** DecenzaPocket from Android settings (no graceful background) → tablet should log `RelayClient: no remote activity for 30000 ms — tearing down ScreenCaptureService` followed by `ScreenCaptureService: stopped` within ~30s.
- [ ] Pair phone, start remote, drop tablet WiFi → `WebSocket disconnected — wasCapturing= true`, capture stops.
- [ ] Phone reconnects after a kill → no auto-resume; fresh `start_remote` required (existing behavior, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)