### PR TITLE
fix(ui): block on-screen start buttons when GHC is active

### DIFF
--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -288,19 +288,19 @@ Item {
                         win.goToScreensaver()
                     break
                 case "startEspresso":
-                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled)
+                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled && (DE1Device.isHeadless || DE1Device.simulationMode))
                         DE1Device.startEspresso()
                     break
                 case "startSteam":
-                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled)
+                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled && (DE1Device.isHeadless || DE1Device.simulationMode))
                         DE1Device.startSteam()
                     break
                 case "startHotWater":
-                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled)
+                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled && (DE1Device.isHeadless || DE1Device.simulationMode))
                         DE1Device.startHotWater()
                     break
                 case "startFlush":
-                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled)
+                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled && (DE1Device.isHeadless || DE1Device.simulationMode))
                         DE1Device.startFlush()
                     break
                 case "idle":

--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -277,6 +277,12 @@ Item {
                     pageStack.push(Qt.resolvedUrl("../../../pages/" + page))
             }
         } else if (category === "command") {
+            // The hardware Group Head Controller (GHC), when present and active, takes
+            // exclusive control of starting shots/steam/etc., so on-screen start calls
+            // are only valid in headless (no/inactive GHC) or simulation mode.
+            var canStart = typeof DE1Device !== "undefined"
+                    && DE1Device.guiEnabled
+                    && (DE1Device.isHeadless || DE1Device.simulationMode)
             switch (target) {
                 case "sleep":
                     if (typeof ScaleDevice !== "undefined" && ScaleDevice && ScaleDevice.connected)
@@ -288,19 +294,19 @@ Item {
                         win.goToScreensaver()
                     break
                 case "startEspresso":
-                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled && (DE1Device.isHeadless || DE1Device.simulationMode))
+                    if (canStart)
                         DE1Device.startEspresso()
                     break
                 case "startSteam":
-                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled && (DE1Device.isHeadless || DE1Device.simulationMode))
+                    if (canStart)
                         DE1Device.startSteam()
                     break
                 case "startHotWater":
-                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled && (DE1Device.isHeadless || DE1Device.simulationMode))
+                    if (canStart)
                         DE1Device.startHotWater()
                     break
                 case "startFlush":
-                    if (typeof DE1Device !== "undefined" && DE1Device.guiEnabled && (DE1Device.isHeadless || DE1Device.simulationMode))
+                    if (canStart)
                         DE1Device.startFlush()
                     break
                 case "idle":

--- a/qml/components/layout/items/EspressoItem.qml
+++ b/qml/components/layout/items/EspressoItem.qml
@@ -179,7 +179,7 @@ Item {
                     var preset = Settings.app.getFavoriteProfile(index)
 
                     if (wasAlreadySelected) {
-                        if (MachineState.isReady) {
+                        if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                             DE1Device.startEspresso()
                         } else {
                             console.log("Cannot start espresso - machine not ready, phase:", MachineState.phase)
@@ -198,7 +198,7 @@ Item {
             // Non-favorite profile pill
             Row {
                 anchors.horizontalCenter: parent.horizontalCenter
-                visible: Settings.app.selectedFavoriteProfile === -1
+                visible: Settings.app.selectedFavoriteProfile === -1 && (DE1Device.isHeadless || DE1Device.simulationMode)
                 spacing: Theme.scaled(8)
 
                 Rectangle {
@@ -226,7 +226,7 @@ Item {
                         id: nonFavMouseArea
                         anchors.fill: parent
                         onClicked: {
-                            if (MachineState.isReady) {
+                            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                                 DE1Device.startEspresso()
                             } else {
                                 console.log("Cannot start espresso - machine not ready, phase:", MachineState.phase)

--- a/qml/components/layout/items/EspressoItem.qml
+++ b/qml/components/layout/items/EspressoItem.qml
@@ -11,6 +11,12 @@ Item {
     property bool isCompact: false
     property string itemId: ""
 
+    // True when the app is allowed to start machine operations on-screen.
+    // The hardware Group Head Controller (GHC), when present and active, takes
+    // exclusive control of starting shots/steam/etc., so on-screen start calls
+    // are only valid in headless (no/inactive GHC) or simulation mode.
+    readonly property bool canStartOperations: DE1Device.isHeadless || DE1Device.simulationMode
+
     // Access the IdlePage's activePresetFunction via the page
     property var idlePage: {
         var p = root.parent
@@ -179,7 +185,7 @@ Item {
                     var preset = Settings.app.getFavoriteProfile(index)
 
                     if (wasAlreadySelected) {
-                        if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+                        if (MachineState.isReady && root.canStartOperations) {
                             DE1Device.startEspresso()
                         } else {
                             console.log("Cannot start espresso - machine not ready, phase:", MachineState.phase)
@@ -198,7 +204,7 @@ Item {
             // Non-favorite profile pill
             Row {
                 anchors.horizontalCenter: parent.horizontalCenter
-                visible: Settings.app.selectedFavoriteProfile === -1 && (DE1Device.isHeadless || DE1Device.simulationMode)
+                visible: Settings.app.selectedFavoriteProfile === -1 && root.canStartOperations
                 spacing: Theme.scaled(8)
 
                 Rectangle {
@@ -226,7 +232,7 @@ Item {
                         id: nonFavMouseArea
                         anchors.fill: parent
                         onClicked: {
-                            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+                            if (MachineState.isReady && root.canStartOperations) {
                                 DE1Device.startEspresso()
                             } else {
                                 console.log("Cannot start espresso - machine not ready, phase:", MachineState.phase)

--- a/qml/components/layout/items/FlushItem.qml
+++ b/qml/components/layout/items/FlushItem.qml
@@ -195,7 +195,7 @@ Item {
                 MainController.applyFlushSettings()
 
                 if (wasAlreadySelected) {
-                    if (MachineState.isReady) {
+                    if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                         DE1Device.startFlush()
                     } else {
                         console.log("Cannot start flush - machine not ready, phase:", MachineState.phase)

--- a/qml/components/layout/items/FlushItem.qml
+++ b/qml/components/layout/items/FlushItem.qml
@@ -11,6 +11,9 @@ Item {
     property bool isCompact: false
     property string itemId: ""
 
+    // See EspressoItem.qml for rationale.
+    readonly property bool canStartOperations: DE1Device.isHeadless || DE1Device.simulationMode
+
     property var idlePage: {
         var p = root.parent
         while (p) {
@@ -195,7 +198,7 @@ Item {
                 MainController.applyFlushSettings()
 
                 if (wasAlreadySelected) {
-                    if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+                    if (MachineState.isReady && root.canStartOperations) {
                         DE1Device.startFlush()
                     } else {
                         console.log("Cannot start flush - machine not ready, phase:", MachineState.phase)

--- a/qml/components/layout/items/HotWaterItem.qml
+++ b/qml/components/layout/items/HotWaterItem.qml
@@ -194,7 +194,7 @@ Item {
                 MainController.applyHotWaterSettings()
 
                 if (wasAlreadySelected) {
-                    if (MachineState.isReady) {
+                    if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                         DE1Device.startHotWater()
                     } else {
                         console.log("Cannot start hot water - machine not ready, phase:", MachineState.phase)

--- a/qml/components/layout/items/HotWaterItem.qml
+++ b/qml/components/layout/items/HotWaterItem.qml
@@ -11,6 +11,9 @@ Item {
     property bool isCompact: false
     property string itemId: ""
 
+    // See EspressoItem.qml for rationale.
+    readonly property bool canStartOperations: DE1Device.isHeadless || DE1Device.simulationMode
+
     property var idlePage: {
         var p = root.parent
         while (p) {
@@ -194,7 +197,7 @@ Item {
                 MainController.applyHotWaterSettings()
 
                 if (wasAlreadySelected) {
-                    if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+                    if (MachineState.isReady && root.canStartOperations) {
                         DE1Device.startHotWater()
                     } else {
                         console.log("Cannot start hot water - machine not ready, phase:", MachineState.phase)

--- a/qml/components/layout/items/SteamItem.qml
+++ b/qml/components/layout/items/SteamItem.qml
@@ -231,7 +231,7 @@ Item {
                     MainController.applySteamSettings()
 
                     if (wasAlreadySelected) {
-                        if (MachineState.isReady) {
+                        if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                             DE1Device.startSteam()
                         } else {
                             console.log("Cannot start steam - machine not ready, phase:", MachineState.phase)

--- a/qml/components/layout/items/SteamItem.qml
+++ b/qml/components/layout/items/SteamItem.qml
@@ -11,6 +11,9 @@ Item {
     property bool isCompact: false
     property string itemId: ""
 
+    // See EspressoItem.qml for rationale.
+    readonly property bool canStartOperations: DE1Device.isHeadless || DE1Device.simulationMode
+
     property var idlePage: {
         var p = root.parent
         while (p) {
@@ -231,7 +234,7 @@ Item {
                     MainController.applySteamSettings()
 
                     if (wasAlreadySelected) {
-                        if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+                        if (MachineState.isReady && root.canStartOperations) {
                             DE1Device.startSteam()
                         } else {
                             console.log("Cannot start steam - machine not ready, phase:", MachineState.phase)

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -30,6 +30,12 @@ ApplicationWindow {
     // Debug flag to force live view on operation pages (for development)
     property bool debugLiveView: false
 
+    // True when the app is allowed to start machine operations on-screen.
+    // The hardware Group Head Controller (GHC), when present and active, takes
+    // exclusive control of starting shots/steam/etc., so on-screen start calls
+    // are only valid in headless (no/inactive GHC) or simulation mode.
+    readonly property bool canStartOperations: DE1Device.isHeadless || DE1Device.simulationMode
+
     // Flag to open BrewDialog when IdlePage becomes active (set by AutoFavoritesPage)
     property bool pendingBrewDialog: false
 
@@ -2911,7 +2917,7 @@ ApplicationWindow {
     Shortcut {
         sequence: "E"
         onActivated: {
-            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+            if (MachineState.isReady && root.canStartOperations) {
                 console.log("[Keyboard] Starting espresso via 'E' key")
                 DE1Device.startEspresso()
             } else {
@@ -2924,7 +2930,7 @@ ApplicationWindow {
     Shortcut {
         sequence: "S"
         onActivated: {
-            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+            if (MachineState.isReady && root.canStartOperations) {
                 console.log("[Keyboard] Starting steam via 'S' key")
                 DE1Device.startSteam()
             } else {
@@ -2937,7 +2943,7 @@ ApplicationWindow {
     Shortcut {
         sequence: "W"
         onActivated: {
-            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+            if (MachineState.isReady && root.canStartOperations) {
                 console.log("[Keyboard] Starting hot water via 'W' key")
                 DE1Device.startHotWater()
             } else {
@@ -2950,7 +2956,7 @@ ApplicationWindow {
     Shortcut {
         sequence: "F"
         onActivated: {
-            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+            if (MachineState.isReady && root.canStartOperations) {
                 console.log("[Keyboard] Starting flush via 'F' key")
                 DE1Device.startFlush()
             } else {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -2911,11 +2911,11 @@ ApplicationWindow {
     Shortcut {
         sequence: "E"
         onActivated: {
-            if (MachineState.isReady) {
+            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                 console.log("[Keyboard] Starting espresso via 'E' key")
                 DE1Device.startEspresso()
             } else {
-                console.log("[Keyboard] Cannot start espresso - machine not ready, phase:", MachineState.phase)
+                console.log("[Keyboard] Cannot start espresso - machine not ready or GHC active, phase:", MachineState.phase)
             }
         }
     }
@@ -2924,11 +2924,11 @@ ApplicationWindow {
     Shortcut {
         sequence: "S"
         onActivated: {
-            if (MachineState.isReady) {
+            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                 console.log("[Keyboard] Starting steam via 'S' key")
                 DE1Device.startSteam()
             } else {
-                console.log("[Keyboard] Cannot start steam - machine not ready, phase:", MachineState.phase)
+                console.log("[Keyboard] Cannot start steam - machine not ready or GHC active, phase:", MachineState.phase)
             }
         }
     }
@@ -2937,11 +2937,11 @@ ApplicationWindow {
     Shortcut {
         sequence: "W"
         onActivated: {
-            if (MachineState.isReady) {
+            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                 console.log("[Keyboard] Starting hot water via 'W' key")
                 DE1Device.startHotWater()
             } else {
-                console.log("[Keyboard] Cannot start hot water - machine not ready, phase:", MachineState.phase)
+                console.log("[Keyboard] Cannot start hot water - machine not ready or GHC active, phase:", MachineState.phase)
             }
         }
     }
@@ -2950,11 +2950,11 @@ ApplicationWindow {
     Shortcut {
         sequence: "F"
         onActivated: {
-            if (MachineState.isReady) {
+            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                 console.log("[Keyboard] Starting flush via 'F' key")
                 DE1Device.startFlush()
             } else {
-                console.log("[Keyboard] Cannot start flush - machine not ready, phase:", MachineState.phase)
+                console.log("[Keyboard] Cannot start flush - machine not ready or GHC active, phase:", MachineState.phase)
             }
         }
     }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -308,7 +308,7 @@ Page {
                         MainController.applySteamSettings()
 
                         if (wasAlreadySelected) {
-                            if (MachineState.isReady) {
+                            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                                 DE1Device.startSteam()
                             } else {
                                 console.log("Cannot start steam - machine not ready, phase:", MachineState.phase)
@@ -346,7 +346,7 @@ Page {
                             var preset = Settings.app.getFavoriteProfile(index)
 
                             if (wasAlreadySelected) {
-                                if (MachineState.isReady) {
+                                if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                                     DE1Device.startEspresso()
                                 } else {
                                     console.log("Cannot start espresso - machine not ready, phase:", MachineState.phase)
@@ -377,7 +377,7 @@ Page {
                     // Green pill showing non-favorite profile name
                     Row {
                         anchors.horizontalCenter: parent.horizontalCenter
-                        visible: Settings.app.selectedFavoriteProfile === -1
+                        visible: Settings.app.selectedFavoriteProfile === -1 && (DE1Device.isHeadless || DE1Device.simulationMode)
                         spacing: Theme.scaled(8)
 
                         Rectangle {
@@ -409,7 +409,7 @@ Page {
                                 id: idleNonFavMouseArea
                                 anchors.fill: parent
                                 onClicked: {
-                                    if (MachineState.isReady) {
+                                    if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                                         DE1Device.startEspresso()
                                     } else {
                                         console.log("Cannot start espresso - machine not ready, phase:", MachineState.phase)
@@ -457,7 +457,7 @@ Page {
                         MainController.applyHotWaterSettings()
 
                         if (wasAlreadySelected) {
-                            if (MachineState.isReady) {
+                            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                                 DE1Device.startHotWater()
                             } else {
                                 console.log("Cannot start hot water - machine not ready, phase:", MachineState.phase)
@@ -491,7 +491,7 @@ Page {
                         MainController.applyFlushSettings()
 
                         if (wasAlreadySelected) {
-                            if (MachineState.isReady) {
+                            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
                                 DE1Device.startFlush()
                             } else {
                                 console.log("Cannot start flush - machine not ready, phase:", MachineState.phase)

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -11,6 +11,12 @@ Page {
     property alias idleBrewDialog: idleBrewDialog
     background: Rectangle { color: Theme.backgroundColor }
 
+    // True when the app is allowed to start machine operations on-screen.
+    // The hardware Group Head Controller (GHC), when present and active, takes
+    // exclusive control of starting shots/steam/etc., so on-screen start calls
+    // are only valid in headless (no/inactive GHC) or simulation mode.
+    readonly property bool canStartOperations: DE1Device.isHeadless || DE1Device.simulationMode
+
     StackView.onActivated: {
         root.currentPageTitle = TranslationManager.translate("idle.pageTitle", "Idle")
         if (root.pendingBrewDialog) {
@@ -308,7 +314,7 @@ Page {
                         MainController.applySteamSettings()
 
                         if (wasAlreadySelected) {
-                            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+                            if (MachineState.isReady && idlePage.canStartOperations) {
                                 DE1Device.startSteam()
                             } else {
                                 console.log("Cannot start steam - machine not ready, phase:", MachineState.phase)
@@ -346,7 +352,7 @@ Page {
                             var preset = Settings.app.getFavoriteProfile(index)
 
                             if (wasAlreadySelected) {
-                                if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+                                if (MachineState.isReady && idlePage.canStartOperations) {
                                     DE1Device.startEspresso()
                                 } else {
                                     console.log("Cannot start espresso - machine not ready, phase:", MachineState.phase)
@@ -377,7 +383,7 @@ Page {
                     // Green pill showing non-favorite profile name
                     Row {
                         anchors.horizontalCenter: parent.horizontalCenter
-                        visible: Settings.app.selectedFavoriteProfile === -1 && (DE1Device.isHeadless || DE1Device.simulationMode)
+                        visible: Settings.app.selectedFavoriteProfile === -1 && idlePage.canStartOperations
                         spacing: Theme.scaled(8)
 
                         Rectangle {
@@ -409,7 +415,7 @@ Page {
                                 id: idleNonFavMouseArea
                                 anchors.fill: parent
                                 onClicked: {
-                                    if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+                                    if (MachineState.isReady && idlePage.canStartOperations) {
                                         DE1Device.startEspresso()
                                     } else {
                                         console.log("Cannot start espresso - machine not ready, phase:", MachineState.phase)
@@ -457,7 +463,7 @@ Page {
                         MainController.applyHotWaterSettings()
 
                         if (wasAlreadySelected) {
-                            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+                            if (MachineState.isReady && idlePage.canStartOperations) {
                                 DE1Device.startHotWater()
                             } else {
                                 console.log("Cannot start hot water - machine not ready, phase:", MachineState.phase)
@@ -491,7 +497,7 @@ Page {
                         MainController.applyFlushSettings()
 
                         if (wasAlreadySelected) {
-                            if (MachineState.isReady && (DE1Device.isHeadless || DE1Device.simulationMode)) {
+                            if (MachineState.isReady && idlePage.canStartOperations) {
                                 DE1Device.startFlush()
                             } else {
                                 console.log("Cannot start flush - machine not ready, phase:", MachineState.phase)


### PR DESCRIPTION
## Summary

- All idle-page preset-pill re-tap start paths, layout widgets (`EspressoItem`, `SteamItem`, `HotWaterItem`, `FlushItem`, `CustomItem`), and keyboard shortcuts (`E`/`S`/`W`/`F`) were calling `DE1Device.start*()` with only a `MachineState.isReady` check — bypassing the `isHeadless` guard
- On machines with a hardware GHC (`isHeadless=false`) this allowed the app to send start commands to the DE1, writing `GHC_MODE=1` and causing the GHC to blink unexpectedly
- Added `&& (DE1Device.isHeadless || DE1Device.simulationMode)` to every unguarded start call across 7 files
- Also hides the green non-favourite profile pill (idle page + `EspressoItem`) when GHC is active, since it has no purpose other than starting espresso
- `MiniGHCItem` was already correct — its container-level `enabled` binding covers all children

## Test plan

- [ ] With GHC connected (`isHeadless=false`): verify tapping preset pills, the green profile name pill, and pressing E/S/W/F keys does **not** start any operation
- [ ] With GHC connected: verify the green non-favourite profile pill is hidden
- [ ] With GHC connected: verify `MiniGHCItem` buttons remain dimmed and non-interactive
- [ ] Without GHC (`isHeadless=true`): verify all start paths still work normally
- [ ] Simulation mode: verify all start paths still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)