### PR TITLE
ci(ios): disable Qt-for-iOS caching to free Actions cache budget

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -76,8 +76,15 @@ jobs:
           target: 'ios'
           arch: 'ios'
           modules: 'qtquick3d qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtimageformats qtcanvaspainter'
-          cache: true
-          cache-key-prefix: 'qt-ios-v4'
+          # Qt-for-iOS caching is intentionally disabled. The iOS Qt install
+          # is ~4.2 GB — over half the 10 GB per-repo Actions cache budget —
+          # and its presence forced GitHub's LRU eviction to thrash the
+          # other 5 platforms' Qt caches (and the ccache entries), making
+          # every release slower. iOS is our least release-critical build,
+          # so it pays the cold Qt-install cost (a few extra minutes) to
+          # keep windows/macos/linux/android Qt caches resident. Re-enable
+          # only if the budget pressure is otherwise resolved.
+          cache: false
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2.23


### PR DESCRIPTION
## Problem

The GitHub Actions cache for this repo sits right at the **10 GB per-repo limit**, and the single largest entry is the **Qt-for-iOS install cache at ~4.2 GB — over half the entire budget**.

GitHub cache *restore* is ref-scoped: a tag-triggered release run (`refs/tags/vX.Y.Z`) can only reuse caches from its own tag ref or `main`. The "Warm main branch cache" step that would seed `main` is effectively never reached in practice (a pre-release tag skips it, and promoting pre-release → latest is a release edit that does not re-trigger the workflow). So this iOS Qt cache never accelerates a *different* release — it only ever helped re-tag/force-push churn within a single pre-release version.

But the **10 GB quota is repo-wide across all refs** even though restore is per-ref. A 4.2 GB iOS blob that benefits nothing but iOS pre-release re-tag churn still consumes half the shared budget, pushing the repo over quota and triggering LRU eviction + post-job cache-save flakes (the v1.7.5 Windows "build failure" was exactly such a sccache-save teardown flake — the build itself succeeded).

## Change

One line in `ios-release.yml`: `cache: true` → `cache: false` on the Qt install step (the now-moot `cache-key-prefix: 'qt-ios-v4'` line is removed), with an inline comment explaining why.

## Trade-off (intentional)

Every iOS release re-downloads + installs Qt-for-iOS cold — a few extra minutes on the iOS job. iOS is the least release-critical build, so it's the right one to pay that cost. In exchange, ~4 GB of repo-wide cache budget stays freed, reducing quota thrash and teardown flakes for every other platform's pre-release churn.

This is **cache-budget hygiene, not a cross-release speedup** — tag-scoped caches do not cross releases regardless. The real cross-release fix (warm `main`-scoped caches on release *promotion*, since the current warm-main step is effectively dead) is a separate follow-up.

## Already done out-of-band

- Deleted 5 redundant older-of-pair timestamped `ccache` duplicates from the v1.7.5 re-tag churn (~2.8 GB).
- Deleted the stale 4.2 GB iOS Qt cache (one-time; this PR stops it being recreated every iOS run).
- Repo cache is now ~3.5 GB / 10 GB.

## Not changed

The other 5 workflows keep `cache: true` for Qt — only iOS is the outsized hog. Per-run timestamped `ccache` keys are intentional (GitHub cache entries are immutable; a static key would freeze ccache) and left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)