### PR TITLE
fix(refractometer): R2 TDS reading dropped when device connects after review page opens

### DIFF
--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -215,8 +215,20 @@ Page {
 
     // Gate by visibility so device-initiated R2 readings between shots don't
     // land on whichever shot happens to be loaded.
+    //
+    // The `BLEManager.refractometerConnected` reference is load-bearing — it
+    // gives the target binding a signal to re-evaluate on. `Refractometer` is
+    // a context property whose value gets swapped (null ↔ live pointer) over
+    // the app lifetime, but `setContextProperty` doesn't emit a notify signal,
+    // so a binding that captured `null` at page-load stays stuck. Adding the
+    // BLEManager Q_PROPERTY (which DOES emit refractometerConnectedChanged)
+    // forces the binding to re-evaluate when the R2 connects after the review
+    // page has already opened. Without this, R2 readings that arrive after
+    // the page opens are silently dropped.
     Connections {
-        target: (typeof Refractometer !== "undefined" && Refractometer) ? Refractometer : null
+        target: BLEManager.refractometerConnected
+            && (typeof Refractometer !== "undefined") && Refractometer
+            ? Refractometer : null
         enabled: postShotReviewPage.visible
         function onTdsChanged(tds) {
             if (!isEditMode) return


### PR DESCRIPTION
## Summary

- After a fresh shot, the post-shot review page opens before the R2 has finished (re)connecting in the common case where the R2 is dormant. Until now, any TDS reading from the R2 in that window was silently dropped — no log, no recorded value.
- The fix re-evaluates the `Connections.target` binding when `BLEManager.refractometerConnected` flips true, so the `tdsChanged` handler wires up as soon as the R2 connects.

## Why

`Refractometer` is a QML context property that gets swapped between `null` and a live `DiFluidR2*` pointer over the app lifetime (main.cpp:1476, 1499, 1518, 1540). `setContextProperty` does **not** emit a Qt notify signal, so a `Connections { target: Refractometer }` binding that captured `null` at page-load time stays stuck on `null` forever — the handler never wires up even after the device connects.

The shape of the binding pre-fix:

```qml
target: (typeof Refractometer !== \"undefined\" && Refractometer) ? Refractometer : null
```

is reactive to nothing the runtime emits, so the only way it could ever resolve to the live pointer is if `Refractometer` happened to already be live the moment the page constructed. After a shot ends and the review page opens, the BLE rediscovery/reconnect cycle typically takes 5+ seconds — well after the page is up.

## Evidence

Real-world v1.7.4 build 3371 session log (Samsung Galaxy Tab):

```
t=241.107  Showing post-shot review page with shotId: 905
t=245.540  [BLE] Found refractometer: \"DiFluid R2 304050\"
t=246.969  [BLE DiFluidR2] Connected and ready for measurements
t=270.908  [Refractometer] tdsChanged 12.57   <- handler not wired
t=275.252  [Refractometer] tdsChanged 12.45
t=279.901  [Refractometer] tdsChanged 12.42
t=283.037  [Refractometer] tdsChanged 12.41
t=286.101  [Refractometer] tdsChanged 12.4
t=289.210  [Refractometer] tdsChanged 12.4
t=300.434  [Refractometer] tdsChanged 12.39
```

Seven readings, all well above the 3.0% plausibility floor, all dropped. Saved shot had `drinkTds = 0`.

## Fix

Chain the target binding through `BLEManager.refractometerConnected`, which is a `Q_PROPERTY` with a NOTIFY signal:

```qml
target: BLEManager.refractometerConnected
    && (typeof Refractometer !== \"undefined\") && Refractometer
    ? Refractometer : null
```

When the R2 finishes connecting, `refractometerConnectedChanged` invalidates the binding, QML re-evaluates, and the now-live `Refractometer` pointer becomes the target. Order of operations in main.cpp's `refractometerDiscovered` handler:

1. `mainController.setRefractometer(refractometer.get())` — no signal
2. `bleManager.setRefractometerDevice(refractometer.get())` — **emits** `refractometerConnectedChanged`
3. `engine.rootContext()->setContextProperty(\"Refractometer\", ...)` — no signal

All three execute synchronously before control returns to the Qt event loop, so by the time the queued binding re-evaluation runs, both `refractometerConnected` is true AND the context property is the live pointer. Safe.

## Test plan

- [x] Build clean (Qt Creator + ctest)
- [x] All 2049 existing tests pass
- [ ] Manual: pull a shot with the R2 disconnected, let the review page open, then take an R2 reading once it auto-connects — TDS should now populate the review page's `editDrinkTds` and EY should auto-calculate

🤖 Generated with [Claude Code](https://claude.com/claude-code)