### PR TITLE
fix(history): use displayText in buildFilter so Gboard preedit reaches FTS (#1138)

### DIFF
--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -147,8 +147,10 @@ Page {
 
     function buildFilter() {
         var filter = {}
-        if (searchField.text.length > 0) {
-            var searchText = searchField.text
+        // Read displayText (not text) so the in-progress IME preedit on Gboard/Samsung
+        // is included — matches the onDisplayTextChanged trigger that scheduled this run.
+        if (searchField.displayText.length > 0) {
+            var searchText = searchField.displayText
 
             // Parse numeric keyword filters from search text
             // Syntax: keyword:N (exact), keyword:N-M (range), keyword:N+ (min only)


### PR DESCRIPTION
## Summary
- Fixes #1138 — Shot History search bar on Samsung/Android does not filter while typing, even after tapping Done.
- `buildFilter()` was still reading `searchField.text`, which is empty on Gboard until the preedit commits — so the debounced filter run always saw stale/empty text. Switching to `displayText` matches the `onDisplayTextChanged` trigger that scheduled the run.

## Why this slipped past #759
PR #759 fanned out the displayText fix to four search bars to make the IME preedit drive change detection. In ShotHistoryPage, the trigger was switched but `buildFilter()`'s read site was missed — so the timer fired, but with an empty `text` because Gboard hadn't committed yet. The sibling pages (ProfileSelector, SettingsSearchDialog, StringBrowserPage) already read `displayText` everywhere, so they were fine.

## Test plan
- [ ] On Samsung tablet with Gboard, open Shot History, tap the search field, type a few characters: the list should narrow live, before tapping Done.
- [ ] Tap Done; the filter remains applied with the same text.
- [ ] Clear button still appears/clears correctly.
- [ ] Numeric keyword search (e.g. `rating:5+`) still parses.
- [ ] Desktop / web behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)