### PR TITLE
fix(ble): persistent scale + R2 reconnect so they re-link on power-up (#1207)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1137,9 +1137,13 @@ int main(int argc, char *argv[])
                      &bleManager, &BLEManager::de1LogMessage);
 #endif
 
-    // Scale auto-reconnect after disconnect: 3 retries with backoff (5s, 30s, 60s).
-    // First retry is quick (5s). Subsequent delays exceed BLE's 20s connection timeout
-    // so each attempt completes before the next fires.
+    // Scale auto-reconnect after disconnect: backoff ramp 5s → 30s → 60s, then
+    // the 60s tail repeats indefinitely while the scale stays disconnected.
+    // First retry is quick (5s); the 30s/60s delays exceed BLE's 20s connection
+    // timeout so each attempt completes before the next fires. We never give up
+    // permanently (matches de1app): a scale powered back on hours later is
+    // reconnected automatically because each retry runs a scan that latches on
+    // the instant the saved scale re-advertises (#1207).
     int scaleReconnectAttempt = 0;
     QTimer scaleReconnectTimer;
     scaleReconnectTimer.setSingleShot(true);
@@ -1152,24 +1156,34 @@ int main(int argc, char *argv[])
     // initiated scan so normal reconnect behaviour resumes.
     bool scaleAutoReconnectSuppressed = false;
 
+    // R2 refractometer auto-reconnect: same persistent backoff as the scale
+    // (5s → 30s → 60s, then 60s forever). The R2 has no DE1-sleep power
+    // management, so there is no deliberate-disconnect suppression to track —
+    // it simply keeps trying whenever it is disconnected and an address is
+    // saved. Shares reconnectDelays with the scale.
+    int refractometerReconnectAttempt = 0;
+    QTimer refractometerReconnectTimer;
+    refractometerReconnectTimer.setSingleShot(true);
+
     QObject::connect(&scaleReconnectTimer, &QTimer::timeout,
                      [&bleManager, &settings, &scaleReconnectAttempt, &scaleReconnectTimer, &reconnectDelays]() {
         if (settings.scaleAddress().isEmpty()) {
             qDebug() << "Scale reconnect: no saved scale address, stopping retries";
             return;
         }
-        qDebug() << "Scale reconnect: attempt" << (scaleReconnectAttempt + 1) << "of" << reconnectDelays.size();
-        bleManager.appendScaleLog(QString("Auto-reconnect attempt %1 of %2")
-                                  .arg(scaleReconnectAttempt + 1)
-                                  .arg(reconnectDelays.size()));
+        qDebug() << "Scale reconnect: attempt" << (scaleReconnectAttempt + 1);
+        bleManager.appendScaleLog(QString("Auto-reconnect attempt %1").arg(scaleReconnectAttempt + 1));
         bleManager.resetScaleConnectionState();
         bleManager.tryDirectConnectToScale();
         scaleReconnectAttempt++;
+        // Persistent reconnect: walk the ramp, then hold on the last (60s)
+        // delay forever. Stops naturally when the scale connects
+        // (connectedChanged), the user forgets it (scaleAddress empty, above),
+        // or the user scans for a different scale.
         if (scaleReconnectAttempt < static_cast<int>(reconnectDelays.size())) {
             scaleReconnectTimer.start(reconnectDelays[scaleReconnectAttempt]);
         } else {
-            qDebug() << "Scale reconnect: retries exhausted, waiting for manual reconnect or app resume";
-            bleManager.appendScaleLog("Auto-reconnect exhausted - tap Scan to retry");
+            scaleReconnectTimer.start(reconnectDelays.back());
         }
     });
 
@@ -1568,6 +1582,53 @@ int main(int argc, char *argv[])
             bleManager.setRefractometerDevice(nullptr);
             engine.rootContext()->setContextProperty("Refractometer", nullptr);
             refractometer.reset();
+        }
+    });
+
+    QObject::connect(&refractometerReconnectTimer, &QTimer::timeout,
+                     [&bleManager, &settings, &refractometerReconnectAttempt,
+                      &refractometerReconnectTimer, &reconnectDelays]() {
+        if (settings.savedRefractometerAddress().isEmpty()) {
+            qDebug() << "Refractometer reconnect: no saved address, stopping retries";
+            return;
+        }
+        if (bleManager.isRefractometerConnected()) {
+            qDebug() << "Refractometer reconnect: already connected, stopping retries";
+            return;
+        }
+        qDebug() << "Refractometer reconnect: attempt" << (refractometerReconnectAttempt + 1);
+        bleManager.appendScaleLog(QString("R2 auto-reconnect attempt %1")
+                                  .arg(refractometerReconnectAttempt + 1));
+        bleManager.tryDirectConnectToRefractometer();
+        refractometerReconnectAttempt++;
+        // Persistent reconnect: walk the ramp, then hold on the 60s tail
+        // forever. Stops when the R2 connects or the user forgets it (both
+        // guarded above).
+        if (refractometerReconnectAttempt < static_cast<int>(reconnectDelays.size())) {
+            refractometerReconnectTimer.start(reconnectDelays[refractometerReconnectAttempt]);
+        } else {
+            refractometerReconnectTimer.start(reconnectDelays.back());
+        }
+    });
+
+    // Arm the R2 reconnect when it drops; stop it when it connects. Without
+    // this the R2 has no disconnect-triggered reconnect at all (only app
+    // startup/resume), so a powered-off R2 stays dead for the rest of the
+    // session. refractometerConnectedChanged also fires transiently while a
+    // fresh connection is still being set up and on Forget — the saved-address
+    // guard and the !isActive() guard keep those from scrambling the backoff.
+    QObject::connect(&bleManager, &BLEManager::refractometerConnectedChanged,
+                     [&bleManager, &settings, &refractometerReconnectTimer,
+                      &refractometerReconnectAttempt, &reconnectDelays]() {
+        if (bleManager.isRefractometerConnected()) {
+            refractometerReconnectTimer.stop();
+            refractometerReconnectAttempt = 0;
+        } else if (!settings.savedRefractometerAddress().isEmpty()
+                   && !refractometerReconnectTimer.isActive()) {
+            refractometerReconnectAttempt = 0;
+            refractometerReconnectTimer.start(reconnectDelays[0]);
+            qDebug() << "Refractometer reconnect: scheduled first retry in"
+                     << reconnectDelays[0] << "ms";
         }
     });
 
@@ -2170,7 +2231,7 @@ int main(int argc, char *argv[])
     // when app is suspended/resumed. Neither DE1 nor scale are put to sleep when
     // backgrounded — users may switch apps while the machine heats up.
     QObject::connect(&app, &QGuiApplication::applicationStateChanged,
-                     [&physicalScale, &bleManager, &settings, &batteryManager, &de1Device, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &de1ReconnectTimer, &de1ReconnectAttempt, &scaleAutoReconnectSuppressed](Qt::ApplicationState state) {
+                     [&physicalScale, &bleManager, &settings, &batteryManager, &de1Device, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &de1ReconnectTimer, &de1ReconnectAttempt, &scaleAutoReconnectSuppressed, &refractometerReconnectTimer, &refractometerReconnectAttempt](Qt::ApplicationState state) {
         static bool wasSuspended = false;
 
         // Log every state transition so the debug log captures pre-suspend
@@ -2255,11 +2316,14 @@ int main(int argc, char *argv[])
                 qDebug() << "App resumed - starting scale reconnect sequence";
             }
 
-            // Try to reconnect refractometer
+            // Refractometer disconnected while suspended - (re)start its
+            // persistent reconnect sequence (mirrors the scale path above).
             if (!bleManager.isRefractometerConnected()
-                && !settings.savedRefractometerAddress().isEmpty()) {
-                QTimer::singleShot(500, &bleManager, &BLEManager::tryDirectConnectToRefractometer);
-                qDebug() << "App resumed - reconnecting refractometer";
+                && !settings.savedRefractometerAddress().isEmpty()
+                && !refractometerReconnectTimer.isActive()) {
+                refractometerReconnectAttempt = 0;
+                refractometerReconnectTimer.start(reconnectDelays[0]);
+                qDebug() << "App resumed - starting refractometer reconnect sequence";
             }
 
             // Resume smart charging check now that app is active again

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1142,8 +1142,9 @@ int main(int argc, char *argv[])
     // First retry is quick (5s); the 30s/60s delays exceed BLE's 20s connection
     // timeout so each attempt completes before the next fires. We never give up
     // permanently (matches de1app): a scale powered back on hours later is
-    // reconnected automatically because each retry runs a scan that latches on
-    // the instant the saved scale re-advertises (#1207).
+    // reconnected automatically because each retry runs a ~15s scan that
+    // connects as soon as it sees the saved scale advertising, so it is picked
+    // up within a retry cycle (#1207).
     int scaleReconnectAttempt = 0;
     QTimer scaleReconnectTimer;
     scaleReconnectTimer.setSingleShot(true);
@@ -1172,7 +1173,12 @@ int main(int argc, char *argv[])
             return;
         }
         qDebug() << "Scale reconnect: attempt" << (scaleReconnectAttempt + 1);
-        bleManager.appendScaleLog(QString("Auto-reconnect attempt %1").arg(scaleReconnectAttempt + 1));
+        // Only surface the bounded ramp in the user-visible scale log; the
+        // 60s tail repeats forever, so logging it there would grow unbounded
+        // (qDebug still traces every attempt).
+        if (scaleReconnectAttempt < static_cast<int>(reconnectDelays.size())) {
+            bleManager.appendScaleLog(QString("Auto-reconnect attempt %1").arg(scaleReconnectAttempt + 1));
+        }
         bleManager.resetScaleConnectionState();
         bleManager.tryDirectConnectToScale();
         scaleReconnectAttempt++;
@@ -1574,7 +1580,15 @@ int main(int argc, char *argv[])
 
     // Handle Forget Refractometer — disconnect and clean up
     QObject::connect(&bleManager, &BLEManager::disconnectRefractometerRequested,
-                     [&refractometer, &mainController, &engine, &bleManager]() {
+                     [&refractometer, &mainController, &engine, &bleManager,
+                      &refractometerReconnectTimer, &refractometerReconnectAttempt]() {
+        // Stop any pending/persistent reconnect — the user forgot this device.
+        // Unconditional (mirrors the scale's disconnectScaleRequested) so a
+        // timer armed by the clearSavedRefractometer → refractometerConnected-
+        // Changed emission is torn down deterministically rather than relying
+        // on the next-tick saved-address guard.
+        refractometerReconnectTimer.stop();
+        refractometerReconnectAttempt = 0;
         if (refractometer) {
             qDebug() << "[Refractometer] Forget requested, disconnecting";
             refractometer->disconnectFromDevice();
@@ -1597,8 +1611,11 @@ int main(int argc, char *argv[])
             return;
         }
         qDebug() << "Refractometer reconnect: attempt" << (refractometerReconnectAttempt + 1);
-        bleManager.appendScaleLog(QString("R2 auto-reconnect attempt %1")
-                                  .arg(refractometerReconnectAttempt + 1));
+        // Bounded ramp only in the user-visible log (the 60s tail is endless).
+        if (refractometerReconnectAttempt < static_cast<int>(reconnectDelays.size())) {
+            bleManager.appendScaleLog(QString("R2 auto-reconnect attempt %1")
+                                      .arg(refractometerReconnectAttempt + 1));
+        }
         bleManager.tryDirectConnectToRefractometer();
         refractometerReconnectAttempt++;
         // Persistent reconnect: walk the ramp, then hold on the 60s tail
@@ -1612,11 +1629,12 @@ int main(int argc, char *argv[])
     });
 
     // Arm the R2 reconnect when it drops; stop it when it connects. Without
-    // this the R2 has no disconnect-triggered reconnect at all (only app
-    // startup/resume), so a powered-off R2 stays dead for the rest of the
-    // session. refractometerConnectedChanged also fires transiently while a
-    // fresh connection is still being set up and on Forget — the saved-address
-    // guard and the !isActive() guard keep those from scrambling the backoff.
+    // this the R2 only reconnected on app startup/resume — a powered-off R2
+    // stayed dead until the next app resume (and forever on desktop, which
+    // never suspends). refractometerConnectedChanged also fires transiently
+    // while a fresh connection is still being set up and on Forget — the
+    // saved-address guard and the !isActive() guard keep those from scrambling
+    // the backoff.
     QObject::connect(&bleManager, &BLEManager::refractometerConnectedChanged,
                      [&bleManager, &settings, &refractometerReconnectTimer,
                       &refractometerReconnectAttempt, &reconnectDelays]() {


### PR DESCRIPTION
## Summary

Fixes #1207. When a BLE scale (e.g. Bookoo) powers off, Decenza's auto-reconnect ran exactly 3 attempts (5s, 30s, 60s ≈ 95s) and then **gave up permanently**. A scale turned back on hours later never reconnected until the user manually tapped "Scale not found" to force a rescan — there was nothing scanning in the meantime. The DiFluid R2 refractometer was strictly worse: it had **no disconnect-triggered reconnect at all** (only app startup / app resume).

This makes both reconnects **persistent**, matching de1app (whose perceived "it reconnects when I start a shot" is really a continuous background reconnect that never permanently gives up):

- Backoff ramp **5s → 30s → 60s, then the 60s tail repeats indefinitely** while the device is disconnected and an address is saved.
- No new BLE plumbing: the existing scan → `onDeviceDiscovered` → connect path already latches onto the saved device the instant it re-advertises. Only the give-up policy changed.
- Scale reconnect still honors the deliberate DE1-sleep suppression (`scaleAutoReconnectSuppressed`) and re-arms on DE1 wake / app resume. The R2 has no DE1-sleep power management, so it simply retries whenever it is disconnected with a saved address.
- App-resume R2 handling switched from a one-shot to (re)arming the persistent timer, mirroring the scale path.

### Why not bind reconnect to the espresso button (as the issue proposed)?
`de1app` does **not** scan on the espresso press — it reconnects continuously/on-advertisement independent of the button. Persistent reconnect is the faithful match and fixes the root cause (came back after hours, never reconnects) rather than the symptom.

### Cost
A ~15s LE scan per ~60s while a saved device is disconnected. Negligible on the countertop tablet, and paused during DE1 sleep for the scale.

## Test plan

- [ ] Build (Qt Creator) — `src/main.cpp` only change, no new includes.
- [ ] Pair a BLE scale, power it off → confirm reconnect retries continue past ~95s (debug log: "Scale reconnect: attempt N" keeps incrementing on a 60s cadence).
- [ ] Leave scale off for several minutes, power it back on → confirm it auto-reconnects within ~60s with no manual tap.
- [ ] Pair an R2, power it off mid-session → confirm it now auto-reconnects (previously never did until app restart).
- [ ] Forget scale / Forget R2 → confirm retries stop (no saved address).
- [ ] DE1 sleep with `keepScaleOn=false` → confirm scale reconnect stays suppressed until DE1 wake (unchanged behavior).
- [ ] Background/resume the app with scale & R2 off → confirm reconnect sequences (re)start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)