### PR TITLE
fix(ai): resolve grinder-calibration profiles by KB id, not displayName

### DIFF
--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -757,20 +757,27 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
         return QJsonObject();
     }
 
-    // Group numeric settings by canonical KB name.
-    // canonicalKey: pk.name if kbId found in KB, else profile_name.
+    // Group numeric settings by canonical KB *id* (identity), not by the
+    // displayName string. Resolving the stored profile_kb_id (or, for very
+    // old shots with an empty kb-id, the profile title) collapses every
+    // declared-equivalent title — displayName + all alsoMatches, e.g.
+    // "D-Flow / Q" ≡ "Damian's Q" ≡ "D-Flow Q variant" — into ONE group,
+    // regardless of which legacy kb-id string each shot persisted (D14a).
+    // Custom/bean-specific recipes that resolve to no id (e.g.
+    // "D-Flow / Q - Jeff") key off the profile title and are excluded from
+    // anchoring downstream by the empty-id check.
     struct ProfileGroup {
-        QString kbId;           // first non-empty kbId seen for this canonical name
-        QString canonicalName;
+        QString kbId;           // resolved canonical id ("" if unresolved)
+        QString canonicalName;  // displayName (resolved) or raw title — logs only
         QList<double> settings;
     };
-    QMap<QString, ProfileGroup> groups;  // key = canonicalName
+    QMap<QString, ProfileGroup> groups;  // key = canonical id, else profile title
 
     int rowCount = 0;
     int nonNumericCount = 0;
     while (q.next()) {
         ++rowCount;
-        const QString kbId = q.value(0).toString().trimmed();
+        const QString rawKbId = q.value(0).toString().trimmed();
         const QString profileName = q.value(1).toString().trimmed();
         const QString settingStr = q.value(2).toString().trimmed();
 
@@ -778,15 +785,20 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
         const double settingVal = settingStr.toDouble(&numericOk);
         if (!numericOk) { ++nonNumericCount; continue; }
 
-        QString canonName = ShotSummarizer::canonicalNameForKbId(kbId);
-        if (canonName.isEmpty())
-            canonName = profileName.isEmpty() ? kbId : profileName;
-        if (canonName.isEmpty()) continue;
+        QString id = ShotSummarizer::resolveKbId(rawKbId);
+        if (id.isEmpty())
+            id = ShotSummarizer::computeProfileKbId(profileName);
 
-        auto& g = groups[canonName];
-        g.canonicalName = canonName;
-        if (g.kbId.isEmpty() && !kbId.isEmpty())
-            g.kbId = kbId;
+        const QString groupKey = !id.isEmpty()
+            ? id
+            : (profileName.isEmpty() ? rawKbId : profileName);
+        if (groupKey.isEmpty()) continue;
+
+        auto& g = groups[groupKey];
+        g.kbId = id;  // stays "" for unresolved (custom) groups
+        g.canonicalName = !id.isEmpty()
+            ? ShotSummarizer::canonicalNameForKbId(id)
+            : groupKey;
         g.settings.append(settingVal);
     }
 
@@ -818,42 +830,41 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
     };
     QList<AnchorCandidate> canonicalCandidates;
     QList<AnchorCandidate> inferredCandidates;
-    QMap<QString, double> medianByName;  // canonical name → median
+    QMap<QString, double> medianById;             // canonical id → median
+    QList<QPair<QString, double>> customMedians;  // (title, median) — unresolved
 
     for (auto& g : groups) {
         const double med = computeMedian(g.settings);
         if (std::isnan(med)) continue;
-        medianByName[g.canonicalName] = med;
 
-        // kbId may be empty for shots predating migration 9 — fall back to
-        // computing it from the canonical name via the KB matcher.
-        QString kbId = g.kbId;
-        if (kbId.isEmpty())
-            kbId = ShotSummarizer::computeProfileKbId(g.canonicalName);
-
+        // g.kbId is the resolved canonical id; empty only when neither the
+        // stored kb-id nor the profile title matched any KB entry — i.e. a
+        // custom/bean-specific recipe (e.g. "D-Flow / Q - Jeff"). Those
+        // can't anchor a UGS-referenced calibration, but are still surfaced
+        // as a history row in the cross-profile table below.
+        const QString kbId = g.kbId;
         if (kbId.isEmpty()) {
+            customMedians.append({ g.canonicalName, med });
             qDebug() << "buildGrinderCalibrationBlock: group" << g.canonicalName
-                     << "skipped — no kbId resolvable";
+                     << "skipped — no kbId resolvable (history-only)";
             continue;
         }
+        medianById[kbId] = med;
+
         const double ugs = ShotSummarizer::ugsForKbId(kbId);
         if (std::isnan(ugs)) {
+            // Resolved, but the entry carries no UGS (e.g. advanced-spring-
+            // lever). Not anchor-eligible; emitted as a history row below.
             qDebug() << "buildGrinderCalibrationBlock: group" << g.canonicalName
                      << "kbId=" << kbId << "skipped — NaN UGS";
             continue;
         }
 
-        // Only the canonical KB name qualifies as an anchor. Variant profiles
-        // (e.g. "D-Flow / Q - Jeff") resolve to a kbId via normalization but
-        // their settings are tuned for specific beans — they don't represent the
-        // canonical UGS position and should not anchor the calibration.
-        const QString kbCanonicalName = ShotSummarizer::canonicalNameForKbId(kbId);
-        if (!kbCanonicalName.isEmpty() && g.canonicalName != kbCanonicalName) {
-            qDebug() << "buildGrinderCalibrationBlock: group" << g.canonicalName
-                     << "kbId=" << kbId << "skipped — variant of" << kbCanonicalName;
-            continue;
-        }
-
+        // No display-string "variant" gate: under id grouping a resolved id
+        // IS the canonical entry, and every alsoMatches-equivalent title
+        // (D-Flow / Q ≡ Damian's Q ≡ D-Flow Q variant) already collapsed
+        // into this one group. Non-equivalent custom recipes resolve to no
+        // id and were filtered by the empty-id branch above.
         const bool inferred = ShotSummarizer::ugsInferredForKbId(kbId);
         qDebug() << "buildGrinderCalibrationBlock: anchor candidate" << g.canonicalName
                  << "kbId=" << kbId << "ugs=" << ugs
@@ -971,8 +982,12 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
 
     // Build the profiles array from all KB entries with a known UGS.
     // Additionally, append any history profiles not in the KB UGS list.
+    // Coverage is tracked by canonical `id` (not displayName): a history
+    // group resolves to an id, and a KB entry IS an id, so the dedup is
+    // identity-exact — an alsoMatches-aliased history group can no longer
+    // split off and get re-emitted as a phantom standalone profile.
     QJsonArray profilesArr;
-    QSet<QString> coveredNames;
+    QSet<QString> coveredIds;
 
     const QList<ShotSummarizer::KbUgsEntry> kbEntries = ShotSummarizer::allKbUgsEntries();
 
@@ -984,9 +999,9 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
               });
 
     for (const ShotSummarizer::KbUgsEntry& e : sortedEntries) {
-        coveredNames.insert(e.name);
+        coveredIds.insert(e.kbId);
 
-        const bool hasHistory = medianByName.contains(e.name);
+        const bool hasHistory = medianById.contains(e.kbId);
         const bool withinRange = !e.ugsInferred
             && e.ugs >= fineAnchor->ugs - 1e-9
             && e.ugs <= coarseAnchor->ugs + 1e-9;
@@ -995,7 +1010,7 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
         QString rgs;
         if (hasHistory) {
             source = QStringLiteral("history");
-            rgs = formatGrinderSetting(medianByName[e.name]);
+            rgs = formatGrinderSetting(medianById[e.kbId]);
         } else if (withinRange) {
             source = QStringLiteral("derived");
             const double computed = fineAnchor->medianSetting
@@ -1016,12 +1031,21 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
         profilesArr.append(p);
     }
 
-    // Append history profiles that have no KB UGS entry (custom titles, etc.).
-    for (auto it = medianByName.constBegin(); it != medianByName.constEnd(); ++it) {
-        if (coveredNames.contains(it.key())) continue;
+    // History profiles with no KB UGS entry in the output: resolved ids
+    // whose entry has no UGS (e.g. advanced-spring-lever), then unresolved
+    // custom/bean-specific titles (e.g. "D-Flow / Q - Jeff").
+    for (auto it = medianById.constBegin(); it != medianById.constEnd(); ++it) {
+        if (coveredIds.contains(it.key())) continue;
         QJsonObject p;
-        p["profileName"] = it.key();
+        p["profileName"] = ShotSummarizer::canonicalNameForKbId(it.key());
         p["rgs"] = formatGrinderSetting(it.value());
+        p["source"] = QStringLiteral("history");
+        profilesArr.append(p);
+    }
+    for (const QPair<QString, double>& cm : customMedians) {
+        QJsonObject p;
+        p["profileName"] = cm.first;
+        p["rgs"] = formatGrinderSetting(cm.second);
         p["source"] = QStringLiteral("history");
         profilesArr.append(p);
     }

--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -817,10 +817,12 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
         return QJsonObject();
     }
 
-    // Compute medians and collect anchor candidates.
-    // Canonical (non-inferred UGS, exact KB name) are preferred; inferred-UGS
-    // profiles are kept as a fallback pool used only when the canonical-only
-    // selection produces a degenerate pair (setting difference < 0.5).
+    // Compute medians and collect anchor candidates. Eligibility is now
+    // purely id-resolution + non-NaN UGS; the old name-exactness check went
+    // away with the variant gate. Non-inferred-UGS candidates are preferred;
+    // inferred-UGS profiles are kept as a fallback pool used only when the
+    // canonical-only selection produces a degenerate pair (setting
+    // difference < 0.5).
     struct AnchorCandidate {
         QString canonicalName;
         QString kbId;
@@ -982,10 +984,12 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
 
     // Build the profiles array from all KB entries with a known UGS.
     // Additionally, append any history profiles not in the KB UGS list.
-    // Coverage is tracked by canonical `id` (not displayName): a history
-    // group resolves to an id, and a KB entry IS an id, so the dedup is
-    // identity-exact — an alsoMatches-aliased history group can no longer
+    // Coverage is tracked by canonical `id` (not displayName): a KB-resolved
+    // history group resolves to an id, and a KB entry IS an id, so the dedup
+    // is identity-exact — an alsoMatches-aliased history group can no longer
     // split off and get re-emitted as a phantom standalone profile.
+    // (Unresolved custom groups carry no id and are handled separately via
+    // customMedians below.)
     QJsonArray profilesArr;
     QSet<QString> coveredIds;
 

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -263,6 +263,16 @@ public:
     static bool ugsInferredForKbId(const QString& kbId);
     static QString canonicalNameForKbId(const QString& kbId);
 
+    // Resolve a stored profile_kb_id (a current `id` OR a legacy normalized
+    // title/alias persisted on old shot records, D14a) to the canonical KB
+    // `id`. Returns "" when unresolved. Exact-match-or-unresolved, never
+    // fuzzy. This is the identity primitive consumers should group/dedupe
+    // on — every declared-equivalent title (displayName + all alsoMatches,
+    // e.g. "D-Flow / Q" ≡ "Damian's Q" ≡ "D-Flow Q variant") collapses to
+    // one `id`, whereas canonicalNameForKbId returns only the displayName
+    // string and cannot be used as an identity key.
+    static QString resolveKbId(const QString& kbIdOrAlias);
+
     struct KbUgsEntry {
         QString kbId;               // the canonical `id`
         QString name;               // displayName

--- a/src/ai/shotsummarizer_kb.cpp
+++ b/src/ai/shotsummarizer_kb.cpp
@@ -391,6 +391,13 @@ QString ShotSummarizer::canonicalNameForKbId(const QString& kbId)
     return id.isEmpty() ? QString() : s_profileKnowledge.value(id).name;
 }
 
+QString ShotSummarizer::resolveKbId(const QString& kbIdOrAlias)
+{
+    if (kbIdOrAlias.isEmpty()) return QString();
+    loadProfileKnowledge();
+    return resolveKbInput(kbIdOrAlias);
+}
+
 std::optional<ShotAnalysis::ExpertBand>
 ShotSummarizer::expertBandForKbId(const QString& kbId)
 {

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -1189,6 +1189,154 @@ private slots:
         });
     }
 
+    void calibrationBlock_resolvedNoUgsEmittedAsHistoryRow()
+    {
+        // New branch: a profile whose kb-id resolves but whose KB entry has
+        // no UGS (e.g. "advanced-spring-lever"). It is recorded in
+        // medianById, skipped as an anchor, excluded from the UGS-sorted KB
+        // loop (allKbUgsEntries drops NaN-UGS entries), then emitted exactly
+        // once by the medianById leftover loop as a history row labelled
+        // with the displayName — NOT the raw id, and not duplicated.
+        const QString path = freshDbPath();
+        initAndClose(path);
+        withRawDb(path, QStringLiteral("calib_nan_ugs_history"), [&](QSqlDatabase& db) {
+            for (int i = 0; i < 3; ++i) {
+                insertShot(db, ShotRow{
+                    .uuid = QStringLiteral("u-df-%1").arg(i),
+                    .timestamp = 1000 + i,
+                    .profileName = QStringLiteral("D-Flow"),
+                    .profileKbId = QStringLiteral("d-flow"),
+                    .finalWeight = 36.0,
+                    .grinderModel = QStringLiteral("Niche Zero"),
+                    .grinderBurrs = QStringLiteral("63mm conical"),
+                    .grinderSetting = QStringLiteral("6.0")
+                });
+                insertShot(db, ShotRow{
+                    .uuid = QStringLiteral("u-al-%1").arg(i),
+                    .timestamp = 2000 + i,
+                    .profileName = QStringLiteral("Allonge"),
+                    .profileKbId = QStringLiteral("allonge"),
+                    .finalWeight = 60.0,
+                    .grinderModel = QStringLiteral("Niche Zero"),
+                    .grinderBurrs = QStringLiteral("63mm conical"),
+                    .grinderSetting = QStringLiteral("16.0")
+                });
+            }
+            for (int i = 0; i < 3; ++i) {
+                insertShot(db, ShotRow{
+                    .uuid = QStringLiteral("u-asl-%1").arg(i),
+                    .timestamp = 3000 + i,
+                    .profileName = QStringLiteral("Advanced Spring Lever"),
+                    .profileKbId = QStringLiteral("advanced-spring-lever"),
+                    .finalWeight = 36.0,
+                    .grinderModel = QStringLiteral("Niche Zero"),
+                    .grinderBurrs = QStringLiteral("63mm conical"),
+                    .grinderSetting = QStringLiteral("8.0")
+                });
+            }
+
+            const QJsonObject r = DialingBlocks::buildGrinderCalibrationBlock(
+                db, QStringLiteral("Niche Zero"), QStringLiteral("63mm conical"),
+                QStringLiteral("espresso"), 0);
+            QVERIFY(!r.isEmpty());
+
+            const QJsonArray profiles = r.value(QStringLiteral("profiles")).toArray();
+            int aslRows = 0;
+            for (const QJsonValue& pv : profiles) {
+                const QJsonObject p = pv.toObject();
+                if (p.value(QStringLiteral("profileName")).toString()
+                        == QStringLiteral("Advanced Spring Lever")) {
+                    ++aslRows;
+                    QCOMPARE(p.value(QStringLiteral("source")).toString(),
+                             QStringLiteral("history"));
+                    QCOMPARE(p.value(QStringLiteral("rgs")).toString(),
+                             QStringLiteral("8"));
+                    QVERIFY2(!p.contains(QStringLiteral("ugs")),
+                             "NaN-UGS history row must not carry a ugs field");
+                }
+            }
+            QCOMPARE(aslRows, 1);  // emitted exactly once, displayName-labelled
+        });
+    }
+
+    void calibrationBlock_unresolvedCustomTitleEmittedAsRawHistoryRow()
+    {
+        // New branch: a bean-specific custom title that resolves to NO id
+        // ("D-Flow / Q - Jeff", empty stored kb-id, not a declared alias —
+        // computeProfileKbId is called with empty editorType so the
+        // editor-default escape hatch can't fire). It must surface exactly
+        // once via customMedians, labelled with the RAW title, and must NOT
+        // collapse into or contaminate the d-flow-q-variant group.
+        const QString path = freshDbPath();
+        initAndClose(path);
+        withRawDb(path, QStringLiteral("calib_custom_history"), [&](QSqlDatabase& db) {
+            for (int i = 0; i < 3; ++i) {
+                insertShot(db, ShotRow{
+                    .uuid = QStringLiteral("u-df-%1").arg(i),
+                    .timestamp = 1000 + i,
+                    .profileName = QStringLiteral("D-Flow"),
+                    .profileKbId = QStringLiteral("d-flow"),
+                    .finalWeight = 36.0,
+                    .grinderModel = QStringLiteral("Niche Zero"),
+                    .grinderBurrs = QStringLiteral("63mm conical"),
+                    .grinderSetting = QStringLiteral("6.0")
+                });
+                insertShot(db, ShotRow{
+                    .uuid = QStringLiteral("u-al-%1").arg(i),
+                    .timestamp = 2000 + i,
+                    .profileName = QStringLiteral("Allonge"),
+                    .profileKbId = QStringLiteral("allonge"),
+                    .finalWeight = 60.0,
+                    .grinderModel = QStringLiteral("Niche Zero"),
+                    .grinderBurrs = QStringLiteral("63mm conical"),
+                    .grinderSetting = QStringLiteral("16.0")
+                });
+            }
+            for (int i = 0; i < 4; ++i) {
+                insertShot(db, ShotRow{
+                    .uuid = QStringLiteral("u-jeff-%1").arg(i),
+                    .timestamp = 3000 + i,
+                    .profileName = QStringLiteral("D-Flow / Q - Jeff"),
+                    .profileKbId = QString(),  // empty → resolves to no id
+                    .finalWeight = 36.0,
+                    .grinderModel = QStringLiteral("Niche Zero"),
+                    .grinderBurrs = QStringLiteral("63mm conical"),
+                    .grinderSetting = QStringLiteral("7.0")
+                });
+            }
+
+            const QJsonObject r = DialingBlocks::buildGrinderCalibrationBlock(
+                db, QStringLiteral("Niche Zero"), QStringLiteral("63mm conical"),
+                QStringLiteral("espresso"), 0);
+            QVERIFY(!r.isEmpty());
+
+            const QJsonArray profiles = r.value(QStringLiteral("profiles")).toArray();
+            int jeffRows = 0;
+            for (const QJsonValue& pv : profiles) {
+                const QJsonObject p = pv.toObject();
+                const QString name = p.value(QStringLiteral("profileName")).toString();
+                // d-flow-q-variant legitimately appears as a cross-profile KB
+                // UGS row, but with NO history shots in this test it must be
+                // derived/extrapolated — never "history". A "history" source
+                // here would mean the custom "D-Flow / Q - Jeff" shots wrongly
+                // collapsed into it (the contamination this guards against).
+                if (name == QStringLiteral("D-Flow Q variant")) {
+                    QVERIFY2(p.value(QStringLiteral("source")).toString()
+                                 != QStringLiteral("history"),
+                             "unresolved custom title must not contaminate d-flow-q-variant");
+                }
+                if (name == QStringLiteral("D-Flow / Q - Jeff")) {
+                    ++jeffRows;
+                    QCOMPARE(p.value(QStringLiteral("source")).toString(),
+                             QStringLiteral("history"));
+                    QCOMPARE(p.value(QStringLiteral("rgs")).toString(),
+                             QStringLiteral("7"));
+                }
+            }
+            QCOMPARE(jeffRows, 1);  // exactly one row, raw title verbatim
+        });
+    }
+
     void calibrationBlock_badgedShotsExcluded()
     {
         // D-Flow: 2 clean shots at 6.0, 3 grind-issue shots at 15.0.

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -1095,6 +1095,100 @@ private slots:
         });
     }
 
+    void calibrationBlock_aliasEquivalentTitlesCollapseToOneGroup()
+    {
+        // Regression: shots persisted under the three declared-equivalent
+        // identifiers of the SAME KB entry (`d-flow-q-variant`) — the
+        // current id, the legacy normalized-title kb-id "d-flow / q", and
+        // the alsoMatches title "Damian's Q" (empty stored kb-id → resolved
+        // from the profile title) — must collapse into ONE group.
+        //
+        // Pre-fix: grouping keyed by displayName string split these into
+        // "D-Flow / Q" / "Damian's Q" / "D-Flow Q variant", the canonical
+        // usage was rejected as "variant of D-Flow Q variant", and the
+        // cross-profile dedup re-emitted phantom standalone rows.
+        const QString path = freshDbPath();
+        initAndClose(path);
+        withRawDb(path, QStringLiteral("calib_alias_collapse"), [&](QSqlDatabase& db) {
+            // Clean canonical anchor pair so the block is non-empty:
+            // D-Flow (UGS 0.5) @6 and Allonge (UGS 8.0) @16.
+            for (int i = 0; i < 3; ++i) {
+                insertShot(db, ShotRow{
+                    .uuid = QStringLiteral("u-df-%1").arg(i),
+                    .timestamp = 1000 + i,
+                    .profileName = QStringLiteral("D-Flow"),
+                    .profileKbId = QStringLiteral("d-flow"),
+                    .finalWeight = 36.0,
+                    .grinderModel = QStringLiteral("Niche Zero"),
+                    .grinderBurrs = QStringLiteral("63mm conical"),
+                    .grinderSetting = QStringLiteral("6.0")
+                });
+                insertShot(db, ShotRow{
+                    .uuid = QStringLiteral("u-al-%1").arg(i),
+                    .timestamp = 2000 + i,
+                    .profileName = QStringLiteral("Allonge"),
+                    .profileKbId = QStringLiteral("allonge"),
+                    .finalWeight = 60.0,
+                    .grinderModel = QStringLiteral("Niche Zero"),
+                    .grinderBurrs = QStringLiteral("63mm conical"),
+                    .grinderSetting = QStringLiteral("16.0")
+                });
+            }
+            // Same logical profile (d-flow-q-variant), three identifiers,
+            // all at setting 9.0 → pooled median must be 9 across all 6.
+            struct QId { QString title; QString kbid; };
+            const QId qIds[] = {
+                { QStringLiteral("D-Flow Q variant"), QStringLiteral("d-flow-q-variant") }, // current id
+                { QStringLiteral("D-Flow / Q"),       QStringLiteral("d-flow / q") },       // legacy title kb-id
+                { QStringLiteral("Damian's Q"),       QString() },                          // resolved from title
+            };
+            int n = 0;
+            for (const QId& q : qIds) {
+                for (int i = 0; i < 2; ++i, ++n) {
+                    insertShot(db, ShotRow{
+                        .uuid = QStringLiteral("u-q-%1").arg(n),
+                        .timestamp = 3000 + n,
+                        .profileName = q.title,
+                        .profileKbId = q.kbid,
+                        .finalWeight = 36.0,
+                        .grinderModel = QStringLiteral("Niche Zero"),
+                        .grinderBurrs = QStringLiteral("63mm conical"),
+                        .grinderSetting = QStringLiteral("9.0")
+                    });
+                }
+            }
+
+            const QJsonObject r = DialingBlocks::buildGrinderCalibrationBlock(
+                db, QStringLiteral("Niche Zero"), QStringLiteral("63mm conical"),
+                QStringLiteral("espresso"), 0);
+            QVERIFY(!r.isEmpty());
+
+            const QJsonArray profiles = r.value(QStringLiteral("profiles")).toArray();
+            int qRows = 0;
+            QString qName, qSource, qRgs;
+            for (const QJsonValue& pv : profiles) {
+                const QJsonObject p = pv.toObject();
+                const QString name = p.value(QStringLiteral("profileName")).toString();
+                // The alias titles must NOT leak as separate phantom rows.
+                QVERIFY2(name != QStringLiteral("D-Flow / Q"),
+                         "alsoMatches title 'D-Flow / Q' must not appear as its own row");
+                QVERIFY2(name != QStringLiteral("Damian's Q"),
+                         "alsoMatches title \"Damian's Q\" must not appear as its own row");
+                if (name == QStringLiteral("D-Flow Q variant")) {
+                    ++qRows;
+                    qName   = name;
+                    qSource = p.value(QStringLiteral("source")).toString();
+                    qRgs    = p.value(QStringLiteral("rgs")).toString();
+                }
+            }
+            QCOMPARE(qRows, 1);  // collapsed to exactly one row, not three
+            QCOMPARE(qSource, QStringLiteral("history"));
+            // Pooled median of all 6 equivalent shots (all at 9.0) → "9".
+            // A split would median only the 2 same-title shots' subset.
+            QCOMPARE(qRgs, QStringLiteral("9"));
+        });
+    }
+
     void calibrationBlock_badgedShotsExcluded()
     {
         // D-Flow: 2 clean shots at 6.0, 3 grind-issue shots at 15.0.


### PR DESCRIPTION
## Summary

`buildGrinderCalibrationBlock` grouped shots by `canonicalNameForKbId()` — a **displayName string** — and rejected any group whose name != that displayName as a "variant". After the JSON KB restructure (#1192), `displayName` ("D-Flow Q variant") no longer equals the real profile title ("D-Flow / Q", which is now an `alsoMatches` alias). So the user's canonical "D-Flow / Q" usage was excluded from anchoring as a "variant of D-Flow Q variant", and legacy per-shot `profile_kb_id` strings split one logical profile into multiple groups.

This makes the dialing code consume the JSON by **stable `id` identity**, the way the new schema intends — not a patch on the string compare.

## Changes

- **`ShotSummarizer::resolveKbId()` (new public API)** — resolves a stored `profile_kb_id` (a current `id` OR a legacy normalized title/alias, D14a) to the canonical `id`. This is the identity primitive consumers should group/dedupe on; `canonicalNameForKbId` only returns a displayName and can't serve as a key. Thin wrapper over the existing private `resolveKbInput` (+ `loadProfileKnowledge`) — strictly additive, no behavior change for existing callers.
- **Group + anchor `buildGrinderCalibrationBlock` by resolved `id`.** Every declared-equivalent title (displayName + all `alsoMatches`: `D-Flow / Q` ≡ `Damian's Q` ≡ `D-Flow Q variant`) now collapses into one group regardless of which legacy kb-id each shot persisted. The string-equality "variant of" gate is **deleted** — a resolved id IS the canonical entry; custom/bean-specific recipes resolve to no id and are excluded by the existing empty-id check.
- **Cross-profile RGS dedup fixed (audit class-B site).** Coverage is now keyed by `id`, not displayName, so an `alsoMatches`-aliased history group can no longer split off and be re-emitted as a phantom standalone profile row.

A codebase-wide audit of every KB-data consumer (`canonicalNameForKbId`, `computeProfileKbId`, `ugsForKbId`, `getAnalysisFlags`, `expertBandForKbId`, `s_aliasToId`, the `profile_kb_id` write path, etc.) found exactly two class-B sites — both in `dialing_blocks.cpp`, both fixed here. All other consumers already key off `id` correctly or use displayName only for human-facing output.

## Out of scope — tracked in #1198

Bean-specific renamed variants like `D-Flow / Q - Jeff` / `D-Flow / Q3` still fall through to the generic editor default (they aren't in `alsoMatches`, and the restructure deliberately removed greedy prefix matching). Restoring that needs a deterministic, validator-gated prefix rule — designed properly in **#1198**, not bolted on here.

## Testing

- New regression test `TstDialingBlocks::calibrationBlock_aliasEquivalentTitlesCollapseToOneGroup`: shots stored under all three declared-equivalent identifiers (`d-flow-q-variant`, legacy `d-flow / q`, title-resolved `Damian's Q`) must collapse into **one** group with the pooled median, and the alias titles must not leak as phantom rows.
- Clean build: 0 compiler errors, 0 warnings (all targets).
- Authoritative real run via Qt Creator (588 ms) over the full reworked surface — all calibration paths (happy / badged / aborted / inferred-fallback / degenerate / fewer-than-two), the variant-distinct-position guards (`dflowVariantUgs_distinctPositions_1160`, `dflowLaPavoniVariant_distinctPosition`), the cross-consumer resolver contract (`resolver_unknownInput_isStrictNoOpAcrossConsumers`), KB-coverage/shipped-KB guards, and the new test: **36 passed, 0 failed, 0 warnings**.
- Caveat: the Qt Creator Autotest MCP returned cached snapshots (1–5 ms) for broad/repeated scopes this session, so a fresh *full-suite* run through it wasn't obtained. The Linux CI workflow runs the complete `ctest` suite on tag push for the full gate. (Flagging the caching behavior as QC-MCP feedback.)

## Test plan

- [ ] CI Linux full `ctest` suite green
- [ ] On device: a `D-Flow / Q` shot's AI dial-in context shows D-Flow/Q anchoring/median (no "skipped — variant of"), and "D-Flow / Q" / "Damian's Q" no longer appear as duplicate profile rows