### PR TITLE
fix(beans): preserve preset selection when clicking a favorite

### DIFF
--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -1072,7 +1072,7 @@ Page {
             inputMask: parent.inputMask
             EnterKey.type: Qt.EnterKeyNext
             Keys.onReturnPressed: nextItemInFocusChain().forceActiveFocus()
-            onTextChanged: parent.textEdited(text)
+            onTextEdited: parent.textEdited(text)
             onActiveFocusChanged: {
                 if (activeFocus) {
                     focusedField = fieldInput


### PR DESCRIPTION
## Summary
- In the Bean Info page, clicking a preset in the favorites list loaded the field values but immediately cleared the selection so the row didn't stay highlighted and `Settings.dye.selectedBeanPreset` reverted to `-1`.
- Root cause: `LabeledField` forwarded `onTextChanged` to its `textEdited` signal. `onTextChanged` fires for binding-driven updates too, so when `applyBeanPreset()` populated the DYE fields the bindings re-fired the field's `textEdited` handlers, which call `deselectPresetOnEdit()`.
- Fix: forward via `onTextEdited` (TextField's built-in user-input-only signal) instead.

## Test plan
- [ ] Open Bean Info, click a preset in the favorites list — values populate **and** the row stays highlighted.
- [ ] Edit any field by typing — the preset deselects as before.
- [ ] Reorder/rename/delete presets still work normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)