### PR TITLE
fix: QSettings store-scope mismatch (migration 16, reconciliation, accessibility)

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -220,7 +220,13 @@ MainController::MainController(QNetworkAccessManager* networkManager,
             || visualizerId != m_migration16InFlightVisualizerId)
             return;
 
-        QSettings s;
+        // Must match the app's settings scope (Settings owns
+        // QSettings("DecentEspresso","DE1Qt")); a bare QSettings()
+        // resolves to a different, empty store (main.cpp sets
+        // applicationName "Decenza"). Same fix applies to every
+        // QSettings construction in this file's reconciliation /
+        // pending-sync code.
+        QSettings s(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
         QJsonArray pending = QJsonDocument::fromJson(
             s.value(QStringLiteral("migration16/pendingVisualizerSync")).toByteArray()).array();
         for (qsizetype i = 0; i < pending.size(); ++i) {
@@ -2581,7 +2587,7 @@ bool MainController::isSawSettling() const {
 
 void MainController::processPendingVisualizerRatingSync()
 {
-    QSettings s;
+    QSettings s(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
     if (!s.contains(QStringLiteral("migration16/pendingVisualizerSync")))
         return;
 
@@ -2602,7 +2608,7 @@ void MainController::dispatchNextPendingVisualizerSync()
     if (!m_migration16InFlightVisualizerId.isEmpty()) return;
     if (!m_visualizer || !m_shotHistory) return;
 
-    QSettings s;
+    QSettings s(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
     const QByteArray raw = s.value(
         QStringLiteral("migration16/pendingVisualizerSync")).toByteArray();
     if (raw.isEmpty()) return;
@@ -2650,7 +2656,7 @@ void MainController::dispatchNextPendingVisualizerSync()
         if (!shot.isValid()) {
             qWarning() << "MainController: migration16 sync — shot" << shotId << "no longer exists; dropping";
             // Pop the bad entry and continue.
-            QSettings ss;
+            QSettings ss(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
             QJsonArray remain = QJsonDocument::fromJson(
                 ss.value(QStringLiteral("migration16/pendingVisualizerSync")).toByteArray()).array();
             if (!remain.isEmpty()) remain.removeFirst();
@@ -2674,7 +2680,7 @@ void MainController::processVisualizerReconciliation()
 {
     if (!m_visualizer || !m_shotHistory) return;
 
-    QSettings s;
+    QSettings s(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
     if (s.value(QStringLiteral("visualizerBackfill/doneV1"), false).toBool())
         return;  // already reconciled on this device
 
@@ -2719,7 +2725,7 @@ void MainController::processVisualizerReconciliation()
             return;
         }
         // Genuinely completed pass — safe to set the run-once flag.
-        QSettings ss;
+        QSettings ss(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
         ss.setValue(QStringLiteral("visualizerBackfill/doneV1"), true);
         ss.sync();
 

--- a/src/core/accessibilitymanager.cpp
+++ b/src/core/accessibilitymanager.cpp
@@ -120,11 +120,15 @@ AccessibilityManager::migrateAccessibilityLegacyStore(QSettings& primary,
 
     if (legacyStatus != QSettings::NoError) {
         // The legacy read provably failed (corrupt INI / access error).
-        // Do NOT burn the one-shot guard on a read we know failed —
-        // retry next launch instead of permanently losing a user's
-        // accessibility settings to a transient unreadable store.
-        // (NativeFormat on Windows/macOS can't always prove failure;
-        // legacyKeyCount is the best available signal there.)
+        // Whatever keys parsed were already copied above (copy-if-absent
+        // makes re-copying on the retry safe); we just don't stamp the
+        // one-shot guard on a read we know failed — retry next launch
+        // instead of permanently losing a user's accessibility settings
+        // to a transient unreadable store. (NativeFormat on Windows/
+        // macOS can't always prove failure: there status() returns
+        // NoError despite a real failure and the guard IS stamped below;
+        // legacyKeyCount is logged purely as a post-hoc breadcrumb, not
+        // a mitigation.)
         out.deferredOnError = true;
         return out;
     }

--- a/src/core/accessibilitymanager.cpp
+++ b/src/core/accessibilitymanager.cpp
@@ -13,8 +13,13 @@
 
 AccessibilityManager::AccessibilityManager(QObject *parent)
     : QObject(parent)
-    , m_settings("Decenza", "DE1")
+    // Primary store, matching every settings_*.cpp domain class. Was
+    // QSettings("Decenza","DE1") — an isolated third store that broke
+    // accessibility backup/restore and survived factory reset. Existing
+    // values are carried over by migrateLegacyStore().
+    , m_settings("DecentEspresso", "DE1Qt")
 {
+    migrateLegacyStore();
     loadSettings();
     initTts();
     if (m_enabled && m_tickEnabled)
@@ -24,10 +29,10 @@ AccessibilityManager::AccessibilityManager(QObject *parent)
 #ifdef DECENZA_TESTING
 AccessibilityManager::AccessibilityManager(TestSkipAudioInit, QObject *parent)
     : QObject(parent)
-    , m_settings("Decenza", "DE1")
+    , m_settings("DecentEspresso", "DE1Qt")
 {
-    // Deliberately skip loadSettings() so tests don't inherit whatever the
-    // dev machine has persisted in QSettings("Decenza", "DE1"). Member
+    // Deliberately skip migrateLegacyStore()/loadSettings() so tests
+    // don't inherit whatever the dev machine has persisted. Member
     // defaults from the header (m_enabled=false, m_ttsEnabled=true, etc.)
     // give a deterministic starting state. Skip initTts() / initTickSound()
     // for the same reason — tests override the dispatch virtuals.
@@ -70,6 +75,44 @@ void AccessibilityManager::shutdown()
             m_tickSounds[i] = nullptr;
         }
     }
+}
+
+void AccessibilityManager::migrateLegacyStore()
+{
+    // One-time: carry accessibility/* from the old isolated
+    // QSettings("Decenza","DE1") store into the primary store. Guarded
+    // so it runs once; copy-if-absent so a re-run (or a user who
+    // already changed a setting post-migration) never clobbers newer
+    // primary values. The legacy store is intentionally left intact
+    // (harmless; supports clean downgrade).
+    constexpr const char* kMigratedFlag = "accessibility/_migratedFromLegacyV1";
+    if (m_settings.value(kMigratedFlag, false).toBool())
+        return;
+
+    static const char* kKeys[] = {
+        "accessibility/enabled",
+        "accessibility/ttsEnabled",
+        "accessibility/tickEnabled",
+        "accessibility/tickSoundIndex",
+        "accessibility/tickVolume",
+        "accessibility/extractionAnnouncementsEnabled",
+        "accessibility/extractionAnnouncementInterval",
+        "accessibility/extractionAnnouncementMode",
+    };
+
+    QSettings legacy(QStringLiteral("Decenza"), QStringLiteral("DE1"));
+    int copied = 0;
+    for (const char* key : kKeys) {
+        if (legacy.contains(QLatin1String(key))
+            && !m_settings.contains(QLatin1String(key))) {
+            m_settings.setValue(QLatin1String(key), legacy.value(QLatin1String(key)));
+            ++copied;
+        }
+    }
+    m_settings.setValue(kMigratedFlag, true);
+    m_settings.sync();
+    qDebug() << "AccessibilityManager: migrated" << copied
+             << "legacy accessibility setting(s) into the primary store";
 }
 
 void AccessibilityManager::loadSettings()

--- a/src/core/accessibilitymanager.cpp
+++ b/src/core/accessibilitymanager.cpp
@@ -77,17 +77,21 @@ void AccessibilityManager::shutdown()
     }
 }
 
-void AccessibilityManager::migrateLegacyStore()
+// Pure, store-injected so it is unit-testable without touching the
+// machine's real QSettings (caller passes the stores by reference).
+// Matches the static-helper testability pattern used elsewhere
+// (e.g. ShotHistoryStorage::reconcileVisualizerLinksStatic).
+AccessibilityManager::LegacyMigrationOutcome
+AccessibilityManager::migrateAccessibilityLegacyStore(QSettings& primary,
+                                                      QSettings& legacy)
 {
-    // One-time: carry accessibility/* from the old isolated
-    // QSettings("Decenza","DE1") store into the primary store. Guarded
-    // so it runs once; copy-if-absent so a re-run (or a user who
-    // already changed a setting post-migration) never clobbers newer
-    // primary values. The legacy store is intentionally left intact
-    // (harmless; supports clean downgrade).
+    LegacyMigrationOutcome out;
+
     constexpr const char* kMigratedFlag = "accessibility/_migratedFromLegacyV1";
-    if (m_settings.value(kMigratedFlag, false).toBool())
-        return;
+    if (primary.value(kMigratedFlag, false).toBool()) {
+        out.alreadyDone = true;
+        return out;
+    }
 
     static const char* kKeys[] = {
         "accessibility/enabled",
@@ -100,17 +104,17 @@ void AccessibilityManager::migrateLegacyStore()
         "accessibility/extractionAnnouncementMode",
     };
 
-    QSettings legacy(QStringLiteral("Decenza"), QStringLiteral("DE1"));
     legacy.sync();  // force a read so status() is meaningful below
     const QSettings::Status legacyStatus = legacy.status();
-    const int legacyKeyCount = static_cast<int>(legacy.allKeys().size());
+    out.legacyKeyCount = static_cast<int>(legacy.allKeys().size());
 
-    int copied = 0;
+    // copy-if-absent: never clobber a newer primary value (a re-run, or
+    // a user who already changed a setting post-migration).
     for (const char* key : kKeys) {
         if (legacy.contains(QLatin1String(key))
-            && !m_settings.contains(QLatin1String(key))) {
-            m_settings.setValue(QLatin1String(key), legacy.value(QLatin1String(key)));
-            ++copied;
+            && !primary.contains(QLatin1String(key))) {
+            primary.setValue(QLatin1String(key), legacy.value(QLatin1String(key)));
+            ++out.copied;
         }
     }
 
@@ -120,20 +124,40 @@ void AccessibilityManager::migrateLegacyStore()
         // retry next launch instead of permanently losing a user's
         // accessibility settings to a transient unreadable store.
         // (NativeFormat on Windows/macOS can't always prove failure;
-        // logging legacyKeyCount is the best available signal there.)
-        qWarning() << "AccessibilityManager: legacy store unreadable (status="
-                   << legacyStatus << ") — deferring migration, guard NOT set";
-        return;
+        // legacyKeyCount is the best available signal there.)
+        out.deferredOnError = true;
+        return out;
     }
 
-    m_settings.setValue(kMigratedFlag, true);
-    m_settings.sync();
+    primary.setValue(kMigratedFlag, true);
+    primary.sync();
+    out.guardStamped = true;
+    return out;
+}
+
+void AccessibilityManager::migrateLegacyStore()
+{
+    // One-time: carry accessibility/* from the old isolated
+    // QSettings("Decenza","DE1") store into the primary store. The
+    // legacy store is intentionally left intact (harmless; supports
+    // clean downgrade — factoryReset() wipes it explicitly).
+    QSettings legacy(QStringLiteral("Decenza"), QStringLiteral("DE1"));
+    const LegacyMigrationOutcome r =
+        migrateAccessibilityLegacyStore(m_settings, legacy);
+
+    if (r.alreadyDone)
+        return;
+    if (r.deferredOnError) {
+        qWarning() << "AccessibilityManager: legacy store unreadable —"
+                      " deferring migration, guard NOT set";
+        return;
+    }
     // qInfo (not qDebug) + legacy key count so a support log can tell
     // "nothing to migrate" (legacyKeyCount==0) apart from "all already
     // present" (copied==0 && legacyKeyCount>0) — an irreversible
     // one-time migration deserves a durable, unambiguous breadcrumb.
-    qInfo() << "AccessibilityManager: migrated" << copied << "of"
-            << legacyKeyCount << "legacy accessibility key(s) into the primary store";
+    qInfo() << "AccessibilityManager: migrated" << r.copied << "of"
+            << r.legacyKeyCount << "legacy accessibility key(s) into the primary store";
 }
 
 void AccessibilityManager::loadSettings()

--- a/src/core/accessibilitymanager.cpp
+++ b/src/core/accessibilitymanager.cpp
@@ -101,6 +101,10 @@ void AccessibilityManager::migrateLegacyStore()
     };
 
     QSettings legacy(QStringLiteral("Decenza"), QStringLiteral("DE1"));
+    legacy.sync();  // force a read so status() is meaningful below
+    const QSettings::Status legacyStatus = legacy.status();
+    const int legacyKeyCount = static_cast<int>(legacy.allKeys().size());
+
     int copied = 0;
     for (const char* key : kKeys) {
         if (legacy.contains(QLatin1String(key))
@@ -109,10 +113,27 @@ void AccessibilityManager::migrateLegacyStore()
             ++copied;
         }
     }
+
+    if (legacyStatus != QSettings::NoError) {
+        // The legacy read provably failed (corrupt INI / access error).
+        // Do NOT burn the one-shot guard on a read we know failed —
+        // retry next launch instead of permanently losing a user's
+        // accessibility settings to a transient unreadable store.
+        // (NativeFormat on Windows/macOS can't always prove failure;
+        // logging legacyKeyCount is the best available signal there.)
+        qWarning() << "AccessibilityManager: legacy store unreadable (status="
+                   << legacyStatus << ") — deferring migration, guard NOT set";
+        return;
+    }
+
     m_settings.setValue(kMigratedFlag, true);
     m_settings.sync();
-    qDebug() << "AccessibilityManager: migrated" << copied
-             << "legacy accessibility setting(s) into the primary store";
+    // qInfo (not qDebug) + legacy key count so a support log can tell
+    // "nothing to migrate" (legacyKeyCount==0) apart from "all already
+    // present" (copied==0 && legacyKeyCount>0) — an irreversible
+    // one-time migration deserves a durable, unambiguous breadcrumb.
+    qInfo() << "AccessibilityManager: migrated" << copied << "of"
+            << legacyKeyCount << "legacy accessibility key(s) into the primary store";
 }
 
 void AccessibilityManager::loadSettings()

--- a/src/core/accessibilitymanager.h
+++ b/src/core/accessibilitymanager.h
@@ -127,9 +127,11 @@ public:
         int  legacyKeyCount = 0;      // total keys in the legacy store
     };
     // Pure, store-injected migration: copy-if-absent accessibility/*
-    // from `legacy` into `primary`, guarded + idempotent, deferring
-    // (without stamping the guard) when the legacy read provably fails.
-    // Stores passed by ref so tests need not touch real QSettings.
+    // from `legacy` into `primary`, guarded + idempotent. Copies happen
+    // BEFORE the status check, so on a provable legacy read failure it
+    // keeps whatever parsed but does NOT stamp the guard (a later run
+    // retries; copy-if-absent makes the re-copy safe). Stores passed by
+    // ref so tests need not touch real QSettings.
     static LegacyMigrationOutcome migrateAccessibilityLegacyStore(
         QSettings& primary, QSettings& legacy);
 

--- a/src/core/accessibilitymanager.h
+++ b/src/core/accessibilitymanager.h
@@ -119,6 +119,11 @@ protected:
 private:
     void loadSettings();
     void saveSettings();
+    // One-time copy of accessibility/* keys from the legacy
+    // QSettings("Decenza","DE1") store into the primary
+    // QSettings("DecentEspresso","DE1Qt") store every other settings
+    // domain uses. Guarded + idempotent. See accessibilitymanager.cpp.
+    void migrateLegacyStore();
     // Internal setter. Externally setEnabled() always announces; toggleEnabled()
     // calls this with announce=false to avoid double-speak (it then issues a
     // single Assertive announcement itself).

--- a/src/core/accessibilitymanager.h
+++ b/src/core/accessibilitymanager.h
@@ -116,13 +116,29 @@ protected:
     // accessibility is being turned off.
     void routeAnnouncement(const QString& text, bool interrupt);
 
+public:
+    // Result of the one-time legacy-store carry-over. Public so the
+    // pure static below is unit-testable.
+    struct LegacyMigrationOutcome {
+        bool alreadyDone = false;     // guard already set — no-op
+        bool deferredOnError = false; // legacy read failed; guard NOT set
+        bool guardStamped = false;    // completed; guard now set
+        int  copied = 0;              // keys copied (absent in primary)
+        int  legacyKeyCount = 0;      // total keys in the legacy store
+    };
+    // Pure, store-injected migration: copy-if-absent accessibility/*
+    // from `legacy` into `primary`, guarded + idempotent, deferring
+    // (without stamping the guard) when the legacy read provably fails.
+    // Stores passed by ref so tests need not touch real QSettings.
+    static LegacyMigrationOutcome migrateAccessibilityLegacyStore(
+        QSettings& primary, QSettings& legacy);
+
 private:
     void loadSettings();
     void saveSettings();
-    // One-time copy of accessibility/* keys from the legacy
-    // QSettings("Decenza","DE1") store into the primary
-    // QSettings("DecentEspresso","DE1Qt") store every other settings
-    // domain uses. Guarded + idempotent. See accessibilitymanager.cpp.
+    // Constructs the real legacy QSettings("Decenza","DE1") and
+    // delegates to migrateAccessibilityLegacyStore(m_settings, …),
+    // logging the outcome. Called once from the normal ctor.
     void migrateLegacyStore();
     // Internal setter. Externally setEnabled() always announces; toggleEnabled()
     // calls this with announce=false to avoid double-speak (it then issues a

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -569,6 +569,16 @@ void Settings::factoryReset()
     defaultSettings.clear();
     defaultSettings.sync();
 
+    // 2b. Clear the legacy AccessibilityManager store. Accessibility now
+    // lives in the primary store (cleared above), but its one-time
+    // migrateLegacyStore() guard is in the primary store too — so after
+    // a factory reset that guard is gone and the next launch would
+    // resurrect old accessibility settings from this legacy store.
+    // Wipe it so factory reset actually resets accessibility.
+    QSettings legacyAccessibility(QStringLiteral("Decenza"), QStringLiteral("DE1"));
+    legacyAccessibility.clear();
+    legacyAccessibility.sync();
+
     // 3. Delete all data directories under AppDataLocation
     QString appDataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     QStringList dataDirs = {

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -815,9 +815,15 @@ bool ShotHistoryStorage::runMigrations()
                 return false;
             }
 
-            // Read user's configured default rating up-front. QSettings is
-            // thread-safe and the key is stable across app versions.
-            QSettings appSettings;
+            // Read user's configured default rating up-front. MUST use
+            // the same QSettings scope the app's Settings object owns
+            // (settings.cpp: QSettings("DecentEspresso","DE1Qt")). A
+            // bare QSettings() resolves to org/app "DecentEspresso"/
+            // "Decenza" (main.cpp setApplicationName) — a DIFFERENT,
+            // empty store — which would silently return the 75 fallback
+            // and no-op the reset for every user whose default ≠ 75.
+            QSettings appSettings(QStringLiteral("DecentEspresso"),
+                                  QStringLiteral("DE1Qt"));
             const int defaultRating = appSettings.value(
                 QStringLiteral("shot/defaultRating"), 75).toInt();
 

--- a/src/network/shotserver_backup.cpp
+++ b/src/network/shotserver_backup.cpp
@@ -1036,23 +1036,32 @@ void ShotServer::handleBackupRestore(QTcpSocket* socket, const QString& tempFile
 
                 // Accessibility → PRIMARY store (where AccessibilityManager
                 // reads it). Writing to the bare/secondary `settings`
-                // would be a silent no-op. Stamp the migration guard so
-                // AccessibilityManager::migrateLegacyStore doesn't later
-                // overwrite a freshly restored value from the legacy store.
-                // (only write keys present, to avoid clobbering defaults)
-                if (extra.contains("accessibility")) {
+                // would be a silent no-op. (only write keys present, to
+                // avoid clobbering defaults)
+                {
                     QSettings accessStore(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
-                    QJsonObject a = extra["accessibility"].toObject();
-                    if (a.contains("enabled")) accessStore.setValue("accessibility/enabled", a["enabled"].toBool());
-                    if (a.contains("ttsEnabled")) accessStore.setValue("accessibility/ttsEnabled", a["ttsEnabled"].toBool());
-                    if (a.contains("tickEnabled")) accessStore.setValue("accessibility/tickEnabled", a["tickEnabled"].toBool());
-                    if (a.contains("tickSoundIndex")) accessStore.setValue("accessibility/tickSoundIndex", a["tickSoundIndex"].toInt());
-                    if (a.contains("tickVolume")) accessStore.setValue("accessibility/tickVolume", a["tickVolume"].toInt());
-                    if (a.contains("extractionAnnouncementsEnabled")) accessStore.setValue("accessibility/extractionAnnouncementsEnabled", a["extractionAnnouncementsEnabled"].toBool());
-                    if (a.contains("extractionAnnouncementInterval")) accessStore.setValue("accessibility/extractionAnnouncementInterval", a["extractionAnnouncementInterval"].toInt());
-                    if (a.contains("extractionAnnouncementMode")) accessStore.setValue("accessibility/extractionAnnouncementMode", a["extractionAnnouncementMode"].toString());
+                    if (extra.contains("accessibility")) {
+                        QJsonObject a = extra["accessibility"].toObject();
+                        if (a.contains("enabled")) accessStore.setValue("accessibility/enabled", a["enabled"].toBool());
+                        if (a.contains("ttsEnabled")) accessStore.setValue("accessibility/ttsEnabled", a["ttsEnabled"].toBool());
+                        if (a.contains("tickEnabled")) accessStore.setValue("accessibility/tickEnabled", a["tickEnabled"].toBool());
+                        if (a.contains("tickSoundIndex")) accessStore.setValue("accessibility/tickSoundIndex", a["tickSoundIndex"].toInt());
+                        if (a.contains("tickVolume")) accessStore.setValue("accessibility/tickVolume", a["tickVolume"].toInt());
+                        if (a.contains("extractionAnnouncementsEnabled")) accessStore.setValue("accessibility/extractionAnnouncementsEnabled", a["extractionAnnouncementsEnabled"].toBool());
+                        if (a.contains("extractionAnnouncementInterval")) accessStore.setValue("accessibility/extractionAnnouncementInterval", a["extractionAnnouncementInterval"].toInt());
+                        if (a.contains("extractionAnnouncementMode")) accessStore.setValue("accessibility/extractionAnnouncementMode", a["extractionAnnouncementMode"].toString());
+                    }
+                    // Stamp the migration guard on ANY successful restore
+                    // (even a backup with no accessibility block): a
+                    // restored profile is authoritative, so
+                    // AccessibilityManager::migrateLegacyStore must not
+                    // later merge this device's stale legacy store over it.
                     accessStore.setValue("accessibility/_migratedFromLegacyV1", true);
                     accessStore.sync();
+                    if (accessStore.status() != QSettings::NoError) {
+                        qWarning() << "ShotServer: accessibility restore sync failed (status="
+                                   << accessStore.status() << ") — settings may not persist";
+                    }
                 }
 
                 // Language

--- a/src/network/shotserver_backup.cpp
+++ b/src/network/shotserver_backup.cpp
@@ -427,15 +427,20 @@ void ShotServer::handleBackupFull(QTcpSocket* socket)
         shotMap["manualGeocoded"] = settings.value("shotMap/manualGeocoded", false).toBool();
         extra["shotMap"] = shotMap;
 
+        // Accessibility lives in the PRIMARY store (AccessibilityManager
+        // now uses QSettings("DecentEspresso","DE1Qt") like every other
+        // settings domain). Reading it off the bare/secondary `settings`
+        // would silently capture defaults — the bug this fixes.
+        QSettings accessStore(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
         QJsonObject accessibility;
-        accessibility["enabled"] = settings.value("accessibility/enabled", false).toBool();
-        accessibility["ttsEnabled"] = settings.value("accessibility/ttsEnabled", true).toBool();
-        accessibility["tickEnabled"] = settings.value("accessibility/tickEnabled", true).toBool();
-        accessibility["tickSoundIndex"] = settings.value("accessibility/tickSoundIndex", 1).toInt();
-        accessibility["tickVolume"] = settings.value("accessibility/tickVolume", 100).toInt();
-        accessibility["extractionAnnouncementsEnabled"] = settings.value("accessibility/extractionAnnouncementsEnabled", true).toBool();
-        accessibility["extractionAnnouncementInterval"] = settings.value("accessibility/extractionAnnouncementInterval", 5).toInt();
-        accessibility["extractionAnnouncementMode"] = settings.value("accessibility/extractionAnnouncementMode", "both").toString();
+        accessibility["enabled"] = accessStore.value("accessibility/enabled", false).toBool();
+        accessibility["ttsEnabled"] = accessStore.value("accessibility/ttsEnabled", true).toBool();
+        accessibility["tickEnabled"] = accessStore.value("accessibility/tickEnabled", true).toBool();
+        accessibility["tickSoundIndex"] = accessStore.value("accessibility/tickSoundIndex", 1).toInt();
+        accessibility["tickVolume"] = accessStore.value("accessibility/tickVolume", 100).toInt();
+        accessibility["extractionAnnouncementsEnabled"] = accessStore.value("accessibility/extractionAnnouncementsEnabled", true).toBool();
+        accessibility["extractionAnnouncementInterval"] = accessStore.value("accessibility/extractionAnnouncementInterval", 5).toInt();
+        accessibility["extractionAnnouncementMode"] = accessStore.value("accessibility/extractionAnnouncementMode", "both").toString();
         extra["accessibility"] = accessibility;
 
         extra["language"] = settings.value("localization/language", "en").toString();
@@ -1029,17 +1034,25 @@ void ShotServer::handleBackupRestore(QTcpSocket* socket, const QString& tempFile
                     settings.setValue("shotMap/manualGeocoded", sm["manualGeocoded"].toBool());
                 }
 
-                // Accessibility (only write keys that are present to avoid overwriting defaults)
+                // Accessibility → PRIMARY store (where AccessibilityManager
+                // reads it). Writing to the bare/secondary `settings`
+                // would be a silent no-op. Stamp the migration guard so
+                // AccessibilityManager::migrateLegacyStore doesn't later
+                // overwrite a freshly restored value from the legacy store.
+                // (only write keys present, to avoid clobbering defaults)
                 if (extra.contains("accessibility")) {
+                    QSettings accessStore(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
                     QJsonObject a = extra["accessibility"].toObject();
-                    if (a.contains("enabled")) settings.setValue("accessibility/enabled", a["enabled"].toBool());
-                    if (a.contains("ttsEnabled")) settings.setValue("accessibility/ttsEnabled", a["ttsEnabled"].toBool());
-                    if (a.contains("tickEnabled")) settings.setValue("accessibility/tickEnabled", a["tickEnabled"].toBool());
-                    if (a.contains("tickSoundIndex")) settings.setValue("accessibility/tickSoundIndex", a["tickSoundIndex"].toInt());
-                    if (a.contains("tickVolume")) settings.setValue("accessibility/tickVolume", a["tickVolume"].toInt());
-                    if (a.contains("extractionAnnouncementsEnabled")) settings.setValue("accessibility/extractionAnnouncementsEnabled", a["extractionAnnouncementsEnabled"].toBool());
-                    if (a.contains("extractionAnnouncementInterval")) settings.setValue("accessibility/extractionAnnouncementInterval", a["extractionAnnouncementInterval"].toInt());
-                    if (a.contains("extractionAnnouncementMode")) settings.setValue("accessibility/extractionAnnouncementMode", a["extractionAnnouncementMode"].toString());
+                    if (a.contains("enabled")) accessStore.setValue("accessibility/enabled", a["enabled"].toBool());
+                    if (a.contains("ttsEnabled")) accessStore.setValue("accessibility/ttsEnabled", a["ttsEnabled"].toBool());
+                    if (a.contains("tickEnabled")) accessStore.setValue("accessibility/tickEnabled", a["tickEnabled"].toBool());
+                    if (a.contains("tickSoundIndex")) accessStore.setValue("accessibility/tickSoundIndex", a["tickSoundIndex"].toInt());
+                    if (a.contains("tickVolume")) accessStore.setValue("accessibility/tickVolume", a["tickVolume"].toInt());
+                    if (a.contains("extractionAnnouncementsEnabled")) accessStore.setValue("accessibility/extractionAnnouncementsEnabled", a["extractionAnnouncementsEnabled"].toBool());
+                    if (a.contains("extractionAnnouncementInterval")) accessStore.setValue("accessibility/extractionAnnouncementInterval", a["extractionAnnouncementInterval"].toInt());
+                    if (a.contains("extractionAnnouncementMode")) accessStore.setValue("accessibility/extractionAnnouncementMode", a["extractionAnnouncementMode"].toString());
+                    accessStore.setValue("accessibility/_migratedFromLegacyV1", true);
+                    accessStore.sync();
                 }
 
                 // Language

--- a/src/network/shotserver_backup.cpp
+++ b/src/network/shotserver_backup.cpp
@@ -1051,9 +1051,9 @@ void ShotServer::handleBackupRestore(QTcpSocket* socket, const QString& tempFile
                         if (a.contains("extractionAnnouncementInterval")) accessStore.setValue("accessibility/extractionAnnouncementInterval", a["extractionAnnouncementInterval"].toInt());
                         if (a.contains("extractionAnnouncementMode")) accessStore.setValue("accessibility/extractionAnnouncementMode", a["extractionAnnouncementMode"].toString());
                     }
-                    // Stamp the migration guard on ANY successful restore
-                    // (even a backup with no accessibility block): a
-                    // restored profile is authoritative, so
+                    // Whenever extra_settings.json is restored (even with
+                    // no accessibility block), stamp the migration guard:
+                    // a restored profile is authoritative, so
                     // AccessibilityManager::migrateLegacyStore must not
                     // later merge this device's stale legacy store over it.
                     accessStore.setValue("accessibility/_migratedFromLegacyV1", true);

--- a/tests/tst_accessibility_announcements.cpp
+++ b/tests/tst_accessibility_announcements.cpp
@@ -1,6 +1,8 @@
 #include <QtTest>
 #include <QSignalSpy>
 #include <QSettings>
+#include <QTemporaryDir>
+#include <QFile>
 
 #include "core/accessibilitymanager.h"
 
@@ -64,18 +66,20 @@ void setup(FakeAccessibilityManager& mgr, bool enabled, bool ttsEnabled, bool sc
 
 }
 
-// AccessibilityManager uses QSettings("Decenza", "DE1") — the two-string ctor
-// hardcodes NativeFormat per Qt docs, so setDefaultFormat()/setPath() can't
-// redirect it (NSUserDefaults / Windows registry / Linux native conf are
-// unaffected). Instead we follow the tst_settings pattern: snapshot the real
-// store's accessibility keys in init() and restore them in cleanup() so the
+// AccessibilityManager now uses the PRIMARY store
+// QSettings("DecentEspresso", "DE1Qt") like every other settings domain
+// (it was an isolated QSettings("Decenza","DE1") — see
+// accessibilitymanager.cpp). The two-string ctor hardcodes NativeFormat
+// per Qt docs, so setDefaultFormat()/setPath() can't redirect it.
+// Instead we follow the tst_settings pattern: snapshot the real store's
+// accessibility keys in init() and restore them in cleanup() so the
 // developer's settings round-trip even when assertions fail mid-test.
 
 class tst_AccessibilityAnnouncements : public QObject {
     Q_OBJECT
 
 private:
-    QSettings m_realSettings{QStringLiteral("Decenza"), QStringLiteral("DE1")};
+    QSettings m_realSettings{QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt")};
     QVariant m_origEnabled;
     QVariant m_origTtsEnabled;
     QVariant m_origTickEnabled;
@@ -278,6 +282,114 @@ private slots:
         QCOMPARE(mgr.platformCalls.size(), 0);
         QCOMPARE(mgr.ttsCalls.size(), 1);
         QCOMPARE(mgr.ttsCalls[0].text, QStringLiteral("Battery 85 percent"));
+    }
+
+    // ---- migrateAccessibilityLegacyStore (one-time legacy carry-over) ----
+    // Store-injected pure static → tested with temp INI QSettings, zero
+    // real-store pollution. Guards an irreversible one-time migration.
+
+    void legacyMigration_copiesAbsentKeysAndStampsGuard() {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        QSettings legacy(dir.filePath("legacy.ini"), QSettings::IniFormat);
+        QSettings primary(dir.filePath("primary.ini"), QSettings::IniFormat);
+        legacy.setValue("accessibility/enabled", true);
+        legacy.setValue("accessibility/tickVolume", 42);
+        legacy.setValue("accessibility/extractionAnnouncementMode", "milestones_only");
+        legacy.sync();
+
+        auto r = AccessibilityManager::migrateAccessibilityLegacyStore(primary, legacy);
+
+        QVERIFY(!r.alreadyDone);
+        QVERIFY(!r.deferredOnError);
+        QVERIFY(r.guardStamped);
+        QCOMPARE(r.copied, 3);
+        QCOMPARE(r.legacyKeyCount, 3);
+        QCOMPARE(primary.value("accessibility/enabled").toBool(), true);
+        QCOMPARE(primary.value("accessibility/tickVolume").toInt(), 42);
+        QCOMPARE(primary.value("accessibility/extractionAnnouncementMode").toString(),
+                 QStringLiteral("milestones_only"));
+        QVERIFY(primary.value("accessibility/_migratedFromLegacyV1").toBool());
+    }
+
+    void legacyMigration_idempotentWhenGuardSet() {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        QSettings legacy(dir.filePath("legacy.ini"), QSettings::IniFormat);
+        QSettings primary(dir.filePath("primary.ini"), QSettings::IniFormat);
+        legacy.setValue("accessibility/enabled", true);
+        legacy.sync();
+        primary.setValue("accessibility/_migratedFromLegacyV1", true);
+        primary.sync();
+
+        auto r = AccessibilityManager::migrateAccessibilityLegacyStore(primary, legacy);
+
+        QVERIFY(r.alreadyDone);
+        QCOMPARE(r.copied, 0);
+        // legacy value must NOT have been pulled in (guard already set)
+        QVERIFY(!primary.contains("accessibility/enabled"));
+    }
+
+    void legacyMigration_copyIfAbsentNeverClobbersPrimary() {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        QSettings legacy(dir.filePath("legacy.ini"), QSettings::IniFormat);
+        QSettings primary(dir.filePath("primary.ini"), QSettings::IniFormat);
+        legacy.setValue("accessibility/enabled", false);   // stale legacy
+        legacy.setValue("accessibility/tickVolume", 10);
+        legacy.sync();
+        primary.setValue("accessibility/enabled", true);   // newer primary
+        primary.sync();
+
+        auto r = AccessibilityManager::migrateAccessibilityLegacyStore(primary, legacy);
+
+        QVERIFY(r.guardStamped);
+        QCOMPARE(r.copied, 1);                              // only tickVolume
+        QCOMPARE(primary.value("accessibility/enabled").toBool(), true);  // preserved
+        QCOMPARE(primary.value("accessibility/tickVolume").toInt(), 10);
+    }
+
+    void legacyMigration_emptyLegacyStillStampsGuard() {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        QSettings legacy(dir.filePath("legacy.ini"), QSettings::IniFormat);
+        QSettings primary(dir.filePath("primary.ini"), QSettings::IniFormat);
+
+        auto r = AccessibilityManager::migrateAccessibilityLegacyStore(primary, legacy);
+
+        QVERIFY(r.guardStamped);          // one-time: don't rescan forever
+        QCOMPARE(r.copied, 0);
+        QCOMPARE(r.legacyKeyCount, 0);    // distinguishes "nothing" from "all present"
+    }
+
+    void legacyMigration_defersWithoutStampingGuardOnUnreadableLegacy() {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString legacyPath = dir.filePath("legacy.ini");
+        // Corrupt INI → QSettings(IniFormat).status() == FormatError.
+        {
+            QFile f(legacyPath);
+            QVERIFY(f.open(QIODevice::WriteOnly));
+            f.write("[General\nthis is : not = valid ][[[ ini \x00\x01\x02");
+            f.close();
+        }
+        QSettings legacy(legacyPath, QSettings::IniFormat);
+        QSettings primary(dir.filePath("primary.ini"), QSettings::IniFormat);
+
+        auto r = AccessibilityManager::migrateAccessibilityLegacyStore(primary, legacy);
+
+        QVERIFY2(r.deferredOnError, "corrupt legacy must defer");
+        QVERIFY2(!r.guardStamped, "must NOT burn the one-shot guard on a failed read");
+        QVERIFY(!primary.value("accessibility/_migratedFromLegacyV1").toBool());
+
+        // A subsequent launch with a now-readable legacy completes.
+        QSettings legacyOk(dir.filePath("legacy_ok.ini"), QSettings::IniFormat);
+        legacyOk.setValue("accessibility/ttsEnabled", false);
+        legacyOk.sync();
+        auto r2 = AccessibilityManager::migrateAccessibilityLegacyStore(primary, legacyOk);
+        QVERIFY(r2.guardStamped);
+        QCOMPARE(r2.copied, 1);
+        QCOMPARE(primary.value("accessibility/ttsEnabled").toBool(), false);
     }
 };
 

--- a/tests/tst_accessibility_announcements.cpp
+++ b/tests/tst_accessibility_announcements.cpp
@@ -374,6 +374,12 @@ private slots:
             f.close();
         }
         QSettings legacy(legacyPath, QSettings::IniFormat);
+        legacy.sync();
+        // Fixture sanity: if a future Qt tolerates this input, fail
+        // loudly ("fixture no longer corrupt") rather than silently
+        // exercising the wrong path.
+        QVERIFY2(legacy.status() != QSettings::NoError,
+                 "corrupt-INI fixture must actually trip QSettings status");
         QSettings primary(dir.filePath("primary.ini"), QSettings::IniFormat);
 
         auto r = AccessibilityManager::migrateAccessibilityLegacyStore(primary, legacy);
@@ -390,6 +396,52 @@ private slots:
         QVERIFY(r2.guardStamped);
         QCOMPARE(r2.copied, 1);
         QCOMPARE(primary.value("accessibility/ttsEnabled").toBool(), false);
+    }
+
+    // NOTE on the copy-before-status ordering invariant (production
+    // copies keys, THEN checks status, so a partially-parseable legacy
+    // hands forward whatever parsed while still deferring the guard):
+    // this cannot be black-box forced here. Qt 6.11's IniFormat parser
+    // is all-or-nothing for our fixtures — it either parses fully
+    // (status NoError) or fails wholesale exposing zero keys (see
+    // _defersWithoutStampingGuardOnUnreadableLegacy, where copied==0 on
+    // FormatError). There is no reliable cross-version way to produce
+    // "FormatError + some keys parsed", so a fixture-based test for the
+    // ordering would be flaky. The invariant is preserved structurally
+    // (copy loop precedes the status gate in migrateAccessibilityLegacyStore)
+    // and its observable contract — deferred read does NOT stamp the
+    // guard, and a later readable run completes — IS deterministically
+    // covered by _defersWithoutStampingGuardOnUnreadableLegacy.
+
+    // The restore handler stamps accessibility/_migratedFromLegacyV1 on
+    // ANY successful restore (even a backup with no accessibility block)
+    // so a restored profile is authoritative. Pin that this actually
+    // suppresses a later legacy merge — the data-loss scenario the
+    // unconditional stamp exists to prevent.
+    void legacyMigration_restoreStampedGuardSuppressesLaterLegacyMerge() {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        QSettings primary(dir.filePath("primary.ini"), QSettings::IniFormat);
+        // Simulate what handleBackupRestore does on any successful
+        // restore (including a no-accessibility-block backup): only the
+        // guard is stamped, no accessibility values present.
+        primary.setValue("accessibility/_migratedFromLegacyV1", true);
+        primary.sync();
+
+        // This device still has a populated legacy store.
+        QSettings legacy(dir.filePath("legacy.ini"), QSettings::IniFormat);
+        legacy.setValue("accessibility/enabled", true);
+        legacy.setValue("accessibility/tickVolume", 99);
+        legacy.sync();
+
+        auto r = AccessibilityManager::migrateAccessibilityLegacyStore(primary, legacy);
+
+        QVERIFY2(r.alreadyDone, "restored profile is authoritative — migration is a no-op");
+        QCOMPARE(r.copied, 0);
+        QVERIFY2(!primary.contains("accessibility/enabled"),
+                 "stale legacy must NOT bleed over a restored profile");
+        QVERIFY2(!primary.contains("accessibility/tickVolume"),
+                 "stale legacy must NOT bleed over a restored profile");
     }
 };
 

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -635,7 +635,13 @@ private slots:
         });
 
         // Set the configured default rating that migration 16 reads.
-        QSettings appSettings;
+        // Must use the SAME scope production reads — the app's Settings
+        // owns QSettings("DecentEspresso","DE1Qt"). A bare QSettings()
+        // here is exactly the scope-mismatch bug this regression-tests:
+        // it passed before the production fix only because production
+        // also (wrongly) used a bare QSettings.
+        QSettings appSettings(QStringLiteral("DecentEspresso"),
+                              QStringLiteral("DE1Qt"));
         const QVariant prior = appSettings.value("shot/defaultRating");
         const QVariant priorPending = appSettings.value("migration16/pendingVisualizerSync");
         appSettings.setValue("shot/defaultRating", 50);


### PR DESCRIPTION
## Summary

On-device verification of the v1.7.5 build carrying #1155 + #1156 surfaced a **real production bug** that the review agents and unit tests all missed.

The app persists structured settings to `QSettings("DecentEspresso","DE1Qt")` (the `Settings` facade + all 12 `settings_*.cpp` domain classes). But `main.cpp:387` sets `applicationName` to `"Decenza"`, so a **bare `QSettings()`** resolves to `DecentEspresso/Decenza` — the *secondary* store (documented at `settings.cpp:567`), which does not hold the primary keys.

Every settings access added by #1155/#1156 used a bare `QSettings()`. Observed on the build-3383 boot log:

- **Migration 16** read `shot/defaultRating` via bare `QSettings` → empty → `75` fallback (not the user's `0`) → the inferred-rating reset was a silent `75→75` no-op.
- **`processVisualizerReconciliation` / `processPendingVisualizerRatingSync`** read Visualizer credentials via bare `QSettings` → empty → `"skipped (no credentials)"` → the reconciliation never ran.

This is why the migration-16 unit test passed (its harness `QSettings` org/app happened to match the bare default) while production silently failed.

## Fixes

1. **Scope fix:** migration 16, the 6 `MainController` reconciliation/pending-sync sites, and the migration-16 regression test now construct `QSettings("DecentEspresso","DE1Qt")` (matching the existing `main.cpp:259` precedent). The test is now a genuine guard (it failed in the wrong-scope world only because test + production were wrong identically).

2. **Same bug class, found by a full audit (`accessibilitymanager`):** `AccessibilityManager` used `QSettings("Decenza","DE1")` — an isolated *third* store — so accessibility **backup captured defaults** and **restore was a silent no-op** (`shotserver_backup.cpp` read `accessibility/*` off the bare secondary store). `AccessibilityManager` now uses the primary store like every other domain, with a guarded, idempotent one-time `migrateLegacyStore()` that carries existing values over; `shotserver_backup.cpp` reads/writes `accessibility/*` on the primary store and stamps the migration guard on restore so a restored value isn't re-clobbered from the legacy store.

## Audit result

Every other bare-`QSettings` site (AI conversations, `shotMap/*`, `storage/*`, datamigration tokens, web-auth sessions, app-name migration, icon-version) is a **self-consistent secondary-store user by design** — no further occurrences of this bug.

## Deployment note

Makes #1155/#1156 actually work for users not yet on the buggy build 3383. Devices that already ran buggy migration 16 (schema_version=16, column dropped) won't auto-re-reset the formerly-inferred shots — handled separately (manual per-device, post-verification).

## Test plan

- [x] `mcp__qtcreator__build` clean; full suite **2054 passed**.
- [x] Migration-16 regression test now seeds/reads `QSettings("DecentEspresso","DE1Qt")` — fails if production reverts to bare scope.
- [ ] Manual: fresh device on the fixed build → migration 16 resets inferred shots to the *configured* default; reconciliation runs (credentials found) and relinks/corrects orphaned uploads.
- [ ] Manual: backup on the fixed build captures real accessibility settings; restore applies them and `AccessibilityManager` reads them.

🤖 Generated with [Claude Code](https://claude.ai/code)