### PR TITLE
fix(ble): arm R2 persistent reconnect at startup, not only on disconnect

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1676,10 +1676,11 @@ int main(int argc, char *argv[])
     // Auto-reconnect refractometer on startup. tryDirectConnect kicks one
     // scan; also arm the persistent reconnect timer so an R2 that is powered
     // off at startup (and therefore never produces a connect→disconnect
-    // transition to arm it) is still picked up when it powers on later. This
-    // is the R2 analogue of the scale's flowScaleFallback startup-failure
-    // arming — the timeout lambda stops itself once the R2 connects or the
-    // address is forgotten.
+    // transition to arm it) is still picked up when it powers on later.
+    // Unlike the scale — whose timer is armed reactively by flowScaleFallback
+    // on a detected connection timeout — the R2 has no failure signal, so we
+    // arm unconditionally here; safe because the timeout lambda self-
+    // terminates once the R2 connects or the address is forgotten.
     if (!settings.savedRefractometerAddress().isEmpty()) {
         bleManager.tryDirectConnectToRefractometer();
         refractometerReconnectAttempt = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1673,9 +1673,17 @@ int main(int argc, char *argv[])
         }
     });
 
-    // Auto-reconnect refractometer on startup
+    // Auto-reconnect refractometer on startup. tryDirectConnect kicks one
+    // scan; also arm the persistent reconnect timer so an R2 that is powered
+    // off at startup (and therefore never produces a connect→disconnect
+    // transition to arm it) is still picked up when it powers on later. This
+    // is the R2 analogue of the scale's flowScaleFallback startup-failure
+    // arming — the timeout lambda stops itself once the R2 connects or the
+    // address is forgotten.
     if (!settings.savedRefractometerAddress().isEmpty()) {
         bleManager.tryDirectConnectToRefractometer();
+        refractometerReconnectAttempt = 0;
+        refractometerReconnectTimer.start(reconnectDelays[0]);
     }
 
 #ifndef Q_OS_IOS


### PR DESCRIPTION
## Summary

Follow-up to #1208. Diagnosed from a user's DE1 log: on the shot-review page the R2 button stayed "R2 off" and turning the R2 on did nothing. The running binary **had** #1208, but the session showed **zero refractometer activity** — the R2 was powered off at app launch.

**Root cause:** #1208 only armed `refractometerReconnectTimer` on (a) a connect→disconnect transition or (b) app resume. An R2 that is off at startup never produces that transition, so the startup `tryDirectConnectToRefractometer()` (a single ~15s scan) was the *only* attempt. With nothing scanning afterward, powering the R2 on later never reconnected it. The scale has no such hole because it arms `scaleReconnectTimer` via `BLEManager::flowScaleFallback` on startup-connect timeout — the R2 had no equivalent.

**Fix:** Arm `refractometerReconnectTimer` right after the startup direct-connect when a saved address exists (the R2 analogue of the scale's `flowScaleFallback` startup arming). The timeout lambda already self-terminates once the R2 connects or the address is forgotten, so it's safe and symmetric with the scale path. +9/−1.

## Test plan

- [ ] Build (passes locally, full rebuild, 0 warnings).
- [ ] With a paired R2 powered **off**, cold-start the app → confirm `Refractometer reconnect: attempt N` lines appear on the 5s/30s/60s ramp.
- [ ] While those retries run, power the R2 on → confirm it connects within a retry cycle and the "R2 off" button flips to connected **without** any manual tap or app restart.
- [ ] R2 on at startup → confirm it connects and the timer stops (no endless retry log).
- [ ] Forget R2 → confirm retries stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)