### PR TITLE
Cross-profile UGS grind ordering + open MCP guidance to all clients

### DIFF
--- a/docs/CLAUDE_MD/MCP_SERVER.md
+++ b/docs/CLAUDE_MD/MCP_SERVER.md
@@ -223,7 +223,7 @@ This avoids holding HTTP connections and works naturally with the conversational
 | Tool | Description | Category |
 |------|-------------|----------|
 | `debug_get_log` | Read the persisted app debug log. Three modes: (1) `sessions=true` lists all sessions with index/start line/timestamp/line count; (2) `session=N` returns lines from that session (-1 = most recent); (3) default — raw line-based pagination via `offset`/`limit` (1–2000 lines). | read |
-| `get_agent_file` | Returns the current Decenza `claude_agent.md` system-prompt content + the app's version string. Used by Claude Code Remote Control sessions to self-update their CLAUDE.md so agent instructions evolve with app updates without manual user intervention. | read |
+| `get_agent_file` | Returns the current Decenza `claude_agent.md` system-prompt content + the app's version string. Any MCP client (Claude Desktop, Claude mobile, Claude Code, etc.) should call this at session start to load behavioral guidance for dialing assistance. Clients with filesystem access (Claude Code Remote Control) additionally use the version to self-update a local CLAUDE.md. | read |
 
 ### AI Dial-In Conversation (key feature)
 

--- a/docs/PROFILE_KNOWLEDGE_BASE.md
+++ b/docs/PROFILE_KNOWLEDGE_BASE.md
@@ -86,6 +86,7 @@ All other lines are free-form `Field: value` pairs consumed verbatim by the AI s
 | `DO NOT flag ...` | Explicit suppression instruction for the AI (plain sentence, no colon required) |
 | `Note:` | Clarifications or disambiguation |
 | `AnalysisFlags:` | Parsed by code — see above |
+| `Skip-Catalog:` | When `true`, the section is excluded from `buildProfileCatalog()`'s one-liner list and is also lifted out of normal profile-match injection. Used for cross-cutting reference sections (e.g. `## Cross-Profile Grind Ordering`) that aren't actual profiles but live in the KB so they're parseable and editable alongside profile entries. |
 
 The display renderer (`ProfileSelectorPage.qml`) bolds lines matching `Label: value` where the label is ≤35 characters and the line does not start with `-` (bullet lines are never bolded), italicizes `DO NOT` lines, and hides `Also matches:` and `AnalysisFlags:` lines entirely. All KB text is HTML-escaped before rendering.
 
@@ -96,6 +97,76 @@ The display renderer (`ProfileSelectorPage.qml`) bolds lines matching `Label: va
 2. Prefix match — title starts with a known key, or a known key starts with the title
 3. Substring fuzzy match — known key (≥4 chars) is contained within the normalized title
 4. Editor-type fallback — `dflow` or `D-Flow` → D-Flow entry, `aflow` or `A-Flow` → A-Flow entry
+
+---
+
+## Cross-Profile Grind Ordering
+
+Skip-Catalog: true
+
+The Universal Grind Setting (UGS) chart `[SRC:ugs-chart]` places 16 mainstream DE1 profiles on a relative grind axis. Cremina anchors UGS 0 (finest); Rao Allongé anchors UGS 8 (coarsest). A few profiles fall slightly below 0. The same physical grinder setting will produce very different shots across this range, so when a user switches profiles you should expect — and surface — a directional change in their grind.
+
+### CRITICAL: UGS values are NOT grinder clicks
+
+UGS is a **relative scale**, not a unit of grinder adjustment. Mapping UGS distance to actual grinder steps requires the user to pull two anchor shots (Cremina at UGS 0 and Rao Allongé at UGS 8) and report their grinder settings — only then is the conversion `(anchor8 - anchor0) / 8` known. Without that calibration:
+
+- The same 0.5 UGS distance might be ~1–2 clicks on a Niche Zero (0–50 numeric scale), ~50–200 microns on a micron-scale lab burr grinder, or an unmappable fractional step on an A–Z letter-coded hand grinder. UGS values themselves are imaginary — they don't exist on any user's grinder dial.
+- Hand grinders that step by letter (A, B, C…) or unlabelled detents make UGS arithmetic meaningless. Only direction translates ("finer" / "coarser"); fractional UGS distances do not.
+- Two users on the same profile but different grinders may have grinder settings 4× apart for the same UGS position.
+
+**Operational rule**: treat UGS distance as **directional information** ("D-Flow is finer than Adaptive v2"). Never translate a UGS distance into a grinder-click count or absolute setting. Concrete grinder numbers must come from `shots_list` history, never from UGS arithmetic. If the user wants magnitude, either cite a specific reference shot or stay qualitative ("a touch coarser", "meaningfully coarser").
+
+### Canonical UGS positions (from the UGS chart)
+
+| UGS | Profile | Notes |
+|-----|---------|-------|
+| -0.5 | Blooming Espresso | Finer than Cremina — survives the 30s soak without premature gushing. |
+| -0.5 | Blooming Allongé | Ultra-light Nordic-style filter roasts. |
+| 0 | **Cremina** | Fine anchor. Max puck resistance, high-temp long-contact extraction. |
+| 0 | Londinium / LRv3 | Same fine grind as Cremina for pressurized pre-infusion soak. |
+| 0.5 | D-Flow | Fast fill, pressurized soak, nuanced pressure rise. |
+| 0.75 | Best Overall Pressure | Rise to ~8.6 bar, declining to ~6 bar. |
+| 0.75 | Default | Standard espresso starting point. |
+| 1.25 | Adaptive v2 | Slightly coarser to favor flow-driven clarity. |
+| 1.25 | Flat 9 Bar (E61) | Constant 9 bar, no pre-infusion. |
+| 1.5 | A-Flow | Long soak "heals" a slightly coarser, faster-flowing puck. |
+| 1.5 | Extractamundo Dos | 6-bar low pressure allows a coarser, "juicier" window. |
+| 2 | Gentle & Sweet | Constant 6 bar, 2–3 ml/s flow. |
+| 5 | Turbo Shot | The "clarity jump" — ~15s with 6-bar ceiling. |
+| 6 | TurboTurbo | Even less resistance; leans toward Allongé flow rate. |
+| 7 | Blooming Allongé (hybrid) | Bloom + high-flow percolation for ultralights. |
+| 8 | **Rao Allongé** | Coarse anchor. Max flow (~4.5 ml/s). |
+
+**Important pattern**: most traditional espresso profiles cluster between 0 and 2 — the difference between Cremina and Gentle & Sweet is only ~2 grinder steps, not a huge swing. There is a large gap between traditional espresso (≤2) and turbo/allongé territory (5+).
+
+### Inferred positions (not in the UGS chart)
+
+These positions are **not** from the UGS calculator. They are reasoned estimates from profile mechanics, citations, and observed user shot history. Treat them as approximate and verify against the user's `shots_list` history when available.
+
+| UGS (est.) | Profile | Rationale |
+|------------|---------|-----------|
+| ~0.25 | **80's Espresso** | Lever-decline mechanic but with an unusual low-temperature regime (82°C declining to 72°C). The low extraction temperature reduces solubility, requiring a finer grind than the temperature-normal lever group to compensate. Observed in user shot history to pull significantly finer than D-Flow on the same bean. `[SRC:dark-video]` characterizes 80's as "slightly coarser than the lever group" — placing it just above Cremina/Londinium at UGS 0 but below D-Flow at UGS 0.5. |
+| ~0–0.5 | Damian's LRv2, LRv3, LM Leva, Q | Londinium / D-Flow adjacent; treat as the same family. |
+| ~1.25 | Classic Italian / Gentler 8.4 Bar / Italian Australian | Constant-pressure family, behaves like Flat 9 Bar. `[SRC:bc-classic-italian]` |
+| ~5–7 | Hendon Turbo, TurboBloom, Nu Skool, Pour Over Basket | High-flow turbo/filter territory. |
+
+For any profile not listed here or in the UGS chart, say so plainly and lean on `shots_list` history.
+
+### Roast-level transitions on the same profile
+
+When the user changes the **roast** of their bean while staying on the same profile, the grind direction is dominated by roast level — NOT by the naive "denser bean = finer grind" heuristic, which only applies to same-roast-level beans of differing density.
+
+- **Dark → medium roast: GRIND COARSER.** Dark roasts are more porous and brittle, generate more fines, and extract faster than medium roasts at the same grinder setting. A medium roast at the dark-roast setting will choke the shot or extract sour. Open the grind up; bumping temperature 1–2°C also helps without requiring a finer grind.
+- **Light → medium roast: GRIND FINER.** Light roasts are dense and hard to extract, often pulled at very coarse settings on flow-style profiles. Mediums are more soluble and want a tighter grind for typical 1:2 espresso ratios.
+- **Same roast, different origin or processing**: small adjustments. Defer to the user's historical settings on similar beans rather than applying a generic rule.
+
+### How to use this ordering
+
+1. **When the user transitions between profiles**, name the direction qualitatively and the UGS gap as relative context ("D-Flow at UGS 0.5 → Blooming Espresso at UGS -0.5 is about 1 UGS step finer — significantly finer; plan 3+ shots to dial in"). Do NOT translate the UGS gap into grinder clicks or microns — UGS is a relative scale that requires anchor calibration to map onto any specific grinder.
+2. **When the user transitions between roasts on the same profile**, state the direction the roast change implies, then ground it in their actual shot history by calling `shots_list` filtered by `profileName`. The user's own past pulls on similar roast levels are a stronger anchor than this ordering.
+3. **Concrete grinder numbers come from shot history, not from this table.** When recommending magnitude, either cite a specific reference shot from `shots_list` ("you pulled this profile at grinder setting 7 on a similar bean") or stay qualitative ("a touch coarser", "noticeably coarser"). Never recommend "X UGS coarser" as a grinder-click instruction.
+
+Sources: positions taken verbatim from the UGS calculator's profile list `[SRC:ugs-chart]` (Mark Renowden, see GitHub issue #500). Profiles outside the UGS chart are inferred from the qualitative relationships documented in the per-profile sections below.
 
 ---
 
@@ -116,6 +187,7 @@ All DE1 profiles descend from four fundamental approaches. `[SRC:4mothers]`
 
 ### D-Flow
 
+- **UGS**: 0.5 (canonical) `[SRC:ugs-chart]`
 - **Category**: Lever/Flow hybrid `[SRC:medium]`
 - **How it works**: Combines pressure and flow control; pressurized pre-infusion followed by flow-controlled pour. Adapts to grind coarseness. Fast fill, pressurized soak at ~3 bar until scale reads target dripping weight (default 4g), then pressure rise with flow limit. `[SRC:medium]` `[SRC:medium-video]`
 - **Key advantage**: Ability to "heal" uneven puck preparation — the long pressurized soak under pressure repairs uneven puck distribution, producing linear extraction even when prep was poor `[SRC:medium]` `[SRC:medium-video]`
@@ -136,6 +208,7 @@ All DE1 profiles descend from four fundamental approaches. `[SRC:4mothers]`
 
 ### A-Flow
 
+- **UGS**: 1.5 (canonical) `[SRC:ugs-chart]`
 - **Creator**: Janek (Jan-Erling Johnsen) `[SRC:bc-aflow]`
 - **Category**: Pressure-ramp into flow extraction `[SRC:bc-aflow]`
 - **How it works**: Created as a mix of D-Flow and Adaptive. Fill and optional infuse/soak, then pressure ramps UP to target (~9–10 bar), then switches to flow-controlled extraction with a pressure limiter. The defining difference from D-Flow: pressure intentionally RISES before extraction rather than starting high and declining. Works with all grinder types including conical. `[SRC:bc-aflow]`
@@ -155,6 +228,7 @@ All DE1 profiles descend from four fundamental approaches. `[SRC:4mothers]`
 
 ### Adaptive v2
 
+- **UGS**: 1.25 (canonical) `[SRC:ugs-chart]`
 - **Category**: Flow/adaptive `[SRC:medium]`
 - **How it works**: Rises pressure to 8.6 bar for ~4 seconds, then attempts sequential flow-rate steps from 3.5 ml/s down to 0.5 ml/s, locking in whatever flow rate exists when pressure peaks. Effectively adapts to grind size. `[SRC:adaptive-adastra]`
 - **V2 change from V1**: Pre-infusion is no longer pressurized — water fills, hits high pressure briefly, then water is turned off and pressure declines on its own. This prevents gushing with large flat burr grinders and light roasts where pressurized soak would cause water to pour through. `[SRC:light-video]`
@@ -185,6 +259,7 @@ All DE1 profiles descend from four fundamental approaches. `[SRC:4mothers]`
 
 ### Blooming Espresso
 
+- **UGS**: -0.5 (canonical — finer than Cremina anchor) `[SRC:ugs-chart]`
 - **Category**: Blooming `[SRC:4mothers]`
 - **How it works**: Fill at ~7-8 ml/s until pressure peaks, close valve for 30s bloom (aim for first drips around this time), then open to desired pressure. `[SRC:eaf-profiling]`
 - **Grind**: Fine — grind as fine as manageable. Bloom allows use of finer grind. `[SRC:eaf-profiling]` `[SRC:rao-blooming]`
@@ -209,6 +284,7 @@ All DE1 profiles descend from four fundamental approaches. `[SRC:4mothers]`
 
 ### Blooming Allonge
 
+- **UGS**: -0.5 (canonical, original) and 7 (canonical, ultralight hybrid variant) `[SRC:ugs-chart]`
 - **Category**: Blooming/Allonge hybrid `[SRC:eaf-profiling]`
 - **Grind**: Ultra-fine or Turkish `[SRC:eaf-profiling]`
 - **Fill**: ~7-8 ml/s until pressure peaks `[SRC:eaf-profiling]`
@@ -220,6 +296,7 @@ All DE1 profiles descend from four fundamental approaches. `[SRC:4mothers]`
 
 ### Allonge (Simple / Rao Allonge)
 
+- **UGS**: 8 (canonical, Rao Allongé — coarse anchor) `[SRC:ugs-chart]`
 - **Category**: Allonge `[SRC:4mothers]`
 - **Grind**: Coarsest of all espresso profiles by far (e.g., 1.8 on test grinder vs 0.5 for Blooming, 1.4 for G&S) `[SRC:eaf-profiling]` `[SRC:4mothers]` `[SRC:light-video]`
 - **Flow rate**: ~4.5 ml/s — the fastest flow rate espresso the DE1 makes `[SRC:eaf-profiling]` `[SRC:light-video]`
@@ -240,6 +317,7 @@ All DE1 profiles descend from four fundamental approaches. `[SRC:4mothers]`
 
 ### Default Profile
 
+- **UGS**: 0.75 (canonical) `[SRC:ugs-chart]`
 - **Category**: Lever `[SRC:medium]`
 - **How it works**: Classic lever-style declining pressure, 8.6 to 6 bar `[SRC:medium]`
 - **Versatility**: Mimics traditional 8.5 bar for fine grinds, behaves like Londinium for optimal grinds, limits flow for coarse grinds `[SRC:medium]`
@@ -252,6 +330,7 @@ All DE1 profiles descend from four fundamental approaches. `[SRC:4mothers]`
 
 ### Londinium
 
+- **UGS**: 0 (canonical, Londinium / LRv3 — same fine grind as Cremina) `[SRC:ugs-chart]`
 - **Category**: Lever `[SRC:medium]`
 - **How it works**: Inspired by spring-lever machines. Fast fill, then pressurized soak at ~3 bar until dripping appears, then ramp to ~9 bar with declining pressure. Emulates: lift lever (water fills), slam lever down (pressure hold), wait for dripping, release to full pressure, spring declines. `[SRC:medium]` `[SRC:dark-video]`
 - **Temperature**: 88C `[SRC:dark-video]`
@@ -272,6 +351,8 @@ All DE1 profiles descend from four fundamental approaches. `[SRC:4mothers]`
 - **Best for**: Darker roasts seeking full body and smoothness; quality dark beans where you want maximum extraction `[SRC:dark]` `[SRC:dark-video]`
 
 ### Damian's D-Flow Family (LM Leva, LRv2, LRv3, Q)
+
+- **UGS**: ~0–0.5 (inferred — Londinium / D-Flow adjacent; LRv3 is at canonical 0)
 
 All four profiles are by Damian (diy.brakel.com.au) and are D-Flow variants sharing the same pressurized soak core. `[SRC:community-index]`
 
@@ -318,6 +399,7 @@ All four profiles are by Damian (diy.brakel.com.au) and are D-Flow variants shar
 
 ### Gentle & Sweet
 
+- **UGS**: 2 (canonical) `[SRC:ugs-chart]`
 - **Category**: Pressure `[SRC:light]`
 - **How it works**: Traditional espresso style — no pre-infusion, no hold, no dripping. Fills headspace, goes straight to 6 bar constant pressure, makes espresso. The puck compresses under flow, slows it down, then coffee flows out. `[SRC:light-video]`
 - **Pressure**: Constant 6 bar. Espresso is generally 6-9 bar; G&S sits at the low end. Under 4 bar you stop making crema and enter drip-coffee territory. `[SRC:gentle-search]` `[SRC:light-video]`
@@ -334,6 +416,7 @@ All four profiles are by Damian (diy.brakel.com.au) and are D-Flow variants shar
 
 ### Extractamundo Dos
 
+- **UGS**: 1.5 (canonical) `[SRC:ugs-chart]`
 - **Category**: Pressure `[SRC:light-video]`
 - **How it works**: Very similar to Gentle & Sweet but with a short pre-infusion pause. Fills headspace, pauses for a few seconds (water sits on puck, some dripping occurs), then rises to ~6 bar target pressure. `[SRC:light-video]`
 - **Pressure**: Targets 6 bar, same as G&S. However, with the same grind setting the pre-infusion means it may not quite reach 6 bar — the extra soak creates less puck resistance. Slightly finer grind needed to match G&S pressure. `[SRC:light-video]`
@@ -361,6 +444,7 @@ All four profiles are by Damian (diy.brakel.com.au) and are D-Flow variants shar
 
 ### Cremina
 
+- **UGS**: 0 (canonical, Cremina — fine anchor) `[SRC:ugs-chart]`
 - **Category**: Lever `[SRC:dark]`
 - **How it works**: Emulates the Cremina lever machine. Fast fill with a brief soak/dwell, then pressure rises. Key difference from Londinium: pressure declines steeply as shot progresses (Londinium stays high). Flow rate drops as shot continues — this is by design. `[SRC:dark-video]`
 - **Temperature**: 92C — 4C higher than Londinium (88C). The higher temperature extracts more, producing more intense/traditional Italian flavors but also more harshness. `[SRC:dark-video]`
@@ -376,6 +460,7 @@ All four profiles are by Damian (diy.brakel.com.au) and are D-Flow variants shar
 
 ### 80's Espresso
 
+- **UGS**: ~0.25 (inferred — finer than D-Flow due to 82°C→72°C low-temp regime; see Cross-Profile Grind Ordering)
 - **Category**: Lever/Pressure `[SRC:dark]` `[SRC:dark-video]`
 - **How it works**: Lever profile at LOW temperature. No pre-infusion — maximum water flow fills the puck, puck compresses, then flows out with declining pressure. Named "80's" because temperature starts at 80C and declines toward 70C. `[SRC:dark-video]`
 - **Temperature**: 80C declining to ~70C — at least 8C cooler than normal espresso, 15C less than traditional machines (95-96C). The low temperature is the key innovation: dark tar flavors are extracted less at lower temperatures. `[SRC:dark-video]`
@@ -391,6 +476,7 @@ All four profiles are by Damian (diy.brakel.com.au) and are D-Flow variants shar
 
 ### Best Overall
 
+- **UGS**: 0.75 (canonical, "Best Overall Pressure") `[SRC:ugs-chart]`
 - **Category**: Lever/Pressure `[SRC:dark]` `[SRC:dark-video]`
 - **How it works**: 3-step simple profile from the appendix of Scott Rao's espresso book ("Best Overall Pressure Profile"). Fast fill (no soak/dripping time), rise to ~8.6 bar, then declining pressure to ~6 bar. Stays within the 6-9 bar espresso range throughout. `[SRC:dark-video]`
 - **Temperature**: 88C `[SRC:dark-video]`
@@ -407,6 +493,7 @@ All four profiles are by Damian (diy.brakel.com.au) and are D-Flow variants shar
 
 ### E61
 
+- **UGS**: 1.25 (canonical, "Flat 9 Bar (E61)") `[SRC:ugs-chart]`
 - **Category**: Flat 9 bar / Pressure `[SRC:dark]` `[SRC:dark-video]`
 - **How it works**: Flat 9 bar constant pressure, no pre-infusion. Very fast fill, pressure rises smoothly, then sustains 9 bar throughout. Simplest possible espresso profile — the DE1 version has perfectly stable temperature (unlike real E61 machines which are notoriously temperature unstable). `[SRC:dark-video]`
 - **Temperature**: 92C. Real E61 machines vary wildly in temperature due to their design (steam-temperature water cooling through exposed chrome group head). `[SRC:dark-video]`
@@ -424,6 +511,7 @@ All four profiles are by Damian (diy.brakel.com.au) and are D-Flow variants shar
 
 ### Turbo Shot
 
+- **UGS**: 5 (canonical) `[SRC:ugs-chart]`
 - **Category**: Flow/Pressure hybrid `[SRC:eaf-profiling]`
 - **How it works**: Full pump output (~7-8 ml/s), reduce to maintain ~6 bar `[SRC:eaf-profiling]`
 - **Grind**: Medium-fine — coarser than typical espresso, fine enough to spike to 6 bar quickly `[SRC:turbo-search]`
@@ -436,6 +524,8 @@ All four profiles are by Damian (diy.brakel.com.au) and are D-Flow variants shar
 - **Best for**: All coffee types; rapid extractions prioritizing clarity and sweetness `[SRC:eaf-profiling]`
 
 ### Hendon Turbo Variants (Jan)
+
+- **UGS**: ~5–6 (inferred — high-flow turbo territory; Turbo Shot anchors at canonical 5)
 
 All three Hendon Turbo profiles were created by Jan, inspired by the 2020 Hendon/Cameron paper on coarse-grind espresso. `[SRC:community-index]`
 
@@ -509,6 +599,7 @@ All three Hendon Turbo profiles were created by Jan, inspired by the 2020 Hendon
 
 ### Classic Italian / Gentler 8.4 Bar / Italian Australian
 
+- **UGS**: ~1.25 (inferred — constant-pressure family, behaves like Flat 9 Bar)
 - **Category**: Flat pressure `[SRC:profile-notes]`
 - **Creator**: Classic Italian Espresso created by **Luca Frangella** `[SRC:bc-classic-italian]`
 - **How it works**: Short preinfusion (4–8s at 4 bar) then sustained flat pressure extraction — 9 bar for Classic Italian, 8.4 bar for the gentler variant, 8.7 bar for Italian Australian. Emulates mainstream café espresso. `[SRC:profile-notes]`
@@ -590,6 +681,7 @@ All three Hendon Turbo profiles were created by Jan, inspired by the 2020 Hendon
 
 ### Gagné Adaptive Shot / Allongé
 
+- **UGS**: ~1.25 (inferred — family-adjacent to Adaptive v2)
 - **Category**: Adaptive/Flow `[SRC:bc-adaptive]`
 - **Creator**: Jonathan Gagné (Coffee ad Astra) `[SRC:bc-adaptive]`
 - **How it works**: After preinfusion, pressure rises to 8.6 bar. A series of "scan" frames then detects the current flow at peak pressure and locks it in for the rest of the shot. The profile adapts to the grind — finer grind produces ~2.2 ml/s standard espresso; coarser grind produces ~4 ml/s Allongé-style. You dial in by targeting a flow rate with grind, not by chasing a pressure curve. `[SRC:bc-adaptive]`
@@ -617,6 +709,7 @@ All three Hendon Turbo profiles were created by Jan, inspired by the 2020 Hendon
 
 ### TurboBloom
 
+- **UGS**: ~5–6 (inferred — high-flow turbo with bloom)
 - **Category**: Blooming/Turbo hybrid `[SRC:community-index]`
 - **Creator**: Collin `[SRC:community-index]`
 - **How it works**: Created as a companion to TurboTurbo after Collin noticed that a very short bloom step recovers positive qualities lost at slower PI flow rates. Fast fill at 8 ml/s saturates the puck quickly, then a very short (~5s) bloom until pressure drops to 2.2 bar, then 6 bar extraction with a 4.5 ml/s flow limiter. The fast fill + short bloom combination achieves even extraction while allowing high flow during the extraction phase. `[SRC:community-index]`
@@ -631,6 +724,7 @@ All three Hendon Turbo profiles were created by Jan, inspired by the 2020 Hendon
 
 ### TurboTurbo
 
+- **UGS**: 6 (canonical) `[SRC:ugs-chart]`
 - **Category**: Turbo (no bloom) `[SRC:community-index]`
 - **Creators**: Collin and Jan `[SRC:community-index]`
 - **How it works**: High-extraction turbo shot without a bloom phase. Rapid preinfusion at 96°C to saturate the puck, then 6 bar extraction at 93°C with a 4.5 ml/s flow limiter. Original design used 97°C/8 ml/s preinfusion; refined to 96°C/4 ml/s for better consistency and less astringency. High temperature is appropriate for the coarse grind: coarser grounds need hotter water to reach the same extraction temperature at the puck. `[SRC:community-index]`
@@ -702,6 +796,7 @@ All three Hendon Turbo profiles were created by Jan, inspired by the 2020 Hendon
 
 ### Pour Over Basket
 
+- **UGS**: ~7+ (inferred — high-flow filter/basket; coarsest territory)
 - **Category**: Pour over (filter through espresso machine) `[SRC:profile-notes]`
 - **How it works**: Produces filter coffee using a pour-over basket placed under the group head. Multi-pulse brewing with prewet, bloom pause, and several water pulses. Not espresso — pressure stays near 0 bar throughout (gravity-fed). `[SRC:profile-notes]`
 - **Variants**: `[SRC:profile-notes]`
@@ -753,6 +848,7 @@ Both profiles by John Weiss; distinct from the "Gentle Flat / Long Preinfusion" 
 
 ### Nu Skool
 
+- **UGS**: ~5–7 (inferred — high-flow turbo territory)
 - **Category**: Flow/New wave light roast `[SRC:community-index]`
 - **Creator**: Dan Calabro `[SRC:community-index]`
 - **How it works**: A family of 3 flow-curve profiles (one per basket size: 14g, 18g, 20g) for maximally prepped coffee. The philosophy: maximize extractability during prep (quality grinders, flat burrs, precise puck prep) so you can brew with lower pressure, lower temperature, and coarser grinds while achieving very high extraction with sweetness and clarity. Dial-in is done by adjusting three flow parameters: **flow floor** (minimum), **flow plateau** (target level), and **flow spectrum** (spread). `[SRC:community-index]`
@@ -1030,3 +1126,4 @@ Broad title and keyword search completed. Zero relevant threads or mentions foun
 | `bc-ilp` | Innovative Long Preinfusion troubleshooting threads — "Innovative Long Preinfusion Profile is Skipping Preinfusion" (5902713440), "long preinfusion profile" (7219702170) | https://3.basecamp.com/3671212/buckets/7351439/messages/5902713440 |
 | `bc-pour-over` | Pour over basket community threads — John Buckman's V60 intro (6478301972), "Tips for pour over basket?" (8927624349), "Need help with pour over basket!" (8728303973), "Filter 2.1 vs Pour Over basket+V60" (5979806761), "Pour Over basket questions" (6955693508) | https://3.basecamp.com/3671212/buckets/7351439/messages/6478301972 |
 | `profile-notes` | Decent profile JSON `notes` field — built-in documentation shipped with each profile | *(embedded in profile JSON files in `resources/profiles/`)* |
+| `ugs-chart` | Universal Grind Setting (UGS) calculator and chart — Mark Renowden's relative grind ordering of 16 mainstream DE1 profiles, anchored at Cremina (UGS 0) and Rao Allongé (UGS 8). Origin discussion: GitHub issue #500. | https://videoblurb.com/UGS/ |

--- a/resources/ai/claude_agent.md
+++ b/resources/ai/claude_agent.md
@@ -4,20 +4,35 @@
 
 You are a dialing-in assistant for the Decent Espresso DE1 machine. The Decenza app exposes live context and tools via MCP — use them before asking the user what they're working on.
 
-## At session start
+This guidance applies to **any MCP client** (Claude Desktop, Claude mobile apps, Claude Code, etc.). Filesystem-specific steps in the "Claude Code Remote Control workflow" section below only apply when you have filesystem access; everything else applies universally.
 
-1. Call the `get_agent_file` MCP tool. If its `version` is newer than the version in the header of this file, overwrite `CLAUDE.md` in the current working directory with the returned `content` and reload it for this session. If the versions match, skip the overwrite.
+## At session start (all clients)
+
+1. Call the `get_agent_file` MCP tool to load the latest version of these instructions. Re-read them if the returned `version` is newer than the one in this file's header.
 2. Read the `decenza://dialing/current_context` MCP resource to identify the active bean, grinder, active profile, machine phase, and most recent shots.
-3. If a file named `dialing/{bean.brand} {bean.type}.md` exists in the working directory, read it to restore prior conversation context — grind history, conclusions, taste notes, and decisions. If it does not exist yet, create it the first time the user concludes a discussion.
 
-## During the conversation
+## During the conversation (all clients)
 
-- Reference the bean log for prior grind settings and conclusions, not just the current shot.
 - Re-read `decenza://dialing/current_context` when the user pulls a new shot and wants you to weigh in on it.
 - Grind settings may be numbers, letters, click counts, or grinder-specific notation like "1+4" (one rotation plus four clicks). Preserve whatever format the user writes — don't normalize.
-- When suggesting grind changes, ground them in the bean log and recent shot data, not in generic dialing advice.
+- When suggesting grind changes, ground them in the user's actual shot history, not in generic dialing advice.
+- **Before recommending a grind direction for a new or unfamiliar bean, call `shots_list` filtered by `profileName` and look at recent shots of similar roast level.** Generic first-principles reasoning ("denser bean = finer grind") is unreliable across roast-level transitions; the user's own historical baselines are the correct anchor. Only fall back to first principles if no relevant history exists.
+- Cite concrete numbers from history ("you sat at grinder setting 10 on Beach Entry, also a medium roast, on this same profile") rather than directional advice ("try a few clicks coarser") whenever the data supports it.
 
-## After each discussion
+## Claude Code Remote Control workflow
+
+The following only applies in a Claude Code Remote Control session, where you have filesystem access to a working directory. Other MCP clients should skip this section.
+
+### At session start
+
+1. After calling `get_agent_file`, if its `version` is newer than the version in the header of the existing `CLAUDE.md` in the current working directory, overwrite `CLAUDE.md` with the returned `content` and reload it for this session. If the versions match, skip the overwrite.
+2. If a file named `dialing/{bean.brand} {bean.type}.md` exists in the working directory, read it to restore prior conversation context — grind history, conclusions, taste notes, and decisions. If it does not exist yet, create it the first time the user concludes a discussion.
+
+### During the conversation
+
+- Reference the bean log for prior grind settings and conclusions, not just the current shot. The bean log complements `shots_list` — use both.
+
+### After each discussion
 
 Append a concise summary to `dialing/{bean.brand} {bean.type}.md` including:
 
@@ -30,6 +45,6 @@ If the file does not exist yet, create it with a header line naming the bean. If
 
 Keep each entry short — these logs are read at the start of every future session and bloated entries waste context.
 
-## First-time setup
+### First-time setup
 
 If the user says "set up Decenza AI chat" and there is no `CLAUDE.md` in the current working directory yet: you have already been told to read `get_agent_file` to fetch this content — also create the `dialing/` subdirectory and briefly confirm to the user that setup is complete. No scripts needed.

--- a/resources/ai/profile_knowledge.md
+++ b/resources/ai/profile_knowledge.md
@@ -3,7 +3,76 @@
 When analyzing a shot, use this section to understand what the profile was DESIGNED to do.
 Do NOT flag intentional profile behaviors as problems.
 
+## Cross-Profile Grind Ordering
+Skip-Catalog: true
+Purpose: Reference for relative grind requirements across profiles, used when the user transitions between profiles or roast levels. This is not a profile — it is cross-cutting reference material.
+
+The Universal Grind Setting (UGS) chart from https://videoblurb.com/UGS/ places 16 mainstream DE1 profiles on a relative grind axis. Cremina anchors UGS 0 (finest); Rao Allongé anchors UGS 8 (coarsest). A few profiles fall slightly below 0. The same physical grinder setting will produce very different shots across this range, so when a user switches profiles you should expect — and surface — a directional change in their grind.
+
+### CRITICAL: UGS values are NOT grinder clicks
+
+UGS is a **relative scale**, not a unit of grinder adjustment. Mapping UGS distance to actual grinder steps requires the user to pull two anchor shots (Cremina at UGS 0 and Rao Allongé at UGS 8) and report their grinder settings — only then is the conversion `(anchor8 - anchor0) / 8` known. Without that calibration:
+
+- The same 0.5 UGS distance might be ~1–2 clicks on a Niche Zero (0–50 numeric scale), ~50–200 microns on a micron-scale lab burr grinder, or an unmappable fractional step on an A–Z letter-coded hand grinder. UGS values themselves are imaginary — they don't exist on any user's grinder dial.
+- Hand grinders that step by letter (A, B, C…) or unlabelled detents make UGS arithmetic meaningless. Only direction translates ("finer" / "coarser"); fractional UGS distances do not.
+- Two users on the same profile but different grinders may have grinder settings 4× apart for the same UGS position.
+
+**Operational rule**: treat UGS distance as **directional information** ("D-Flow is finer than Adaptive v2"). Never translate a UGS distance into a grinder-click count or absolute setting. Concrete grinder numbers must come from `shots_list` history, never from UGS arithmetic. If the user wants magnitude, either cite a specific reference shot or stay qualitative ("a touch coarser", "meaningfully coarser").
+
+### Canonical UGS positions (from the UGS chart)
+
+| UGS | Profile | Notes |
+|-----|---------|-------|
+| -0.5 | Blooming Espresso | Finer than Cremina — survives the 30s soak without premature gushing. |
+| -0.5 | Blooming Allongé | Ultra-light Nordic-style filter roasts. |
+| 0 | **Cremina** | Fine anchor. Max puck resistance, high-temp long-contact extraction. |
+| 0 | Londinium / LRv3 | Same fine grind as Cremina for pressurized pre-infusion soak. |
+| 0.5 | D-Flow | Fast fill, pressurized soak, nuanced pressure rise. |
+| 0.75 | Best Overall Pressure | Rise to ~8.6 bar, declining to ~6 bar. |
+| 0.75 | Default | Standard espresso starting point. |
+| 1.25 | Adaptive v2 | Slightly coarser to favor flow-driven clarity. |
+| 1.25 | Flat 9 Bar (E61) | Constant 9 bar, no pre-infusion. |
+| 1.5 | A-Flow | Long soak "heals" a slightly coarser, faster-flowing puck. |
+| 1.5 | Extractamundo Dos | 6-bar low pressure allows a coarser, "juicier" window. |
+| 2 | Gentle & Sweet | Constant 6 bar, 2–3 ml/s flow. |
+| 5 | Turbo Shot | The "clarity jump" — ~15s with 6-bar ceiling. |
+| 6 | TurboTurbo | Even less resistance; leans toward Allongé flow rate. |
+| 7 | Blooming Allongé (hybrid) | Bloom + high-flow percolation for ultralights. |
+| 8 | **Rao Allongé** | Coarse anchor. Max flow (~4.5 ml/s). |
+
+**Important pattern**: most traditional espresso profiles cluster between 0 and 2 — the difference between Cremina and Gentle & Sweet is only ~2 grinder steps, not a huge swing. There is a large gap between traditional espresso (≤2) and turbo/allongé territory (5+).
+
+### Inferred positions (not in the UGS chart)
+
+These positions are **not** from the UGS calculator. They are reasoned estimates from profile mechanics, citations, and observed user shot history. Treat them as approximate and verify against the user's `shots_list` history when available.
+
+| UGS (est.) | Profile | Rationale |
+|------------|---------|-----------|
+| ~0.25 | **80's Espresso** | Lever-decline mechanic but with an unusual low-temperature regime (82°C declining to 72°C). The low extraction temperature reduces solubility, requiring a finer grind than the temperature-normal lever group to compensate. Observed in user shot history to pull significantly finer than D-Flow on the same bean. |
+| ~0–0.5 | Damian's LRv2, LRv3, LM Leva, Q | Londinium / D-Flow adjacent; treat as the same family. |
+| ~1.25 | Classic Italian / Gentler 8.4 Bar / Italian Australian | Constant-pressure family, behaves like Flat 9 Bar. |
+| ~5–7 | Hendon Turbo, TurboBloom, Nu Skool, Pour Over Basket | High-flow turbo/filter territory. |
+
+For any profile not listed here or in the UGS chart, say so plainly and lean on `shots_list` history.
+
+### Roast-level transitions on the same profile
+
+When the user changes the **roast** of their bean while staying on the same profile, the grind direction is dominated by roast level — NOT by the naive "denser bean = finer grind" heuristic, which only applies to same-roast-level beans of differing density.
+
+- **Dark → medium roast: GRIND COARSER.** Dark roasts are more porous and brittle, generate more fines, and extract faster than medium roasts at the same grinder setting. A medium roast at the dark-roast setting will choke the shot or extract sour. Open the grind up; bumping temperature 1–2°C also helps without requiring a finer grind.
+- **Light → medium roast: GRIND FINER.** Light roasts are dense and hard to extract, often pulled at very coarse settings on flow-style profiles. Mediums are more soluble and want a tighter grind for typical 1:2 espresso ratios.
+- **Same roast, different origin or processing**: small adjustments. Defer to the user's historical settings on similar beans rather than applying a generic rule.
+
+### How to use this ordering
+
+1. **When the user transitions between profiles**, name the direction qualitatively and the UGS gap as relative context ("D-Flow at UGS 0.5 → Blooming Espresso at UGS -0.5 is about 1 UGS step finer — significantly finer; plan 3+ shots to dial in"). Do NOT translate the UGS gap into grinder clicks or microns — UGS is a relative scale that requires anchor calibration to map onto any specific grinder.
+2. **When the user transitions between roasts on the same profile**, state the direction the roast change implies, then ground it in their actual shot history by calling `shots_list` filtered by `profileName`. The user's own past pulls on similar roast levels are a stronger anchor than this ordering.
+3. **Concrete grinder numbers come from shot history, not from this table.** When recommending magnitude, either cite a specific reference shot from `shots_list` ("you pulled this profile at grinder setting 7 on a similar bean") or stay qualitative ("a touch coarser", "noticeably coarser"). Never recommend "X UGS coarser" as a grinder-click instruction.
+
+Source: Universal Grind Setting calculator and chart (Mark Renowden, https://videoblurb.com/UGS/) — see GitHub issue #500. Profiles not in the chart are inferred from the qualitative relationships in the per-profile sections below.
+
 ## D-Flow
+UGS: 0.5 (Damian's LRv2/LRv3 variants sit at 0 like Londinium; base D-Flow and Damian's Q at 0.5)
 Also matches: "D-Flow / default", "D-Flow / Q", "D-Flow / La Pavoni", "Damian's Q", "Damian's LRv2", "Damian's LRv3", "Damian's LM Leva", "Damian's D-Flow"
 AnalysisFlags: flow_trend_ok
 Category: Lever/Flow hybrid (Londinium family)
@@ -24,6 +93,7 @@ DO NOT flag declining pressure, the flow safety step switching to flow control (
 DO NOT flag slow 0–0.4 ml/s flow in the first 20s as a problem — this is the pressurized soak phase and is intentional across all Damian variants.
 
 ## A-Flow
+UGS: 1.5
 Creator: Janek (Jan-Erling Johnsen)
 Category: Pressure-ramp into flow extraction
 Family: pressure-ramp-flow
@@ -39,6 +109,7 @@ AnalysisFlags: flow_trend_ok
 DO NOT flag the pressure ramp-up phase as overpressure — the intentional rise to 9-10 bar before flow extraction is how this profile works.
 
 ## Adaptive v2
+UGS: 1.25
 Category: Flow/adaptive
 Family: flow-adaptive
 How it works: Ramps pressure toward ~9 bar (exits at 8.8 bar) for ~6 seconds, then adapts to grind coarseness by locking in whatever flow rate exists. Switches to stable flow after pressure peak. Extraction flow limiter at 9.5 bar. The Low Pressure Infusion variant (by Trevor Rainey + Jonathan Gagné) modifies this with a high-flow fill (8 ml/s), 3 bar soak pressure, and 8 bar rise — targeting ~30s total shot time. Canonical recipe for LPI variant: 15g dose, ~33g out in ~30s, targeting ~4g drip-through during bloom and ~1.5 ml/s flow at pressurize step.
@@ -51,6 +122,7 @@ Roast: Good for light (v2 updated for light roasts). Excellent for medium-light.
 DO NOT flag variable pressure curves, steep pre-infusion pressure drop, or a slight flow jump at peak pressure as problems — all are by design.
 
 ## Blooming Espresso
+UGS: -0.5
 Category: Blooming
 Family: blooming
 AnalysisFlags: flow_trend_ok, channeling_expected
@@ -67,6 +139,7 @@ This is the hardest profile to dial in — requires lots of beans to experiment.
 DO NOT flag channeling in dC/dt — the zero-flow bloom followed by ramp to extraction flow always produces large conductance derivative spikes. dC/dt is unreliable for any profile with a zero-flow phase before extraction.
 
 ## Blooming Allonge
+UGS: -0.5 (original) / 7 (ultralight hybrid variant)
 Also matches: "Blooming Allongé"
 Category: Blooming/Allonge hybrid
 Family: blooming
@@ -81,6 +154,7 @@ Roast: Best for ultra-light, Nordic filter roasts.
 DO NOT flag zero flow during bloom or low pressure during percolation as problems.
 
 ## Allonge
+UGS: 8 (Rao Allongé — coarse anchor)
 Also matches: "Allongé", "Rao Allongé"
 Category: Allonge
 Family: allonge
@@ -95,6 +169,7 @@ DO NOT flag high ratio, low pressure, or minor channeling as problems — all ar
 AnalysisFlags: channeling_expected, grind_check_skip
 
 ## Default
+UGS: 0.75
 Category: Lever
 Family: lever-decline
 How it works: Classic lever-style declining pressure, 8.6 to 6 bar. Fast fill, immediate pressure rise, then decline.
@@ -107,6 +182,7 @@ DO NOT flag declining pressure as a problem — it defines lever-style profiles.
 AnalysisFlags: flow_trend_ok
 
 ## Londinium
+UGS: 0 (Londinium / LRv3 — same as Cremina)
 Also matches: "Londonium", "Londinium / LRv3"
 AnalysisFlags: flow_trend_ok
 Category: Lever
@@ -122,6 +198,7 @@ Roast: Excellent for dark (full body without harshness). Good for medium-dark. S
 DO NOT flag the 3 bar soak phase as "low pressure" — it's intentional pre-infusion.
 
 ## Turbo Shot
+UGS: 5
 Also matches: "Hendon Turbo", "Hendon Turbo 6b Pressure Decline", "Hendon Turbo Bloom", "Hendon Turbo Flow"
 Category: Flow/Pressure hybrid
 Family: turbo
@@ -189,6 +266,7 @@ Starting point: 15g:195g, 2 ml/s, ~100s
 DO NOT flag ultra-high ratio or ultra-low pressure as problems — this is filter simulation.
 
 ## Gentle & Sweet
+UGS: 2
 Also matches: "Gentle and sweet"
 Category: Pressure
 Family: flat-pressure
@@ -204,6 +282,7 @@ DO NOT recommend increasing temperature — the moderate 88°C is by design to p
 AnalysisFlags: flow_trend_ok
 
 ## Extractamundo Dos
+UGS: 1.5
 Category: Pressure
 Family: blooming
 How it works: Fill at high pressure, then a dynamic bloom phase (flow drops to zero, pressure decays to ~2.2 bar), then rise to 6 bar for extraction. The bloom phase temperature drops to 67.5°C — this is intentional and controls extraction character.
@@ -232,6 +311,7 @@ DO NOT flag varying pressure as a problem — the machine controls flow, not pre
 DO NOT flag pressure fluctuations during extraction as channeling — pressure naturally moves as puck resistance changes under constant flow.
 
 ## Cremina lever machine
+UGS: 0 (Cremina — fine anchor)
 Also matches: "Cremina"
 Category: Lever
 Family: lever-decline
@@ -263,6 +343,7 @@ DO NOT flag slow flow (1–1.5 ml/s), long duration, or low ratio as problems �
 DO NOT flag channeling in dC/dt — the blooming phase (near-zero flow) followed by extraction onset produces conductance derivative spikes unrelated to puck quality. This is a milk-drink texture-first profile.
 
 ## 80's Espresso
+UGS: ~0.25 (inferred — low-temp regime requires finer grind than D-Flow)
 Category: Lever at low temperature
 Family: lever-decline
 How it works: Lever profile at very low temperature (82→72°C declining). Fast preinfusion fill at 7.5 ml/s, then 7.8 bar declining to 5 bar. Intentionally under-extracts to minimize tar/burnt flavors from dark beans.
@@ -276,6 +357,7 @@ DO NOT flag low temperature as a problem — it's the entire point of this profi
 AnalysisFlags: flow_trend_ok
 
 ## Best Overall
+UGS: 0.75
 Category: Lever (simple 3-step)
 Family: lever-decline
 How it works: Three-step: fast fill → 8.4 bar peak → declining pressure to ~6 bar. No long soak time (unlike Londinium). Traditional pressure-controlled shot.
@@ -288,6 +370,7 @@ Roast: Good for dark. Good for medium.
 AnalysisFlags: flow_trend_ok
 
 ## E61
+UGS: 1.25
 Also matches: "E61 classic gently up to 10 bar", "E61 rocketing up to 10 bar", "E61 with fast preinfusion to 9 bar"
 Category: Flat pressure
 Family: flat-pressure
@@ -304,6 +387,7 @@ DO NOT flag increasing flow as a problem — it's characteristic of flat 9 bar p
 AnalysisFlags: flow_trend_ok
 
 ## Classic Italian / Traditional Flat Pressure
+UGS: ~1.25 (inferred)
 Also matches: "Classic Italian espresso", "Gentler but still traditional 8.4 bar", "Italian Australian espresso"
 Category: Flat pressure
 Family: flat-pressure
@@ -387,6 +471,7 @@ DO NOT flag variable bloom duration or zero flow during bloom as problems — th
 DO NOT flag channeling in dC/dt — the zero-flow bloom followed by extraction ramp produces large conductance derivative spikes regardless of puck quality.
 
 ## Gagné Adaptive
+UGS: ~1.25 (inferred)
 Also matches: "Gagné/Adaptive Shot 92C v1.0", "Gagné/Adaptive Allongé 94C v1.0", "Gagne Adaptive Shot", "Gagne Adaptive Allonge"
 Category: Adaptive/Flow
 Family: flow-adaptive
@@ -416,6 +501,7 @@ DO NOT flag channeling in dC/dt — the bloom path (triggered by fine grinds) pr
 AnalysisFlags: channeling_expected
 
 ## TurboBloom
+UGS: ~5–6 (inferred)
 Category: Blooming/Turbo hybrid
 Family: turbo
 AnalysisFlags: flow_trend_ok, grind_check_skip, channeling_expected
@@ -430,6 +516,7 @@ Roast: All roasts, optimized for high-extraction grinders.
 DO NOT flag zero flow during bloom, low bloom temperature, high extraction flow, or the short bloom duration as problems — all are intentional design elements.
 
 ## TurboTurbo
+UGS: 6
 Also matches: "Turboturbo"
 Category: Turbo (no bloom)
 Family: turbo
@@ -445,6 +532,7 @@ Roast: All roasts.
 DO NOT flag high flow, fast duration, high temperatures, or high ratio as problems — these are intentional design elements for high-extraction coarse-grind setups.
 
 ## Nu Skool
+UGS: ~5–7 (inferred)
 Also matches: "Nu Skool 14g", "Nu Skool 18g", "Nu Skool 20g", "Nu Skool large basket"
 Category: Flow/New wave light roast
 Family: flow-adaptive
@@ -521,6 +609,7 @@ DO NOT flag gradual pressure decline, long extraction duration, or temperature c
 AnalysisFlags: flow_trend_ok
 
 ## Pour Over Basket
+UGS: ~7+ (inferred)
 Also matches: "Pour over basket/Decent pour over", "Pour over basket/Kalita 20g in, 340ml out", "Pour over basket/V60 15g in, 250g out", "Pour over basket/V60 20g in, 340g out", "Pour over basket/V60 22g in, 375g out", "Pour over basket/Cold brew 22g in, 375ml out"
 Category: Pour over (filter brewing through espresso machine)
 Family: filter

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -1387,6 +1387,16 @@ QString ShotSummarizer::shotAnalysisSystemPrompt(const QString& beverageType, co
                 "non-current profile, say you don't have its recipe and offer to discuss\n"
                 "tradeoffs in qualitative terms.\n");
         }
+
+        // Cross-cutting reference sections (Skip-Catalog: true) — currently
+        // contains "Cross-Profile Grind Ordering". Injected unconditionally so
+        // the model can reason about cross-profile and cross-roast grind
+        // direction without needing the user's current profile to match a
+        // specific section.
+        const QString crossProfile = crossProfileReferenceContent();
+        if (!crossProfile.isEmpty()) {
+            base += QStringLiteral("\n\n") + crossProfile;
+        }
     }
 
     // Look up profile-specific knowledge by KB ID (computed from title/alias matching),
@@ -1473,6 +1483,8 @@ void ShotSummarizer::loadProfileKnowledge()
                     const QString flag = f.trimmed();
                     if (!flag.isEmpty()) pk.analysisFlags << flag;
                 }
+            } else if (line.startsWith(QStringLiteral("Skip-Catalog:"))) {
+                pk.skipCatalog = (line.mid(13).trimmed().toLower() == QStringLiteral("true"));
             }
         }
 
@@ -1517,6 +1529,7 @@ void ShotSummarizer::buildProfileCatalog()
 
     for (auto it = s_profileKnowledge.constBegin(); it != s_profileKnowledge.constEnd(); ++it) {
         const ProfileKnowledge& pk = it.value();
+        if (pk.skipCatalog) continue;  // cross-cutting reference, not a profile
         if (seen.contains(pk.name)) continue;
         seen.insert(pk.name);
 
@@ -1548,6 +1561,25 @@ void ShotSummarizer::buildProfileCatalog()
     s_profileCatalog = lines.join('\n');
 
     qDebug() << "ShotSummarizer: Built profile catalog with" << lines.size() << "entries";
+}
+
+QString ShotSummarizer::crossProfileReferenceContent()
+{
+    loadProfileKnowledge();
+
+    // Collect every section marked "Skip-Catalog: true" — these are cross-cutting
+    // reference blocks (e.g. Cross-Profile Grind Ordering) that belong in the
+    // system prompt unconditionally, not gated on a profile match.
+    QSet<QString> seen;
+    QStringList sections;
+    for (auto it = s_profileKnowledge.constBegin(); it != s_profileKnowledge.constEnd(); ++it) {
+        const ProfileKnowledge& pk = it.value();
+        if (!pk.skipCatalog) continue;
+        if (seen.contains(pk.name)) continue;  // each alias keys to the same content
+        seen.insert(pk.name);
+        sections << QStringLiteral("## ") + pk.name + QStringLiteral("\n\n") + pk.content;
+    }
+    return sections.join(QStringLiteral("\n\n"));
 }
 
 void ShotSummarizer::loadDialInReference()
@@ -1744,6 +1776,18 @@ If no tasting feedback is provided, analyze curves and extraction metrics, but n
 )") + sharedGrinderGuidance() + QStringLiteral(R"(
 - **Flat burrs**: Higher channeling risk in espresso. Flow deviations may indicate alignment issues.
 - **Conical burrs**: More forgiving puck prep, flow tends to be more stable.
+
+## Grinder Adjustment Procedure
+
+Before recommending a grinder change with any magnitude (clicks, microns, "to setting X", "half a step"), follow this procedure:
+
+1. **Check available shot history.** Always start with the `dialInSessions` block in this prompt — recent dial-in shots for the current bean + grinder. **If you have shot-history tools** (MCP clients have `shots_list` filtered by `profileName` and roast level), call them for broader history beyond `dialInSessions`. The in-app advisor has no tools — only what is already in the prompt is available to it.
+2. **If a reference shot exists**: anchor the recommendation to it. Cite the specific historical setting and the shot it came from ("you pulled this profile at grinder setting 7 on shot 882 — start there").
+3. **If no reference shot exists** after exhausting available history sources: stay directional only. This is the correct response, not a degraded fallback. Use phrases like "a touch coarser", "noticeably finer", "significantly coarser". Never assign a number, click count, or grinder-step delta when you have no historical anchor.
+
+UGS distances in the Cross-Profile Grind Ordering section are **relative-scale comparisons between profiles**, not grinder-click translations. Do not convert a UGS distance into grinder steps, microns, or letter-coded positions under any circumstance — that conversion requires per-user two-anchor calibration that the user has not performed. UGS values are also not visible on the user's grinder dial.
+
+The "Common Espresso Patterns" section below tells you the **direction** of grinder changes ("Grind coarser", "Grind finer"). The **magnitude** must come from this procedure — never from a guess, never from UGS arithmetic. When in doubt, stay directional.
 
 ## Common Espresso Patterns
 

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -32,6 +32,10 @@ QString ShotSummarizer::s_profileCatalog;
 QString ShotSummarizer::s_dialInReference;
 bool ShotSummarizer::s_dialInReferenceLoaded = false;
 
+// Static cache for cross-profile reference content (Skip-Catalog sections)
+QString ShotSummarizer::s_crossProfileReference;
+bool ShotSummarizer::s_crossProfileReferenceLoaded = false;
+
 // Normalize a profile key: lowercase, strip diacritics, normalize punctuation
 static QString normalizeProfileKey(const QString& key)
 {
@@ -1389,10 +1393,9 @@ QString ShotSummarizer::shotAnalysisSystemPrompt(const QString& beverageType, co
         }
 
         // Cross-cutting reference sections (Skip-Catalog: true) — currently
-        // contains "Cross-Profile Grind Ordering". Injected unconditionally so
-        // the model can reason about cross-profile and cross-roast grind
-        // direction without needing the user's current profile to match a
-        // specific section.
+        // contains "Cross-Profile Grind Ordering". Injected within the espresso
+        // path (filter and pour-over excluded) so the model can reason about
+        // cross-profile and cross-roast grind direction.
         const QString crossProfile = crossProfileReferenceContent();
         if (!crossProfile.isEmpty()) {
             base += QStringLiteral("\n\n") + crossProfile;
@@ -1565,21 +1568,22 @@ void ShotSummarizer::buildProfileCatalog()
 
 QString ShotSummarizer::crossProfileReferenceContent()
 {
+    if (s_crossProfileReferenceLoaded) return s_crossProfileReference;
+
     loadProfileKnowledge();
 
-    // Collect every section marked "Skip-Catalog: true" — these are cross-cutting
-    // reference blocks (e.g. Cross-Profile Grind Ordering) that belong in the
-    // system prompt unconditionally, not gated on a profile match.
     QSet<QString> seen;
     QStringList sections;
     for (auto it = s_profileKnowledge.constBegin(); it != s_profileKnowledge.constEnd(); ++it) {
         const ProfileKnowledge& pk = it.value();
         if (!pk.skipCatalog) continue;
-        if (seen.contains(pk.name)) continue;  // each alias keys to the same content
+        if (seen.contains(pk.name)) continue;
         seen.insert(pk.name);
         sections << QStringLiteral("## ") + pk.name + QStringLiteral("\n\n") + pk.content;
     }
-    return sections.join(QStringLiteral("\n\n"));
+    s_crossProfileReference = sections.join(QStringLiteral("\n\n"));
+    s_crossProfileReferenceLoaded = true;
+    return s_crossProfileReference;
 }
 
 void ShotSummarizer::loadDialInReference()

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -1456,7 +1456,17 @@ void ShotSummarizer::loadProfileKnowledge()
 
         ProfileKnowledge pk;
         pk.name = currentTitle;
-        pk.content = currentContent.trimmed();
+
+        // Strip parser-directive lines that are not useful to the AI
+        {
+            QStringList filtered;
+            for (const QString& l : currentContent.split('\n')) {
+                if (!l.startsWith(QStringLiteral("Skip-Catalog:")) &&
+                    !l.startsWith(QStringLiteral("Purpose:")))
+                    filtered << l;
+            }
+            pk.content = filtered.join('\n').trimmed();
+        }
 
         // Extract the main name and any aliases from "Also matches:" line
         QStringList keys;

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -248,6 +248,13 @@ public:
     // in profile_knowledge.md and control which checks analyzeShot() suppresses.
     static QStringList getAnalysisFlags(const QString& kbId);
 
+    // Cross-cutting reference content (sections marked Skip-Catalog: true) —
+    // injected unconditionally into the system prompt and per-profile MCP
+    // payloads, since they apply across profiles rather than to any one.
+    // Currently surfaces the "Cross-Profile Grind Ordering" section from
+    // profile_knowledge.md.
+    static QString crossProfileReferenceContent();
+
 private:
     // Render the prose body (## Shot Summary, ## Phase Data, ## Tasting
     // Feedback, ## Detector Observations) the legacy buildUserPrompt
@@ -351,6 +358,10 @@ private:
         //   flow_trend_ok       — don't flag declining/rising flow as a caution
         //   channeling_expected — minor channeling is normal for this profile
         QStringList analysisFlags;
+        // True when "Skip-Catalog: true" appears in the section. Marks the
+        // section as cross-cutting reference material rather than a profile —
+        // excluded from buildProfileCatalog() and from per-profile injection.
+        bool skipCatalog = false;
     };
     static QMap<QString, ProfileKnowledge> s_profileKnowledge;
     static bool s_knowledgeLoaded;

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -249,10 +249,10 @@ public:
     static QStringList getAnalysisFlags(const QString& kbId);
 
     // Cross-cutting reference content (sections marked Skip-Catalog: true) —
-    // injected unconditionally into the system prompt and per-profile MCP
-    // payloads, since they apply across profiles rather than to any one.
-    // Currently surfaces the "Cross-Profile Grind Ordering" section from
-    // profile_knowledge.md.
+    // injected into the espresso system prompt and per-profile MCP payloads
+    // (filter/pour-over beverage types excluded), since they apply across
+    // profiles rather than to any one. Currently surfaces the
+    // "Cross-Profile Grind Ordering" section from profile_knowledge.md.
     static QString crossProfileReferenceContent();
 
 private:
@@ -360,7 +360,7 @@ private:
         QStringList analysisFlags;
         // True when "Skip-Catalog: true" appears in the section. Marks the
         // section as cross-cutting reference material rather than a profile —
-        // excluded from buildProfileCatalog() and from per-profile injection.
+        // excluded from buildProfileCatalog().
         bool skipCatalog = false;
     };
     static QMap<QString, ProfileKnowledge> s_profileKnowledge;
@@ -377,4 +377,8 @@ private:
     static QString s_dialInReference;
     static bool s_dialInReferenceLoaded;
     static void loadDialInReference();
+
+    // Cross-profile reference content cache (Skip-Catalog sections)
+    static QString s_crossProfileReference;
+    static bool s_crossProfileReferenceLoaded;
 };

--- a/src/mcp/mcpresources.cpp
+++ b/src/mcp/mcpresources.cpp
@@ -148,7 +148,8 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
 
     // decenza://dialing/current_context
     // Compact snapshot of the active bean, grinder, last 3 shots, active profile, and machine
-    // phase — intended for a Claude Code Remote Control session to read at turn start.
+    // phase — intended for any MCP client (Claude Desktop, Claude mobile, Claude Code, etc.) to
+    // read at session start and re-read when the user pulls a new shot.
     registry->registerAsyncResource(
         "decenza://dialing/current_context",
         "Current Dialing Context",

--- a/src/mcp/mcptools_agent.cpp
+++ b/src/mcp/mcptools_agent.cpp
@@ -10,16 +10,19 @@
 void registerAgentTools(McpToolRegistry* registry)
 {
     // get_agent_file
-    // Returns the current Decenza CLAUDE.md content and a version string tied to the Decenza app
-    // version. Claude Code Remote Control sessions call this at session start to self-update the
-    // CLAUDE.md in their working directory, so agent instructions evolve with app updates without
-    // any manual user intervention.
+    // Returns the current Decenza dialing-assistant system prompt and a version string tied to
+    // the Decenza app version. Any MCP client (Claude Desktop, Claude mobile, Claude Code, etc.)
+    // should call this at session start to load behavioral guidance for dialing assistance, so
+    // agent instructions evolve with app updates without manual user intervention. Claude Code
+    // Remote Control sessions additionally use the `version` to self-update a `CLAUDE.md` file in
+    // the working directory; other clients can simply read and follow the returned `content`.
     registry->registerTool(
         "get_agent_file",
-        "Returns the current Decenza CLAUDE.md content and version. "
-        "Claude Code Remote Control sessions should call this at session start: "
-        "if the returned `version` is newer than the version header in the existing CLAUDE.md "
-        "in the working directory, overwrite it with the returned `content` and reload.",
+        "Returns the Decenza dialing-assistant system prompt and version. "
+        "Any MCP client should call this at session start to load behavioral guidance for "
+        "dialing assistance — read the returned `content` and follow it for the rest of the "
+        "session. Clients with filesystem access (e.g. Claude Code Remote Control) may "
+        "additionally use `version` to self-update a local CLAUDE.md.",
         QJsonObject{
             {"type", "object"},
             {"properties", QJsonObject{}}

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -221,6 +221,17 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         profileKnowledge = ShotSummarizer::profileKnowledgeForKbId(dbResult.profileKbId);
                         if (profileKnowledge.isEmpty())
                             profileKnowledge = ShotSummarizer::findProfileSection(profileTitle, profileType);
+
+                        // Append cross-cutting reference (e.g. Cross-Profile
+                        // Grind Ordering) so default-mode MCP clients still
+                        // see direction guidance for profile/roast transitions
+                        // without having to ask for the full system prompt.
+                        const QString crossProfile = ShotSummarizer::crossProfileReferenceContent();
+                        if (!crossProfile.isEmpty()) {
+                            if (!profileKnowledge.isEmpty())
+                                profileKnowledge += QStringLiteral("\n\n");
+                            profileKnowledge += crossProfile;
+                        }
                     }
                     if (!profileKnowledge.isEmpty())
                         result["profileKnowledge"] = profileKnowledge;

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -222,15 +222,51 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         if (profileKnowledge.isEmpty())
                             profileKnowledge = ShotSummarizer::findProfileSection(profileTitle, profileType);
 
-                        // Append cross-cutting reference (e.g. Cross-Profile
-                        // Grind Ordering) so default-mode MCP clients still
-                        // see direction guidance for profile/roast transitions
-                        // without having to ask for the full system prompt.
-                        const QString crossProfile = ShotSummarizer::crossProfileReferenceContent();
-                        if (!crossProfile.isEmpty()) {
-                            if (!profileKnowledge.isEmpty())
-                                profileKnowledge += QStringLiteral("\n\n");
-                            profileKnowledge += crossProfile;
+                        // Espresso-only: cross-cutting reference content and
+                        // anti-hallucination framing (profile families +
+                        // other-profile parameter discipline). Mirrors what
+                        // shotAnalysisSystemPrompt() injects in full-knowledge
+                        // mode; omitted for filter/pour-over as the content is
+                        // espresso-centric.
+                        if (bevType.toLower() != "filter" && bevType.toLower() != "pourover") {
+                            const QString crossProfile = ShotSummarizer::crossProfileReferenceContent();
+                            if (!crossProfile.isEmpty()) {
+                                if (!profileKnowledge.isEmpty())
+                                    profileKnowledge += QStringLiteral("\n\n");
+                                profileKnowledge += crossProfile;
+                            }
+
+                            profileKnowledge += QStringLiteral(
+                                "\n\n## Profile families\n\n"
+                                "Each profile carries a `[family: <name>]` tag. Profiles in the same\n"
+                                "family implement the same underlying extraction mechanic. Recommending\n"
+                                "a within-family switch (e.g., D-Flow → LRv2 — both `lever-decline`) is\n"
+                                "USUALLY a parameter tweak in disguise: the user could achieve the same\n"
+                                "outcome by adjusting temperature, dose, or grind on their current\n"
+                                "profile. Within-family switches are only meaningful when the\n"
+                                "alternative encodes a constraint the user CANNOT replicate by tweaking\n"
+                                "the current profile (e.g., `80's Espresso` is `lever-decline` like\n"
+                                "D-Flow, but bakes in a low-temperature regime — 82°C declining to\n"
+                                "72°C — that's hard to replicate by editing D-Flow's frame temps).\n\n"
+                                "When you recommend a profile switch, name the family of the current\n"
+                                "and proposed profile and explain what the family change buys the user.\n"
+                                "If both are the same family, EITHER explain the specific constraint the\n"
+                                "alternative bakes in, OR drop the recommendation and suggest a parameter\n"
+                                "tweak on the current profile instead.\n\n"
+                                "## Other-profile parameter discipline\n\n"
+                                "You have full recipe data (frame setpoints, temperatures, pressures,\n"
+                                "durations) ONLY for the current shot's profile in `result.profile.recipe`.\n"
+                                "For every other profile, you have ONLY what is in your training data —\n"
+                                "which may be outdated or incorrect. DO NOT quote specific numeric\n"
+                                "setpoints (e.g., \"Londinium runs 89-90°C\", \"E61 peaks at 9 bar\")\n"
+                                "of profiles other than the current one — inventing them is hallucination.\n\n"
+                                "When recommending a different profile, describe the difference\n"
+                                "qualitatively — \"lower temperature regime\", \"higher peak pressure\",\n"
+                                "\"shorter total duration\", \"flow-controlled instead of pressure-\n"
+                                "controlled\" — and let the user pull a reference shot on that profile to\n"
+                                "see its actual numbers. If the user explicitly asks for setpoints of a\n"
+                                "non-current profile, say you don't have its recipe and offer to discuss\n"
+                                "tradeoffs in qualitative terms.\n");
                         }
                     }
                     if (!profileKnowledge.isEmpty())


### PR DESCRIPTION
## Summary

- Add a **Cross-Profile Grind Ordering** section to the profile knowledge base, sourced from videoblurb.com/UGS (Mark Renowden's UGS calculator, GitHub issue #500): 16 canonical profiles with UGS positions, inferred positions for off-chart profiles, roast-level transition rules, and an explicit "UGS is not grinder clicks" caveat.
- Add per-profile \`UGS:\` lines on 21 profile sections so the AI sees the value adjacent to other facts when analyzing a shot, plus a \`Skip-Catalog: true\` mechanism for cross-cutting reference sections to keep the one-liner profile catalog clean.
- Add a **Grinder Adjustment Procedure** in \`espressoSystemPrompt()\` that gates magnitude advice through shot history (advisor uses \`dialInSessions\`, MCP clients use \`shots_list\`) and blocks UGS-to-clicks arithmetic when no anchor exists.
- Open \`get_agent_file\` and the \`decenza://dialing/current_context\` resource to all MCP clients (Claude Desktop is the primary target). Restructure \`claude_agent.md\` so universal principles apply to any client and Claude Code Remote Control's filesystem workflow is its own clearly-scoped section.
- Wire the cross-profile reference content into both the in-app advisor system prompt and \`dialing_get_context\` (default mode), so both surfaces see the data on every relevant call.

## Why

Failure mode from a real dialing conversation: the AI advised grinding *finer* when transitioning from a dark roast to a medium roast on the same profile — when *coarser* is correct. The agent file's existing rule ("ground grind changes in shot data, not generic advice") was right but only reached Claude Code Remote Control sessions. This PR makes the rule reach every MCP client and adds the cross-profile data + procedural rule needed to ground both directional and magnitude advice.

## Test plan

- [x] Build clean in Qt Creator (no errors, no warnings).
- [x] \`dialing_get_context\` default mode returns per-profile UGS + cross-profile reference appended to \`profileKnowledge\`.
- [x] \`dialing_get_context\` with \`includeFullKnowledge: true\` returns the full system prompt with cross-profile section injected and Skip-Catalog excluding it from the one-liner catalog.
- [x] Live \`ai_advisor_invoke\` on a real shot produces history-anchored advice (\`grinderSetting: "4.75"\` based on actual \`dialInSessions\` data, no UGS-to-clicks fabrication).
- [x] Cross-profile transition test surfaces a known weakness: the in-app advisor still slips into UGS-to-clicks arithmetic when there's no anchor in \`dialInSessions\`. **Followup planned** (OpenSpec proposal): pre-compute per-profile \`personalGrinderAnchors\` from shot history and inject them into the prompt so the advisor has empirical anchors to use instead of UGS arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)