### PR TITLE
fix(shutdown): don't false-warn on BLE drain in simulation mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2362,11 +2362,19 @@ int main(int argc, char *argv[])
 
         bool needBleWait = false;
 
+        // transport() is null in simulation mode (sim uses the simulator, not a
+        // real transport), yet de1Device.isConnected() is unconditionally true
+        // in sim. Gate the drain wait on a real connected transport: otherwise
+        // every sim-mode quit enters the wait with no queueDrained source and
+        // always trips the safety-net timeout with a misleading warning.
+        auto* de1Transport = de1Device.transport();
+        const bool de1TransportConnected = de1Transport && de1Transport->isConnected();
+
         // Put DE1 to sleep if connected (this is more reliable than QML onClosing on mobile)
         if (de1Device.isConnected()) {
             qDebug() << "Sending DE1 to sleep on app exit";
             de1Device.goToSleep();
-            needBleWait = true;
+            needBleWait = de1TransportConnected;
         }
 
         // Put scale to sleep if connected
@@ -2378,14 +2386,13 @@ int main(int argc, char *argv[])
         // Wait for BLE writes to complete before exiting
         if (needBleWait) {
             QEventLoop waitLoop;
-            auto* transport = de1Device.transport();
             bool drained = false;
             int timeoutMs = 1500; // Safety-net timeout
 
-            if (transport && transport->isConnected()) {
-                QObject::connect(transport, &DE1Transport::queueDrained,
+            if (de1TransportConnected) {
+                QObject::connect(de1Transport, &DE1Transport::queueDrained,
                                  &waitLoop, [&]() { drained = true; waitLoop.quit(); });
-                QObject::connect(transport, &DE1Transport::disconnected,
+                QObject::connect(de1Transport, &DE1Transport::disconnected,
                                  &waitLoop, [&]() { waitLoop.quit(); });
                 timeoutMs = 2000;
             }


### PR DESCRIPTION
## Summary

`MainController`'s `aboutToQuit` cleanup keyed the BLE-drain wait off `de1Device.isConnected()`, which returns `true` unconditionally in simulation mode ([`de1device.cpp:207`](https://github.com/Kulitorum/Decenza/blob/main/src/ble/de1device.cpp#L207)) even though `transport()` is `null` (sim uses the simulator, not a real BLE transport).

Consequence: **every simulator-mode quit** entered the drain wait loop with no `queueDrained` signal source, so it could only exit via the 1500 ms safety-net `QTimer`, then logged:

```
WARN  BLE queue drain timed out after 1500 ms — sleep command may not have been delivered.
```

This is a guaranteed false positive in sim (confirmed in a debug-log session: the `1500` — not the real-transport `2000` — plus the adjacent `setUsbChargerOnUrgent: no transport` prove the transport branch was skipped). It also added a needless ~1.5 s delay to every sim shutdown, and the noise trains the eye to ignore a warning that *is* meaningful on real hardware.

## Fix

Hoist the transport lookup and gate the DE1 leg of `needBleWait` (and the wait connections) on a real connected transport instead of `de1Device.isConnected()`.

- **Real hardware:** unchanged — transport connected → `needBleWait = true`, 2000 ms timeout, waits on `queueDrained`/`disconnected` exactly as before.
- **Simulation:** `goToSleep()` is still sent to the simulator (harmless, keeps sim state correct), but the drain wait is skipped — no spurious 1.5 s hang, no misleading warning.
- **Sim + a real BLE scale connected** (rare): scale leg still sets `needBleWait`, scale `sleepCompleted` path preserved.

## Test plan

- [ ] Simulator mode: quit the app; confirm no "BLE queue drain timed out" warning and no ~1.5 s exit delay.
- [ ] Real DE1 connected: quit; confirm "Waiting for BLE queue to drain..." → "BLE queue drained successfully" (2000 ms budget, unchanged).
- [ ] Real DE1 where the sleep write genuinely can't flush: confirm the timeout warning still fires (diagnostic preserved on real hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)