### PR TITLE
fix(ai): skip cold-startup warmup in temperature instability detector

### DIFF
--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -295,7 +295,11 @@ The simplest of the five. `temperatureUnstable = true` when:
   TEMP_UNSTABLE_THRESHOLD` (2.0 °C).
 
 `avgTempDeviation` is the average absolute deviation over the pour window
-where the goal is non-zero.
+where the goal is non-zero. Leading samples where the group head is still
+warming up are excluded: any sample at the start of the window where
+`goal − actual > TEMP_WARMUP_SKIP_C` (3.0 °C) is skipped. The skip is
+one-directional (cold only) and latches off on the first in-range sample,
+so a mid-shot temperature drop is still counted as instability.
 
 The `pourStart > 0` and `reachedExtractionPhase` guards live exclusively
 in `analyzeShot`. Save-time (`saveShot`), load-time recompute

--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -301,6 +301,12 @@ warming up are excluded: any sample at the start of the window where
 one-directional (cold only) and latches off on the first in-range sample,
 so a mid-shot temperature drop is still counted as instability.
 
+If every pour sample is below the warmup threshold (count == 0), the
+function returns 0.0 and no badge fires. This is intentional: a machine
+that never reaches operating temperature during a full extraction is
+extremely unlikely in practice, and returning silence is preferable to a
+misleading badge when there is no valid signal.
+
 The `pourStart > 0` and `reachedExtractionPhase` guards live exclusively
 in `analyzeShot`. Save-time (`saveShot`), load-time recompute
 (`loadShotRecordStatic`), the dialog, the AI advisor, and MCP all

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -343,6 +343,11 @@ double ShotAnalysis::avgTempDeviation(const QVector<QPointF>& tempData,
         devSum += std::abs(pt.y() - goal);
         ++count;
     }
+    // count == 0: every pour sample was below the warmup threshold — the machine
+    // never reached operating temperature during extraction. No usable data means
+    // no diagnosis; return 0.0 so the caller fires no badge. This is intentional:
+    // a machine that stays this cold for a full extraction is extremely rare, and
+    // silence is preferable to a misleading badge with no valid signal.
     return count > 0 ? devSum / count : 0.0;
 }
 

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -327,14 +327,21 @@ double ShotAnalysis::avgTempDeviation(const QVector<QPointF>& tempData,
 {
     double devSum = 0;
     int count = 0;
+    bool warmupDone = false;
     for (const auto& pt : tempData) {
         if (pt.x() < startTime) continue;
         if (pt.x() > endTime) break;
         double goal = findValueAtTime(tempGoalData, pt.x());
-        if (goal > 0) {
-            devSum += std::abs(pt.y() - goal);
-            ++count;
+        if (goal <= 0) continue;
+        // Skip leading samples where the group head is still warming up to
+        // operating temperature. Once the first in-range sample is seen,
+        // warmupDone latches so a mid-shot temperature drop still counts.
+        if (!warmupDone) {
+            if (goal - pt.y() > TEMP_WARMUP_SKIP_C) continue;
+            warmupDone = true;
         }
+        devSum += std::abs(pt.y() - goal);
+        ++count;
     }
     return count > 0 ? devSum / count : 0.0;
 }

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -30,6 +30,13 @@ public:
     static constexpr double TEMP_UNSTABLE_THRESHOLD = 2.0;        // °C avg deviation from goal
     static constexpr double TEMP_STEPPING_RANGE = 5.0;            // °C goal range = intentional stepping
     static constexpr double TEMP_MIN_EXTRACTION_SEC = 1.0;        // min seconds of extraction past frame 1 to score temp
+    // Skip leading pour samples where the machine hasn't yet reached operating
+    // temperature. Cold-start shots (e.g. first shot after idle) begin with the
+    // group head below goal; excluding this warmup ramp prevents false-positive
+    // "Temperature unstable" badges on otherwise clean shots. Only applied at
+    // the leading edge — if temperature drops this far below goal mid-shot,
+    // that is a real instability event and is counted.
+    static constexpr double TEMP_WARMUP_SKIP_C = 3.0;
 
     // Mode-aware detection window tuning. A sample counts toward channeling
     // detection only inside a window where the active control goal (pressure

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -34,8 +34,8 @@ public:
     // temperature. Cold-start shots (e.g. first shot after idle) begin with the
     // group head below goal; excluding this warmup ramp prevents false-positive
     // "Temperature unstable" badges on otherwise clean shots. Only applied at
-    // the leading edge — if temperature drops this far below goal mid-shot,
-    // that is a real instability event and is counted.
+    // the leading edge — once the first in-range sample is seen, the latch fires
+    // and all subsequent deviations (both below and above goal) are counted.
     static constexpr double TEMP_WARMUP_SKIP_C = 3.0;
 
     // Mode-aware detection window tuning. A sample counts toward channeling

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -2042,6 +2042,69 @@ private slots:
         QVERIFY(t.grindIssueDetected);
         QVERIFY(t.skipFirstFrameDetected);
     }
+
+    // avgTempDeviation -------------------------------------------------------
+
+    void avgTempDeviation_coldStartWarmupSkipped()
+    {
+        // First 3s: actual = 84°C, goal = 88°C → delta = 4°C > TEMP_WARMUP_SKIP_C (3.0)
+        // → those samples are skipped. Remaining 7s: actual = 87°C → delta = 1°C < threshold.
+        // Average over the non-skipped samples should be ~1°C → well below 2°C badge threshold.
+        const double goal = 88.0;
+        const double warmSamples = 7.0 * 10; // 7s at 10 Hz
+
+        QVector<QPointF> temp, tempGoal;
+        for (int i = 0; i < 30; ++i) {          // 3s cold: 84°C
+            temp.append(QPointF(i * 0.1, 84.0));
+            tempGoal.append(QPointF(i * 0.1, goal));
+        }
+        for (int i = 30; i < 130; ++i) {        // 10s warm: 87°C
+            temp.append(QPointF(i * 0.1, 87.0));
+            tempGoal.append(QPointF(i * 0.1, goal));
+        }
+
+        const double dev = ShotAnalysis::avgTempDeviation(temp, tempGoal, 0.0, 13.0);
+        QVERIFY2(dev < ShotAnalysis::TEMP_UNSTABLE_THRESHOLD,
+                 "cold-start leading samples should be skipped; stable tail should not badge");
+        QCOMPARE_LT(std::abs(dev - 1.0), 0.01); // should average to exactly 1.0°C
+    }
+
+    void avgTempDeviation_midShotDropCountedAfterLatch()
+    {
+        // 2s stable at goal, then 3s of a 5°C below-goal drop mid-shot.
+        // Latch fires on the stable prefix; the drop is counted and pushes avg above threshold.
+        const double goal = 93.0;
+
+        QVector<QPointF> temp, tempGoal;
+        for (int i = 0; i < 20; ++i) {          // 2s stable: 93°C (delta=0)
+            temp.append(QPointF(i * 0.1, 93.0));
+            tempGoal.append(QPointF(i * 0.1, goal));
+        }
+        for (int i = 20; i < 50; ++i) {         // 3s drop: 88°C (delta=5°C)
+            temp.append(QPointF(i * 0.1, 88.0));
+            tempGoal.append(QPointF(i * 0.1, goal));
+        }
+
+        const double dev = ShotAnalysis::avgTempDeviation(temp, tempGoal, 0.0, 5.0);
+        QVERIFY2(dev > ShotAnalysis::TEMP_UNSTABLE_THRESHOLD,
+                 "mid-shot temperature drop must be counted after warmup latch fires");
+    }
+
+    void avgTempDeviation_allSamplesColdReturnsZero()
+    {
+        // Every pour sample is 5°C below goal throughout — machine never warmed up.
+        // count stays 0; function must return 0.0 (no usable data → no badge).
+        const double goal = 90.0;
+
+        QVector<QPointF> temp, tempGoal;
+        for (int i = 0; i < 50; ++i) {
+            temp.append(QPointF(i * 0.1, 85.0));    // delta = 5°C > TEMP_WARMUP_SKIP_C
+            tempGoal.append(QPointF(i * 0.1, goal));
+        }
+
+        const double dev = ShotAnalysis::avgTempDeviation(temp, tempGoal, 0.0, 5.0);
+        QCOMPARE(dev, 0.0); // no usable data → no badge (intentional)
+    }
 };
 
 QTEST_MAIN(tst_ShotAnalysis)


### PR DESCRIPTION
## Summary

- Adds `TEMP_WARMUP_SKIP_C = 3.0` °C constant to `ShotAnalysis`
- `avgTempDeviation` now skips leading pour samples where `goal − actual > 3.0 °C` (group head still heating up)
- Skip is one-directional (cold only) and latches off on the first in-range sample — mid-shot temperature drops are still counted as instability
- Updates `docs/SHOT_REVIEW.md` to document the new gate

Fixes the false-positive **Temp unstable** badge from issue #1075 (Londinium 3-bar soak): pourStart was t=2.086s with machine at 72.9 °C vs goal 88.5 °C. Average deviation over the full pour was 2.02 °C (just above the 2.0 °C threshold); after skipping the warmup ramp the average drops to 1.05 °C → no badge.

## Test plan

- [ ] Build and run a Londinium-style shot on a cold machine — "Temp unstable" badge should no longer appear when extraction temperature is stable
- [ ] Confirm a genuinely unstable mid-shot temperature (e.g. thermosiphon interruption) still badges correctly
- [ ] No existing `shot_eval --validate` fixture changes expected (fixtures pass empty temperature vectors to `generateSummary`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)