### PR TITLE
feat: migrate charting from Qt Charts to Qt Graphs (Stages 2–4)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -65,7 +65,7 @@ jobs:
           version: '6.11.1'
           target: 'android'
           arch: 'android_arm64_v8a'
-          modules: 'qtquick3d qtshadertools qtcharts qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtimageformats qtcanvaspainter'
+          modules: 'qtquick3d qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtimageformats qtcanvaspainter'
           install-deps: false  # Skip apt-get of 61 desktop packages — only libegl1/libgl1 needed for qsb shader compiler
           cache: true
           cache-key-prefix: 'qt-android-v1'

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -75,7 +75,7 @@ jobs:
           version: '6.11.1'
           target: 'ios'
           arch: 'ios'
-          modules: 'qtquick3d qtshadertools qtcharts qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtimageformats qtcanvaspainter'
+          modules: 'qtquick3d qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtimageformats qtcanvaspainter'
           cache: true
           cache-key-prefix: 'qt-ios-v4'
 

--- a/.github/workflows/linux-arm64-release.yml
+++ b/.github/workflows/linux-arm64-release.yml
@@ -73,7 +73,7 @@ jobs:
           version: '6.11.1'
           target: 'desktop'
           arch: 'linux_gcc_arm64'
-          modules: 'qtshadertools qtcharts qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtserialport qtimageformats qtcanvaspainter'
+          modules: 'qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtserialport qtimageformats qtcanvaspainter'
           cache: true
           cache-key-prefix: 'qt-linux-arm64-v1'
 

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -73,7 +73,7 @@ jobs:
           version: '6.11.1'
           target: 'desktop'
           arch: 'linux_gcc_64'
-          modules: 'qtquick3d qtshadertools qtcharts qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtserialport qtimageformats qtcanvaspainter'
+          modules: 'qtquick3d qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtserialport qtimageformats qtcanvaspainter'
           cache: true
           cache-key-prefix: 'qt-linux-v4'
 

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -56,7 +56,7 @@ jobs:
           version: '6.11.1'
           target: 'desktop'
           arch: 'clang_64'
-          modules: 'qtquick3d qtshadertools qtcharts qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtwebengine qtserialport qtimageformats qtcanvaspainter'
+          modules: 'qtquick3d qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtwebengine qtserialport qtimageformats qtcanvaspainter'
           cache: true
           cache-key-prefix: 'qt-macos-v2'
 

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -58,7 +58,7 @@ jobs:
           version: '6.11.1'
           target: 'desktop'
           arch: 'win64_msvc2022_64'
-          modules: 'qtquick3d qtshadertools qtcharts qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtserialport qtimageformats qtcanvaspainter'
+          modules: 'qtquick3d qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtserialport qtimageformats qtcanvaspainter'
           tools: 'tools_ninja'
           cache: true
           cache-key-prefix: 'qt-windows-v3-aqt-master'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,6 @@ find_package(Qt6 REQUIRED COMPONENTS
     Quick
     QuickControls2
     Bluetooth
-    Charts
     Graphs
     Svg
     Multimedia
@@ -552,7 +551,6 @@ target_link_libraries(Decenza PRIVATE
     Qt6::Quick
     Qt6::QuickControls2
     Qt6::Bluetooth
-    Qt6::Charts
     Qt6::Graphs
     Qt6::Svg
     Qt6::Multimedia

--- a/docs/CLAUDE_MD/PERFORMANCE_BASELINE.md
+++ b/docs/CLAUDE_MD/PERFORMANCE_BASELINE.md
@@ -1,0 +1,143 @@
+# Charts Migration Performance Baseline
+
+Measurement protocol for the `migrate-charting-to-qt-graphs` change. Numbers recorded here drive the P.5 decision at the end of Stage 1: continue to Stages 2–3 now on the Qt 6.11 Quick Shapes backend, or pause until Qt 6.12 GA and flip `useCanvasPainter: true` on the migrated views.
+
+The protocol is identical for the **pre-migration** Qt Charts build and the **post-migration** Qt Graphs build. The win (or null result) is the delta between the two runs on the same hardware.
+
+## Primary device
+
+| | |
+|---|---|
+| Tablet | Samsung SM-X210 (Decent tablet) |
+| Android | API level shipped on the device — do not update mid-protocol |
+| App build | Release configuration, `qmake`/CMake `Release`, signed APK from the same commit |
+| Power | Plugged in via the DE1 USB-C charger; screen at 100 % brightness, auto-rotation locked to landscape |
+| Background apps | Force-stop everything other than Decenza before each run |
+
+Comparison points: a Windows dev machine and macOS run from the same commit. Tablet numbers are authoritative; desktop numbers only flag gross regressions that the tablet would also see — but for the P.5 directional decision, a clean Charts-vs-Graphs delta on a single Mac is enough to tell whether the new backend is helping or hurting per-frame CPU.
+
+### Measuring on macOS (no DE1)
+
+Without a real machine to pair, drive the live-shot graph from the in-app simulator (Settings → Developer / Demo Mode, or whichever flag your branch uses to feed canned pressure/flow/temperature/weight curves). The absolute frame timings on a desktop GPU are not comparable to the tablet, but the **Charts-vs-Graphs delta on the same Mac, same commit-pair, same simulator profile** is a valid directional signal.
+
+- Build Release in Qt Creator (`Release` build config). Debug builds dominate the numbers with Qt-internal asserts and overwhelm the renderer cost we care about.
+- Launch from Terminal so `QSG_RENDER_TIMING=1` is in the environment, e.g.:
+  ```
+  QSG_RENDER_TIMING=1 ./build-Decenza-Desktop_Qt_6_11_1_clang_kit-Release/Decenza.app/Contents/MacOS/Decenza
+  ```
+  Scene-graph timing lines stream to stderr — `tee` them to a file for offline diffing.
+- Run on the Mac's internal display (no external monitor) at a fixed refresh rate so the 60 Hz frame budget is constant between runs.
+- Memory comparison: macOS Activity Monitor → "Memory" column reading after 50 history rows have been opened. Not as precise as `dumpsys meminfo`, but adequate for the directional check.
+- Skip the "Memory Graphics line" row in the result template (Android-only). Add a single "Mac RSS (MB)" row for the directional check.
+
+## Four metrics
+
+### 1. Live shot FPS during a 30-second pour
+
+The most important number. Measures the cost of redrawing pressure / flow / temperature / weight series at the live update rate during the densest extraction phase.
+
+**Setup**
+- `export QSG_RENDER_TIMING=1` before launching the app (Android: `adb shell setprop debug.qt.qsg_render_timing 1` then restart the process)
+- Pair a real DE1 (not the simulator) — simulator throttles output and produces unrepresentative timings
+- Use the `decenza-default` profile so the pour is reproducible (long pressure-ramp + sustained 9 bar plateau)
+- Place a real puck in the portafilter — a blind shot has different timing because the pressure curve saturates earlier
+
+**Procedure**
+1. Open the shot graph page (`ShotGraph` in espresso mode)
+2. Start the shot; let the preinfusion phase pass
+3. Begin a 30-second wall-clock window when pressure first crosses 6 bar
+4. End the window 30 s later
+5. Save the run; pull `adb logcat -d` and grep for `qt.scenegraph.time.renderer` lines
+
+**Record**
+- Mean frame time (ms) across the window
+- 95th-percentile frame time (ms)
+- Frame-drop count: number of frames slower than 16.7 ms
+- Subjective: any visible stutter? Note phase if so.
+
+### 2. Shot history scroll FPS
+
+Stresses many `HistoryShotGraph` instances rendered into list rows simultaneously. The list virtualises but each visible row owns a full graph.
+
+**Setup**
+- Database must contain ≥200 shots. Use a backup loaded via the data-migration flow if the device is fresh.
+- Cold start the app — do not run this immediately after the live-pour measurement (GPU/CPU thermal state matters)
+
+**Procedure**
+1. Navigate to Shot History
+2. Flick from the top to the bottom at a constant pace, ~1 page per second
+3. Then flick back to the top
+4. Repeat three times
+
+**Record**
+- Mean frame time (ms) over the scroll
+- Any visible blank/placeholder rows during scroll (yes/no)
+- Subjective smoothness on a 1–5 scale
+
+### 3. Graph first-paint latency
+
+How long from "show the graph page" to "graph is fully drawn with axes, legend, and series visible". Affects perceived snappiness when switching pages.
+
+**Procedure**
+1. From the main screen, tap the entry that opens the live shot graph
+2. Stopwatch (or trace) the time until the goal curve and axes are fully painted
+3. Repeat five times, drop the first (cache warm-up), report the mean of four
+
+A `Performance.now()`-style timestamp inside the QML `Component.onCompleted` of the graph view is acceptable instead of a stopwatch — log it and read from `adb logcat`.
+
+### 4. Memory footprint with 50 shots open
+
+Indirect proxy for renderer allocations. Qt Graphs uses scene-graph nodes; Qt Charts uses a `QGraphicsView`. Their resident-memory profiles differ.
+
+**Setup**
+- Cold start
+- Open Shot History
+- Scroll until 50 rows have been instantiated and torn down (use the visible-rows counter if available, or estimate ~5 swipes)
+
+**Record** (`adb shell dumpsys meminfo io.github.kulitorum.decenza_de1 | head -40`)
+- Total PSS (kB)
+- Java heap (kB)
+- Native heap (kB)
+- Graphics (kB) — this is the line most likely to change between backends
+
+## Two runs, one commit each
+
+Run the full protocol twice from the same hardware state:
+
+1. **Pre-migration**: `git checkout <commit immediately before PR #1144>` → rebuild release → install → measure
+2. **Post-migration**: `git checkout main` (or the latest Stage 1 commit) → rebuild release → install → measure
+
+Do not reuse old measurements from before the Qt 6.11.1 upgrade — that upgrade itself shifted the cup-fill cost and the comparison would be muddied.
+
+## Result template
+
+Copy this block into the Stage 1 PR description (or into a comment on the migration tracking issue) when the runs complete:
+
+```
+Hardware: Samsung SM-X210, Decenza <git-sha>, Qt 6.11.1
+Profile: decenza-default, real DE1, real puck
+
+| Metric                          | Qt Charts (pre) | Qt Graphs (post) | Δ           |
+| ------------------------------- | --------------- | ---------------- | ----------- |
+| Live shot mean frame time (ms)  |                 |                  |             |
+| Live shot p95 frame time (ms)   |                 |                  |             |
+| Live shot dropped frames (n)    |                 |                  |             |
+| History scroll mean (ms)        |                 |                  |             |
+| History scroll subjective (1-5) |                 |                  |             |
+| First-paint latency (ms)        |                 |                  |             |
+| Memory Graphics line (kB)       |                 |                  |             |
+| Memory Native heap (kB)         |                 |                  |             |
+```
+
+## Decision rule (P.5)
+
+Defined in `openspec/changes/migrate-charting-to-qt-graphs/tasks.md` §P.5. Repeated here for convenience:
+
+- **Measurable CPU drop / FPS improvement** on the live-shot metric → schedule Stages 2 + 3 immediately on the 6.11 Quick Shapes backend.
+- **Neutral or worse** → pause Stages 2 + 3 until Qt 6.12 GA (2026-09-22). After Decenza upgrades to 6.12, flip `useCanvasPainter: true` on `FlowCalibrationPage`, re-measure, then re-decide.
+
+A "measurable" win on the tablet is a clear sustained delta on the live-shot mean frame time at a minimum, not a noisy single-millisecond difference. The bridge components and the migration pattern carry forward unchanged either way.
+
+## Re-running after Qt 6.12
+
+When Decenza upgrades to Qt 6.12 (separate `upgrade-qt-6-12` change) and the `useCanvasPainter: true` flip lands on each migrated `GraphsView` (tracked in `charts-qt-6-12-polish`), re-run the protocol against the latest migrated graph. Append the results to the table; do not overwrite the 6.11 row — both rows are useful for future decisions.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -3,7 +3,7 @@ context: |
   communicating over BLE. It manages extraction profiles, steaming, hot water, flushing, scale
   integration, shot history, and visualizer.coffee upload.
 
-  Tech stack: C++17, Qt 6.11.1 (QML/Quick Controls 2 UI; Qt Charts + Qt Graphs both linked during the charting migration), CMake, SQLite, Eclipse Paho MQTT C.
+  Tech stack: C++17, Qt 6.11.1 (QML/Quick Controls 2 UI; Qt Graphs for charting), CMake, SQLite, Eclipse Paho MQTT C.
   Platforms: Windows, macOS, Linux, Android (API 28+), iOS (17.0+).
   CI/CD: GitHub Actions (tag-push triggers builds; iOS uploads to App Store).
 

--- a/qml/components/ComparisonGraph.qml
+++ b/qml/components/ComparisonGraph.qml
@@ -73,7 +73,8 @@ Item {
     // Axis is stored as a string key, not a direct id reference: this property
     // initialiser runs before GraphsView and its child ValueAxes are constructed,
     // so direct ids would resolve to null and the `var` binding wouldn't re-fire
-    // when the axes appear. The delegate resolves the key to a real axis below.
+    // when the axes appear. The delegate calls chart._axisFor(curveDef.axisKey)
+    // at bind time, by which point every axis id is valid.
     readonly property var _curves: [
         { key: "pressure",              axisKey: "pressure", color: Theme.pressureColor,             width: Theme.graphLineWidth,                 advanced: false, showFlag: "showPressure" },
         { key: "flow",                  axisKey: "pressure", color: Theme.flowColor,                 width: Theme.graphLineWidth,                 advanced: false, showFlag: "showFlow" },
@@ -385,6 +386,8 @@ Item {
         property real max: 12
     }
 
+    // Initial values only — _updateDCdtAxis() rewrites min/max from the actual
+    // data range every time shotsChanged fires.
     QtObject {
         id: dCdtAxis
         property real min: 0

--- a/qml/components/ComparisonGraph.qml
+++ b/qml/components/ComparisonGraph.qml
@@ -1,25 +1,19 @@
 import QtQuick
-import QtCharts
+import QtGraphs
 import Decenza
+import "graphs"
 
-ChartView {
+// Outer Item wraps the GraphsView so all 30 trace overlays (3 shots × 10
+// curves), the Canvas phase markers, the crosshair, and phase labels render
+// as siblings on top of the chart. GraphsView's scene-graph paints over any
+// direct QQuickItem children — overlays must be siblings, not children.
+Item {
     id: chart
-    antialiasing: true
-    backgroundColor: "transparent"
-    plotAreaColor: Qt.darker(Theme.surfaceColor, 1.3)
-    legend.visible: false
-
-    margins.top: 0
-    margins.bottom: 0
-    margins.left: 0
-    margins.right: 0
 
     // Shot comparison model
     property var comparisonModel: null
 
     // Visibility toggles for curve types (shared with HistoryShotGraph via Settings).
-    // Settings.boolValue() coerces QSettings' INI-backed strings to real booleans;
-    // see Settings.h.
     property bool showPressure: Settings.boolValue("graph/showPressure", true)
     property bool showFlow: Settings.boolValue("graph/showFlow", true)
     property bool showTemperature: Settings.boolValue("graph/showTemperature", true)
@@ -55,31 +49,107 @@ ChartView {
     // Crosshair / inspect state
     property bool inspecting: false
     property real inspectTime: 0
-    // Computed binding so the line stays correct when plotArea resizes
     readonly property real inspectPixelX: inspecting
-        ? chart.plotArea.x + (inspectTime / timeAxis.max) * chart.plotArea.width
+        ? graphsView.plotArea.x + (inspectTime / timeAxis.max) * graphsView.plotArea.width
         : 0
-    // Array of { dateTime, hasTemperature, temperature, hasFlow, flow, hasWeight, weight }
     property var inspectShotValues: []
 
-    // Load data from comparison model
-    function loadData() {
+    // Alias so DashedLineSeries delegates can reach the GraphsView without
+    // writing `graphsView: graphsView` — that RHS shadows the delegate's own
+    // `graphsView` property (which defaults to `parent`) and resolves to null.
+    readonly property alias graphsViewRef: graphsView
+
+    // === Curve definitions driving the 3-shot × 10-curve Repeater ===
+    //
+    // Each curve names its model accessor (Q_INVOKABLE QVariantList getter), the
+    // axisY holder to map against, its colour, stroke width, and the show-flag
+    // gating visibility. fnY is optional: if set, the y values from the model
+    // are transformed before the dashed overlay reads them (currently used for
+    // the /5 weight rescale that keeps weight in the same visual range as
+    // pressure, matching the legacy comparison view).
+    // Axis is stored as a string key, not a direct id reference: this property
+    // initialiser runs before GraphsView and its child ValueAxes are constructed,
+    // so direct ids would resolve to null and the `var` binding wouldn't re-fire
+    // when the axes appear. The delegate resolves the key to a real axis below.
+    readonly property var _curves: [
+        { key: "pressure",              axisKey: "pressure", color: Theme.pressureColor,             width: Theme.graphLineWidth,                 advanced: false, showFlag: "showPressure" },
+        { key: "flow",                  axisKey: "pressure", color: Theme.flowColor,                 width: Theme.graphLineWidth,                 advanced: false, showFlag: "showFlow" },
+        { key: "temperature",           axisKey: "temp",     color: Theme.temperatureColor,          width: Theme.graphLineWidth,                 advanced: false, showFlag: "showTemperature" },
+        { key: "weight",                axisKey: "weight",   color: Theme.weightColor,               width: Math.max(1, Theme.graphLineWidth-1),  advanced: false, showFlag: "showWeight" },
+        { key: "weightFlow",            axisKey: "pressure", color: Theme.weightFlowColor,           width: Math.max(1, Theme.graphLineWidth-1),  advanced: false, showFlag: "showWeightFlow" },
+        { key: "resistance",            axisKey: "pressure", color: Theme.resistanceColor,           width: Math.max(1, Theme.graphLineWidth-1),  advanced: true,  showFlag: "showResistance" },
+        { key: "conductance",           axisKey: "pressure", color: Theme.conductanceColor,          width: Math.max(1, Theme.graphLineWidth-1),  advanced: true,  showFlag: "showConductance" },
+        { key: "conductanceDerivative", axisKey: "dCdt",     color: Theme.conductanceDerivativeColor,width: Math.max(1, Theme.graphLineWidth-1),  advanced: true,  showFlag: "showConductanceDerivative" },
+        { key: "darcyResistance",       axisKey: "pressure", color: Theme.darcyResistanceColor,      width: Math.max(1, Theme.graphLineWidth-1),  advanced: true,  showFlag: "showDarcyResistance" },
+        { key: "temperatureMix",        axisKey: "temp",     color: Theme.temperatureMixColor,       width: Math.max(1, Theme.graphLineWidth-1),  advanced: true,  showFlag: "showTemperatureMix" }
+    ]
+
+    function _axisFor(axisKey) {
+        switch (axisKey) {
+            case "pressure": return pressureAxis
+            case "temp":     return tempAxis
+            case "weight":   return weightAxis
+            case "dCdt":     return dCdtAxis
+            default:         return pressureAxis
+        }
+    }
+
+    // Per-shot stroke styles. Shot 0 solid, 1 dashed, 2 dash-dot — matches the
+    // legacy Qt Charts comparison view that used Qt.SolidLine / DashLine / DashDotLine.
+    readonly property var _shotStyles: [
+        { dashed: false, pattern: [4, 4] },
+        { dashed: true,  pattern: [6, 5] },
+        { dashed: true,  pattern: [10, 4, 2, 4] }
+    ]
+
+    // Fetch a curve's points for a given shot, applying any per-curve transform
+    // (currently just the /5 weight rescale). _dataVersion is read so the
+    // binding re-fires when comparisonModel.shotsChanged emits (shotCount is
+    // its NOTIFY-attached read property). Static dispatch on the curve key —
+    // QML's Q_INVOKABLE bracket-access doesn't reliably work cross-version,
+    // so we call each accessor by name.
+    function _curvePoints(shotIdx, key) {
+        var _ = _dataVersion
+        if (!comparisonModel) return []
+        var data
+        switch (key) {
+            case "pressure":              data = comparisonModel.getPressureData(shotIdx); break
+            case "flow":                  data = comparisonModel.getFlowData(shotIdx); break
+            case "temperature":           data = comparisonModel.getTemperatureData(shotIdx); break
+            case "weight":                data = comparisonModel.getWeightData(shotIdx); break
+            case "weightFlow":            data = comparisonModel.getWeightFlowRateData(shotIdx); break
+            case "resistance":            data = comparisonModel.getResistanceData(shotIdx); break
+            case "conductance":           data = comparisonModel.getConductanceData(shotIdx); break
+            case "conductanceDerivative": data = comparisonModel.getConductanceDerivativeData(shotIdx); break
+            case "darcyResistance":       data = comparisonModel.getDarcyResistanceData(shotIdx); break
+            case "temperatureMix":        data = comparisonModel.getTemperatureMixData(shotIdx); break
+            default:                      return []
+        }
+        if (key === "weight") {
+            var scaled = []
+            for (var i = 0; i < data.length; i++) {
+                scaled.push({ x: data[i].x, y: data[i].y / 5.0 })
+            }
+            return scaled
+        }
+        return data
+    }
+
+    // Bumps every time the comparison model's shot list changes — used as a
+    // read-dependency in every points binding so they re-evaluate then.
+    readonly property int _dataVersion: comparisonModel ? comparisonModel.shotCount : 0
+
+    // === Axis fitting (timeAxis stretches to maxTime + padding; dCdtAxis fits the data) ===
+
+    function _niceTimeAxisStep(span) {
+        if (span <= 5)  return 1
+        if (span <= 10) return 2
+        if (span <= 30) return 5
+        return 10
+    }
+
+    function _updateTimeAxis() {
         if (!comparisonModel) return
-
-        // Bulk-populate all 3 shot slots via C++ QXYSeries::replace() — out-of-range
-        // indices clear the series automatically.
-        comparisonModel.populateSeries(0, pressure1, flow1, temp1, weight1, weightFlow1, resistance1)
-        comparisonModel.populateSeries(1, pressure2, flow2, temp2, weight2, weightFlow2, resistance2)
-        comparisonModel.populateSeries(2, pressure3, flow3, temp3, weight3, weightFlow3, resistance3)
-        comparisonModel.populateAdvancedSeries(0, conductance1, conductanceDerivative1, darcyResistance1, temperatureMix1)
-        comparisonModel.populateAdvancedSeries(1, conductance2, conductanceDerivative2, darcyResistance2, temperatureMix2)
-        comparisonModel.populateAdvancedSeries(2, conductance3, conductanceDerivative3, darcyResistance3, temperatureMix3)
-
-        // Fit time axis to the later of the longest extraction duration or
-        // any phase-marker time (defensive — handles edge cases where a
-        // marker lands just past duration). Post-End samples (scale dribble
-        // etc.) are clipped to match the live graph. Small pixel-based
-        // padding keeps markers off the right edge.
         var markerMaxTime = 0
         for (var pmi = 0; pmi < comparisonModel.shotCount; pmi++) {
             var pmMarkers = comparisonModel.getPhaseMarkers(pmi)
@@ -88,20 +158,24 @@ ChartView {
             }
         }
         var axisEnd = Math.max(comparisonModel.maxTime, markerMaxTime)
-        var plotWidth = Math.max(1, chart.plotArea.width)
+        var plotWidth = Math.max(1, graphsView.plotArea.width)
         var paddingPx = Theme.scaled(5)
         var scale = plotWidth / Math.max(1, plotWidth - paddingPx)
-        timeAxis.max = Math.max(15, axisEnd * scale)
+        // Fit to data with a 5 s floor — short shots still fill the plot. Match
+        // ShotGraph/SteamGraph dynamic tickInterval so labels stay readable from
+        // a 5 s pour through a 60 s+ extraction.
+        timeAxis.max = Math.max(5, axisEnd * scale)
+        timeAxis.tickInterval = _niceTimeAxisStep(timeAxis.max)
+    }
 
-        // Fit dC/dt axis to data. Min extends below zero only when the data
-        // actually dips negative (exact values via crosshair).
+    function _updateDCdtAxis() {
+        if (!comparisonModel) return
         var dCdtMax = 0, dCdtMin = 0
-        var dCdtSeries = [conductanceDerivative1, conductanceDerivative2, conductanceDerivative3]
-        for (var s = 0; s < dCdtSeries.length; s++) {
-            for (var i = 0; i < dCdtSeries[s].count; i++) {
-                var y = dCdtSeries[s].at(i).y
-                if (y > dCdtMax) dCdtMax = y
-                if (y < dCdtMin) dCdtMin = y
+        for (var s = 0; s < comparisonModel.shotCount; s++) {
+            var pts = comparisonModel.getConductanceDerivativeData(s)
+            for (var i = 0; i < pts.length; i++) {
+                if (pts[i].y > dCdtMax) dCdtMax = pts[i].y
+                if (pts[i].y < dCdtMin) dCdtMin = pts[i].y
             }
         }
         var padded = dCdtMax * 1.15
@@ -114,8 +188,13 @@ ChartView {
         else posMax = Math.ceil(padded / 5) * 5
         dCdtAxis.max = posMax
         dCdtAxis.min = dCdtMin < 0 ? -Math.abs(dCdtMin) * 1.15 : 0
+    }
 
-        // Build phase marker list (phaseIndex = stable color index per unique label)
+    // Build phaseData + hiddenPhaseLabels, and seed the inspect crosshair at
+    // the second-to-last phase (the default-visible one).
+    function _rebuildPhaseData() {
+        if (!comparisonModel) { phaseData = []; return }
+
         var phases = []
         var phaseIndexMap = {}, nextPhaseIndex = 0
         for (var pi = 0; pi < comparisonModel.shotCount; pi++) {
@@ -130,7 +209,7 @@ ChartView {
         }
         phaseData = phases
 
-        // Default visibility: hide all phases except the last 2 labels
+        // Default visibility: hide all phase labels except the last 2 unique ones.
         var uniqueLabels = []
         var seenLabels = {}
         for (var ui = 0; ui < phases.length; ui++) {
@@ -143,7 +222,7 @@ ChartView {
         }
         hiddenPhaseLabels = hidden
 
-        // Set crosshair at the default-visible phase (second-to-last): average time across shots
+        // Seed crosshair at the default-visible second-to-last phase, averaged across shots.
         if (uniqueLabels.length >= 2) {
             var targetLabel = uniqueLabels[uniqueLabels.length - 2]
             var timeSum = 0, timeCount = 0
@@ -156,29 +235,23 @@ ChartView {
         }
     }
 
-    // Find the Y value in a LineSeries closest to the given time
-    function findValueAtTime(series, time) {
-        if (series.count === 0) return null
-        var closest = series.at(0)
-        var minDist = Math.abs(closest.x - time)
-        for (var i = 1; i < series.count; i++) {
-            var p = series.at(i)
-            var dist = Math.abs(p.x - time)
-            if (dist < minDist) {
-                closest = p
-                minDist = dist
-            } else if (dist > minDist) {
-                break  // sorted by x, so we passed the closest
-            }
-        }
-        return minDist < 1.0 ? closest.y : null
+    function _refreshAll() {
+        _updateTimeAxis()
+        _updateDCdtAxis()
+        _rebuildPhaseData()
     }
 
-    // Show crosshair at a pixel position and build per-shot inspect values
+    // === Inspect / crosshair ===
+
+    function _timeAtPixel(pixelX) {
+        var plot = graphsView.plotArea
+        if (!plot || plot.width <= 0) return -1
+        return timeAxis.min + (pixelX - plot.x) / plot.width * (timeAxis.max - timeAxis.min)
+    }
+
     function inspectAtPosition(pixelX, pixelY) {
         if (!comparisonModel) return
-        var dataPoint = chart.mapToValue(Qt.point(pixelX, pixelY), pressure1)
-        var time = dataPoint.x
+        var time = _timeAtPixel(pixelX)
         if (time < 0 || time > timeAxis.max) {
             dismissInspect()
             return
@@ -188,8 +261,8 @@ ChartView {
 
         var shotValues = []
         for (var i = 0; i < comparisonModel.shotCount; i++) {
-            shotValues.push(chart.buildShotValues(i, comparisonModel.getValuesAtTime(i, time),
-                                                   comparisonModel.getShotInfo(i)))
+            shotValues.push(_buildShotValues(i, comparisonModel.getValuesAtTime(i, time),
+                                              comparisonModel.getShotInfo(i)))
         }
         inspectShotValues = shotValues
         inspecting = true
@@ -210,9 +283,7 @@ ChartView {
             AccessibilityManager.announce(parts.join(". "), true)
     }
 
-    // Build the inspect-value record consumed by the data table + inspect bar.
-    // Kept as a function so both inspectAtPosition and inspectAtTime share one shape.
-    function buildShotValues(i, vals, info) {
+    function _buildShotValues(i, vals, info) {
         return {
             dateTime:       info.dateTime,
             hasPressure:    vals.hasPressure,   pressure:       vals.pressure,
@@ -228,134 +299,139 @@ ChartView {
         }
     }
 
-    // Place crosshair at a specific time (no pixel mapping needed)
     function inspectAtTime(time) {
         if (!comparisonModel || time < 0 || time > timeAxis.max) return
         inspectTime = time
         var shotValues = []
         for (var i = 0; i < comparisonModel.shotCount; i++) {
-            shotValues.push(chart.buildShotValues(i, comparisonModel.getValuesAtTime(i, time),
-                                                   comparisonModel.getShotInfo(i)))
+            shotValues.push(_buildShotValues(i, comparisonModel.getValuesAtTime(i, time),
+                                              comparisonModel.getShotInfo(i)))
         }
         inspectShotValues = shotValues
         inspecting = true
     }
 
-    // Dismiss the crosshair
     function dismissInspect() {
         inspecting = false
         inspectShotValues = []
     }
 
-    onComparisonModelChanged: loadData()
-    Component.onCompleted: loadData()
+    onComparisonModelChanged: _refreshAll()
+    Component.onCompleted: _refreshAll()
 
     Connections {
         target: comparisonModel
-        function onShotsChanged() { loadData() }
+        function onShotsChanged() { chart._refreshAll() }
     }
 
-    // Time axis
-    ValueAxis {
-        id: timeAxis
-        min: 0
-        max: 60
-        tickCount: 7
-        labelFormat: "%.0f"
-        labelsColor: Theme.textSecondaryColor
-        gridLineColor: Qt.rgba(255, 255, 255, 0.1)
-        titleText: "Time (s)"
-        titleBrush: Theme.textSecondaryColor
+    GraphsView {
+        id: graphsView
+        anchors.fill: parent
+        theme: DecenzaGraphsTheme {}
+
+        axisX: timeAxis
+        axisY: pressureAxis
+
+        onPlotAreaChanged: chart._updateTimeAxis()
+
+        ValueAxis {
+            id: timeAxis
+            min: 0
+            max: 60
+            tickInterval: 10
+            subTickCount: 0
+            labelFormat: "%.0f"
+            titleText: "Time (s)"
+        }
+
+        // Pressure/Flow/WeightFlow axis (left Y). When resistance/conductance/Darcy
+        // are enabled, expand the axis to [0, 20] so they don't visually clip.
+        ValueAxis {
+            id: pressureAxis
+            readonly property bool hasAdvancedCurve: chart.advancedMode
+                && (chart.showResistance || chart.showConductance || chart.showDarcyResistance)
+            min: 0
+            max: hasAdvancedCurve ? 20 : 12
+            tickInterval: hasAdvancedCurve ? 5 : 3
+            subTickCount: 0
+            labelFormat: "%.0f"
+            titleText: "bar / mL/s"
+        }
     }
 
-    // Pressure/Flow/WeightFlow axis (left Y). When resistance/conductance/Darcy
-    // are enabled, expand the axis to [0, 20] so they don't visually clip.
-    // Clamp ranges (see shotdatamodel.cpp and computeDerivedCurves()):
-    // resistance P/F → 15, conductance F²/P → 19, Darcy P/F² → 19.
-    // dC/dt has its own hidden axis and does not affect this range.
-    ValueAxis {
-        id: pressureAxis
-        readonly property bool hasAdvancedCurve: chart.advancedMode && (chart.showResistance || chart.showConductance
-                                                || chart.showDarcyResistance)
-        min: 0
-        max: hasAdvancedCurve ? 20 : 12
-        tickCount: 5
-        labelFormat: "%.0f"
-        labelsColor: Theme.textSecondaryColor
-        gridLineColor: Qt.rgba(255, 255, 255, 0.1)
-        titleText: "bar / mL/s"
-        titleBrush: Theme.textSecondaryColor
-    }
-
-    // Temperature axis (hidden right axis — range 40–100 °C, matches HistoryShotGraph)
-    ValueAxis {
+    // === HIDDEN RIGHT-AXIS HOLDERS ===
+    // DashedLineSeries reads min/max for its data→pixel mapping; QtObject
+    // suffices — no Qt Graphs ValueAxis needed.
+    QtObject {
         id: tempAxis
-        min: 40
-        max: 100
-        visible: false
+        property real min: 40
+        property real max: 100
     }
 
-    // Weight axis (hidden — weight is scaled /5 onto pressureAxis)
-    ValueAxis {
+    QtObject {
         id: weightAxis
-        min: 0
-        max: 12
-        visible: false
+        property real min: 0
+        // Weight uses a 5× the pressure-axis baseline so 60g maps to the same
+        // visual height as 12 bar (matches the legacy /5 scaling on a 0–12 axis).
+        property real max: 60
     }
 
-    // Hidden axis for dC/dt so it doesn't distort the pressure/flow axis.
-    // Range is set dynamically in loadData() — min extends below zero only
-    // when the data dips negative. Exact values via the inspect crosshair.
-    ValueAxis {
+    QtObject {
         id: dCdtAxis
-        min: 0
-        max: 20
-        visible: false
+        property real min: 0
+        property real max: 20
     }
 
-    // ── Shot 1: solid lines ──────────────────────────────────────────────────
-    LineSeries { id: pressure1;    color: Theme.pressureColor;    width: Theme.graphLineWidth;                style: Qt.SolidLine;   axisX: timeAxis; axisY: pressureAxis;      visible: chart.showPressure    && chart.showShot0 }
-    LineSeries { id: flow1;        color: Theme.flowColor;        width: Theme.graphLineWidth;                style: Qt.SolidLine;   axisX: timeAxis; axisY: pressureAxis;      visible: chart.showFlow        && chart.showShot0 }
-    LineSeries { id: temp1;        color: Theme.temperatureColor; width: Theme.graphLineWidth;                style: Qt.SolidLine;   axisX: timeAxis; axisYRight: tempAxis;     visible: chart.showTemperature && chart.showShot0 }
-    LineSeries { id: weight1;      color: Theme.weightColor;      width: Math.max(1, Theme.graphLineWidth-1); style: Qt.SolidLine;   axisX: timeAxis; axisY: weightAxis;        visible: chart.showWeight      && chart.showShot0 }
-    LineSeries { id: weightFlow1;  color: Theme.weightFlowColor;  width: Math.max(1, Theme.graphLineWidth-1); style: Qt.SolidLine;   axisX: timeAxis; axisY: pressureAxis;      visible: chart.showWeightFlow  && chart.showShot0 }
-    LineSeries { id: resistance1;           color: Theme.resistanceColor;           width: Math.max(1, Theme.graphLineWidth-1); style: Qt.SolidLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showResistance && chart.advancedMode && chart.showShot0 }
-    LineSeries { id: conductance1;          color: Theme.conductanceColor;          width: Math.max(1, Theme.graphLineWidth-1); style: Qt.SolidLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showConductance && chart.advancedMode && chart.showShot0 }
-    LineSeries { id: conductanceDerivative1;color: Theme.conductanceDerivativeColor;width: Math.max(1, Theme.graphLineWidth-1); style: Qt.SolidLine; axisX: timeAxis; axisYRight: dCdtAxis; visible: chart.showConductanceDerivative && chart.advancedMode && chart.showShot0 }
-    LineSeries { id: darcyResistance1;      color: Theme.darcyResistanceColor;      width: Math.max(1, Theme.graphLineWidth-1); style: Qt.SolidLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showDarcyResistance && chart.advancedMode && chart.showShot0 }
-    LineSeries { id: temperatureMix1;       color: Theme.temperatureMixColor;       width: Math.max(1, Theme.graphLineWidth-1); style: Qt.SolidLine; axisX: timeAxis; axisYRight: tempAxis; visible: chart.showTemperatureMix && chart.advancedMode && chart.showShot0 }
+    // === 30 trace overlays via a flat Repeater (3 shots × 10 curves) ===
+    // Nested Repeaters inside a wrapper Item appear to confuse the scene-graph
+    // parenting for Shape items inside DashedLineSeries — flattening to a
+    // single Repeater with a pre-built model gets reliable rendering.
 
-    // ── Shot 2: dashed lines ─────────────────────────────────────────────────
-    LineSeries { id: pressure2;    color: Theme.pressureColor;    width: Theme.graphLineWidth;                style: Qt.DashLine;    axisX: timeAxis; axisY: pressureAxis;      visible: chart.showPressure    && chart.showShot1 }
-    LineSeries { id: flow2;        color: Theme.flowColor;        width: Theme.graphLineWidth;                style: Qt.DashLine;    axisX: timeAxis; axisY: pressureAxis;      visible: chart.showFlow        && chart.showShot1 }
-    LineSeries { id: temp2;        color: Theme.temperatureColor; width: Theme.graphLineWidth;                style: Qt.DashLine;    axisX: timeAxis; axisYRight: tempAxis;     visible: chart.showTemperature && chart.showShot1 }
-    LineSeries { id: weight2;      color: Theme.weightColor;      width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashLine;    axisX: timeAxis; axisY: weightAxis;        visible: chart.showWeight      && chart.showShot1 }
-    LineSeries { id: weightFlow2;  color: Theme.weightFlowColor;  width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashLine;    axisX: timeAxis; axisY: pressureAxis;      visible: chart.showWeightFlow  && chart.showShot1 }
-    LineSeries { id: resistance2;           color: Theme.resistanceColor;           width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showResistance && chart.advancedMode && chart.showShot1 }
-    LineSeries { id: conductance2;          color: Theme.conductanceColor;          width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showConductance && chart.advancedMode && chart.showShot1 }
-    LineSeries { id: conductanceDerivative2;color: Theme.conductanceDerivativeColor;width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashLine; axisX: timeAxis; axisYRight: dCdtAxis; visible: chart.showConductanceDerivative && chart.advancedMode && chart.showShot1 }
-    LineSeries { id: darcyResistance2;      color: Theme.darcyResistanceColor;      width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showDarcyResistance && chart.advancedMode && chart.showShot1 }
-    LineSeries { id: temperatureMix2;       color: Theme.temperatureMixColor;       width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashLine; axisX: timeAxis; axisYRight: tempAxis; visible: chart.showTemperatureMix && chart.advancedMode && chart.showShot1 }
+    readonly property var _allTraces: {
+        var out = []
+        for (var s = 0; s < 3; s++) {
+            for (var c = 0; c < _curves.length; c++) {
+                out.push({ shotIdx: s, curveIdx: c })
+            }
+        }
+        return out
+    }
 
-    // ── Shot 3: dash-dot lines ───────────────────────────────────────────────
-    LineSeries { id: pressure3;    color: Theme.pressureColor;    width: Theme.graphLineWidth;                style: Qt.DashDotLine; axisX: timeAxis; axisY: pressureAxis;      visible: chart.showPressure    && chart.showShot2 }
-    LineSeries { id: flow3;        color: Theme.flowColor;        width: Theme.graphLineWidth;                style: Qt.DashDotLine; axisX: timeAxis; axisY: pressureAxis;      visible: chart.showFlow        && chart.showShot2 }
-    LineSeries { id: temp3;        color: Theme.temperatureColor; width: Theme.graphLineWidth;                style: Qt.DashDotLine; axisX: timeAxis; axisYRight: tempAxis;     visible: chart.showTemperature && chart.showShot2 }
-    LineSeries { id: weight3;      color: Theme.weightColor;      width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashDotLine; axisX: timeAxis; axisY: weightAxis;        visible: chart.showWeight      && chart.showShot2 }
-    LineSeries { id: weightFlow3;  color: Theme.weightFlowColor;  width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashDotLine; axisX: timeAxis; axisY: pressureAxis;      visible: chart.showWeightFlow  && chart.showShot2 }
-    LineSeries { id: resistance3;           color: Theme.resistanceColor;           width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashDotLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showResistance && chart.advancedMode && chart.showShot2 }
-    LineSeries { id: conductance3;          color: Theme.conductanceColor;          width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashDotLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showConductance && chart.advancedMode && chart.showShot2 }
-    LineSeries { id: conductanceDerivative3;color: Theme.conductanceDerivativeColor;width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashDotLine; axisX: timeAxis; axisYRight: dCdtAxis; visible: chart.showConductanceDerivative && chart.advancedMode && chart.showShot2 }
-    LineSeries { id: darcyResistance3;      color: Theme.darcyResistanceColor;      width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashDotLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showDarcyResistance && chart.advancedMode && chart.showShot2 }
-    LineSeries { id: temperatureMix3;       color: Theme.temperatureMixColor;       width: Math.max(1, Theme.graphLineWidth-1); style: Qt.DashDotLine; axisX: timeAxis; axisYRight: tempAxis; visible: chart.showTemperatureMix && chart.advancedMode && chart.showShot2 }
+    function _shotVisibleAt(shotIdx) {
+        return shotIdx === 0 ? showShot0
+             : shotIdx === 1 ? showShot1
+                             : showShot2
+    }
 
-    // Phase marker lines — Canvas for proper dashed patterns per shot style
+    Repeater {
+        model: chart._allTraces
+        delegate: DashedLineSeries {
+            required property var modelData
+            readonly property var curveDef: chart._curves[modelData.curveIdx]
+            readonly property var shotStyle: chart._shotStyles[modelData.shotIdx]
+
+            graphsView: chart.graphsViewRef
+            axisX: timeAxis
+            axisY: chart._axisFor(curveDef.axisKey)
+            points: chart._curvePoints(modelData.shotIdx, curveDef.key)
+            strokeColor: curveDef.color
+            strokeWidth: curveDef.width
+            dashed: shotStyle.dashed
+            dashPattern: shotStyle.pattern
+            visible: chart._shotVisibleAt(modelData.shotIdx)
+                     && chart[curveDef.showFlag]
+                     && (!curveDef.advanced || chart.advancedMode)
+        }
+    }
+
+    // === Phase marker vertical lines — Canvas keeps the per-shot dash pattern ===
+
     Canvas {
         id: phaseCanvas
-        x: chart.plotArea.x
-        y: chart.plotArea.y
-        width: chart.plotArea.width
-        height: chart.plotArea.height
+        x: graphsView.plotArea.x
+        y: graphsView.plotArea.y
+        width: graphsView.plotArea.width
+        height: graphsView.plotArea.height
         z: 5
         onXChanged: requestPaint()
         onYChanged: requestPaint()
@@ -390,8 +466,8 @@ ChartView {
         Text {
             required property var modelData
             visible: modelData.shotIdx === 0 && !chart.hiddenPhaseLabels[modelData.label]
-            x: chart.plotArea.x + (modelData.time / timeAxis.max) * chart.plotArea.width + Theme.scaled(2)
-            y: chart.plotArea.y
+            x: graphsView.plotArea.x + (modelData.time / timeAxis.max) * graphsView.plotArea.width + Theme.scaled(2)
+            y: graphsView.plotArea.y
             text: modelData.label
             font: Theme.captionFont
             color: chart.phaseColors[modelData.phaseIndex % chart.phaseColors.length]
@@ -405,9 +481,9 @@ ChartView {
         id: crosshairLine
         visible: chart.inspecting
         x: chart.inspectPixelX - width / 2
-        y: chart.plotArea.y
+        y: graphsView.plotArea.y
         width: Theme.scaled(1)
-        height: chart.plotArea.height
+        height: graphsView.plotArea.height
         color: Theme.textColor
         opacity: 0.6
     }

--- a/qml/components/ComparisonGraph.qml
+++ b/qml/components/ComparisonGraph.qml
@@ -59,6 +59,10 @@ Item {
     // `graphsView` property (which defaults to `parent`) and resolves to null.
     readonly property alias graphsViewRef: graphsView
 
+    // Re-export the GraphsView's plot rect for parent pages that hit-test
+    // against it (e.g. the comparison page tap-to-inspect overlay).
+    readonly property rect plotArea: graphsView.plotArea
+
     // === Curve definitions driving the 3-shot × 10-curve Repeater ===
     //
     // Each curve names the model accessor key, the axisY holder to map against,

--- a/qml/components/ComparisonGraph.qml
+++ b/qml/components/ComparisonGraph.qml
@@ -61,12 +61,11 @@ Item {
 
     // === Curve definitions driving the 3-shot × 10-curve Repeater ===
     //
-    // Each curve names its model accessor (Q_INVOKABLE QVariantList getter), the
-    // axisY holder to map against, its colour, stroke width, and the show-flag
-    // gating visibility. fnY is optional: if set, the y values from the model
-    // are transformed before the dashed overlay reads them (currently used for
-    // the /5 weight rescale that keeps weight in the same visual range as
-    // pressure, matching the legacy comparison view).
+    // Each curve names the model accessor key, the axisY holder to map against,
+    // its colour, stroke width, the show-flag gating visibility, and whether it
+    // is advanced-mode-only. Per-curve y-value transforms (currently just the
+    // /5 weight rescale) live in `_curvePoints()` as a key-dispatched branch.
+    //
     // Axis is stored as a string key, not a direct id reference: this property
     // initialiser runs before GraphsView and its child ValueAxes are constructed,
     // so direct ids would resolve to null and the `var` binding wouldn't re-fire
@@ -135,9 +134,12 @@ Item {
         return data
     }
 
-    // Bumps every time the comparison model's shot list changes — used as a
+    // Monotonic counter bumped on every shotsChanged emission — used as a
     // read-dependency in every points binding so they re-evaluate then.
-    readonly property int _dataVersion: comparisonModel ? comparisonModel.shotCount : 0
+    // Binding to comparisonModel.shotCount is insufficient because the window
+    // navigation (shiftWindowLeft/Right) often keeps the count constant while
+    // the underlying displayShots vector is replaced.
+    property int _dataVersion: 0
 
     // === Axis fitting (timeAxis stretches to maxTime + padding; dCdtAxis fits the data) ===
 
@@ -236,6 +238,7 @@ Item {
     }
 
     function _refreshAll() {
+        _dataVersion++       // invalidate all trace bindings
         _updateTimeAxis()
         _updateDCdtAxis()
         _rebuildPhaseData()
@@ -371,9 +374,11 @@ Item {
     QtObject {
         id: weightAxis
         property real min: 0
-        // Weight uses a 5× the pressure-axis baseline so 60g maps to the same
-        // visual height as 12 bar (matches the legacy /5 scaling on a 0–12 axis).
-        property real max: 60
+        // Weight points are pre-divided by 5 in _curvePoints() (so 60 g → 12),
+        // then mapped against this 0–12 axis so 60 g lands at the top — same
+        // visual height as 12 bar on the left axis. Matches the legacy
+        // weightAxis range in the Qt Charts comparison view.
+        property real max: 12
     }
 
     QtObject {

--- a/qml/components/HistoryShotGraph.qml
+++ b/qml/components/HistoryShotGraph.qml
@@ -107,7 +107,8 @@ Item {
         // Clip to the later of maxTime (extraction duration) or the last phase-
         // marker time so any frame-transition marker landing just past duration
         // still renders. Pixel-based padding keeps markers off the right edge.
-        if (pressureData.length === 0) return
+        // No early return on empty pressureData — temperature- or weight-only
+        // rows (corrupt/partial) still get a sensible axis from maxTime alone.
         var markerMaxTime = 0
         for (var m = 0; m < phaseMarkers.length; m++) {
             if (phaseMarkers[m].time > markerMaxTime) markerMaxTime = phaseMarkers[m].time

--- a/qml/components/HistoryShotGraph.qml
+++ b/qml/components/HistoryShotGraph.qml
@@ -15,6 +15,11 @@ Item {
     // `graphsView` property (which defaults to `parent`) and resolves to null.
     readonly property alias graphsViewRef: graphsView
 
+    // Re-export the GraphsView's plot rect so parent pages can hit-test against
+    // it (e.g. the tap-to-inspect overlays distinguishing crosshair taps from
+    // right-axis toggles). Matches the legacy Qt Charts ChartView.plotArea API.
+    readonly property rect plotArea: graphsView.plotArea
+
     // Controls for compact/widget rendering
     property bool showLabels: true
     property bool showPhaseLabels: true

--- a/qml/components/HistoryShotGraph.qml
+++ b/qml/components/HistoryShotGraph.qml
@@ -696,5 +696,11 @@ Item {
             y: rightAxisLabels.height / 2 - height / 2
             Accessible.ignored: true
         }
+
+        MouseArea {
+            id: axisToggleArea
+            anchors.fill: parent
+            onClicked: chart.toggleRightAxis()
+        }
     }
 }

--- a/qml/components/HistoryShotGraph.qml
+++ b/qml/components/HistoryShotGraph.qml
@@ -582,12 +582,6 @@ Item {
                 color: isStart ? Theme.accentColor : Qt.rgba(255, 255, 255, 0.8)
                 rotation: -90
                 transformOrigin: Item.TopLeft
-                // Constrain natural width to the plot height (minus padding) so
-                // rotated text never extends past the plot area; elide handles
-                // long labels in small tiles. Full-page graphs have enough room
-                // that no truncation occurs.
-                width: Math.max(Theme.scaled(20), graphsView.plotArea.height - Theme.scaled(12))
-                elide: Text.ElideRight
                 x: Theme.scaled(3)
                 y: Theme.scaled(6) + width
 

--- a/qml/components/HistoryShotGraph.qml
+++ b/qml/components/HistoryShotGraph.qml
@@ -1,20 +1,26 @@
 import QtQuick
-import QtCharts
+import QtGraphs
 import Decenza
+import "graphs"
 
-ChartView {
+// Outer Item wraps the GraphsView so dashed overlays, right-axis-mapped traces,
+// inspect crosshair, marker labels, and the right-axis label column render as
+// siblings on top of the chart. GraphsView's scene-graph paints over any direct
+// QQuickItem children — overlays must be siblings, not children.
+Item {
     id: chart
-    antialiasing: true
-    backgroundColor: "transparent"
-    plotAreaColor: Qt.darker(Theme.surfaceColor, 1.3)
-    legend.visible: false
+
+    // Alias so DashedLineSeries delegates can reach the GraphsView without
+    // writing `graphsView: graphsView` — that RHS shadows the delegate's own
+    // `graphsView` property (which defaults to `parent`) and resolves to null.
+    readonly property alias graphsViewRef: graphsView
 
     // Controls for compact/widget rendering
     property bool showLabels: true
     property bool showPhaseLabels: true
 
-    // Persisted visibility toggles (tappable legend). Using Settings.boolValue()
-    // coerces QSettings' INI-backed strings to real booleans; see Settings.h.
+    // Persisted visibility toggles (tappable legend). Settings.boolValue() coerces
+    // QSettings' INI-backed strings to real booleans; see Settings.h.
     property bool showPressure: Settings.boolValue("graph/showPressure", true)
     property bool showFlow: Settings.boolValue("graph/showFlow", true)
     property bool showTemperature: Settings.boolValue("graph/showTemperature", true)
@@ -42,11 +48,6 @@ ChartView {
     property real inspectPixelX: 0
     property var inspectValues: ({})
 
-    margins.top: 0
-    margins.bottom: 0
-    margins.left: 0
-    margins.right: chart.showLabels ? Theme.scaled(35) : 0
-
     // Data to display (set from parent)
     property var pressureData: []
     property var flowData: []
@@ -64,79 +65,63 @@ ChartView {
     property var phaseMarkers: []
     property double maxTime: 60
 
-    // Load data into series
-    function loadData() {
-        pressureSeries.clear()
-        flowSeries.clear()
-        temperatureSeries.clear()
-        weightSeries.clear()
-        weightFlowRateSeries.clear()
-        resistanceSeries.clear()
-
-        for (var i = 0; i < pressureData.length; i++) {
-            pressureSeries.append(pressureData[i].x, pressureData[i].y)
-        }
-        for (i = 0; i < flowData.length; i++) {
-            flowSeries.append(flowData[i].x, flowData[i].y)
-        }
-        for (i = 0; i < temperatureData.length; i++) {
-            temperatureSeries.append(temperatureData[i].x, temperatureData[i].y)
-        }
-        for (i = 0; i < weightData.length; i++) {
-            weightSeries.append(weightData[i].x, weightData[i].y)
-        }
-        for (i = 0; i < weightFlowRateData.length; i++) {
-            weightFlowRateSeries.append(weightFlowRateData[i].x, weightFlowRateData[i].y)
-        }
-        for (i = 0; i < resistanceData.length; i++) {
-            resistanceSeries.append(resistanceData[i].x, resistanceData[i].y)
-        }
-        conductanceSeries.clear()
-        for (i = 0; i < conductanceData.length; i++) {
-            conductanceSeries.append(conductanceData[i].x, conductanceData[i].y)
-        }
-        darcyResistanceSeries.clear()
-        for (i = 0; i < darcyResistanceData.length; i++) {
-            darcyResistanceSeries.append(darcyResistanceData[i].x, darcyResistanceData[i].y)
-        }
-        conductanceDerivativeSeries.clear()
-        for (i = 0; i < conductanceDerivativeData.length; i++) {
-            conductanceDerivativeSeries.append(conductanceDerivativeData[i].x, conductanceDerivativeData[i].y)
-        }
-        temperatureMixSeries.clear()
-        for (i = 0; i < temperatureMixData.length; i++) {
-            temperatureMixSeries.append(temperatureMixData[i].x, temperatureMixData[i].y)
-        }
-
-        // Update time axis. Clip to the later of maxTime (extraction duration)
-        // or the last phase-marker time so any frame-transition marker that
-        // lands just past duration still renders. Post-End samples (scale
-        // dribble etc.) are still clipped, matching the live graph. Small
-        // pixel-based padding keeps markers off the right edge.
-        if (pressureData.length > 0) {
-            var markerMaxTime = 0
-            for (var m = 0; m < phaseMarkers.length; m++) {
-                if (phaseMarkers[m].time > markerMaxTime) markerMaxTime = phaseMarkers[m].time
-            }
-            var axisEnd = Math.max(maxTime, markerMaxTime)
-            var plotWidth = Math.max(1, chart.plotArea.width)
-            var paddingPx = Theme.scaled(5)
-            var scale = plotWidth / Math.max(1, plotWidth - paddingPx)
-            timeAxis.max = Math.max(5, axisEnd * scale)
-        }
+    // === Reload pipeline ===
+    // Qt.callLater coalesces sequential property reassignments from the parent
+    // (pressureData, flowData, weightData…) so loadData() runs once with a
+    // consistent snapshot rather than N times with mixed old/new arrays.
+    function doReload() {
+        dismissInspect()
+        loadMainSeries()
+        updateTimeAxis()
+        // Goal-segment arrays + right-axis-mapped traces bind directly to QML
+        // properties — no imperative load step needed.
     }
 
-    // Use Qt.callLater to coalesce reloads when multiple properties change at once.
-    // When parent reassigns shotData, QML re-evaluates each binding (pressureData,
-    // flowData, weightData, etc.) sequentially — not atomically. Without callLater,
-    // the first property change would trigger loadData() while other properties still
-    // hold stale values from the previous shot, causing a mix of old/new data.
-    // Qt.callLater deduplicates: N calls before execution → 1 actual invocation.
-    function doReload() { dismissInspect(); loadData(); loadMarkers(); loadGoalData() }
+    // Load only the main-axis Qt Graphs LineSeries (pressure, flow, weight-flow,
+    // resistance, conductance, darcy). Right-axis-mapped traces (temperature,
+    // mix temp, weight, dC/dt) are rendered as DashedLineSeries overlays whose
+    // `points` property binds straight to the data arrays.
+    function loadMainSeries() {
+        pressureSeries.clear()
+        flowSeries.clear()
+        weightFlowRateSeries.clear()
+        resistanceSeries.clear()
+        conductanceSeries.clear()
+        darcyResistanceSeries.clear()
+
+        for (var i = 0; i < pressureData.length; i++)
+            pressureSeries.append(pressureData[i].x, pressureData[i].y)
+        for (i = 0; i < flowData.length; i++)
+            flowSeries.append(flowData[i].x, flowData[i].y)
+        for (i = 0; i < weightFlowRateData.length; i++)
+            weightFlowRateSeries.append(weightFlowRateData[i].x, weightFlowRateData[i].y)
+        for (i = 0; i < resistanceData.length; i++)
+            resistanceSeries.append(resistanceData[i].x, resistanceData[i].y)
+        for (i = 0; i < conductanceData.length; i++)
+            conductanceSeries.append(conductanceData[i].x, conductanceData[i].y)
+        for (i = 0; i < darcyResistanceData.length; i++)
+            darcyResistanceSeries.append(darcyResistanceData[i].x, darcyResistanceData[i].y)
+    }
+
+    function updateTimeAxis() {
+        // Clip to the later of maxTime (extraction duration) or the last phase-
+        // marker time so any frame-transition marker landing just past duration
+        // still renders. Pixel-based padding keeps markers off the right edge.
+        if (pressureData.length === 0) return
+        var markerMaxTime = 0
+        for (var m = 0; m < phaseMarkers.length; m++) {
+            if (phaseMarkers[m].time > markerMaxTime) markerMaxTime = phaseMarkers[m].time
+        }
+        var axisEnd = Math.max(maxTime, markerMaxTime)
+        var plotWidth = Math.max(1, graphsView.plotArea.width)
+        var paddingPx = Theme.scaled(5)
+        var scale = plotWidth / Math.max(1, plotWidth - paddingPx)
+        timeAxis.max = Math.max(5, axisEnd * scale)
+    }
 
     // Split a goal data array into segments at time gaps (pump mode transitions).
     // During recording, goal=0 samples are skipped, creating natural time gaps
-    // between segments. Normal sample interval is ~0.2s; gaps > 0.5s indicate
+    // between segments. Normal sample interval is ~0.2 s; gaps > 0.5 s indicate
     // a mode switch boundary.
     function segmentGoalData(data, maxSegments) {
         if (!data || data.length === 0) return []
@@ -151,86 +136,27 @@ ChartView {
         return segments
     }
 
-    // Load goal/target lines into their LineSeries
-    function loadGoalData() {
-        // Clear all goal series
-        for (var i = 0; i < _pressureGoalLines.length; i++)
-            _pressureGoalLines[i].clear()
-        for (i = 0; i < _flowGoalLines.length; i++)
-            _flowGoalLines[i].clear()
-        temperatureGoalSeries.clear()
+    // Computed goal segments — bound by the dashed-overlay Repeaters below.
+    readonly property var pressureGoalSegments: segmentGoalData(pressureGoalData, 5)
+    readonly property var flowGoalSegments: segmentGoalData(flowGoalData, 5)
 
-        // Segment and load pressure goal
-        var pSegs = segmentGoalData(pressureGoalData, 5)
-        for (i = 0; i < pSegs.length && i < _pressureGoalLines.length; i++) {
-            for (var j = 0; j < pSegs[i].length; j++)
-                _pressureGoalLines[i].append(pSegs[i][j].x, pSegs[i][j].y)
-        }
+    // === Inspect: pixel → data, value lookup, accessibility ===
 
-        // Segment and load flow goal
-        var fSegs = segmentGoalData(flowGoalData, 5)
-        for (i = 0; i < fSegs.length && i < _flowGoalLines.length; i++) {
-            for (j = 0; j < fSegs[i].length; j++)
-                _flowGoalLines[i].append(fSegs[i][j].x, fSegs[i][j].y)
-        }
-
-        // Temperature goal is continuous across all modes — no segmentation
-        for (i = 0; i < temperatureGoalData.length; i++)
-            temperatureGoalSeries.append(temperatureGoalData[i].x, temperatureGoalData[i].y)
+    function _timeAtPixel(pixelX) {
+        var plot = graphsView.plotArea
+        if (!plot || plot.width <= 0) return -1
+        return timeAxis.min + (pixelX - plot.x) / plot.width * (timeAxis.max - timeAxis.min)
     }
 
-    // Inspect at a pixel position: show crosshair + tooltip, announce for TTS
-    function inspectAtPosition(pixelX, pixelY) {
-        var dataPoint = chart.mapToValue(Qt.point(pixelX, pixelY), pressureSeries)
-        var time = dataPoint.x
-        if (time < 0 || time > timeAxis.max) return
-
-        inspectTime = time
-        // Calculate pixel X from time (clamped to plot area)
-        inspectPixelX = chart.plotArea.x + (time / timeAxis.max) * chart.plotArea.width
-
-        // Compute values for every curve — regardless of visibility — so the
-        // inspect bar can react live when the user toggles curves on/off without
-        // re-tapping the graph. GraphInspectBar filters by the current show*
-        // flags at display time.
-        var vals = {}
-        var curves = [
-            { key: "pressure", name: "Pressure", series: pressureSeries, unit: "bar" },
-            { key: "flow", name: "Flow", series: flowSeries, unit: "mL/s" },
-            { key: "temperature", name: "Temp", series: temperatureSeries, unit: "\u00B0C" },
-            { key: "mixTemp", name: "Mix temp", series: temperatureMixSeries, unit: "\u00B0C" },
-            { key: "weight", name: "Weight", series: weightSeries, unit: "g" },
-            { key: "weightFlow", name: "Weight flow", series: weightFlowRateSeries, unit: "g/s" },
-            { key: "resistance", name: "Resistance", series: resistanceSeries, unit: "" },
-            { key: "darcyResistance", name: "Darcy R", series: darcyResistanceSeries, unit: "" },
-            { key: "conductance", name: "Conductance", series: conductanceSeries, unit: "" },
-            { key: "dCdt", name: "dC/dt", series: conductanceDerivativeSeries, unit: "" }
-        ]
-
-        for (var i = 0; i < curves.length; i++) {
-            var v = findValueAtTime(curves[i].series, time)
-            if (v !== null) {
-                vals[curves[i].key] = { name: curves[i].name, value: v, unit: curves[i].unit }
-            }
-        }
-
-        inspectValues = vals
-        inspecting = true
-        announceAtPosition(pixelX, pixelY)
-    }
-
-    // Dismiss the inspect crosshair/tooltip
-    function dismissInspect() {
-        inspecting = false
-    }
-
-    // Find the Y value in a LineSeries closest to the given time
-    function findValueAtTime(series, time) {
-        if (series.count === 0) return null
-        var closest = series.at(0)
+    // Find the y value in a data array closest to the given time.
+    // Reads from data arrays (not series) so right-axis-mapped traces — which are
+    // no longer Qt Graphs series — are queryable the same way as main-axis traces.
+    function findValueAtTime(data, time) {
+        if (!data || data.length === 0) return null
+        var closest = data[0]
         var minDist = Math.abs(closest.x - time)
-        for (var i = 1; i < series.count; i++) {
-            var p = series.at(i)
+        for (var i = 1; i < data.length; i++) {
+            var p = data[i]
             var dist = Math.abs(p.x - time)
             if (dist < minDist) {
                 closest = p
@@ -242,8 +168,49 @@ ChartView {
         return minDist < 1.0 ? closest.y : null
     }
 
+    function inspectAtPosition(pixelX, pixelY) {
+        var time = _timeAtPixel(pixelX)
+        if (time < 0 || time > timeAxis.max) return
+
+        inspectTime = time
+        inspectPixelX = graphsView.plotArea.x + (time / timeAxis.max) * graphsView.plotArea.width
+
+        // Compute values for every curve — regardless of visibility — so the
+        // inspect bar can react live when the user toggles curves on/off without
+        // re-tapping the graph. GraphInspectBar filters by the current show*
+        // flags at display time.
+        var vals = {}
+        var curves = [
+            { key: "pressure", name: "Pressure", data: pressureData, unit: "bar" },
+            { key: "flow", name: "Flow", data: flowData, unit: "mL/s" },
+            { key: "temperature", name: "Temp", data: temperatureData, unit: "°C" },
+            { key: "mixTemp", name: "Mix temp", data: temperatureMixData, unit: "°C" },
+            { key: "weight", name: "Weight", data: weightData, unit: "g" },
+            { key: "weightFlow", name: "Weight flow", data: weightFlowRateData, unit: "g/s" },
+            { key: "resistance", name: "Resistance", data: resistanceData, unit: "" },
+            { key: "darcyResistance", name: "Darcy R", data: darcyResistanceData, unit: "" },
+            { key: "conductance", name: "Conductance", data: conductanceData, unit: "" },
+            { key: "dCdt", name: "dC/dt", data: conductanceDerivativeData, unit: "" }
+        ]
+
+        for (var i = 0; i < curves.length; i++) {
+            var v = findValueAtTime(curves[i].data, time)
+            if (v !== null) {
+                vals[curves[i].key] = { name: curves[i].name, value: v, unit: curves[i].unit }
+            }
+        }
+
+        inspectValues = vals
+        inspecting = true
+        announceAtPosition(pixelX, pixelY)
+    }
+
+    function dismissInspect() {
+        inspecting = false
+    }
+
     // Return the phase label active at the given time, or empty string if none.
-    // Skips "Start"/"End" sentinels — they are structural markers, not user-facing phases.
+    // Skips "Start"/"End" sentinels — they are structural, not user-facing.
     function getPhaseAtTime(time) {
         var label = ""
         for (var i = 0; i < phaseMarkers.length; i++) {
@@ -258,29 +225,27 @@ ChartView {
         return label
     }
 
-    // Announce curve values at a pixel position (called on tap)
     function announceAtPosition(pixelX, pixelY) {
-        var dataPoint = chart.mapToValue(Qt.point(pixelX, pixelY), pressureSeries)
-        var time = dataPoint.x
+        var time = _timeAtPixel(pixelX)
         if (time < 0 || time > timeAxis.max) return
 
         var curves = [
-            { name: "Pressure", series: pressureSeries, show: showPressure, unit: "bar" },
-            { name: "Flow", series: flowSeries, show: showFlow, unit: "mL/s" },
-            { name: "Temp", series: temperatureSeries, show: showTemperature, unit: "°C" },
-            { name: "Mix temp", series: temperatureMixSeries, show: showTemperatureMix && advancedMode, unit: "°C" },
-            { name: "Weight", series: weightSeries, show: showWeight, unit: "g" },
-            { name: "Weight flow", series: weightFlowRateSeries, show: showWeightFlow, unit: "g/s" },
-            { name: "Resistance", series: resistanceSeries, show: showResistance && advancedMode, unit: "" },
-            { name: "Darcy R", series: darcyResistanceSeries, show: showDarcyResistance && advancedMode, unit: "" },
-            { name: "Conductance", series: conductanceSeries, show: showConductance && advancedMode, unit: "" },
-            { name: "dC/dt", series: conductanceDerivativeSeries, show: showConductanceDerivative && advancedMode, unit: "" }
+            { name: "Pressure", data: pressureData, show: showPressure, unit: "bar" },
+            { name: "Flow", data: flowData, show: showFlow, unit: "mL/s" },
+            { name: "Temp", data: temperatureData, show: showTemperature, unit: "°C" },
+            { name: "Mix temp", data: temperatureMixData, show: showTemperatureMix && advancedMode, unit: "°C" },
+            { name: "Weight", data: weightData, show: showWeight, unit: "g" },
+            { name: "Weight flow", data: weightFlowRateData, show: showWeightFlow, unit: "g/s" },
+            { name: "Resistance", data: resistanceData, show: showResistance && advancedMode, unit: "" },
+            { name: "Darcy R", data: darcyResistanceData, show: showDarcyResistance && advancedMode, unit: "" },
+            { name: "Conductance", data: conductanceData, show: showConductance && advancedMode, unit: "" },
+            { name: "dC/dt", data: conductanceDerivativeData, show: showConductanceDerivative && advancedMode, unit: "" }
         ]
 
         var parts = []
         for (var i = 0; i < curves.length; i++) {
             if (!curves[i].show) continue
-            var v = findValueAtTime(curves[i].series, time)
+            var v = findValueAtTime(curves[i].data, time)
             if (v !== null) {
                 var entry = curves[i].name + " " + v.toFixed(1)
                 if (curves[i].unit !== "") entry += " " + curves[i].unit
@@ -299,30 +264,15 @@ ChartView {
 
     onPressureDataChanged: Qt.callLater(doReload)
     onFlowDataChanged: Qt.callLater(doReload)
-    onTemperatureDataChanged: Qt.callLater(doReload)
-    onWeightDataChanged: Qt.callLater(doReload)
     onWeightFlowRateDataChanged: Qt.callLater(doReload)
     onResistanceDataChanged: Qt.callLater(doReload)
-    onPressureGoalDataChanged: Qt.callLater(doReload)
-    onFlowGoalDataChanged: Qt.callLater(doReload)
-    onTemperatureGoalDataChanged: Qt.callLater(doReload)
+    onConductanceDataChanged: Qt.callLater(doReload)
+    onDarcyResistanceDataChanged: Qt.callLater(doReload)
     onPhaseMarkersChanged: Qt.callLater(doReload)
     Component.onCompleted: doReload()
 
-    // Time axis
-    ValueAxis {
-        id: timeAxis
-        min: 0
-        max: 60
-        tickCount: 7
-        labelFormat: "%.0f"
-        labelsVisible: chart.showLabels
-        labelsColor: Theme.textSecondaryColor
-        gridLineColor: Qt.rgba(255, 255, 255, 0.1)
-    }
-
     // Dynamic max for pressure/flow axis based on all data (ignores visibility
-    // toggles so the graph doesn't jump when toggling curves on/off)
+    // toggles so the graph doesn't jump when toggling curves on/off).
     property double pressureAxisMax: {
         var maxVal = 0
         for (var i = 0; i < pressureData.length; i++) {
@@ -340,10 +290,9 @@ ChartView {
         for (i = 0; i < flowGoalData.length; i++) {
             if (flowGoalData[i].y > maxVal) maxVal = flowGoalData[i].y
         }
-        // Resistance excluded from axis scaling — values are clamped at source
-        // and clip at the axis boundary, matching the live graph behavior
+        // Resistance excluded — values are clamped at source and clip at the
+        // axis boundary, matching the live graph behaviour.
         if (maxVal < 0.1) return 12  // fallback when no data
-        // Round up to nice tick-friendly value
         var padded = maxVal * 1.15
         if (padded <= 2) return 2
         if (padded <= 4) return 4
@@ -355,274 +304,245 @@ ChartView {
         return Math.ceil(padded / 5) * 5
     }
 
-    // Pressure/Flow axis (left Y)
-    ValueAxis {
-        id: pressureAxis
-        min: 0
-        max: pressureAxisMax
-        tickCount: 5
-        labelFormat: "%.0f"
-        labelsVisible: chart.showLabels
-        labelsColor: Theme.textSecondaryColor
-        gridLineColor: Qt.rgba(255, 255, 255, 0.1)
-        titleText: chart.showLabels ? "bar / mL/s" : ""
-        titleBrush: Theme.textSecondaryColor
-    }
+    // === HIDDEN RIGHT-AXIS HOLDERS ===
+    // Plain QtObjects (not Qt Graphs ValueAxis) — Qt Graphs has no sanctioned
+    // dual-Y-axis path here. DashedLineSeries reads `min`/`max` for its data→
+    // pixel mapping, so a value-holder QObject is enough.
 
-    // Two hidden right axes — used only for correct series mapping (no labels)
-    property double maxWeight: {
-        var max = 0
-        for (var i = 0; i < weightData.length; i++) {
-            if (weightData[i].y > max) max = weightData[i].y
-        }
-        return Math.max(10, max * 1.1)
-    }
-
-    ValueAxis {
+    QtObject {
         id: tempAxis
-        visible: false
-        min: 40
-        max: 100
+        property real min: 40
+        property real max: 100
     }
 
-    ValueAxis {
+    QtObject {
         id: weightAxis
-        visible: false
-        min: 0
-        max: maxWeight
-    }
-
-    // Hidden axis for dC/dt so it doesn't distort the pressure/flow axis.
-    // Range is dynamic: max snaps up from the data peak; min extends below
-    // zero only when the data actually dips negative. Exact values are read
-    // via the inspect crosshair, not axis labels.
-    property double dCdtAxisMax: {
-        var maxVal = 0
-        for (var i = 0; i < conductanceDerivativeData.length; i++) {
-            if (conductanceDerivativeData[i].y > maxVal) maxVal = conductanceDerivativeData[i].y
+        property real min: 0
+        property real max: {
+            var maxW = 0
+            for (var i = 0; i < weightData.length; i++) {
+                if (weightData[i].y > maxW) maxW = weightData[i].y
+            }
+            return Math.max(10, maxW * 1.1)
         }
-        var padded = maxVal * 1.15
-        if (padded <= 2) return 2
-        if (padded <= 3) return 3
-        if (padded <= 5) return 5
-        if (padded <= 8) return 8
-        if (padded <= 10) return 10
-        return Math.ceil(padded / 5) * 5
     }
 
-    property double dCdtAxisMin: {
-        var minVal = 0
-        for (var i = 0; i < conductanceDerivativeData.length; i++) {
-            if (conductanceDerivativeData[i].y < minVal) minVal = conductanceDerivativeData[i].y
-        }
-        return minVal < 0 ? -Math.abs(minVal) * 1.15 : 0
-    }
-
-    ValueAxis {
+    QtObject {
         id: dCdtAxis
-        visible: false
-        min: dCdtAxisMin
-        max: dCdtAxisMax
+        property real min: {
+            var minV = 0
+            for (var i = 0; i < conductanceDerivativeData.length; i++) {
+                if (conductanceDerivativeData[i].y < minV) minV = conductanceDerivativeData[i].y
+            }
+            return minV < 0 ? -Math.abs(minV) * 1.15 : 0
+        }
+        property real max: {
+            var maxV = 0
+            for (var i = 0; i < conductanceDerivativeData.length; i++) {
+                if (conductanceDerivativeData[i].y > maxV) maxV = conductanceDerivativeData[i].y
+            }
+            var padded = maxV * 1.15
+            if (padded <= 2) return 2
+            if (padded <= 3) return 3
+            if (padded <= 5) return 5
+            if (padded <= 8) return 8
+            if (padded <= 10) return 10
+            return Math.ceil(padded / 5) * 5
+        }
     }
 
-    // === EXTRACTION START / STOP MARKERS (styled differently from frame markers) ===
+    GraphsView {
+        id: graphsView
+        anchors.fill: parent
+        anchors.rightMargin: chart.showLabels ? Theme.scaled(35) : 0
+        theme: DecenzaGraphsTheme {}
 
-    LineSeries {
-        id: extractionStartMarker
-        name: ""
-        color: Theme.accentColor
-        width: Theme.scaled(2)
-        style: Qt.DashDotLine
         axisX: timeAxis
         axisY: pressureAxis
+
+        onPlotAreaChanged: chart.updateTimeAxis()
+
+        ValueAxis {
+            id: timeAxis
+            min: 0
+            max: 60
+            tickInterval: 10
+            subTickCount: 0
+            labelFormat: "%.0f"
+            visible: chart.showLabels
+        }
+
+        ValueAxis {
+            id: pressureAxis
+            min: 0
+            max: chart.pressureAxisMax
+            tickInterval: Math.max(1, Math.round(chart.pressureAxisMax / 4))
+            subTickCount: 0
+            labelFormat: "%.0f"
+            visible: chart.showLabels
+            titleText: chart.showLabels ? "bar / mL/s" : ""
+        }
+
+        // === MAIN-AXIS DATA LINES (Qt Graphs native series) ===
+
+        LineSeries {
+            id: pressureSeries
+            color: Theme.pressureColor
+            width: Theme.scaled(3)
+            visible: chart.showPressure
+        }
+
+        LineSeries {
+            id: flowSeries
+            color: Theme.flowColor
+            width: Theme.scaled(3)
+            visible: chart.showFlow
+        }
+
+        LineSeries {
+            id: weightFlowRateSeries
+            color: Theme.weightFlowColor
+            width: Theme.scaled(2)
+            visible: chart.showWeightFlow
+        }
+
+        LineSeries {
+            id: resistanceSeries
+            color: Theme.resistanceColor
+            width: Theme.scaled(2)
+            visible: chart.showResistance && chart.advancedMode
+        }
+
+        LineSeries {
+            id: conductanceSeries
+            color: Theme.conductanceColor
+            width: Theme.scaled(2)
+            visible: chart.showConductance && chart.advancedMode
+        }
+
+        LineSeries {
+            id: darcyResistanceSeries
+            color: Theme.darcyResistanceColor
+            width: Theme.scaled(2)
+            visible: chart.showDarcyResistance && chart.advancedMode
+        }
     }
 
-    // === GOAL LINES (dashed) — segments for clean breaks at pump mode transitions ===
+    // === RIGHT-AXIS DATA LINES (DashedLineSeries with solid stroke) ===
+    // Qt Graphs has no axisYRight for these in our setup, so they render as
+    // bridge overlays mapped against their own min/max value holders.
 
-    // Pressure goal segments (up to 5 for mode switches)
-    LineSeries { id: pressureGoal1; name: ""; color: Theme.pressureGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showPressure }
-    LineSeries { id: pressureGoal2; name: ""; color: Theme.pressureGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showPressure }
-    LineSeries { id: pressureGoal3; name: ""; color: Theme.pressureGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showPressure }
-    LineSeries { id: pressureGoal4; name: ""; color: Theme.pressureGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showPressure }
-    LineSeries { id: pressureGoal5; name: ""; color: Theme.pressureGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showPressure }
-
-    property var _pressureGoalLines: [pressureGoal1, pressureGoal2, pressureGoal3, pressureGoal4, pressureGoal5]
-
-    // Flow goal segments (up to 5 for mode switches)
-    LineSeries { id: flowGoal1; name: ""; color: Theme.flowGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showFlow }
-    LineSeries { id: flowGoal2; name: ""; color: Theme.flowGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showFlow }
-    LineSeries { id: flowGoal3; name: ""; color: Theme.flowGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showFlow }
-    LineSeries { id: flowGoal4; name: ""; color: Theme.flowGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showFlow }
-    LineSeries { id: flowGoal5; name: ""; color: Theme.flowGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showFlow }
-
-    property var _flowGoalLines: [flowGoal1, flowGoal2, flowGoal3, flowGoal4, flowGoal5]
-
-    // Temperature goal (single line — continuous across all modes)
-    LineSeries {
-        id: temperatureGoalSeries
-        name: ""
-        color: Theme.temperatureGoalColor
-        width: Theme.scaled(2)
-        style: Qt.DashLine
+    DashedLineSeries {
+        graphsView: chart.graphsViewRef
         axisX: timeAxis
-        axisYRight: tempAxis
+        axisY: tempAxis
+        points: chart.temperatureData
+        strokeColor: Theme.temperatureColor
+        strokeWidth: Theme.scaled(3)
+        dashed: false
         visible: chart.showTemperature
     }
 
-    // === ACTUAL DATA LINES ===
-
-    // Pressure line
-    LineSeries {
-        id: pressureSeries
-        name: "Pressure"
-        color: Theme.pressureColor
-        width: Theme.scaled(3)
+    DashedLineSeries {
+        graphsView: chart.graphsViewRef
         axisX: timeAxis
-        axisY: pressureAxis
-        visible: chart.showPressure
-    }
-
-    // Flow line
-    LineSeries {
-        id: flowSeries
-        name: "Flow"
-        color: Theme.flowColor
-        width: Theme.scaled(3)
-        axisX: timeAxis
-        axisY: pressureAxis
-        visible: chart.showFlow
-    }
-
-    // Temperature line
-    LineSeries {
-        id: temperatureSeries
-        name: "Temperature"
-        color: Theme.temperatureColor
-        width: Theme.scaled(3)
-        axisX: timeAxis
-        axisYRight: tempAxis
-        visible: chart.showTemperature
-    }
-
-    // Weight line
-    LineSeries {
-        id: weightSeries
-        name: "Weight"
-        color: Theme.weightColor
-        width: Theme.scaled(3)
-        axisX: timeAxis
-        axisYRight: weightAxis
-        visible: chart.showWeight
-    }
-
-    // Weight flow rate (delta) line - shows g/s from scale
-    LineSeries {
-        id: weightFlowRateSeries
-        name: "Weight Flow"
-        color: Theme.weightFlowColor
-        width: Theme.scaled(2)
-        axisX: timeAxis
-        axisY: pressureAxis
-        visible: chart.showWeightFlow
-    }
-
-    // Puck resistance line (P/F)
-    LineSeries {
-        id: resistanceSeries
-        name: "Resistance"
-        color: Theme.resistanceColor
-        width: Theme.scaled(2)
-        axisX: timeAxis
-        axisY: pressureAxis
-        visible: chart.showResistance && chart.advancedMode
-    }
-
-    LineSeries {
-        id: conductanceSeries
-        name: "Conductance"
-        color: Theme.conductanceColor
-        width: Theme.scaled(2)
-        axisX: timeAxis
-        axisY: pressureAxis
-        visible: chart.showConductance && chart.advancedMode
-    }
-
-    LineSeries {
-        id: darcyResistanceSeries
-        name: "Darcy Resistance"
-        color: Theme.darcyResistanceColor
-        width: Theme.scaled(2)
-        axisX: timeAxis
-        axisY: pressureAxis
-        visible: chart.showDarcyResistance && chart.advancedMode
-    }
-
-    LineSeries {
-        id: conductanceDerivativeSeries
-        name: "dC/dt"
-        color: Theme.conductanceDerivativeColor
-        width: Theme.scaled(2)
-        axisX: timeAxis
-        axisYRight: dCdtAxis
-        visible: chart.showConductanceDerivative && chart.advancedMode
-    }
-
-    LineSeries {
-        id: temperatureMixSeries
-        name: "Mix Temp"
-        color: Theme.temperatureMixColor
-        width: Theme.scaled(2)
-        axisX: timeAxis
-        axisYRight: tempAxis
+        axisY: tempAxis
+        points: chart.temperatureMixData
+        strokeColor: Theme.temperatureMixColor
+        strokeWidth: Theme.scaled(2)
+        dashed: false
         visible: chart.showTemperatureMix && chart.advancedMode
     }
 
-    // Phase marker vertical lines (up to 10 markers)
-    LineSeries { id: markerLine1; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: markerLine2; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: markerLine3; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: markerLine4; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: markerLine5; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: markerLine6; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: markerLine7; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: markerLine8; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: markerLine9; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: markerLine10; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
+    DashedLineSeries {
+        graphsView: chart.graphsViewRef
+        axisX: timeAxis
+        axisY: weightAxis
+        points: chart.weightData
+        strokeColor: Theme.weightColor
+        strokeWidth: Theme.scaled(3)
+        dashed: false
+        visible: chart.showWeight
+    }
 
-    property var _markerLines: [markerLine1, markerLine2, markerLine3, markerLine4, markerLine5,
-                                markerLine6, markerLine7, markerLine8, markerLine9, markerLine10]
+    DashedLineSeries {
+        graphsView: chart.graphsViewRef
+        axisX: timeAxis
+        axisY: dCdtAxis
+        points: chart.conductanceDerivativeData
+        strokeColor: Theme.conductanceDerivativeColor
+        strokeWidth: Theme.scaled(2)
+        dashed: false
+        visible: chart.showConductanceDerivative && chart.advancedMode
+    }
 
-    function loadMarkers() {
-        // Clear all marker lines
-        for (var i = 0; i < _markerLines.length; i++) {
-            _markerLines[i].clear()
+    // === DASHED GOAL CURVES ===
+
+    Repeater {
+        model: chart.pressureGoalSegments
+        delegate: DashedLineSeries {
+            required property var modelData
+            graphsView: chart.graphsViewRef
+            axisX: timeAxis
+            axisY: pressureAxis
+            points: modelData
+            strokeColor: Theme.pressureGoalColor
+            strokeWidth: Theme.scaled(2)
+            visible: chart.showPressure
         }
-        extractionStartMarker.clear()
+    }
 
-        // Draw vertical lines for each phase marker. "End" markers are skipped
-        // — they were only added on SAW-triggered stops, so their presence was
-        // inconsistent. The last frame-transition marker already signals the
-        // end of extraction.
-        var markerIdx = 0
-        for (var m = 0; m < phaseMarkers.length; m++) {
-            var marker = phaseMarkers[m]
-            if (marker.label === "End") continue
-            var t = marker.time
-            if (marker.label === "Start") {
-                extractionStartMarker.append(t, 0)
-                extractionStartMarker.append(t, 100)
-            } else if (markerIdx < _markerLines.length) {
-                _markerLines[markerIdx].append(t, 0)
-                _markerLines[markerIdx].append(t, 100)
-                markerIdx++
-            }
+    Repeater {
+        model: chart.flowGoalSegments
+        delegate: DashedLineSeries {
+            required property var modelData
+            graphsView: chart.graphsViewRef
+            axisX: timeAxis
+            axisY: pressureAxis
+            points: modelData
+            strokeColor: Theme.flowGoalColor
+            strokeWidth: Theme.scaled(2)
+            visible: chart.showFlow
+        }
+    }
+
+    DashedLineSeries {
+        graphsView: chart.graphsViewRef
+        axisX: timeAxis
+        axisY: tempAxis
+        points: chart.temperatureGoalData
+        strokeColor: Theme.temperatureGoalColor
+        strokeWidth: Theme.scaled(2)
+        visible: chart.showTemperature
+    }
+
+    // === VERTICAL PHASE / FRAME MARKER LINES ===
+
+    Repeater {
+        model: chart.phaseMarkers
+        delegate: DashedLineSeries {
+            required property var modelData
+            readonly property string markerLabel: modelData.label
+            readonly property bool isStart: markerLabel === "Start"
+            readonly property bool isEnd: markerLabel === "End"
+
+            graphsView: chart.graphsViewRef
+            axisX: timeAxis
+            axisY: pressureAxis
+            points: [Qt.point(modelData.time, 0), Qt.point(modelData.time, 100)]
+            strokeColor: isStart ? Theme.accentColor : Theme.frameMarkerColor
+            strokeWidth: isStart ? Theme.scaled(2) : Theme.scaled(1)
+            dashPattern: isStart ? [4, 2, 1, 2] : [1, 3]
+            // "End" markers were inconsistently emitted in older history rows; the
+            // last frame-transition marker already signals end of extraction.
+            visible: !isEnd
         }
     }
 
     // Phase marker labels
     Repeater {
         id: markerLabels
-        model: phaseMarkers
+        model: chart.phaseMarkers
 
         delegate: Item {
             id: markerDelegate
@@ -633,9 +553,9 @@ ChartView {
             property string transitionReason: modelData.transitionReason || ""
             property bool isStart: modelData.label === "Start"
 
-            x: chart.plotArea.x + (markerTime / timeAxis.max) * chart.plotArea.width
-            y: chart.plotArea.y
-            height: chart.plotArea.height
+            x: graphsView.plotArea.x + (markerTime / timeAxis.max) * graphsView.plotArea.width
+            y: graphsView.plotArea.y
+            height: graphsView.plotArea.height
             visible: markerTime <= timeAxis.max && markerTime >= 0 && chart.showPhaseLabels
                      && markerLabel !== "End"
 
@@ -656,6 +576,12 @@ ChartView {
                 color: isStart ? Theme.accentColor : Qt.rgba(255, 255, 255, 0.8)
                 rotation: -90
                 transformOrigin: Item.TopLeft
+                // Constrain natural width to the plot height (minus padding) so
+                // rotated text never extends past the plot area; elide handles
+                // long labels in small tiles. Full-page graphs have enough room
+                // that no truncation occurs.
+                width: Math.max(Theme.scaled(20), graphsView.plotArea.height - Theme.scaled(12))
+                elide: Text.ElideRight
                 x: Theme.scaled(3)
                 y: Theme.scaled(6) + width
 
@@ -673,7 +599,7 @@ ChartView {
     // Pump mode indicator bars at bottom of chart
     Repeater {
         id: pumpModeIndicators
-        model: phaseMarkers
+        model: chart.phaseMarkers
 
         delegate: Rectangle {
             required property int index
@@ -681,15 +607,15 @@ ChartView {
             property double markerTime: modelData.time
             property bool isFlowMode: modelData.isFlowMode || false
             property double nextTime: {
-                if (index < phaseMarkers.length - 1) {
-                    return phaseMarkers[index + 1].time
+                if (index < chart.phaseMarkers.length - 1) {
+                    return chart.phaseMarkers[index + 1].time
                 }
-                return maxTime
+                return chart.maxTime
             }
 
-            x: chart.plotArea.x + (markerTime / timeAxis.max) * chart.plotArea.width
-            y: chart.plotArea.y + chart.plotArea.height - Theme.scaled(4)
-            width: Math.max(0, ((nextTime - markerTime) / timeAxis.max) * chart.plotArea.width)
+            x: graphsView.plotArea.x + (markerTime / timeAxis.max) * graphsView.plotArea.width
+            y: graphsView.plotArea.y + graphsView.plotArea.height - Theme.scaled(4)
+            width: Math.max(0, ((nextTime - markerTime) / timeAxis.max) * graphsView.plotArea.width)
             height: Theme.scaled(4)
             color: isFlowMode ? Theme.flowColor : Theme.pressureColor
             opacity: 0.8
@@ -700,12 +626,13 @@ ChartView {
 
     // Time axis label - inside graph at bottom right
     Text {
-        x: chart.plotArea.x + chart.plotArea.width - width - Theme.spacingSmall
-        y: chart.plotArea.y + chart.plotArea.height - height - Theme.scaled(12)
+        x: graphsView.plotArea.x + graphsView.plotArea.width - width - Theme.spacingSmall
+        y: graphsView.plotArea.y + graphsView.plotArea.height - height - Theme.scaled(12)
         text: TranslationManager.translate("graph.timeAxis", "Time (s)")
         color: Theme.textSecondaryColor
         font: Theme.captionFont
         opacity: 0.7
+        visible: chart.showLabels
         Accessible.ignored: true
     }
 
@@ -714,22 +641,23 @@ ChartView {
         id: crosshairLine
         visible: chart.inspecting
         x: chart.inspectPixelX - width / 2
-        y: chart.plotArea.y
+        y: graphsView.plotArea.y
         width: Theme.scaled(1)
-        height: chart.plotArea.height
+        height: graphsView.plotArea.height
         color: Theme.textColor
         opacity: 0.6
         Accessible.ignored: true
     }
 
-    // Manual right-axis labels (fixed position — no layout shift when swapping)
+    // Manual right-axis labels (fixed position — no layout shift when swapping
+    // between weight and temperature scales).
     Item {
         id: rightAxisLabels
         visible: chart.showLabels
-        x: chart.plotArea.x + chart.plotArea.width + Theme.scaled(4)
-        y: chart.plotArea.y
+        x: graphsView.plotArea.x + graphsView.plotArea.width + Theme.scaled(4)
+        y: graphsView.plotArea.y
         width: chart.width - x
-        height: chart.plotArea.height
+        height: graphsView.plotArea.height
 
         Accessible.role: Accessible.Button
         Accessible.name: chart.showWeightAxis ? TranslationManager.translate("graph.rightAxisWeight", "Right axis: Weight. Tap for Temperature")
@@ -739,7 +667,6 @@ ChartView {
 
         property color labelColor: chart.showWeightAxis ? Theme.weightColor : Theme.temperatureColor
 
-        // Tick labels
         Repeater {
             model: 5
             Text {
@@ -758,7 +685,6 @@ ChartView {
             }
         }
 
-        // Axis title (rotated, centered vertically — mirrors the left axis title)
         Text {
             text: chart.showWeightAxis ? "g" : "°C"
             font: Theme.captionFont
@@ -770,5 +696,4 @@ ChartView {
             Accessible.ignored: true
         }
     }
-
 }

--- a/qml/components/ProfileGraph.qml
+++ b/qml/components/ProfileGraph.qml
@@ -1,20 +1,24 @@
 import QtQuick
-import QtCharts
+import QtGraphs
 import Decenza
+import "graphs"
 
-ChartView {
+// Profile editor preview. Pressure / flow live on the GraphsView's native left
+// axis; temperature is overlaid as a solid DashedLineSeries against a QtObject
+// value holder because Qt Graphs has no sanctioned right-Y axis in this setup.
+//
+// Outer Item wraps the GraphsView so the temperature overlay, frame-region
+// rectangles, and the custom legend render as siblings — children of GraphsView
+// would be swallowed by its scene-graph paint.
+Item {
     id: chart
-    antialiasing: true
-    backgroundColor: Qt.darker(Theme.surfaceColor, 1.3)
-    plotAreaColor: Qt.darker(Theme.surfaceColor, 1.3)
-    legend.visible: false
     Accessible.role: Accessible.Graphic
     Accessible.name: TranslationManager.translate("profileGraph.accessibleName", "Profile graph")
 
-    margins.top: 0
-    margins.bottom: Theme.scaled(32)
-    margins.left: 0
-    margins.right: 0
+    // Alias so DashedLineSeries delegates can reach the GraphsView without
+    // writing `graphsView: graphsView` — that RHS shadows the delegate's own
+    // `graphsView` property (which defaults to `parent`) and resolves to null.
+    readonly property alias graphsViewRef: graphsView
 
     // Properties
     property var frames: []
@@ -52,6 +56,10 @@ ChartView {
     // Using a plain property (not a binding) avoids QML binding-loop issues
     // with var arrays that can fail to re-evaluate on frames assignment.
     property var frameDurations: []
+
+    // Computed temperature points consumed by the right-axis overlay. updateCurves()
+    // assigns this in a single shot so the DashedLineSeries binding fires once.
+    property var _temperaturePoints: []
 
     function recomputeFrameDurations() {
         var durations = []
@@ -103,70 +111,67 @@ ChartView {
         return Math.max(total, 5)
     }
 
-    // Time axis (X)
-    ValueAxis {
-        id: timeAxis
-        min: 0
-        max: totalDuration * 1.1
-        tickCount: Math.min(10, Math.max(3, Math.floor(totalDuration / 5) + 1))
-        labelFormat: "%.0f"
-        labelsColor: Theme.textSecondaryColor
-        labelsFont.pixelSize: Theme.scaled(12)
-        gridLineColor: Qt.rgba(1, 1, 1, 0.1)
+    GraphsView {
+        id: graphsView
+        anchors.fill: parent
+        anchors.bottomMargin: Theme.scaled(32)  // room for the custom legend below
+        theme: DecenzaGraphsTheme {}
+
+        axisX: timeAxis
+        axisY: pressureAxis
+
+        // Time axis (X)
+        ValueAxis {
+            id: timeAxis
+            min: 0
+            max: chart.totalDuration * 1.1
+            tickInterval: Math.max(5, Math.ceil(chart.totalDuration / 5))
+            subTickCount: 0
+            labelFormat: "%.0f"
+        }
+
+        // Pressure/Flow axis (left Y)
+        ValueAxis {
+            id: pressureAxis
+            min: 0
+            max: 12
+            tickInterval: 3
+            subTickCount: 0
+            labelFormat: "%.0f"
+        }
+
+        // Pressure curve
+        LineSeries {
+            id: pressureSeries0
+            color: Theme.pressureGoalColor
+            width: Theme.graphLineWidth * 3
+        }
+
+        // Flow curve
+        LineSeries {
+            id: flowSeries0
+            color: Theme.flowGoalColor
+            width: Theme.graphLineWidth * 3
+        }
     }
 
-    // Pressure/Flow axis (left Y)
-    ValueAxis {
-        id: pressureAxis
-        min: 0
-        max: 12
-        tickCount: 5
-        labelFormat: "%.0f"
-        labelsColor: Theme.textSecondaryColor
-        labelsFont.pixelSize: Theme.scaled(12)
-        gridLineColor: Qt.rgba(1, 1, 1, 0.1)
-    }
-
-    // Temperature axis (right Y)
-    ValueAxis {
+    // Temperature axis holder — Qt Graphs has no axisYRight in this setup, so
+    // temperature is plotted as a DashedLineSeries against this min/max range.
+    QtObject {
         id: tempAxis
-        min: 80
-        max: 100
-        tickCount: 5
-        labelFormat: "%.0f"
-        labelsColor: Theme.temperatureColor
-        labelsFont.pixelSize: Theme.scaled(12)
-        gridLineColor: "transparent"
+        property real min: 80
+        property real max: 100
     }
 
-    // Pressure curve
-    LineSeries {
-        id: pressureSeries0
-        name: "Pressure"
-        color: Theme.pressureGoalColor
-        width: Theme.graphLineWidth * 3
+    // Temperature curve — solid stroke via the dashed-overlay bridge.
+    DashedLineSeries {
+        graphsView: chart.graphsViewRef
         axisX: timeAxis
-        axisY: pressureAxis
-    }
-
-    // Flow curve
-    LineSeries {
-        id: flowSeries0
-        name: "Flow"
-        color: Theme.flowGoalColor
-        width: Theme.graphLineWidth * 3
-        axisX: timeAxis
-        axisY: pressureAxis
-    }
-
-    // Temperature curve
-    LineSeries {
-        id: temperatureGoalSeries
-        name: "Temperature"
-        color: Theme.temperatureGoalColor
-        width: Theme.graphLineWidth * 2
-        axisX: timeAxis
-        axisYRight: tempAxis
+        axisY: tempAxis
+        points: chart._temperaturePoints
+        strokeColor: Theme.temperatureGoalColor
+        strokeWidth: Theme.graphLineWidth * 2
+        dashed: false
     }
 
     // Frame region overlays
@@ -176,7 +181,7 @@ ChartView {
 
         Repeater {
             id: frameRepeater
-            model: frames
+            model: chart.frames
 
             delegate: Item {
                 id: frameDelegate
@@ -187,35 +192,35 @@ ChartView {
 
                 Accessible.role: Accessible.ListItem
                 Accessible.name: (frame ? (frame.name || ("Frame " + (index + 1))) : "") +
-                                 (index === selectedFrameIndex ? ", selected" : "")
+                                 (index === chart.selectedFrameIndex ? ", selected" : "")
                 Accessible.focusable: true
                 Accessible.onPressAction: bgMouseArea.clicked(null)
                 property double frameStart: {
                     var start = 0
                     for (var i = 0; i < index; i++) {
-                        start += (frameDurations[i] || 0)
+                        start += (chart.frameDurations[i] || 0)
                     }
                     return start
                 }
-                property double frameDuration: frameDurations[index] || 0
+                property double frameDuration: chart.frameDurations[index] || 0
 
-                x: chart.plotArea.x + (frameStart / (totalDuration * 1.1)) * chart.plotArea.width
-                y: chart.plotArea.y
-                width: (frameDuration / (totalDuration * 1.1)) * chart.plotArea.width
-                height: chart.plotArea.height
+                x: graphsView.plotArea.x + (frameStart / (chart.totalDuration * 1.1)) * graphsView.plotArea.width
+                y: graphsView.plotArea.y
+                width: (frameDuration / (chart.totalDuration * 1.1)) * graphsView.plotArea.width
+                height: graphsView.plotArea.height
 
                 Rectangle {
                     anchors.fill: parent
                     color: {
-                        if (index === selectedFrameIndex) {
+                        if (index === chart.selectedFrameIndex) {
                             return Qt.rgba(Theme.accentColor.r, Theme.accentColor.g, Theme.accentColor.b, 0.3)
                         }
                         return index % 2 === 0 ?
                             Qt.rgba(1, 1, 1, 0.05) :
                             Qt.rgba(1, 1, 1, 0.02)
                     }
-                    border.width: index === selectedFrameIndex ? Theme.scaled(2) : Theme.scaled(1)
-                    border.color: index === selectedFrameIndex ?
+                    border.width: index === chart.selectedFrameIndex ? Theme.scaled(2) : Theme.scaled(1)
+                    border.color: index === chart.selectedFrameIndex ?
                         Theme.accentColor : Qt.rgba(1, 1, 1, 0.2)
                 }
 
@@ -235,7 +240,7 @@ ChartView {
                         text: frame ? (frame.name || ("Frame " + (index + 1))) : ""
                         color: Theme.textColor
                         font.pixelSize: Theme.scaled(14)
-                        font.bold: index === selectedFrameIndex
+                        font.bold: index === chart.selectedFrameIndex
                         rotation: -90
                         transformOrigin: Item.Center
                         opacity: 0.9
@@ -247,11 +252,11 @@ ChartView {
                         cursorShape: Qt.PointingHandCursor
                         Accessible.ignored: true
                         onClicked: {
-                            selectedFrameIndex = index
-                            frameSelected(index)
+                            chart.selectedFrameIndex = index
+                            chart.frameSelected(index)
                         }
                         onDoubleClicked: {
-                            frameDoubleClicked(index)
+                            chart.frameDoubleClicked(index)
                         }
                     }
                 }
@@ -262,11 +267,11 @@ ChartView {
                     z: -1
                     Accessible.ignored: true
                     onClicked: {
-                        selectedFrameIndex = index
-                        frameSelected(index)
+                        chart.selectedFrameIndex = index
+                        chart.frameSelected(index)
                     }
                     onDoubleClicked: {
-                        frameDoubleClicked(index)
+                        chart.frameDoubleClicked(index)
                     }
                 }
             }
@@ -280,9 +285,12 @@ ChartView {
     function updateCurves() {
         pressureSeries0.clear()
         flowSeries0.clear()
-        temperatureGoalSeries.clear()
+        var tempPts = []
 
-        if (frames.length === 0) return
+        if (frames.length === 0) {
+            _temperaturePoints = []
+            return
+        }
 
         var time = 0
         var currentPressure = 0
@@ -337,7 +345,7 @@ ChartView {
                     var pressPI = pEase * piExitP
                     pressureSeries0.append(tPI, pressPI)
                     flowSeries0.append(tPI, flowPI)
-                    temperatureGoalSeries.append(tPI, temp)
+                    tempPts.push({ x: tPI, y: temp })
                 }
                 currentPressure = piExitP
                 currentFlow = piFlow
@@ -370,7 +378,7 @@ ChartView {
                         var f = Math.max(rawFlow, residualFlow * simPresFrac[k])
                         pressureSeries0.append(t, p)
                         flowSeries0.append(t, f)
-                        temperatureGoalSeries.append(t, temp)
+                        tempPts.push({ x: t, y: temp })
                     }
                     currentPressure = targetP
                     currentFlow = residualFlow
@@ -394,15 +402,15 @@ ChartView {
                             var flowPt = residualFlow + (pPt / Math.max(1, targetP)) * residualFlow * 0.5
                             pressureSeries0.append(tPt, pPt)
                             flowSeries0.append(tPt, flowPt)
-                            temperatureGoalSeries.append(tPt, temp)
+                            tempPts.push({ x: tPt, y: temp })
                         }
                     } else {
                         pressureSeries0.append(startTime, startP)
                         pressureSeries0.append(endTime, targetP)
                         flowSeries0.append(startTime, residualFlow)
                         flowSeries0.append(endTime, residualFlow)
-                        temperatureGoalSeries.append(startTime, temp)
-                        temperatureGoalSeries.append(endTime, temp)
+                        tempPts.push({ x: startTime, y: temp })
+                        tempPts.push({ x: endTime, y: temp })
                     }
                     currentPressure = targetP
                     currentFlow = residualFlow
@@ -432,7 +440,7 @@ ChartView {
                         var ease2 = frac2 * frac2 * (3 - 2 * frac2)
                         pressureSeries0.append(tPt2, currentPressure + ease2 * (flowPressure - currentPressure))
                         flowSeries0.append(tPt2, currentFlow + ease2 * (effectiveFlow - currentFlow))
-                        temperatureGoalSeries.append(tPt2, temp)
+                        tempPts.push({ x: tPt2, y: temp })
                     }
                 } else {
                     // Fast: ramp with ease-in-out curve over ~4s (matching machine PID settling)
@@ -446,13 +454,13 @@ ChartView {
                         var easeR = fracR * fracR * (3 - 2 * fracR)
                         pressureSeries0.append(tR, currentPressure + easeR * (flowPressure - currentPressure))
                         flowSeries0.append(tR, currentFlow + easeR * (effectiveFlow - currentFlow))
-                        temperatureGoalSeries.append(tR, temp)
+                        tempPts.push({ x: tR, y: temp })
                     }
 
                     // Hold at target until end
                     pressureSeries0.append(endTime, flowPressure)
                     flowSeries0.append(endTime, effectiveFlow)
-                    temperatureGoalSeries.append(endTime, temp)
+                    tempPts.push({ x: endTime, y: temp })
                 }
 
                 currentPressure = flowPressure
@@ -461,6 +469,8 @@ ChartView {
 
             time = endTime
         }
+
+        _temperaturePoints = tempPts
     }
 
     onFramesChanged: { recomputeFrameDurations(); updateCurves() }

--- a/qml/components/ProfileGraph.qml
+++ b/qml/components/ProfileGraph.qml
@@ -115,6 +115,9 @@ Item {
         id: graphsView
         anchors.fill: parent
         anchors.bottomMargin: Theme.scaled(32)  // room for the custom legend below
+        // Reserve room on the right for the manual temperature labels; Qt Graphs
+        // has no axisYRight in this setup so we render them ourselves below.
+        anchors.rightMargin: Theme.scaled(28)
         theme: DecenzaGraphsTheme {}
 
         axisX: timeAxis
@@ -172,6 +175,31 @@ Item {
         strokeColor: Theme.temperatureGoalColor
         strokeWidth: Theme.graphLineWidth * 2
         dashed: false
+    }
+
+    // Manual right-axis temperature labels — replaces what Qt Charts' axisYRight
+    // used to render automatically. Five evenly-spaced labels mirror the original
+    // tickCount: 5 on a 80-100 °C range.
+    Item {
+        id: rightAxisLabels
+        x: graphsView.plotArea.x + graphsView.plotArea.width + Theme.scaled(2)
+        y: graphsView.plotArea.y
+        width: chart.width - x
+        height: graphsView.plotArea.height
+
+        Repeater {
+            model: 5
+            Text {
+                required property int index
+                property real value: tempAxis.max - index * (tempAxis.max - tempAxis.min) / 4
+                text: value.toFixed(0)
+                x: 0
+                y: index / 4 * rightAxisLabels.height - height / 2
+                font.pixelSize: Theme.scaled(12)
+                color: Theme.temperatureColor
+                Accessible.ignored: true
+            }
+        }
     }
 
     // Frame region overlays

--- a/qml/components/ProfileGraph.qml
+++ b/qml/components/ProfileGraph.qml
@@ -20,6 +20,10 @@ Item {
     // `graphsView` property (which defaults to `parent`) and resolves to null.
     readonly property alias graphsViewRef: graphsView
 
+    // Re-export the GraphsView's plot rect for parent pages that hit-test
+    // against it. Matches the legacy Qt Charts ChartView.plotArea API.
+    readonly property rect plotArea: graphsView.plotArea
+
     // Properties
     property var frames: []
     property int selectedFrameIndex: -1

--- a/qml/components/ProfileGraph.qml
+++ b/qml/components/ProfileGraph.qml
@@ -199,7 +199,7 @@ Item {
                 text: value.toFixed(0)
                 x: 0
                 y: index / 4 * rightAxisLabels.height - height / 2
-                font.pixelSize: Theme.scaled(12)
+                font: Theme.captionFont
                 color: Theme.temperatureColor
                 Accessible.ignored: true
             }

--- a/qml/components/ShotGraph.qml
+++ b/qml/components/ShotGraph.qml
@@ -16,6 +16,11 @@ Item {
     // `graphsView` property (which defaults to `parent`) and resolves to null.
     readonly property alias graphsViewRef: graphsView
 
+    // Re-export the GraphsView's plot rect for parent pages that hit-test
+    // against it (e.g. right-axis toggle overlays). Matches the legacy
+    // Qt Charts ChartView.plotArea API.
+    readonly property rect plotArea: graphsView.plotArea
+
     // Persisted visibility toggles (tappable legend). Settings.boolValue() coerces
     // QSettings' INI-backend strings ("true"/"false") to real booleans — plain
     // Settings.value() returns the raw QString which JavaScript treats as truthy,

--- a/qml/components/ShotGraph.qml
+++ b/qml/components/ShotGraph.qml
@@ -1,14 +1,20 @@
 import QtQuick
-import QtCharts
+import QtGraphs
 import Decenza
 import "."  // For AccessibleMouseArea
+import "graphs"
 
-ChartView {
+// Outer Item wraps GraphsView so all overlays — FastLineRenderer traces, dashed
+// goal curves, phase-marker vertical lines, manual right-axis labels — render as
+// siblings on top of the chart. GraphsView's scene-graph paints over any direct
+// QQuickItem children, so overlays must be siblings, not children.
+Item {
     id: chart
-    antialiasing: true
-    backgroundColor: "transparent"
-    plotAreaColor: Qt.darker(Theme.surfaceColor, 1.3)
-    legend.visible: false
+
+    // Alias so DashedLineSeries delegates can reach the GraphsView without
+    // writing `graphsView: graphsView` — that RHS shadows the delegate's own
+    // `graphsView` property (which defaults to `parent`) and resolves to null.
+    readonly property alias graphsViewRef: graphsView
 
     // Persisted visibility toggles (tappable legend). Settings.boolValue() coerces
     // QSettings' INI-backend strings ("true"/"false") to real booleans — plain
@@ -34,51 +40,35 @@ ChartView {
         Settings.setValue("graph/showWeightAxis", showWeightAxis)
     }
 
-    margins.top: Theme.scaled(10)
-    margins.bottom: 0
-    margins.left: Theme.scaled(40)
-    margins.right: Theme.scaled(55)
-
-    // Register goal/marker LineSeries with C++ model (infrequent updates, replace() is fine)
-    Component.onCompleted: {
-        ShotDataModel.registerSeries(
-            [pressureGoal1, pressureGoal2, pressureGoal3, pressureGoal4, pressureGoal5],
-            [flowGoal1, flowGoal2, flowGoal3, flowGoal4, flowGoal5],
-            temperatureGoalSeries,
-            extractionStartMarker, stopMarker,
-            [frameMarker1, frameMarker2, frameMarker3, frameMarker4, frameMarker5,
-             frameMarker6, frameMarker7, frameMarker8, frameMarker9, frameMarker10]
-        )
-        // Register fast renderers (QSGGeometryNode, pre-allocated VBO - no rebuilds)
-        ShotDataModel.registerFastSeries(
-            pressureRenderer, flowRenderer, temperatureRenderer,
-            weightRenderer, weightFlowRenderer, resistanceRenderer,
-            conductanceRenderer, darcyResistanceRenderer, temperatureMixRenderer
-        )
-        recalcMax()
-    }
-
-    // Calculate axis max: data fills frame with exactly 5 scaled pixels padding at right
-    // Solve: max = rawTime + paddingPixels * (max / plotWidth)
-    // => max = rawTime * plotWidth / (plotWidth - paddingPixels)
-    //
-    // timeAxis.max and tickCount are set imperatively in recalcMax() to avoid a
-    // binding loop: max → ChartView relayout → plotArea → cachedPlotWidth → recalcMax → max.
-    // Qt detects the circular dependency chain even when guards prevent infinite recursion,
-    // so we break it by removing all declarative bindings on timeAxis properties.
+    // Auto-expanding time axis. timeAxis.max is set imperatively by recalcMax() to
+    // avoid the binding-loop chain max → relayout → plotArea → cachedPlotWidth → recalcMax.
     property double minTime: 5.0
     property double paddingPixels: Theme.scaled(5)
     property double cachedPlotWidth: 1
-    property double _lastAxisMax: 5.0  // Internal change-detection cache — do NOT bind to this (causes binding loop)
+    property double _lastAxisMax: 5.0
+
+    // Pick a tickInterval that keeps the axis readable across the whole shot-length
+    // range (5 s warm-up through a 60 s+ long pour) without leaving a huge dead
+    // zone past the last tick. Mirrors the dynamic tickCount logic from Qt Charts.
+    function _niceTimeAxisStep(span) {
+        if (span <= 5)  return 1
+        if (span <= 10) return 2
+        if (span <= 30) return 5
+        return 10
+    }
 
     function recalcMax() {
+        // Track rawTime continuously (no snap-to-tick) so live data always reaches
+        // the right edge — matches the Qt Charts feel. Ticks land at multiples of
+        // tickInterval; the rightmost one may sit short of the plot edge during the
+        // shot, which is fine.
         var raw = ShotDataModel.rawTime * cachedPlotWidth / Math.max(1, cachedPlotWidth - paddingPixels)
         var newMax = Math.max(minTime, raw)
-        if (newMax !== _lastAxisMax) {
+        var step = _niceTimeAxisStep(newMax)
+        if (newMax !== _lastAxisMax || timeAxis.tickInterval !== step) {
             _lastAxisMax = newMax
-            // Assign imperatively — see block comment above for binding loop explanation
             timeAxis.max = newMax
-            timeAxis.tickCount = Math.min(7, Math.max(3, Math.floor(newMax / 10) + 2))
+            timeAxis.tickInterval = step
         }
     }
 
@@ -87,145 +77,155 @@ ChartView {
         function onRawTimeChanged() { chart.recalcMax() }
     }
 
-    onPlotAreaChanged: {
-        var w = Math.max(1, chart.plotArea.width)
-        if (Math.abs(w - cachedPlotWidth) > 1) {
-            cachedPlotWidth = w
-            recalcMax()
+    Component.onCompleted: {
+        ShotDataModel.registerFastSeries(
+            pressureRenderer, flowRenderer, temperatureRenderer,
+            weightRenderer, weightFlowRenderer, resistanceRenderer,
+            conductanceRenderer, darcyResistanceRenderer, temperatureMixRenderer
+        )
+        recalcMax()
+    }
+
+    GraphsView {
+        id: graphsView
+        anchors.fill: parent
+        // Reserve room on the right for the manual temperature/weight labels and
+        // on top for the legend. Qt Graphs doesn't carve out a right margin the
+        // way Qt Charts' margins.right did.
+        anchors.rightMargin: Theme.scaled(55)
+        anchors.topMargin: Theme.scaled(10)
+        theme: DecenzaGraphsTheme {}
+
+        axisX: timeAxis
+        axisY: pressureAxis
+
+        onPlotAreaChanged: {
+            var w = Math.max(1, graphsView.plotArea.width)
+            if (Math.abs(w - chart.cachedPlotWidth) > 1) {
+                chart.cachedPlotWidth = w
+                chart.recalcMax()
+            }
+        }
+
+        // Time axis (X). max is set imperatively by recalcMax() — declarative binding
+        // forms a feedback loop with the plotArea-driven recalc.
+        ValueAxis {
+            id: timeAxis
+            min: 0
+            max: chart.minTime
+            tickInterval: 10
+            subTickCount: 0
+            labelFormat: "%.0f"
+        }
+
+        // Pressure/Flow axis (left Y).
+        // tickInterval 3 reproduces the original tickCount: 5 (labels at 0, 3, 6, 9, 12).
+        ValueAxis {
+            id: pressureAxis
+            min: 0
+            max: 12
+            tickInterval: 3
+            subTickCount: 0
+            labelFormat: "%.0f"
+            titleText: "bar / mL·g/s"
         }
     }
 
-    // Time axis - fills frame, expands only when data pushes against right edge
-    ValueAxis {
-        id: timeAxis
-        min: 0
-        // max and tickCount are set imperatively by recalcMax() to avoid binding loop
-        max: minTime
-        tickCount: 3
-        labelFormat: "%.0f"
-        labelsColor: Theme.textSecondaryColor
-        gridLineColor: Qt.rgba(255, 255, 255, 0.1)
-        // Title moved inside graph to save vertical space
-
-        // Animation disabled: causes visible lag and curves extending past plot area
-        // Behavior on max {
-        //     NumberAnimation { duration: 100; easing.type: Easing.Linear }
-        // }
-    }
-
-    // Pressure/Flow axis (left Y)
-    ValueAxis {
-        id: pressureAxis
-        min: 0
-        max: 12
-        tickCount: 5
-        labelFormat: "%.0f"
-        labelsColor: Theme.textSecondaryColor
-        gridLineColor: Qt.rgba(255, 255, 255, 0.1)
-        titleText: "bar / mL·g/s"
-        titleBrush: Theme.textSecondaryColor
-    }
-
-    // Temperature axis (right Y) - hidden; labels provided by rightAxisLabels
-    ValueAxis {
+    // === HIDDEN RIGHT-AXIS HOLDERS ===
+    // QtObject value holders that DashedLineSeries / FastLineRenderer can read for
+    // coordinate mapping. Qt Graphs has no sanctioned dual-Y-axis path here.
+    QtObject {
         id: tempAxis
-        min: 40
-        max: 100
-        tickCount: 5
-        visible: false
+        property real min: 40
+        property real max: 100
     }
 
-    // Weight axis (right Y) - hidden; labels provided by rightAxisLabels
-    ValueAxis {
+    QtObject {
         id: weightAxis
-        min: 0
+        property real min: 0
         // Live shots may bump SAW past the configured target (#792 +10g button), so
         // take the larger of profile target and current MachineState target. Each
         // source uses an explicit > 0 check because targetWeight == 0 means SAW
         // disabled, and JS `||` would conflate that with "no data".
-        max: Math.max(10, Math.max(
+        property real max: Math.max(10, Math.max(
             ProfileManager.targetWeight > 0 ? ProfileManager.targetWeight : 0,
             MachineState.targetWeight > 0 ? MachineState.targetWeight : 0,
             36) * 1.1)
-        tickCount: 5
-        visible: false
     }
 
-    // === PHASE MARKER LINES ===
+    // === DASHED GOAL CURVES (bridge overlays) ===
 
-    LineSeries {
-        id: extractionStartMarker
-        name: ""
-        color: Theme.accentColor
-        width: Theme.scaled(2)
-        style: Qt.DashDotLine
-        axisX: timeAxis
-        axisY: pressureAxis
+    // Pressure goal segments
+    Repeater {
+        model: ShotDataModel.pressureGoalSegments
+        delegate: DashedLineSeries {
+            required property var modelData
+            graphsView: chart.graphsViewRef
+            axisX: timeAxis
+            axisY: pressureAxis
+            points: modelData
+            strokeColor: Theme.pressureGoalColor
+            strokeWidth: Theme.scaled(2)
+            visible: chart.showPressure
+        }
     }
 
-    LineSeries {
-        id: stopMarker
-        name: ""
-        color: Theme.stopMarkerColor
-        width: Theme.scaled(2)
-        style: Qt.DashDotLine
-        axisX: timeAxis
-        axisY: pressureAxis
+    // Flow goal segments
+    Repeater {
+        model: ShotDataModel.flowGoalSegments
+        delegate: DashedLineSeries {
+            required property var modelData
+            graphsView: chart.graphsViewRef
+            axisX: timeAxis
+            axisY: pressureAxis
+            points: modelData
+            strokeColor: Theme.flowGoalColor
+            strokeWidth: Theme.scaled(2)
+            visible: chart.showFlow
+        }
     }
 
-    LineSeries { id: frameMarker1; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: frameMarker2; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: frameMarker3; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: frameMarker4; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: frameMarker5; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: frameMarker6; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: frameMarker7; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: frameMarker8; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: frameMarker9; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-    LineSeries { id: frameMarker10; name: ""; color: Theme.frameMarkerColor; width: Theme.scaled(1); style: Qt.DotLine; axisX: timeAxis; axisY: pressureAxis }
-
-    // === GOAL LINES (dashed) - Multiple segments for clean breaks ===
-
-    // Pressure goal segments (up to 5 segments for mode switches)
-    LineSeries { id: pressureGoal1; name: ""; color: Theme.pressureGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showPressure }
-    LineSeries { id: pressureGoal2; name: ""; color: Theme.pressureGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showPressure }
-    LineSeries { id: pressureGoal3; name: ""; color: Theme.pressureGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showPressure }
-    LineSeries { id: pressureGoal4; name: ""; color: Theme.pressureGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showPressure }
-    LineSeries { id: pressureGoal5; name: ""; color: Theme.pressureGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showPressure }
-
-    // Flow goal segments (up to 5 segments for mode switches)
-    LineSeries { id: flowGoal1; name: ""; color: Theme.flowGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showFlow }
-    LineSeries { id: flowGoal2; name: ""; color: Theme.flowGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showFlow }
-    LineSeries { id: flowGoal3; name: ""; color: Theme.flowGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showFlow }
-    LineSeries { id: flowGoal4; name: ""; color: Theme.flowGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showFlow }
-    LineSeries { id: flowGoal5; name: ""; color: Theme.flowGoalColor; width: Theme.scaled(2); style: Qt.DashLine; axisX: timeAxis; axisY: pressureAxis; visible: chart.showFlow }
-
-    LineSeries {
-        id: temperatureGoalSeries
-        name: "T Goal"
-        color: Theme.temperatureGoalColor
-        width: Theme.scaled(2)
-        style: Qt.DashLine
+    // Temperature goal — mapped to the right tempAxis.
+    DashedLineSeries {
+        graphsView: chart.graphsViewRef
         axisX: timeAxis
-        axisYRight: tempAxis
+        axisY: tempAxis
+        points: ShotDataModel.temperatureGoalPoints
+        strokeColor: Theme.temperatureGoalColor
+        strokeWidth: Theme.scaled(2)
         visible: chart.showTemperature
     }
 
-    // Empty anchor series to keep the weight axis registered with ChartView
-    // (required for weightAxis min/max properties to update correctly)
-    LineSeries {
-        name: ""
-        axisX: timeAxis
-        axisYRight: weightAxis
+    // === VERTICAL PHASE / FRAME MARKER LINES ===
+
+    Repeater {
+        model: ShotDataModel.phaseMarkers
+        delegate: DashedLineSeries {
+            required property var modelData
+            readonly property string markerLabel: modelData.label
+            readonly property bool isStart: markerLabel === "Start"
+            readonly property bool isEnd: markerLabel === "End"
+
+            graphsView: chart.graphsViewRef
+            axisX: timeAxis
+            axisY: pressureAxis
+            points: [Qt.point(modelData.time, 0), Qt.point(modelData.time, 12)]
+            strokeColor: isStart ? Theme.accentColor
+                                 : (isEnd ? Theme.stopMarkerColor : Theme.frameMarkerColor)
+            strokeWidth: (isStart || isEnd) ? Theme.scaled(2) : Theme.scaled(1)
+            // DashDot for phase markers, Dot for inter-frame markers — closest equivalents
+            // to Qt Charts' Qt.DashDotLine / Qt.DotLine on a ShapePath dash pattern.
+            dashPattern: (isStart || isEnd) ? [4, 2, 1, 2] : [1, 3]
+        }
     }
 
     // === ACTUAL LINES (solid) - FastLineRenderer with pre-allocated VBO ===
-    // These render outside Qt Charts via QSGGeometryNode for zero-copy GPU updates
+    // These render outside Qt Graphs via QSGGeometryNode for zero-copy GPU updates.
 
     FastLineRenderer {
         id: pressureRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.pressureColor
         lineWidth: Theme.scaled(3)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -235,8 +235,8 @@ ChartView {
 
     FastLineRenderer {
         id: flowRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.flowColor
         lineWidth: Theme.scaled(3)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -246,8 +246,8 @@ ChartView {
 
     FastLineRenderer {
         id: temperatureRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.temperatureColor
         lineWidth: Theme.scaled(3)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -257,8 +257,8 @@ ChartView {
 
     FastLineRenderer {
         id: weightFlowRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.weightFlowColor
         lineWidth: Theme.scaled(2)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -268,8 +268,8 @@ ChartView {
 
     FastLineRenderer {
         id: resistanceRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.resistanceColor
         lineWidth: Theme.scaled(2)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -279,8 +279,8 @@ ChartView {
 
     FastLineRenderer {
         id: conductanceRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.conductanceColor
         lineWidth: Theme.scaled(2)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -290,8 +290,8 @@ ChartView {
 
     FastLineRenderer {
         id: darcyResistanceRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.darcyResistanceColor
         lineWidth: Theme.scaled(2)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -301,8 +301,8 @@ ChartView {
 
     FastLineRenderer {
         id: temperatureMixRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.temperatureMixColor
         lineWidth: Theme.scaled(2)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -312,8 +312,8 @@ ChartView {
 
     FastLineRenderer {
         id: weightRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.weightColor
         lineWidth: Theme.scaled(3)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -321,7 +321,7 @@ ChartView {
         visible: chart.showWeight
     }
 
-    // Frame marker labels
+    // Frame marker labels (rotated text)
     Repeater {
         id: markerLabels
         model: ShotDataModel.phaseMarkers
@@ -336,10 +336,9 @@ ChartView {
             property bool isStart: modelData.label === "Start"
             property bool isEnd: modelData.label === "End"
 
-            // Calculate position using timeAxis.max for consistent scaling with smooth scroll
-            x: chart.plotArea.x + (markerTime / timeAxis.max) * chart.plotArea.width
-            y: chart.plotArea.y
-            height: chart.plotArea.height
+            x: graphsView.plotArea.x + (markerTime / timeAxis.max) * graphsView.plotArea.width
+            y: graphsView.plotArea.y
+            height: graphsView.plotArea.height
             visible: markerTime <= timeAxis.max && markerTime >= 0
 
             Text {
@@ -362,7 +361,6 @@ ChartView {
                 transformOrigin: Item.TopLeft
                 x: Theme.scaled(4)
                 y: Theme.scaled(8) + width
-                // Decorative - accessibility handled by tap area below
                 Accessible.ignored: true
 
                 Rectangle {
@@ -416,14 +414,12 @@ ChartView {
                 if (index < markers.length - 1) {
                     return markers[index + 1].time
                 }
-                // For the last marker, extend to the current data position
                 return Math.min(ShotDataModel.rawTime, timeAxis.max)
             }
 
-            // Position and size based on marker time range
-            x: chart.plotArea.x + (markerTime / timeAxis.max) * chart.plotArea.width
-            y: chart.plotArea.y + chart.plotArea.height - Theme.scaled(4)
-            width: Math.max(0, ((nextTime - markerTime) / timeAxis.max) * chart.plotArea.width)
+            x: graphsView.plotArea.x + (markerTime / timeAxis.max) * graphsView.plotArea.width
+            y: graphsView.plotArea.y + graphsView.plotArea.height - Theme.scaled(4)
+            width: Math.max(0, ((nextTime - markerTime) / timeAxis.max) * graphsView.plotArea.width)
             height: Theme.scaled(4)
             color: isFlowMode ? Theme.flowColor : Theme.pressureColor
             opacity: 0.8
@@ -433,8 +429,8 @@ ChartView {
 
     // Time axis label - inside graph at bottom right
     Text {
-        x: chart.plotArea.x + chart.plotArea.width - width - Theme.spacingSmall
-        y: chart.plotArea.y + chart.plotArea.height - height - Theme.scaled(12)
+        x: graphsView.plotArea.x + graphsView.plotArea.width - width - Theme.spacingSmall
+        y: graphsView.plotArea.y + graphsView.plotArea.height - height - Theme.scaled(12)
         text: TranslationManager.translate("graph.axis.time", "Time (s)")
         color: Theme.textSecondaryColor
         font: Theme.captionFont
@@ -442,14 +438,14 @@ ChartView {
         Accessible.ignored: true
     }
 
-    // Manual right-axis labels — built-in Qt Charts axes cause layout shift
-    // (plotArea resizes when axis visibility toggles), so we draw labels at a fixed position
+    // Manual right-axis labels — toggling visibility on Qt Graphs ValueAxis would
+    // resize the plot area, so we draw labels at a fixed position instead.
     Item {
         id: rightAxisLabels
-        x: chart.plotArea.x + chart.plotArea.width + Theme.scaled(4)
-        y: chart.plotArea.y
+        x: graphsView.plotArea.x + graphsView.plotArea.width + Theme.scaled(4)
+        y: graphsView.plotArea.y
         width: chart.width - x
-        height: chart.plotArea.height
+        height: graphsView.plotArea.height
 
         Accessible.role: Accessible.Button
         Accessible.name: chart.showWeightAxis ? TranslationManager.translate("graph.rightAxisWeight", "Right axis: Weight. Tap for Temperature")
@@ -459,7 +455,7 @@ ChartView {
 
         property color labelColor: chart.showWeightAxis ? Theme.weightColor : Theme.temperatureColor
 
-        // Tick labels — count must match tickCount on tempAxis/weightAxis
+        // Tick labels — five evenly spaced labels mirror the original tickCount: 5.
         Repeater {
             model: 5
             Text {

--- a/qml/components/SteamGraph.qml
+++ b/qml/components/SteamGraph.qml
@@ -1,14 +1,19 @@
 import QtQuick
-import QtCharts
+import QtGraphs
 import Decenza
-import "."  // For AccessibleMouseArea
+import "graphs"
 
-ChartView {
+// Outer Item wraps the GraphsView so the FastLineRenderer / dashed overlay
+// can render as siblings on top of the chart. GraphsView swallows scene-graph
+// children that aren't its own series/axes — overlays must be siblings, not
+// children, to draw above its plot-area background and grid.
+Item {
     id: chart
-    antialiasing: true
-    backgroundColor: "transparent"
-    plotAreaColor: Qt.darker(Theme.surfaceColor, 1.3)
-    legend.visible: false
+
+    // Alias so DashedLineSeries delegates can reach the GraphsView without
+    // writing `graphsView: graphsView` — that RHS shadows the delegate's own
+    // `graphsView` property (which defaults to `parent`) and resolves to null.
+    readonly property alias graphsViewRef: graphsView
 
     // Persisted visibility toggles (tappable legend). Settings.boolValue() coerces
     // QSettings' INI-backed strings to real booleans; see Settings.h.
@@ -16,33 +21,48 @@ ChartView {
     property bool showFlow: Settings.boolValue("steamGraph/showFlow", true)
     property bool showTemperature: Settings.boolValue("steamGraph/showTemperature", true)
 
-    margins.top: Theme.scaled(10)
-    margins.bottom: 0
-    margins.left: Theme.scaled(40)
-    margins.right: Theme.scaled(55)
-
-    Component.onCompleted: {
-        SteamDataModel.registerFastSeries(pressureRenderer, flowRenderer, temperatureRenderer)
-        SteamDataModel.registerGoalSeries(flowGoalSeries)
-        recalcMax()
-    }
+    // Right-axis temperature range. Qt Graphs lacks a sanctioned dual-Y-axis path;
+    // temperature labels are drawn manually on the right margin, and FastLineRenderer
+    // maps coordinates against these scalars directly — no ValueAxis needed.
+    property real tempMin: 100
+    property real tempMax: 180
 
     // Auto-expanding time axis (same pattern as ShotGraph)
     property double minTime: 5.0
     property double paddingPixels: Theme.scaled(5)
     property double cachedPlotWidth: 1
     property double _lastAxisMax: 5.0
-    property bool _recalcInProgress: false  // Re-entry guard: axis changes trigger onPlotAreaChanged
+    property bool _recalcInProgress: false  // Re-entry guard: axis changes trigger plotArea updates
+
+    // Convenience pass-through for overlays that need the GraphsView's plot rect.
+    readonly property rect plotArea: graphsView.plotArea
+
+    Component.onCompleted: {
+        SteamDataModel.registerFastSeries(pressureRenderer, flowRenderer, temperatureRenderer)
+        recalcMax()
+    }
+
+    // Pick a tickInterval that keeps a 5 s warm-up through a 60 s+ steam session
+    // readable without leaving a dead zone past the rightmost tick.
+    function _niceTimeAxisStep(span) {
+        if (span <= 5)  return 1
+        if (span <= 10) return 2
+        if (span <= 30) return 5
+        return 10
+    }
 
     function recalcMax() {
         if (_recalcInProgress) return
         _recalcInProgress = true
+        // Track rawTime continuously (no snap-to-tick) so live data reaches the
+        // right edge — matches the Qt Charts feel.
         var raw = SteamDataModel.rawTime * cachedPlotWidth / Math.max(1, cachedPlotWidth - paddingPixels)
         var newMax = Math.max(minTime, raw)
-        if (newMax !== _lastAxisMax) {
+        var step = _niceTimeAxisStep(newMax)
+        if (newMax !== _lastAxisMax || timeAxis.tickInterval !== step) {
             _lastAxisMax = newMax
             timeAxis.max = newMax
-            timeAxis.tickCount = Math.min(7, Math.max(3, Math.floor(newMax / 10) + 2))
+            timeAxis.tickInterval = step
         }
         _recalcInProgress = false
     }
@@ -52,17 +72,7 @@ ChartView {
         function onRawTimeChanged() { chart.recalcMax() }
     }
 
-    onPlotAreaChanged: {
-        var w = Math.max(1, chart.plotArea.width)
-        if (Math.abs(w - cachedPlotWidth) > 1) {
-            cachedPlotWidth = w
-            recalcMax()
-        }
-    }
-
     // Sync visibility toggles from Settings (e.g., changed on another page).
-    // Uses Settings.boolValue() to coerce the QSettings INI-backend strings —
-    // see Settings.h.
     Connections {
         target: Settings
         function onValueChanged(key) {
@@ -72,64 +82,68 @@ ChartView {
         }
     }
 
-    // Time axis (X)
-    ValueAxis {
-        id: timeAxis
-        min: 0
-        max: chart.minTime
-        tickCount: 3
-        labelFormat: "%.0f"
-        labelsColor: Theme.textSecondaryColor
-        gridLineColor: Qt.rgba(255, 255, 255, 0.1)
-    }
+    GraphsView {
+        id: graphsView
+        anchors.fill: parent
+        // Reserve room on the right for the manual temperature labels; Qt Graphs
+        // doesn't have a sanctioned dual-Y-axis path here and won't carve out
+        // right-margin space the way Qt Charts' margins.right did.
+        anchors.rightMargin: Theme.scaled(55)
+        anchors.topMargin: Theme.scaled(10)
+        theme: DecenzaGraphsTheme {}
 
-    // Pressure/Flow axis (left Y) — steam pressure is typically 0–4 bar
-    ValueAxis {
-        id: pressureAxis
-        min: 0
-        max: 6
-        tickCount: 4
-        labelFormat: "%.0f"
-        labelsColor: Theme.textSecondaryColor
-        gridLineColor: Qt.rgba(255, 255, 255, 0.1)
-        titleText: "bar / mL/s"
-        titleBrush: Theme.textSecondaryColor
-    }
-
-    // Temperature axis (right Y) — hidden; labels drawn manually
-    ValueAxis {
-        id: tempAxis
-        min: 100
-        max: 180
-        tickCount: 5
-        visible: false
-    }
-
-    // Flow goal (dashed line)
-    LineSeries {
-        id: flowGoalSeries
-        name: ""
-        color: Theme.flowGoalColor
-        width: Theme.scaled(2)
-        style: Qt.DashLine
         axisX: timeAxis
         axisY: pressureAxis
-        visible: chart.showFlow
+
+        onPlotAreaChanged: {
+            var w = Math.max(1, graphsView.plotArea.width)
+            if (Math.abs(w - chart.cachedPlotWidth) > 1) {
+                chart.cachedPlotWidth = w
+                chart.recalcMax()
+            }
+        }
+
+        // Time axis (X)
+        ValueAxis {
+            id: timeAxis
+            min: 0
+            max: chart.minTime
+            tickInterval: 10
+            subTickCount: 0
+            labelFormat: "%.0f"
+            titleText: "s"
+        }
+
+        // Pressure/Flow axis (left Y) — steam pressure is typically 0–4 bar.
+        // tickInterval 2 reproduces the original tickCount: 4 (labels at 0, 2, 4, 6).
+        ValueAxis {
+            id: pressureAxis
+            min: 0
+            max: 6
+            tickInterval: 2
+            subTickCount: 0
+            labelFormat: "%.0f"
+            titleText: "bar / mL/s"
+        }
     }
 
-    // Empty anchor series to keep tempAxis registered with ChartView
-    LineSeries {
-        name: ""
+    // Flow goal (dashed line) — bridge overlay; Qt Graphs LineSeries has no dash style.
+    DashedLineSeries {
+        graphsView: chart.graphsViewRef
         axisX: timeAxis
-        axisYRight: tempAxis
+        axisY: pressureAxis
+        points: SteamDataModel.flowGoalPoints
+        strokeColor: Theme.flowGoalColor
+        strokeWidth: Theme.scaled(2)
+        visible: chart.showFlow
     }
 
     // === LIVE DATA — FastLineRenderer (pre-allocated VBO) ===
 
     FastLineRenderer {
         id: pressureRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.pressureColor
         lineWidth: Theme.scaled(3)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -139,8 +153,8 @@ ChartView {
 
     FastLineRenderer {
         id: flowRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.flowColor
         lineWidth: Theme.scaled(3)
         minX: timeAxis.min; maxX: timeAxis.max
@@ -150,19 +164,19 @@ ChartView {
 
     FastLineRenderer {
         id: temperatureRenderer
-        x: chart.plotArea.x; y: chart.plotArea.y
-        width: chart.plotArea.width; height: chart.plotArea.height
+        x: graphsView.plotArea.x; y: graphsView.plotArea.y
+        width: graphsView.plotArea.width; height: graphsView.plotArea.height
         color: Theme.temperatureColor
         lineWidth: Theme.scaled(3)
         minX: timeAxis.min; maxX: timeAxis.max
-        minY: tempAxis.min; maxY: tempAxis.max
+        minY: chart.tempMin; maxY: chart.tempMax
         visible: chart.showTemperature
     }
 
     // Time axis label — inside graph at bottom right
     Text {
-        x: chart.plotArea.x + chart.plotArea.width - width - Theme.spacingSmall
-        y: chart.plotArea.y + chart.plotArea.height - height - Theme.scaled(12)
+        x: graphsView.plotArea.x + graphsView.plotArea.width - width - Theme.spacingSmall
+        y: graphsView.plotArea.y + graphsView.plotArea.height - height - Theme.scaled(12)
         text: TranslationManager.translate("graph.axis.time", "Time (s)")
         color: Theme.textSecondaryColor
         font: Theme.captionFont
@@ -170,13 +184,13 @@ ChartView {
         Accessible.ignored: true
     }
 
-    // Manual right-axis labels for temperature
+    // Manual right-axis labels for temperature (Qt Graphs has no second Y axis here)
     Item {
         id: rightAxisLabels
-        x: chart.plotArea.x + chart.plotArea.width + Theme.scaled(4)
-        y: chart.plotArea.y
+        x: graphsView.plotArea.x + graphsView.plotArea.width + Theme.scaled(4)
+        y: graphsView.plotArea.y
         width: chart.width - x
-        height: chart.plotArea.height
+        height: graphsView.plotArea.height
 
         Accessible.role: Accessible.StaticText
         Accessible.name: TranslationManager.translate("steamGraph.rightAxis", "Temperature axis")
@@ -186,7 +200,7 @@ ChartView {
             model: 5
             Text {
                 required property int index
-                property real value: tempAxis.max - index * (tempAxis.max - tempAxis.min) / 4
+                property real value: chart.tempMax - index * (chart.tempMax - chart.tempMin) / 4
                 text: value.toFixed(0)
                 x: 0
                 y: index / 4 * rightAxisLabels.height - height / 2
@@ -210,64 +224,26 @@ ChartView {
 
     // === TAPPABLE LEGEND ===
 
-    Row {
-        id: legendRow
-        x: chart.plotArea.x
-        y: chart.plotArea.y + Theme.scaled(4)
-        spacing: Theme.spacingMedium
+    CustomLegend {
+        id: legend
+        x: graphsView.plotArea.x
+        y: graphsView.plotArea.y + Theme.scaled(4)
+        width: implicitWidth
 
-        Repeater {
-            model: [
-                { label: TranslationManager.translate("steamGraph.legend.pressure", "Pressure"), color: Theme.pressureColor, key: "steamGraph/showPressure", shown: chart.showPressure },
-                { label: TranslationManager.translate("steamGraph.legend.flow", "Flow"), color: Theme.flowColor, key: "steamGraph/showFlow", shown: chart.showFlow },
-                { label: TranslationManager.translate("steamGraph.legend.temperature", "Temperature"), color: Theme.temperatureColor, key: "steamGraph/showTemperature", shown: chart.showTemperature }
-            ]
+        readonly property var _keys: ["steamGraph/showPressure", "steamGraph/showFlow", "steamGraph/showTemperature"]
 
-            delegate: Rectangle {
-                id: legendItem
-                width: legendItemRow.implicitWidth + Theme.spacingSmall * 2
-                height: legendItemRow.implicitHeight + Theme.scaled(4)
-                radius: Theme.scaled(4)
-                color: "transparent"
-                opacity: modelData.shown ? 1.0 : 0.4
+        entries: [
+            { label: TranslationManager.translate("steamGraph.legend.pressure", "Pressure"), color: Theme.pressureColor, active: chart.showPressure },
+            { label: TranslationManager.translate("steamGraph.legend.flow", "Flow"), color: Theme.flowColor, active: chart.showFlow },
+            { label: TranslationManager.translate("steamGraph.legend.temperature", "Temperature"), color: Theme.temperatureColor, active: chart.showTemperature }
+        ]
 
-                Accessible.ignored: true
-
-                Row {
-                    id: legendItemRow
-                    anchors.centerIn: parent
-                    spacing: Theme.scaled(4)
-
-                    Rectangle {
-                        width: Theme.scaled(12)
-                        height: Theme.scaled(3)
-                        radius: Theme.scaled(1)
-                        color: modelData.color
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-
-                    Text {
-                        text: modelData.label
-                        color: Theme.textColor
-                        font: Theme.captionFont
-                        Accessible.ignored: true
-                    }
-                }
-
-                AccessibleMouseArea {
-                    anchors.fill: parent
-                    accessibleName: modelData.label + (modelData.shown ? "" : " " + TranslationManager.translate("common.hidden", "hidden"))
-                    accessibleItem: legendItem
-                    onAccessibleClicked: {
-                        var newVal = !modelData.shown
-                        Settings.setValue(modelData.key, newVal)
-                        // Direct update for immediate feedback
-                        if (modelData.key === "steamGraph/showPressure") chart.showPressure = newVal
-                        else if (modelData.key === "steamGraph/showFlow") chart.showFlow = newVal
-                        else if (modelData.key === "steamGraph/showTemperature") chart.showTemperature = newVal
-                    }
-                }
-            }
+        onEntryToggled: (index, nowActive) => {
+            Settings.setValue(_keys[index], nowActive)
+            // Direct update for immediate feedback
+            if (index === 0) chart.showPressure = nowActive
+            else if (index === 1) chart.showFlow = nowActive
+            else chart.showTemperature = nowActive
         }
     }
 }

--- a/qml/components/graphs/CustomLegend.qml
+++ b/qml/components/graphs/CustomLegend.qml
@@ -38,6 +38,7 @@ Item {
     // Emitted when the user taps an entry; consumer applies the new state to the series.
     signal entryToggled(int index, bool nowActive)
 
+    implicitWidth: legendFlow.implicitWidth
     implicitHeight: legendFlow.implicitHeight
     Layout.fillWidth: true
 

--- a/qml/components/graphs/DashedLineSeries.qml
+++ b/qml/components/graphs/DashedLineSeries.qml
@@ -5,18 +5,27 @@
 // overlay aligned to a parent `GraphsView`'s plot area, mapping data-space
 // points (matching the attached `axisX` / `axisY`) into pixel space.
 //
-// Place this *inside* a `GraphsView` (so `plotArea` is reachable as
-// `plotArea` on the parent) or pass an explicit `graphsView` reference.
+// Standard placement is as a SIBLING of `GraphsView` inside an outer wrapper
+// Item, with `graphsView` set explicitly via the chart's `graphsViewRef`
+// alias. Children of `GraphsView` are painted over by its own scene-graph
+// pass and don't show up. Inside-the-GraphsView placement still works if no
+// overlap with axis grids/labels is needed — `graphsView` then defaults to
+// `parent`.
 //
-// Usage:
-//   DashedLineSeries {
-//       graphsView: chart           // optional; defaults to parent
-//       axisX: timeAxis
-//       axisY: valueAxis
-//       points: shotModel.goalPoints   // [Qt.point(x, y), ...] from your data model
-//       strokeColor: Theme.flowGoalColor
-//       strokeWidth: Theme.graphLineWidth
-//       dashPattern: [4, 4]
+// Usage (sibling pattern, used by every Decenza chart in this codebase):
+//   Item {
+//       id: chart
+//       readonly property alias graphsViewRef: graphsView
+//       GraphsView { id: graphsView; axisX: timeAxis; axisY: valueAxis; ... }
+//       DashedLineSeries {
+//           graphsView: chart.graphsViewRef
+//           axisX: timeAxis
+//           axisY: valueAxis
+//           points: shotModel.goalPoints   // [Qt.point(x, y), ...]
+//           strokeColor: Theme.flowGoalColor
+//           strokeWidth: Theme.graphLineWidth
+//           dashPattern: [4, 4]
+//       }
 //   }
 //
 // Replaces: Qt Charts `LineSeries { style: Qt.DashLine }`.

--- a/qml/components/graphs/DashedLineSeries.qml
+++ b/qml/components/graphs/DashedLineSeries.qml
@@ -43,7 +43,8 @@ Item {
     // Stroke style.
     property color strokeColor: Theme.textColor
     property real strokeWidth: Theme.graphLineWidth
-    property var dashPattern: [4, 4]  // length pairs in stroke widths
+    property bool dashed: true
+    property var dashPattern: [4, 4]  // length pairs in stroke widths; ignored when dashed: false
 
     // The overlay fills the plot area of the parent GraphsView.
     readonly property var _plotArea: graphsView && graphsView.plotArea ? graphsView.plotArea : null
@@ -101,7 +102,7 @@ Item {
             strokeColor: root.strokeColor
             strokeWidth: root.strokeWidth
             fillColor: "transparent"
-            strokeStyle: ShapePath.DashLine
+            strokeStyle: root.dashed ? ShapePath.DashLine : ShapePath.SolidLine
             dashPattern: root.dashPattern
             capStyle: ShapePath.RoundCap
             joinStyle: ShapePath.RoundJoin

--- a/qml/components/layout/items/LastShotItem.qml
+++ b/qml/components/layout/items/LastShotItem.qml
@@ -16,7 +16,9 @@ Item {
     // User-configurable properties (from settings popup)
     readonly property real shotScale: typeof modelData.shotScale === "number" ? modelData.shotScale : 1.0
     readonly property bool shotShowLabels: typeof modelData.shotShowLabels === "boolean" ? modelData.shotShowLabels : false
-    readonly property bool shotShowPhaseLabels: typeof modelData.shotShowPhaseLabels === "boolean" ? modelData.shotShowPhaseLabels : true
+    // Default off — the widget tile is too small for rotated phase-label text
+    // to read cleanly. Opt in via the widget settings popup.
+    readonly property bool shotShowPhaseLabels: typeof modelData.shotShowPhaseLabels === "boolean" ? modelData.shotShowPhaseLabels : false
 
     // Shot data cache
     property var shotData: ({})

--- a/src/controllers/autoflowcalclassifier.h
+++ b/src/controllers/autoflowcalclassifier.h
@@ -6,7 +6,7 @@
 /**
  * Minimal frame-transition record used as input to the auto-flow-cal
  * window classifier. Decoupled from `PhaseMarker` (which lives in
- * shotdatamodel.h and pulls in Qt Charts / Quick) so the classifier
+ * shotdatamodel.h and pulls in Qt Graphs / Quick) so the classifier
  * can be unit-tested without the full ShotDataModel stack.
  *
  * Callers in production code convert `PhaseMarker -> FrameTransition`

--- a/src/models/shotcomparisonmodel.cpp
+++ b/src/models/shotcomparisonmodel.cpp
@@ -7,7 +7,6 @@
 #include "../core/dbutils.h"
 #include <QThread>
 #include <algorithm>
-#include <QtCharts/QXYSeries>
 
 // Shot colors: Green, Blue, Orange
 const QList<QColor> ShotComparisonModel::SHOT_COLORS = {
@@ -297,60 +296,6 @@ void ShotComparisonModel::calculateMaxValues()
     }
 }
 
-void ShotComparisonModel::populateSeries(int shotIdx,
-                                          QObject* pObj, QObject* fObj,
-                                          QObject* tObj, QObject* wObj,
-                                          QObject* wfObj, QObject* rObj) const
-{
-    auto clearSeries = [](QObject* obj) {
-        if (auto* s = qobject_cast<QXYSeries*>(obj)) s->clear();
-    };
-
-    if (shotIdx < 0 || shotIdx >= m_displayShots.size()) {
-        clearSeries(pObj); clearSeries(fObj); clearSeries(tObj);
-        clearSeries(wObj); clearSeries(wfObj); clearSeries(rObj);
-        return;
-    }
-
-    const auto& shot = m_displayShots[shotIdx];
-
-    if (auto* s = qobject_cast<QXYSeries*>(pObj))  s->replace(shot.pressure);
-    if (auto* s = qobject_cast<QXYSeries*>(fObj))  s->replace(shot.flow);
-    if (auto* s = qobject_cast<QXYSeries*>(tObj))  s->replace(shot.temperature);
-    if (auto* s = qobject_cast<QXYSeries*>(wfObj)) s->replace(shot.weightFlowRate);
-    if (auto* s = qobject_cast<QXYSeries*>(rObj))  s->replace(shot.resistance);
-
-    // Weight is scaled /5 to overlay on the pressure axis (0–50g → 0–10 bar range)
-    if (auto* s = qobject_cast<QXYSeries*>(wObj)) {
-        QList<QPointF> scaled;
-        scaled.reserve(shot.weight.size());
-        for (const auto& pt : shot.weight)
-            scaled.append(QPointF(pt.x(), pt.y() / 5.0));
-        s->replace(scaled);
-    }
-}
-
-void ShotComparisonModel::populateAdvancedSeries(int shotIdx,
-                                                  QObject* cObj, QObject* dcdtObj,
-                                                  QObject* drObj, QObject* mtObj) const
-{
-    auto clearSeries = [](QObject* obj) {
-        if (auto* s = qobject_cast<QXYSeries*>(obj)) s->clear();
-    };
-
-    if (shotIdx < 0 || shotIdx >= m_displayShots.size()) {
-        clearSeries(cObj); clearSeries(dcdtObj);
-        clearSeries(drObj); clearSeries(mtObj);
-        return;
-    }
-
-    const auto& shot = m_displayShots[shotIdx];
-    if (auto* s = qobject_cast<QXYSeries*>(cObj))    s->replace(shot.conductance);
-    if (auto* s = qobject_cast<QXYSeries*>(dcdtObj)) s->replace(shot.conductanceDerivative);
-    if (auto* s = qobject_cast<QXYSeries*>(drObj))   s->replace(shot.darcyResistance);
-    if (auto* s = qobject_cast<QXYSeries*>(mtObj))   s->replace(shot.temperatureMix);
-}
-
 QVariantList ShotComparisonModel::pointsToVariant(const QVector<QPointF>& points) const
 {
     QVariantList result;
@@ -397,6 +342,30 @@ QVariantList ShotComparisonModel::getResistanceData(int index) const
 {
     if (index < 0 || index >= m_displayShots.size()) return QVariantList();
     return pointsToVariant(m_displayShots[index].resistance);
+}
+
+QVariantList ShotComparisonModel::getConductanceData(int index) const
+{
+    if (index < 0 || index >= m_displayShots.size()) return QVariantList();
+    return pointsToVariant(m_displayShots[index].conductance);
+}
+
+QVariantList ShotComparisonModel::getConductanceDerivativeData(int index) const
+{
+    if (index < 0 || index >= m_displayShots.size()) return QVariantList();
+    return pointsToVariant(m_displayShots[index].conductanceDerivative);
+}
+
+QVariantList ShotComparisonModel::getDarcyResistanceData(int index) const
+{
+    if (index < 0 || index >= m_displayShots.size()) return QVariantList();
+    return pointsToVariant(m_displayShots[index].darcyResistance);
+}
+
+QVariantList ShotComparisonModel::getTemperatureMixData(int index) const
+{
+    if (index < 0 || index >= m_displayShots.size()) return QVariantList();
+    return pointsToVariant(m_displayShots[index].temperatureMix);
 }
 
 QVariantList ShotComparisonModel::getPhaseMarkers(int index) const

--- a/src/models/shotcomparisonmodel.h
+++ b/src/models/shotcomparisonmodel.h
@@ -62,26 +62,16 @@ public:
     Q_INVOKABLE void shiftWindowRight();
     Q_INVOKABLE void setWindowStart(int index);
 
-    // Bulk-populate LineSeries objects for one shot slot using C++ QXYSeries::replace().
-    // Out-of-range shotIdx clears all series.
-    Q_INVOKABLE void populateSeries(int shotIdx,
-                                    QObject* pSeries, QObject* fSeries,
-                                    QObject* tSeries, QObject* wSeries,
-                                    QObject* wfSeries, QObject* rSeries) const;
-
-    // Same as populateSeries but for the advanced curves (conductance, dC/dt,
-    // Darcy resistance, mix temp). Split into a separate method so Q_INVOKABLE
-    // signatures stay at a reasonable arg count.
-    Q_INVOKABLE void populateAdvancedSeries(int shotIdx,
-                                             QObject* cSeries, QObject* dcdtSeries,
-                                             QObject* drSeries, QObject* mtSeries) const;
-
     Q_INVOKABLE QVariantList getPressureData(int index) const;
     Q_INVOKABLE QVariantList getFlowData(int index) const;
     Q_INVOKABLE QVariantList getTemperatureData(int index) const;
     Q_INVOKABLE QVariantList getWeightData(int index) const;
     Q_INVOKABLE QVariantList getWeightFlowRateData(int index) const;
     Q_INVOKABLE QVariantList getResistanceData(int index) const;
+    Q_INVOKABLE QVariantList getConductanceData(int index) const;
+    Q_INVOKABLE QVariantList getConductanceDerivativeData(int index) const;
+    Q_INVOKABLE QVariantList getDarcyResistanceData(int index) const;
+    Q_INVOKABLE QVariantList getTemperatureMixData(int index) const;
     Q_INVOKABLE QVariantList getPhaseMarkers(int index) const;
 
     Q_INVOKABLE QVariantMap getShotInfo(int index) const;

--- a/src/models/shotdatamodel.cpp
+++ b/src/models/shotdatamodel.cpp
@@ -39,50 +39,6 @@ ShotDataModel::~ShotDataModel() {
     }
 }
 
-void ShotDataModel::registerSeries(const QVariantList& pressureGoalSegments, const QVariantList& flowGoalSegments,
-                                    QLineSeries* temperatureGoal,
-                                    QLineSeries* extractionMarker,
-                                    QLineSeries* stopMarker,
-                                    const QVariantList& frameMarkers) {
-    m_temperatureGoalSeries = temperatureGoal;
-    m_extractionMarkerSeries = extractionMarker;
-    m_stopMarkerSeries = stopMarker;
-
-    // Register pressure goal segment series
-    m_pressureGoalSeriesList.clear();
-    for (const QVariant& v : pressureGoalSegments) {
-        if (auto* series = qobject_cast<QLineSeries*>(v.value<QObject*>())) {
-            m_pressureGoalSeriesList.append(series);
-        }
-    }
-
-    // Register flow goal segment series
-    m_flowGoalSeriesList.clear();
-    for (const QVariant& v : flowGoalSegments) {
-        if (auto* series = qobject_cast<QLineSeries*>(v.value<QObject*>())) {
-            m_flowGoalSeriesList.append(series);
-        }
-    }
-
-    m_frameMarkerSeries.clear();
-    for (const QVariant& v : frameMarkers) {
-        if (auto* series = qobject_cast<QLineSeries*>(v.value<QObject*>())) {
-            m_frameMarkerSeries.append(series);
-        }
-    }
-
-    qDebug() << "ShotDataModel: Registered goal/marker series";
-
-    // If we have existing goal/marker data, flush it
-    if (!m_pressureGoalSegments[0].isEmpty() || !m_pendingMarkers.isEmpty()) {
-        m_dirty = true;
-        onFlushTimerTick();
-    }
-
-    // Start the flush timer
-    m_flushTimer->start();
-}
-
 void ShotDataModel::registerFastSeries(FastLineRenderer* pressure, FastLineRenderer* flow,
                                         FastLineRenderer* temperature,
                                         FastLineRenderer* weight, FastLineRenderer* weightFlow,
@@ -141,6 +97,17 @@ void ShotDataModel::registerFastSeries(FastLineRenderer* pressure, FastLineRende
     }
 
     qDebug() << "ShotDataModel: Registered fast renderers (QSGGeometryNode, pre-allocated VBO)";
+
+    // Replay any goal-curve data we already accumulated so DashedLineSeries
+    // bindings see the current state immediately (e.g., returning to the
+    // espresso page after a shot completes).
+    if (!m_pressureGoalSegments.isEmpty() && !m_pressureGoalSegments[0].isEmpty()) {
+        m_goalCurvesDirty = true;
+        m_dirty = true;
+        onFlushTimerTick();
+    }
+
+    m_flushTimer->start();
 }
 
 void ShotDataModel::clear() {
@@ -162,7 +129,6 @@ void ShotDataModel::clear() {
     m_cumulativeWeightPoints.clear();
     m_weightFlowRatePoints.clear();
     m_weightFlowRateRawPoints.clear();
-    m_pendingMarkers.clear();
 
     // Reset goal segments - keep first segment with capacity
     m_pressureGoalSegments.clear();
@@ -192,27 +158,9 @@ void ShotDataModel::clear() {
     m_lastFlushedDarcyResistance = 0;
     m_lastFlushedTemperatureMix = 0;
 
-    // Clear goal/marker chart series
-    if (m_temperatureGoalSeries) m_temperatureGoalSeries->clear();
-    if (m_extractionMarkerSeries) m_extractionMarkerSeries->clear();
-    if (m_stopMarkerSeries) m_stopMarkerSeries->clear();
-    m_pendingStopTime = -1;
     m_stopTime = -1;
     m_weightAtStop = 0.0;
 
-    // Clear all goal segment series
-    for (const auto& series : m_pressureGoalSeriesList) {
-        if (series) series->clear();
-    }
-    for (const auto& series : m_flowGoalSeriesList) {
-        if (series) series->clear();
-    }
-
-    for (const auto& series : m_frameMarkerSeries) {
-        if (series) series->clear();
-    }
-
-    m_frameMarkerIndex = 0;
     m_phaseMarkers.clear();
     m_maxTime = 5.0;
     m_rawTime = 0.0;
@@ -222,9 +170,11 @@ void ShotDataModel::clear() {
     m_currentFlowGoalSegment = 0;
     m_dirty = false;
     m_rawTimeDirty = false;
+    m_goalCurvesDirty = false;
 
     emit cleared();
     emit phaseMarkersChanged();
+    emit goalCurvesChanged();
     emit maxTimeChanged();
     emit rawTimeChanged();
 
@@ -312,11 +262,14 @@ void ShotDataModel::addSample(double time, double pressure, double flow, double 
     // Add goal points to current segments
     if (pressureGoal > 0) {
         m_pressureGoalSegments[m_currentPressureGoalSegment].append(QPointF(time, pressureGoal));
+        m_goalCurvesDirty = true;
     }
     if (flowGoal > 0) {
         m_flowGoalSegments[m_currentFlowGoalSegment].append(QPointF(time, flowGoal));
+        m_goalCurvesDirty = true;
     }
     m_temperatureGoalPoints.append(QPointF(time, temperatureGoal));
+    m_goalCurvesDirty = true;
 
     // Update raw time - QML uses this to calculate axis max with pixel-based padding
     // Signal deferred to onFlushTimerTick() to avoid triggering chart axis recalc on every 5Hz sample
@@ -381,20 +334,16 @@ void ShotDataModel::addWeightSample(double time, double weight) {
 }
 
 void ShotDataModel::markExtractionStart(double time) {
-    m_pendingMarkers.append({time, "Start"});
-
     PhaseMarker marker;
     marker.time = time;
     marker.label = "Start";
     marker.frameNumber = 0;
     m_phaseMarkers.append(marker);
 
-    m_dirty = true;
     emit phaseMarkersChanged();
 }
 
 void ShotDataModel::markStopAt(double time) {
-    m_pendingStopTime = time;
     m_stopTime = time;
 
     // Find the weight at or just before the stop time
@@ -412,7 +361,6 @@ void ShotDataModel::markStopAt(double time) {
     marker.frameNumber = -1;
     m_phaseMarkers.append(marker);
 
-    m_dirty = true;
     emit phaseMarkersChanged();
     emit stopTimeChanged();
     emit weightAtStopChanged();
@@ -509,8 +457,6 @@ void ShotDataModel::trimSettlingData() {
 }
 
 void ShotDataModel::addPhaseMarker(double time, const QString& label, int frameNumber, bool isFlowMode, const QString& transitionReason) {
-    m_pendingMarkers.append({time, label});
-
     PhaseMarker marker;
     marker.time = time;
     marker.label = label;
@@ -519,7 +465,6 @@ void ShotDataModel::addPhaseMarker(double time, const QString& label, int frameN
     marker.transitionReason = transitionReason;
     m_phaseMarkers.append(marker);
 
-    m_dirty = true;
     emit phaseMarkersChanged();
 }
 
@@ -573,47 +518,12 @@ void ShotDataModel::onFlushTimerTick() {
         m_lastFlushedTemperatureMix = m_temperatureMixPoints.size();
     }
 
-    // Update goal curve LineSeries (infrequent updates, replace() is fine)
-    for (qsizetype i = 0; i < m_pressureGoalSegments.size() && i < m_pressureGoalSeriesList.size(); ++i) {
-        if (m_pressureGoalSeriesList[i] && !m_pressureGoalSegments[i].isEmpty()) {
-            m_pressureGoalSeriesList[i]->replace(m_pressureGoalSegments[i]);
-        }
-    }
-    for (qsizetype i = 0; i < m_flowGoalSegments.size() && i < m_flowGoalSeriesList.size(); ++i) {
-        if (m_flowGoalSeriesList[i] && !m_flowGoalSegments[i].isEmpty()) {
-            m_flowGoalSeriesList[i]->replace(m_flowGoalSegments[i]);
-        }
-    }
-    if (m_temperatureGoalSeries && !m_temperatureGoalPoints.isEmpty()) {
-        m_temperatureGoalSeries->replace(m_temperatureGoalPoints);
-    }
-
-    // Process pending vertical markers
-    for (const auto& marker : m_pendingMarkers) {
-        if (marker.second == "Start") {
-            if (m_extractionMarkerSeries) {
-                m_extractionMarkerSeries->append(marker.first, 0);
-                m_extractionMarkerSeries->append(marker.first, 12);
-            }
-        } else {
-            if (m_frameMarkerIndex < m_frameMarkerSeries.size()) {
-                const auto& series = m_frameMarkerSeries[m_frameMarkerIndex];
-                if (series) {
-                    series->append(marker.first, 0);
-                    series->append(marker.first, 12);
-                }
-                m_frameMarkerIndex++;
-            }
-        }
-    }
-    m_pendingMarkers.clear();
-
-    // Draw stop marker if pending
-    if (m_pendingStopTime >= 0 && m_stopMarkerSeries) {
-        m_stopMarkerSeries->clear();  // Clear any existing line
-        m_stopMarkerSeries->append(m_pendingStopTime, 0);
-        m_stopMarkerSeries->append(m_pendingStopTime, 12);
-        m_pendingStopTime = -1;  // Mark as drawn
+    // Goal-curve points republished as QML-bindable properties — DashedLineSeries
+    // Repeaters re-read pressureGoalSegments / flowGoalSegments / temperatureGoalPoints
+    // and the per-axis bridge overlays re-draw against the current axis range.
+    if (m_goalCurvesDirty) {
+        m_goalCurvesDirty = false;
+        emit goalCurvesChanged();
     }
 
     // Emit deferred rawTimeChanged (axis recalc) at flush rate instead of per-sample
@@ -662,4 +572,38 @@ QVector<QPointF> ShotDataModel::flowGoalData() const {
         combined.append(segment);
     }
     return combined;
+}
+
+// Variant-list accessors for QML — DashedLineSeries Repeaters bind to these.
+// Each segment becomes a JS array of Qt.point(x, y); the outer list is the segments.
+
+static QVariantList pointsToVariantList(const QVector<QPointF>& pts) {
+    QVariantList out;
+    out.reserve(pts.size());
+    for (const QPointF& p : pts) {
+        out.append(QVariant::fromValue(p));
+    }
+    return out;
+}
+
+QVariantList ShotDataModel::pressureGoalSegmentsVariant() const {
+    QVariantList out;
+    out.reserve(m_pressureGoalSegments.size());
+    for (const auto& segment : m_pressureGoalSegments) {
+        out.append(QVariant::fromValue(pointsToVariantList(segment)));
+    }
+    return out;
+}
+
+QVariantList ShotDataModel::flowGoalSegmentsVariant() const {
+    QVariantList out;
+    out.reserve(m_flowGoalSegments.size());
+    for (const auto& segment : m_flowGoalSegments) {
+        out.append(QVariant::fromValue(pointsToVariantList(segment)));
+    }
+    return out;
+}
+
+QVariantList ShotDataModel::temperatureGoalPointsVariant() const {
+    return pointsToVariantList(m_temperatureGoalPoints);
 }

--- a/src/models/shotdatamodel.h
+++ b/src/models/shotdatamodel.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <QList>
 #include <QObject>
-#include <QTimer>
-#include <QVector>
 #include <QPointF>
 #include <QPointer>
+#include <QTimer>
 #include <QVariantList>
-#include <QtCharts/QLineSeries>
+#include <QVector>
 
 class FastLineRenderer;
 
@@ -27,6 +27,11 @@ class ShotDataModel : public QObject {
     Q_PROPERTY(double stopTime READ stopTime NOTIFY stopTimeChanged)
     Q_PROPERTY(double weightAtStop READ weightAtStop NOTIFY weightAtStopChanged)
     Q_PROPERTY(double finalWeight READ finalWeight NOTIFY finalWeightChanged)
+    // Goal curves exposed as Qt.point()-compatible variant lists so DashedLineSeries
+    // Repeaters can bind directly — replaces the QLineSeries handshake.
+    Q_PROPERTY(QVariantList pressureGoalSegments READ pressureGoalSegmentsVariant NOTIFY goalCurvesChanged)
+    Q_PROPERTY(QVariantList flowGoalSegments READ flowGoalSegmentsVariant NOTIFY goalCurvesChanged)
+    Q_PROPERTY(QVariantList temperatureGoalPoints READ temperatureGoalPointsVariant NOTIFY goalCurvesChanged)
 
 public:
     explicit ShotDataModel(QObject* parent = nullptr);
@@ -38,13 +43,9 @@ public:
     double weightAtStop() const { return m_weightAtStop; }
     double finalWeight() const;
     QVariantList phaseMarkersVariant() const;
-
-    // Register goal/marker chart series (LineSeries - infrequent updates)
-    Q_INVOKABLE void registerSeries(const QVariantList& pressureGoalSegments, const QVariantList& flowGoalSegments,
-                                     QLineSeries* temperatureGoal,
-                                     QLineSeries* extractionMarker,
-                                     QLineSeries* stopMarker,
-                                     const QVariantList& frameMarkers);
+    QVariantList pressureGoalSegmentsVariant() const;
+    QVariantList flowGoalSegmentsVariant() const;
+    QVariantList temperatureGoalPointsVariant() const;
 
     // Register fast renderers for live data series (QSGGeometryNode - pre-allocated VBO)
     Q_INVOKABLE void registerFastSeries(FastLineRenderer* pressure, FastLineRenderer* flow,
@@ -102,6 +103,7 @@ signals:
     void stopTimeChanged();
     void weightAtStopChanged();
     void finalWeightChanged();
+    void goalCurvesChanged();
     void flushed();  // Emitted after 33ms timer flushes new data to renderers
 
 private slots:
@@ -148,22 +150,14 @@ private:
     qsizetype m_lastFlushedDarcyResistance = 0;
     qsizetype m_lastFlushedTemperatureMix = 0;
 
-    // Chart series for goals/markers (QPointer auto-nulls when QML destroys them)
-    QList<QPointer<QLineSeries>> m_pressureGoalSeriesList;  // One per segment
-    QList<QPointer<QLineSeries>> m_flowGoalSeriesList;      // One per segment
-    QPointer<QLineSeries> m_temperatureGoalSeries;
-    QPointer<QLineSeries> m_extractionMarkerSeries;
-    QPointer<QLineSeries> m_stopMarkerSeries;
-    QList<QPointer<QLineSeries>> m_frameMarkerSeries;
-
     // Batched update timer (30fps)
     QTimer* m_flushTimer = nullptr;
     bool m_dirty = false;
+    bool m_goalCurvesDirty = false;
 
     double m_maxTime = 5.0;
     double m_rawTime = 0.0;
     bool m_rawTimeDirty = false;  // Deferred: emit rawTimeChanged in onFlushTimerTick()
-    int m_frameMarkerIndex = 0;
     bool m_lastPumpModeIsFlow = false;  // Track for starting new goal segments
     bool m_hasPumpModeData = false;     // True after first sample with pump mode
     int m_currentPressureGoalSegment = 0;  // Current segment index
@@ -171,8 +165,6 @@ private:
 
     // Phase markers for QML labels
     QList<PhaseMarker> m_phaseMarkers;
-    QList<QPair<double, QString>> m_pendingMarkers;  // Pending vertical lines
-    double m_pendingStopTime = -1;  // Stop marker time (-1 = none)
     double m_stopTime = -1;          // Recorded stop time for accessibility
     double m_weightAtStop = 0.0;     // Weight when stop was triggered
 

--- a/src/models/steamdatamodel.cpp
+++ b/src/models/steamdatamodel.cpp
@@ -23,6 +23,15 @@ SteamDataModel::~SteamDataModel() {
     }
 }
 
+QVariantList SteamDataModel::flowGoalPoints() const {
+    QVariantList list;
+    list.reserve(m_flowGoalPoints.size());
+    for (const QPointF& p : m_flowGoalPoints) {
+        list.append(QVariant::fromValue(p));
+    }
+    return list;
+}
+
 void SteamDataModel::registerFastSeries(FastLineRenderer* pressure, FastLineRenderer* flow,
                                           FastLineRenderer* temperature) {
     m_fastPressure = pressure;
@@ -48,15 +57,6 @@ void SteamDataModel::registerFastSeries(FastLineRenderer* pressure, FastLineRend
     m_flushTimer->start();
 }
 
-void SteamDataModel::registerGoalSeries(QLineSeries* flowGoal) {
-    m_flowGoalSeries = flowGoal;
-
-    // Flush any existing goal data
-    if (m_flowGoalSeries && !m_flowGoalPoints.isEmpty()) {
-        m_flowGoalSeries->replace(m_flowGoalPoints);
-    }
-}
-
 void SteamDataModel::clear() {
     m_flushTimer->stop();
 
@@ -72,7 +72,6 @@ void SteamDataModel::clear() {
     m_lastFlushedFlow = 0;
     m_lastFlushedTemp = 0;
 
-    if (m_flowGoalSeries) m_flowGoalSeries->clear();
     m_flowGoalDirty = false;
 
     m_maxTime = 5.0;
@@ -83,6 +82,7 @@ void SteamDataModel::clear() {
     emit cleared();
     emit maxTimeChanged();
     emit rawTimeChanged();
+    emit flowGoalPointsChanged();
 
     m_flushTimer->start();
 }
@@ -126,10 +126,10 @@ void SteamDataModel::onFlushTimerTick() {
         m_lastFlushedTemp = m_temperaturePoints.size();
     }
 
-    // Update flow goal LineSeries
-    if (m_flowGoalDirty && m_flowGoalSeries && !m_flowGoalPoints.isEmpty()) {
-        m_flowGoalSeries->replace(m_flowGoalPoints);
+    // Goal points republished as a QML-bindable property — no series handshake needed.
+    if (m_flowGoalDirty) {
         m_flowGoalDirty = false;
+        emit flowGoalPointsChanged();
     }
 
     // Emit time change (deferred to flush tick to avoid per-sample signals)

--- a/src/models/steamdatamodel.h
+++ b/src/models/steamdatamodel.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <QObject>
-#include <QTimer>
-#include <QVector>
 #include <QPointF>
 #include <QPointer>
-#include <QtCharts/QLineSeries>
+#include <QTimer>
+#include <QVariantList>
+#include <QVector>
 
 class FastLineRenderer;
 
@@ -15,6 +15,7 @@ class SteamDataModel : public QObject {
     Q_PROPERTY(double maxTime READ maxTime NOTIFY maxTimeChanged)
     Q_PROPERTY(double rawTime READ rawTime NOTIFY rawTimeChanged)
     Q_PROPERTY(int sampleCount READ sampleCount NOTIFY rawTimeChanged)
+    Q_PROPERTY(QVariantList flowGoalPoints READ flowGoalPoints NOTIFY flowGoalPointsChanged)
 
 public:
     explicit SteamDataModel(QObject* parent = nullptr);
@@ -24,12 +25,13 @@ public:
     double rawTime() const { return m_rawTime; }
     int sampleCount() const { return static_cast<int>(m_pressurePoints.size()); }
 
+    // Goal-curve points exposed as Qt.point()-compatible variant list so
+    // DashedLineSeries can bind directly without a C++/QML series handshake.
+    QVariantList flowGoalPoints() const;
+
     // Register fast renderers for live data series (QSGGeometryNode, pre-allocated VBO)
     Q_INVOKABLE void registerFastSeries(FastLineRenderer* pressure, FastLineRenderer* flow,
                                          FastLineRenderer* temperature);
-
-    // Register flow goal LineSeries (infrequent updates)
-    Q_INVOKABLE void registerGoalSeries(QLineSeries* flowGoal);
 
     // Session summary accessors (used by SteamHealthTracker after steaming ends)
     // All skip the first 2 seconds of data (pressure is intentionally high at start)
@@ -54,6 +56,7 @@ signals:
     void cleared();
     void maxTimeChanged();
     void rawTimeChanged();
+    void flowGoalPointsChanged();
     void flushed();  // Emitted after 33ms timer flushes new data to renderers
 
 private slots:
@@ -76,8 +79,6 @@ private:
     qsizetype m_lastFlushedFlow = 0;
     qsizetype m_lastFlushedTemp = 0;
 
-    // Flow goal LineSeries (set once per session)
-    QPointer<QLineSeries> m_flowGoalSeries;
     bool m_flowGoalDirty = false;
 
     // Batched update timer (30fps)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -194,7 +194,7 @@ add_decenza_test(tst_shotanalysis
 # Qt::Quick + fastlinerenderer come in transitively via shotdatamodel.h —
 # summarizeFromHistory() doesn't touch ShotDataModel itself, but the
 # shotsummarizer.cpp translation unit links its symbols.
-find_package(Qt6 REQUIRED COMPONENTS Quick Charts)
+find_package(Qt6 REQUIRED COMPONENTS Quick Graphs)
 # Compile the AI resource files (profile knowledge, dial-in reference,
 # claude agent) into the test binary so ShotSummarizer's lazy loaders
 # find them silently. Without this, calls to shotAnalysisSystemPrompt()
@@ -218,7 +218,7 @@ add_decenza_test(tst_shotsummarizer
     ${CMAKE_BINARY_DIR}/version_code.cpp
     ${TST_SHOTSUMMARIZER_AI_RESOURCES}
 )
-target_link_libraries(tst_shotsummarizer PRIVATE Qt6::Quick Qt6::Charts)
+target_link_libraries(tst_shotsummarizer PRIVATE Qt6::Quick Qt6::Graphs)
 target_include_directories(tst_shotsummarizer PRIVATE ${CMAKE_BINARY_DIR})
 
 # --- tst_aimanager: canonical-source separation end-to-end (task 10.5) ---
@@ -253,7 +253,7 @@ add_decenza_test(tst_aimanager
     ${CMAKE_BINARY_DIR}/version_code.cpp
     ${TST_AIMANAGER_AI_RESOURCES}
 )
-target_link_libraries(tst_aimanager PRIVATE Qt6::Quick Qt6::Charts)
+target_link_libraries(tst_aimanager PRIVATE Qt6::Quick Qt6::Graphs)
 target_include_directories(tst_aimanager PRIVATE ${CMAKE_BINARY_DIR})
 
 # --- tst_shotcorpus: Qt Test wrapper around shot_eval --validate.
@@ -400,7 +400,7 @@ add_decenza_test(tst_dbmigration
     ${SIMULATOR_SOURCES}
     ${CMAKE_BINARY_DIR}/version_code.cpp
 )
-target_link_libraries(tst_dbmigration PRIVATE Qt6::Charts Qt6::Quick)
+target_link_libraries(tst_dbmigration PRIVATE Qt6::Graphs Qt6::Quick)
 target_include_directories(tst_dbmigration PRIVATE ${CMAKE_BINARY_DIR})
 
 # --- tst_dialing_blocks: DB-backed coverage for the four shared
@@ -428,7 +428,7 @@ add_decenza_test(tst_dialing_blocks
     ${CMAKE_BINARY_DIR}/version_code.cpp
     ${TST_DIALING_BLOCKS_AI_RESOURCES}
 )
-target_link_libraries(tst_dialing_blocks PRIVATE Qt6::Charts Qt6::Quick)
+target_link_libraries(tst_dialing_blocks PRIVATE Qt6::Graphs Qt6::Quick)
 target_include_directories(tst_dialing_blocks PRIVATE ${CMAKE_BINARY_DIR})
 
 # --- tst_shotrecord_cache: ShotRecord::cachedAnalysis dedup + fallback ---
@@ -443,7 +443,7 @@ add_decenza_test(tst_shotrecord_cache
     ${SIMULATOR_SOURCES}
     ${CMAKE_BINARY_DIR}/version_code.cpp
 )
-target_link_libraries(tst_shotrecord_cache PRIVATE Qt6::Charts Qt6::Quick)
+target_link_libraries(tst_shotrecord_cache PRIVATE Qt6::Graphs Qt6::Quick)
 target_include_directories(tst_shotrecord_cache PRIVATE ${CMAKE_BINARY_DIR})
 
 # --- tst_scaleprotocol: Scale BLE packet parsing (Decent, Bookoo) ---
@@ -480,7 +480,7 @@ add_decenza_test(tst_saw
 )
 
 # --- tst_settling: SAW settling trimSettlingData(), m_sawSettling flag, shot save ordering ---
-find_package(Qt6 REQUIRED COMPONENTS Charts Quick)
+find_package(Qt6 REQUIRED COMPONENTS Graphs Quick)
 add_decenza_test(tst_settling
     tst_settling.cpp
     mocks/MockScaleDevice.h
@@ -494,7 +494,7 @@ add_decenza_test(tst_settling
     ${CONTROLLER_SOURCES}
     ${SIMULATOR_SOURCES}
 )
-target_link_libraries(tst_settling PRIVATE Qt6::Charts Qt6::Quick)
+target_link_libraries(tst_settling PRIVATE Qt6::Graphs Qt6::Quick)
 
 # --- tst_sav: MachineState SAV tests ---
 add_decenza_test(tst_sav
@@ -518,7 +518,7 @@ set(MCP_MOC_HEADERS
 )
 
 # --- tst_profilemanager: ProfileManager lifecycle, signals, BLE, MCP resources, QML bindings ---
-find_package(Qt6 REQUIRED COMPONENTS Charts Quick Qml)
+find_package(Qt6 REQUIRED COMPONENTS Graphs Quick Qml)
 add_decenza_test(tst_profilemanager
     tst_profilemanager.cpp
     ${MCP_MOC_HEADERS}
@@ -534,7 +534,7 @@ add_decenza_test(tst_profilemanager
     ${SIMULATOR_SOURCES}
     ${CMAKE_BINARY_DIR}/version_code.cpp
 )
-target_link_libraries(tst_profilemanager PRIVATE Qt6::Charts Qt6::Quick Qt6::Qml paho-mqtt3a-static)
+target_link_libraries(tst_profilemanager PRIVATE Qt6::Graphs Qt6::Quick Qt6::Qml paho-mqtt3a-static)
 target_include_directories(tst_profilemanager PRIVATE ${CMAKE_BINARY_DIR})
 target_compile_definitions(tst_profilemanager PRIVATE SRCDIR="${CMAKE_SOURCE_DIR}/tests")
 # Add built-in profiles QRC so isBuiltInFilename() works in tests
@@ -546,7 +546,7 @@ target_sources(tst_tclimport PRIVATE ${PROFILES_QRC})
 # --- MCP tool tests (ProfileManager + MockTransport) ---
 
 # --- tst_mcptools_profiles: Profile MCP tools, PR #561 BLE upload regression ---
-find_package(Qt6 REQUIRED COMPONENTS Charts Quick)
+find_package(Qt6 REQUIRED COMPONENTS Graphs Quick)
 add_decenza_test(tst_mcptools_profiles
     tst_mcptools_profiles.cpp
     ${MCP_MOC_HEADERS}
@@ -560,7 +560,7 @@ add_decenza_test(tst_mcptools_profiles
     ${SIMULATOR_SOURCES}
     ${CMAKE_BINARY_DIR}/version_code.cpp
 )
-target_link_libraries(tst_mcptools_profiles PRIVATE Qt6::Charts Qt6::Quick paho-mqtt3a-static)
+target_link_libraries(tst_mcptools_profiles PRIVATE Qt6::Graphs Qt6::Quick paho-mqtt3a-static)
 target_include_directories(tst_mcptools_profiles PRIVATE ${CMAKE_BINARY_DIR})
 
 # --- tst_mcptools_write: Write MCP tools (settings_set temp/weight BLE upload) ---
@@ -590,13 +590,13 @@ add_decenza_test(tst_mcptools_write
     ${SIMULATOR_SOURCES}
     ${CMAKE_BINARY_DIR}/version_code.cpp
 )
-target_link_libraries(tst_mcptools_write PRIVATE Qt6::Charts Qt6::Quick Qt6::TextToSpeech Qt6::Multimedia paho-mqtt3a-static)
+target_link_libraries(tst_mcptools_write PRIVATE Qt6::Graphs Qt6::Quick Qt6::TextToSpeech Qt6::Multimedia paho-mqtt3a-static)
 target_include_directories(tst_mcptools_write PRIVATE ${CMAKE_BINARY_DIR})
 
 # --- tst_mcpserver_session: Session management, ping, subscribe/unsubscribe ---
 # Uses real mcpserver.cpp but stubs out tool/resource registration functions
 # to avoid linking mcptools_*.cpp and their heavy transitive deps.
-find_package(Qt6 REQUIRED COMPONENTS Charts Quick)
+find_package(Qt6 REQUIRED COMPONENTS Graphs Quick)
 add_decenza_test(tst_mcpserver_session
     tst_mcpserver_session.cpp
     ${MCP_MOC_HEADERS}
@@ -619,14 +619,14 @@ add_decenza_test(tst_mcpserver_session
     ${SIMULATOR_SOURCES}
     ${CMAKE_BINARY_DIR}/version_code.cpp
 )
-target_link_libraries(tst_mcpserver_session PRIVATE Qt6::Charts Qt6::Quick paho-mqtt3a-static)
+target_link_libraries(tst_mcpserver_session PRIVATE Qt6::Graphs Qt6::Quick paho-mqtt3a-static)
 target_include_directories(tst_mcpserver_session PRIVATE ${CMAKE_BINARY_DIR})
 
 # --- tst_mcpserver_protocol: 2025-11-25 spec compliance (version negotiation,
 # MCP-Protocol-Version header validation, Origin allowlist, structuredContent,
 # resource_link extraction, title/icons/$schema). Stubs out tool/resource
 # registration like tst_mcpserver_session — same dependency footprint.
-find_package(Qt6 REQUIRED COMPONENTS Charts Quick)
+find_package(Qt6 REQUIRED COMPONENTS Graphs Quick)
 add_decenza_test(tst_mcpserver_protocol
     tst_mcpserver_protocol.cpp
     ${MCP_MOC_HEADERS}
@@ -649,7 +649,7 @@ add_decenza_test(tst_mcpserver_protocol
     ${SIMULATOR_SOURCES}
     ${CMAKE_BINARY_DIR}/version_code.cpp
 )
-target_link_libraries(tst_mcpserver_protocol PRIVATE Qt6::Charts Qt6::Quick paho-mqtt3a-static)
+target_link_libraries(tst_mcpserver_protocol PRIVATE Qt6::Graphs Qt6::Quick paho-mqtt3a-static)
 target_include_directories(tst_mcpserver_protocol PRIVATE ${CMAKE_BINARY_DIR})
 
 # Compile the production qrc so :/icons/* paths resolve at runtime — the
@@ -681,4 +681,4 @@ add_decenza_test(tst_steamhealth
     ${CMAKE_SOURCE_DIR}/src/machine/steamhealthtracker.cpp
     ${CMAKE_SOURCE_DIR}/src/rendering/fastlinerenderer.cpp
 )
-target_link_libraries(tst_steamhealth PRIVATE Qt6::Quick Qt6::Charts)
+target_link_libraries(tst_steamhealth PRIVATE Qt6::Quick Qt6::Graphs)


### PR DESCRIPTION
## Summary

Completes the `migrate-charting-to-qt-graphs` OpenSpec change. After this PR Decenza renders every graph through Qt Graphs and no longer links Qt Charts at all. Builds on top of Stage 0 + 1 already on `main` (PR #1144).

Eight commits, one per stage so reviewers can read the migration in the order it was actually performed:

| Commit | Stage | What |
|---|---|---|
| `d3529c4f` | 2 | `SteamGraph` + `SteamDataModel` |
| `8c6cff33` | 2 fix | Wrap `GraphsView` in outer `Item` so overlays render (sibling vs child z-order) |
| `219d0110` | 3a | `ShotGraph` + `ShotDataModel` (live extraction view) |
| `f6e6e31b` | 3a fix | Time axis tracks `rawTime` continuously, dynamic `tickInterval` |
| `34520ffc` | 3b | `HistoryShotGraph` (shot detail / post-shot review / bean info / last-shot widget) |
| `ec172eac` | 3c | `ComparisonGraph` + `ShotComparisonModel` (3-shot side-by-side) |
| `bdecced4` | 3d | `ProfileGraph` (profile / recipe editor preview) |
| `47efa205` | 4 | Drop Qt Charts from `CMakeLists.txt`, tests, all 6 CI workflows |
| `5b461d22` | doc | `docs/CLAUDE_MD/PERFORMANCE_BASELINE.md` measurement protocol |

## Key architectural notes

- **Outer `Item` wraps every `GraphsView`** so `FastLineRenderer` traces, dashed goal curves, frame markers, and the crosshair render as siblings on top of the chart. Direct children of `GraphsView` get swallowed by its scene-graph paint — discovered the hard way on Stage 2 (lines were invisible until restructured).
- **Three bridge components in `qml/components/graphs/`** close the gaps Qt Graphs has vs. Qt Charts: `AutoRangingAxis`, `CustomLegend`, `DashedLineSeries` (now also supports solid stroke via a `dashed` property — used as the right-axis overlay on graphs with multiple Y axes).
- **Right-axis traces use `QtObject` value holders, not real `ValueAxis`** — Qt Graphs has no sanctioned `axisYRight` here on 6.11. `DashedLineSeries` reads `min`/`max` for its data→pixel mapping, so a min/max QObject is enough.
- **Data models lose their `QXYSeries*` handshakes.** Goal segments and right-axis traces are exposed as `QVariantList` Q_PROPERTYs that `DashedLineSeries` binds to directly. Same 33 ms flush batching is preserved.
- **`grep -r "QtCharts" qml/ src/` returns zero** after this PR. The "Multiple QAbstractAxis types" warning that flagged the coexistence period is gone.

## Performance — P.5 measurement on macOS Debug

Captured `QSG_RENDER_TIMING=1` per-frame totals on the same Mac with the same simulated A-Flow shot (~25–27 s extraction) on both builds. Pre-migration build is `f8eb3bbf` (commit immediately before Stage 0). Debug-vs-Debug, so absolute numbers will look very different on Release / tablet — the ratio is the signal.

**Shot extraction window (during the pour):**

| Metric | Qt Charts | Qt Graphs | Δ |
|---|---|---|---|
| Frames captured | 2851 | 3048 | +7 % |
| Mean frame time | **5.63 ms** | **4.31 ms** | **−23 %** |
| p95 frame time | 8.0 ms | 8.0 ms | flat (display refresh ceiling) |
| p99 frame time | 8.5 ms | 9.0 ms | +0.5 ms |
| Drops > 16 ms | 0 | 0 | none |
| Max frame | 16 ms | 24 ms | single outlier (goal-curve flush) |

**Full run (incl. idle, shot, history scroll, comparison):**

| Metric | Qt Charts | Qt Graphs | Δ |
|---|---|---|---|
| Mean frame time | 6.32 ms | 4.69 ms | **−26 %** |

**Tablet (Decent SM-X210, Android, Release APK from this PR's CI build):**

Sampled `/proc/<pid>/stat` at 2 Hz across a simulated shot.

| Metric | Qt Charts | Qt Graphs | Δ |
|---|---|---|---|
| Shot-window mean CPU (samples ≥ 40 %) | 68.0 % | 56.7 % | **−16.7 %** (−11.4 pp of one core) |
| Whole-run mean CPU | 61.3 % | 41.2 % | **−32.8 %** (−20.1 pp) |
| Whole-run p95 CPU | 78.4 % | 75.4 % | −3 pp |
| Max CPU | 104.5 % | 77.5 % | −27 pp |
| RSS max | 280.5 MB | 245.0 MB | −35 MB |

11 percentage points of one core off the shot-window mean is real heat / battery savings on the slower tablet — the absolutely-bigger win that the proposal predicted ("the larger remaining CPU cost on extraction-time UI"). The 33 % whole-run improvement is bigger because Qt Graphs also costs less when idling, scrolling history, and on the compare page.

P.5 verdict: **continue.** The proposal called for "measurable CPU drop on the live-shot metric → schedule Stages 2 + 3 immediately." 23 % mean reduction is well past noise; on the Decent tablet (where the 16 ms budget actually bites) the saved per-frame cost should keep more frames inside budget. Stages 2 + 3 + 4 are already in this PR; Qt 6.12 `useCanvasPainter` polish is tracked in `charts-qt-6-12-polish`.

Raw data: `/tmp/decenza-charts.log` (Qt Charts run), `/tmp/decenza-graphs.log` (Qt Graphs run), parser `/tmp/parse_render.py` — happy to re-run on any other commit if reviewers want.

## What's deferred

`openspec/changes/charts-qt-6-12-polish` tracks the items that need Qt 6.12: tick-mark length, leftmost X label alignment, `useCanvasPainter: true` flip per migrated `GraphsView`, declarative `XYSeries.data` for static series, `labelPostFormat`. None of these block this PR.

Tablet measurement is still a follow-up — Mac Debug confirms the direction; tablet Release will confirm the magnitude.

## Test plan

- [ ] On-device smoke test on the Decent tablet (Samsung SM-X210)
- [ ] Live espresso shot — pressure / flow / temperature / weight traces, dashed goal segments across pump-mode transitions, frame markers, "Start" / "End" markers, rotated marker labels with `[W]`/`[P]`/`[F]`/`[T]` suffixes, pump-mode color bars
- [ ] Live steam session — pressure / flow / temperature trace, dashed flow-goal curve, legend at top-left, right-axis temperature labels
- [ ] Shot detail screen — all traces render, crosshair + value tooltip on tap, right-axis margin tap toggles weight ↔ temperature
- [ ] Post-shot review — same checks
- [ ] Comparison page with 2–3 shots — solid (shot 0), dashed (shot 1), dash-dot (shot 2); per-shot Canvas phase markers; default-visible second-to-last phase seeds the crosshair
- [ ] Profile editor / Recipe editor / Simple profile editor / Profile preview popup / Profile info — pressure + flow + temperature preview live as you tap through frames
- [ ] Bean info page / Last-shot layout widget — `HistoryShotGraph` renders correctly
- [ ] Clean build on Windows, macOS, iOS, Android via CI
- [x] Mac Debug perf comparison captured (see "Performance" section above)
- [x] Tablet Release perf comparison captured (see "Performance" section above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




