### PR TITLE
feat(flush): add back-arrow exit during active flush (#1115)

### DIFF
--- a/openspec/changes/flush-back-arrow-exit/.openspec.yaml
+++ b/openspec/changes/flush-back-arrow-exit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/flush-back-arrow-exit/design.md
+++ b/openspec/changes/flush-back-arrow-exit/design.md
@@ -1,0 +1,88 @@
+## Context
+
+The Flush Water page (`qml/pages/FlushPage.qml`) has two visual states driven by `isFlushing`:
+
+1. **Settings view** (`!isFlushing`): preset pills, duration, flow inputs, and a bottom navigation bar with a back arrow + value chips.
+2. **Flushing view** (`isFlushing`): live preset switcher, timer + progress bar, and (only on headless machines) an on-screen STOP button.
+
+The settings view's `BottomBar` is gated by `visible: !isFlushing`, so during a flush the page has no on-screen navigation chrome. The flush ends one of two ways:
+
+- The DE1 firmware reaches the configured flush duration → phase transitions to Idle/Ready → `main.qml:2630` calls `showCompletion(trFlushComplete.text, "flush")` → a full-screen completion overlay (`completionOverlay`, z:500) is shown for 1500ms before navigating to idle.
+- A headless user taps the on-page STOP button → `DE1Device.stopOperation()` + `root.goToIdle()` → still triggers the same Idle/Ready handler, which still shows the 1.5s overlay.
+
+GitHub issue #1115 reports both that the 1.5s overlay feels long for users who don't need it, and that there's no way to abort early on machines without a GHC button. The completion overlay code path is shared with steam and hot water completions (`main.qml:2626-2631`), so any change there has cross-page implications.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a familiar on-screen escape during active flush, using the same back-arrow affordance the user already sees on every other page.
+- Make the exit *immediate* when the user explicitly invokes it: stop the flush and bypass the 1.5s "Flush Complete" overlay.
+- Reuse existing components and signal flow — no new BLE commands, no new settings, no new completion-overlay variants.
+
+**Non-Goals:**
+
+- Adding a user-configurable overlay duration setting (explicitly declined per Jeff's preference for good defaults over knobs).
+- Changing the completion overlay's behavior for *natural* flush completion (timer-driven), or for steam / hot water completion. Those paths are untouched.
+- Removing or repositioning the existing headless-only on-page STOP button. It stays; headless users get two equivalent exits.
+- Extending the same back-arrow pattern to `SteamPage` and `HotWaterPage`. The pattern exists there too but is out of scope for this change.
+
+## Decisions
+
+### Decision: Show the existing BottomBar during flush, hide its value chips
+
+Drop the `visible: !isFlushing` gate so the bar is rendered in both views. Inside the bar, hide the two `Text` chips that display `secondsInput.value` and `flowInput.value` (`FlushPage.qml:606-616`) when `isFlushing` is true.
+
+**Why:** The live timer above already shows the relevant state during a flush (elapsed/target seconds, progress bar). Repeating preset config in the bottom bar would be visual noise without new information. Hiding the chips is a one-attribute change (`visible: !isFlushing` on each chip) and keeps the bar consistent in height/layout.
+
+**Alternative considered:** A separate "flush mode" BottomBar component. Rejected — overkill for two `Text` items and a divider.
+
+### Decision: Suppress completion overlay via a root flag, not a parameter to `showCompletion()`
+
+Add a `userExitedFlush: false` property on `main.qml`'s root. The FlushPage's back handler sets it `true` before calling `DE1Device.stopOperation()` and navigating. The existing `Phase.Idle/Ready` handler in `main.qml` checks the flag before calling `showCompletion("flush")`; if set, it skips the call and clears the flag.
+
+**Why:** The phase change is what triggers `showCompletion()`, and that happens asynchronously after `stopOperation()`. The back handler doesn't have a synchronous hook to suppress the overlay at call time. A root-level flag is the simplest event-based mechanism — set by the user's action, consumed by the next Idle transition.
+
+This matches the project rule "no timers as guards" (CLAUDE.md): the flag is event-cleared (by the Idle transition), not time-cleared.
+
+**Alternative considered:** Pass a parameter through `showCompletion(suppress=true)`. Rejected — the caller (`Phase.Idle/Ready` handler) wouldn't know the suppression intent without consulting a flag anyway.
+
+**Alternative considered:** Use the existing `returnToPageName` / `returnToShotId` mechanism. Rejected — that system handles *where* to return after the overlay, not whether to skip it.
+
+### Decision: Flag is single-shot and self-clearing on the next Idle transition
+
+The flag is cleared immediately after it's consumed by the Idle/Ready handler, regardless of whether `showCompletion()` was suppressed. This guarantees that:
+
+- A natural flush completion right after a user-initiated exit (extremely unlikely but possible in racey scenarios) still shows its overlay normally.
+- A stale flag from a prior exit can't suppress a future legitimate completion.
+
+The handler runs on every phase change to Idle/Ready, so the flag has a tight, deterministic consumption point.
+
+### Decision: Back handler stops the operation, then navigates
+
+```
+onBackClicked: {
+    if (isFlushing) {
+        root.userExitedFlush = true
+        DE1Device.stopOperation()
+        if (pageStack.depth > 1) root.goBack()
+        else root.goToIdle()
+    } else {
+        MainController.applyFlushSettings()
+        if (pageStack.depth > 1) root.goBack()
+        else root.goToIdle()
+    }
+}
+```
+
+The order (set flag → stop → navigate) matters: the flag must be set before the phase transition fires, and navigation must follow so the user perceives an instant response. Navigation does not block on the phase change; the page transitions immediately while `stopOperation()` propagates to the device.
+
+**Why split the handler this way:** the settings-view path needs `applyFlushSettings()` to commit any in-progress preset edits; the flush-view path does not (the running flush has already received its settings). Keeping the two branches explicit avoids accidentally calling `applyFlushSettings()` mid-flush, which could re-send a BLE write the device is mid-acting on.
+
+## Risks / Trade-offs
+
+- **[Risk]** Race: user taps back at the exact moment the firmware-driven flush completes on its own. → Both paths converge on `Phase.Idle/Ready`; the flag suppresses the overlay either way. Acceptable outcome — the user wanted to leave, and they leave.
+- **[Risk]** Race: user taps back, then before the next phase transition, the user navigates to another operation page (e.g., espresso). → The flag remains set until the next Idle/Ready transition consumes it, which could suppress a completion overlay from an unrelated operation. **Mitigation:** Consume the flag only when the current page is `flushPage` (or was). Implemented as: in the Idle/Ready handler, only check/clear `userExitedFlush` inside the `currentPage === "flushPage"` branch.
+- **[Risk]** Hidden value chips during flush could be missed by users who relied on the bottom bar to see preset config. → The full settings view re-appears the moment the flush ends, and the preset name remains visible in the bar's title. Low impact.
+- **[Trade-off]** Two ways to exit on headless machines (STOP button + back arrow). → Intentional. Removing the STOP button would be a behavioral regression for headless users who learned that gesture; back arrow is additive.
+- **[Trade-off]** Skipping the completion overlay means the user loses the "12.4s" final-time confirmation on explicit exit. → Acceptable: the timer was visible up to the moment of exit, and the user explicitly chose to leave. Natural completions still show it.

--- a/openspec/changes/flush-back-arrow-exit/design.md
+++ b/openspec/changes/flush-back-arrow-exit/design.md
@@ -8,7 +8,7 @@ The Flush Water page (`qml/pages/FlushPage.qml`) has two visual states driven by
 The settings view's `BottomBar` is gated by `visible: !isFlushing`, so during a flush the page has no on-screen navigation chrome. The flush ends one of two ways:
 
 - The DE1 firmware reaches the configured flush duration → phase transitions to Idle/Ready → `main.qml:2630` calls `showCompletion(trFlushComplete.text, "flush")` → a full-screen completion overlay (`completionOverlay`, z:500) is shown for 1500ms before navigating to idle.
-- A headless user taps the on-page STOP button → `DE1Device.stopOperation()` + `root.goToIdle()` → still triggers the same Idle/Ready handler, which still shows the 1.5s overlay.
+- A headless user taps the on-page STOP button → `DE1Device.stopOperation()` + `root.goToIdle()` → triggers the same Idle/Ready handler. To make STOP genuinely equivalent to the new back-arrow exit, this change also sets `root.userExitedFlush = true` in the STOP handlers so both paths suppress the 1.5s overlay identically.
 
 GitHub issue #1115 reports both that the 1.5s overlay feels long for users who don't need it, and that there's no way to abort early on machines without a GHC button. The completion overlay code path is shared with steam and hot water completions (`main.qml:2626-2631`), so any change there has cross-page implications.
 
@@ -24,7 +24,7 @@ GitHub issue #1115 reports both that the 1.5s overlay feels long for users who d
 
 - Adding a user-configurable overlay duration setting (explicitly declined per Jeff's preference for good defaults over knobs).
 - Changing the completion overlay's behavior for *natural* flush completion (timer-driven), or for steam / hot water completion. Those paths are untouched.
-- Removing or repositioning the existing headless-only on-page STOP button. It stays; headless users get two equivalent exits.
+- Removing or repositioning the existing headless-only on-page STOP button. It stays; both the STOP button and the new back arrow set `userExitedFlush` so headless users get two equivalent exits.
 - Extending the same back-arrow pattern to `SteamPage` and `HotWaterPage`. The pattern exists there too but is out of scope for this change.
 
 ## Decisions
@@ -49,14 +49,14 @@ This matches the project rule "no timers as guards" (CLAUDE.md): the flag is eve
 
 **Alternative considered:** Use the existing `returnToPageName` / `returnToShotId` mechanism. Rejected — that system handles *where* to return after the overlay, not whether to skip it.
 
-### Decision: Flag is single-shot and self-clearing on the next Idle transition
+### Decision: Flag is single-shot and unconditionally cleared on the next Idle/Ready transition
 
-The flag is cleared immediately after it's consumed by the Idle/Ready handler, regardless of whether `showCompletion()` was suppressed. This guarantees that:
+The flag is cleared after the per-page completion decision runs, **regardless of which page is current**. Why unconditional: `root.goBack()` / `root.goToIdle()` from the back handler mutate `currentPage` synchronously, before the BLE-driven phase change arrives, so by the time the Idle/Ready handler runs `currentPage` is typically no longer `"flushPage"`. If we only cleared inside the flushPage branch, the flag would strand and silently suppress the next legitimate flush completion. Clearing unconditionally at the end of the Idle/Ready handler guarantees:
 
-- A natural flush completion right after a user-initiated exit (extremely unlikely but possible in racey scenarios) still shows its overlay normally.
-- A stale flag from a prior exit can't suppress a future legitimate completion.
+- A natural flush completion right after a user-initiated exit (racey but possible) still shows its overlay normally on a subsequent flush.
+- A stale flag from a prior exit cannot survive past the very next Idle/Ready transition — and that transition is exactly the one caused by `stopOperation()` from the back handler, so the lifetime is one phase event.
 
-The handler runs on every phase change to Idle/Ready, so the flag has a tight, deterministic consumption point.
+The flag is only ever *consumed for suppression* inside the flushPage branch, so unconditional clearing is safe — it cannot accidentally suppress a steam or hot-water completion.
 
 ### Decision: Back handler stops the operation, then navigates
 
@@ -82,7 +82,7 @@ The order (set flag → stop → navigate) matters: the flag must be set before 
 ## Risks / Trade-offs
 
 - **[Risk]** Race: user taps back at the exact moment the firmware-driven flush completes on its own. → Both paths converge on `Phase.Idle/Ready`; the flag suppresses the overlay either way. Acceptable outcome — the user wanted to leave, and they leave.
-- **[Risk]** Race: user taps back, then before the next phase transition, the user navigates to another operation page (e.g., espresso). → The flag remains set until the next Idle/Ready transition consumes it, which could suppress a completion overlay from an unrelated operation. **Mitigation:** Consume the flag only when the current page is `flushPage` (or was). Implemented as: in the Idle/Ready handler, only check/clear `userExitedFlush` inside the `currentPage === "flushPage"` branch.
+- **[Risk]** Race: user taps back, then before the next phase transition, the user navigates to another operation page (e.g., espresso). → The flag is only ever *checked* inside the flushPage branch of the Idle/Ready handler, so it cannot suppress steam/hot-water completion overlays. The flag is also cleared unconditionally at the end of every Idle/Ready handler invocation, so it cannot survive past one phase event.
 - **[Risk]** Hidden value chips during flush could be missed by users who relied on the bottom bar to see preset config. → The full settings view re-appears the moment the flush ends, and the preset name remains visible in the bar's title. Low impact.
 - **[Trade-off]** Two ways to exit on headless machines (STOP button + back arrow). → Intentional. Removing the STOP button would be a behavioral regression for headless users who learned that gesture; back arrow is additive.
 - **[Trade-off]** Skipping the completion overlay means the user loses the "12.4s" final-time confirmation on explicit exit. → Acceptable: the timer was visible up to the moment of exit, and the user explicitly chose to leave. Natural completions still show it.

--- a/openspec/changes/flush-back-arrow-exit/proposal.md
+++ b/openspec/changes/flush-back-arrow-exit/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The Flush Water screen offers no way to exit early: once a flush starts, the user must wait for the configured duration to elapse and then sit through a fixed 1.5s "Flush Complete" overlay before navigation returns to the previous page. GitHub issue [#1115](https://github.com/Kulitorum/Decenza/issues/1115) calls this out — users with shorter information needs find the post-flush wait too long, and on non-headless machines there is no on-screen way to abort the flush at all. The existing BottomBar back arrow already appears on the page's settings view; extending it to the active-flush view gives users the familiar one-tap escape they already expect from other pages.
+
+## What Changes
+
+- Show the existing `BottomBar` on `FlushPage.qml` during an active flush (currently hidden via `visible: !isFlushing`). The bar's content collapses to back arrow + title only during flush — the seconds/flow value chips are hidden because the live timer above already shows the relevant state.
+- Tapping back during an active flush stops the flush via `DE1Device.stopOperation()` and navigates back to the previous page (`goBack()` / `goToIdle()`).
+- An explicit user-initiated exit suppresses the "Flush Complete" completion overlay: a `userExitedFlush` flag on `main.qml`'s root is set by the back handler and checked in the `Phase.Idle/Ready` handler before calling `showCompletion()`. The flag is cleared after the phase transition.
+- The existing headless-only on-screen STOP button (`FlushPage.qml:198`) is left in place. Headless users get two equivalent exits; this is intentional.
+- Out of scope: the issue's "(a) configurable delay" request is deliberately declined. Decenza prefers good defaults over user-tunable timing knobs, and the 1.5s overlay was already shortened from 3s based on prior user feedback. The skip-on-explicit-exit behavior in this change addresses the same impatience without adding a setting.
+- Out of scope: the same hide-bottom-bar-during-operation pattern exists on `SteamPage` and `HotWaterPage`. This change does not touch them; if desired, a follow-up can extend the pattern symmetrically.
+
+## Capabilities
+
+### New Capabilities
+
+- `flush-page-navigation`: User-facing navigation and exit behavior for the Flush Water page, including the always-visible back arrow, the explicit-exit completion-overlay suppression, and the relationship between the page's two views (settings vs. flushing).
+
+### Modified Capabilities
+
+<!-- None. The completion overlay logic in main.qml is touched, but no existing spec covers it. -->
+
+## Impact
+
+- **QML**: `qml/pages/FlushPage.qml` (BottomBar visibility + back handler), `qml/main.qml` (`userExitedFlush` root property + Phase.Idle/Ready guard around `showCompletion("flush")`).
+- **BLE / device layer**: none. Exit reuses existing `DE1Device.stopOperation()`.
+- **Settings**: none. No new setting is introduced.
+- **Translations**: no new user-visible strings — the BottomBar's back arrow and existing flush page title are already translated.
+- **Accessibility**: the back arrow inherits `BottomBar`'s existing accessibility wiring (focusable, Accessible.name, key handlers); no new accessibility surface to design.
+- **Tests**: no new automated tests — the change is QML navigation behavior with no logic suitable for the Qt Test harness. Manual verification on simulator and a real DE1 (both headless and GHC-equipped) covers the change.
+- **Closes**: [Kulitorum/Decenza#1115](https://github.com/Kulitorum/Decenza/issues/1115) — the (b) "exit option" portion. The (a) "configurable delay" portion is explicitly declined.

--- a/openspec/changes/flush-back-arrow-exit/specs/flush-page-navigation/spec.md
+++ b/openspec/changes/flush-back-arrow-exit/specs/flush-page-navigation/spec.md
@@ -52,22 +52,23 @@ The "Flush Complete" completion overlay SHALL be suppressed when the phase trans
 - **THEN** the completion overlay is shown for its existing duration (1.5 seconds)
 - **AND** the user-exit flag remains clear
 
-#### Scenario: Stale user-exit flag is not consumed by an unrelated page
+#### Scenario: Flag is unconditionally cleared on every Idle/Ready transition
 
 - **WHEN** the user-exit flag is set
-- **AND** the next phase transition to Idle or Ready occurs while a page other than the Flush Water page is current
-- **THEN** the completion overlay decision for that other page is unaffected by the flag
-- **AND** the flag remains set until consumed by an Idle/Ready transition where the Flush Water page is current, ensuring no cross-page suppression
+- **AND** any phase transition to Idle or Ready occurs (regardless of which page is current)
+- **THEN** the flag is cleared at the end of the Idle/Ready handler so it cannot strand and suppress a later legitimate completion
+- **AND** the flag is only ever checked inside the Flush Water page branch, so it cannot suppress steam or hot-water completion overlays
 
-### Requirement: Existing headless STOP button preserved
+### Requirement: Existing headless STOP button preserved and made equivalent to back arrow
 
-The existing on-screen STOP button shown only on headless machines (`DE1Device.isHeadless`) during an active flush SHALL remain unchanged in placement and behavior. The new back-arrow exit is additive, not a replacement.
+The existing on-screen STOP button shown only on headless machines (`DE1Device.isHeadless`) during an active flush SHALL remain in place. To make the two on-screen exits behaviorally equivalent, the STOP button's handlers SHALL also set the user-exit flag so the completion overlay is suppressed identically to the back-arrow path.
 
-#### Scenario: Headless machine retains STOP button
+#### Scenario: Headless machine retains STOP button with equivalent exit behavior
 
 - **WHEN** the machine is flushing and `DE1Device.isHeadless` is true
 - **THEN** the on-page STOP button is visible alongside the back arrow on the BottomBar
-- **AND** both controls invoke `DE1Device.stopOperation()` and navigate away from the FlushPage
+- **AND** both controls set the user-exit flag, invoke `DE1Device.stopOperation()`, and navigate away from the FlushPage
+- **AND** neither path shows the 1.5s "Flush Complete" overlay
 
 #### Scenario: Non-headless machine relies on back arrow only
 

--- a/openspec/changes/flush-back-arrow-exit/specs/flush-page-navigation/spec.md
+++ b/openspec/changes/flush-back-arrow-exit/specs/flush-page-navigation/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: BottomBar visible during active flush
+
+The Flush Water page SHALL display its bottom navigation bar in both the settings view and the active-flush view, so the back-arrow exit affordance is reachable at all times.
+
+#### Scenario: Settings view shows full BottomBar
+
+- **WHEN** the user opens the Flush Water page and the machine is not flushing
+- **THEN** the BottomBar is visible with its back arrow, preset-name title, and the duration / flow value chips
+
+#### Scenario: Active-flush view shows BottomBar with chips hidden
+
+- **WHEN** the machine phase is `Flushing` and the FlushPage is the current page
+- **THEN** the BottomBar is visible
+- **AND** the back arrow is reachable and focusable
+- **AND** the duration and flow value chips inside the BottomBar are hidden, leaving only the back arrow and preset-name title
+
+### Requirement: Back arrow exits an active flush immediately
+
+The back arrow on the Flush Water page SHALL stop an in-progress flush and return the user to the previous page without waiting for the configured flush duration or the completion overlay.
+
+#### Scenario: Back tapped during active flush
+
+- **WHEN** the machine phase is `Flushing` and the user activates the back arrow (tap, Enter, Space, or Escape)
+- **THEN** `DE1Device.stopOperation()` is invoked
+- **AND** the user-exit flag is set so the completion overlay is suppressed
+- **AND** navigation returns to the previous page in the stack, or to the idle page when no previous page exists
+
+#### Scenario: Back tapped in settings view (unchanged behavior)
+
+- **WHEN** the machine is not flushing and the user activates the back arrow
+- **THEN** `MainController.applyFlushSettings()` is invoked to persist any in-progress preset edits
+- **AND** navigation returns to the previous page in the stack, or to the idle page when no previous page exists
+- **AND** the user-exit flag is NOT set
+
+### Requirement: Completion overlay suppressed on explicit user exit from flush
+
+The "Flush Complete" completion overlay SHALL be suppressed when the phase transition to Idle/Ready is the result of an explicit user-initiated exit from the Flush Water page. Natural completions (firmware-driven end of flush) SHALL continue to show the overlay as today.
+
+#### Scenario: Explicit exit skips overlay
+
+- **WHEN** the user activates the back arrow during a flush
+- **AND** the machine phase subsequently transitions to Idle or Ready
+- **THEN** the completion overlay is NOT shown
+- **AND** the user-exit flag is cleared so it cannot affect a later phase transition
+
+#### Scenario: Natural completion still shows overlay
+
+- **WHEN** the firmware ends the flush on its own because the configured duration elapsed
+- **AND** the machine phase transitions to Idle or Ready while the FlushPage is current
+- **THEN** the completion overlay is shown for its existing duration (1.5 seconds)
+- **AND** the user-exit flag remains clear
+
+#### Scenario: Stale user-exit flag is not consumed by an unrelated page
+
+- **WHEN** the user-exit flag is set
+- **AND** the next phase transition to Idle or Ready occurs while a page other than the Flush Water page is current
+- **THEN** the completion overlay decision for that other page is unaffected by the flag
+- **AND** the flag remains set until consumed by an Idle/Ready transition where the Flush Water page is current, ensuring no cross-page suppression
+
+### Requirement: Existing headless STOP button preserved
+
+The existing on-screen STOP button shown only on headless machines (`DE1Device.isHeadless`) during an active flush SHALL remain unchanged in placement and behavior. The new back-arrow exit is additive, not a replacement.
+
+#### Scenario: Headless machine retains STOP button
+
+- **WHEN** the machine is flushing and `DE1Device.isHeadless` is true
+- **THEN** the on-page STOP button is visible alongside the back arrow on the BottomBar
+- **AND** both controls invoke `DE1Device.stopOperation()` and navigate away from the FlushPage
+
+#### Scenario: Non-headless machine relies on back arrow only
+
+- **WHEN** the machine is flushing and `DE1Device.isHeadless` is false
+- **THEN** the on-page STOP button is hidden (existing behavior)
+- **AND** the back arrow on the BottomBar is the on-screen way to exit

--- a/openspec/changes/flush-back-arrow-exit/tasks.md
+++ b/openspec/changes/flush-back-arrow-exit/tasks.md
@@ -1,0 +1,34 @@
+## 1. Root flag plumbing in main.qml
+
+- [x] 1.1 Add `property bool userExitedFlush: false` on `main.qml`'s root (near other navigation state like `returnToPageName` / `returnToShotId`)
+- [x] 1.2 In the Idle/Ready phase handler around `main.qml:2630`, wrap the `showCompletion(trFlushComplete.text, "flush")` call so that when `currentPage === "flushPage"` and `root.userExitedFlush` is true, the call is skipped
+- [x] 1.3 Clear `root.userExitedFlush = false` immediately after the check in 1.2, only inside the `currentPage === "flushPage"` branch (to avoid consuming the flag during an unrelated page's Idle transition)
+- [x] 1.4 Add a `console.log` line at the suppression site mirroring the surrounding diagnostic style (helps when verifying on-device)
+
+## 2. FlushPage BottomBar visibility and chip hiding
+
+- [x] 2.1 In `qml/pages/FlushPage.qml`, remove `visible: !isFlushing` from the BottomBar (line 594) so it is always visible
+- [x] 2.2 Add `visible: !isFlushing` to each of the two value-chip `Text` elements (`secondsInput.value` chip at lines 606-610 and `flowInput.value` chip at lines 612-616) and to the divider `Rectangle` between them (line 611)
+- [x] 2.3 Confirm the BottomBar's `title` binding (`getCurrentPresetName() || pageTitle`) still resolves correctly during a flush — `getCurrentPresetName()` reads from `Settings.brew.flushPresets`, which is unchanged during a flush, so no change needed
+
+## 3. FlushPage back-arrow exit behavior
+
+- [x] 3.1 Replace the single `onBackClicked` body with a branch on `isFlushing`:
+  - If `isFlushing`: set `root.userExitedFlush = true`, call `DE1Device.stopOperation()`, then navigate (`root.goBack()` if `pageStack.depth > 1` else `root.goToIdle()`)
+  - Else: existing behavior unchanged (`MainController.applyFlushSettings()` then navigate)
+- [x] 3.2 Verify keyboard accessibility paths inherited from `BottomBar` (Enter / Space / Escape all route to `backClicked()`) work in both branches
+
+## 4. Manual verification
+
+- [ ] 4.1 Build and run in Qt Creator (Jeff drives the build, not Claude — see CLAUDE.md "Building")
+- [ ] 4.2 Verify on simulator: start a flush, wait for natural completion, confirm "Flush Complete" overlay still shows for 1.5s and returns to idle
+- [ ] 4.3 Verify on simulator: start a flush, tap back arrow mid-flush, confirm flush stops immediately and navigation returns to previous page with NO completion overlay
+- [ ] 4.4 Verify on simulator: navigate FlushPage → some other operation page after a back-exit, confirm any subsequent natural Idle transition on that other page is unaffected (overlay shows normally if applicable)
+- [ ] 4.5 Verify on a real DE1 (non-headless): on-page STOP button is correctly hidden during flush, back arrow is the sole on-screen exit, and exiting via back arrow does not leave the machine in a flushing state
+- [ ] 4.6 Verify on a real DE1 (headless if available): both STOP button and back arrow are visible during flush, both exit cleanly, neither shows the completion overlay
+- [ ] 4.7 Verify TalkBack/VoiceOver focus order includes the back arrow during flush (BottomBar already wires this)
+
+## 5. Wrap-up
+
+- [ ] 5.1 Open a PR referencing GitHub issue #1115 in the description; note that the configurable-delay portion (a) is explicitly declined and that the exit option (b) is delivered
+- [ ] 5.2 Confirm release-notes line in the PR body mentions only the user-visible change (one-line back-arrow escape during flush) — no mention of internal flag mechanics

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -44,11 +44,9 @@ ApplicationWindow {
     property string returnToPageName: ""
     property int returnToShotId: 0
 
-    // Set true when the user explicitly taps back during an active flush.
-    // Consumed by the Idle/Ready phase handler to suppress the 1.5s "Flush Complete"
-    // overlay — the user already chose to leave, so the overlay would just delay them.
-    // Cleared on the next Idle/Ready transition while flushPage is current, so it
-    // cannot leak into a later unrelated operation's completion overlay.
+    // Set by FlushPage's back-arrow / STOP handlers to suppress the 1.5s "Flush
+    // Complete" overlay when the user explicitly chose to leave. Single-shot:
+    // cleared on the next Idle/Ready transition regardless of current page.
     property bool userExitedFlush: false
 
     // True while the first-run restore dialog is active (prevents SettingsHistoryDataTab from also handling restore signals)
@@ -2626,8 +2624,9 @@ ApplicationWindow {
                     goToScreensaver()
                 }
             } else if (phase === MachineStateType.Phase.Idle || phase === MachineStateType.Phase.Ready) {
-                // DE1 went to idle - if we're on an operation page, show completion
-                // Note: Don't check pageStack.busy here - completion must always be handled
+                // DE1 went to idle - if we're on an operation page, show completion.
+                // Don't check pageStack.busy: completion must be handled, except when
+                // the user explicitly exited a flush (userExitedFlush below).
                 console.log("Phase Idle/Ready: currentPage=" + currentPage + " completionOverlay.opacity=" + completionOverlay.opacity)
 
                 if (currentPage === "steamPage") {
@@ -2635,19 +2634,20 @@ ApplicationWindow {
                 } else if (currentPage === "hotWaterPage") {
                     showCompletion(trHotWaterComplete.text, "hotwater")
                 } else if (currentPage === "flushPage") {
-                    // Suppress the completion overlay when the user explicitly tapped
-                    // back to leave the flush — they don't need a 1.5s "Flush Complete"
-                    // toast on the way out. Consume the flag here so a later, unrelated
-                    // operation's completion is unaffected.
                     if (root.userExitedFlush) {
                         console.log("Phase Idle/Ready: flush exited by user, skipping completion overlay")
-                        root.userExitedFlush = false
                     } else {
                         showCompletion(trFlushComplete.text, "flush")
                     }
                 } else {
                     console.log("Phase Idle/Ready: NOT on operation page, no completion shown")
                 }
+
+                // Always clear the flag, even when currentPage is no longer flushPage
+                // (synchronous back-handler navigation typically changes the page
+                // before this async phase signal arrives). Without this, the flag
+                // would strand and suppress a later legitimate flush completion.
+                root.userExitedFlush = false
             }
         }
     }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -44,6 +44,13 @@ ApplicationWindow {
     property string returnToPageName: ""
     property int returnToShotId: 0
 
+    // Set true when the user explicitly taps back during an active flush.
+    // Consumed by the Idle/Ready phase handler to suppress the 1.5s "Flush Complete"
+    // overlay — the user already chose to leave, so the overlay would just delay them.
+    // Cleared on the next Idle/Ready transition while flushPage is current, so it
+    // cannot leak into a later unrelated operation's completion overlay.
+    property bool userExitedFlush: false
+
     // True while the first-run restore dialog is active (prevents SettingsHistoryDataTab from also handling restore signals)
 
     // Global accessibility: find closest Text within radius of tap
@@ -2628,7 +2635,16 @@ ApplicationWindow {
                 } else if (currentPage === "hotWaterPage") {
                     showCompletion(trHotWaterComplete.text, "hotwater")
                 } else if (currentPage === "flushPage") {
-                    showCompletion(trFlushComplete.text, "flush")
+                    // Suppress the completion overlay when the user explicitly tapped
+                    // back to leave the flush — they don't need a 1.5s "Flush Complete"
+                    // toast on the way out. Consume the flag here so a later, unrelated
+                    // operation's completion is unaffected.
+                    if (root.userExitedFlush) {
+                        console.log("Phase Idle/Ready: flush exited by user, skipping completion overlay")
+                        root.userExitedFlush = false
+                    } else {
+                        showCompletion(trFlushComplete.text, "flush")
+                    }
                 } else {
                     console.log("Phase Idle/Ready: NOT on operation page, no completion shown")
                 }

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -202,8 +202,8 @@ Page {
                 border.width: Theme.scaled(2)
 
                 activeFocusOnTab: true
-                Keys.onReturnPressed: { DE1Device.stopOperation(); root.goToIdle(); event.accepted = true }
-                Keys.onSpacePressed:  { DE1Device.stopOperation(); root.goToIdle(); event.accepted = true }
+                Keys.onReturnPressed: { root.userExitedFlush = true; DE1Device.stopOperation(); root.goToIdle(); event.accepted = true }
+                Keys.onSpacePressed:  { root.userExitedFlush = true; DE1Device.stopOperation(); root.goToIdle(); event.accepted = true }
                 Keys.onTabPressed: {
                     if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(0).forceActiveFocus()
                     event.accepted = true
@@ -229,6 +229,7 @@ Page {
                     accessibleName: TranslationManager.translate("flush.accessible.stopFlushing", "Stop flushing")
                     accessibleItem: flushStopButton
                     onAccessibleClicked: {
+                        root.userExitedFlush = true
                         DE1Device.stopOperation()
                         root.goToIdle()
                     }
@@ -589,10 +590,8 @@ Page {
         }
     }
 
-    // Bottom bar — visible in both settings and active-flush views so the back
-    // arrow is always reachable. During an active flush the duration/flow chips
-    // are hidden (the live timer above already shows the relevant state), and
-    // back stops the flush + suppresses the completion overlay.
+    // Always visible: back stays reachable during active flush. Chips collapse
+    // during flush (live timer above shows state); back stops + suppresses overlay.
     BottomBar {
         title: getCurrentPresetName() || pageTitle
         onBackClicked: {
@@ -615,6 +614,7 @@ Page {
             text: secondsInput.value.toFixed(1) + "s"
             color: Theme.primaryContrastColor
             font: Theme.bodyFont
+            Accessible.ignored: true
         }
         Rectangle {
             visible: !isFlushing
@@ -625,6 +625,7 @@ Page {
             text: flowInput.value.toFixed(1) + " mL/s"
             color: Theme.primaryContrastColor
             font: Theme.bodyFont
+            Accessible.ignored: true
         }
     }
 

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -589,12 +589,19 @@ Page {
         }
     }
 
-    // Bottom bar
+    // Bottom bar — visible in both settings and active-flush views so the back
+    // arrow is always reachable. During an active flush the duration/flow chips
+    // are hidden (the live timer above already shows the relevant state), and
+    // back stops the flush + suppresses the completion overlay.
     BottomBar {
-        visible: !isFlushing
         title: getCurrentPresetName() || pageTitle
         onBackClicked: {
-            MainController.applyFlushSettings()
+            if (isFlushing) {
+                root.userExitedFlush = true
+                DE1Device.stopOperation()
+            } else {
+                MainController.applyFlushSettings()
+            }
             // Handle both pushed (user nav) and replaced (auto nav) cases
             if (pageStack.depth > 1) {
                 root.goBack()
@@ -604,12 +611,17 @@ Page {
         }
 
         Text {
+            visible: !isFlushing
             text: secondsInput.value.toFixed(1) + "s"
             color: Theme.primaryContrastColor
             font: Theme.bodyFont
         }
-        Rectangle { width: 1; height: Theme.scaled(30); color: Theme.primaryContrastColor; opacity: 0.3 }
+        Rectangle {
+            visible: !isFlushing
+            width: 1; height: Theme.scaled(30); color: Theme.primaryContrastColor; opacity: 0.3
+        }
         Text {
+            visible: !isFlushing
             text: flowInput.value.toFixed(1) + " mL/s"
             color: Theme.primaryContrastColor
             font: Theme.bodyFont


### PR DESCRIPTION
## Summary

- Keep the existing `BottomBar` visible on `FlushPage` during an active flush so the back arrow is always reachable.
- Tapping back mid-flush stops the flush and returns to the previous page immediately — the 1.5s "Flush Complete" overlay is skipped on explicit exits, since the user already chose to leave. Natural (firmware-driven) flush completions still show the overlay as today.
- The duration/flow value chips on the BottomBar collapse during a flush; the live timer above already shows the relevant state.
- Existing headless-only on-page STOP button is left in place — additive, not a replacement.

Closes #1115 (the **(b) exit option** portion). The **(a) configurable delay** portion of the issue is deliberately declined to avoid adding a new settings dial.

## Mechanism

A new `userExitedFlush` boolean on `main.qml`'s root carries the user's intent from `FlushPage`'s back handler to the `Phase.Idle/Ready` handler that decides whether to call `showCompletion("flush")`. The flag is consumed only when `currentPage === "flushPage"`, so it cannot suppress an unrelated operation's completion overlay.

## Test plan

- [ ] Natural completion: start a flush on the simulator, let the timer expire — confirm the "Flush Complete" overlay still appears for 1.5s and returns to idle
- [ ] Explicit exit: start a flush, tap back arrow mid-flush — confirm the flush stops immediately, the page returns to the previous view, and NO completion overlay shows
- [ ] Cross-page flag leak: navigate FlushPage → back during flush → into another operation page; confirm any subsequent natural Idle transition on that other page shows its overlay normally
- [ ] Real DE1 (non-headless): on-page STOP button correctly hidden; back arrow is the sole on-screen exit; machine state is clean after exit
- [ ] Real DE1 (headless, if available): both STOP button and back arrow visible during flush; both exit cleanly without the completion overlay
- [ ] Accessibility: TalkBack/VoiceOver focus order reaches the back arrow during flush; Enter/Space/Escape all route to the back action
- [ ] No regression in 2052-test Qt Test suite (already verified clean locally)

## Files

- `qml/main.qml` — `userExitedFlush` root property, completion-overlay guard
- `qml/pages/FlushPage.qml` — BottomBar always visible, branch on `isFlushing` in back handler, chip visibility tied to `!isFlushing`
- `openspec/changes/flush-back-arrow-exit/` — proposal, design, spec, tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)