### PR TITLE
fix(ai): conversation index, grinderCalibration in-app path, 80s Espresso UGS, CI test

### DIFF
--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -544,13 +544,11 @@ Rectangle {
                             if (!conversation.hasHistory) {
                                 // ask() doesn't touch the index; switchConversation() must run first
                                 // so the web UI shows this conversation (e.g. after a clear).
-                                if (MainController.aiManager && overlay.savedBeanBrand !== undefined) {
-                                    MainController.aiManager.switchConversation(
-                                        overlay.savedBeanBrand || "",
-                                        overlay.savedBeanType || "",
-                                        overlay.savedProfileName || ""
-                                    )
-                                }
+                                MainController.aiManager.switchConversation(
+                                    overlay.savedBeanBrand || "",
+                                    overlay.savedBeanType || "",
+                                    overlay.savedProfileName || ""
+                                )
                                 var bevType = (overlay.beverageType || "espresso").toLowerCase()
                                 var systemPrompt = conversation.multiShotSystemPrompt(bevType, overlay.savedProfileName)
                                 conversation.ask(systemPrompt, message)

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -542,6 +542,15 @@ Rectangle {
                             // Use ask() for new conversation, followUp() for existing
                             var sent = false
                             if (!conversation.hasHistory) {
+                                // ask() doesn't touch the index; switchConversation() must run first
+                                // so the web UI shows this conversation (e.g. after a clear).
+                                if (MainController.aiManager && overlay.savedBeanBrand !== undefined) {
+                                    MainController.aiManager.switchConversation(
+                                        overlay.savedBeanBrand || "",
+                                        overlay.savedBeanType || "",
+                                        overlay.savedProfileName || ""
+                                    )
+                                }
                                 var bevType = (overlay.beverageType || "espresso").toLowerCase()
                                 var systemPrompt = conversation.multiShotSystemPrompt(bevType, overlay.savedProfileName)
                                 conversation.ask(systemPrompt, message)

--- a/resources/ai/profile_knowledge.md
+++ b/resources/ai/profile_knowledge.md
@@ -48,7 +48,7 @@ These positions are **not** from the UGS calculator. They are reasoned estimates
 
 | UGS (est.) | Profile | Rationale |
 |------------|---------|-----------|
-| ~0.25 | **80's Espresso** | Lever-decline mechanic but with an unusual low-temperature regime (82°C declining to 72°C). The low extraction temperature reduces solubility, requiring a finer grind than the temperature-normal lever group to compensate. Observed in user shot history to pull significantly finer than D-Flow on the same bean. |
+| ~-0.5 | **80's Espresso** | Lever-decline mechanic with an extreme low-temperature regime (82°C declining to 72°C). The very low extraction temperature dramatically reduces solubility, requiring a much finer grind than any temperature-normal lever profile. Empirically observed to pull ~3–4 grinder steps finer than D-Flow / Q on the same bean and grinder — placing it finer than Cremina/LRv3 territory, not between them and D-Flow. |
 | ~0–0.5 | Damian's LRv2, LRv3, LM Leva, Q | Londinium / D-Flow adjacent; treat as the same family. |
 | ~1.25 | Classic Italian / Gentler 8.4 Bar / Italian Australian | Constant-pressure family, behaves like Flat 9 Bar. |
 | ~5–7 | Hendon Turbo, TurboBloom, Nu Skool, Pour Over Basket | High-flow turbo/filter territory. |
@@ -343,13 +343,13 @@ DO NOT flag slow flow (1–1.5 ml/s), long duration, or low ratio as problems �
 DO NOT flag channeling in dC/dt — the blooming phase (near-zero flow) followed by extraction onset produces conductance derivative spikes unrelated to puck quality. This is a milk-drink texture-first profile.
 
 ## 80's Espresso
-UGS: ~0.25 (inferred — low-temp regime requires finer grind than D-Flow)
+UGS: ~-0.5 (inferred — extreme low-temp regime requires much finer grind than any temperature-normal lever profile; empirically ~3–4 steps finer than D-Flow on the same grinder)
 Category: Lever at low temperature
 Family: lever-decline
 How it works: Lever profile at very low temperature (82→72°C declining). Fast preinfusion fill at 7.5 ml/s, then 7.8 bar declining to 5 bar. Intentionally under-extracts to minimize tar/burnt flavors from dark beans.
 Expected curves: Lever-style declining pressure (7.8→5 bar). Temperature starts at 82°C and declines toward 72°C. Flow should be SLOW (ideally 1-1.2 ml/s for best results). If flow peaks at 1.9+ ml/s, shot will be dusty/thin — slower is better.
 Duration: 35-45s is ideal (lever-style timing). 25s is too short.
-Grind: Medium (coarser than Londinium/Cremina, finer than E61)
+Grind: Very fine — finer than Cremina/LRv3 territory. Switching FROM 80's Espresso to LRv3 requires grind coarser by ~1.5–2 steps on a Niche Zero-scale grinder (UGS distance of 0.5, conversionKey ~3.5).
 Flavor: Bread fruit, raisins, baker's chocolate without burn. Minimizes tar flavors.
 Best with 12g waisted basket for maximum mouthfeel and minimal channeling. 1:1 ratio (Italian style) also works well.
 Roast: Dark only. Designed specifically to get fruitiness from dark beans by using low temperature.

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -1092,7 +1092,10 @@ void AIManager::requestRecentShotContext(const QString& beanBrand, const QString
             q.prepare("SELECT grinder_brand, grinder_model, grinder_burrs, beverage_type "
                       "FROM shots WHERE id = ?");
             q.bindValue(0, static_cast<qint64>(excludeShotId));
-            if (q.exec() && q.next()) {
+            if (!q.exec()) {
+                qWarning() << "AIManager::requestRecentShotContext: grinder ctx query failed:"
+                           << q.lastError().text();
+            } else if (q.next()) {
                 grinderBrand = q.value(0).toString();
                 QString model = q.value(1).toString();
                 QString burrs = q.value(2).toString();
@@ -1287,7 +1290,8 @@ void AIManager::emitRecentShotContext(
                 .arg(coarse[QStringLiteral("ugs")].toDouble())
                 .arg(coarse[QStringLiteral("medianSetting")].toString())
                 .arg(coarse[QStringLiteral("sampleCount")].toInt());
-            cal += QStringLiteral("- **Conversion**: %1 grinder steps per UGS unit\n").arg(ck);
+            if (ck > 1e-9)
+                cal += QStringLiteral("- **Conversion**: %1 grinder steps per UGS unit\n").arg(ck);
 
             QStringList profLines;
             const QJsonArray profiles = grinderCalibration[QStringLiteral("profiles")].toArray();

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -1084,20 +1084,24 @@ void AIManager::requestRecentShotContext(const QString& beanBrand, const QString
     QThread* thread = QThread::create([self, dbPath, beanBrand, beanType, profileName, excludeShotId, serial]() {
         auto qualifiedShots = loadQualifiedShots(dbPath, beanBrand, beanType, profileName, excludeShotId);
 
-        // Query grinder context on background thread using the shared helper (also used by MCP dialing_get_context)
         GrinderContext grinderCtx;
         QString grinderBrand;
+        QJsonObject grinderCalibration;
         withTempDb(dbPath, "ai_grinder_ctx", [&](QSqlDatabase& db) {
             QSqlQuery q(db);
-            q.prepare("SELECT grinder_brand, grinder_model, beverage_type "
+            q.prepare("SELECT grinder_brand, grinder_model, grinder_burrs, beverage_type "
                       "FROM shots WHERE id = ?");
             q.bindValue(0, static_cast<qint64>(excludeShotId));
             if (q.exec() && q.next()) {
                 grinderBrand = q.value(0).toString();
                 QString model = q.value(1).toString();
-                QString bev = q.value(2).toString();
-                if (!model.isEmpty())
+                QString burrs = q.value(2).toString();
+                QString bev = q.value(3).toString();
+                if (!model.isEmpty()) {
                     grinderCtx = ShotHistoryStorage::queryGrinderContext(db, model, bev);
+                    grinderCalibration = DialingBlocks::buildGrinderCalibrationBlock(
+                        db, model, burrs, bev, excludeShotId);
+                }
             }
         });
 
@@ -1107,9 +1111,10 @@ void AIManager::requestRecentShotContext(const QString& beanBrand, const QString
         // (`friend class tst_AIManager`) without standing up a real DB.
         QMetaObject::invokeMethod(qApp, [self, serial, qualifiedShots = std::move(qualifiedShots),
                                          grinderCtx = std::move(grinderCtx),
-                                         grinderBrand = std::move(grinderBrand)]() mutable {
+                                         grinderBrand = std::move(grinderBrand),
+                                         grinderCalibration = std::move(grinderCalibration)]() mutable {
             if (!self) return;
-            self->emitRecentShotContext(qualifiedShots, grinderCtx, grinderBrand, serial);
+            self->emitRecentShotContext(qualifiedShots, grinderCtx, grinderBrand, serial, grinderCalibration);
         }, Qt::QueuedConnection);
     });
 
@@ -1121,7 +1126,8 @@ void AIManager::emitRecentShotContext(
     const QList<QPair<qint64, ShotProjection>>& qualifiedShots,
     const GrinderContext& grinderCtx,
     const QString& grinderBrand,
-    int serial)
+    int serial,
+    const QJsonObject& grinderCalibration)
 {
     if (serial != m_contextSerial) {
         // Stale request superseded by a newer one — emit empty so QML clears contextLoading.
@@ -1257,6 +1263,52 @@ void AIManager::emitRecentShotContext(
             }
         }
         result += section;
+    }
+
+    // Append grinder calibration (RGS anchors + conversionKey). Goes into
+    // historicalContext → first user message → cached by the Anthropic
+    // provider exactly like the shot history and grinder context sections.
+    if (!grinderCalibration.isEmpty()) {
+        QJsonObject fine = grinderCalibration["fineAnchor"].toObject();
+        QJsonObject coarse = grinderCalibration["coarseAnchor"].toObject();
+        double ck = grinderCalibration["conversionKey"].toDouble();
+        QString model = grinderCalibration["grinderModel"].toString();
+
+        if (!fine.isEmpty() && !coarse.isEmpty()) {
+            QString cal = QStringLiteral("\n\n## Grinder Calibration\n\n");
+            cal += QStringLiteral("Calibrated on your %1 using anchor shots:\n\n").arg(model);
+            cal += QStringLiteral("- **Fine anchor**: %1 (UGS %2) — median setting **%3** (%4 shots)\n")
+                .arg(fine[QStringLiteral("profileName")].toString())
+                .arg(fine[QStringLiteral("ugs")].toDouble())
+                .arg(fine[QStringLiteral("medianSetting")].toString())
+                .arg(fine[QStringLiteral("sampleCount")].toInt());
+            cal += QStringLiteral("- **Coarse anchor**: %1 (UGS %2) — median setting **%3** (%4 shots)\n")
+                .arg(coarse[QStringLiteral("profileName")].toString())
+                .arg(coarse[QStringLiteral("ugs")].toDouble())
+                .arg(coarse[QStringLiteral("medianSetting")].toString())
+                .arg(coarse[QStringLiteral("sampleCount")].toInt());
+            cal += QStringLiteral("- **Conversion**: %1 grinder steps per UGS unit\n").arg(ck);
+
+            QStringList profLines;
+            const QJsonArray profiles = grinderCalibration[QStringLiteral("profiles")].toArray();
+            for (const QJsonValue& v : profiles) {
+                const QJsonObject p = v.toObject();
+                const QString src = p[QStringLiteral("source")].toString();
+                if (src == QStringLiteral("history") || src == QStringLiteral("derived")) {
+                    profLines << QStringLiteral("- **%1** (UGS %2): **%3** (%4)")
+                        .arg(p[QStringLiteral("profileName")].toString())
+                        .arg(p[QStringLiteral("ugs")].toDouble())
+                        .arg(p[QStringLiteral("rgs")].toString())
+                        .arg(src);
+                }
+            }
+            if (!profLines.isEmpty()) {
+                cal += QStringLiteral("\nProfile RGS — seed starting grind when switching profiles:\n\n");
+                cal += profLines.join('\n') + '\n';
+            }
+
+            result += cal;
+        }
     }
 
     emit recentShotContextReady(result);

--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -356,7 +356,8 @@ private:
         const QList<QPair<qint64, ShotProjection>>& qualifiedShots,
         const GrinderContext& grinderCtx,
         const QString& grinderBrand,
-        int serial);
+        int serial,
+        const QJsonObject& grinderCalibration = QJsonObject());
 
     // Conversation for multi-turn interactions
     AIConversation* m_conversation = nullptr;

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -878,6 +878,88 @@ private slots:
                  "stale request must emit empty string");
     }
 
+    void emitRecentShotContext_appendsGrinderCalibrationBlock()
+    {
+        // Pins the ## Grinder Calibration prose rendering in emitRecentShotContext:
+        // history and derived profile entries appear; extrapolated entries do not.
+        QNetworkAccessManager nam;
+        Settings settings;
+        AIManager mgr(&nam, &settings);
+        mgr.m_contextSerial = 42;
+
+        auto makeAnchor = [](const QString& name, double ugs,
+                              const QString& setting, int count) {
+            QJsonObject a;
+            a[QStringLiteral("profileName")] = name;
+            a[QStringLiteral("ugs")] = ugs;
+            a[QStringLiteral("medianSetting")] = setting;
+            a[QStringLiteral("sampleCount")] = count;
+            return a;
+        };
+
+        QJsonObject calibration;
+        calibration[QStringLiteral("grinderModel")] = QStringLiteral("Niche Zero");
+        calibration[QStringLiteral("fineAnchor")]   = makeAnchor(QStringLiteral("D-Flow"), 0.0, QStringLiteral("7.75"), 8);
+        calibration[QStringLiteral("coarseAnchor")] = makeAnchor(QStringLiteral("Classic Italian"), 1.25, QStringLiteral("12.1"), 3);
+        calibration[QStringLiteral("conversionKey")] = 3.48;
+
+        QJsonArray profiles;
+        {
+            QJsonObject p;
+            p[QStringLiteral("profileName")] = QStringLiteral("D-Flow");
+            p[QStringLiteral("ugs")] = 0.0;
+            p[QStringLiteral("rgs")] = QStringLiteral("7.75");
+            p[QStringLiteral("source")] = QStringLiteral("history");
+            profiles.append(p);
+        }
+        {
+            QJsonObject p;
+            p[QStringLiteral("profileName")] = QStringLiteral("LRv3");
+            p[QStringLiteral("ugs")] = 0.5;
+            p[QStringLiteral("rgs")] = QStringLiteral("9.49");
+            p[QStringLiteral("source")] = QStringLiteral("derived");
+            profiles.append(p);
+        }
+        {
+            QJsonObject p;
+            p[QStringLiteral("profileName")] = QStringLiteral("Turbo 35");
+            p[QStringLiteral("ugs")] = 5.0;
+            p[QStringLiteral("rgs")] = QStringLiteral("25.0");
+            p[QStringLiteral("source")] = QStringLiteral("extrapolated"); // must not appear
+            profiles.append(p);
+        }
+        calibration[QStringLiteral("profiles")] = profiles;
+
+        QSignalSpy spy(&mgr, &AIManager::recentShotContextReady);
+        QVERIFY(spy.isValid());
+
+        mgr.emitRecentShotContext({}, GrinderContext{}, {}, 42, calibration);
+
+        QCOMPARE(spy.count(), 1);
+        const QString payload = spy.takeFirst().at(0).toString();
+
+        QVERIFY2(payload.contains(QStringLiteral("## Grinder Calibration")),
+                 "calibration section header missing");
+        QVERIFY2(payload.contains(QStringLiteral("Niche Zero")),
+                 "grinder model missing");
+        QVERIFY2(payload.contains(QStringLiteral("Fine anchor")),
+                 "fine anchor label missing");
+        QVERIFY2(payload.contains(QStringLiteral("D-Flow")),
+                 "fine anchor profile name missing");
+        QVERIFY2(payload.contains(QStringLiteral("Coarse anchor")),
+                 "coarse anchor label missing");
+        QVERIFY2(payload.contains(QStringLiteral("Classic Italian")),
+                 "coarse anchor profile name missing");
+        QVERIFY2(payload.contains(QStringLiteral("3.48")),
+                 "conversion key missing");
+        QVERIFY2(payload.contains(QStringLiteral("Profile RGS")),
+                 "profile table header missing");
+        QVERIFY2(payload.contains(QStringLiteral("LRv3")),
+                 "derived profile entry missing");
+        QVERIFY2(!payload.contains(QStringLiteral("Turbo 35")),
+                 "extrapolated profile must not appear in prose table");
+    }
+
     // =====================================================================
     // AIConversation::extractShotFields — issue #1039
     // Pins the structured-field migration: dose / yield / duration /
@@ -2135,14 +2217,17 @@ private slots:
         // must return 0 without error.
         QSettings s;
         s.clear();
+
+        // Construct AIManager first so clearAllConversationsOnce() fires on
+        // empty settings and marks itself done before we write test data.
+        QNetworkAccessManager nam;
+        Settings appSettings;
+        AIManager mgr(&nam, &appSettings);
+
         const QString key = "test_legacy_shotid";
         const QString prefix = QStringLiteral("ai/conversations/") + key + "/";
         s.setValue(prefix + "messages", QByteArrayLiteral(
             "[{\"role\":\"user\",\"content\":\"u\"},{\"role\":\"assistant\",\"content\":\"a\"}]"));
-
-        QNetworkAccessManager nam;
-        Settings appSettings;
-        AIManager mgr(&nam, &appSettings);
         AIConversation conv(&mgr);
         conv.setStorageKey(key);
         conv.loadFromStorage();

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -1550,6 +1550,15 @@ private slots:
         // byte-equivalent across surfaces (#1041 parity contract).
         QSettings s;
         s.clear();
+
+        // Create AIManager first so clearAllConversationsOnce() fires on empty
+        // settings and marks itself done — otherwise it would wipe the test
+        // data we store below (the marker lives in QSettings and is absent
+        // after s.clear(), causing the migration to re-fire on every CI run).
+        QNetworkAccessManager nam;
+        Settings appSettings;
+        AIManager mgr(&nam, &appSettings);
+
         const QString key = "test_recent_advice_parity";
         const QString prefix = QStringLiteral("ai/conversations/") + key + "/";
 
@@ -1575,11 +1584,6 @@ private slots:
                 "\"reasoning\":\"r2\"}}]");
         s.setValue(prefix + "systemPrompt", "system");
         s.setValue(prefix + "messages", messages);
-
-        // In-app: live AIConversation -> recentAssistantTurns(3).
-        QNetworkAccessManager nam;
-        Settings appSettings;
-        AIManager mgr(&nam, &appSettings);
         AIConversation conv(&mgr);
         conv.setStorageKey(key);
         conv.loadFromStorage();


### PR DESCRIPTION
## Summary

- **Conversation index after clear**: `ConversationOverlay.qml` `sendFollowUp()` was calling `ask()` without first calling `switchConversation()` in the `!hasHistory` branch. The conversation was active in-app but invisible on the web AI conversations page. Fix: call `switchConversation()` before `ask()` so `touchConversationEntry()` runs and registers the conversation.
- **grinderCalibration missing from in-app path**: `requestRecentShotContext()` / `emitRecentShotContext()` only returned shot history + observed grinder range prose — no RGS anchor calibration. Now computes `buildGrinderCalibrationBlock()` in the background DB thread and renders the `## Grinder Calibration` prose in `emitRecentShotContext()`. This lands in `overlay.historicalContext`, which is prepended to the first user message and therefore in the Anthropic cache-control window.
- **80's Espresso UGS**: Corrected from ~0.25 to ~-0.5 based on empirical shots (80's at 4.0, D-Flow at 7.75 on a Niche Zero; gap of 3.75 steps implies UGS ~0.5 finer than D-Flow). Updated cross-profile table and `UGS:` field in `profile_knowledge.md`. LRv3 starting point from 80's is now documented as ~5.75–6.0 (0.5 × 3.75 = 1.875 steps coarser).
- **Linux CI test failure**: `tst_aimanager` `aiConversation_recentAdviceParity_inAppMatchesMcpStaticLoader` was failing on Linux (but passing on macOS locally). `s.clear()` wiped the `ai/migrations/grinder_calibration_v1.7.2` marker, so `clearAllConversationsOnce()` fired in the AIManager constructor and deleted the test data stored just before it. Fix: construct `AIManager` before writing test QSettings data.
- **Review fixes**: Remove dead `savedBeanBrand !== undefined` guard (QML `property string` is never `undefined`; `aiManager` already null-checked); log `qWarning + lastError` on grinder ctx query failure instead of silently skipping; gate conversion key line with `ck > 1e-9`; fix same `AIManager` construction ordering hazard in `legacyConversationHasZeroShotId` test; add `emitRecentShotContext_appendsGrinderCalibrationBlock` test pinning prose rendering and source-filter behavior.

## Test plan

- [ ] Clear an AI conversation in-app, type a new message → conversation appears on web AI page after refresh
- [ ] Grinder Calibration section visible in the first context block of a new conversation (check via AI advisor MCP or by inspecting the logged prompt)
- [ ] AI recommendation for switching 80's Espresso → LRv3 quotes ~5.75–6.0 as the starting grind on Niche Zero
- [ ] `tst_aimanager` passes on Linux CI (no `aiConversation_recentAdviceParity` failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)