### PR TITLE
fix(ui): remove per-shot dismiss from QuickRatingRow

### DIFF
--- a/qml/components/QuickRatingRow.qml
+++ b/qml/components/QuickRatingRow.qml
@@ -6,13 +6,9 @@ import Decenza
 // QuickRatingRow — issue #1055 Layer 2.
 //
 // Low-friction one-tap rating row shown above the metadata fold on the
-// post-shot review page when the shot is unrated. Three icon buttons map
-// to default scores 80 / 60 / 40 (good / okay / bad). Tapping persists
-// the score immediately via the existing saveEditedShot path.
-//
-// Once the shot is rated (currentScore > 0) the row collapses into a
-// compact "Rated N — tap to revise" pill that reopens the three-icon
-// state on tap, so the row is also a fast revision surface.
+// post-shot review page for unrated shots (enjoymentSource != "user").
+// Three icon buttons map to scores 80 / 60 / 40 (good / okay / bad).
+// Tapping persists the score immediately via saveEditedShot.
 //
 // Translation: all visible text routes through TranslationManager so
 // non-English locales work. Accessibility: each interactive element is
@@ -21,29 +17,16 @@ import Decenza
 RowLayout {
     id: root
 
-    // Inputs ---------------------------------------------------------
-    // The shot's current enjoyment score (0 = unrated → row visible).
-    property int currentScore: 0
-
-    // Outputs --------------------------------------------------------
     // Emitted when the user taps a rating icon. Caller writes the score
     // through to the shot via saveEditedShot.
     signal rateClicked(int score)
-    // Emitted when the user taps the collapsed "Rated N — tap to
-    // revise" pill. Caller is expected to zero `currentScore` so the
-    // three-icon picker re-appears for a new tap. The component
-    // does NOT mutate `currentScore` itself — the caller owns the
-    // persisted value.
-    signal reviseClicked()
 
     spacing: Theme.spacingMedium
 
-    // Three-icon state — visible when currentScore == 0.
     Item {
         id: tripleState
         Layout.fillWidth: true
         Layout.preferredHeight: Theme.scaled(80)
-        visible: root.currentScore === 0
 
         RowLayout {
             anchors.fill: parent
@@ -110,23 +93,5 @@ RowLayout {
 
             Item { Layout.fillWidth: true }
         }
-    }
-
-    // Collapsed "Rated N — tap to revise" pill — visible after a tap
-    // landed a non-zero score. Tapping emits reviseClicked so the
-    // caller can zero its bound currentScore and re-show the three-icon
-    // picker; the pill itself does not mutate currentScore.
-    AccessibleButton {
-        id: collapsedPill
-        Layout.fillWidth: true
-        Layout.preferredHeight: Theme.scaled(40)
-        visible: root.currentScore > 0
-        accessibleName: TranslationManager.translate(
-            "rating.quick.revise.accessibility",
-            "Rated, tap to revise") + " " + root.currentScore
-        text: TranslationManager.translate(
-            "rating.quick.revise.label", "Rated %1 — tap to revise")
-            .replace("%1", root.currentScore)
-        onClicked: root.reviseClicked()
     }
 }

--- a/qml/components/QuickRatingRow.qml
+++ b/qml/components/QuickRatingRow.qml
@@ -6,11 +6,9 @@ import Decenza
 // QuickRatingRow — issue #1055 Layer 2.
 //
 // Low-friction one-tap rating row shown above the metadata fold on the
-// post-shot review page when the shot is unrated AND the user has not
-// dismissed the prompt for that shot. Three icon buttons map to default
-// scores 80 / 60 / 40 (good / okay / bad). Tapping persists the score
-// immediately via the existing saveEditedShot path; tapping the small
-// dismiss × hides the row for that shot via a per-shot QSettings key.
+// post-shot review page when the shot is unrated. Three icon buttons map
+// to default scores 80 / 60 / 40 (good / okay / bad). Tapping persists
+// the score immediately via the existing saveEditedShot path.
 //
 // Once the shot is rated (currentScore > 0) the row collapses into a
 // compact "Rated N — tap to revise" pill that reopens the three-icon
@@ -26,10 +24,6 @@ RowLayout {
     // Inputs ---------------------------------------------------------
     // The shot's current enjoyment score (0 = unrated → row visible).
     property int currentScore: 0
-    // Whether the user has dismissed the prompt for this specific shot.
-    // Caller owns persistence (per-shot QSettings key) and binds this
-    // property; the row only emits the dismiss signal.
-    property bool dismissed: false
 
     // Outputs --------------------------------------------------------
     // Emitted when the user taps a rating icon. Caller writes the score
@@ -41,14 +35,7 @@ RowLayout {
     // does NOT mutate `currentScore` itself — the caller owns the
     // persisted value.
     signal reviseClicked()
-    // Emitted when the user taps the dismiss control. Caller persists
-    // the per-shot dismissed flag.
-    signal dismissedClicked()
 
-    // Layout ---------------------------------------------------------
-    // Hidden entirely when dismissed; otherwise either the three-icon
-    // bar or the collapsed "Rated N" pill.
-    visible: !root.dismissed
     spacing: Theme.spacingMedium
 
     // Three-icon state — visible when currentScore == 0.
@@ -121,21 +108,7 @@ RowLayout {
                 }
             }
 
-            Item { Layout.fillWidth: true }  // spacer pushes dismiss to right edge
-
-            AccessibleButton {
-                accessibleName: TranslationManager.translate(
-                    "rating.quick.dismiss.accessibility", "Dismiss rating prompt")
-                Layout.preferredWidth: Theme.scaled(36)
-                Layout.preferredHeight: Theme.scaled(36)
-                onClicked: root.dismissedClicked()
-                contentItem: Image {
-                    source: "qrc:/icons/cross.svg"
-                    sourceSize.width: Theme.scaled(16)
-                    sourceSize.height: Theme.scaled(16)
-                    fillMode: Image.PreserveAspectFit
-                }
-            }
+            Item { Layout.fillWidth: true }
         }
     }
 

--- a/qml/components/QuickRatingRow.qml
+++ b/qml/components/QuickRatingRow.qml
@@ -42,7 +42,7 @@ RowLayout {
     Item {
         id: tripleState
         Layout.fillWidth: true
-        Layout.preferredHeight: Theme.scaled(56)
+        Layout.preferredHeight: Theme.scaled(80)
         visible: root.currentScore === 0
 
         RowLayout {
@@ -69,13 +69,13 @@ RowLayout {
             AccessibleButton {
                 accessibleName: TranslationManager.translate(
                     "rating.quick.good.accessibility", "Rate this shot good")
-                Layout.preferredWidth: Theme.scaled(48)
-                Layout.preferredHeight: Theme.scaled(48)
+                Layout.preferredWidth: Theme.scaled(72)
+                Layout.preferredHeight: Theme.scaled(72)
                 onClicked: root.rateClicked(80)
                 contentItem: Image {
                     source: Theme.emojiToImage("😊")  // 😊
-                    sourceSize.width: Theme.scaled(28)
-                    sourceSize.height: Theme.scaled(28)
+                    sourceSize.width: Theme.scaled(48)
+                    sourceSize.height: Theme.scaled(48)
                     fillMode: Image.PreserveAspectFit
                 }
             }
@@ -83,13 +83,13 @@ RowLayout {
             AccessibleButton {
                 accessibleName: TranslationManager.translate(
                     "rating.quick.ok.accessibility", "Rate this shot okay")
-                Layout.preferredWidth: Theme.scaled(48)
-                Layout.preferredHeight: Theme.scaled(48)
+                Layout.preferredWidth: Theme.scaled(72)
+                Layout.preferredHeight: Theme.scaled(72)
                 onClicked: root.rateClicked(60)
                 contentItem: Image {
                     source: Theme.emojiToImage("😐")  // 😐
-                    sourceSize.width: Theme.scaled(28)
-                    sourceSize.height: Theme.scaled(28)
+                    sourceSize.width: Theme.scaled(48)
+                    sourceSize.height: Theme.scaled(48)
                     fillMode: Image.PreserveAspectFit
                 }
             }
@@ -97,13 +97,13 @@ RowLayout {
             AccessibleButton {
                 accessibleName: TranslationManager.translate(
                     "rating.quick.bad.accessibility", "Rate this shot bad")
-                Layout.preferredWidth: Theme.scaled(48)
-                Layout.preferredHeight: Theme.scaled(48)
+                Layout.preferredWidth: Theme.scaled(72)
+                Layout.preferredHeight: Theme.scaled(72)
                 onClicked: root.rateClicked(40)
                 contentItem: Image {
                     source: Theme.emojiToImage("😟")  // 😟
-                    sourceSize.width: Theme.scaled(28)
-                    sourceSize.height: Theme.scaled(28)
+                    sourceSize.width: Theme.scaled(48)
+                    sourceSize.height: Theme.scaled(48)
                     fillMode: Image.PreserveAspectFit
                 }
             }

--- a/qml/components/QuickRatingRow.qml
+++ b/qml/components/QuickRatingRow.qml
@@ -101,7 +101,7 @@ RowLayout {
                 Layout.preferredHeight: Theme.scaled(48)
                 onClicked: root.rateClicked(40)
                 contentItem: Image {
-                    source: Theme.emojiToImage("😞")  // 😞
+                    source: Theme.emojiToImage("😟")  // 😟
                     sourceSize.width: Theme.scaled(28)
                     sourceSize.height: Theme.scaled(28)
                     fillMode: Image.PreserveAspectFit

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -669,18 +669,17 @@ Page {
 
             // Rating (moved to top, right after graph)
             // QuickRatingRow — issue #1055 Layer 2. Three-icon one-tap
-            // rating row, visible whenever editEnjoyment is 0 (unrated).
-            // The precision slider below remains the fine-tuning surface.
+            // rating row, visible when the shot has no user rating.
+            // Inferred scores (enjoymentSource="inferred") are internal AI
+            // signals and are never shown to the user, so inferred shots
+            // show the row too. The precision slider is the fine-tuning surface.
             QuickRatingRow {
                 Layout.fillWidth: true
-                visible: postShotReviewPage.isEditMode && editEnjoyment === 0
-                currentScore: editEnjoyment
+                visible: postShotReviewPage.isEditMode &&
+                         (editShotData.enjoymentSource ?? "none") !== "user"
                 onRateClicked: function(score) {
                     editEnjoyment = score
                     postShotReviewPage.saveEditedShot()
-                }
-                onReviseClicked: {
-                    editEnjoyment = 0
                 }
             }
 

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -204,18 +204,6 @@ Page {
     property double editDrinkEy: 0
     property int editEnjoyment: 0  // 0 = unrated
 
-    // Dismissed-for-this-shot mirror for QuickRatingRow's visibility
-    // (issue #1055 Layer 2). QSettings is not a notifiable QML property,
-    // so we cache the per-shot flag here at the page root and refresh
-    // it whenever editShotId changes. The QuickRatingRow's `visible`
-    // binding observes this property, so tapping dismiss takes effect
-    // immediately.
-    property bool _ratingPromptDismissed:
-        Settings.value("shotRatingDismissed/" + editShotId, false) === true
-    onEditShotIdChanged: {
-        _ratingPromptDismissed =
-            Settings.value("shotRatingDismissed/" + editShotId, false) === true
-    }
     property string editNotes: ""
     property string editBeverageType: "espresso"
 
@@ -681,33 +669,21 @@ Page {
 
             // Rating (moved to top, right after graph)
             // QuickRatingRow — issue #1055 Layer 2. Three-icon one-tap
-            // rating row, visible only when the shot has no USER rating
-            // AND the user hasn't dismissed for this shot. Inferred-rated
-            // shots (enjoymentSource == "inferred") still show the row so
-            // the user can confirm or override the inferred score. The
-            // precision slider below remains the fine-tuning surface.
-            // Dismiss mirror lives on the page root (_ratingPromptDismissed)
-            // so the binding updates reactively on tap.
+            // rating row, visible whenever the shot has no USER rating.
+            // Inferred-rated shots (enjoymentSource == "inferred") still
+            // show the row so the user can confirm or override the score.
+            // The precision slider below remains the fine-tuning surface.
             QuickRatingRow {
                 Layout.fillWidth: true
                 visible: postShotReviewPage.isEditMode &&
-                         (editShotData.enjoymentSource ?? "none") !== "user" &&
-                         !postShotReviewPage._ratingPromptDismissed
+                         (editShotData.enjoymentSource ?? "none") !== "user"
                 currentScore: editEnjoyment
                 onRateClicked: function(score) {
                     editEnjoyment = score
                     postShotReviewPage.saveEditedShot()
                 }
                 onReviseClicked: {
-                    // Pop the row back to the three-icon picker without
-                    // wiping the persisted score; user picks a new face,
-                    // saveEditedShot then overwrites with the new value.
                     editEnjoyment = 0
-                }
-                onDismissedClicked: {
-                    Settings.setValue(
-                        "shotRatingDismissed/" + postShotReviewPage.editShotId, true)
-                    postShotReviewPage._ratingPromptDismissed = true
                 }
             }
 

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -137,7 +137,9 @@ Page {
                 if (editDrinkTds === 0)
                     editDrinkTds = editShotData.drinkTdsPct ?? 0
                 editDrinkEy = editShotData.drinkEyPct ?? 0
-                editEnjoyment = editShotData.enjoyment0to100 ?? 0  // Use ?? to avoid treating 0 as falsy
+                editEnjoyment = (editShotData.enjoymentSource === "inferred")
+                    ? 0
+                    : (editShotData.enjoyment0to100 ?? 0)
                 editNotes = editShotData.espressoNotes || ""
                 editBeverageType = editShotData.beverageType || "espresso"
                 // Recompute EY now that dose/weight are loaded (covers the case where TDS

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -669,22 +669,11 @@ Page {
 
             // Rating (moved to top, right after graph)
             // QuickRatingRow — issue #1055 Layer 2. Three-icon one-tap
-            // rating row, visible whenever the shot has no USER rating.
-            // Inferred-rated shots (enjoymentSource == "inferred") still
-            // show the row so the user can confirm or override the score.
+            // rating row, visible whenever editEnjoyment is 0 (unrated).
             // The precision slider below remains the fine-tuning surface.
             QuickRatingRow {
                 Layout.fillWidth: true
-                visible: {
-                    var src = editShotData.enjoymentSource ?? "none"
-                    var show = postShotReviewPage.isEditMode && src !== "user"
-                    console.log("[QuickRatingRow] editShotId=" + postShotReviewPage.editShotId
-                        + " isEditMode=" + postShotReviewPage.isEditMode
-                        + " enjoymentSource=" + src
-                        + " editEnjoyment=" + editEnjoyment
-                        + " visible=" + show)
-                    return show
-                }
+                visible: postShotReviewPage.isEditMode && editEnjoyment === 0
                 currentScore: editEnjoyment
                 onRateClicked: function(score) {
                     editEnjoyment = score

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -675,8 +675,16 @@ Page {
             // The precision slider below remains the fine-tuning surface.
             QuickRatingRow {
                 Layout.fillWidth: true
-                visible: postShotReviewPage.isEditMode &&
-                         (editShotData.enjoymentSource ?? "none") !== "user"
+                visible: {
+                    var src = editShotData.enjoymentSource ?? "none"
+                    var show = postShotReviewPage.isEditMode && src !== "user"
+                    console.log("[QuickRatingRow] editShotId=" + postShotReviewPage.editShotId
+                        + " isEditMode=" + postShotReviewPage.isEditMode
+                        + " enjoymentSource=" + src
+                        + " editEnjoyment=" + editEnjoyment
+                        + " visible=" + show)
+                    return show
+                }
                 currentScore: editEnjoyment
                 onRateClicked: function(score) {
                     editEnjoyment = score

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1802,15 +1802,16 @@ bool ShotHistoryStorage::updateShotMetadataStatic(QSqlDatabase& db, qint64 shotI
     };
 
     // Issue #1055 Layer 3: when the caller writes `enjoyment` without
-    // an explicit `enjoymentSource`, default the source to "user". Any
-    // explicit user-driven write path (manual editor, QuickRatingRow,
-    // conversational reply) is by definition a user rating; only the
-    // inferred-good evaluator passes "inferred". Materialize a local
-    // copy of the map so we don't mutate the caller's argument.
+    // an explicit `enjoymentSource`, default the source to "user" — but
+    // only for non-zero scores. 0 always means unrated regardless of who
+    // wrote it; stamping it "user" would hide the QuickRatingRow and
+    // mislead the AI into treating the shot as deliberately rated bad.
     QVariantMap effective = metadata;
     if (effective.contains(QStringLiteral("enjoyment")) &&
         !effective.contains(QStringLiteral("enjoymentSource"))) {
-        effective.insert(QStringLiteral("enjoymentSource"), QStringLiteral("user"));
+        const int score = effective.value(QStringLiteral("enjoyment")).toInt();
+        effective.insert(QStringLiteral("enjoymentSource"),
+                         score > 0 ? QStringLiteral("user") : QStringLiteral("none"));
     }
 
     // Build SET clause from only the keys present in the (effective) metadata.


### PR DESCRIPTION
## Summary

- Removes the × dismiss button from `QuickRatingRow` — the prompt always shows for unrated shots when in edit mode
- Drops `dismissed` property, `dismissedClicked` signal, `_ratingPromptDismissed` page property, and `onEditShotIdChanged` QSettings cache
- Removes the collapsed "Rated N — tap to revise" pill and its dead `currentScore`/`reviseClicked` API — the row is visible only when unrated so the pill was never reachable
- Fixes visibility condition to `enjoymentSource !== "user"`: inferred scores are internal AI signals; users see 0 and are prompted to rate
- Fixes C++ invariant: `enjoyment=0` now saves `enjoymentSource="none"`, never `"user"`

## Why

The dismiss suppressed the rating row permanently per shot via a QSettings key. If a user went back to edit an unrated shot, the row would never reappear.

Inferred scores (Layer 3 auto-rater) were leaking into the UI — the slider showed 75 for shots the user had never rated.

Orphaned `shotRatingDismissed/*` QSettings keys on existing installs are harmless dead data.

## Test plan

- [ ] Open post-shot review for an unrated shot — QuickRatingRow shows three emoji icons, no × button
- [ ] Open post-shot review for an AI-inferred shot (`enjoymentSource="inferred"`) — row visible, slider shows 0
- [ ] Tap a face — score saves, row hides; re-open shot — row stays hidden
- [ ] Navigate away and back to the same unrated shot — row is still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)