### PR TITLE
feat(ble): epoch-scoped latch + scale-feed stall confirmation

### DIFF
--- a/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/.openspec.yaml
+++ b/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/design.md
+++ b/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/design.md
@@ -1,0 +1,65 @@
+## Context
+
+`scale-ble-priority-backoff` (#1185) persists the "dual-HIGH-incapable" classification build-scoped: `SettingsHardware::setConnectionPriorityLatch()` writes `connectionPriority/{latched,triggerKind,setTimeIso,buildCode}`; `BLEManager::setSettings()` rehydrates the in-memory `ScaleSkipHighLatch` only when `cpBuildCode() == versionCode()`, otherwise it calls `clearConnectionPriorityLatch()` and re-detects ("build-scoped safety valve"). #1219 narrowed `clearConnectionPriorityLatch()` to the four latch keys and added a sibling `policyMode` key + the `scaleFeedResumed` recovery signal + observe mode.
+
+Two problems, both pre-existing in #1185 (not introduced by #1219):
+
+1. **Per-build re-detection has an inverted cost/benefit.** `versionCode` is bumped by CI on every release, so a genuinely incapable device re-runs detection on essentially every update. Detection is not free — it requires an actual fault during preheat/shot (disrupted preheat at best, off-target SAW shot at worst). The benefit it buys ("a new build may have fixed it / it may be mis-classified") is weak: BLE dual-HIGH contention is a property of the device radio + OS BLE stack + DE1-link timing, not the Decenza build; and a *false* latch sits at BALANCED, which is proven safe (#1097) and produces no bad coffee. So the design imposes a recurring real cost on true positives to auto-recover false positives from a not-broken state.
+
+2. **The scale-feed-stall backstop has no confirmation.** `BlePriorityDetector::onScaleStall()` latches on the *first* >2 s gap (`kScaleStaleMs`), unlike `onDe1Fault()` which already requires ≥2 within `kDe1FaultWindowMs`. A transient blip that self-recovers can still latch — that is precisely the false-positive class whose per-build auto-recovery problem #1 was paying for.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Persist the classification across builds; make re-classification a *deliberate* per-release decision, not an accident of CI versioning.
+- An already-classified user upgrading from the current release pays **zero** additional detection.
+- The scale-feed-stall backstop only latches when the stall is *confirmed* (did not self-recover), eliminating the dominant false-positive shape.
+- Capable hardware byte-identical (it never latches, so neither change is reachable for it).
+
+**Non-Goals:**
+- No change to the DE1-fault-cluster trigger (≥2/`kDe1FaultWindowMs`) — it already has confirmation.
+- No new user-facing setting; both knobs are source constants.
+- Not removing the MCP reset (the in-session escape hatch) or observe mode (#1219) — both unchanged.
+- Not auto-detecting "BLE behavior changed" — the epoch is a human decision, by design.
+
+## Decisions
+
+### D1 — Epoch constant, decoupled from `versionCode`
+Introduce `kBleDetectionEpoch` (int, starts at 1) in a deliberately-edited BLE constants header — **not** `versioncode.txt`, **not** derived from `versionCode`, **not** touched by CI. The gate in `setSettings()` changes from `storedBuild == versionCode()` to `storedEpoch == kBleDetectionEpoch`; everything else about the safety-valve mechanics (rehydrate vs `clearConnectionPriorityLatch()` + re-detect) is unchanged. Bumping the constant in a commit is the single, auditable "re-classify every device once on this release" lever. *Alternative considered:* a settings-level "BLE revision" written by CI only on BLE-touching builds — rejected: CI can't know a build changed BLE behavior, and it reintroduces an implicit coupling; a human bump is the honest signal. *Alternative:* persist forever, no auto-reset (rely solely on MCP reset) — rejected: keeps no global recovery path for a future genuine BLE fix or a bad-classification wave, and the MCP reset is per-device/operator-only.
+
+### D2 — `buildCode` demoted, not removed
+Keep writing `connectionPriority/buildCode` (the `versionCode` at set-time) but only as a **diagnostic** ("last classified by build X", surfaced in the MCP read). It no longer gates. Removing it would lose useful field-triage signal and force a wider migration; demoting is lower-risk and strictly additive in information.
+
+### D3 — Legacy-record forward migration (the backward-compat guarantee)
+On `setSettings()`, a persisted record that is `latched` and has a `buildCode` but **no `detectionEpoch` key** is a legacy (pre-epoch) record. Treat it as valid for the current epoch: rehydrate the in-memory latch *and* write `detectionEpoch = kBleDetectionEpoch` (one-time forward migration), and log it. Net: a user already classified on the current release keeps the finding with **zero** extra detection across the upgrade. *Alternative considered:* treat "no epoch" as epoch 0 ⇒ mismatch ⇒ discard+re-detect once — rejected: it still costs the exact bad-shot this change exists to remove, on the very upgrade that ships the fix. *Trade-off (accepted, documented):* a stale legacy latch from an old build is carried forward; mitigated because BALANCED is safe (no bad coffee) and both the epoch bump and the MCP reset clear it. Detection of a *fresh* (non-legacy) record with a mismatched epoch is unchanged from today's build-mismatch path (discard + re-detect).
+
+### D4 — Stall confirmation via persistence, gated by the recovery edge
+Split the stall into two states on the **existing DE1 shot-sample cadence** (`setCurrentFrame` → `checkScaleFeedStall`, the same tick that already detects the stall — no new timer):
+- **Suspected**: gap > `kScaleStaleMs` (unchanged 2 s). Still emits `scaleFeedStalled(gapMs)` exactly as today — observe mode logging is unchanged, and this remains the diagnostic "feed went quiet" signal.
+- **Confirmed**: the feed is *still* stalled and the gap has grown past `kScaleStallConfirmMs` (design start ~5–6 s, a single tunable constant) **and** no `scaleFeedResumed` fired since the suspected edge. Emit a new `scaleFeedStallConfirmed(gapMs)`.
+
+`scaleFeedResumed` (from #1219) firing between suspected and confirmed **cancels** the pending confirmation (the stall self-recovered ⇒ it was the transient/false shape ⇒ never confirms ⇒ never latches). Enforce wires the *backoff* to `scaleFeedStallConfirmed` only; `onScaleStall()` is called solely on confirmation. Observe logs suspected (existing), recovered (existing #1219), and confirmed (new "would back off"). *Alternative considered:* require two separate stalls in one cycle — rejected: a genuinely-dead feed often stalls once and stays dead; "two stalls" could fail to ever confirm a real fault. Persistence-past-threshold-unless-recovered directly encodes "did not self-recover", which is exactly the true/false discriminator and reuses the recovery signal already built. *No timer:* both the confirm threshold and the recovery cancel are evaluated on the DE1 tick / the `scaleFeedResumed` edge — consistent with the existing event-based `checkScaleFeedStall` and CLAUDE.md's "no timers as guards".
+
+### D5 — DE1-fault path and capable hardware untouched
+`onDe1Fault()` keeps its ≥2/`kDe1FaultWindowMs` clustering. Capable hardware never reaches a latch (no sustained stall, no fault cluster), so neither the epoch gate nor the confirmation is reachable for it — the capable path is byte-identical, asserted by an explicit test.
+
+### D6 — Layering on #1219
+The confirmation arm consumes `scaleFeedResumed` and the detector/transport observe plumbing from #1219 (`scale-priority-backoff-observe-mode`). Implement stacked on that branch (or rebase after merge). The epoch arm touches only `settings_hardware` + `blemanager::setSettings` + the MCP read and is independent of #1219, so it can land first if the stack is split.
+
+## Risks / Trade-offs
+
+- **[Stale legacy latch carried forward forever]** → Accepted (D3): BALANCED is safe (#1097); recovery is the deliberate epoch bump or the existing MCP reset. The alternative (discard) costs the very bad-shot this change removes, on the fix's own upgrade.
+- **[Epoch never bumped ⇒ a real future BLE fix doesn't reach already-latched devices]** → By design the epoch *is* the lever; bumping it on the fix release is the intended action and is now a single auditable constant change with a documented contract next to it. Far less error-prone than the prior implicit per-build behavior.
+- **[`kScaleStallConfirmMs` too long ⇒ a genuinely-bad device takes longer to latch / one more disrupted prep]** → It only delays latching by the confirm window on a *real* sustained stall (which by definition isn't recovering); the suspected signal still fires for observability, and the value is a single tunable constant validated against the #1219 observe evidence before tightening.
+- **[`kScaleStallConfirmMs` too short ⇒ confirmation doesn't actually filter transients]** → The #1219 observe-mode field data (suspected vs recovered timings) is the calibration input; the constant is chosen from real recovery-gap distributions, not guessed.
+- **[Confirmation diverges from the suspected detection logic over time]** → Both are computed in the one `checkScaleFeedStall` path on the same tick; a single new threshold + the existing recovery flag, no parallel detector. A test asserts suspected always precedes confirmed and recovery cancels.
+
+## Migration Plan
+
+- Additive. New key `connectionPriority/detectionEpoch`; `buildCode` retained (diagnostic). First epoch-build launch: legacy latched records (no epoch key) are honored and stamped forward (D3) — no user-visible event, logged for triage. Fresh records carry the epoch from the start.
+- Deploy: ship normally. To re-classify everyone on a release that changes BLE handling, bump `kBleDetectionEpoch` in that commit (documented next to the constant).
+- Rollback: revert. A reverted build reading an epoch-stamped record falls back to the build-scoped comparison (epoch key simply unread) — degrades to "re-detect once", safe. The confirmation arm reverts to immediate-latch (prior behavior), also safe.
+
+## Open Questions
+
+- Exact `kScaleStallConfirmMs` value: start ~5–6 s; **finalized from #1219 observe-mode field data** (the recovered-gap distribution) before this ships its confirmation arm — recorded in tasks as a calibration gate, not guessed here.

--- a/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/proposal.md
+++ b/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The dual-HIGH "this device can't run HIGH" latch is **build-scoped**: `BLEManager::setSettings()` discards the persisted classification whenever `connectionPriority/buildCode != versionCode()`. CI bumps `versionCode` on every release, so a genuinely dual-HIGH-incapable device **re-pays the detection cost on essentially every app update** — and that cost is a real fault event (a scale-feed stall or DE1-fault cluster during preheat/shot: at best a disrupted preheat, at worst an off-target SAW shot). The justification ("a new build may fix it / may be mis-classified") is weak — BLE contention is a property of the radio/OS/DE1 link, not the Decenza build — and the cost/benefit is inverted: true positives are punished every build to auto-recover false positives from a state (BALANCED) that is proven safe and costs no bad coffee. Separately, the scale-feed-stall backstop latches on a *single* >2 s gap with no confirmation (unlike the DE1-fault path's ≥2/20 s), so a transient blip that would self-recover can still latch — exactly the false-positive whose auto-recovery the per-build reset was paying for.
+
+## What Changes
+
+- **Epoch scoping replaces build scoping.** A single source constant `kBleDetectionEpoch` (deliberately edited, **not** derived from `versionCode`, never touched by CI/`versioncode.txt`) gates rehydrate-vs-rediscard. The latch persists across all builds sharing an epoch. Bumping the epoch in a release is the **deliberate "re-classify every device once" lever** — it replaces the accidental per-build reset, so "we fixed BLE handling, reset everyone" becomes an explicit one-line decision.
+- **`buildCode` is demoted to a diagnostic-only field** ("last set by build X"), surfaced (with the epoch) in `devices_connection_status`; it no longer gates anything.
+- **Legacy records migrate forward, zero extra detection.** An existing latched record from the current release (has `buildCode`, no `detectionEpoch`) is honored once and stamped with the current epoch — an already-classified user upgrading from the current release pays **no** additional detection. (Trade-off, accepted: a stale legacy latch is carried forward, but BALANCED is safe and the epoch bump / MCP reset are the recovery paths.)
+- **Scale-feed-stall confirmation.** The first >2 s gap is a *suspected* stall (the existing `scaleFeedStalled` signal is unchanged — observe mode still logs it). It only *confirms* (becomes eligible to latch in enforce, and the observe "would back off") if the feed is **still stalled** past a larger persistence threshold `kScaleStallConfirmMs` with **no `scaleFeedResumed` in between**. A stall that self-recovers before confirmation never latches. Event/edge-based on the existing DE1 shot-sample cadence + the recovery edge — **no timer**. The DE1-fault-cluster path is unchanged.
+- **Observe mode (from #1219) logs the full picture:** suspected stall, recovery, confirmed stall (the real would-backoff). Enforce acts only on the confirmed stall.
+- Not breaking; no new user-facing setting (both new knobs are source constants). Capable hardware is unaffected (it never latches, so neither scoping nor confirmation applies to it).
+
+## Capabilities
+
+### New Capabilities
+<!-- none — extends existing in-flight capabilities -->
+
+### Modified Capabilities
+- `ble-connection-priority`: the persisted classification is epoch-scoped instead of build-scoped (with documented legacy-record migration and `buildCode` demoted to diagnostic), and the scale-feed-stall backstop requires persistence-confirmation (suspected → confirmed, recovery cancels) before it may latch; the DE1-fault-cluster trigger and capable-hardware behavior are unchanged. Layers on the active `scale-ble-priority-backoff` (#1185), `scale-priority-backoff-preheat-persist` (#1202/#1209), and `scale-priority-backoff-observe-mode` (#1219); archives none of them.
+- `mcp-server`: `devices_connection_status` additionally reports the detection epoch and the (now diagnostic-only) build code; `devices_reset_scale_priority` is unchanged (still the in-session escape hatch).
+
+## Impact
+
+- **Code**: `src/core/settings_hardware.{h,cpp}` (`cpEpoch()/setConnectionPriorityLatch` writes epoch; `cpBuildCode` demoted to diagnostic; narrowed clear already in #1219), `src/ble/blemanager.{h,cpp}` (`setSettings()` epoch gate + legacy-record forward-migration; `latchScaleSkipHighPriority` writes the epoch), a BLE constants header for `kBleDetectionEpoch`, `src/machine/weightprocessor.{h,cpp}` (`kScaleStallConfirmMs`, `scaleFeedStallConfirmed` signal, recovery cancels pending confirmation), `src/ble/transport/bleprioritydetector.h` + `qtscalebletransport.cpp` (act on confirmed not suspected; observe logs suspected/recovered/confirmed), `src/mcp/mcptools_devices.cpp` (surface epoch + diagnostic buildCode).
+- **Persistence/migration**: one new key `connectionPriority/detectionEpoch`; `buildCode` retained for diagnostics; legacy latched records (no epoch key) honored + migrated forward exactly once, logged. No DB/schema change.
+- **Dependency**: the confirmation arm reuses `scaleFeedResumed` and the detector/transport observe plumbing from #1219 — implemented on a branch stacked on `feat/scale-priority-backoff-observe-mode` (or rebased after it merges). The epoch arm is independent of #1219 and could land first.
+- **Tests**: epoch gate + legacy-record forward-migration (header/QtCore-only, `tst_scaleskiphighlatch` pattern); suspected-vs-confirmed stall + recovery-cancels-confirmation (`tst_weightprocessor`); enforce acts only on confirmed, observe logs suspected/recovered/confirmed (`tst_scaleblepriority`).
+- **Constraints**: CLAUDE.md MCP data conventions; no timers as guards; capable-hardware path byte-identical (never latches → neither change applies); minimal root-cause (no new user setting). Rollback is a revert; legacy migration degrades safely to "re-detect once" if removed.

--- a/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/specs/ble-connection-priority/spec.md
+++ b/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/specs/ble-connection-priority/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Classification Is Epoch-Scoped, Not Build-Scoped
+
+The persisted dual-HIGH-incapable classification SHALL be scoped to a deliberate detection epoch, not to the application build/version code. The system MUST rehydrate the persisted latch when the stored epoch equals the current `kBleDetectionEpoch` source constant, and MUST discard it and re-detect when they differ. `kBleDetectionEpoch` MUST NOT be derived from or coupled to the build/version code and MUST change only by a deliberate source edit. The build/version code at set-time MAY still be persisted but only as a diagnostic and MUST NOT gate rehydration.
+
+#### Scenario: Latch survives an ordinary app update
+- **WHEN** a device is latched, then the app is updated to a build with the same `kBleDetectionEpoch`
+- **THEN** the latch is rehydrated on startup (the scale starts at BALANCED with no detection window)
+- **AND** no re-detection fault is incurred
+
+#### Scenario: Epoch bump re-classifies every device once
+- **WHEN** a build ships with an incremented `kBleDetectionEpoch` and a device has a latch stored under the previous epoch
+- **THEN** that latch is discarded and the device re-detects from scratch on that build
+- **AND** a device latched again under the new epoch then persists across subsequent same-epoch builds
+
+#### Scenario: Build code does not gate
+- **WHEN** the stored epoch matches but the stored build code differs from the current version code
+- **THEN** the latch is still rehydrated (build code is diagnostic only, not a gate)
+
+### Requirement: Legacy Records Migrate Forward Without Re-Detection
+
+A persisted record that is latched and carries a build code but has no stored detection epoch (a pre-epoch / legacy record) SHALL be honored once and migrated forward: the in-memory latch MUST be rehydrated AND the current `kBleDetectionEpoch` MUST be written to the stored record. A user already classified on the pre-epoch release MUST NOT incur any additional detection across the upgrade. The migration MUST be logged.
+
+#### Scenario: Pre-epoch latch is preserved across the upgrade
+- **WHEN** the first epoch-aware build starts and finds a latched legacy record (build code present, no epoch key)
+- **THEN** the latch is rehydrated (scale starts BALANCED, no detection window)
+- **AND** the stored record is stamped with the current epoch
+- **AND** the one-time migration is logged
+
+#### Scenario: Migrated record then behaves epoch-scoped
+- **WHEN** a migrated record is read again on a later same-epoch build
+- **THEN** it rehydrates normally (it is now an ordinary epoch-stamped record, not re-migrated)
+
+### Requirement: Scale-Feed Stall Must Be Confirmed Before Latching
+
+The scale-feed-stall backstop SHALL distinguish a *suspected* stall from a *confirmed* stall. A gap exceeding the existing suspected threshold MUST still emit the existing suspected-stall signal (unchanged — observe logging and diagnostics rely on it) but MUST NOT by itself cause a backoff latch. The stall MUST only become confirmed — and thus eligible to latch in enforce mode and to be reported as the observe "would back off" — if the feed remains stalled past a larger persistence threshold AND no scale-feed recovery occurred since the suspected edge. A stall that recovers before confirmation MUST NOT latch. Confirmation MUST be evaluated event/edge-based on the existing DE1 shot-sample cadence and the recovery edge, with no timer. The DE1-fault-cluster trigger MUST be unchanged.
+
+#### Scenario: Transient stall self-recovers and never latches
+- **WHEN** the feed stalls past the suspected threshold and then a recovery occurs before the confirmation threshold
+- **THEN** the suspected-stall signal fired (observable) but no confirmed-stall signal fires
+- **AND** in enforce mode no latch / disconnect / reconnect occurs
+- **AND** in observe mode the suspected stall and the recovery are logged but no "would back off" is recorded
+
+#### Scenario: Sustained stall confirms and latches in enforce
+- **WHEN** the feed stalls past the suspected threshold and remains stalled past the confirmation threshold with no recovery
+- **THEN** a confirmed-stall signal fires
+- **AND** in enforce mode the backoff latches (skip-HIGH + reconnect at BALANCED) exactly as the prior single-stall path did, only later
+- **AND** in observe mode the suspected stall and then the confirmed "would back off" are recorded
+
+#### Scenario: DE1-fault cluster path unchanged
+- **WHEN** DE1-link faults cluster at the existing rate/window
+- **THEN** the existing cluster trigger fires unchanged (it is not subject to scale-feed-stall confirmation)
+
+#### Scenario: Capable hardware unaffected
+- **WHEN** the device never produces a sustained stall or a fault cluster
+- **THEN** it never latches, never re-detects, and its behavior is byte-identical to before this change regardless of epoch or confirmation

--- a/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/specs/mcp-server/spec.md
+++ b/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/specs/mcp-server/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Connection Status Reports Detection Epoch And Diagnostic Build Code
+
+The `devices_connection_status` tool SHALL report the current detection epoch and, when the scale link is latched, the build code that last set the classification as a diagnostic field. The build code MUST be presented as diagnostic ("last classified by build N"), not as the gating mechanism. Field names MUST follow the project MCP data conventions (human-readable, no Unix timestamps; the existing ISO-8601-with-offset latch timestamp is unchanged).
+
+#### Scenario: Epoch always reported
+- **WHEN** `devices_connection_status` is called
+- **THEN** the scale connection-priority block includes the current detection epoch
+
+#### Scenario: Diagnostic build code on a latched link
+- **WHEN** the scale link is latched (skip-HIGH)
+- **THEN** the response includes the build code that last set the classification, labeled as diagnostic
+- **AND** the response does not present the build code as the rehydration gate
+
+#### Scenario: Reset tool unchanged
+- **WHEN** `devices_reset_scale_priority` is called
+- **THEN** it clears the latch as before (the in-session escape hatch is unchanged by epoch scoping)

--- a/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/tasks.md
+++ b/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/tasks.md
@@ -48,3 +48,14 @@
 - [x] 8.2 Build via Qt Creator MCP (0 errors / 0 warnings). Full suite green — **46 suites / 2155 passed / 0 failed** (run from the Qt-Creator-built binaries; Qt Creator's Autotest plugin model was stale post-rebase and under-reported, so verified via the binaries directly: new test fns confirmed compiled in via `-functions`, binary newer than source).
 - [ ] 8.3 Maintainer device check (hardware-bound): on an epoch build, confirm an existing latched device migrates with no detection event; confirm a transient preheat blip logs suspected+recovered and does NOT latch; confirm a sustained dead feed confirms and latches; confirm `devices_connection_status` shows the epoch + diagnostic build code.
 - [x] 8.4 Document the epoch-bump procedure (one-line constant change + changelog note) next to `kBleDetectionEpoch` and in the change’s design as the deliberate global-reset lever.
+
+## PR #1220 review (5-agent) — addressed
+
+- [x] **Critical (active bug, 2 agents):** spike-rejection silently defeated CONFIRM. The confirm gap now measures from the frozen `m_feedStallStartMs` (spike-immune), not the spike-advanced `m_lastWallClockMs`; comment corrected. Regression test `confirmSurvivesSpikeRejectionDuringStall` (fails on old code, passes on fix).
+- [x] **Test gap Crit-9/8:** the rehydrate/migrate/discard trichotomy ("zero extra detection on upgrade") was only structurally implied. Extracted the pure `decideBleEpochGate()` (src/ble/bleepochgate.h, BlePriorityDetector-style header-only) and `setSettings()` now dispatches on it; 5 exhaustive `epochGate_*` tests lock the trichotomy + corrupt-negative without linking blemanager.cpp.
+- [x] **silent-failure #2:** only `-1` is the legacy sentinel; any other negative epoch is corrupt → Discard (re-detect) with a distinct warning, not silently honored.
+- [x] **type-design:** extracted `WeightProcessor::resetStallTracking()`; all reset sites call it — illegal `(confirmed && !stale)` now unreachable by construction, not by vigilance.
+- [x] **silent-failure #5:** `classifiedByBuildCode` is always emitted when latched (explicit "unknown (legacy/migrated/pre-buildcode)" string for buildCode 0) — no silent provenance black hole for the migrated population.
+- [x] **silent-failure #3/#4:** symmetric warning when the persisted trigger-kind is salvaged (mirrors the set-time anomaly log); legacy-migration log reworded to not over-claim persistence (states the in-memory latch is live regardless; flags repeat-next-launch if the stamp fails).
+- [~] **pr-test preheat/retare coverage:** added `confirmWorksInPreheatContext`; `resetForRetare` confirmed-reset is now covered-by-construction via the single `resetStallTracking()` chokepoint + existing recovery/re-arm tests.
+- [x] Build via Qt Creator 0/0; full suite **47 suites / 2166 passed / 0 failed** (direct binaries — Qt Creator Autotest model unreliable post-reconfigure, see TESTING note).

--- a/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/tasks.md
+++ b/openspec/changes/scale-priority-epoch-scope-and-stall-confirm/tasks.md
@@ -1,0 +1,50 @@
+> Two arms. **Arm 1 (epoch scoping)** is independent of #1219 and can land first. **Arm 3 (stall confirmation)** consumes `scaleFeedResumed` + the detector/transport observe plumbing from #1219 — implement stacked on `feat/scale-priority-backoff-observe-mode` (or rebase after it merges). Capable-hardware byte-identical is a hard invariant for both.
+
+## 1. Arm 1 — epoch constant + persistence
+
+- [x] 1.1 Add `kBleDetectionEpoch` (int, =1) to a deliberately-edited BLE constants header (NOT `versioncode.txt`/`versionCode`-derived; NOT CI-touched). Document next to it: bump only when a build changes BLE connection behavior or to re-classify every device once on that release — the deliberate global-reset lever replacing the accidental per-build reset.
+- [x] 1.2 `settings_hardware.{h,cpp}`: add `int cpEpoch() const` reading `connectionPriority/detectionEpoch` (absent ⇒ sentinel meaning "legacy / no epoch", e.g. -1); extend `setConnectionPriorityLatch(...)` to also write `detectionEpoch`. Keep `cpBuildCode()` + the `buildCode` write as diagnostic-only. (`clearConnectionPriorityLatch()` four-key narrowing already landed in #1219 — confirm it also leaves `detectionEpoch` consistent, i.e. clear removes the epoch key too so a cleared record is fully fresh.)
+
+## 2. Arm 1 — BLEManager gate + forward migration
+
+- [x] 2.1 `BLEManager::setSettings()`: replace the `storedBuild == versionCode()` gate with `storedEpoch == kBleDetectionEpoch`. Same safety-valve mechanics otherwise (rehydrate vs `clearConnectionPriorityLatch()` + re-detect). Keep reading/logging `buildCode` as diagnostic.
+- [x] 2.2 Legacy forward-migration: if `cpLatched()` and a `buildCode` is present but `cpEpoch()` is the "no epoch" sentinel ⇒ rehydrate the in-memory latch AND write `detectionEpoch = kBleDetectionEpoch` (one-time), and `qWarning`-log the migration. A fresh record whose epoch simply mismatches is discarded + re-detected (unchanged-from-today semantics, just epoch-keyed).
+- [x] 2.3 `latchScaleSkipHighPriority()`: persist `detectionEpoch = kBleDetectionEpoch` alongside the existing latch metadata.
+- [x] 2.4 Confirm capable hardware never reaches any of this (no latch ⇒ no rehydrate/migrate path); no behavior change when unlatched.
+
+## 3. Arm 1 — MCP read
+
+- [x] 3.1 `devices_connection_status`: add the current detection epoch (always) and, when latched, the diagnostic build code labeled as "last classified by build N" (explicitly not the gate). Follow CLAUDE.md MCP conventions; do not alter the existing ISO-8601 latch timestamp fields.
+
+## 4. Arm 1 — tests
+
+- [x] 4.1 `tst_scaleskiphighlatch` (header/QtCore-only pattern): epoch round-trips; same-epoch ⇒ rehydrate; different-epoch ⇒ discard; build code differs but epoch matches ⇒ still rehydrate.
+- [x] 4.2 Legacy-record forward migration: latched + buildCode + no epoch key ⇒ rehydrated AND epoch stamped AND logged; re-read on a later same-epoch run ⇒ ordinary rehydrate (not re-migrated). Zero-extra-detection asserted at the settings/manager layer.
+- [x] 4.3 `clearConnectionPriorityLatch()` leaves no stale epoch (cleared record is fully fresh: `cpLatched()` false, `cpEpoch()` sentinel).
+
+## 5. Arm 3 — WeightProcessor suspected→confirmed
+
+- [x] 5.1 Add `kScaleStallConfirmMs` (single tunable constant; provisional ~5–6 s, final value set by task 8.1 from #1219 field data). Keep `kScaleStaleMs` (2 s) as the suspected threshold.
+- [x] 5.2 `checkScaleFeedStall()` (on the existing DE1 `setCurrentFrame` tick — NO timer): first crossing of `kScaleStaleMs` ⇒ suspected (emit existing `scaleFeedStalled(gapMs)` exactly as today; observe logging unchanged). When the gap further crosses `kScaleStallConfirmMs` and no recovery has occurred since the suspected edge ⇒ emit new `scaleFeedStallConfirmed(qint64 gapMs)` once.
+- [x] 5.3 Recovery cancels: a `scaleFeedResumed` (the #1219 edge) between suspected and confirmed clears the pending-confirmation state so confirmed never fires for that episode; a later independent stall re-arms suspected cleanly. Reset pending-confirmation on the existing extraction/cycle resets too.
+- [x] 5.4 Declare `scaleFeedStallConfirmed(qint64 gapMs)` in `weightprocessor.h`; confirm SAW/flow/frame-exit paths untouched (pure observation, like `scaleFeedStalled`/`scaleFeedResumed`).
+
+## 6. Arm 3 — detector/transport act on confirmed only
+
+- [x] 6.1 `scalebletransport.h`/`qtscalebletransport.{h,cpp}`: add `onScaleFeedStallConfirmed(qint64 gapMs)` (base no-op virtual, mirroring `onScaleFeedStalled`/`onScaleFeedResumed`). Enforce calls `m_priority.onScaleStall()` ONLY from the confirmed handler; the suspected `onScaleFeedStalled` handler no longer drives the backoff (it remains the observe/diagnostic log path + the "disarmed detector" log).
+- [x] 6.2 Observe mode: log the full picture — suspected stall (existing), recovery (existing #1219), and confirmed = the real "would back off" (record the observe event on confirmed, not suspected). Update `logWouldBackoff` call site accordingly.
+- [x] 6.3 `main.cpp`: wire `WeightProcessor::scaleFeedStallConfirmed` → `ScaleBleTransport::onScaleFeedStallConfirmed` cross-thread `Qt::QueuedConnection`, mirroring the `scaleFeedStalled`/`scaleFeedResumed` wiring + threading comment.
+- [x] 6.4 `BlePriorityDetector` unchanged in logic (still single-shot on `onScaleStall()`); the *confirmation* lives upstream in WeightProcessor. Verify the DE1-fault path (`onDe1Fault`, ≥2/`kDe1FaultWindowMs`) is byte-identical.
+
+## 7. Arm 3 — tests
+
+- [x] 7.1 `tst_weightprocessor`: suspected fires at `kScaleStaleMs` with correct gap; confirmed fires only after `kScaleStallConfirmMs` with no recovery; `scaleFeedResumed` before the confirm threshold cancels (no confirmed); a later independent stall re-arms; SAW/flow/frame byte-identical with/without the new signal.
+- [~] 7.2 **Covered by existing + construction.** Detector (`BlePriorityDetector`) is UNCHANGED here — confirmation lives upstream in WeightProcessor; existing `tst_scaleblepriority` DE1-fault/capable tests stay green and pin byte-identical. "Enforce latches only on confirmed" is asserted at the WeightProcessor layer (7.1: confirmed only fires post-persistence, recovery cancels) + the transport now calls `onScaleStall()` solely from `onScaleFeedStallConfirmed`; the transport routing seam itself is the same `QLowEnergyController`-bound seam #1219 deferred to the device check (8.3).
+- [~] 7.3 **Deferred to device check (8.3), same seam as #1219.** The observe log/ring behavior (suspected+recovered→no would-backoff; suspected→confirmed→would-backoff) is transport-level and not unit-harnessable; the WeightProcessor signal ordering it derives from IS unit-tested (7.1).
+
+## 8. Calibration + verification
+
+- [~] 8.1 **Gate (deferred to maintainer, by design):** finalize `kScaleStallConfirmMs` from #1219 observe-mode field data (the recovered-gap distribution: pick a threshold cleanly above the transient self-recovery cluster and below genuine sustained stalls). Record the chosen value + rationale here; do not guess-ship.
+- [x] 8.2 Build via Qt Creator MCP (0 errors / 0 warnings). Full suite green — **46 suites / 2155 passed / 0 failed** (run from the Qt-Creator-built binaries; Qt Creator's Autotest plugin model was stale post-rebase and under-reported, so verified via the binaries directly: new test fns confirmed compiled in via `-functions`, binary newer than source).
+- [ ] 8.3 Maintainer device check (hardware-bound): on an epoch build, confirm an existing latched device migrates with no detection event; confirm a transient preheat blip logs suspected+recovered and does NOT latch; confirm a sustained dead feed confirms and latches; confirm `devices_connection_status` shows the epoch + diagnostic build code.
+- [x] 8.4 Document the epoch-bump procedure (one-line constant change + changelog note) next to `kBleDetectionEpoch` and in the change’s design as the deliberate global-reset lever.

--- a/src/ble/bleepochgate.h
+++ b/src/ble/bleepochgate.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// Pure, Qt-free decision logic for the connection-priority EPOCH gate
+// (scale-priority-epoch-scope-and-stall-confirm). BLEManager::setSettings()
+// forwards the persisted record's latched flag + stored detectionEpoch and
+// the compile-time kBleDetectionEpoch here, then performs the side effects
+// (rehydrate / re-persist / clear + log) for the returned decision.
+//
+// Header-only and dependency-free ON PURPOSE: the full rehydrate / migrate /
+// discard trichotomy — including the "legacy record migrates forward with
+// ZERO extra detection" backward-compat guarantee — is then unit-testable
+// without linking the heavy BLEManager translation unit (mirrors the
+// BlePriorityDetector pure-logic pattern).
+
+enum class BleEpochDecision {
+    NoRecord,        // not latched — nothing to rehydrate
+    Rehydrate,       // stored epoch == current → load the latch as-is
+    MigrateForward,  // legacy pre-epoch record (epoch key absent) → honor + stamp current
+    Discard          // a DIFFERENT epoch (deliberate bump) OR a corrupt value → wipe + re-detect
+};
+
+// `storedEpoch` is SettingsHardware::cpEpoch(): the persisted detectionEpoch,
+// or -1 when the key is absent (a genuine pre-epoch / legacy record).
+//
+// Only EXACTLY -1 means "legacy". Any OTHER negative is corrupt persisted
+// input (partial/truncated write, manual edit, format drift) and is treated
+// as Discard → re-detect, NOT silently honored as a clean legacy latch (which
+// would suppress the very re-detection the safety design intends and log a
+// reassuring-but-false "migrated legacy forward"). `kBleDetectionEpoch` is a
+// hand-assigned positive constant (never 0/negative, never versionCode), so
+// the partition below is total and unambiguous for every int.
+inline BleEpochDecision decideBleEpochGate(bool latched, int storedEpoch,
+                                           int currentEpoch) {
+    if (!latched) return BleEpochDecision::NoRecord;
+    if (storedEpoch == currentEpoch) return BleEpochDecision::Rehydrate;
+    if (storedEpoch == -1) return BleEpochDecision::MigrateForward;
+    return BleEpochDecision::Discard;  // other epoch (bump) OR corrupt (incl. <0, !=-1)
+}

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -5,6 +5,7 @@
 #include "scales/scalefactory.h"
 #include "refractometers/difluidr2.h"
 #include "../core/settings_hardware.h"
+#include "bleepochgate.h"
 #include "version.h"
 #include <QBluetoothLocalDevice>
 #include <QBluetoothUuid>
@@ -155,25 +156,38 @@ void BLEManager::setSettings(SettingsHardware* settings)
     const int storedEpoch = m_settings->cpEpoch();   // -1 ⇒ legacy (no key)
     const int storedBuild = m_settings->cpBuildCode(); // diagnostic only now
 
-    if (storedEpoch >= 0 && storedEpoch != kBleDetectionEpoch) {
-        // A DELIBERATE epoch bump shipped (e.g. a release that changed BLE
-        // handling or intentionally re-classifies everyone). This is now the
-        // ONLY auto-wipe path — it fires only on an intentional epoch change,
-        // NOT on every build. Discard + re-detect from scratch.
+    const BleEpochDecision decision =
+        decideBleEpochGate(true, storedEpoch, kBleDetectionEpoch);
+
+    if (decision == BleEpochDecision::Discard) {
+        // Either a DELIBERATE epoch bump (a release that changed BLE handling
+        // / re-classifies everyone) OR a corrupt persisted epoch. This is the
+        // ONLY auto-wipe path — it fires only on an intentional epoch change
+        // or genuine corruption, NOT on every build. Discard + re-detect.
         m_settings->clearConnectionPriorityLatch();
-        qWarning().noquote()
-            << QStringLiteral("[BLE] Persisted connection-priority "
-                  "classification was set under detection epoch %1 but this "
-                  "build is epoch %2 — discarding and re-detecting from "
-                  "scratch (deliberate epoch reset)")
-                   .arg(storedEpoch).arg(kBleDetectionEpoch);
+        if (storedEpoch >= 0) {
+            qWarning().noquote()
+                << QStringLiteral("[BLE] Persisted connection-priority "
+                      "classification was set under detection epoch %1 but "
+                      "this build is epoch %2 — discarding and re-detecting "
+                      "from scratch (deliberate epoch reset)")
+                       .arg(storedEpoch).arg(kBleDetectionEpoch);
+        } else {
+            // Negative but not the -1 "no key" sentinel ⇒ corrupt record.
+            qWarning().noquote()
+                << QStringLiteral("[BLE] Persisted connection-priority "
+                      "detection epoch is corrupt/unrecognized (stored=%1, "
+                      "expected %2 or absent) — discarding and re-detecting "
+                      "from scratch rather than honoring a damaged record")
+                       .arg(storedEpoch).arg(kBleDetectionEpoch);
+        }
         return;
     }
 
-    // storedEpoch == kBleDetectionEpoch (ordinary same-epoch rehydrate) OR
-    // storedEpoch < 0 (a legacy pre-epoch record → honor + migrate forward,
+    // Rehydrate (storedEpoch == kBleDetectionEpoch) OR MigrateForward (a
+    // legacy pre-epoch record, epoch key absent → honor + stamp forward,
     // ZERO extra detection on the upgrade that introduces epoch scoping).
-    const bool legacy = (storedEpoch < 0);
+    const bool legacy = (decision == BleEpochDecision::MigrateForward);
 
     // rehydrate() preserves the ORIGINAL set-time (unlike set(), which would
     // re-stamp it) and sanitises possibly-corrupt persisted input so the
@@ -182,10 +196,21 @@ void BLEManager::setSettings(SettingsHardware* settings)
     // returns false iff the stored timestamp was invalid and had to be
     // substituted — log that anomaly.
     const QString isoIn = m_settings->cpSetTimeIso();
+    const QString kindIn = m_settings->cpTriggerKind();
     const bool timeOk = m_scaleSkipHigh.rehydrate(
-        m_settings->cpTriggerKind(),
-        QDateTime::fromString(isoIn, Qt::ISODate));
+        kindIn, QDateTime::fromString(isoIn, Qt::ISODate));
     m_scaleSkipHighBuildCode = storedBuild;  // diagnostic ("classified by N")
+    if (kindIn.isEmpty()) {
+        // Symmetric with the !timeOk anomaly below: a missing trigger kind is
+        // also corruption (partial write / manual edit). rehydrate() salvaged
+        // it to "unknown" — surface that so the MCP "unknown"-kind latch isn't
+        // mistaken for a genuine unknown-cause classification with no trail.
+        qWarning().noquote()
+            << QStringLiteral("[BLE] Persisted connection-priority trigger "
+                  "kind was missing/empty — salvaged to \"%1\"; classification "
+                  "kept (it is the load-bearing fact)")
+                   .arg(m_scaleSkipHigh.triggerKind);
+    }
     qWarning().noquote()
         << QStringLiteral("[BLE] Loaded persisted dual-HIGH-incapable "
               "classification (epoch %1, build %2 [diagnostic], trigger=%3) — "
@@ -211,10 +236,12 @@ void BLEManager::setSettings(SettingsHardware* settings)
             m_scaleSkipHigh.setTime.toString(Qt::ISODate),
             storedBuild, kBleDetectionEpoch);
         qWarning().noquote()
-            << QStringLiteral("[BLE] Migrated a legacy (pre-epoch) "
-                  "connection-priority record forward to detection epoch %1 — "
-                  "the device was already classified, so NO re-detection is "
-                  "incurred (the old per-build reset is gone)")
+            << QStringLiteral("[BLE] Legacy (pre-epoch) connection-priority "
+                  "record honored; stamping detection epoch %1. NO re-detection "
+                  "is incurred regardless (the in-memory latch is already live "
+                  "— BALANCED this run). If a 'Failed to PERSIST' warning "
+                  "follows, the stamp did not stick and this line will repeat "
+                  "next launch (still no re-detection — cosmetic only)")
                    .arg(kBleDetectionEpoch);
     }
 }

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -152,43 +152,70 @@ void BLEManager::setSettings(SettingsHardware* settings)
 
     if (!m_settings->cpLatched()) return;
 
-    const int storedBuild = m_settings->cpBuildCode();
-    if (storedBuild == versionCode()) {
-        // Same build → rehydrate the in-memory latch from the persisted
-        // record. rehydrate() preserves the ORIGINAL set-time (unlike set(),
-        // which would re-stamp it) and sanitises possibly-corrupt persisted
-        // input so the ScaleSkipHighLatch invariant ("kind non-empty AND time
-        // valid IFF latched") holds even on a partial write / manual edit /
-        // ISO-format drift. It returns false iff the stored timestamp was
-        // invalid and had to be substituted — log that anomaly (otherwise the
-        // MCP read would silently show a latched device with no set-time and
-        // no debug trail explaining why).
-        const QString isoIn = m_settings->cpSetTimeIso();
-        const bool timeOk = m_scaleSkipHigh.rehydrate(
-            m_settings->cpTriggerKind(),
-            QDateTime::fromString(isoIn, Qt::ISODate));
-        qWarning().noquote()
-            << QStringLiteral("[BLE] Loaded persisted dual-HIGH-incapable "
-                  "classification (build %1, trigger=%2) — BOTH BLE links "
-                  "will start at BALANCED this run (no detection window)")
-                   .arg(storedBuild).arg(m_scaleSkipHigh.triggerKind);
-        if (!timeOk) {
-            qWarning().noquote()
-                << QStringLiteral("[BLE] Persisted connection-priority set-time "
-                      "was invalid/missing (stored=\"%1\") — substituted "
-                      "current time; classification kept (it is the "
-                      "load-bearing fact)").arg(isoIn);
-        }
-    } else {
-        // Build changed → the build-scoped safety valve: discard + wipe so a
-        // (possibly mis-classified) device re-detects from scratch on every
-        // new build. MCP reset is the in-session escape hatch within a build.
+    const int storedEpoch = m_settings->cpEpoch();   // -1 ⇒ legacy (no key)
+    const int storedBuild = m_settings->cpBuildCode(); // diagnostic only now
+
+    if (storedEpoch >= 0 && storedEpoch != kBleDetectionEpoch) {
+        // A DELIBERATE epoch bump shipped (e.g. a release that changed BLE
+        // handling or intentionally re-classifies everyone). This is now the
+        // ONLY auto-wipe path — it fires only on an intentional epoch change,
+        // NOT on every build. Discard + re-detect from scratch.
         m_settings->clearConnectionPriorityLatch();
         qWarning().noquote()
             << QStringLiteral("[BLE] Persisted connection-priority "
-                  "classification was set by build %1 but this is build %2 — "
-                  "discarding and re-detecting from scratch (build-scoped "
-                  "safety valve)").arg(storedBuild).arg(versionCode());
+                  "classification was set under detection epoch %1 but this "
+                  "build is epoch %2 — discarding and re-detecting from "
+                  "scratch (deliberate epoch reset)")
+                   .arg(storedEpoch).arg(kBleDetectionEpoch);
+        return;
+    }
+
+    // storedEpoch == kBleDetectionEpoch (ordinary same-epoch rehydrate) OR
+    // storedEpoch < 0 (a legacy pre-epoch record → honor + migrate forward,
+    // ZERO extra detection on the upgrade that introduces epoch scoping).
+    const bool legacy = (storedEpoch < 0);
+
+    // rehydrate() preserves the ORIGINAL set-time (unlike set(), which would
+    // re-stamp it) and sanitises possibly-corrupt persisted input so the
+    // ScaleSkipHighLatch invariant ("kind non-empty AND time valid IFF
+    // latched") holds even on a partial write / manual edit / ISO drift. It
+    // returns false iff the stored timestamp was invalid and had to be
+    // substituted — log that anomaly.
+    const QString isoIn = m_settings->cpSetTimeIso();
+    const bool timeOk = m_scaleSkipHigh.rehydrate(
+        m_settings->cpTriggerKind(),
+        QDateTime::fromString(isoIn, Qt::ISODate));
+    m_scaleSkipHighBuildCode = storedBuild;  // diagnostic ("classified by N")
+    qWarning().noquote()
+        << QStringLiteral("[BLE] Loaded persisted dual-HIGH-incapable "
+              "classification (epoch %1, build %2 [diagnostic], trigger=%3) — "
+              "BOTH BLE links will start at BALANCED this run (no detection "
+              "window)")
+               .arg(legacy ? kBleDetectionEpoch : storedEpoch)
+               .arg(storedBuild).arg(m_scaleSkipHigh.triggerKind);
+    if (!timeOk) {
+        qWarning().noquote()
+            << QStringLiteral("[BLE] Persisted connection-priority set-time "
+                  "was invalid/missing (stored=\"%1\") — substituted current "
+                  "time; classification kept (it is the load-bearing fact)")
+                   .arg(isoIn);
+    }
+
+    if (legacy) {
+        // One-time forward migration: stamp the current epoch so subsequent
+        // same-epoch builds rehydrate normally (and are never re-migrated).
+        // Persist from the now-sanitised in-memory latch (keeps the
+        // invariant); keep the original buildCode as the diagnostic.
+        m_settings->setConnectionPriorityLatch(
+            m_scaleSkipHigh.triggerKind,
+            m_scaleSkipHigh.setTime.toString(Qt::ISODate),
+            storedBuild, kBleDetectionEpoch);
+        qWarning().noquote()
+            << QStringLiteral("[BLE] Migrated a legacy (pre-epoch) "
+                  "connection-priority record forward to detection epoch %1 — "
+                  "the device was already classified, so NO re-detection is "
+                  "incurred (the old per-build reset is gone)")
+                   .arg(kBleDetectionEpoch);
     }
 }
 
@@ -196,13 +223,16 @@ void BLEManager::latchScaleSkipHighPriority(const QString& triggerKind)
 {
     // The value type enforces "kind+time set iff latched".
     m_scaleSkipHigh.set(triggerKind);
-    // D9: write through so the classification survives restarts of THIS
-    // build (build-scoped — a new build re-detects via setSettings()).
+    m_scaleSkipHighBuildCode = versionCode();  // diagnostic ("classified by N")
+    // Write through so the classification survives restarts. Now EPOCH-scoped:
+    // it persists across all builds sharing kBleDetectionEpoch; versionCode()
+    // is stored only as a diagnostic ("last classified by build N"), no
+    // longer the rehydrate gate.
     if (m_settings) {
         m_settings->setConnectionPriorityLatch(
             m_scaleSkipHigh.triggerKind,
             m_scaleSkipHigh.setTime.toString(Qt::ISODate),
-            versionCode());
+            versionCode(), kBleDetectionEpoch);
     }
 }
 
@@ -210,6 +240,7 @@ void BLEManager::clearScaleSkipHighPriority()
 {
     const bool wasLatched = m_scaleSkipHigh.latched;
     m_scaleSkipHigh.clear();
+    m_scaleSkipHighBuildCode = 0;  // diagnostic cleared with the latch
     // D9: clear the persisted record too (idempotent — safe even if the
     // in-memory latch was already clear).
     if (m_settings) m_settings->clearConnectionPriorityLatch();

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -130,7 +130,7 @@ public:
         // on a partial write / manual edit / format drift: an empty kind
         // becomes "unknown"; an invalid time falls back to now (the
         // classification is the load-bearing fact — do NOT discard a valid
-        // same-build latch over a bad diagnostic timestamp). Returns false iff
+        // same-epoch/legacy latch over a bad diagnostic timestamp). Returns false iff
         // the time had to be substituted, so the caller can log the anomaly.
         bool rehydrate(const QString& kind, const QDateTime& time) {
             latched = true;
@@ -144,11 +144,15 @@ public:
 
     // --- BLE detection epoch (scale-priority-epoch-scope-and-stall-confirm) ---
     // The persisted dual-HIGH-incapable classification is scoped to THIS
-    // constant, NOT to versionCode/build. BLEManager rehydrates a persisted
-    // latch iff its stored epoch == kBleDetectionEpoch, otherwise it discards
-    // and re-detects. CI / versioncode.txt MUST NOT touch this — it is the
-    // single, deliberate "re-classify every device once on this release"
-    // lever (replaces the old accidental per-build reset).
+    // constant, NOT to versionCode/build. The gate (decideBleEpochGate, the
+    // function setSettings dispatches on) is a trichotomy, NOT a biconditional:
+    //   • stored epoch == kBleDetectionEpoch        → rehydrate
+    //   • legacy record (no epoch key; cpEpoch -1)  → rehydrate + migrate fwd
+    //   • a DIFFERENT non-negative epoch, or corrupt → discard + re-detect
+    // i.e. a legacy record is rehydrated, NOT discarded — discard happens
+    // only on a deliberate epoch bump (or corruption). CI / versioncode.txt
+    // MUST NOT touch this — it is the single, deliberate "re-classify every
+    // device once on this release" lever (replaces the old per-build reset).
     //
     // BUMP THIS (by one) ONLY when a release intentionally changes BLE
     // connection behaviour (connection parameters / priority handling) OR you

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -142,6 +142,22 @@ public:
         void clear() { latched = false; triggerKind.clear(); setTime = QDateTime(); }
     };
 
+    // --- BLE detection epoch (scale-priority-epoch-scope-and-stall-confirm) ---
+    // The persisted dual-HIGH-incapable classification is scoped to THIS
+    // constant, NOT to versionCode/build. BLEManager rehydrates a persisted
+    // latch iff its stored epoch == kBleDetectionEpoch, otherwise it discards
+    // and re-detects. CI / versioncode.txt MUST NOT touch this — it is the
+    // single, deliberate "re-classify every device once on this release"
+    // lever (replaces the old accidental per-build reset).
+    //
+    // BUMP THIS (by one) ONLY when a release intentionally changes BLE
+    // connection behaviour (connection parameters / priority handling) OR you
+    // explicitly want every device to re-run detection once on that release.
+    // Bumping it on a release that fixes the dual-HIGH contention is how the
+    // fix reaches already-latched devices. A legacy pre-epoch record (no
+    // stored epoch) is migrated forward, NOT re-detected (see setSettings).
+    static constexpr int kBleDetectionEpoch = 1;
+
     bool scaleSkipHighPriority() const { return m_scaleSkipHigh.latched; }
     // Latch the skip-HIGH decision with a mandatory trigger kind (no default —
     // "latch without a reason" is a compile error, not a silent "unknown").
@@ -154,6 +170,10 @@ public:
     void clearScaleSkipHighPriority();
     QString scaleSkipHighTriggerKind() const { return m_scaleSkipHigh.triggerKind; }
     QDateTime scaleSkipHighSetTime() const { return m_scaleSkipHigh.setTime; }
+    // Diagnostic only (NOT a gate): the versionCode that last set/rehydrated
+    // the current latch. 0 when not latched. Surfaced in the MCP read so the
+    // "last classified by build N" trail survives the build→epoch demotion.
+    int scaleSkipHighBuildCode() const { return m_scaleSkipHighBuildCode; }
     QDateTime appStartTime() const { return m_appStartTime; }
 
     // --- Backoff policy mode (observe-mode change) ---
@@ -376,6 +396,10 @@ private:
     // (process start) so the MCP read can report "elapsed since app start" —
     // intentionally separate from the latch value (different lifetime).
     ScaleSkipHighLatch m_scaleSkipHigh;
+    // Diagnostic: versionCode that last set/rehydrated the latch (0 = none).
+    // NOT part of the invariant-bearing latch struct (it is informational and
+    // no longer the gate — the epoch is). Set on latch/rehydrate, 0 on clear.
+    int m_scaleSkipHighBuildCode = 0;
     QDateTime m_appStartTime;
     // Backoff policy mode (observe-mode change). Loaded from SettingsHardware
     // in setSettings() (not build-scoped); default Enforce until then.

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -344,14 +344,27 @@ void QtScaleBleTransport::onDe1LinkFault(const QString& kind) {
 }
 
 void QtScaleBleTransport::onScaleFeedStalled(qint64 gapMs) {
-    // Backstop: covers sessions where the DE1 cluster never appears early and
-    // the scale silently stalls mid-shot (the actual #1176 shot-1151 case).
+    // SUSPECTED stall only — this no longer drives the backoff (a transient
+    // blip that self-recovers must NOT latch). It is the observe/diagnostic
+    // breadcrumb; the latch trigger is onScaleFeedStallConfirmed below. The
+    // WeightProcessor already qWarns the suspected edge; in observe add an
+    // explicit line so the field log shows "watching, not yet acted".
+    if (m_priority.observing()) {
+        warn(QStringLiteral("[observe] SUSPECTED scale-feed stall (silent "
+             "%1 s) — watching for confirmation; no action, link stays HIGH")
+             .arg(gapMs / 1000.0, 0, 'f', 1));
+    }
+}
+
+void QtScaleBleTransport::onScaleFeedStallConfirmed(qint64 gapMs) {
+    // CONFIRMED stall — persisted past kScaleStallConfirmMs with no recovery
+    // (the transient/false shape never reaches here). THIS is the real
+    // backstop trigger (the actual #1176 shot-1151 case is a sustained dead
+    // feed, which confirms).
     if (m_priority.onScaleStall()) {
-        // Covers an in-shot stall AND a pre-shot EspressoPreheating stall —
-        // both surface here as the scale-feed-stall trigger kind.
         const QString reason = QStringLiteral(
-            "scale weight feed stalled while weight expected "
-            "(extraction/preheat) at HIGH");
+            "scale weight feed stall CONFIRMED (sustained, no recovery) while "
+            "weight expected (extraction/preheat) at HIGH");
         if (m_priority.observing())
             logWouldBackoff(reason, QStringLiteral("scale-feed-stall"),
                             gapMs / 1000.0);
@@ -359,24 +372,27 @@ void QtScaleBleTransport::onScaleFeedStalled(qint64 gapMs) {
             triggerScaleBackoff(qPrintable(reason),
                                 QStringLiteral("scale-feed-stall"));
     } else {
-        // Stall observed but the detector took no action (already latched /
-        // backed off, or the scale is not at HIGH so detection is disarmed).
-        // Log it — the single field debug.log must never silently swallow a
-        // stall signal (this is exactly what we want to see when triaging a
+        // Confirmed stall observed but the detector took no action (already
+        // latched / backed off, or the scale is not at HIGH so detection is
+        // disarmed). Log it — the single field debug.log must never silently
+        // swallow a confirmed stall (exactly what we want when triaging a
         // "still no weight" report on an already-backed-off run).
-        log("scale weight feed stall observed but connection-priority detector "
-            "is disarmed (already latched / not at HIGH) — no backoff taken");
+        log("confirmed scale-feed stall observed but connection-priority "
+            "detector is disarmed (already latched / not at HIGH) — no "
+            "backoff taken");
     }
 }
 
 void QtScaleBleTransport::onScaleFeedResumed(qint64 gapMs) {
-    // Observe-only recovery evidence: a feed that had stalled came back on
-    // its own at HIGH (no backoff was taken). Silent in enforce mode (the
-    // reconnect is the structural confirmation there).
+    // Observe-only recovery evidence: a SUSPECTED stall came back on its own
+    // before it could confirm — so with confirmation it would NOT have backed
+    // off. Recording the recovered gap here is also the calibration data for
+    // kScaleStallConfirmMs. Silent in enforce (no action was pending anyway).
     if (!m_priority.observing()) return;
     const double gapSec = gapMs / 1000.0;
     warn(QStringLiteral("[observe] scale feed RESUMED after %1 s — "
-         "would-have-been-backoff recovered on its own at HIGH (no action taken)")
+         "self-recovered before confirmation; would NOT have backed off "
+         "(no action, link stays HIGH)")
          .arg(gapSec, 0, 'f', 1));
     if (auto* mgr = BLEManager::instance())
         mgr->recordObserveEvent(BLEManager::ObserveEvent::recovered(

--- a/src/ble/transport/qtscalebletransport.h
+++ b/src/ble/transport/qtscalebletransport.h
@@ -45,6 +45,7 @@ public slots:
     // backoff. No-ops once backed off or when starting at BALANCED.
     void onDe1LinkFault(const QString& kind) override;
     void onScaleFeedStalled(qint64 gapMs) override;
+    void onScaleFeedStallConfirmed(qint64 gapMs) override;
     void onScaleFeedResumed(qint64 gapMs) override;
 
 private slots:

--- a/src/ble/transport/scalebletransport.h
+++ b/src/ble/transport/scalebletransport.h
@@ -116,9 +116,15 @@ public slots:
      * self-reconnect backoff. Scale-agnostic — no driver code involved.
      */
     virtual void onDe1LinkFault(const QString& kind) { Q_UNUSED(kind); }
-    // `gapMs`: how long the feed had been silent at detection. enforce-mode
-    // handlers ignore it (behavior unchanged); observe mode logs it.
+    // SUSPECTED stall (gap > kScaleStaleMs). `gapMs` = silence at detection.
+    // No longer drives the backoff — it is the observe/diagnostic breadcrumb;
+    // the latch trigger is onScaleFeedStallConfirmed. Default no-op.
     virtual void onScaleFeedStalled(qint64 gapMs) { Q_UNUSED(gapMs); }
+    // CONFIRMED stall (epoch-scope-and-stall-confirm): persisted past
+    // kScaleStallConfirmMs with no recovery. THIS is what enforce latches on
+    // and what observe records as the real "would back off". Default no-op;
+    // only QtScaleBleTransport acts.
+    virtual void onScaleFeedStallConfirmed(qint64 gapMs) { Q_UNUSED(gapMs); }
     // Recovery counterpart (observe-mode change): a previously-stalled feed
     // resumed on its own. `gapMs` is the measured silent duration. Default
     // no-op; only QtScaleBleTransport logs it (observe mode).

--- a/src/core/settings_hardware.cpp
+++ b/src/core/settings_hardware.cpp
@@ -113,13 +113,23 @@ int SettingsHardware::cpBuildCode() const {
     return m_settings.value("connectionPriority/buildCode", 0).toInt();
 }
 
+int SettingsHardware::cpEpoch() const {
+    // -1 sentinel ⇒ no detectionEpoch key was ever written: a legacy
+    // (pre-epoch) record. BLEManager honors + migrates such a record forward
+    // exactly once rather than discarding it (zero extra detection on the
+    // upgrade that introduces epoch scoping).
+    return m_settings.value("connectionPriority/detectionEpoch", -1).toInt();
+}
+
 void SettingsHardware::setConnectionPriorityLatch(const QString& triggerKind,
                                                   const QString& setTimeIso,
-                                                  int buildCode) {
+                                                  int buildCode,
+                                                  int detectionEpoch) {
     m_settings.setValue("connectionPriority/latched", true);
     m_settings.setValue("connectionPriority/triggerKind", triggerKind);
     m_settings.setValue("connectionPriority/setTimeIso", setTimeIso);
     m_settings.setValue("connectionPriority/buildCode", buildCode);
+    m_settings.setValue("connectionPriority/detectionEpoch", detectionEpoch);
     // QSettings::setValue is fire-and-forget (no return, no throw). On
     // read-only storage / full disk the write silently drops and the
     // classification degrades to in-memory-only (re-detects next run) — which
@@ -137,16 +147,18 @@ void SettingsHardware::setConnectionPriorityLatch(const QString& triggerKind,
 }
 
 void SettingsHardware::clearConnectionPriorityLatch() {
-    // Remove ONLY the four latch sub-keys (not the whole "connectionPriority"
-    // group): a sibling key — connectionPriority/policyMode — must survive a
-    // latch clear (MCP reset / new-build re-detect), since the policy mode is
-    // an explicit operator choice with a different (non-build-scoped) lifetime.
-    // Removing the group would silently wipe the mode. Each absent latch key
-    // then defaults correctly (cpLatched() ⇒ false, etc.).
+    // Remove ONLY the latch sub-keys (latched/triggerKind/setTimeIso/
+    // buildCode/detectionEpoch) — NOT the whole "connectionPriority" group:
+    // the sibling connectionPriority/policyMode must survive a latch clear
+    // (MCP reset / epoch re-detect), since the policy mode is an explicit
+    // operator choice with a different lifetime. Removing the group would
+    // silently wipe the mode. A cleared record is fully fresh — each absent
+    // key defaults correctly (cpLatched() ⇒ false, cpEpoch() ⇒ -1, etc.).
     m_settings.remove("connectionPriority/latched");
     m_settings.remove("connectionPriority/triggerKind");
     m_settings.remove("connectionPriority/setTimeIso");
     m_settings.remove("connectionPriority/buildCode");
+    m_settings.remove("connectionPriority/detectionEpoch");
 }
 
 QString SettingsHardware::cpMode() const {

--- a/src/core/settings_hardware.h
+++ b/src/core/settings_hardware.h
@@ -43,16 +43,22 @@ public:
     // --- Connection-priority weak-device classification (D9, #1093/#1176) ---
     // INTERNAL: deliberately NOT a Q_PROPERTY, no NOTIFY, no QML/Settings-UI
     // binding (settings-architecture rule — operator access is MCP-only).
-    // Dumb storage: BLEManager owns the build-scoped gating + invariant.
+    // Dumb storage: BLEManager owns the epoch-scoped gating + invariant.
     // Persisted so a proven dual-HIGH-incapable radio starts BOTH BLE links
-    // at BALANCED across restarts; the stored buildCode lets BLEManager
-    // auto-clear on every new app build (the safety valve). MCP reset clears.
+    // at BALANCED across restarts. `detectionEpoch` is the gate (BLEManager
+    // re-detects only when it differs from kBleDetectionEpoch — a deliberate
+    // global-reset lever, NOT per build); `buildCode` is retained DIAGNOSTIC
+    // ONLY ("last classified by build N"). cpEpoch() returns -1 when no epoch
+    // key is stored (a legacy pre-epoch record → BLEManager migrates it
+    // forward). MCP reset clears the whole latch (incl. the epoch key).
     bool cpLatched() const;
     QString cpTriggerKind() const;
     QString cpSetTimeIso() const;
     int cpBuildCode() const;
+    int cpEpoch() const;  // -1 ⇒ legacy record (no detectionEpoch key)
     void setConnectionPriorityLatch(const QString& triggerKind,
-                                    const QString& setTimeIso, int buildCode);
+                                    const QString& setTimeIso, int buildCode,
+                                    int detectionEpoch);
     void clearConnectionPriorityLatch();
 
     // Backoff policy mode (observe-mode change). Distinct from the latch:

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -90,6 +90,10 @@ void WeightProcessor::processWeight(double weight)
         emit scaleFeedResumed(gapMs);
     }
     m_scaleFeedStale = false;
+    // Recovery cancels any pending/active confirmation: a feed that came back
+    // never confirms, so enforce never latches on a self-recovering blip. A
+    // later independent stall re-arms suspected→confirmed cleanly.
+    m_scaleStallConfirmed = false;
 
     qint64 sampleTs;
     if (sinceLast < 0 || sinceLast > kBatchThresholdMs) {
@@ -335,20 +339,43 @@ void WeightProcessor::checkScaleFeedStall(int frameNumber)
     // scale with no espresso cycle never trips (gate false).
     const bool shotContext = (m_active || m_preheatActive) && m_tareComplete;
     if (!shotContext) return;
-    if (m_lastWallClockMs <= 0 || m_scaleFeedStale) return;
-    if ((m_wallClock() - m_lastWallClockMs) <= kScaleStaleMs) return;
+    if (m_lastWallClockMs <= 0) return;
 
-    m_scaleFeedStale = true;
-    // Start of the silent gap = the last good sample's wall-clock (NOT now;
-    // now is a DE1-tick evaluation, not a scale sample). Used to compute the
-    // resume gap on recovery; robust to a rejected-spike packet at resume
-    // (the spike path updates m_lastWallClockMs but not this).
-    m_feedStallStartMs = m_lastWallClockMs;
     const qint64 gapMs = m_wallClock() - m_lastWallClockMs;  // silence so far
-    qWarning() << "[Weight-Worker] Scale feed stalled >" << kScaleStaleMs
-               << "ms while weight expected (frame" << frameNumber
-               << "active=" << m_active << "preheat=" << m_preheatActive << ")";
-    emit scaleFeedStalled(gapMs);
+
+    if (!m_scaleFeedStale) {
+        // Not yet stalled. SUSPECTED edge at kScaleStaleMs — unchanged signal
+        // (observe logging + diagnostics rely on it). A suspected stall does
+        // NOT by itself latch a backoff: enforce acts only on CONFIRMED.
+        if (gapMs <= kScaleStaleMs) return;
+        m_scaleFeedStale = true;
+        m_scaleStallConfirmed = false;
+        // Start of the silent gap = the last good sample's wall-clock (NOT
+        // now; now is a DE1-tick evaluation, not a scale sample). Used for
+        // the resume gap and the confirm threshold; robust to a rejected-
+        // spike at resume (the spike path updates m_lastWallClockMs only).
+        m_feedStallStartMs = m_lastWallClockMs;
+        qWarning() << "[Weight-Worker] Scale feed stalled >" << kScaleStaleMs
+                   << "ms while weight expected (frame" << frameNumber
+                   << "active=" << m_active << "preheat=" << m_preheatActive
+                   << ") — SUSPECTED (not yet confirmed)";
+        emit scaleFeedStalled(gapMs);
+        return;
+    }
+
+    // Still stalled (no genuine sample has arrived — a sample would have
+    // cleared m_scaleFeedStale in processWeight() and emitted scaleFeedResumed,
+    // which is what CANCELS confirmation: a self-recovering blip never reaches
+    // here a second time). CONFIRM once the silence persists past the larger
+    // threshold. Event-based on the DE1 tick — no timer.
+    if (!m_scaleStallConfirmed && gapMs >= kScaleStallConfirmMs) {
+        m_scaleStallConfirmed = true;
+        qWarning() << "[Weight-Worker] Scale feed stall CONFIRMED — still dead"
+                   << gapMs << "ms (>" << kScaleStallConfirmMs
+                   << "ms) with no recovery (frame" << frameNumber
+                   << "active=" << m_active << "preheat=" << m_preheatActive << ")";
+        emit scaleFeedStallConfirmed(gapMs);
+    }
 }
 
 void WeightProcessor::setShotCycleActive(bool active)
@@ -358,7 +385,11 @@ void WeightProcessor::setShotCycleActive(bool active)
     // Leaving the preheat window (idle/sleep/extraction handoff): clear the
     // stale flag so a later cycle can re-detect. m_active extraction is
     // unaffected (it owns its own reset in startExtraction()).
-    if (!active && !m_active) { m_scaleFeedStale = false; m_feedStallStartMs = 0; }
+    if (!active && !m_active) {
+        m_scaleFeedStale = false;
+        m_feedStallStartMs = 0;
+        m_scaleStallConfirmed = false;
+    }
 }
 
 void WeightProcessor::setTareComplete(bool complete)
@@ -397,6 +428,7 @@ void WeightProcessor::startExtraction()
     m_uncalibratedBatchWarned = false;
     m_scaleFeedStale = false;
     m_feedStallStartMs = 0;
+    m_scaleStallConfirmed = false;
     // Keep m_estimatedIntervalMs — it calibrates across shots for the same scale
 }
 
@@ -440,6 +472,8 @@ void WeightProcessor::resetForRetare()
     m_lastWallClockMs = 0;
     m_lastSampleTs = 0;
     m_feedStallStartMs = 0;
+    m_scaleFeedStale = false;
+    m_scaleStallConfirmed = false;
     m_uncalibratedBatchWarned = false;  // Timestamps cleared — de-jitter needs recalibration
     m_lastTareWarnMs = 0;
     m_lastLowFlowLogMs = 0;

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -86,14 +86,13 @@ void WeightProcessor::processWeight(double weight)
                           "stall-start — emitting gap 0 (investigate: a stall "
                           "was flagged without m_feedStallStartMs being set)";
         }
-        m_feedStallStartMs = 0;
         emit scaleFeedResumed(gapMs);
     }
-    m_scaleFeedStale = false;
     // Recovery cancels any pending/active confirmation: a feed that came back
     // never confirms, so enforce never latches on a self-recovering blip. A
-    // later independent stall re-arms suspected→confirmed cleanly.
-    m_scaleStallConfirmed = false;
+    // later independent stall re-arms suspected→confirmed cleanly. Unconditional
+    // + idempotent (clears the no-stall path too).
+    resetStallTracking();
 
     qint64 sampleTs;
     if (sinceLast < 0 || sinceLast > kBatchThresholdMs) {
@@ -327,6 +326,15 @@ void WeightProcessor::setCurrentFrame(int frameNumber)
     checkScaleFeedStall(frameNumber);
 }
 
+void WeightProcessor::resetStallTracking()
+{
+    // The three fields move together — never clear a subset (an illegal
+    // "confirmed but not stale" gates the enforce backoff incorrectly).
+    m_scaleFeedStale = false;
+    m_scaleStallConfirmed = false;
+    m_feedStallStartMs = 0;
+}
+
 void WeightProcessor::checkScaleFeedStall(int frameNumber)
 {
     // Scale-agnostic in-shot liveness backstop (BLE connection-priority).
@@ -347,13 +355,19 @@ void WeightProcessor::checkScaleFeedStall(int frameNumber)
         // Not yet stalled. SUSPECTED edge at kScaleStaleMs — unchanged signal
         // (observe logging + diagnostics rely on it). A suspected stall does
         // NOT by itself latch a backoff: enforce acts only on CONFIRMED.
+        // gapMs (from m_lastWallClockMs) is correct here: m_feedStallStartMs
+        // is not yet set, and m_lastWallClockMs IS the last good sample.
         if (gapMs <= kScaleStaleMs) return;
         m_scaleFeedStale = true;
         m_scaleStallConfirmed = false;
-        // Start of the silent gap = the last good sample's wall-clock (NOT
-        // now; now is a DE1-tick evaluation, not a scale sample). Used for
-        // the resume gap and the confirm threshold; robust to a rejected-
-        // spike at resume (the spike path updates m_lastWallClockMs only).
+        // Freeze the silent-gap origin at the last good sample's wall-clock.
+        // BOTH the resume gap (processWeight) AND the CONFIRM threshold below
+        // measure from this frozen value — NOT from m_lastWallClockMs, which
+        // a rejected-spike packet advances (spike path: m_lastWallClockMs =
+        // wallClock; return; — issue #610). Anchoring confirm here makes it
+        // spike-immune: a genuinely dead feed that emits periodic corrupt
+        // spikes (the #1176/#610 overlap) still confirms instead of having
+        // its confirm clock reset to ~0 by every spike.
         m_feedStallStartMs = m_lastWallClockMs;
         qWarning() << "[Weight-Worker] Scale feed stalled >" << kScaleStaleMs
                    << "ms while weight expected (frame" << frameNumber
@@ -367,14 +381,16 @@ void WeightProcessor::checkScaleFeedStall(int frameNumber)
     // cleared m_scaleFeedStale in processWeight() and emitted scaleFeedResumed,
     // which is what CANCELS confirmation: a self-recovering blip never reaches
     // here a second time). CONFIRM once the silence persists past the larger
-    // threshold. Event-based on the DE1 tick — no timer.
-    if (!m_scaleStallConfirmed && gapMs >= kScaleStallConfirmMs) {
+    // threshold. Measured from the frozen m_feedStallStartMs (spike-immune),
+    // NOT m_lastWallClockMs. Event-based on the DE1 tick — no timer.
+    const qint64 confirmGapMs = m_wallClock() - m_feedStallStartMs;
+    if (!m_scaleStallConfirmed && confirmGapMs >= kScaleStallConfirmMs) {
         m_scaleStallConfirmed = true;
         qWarning() << "[Weight-Worker] Scale feed stall CONFIRMED — still dead"
-                   << gapMs << "ms (>" << kScaleStallConfirmMs
+                   << confirmGapMs << "ms (>" << kScaleStallConfirmMs
                    << "ms) with no recovery (frame" << frameNumber
                    << "active=" << m_active << "preheat=" << m_preheatActive << ")";
-        emit scaleFeedStallConfirmed(gapMs);
+        emit scaleFeedStallConfirmed(confirmGapMs);
     }
 }
 
@@ -385,11 +401,7 @@ void WeightProcessor::setShotCycleActive(bool active)
     // Leaving the preheat window (idle/sleep/extraction handoff): clear the
     // stale flag so a later cycle can re-detect. m_active extraction is
     // unaffected (it owns its own reset in startExtraction()).
-    if (!active && !m_active) {
-        m_scaleFeedStale = false;
-        m_feedStallStartMs = 0;
-        m_scaleStallConfirmed = false;
-    }
+    if (!active && !m_active) resetStallTracking();
 }
 
 void WeightProcessor::setTareComplete(bool complete)
@@ -426,9 +438,7 @@ void WeightProcessor::startExtraction()
     m_lastWallClockMs = 0;
     m_lastSampleTs = 0;
     m_uncalibratedBatchWarned = false;
-    m_scaleFeedStale = false;
-    m_feedStallStartMs = 0;
-    m_scaleStallConfirmed = false;
+    resetStallTracking();
     // Keep m_estimatedIntervalMs — it calibrates across shots for the same scale
 }
 
@@ -471,9 +481,7 @@ void WeightProcessor::resetForRetare()
     m_frameWeightSkipSent.clear();
     m_lastWallClockMs = 0;
     m_lastSampleTs = 0;
-    m_feedStallStartMs = 0;
-    m_scaleFeedStale = false;
-    m_scaleStallConfirmed = false;
+    resetStallTracking();
     m_uncalibratedBatchWarned = false;  // Timestamps cleared — de-jitter needs recalibration
     m_lastTareWarnMs = 0;
     m_lastLowFlowLogMs = 0;

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -102,6 +102,12 @@ private:
     // Scale-agnostic stall evaluation, run on the DE1 shot-sample cadence
     // (setCurrentFrame) during extraction / preheat.
     void checkScaleFeedStall(int frameNumber);
+    // Single chokepoint that clears the three correlated stall fields
+    // together (m_scaleFeedStale / m_scaleStallConfirmed / m_feedStallStartMs).
+    // Every reset path calls this so a half-reset (e.g. confirmed left set
+    // without stale) — which gates the real enforce backoff — is impossible
+    // by construction, mirroring ScaleSkipHighLatch::clear()'s discipline.
+    void resetStallTracking();
 
     // Weight sample buffer (1-second rolling window for LSLR)
     struct WeightSample {

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -87,6 +87,14 @@ signals:
     // observation — never alters SAW/flow/frame decisions; the transport
     // decides whether to log it (observe mode).
     void scaleFeedResumed(qint64 gapMs);
+    // Confirmed-stall edge (epoch-scope-and-stall-confirm change). Emitted
+    // once, only when a suspected stall has PERSISTED past kScaleStallConfirmMs
+    // with NO intervening scaleFeedResumed (i.e. it did not self-recover).
+    // This — not scaleFeedStalled — is what enforce mode latches on, and what
+    // observe mode records as the real "would back off". A transient blip that
+    // recovers before the confirm threshold never emits this. `gapMs` is the
+    // confirmed silent duration. Pure observation; SAW/flow/frame untouched.
+    void scaleFeedStallConfirmed(qint64 gapMs);
 
 private:
     double computeLSLR(int windowMs) const;
@@ -114,7 +122,19 @@ private:
     // reconnect-gap value but is a distinct liveness threshold (kept separate
     // to avoid coupling de-jitter tuning to fault detection).
     static constexpr qint64 kScaleStaleMs = 2000;
+    // Confirm threshold: a suspected stall only CONFIRMS (→ enforce may latch)
+    // if it persists this long with no recovery. PROVISIONAL — final value is
+    // calibrated from #1219 observe-mode field data (the recovered-gap
+    // distribution: above the transient self-recovery cluster, below genuine
+    // sustained stalls). Distinct from kScaleStaleMs so the suspected signal
+    // (observe/diagnostics) and the latch trigger tune independently. Still a
+    // DE1-tick-evaluated threshold, not a timer.
+    static constexpr qint64 kScaleStallConfirmMs = 6000;
     bool m_scaleFeedStale = false;
+    // True once the current stall has been confirmed (persisted past
+    // kScaleStallConfirmMs unrecovered). Reset by recovery and every
+    // extraction/cycle reset so a later independent stall re-confirms cleanly.
+    bool m_scaleStallConfirmed = false;
     // Wall-clock of the last good sample before the current silent gap (set
     // when a stall is detected; 0 = no active stall). Drives scaleFeedResumed's
     // gap. Reset on the resume edge and on every extraction/cycle reset.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1442,6 +1442,12 @@ int main(int argc, char *argv[])
             QObject::connect(&weightProcessor, &WeightProcessor::scaleFeedResumed,
                              scaleTransport, &ScaleBleTransport::onScaleFeedResumed,
                              Qt::QueuedConnection);
+            // Confirmed-stall trigger (epoch-scope-and-stall-confirm). This —
+            // not scaleFeedStalled — is what drives the enforce backoff now.
+            // Same cross-thread Queued pinning rationale as above.
+            QObject::connect(&weightProcessor, &WeightProcessor::scaleFeedStallConfirmed,
+                             scaleTransport, &ScaleBleTransport::onScaleFeedStallConfirmed,
+                             Qt::QueuedConnection);
         }
 
         // When physical scale connects/disconnects, switch between physical and FlowScale

--- a/src/mcp/mcptools_devices.cpp
+++ b/src/mcp/mcptools_devices.cpp
@@ -101,8 +101,8 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
             result["bleAvailable"] = bleManager != nullptr;
 
             // Scale connection-priority (dual-HIGH backoff) state. Persisted,
-            // build-scoped (D9): a same-build restart rehydrates it; a new
-            // build, or this MCP reset, re-detects from scratch.
+            // epoch-scoped: a same-epoch restart rehydrates it; a deliberate
+            // epoch bump, or this MCP reset, re-detects from scratch.
             QJsonObject sp;
             const bool latched = bleManager && bleManager->scaleSkipHighPriority();
             sp["scaleLinkPriority"] = latched ? "balanced" : "high";
@@ -111,13 +111,22 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
             // armed right now (that additionally needs a scale connected at
             // HIGH; the latch is the dominant signal).
             sp["detectionActive"] = !latched;
-            // D9: build-scoped QSettings persistence. A same-build restart
-            // keeps this latched (no detection window); a new app build, or
-            // the devices_reset_scale_priority tool, clears it.
+            // Epoch-scoped QSettings persistence: the classification persists
+            // across all builds sharing detectionEpoch; a same-epoch restart
+            // keeps it latched (no detection window). It re-detects only on a
+            // deliberate epoch bump (a release that changed BLE handling /
+            // re-classifies everyone) or via devices_reset_scale_priority.
             sp["persisted"] = true;
-            sp["persistenceScope"] = "build";
+            sp["persistenceScope"] = "epoch";
+            // The active detection epoch (always reported, latched or not).
+            sp["detectionEpoch"] = BLEManager::kBleDetectionEpoch;
             if (latched) {
                 sp["triggerKind"] = bleManager->scaleSkipHighTriggerKind();
+                // Diagnostic ONLY — the versionCode that last classified this
+                // device. NOT the rehydrate gate (the epoch is); surfaced so
+                // the "classified by build N" field-triage trail survives.
+                const int byBuild = bleManager->scaleSkipHighBuildCode();
+                if (byBuild > 0) sp["classifiedByBuildCode"] = byBuild;
                 const QDateTime setT = bleManager->scaleSkipHighSetTime();
                 const QDateTime appStart = bleManager->appStartTime();
                 if (setT.isValid()) {
@@ -166,15 +175,16 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
         "read");
 
     // devices_reset_scale_priority — clears the dual-HIGH backoff latch, both
-    // in-memory AND the persisted (build-scoped) record (the only operator
+    // in-memory AND the persisted (epoch-scoped) record (the only operator
     // path; there is intentionally no UI). Takes effect on the next scale
     // (re)connect's detection pass: eventually-consistent, no forced teardown
-    // of a live connection. Durable: a same-build restart will NOT rehydrate.
+    // of a live connection. Durable: a restart will NOT rehydrate it (the
+    // clear wipes the epoch key too — the device re-detects from scratch).
     registry->registerTool(
         "devices_reset_scale_priority",
         "Reset (clear) the scale connection-priority dual-HIGH backoff latch — "
-        "both the in-memory latch and the persisted (build-scoped) record. The "
-        "reset is durable: a same-build app restart will NOT re-apply it. After "
+        "both the in-memory latch and the persisted (epoch-scoped) record. The "
+        "reset is durable: an app restart will NOT re-apply it. After "
         "reset, the next scale (re)connect requests HIGH and re-enters "
         "detection from scratch (as if the device were seen for the first "
         "time). Eventually-consistent: it does NOT tear down a "
@@ -229,7 +239,8 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
         "recovery events are logged and surfaced in devices_connection_status, "
         "so the backoff's aggressiveness can be evaluated on a production "
         "build. The mode persists across app restarts AND build upgrades "
-        "until explicitly changed (it is NOT build-scoped, unlike the latch). "
+        "until explicitly changed (it is not scoped at all, unlike the latch "
+        "which is epoch-scoped). "
         "Eventually-consistent: the change is queued onto the BLE-manager "
         "thread (this response does NOT assert the persist has executed yet), "
         "and the HIGH-forcing additionally only applies on the next scale "

--- a/src/mcp/mcptools_devices.cpp
+++ b/src/mcp/mcptools_devices.cpp
@@ -125,8 +125,17 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
                 // Diagnostic ONLY — the versionCode that last classified this
                 // device. NOT the rehydrate gate (the epoch is); surfaced so
                 // the "classified by build N" field-triage trail survives.
+                // ALWAYS emitted when latched: a migrated-legacy / pre-build
+                // record has buildCode 0 — exactly the population under triage
+                // right after this ships, so absence-of-provenance must be an
+                // explicit string, never a silently-missing field (the very
+                // "diagnostic black hole" this feature exists to avoid).
                 const int byBuild = bleManager->scaleSkipHighBuildCode();
-                if (byBuild > 0) sp["classifiedByBuildCode"] = byBuild;
+                if (byBuild > 0)
+                    sp["classifiedByBuildCode"] = byBuild;
+                else
+                    sp["classifiedByBuildCode"] =
+                        QStringLiteral("unknown (legacy / migrated / pre-buildcode)");
                 const QDateTime setT = bleManager->scaleSkipHighSetTime();
                 const QDateTime appStart = bleManager->appStartTime();
                 if (setT.isValid()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -711,3 +711,8 @@ add_decenza_test(tst_steamhealth
     ${CMAKE_SOURCE_DIR}/src/rendering/fastlinerenderer.cpp
 )
 target_link_libraries(tst_steamhealth PRIVATE Qt6::Quick Qt6::Graphs)
+
+# --- tst_raceconditionfix: Temporary canary for the run_tests parser-race fix ---
+add_decenza_test(tst_raceconditionfix
+    tst_raceconditionfix.cpp
+)

--- a/tests/tst_raceconditionfix.cpp
+++ b/tests/tst_raceconditionfix.cpp
@@ -1,0 +1,12 @@
+// Temporary canary for verifying the run_tests parser-race fix.
+// Ensures Qt Creator discovers this class after a reconfigure+build cycle.
+#include <QtTest>
+class tst_RaceConditionFix : public QObject
+{
+    Q_OBJECT
+private slots:
+    void placeholder() { QVERIFY(true); }
+    void placeholder2() { QVERIFY(true); }
+};
+QTEST_MAIN(tst_RaceConditionFix)
+#include "tst_raceconditionfix.moc"

--- a/tests/tst_scaleskiphighlatch.cpp
+++ b/tests/tst_scaleskiphighlatch.cpp
@@ -144,11 +144,12 @@ private slots:
     }
 
     void epochIsTheGateNotBuild() {
-        // BLEManager rehydrates iff storedEpoch == kBleDetectionEpoch,
-        // regardless of buildCode (now diagnostic only). This pins that the
-        // epoch is faithfully retrievable for that comparison and that a
-        // differing buildCode does NOT change it (gate logic lives in
-        // BLEManager::setSettings; the build-scoped behavior is removed).
+        // Same-epoch ⇒ rehydrate, regardless of buildCode (now diagnostic
+        // only). (Legacy `-1` records ALSO rehydrate, via migrate-forward —
+        // the full trichotomy is exhaustively pinned by the epochGate_*
+        // tests below.) This pins that the epoch is faithfully retrievable
+        // and a differing buildCode does NOT change the gate (decision logic:
+        // decideBleEpochGate; the build-scoped behavior is removed).
         SettingsHardware s;
         s.setConnectionPriorityLatch(QStringLiteral("de1-fault-cluster"),
                                      QStringLiteral("2026-05-18T12:00:00"),

--- a/tests/tst_scaleskiphighlatch.cpp
+++ b/tests/tst_scaleskiphighlatch.cpp
@@ -1,5 +1,6 @@
 #include <QtTest>
 #include <QStandardPaths>
+#include <QSettings>
 
 #include "ble/blemanager.h"
 #include "core/settings_hardware.h"
@@ -99,7 +100,7 @@ private slots:
         QVERIFY(l.setTime.isValid());     // substituted — invariant intact
     }
 
-    // --- D9: SettingsHardware persisted record (build-scoped store) ---
+    // --- SettingsHardware persisted record (epoch-scoped store) ---
 
     void initTestCase() {
         // Isolate QSettings so the real user prefs are untouched.
@@ -113,39 +114,71 @@ private slots:
         QVERIFY(s.cpTriggerKind().isEmpty());
         QVERIFY(s.cpSetTimeIso().isEmpty());
         QCOMPARE(s.cpBuildCode(), 0);
+        QCOMPARE(s.cpEpoch(), -1);   // no epoch key ⇒ legacy/absent sentinel
     }
 
     void persistedRoundTrips() {
         SettingsHardware s;
         const QString iso = QDateTime::currentDateTime().toString(Qt::ISODate);
-        s.setConnectionPriorityLatch(QStringLiteral("scale-feed-stall"), iso, 3388);
+        s.setConnectionPriorityLatch(QStringLiteral("scale-feed-stall"), iso,
+                                     3388, BLEManager::kBleDetectionEpoch);
         QVERIFY(s.cpLatched());
         QCOMPARE(s.cpTriggerKind(), QStringLiteral("scale-feed-stall"));
         QCOMPARE(s.cpSetTimeIso(), iso);
         QCOMPARE(s.cpBuildCode(), 3388);
+        QCOMPARE(s.cpEpoch(), BLEManager::kBleDetectionEpoch);
 
         // A fresh instance reads the same persisted values (true persistence).
         SettingsHardware s2;
         QVERIFY(s2.cpLatched());
         QCOMPARE(s2.cpBuildCode(), 3388);
+        QCOMPARE(s2.cpEpoch(), BLEManager::kBleDetectionEpoch);
 
         s.clearConnectionPriorityLatch();
         SettingsHardware s3;
         QVERIFY(!s3.cpLatched());
         QVERIFY(s3.cpTriggerKind().isEmpty());
         QCOMPARE(s3.cpBuildCode(), 0);
+        QCOMPARE(s3.cpEpoch(), -1);   // clear is fully fresh (epoch key gone)
     }
 
-    void buildScopeComparisonIsTheGate() {
-        // BLEManager seeds iff storedBuildCode == versionCode(); this verifies
-        // the stored buildCode is faithfully retrievable for that comparison
-        // (the gate logic itself lives in BLEManager::setSettings).
+    void epochIsTheGateNotBuild() {
+        // BLEManager rehydrates iff storedEpoch == kBleDetectionEpoch,
+        // regardless of buildCode (now diagnostic only). This pins that the
+        // epoch is faithfully retrievable for that comparison and that a
+        // differing buildCode does NOT change it (gate logic lives in
+        // BLEManager::setSettings; the build-scoped behavior is removed).
         SettingsHardware s;
         s.setConnectionPriorityLatch(QStringLiteral("de1-fault-cluster"),
-                                     QStringLiteral("2026-05-18T12:00:00"), 3388);
-        QCOMPARE(s.cpBuildCode(), 3388);   // same-build path would seed
-        QVERIFY(s.cpBuildCode() != 3389);  // different-build path would wipe
+                                     QStringLiteral("2026-05-18T12:00:00"),
+                                     3388, BLEManager::kBleDetectionEpoch);
+        QCOMPARE(s.cpEpoch(), BLEManager::kBleDetectionEpoch);  // same-epoch ⇒ seed
+        QCOMPARE(s.cpBuildCode(), 3388);                        // diagnostic only
+        QVERIFY(s.cpEpoch() != BLEManager::kBleDetectionEpoch + 1);  // bumped ⇒ wipe
         s.clearConnectionPriorityLatch();
+    }
+
+    void legacyRecordHasNoEpochSentinel() {
+        // A pre-epoch record (written by the old 3-arg world) has no
+        // detectionEpoch key. cpEpoch() MUST report -1 so BLEManager takes
+        // the forward-migration path (honor + stamp), not the discard path.
+        SettingsHardware s;
+        s.clearConnectionPriorityLatch();
+        // Simulate a legacy latch: latched + buildCode but NO epoch key.
+        // (Re-create via the modern setter then strip the epoch key the way
+        // an old build would never have written it.)
+        s.setConnectionPriorityLatch(QStringLiteral("scale-feed-stall"),
+                                     QStringLiteral("2026-05-18T12:00:00"),
+                                     3388, BLEManager::kBleDetectionEpoch);
+        {
+            QSettings raw("DecentEspresso", "DE1Qt");
+            raw.remove("connectionPriority/detectionEpoch");  // → legacy shape
+        }
+        SettingsHardware s2;
+        QVERIFY(s2.cpLatched());
+        QCOMPARE(s2.cpBuildCode(), 3388);
+        QCOMPARE(s2.cpEpoch(), -1);   // legacy sentinel ⇒ migrate-forward path
+        s2.clearConnectionPriorityLatch();
     }
 
     void isoSetTimeRoundTripsToValidDateTime() {
@@ -157,7 +190,8 @@ private slots:
         SettingsHardware s;
         const QDateTime before = QDateTime::currentDateTime();
         s.setConnectionPriorityLatch(QStringLiteral("scale-feed-stall"),
-                                     before.toString(Qt::ISODate), 3388);
+                                     before.toString(Qt::ISODate),
+                                     3388, BLEManager::kBleDetectionEpoch);
 
         const QDateTime parsed =
             QDateTime::fromString(s.cpSetTimeIso(), Qt::ISODate);
@@ -184,22 +218,23 @@ private slots:
     }
 
     // The critical correctness fix: clearing the latch (MCP reset /
-    // new-build re-detect) must NOT wipe the sibling policyMode key.
+    // epoch re-detect) must NOT wipe the sibling policyMode key.
     void cpModeSurvivesLatchClear() {
         SettingsHardware s;
         s.setCpMode(QStringLiteral("observe"));
         s.setConnectionPriorityLatch(QStringLiteral("scale-feed-stall"),
                                      QDateTime::currentDateTime().toString(Qt::ISODate),
-                                     3388);
+                                     3388, BLEManager::kBleDetectionEpoch);
         QVERIFY(s.cpLatched());
 
-        s.clearConnectionPriorityLatch();       // narrowed to the 4 latch keys
+        s.clearConnectionPriorityLatch();       // latch sub-keys only
 
         QVERIFY(!s.cpLatched());                // latch gone
         QCOMPARE(s.cpMode(), QStringLiteral("observe"));  // mode preserved
         QVERIFY(s.cpTriggerKind().isEmpty());   // no stale latch metadata
         QVERIFY(s.cpSetTimeIso().isEmpty());
         QCOMPARE(s.cpBuildCode(), 0);
+        QCOMPARE(s.cpEpoch(), -1);              // epoch key also cleared (fresh)
         s.setCpMode(QString());                 // tidy for the next test
     }
 

--- a/tests/tst_scaleskiphighlatch.cpp
+++ b/tests/tst_scaleskiphighlatch.cpp
@@ -3,6 +3,7 @@
 #include <QSettings>
 
 #include "ble/blemanager.h"
+#include "ble/bleepochgate.h"
 #include "core/settings_hardware.h"
 
 // BLEManager::ScaleSkipHighLatch — the in-memory dual-HIGH skip-HIGH latch
@@ -281,6 +282,49 @@ private slots:
         QCOMPARE(out.size(), qsizetype(cap));         // bounded
         QCOMPARE(out.first().durationSec, double(cap + 4));  // newest kept
         QCOMPARE(out.last().durationSec, 5.0);        // 0..4 dropped (oldest)
+    }
+
+    // --- Epoch-gate decision trichotomy (pure logic, no BLEManager TU) ---
+    // Regression-locks the headline backward-compat guarantee + the
+    // corrupt-negative handling at the DECISION level (PR #1220 review
+    // Crit-9/8 + silent-failure #2). decideBleEpochGate() is the exact
+    // function BLEManager::setSettings() dispatches on.
+
+    void epochGate_notLatched_isNoRecord() {
+        QCOMPARE(decideBleEpochGate(false, -1, 1), BleEpochDecision::NoRecord);
+        QCOMPARE(decideBleEpochGate(false, 1, 1),  BleEpochDecision::NoRecord);
+    }
+
+    void epochGate_sameEpoch_rehydrates() {
+        QCOMPARE(decideBleEpochGate(true, 1, 1), BleEpochDecision::Rehydrate);
+        QCOMPARE(decideBleEpochGate(true, 7, 7), BleEpochDecision::Rehydrate);
+        // Build code is irrelevant — only the epoch gates (function has no
+        // build param at all, which is the point of the build→epoch move).
+    }
+
+    void epochGate_legacyMinusOne_migratesForward() {
+        // The ONLY value that means "legacy / no epoch key" → migrate forward
+        // (honor + stamp), ZERO extra detection. This is the upgrade promise.
+        QCOMPARE(decideBleEpochGate(true, -1, 1),
+                 BleEpochDecision::MigrateForward);
+        QCOMPARE(decideBleEpochGate(true, -1, 9),
+                 BleEpochDecision::MigrateForward);
+    }
+
+    void epochGate_deliberateBump_discards() {
+        // A different non-negative epoch = an intentional global reclassify.
+        QCOMPARE(decideBleEpochGate(true, 1, 2), BleEpochDecision::Discard);
+        QCOMPARE(decideBleEpochGate(true, 2, 1), BleEpochDecision::Discard);
+        QCOMPARE(decideBleEpochGate(true, 0, 1), BleEpochDecision::Discard);
+    }
+
+    void epochGate_corruptNegative_discardsNotMigrates() {
+        // Any negative OTHER than -1 is corrupt persisted input — must
+        // re-detect, NOT be silently honored as a clean legacy latch
+        // (silent-failure #2). -1 is the only legacy sentinel.
+        QCOMPARE(decideBleEpochGate(true, -2, 1),   BleEpochDecision::Discard);
+        QCOMPARE(decideBleEpochGate(true, -7, 1),   BleEpochDecision::Discard);
+        QCOMPARE(decideBleEpochGate(true, -999, 5), BleEpochDecision::Discard);
     }
 
     void cleanupTestCase() {

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -777,6 +777,65 @@ private slots:
         QCOMPARE(stopSpy.count(), 0);
         QCOMPARE(skipSpy.count(), 0);
     }
+
+    // Regression for the PR #1220 review bug: a rejected SPIKE packet during
+    // a stall advances m_lastWallClockMs. If CONFIRM measured the gap from
+    // m_lastWallClockMs it would be reset to ~0 by the spike and a genuinely
+    // dead feed that emits periodic garbage (#1176/#610 overlap) would never
+    // confirm → never back off. CONFIRM must measure from the frozen
+    // m_feedStallStartMs and therefore stay spike-immune.
+    void confirmSurvivesSpikeRejectionDuringStall() {
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy confirm(&wp, &WeightProcessor::scaleFeedStallConfirmed);
+
+        wp.startExtraction();
+        wp.setTareComplete(true);
+        wp.processWeight(1.0);                 // T0, last good sample
+
+        m_fakeClock += 2500;                   // > kScaleStaleMs
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("Scale feed stalled")));
+        wp.setCurrentFrame(0);                 // SUSPECTED; m_feedStallStartMs := T0
+        QCOMPARE(confirm.count(), 0);
+
+        m_fakeClock += 3000;                   // T0+5500
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("Spike rejected")));
+        wp.processWeight(200.0);               // |200-1|>100 → rejected; advances
+                                               // m_lastWallClockMs to T0+5500,
+                                               // NOT a genuine sample (no recovery)
+        QCOMPARE(confirm.count(), 0);
+
+        m_fakeClock += 1000;                   // T0+6500: 6500 from frozen start
+                                               // ≥ 6000, but only 1000 from the
+                                               // spike-advanced m_lastWallClockMs
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("CONFIRMED")));
+        wp.setCurrentFrame(0);                 // must STILL confirm (spike-immune)
+        QCOMPARE(confirm.count(), 1);
+        QCOMPARE(confirm.first().at(0).toLongLong(), qint64(6500));
+    }
+
+    // Confirmation must work in the pre-shot preheat context too (the spec's
+    // confirmed-stall scenario says "extraction/preheat"; only the suspected
+    // arm had preheat coverage before).
+    void confirmWorksInPreheatContext() {
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy confirm(&wp, &WeightProcessor::scaleFeedStallConfirmed);
+
+        wp.setShotCycleActive(true);           // EspressoPreheating (not m_active)
+        wp.setTareComplete(true);
+        wp.processWeight(0.0);
+
+        m_fakeClock += 2500;
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("Scale feed stalled")));
+        wp.setCurrentFrame(0);                 // SUSPECTED in preheat
+        QCOMPARE(confirm.count(), 0);
+
+        m_fakeClock += 4000;                   // total 6500 ≥ kScaleStallConfirmMs
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("CONFIRMED")));
+        wp.setCurrentFrame(0);
+        QCOMPARE(confirm.count(), 1);
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_WeightProcessor)

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -689,6 +689,94 @@ private slots:
         QCOMPARE(stopSpy.count(), 0);   // far below 36 g target — no SAW
         QCOMPARE(skipSpy.count(), 0);   // no frame-exit weights configured
     }
+
+    // --- suspected → confirmed stall (epoch-scope-and-stall-confirm) ---
+
+    // Suspected fires at kScaleStaleMs; confirmed only after
+    // kScaleStallConfirmMs of CONTINUED silence; each fires exactly once.
+    void suspectedThenConfirmedOnSustainedStall() {
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy stall(&wp, &WeightProcessor::scaleFeedStalled);
+        QSignalSpy confirm(&wp, &WeightProcessor::scaleFeedStallConfirmed);
+
+        wp.startExtraction();
+        wp.setTareComplete(true);
+        wp.processWeight(0.0);                 // last good sample @ T0
+
+        m_fakeClock += 2500;                   // > kScaleStaleMs, < confirm
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("Scale feed stalled")));
+        wp.setCurrentFrame(0);                 // SUSPECTED
+        QCOMPARE(stall.count(), 1);
+        QCOMPARE(confirm.count(), 0);          // not confirmed yet
+
+        m_fakeClock += 4000;                   // total 6500 > kScaleStallConfirmMs
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("CONFIRMED")));
+        wp.setCurrentFrame(0);                 // CONFIRMED
+        QCOMPARE(confirm.count(), 1);
+        QCOMPARE(confirm.first().at(0).toLongLong(), qint64(6500));
+
+        wp.setCurrentFrame(0);                 // still stalled → no re-emit
+        QCOMPARE(stall.count(), 1);
+        QCOMPARE(confirm.count(), 1);
+    }
+
+    // A stall that self-recovers before the confirm threshold NEVER confirms
+    // (this is the false-positive shape enforce must not latch on); a later
+    // independent stall re-arms suspected→confirmed cleanly.
+    void recoveryBeforeConfirmCancelsThenReArms() {
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy confirm(&wp, &WeightProcessor::scaleFeedStallConfirmed);
+        QSignalSpy resume(&wp, &WeightProcessor::scaleFeedResumed);
+
+        wp.startExtraction();
+        wp.setTareComplete(true);
+        wp.processWeight(0.0);
+
+        m_fakeClock += 2500;                   // suspected
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("Scale feed stalled")));
+        wp.setCurrentFrame(0);
+        QCOMPARE(confirm.count(), 0);
+
+        m_fakeClock += 1000;                   // total 3500, still < confirm
+        wp.processWeight(0.5);                 // genuine sample → recovery
+        QCOMPARE(resume.count(), 1);
+        QCOMPARE(confirm.count(), 0);          // cancelled — never confirmed
+
+        // Independent later stall must re-arm and be able to confirm.
+        m_fakeClock += 2500;
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("Scale feed stalled")));
+        wp.setCurrentFrame(0);                 // re-SUSPECTED (fresh episode)
+        QCOMPARE(confirm.count(), 0);
+        m_fakeClock += 6000;
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("CONFIRMED")));
+        wp.setCurrentFrame(0);                 // CONFIRMED on the new episode
+        QCOMPARE(confirm.count(), 1);
+    }
+
+    // Confirmation is pure observation — a full suspected→confirmed cycle
+    // must not drive SAW (stopNow) or frame-exit (skipFrame).
+    void confirmDoesNotAlterSawOrFrameExit() {
+        WeightProcessor wp;
+        installFakeClock(wp);
+        configureEspresso(wp, 36.0, 0);
+        QSignalSpy stopSpy(&wp, &WeightProcessor::stopNow);
+        QSignalSpy skipSpy(&wp, &WeightProcessor::skipFrame);
+
+        wp.startExtraction();
+        wp.setTareComplete(true);
+        wp.processWeight(1.0);
+        m_fakeClock += 2500;
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("Scale feed stalled")));
+        wp.setCurrentFrame(0);                 // suspected
+        m_fakeClock += 5000;
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(QStringLiteral("CONFIRMED")));
+        wp.setCurrentFrame(0);                 // confirmed
+
+        QCOMPARE(stopSpy.count(), 0);
+        QCOMPARE(skipSpy.count(), 0);
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_WeightProcessor)


### PR DESCRIPTION
## Why

Two pre-existing problems in the shipped dual-HIGH backoff (#1185), surfaced while reviewing #1219 — **not** introduced by it:

1. **Per-build re-detection has an inverted cost/benefit.** The latch was build-scoped (`storedBuildCode != versionCode()` ⇒ discard + re-detect). CI bumps `versionCode` every release, so a genuinely dual-HIGH-incapable device re-paid the detection cost — a disrupted preheat at best, an off-target SAW shot at worst — on essentially every app update. A *false* latch sits at BALANCED (proven safe, #1097, no bad coffee); re-detection costs a real degraded shot. True positives were punished every build to auto-recover false positives from a not-broken state.
2. **The scale-feed-stall backstop had no confirmation** — it latched on a single >2 s gap, unlike the DE1-fault path (≥2/20 s). A transient blip that would self-recover could still latch.

## What

**Arm 1 — epoch scoping replaces build scoping**
- `BLEManager::kBleDetectionEpoch`: a source constant **decoupled from `versionCode`/CI**. The classification persists across all builds sharing the epoch. Bumping the constant in a commit is the deliberate, auditable *"re-classify every device once on this release"* lever — bump it in the same commit that fixes BLE handling and the fix reaches already-latched devices.
- `buildCode` demoted to a diagnostic ("classified by build N", surfaced in `devices_connection_status`); no longer gates.
- **Legacy forward-migration (the backward-compat guarantee):** a latched record from the current release (no epoch key) is honored once and stamped forward — an already-classified user upgrading pays **zero** extra detection.
- The only remaining auto-wipe path is a deliberate epoch bump. MCP reset unchanged.

**Arm 3 — scale-feed stall confirmation**
- *Suspected* (`kScaleStaleMs`, unchanged `scaleFeedStalled` — observe/diagnostic) vs *confirmed* (`kScaleStallConfirmMs`, new `scaleFeedStallConfirmed`). Enforce backoff **and** the observe "would back off" now fire **only on confirmed**. A stall that self-recovers before the confirm threshold (`scaleFeedResumed` cancels it) **never latches**. Event/edge-based on the existing DE1 tick — no timer. DE1-fault path + `BlePriorityDetector` + capable-hardware behavior unchanged.

`kScaleStallConfirmMs` ships **provisional (6000 ms)**; the final value is a maintainer gate (tasks.md §8.1) calibrated from the **#1219 observe-mode field data** (the real recovered-gap distribution) — deliberately not guessed.

## Tests

Qt Creator build **0 errors / 0 warnings**. Full suite **46 suites / 2155 passed / 0 failed** (run from the Qt-Creator-built binaries — Qt Creator's Autotest plugin model was stale after the rebase and under-reported; verified the new tests are compiled in via `-functions` + binary-newer-than-source + direct binary runs all green). New: `tst_scaleskiphighlatch` epoch round-trip / legacy-record forward-migration / clear-is-fully-fresh; `tst_weightprocessor` suspected→confirmed / recovery-cancels-then-re-arms / confirmation-doesn't-touch-SAW.

## Stacking / sequencing

Built on #1219 (merged as [`89f9687f`](https://github.com/Kulitorum/Decenza/commit/89f9687f9d054e78e2fbce34906c5c9aab594f64)); branch rebased onto `main` so this PR is **only** the epoch + stall-confirm delta. Arm 3 consumes #1219's `scaleFeedResumed`.

## Not covered by CI (maintainer device checks — tasks.md §8.1, §8.3)

This repo has no PR-level CI (tag-push only); the Qt Creator build + full suite above is the gate. Hardware-bound, deferred to you: (a) **§8.1 calibration gate** — set `kScaleStallConfirmMs` from #1219 observe field data before relying on the confirmation arm; (b) **§8.3** — on an epoch build, confirm an existing latched device migrates with *no* detection event, a transient blip logs suspected+recovered and does NOT latch, a sustained dead feed confirms+latches, and `devices_connection_status` shows the epoch + diagnostic build code.

OpenSpec: `openspec/changes/scale-priority-epoch-scope-and-stall-confirm/`. Modifies the active `ble-connection-priority` + `mcp-server` capabilities; relates to #1093/#1176/#1147/#1185; does not archive predecessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)