### PR TITLE
AI: pour control-mode provenance so SAW yield/duration isn't read as dial-in feedback

### DIFF
--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -61,14 +61,13 @@ QJsonObject shotToJson(const ShotProjection& shot,
     h["doseG"] = shot.doseWeightG;
     h["yieldG"] = shot.finalWeightG;
     h["durationSec"] = shot.durationSec;
-    // Issue #1158: control-mode provenance so the LLM doesn't read
-    // yieldG / durationSec as dial-in feedback on stop-at-weight +
-    // flow-controlled shots. Paired with `targetWeightG` (added below
-    // when set) this lets shotAnalysisSystemPrompt()'s stop-at-weight
-    // rule fire.
-    const QString pourControl = DialingBlocks::pourControlFromProfileJson(shot.profileJson);
-    if (!pourControl.isEmpty())
-        h["pourControl"] = pourControl;
+    // Issue #1158: `pourControl` is NOT emitted here. It is a
+    // profile-family property, so buildDialInSessionsBlock hoists it to
+    // the session `context` when every shot in the session shares it
+    // (the common case → zero per-shot repetition) and only falls back
+    // to a per-shot field when a session genuinely mixes flow/pressure
+    // variants. Same dedup discipline as the grinder/bean identity
+    // hoist above.
     h["enjoyment0to100"] = shot.enjoyment0to100 > 0
         ? QJsonValue(shot.enjoyment0to100)
         : QJsonValue(QJsonValue::Null);
@@ -158,9 +157,27 @@ QJsonArray buildDialInSessionsBlock(QSqlDatabase& db,
         const DialingHelpers::HoistedSession hoisted =
             DialingHelpers::hoistSessionContext(identities);
 
+        // Issue #1158: pour control mode per shot, from each shot's own
+        // recipe. Hoist to session context when uniform (the common
+        // case — a session is usually one profile), emit per-shot only
+        // when a session mixes flow/pressure variants of the same kbId
+        // family (e.g. D-Flow/Q vs Damian's LM Leva). "" (no usable
+        // recipe) breaks uniformity so we never assert a value we
+        // didn't derive.
+        QStringList pourControls;
+        pourControls.reserve(ordered.size());
+        for (const ShotProjection& s : ordered)
+            pourControls.append(pourControlFromProfileJson(s.profileJson));
+        const bool pourControlUniform =
+            !pourControls.first().isEmpty()
+            && std::all_of(pourControls.cbegin(), pourControls.cend(),
+                           [&](const QString& p){ return p == pourControls.first(); });
+
         QJsonArray sessionShots;
         for (qsizetype i = 0; i < ordered.size(); ++i) {
             QJsonObject h = shotToJson(ordered[i], hoisted.perShotOverrides[i]);
+            if (!pourControlUniform && !pourControls[i].isEmpty())
+                h["pourControl"] = pourControls[i];
             if (i > 0) {
                 QJsonObject diff = changeFromPrev(ordered[i-1], ordered[i]);
                 h["changeFromPrev"] = diff.isEmpty() ? QJsonValue(QJsonValue::Null) : QJsonValue(diff);
@@ -181,6 +198,10 @@ QJsonArray buildDialInSessionsBlock(QSqlDatabase& db,
             contextObj["beanBrand"] = hoisted.context.beanBrand;
         if (!hoisted.context.beanType.isEmpty())
             contextObj["beanType"] = hoisted.context.beanType;
+        // Issue #1158: hoisted pour control mode — one field for the
+        // whole session instead of repeating it on every shot.
+        if (pourControlUniform)
+            contextObj["pourControl"] = pourControls.first();
 
         QJsonObject sessionObj;
         sessionObj["sessionStart"] = ordered.first().timestampIso;

--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -66,7 +66,7 @@ QJsonObject shotToJson(const ShotProjection& shot,
     // flow-controlled shots. Paired with `targetWeightG` (added below
     // when set) this lets shotAnalysisSystemPrompt()'s stop-at-weight
     // rule fire.
-    const QString pourControl = DialingBlocks::pourControlFromPhases(shot.phases);
+    const QString pourControl = DialingBlocks::pourControlFromProfileJson(shot.profileJson);
     if (!pourControl.isEmpty())
         h["pourControl"] = pourControl;
     h["enjoyment0to100"] = shot.enjoyment0to100 > 0
@@ -243,7 +243,7 @@ QJsonObject buildBestRecentShotBlock(QSqlDatabase& db,
     // dialInSessions entries, so the LLM applies the recipe rule when
     // anchoring on the best shot instead of treating its yield/duration
     // as a dial-in target.
-    const QString bestPourControl = DialingBlocks::pourControlFromPhases(best.phases);
+    const QString bestPourControl = DialingBlocks::pourControlFromProfileJson(best.profileJson);
     if (!bestPourControl.isEmpty())
         b["pourControl"] = bestPourControl;
     if (best.targetWeightG > 0)

--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -61,6 +61,14 @@ QJsonObject shotToJson(const ShotProjection& shot,
     h["doseG"] = shot.doseWeightG;
     h["yieldG"] = shot.finalWeightG;
     h["durationSec"] = shot.durationSec;
+    // Issue #1158: control-mode provenance so the LLM doesn't read
+    // yieldG / durationSec as dial-in feedback on stop-at-weight +
+    // flow-controlled shots. Paired with `targetWeightG` (added below
+    // when set) this lets shotAnalysisSystemPrompt()'s stop-at-weight
+    // rule fire.
+    const QString pourControl = DialingBlocks::pourControlFromPhases(shot.phases);
+    if (!pourControl.isEmpty())
+        h["pourControl"] = pourControl;
     h["enjoyment0to100"] = shot.enjoyment0to100 > 0
         ? QJsonValue(shot.enjoyment0to100)
         : QJsonValue(QJsonValue::Null);
@@ -231,6 +239,15 @@ QJsonObject buildBestRecentShotBlock(QSqlDatabase& db,
     b["doseG"] = best.doseWeightG;
     b["yieldG"] = best.finalWeightG;
     b["durationSec"] = best.durationSec;
+    // Issue #1158: same control-mode + stop-at-weight provenance as the
+    // dialInSessions entries, so the LLM applies the recipe rule when
+    // anchoring on the best shot instead of treating its yield/duration
+    // as a dial-in target.
+    const QString bestPourControl = DialingBlocks::pourControlFromPhases(best.phases);
+    if (!bestPourControl.isEmpty())
+        b["pourControl"] = bestPourControl;
+    if (best.targetWeightG > 0)
+        b["targetWeightG"] = best.targetWeightG;
     b["grinderSetting"] = best.grinderSetting;
     b["grinderModel"] = best.grinderModel;
     b["beanBrand"] = best.beanBrand;

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -103,6 +103,33 @@ inline QString pourControlFromProfileJson(const QString& profileJson)
         ? QStringLiteral("flow") : QStringLiteral("pressure");
 }
 
+// Issue #1158: append the stop-at-weight clarification to a rendered
+// recipe string. The frame durations in the recipe are maximums; under
+// stop-at-weight the shot truncates when the scale hits the target,
+// typically long before those frame times elapse (e.g. a
+// "Pouring (127s)" frame that really runs ~25s). Stating this inline,
+// next to the frames where the misread happens, stops the model
+// reading the frame ceiling as the intended shot length (issue #1147,
+// "the concern is duration — you're pulling in 32–34s").
+//
+// Both recipe-assembly sites call this — `dialing_get_context`'s
+// profile block (mcptools_dialing.cpp) and the in-app advisor's
+// ShotSummarizer::buildCurrentProfileBlock — so the MCP and advisor
+// surfaces cannot drift. No-op when the recipe is empty or no target
+// weight is set; phrased conditionally so it stays correct even if
+// targetWeightG is a volume/timer fallback rather than a real SAW
+// target.
+inline QString withStopAtWeightNote(QString recipe, double targetWeightG)
+{
+    if (recipe.isEmpty() || targetWeightG <= 0) return recipe;
+    recipe += QStringLiteral(
+        "\nStop-at-weight: if a target weight is set (see targetWeightG), "
+        "the shot ends when the scale reaches it — usually well before "
+        "the frame durations above elapse — so the actual shot time and "
+        "final yield follow the weight cutoff, not the frame timers.\n");
+    return recipe;
+}
+
 // Dial-in history grouped into sessions (runs of shots on the same
 // profile within ~60 minutes of each other). Returns `[]`-shaped
 // QJsonArray; the array is empty when the profile has no prior shots.

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -4,11 +4,10 @@
 #include "aiconversation.h"   // HistoricalAssistantTurn — input to buildRecentAdviceBlock
 
 #include <QJsonArray>
+#include <QJsonDocument>
 #include <QJsonObject>
 #include <QList>
 #include <QString>
-#include <QVariantList>
-#include <QVariantMap>
 #include <QtGlobal>
 
 class QSqlDatabase;
@@ -44,15 +43,24 @@ namespace DialingBlocks {
 // parameters don't transfer.
 constexpr qint64 kBestRecentShotWindowDays = 90;
 
-// Issue #1158: derive the pour's control mode from a shot's phase
-// markers (`ShotProjection::phases` — a QVariantList of QVariantMaps
-// each carrying an `isFlowMode` bool). The final phase marker is the
-// pour/ending frame in every shipped Decent profile family, so its
-// `isFlowMode` reports whether the pour tracked a FLOW target (D-Flow /
-// Londinium / lever-hybrid) or a PRESSURE target. Returns "flow" /
-// "pressure", or "" when the shot has no usable phase markers (shots
-// imported from de1app / visualizer.coffee) so the caller keeps the
-// field sparse like the rest of the per-shot envelope.
+// Issue #1158: derive the pour's control mode from the profile recipe.
+// The profile JSON's `steps` array holds the frames; the dominant
+// extraction frame (the one with the largest `seconds`) is the pour,
+// and its `pump` field ("flow" / "pressure") is what the user targets
+// during it. We read this from the recipe — NOT the runtime phase
+// markers — because the markers are recorded frame transitions
+// (merged/truncated at runtime) and do not reliably identify the flow
+// pour: an earlier phase-marker heuristic returned "pressure" for a
+// flow-controlled D-Flow / Q pour (issue #1147 follow-up). profileJson
+// is available on every path that emits a shot — the dialInSessions
+// loader (`loadRecentShotsByKbIdStatic` selects `profile_json`) and the
+// full bestRecentShot load both carry it.
+//
+// Returns "flow" / "pressure", or "" when profileJson is empty,
+// unparseable, has no steps, or the chosen frame has no `pump` (de1app
+// / visualizer imports may lack a usable recipe) so callers keep the
+// field sparse like the rest of the per-shot envelope. Sparse-omit is
+// deliberate: a confidently-wrong value is worse than an absent one.
 //
 // This is the structured signal that lets the LLM apply the
 // stop-at-weight rule in ShotSummarizer::shotAnalysisSystemPrompt(): a
@@ -64,15 +72,35 @@ constexpr qint64 kBestRecentShotWindowDays = 90;
 // Defined inline (same rationale as buildCurrentBeanBlock) so test
 // binaries can exercise the derivation without linking the DB-dependent
 // block builders.
-inline QString pourControlFromPhases(const QVariantList& phases)
+inline QString pourControlFromProfileJson(const QString& profileJson)
 {
-    for (auto it = phases.crbegin(); it != phases.crend(); ++it) {
-        const QVariantMap m = it->toMap();
-        if (!m.contains(QStringLiteral("isFlowMode"))) continue;
-        return m.value(QStringLiteral("isFlowMode")).toBool()
-            ? QStringLiteral("flow") : QStringLiteral("pressure");
+    if (profileJson.isEmpty()) return QString();
+    QJsonParseError err{};
+    const QJsonObject obj =
+        QJsonDocument::fromJson(profileJson.toUtf8(), &err).object();
+    if (err.error != QJsonParseError::NoError) return QString();
+    const QJsonArray steps = obj.value(QStringLiteral("steps")).toArray();
+    if (steps.isEmpty()) return QString();
+
+    // Pick the longest frame — the dominant extraction (pour) frame —
+    // rather than the last frame, so a short trailing decline/ending
+    // frame can't flip the classification.
+    QString pump;
+    double maxSeconds = -1.0;
+    for (const QJsonValue& sv : steps) {
+        const QJsonObject step = sv.toObject();
+        const QJsonValue secVal = step.value(QStringLiteral("seconds"));
+        const double sec = secVal.isString()
+            ? secVal.toString().toDouble()
+            : secVal.toDouble();
+        if (sec > maxSeconds) {
+            maxSeconds = sec;
+            pump = step.value(QStringLiteral("pump")).toString();
+        }
     }
-    return QString();
+    if (pump.isEmpty()) return QString();
+    return pump == QStringLiteral("flow")
+        ? QStringLiteral("flow") : QStringLiteral("pressure");
 }
 
 // Dial-in history grouped into sessions (runs of shots on the same

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -7,6 +7,8 @@
 #include <QJsonObject>
 #include <QList>
 #include <QString>
+#include <QVariantList>
+#include <QVariantMap>
 #include <QtGlobal>
 
 class QSqlDatabase;
@@ -41,6 +43,37 @@ namespace DialingBlocks {
 // from years ago runs on different beans, possibly worn burrs, and the
 // parameters don't transfer.
 constexpr qint64 kBestRecentShotWindowDays = 90;
+
+// Issue #1158: derive the pour's control mode from a shot's phase
+// markers (`ShotProjection::phases` — a QVariantList of QVariantMaps
+// each carrying an `isFlowMode` bool). The final phase marker is the
+// pour/ending frame in every shipped Decent profile family, so its
+// `isFlowMode` reports whether the pour tracked a FLOW target (D-Flow /
+// Londinium / lever-hybrid) or a PRESSURE target. Returns "flow" /
+// "pressure", or "" when the shot has no usable phase markers (shots
+// imported from de1app / visualizer.coffee) so the caller keeps the
+// field sparse like the rest of the per-shot envelope.
+//
+// This is the structured signal that lets the LLM apply the
+// stop-at-weight rule in ShotSummarizer::shotAnalysisSystemPrompt(): a
+// flow-controlled pour that stops at a weight target pins yield and
+// makes duration ≈ stopWeight ÷ flowTarget, so neither is grind
+// feedback. Without it the model only sees yieldG / durationSec on
+// historical shots and reads them as dial-in outcomes (issue #1147).
+//
+// Defined inline (same rationale as buildCurrentBeanBlock) so test
+// binaries can exercise the derivation without linking the DB-dependent
+// block builders.
+inline QString pourControlFromPhases(const QVariantList& phases)
+{
+    for (auto it = phases.crbegin(); it != phases.crend(); ++it) {
+        const QVariantMap m = it->toMap();
+        if (!m.contains(QStringLiteral("isFlowMode"))) continue;
+        return m.value(QStringLiteral("isFlowMode")).toBool()
+            ? QStringLiteral("flow") : QStringLiteral("pressure");
+    }
+    return QString();
+}
 
 // Dial-in history grouped into sessions (runs of shots on the same
 // profile within ~60 minutes of each other). Returns `[]`-shaped

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -112,13 +112,21 @@ inline QString pourControlFromProfileJson(const QString& profileJson)
 // reading the frame ceiling as the intended shot length (issue #1147,
 // "the concern is duration — you're pulling in 32–34s").
 //
-// Both recipe-assembly sites call this — `dialing_get_context`'s
-// profile block (mcptools_dialing.cpp) and the in-app advisor's
-// ShotSummarizer::buildCurrentProfileBlock — so the MCP and advisor
-// surfaces cannot drift. No-op when the recipe is empty or no target
-// weight is set; phrased conditionally so it stays correct even if
-// targetWeightG is a volume/timer fallback rather than a real SAW
-// target.
+// Both *structured profile-block* recipe-assembly sites call this —
+// `dialing_get_context`'s profile block (mcptools_dialing.cpp) and the
+// in-app advisor's ShotSummarizer::buildCurrentProfileBlock — so those
+// two surfaces cannot drift. NOTE: this does not cover every place a
+// recipe is rendered: the prose multi-shot *history* blocks
+// (AIManager / ShotSummarizer history context) call
+// `Profile::describeFramesFromJson` directly without this note. That is
+// intentional — those blocks explicitly tell the model not to comment
+// on frame-level recipe detail, so the stop-at-weight clarification is
+// only needed where the recipe is presented as the current shot's spec.
+// No-op when the recipe is empty or no target weight is set; phrased
+// conditionally so it stays correct even if targetWeightG is a
+// volume/timer fallback rather than a real SAW target. Callers must
+// pass the target weight from the SAME source as the recipe string
+// (the analyzed shot), or the two structured surfaces will diverge.
 inline QString withStopAtWeightNote(QString recipe, double targetWeightG)
 {
     if (recipe.isEmpty() || targetWeightG <= 0) return recipe;

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -1768,6 +1768,8 @@ The profile recipe is included with each shot. Use it to set expectations BEFORE
 
 **Pressure → Flow transition**: When a profile switches from pressure-controlled fill/infuse to flow-controlled pour, pressure becomes passive after the switch. A declining pressure curve is the expected signature of this pattern, not a problem. This is the lever/flow hybrid pattern used by D-Flow, Londinium, and similar profiles.
 
+**Stop-at-weight + flow-controlled pour → yield and duration are mechanical, not dial-in feedback**: When the pour is FLOW-controlled and the profile stops at a weight target (the recipe's pour frame is flow-controlled and a `targetWeightG` is set; historical and best-shot entries also carry an explicit `pourControl: "flow"`), the final yield is pinned by the scale cutoff and the total time is approximately stopWeight ÷ flowTarget — both are set by the recipe, not the grind. Do NOT credit a grind change for "yield landed on target", and do NOT treat a shorter or longer duration as a dial-in or quality signal for these shots. Grind only moves yield/time here in the extremes: a puck so fine it chokes and never reaches the flow target, or so coarse it gushes with almost no resistance. Judge these shots by the pressure the puck developed at the target flow, taste, TDS/EY, and channeling instead.
+
 **Exit conditions**: Frames with exit conditions (e.g., "exit:p>3.0") advance when the condition is met. Short phase durations (1-2s) after exit conditions are normal — the machine transitions quickly.
 
 ## How to Read the Data

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -536,7 +536,27 @@ static QJsonObject buildCurrentProfileBlock(const ShotSummary& summary)
     QJsonObject profile;
     profile["title"] = summary.profileTitle;
     if (!summary.profileNotes.isEmpty()) profile["intent"] = summary.profileNotes;
-    if (!summary.profileRecipe.isEmpty()) profile["recipe"] = summary.profileRecipe;
+    if (!summary.profileRecipe.isEmpty()) {
+        QString recipe = summary.profileRecipe;
+        // Issue #1158: the frame durations rendered above are maximums.
+        // Under stop-at-weight the shot is truncated when the scale
+        // hits the target — typically long before those frame times
+        // elapse (e.g. a "Pouring (127s)" frame that really runs ~25s).
+        // State that explicitly here so the model doesn't read the
+        // frame ceiling as the intended shot length, and pair it with
+        // the stop-at-weight rule in shotAnalysisSystemPrompt(). Gated
+        // on a target being set; phrased conditionally so it stays
+        // correct even if the target is a volume/timer fallback.
+        if (summary.targetWeight > 0) {
+            recipe += QStringLiteral(
+                "\nStop-at-weight: if a target weight is set (see "
+                "targetWeightG), the shot ends when the scale reaches it "
+                "— usually well before the frame durations above "
+                "elapse — so the actual shot time and final yield "
+                "follow the weight cutoff, not the frame timers.\n");
+        }
+        profile["recipe"] = recipe;
+    }
     if (summary.targetWeight > 0) profile["targetWeightG"] = summary.targetWeight;
     if (summary.targetTemperatureC > 0) profile["targetTemperatureC"] = summary.targetTemperatureC;
     if (summary.recommendedDoseG > 0) profile["recommendedDoseG"] = summary.recommendedDoseG;
@@ -1768,7 +1788,7 @@ The profile recipe is included with each shot. Use it to set expectations BEFORE
 
 **Pressure → Flow transition**: When a profile switches from pressure-controlled fill/infuse to flow-controlled pour, pressure becomes passive after the switch. A declining pressure curve is the expected signature of this pattern, not a problem. This is the lever/flow hybrid pattern used by D-Flow, Londinium, and similar profiles.
 
-**Stop-at-weight + flow-controlled pour → yield and duration are mechanical, not dial-in feedback**: When the pour is FLOW-controlled and the profile stops at a weight target (the recipe's pour frame is flow-controlled and a `targetWeightG` is set; historical and best-shot entries also carry an explicit `pourControl: "flow"`), the final yield is pinned by the scale cutoff and the total time is approximately stopWeight ÷ flowTarget — both are set by the recipe, not the grind. Do NOT credit a grind change for "yield landed on target", and do NOT treat a shorter or longer duration as a dial-in or quality signal for these shots. Grind only moves yield/time here in the extremes: a puck so fine it chokes and never reaches the flow target, or so coarse it gushes with almost no resistance. Judge these shots by the pressure the puck developed at the target flow, taste, TDS/EY, and channeling instead.
+**Stop-at-weight + flow-controlled pour → yield and duration are mechanical, not dial-in feedback**: When the pour is FLOW-controlled and the profile stops at a weight target (the recipe's pour frame is flow-controlled and a `targetWeightG` is set; for dial-in history this is the explicit `pourControl: "flow"` on the session `context`, or on the individual shot when a session mixes variants, and on `bestRecentShot`), the final yield is pinned by the scale cutoff and the total time is approximately stopWeight ÷ flowTarget — both are set by the recipe, not the grind. Do NOT credit a grind change for "yield landed on target", and do NOT treat a shorter or longer duration as a dial-in or quality signal for these shots. Grind only moves yield/time here in the extremes: a puck so fine it chokes and never reaches the flow target, or so coarse it gushes with almost no resistance. Judge these shots by the pressure the puck developed at the target flow, taste, TDS/EY, and channeling instead.
 
 **Exit conditions**: Frames with exit conditions (e.g., "exit:p>3.0") advance when the condition is met. Short phase durations (1-2s) after exit conditions are normal — the machine transitions quickly.
 

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -536,27 +536,12 @@ static QJsonObject buildCurrentProfileBlock(const ShotSummary& summary)
     QJsonObject profile;
     profile["title"] = summary.profileTitle;
     if (!summary.profileNotes.isEmpty()) profile["intent"] = summary.profileNotes;
-    if (!summary.profileRecipe.isEmpty()) {
-        QString recipe = summary.profileRecipe;
-        // Issue #1158: the frame durations rendered above are maximums.
-        // Under stop-at-weight the shot is truncated when the scale
-        // hits the target — typically long before those frame times
-        // elapse (e.g. a "Pouring (127s)" frame that really runs ~25s).
-        // State that explicitly here so the model doesn't read the
-        // frame ceiling as the intended shot length, and pair it with
-        // the stop-at-weight rule in shotAnalysisSystemPrompt(). Gated
-        // on a target being set; phrased conditionally so it stays
-        // correct even if the target is a volume/timer fallback.
-        if (summary.targetWeight > 0) {
-            recipe += QStringLiteral(
-                "\nStop-at-weight: if a target weight is set (see "
-                "targetWeightG), the shot ends when the scale reaches it "
-                "— usually well before the frame durations above "
-                "elapse — so the actual shot time and final yield "
-                "follow the weight cutoff, not the frame timers.\n");
-        }
-        profile["recipe"] = recipe;
-    }
+    // Issue #1158: append the stop-at-weight clarification via the
+    // shared helper so this (advisor) path and dialing_get_context's
+    // MCP profile block render the recipe identically.
+    if (!summary.profileRecipe.isEmpty())
+        profile["recipe"] = DialingBlocks::withStopAtWeightNote(
+            summary.profileRecipe, summary.targetWeight);
     if (summary.targetWeight > 0) profile["targetWeightG"] = summary.targetWeight;
     if (summary.targetTemperatureC > 0) profile["targetTemperatureC"] = summary.targetTemperatureC;
     if (summary.recommendedDoseG > 0) profile["recommendedDoseG"] = summary.recommendedDoseG;

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -320,10 +320,22 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         if (!sd.profileJson.isEmpty()) {
                             // Issue #1158: shared helper appends the
                             // stop-at-weight note so this MCP recipe
-                            // matches the in-app advisor's exactly.
+                            // matches the in-app advisor's exactly. Gate
+                            // it on the SHOT's stored target weight
+                            // (`sd.targetWeightG`) — the same source the
+                            // recipe text comes from (`sd.profileJson`)
+                            // and the same source the advisor uses
+                            // (`summary.targetWeight`). Using the
+                            // current profile's target here instead
+                            // would re-introduce MCP/advisor drift for
+                            // historical shots whose profile differs
+                            // from the loaded one. The emitted
+                            // `targetWeightG` field below stays
+                            // current-profile per the documented
+                            // shot-vs-targets asymmetry.
                             const QString recipe = DialingBlocks::withStopAtWeightNote(
                                 Profile::describeFramesFromJson(sd.profileJson),
-                                profileManager->profileTargetWeight());
+                                sd.targetWeightG);
                             if (!recipe.isEmpty())
                                 profileInfo["recipe"] = recipe;
                         }

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -318,7 +318,12 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         if (!sd.profileNotes.isEmpty())
                             profileInfo["intent"] = sd.profileNotes;
                         if (!sd.profileJson.isEmpty()) {
-                            const QString recipe = Profile::describeFramesFromJson(sd.profileJson);
+                            // Issue #1158: shared helper appends the
+                            // stop-at-weight note so this MCP recipe
+                            // matches the in-app advisor's exactly.
+                            const QString recipe = DialingBlocks::withStopAtWeightNote(
+                                Profile::describeFramesFromJson(sd.profileJson),
+                                profileManager->profileTargetWeight());
                             if (!recipe.isEmpty())
                                 profileInfo["recipe"] = recipe;
                         }

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -1328,6 +1328,47 @@ private slots:
             QCOMPARE(a, b);
         });
     }
+
+    // -------------------------------------------------------------------
+    // pourControlFromPhases (issue #1158) — pure derivation, no DB.
+    // The final phase marker is the pour frame; its isFlowMode decides
+    // the reported control mode. No markers → "" so the field stays
+    // sparse. A trailing marker missing isFlowMode is skipped so the
+    // pour frame still wins.
+    // -------------------------------------------------------------------
+    void pourControlFromPhases_derivesFromLastUsablePhase()
+    {
+        auto phase = [](const QString& label, QVariant isFlowMode) {
+            QVariantMap m;
+            m["label"] = label;
+            if (isFlowMode.isValid()) m["isFlowMode"] = isFlowMode;
+            return QVariant(m);
+        };
+
+        // No phase markers (de1app / visualizer import) → omitted.
+        QCOMPARE(DialingBlocks::pourControlFromPhases({}), QString());
+
+        // Flow-controlled pour (D-Flow family): last phase isFlowMode=true.
+        const QVariantList dflow = {
+            phase("Filling", false), phase("Infusing", false),
+            phase("Pouring", true)
+        };
+        QCOMPARE(DialingBlocks::pourControlFromPhases(dflow), QStringLiteral("flow"));
+
+        // Pressure-controlled pour (classic 9-bar): last phase false.
+        const QVariantList ninebar = {
+            phase("Preinfusion", false), phase("Pour", false)
+        };
+        QCOMPARE(DialingBlocks::pourControlFromPhases(ninebar), QStringLiteral("pressure"));
+
+        // Trailing marker without isFlowMode is skipped; the real pour
+        // frame (flow) still determines the result.
+        const QVariantList trailingUnknown = {
+            phase("Fill", false), phase("Pour", true), phase("Ending", QVariant())
+        };
+        QCOMPARE(DialingBlocks::pourControlFromPhases(trailingUnknown),
+                 QStringLiteral("flow"));
+    }
 };
 
 QTEST_GUILESS_MAIN(TstDialingBlocks)

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -1330,43 +1330,54 @@ private slots:
     }
 
     // -------------------------------------------------------------------
-    // pourControlFromPhases (issue #1158) — pure derivation, no DB.
-    // The final phase marker is the pour frame; its isFlowMode decides
-    // the reported control mode. No markers → "" so the field stays
-    // sparse. A trailing marker missing isFlowMode is skipped so the
-    // pour frame still wins.
+    // pourControlFromProfileJson (issue #1158) — pure derivation, no DB.
+    // Reads the profile recipe (`steps`), picks the longest frame (the
+    // pour), and reports its `pump`. Empty / malformed / step-less JSON
+    // → "" so the field stays sparse (a confidently-wrong value is
+    // worse than an absent one — that was the v1 phase-marker bug). A
+    // short trailing decline frame must not flip the classification.
     // -------------------------------------------------------------------
-    void pourControlFromPhases_derivesFromLastUsablePhase()
+    void pourControlFromProfileJson_derivesFromLongestFrame()
     {
-        auto phase = [](const QString& label, QVariant isFlowMode) {
-            QVariantMap m;
-            m["label"] = label;
-            if (isFlowMode.isValid()) m["isFlowMode"] = isFlowMode;
-            return QVariant(m);
-        };
+        // Empty / malformed / no steps → omitted.
+        QCOMPARE(DialingBlocks::pourControlFromProfileJson(QString()), QString());
+        QCOMPARE(DialingBlocks::pourControlFromProfileJson(QStringLiteral("{not json")), QString());
+        QCOMPARE(DialingBlocks::pourControlFromProfileJson(QStringLiteral("{\"steps\":[]}")), QString());
 
-        // No phase markers (de1app / visualizer import) → omitted.
-        QCOMPARE(DialingBlocks::pourControlFromPhases({}), QString());
+        // D-Flow / Q shape: Filling(25s,P) Infusing(1s,P) Pouring(127s,FLOW)
+        // — the long pour is flow-controlled. This is the exact #1147
+        // shot whose v1 phase-marker derivation wrongly said "pressure".
+        const QString dflowQ = QStringLiteral(
+            "{\"steps\":["
+            "{\"name\":\"Filling\",\"pump\":\"pressure\",\"seconds\":25},"
+            "{\"name\":\"Infusing\",\"pump\":\"pressure\",\"seconds\":1},"
+            "{\"name\":\"Pouring\",\"pump\":\"flow\",\"seconds\":127}]}");
+        QCOMPARE(DialingBlocks::pourControlFromProfileJson(dflowQ), QStringLiteral("flow"));
 
-        // Flow-controlled pour (D-Flow family): last phase isFlowMode=true.
-        const QVariantList dflow = {
-            phase("Filling", false), phase("Infusing", false),
-            phase("Pouring", true)
-        };
-        QCOMPARE(DialingBlocks::pourControlFromPhases(dflow), QStringLiteral("flow"));
+        // Classic pressure pour: preinfusion(flow,short) then long
+        // pressure pour.
+        const QString ninebar = QStringLiteral(
+            "{\"steps\":["
+            "{\"name\":\"Preinfusion\",\"pump\":\"flow\",\"seconds\":10},"
+            "{\"name\":\"Pour\",\"pump\":\"pressure\",\"seconds\":40}]}");
+        QCOMPARE(DialingBlocks::pourControlFromProfileJson(ninebar), QStringLiteral("pressure"));
 
-        // Pressure-controlled pour (classic 9-bar): last phase false.
-        const QVariantList ninebar = {
-            phase("Preinfusion", false), phase("Pour", false)
-        };
-        QCOMPARE(DialingBlocks::pourControlFromPhases(ninebar), QStringLiteral("pressure"));
+        // A short trailing pressure "decline" frame must NOT flip a
+        // long flow pour to "pressure".
+        const QString flowWithTail = QStringLiteral(
+            "{\"steps\":["
+            "{\"name\":\"Fill\",\"pump\":\"pressure\",\"seconds\":20},"
+            "{\"name\":\"Pour\",\"pump\":\"flow\",\"seconds\":110},"
+            "{\"name\":\"Decline\",\"pump\":\"pressure\",\"seconds\":3}]}");
+        QCOMPARE(DialingBlocks::pourControlFromProfileJson(flowWithTail),
+                 QStringLiteral("flow"));
 
-        // Trailing marker without isFlowMode is skipped; the real pour
-        // frame (flow) still determines the result.
-        const QVariantList trailingUnknown = {
-            phase("Fill", false), phase("Pour", true), phase("Ending", QVariant())
-        };
-        QCOMPARE(DialingBlocks::pourControlFromPhases(trailingUnknown),
+        // `seconds` as a string (de1app Tcl-origin JSON) still parses.
+        const QString stringSeconds = QStringLiteral(
+            "{\"steps\":["
+            "{\"name\":\"Fill\",\"pump\":\"pressure\",\"seconds\":\"25\"},"
+            "{\"name\":\"Pour\",\"pump\":\"flow\",\"seconds\":\"127\"}]}");
+        QCOMPARE(DialingBlocks::pourControlFromProfileJson(stringSeconds),
                  QStringLiteral("flow"));
     }
 };

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -54,6 +54,11 @@ struct ShotRow {
     QString grinderSetting;
     int enjoyment = 0;
     QString espressoNotes;
+    // Issue #1158: profile recipe snapshot + SAW target. Empty/0 by
+    // default so existing fixtures are unaffected (pourControl /
+    // targetWeightG simply stay absent, exactly as before this PR).
+    QString profileJson;
+    double targetWeight = 0.0;  // → shots.yield_override
 };
 
 // Run work with a scoped raw SQLite connection on `path`. Same pattern
@@ -81,13 +86,15 @@ qint64 insertShot(QSqlDatabase& db, const ShotRow& r)
             duration_seconds, final_weight, dose_weight,
             bean_brand, bean_type, roast_level,
             grinder_brand, grinder_model, grinder_burrs, grinder_setting,
-            enjoyment, espresso_notes, profile_kb_id
+            enjoyment, espresso_notes, profile_kb_id,
+            profile_json, yield_override
         ) VALUES (
             :uuid, :timestamp, :profile_name, :beverage_type,
             :duration, :final_weight, :dose_weight,
             :bean_brand, :bean_type, :roast_level,
             :grinder_brand, :grinder_model, :grinder_burrs, :grinder_setting,
-            :enjoyment, :espresso_notes, :profile_kb_id
+            :enjoyment, :espresso_notes, :profile_kb_id,
+            :profile_json, :yield_override
         )
     )"));
     q.bindValue(":uuid", r.uuid);
@@ -107,6 +114,8 @@ qint64 insertShot(QSqlDatabase& db, const ShotRow& r)
     q.bindValue(":enjoyment", r.enjoyment);
     q.bindValue(":espresso_notes", r.espressoNotes);
     q.bindValue(":profile_kb_id", r.profileKbId.isEmpty() ? QVariant() : r.profileKbId);
+    q.bindValue(":profile_json", r.profileJson);
+    q.bindValue(":yield_override", r.targetWeight);
     if (!q.exec ()) {
         qWarning() << "insertShot failed:" << q.lastError().text();
         return -1;
@@ -1379,6 +1388,162 @@ private slots:
             "{\"name\":\"Pour\",\"pump\":\"flow\",\"seconds\":\"127\"}]}");
         QCOMPARE(DialingBlocks::pourControlFromProfileJson(stringSeconds),
                  QStringLiteral("flow"));
+    }
+
+    // -------------------------------------------------------------------
+    // withStopAtWeightNote (issue #1158) — pure, no DB. No-op on empty
+    // recipe or non-positive target; appends exactly one note otherwise,
+    // preserving the original recipe prefix.
+    // -------------------------------------------------------------------
+    void withStopAtWeightNote_appendsNoteOnlyWhenWeightAndRecipePresent()
+    {
+        // Empty recipe → unchanged regardless of weight.
+        QCOMPARE(DialingBlocks::withStopAtWeightNote(QString(), 36.0), QString());
+
+        const QString recipe =
+            QStringLiteral("## Profile Recipe (1 frames)\n1. Pouring FLOW\n");
+        // Non-positive target → recipe untouched (no note).
+        QCOMPARE(DialingBlocks::withStopAtWeightNote(recipe, 0.0), recipe);
+        QCOMPARE(DialingBlocks::withStopAtWeightNote(recipe, -1.0), recipe);
+
+        // Recipe + positive target → exactly one note appended after the
+        // original recipe text.
+        const QString out = DialingBlocks::withStopAtWeightNote(recipe, 36.0);
+        QVERIFY(out.startsWith(recipe));
+        QVERIFY(out.contains(QStringLiteral("Stop-at-weight:")));
+        QVERIFY(out.contains(QStringLiteral("weight cutoff")));
+        QCOMPARE(out.count(QStringLiteral("Stop-at-weight:")), 1);
+    }
+
+    // -------------------------------------------------------------------
+    // dialInSessions pourControl (issue #1158) — DB-level. A uniform
+    // session hoists pourControl to context with no per-shot field; a
+    // session that mixes flow/pressure variants emits it per-shot and
+    // omits the context value. (Previously only the pure derivation was
+    // covered; the hoist/per-shot wiring was dark.)
+    // -------------------------------------------------------------------
+    void dialInSessions_hoistsPourControlWhenUniform_elsePerShot()
+    {
+        const QString kFlow = QStringLiteral(
+            "{\"steps\":[{\"name\":\"Filling\",\"pump\":\"pressure\",\"seconds\":25},"
+            "{\"name\":\"Pouring\",\"pump\":\"flow\",\"seconds\":127}]}");
+        const QString kPressure = QStringLiteral(
+            "{\"steps\":[{\"name\":\"Preinfusion\",\"pump\":\"flow\",\"seconds\":10},"
+            "{\"name\":\"Pour\",\"pump\":\"pressure\",\"seconds\":40}]}");
+        const qint64 now = QDateTime::currentSecsSinceEpoch();
+
+        // Uniform-flow session → hoisted.
+        const QString pathU = freshDbPath();
+        initAndClose(pathU);
+        withRawDb(pathU, QStringLiteral("pc_uniform"), [&](QSqlDatabase& db) {
+            ShotRow a1;
+            a1.uuid = QStringLiteral("pc-a1");
+            a1.profileName = QStringLiteral("D-Flow / Q");
+            a1.profileKbId = QStringLiteral("kb-dfq");
+            a1.timestamp = now - 4000;
+            a1.grinderModel = QStringLiteral("Zero");
+            a1.grinderSetting = QStringLiteral("5");
+            a1.profileJson = kFlow;
+            QVERIFY(insertShot(db, a1) > 0);
+            ShotRow a2 = a1;
+            a2.uuid = QStringLiteral("pc-a2");
+            a2.timestamp = now - 3700;
+            QVERIFY(insertShot(db, a2) > 0);
+
+            const QJsonArray sessions = DialingBlocks::buildDialInSessionsBlock(
+                db, QStringLiteral("kb-dfq"), /*resolvedShotId=*/-1, /*historyLimit=*/10);
+            QCOMPARE(sessions.size(), 1);
+            const QJsonObject session = sessions.at(0).toObject();
+            QCOMPARE(session.value(QStringLiteral("context")).toObject()
+                         .value(QStringLiteral("pourControl")).toString(),
+                     QStringLiteral("flow"));
+            const QJsonArray shots = session.value(QStringLiteral("shots")).toArray();
+            QCOMPARE(shots.size(), 2);
+            for (const auto& s : shots)
+                QVERIFY(!s.toObject().contains(QStringLiteral("pourControl")));
+        });
+
+        // Mixed flow/pressure session → per-shot, not hoisted.
+        const QString pathM = freshDbPath();
+        initAndClose(pathM);
+        withRawDb(pathM, QStringLiteral("pc_mixed"), [&](QSqlDatabase& db) {
+            ShotRow m1;
+            m1.uuid = QStringLiteral("pc-m1");
+            m1.profileName = QStringLiteral("D-Flow / Q");
+            m1.profileKbId = QStringLiteral("kb-dfq");
+            m1.timestamp = now - 4000;
+            m1.grinderModel = QStringLiteral("Zero");
+            m1.grinderSetting = QStringLiteral("5");
+            m1.profileJson = kFlow;
+            QVERIFY(insertShot(db, m1) > 0);
+            ShotRow m2 = m1;
+            m2.uuid = QStringLiteral("pc-m2");
+            m2.timestamp = now - 3700;
+            m2.profileJson = kPressure;
+            QVERIFY(insertShot(db, m2) > 0);
+
+            const QJsonArray sessions = DialingBlocks::buildDialInSessionsBlock(
+                db, QStringLiteral("kb-dfq"), -1, 10);
+            QCOMPARE(sessions.size(), 1);
+            const QJsonObject session = sessions.at(0).toObject();
+            QVERIFY(!session.value(QStringLiteral("context")).toObject()
+                         .contains(QStringLiteral("pourControl")));
+            const QJsonArray shots = session.value(QStringLiteral("shots")).toArray();
+            QCOMPARE(shots.size(), 2);
+            bool sawFlow = false, sawPressure = false;
+            for (const auto& s : shots) {
+                const QString pc = s.toObject()
+                                       .value(QStringLiteral("pourControl")).toString();
+                if (pc == QStringLiteral("flow")) sawFlow = true;
+                if (pc == QStringLiteral("pressure")) sawPressure = true;
+            }
+            QVERIFY(sawFlow);
+            QVERIFY(sawPressure);
+        });
+    }
+
+    // -------------------------------------------------------------------
+    // bestRecentShot pourControl + targetWeightG (issue #1158) — DB-level.
+    // -------------------------------------------------------------------
+    void bestRecentShot_emitsPourControlAndTargetWeightFromRecipe()
+    {
+        const QString kFlow = QStringLiteral(
+            "{\"steps\":[{\"name\":\"Filling\",\"pump\":\"pressure\",\"seconds\":25},"
+            "{\"name\":\"Pouring\",\"pump\":\"flow\",\"seconds\":127}]}");
+        const qint64 now = QDateTime::currentSecsSinceEpoch();
+        const QString path = freshDbPath();
+        initAndClose(path);
+        withRawDb(path, QStringLiteral("pc_best"), [&](QSqlDatabase& db) {
+            ShotRow best;
+            best.uuid = QStringLiteral("pc-best");
+            best.profileName = QStringLiteral("D-Flow / Q");
+            best.profileKbId = QStringLiteral("kb-dfq");
+            best.timestamp = now - 7 * kSecPerDay;
+            best.grinderModel = QStringLiteral("Zero");
+            best.grinderSetting = QStringLiteral("5");
+            best.enjoyment = 85;
+            best.profileJson = kFlow;
+            best.targetWeight = 36.0;
+            const qint64 bestId = insertShot(db, best);
+            QVERIFY(bestId > 0);
+
+            ShotRow current = best;
+            current.uuid = QStringLiteral("pc-cur");
+            current.timestamp = now - kSecPerDay;
+            current.enjoyment = 0;
+            const qint64 currentId = insertShot(db, current);
+            QVERIFY(currentId > 0);
+            const ShotProjection currentProj = projectionForShot(db, currentId);
+            QVERIFY(currentProj.isValid());
+
+            const QJsonObject best_ = DialingBlocks::buildBestRecentShotBlock(
+                db, QStringLiteral("kb-dfq"), currentId, currentProj);
+            QVERIFY(!best_.isEmpty());
+            QCOMPARE(best_.value(QStringLiteral("id")).toVariant().toLongLong(), bestId);
+            QCOMPARE(best_.value(QStringLiteral("pourControl")).toString(),
+                     QStringLiteral("flow"));
+            QCOMPARE(best_.value(QStringLiteral("targetWeightG")).toDouble(), 36.0);
+        });
     }
 };
 


### PR DESCRIPTION
Addresses #1158 (broken out from #1147). Plain reference, not a closing keyword — the reporter hasn't confirmed the fix yet.

## Problem

External Claude (via the Decenza MCP `dialing_get_context`) and the in-app advisor were asserting physically-wrong causation on stop-at-weight + flow-controlled profiles:

- *"you stepped finer to 22.5 and the next two both landed right on target … Good instinct."* — yield is pinned by the scale cutoff, not the grind.
- *"The concern is duration — you're pulling in 32–34s…"* — for a flow-controlled pour that stops at weight, duration ≈ stopWeight ÷ flowTarget, not a grind/quality signal.

Root cause: the `dialInSessions` / `bestRecentShot` blocks shipped only `yieldG` / `durationSec` for historical shots with **no control-mode provenance**, and the rendered recipe showed only frame *maximum* durations (e.g. "Pouring (127s)") with no indication the shot truncates at the weight target — so the model pattern-matched yield/duration as dial-in outcomes.

## Change

- `DialingBlocks::pourControlFromProfileJson(const QString& profileJson)` — inline, test-linkable (same rationale as `buildCurrentBeanBlock`). Parses the profile recipe's `steps[]` and returns the **longest-duration frame's `pump`** (`"flow"` / `"pressure"`); returns `""` when the recipe is empty / unparseable / step-less so the field stays sparse. (An earlier draft derived this from runtime phase markers; live MCP verification showed that misclassified a flow D-Flow/Q pour as `"pressure"`, so it was replaced with this recipe-based derivation — see commit history.)
- Emit `pourControl` on dial-in history: **hoisted to the session `context`** when every shot in a session shares it (the common case → zero per-shot repetition), emitted per-shot only when a session mixes flow/pressure variants. Also emit `pourControl` + `targetWeightG` on `bestRecentShot`.
- `DialingBlocks::withStopAtWeightNote(recipe, targetWeightG)` — shared inline helper that appends a one-line stop-at-weight clarification to the rendered recipe (frame durations are maximums; the shot truncates at the weight target). Called by **both** structured profile-block recipe-assembly sites — `dialing_get_context` (`mcptools_dialing.cpp`) and the in-app advisor (`ShotSummarizer::buildCurrentProfileBlock`) — gated on the analyzed shot's own target weight on both paths so they cannot drift.
- New rule in the shared `shotAnalysisSystemPrompt()` ("Reading the Recipe for Expected Behavior"): for a flow-controlled pour that stops at a weight target, yield landing on target is mechanical (don't credit grind) and duration ≈ stopWeight ÷ flowTarget (not a dial-in/quality signal); judge by pressure-at-flow, taste, TDS/EY, channeling.

Ships to **both** the MCP and the in-app advisor via the shared block builders + shared system prompt.

## Scope

- **No schema change** — all signals already in the data path.
- Manual-stop detection (the Rao Allongé 71g/89g case) is intentionally **out of scope** — that needs `ShotTimingController` plumbing and is tracked in #1161.

## Test plan

- [x] Worktree build green via Qt Creator (0 errors, 0 warnings)
- [x] `pourControlFromProfileJson_derivesFromLongestFrame` — empty/malformed/no-steps → omitted; D-Flow/Q flow recipe → `flow`; pressure recipe → `pressure`; short trailing decline frame does not flip; string-valued `seconds`.
- [x] `withStopAtWeightNote_appendsNoteOnlyWhenWeightAndRecipePresent` — no-op on empty recipe / non-positive target; exactly one note appended otherwise.
- [x] DB-level: `dialInSessions_hoistsPourControlWhenUniform_elsePerShot` (uniform → hoisted to context, absent per-shot; mixed → per-shot, not hoisted) and `bestRecentShot_emitsPourControlAndTargetWeightFromRecipe`.
- [x] End-to-end verified live on the running MCP against real D-Flow/Q shots (correct `pourControl`, hoisting, and recipe stop-at-weight note in `dialing_get_context`).
- [ ] Reporter (@fredphoesh) to sanity-check advice quality on a D-Flow conversation via MCP

## Review follow-ups (addressed)

Applied from the automated code review on this PR:
- MCP path now gates the stop-at-weight note on the **shot's** stored target (`sd.targetWeightG`), matching the advisor — previously used the currently-loaded profile's target, which could drift for historical shots.
- Narrowed the `withStopAtWeightNote` "cannot drift" comment to the two structured profile-block surfaces (prose multi-shot history blocks intentionally render recipes without the note).
- Added the missing DB-level integration tests and the `withStopAtWeightNote` unit test (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)