### PR TITLE
fix(ble): skip CONNECTION_PRIORITY_HIGH on scale on Android < 11

### DIFF
--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -6,6 +6,10 @@
 #include <QTimer>
 #include <QLowEnergyConnectionParameters>
 
+#ifdef Q_OS_ANDROID
+#include <QJniObject>
+#endif
+
 // Helper macro for consistent logging
 #define QT_TRANSPORT_LOG(msg) log(msg)
 
@@ -258,10 +262,39 @@ void QtScaleBleTransport::onControllerConnected() {
     QT_TRANSPORT_LOG("Controller connected!");
     m_connected = true;
 
-    // Request CONNECTION_PRIORITY_HIGH — see bletransport.cpp for details.
+    // Request CONNECTION_PRIORITY_HIGH on the scale link (7.5-15ms intervals)
+    // — see bletransport.cpp for the general rationale. The DE1 always asks
+    // for HIGH unconditionally; the scale only asks on Android 11+.
+    //
+    // On older Android (< 11) with weaker BT chipsets — notably the Decent
+    // P80X tablet (Android 9) — running both DE1 and a notify-heavy scale
+    // simultaneously at HIGH priority appears to starve DE1 GATT writes
+    // (single-write CharacteristicWriteError → AuthorizationError disconnect,
+    // #1087/#1091/#1093). Falling the scale back to BALANCED (~30-50ms) costs
+    // a bit of weight-update latency but avoids the radio contention. Newer
+    // Android stacks handle dual-HIGH cleanly so we keep the low-latency
+    // behaviour for users on capable hardware.
     if (m_controller) {
+#ifdef Q_OS_ANDROID
+        const jint sdkInt = QJniObject::getStaticField<jint>(
+            "android/os/Build$VERSION", "SDK_INT");
+        constexpr jint kMinSdkForScaleHighPriority = 30;  // Android 11
+        if (sdkInt < kMinSdkForScaleHighPriority) {
+            QT_TRANSPORT_LOG(QString(
+                "Skipping CONNECTION_PRIORITY_HIGH on scale "
+                "(Android SDK %1 < %2) — see #1093")
+                .arg(sdkInt).arg(kMinSdkForScaleHighPriority));
+        } else {
+            QT_TRANSPORT_LOG(QString(
+                "Requesting CONNECTION_PRIORITY_HIGH on scale (Android SDK %1)")
+                .arg(sdkInt));
+            QLowEnergyConnectionParameters params;
+            m_controller->requestConnectionUpdate(params);
+        }
+#else
         QLowEnergyConnectionParameters params;
         m_controller->requestConnectionUpdate(params);
+#endif
     }
 
     emit connected();


### PR DESCRIPTION
## Summary

Targeted experiment for the DE1 + Eureka Precisa wedge on Decent P80X tablets (#1087, #1091, #1093). The build-3359 / 3363 debug logs proved the gate from #1092 works and the failure mode is a **single-write GATT stall** — not queue overflow.

Hypothesis: on weaker BT chipsets (notably Android 9 / P80X), running both the DE1 and a notify-heavy scale at `CONNECTION_PRIORITY_HIGH` saturates the radio scheduler and starves DE1 GATT writes (`CharacteristicWriteError` on `0xa00f`/`0xa010` → `AuthorizationError` disconnect a few seconds later).

This PR is the cheapest test of that hypothesis without changing behaviour for users on modern hardware:

- **DE1 transport**: unchanged — still requests `CONNECTION_PRIORITY_HIGH` on every connect. Tight profile-upload write loops benefit from low latency.
- **Scale transport on Android 11+ (SDK ≥ 30)**: unchanged — still requests `CONNECTION_PRIORITY_HIGH`. Modern Android stacks handle dual-HIGH fine and the user benefits from snappier weight updates.
- **Scale transport on Android < 11 (SDK < 30)**: **skip** the `requestConnectionUpdate` call. Android falls back to its default BALANCED priority (~30–50 ms intervals). Loses a little weight-update latency in exchange for not double-saturating the radio.

The decision is logged at scale-connect time either way:

```
[BLE QtTransport] Requesting CONNECTION_PRIORITY_HIGH on scale (Android SDK 36)
```

or

```
[BLE QtTransport] Skipping CONNECTION_PRIORITY_HIGH on scale (Android SDK 28 < 30) — see #1093
```

So the next debug log will tell us which branch the device took.

## What "we'll know if this fixed it" looks like

- mcastaldelli's P80X (SDK 28) hits the skip branch.
- DE1 + Precisa connect, scale traffic flows.
- DE1 GATT writes (`0000a00f`, `0000a010`) succeed instead of cascading into `CharacteristicWriteError` retries and `AuthorizationError`.
- Profile changes flash purple again with the scale connected.

If the wedge persists with this branch active, dual-HIGH wasn't the cause and we move on to JNI-level instrumentation of the Android `BluetoothGatt` callback layer.

## Why SDK 30 / Android 11 as the threshold

It's a coarse cut, not a sharp one — the actual variable is BT chipset / firmware quality. Android 11+ correlates well enough with "device is recent enough that the BT stack can handle dual-HIGH"; pre-11 catches the older Pie tablets where this regression has been reported. We can adjust the threshold if reports come in from intermediate-version devices.

## Test plan

- [ ] Build for Android, smoke-test on Jeff's Tab A9+ (SDK 36) — verify log says "Requesting CONNECTION_PRIORITY_HIGH on scale (Android SDK 36)" and behaviour is unchanged.
- [ ] Build for Android, ship to mcastaldelli's P80X (SDK 28) — verify log says "Skipping CONNECTION_PRIORITY_HIGH on scale (Android SDK 28 < 30)" and DE1 + Precisa stay usable concurrently.
- [ ] Desktop / iOS build — preprocessor block compiles cleanly with `Q_OS_ANDROID` undefined; behaviour identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)