### PR TITLE
diag(network): instrument ShotServer listen socket health

### DIFF
--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -437,6 +437,11 @@ bool ShotServer::start()
             // newConnection fires on TCP accept (before SSL handshake), when hasPendingConnections() is still false.
             // pendingConnectionAvailable fires after handshake completes and socket is added to the pending queue.
             connect(m_server, &QTcpServer::pendingConnectionAvailable, this, &ShotServer::onNewConnection);
+            connect(m_server, &QTcpServer::acceptError, this, [this](QAbstractSocket::SocketError err) {
+                qWarning() << "ShotServer: accept error:" << err
+                           << "socketDescriptor:" << m_server->socketDescriptor()
+                           << "isListening:" << m_server->isListening();
+            });
             connect(sslServer, &QSslServer::sslErrors, this, [](QSslSocket* socket, const QList<QSslError>& errors) {
                 for (const auto& err : errors)
                     qWarning() << "ShotServer: SSL error:" << err.errorString();
@@ -467,6 +472,11 @@ bool ShotServer::start()
         // Plain HTTP mode (security disabled)
         m_server = new QTcpServer(this);
         connect(m_server, &QTcpServer::newConnection, this, &ShotServer::onNewConnection);
+        connect(m_server, &QTcpServer::acceptError, this, [this](QAbstractSocket::SocketError err) {
+            qWarning() << "ShotServer: accept error:" << err
+                       << "socketDescriptor:" << m_server->socketDescriptor()
+                       << "isListening:" << m_server->isListening();
+        });
 
         if (!m_server->listen(QHostAddress::Any, m_port)) {
             qWarning() << "ShotServer: Failed to start on port" << m_port << m_server->errorString();
@@ -893,6 +903,15 @@ void ShotServer::cleanupPendingRequest(QTcpSocket* socket)
 
 void ShotServer::onCleanupTimerTick()
 {
+    if (m_server) {
+        qintptr fd = m_server->socketDescriptor();
+        bool listening = m_server->isListening();
+        if (fd == -1 && listening)
+            qWarning() << "ShotServer: socketDescriptor() == -1 while isListening() == true — listen socket may have been invalidated by OS";
+        else
+            qDebug() << "ShotServer: health check — isListening:" << listening << "socketDescriptor:" << fd;
+    }
+
     QList<QTcpSocket*> staleConnections;
     for (auto it = m_pendingRequests.begin(); it != m_pendingRequests.end(); ++it) {
         if (it.value().lastActivity.isValid() &&


### PR DESCRIPTION
## Summary

- Connect `QTcpServer::acceptError` on both HTTP and HTTPS server paths — logs the error code, socket descriptor, and listening state whenever the OS rejects an incoming connection at the accept level
- Add a 30-second health check in `onCleanupTimerTick` that logs `socketDescriptor()` alongside `isListening()`; warns if the descriptor is `-1` while Qt still believes the server is listening (the signature of a silently-invalidated listen socket)

## Background

There have been occasional reports of the MCP server becoming completely unreachable while the app is still running, with no error messages in the log. Inspection of a recent session showed all `ShotServer:` log entries stopping abruptly after an MCP SSE disconnect during a steam session, with the Qt event loop continuing normally (battery/memory timers firing). The root cause is unknown — candidates include the Android OS invalidating the bound TCP socket fd during a network-interface transition, or an OS-level accept failure that Qt doesn't currently surface.

This change is **diagnostics only** — no functional change. The next occurrence will produce a clear WARN line identifying which failure mode is actually happening.

## Test plan

- [ ] Build and run on Android; confirm `ShotServer: health check — isListening: true socketDescriptor: <N>` appears in the log every 30 seconds while the server is running
- [ ] Confirm no regression in normal MCP connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)