### PR TITLE
docs(openspec): Phase B (A-Flow) shadow gate — STOP, row not added

### DIFF
--- a/openspec/changes/flag-off-expert-band-in-shot-summary/tasks.md
+++ b/openspec/changes/flag-off-expert-band-in-shot-summary/tasks.md
@@ -60,10 +60,17 @@ Four review agents: code-reviewer **approve / 0 issues** (verdict ordering, `arg
 - [ ] **Follow-up — `prepareAnalysisInputs` integration test.** The D14a fix's ternary (`!freshKbId.isEmpty() ? freshKbId : profileKbId`) is covered at the building-block level (`tst_dialing_blocks::expertBand_staleKbId_…`) but not by a direct `prepareAnalysisInputs` call (its closure needs the `ai.qrc` + `profile.cpp`→Qt-Bluetooth chain in a test target — the same closure tension that put the regression in `tst_dialing_blocks`). Recorded as a known gap; add when a storage test target gains the KB resource, or accept the building-block coverage.
 - Considered & **kept as-is**: `loadProfileKnowledge` `qWarning` (not `qCritical`) on resource-open failure — test binaries deliberately lack the qrc (per the in-code comment); upgrading severity would spray criticals through every such suite and break the strict no-noise test discipline. The in-app path cannot fail (qrc linked).
 
-## Phase B — A-Flow family (only if A6 passed)
+## Phase B — A-Flow family (evaluated; STOP — row deliberately NOT added)
 
-- [ ] B1 Add the A-Flow variants (all 5) as cited rows — pressure 6–9, `[SRC:aflow-repo]` (band-only, no ceiling; softer signal). No code change beyond the table rows.
-- [ ] B2 Extend slice tests to an A-Flow fixture; re-run the A6 shadow gate over A-Flow shots. Flat/noisy → do not add A-Flow rows; Phase A result stands. Record before/after.
+A6 passed (A6.3 GO), so Phase B was run. The cited band is real — A-Flow repo editor-level dial-in guidance step 1, verbatim: *"grind fine enough to reach a pressure peak between 6 and 9 bar at extraction"* `[SRC:aflow-repo]` (PROFILE_KNOWLEDGE_BASE.md:240). B1's premise was not a fabrication. But the B2 shadow gate failed flat/noisy, so per the Phase-B fail-safe the row is **omitted** and Phase A stands. This is the designed outcome of a flat gate, recorded — not an unfilled gap.
+
+- [x] B1 **Done then reverted (gate-driven).** Added the single canonical `A-Flow` row (PressurePeak 6–9, `[SRC:aflow-repo]`, confidence `medium`; all 5 shipped A-Flow profiles canonical-key to the one `## A-Flow` KB section — same structural dedup as the gold pair), ran B2, then removed it. The KB cpp now carries a recorded-absence comment in its place (do not re-add without a fresh gate pass). Corpus stayed 17/17 with the row present.
+- [x] B2 **GATE: flat/noisy → DO NOT ADD (recorded before/after).** Shadow gate over **all 53 real A-Flow shots** in the 908-shot library, production path:
+  - **Before B1:** 0/53 A-Flow fires (no row). **After B1:** 20/53 fire (38%), zero cross-profile leakage maintained.
+  - **Zero marginal discoverability:** every one of the 20 fires carried verdict `skipFirstFrame` — **0 `expertBandDeviation`-lead**. The band never independently surfaces an A-Flow shot (the tint is already on from the real fault). Gold pair had ~14% band-lead; A-Flow has 0%.
+  - **Signal unmeasurable:** **0 of 53** A-Flow shots are user-rated, so the A6.3 criterion ("measurably more positive than false-flag") cannot be evaluated at all — no evidence the fires track worse shots.
+  - **Structural noise confirmed:** ~6 of 20 fires were peaks at 10–12 bar — the A-Flow editor's *intentional* pressure-up ramp that `profile_knowledge.md` explicitly says "DO NOT flag." The pour-window peak captures the ramp; the row is net-noisy by construction for this family, exactly the pre-registered risk.
+  - **Outcome:** row removed; no A-Flow slice fixture added (moot — no row). Phase A result stands unchanged. Phase C (confounded/contextual tail) inherits the same gate discipline and is **not** auto-started by this result.
 
 ## Phase C — Confounded/contextual tail (only if B passed; per-arm, each independently droppable)
 

--- a/src/ai/shotsummarizer_kb.cpp
+++ b/src/ai/shotsummarizer_kb.cpp
@@ -429,6 +429,17 @@ ShotAnalysis::ExpertBand ShotSummarizer::expertBandForKbId(const QString& kbId)
         { QStringLiteral("D-Flow La Pavoni variant"),
           { Axis::PressurePeak, 6.0, 9.0,
             QStringLiteral("[SRC:profile-notes]"), QStringLiteral("high") } },
+        // Phase B (A-Flow) was evaluated and DELIBERATELY NOT ADDED. The
+        // cited band exists ("pressure peak 6–9 bar at extraction"
+        // [SRC:aflow-repo]), but the B2 shadow gate over 53 real A-Flow
+        // shots failed flat/noisy: 0 of 53 rated (signal unmeasurable),
+        // every one of the 20 fires sat under a pre-existing skipFirstFrame
+        // verdict (zero marginal discoverability — never the lead), and ~6
+        // were the A-Flow editor's intentional 9–12 bar pressure-up ramp
+        // that the KB explicitly says not to flag. Per the Phase-B
+        // fail-safe this row is omitted and Phase A stands — absence here
+        // is the recorded designed outcome, not an unfilled gap. See
+        // tasks.md B1/B2. Do not re-add without a new gate pass.
     };
     if (kbId.isEmpty()) return {};
     loadProfileKnowledge();


### PR DESCRIPTION
## Summary

A6.3 = GO unblocked Phase B (A-Flow family) of `flag-off-expert-band-in-shot-summary`. Phase B was run and the B2 shadow gate **failed flat/noisy**, so per the change's own Phase-B fail-safe the A-Flow row is **deliberately not added** and Phase A stands. This PR records that decision; it is **comment + decision-record only — zero functional change**.

The cited band is genuine (not a fabrication): the A-Flow repo's editor-level dial-in guidance step 1, verbatim — *"grind fine enough to reach a pressure peak between 6 and 9 bar at extraction"* `[SRC:aflow-repo]` (`docs/PROFILE_KNOWLEDGE_BASE.md:240`). B1 was implemented (single canonical `A-Flow` row, covers all 5 shipped A-Flow profiles via the same structural dedup as the gold pair), the gate run, then the row reverted.

### B2 shadow gate — all 53 real A-Flow shots in the local library

| Signal | Result |
|---|---|
| Before B1 → after B1 | 0/53 fires → 20/53 (38%); zero cross-profile leakage maintained |
| Marginal discoverability | **0** `expertBandDeviation`-lead — all 20 fires sit under a pre-existing `skipFirstFrame` verdict (gold pair was ~14% band-lead) |
| Quality signal | **0 of 53** A-Flow shots rated → A6.3 "measurably more positive than false-flag" is **unmeasurable** for this family |
| Structural noise | ~6 of 20 fires are the A-Flow editor's *intentional* 9–12 bar pressure-up ramp the KB explicitly says "DO NOT flag" — net-noise by construction (the pre-registered risk) |

**Outcome:** row omitted, no A-Flow slice fixture (moot — no row). Phase A unchanged: gold pair still 147 fires, A-Flow back to 0, corpus 17/17, full Qt suite 2084/0/0. Phase C is **not** auto-started.

## Test plan

- [x] `shot_eval --validate tests/data/shots/manifest.json` → 17/17 (with and without the row)
- [x] Revert confirmed: A-Flow fires 0, gold-pair fires 147 (identical to merged Phase A)
- [x] App build 0 errors / 0 warnings (Qt Creator)
- [x] Full Qt Test suite: 2084 passed, 0 failed (identical to Phase A baseline)
- [x] `openspec validate flag-off-expert-band-in-shot-summary --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)