### PR TITLE
fix(ble): arm DE1 reconnect timer after startup connection failure

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -960,6 +960,11 @@ int main(int argc, char *argv[])
     int de1ReconnectAttempt = 0;
     QTimer de1ReconnectTimer;
     de1ReconnectTimer.setSingleShot(true);
+    // Tracks "was connected or connecting" for edge-detection in the
+    // connectedChanged handler. Updated by connectingChanged so startup
+    // failures (connecting→failed, never reached connected) also arm the
+    // retry timer — not just mid-session disconnects (connected→disconnected).
+    bool de1WasActive = false;
 
     // Auto-wake manager for scheduled wake-ups
     AutoWakeManager autoWakeManager(settings.autoWake());
@@ -1179,6 +1184,14 @@ int main(int argc, char *argv[])
         }
     });
 
+    // When the DE1 starts connecting, mark it as active so that if the
+    // attempt fails before reaching connected, connectedChanged will still
+    // recognise the inactive transition and arm the retry timer.
+    QObject::connect(&de1Device, &DE1Device::connectingChanged,
+                     [&de1Device, &de1WasActive]() {
+        if (de1Device.isConnecting()) de1WasActive = true;
+    });
+
     // When DE1 connects or disconnects, manage reconnect timer.
     //
     // connectedChanged() can fire multiple times while the device is already
@@ -1186,31 +1199,31 @@ int main(int argc, char *argv[])
     // unconditionally, and our reconnect path calls disconnect() on the old
     // transport before spinning up a new one. Without edge-tracking, every
     // spurious emission would reset de1ReconnectAttempt=0 and re-arm the 5 s
-    // timer, scrambling the backoff schedule (a mid-attempt spurious emit
-    // was observed converting a 30 s retry into a 60 s retry and losing the
-    // attempt counter). Track the previous state and only act on genuine
-    // edges.
-    static bool s_de1WasConnected = false;
+    // timer, scrambling the backoff schedule. de1WasActive is set true by
+    // connectingChanged when a connection attempt starts and cleared here on
+    // each inactive→inactive emission, so startup failures (connecting→failed
+    // without ever reaching connected) also arm the retry timer.
     QObject::connect(&de1Device, &DE1Device::connectedChanged,
-                     [&de1Device, &de1ReconnectTimer, &de1ReconnectAttempt, &settings
+                     [&de1Device, &de1ReconnectTimer, &de1ReconnectAttempt, &settings, &de1WasActive
 #ifndef Q_OS_IOS
                      , &usbManager
 #endif
                      ]() {
         const bool isConnected = de1Device.isConnected();
-        if (isConnected == s_de1WasConnected) {
-            return;  // Spurious same-state emission — ignore
+        const bool isActive = isConnected || de1Device.isConnecting();
+        if (!de1WasActive && !isActive) {
+            return;  // Spurious inactive→inactive emission — ignore
         }
-        s_de1WasConnected = isConnected;
+        const bool wasActive = de1WasActive;
+        de1WasActive = isActive;
 
         if (isConnected) {
-            // Just transitioned disconnected → connected: stop any pending
-            // reconnect attempts.
+            // Just transitioned to connected: stop any pending reconnect attempts.
             de1ReconnectTimer.stop();
             de1ReconnectAttempt = 0;
-        } else {
-            // Just transitioned connected → disconnected: start auto-reconnect
-            // if we have a saved address.
+        } else if (wasActive) {
+            // Was active (connecting or connected), now neither: start
+            // auto-reconnect if we have a saved address.
 #ifndef Q_OS_IOS
             if (usbManager.isDe1Connected()) {
                 // Don't try BLE reconnect if USB is handling the DE1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1200,9 +1200,10 @@ int main(int argc, char *argv[])
     // transport before spinning up a new one. Without edge-tracking, every
     // spurious emission would reset de1ReconnectAttempt=0 and re-arm the 5 s
     // timer, scrambling the backoff schedule. de1WasActive is set true by
-    // connectingChanged when a connection attempt starts and cleared here on
-    // each inactive→inactive emission, so startup failures (connecting→failed
-    // without ever reaching connected) also arm the retry timer.
+    // connectingChanged when a connection attempt starts and reset to false
+    // here on each active→inactive transition, so startup failures
+    // (connecting→failed without ever reaching connected) also arm the retry
+    // timer while spurious inactive→inactive emissions are still suppressed.
     QObject::connect(&de1Device, &DE1Device::connectedChanged,
                      [&de1Device, &de1ReconnectTimer, &de1ReconnectAttempt, &settings, &de1WasActive
 #ifndef Q_OS_IOS
@@ -1230,7 +1231,9 @@ int main(int argc, char *argv[])
                 return;
             }
 #endif
-            if (!settings.machineAddress().isEmpty() && !de1ReconnectTimer.isActive()) {
+            if (settings.machineAddress().isEmpty()) {
+                qDebug() << "DE1 reconnect: no saved address — skipping auto-reconnect";
+            } else if (!de1ReconnectTimer.isActive()) {
                 de1ReconnectAttempt = 0;
                 de1ReconnectTimer.start(5000);  // First retry after 5s
                 qDebug() << "DE1 reconnect: scheduled first retry in 5000 ms";


### PR DESCRIPTION
## Summary

- The DE1 reconnect timer was never armed when a `ConnectionError` occurred during the initial startup connection attempt
- Root cause: the `connectedChanged` edge-tracking used `static bool s_de1WasConnected = false` — since the DE1 was never connected, both before and after the error `isConnected = false`, so the guard treated it as a spurious same-state emission and returned early
- Fix: track `de1WasActive` (connected OR connecting) via a new `connectingChanged` connection; `connectedChanged` now ignores only inactive→inactive transitions, so startup failures correctly arm the 5s/30s/60s backoff retry sequence

## Test plan

- [ ] Verify DE1 ConnectionError at startup triggers retry attempts (log shows `DE1 reconnect: scheduled first retry in 5000 ms` and subsequent `DE1 reconnect: attempt N of 12`)
- [ ] Verify mid-session disconnect still triggers retry (existing behavior unchanged)
- [ ] Verify backoff schedule is not scrambled during retry loop (30s after attempt 1, 60s after subsequent)
- [ ] Verify app doesn't attempt BLE reconnect when USB DE1 is connected (iOS/non-iOS guard still in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)