### PR TITLE
fix(ble): stop periodic CCCD re-writes on all scales; gate profile upload queue

### DIFF
--- a/src/ble/scales/acaiascale.cpp
+++ b/src/ble/scales/acaiascale.cpp
@@ -395,14 +395,9 @@ void AcaiaScale::decodeWeight(const QByteArray& data, int payloadOffset) {
 }
 
 void AcaiaScale::sendKeepAlive() {
-    if (!m_transport || !m_characteristicsReady) return;
-
-    // Re-enable BLE notifications to prevent OS-level subscription expiry
-    if (m_isPyxis) {
-        m_transport->enableNotifications(Scale::Acaia::SERVICE, Scale::Acaia::STATUS);
-    } else {
-        m_transport->enableNotifications(Scale::AcaiaIPS::SERVICE, Scale::AcaiaIPS::CHARACTERISTIC);
-    }
+    // No keep-alive needed — the 3s heartbeat packets (sendHeartbeat()) maintain the
+    // connection and keep notifications active. Periodic CCCD re-writes are unnecessary
+    // and risk AuthorizationError disconnects.
 }
 
 void AcaiaScale::sendTareCommand() {

--- a/src/ble/scales/acaiascale.cpp
+++ b/src/ble/scales/acaiascale.cpp
@@ -395,9 +395,9 @@ void AcaiaScale::decodeWeight(const QByteArray& data, int payloadOffset) {
 }
 
 void AcaiaScale::sendKeepAlive() {
-    // No keep-alive needed — the 3s heartbeat packets (sendHeartbeat()) maintain the
-    // connection and keep notifications active. Periodic CCCD re-writes are unnecessary
-    // and risk AuthorizationError disconnects.
+    // No keep-alive needed — the 3s heartbeat packets (sendHeartbeat()) keep the BLE
+    // link alive. Periodic CCCD re-writes are unnecessary and risk AuthorizationError
+    // disconnects.
 }
 
 void AcaiaScale::sendTareCommand() {

--- a/src/ble/scales/atomhearteclairscale.cpp
+++ b/src/ble/scales/atomhearteclairscale.cpp
@@ -155,8 +155,8 @@ void AtomheartEclairScale::sendCommand(const QByteArray& cmd) {
 }
 
 void AtomheartEclairScale::sendKeepAlive() {
-    if (m_transport && m_characteristicsReady)
-        m_transport->enableNotifications(Scale::AtomheartEclair::SERVICE, Scale::AtomheartEclair::STATUS);
+    // No keep-alive needed — notifications stay active without periodic CCCD re-writes.
+    // Re-writing the CCCD risks AuthorizationError disconnects.
 }
 
 void AtomheartEclairScale::tare() {

--- a/src/ble/scales/bookooscale.cpp
+++ b/src/ble/scales/bookooscale.cpp
@@ -178,8 +178,9 @@ void BookooScale::sendCommand(const QByteArray& cmd) {
 }
 
 void BookooScale::sendKeepAlive() {
-    if (m_transport && m_characteristicsReady)
-        m_transport->enableNotifications(Scale::Bookoo::SERVICE, Scale::Bookoo::STATUS);
+    // No keep-alive needed — notifications stay active without periodic CCCD re-writes.
+    // Re-writing the CCCD risks AuthorizationError disconnects on BLE stacks that
+    // reject duplicate subscription requests.
 }
 
 void BookooScale::tare() {

--- a/src/ble/scales/bookooscale.cpp
+++ b/src/ble/scales/bookooscale.cpp
@@ -179,8 +179,7 @@ void BookooScale::sendCommand(const QByteArray& cmd) {
 
 void BookooScale::sendKeepAlive() {
     // No keep-alive needed — notifications stay active without periodic CCCD re-writes.
-    // Re-writing the CCCD risks AuthorizationError disconnects on BLE stacks that
-    // reject duplicate subscription requests.
+    // Re-writing the CCCD risks AuthorizationError disconnects.
 }
 
 void BookooScale::tare() {

--- a/src/ble/scales/difluidscale.cpp
+++ b/src/ble/scales/difluidscale.cpp
@@ -139,8 +139,8 @@ void DifluidScale::sendCommand(const QByteArray& cmd) {
 }
 
 void DifluidScale::sendKeepAlive() {
-    if (m_transport && m_characteristicsReady)
-        m_transport->enableNotifications(Scale::DiFluid::SERVICE, Scale::DiFluid::CHARACTERISTIC);
+    // No keep-alive needed — notifications stay active without periodic CCCD re-writes.
+    // Re-writing the CCCD risks AuthorizationError disconnects.
 }
 
 void DifluidScale::enableNotifications() {

--- a/src/ble/scales/felicitascale.cpp
+++ b/src/ble/scales/felicitascale.cpp
@@ -161,8 +161,8 @@ void FelicitaScale::sendCommand(uint8_t cmd) {
 }
 
 void FelicitaScale::sendKeepAlive() {
-    if (m_transport && m_characteristicsReady)
-        m_transport->enableNotifications(Scale::Felicita::SERVICE, Scale::Felicita::CHARACTERISTIC);
+    // No keep-alive needed — notifications stay active without periodic CCCD re-writes.
+    // Re-writing the CCCD risks AuthorizationError disconnects.
 }
 
 void FelicitaScale::tare() {

--- a/src/ble/scales/hiroiascale.cpp
+++ b/src/ble/scales/hiroiascale.cpp
@@ -139,8 +139,8 @@ void HiroiaScale::onCharacteristicChanged(const QBluetoothUuid& characteristicUu
 }
 
 void HiroiaScale::sendKeepAlive() {
-    if (m_transport && m_characteristicsReady)
-        m_transport->enableNotifications(Scale::HiroiaJimmy::SERVICE, Scale::HiroiaJimmy::STATUS);
+    // No keep-alive needed — notifications stay active without periodic CCCD re-writes.
+    // Re-writing the CCCD risks AuthorizationError disconnects.
 }
 
 void HiroiaScale::tare() {

--- a/src/ble/scales/skalescale.cpp
+++ b/src/ble/scales/skalescale.cpp
@@ -163,10 +163,8 @@ void SkaleScale::sendCommand(uint8_t cmd) {
 }
 
 void SkaleScale::sendKeepAlive() {
-    if (m_transport && m_characteristicsReady) {
-        m_transport->enableNotifications(Scale::Skale::SERVICE, Scale::Skale::WEIGHT);
-        m_transport->enableNotifications(Scale::Skale::SERVICE, Scale::Skale::BUTTON);
-    }
+    // No keep-alive needed — notifications stay active without periodic CCCD re-writes.
+    // Re-writing the CCCD risks AuthorizationError disconnects.
 }
 
 void SkaleScale::tare() {

--- a/src/ble/scales/smartchefscale.cpp
+++ b/src/ble/scales/smartchefscale.cpp
@@ -132,8 +132,8 @@ void SmartChefScale::onCharacteristicChanged(const QBluetoothUuid& characteristi
 }
 
 void SmartChefScale::sendKeepAlive() {
-    if (m_transport && m_characteristicsReady)
-        m_transport->enableNotifications(Scale::Generic::SERVICE, Scale::Generic::STATUS);
+    // No keep-alive needed — scale streams notifications continuously once subscribed.
+    // Re-writing the CCCD causes AuthorizationError disconnects (same issue as Eureka Precisa).
 }
 
 void SmartChefScale::tare() {

--- a/src/ble/scales/smartchefscale.cpp
+++ b/src/ble/scales/smartchefscale.cpp
@@ -133,7 +133,8 @@ void SmartChefScale::onCharacteristicChanged(const QBluetoothUuid& characteristi
 
 void SmartChefScale::sendKeepAlive() {
     // No keep-alive needed — scale streams notifications continuously once subscribed.
-    // Re-writing the CCCD causes AuthorizationError disconnects (same issue as Eureka Precisa).
+    // Re-writing the CCCD causes AuthorizationError disconnects; de1app writes CCCD only
+    // once at connect time and never again.
 }
 
 void SmartChefScale::tare() {

--- a/src/ble/scales/variaakuscale.cpp
+++ b/src/ble/scales/variaakuscale.cpp
@@ -266,8 +266,8 @@ void VariaAkuScale::sendCommand(const QByteArray& cmd) {
 }
 
 void VariaAkuScale::sendKeepAlive() {
-    if (m_transport && m_characteristicsReady)
-        m_transport->enableNotifications(Scale::VariaAku::SERVICE, Scale::VariaAku::STATUS);
+    // No keep-alive needed — notifications stay active without periodic CCCD re-writes.
+    // Re-writing the CCCD risks AuthorizationError disconnects.
 }
 
 void VariaAkuScale::tare() {

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -181,6 +181,10 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                     .arg(m_profileUploadRetryAttempts)
                     .arg(m_lastUploadFailureReason);
                 m_profileUploadRetryTimer.stop();
+                if (hadPending) {
+                    // Preserve intent so reconnect path re-uploads the latest profile.
+                    m_profileUploadPending = true;
+                }
                 if (!m_de1CommunicationFailure) {
                     m_de1CommunicationFailure = true;
                     emit de1CommunicationFailureChanged();
@@ -201,8 +205,9 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                 .arg(kMaxUploadRetryAttempts);
             m_profileUploadRetryTimer.start(delayMs);
             updateProfileUploadRetrying();
-            // On retryable failure, the retry timer will call uploadCurrentProfile() which
-            // uploads m_currentProfile (the latest selection) — no need to track hadPending.
+            // hadPending was already consumed and m_uploadPendingAfterInFlight cleared at the top
+            // of this handler. The retry timer calls uploadCurrentProfile(), which re-reads
+            // m_currentProfile at fire time and thus naturally uploads the latest selection.
 
             // Safety: if a shot is already running on the DE1 (started via the
             // group-head button before the new profile landed), the DE1 is
@@ -238,6 +243,12 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
             if (m_device && !m_device->isConnected()) {
                 // Safety reset: clear in-flight gate in case profileUploaded(false, "BLE disconnect")
                 // fires after this signal (signal ordering is not guaranteed).
+                if (m_uploadPendingAfterInFlight) {
+                    // A deferred profile change was queued mid-upload. Preserve the intent
+                    // so the reconnect path (initialSettingsComplete → uploadCurrentProfile)
+                    // re-uploads the latest profile when the link comes back.
+                    m_profileUploadPending = true;
+                }
                 m_uploadInFlight = false;
                 m_uploadPendingAfterInFlight = false;
                 if (m_profileUploadRetryTimer.isActive()
@@ -1473,6 +1484,8 @@ void ProfileManager::uploadCurrentProfile() {
         // Android BLE GATT write queue. The profileUploaded signal will trigger a follow-up
         // upload when the current one completes, carrying the latest m_currentProfile.
         if (m_uploadInFlight) {
+            qDebug() << "ProfileManager: uploadCurrentProfile deferred — "
+                        "upload in flight, will retry on profileUploaded";
             m_uploadPendingAfterInFlight = true;
             return;
         }

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -140,6 +140,12 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
     if (m_device) {
         connect(m_device, &DE1Device::profileUploaded, this,
                 [this](bool success, const QString& reason) {
+            // Clear the in-flight gate so the next uploadCurrentProfile() call can proceed.
+            // If a newer profile change arrived while the upload was in flight, trigger it now.
+            m_uploadInFlight = false;
+            bool hadPending = m_uploadPendingAfterInFlight;
+            m_uploadPendingAfterInFlight = false;
+
             if (success) {
                 // A successful upload clears all retry state. If a prior
                 // communication-failure dialog is still up, leave it — the
@@ -150,12 +156,19 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                 m_profileUploadRetryAttempts = 0;
                 m_lastUploadFailureReason.clear();
                 updateProfileUploadRetrying();
+                if (hadPending) {
+                    uploadCurrentProfile();
+                }
                 return;
             }
             if (!isRetryableUploadFailure(reason)) {
                 // Not a retry condition — don't bump the counter. The
                 // existing m_profileUploadPending / phaseChanged machinery
                 // handles queue-clear and supersede cases on its own.
+                // The pending upload (if any) will ride the reconnect path.
+                if (hadPending) {
+                    m_profileUploadPending = true;
+                }
                 return;
             }
             m_lastUploadFailureReason = reason;
@@ -188,6 +201,8 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
                 .arg(kMaxUploadRetryAttempts);
             m_profileUploadRetryTimer.start(delayMs);
             updateProfileUploadRetrying();
+            // On retryable failure, the retry timer will call uploadCurrentProfile() which
+            // uploads m_currentProfile (the latest selection) — no need to track hadPending.
 
             // Safety: if a shot is already running on the DE1 (started via the
             // group-head button before the new profile landed), the DE1 is
@@ -221,6 +236,10 @@ ProfileManager::ProfileManager(Settings* settings, DE1Device* device,
         // start from attempt 1.
         connect(m_device, &DE1Device::connectedChanged, this, [this]() {
             if (m_device && !m_device->isConnected()) {
+                // Safety reset: clear in-flight gate in case profileUploaded(false, "BLE disconnect")
+                // fires after this signal (signal ordering is not guaranteed).
+                m_uploadInFlight = false;
+                m_uploadPendingAfterInFlight = false;
                 if (m_profileUploadRetryTimer.isActive()
                     || m_profileUploadRetryAttempts > 0) {
                     qDebug() << "ProfileManager: resetting upload-retry state "
@@ -1450,7 +1469,16 @@ void ProfileManager::uploadCurrentProfile() {
     }
 
     if (m_device && m_device->isConnected()) {
+        // If a profile upload is already in flight, defer this one rather than flooding the
+        // Android BLE GATT write queue. The profileUploaded signal will trigger a follow-up
+        // upload when the current one completes, carrying the latest m_currentProfile.
+        if (m_uploadInFlight) {
+            m_uploadPendingAfterInFlight = true;
+            return;
+        }
+
         m_profileUploadPending = false;
+        m_uploadInFlight = true;
         double groupTemp;
 
         // Apply temperature override as delta offset (preserves per-frame differences)

--- a/src/controllers/profilemanager.h
+++ b/src/controllers/profilemanager.h
@@ -228,6 +228,8 @@ private:
     QString m_previousProfileName;
     bool m_profileModified = false;
     bool m_profileUploadPending = false;
+    bool m_uploadInFlight = false;        // True while a profile upload is in progress at DE1Device
+    bool m_uploadPendingAfterInFlight = false;  // True if a newer profile change arrived mid-upload
     bool m_startupLoadDone = false;
 
     // Auto-retry state for failed profile uploads. A failure with a retryable


### PR DESCRIPTION
## Summary

- **All 9 remaining scales with CCCD-writing `sendKeepAlive()` changed to no-ops**: SmartChef, Bookoo, Acaia, Felicita, DiFluid, Hiroia, AtomheartEclair, Skale, VariaAku. Periodic CCCD re-writes are harmless on forgiving stacks but cause `AuthorizationError` disconnects on stricter ones. de1app writes CCCD exactly once at connect time — this matches that behavior.
- **ProfileManager now gates profile uploads to at most one in-flight at a time**: When `uploadCurrentProfile()` is called while a previous upload is still in progress, it sets `m_uploadPendingAfterInFlight` and returns immediately instead of queuing additional write-with-response frames into the Android BLE GATT queue. When `profileUploaded` fires, the latest pending profile is uploaded. Fixes DE1 AuthorizationError from rapid profile swiping (issue #1091).

## Root causes fixed

**Issue #1087 / #1090 (already shipped):** Eureka Precisa's `sendKeepAlive()` re-wrote the CCCD every 30s, triggering `AuthorizationError` at exactly t=98s (2nd keepalive). SmartChef had the identical bug (same Generic service UUIDs).

**Issue #1091 (this PR):** User swiped through 7 profiles in 4 seconds. Each triggered `uploadCurrentProfile()` → 7 separate write-with-response sequences queued into Android's GATT queue simultaneously. The queue overflowed, causing `AuthorizationError` on the DE1 at t=50s and a broken BLE state for the rest of the session.

## What `sendKeepAlive()` still does

The base-class 30s timer still fires and still calls the virtual `sendKeepAlive()`. Two scales continue doing real work:
- **TimemoreScale** — sends poll command packets (protocol requirement, not CCCD)
- **DecentScale** — already a no-op (has its own 1s heartbeat)

For all other scales the override now returns immediately. BLE connections stay alive via the stack's connection supervision timeout; notification subscriptions persist until disconnect.

## Test plan
- [ ] Connect Eureka Precisa / SmartChef — verify no AuthorizationError after 60+ seconds
- [ ] With DE1 + scale connected, rapidly swipe through 5+ favorite profiles — verify DE1 does not throw AuthorizationError; final selected profile is what gets uploaded
- [ ] Normal profile selection (single switch) still uploads immediately
- [ ] Disconnect/reconnect cycle still re-uploads the current profile

Closes #1091