### PR TITLE
fix: preserve shot history scroll position when returning from a shot

### DIFF
--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -29,6 +29,12 @@ Page {
     property int filteredTotalCount: 0
     property bool _waitingForShotLoad: false
 
+    // First activation does a full reset-to-top load. Subsequent activations
+    // (returning from a pushed child page like Shot Detail) re-query the same
+    // window and restore the scroll position instead of jumping to the top.
+    property bool _initialized: false
+    property real _pendingRestoreContentY: -1
+
     // Wait for async loadShotWithMetadata to complete before popping
     Connections {
         target: MainController
@@ -71,21 +77,29 @@ Page {
 
     StackView.onActivated: {
         root.currentPageTitle = TranslationManager.translate("shothistory.title", "Shot History")
-        if (initialFilter) {
-            // Populate search field with filter terms so user can edit/save
-            var parts = []
-            if (initialFilter.beanBrand) parts.push(initialFilter.beanBrand)
-            if (initialFilter.beanType) parts.push(initialFilter.beanType)
-            if (initialFilter.profileName) parts.push(initialFilter.profileName)
-            if (initialFilter.grinderBrand) parts.push(initialFilter.grinderBrand)
-            if (initialFilter.grinderModel) parts.push(initialFilter.grinderModel)
-            if (initialFilter.grinderSetting) parts.push(initialFilter.grinderSetting)
-            _populatingSearch = true
-            searchField.text = parts.join(" ")
-            searchField.lastTriggeredText = searchField.text.trim()
-            _populatingSearch = false
+        if (!_initialized) {
+            _initialized = true
+            if (initialFilter) {
+                // Populate search field with filter terms so user can edit/save
+                var parts = []
+                if (initialFilter.beanBrand) parts.push(initialFilter.beanBrand)
+                if (initialFilter.beanType) parts.push(initialFilter.beanType)
+                if (initialFilter.profileName) parts.push(initialFilter.profileName)
+                if (initialFilter.grinderBrand) parts.push(initialFilter.grinderBrand)
+                if (initialFilter.grinderModel) parts.push(initialFilter.grinderModel)
+                if (initialFilter.grinderSetting) parts.push(initialFilter.grinderSetting)
+                _populatingSearch = true
+                searchField.text = parts.join(" ")
+                searchField.lastTriggeredText = searchField.text.trim()
+                _populatingSearch = false
+            }
+            loadShots()
+        } else {
+            // Returning from a pushed child page (Shot Detail, comparison,
+            // post-shot review): re-query the same window so edited ratings or
+            // badges stay fresh, then restore where the user was scrolled.
+            reloadPreservingScroll()
         }
-        loadShots()
     }
 
     function loadShots() {
@@ -96,6 +110,20 @@ Page {
         shotListView.contentY = 0
         var filter = buildFilter()
         MainController.shotHistory.requestShotsFiltered(filter, 0, pageSize)
+    }
+
+    // Refresh the list without losing the user's place. Re-queries every row
+    // that was already loaded (not just the first page) so the model isn't
+    // truncated, then restores contentY once the rows are laid out.
+    function reloadPreservingScroll() {
+        loadMoreTimer.stop()
+        isLoadingMore = false
+        currentOffset = 0
+        hasMoreShots = true
+        _pendingRestoreContentY = shotListView.contentY
+        var windowSize = Math.max(shotListModel.count, pageSize)
+        var filter = buildFilter()
+        MainController.shotHistory.requestShotsFiltered(filter, 0, windowSize)
     }
 
     function loadMoreShots() {
@@ -140,6 +168,16 @@ Page {
                 }
                 currentOffset = results.length
                 hasMoreShots = results.length >= pageSize
+                if (_pendingRestoreContentY >= 0) {
+                    var targetY = _pendingRestoreContentY
+                    _pendingRestoreContentY = -1
+                    // Defer until the ListView has re-laid-out the refreshed
+                    // model so contentHeight is final before we clamp/restore.
+                    Qt.callLater(function() {
+                        var maxY = Math.max(0, shotListView.contentHeight - shotListView.height)
+                        shotListView.contentY = Math.min(targetY, maxY)
+                    })
+                }
             }
             filteredTotalCount = totalCount
         }

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -107,6 +107,11 @@ Page {
         isLoadingMore = false
         currentOffset = 0
         hasMoreShots = true
+        // Explicit reset-to-top entry point (filter/sort/search change, clear
+        // filter, batch delete): discard any pending scroll-restore from a
+        // superseded reloadPreservingScroll() so it can't be applied to this
+        // refreshed result set once its own in-flight request is dropped.
+        _pendingRestoreContentY = -1
         shotListView.contentY = 0
         var filter = buildFilter()
         MainController.shotHistory.requestShotsFiltered(filter, 0, pageSize)
@@ -154,7 +159,7 @@ Page {
                 hasMoreShots = results.length >= pageSize
                 isLoadingMore = false
             } else {
-                // loadShots result (full refresh)
+                // Full refresh (loadShots or reloadPreservingScroll)
                 var j
                 for (j = 0; j < results.length; j++) {
                     if (j < shotListModel.count) {


### PR DESCRIPTION
## Summary

Reviewing shots one-by-one was broken: open a shot from the middle of Shot History, tap the back arrow, and the list jumped back to the top instead of staying where you were — so you couldn't easily look at the next shot.

Root cause: `ShotHistoryPage`'s `StackView.onActivated` fires on **every** return (including popping back from `ShotDetailPage`) and unconditionally called `loadShots()`, which both reset `contentY = 0` **and** truncated the model back to the first page (50 rows). So if you'd infinite-scrolled past row 50, even the raw scroll offset couldn't be restored.

## Changes (`qml/pages/ShotHistoryPage.qml`)

- Added `_initialized` / `_pendingRestoreContentY` page properties.
- `StackView.onActivated` now only does the full top-reset `loadShots()` on the **first** activation. Returning from a pushed child page calls a new `reloadPreservingScroll()`.
- `reloadPreservingScroll()` re-queries the **same number of rows** that were already loaded (not just the first page), so the model isn't truncated, then restores `contentY` via `Qt.callLater` (clamped to valid range) once the list has re-laid-out.
- Re-querying (rather than skipping the reload) keeps the list fresh when a rating/notes/badge was edited on the detail or post-shot-review page.

Filter / search / sort changes and deletes still reset to the top as before (they call `loadShots()` directly, unchanged).

## Test plan

- [ ] Open a shot from mid-list → back arrow → list stays where you were, next shot visible.
- [ ] Scroll deep (past the first 50 rows, infinite-scroll loaded more) → open a shot → back → position still preserved.
- [ ] Edit a rating/notes on the detail or post-shot-review page → back → the row reflects the change.
- [ ] Change filter/search/sort, and delete a shot → list still resets to the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)