### PR TITLE
fix(migration): strip IPv6-mapped prefix from discovered device address

### DIFF
--- a/src/core/datamigrationclient.cpp
+++ b/src/core/datamigrationclient.cpp
@@ -1238,7 +1238,7 @@ void DataMigrationClient::onDiscoveryDatagram()
             device["appVersion"] = obj["appVersion"].toString();
             device["serverUrl"] = serverUrl;
             device["port"] = obj["port"].toInt();
-            device["ipAddress"] = senderAddress.toString();
+            device["ipAddress"] = senderIp;
 
             m_discoveredDevices.append(device);
             emit discoveredDevicesChanged();


### PR DESCRIPTION
## Summary
- Discovered-device cards/combobox were showing `::ffff:192.168.10.163` instead of `192.168.10.163`.
- Root cause: `onDiscoveryDatagram()` stored the raw `senderAddress.toString()` for `ipAddress`, bypassing the `::ffff:` strip already applied to `senderIp` (used for self-detection a few lines above).
- Fix reuses the normalized `senderIp` — one line, no new logic.

## Impact
- Cosmetic display fix. The card's Connect uses the server-reported `serverUrl` (already clean), so device discovery/connect was unaffected.
- Real benefit: pasting the displayed address into the Manual Connection field now yields a valid URL instead of a bracket-less IPv6 string Qt can't resolve.

## Test plan
- [ ] Search for a device on a dual-stack network; verify the card shows `192.168.x.x` (no `::ffff:` prefix)
- [ ] Copy that address into the Manual Connection field and connect successfully