### PR TITLE
fix(ble): log negotiated connection params + state at controller error

### DIFF
--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -392,7 +392,17 @@ void BleTransport::onControllerError(QLowEnergyController::Error error) {
         default:
             errorName = QString::number(static_cast<int>(error)); userMessage = "Connection error"; break;
     }
-    warn(QString("!!! CONTROLLER ERROR: %1 !!!").arg(errorName));
+    QString stateName;
+    switch (m_controller ? m_controller->state() : QLowEnergyController::UnconnectedState) {
+        case QLowEnergyController::UnconnectedState: stateName = "Unconnected"; break;
+        case QLowEnergyController::ConnectingState:  stateName = "Connecting"; break;
+        case QLowEnergyController::ConnectedState:   stateName = "Connected"; break;
+        case QLowEnergyController::DiscoveringState: stateName = "Discovering"; break;
+        case QLowEnergyController::DiscoveredState:  stateName = "Discovered"; break;
+        case QLowEnergyController::ClosingState:     stateName = "Closing"; break;
+        default: stateName = QString::number(static_cast<int>(m_controller ? m_controller->state() : -1)); break;
+    }
+    warn(QString("!!! CONTROLLER ERROR: %1 (state=%2) !!!").arg(errorName, stateName));
     emit errorOccurred(userMessage);
 
     // Dump a one-shot Linux BT diagnostics block into the debug log the
@@ -599,6 +609,16 @@ bool BleTransport::setupController(const QBluetoothDeviceInfo& device) {
             this, &BleTransport::onControllerDisconnected, qc);
     connect(m_controller, &QLowEnergyController::errorOccurred,
             this, &BleTransport::onControllerError, qc);
+    // Log the connection parameters Android actually grants us (vs what we
+    // requested via requestConnectionUpdate). This fires at least once shortly
+    // after connect, and again any time the link parameters change. Lets us
+    // see the real negotiated interval/latency/timeout for diagnosing radio
+    // contention when the DE1 + a scale share the same Android BT pipeline.
+    connect(m_controller, &QLowEnergyController::connectionUpdated, this,
+            [this](const QLowEnergyConnectionParameters& p) {
+        this->log(QString("connectionUpdated: interval=%1ms latency=%2 supervisionTimeout=%3ms")
+            .arg(p.minimumInterval()).arg(p.latency()).arg(p.supervisionTimeout()));
+    }, qc);
     connect(m_controller, &QLowEnergyController::serviceDiscovered,
             this, &BleTransport::onServiceDiscovered, qc);
     connect(m_controller, &QLowEnergyController::discoveryFinished,

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -85,6 +85,14 @@ void QtScaleBleTransport::connectToDevice(const QBluetoothDeviceInfo& device) {
             this, &QtScaleBleTransport::onControllerDisconnected, qc);
     connect(m_controller, &QLowEnergyController::errorOccurred,
             this, &QtScaleBleTransport::onControllerError, qc);
+    // Log negotiated connection parameters (see bletransport.cpp for rationale).
+    // We need to compare scale + DE1 against each other on the same Android BT
+    // pipeline, so log on both transports.
+    connect(m_controller, &QLowEnergyController::connectionUpdated, this,
+            [this](const QLowEnergyConnectionParameters& p) {
+        this->log(QString("connectionUpdated: interval=%1ms latency=%2 supervisionTimeout=%3ms")
+            .arg(p.minimumInterval()).arg(p.latency()).arg(p.supervisionTimeout()));
+    }, qc);
     connect(m_controller, &QLowEnergyController::serviceDiscovered,
             this, &QtScaleBleTransport::onServiceDiscovered, qc);
     connect(m_controller, &QLowEnergyController::discoveryFinished,
@@ -282,7 +290,17 @@ void QtScaleBleTransport::onControllerError(QLowEnergyController::Error err) {
         case QLowEnergyController::MissingPermissionsError: errorName = "MissingPermissionsError"; break;
         default: errorName = QString::number(static_cast<int>(err)); break;
     }
-    QString msg = QString("!!! CONTROLLER ERROR: %1 !!!").arg(errorName);
+    QString stateName;
+    switch (m_controller ? m_controller->state() : QLowEnergyController::UnconnectedState) {
+        case QLowEnergyController::UnconnectedState: stateName = "Unconnected"; break;
+        case QLowEnergyController::ConnectingState:  stateName = "Connecting"; break;
+        case QLowEnergyController::ConnectedState:   stateName = "Connected"; break;
+        case QLowEnergyController::DiscoveringState: stateName = "Discovering"; break;
+        case QLowEnergyController::DiscoveredState:  stateName = "Discovered"; break;
+        case QLowEnergyController::ClosingState:     stateName = "Closing"; break;
+        default: stateName = QString::number(static_cast<int>(m_controller ? m_controller->state() : -1)); break;
+    }
+    QString msg = QString("!!! CONTROLLER ERROR: %1 (state=%2) !!!").arg(errorName, stateName);
     QT_TRANSPORT_LOG(msg);
     emit error(msg);
 


### PR DESCRIPTION
## Summary

Adds two read-only diagnostic subscriptions on both DE1 (`BleTransport`) and scale (`QtScaleBleTransport`) so the next debug log from issue #1093 can answer questions we currently can't:

- **`QLowEnergyController::connectionUpdated`** — logs the negotiated interval / slave latency / supervision timeout that Android actually grants us. We currently call `requestConnectionUpdate` with default `QLowEnergyConnectionParameters` (which maps to `CONNECTION_PRIORITY_HIGH` on Android) on both transports, but we have no visibility into what Android actually agreed to, or whether it changes mid-session under radio contention.
- **State annotation on controller errors** — appends `(state=Connecting/Connected/Closing/...)` to the existing `!!! CONTROLLER ERROR: %1 !!!` warning on both transports, so we can tell whether `AuthorizationError` fires while we're nominally Connected vs. while a teardown is already in progress.

No behavior change. Both files already include `QLowEnergyConnectionParameters`.

## Why now

Chasing the DE1 + Eureka Precisa wedge on Android 9 / P80X tablet (#1087, #1091, #1093). The build-3359 log proved the gate from #1092 works and the failure is a single-write GATT stall — not queue overflow — so the next thing to triangulate is whether dual `CONNECTION_PRIORITY_HIGH` is even being granted, or whether one link silently runs at a different interval. PR #1094's diagnostic logging covers scale-side traffic volume but not the negotiated link parameters; this fills that gap.

## Test plan

- [ ] Build for Android, smoke-test that DE1 connect logs a `connectionUpdated:` line and an existing controller error path still logs (induce by toggling BT during connect)
- [ ] Build for desktop (macOS) — verify no compile warnings; QLowEnergyController::connectionUpdated exists on all platforms but is mostly Android-meaningful
- [ ] Confirm log lines appear in `Settings > History and Data > debug log` after a DE1 + scale connect cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)