### PR TITLE
chore(ble): drop noisy per-write logs and Android-dead connectionUpdated

### DIFF
--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -609,16 +609,6 @@ bool BleTransport::setupController(const QBluetoothDeviceInfo& device) {
             this, &BleTransport::onControllerDisconnected, qc);
     connect(m_controller, &QLowEnergyController::errorOccurred,
             this, &BleTransport::onControllerError, qc);
-    // Log the connection parameters Android actually grants us (vs what we
-    // requested via requestConnectionUpdate). This fires at least once shortly
-    // after connect, and again any time the link parameters change. Lets us
-    // see the real negotiated interval/latency/timeout for diagnosing radio
-    // contention when the DE1 + a scale share the same Android BT pipeline.
-    connect(m_controller, &QLowEnergyController::connectionUpdated, this,
-            [this](const QLowEnergyConnectionParameters& p) {
-        this->log(QString("connectionUpdated: interval=%1ms latency=%2 supervisionTimeout=%3ms")
-            .arg(p.minimumInterval()).arg(p.latency()).arg(p.supervisionTimeout()));
-    }, qc);
     connect(m_controller, &QLowEnergyController::serviceDiscovered,
             this, &BleTransport::onServiceDiscovered, qc);
     connect(m_controller, &QLowEnergyController::discoveryFinished,
@@ -683,9 +673,6 @@ void BleTransport::writeCharacteristic(const QBluetoothUuid& uuid, const QByteAr
     m_lastWriteUuid = uuidShort;
     m_lastWriteData = data;
     m_writeTimeoutTimer.start();
-    // Log every submission so we can correlate DE1 write failures with surrounding scale BLE
-    // activity (scale CCCD writes, scale notify bursts) on the same Android GATT pipeline.
-    log(QString("write submit %1 (%2 bytes)").arg(uuidShort).arg(data.size()));
     m_service->writeCharacteristic(m_characteristics[uuid], data);
 }
 

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -89,14 +89,6 @@ void QtScaleBleTransport::connectToDevice(const QBluetoothDeviceInfo& device) {
             this, &QtScaleBleTransport::onControllerDisconnected, qc);
     connect(m_controller, &QLowEnergyController::errorOccurred,
             this, &QtScaleBleTransport::onControllerError, qc);
-    // Log negotiated connection parameters (see bletransport.cpp for rationale).
-    // We need to compare scale + DE1 against each other on the same Android BT
-    // pipeline, so log on both transports.
-    connect(m_controller, &QLowEnergyController::connectionUpdated, this,
-            [this](const QLowEnergyConnectionParameters& p) {
-        this->log(QString("connectionUpdated: interval=%1ms latency=%2 supervisionTimeout=%3ms")
-            .arg(p.minimumInterval()).arg(p.latency()).arg(p.supervisionTimeout()));
-    }, qc);
     connect(m_controller, &QLowEnergyController::serviceDiscovered,
             this, &QtScaleBleTransport::onServiceDiscovered, qc);
     connect(m_controller, &QLowEnergyController::discoveryFinished,
@@ -229,11 +221,6 @@ void QtScaleBleTransport::writeCharacteristic(const QBluetoothUuid& serviceUuid,
         ? QLowEnergyService::WriteWithoutResponse
         : QLowEnergyService::WriteWithResponse;
 
-    // Log every write so we can correlate scale BLE activity with DE1 write failures.
-    QT_TRANSPORT_LOG(QString("write %1 (%2 bytes, %3)")
-        .arg(characteristicUuid.toString().mid(1, 8))
-        .arg(data.size())
-        .arg(writeType == WriteType::WithoutResponse ? "WithoutResponse" : "WithResponse"));
     service->writeCharacteristic(characteristic, data, mode);
 }
 


### PR DESCRIPTION
## Summary

After the #1093 dual-HIGH root cause was confirmed and fixed by #1097, two pieces of diagnostic logging are no longer earning their volume. Removing them while keeping every diagnostic that has ongoing operational value.

## What's removed

- **Per-write submission logs on both transports** (added in #1094):
  - `[BLE QtTransport] write <uuid> (N bytes, WithResponse/WithoutResponse)`
  - `[BLE DE1] write submit <uuid> (N bytes)`

  These were added to correlate scale BLE activity with DE1 write failures. That correlation question is solved. In steady state with a Decent Scale connected, the scale-side per-write log alone accounted for **~78% of all log lines** (one line per ~1 s heartbeat). The DE1 side is bursty rather than continuous but adds another layer of noise during shots. If a similar issue recurs, we can reintroduce both via a temporary PR.

- **`connectionUpdated` lambda subscriptions on both transports** (added in #1096) — verified across the 3363 + 3364 sessions to fire **zero times**. Qt's Android BLE backend only emits this signal for peripheral-initiated parameter updates, not central-initiated ones (which is what `requestConnectionUpdate` issues). Pure dead code on Android, which is the platform that matters here.

## What stays

Every diagnostic that is rare-enough-to-not-be-spam **and** still useful for future bug reports:

| Log line | Source | Why kept |
|----------|--------|----------|
| `Skipping/Requesting CONNECTION_PRIORITY_HIGH on scale (Android SDK ...)` | #1097 | once per connect; proves which gate branch fired |
| `!!! CONTROLLER ERROR: <name> (state=<state>) !!!` | #1096 | only on errors; state context is always useful |
| `ProfileManager: uploadCurrentProfile deferred — upload in flight` | #1092 | only during rapid profile changes; proves the gate works |
| `[BLE QtTransport] notify rate: N in last Xms` | #1094 | 5 s summary; cheap, lets us spot-check scale traffic |
| `[BLE QtTransport] write CCCD enable <uuid>` | #1094 | once per CCCD enable; watchdog for double-enables |

## Test plan

- [ ] Compiles cleanly on Android (both `QLowEnergyConnectionParameters` includes still needed by the `requestConnectionUpdate` calls)
- [ ] Compiles cleanly on macOS / iOS (no platform-specific code added or removed)
- [ ] Smoke-test on Tab A9+: connect DE1 + Decent Scale, verify the heartbeat per-write spam is gone and notify-rate summary still appears every 5 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)