### PR TITLE
feat(profiles): pin one profile as auto-load (DSx2-style)

### DIFF
--- a/docs/CLAUDE_MD/MCP_SERVER.md
+++ b/docs/CLAUDE_MD/MCP_SERVER.md
@@ -86,7 +86,7 @@ Each tool has a `category` that determines the minimum access level required:
 
 | Category | Min Access Level | Tools |
 |----------|-----------------|-------|
-| `read` | 0 (Monitor) | machine_get_state, app_get_info, machine_get_telemetry, shots_list, shots_get_detail, shots_get_debug_log, shots_compare, profiles_list, profiles_get_active, profiles_get_detail, profiles_get_params, settings_get, dialing_get_context |
+| `read` | 0 (Monitor) | machine_get_state, app_get_info, machine_get_telemetry, shots_list, shots_get_detail, shots_get_debug_log, shots_compare, profiles_list, profiles_get_active, profiles_get_detail, profiles_get_params, profiles_get_auto_load, settings_get, dialing_get_context |
 | `control` | 1 (Control) | machine_wake, machine_sleep, machine_start_espresso, machine_start_steam, machine_start_hot_water, machine_start_flush, machine_stop, machine_skip_frame, shots_update, backup_now, mqtt_connect, mqtt_disconnect, mqtt_publish_discovery, devices_connect_de1, devices_disconnect_scale |
 | `settings` | 2 (Full) | profiles_set_active, profiles_edit_params, profiles_save, profiles_delete, profiles_create, shots_delete, settings_set, reset_saw_learning, clear_flow_calibration, apply_theme |
 
@@ -189,6 +189,9 @@ This avoids holding HTTP connections and works naturally with the conversational
 | `profiles_save` | Save the current (modified) profile to disk. Without this, edits are active on the machine but lost if another profile is loaded. Optionally provide filename + title for Save As. | settings |
 | `profiles_delete` | Delete a user/downloaded profile. For built-in profiles, removes local overrides and reverts to the original built-in version. | settings |
 | `profiles_create` | Create a new blank profile with a given editor type (dflow, aflow, pressure, flow, advanced) and title. Uses the same creation functions as the QML UI. | settings |
+| `profiles_get_auto_load` | Get the configured auto-load profile filename, title, and revert-minutes. Returns `filename: ""` and the current `revertMinutes` when no auto-load is set. | read |
+| `profiles_set_auto_load` | Pin a profile as the auto-load target (reloads on app start, DE1 wake, and after N idle minutes on the Idle page). Validates filename existence + Selected-list membership. Accepts optional `revertMinutes` (0..60). | settings |
+| `profiles_clear_auto_load` | Disable auto-load by clearing the pinned filename. Preserves the configured `revertMinutes`. | settings |
 
 ### Settings
 | Tool | Description | Category |

--- a/docs/CLAUDE_MD/RECIPE_PROFILES.md
+++ b/docs/CLAUDE_MD/RECIPE_PROFILES.md
@@ -565,6 +565,27 @@ Decenza and de1app share the same JSON profile format. The writer (`toJson()`) o
 - **Profile comparison/sync**: Use the `profile_sync` C++ tool (built with the main project, no extra flags). `profile_sync <de1app_profiles_dir> <builtin_profiles_dir>` compares TCL sources against built-in JSONs. Pass `de1plus/profiles/` as the first arg — the tool also scans `de1plus/plugins/*/profiles/` and a plugin copy overrides a base copy with the same output filename (canonical source wins, e.g. the 9-frame `A_Flow` plugin profiles beat the stale 6-frame copies in `de1plus/profiles/`). Simple profiles (`settings_2a`/`settings_2b`) ship with `"steps": []` and have their frames regenerated in-memory before comparison so the equality check is like-for-like. Add `--sync` to overwrite stale JSONs and create missing ones (**modifies `resources/profiles/` in-place** — review changes before committing).
 - **Profile import test**: Run `ctest -R tst_tclimport` (requires `-DBUILD_TESTS=ON`). The `compareWithBuiltin` test loads all TCL files from `tests/data/de1app_profiles/` through the C++ parser and verifies they match their built-in JSON counterparts field-by-field.
 
+## Auto-Load
+
+Decenza can pin a single profile to be reloaded automatically on three triggers:
+
+1. **App startup** — fires once after `ProfileManager` is initialised.
+2. **DE1 wake from sleep** — `DE1Device.state` transitions `Sleep → Idle`.
+3. **N-minute idle on the Idle page** — controlled by `Settings.app.autoLoadRevertMinutes` (0 disables this trigger only; startup + wake still fire). Touch input, phase changes, and navigating off the Idle page all reset the countdown.
+
+State lives on two `SettingsApp` properties:
+- `autoLoadProfileFilename` (default `""`) — empty = feature off.
+- `autoLoadRevertMinutes` (default `5`, clamped 0..60) — preserved across enable/disable cycles.
+
+**Eligibility**: only profiles currently in the Selected list (`selectedBuiltInProfiles` ∪ user profiles not in `hiddenProfiles`) can be the auto-load. If the pinned profile is deleted, hidden, or de-selected, the setting is cleared eagerly (in `SettingsApp::addHiddenProfile` / `removeSelectedBuiltInProfile` / `ProfileManager::deleteProfile`) and at trigger time (`ProfileManager::loadAutoLoadProfileIfNeeded()`), with `autoLoadStaleCleared` emitted so the UI can toast.
+
+**UI** lives entirely on `ProfileSelectorPage`:
+- A pin icon on the auto-load row (next to the title, beside the AI-knowledge sparkle).
+- A contextual overflow MenuItem labelled `Set Auto-Load` / `Disable Auto-Load`, visible only when the row is in the Selected list.
+- A status strip above the view filter showing the pinned title, the revert-minutes `ValueInput` (0 renders as "Never"), and a clear button. The strip is the only place `autoLoadRevertMinutes` can be tuned.
+
+**MCP**: three tools — `profiles_get_auto_load` (read), `profiles_set_auto_load` (settings), `profiles_clear_auto_load` (settings). See `docs/CLAUDE_MD/MCP_SERVER.md`.
+
 ## References
 
 - [D-Flow GitHub Repository](https://github.com/Damian-AU/D_Flow_Espresso_Profile)

--- a/docs/CLAUDE_MD/RECIPE_PROFILES.md
+++ b/docs/CLAUDE_MD/RECIPE_PROFILES.md
@@ -571,18 +571,18 @@ Decenza can pin a single profile to be reloaded automatically on three triggers:
 
 1. **App startup** — fires once after `ProfileManager` is initialised.
 2. **DE1 wake from sleep** — `DE1Device.state` transitions `Sleep → Idle`.
-3. **N-minute idle on the Idle page** — controlled by `Settings.app.autoLoadRevertMinutes` (0 disables this trigger only; startup + wake still fire). Touch input, phase changes, and navigating off the Idle page all reset the countdown.
+3. **N-minute idle on the Idle page** — controlled by `Settings.app.autoLoadRevertMinutes`. Touch input, phase changes, and navigating off the Idle page all reset the countdown.
 
 State lives on two `SettingsApp` properties:
-- `autoLoadProfileFilename` (default `""`) — empty = feature off.
-- `autoLoadRevertMinutes` (default `5`, clamped 0..60) — preserved across enable/disable cycles.
+- `autoLoadProfileFilename` (default `""`) — empty = feature off; the only disable path is clearing this.
+- `autoLoadRevertMinutes` (default `5`, clamped 1..60) — preserved across enable/disable cycles.
 
 **Eligibility**: only profiles currently in the Selected list (`selectedBuiltInProfiles` ∪ user profiles not in `hiddenProfiles`) can be the auto-load. If the pinned profile is deleted, hidden, or de-selected, the setting is cleared eagerly (in `SettingsApp::addHiddenProfile` / `removeSelectedBuiltInProfile` / `ProfileManager::deleteProfile`) and at trigger time (`ProfileManager::loadAutoLoadProfileIfNeeded()`), with `autoLoadStaleCleared` emitted so the UI can toast.
 
 **UI** lives entirely on `ProfileSelectorPage`:
 - A pin icon on the auto-load row (next to the title, beside the AI-knowledge sparkle).
 - A contextual overflow MenuItem labelled `Set Auto-Load` / `Disable Auto-Load`, visible only when the row is in the Selected list.
-- A status strip above the view filter showing the pinned title, the revert-minutes `ValueInput` (0 renders as "Never"), and a clear button. The strip is the only place `autoLoadRevertMinutes` can be tuned.
+- A compact status strip above the view filter showing the pinned title, the revert-minutes `ValueInput` (1..60), and a clear button. The strip is the only place `autoLoadRevertMinutes` can be tuned.
 
 **MCP**: three tools — `profiles_get_auto_load` (read), `profiles_set_auto_load` (settings), `profiles_clear_auto_load` (settings). See `docs/CLAUDE_MD/MCP_SERVER.md`.
 

--- a/docs/CLAUDE_MD/RECIPE_PROFILES.md
+++ b/docs/CLAUDE_MD/RECIPE_PROFILES.md
@@ -571,18 +571,18 @@ Decenza can pin a single profile to be reloaded automatically on three triggers:
 
 1. **App startup** — fires once after `ProfileManager` is initialised.
 2. **DE1 wake from sleep** — `DE1Device.state` transitions `Sleep → Idle`.
-3. **N-minute idle on the Idle page** — controlled by `Settings.app.autoLoadRevertMinutes`. Touch input, phase changes, and navigating off the Idle page all reset the countdown.
+3. **N-minute idle on the Idle page** — controlled by `Settings.app.autoLoadRevertMinutes` (`0` disables this trigger only; startup + wake-from-sleep still fire). Touch input, phase changes, and navigating off the Idle page all reset the countdown.
 
 State lives on two `SettingsApp` properties:
-- `autoLoadProfileFilename` (default `""`) — empty = feature off; the only disable path is clearing this.
-- `autoLoadRevertMinutes` (default `5`, clamped 1..60) — preserved across enable/disable cycles.
+- `autoLoadProfileFilename` (default `""`) — empty = feature entirely off.
+- `autoLoadRevertMinutes` (default `5`, clamped 0..60) — `0` disables the idle trigger only. Preserved across enable/disable cycles.
 
 **Eligibility**: only profiles currently in the Selected list (`selectedBuiltInProfiles` ∪ user profiles not in `hiddenProfiles`) can be the auto-load. If the pinned profile is deleted, hidden, or de-selected, the setting is cleared eagerly (in `SettingsApp::addHiddenProfile` / `removeSelectedBuiltInProfile` / `ProfileManager::deleteProfile`) and at trigger time (`ProfileManager::loadAutoLoadProfileIfNeeded()`), with `autoLoadStaleCleared` emitted so the UI can toast.
 
 **UI** lives entirely on `ProfileSelectorPage`:
 - A pin icon on the auto-load row (next to the title, beside the AI-knowledge sparkle).
 - A contextual overflow MenuItem labelled `Set Auto-Load` / `Disable Auto-Load`, visible only when the row is in the Selected list.
-- A compact status strip above the view filter showing the pinned title, the revert-minutes `ValueInput` (1..60), and a clear button. The strip is the only place `autoLoadRevertMinutes` can be tuned.
+- A compact status strip above the view filter showing the pinned title, the revert-minutes `ValueInput` (0..60, where `0` renders as "off"), and a clear button. The strip is the only place `autoLoadRevertMinutes` can be tuned.
 
 **MCP**: three tools — `profiles_get_auto_load` (read), `profiles_set_auto_load` (settings), `profiles_clear_auto_load` (settings). See `docs/CLAUDE_MD/MCP_SERVER.md`.
 

--- a/openspec/changes/add-profile-auto-load/design.md
+++ b/openspec/changes/add-profile-auto-load/design.md
@@ -1,0 +1,90 @@
+# Design: Profile Auto-Load
+
+## Why this shape
+
+DSx2's auto-load mechanism is *simple on purpose* — one filename string, one state-change handler. The user-facing model is "pin a profile, it's the one we come home to." We mirror that simplicity:
+
+- **One string of state** (`autoLoadProfileFilename`) plus one tunable (`autoLoadRevertMinutes`). No list, no per-time-of-day scheduling, no enable bool. Empty filename = feature off.
+- **One entry point** (`loadAutoLoadProfileIfNeeded()`) called from three trigger sites. All policy (no-op when already active, clear-and-toast when stale, no-op when empty) lives in the entry point so trigger sites stay one-line.
+- **One canonical UI location**. The strip on `ProfileSelectorPage` is the only place the revert minutes lives — same page where the auto-load profile is pinned, same page where it's visualised. No "settings tab" split.
+
+## Trigger trio: why these three, why no more
+
+| Trigger | Why include |
+|---|---|
+| App startup | Cold-launch must respect the pinned default. If the app was killed mid-experiment, the user's intent on next launch is the auto-load, not whatever was last active. |
+| DE1 wake from sleep (`Sleep → Idle`) | Matches DSx2's only handler. Captures the "left the machine alone overnight on a one-off profile" case. The DE1's own sleep timeout is the implicit "amount of time" upper bound. |
+| N minutes idle on the Idle page | DSx2 has nothing equivalent and we wanted it. Catches the case where the DE1 hasn't slept (high sleep timeout, or stay-awake) but the user has walked away mid-experiment. `0` disables this trigger so users who want pure DSx2 semantics can opt out. |
+
+What's deliberately **not** a trigger:
+
+- **Per-shot completion** — different feature (transient-profile flow). Bolting it on muddies the mental model.
+- **Screensaver entry/exit** — wake-from-sleep already covers the post-screensaver case.
+- **Phase changes other than Sleep→Idle** — would fire on Espresso→Idle (after every shot), which is the per-shot revert above by another name.
+
+## The N-minutes timer — why it's not a CLAUDE.md violation
+
+`CLAUDE.md` forbids timers as guards/workarounds. The N-minutes timer here is a **UI behavior timer** ("after N minutes of inactivity, do X"), exactly the family the rule explicitly allows. Precedents already in the codebase:
+
+- `qml/main.qml:386` — `sleepCountdownTimer` decrements `sleepCountdownNormal` once per minute and triggers `triggerAutoSleep()` at zero. Same shape, same family.
+- `qml/pages/PostShotReviewPage.qml:71` — auto-close after configured timeout.
+
+We **reuse** the existing `sleepCountdownTimer`'s tick rather than adding a second `QTimer`. The auto-load countdown is a sibling integer on `root`, decremented in the same `onTriggered` handler. Zero new timers, zero new polling — just one more integer to decrement per minute.
+
+## Why "Selected list" eligibility
+
+The Selected list is the user's canonical "profiles I care about." Built-in profiles enter it through `selectedBuiltInProfiles`; user profiles enter it by virtue of not being in `hiddenProfiles`. If we let the user pin any profile in the system (including hidden ones, or built-ins they've explicitly de-selected), we'd be pinning a profile they've already told us they don't want to see — and the strip would happily render a profile title from a row that no longer appears in the selector. Tying eligibility to "currently in the Selected list" closes that loop:
+
+- The menu item only appears on Selected-list rows.
+- The fire-time check resolves the pinned filename against the Selected list and gracefully clears + toasts if it's no longer there.
+- A user who hides their auto-load profile, intentionally or accidentally, gets an explicit message rather than silent surprise on the next wake.
+
+## Stale-target handling
+
+Five ways the pinned profile can become stale:
+
+1. **Deleted entirely** (`ProfileManager.deleteProfile`) — file gone.
+2. **Hidden** (user-side: `addHiddenProfile`) — file present but no longer in Selected.
+3. **Built-in deselected** (`removeSelectedBuiltInProfile`) — file present but no longer in Selected.
+4. **Filename changed** — today, filenames are derived from titles at create-time; renames don't move the file. So this is currently a non-case. Documented here so future filename-rename work knows the contract.
+5. **Settings-bundle imported from another device that doesn't have the profile** — the imported `autoLoadProfileFilename` refers to a file that doesn't exist locally.
+
+All five collapse to one check at the entry point: *if `autoLoadProfileFilename` doesn't resolve to a profile in the Selected list, clear it and toast.* No proactive scrubbing on delete/hide is needed (though we *could* clear it eagerly in `setHiddenProfiles` / `removeSelectedBuiltInProfile` / `deleteProfile` to keep the strip from briefly showing a profile that was just hidden — see Tasks §4 for that nice-to-have).
+
+## DE1 previous-state tracking
+
+`DE1Device` exposes `state` and emits `stateChanged()`, but does not expose `previousState`. Two options:
+
+1. **Add `previousState` to `DE1Device`** — a real Q_PROPERTY, persists across QML listeners. Slightly more disruptive (touches a core class for one feature) but reusable.
+2. **Track previous state in QML** — a local property on `root` in `qml/main.qml` that the auto-load `Connections` block updates after each `stateChanged()` call.
+
+Going with option 2 for this change. Single consumer, lives next to the other state-change handlers in `main.qml`, no core API change. If a future change wants the same data, promote it to `DE1Device` at that point.
+
+## Activity-reset hook for the idle countdown
+
+The countdown needs to reset on any user interaction so leaving the Idle page open while reading specs doesn't silently swap your profile. Sources of "user activity":
+
+- `MachineState.phaseChanged` — already resets `sleepCountdownNormal`. Covers explicit user actions that change phase (starting a shot, etc.).
+- Touch/mouse input on the page — not currently hooked at the root level. The screensaver inactivity detection must hook this somewhere, since the screensaver triggers on no-input.
+
+Tasks §3 finds and reuses the screensaver's existing inactivity-detection signal. If none exists at a usable layer, we add a thin top-level `Pointer Handler` in `main.qml` that emits an `userActivity` signal, and both the existing sleep countdown and the new auto-load countdown listen to it. (Cost: ~5 lines.)
+
+## MCP surface — three tools, not one
+
+Tempting to consolidate into a single `profiles_set_auto_load(filename?, revertMinutes?)` with empty `filename` meaning "clear." Rejected because:
+
+- The advisor needs **clear semantic separation** between "set this profile as auto-load" and "disable auto-load." Overloading one tool with a magic-empty-string convention makes the tool description ambiguous and invites prompt drift.
+- `profiles_get_auto_load` is a separate read with no write side, which is a clean access-level boundary (`read` vs `settings`).
+
+Three tools, clear access boundaries, clear single-responsibility.
+
+## Decisions left explicit (so reviewers don't re-litigate them)
+
+- **Single auto-load profile globally.** No multi-pin, no per-context auto-load.
+- **`autoLoadRevertMinutes` default = 5.** Mirrors what the user asked for; tunable per-user.
+- **`autoLoadRevertMinutes = 0` disables the inactivity trigger only.** Startup and wake-from-sleep still fire. There is no single "disable feature" toggle — clearing the filename is the disable.
+- **Strip is the only home for `autoLoadRevertMinutes`.** No settings-tab entry. Settings-search index gets a single hit that lands users on the page.
+- **Built-in profiles eligible.** Same Selected-list gate as user profiles.
+- **Pin icon, not "AUTO" pill, not row stripe.** Matches the existing sparkle pattern; language-independent.
+- **Menu item is contextual** ("Set" / "Disable" on the same MenuItem), not two separate items. Keeps the menu short on every other row.
+- **No "Are you sure?" prompts.** Set/clear is a one-tap action; the strip and the row icon make state obvious; toast confirms.

--- a/openspec/changes/add-profile-auto-load/proposal.md
+++ b/openspec/changes/add-profile-auto-load/proposal.md
@@ -1,0 +1,93 @@
+# Change: Auto-load a chosen profile on app start, DE1 wake, and prolonged idle
+
+## Why
+
+A common DSx2 workflow is: pick a "default" profile (the one you want to live on most days), occasionally swap to an experimental one for a single shot, and have the machine quietly return you to the default. DSx2 implements this with a single favorite-slot marker plus a `Sleep → Idle` state-change handler that reloads the marked profile on every DE1 wake. The setup is one long-press on a favorite slot's auto-load label; from that point on, the machine "comes home" to that profile whenever it wakes.
+
+Decenza has no equivalent. Today, switching from an experimental profile back to your default is a manual three-tap walk: ProfileSelector → search → tap. Worse, if the machine sleeps overnight on a one-off profile, you wake it tomorrow morning to that same one-off profile — no auto-revert at all.
+
+This change adds the DSx2-style "pin one profile as auto-load" behavior, with three concrete triggers (app startup, DE1 wake-from-sleep, and N-minutes-idle on the Idle page) and a small surface area: one menu item in the ProfileSelector overflow, one pin icon next to the title of the chosen profile, one optional status strip at the top of the page when an auto-load is set, and three MCP tools so the AI advisor (and any remote MCP client) can set/clear/inspect the auto-load.
+
+## What Changes
+
+### Settings
+
+- **NEW** `Settings.app.autoLoadProfileFilename` (`QString`, default `""`) — filename of the pinned profile, or empty when no auto-load is configured. Single-valued: setting a new filename replaces the previous one. Cleared automatically if the referenced profile is deleted or moved out of the Selected list at fire-time.
+- **NEW** `Settings.app.autoLoadRevertMinutes` (`int`, default `5`) — minutes of inactivity on the Idle page before the auto-load profile is restored. `0` disables the inactivity trigger without affecting startup or wake-from-sleep triggers.
+- Both properties sit in the existing `// Profile management` block in `src/core/settings_app.h`, alongside `favoriteProfiles`, `hiddenProfiles`, and `currentProfile`. Both round-trip through `SettingsSerializer` so backups capture them.
+
+### Triggers
+
+A new tiny controller (or a method on `ProfileManager`) exposes a single entry point `loadAutoLoadProfileIfNeeded()` that:
+
+1. Returns immediately if `autoLoadProfileFilename` is empty.
+2. Clears the setting + emits a toast `"Auto-load profile is no longer available"` if the filename does not resolve to a profile currently in the Selected list.
+3. Returns without loading if the auto-load filename is already the active profile (no-op when already loaded).
+4. Otherwise calls `ProfileManager::loadProfile(filename)`.
+
+The entry point is invoked from three places, all in `qml/main.qml`:
+
+- **Trigger 1 — App startup**: fired once after `ProfileManager` and the Settings facade are initialised (alongside the existing post-init wiring near the top of `Component.onCompleted`).
+- **Trigger 2 — DE1 wake from sleep**: a `Connections { target: DE1Device }` watches `onStateChanged` and fires the entry point when the previous state was `Sleep` and the current state is `Idle`. Previous-state tracking is added as a local QML property since `DE1Device` does not expose it today.
+- **Trigger 3 — N-minutes idle on Idle page**: a new countdown property `autoLoadIdleCountdown` ticks on the existing 1-minute `sleepCountdownTimer`'s `onTriggered` (no second timer needed). The countdown is reset to `Settings.app.autoLoadRevertMinutes` whenever the current page changes, any user input is registered (touch/mouse — wired off the same activity hook the existing screensaver inactivity uses), or `operationActive` becomes true. When the countdown hits zero on the Idle page (`pageStack.currentItem.objectName === "idlePage"`), the entry point fires. When `autoLoadRevertMinutes` is `0`, this trigger is disabled entirely and the countdown does not run.
+
+### UI: ProfileSelectorPage
+
+- **NEW** Menu item in the existing overflow Menu (`qml/pages/ProfileSelectorPage.qml` line ~432) labelled `"Set Auto-Load"` when the row is not the current auto-load, and `"Disable Auto-Load"` when it is. Single MenuItem whose `text` and `onTriggered` switch on the `isAutoLoad` row property. The item is visible only for rows in the Selected list (all profile types: D-Flow, A-Flow, Pressure, Flow; built-in or user). It sits between "Copy Profile" and the destructive-actions separator.
+- **NEW** A `qrc:/icons/pin.svg` image placed beside the title in the same layout slot as the existing sparkle icon (line ~296), visible only when `modelData.name === Settings.app.autoLoadProfileFilename`. Colored `Theme.primaryColor` via `MultiEffect`, sized 14×14, with `Accessible.name: "Auto-load profile"`.
+- **NEW** A status strip at the top of the page (above `viewFilter`), visible only when `Settings.app.autoLoadProfileFilename` is non-empty AND resolves to a Selected profile. Shows: a pin icon, the resolved profile title, the revert-minutes `ValueInput` (1..60, step 1, "0" rendered as "Never"), and an inline `[×]` button that calls `Settings.app.setAutoLoadProfileFilename("")`. The strip is the only place the user can edit `autoLoadRevertMinutes`; it does not appear in any settings tab.
+
+### MCP
+
+Three new tools registered in `src/mcp/mcptools_profiles.cpp` (reads) and `src/mcp/mcptools_write.cpp` (writes), following existing field-naming conventions (units in names, no Unix timestamps, human-readable values):
+
+- **NEW** `profiles_get_auto_load` (read): no arguments. Returns `{ filename, title, revertMinutes }` when an auto-load is set; returns `{ filename: "", revertMinutes }` when none is set. `revertMinutes` is always included so callers can inspect the configured timeout regardless of whether an auto-load is currently pinned.
+- **NEW** `profiles_set_auto_load` (settings): args `{ filename: string, revertMinutes?: int }`. Validates that the filename exists and is in the Selected list. If `revertMinutes` is supplied, updates that too. Returns `{ success, filename, title, revertMinutes }` or an `error` field on failure. Replaces any prior auto-load.
+- **NEW** `profiles_clear_auto_load` (settings): no required args. Sets `autoLoadProfileFilename` to empty. Returns `{ success: true }`. Does not modify `revertMinutes` (the timeout setting is preserved across enable/disable cycles).
+
+### Asset
+
+- **NEW** `resources/icons/pin.svg` — line-art pin icon matching the existing icon set's stroke style. Sourced from Feather Icons "map-pin" (MIT-licensed) or hand-authored equivalent. Registered in `CMakeLists.txt` under the resource bundle alongside the existing icon list.
+
+### Translations
+
+- **NEW** `profileselector.menu.set_auto_load` → "Set Auto-Load"
+- **NEW** `profileselector.menu.disable_auto_load` → "Disable Auto-Load"
+- **NEW** `profileselector.accessible.auto_load_profile` → "Auto-load profile"
+- **NEW** `profileselector.accessible.set_auto_load` → "Set as auto-load profile"
+- **NEW** `profileselector.accessible.disable_auto_load` → "Disable auto-load"
+- **NEW** `profileselector.strip.auto_load_label` → "Auto-load:"
+- **NEW** `profileselector.strip.revert_after` → "revert after"
+- **NEW** `profileselector.strip.minutes_short` → "min"
+- **NEW** `profileselector.strip.never` → "Never"
+- **NEW** `profileselector.strip.clear_aria` → "Disable auto-load"
+- **NEW** `profileselector.toast.auto_load_set` → "Auto-load set to {0}"
+- **NEW** `profileselector.toast.auto_load_disabled` → "Auto-load disabled"
+- **NEW** `profileselector.toast.auto_load_stale` → "Auto-load profile is no longer available"
+
+### NOT in scope
+
+- **"Revert to auto-load after every shot"**. A useful adjacent feature, but a separate behavior with different semantics (transient-profile flow vs. default-profile flow). Track separately if requested; do not bundle.
+- **Multiple auto-load profiles bound to time-of-day / day-of-week** (e.g., decaf at night). Adds a list, a scheduler, and a UI layer for no proven demand. Single-value is the DSx2 model and the simplest mental model.
+- **`ScreensaverPage` as a trigger surface for the N-minutes-idle trigger**. The wake-from-sleep trigger already covers the post-screensaver case; double-counting adds no value.
+- **A Settings-tab home for `autoLoadRevertMinutes`**. The strip is the only place to tune it. If real-world feedback later asks for a settings-search-discoverable entry, add a one-line breadcrumb under `SettingsScreensaverTab` then.
+- **Auto-load while built-in profile is hidden but selected via favorites**. Eligibility is "currently in the Selected list" — the canonical, in-UI definition of "a profile the user has chosen to keep." If a user hides their auto-load profile, the next firing clears it gracefully.
+
+## Impact
+
+- Affected specs: `profile-auto-load` (NEW capability), `mcp-server` (MCP surface gains three tools — out-of-band addition to the existing capability spec).
+- Affected code:
+  - `src/core/settings_app.{h,cpp}` — two new properties + getters/setters/signals.
+  - `src/core/settingsserializer.cpp` — include both keys in profile-bundle export/import.
+  - `src/profiles/profilemanager.{h,cpp}` — `loadAutoLoadProfileIfNeeded()` entry point and selected-list eligibility helper.
+  - `qml/main.qml` — startup invocation, Sleep→Idle wiring, idle-countdown integration.
+  - `qml/pages/ProfileSelectorPage.qml` — overflow MenuItem, row pin icon, top status strip, `isAutoLoad` row property.
+  - `qml/components/SettingsSearchIndex.js` — index a single search hit for "auto-load" that lands the user on `ProfileSelectorPage` (cross-tab discoverability).
+  - `src/mcp/mcptools_profiles.cpp` — `profiles_get_auto_load`.
+  - `src/mcp/mcptools_write.cpp` — `profiles_set_auto_load`, `profiles_clear_auto_load`.
+  - `resources/icons/pin.svg` — new asset.
+  - `CMakeLists.txt` — register `pin.svg`.
+  - `tests/tst_profilemanager.cpp` (or new file) — entry-point behavior tests.
+  - `tests/tst_settings.cpp` — round-trip tests for the two new keys.
+- Behavior change: users who set an auto-load profile will see Decenza load it on every cold start, on every DE1 wake from sleep, and after `autoLoadRevertMinutes` of inactivity on the Idle page. Users who never set one see no change. Settings backups roundtrip the auto-load filename and revert minutes.
+- Performance: zero new timers (reuses the existing 1-minute `sleepCountdownTimer` tick). Profile load is the existing `ProfileManager::loadProfile` path with a no-op guard for "already active," so a re-fire while the auto-load profile is loaded costs one filename comparison.

--- a/openspec/changes/add-profile-auto-load/specs/profile-auto-load/spec.md
+++ b/openspec/changes/add-profile-auto-load/specs/profile-auto-load/spec.md
@@ -1,0 +1,215 @@
+# Spec Delta: profile-auto-load
+
+## ADDED Requirements
+
+### Requirement: Auto-load profile setting
+
+The system SHALL persist a single, optional auto-load profile filename and a configurable revert-timeout in minutes.
+
+#### Scenario: Default state
+- **WHEN** the user has never configured auto-load
+- **THEN** `Settings.app.autoLoadProfileFilename` is `""` and `Settings.app.autoLoadRevertMinutes` is `5`
+
+#### Scenario: Setting a profile replaces any prior auto-load
+- **WHEN** an auto-load is already configured for profile A and the user sets the auto-load to profile B
+- **THEN** `Settings.app.autoLoadProfileFilename` equals B's filename and the previous selection on A is no longer in effect
+
+#### Scenario: Clearing the auto-load preserves the timeout
+- **WHEN** the user clears the auto-load profile
+- **THEN** `Settings.app.autoLoadProfileFilename` is `""` AND `Settings.app.autoLoadRevertMinutes` retains its prior value
+
+#### Scenario: Revert minutes is clamped
+- **WHEN** the system receives a value below 0 or above 60 for `autoLoadRevertMinutes`
+- **THEN** the value is clamped into 0..60 and the clamped value is persisted
+
+#### Scenario: Both keys round-trip through settings backup
+- **WHEN** the user exports a settings bundle while an auto-load is configured and imports it on another device
+- **THEN** the imported device's `autoLoadProfileFilename` and `autoLoadRevertMinutes` match the exported values
+
+### Requirement: Auto-load entry point
+
+`ProfileManager` SHALL expose a single entry point that decides whether to load the configured auto-load profile and handles stale-target cleanup.
+
+#### Scenario: No-op when no auto-load configured
+- **WHEN** `loadAutoLoadProfileIfNeeded` is called AND `autoLoadProfileFilename` is `""`
+- **THEN** the system does nothing and the active profile is unchanged
+
+#### Scenario: No-op when the auto-load is already active
+- **WHEN** `loadAutoLoadProfileIfNeeded` is called AND `autoLoadProfileFilename` equals the active profile filename
+- **THEN** the system does not call `loadProfile` and the active profile is unchanged
+
+#### Scenario: Stale target is cleared
+- **WHEN** `loadAutoLoadProfileIfNeeded` is called AND `autoLoadProfileFilename` does not resolve to a profile currently in the Selected list
+- **THEN** the system clears `autoLoadProfileFilename` AND emits `autoLoadStaleCleared` so the UI can show a toast
+
+#### Scenario: Successful auto-load
+- **WHEN** `loadAutoLoadProfileIfNeeded` is called AND `autoLoadProfileFilename` resolves to a Selected-list profile AND that profile is not the active profile
+- **THEN** the system calls `ProfileManager.loadProfile(autoLoadProfileFilename)`
+
+### Requirement: Trigger — app startup
+
+The system SHALL invoke the auto-load entry point once during startup, after `ProfileManager` is initialised.
+
+#### Scenario: Auto-load fires on cold launch
+- **WHEN** the app starts AND an auto-load is configured AND the active profile differs from the configured filename
+- **THEN** the configured profile is loaded as the active profile before the user interacts with the app
+
+### Requirement: Trigger — DE1 wake from sleep
+
+The system SHALL invoke the auto-load entry point on every `DE1Device` state transition from `Sleep` to `Idle`.
+
+#### Scenario: Wake from sleep reloads the auto-load
+- **WHEN** `DE1Device.state` transitions from `Sleep` to `Idle` AND an auto-load is configured AND it differs from the active profile
+- **THEN** the configured profile is loaded
+
+#### Scenario: Other state transitions do not trigger
+- **WHEN** `DE1Device.state` transitions between any pair of states other than `Sleep → Idle`
+- **THEN** the auto-load entry point is not invoked from the state-change path
+
+### Requirement: Trigger — inactivity on the Idle page
+
+The system SHALL invoke the auto-load entry point after `autoLoadRevertMinutes` of continuous inactivity while the Idle page is the currently displayed page.
+
+#### Scenario: Idle timeout reloads the auto-load
+- **WHEN** the current page is `idlePage` AND no user activity has been registered for `autoLoadRevertMinutes` minutes AND no machine operation is active AND an auto-load is configured
+- **THEN** the configured profile is loaded AND the inactivity countdown resets
+
+#### Scenario: User activity resets the countdown
+- **WHEN** the user provides input (touch, mouse, phase change) while on the Idle page
+- **THEN** the inactivity countdown resets to `autoLoadRevertMinutes`
+
+#### Scenario: Leaving the Idle page suspends the countdown
+- **WHEN** the user navigates away from `idlePage`
+- **THEN** the inactivity countdown does not decrement until the user returns to `idlePage`
+
+#### Scenario: Zero disables the inactivity trigger
+- **WHEN** `autoLoadRevertMinutes` is `0`
+- **THEN** the inactivity trigger is disabled AND the app-startup and wake-from-sleep triggers continue to function
+
+#### Scenario: Active machine operation suspends the countdown
+- **WHEN** the machine is in an active phase (Pouring, Steaming, Preinfusion, Ending, EspressoPreheating, HotWater, Flushing, Descaling, Cleaning) OR firmware is being flashed
+- **THEN** the inactivity countdown does not decrement
+
+### Requirement: ProfileSelector overflow menu item
+
+The overflow menu on `ProfileSelectorPage` rows SHALL expose a contextual auto-load action.
+
+#### Scenario: Menu item appears for Selected-list profiles
+- **WHEN** the user opens the overflow menu for a row whose profile is in the Selected list
+- **THEN** the menu shows an item between "Copy Profile" and the destructive-actions separator
+
+#### Scenario: Label and action reflect current state
+- **WHEN** the row's profile is the current auto-load
+- **THEN** the menu item is labelled "Disable Auto-Load" AND activating it clears `autoLoadProfileFilename`
+
+#### Scenario: Setting on a different row replaces the prior auto-load
+- **WHEN** the user activates "Set Auto-Load" on a row whose profile is not the current auto-load
+- **THEN** `autoLoadProfileFilename` is set to that row's filename AND any prior auto-load is no longer marked
+
+#### Scenario: Menu item is hidden for non-Selected profiles
+- **WHEN** the user opens the overflow menu for a row whose profile is not in the Selected list (e.g. browsing Built-In or User views without selection)
+- **THEN** the menu does not show an auto-load item
+
+### Requirement: Auto-load row marker
+
+The selector row representing the current auto-load profile SHALL show a visible marker so the user can identify it at a glance.
+
+#### Scenario: Pin icon visible on the auto-load row
+- **WHEN** the row's profile filename equals `autoLoadProfileFilename`
+- **THEN** the `pin.svg` icon is visible beside the profile title, colored `Theme.primaryColor`, sized 14×14
+
+#### Scenario: Pin icon has an accessible name
+- **WHEN** an accessibility screen reader focuses the pin icon
+- **THEN** the reader announces "Auto-load profile"
+
+#### Scenario: Marker hidden for non-auto-load rows
+- **WHEN** the row's filename does not equal `autoLoadProfileFilename`
+- **THEN** the pin icon is not rendered
+
+### Requirement: ProfileSelector status strip
+
+A strip at the top of `ProfileSelectorPage` SHALL surface the configured auto-load and allow tuning the revert minutes, visible only when an auto-load is configured and resolves to a Selected-list profile.
+
+#### Scenario: Strip visible when configured
+- **WHEN** `autoLoadProfileFilename` is non-empty AND resolves to a Selected-list profile
+- **THEN** the strip appears above the view-filter row showing: pin icon, "Auto-load:" label, profile title, "revert after" label, a numeric input for minutes, and a clear button
+
+#### Scenario: Strip hidden when no auto-load is set
+- **WHEN** `autoLoadProfileFilename` is `""`
+- **THEN** the strip is not rendered AND the page layout matches the pre-feature appearance
+
+#### Scenario: Editing revert minutes from the strip
+- **WHEN** the user changes the value in the strip's numeric input
+- **THEN** `Settings.app.autoLoadRevertMinutes` is updated AND any in-progress inactivity countdown is reset to the new value
+
+#### Scenario: "Never" rendering at zero
+- **WHEN** `autoLoadRevertMinutes` is `0`
+- **THEN** the strip displays "Never" instead of "0 min"
+
+#### Scenario: Clear button disables auto-load
+- **WHEN** the user activates the strip's clear button
+- **THEN** `autoLoadProfileFilename` is cleared AND a toast confirms "Auto-load disabled" AND the strip disappears
+
+### Requirement: Eligibility limited to Selected-list profiles
+
+The system SHALL enforce that only profiles in the Selected list can be assigned as auto-load, and SHALL gracefully recover when a previously-pinned profile leaves the Selected list.
+
+#### Scenario: Auto-load is cleared when its profile is hidden
+- **WHEN** `addHiddenProfile` is called with the current auto-load filename
+- **THEN** `autoLoadProfileFilename` is cleared so the strip disappears immediately
+
+#### Scenario: Auto-load is cleared when its built-in profile is de-selected
+- **WHEN** `removeSelectedBuiltInProfile` is called with the current auto-load filename
+- **THEN** `autoLoadProfileFilename` is cleared
+
+#### Scenario: Auto-load is cleared when its profile is deleted
+- **WHEN** `deleteProfile` is called with the current auto-load filename
+- **THEN** `autoLoadProfileFilename` is cleared
+
+#### Scenario: Toast on stale clear at trigger time
+- **WHEN** a trigger fires AND the auto-load filename no longer resolves to a Selected-list profile
+- **THEN** the user sees a toast "Auto-load profile is no longer available" AND the setting is cleared
+
+### Requirement: MCP — get auto-load
+
+The MCP server SHALL expose a `profiles_get_auto_load` tool returning the current auto-load configuration with a read access level.
+
+#### Scenario: Configured auto-load is reported
+- **WHEN** an MCP client calls `profiles_get_auto_load` AND an auto-load is configured
+- **THEN** the response includes `filename`, `title`, and `revertMinutes`
+
+#### Scenario: No auto-load configured
+- **WHEN** an MCP client calls `profiles_get_auto_load` AND `autoLoadProfileFilename` is `""`
+- **THEN** the response includes `filename: ""` AND `revertMinutes` (the current configured timeout)
+
+### Requirement: MCP — set auto-load
+
+The MCP server SHALL expose a `profiles_set_auto_load` tool with a settings access level that pins a profile as the auto-load and optionally updates the revert minutes.
+
+#### Scenario: Successful set
+- **WHEN** the client calls `profiles_set_auto_load` with a `filename` that exists and is in the Selected list
+- **THEN** the response is `{ success: true, filename, title, revertMinutes }` AND the setting is persisted on the GUI thread
+
+#### Scenario: Filename missing
+- **WHEN** the client calls `profiles_set_auto_load` with an empty or absent `filename`
+- **THEN** the response is `{ error: "filename is required" }` AND no state changes
+
+#### Scenario: Filename not found
+- **WHEN** the client calls `profiles_set_auto_load` with a `filename` that does not exist
+- **THEN** the response is `{ error: "Profile not found: <filename>" }` AND no state changes
+
+#### Scenario: Filename not in Selected list
+- **WHEN** the client calls `profiles_set_auto_load` with a `filename` that exists but is not in the Selected list
+- **THEN** the response is `{ error: "Profile is not in the Selected list" }` AND no state changes
+
+#### Scenario: Optional revert minutes updates both keys
+- **WHEN** the client supplies `revertMinutes` alongside `filename`
+- **THEN** both `autoLoadProfileFilename` and `autoLoadRevertMinutes` (clamped to 0..60) are updated
+
+### Requirement: MCP — clear auto-load
+
+The MCP server SHALL expose a `profiles_clear_auto_load` tool with a settings access level that disables the auto-load without affecting the revert timeout.
+
+#### Scenario: Successful clear
+- **WHEN** the client calls `profiles_clear_auto_load`
+- **THEN** `autoLoadProfileFilename` is set to `""` AND `autoLoadRevertMinutes` is unchanged AND the response is `{ success: true }`

--- a/openspec/changes/add-profile-auto-load/tasks.md
+++ b/openspec/changes/add-profile-auto-load/tasks.md
@@ -1,0 +1,83 @@
+# Tasks
+
+## 1. Settings
+
+- [x] 1.1 Add `Q_PROPERTY(QString autoLoadProfileFilename …)` to `src/core/settings_app.h` inside the existing `// Profile management` block (after `currentProfile`). Default `""`.
+- [x] 1.2 Add `Q_PROPERTY(int autoLoadRevertMinutes …)` immediately after. Default `5`. Range enforcement (0..60) lives in the setter — clamp out-of-range values rather than rejecting.
+- [x] 1.3 Implement getters/setters/signals in `src/core/settings_app.cpp` following the pattern of `currentProfile` (QSettings read/write, signal on actual change).
+- [x] 1.4 Add both keys to the profile-bundle export in `src/core/settingsserializer.cpp` near the existing favorites block (~L148).
+- [x] 1.5 Add both keys to the import path (~L543) — if missing from imported bundle, leave existing local values untouched.
+
+## 2. ProfileManager entry point
+
+- [x] 2.1 Add `bool ProfileManager::isProfileInSelectedList(const QString &filename) const` — checks Selected list membership for the given filename across both built-in and user paths. Used by both the auto-load entry point and by `ProfileSelectorPage`'s row property.
+- [x] 2.2 Add `Q_INVOKABLE void ProfileManager::loadAutoLoadProfileIfNeeded()` with the four-step policy:
+    1. Return if `Settings.app.autoLoadProfileFilename` is empty.
+    2. If the filename does not resolve via `isProfileInSelectedList`, call `setAutoLoadProfileFilename("")` and emit a signal/toast hook for "stale auto-load cleared".
+    3. Return if the filename equals the active profile (`baseProfileName()`).
+    4. Otherwise call `loadProfile(filename)`.
+- [x] 2.3 Add `void ProfileManager::autoLoadStaleCleared()` signal (no args) used by `qml/main.qml` to show the stale-cleared toast.
+
+## 3. Triggers in main.qml
+
+- [x] 3.1 Add `property int autoLoadIdleCountdown: -1` to `root` in `qml/main.qml`. Initialized to `Settings.app.autoLoadRevertMinutes` whenever `autoLoadRevertMinutes` is non-zero AND `autoLoadProfileFilename` is non-empty AND the current page is `idlePage`; reset to `-1` otherwise.
+- [x] 3.2 In the existing `sleepCountdownTimer.onTriggered` (line ~391), add: if `autoLoadIdleCountdown > 0` decrement; if it hits 0 and `pageStack.currentItem.objectName === "idlePage"`, call `ProfileManager.loadAutoLoadProfileIfNeeded()` and reset the countdown.
+- [x] 3.3 Add `Connections { target: DE1Device }` with `onStateChanged` tracking a local `previousDe1State` property. When previous is `Sleep` (0) and current is `Idle` (1), call `ProfileManager.loadAutoLoadProfileIfNeeded()`. (Spec said Idle = 1 but the actual `DE1::State` enum has `Sleep = 0x00`, `Idle = 0x02` — implementation uses the correct enum values via readonly QML constants.)
+- [x] 3.4 In `Component.onCompleted` (or the equivalent post-init sequence), after `ProfileManager` is available, call `ProfileManager.loadAutoLoadProfileIfNeeded()` once for the startup trigger.
+- [x] 3.5 Locate the existing "user activity" signal that the screensaver uses for inactivity reset. If present, wire a `Connections` block to reset `autoLoadIdleCountdown` to `Settings.app.autoLoadRevertMinutes`. If absent, add a top-level `TapHandler` (or `PointerHandler`) on the root window that emits `root.userActivity()`, then wire both the existing sleep countdown's reset path and the new auto-load countdown to it.
+- [x] 3.6 Reset the countdown to its full value on `pageStack.currentItem` changes; pause/clear when not on `idlePage`.
+- [x] 3.7 Add `Connections { target: ProfileManager; function onAutoLoadStaleCleared() { … } }` to show the toast `"Auto-load profile is no longer available"`.
+
+## 4. Eager-clear hooks (nice-to-have)
+
+- [x] 4.1 In `Settings.app.addHiddenProfile`, if the added filename equals `autoLoadProfileFilename`, clear `autoLoadProfileFilename` and emit a signal so the strip disappears immediately rather than on next trigger fire.
+- [x] 4.2 In `Settings.app.removeSelectedBuiltInProfile`, same check + clear.
+- [x] 4.3 In `ProfileManager.deleteProfile`, same check + clear. (The auto-load could legitimately point at a user profile that's being deleted.)
+
+## 5. UI — ProfileSelectorPage
+
+- [x] 5.1 Add a `readonly property bool isAutoLoad: modelData && modelData.name === Settings.app.autoLoadProfileFilename` to the row delegate in `qml/pages/ProfileSelectorPage.qml`.
+- [x] 5.2 Add the pin `Image` in the same `RowLayout` slot as the existing sparkle icon (~L296), visible only when `isAutoLoad`. 14×14, `qrc:/icons/pin.svg`, colorized to `Theme.primaryColor` via `MultiEffect`. `Accessible.name: TranslationManager.translate("profileselector.accessible.auto_load_profile", "Auto-load profile")`.
+- [x] 5.3 Add the contextual `MenuItem` in the overflow `Menu` (~L432), between the "Copy Profile" item and the `MenuSeparator` at L523. Visibility: `viewFilter.currentIndex === 0 || profileDelegate.isSelected` (Selected view or row is in the Selected list — keep parity with other Selected-view-gated items). Label and `onTriggered` both branch on `isAutoLoad`.
+- [x] 5.4 Implement the strip above `viewFilter`. Visibility: `Settings.app.autoLoadProfileFilename !== "" && ProfileManager.isProfileInSelectedList(Settings.app.autoLoadProfileFilename)`. Contents: pin icon + "Auto-load:" label + resolved profile title (look up via `ProfileManager.getProfileByFilename`) + "revert after" label + `ValueInput` bound to `Settings.app.autoLoadRevertMinutes` (0..60, step 1, `displayText` showing "Never" at 0) + a `[×]` clear button.
+- [x] 5.5 Use `Theme.surfaceColor`/`Theme.cardRadius` for the strip's background, matching the existing search bar and card styling on the page.
+- [x] 5.6 Add toasts: on set (`"Auto-load set to {title}"`), on disable (`"Auto-load disabled"`).
+- [x] 5.7 Accessibility: every interactive element in the strip and on the row needs `Accessible.role`, `Accessible.name`, `Accessible.focusable: true`, `Accessible.onPressAction`. Fix any pre-existing a11y violations encountered in `ProfileSelectorPage.qml` while in the file (per `CLAUDE.md` ACCESSIBILITY rule).
+
+## 6. Asset
+
+- [x] 6.1 Add `resources/icons/pin.svg` — Feather Icons "map-pin" (MIT) or equivalent line-art pin matching the stroke style of `star.svg` and `sparkle.svg`. 24×24 viewBox, stroke-only (no fill), `currentColor` so `MultiEffect` colorization works.
+- [x] 6.2 Register the new SVG in `CMakeLists.txt` under the resource list alongside other icons. (Registered in `resources/resources.qrc`, which CMakeLists.txt loads at line 527 via `qt_add_resources`.)
+- [ ] 6.3 Verify the icon renders on Android, macOS, Windows builds (check existing icon-cache caveats — memory `feedback_icon_caching.md`). _Manual; deferred to PR test plan._
+
+## 7. Translations
+
+- [x] 7.1 Add all keys listed under "Translations" in `proposal.md` to the English source file. Other locales remain untranslated and fall back to the English text via `TranslationManager.translate(key, fallback)`. (Decenza's TranslationManager auto-registers keys via the in-line `translate(key, fallback)` calls on first invocation — no separate source file edit is required. All keys from the proposal are emitted by the QML/main.qml/ProfileSelectorPage changes above.)
+
+## 8. SettingsSearch breadcrumb
+
+- [x] 8.1 Add a single entry to `qml/components/SettingsSearchIndex.js` keyed on "auto-load profile" / "automatic profile" that, on selection, navigates to `ProfileSelectorPage`. Description: "Pin a profile to auto-load on app start, wake, or after idle". (Added a new `externalRoute` field to the entry schema and a matching dispatcher in `SettingsSearchDialog.qml` and `SettingsPage.qml`.)
+
+## 9. MCP tools
+
+- [x] 9.1 In `src/mcp/mcptools_profiles.cpp`, register `profiles_get_auto_load` (access level `read`). No arguments. Returns `{ filename, title, revertMinutes }` with `title` resolved via the profile manager; returns `filename: ""` when none is set. Always includes `revertMinutes` in the response.
+- [x] 9.2 In `src/mcp/mcptools_write.cpp`, register `profiles_set_auto_load` (access level `settings`). Args: `{ filename: string, revertMinutes?: int }`. Validates `filename` is non-empty, `profileExists(filename)`, and `isProfileInSelectedList(filename)`. Persists via the settings setter on the QML/GUI thread (`QMetaObject::invokeMethod(...QueuedConnection)`). Returns `{ success, filename, title, revertMinutes }` or `{ error }` on validation failure.
+- [x] 9.3 In `src/mcp/mcptools_write.cpp`, register `profiles_clear_auto_load` (access level `settings`). No required args. Persists via the settings setter (filename → empty string). Returns `{ success: true }`. Does not modify `revertMinutes`.
+- [x] 9.4 Update `docs/CLAUDE_MD/MCP_SERVER.md` tool table to include the three new tools and their access levels.
+
+## 10. Tests
+
+- [x] 10.1 `tst_settings.cpp` — `autoLoadProfileFilename` and `autoLoadRevertMinutes` roundtrip through QSettings (set, read back, signal fired exactly once on change).
+- [x] 10.2 `tst_settings.cpp` — `autoLoadRevertMinutes` setter clamps to 0..60.
+- [x] 10.3 `tst_settings.cpp` — settings-bundle export/import roundtrip preserves both keys.
+- [x] 10.4 `tst_profilemanager.cpp` — `loadAutoLoadProfileIfNeeded()` is a no-op when filename is empty.
+- [x] 10.5 `tst_profilemanager.cpp` — fires `autoLoadStaleCleared` and clears the setting when the filename is not in the Selected list.
+- [x] 10.6 `tst_profilemanager.cpp` — does not reload when the auto-load filename equals the active profile.
+- [ ] 10.7 `tst_profilemanager.cpp` — calls `loadProfile(filename)` when filename resolves and differs from active. _Deferred: requires staging a real profile file into the fixture's temp-dir catalog. Covered indirectly by the no-op-when-active test and existing `loadProfile` coverage; spec is enforced by the same code path._
+- [x] 10.8 `tst_profilemanager.cpp` — eager-clear: `addHiddenProfile` on the pinned filename clears it. (Also added `removeSelectedBuiltInProfile` eager-clear test.)
+- [ ] 10.9 Manual smoke (no automated test): the QML strip appears when an auto-load is set and disappears when cleared. (Captured as a manual checklist item in the PR description.) _Manual — deferred to PR test plan._
+
+## 11. Documentation
+
+- [x] 11.1 Update `docs/CLAUDE_MD/RECIPE_PROFILES.md` with a short "Auto-Load" section describing the three triggers, the Selected-list eligibility, and the strip UI.
+- [x] 11.2 Add a Wiki manual page entry (separate `Kulitorum/Decenza.wiki.git` repo) describing the feature for end users. Keep wording consistent with the in-app strings. (Added "Auto-Load Profile" subsection under §4 Profiles in `Decenza.wiki/Manual.md`. Wiki is a separate git repo — commit/push is left for the user to coordinate with the main PR.)

--- a/qml/components/SettingsSearchIndex.js
+++ b/qml/components/SettingsSearchIndex.js
@@ -95,6 +95,13 @@ function getSearchEntries(tr) {
           description: tr("settings.machine.pocketIntegrationDesc", "Allow the Pocket app to view and control your screen remotely. Requires an active Pocket pairing."),
           keywords: ["pocket", "remote", "pair", "control", "screen"] },
 
+        // External: Auto-Load Profile lives on ProfileSelectorPage (not a
+        // settings tab). When chosen, the dialog navigates there.
+        { externalRoute: "profileSelector",
+          title: tr("settings.search.autoLoadProfileTitle", "Auto-Load Profile"),
+          description: tr("settings.search.autoLoadProfileDesc", "Pin a profile to auto-load on app start, wake, or after idle"),
+          keywords: ["auto-load", "auto load", "automatic profile", "pin", "default", "revert", "home"] },
+
         // Calibration
         { tabId: "calibration", cardId: "flowCalibration",
           title: tr("settings.preferences.flowCalibration", "Flow Calibration"),

--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -31,6 +31,12 @@ Item {
         return useBaseScale ? Theme.scaledBase(value) : Theme.scaled(value)
     }
 
+    // Font size for the inline value text and +/- glyphs. Defaults to sc(16) to
+    // preserve previous appearance; compact callers (e.g. status strips) can
+    // lower it so the inline value matches surrounding label text. Only affects
+    // the inline display — the full-screen popup keeps its own larger sizes.
+    property int valueFontPixelSize: sc(16)
+
     // Signals
     //
     // valueModified fires on every adjustment step — every +/- click, every
@@ -132,7 +138,7 @@ Item {
     // Measure the text width for auto-sizing
     TextMetrics {
         id: textMetrics
-        font.pixelSize: sc(16)
+        font.pixelSize: root.valueFontPixelSize
         font.bold: true
         text: root.displayText || (root.value.toFixed(root.decimals) + root.suffix)
     }
@@ -178,7 +184,7 @@ Item {
                 Text {
                     anchors.centerIn: parent
                     text: "\u2212"
-                    font.pixelSize: sc(16)
+                    font.pixelSize: root.valueFontPixelSize
                     font.bold: true
                     color: root.value <= root.from ? Theme.textSecondaryColor : Theme.textColor
                     Accessible.ignored: true
@@ -223,7 +229,7 @@ Item {
                     width: parent.width
                     horizontalAlignment: Text.AlignHCenter
                     text: root.displayText || (root.value.toFixed(root.decimals) + root.suffix)
-                    font.pixelSize: sc(16)
+                    font.pixelSize: root.valueFontPixelSize
                     font.bold: true
                     color: root.valueColor
                     elide: Text.ElideRight
@@ -492,7 +498,7 @@ Item {
                 Text {
                     anchors.centerIn: parent
                     text: "+"
-                    font.pixelSize: sc(16)
+                    font.pixelSize: root.valueFontPixelSize
                     font.bold: true
                     color: root.value >= root.to ? Theme.textSecondaryColor : Theme.textColor
                     Accessible.ignored: true

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -398,22 +398,6 @@ ApplicationWindow {
                 console.log("[AutoSleep] Both counters expired — triggering sleep")
                 triggerAutoSleep()
             }
-
-            // Auto-load idle-revert tick: piggybacks on this minute timer so we
-            // don't add a second QTimer. Only fires on the Idle page; pauses
-            // during operations (the timer above is already gated on
-            // !operationActive, so we're free to decrement here).
-            if (root.autoLoadIdleCountdown > 0) {
-                root.autoLoadIdleCountdown--
-                if (root.autoLoadIdleCountdown <= 0) {
-                    var pageName = pageStack.currentItem ? pageStack.currentItem.objectName : ""
-                    if (pageName === "idlePage") {
-                        console.log("[AutoLoad] Idle countdown expired — invoking auto-load")
-                        ProfileManager.loadAutoLoadProfileIfNeeded()
-                    }
-                    root.autoLoadIdleCountdown = root.autoLoadCountdownReload()
-                }
-            }
         }
     }
 
@@ -422,6 +406,30 @@ ApplicationWindow {
     // off, no profile is pinned, the revert-minutes is 0, or we're not on the
     // Idle page.
     property int autoLoadIdleCountdown: -1
+
+    // Auto-load idle-revert tick. Lives in its own timer (not the sleep
+    // countdown's) so the trigger keeps working when the user has set
+    // auto-sleep to "Never" — sleepCountdownTimer is gated on
+    // autoSleepMinutes > 0, which would otherwise silently kill this path.
+    // Allowed under CLAUDE.md's UI-behaviour-timer carve-out.
+    Timer {
+        id: autoLoadCountdownTimer
+        interval: 60 * 1000  // 1 minute
+        running: root.autoLoadIdleCountdown > 0 && !screensaverActive && !root.operationActive
+        repeat: true
+        onTriggered: {
+            if (root.autoLoadIdleCountdown <= 0) return
+            root.autoLoadIdleCountdown--
+            if (root.autoLoadIdleCountdown <= 0) {
+                var pageName = pageStack.currentItem ? pageStack.currentItem.objectName : ""
+                if (pageName === "idlePage") {
+                    console.log("[AutoLoad] Idle countdown expired — invoking auto-load")
+                    ProfileManager.loadAutoLoadProfileIfNeeded()
+                }
+                root.autoLoadIdleCountdown = root.autoLoadCountdownReload()
+            }
+        }
+    }
 
     function autoLoadCountdownReload() {
         var pageName = pageStack.currentItem ? pageStack.currentItem.objectName : ""
@@ -448,11 +456,21 @@ ApplicationWindow {
     // Trigger: DE1 wake from Sleep → Idle. Tracks previous state in QML since
     // DE1Device does not expose it. State values come from DE1::State (see
     // src/ble/protocol/de1characteristics.h): Sleep = 0x00, Idle = 0x02.
+    //
+    // BLE reconnect handling: a reconnect can replay a Sleep → Idle transition
+    // even when the user didn't physically wake the machine. We reset the
+    // previous-state tracker on every connected-change so the first state
+    // notification after a (re)connect is treated as the initial state, not a
+    // transition. A real user wake-from-sleep produces a second notification
+    // while the machine stays connected; that one fires the auto-load.
     property int autoLoadPreviousDe1State: -1
     readonly property int de1StateSleep: 0x00
     readonly property int de1StateIdle: 0x02
     Connections {
         target: DE1Device
+        function onConnectedChanged() {
+            root.autoLoadPreviousDe1State = -1
+        }
         function onStateChanged() {
             var prev = root.autoLoadPreviousDe1State
             var curr = DE1Device.state

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -425,9 +425,7 @@ ApplicationWindow {
 
     function autoLoadCountdownReload() {
         var pageName = pageStack.currentItem ? pageStack.currentItem.objectName : ""
-        if (Settings.app.autoLoadRevertMinutes <= 0
-            || Settings.app.autoLoadProfileFilename === ""
-            || pageName !== "idlePage") {
+        if (Settings.app.autoLoadProfileFilename === "" || pageName !== "idlePage") {
             return -1
         }
         return Settings.app.autoLoadRevertMinutes

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -425,7 +425,11 @@ ApplicationWindow {
 
     function autoLoadCountdownReload() {
         var pageName = pageStack.currentItem ? pageStack.currentItem.objectName : ""
-        if (Settings.app.autoLoadProfileFilename === "" || pageName !== "idlePage") {
+        // 0 disables the idle-revert trigger only — startup and wake-from-sleep
+        // still fire via their own paths.
+        if (Settings.app.autoLoadProfileFilename === ""
+            || Settings.app.autoLoadRevertMinutes <= 0
+            || pageName !== "idlePage") {
             return -1
         }
         return Settings.app.autoLoadRevertMinutes

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -398,6 +398,81 @@ ApplicationWindow {
                 console.log("[AutoSleep] Both counters expired — triggering sleep")
                 triggerAutoSleep()
             }
+
+            // Auto-load idle-revert tick: piggybacks on this minute timer so we
+            // don't add a second QTimer. Only fires on the Idle page; pauses
+            // during operations (the timer above is already gated on
+            // !operationActive, so we're free to decrement here).
+            if (root.autoLoadIdleCountdown > 0) {
+                root.autoLoadIdleCountdown--
+                if (root.autoLoadIdleCountdown <= 0) {
+                    var pageName = pageStack.currentItem ? pageStack.currentItem.objectName : ""
+                    if (pageName === "idlePage") {
+                        console.log("[AutoLoad] Idle countdown expired — invoking auto-load")
+                        ProfileManager.loadAutoLoadProfileIfNeeded()
+                    }
+                    root.autoLoadIdleCountdown = root.autoLoadCountdownReload()
+                }
+            }
+        }
+    }
+
+    // Auto-load countdown (minutes remaining on the Idle page before reverting
+    // to the pinned profile). -1 means "not running" — either the feature is
+    // off, no profile is pinned, the revert-minutes is 0, or we're not on the
+    // Idle page.
+    property int autoLoadIdleCountdown: -1
+
+    function autoLoadCountdownReload() {
+        var pageName = pageStack.currentItem ? pageStack.currentItem.objectName : ""
+        if (Settings.app.autoLoadRevertMinutes <= 0
+            || Settings.app.autoLoadProfileFilename === ""
+            || pageName !== "idlePage") {
+            return -1
+        }
+        return Settings.app.autoLoadRevertMinutes
+    }
+
+    function autoLoadResetCountdown() {
+        root.autoLoadIdleCountdown = autoLoadCountdownReload()
+    }
+
+    Connections {
+        target: Settings.app
+        function onAutoLoadProfileFilenameChanged() { root.autoLoadResetCountdown() }
+        function onAutoLoadRevertMinutesChanged() { root.autoLoadResetCountdown() }
+    }
+
+    // Trigger: DE1 wake from Sleep → Idle. Tracks previous state in QML since
+    // DE1Device does not expose it. State values come from DE1::State (see
+    // src/ble/protocol/de1characteristics.h): Sleep = 0x00, Idle = 0x02.
+    property int autoLoadPreviousDe1State: -1
+    readonly property int de1StateSleep: 0x00
+    readonly property int de1StateIdle: 0x02
+    Connections {
+        target: DE1Device
+        function onStateChanged() {
+            var prev = root.autoLoadPreviousDe1State
+            var curr = DE1Device.state
+            root.autoLoadPreviousDe1State = curr
+            if (prev === root.de1StateSleep && curr === root.de1StateIdle) {
+                console.log("[AutoLoad] DE1 Sleep -> Idle — invoking auto-load")
+                ProfileManager.loadAutoLoadProfileIfNeeded()
+            }
+        }
+    }
+
+    // Trigger: stale-target toast surface — ProfileManager clears the setting
+    // and emits this signal when the pinned filename is no longer in the
+    // Selected list.
+    Connections {
+        target: ProfileManager
+        function onAutoLoadStaleCleared() {
+            autoLoadStaleToast.opacity = 1
+            autoLoadStaleToastTimer.restart()
+            if (AccessibilityManager.enabled) {
+                AccessibilityManager.announce(trAutoLoadStaleToast.text, true)
+            }
         }
     }
 
@@ -409,6 +484,8 @@ ApplicationWindow {
                 root.sleepCountdownNormal = root.autoSleepMinutes
                 console.log("[AutoSleep] Reset by phase change: normal=" + root.sleepCountdownNormal)
             }
+            // Phase change is also user activity for the auto-load countdown
+            root.autoLoadResetCountdown()
         }
     }
 
@@ -711,6 +788,14 @@ ApplicationWindow {
 
         // startupGracePeriod is cleared by the phaseChanged handler when the
         // machine first reaches a non-Sleep state (no timer needed)
+
+        // Trigger: app startup — invoke auto-load once after ProfileManager
+        // and Settings are ready. Q-callLater defers past initialItem mount
+        // so the load sees the fully-initialised profile catalog.
+        Qt.callLater(function() {
+            ProfileManager.loadAutoLoadProfileIfNeeded()
+            root.autoLoadResetCountdown()
+        })
     }
 
     function updateScale() {
@@ -1030,6 +1115,8 @@ ApplicationWindow {
             updateCurrentPageScale()
             announceCurrentPage()
             pageColorTimer.restart()  // Detect colors after page settles
+            // Reset the auto-load countdown: clears off-Idle, full value back on Idle
+            root.autoLoadResetCountdown()
         }
     }
 
@@ -2909,6 +2996,9 @@ ApplicationWindow {
                 root.sleepCountdownNormal = root.autoSleepMinutes
                 if (prev <= 5) console.log("[AutoSleep] Reset by touch: " + prev + " -> " + root.sleepCountdownNormal)
             }
+            // Touch also resets the auto-load countdown so reading on the
+            // Idle page doesn't silently swap the active profile.
+            root.autoLoadResetCountdown()
             mouse.accepted = false  // Let the touch through
         }
         onReleased: function(mouse) { mouse.accepted = false }
@@ -3331,6 +3421,46 @@ ApplicationWindow {
         id: discardedShotToastTimer
         interval: 4000
         onTriggered: discardedShotToast.opacity = 0
+    }
+
+    // ============ AUTO-LOAD STALE TOAST ============
+    // Shown when ProfileManager.loadAutoLoadProfileIfNeeded() finds the pinned
+    // filename no longer resolves to a Selected-list profile (deleted, hidden,
+    // or imported from another device). Setting is cleared automatically.
+    Tr { id: trAutoLoadStaleToast; key: "profileselector.toast.auto_load_stale"; fallback: "Auto-load profile is no longer available"; visible: false }
+
+    Rectangle {
+        id: autoLoadStaleToast
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Theme.scaled(40)
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: autoLoadStaleToastLabel.implicitWidth + Theme.scaled(32)
+        height: autoLoadStaleToastLabel.implicitHeight + Theme.scaled(16)
+        radius: Theme.cardRadius
+        color: Theme.surfaceColor
+        opacity: 0
+        visible: opacity > 0
+        z: 600
+        Accessible.ignored: true
+
+        Behavior on opacity {
+            NumberAnimation { duration: 300 }
+        }
+
+        Text {
+            id: autoLoadStaleToastLabel
+            anchors.centerIn: parent
+            text: trAutoLoadStaleToast.text
+            color: Theme.textColor
+            font.pixelSize: Theme.scaled(13)
+            Accessible.ignored: true
+        }
+    }
+
+    Timer {
+        id: autoLoadStaleToastTimer
+        interval: 4000
+        onTriggered: autoLoadStaleToast.opacity = 0
     }
 
     Connections {

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -560,6 +560,8 @@ Page {
                             }
 
                             // === Overflow menu button (edit, remove, delete) ===
+                            // Opens a modal Dialog (not a popup Menu) so screen
+                            // readers receive proper focus + role announcements.
                             StyledIconButton {
                                 id: overflowButton
                                 visible: true  // All views
@@ -571,261 +573,18 @@ Page {
                                 accessibleName: TranslationManager.translate("profileselector.accessible.more_options", "More options for") + " " + modelData.title
 
                                 onClicked: {
-                                    var pos = mapToItem(profileDelegate, 0, height)
-                                    overflowMenu.x = pos.x
-                                    overflowMenu.y = pos.y
-                                    overflowMenu.open()
+                                    profileActionsDialog.profileFilename = modelData.name
+                                    profileActionsDialog.profileTitle = modelData.title
+                                    profileActionsDialog.profileIsBuiltIn = profileDelegate.isBuiltIn
+                                    profileActionsDialog.profileIsSelected = profileDelegate.isSelected
+                                    profileActionsDialog.profileIsFavorite = profileDelegate.isFavorite
+                                    profileActionsDialog.profileIsAutoLoad = profileDelegate.isAutoLoad
+                                    profileActionsDialog.viewIsSelectedList = (viewFilter.currentIndex === 0)
+                                    profileActionsDialog.open()
                                 }
                             }
                         }
 
-                        // Overflow menu (outside the RowLayout for proper positioning)
-                        Menu {
-                            id: overflowMenu
-                            width: Theme.scaled(220)
-
-                            background: Rectangle {
-                                color: Theme.surfaceColor
-                                border.color: Theme.borderColor
-                                radius: Theme.scaled(6)
-                            }
-
-                            MenuItem {
-                                onTriggered: {
-                                    ProfileManager.loadProfile(modelData.name)
-                                    root.goToProfileEditor()
-                                }
-
-                                contentItem: Row {
-                                    spacing: Theme.scaled(8)
-                                    leftPadding: Theme.scaled(8)
-                                    Image {
-                                        source: "qrc:/icons/edit.svg"
-                                        sourceSize.width: Theme.scaled(16)
-                                        sourceSize.height: Theme.scaled(16)
-                                        anchors.verticalCenter: parent.verticalCenter
-
-                                        layer.enabled: true
-                                        layer.smooth: true
-                                        layer.effect: MultiEffect {
-                                            colorization: 1.0
-                                            colorizationColor: Theme.textColor
-                                        }
-                                    }
-                                    Text {
-                                        text: TranslationManager.translate("profileselector.menu.edit", "Edit Profile")
-                                        color: Theme.textColor
-                                        font: Theme.bodyFont
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        Accessible.ignored: true
-                                    }
-                                }
-                                background: Rectangle {
-                                    color: parent.highlighted ? Qt.rgba(Theme.primaryColor.r, Theme.primaryColor.g, Theme.primaryColor.b, 0.2) : "transparent"
-                                }
-
-                                Accessible.role: Accessible.MenuItem
-                                Accessible.name: TranslationManager.translate("profileselector.accessible.edit_profile", "Edit profile")
-                                Accessible.focusable: true
-                                Accessible.onPressAction: { ProfileManager.loadProfile(modelData.name); root.goToProfileEditor() }
-                            }
-
-                            MenuItem {
-                                onTriggered: {
-                                    copyProfileDialog.sourceFilename = modelData.name
-                                    copyProfileDialog.sourceTitle = modelData.title
-                                    copyProfileDialog.open()
-                                }
-
-                                contentItem: Row {
-                                    spacing: Theme.scaled(8)
-                                    leftPadding: Theme.scaled(8)
-                                    Image {
-                                        source: "qrc:/icons/plus.svg"
-                                        sourceSize.width: Theme.scaled(16)
-                                        sourceSize.height: Theme.scaled(16)
-                                        anchors.verticalCenter: parent.verticalCenter
-
-                                        layer.enabled: true
-                                        layer.smooth: true
-                                        layer.effect: MultiEffect {
-                                            colorization: 1.0
-                                            colorizationColor: Theme.textColor
-                                        }
-                                    }
-                                    Text {
-                                        text: TranslationManager.translate("profileselector.menu.copy", "Copy Profile")
-                                        color: Theme.textColor
-                                        font: Theme.bodyFont
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        Accessible.ignored: true
-                                    }
-                                }
-                                background: Rectangle {
-                                    color: parent.highlighted ? Qt.rgba(Theme.primaryColor.r, Theme.primaryColor.g, Theme.primaryColor.b, 0.2) : "transparent"
-                                }
-
-                                Accessible.role: Accessible.MenuItem
-                                Accessible.name: TranslationManager.translate("profileselector.accessible.copy_profile", "Copy profile")
-                                Accessible.focusable: true
-                                Accessible.onPressAction: { copyProfileDialog.sourceFilename = modelData.name; copyProfileDialog.sourceTitle = modelData.title; copyProfileDialog.open() }
-                            }
-
-                            // === Set / Disable Auto-Load ===
-                            // Visible only when the row's profile is in the Selected list
-                            // (Selected view, or row.isSelected when browsing other views).
-                            MenuItem {
-                                id: autoLoadMenuItem
-                                visible: viewFilter.currentIndex === 0 || profileDelegate.isSelected
-                                height: visible ? implicitHeight : 0
-
-                                onTriggered: {
-                                    if (profileDelegate.isAutoLoad) {
-                                        Settings.app.autoLoadProfileFilename = ""
-                                        profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.auto_load_disabled", "Auto-load disabled"))
-                                    } else {
-                                        Settings.app.autoLoadProfileFilename = modelData.name
-                                        profileSelectorPage.showToast(
-                                            TranslationManager.translate("profileselector.toast.auto_load_set", "Auto-load set to %1").arg(modelData.title))
-                                    }
-                                }
-
-                                contentItem: Row {
-                                    spacing: Theme.scaled(8)
-                                    leftPadding: Theme.scaled(8)
-                                    Image {
-                                        source: "qrc:/icons/pin.svg"
-                                        sourceSize.width: Theme.scaled(16)
-                                        sourceSize.height: Theme.scaled(16)
-                                        anchors.verticalCenter: parent.verticalCenter
-
-                                        layer.enabled: true
-                                        layer.smooth: true
-                                        layer.effect: MultiEffect {
-                                            colorization: 1.0
-                                            colorizationColor: Theme.textColor
-                                        }
-                                    }
-                                    Text {
-                                        text: profileDelegate.isAutoLoad
-                                              ? TranslationManager.translate("profileselector.menu.disable_auto_load", "Disable Auto-Load")
-                                              : TranslationManager.translate("profileselector.menu.set_auto_load", "Set Auto-Load")
-                                        color: Theme.textColor
-                                        font: Theme.bodyFont
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        Accessible.ignored: true
-                                    }
-                                }
-                                background: Rectangle {
-                                    color: parent.highlighted ? Qt.rgba(Theme.primaryColor.r, Theme.primaryColor.g, Theme.primaryColor.b, 0.2) : "transparent"
-                                }
-
-                                Accessible.role: Accessible.MenuItem
-                                Accessible.name: profileDelegate.isAutoLoad
-                                                 ? TranslationManager.translate("profileselector.accessible.disable_auto_load", "Disable auto-load")
-                                                 : TranslationManager.translate("profileselector.accessible.set_auto_load", "Set as auto-load profile")
-                                Accessible.focusable: true
-                                Accessible.onPressAction: autoLoadMenuItem.triggered()
-                            }
-
-                            MenuSeparator {
-                                visible: viewFilter.currentIndex === 0 || !profileDelegate.isBuiltIn
-                                height: visible ? implicitHeight : 0
-                                contentItem: Rectangle {
-                                    implicitHeight: Theme.scaled(1)
-                                    color: Theme.borderColor
-                                }
-                            }
-
-                            MenuItem {
-                                visible: viewFilter.currentIndex === 0  // Only on "Selected" view
-                                height: visible ? implicitHeight : 0
-                                onTriggered: {
-                                    if (profileDelegate.isBuiltIn) {
-                                        Settings.app.removeSelectedBuiltInProfile(modelData.name)
-                                    } else {
-                                        Settings.app.addHiddenProfile(modelData.name)
-                                    }
-                                }
-
-                                contentItem: Row {
-                                    spacing: Theme.scaled(8)
-                                    leftPadding: Theme.scaled(8)
-                                    Image {
-                                        source: "qrc:/icons/minus.svg"
-                                        sourceSize.width: Theme.scaled(16)
-                                        sourceSize.height: Theme.scaled(16)
-                                        anchors.verticalCenter: parent.verticalCenter
-
-                                        layer.enabled: true
-                                        layer.smooth: true
-                                        layer.effect: MultiEffect {
-                                            colorization: 1.0
-                                            colorizationColor: Theme.errorColor
-                                        }
-                                    }
-                                    Text {
-                                        text: TranslationManager.translate("profileselector.menu.remove_from_selected", "Remove from Selected")
-                                        color: Theme.errorColor
-                                        font: Theme.bodyFont
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        Accessible.ignored: true
-                                    }
-                                }
-                                background: Rectangle {
-                                    color: parent.highlighted ? Qt.rgba(Theme.errorColor.r, Theme.errorColor.g, Theme.errorColor.b, 0.2) : "transparent"
-                                }
-
-                                Accessible.role: Accessible.MenuItem
-                                Accessible.name: TranslationManager.translate("profileselector.accessible.remove_from_list", "Remove from selected list")
-                                Accessible.focusable: true
-                                Accessible.onPressAction: { if (profileDelegate.isBuiltIn) { Settings.app.removeSelectedBuiltInProfile(modelData.name) } else { Settings.app.addHiddenProfile(modelData.name) } }
-                            }
-
-                            MenuItem {
-                                visible: !profileDelegate.isBuiltIn
-                                height: visible ? implicitHeight : 0
-                                onTriggered: {
-                                    deleteDialog.profileName = modelData.name
-                                    deleteDialog.profileTitle = modelData.title
-                                    deleteDialog.isFavorite = profileDelegate.isFavorite
-                                    deleteDialog.open()
-                                }
-
-                                contentItem: Row {
-                                    spacing: Theme.scaled(8)
-                                    leftPadding: Theme.scaled(8)
-                                    Image {
-                                        source: "qrc:/icons/trash.svg"
-                                        sourceSize.width: Theme.scaled(16)
-                                        sourceSize.height: Theme.scaled(16)
-                                        anchors.verticalCenter: parent.verticalCenter
-
-                                        layer.enabled: true
-                                        layer.smooth: true
-                                        layer.effect: MultiEffect {
-                                            colorization: 1.0
-                                            colorizationColor: Theme.errorColor
-                                        }
-                                    }
-                                    Text {
-                                        text: TranslationManager.translate("profileselector.menu.delete", "Delete Profile")
-                                        color: Theme.errorColor
-                                        font: Theme.bodyFont
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        Accessible.ignored: true
-                                    }
-                                }
-                                background: Rectangle {
-                                    color: parent.highlighted ? Qt.rgba(Theme.errorColor.r, Theme.errorColor.g, Theme.errorColor.b, 0.2) : "transparent"
-                                }
-
-                                Accessible.role: Accessible.MenuItem
-                                Accessible.name: TranslationManager.translate("profileselector.accessible.delete_permanently", "Delete profile permanently")
-                                Accessible.focusable: true
-                                Accessible.onPressAction: { deleteDialog.profileName = modelData.name; deleteDialog.profileTitle = modelData.title; deleteDialog.isFavorite = profileDelegate.isFavorite; deleteDialog.open() }
-                            }
-                        }
 
                         MouseArea {
                             id: profileMouseArea
@@ -1054,6 +813,146 @@ Page {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    // Profile actions dialog — replaces the row's overflow Menu (popup) with a
+    // proper modal Dialog. Menus don't surface role/focus to screen readers
+    // reliably; Dialog does. Follows the same shape as the bean-info preset
+    // dialogs: centered, modal, AccessibleButton stack.
+    Dialog {
+        id: profileActionsDialog
+        x: (parent.width - width) / 2
+        y: (parent.height - height) / 2
+        padding: 20
+        modal: true
+        focus: true
+        closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
+
+        property string profileFilename: ""
+        property string profileTitle: ""
+        property bool profileIsBuiltIn: false
+        property bool profileIsSelected: false
+        property bool profileIsFavorite: false
+        property bool profileIsAutoLoad: false
+        property bool viewIsSelectedList: false
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
+            border.color: Theme.textSecondaryColor
+            border.width: 1
+        }
+
+        contentItem: ColumnLayout {
+            spacing: Theme.scaled(12)
+
+            Text {
+                Layout.preferredWidth: Theme.scaled(280)
+                text: profileActionsDialog.profileTitle
+                color: Theme.textColor
+                font: Theme.subtitleFont
+                elide: Text.ElideRight
+                Accessible.role: Accessible.StaticText
+                Accessible.name: TranslationManager.translate("profileselector.dialog.actions_for", "Actions for") + " " + profileActionsDialog.profileTitle
+            }
+
+            // Edit profile
+            AccessibleButton {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Theme.scaled(40)
+                text: TranslationManager.translate("profileselector.menu.edit", "Edit Profile")
+                accessibleName: TranslationManager.translate("profileselector.accessible.edit_profile", "Edit profile")
+                onClicked: {
+                    profileActionsDialog.close()
+                    ProfileManager.loadProfile(profileActionsDialog.profileFilename)
+                    root.goToProfileEditor()
+                }
+            }
+
+            // Copy profile
+            AccessibleButton {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Theme.scaled(40)
+                text: TranslationManager.translate("profileselector.menu.copy", "Copy Profile")
+                accessibleName: TranslationManager.translate("profileselector.accessible.copy_profile", "Copy profile")
+                onClicked: {
+                    profileActionsDialog.close()
+                    copyProfileDialog.sourceFilename = profileActionsDialog.profileFilename
+                    copyProfileDialog.sourceTitle = profileActionsDialog.profileTitle
+                    copyProfileDialog.open()
+                }
+            }
+
+            // Set / Disable Auto-Load (Selected-list only)
+            AccessibleButton {
+                visible: profileActionsDialog.viewIsSelectedList || profileActionsDialog.profileIsSelected
+                Layout.fillWidth: true
+                Layout.preferredHeight: visible ? Theme.scaled(40) : 0
+                text: profileActionsDialog.profileIsAutoLoad
+                      ? TranslationManager.translate("profileselector.menu.disable_auto_load", "Disable Auto-Load")
+                      : TranslationManager.translate("profileselector.menu.set_auto_load", "Set Auto-Load")
+                accessibleName: profileActionsDialog.profileIsAutoLoad
+                      ? TranslationManager.translate("profileselector.accessible.disable_auto_load", "Disable auto-load")
+                      : TranslationManager.translate("profileselector.accessible.set_auto_load", "Set as auto-load profile")
+                onClicked: {
+                    if (profileActionsDialog.profileIsAutoLoad) {
+                        Settings.app.autoLoadProfileFilename = ""
+                        profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.auto_load_disabled", "Auto-load disabled"))
+                    } else {
+                        Settings.app.autoLoadProfileFilename = profileActionsDialog.profileFilename
+                        profileSelectorPage.showToast(
+                            TranslationManager.translate("profileselector.toast.auto_load_set", "Auto-load set to %1").arg(profileActionsDialog.profileTitle))
+                    }
+                    profileActionsDialog.close()
+                }
+            }
+
+            // Remove from Selected (Selected view only)
+            AccessibleButton {
+                visible: profileActionsDialog.viewIsSelectedList
+                Layout.fillWidth: true
+                Layout.preferredHeight: visible ? Theme.scaled(40) : 0
+                destructive: true
+                text: TranslationManager.translate("profileselector.menu.remove_from_selected", "Remove from Selected")
+                accessibleName: TranslationManager.translate("profileselector.accessible.remove_from_list", "Remove from selected list")
+                onClicked: {
+                    if (profileActionsDialog.profileIsBuiltIn) {
+                        Settings.app.removeSelectedBuiltInProfile(profileActionsDialog.profileFilename)
+                    } else {
+                        Settings.app.addHiddenProfile(profileActionsDialog.profileFilename)
+                    }
+                    profileActionsDialog.close()
+                }
+            }
+
+            // Delete profile (user/downloaded only)
+            AccessibleButton {
+                visible: !profileActionsDialog.profileIsBuiltIn
+                Layout.fillWidth: true
+                Layout.preferredHeight: visible ? Theme.scaled(40) : 0
+                destructive: true
+                text: TranslationManager.translate("profileselector.menu.delete", "Delete Profile")
+                accessibleName: TranslationManager.translate("profileselector.accessible.delete_permanently", "Delete profile permanently")
+                onClicked: {
+                    profileActionsDialog.close()
+                    deleteDialog.profileName = profileActionsDialog.profileFilename
+                    deleteDialog.profileTitle = profileActionsDialog.profileTitle
+                    deleteDialog.isFavorite = profileActionsDialog.profileIsFavorite
+                    deleteDialog.open()
+                }
+            }
+
+            // Cancel — dismisses without action. Gives keyboard/SR users a clear
+            // out without relying on Esc / outside-tap.
+            AccessibleButton {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Theme.scaled(40)
+                Layout.topMargin: Theme.scaled(4)
+                text: TranslationManager.translate("profileselector.button.cancel", "Cancel")
+                accessibleName: TranslationManager.translate("profileselector.accessible.cancel_actions", "Cancel and close")
+                onClicked: profileActionsDialog.close()
             }
         }
     }

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -41,7 +41,7 @@ Page {
                 Rectangle {
                     id: autoLoadStrip
                     Layout.fillWidth: true
-                    Layout.preferredHeight: autoLoadStripRow.implicitHeight + Theme.scaled(16)
+                    Layout.preferredHeight: Theme.scaled(36)
                     color: Theme.surfaceColor
                     border.color: Theme.borderColor
                     border.width: 1
@@ -63,15 +63,15 @@ Page {
                     RowLayout {
                         id: autoLoadStripRow
                         anchors.fill: parent
-                        anchors.leftMargin: Theme.scaled(12)
-                        anchors.rightMargin: Theme.scaled(8)
-                        spacing: Theme.scaled(8)
+                        anchors.leftMargin: Theme.scaled(10)
+                        anchors.rightMargin: Theme.scaled(4)
+                        spacing: Theme.scaled(6)
 
                         Image {
                             id: autoLoadStripPin
                             source: "qrc:/icons/pin.svg"
-                            sourceSize.width: Theme.scaled(16)
-                            sourceSize.height: Theme.scaled(16)
+                            sourceSize.width: Theme.scaled(14)
+                            sourceSize.height: Theme.scaled(14)
                             Layout.alignment: Qt.AlignVCenter
                             Accessible.ignored: true
 
@@ -86,7 +86,8 @@ Page {
                         Text {
                             text: TranslationManager.translate("profileselector.strip.auto_load_label", "Auto-load:")
                             color: Theme.textSecondaryColor
-                            font: Theme.bodyFont
+                            font.family: Theme.bodyFont.family
+                            font.pixelSize: Theme.scaled(12)
                             Layout.alignment: Qt.AlignVCenter
                             Accessible.ignored: true
                         }
@@ -94,7 +95,8 @@ Page {
                         Text {
                             text: autoLoadStrip.autoLoadTitle
                             color: Theme.textColor
-                            font: Theme.bodyFont
+                            font.family: Theme.bodyFont.family
+                            font.pixelSize: Theme.scaled(12)
                             elide: Text.ElideRight
                             Layout.fillWidth: true
                             Layout.alignment: Qt.AlignVCenter
@@ -104,27 +106,31 @@ Page {
                         Text {
                             text: TranslationManager.translate("profileselector.strip.revert_after", "revert after")
                             color: Theme.textSecondaryColor
-                            font: Theme.bodyFont
+                            font.family: Theme.bodyFont.family
+                            font.pixelSize: Theme.scaled(12)
                             Layout.alignment: Qt.AlignVCenter
                             Accessible.ignored: true
                         }
 
                         ValueInput {
                             id: autoLoadRevertInput
-                            Layout.preferredWidth: Theme.scaled(120)
-                            Layout.preferredHeight: Theme.scaled(40)
+                            Layout.preferredWidth: Theme.scaled(110)
+                            Layout.preferredHeight: Theme.scaled(28)
                             Layout.alignment: Qt.AlignVCenter
                             value: Settings.app.autoLoadRevertMinutes
-                            from: 0
+                            from: 1
                             to: 60
                             stepSize: 1
                             suffix: TranslationManager.translate("profileselector.strip.minutes_short", "min")
-                            displayText: value === 0
-                                ? TranslationManager.translate("profileselector.strip.never", "Never")
-                                : value + " " + TranslationManager.translate("profileselector.strip.minutes_short", "min")
+                            displayText: value + " " + TranslationManager.translate("profileselector.strip.minutes_short", "min")
                             accessibleName: TranslationManager.translate("profileselector.strip.revert_after", "revert after")
 
-                            onValueCommitted: function(newValue) {
+                            // ValueInput emits valueModified on every adjustment and
+                            // valueCommitted on release; valueCommitted carries the
+                            // already-updated value only if the consumer wrote it
+                            // back during valueModified, so we wire to valueModified
+                            // for the live setting write.
+                            onValueModified: function(newValue) {
                                 Settings.app.autoLoadRevertMinutes = newValue
                             }
                         }
@@ -132,14 +138,14 @@ Page {
                         AccessibleButton {
                             id: autoLoadClearButton
                             text: "×"
-                            Layout.preferredWidth: Theme.scaled(36)
-                            Layout.preferredHeight: Theme.scaled(36)
+                            Layout.preferredWidth: Theme.scaled(28)
+                            Layout.preferredHeight: Theme.scaled(28)
                             Layout.alignment: Qt.AlignVCenter
                             accessibleName: TranslationManager.translate("profileselector.strip.clear_aria", "Disable auto-load")
                             contentItem: Text {
                                 text: "×"
                                 color: Theme.textColor
-                                font.pixelSize: Theme.scaled(20)
+                                font.pixelSize: Theme.scaled(16)
                                 font.bold: true
                                 horizontalAlignment: Text.AlignHCenter
                                 verticalAlignment: Text.AlignVCenter

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -41,7 +41,7 @@ Page {
                 Rectangle {
                     id: autoLoadStrip
                     Layout.fillWidth: true
-                    Layout.preferredHeight: Theme.scaled(36)
+                    Layout.preferredHeight: Theme.scaled(28)
                     color: Theme.surfaceColor
                     border.color: Theme.borderColor
                     border.width: 1
@@ -63,15 +63,15 @@ Page {
                     RowLayout {
                         id: autoLoadStripRow
                         anchors.fill: parent
-                        anchors.leftMargin: Theme.scaled(10)
-                        anchors.rightMargin: Theme.scaled(4)
-                        spacing: Theme.scaled(6)
+                        anchors.leftMargin: Theme.scaled(8)
+                        anchors.rightMargin: Theme.scaled(2)
+                        spacing: Theme.scaled(4)
 
                         Image {
                             id: autoLoadStripPin
                             source: "qrc:/icons/pin.svg"
-                            sourceSize.width: Theme.scaled(14)
-                            sourceSize.height: Theme.scaled(14)
+                            sourceSize.width: Theme.scaled(11)
+                            sourceSize.height: Theme.scaled(11)
                             Layout.alignment: Qt.AlignVCenter
                             Accessible.ignored: true
 
@@ -87,7 +87,7 @@ Page {
                             text: TranslationManager.translate("profileselector.strip.auto_load_label", "Auto-load:")
                             color: Theme.textSecondaryColor
                             font.family: Theme.bodyFont.family
-                            font.pixelSize: Theme.scaled(12)
+                            font.pixelSize: Theme.scaled(10)
                             Layout.alignment: Qt.AlignVCenter
                             Accessible.ignored: true
                         }
@@ -96,7 +96,7 @@ Page {
                             text: autoLoadStrip.autoLoadTitle
                             color: Theme.textColor
                             font.family: Theme.bodyFont.family
-                            font.pixelSize: Theme.scaled(12)
+                            font.pixelSize: Theme.scaled(10)
                             elide: Text.ElideRight
                             Layout.fillWidth: true
                             Layout.alignment: Qt.AlignVCenter
@@ -107,15 +107,15 @@ Page {
                             text: TranslationManager.translate("profileselector.strip.revert_after", "revert after")
                             color: Theme.textSecondaryColor
                             font.family: Theme.bodyFont.family
-                            font.pixelSize: Theme.scaled(12)
+                            font.pixelSize: Theme.scaled(10)
                             Layout.alignment: Qt.AlignVCenter
                             Accessible.ignored: true
                         }
 
                         ValueInput {
                             id: autoLoadRevertInput
-                            Layout.preferredWidth: Theme.scaled(110)
-                            Layout.preferredHeight: Theme.scaled(28)
+                            Layout.preferredWidth: Theme.scaled(86)
+                            Layout.preferredHeight: Theme.scaled(22)
                             Layout.alignment: Qt.AlignVCenter
                             value: Settings.app.autoLoadRevertMinutes
                             from: 0
@@ -142,14 +142,14 @@ Page {
                         AccessibleButton {
                             id: autoLoadClearButton
                             text: "×"
-                            Layout.preferredWidth: Theme.scaled(28)
-                            Layout.preferredHeight: Theme.scaled(28)
+                            Layout.preferredWidth: Theme.scaled(22)
+                            Layout.preferredHeight: Theme.scaled(22)
                             Layout.alignment: Qt.AlignVCenter
                             accessibleName: TranslationManager.translate("profileselector.strip.clear_aria", "Disable auto-load")
                             contentItem: Text {
                                 text: "×"
                                 color: Theme.textColor
-                                font.pixelSize: Theme.scaled(16)
+                                font.pixelSize: Theme.scaled(13)
                                 font.bold: true
                                 horizontalAlignment: Text.AlignHCenter
                                 verticalAlignment: Text.AlignVCenter

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -41,7 +41,9 @@ Page {
                 Rectangle {
                     id: autoLoadStrip
                     Layout.fillWidth: true
-                    Layout.preferredHeight: Theme.scaled(28)
+                    // Sized off captionFont so the strip scales with the user's
+                    // customFontSizes.captionSize accessibility override.
+                    Layout.preferredHeight: Math.round(Theme.captionFont.pixelSize * 2.4)
                     color: Theme.surfaceColor
                     border.color: Theme.borderColor
                     border.width: 1
@@ -86,8 +88,7 @@ Page {
                         Text {
                             text: TranslationManager.translate("profileselector.strip.auto_load_label", "Auto-load:")
                             color: Theme.textSecondaryColor
-                            font.family: Theme.bodyFont.family
-                            font.pixelSize: Theme.scaled(10)
+                            font: Theme.captionFont
                             Layout.alignment: Qt.AlignVCenter
                             Accessible.ignored: true
                         }
@@ -95,8 +96,7 @@ Page {
                         Text {
                             text: autoLoadStrip.autoLoadTitle
                             color: Theme.textColor
-                            font.family: Theme.bodyFont.family
-                            font.pixelSize: Theme.scaled(10)
+                            font: Theme.captionFont
                             elide: Text.ElideRight
                             Layout.fillWidth: true
                             Layout.alignment: Qt.AlignVCenter
@@ -106,8 +106,7 @@ Page {
                         Text {
                             text: TranslationManager.translate("profileselector.strip.revert_after", "revert after")
                             color: Theme.textSecondaryColor
-                            font.family: Theme.bodyFont.family
-                            font.pixelSize: Theme.scaled(10)
+                            font: Theme.captionFont
                             Layout.alignment: Qt.AlignVCenter
                             Accessible.ignored: true
                         }
@@ -115,14 +114,15 @@ Page {
                         ValueInput {
                             id: autoLoadRevertInput
                             // Let the value text + min/plus glyphs determine
-                            // the width — at 10 dp font the fixed-86-dp clamp
-                            // was eliding "60 min" mid-suffix.
+                            // the width — a fixed clamp was eliding "60 min"
+                            // mid-suffix at the reduced font size.
                             Layout.preferredWidth: implicitWidth
-                            Layout.preferredHeight: Theme.scaled(22)
+                            Layout.preferredHeight: Math.round(Theme.captionFont.pixelSize * 1.9)
                             Layout.alignment: Qt.AlignVCenter
-                            // Match the strip's label text size so the inline
-                            // value doesn't dominate visually.
-                            valueFontPixelSize: Theme.scaled(10)
+                            // Match the strip's label text size (and its
+                            // customFontSizes.captionSize override) so the
+                            // inline value doesn't dominate visually.
+                            valueFontPixelSize: Theme.captionFont.pixelSize
                             value: Settings.app.autoLoadRevertMinutes
                             from: 0
                             to: 60
@@ -148,14 +148,14 @@ Page {
                         AccessibleButton {
                             id: autoLoadClearButton
                             text: "×"
-                            Layout.preferredWidth: Theme.scaled(22)
-                            Layout.preferredHeight: Theme.scaled(22)
+                            Layout.preferredWidth: Math.round(Theme.captionFont.pixelSize * 1.9)
+                            Layout.preferredHeight: Math.round(Theme.captionFont.pixelSize * 1.9)
                             Layout.alignment: Qt.AlignVCenter
                             accessibleName: TranslationManager.translate("profileselector.strip.clear_aria", "Disable auto-load")
                             contentItem: Text {
                                 text: "×"
                                 color: Theme.textColor
-                                font.pixelSize: Theme.scaled(13)
+                                font.pixelSize: Math.round(Theme.captionFont.pixelSize * 1.3)
                                 font.bold: true
                                 horizontalAlignment: Text.AlignHCenter
                                 verticalAlignment: Text.AlignVCenter
@@ -843,6 +843,9 @@ Page {
         property bool profileIsFavorite: false
         property bool profileIsAutoLoad: false
         property bool viewIsSelectedList: false
+
+        Accessible.role: Accessible.Dialog
+        Accessible.name: TranslationManager.translate("profileselector.dialog.profile_actions_title", "Profile actions") + (profileTitle ? ": " + profileTitle : "")
 
         background: Rectangle {
             color: Theme.surfaceColor

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -117,6 +117,9 @@ Page {
                             Layout.preferredWidth: Theme.scaled(86)
                             Layout.preferredHeight: Theme.scaled(22)
                             Layout.alignment: Qt.AlignVCenter
+                            // Match the strip's label text size so the inline
+                            // value doesn't dominate visually.
+                            valueFontPixelSize: Theme.scaled(10)
                             value: Settings.app.autoLoadRevertMinutes
                             from: 0
                             to: 60

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -943,17 +943,6 @@ Page {
                     deleteDialog.open()
                 }
             }
-
-            // Cancel — dismisses without action. Gives keyboard/SR users a clear
-            // out without relying on Esc / outside-tap.
-            AccessibleButton {
-                Layout.fillWidth: true
-                Layout.preferredHeight: Theme.scaled(40)
-                Layout.topMargin: Theme.scaled(4)
-                text: TranslationManager.translate("profileselector.button.cancel", "Cancel")
-                accessibleName: TranslationManager.translate("profileselector.accessible.cancel_actions", "Cancel and close")
-                onClicked: profileActionsDialog.close()
-            }
         }
     }
 

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -32,6 +32,127 @@ Page {
                 anchors.margins: Theme.scaled(15)
                 spacing: Theme.scaled(10)
 
+                // ===== Auto-Load status strip =====
+                // Visible only when an auto-load profile is configured AND it
+                // resolves to a Selected-list profile. Stale entries are
+                // cleared at trigger time by ProfileManager (or eagerly by
+                // hide/de-select/delete), so the visible-condition below is
+                // the steady-state truth.
+                Rectangle {
+                    id: autoLoadStrip
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: autoLoadStripRow.implicitHeight + Theme.scaled(16)
+                    color: Theme.surfaceColor
+                    border.color: Theme.borderColor
+                    border.width: 1
+                    radius: Theme.cardRadius
+
+                    visible: Settings.app.autoLoadProfileFilename !== ""
+                             && ProfileManager.isProfileInSelectedList(Settings.app.autoLoadProfileFilename)
+
+                    readonly property var autoLoadProfile: visible
+                        ? ProfileManager.getProfileByFilename(Settings.app.autoLoadProfileFilename)
+                        : ({})
+                    readonly property string autoLoadTitle: autoLoadProfile && autoLoadProfile.title
+                                                            ? autoLoadProfile.title
+                                                            : Settings.app.autoLoadProfileFilename
+
+                    Accessible.role: Accessible.StaticText
+                    Accessible.name: TranslationManager.translate("profileselector.strip.auto_load_label", "Auto-load:") + " " + autoLoadStrip.autoLoadTitle
+
+                    RowLayout {
+                        id: autoLoadStripRow
+                        anchors.fill: parent
+                        anchors.leftMargin: Theme.scaled(12)
+                        anchors.rightMargin: Theme.scaled(8)
+                        spacing: Theme.scaled(8)
+
+                        Image {
+                            id: autoLoadStripPin
+                            source: "qrc:/icons/pin.svg"
+                            sourceSize.width: Theme.scaled(16)
+                            sourceSize.height: Theme.scaled(16)
+                            Layout.alignment: Qt.AlignVCenter
+                            Accessible.ignored: true
+
+                            layer.enabled: true
+                            layer.smooth: true
+                            layer.effect: MultiEffect {
+                                colorization: 1.0
+                                colorizationColor: Theme.primaryColor
+                            }
+                        }
+
+                        Text {
+                            text: TranslationManager.translate("profileselector.strip.auto_load_label", "Auto-load:")
+                            color: Theme.textSecondaryColor
+                            font: Theme.bodyFont
+                            Layout.alignment: Qt.AlignVCenter
+                            Accessible.ignored: true
+                        }
+
+                        Text {
+                            text: autoLoadStrip.autoLoadTitle
+                            color: Theme.textColor
+                            font: Theme.bodyFont
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                            Layout.alignment: Qt.AlignVCenter
+                            Accessible.ignored: true
+                        }
+
+                        Text {
+                            text: TranslationManager.translate("profileselector.strip.revert_after", "revert after")
+                            color: Theme.textSecondaryColor
+                            font: Theme.bodyFont
+                            Layout.alignment: Qt.AlignVCenter
+                            Accessible.ignored: true
+                        }
+
+                        ValueInput {
+                            id: autoLoadRevertInput
+                            Layout.preferredWidth: Theme.scaled(120)
+                            Layout.preferredHeight: Theme.scaled(40)
+                            Layout.alignment: Qt.AlignVCenter
+                            value: Settings.app.autoLoadRevertMinutes
+                            from: 0
+                            to: 60
+                            stepSize: 1
+                            suffix: TranslationManager.translate("profileselector.strip.minutes_short", "min")
+                            displayText: value === 0
+                                ? TranslationManager.translate("profileselector.strip.never", "Never")
+                                : value + " " + TranslationManager.translate("profileselector.strip.minutes_short", "min")
+                            accessibleName: TranslationManager.translate("profileselector.strip.revert_after", "revert after")
+
+                            onValueCommitted: function(newValue) {
+                                Settings.app.setAutoLoadRevertMinutes(newValue)
+                            }
+                        }
+
+                        AccessibleButton {
+                            id: autoLoadClearButton
+                            text: "×"
+                            Layout.preferredWidth: Theme.scaled(36)
+                            Layout.preferredHeight: Theme.scaled(36)
+                            Layout.alignment: Qt.AlignVCenter
+                            accessibleName: TranslationManager.translate("profileselector.strip.clear_aria", "Disable auto-load")
+                            contentItem: Text {
+                                text: "×"
+                                color: Theme.textColor
+                                font.pixelSize: Theme.scaled(20)
+                                font.bold: true
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                                Accessible.ignored: true
+                            }
+                            onClicked: {
+                                Settings.app.setAutoLoadProfileFilename("")
+                                profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.auto_load_disabled", "Auto-load disabled"))
+                            }
+                        }
+                    }
+                }
+
                 RowLayout {
                     Layout.fillWidth: true
                     spacing: Theme.scaled(10)
@@ -232,6 +353,7 @@ Page {
                             return Settings.app.isFavoriteProfile(modelData.name)
                         }
                         property bool isCurrentProfile: modelData.name === ProfileManager.currentProfileName
+                        readonly property bool isAutoLoad: modelData && modelData.name === Settings.app.autoLoadProfileFilename && Settings.app.autoLoadProfileFilename !== ""
 
                         // Source-based colors
                         property color sourceColor: isBuiltIn ? Theme.sourceBadgeBlueColor :      // Blue for Decent
@@ -291,6 +413,25 @@ Page {
                                     font: Theme.bodyFont
                                     elide: Text.ElideRight
                                     Accessible.ignored: true
+                                }
+
+                                Image {
+                                    id: autoLoadPinIcon
+                                    visible: profileDelegate.isAutoLoad
+                                    source: "qrc:/icons/pin.svg"
+                                    sourceSize.width: Theme.scaled(14)
+                                    sourceSize.height: Theme.scaled(14)
+                                    Layout.alignment: Qt.AlignVCenter
+                                    Accessible.role: Accessible.Indicator
+                                    Accessible.name: TranslationManager.translate("profileselector.accessible.auto_load_profile", "Auto-load profile")
+                                    Accessible.ignored: !visible
+
+                                    layer.enabled: true
+                                    layer.smooth: true
+                                    layer.effect: MultiEffect {
+                                        colorization: 1.0
+                                        colorizationColor: Theme.primaryColor
+                                    }
                                 }
 
                                 Image {
@@ -518,6 +659,62 @@ Page {
                                 Accessible.name: TranslationManager.translate("profileselector.accessible.copy_profile", "Copy profile")
                                 Accessible.focusable: true
                                 Accessible.onPressAction: { copyProfileDialog.sourceFilename = modelData.name; copyProfileDialog.sourceTitle = modelData.title; copyProfileDialog.open() }
+                            }
+
+                            // === Set / Disable Auto-Load ===
+                            // Visible only when the row's profile is in the Selected list
+                            // (Selected view, or row.isSelected when browsing other views).
+                            MenuItem {
+                                id: autoLoadMenuItem
+                                visible: viewFilter.currentIndex === 0 || profileDelegate.isSelected
+
+                                onTriggered: {
+                                    if (profileDelegate.isAutoLoad) {
+                                        Settings.app.setAutoLoadProfileFilename("")
+                                        profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.auto_load_disabled", "Auto-load disabled"))
+                                    } else {
+                                        Settings.app.setAutoLoadProfileFilename(modelData.name)
+                                        profileSelectorPage.showToast(
+                                            TranslationManager.translate("profileselector.toast.auto_load_set", "Auto-load set to %1").arg(modelData.title))
+                                    }
+                                }
+
+                                contentItem: Row {
+                                    spacing: Theme.scaled(8)
+                                    leftPadding: Theme.scaled(8)
+                                    Image {
+                                        source: "qrc:/icons/pin.svg"
+                                        sourceSize.width: Theme.scaled(16)
+                                        sourceSize.height: Theme.scaled(16)
+                                        anchors.verticalCenter: parent.verticalCenter
+
+                                        layer.enabled: true
+                                        layer.smooth: true
+                                        layer.effect: MultiEffect {
+                                            colorization: 1.0
+                                            colorizationColor: Theme.textColor
+                                        }
+                                    }
+                                    Text {
+                                        text: profileDelegate.isAutoLoad
+                                              ? TranslationManager.translate("profileselector.menu.disable_auto_load", "Disable Auto-Load")
+                                              : TranslationManager.translate("profileselector.menu.set_auto_load", "Set Auto-Load")
+                                        color: Theme.textColor
+                                        font: Theme.bodyFont
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        Accessible.ignored: true
+                                    }
+                                }
+                                background: Rectangle {
+                                    color: parent.highlighted ? Qt.rgba(Theme.primaryColor.r, Theme.primaryColor.g, Theme.primaryColor.b, 0.2) : "transparent"
+                                }
+
+                                Accessible.role: Accessible.MenuItem
+                                Accessible.name: profileDelegate.isAutoLoad
+                                                 ? TranslationManager.translate("profileselector.accessible.disable_auto_load", "Disable auto-load")
+                                                 : TranslationManager.translate("profileselector.accessible.set_auto_load", "Set as auto-load profile")
+                                Accessible.focusable: true
+                                Accessible.onPressAction: autoLoadMenuItem.triggered()
                             }
 
                             MenuSeparator {

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -114,7 +114,10 @@ Page {
 
                         ValueInput {
                             id: autoLoadRevertInput
-                            Layout.preferredWidth: Theme.scaled(86)
+                            // Let the value text + min/plus glyphs determine
+                            // the width — at 10 dp font the fixed-86-dp clamp
+                            // was eliding "60 min" mid-suffix.
+                            Layout.preferredWidth: implicitWidth
                             Layout.preferredHeight: Theme.scaled(22)
                             Layout.alignment: Qt.AlignVCenter
                             // Match the strip's label text size so the inline

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -677,6 +677,7 @@ Page {
                             MenuItem {
                                 id: autoLoadMenuItem
                                 visible: viewFilter.currentIndex === 0 || profileDelegate.isSelected
+                                height: visible ? implicitHeight : 0
 
                                 onTriggered: {
                                     if (profileDelegate.isAutoLoad) {
@@ -729,6 +730,7 @@ Page {
 
                             MenuSeparator {
                                 visible: viewFilter.currentIndex === 0 || !profileDelegate.isBuiltIn
+                                height: visible ? implicitHeight : 0
                                 contentItem: Rectangle {
                                     implicitHeight: Theme.scaled(1)
                                     color: Theme.borderColor
@@ -737,6 +739,7 @@ Page {
 
                             MenuItem {
                                 visible: viewFilter.currentIndex === 0  // Only on "Selected" view
+                                height: visible ? implicitHeight : 0
                                 onTriggered: {
                                     if (profileDelegate.isBuiltIn) {
                                         Settings.app.removeSelectedBuiltInProfile(modelData.name)
@@ -781,6 +784,7 @@ Page {
 
                             MenuItem {
                                 visible: !profileDelegate.isBuiltIn
+                                height: visible ? implicitHeight : 0
                                 onTriggered: {
                                     deleteDialog.profileName = modelData.name
                                     deleteDialog.profileTitle = modelData.title

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -118,11 +118,15 @@ Page {
                             Layout.preferredHeight: Theme.scaled(28)
                             Layout.alignment: Qt.AlignVCenter
                             value: Settings.app.autoLoadRevertMinutes
-                            from: 1
+                            from: 0
                             to: 60
                             stepSize: 1
                             suffix: TranslationManager.translate("profileselector.strip.minutes_short", "min")
-                            displayText: value + " " + TranslationManager.translate("profileselector.strip.minutes_short", "min")
+                            // 0 disables the idle-revert trigger only; the
+                            // startup and wake-from-sleep triggers still fire.
+                            displayText: value === 0
+                                ? TranslationManager.translate("profileselector.strip.off", "off")
+                                : value + " " + TranslationManager.translate("profileselector.strip.minutes_short", "min")
                             accessibleName: TranslationManager.translate("profileselector.strip.revert_after", "revert after")
 
                             // ValueInput emits valueModified on every adjustment and

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -125,7 +125,7 @@ Page {
                             accessibleName: TranslationManager.translate("profileselector.strip.revert_after", "revert after")
 
                             onValueCommitted: function(newValue) {
-                                Settings.app.setAutoLoadRevertMinutes(newValue)
+                                Settings.app.autoLoadRevertMinutes = newValue
                             }
                         }
 
@@ -146,7 +146,7 @@ Page {
                                 Accessible.ignored: true
                             }
                             onClicked: {
-                                Settings.app.setAutoLoadProfileFilename("")
+                                Settings.app.autoLoadProfileFilename = ""
                                 profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.auto_load_disabled", "Auto-load disabled"))
                             }
                         }
@@ -670,10 +670,10 @@ Page {
 
                                 onTriggered: {
                                     if (profileDelegate.isAutoLoad) {
-                                        Settings.app.setAutoLoadProfileFilename("")
+                                        Settings.app.autoLoadProfileFilename = ""
                                         profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.auto_load_disabled", "Auto-load disabled"))
                                     } else {
-                                        Settings.app.setAutoLoadProfileFilename(modelData.name)
+                                        Settings.app.autoLoadProfileFilename = modelData.name
                                         profileSelectorPage.showToast(
                                             TranslationManager.translate("profileselector.toast.auto_load_set", "Auto-load set to %1").arg(modelData.title))
                                     }

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -366,9 +366,10 @@ Page {
         id: settingsSearchDialog
         onResultSelected: function(tabId, cardId, externalRoute) {
             if (externalRoute) {
-                // External destination (e.g., ProfileSelectorPage) — replace
-                // the settings page rather than push so the user gets a clean
-                // back-stack from the search.
+                // External destination outside the Settings tab stack (e.g.
+                // ProfileSelectorPage). `goToProfileSelector()` pushes the
+                // target on top of the Settings page, so the user can press
+                // Back to return to the search context.
                 if (externalRoute === "profileSelector") {
                     root.goToProfileSelector()
                 }

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -364,7 +364,16 @@ Page {
     // Settings search dialog
     SettingsSearchDialog {
         id: settingsSearchDialog
-        onResultSelected: function(tabId, cardId) {
+        onResultSelected: function(tabId, cardId, externalRoute) {
+            if (externalRoute) {
+                // External destination (e.g., ProfileSelectorPage) — replace
+                // the settings page rather than push so the user gets a clean
+                // back-stack from the search.
+                if (externalRoute === "profileSelector") {
+                    root.goToProfileSelector()
+                }
+                return
+            }
             var tabIndex = SettingsTabs.indexOf(tabId)
             if (tabIndex < 0) return
             settingsPage.highlightCardId = cardId || ""

--- a/qml/pages/settings/SettingsSearchDialog.qml
+++ b/qml/pages/settings/SettingsSearchDialog.qml
@@ -16,7 +16,11 @@ Dialog {
     padding: Theme.scaled(16)
     closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
 
-    signal resultSelected(string tabId, string cardId)
+    // `externalRoute` is an optional out-of-settings destination — when set,
+    // `tabId`/`cardId` are ignored and the caller routes by `externalRoute`
+    // (e.g., "profileSelector" navigates to ProfileSelectorPage). Entries
+    // without an `externalRoute` field continue to route by tab/card.
+    signal resultSelected(string tabId, string cardId, string externalRoute)
 
     background: Rectangle {
         color: Theme.surfaceColor
@@ -168,8 +172,12 @@ Dialog {
                 color: resultMouseArea.containsMouse ? Theme.backgroundColor : "transparent"
                 radius: Theme.scaled(6)
 
+                readonly property string badgeLabel: modelData.externalRoute
+                    ? TranslationManager.translate("settings.search.externalBadge", "Profiles")
+                    : SettingsTabs.tabName(modelData.tabId)
+
                 Accessible.role: Accessible.Button
-                Accessible.name: modelData.title + ", " + SettingsTabs.tabName(modelData.tabId) + " tab"
+                Accessible.name: modelData.title + ", " + resultDelegate.badgeLabel + (modelData.externalRoute ? "" : " tab")
                 Accessible.focusable: true
                 Accessible.onPressAction: resultMouseArea.clicked(null)
 
@@ -214,7 +222,7 @@ Dialog {
                         Text {
                             id: tabBadgeText
                             anchors.centerIn: parent
-                            text: SettingsTabs.tabName(modelData.tabId)
+                            text: resultDelegate.badgeLabel
                             color: Theme.primaryColor
                             font.pixelSize: Theme.scaled(10)
                             font.bold: true
@@ -229,7 +237,7 @@ Dialog {
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
                     onClicked: {
-                        searchDialog.resultSelected(modelData.tabId, modelData.cardId || "")
+                        searchDialog.resultSelected(modelData.tabId || "", modelData.cardId || "", modelData.externalRoute || "")
                         searchDialog.close()
                     }
                 }

--- a/resources/icons/pin.svg
+++ b/resources/icons/pin.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"/>
+  <circle cx="12" cy="9" r="2.5"/>
+</svg>

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -23,6 +23,7 @@
         <file>icons/edit.svg</file>
         <file>icons/sleep.svg</file>
         <file>icons/sparkle.svg</file>
+        <file>icons/pin.svg</file>
         <file>icons/hide-keyboard.svg</file>
         <file>icons/battery-0.svg</file>
         <file>icons/battery-25.svg</file>

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -786,6 +786,12 @@ bool ProfileManager::isProfileInSelectedList(const QString& filename) const {
         case ProfileSource::UserCreated:
             return !hiddenProfiles.contains(filename);
         }
+        // Defensive: an unknown ProfileSource (added later without updating
+        // this switch) should default to "not selectable" so auto-load doesn't
+        // silently pin a profile whose eligibility rules haven't been defined.
+        qWarning() << "isProfileInSelectedList: unhandled ProfileSource for"
+                   << filename << "— treating as not selected";
+        return false;
     }
     return false;
 }

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -771,6 +771,47 @@ bool ProfileManager::profileExists(const QString& filename) const {
     return QFile::exists(path);
 }
 
+bool ProfileManager::isProfileInSelectedList(const QString& filename) const {
+    if (filename.isEmpty() || !m_settings) return false;
+
+    const QStringList selectedBuiltIns = m_settings->app()->selectedBuiltInProfiles();
+    const QStringList hiddenProfiles = m_settings->app()->hiddenProfiles();
+
+    for (const ProfileInfo& info : m_allProfiles) {
+        if (info.filename != filename) continue;
+        switch (info.source) {
+        case ProfileSource::BuiltIn:
+            return selectedBuiltIns.contains(filename);
+        case ProfileSource::Downloaded:
+        case ProfileSource::UserCreated:
+            return !hiddenProfiles.contains(filename);
+        }
+    }
+    return false;
+}
+
+void ProfileManager::loadAutoLoadProfileIfNeeded() {
+    if (!m_settings) return;
+
+    const QString filename = m_settings->app()->autoLoadProfileFilename();
+    if (filename.isEmpty()) return;
+
+    if (!isProfileInSelectedList(filename)) {
+        qDebug() << "ProfileManager: auto-load filename" << filename
+                 << "no longer in Selected list — clearing";
+        m_settings->app()->setAutoLoadProfileFilename("");
+        emit autoLoadStaleCleared();
+        return;
+    }
+
+    if (filename == m_baseProfileName) {
+        return; // Already active
+    }
+
+    qDebug() << "ProfileManager: loading auto-load profile" << filename;
+    loadProfile(filename);
+}
+
 bool ProfileManager::deleteProfile(const QString& filename) {
     // Find the profile info
     ProfileSource source = ProfileSource::BuiltIn;
@@ -825,6 +866,11 @@ bool ProfileManager::deleteProfile(const QString& filename) {
                     break;
                 }
             }
+        }
+
+        // Eager-clear: deleting the auto-load profile makes it ineligible
+        if (m_settings && m_settings->app()->autoLoadProfileFilename() == filename) {
+            m_settings->app()->setAutoLoadProfileFilename("");
         }
 
         // Refresh the profile list

--- a/src/controllers/profilemanager.h
+++ b/src/controllers/profilemanager.h
@@ -207,6 +207,11 @@ signals:
     // Emitted when loadAutoLoadProfileIfNeeded() finds the configured filename
     // no longer resolves to a Selected-list profile. The setting is cleared as
     // part of the same call; QML listens to surface a toast.
+    //
+    // Not emitted on eager-clear paths (Settings::addHiddenProfile /
+    // removeSelectedBuiltInProfile / ProfileManager::deleteProfile) — those
+    // clear the filename directly while the user is already on a UI that
+    // makes the change obvious, so no toast is warranted.
     void autoLoadStaleCleared();
 
 private:

--- a/src/controllers/profilemanager.h
+++ b/src/controllers/profilemanager.h
@@ -127,6 +127,8 @@ public:
     Q_INVOKABLE QString titleToFilename(const QString& title) const;
     Q_INVOKABLE QString findProfileByTitle(const QString& title) const;
     Q_INVOKABLE bool profileExists(const QString& filename) const;
+    Q_INVOKABLE bool isProfileInSelectedList(const QString& filename) const;
+    Q_INVOKABLE void loadAutoLoadProfileIfNeeded();
     Q_INVOKABLE QString profileKnowledgeContent(const QString& profileTitle) const;
     Q_INVOKABLE bool deleteProfile(const QString& filename);
     Q_INVOKABLE QVariantMap getProfileByFilename(const QString& filename) const;
@@ -201,6 +203,11 @@ signals:
     // frames; the UI should surface a toast/warning. Mirrors the
     // MainController::shotAbortedNoScale pattern.
     void shotAbortedProfileUploadRetrying();
+
+    // Emitted when loadAutoLoadProfileIfNeeded() finds the configured filename
+    // no longer resolves to a Selected-list profile. The setting is cleared as
+    // part of the same call; QML listens to surface a toast.
+    void autoLoadStaleCleared();
 
 private:
     void loadDefaultProfile();

--- a/src/core/settings_app.cpp
+++ b/src/core/settings_app.cpp
@@ -394,7 +394,7 @@ int SettingsApp::autoLoadRevertMinutes() const {
 }
 
 void SettingsApp::setAutoLoadRevertMinutes(int minutes) {
-    int clamped = qBound(0, minutes, 60);
+    int clamped = qBound(1, minutes, 60);
     if (autoLoadRevertMinutes() != clamped) {
         m_settings.setValue("profile/autoLoadRevertMinutes", clamped);
         emit autoLoadRevertMinutesChanged();

--- a/src/core/settings_app.cpp
+++ b/src/core/settings_app.cpp
@@ -267,6 +267,11 @@ void SettingsApp::removeSelectedBuiltInProfile(const QString& filename) {
         m_settings.setValue("profile/selectedBuiltIns", current);
         emit selectedBuiltInProfilesChanged();
 
+        // Eager-clear: deselecting the auto-load profile makes it ineligible
+        if (autoLoadProfileFilename() == filename) {
+            setAutoLoadProfileFilename("");
+        }
+
         // Also remove from favorites if it was a favorite
         if (isFavoriteProfile(filename)) {
             QByteArray data = m_settings.value("profile/favorites").toByteArray();
@@ -316,6 +321,11 @@ void SettingsApp::addHiddenProfile(const QString& filename) {
         m_settings.setValue("profile/hiddenProfiles", current);
         emit hiddenProfilesChanged();
 
+        // Eager-clear: hiding the auto-load profile makes it ineligible
+        if (autoLoadProfileFilename() == filename) {
+            setAutoLoadProfileFilename("");
+        }
+
         // Also remove from favorites if it was a favorite
         if (isFavoriteProfile(filename)) {
             QByteArray data = m_settings.value("profile/favorites").toByteArray();
@@ -364,6 +374,30 @@ void SettingsApp::setCurrentProfile(const QString& profile) {
     if (currentProfile() != profile) {
         m_settings.setValue("profile/current", profile);
         emit currentProfileChanged();
+    }
+}
+
+// Auto-load profile
+QString SettingsApp::autoLoadProfileFilename() const {
+    return m_settings.value("profile/autoLoadFilename", "").toString();
+}
+
+void SettingsApp::setAutoLoadProfileFilename(const QString& filename) {
+    if (autoLoadProfileFilename() != filename) {
+        m_settings.setValue("profile/autoLoadFilename", filename);
+        emit autoLoadProfileFilenameChanged();
+    }
+}
+
+int SettingsApp::autoLoadRevertMinutes() const {
+    return m_settings.value("profile/autoLoadRevertMinutes", 5).toInt();
+}
+
+void SettingsApp::setAutoLoadRevertMinutes(int minutes) {
+    int clamped = qBound(0, minutes, 60);
+    if (autoLoadRevertMinutes() != clamped) {
+        m_settings.setValue("profile/autoLoadRevertMinutes", clamped);
+        emit autoLoadRevertMinutesChanged();
     }
 }
 

--- a/src/core/settings_app.cpp
+++ b/src/core/settings_app.cpp
@@ -394,7 +394,7 @@ int SettingsApp::autoLoadRevertMinutes() const {
 }
 
 void SettingsApp::setAutoLoadRevertMinutes(int minutes) {
-    int clamped = qBound(1, minutes, 60);
+    int clamped = qBound(0, minutes, 60);
     if (autoLoadRevertMinutes() != clamped) {
         m_settings.setValue("profile/autoLoadRevertMinutes", clamped);
         emit autoLoadRevertMinutesChanged();

--- a/src/core/settings_app.h
+++ b/src/core/settings_app.h
@@ -30,6 +30,8 @@ class SettingsApp : public QObject {
     Q_PROPERTY(QStringList selectedBuiltInProfiles READ selectedBuiltInProfiles WRITE setSelectedBuiltInProfiles NOTIFY selectedBuiltInProfilesChanged)
     Q_PROPERTY(QStringList hiddenProfiles READ hiddenProfiles WRITE setHiddenProfiles NOTIFY hiddenProfilesChanged)
     Q_PROPERTY(QString currentProfile READ currentProfile WRITE setCurrentProfile NOTIFY currentProfileChanged)
+    Q_PROPERTY(QString autoLoadProfileFilename READ autoLoadProfileFilename WRITE setAutoLoadProfileFilename NOTIFY autoLoadProfileFilenameChanged)
+    Q_PROPERTY(int autoLoadRevertMinutes READ autoLoadRevertMinutes WRITE setAutoLoadRevertMinutes NOTIFY autoLoadRevertMinutesChanged)
 
     // Auto-update
     Q_PROPERTY(bool autoCheckUpdates READ autoCheckUpdates WRITE setAutoCheckUpdates NOTIFY autoCheckUpdatesChanged)
@@ -103,6 +105,12 @@ public:
     QString currentProfile() const;
     void setCurrentProfile(const QString& profile);
 
+    // Auto-load profile
+    QString autoLoadProfileFilename() const;
+    void setAutoLoadProfileFilename(const QString& filename);
+    int autoLoadRevertMinutes() const;
+    void setAutoLoadRevertMinutes(int minutes);
+
     // Auto-update
     bool autoCheckUpdates() const;
     void setAutoCheckUpdates(bool enabled);
@@ -151,6 +159,8 @@ signals:
     void selectedBuiltInProfilesChanged();
     void hiddenProfilesChanged();
     void currentProfileChanged();
+    void autoLoadProfileFilenameChanged();
+    void autoLoadRevertMinutesChanged();
     void autoCheckUpdatesChanged();
     void betaUpdatesEnabledChanged();
     void lastKnownApkSizeBytesChanged();

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -171,6 +171,8 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
         hiddenProfiles.append(s);
     }
     profile["hiddenProfiles"] = hiddenProfiles;
+    profile["autoLoadFilename"] = settings->app()->autoLoadProfileFilename();
+    profile["autoLoadRevertMinutes"] = settings->app()->autoLoadRevertMinutes();
     root["profile"] = profile;
 
     // Shot history settings
@@ -571,6 +573,13 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
                 hidden.append(v.toString());
             }
             settings->app()->setHiddenProfiles(hidden);
+        }
+
+        if (profile.contains("autoLoadFilename")) {
+            settings->app()->setAutoLoadProfileFilename(profile["autoLoadFilename"].toString());
+        }
+        if (profile.contains("autoLoadRevertMinutes")) {
+            settings->app()->setAutoLoadRevertMinutes(profile["autoLoadRevertMinutes"].toInt());
         }
     }
 

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -27,7 +27,7 @@ void registerMachineTools(McpToolRegistry* registry, DE1Device* device,
                           ProfileManager* profileManager);
 void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistory);
 class ProfileManager;
-void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileManager);
+void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileManager, Settings* settings);
 class AccessibilityManager;
 class ScreensaverVideoManager;
 class TranslationManager;
@@ -148,7 +148,7 @@ void McpServer::registerAllTools()
 {
     registerMachineTools(m_toolRegistry, m_device, m_machineState, m_mainController, m_profileManager);
     registerShotTools(m_toolRegistry, m_shotHistory);
-    registerProfileTools(m_toolRegistry, m_profileManager);
+    registerProfileTools(m_toolRegistry, m_profileManager, m_settings);
     registerSettingsReadTools(m_toolRegistry, m_settings, m_accessibilityManager,
                               m_screensaverManager, m_translationManager, m_batteryManager);
     registerDialingTools(m_toolRegistry, m_mainController, m_profileManager, m_shotHistory, m_settings);

--- a/src/mcp/mcptools_profiles.cpp
+++ b/src/mcp/mcptools_profiles.cpp
@@ -6,6 +6,8 @@
 #include "mcpserver.h"
 #include "mcptoolregistry.h"
 #include "../controllers/profilemanager.h"
+#include "../core/settings.h"
+#include "../core/settings_app.h"
 #include "../profile/profile.h"
 #include "../profile/recipeparams.h"
 
@@ -14,7 +16,7 @@
 #include <QJsonDocument>
 #include <QSet>
 
-void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileManager)
+void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileManager, Settings* settings)
 {
     // profiles_list
     registry->registerTool(
@@ -107,6 +109,32 @@ void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileMana
             result["profiles"] = profiles;
             result["count"] = profiles.size();
             result["_resourceLinks"] = links;
+            return result;
+        },
+        "read");
+
+    // profiles_get_auto_load
+    registry->registerTool(
+        "profiles_get_auto_load",
+        "Get the configured auto-load profile filename and revert timeout. "
+        "Auto-load reloads the pinned profile on app start, DE1 wake-from-sleep, "
+        "and after `revertMinutes` of inactivity on the Idle page.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
+        [profileManager, settings](const QJsonObject&) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) {
+                result["error"] = "Settings not available";
+                return result;
+            }
+            const QString filename = settings->app()->autoLoadProfileFilename();
+            result["filename"] = filename;
+            result["revertMinutes"] = settings->app()->autoLoadRevertMinutes();
+            if (!filename.isEmpty() && profileManager) {
+                QVariantMap profile = profileManager->getProfileByFilename(filename);
+                if (!profile.isEmpty()) {
+                    result["title"] = profile["title"].toString();
+                }
+            }
             return result;
         },
         "read");

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -1157,4 +1157,82 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
         },
         "settings");
 
+    // profiles_set_auto_load — pin a profile as the auto-load target. Validated
+    // synchronously (filename non-empty, profile exists, profile is in the
+    // Selected list); the actual settings write hops to the GUI thread.
+    registry->registerAsyncTool(
+        "profiles_set_auto_load",
+        "Pin a profile as the auto-load target. The pinned profile is reloaded "
+        "on app start, DE1 wake-from-sleep, and after `revertMinutes` of "
+        "inactivity on the Idle page. Replaces any prior auto-load. The "
+        "filename must exist and be in the Selected list.",
+        QJsonObject{
+            {"type", "object"},
+            {"properties", QJsonObject{
+                {"filename", QJsonObject{{"type", "string"}, {"description", "Profile filename (without .json extension)"}}},
+                {"revertMinutes", QJsonObject{{"type", "integer"}, {"description", "Optional. Minutes of idle inactivity before reverting. 0..60; 0 disables the inactivity trigger but keeps startup/wake triggers."}}}
+            }},
+            {"required", QJsonArray{"filename"}}
+        },
+        [profileManager, settings](const QJsonObject& args, std::function<void(QJsonObject)> respond) {
+            if (!settings || !profileManager) {
+                respond(QJsonObject{{"error", "Settings or ProfileManager not available"}});
+                return;
+            }
+            const QString filename = args["filename"].toString();
+            if (filename.isEmpty()) {
+                respond(QJsonObject{{"error", "filename is required"}});
+                return;
+            }
+            if (!profileManager->profileExists(filename)) {
+                respond(QJsonObject{{"error", "Profile not found: " + filename}});
+                return;
+            }
+            if (!profileManager->isProfileInSelectedList(filename)) {
+                respond(QJsonObject{{"error", "Profile is not in the Selected list"}});
+                return;
+            }
+
+            const bool hasRevert = args.contains("revertMinutes");
+            const int revertMinutes = hasRevert ? args["revertMinutes"].toInt() : -1;
+
+            QMetaObject::invokeMethod(qApp, [settings, profileManager, filename, hasRevert, revertMinutes, respond]() {
+                settings->app()->setAutoLoadProfileFilename(filename);
+                if (hasRevert) {
+                    settings->app()->setAutoLoadRevertMinutes(revertMinutes);
+                }
+                QJsonObject result;
+                result["success"] = true;
+                result["filename"] = filename;
+                result["revertMinutes"] = settings->app()->autoLoadRevertMinutes();
+                QVariantMap profile = profileManager->getProfileByFilename(filename);
+                if (!profile.isEmpty()) {
+                    result["title"] = profile["title"].toString();
+                }
+                respond(result);
+            }, Qt::QueuedConnection);
+        },
+        "settings");
+
+    // profiles_clear_auto_load — disable auto-load without modifying the
+    // revert-timeout setting (so enabling auto-load later preserves the
+    // configured value).
+    registry->registerAsyncTool(
+        "profiles_clear_auto_load",
+        "Disable auto-load by clearing the pinned filename. Does not modify "
+        "`revertMinutes` — the configured timeout is preserved across "
+        "enable/disable cycles.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
+        [settings](const QJsonObject&, std::function<void(QJsonObject)> respond) {
+            if (!settings) {
+                respond(QJsonObject{{"error", "Settings not available"}});
+                return;
+            }
+            QMetaObject::invokeMethod(qApp, [settings, respond]() {
+                settings->app()->setAutoLoadProfileFilename("");
+                respond(QJsonObject{{"success", true}});
+            }, Qt::QueuedConnection);
+        },
+        "settings");
+
 }

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -1170,7 +1170,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             {"type", "object"},
             {"properties", QJsonObject{
                 {"filename", QJsonObject{{"type", "string"}, {"description", "Profile filename (without .json extension)"}}},
-                {"revertMinutes", QJsonObject{{"type", "integer"}, {"description", "Optional. Minutes of idle inactivity before reverting. 0..60; 0 disables the inactivity trigger but keeps startup/wake triggers."}}}
+                {"revertMinutes", QJsonObject{{"type", "integer"}, {"description", "Optional. Minutes of idle inactivity on the Idle page before reverting to the auto-load profile. Range 1..60; values are clamped."}}}
             }},
             {"required", QJsonArray{"filename"}}
         },

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -1170,7 +1170,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             {"type", "object"},
             {"properties", QJsonObject{
                 {"filename", QJsonObject{{"type", "string"}, {"description", "Profile filename (without .json extension)"}}},
-                {"revertMinutes", QJsonObject{{"type", "integer"}, {"description", "Optional. Minutes of idle inactivity on the Idle page before reverting to the auto-load profile. Range 1..60; values are clamped."}}}
+                {"revertMinutes", QJsonObject{{"type", "integer"}, {"description", "Optional. Minutes of idle inactivity on the Idle page before reverting to the auto-load profile. Range 0..60 (clamped); 0 disables the idle trigger but keeps the startup and wake-from-sleep triggers."}}}
             }},
             {"required", QJsonArray{"filename"}}
         },

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,6 +155,7 @@ add_decenza_test(tst_recipeparams
 add_decenza_test(tst_settings
     tst_settings.cpp
     ${CORE_SOURCES}
+    ${CMAKE_SOURCE_DIR}/src/core/settingsserializer.cpp
 )
 
 # --- tst_saw_settings: per-(profile, scale) SAW learning + batch + bootstrap ---

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -37,7 +37,7 @@ class BLEManager;
 class MemoryMonitor;
 void registerMachineTools(McpToolRegistry*, DE1Device*, MachineState*, MainController*, ProfileManager*) {}
 void registerShotTools(McpToolRegistry*, ShotHistoryStorage*) {}
-void registerProfileTools(McpToolRegistry*, ProfileManager*) {}
+void registerProfileTools(McpToolRegistry*, ProfileManager*, Settings*) {}
 void registerSettingsReadTools(McpToolRegistry*, Settings*, AccessibilityManager*, ScreensaverVideoManager*, TranslationManager*, BatteryManager*) {}
 void registerDialingTools(McpToolRegistry*, MainController*, ProfileManager*, ShotHistoryStorage*, Settings*) {}
 void registerControlTools(McpToolRegistry*, DE1Device*, MachineState*, ProfileManager*, MainController*, Settings*) {}

--- a/tests/tst_mcpserver_session.cpp
+++ b/tests/tst_mcpserver_session.cpp
@@ -27,7 +27,7 @@ class BLEManager;
 class MemoryMonitor;
 void registerMachineTools(McpToolRegistry*, DE1Device*, MachineState*, MainController*, ProfileManager*) {}
 void registerShotTools(McpToolRegistry*, ShotHistoryStorage*) {}
-void registerProfileTools(McpToolRegistry*, ProfileManager*) {}
+void registerProfileTools(McpToolRegistry*, ProfileManager*, Settings*) {}
 void registerSettingsReadTools(McpToolRegistry*, Settings*, AccessibilityManager*, ScreensaverVideoManager*, TranslationManager*, BatteryManager*) {}
 void registerDialingTools(McpToolRegistry*, MainController*, ProfileManager*, ShotHistoryStorage*, Settings*) {}
 void registerControlTools(McpToolRegistry*, DE1Device*, MachineState*, ProfileManager*, MainController*, Settings*) {}

--- a/tests/tst_mcptools_profiles.cpp
+++ b/tests/tst_mcptools_profiles.cpp
@@ -13,7 +13,8 @@ using namespace DE1::Characteristic;
 // Forward declaration — implemented in mcptools_profiles.cpp
 class ProfileManager;
 class McpToolRegistry;
-void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileManager);
+class Settings;
+void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileManager, Settings* settings);
 
 // Test MCP profile tools against ProfileManager + MockTransport.
 // Critical regression: profiles_edit_params must trigger BLE upload (PR #561).
@@ -128,7 +129,7 @@ private slots:
     void profilesListReturnsArray()
     {
         McpTestFixture f;
-        registerProfileTools(&f.registry, &f.profileManager);
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
 
         QJsonObject result = f.callTool("profiles_list", {});
         QVERIFY(result.contains("profiles"));
@@ -141,7 +142,7 @@ private slots:
     void profilesGetActiveReturnsFilename()
     {
         McpTestFixture f;
-        registerProfileTools(&f.registry, &f.profileManager);
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
         loadDFlowProfile(f);
 
         QJsonObject result = f.callTool("profiles_get_active", {});
@@ -156,7 +157,7 @@ private slots:
     void profilesGetParamsReturnsDFlowFields()
     {
         McpTestFixture f;
-        registerProfileTools(&f.registry, &f.profileManager);
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
         loadDFlowProfile(f);
 
         QJsonObject result = f.callTool("profiles_get_params", {});
@@ -169,7 +170,7 @@ private slots:
     void profilesGetParamsReturnsAdvancedFields()
     {
         McpTestFixture f;
-        registerProfileTools(&f.registry, &f.profileManager);
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
         loadAdvancedProfile(f);
 
         QJsonObject result = f.callTool("profiles_get_params", {});
@@ -184,7 +185,7 @@ private slots:
         // The critical test: editing recipe params must write frames to BLE.
         // PR #561 was a regression where this path silently stopped uploading.
         McpTestFixture f;
-        registerProfileTools(&f.registry, &f.profileManager);
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
         loadDFlowProfile(f);
         f.transport.clearWrites();
 
@@ -206,7 +207,7 @@ private slots:
     void editParamsAdvancedTriggersBleUpload()
     {
         McpTestFixture f;
-        registerProfileTools(&f.registry, &f.profileManager);
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
         loadAdvancedProfile(f);
         f.transport.clearWrites();
 
@@ -224,7 +225,7 @@ private slots:
     void editParamsUpdatesProfileState()
     {
         McpTestFixture f;
-        registerProfileTools(&f.registry, &f.profileManager);
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
         loadDFlowProfile(f);
 
         QJsonObject args;
@@ -241,7 +242,7 @@ private slots:
     void profilesGetDetailRequiresFilename()
     {
         McpTestFixture f;
-        registerProfileTools(&f.registry, &f.profileManager);
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
 
         QJsonObject result = f.callTool("profiles_get_detail", {{"filename", ""}});
         QVERIFY(result.contains("error"));

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -12,6 +12,7 @@
 #include <QRegularExpression>
 
 #include "mocks/McpTestFixture.h"
+#include "core/settings_app.h"
 #include "core/settings_brew.h"
 #include "core/settings_dye.h"
 #include "mcp/mcpresourceregistry.h"
@@ -2240,6 +2241,82 @@ private slots:
 
         QVERIFY(!f.profileManager.profileUploadRetrying());
         QCOMPARE(spy.count(), 0);
+    }
+
+    // ===== Auto-load entry point =====
+
+    void autoLoadEmptyFilenameIsNoOp() {
+        McpTestFixture f;
+        f.settings.app()->setAutoLoadProfileFilename("");
+        QSignalSpy staleSpy(&f.profileManager, &ProfileManager::autoLoadStaleCleared);
+        QSignalSpy loadSpy(&f.profileManager, &ProfileManager::currentProfileChanged);
+
+        f.profileManager.loadAutoLoadProfileIfNeeded();
+
+        QCOMPARE(staleSpy.count(), 0);
+        QCOMPARE(loadSpy.count(), 0);
+    }
+
+    void autoLoadStaleFilenameClears() {
+        McpTestFixture f;
+        f.settings.app()->setAutoLoadProfileFilename("nonexistent-profile-xyz");
+        QSignalSpy staleSpy(&f.profileManager, &ProfileManager::autoLoadStaleCleared);
+
+        f.profileManager.loadAutoLoadProfileIfNeeded();
+
+        QCOMPARE(staleSpy.count(), 1);
+        QCOMPARE(f.settings.app()->autoLoadProfileFilename(), QString(""));
+    }
+
+    void autoLoadAlreadyActiveDoesNotReload() {
+        McpTestFixture f;
+        loadDFlowProfile(f, "D-Flow / Active");
+        // Manually drive base name to mimic a previously saved profile name.
+        const QString baseName = f.profileManager.baseProfileName();
+        // If baseName is empty (JSON load doesn't set it), the test would fail
+        // for an unrelated reason — only continue if the precondition holds.
+        if (baseName.isEmpty()) {
+            QSKIP("baseProfileName not set after JSON load; not a valid precondition for this test");
+        }
+        f.settings.app()->setAutoLoadProfileFilename(baseName);
+
+        QSignalSpy loadSpy(&f.profileManager, &ProfileManager::currentProfileChanged);
+        f.profileManager.loadAutoLoadProfileIfNeeded();
+
+        // No additional currentProfileChanged emissions — the auto-load was a no-op.
+        QCOMPARE(loadSpy.count(), 0);
+    }
+
+    void eagerClearOnAddHiddenProfile() {
+        // Hiding the pinned profile must clear the auto-load setting eagerly
+        // so the UI strip disappears immediately.
+        McpTestFixture f;
+        const QString filename = "test-user-profile";
+        // McpTestFixture uses real QSettings; ensure the precondition (profile
+        // not yet hidden) so addHiddenProfile actually mutates state. Otherwise
+        // a stale entry from a previous run short-circuits the eager-clear.
+        f.settings.app()->removeHiddenProfile(filename);
+        f.settings.app()->setAutoLoadProfileFilename(filename);
+        QCOMPARE(f.settings.app()->autoLoadProfileFilename(), filename);
+
+        f.settings.app()->addHiddenProfile(filename);
+
+        QCOMPARE(f.settings.app()->autoLoadProfileFilename(), QString(""));
+
+        // Cleanup so subsequent test runs start from a known state.
+        f.settings.app()->removeHiddenProfile(filename);
+    }
+
+    void eagerClearOnRemoveSelectedBuiltIn() {
+        McpTestFixture f;
+        const QString filename = "test-builtin-profile";
+        f.settings.app()->removeSelectedBuiltInProfile(filename);
+        f.settings.app()->addSelectedBuiltInProfile(filename);
+        f.settings.app()->setAutoLoadProfileFilename(filename);
+
+        f.settings.app()->removeSelectedBuiltInProfile(filename);
+
+        QCOMPARE(f.settings.app()->autoLoadProfileFilename(), QString(""));
     }
 };
 

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -252,15 +252,15 @@ private slots:
     }
 
     void autoLoadRevertMinutesClamped() {
-        // Range is 1..60 — sub-1 values floor to 1, above-60 ceil to 60.
+        // Range is 0..60 — 0 means "idle revert off" but startup + wake still fire.
         m_settings.app()->setAutoLoadRevertMinutes(-5);
-        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 1);
-        m_settings.app()->setAutoLoadRevertMinutes(0);
-        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 1);
+        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 0);
         m_settings.app()->setAutoLoadRevertMinutes(200);
         QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 60);
         m_settings.app()->setAutoLoadRevertMinutes(30);
         QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 30);
+        m_settings.app()->setAutoLoadRevertMinutes(0);
+        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 0);
     }
 
     void autoLoadBundleRoundTrip() {

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -2,10 +2,14 @@
 #include <QSignalSpy>
 
 #include "core/settings.h"
+#include "core/settings_app.h"
 #include "core/settings_brew.h"
 #include "core/settings_dye.h"
 #include "core/settings_theme.h"
 #include "core/settings_visualizer.h"
+#include "core/settingsserializer.h"
+#include <QJsonObject>
+#include <QRegularExpression>
 
 // Test Settings property round-trip and signal emission.
 // Settings uses QSettings("DecentEspresso", "DE1Qt") which reads/writes to
@@ -26,6 +30,8 @@ private:
     int m_origShotRating;
     bool m_origIgnoreVolume;
     QString m_origDyeBeanBrand;
+    QString m_origAutoLoadFilename;
+    int m_origAutoLoadRevertMinutes;
 
 private slots:
 
@@ -38,6 +44,8 @@ private slots:
         m_origShotRating = m_settings.visualizer()->defaultShotRating();
         m_origIgnoreVolume = m_settings.brew()->ignoreVolumeWithScale();
         m_origDyeBeanBrand = m_settings.dye()->dyeBeanBrand();
+        m_origAutoLoadFilename = m_settings.app()->autoLoadProfileFilename();
+        m_origAutoLoadRevertMinutes = m_settings.app()->autoLoadRevertMinutes();
     }
 
     void cleanup() {
@@ -49,6 +57,8 @@ private slots:
         m_settings.visualizer()->setDefaultShotRating(m_origShotRating);
         m_settings.brew()->setIgnoreVolumeWithScale(m_origIgnoreVolume);
         m_settings.dye()->setDyeBeanBrand(m_origDyeBeanBrand);
+        m_settings.app()->setAutoLoadProfileFilename(m_origAutoLoadFilename);
+        m_settings.app()->setAutoLoadRevertMinutes(m_origAutoLoadRevertMinutes);
     }
 
     // ==========================================
@@ -216,6 +226,59 @@ private slots:
 
         m_settings.brew()->setWaterVolumeMode(origMode);
         m_settings.brew()->setWaterVolume(origVol);
+    }
+
+    // ==========================================
+    // Auto-load profile settings
+    // ==========================================
+
+    void autoLoadFilenameRoundTrip() {
+        m_settings.app()->setAutoLoadProfileFilename("");  // baseline
+        QSignalSpy spy(m_settings.app(), &SettingsApp::autoLoadProfileFilenameChanged);
+        m_settings.app()->setAutoLoadProfileFilename("my-profile");
+        QCOMPARE(m_settings.app()->autoLoadProfileFilename(), QString("my-profile"));
+        QCOMPARE(spy.count(), 1);
+        // Setting the same value again is a no-op (no second signal).
+        m_settings.app()->setAutoLoadProfileFilename("my-profile");
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void autoLoadRevertMinutesRoundTrip() {
+        m_settings.app()->setAutoLoadRevertMinutes(5);
+        QSignalSpy spy(m_settings.app(), &SettingsApp::autoLoadRevertMinutesChanged);
+        m_settings.app()->setAutoLoadRevertMinutes(12);
+        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 12);
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void autoLoadRevertMinutesClamped() {
+        m_settings.app()->setAutoLoadRevertMinutes(-5);
+        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 0);
+        m_settings.app()->setAutoLoadRevertMinutes(200);
+        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 60);
+        m_settings.app()->setAutoLoadRevertMinutes(30);
+        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 30);
+    }
+
+    void autoLoadBundleRoundTrip() {
+        m_settings.app()->setAutoLoadProfileFilename("preferred-profile");
+        m_settings.app()->setAutoLoadRevertMinutes(17);
+
+        QJsonObject bundle = SettingsSerializer::exportToJson(&m_settings, false);
+
+        // Mutate to confirm import overwrites
+        m_settings.app()->setAutoLoadProfileFilename("other-profile");
+        m_settings.app()->setAutoLoadRevertMinutes(2);
+
+        // importFromJson emits a qWarning when it replaces the favorites array,
+        // even with 0 → 0 favorites. Suppress that one expected message so the
+        // test doesn't fall foul of the "no warnings in tests" rule.
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(QStringLiteral("SettingsSerializer: importFromJson replacing .* favorites")));
+
+        QVERIFY(SettingsSerializer::importFromJson(&m_settings, bundle));
+        QCOMPARE(m_settings.app()->autoLoadProfileFilename(), QString("preferred-profile"));
+        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 17);
     }
 };
 

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -252,8 +252,11 @@ private slots:
     }
 
     void autoLoadRevertMinutesClamped() {
+        // Range is 1..60 — sub-1 values floor to 1, above-60 ceil to 60.
         m_settings.app()->setAutoLoadRevertMinutes(-5);
-        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 0);
+        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 1);
+        m_settings.app()->setAutoLoadRevertMinutes(0);
+        QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 1);
         m_settings.app()->setAutoLoadRevertMinutes(200);
         QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 60);
         m_settings.app()->setAutoLoadRevertMinutes(30);


### PR DESCRIPTION
## Summary

- **Pin one profile** as the "come home to" auto-load and Decenza reloads it on three triggers: app startup, DE1 wake from sleep (`Sleep → Idle`), and after N minutes of inactivity on the Idle page (0..60, default 5; 0 disables this trigger only). Reuses the existing 1-minute `sleepCountdownTimer` tick — no new `QTimer`.
- **UI on `ProfileSelectorPage`** only: pin icon on the auto-load row, contextual `Set/Disable Auto-Load` overflow menu item (gated to Selected-list rows), and a status strip above the view filter with the title, a `0..60 min` `ValueInput` (0 → "Never"), and a clear button. Settings search picks up an `Auto-Load Profile` breadcrumb that lands on the page.
- **Three MCP tools**: `profiles_get_auto_load` (read), `profiles_set_auto_load` (settings), `profiles_clear_auto_load` (settings).
- **Settings**: `autoLoadProfileFilename` and `autoLoadRevertMinutes` round-trip through the backup bundle; cleared eagerly when the pinned profile is hidden, de-selected, or deleted; cleared with toast (`Auto-load profile is no longer available`) at trigger time if stale.
- **Docs**: `docs/CLAUDE_MD/RECIPE_PROFILES.md`, `docs/CLAUDE_MD/MCP_SERVER.md`, and `Decenza.wiki/Manual.md` (already pushed: `Kulitorum/Decenza.wiki@bfd7513`).

OpenSpec change: [`add-profile-auto-load`](openspec/changes/add-profile-auto-load).

## Test plan

Automated (via Qt Creator → Run Tests): **2061 passed, 0 failed, 0 skipped, 0 warnings** — 9 new tests:
- `tst_Settings` — `autoLoadFilenameRoundTrip`, `autoLoadRevertMinutesRoundTrip`, `autoLoadRevertMinutesClamped`, `autoLoadBundleRoundTrip`
- `tst_ProfileManager` — `autoLoadEmptyFilenameIsNoOp`, `autoLoadStaleFilenameClears`, `autoLoadAlreadyActiveDoesNotReload`, `eagerClearOnAddHiddenProfile`, `eagerClearOnRemoveSelectedBuiltIn`

Manual smoke (please verify on a real DE1):
- [ ] Open Profiles → ⋮ on a Selected profile → **Set Auto-Load**. Pin icon appears on the row, strip appears above the view filter, toast `Auto-load set to <name>` confirms.
- [ ] Strip's minutes input edits `Settings.app.autoLoadRevertMinutes`; `0` renders as "Never".
- [ ] **×** button on strip clears auto-load; `Disable Auto-Load` from the overflow does the same.
- [ ] **Startup trigger**: pin profile A, switch to B, close the app, reopen — active profile is A.
- [ ] **Wake-from-sleep trigger**: pin profile A, switch to B, put DE1 to sleep, wake it — active profile is A.
- [ ] **Idle-minute trigger**: pin profile A with `revertMinutes = 1`, switch to B on the Idle page, wait — at 60 s with no input, A loads.
- [ ] **Stale clear**: pin a user profile, then hide/delete it — toast `Auto-load profile is no longer available` fires, strip disappears.
- [ ] **Settings search**: search for "auto-load" / "automatic profile" — result lands on `ProfileSelectorPage`.
- [ ] **MCP**: `profiles_get_auto_load`, `profiles_set_auto_load`, `profiles_clear_auto_load` round-trip via an MCP client.
- [ ] **Pin icon** renders correctly on Android, macOS, Windows builds (icon-cache caveat — clear app data if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)