### PR TITLE
feat(accessibility): include phase name and units in shot graph TalkBack announcement

### DIFF
--- a/qml/components/HistoryShotGraph.qml
+++ b/qml/components/HistoryShotGraph.qml
@@ -242,14 +242,18 @@ ChartView {
         return minDist < 1.0 ? closest.y : null
     }
 
-    // Return the phase label active at the given time, or empty string if none
+    // Return the phase label active at the given time, or empty string if none.
+    // Skips "Start"/"End" sentinels — they are structural markers, not user-facing phases.
     function getPhaseAtTime(time) {
         var label = ""
         for (var i = 0; i < phaseMarkers.length; i++) {
-            if (phaseMarkers[i].time <= time)
-                label = phaseMarkers[i].label
-            else
+            var m = phaseMarkers[i]
+            if (m.time <= time) {
+                if (m.label !== "Start" && m.label !== "End")
+                    label = m.label
+            } else {
                 break
+            }
         }
         return label
     }

--- a/qml/components/HistoryShotGraph.qml
+++ b/qml/components/HistoryShotGraph.qml
@@ -242,6 +242,18 @@ ChartView {
         return minDist < 1.0 ? closest.y : null
     }
 
+    // Return the phase label active at the given time, or empty string if none
+    function getPhaseAtTime(time) {
+        var label = ""
+        for (var i = 0; i < phaseMarkers.length; i++) {
+            if (phaseMarkers[i].time <= time)
+                label = phaseMarkers[i].label
+            else
+                break
+        }
+        return label
+    }
+
     // Announce curve values at a pixel position (called on tap)
     function announceAtPosition(pixelX, pixelY) {
         var dataPoint = chart.mapToValue(Qt.point(pixelX, pixelY), pressureSeries)
@@ -249,16 +261,16 @@ ChartView {
         if (time < 0 || time > timeAxis.max) return
 
         var curves = [
-            { name: "Pressure", series: pressureSeries, show: showPressure },
-            { name: "Flow", series: flowSeries, show: showFlow },
-            { name: "Temp", series: temperatureSeries, show: showTemperature },
-            { name: "Mix temp", series: temperatureMixSeries, show: showTemperatureMix && advancedMode },
-            { name: "Weight", series: weightSeries, show: showWeight },
-            { name: "Weight flow", series: weightFlowRateSeries, show: showWeightFlow },
-            { name: "Resistance", series: resistanceSeries, show: showResistance && advancedMode },
-            { name: "Darcy R", series: darcyResistanceSeries, show: showDarcyResistance && advancedMode },
-            { name: "Conductance", series: conductanceSeries, show: showConductance && advancedMode },
-            { name: "dC/dt", series: conductanceDerivativeSeries, show: showConductanceDerivative && advancedMode }
+            { name: "Pressure", series: pressureSeries, show: showPressure, unit: "bar" },
+            { name: "Flow", series: flowSeries, show: showFlow, unit: "mL/s" },
+            { name: "Temp", series: temperatureSeries, show: showTemperature, unit: "°C" },
+            { name: "Mix temp", series: temperatureMixSeries, show: showTemperatureMix && advancedMode, unit: "°C" },
+            { name: "Weight", series: weightSeries, show: showWeight, unit: "g" },
+            { name: "Weight flow", series: weightFlowRateSeries, show: showWeightFlow, unit: "g/s" },
+            { name: "Resistance", series: resistanceSeries, show: showResistance && advancedMode, unit: "" },
+            { name: "Darcy R", series: darcyResistanceSeries, show: showDarcyResistance && advancedMode, unit: "" },
+            { name: "Conductance", series: conductanceSeries, show: showConductance && advancedMode, unit: "" },
+            { name: "dC/dt", series: conductanceDerivativeSeries, show: showConductanceDerivative && advancedMode, unit: "" }
         ]
 
         var parts = []
@@ -266,13 +278,18 @@ ChartView {
             if (!curves[i].show) continue
             var v = findValueAtTime(curves[i].series, time)
             if (v !== null) {
-                parts.push(curves[i].name + " " + v.toFixed(1))
+                var entry = curves[i].name + " " + v.toFixed(1)
+                if (curves[i].unit !== "") entry += " " + curves[i].unit
+                parts.push(entry)
             }
         }
 
         if (parts.length === 0) return
         if (typeof AccessibilityManager !== "undefined") {
-            AccessibilityManager.announce(time.toFixed(1) + ". " + parts.join(". "), true)
+            var phase = getPhaseAtTime(time)
+            var header = "At " + time.toFixed(1) + " seconds"
+            if (phase !== "") header += ", " + phase + " phase"
+            AccessibilityManager.announce(header + ". " + parts.join(". "), true)
         }
     }
 


### PR DESCRIPTION
## Summary

- TalkBack users tapping the history shot graph now hear the active extraction phase name alongside the time and curve values
- Units added to every curve value in the announcement (bar, mL/s, °C, g, g/s)
- New `getPhaseAtTime()` helper looks up the phase marker active at the tapped time from the existing `phaseMarkers` array

**Before:** `"10.5. Pressure 9.0. Flow 2.5. Weight 18.0."`
**After:** `"At 10.5 seconds, Rise and Hold phase. Pressure 9.0 bar. Flow 2.5 mL/s. Weight 18.0 g."`

## Test plan

- [ ] Open a saved shot in the history detail page
- [ ] Enable TalkBack on Android
- [ ] Tap different points along the shot graph
- [ ] Verify announcement includes the phase name (e.g. "Pre-infusion", "Rise and Hold", "Decline") at the correct time boundaries
- [ ] Verify units are read aloud for each curve value
- [ ] Verify behavior is unchanged when no phase markers are present (announcement omits the phase clause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)