### PR TITLE
fix(updates): timeout + diagnostics for APK download stalls (#1089)

### DIFF
--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -510,12 +510,13 @@ void UpdateChecker::startDownload()
     QNetworkRequest request(m_downloadUrl);
     request.setHeader(QNetworkRequest::UserAgentHeader, "Decenza");
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
-    // 60s inactivity timeout — without this a stalled Wi-Fi (no FIN, no RST,
+    // 90s inactivity timeout — without this a stalled Wi-Fi (no FIN, no RST,
     // packets blackholed) leaves the reply hanging forever. The hang has been
     // observed to coincide with activity destruction on Samsung devices when
     // a network change races with a long-running QSocketNotifier (issue #1089).
     // A clean self-abort emits errorOccurred → finished, which we already handle.
-    request.setTransferTimeout(60000);
+    // 90s is well above any normal inactivity gap on a healthy connection.
+    request.setTransferTimeout(90000);
 
     m_currentReply = m_network->get(request);
     connect(m_currentReply, &QNetworkReply::downloadProgress, this, &UpdateChecker::onDownloadProgress);

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -510,6 +510,12 @@ void UpdateChecker::startDownload()
     QNetworkRequest request(m_downloadUrl);
     request.setHeader(QNetworkRequest::UserAgentHeader, "Decenza");
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    // 60s inactivity timeout — without this a stalled Wi-Fi (no FIN, no RST,
+    // packets blackholed) leaves the reply hanging forever. The hang has been
+    // observed to coincide with activity destruction on Samsung devices when
+    // a network change races with a long-running QSocketNotifier (issue #1089).
+    // A clean self-abort emits errorOccurred → finished, which we already handle.
+    request.setTransferTimeout(60000);
 
     m_currentReply = m_network->get(request);
     connect(m_currentReply, &QNetworkReply::downloadProgress, this, &UpdateChecker::onDownloadProgress);
@@ -523,6 +529,16 @@ void UpdateChecker::startDownload()
                 m_errorMessage = "Download failed: could not write file (" + m_downloadFile->errorString() + ")";
                 m_currentReply->abort();
             }
+        }
+    });
+    // Log transport errors as soon as they happen so we can distinguish a
+    // stalled-then-self-aborted reply from a clean transport failure.
+    // finished() still fires after this — that's where teardown happens.
+    connect(m_currentReply, &QNetworkReply::errorOccurred, this,
+            [this](QNetworkReply::NetworkError code) {
+        if (m_currentReply) {
+            qWarning() << "UpdateChecker: Download errorOccurred code=" << code
+                       << "msg=" << m_currentReply->errorString();
         }
     });
     connect(m_currentReply, &QNetworkReply::finished, this, &UpdateChecker::onDownloadFinished);

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -511,11 +511,13 @@ void UpdateChecker::startDownload()
     request.setHeader(QNetworkRequest::UserAgentHeader, "Decenza");
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     // 90s inactivity timeout — without this a stalled Wi-Fi (no FIN, no RST,
-    // packets blackholed) leaves the reply hanging forever. The hang has been
-    // observed to coincide with activity destruction on Samsung devices when
-    // a network change races with a long-running QSocketNotifier (issue #1089).
-    // A clean self-abort emits errorOccurred → finished, which we already handle.
-    // 90s is well above any normal inactivity gap on a healthy connection.
+    // packets blackholed) leaves the reply hanging forever, and on Android the
+    // hang has been observed to coincide with activity destruction when a
+    // network change races with the in-flight socket reader (issue #1089).
+    // A clean self-abort emits errorOccurred → finished, which we already
+    // handle. 90s is well above any normal inactivity gap on a healthy
+    // connection. (Qt 6.10's setTransferTimeout resets on every received
+    // chunk — true inactivity semantics, not a total-transfer cap.)
     request.setTransferTimeout(90000);
 
     m_currentReply = m_network->get(request);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <QElapsedTimer>
 #include <QNetworkAccessManager>
+#include <QNetworkInformation>
 #ifdef Q_OS_MACOS
 #include <QProcess>
 #endif
@@ -464,6 +465,21 @@ int main(int argc, char *argv[])
     // pooling, reduced thread count). Passed by pointer to most HTTP consumers.
     // Exceptions: CrashReporter, LibrarySharing, ShotServer test endpoint keep own NAM.
     QNetworkAccessManager sharedNetworkManager;
+
+    // Monitor network reachability so the debug log captures connectivity
+    // changes that race with long-running downloads (issue #1089). Best-effort:
+    // load fails on platforms without a backend, in which case we just don't log.
+    if (QNetworkInformation::loadDefaultBackend()) {
+        if (auto* info = QNetworkInformation::instance()) {
+            qDebug() << "[Network] initial reachability:" << info->reachability();
+            QObject::connect(info, &QNetworkInformation::reachabilityChanged,
+                             [](QNetworkInformation::Reachability r) {
+                qDebug() << "[Network] reachability changed ->" << r;
+            });
+        }
+    } else {
+        qDebug() << "[Network] QNetworkInformation backend unavailable";
+    }
 
     TranslationManager translationManager(&sharedNetworkManager, &settings);
     checkpoint("TranslationManager");
@@ -2118,6 +2134,18 @@ int main(int argc, char *argv[])
     QObject::connect(&app, &QGuiApplication::applicationStateChanged,
                      [&physicalScale, &bleManager, &settings, &batteryManager, &de1Device, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &de1ReconnectTimer, &de1ReconnectAttempt, &scaleAutoReconnectSuppressed](Qt::ApplicationState state) {
         static bool wasSuspended = false;
+
+        // Log every state transition so the debug log captures pre-suspend
+        // flickers (Inactive, Hidden) that precede an activity destroy.
+        // Adds one line per transition — negligible noise.
+        const char* name = "Unknown";
+        switch (state) {
+            case Qt::ApplicationSuspended: name = "Suspended"; break;
+            case Qt::ApplicationHidden:    name = "Hidden";    break;
+            case Qt::ApplicationInactive:  name = "Inactive";  break;
+            case Qt::ApplicationActive:    name = "Active";    break;
+        }
+        qDebug() << "[AppState] applicationStateChanged ->" << name;
 
         if (state == Qt::ApplicationSuspended) {
             wasSuspended = true;


### PR DESCRIPTION
## Summary

- Adds a 90s inactivity timeout to the APK download `QNetworkRequest` so a stalled reply self-aborts cleanly instead of hanging indefinitely.
- Wires `QNetworkReply::errorOccurred` to log transport errors at the moment they happen.
- Logs every `QGuiApplication::applicationStateChanged` transition (Active/Inactive/Hidden/Suspended) instead of just Suspended.
- Wires `QNetworkInformation::reachabilityChanged` so connectivity transitions show up in the debug log.

## Why

Issue #1089 reports APK downloads stalling and ending in a clean app exit (`Application exiting` via `aboutToQuit`) when the transfer takes longer than ~35-40s. The reporter's debug log showed 4 failures and 4 successes split cleanly on download duration:

| Result | Time |
|---|---|
| Success | 22, 28, 31, 34 s |
| Failure (time to kill) | 43, 57, 61, 77 s |

One failure had a confirmed network blip (`"Network unreachable"` from `WeatherManager`) 31s before the activity was destroyed. The APK download had **no transfer timeout** and **no `errorOccurred` handler**, so a stalled Wi-Fi (no FIN, no RST, packets blackholed) leaves the `QNetworkReply` hanging forever. On Android that hang has been observed to coincide with activity destruction when a network state change races with the dangling `QSocketNotifier`.

The 90s timeout is the candidate real fix. The other three are diagnostics that prove or disprove the hypothesis with the next user log.

## Test plan

- [ ] Build runs cleanly on Android, macOS, and Windows targets.
- [ ] Verify a normal-speed APK download still completes (no false-positive timeout).
- [ ] Force a stalled download (airplane mode mid-transfer) and confirm `errorOccurred` is logged and the reply terminates within 90s with `OperationCanceledError`.
- [ ] Confirm `[Network] initial reachability: ...` appears at startup and `[Network] reachability changed -> ...` appears when toggling Wi-Fi.
- [ ] Confirm `[AppState] applicationStateChanged -> Active` (and other states) appear on background/foreground transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)