### PR TITLE
fix(ai): render conversation emoji as SVG to avoid CoreText sbix crash

### DIFF
--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -312,7 +312,10 @@ Rectangle {
 
                         Accessible.role: Accessible.EditableText
                         Accessible.name: TranslationManager.translate("conversation.accessible.transcript", "AI conversation transcript")
-                        Accessible.description: Theme.stripMarkdown(text)
+                        // text now carries <img> emoji substitutions; strip the
+                        // HTML tags (toAccessibleText) before stripping Markdown
+                        // so VoiceOver/TalkBack don't read literal "<img src=…>".
+                        Accessible.description: Theme.stripMarkdown(Theme.toAccessibleText(text))
                         Accessible.focusable: true
                         activeFocusOnTab: true
 

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -293,8 +293,13 @@ Rectangle {
                     TextArea {
                         id: conversationText
                         width: parent.width
+                        // Substitute emoji with Twemoji SVG <img> (project-wide
+                        // pattern) so a color/sbix glyph never reaches CoreText's
+                        // crashing emoji path. Qt's Markdown importer passes the
+                        // inline <img> through, so markdown formatting AND emoji
+                        // both render. See docs/CLAUDE_MD/EMOJI_SYSTEM.md.
                         text: MainController.aiManager && MainController.aiManager.conversation
-                              ? MainController.aiManager.conversation.getConversationText()
+                              ? Theme.replaceEmojiWithImg(MainController.aiManager.conversation.getConversationText(), Theme.bodyFont.pixelSize)
                               : ""
                         textFormat: Text.MarkdownText
                         wrapMode: TextEdit.WordWrap
@@ -830,7 +835,7 @@ Rectangle {
             // that handler reads _pendingScrollKind, performs the scroll, and
             // wakes the render thread.
             overlay._pendingScrollKind = isResponse ? "preResponse" : "bottom"
-            conversationText.text = MainController.aiManager.conversation.getConversationText()
+            conversationText.text = Theme.replaceEmojiWithImg(MainController.aiManager.conversation.getConversationText(), Theme.bodyFont.pixelSize)
         }
     }
 


### PR DESCRIPTION
## Summary

The AI **ConversationOverlay** renders the whole conversation in a read-only `TextArea` (`textFormat: Text.MarkdownText`). AI replies routinely include emoji (e.g. `✅` U+2705). That `TextArea` was the **only** text widget not run through the app-wide `Theme.replaceEmojiWithImg()` substitution, so a raw color/sbix emoji glyph reached CoreText's emoji path on the `QSGRenderThread`:

```
QQuickTextEdit::updatePaintNode → QTextureGlyphCache::populate
 → QCoreTextFontEngine::imageForGlyph → CoreText CopyEmojiImage
 → ImageIO PNGReadPlugin → SIGBUS @ 0xbad4007  (macOS 26.5)
```

## Evidence (not a guess, not a UAF)

- Live Qt Creator debugger at the fault: the faulting font engine was a **valid** `.Apple Color Emoji UI` `QCoreTextFontEngine` (coherent metrics, valid `face_id`) — not freed/garbage, so not a use-after-free.
- A pre-render scan of the **exact string** handed to the `TextArea` (`getConversationText()`, 9,848 chars) found exactly one emoji-range codepoint: **`U+2705 ✅` at index 6138** ("…26.5s ✅ Your best…"). Every other flagged char was an ordinary symbol (`→ — – ₂`) that renders as a normal outline glyph.
- Reproduced deterministically: viewing/editing that conversation crashed every time.
- Unrelated to the autosave/undo change ([#1191](https://github.com/Kulitorum/Decenza/pull/1191)) — that branch only correlated incidentally; this is a pre-existing gap in the AI conversation view.

## Fix

Both places that assign `conversationText.text` now wrap it in `Theme.replaceEmojiWithImg(..., Theme.bodyFont.pixelSize)` — the same emoji→Twemoji-SVG pattern used everywhere else in the app (`docs/CLAUDE_MD/EMOJI_SYSTEM.md`). Emoji render as sized SVG images, Markdown formatting is preserved (Qt's Markdown importer passes the inline `<img>` through), and no color/sbix glyph ever reaches CoreText. Scope: `qml/components/ConversationOverlay.qml` only (+7/-2).

## Test plan

- [ ] Open the AI conversation containing `✅` (the previously 100%-reproducing case) → no crash.
- [ ] The `✅` renders as the Twemoji SVG image inline, sized to body font.
- [ ] Markdown formatting (bold, lists, `---` separators, `→`/`—`/`–`) still renders correctly.
- [ ] Send a new AI message that returns emoji → still no crash, emoji as image.
- [ ] Sanity-check on a non-macOS target (Android tablet) for layout regressions.

## Known residual (separate, not fixed here)

`inputDialogTextArea` (the editable user-input field in the same overlay) is the same unprotected path if a user *types/pastes* an emoji. Lower-frequency and editable (needs round-trip-safe handling), tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)