### PR TITLE
feat(about): add Manual button to the version card

### DIFF
--- a/qml/pages/settings/SettingsUpdateTab.qml
+++ b/qml/pages/settings/SettingsUpdateTab.qml
@@ -82,9 +82,17 @@ Item {
                         }
                     }
 
-                    // Easter egg: tap 7 times to enable translation upload
+                    // Easter egg: tap 7 times to enable translation upload.
+                    // Bounds stop at the Manual button's left edge so the two
+                    // accessible elements never overlap — ACCESSIBILITY.md
+                    // forbids nesting accessible elements (TalkBack would
+                    // otherwise expose only one).
                     AccessibleMouseArea {
-                        anchors.fill: parent
+                        anchors.left: parent.left
+                        anchors.top: parent.top
+                        anchors.bottom: parent.bottom
+                        anchors.right: manualButton.left
+                        anchors.rightMargin: Theme.scaled(6)
                         accessibleName: TranslationManager.translate("update.versionBuild", "Version %1, Build %2").arg(AppVersion).arg(AppVersionCode)
                         onAccessibleClicked: {
                             var now = Date.now()
@@ -115,43 +123,20 @@ Item {
                     }
 
                     // Opens the user manual (GitHub wiki) in the default
-                    // browser. Declared after the easter-egg mouse area (and
-                    // z:1) so taps on the button open the manual while taps
-                    // elsewhere on the card still feed the tap counter.
-                    Rectangle {
+                    // browser. AccessibleButton (a Control) gives keyboard
+                    // Tab focus, announce-first screen-reader behavior and
+                    // press feedback for free; its bounds are disjoint from
+                    // the easter-egg area above, which is anchored to stop at
+                    // this button's left edge.
+                    AccessibleButton {
                         id: manualButton
                         anchors.right: parent.right
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.rightMargin: Theme.scaled(10)
-                        z: 1
-                        radius: Theme.buttonRadius
-                        color: manualButtonArea.pressed ? Qt.darker(Theme.primaryColor, 1.2)
-                                                        : Theme.primaryColor
-                        implicitWidth: manualButtonLabel.implicitWidth + Theme.scaled(20)
-                        implicitHeight: Theme.scaled(28)
-
-                        Accessible.role: Accessible.Button
-                        Accessible.name: TranslationManager.translate("about.manual", "Manual")
-                        Accessible.description: TranslationManager.translate("about.manualHint", "Open the Decenza user manual in your browser")
-                        Accessible.focusable: true
-                        Accessible.onPressAction: manualButtonArea.clicked(null)
-
-                        Text {
-                            id: manualButtonLabel
-                            anchors.centerIn: parent
-                            text: TranslationManager.translate("about.manual", "Manual")
-                            font.pixelSize: Theme.scaled(13)
-                            font.bold: true
-                            color: Theme.primaryContrastColor
-                            Accessible.ignored: true
-                        }
-
-                        MouseArea {
-                            id: manualButtonArea
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: Qt.openUrlExternally("https://github.com/Kulitorum/Decenza/wiki")
-                        }
+                        primary: true
+                        text: TranslationManager.translate("settings.update.manual", "Manual")
+                        accessibleName: TranslationManager.translate("settings.update.manualAccessible", "Open the Decenza user manual")
+                        onClicked: Qt.openUrlExternally("https://github.com/Kulitorum/Decenza/wiki")
                     }
                 }
 

--- a/qml/pages/settings/SettingsUpdateTab.qml
+++ b/qml/pages/settings/SettingsUpdateTab.qml
@@ -113,6 +113,46 @@ Item {
                             }
                         }
                     }
+
+                    // Opens the user manual (GitHub wiki) in the default
+                    // browser. Declared after the easter-egg mouse area (and
+                    // z:1) so taps on the button open the manual while taps
+                    // elsewhere on the card still feed the tap counter.
+                    Rectangle {
+                        id: manualButton
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.rightMargin: Theme.scaled(10)
+                        z: 1
+                        radius: Theme.buttonRadius
+                        color: manualButtonArea.pressed ? Qt.darker(Theme.primaryColor, 1.2)
+                                                        : Theme.primaryColor
+                        implicitWidth: manualButtonLabel.implicitWidth + Theme.scaled(20)
+                        implicitHeight: Theme.scaled(28)
+
+                        Accessible.role: Accessible.Button
+                        Accessible.name: TranslationManager.translate("about.manual", "Manual")
+                        Accessible.description: TranslationManager.translate("about.manualHint", "Open the Decenza user manual in your browser")
+                        Accessible.focusable: true
+                        Accessible.onPressAction: manualButtonArea.clicked(null)
+
+                        Text {
+                            id: manualButtonLabel
+                            anchors.centerIn: parent
+                            text: TranslationManager.translate("about.manual", "Manual")
+                            font.pixelSize: Theme.scaled(13)
+                            font.bold: true
+                            color: Theme.primaryContrastColor
+                            Accessible.ignored: true
+                        }
+
+                        MouseArea {
+                            id: manualButtonArea
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: Qt.openUrlExternally("https://github.com/Kulitorum/Decenza/wiki")
+                        }
+                    }
                 }
 
                 // Auto-check toggle

--- a/qml/pages/settings/SettingsUpdateTab.qml
+++ b/qml/pages/settings/SettingsUpdateTab.qml
@@ -47,8 +47,14 @@ Item {
                     color: Theme.backgroundColor
                     radius: Theme.scaled(8)
 
+                    // Centered within the region left of the Manual button
+                    // (not the whole card) so long platform strings / large
+                    // text scaling can never collide with the button.
                     ColumnLayout {
-                        anchors.centerIn: parent
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent.left
+                        anchors.right: manualButton.left
+                        anchors.rightMargin: Theme.scaled(6)
                         spacing: Theme.scaled(1)
 
                         Text {
@@ -74,7 +80,9 @@ Item {
                         }
 
                         Text {
-                            Layout.alignment: Qt.AlignHCenter
+                            Layout.fillWidth: true
+                            horizontalAlignment: Text.AlignHCenter
+                            elide: Text.ElideRight
                             text: DE1Device.simulationMode ? "SIMULATION MODE" : MainController.updateChecker.platformName
                             color: DE1Device.simulationMode ? Theme.primaryColor : Theme.textSecondaryColor
                             font.pixelSize: Theme.scaled(11)


### PR DESCRIPTION
## Summary

Adds a **Manual** button to the right of the Decenza / version / build stack on the About page (**Settings → Update**, the "Current Version" card). Tapping it opens the user manual — the GitHub wiki at <https://github.com/Kulitorum/Decenza/wiki> — in the default browser, giving users one-tap access to the docs.

## Details

- Placed inside the existing version card, `anchors.right` / `verticalCenter`.
- Declared **after** the existing 7-tap translation-upload easter-egg `AccessibleMouseArea` and given `z: 1`, so taps on the button open the manual while taps elsewhere on the card still feed the tap counter (no regression to the easter egg).
- Styled with the same `Theme` tokens and the accessible-button idiom as the adjacent Donate button in the same file (`Accessible.role/name/focusable/onPressAction`, `Qt.openUrlExternally`, pressed-state color).
- Label + accessible name internationalized via `TranslationManager.translate` (`about.manual`, `about.manualHint`), consistent with neighbouring strings.

## Testing

- Qt Creator (Debug) build: **0 errors, 0 warnings** — includes `qmlcachegen`, so the new QML is syntactically valid and bindings resolve.
- Visual placement not yet runtime-verified; recommend a quick look on the About page (the layout uses the same anchor pattern as the existing Donate button, low risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)