### PR TITLE
fix(ble): drop redundant scale CCCD auto-enable + add cross-transport diagnostics

### DIFF
--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -663,6 +663,9 @@ void BleTransport::writeCharacteristic(const QBluetoothUuid& uuid, const QByteAr
     m_lastWriteUuid = uuidShort;
     m_lastWriteData = data;
     m_writeTimeoutTimer.start();
+    // Log every submission so we can correlate DE1 write failures with surrounding scale BLE
+    // activity (scale CCCD writes, scale notify bursts) on the same Android GATT pipeline.
+    log(QString("write submit %1 (%2 bytes)").arg(uuidShort).arg(data.size()));
     m_service->writeCharacteristic(m_characteristics[uuid], data);
 }
 

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -1,6 +1,7 @@
 #include "qtscalebletransport.h"
 #include "../blecapability.h"
 #include "../blemanager.h"
+#include <QDateTime>
 #include <QDebug>
 #include <QTimer>
 #include <QLowEnergyConnectionParameters>
@@ -161,10 +162,7 @@ void QtScaleBleTransport::discoverCharacteristics(const QBluetoothUuid& serviceU
 
 void QtScaleBleTransport::enableNotifications(const QBluetoothUuid& serviceUuid,
                                               const QBluetoothUuid& characteristicUuid) {
-    const bool firstEnable = !m_notificationsEnabledOnce;
-    if (firstEnable) {
-        QT_TRANSPORT_LOG(QString("Enabling notifications for %1").arg(characteristicUuid.toString()));
-    }
+    QT_TRANSPORT_LOG(QString("Enabling notifications for %1").arg(characteristicUuid.toString()));
 
     QLowEnergyService* service = m_services.value(serviceUuid);
     if (!service) {
@@ -184,15 +182,14 @@ void QtScaleBleTransport::enableNotifications(const QBluetoothUuid& serviceUuid,
         QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration);
 
     if (cccd.isValid()) {
-        if (firstEnable) {
-            QT_TRANSPORT_LOG("Writing CCCD to enable notifications");
-        }
+        // Always log: with auto-enable removed and keepalive CCCD re-writes gone, this should
+        // fire once per characteristic per session. If it appears more often, something is
+        // re-enabling notifications and we want to see it.
+        QT_TRANSPORT_LOG(QString("write CCCD enable %1").arg(characteristicUuid.toString().mid(1, 8)));
         service->writeDescriptor(cccd, QByteArray::fromHex("0100"));
     } else {
         QT_TRANSPORT_LOG("CCCD descriptor not found - scale may still send notifications");
     }
-
-    m_notificationsEnabledOnce = true;
 
     // Emit immediately (fire-and-forget) - don't wait for CCCD write response.
     // Some scales (e.g. Bookoo) reject CCCD writes but still send notifications.
@@ -221,6 +218,11 @@ void QtScaleBleTransport::writeCharacteristic(const QBluetoothUuid& serviceUuid,
         ? QLowEnergyService::WriteWithoutResponse
         : QLowEnergyService::WriteWithResponse;
 
+    // Log every write so we can correlate scale BLE activity with DE1 write failures.
+    QT_TRANSPORT_LOG(QString("write %1 (%2 bytes, %3)")
+        .arg(characteristicUuid.toString().mid(1, 8))
+        .arg(data.size())
+        .arg(writeType == WriteType::WithoutResponse ? "WithoutResponse" : "WithResponse"));
     service->writeCharacteristic(characteristic, data, mode);
 }
 
@@ -261,7 +263,8 @@ void QtScaleBleTransport::onControllerConnected() {
 void QtScaleBleTransport::onControllerDisconnected() {
     QT_TRANSPORT_LOG("Controller disconnected");
     m_connected = false;
-    m_notificationsEnabledOnce = false;
+    m_notifyCountSinceSummary = 0;
+    m_lastNotifySummaryMs = 0;
     emit disconnected();
 }
 
@@ -355,37 +358,34 @@ void QtScaleBleTransport::onServiceStateChanged(QLowEnergyService::ServiceState 
                                          static_cast<int>(props));
         }
 
-        // Delay notification enabling by one event loop tick (iOS descriptor timing)
-        QTimer::singleShot(0, this, [this, service, serviceUuid]() {
-            if (!service) return;
-
-            QT_TRANSPORT_LOG("Auto-enabling notifications for all Notify/Indicate characteristics...");
-            const QList<QLowEnergyCharacteristic> chars = service->characteristics();
-            for (const QLowEnergyCharacteristic& c : chars) {
-                auto props = c.properties();
-                if (props.testFlag(QLowEnergyCharacteristic::Notify) ||
-                    props.testFlag(QLowEnergyCharacteristic::Indicate)) {
-
-                    auto cccd = c.descriptor(QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration);
-                    QT_TRANSPORT_LOG(QString("Notify-capable %1, CCCD valid=%2")
-                        .arg(c.uuid().toString())
-                        .arg(cccd.isValid()));
-
-                    if (cccd.isValid()) {
-                        QT_TRANSPORT_LOG(QString("Auto-enabling notify for %1").arg(c.uuid().toString()));
-                        service->writeDescriptor(cccd, QByteArray::fromHex("0100"));
-                    }
-                }
-            }
-
-            emit characteristicsDiscoveryFinished(serviceUuid);
-        });
+        // Each scale calls enableNotifications() explicitly for the characteristic(s) it needs;
+        // the transport no longer auto-enables CCCDs for every notify-capable characteristic.
+        // The auto-enable was a redundant second CCCD write per characteristic that piled onto
+        // the Android GATT pipeline at scale-connect time. On Android 9 + concurrent DE1 GATT
+        // writes, those extra descriptor writes appear to starve DE1 writes
+        // (CharacteristicWriteError on 0xa00f / 0xa010). The CoreBluetooth transport already
+        // disabled this for the same reason. de1app writes CCCDs once, never automatically.
+        emit characteristicsDiscoveryFinished(serviceUuid);
     }
 }
 
 void QtScaleBleTransport::onCharacteristicChanged(const QLowEnergyCharacteristic& c,
                                                    const QByteArray& value) {
-    // Don't log every notification - too spammy (weight updates come constantly)
+    // Per-packet logs would flood — log a periodic summary (count + interval) instead so
+    // we can see scale notify volume in the timeline without drowning out other events.
+    ++m_notifyCountSinceSummary;
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    if (m_lastNotifySummaryMs == 0) m_lastNotifySummaryMs = nowMs;
+    constexpr qint64 kSummaryIntervalMs = 5000;
+    if (nowMs - m_lastNotifySummaryMs >= kSummaryIntervalMs) {
+        QT_TRANSPORT_LOG(QString("notify rate: %1 in last %2 ms (last %3 = %4 bytes)")
+            .arg(m_notifyCountSinceSummary)
+            .arg(nowMs - m_lastNotifySummaryMs)
+            .arg(c.uuid().toString().mid(1, 8))
+            .arg(value.size()));
+        m_notifyCountSinceSummary = 0;
+        m_lastNotifySummaryMs = nowMs;
+    }
     emit characteristicChanged(c.uuid(), value);
 }
 

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -182,9 +182,8 @@ void QtScaleBleTransport::enableNotifications(const QBluetoothUuid& serviceUuid,
         QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration);
 
     if (cccd.isValid()) {
-        // Always log: with auto-enable removed and keepalive CCCD re-writes gone, this should
-        // fire once per characteristic per session. If it appears more often, something is
-        // re-enabling notifications and we want to see it.
+        // Expected to fire once per characteristic per session. If it appears more often,
+        // something is re-enabling notifications and we want to see it in the log.
         QT_TRANSPORT_LOG(QString("write CCCD enable %1").arg(characteristicUuid.toString().mid(1, 8)));
         service->writeDescriptor(cccd, QByteArray::fromHex("0100"));
     } else {
@@ -364,7 +363,8 @@ void QtScaleBleTransport::onServiceStateChanged(QLowEnergyService::ServiceState 
         // the Android GATT pipeline at scale-connect time. On Android 9 + concurrent DE1 GATT
         // writes, those extra descriptor writes appear to starve DE1 writes
         // (CharacteristicWriteError on 0xa00f / 0xa010). The CoreBluetooth transport already
-        // disabled this for the same reason. de1app writes CCCDs once, never automatically.
+        // skipped auto-enable (its rationale was Bookoo-scale double-enable confusion);
+        // de1app writes CCCDs once, never automatically.
         emit characteristicsDiscoveryFinished(serviceUuid);
     }
 }

--- a/src/ble/transport/qtscalebletransport.h
+++ b/src/ble/transport/qtscalebletransport.h
@@ -58,5 +58,8 @@ private:
     QString m_deviceName;
     QString m_deviceId;  // UUID on iOS, address on other platforms - for duplicate detection
     bool m_connected = false;
-    bool m_notificationsEnabledOnce = false;  // Suppress routine CCCD logging after first enable
+    // Periodic notify-rate logging — counts notifications since the last summary line so
+    // we can correlate scale traffic volume with DE1 write failures without per-packet spam.
+    int m_notifyCountSinceSummary = 0;
+    qint64 m_lastNotifySummaryMs = 0;
 };


### PR DESCRIPTION
## Summary

Two-part change targeting the Precisa-on-P80X scale interference bug ([#1087](https://github.com/Kulitorum/Decenza/issues/1087), [#1091](https://github.com/Kulitorum/Decenza/issues/1091), [#1093](https://github.com/Kulitorum/Decenza/issues/1093)).

### 1. Fix experiment: drop the auto-CCCD-enable in `QtScaleBleTransport`

`QtScaleBleTransport::onServiceStateChanged` was auto-writing CCCDs for **every** notify-capable characteristic right after service discovery, in addition to each scale's own `enableNotifications()` call. That's two CCCD writes per characteristic, hitting the Android GATT pipeline at exactly the moment scale connection completes.

In all four user logs across 1.7.2 / 1.7.3 / 1.7.4, the failure pattern is the same: scale connects, then 5–10 s later DE1 writes start failing with `CharacteristicWriteError` on `0xa00f` / `0xa010`. The timing matches the auto-CCCD writes landing on the shared HCI pipeline.

The `CoreBluetoothScaleBleTransport` (iOS/macOS) already disabled this auto-enable, citing Bookoo issues. de1app never auto-writes CCCDs at all. We're matching that behavior on Qt's path.

If hypothesis correct → user's profile changes after scale connect start working again. If wrong → no harm done (each scale already writes its own CCCD), and the diagnostics below tell us the real cause.

### 2. Cross-transport diagnostics, in case the experiment fails

If the auto-enable wasn't the cause, the next log we get back will let us pin it down without another round-trip:

- Every scale `writeCharacteristic` call → `[BLE QtTransport] write <uuid> (<n> bytes, WithResponse)`
- Every scale CCCD enable → `[BLE QtTransport] write CCCD enable <uuid>`
- Every DE1 `writeCharacteristic` submission → `[BLE DE1] write submit <uuid> (<n> bytes)`
- Scale notify-rate summary every 5 s → `[BLE QtTransport] notify rate: 124 in last 5012 ms (last 0000fff1 = 9 bytes)`

Together these give us a timeline of every BLE operation on both transports on the shared Android GATT pipeline. When DE1 writes fail we'll see exactly what scale traffic was happening in the same window — descriptor writes, command writes, or notify bursts.

## Test plan

- [ ] User installs build and reproduces the original repro: connect DE1, change profiles (works), connect Precisa, change profiles
- [ ] If profile changes now flash purple after scale connect → fix worked, remove diagnostics in a follow-up PR
- [ ] If still broken → next debug log identifies the actual conflicting BLE operation