### PR TITLE
docs(openspec): migrate-charting-to-qt-graphs — accelerate Stage 0 + 1 on 6.11.1

### DIFF
--- a/openspec/changes/migrate-charting-to-qt-graphs/proposal.md
+++ b/openspec/changes/migrate-charting-to-qt-graphs/proposal.md
@@ -1,12 +1,12 @@
 # Change: Migrate Charting from Qt Charts to Qt Graphs
 
-## Status: READY TO START — Qt 6.11.1 LANDED (consider waiting for Qt 6.12)
+## Status: STAGE 0 + STAGE 1 RECOMMENDED NOW (accelerated path)
 
 **Gates 1, 3, 4 are satisfied.** QTBUG-142046 is closed and fixed in Qt 6.11.0 (released 2026-03-23) via new `visualMin`/`visualMax` read-only properties on `QValueAxis` and `QDateTimeAxis`. `QXYSeries::replace(QList<QPointF>)` is `Q_INVOKABLE` from QML in 6.11.1 with docs explicitly noting it is "much faster than replacing data points one by one." Decenza upgraded to Qt 6.11.1 (released 2026-05-12) via the `upgrade-qt-6-11-1` change.
 
 **Gate 2 is open but the gaps are known and the Stage 0 bridge plan presumes they exist** — see "Re-evaluation against the released 6.11.1" below.
 
-**Strategic timing consideration: Qt 6.12 lands a `QCanvasPainter` rendering backend for Graphs** (feature-flagged, ships 2026-09-22). This is the same RHI path Decenza adopted for `CupFillView`. Starting Stage 0 on 6.11.1 is safe — switching the backend later is a one-line per-`GraphsView` change (`useCanvasPainter: true`) — but waiting for 6.12 GA means a single round of visual/perf validation against the long-term backend. See "Qt 6.12 Roadmap" section below.
+**Recommendation (revised 2026-05-13): start Stage 0 + Stage 1 on 6.11.1 now, do not wait for Qt 6.12 GA.** The primary motivation is **older-tablet CPU headroom**. Qt Charts is software-rasterized via the Graphics View Framework — every chart pixel is drawn by CPU. Qt Graphs on today's Quick Shapes backend (6.11.1) does CPU-side path triangulation then submits triangle meshes to the GPU via RHI for actual rasterization — meaningfully less CPU than Charts on its own. The 6.12 `QCanvasPainter` backend pushes more work to the GPU still, but enabling it on already-migrated graphs is a one-line `useCanvasPainter: true` flip per `GraphsView`, not a re-migration. The bridge components (`AutoRangingAxis`, `CustomLegend`, `DashedLineSeries`) are renderer-agnostic and outlive the backend choice. Stage 1 (`FlowCalibrationPage`) is the smallest graph in the app and is the cheap experiment that decides whether to charge ahead to Stages 2–3 or pause for 6.12 — see "Timing recommendation" in the Qt 6.12 Roadmap section.
 
 **Note on crosshair logic**: the fix is a new API (`visualMin`/`visualMax`) rather than a change to `min`/`max` behavior. `ShotGraph.qml`'s crosshair pixel↔data mapping must be updated to use `visualMin`/`visualMax` instead of `min`/`max`.
 
@@ -87,13 +87,31 @@ The four Stage 0 bridge components remain Decenza's responsibility:
 
 These are not on the 6.12 dev log; do not plan around them landing in 6.12.
 
-### Timing recommendation
+### Timing recommendation (revised 2026-05-13)
 
-If we start Stage 0 on 6.11.1 today, we land on the Quick Shapes backend. Switching to the `QCanvasPainter` backend after 6.12 ships is a per-`GraphsView` one-liner (`useCanvasPainter: true`) — not a re-migration. The Stage 0 bridges (`AutoRangingAxis`, `CustomLegend`, `DashedLineSeries`) are renderer-agnostic and would survive a backend switch.
+**Start Stage 0 + Stage 1 now on 6.11.1.** The cup-fill GPU migration that landed in `upgrade-qt-6-11-1` removed roughly 11 % of one core on the Decent tablet, but graph repainting is the larger remaining CPU cost on extraction-time UI — Qt Charts is fully software-rasterized. Today's Qt Graphs Quick Shapes backend already does GPU rasterization (CPU triangulates paths to meshes, GPU rasterizes via RHI); the 6.12 `QCanvasPainter` backend reduces the CPU prep further. Net: even pre-6.12 there is a real, measurable CPU win for slower tablets, and the 6.12 backend flip is a one-line follow-up per `GraphsView`.
 
-If we wait for Qt 6.12 GA (2026-09-22), we run visual/perf validation once against the long-term backend. ~4 calendar months of delay.
+**Why Stage 1 is the cheap experiment, not Stage 0:**
 
-There is no functional blocker either way. The decision is calendar-time vs. validation-rounds-cost.
+Stage 0 ships infrastructure only (`Qt6::Graphs` linked, three bridge components, no user-visible change). Stage 1 migrates `FlowCalibrationPage` (the smallest graph in the app, ~272 lines) — that is the first place a real before/after CPU/FPS measurement is possible. The decision tree at the end of Stage 1:
+
+- **If Stage 1 measurement shows measurable CPU drop on the Decent tablet** → continue immediately to Stages 2–3.
+- **If Stage 1 is neutral or worse** → pause, wait for 6.12 GA (2026-09-22), flip `useCanvasPainter: true`, re-measure. Stage 0 + 1 work is not wasted — the bridges are reusable and the migration pattern is validated.
+
+**Estimated cost of Stage 0 + Stage 1: 4–6 focused days, worst case ~1.5 weeks** if `GraphsView.plotArea` has edge cases during axis animation. Breakdown:
+
+- `AutoRangingAxis.qml` — ~50 lines, logic-only, ½ day.
+- `CustomLegend.qml` — ~100 lines themed via `Theme.qml` (will visually match the rest of the app better than Qt Charts' Widget-styled built-in legend), ~1 day.
+- `DashedLineSeries.qml` — ~150 lines; `ShapePath` overlay with data→pixel mapping via `GraphsView.plotArea`. Trickiest piece; 1–2 days. `FlowCalibrationPage` doesn't zoom, so any `plotArea` edge cases discovered here are bounded.
+- Stage 0 build wiring + 0.2 spike — ½–1 day.
+- Stage 1 `FlowCalibrationPage` migration + measurement — ~1 day, mostly mechanical (`ChartView` → `GraphsView`, swap axis/legend types, replace dashed goal-curve with the new overlay).
+
+**Visual risk areas (small):**
+
+- Axis label text moves from `QPainter::drawText` to `QQuickText` scene-graph rendering — usually sharper, but subtly different. On the tablet this typically reads as a slight improvement.
+- 1px-wide series at very thin widths may antialias differently between CPU and GPU. Goal curves (2px+) are unaffected.
+
+The bigger items (Stages 2–3, the espresso graph family) only get scheduled after the Stage 1 measurement is in hand. So the worst case for accelerating is: 4–6 days produces a real measurement and three reusable bridge components, then a defensible pause.
 
 ## What Changes
 

--- a/openspec/changes/migrate-charting-to-qt-graphs/tasks.md
+++ b/openspec/changes/migrate-charting-to-qt-graphs/tasks.md
@@ -22,10 +22,15 @@ This section's tasks run until the gate conditions in `proposal.md` are satisfie
 ### P.3 Earliest checkpoint: Qt 6.11.1 release
 - [x] **Done 2026-05-13** — Qt 6.11.1 shipped 2026-05-12 and Decenza upgraded via the `upgrade-qt-6-11-1` change (archived 2026-05-13). Full gate-condition audit performed against the released 6.11.1 docs + the Qt Graphs 2D migration guide. Result captured in `proposal.md` under "Re-evaluation against the released 6.11.1": gates 1 + 3 + 4 satisfied; gate 2 (feature parity) remains formally open but the Stage 0 plan was always designed to build the missing bridges (`AutoRangingAxis`, `CustomLegend`, `DashedLineSeries`) in-tree. Pragmatic reading: gates effectively reduce to "Qt 6.11.x + bulk-replace + visualMin/Max" — all met.
 
-### P.4 Qt 6.12 monitoring (active until 6.12 GA, 2026-09-22)
+### P.4 Qt 6.12 monitoring (active until 6.12 GA, 2026-09-22) — runs alongside Stages 0 + 1
 - [ ] Watch `qt/qtgraphs.git` `dev` branch for landings up to feature freeze 2026-05-29. Two major items already landed: `QCanvasPainter` backend ([QTBUG-140734](https://qt-project.atlassian.net/browse/QTBUG-140734)) and declarative XYSeries data API (QTBUG-134005, QTBUG-141139). See `proposal.md` "Qt 6.12 Roadmap" section.
 - [ ] At each 6.12 beta (2026-06-11 / 2026-07-16 / 2026-08-18), re-check `dev` log for any new legend / auto-ranging / dashed-stroke / coord-mapping landings. None present as of 2026-05-13; do not plan around them appearing.
-- [ ] At 6.12 RC (2026-09-08) or GA (2026-09-22), make the start-now-vs-wait decision in `proposal.md` "Timing recommendation": either begin Stage 0 on 6.11.1 (and treat `useCanvasPainter: true` as a follow-up after 6.12) or wait for 6.12 GA and validate once against the long-term backend.
+- [ ] At 6.12 GA (2026-09-22): once Decenza upgrades to 6.12 (a separate `upgrade-qt-6-12` change), flip `useCanvasPainter: true` per `GraphsView` on every graph migrated so far and re-measure. One-line per file; no re-migration.
+
+### P.5 Decision after Stage 1 measurement (cheap-experiment gate)
+- [ ] **After Stage 1 (`FlowCalibrationPage`) ships and a real CPU/FPS measurement is recorded on the Decent tablet during a Flow Calibration pour**, decide whether to continue:
+  - If CPU usage / FPS shows a measurable win on the Quick Shapes backend → schedule Stages 2 + 3.
+  - If neutral or worse → pause Stages 2 + 3 until Qt 6.12 GA, flip the `QCanvasPainter` backend (`useCanvasPainter: true`) on the already-migrated graphs, re-measure. Stage 0 infrastructure + Stage 1 migration are not wasted — they carry forward unchanged.
 
 ## Stage 0 — Foundation
 


### PR DESCRIPTION
## Summary

Revises the migration timing recommendation: **start Stage 0 + Stage 1 on 6.11.1 now, do not wait for Qt 6.12 GA**.

After the cup-fill GPU migration shipped (≈11 % of one core freed on the Decent tablet — see #1101), the older-tablet CPU headroom story shifts the math: graph repainting is the larger remaining CPU cost on extraction-time UI, and Qt Charts is fully software-rasterized. Today's Qt Graphs Quick Shapes backend already does GPU rasterization via RHI (CPU triangulates → GPU rasterizes) and is a measurable win over Charts. The 6.12 `QCanvasPainter` backend reduces CPU prep further, but flipping it on already-migrated graphs is a one-line `useCanvasPainter: true` change per `GraphsView` — not a re-migration.

## Approach

Stage 0 + Stage 1 on 6.11.1 as a bounded experiment. Stage 1 is `FlowCalibrationPage` — the smallest graph in the app (~272 lines) and the first place a real before/after CPU/FPS measurement is possible on the tablet.

**Decision tree after Stage 1:**
- Measurable win on Quick Shapes → continue immediately to Stages 2 + 3.
- Neutral / worse → pause, wait for 6.12 GA, flip the backend, re-measure. Stage 0 + Stage 1 work carries forward unchanged.

## Cost

Stage 0 + Stage 1: **4–6 focused days** (worst case ~1.5 weeks if `GraphsView.plotArea` has edge cases). Breakdown inline in the proposal:
- `AutoRangingAxis.qml` ~50 lines, ½ day
- `CustomLegend.qml` ~100 lines, themed via `Theme.qml`, ~1 day
- `DashedLineSeries.qml` ~150 lines (trickiest piece — `plotArea` coord mapping), 1–2 days
- Stage 0 build wiring + 0.2 spike: ½–1 day
- Stage 1 mechanical migration: ~1 day

## Files

- `openspec/changes/migrate-charting-to-qt-graphs/proposal.md` — Status line flipped to "STAGE 0 + STAGE 1 RECOMMENDED NOW"; Timing recommendation section rewritten with the cost breakdown and the post-Stage-1 decision tree.
- `openspec/changes/migrate-charting-to-qt-graphs/tasks.md` — new P.5 codifying the Stage-1-measurement gate; P.4 narrowed to "monitor 6.12 dev + flip the backend at GA."

No behaviour change; `openspec validate migrate-charting-to-qt-graphs` clean.

## Test plan

- [x] `openspec validate migrate-charting-to-qt-graphs` passes.
- [x] Docs-only; no code/build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)