### PR TITLE
feat(settings): make DE1 fan threshold user-configurable

### DIFF
--- a/openspec/changes/fan-threshold-setting/.openspec.yaml
+++ b/openspec/changes/fan-threshold-setting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/fan-threshold-setting/design.md
+++ b/openspec/changes/fan-threshold-setting/design.md
@@ -1,0 +1,42 @@
+## Context
+
+`DE1Device::sendInitialSettings()` writes `FAN_THRESHOLD = 60` unconditionally on every BLE connect. The DE1 firmware default is fan-always-on (threshold near 0°C), so if this write ever fails the fan never turns off. de1app stores this as `$::settings(fan_threshold)` — a user-configurable value defaulting to 60 — and writes that value on connect.
+
+The other heater calibration values (`heaterIdleTemp`, `heaterWarmupFlow`, `heaterTestFlow`, `heaterWarmupTimeout`) are already user-configurable in `SettingsHardware` and editable via the heater calibration popup in `SettingsCalibrationTab.qml`. Fan threshold belongs in the same place.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Persist a user-configurable fan threshold in `SettingsHardware` (default 60)
+- Write the user's value instead of the hardcoded 60 in `sendInitialSettings()`
+- Expose the setting in the existing heater calibration popup alongside the other hardware tuning sliders
+- Update the "Defaults for cafe" button to reset fan threshold to 60
+
+**Non-Goals:**
+- Reading back the current FAN_THRESHOLD from the DE1 on connect (de1app does this but adds round-trip complexity; the user's saved value is authoritative)
+- Exposing fan threshold outside the calibration popup (not a common adjustment; the warning gate is appropriate)
+- Firmware version checks or conditional writes (existing `sendInitialSettings()` does not do these)
+
+## Decisions
+
+**Add to `SettingsHardware`, not a new domain.**
+All heater calibration values live in `SettingsHardware`. FAN_THRESHOLD is written from `sendInitialSettings()` alongside the other hardware MMR writes, and shown in the same UI popup. It is the natural domain fit.
+
+**Range 0–60°C, matching de1app.**
+de1app's calibration slider is defined as `-from 0 -to 60`. 0 means "fan always on" (the DE1 firmware default); 60 is the standard quiet-operation value and the slider maximum. The label for 0 shows "always on" (mirroring de1app's `return_fan_threshold_calibration`). Step is 1°C.
+
+**Place in existing heater calibration popup, not a new card.**
+The popup is already behind a warning dialog (`calibrationWarningDialog`). Fan threshold is an expert setting with the same risk profile as the other heater values — adding it to the popup is the correct UX, not a new surface.
+
+**Key navigation must be updated.**
+The popup uses `KeyNavigation.tab`/`.backtab` chains. The new slider must be inserted into the chain (after heaterTestTimeout, before the "Defaults for cafe" button) and the `defaultsButton` reset handler extended.
+
+## Risks / Trade-offs
+
+[Existing users had an implicit 60°C they couldn't change] → No migration needed. The `QSettings` default is 60, so existing installations get 60 on first read — identical to the previous hardcoded value.
+
+[Fan threshold is an expert setting that can affect machine behaviour] → Mitigated by the existing warning dialog gate. No additional protection needed.
+
+## Migration Plan
+
+No data migration. The property reads from `QSettings` with a default of 60, matching the previously hardcoded value. Existing users see no change in behaviour.

--- a/openspec/changes/fan-threshold-setting/proposal.md
+++ b/openspec/changes/fan-threshold-setting/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Decenza hardcodes the DE1 fan threshold at 60°C on every connect, ignoring any user preference. The de1app stores this value per-user in `settings(fan_threshold)` and writes that value on connect — Decenza should do the same, exposing the setting alongside the other heater calibration controls.
+
+## What Changes
+
+- Add `fanThreshold` property to `SettingsHardware` (default 60, stored under `calibration/fanThreshold`)
+- Replace the hardcoded `writeMMR(FAN_THRESHOLD, 60)` in `sendInitialSettings()` with the user's saved value
+- Add a `ValueInput` slider for fan threshold to the existing heater calibration popup in `SettingsCalibrationTab.qml`
+- Update the "Defaults for cafe" button to reset `fanThreshold` to 60
+
+## Capabilities
+
+### New Capabilities
+
+- `fan-threshold-setting`: User-configurable DE1 fan temperature threshold, persisted in `SettingsHardware` and applied on every BLE connect via MMR write
+
+### Modified Capabilities
+
+- `settings-architecture`: `SettingsHardware` gains a new `fanThreshold` property (requirement change: new domain property with persist/notify)
+
+## Impact
+
+- `src/core/settings_hardware.h` / `settings_hardware.cpp` — new `fanThreshold` Q_PROPERTY
+- `src/ble/de1device.cpp` — `sendInitialSettings()` reads from settings instead of hardcoding 60
+- `qml/pages/settings/SettingsCalibrationTab.qml` — new `ValueInput` row in the heater calibration popup + updated `KeyNavigation` chain + `defaultsButton` reset

--- a/openspec/changes/fan-threshold-setting/specs/fan-threshold-setting/spec.md
+++ b/openspec/changes/fan-threshold-setting/specs/fan-threshold-setting/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Fan threshold is user-configurable and persisted
+`SettingsHardware` SHALL expose a `fanThreshold` property (`int`, range 0–60, default 60) backed by `QSettings` key `calibration/fanThreshold`. It SHALL follow the standard domain property pattern: `Q_PROPERTY` with `READ`/`WRITE`/`NOTIFY`, setter that guards on value change and emits the signal, and getter that reads from `QSettings` with the default.
+
+#### Scenario: Default value on fresh install
+- **WHEN** a user launches Decenza for the first time (no existing `calibration/fanThreshold` key in QSettings)
+- **THEN** `Settings.hardware.fanThreshold` returns 60
+- **AND** the DE1 receives `FAN_THRESHOLD = 60` on the next BLE connect
+
+#### Scenario: Persisted value survives restart
+- **WHEN** the user sets fan threshold to 40 and restarts the app
+- **THEN** `Settings.hardware.fanThreshold` returns 40
+- **AND** the DE1 receives `FAN_THRESHOLD = 40` on the next BLE connect
+
+### Requirement: Fan threshold is written to the DE1 on every BLE connect
+`DE1Device::sendInitialSettings()` SHALL write `DE1::MMR::FAN_THRESHOLD` using the value from `SettingsHardware::fanThreshold()` instead of a hardcoded literal. The write SHALL occur on every connection (including reconnects), consistent with all other MMR writes in `sendInitialSettings()`.
+
+#### Scenario: User-configured value is sent on connect
+- **WHEN** the user has set fan threshold to 45 and the DE1 connects
+- **THEN** the BLE log shows `[MMR] write: 0x803808 = 45`
+- **AND** NOT `[MMR] write: 0x803808 = 60`
+
+#### Scenario: Default value sent when never explicitly set
+- **WHEN** no fan threshold has been configured and the DE1 connects
+- **THEN** the BLE log shows `[MMR] write: 0x803808 = 60`
+
+### Requirement: Fan threshold slider in heater calibration popup
+The heater calibration popup in `SettingsCalibrationTab.qml` SHALL include a `ValueInput` slider for fan threshold. The slider SHALL have range 0–60, step 1, and display the value as `N°C` for N > 0 or `"Always on"` for N = 0 (matching de1app's label behaviour). It SHALL be positioned after the existing heater test timeout slider. The `KeyNavigation` chain SHALL include the new slider (tab order: heaterTestTimeout → fanThreshold → defaultsButton). The "Defaults for cafe" button SHALL reset `Settings.hardware.fanThreshold` to 60 alongside the other hardware defaults.
+
+#### Scenario: Slider shows current value
+- **WHEN** the user opens the heater calibration popup
+- **THEN** the fan threshold slider reflects the current `Settings.hardware.fanThreshold` value
+
+#### Scenario: Zero displays as "Always on"
+- **WHEN** the user drags the fan threshold slider to 0
+- **THEN** the slider label reads "Always on" (not "0°C")
+
+#### Scenario: Non-zero displays temperature
+- **WHEN** the slider is set to 42
+- **THEN** the label reads "42°C"
+
+#### Scenario: Defaults for cafe resets fan threshold
+- **WHEN** the user clicks "Defaults for cafe" in the heater calibration popup
+- **THEN** `Settings.hardware.fanThreshold` is set to 60

--- a/openspec/changes/fan-threshold-setting/tasks.md
+++ b/openspec/changes/fan-threshold-setting/tasks.md
@@ -1,0 +1,15 @@
+## 1. SettingsHardware — fanThreshold property
+
+- [x] 1.1 Add `Q_PROPERTY(int fanThreshold READ fanThreshold WRITE setFanThreshold NOTIFY fanThresholdChanged)` to `src/core/settings_hardware.h`
+- [x] 1.2 Add `fanThreshold()` getter (reads `calibration/fanThreshold`, default 60) and `setFanThreshold()` setter (guards on change, writes key, emits signal) to `src/core/settings_hardware.cpp`
+- [x] 1.3 Add `void fanThresholdChanged()` signal declaration to `src/core/settings_hardware.h`
+
+## 2. BLE — write user value on connect
+
+- [x] 2.1 In `src/ble/de1device.cpp` `sendInitialSettings()`, replace `writeMMR(DE1::MMR::FAN_THRESHOLD, 60)` with `writeMMR(DE1::MMR::FAN_THRESHOLD, m_settings->hardware()->fanThreshold())`
+
+## 3. UI — fan threshold slider in heater calibration popup
+
+- [x] 3.1 In `qml/pages/settings/SettingsCalibrationTab.qml`, add a label and `ValueInput` slider for fan threshold after the heater test timeout slider (`heaterTestTimeoutSlider`): range 0–60, step 1, `displayText` shows `N + "°C"` for N > 0 or `TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on")` for N = 0, bound to `Settings.hardware.fanThreshold`
+- [x] 3.2 Update `KeyNavigation` chain: `heaterTestTimeoutSlider.KeyNavigation.tab` → new fanThreshold slider; new slider `KeyNavigation.tab` → `defaultsButton`; `defaultsButton.KeyNavigation.backtab` → new slider
+- [x] 3.3 Add `Settings.hardware.fanThreshold = 60` to the `defaultsButton` `onClicked` handler alongside the other hardware resets

--- a/qml/pages/settings/SettingsCalibrationTab.qml
+++ b/qml/pages/settings/SettingsCalibrationTab.qml
@@ -770,7 +770,11 @@ Item {
 
                 // Heater test time-out
                 Text { text: TranslationManager.translate("settings.calibration.heaterTestTimeout", "Heater test time-out"); font: Theme.captionFont; color: Theme.textSecondaryColor }
-                ValueInput { id: heaterTestTimeoutSlider; Layout.fillWidth: true; accessibleName: TranslationManager.translate("settings.calibration.heaterTestTimeout", "Heater test time-out"); from: 10; to: 300; stepSize: 1; displayText: (value / 10).toFixed(1) + " s"; rangeText: "1.0 — 30.0 s"; value: Settings.hardware.heaterWarmupTimeout; onValueModified: function(newValue) { Settings.hardware.heaterWarmupTimeout = Math.round(newValue) }; KeyNavigation.tab: defaultsButton; KeyNavigation.backtab: heaterTestFlowSlider }
+                ValueInput { id: heaterTestTimeoutSlider; Layout.fillWidth: true; accessibleName: TranslationManager.translate("settings.calibration.heaterTestTimeout", "Heater test time-out"); from: 10; to: 300; stepSize: 1; displayText: (value / 10).toFixed(1) + " s"; rangeText: "1.0 — 30.0 s"; value: Settings.hardware.heaterWarmupTimeout; onValueModified: function(newValue) { Settings.hardware.heaterWarmupTimeout = Math.round(newValue) }; KeyNavigation.tab: fanThresholdSlider; KeyNavigation.backtab: heaterTestFlowSlider }
+
+                // Fan temperature threshold
+                Text { text: TranslationManager.translate("settings.calibration.fanThreshold", "Fan temperature threshold"); font: Theme.captionFont; color: Theme.textSecondaryColor }
+                ValueInput { id: fanThresholdSlider; Layout.fillWidth: true; accessibleName: TranslationManager.translate("settings.calibration.fanThreshold", "Fan temperature threshold"); from: 0; to: 60; stepSize: 1; displayText: value === 0 ? TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on") : value + "°C"; rangeText: TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on") + " — 60°C"; value: Settings.hardware.fanThreshold; onValueModified: function(newValue) { Settings.hardware.fanThreshold = Math.round(newValue) }; KeyNavigation.tab: defaultsButton; KeyNavigation.backtab: heaterTestTimeoutSlider }
 
                 Rectangle { Layout.fillWidth: true; height: 1; color: Theme.borderColor }
 
@@ -786,13 +790,14 @@ Item {
                         Settings.hardware.heaterWarmupFlow = 20
                         Settings.hardware.heaterTestFlow = 40
                         Settings.hardware.heaterWarmupTimeout = 10
+                        Settings.hardware.fanThreshold = 60
                         // Cafe defaults force two-tap stop for safety: the first tap puts
                         // the firmware in Puffing, allowing the auto-flush timer to clear
                         // the wand reliably. Toggle UI lives in Steam Heater (Machine tab).
                         Settings.hardware.steamTwoTapStop = true
                     }
                     KeyNavigation.tab: doneButton
-                    KeyNavigation.backtab: heaterTestTimeoutSlider
+                    KeyNavigation.backtab: fanThresholdSlider
                 }
 
                 RowLayout {

--- a/qml/pages/settings/SettingsCalibrationTab.qml
+++ b/qml/pages/settings/SettingsCalibrationTab.qml
@@ -772,9 +772,10 @@ Item {
                 Text { text: TranslationManager.translate("settings.calibration.heaterTestTimeout", "Heater test time-out"); font: Theme.captionFont; color: Theme.textSecondaryColor }
                 ValueInput { id: heaterTestTimeoutSlider; Layout.fillWidth: true; accessibleName: TranslationManager.translate("settings.calibration.heaterTestTimeout", "Heater test time-out"); from: 10; to: 300; stepSize: 1; displayText: (value / 10).toFixed(1) + " s"; rangeText: "1.0 — 30.0 s"; value: Settings.hardware.heaterWarmupTimeout; onValueModified: function(newValue) { Settings.hardware.heaterWarmupTimeout = Math.round(newValue) }; KeyNavigation.tab: fanThresholdSlider; KeyNavigation.backtab: heaterTestFlowSlider }
 
-                // Fan temperature threshold
-                Text { text: TranslationManager.translate("settings.calibration.fanThreshold", "Fan temperature threshold"); font: Theme.captionFont; color: Theme.textSecondaryColor }
-                ValueInput { id: fanThresholdSlider; Layout.fillWidth: true; accessibleName: TranslationManager.translate("settings.calibration.fanThreshold", "Fan temperature threshold"); from: 0; to: 60; stepSize: 1; displayText: value === 0 ? TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on") : value + "°C"; rangeText: TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on") + " — 60°C"; value: Settings.hardware.fanThreshold; onValueModified: function(newValue) { Settings.hardware.fanThreshold = Math.round(newValue) }; KeyNavigation.tab: defaultsButton; KeyNavigation.backtab: heaterTestTimeoutSlider }
+                // Fan temperature threshold: 0 = "Always on" (fan runs continuously,
+                // matching DE1 firmware default); 1–60 suppresses fan below that temp.
+                Text { text: TranslationManager.translate("settings.calibration.fanThreshold", "Fan temperature threshold"); font: Theme.captionFont; color: Theme.temperatureColor }
+                ValueInput { id: fanThresholdSlider; Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("settings.calibration.fanThreshold", "Fan temperature threshold"); from: 0; to: 60; stepSize: 1; displayText: value === 0 ? TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on") : value + "°C"; rangeText: TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on") + " — 60°C"; value: Settings.hardware.fanThreshold; onValueModified: function(newValue) { Settings.hardware.fanThreshold = Math.round(newValue) }; KeyNavigation.tab: defaultsButton; KeyNavigation.backtab: heaterTestTimeoutSlider }
 
                 Rectangle { Layout.fillWidth: true; height: 1; color: Theme.borderColor }
 

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1439,8 +1439,10 @@ void DE1Device::sendInitialSettings() {
         emit usbChargerOnChanged();
     }
 
-    // CRITICAL: Set fan temperature threshold via MMR
-    writeMMR(DE1::MMR::FAN_THRESHOLD, 60);
+    // CRITICAL: Set fan temperature threshold via MMR.
+    // Default DE1 fan runs continuously; threshold > 0 means fan only runs when
+    // internal temp exceeds this value. 0 = always on (DE1 firmware default).
+    writeMMR(DE1::MMR::FAN_THRESHOLD, m_settings ? m_settings->fanThreshold() : 60);
 
     // Heater tweaks — matches de1app's set_heater_tweaks()
     if (m_settings) {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -123,6 +123,7 @@ MainController::MainController(QNetworkAccessManager* networkManager,
         connect(hw, &SettingsHardware::heaterWarmupTimeoutChanged, this, startHeaterTimer);
         connect(hw, &SettingsHardware::hotWaterFlowRateChanged, this, startHeaterTimer);
         connect(hw, &SettingsHardware::steamTwoTapStopChanged, this, startHeaterTimer);
+        connect(hw, &SettingsHardware::fanThresholdChanged, this, startHeaterTimer);
     }
     // Connect to machine state events
     if (m_machineState) {
@@ -1368,6 +1369,7 @@ void MainController::applyHeaterTweaks() {
     m_device->writeMMR(DE1::MMR::ESPRESSO_WARMUP_TIMEOUT, m_settings->hardware()->heaterWarmupTimeout(), reason);
     m_device->writeMMR(DE1::MMR::HOT_WATER_FLOW_RATE, m_settings->hardware()->hotWaterFlowRate(), reason);
     m_device->writeMMR(DE1::MMR::STEAM_TWO_TAP_STOP, m_settings->hardware()->steamTwoTapStop() ? 1 : 0, reason);
+    m_device->writeMMR(DE1::MMR::FAN_THRESHOLD, m_settings->hardware()->fanThreshold(), reason);
 }
 
 double MainController::getGroupTemperature() const {

--- a/src/core/settings_hardware.cpp
+++ b/src/core/settings_hardware.cpp
@@ -78,3 +78,15 @@ void SettingsHardware::setSteamTwoTapStop(bool value) {
         emit steamTwoTapStopChanged();
     }
 }
+
+int SettingsHardware::fanThreshold() const {
+    int val = m_settings.value("calibration/fanThreshold", 60).toInt();
+    return qBound(0, val, 60);
+}
+
+void SettingsHardware::setFanThreshold(int value) {
+    if (fanThreshold() != value) {
+        m_settings.setValue("calibration/fanThreshold", value);
+        emit fanThresholdChanged();
+    }
+}

--- a/src/core/settings_hardware.cpp
+++ b/src/core/settings_hardware.cpp
@@ -85,6 +85,7 @@ int SettingsHardware::fanThreshold() const {
 }
 
 void SettingsHardware::setFanThreshold(int value) {
+    value = qBound(0, value, 60);
     if (fanThreshold() != value) {
         m_settings.setValue("calibration/fanThreshold", value);
         emit fanThresholdChanged();

--- a/src/core/settings_hardware.h
+++ b/src/core/settings_hardware.h
@@ -14,6 +14,7 @@ class SettingsHardware : public QObject {
     Q_PROPERTY(int heaterWarmupTimeout READ heaterWarmupTimeout WRITE setHeaterWarmupTimeout NOTIFY heaterWarmupTimeoutChanged)
     Q_PROPERTY(int hotWaterFlowRate READ hotWaterFlowRate WRITE setHotWaterFlowRate NOTIFY hotWaterFlowRateChanged)
     Q_PROPERTY(bool steamTwoTapStop READ steamTwoTapStop WRITE setSteamTwoTapStop NOTIFY steamTwoTapStopChanged)
+    Q_PROPERTY(int fanThreshold READ fanThreshold WRITE setFanThreshold NOTIFY fanThresholdChanged)
 
 public:
     explicit SettingsHardware(QObject* parent = nullptr);
@@ -36,6 +37,9 @@ public:
     bool steamTwoTapStop() const;
     void setSteamTwoTapStop(bool value);
 
+    int fanThreshold() const;
+    void setFanThreshold(int value);
+
 signals:
     void heaterIdleTempChanged();
     void heaterWarmupFlowChanged();
@@ -43,6 +47,7 @@ signals:
     void heaterWarmupTimeoutChanged();
     void hotWaterFlowRateChanged();
     void steamTwoTapStopChanged();
+    void fanThresholdChanged();
 
 private:
     mutable QSettings m_settings;


### PR DESCRIPTION
## Summary

- Adds `fanThreshold` property to `SettingsHardware` (default 60, range 0–60, persisted under `calibration/fanThreshold`) matching de1app's `settings(fan_threshold)`
- Writes the user's configured value instead of the hardcoded 60 in `sendInitialSettings()`
- Adds a "Fan temperature threshold" `ValueInput` slider to the heater calibration popup (after "Heater test time-out"), with 0 displaying as "Always on" matching de1app behaviour
- "Defaults for cafe" resets fan threshold to 60 alongside the other hardware values
- `fanThresholdChanged` is wired to `applyHeaterTweaks` so changes take effect immediately while connected

## Background

Decenza previously hardcoded 60°C on every BLE connect. de1app stores this as a user setting (`settings(fan_threshold)`, default 60, slider range 0–60) and writes it on connect. The DE1 firmware default is 0 (fan always on); setting 60 keeps the fan off during normal operation.

Note: the Linux-specific timing bug (where the MMR write fails silently because write characteristics are not yet available when `parseVersion()` fires) is tracked separately in PR #1116. That fix and this one are orthogonal — both are needed for Linux users to get a correct, user-configured fan threshold on connect.

## Test plan

- [ ] Open Settings → Calibration tab → "Calibrate…" → confirm "Fan temperature threshold" slider appears after "Heater test time-out"
- [ ] Drag slider to 0 → label shows "Always on"
- [ ] Drag to non-zero value → label shows N°C
- [ ] While connected to DE1, change the fan threshold and close the dialog → BLE log shows `[MMR] write: 0x803808 = <new value>` without reconnecting
- [ ] Close and reopen app → slider reflects saved value
- [ ] Connect to DE1 → BLE log shows `[MMR] write: 0x803808 = <user value>`
- [ ] "Defaults for cafe" resets fan threshold to 60

🤖 Generated with [Claude Code](https://claude.com/claude-code)