### PR TITLE
feat (profile) Add save-a-copy feature for profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ screenshot.png
 logcat_*.txt
 -.zip
 .claude/*
+
+# Local how-to docs
+.howto.md
 !.claude/skills/
 !.claude/agents/
 !.claude/commands/

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -477,6 +477,45 @@ Page {
                                 Accessible.name: TranslationManager.translate("profileselector.accessible.edit_profile", "Edit profile")
                             }
 
+                            MenuItem {
+                                onTriggered: {
+                                    copyProfileDialog.sourceFilename = modelData.name
+                                    copyProfileDialog.sourceTitle = modelData.title
+                                    copyProfileDialog.open()
+                                }
+
+                                contentItem: Row {
+                                    spacing: Theme.scaled(8)
+                                    leftPadding: Theme.scaled(8)
+                                    Image {
+                                        source: "qrc:/icons/plus.svg"
+                                        sourceSize.width: Theme.scaled(16)
+                                        sourceSize.height: Theme.scaled(16)
+                                        anchors.verticalCenter: parent.verticalCenter
+
+                                        layer.enabled: true
+                                        layer.smooth: true
+                                        layer.effect: MultiEffect {
+                                            colorization: 1.0
+                                            colorizationColor: Theme.textColor
+                                        }
+                                    }
+                                    Text {
+                                        text: TranslationManager.translate("profileselector.menu.copy", "Copy Profile")
+                                        color: Theme.textColor
+                                        font: Theme.bodyFont
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        Accessible.ignored: true
+                                    }
+                                }
+                                background: Rectangle {
+                                    color: parent.highlighted ? Qt.rgba(Theme.primaryColor.r, Theme.primaryColor.g, Theme.primaryColor.b, 0.2) : "transparent"
+                                }
+
+                                Accessible.role: Accessible.MenuItem
+                                Accessible.name: TranslationManager.translate("profileselector.accessible.copy_profile", "Copy profile")
+                            }
+
                             MenuSeparator {
                                 visible: viewFilter.currentIndex === 0 || !profileDelegate.isBuiltIn
                                 contentItem: Rectangle {
@@ -1114,6 +1153,128 @@ Page {
             radius: Theme.scaled(8)
             border.color: Theme.borderColor
         }
+    }
+
+    // Copy Profile Dialog
+    Dialog {
+        id: copyProfileDialog
+        anchors.centerIn: parent
+        width: Theme.scaled(400)
+        padding: 0
+        modal: true
+
+        property string sourceFilename: ""
+        property string sourceTitle: ""
+
+        onAboutToShow: {
+            copyProfileNameField.text = sourceTitle + " " + TranslationManager.translate("profileselector.copy.suffix", "Copy")
+            copyProfileNameField.forceActiveFocus()
+            copyProfileNameField.selectAll()
+        }
+
+        header: Item {
+            implicitHeight: Theme.scaled(50)
+
+            Text {
+                anchors.left: parent.left
+                anchors.leftMargin: Theme.scaled(20)
+                anchors.verticalCenter: parent.verticalCenter
+                text: TranslationManager.translate("profileselector.copyProfile.title", "Copy Profile")
+                font: Theme.titleFont
+                color: Theme.textColor
+            }
+
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 1
+                color: Theme.borderColor
+            }
+        }
+
+        contentItem: ColumnLayout {
+            spacing: Theme.scaled(12)
+
+            Item { implicitHeight: Theme.scaled(8) }
+
+            Text {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.scaled(20)
+                Layout.rightMargin: Theme.scaled(20)
+                text: TranslationManager.translate("profileselector.copyProfile.label", "Enter a name for the copy:")
+                color: Theme.textColor
+                font: Theme.bodyFont
+                wrapMode: Text.Wrap
+            }
+
+            StyledTextField {
+                id: copyProfileNameField
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.scaled(20)
+                Layout.rightMargin: Theme.scaled(20)
+                Layout.preferredHeight: Theme.scaled(44)
+                placeholder: TranslationManager.translate("profileselector.copyProfile.placeholder", "Profile name")
+                font.pixelSize: Theme.scaled(16)
+
+                Keys.onReturnPressed: {
+                    Qt.inputMethod.commit()
+                    if (copyProfileNameField.text.trim() !== "") {
+                        copyProfileButton.clicked()
+                    }
+                }
+            }
+
+            Item { implicitHeight: Theme.scaled(8) }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.scaled(20)
+                Layout.rightMargin: Theme.scaled(20)
+                spacing: Theme.scaled(12)
+
+                Item { Layout.fillWidth: true }
+
+                AccessibleButton {
+                    text: TranslationManager.translate("common.button.cancel", "Cancel")
+                    accessibleName: TranslationManager.translate("common.accessibility.cancel", "Cancel")
+                    Layout.preferredHeight: Theme.scaled(40)
+                    onClicked: copyProfileDialog.close()
+                }
+
+                AccessibleButton {
+                    id: copyProfileButton
+                    text: TranslationManager.translate("profileselector.copyProfile.button", "Copy")
+                    accessibleName: TranslationManager.translate("profileselector.copyProfile.accessible", "Copy profile with new name")
+                    primary: true
+                    enabled: copyProfileNameField.text.trim() !== ""
+                    Layout.preferredHeight: Theme.scaled(40)
+                    onClicked: {
+                        Qt.inputMethod.commit()
+                        var newTitle = copyProfileNameField.text.trim()
+                        if (newTitle !== "") {
+                            if (ProfileManager.duplicateProfile(copyProfileDialog.sourceFilename, newTitle)) {
+                                profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.profile_copied", "Profile copied"))
+                                copyProfileDialog.close()
+                            } else {
+                                profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.copy_failed", "Failed to copy profile"))
+                            }
+                        }
+                    }
+                }
+            }
+
+            Item { implicitHeight: Theme.scaled(8) }
+        }
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.scaled(8)
+            border.color: Theme.borderColor
+        }
+
+        Accessible.role: Accessible.Dialog
+        Accessible.name: TranslationManager.translate("profileselector.copyProfile.title", "Copy Profile")
     }
 
     // Toast notification

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -1193,78 +1193,86 @@ Page {
             }
         }
 
-        contentItem: ColumnLayout {
-            spacing: Theme.scaled(12)
+        contentItem: KeyboardAwareContainer {
+            inOverlay: true
+            textFields: [copyProfileNameField]
+            implicitHeight: copyProfileColumn.implicitHeight
+            implicitWidth: copyProfileColumn.implicitWidth
 
-            Item { implicitHeight: Theme.scaled(8) }
-
-            Text {
-                Layout.fillWidth: true
-                Layout.leftMargin: Theme.scaled(20)
-                Layout.rightMargin: Theme.scaled(20)
-                text: TranslationManager.translate("profileselector.copyProfile.label", "Enter a name for the copy:")
-                color: Theme.textColor
-                font: Theme.bodyFont
-                wrapMode: Text.Wrap
-            }
-
-            StyledTextField {
-                id: copyProfileNameField
-                Layout.fillWidth: true
-                Layout.leftMargin: Theme.scaled(20)
-                Layout.rightMargin: Theme.scaled(20)
-                Layout.preferredHeight: Theme.scaled(44)
-                placeholder: TranslationManager.translate("profileselector.copyProfile.placeholder", "Profile name")
-                font.pixelSize: Theme.scaled(16)
-
-                Keys.onReturnPressed: {
-                    Qt.inputMethod.commit()
-                    if (copyProfileNameField.text.trim() !== "") {
-                        copyProfileButton.clicked()
-                    }
-                }
-            }
-
-            Item { implicitHeight: Theme.scaled(8) }
-
-            RowLayout {
-                Layout.fillWidth: true
-                Layout.leftMargin: Theme.scaled(20)
-                Layout.rightMargin: Theme.scaled(20)
+            ColumnLayout {
+                id: copyProfileColumn
+                anchors.fill: parent
                 spacing: Theme.scaled(12)
 
-                Item { Layout.fillWidth: true }
+                Item { implicitHeight: Theme.scaled(8) }
 
-                AccessibleButton {
-                    text: TranslationManager.translate("common.button.cancel", "Cancel")
-                    accessibleName: TranslationManager.translate("common.accessibility.cancel", "Cancel")
-                    Layout.preferredHeight: Theme.scaled(40)
-                    onClicked: copyProfileDialog.close()
+                Text {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.scaled(20)
+                    Layout.rightMargin: Theme.scaled(20)
+                    text: TranslationManager.translate("profileselector.copyProfile.label", "Enter a name for the copy:")
+                    color: Theme.textColor
+                    font: Theme.bodyFont
+                    wrapMode: Text.Wrap
                 }
 
-                AccessibleButton {
-                    id: copyProfileButton
-                    text: TranslationManager.translate("profileselector.copyProfile.button", "Copy")
-                    accessibleName: TranslationManager.translate("profileselector.copyProfile.accessible", "Copy profile with new name")
-                    primary: true
-                    enabled: copyProfileNameField.text.trim() !== ""
-                    Layout.preferredHeight: Theme.scaled(40)
-                    onClicked: {
+                StyledTextField {
+                    id: copyProfileNameField
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.scaled(20)
+                    Layout.rightMargin: Theme.scaled(20)
+                    Layout.preferredHeight: Theme.scaled(44)
+                    placeholder: TranslationManager.translate("profileselector.copyProfile.placeholder", "Profile name")
+
+                    Keys.onReturnPressed: {
                         Qt.inputMethod.commit()
-                        var newTitle = copyProfileNameField.text.trim()
-                        if (newTitle !== "") {
-                            if (ProfileManager.duplicateProfile(copyProfileDialog.sourceFilename, newTitle)) {
-                                profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.profile_copied", "Profile copied"))
-                                copyProfileDialog.close()
-                            } else {
-                                profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.copy_failed", "Failed to copy profile"))
+                        if (copyProfileNameField.displayText.trim() !== "") {
+                            copyProfileButton.clicked()
+                        }
+                    }
+                }
+
+                Item { implicitHeight: Theme.scaled(8) }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.scaled(20)
+                    Layout.rightMargin: Theme.scaled(20)
+                    spacing: Theme.scaled(12)
+
+                    Item { Layout.fillWidth: true }
+
+                    AccessibleButton {
+                        text: TranslationManager.translate("common.button.cancel", "Cancel")
+                        accessibleName: TranslationManager.translate("common.accessibility.cancel", "Cancel")
+                        Layout.preferredHeight: Theme.scaled(40)
+                        onClicked: copyProfileDialog.close()
+                    }
+
+                    AccessibleButton {
+                        id: copyProfileButton
+                        text: TranslationManager.translate("profileselector.copyProfile.button", "Copy")
+                        accessibleName: TranslationManager.translate("profileselector.copyProfile.accessible", "Copy profile with new name")
+                        primary: true
+                        enabled: copyProfileNameField.displayText.trim() !== ""
+                        Layout.preferredHeight: Theme.scaled(40)
+                        onClicked: {
+                            Qt.inputMethod.commit()
+                            var newTitle = copyProfileNameField.text.trim()
+                            if (newTitle !== "") {
+                                if (ProfileManager.duplicateProfile(copyProfileDialog.sourceFilename, newTitle)) {
+                                    profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.profile_copied", "Profile copied"))
+                                    copyProfileDialog.close()
+                                } else {
+                                    profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.copy_failed", "Failed to copy profile"))
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            Item { implicitHeight: Theme.scaled(8) }
+                Item { implicitHeight: Theme.scaled(8) }
+            }
         }
 
         background: Rectangle {

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -1777,6 +1777,112 @@ bool ProfileManager::saveProfileAs(const QString& filename, const QString& title
     return success;
 }
 
+bool ProfileManager::duplicateProfile(const QString& sourceFilename, const QString& newTitle) {
+    // Generate a unique filename from the title
+    QString newFilename = titleToFilename(newTitle);
+    
+    // Check if the new filename already exists
+    if (profileExists(newFilename)) {
+        qWarning() << "ProfileManager::duplicateProfile: Profile already exists:" << newFilename;
+        return false;
+    }
+
+    // Prevent duplicating with a built-in profile filename
+    if (isBuiltInFilename(newFilename)) {
+        qWarning() << "ProfileManager::duplicateProfile: Cannot use built-in profile filename:" << newFilename;
+        return false;
+    }
+
+    // Load the source profile JSON
+    QString jsonContent;
+    
+    // Try ProfileStorage first
+    if (m_profileStorage && m_profileStorage->isConfigured()) {
+        jsonContent = m_profileStorage->readProfile(sourceFilename);
+    }
+    
+    // If not found in ProfileStorage, try loading from file
+    if (jsonContent.isEmpty()) {
+        // Check built-in profiles
+        QString builtInPath = ":/profiles/" + sourceFilename + ".json";
+        QFile builtInFile(builtInPath);
+        if (builtInFile.open(QIODevice::ReadOnly)) {
+            jsonContent = QString::fromUtf8(builtInFile.readAll());
+            builtInFile.close();
+        }
+        
+        // Check downloaded profiles
+        if (jsonContent.isEmpty()) {
+            QString downloadedPath = downloadedProfilesPath() + "/" + sourceFilename + ".json";
+            QFile downloadedFile(downloadedPath);
+            if (downloadedFile.open(QIODevice::ReadOnly)) {
+                jsonContent = QString::fromUtf8(downloadedFile.readAll());
+                downloadedFile.close();
+            }
+        }
+        
+        // Check user profiles
+        if (jsonContent.isEmpty()) {
+            QString userPath = userProfilesPath() + "/" + sourceFilename + ".json";
+            QFile userFile(userPath);
+            if (userFile.open(QIODevice::ReadOnly)) {
+                jsonContent = QString::fromUtf8(userFile.readAll());
+                userFile.close();
+            }
+        }
+    }
+    
+    if (jsonContent.isEmpty()) {
+        qWarning() << "ProfileManager::duplicateProfile: Could not load source profile:" << sourceFilename;
+        return false;
+    }
+
+    // Parse the profile JSON
+    Profile duplicatedProfile = Profile::loadFromJsonString(jsonContent);
+    if (duplicatedProfile.title().isEmpty()) {
+        qWarning() << "ProfileManager::duplicateProfile: Failed to parse source profile JSON";
+        return false;
+    }
+
+    // Update the title and clear read-only flag
+    duplicatedProfile.setTitle(newTitle);
+    duplicatedProfile.setReadOnly(0);
+
+    // Save the duplicated profile
+    bool success = false;
+    
+    // Try ProfileStorage first (SAF on Android)
+    if (m_profileStorage && m_profileStorage->isConfigured()) {
+        success = m_profileStorage->writeProfile(newFilename, duplicatedProfile.toJsonString());
+        if (success) {
+            qDebug() << "Duplicated profile to ProfileStorage:" << newFilename;
+        }
+    }
+
+    if (!success) {
+        // Fall back to local file
+        QString path = userProfilesPath() + "/" + newFilename + ".json";
+        success = duplicatedProfile.saveToFile(path);
+        if (success) {
+            qDebug() << "Duplicated profile to local file:" << path;
+        } else {
+            qWarning() << "Failed to save duplicated profile to:" << path;
+        }
+    }
+
+    if (success) {
+        // Add to favorites
+        if (m_settings) {
+            m_settings->app()->addFavoriteProfile(newTitle, newFilename);
+        }
+        
+        // Refresh the profile list to show the new profile
+        refreshProfiles();
+    }
+    
+    return success;
+}
+
 
 // === Profile editing (recipe/frame) ===
 

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -1780,10 +1780,11 @@ bool ProfileManager::saveProfileAs(const QString& filename, const QString& title
 bool ProfileManager::duplicateProfile(const QString& sourceFilename, const QString& newTitle) {
     // Generate a unique filename from the title
     QString newFilename = titleToFilename(newTitle);
-    
-    // Check if the new filename already exists
-    if (profileExists(newFilename)) {
-        qWarning() << "ProfileManager::duplicateProfile: Profile already exists:" << newFilename;
+
+    // titleToFilename strips everything but letters/digits/underscores; titles that are
+    // entirely non-Latin (CJK / Cyrillic / emoji / punctuation) reduce to an empty string.
+    if (newFilename.isEmpty()) {
+        qWarning() << "ProfileManager::duplicateProfile: title sanitises to empty filename:" << newTitle;
         return false;
     }
 
@@ -1793,56 +1794,79 @@ bool ProfileManager::duplicateProfile(const QString& sourceFilename, const QStri
         return false;
     }
 
-    // Load the source profile JSON
+    // Check if the new filename already exists in any of the locations we might write to.
+    // profileExists() only checks m_availableProfiles + profilesPath() root, so we also
+    // probe ProfileStorage and the user/downloaded folders to avoid silent overwrite when
+    // m_availableProfiles is stale.
+    auto collides = [this](const QString& fn) {
+        if (profileExists(fn))
+            return true;
+        if (m_profileStorage && m_profileStorage->isConfigured()
+            && !m_profileStorage->readProfile(fn).isEmpty())
+            return true;
+        if (QFile::exists(userProfilesPath() + "/" + fn + ".json"))
+            return true;
+        if (QFile::exists(downloadedProfilesPath() + "/" + fn + ".json"))
+            return true;
+        return false;
+    };
+    if (collides(newFilename)) {
+        qWarning() << "ProfileManager::duplicateProfile: Profile already exists:" << newFilename;
+        return false;
+    }
+
+    // Load the source profile JSON. Order mirrors loadProfile() so a user-edited copy
+    // of a built-in profile is preferred over the pristine resource.
     QString jsonContent;
-    
-    // Try ProfileStorage first
+
+    // 1. ProfileStorage (SAF on Android)
     if (m_profileStorage && m_profileStorage->isConfigured()) {
         jsonContent = m_profileStorage->readProfile(sourceFilename);
     }
-    
-    // If not found in ProfileStorage, try loading from file
+
+    // 2. User profiles (local fallback)
     if (jsonContent.isEmpty()) {
-        // Check built-in profiles
+        QString userPath = userProfilesPath() + "/" + sourceFilename + ".json";
+        QFile userFile(userPath);
+        if (userFile.open(QIODevice::ReadOnly)) {
+            jsonContent = QString::fromUtf8(userFile.readAll());
+        }
+    }
+
+    // 3. Downloaded profiles (local fallback)
+    if (jsonContent.isEmpty()) {
+        QString downloadedPath = downloadedProfilesPath() + "/" + sourceFilename + ".json";
+        QFile downloadedFile(downloadedPath);
+        if (downloadedFile.open(QIODevice::ReadOnly)) {
+            jsonContent = QString::fromUtf8(downloadedFile.readAll());
+        }
+    }
+
+    // 4. Built-in profiles
+    if (jsonContent.isEmpty()) {
         QString builtInPath = ":/profiles/" + sourceFilename + ".json";
         QFile builtInFile(builtInPath);
         if (builtInFile.open(QIODevice::ReadOnly)) {
             jsonContent = QString::fromUtf8(builtInFile.readAll());
-            builtInFile.close();
-        }
-        
-        // Check downloaded profiles
-        if (jsonContent.isEmpty()) {
-            QString downloadedPath = downloadedProfilesPath() + "/" + sourceFilename + ".json";
-            QFile downloadedFile(downloadedPath);
-            if (downloadedFile.open(QIODevice::ReadOnly)) {
-                jsonContent = QString::fromUtf8(downloadedFile.readAll());
-                downloadedFile.close();
-            }
-        }
-        
-        // Check user profiles
-        if (jsonContent.isEmpty()) {
-            QString userPath = userProfilesPath() + "/" + sourceFilename + ".json";
-            QFile userFile(userPath);
-            if (userFile.open(QIODevice::ReadOnly)) {
-                jsonContent = QString::fromUtf8(userFile.readAll());
-                userFile.close();
-            }
         }
     }
-    
+
     if (jsonContent.isEmpty()) {
         qWarning() << "ProfileManager::duplicateProfile: Could not load source profile:" << sourceFilename;
         return false;
     }
 
-    // Parse the profile JSON
-    Profile duplicatedProfile = Profile::loadFromJsonString(jsonContent);
-    if (duplicatedProfile.title().isEmpty()) {
-        qWarning() << "ProfileManager::duplicateProfile: Failed to parse source profile JSON";
+    // Verify the JSON is well-formed before handing it to Profile::loadFromJsonString,
+    // which returns a default-constructed Profile (title="Default") on parse failure —
+    // so a checking-the-title guard alone would silently save a near-empty profile.
+    QJsonParseError parseErr;
+    QJsonDocument doc = QJsonDocument::fromJson(jsonContent.toUtf8(), &parseErr);
+    if (parseErr.error != QJsonParseError::NoError || !doc.isObject()) {
+        qWarning() << "ProfileManager::duplicateProfile: source JSON is malformed:" << parseErr.errorString();
         return false;
     }
+
+    Profile duplicatedProfile = Profile::loadFromJsonString(jsonContent);
 
     // Update the title and clear read-only flag
     duplicatedProfile.setTitle(newTitle);

--- a/src/controllers/profilemanager.h
+++ b/src/controllers/profilemanager.h
@@ -168,6 +168,7 @@ public slots:
     Q_INVOKABLE void uploadProfile(const QVariantMap& profileData);
     Q_INVOKABLE bool saveProfile(const QString& filename);
     Q_INVOKABLE bool saveProfileAs(const QString& filename, const QString& title);
+    Q_INVOKABLE bool duplicateProfile(const QString& sourceFilename, const QString& newTitle);
 
     // Communication-failure dialog support.
     bool de1CommunicationFailure() const { return m_de1CommunicationFailure; }


### PR DESCRIPTION
Within the Profile section, click the 3 dot button. In addition to the "edit profile" button  now is a "copy profile" button. You can select a profile and save a copy under a different name.

<img width="1946" height="832" alt="Screenshot from 2026-05-07 23-12-27" src="https://github.com/user-attachments/assets/5de431ed-380e-4a24-94db-b20997b01523" />

</br></br>

<img width="1033" height="648" alt="Screenshot from 2026-05-07 23-16-31" src="https://github.com/user-attachments/assets/b46b5aca-c25f-469a-978a-eb4bae5a600c" />

