### PR TITLE
ci(linux-arm64): install qtquick3d (qtgraphs depends on it)

### DIFF
--- a/.github/workflows/linux-arm64-release.yml
+++ b/.github/workflows/linux-arm64-release.yml
@@ -73,7 +73,7 @@ jobs:
           version: '6.11.1'
           target: 'desktop'
           arch: 'linux_gcc_arm64'
-          modules: 'qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtserialport qtimageformats qtcanvaspainter'
+          modules: 'qtquick3d qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtserialport qtimageformats qtcanvaspainter'
           cache: true
           cache-key-prefix: 'qt-linux-arm64-v1'
 


### PR DESCRIPTION
## Summary

The Linux ARM64 build started failing on the v1.7.5 re-tag after #1146 because Qt Graphs has a transitive dependency on Qt Quick 3D, and the Linux ARM64 workflow was the only one not installing it.

Failed CI run (CMake configure error):
https://github.com/Kulitorum/Decenza/actions/runs/25889426755

Error from logs:
\`\`\`
Qt6Graphs could not be found because dependency Qt6Quick3D could not be found.
\`\`\`

The other five release workflows (Android, iOS, macOS, Windows, Linux x64) all already list \`qtquick3d\` in the aqtinstall \`modules:\` string. This one-line change brings Linux ARM64 in line.

## Test plan

- [ ] Land this PR
- [ ] Re-tag v1.7.5 at the merge commit to retrigger all 6 builds
- [ ] Linux ARM64 workflow turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)