### PR TITLE
fix(shotserver): guard sendResponse against socket UAF

### DIFF
--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -2634,9 +2634,19 @@ btn.textContent='Copied!';setTimeout(function(){btn.textContent='Copy'},2000);
     }
 }
 
-void ShotServer::sendResponse(QTcpSocket* socket, int statusCode, const QString& contentType,
+void ShotServer::sendResponse(QTcpSocket* rawSocket, int statusCode, const QString& contentType,
                                const QByteArray& body, const QByteArray& extraHeaders)
 {
+    // Raw socket pointers reach this function via posted QMetaCallEvents and
+    // multiple synchronous frames. If the peer drops the TCP connection while a
+    // queued event is in flight, onDisconnected → deleteLater can destroy the
+    // socket before/while we write. Wrap once in QPointer so a mid-call
+    // destruction reads as null rather than a UAF on the underlying QIODevice.
+    QPointer<QTcpSocket> socket(rawSocket);
+    if (!socket || socket->state() != QAbstractSocket::ConnectedState) {
+        return;
+    }
+
     QString statusText;
     switch (statusCode) {
         case 200: statusText = "OK"; break;
@@ -2665,10 +2675,11 @@ void ShotServer::sendResponse(QTcpSocket* socket, int statusCode, const QString&
     response.append("\r\n");
     response.append(body);
 
+    if (!socket) return;
     socket->write(response);
+    if (!socket) return;
     socket->flush();
-
-    // Reset idle timer — close connection if no new request arrives
+    if (!socket) return;
     resetKeepAliveTimer(socket);
 }
 
@@ -2765,8 +2776,13 @@ void ShotServer::sendFile(QTcpSocket* socket, const QString& path, const QString
     }
 }
 
-void ShotServer::sendRedirect(QTcpSocket* socket, const QString& location, const QString& setCookie)
+void ShotServer::sendRedirect(QTcpSocket* rawSocket, const QString& location, const QString& setCookie)
 {
+    // Same lifetime trap as sendResponse — guard against the socket being
+    // destroyed under us while the response is being constructed.
+    QPointer<QTcpSocket> socket(rawSocket);
+    if (!socket || socket->state() != QAbstractSocket::ConnectedState) return;
+
     QByteArray response;
     response.append("HTTP/1.1 302 Found\r\n");
     response.append(QString("Location: %1\r\n").arg(location).toUtf8());
@@ -2777,8 +2793,11 @@ void ShotServer::sendRedirect(QTcpSocket* socket, const QString& location, const
     response.append("Connection: keep-alive\r\n");
     response.append(QString("Keep-Alive: timeout=%1\r\n").arg(KEEPALIVE_TIMEOUT_S).toUtf8());
     response.append("\r\n");
+    if (!socket) return;
     socket->write(response);
+    if (!socket) return;
     socket->flush();
+    if (!socket) return;
     resetKeepAliveTimer(socket);
 }
 

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -2680,6 +2680,8 @@ void ShotServer::sendResponse(QTcpSocket* rawSocket, int statusCode, const QStri
     if (!socket) return;
     socket->flush();
     if (!socket) return;
+    // Arm the idle-close timer for HTTP keep-alive: drop the connection if no
+    // further request arrives within KEEPALIVE_TIMEOUT_S seconds.
     resetKeepAliveTimer(socket);
 }
 
@@ -2717,8 +2719,15 @@ void ShotServer::sendHtml(QTcpSocket* socket, const QString& html)
     sendResponse(socket, 200, "text/html; charset=utf-8", finalHtml.toUtf8());
 }
 
-void ShotServer::sendFile(QTcpSocket* socket, const QString& path, const QString& contentType)
+void ShotServer::sendFile(QTcpSocket* rawSocket, const QString& path, const QString& contentType)
 {
+    // waitForBytesWritten() below spins a local event loop, so unlike
+    // sendResponse the socket really can be destroyed mid-function via a
+    // deleteLater queued from onDisconnected. Hold a QPointer and re-check it
+    // after every operation that yields to the event loop.
+    QPointer<QTcpSocket> socket(rawSocket);
+    if (!socket || socket->state() != QAbstractSocket::ConnectedState) return;
+
     QFile file(path);
     if (!file.open(QIODevice::ReadOnly)) {
         sendResponse(socket, 404, "text/plain", "File not found");
@@ -2740,9 +2749,10 @@ void ShotServer::sendFile(QTcpSocket* socket, const QString& path, const QString
         "\r\n"
     ).arg(contentType).arg(fileSize).arg(filename).toUtf8();
 
+    if (!socket) return;
     if (socket->write(headers) == -1) {
         qWarning() << "ShotServer::sendFile: Failed to write headers -" << socket->errorString();
-        socket->abort();
+        if (socket) socket->abort();
         return;
     }
 
@@ -2756,21 +2766,26 @@ void ShotServer::sendFile(QTcpSocket* socket, const QString& path, const QString
             success = false;
             break;
         }
+        if (!socket) return;
         if (socket->write(chunk) == -1) {
             qWarning() << "ShotServer::sendFile: Socket write failed -" << socket->errorString();
             success = false;
             break;
         }
+        if (!socket) return;
         if (!socket->waitForBytesWritten(5000)) {
-            qWarning() << "ShotServer::sendFile: Write timed out";
+            // Either a write timeout OR the socket was destroyed by a
+            // deleteLater fired from the nested event loop above.
+            if (socket) qWarning() << "ShotServer::sendFile: Write timed out";
             success = false;
             break;
         }
     }
 
+    if (!socket) return;
     if (success) {
         socket->flush();
-        socket->disconnectFromHost();
+        if (socket) socket->disconnectFromHost();
     } else {
         socket->abort();
     }


### PR DESCRIPTION
## Summary

- Two reproducible Android crashes (#1132, #1133) from the same user, both with the user note **"Edit theme on Web server"**, both SIGSEGV in `QIODevice::write` called from `ShotServer::sendResponse`, both with the identical `#7→#6` offset delta (`0x46154`) — so the same call path each time.
- Stack: `QObject::event` → (queued lambda, frame #7) → `ShotServer::sendResponse` → `QIODevice::write+16`. `+16` is the prologue dereference of `this`, i.e. the `QTcpSocket` is destroyed when we try to write to it.
- Most likely sequence: theme edit posts a queued event (or the request body finishes streaming back via the `QThread::create` → `invokeMethod` path), the peer drops the TCP connection, `disconnected` → `onDisconnected` → `deleteLater` schedules destruction, but the queued response write still has the raw pointer on the stack and crashes when the deferred-delete fires before the write completes.

## Fix

Wrap the `QTcpSocket*` parameter in `QPointer<QTcpSocket>` at the very top of `sendResponse` and `sendRedirect`, bail if the socket is null or no longer in `ConnectedState`, and re-check the QPointer before each socket access (`write`, `flush`, `resetKeepAliveTimer`). A mid-call destruction now reads as null instead of UAF.

## Test plan

- [ ] Build Android, edit theme via web server, drop the browser connection mid-request (e.g. reload during a color edit), confirm no crash
- [ ] Normal theme-editing flow still works end-to-end (color edits round-trip, SSE notifications fire)
- [ ] Confirm no `qDebug()` spam for the dropped-write case (silent drop is the desired behavior)
- [ ] Existing ShotServer + MCP tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)