### PR TITLE
fix(logging): suppress spurious Qt "window doesn't exist." message (QTBUG-146779)

### DIFF
--- a/src/core/btlogfilter.cpp
+++ b/src/core/btlogfilter.cpp
@@ -16,6 +16,11 @@ void messageHandler(QtMsgType type, const QMessageLogContext& context, const QSt
         return;  // our independent probe says caps are effective; drop the false alarm
     }
 #endif
+    // QTBUG-146779: Qt spuriously emits "window doesn't exist." during early
+    // startup and window/accessibility teardown. Harmless, but it lands at
+    // critical severity and floods the error log. Drop until the upstream fix.
+    if (msg == QLatin1String("window doesn't exist."))
+        return;
     if (g_previousHandler) g_previousHandler(type, context, msg);
 }
 } // namespace
@@ -24,10 +29,8 @@ namespace BtLogFilter {
 
 void install()
 {
-#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     if (g_previousHandler) return;
     g_previousHandler = qInstallMessageHandler(messageHandler);
-#endif
 }
 
 } // namespace BtLogFilter

--- a/src/core/btlogfilter.h
+++ b/src/core/btlogfilter.h
@@ -2,17 +2,18 @@
 
 #include <QtGlobal>
 
-// Chains into qInstallMessageHandler to drop Qt's "Missing CAP_NET_ADMIN
-// permission..." bluetooth warning when BleCapability::linuxMissing() is
-// false — Qt prints the warning under conditions that don't always mean
-// caps are missing, and the false alarm misleads users who have already
-// granted the capability.
+// Chains into qInstallMessageHandler to drop spurious Qt messages before
+// they reach any other handler:
+//   - "Missing CAP_NET_ADMIN permission..." bluetooth warning (Linux only)
+//     when BleCapability::linuxMissing() is false — Qt prints it under
+//     conditions that don't always mean caps are missing, misleading users
+//     who have already granted the capability.
+//   - "window doesn't exist." (all platforms) — QTBUG-146779, a harmless
+//     critical-severity message Qt emits during startup/teardown.
 //
 // Install AFTER AsyncLogger, CrashHandler, and WebDebugLogger so this
 // filter sits at the top of the static chain and can suppress the false
-// warning before it reaches any other handler.
-//
-// No-op on non-Linux.
+// messages before they reach any other handler.
 namespace BtLogFilter {
 
 void install();


### PR DESCRIPTION
## Summary
- Qt emits `window doesn't exist.` at **critical** severity during early startup and window/accessibility teardown ([QTBUG-146779](https://qt-project.atlassian.net/browse/QTBUG-146779)). It is harmless but floods the error log — ~34× in a single session — making real errors hard to spot in `debug_get_log`.
- Drop the exact message in `BtLogFilter`, which sits at the **top** of the `qInstallMessageHandler` chain (installed last, main.cpp:351), so it never reaches the web debug logger, async/persisted logger, or console.
- **Also fixes a latent bug:** `BtLogFilter::install()` was wrapped in `#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)`, making it a no-op on Android/macOS — exactly the platforms where this message appears. `install()` is now cross-platform; the CAP_NET_ADMIN rule stays Linux-gated by its own `#if`.

## Notes
- Exact `==` match (`QLatin1String("window doesn't exist.")`), not `contains`, so it cannot accidentally suppress a legitimate message.
- Remove once the upstream Qt fix lands.

## Test plan
- [ ] Launch on Android; confirm `window doesn't exist.` no longer appears in `de1 debug_get_log` (was ~8–34×/session)
- [ ] Confirm real ERROR/WARN lines still log normally
- [ ] Linux: CAP_NET_ADMIN false-alarm suppression still works (unchanged path)