### PR TITLE
ci(windows): migrate to VS2026 runner (setup-msvc-dev@v4 + vs/18 redist)

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -64,7 +64,7 @@ jobs:
           cache-key-prefix: 'qt-windows-v2'
 
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
           arch: x64
 
@@ -141,7 +141,7 @@ jobs:
         shell: powershell
         run: |
           New-Item -ItemType Directory -Force -Path vcredist
-          Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "vcredist\vc_redist.x64.exe"
+          Invoke-WebRequest -Uri "https://aka.ms/vs/18/release/vc_redist.x64.exe" -OutFile "vcredist\vc_redist.x64.exe"
 
       - name: Install Inno Setup
         shell: powershell

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -80,7 +80,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           variant: sccache
-          key: sccache-windows-x64-qt6.10.3
+          key: sccache-windows-x64-qt6.10.3-vs2026
           max-size: 500M
 
       - name: Locate OpenSSL 3


### PR DESCRIPTION
## Summary

- Replace unmaintained `ilammy/msvc-dev-cmd@v1` with `TheMrMilchmann/setup-msvc-dev@v4` (Node 24 compatible)
- Update VC++ redistributable download URL from `vs/17` (VS2022) to `vs/18` (VS2026)
- Ahead of the `windows-latest` → `windows-2025-vs2026` redirect on May 12, 2026

Qt `win64_msvc2022_64` binaries remain unchanged — VS2026 preserves ABI compatibility with VS2022, so no users are affected. The VS2026 runtime still uses `VCRUNTIME140.dll` and runs on Windows 10+.

## Test plan

- [ ] Trigger a manual Windows build (`workflow_dispatch`) and verify the installer builds successfully
- [ ] Confirm the VC++ redist downloads from the `vs/18` URL without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)