### PR TITLE
fix(a11y): attach dialog Accessible role/name to contentItem, not the Dialog

### DIFF
--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -844,9 +844,6 @@ Page {
         property bool profileIsAutoLoad: false
         property bool viewIsSelectedList: false
 
-        Accessible.role: Accessible.Dialog
-        Accessible.name: TranslationManager.translate("profileselector.dialog.profile_actions_title", "Profile actions") + (profileTitle ? ": " + profileTitle : "")
-
         background: Rectangle {
             color: Theme.surfaceColor
             radius: Theme.cardRadius
@@ -856,6 +853,12 @@ Page {
 
         contentItem: ColumnLayout {
             spacing: Theme.scaled(12)
+
+            // Accessible.* must attach to an Item-derived object; Dialog
+            // (a Popup) is not one, so the dialog semantics live on its
+            // contentItem instead.
+            Accessible.role: Accessible.Dialog
+            Accessible.name: TranslationManager.translate("profileselector.dialog.profile_actions_title", "Profile actions") + (profileActionsDialog.profileTitle ? ": " + profileActionsDialog.profileTitle : "")
 
             Text {
                 Layout.preferredWidth: Theme.scaled(280)
@@ -1315,6 +1318,12 @@ Page {
             implicitHeight: copyProfileColumn.implicitHeight
             implicitWidth: copyProfileColumn.implicitWidth
 
+            // Accessible.* must attach to an Item-derived object; Dialog
+            // (a Popup) is not one, so the dialog semantics live on its
+            // contentItem instead.
+            Accessible.role: Accessible.Dialog
+            Accessible.name: TranslationManager.translate("profileselector.copyProfile.title", "Copy Profile")
+
             ColumnLayout {
                 id: copyProfileColumn
                 anchors.fill: parent
@@ -1396,9 +1405,6 @@ Page {
             radius: Theme.scaled(8)
             border.color: Theme.borderColor
         }
-
-        Accessible.role: Accessible.Dialog
-        Accessible.name: TranslationManager.translate("profileselector.copyProfile.title", "Copy Profile")
     }
 
     // Toast notification


### PR DESCRIPTION
## Summary

`Dialog` (QtQuick.Controls) derives from `Popup` → `QtObject`, **not** `Item`, so `Accessible.role` / `Accessible.name` attached directly on a `Dialog` is rejected at runtime:

```
qrc:/qt/qml/Decenza/qml/pages/ProfileSelectorPage.qml:830:5: QML Dialog: Accessible attached property must be attached to an object deriving from Item or Action
qrc:/qt/qml/Decenza/qml/pages/ProfileSelectorPage.qml:1275:5: QML Dialog: Accessible attached property must be attached to an object deriving from Item or Action
```

Net effect: `profileActionsDialog` and `copyProfileDialog` exposed **no role/name to TalkBack/VoiceOver at all** — a real accessibility regression, not just log noise.

## Fix

Move `Accessible.role: Accessible.Dialog` + `Accessible.name` off each `Dialog` and onto its `Item`-derived `contentItem`:
- `profileActionsDialog` → `ColumnLayout` contentItem
- `copyProfileDialog` → `KeyboardAwareContainer` contentItem

This matches the established project pattern (`SelectionDialog`, `McpConfirmDialog` never attach `Accessible` to the `Dialog` object itself). Audited the rest of the file: the other three `Dialog`s, the `Timer`, `Component`, and `Repeater` have no misattached `Accessible`; the remaining ~40 `Accessible.*` usages are all on `Item`-derived elements (valid). These two were the only occurrences.

## Test plan

- [ ] Build (passes locally, 0 warnings).
- [ ] Run app, open the profile-actions overflow dialog and the copy-profile dialog → confirm the two QML warnings no longer print.
- [ ] With TalkBack/VoiceOver, open both dialogs → confirm each is announced as a dialog with its title ("Profile actions: <name>", "Copy Profile").

🤖 Generated with [Claude Code](https://claude.com/claude-code)