### PR TITLE
fix(logging): re-emit session marker after log file trim

### DIFF
--- a/src/network/webdebuglogger.cpp
+++ b/src/network/webdebuglogger.cpp
@@ -139,9 +139,10 @@ void WebDebugLogger::trimLogFile()
         newlinePos = trimPoint;
     }
 
-    // Write trimmed content
+    // Write trimmed content; re-emit the session marker so it survives the trim.
     if (file.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate)) {
         file.write("... [log trimmed] ...\n");
+        file.write(("========== SESSION START: " + m_startTime.toString(Qt::ISODate) + " ==========\n").toUtf8());
         file.write(content.mid(newlinePos + 1));
     }
 }


### PR DESCRIPTION
## Summary

- `trimLogFile()` kept the last 80% of the log file but discarded the beginning, where the `SESSION START` marker is written at app launch
- After any trim, `debug_get_log` with `sessions=true` returned `sessionCount: 0` even with 21k+ lines in the file
- Fix: write the current session marker immediately after the `... [log trimmed] ...` sentinel, so it is always present

## Test plan

- [ ] Let the app run long enough to trigger a log trim (or manually call `trimLogFile` in a debug build)
- [ ] Confirm `debug_get_log sessions=true` returns at least one session entry after the trim

🤖 Generated with [Claude Code](https://claude.ai/code)