### PR TITLE
fix(ble): arm scale reconnect timer after startup connection failure

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1153,18 +1153,33 @@ int main(int argc, char *argv[])
     });
 
     // Arm the scale retry timer when a startup direct-connect attempt times out.
-    // Without this, a startup ConnectionError (scale asleep / not advertising)
+    // Without this, a startup connection timeout (scale asleep / not advertising, 20 s)
     // leaves the scale disconnected until the user manually reopens the app —
     // same root cause as the DE1 reconnect bug fixed in a0bade6f. flowScaleFallback
-    // is guarded by m_flowScaleFallbackEmitted so it fires at most once per connect
-    // attempt; the retry loop above handles subsequent failures itself.
+    // is guarded by m_flowScaleFallbackEmitted so it fires at most once per session
+    // (until the scale connects or the user clears it — resetScaleConnectionState()
+    // deliberately does not reset this guard); the retry loop above handles
+    // subsequent timeout failures itself.
     QObject::connect(&bleManager, &BLEManager::flowScaleFallback,
-                     [&settings, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays]() {
-        if (!settings.scaleAddress().isEmpty() && !scaleReconnectTimer.isActive()) {
-            scaleReconnectAttempt = 0;
-            scaleReconnectTimer.start(reconnectDelays[0]);
-            qDebug() << "Scale reconnect: scheduled first retry in" << reconnectDelays[0] << "ms (startup failure)";
+                     [&settings, &bleManager, &scaleReconnectTimer, &scaleReconnectAttempt,
+                      &reconnectDelays, &scaleAutoReconnectSuppressed]() {
+        if (settings.scaleAddress().isEmpty()) {
+            qDebug() << "Scale reconnect (startup): no saved address, skipping";
+            return;
         }
+        if (scaleAutoReconnectSuppressed) {
+            qDebug() << "Scale reconnect (startup): suppressed (keepScaleOn=false), skipping";
+            return;
+        }
+        if (scaleReconnectTimer.isActive()) {
+            qDebug() << "Scale reconnect (startup): timer already active, skipping";
+            return;
+        }
+        scaleReconnectAttempt = 0;
+        scaleReconnectTimer.start(reconnectDelays[0]);
+        bleManager.appendScaleLog(QString("Scheduling reconnect in %1 s (startup failure)")
+                                  .arg(reconnectDelays[0] / 1000));
+        qDebug() << "Scale reconnect: scheduled first retry in" << reconnectDelays[0] << "ms (startup failure)";
     });
 
     // DE1 auto-reconnect after disconnect. Matches de1app behaviour: on Android it

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1152,6 +1152,21 @@ int main(int argc, char *argv[])
         }
     });
 
+    // Arm the scale retry timer when a startup direct-connect attempt times out.
+    // Without this, a startup ConnectionError (scale asleep / not advertising)
+    // leaves the scale disconnected until the user manually reopens the app —
+    // same root cause as the DE1 reconnect bug fixed in a0bade6f. flowScaleFallback
+    // is guarded by m_flowScaleFallbackEmitted so it fires at most once per connect
+    // attempt; the retry loop above handles subsequent failures itself.
+    QObject::connect(&bleManager, &BLEManager::flowScaleFallback,
+                     [&settings, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays]() {
+        if (!settings.scaleAddress().isEmpty() && !scaleReconnectTimer.isActive()) {
+            scaleReconnectAttempt = 0;
+            scaleReconnectTimer.start(reconnectDelays[0]);
+            qDebug() << "Scale reconnect: scheduled first retry in" << reconnectDelays[0] << "ms (startup failure)";
+        }
+    });
+
     // DE1 auto-reconnect after disconnect. Matches de1app behaviour: on Android it
     // retries essentially forever (99999999 attempts) because the DE1 may be in deep
     // sleep and take a while to become reachable. We use backoff: 5s, 30s, then 60s


### PR DESCRIPTION
## Summary

- At startup the app tries a direct BLE connect to the saved Decent Scale address. If the scale is asleep or not advertising, it fails with a `ConnectionError` (~12 s), then `onScaleConnectionTimeout()` fires (~22 s) and emits `flowScaleFallback` — but nothing was listening to arm the retry timer.
- Result: scale stayed disconnected until the user manually reopened the app (observed: 6+ hour gap in today's debug log).
- Fix: connect to `flowScaleFallback` in `main.cpp` to arm `scaleReconnectTimer` with a 5 s first retry, then the existing 5 s → 30 s → 60 s backoff loop takes over. Mirrors the DE1 fix from a0bade6f exactly.

## Test plan

- [ ] Start the app with the Decent Scale powered off — confirm "Scale reconnect: scheduled first retry in 5000 ms (startup failure)" appears in the debug log ~22 s after launch
- [ ] Power on the scale within a minute — confirm it connects automatically without tapping Scan
- [ ] Normal flow (scale already on at startup) — confirm scale still connects immediately with no regression

🤖 Generated with [Claude Code](https://claude.ai/code)