### PR TITLE
fix(update): retry download until GitHub returns Content-Length (#1089)

### DIFF
--- a/src/core/settings_app.cpp
+++ b/src/core/settings_app.cpp
@@ -395,7 +395,9 @@ qint64 SettingsApp::lastKnownApkSizeBytes() const {
 }
 
 void SettingsApp::setLastKnownApkSizeBytes(qint64 size) {
+    if (lastKnownApkSizeBytes() == size) return;
     m_settings.setValue("updates/lastKnownApkSizeBytes", size);
+    emit lastKnownApkSizeBytesChanged();
 }
 
 bool SettingsApp::firmwareNightlyChannel() const {

--- a/src/core/settings_app.cpp
+++ b/src/core/settings_app.cpp
@@ -390,6 +390,14 @@ void SettingsApp::setBetaUpdatesEnabled(bool enabled) {
     }
 }
 
+qint64 SettingsApp::lastKnownApkSizeBytes() const {
+    return m_settings.value("updates/lastKnownApkSizeBytes", 0).toLongLong();
+}
+
+void SettingsApp::setLastKnownApkSizeBytes(qint64 size) {
+    m_settings.setValue("updates/lastKnownApkSizeBytes", size);
+}
+
 bool SettingsApp::firmwareNightlyChannel() const {
     return m_settings.value("firmware/nightlyChannel", false).toBool();
 }

--- a/src/core/settings_app.h
+++ b/src/core/settings_app.h
@@ -34,6 +34,7 @@ class SettingsApp : public QObject {
     // Auto-update
     Q_PROPERTY(bool autoCheckUpdates READ autoCheckUpdates WRITE setAutoCheckUpdates NOTIFY autoCheckUpdatesChanged)
     Q_PROPERTY(bool betaUpdatesEnabled READ betaUpdatesEnabled WRITE setBetaUpdatesEnabled NOTIFY betaUpdatesEnabledChanged)
+    Q_PROPERTY(qint64 lastKnownApkSizeBytes READ lastKnownApkSizeBytes WRITE setLastKnownApkSizeBytes NOTIFY lastKnownApkSizeBytesChanged)
 
     // DE1 firmware update channel. When false (default), firmware comes
     // from fast.decentespresso.com/download/sync/de1plus; when true,
@@ -152,6 +153,7 @@ signals:
     void currentProfileChanged();
     void autoCheckUpdatesChanged();
     void betaUpdatesEnabledChanged();
+    void lastKnownApkSizeBytesChanged();
     void firmwareNightlyChannelChanged();
     void dailyBackupHourChanged();
     void waterLevelDisplayUnitChanged();

--- a/src/core/settings_app.h
+++ b/src/core/settings_app.h
@@ -109,6 +109,8 @@ public:
     void setBetaUpdatesEnabled(bool enabled);
     bool firmwareNightlyChannel() const;
     void setFirmwareNightlyChannel(bool enabled);
+    qint64 lastKnownApkSizeBytes() const;
+    void setLastKnownApkSizeBytes(qint64 size);
 
     // Daily backup
     int dailyBackupHour() const;

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -586,8 +586,14 @@ void UpdateChecker::startDownload()
 
 void UpdateChecker::onDownloadProgress(qint64 received, qint64 total)
 {
-    if (total > 0) {
-        m_downloadProgress = static_cast<int>((received * 100) / total);
+    qint64 effectiveTotal = total;
+    if (effectiveTotal > 0) {
+        m_settings->app()->setLastKnownApkSizeBytes(effectiveTotal);
+    } else {
+        effectiveTotal = m_settings->app()->lastKnownApkSizeBytes();
+    }
+    if (effectiveTotal > 0) {
+        m_downloadProgress = static_cast<int>((received * 100) / effectiveTotal);
         emit downloadProgressChanged();
     }
 }

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -461,6 +461,8 @@ void UpdateChecker::downloadAndInstall()
 
     m_downloading = true;
     m_downloadProgress = 0;
+    m_contentLengthRetries = 0;
+    m_contentLengthConfirmed = false;
     m_errorMessage.clear();
     emit downloadingChanged();
     emit downloadProgressChanged();
@@ -471,6 +473,10 @@ void UpdateChecker::downloadAndInstall()
 
 void UpdateChecker::startDownload()
 {
+    // Guard: dismissUpdate() clears m_downloading; if the retry timer fires
+    // after dismiss we must not start a new download.
+    if (!m_downloading) return;
+
     // Prepare download path
     QString savePath;
 #ifdef Q_OS_ANDROID
@@ -523,15 +529,45 @@ void UpdateChecker::startDownload()
     m_currentReply = m_network->get(request);
     connect(m_currentReply, &QNetworkReply::downloadProgress, this, &UpdateChecker::onDownloadProgress);
     connect(m_currentReply, &QNetworkReply::readyRead, this, [this]() {
-        if (m_downloadFile && m_currentReply) {
-            QByteArray chunk = m_currentReply->readAll();
-            if (m_downloadFile->write(chunk) != chunk.size()) {
-                qWarning() << "UpdateChecker: Write failed during download:" << m_downloadFile->errorString();
-                // Set the real error before aborting — abort() triggers onDownloadFinished
-                // with OperationCanceledError, which would show a misleading message
-                m_errorMessage = "Download failed: could not write file (" + m_downloadFile->errorString() + ")";
+        if (!m_currentReply || !m_downloadFile) return;
+
+        // On the first chunk of every attempt, verify GitHub returned Content-Length
+        // so the progress bar works. If not, abort and retry — GitHub's CDN sometimes
+        // omits it but will include it on a subsequent connection. After kMaxRetries
+        // attempts we give up and proceed without progress tracking.
+        if (!m_contentLengthConfirmed) {
+            constexpr int kMaxRetries = 10;
+            const qint64 contentLength =
+                m_currentReply->header(QNetworkRequest::ContentLengthHeader).toLongLong();
+            if (contentLength <= 0 && m_contentLengthRetries < kMaxRetries) {
+                m_contentLengthRetries++;
+                qDebug() << "UpdateChecker: no Content-Length on attempt" << m_contentLengthRetries
+                         << "/" << kMaxRetries << "- retrying in 2s";
+                disconnect(m_currentReply, &QNetworkReply::finished,
+                           this, &UpdateChecker::onDownloadFinished);
                 m_currentReply->abort();
+                m_currentReply->deleteLater();
+                m_currentReply = nullptr;
+                m_downloadFile->close();
+                delete m_downloadFile;
+                m_downloadFile = nullptr;
+                QTimer::singleShot(2000, this, &UpdateChecker::startDownload);
+                return;
             }
+            if (contentLength <= 0) {
+                qDebug() << "UpdateChecker: no Content-Length after" << kMaxRetries
+                         << "retries, proceeding without progress tracking";
+            }
+            m_contentLengthConfirmed = true;
+        }
+
+        QByteArray chunk = m_currentReply->readAll();
+        if (m_downloadFile->write(chunk) != chunk.size()) {
+            qWarning() << "UpdateChecker: Write failed during download:" << m_downloadFile->errorString();
+            // Set the real error before aborting — abort() triggers onDownloadFinished
+            // with OperationCanceledError, which would show a misleading message
+            m_errorMessage = "Download failed: could not write file (" + m_downloadFile->errorString() + ")";
+            m_currentReply->abort();
         }
     });
     // Log transport errors as soon as they happen so we can distinguish a
@@ -626,7 +662,10 @@ void UpdateChecker::onDownloadFinished()
         // Preserve specific error set by readyRead write failure (otherwise
         // abort() produces a generic "Operation canceled" message)
         if (m_errorMessage.isEmpty()) {
-            m_errorMessage = "Download failed: " + m_currentReply->errorString();
+            const bool isTimeout = (m_currentReply->error() == QNetworkReply::TimeoutError);
+            m_errorMessage = isTimeout
+                ? "Download timed out — check your network connection and tap Download & Install to try again."
+                : "Download failed: " + m_currentReply->errorString();
         }
         emit errorMessageChanged();
         {
@@ -740,32 +779,37 @@ void UpdateChecker::dismissUpdate()
     // this, the QNetworkReply continues, onDownloadFinished() fires, and the
     // system install dialog appears despite the user explicitly dismissing.
     // Disconnect finished() first so the slot does not run during abort().
-    if (m_downloading && m_currentReply) {
-        QString partialPath;
-        if (m_downloadFile) partialPath = m_downloadFile->fileName();
-        disconnect(m_currentReply, &QNetworkReply::finished, this, &UpdateChecker::onDownloadFinished);
-        m_currentReply->abort();
-        m_currentReply->deleteLater();
-        m_currentReply = nullptr;
-        if (m_downloadFile) {
-            m_downloadFile->close();
-            delete m_downloadFile;
-            m_downloadFile = nullptr;
+    // Note: m_currentReply may be null while a Content-Length retry timer is
+    // pending — we must still clear m_downloading so the startDownload() guard
+    // stops the timer callback from launching a new request after dismiss.
+    if (m_downloading) {
+        if (m_currentReply) {
+            QString partialPath;
+            if (m_downloadFile) partialPath = m_downloadFile->fileName();
+            disconnect(m_currentReply, &QNetworkReply::finished, this, &UpdateChecker::onDownloadFinished);
+            m_currentReply->abort();
+            m_currentReply->deleteLater();
+            m_currentReply = nullptr;
+            if (m_downloadFile) {
+                m_downloadFile->close();
+                delete m_downloadFile;
+                m_downloadFile = nullptr;
+            }
+            if (!partialPath.isEmpty()) {
+                // Generation guard: if a new startDownload() (programmatic or via a
+                // subsequent user action) reuses the same filename before this thread
+                // runs, we must not delete the new download's freshly-opened file.
+                const int capturedGen = s_downloadGeneration.loadAcquire();
+                QThread* t = QThread::create([partialPath, capturedGen]() {
+                    if (s_downloadGeneration.loadAcquire() == capturedGen)
+                        QFile::remove(partialPath);
+                });
+                connect(t, &QThread::finished, t, &QThread::deleteLater);
+                t->start();
+            }
         }
         m_downloading = false;
         emit downloadingChanged();
-        if (!partialPath.isEmpty()) {
-            // Generation guard: if a new startDownload() (programmatic or via a
-            // subsequent user action) reuses the same filename before this thread
-            // runs, we must not delete the new download's freshly-opened file.
-            const int capturedGen = s_downloadGeneration.loadAcquire();
-            QThread* t = QThread::create([partialPath, capturedGen]() {
-                if (s_downloadGeneration.loadAcquire() == capturedGen)
-                    QFile::remove(partialPath);
-            });
-            connect(t, &QThread::finished, t, &QThread::deleteLater);
-            t->start();
-        }
     }
 
     // Dismiss is an explicit user action: clean up the cached APK unconditionally.

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -4,6 +4,8 @@
 #include "settings_app.h"
 #include "version.h"
 
+#include <algorithm>
+
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -593,7 +595,7 @@ void UpdateChecker::onDownloadProgress(qint64 received, qint64 total)
         effectiveTotal = m_settings->app()->lastKnownApkSizeBytes();
     }
     if (effectiveTotal > 0) {
-        m_downloadProgress = static_cast<int>((received * 100) / effectiveTotal);
+        m_downloadProgress = std::clamp(static_cast<int>((received * 100) / effectiveTotal), 0, 100);
         emit downloadProgressChanged();
     }
 }
@@ -786,9 +788,10 @@ void UpdateChecker::dismissUpdate()
     // this, the QNetworkReply continues, onDownloadFinished() fires, and the
     // system install dialog appears despite the user explicitly dismissing.
     // Disconnect finished() first so the slot does not run during abort().
-    // Note: m_currentReply may be null while a Content-Length retry timer is
-    // pending — we must still clear m_downloading so the startDownload() guard
-    // stops the timer callback from launching a new request after dismiss.
+    // Note: m_currentReply may be null while a queued startDownload() invocation
+    // is pending (via QMetaObject::invokeMethod QueuedConnection) — we must still
+    // clear m_downloading so the startDownload() guard stops the queued callback
+    // from launching a new request after dismiss.
     if (m_downloading) {
         if (m_currentReply) {
             QString partialPath;

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -542,16 +542,17 @@ void UpdateChecker::startDownload()
             if (contentLength <= 0 && m_contentLengthRetries < kMaxRetries) {
                 m_contentLengthRetries++;
                 qDebug() << "UpdateChecker: no Content-Length on attempt" << m_contentLengthRetries
-                         << "/" << kMaxRetries << "- retrying in 2s";
+                         << "/" << kMaxRetries << "- retrying";
                 disconnect(m_currentReply, &QNetworkReply::finished,
                            this, &UpdateChecker::onDownloadFinished);
+                disconnect(m_currentReply, &QNetworkReply::errorOccurred, this, nullptr);
                 m_currentReply->abort();
                 m_currentReply->deleteLater();
                 m_currentReply = nullptr;
                 m_downloadFile->close();
                 delete m_downloadFile;
                 m_downloadFile = nullptr;
-                QTimer::singleShot(2000, this, &UpdateChecker::startDownload);
+                QMetaObject::invokeMethod(this, &UpdateChecker::startDownload, Qt::QueuedConnection);
                 return;
             }
             if (contentLength <= 0) {

--- a/src/core/updatechecker.h
+++ b/src/core/updatechecker.h
@@ -121,6 +121,8 @@ private:
     QString m_downloadedApkPath;
     qint64 m_expectedDownloadSize = 0;
     bool m_installInFlight = false;  // True between installApk() dispatch and terminal PackageInstaller status
+    int m_contentLengthRetries = 0;  // Attempts so far waiting for a response with Content-Length
+    bool m_contentLengthConfirmed = false;  // True once a response with Content-Length has been seen
     // Generation counter lives at file scope in updatechecker.cpp so background
     // QFile::remove threads don't capture `this` (see s_downloadGeneration).
 


### PR DESCRIPTION
## Summary

- On the first `readyRead` of each download attempt, check whether GitHub returned a `Content-Length` header. If absent (chunked encoding, no size known), abort and retry after 2 s — up to 10 attempts. Once a response with `Content-Length` arrives the download proceeds with a working progress bar. After 10 failed attempts we fall through and download anyway so the user still gets the update.
- Fix `dismissUpdate()` to unconditionally clear `m_downloading` when downloading, not only when `m_currentReply != null`. During the 2-second inter-retry window `m_currentReply` is null, so the old code left the pending `startDownload()` timer live after the user tapped "Later".
- Add a `startDownload()` guard (`if (!m_downloading) return`) so any pending retry timer is a no-op after dismiss.
- Improve the timeout error message to say the issue is network-related and that the user can tap **Download & Install** to retry, rather than showing the opaque Qt `"Operation timed out"` string.

## Root cause (from debug logs on #1089)

GitHub's CDN omits `Content-Length` on some connections. `onDownloadProgress` only updates `m_downloadProgress` when `total > 0`, so the bar was frozen at 0% for the entire transfer even while bytes were flowing. The user couldn't distinguish a genuine stall from a normal download, and the 90 s inactivity timeout (added in the previous beta) was the only thing that eventually produced an error — but with a useless message.

## Test plan

- [ ] Accept an update prompt on Android — progress bar should reach 100% (or cycle through retries visibly in logs until a Content-Length response is found)
- [ ] Tap "Later" on the update prompt while a Content-Length retry is pending — download should stop, no ghost download starts after 2 s
- [ ] Let a download time out (e.g. airplane mode mid-download) — error should read "Download timed out — check your network connection and tap Download & Install to try again."
- [ ] Tap **Download & Install** after a timeout — should restart cleanly without needing an app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)