### PR TITLE
fix(ble): stop periodic CCCD re-writes on Eureka Precisa to prevent disconnect

### DIFF
--- a/src/ble/scales/eurekaprecisascale.cpp
+++ b/src/ble/scales/eurekaprecisascale.cpp
@@ -160,8 +160,9 @@ void EurekaPrecisaScale::sendCommand(const QByteArray& cmd) {
 }
 
 void EurekaPrecisaScale::sendKeepAlive() {
-    if (m_transport && m_characteristicsReady)
-        m_transport->enableNotifications(Scale::Generic::SERVICE, Scale::Generic::STATUS);
+    // Eureka Precisa streams weight notifications continuously once subscribed.
+    // Periodic CCCD re-writes cause AuthorizationError disconnects on this scale —
+    // the de1app only writes the CCCD once (200ms after connect) and never again.
 }
 
 void EurekaPrecisaScale::tare() {

--- a/src/ble/scales/eurekaprecisascale.cpp
+++ b/src/ble/scales/eurekaprecisascale.cpp
@@ -160,9 +160,9 @@ void EurekaPrecisaScale::sendCommand(const QByteArray& cmd) {
 }
 
 void EurekaPrecisaScale::sendKeepAlive() {
-    // Eureka Precisa streams weight notifications continuously once subscribed.
-    // Periodic CCCD re-writes cause AuthorizationError disconnects on this scale —
-    // the de1app only writes the CCCD once (200ms after connect) and never again.
+    // No keep-alive needed — this scale streams notifications continuously once
+    // subscribed; re-writing the CCCD causes AuthorizationError disconnects
+    // (de1app writes CCCD only once at connect time and never again).
 }
 
 void EurekaPrecisaScale::tare() {

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -405,7 +405,7 @@ void QtScaleBleTransport::onCharacteristicWritten(const QLowEnergyCharacteristic
 
 void QtScaleBleTransport::onDescriptorWritten(const QLowEnergyDescriptor& d, const QByteArray& value) {
     Q_UNUSED(value);
-    // CCCD confirmations are expected and frequent (keep-alive re-enables every ~5 min) - don't log
+    // CCCD confirmations are not logged — some scales send them frequently
     Q_UNUSED(d);
 }
 


### PR DESCRIPTION
## Summary

- `EurekaPrecisaScale::sendKeepAlive()` was calling `enableNotifications()` every 30s, which writes the CCCD descriptor to re-enable notifications
- The Eureka Precisa rejects repeated CCCD writes and responds with `AuthorizationError`, tearing down the entire BLE connection at ~60s after connect
- The de1app writes the CCCD exactly once (200ms after connect) and never again — this change matches that behaviour

## Root cause (from issue #1087 debug log)

Scale connects at t=38s. Keep-alive fires every 30s → CCCD re-write at t=68s, then t=98s:

```
[ 98.557]  DescriptorWriteError (non-fatal, scale may still send notifications)
[ 98.609]  !!! CONTROLLER ERROR: AuthorizationError !!!
[ 98.643]  Scale "CFS-9002" DISCONNECTED
```

After the AuthorizationError, Android BLE enters a bad state for that device address, causing all reconnect attempts to time out even though the scale is actively advertising. That's why users can't recover the connection without restarting the app.

## Why de1app doesn't hit this

The Tcl app does `after 200 eureka_precisa_enable_weight_notifications` once on connect, then nothing. The Eureka Precisa streams weight data continuously once subscribed — periodic CCCD re-writes serve no purpose and break the connection on this scale.

## Test plan

- [ ] Connect Eureka Precisa scale + DE1 simultaneously on Android
- [ ] Confirm scale stays connected past the 60s mark
- [ ] Confirm DE1 BLE writes (profile upload, MMR) continue to work while scale is connected
- [ ] Confirm no AuthorizationError in debug log after ~2 min of idle use

Fixes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)