### PR TITLE
fix(profile): address copy-profile code review follow-up

### DIFF
--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -475,6 +475,8 @@ Page {
 
                                 Accessible.role: Accessible.MenuItem
                                 Accessible.name: TranslationManager.translate("profileselector.accessible.edit_profile", "Edit profile")
+                                Accessible.focusable: true
+                                Accessible.onPressAction: { ProfileManager.loadProfile(modelData.name); root.goToProfileEditor() }
                             }
 
                             MenuItem {
@@ -514,6 +516,8 @@ Page {
 
                                 Accessible.role: Accessible.MenuItem
                                 Accessible.name: TranslationManager.translate("profileselector.accessible.copy_profile", "Copy profile")
+                                Accessible.focusable: true
+                                Accessible.onPressAction: { copyProfileDialog.sourceFilename = modelData.name; copyProfileDialog.sourceTitle = modelData.title; copyProfileDialog.open() }
                             }
 
                             MenuSeparator {
@@ -564,6 +568,8 @@ Page {
 
                                 Accessible.role: Accessible.MenuItem
                                 Accessible.name: TranslationManager.translate("profileselector.accessible.remove_from_list", "Remove from selected list")
+                                Accessible.focusable: true
+                                Accessible.onPressAction: { if (profileDelegate.isBuiltIn) { Settings.app.removeSelectedBuiltInProfile(modelData.name) } else { Settings.app.addHiddenProfile(modelData.name) } }
                             }
 
                             MenuItem {
@@ -605,6 +611,8 @@ Page {
 
                                 Accessible.role: Accessible.MenuItem
                                 Accessible.name: TranslationManager.translate("profileselector.accessible.delete_permanently", "Delete profile permanently")
+                                Accessible.focusable: true
+                                Accessible.onPressAction: { deleteDialog.profileName = modelData.name; deleteDialog.profileTitle = modelData.title; deleteDialog.isFavorite = profileDelegate.isFavorite; deleteDialog.open() }
                             }
                         }
 
@@ -1155,7 +1163,7 @@ Page {
         }
     }
 
-    // Copy Profile Dialog
+    // Copy profile dialog
     Dialog {
         id: copyProfileDialog
         anchors.centerIn: parent

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -1781,8 +1781,9 @@ bool ProfileManager::duplicateProfile(const QString& sourceFilename, const QStri
     // Generate a unique filename from the title
     QString newFilename = titleToFilename(newTitle);
 
-    // titleToFilename strips everything but letters/digits/underscores; titles that are
-    // entirely non-Latin (CJK / Cyrillic / emoji / punctuation) reduce to an empty string.
+    // titleToFilename transliterates accented Latin, then replaces remaining non-alphanumerics
+    // with underscores. Only emoji/punctuation/symbol-only titles (no Unicode letters or digits)
+    // reduce to an empty string; CJK and Cyrillic titles produce a non-empty Unicode filename.
     if (newFilename.isEmpty()) {
         qWarning() << "ProfileManager::duplicateProfile: title sanitises to empty filename:" << newTitle;
         return false;
@@ -1802,7 +1803,7 @@ bool ProfileManager::duplicateProfile(const QString& sourceFilename, const QStri
         if (profileExists(fn))
             return true;
         if (m_profileStorage && m_profileStorage->isConfigured()
-            && !m_profileStorage->readProfile(fn).isEmpty())
+            && m_profileStorage->profileExists(fn))
             return true;
         if (QFile::exists(userProfilesPath() + "/" + fn + ".json"))
             return true;
@@ -1868,11 +1869,10 @@ bool ProfileManager::duplicateProfile(const QString& sourceFilename, const QStri
 
     Profile duplicatedProfile = Profile::loadFromJsonString(jsonContent);
 
-    // Update the title and clear read-only flag
+    // Clear read-only so the copy is editable even when duplicated from a built-in profile
     duplicatedProfile.setTitle(newTitle);
     duplicatedProfile.setReadOnly(0);
 
-    // Save the duplicated profile
     bool success = false;
     
     // Try ProfileStorage first (SAF on Android)
@@ -1895,12 +1895,9 @@ bool ProfileManager::duplicateProfile(const QString& sourceFilename, const QStri
     }
 
     if (success) {
-        // Add to favorites
         if (m_settings) {
-            m_settings->app()->addFavoriteProfile(newTitle, newFilename);
+            m_settings->app()->addSelectedBuiltInProfile(newFilename);
         }
-        
-        // Refresh the profile list to show the new profile
         refreshProfiles();
     }
     


### PR DESCRIPTION
## Summary

Follow-up to #1104 addressing issues found in code review.

- Replace `addFavoriteProfile` with `addSelectedBuiltInProfile` so copying a non-favorite profile does not auto-star the copy
- Use `profileStorage->profileExists()` in the collision check instead of `readProfile()` (avoids reading the full file just to test existence)
- Add `Accessible.focusable: true` + `Accessible.onPressAction` to all four `MenuItem` items (Edit, Copy, Remove from list, Delete) in `ProfileSelectorPage.qml` — pre-existing omission, required by CLAUDE.md
- Fix incorrect comment claiming CJK/Cyrillic titles reduce to an empty filename (`QChar::isLetterOrNumber` includes those scripts)
- Remove what-comments; keep only a why-comment for `setReadOnly(0)`
- Fix section comment casing: `Copy Profile Dialog` → `Copy profile dialog`

## Test plan

- [ ] Copy a profile that is not a favorite — confirm the copy appears in the profile list but is not starred
- [ ] Copy a profile that is a favorite — confirm the copy is not auto-starred
- [ ] Verify all four overflow menu items (Edit, Copy, Remove, Delete) are accessible via TalkBack/VoiceOver
- [ ] All 2052 unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)