### PR TITLE
fix(ai): include roast level and roast date in advisor setup header

### DIFF
--- a/src/ai/aiconversation.cpp
+++ b/src/ai/aiconversation.cpp
@@ -498,7 +498,7 @@ QString AIConversation::getConversationText() const
                 text += "**You:** " + content;
             }
         } else if (role == "assistant") {
-            text += "**" + providerName() + ":** " + content;
+            text += "**" + providerName() + ":** " + stripStructuredNextBlock(content);
         }
     }
 
@@ -595,6 +595,40 @@ QString AIConversation::multiShotSystemPrompt(const QString& beverageType, const
         "Track progress across shots and reference previous attempts to identify trends. "
         "Keep advice to ONE specific change per shot — don't overload with multiple adjustments.");
     return base;
+}
+
+QString AIConversation::stripStructuredNextBlock(const QString& content)
+{
+    // Strip the trailing ```json ... ``` block that the system prompt asks the
+    // model to append when making a concrete parameter recommendation. The block
+    // is parsed and stored as structuredNext on the message; it must not appear
+    // in the displayed conversation text.
+    QList<qsizetype> fences;
+    qsizetype pos = 0;
+    while (true) {
+        pos = content.indexOf(QStringLiteral("```"), pos);
+        if (pos < 0) break;
+        fences.append(pos);
+        pos += 3;
+    }
+    if (fences.size() < 2) return content;
+
+    const qsizetype openerStart = fences.at(fences.size() - 2);
+    const qsizetype closerStart = fences.at(fences.size() - 1);
+
+    // Closer must be followed only by whitespace.
+    for (qsizetype i = closerStart + 3; i < content.size(); ++i) {
+        if (!content[i].isSpace()) return content;
+    }
+
+    // Opener tag must be "json".
+    const qsizetype tagStart = openerStart + 3;
+    const qsizetype nl = content.indexOf(QLatin1Char('\n'), tagStart);
+    if (nl < 0 || nl >= closerStart) return content;
+    if (content.mid(tagStart, nl - tagStart).trimmed().compare(QStringLiteral("json"), Qt::CaseInsensitive) != 0)
+        return content;
+
+    return content.left(openerStart).trimmed();
 }
 
 QString AIConversation::extractShotProse(const QString& content)

--- a/src/ai/aiconversation.h
+++ b/src/ai/aiconversation.h
@@ -249,6 +249,7 @@ private:
     void trimHistory();
     static QString summarizeShotMessage(const QString& content);
     static QString summarizeAdvice(const QString& response);
+    static QString stripStructuredNextBlock(const QString& content);
 
     // Legacy fallback: extracts the `shotAnalysis` prose from the JSON
     // envelope when present, otherwise returns the message unchanged.

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -1150,7 +1150,7 @@ void AIManager::emitRecentShotContext(
     // identity.
     QString profileTitle, profileIntent, profileRecipe;
     QString setupGrinderBrand, setupGrinderModel, setupGrinderBurrs;
-    QString setupBeanBrand, setupBeanType;
+    QString setupBeanBrand, setupBeanType, setupRoastLevel, setupRoastDate;
     // Empty fields read as "unrecorded, inherit" — not "different."
     // Older shots predating DYE recording have empty grinder/bean
     // strings; treating those as a mismatch would suppress the
@@ -1174,6 +1174,8 @@ void AIManager::emitRecentShotContext(
         seedOrCompare(setupGrinderBurrs, s.grinderBurrs);
         seedOrCompare(setupBeanBrand, s.beanBrand);
         seedOrCompare(setupBeanType, s.beanType);
+        seedOrCompare(setupRoastLevel, s.roastLevel);
+        seedOrCompare(setupRoastDate, s.roastDate);
         if (profileTitle.isEmpty() && !s.profileName.isEmpty())
             profileTitle = s.profileName;
         if (profileIntent.isEmpty() && !s.profileNotes.isEmpty())
@@ -1236,8 +1238,12 @@ void AIManager::emitRecentShotContext(
                 beanName = setupBeanBrand;
             else if (!setupBeanType.isEmpty())
                 beanName = setupBeanType;
-            if (!beanName.isEmpty())
-                parts << (parts.isEmpty() ? beanName : "on " + beanName);
+            if (!beanName.isEmpty()) {
+                QString beanFull = beanName;
+                if (!setupRoastLevel.isEmpty()) beanFull += " (" + setupRoastLevel + ")";
+                if (!setupRoastDate.isEmpty()) beanFull += ", roasted " + setupRoastDate;
+                parts << (parts.isEmpty() ? beanFull : "on " + beanFull);
+            }
 
             result += "### Setup: " + parts.join(" ") + "\n\n";
         }

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -2238,6 +2238,236 @@ private slots:
 
         s.clear();
     }
+
+    // -----------------------------------------------------------------
+    // emitRecentShotContext — roast level / date in Setup header
+    // Pins the fix from PR #1074: roastLevel and roastDate must appear in
+    // the hoisted ### Setup: header alongside grinder + bean identity.
+    // -----------------------------------------------------------------
+
+    void emitRecentShotContext_setupHeader_includesRoastLevelAndDate()
+    {
+        QNetworkAccessManager nam;
+        Settings settings;
+        AIManager mgr(&nam, &settings);
+        mgr.m_contextSerial = 20;
+
+        const qint64 base = QDateTime::currentSecsSinceEpoch() - 3600;
+        QList<QPair<qint64, ShotProjection>> qualifiedShots;
+        ShotProjection shot = makeShot(1, base,
+            QString(), QString(), QString(), QStringLiteral("4.0"),
+            QStringLiteral("Northbound"), QStringLiteral("Spring Tour"),
+            QStringLiteral("Profile"), QString(), QString());
+        shot.roastLevel = QStringLiteral("Medium-Dark");
+        shot.roastDate  = QStringLiteral("2026-03-15");
+        qualifiedShots.append({base, shot});
+
+        QSignalSpy spy(&mgr, &AIManager::recentShotContextReady);
+        mgr.emitRecentShotContext(qualifiedShots, GrinderContext{}, QString(), 20);
+
+        QCOMPARE(spy.count(), 1);
+        const QString payload = spy.takeFirst().at(0).toString();
+
+        QVERIFY2(payload.contains(QStringLiteral("(Medium-Dark)")),
+                 "roastLevel must appear in parentheses after bean name");
+        QVERIFY2(payload.contains(QStringLiteral(", roasted 2026-03-15")),
+                 "roastDate must appear as ', roasted <date>' after roast level");
+        QVERIFY2(payload.contains(
+                     QStringLiteral("Northbound - Spring Tour (Medium-Dark), roasted 2026-03-15")),
+                 qPrintable("Expected bean+roast segment in Setup header; payload: "
+                            + payload.left(500)));
+    }
+
+    void emitRecentShotContext_setupHeader_roastLevelOnly()
+    {
+        QNetworkAccessManager nam;
+        Settings settings;
+        AIManager mgr(&nam, &settings);
+        mgr.m_contextSerial = 21;
+
+        const qint64 base = QDateTime::currentSecsSinceEpoch() - 3600;
+        QList<QPair<qint64, ShotProjection>> qualifiedShots;
+        ShotProjection shot = makeShot(1, base,
+            QString(), QString(), QString(), QStringLiteral("4.0"),
+            QStringLiteral("Northbound"), QStringLiteral("Spring Tour"),
+            QStringLiteral("Profile"), QString(), QString());
+        shot.roastLevel = QStringLiteral("Light");
+        qualifiedShots.append({base, shot});
+
+        QSignalSpy spy(&mgr, &AIManager::recentShotContextReady);
+        mgr.emitRecentShotContext(qualifiedShots, GrinderContext{}, QString(), 21);
+
+        QCOMPARE(spy.count(), 1);
+        const QString payload = spy.takeFirst().at(0).toString();
+
+        QVERIFY2(payload.contains(QStringLiteral("(Light)")),
+                 "roastLevel must appear in parentheses even when roastDate is absent");
+        QVERIFY2(!payload.contains(QStringLiteral("roasted")),
+                 "no 'roasted' text when roastDate is absent");
+    }
+
+    void emitRecentShotContext_setupHeader_roastDateOnly()
+    {
+        QNetworkAccessManager nam;
+        Settings settings;
+        AIManager mgr(&nam, &settings);
+        mgr.m_contextSerial = 22;
+
+        const qint64 base = QDateTime::currentSecsSinceEpoch() - 3600;
+        QList<QPair<qint64, ShotProjection>> qualifiedShots;
+        ShotProjection shot = makeShot(1, base,
+            QString(), QString(), QString(), QStringLiteral("4.0"),
+            QStringLiteral("Northbound"), QStringLiteral("Spring Tour"),
+            QStringLiteral("Profile"), QString(), QString());
+        shot.roastDate = QStringLiteral("2026-01-10");
+        qualifiedShots.append({base, shot});
+
+        QSignalSpy spy(&mgr, &AIManager::recentShotContextReady);
+        mgr.emitRecentShotContext(qualifiedShots, GrinderContext{}, QString(), 22);
+
+        QCOMPARE(spy.count(), 1);
+        const QString payload = spy.takeFirst().at(0).toString();
+
+        QVERIFY2(payload.contains(QStringLiteral("roasted 2026-01-10")),
+                 "roastDate must appear as 'roasted <date>' even when roastLevel is absent");
+        QVERIFY2(!payload.contains(QStringLiteral("()")),
+                 "no empty parentheses when roastLevel is absent");
+    }
+
+    void emitRecentShotContext_roastLevelConflictSuppressesSetup()
+    {
+        QNetworkAccessManager nam;
+        Settings settings;
+        AIManager mgr(&nam, &settings);
+        mgr.m_contextSerial = 23;
+
+        const qint64 base = QDateTime::currentSecsSinceEpoch() - 86400;
+        QList<QPair<qint64, ShotProjection>> qualifiedShots;
+
+        ShotProjection shot1 = makeShot(1, base + 3600,
+            QStringLiteral("Niche"), QStringLiteral("Zero"),
+            QStringLiteral("63mm Kony"), QStringLiteral("4.0"),
+            QStringLiteral("Northbound"), QStringLiteral("Spring Tour"),
+            QStringLiteral("Profile"), QString(), QString());
+        shot1.roastLevel = QStringLiteral("Light");
+
+        ShotProjection shot2 = makeShot(2, base,
+            QStringLiteral("Niche"), QStringLiteral("Zero"),
+            QStringLiteral("63mm Kony"), QStringLiteral("4.0"),
+            QStringLiteral("Northbound"), QStringLiteral("Spring Tour"),
+            QStringLiteral("Profile"), QString(), QString());
+        shot2.roastLevel = QStringLiteral("Dark");
+
+        qualifiedShots.append({base + 3600, shot1});
+        qualifiedShots.append({base, shot2});
+
+        QSignalSpy spy(&mgr, &AIManager::recentShotContextReady);
+        mgr.emitRecentShotContext(qualifiedShots, GrinderContext{}, QStringLiteral("Niche"), 23);
+
+        QCOMPARE(spy.count(), 1);
+        const QString payload = spy.takeFirst().at(0).toString();
+
+        QCOMPARE(payload.count(QStringLiteral("### Setup:")), 0);
+    }
+
+    // -----------------------------------------------------------------
+    // AIConversation::stripStructuredNextBlock
+    // Pins the fix from PR #1074: the trailing ```json ... ``` block the
+    // AI appends must be stripped before display in getConversationText.
+    // -----------------------------------------------------------------
+
+    void stripStructuredNextBlock_noFencedBlock_returnsUnchanged()
+    {
+        const QString plain = QStringLiteral("Adjust your grinder to 4.5.");
+        QCOMPARE(AIConversation::stripStructuredNextBlock(plain), plain);
+    }
+
+    void stripStructuredNextBlock_validTrailingJsonBlock_stripsBlock()
+    {
+        const QString content = QStringLiteral(
+            "Try 4.75.\n\n```json\n{\"grinderSetting\":\"4.75\"}\n```");
+        const QString result = AIConversation::stripStructuredNextBlock(content);
+        QCOMPARE(result, QStringLiteral("Try 4.75."));
+        QVERIFY2(!result.contains(QStringLiteral("```")),
+                 "stripped result must not contain any fence markers");
+    }
+
+    void stripStructuredNextBlock_nonJsonTag_returnsUnchanged()
+    {
+        const QString content = QStringLiteral(
+            "Try 4.75.\n\n```python\nprint('hello')\n```");
+        QCOMPARE(AIConversation::stripStructuredNextBlock(content), content);
+    }
+
+    void stripStructuredNextBlock_trailingContentAfterCloser_returnsUnchanged()
+    {
+        const QString content = QStringLiteral(
+            "Try 4.75.\n\n```json\n{\"grinderSetting\":\"4.75\"}\n```\nOne more thing.");
+        QCOMPARE(AIConversation::stripStructuredNextBlock(content), content);
+    }
+
+    void stripStructuredNextBlock_oddFenceCount_stripsIfLastTwoFormValidBlock()
+    {
+        // Prose contains an earlier fenced block (even count before the json
+        // block), then a valid trailing json block. The last two fences must
+        // form the json block and be stripped; earlier fences are untouched.
+        const QString content = QStringLiteral(
+            "For reference:\n```plain\ncode\n```\n\n"
+            "```json\n{\"grinderSetting\":\"4.75\"}\n```");
+        const QString result = AIConversation::stripStructuredNextBlock(content);
+        QVERIFY2(!result.contains(QStringLiteral("```json")),
+                 "trailing json block must be stripped even when earlier fences exist");
+        QVERIFY2(result.contains(QStringLiteral("For reference:")),
+                 "prose before the json block must be preserved");
+        QVERIFY2(result.contains(QStringLiteral("```plain")),
+                 "earlier non-json fences must be preserved");
+    }
+
+    void stripStructuredNextBlock_missingNewlineAfterTag_returnsUnchanged()
+    {
+        // No newline between the opening tag and the JSON body — the tag
+        // check requires a newline delimiter; without it the block is
+        // malformed and must not strip.
+        const QString content = QStringLiteral(
+            "Try 4.75.\n\n```json{\"grinderSetting\":\"4.75\"}\n```");
+        QCOMPARE(AIConversation::stripStructuredNextBlock(content), content);
+    }
+
+    void aiConversation_getConversationText_stripsJsonBlock()
+    {
+        QSettings s;
+        s.clear();
+
+        QNetworkAccessManager nam;
+        Settings appSettings;
+        AIManager mgr(&nam, &appSettings);
+        AIConversation conv(&mgr);
+        conv.setStorageKey(QStringLiteral("test_strip_conversation_text"));
+
+        conv.m_systemPrompt = QStringLiteral("system");
+        conv.addUserMessage(QStringLiteral("What grind setting?"));
+
+        const QString response = QStringLiteral(
+            "Try grinder 4.75 for a 32-38 s shot.\n\n"
+            "```json\n{\"grinderSetting\":\"4.75\","
+            "\"expectedDurationSec\":[32,38],"
+            "\"expectedFlowMlPerSec\":[1.0,1.5],"
+            "\"successCondition\":\"OK\","
+            "\"reasoning\":\"r\"}\n```");
+        const auto parsed = AIManager::parseStructuredNext(response);
+        conv.addAssistantMessage(response, parsed);
+
+        const QString text = conv.getConversationText();
+
+        QVERIFY2(text.contains(QStringLiteral("Try grinder 4.75")),
+                 "prose advice must appear in conversation text");
+        QVERIFY2(!text.contains(QStringLiteral("```json")),
+                 "json fence must not appear in conversation text");
+        QVERIFY2(!text.contains(QStringLiteral("grinderSetting")),
+                 "json body must not appear in conversation text");
+
+        s.clear();
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_AIManager)


### PR DESCRIPTION
## Summary

- **Roast level missing from AI context**: The conversation flow's `### Setup:` header hoisted bean brand/type and grinder identity but omitted `roastLevel` and `roastDate`. The AI was correctly following its system-prompt instruction to ask about blank fields, causing unnecessary "what's your roast level?" prompts even when the shot had that data recorded. Fix adds both fields to the `seedOrCompare` collection in `emitRecentShotContext` and appends them to the bean name (e.g. `Northbound Coffee Roasters - Spring Tour 2026 #2 (Dark), roasted 2026-03-30`).

- **Trailing JSON block visible in conversation**: Every AI response that made a parameter recommendation ended with the raw `nextShot` \`\`\`json\`\`\` block in the chat UI. That block is parsed and stored as `structuredNext` internally — it should never appear in the displayed text. Fix strips it in `getConversationText()` via a new `stripStructuredNextBlock()` helper that uses the same fence-walking logic as `parseStructuredNext`.

## Test plan

- [ ] Open AI advisor from a shot with roast level set — AI should no longer ask for it (no need to clear existing conversations; fix takes effect on next message sent with shot context)
- [ ] AI responses with grind/dose recommendations no longer show the raw JSON block at the end
- [ ] Responses without a recommendation (clarifying questions) are unaffected
- [ ] Existing tests pass — `emitRecentShotContext_*` tests use empty roastLevel/roastDate so no assertion changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)