### PR TITLE
fix(android,shotserver): add ACCESS_NETWORK_STATE + gate health-check log to state changes

### DIFF
--- a/android/AndroidManifest.xml.in
+++ b/android/AndroidManifest.xml.in
@@ -13,6 +13,14 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Lets Qt's QNetworkInformation report real reachability instead of
+         "Unknown". Without this, QtAndroidNetworkInformation.registerReceiver()
+         throws a SecurityException at every cold start (issue #1124) and any
+         reachability-driven code (Visualizer retry, ShotServer wifi-loss
+         handling, UpdateChecker reconnect retry) sees stale state forever.
+         Normal protection level — granted at install time, no runtime
+         prompt. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!-- Allows us to hold a WifiManager.MulticastLock so incoming UDP broadcast
          discovery datagrams aren't filtered by the OS on Wi-Fi. -->
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -906,10 +906,18 @@ void ShotServer::onCleanupTimerTick()
     if (m_server) {
         qintptr fd = m_server->socketDescriptor();
         bool listening = m_server->isListening();
-        if (fd == -1 && listening)
+        if (fd == -1 && listening) {
+            // The bug we're hunting — always log this when it happens, no
+            // de-dup, so consecutive ticks paint a clear timeline.
             qWarning() << "ShotServer: socketDescriptor() == -1 while isListening() == true — listen socket may have been invalidated by OS";
-        else
+        } else if (fd != m_lastHealthFd || listening != m_lastHealthListening) {
+            // Only log when state changes (incl. the first tick after startup).
+            // Steady-state was burning ~120 lines/hr without surfacing any new
+            // signal; a flip in either field is the actual breadcrumb.
             qDebug() << "ShotServer: health check — isListening:" << listening << "socketDescriptor:" << fd;
+        }
+        m_lastHealthFd = fd;
+        m_lastHealthListening = listening;
     }
 
     QList<QTcpSocket*> staleConnections;

--- a/src/network/shotserver.h
+++ b/src/network/shotserver.h
@@ -242,6 +242,14 @@ private:
 
     QTcpServer* m_server = nullptr;
     QUdpSocket* m_discoverySocket = nullptr;
+
+    // Listen-socket health-check state. We only log on state change instead
+    // of every 30s tick — both to cut steady-state noise and so the actual
+    // signal (a flip in isListening/socketDescriptor) stands out when
+    // chasing the listen-socket invalidation bug. Sentinel `-2` distinguishes
+    // "no health check yet observed" from a valid `-1` socket descriptor.
+    qintptr m_lastHealthFd = -2;
+    bool m_lastHealthListening = false;
 #ifdef Q_OS_ANDROID
     QJniObject m_multicastLock;
 #endif


### PR DESCRIPTION
## Summary

Two unrelated cleanups bundled because they share log-noise origin.

### 1. Closes #1124 — missing `ACCESS_NETWORK_STATE`

Every cold start of the Android build threw:
```
WARN java.lang.SecurityException: ConnectivityService: Neither user 10311 nor current process has android.permission.ACCESS_NETWORK_STATE.
  at org.qtproject.qt.android.networkinformation.QtAndroidNetworkInformation.registerReceiver(...)
```
and left `QNetworkInformation::Reachability::Unknown` for the rest of the session, defeating reachability-driven retry paths.

Added `<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />` to [`android/AndroidManifest.xml.in`](https://github.com/Kulitorum/Decenza/blob/main/android/AndroidManifest.xml.in). Normal protection level, granted at install time — no runtime prompt.

### 2. ShotServer health-check: log only on state change

The 30s health-check tick was emitting `isListening: true socketDescriptor: N` every tick (~120 lines/hr) even when nothing changed. This buried the bug we're actually hunting — the `socketDescriptor() == -1 while isListening() == true` listen-socket-invalidation case.

Now logs only when `isListening` or `socketDescriptor` flips. The real warning (the bug signal) still fires every tick when it happens, un-deduped, so consecutive ticks paint a clear timeline of when the socket dies.

## Test plan

- [x] `mcp__qtcreator__build` — green
- [x] `mcp__qtcreator__run_tests` — 2061 passing, 0 warnings
- [ ] Manual: cold-start the Android build, confirm:
  - No `SecurityException` stack trace at `[~0.086]`
  - `[Network] initial reachability:` reports a real value (`Online` / `Local`) instead of `Unknown`
- [ ] Manual: cold-start, watch ShotServer log:
  - First tick shows `ShotServer: health check — ...` once
  - Subsequent ticks are silent while state holds
  - On wifi drop / kill 9 the socket, the `-1 while listening` warning fires every tick (un-deduped, intentional)

🤖 Generated with [Claude Code](https://claude.ai/code)