### PR TITLE
fix(ui): fix Shot Summary dialog always showing empty

### DIFF
--- a/qml/components/ShotAnalysisDialog.qml
+++ b/qml/components/ShotAnalysisDialog.qml
@@ -29,14 +29,12 @@ Dialog {
     footer: null
 
     // Analysis lines come from `shotData.summaryLines`, populated by
-    // ShotHistoryStorage::convertShotRecord's analyzeShot() pass. Empty
-    // fallback when the field is missing — better to render the dialog
-    // header with no body than to risk a divergent recomputation. Any
-    // shotData that reaches the dialog has flowed through convertShotRecord,
-    // so the empty case is theoretical.
+    // ShotHistoryStorage::convertShotRecord's analyzeShot() pass.
+    // QML exposes QVariantList from a Q_GADGET as a QML sequence type, not a
+    // native JS Array — Array.isArray() returns false for it. Use ?? instead.
     property var analysisLines: {
         if (!analysisDialog.visible) return []
-        return Array.isArray(shotData?.summaryLines) ? shotData.summaryLines : []
+        return shotData?.summaryLines ?? []
     }
 
     contentItem: ColumnLayout {


### PR DESCRIPTION
## Summary

- `Array.isArray()` returns `false` for QML sequence types, which is how QML exposes `QVariantList` from a Q_GADGET `Q_PROPERTY`
- The `analysisLines` binding in `ShotAnalysisDialog` was using `Array.isArray(shotData?.summaryLines)` as a guard, so it always fell back to `[]` — rendering every Shot Summary dialog empty
- Fix: replace `Array.isArray(lines) ? lines : []` with `lines ?? []`, which accepts both JS arrays and QML sequence types

## Root cause timeline

- **2026-04-29 PR #934**: introduced `summaryLines` reading with `Array.isArray` guard (worked correctly — `shotData` was a `QVariantMap`, so `summaryLines` came back as a real JS Array)
- **2026-04-30 PR #975**: `ShotProjection` Q_GADGET refactor changed the delivery path — `summaryLines` now comes back as a QML sequence type where `Array.isArray()` returns `false`
- Broken for 3 days; reported in issue #1075 alongside the channeling false-positive (fixed separately in #1076)

## Test plan

- [ ] Open Shot Detail for any shot and tap "Shot Summary" — dialog now shows analysis lines
- [ ] Open Post-Shot Review after a pull and tap "Shot Summary" — same
- [ ] Shots with no detectable issues still show at minimum a verdict line

Closes #1075 (shot summary empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)