### PR TITLE
fix(android): restore periodic idle GC during extended idle

### DIFF
--- a/android/src/io/github/kulitorum/decenza_de1/BleHelper.java
+++ b/android/src/io/github/kulitorum/decenza_de1/BleHelper.java
@@ -68,9 +68,9 @@ public class BleHelper {
     /**
      * Trigger a proactive GC while the app is sitting idle.
      *
-     * Called after the machine has been on the idle screen for a sustained
-     * period (e.g. 30 seconds). Cleans the Java heap so it is in good shape
-     * before the next shot without risking a GC pause during extraction.
+     * Called at app startup and every 15 minutes while the machine is idle.
+     * Cleans the Java heap so it is in good shape before the next shot without
+     * risking a GC pause during extraction.
      */
     public static void idleGc() {
         setHeapUtilization(HEAP_UTIL_IDLE);

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1212,8 +1212,11 @@ void DE1Device::writeMMR(uint32_t address, uint32_t value,
         return;
     }
 
-    // Log only when the value changes; force-resends of an unchanged value
-    // (e.g. the USB charger 10-minute keepalive) are silent to avoid noise.
+    // Log only when the value changes. force=true + unchanged is intentionally
+    // silent: the USB charger keepalive fires every 60 s at the same value and
+    // was the dominant source of log noise. For writeMMRVerified retries the
+    // caller already logs "[MMR] verify retry" before invoking writeMMR, so
+    // the retry BLE write is still traceable without a duplicate log here.
     if (!valueUnchanged) {
         qDebug().noquote() << QString("[MMR] write: 0x%1 = %2%3")
             .arg(address, 6, 16, QLatin1Char('0'))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -755,15 +755,18 @@ int main(int argc, char *argv[])
     // to reduce stop-the-world pause impact on BLE delivery and SAW latency.
     //
     // Strategy:
+    //   - App startup:
+    //       • Call idleGc() immediately and start the 15-minute periodic timer.
     //   - EspressoPreheating / HotWater / Flush start:
-    //       • Cancel any pending idle GC timer (don't want GC firing at shot start).
+    //       • Stop the periodic timer (no GC right before or during a shot).
     //       • Raise heap utilization threshold to 0.95 (GC only if heap is 95% full).
     //         No explicit System.gc() here — GC near preinfusion is worse than no GC.
     //   - Returning to Idle/Ready:
-    //       • Reset heap threshold to default.
-    //       • Schedule post-shot cleanup GC immediately (fine, nothing critical running).
-    //       • Start 30-second idle timer; if still idle when it fires, run a second
-    //         proactive GC to clean up any accumulation since the post-shot pass.
+    //       • onFlowingEnded() resets the heap threshold and runs an immediate GC.
+    //       • Restart the 15-minute periodic timer for ongoing idle maintenance.
+    //
+    // During extended idle (screensaver, overnight) the timer fires every 15 minutes
+    // to prevent unbounded Java heap growth from BLE GATT callbacks.
     //
     // s_inOperation prevents double-calls as the machine moves through sub-phases
     // (EspressoPreheating → Preinfusion → Pouring → Ending).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -769,8 +769,8 @@ int main(int argc, char *argv[])
     // (EspressoPreheating → Preinfusion → Pouring → Ending).
 
     auto* idleGcTimer = new QTimer();
-    idleGcTimer->setSingleShot(true);
-    idleGcTimer->setInterval(30000);  // 30 seconds of idle before proactive GC
+    idleGcTimer->setSingleShot(false);
+    idleGcTimer->setInterval(15 * 60 * 1000);  // 15-minute periodic idle GC
     QObject::connect(idleGcTimer, &QTimer::timeout, []() {
         QJniObject::callStaticMethod<void>(
             "io/github/kulitorum/decenza_de1/BleHelper",
@@ -799,7 +799,7 @@ int main(int argc, char *argv[])
 
         if (enteringOp) {
             s_inOperation = true;
-            idleGcTimer->stop();  // Cancel idle GC — don't start a GC right before a shot
+            idleGcTimer->stop();  // Pause periodic GC during operations
             QJniObject::callStaticMethod<void>(
                 "io/github/kulitorum/decenza_de1/BleHelper",
                 "onFlowingStarted", "()V");
@@ -807,17 +807,18 @@ int main(int argc, char *argv[])
             s_inOperation = false;
             QJniObject::callStaticMethod<void>(
                 "io/github/kulitorum/decenza_de1/BleHelper",
-                "onFlowingEnded", "()V");
-            idleGcTimer->start();  // Schedule proactive GC if still idle in 30s
+                "onFlowingEnded", "()V");  // runs immediate post-shot GC
+            idleGcTimer->start();  // Resume periodic idle GC
         }
     });
 
-    // Set idle heap utilization at startup — the app starts idle and onFlowingEnded()
-    // won't fire until the first shot ends. Without this, ART uses its default (0.75)
-    // and BLE stack garbage accumulates for a long time before GC triggers.
+    // Run GC at startup and start the periodic idle timer. The app starts idle
+    // and onFlowingEnded() won't fire until the first shot ends, so without this
+    // the heap accumulates BLE stack garbage unchecked until the first shot.
     QJniObject::callStaticMethod<void>(
         "io/github/kulitorum/decenza_de1/BleHelper",
         "idleGc", "()V");
+    idleGcTimer->start();
 
     // BLE dead system recovery: Android's Bluetooth system service can die
     // (DeadSystemException) during deep sleep or OEM power management.


### PR DESCRIPTION
## Summary

- The idle GC timer was single-shot: fired once 30 seconds after each shot, then stopped
- During long idle (screensaver overnight, no shots pulled), the Java heap grew linearly — observed 3.8 MB → 22.5 MB over 32 minutes with no GC
- `onFlowingEnded()` already runs an immediate `System.gc()` for post-shot cleanup; the timer's job is ongoing maintenance
- Fix: make the timer non-single-shot at 15-minute intervals, and start it at app launch so pre-first-shot idle is covered too

## Behaviour

| Situation | Before | After |
|---|---|---|
| App startup | `idleGc()` once | `idleGc()` once + timer starts |
| During a shot | timer stopped | timer stopped |
| Post-shot | timer fires once at 30s | immediate GC via `onFlowingEnded()` + timer resumes at 15 min |
| Overnight idle | no GC | GC every 15 min |

## Test plan

- [ ] Build and deploy to Android
- [ ] Leave the app idle for 30+ minutes and confirm Java heap stays bounded (sawtooth, not linear growth)
- [ ] Pull a shot and confirm no GC pause artifacts

🤖 Generated with [Claude Code](https://claude.ai/code)