### PR TITLE
fix(visualizer): restore upload UI feedback on post-shot review page

### DIFF
--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -56,6 +56,7 @@ Page {
     property bool isEditMode: editShotId > 0
     property bool autoClose: true  // false when user opens manually (no auto-dismiss)
     property bool advancedMode: Settings.boolValue("shotReview/advancedMode", false)
+    property string uploadError: ""
 
     // Pick up toggle changes made on any other page sharing this setting
     // (Shot Detail, Shot Comparison, Espresso view selector).
@@ -245,7 +246,7 @@ Page {
         editDrinkWeight !== (editShotData.finalWeightG ?? 0) ||
         editDrinkTds !== (editShotData.drinkTdsPct ?? 0) ||
         editDrinkEy !== (editShotData.drinkEyPct ?? 0) ||
-        editEnjoyment !== (editShotData.enjoyment0to100 ?? 0) ||
+        editEnjoyment !== ((editShotData.enjoymentSource === "inferred") ? 0 : (editShotData.enjoyment0to100 ?? 0)) ||
         editNotes !== (editShotData.espressoNotes || "") ||
         editBeverageType !== (editShotData.beverageType || "espresso")
     )
@@ -268,10 +269,13 @@ Page {
             "finalWeight": editDrinkWeight,
             "drinkTds": editDrinkTds,
             "drinkEy": editDrinkEy,
-            "enjoyment": editEnjoyment,
             "espressoNotes": editNotes,
             "beverageType": editBeverageType
         }
+        // Don't write inferred enjoyment back to DB — it's AI-only data.
+        // Include enjoyment only when the user has explicitly set a value.
+        if (editShotData.enjoymentSource !== "inferred" || editEnjoyment > 0)
+            metadata["enjoyment"] = editEnjoyment
         MainController.shotHistory.requestUpdateShotMetadata(editShotId, metadata)
 
         // Sync sticky metadata back to Settings (bean/grinder info) for the next shot.
@@ -308,6 +312,7 @@ Page {
             }
         }
         function onUploadSuccess(shotId, url) {
+            uploadError = ""
             // Update the shot history with visualizer info (async);
             // reload triggered by onVisualizerInfoUpdated handler above
             if (editShotId > 0) {
@@ -315,10 +320,14 @@ Page {
             }
         }
         function onUpdateSuccess(visualizerId) {
+            uploadError = ""
             // Reload shot data to refresh the UI after metadata update
             if (editShotId > 0) {
                 loadShotForEditing()
             }
+        }
+        function onUploadFailed(error) {
+            uploadError = error
         }
     }
 
@@ -1343,9 +1352,13 @@ Page {
                         saveEditedShot()
                     }
 
+                    uploadError = ""
                     if (editShotData.visualizerId) {
-                        // Re-upload: PATCH metadata from current edit fields
-                        var currentData = {
+                        // Re-upload: PATCH metadata from current edit fields.
+                        // Pass editShotData as Q_GADGET base (V4 preserves all
+                        // properties); plain JS object via updateShotOnVisualizer
+                        // would produce a default-constructed ShotProjection.
+                        var patchOverrides = {
                             "beanBrand": editBeanBrand,
                             "beanType": editBeanType,
                             "roastDate": editRoastDate,
@@ -1359,12 +1372,12 @@ Page {
                             "finalWeightG": editDrinkWeight,
                             "drinkTdsPct": editDrinkTds,
                             "drinkEyPct": editDrinkEy,
-                            "enjoyment0to100": editEnjoyment,
-                            "espressoNotes": editNotes,
-                            "profileName": editShotData.profileName || ""
+                            "espressoNotes": editNotes
                         }
-                        MainController.visualizer.updateShotOnVisualizer(
-                            editShotData.visualizerId, currentData)
+                        if (editShotData.enjoymentSource !== "inferred" || editEnjoyment > 0)
+                            patchOverrides["enjoyment0to100"] = editEnjoyment
+                        MainController.visualizer.updateShotOnVisualizerWithOverrides(
+                            editShotData.visualizerId, editShotData, patchOverrides)
                     } else {
                         // First upload: pass editShotData directly (preserves id,
                         // durationSec, and frame arrays) and supply current edit-field
@@ -1372,24 +1385,26 @@ Page {
                         // not work here — Q_GADGET properties are non-enumerable in V4,
                         // so Object.assign silently drops them, leaving id=0 and causing
                         // isValid() to fail with no UI feedback.
+                        var uploadOverrides = {
+                            "beanBrand": editBeanBrand,
+                            "beanType": editBeanType,
+                            "roastDate": editRoastDate,
+                            "roastLevel": editRoastLevel,
+                            "grinderBrand": editGrinderBrand,
+                            "grinderModel": editGrinderModel,
+                            "grinderBurrs": editGrinderBurrs,
+                            "grinderSetting": editGrinderSetting,
+                            "barista": editBarista,
+                            "doseWeightG": editDoseWeight,
+                            "finalWeightG": editDrinkWeight,
+                            "drinkTdsPct": editDrinkTds,
+                            "drinkEyPct": editDrinkEy,
+                            "espressoNotes": editNotes
+                        }
+                        if (editShotData.enjoymentSource !== "inferred" || editEnjoyment > 0)
+                            uploadOverrides["enjoyment0to100"] = editEnjoyment
                         MainController.visualizer.uploadShotFromHistoryWithOverrides(
-                            editShotData, {
-                                "beanBrand": editBeanBrand,
-                                "beanType": editBeanType,
-                                "roastDate": editRoastDate,
-                                "roastLevel": editRoastLevel,
-                                "grinderBrand": editGrinderBrand,
-                                "grinderModel": editGrinderModel,
-                                "grinderBurrs": editGrinderBurrs,
-                                "grinderSetting": editGrinderSetting,
-                                "barista": editBarista,
-                                "doseWeightG": editDoseWeight,
-                                "finalWeightG": editDrinkWeight,
-                                "drinkTdsPct": editDrinkTds,
-                                "drinkEyPct": editDrinkEy,
-                                "enjoyment0to100": editEnjoyment,
-                                "espressoNotes": editNotes
-                            })
+                            editShotData, uploadOverrides)
                     }
                 }
             }
@@ -1404,6 +1419,15 @@ Page {
             fallback: editShotData.visualizerId ? "Updating..." : "Uploading..."
             color: Theme.textSecondaryColor
             font: Theme.labelFont
+        }
+
+        Text {
+            visible: uploadError.length > 0 && !MainController.visualizer.uploading
+            text: uploadError
+            color: Theme.errorColor
+            font: Theme.labelFont
+            wrapMode: Text.WordWrap
+            Layout.fillWidth: true
         }
 
         // AI Advice button - visible when AI is configured and we have shot data

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -1355,9 +1355,8 @@ Page {
                     uploadError = ""
                     if (editShotData.visualizerId) {
                         // Re-upload: PATCH metadata from current edit fields.
-                        // Pass editShotData as Q_GADGET base (V4 preserves all
-                        // properties); plain JS object via updateShotOnVisualizer
-                        // would produce a default-constructed ShotProjection.
+                        // Pass editShotData as Q_GADGET base so profileName (and any
+                        // field not in patchOverrides) comes from the original shot record.
                         var patchOverrides = {
                             "beanBrand": editBeanBrand,
                             "beanType": editBeanType,
@@ -1368,14 +1367,18 @@ Page {
                             "grinderBurrs": editGrinderBurrs,
                             "grinderSetting": editGrinderSetting,
                             "barista": editBarista,
+                            "beverageType": editBeverageType,
                             "doseWeightG": editDoseWeight,
                             "finalWeightG": editDrinkWeight,
                             "drinkTdsPct": editDrinkTds,
                             "drinkEyPct": editDrinkEy,
-                            "espressoNotes": editNotes
+                            "espressoNotes": editNotes,
+                            // Always include enjoyment so it overrides the base shot value.
+                            // editEnjoyment is initialized to 0 for inferred shots, which
+                            // keeps the inferred rating from leaking to Visualizer (the
+                            // serializer skips enjoyment0to100 == 0).
+                            "enjoyment0to100": editEnjoyment
                         }
-                        if (editShotData.enjoymentSource !== "inferred" || editEnjoyment > 0)
-                            patchOverrides["enjoyment0to100"] = editEnjoyment
                         MainController.visualizer.updateShotOnVisualizerWithOverrides(
                             editShotData.visualizerId, editShotData, patchOverrides)
                     } else {
@@ -1384,7 +1387,7 @@ Page {
                         // values as overrides. Object.assign({}, editShotData, ...) does
                         // not work here — Q_GADGET properties are non-enumerable in V4,
                         // so Object.assign silently drops them, leaving id=0 and causing
-                        // isValid() to fail with no UI feedback.
+                        // isValid() to fail.
                         var uploadOverrides = {
                             "beanBrand": editBeanBrand,
                             "beanType": editBeanType,
@@ -1395,14 +1398,14 @@ Page {
                             "grinderBurrs": editGrinderBurrs,
                             "grinderSetting": editGrinderSetting,
                             "barista": editBarista,
+                            "beverageType": editBeverageType,
                             "doseWeightG": editDoseWeight,
                             "finalWeightG": editDrinkWeight,
                             "drinkTdsPct": editDrinkTds,
                             "drinkEyPct": editDrinkEy,
-                            "espressoNotes": editNotes
+                            "espressoNotes": editNotes,
+                            "enjoyment0to100": editEnjoyment
                         }
-                        if (editShotData.enjoymentSource !== "inferred" || editEnjoyment > 0)
-                            uploadOverrides["enjoyment0to100"] = editEnjoyment
                         MainController.visualizer.uploadShotFromHistoryWithOverrides(
                             editShotData, uploadOverrides)
                     }
@@ -1423,7 +1426,7 @@ Page {
 
         Text {
             visible: uploadError.length > 0 && !MainController.visualizer.uploading
-            text: uploadError
+            text: TranslationManager.translate("postshotreview.upload.failed", "Upload failed") + ": " + uploadError
             color: Theme.errorColor
             font: Theme.labelFont
             wrapMode: Text.WordWrap

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -1366,26 +1366,30 @@ Page {
                         MainController.visualizer.updateShotOnVisualizer(
                             editShotData.visualizerId, currentData)
                     } else {
-                        // First upload: merge current edits into shot data (editShotData
-                        // was loaded at page open and may have stale metadata)
-                        var uploadData = Object.assign({}, editShotData, {
-                            "beanBrand": editBeanBrand,
-                            "beanType": editBeanType,
-                            "roastDate": editRoastDate,
-                            "roastLevel": editRoastLevel,
-                            "grinderBrand": editGrinderBrand,
-                            "grinderModel": editGrinderModel,
-                            "grinderBurrs": editGrinderBurrs,
-                            "grinderSetting": editGrinderSetting,
-                            "barista": editBarista,
-                            "doseWeightG": editDoseWeight,
-                            "finalWeightG": editDrinkWeight,
-                            "drinkTdsPct": editDrinkTds,
-                            "drinkEyPct": editDrinkEy,
-                            "enjoyment0to100": editEnjoyment,
-                            "espressoNotes": editNotes
-                        })
-                        MainController.visualizer.uploadShotFromHistory(uploadData)
+                        // First upload: pass editShotData directly (preserves id,
+                        // durationSec, and frame arrays) and supply current edit-field
+                        // values as overrides. Object.assign({}, editShotData, ...) does
+                        // not work here — Q_GADGET properties are non-enumerable in V4,
+                        // so Object.assign silently drops them, leaving id=0 and causing
+                        // isValid() to fail with no UI feedback.
+                        MainController.visualizer.uploadShotFromHistoryWithOverrides(
+                            editShotData, {
+                                "beanBrand": editBeanBrand,
+                                "beanType": editBeanType,
+                                "roastDate": editRoastDate,
+                                "roastLevel": editRoastLevel,
+                                "grinderBrand": editGrinderBrand,
+                                "grinderModel": editGrinderModel,
+                                "grinderBurrs": editGrinderBurrs,
+                                "grinderSetting": editGrinderSetting,
+                                "barista": editBarista,
+                                "doseWeightG": editDoseWeight,
+                                "finalWeightG": editDrinkWeight,
+                                "drinkTdsPct": editDrinkTds,
+                                "drinkEyPct": editDrinkEy,
+                                "enjoyment0to100": editEnjoyment,
+                                "espressoNotes": editNotes
+                            })
                     }
                 }
             }

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -169,6 +169,7 @@ void VisualizerUploader::uploadShotFromHistoryWithOverrides(
     applyStr   (&ShotProjection::grinderSetting,  "grinderSetting");
     applyStr   (&ShotProjection::barista,         "barista");
     applyStr   (&ShotProjection::espressoNotes,   "espressoNotes");
+    applyStr   (&ShotProjection::beverageType,    "beverageType");
     applyDouble(&ShotProjection::doseWeightG,     "doseWeightG");
     applyDouble(&ShotProjection::finalWeightG,    "finalWeightG");
     applyDouble(&ShotProjection::drinkTdsPct,     "drinkTdsPct");
@@ -207,6 +208,7 @@ void VisualizerUploader::updateShotOnVisualizerWithOverrides(
     applyStr   (&ShotProjection::grinderSetting,  "grinderSetting");
     applyStr   (&ShotProjection::barista,         "barista");
     applyStr   (&ShotProjection::espressoNotes,   "espressoNotes");
+    applyStr   (&ShotProjection::beverageType,    "beverageType");
     applyDouble(&ShotProjection::doseWeightG,     "doseWeightG");
     applyDouble(&ShotProjection::finalWeightG,    "finalWeightG");
     applyDouble(&ShotProjection::drinkTdsPct,     "drinkTdsPct");

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -34,7 +34,7 @@ static QJsonArray interpolateGoalData(const QVector<QPointF>& goalData, const QV
 
     if (goalData.isEmpty() || masterData.isEmpty()) {
         // Return zeros for all timestamps if no goal data
-        for (int i = 0; i < masterData.size(); ++i) {
+        for (qsizetype i = 0; i < masterData.size(); ++i) {
             result.append(0.0);
         }
         return result;
@@ -43,7 +43,7 @@ static QJsonArray interpolateGoalData(const QVector<QPointF>& goalData, const QV
     // Gap threshold: if consecutive goal points are more than 0.5s apart, treat as a gap
     constexpr double GAP_THRESHOLD = 0.5;
 
-    int goalIdx = 0;
+    qsizetype goalIdx = 0;
     for (const auto& masterPt : masterData) {
         double t = masterPt.x();
 
@@ -176,6 +176,44 @@ void VisualizerUploader::uploadShotFromHistoryWithOverrides(
     applyInt   (&ShotProjection::enjoyment0to100, "enjoyment0to100");
 
     uploadShotFromHistory(shot);
+}
+
+void VisualizerUploader::updateShotOnVisualizerWithOverrides(
+    const QString& visualizerId,
+    const ShotProjection& baseShot,
+    const QVariantMap& overrides)
+{
+    ShotProjection shot = baseShot;
+    auto applyStr    = [&](QString       ShotProjection::*f, const char* k) {
+        auto it = overrides.find(QLatin1String(k));
+        if (it != overrides.end()) shot.*f = it->toString();
+    };
+    auto applyDouble = [&](double        ShotProjection::*f, const char* k) {
+        auto it = overrides.find(QLatin1String(k));
+        if (it != overrides.end()) shot.*f = it->toDouble();
+    };
+    auto applyInt    = [&](int           ShotProjection::*f, const char* k) {
+        auto it = overrides.find(QLatin1String(k));
+        if (it != overrides.end()) shot.*f = it->toInt();
+    };
+
+    applyStr   (&ShotProjection::beanBrand,       "beanBrand");
+    applyStr   (&ShotProjection::beanType,        "beanType");
+    applyStr   (&ShotProjection::roastDate,       "roastDate");
+    applyStr   (&ShotProjection::roastLevel,      "roastLevel");
+    applyStr   (&ShotProjection::grinderBrand,    "grinderBrand");
+    applyStr   (&ShotProjection::grinderModel,    "grinderModel");
+    applyStr   (&ShotProjection::grinderBurrs,    "grinderBurrs");
+    applyStr   (&ShotProjection::grinderSetting,  "grinderSetting");
+    applyStr   (&ShotProjection::barista,         "barista");
+    applyStr   (&ShotProjection::espressoNotes,   "espressoNotes");
+    applyDouble(&ShotProjection::doseWeightG,     "doseWeightG");
+    applyDouble(&ShotProjection::finalWeightG,    "finalWeightG");
+    applyDouble(&ShotProjection::drinkTdsPct,     "drinkTdsPct");
+    applyDouble(&ShotProjection::drinkEyPct,      "drinkEyPct");
+    applyInt   (&ShotProjection::enjoyment0to100, "enjoyment0to100");
+
+    updateShotOnVisualizer(visualizerId, shot);
 }
 
 void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, const ShotProjection& shotData)

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -142,6 +142,42 @@ void VisualizerUploader::uploadShotFromHistory(const ShotProjection& shotData)
     sendUpload(jsonData);
 }
 
+void VisualizerUploader::uploadShotFromHistoryWithOverrides(
+    const ShotProjection& baseShot, const QVariantMap& overrides)
+{
+    ShotProjection shot = baseShot;
+    auto applyStr    = [&](QString       ShotProjection::*f, const char* k) {
+        auto it = overrides.find(QLatin1String(k));
+        if (it != overrides.end()) shot.*f = it->toString();
+    };
+    auto applyDouble = [&](double        ShotProjection::*f, const char* k) {
+        auto it = overrides.find(QLatin1String(k));
+        if (it != overrides.end()) shot.*f = it->toDouble();
+    };
+    auto applyInt    = [&](int           ShotProjection::*f, const char* k) {
+        auto it = overrides.find(QLatin1String(k));
+        if (it != overrides.end()) shot.*f = it->toInt();
+    };
+
+    applyStr   (&ShotProjection::beanBrand,       "beanBrand");
+    applyStr   (&ShotProjection::beanType,        "beanType");
+    applyStr   (&ShotProjection::roastDate,       "roastDate");
+    applyStr   (&ShotProjection::roastLevel,      "roastLevel");
+    applyStr   (&ShotProjection::grinderBrand,    "grinderBrand");
+    applyStr   (&ShotProjection::grinderModel,    "grinderModel");
+    applyStr   (&ShotProjection::grinderBurrs,    "grinderBurrs");
+    applyStr   (&ShotProjection::grinderSetting,  "grinderSetting");
+    applyStr   (&ShotProjection::barista,         "barista");
+    applyStr   (&ShotProjection::espressoNotes,   "espressoNotes");
+    applyDouble(&ShotProjection::doseWeightG,     "doseWeightG");
+    applyDouble(&ShotProjection::finalWeightG,    "finalWeightG");
+    applyDouble(&ShotProjection::drinkTdsPct,     "drinkTdsPct");
+    applyDouble(&ShotProjection::drinkEyPct,      "drinkEyPct");
+    applyInt   (&ShotProjection::enjoyment0to100, "enjoyment0to100");
+
+    uploadShotFromHistory(shot);
+}
+
 void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, const ShotProjection& shotData)
 {
     if (visualizerId.isEmpty()) {

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -73,9 +73,9 @@ public:
     // Update metadata on an already-uploaded shot (PATCH to visualizer.coffee)
     Q_INVOKABLE void updateShotOnVisualizer(const QString& visualizerId, const ShotProjection& shotData);
 
-    // PATCH with overrides applied on top of a base ShotProjection — same rationale
-    // as uploadShotFromHistoryWithOverrides: pass the Q_GADGET directly, not a plain
-    // JS object, so V4 transfers the full projection instead of a default-constructed one.
+    // PATCH with overrides applied on top of a base ShotProjection.
+    // Pass the Q_GADGET directly so fields not present in overrides (notably profileName)
+    // are taken from the original shot record rather than left empty.
     Q_INVOKABLE void updateShotOnVisualizerWithOverrides(
         const QString& visualizerId,
         const ShotProjection& baseShot,

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -73,6 +73,14 @@ public:
     // Update metadata on an already-uploaded shot (PATCH to visualizer.coffee)
     Q_INVOKABLE void updateShotOnVisualizer(const QString& visualizerId, const ShotProjection& shotData);
 
+    // PATCH with overrides applied on top of a base ShotProjection — same rationale
+    // as uploadShotFromHistoryWithOverrides: pass the Q_GADGET directly, not a plain
+    // JS object, so V4 transfers the full projection instead of a default-constructed one.
+    Q_INVOKABLE void updateShotOnVisualizerWithOverrides(
+        const QString& visualizerId,
+        const ShotProjection& baseShot,
+        const QVariantMap& overrides);
+
     // Test connection with current credentials
     Q_INVOKABLE void testConnection();
 

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -59,11 +59,16 @@ public:
                                  qint64 shotEpoch = 0);
 
     // Upload a shot from history (takes the typed projection from
-    // ShotHistoryStorage::convertShotRecord). QML callers can pass either a
-    // ShotProjection (from shotReady) or a JS object (post-Object.assign in
-    // PostShotReviewPage); the QVariantMap → ShotProjection meta-converter
-    // registered at startup handles both shapes.
+    // ShotHistoryStorage::convertShotRecord).
     Q_INVOKABLE void uploadShotFromHistory(const ShotProjection& shotData);
+
+    // Upload with metadata overrides applied on top of a base ShotProjection.
+    // Use from QML instead of Object.assign({}, editShotData, overrides): V4 can
+    // pass a QQmlValueTypeWrapper as ShotProjection, but Object.assign on a
+    // Q_GADGET yields a plain object that omits id/durationSec/frames, causing
+    // isValid() to fail silently with no UI feedback.
+    Q_INVOKABLE void uploadShotFromHistoryWithOverrides(
+        const ShotProjection& baseShot, const QVariantMap& overrides);
 
     // Update metadata on an already-uploaded shot (PATCH to visualizer.coffee)
     Q_INVOKABLE void updateShotOnVisualizer(const QString& visualizerId, const ShotProjection& shotData);


### PR DESCRIPTION
## Summary

- After the `ShotProjection` Q_GADGET refactor in #975, `Object.assign({}, editShotData, {...})` in PostShotReviewPage silently dropped the Q_GADGET's fields (`id`, `durationSec`, frame arrays) because Q_GADGET properties are non-enumerable in Qt's V4 JS engine
- The resulting plain JS object was passed to `uploadShotFromHistory(const ShotProjection&)`, which produced a default-constructed `ShotProjection` with `id=0` — `isValid()` returned false, `uploadFailed` was emitted silently, `m_uploading` was never set, and the button showed no state change whatsoever
- Adds `uploadShotFromHistoryWithOverrides(const ShotProjection&, const QVariantMap&)`: takes the Q_GADGET directly (V4 handles `QQmlValueTypeWrapper → ShotProjection` correctly) and applies metadata overrides from a plain `QVariantMap`, then delegates to `uploadShotFromHistory`

## Root cause detail

The Q_GADGET refactor's commit message claimed a registered `QVariantMap → ShotProjection` meta-converter would handle `Object.assign`'d JS objects. In practice:
1. `Object.assign` doesn't enumerate Q_GADGET properties → `uploadData` contains only the 15 metadata override fields, no `id`
2. Even if it did, Qt V4's `Q_INVOKABLE` parameter conversion does not invoke `QMetaType::registerConverter` converters — it uses its own type-matching path

## Test plan

- [ ] Pull a shot on Android → post-shot review page opens
- [ ] Change a detail (rating or final weight)
- [ ] Tap **Upload** — button should hide and **"Uploading..."** should appear
- [ ] After upload completes, button should reappear as **"Re-Upload to Visualizer"**
- [ ] Verify shot appears on visualizer.coffee with the edited metadata
- [ ] Confirm History → shot detail → Upload still works (no regression — that path passes `shotData` directly, unaffected by this change)

Closes #1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)