### PR TITLE
fix: remove inferred-good shot auto-rating (#1150)

### DIFF
--- a/openspec/changes/remove-inferred-shot-ratings/.openspec.yaml
+++ b/openspec/changes/remove-inferred-shot-ratings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/remove-inferred-shot-ratings/design.md
+++ b/openspec/changes/remove-inferred-shot-ratings/design.md
@@ -1,0 +1,79 @@
+## Context
+
+The May-4 `add-shot-rating-capture` change shipped three layers to combat advisor "rating starvation" (a user database with 199 unrated shots was the originating evidence). Layers 1 and 2 (conversational capture, QuickRatingRow) directly elicit ratings from the user and have proven their worth in practice. Layer 3 — auto-stamping 75 on clean shots — was the cheap fallback layer, intended to keep `bestRecentShot` warm when the elicitation layers haven't yet collected user ratings.
+
+Two weeks of real-world data showed Layer 3 was a net negative. Issue [#1150](https://github.com/Kulitorum/Decenza/issues/1150) makes the user-visible failure concrete: the Visualizer "Default Shot Rating" setting (a long-standing user preference) is silently overwritten by the auto-rating. On the advisor side, the inferred score is paired with `confidence: "inferred"` and a system-prompt instruction telling the LLM to treat it as a hint requiring user confirmation — i.e., the value is engineered to be ignored. Meanwhile the LLM already receives the underlying detector signals (`verdictCategory`, `channelingSeverity`, `grindDirection`) which carry the same information directly.
+
+This change removes Layer 3 entirely and restores the pre-Layer-3 contract: a shot's rating is what the user said it is, full stop.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Stop auto-stamping `enjoyment=75` on saved shots.
+- Restore the Visualizer "Default Shot Rating" setting as the single source of truth for unrated-shot rating.
+- Remove all `enjoymentSource` / `confidence: "inferred"` plumbing from the C++ surface, MCP tools, AI system prompts, and `ShotProjection`.
+- Drop the `shots.enjoyment_source` column from the SQLite schema cleanly.
+- Reset the ~11 days of auto-stamped 75s already in user databases to the user's configured default, so they stop polluting `bestRecentShot` selection and Visualizer uploads.
+- Keep Layer 1 and Layer 2 untouched.
+
+**Non-Goals:**
+- Reworking `bestRecentShot` selection beyond removing the inferred tier (it falls back to the pre-Layer-3 "highest user-rated in last 90 days" rule).
+- Changing the elicitation prompts in Layer 1 / Layer 2.
+- Building a richer rating provenance model (`source`, `confidence`, etc.) — the experiment showed we don't need it.
+- Downgrade compatibility. Downgrading to a Layer-3 build after this lands will re-add the column at default `'none'`; the reset enjoyment values stay reset.
+
+## Decisions
+
+### Drop the column, don't leave it dormant
+
+Considered: keep `shots.enjoyment_source` in the schema as a deprecated column, stop reading/writing it, deal with cleanup later.
+
+Chose: drop the column in the same migration that resets affected rows.
+
+**Rationale:** Jeff's call — "drop the column as that is generally a safe thing and it could cause confusion later." Dormant columns rot: a future engineer reading the schema will wonder what `enjoyment_source` is for, find archived spec text referencing it, and waste time. SQLite ≥ 3.35 supports `ALTER TABLE ... DROP COLUMN`, which is already used by migration 15 (dropping `temperature_unstable`). No new platform constraint.
+
+### Migrate `enjoyment_source = 'inferred'` rows to the user's configured default, not 0
+
+Considered:
+- Reset to `0` (simplest).
+- Reset to `75` (preserve the inferred score as if a user had rated it 75).
+- Reset to the user's `defaultShotRating` setting (Jeff's call).
+
+Chose: reset to `defaultShotRating`.
+
+**Rationale:** The bug report's pain point is exactly that the user's configured default was overridden. The most coherent rollback is to land each affected row on the value it *would have had* if Layer 3 had never run — which is the user's default at save time. We don't have per-row history of that setting, so the current value of `shot/defaultRating` (read directly from QSettings during migration) is the best proxy. Resetting to `0` is wrong because most users have a non-zero default and it would create a different surprising "Visualizer shows 0% on real shots" failure. Keeping `75` is wrong because it bakes the bug into history.
+
+Edge case: a user changes `defaultShotRating` between save time and migration time. We use the value at migration time. This is a one-time fix-up; if it lands a few rows on the wrong number, the user can re-rate those shots via the existing UI. The alternative (per-row reconstruction) would require shot timestamps and a setting-change audit log neither of which we have.
+
+### Migration reads QSettings directly, not the `Settings` façade
+
+Migrations run inside `ShotHistoryStorage::initializeDatabase` on the worker thread. The `Settings` C++ object may or may not be fully constructed at that point depending on init order. `QSettings` itself is thread-safe and the key is stable (`shot/defaultRating`, default `75`). The migration reads it via a fresh `QSettings` instance and the same hard-coded default as `SettingsVisualizer::defaultShotRating()`. No new dependency wiring.
+
+### `bestRecentShot` falls back to "highest user-rated in last 90 days"
+
+Pre-Layer-3 behavior: `bestRecentShot` resolved to the highest `enjoyment0to100` shot in the 90-day window with a non-null rating. We restore this exactly: drop the user/inferred tier-preference, drop the `confidence` field, keep the 90-day window and the existing per-profile filter. A user with no rated shots in 90 days simply doesn't get a `bestRecentShot` block — same as before May 4. This is acceptable; the elicitation layers (1 and 2) are now responsible for keeping that pool populated.
+
+### No grace period / feature flag
+
+Considered shipping the code change behind a flag and removing it after a release cycle.
+
+Chose: no flag. Layer 3 has shipped to production for ~11 days; rolling it back cleanly is preferable to a tri-state code path. The DB migration is one-way per the proposal, and the C++ removal is local and well-contained.
+
+## Risks / Trade-offs
+
+- **Risk:** A migration-time crash leaves the DB in an intermediate state — column dropped but enjoyment reset only partially, or reset done but column drop failed. **Mitigation:** Wrap the migration in a transaction (Qt's `QSqlDatabase::transaction()`); the existing migration runner pattern already uses transactions per migration step. If the transaction rolls back, the migration retries on next launch.
+- **Risk:** Existing inferred rows that the user has *since* re-rated via the editor (so `enjoyment_source = 'user'`) won't be touched — correct behavior, but worth noting that the migration's scope is narrow (`WHERE enjoyment_source = 'inferred'` only).
+- **Risk:** `bestRecentShot` immediately goes dark for users who had been relying on inferred fallback. **Mitigation:** Acceptable. The elicitation layers now do their job; the dark block was the failure mode that motivated Layer 3 in the first place, but Layer 3's "fix" was making the LLM ignore its own output. Going dark surfaces the real problem (user hasn't rated) instead of hiding it.
+- **Trade-off:** Loses the ~70 lines of telemetry-like signal that "this shot looked detector-clean." The data is fully reconstructible from the existing detector columns (`channeling_detected`, `pour_truncated_detected`, etc.) — no information is lost, only a derived field.
+- **Risk:** Tests in `tests/shotanalysis_tests`, `tests/dialing_blocks_tests`, `tests/aimanager_tests`, and `tests/mcptools_tests` reference `enjoymentSource` / `confidence`. The task list enumerates each test to delete or update — failing to update one will break the build. **Mitigation:** post-implementation `grep -rn enjoymentSource\\\\|enjoyment_source\\\\|inferred-good\\\\|bestRecentShot.confidence src/ tests/` should return empty.
+
+## Migration Plan
+
+1. **Code lands** (PR): all C++ / MCP / system-prompt code is removed in a single PR alongside the migration. Build green, tests green, manual smoke (run an unrated shot, confirm it saves with the Visualizer default and not 75).
+2. **Migration runs on first launch** of the new build: each user's DB picks up migration 16. Affected rows reset to `shot/defaultRating`; column dropped.
+3. **Verification:** the MCP `shots_list` tool no longer accepts `enjoymentSource` as a filter; the dialing-context envelope no longer carries `confidence` on `bestRecentShot`; new shots saved clean no longer auto-rate. (Manual + the migration test in `tests/shothistorystorage_tests`.)
+4. **Rollback strategy:** not supported. Downgrading to a Layer-3 build re-runs migration 14 which adds the column back at `'none'` — no schema crash, but users would see clean shots auto-rated again. We accept this; the Decenza release cadence is forward-only via auto-update.
+
+## Open Questions
+
+None — Jeff's two clarifications (drop the column, reset to user's default rather than 0) resolved the remaining ambiguity. Implementation can proceed.

--- a/openspec/changes/remove-inferred-shot-ratings/proposal.md
+++ b/openspec/changes/remove-inferred-shot-ratings/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Layer 3 of the May-4 `add-shot-rating-capture` change (issue #1055) auto-stamps clean+onTarget+yield-OK+duration-OK unrated shots with `enjoyment=75, enjoymentSource="inferred"` so the advisor's `bestRecentShot` block stays warm even when the user never rates anything. In practice it has produced two failures:
+
+1. **User-visible breakage** — issue [#1150](https://github.com/Kulitorum/Decenza/issues/1150): the Visualizer "Default Shot Rating" setting is silently overwritten. A user who set it to 0% still gets shots saved at 75%.
+2. **No measurable advisor benefit** — the inferred 75 carries `confidence: "inferred"` which the system prompt teaches the LLM to ignore as a hint. The LLM already receives the underlying signals (`verdictCategory: "clean"`, `channelingSeverity: "none"`, `grindDirection: "onTarget"`) directly. Synthesizing a score the LLM is told to disregard adds plumbing without changing decisions.
+
+Treat Layer 3 as a failed experiment. Going forward, a shot's rating is whatever the user provided (manually, via QuickRatingRow, or via conversational reply) and nothing else.
+
+## What Changes
+
+- **BREAKING**: post-shot save no longer auto-rates clean shots. Shots saved without a user rating remain at whatever default the user configured (`SettingsVisualizer::defaultShotRating`, same as pre-Layer-3 behavior).
+- **BREAKING**: `bestRecentShot.confidence` and `currentBean.enjoymentSource` / `dialInSessions[].shots[].enjoymentSource` removed from the dialing-context envelope. The `tastingFeedback.hasEnjoymentScore` boolean is again the sole signal for "user has / has not rated this shot."
+- **BREAKING**: `ShotProjection::enjoymentSource` field removed. MCP `enjoymentSource` filter on `shots_list` and `enjoymentSource` validation on `updateShot` removed.
+- **BREAKING**: `shots.enjoyment_source` SQLite column dropped (migration 16). Before the drop, rows with `enjoyment_source = 'inferred'` have their `enjoyment` reset to the user's configured default rating (QSettings key `shot/defaultRating`, fallback `75`), so the auto-stamped 75s from the last ~11 days stop polluting `bestRecentShot` and local Visualizer uploads.
+- **Visualizer back-sync**: any row reset by migration 16 that has a non-empty `visualizer_id` SHALL be re-PATCHed to visualizer.coffee with the corrected `espresso_enjoyment` value, so the cloud copy of the shot matches the corrected local record. The sync is deferred to first app boot after the migration (network/credentials may not be ready at migration time), persisted in a QSettings pending list that survives crashes / no-network startups, and drains lazily once Visualizer credentials are available.
+- Layer 1 (conversational rating capture) and Layer 2 (QuickRatingRow) stay exactly as they are.
+- System prompt teaching about `inferred` ratings, `confidence`, and the "treat inferred as a hint" framing all removed.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `shot-rating-capture`: remove the Layer 3 requirements — the inferred-good evaluator that auto-rates 75, the `ShotProjection.enjoymentSource` field with values `"none" | "user" | "inferred"`, the `bestRecentShot.confidence` field, the `currentBean` / `dialInSessions[].shots[]` `enjoymentSource` emissions, and the schema migration that added the `enjoyment_source` column. Layer 1 (conversational rating capture) and Layer 2 (QuickRatingRow) requirements remain unchanged. (The `bestRecentShot.confidence` and per-shot `enjoymentSource` requirements live in this spec, not in `dialing-context-payload`, so this is the only spec needing modification.)
+
+## Impact
+
+- **Code:**
+  - `src/history/shothistorystorage.cpp` — drop the auto-rating block (~lines 1014-1042) and the `enjoyment_source` column reads/writes throughout (insert binding ~1184, select projection ~1502, migration 14 lines 742-758, data-import path ~2315-2358, metadata column map ~1822). Add migration 16: `UPDATE shots SET enjoyment = <user default> WHERE enjoyment_source = 'inferred'; ALTER TABLE shots DROP COLUMN enjoyment_source`.
+  - `src/history/shotprojection.h` — remove `enjoymentSource` field and any related serialization.
+  - `src/ai/dialing_blocks.h` — remove `enjoymentSource: "inferred"` emission on `currentBean` and `dialInSessions[].shots[]`; remove `confidence` on `bestRecentShot`; restore user-rating-only selection logic (revert preference tiering).
+  - `src/ai/shotsummarizer.cpp` / `.h` — remove `enjoymentSource` field on the input struct, the system-prompt paragraphs teaching `inferred` / `confidence`, and any tie-break code.
+  - `src/mcp/mcptools_shots.cpp` — drop the `enjoymentSource` filter argument and the field in the output payload.
+  - `src/mcp/mcptools_write.cpp` — drop the `enjoymentSource` field in the `updateShot` schema and validator.
+- **Docs:**
+  - `docs/SHOT_REVIEW.md` — remove any mention of the inferred mechanism; the recompute-on-load contract no longer touches rating.
+- **Tests:**
+  - Delete tests added by `add-shot-rating-capture`'s Layer 3: `inferredGoodTriggers`, `inferredGoodSkippedOnAnyFailure`, `inferredGoodNoOverwriteOfUserRating`, `bestRecentShotPrefersUserOverInferred`, `bestRecentShotInferredFallback`.
+  - Add migration-16 test: synthesize a DB with three rows (`enjoyment=75, source='inferred'`, `enjoyment=90, source='user'`, `enjoyment=0, source='none'`), run migration with `shot/defaultRating=50`, assert the inferred row's enjoyment becomes `50`, the column is gone, the other two rows untouched.
+  - Update bestRecentShot tests to expect no `confidence` field and user-rating-only candidate gate.
+- **Migration is one-way.** A user who downgrades to a Layer-3 build after this ships will find the column missing and migration 14 will re-add it (default `'none'`) — the reset enjoyment values stay reset. Acceptable: downgrade isn't a supported flow.
+- **MainController:** new `processPendingVisualizerRatingSync()` method, hooked into the existing post-boot Visualizer-ready signal path (no new timers per the CLAUDE.md "no timers as guards" rule). Drains the pending list one entry at a time using the existing `VisualizerUploader::updateShotOnVisualizer` API.
+- **No setting / UI surface changes.** The Visualizer "Default Shot Rating" already exists and is the canonical default. After this change it once again becomes the actual default for unrated shots.

--- a/openspec/changes/remove-inferred-shot-ratings/specs/shot-rating-capture/spec.md
+++ b/openspec/changes/remove-inferred-shot-ratings/specs/shot-rating-capture/spec.md
@@ -1,0 +1,36 @@
+## REMOVED Requirements
+
+### Requirement: Inferred-good shots SHALL be auto-rated with `enjoymentSource == "inferred"`
+
+**Reason:** Failed experiment. Two-week trial after the May-4 `add-shot-rating-capture` ship surfaced two failures: (1) issue #1150 — the auto-rating silently overwrites the user's configured Visualizer "Default Shot Rating" (a long-standing pre-existing setting), producing visibly-wrong shot ratings; (2) the AI advisor receives the inferred score paired with `confidence: "inferred"` and a system-prompt instruction to treat it as a hint requiring user confirmation, while it already has the underlying detector signals (`verdictCategory == "clean"`, `channelingSeverity == "none"`, `grindDirection == "onTarget"`) that the inferred score is derived from. The synthesized rating adds no decision-relevant information beyond what the LLM already sees.
+
+**Migration:** The post-shot analysis pipeline SHALL no longer evaluate inferred-good criteria. The Visualizer "Default Shot Rating" setting (`shot/defaultRating`, exposed via `SettingsVisualizer::defaultShotRating`) becomes the sole default for unrated shots, restoring the pre-Layer-3 contract. Existing rows in the `shots` table where `enjoyment_source = 'inferred'` SHALL be reset to the user's configured default via a one-time schema migration that also drops the now-unused column (see the `enjoymentSource SHALL persist as a ShotProjection field` requirement's migration entry below).
+
+### Requirement: `enjoymentSource` SHALL persist as a `ShotProjection` field with values `"none" | "user" | "inferred"`
+
+**Reason:** With Layer 3 removed, the only meaningful states are "the user has rated this shot" (`enjoyment0to100 > 0`) and "they haven't" (`enjoyment0to100 == 0`). A separate provenance string adds no information beyond the boolean already encoded by the rating value, and propagates plumbing across `ShotProjection`, `ShotHistoryStorage`, the metadata-update path, the MCP `shots_list` filter and `updateShot` validator, and the import/export paths.
+
+**Migration:** A one-time schema migration (numbered 16, immediately following the existing migration 15) SHALL:
+
+1. Read the user's `shot/defaultRating` value from `QSettings` (fallback default `75`, matching `SettingsVisualizer::defaultShotRating`).
+2. `SELECT id, visualizer_id FROM shots WHERE enjoyment_source = 'inferred' AND visualizer_id IS NOT NULL AND visualizer_id != ''` — for each result, append `{shotId, visualizerId}` to the `migration16/pendingVisualizerSync` `QSettings` list so the Visualizer cloud copy can be corrected after the app finishes booting.
+3. `UPDATE shots SET enjoyment = <default> WHERE enjoyment_source = 'inferred'` — restoring the auto-stamped rows to the value they would have had if Layer 3 had never run.
+4. `ALTER TABLE shots DROP COLUMN enjoyment_source` — SQLite ≥ 3.35 (already required by migration 15's `DROP COLUMN temperature_unstable`).
+5. All four steps SHALL run inside a single `QSqlDatabase::transaction()` so any failure mid-flight rolls back cleanly and retries on next launch.
+6. The migration SHALL be idempotent: re-running it (e.g., after a downgrade-then-upgrade cycle that re-added the column via migration 14) SHALL detect the column's presence, repeat steps 1-4, and finish without error.
+
+**Visualizer back-sync (post-migration, on app boot):** `MainController` SHALL drain the `migration16/pendingVisualizerSync` `QSettings` list once Visualizer credentials are confirmed available, calling `VisualizerUploader::updateShotOnVisualizer(visualizerId, projection)` for each pending entry. On successful PATCH, the entry SHALL be removed from the list. On failure (no credentials, network error, server 4xx/5xx) the entry SHALL remain in the list and be retried on next boot. The drain SHALL process entries serially (one PATCH in flight at a time) and SHALL NOT use a timer guard — it hooks into the existing Visualizer-ready signal path. When the list is empty, the drain is a noop.
+
+`ShotProjection::enjoymentSource` SHALL be removed. `ShotHistoryStorage::updateShotMetadataStatic` SHALL no longer accept an `enjoymentSource` key in its metadata map. The MCP `shots_list` tool SHALL no longer expose an `enjoymentSource` filter argument or emit the field in shot entries. The MCP `updateShot` tool SHALL no longer expose or validate an `enjoymentSource` argument. The import path (`import_history`) SHALL skip the `enjoyment_source` field when present in source data (forward-compat with older exports).
+
+### Requirement: `bestRecentShot` SHALL surface a `confidence` field and prefer user ratings over inferred
+
+**Reason:** With Layer 3 removed there are no inferred candidates to distinguish from user-rated ones. The pre-Layer-3 contract — `bestRecentShot` resolves to the highest user-rated shot in the 90-day window, omitted entirely when no rated candidate exists — is restored. The `confidence` field becomes meaningless under that contract.
+
+**Migration:** The `bestRecentShot` block SHALL no longer carry a `confidence` field. Candidate selection SHALL revert to "highest `enjoyment0to100` in the 90-day window where `enjoyment0to100 > 0`, scoped to the relevant profile per the existing rules." Shots with no user rating SHALL NOT be eligible (same as the pre-Layer-3 contract). The system prompt SHALL no longer teach `bestRecentShot.confidence` semantics or the "treat inferred as a hint" framing.
+
+### Requirement: `currentBean` and `dialInSessions[].shots[]` SHALL surface `enjoymentSource` only when "inferred"
+
+**Reason:** No shots are ever stamped `"inferred"` after this change, so the field is always absent. Keeping the conditional emission code is dead weight.
+
+**Migration:** The `currentBean` block SHALL NOT carry an `enjoymentSource` key in any condition. Per-shot entries in `dialInSessions[].shots[]` SHALL NOT carry an `enjoymentSource` key in any condition. The dialing-block builders (`buildCurrentBeanBlock`, `buildDialInSessionsBlock`, `buildBestRecentShotBlock` in `src/ai/dialing_blocks.h`) SHALL remove the conditional emission code paths. The system prompt SHALL remove the paragraphs teaching `currentBean.enjoymentSource: "inferred"` and `dialInSessions[].shots[].enjoymentSource: "inferred"`.

--- a/openspec/changes/remove-inferred-shot-ratings/tasks.md
+++ b/openspec/changes/remove-inferred-shot-ratings/tasks.md
@@ -1,0 +1,79 @@
+## 1. Schema migration (DB rollback)
+
+- [x] 1.1 In `src/history/shothistorystorage.cpp`, add migration 16. Steps, all inside a single `QSqlDatabase::transaction()` / `commit()` block (rollback on any step failure):
+  1. Read `shot/defaultRating` from `QSettings` (fallback `75`).
+  2. `SELECT id, visualizer_id FROM shots WHERE enjoyment_source = 'inferred' AND visualizer_id IS NOT NULL AND visualizer_id != ''` — capture the (shotId, visualizerId) pairs of rows that were uploaded to Visualizer; serialize as a JSON array and stash in `QSettings` under key `migration16/pendingVisualizerSync` (append, don't overwrite — preserves any partially-drained list from a prior failed sync).
+  3. `UPDATE shots SET enjoyment = <default> WHERE enjoyment_source = 'inferred'`.
+  4. `ALTER TABLE shots DROP COLUMN enjoyment_source`.
+  5. Bump `kSchemaVersion` to 16.
+- [x] 1.2 Confirm migration 14 still works on a clean DB (no code change expected; documenting that a downgrade-then-upgrade cycle re-adds the column at `'none'` and migration 16 then drops it again with no inferred rows to reset — safe noop).
+- [x] 1.3 Add `tests/tst_dbmigration.cpp` test `v16_resetsInferredAndDropsColumn`: synthesize a DB at version 14 schema (column present), insert four rows — (`enjoyment=75 source='inferred' visualizer_id='V1'`), (`enjoyment=75 source='inferred' visualizer_id=NULL`), (`enjoyment=90 source='user' visualizer_id='V2'`), (`enjoyment=0 source='none'`) — set `QSettings shot/defaultRating = 50`, run `ShotHistoryStorage::initialize`. Assert: column gone, both inferred rows' enjoyment now `50`, user row untouched at `90`, none row untouched at `0`, schema_version is `16`, AND the `migration16/pendingVisualizerSync` QSettings key contains exactly one entry (the one with `visualizer_id='V1'`).
+- [x] 1.4 Update or remove `tst_dbmigration.cpp::v14_idempotentReapply` — the test currently asserts the column survives idempotent re-init; after migration 16 it must NOT survive. Rename to `v16_columnIsDropped` and update the assertion.
+
+## 2. Storage / projection cleanup
+
+- [x] 2.1 In `src/history/shotprojection.h`, remove the `enjoymentSource` field (line ~42-44) and any serialization references.
+- [x] 2.2 In `src/history/shothistory_types.h`, remove the `enjoymentSource` field from `ShotData` (~line 57) and `ShotRecord` (~line 215).
+- [x] 2.3 In `src/history/shothistorystorage.cpp`:
+  - Remove the inferred-good evaluator block (lines ~995-1042 — the `if (data.espressoEnjoyment <= 0)` clause and the `else if` clause that sets `enjoymentSource = "user"`).
+  - Remove `enjoyment_source` from the INSERT column list (~line 1133), placeholder list (~line 1143), and `bindValue` (~line 1184).
+  - Remove `enjoyment_source` from the SELECT column list in `loadShotRecordStatic` / `convertShotRecord` (~line 1502).
+  - Remove the `{"enjoymentSource", "enjoyment_source"}` entry from the metadata column map (~line 1822) and the surrounding default-to-`"user"` logic (~line 1825).
+  - Remove `enjoyment_source` from the data-import SELECT (~line 2315) and the value-read at line 2358; skip-with-warning if the source DB has it.
+- [x] 2.4 Update `convertShotRecord` and any other `ShotRecord` ↔ `ShotProjection` converters to no longer carry the field.
+
+## 3. AI / dialing-blocks cleanup
+
+- [x] 3.1 In `src/ai/dialing_blocks.cpp` and `src/ai/dialing_blocks.h`:
+  - Remove the `enjoymentSource: "inferred"` conditional emission in `buildCurrentBeanBlock` (~line 67 and the helper).
+  - Remove the same in `buildDialInSessionsBlock` (~line 123).
+  - Restore `buildBestRecentShotBlock` to pre-Layer-3 logic: highest `enjoyment0to100 > 0` in the 90-day window, no `confidence` field, no user/inferred tier preference. Remove the SQL clauses that reference `enjoyment_source` (~lines 205, 256).
+- [x] 3.2 In `src/ai/shotsummarizer.h`, remove the `enjoymentSource` field on the input struct (~line 124-125) and any setters.
+- [x] 3.3 In `src/ai/shotsummarizer.cpp`:
+  - Remove the system-prompt paragraph teaching `currentBean.enjoymentSource: "inferred"` and the `"inferred"` value on `dialInSessions[].shots[].enjoymentSource` (~lines 1142-1149).
+  - Remove the `bestRecentShot.confidence` system-prompt teaching.
+  - Remove any code that copies `enjoymentSource` from `ShotProjection` into the prompt-input struct.
+
+## 4. MCP tool cleanup
+
+- [x] 4.1 In `src/mcp/mcptools_shots.cpp`:
+  - Remove the `enjoymentSource` filter argument from `shots_list`'s JSON schema (~lines 117-125).
+  - Remove the filter validation block (~line 154) and all references to `enjoymentSourceFilter` (~lines 249-311).
+  - Remove the `enjoymentSource` field from the per-shot output JSON (~line 270-271).
+- [x] 4.2 In `src/mcp/mcptools_write.cpp`:
+  - Remove the `enjoymentSource` argument from `updateShot`'s JSON schema (~lines 53-58).
+  - Remove the validation block that rejects non-`"user" | "inferred" | "none"` values (~lines 92-98).
+  - Remove the metadata-map write for `enjoymentSource`.
+- [x] 4.3 Update `docs/CLAUDE_MD/MCP_SERVER.md` if it documents the removed argument / filter.
+
+## 5. Visualizer back-sync of corrected ratings
+
+- [x] 5.0a In `src/controllers/maincontroller.cpp` / `.h`, add a private method `processPendingVisualizerRatingSync()` and a `QStringList` member to track in-flight work. Called once Visualizer credentials are confirmed available (existing signal — check `VisualizerUploader::testConnection` success or simply on first phase transition to `Idle`). The method:
+  1. Reads `migration16/pendingVisualizerSync` from `QSettings` (JSON array of `{shotId, visualizerId}` pairs).
+  2. If empty or Visualizer credentials are absent, returns silently.
+  3. Pops one entry, loads the shot via `ShotHistoryStorage::requestShot(shotId, callback)`.
+  4. In the callback, calls `m_visualizer->updateShotOnVisualizer(visualizerId, projection)` — this PATCHes the corrected `enjoyment` (and re-sends the rest of the metadata, which is correct because we already updated the local row).
+  5. On `VisualizerUploader::uploadSuccess` (or equivalent), removes the entry from the QSettings list and recurses to drain the next entry. On `uploadFailed`, leaves the entry in the list (it retries on next app boot) and aborts the drain to avoid hammering the API.
+- [x] 5.0b Wire `processPendingVisualizerRatingSync()` into `MainController`'s boot sequence so it runs after `VisualizerUploader` is constructed and credentials are loaded. Use existing mechanisms — do NOT add a timer guard (per CLAUDE.md "no timers as guards" rule). The natural hook is the existing `testConnection` success path or the first phase-change to `Idle`.
+- [ ] 5.0c Add a test in `tests/tst_maincontroller.cpp` (or appropriate harness) — or, if MainController is hard to test in isolation, a focused test on the QSettings list draining: seed `migration16/pendingVisualizerSync` with two pairs, mock the VisualizerUploader's PATCH (intercept the request), assert two PATCH calls with the correct visualizerIds and the corrected `espresso_enjoyment` value.
+- [ ] 5.0d Manual smoke: with a DB known to contain inferred-rated shots that were uploaded to Visualizer, run the new build, confirm via Visualizer.coffee web UI that the shot's rating now matches the local value (the user's `defaultShotRating`, not 75).
+
+## 6. Tests
+
+- [x] 6.1 Delete `tst_dialing_blocks.cpp::bestRecentShot_prefersUserOverInferredEvenWhenInferredScoresHigher` and `bestRecentShot_inferredFallbackWhenNoUserRated` (lines ~870, ~892). Delete the `insertShotWithSource` helper (~line 845); update remaining callers (e.g., `bestRecentShot_emptyWhenNoCandidates` at line 914) to use `insertShot` directly.
+- [x] 6.2 Update `tst_dialing_blocks.cpp::bestRecentShot_emptyWhenNoCandidates` to assert `confidence` is absent in any bestRecentShot block returned by post-change code (if there's a positive test, add one for "user-only" highest-rated). Cross-check that no remaining test asserts presence of `confidence`.
+- [x] 6.3 Search for stragglers: `grep -rn "enjoymentSource\\|enjoyment_source\\|inferred-good\\|Layer 3\\|kInferredScore\\|confidence.*inferred\\|inferredGood" src/ tests/ docs/` should return empty except for archived OpenSpec changes.
+- [x] 6.4 Run the `shotanalysis_tests`, `dialing_blocks_tests`, `mcp_tools_tests`, `shotsummarizer_tests`, `dbmigration_tests`, `shothistorystorage_tests` Qt Creator targets via `mcp__qtcreator__run_tests`; resolve any failures introduced by the removal.
+- [ ] 6.5 Manual smoke: build the app, pull an espresso shot through to save, confirm the shot row in `shots` has `enjoyment` equal to the Visualizer "Default Shot Rating" setting (not 75 unless that's the user's default). Repeat with `defaultShotRating = 0` to confirm the bug from issue #1150 is fixed.
+
+## 7. Docs and proposal hygiene
+
+- [x] 7.1 In `docs/SHOT_REVIEW.md`, remove any reference to the inferred-good evaluator / `enjoymentSource = "inferred"` if present. The recompute-on-load contract no longer touches enjoyment at all.
+- [x] 7.2 No CLAUDE.md updates required (CLAUDE.md doesn't currently document the inferred mechanism).
+
+## 8. Release / wrap-up
+
+- [ ] 8.1 Commit the change with conventional-commit message `fix: remove inferred-good shot auto-rating (#1150)` and open a PR.
+- [ ] 8.2 Reference issue #1150 in the PR body so it auto-closes on merge.
+- [ ] 8.3 Update the release notes (when next version cuts) with a user-visible line: "Fixed: shots saved with the user's configured Default Shot Rating again, no longer overwritten by the auto-rating heuristic (issue #1150). Existing affected shots are reset on first launch and re-synced to Visualizer."
+- [ ] 8.4 After merge, archive this OpenSpec change via the `openspec-archive-change` flow.

--- a/qml/components/QuickRatingRow.qml
+++ b/qml/components/QuickRatingRow.qml
@@ -6,7 +6,7 @@ import Decenza
 // QuickRatingRow — issue #1055 Layer 2.
 //
 // Low-friction one-tap rating row shown above the metadata fold on the
-// post-shot review page for unrated shots (enjoymentSource != "user").
+// post-shot review page for unrated shots (enjoyment == 0).
 // Three icon buttons map to scores 80 / 60 / 40 (good / okay / bad).
 // Tapping persists the score immediately via saveEditedShot.
 //

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -139,9 +139,7 @@ Page {
                     editDrinkTds = editShotData.drinkTdsPct ?? 0
                     editDrinkEy = editShotData.drinkEyPct ?? 0
                 }
-                editEnjoyment = (editShotData.enjoymentSource === "inferred")
-                    ? 0
-                    : (editShotData.enjoyment0to100 ?? 0)
+                editEnjoyment = editShotData.enjoyment0to100 ?? 0
                 editNotes = editShotData.espressoNotes || ""
                 editBeverageType = editShotData.beverageType || "espresso"
                 // Recompute EY now that dose/weight are loaded (covers the case where TDS
@@ -269,7 +267,7 @@ Page {
         editDrinkWeight !== (editShotData.finalWeightG ?? 0) ||
         editDrinkTds !== (editShotData.drinkTdsPct ?? 0) ||
         editDrinkEy !== (editShotData.drinkEyPct ?? 0) ||
-        editEnjoyment !== ((editShotData.enjoymentSource === "inferred") ? 0 : (editShotData.enjoyment0to100 ?? 0)) ||
+        editEnjoyment !== (editShotData.enjoyment0to100 ?? 0) ||
         editNotes !== (editShotData.espressoNotes || "") ||
         editBeverageType !== (editShotData.beverageType || "espresso")
     )
@@ -295,10 +293,7 @@ Page {
             "espressoNotes": editNotes,
             "beverageType": editBeverageType
         }
-        // Don't write inferred enjoyment back to DB — it's AI-only data.
-        // Include enjoyment only when the user has explicitly set a value.
-        if (editShotData.enjoymentSource !== "inferred" || editEnjoyment > 0)
-            metadata["enjoyment"] = editEnjoyment
+        metadata["enjoyment"] = editEnjoyment
         MainController.shotHistory.requestUpdateShotMetadata(editShotId, metadata)
 
         // Sync sticky metadata back to Settings (bean/grinder info) for the next shot.
@@ -701,14 +696,11 @@ Page {
 
             // Rating (moved to top, right after graph)
             // QuickRatingRow — issue #1055 Layer 2. Three-icon one-tap
-            // rating row, visible when the shot has no user rating.
-            // Inferred scores (enjoymentSource="inferred") are internal AI
-            // signals and are never shown to the user, so inferred shots
-            // show the row too. The precision slider is the fine-tuning surface.
+            // rating row, visible when the user hasn't rated this shot
+            // yet. The precision slider below is the fine-tuning surface.
             QuickRatingRow {
                 Layout.fillWidth: true
-                visible: postShotReviewPage.isEditMode &&
-                         (editShotData.enjoymentSource ?? "none") !== "user"
+                visible: postShotReviewPage.isEditMode && editEnjoyment === 0
                 onRateClicked: function(score) {
                     editEnjoyment = score
                     postShotReviewPage.saveEditedShot()

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -1386,10 +1386,6 @@ Page {
                             "drinkTdsPct": editDrinkTds,
                             "drinkEyPct": editDrinkEy,
                             "espressoNotes": editNotes,
-                            // Always include enjoyment so it overrides the base shot value.
-                            // editEnjoyment is initialized to 0 for inferred shots, which
-                            // keeps the inferred rating from leaking to Visualizer (the
-                            // serializer skips enjoyment0to100 == 0).
                             "enjoyment0to100": editEnjoyment
                         }
                         MainController.visualizer.updateShotOnVisualizerWithOverrides(

--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -64,10 +64,6 @@ QJsonObject shotToJson(const ShotProjection& shot,
     h["enjoyment0to100"] = shot.enjoyment0to100 > 0
         ? QJsonValue(shot.enjoyment0to100)
         : QJsonValue(QJsonValue::Null);
-    // Issue #1055 Layer 3: per-shot enjoymentSource only when "inferred"
-    // — sparse so the LLM only sees the field when it carries meaning.
-    if (shot.enjoymentSource == QStringLiteral("inferred"))
-        h["enjoymentSource"] = QStringLiteral("inferred");
     h["grinderSetting"] = shot.grinderSetting;
     if (!override.grinderBrand.isEmpty())
         h["grinderBrand"] = override.grinderBrand;
@@ -202,17 +198,15 @@ QJsonObject buildBestRecentShotBlock(QSqlDatabase& db,
         QDateTime::currentSecsSinceEpoch()
         - kBestRecentShotWindowDays * 24 * 3600;
     QSqlQuery bestQ(db);
-    // Issue #1055 Layer 3: prefer user-rated candidates over inferred
-    // ones regardless of score. The CASE expression sorts user-rated
-    // rows before inferred rows; within each tier, highest enjoyment
-    // wins, then most recent. The existing enjoyment > 0 gate keeps
-    // 'none'-source rows out (they have enjoyment == 0 by construction).
+    // Highest user-rated shot in the 90-day window for this profile.
+    // Falls back to nothing when the user has no rated shots — the
+    // elicitation paths (QuickRatingRow, conversational capture) keep
+    // this pool populated.
     bestQ.prepare(
-        "SELECT id, enjoyment_source FROM shots "
+        "SELECT id FROM shots "
         "WHERE profile_kb_id = ? AND enjoyment > 0 "
         "AND id != ? AND timestamp >= ? "
-        "ORDER BY CASE WHEN enjoyment_source = 'user' THEN 0 ELSE 1 END, "
-        "         enjoyment DESC, timestamp DESC LIMIT 1");
+        "ORDER BY enjoyment DESC, timestamp DESC LIMIT 1");
     bestQ.addBindValue(profileKbId);
     bestQ.addBindValue(resolvedShotId);
     bestQ.addBindValue(windowFloorSec);
@@ -226,7 +220,6 @@ QJsonObject buildBestRecentShotBlock(QSqlDatabase& db,
     if (!bestQ.next()) return QJsonObject();   // no rated shot in window — documented omission
 
     const qint64 bestId = bestQ.value(0).toLongLong();
-    const QString bestEnjoymentSource = bestQ.value(1).toString();
     ShotRecord bestRecord = ShotHistoryStorage::loadShotRecordStatic(db, bestId);
     const ShotProjection best = ShotHistoryStorage::convertShotRecord(bestRecord);
     if (!best.isValid()) return QJsonObject();
@@ -253,15 +246,6 @@ QJsonObject buildBestRecentShotBlock(QSqlDatabase& db,
     if (!diff.isEmpty())
         b["changeFromBest"] = diff;
 
-    // Issue #1055 Layer 3: surface the rating provenance so the LLM
-    // knows whether to anchor on this shot ("user_rated") or treat it
-    // as a hint requiring user confirmation ("inferred"). The query's
-    // CASE-based ORDER BY guarantees user-rated wins when both tiers
-    // have candidates, so seeing "inferred" here means no user-rated
-    // shot exists in the 90-day window for this profile.
-    b["confidence"] = bestEnjoymentSource == QStringLiteral("user")
-        ? QStringLiteral("user_rated")
-        : QStringLiteral("inferred");
     return b;
 }
 

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -93,11 +93,6 @@ struct CurrentBeanBlockInputs {
     QString grinderBurrs;
     QString grinderSetting;
     double doseWeightG = 0;
-    // Issue #1055 Layer 3. When the resolved shot's source is "inferred",
-    // the LLM needs to know not to anchor on it as user-validated.
-    // "user" / "none" → field omitted (the existing tastingFeedback
-    // booleans cover those cases).
-    QString enjoymentSource = QStringLiteral("none");
 };
 
 // Defined inline so test binaries that link only `shotsummarizer.cpp`
@@ -119,12 +114,6 @@ inline QJsonObject buildCurrentBeanBlock(const CurrentBeanBlockInputs& in)
     const QJsonObject freshness = DialingHelpers::buildBeanFreshness(in.roastDate);
     if (!freshness.isEmpty())
         bean["beanFreshness"] = freshness;
-
-    // Issue #1055 Layer 3: emit only when source is "inferred". User
-    // and absent are uninformative for the LLM (covered by
-    // tastingFeedback.hasEnjoymentScore booleans).
-    if (in.enjoymentSource == QStringLiteral("inferred"))
-        bean["enjoymentSource"] = QStringLiteral("inferred");
 
     return bean;
 }

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -406,7 +406,6 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
     summary.drinkTds = shotData.drinkTdsPct;
     summary.drinkEy = shotData.drinkEyPct;
     summary.enjoymentScore = shotData.enjoyment0to100;
-    summary.enjoymentSource = shotData.enjoymentSource;
     summary.tastingNotes = shotData.espressoNotes;
 
     // Convert curve data
@@ -529,7 +528,6 @@ static QJsonObject buildCurrentBeanBlock(const ShotSummary& summary)
     in.grinderBurrs = summary.grinderBurrs;
     in.grinderSetting = summary.grinderSetting;
     in.doseWeightG = summary.doseWeight;
-    in.enjoymentSource = summary.enjoymentSource;
     return DialingBlocks::buildCurrentBeanBlock(in);
 }
 
@@ -1137,19 +1135,6 @@ QString ShotSummarizer::shotAnalysisSystemPrompt(const QString& beverageType, co
         "tasted (score 1–100, 1–2 lines of flavor notes, TDS reading if available)\n"
         "before suggesting changes. Curve-only analysis without taste feedback\n"
         "misses the variable that matters most.\n\n"
-        "**`bestRecentShot.confidence`** (when present): `\"user_rated\"` means\n"
-        "the user explicitly scored that shot — anchor on it as a known good\n"
-        "outcome. `\"inferred\"` means the deterministic detectors flagged the\n"
-        "shot as clean and on-target so the app provisionally rated it 75; treat\n"
-        "it as a HINT, not ground truth. Confirm with the user (\"the metrics\n"
-        "from your shot on <date> looked clean — does that one taste good to\n"
-        "you?\") before strongly anchoring on an inferred candidate.\n\n"
-        "**`currentBean.enjoymentSource: \"inferred\"`** / **`dialInSessions[].shots[].enjoymentSource: \"inferred\"`**\n"
-        "(when present): same provenance signal at the per-shot level — the\n"
-        "shot's enjoyment was inferred by detector signals, not stated by the\n"
-        "user. Don't treat it as user-validated success. The field is omitted\n"
-        "for user-rated and unrated shots (the existing `tastingFeedback.hasEnjoymentScore`\n"
-        "boolean covers absence).\n\n"
         "**`currentBean.beanFreshness`**: when present, carries `roastDate`,\n"
         "`freshnessKnown` (currently always `false` until storage tracking is\n"
         "added), and an `instruction`. NEVER quote calendar age until\n"

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -121,10 +121,6 @@ struct ShotSummary {
     double drinkTds = 0;
     double drinkEy = 0;
     int enjoymentScore = 0;
-    // "none" | "user" | "inferred" — issue #1055 Layer 3. Lets the
-    // user-prompt envelope teach the LLM to treat inferred ratings as
-    // hints rather than ground truth.
-    QString enjoymentSource = QStringLiteral("none");
     QString tastingNotes;
 };
 

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -50,6 +50,7 @@
 #include <QVariantMap>
 #include <QRandomGenerator>
 #include <algorithm>
+#include <memory>
 #include <QCoreApplication>
 #ifdef Q_OS_ANDROID
 #include <QJniObject>
@@ -196,7 +197,7 @@ MainController::MainController(QNetworkAccessManager* networkManager,
         QSettings s;
         QJsonArray pending = QJsonDocument::fromJson(
             s.value(QStringLiteral("migration16/pendingVisualizerSync")).toByteArray()).array();
-        for (int i = 0; i < pending.size(); ++i) {
+        for (qsizetype i = 0; i < pending.size(); ++i) {
             if (pending[i].toObject().value("visualizerId").toString() == visualizerId) {
                 pending.removeAt(i);
                 break;
@@ -2585,16 +2586,20 @@ void MainController::dispatchNextPendingVisualizerSync()
     m_migration16InFlightVisualizerId = visualizerId;
 
     // Load the (now-corrected) shot off the background thread and
-    // dispatch the PATCH from the callback. Connection is single-shot:
-    // we only react to the matching shotId so other shotReady listeners
-    // are unaffected.
+    // dispatch the PATCH from the callback. shotReady fires for every
+    // shot load app-wide, so we filter on shotId and disconnect once
+    // we've handled the matching one. The Connection handle is held in
+    // a shared_ptr captured by the lambda so it self-destructs whether
+    // the lambda is invoked (explicit disconnect below) or the context
+    // object dies first (Qt auto-disconnects on `this`, then the lambda
+    // copy in Qt's connection store gets cleaned up). Pre-shared_ptr
+    // this used a raw `new` that leaked on context destruction.
     QPointer<MainController> self(this);
-    auto* conn = new QMetaObject::Connection;
+    auto conn = std::make_shared<QMetaObject::Connection>();
     *conn = connect(m_shotHistory, &ShotHistoryStorage::shotReady, this,
         [self, conn, shotId, visualizerId](qint64 readyId, const ShotProjection& shot) {
         if (!self || readyId != shotId) return;
         QObject::disconnect(*conn);
-        delete conn;
         if (!shot.isValid()) {
             qWarning() << "MainController: migration16 sync — shot" << shotId << "no longer exists; dropping";
             // Pop the bad entry and continue.

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -42,8 +42,10 @@
 #include <QPointer>
 #include <tuple>
 #include <QDateTime>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QSettings>
 #include <QStandardPaths>
 #include <QVariantMap>
 #include <QRandomGenerator>
@@ -175,6 +177,43 @@ MainController::MainController(QNetworkAccessManager* networkManager,
     m_shotHistory = new ShotHistoryStorage(this);
     m_shotHistory->initialize();
     connect(m_shotHistory, &QObject::destroyed, this, [this]() { m_savingShot = false; });
+
+    // Migration 16 ran inside initialize() above. If it found inferred
+    // shots that were uploaded to Visualizer, it queued them in
+    // QSettings under migration16/pendingVisualizerSync. Drain that
+    // list now — guarded internally on credentials being available;
+    // failed entries persist for the next boot.
+    processPendingVisualizerRatingSync();
+    connect(m_visualizer, &VisualizerUploader::updateSuccess, this,
+            [this](const QString& visualizerId) {
+        if (!m_migration16SyncInFlight) return;
+        QSettings s;
+        QJsonArray pending = QJsonDocument::fromJson(
+            s.value(QStringLiteral("migration16/pendingVisualizerSync")).toByteArray()).array();
+        // Drop the in-flight entry. There may be more than one with the
+        // same visualizerId in theory (duplicate uploads); remove the
+        // first match only.
+        for (int i = 0; i < pending.size(); ++i) {
+            if (pending[i].toObject().value("visualizerId").toString() == visualizerId) {
+                pending.removeAt(i);
+                break;
+            }
+        }
+        if (pending.isEmpty())
+            s.remove(QStringLiteral("migration16/pendingVisualizerSync"));
+        else
+            s.setValue(QStringLiteral("migration16/pendingVisualizerSync"),
+                       QJsonDocument(pending).toJson(QJsonDocument::Compact));
+        m_migration16SyncInFlight = false;
+        dispatchNextPendingVisualizerSync();
+    });
+    connect(m_visualizer, &VisualizerUploader::uploadFailed, this,
+            [this](const QString& /*error*/) {
+        if (!m_migration16SyncInFlight) return;
+        // Leave the entry in the pending list — retry on next boot.
+        // Abort the drain so we don't hammer the API.
+        m_migration16SyncInFlight = false;
+    });
 
     // Create shot importer for importing .shot files from DE1 app
     m_shotImporter = new ShotImporter(m_shotHistory, this);
@@ -2483,6 +2522,93 @@ void MainController::onScaleWeightChanged(double weight) {
 
 bool MainController::isSawSettling() const {
     return m_timingController ? m_timingController->isSawSettling() : false;
+}
+
+void MainController::processPendingVisualizerRatingSync()
+{
+    QSettings s;
+    if (!s.contains(QStringLiteral("migration16/pendingVisualizerSync")))
+        return;
+
+    // Visualizer needs credentials to PATCH. If absent, leave the list
+    // for a future boot where the user has configured an account.
+    const QString user = s.value(QStringLiteral("visualizer/username")).toString();
+    const QString pass = s.value(QStringLiteral("visualizer/password")).toString();
+    if (user.isEmpty() || pass.isEmpty()) {
+        qDebug() << "MainController: migration16 pending Visualizer sync skipped (no credentials)";
+        return;
+    }
+
+    dispatchNextPendingVisualizerSync();
+}
+
+void MainController::dispatchNextPendingVisualizerSync()
+{
+    if (m_migration16SyncInFlight) return;
+    if (!m_visualizer || !m_shotHistory) return;
+
+    QSettings s;
+    const QByteArray raw = s.value(
+        QStringLiteral("migration16/pendingVisualizerSync")).toByteArray();
+    if (raw.isEmpty()) return;
+
+    const QJsonArray pending = QJsonDocument::fromJson(raw).array();
+    if (pending.isEmpty()) {
+        s.remove(QStringLiteral("migration16/pendingVisualizerSync"));
+        return;
+    }
+
+    const QJsonObject entry = pending.first().toObject();
+    const qint64 shotId = entry.value("shotId").toVariant().toLongLong();
+    const QString visualizerId = entry.value("visualizerId").toString();
+    if (shotId <= 0 || visualizerId.isEmpty()) {
+        // Malformed entry — drop and try the next one. Re-write the list
+        // without the bad entry and recurse.
+        QJsonArray rest = pending;
+        rest.removeFirst();
+        if (rest.isEmpty())
+            s.remove(QStringLiteral("migration16/pendingVisualizerSync"));
+        else
+            s.setValue(QStringLiteral("migration16/pendingVisualizerSync"),
+                       QJsonDocument(rest).toJson(QJsonDocument::Compact));
+        dispatchNextPendingVisualizerSync();
+        return;
+    }
+
+    m_migration16SyncInFlight = true;
+
+    // Load the (now-corrected) shot off the background thread and
+    // dispatch the PATCH from the callback. Connection is single-shot:
+    // we only react to the matching shotId so other shotReady listeners
+    // are unaffected.
+    QPointer<MainController> self(this);
+    auto* conn = new QMetaObject::Connection;
+    *conn = connect(m_shotHistory, &ShotHistoryStorage::shotReady, this,
+        [self, conn, shotId, visualizerId](qint64 readyId, const ShotProjection& shot) {
+        if (!self || readyId != shotId) return;
+        QObject::disconnect(*conn);
+        delete conn;
+        if (!shot.isValid()) {
+            qWarning() << "MainController: migration16 sync — shot" << shotId << "no longer exists; dropping";
+            // Pop the bad entry and continue.
+            QSettings ss;
+            QJsonArray remain = QJsonDocument::fromJson(
+                ss.value(QStringLiteral("migration16/pendingVisualizerSync")).toByteArray()).array();
+            if (!remain.isEmpty()) remain.removeFirst();
+            if (remain.isEmpty())
+                ss.remove(QStringLiteral("migration16/pendingVisualizerSync"));
+            else
+                ss.setValue(QStringLiteral("migration16/pendingVisualizerSync"),
+                            QJsonDocument(remain).toJson(QJsonDocument::Compact));
+            self->m_migration16SyncInFlight = false;
+            self->dispatchNextPendingVisualizerSync();
+            return;
+        }
+        qDebug() << "MainController: migration16 sync — re-PATCHing visualizerId" << visualizerId
+                 << "with corrected enjoyment" << shot.enjoyment0to100;
+        self->m_visualizer->updateShotOnVisualizer(visualizerId, shot);
+    });
+    m_shotHistory->requestShot(shotId);
 }
 
 void MainController::setRefractometer(DiFluidR2* refractometer) {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -186,13 +186,16 @@ MainController::MainController(QNetworkAccessManager* networkManager,
     processPendingVisualizerRatingSync();
     connect(m_visualizer, &VisualizerUploader::updateSuccess, this,
             [this](const QString& visualizerId) {
-        if (!m_migration16SyncInFlight) return;
+        // Only react when this matches the migration16 PATCH we issued;
+        // other concurrent updates (e.g., user-initiated edits from
+        // PostShotReviewPage) must not pop our queue entries.
+        if (m_migration16InFlightVisualizerId.isEmpty()
+            || visualizerId != m_migration16InFlightVisualizerId)
+            return;
+
         QSettings s;
         QJsonArray pending = QJsonDocument::fromJson(
             s.value(QStringLiteral("migration16/pendingVisualizerSync")).toByteArray()).array();
-        // Drop the in-flight entry. There may be more than one with the
-        // same visualizerId in theory (duplicate uploads); remove the
-        // first match only.
         for (int i = 0; i < pending.size(); ++i) {
             if (pending[i].toObject().value("visualizerId").toString() == visualizerId) {
                 pending.removeAt(i);
@@ -204,15 +207,19 @@ MainController::MainController(QNetworkAccessManager* networkManager,
         else
             s.setValue(QStringLiteral("migration16/pendingVisualizerSync"),
                        QJsonDocument(pending).toJson(QJsonDocument::Compact));
-        m_migration16SyncInFlight = false;
+        m_migration16InFlightVisualizerId.clear();
         dispatchNextPendingVisualizerSync();
     });
     connect(m_visualizer, &VisualizerUploader::uploadFailed, this,
             [this](const QString& /*error*/) {
-        if (!m_migration16SyncInFlight) return;
-        // Leave the entry in the pending list — retry on next boot.
-        // Abort the drain so we don't hammer the API.
-        m_migration16SyncInFlight = false;
+        // VisualizerUploader::uploadFailed carries no shot-id correlation, so
+        // we can't tell whether the failure was ours or someone else's. The
+        // safe rule: if a migration16 PATCH is in flight, assume it failed
+        // (the same upload session can't error AND succeed on the network
+        // layer), leave the entry in the pending list, and abort the drain.
+        // A spurious abort just means the queue picks up on next boot.
+        if (m_migration16InFlightVisualizerId.isEmpty()) return;
+        m_migration16InFlightVisualizerId.clear();
     });
 
     // Create shot importer for importing .shot files from DE1 app
@@ -2544,7 +2551,7 @@ void MainController::processPendingVisualizerRatingSync()
 
 void MainController::dispatchNextPendingVisualizerSync()
 {
-    if (m_migration16SyncInFlight) return;
+    if (!m_migration16InFlightVisualizerId.isEmpty()) return;
     if (!m_visualizer || !m_shotHistory) return;
 
     QSettings s;
@@ -2575,7 +2582,7 @@ void MainController::dispatchNextPendingVisualizerSync()
         return;
     }
 
-    m_migration16SyncInFlight = true;
+    m_migration16InFlightVisualizerId = visualizerId;
 
     // Load the (now-corrected) shot off the background thread and
     // dispatch the PATCH from the callback. Connection is single-shot:
@@ -2600,7 +2607,7 @@ void MainController::dispatchNextPendingVisualizerSync()
             else
                 ss.setValue(QStringLiteral("migration16/pendingVisualizerSync"),
                             QJsonDocument(remain).toJson(QJsonDocument::Compact));
-            self->m_migration16SyncInFlight = false;
+            self->m_migration16InFlightVisualizerId.clear();
             self->dispatchNextPendingVisualizerSync();
             return;
         }

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -237,6 +237,19 @@ private:
     // `reason` is a caller tag that flows into the [ShotSettings] BLE log.
     void sendMachineSettings(const QString& reason = QString());
 
+    // Drain the migration16 pending list, re-PATCHing each affected
+    // shot's rating to Visualizer so the cloud copy matches the local
+    // corrected value. Serial: pops one entry, dispatches the PATCH,
+    // resumes from the VisualizerUploader::updateSuccess signal. On
+    // failure (no creds, network error) the entry remains in the list
+    // and retries on next app boot.
+    void processPendingVisualizerRatingSync();
+    void dispatchNextPendingVisualizerSync();
+    // True once a PATCH from the migration16 drain is in flight, so we
+    // don't dispatch a second one until updateSuccess / uploadFailed
+    // resolves the first.
+    bool m_migration16SyncInFlight = false;
+
     ProfileManager* m_profileManager = nullptr;
 
     QNetworkAccessManager* m_networkManager = nullptr;

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -245,10 +245,13 @@ private:
     // and retries on next app boot.
     void processPendingVisualizerRatingSync();
     void dispatchNextPendingVisualizerSync();
-    // True once a PATCH from the migration16 drain is in flight, so we
-    // don't dispatch a second one until updateSuccess / uploadFailed
-    // resolves the first.
-    bool m_migration16SyncInFlight = false;
+    // Tracks the visualizerId of the migration16 PATCH currently in
+    // flight. Empty string when no migration16 sync is active. Compared
+    // against the visualizerId argument on updateSuccess / uploadFailed
+    // so other concurrent PATCHes (e.g., from PostShotReviewPage's
+    // metadata save) don't pop migration16 entries off the queue or
+    // stall the drain. See PR #1155 review note 2.
+    QString m_migration16InFlightVisualizerId;
 
     ProfileManager* m_profileManager = nullptr;
 

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -54,8 +54,6 @@ struct ShotRecord {
     QString profileNotes;
     QString visualizerId;
     QString visualizerUrl;
-    // "none" | "user" | "inferred" — issue #1055 Layer 3.
-    QString enjoymentSource = QStringLiteral("none");
 
     // Time-series data (lazily loaded)
     QVector<QPointF> pressure;
@@ -212,13 +210,6 @@ struct ShotSaveData {
     QString barista;
     QString profileNotes;
     QString debugLog;
-    // "none" | "user" | "inferred" — issue #1055 Layer 3. Set to
-    // "inferred" when the post-shot pipeline auto-rates a clean,
-    // on-target unrated shot. User-driven save paths leave this as
-    // "none" (default) — the inferred-good evaluator only runs on shots
-    // that the user didn't rate, and any subsequent user write through
-    // updateShotMetadataStatic flips it to "user".
-    QString enjoymentSource = QStringLiteral("none");
 
     // AI knowledge base ID (e.g. "d-flow", "blooming espresso") — computed at save time
     QString profileKbId;

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -740,10 +740,13 @@ bool ShotHistoryStorage::runMigrations()
         currentVersion = 13;
     }
 
-    // Migration 14: enjoyment_source column was introduced here. The
-    // column has been dropped by migration 16 (rolling back the Layer 3
-    // inferred auto-rating experiment) — this step now runs only on
-    // legacy v13 DBs so migration 16 has a consistent column to drop.
+    // Migration 14: enjoyment_source column was introduced here. Layer 3
+    // (the inferred auto-rating experiment that owned this column) was
+    // rolled back in migration 16 below, which drops it. This step is
+    // kept rather than fast-forwarded so legacy v13 DBs still pass
+    // through the same back-fill (`enjoyment_source = 'user'` for rated
+    // rows) that migration 16 later reads to build the back-sync list.
+    // Migration 16 is independently safe via its hasColumn() guard.
     if (currentVersion < 14) {
         qDebug() << "ShotHistoryStorage: Running migration to version 14 (enjoyment_source)";
 

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -20,6 +20,7 @@
 #include <QRegularExpression>
 #include <QLocale>
 #include <QDebug>
+#include <QSettings>
 #include <QThread>
 #include <algorithm>
 #include <cmath>
@@ -739,12 +740,10 @@ bool ShotHistoryStorage::runMigrations()
         currentVersion = 13;
     }
 
-    // Migration 14: enjoyment_source column. Tracks whether
-    // enjoyment0to100 came from the user (manual editor, QuickRatingRow,
-    // conversational reply) or was inferred by the post-shot detector
-    // pipeline. Lets bestRecentShot prefer user-rated candidates and
-    // lets the system prompt teach the LLM to treat inferred ratings
-    // as hints rather than ground truth (issue #1055 Layer 3).
+    // Migration 14: enjoyment_source column was introduced here. The
+    // column has been dropped by migration 16 (rolling back the Layer 3
+    // inferred auto-rating experiment) — this step now runs only on
+    // legacy v13 DBs so migration 16 has a consistent column to drop.
     if (currentVersion < 14) {
         qDebug() << "ShotHistoryStorage: Running migration to version 14 (enjoyment_source)";
 
@@ -789,6 +788,109 @@ bool ShotHistoryStorage::runMigrations()
         query.exec("DELETE FROM schema_version");
         query.exec("INSERT INTO schema_version (version) VALUES (15)");
         currentVersion = 15;
+    }
+
+    // Migration 16: drop enjoyment_source column. Layer 3 of the
+    // shot-rating-capture change auto-stamped clean unrated shots with
+    // enjoyment=75 and enjoymentSource="inferred", but the inferred
+    // signal added no value over the LLM's existing detector observations
+    // and silently overwrote the user's configured "Default Shot Rating"
+    // (issue #1150). The column is dropped here. Before dropping:
+    //   1) Stash the (shotId, visualizerId) pairs of inferred rows that
+    //      were uploaded to Visualizer in a QSettings pending list so
+    //      MainController can re-PATCH them with the corrected rating.
+    //   2) Reset every inferred row's enjoyment to the user's configured
+    //      default rating (QSettings shot/defaultRating, fallback 75 —
+    //      matching SettingsVisualizer::defaultShotRating).
+    if (currentVersion < 16) {
+        qDebug() << "ShotHistoryStorage: Running migration to version 16 (drop enjoyment_source)";
+
+        if (hasColumn("shots", "enjoyment_source")) {
+            if (!m_db.transaction()) {
+                qWarning() << "ShotHistoryStorage: migration 16 transaction begin failed:"
+                           << m_db.lastError().text();
+                return false;
+            }
+
+            // Read user's configured default rating up-front. QSettings is
+            // thread-safe and the key is stable across app versions.
+            QSettings appSettings;
+            const int defaultRating = appSettings.value(
+                QStringLiteral("shot/defaultRating"), 75).toInt();
+
+            // 1) Collect inferred rows that were uploaded to Visualizer so
+            //    the cloud copy can be corrected after boot. Append to any
+            //    existing pending list (preserves entries from a prior
+            //    failed sync run).
+            {
+                QSqlQuery pendingQ(m_db);
+                if (!pendingQ.exec("SELECT id, visualizer_id FROM shots "
+                                   "WHERE enjoyment_source = 'inferred' "
+                                   "AND visualizer_id IS NOT NULL "
+                                   "AND visualizer_id != ''")) {
+                    qWarning() << "ShotHistoryStorage: migration 16 SELECT failed:"
+                               << pendingQ.lastError().text();
+                    m_db.rollback();
+                    return false;
+                }
+                QJsonArray pending;
+                {
+                    const QByteArray existingJson = appSettings.value(
+                        QStringLiteral("migration16/pendingVisualizerSync")).toByteArray();
+                    if (!existingJson.isEmpty())
+                        pending = QJsonDocument::fromJson(existingJson).array();
+                }
+                while (pendingQ.next()) {
+                    QJsonObject entry;
+                    entry["shotId"] = pendingQ.value(0).toLongLong();
+                    entry["visualizerId"] = pendingQ.value(1).toString();
+                    pending.append(entry);
+                }
+                if (!pending.isEmpty()) {
+                    appSettings.setValue(
+                        QStringLiteral("migration16/pendingVisualizerSync"),
+                        QJsonDocument(pending).toJson(QJsonDocument::Compact));
+                }
+            }
+
+            // 2) Reset enjoyment on inferred rows to the user's default.
+            {
+                QSqlQuery resetQ(m_db);
+                resetQ.prepare("UPDATE shots SET enjoyment = :rating "
+                               "WHERE enjoyment_source = 'inferred'");
+                resetQ.bindValue(":rating", defaultRating);
+                if (!resetQ.exec()) {
+                    qWarning() << "ShotHistoryStorage: migration 16 UPDATE failed:"
+                               << resetQ.lastError().text();
+                    m_db.rollback();
+                    return false;
+                }
+            }
+
+            // 3) Drop the column. SQLite >= 3.35 (required since v15).
+            if (!query.exec("ALTER TABLE shots DROP COLUMN enjoyment_source")) {
+                qWarning() << "ShotHistoryStorage: migration 16 DROP COLUMN failed:"
+                           << query.lastError().text();
+                m_db.rollback();
+                return false;
+            }
+
+            query.exec("DELETE FROM schema_version");
+            query.exec("INSERT INTO schema_version (version) VALUES (16)");
+
+            if (!m_db.commit()) {
+                qWarning() << "ShotHistoryStorage: migration 16 commit failed:"
+                           << m_db.lastError().text();
+                m_db.rollback();
+                return false;
+            }
+        } else {
+            // Column already absent (fresh DB or a previously-completed
+            // migration 16). Just record the schema version.
+            query.exec("DELETE FROM schema_version");
+            query.exec("INSERT INTO schema_version (version) VALUES (16)");
+        }
+        currentVersion = 16;
     }
 
     m_schemaVersion = currentVersion;
@@ -991,55 +1093,6 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
             data.targetWeight, data.finalWeight,
             inputs.frameCount);
         decenza::applyBadgesToTarget(data, analysis.detectors);
-
-        // Issue #1055 Layer 3: inferred-good auto-rating. All five
-        // gates from the spec must pass before the unrated shot earns
-        // a provisional enjoyment of 75 with source "inferred":
-        //   1. verdictCategory == "clean"
-        //   2. channelingSeverity == "none"
-        //   3. grindDirection == "onTarget"
-        //   4. yield within 0.5g of the saved targetWeight (when set)
-        //      — proxy for the spec's ratio-within-0.1 gate, since
-        //      targetWeight is what the user wired in profile setup
-        //   5. duration in [15s, 60s] — sanity bound around typical
-        //      espresso pulls; serves as the bounded fallback the spec
-        //      calls for when no profile median is available. The
-        //      profile-median version is deferred (would require a DB
-        //      query inside saveShot's hot path).
-        // The bestRecentShot block can then anchor on the shot until
-        // the user provides their own rating (which flips enjoymentSource
-        // back to "user" via updateShotMetadataStatic). The system
-        // prompt teaches the LLM to treat inferred ratings as a hint
-        // requiring user confirmation.
-        if (data.espressoEnjoyment <= 0) {
-            const auto& d = analysis.detectors;
-            const bool detectorsClean =
-                d.verdictCategory == QStringLiteral("clean")
-                && d.channelingSeverity == QStringLiteral("none")
-                && d.grindDirection == QStringLiteral("onTarget");
-            // Yield gate: skip when no targetWeight is recorded (legacy
-            // shots, or profiles without a target). When recorded,
-            // require the actual yield within 0.5g.
-            const bool yieldOk = data.targetWeight <= 0
-                || std::abs(data.finalWeight - data.targetWeight) <= 0.5;
-            // Duration gate: bounded sanity check.
-            const bool durationOk = data.duration >= 15.0 && data.duration <= 60.0;
-
-            if (detectorsClean && yieldOk && durationOk) {
-                constexpr int kInferredScore = 75;
-                data.espressoEnjoyment = kInferredScore;
-                data.enjoymentSource = QStringLiteral("inferred");
-                qDebug() << "ShotHistoryStorage: inferred-good auto-rating —"
-                         << "shot saved with enjoyment" << kInferredScore
-                         << "(clean+onTarget+no-channeling+yield+duration)";
-            }
-        } else if (data.enjoymentSource.isEmpty() ||
-                   data.enjoymentSource == QStringLiteral("none")) {
-            // The save path carries an explicit user-set enjoyment;
-            // record the source as "user" so future filtering / queries
-            // can distinguish from inferred ratings.
-            data.enjoymentSource = QStringLiteral("user");
-        }
     }
 
     // Compress sample data on main thread (reads QObject data vectors)
@@ -1130,7 +1183,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     profile_notes, debug_log,
                     temperature_override, yield_override, profile_kb_id,
                     channeling_detected, grind_issue_detected,
-                    skip_first_frame_detected, pour_truncated_detected, enjoyment_source
+                    skip_first_frame_detected, pour_truncated_detected
                 ) VALUES (
                     :uuid, :timestamp, :profile_name, :profile_json, :beverage_type,
                     :duration, :final_weight, :dose_weight,
@@ -1140,7 +1193,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     :profile_notes, :debug_log,
                     :temperature_override, :yield_override, :profile_kb_id,
                     :channeling_detected, :grind_issue_detected,
-                    :skip_first_frame_detected, :pour_truncated_detected, :enjoyment_source
+                    :skip_first_frame_detected, :pour_truncated_detected
                 )
             )");
 
@@ -1175,14 +1228,6 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
             query.bindValue(":grind_issue_detected", data.grindIssueDetected ? 1 : 0);
             query.bindValue(":skip_first_frame_detected", data.skipFirstFrameDetected ? 1 : 0);
             query.bindValue(":pour_truncated_detected", data.pourTruncatedDetected ? 1 : 0);
-            // Issue #1055 Layer 3: enjoymentSource defaults to "user"
-            // when the save path carries an explicit enjoyment value
-            // (manual save flow), and to "inferred" / "none" otherwise
-            // depending on whether the inferred-good evaluator fired.
-            // The caller (saveShot pre-write hook) is responsible for
-            // setting data.enjoymentSource appropriately.
-            query.bindValue(":enjoyment_source",
-                data.enjoymentSource.isEmpty() ? QStringLiteral("none") : data.enjoymentSource);
 
             if (!query.exec()) {
                 qWarning() << "ShotHistoryStorage: Failed to insert shot:" << query.lastError().text();
@@ -1499,7 +1544,7 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
                profile_notes, visualizer_id, visualizer_url, debug_log,
                temperature_override, yield_override, beverage_type, profile_kb_id,
                channeling_detected, grind_issue_detected,
-               skip_first_frame_detected, pour_truncated_detected, enjoyment_source
+               skip_first_frame_detected, pour_truncated_detected
         FROM shots WHERE id = ?
     )")) {
         qWarning() << "ShotHistoryStorage::loadShotRecordStatic: prepare failed:" << query.lastError().text();
@@ -1546,8 +1591,6 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     record.grindIssueDetected = query.value(31).toInt() != 0;
     record.skipFirstFrameDetected = query.value(32).toInt() != 0;
     record.pourTruncatedDetected = query.value(33).toInt() != 0;
-    record.enjoymentSource = query.value(34).toString();
-    if (record.enjoymentSource.isEmpty()) record.enjoymentSource = QStringLiteral("none");
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     // Snapshot stored badge values before the recompute block overwrites them, so
@@ -1819,26 +1862,12 @@ bool ShotHistoryStorage::updateShotMetadataStatic(QSqlDatabase& db, qint64 shotI
         {"doseWeight",      "dose_weight"},
         {"finalWeight",     "final_weight"},
         {"beverageType",    "beverage_type"},
-        {"enjoymentSource", "enjoyment_source"},  // issue #1055 Layer 3
     };
 
-    // Issue #1055 Layer 3: when the caller writes `enjoyment` without
-    // an explicit `enjoymentSource`, default the source to "user" — but
-    // only for non-zero scores. 0 always means unrated regardless of who
-    // wrote it; stamping it "user" would hide the QuickRatingRow and
-    // mislead the AI into treating the shot as deliberately rated bad.
-    QVariantMap effective = metadata;
-    if (effective.contains(QStringLiteral("enjoyment")) &&
-        !effective.contains(QStringLiteral("enjoymentSource"))) {
-        const int score = effective.value(QStringLiteral("enjoyment")).toInt();
-        effective.insert(QStringLiteral("enjoymentSource"),
-                         score > 0 ? QStringLiteral("user") : QStringLiteral("none"));
-    }
-
-    // Build SET clause from only the keys present in the (effective) metadata.
+    // Build SET clause from only the keys present in the metadata.
     QStringList setClauses;
     for (const auto& [metaKey, dbCol] : fieldMap) {
-        if (effective.contains(metaKey))
+        if (metadata.contains(metaKey))
             setClauses << QString("%1 = :%1").arg(dbCol);
     }
 
@@ -1857,10 +1886,10 @@ bool ShotHistoryStorage::updateShotMetadataStatic(QSqlDatabase& db, qint64 shotI
         return false;
     }
 
-    // Bind only the columns present in the (effective) metadata.
+    // Bind only the columns present in the metadata.
     for (const auto& [metaKey, dbCol] : fieldMap) {
-        if (effective.contains(metaKey))
-            query.bindValue(QString(":%1").arg(dbCol), effective.value(metaKey));
+        if (metadata.contains(metaKey))
+            query.bindValue(QString(":%1").arg(dbCol), metadata.value(metaKey));
     }
     query.bindValue(":id", shotId);
 
@@ -2311,9 +2340,8 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                         profile_notes, visualizer_id, visualizer_url, debug_log,
                         temperature_override, yield_override, profile_kb_id,
                         channeling_detected, grind_issue_detected,
-                        skip_first_frame_detected, pour_truncated_detected,
-                        enjoyment_source)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skip_first_frame_detected, pour_truncated_detected)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 )");
 
                 insert.addBindValue(uuid);
@@ -2355,8 +2383,6 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                 insert.addBindValue((sf.isValid() && !sf.isNull()) ? sf : QVariant(0));
                 QVariant pt = srcShots.value("pour_truncated_detected");
                 insert.addBindValue((pt.isValid() && !pt.isNull()) ? pt : QVariant(0));
-                QVariant es = srcShots.value("enjoyment_source");
-                insert.addBindValue((es.isValid() && !es.isNull()) ? es : QVariant(QString("none")));
 
                 if (!insert.exec()) {
                     qWarning() << "ShotHistoryStorage::importDatabaseStatic: Failed to import shot:" << insert.lastError().text();

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -53,8 +53,6 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.beanBrand = record.summary.beanBrand;
     p.beanType = record.summary.beanType;
     p.enjoyment0to100 = record.summary.enjoyment;
-    p.enjoymentSource = record.enjoymentSource.isEmpty()
-        ? QStringLiteral("none") : record.enjoymentSource;
     p.hasVisualizerUpload = record.summary.hasVisualizerUpload;
     p.beverageType = record.summary.beverageType;
     p.roastDate = record.roastDate;

--- a/src/history/shotprojection.cpp
+++ b/src/history/shotprojection.cpp
@@ -17,7 +17,6 @@ QVariantMap ShotProjection::toVariantMap() const
     m["beanBrand"] = beanBrand;
     m["beanType"] = beanType;
     m["enjoyment0to100"] = enjoyment0to100;
-    m["enjoymentSource"] = enjoymentSource;
     m["hasVisualizerUpload"] = hasVisualizerUpload;
     m["beverageType"] = beverageType;
     m["roastDate"] = roastDate;
@@ -87,8 +86,6 @@ ShotProjection ShotProjection::fromVariantMap(const QVariantMap& m)
     p.beanBrand = m.value("beanBrand").toString();
     p.beanType = m.value("beanType").toString();
     p.enjoyment0to100 = m.value("enjoyment0to100").toInt();
-    p.enjoymentSource = m.value("enjoymentSource").toString();
-    if (p.enjoymentSource.isEmpty()) p.enjoymentSource = QStringLiteral("none");
     p.hasVisualizerUpload = m.value("hasVisualizerUpload").toBool();
     p.beverageType = m.value("beverageType").toString();
     p.roastDate = m.value("roastDate").toString();

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -39,9 +39,6 @@ class ShotProjection {
     Q_PROPERTY(QString beanBrand MEMBER beanBrand)
     Q_PROPERTY(QString beanType MEMBER beanType)
     Q_PROPERTY(int enjoyment0to100 MEMBER enjoyment0to100)
-    // "none" | "user" | "inferred" — issue #1055 Layer 3. Reflects the
-    // shots.enjoyment_source column added by migration 14.
-    Q_PROPERTY(QString enjoymentSource MEMBER enjoymentSource)
     Q_PROPERTY(bool hasVisualizerUpload MEMBER hasVisualizerUpload)
     Q_PROPERTY(QString beverageType MEMBER beverageType)
     Q_PROPERTY(QString roastDate MEMBER roastDate)
@@ -107,7 +104,6 @@ public:
     QString beanBrand;
     QString beanType;
     int enjoyment0to100 = 0;
-    QString enjoymentSource = QStringLiteral("none");
     bool hasVisualizerUpload = false;
     QString beverageType;
     QString roastDate;

--- a/src/mcp/mcpresources.cpp
+++ b/src/mcp/mcpresources.cpp
@@ -110,7 +110,7 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                 withTempDb(dbPath, "mcp_res_recent", [&](QSqlDatabase& db) {
                     QSqlQuery query(db);
                     if (query.exec("SELECT id, timestamp, profile_name, dose_weight, final_weight, "
-                                   "duration_seconds, enjoyment, enjoyment_source, "
+                                   "duration_seconds, enjoyment, "
                                    "bean_brand, bean_type "
                                    "FROM shots ORDER BY timestamp DESC LIMIT 10")) {
                         while (query.next()) {
@@ -124,9 +124,6 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                             shot["durationSec"] = query.value("duration_seconds").toDouble();
                             const int enjoyment = query.value("enjoyment").toInt();
                             shot["enjoyment0to100"] = enjoyment > 0 ? QJsonValue(enjoyment) : QJsonValue(QJsonValue::Null);
-                            QString src = query.value("enjoyment_source").toString();
-                            if (src.isEmpty()) src = QStringLiteral("none");
-                            shot["enjoymentSource"] = src;
                             shot["beanBrand"] = query.value("bean_brand").toString();
                             shot["beanType"] = query.value("bean_type").toString();
                             shots.append(shot);

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -295,7 +295,6 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         in.grinderBurrs = sd.grinderBurrs;
                         in.grinderSetting = sd.grinderSetting;
                         in.doseWeightG = sd.doseWeightG;
-                        in.enjoymentSource = sd.enjoymentSource;
                         result["currentBean"] = DialingBlocks::buildCurrentBeanBlock(in);
                     }
 

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -86,16 +86,6 @@ static void nullifyUnratedFields(QJsonObject& obj)
         if (v <= 0.0)
             obj[k] = QJsonValue(QJsonValue::Null);
     }
-    // Paired invariant: an unrated shot (enjoyment0to100 nulled) must
-    // also surface enjoymentSource = "none". Migration 14's data
-    // invariants make a contradictory ('inferred' / 'user' source on
-    // an enjoyment-zero row) shot impossible today, but this guard
-    // protects MCP consumers from any future drift between the two
-    // columns.
-    if (obj.contains(QStringLiteral("enjoymentSource"))
-        && obj.value(QStringLiteral("enjoyment0to100")).isNull()) {
-        obj[QStringLiteral("enjoymentSource")] = QStringLiteral("none");
-    }
 }
 
 void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistory)
@@ -115,14 +105,6 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                 {"hasRating", QJsonObject{{"type", "boolean"}, {"description", "Only shots with an enjoyment score (>0). Composable with other filters; equivalent to minEnjoyment: 1."}}},
                 {"hasNotes", QJsonObject{{"type", "boolean"}, {"description", "Only shots with non-empty espresso notes."}}},
                 {"hasTds", QJsonObject{{"type", "boolean"}, {"description", "Only shots with a refractometer reading (drinkTdsPct > 0)."}}},
-                {"enjoymentSource", QJsonObject{{"type", "string"},
-                    {"enum", QJsonArray{"user", "inferred", "none"}},
-                    {"description", "Filter by rating provenance. One of \"user\" | \"inferred\" | \"none\". "
-                     "\"user\" = scored manually by the user. "
-                     "\"inferred\" = auto-rated 75 by the post-shot detector pipeline (clean verdict + onTarget grind + on-target yield + sane duration). "
-                     "\"none\" = unrated (matches enjoyment_source = 'none' as well as legacy NULL/empty rows). "
-                     "Composable with hasRating / minEnjoyment, but note that \"none\" + hasRating: true is contradictory by construction (a 'none'-source row has enjoyment = 0). "
-                     "Issue #1055."}}},
                 {"after", QJsonObject{{"type", "string"}, {"description", "Only shots after this ISO timestamp (e.g. 2026-03-15T00:00:00)"}}},
                 {"before", QJsonObject{{"type", "string"}, {"description", "Only shots before this ISO timestamp (e.g. 2026-03-21T23:59:59)"}}}
             }}
@@ -145,19 +127,6 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
             const bool hasRating = args.value("hasRating").toBool();
             const bool hasNotes = args.value("hasNotes").toBool();
             const bool hasTds = args.value("hasTds").toBool();
-            const QString enjoymentSourceFilter = args.value("enjoymentSource").toString();
-            // Mirror shots_update's strict three-value enum check so MCP
-            // callers get a real error on a typo instead of a silent
-            // empty result set.
-            if (!enjoymentSourceFilter.isEmpty()
-                && enjoymentSourceFilter != QLatin1String("user")
-                && enjoymentSourceFilter != QLatin1String("inferred")
-                && enjoymentSourceFilter != QLatin1String("none")) {
-                respond(QJsonObject{{"error",
-                    QString("enjoymentSource filter must be \"user\", \"inferred\", or \"none\"; got \"%1\"")
-                        .arg(enjoymentSourceFilter)}});
-                return;
-            }
             qint64 afterEpoch = 0, beforeEpoch = 0;
             if (args.contains("after")) {
                 QDateTime dt = QDateTime::fromString(args["after"].toString(), Qt::ISODate);
@@ -172,7 +141,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
 
             QThread* thread = QThread::create(
                 [dbPath, limit, offset, profileFilter, beanFilter,
-                 minEnjoyment, hasRating, hasNotes, hasTds, enjoymentSourceFilter,
+                 minEnjoyment, hasRating, hasNotes, hasTds,
                  afterEpoch, beforeEpoch, currentDateTime, respond]() {
                 QJsonObject result;
                 QJsonArray shots;
@@ -180,7 +149,7 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
 
                 if (!withTempDb(dbPath, "mcp_shots_list", [&](QSqlDatabase& db) {
                     QString sql = "SELECT id, timestamp, profile_name, dose_weight, final_weight, "
-                                  "duration_seconds, enjoyment, enjoyment_source, "
+                                  "duration_seconds, enjoyment, "
                                   "grinder_setting, grinder_model, "
                                   "espresso_notes, bean_brand, bean_type, yield_override, profile_json "
                                   "FROM shots WHERE 1=1 ";
@@ -210,22 +179,6 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         sql += " AND drink_tds > 0";
                         countSql += " AND drink_tds > 0";
                     }
-                    if (enjoymentSourceFilter == QLatin1String("none")) {
-                        // "none" is the default for unrated rows. Migration 14
-                        // sets enjoyment_source NOT NULL DEFAULT 'none' and
-                        // backfills, but a defensive OR-NULL/empty match keeps
-                        // the filter robust against any legacy or hand-edited
-                        // row that might have slipped through.
-                        sql += " AND (enjoyment_source = 'none'"
-                               " OR enjoyment_source IS NULL"
-                               " OR enjoyment_source = '')";
-                        countSql += " AND (enjoyment_source = 'none'"
-                                    " OR enjoyment_source IS NULL"
-                                    " OR enjoyment_source = '')";
-                    } else if (!enjoymentSourceFilter.isEmpty()) {
-                        sql += " AND enjoyment_source = :enjoymentSource";
-                        countSql += " AND enjoyment_source = :enjoymentSource";
-                    }
                     if (afterEpoch > 0) {
                         sql += " AND timestamp >= :after";
                         countSql += " AND timestamp >= :after";
@@ -244,12 +197,6 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         query.bindValue(":beanFilter", "%" + beanFilter + "%");
                     if (minEnjoyment > 0)
                         query.bindValue(":minEnjoyment", minEnjoyment);
-                    // "none" branch uses literal SQL (matches NULL/empty too)
-                    // and has no :enjoymentSource placeholder; only bind when
-                    // the filter is "user" or "inferred".
-                    if (enjoymentSourceFilter == QLatin1String("user")
-                        || enjoymentSourceFilter == QLatin1String("inferred"))
-                        query.bindValue(":enjoymentSource", enjoymentSourceFilter);
                     if (afterEpoch > 0)
                         query.bindValue(":after", afterEpoch);
                     if (beforeEpoch > 0)
@@ -267,14 +214,6 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                             shot["durationSec"] = query.value("duration_seconds").toDouble();
                             const int enjoyment = query.value("enjoyment").toInt();
                             shot["enjoyment0to100"] = enjoyment > 0 ? QJsonValue(enjoyment) : QJsonValue(QJsonValue::Null);
-                            // Rating provenance (issue #1055). "user" = scored
-                            // by the user, "inferred" = auto-rated by the
-                            // post-shot detector pipeline, "none" = unrated.
-                            // Lets MCP consumers distinguish user-validated
-                            // successes from app-suggested ones.
-                            QString enjoymentSource = query.value("enjoyment_source").toString();
-                            if (enjoymentSource.isEmpty()) enjoymentSource = QStringLiteral("none");
-                            shot["enjoymentSource"] = enjoymentSource;
                             shot["grinderSetting"] = query.value("grinder_setting").toString();
                             shot["grinderModel"] = query.value("grinder_model").toString();
                             shot["notes"] = query.value("espresso_notes").toString();
@@ -307,9 +246,6 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                         countQuery.bindValue(":beanFilter", "%" + beanFilter + "%");
                     if (minEnjoyment > 0)
                         countQuery.bindValue(":minEnjoyment", minEnjoyment);
-                    if (enjoymentSourceFilter == QLatin1String("user")
-                        || enjoymentSourceFilter == QLatin1String("inferred"))
-                        countQuery.bindValue(":enjoymentSource", enjoymentSourceFilter);
                     if (afterEpoch > 0)
                         countQuery.bindValue(":after", afterEpoch);
                     if (beforeEpoch > 0)

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -49,13 +49,6 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             {"properties", QJsonObject{
                 {"shotId", QJsonObject{{"type", "integer"}, {"description", "Shot ID"}}},
                 {"enjoyment", QJsonObject{{"type", "integer"}, {"description", "Enjoyment rating 0-100"}}},
-                {"enjoymentSource", QJsonObject{{"type", "string"},
-                    {"enum", QJsonArray{"user", "inferred", "none"}},
-                    {"description", "Rating provenance. One of \"user\" | \"inferred\" | \"none\". When a numeric "
-                     "`enjoyment` write is present and `enjoymentSource` is omitted, the source defaults to \"user\". "
-                     "Setting `enjoymentSource: \"none\"` explicitly clears the numeric rating to 0 in the same write — "
-                     "a downgrade from inferred/user to unrated leaves no contradictory state behind. \"inferred\" is "
-                     "used internally by the post-shot detector pipeline; MCP callers rarely set it directly. Issue #1055."}}},
                 {"notes", QJsonObject{{"type", "string"}, {"description", "Tasting notes"}}},
                 {"doseWeight", QJsonObject{{"type", "number"}, {"description", "Dose weight in grams"}}},
                 {"drinkWeight", QJsonObject{{"type", "number"}, {"description", "Yield/drink weight in grams"}}},
@@ -89,27 +82,6 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             QVariantMap metadata;
             if (args.contains("enjoyment"))
                 metadata["enjoyment"] = qBound(0, args["enjoyment"].toInt(), 100);
-            if (args.contains("enjoymentSource")) {
-                const QString src = args["enjoymentSource"].toString();
-                if (src != QLatin1String("user")
-                    && src != QLatin1String("inferred")
-                    && src != QLatin1String("none")) {
-                    respond(QJsonObject{{"error",
-                        QString("enjoymentSource must be \"user\", \"inferred\", or \"none\"; got \"%1\"").arg(src)}});
-                    return;
-                }
-                metadata["enjoymentSource"] = src;
-                // Pair the source flip with a numeric clear when the
-                // caller is downgrading to unrated. Without this, the
-                // row would land with enjoyment_source = 'none' AND
-                // enjoyment > 0 — a contradictory state where
-                // hasRating: true and enjoymentSource: "none" both
-                // match the same shot. Caller-supplied `enjoyment`
-                // wins (still respect the explicit number).
-                if (src == QLatin1String("none") && !metadata.contains("enjoyment")) {
-                    metadata["enjoyment"] = 0;
-                }
-            }
             if (args.contains("notes"))
                 metadata["espressoNotes"] = args["notes"].toString();
             if (args.contains("doseWeight"))

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -1,3 +1,27 @@
+// visualizer.coffee REST client.
+//
+// Authoritative API reference:   https://apidocs.visualizer.coffee
+//   Spec source:                 OpenAPI 3.1 (current version 1.8.2).
+//   Public endpoints used:       POST /api/shots/upload       (initial upload)
+//                                PATCH /api/shots/{id}        (update metadata)
+//
+// Schema conventions worth knowing before editing the JSON builders:
+//   - Every editable scalar field is `nullable: true`. Use JSON `null`
+//     to clear a value on PATCH; sending literal 0 / "" sets the field
+//     to that *value* (e.g. `espresso_enjoyment: 0` displays as "Rated
+//     0/100", not "Unrated"). The cupping scores (fragrance/aroma/etc.)
+//     are integer 0-15 — 0 is a real score, confirming this convention.
+//   - `bean_weight`, `drink_weight`, `drink_tds`, `drink_ey` are typed
+//     `string` in the API schema, not number. Rails coerces, but the
+//     contract is string + nullable.
+//   - POST (create): omitting a field == leaving it unset on the new
+//     resource. The CREATE-path builders here use skip-on-zero/empty,
+//     which is the conventional Rails strong-params behavior.
+//   - PATCH (update): omitting == "don't change"; `null` == "clear";
+//     value == "set". `updateShotOnVisualizer` emits every editable
+//     field explicitly (null for unset) so the cloud copy mirrors
+//     local state — including local clears. Issue #1150 / migration 16.
+
 #include "visualizeruploader.h"
 #include "../models/shotdatamodel.h"
 #include "../core/settings.h"

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -245,18 +245,19 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
     // Field-pointer accessors give compile-time safety on the projection side;
     // the API field strings are visualizer.coffee's external schema (snake_case)
     // and intentionally distinct from the projection's field names.
+    //
+    // This is a PATCH — we always send the current local value so a
+    // local clear (TDS reset to 0, enjoyment cleared, etc.) propagates
+    // to Visualizer. Skipping zero/empty would mean a user could lower
+    // a field locally and never have the cloud copy catch up. Required
+    // by migration 16's back-sync for issue #1150 users whose default
+    // rating is 0, and a sensible default for any user-initiated clear.
     QJsonObject shotObj;
     auto setStr = [&](const QString& apiField, QString ShotProjection::*field) {
-        const QString& s = shotData.*field;
-        if (!s.isEmpty()) shotObj[apiField] = s;
+        shotObj[apiField] = shotData.*field;
     };
     auto setDouble = [&](const QString& apiField, double ShotProjection::*field) {
-        const double v = shotData.*field;
-        if (v > 0) shotObj[apiField] = v;
-    };
-    auto setInt = [&](const QString& apiField, int ShotProjection::*field) {
-        const int v = shotData.*field;
-        if (v > 0) shotObj[apiField] = v;
+        shotObj[apiField] = shotData.*field;
     };
 
     setStr("bean_brand", &ShotProjection::beanBrand);
@@ -266,14 +267,12 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
     setDouble("bean_weight", &ShotProjection::doseWeightG);
     setDouble("drink_weight", &ShotProjection::finalWeightG);
     // Combine brand + model for visualizer (no separate brand field in API)
-    {
-        QString combined = (shotData.grinderBrand.trimmed() + " " + shotData.grinderModel.trimmed()).trimmed();
-        if (!combined.isEmpty()) shotObj["grinder_model"] = combined;
-    }
+    shotObj["grinder_model"] =
+        (shotData.grinderBrand.trimmed() + " " + shotData.grinderModel.trimmed()).trimmed();
     setStr("grinder_setting", &ShotProjection::grinderSetting);
     setDouble("drink_tds", &ShotProjection::drinkTdsPct);
     setDouble("drink_ey", &ShotProjection::drinkEyPct);
-    setInt("espresso_enjoyment", &ShotProjection::enjoyment0to100);
+    shotObj["espresso_enjoyment"] = shotData.enjoyment0to100;
     setStr("espresso_notes", &ShotProjection::espressoNotes);
     setStr("barista", &ShotProjection::barista);
     setStr("profile_title", &ShotProjection::profileName);

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -246,18 +246,22 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
     // the API field strings are visualizer.coffee's external schema (snake_case)
     // and intentionally distinct from the projection's field names.
     //
-    // This is a PATCH — we always send the current local value so a
-    // local clear (TDS reset to 0, enjoyment cleared, etc.) propagates
-    // to Visualizer. Skipping zero/empty would mean a user could lower
-    // a field locally and never have the cloud copy catch up. Required
-    // by migration 16's back-sync for issue #1150 users whose default
-    // rating is 0, and a sensible default for any user-initiated clear.
+    // This is a PATCH and we always emit every editable field — the
+    // Visualizer API marks them `nullable: true`, so we use JSON null
+    // to clear a value the user has unset locally (TDS reset, rating
+    // cleared, etc.). Sending literal 0 / "" would set the field to a
+    // *value* of zero/empty-string rather than clearing it, which on
+    // visualizer.coffee renders as e.g. "Rating: 0/100" instead of
+    // "Unrated". Required by migration 16's back-sync for issue #1150
+    // users whose default rating is 0.
     QJsonObject shotObj;
     auto setStr = [&](const QString& apiField, QString ShotProjection::*field) {
-        shotObj[apiField] = shotData.*field;
+        const QString& s = shotData.*field;
+        shotObj[apiField] = s.isEmpty() ? QJsonValue(QJsonValue::Null) : QJsonValue(s);
     };
     auto setDouble = [&](const QString& apiField, double ShotProjection::*field) {
-        shotObj[apiField] = shotData.*field;
+        const double v = shotData.*field;
+        shotObj[apiField] = v > 0 ? QJsonValue(v) : QJsonValue(QJsonValue::Null);
     };
 
     setStr("bean_brand", &ShotProjection::beanBrand);
@@ -267,12 +271,18 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
     setDouble("bean_weight", &ShotProjection::doseWeightG);
     setDouble("drink_weight", &ShotProjection::finalWeightG);
     // Combine brand + model for visualizer (no separate brand field in API)
-    shotObj["grinder_model"] =
-        (shotData.grinderBrand.trimmed() + " " + shotData.grinderModel.trimmed()).trimmed();
+    {
+        const QString combined =
+            (shotData.grinderBrand.trimmed() + " " + shotData.grinderModel.trimmed()).trimmed();
+        shotObj["grinder_model"] =
+            combined.isEmpty() ? QJsonValue(QJsonValue::Null) : QJsonValue(combined);
+    }
     setStr("grinder_setting", &ShotProjection::grinderSetting);
     setDouble("drink_tds", &ShotProjection::drinkTdsPct);
     setDouble("drink_ey", &ShotProjection::drinkEyPct);
-    shotObj["espresso_enjoyment"] = shotData.enjoyment0to100;
+    shotObj["espresso_enjoyment"] = shotData.enjoyment0to100 > 0
+        ? QJsonValue(shotData.enjoyment0to100)
+        : QJsonValue(QJsonValue::Null);
     setStr("espresso_notes", &ShotProjection::espressoNotes);
     setStr("barista", &ShotProjection::barista);
     setStr("profile_title", &ShotProjection::profileName);

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -3,10 +3,12 @@
 #include <QSqlQuery>
 #include <QSqlError>
 #include <QTemporaryDir>
+#include <QDateTime>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QRegularExpression>
+#include <QSettings>
 
 #include "history/shothistorystorage.h"
 
@@ -164,7 +166,7 @@ private slots:
             QVERIFY(hasTable(db, "shot_samples"));
             QVERIFY(hasTable(db, "shot_phases"));
             QVERIFY(hasTable(db, "schema_version"));
-            QCOMPARE(getSchemaVersion(db), 15);
+            QCOMPARE(getSchemaVersion(db), 16);
         });
     }
 
@@ -228,7 +230,7 @@ private slots:
         initAndClose(path, storage);
 
         withRawDb(path, "v1_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 15);
+            QCOMPARE(getSchemaVersion(db), 16);
             QVERIFY(hasColumn(db, "shots", "temperature_override"));
             QVERIFY(hasColumn(db, "shots", "yield_override"));
             QVERIFY(hasColumn(db, "shots", "beverage_type"));
@@ -342,7 +344,7 @@ private slots:
         withRawDb(path, "v9_verify", [](QSqlDatabase& db) {
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasIndex(db, "idx_shots_profile_kb_id"));
-            QCOMPARE(getSchemaVersion(db), 15);
+            QCOMPARE(getSchemaVersion(db), 16);
         });
     }
 
@@ -356,7 +358,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "idempotent", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 15);
+            QCOMPARE(getSchemaVersion(db), 16);
         });
     }
 
@@ -376,7 +378,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "empty_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 15);
+            QCOMPARE(getSchemaVersion(db), 16);
         });
     }
 
@@ -399,7 +401,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "null_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 15);
+            QCOMPARE(getSchemaVersion(db), 16);
             QSqlQuery q(db);
             q.exec("SELECT grinder_brand FROM shots WHERE uuid = 'test-null'");
             QVERIFY(q.next());
@@ -544,16 +546,13 @@ private slots:
         });
     }
 
-    // Migration 14: enjoyment_source column added. Idempotency check —
-    // running ShotHistoryStorage::initialize twice on the same DB does
-    // not re-apply the ALTER (which would fail with a duplicate-column
-    // error) and the schema_version reaches the latest version (currently
-    // 15, post the temperature_unstable drop). The back-fill logic
-    // (UPDATE shots SET enjoyment_source = 'user' WHERE enjoyment > 0)
-    // is exercised in production; constructing a partial v13 schema
-    // here would force an unrealistic state through ShotHistoryStorage's
-    // distinct-cache prewarm path.
-    void v14_idempotentReapply()
+    // Migration 16: drop enjoyment_source column. Layer 3's inferred
+    // auto-rating was rolled back as a failed experiment — migration 14
+    // added the column, migration 16 drops it after resetting any
+    // inferred rows to the user's configured default rating. Idempotency
+    // check: running ShotHistoryStorage::initialize twice on the same DB
+    // ends at schema_version 16 and the column is GONE on both passes.
+    void v16_columnIsDropped()
     {
         const QString path = freshDbPath();
         {
@@ -565,19 +564,138 @@ private slots:
             initAndClose(path, s2);
         }
 
-        bool hasColumn = false;
+        bool hasEnjoymentSource = false;
         int versionFound = 0;
-        withRawDb(path, "v14_idem", [&](QSqlDatabase& db) {
+        withRawDb(path, "v16_idem", [&](QSqlDatabase& db) {
             QSqlQuery q(db);
             QVERIFY(q.exec("SELECT version FROM schema_version"));
             if (q.next()) versionFound = q.value(0).toInt();
             QVERIFY(q.exec("PRAGMA table_info(shots)"));
             while (q.next()) {
-                if (q.value(1).toString() == "enjoyment_source") { hasColumn = true; break; }
+                if (q.value(1).toString() == "enjoyment_source") {
+                    hasEnjoymentSource = true;
+                    break;
+                }
             }
         });
-        QCOMPARE(versionFound, 15);
-        QVERIFY2(hasColumn, "enjoyment_source column survives idempotent re-initialize");
+        QCOMPARE(versionFound, 16);
+        QVERIFY2(!hasEnjoymentSource,
+                 "enjoyment_source column must be absent after migration 16");
+    }
+
+    // Migration 16 contract: rows with enjoyment_source = 'inferred'
+    // have their enjoyment reset to the user's configured default
+    // rating (QSettings shot/defaultRating). Rows uploaded to
+    // Visualizer (visualizer_id non-empty) are stashed in the pending
+    // sync list for MainController to re-PATCH after boot.
+    void v16_resetsInferredAndDropsColumn()
+    {
+        const QString path = freshDbPath();
+
+        // First init creates the current schema (column already absent).
+        // Re-add the column with v14 semantics, insert representative
+        // rows, then rewind schema_version to 15 so the next init runs
+        // migration 16 in isolation.
+        {
+            ShotHistoryStorage s1;
+            initAndClose(path, s1);
+        }
+
+        const qint64 now = QDateTime::currentSecsSinceEpoch();
+        withRawDb(path, "v16_seed", [&](QSqlDatabase& db) {
+            QSqlQuery q(db);
+            QVERIFY(q.exec("ALTER TABLE shots ADD COLUMN enjoyment_source TEXT NOT NULL DEFAULT 'none'"));
+
+            // (u1) inferred + visualizer-uploaded — must be reset AND queued
+            q.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, "
+                      "enjoyment, enjoyment_source, visualizer_id) "
+                      "VALUES (?, ?, 'P', 30, 75, 'inferred', 'V1')");
+            q.addBindValue("u1"); q.addBindValue(now - 3600);
+            QVERIFY(q.exec());
+            // (u2) inferred + not uploaded — reset but not queued
+            q.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, "
+                      "enjoyment, enjoyment_source, visualizer_id) "
+                      "VALUES (?, ?, 'P', 30, 75, 'inferred', NULL)");
+            q.addBindValue("u2"); q.addBindValue(now - 7200);
+            QVERIFY(q.exec());
+            // (u3) user-rated — untouched
+            q.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, "
+                      "enjoyment, enjoyment_source, visualizer_id) "
+                      "VALUES (?, ?, 'P', 30, 90, 'user', 'V2')");
+            q.addBindValue("u3"); q.addBindValue(now - 10800);
+            QVERIFY(q.exec());
+            // (u4) unrated — untouched
+            q.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, "
+                      "enjoyment, enjoyment_source, visualizer_id) "
+                      "VALUES (?, ?, 'P', 30, 0, 'none', NULL)");
+            q.addBindValue("u4"); q.addBindValue(now - 14400);
+            QVERIFY(q.exec());
+
+            QVERIFY(q.exec("UPDATE schema_version SET version = 15"));
+        });
+
+        // Set the configured default rating that migration 16 reads.
+        QSettings appSettings;
+        const QVariant prior = appSettings.value("shot/defaultRating");
+        const QVariant priorPending = appSettings.value("migration16/pendingVisualizerSync");
+        appSettings.setValue("shot/defaultRating", 50);
+        appSettings.remove("migration16/pendingVisualizerSync");
+
+        // Run migration 16.
+        {
+            ShotHistoryStorage s2;
+            initAndClose(path, s2);
+        }
+
+        bool columnGone = true;
+        int versionFound = 0;
+        int enjoy1 = -1, enjoy2 = -1, enjoy3 = -1, enjoy4 = -1;
+        withRawDb(path, "v16_verify", [&](QSqlDatabase& db) {
+            QSqlQuery q(db);
+            QVERIFY(q.exec("SELECT version FROM schema_version"));
+            if (q.next()) versionFound = q.value(0).toInt();
+
+            QVERIFY(q.exec("PRAGMA table_info(shots)"));
+            while (q.next()) {
+                if (q.value(1).toString() == "enjoyment_source") {
+                    columnGone = false;
+                    break;
+                }
+            }
+
+            QVERIFY(q.exec("SELECT uuid, enjoyment FROM shots ORDER BY uuid"));
+            while (q.next()) {
+                const QString u = q.value(0).toString();
+                const int e = q.value(1).toInt();
+                if      (u == "u1") enjoy1 = e;
+                else if (u == "u2") enjoy2 = e;
+                else if (u == "u3") enjoy3 = e;
+                else if (u == "u4") enjoy4 = e;
+            }
+        });
+
+        QCOMPARE(versionFound, 16);
+        QVERIFY2(columnGone, "enjoyment_source column must be dropped");
+        QCOMPARE(enjoy1, 50);
+        QCOMPARE(enjoy2, 50);
+        QCOMPARE(enjoy3, 90);
+        QCOMPARE(enjoy4, 0);
+
+        // Visualizer back-sync queue: exactly one entry (V1 — V2 belongs to
+        // a user-rated row that we never auto-stamped, so it's not queued).
+        const QByteArray pendingJson = appSettings.value(
+            "migration16/pendingVisualizerSync").toByteArray();
+        const QJsonArray pending = QJsonDocument::fromJson(pendingJson).array();
+        QCOMPARE(pending.size(), 1);
+        QCOMPARE(pending.first().toObject().value("visualizerId").toString(),
+                 QStringLiteral("V1"));
+
+        // Restore QSettings so we don't leak test state.
+        if (prior.isValid()) appSettings.setValue("shot/defaultRating", prior);
+        else appSettings.remove("shot/defaultRating");
+        if (priorPending.isValid())
+            appSettings.setValue("migration16/pendingVisualizerSync", priorPending);
+        else appSettings.remove("migration16/pendingVisualizerSync");
     }
 };
 

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -839,44 +839,34 @@ private slots:
     // intentionally avoids the AI module to stay focused on the SQL block
     // builders.
     // -----------------------------------------------------------------
-    // bestRecentShot.confidence (issue #1055 Layer 3)
+    // bestRecentShot — user-rated only (Layer 3 inferred fallback removed)
     // -----------------------------------------------------------------
 
-    static qint64 insertShotWithSource(QSqlDatabase& db,
-                                       const QString& uuid, qint64 ts,
-                                       const QString& kbId, int enjoyment,
-                                       const QString& source)
-    {
-        const qint64 id = insertShot(db, ShotRow{
-            .uuid = uuid, .timestamp = ts,
-            .profileName = QStringLiteral("P"), .profileKbId = kbId,
-            .duration = 30, .finalWeight = 36, .doseWeight = 18,
-            .grinderSetting = QStringLiteral("4.0"),
-            .enjoyment = enjoyment
-        });
-        if (id <= 0) return -1;
-        // Patch enjoyment_source on the just-inserted row. The insert
-        // helper doesn't know about the new column, and migration 14
-        // back-fills 'user' for enjoyment > 0 rows by default — so this
-        // test override is needed only to label rows as 'inferred'.
-        QSqlQuery up(db);
-        up.prepare("UPDATE shots SET enjoyment_source = ? WHERE id = ?");
-        up.addBindValue(source);
-        up.addBindValue(id);
-        up.exec ();
-        return id;
-    }
-
-    void bestRecentShot_prefersUserOverInferredEvenWhenInferredScoresHigher()
+    void bestRecentShot_highestUserRatedWins()
     {
         const QString dbPath = freshDbPath();
         initAndClose(dbPath);
         const qint64 now = QDateTime::currentSecsSinceEpoch();
 
-        withRawDb(dbPath, "best_user_pref", [&](QSqlDatabase& db) {
-            insertShotWithSource(db, "user70", now - 24*3600, "kb", 70, "user");
-            insertShotWithSource(db, "infer85", now - 12*3600, "kb", 85, "inferred");
-            const qint64 currentId = insertShotWithSource(db, "current", now - 3600, "kb", 0, "none");
+        withRawDb(dbPath, "best_user_only", [&](QSqlDatabase& db) {
+            insertShot(db, ShotRow{
+                .uuid = "user70", .timestamp = now - 24*3600,
+                .profileName = "P", .profileKbId = "kb",
+                .duration = 30, .finalWeight = 36, .doseWeight = 18,
+                .grinderSetting = "4.0", .enjoyment = 70
+            });
+            insertShot(db, ShotRow{
+                .uuid = "user85", .timestamp = now - 12*3600,
+                .profileName = "P", .profileKbId = "kb",
+                .duration = 30, .finalWeight = 36, .doseWeight = 18,
+                .grinderSetting = "4.0", .enjoyment = 85
+            });
+            const qint64 currentId = insertShot(db, ShotRow{
+                .uuid = "current", .timestamp = now - 3600,
+                .profileName = "P", .profileKbId = "kb",
+                .duration = 30, .finalWeight = 36, .doseWeight = 18,
+                .grinderSetting = "4.0", .enjoyment = 0
+            });
 
             ShotRecord rec = ShotHistoryStorage::loadShotRecordStatic(db, currentId);
             const ShotProjection cur = ShotHistoryStorage::convertShotRecord(rec);
@@ -884,30 +874,10 @@ private slots:
             const QJsonObject best = DialingBlocks::buildBestRecentShotBlock(
                 db, "kb", currentId, cur);
             QVERIFY(!best.isEmpty());
-            QCOMPARE(best.value("enjoyment0to100").toInt(), 70);
-            QCOMPARE(best.value("confidence").toString(), QStringLiteral("user_rated"));
-        });
-    }
-
-    void bestRecentShot_inferredFallbackWhenNoUserRated()
-    {
-        const QString dbPath = freshDbPath();
-        initAndClose(dbPath);
-        const qint64 now = QDateTime::currentSecsSinceEpoch();
-
-        withRawDb(dbPath, "best_inferred_fallback", [&](QSqlDatabase& db) {
-            insertShotWithSource(db, "infer75", now - 24*3600, "kb", 75, "inferred");
-            insertShotWithSource(db, "infer80", now - 12*3600, "kb", 80, "inferred");
-            const qint64 currentId = insertShotWithSource(db, "current", now - 3600, "kb", 0, "none");
-
-            ShotRecord rec = ShotHistoryStorage::loadShotRecordStatic(db, currentId);
-            const ShotProjection cur = ShotHistoryStorage::convertShotRecord(rec);
-
-            const QJsonObject best = DialingBlocks::buildBestRecentShotBlock(
-                db, "kb", currentId, cur);
-            QVERIFY(!best.isEmpty());
-            QCOMPARE(best.value("enjoyment0to100").toInt(), 80);
-            QCOMPARE(best.value("confidence").toString(), QStringLiteral("inferred"));
+            QCOMPARE(best.value("enjoyment0to100").toInt(), 85);
+            // Layer 3 removed: bestRecentShot no longer carries `confidence`.
+            QVERIFY2(!best.contains("confidence"),
+                     "bestRecentShot must not carry the removed `confidence` field");
         });
     }
 
@@ -919,8 +889,18 @@ private slots:
 
         withRawDb(dbPath, "best_empty", [&](QSqlDatabase& db) {
             // Only unrated rows in the window — block must be omitted.
-            insertShotWithSource(db, "u-cur", now - 3600, "kb", 0, "none");
-            const qint64 currentId = insertShotWithSource(db, "current", now - 60, "kb", 0, "none");
+            insertShot(db, ShotRow{
+                .uuid = "u-cur", .timestamp = now - 3600,
+                .profileName = "P", .profileKbId = "kb",
+                .duration = 30, .finalWeight = 36, .doseWeight = 18,
+                .grinderSetting = "4.0", .enjoyment = 0
+            });
+            const qint64 currentId = insertShot(db, ShotRow{
+                .uuid = "current", .timestamp = now - 60,
+                .profileName = "P", .profileKbId = "kb",
+                .duration = 30, .finalWeight = 36, .doseWeight = 18,
+                .grinderSetting = "4.0", .enjoyment = 0
+            });
             ShotRecord rec = ShotHistoryStorage::loadShotRecordStatic(db, currentId);
             const ShotProjection cur = ShotHistoryStorage::convertShotRecord(rec);
 


### PR DESCRIPTION
## Summary

Layer 3 of the May-4 \`shot-rating-capture\` change auto-stamped clean unrated shots with \`enjoyment=75\` and \`enjoymentSource="inferred"\` so the advisor's \`bestRecentShot\` block could stay warm even when the user hadn't rated anything. Two weeks of production data showed two failures:

1. **User-visible breakage** — issue #1150: the Visualizer "Default Shot Rating" setting (a long-standing user preference) was silently overwritten by the auto-rated 75.
2. **No measurable advisor benefit** — the inferred score was paired with \`confidence: "inferred"\` and a system-prompt instruction telling the LLM to treat it as a hint requiring user confirmation. Meanwhile the LLM already received the underlying detector signals (\`verdictCategory\`, \`channelingSeverity\`, \`grindDirection\`) directly.

This PR treats Layer 3 as a failed experiment and rolls it back. A shot's rating is now exclusively what the user provided (manually, via QuickRatingRow, or via conversational reply). Layers 1 and 2 are untouched.

## Key changes

- **Migration 16** drops \`shots.enjoyment_source\` in a transaction. Before the drop, rows with \`enjoyment_source = 'inferred'\` have their \`enjoyment\` reset to the user's configured default (\`QSettings shot/defaultRating\`, fallback 75) — **not** to 0, since most users have a non-zero default. Visualizer-uploaded affected rows are stashed in a pending-sync \`QSettings\` list.
- **MainController Visualizer back-sync** — \`processPendingVisualizerRatingSync\` drains the pending list serially via \`VisualizerUploader::updateShotOnVisualizer\` once credentials are available, so the cloud copy on visualizer.coffee also reflects the corrected rating. Failed entries persist for the next boot.
- **End-to-end strip** of \`enjoymentSource\` / \`bestRecentShot.confidence\` / "inferred" plumbing: \`ShotProjection\`, \`ShotData\` / \`ShotRecord\`, the INSERT/SELECT/UPDATE column maps, the MCP \`shots_list\` filter, the MCP \`updateShot\` validator, the dialing-block builders, \`ShotSummary\` fields, and the related system-prompt teaching.
- **QML cleanup** — \`PostShotReviewPage\` no longer treats inferred ratings specially; \`QuickRatingRow\` shows when \`editEnjoyment === 0\`.
- **Tests** — deleted the two Layer-3 \`bestRecentShot_*OverInferred*\` tests; renamed \`v14_idempotentReapply\` to \`v16_columnIsDropped\`; added \`v16_resetsInferredAndDropsColumn\` covering the full migration contract including the pending Visualizer sync queue.

## OpenSpec

This is the implementation of \`openspec/changes/remove-inferred-shot-ratings/\` (modifies the \`shot-rating-capture\` spec).

## Test plan

- [x] \`mcp__qtcreator__build\` — clean (0 errors, 0 warnings, ~138s).
- [x] \`mcp__qtcreator__run_tests\` — 2051 passed, 0 failed, 0 skipped.
- [x] New test \`v16_resetsInferredAndDropsColumn\` verifies migration end-to-end: inferred rows reset to QSettings default, user-rated rows untouched, column dropped, schema_version 16, pending-sync list contains exactly the Visualizer-uploaded inferred rows.
- [ ] Manual smoke on a device with inferred-rated shots in DB: verify shots are reset to the user's \`defaultShotRating\` on first launch and that Visualizer-uploaded ones are re-PATCHed.
- [ ] Manual smoke: pull a fresh espresso shot, confirm it saves with the user's \`defaultShotRating\` (not auto-75).

Closes #1150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)