### PR TITLE
fix(ci): stop shot_eval sharing qrc_ai.cpp custom command with Decenza (macOS Xcode generator)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1042,9 +1042,16 @@ if(NOT ANDROID AND NOT IOS)
     # match live-shot behavior exactly. Usage:
     #   curl https://visualizer.coffee/api/shots/<uuid>/download > shot.json
     #   ./shot_eval shot.json [more.json ...]
-    # Embed the AI KB resource (:/ai/profile_knowledge.md) so the tool's
-    # band/flags resolution matches the app (loadProfileKnowledge reads it).
-    qt_add_resources(SHOT_EVAL_AI_RES resources/ai.qrc)
+    # The AI KB resource (:/ai/profile_knowledge.md) is embedded below via the
+    # target-scoped qt_add_resources signature (NOT the classic variable form
+    # over resources/ai.qrc). Both forms map the files to the same :/ai/...
+    # paths loadProfileKnowledge reads, but the classic form would derive the
+    # generated source name from the .qrc basename — colliding with the
+    # Decenza target's own qrc_ai.cpp (same directory scope). One custom
+    # command attached to two unrelated targets is rejected by the macOS CI
+    # Xcode "new build system" generator (Ninja tolerates it). The
+    # target-scoped form emits a uniquely-named source bound to shot_eval
+    # only, so there is no shared custom command.
     add_executable(shot_eval
         tools/shot_eval/main.cpp
         src/ai/shotanalysis.cpp
@@ -1059,13 +1066,25 @@ if(NOT ANDROID AND NOT IOS)
         # path is not exercised — see the scoped note in main.cpp's
         # "App parity (scoped)" block.
         src/ai/shotsummarizer_kb.cpp
-        ${SHOT_EVAL_AI_RES}
     )
     # Qt6::Sql is linked for the QSqlDatabase include pulled in via
     # history/shothistorystorage.h (where HistoryPhaseMarker lives). The
     # tool itself doesn't open any databases.
     target_link_libraries(shot_eval PRIVATE Qt6::Core Qt6::Sql)
     target_include_directories(shot_eval PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    # Target-scoped resource: BASE=resources keeps the files at :/ai/<name>
+    # (identical to resources/ai.qrc's prefix="/" mapping), and the unique
+    # resource name "shot_eval_ai" produces a shot_eval-only generated source
+    # instead of the shared qrc_ai.cpp. Keep this file list in sync with
+    # resources/ai.qrc.
+    qt_add_resources(shot_eval "shot_eval_ai"
+        PREFIX "/"
+        BASE "${CMAKE_SOURCE_DIR}/resources"
+        FILES
+            "${CMAKE_SOURCE_DIR}/resources/ai/profile_knowledge.md"
+            "${CMAKE_SOURCE_DIR}/resources/ai/espresso_dial_in_reference.md"
+            "${CMAKE_SOURCE_DIR}/resources/ai/claude_agent.md"
+    )
 
     # saw_replay: Phase 0 simulator for SAW prediction model proposals.
     # Replays a corpus of historical shots through OLD (weighted-avg) and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1049,9 +1049,10 @@ if(NOT ANDROID AND NOT IOS)
     # generated source name from the .qrc basename — colliding with the
     # Decenza target's own qrc_ai.cpp (same directory scope). One custom
     # command attached to two unrelated targets is rejected by the macOS CI
-    # Xcode "new build system" generator (Ninja tolerates it). The
-    # target-scoped form emits a uniquely-named source bound to shot_eval
-    # only, so there is no shared custom command.
+    # Xcode "new build system" generator; the local/Linux/Windows/iOS/Android
+    # Ninja generator did not flag it. The target-scoped form emits a
+    # uniquely-named source bound to shot_eval only, so there is no shared
+    # custom command.
     add_executable(shot_eval
         tools/shot_eval/main.cpp
         src/ai/shotanalysis.cpp
@@ -1075,8 +1076,11 @@ if(NOT ANDROID AND NOT IOS)
     # Target-scoped resource: BASE=resources keeps the files at :/ai/<name>
     # (identical to resources/ai.qrc's prefix="/" mapping), and the unique
     # resource name "shot_eval_ai" produces a shot_eval-only generated source
-    # instead of the shared qrc_ai.cpp. Keep this file list in sync with
-    # resources/ai.qrc.
+    # instead of the shared qrc_ai.cpp. NOTE: this list is maintained
+    # independently of resources/ai.qrc (still consumed by the Decenza target
+    # above) — there is no enforced coupling, so adding a KB file requires
+    # editing BOTH this list and resources/ai.qrc or shot_eval silently lacks
+    # the new resource.
     qt_add_resources(shot_eval "shot_eval_ai"
         PREFIX "/"
         BASE "${CMAKE_SOURCE_DIR}/resources"


### PR DESCRIPTION
## Summary

The macOS CI build has been failing at the **CMake Generate** step since `shot_eval` started embedding the AI KB resource:

```
CMake Error in CMakeLists.txt:
  The custom command generating
    build/macos/qrc_ai.cpp
  is attached to multiple targets:
    Decenza
    shot_eval
  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".
```

**Root cause:** `shot_eval` used the classic `qt_add_resources(SHOT_EVAL_AI_RES resources/ai.qrc)` signature in the *same directory scope* as the `Decenza` app target's own `qt_add_resources(RESOURCES resources/ai.qrc)`. Both derive the generated source name from the `.qrc` basename (`ai` → `qrc_ai.cpp`), so a single custom command ended up attached to two unrelated targets. The macOS CI uses the Xcode "new build system" generator, which forbids this. Ninja (local / Linux / Windows / iOS / Android) tolerates it, so the break was macOS-only and slipped through.

**Fix:** Switch `shot_eval` to the target-scoped `qt_add_resources(shot_eval "shot_eval_ai" PREFIX "/" BASE resources FILES ...)` signature. `PREFIX "/" + BASE resources` keeps the files at the identical `:/ai/<name>` paths `loadProfileKnowledge` reads; the unique resource name emits a `shot_eval`-only generated source (`qrc_shot_eval_ai.cpp`) instead of the shared `qrc_ai.cpp`. The `Decenza` target's resource wiring is untouched — its `qrc_ai.cpp` is now exclusively its own.

The `tests/` `ai.qrc` consumers are in a separate directory scope (own output dir) and aren't built in the macOS release config, so they were never part of the conflict and need no change.

## Test plan

- [x] `cmake -G Ninja` configure + generate succeeds
- [x] `ninja shot_eval` builds; rcc emits `qrc_shot_eval_ai.cpp` (not the shared `qrc_ai.cpp`)
- [x] `shot_eval --validate tests/data/shots/manifest.json` → 21/21 shots pass (KB resolution + expert-band fixtures intact, proving `:/ai/profile_knowledge.md` still maps)
- [ ] macOS CI (Xcode generator) Configure step passes on this branch's push

🤖 Generated with [Claude Code](https://claude.com/claude-code)