### PR TITLE
feat(ai): retry 5xx and 429 responses from AI providers

### DIFF
--- a/src/ai/aiprovider.cpp
+++ b/src/ai/aiprovider.cpp
@@ -59,9 +59,9 @@ QJsonArray AIProvider::buildOpenAIMessages(const QString& systemPrompt, const QJ
 
 bool AIProvider::isRetryableHttpStatus(int httpStatus, int retryCount)
 {
-    // Primary transient codes: retry up to kMaxRetries times
+    // Primary transient codes: retry up to MAX_RETRIES times
     if (httpStatus == 429 || httpStatus == 502 || httpStatus == 503 || httpStatus == 504)
-        return retryCount < kMaxRetries;
+        return retryCount < MAX_RETRIES;
     // Other 5xx (e.g. 500 internal server error): retry once only
     if (httpStatus >= 500 && httpStatus < 600)
         return retryCount < 1;
@@ -92,7 +92,14 @@ bool AIProvider::tryScheduleRetry(QNetworkReply* reply)
     const QByteArray body = reply->readAll();
     qWarning() << name() << "HTTP" << status << "- retry" << m_retryCount
                << "in" << delay << "ms" << (body.isEmpty() ? QByteArray() : ("- " + body.left(200)));
-    QTimer::singleShot(delay, this, [this]() { m_retryFn(); });
+    // QTimer::singleShot is intentional: the server signalled a transient error and we must
+    // wait before retrying (rate-limit or overload backoff). This is a server-driven delay,
+    // not a heuristic guard. The generation counter prevents stale timers from firing if a
+    // new analyze() call arrives before this one fires.
+    const int gen = m_reqGen;
+    QTimer::singleShot(delay, this, [this, gen]() {
+        if (gen == m_reqGen) m_retryFn();
+    });
     return true;
 }
 
@@ -157,6 +164,7 @@ void OpenAIProvider::analyze(const QString& systemPrompt, const QString& userPro
 
     setStatus(Status::Busy);
     m_retryCount = 0;
+    ++m_reqGen;
 
     QJsonObject requestBody;
     requestBody["model"] = QString::fromLatin1(MODEL);
@@ -184,6 +192,7 @@ void OpenAIProvider::analyzeConversation(const QString& systemPrompt, const QJso
 
     setStatus(Status::Busy);
     m_retryCount = 0;
+    ++m_reqGen;
 
     QJsonObject requestBody;
     requestBody["model"] = QString::fromLatin1(MODEL);
@@ -360,6 +369,7 @@ void AnthropicProvider::analyze(const QString& systemPrompt, const QString& user
 
     setStatus(Status::Busy);
     m_retryCount = 0;
+    ++m_reqGen;
 
     QJsonObject requestBody;
     requestBody["model"] = QString::fromLatin1(MODEL);
@@ -384,6 +394,7 @@ void AnthropicProvider::analyzeConversation(const QString& systemPrompt, const Q
 
     setStatus(Status::Busy);
     m_retryCount = 0;
+    ++m_reqGen;
 
     QJsonObject requestBody;
     requestBody["model"] = QString::fromLatin1(MODEL);
@@ -641,6 +652,7 @@ void GeminiProvider::analyze(const QString& systemPrompt, const QString& userPro
 
     setStatus(Status::Busy);
     m_retryCount = 0;
+    ++m_reqGen;
 
     // Gemini uses a different format
     QJsonObject requestBody;
@@ -678,6 +690,7 @@ void GeminiProvider::analyzeConversation(const QString& systemPrompt, const QJso
 
     setStatus(Status::Busy);
     m_retryCount = 0;
+    ++m_reqGen;
 
     QJsonObject requestBody;
 
@@ -896,6 +909,7 @@ void OpenRouterProvider::analyze(const QString& systemPrompt, const QString& use
 
     setStatus(Status::Busy);
     m_retryCount = 0;
+    ++m_reqGen;
 
     // OpenRouter uses OpenAI-compatible format
     QJsonObject requestBody;
@@ -924,6 +938,7 @@ void OpenRouterProvider::analyzeConversation(const QString& systemPrompt, const 
 
     setStatus(Status::Busy);
     m_retryCount = 0;
+    ++m_reqGen;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -1105,6 +1120,7 @@ void OllamaProvider::analyze(const QString& systemPrompt, const QString& userPro
 
     setStatus(Status::Busy);
     m_retryCount = 0;
+    ++m_reqGen;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -1128,6 +1144,7 @@ void OllamaProvider::analyzeConversation(const QString& systemPrompt, const QJso
 
     setStatus(Status::Busy);
     m_retryCount = 0;
+    ++m_reqGen;
 
     // Use /api/chat which supports messages array natively
     QJsonObject requestBody;

--- a/src/ai/aiprovider.cpp
+++ b/src/ai/aiprovider.cpp
@@ -3,6 +3,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QNetworkRequest>
+#include <QTimer>
 #include <QUrl>
 #include <QVariant>
 
@@ -56,6 +57,45 @@ QJsonArray AIProvider::buildOpenAIMessages(const QString& systemPrompt, const QJ
     return apiMessages;
 }
 
+bool AIProvider::isRetryableHttpStatus(int httpStatus, int retryCount)
+{
+    // Primary transient codes: retry up to kMaxRetries times
+    if (httpStatus == 429 || httpStatus == 502 || httpStatus == 503 || httpStatus == 504)
+        return retryCount < kMaxRetries;
+    // Other 5xx (e.g. 500 internal server error): retry once only
+    if (httpStatus >= 500 && httpStatus < 600)
+        return retryCount < 1;
+    return false;
+}
+
+int AIProvider::computeRetryDelayMs(int retryCount, QNetworkReply* reply)
+{
+    const int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if (httpStatus == 429) {
+        const QByteArray retryAfter = reply->rawHeader("Retry-After");
+        if (!retryAfter.isEmpty()) {
+            bool ok;
+            const int seconds = retryAfter.toInt(&ok);
+            if (ok && seconds > 0)
+                return qMin(seconds * 1000, 30000);
+        }
+    }
+    return 1000 << (retryCount - 1);  // 1s, 2s, 4s for retries 1, 2, 3
+}
+
+bool AIProvider::tryScheduleRetry(QNetworkReply* reply)
+{
+    if (!m_retryFn) return false;
+    const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if (!isRetryableHttpStatus(status, m_retryCount)) return false;
+    const int delay = computeRetryDelayMs(++m_retryCount, reply);
+    const QByteArray body = reply->readAll();
+    qWarning() << name() << "HTTP" << status << "- retry" << m_retryCount
+               << "in" << delay << "ms" << (body.isEmpty() ? QByteArray() : ("- " + body.left(200)));
+    QTimer::singleShot(delay, this, [this]() { m_retryFn(); });
+    return true;
+}
+
 void AIProvider::analyzeConversation(const QString& systemPrompt, const QJsonArray& messages)
 {
     // Default fallback: flatten messages into a single string and call analyze()
@@ -99,6 +139,8 @@ void OpenAIProvider::sendRequest(const QJsonObject& requestBody)
     req.setRawHeader("Authorization", ("Bearer " + m_apiKey).toUtf8());
     req.setTransferTimeout(ANALYSIS_TIMEOUT_MS);
 
+    m_retryFn = [this, requestBody]() { sendRequest(requestBody); };
+
     QByteArray body = QJsonDocument(requestBody).toJson();
     QNetworkReply* reply = m_networkManager->post(req, body);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
@@ -114,6 +156,7 @@ void OpenAIProvider::analyze(const QString& systemPrompt, const QString& userPro
     }
 
     setStatus(Status::Busy);
+    m_retryCount = 0;
 
     QJsonObject requestBody;
     requestBody["model"] = QString::fromLatin1(MODEL);
@@ -140,6 +183,7 @@ void OpenAIProvider::analyzeConversation(const QString& systemPrompt, const QJso
     }
 
     setStatus(Status::Busy);
+    m_retryCount = 0;
 
     QJsonObject requestBody;
     requestBody["model"] = QString::fromLatin1(MODEL);
@@ -151,6 +195,7 @@ void OpenAIProvider::analyzeConversation(const QString& systemPrompt, const QJso
 
 void OpenAIProvider::onAnalysisReply(QNetworkReply* reply)
 {
+    if (tryScheduleRetry(reply)) { reply->deleteLater(); return; }
     reply->deleteLater();
     setStatus(Status::Ready);
 
@@ -297,6 +342,8 @@ void AnthropicProvider::sendRequest(const QJsonObject& requestBody)
     // Break-even is ~2 reads per write, easily met for any iterative dial-in.
     req.setTransferTimeout(ANALYSIS_TIMEOUT_MS);
 
+    m_retryFn = [this, requestBody]() { sendRequest(requestBody); };
+
     QByteArray body = QJsonDocument(requestBody).toJson();
     QNetworkReply* reply = m_networkManager->post(req, body);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
@@ -312,6 +359,7 @@ void AnthropicProvider::analyze(const QString& systemPrompt, const QString& user
     }
 
     setStatus(Status::Busy);
+    m_retryCount = 0;
 
     QJsonObject requestBody;
     requestBody["model"] = QString::fromLatin1(MODEL);
@@ -335,6 +383,7 @@ void AnthropicProvider::analyzeConversation(const QString& systemPrompt, const Q
     }
 
     setStatus(Status::Busy);
+    m_retryCount = 0;
 
     QJsonObject requestBody;
     requestBody["model"] = QString::fromLatin1(MODEL);
@@ -404,6 +453,7 @@ QJsonArray AnthropicProvider::buildCachedSystemPrompt(const QString& systemPromp
 
 void AnthropicProvider::onAnalysisReply(QNetworkReply* reply)
 {
+    if (tryScheduleRetry(reply)) { reply->deleteLater(); return; }
     reply->deleteLater();
     setStatus(Status::Ready);
 
@@ -573,6 +623,8 @@ void GeminiProvider::sendRequest(const QJsonObject& requestBody)
     generationConfig["thinkingConfig"] = thinkingConfig;
     bodyWithConfig["generationConfig"] = generationConfig;
 
+    m_retryFn = [this, requestBody]() { sendRequest(requestBody); };
+
     QByteArray body = QJsonDocument(bodyWithConfig).toJson();
     QNetworkReply* reply = m_networkManager->post(req, body);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
@@ -588,6 +640,7 @@ void GeminiProvider::analyze(const QString& systemPrompt, const QString& userPro
     }
 
     setStatus(Status::Busy);
+    m_retryCount = 0;
 
     // Gemini uses a different format
     QJsonObject requestBody;
@@ -624,6 +677,7 @@ void GeminiProvider::analyzeConversation(const QString& systemPrompt, const QJso
     }
 
     setStatus(Status::Busy);
+    m_retryCount = 0;
 
     QJsonObject requestBody;
 
@@ -661,6 +715,7 @@ void GeminiProvider::analyzeConversation(const QString& systemPrompt, const QJso
 
 void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
 {
+    if (tryScheduleRetry(reply)) { reply->deleteLater(); return; }
     reply->deleteLater();
     setStatus(Status::Ready);
 
@@ -823,6 +878,8 @@ void OpenRouterProvider::sendRequest(const QJsonObject& requestBody)
     req.setRawHeader("X-Title", "Decenza");
     req.setTransferTimeout(ANALYSIS_TIMEOUT_MS);
 
+    m_retryFn = [this, requestBody]() { sendRequest(requestBody); };
+
     QByteArray body = QJsonDocument(requestBody).toJson();
     QNetworkReply* reply = m_networkManager->post(req, body);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
@@ -838,6 +895,7 @@ void OpenRouterProvider::analyze(const QString& systemPrompt, const QString& use
     }
 
     setStatus(Status::Busy);
+    m_retryCount = 0;
 
     // OpenRouter uses OpenAI-compatible format
     QJsonObject requestBody;
@@ -865,6 +923,7 @@ void OpenRouterProvider::analyzeConversation(const QString& systemPrompt, const 
     }
 
     setStatus(Status::Busy);
+    m_retryCount = 0;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -876,6 +935,7 @@ void OpenRouterProvider::analyzeConversation(const QString& systemPrompt, const 
 
 void OpenRouterProvider::onAnalysisReply(QNetworkReply* reply)
 {
+    if (tryScheduleRetry(reply)) { reply->deleteLater(); return; }
     reply->deleteLater();
     setStatus(Status::Ready);
 
@@ -1027,6 +1087,8 @@ void OllamaProvider::sendRequest(const QUrl& url, const QJsonObject& requestBody
     req.setHeader(QNetworkRequest::ContentTypeHeader, QVariant(QString("application/json")));
     req.setTransferTimeout(LOCAL_ANALYSIS_TIMEOUT_MS);
 
+    m_retryFn = [this, url, requestBody]() { sendRequest(url, requestBody); };
+
     QByteArray body = QJsonDocument(requestBody).toJson();
     QNetworkReply* reply = m_networkManager->post(req, body);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
@@ -1042,6 +1104,7 @@ void OllamaProvider::analyze(const QString& systemPrompt, const QString& userPro
     }
 
     setStatus(Status::Busy);
+    m_retryCount = 0;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -1064,6 +1127,7 @@ void OllamaProvider::analyzeConversation(const QString& systemPrompt, const QJso
     }
 
     setStatus(Status::Busy);
+    m_retryCount = 0;
 
     // Use /api/chat which supports messages array natively
     QJsonObject requestBody;
@@ -1080,6 +1144,7 @@ void OllamaProvider::analyzeConversation(const QString& systemPrompt, const QJso
 
 void OllamaProvider::onAnalysisReply(QNetworkReply* reply)
 {
+    if (tryScheduleRetry(reply)) { reply->deleteLater(); return; }
     reply->deleteLater();
     setStatus(Status::Ready);
 

--- a/src/ai/aiprovider.h
+++ b/src/ai/aiprovider.h
@@ -51,17 +51,18 @@ protected:
     // Build OpenAI-compatible messages array: system message + conversation messages
     static QJsonArray buildOpenAIMessages(const QString& systemPrompt, const QJsonArray& messages);
 
-    // Retry support: call from each provider's sendRequest() and onAnalysisReply()
+    // Retry support: each sendRequest() assigns m_retryFn; each onAnalysisReply() calls tryScheduleRetry()
     bool tryScheduleRetry(QNetworkReply* reply);  // returns true if retry was scheduled
 
     static constexpr int ANALYSIS_TIMEOUT_MS = 60000;   // 60s for cloud AI analysis
     static constexpr int TEST_TIMEOUT_MS = 15000;        // 15s for connection tests
-    static constexpr int kMaxRetries = 3;                // max retries for 429/502/503/504
+    static constexpr int MAX_RETRIES = 3;                // max retries for 429/502/503/504
 
     QNetworkAccessManager* m_networkManager = nullptr;
     Status m_status = Status::Ready;
     std::function<void()> m_retryFn;  // set by each sendRequest() to re-send the pending request
-    int m_retryCount = 0;             // reset to 0 before each new analyze() call
+    int m_retryCount = 0;             // reset to 0 before each new analyze() / analyzeConversation() call
+    int m_reqGen = 0;                 // incremented on each new request; guards against stale retry timers
 
 private:
     static bool isRetryableHttpStatus(int httpStatus, int retryCount);

--- a/src/ai/aiprovider.h
+++ b/src/ai/aiprovider.h
@@ -5,6 +5,7 @@
 #include <QJsonArray>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <functional>
 
 // Abstract base class for AI providers
 class AIProvider : public QObject {
@@ -50,11 +51,21 @@ protected:
     // Build OpenAI-compatible messages array: system message + conversation messages
     static QJsonArray buildOpenAIMessages(const QString& systemPrompt, const QJsonArray& messages);
 
+    // Retry support: call from each provider's sendRequest() and onAnalysisReply()
+    bool tryScheduleRetry(QNetworkReply* reply);  // returns true if retry was scheduled
+
     static constexpr int ANALYSIS_TIMEOUT_MS = 60000;   // 60s for cloud AI analysis
     static constexpr int TEST_TIMEOUT_MS = 15000;        // 15s for connection tests
+    static constexpr int kMaxRetries = 3;                // max retries for 429/502/503/504
 
     QNetworkAccessManager* m_networkManager = nullptr;
     Status m_status = Status::Ready;
+    std::function<void()> m_retryFn;  // set by each sendRequest() to re-send the pending request
+    int m_retryCount = 0;             // reset to 0 before each new analyze() call
+
+private:
+    static bool isRetryableHttpStatus(int httpStatus, int retryCount);
+    static int computeRetryDelayMs(int retryCount, QNetworkReply* reply);
 };
 
 // OpenAI provider

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -290,8 +290,6 @@ void QtScaleBleTransport::onControllerConnected() {
 void QtScaleBleTransport::onControllerDisconnected() {
     QT_TRANSPORT_LOG("Controller disconnected");
     m_connected = false;
-    m_notifyCountSinceSummary = 0;
-    m_lastNotifySummaryMs = 0;
     emit disconnected();
 }
 


### PR DESCRIPTION
Closes #1109

## Summary

- Adds automatic retry logic to all five AI providers (OpenAI, Anthropic, Gemini, OpenRouter, Ollama)
- **429 / 502 / 503 / 504**: retry up to 3 times with exponential backoff (1s → 2s → 4s); 429 respects `Retry-After` header when present
- **Other 5xx**: retry once, then fail
- **4xx (except 429)**: fail immediately — retrying won't help

## Implementation

Retry state lives entirely in the `AIProvider` base class:
- `m_retryFn` (`std::function<void()>`) — each `sendRequest()` captures its own pending request body so the base class can re-issue it without knowing provider details
- `m_retryCount` — reset to 0 at the start of each `analyze()` / `analyzeConversation()` call
- `tryScheduleRetry(reply)` — checks status, increments counter, logs, schedules via `QTimer::singleShot`; returns `true` if a retry was scheduled
- `isRetryableHttpStatus()` / `computeRetryDelayMs()` — private static helpers

Each provider gains three one-liners: reset counter in `analyze()`, set `m_retryFn` in `sendRequest()`, check `tryScheduleRetry()` at the top of `onAnalysisReply()`. Status stays `Busy` during retries.

Also fixes two stale member references (`m_notifyCountSinceSummary`, `m_lastNotifySummaryMs`) in `QtScaleBleTransport::onControllerDisconnected()` left behind by #1111 that were causing build errors.

## Test plan

- [ ] Trigger a Gemini 503 (e.g. by temporarily using an invalid endpoint or during a real outage) and confirm the request retries automatically without user interaction
- [ ] Verify `analysisFailed` is still emitted after 3 retries on a persistent 503
- [ ] Verify 401 / 403 still fails immediately (no retry)
- [ ] Verify a successful response on the second attempt shows no failure to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)