### PR TITLE
Remove temperatureUnstable badge end-to-end (#1128)

### DIFF
--- a/docs/CLAUDE_MD/MCP_SERVER.md
+++ b/docs/CLAUDE_MD/MCP_SERVER.md
@@ -294,7 +294,6 @@ Both are populated by a single call to `ShotAnalysis::analyzeShot`, so they cann
   "channeling": { "checked": true, "severity": "none" | "transient" | "sustained", "spikeTimeSec": 18.2 },
   "flowTrend":  { "checked": true, "direction": "stable" | "rising" | "falling", "deltaMlPerSec": 0.3 },
   "preinfusion": { "observed": true, "dripWeightG": 1.4, "durationSec": 8.3 },
-  "tempStability": { "checked": true, "intentionalStepping": false, "avgDeviationC": 1.1, "unstable": false },
   "grind": {
     "checked": true, "hasData": true,
     "direction": "tooFine" | "tooCoarse" | "onTarget" | "chokedPuck" | "yieldOvershoot",
@@ -353,7 +352,7 @@ Either sub-arm sets `chokedPuck = true`. The per-sample pressure floor is `minPr
 
 When a detector's `checked` (or `hasData`) flag is `false`, the detector was suppressed — most often by the `pourTruncated` cascade, but also by beverage-type skips (filter / pourover) or per-profile analysis flags (e.g. `flow_trend_ok`). Treat that as "no signal for this detector," not "clean signal."
 
-The five legacy badge booleans (`channelingDetected`, `temperatureUnstable`, `grindIssueDetected`, `skipFirstFrameDetected`, `pourTruncatedDetected`) remain available for backwards compatibility and are computed identically — `detectorResults` is a superset.
+The four legacy badge booleans (`channelingDetected`, `grindIssueDetected`, `skipFirstFrameDetected`, `pourTruncatedDetected`) remain available for backwards compatibility and are computed identically — `detectorResults` is a superset. The historical fifth (`temperatureUnstable`) and its `tempStability` block were removed end-to-end (see openspec change `remove-temperature-unstable-badge`).
 
 ## Resources (SSE Notifications)
 

--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -42,7 +42,7 @@ shared `shotReview/advancedMode` setting toggles information density on both.
 
 ### Quality badges
 
-Five flags, surfaced via `qml/components/QualityBadges.qml`. When any fire,
+Four flags, surfaced via `qml/components/QualityBadges.qml`. When any fire,
 those chips show; when none fire, a single green "Clean extraction" chip
 shows. A tappable "Shot Summary" chip always sits at the end of the row —
 it's the entry point to the analysis dialog described in §3.
@@ -51,23 +51,27 @@ it's the entry point to the analysis dialog described in §3.
 | -------------------------- | ------ | ---------------------- | ---------------------------- |
 | `pourTruncatedDetected`    | red    | "Puck failed"          | `detectPourTruncated`        |
 | `channelingDetected`       | red    | "Channeling detected"  | `detectChannelingFromDerivative` |
-| `temperatureUnstable`      | orange | "Temp unstable"        | `avgTempDeviation` + threshold |
 | `grindIssueDetected`       | orange | "Grind issue"          | `detectGrindIssue` (`analyzeFlowVsGoal`) |
 | `skipFirstFrameDetected`   | red    | "First step skipped"   | `detectSkipFirstFrame`       |
 
+(A fifth flag, `temperatureUnstable`, was retired — see openspec change
+`remove-temperature-unstable-badge`. The detector measured average
+deviation from goal but was labeled "Temp unstable"; in practice, the
+deviation it caught was profile-design intent on D-Flow / Extractamundo /
+TurboBloom and 9+ other built-in profiles whose temperature gap is by
+design.)
+
 **Suppression cascade.** `pourTruncatedDetected` is dominant: when it fires,
-`channelingDetected` / `temperatureUnstable` / `grindIssueDetected` are
-forced to false. The cascade is enforced in exactly one place —
-`ShotAnalysis::analyzeShot` — and the boolean badge columns are a
-deterministic projection of the resulting `DetectorResults` struct (see
-§4 mapping table; helper at `src/history/shotbadgeprojection.h`). Save-
-time, load-time recompute, the dialog, the AI advisor, and MCP
-`shots_get_detail` all share that one pipeline and projection. The puck
-failed to build pressure, so the curves the
-other three detectors read off don't mean what they normally mean
+`channelingDetected` / `grindIssueDetected` are forced to false. The
+cascade is enforced in exactly one place — `ShotAnalysis::analyzeShot` —
+and the boolean badge columns are a deterministic projection of the
+resulting `DetectorResults` struct (see §4 mapping table; helper at
+`src/history/shotbadgeprojection.h`). Save-time, load-time recompute, the
+dialog, the AI advisor, and MCP `shots_get_detail` all share that one
+pipeline and projection. The puck failed to build pressure, so the curves
+the other detectors read off don't mean what they normally mean
 (conductance saturates → derivative flat, flow tracks preinfusion goal →
-grind delta ≈ 0, temp drift measured against a pour that didn't really
-happen). `skipFirstFrameDetected` is **not** suppressed — it's a
+grind delta ≈ 0). `skipFirstFrameDetected` is **not** suppressed — it's a
 machine/profile issue orthogonal to puck integrity. The clean-extraction
 green chip's visibility gate also includes `!pourTruncatedDetected` so a
 suppressed puck-failure shot can't fall through to the wrong all-clear.
@@ -274,48 +278,7 @@ other reason). Consumers wanting "verified clean" specifically must read
 - `analysisFlags` contains `grind_check_skip`.
 - Pressure data is empty (the arm-2 path early-returns).
 
-### 2.3 Temperature unstable
-
-The simplest of the five. `temperatureUnstable = true` when:
-
-- `temperature` and `temperatureGoal` both have > 10 samples, AND
-- `pourStart > 0` (a Pour / infus / Start phase marker was found — without
-  it, `avgTempDeviation` would average from t=0 and pull in the preheat
-  ramp), AND
-- `reachedExtractionPhase(phases, duration)` is true: at least one phase
-  marker with `frameNumber ≥ 1` exists `TEMP_MIN_EXTRACTION_SEC` (1.0 s)
-  before the shot's last sample. Aborted shots that died during
-  preinfusion-start would otherwise read the machine's preheat ramp as
-  drift; the firmware sometimes records the 0→1 transition in the final
-  ms before stop, so a marker-presence-only check is not enough — the
-  phase has to have actually lasted, AND
-- `hasIntentionalTempStepping(temperatureGoal)` is false (goal range ≤
-  `TEMP_STEPPING_RANGE` = 5 °C — D-Flow 84 → 94 is intentional, ignore), AND
-- `avgTempDeviation(temperature, temperatureGoal, pourStart, pourEnd) >
-  TEMP_UNSTABLE_THRESHOLD` (2.0 °C).
-
-`avgTempDeviation` is the average absolute deviation over the pour window
-where the goal is non-zero. Leading samples where the group head is still
-warming up are excluded: any sample at the start of the window where
-`goal − actual > TEMP_WARMUP_SKIP_C` (3.0 °C) is skipped. The skip is
-one-directional (cold only) and latches off on the first in-range sample,
-so a mid-shot temperature drop is still counted as instability.
-
-If every pour sample is below the warmup threshold (count == 0), the
-function returns 0.0 and no badge fires. This is intentional: a machine
-that never reaches operating temperature during a full extraction is
-extremely unlikely in practice, and returning silence is preferable to a
-misleading badge when there is no valid signal.
-
-The `pourStart > 0` and `reachedExtractionPhase` guards live exclusively
-in `analyzeShot`. Save-time (`saveShot`), load-time recompute
-(`loadShotRecordStatic`), the dialog, the AI advisor, and MCP all
-delegate to the same `analyzeShot` body, so the cascade definition is
-the gates — no risk of asymmetry across the call sites and no chance for
-`loadShotRecordStatic`'s drift-on-load write-back to disagree with what
-save produced (see §4).
-
-### 2.4 Skip first frame
+### 2.3 Skip first frame
 
 `detectSkipFirstFrame` operates on phase markers only — no curves needed. Two
 distinct branches inside one function, picked from the marker stream:
@@ -346,7 +309,7 @@ malformed.
 `firstFrameConfiguredSeconds` is fed in by callers from `ProfileFrameInfo`
 (parsed from the stored profile JSON via `profileFrameInfoFromJson`).
 
-### 2.5 Pour truncated (puck failed)
+### 2.4 Pour truncated (puck failed)
 
 `detectPourTruncated` returns true when peak pressure inside the pour window
 stays below `PRESSURE_FLOOR_BAR` (2.5). It catches the failure mode where
@@ -356,11 +319,11 @@ wrong diagnosis. Skipped for filter / pourover / tea / steam / cleaning
 beverages where low pressure is expected.
 
 **Suppression cascade.** When this detector fires, `analyzeShot` (the
-single enforcement point) skips the channeling, temperature, and grind
-blocks, leaving those `DetectorResults` fields at their `false` defaults.
-The badge projection then reads those defaults so `channelingDetected` /
-`temperatureUnstable` / `grindIssueDetected` all stay `false`. See §1
-for the rationale; see §4 for the projection mapping.
+single enforcement point) skips the channeling and grind blocks, leaving
+those `DetectorResults` fields at their `false` defaults. The badge
+projection then reads those defaults so `channelingDetected` /
+`grindIssueDetected` stay `false`. See §1 for the rationale; see §4 for
+the projection mapping.
 
 **Population the badge catches.** A puck-failure shot can come from any of:
 grind way too coarse, distribution failure (massive channel), no/loose
@@ -449,11 +412,7 @@ top-to-bottom:
 3. **Preinfusion drip** — when preinfusion lasted > 1 s and at least 0.5 g
    landed during it, emits "Preinfusion: Xg in Ys" as an "observation".
    Not gated on `pourTruncated` — drip mass is a fact, not a diagnosis.
-4. **Temperature stability** — when `hasIntentionalTempStepping` is false
-   and `avgTempDeviation` exceeds 2 °C, emits "Temperature drifted X °C
-   from goal on average" as "caution". **Suppressed when `pourTruncated`
-   fires.**
-5. **Grind direction** — uses the same `analyzeFlowVsGoal` path as the
+4. **Grind direction** — uses the same `analyzeFlowVsGoal` path as the
    badge. Emits one of: "Pour produced near-zero flow while pressure
    held — puck choked" ("warning") when `chokedPuck` fires, "Flow
    averaged X mL/s below target — grind may be too fine" ("caution"),
@@ -463,13 +422,13 @@ top-to-bottom:
    data on a non-degenerate espresso pour — "Could not analyze grind on
    this profile shape — check flow trend, channeling, and taste
    instead" ("observation"). **Suppressed when `pourTruncated` fires.**
-6. **Pour truncated** — `detectPourTruncated`. Emits "Pour never
+5. **Pour truncated** — `detectPourTruncated`. Emits "Pour never
    pressurized (peak X bar) — puck offered no resistance. Likely
    causes: grind way too coarse, distribution failure, no/loose puck,
    severe underdose, or profile without a pressure cap." as "warning"
    when peak pressure stayed under 2.5 bar. The actual peak value is
    substituted into the line.
-7. **Skip first frame** — `detectSkipFirstFrame`. Emits "First profile
+6. **Skip first frame** — `detectSkipFirstFrame`. Emits "First profile
    step skipped — likely a DE1 firmware bug…" as "warning". Not gated
    on `pourTruncated` — frame-skip is orthogonal to puck integrity.
 
@@ -560,7 +519,7 @@ in `detectorResults` but produce no prose line. The verdict prose is
 intentionally NOT exposed as a separate field; external agents read
 `verdictCategory` and compose their own framing.
 
-The five legacy badge booleans (`channelingDetected`, etc.) on
+The four legacy badge booleans (`channelingDetected`, etc.) on
 `convertShotRecord` remain available for backwards compatibility.
 
 ---
@@ -569,15 +528,17 @@ The five legacy badge booleans (`channelingDetected`, etc.) on
 
 ### Save-time: stored columns
 
-The `shots` table has five flag columns: `pour_truncated_detected`,
-`channeling_detected`, `temperature_unstable`, `grind_issue_detected`,
+The `shots` table has four flag columns: `pour_truncated_detected`,
+`channeling_detected`, `grind_issue_detected`,
 `skip_first_frame_detected`. At shot save (or import), the badges are
 computed once from the captured curves and written into these columns
-alongside the rest of the shot record.
+alongside the rest of the shot record. The historical fifth column
+(`temperature_unstable`) was added in migration 10 and dropped in
+migration 15 — see openspec change `remove-temperature-unstable-badge`.
 
 ### Single-pass detector pipeline + projection (post PR #934, #935, #936)
 
-`saveShot` and `loadShotRecordStatic` both compute all five quality
+`saveShot` and `loadShotRecordStatic` both compute all four quality
 badges via a single `ShotAnalysis::analyzeShot(...)` call and project the
 booleans from the returned `DetectorResults` struct using the helper in
 `src/history/shotbadgeprojection.h`. The cascade lives in exactly one
@@ -591,7 +552,6 @@ or hand-rolled gate conditions in the storage layer.
 |---|---|
 | `pourTruncatedDetected` | `d.pourTruncated` |
 | `channelingDetected` | `d.channelingSeverity == "sustained"` (Transient does NOT fire the badge) |
-| `temperatureUnstable` | `d.tempUnstable` (gates `tempStabilityChecked` / `!intentionalStepping` / `avgDev > threshold` already applied inside `analyzeShot`) |
 | `grindIssueDetected` | `d.grindHasData && (d.grindChokedPuck \|\| d.grindYieldOvershoot \|\| std::abs(d.grindFlowDeltaMlPerSec) > FLOW_DEVIATION_THRESHOLD)` |
 | `skipFirstFrameDetected` | `d.skipFirstFrame` |
 
@@ -606,9 +566,6 @@ Notes on the projection:
   The `grindHasData` conjunct is a defensive zero — it short-circuits
   the projection if any of the grind sub-flags are set on a struct
   whose `hasData` is false.
-- `tempUnstable` already encodes its gates inside `analyzeShot`, so the
-  projection just reads the flag — no caller-side `pourStart > 0` or
-  `reachedExtractionPhase` conjuncts needed.
 - `pourTruncated` and `skipFirstFrame` are 1:1 with their struct fields.
 
 The projection is unit-tested via `tst_shotanalysis::badgeProjection_*` —
@@ -618,7 +575,7 @@ the load-bearing `Transient` carve-out.
 ### Load-time: always recompute (PR #893, extended for the 5th badge in PR #922)
 
 `ShotHistoryStorage::loadShotRecordStatic` reads the stored columns, then
-**unconditionally recomputes all five badges** from the loaded curve data
+**unconditionally recomputes all four badges** from the loaded curve data
 before returning. The recompute is now a single `analyzeShot` + projection
 call (post PR #936), so it cannot diverge from the save-time computation.
 This means the in-memory `ShotRecord` always reflects the current detector
@@ -638,13 +595,12 @@ structured `detectorResults` JSON for MCP / dialog consumers.
 
 When a shot is opened in `ShotDetailPage` or `PostShotReviewPage`, QML calls
 `MainController.shotHistory.requestReanalyzeBadges(id)`. That method runs on
-the DB worker thread and recomputes the five flags. If at least one flag
+the DB worker thread and recomputes the four flags. If at least one flag
 differs from the stored value, it issues an `UPDATE` *and* emits
-`shotBadgesUpdated(shotId, channeling, tempUnstable, grindIssue,
-skipFirstFrame, pourTruncated)` (six args; the puck-failure flag was added
-in PR #922) so the UI can refresh without a full reload. If every flag
-already matches the stored value, the worker exits silently — no `UPDATE`,
-no signal, no UI refresh.
+`shotBadgesUpdated(shotId, channeling, grindIssue, skipFirstFrame,
+pourTruncated)` (five args) so the UI can refresh without a full reload.
+If every flag already matches the stored value, the worker exits silently
+— no `UPDATE`, no signal, no UI refresh.
 
 The wiring lives at `qml/pages/ShotDetailPage.qml` (in `onShotReady`) and
 `qml/pages/PostShotReviewPage.qml`. The visualizer-update reload path
@@ -675,14 +631,14 @@ require another sweep.
 
 ### Detector logic
 
-- `src/ai/shotanalysis.{h,cpp}` — all five detectors, `analyzeFlowVsGoal`,
+- `src/ai/shotanalysis.{h,cpp}` — all four detectors, `analyzeFlowVsGoal`,
   `buildChannelingWindows`, `detectChannelingFromDerivative`,
   `detectGrindIssue`, `detectSkipFirstFrame`, `detectPourTruncated`,
-  `hasIntentionalTempStepping`, `avgTempDeviation`, `shouldSkipChannelingCheck`,
-  `analyzeShot` (returns `AnalysisResult { lines, detectors }` — feeds
-  the Shot Summary dialog and MCP; see §3), `generateSummary` (thin
-  wrapper returning `analyzeShot(...).lines`), `DetectorResults` /
-  `AnalysisResult` structs, all tuning constants.
+  `shouldSkipChannelingCheck`, `analyzeShot` (returns
+  `AnalysisResult { lines, detectors }` — feeds the Shot Summary dialog
+  and MCP; see §3), `generateSummary` (thin wrapper returning
+  `analyzeShot(...).lines`), `DetectorResults` / `AnalysisResult`
+  structs, all tuning constants.
 
 ### Persistence
 
@@ -697,8 +653,9 @@ require another sweep.
     emits `summaryLines` (prose) and a nested `detectorResults` JSON
     object on every shot record served by MCP / web endpoints. The dialog
     reads `summaryLines` directly from the resulting `shotData` map.
-  - DB migrations for the five flag columns (10–13; migration 13 adds
-    `pour_truncated_detected`).
+  - DB migrations for the four flag columns (10–13; migration 13 adds
+    `pour_truncated_detected`; migration 15 drops the
+    `temperature_unstable` column added by migration 10).
   - `computeDerivedCurves` — fills conductance / dC/dt for legacy shots that
     predate migration 10.
   - `profileFrameInfoFromJson` — extracts `frameCount` and
@@ -721,11 +678,10 @@ require another sweep.
   `shotData.summaryLines` directly (populated by `convertShotRecord`)
   and renders the `{ text, type }` lines via a `Repeater`.
 - `qml/pages/ShotDetailPage.qml` and `qml/pages/PostShotReviewPage.qml` —
-  consume `shotData.channelingDetected` / `temperatureUnstable` /
-  `grindIssueDetected` / `skipFirstFrameDetected` / `pourTruncatedDetected`,
-  listen for `shotBadgesUpdated`, call `requestReanalyzeBadges` on load,
-  host the `ShotAnalysisDialog` instance and wire `summaryRequested` to
-  `open()`.
+  consume `shotData.channelingDetected` / `grindIssueDetected` /
+  `skipFirstFrameDetected` / `pourTruncatedDetected`, listen for
+  `shotBadgesUpdated`, call `requestReanalyzeBadges` on load, host the
+  `ShotAnalysisDialog` instance and wire `summaryRequested` to `open()`.
 - `qml/pages/ShotHistoryPage.qml` — filter chips that consume the stored
   columns.
 
@@ -781,7 +737,9 @@ To add a fixture:
   view.
 - Issue #894 — residual stored-column drift (history-list filter and
   `shots_list` MCP read stored, not recomputed values).
-- PR #898 — `temperatureUnstable` gating fix (`reachedExtractionPhase`).
+- PR #898 — `temperatureUnstable` gating fix (`reachedExtractionPhase`)
+  — superseded; the badge has since been removed entirely (see
+  `remove-temperature-unstable-badge` openspec change).
 - PR #901 — flow/pressure-mode rising-pressure gate fix.
 - PR #910 — yield-overshoot ("gusher") arm in `analyzeFlowVsGoal`.
 - PR #922 / Issue #903 — fifth badge `pourTruncatedDetected` ("Puck failed"),
@@ -797,13 +755,10 @@ To add a fixture:
   framing the lines as detector evidence. The `verdict` line is filtered
   out before emission so the AI reasons from the same observations the
   user sees in the dialog without anchoring on the dialog's prescriptive
-  conclusion. Per-phase `PhaseSummary::temperatureUnstable` markers are
-  gated on the same `reachedExtractionPhase` + `pourTruncatedDetected`
-  cascade the aggregate temp detector uses. Cleanup: dropped dead
-  `ShotSummary` fields (`channelingDetected`, `temperatureUnstable`,
-  `timeToFirstDrip`, `preinfusionDuration`, `mainExtractionDuration`)
-  and the wrapper helpers (`detectChannelingInPhases`,
-  `calculateTemperatureStability`) they fed.
+  conclusion. Cleanup: dropped dead `ShotSummary` fields
+  (`channelingDetected`, `timeToFirstDrip`, `preinfusionDuration`,
+  `mainExtractionDuration`) and the wrapper helpers
+  (`detectChannelingInPhases`) they fed.
 - PR #933 / Issue #931 — `convertShotRecord` runs `analyzeShot` once
   per shot conversion and emits both `summaryLines` (prose) and
   structured `detectorResults` JSON on `shots_get_detail` /
@@ -814,6 +769,18 @@ To add a fixture:
   outputs in lockstep. Verdict prose is intentionally NOT exposed —
   agents read the stable `verdictCategory` enum instead. Field
   reference: `docs/CLAUDE_MD/MCP_SERVER.md` "Shot Detector Outputs".
+- openspec change `remove-temperature-unstable-badge` / Issue #1128 —
+  retired the `temperatureUnstable` badge end-to-end (detector,
+  projection, badge UI, MCP `detectorResults.tempStability`, history
+  filter, DB column via migration 15). The detector measured average
+  deviation from goal but was labeled "Temp unstable" — and the
+  deviation it caught was, in practice, profile-design intent on
+  D-Flow / Extractamundo / TurboBloom and 9+ other built-in profiles.
+  `analyzeShot` and `generateSummary` lost their `temperature` and
+  `temperatureGoal` parameters; the static helpers
+  `hasIntentionalTempStepping`, `avgTempDeviation`, and
+  `reachedExtractionPhase` were removed. `shotBadgesUpdated` shrank
+  from 6 to 5 args.
 
 External resources that informed the diagnostic patterns:
 

--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -83,7 +83,7 @@ take effect on existing shots without a manual re-analyze.
 
 ## 2. Detector internals
 
-All five detectors live in `src/ai/shotanalysis.{h,cpp}` as static methods on
+All four detectors live in `src/ai/shotanalysis.{h,cpp}` as static methods on
 `ShotAnalysis`. Tuning constants are defined at the top of the header so they
 can be tweaked in one place. The header is heavily commented — read it
 alongside this section.
@@ -380,7 +380,7 @@ Each line carries a `type`:
 | Type          | Dot color                     | Used for                                   |
 | ------------- | ----------------------------- | ------------------------------------------ |
 | `good`        | success (green)               | "Puck stable", happy-path observations     |
-| `caution`     | warning (orange)              | flow drift, temp drift, grind direction    |
+| `caution`     | warning (orange)              | flow drift, grind direction                |
 | `warning`     | error (red)                   | sustained channeling, choked puck, frame skip, pour truncated |
 | `observation` | text-secondary (neutral grey) | preinfusion drip mass / duration           |
 | `verdict`     | no dot, larger font           | always exactly one, last in the list       |
@@ -391,7 +391,7 @@ from the observation lines.
 ### Observations emitted
 
 `analyzeShot` computes `pourTruncated` first; when it fires, the
-channeling / flow-trend / temperature / grind blocks below all skip
+channeling / flow-trend / grind blocks below all skip
 emission entirely. The list collapses to a single warning + the
 puck-failed verdict. Order otherwise follows `analyzeShot`
 top-to-bottom:
@@ -439,10 +439,10 @@ the first match (more specific failures take precedence over generic
 puck-integrity advice):
 
 1. **Pour truncated** → "Don't tune off this shot — peak pressure never
-   built, so the other quality signals (channeling, grind direction,
-   temp) are unreliable. Check prep (dose, distribution, basket, grind)
-   and pull another." Dominates over channeling / grind / temperature
-   since the puck never built any resistance worth analyzing; leads with
+   built, so the other quality signals (channeling, grind direction)
+   are unreliable. Check prep (dose, distribution, basket, grind)
+   and pull another." Dominates over channeling / grind since the puck
+   never built any resistance worth analyzing; leads with
    the meta-action because the shot has no useful tuning signal.
 2. **Skip first frame** → "First profile step was skipped — power-cycle…"
    Pre-empts choked-puck because a frame-skip can synthesise extraction
@@ -462,7 +462,7 @@ puck-integrity advice):
    issues to watch." (The in-source comment phrases this as "if the
    only caution is a grind direction," but the implementation does not
    actually check for uniqueness — a directional grind delta wins over
-   a co-occurring temperature or flow-trend caution.)
+   a co-occurring flow-trend caution.)
 6. **Otherwise, grind not analyzable** → "Clean shot, but grind could not
    be evaluated for this profile shape." Fires when no warnings/cautions
    were emitted AND `grindCoverage == "notAnalyzable"`. Distinguishes

--- a/openspec/changes/remove-temperature-unstable-badge/.openspec.yaml
+++ b/openspec/changes/remove-temperature-unstable-badge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/remove-temperature-unstable-badge/design.md
+++ b/openspec/changes/remove-temperature-unstable-badge/design.md
@@ -38,7 +38,7 @@ The change is mechanical deletion across this surface. The architectural decisio
 
 ### Decision 1: Drop the `temperature_unstable` SQLite column outright
 
-**Choice:** Migration 14 issues `ALTER TABLE shots DROP COLUMN temperature_unstable;` matching the existing migration style in `shothistorystorage.cpp`.
+**Choice:** Migration 15 issues `ALTER TABLE shots DROP COLUMN temperature_unstable;` matching the existing migration style in `shothistorystorage.cpp`. (Migration 14 was taken by `enjoyment_source` between when this design doc was first drafted and when the implementation landed.)
 
 **Alternatives considered:**
 - *Leave the column dormant.* Pros: zero migration risk, no DB change. Cons: column rot accumulates; future readers wonder why the column exists; load path either ignores it (silently confusing) or has dead read code. Rejected — we have the migration framework in place and the column is now dead weight.
@@ -99,7 +99,7 @@ The change is mechanical deletion across this surface. The architectural decisio
 ## Migration Plan
 
 1. **Code changes ship in app version N** (current main → next release). The new code stops writing to `temperature_unstable`, stops reading it on load, and stops emitting it in MCP / signal / QML.
-2. **Schema migration 14 runs on first launch** of version N. Drops the column. Idempotent — checks the schema before running, like existing migrations.
+2. **Schema migration 15 runs on first launch** of version N. Drops the column. Idempotent — checks the schema before running, like existing migrations.
 3. **Rollback story:** if we have to roll back to N-1 after a user has run the migration, the column is gone but N-1's load path tolerates a missing column? **Verify before merge** — if N-1 reads the column unconditionally, rollback would crash. Likely we have to either (a) accept no-rollback, or (b) make the column drop conditional on a feature-flag / settings key. Default plan: no-rollback (consistent with all prior migrations being one-way).
 
 No data migration is needed (no value being preserved or transformed).

--- a/openspec/changes/remove-temperature-unstable-badge/design.md
+++ b/openspec/changes/remove-temperature-unstable-badge/design.md
@@ -1,0 +1,105 @@
+## Context
+
+The `temperatureUnstable` quality badge has existed since PR #649 (Tier 1 diagnostics), refined repeatedly: PR #898 added the `reachedExtractionPhase` gate, PR #1078 added the cold-startup warmup skip, and the `hasIntentionalTempStepping` check has carried the weight of suppressing it on the dozens of profiles whose actual-vs-goal temp gap is by design.
+
+Today the detector reads stored shot curves, computes `avgTempDeviation(temperature, temperatureGoal, pourStart, pourEnd)`, and fires the badge when deviation exceeds `TEMP_UNSTABLE_THRESHOLD = 2.0°C` — unless `hasIntentionalTempStepping(temperatureGoal) == true` (goal range > `TEMP_STEPPING_RANGE = 5.0°C`) or the gates above (`pourStart > 0`, `reachedExtractionPhase`) reject the shot.
+
+The detector touches a wider surface than its 30 lines suggest:
+- `src/ai/shotanalysis.{h,cpp}`: detector logic, four constants, three static helpers, four `DetectorResults` fields.
+- `src/history/shothistorystorage.cpp`: stored column `temperature_unstable`, write at save, recompute at load, lazy-persist in `requestReanalyzeBadges`, history-list filter in `buildFilterQuery`, MCP serialization in `convertShotRecord`.
+- `src/history/shotbadgeprojection.h`: one row in the projection table.
+- `src/ai/shotsummarizer.{h,cpp}`: per-phase `PhaseSummary::temperatureUnstable` markers, the `markPerPhaseTempInstability` helper, AI prompt observation lines.
+- `src/mcp/mcptools_shots.cpp`: nested `detectorResults.temperature` block.
+- QML: `qml/components/QualityBadges.qml` chip rendering, host-page property bindings (`ShotDetailPage.qml`, `PostShotReviewPage.qml`), filter chip on `ShotHistoryPage.qml`, `shotBadgesUpdated` signal arity (6 → 5 args).
+- DB schema: column added in migration 11; will need a removal migration.
+- Tests: ~10 cases in `tst_shotanalysis.cpp` and N entries across `tests/data/shots/manifest.json`.
+- Docs: `docs/SHOT_REVIEW.md` §1, §2.3, §3, §4, §5, §6, §7; `docs/CLAUDE_MD/MCP_SERVER.md` "Shot Detector Outputs"; the `shot-analysis-pipeline` capability spec.
+
+The change is mechanical deletion across this surface. The architectural decisions are: (a) what to do with the existing DB column, (b) how to handle the QML signal arity change, (c) whether to keep `reachedExtractionPhase` and `avgTempDeviation` in case they're useful later, (d) what happens to historical shots whose stored `temperature_unstable = 1` survives the schema change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate the false-positive badge end-to-end on every code path that reads or writes it (badge UI, dialog observation, MCP, AI prompt, history filter, DB).
+- Remove the dead constants, helpers, and `DetectorResults` fields so the codebase doesn't carry obviously unused machinery.
+- Update the `shot-analysis-pipeline` capability spec to reflect the smaller `DetectorResults` shape and the four-badge projection.
+- Drop or rewrite the spec's existing temperature-related requirements (the "Intentional temperature stepping does NOT fire the temp badge" scenario, etc.) so the spec doesn't lie.
+- Keep historical shots loadable. Old DB rows with `temperature_unstable = 1` should not crash the load path or surface stale state.
+- One coherent migration step — not a multi-version dance.
+
+**Non-Goals:**
+- Designing a replacement detector. We're removing because the signal isn't worth fixing; if a future change wants to add a real instability detector (variance, mid-shot crash, heater-failure heuristic), that's a separate proposal.
+- Profile-tagging via `temp_drift_expected` analysisFlag (the rejected alternative).
+- The grind-detector false positives surfaced in the same #1128 investigation — separate change.
+- Graceful API deprecation for MCP consumers. This is defect removal; the field disappears.
+- Backporting badge data on shot import (Visualizer JSON imports never carried the field anyway).
+
+## Decisions
+
+### Decision 1: Drop the `temperature_unstable` SQLite column outright
+
+**Choice:** Migration 14 issues `ALTER TABLE shots DROP COLUMN temperature_unstable;` matching the existing migration style in `shothistorystorage.cpp`.
+
+**Alternatives considered:**
+- *Leave the column dormant.* Pros: zero migration risk, no DB change. Cons: column rot accumulates; future readers wonder why the column exists; load path either ignores it (silently confusing) or has dead read code. Rejected — we have the migration framework in place and the column is now dead weight.
+- *Set the column to NULL on load and keep the schema.* Worst of both — extra write traffic on every load, no schema cleanup.
+
+**Rationale:** SQLite has supported `ALTER TABLE … DROP COLUMN` since 3.35 (March 2021); we ship newer than that on every platform. The existing migrations 10–13 are pure column additions, so this will be the first removal — no precedent to follow but no precedent to break either. Use a single-statement transaction matching nearby code style.
+
+### Decision 2: Drop `reachedExtractionPhase`, `avgTempDeviation`, `hasIntentionalTempStepping` rather than keep them
+
+**Choice:** All three static helpers are removed from `ShotAnalysis`.
+
+**Alternatives considered:**
+- *Keep them for future reuse.* Pros: easier to revive a temp detector later. Cons: dead code, dead test surface, confused readers, the helpers inevitably bit-rot, and the next reviver should be making fresh design decisions anyway (e.g., `reachedExtractionPhase` as defined gates on `TEMP_MIN_EXTRACTION_SEC` which only made sense for the temp detector).
+
+**Rationale:** YAGNI. If we ever reintroduce a temp detector it'll have different gates and we'll write fresh helpers. Carrying these forward earns nothing.
+
+### Decision 3: Reduce `shotBadgesUpdated` signal arity from 6 args to 5 (drop `tempUnstable`)
+
+**Choice:** Change the signal signature; update both QML connections (`ShotDetailPage.qml`, `PostShotReviewPage.qml`); update the lazy-persist emit site in `requestReanalyzeBadges`.
+
+**Alternatives considered:**
+- *Pass `false` permanently in the temp slot.* Avoids QML breakage during the change but leaves a permanently-false bool in the signal — every reader has to know it's vestigial.
+
+**Rationale:** Signal signatures are part of the QML/C++ contract. Carrying a vestigial slot adds no safety since the QML side is in this same repo and changes together. Cleaner to bite the bullet.
+
+### Decision 4: Existing stored `temperature_unstable = 1` rows surface as nothing
+
+**Choice:** Migration drops the column. Lazy-persist no longer touches it. The badge no longer renders. No retroactive UI adjustment for shots that historically had the badge.
+
+**Alternatives considered:**
+- *Show a "had-temp-unstable historically" indicator.* No user value — the underlying detector was firing on profile design, so the historical badge was likely wrong anyway.
+
+**Rationale:** The badge was noise; surfacing its history is more noise.
+
+### Decision 5: Update the `shot-analysis-pipeline` capability spec rather than create a sibling spec
+
+**Choice:** The change ships a `specs/shot-analysis-pipeline/spec.md` delta that removes the temperature-related requirements / scenarios and rewrites the projection-mapping requirement to drop the `temperatureUnstable` row.
+
+**Alternatives considered:**
+- *Leave the spec mentioning temp and document the removal in proposal/design only.* Diverges spec from code.
+
+**Rationale:** OpenSpec convention: specs describe current behavior. The change deletes behavior, the spec deletion follows.
+
+## Risks / Trade-offs
+
+[**Stored shots that drift on reload**] Today, shots loaded from history get their badges recomputed (PR #893's "always recompute on load"). For five-badge shots, recompute matched the column. Post-change, recompute will run with four badges and `temperature_unstable` won't exist as a column. → Mitigation: the lazy-persist code path needs to be updated *before* the migration runs (the migration runs on first launch after upgrade, the C++ code is already at the new version). Confirmed by reading the load path: the column is read into a local before the recompute compares it; just remove that local and the compare branch.
+
+[**MCP consumer breakage**] External MCP clients that read `detectorResults.temperature` get a missing field. → Mitigation: this is the documented "post-1.7.4" change list; ship in a release with a clear changelog entry. The MCP clients we know about (the in-app advisor) are in this repo and update together. External AI agents querying historical shots will see the field disappear silently — same model as any breaking change to a JSON shape.
+
+[**Test corpus drift**] The `shot_corpus_regression` ctest target uses `tests/data/shots/manifest.json` to lock in expected detector verdicts. Every fixture currently asserts on `temperature_unstable`. → Mitigation: bulk-edit the manifest to drop the field; run the suite locally before push to confirm it's the only assertion that needs to move.
+
+[**Per-phase `PhaseSummary::temperatureUnstable` removal cascades to AI prompt format**] The AI advisor's user prompt currently lists per-phase temp markers. Removing them changes the prompt format slightly, which could affect cached responses (Anthropic prompt cache 1-hour TTL). → Mitigation: cache invalidation is automatic when the prompt template changes; existing cached entries simply expire. No code action needed.
+
+[**SQLite DROP COLUMN compatibility**] We rely on SQLite ≥ 3.35. → Mitigation: every Qt 6.10 platform we ship ships SQLite > 3.35 (Android NDK, iOS, macOS system, Windows bundled). No platform issue.
+
+[**Implicit dependencies on the temp helpers**] Other code may grep-call `reachedExtractionPhase` or `hasIntentionalTempStepping` from beyond what I've listed. → Mitigation: full repo grep for each removed symbol before deleting; tasks.md specifies an explicit grep step.
+
+## Migration Plan
+
+1. **Code changes ship in app version N** (current main → next release). The new code stops writing to `temperature_unstable`, stops reading it on load, and stops emitting it in MCP / signal / QML.
+2. **Schema migration 14 runs on first launch** of version N. Drops the column. Idempotent — checks the schema before running, like existing migrations.
+3. **Rollback story:** if we have to roll back to N-1 after a user has run the migration, the column is gone but N-1's load path tolerates a missing column? **Verify before merge** — if N-1 reads the column unconditionally, rollback would crash. Likely we have to either (a) accept no-rollback, or (b) make the column drop conditional on a feature-flag / settings key. Default plan: no-rollback (consistent with all prior migrations being one-way).
+
+No data migration is needed (no value being preserved or transformed).

--- a/openspec/changes/remove-temperature-unstable-badge/proposal.md
+++ b/openspec/changes/remove-temperature-unstable-badge/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Issue #1128 surfaced a recurring false-positive "Temp unstable" badge on Extractamundo Dos! and similar profiles. Audit of the 60+ built-in profiles found at least 12 whose actual-vs-goal temperature gap is **by design** — D-Flow family (`espresso_temperature_steps_enabled = 0`, KB explicitly says "DO NOT flag the large gap…it is by design"), Extractamundo Dos! / TurboBloom (16°C bloom drops the head physically can't cool to), 80's Espresso / TurboTurbo / Classic Italian / Blooming Espresso / A-Flow dark / Innovative long preinfusion / Flow Profile straight & milky (6–10°C designed swings).
+
+The detector measures **average deviation from goal** but is labeled "Temp unstable" — the math doesn't match the label. The `hasIntentionalTempStepping` curve-based suppression is fragile: it relies on the captured `temperatureGoal` series spanning the full goal range, which collapses to a near-constant on some firmware/BLE paths (one user-shared shot showed goal frozen at 72.5°C despite a profile spanning 67.5–83.5°C). The remaining diagnostic value (cold portafilter crash, heater failure, boiler exhaustion) is rare, already visible in the post-shot temperature chart, and crowded out by the false-positive noise. Tagging profiles individually with a new `temp_drift_expected` flag was the alternative considered — rejected because every new "intentional drop" profile would need the flag, the false positive remains permanent until tagged, and the underlying detector still measures the wrong thing.
+
+## What Changes
+
+- **BREAKING:** Remove the `temperatureUnstable` quality badge end-to-end: detector logic, badge column, dialog observation line, AI advisor prompt input, MCP `detectorResults.temperature` field, history-list filter chip, and DB read paths.
+- Drop these symbols from `src/ai/shotanalysis.{h,cpp}`: `tempUnstable`, `tempStabilityChecked`, `tempIntentionalStepping`, `tempAvgDeviationC` fields on `DetectorResults`; `TEMP_UNSTABLE_THRESHOLD`, `TEMP_STEPPING_RANGE`, `TEMP_WARMUP_SKIP_C`, `TEMP_MIN_EXTRACTION_SEC` constants; `hasIntentionalTempStepping` (both overloads), `avgTempDeviation`, `reachedExtractionPhase` static methods (the last is only used by the temp detector); the temperature-stability block in `analyzeShot`.
+- Drop the projection row from `src/history/shotbadgeprojection.h`.
+- Drop the chip from `qml/components/QualityBadges.qml`; remove `temperatureUnstable` property bindings and the badge-update signal arity from `qml/pages/ShotDetailPage.qml`, `qml/pages/PostShotReviewPage.qml`, and the `shotBadgesUpdated` signal in `ShotHistoryStorage` (currently 6 args → 5).
+- `qml/components/ShotAnalysisDialog.qml` updates automatically — it renders `shotData.summaryLines` and we stop emitting the `temperature_drift` line. The `caution` line type stays for other uses.
+- `src/history/shothistorystorage.cpp`: drop column read/write in `loadShotRecordStatic`, `saveShot`, `requestReanalyzeBadges`, `convertShotRecord`, `buildFilterQuery`, and the lazy-persist path. Add a migration to drop the `temperature_unstable` column, matching the existing migration style (column adds happen in migrations 10–13; this is the first removal so we'll match nearby pragma usage).
+- Drop the temperature block from `src/mcp/mcptools_shots.cpp` `detectorResults` JSON; update `docs/CLAUDE_MD/MCP_SERVER.md` "Shot Detector Outputs" section.
+- Drop temperature drift from per-phase `PhaseSummary::temperatureUnstable` markers in `src/ai/shotsummarizer.{h,cpp}`; remove the `markPerPhaseTempInstability` helper and any AI prompt fragments that mention temperature drift.
+- Remove the `temperatureUnstable` filter chip from `qml/pages/ShotHistoryPage.qml` and corresponding query helpers.
+- `docs/SHOT_REVIEW.md`: update §1 (badges table down to four flags), delete §2.3 entirely, update §3 (drop "Temperature stability" observation #4 from the dialog list, drop the `temperature_drift` line kind), §4 (drop the projection-mapping row), §5 (note the dropped column), §6 (drop temp manifest assertions), §7 (note the removal in references).
+- `tests/data/shots/manifest.json`: drop `temperature_unstable` assertions across all fixtures.
+- `tests/tst_shotanalysis.cpp`: delete `temperatureUnstable_*`, `intentionalTempStepping_*`, `avgTempDeviation_*`, `reachedExtractionPhase_*` test cases. Update any combined-cascade tests that assert on temp output to drop the temp expectation.
+
+## Capabilities
+
+### New Capabilities
+None.
+
+### Modified Capabilities
+- `shot-analysis-pipeline`: removes the temperature-unstable detector branch from `analyzeShot`, drops `tempUnstable` / `tempStabilityChecked` / `tempIntentionalStepping` / `tempAvgDeviationC` from `DetectorResults`, drops the badge-projection row, drops the per-phase `PhaseSummary::temperatureUnstable` marker, and removes `reachedExtractionPhase` from the helper surface. Existing requirements that mention `tempUnstable`, `temperatureUnstable`, `TEMP_STEPPING_RANGE`, or per-phase temp markers must be deleted or rewritten to drop those clauses.
+
+## Impact
+
+- **Code**: ~15-20 files. Detector logic itself is ~30 lines; the rest is fanout (DB column, projection helper, badge UI, MCP serializer, AI prompt, filter query, manifest, tests, docs).
+- **Database**: one schema migration adding a column-drop step. SQLite `ALTER TABLE … DROP COLUMN` is supported on the version we ship; matches existing migration pattern.
+- **APIs (BREAKING)**: external MCP consumers reading `detectorResults.temperature` lose the field. The five legacy badge booleans on `convertShotRecord` shrink to four (`temperatureUnstable` removed). No deprecation period — this is a defect-removal change, not a feature deprecation.
+- **History compatibility**: existing shots that have stored `temperature_unstable = 1` are unaffected at the user-facing layer (badge no longer renders) and the column read is dropped. Lazy-persist on view becomes a four-badge update.
+- **CI**: `shot_corpus_regression` ctest target's manifest must be updated to drop temp assertions or it will fail.
+- **Closes**: GitHub issue #1128.
+- **Out of scope for this change**:
+  - Replacing the detector with an "actual instability" measure (variance / mid-shot crash). Worth considering separately; weak enough value that we may never add it.
+  - Tagging profiles with a `temp_drift_expected` flag (the rejected alternative).
+  - The grind-detector false positives also surfaced by #1128 — separate change.

--- a/openspec/changes/remove-temperature-unstable-badge/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/changes/remove-temperature-unstable-badge/specs/shot-analysis-pipeline/spec.md
@@ -1,0 +1,167 @@
+## MODIFIED Requirements
+
+### Requirement: AI advisor's historical-shot path SHALL reuse pre-computed `summaryLines` when present
+
+When `ShotSummarizer::summarizeFromHistory(shotData)` is invoked with a `shotData` map whose `summaryLines` field is a non-empty list, the function SHALL populate `ShotSummary::summaryLines` from that field directly AND SHALL skip its inline `ShotAnalysis::generateSummary(...)` invocation. The function SHALL also derive `ShotSummary::pourTruncatedDetected` from `shotData["detectorResults"]["pourTruncated"]` when the `detectorResults` field is present.
+
+When `summaryLines` is absent or empty (legacy shots, direct test callers, imported shots without the new fields), the function SHALL fall back to the existing inline detector orchestration path. The fast and fallback paths SHALL produce equivalent `ShotSummary::summaryLines` for identical shot data — they cannot drift because both ultimately rely on the same `ShotAnalysis::analyzeShot` body.
+
+The live-path entry point `ShotSummarizer::summarize(ShotDataModel*)` is OUT OF SCOPE — it operates on an in-progress shot for which no `convertShotRecord` has run, and SHALL continue to call `analyzeShot` (via `generateSummary`) inline.
+
+#### Scenario: Modern shotData with pre-computed lines bypasses recomputation
+
+- **GIVEN** a `shotData` map produced by `ShotHistoryStorage::convertShotRecord`, with `summaryLines` containing a known list and `detectorResults.pourTruncated == true`
+- **WHEN** the AI advisor invokes `summarizeFromHistory(shotData)`
+- **THEN** the resulting `ShotSummary.summaryLines` SHALL equal the input `shotData.summaryLines`
+- **AND** `ShotSummary.pourTruncatedDetected` SHALL be `true`
+- **AND** `ShotAnalysis::generateSummary(...)` SHALL NOT be invoked by `summarizeFromHistory` for this call
+
+#### Scenario: Legacy shotData without summaryLines uses the inline path
+
+- **GIVEN** a `shotData` map whose `summaryLines` field is missing or empty
+- **WHEN** the AI advisor invokes `summarizeFromHistory(shotData)`
+- **THEN** the function SHALL invoke `ShotAnalysis::generateSummary(...)` inline
+- **AND** the resulting `ShotSummary.summaryLines` SHALL be non-empty for shots with sufficient curve data
+
+#### Scenario: Fast and fallback paths produce equivalent results
+
+- **GIVEN** two equivalent `shotData` maps for the same shot, `A` with `summaryLines` pre-populated and `B` without
+- **WHEN** `summarizeFromHistory(A)` and `summarizeFromHistory(B)` are both invoked
+- **THEN** the resulting `ShotSummary::summaryLines` from each call SHALL contain the same lines in the same order with the same `text` and `type` values
+
+#### Scenario: Fast path preserves the pour-truncated cascade
+
+- **GIVEN** a `shotData` map with non-empty `summaryLines` and `detectorResults.pourTruncated == true`
+- **WHEN** the AI advisor invokes `summarizeFromHistory(shotData)`
+- **THEN** `ShotSummary::pourTruncatedDetected` SHALL be `true`
+
+### Requirement: Save and load paths SHALL derive boolean quality badges from `DetectorResults` via a single documented projection
+
+`ShotHistoryStorage::saveShot` (save-time badge computation) and `ShotHistoryStorage::loadShotRecordStatic` (recompute-on-load) SHALL invoke `ShotAnalysis::analyzeShot(...)` exactly once per shot and project the four boolean badge columns from the returned `DetectorResults` struct using the documented mapping. Neither function SHALL retain hand-rolled per-detector calls or hand-rolled cascade gate conditions; the cascade SHALL live in exactly one place — `ShotAnalysis::analyzeShot`.
+
+The projection mapping SHALL be implemented in `decenza::deriveBadgesFromAnalysis` (header-only, in `src/history/shotbadgeprojection.h`) as:
+
+| Badge column | `DetectorResults` projection |
+|---|---|
+| `pourTruncatedDetected` | `d.pourTruncated` |
+| `channelingDetected` | `d.channelingSeverity == "sustained"` (Transient does NOT set the badge) |
+| `grindIssueDetected` | `d.grindHasData && (d.grindChokedPuck || d.grindYieldOvershoot || std::abs(d.grindFlowDeltaMlPerSec) > FLOW_DEVIATION_THRESHOLD)` |
+| `skipFirstFrameDetected` | `d.skipFirstFrame` |
+
+`FLOW_DEVIATION_THRESHOLD` SHALL be read from `ShotAnalysis::FLOW_DEVIATION_THRESHOLD`; consumers MUST NOT inline the numeric value.
+
+The lazy-persist write-back in `loadShotRecordStatic` (when stored badge columns differ from recomputed values, the recomputed values are written back to the DB) SHALL continue to function; the recomputed values just come from the projection helper instead of from per-detector calls.
+
+`ShotAnalysis::analyzeShot` SHALL accept an optional `expectedFrameCount` parameter and forward it to `detectSkipFirstFrame`. Save and load paths SHALL pass the profile's actual frame count so 1-frame profiles correctly suppress the skip-first-frame detector. Backwards-compatible: the parameter defaults to `-1` (unknown), preserving behavior for callers (legacy `generateSummary` wrapper) that don't pass it.
+
+The DB schema, the badge column types, and the badge-driven UI surfaces (history-list filter chips, badge UI, `shots_list` MCP) are OUT OF SCOPE — they continue to read the same four boolean columns; only the *production* of those values is unified.
+
+The Sustained-only semantic for `channelingDetected` SHALL be preserved exactly. A shot whose `DetectorResults.channelingSeverity` is `"transient"` MUST result in `channelingDetected = false`. This matches the badge behavior established by PR #922 and is documented in the projection table.
+
+#### Scenario: Clean shot projects to all-false badge columns
+
+- **GIVEN** a shot whose `analyzeShot` returns `DetectorResults` with `verdictCategory = "clean"` and all detector gates clear
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** all four boolean badge columns SHALL be `false`
+
+#### Scenario: Pour-truncated cascade dominates the projection
+
+- **GIVEN** a shot whose `analyzeShot` returns `pourTruncated = true` (and consequently `channelingChecked = false`, `grindChecked = false`)
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `pourTruncatedDetected` SHALL be `true`
+- **AND** `channelingDetected`, `grindIssueDetected` SHALL each be `false`
+- **AND** `skipFirstFrameDetected` SHALL reflect `d.skipFirstFrame` independently (skip-first-frame is NOT suppressed by the cascade, matching PR #922's invariant)
+
+#### Scenario: Transient channeling does NOT set the badge
+
+- **GIVEN** a shot whose `analyzeShot` returns `channelingSeverity = "transient"`
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `channelingDetected` SHALL be `false`
+- **AND** the Shot Summary dialog SHALL still render the "Transient channel at Xs (self-healed)" caution line (the dialog reads `summaryLines`, not the boolean badge)
+
+#### Scenario: Sustained channeling sets the badge
+
+- **GIVEN** a shot whose `analyzeShot` returns `channelingSeverity = "sustained"`
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `channelingDetected` SHALL be `true`
+
+#### Scenario: Choked-puck shot fires the grind badge via the chokedPuck arm
+
+- **GIVEN** a shot whose `analyzeShot` returns `grindHasData = true`, `grindChokedPuck = true`, `grindFlowDeltaMlPerSec` near zero
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `grindIssueDetected` SHALL be `true`
+
+#### Scenario: Yield-overshoot shot fires the grind badge via the yieldOvershoot arm
+
+- **GIVEN** a shot whose `analyzeShot` returns `grindHasData = true`, `grindYieldOvershoot = true`
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `grindIssueDetected` SHALL be `true`
+
+#### Scenario: Flow delta within tolerance does NOT fire the grind badge
+
+- **GIVEN** a shot whose `analyzeShot` returns `grindHasData = true`, both `grindChokedPuck` and `grindYieldOvershoot` false, and `|grindFlowDeltaMlPerSec| <= FLOW_DEVIATION_THRESHOLD`
+- **WHEN** save-time or load-time badge derivation runs
+- **THEN** `grindIssueDetected` SHALL be `false`
+
+#### Scenario: 1-frame profile suppresses skip-first-frame detection
+
+- **GIVEN** a shot from a profile with `frameCount = 1`
+- **WHEN** save or load runs `analyzeShot` with `expectedFrameCount = 1`
+- **THEN** `analyzeShot` SHALL pass `expectedFrameCount` through to `detectSkipFirstFrame`
+- **AND** `detectSkipFirstFrame` SHALL return `false` (no second frame to skip to)
+- **AND** `skipFirstFrameDetected` SHALL be `false`
+
+### Requirement: ShotSummarizer's detector-orchestration glue SHALL live in exactly one helper
+
+`ShotSummarizer::summarize` (live shot) and `ShotSummarizer::summarizeFromHistory` (saved shot) SHALL each delegate their final detector-orchestration block to a single private static helper `ShotSummarizer::runShotAnalysisAndPopulate`. The helper accepts pre-extracted typed inputs (curves, markers, beverage type, analysis flags, frame info, target/final weights) plus an optional cached `AnalysisResult`, and populates the passed-in `ShotSummary`'s `summaryLines` and `pourTruncatedDetected`.
+
+The two callers SHALL retain their respective input-adapter roles (live extracts from `ShotDataModel*`; history extracts from `QVariantMap` via `variantListToPoints`) but SHALL NOT contain duplicated `analyzeShot`-call + result-unpacking logic.
+
+The fast-path optimization from change `dedup-ai-advisor-history-path` (reading pre-computed `summaryLines` when present on `summarizeFromHistory`'s input) SHALL be preserved by passing the cached `AnalysisResult` to the helper when applicable; the helper's `cachedAnalysis.has_value()` branch handles the rest.
+
+#### Scenario: Live and history paths reuse the same orchestration helper
+
+- **GIVEN** the same shot data presented to both `summarize(ShotDataModel*, ...)` and `summarizeFromHistory(QVariantMap)`
+- **WHEN** the two functions run
+- **THEN** both SHALL call `ShotSummarizer::runShotAnalysisAndPopulate` with equivalent inputs
+- **AND** the resulting `ShotSummary` SHALL be byte-equal across the two paths (same `summaryLines`, same `pourTruncatedDetected`)
+
+#### Scenario: Cached AnalysisResult fast-path is preserved through the helper
+
+- **GIVEN** a `summarizeFromHistory` call where `shotData["summaryLines"]` is non-empty
+- **WHEN** the helper is invoked with a cached `AnalysisResult` derived from those lines
+- **THEN** the helper SHALL NOT re-run `analyzeShot`
+- **AND** SHALL populate `summary.summaryLines` from the cache and derive `pourTruncatedDetected` from `cachedAnalysis.detectors.pourTruncated`
+
+### Requirement: `ShotSummarizer::summarize` (live shot path) SHALL have direct unit-test coverage
+
+The live-shot summary path `ShotSummarizer::summarize(const ShotDataModel*, const Profile*, const ShotMetadata&, double doseWeight, double finalWeight)` SHALL be exercised by at least two direct unit tests in `tst_shotsummarizer.cpp`, mirroring the canonical scenarios already covered for the saved-shot path:
+
+1. **Puck-failure suppression cascade**: a shot whose pressure stays below `PRESSURE_FLOOR_BAR` produces `pourTruncatedDetected = true`, the `"Pour never pressurized"` warning line, the puck-failed verdict, and NO channeling lines.
+2. **Healthy shot baseline**: a clean shot produces non-empty observation lines, a verdict line, and `pourTruncatedDetected = false`.
+
+The tests SHALL use a `MockShotDataModel` (or equivalent test double) that exposes the curve and phase-marker accessor methods `summarize()` reads. The mock SHALL NOT depend on the full `ShotDataModel` runtime (no signals, no `QObject`-machinery beyond what's needed to satisfy the function signature).
+
+#### Scenario: Live path puck-failure test passes
+
+- **GIVEN** a `MockShotDataModel` populated with puck-failure curves (pressure flat at 1.0 bar, flow at preinfusion goal, conductance derivative spikes)
+- **WHEN** `summarize(mock, profile, metadata, 18.0, 36.0)` runs
+- **THEN** the resulting `ShotSummary::pourTruncatedDetected` SHALL be `true`
+- **AND** `summaryLines` SHALL contain the `"Pour never pressurized"` warning
+- **AND** SHALL NOT contain `"Sustained channeling"` lines
+
+#### Scenario: Live and history paths produce equivalent summaries (optional)
+
+- **GIVEN** the same shot data presented to `summarize()` (via mock) and `summarizeFromHistory()` (via QVariantMap)
+- **WHEN** both run
+- **THEN** the resulting `ShotSummary::summaryLines`, `pourTruncatedDetected`, and `phases` SHALL be byte-equal
+
+## REMOVED Requirements
+
+### Requirement: Intentional temperature stepping does NOT fire the temp badge
+
+**Reason**: The temperature-unstable badge is being removed entirely. The Shot Summary dialog and badge UI no longer carry a temp-stability concept, so suppression rules for it become moot. Audit found 12+ built-in profiles where actual-vs-goal temperature gap is by design (D-Flow family with `espresso_temperature_steps_enabled = 0`, Extractamundo / TurboBloom 16°C bloom drops, 80's Espresso / TurboTurbo / Classic Italian / etc. with 6–10°C designed swings). The `hasIntentionalTempStepping` curve-based suppression is fragile (collapses when the captured `temperatureGoal` series is sparse), and the underlying detector measures *deviation from goal* while being labeled *unstable* — the math doesn't match the label.
+
+**Migration**: There is no replacement detector. External MCP consumers that read `detectorResults.temperature` lose the field; consumers that filter shots by `temperature_unstable` must drop that predicate. The diagnostic value the badge attempted to surface (cold portafilter crash, heater failure, boiler exhaustion) remains visible in the post-shot temperature chart. A future change MAY reintroduce a true *instability* detector (variance / mid-shot crash) but it is out of scope for this change.
+
+This requirement was previously a scenario under "Save and load paths SHALL derive boolean quality badges from `DetectorResults` via a single documented projection." Its removal is reflected in the modified version of that requirement (the `temperatureUnstable` row is dropped from the projection table, and the `temperatureUnstable` clause is removed from the pour-truncated-cascade scenario).

--- a/openspec/changes/remove-temperature-unstable-badge/tasks.md
+++ b/openspec/changes/remove-temperature-unstable-badge/tasks.md
@@ -1,0 +1,86 @@
+## 1. Pre-flight grep audit
+
+- [x] 1.1 `grep -rn` each removed symbol across the repo and build a complete call-site list to verify the deletions in §2-§7 are exhaustive: `tempUnstable`, `tempStabilityChecked`, `tempIntentionalStepping`, `tempAvgDeviationC`, `temperatureUnstable`, `temperature_unstable`, `TEMP_UNSTABLE_THRESHOLD`, `TEMP_STEPPING_RANGE`, `TEMP_WARMUP_SKIP_C`, `TEMP_MIN_EXTRACTION_SEC`, `hasIntentionalTempStepping`, `avgTempDeviation`, `reachedExtractionPhase`, `markPerPhaseTempInstability`, `temperature_drift`. Save as `/tmp/temp_unstable_audit.txt` for cross-reference during the rest of the change.
+- [x] 1.2 Confirm no other detector or feature uses `reachedExtractionPhase`, `avgTempDeviation`, or `hasIntentionalTempStepping`. If any non-temp-detector caller surfaces (unexpected), raise it back to design before proceeding.
+
+## 2. Detector removal in `src/ai/shotanalysis.{h,cpp}`
+
+- [x] 2.1 Delete the four constants from `shotanalysis.h`: `TEMP_UNSTABLE_THRESHOLD`, `TEMP_STEPPING_RANGE`, `TEMP_WARMUP_SKIP_C`, `TEMP_MIN_EXTRACTION_SEC`. Delete the comment block above them.
+- [x] 2.2 Delete the static-method declarations: `hasIntentionalTempStepping` (both overloads), `avgTempDeviation`, `reachedExtractionPhase`. Delete their accompanying docstrings.
+- [x] 2.3 Delete the four fields from `DetectorResults`: `tempStabilityChecked`, `tempIntentionalStepping`, `tempAvgDeviationC`, `tempUnstable`. Delete their accompanying docstring section ("=== Temperature stability ===").
+- [x] 2.4 In `shotanalysis.cpp`, delete the function bodies for `hasIntentionalTempStepping` (both overloads), `avgTempDeviation`, `reachedExtractionPhase`.
+- [x] 2.5 In `shotanalysis.cpp` `analyzeShot`, delete the entire "--- Temperature stability ---" block (the `if (!pourTruncated && temperature.size() > 10 && ...)` clause). Also remove `temperature` and `temperatureGoal` from `analyzeShot`'s parameter list **only if no other detector reads them** — verify by grep before removing.
+- [x] 2.6 Update `analyzeShot` and `generateSummary` declarations in the header to drop `temperature` / `temperatureGoal` parameters if §2.5 confirmed they're unused. Update all call sites accordingly (`shotsummarizer.cpp`, `shothistorystorage*.cpp`, `tools/shot_eval/main.cpp`, `tests/tst_shotanalysis.cpp`).
+- [x] 2.7 Remove `verdictCategory` mentions of temperature ("temp" doesn't appear in the verdict cascade today, but verify) — ensure verdict precedence comments and code don't reference the temp branch.
+
+## 3. Badge projection in `src/history/shotbadgeprojection.h`
+
+- [x] 3.1 Delete the `temperatureUnstable` row from `decenza::deriveBadgesFromAnalysis`. Update the docstring projection table.
+- [x] 3.2 Delete the `applyBadgesToTarget` field for `temperatureUnstable` and any companion struct field on `BadgeRow` (or whatever the shared struct is named).
+
+## 4. Per-phase temp markers in `src/ai/shotsummarizer.{h,cpp}`
+
+- [x] 4.1 Delete the `markPerPhaseTempInstability` helper and its declaration.
+- [x] 4.2 Delete the `PhaseSummary::temperatureUnstable` field.
+- [x] 4.3 Delete the call site in the `runShotAnalysisAndPopulate` helper that invokes `markPerPhaseTempInstability`. Update the helper docstring to drop the per-phase temp obligation.
+- [x] 4.4 Search the AI advisor prompt builders (`buildUserPrompt`, `summarizeFromHistory`, anywhere `PhaseSummary` is rendered into prompt text) for temperature-drift mentions and delete them. Re-check the prompt template still parses cleanly with no orphan headers.
+
+## 5. Storage layer in `src/history/shothistorystorage*.cpp`
+
+- [x] 5.1 Drop the `temperature_unstable` column read in `loadShotRecordStatic` (the local var, the field assignment, and the lazy-persist comparison branch).
+- [x] 5.2 Drop the `temperature_unstable` column write in `saveShot` and any insert SQL string.
+- [x] 5.3 Update `requestReanalyzeBadges`: drop the temp arg from the worker, drop it from the comparison, drop it from the `shotBadgesUpdated` emit (5 args, not 6).
+- [x] 5.4 Drop the `temperature_unstable` predicate from `buildFilterQuery`.
+- [x] 5.5 Drop the field write in `convertShotRecord`'s output map AND the temperature block from the nested `detectorResults` it builds.
+- [x] 5.6 Add migration 14 to drop the column. Match the existing migration style (in-band SQL, `withTempDb`, version bump, idempotent skip-if-absent guard). Statement: `ALTER TABLE shots DROP COLUMN temperature_unstable;`.
+- [x] 5.7 Update `ShotHistoryStorage::shotBadgesUpdated` signal declaration in the `.h` to take 5 booleans (`channelingDetected, grindIssue, skipFirstFrame, pourTruncated` — pick the existing arg order minus `tempUnstable`).
+
+## 6. MCP serializer in `src/mcp/mcptools_shots.cpp`
+
+- [x] 6.1 Drop the `temperature` block from `detectorResults` JSON in `shots_get_detail` / `shots_compare`.
+- [x] 6.2 Verify `shots_list` doesn't expose a `temperature_unstable` column field; if it does, drop it.
+
+## 7. QML + UI
+
+- [x] 7.1 `qml/components/QualityBadges.qml`: delete the temp chip (the `Repeater`/`if` clause for `temperatureUnstable`) and any chip text bindings. Re-check the row layout after one chip is removed.
+- [x] 7.2 `qml/pages/ShotDetailPage.qml`: drop the `temperatureUnstable` property binding, drop the arg from the `shotBadgesUpdated` `Connections` handler, drop any `if (shotData.temperatureUnstable)` branches.
+- [x] 7.3 `qml/pages/PostShotReviewPage.qml`: same treatment as §7.2.
+- [x] 7.4 `qml/pages/ShotHistoryPage.qml`: delete the "Temp unstable" filter chip and its query helper. Confirm the filter row still aligns visually after the chip drop.
+- [x] 7.5 Confirm `ShotAnalysisDialog.qml` needs no edits (it reads `summaryLines`).
+
+## 8. Tests
+
+- [x] 8.1 In `tests/tst_shotanalysis.cpp`, delete: `temperatureUnstable_*`, `intentionalTempStepping_*` (both threshold-edge variants), `avgTempDeviation_*` (warmup-skip, mid-shot-drop, no-data), `reachedExtractionPhase_*`. Update `analyzeShot_*` cascade tests to drop temp expectations and pass empty temp curves.
+- [x] 8.2 Update `tst_shotanalysis::badgeProjection_*` tests: remove the `temperatureUnstable` row test (`badgeProjection_tempUnstable_setsBadge` if such exists) and any combined-cascade assertion that asserts on the temp badge.
+- [x] 8.3 In `tests/data/shots/manifest.json`, drop `temperature_unstable` keys from every fixture entry. (Use `jq` or a careful `sed` — manifest entries are nested.)
+- [x] 8.4 Run `shot_eval --validate tests/data/shots/manifest.json` locally to confirm the corpus still passes.
+- [x] 8.5 Update `tools/shot_eval/main.cpp` if it references any removed symbol or the temp parameter on `analyzeShot`. Drop the temp-eval column from output if present (it isn't today, but double-check).
+- [x] 8.6 Update `tst_shotsummarizer.cpp` aborted-during-preinfusion test: it currently asserts that `PhaseSummary::temperatureUnstable` markers are NOT set. Either delete the test (it's about a feature that no longer exists) or rewrite it to assert the puck-failure cascade only.
+
+## 9. Documentation
+
+- [x] 9.1 `docs/SHOT_REVIEW.md` §1 (badges table): drop the `temperatureUnstable` row. Update count in surrounding prose ("Five flags" → "Four flags").
+- [x] 9.2 `docs/SHOT_REVIEW.md`: delete §2.3 ("Temperature unstable") entirely and renumber subsequent sections (2.4 → 2.3, 2.5 → 2.4).
+- [x] 9.3 `docs/SHOT_REVIEW.md` §3 ("Observations emitted"): delete the "Temperature stability" item (#4) and renumber. Drop the `temperature_drift` line `kind` from the line-types table if present.
+- [x] 9.4 `docs/SHOT_REVIEW.md` §3 ("Verdict precedence"): verify no temp branch was in the cascade (it shouldn't be, but confirm).
+- [x] 9.5 `docs/SHOT_REVIEW.md` §4 (projection table): drop the `temperatureUnstable` row. Update prose around it ("five flag columns" → "four").
+- [x] 9.6 `docs/SHOT_REVIEW.md` §5 (persistence): note the dropped column and migration.
+- [x] 9.7 `docs/SHOT_REVIEW.md` §6 (regression corpus): drop temperature mentions from the manifest format paragraph.
+- [x] 9.8 `docs/SHOT_REVIEW.md` §7 (references): add a note referencing this change archive once landed.
+- [x] 9.9 `docs/CLAUDE_MD/MCP_SERVER.md` "Shot Detector Outputs": drop the temperature block from the documented JSON shape.
+- [x] 9.10 `CLAUDE.md`: nothing to change directly (the `docs/SHOT_REVIEW.md` link is unaffected), but verify by re-reading the SHOT_REVIEW link section.
+
+## 10. Manual & build verification
+
+- [x] 10.1 Build via Qt Creator (debug + release) — should be clean, no warnings about unused `temperature` parameters anywhere.
+- [x] 10.2 Run the full Qt Test suite via `mcp__qtcreator__run_tests` (per project policy). Zero failures, zero WARN lines.
+- [ ] 10.3 Open at least three historical shots that previously had the badge — confirm the chip is gone, dialog has no "Temperature drifted" line, MCP `shots_get_detail` returns no `temperature` block.
+- [ ] 10.4 Pull a fresh espresso shot live: confirm post-shot review page renders correctly (no chip, no orphan layout space).
+- [ ] 10.5 Trigger the schema migration on a copy of the production DB. Verify `PRAGMA table_info(shots)` shows the column dropped and existing shot reads still work.
+- [x] 10.6 Run shot_eval against `/tmp/issue1128/*.json` and `tests/data/shots/*.json` — verdicts on the corpus should be unchanged for everything except temp-related assertions.
+
+## 11. PR & archive
+
+- [ ] 11.1 Run `/pr-review-toolkit:review-pr` on the diff before opening the PR.
+- [ ] 11.2 Open the PR with `gh pr create`. Body references issue #1128 with `Closes #1128`.
+- [ ] 11.3 After merge, archive this OpenSpec change with `/openspec-archive-change remove-temperature-unstable-badge`.

--- a/openspec/changes/remove-temperature-unstable-badge/tasks.md
+++ b/openspec/changes/remove-temperature-unstable-badge/tasks.md
@@ -32,7 +32,7 @@
 - [x] 5.3 Update `requestReanalyzeBadges`: drop the temp arg from the worker, drop it from the comparison, drop it from the `shotBadgesUpdated` emit (5 args, not 6).
 - [x] 5.4 Drop the `temperature_unstable` predicate from `buildFilterQuery`.
 - [x] 5.5 Drop the field write in `convertShotRecord`'s output map AND the temperature block from the nested `detectorResults` it builds.
-- [x] 5.6 Add migration 14 to drop the column. Match the existing migration style (in-band SQL, `withTempDb`, version bump, idempotent skip-if-absent guard). Statement: `ALTER TABLE shots DROP COLUMN temperature_unstable;`.
+- [x] 5.6 Add migration 15 to drop the column (migration 14 was taken by `enjoyment_source` between drafting and implementation). Match the existing migration style (in-band SQL, `withTempDb`, version bump, idempotent skip-if-absent guard). Statement: `ALTER TABLE shots DROP COLUMN temperature_unstable;`. Bail-out on exec failure so a stranded column can't ship with schema_version=15.
 - [x] 5.7 Update `ShotHistoryStorage::shotBadgesUpdated` signal declaration in the `.h` to take 5 booleans (`channelingDetected, grindIssue, skipFirstFrame, pourTruncated` — pick the existing arg order minus `tempUnstable`).
 
 ## 6. MCP serializer in `src/mcp/mcptools_shots.cpp`

--- a/openspec/specs/dialing-context-payload/spec.md
+++ b/openspec/specs/dialing-context-payload/spec.md
@@ -270,7 +270,7 @@ The system SHALL compute a `grinderCalibration` block and include it in the dial
 2. The resolved shot's `beverageType` is espresso (NOT `filter` or `pourover`).
 3. At least 2 profiles in the all-time history (same grinder model + burrs) have qualifying shots with numeric grinder settings AND a canonical (non-inferred) UGS value in the knowledge base.
 
-A shot qualifies when: `final_weight >= 5g` (not aborted) AND no quality badge is set (`grind_issue_detected = 0`, `channeling_detected = 0`, `pour_truncated_detected = 0`, `temperature_unstable = 0`, `skip_first_frame_detected = 0`). Badge columns default to 0 for shots predating the badge migrations, so all old shots pass this filter.
+A shot qualifies when: `final_weight >= 5g` (not aborted) AND no quality badge is set (`grind_issue_detected = 0`, `channeling_detected = 0`, `pour_truncated_detected = 0`, `skip_first_frame_detected = 0`). Badge columns default to 0 for shots predating the badge migrations, so all old shots pass this filter. (The historical `temperature_unstable` predicate was retired alongside its column in the openspec change `remove-temperature-unstable-badge`.)
 
 The block SHALL be omitted (no key, no `null`) when any precondition fails.
 

--- a/openspec/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/specs/shot-analysis-pipeline/spec.md
@@ -35,8 +35,6 @@ When `ShotSummarizer::summarizeFromHistory(shotData)` is invoked with a `shotDat
 
 When `summaryLines` is absent or empty (legacy shots, direct test callers, imported shots without the new fields), the function SHALL fall back to the existing inline detector orchestration path. The fast and fallback paths SHALL produce equivalent `ShotSummary::summaryLines` for identical shot data — they cannot drift because both ultimately rely on the same `ShotAnalysis::analyzeShot` body.
 
-The per-phase temperature instability markers (`markPerPhaseTempInstability`) SHALL remain gated on `!summary.pourTruncatedDetected AND ShotAnalysis::reachedExtractionPhase(historyMarkers, summary.totalDuration)` regardless of which path produced the summary lines.
-
 The live-path entry point `ShotSummarizer::summarize(ShotDataModel*)` is OUT OF SCOPE — it operates on an in-progress shot for which no `convertShotRecord` has run, and SHALL continue to call `analyzeShot` (via `generateSummary`) inline.
 
 #### Scenario: Modern shotData with pre-computed lines bypasses recomputation
@@ -65,11 +63,10 @@ The live-path entry point `ShotSummarizer::summarize(ShotDataModel*)` is OUT OF 
 - **GIVEN** a `shotData` map with non-empty `summaryLines` and `detectorResults.pourTruncated == true`
 - **WHEN** the AI advisor invokes `summarizeFromHistory(shotData)`
 - **THEN** `ShotSummary::pourTruncatedDetected` SHALL be `true`
-- **AND** no `PhaseSummary::temperatureUnstable` markers SHALL be set on the summary's phase list (the cascade gates the per-phase pass identically to the slow path)
 
 ### Requirement: Save and load paths SHALL derive boolean quality badges from `DetectorResults` via a single documented projection
 
-`ShotHistoryStorage::saveShot` (save-time badge computation) and `ShotHistoryStorage::loadShotRecordStatic` (recompute-on-load) SHALL invoke `ShotAnalysis::analyzeShot(...)` exactly once per shot and project the five boolean badge columns from the returned `DetectorResults` struct using the documented mapping. Neither function SHALL retain hand-rolled per-detector calls or hand-rolled cascade gate conditions; the cascade SHALL live in exactly one place — `ShotAnalysis::analyzeShot`.
+`ShotHistoryStorage::saveShot` (save-time badge computation) and `ShotHistoryStorage::loadShotRecordStatic` (recompute-on-load) SHALL invoke `ShotAnalysis::analyzeShot(...)` exactly once per shot and project the four boolean badge columns from the returned `DetectorResults` struct using the documented mapping. Neither function SHALL retain hand-rolled per-detector calls or hand-rolled cascade gate conditions; the cascade SHALL live in exactly one place — `ShotAnalysis::analyzeShot`.
 
 The projection mapping SHALL be implemented in `decenza::deriveBadgesFromAnalysis` (header-only, in `src/history/shotbadgeprojection.h`) as:
 
@@ -77,7 +74,6 @@ The projection mapping SHALL be implemented in `decenza::deriveBadgesFromAnalysi
 |---|---|
 | `pourTruncatedDetected` | `d.pourTruncated` |
 | `channelingDetected` | `d.channelingSeverity == "sustained"` (Transient does NOT set the badge) |
-| `temperatureUnstable` | `d.tempUnstable` |
 | `grindIssueDetected` | `d.grindHasData && (d.grindChokedPuck || d.grindYieldOvershoot || std::abs(d.grindFlowDeltaMlPerSec) > FLOW_DEVIATION_THRESHOLD)` |
 | `skipFirstFrameDetected` | `d.skipFirstFrame` |
 
@@ -87,7 +83,7 @@ The lazy-persist write-back in `loadShotRecordStatic` (when stored badge columns
 
 `ShotAnalysis::analyzeShot` SHALL accept an optional `expectedFrameCount` parameter and forward it to `detectSkipFirstFrame`. Save and load paths SHALL pass the profile's actual frame count so 1-frame profiles correctly suppress the skip-first-frame detector. Backwards-compatible: the parameter defaults to `-1` (unknown), preserving behavior for callers (legacy `generateSummary` wrapper) that don't pass it.
 
-The DB schema, the badge column types, and the badge-driven UI surfaces (history-list filter chips, badge UI, `shots_list` MCP) are OUT OF SCOPE — they continue to read the same five boolean columns; only the *production* of those values is unified.
+The DB schema, the badge column types, and the badge-driven UI surfaces (history-list filter chips, badge UI, `shots_list` MCP) are OUT OF SCOPE — they continue to read the same four boolean columns; only the *production* of those values is unified.
 
 The Sustained-only semantic for `channelingDetected` SHALL be preserved exactly. A shot whose `DetectorResults.channelingSeverity` is `"transient"` MUST result in `channelingDetected = false`. This matches the badge behavior established by PR #922 and is documented in the projection table.
 
@@ -95,14 +91,14 @@ The Sustained-only semantic for `channelingDetected` SHALL be preserved exactly.
 
 - **GIVEN** a shot whose `analyzeShot` returns `DetectorResults` with `verdictCategory = "clean"` and all detector gates clear
 - **WHEN** save-time or load-time badge derivation runs
-- **THEN** all five boolean badge columns SHALL be `false`
+- **THEN** all four boolean badge columns SHALL be `false`
 
 #### Scenario: Pour-truncated cascade dominates the projection
 
-- **GIVEN** a shot whose `analyzeShot` returns `pourTruncated = true` (and consequently `channelingChecked = false`, `grindChecked = false`, `tempUnstable = false`)
+- **GIVEN** a shot whose `analyzeShot` returns `pourTruncated = true` (and consequently `channelingChecked = false`, `grindChecked = false`)
 - **WHEN** save-time or load-time badge derivation runs
 - **THEN** `pourTruncatedDetected` SHALL be `true`
-- **AND** `channelingDetected`, `temperatureUnstable`, `grindIssueDetected` SHALL each be `false`
+- **AND** `channelingDetected`, `grindIssueDetected` SHALL each be `false`
 - **AND** `skipFirstFrameDetected` SHALL reflect `d.skipFirstFrame` independently (skip-first-frame is NOT suppressed by the cascade, matching PR #922's invariant)
 
 #### Scenario: Transient channeling does NOT set the badge
@@ -135,13 +131,6 @@ The Sustained-only semantic for `channelingDetected` SHALL be preserved exactly.
 - **GIVEN** a shot whose `analyzeShot` returns `grindHasData = true`, both `grindChokedPuck` and `grindYieldOvershoot` false, and `|grindFlowDeltaMlPerSec| <= FLOW_DEVIATION_THRESHOLD`
 - **WHEN** save-time or load-time badge derivation runs
 - **THEN** `grindIssueDetected` SHALL be `false`
-
-#### Scenario: Intentional temperature stepping does NOT fire the temp badge
-
-- **GIVEN** a shot using a profile whose temperature goal range exceeds `TEMP_STEPPING_RANGE` (e.g. D-Flow 84→94°C)
-- **AND** `analyzeShot` returns `tempIntentionalStepping = true`, `tempUnstable = false`
-- **WHEN** save-time or load-time badge derivation runs
-- **THEN** `temperatureUnstable` SHALL be `false`
 
 #### Scenario: 1-frame profile suppresses skip-first-frame detection
 
@@ -252,7 +241,7 @@ A future addition to `PhaseSummary`'s field set or per-phase metric computation 
 
 `ShotAnalysis::DetectorResults` SHALL include `pourStartSec` and `pourEndSec` fields populated by `analyzeShot` from the same `pourStart` / `pourEnd` locals it uses internally for the suppression cascade and detector gates. These fields SHALL be the canonical pour-window values for any consumer that needs them.
 
-`ShotSummarizer::computePourWindow` SHALL be deleted. Its sole consumer (the `markPerPhaseTempInstability` gate) SHALL read from `AnalysisResult::detectors::pourStartSec` / `pourEndSec` instead.
+`ShotSummarizer::computePourWindow` SHALL be deleted. MCP consumers reading `pourStartSec` / `pourEndSec` SHALL read from `AnalysisResult::detectors::pourStartSec` / `pourEndSec` instead of re-deriving the window themselves.
 
 `ShotHistoryStorage::convertShotRecord` SHALL serialize the two new fields onto the MCP `detectorResults` JSON object so external agents have access to the same pour-window values the in-app cascade uses.
 
@@ -263,11 +252,11 @@ A future addition to `PhaseSummary`'s field set or per-phase metric computation 
 - **THEN** `result.detectors.pourStartSec` SHALL equal the `pourStart` value `analyzeShot` uses internally for its suppression-cascade gates
 - **AND** `result.detectors.pourEndSec` SHALL equal the corresponding `pourEnd` value
 
-#### Scenario: ShotSummarizer's per-phase temp gate uses the exposed window
+#### Scenario: computePourWindow is gone
 
-- **GIVEN** a shot for which `markPerPhaseTempInstability` would run (not pour-truncated, reached extraction phase)
-- **WHEN** `ShotSummarizer::summarize` or `summarizeFromHistory` runs
-- **THEN** the gate's pour-window inputs SHALL come from `summary.pourStartSec` / `pourEndSec` (or equivalent cached `AnalysisResult` fields)
+- **GIVEN** the current codebase
+- **WHEN** any consumer needs the pour window
+- **THEN** it SHALL read from `AnalysisResult::detectors::pourStartSec` / `pourEndSec`
 - **AND** `computePourWindow` SHALL no longer exist in the codebase
 
 #### Scenario: MCP consumers see the pour window
@@ -278,9 +267,9 @@ A future addition to `PhaseSummary`'s field set or per-phase metric computation 
 
 ### Requirement: ShotSummarizer's detector-orchestration glue SHALL live in exactly one helper
 
-`ShotSummarizer::summarize` (live shot) and `ShotSummarizer::summarizeFromHistory` (saved shot) SHALL each delegate their final detector-orchestration block to a single private static helper `ShotSummarizer::runShotAnalysisAndPopulate`. The helper accepts pre-extracted typed inputs (curves, markers, beverage type, analysis flags, frame info, target/final weights) plus an optional cached `AnalysisResult`, and populates the passed-in `ShotSummary`'s `summaryLines`, `pourTruncatedDetected`, and per-phase `temperatureUnstable` markers.
+`ShotSummarizer::summarize` (live shot) and `ShotSummarizer::summarizeFromHistory` (saved shot) SHALL each delegate their final detector-orchestration block to a single private static helper `ShotSummarizer::runShotAnalysisAndPopulate`. The helper accepts pre-extracted typed inputs (curves, markers, beverage type, analysis flags, frame info, target/final weights) plus an optional cached `AnalysisResult`, and populates the passed-in `ShotSummary`'s `summaryLines` and `pourTruncatedDetected`.
 
-The two callers SHALL retain their respective input-adapter roles (live extracts from `ShotDataModel*`; history extracts from `QVariantMap` via `variantListToPoints`) but SHALL NOT contain duplicated `analyzeShot`-call + result-unpacking + `markPerPhaseTempInstability`-gating logic.
+The two callers SHALL retain their respective input-adapter roles (live extracts from `ShotDataModel*`; history extracts from `QVariantMap` via `variantListToPoints`) but SHALL NOT contain duplicated `analyzeShot`-call + result-unpacking logic.
 
 The fast-path optimization from change `dedup-ai-advisor-history-path` (reading pre-computed `summaryLines` when present on `summarizeFromHistory`'s input) SHALL be preserved by passing the cached `AnalysisResult` to the helper when applicable; the helper's `cachedAnalysis.has_value()` branch handles the rest.
 
@@ -289,7 +278,7 @@ The fast-path optimization from change `dedup-ai-advisor-history-path` (reading 
 - **GIVEN** the same shot data presented to both `summarize(ShotDataModel*, ...)` and `summarizeFromHistory(QVariantMap)`
 - **WHEN** the two functions run
 - **THEN** both SHALL call `ShotSummarizer::runShotAnalysisAndPopulate` with equivalent inputs
-- **AND** the resulting `ShotSummary` SHALL be byte-equal across the two paths (same `summaryLines`, same `pourTruncatedDetected`, same per-phase `temperatureUnstable` flags)
+- **AND** the resulting `ShotSummary` SHALL be byte-equal across the two paths (same `summaryLines`, same `pourTruncatedDetected`)
 
 #### Scenario: Cached AnalysisResult fast-path is preserved through the helper
 
@@ -300,11 +289,10 @@ The fast-path optimization from change `dedup-ai-advisor-history-path` (reading 
 
 ### Requirement: `ShotSummarizer::summarize` (live shot path) SHALL have direct unit-test coverage
 
-The live-shot summary path `ShotSummarizer::summarize(const ShotDataModel*, const Profile*, const ShotMetadata&, double doseWeight, double finalWeight)` SHALL be exercised by at least three direct unit tests in `tst_shotsummarizer.cpp`, mirroring the canonical scenarios already covered for the saved-shot path:
+The live-shot summary path `ShotSummarizer::summarize(const ShotDataModel*, const Profile*, const ShotMetadata&, double doseWeight, double finalWeight)` SHALL be exercised by at least two direct unit tests in `tst_shotsummarizer.cpp`, mirroring the canonical scenarios already covered for the saved-shot path:
 
-1. **Puck-failure suppression cascade**: a shot whose pressure stays below `PRESSURE_FLOOR_BAR` produces `pourTruncatedDetected = true`, the `"Pour never pressurized"` warning line, the puck-failed verdict, and NO channeling / temp-drift lines.
-2. **Aborted-during-preinfusion gate**: a shot that died during preinfusion-start does NOT flag per-phase `temperatureUnstable`, even with a large measured temp deviation, because `reachedExtractionPhase` returns false.
-3. **Healthy shot baseline**: a clean shot produces non-empty observation lines, a verdict line, and `pourTruncatedDetected = false`.
+1. **Puck-failure suppression cascade**: a shot whose pressure stays below `PRESSURE_FLOOR_BAR` produces `pourTruncatedDetected = true`, the `"Pour never pressurized"` warning line, the puck-failed verdict, and NO channeling lines.
+2. **Healthy shot baseline**: a clean shot produces non-empty observation lines, a verdict line, and `pourTruncatedDetected = false`.
 
 The tests SHALL use a `MockShotDataModel` (or equivalent test double) that exposes the curve and phase-marker accessor methods `summarize()` reads. The mock SHALL NOT depend on the full `ShotDataModel` runtime (no signals, no `QObject`-machinery beyond what's needed to satisfy the function signature).
 
@@ -314,7 +302,7 @@ The tests SHALL use a `MockShotDataModel` (or equivalent test double) that expos
 - **WHEN** `summarize(mock, profile, metadata, 18.0, 36.0)` runs
 - **THEN** the resulting `ShotSummary::pourTruncatedDetected` SHALL be `true`
 - **AND** `summaryLines` SHALL contain the `"Pour never pressurized"` warning
-- **AND** SHALL NOT contain `"Sustained channeling"` or `"Temperature drifted"` lines
+- **AND** SHALL NOT contain `"Sustained channeling"` lines
 
 #### Scenario: Live and history paths produce equivalent summaries (optional)
 
@@ -334,9 +322,9 @@ The function SHALL set `GrindCheck::hasData = true` whenever EITHER arm could sp
 - `"notAnalyzable"` — `GrindCheck.hasData == false && GrindCheck.skipped == false`, AND the espresso shot's pour window was non-degenerate (`pourEndSec > pourStartSec`), AND the beverage type is not in the non-espresso skip list.
 - `"skipped"` — `GrindCheck.skipped == true` (non-espresso beverages or profiles carrying the `grind_check_skip` analysis flag).
 
-When the pourTruncated cascade is active, the field SHALL be omitted entirely (consistent with how the channeling, flow-trend, temp, and grind blocks are already suppressed in that cascade).
+When the pourTruncated cascade is active, the field SHALL be omitted entirely (consistent with how the channeling, flow-trend, and grind blocks are already suppressed in that cascade).
 
-The five quality-badge boolean projections in `src/history/shotbadgeprojection.h` SHALL NOT change. Specifically: `grindIssueDetected` SHALL still require `grindHasData && (grindChokedPuck || grindYieldOvershoot || |grindFlowDeltaMlPerSec| > FLOW_DEVIATION_THRESHOLD)`. A verified-clean result SHALL project `grindIssueDetected = false`. A yield-shortfall-only result (yield arm fired, flow arm gates didn't pass) SHALL project `grindIssueDetected = true` because `chokedPuck` is set when either choke sub-arm fires.
+The four quality-badge boolean projections in `src/history/shotbadgeprojection.h` SHALL NOT change. Specifically: `grindIssueDetected` SHALL still require `grindHasData && (grindChokedPuck || grindYieldOvershoot || |grindFlowDeltaMlPerSec| > FLOW_DEVIATION_THRESHOLD)`. A verified-clean result SHALL project `grindIssueDetected = false`. A yield-shortfall-only result (yield arm fired, flow arm gates didn't pass) SHALL project `grindIssueDetected = true` because `chokedPuck` is set when either choke sub-arm fires.
 
 #### Scenario: Verified-clean shot emits a positive signal
 

--- a/qml/components/QualityBadges.qml
+++ b/qml/components/QualityBadges.qml
@@ -14,7 +14,7 @@ Item {
     required property bool grindIssueDetected
     required property bool skipFirstFrameDetected
     // Puck-failure flag (peak pressure < PRESSURE_FLOOR_BAR). Dominant: when
-    // true the C++ detector path forces channeling/temp/grind to false so
+    // true the C++ detector path forces channeling/grind to false so
     // this chip stands alone. (skipFirstFrameDetected is intentionally NOT
     // suppressed — it's a machine/profile issue orthogonal to puck integrity
     // and can co-fire with this chip.) The clean-extraction green chip

--- a/qml/components/QualityBadges.qml
+++ b/qml/components/QualityBadges.qml
@@ -5,13 +5,12 @@ import Decenza
 
 // Compact quality status chip(s) for a shot. Sized to its content (shrink-wraps).
 // Note: always shows at least one chip when visible — either a flag or "Clean extraction".
-// Shows the most important quality indicator: channeling (red), temp unstable (orange),
-// grind issue (orange), or clean extraction (green). Multiple flags show multiple chips.
+// Shows the most important quality indicator: channeling (red), grind issue
+// (orange), or clean extraction (green). Multiple flags show multiple chips.
 Item {
     id: root
 
     required property bool channelingDetected
-    required property bool temperatureUnstable
     required property bool grindIssueDetected
     required property bool skipFirstFrameDetected
     // Puck-failure flag (peak pressure < PRESSURE_FLOOR_BAR). Dominant: when
@@ -62,41 +61,6 @@ Item {
                     fallback: "Channeling detected"
                     font: Theme.captionFont
                     color: Theme.errorColor
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-            }
-        }
-
-        // Temperature unstable badge (orange/warning)
-        Rectangle {
-            visible: root.temperatureUnstable
-            width: tempRow.width + Theme.spacingMedium * 2
-            height: Theme.scaled(28)
-            radius: Theme.scaled(14)
-            color: Qt.rgba(Theme.warningColor.r, Theme.warningColor.g, Theme.warningColor.b, 0.15)
-            border.color: Theme.warningColor
-            border.width: Theme.scaled(1)
-
-            Accessible.role: Accessible.StaticText
-            Accessible.name: tempText.text
-            Accessible.focusable: true
-
-            Row {
-                id: tempRow
-                anchors.centerIn: parent
-                spacing: Theme.scaled(4)
-                Rectangle {
-                    width: Theme.scaled(8); height: Theme.scaled(8); radius: Theme.scaled(4)
-                    color: Theme.warningColor; anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-                Tr {
-                    id: tempText
-                    key: "badges.tempUnstable"
-                    fallback: "Temp unstable"
-                    font: Theme.captionFont
-                    color: Theme.warningColor
                     anchors.verticalCenter: parent.verticalCenter
                     Accessible.ignored: true
                 }
@@ -211,7 +175,7 @@ Item {
 
         // Clean extraction badge (green) — only shown when no flags are set
         Rectangle {
-            visible: !root.channelingDetected && !root.temperatureUnstable && !root.grindIssueDetected && !root.skipFirstFrameDetected && !root.pourTruncatedDetected
+            visible: !root.channelingDetected && !root.grindIssueDetected && !root.skipFirstFrameDetected && !root.pourTruncatedDetected
             width: cleanRow.width + Theme.spacingMedium * 2
             height: Theme.scaled(28)
             radius: Theme.scaled(14)

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -154,11 +154,10 @@ Page {
                 // below catches the persist event.
             }
         }
-        function onShotBadgesUpdated(shotId, channeling, tempUnstable, grindIssue, skipFirstFrame, pourTruncated) {
+        function onShotBadgesUpdated(shotId, channeling, grindIssue, skipFirstFrame, pourTruncated) {
             if (shotId !== postShotReviewPage.editShotId) return
             var updated = Object.assign({}, editShotData)
             updated.channelingDetected = channeling
-            updated.temperatureUnstable = tempUnstable
             updated.grindIssueDetected = grindIssue
             updated.skipFirstFrameDetected = skipFirstFrame
             updated.pourTruncatedDetected = pourTruncated
@@ -416,14 +415,12 @@ Page {
                         QualityBadges {
                             visible: !!(editShotData.profileKbId
                                         || editShotData.channelingDetected
-                                        || editShotData.temperatureUnstable
                                         || editShotData.grindIssueDetected
                                         || editShotData.skipFirstFrameDetected
                                         || editShotData.pourTruncatedDetected)
                             Layout.fillWidth: false
                             Layout.maximumWidth: postShotReviewPage.width * 0.5
                             channelingDetected: editShotData.channelingDetected ?? false
-                            temperatureUnstable: editShotData.temperatureUnstable ?? false
                             grindIssueDetected: editShotData.grindIssueDetected ?? false
                             skipFirstFrameDetected: editShotData.skipFirstFrameDetected ?? false
                             pourTruncatedDetected: editShotData.pourTruncatedDetected ?? false

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -80,11 +80,10 @@ Page {
                 console.warn("ShotDetailPage: Failed to save visualizer info for shot", id)
             }
         }
-        function onShotBadgesUpdated(id, channeling, tempUnstable, grindIssue, skipFirstFrame, pourTruncated) {
+        function onShotBadgesUpdated(id, channeling, grindIssue, skipFirstFrame, pourTruncated) {
             if (id !== shotDetailPage.shotId) return
             var updated = Object.assign({}, shotData)
             updated.channelingDetected = channeling
-            updated.temperatureUnstable = tempUnstable
             updated.grindIssueDetected = grindIssue
             updated.skipFirstFrameDetected = skipFirstFrame
             updated.pourTruncatedDetected = pourTruncated
@@ -244,14 +243,12 @@ Page {
                         QualityBadges {
                             visible: !!(shotData.profileKbId
                                         || shotData.channelingDetected
-                                        || shotData.temperatureUnstable
                                         || shotData.grindIssueDetected
                                         || shotData.skipFirstFrameDetected
                                         || shotData.pourTruncatedDetected)
                             Layout.fillWidth: false
                             Layout.maximumWidth: shotDetailPage.width * 0.5
                             channelingDetected: shotData.channelingDetected ?? false
-                            temperatureUnstable: shotData.temperatureUnstable ?? false
                             grindIssueDetected: shotData.grindIssueDetected ?? false
                             skipFirstFrameDetected: shotData.skipFirstFrameDetected ?? false
                             pourTruncatedDetected: shotData.pourTruncatedDetected ?? false

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -741,7 +741,7 @@ Page {
 
                             // Quality issue indicator dots. Order: red puckFailed first
                             // (most severe — shot has no tuning signal), then channeling
-                            // (red), temp/grind (orange), skipFirstFrame (red).
+                            // (red), grind (orange), skipFirstFrame (red).
                             Rectangle {
                                 width: Theme.scaled(8); height: Theme.scaled(8); radius: Theme.scaled(4)
                                 color: Theme.errorColor

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -194,10 +194,9 @@ Page {
                 }
             }
 
-            // Parse quality flag keywords (channeling:yes, temp:yes, grind:yes, skipframe:yes, puckfailed:yes)
+            // Parse quality flag keywords (channeling:yes, grind:yes, skipframe:yes, puckfailed:yes)
             var flagKeywords = [
                 { pattern: /\bchanneling:yes\b/gi, filterKey: "filterChanneling" },
-                { pattern: /\btemp:yes\b/gi, filterKey: "filterTemperatureUnstable" },
                 { pattern: /\bgrind:yes\b/gi, filterKey: "filterGrindIssue" },
                 { pattern: /\bskipframe:yes\b/gi, filterKey: "filterSkipFirstFrame" },
                 { pattern: /\bpuckfailed:yes\b/gi, filterKey: "filterPourTruncated" }
@@ -607,7 +606,6 @@ Page {
                     var issues = []
                     if (model.pourTruncatedDetected) issues.push("puck failed")
                     if (model.channelingDetected) issues.push("channeling")
-                    if (model.temperatureUnstable) issues.push("temp unstable")
                     if (model.grindIssueDetected) issues.push("grind issue")
                     if (model.skipFirstFrameDetected) issues.push("first step skipped")
                     if (issues.length > 0) parts.push(issues.join(", "))
@@ -754,12 +752,6 @@ Page {
                                 width: Theme.scaled(8); height: Theme.scaled(8); radius: Theme.scaled(4)
                                 color: Theme.errorColor
                                 visible: model.channelingDetected ?? false
-                                Accessible.ignored: true
-                            }
-                            Rectangle {
-                                width: Theme.scaled(8); height: Theme.scaled(8); radius: Theme.scaled(4)
-                                color: Theme.warningColor
-                                visible: model.temperatureUnstable ?? false
                                 Accessible.ignored: true
                             }
                             Rectangle {
@@ -1329,21 +1321,6 @@ Page {
                 Text { text: "channeling:yes"; font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
 
                 Rectangle {
-                    color: tempArea.pressed ? Theme.surfaceColor : "transparent"
-                    radius: Theme.scaled(4)
-                    implicitWidth: tempLabel.implicitWidth + Theme.scaled(8)
-                    implicitHeight: tempLabel.implicitHeight + Theme.scaled(4)
-                    Accessible.role: Accessible.Button
-                    Accessible.name: TranslationManager.translate("shothistory.insertKeyword", "Insert %1").arg("temp:yes")
-                    Accessible.focusable: true
-                    Accessible.onPressAction: tempArea.clicked(null)
-                    Text { id: tempLabel; text: "temp:yes"; anchors.centerIn: parent; font.pixelSize: Theme.labelFont.pixelSize; color: Theme.primaryColor; font.bold: true; Accessible.ignored: true }
-                    MouseArea { id: tempArea; anchors.fill: parent; onClicked: insertSearchKeyword("temp:yes") }
-                }
-                Text { text: TranslationManager.translate("shothistory.helptemp", "Temp unstable"); font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
-                Text { text: "temp:yes"; font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
-
-                Rectangle {
                     color: grindArea.pressed ? Theme.surfaceColor : "transparent"
                     radius: Theme.scaled(4)
                     implicitWidth: grindLabel.implicitWidth + Theme.scaled(8)
@@ -1372,12 +1349,27 @@ Page {
                 }
                 Text { text: TranslationManager.translate("shothistory.helpskipframe", "First step skipped"); font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
                 Text { text: "skipframe:yes"; font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
+
+                Rectangle {
+                    color: puckFailedArea.pressed ? Theme.surfaceColor : "transparent"
+                    radius: Theme.scaled(4)
+                    implicitWidth: puckFailedLabel.implicitWidth + Theme.scaled(8)
+                    implicitHeight: puckFailedLabel.implicitHeight + Theme.scaled(4)
+                    Accessible.role: Accessible.Button
+                    Accessible.name: TranslationManager.translate("shothistory.insertKeyword", "Insert %1").arg("puckfailed:yes")
+                    Accessible.focusable: true
+                    Accessible.onPressAction: puckFailedArea.clicked(null)
+                    Text { id: puckFailedLabel; text: "puckfailed:yes"; anchors.centerIn: parent; font.pixelSize: Theme.labelFont.pixelSize; color: Theme.primaryColor; font.bold: true; Accessible.ignored: true }
+                    MouseArea { id: puckFailedArea; anchors.fill: parent; onClicked: insertSearchKeyword("puckfailed:yes") }
+                }
+                Text { text: TranslationManager.translate("shothistory.helppuckfailed", "Puck failed"); font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
+                Text { text: "puckfailed:yes"; font.pixelSize: Theme.labelFont.pixelSize; color: Theme.textSecondaryColor; Accessible.ignored: true }
             }
 
             // Syntax explanation
             Text {
                 text: TranslationManager.translate("shothistory.searchhelpsyntax",
-                    "Syntax: N (exact), N-M (range), N+ (minimum)\nQuality flags: channeling:yes, temp:yes, grind:yes, skipframe:yes\nCombine keywords with text: ethiopia dose:18 channeling:yes")
+                    "Syntax: N (exact), N-M (range), N+ (minimum)\nQuality flags: channeling:yes, grind:yes, skipframe:yes, puckfailed:yes\nCombine keywords with text: ethiopia dose:18 channeling:yes")
                 font: Theme.captionFont
                 color: Theme.textSecondaryColor
                 wrapMode: Text.Wrap

--- a/src/ai/aiconversation.cpp
+++ b/src/ai/aiconversation.cpp
@@ -771,20 +771,15 @@ AIConversation::ShotFields AIConversation::extractShotFields(const QString& cont
             //
             // The substring needles match the actual production strings
             // (case-insensitive). Earlier code looked for "Channeling
-            // detected" (capital C) and "Temperature unstable", neither of
-            // which the detector ever emitted — so detector flags were
-            // always silently false. Fixing here corrects both the
-            // structured-array fallback and the prose path.
+            // detected" (capital C), which the detector never emitted —
+            // so the flag was always silently false. Fixing here corrects
+            // both the structured-array fallback and the prose path.
             auto kindIsChanneling = [](const QString& kind) {
                 return kind == QStringLiteral("channeling_sustained")
                     || kind == QStringLiteral("channeling_transient");
             };
             auto containsChannelingText = [](const QString& s) {
                 return s.contains(QStringLiteral("channeling detected"),
-                                  Qt::CaseInsensitive);
-            };
-            auto containsTempInstabilityText = [](const QString& s) {
-                return s.contains(QStringLiteral("Temperature drifted"),
                                   Qt::CaseInsensitive);
             };
             const QJsonArray observations = shot.value(
@@ -797,21 +792,16 @@ AIConversation::ShotFields AIConversation::extractShotFields(const QString& cont
                     if (!kind.isEmpty()) {
                         if (kindIsChanneling(kind))
                             fields.channelingDetected = true;
-                        if (kind == QStringLiteral("temperature_drift"))
-                            fields.temperatureUnstable = true;
                     } else {
                         // Pre-#1037 entries without a `kind`: fall back
                         // to substring on the line's freeform `text`.
                         if (containsChannelingText(text))
                             fields.channelingDetected = true;
-                        if (containsTempInstabilityText(text))
-                            fields.temperatureUnstable = true;
                     }
                 }
             } else {
                 const QString prose = obj.value(QStringLiteral("shotAnalysis")).toString();
                 fields.channelingDetected = containsChannelingText(prose);
-                fields.temperatureUnstable = containsTempInstabilityText(prose);
             }
 
             fields.fromStructuredEnvelope = true;
@@ -837,8 +827,6 @@ AIConversation::ShotFields AIConversation::extractShotFields(const QString& cont
     // Same actual production strings the structured path matches above.
     fields.channelingDetected = prose.contains(
         QStringLiteral("channeling detected"), Qt::CaseInsensitive);
-    fields.temperatureUnstable = prose.contains(
-        QStringLiteral("Temperature drifted"), Qt::CaseInsensitive);
     fields.fromStructuredEnvelope = false;
     return fields;
 }
@@ -1069,7 +1057,6 @@ QString AIConversation::summarizeShotMessage(const QString& content)
         summary += ", \"" + truncated + "\"";
     }
     if (fields.channelingDetected) summary += " [channeling]";
-    if (fields.temperatureUnstable) summary += " [temp unstable]";
 
     return summary;
 }

--- a/src/ai/aiconversation.h
+++ b/src/ai/aiconversation.h
@@ -273,7 +273,6 @@ private:
         QString score;
         QString notes;
         bool channelingDetected = false;
-        bool temperatureUnstable = false;
         bool fromStructuredEnvelope = false;  // false ⇒ legacy regex path fired
     };
 

--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -659,7 +659,6 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
         "  AND COALESCE(grind_issue_detected, 0) = 0 "
         "  AND COALESCE(channeling_detected, 0) = 0 "
         "  AND COALESCE(pour_truncated_detected, 0) = 0 "
-        "  AND COALESCE(temperature_unstable, 0) = 0 "
         "  AND COALESCE(skip_first_frame_detected, 0) = 0 "
         "ORDER BY timestamp DESC");
     q.addBindValue(grinderModel);

--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -645,7 +645,7 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
     //
     // Only include shots with clean extraction:
     //   - final_weight >= 15g (not aborted; 5g is too small to be a real extraction)
-    //   - no quality badge set (grind issue, channeling, pour truncated, temp unstable)
+    //   - no quality badge set (grind issue, channeling, pour truncated, skip-first-frame)
     // Badge columns default to 0 on old shots (pre-migration), so the filter
     // is safe on all DB versions.
     QSqlQuery q(db);

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -709,7 +709,7 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
 
     // --- Pour-truncated detection (runs first; dominates the cascade) ---
     // When peak pressure stayed below PRESSURE_FLOOR_BAR the puck never built,
-    // so channeling / flow-trend / temp-stability / grind blocks are all
+    // so channeling / flow-trend / grind blocks are all
     // reading off curves the failed puck didn't produce. Skip those blocks
     // entirely when this fires, and emit a single "Puck failed" warning +
     // verdict that names the meta-action ("don't tune off this shot"). Peak
@@ -1018,7 +1018,7 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
     if (pourTruncated) {
         // Dominates over every other signal. Lead with the meta-action
         // ("don't tune off this shot") because peak pressure never built —
-        // the channeling / grind / temp detectors are reading off curves the
+        // the channeling / grind detectors are reading off curves the
         // failed puck didn't produce, so their silence (or any drift they
         // happen to flag) is not a tuning signal. Naming the unreliable
         // detectors explicitly is important: a user who sees no Channeling
@@ -1027,7 +1027,7 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
         d.verdictCategory = QStringLiteral("puckTruncated");
         verdict["text"] = QStringLiteral("Verdict: Don't tune off this shot \u2014 "
             "peak pressure never built, so the other quality signals "
-            "(channeling, grind direction, temp) are unreliable. Check prep "
+            "(channeling, grind direction) are unreliable. Check prep "
             "(dose, distribution, basket, grind) and pull another.");
     } else if (skipFirstFrame) {
         // Skip-first-frame is a machine/profile issue, not puck integrity — give specific advice

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -302,82 +302,6 @@ bool ShotAnalysis::shouldSkipChannelingCheck(const QString& beverageType,
     return false;
 }
 
-bool ShotAnalysis::hasIntentionalTempStepping(const QVector<QPointF>& tempGoalData)
-{
-    double goalMin = 999, goalMax = 0;
-    for (const auto& gp : tempGoalData) {
-        if (gp.y() > 0) {
-            goalMin = qMin(goalMin, gp.y());
-            goalMax = qMax(goalMax, gp.y());
-        }
-    }
-    return (goalMax - goalMin) > TEMP_STEPPING_RANGE;
-}
-
-bool ShotAnalysis::hasIntentionalTempStepping(const QVector<QPointF>& tempGoalData,
-                                                double startTime, double endTime)
-{
-    double goalMin = 999, goalMax = 0;
-    bool hasGoal = false;
-    for (const auto& gp : tempGoalData) {
-        if (gp.x() < startTime) continue;
-        if (gp.x() > endTime) break;
-        if (gp.y() > 0) {
-            goalMin = qMin(goalMin, gp.y());
-            goalMax = qMax(goalMax, gp.y());
-            hasGoal = true;
-        }
-    }
-    return hasGoal && (goalMax - goalMin) > TEMP_STEPPING_RANGE;
-}
-
-double ShotAnalysis::avgTempDeviation(const QVector<QPointF>& tempData,
-                                        const QVector<QPointF>& tempGoalData,
-                                        double startTime, double endTime)
-{
-    double devSum = 0;
-    int count = 0;
-    bool warmupDone = false;
-    for (const auto& pt : tempData) {
-        if (pt.x() < startTime) continue;
-        if (pt.x() > endTime) break;
-        double goal = findValueAtTime(tempGoalData, pt.x());
-        if (goal <= 0) continue;
-        // Skip leading samples where the group head is still warming up to
-        // operating temperature. Once the first in-range sample is seen,
-        // warmupDone latches so a mid-shot temperature drop still counts.
-        if (!warmupDone) {
-            if (goal - pt.y() > TEMP_WARMUP_SKIP_C) continue;
-            warmupDone = true;
-        }
-        devSum += std::abs(pt.y() - goal);
-        ++count;
-    }
-    // count == 0: every pour sample was below the warmup threshold — the machine
-    // never reached operating temperature during extraction. No usable data means
-    // no diagnosis; return 0.0 so the caller fires no badge. This is intentional:
-    // a machine that stays this cold for a full extraction is extremely rare, and
-    // silence is preferable to a misleading badge with no valid signal.
-    return count > 0 ? devSum / count : 0.0;
-}
-
-bool ShotAnalysis::reachedExtractionPhase(const QList<HistoryPhaseMarker>& phases,
-                                           double shotDuration)
-{
-    if (shotDuration <= 0.0) return false;
-    for (const auto& pm : phases) {
-        if (pm.frameNumber < 1) continue;
-        // Frame ≥ 1 marker found. The shot must have continued past it for
-        // long enough to actually run extraction. Aborted shots sometimes
-        // record the 0→1 transition in firmware in the final ms before the
-        // shot ends (frame marker present, but no samples land inside it),
-        // so a presence-only check would let those slip through.
-        if (shotDuration - pm.time >= TEMP_MIN_EXTRACTION_SEC)
-            return true;
-    }
-    return false;
-}
-
 double ShotAnalysis::findValueAtTime(const QVector<QPointF>& data, double time)
 {
     if (data.isEmpty()) return 0.0;
@@ -741,8 +665,6 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
     const QVector<QPointF>& pressure,
     const QVector<QPointF>& flow,
     const QVector<QPointF>& weight,
-    const QVector<QPointF>& temperature,
-    const QVector<QPointF>& temperatureGoal,
     const QVector<QPointF>& conductanceDerivative,
     const QList<HistoryPhaseMarker>& phases,
     const QString& beverageType,
@@ -905,31 +827,6 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
             line["type"] = QStringLiteral("observation");
             line["kind"] = QStringLiteral("preinfusion_drip");
             lines.append(line);
-        }
-    }
-
-    // --- Temperature stability ---
-    // Gated on reachedExtractionPhase so aborted shots that died during
-    // preinfusion-start (frame 0 only) don't fire on the preheat ramp.
-    // Suppressed when pourTruncated fires — temp drift on a puck that never
-    // built is a downstream symptom, not a useful diagnosis.
-    if (!pourTruncated
-        && temperature.size() > 10 && temperatureGoal.size() > 10 && pourStart > 0
-        && reachedExtractionPhase(phases, duration)) {
-        d.tempStabilityChecked = true;
-        if (hasIntentionalTempStepping(temperatureGoal)) {
-            d.tempIntentionalStepping = true;
-        } else {
-            const double avgDev = avgTempDeviation(temperature, temperatureGoal, pourStart, pourEnd);
-            d.tempAvgDeviationC = avgDev;
-            if (avgDev > TEMP_UNSTABLE_THRESHOLD) {
-                d.tempUnstable = true;
-                QVariantMap line;
-                line["text"] = QStringLiteral("Temperature drifted %1\u00B0C from goal on average").arg(avgDev, 0, 'f', 1);
-                line["type"] = QStringLiteral("caution");
-                line["kind"] = QStringLiteral("temperature_drift");
-                lines.append(line);
-            }
         }
     }
 
@@ -1216,8 +1113,6 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
 QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
                                              const QVector<QPointF>& flow,
                                              const QVector<QPointF>& weight,
-                                             const QVector<QPointF>& temperature,
-                                             const QVector<QPointF>& temperatureGoal,
                                              const QVector<QPointF>& conductanceDerivative,
                                              const QList<HistoryPhaseMarker>& phases,
                                              const QString& beverageType,
@@ -1230,7 +1125,7 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
                                              double finalWeightG,
                                              int expectedFrameCount)
 {
-    return analyzeShot(pressure, flow, weight, temperature, temperatureGoal,
+    return analyzeShot(pressure, flow, weight,
                        conductanceDerivative, phases, beverageType, duration,
                        pressureGoal, flowGoal, analysisFlags,
                        firstFrameConfiguredSeconds, targetWeightG, finalWeightG,

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -27,16 +27,6 @@ public:
     static constexpr double CHANNELING_DC_POUR_SKIP_SEC = 2.0;    // skip first N seconds of pour (transition spike)
     static constexpr double CHANNELING_DC_POUR_SKIP_END_SEC = 1.5; // skip last N seconds of pour (natural tail acceleration)
     static constexpr double CHANNELING_MAX_AVG_FLOW = 3.0;        // mL/s — skip turbo/filter shots
-    static constexpr double TEMP_UNSTABLE_THRESHOLD = 2.0;        // °C avg deviation from goal
-    static constexpr double TEMP_STEPPING_RANGE = 5.0;            // °C goal range = intentional stepping
-    static constexpr double TEMP_MIN_EXTRACTION_SEC = 1.0;        // min seconds of extraction past frame 1 to score temp
-    // Skip leading pour samples where the machine hasn't yet reached operating
-    // temperature. Cold-start shots (e.g. first shot after idle) begin with the
-    // group head below goal; excluding this warmup ramp prevents false-positive
-    // "Temperature unstable" badges on otherwise clean shots. Only applied at
-    // the leading edge — once the first in-range sample is seen, the latch fires
-    // and all subsequent deviations (both below and above goal) are counted.
-    static constexpr double TEMP_WARMUP_SKIP_C = 3.0;
 
     // Mode-aware detection window tuning. A sample counts toward channeling
     // detection only inside a window where the active control goal (pressure
@@ -135,32 +125,6 @@ public:
     static bool shouldSkipChannelingCheck(const QString& beverageType,
                                            const QVector<QPointF>& flowData,
                                            double pourStart, double pourEnd);
-
-    // --- Temperature stability ---
-
-    // Check if temperature goal range indicates intentional stepping (e.g. D-Flow 84→94°C).
-    static bool hasIntentionalTempStepping(const QVector<QPointF>& tempGoalData);
-
-    // Check if temperature goal range indicates intentional stepping within a time range.
-    static bool hasIntentionalTempStepping(const QVector<QPointF>& tempGoalData,
-                                            double startTime, double endTime);
-
-    // Calculate average absolute deviation from goal in a time range.
-    // Returns 0 if no data or no goal data.
-    static double avgTempDeviation(const QVector<QPointF>& tempData,
-                                    const QVector<QPointF>& tempGoalData,
-                                    double startTime, double endTime);
-
-    // Returns true when the shot reached actual extraction — at least one phase
-    // marker with frameNumber >= 1 sits more than TEMP_MIN_EXTRACTION_SEC before
-    // the shot's last sample. Used to gate the temperature-stability detector
-    // so that aborted shots which died during preinfusion-start don't get
-    // flagged for temp drift caused by the machine still preheating. Frame 1 is
-    // sometimes recorded in firmware in the final ms of an aborted shot
-    // (the marker exists but no samples land inside it), so checking marker
-    // presence alone is not sufficient — we require the phase to have lasted.
-    static bool reachedExtractionPhase(const QList<HistoryPhaseMarker>& phases,
-                                        double shotDuration);
 
     // --- Helpers ---
 
@@ -381,9 +345,9 @@ public:
     // same signals without parsing prose. Every observation line in
     // `summaryLines` is formatted from one of these fields, but the
     // struct is a *superset* of what `summaryLines` renders: clean signals
-    // (e.g. `flowTrend = "stable"`, `grindDirection = "onTarget"`,
-    // `tempUnstable = false`) are captured here even when no prose line
-    // is emitted — silence in the dialog is not silence in the struct.
+    // (e.g. `flowTrend = "stable"`, `grindDirection = "onTarget"`) are
+    // captured here even when no prose line is emitted — silence in the
+    // dialog is not silence in the struct.
     // Kept in sync with `summaryLines` by construction: `analyzeShot`
     // populates this struct as it walks the detectors and formats lines
     // from the same intermediates, so a detector flip moves both
@@ -439,12 +403,6 @@ public:
         bool preinfusionObserved = false;
         double preinfusionDripWeightG = 0.0;
         double preinfusionDripDurationSec = 0.0;
-
-        // === Temperature stability ===
-        bool tempStabilityChecked = false;
-        bool tempIntentionalStepping = false;
-        double tempAvgDeviationC = 0.0;
-        bool tempUnstable = false;
 
         // === Grind direction (mirrors GrindCheck plus a derived label) ===
         bool grindChecked = false;
@@ -546,8 +504,6 @@ public:
     static AnalysisResult analyzeShot(const QVector<QPointF>& pressure,
                                        const QVector<QPointF>& flow,
                                        const QVector<QPointF>& weight,
-                                       const QVector<QPointF>& temperature,
-                                       const QVector<QPointF>& temperatureGoal,
                                        const QVector<QPointF>& conductanceDerivative,
                                        const QList<HistoryPhaseMarker>& phases,
                                        const QString& beverageType,
@@ -566,8 +522,6 @@ public:
     static QVariantList generateSummary(const QVector<QPointF>& pressure,
                                          const QVector<QPointF>& flow,
                                          const QVector<QPointF>& weight,
-                                         const QVector<QPointF>& temperature,
-                                         const QVector<QPointF>& temperatureGoal,
                                          const QVector<QPointF>& conductanceDerivative,
                                          const QList<HistoryPhaseMarker>& phases,
                                          const QString& beverageType,

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -12,8 +12,8 @@ struct HistoryPhaseMarker;
 // Used by ShotSummarizer (AI prompts), ShotHistoryStorage (save-time flags),
 // and ShotAnalysisDialog.qml (user-facing summary via Q_INVOKABLE).
 //
-// Single source of truth for channeling detection, temperature stability,
-// and shot summary generation. Threshold constants are defined here so
+// Single source of truth for channeling detection, grind direction, and
+// shot summary generation. Threshold constants are defined here so
 // tuning happens in one place.
 class ShotAnalysis {
 public:

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -466,15 +466,11 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
     // of running analyzeShot a second time on the same data — both the fast
     // path's pre-computed lines and the slow path's recomputation invoke the
     // same analyzeShot body on equivalent inputs, so the two paths produce
-    // matching observation lines. Per-phase temperature markers are still
-    // gated on the same conditions as the slow path; only the detector
-    // orchestration block is bypassed.
+    // matching observation lines.
     //
     // Precondition: callers populating `summaryLines` MUST also populate
-    // `detectorResults.pourTruncated` (convertShotRecord does both, atomically).
-    // If detectorResults is absent, .toBool() defaults to false, so a callsite
-    // that stuffs only summaryLines could mis-suppress per-phase temp markers
-    // on a truncated-pour shot. Today no such callsite exists.
+    // `detectorResults.pourTruncated` (convertShotRecord does both, atomically),
+    // since downstream consumers read the flag separately from the prose.
     if (!shotData.summaryLines.isEmpty()) {
         summary.summaryLines = shotData.summaryLines;
         summary.pourTruncatedDetected = shotData.detectorResults.value("pourTruncated").toBool();
@@ -1274,7 +1270,7 @@ QString ShotSummarizer::shotAnalysisSystemPrompt(const QString& beverageType, co
         "them as diagnostic signals (evidence), not your conclusions. Severity\n"
         "tags reflect detector confidence, not your final assessment:\n\n"
         "- [warning] high-confidence failure mode (sustained channeling, choked puck, yield overshoot/gusher, pour truncated, frame skip)\n"
-        "- [caution] directional hint (grind drift, flow trend, temp drift)\n"
+        "- [caution] directional hint (grind drift, flow trend)\n"
         "- [good] positive signal (puck stable)\n"
         "- [observation] context (preinfusion drip mass)\n\n"
         "Cross-check against the raw curves and the user's tasting feedback, and\n"

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -157,27 +157,10 @@ QList<PhaseSummary> ShotSummarizer::buildPhaseSummariesForRange(
 }
 
 
-void ShotSummarizer::markPerPhaseTempInstability(ShotSummary& summary,
-    const QVector<QPointF>& tempData, const QVector<QPointF>& tempGoalData) const
-{
-    if (tempGoalData.isEmpty()) return;
-
-    for (auto& phase : summary.phases) {
-        if (ShotAnalysis::hasIntentionalTempStepping(tempGoalData, phase.startTime, phase.endTime)) {
-            phase.temperatureUnstable = false;
-            continue;
-        }
-        double avgDev = ShotAnalysis::avgTempDeviation(tempData, tempGoalData, phase.startTime, phase.endTime);
-        phase.temperatureUnstable = (avgDev > ShotAnalysis::TEMP_UNSTABLE_THRESHOLD);
-    }
-}
-
 void ShotSummarizer::runShotAnalysisAndPopulate(ShotSummary& summary,
     const QVector<QPointF>& pressure,
     const QVector<QPointF>& flow,
     const QVector<QPointF>& weight,
-    const QVector<QPointF>& temperature,
-    const QVector<QPointF>& temperatureGoal,
     const QVector<QPointF>& conductanceDerivative,
     const QList<HistoryPhaseMarker>& markers,
     const QVector<QPointF>& pressureGoal,
@@ -188,7 +171,7 @@ void ShotSummarizer::runShotAnalysisAndPopulate(ShotSummary& summary,
     int frameCount) const
 {
     const ShotAnalysis::AnalysisResult analysis = ShotAnalysis::analyzeShot(
-        pressure, flow, weight, temperature, temperatureGoal,
+        pressure, flow, weight,
         conductanceDerivative, markers,
         summary.beverageType, summary.totalDuration,
         pressureGoal, flowGoal, analysisFlags,
@@ -196,10 +179,6 @@ void ShotSummarizer::runShotAnalysisAndPopulate(ShotSummary& summary,
         frameCount);
     summary.summaryLines = analysis.lines;
     summary.pourTruncatedDetected = analysis.detectors.pourTruncated;
-    summary.tempIntentionalStepping = analysis.detectors.tempIntentionalStepping;
-    if (!summary.pourTruncatedDetected
-        && ShotAnalysis::reachedExtractionPhase(markers, summary.totalDuration))
-        markPerPhaseTempInstability(summary, temperature, temperatureGoal);
 }
 
 ShotSummary ShotSummarizer::summarize(const ShotDataModel* shotData,
@@ -321,7 +300,6 @@ ShotSummary ShotSummarizer::summarize(const ShotDataModel* shotData,
     // pourTruncatedDetected onto summary. The suppression cascade (pour
     // truncated → channeling/temp/grind forced false) lives in exactly one
     // place — see SHOT_REVIEW.md §3.
-    const auto& tempGoalData = shotData->temperatureGoalData();
     const QStringList analysisFlags = getAnalysisFlags(summary.profileKbId);
     const double firstFrameSeconds = (profile && !profile->steps().isEmpty())
         ? profile->steps().first().seconds : -1.0;
@@ -334,7 +312,7 @@ ShotSummary ShotSummarizer::summarize(const ShotDataModel* shotData,
         ? static_cast<int>(profile->steps().size()) : -1;
 
     runShotAnalysisAndPopulate(summary,
-        pressureData, flowData, cumulativeWeightData, tempData, tempGoalData,
+        pressureData, flowData, cumulativeWeightData,
         shotData->conductanceDerivativeData(), historyMarkers,
         summary.pressureGoalCurve, summary.flowGoalCurve, analysisFlags,
         firstFrameSeconds, summary.targetWeight, frameCount);
@@ -500,15 +478,6 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
     if (!shotData.summaryLines.isEmpty()) {
         summary.summaryLines = shotData.summaryLines;
         summary.pourTruncatedDetected = shotData.detectorResults.value("pourTruncated").toBool();
-        // .toMap() on a missing tempStability key returns an empty map and
-        // .toBool() then defaults to false — a row without the envelope
-        // reads as !intentionalStepping (correct fallback).
-        summary.tempIntentionalStepping = shotData.detectorResults
-            .value("tempStability").toMap()
-            .value("intentionalStepping").toBool();
-        if (!summary.pourTruncatedDetected
-            && ShotAnalysis::reachedExtractionPhase(historyMarkers, summary.totalDuration))
-            markPerPhaseTempInstability(summary, summary.tempCurve, summary.tempGoalCurve);
         return summary;
     }
 
@@ -542,7 +511,7 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
 
     runShotAnalysisAndPopulate(summary,
         summary.pressureCurve, summary.flowCurve, summary.weightCurve,
-        summary.tempCurve, summary.tempGoalCurve, derivCurve, historyMarkers,
+        derivCurve, historyMarkers,
         summary.pressureGoalCurve, summary.flowGoalCurve, analysisFlags,
         firstFrameSeconds, targetWeightG, frameCount);
 
@@ -638,12 +607,11 @@ static QJsonObject buildOverallPeaksBlock(const ShotSummary& summary)
 }
 
 // Build a structured phases[] array. Each phase carries name, duration,
-// control mode, peak pressure / flow within the phase, and per-phase
-// `temperatureUnstable` flag. Phase samples (start / peakDeviation /
-// end) stay in the prose body for now — the deterministic detector
-// lines that summarize them already live in `detectorObservations`.
-// Issue #1037: structural fields the AI can iterate over without
-// pattern-matching prose.
+// control mode, and peak pressure / flow within the phase. Phase samples
+// (start / peakDeviation / end) stay in the prose body for now — the
+// deterministic detector lines that summarize them already live in
+// `detectorObservations`. Issue #1037: structural fields the AI can
+// iterate over without pattern-matching prose.
 //
 // Threading: pure read of `summary.phases` and the curve members. Safe
 // to call on any thread that owns `summary`. Same threading contract
@@ -669,15 +637,6 @@ static QJsonArray buildPhasesBlock(const ShotSummary& summary)
         if (fp.value(QStringLiteral("value")).toDouble() > 0.1)
             phasePeaks["flowMlPerSec"] = fp;
         if (!phasePeaks.isEmpty()) p["peaks"] = phasePeaks;
-        // Per-phase temperature flag. The same suppression cascade the
-        // prose body uses — a failed pour's temp drift is a downstream
-        // symptom, not signal; intentional cross-phase stepping is
-        // by-design, not instability.
-        if (phase.temperatureUnstable
-            && !summary.pourTruncatedDetected
-            && !summary.tempIntentionalStepping) {
-            p["temperatureUnstable"] = true;
-        }
         phases.append(p);
     }
     return phases;
@@ -687,7 +646,7 @@ static QJsonArray buildPhasesBlock(const ShotSummary& summary)
 // `{type, kind, text}`:
 //   - `type` ∈ {warning, caution, good, observation} — severity tag.
 //   - `kind` is a stable enum identifier ("channeling_sustained",
-//     "temperature_drift", "grind_too_fine", etc.) populated by the
+//     "grind_too_fine", etc.) populated by the
 //     deterministic detector pipeline. Consumers SHOULD read by `kind`
 //     instead of substring-matching `text`, which is freeform prose
 //     intended for the LLM and may be reworded across releases.
@@ -962,14 +921,6 @@ QString ShotSummarizer::renderShotAnalysisProse(const ShotSummary& summary, Rend
             out << "\u00B0C ";
             out << QString::number(weight, 'f', 1) << "g\n";
         }
-        // Suppress per-phase temp instability when the puck never built \u2014
-        // temp drift on a failed pour is a downstream symptom, not signal.
-        // Also suppress on intentionally-stepping profiles: per-phase
-        // deviation against a stepped goal is by design, not instability.
-        if (phase.temperatureUnstable
-            && !summary.pourTruncatedDetected
-            && !summary.tempIntentionalStepping)
-            out << "- **Temperature instability**: Average temperature deviated from target by >2\u00B0C during this phase\n";
         out << "\n";
     }
 

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -42,7 +42,6 @@ struct PhaseSummary {
 
     // Temperature metrics (C)
     double avgTemperature = 0;
-    bool temperatureUnstable = false;
 
     // Weight gained during this phase
     double weightGained = 0;
@@ -90,15 +89,9 @@ struct ShotSummary {
     // false) is enforced in exactly one place. See docs/SHOT_REVIEW.md §3.
     QVariantList summaryLines;
 
-    // Pour-truncated flag — gates the per-phase temperature markers below
-    // (which analyzeShot's aggregate output doesn't surface).
+    // Pour-truncated flag carried alongside summaryLines for callers that
+    // need the cascade dominator without re-running detectors.
     bool pourTruncatedDetected = false;
-
-    // True when the profile goal steps temperature across the shot (e.g.
-    // 82→72°C). markPerPhaseTempInstability only checks for stepping within
-    // a single phase, so cross-phase stepping (flat goal per phase, different
-    // goal each phase) needs this global flag to suppress per-phase prose.
-    bool tempIntentionalStepping = false;
 
     // Profile recipe rendered from profileJson (frame-by-frame intent).
     // Pre-computed at summarize() time so the JSON user prompt can ship it
@@ -321,21 +314,9 @@ private:
         const QVector<QPointF>& weight,
         const QList<HistoryPhaseMarker>& markers,
         double totalDuration);
-    // Per-phase temperature instability. Sets only PhaseSummary::temperatureUnstable;
-    // the aggregate "Temperature drifted X°C from goal" observation is produced by
-    // ShotAnalysis::analyzeShot instead. Callers must gate on
-    // !pourTruncatedDetected AND ShotAnalysis::reachedExtractionPhase() — same
-    // gates the aggregate detector uses. Without the reachedExtractionPhase
-    // check, aborted-during-preinfusion shots get false positives on the
-    // preheat ramp; see SHOT_REVIEW.md §2.3 and PR #898.
-    void markPerPhaseTempInstability(ShotSummary& summary,
-        const QVector<QPointF>& tempData, const QVector<QPointF>& tempGoalData) const;
-
     // Run the detector pipeline and stamp the result onto `summary`: call
-    // `ShotAnalysis::analyzeShot`, copy `summaryLines` from the result,
-    // derive `pourTruncatedDetected` from `detectors.pourTruncated`, then
-    // conditionally call `markPerPhaseTempInstability` under the cascade
-    // gate (`!pourTruncatedDetected && reachedExtractionPhase(markers, ...)`).
+    // `ShotAnalysis::analyzeShot`, copy `summaryLines` from the result, and
+    // derive `pourTruncatedDetected` from `detectors.pourTruncated`.
     //
     // Preconditions on `summary`: `beverageType`, `totalDuration`, and
     // `finalWeight` must already be populated — this helper reads them off
@@ -347,15 +328,11 @@ private:
     // (saved-shot recompute), so those two paths can no longer drift on
     // detector wiring. The fast path of `summarizeFromHistory` bypasses
     // this helper — it consumes pre-computed `summaryLines` +
-    // `detectorResults.pourTruncated` from `convertShotRecord` (PR #939, D)
-    // and runs the same cascade gate inline; that gate must be kept in
-    // sync with this helper's gate.
+    // `detectorResults.pourTruncated` from `convertShotRecord` (PR #939, D).
     void runShotAnalysisAndPopulate(ShotSummary& summary,
         const QVector<QPointF>& pressure,
         const QVector<QPointF>& flow,
         const QVector<QPointF>& weight,
-        const QVector<QPointF>& temperature,
-        const QVector<QPointF>& temperatureGoal,
         const QVector<QPointF>& conductanceDerivative,
         const QList<HistoryPhaseMarker>& markers,
         const QVector<QPointF>& pressureGoal,

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -85,7 +85,7 @@ struct ShotSummary {
     // a QVariantMap with "text" (QString) and "type" (QString: "good" |
     // "caution" | "warning" | "observation" | "verdict"). Sharing the dialog's
     // output keeps the AI advisor's prompt and the badge UI in lockstep, so
-    // the suppression cascade (pour truncated → channeling/temp/grind forced
+    // the suppression cascade (pour truncated → channeling/grind forced
     // false) is enforced in exactly one place. See docs/SHOT_REVIEW.md §3.
     QVariantList summaryLines;
 

--- a/src/history/shotbadgeprojection.h
+++ b/src/history/shotbadgeprojection.h
@@ -6,7 +6,7 @@
 #include <cmath>
 
 // Projection from the typed ShotAnalysis::DetectorResults struct onto the
-// five boolean quality-badge columns persisted in the `shots` DB table and
+// four boolean quality-badge columns persisted in the `shots` DB table and
 // surfaced via QualityBadges.qml. Single source of truth for the badge↔struct
 // mapping — used by both save-time computation (saveShot) and the
 // recompute-on-load path (loadShotRecordStatic) so the cascade definition
@@ -21,9 +21,6 @@
 //   - grindIssueDetected fires on chokedPuck OR yieldOvershoot OR
 //     |flowDelta| > FLOW_DEVIATION_THRESHOLD, mirroring ShotAnalysis::
 //     detectGrindIssue's semantics.
-//   - tempUnstable already encodes its gates inside analyzeShot
-//     (tempStabilityChecked && !tempIntentionalStepping && avgDev > threshold),
-//     so no caller-side conjuncts are needed.
 //   - pourTruncated and skipFirstFrame are 1:1 with their struct fields.
 //
 // Header-only by design: lets unit tests (`tst_shotanalysis`'s
@@ -32,11 +29,10 @@
 
 namespace decenza {
 
-// Bag of the five boolean badge values, returned by deriveBadgesFromAnalysis.
+// Bag of the four boolean badge values, returned by deriveBadgesFromAnalysis.
 struct BadgeFlags {
     bool pourTruncatedDetected = false;
     bool channelingDetected = false;
-    bool temperatureUnstable = false;
     bool grindIssueDetected = false;
     bool skipFirstFrameDetected = false;
 };
@@ -48,7 +44,6 @@ inline BadgeFlags deriveBadgesFromAnalysis(const ShotAnalysis::DetectorResults& 
     flags.pourTruncatedDetected = d.pourTruncated;
     flags.skipFirstFrameDetected = d.skipFirstFrame;
     flags.channelingDetected = (d.channelingSeverity == QStringLiteral("sustained"));
-    flags.temperatureUnstable = d.tempUnstable;
     flags.grindIssueDetected = d.grindHasData
         && (d.grindChokedPuck
             || d.grindYieldOvershoot
@@ -67,7 +62,6 @@ inline void applyBadgesToTarget(T& target, const ShotAnalysis::DetectorResults& 
     target.pourTruncatedDetected = flags.pourTruncatedDetected;
     target.skipFirstFrameDetected = flags.skipFirstFrameDetected;
     target.channelingDetected = flags.channelingDetected;
-    target.temperatureUnstable = flags.temperatureUnstable;
     target.grindIssueDetected = flags.grindIssueDetected;
 }
 

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -104,16 +104,15 @@ struct ShotRecord {
     // Quality flags (computed at save time, recomputed on-the-fly for legacy shots).
     //
     // pourTruncatedDetected is the dominant flag — when it fires, the puck never
-    // built pressure, so channeling / temp / grind signals are unreliable readings
+    // built pressure, so channeling / grind signals are unreliable readings
     // off curves the failed puck didn't produce. The save and load paths force
-    // those three (channelingDetected, temperatureUnstable, grindIssueDetected) to
-    // false in that case so the UI doesn't show contradictory "Temp unstable" or
-    // "Clean extraction" chips on top of a puck failure. skipFirstFrameDetected
-    // is NOT suppressed — it's a machine/profile issue orthogonal to puck
-    // integrity and can co-fire with pourTruncatedDetected.
+    // those two (channelingDetected, grindIssueDetected) to false in that case
+    // so the UI doesn't show a contradictory "Clean extraction" chip on top
+    // of a puck failure. skipFirstFrameDetected is NOT suppressed — it's a
+    // machine/profile issue orthogonal to puck integrity and can co-fire
+    // with pourTruncatedDetected.
     // See ShotAnalysis::detectPourTruncated for the underlying detector.
     bool channelingDetected = false;
-    bool temperatureUnstable = false;
     bool grindIssueDetected = false;
     bool skipFirstFrameDetected = false;
     bool pourTruncatedDetected = false;
@@ -177,7 +176,6 @@ struct ShotFilter {
     QString searchText;        // FTS search in notes
     bool onlyWithVisualizer = false;
     bool filterChanneling = false;
-    bool filterTemperatureUnstable = false;
     bool filterGrindIssue = false;
     bool filterSkipFirstFrame = false;
     bool filterPourTruncated = false;
@@ -226,11 +224,10 @@ struct ShotSaveData {
     QString profileKbId;
 
     // Quality flags (computed at save time using ShotAnalysis helpers). When
-    // pourTruncatedDetected fires, channelingDetected / temperatureUnstable /
-    // grindIssueDetected are forced to false; skipFirstFrameDetected is not.
-    // See the matching comment on ShotRecord.
+    // pourTruncatedDetected fires, channelingDetected / grindIssueDetected
+    // are forced to false; skipFirstFrameDetected is not. See the matching
+    // comment on ShotRecord.
     bool channelingDetected = false;
-    bool temperatureUnstable = false;
     bool grindIssueDetected = false;
     bool skipFirstFrameDetected = false;
     bool pourTruncatedDetected = false;

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -761,6 +761,25 @@ bool ShotHistoryStorage::runMigrations()
         currentVersion = 14;
     }
 
+    // Migration 15: Drop temperature_unstable column. The temp-stability badge
+    // was retired because the underlying detector measured average deviation
+    // from goal but was labeled "Temp unstable" - and the deviation it caught
+    // was, in practice, profile-design intent (D-Flow / Extractamundo /
+    // TurboBloom and 9+ other profiles deliberately ask the head to do things
+    // it can't physically follow). Removed end-to-end; this migration drops
+    // the now-unused column. SQLite >= 3.35 is required for ALTER TABLE
+    // DROP COLUMN; every Qt 6.10 platform we ship satisfies this.
+    if (currentVersion < 15) {
+        qDebug() << "ShotHistoryStorage: Running migration to version 15 (drop temperature_unstable)";
+
+        if (hasColumn("shots", "temperature_unstable"))
+            query.exec("ALTER TABLE shots DROP COLUMN temperature_unstable");
+
+        query.exec("DELETE FROM schema_version");
+        query.exec("INSERT INTO schema_version (version) VALUES (15)");
+        currentVersion = 15;
+    }
+
     m_schemaVersion = currentVersion;
     return true;
 }
@@ -943,7 +962,7 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
         computePhaseSummaries(tmpRecord);
         data.phaseSummariesJson = tmpRecord.phaseSummariesJson;
 
-        // Compute all five quality badges via a single ShotAnalysis::analyzeShot
+        // Compute all four quality badges via a single ShotAnalysis::analyzeShot
         // pass and project the booleans from DetectorResults using the
         // documented mapping. This unifies the save-time, load-time, and
         // dialog/AI/MCP cascades on one pipeline — the cascade lives in exactly
@@ -954,7 +973,6 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
         const auto analysis = ShotAnalysis::analyzeShot(
             tmpRecord.pressure, shotData->flowData(),
             shotData->cumulativeWeightData(),
-            shotData->temperatureData(), shotData->temperatureGoalData(),
             shotData->conductanceDerivativeData(),
             tmpRecord.phases, data.beverageType, duration,
             shotData->pressureGoalData(), shotData->flowGoalData(),
@@ -1100,7 +1118,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
                     profile_notes, debug_log,
                     temperature_override, yield_override, profile_kb_id,
-                    channeling_detected, temperature_unstable, grind_issue_detected,
+                    channeling_detected, grind_issue_detected,
                     skip_first_frame_detected, pour_truncated_detected, enjoyment_source
                 ) VALUES (
                     :uuid, :timestamp, :profile_name, :profile_json, :beverage_type,
@@ -1110,7 +1128,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     :drink_tds, :drink_ey, :enjoyment, :espresso_notes, :bean_notes, :barista,
                     :profile_notes, :debug_log,
                     :temperature_override, :yield_override, :profile_kb_id,
-                    :channeling_detected, :temperature_unstable, :grind_issue_detected,
+                    :channeling_detected, :grind_issue_detected,
                     :skip_first_frame_detected, :pour_truncated_detected, :enjoyment_source
                 )
             )");
@@ -1143,7 +1161,6 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
             query.bindValue(":yield_override", data.targetWeight);
             query.bindValue(":profile_kb_id", data.profileKbId.isEmpty() ? QVariant() : data.profileKbId);
             query.bindValue(":channeling_detected", data.channelingDetected ? 1 : 0);
-            query.bindValue(":temperature_unstable", data.temperatureUnstable ? 1 : 0);
             query.bindValue(":grind_issue_detected", data.grindIssueDetected ? 1 : 0);
             query.bindValue(":skip_first_frame_detected", data.skipFirstFrameDetected ? 1 : 0);
             query.bindValue(":pour_truncated_detected", data.pourTruncatedDetected ? 1 : 0);
@@ -1307,7 +1324,6 @@ void ShotHistoryStorage::requestShot(qint64 shotId)
             if (badgesPersisted) {
                 emit shotBadgesUpdated(shotId,
                     record.channelingDetected,
-                    record.temperatureUnstable,
                     record.grindIssueDetected,
                     record.skipFirstFrameDetected,
                     record.pourTruncatedDetected);
@@ -1334,7 +1350,7 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
     QThread* thread = QThread::create([this, dbPath, shotId, destroyed]() {
         bool recordFound = false;
         bool badgesPersisted = false;
-        bool newChanneling = false, newTempUnstable = false;
+        bool newChanneling = false;
         bool newGrindIssue = false, newSkipFirstFrame = false, newPourTruncated = false;
 
         withTempDb(dbPath, "shs_badges", [&](QSqlDatabase& db) {
@@ -1342,7 +1358,6 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
             if (record.summary.id == 0) return;
             recordFound = true;
             newChanneling = record.channelingDetected;
-            newTempUnstable = record.temperatureUnstable;
             newGrindIssue = record.grindIssueDetected;
             newSkipFirstFrame = record.skipFirstFrameDetected;
             newPourTruncated = record.pourTruncatedDetected;
@@ -1351,9 +1366,9 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
         if (!recordFound || !badgesPersisted || *destroyed) return;
         QMetaObject::invokeMethod(
             this,
-            [this, shotId, newChanneling, newTempUnstable, newGrindIssue, newSkipFirstFrame, newPourTruncated, destroyed]() {
+            [this, shotId, newChanneling, newGrindIssue, newSkipFirstFrame, newPourTruncated, destroyed]() {
                 if (*destroyed) return;
-                emit shotBadgesUpdated(shotId, newChanneling, newTempUnstable, newGrindIssue, newSkipFirstFrame, newPourTruncated);
+                emit shotBadgesUpdated(shotId, newChanneling, newGrindIssue, newSkipFirstFrame, newPourTruncated);
             },
             Qt::QueuedConnection);
     });
@@ -1472,7 +1487,7 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
                drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
                profile_notes, visualizer_id, visualizer_url, debug_log,
                temperature_override, yield_override, beverage_type, profile_kb_id,
-               channeling_detected, temperature_unstable, grind_issue_detected,
+               channeling_detected, grind_issue_detected,
                skip_first_frame_detected, pour_truncated_detected, enjoyment_source
         FROM shots WHERE id = ?
     )")) {
@@ -1517,18 +1532,16 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     record.summary.beverageType = query.value(28).toString();
     record.profileKbId = query.value(29).toString();
     record.channelingDetected = query.value(30).toInt() != 0;
-    record.temperatureUnstable = query.value(31).toInt() != 0;
-    record.grindIssueDetected = query.value(32).toInt() != 0;
-    record.skipFirstFrameDetected = query.value(33).toInt() != 0;
-    record.pourTruncatedDetected = query.value(34).toInt() != 0;
-    record.enjoymentSource = query.value(35).toString();
+    record.grindIssueDetected = query.value(31).toInt() != 0;
+    record.skipFirstFrameDetected = query.value(32).toInt() != 0;
+    record.pourTruncatedDetected = query.value(33).toInt() != 0;
+    record.enjoymentSource = query.value(34).toString();
     if (record.enjoymentSource.isEmpty()) record.enjoymentSource = QStringLiteral("none");
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     // Snapshot stored badge values before the recompute block overwrites them, so
     // we can detect drift and persist the corrected flags below.
     const bool storedChanneling = record.channelingDetected;
-    const bool storedTempUnstable = record.temperatureUnstable;
     const bool storedGrindIssue = record.grindIssueDetected;
     const bool storedSkipFirstFrame = record.skipFirstFrameDetected;
     const bool storedPourTruncated = record.pourTruncatedDetected;
@@ -1608,7 +1621,6 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
         const AnalysisInputs inputs = prepareAnalysisInputs(record.profileKbId, record.profileJson);
         auto analysis = ShotAnalysis::analyzeShot(
             record.pressure, record.flow, record.weight,
-            record.temperature, record.temperatureGoal,
             record.conductanceDerivative,
             record.phases, record.summary.beverageType, record.summary.duration,
             record.pressureGoal, record.flowGoal,
@@ -1629,19 +1641,17 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     // converges with detector improvements as shots are viewed without needing a
     // separate bulk-resweep migration. The UPDATE is skipped when nothing changed.
     const bool flagsChanged = (storedChanneling != record.channelingDetected
-        || storedTempUnstable != record.temperatureUnstable
         || storedGrindIssue != record.grindIssueDetected
         || storedSkipFirstFrame != record.skipFirstFrameDetected
         || storedPourTruncated != record.pourTruncatedDetected);
     if (flagsChanged) {
         QSqlQuery upd(db);
         upd.prepare("UPDATE shots SET channeling_detected=:c,"
-                    " temperature_unstable=:t, grind_issue_detected=:g,"
+                    " grind_issue_detected=:g,"
                     " skip_first_frame_detected=:s,"
                     " pour_truncated_detected=:p,"
                     " updated_at = strftime('%s', 'now') WHERE id=:id");
         upd.bindValue(":c", record.channelingDetected ? 1 : 0);
-        upd.bindValue(":t", record.temperatureUnstable ? 1 : 0);
         upd.bindValue(":g", record.grindIssueDetected ? 1 : 0);
         upd.bindValue(":s", record.skipFirstFrameDetected ? 1 : 0);
         upd.bindValue(":p", record.pourTruncatedDetected ? 1 : 0);
@@ -2289,9 +2299,9 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                         enjoyment, espresso_notes, bean_notes, barista,
                         profile_notes, visualizer_id, visualizer_url, debug_log,
                         temperature_override, yield_override, profile_kb_id,
-                        channeling_detected, temperature_unstable, grind_issue_detected,
+                        channeling_detected, grind_issue_detected,
                         skip_first_frame_detected)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 )");
 
                 insert.addBindValue(uuid);
@@ -2327,8 +2337,6 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                 // Quality flags — fallback to 0 for pre-migration source databases
                 QVariant ch = srcShots.value("channeling_detected");
                 insert.addBindValue((ch.isValid() && !ch.isNull()) ? ch : QVariant(0));
-                QVariant tu = srcShots.value("temperature_unstable");
-                insert.addBindValue((tu.isValid() && !tu.isNull()) ? tu : QVariant(0));
                 QVariant gi = srcShots.value("grind_issue_detected");
                 insert.addBindValue((gi.isValid() && !gi.isNull()) ? gi : QVariant(0));
                 QVariant sf = srcShots.value("skip_first_frame_detected");
@@ -2513,7 +2521,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
             drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
             profile_notes, debug_log,
             temperature_override, yield_override, profile_kb_id,
-            channeling_detected, temperature_unstable, grind_issue_detected,
+            channeling_detected, grind_issue_detected,
             skip_first_frame_detected, pour_truncated_detected
         ) VALUES (
             :uuid, :timestamp, :profile_name, :profile_json, :beverage_type,
@@ -2523,7 +2531,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
             :drink_tds, :drink_ey, :enjoyment, :espresso_notes, :bean_notes, :barista,
             :profile_notes, :debug_log,
             :temperature_override, :yield_override, :profile_kb_id,
-            :channeling_detected, :temperature_unstable, :grind_issue_detected,
+            :channeling_detected, :grind_issue_detected,
             :skip_first_frame_detected, :pour_truncated_detected
         )
     )");
@@ -2558,7 +2566,6 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
     query.bindValue(":yield_override", record.targetWeight);
     query.bindValue(":profile_kb_id", record.profileKbId.isEmpty() ? QVariant() : record.profileKbId);
     query.bindValue(":channeling_detected", record.channelingDetected ? 1 : 0);
-    query.bindValue(":temperature_unstable", record.temperatureUnstable ? 1 : 0);
     query.bindValue(":grind_issue_detected", record.grindIssueDetected ? 1 : 0);
     query.bindValue(":skip_first_frame_detected", record.skipFirstFrameDetected ? 1 : 0);
     query.bindValue(":pour_truncated_detected", record.pourTruncatedDetected ? 1 : 0);

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -719,11 +719,11 @@ bool ShotHistoryStorage::runMigrations()
 
     // Migration 13: Add pour_truncated_detected flag.
     // Catches puck failures where peak pressure stayed below PRESSURE_FLOOR_BAR
-    // (puck offered no resistance — channeling/temp/grind detectors stay silent
+    // (puck offered no resistance — channeling/grind detectors stay silent
     // or fire wrong because the curves they read off never built). When this
-    // flag is true the other three quality flags stay false because
+    // flag is true the other quality flags stay false because
     // ShotAnalysis::analyzeShot's suppression cascade skips the
-    // channeling/temp/grind blocks, leaving those DetectorResults fields at
+    // channeling/grind blocks, leaving those DetectorResults fields at
     // their defaults; the badge projection (decenza::deriveBadgesFromAnalysis)
     // then reads those defaults. The cascade lives in exactly one place —
     // ShotAnalysis::analyzeShot — and the UI shows a single red "Puck failed"
@@ -772,8 +772,19 @@ bool ShotHistoryStorage::runMigrations()
     if (currentVersion < 15) {
         qDebug() << "ShotHistoryStorage: Running migration to version 15 (drop temperature_unstable)";
 
-        if (hasColumn("shots", "temperature_unstable"))
-            query.exec("ALTER TABLE shots DROP COLUMN temperature_unstable");
+        if (hasColumn("shots", "temperature_unstable")) {
+            // Bail out without bumping schema_version if DROP COLUMN fails.
+            // Otherwise we'd advance to v15 with the column stranded — and
+            // since post-v15 SELECTs no longer reference the column, the
+            // load path would silently see stale data instead of erroring.
+            // Better to retry the migration on next launch than to leave
+            // the schema in a half-migrated state.
+            if (!query.exec("ALTER TABLE shots DROP COLUMN temperature_unstable")) {
+                qWarning() << "ShotHistoryStorage: migration 15 DROP COLUMN failed:"
+                           << query.lastError().text();
+                return false;
+            }
+        }
 
         query.exec("DELETE FROM schema_version");
         query.exec("INSERT INTO schema_version (version) VALUES (15)");
@@ -1604,7 +1615,7 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     // (post-migration-10) or filled by computeDerivedCurves() above (legacy).
     // The grind and skip-first-frame sub-blocks need only flow / flowGoal /
     // pressure / phases, which are always available.
-    // Compute all five quality badges via a single ShotAnalysis::analyzeShot
+    // Compute all four quality badges via a single ShotAnalysis::analyzeShot
     // pass and project the booleans from DetectorResults. The cascade lives in
     // exactly one place (analyzeShot's body) and the badge columns are a
     // deterministic projection — see decenza::deriveBadgesFromAnalysis (in
@@ -2300,8 +2311,9 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                         profile_notes, visualizer_id, visualizer_url, debug_log,
                         temperature_override, yield_override, profile_kb_id,
                         channeling_detected, grind_issue_detected,
-                        skip_first_frame_detected)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skip_first_frame_detected, pour_truncated_detected,
+                        enjoyment_source)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 )");
 
                 insert.addBindValue(uuid);
@@ -2341,6 +2353,10 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                 insert.addBindValue((gi.isValid() && !gi.isNull()) ? gi : QVariant(0));
                 QVariant sf = srcShots.value("skip_first_frame_detected");
                 insert.addBindValue((sf.isValid() && !sf.isNull()) ? sf : QVariant(0));
+                QVariant pt = srcShots.value("pour_truncated_detected");
+                insert.addBindValue((pt.isValid() && !pt.isNull()) ? pt : QVariant(0));
+                QVariant es = srcShots.value("enjoyment_source");
+                insert.addBindValue((es.isValid() && !es.isNull()) ? es : QVariant(QString("none")));
 
                 if (!insert.exec()) {
                     qWarning() << "ShotHistoryStorage::importDatabaseStatic: Failed to import shot:" << insert.lastError().text();

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -237,7 +237,7 @@ signals:
     void mostRecentShotIdReady(qint64 shotId);
     void distinctCacheReady();
     void grinderFieldsUpdated(int updatedCount);
-    void shotBadgesUpdated(qint64 shotId, bool channelingDetected, bool temperatureUnstable, bool grindIssueDetected, bool skipFirstFrameDetected, bool pourTruncatedDetected);
+    void shotBadgesUpdated(qint64 shotId, bool channelingDetected, bool grindIssueDetected, bool skipFirstFrameDetected, bool pourTruncatedDetected);
 
 private:
     bool createTables();

--- a/src/history/shothistorystorage_queries.cpp
+++ b/src/history/shothistorystorage_queries.cpp
@@ -175,7 +175,6 @@ ShotFilter ShotHistoryStorage::parseFilterMap(const QVariantMap& filterMap)
     filter.searchText = filterMap.value("searchText").toString();
     filter.onlyWithVisualizer = filterMap.value("onlyWithVisualizer", false).toBool();
     filter.filterChanneling = filterMap.value("filterChanneling", false).toBool();
-    filter.filterTemperatureUnstable = filterMap.value("filterTemperatureUnstable", false).toBool();
     filter.filterGrindIssue = filterMap.value("filterGrindIssue", false).toBool();
     filter.filterSkipFirstFrame = filterMap.value("filterSkipFirstFrame", false).toBool();
     filter.filterPourTruncated = filterMap.value("filterPourTruncated", false).toBool();
@@ -252,9 +251,6 @@ QString ShotHistoryStorage::buildFilterQuery(const ShotFilter& filter, QVariantL
     }
     if (filter.filterChanneling) {
         conditions << "channeling_detected = 1";
-    }
-    if (filter.filterTemperatureUnstable) {
-        conditions << "temperature_unstable = 1";
     }
     if (filter.filterGrindIssue) {
         conditions << "grind_issue_detected = 1";
@@ -359,7 +355,7 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                    enjoyment, visualizer_id, grinder_setting,
                    temperature_override, yield_override, beverage_type,
                    drink_tds, drink_ey,
-                   channeling_detected, temperature_unstable, grind_issue_detected,
+                   channeling_detected, grind_issue_detected,
                    skip_first_frame_detected, pour_truncated_detected
             FROM shots
             WHERE id IN (SELECT rowid FROM shots_fts WHERE shots_fts MATCH '%1')
@@ -374,7 +370,7 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                    enjoyment, visualizer_id, grinder_setting,
                    temperature_override, yield_override, beverage_type,
                    drink_tds, drink_ey,
-                   channeling_detected, temperature_unstable, grind_issue_detected,
+                   channeling_detected, grind_issue_detected,
                    skip_first_frame_detected, pour_truncated_detected
             FROM shots
             %1
@@ -441,10 +437,9 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
                             shot["drinkTdsPct"] = query.value(15).toDouble();
                             shot["drinkEyPct"] = query.value(16).toDouble();
                             shot["channelingDetected"] = query.value(17).toInt() != 0;
-                            shot["temperatureUnstable"] = query.value(18).toInt() != 0;
-                            shot["grindIssueDetected"] = query.value(19).toInt() != 0;
-                            shot["skipFirstFrameDetected"] = query.value(20).toInt() != 0;
-                            shot["pourTruncatedDetected"] = query.value(21).toInt() != 0;
+                            shot["grindIssueDetected"] = query.value(18).toInt() != 0;
+                            shot["skipFirstFrameDetected"] = query.value(19).toInt() != 0;
+                            shot["pourTruncatedDetected"] = query.value(20).toInt() != 0;
 
                             QDateTime dt = QDateTime::fromSecsSinceEpoch(
                                 query.value(2).toLongLong());

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -93,7 +93,6 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.weightFlowRate = pointsToVariant(record.weightFlowRate);
 
     p.channelingDetected = record.channelingDetected;
-    p.temperatureUnstable = record.temperatureUnstable;
     p.grindIssueDetected = record.grindIssueDetected;
     p.skipFirstFrameDetected = record.skipFirstFrameDetected;
     p.pourTruncatedDetected = record.pourTruncatedDetected;
@@ -122,7 +121,7 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
             const AnalysisInputs inputs = prepareAnalysisInputs(record.profileKbId, record.profileJson);
             analysisOwned = ShotAnalysis::analyzeShot(
                 record.pressure, record.flow, record.weight,
-                record.temperature, record.temperatureGoal, record.conductanceDerivative,
+                record.conductanceDerivative,
                 record.phases, record.summary.beverageType, record.summary.duration,
                 record.pressureGoal, record.flowGoal,
                 inputs.analysisFlags, inputs.firstFrameSeconds,
@@ -159,15 +158,6 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
             preinfusion["durationSec"] = d.preinfusionDripDurationSec;
         }
         detectorResults["preinfusion"] = preinfusion;
-
-        QVariantMap tempStability;
-        tempStability["checked"] = d.tempStabilityChecked;
-        if (d.tempStabilityChecked) {
-            tempStability["intentionalStepping"] = d.tempIntentionalStepping;
-            tempStability["avgDeviationC"] = d.tempAvgDeviationC;
-            tempStability["unstable"] = d.tempUnstable;
-        }
-        detectorResults["tempStability"] = tempStability;
 
         QVariantMap grind;
         grind["checked"] = d.grindChecked;

--- a/src/history/shotprojection.cpp
+++ b/src/history/shotprojection.cpp
@@ -56,7 +56,6 @@ QVariantMap ShotProjection::toVariantMap() const
     m["weightFlowRate"] = weightFlowRate;
 
     m["channelingDetected"] = channelingDetected;
-    m["temperatureUnstable"] = temperatureUnstable;
     m["grindIssueDetected"] = grindIssueDetected;
     m["skipFirstFrameDetected"] = skipFirstFrameDetected;
     m["pourTruncatedDetected"] = pourTruncatedDetected;
@@ -113,7 +112,6 @@ ShotProjection ShotProjection::fromVariantMap(const QVariantMap& m)
     p.profileKbId = m.value("profileKbId").toString();
 
     p.channelingDetected = m.value("channelingDetected").toBool();
-    p.temperatureUnstable = m.value("temperatureUnstable").toBool();
     p.grindIssueDetected = m.value("grindIssueDetected").toBool();
     p.skipFirstFrameDetected = m.value("skipFirstFrameDetected").toBool();
     p.pourTruncatedDetected = m.value("pourTruncatedDetected").toBool();

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -65,7 +65,6 @@ class ShotProjection {
     Q_PROPERTY(QString profileKbId MEMBER profileKbId)
 
     Q_PROPERTY(bool channelingDetected MEMBER channelingDetected)
-    Q_PROPERTY(bool temperatureUnstable MEMBER temperatureUnstable)
     Q_PROPERTY(bool grindIssueDetected MEMBER grindIssueDetected)
     Q_PROPERTY(bool skipFirstFrameDetected MEMBER skipFirstFrameDetected)
     Q_PROPERTY(bool pourTruncatedDetected MEMBER pourTruncatedDetected)
@@ -132,7 +131,6 @@ public:
     QString profileKbId;
 
     bool channelingDetected = false;
-    bool temperatureUnstable = false;
     bool grindIssueDetected = false;
     bool skipFirstFrameDetected = false;
     bool pourTruncatedDetected = false;

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -44,7 +44,7 @@ static void stripDetectorInternals(QJsonObject& obj)
         return;
     QJsonObject detectorResults = obj.value("detectorResults").toObject();
     static const char* detectorKeys[] = {
-        "grind", "channeling", "flowTrend", "tempStability", "preinfusion"
+        "grind", "channeling", "flowTrend", "preinfusion"
     };
     for (const char* key : detectorKeys) {
         const QString k = QString::fromLatin1(key);
@@ -366,7 +366,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
         "shots_get_detail",
         "Get a shot record. Default detail='summary' returns scalars, phase summaries, "
         "summary lines, detector results (every detector wrapped in its own envelope object: "
-        "grind / channeling / flowTrend / tempStability / preinfusion / pour / skipFirstFrame / "
+        "grind / channeling / flowTrend / preinfusion / pour / skipFirstFrame / "
         "verdict), and ratings (~3K chars). Pass detail='full' to include time-series curves "
         "(pressure, flow, temperature, weight), debug log, and embedded profile JSON (~85K chars "
         "— only useful for curve-aware analysis).",

--- a/src/network/shotserver_shots.cpp
+++ b/src/network/shotserver_shots.cpp
@@ -1179,11 +1179,10 @@ QString ShotServer::generateShotDetailPage(qint64 shotId, const ShotProjection& 
             .arg(kind, text);
     };
     QString badgesHtml = QStringLiteral("<div class=\"shot-quality\">");
-    const bool hasFlag = shot.channelingDetected || shot.temperatureUnstable
+    const bool hasFlag = shot.channelingDetected
                        || shot.grindIssueDetected || shot.pourTruncatedDetected
                        || shot.skipFirstFrameDetected;
     if (shot.channelingDetected)     badgesHtml += badgeChip("danger",  "Channeling detected");
-    if (shot.temperatureUnstable)    badgesHtml += badgeChip("warning", "Temp unstable");
     if (shot.grindIssueDetected)     badgesHtml += badgeChip("warning", "Grind issue");
     if (shot.pourTruncatedDetected)  badgesHtml += badgeChip("danger",  "Puck failed");
     if (shot.skipFirstFrameDetected) badgesHtml += badgeChip("danger",  "First step skipped");

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -1016,21 +1016,19 @@ private slots:
     {
         // Use the actual production-emitted strings from
         // ShotAnalysis::analyzeShot — "Sustained channeling detected"
-        // (lowercase "c" in "channeling") and "Temperature drifted X°C
-        // from goal on average". These are what the deterministic
+        // (lowercase "c" in "channeling"). This is what the deterministic
         // detector pipeline writes into summaryLines.text, and the
-        // substring matchers in extractShotFields are tuned to them.
+        // substring matcher in extractShotFields is tuned to it.
         const QString content = QStringLiteral(
             "## Shot (2026-05-01)\n\nHere's my latest shot:\n\n"
             "{"
             "  \"shot\": {\"doseG\": 18.0, \"yieldG\": 36.0},"
-            "  \"shotAnalysis\": \"## Shot Summary\\n- [warning] Sustained channeling detected in dC/dt\\n- [caution] Temperature drifted 2.4\\u00B0C from goal on average\""
+            "  \"shotAnalysis\": \"## Shot Summary\\n- [warning] Sustained channeling detected in dC/dt\""
             "}\n\nWhat to do?");
 
         const auto fields = AIConversation::extractShotFields(content);
         QVERIFY(fields.fromStructuredEnvelope);
         QVERIFY(fields.channelingDetected);
-        QVERIFY(fields.temperatureUnstable);
     }
 
     // After issue #1037, the structured `shot.detectorObservations[]`
@@ -1054,8 +1052,6 @@ private slots:
         QVERIFY(fields.fromStructuredEnvelope);
         QVERIFY2(fields.channelingDetected,
                  "detectorObservations[] takes precedence over the prose body");
-        QVERIFY2(!fields.temperatureUnstable,
-                 "no temp-unstable observation present, so the flag must stay false");
     }
 
     // The structured-array path's stable `kind` enum is the canonical
@@ -1071,9 +1067,7 @@ private slots:
             "    \"doseG\": 18.0,"
             "    \"detectorObservations\": ["
             "      {\"type\": \"warning\", \"kind\": \"channeling_sustained\","
-            "       \"text\": \"PUCK PREP ISSUE — totally rewritten in a future release\"},"
-            "      {\"type\": \"caution\", \"kind\": \"temperature_drift\","
-            "       \"text\": \"Heating element behaving oddly\"}"
+            "       \"text\": \"PUCK PREP ISSUE — totally rewritten in a future release\"}"
             "    ]"
             "  }"
             "}");
@@ -1082,8 +1076,6 @@ private slots:
         QVERIFY(fields.fromStructuredEnvelope);
         QVERIFY2(fields.channelingDetected,
                  "kind=channeling_sustained must set channelingDetected even when text drifts");
-        QVERIFY2(fields.temperatureUnstable,
-                 "kind=temperature_drift must set temperatureUnstable even when text drifts");
     }
 
     // Transient channeling also sets the flag (kind=channeling_transient).
@@ -1103,22 +1095,20 @@ private slots:
     }
 
     // Pre-#1037 envelopes ship `text` without `kind`. Substring fallback
-    // against the production text strings (`channeling detected` /
-    // `Temperature drifted`) keeps those envelopes working.
+    // against the production text string (`channeling detected`) keeps
+    // those envelopes working.
     void aiConversation_extractShotFields_kindAbsentFallsBackToTextSubstring()
     {
         const QString content = QStringLiteral(
             "{"
             "  \"shot\": {"
             "    \"detectorObservations\": ["
-            "      {\"type\": \"warning\", \"text\": \"Sustained channeling detected in dC/dt\"},"
-            "      {\"type\": \"caution\", \"text\": \"Temperature drifted 2.4\\u00B0C from goal on average\"}"
+            "      {\"type\": \"warning\", \"text\": \"Sustained channeling detected in dC/dt\"}"
             "    ]"
             "  }"
             "}");
         const auto fields = AIConversation::extractShotFields(content);
         QVERIFY(fields.channelingDetected);
-        QVERIFY(fields.temperatureUnstable);
     }
 
     void aiConversation_extractShotFields_legacyProseFallsBackToRegex()
@@ -1146,7 +1136,6 @@ private slots:
         QCOMPARE(fields.grinder, QStringLiteral("Niche Zero"));
         QCOMPARE(fields.profileTitle, QStringLiteral("80's Espresso"));
         QVERIFY(fields.channelingDetected);
-        QVERIFY(!fields.temperatureUnstable);
     }
 
     // Cross-era equivalence: the structured path produces the same

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -10,7 +10,7 @@
 
 #include "history/shothistorystorage.h"
 
-// Test the ShotHistoryStorage schema creation and migration chain (v1->v12).
+// Test the ShotHistoryStorage schema creation and migration chain (v1->v15).
 //
 // Strategy: create a temp DB with an old schema (missing columns),
 // set schema_version to an old value, then call initialize() which runs
@@ -452,7 +452,7 @@ private slots:
     }
 
     // ==========================================
-    // Full chain v1->v12 preserves existing data
+    // Full chain v1->v15 preserves existing data
     // ==========================================
 
     void fullChainPreservesData() {
@@ -547,7 +547,8 @@ private slots:
     // Migration 14: enjoyment_source column added. Idempotency check —
     // running ShotHistoryStorage::initialize twice on the same DB does
     // not re-apply the ALTER (which would fail with a duplicate-column
-    // error) and the schema_version stays at 14. The back-fill logic
+    // error) and the schema_version reaches the latest version (currently
+    // 15, post the temperature_unstable drop). The back-fill logic
     // (UPDATE shots SET enjoyment_source = 'user' WHERE enjoyment > 0)
     // is exercised in production; constructing a partial v13 schema
     // here would force an unrealistic state through ShotHistoryStorage's

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -164,7 +164,7 @@ private slots:
             QVERIFY(hasTable(db, "shot_samples"));
             QVERIFY(hasTable(db, "shot_phases"));
             QVERIFY(hasTable(db, "schema_version"));
-            QCOMPARE(getSchemaVersion(db), 14);
+            QCOMPARE(getSchemaVersion(db), 15);
         });
     }
 
@@ -183,7 +183,9 @@ private slots:
             QVERIFY(hasColumn(db, "shots", "grinder_burrs"));
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasColumn(db, "shots", "channeling_detected"));
-            QVERIFY(hasColumn(db, "shots", "temperature_unstable"));
+            // temperature_unstable was added in migration 10 and dropped in
+            // migration 15 — see remove-temperature-unstable-badge change.
+            QVERIFY(!hasColumn(db, "shots", "temperature_unstable"));
             QVERIFY(hasColumn(db, "shots", "grind_issue_detected"));
             QVERIFY(hasColumn(db, "shots", "skip_first_frame_detected"));
             QVERIFY(hasColumn(db, "shots", "pour_truncated_detected"));
@@ -226,7 +228,7 @@ private slots:
         initAndClose(path, storage);
 
         withRawDb(path, "v1_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 14);
+            QCOMPARE(getSchemaVersion(db), 15);
             QVERIFY(hasColumn(db, "shots", "temperature_override"));
             QVERIFY(hasColumn(db, "shots", "yield_override"));
             QVERIFY(hasColumn(db, "shots", "beverage_type"));
@@ -234,7 +236,9 @@ private slots:
             QVERIFY(hasColumn(db, "shots", "grinder_burrs"));
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasColumn(db, "shots", "channeling_detected"));
-            QVERIFY(hasColumn(db, "shots", "temperature_unstable"));
+            // temperature_unstable was added in migration 10 and dropped in
+            // migration 15 — see remove-temperature-unstable-badge change.
+            QVERIFY(!hasColumn(db, "shots", "temperature_unstable"));
             QVERIFY(hasColumn(db, "shots", "grind_issue_detected"));
             QVERIFY(hasColumn(db, "shots", "skip_first_frame_detected"));
             QVERIFY(hasColumn(db, "shots", "pour_truncated_detected"));
@@ -338,7 +342,7 @@ private slots:
         withRawDb(path, "v9_verify", [](QSqlDatabase& db) {
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasIndex(db, "idx_shots_profile_kb_id"));
-            QCOMPARE(getSchemaVersion(db), 14);
+            QCOMPARE(getSchemaVersion(db), 15);
         });
     }
 
@@ -352,7 +356,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "idempotent", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 14);
+            QCOMPARE(getSchemaVersion(db), 15);
         });
     }
 
@@ -372,7 +376,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "empty_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 14);
+            QCOMPARE(getSchemaVersion(db), 15);
         });
     }
 
@@ -395,7 +399,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "null_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 14);
+            QCOMPARE(getSchemaVersion(db), 15);
             QSqlQuery q(db);
             q.exec("SELECT grinder_brand FROM shots WHERE uuid = 'test-null'");
             QVERIFY(q.next());
@@ -571,7 +575,7 @@ private slots:
                 if (q.value(1).toString() == "enjoyment_source") { hasColumn = true; break; }
             }
         });
-        QCOMPARE(versionFound, 14);
+        QCOMPARE(versionFound, 15);
         QVERIFY2(hasColumn, "enjoyment_source column survives idempotent re-initialize");
     }
 };

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -1198,8 +1198,8 @@ private slots:
 
     // ---- Suppression cascade in analyzeShot ----
     //
-    // When pourTruncated fires, the channeling / flow-trend / temp-stability /
-    // grind blocks all read off curves the failed puck didn't produce, so
+    // When pourTruncated fires, the channeling / flow-trend / grind blocks
+    // all read off curves the failed puck didn't produce, so
     // their output is unreliable. The summary path suppresses those blocks
     // entirely and emits a single "Pour never pressurized" warning + the
     // "Don't tune off this shot" verdict instead. These tests lock in that
@@ -1575,9 +1575,8 @@ private slots:
     // (`shots_get_detail`) read these directly instead of re-deriving the
     // window from phase markers; the previous `ShotSummarizer::computePourWindow`
     // re-derivation is what let drift creep in (PR #944 deleted it).
-    // ShotSummarizer's per-phase temperature instability check iterates
-    // `summary.phases` directly and doesn't read these fields — only the
-    // `pourTruncatedDetected` cascade gate couples it to analyzeShot.
+    // MCP consumers read `pourStartSec` / `pourEndSec` directly off
+    // DetectorResults instead of re-deriving the window themselves.
     void analyzeShot_pourWindow_matchesPhaseBoundaries()
     {
         QList<HistoryPhaseMarker> phases{
@@ -1607,9 +1606,10 @@ private slots:
     // No-marker whole-shot fallback: when phases is empty but pressure data
     // is present, analyzeShot still runs but the boundary loop produces no
     // hits, so pourStart stays at 0 and pourEnd stays at the full shot
-    // duration. ShotSummarizer's per-phase temp gate sees this as "whole
-    // shot is the pour window" — same behavior as the deleted
-    // computePourWindow's `pourEnd = summary.totalDuration` default.
+    // duration — same behavior as the deleted computePourWindow's
+    // `pourEnd = summary.totalDuration` default. MCP consumers reading
+    // pourStartSec / pourEndSec from DetectorResults see the whole shot
+    // as the pour window on legacy / phase-marker-less shots.
     void analyzeShot_pourWindow_noMarkers_spansWholeShot()
     {
         const double duration = 30.0;
@@ -1721,7 +1721,7 @@ private slots:
     }
     // ---- Badge projection (decenza::deriveBadgesFromAnalysis) ----
     //
-    // The five boolean quality-badge columns are now a deterministic
+    // The four boolean quality-badge columns are now a deterministic
     // projection of ShotAnalysis::DetectorResults via the helper in
     // src/history/shotbadgeprojection.h. saveShot and loadShotRecordStatic
     // both call analyzeShot once and apply the projection — the cascade

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -933,7 +933,7 @@ private slots:
         QVector<QPointF> weight;  // unused
 
         const QVariantList lines = ShotAnalysis::generateSummary(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, /*beverageType=*/"espresso", /*duration=*/60.0,
             /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
 
@@ -1123,7 +1123,7 @@ private slots:
         QVector<QPointF> weight;
 
         const QVariantList lines = ShotAnalysis::generateSummary(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, /*beverageType=*/"espresso", /*duration=*/35.4,
             /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{},
             /*firstFrameConfiguredSeconds=*/-1.0,
@@ -1228,7 +1228,7 @@ private slots:
         QVector<QPointF> weight;
 
         const QVariantList lines = ShotAnalysis::generateSummary(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, /*beverageType=*/"espresso", /*duration=*/7.0,
             /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
 
@@ -1255,38 +1255,6 @@ private slots:
                  qPrintable("verdict should name the unreliable signals: " + verdictText));
     }
 
-    // Temperature drift well above the 2°C threshold must NOT produce a
-    // "Temperature drifted" caution line when pourTruncated fires. This is
-    // the exact misdiagnosis from shot 868 — fix is the suppression gate in
-    // analyzeShot.
-    void pourTruncated_summary_suppressesTempDriftLine()
-    {
-        QList<HistoryPhaseMarker> phases{
-            phase(0.0, "preinfusion start", 0, /*isFlowMode=*/true),
-            phase(2.0, "pour",              1, /*isFlowMode=*/true),
-        };
-        QVector<QPointF> pressure = flatSeries(0.0, 7.0, 0.6);  // puck failure
-        QVector<QPointF> flow = flatSeries(0.0, 7.0, 7.0);
-        QVector<QPointF> flowGoal = flatSeries(0.0, 7.0, 7.5);
-        // 5°C below goal — would normally trip the temp-unstable detector.
-        QVector<QPointF> temperature = flatSeries(0.0, 7.0, 77.0);
-        QVector<QPointF> temperatureGoal = flatSeries(0.0, 7.0, 82.0);
-        QVector<QPointF> dCdt = flatSeries(0.0, 7.0, 0.0);
-        QVector<QPointF> weight;
-
-        const QVariantList lines = ShotAnalysis::generateSummary(
-            pressure, flow, weight, temperature, temperatureGoal,
-            dCdt, phases, /*beverageType=*/"espresso", /*duration=*/7.0,
-            /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
-
-        for (const QVariant& v : lines) {
-            const QVariantMap m = v.toMap();
-            const QString text = m["text"].toString();
-            QVERIFY2(!text.contains("Temperature drifted", Qt::CaseInsensitive),
-                     qPrintable("temp-drift line leaked through suppression: " + text));
-        }
-    }
-
     // Sustained dC/dt elevation must NOT produce a channeling line (or its
     // green "Puck stable — no channeling spikes" companion) when
     // pourTruncated fires — the conductance signal is unreliable when peak
@@ -1309,7 +1277,7 @@ private slots:
         QVector<QPointF> weight;
 
         const QVariantList lines = ShotAnalysis::generateSummary(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, /*beverageType=*/"espresso", /*duration=*/7.0,
             /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
 
@@ -1355,7 +1323,7 @@ private slots:
         QVector<QPointF> weight;
 
         const auto result = ShotAnalysis::analyzeShot(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, "espresso", 60.0,
             /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
 
@@ -1401,7 +1369,7 @@ private slots:
         QVector<QPointF> weight;
 
         const auto result = ShotAnalysis::analyzeShot(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, "espresso", 7.0,
             /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
 
@@ -1439,7 +1407,7 @@ private slots:
         QVector<QPointF> weight = rampSeries(0.0, 30.0, 0.0, 36.0);
 
         const auto result = ShotAnalysis::analyzeShot(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, "espresso", 30.0,
             pressureGoal, flowGoal, /*analysisFlags=*/{},
             /*firstFrameConfiguredSeconds=*/-1.0,
@@ -1483,7 +1451,7 @@ private slots:
         QVector<QPointF> weight;
 
         const auto result = ShotAnalysis::analyzeShot(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, "espresso", 30.0,
             pressureGoal, flowGoal, /*analysisFlags=*/{},
             /*firstFrameConfiguredSeconds=*/-1.0,
@@ -1534,7 +1502,7 @@ private slots:
         QVector<QPointF> weight;
 
         const auto result = ShotAnalysis::analyzeShot(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, "espresso", 25.0,
             pressureGoal, flowGoal, /*analysisFlags=*/{},
             /*firstFrameConfiguredSeconds=*/-1.0,
@@ -1582,7 +1550,7 @@ private slots:
         QVector<QPointF> weight;
 
         const auto result = ShotAnalysis::analyzeShot(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, "espresso", 7.0,
             /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{});
 
@@ -1628,7 +1596,7 @@ private slots:
         QVector<QPointF> weight = rampSeries(0.0, 30.0, 0.0, 36.0);
 
         const auto result = ShotAnalysis::analyzeShot(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, "espresso", 30.0,
             pressureGoal, flowGoal);
         const auto& d = result.detectors;
@@ -1653,7 +1621,7 @@ private slots:
         QVector<QPointF> weight = rampSeries(0.0, duration, 0.0, 36.0);
 
         const auto result = ShotAnalysis::analyzeShot(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, /*phases=*/{}, "espresso", duration);
         const auto& d = result.detectors;
         QCOMPARE(d.pourStartSec, 0.0);
@@ -1668,8 +1636,8 @@ private slots:
     {
         QVector<QPointF> pressure;  // empty — triggers early return
         const auto result = ShotAnalysis::analyzeShot(
-            pressure, /*flow=*/{}, /*weight=*/{}, /*temperature=*/{},
-            /*tempGoal=*/{}, /*dCdt=*/{}, /*phases=*/{}, "espresso", 30.0);
+            pressure, /*flow=*/{}, /*weight=*/{},
+            /*dCdt=*/{}, /*phases=*/{}, "espresso", 30.0);
         const auto& d = result.detectors;
         QCOMPARE(d.pourStartSec, 0.0);
         QCOMPARE(d.pourEndSec, 0.0);
@@ -1694,7 +1662,7 @@ private slots:
         QVector<QPointF> weight = rampSeries(0.0, duration, 0.0, 36.0);
 
         const auto result = ShotAnalysis::analyzeShot(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, "espresso", duration);
         const auto& d = result.detectors;
         QCOMPARE(d.pourStartSec, 2.0);
@@ -1729,14 +1697,14 @@ private slots:
         // save/load/MCP for 1-frame profiles — see SHOT_REVIEW.md §4.
         const int frameCount = 2;
         const QVariantList legacy = ShotAnalysis::generateSummary(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, "espresso", 30.0,
             /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{},
             /*firstFrameConfiguredSeconds=*/-1.0,
             /*targetWeightG=*/0.0, /*finalWeightG=*/0.0,
             frameCount);
         const auto fresh = ShotAnalysis::analyzeShot(
-            pressure, flow, weight, temperature, temperatureGoal,
+            pressure, flow, weight,
             dCdt, phases, "espresso", 30.0,
             /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{},
             /*firstFrameConfiguredSeconds=*/-1.0,
@@ -1770,8 +1738,6 @@ private slots:
         d.channelingSeverity = QStringLiteral("none");
         d.flowTrendChecked = true;
         d.flowTrend = QStringLiteral("stable");
-        d.tempStabilityChecked = true;
-        d.tempUnstable = false;
         d.grindChecked = true;
         d.grindHasData = true;
         d.grindDirection = QStringLiteral("onTarget");
@@ -1781,7 +1747,6 @@ private slots:
         const auto flags = decenza::deriveBadgesFromAnalysis(d);
         QVERIFY(!flags.pourTruncatedDetected);
         QVERIFY(!flags.channelingDetected);
-        QVERIFY(!flags.temperatureUnstable);
         QVERIFY(!flags.grindIssueDetected);
         QVERIFY(!flags.skipFirstFrameDetected);
     }
@@ -1796,8 +1761,6 @@ private slots:
         ShotAnalysis::DetectorResults d;
         d.channelingChecked = true;
         d.channelingSeverity = QStringLiteral("none");
-        d.tempStabilityChecked = true;
-        d.tempUnstable = false;
         d.grindChecked = true;
         d.grindHasData = true;
         d.grindVerifiedClean = true;          // new positive signal
@@ -1832,8 +1795,6 @@ private slots:
                  "pourTruncated must project to pourTruncatedDetected");
         QVERIFY2(!flags.channelingDetected,
                  "cascade must leave channelingDetected at false");
-        QVERIFY2(!flags.temperatureUnstable,
-                 "cascade must leave temperatureUnstable at false");
         QVERIFY2(!flags.grindIssueDetected,
                  "cascade must leave grindIssueDetected at false");
         QVERIFY2(!flags.skipFirstFrameDetected,
@@ -1853,7 +1814,6 @@ private slots:
         QVERIFY(flags.pourTruncatedDetected);
         QVERIFY(flags.skipFirstFrameDetected);
         QVERIFY(!flags.channelingDetected);
-        QVERIFY(!flags.temperatureUnstable);
         QVERIFY(!flags.grindIssueDetected);
     }
 
@@ -1983,50 +1943,15 @@ private slots:
         QVERIFY(flags.skipFirstFrameDetected);
     }
 
-    void badgeProjection_tempUnstable_firesBadge()
-    {
-        // tempUnstable already encodes the gates inside analyzeShot
-        // (tempStabilityChecked && !tempIntentionalStepping && avgDev > threshold);
-        // the projection just reads the flag.
-        ShotAnalysis::DetectorResults d;
-        d.tempStabilityChecked = true;
-        d.tempIntentionalStepping = false;
-        d.tempAvgDeviationC = 3.0;
-        d.tempUnstable = true;
-        d.verdictCategory = QStringLiteral("minorIssues");
-
-        const auto flags = decenza::deriveBadgesFromAnalysis(d);
-        QVERIFY(flags.temperatureUnstable);
-    }
-
-    void badgeProjection_tempIntentionalStepping_doesNotFireBadge()
-    {
-        // D-Flow style profile with intentional temp stepping: tempUnstable
-        // stays false even with a large measured deviation, because the
-        // gate is held inside analyzeShot. Locks in that the projection
-        // doesn't second-guess the struct.
-        ShotAnalysis::DetectorResults d;
-        d.tempStabilityChecked = true;
-        d.tempIntentionalStepping = true;
-        d.tempAvgDeviationC = 8.0;  // would normally trip threshold
-        d.tempUnstable = false;
-        d.verdictCategory = QStringLiteral("clean");
-
-        const auto flags = decenza::deriveBadgesFromAnalysis(d);
-        QVERIFY2(!flags.temperatureUnstable,
-                 "intentional temp stepping must NOT fire the temp badge");
-    }
-
-    void badgeProjection_applyBadgesToTarget_writesAllFiveFields()
+    void badgeProjection_applyBadgesToTarget_writesAllFourFields()
     {
         // Compile-time + runtime check that the templated apply helper
-        // writes all five fields onto a target struct shape. Uses a local
+        // writes all four fields onto a target struct shape. Uses a local
         // throwaway struct that mimics ShotSaveData / ShotRecord's badge
         // surface — keeps this test independent of the storage TU layout.
         struct FakeTarget {
             bool pourTruncatedDetected = false;
             bool channelingDetected = false;
-            bool temperatureUnstable = false;
             bool grindIssueDetected = false;
             bool skipFirstFrameDetected = false;
         };
@@ -2035,79 +1960,14 @@ private slots:
         d.pourTruncated = true;
         d.skipFirstFrame = true;
         d.channelingSeverity = QStringLiteral("sustained");
-        d.tempUnstable = true;
         d.grindHasData = true;
         d.grindChokedPuck = true;
 
         decenza::applyBadgesToTarget(t, d);
         QVERIFY(t.pourTruncatedDetected);
         QVERIFY(t.channelingDetected);
-        QVERIFY(t.temperatureUnstable);
         QVERIFY(t.grindIssueDetected);
         QVERIFY(t.skipFirstFrameDetected);
-    }
-
-    // avgTempDeviation -------------------------------------------------------
-
-    void avgTempDeviation_coldStartWarmupSkipped()
-    {
-        // First 3s: actual = 84°C, goal = 88°C → delta = 4°C > TEMP_WARMUP_SKIP_C (3.0)
-        // → those samples are skipped. Remaining 7s: actual = 87°C → delta = 1°C < threshold.
-        // Average over the non-skipped samples should be ~1°C → well below 2°C badge threshold.
-        const double goal = 88.0;
-        const double warmSamples = 7.0 * 10; // 7s at 10 Hz
-
-        QVector<QPointF> temp, tempGoal;
-        for (int i = 0; i < 30; ++i) {          // 3s cold: 84°C
-            temp.append(QPointF(i * 0.1, 84.0));
-            tempGoal.append(QPointF(i * 0.1, goal));
-        }
-        for (int i = 30; i < 130; ++i) {        // 10s warm: 87°C
-            temp.append(QPointF(i * 0.1, 87.0));
-            tempGoal.append(QPointF(i * 0.1, goal));
-        }
-
-        const double dev = ShotAnalysis::avgTempDeviation(temp, tempGoal, 0.0, 13.0);
-        QVERIFY2(dev < ShotAnalysis::TEMP_UNSTABLE_THRESHOLD,
-                 "cold-start leading samples should be skipped; stable tail should not badge");
-        QCOMPARE_LT(std::abs(dev - 1.0), 0.01); // should average to exactly 1.0°C
-    }
-
-    void avgTempDeviation_midShotDropCountedAfterLatch()
-    {
-        // 2s stable at goal, then 3s of a 5°C below-goal drop mid-shot.
-        // Latch fires on the stable prefix; the drop is counted and pushes avg above threshold.
-        const double goal = 93.0;
-
-        QVector<QPointF> temp, tempGoal;
-        for (int i = 0; i < 20; ++i) {          // 2s stable: 93°C (delta=0)
-            temp.append(QPointF(i * 0.1, 93.0));
-            tempGoal.append(QPointF(i * 0.1, goal));
-        }
-        for (int i = 20; i < 50; ++i) {         // 3s drop: 88°C (delta=5°C)
-            temp.append(QPointF(i * 0.1, 88.0));
-            tempGoal.append(QPointF(i * 0.1, goal));
-        }
-
-        const double dev = ShotAnalysis::avgTempDeviation(temp, tempGoal, 0.0, 5.0);
-        QVERIFY2(dev > ShotAnalysis::TEMP_UNSTABLE_THRESHOLD,
-                 "mid-shot temperature drop must be counted after warmup latch fires");
-    }
-
-    void avgTempDeviation_allSamplesColdReturnsZero()
-    {
-        // Every pour sample is 5°C below goal throughout — machine never warmed up.
-        // count stays 0; function must return 0.0 (no usable data → no badge).
-        const double goal = 90.0;
-
-        QVector<QPointF> temp, tempGoal;
-        for (int i = 0; i < 50; ++i) {
-            temp.append(QPointF(i * 0.1, 85.0));    // delta = 5°C > TEMP_WARMUP_SKIP_C
-            tempGoal.append(QPointF(i * 0.1, goal));
-        }
-
-        const double dev = ShotAnalysis::avgTempDeviation(temp, tempGoal, 0.0, 5.0);
-        QCOMPARE(dev, 0.0); // no usable data → no badge (intentional)
     }
 };
 

--- a/tests/tst_shotrecord_cache.cpp
+++ b/tests/tst_shotrecord_cache.cpp
@@ -160,7 +160,6 @@ private slots:
         // would do) and stash the result in cachedAnalysis.
         recordCached.cachedAnalysis = ShotAnalysis::analyzeShot(
             recordCached.pressure, recordCached.flow, recordCached.weight,
-            recordCached.temperature, recordCached.temperatureGoal,
             recordCached.conductanceDerivative,
             recordCached.phases, recordCached.summary.beverageType,
             recordCached.summary.duration,

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -46,8 +46,7 @@ void appendFlat(QVariantList& out, double t0, double t1, double value, double ra
 }
 
 // Append a phase marker. Defaults to pressure-mode (isFlowMode=false) and
-// frameNumber=1 so the marker counts toward reachedExtractionPhase()'s
-// "real frame ran" check.
+// frameNumber=1 so the marker indicates a real extraction frame.
 void appendPhase(QVariantList& out, double time, const QString& label,
                  int frameNumber = 1, bool isFlowMode = false)
 {
@@ -158,7 +157,7 @@ private slots:
     // generateSummary's cascade now forces channeling/temp/grind to silence
     // and emits only the "Pour never pressurized" warning + the "Don't tune
     // off this shot" verdict.
-    void pourTruncatedSuppressesChannelingAndTempLines()
+    void pourTruncatedSuppressesChannelingLines()
     {
         QVariantMap shot;
         shot["beverageType"] = QStringLiteral("espresso");
@@ -177,12 +176,6 @@ private slots:
         QVariantList flow;
         appendFlat(flow, 0.0, 30.0, 1.5);
 
-        // Temperature drifting 5°C below goal — would trigger
-        // temperatureUnstable on its own. Must be suppressed.
-        QVariantList temperature, temperatureGoal;
-        appendFlat(temperature, 0.0, 30.0, 88.0);
-        appendFlat(temperatureGoal, 0.0, 30.0, 93.0);
-
         // Conductance derivative with sustained spikes — would normally
         // trip the channeling detector. Must be suppressed (puck never
         // built, conductance saturates → derivative is meaningless).
@@ -198,8 +191,6 @@ private slots:
 
         shot["pressure"] = pressure;
         shot["flow"] = flow;
-        shot["temperature"] = temperature;
-        shot["temperatureGoal"] = temperatureGoal;
         shot["conductanceDerivative"] = derivative;
         shot["weight"] = weight;
         shot["phases"] = phases;
@@ -214,8 +205,6 @@ private slots:
                  "summaryLines must contain the puck-failed warning from generateSummary");
         QVERIFY2(!linesContain(summary.summaryLines, QStringLiteral("Sustained channeling")),
                  "channeling line must be suppressed by the cascade");
-        QVERIFY2(!linesContain(summary.summaryLines, QStringLiteral("Temperature drifted")),
-                 "temperature drift line must be suppressed by the cascade");
         // Verdict line dominates with the meta-action — see SHOT_REVIEW.md §3.
         QVERIFY2(linesContainType(summary.summaryLines, QStringLiteral("verdict")),
                  "every shot must end with a verdict line");
@@ -235,255 +224,8 @@ private slots:
                  "prompt must surface the puck-failed warning to the AI");
         QVERIFY2(!prompt.contains(QStringLiteral("Puck integrity")),
                  "old hand-rolled 'Puck integrity' line must be gone");
-        QVERIFY2(!prompt.contains(QStringLiteral("Temperature deviation")),
-                 "old hand-rolled 'Temperature deviation' line must be gone");
         QVERIFY2(!prompt.contains(QStringLiteral("Sustained channeling")),
                  "channeling line must not reach the prompt on a truncated pour");
-    }
-
-    // Aborted-during-preinfusion shape: frame 0 only, no real extraction phase.
-    // Pin the contract that markPerPhaseTempInstability is gated on
-    // ShotAnalysis::reachedExtractionPhase — without the gate, the per-phase
-    // prompt block would emit "Temperature instability" on the preheat ramp
-    // even though generateSummary correctly suppresses the aggregate caution.
-    // Matches the gate the aggregate detector got in PR #898.
-    void abortedPreinfusionDoesNotFlagPerPhaseTemp()
-    {
-        QVariantMap shot;
-        shot["beverageType"] = QStringLiteral("espresso");
-        shot["durationSec"] = 3.0;  // very short — died during preinfusion-start
-        shot["doseWeightG"] = 18.0;
-        shot["finalWeightG"] = 0.5;
-
-        // Pressure built enough to clear pourTruncated (peak >= 2.5 bar) — we
-        // want to isolate the reachedExtractionPhase gate, not the puck-failure
-        // cascade.
-        QVariantList pressure;
-        appendFlat(pressure, 0.0, 3.0, 4.0);
-
-        QVariantList flow;
-        appendFlat(flow, 0.0, 3.0, 0.5);
-
-        // 5°C below goal — would trigger per-phase temperatureUnstable on its
-        // own. Must stay false because the shot never reached extraction.
-        QVariantList temperature, temperatureGoal;
-        appendFlat(temperature, 0.0, 3.0, 88.0);
-        appendFlat(temperatureGoal, 0.0, 3.0, 93.0);
-
-        QVariantList weight;
-        appendFlat(weight, 0.0, 3.0, 0.5);
-
-        // Only frame 0 marker — no frame >= 1 sample lasted, so
-        // reachedExtractionPhase must return false.
-        QVariantList phases;
-        appendPhase(phases, 0.0, QStringLiteral("Preinfusion"), 0);
-
-        shot["pressure"] = pressure;
-        shot["flow"] = flow;
-        shot["temperature"] = temperature;
-        shot["temperatureGoal"] = temperatureGoal;
-        shot["conductanceDerivative"] = QVariantList();
-        shot["weight"] = weight;
-        shot["phases"] = phases;
-        shot["pressureGoal"] = QVariantList();
-        shot["flowGoal"] = QVariantList();
-
-        ShotSummarizer summarizer;
-        ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
-
-        QVERIFY2(!summary.pourTruncatedDetected,
-                 "test setup: pressure peaked above floor so pourTruncated should not fire");
-        for (const PhaseSummary& phase : summary.phases) {
-            QVERIFY2(!phase.temperatureUnstable,
-                     "per-phase temp markers must be suppressed when the shot didn't reach extraction");
-        }
-        const QString prompt = summarizer.buildUserPrompt(summary);
-        QVERIFY2(!prompt.contains(QStringLiteral("Temperature instability")),
-                 "preheat-ramp drift must not surface in the prompt for aborted-preinfusion shots");
-    }
-
-    // When the profile goal steps temperature across phases (flat goal
-    // within each phase, different goal each phase — e.g. 82→72°C), the
-    // per-phase hasIntentionalTempStepping check returns false but the
-    // global detector flags the shot as stepping. The per-phase prose
-    // gate must use the global flag, not the per-phase signal, or the
-    // prose contradicts the detectorResults envelope.
-    void intentionalCrossPhaseSteppingSuppressesPerPhaseTempProse()
-    {
-        QVariantMap shot;
-        shot["beverageType"] = QStringLiteral("espresso");
-        shot["durationSec"] = 30.0;
-        shot["doseWeightG"] = 18.0;
-        shot["finalWeightG"] = 36.0;
-
-        QVariantList pressure;
-        appendFlat(pressure, 0.0, 8.0, 2.0);
-        appendFlat(pressure, 8.0, 30.0, 9.0);
-
-        QVariantList flow;
-        appendFlat(flow, 0.0, 30.0, 1.8);
-
-        // Per-phase the goal is flat (82 in preinfusion, 72 in pour). The
-        // bounded hasIntentionalTempStepping returns false for both phases
-        // (no per-phase range). Globally the goal spans 82→72 = 10°C, well
-        // above TEMP_STEPPING_RANGE — the global detector flags the shot as
-        // intentionally stepping.
-        QVariantList temperature, temperatureGoal;
-        appendFlat(temperature, 0.0, 8.0, 79.0);   // 3°C below goal in preinfusion
-        appendFlat(temperature, 8.0 + 0.1, 30.0, 69.0);  // 3°C below goal in pour
-        appendFlat(temperatureGoal, 0.0, 8.0, 82.0);
-        appendFlat(temperatureGoal, 8.0 + 0.1, 30.0, 72.0);
-
-        QVariantList derivative;
-        appendFlat(derivative, 0.0, 30.0, 0.0);
-
-        QVariantList weight;
-        appendFlat(weight, 0.0, 30.0, 36.0);
-
-        QVariantList phases;
-        appendPhase(phases, 0.0, QStringLiteral("Preinfusion"), 0);
-        appendPhase(phases, 8.0, QStringLiteral("Pour"), 1);
-
-        shot["pressure"] = pressure;
-        shot["flow"] = flow;
-        shot["temperature"] = temperature;
-        shot["temperatureGoal"] = temperatureGoal;
-        shot["conductanceDerivative"] = derivative;
-        shot["weight"] = weight;
-        shot["phases"] = phases;
-        shot["pressureGoal"] = QVariantList();
-        shot["flowGoal"] = QVariantList();
-
-        ShotSummarizer summarizer;
-        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
-
-        QVERIFY2(summary.tempIntentionalStepping,
-                 "82->72 cross-phase goal must set tempIntentionalStepping (matches detectorResults envelope)");
-        QVERIFY2(!summary.pourTruncatedDetected,
-                 "test setup: 9-bar peak should not trip pourTruncated");
-
-        const QString prompt = summarizer.buildUserPrompt(summary);
-        QVERIFY2(!prompt.contains(QStringLiteral("Temperature instability")),
-                 "per-phase Temperature instability prose must be suppressed when the profile is intentionally stepping");
-    }
-
-    // Defensive: when a fast-path shotData carries no `tempStability`
-    // envelope, the .toMap().value(...).toBool() chain must default to
-    // false rather than crashing. Without this, suppression on rows
-    // without the envelope would silently de-couple from the live path.
-    void summarizeFromHistory_fastPathMissingTempStabilityEnvelopeDefaultsFalse()
-    {
-        QVariantMap shot = buildHealthyShotMap();
-        QVariantMap line;
-        line["text"] = QStringLiteral("dummy");
-        line["type"] = QStringLiteral("good");
-        QVariantList lines;
-        lines.append(line);
-        shot["summaryLines"] = lines;
-
-        // Detector envelope present but no tempStability key.
-        // pourTruncated stays false.
-        QVariantMap detectors;
-        detectors["pourTruncated"] = false;
-        shot["detectorResults"] = detectors;
-
-        ShotSummarizer summarizer;
-        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
-
-        QVERIFY2(!summary.tempIntentionalStepping,
-                 "missing tempStability envelope must default to !intentionalStepping (legacy rows)");
-    }
-
-    // Fast path end-to-end: with non-empty summaryLines (skips analyzeShot)
-    // and a tempStability envelope flagging intentionalStepping, the per-phase
-    // markPerPhaseTempInstability still marks phases unstable (per-phase goal
-    // is flat, avg deviation > 2°C) but the gate in buildUserPrompt must
-    // suppress the prose because of the global flag. Asserts the prompt
-    // string itself, not just the bool — without that, a future refactor
-    // that breaks the gate while leaving propagation intact would slip past.
-    void summarizeFromHistory_fastPathSuppressesProseWhenSteppingFlagSet()
-    {
-        QVariantMap shot = buildHealthyShotMap();
-        // Override temp curves so each phase has avg deviation ~3°C against
-        // a flat-per-phase goal — phase.temperatureUnstable will be set
-        // unless the gate suppresses it.
-        QVariantList temperature, temperatureGoal;
-        appendFlat(temperature, 0.0, 8.0, 79.0);
-        appendFlat(temperature, 8.0 + 0.1, 30.0, 69.0);
-        appendFlat(temperatureGoal, 0.0, 8.0, 82.0);
-        appendFlat(temperatureGoal, 8.0 + 0.1, 30.0, 72.0);
-        shot["temperature"] = temperature;
-        shot["temperatureGoal"] = temperatureGoal;
-
-        QVariantMap line;
-        line["text"] = QStringLiteral("dummy");
-        line["type"] = QStringLiteral("good");
-        QVariantList lines;
-        lines.append(line);
-        shot["summaryLines"] = lines;
-
-        QVariantMap tempStability;
-        tempStability["checked"] = true;
-        tempStability["intentionalStepping"] = true;
-        tempStability["avgDeviationC"] = 3.0;
-        tempStability["unstable"] = false;
-        QVariantMap detectors;
-        detectors["pourTruncated"] = false;
-        detectors["tempStability"] = tempStability;
-        shot["detectorResults"] = detectors;
-
-        ShotSummarizer summarizer;
-        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
-
-        QVERIFY2(summary.tempIntentionalStepping,
-                 "fast path must derive tempIntentionalStepping from detectorResults.tempStability");
-        const QString prompt = summarizer.buildUserPrompt(summary);
-        QVERIFY2(!prompt.contains(QStringLiteral("Temperature instability")),
-                 "fast path must suppress per-phase prose when the envelope flags intentional stepping");
-    }
-
-    // Negative control for the gate: same temp deviation as the test above,
-    // but the envelope explicitly says !intentionalStepping. The per-phase
-    // "Temperature instability" prose must still emit. Without this control,
-    // an over-aggressive gate (default-true, inverted condition) would
-    // silently swallow legitimate warnings on every shot and every other
-    // test would still pass.
-    void summarizeFromHistory_fastPathEmitsProseWhenNotStepping()
-    {
-        QVariantMap shot = buildHealthyShotMap();
-        QVariantList temperature, temperatureGoal;
-        appendFlat(temperature, 0.0, 8.0, 79.0);
-        appendFlat(temperature, 8.0 + 0.1, 30.0, 69.0);
-        appendFlat(temperatureGoal, 0.0, 8.0, 82.0);
-        appendFlat(temperatureGoal, 8.0 + 0.1, 30.0, 72.0);
-        shot["temperature"] = temperature;
-        shot["temperatureGoal"] = temperatureGoal;
-
-        QVariantMap line;
-        line["text"] = QStringLiteral("dummy");
-        line["type"] = QStringLiteral("good");
-        QVariantList lines;
-        lines.append(line);
-        shot["summaryLines"] = lines;
-
-        QVariantMap tempStability;
-        tempStability["checked"] = true;
-        tempStability["intentionalStepping"] = false;
-        tempStability["avgDeviationC"] = 3.0;
-        tempStability["unstable"] = true;
-        QVariantMap detectors;
-        detectors["pourTruncated"] = false;
-        detectors["tempStability"] = tempStability;
-        shot["detectorResults"] = detectors;
-
-        ShotSummarizer summarizer;
-        const ShotSummary summary = summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
-
-        QVERIFY2(!summary.tempIntentionalStepping,
-                 "control: explicit !intentionalStepping must not flip the flag");
-        const QString prompt = summarizer.buildUserPrompt(summary);
-        QVERIFY2(prompt.contains(QStringLiteral("Temperature instability")),
-                 "without the stepping flag the per-phase instability prose must still surface");
     }
 
     // Sanity: a healthy shot (peak pressure ~9 bar) flows through the same
@@ -702,7 +444,7 @@ private slots:
     // a real inclusion window — without that, channeling would stay
     // silent because no flow/pressure goal exists, and the assertion
     // !"Sustained channeling" would pass for the wrong reason.
-    void summarize_pourTruncated_suppressesChannelingAndTempLines_live()
+    void summarize_pourTruncated_suppressesChannelingLines_live()
     {
         ShotDataModel model;
         std::vector<LiveSample> samples;
@@ -739,45 +481,6 @@ private slots:
                  "summaryLines must contain the puck-failed warning");
         QVERIFY2(!linesContain(summary.summaryLines, QStringLiteral("Sustained channeling")),
                  "channeling line must be suppressed by the cascade");
-        QVERIFY2(!linesContain(summary.summaryLines, QStringLiteral("Temperature drifted")),
-                 "temperature drift line must be suppressed by the cascade");
-        QVERIFY2(linesContainType(summary.summaryLines, QStringLiteral("verdict")),
-                 "every shot must end with a verdict line");
-    }
-
-    // Live-path aborted-preinfusion: pin the reachedExtractionPhase gate on
-    // the live path. Mirrors abortedPreinfusionDoesNotFlagPerPhaseTemp;
-    // sample isFlowMode and the marker isFlowMode are both `false` to
-    // match the history-path mirror exactly.
-    void summarize_abortedPreinfusion_doesNotFlagPerPhaseTemp_live()
-    {
-        ShotDataModel model;
-        std::vector<LiveSample> samples;
-        // Pressure peaks at 4 bar so pourTruncated does NOT fire — we want to
-        // isolate the per-phase temp gate, not the puck-failure cascade.
-        for (double t = 0.0; t <= 3.0 + 1e-9; t += 0.1) {
-            samples.push_back({
-                /*t=*/t, /*pressure=*/4.0, /*flow=*/0.5,
-                /*temperature=*/88.0, /*pressureGoal=*/0.0, /*flowGoal=*/0.0,
-                /*temperatureGoal=*/93.0, /*isFlowMode=*/false});
-        }
-        // Frame 0 only, isFlowMode=false to mirror the history-path test —
-        // reachedExtractionPhase must return false.
-        populateLiveShot(&model, samples,
-            {{0.0, QStringLiteral("Preinfusion"), 0, false}},
-            /*finalWeight=*/0.5);
-
-        ShotMetadata metadata;
-        ShotSummarizer summarizer;
-        const ShotSummary summary = summarizer.summarize(&model, /*profile=*/nullptr,
-            metadata, /*doseWeight=*/18.0, /*finalWeight=*/0.5);
-
-        QVERIFY2(!summary.pourTruncatedDetected,
-                 "test setup: 4-bar peak should not trip pourTruncated");
-        for (const PhaseSummary& phase : summary.phases) {
-            QVERIFY2(!phase.temperatureUnstable,
-                     "per-phase temp markers must stay false on aborted-preinfusion shots");
-        }
         QVERIFY2(linesContainType(summary.summaryLines, QStringLiteral("verdict")),
                  "every shot must end with a verdict line");
     }
@@ -822,8 +525,7 @@ private slots:
 
     // Cascade integrity through the fast path: when shotData carries a
     // detectorResults.pourTruncated == true, summarizeFromHistory MUST set
-    // summary.pourTruncatedDetected = true AND skip the per-phase temp
-    // instability marking, exactly like the slow path's cascade.
+    // summary.pourTruncatedDetected = true.
     void summarizeFromHistory_fastPathPreservesPourTruncatedCascade()
     {
         QVariantMap shot = buildHealthyShotMap();
@@ -844,11 +546,6 @@ private slots:
 
         QVERIFY2(summary.pourTruncatedDetected,
                  "fast path must derive pourTruncatedDetected from detectorResults");
-        // Per-phase temperature markers must NOT be set when pourTruncated fires.
-        for (const PhaseSummary& phase : summary.phases) {
-            QVERIFY2(!phase.temperatureUnstable,
-                     "pourTruncated cascade must suppress per-phase temp markers in fast path");
-        }
     }
 
     // ---- buildPhaseSummariesForRange dedup (post-G) ----

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -474,15 +474,15 @@ EvaluatedShot evaluate(const LoadedShot& s)
     // User-facing verdict text. Calls into the same generateSummary() that the
     // Shot Summary popup uses, so the manifest can lock in the verdict-cascade
     // wording and catch regressions to the suppression rules (e.g. PR #922's
-    // pourTruncated → "Don't tune off this shot" verdict). Pass empty vectors
-    // for weight / temperature / temperatureGoal — the function tolerates
-    // missing curves and skips the corresponding observation lines, but the
-    // verdict cascade still picks the right branch from pressure / flow / dC/dt
-    // and the phase markers, which is what the manifest gates check.
+    // pourTruncated → "Don't tune off this shot" verdict). Pass an empty
+    // weight vector — the function tolerates the missing curve and skips the
+    // preinfusion-drip observation; the verdict cascade still picks the right
+    // branch from pressure / flow / dC/dt and the phase markers, which is what
+    // the manifest gates check.
     {
         const QVariantList lines = ShotAnalysis::generateSummary(
-            s.pressure, s.flow, /*weight=*/{}, /*temperature=*/{},
-            /*temperatureGoal=*/{}, s.conductanceDerivative, s.phases,
+            s.pressure, s.flow, /*weight=*/{},
+            s.conductanceDerivative, s.phases,
             s.beverageType, s.durationSec, s.pressureGoal, s.flowGoal,
             /*analysisFlags=*/{}, /*firstFrameConfiguredSeconds=*/-1.0,
             s.targetWeightG, s.yieldG);


### PR DESCRIPTION
## Summary

- Retires the `temperatureUnstable` quality badge across detector, projection, badge UI, MCP, history filter, and DB column. The detector measured average deviation from goal but was labeled "Temp unstable" — the math didn't match the label, and 12+ built-in profiles intentionally produce large gaps the badge mistook for problems.
- Adds `puckfailed:yes` chip to the Search Syntax help (it was in the syntax footer but missing from the per-keyword chip row).

## Why

Issue #1128: waltzingfool was getting persistent false-positive "Temp unstable" badges on Extractamundo Dos! Audit found at least 12 built-in profiles whose actual-vs-goal temperature gap is by design:
- D-Flow / Damian's Q / D-Flow La Pavoni — `espresso_temperature_steps_enabled = 0`; KB explicitly says "DO NOT flag the large gap (94°C target / ~88°C actual) — by design"
- Extractamundo Dos! / TurboBloom — 16°C bloom drops the head physically can't cool to
- 80's Espresso / TurboTurbo / Classic Italian / Blooming Espresso / A-Flow dark / Innovative long preinfusion / Flow Profile straight & milky — 6–10°C designed swings

The `hasIntentionalTempStepping` curve-based suppression was supposed to catch these but is fragile — one Visualizer-shared shot showed the captured `temperatureGoal` series collapsed to a single constant 72.5°C even on a profile that spans 67.5–83.5°C, and suppression failed.

The remaining diagnostic value (cold portafilter crash, heater failure, boiler exhaustion) is rare, already visible in the post-shot temperature chart, and crowded out by the false-positive noise. Tagging profiles individually with a `temp_drift_expected` flag was considered and rejected — every new "intentional drop" profile would need the flag, the false positive would remain permanent until tagged, and the underlying detector still measures the wrong thing.

## What Changes

**Detector (`src/ai/shotanalysis.{h,cpp}`)**
- Delete fields: `tempUnstable`, `tempStabilityChecked`, `tempIntentionalStepping`, `tempAvgDeviationC` from `DetectorResults`
- Delete constants: `TEMP_UNSTABLE_THRESHOLD`, `TEMP_STEPPING_RANGE`, `TEMP_WARMUP_SKIP_C`, `TEMP_MIN_EXTRACTION_SEC`
- Delete static helpers: `hasIntentionalTempStepping` (both overloads), `avgTempDeviation`, `reachedExtractionPhase`
- Drop `temperature` and `temperatureGoal` parameters from `analyzeShot` and `generateSummary` (no remaining consumer)
- Delete the temperature-stability block in `analyzeShot`

**Projection (`src/history/shotbadgeprojection.h`)**: drop `temperatureUnstable` row from `BadgeFlags` and the projection helper.

**Storage (`src/history/shothistorystorage*.cpp`)**:
- Migration 15 drops `temperature_unstable` column via `ALTER TABLE shots DROP COLUMN`
- All SQL strings (save, load, lazy-persist UPDATE, import, filter query) updated
- `shotBadgesUpdated` signal arity 6 → 5
- `ShotRecord::temperatureUnstable` and `ShotSaveData::temperatureUnstable` removed; same for `ShotProjection`

**ShotSummarizer (`src/ai/shotsummarizer.{h,cpp}`)**:
- Delete `markPerPhaseTempInstability` helper
- Delete `PhaseSummary::temperatureUnstable` and `ShotSummary::tempIntentionalStepping`
- Drop temperature-drift mentions from AI prompt builders

**MCP (`src/mcp/mcptools_shots.cpp`, `src/history/shothistorystorage_serialize.cpp`)**: drop `tempStability` block from `detectorResults` JSON.

**QML**:
- `QualityBadges.qml`: delete the orange "Temp unstable" chip
- `ShotDetailPage.qml`, `PostShotReviewPage.qml`: drop `temperatureUnstable` property bindings + 5-arg signal handler
- `ShotHistoryPage.qml`: drop the "Temp unstable" filter chip from the search-syntax help; **adds** the missing `puckfailed:yes` chip in the same dialog

**Other**: `aiconversation.cpp` regex/structured-array path drops `temperatureUnstable` field; `dialing_blocks.cpp` drops `COALESCE(temperature_unstable, 0)` from grinder-calibration WHERE.

**Docs**: `SHOT_REVIEW.md` §1 badges table (Five flags → Four), §2.3 deleted, §3 observation list renumbered, §4 projection table updated, §5/7 reference notes; `CLAUDE_MD/MCP_SERVER.md` Shot Detector Outputs section updated.

**Tests**: temperature-specific tests in `tst_shotanalysis.cpp`, `tst_shotsummarizer.cpp`, `tst_aimanager.cpp` deleted; surviving call sites updated for new `analyzeShot`/`generateSummary` signatures; `tst_dbmigration.cpp` expects schema 15.

**OpenSpec change**: full proposal/design/specs/tasks at `openspec/changes/remove-temperature-unstable-badge/`.

## Test plan

- [x] All Qt tests pass: 2049 / 2049 (was 2049 / 2049 with 6 dbmigration failures expecting schema 14, now bumped to 15)
- [x] `shot_eval --validate manifest.json` — 15 / 15 corpus shots pass unchanged
- [x] `shot_eval` against `/tmp/issue1128/*.json` — grind verdicts on the 6 user-shared shots are unchanged from before; the temp signal is now silently absent
- [ ] Manual: open a historical shot that previously had a "Temp unstable" badge — confirm the chip is gone, no orphan layout space, and the dialog has no "Temperature drifted" line
- [ ] Manual: pull a fresh espresso shot live — confirm the post-shot review page renders correctly (no chip, no orphan layout space)
- [ ] Manual: trigger schema migration on a copy of the production DB — verify `PRAGMA table_info(shots)` shows the column dropped
- [ ] Manual: confirm the `puckfailed:yes` chip now appears in Search Syntax help dialog (regression item from review feedback)

Closes #1128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)