### PR TITLE
feat(autowake): raise stay-awake cap from 8h to 12h

### DIFF
--- a/qml/pages/settings/SettingsScreensaverTab.qml
+++ b/qml/pages/settings/SettingsScreensaverTab.qml
@@ -596,7 +596,7 @@ Item {
                                 Layout.preferredWidth: Theme.scaled(80)
                                 Layout.preferredHeight: Theme.scaled(34)
                                 from: 15
-                                to: 480
+                                to: 720
                                 stepSize: 15
                                 decimals: 0
                                 value: Settings.autoWake.autoWakeStayAwakeMinutes


### PR DESCRIPTION
## Summary

[Kulitorum/Decenza#1204](https://github.com/Kulitorum/Decenza/issues/1204) asks for an auto-wake stay-awake duration longer than 8 h (the reporter wakes the machine at 6:10 am but wants it ready until ~5 pm).

The "Stay awake" duration slider in **Settings → Screensaver** was capped at `480` min (8 h). This raises the cap to `720` min (**12 h**), stepping by 15 min as before.

## Why this is safe / sufficient

The slider was the *only* enforced limit. Nothing else clamps the value:

- `SettingsAutoWake::setAutoWakeStayAwakeMinutes()` — no clamp
- MCP `settings_set` (`mcptools_write.cpp`) — passes the int through unchanged
- `main.qml` — uses the value as a plain per-minute countdown (`sleepCountdownStayAwake`)

The existing `displayText` formatter already renders the `Nh Mm` string correctly across the extended range (e.g. `12h`, `9h 30m`).

## Changes

- `qml/pages/settings/SettingsScreensaverTab.qml`: `ValueInput.to: 480` → `720`

## Testing

UI-only one-line change; verified by reading the consumers above (countdown logic and formatter handle 720 with no edge cases). Recommend a quick manual check that the slider reaches "12h" and the machine stays awake past 8 h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)