### PR TITLE
fix(mcp): set-priority-mode uninvokable + gate destructive device tools behind confirmation

### DIFF
--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -1179,18 +1179,29 @@ bool McpServer::needsChatConfirmation(const QString& toolName) const
     int level = m_settings->mcp()->mcpConfirmationLevel();
     if (level == 0) return false;
 
-    // All non-zero levels: settings/profile/dial-in write ops + the
-    // persistent connection-priority device-policy mutations. Those two
-    // devices_* tools advertise a `confirmed` arg, but the handler must NOT
-    // check it — McpServer strips `confirmed` before the handler runs, so
-    // confirmation is enforced HERE (server-side), not in the handler. A
-    // handler-side check is unreachable-true and was the shipped #1219 bug.
+    // All non-zero levels: confirm tools that cause IRREVERSIBLE data loss or
+    // change PERSISTENT device/startup state. (Reversible/routine ops —
+    // tare, timers, scan, connect, theme, backup, mqtt — are deliberately
+    // NOT here: prompt fatigue would erode the safety net's value.) The MCP
+    // server is network-exposed, so an ungated destructive tool is remotely
+    // invocable with no operator prompt — that is the threat model here.
+    //
+    // Confirmation is enforced HERE (server-side); handlers must NEVER check
+    // `confirmed` themselves — McpServer strips it before the handler runs.
+    // A handler-side check is unreachable-true and was the shipped #1219 bug.
     if (toolName == "profiles_set_active" || toolName == "profiles_edit_params" ||
         toolName == "profiles_save" || toolName == "profiles_delete" ||
         toolName == "profiles_create" || toolName == "shots_delete" ||
         toolName == "settings_set" ||
         toolName == "devices_set_scale_priority_mode" ||
-        toolName == "devices_reset_scale_priority")
+        toolName == "devices_reset_scale_priority" ||
+        // Irreversible learning/calibration wipes + forget-the-scale (the
+        // last also advertises a `confirmed` arg that was never enforced —
+        // same class as the #1219 bug above).
+        toolName == "reset_saw_learning" ||
+        toolName == "reset_saw_learning_for_profile" ||
+        toolName == "clear_flow_calibration" ||
+        toolName == "devices_disconnect_scale")
         return true;
 
     // Level 2 (All Control): also non-start machine control ops
@@ -1224,6 +1235,15 @@ QString McpServer::confirmationDescription(const QString& toolName) const
          "Change the scale connection-priority backoff policy (enforce/observe)"},
         {"devices_reset_scale_priority",
          "Clear the scale connection-priority backoff latch"},
+        {"reset_saw_learning",
+         "Erase ALL stop-at-weight learning (global pool, every profile/scale "
+         "history, bootstrap) — irreversible"},
+        {"reset_saw_learning_for_profile",
+         "Erase stop-at-weight learning for one profile/scale pair — irreversible"},
+        {"clear_flow_calibration",
+         "Clear the profile's flow calibration (re-learned over future shots)"},
+        {"devices_disconnect_scale",
+         "Disconnect and forget the saved scale (must be re-paired)"},
     };
     return descriptions.value(toolName, toolName);
 }

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -1179,11 +1179,18 @@ bool McpServer::needsChatConfirmation(const QString& toolName) const
     int level = m_settings->mcp()->mcpConfirmationLevel();
     if (level == 0) return false;
 
-    // All non-zero levels: settings/profile/dial-in write ops
+    // All non-zero levels: settings/profile/dial-in write ops + the
+    // persistent connection-priority device-policy mutations. Those two
+    // devices_* tools advertise a `confirmed` arg, but the handler must NOT
+    // check it — McpServer strips `confirmed` before the handler runs, so
+    // confirmation is enforced HERE (server-side), not in the handler. A
+    // handler-side check is unreachable-true and was the shipped #1219 bug.
     if (toolName == "profiles_set_active" || toolName == "profiles_edit_params" ||
         toolName == "profiles_save" || toolName == "profiles_delete" ||
         toolName == "profiles_create" || toolName == "shots_delete" ||
-        toolName == "settings_set")
+        toolName == "settings_set" ||
+        toolName == "devices_set_scale_priority_mode" ||
+        toolName == "devices_reset_scale_priority")
         return true;
 
     // Level 2 (All Control): also non-start machine control ops
@@ -1213,6 +1220,10 @@ QString McpServer::confirmationDescription(const QString& toolName) const
         {"profiles_create", "Create a new profile"},
         {"shots_delete", "Delete a shot permanently"},
         {"settings_set", "Change machine settings"},
+        {"devices_set_scale_priority_mode",
+         "Change the scale connection-priority backoff policy (enforce/observe)"},
+        {"devices_reset_scale_priority",
+         "Clear the scale connection-priority backoff latch"},
     };
     return descriptions.value(toolName, toolName);
 }

--- a/src/mcp/mcptools_devices.cpp
+++ b/src/mcp/mcptools_devices.cpp
@@ -275,12 +275,14 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
                                   "\"observe\" (mode unchanged)";
                 return result;
             }
-            if (!args.value("confirmed").toBool()) {
-                result["error"] = "Confirmation required: re-call with "
-                                  "confirmed=true (mode unchanged)";
-                result["confirmationRequired"] = true;
-                return result;
-            }
+            // NOTE: do NOT check `confirmed` here. McpServer strips the
+            // `confirmed` key before invoking any handler (mcpserver.cpp:
+            // "Strip the confirmed key before passing to tool handler"), and
+            // the chat-confirmation handshake is owned entirely by the server
+            // via needsChatConfirmation(). A handler-side `confirmed` check is
+            // unreachable-true and makes the tool permanently uninvokable
+            // (this was the shipped #1219 bug). Confirmation for this tool is
+            // enforced by listing it in McpServer::needsChatConfirmation().
             const QString prev = BLEManager::backoffModeToString(
                 bleManager->backoffMode());
             const auto target = BLEManager::backoffModeFromString(mode);


### PR DESCRIPTION
## Bug 1 — `devices_set_scale_priority_mode` uninvokable (shipped in #1219, found on-device)

Rejected **100% of calls** even with `confirmed:true`. Root cause (code-cited): `McpServer` unconditionally strips `confirmed` before invoking any handler (`mcpserver.cpp` "Strip the confirmed key before passing to tool handler"); chat-confirmation is owned by `needsChatConfirmation()`. The #1219 handler's `if (!args.value("confirmed").toBool())` was **unreachable-true**. Sibling `devices_reset_scale_priority` works only because it (correctly) doesn't re-check `confirmed` — the #1220 review's "advertises but doesn't read it" note was the *correct* pattern.

**Fix:** remove the handler-side `confirmed` check; add `devices_set_scale_priority_mode` + `devices_reset_scale_priority` to `needsChatConfirmation()` so the framework actually requires + prompts confirmation (and executes promptly at `mcpConfirmationLevel 0`, like every other tool). This unblocks the entire observe-mode on-device evaluation (#1219 §9.2 → #1220 §8.1).

## Bug 2 — destructive device tools were ungated (audit follow-up)

The MCP server is **network-exposed** (ShotServer :8888, live remote SSE clients), so these were remotely invocable with **no operator prompt**:

- `reset_saw_learning` — erases global pool + ALL per-(profile,scale) histories + bootstrap (irreversible)
- `reset_saw_learning_for_profile` — erases one pair's learning (irreversible)
- `clear_flow_calibration` — clears the flow-calibration multiplier
- `devices_disconnect_scale` — disconnects **and forgets** the saved scale; also already advertised an unenforced `confirmed` arg (same class as Bug 1)

All four added to `needsChatConfirmation()` + `confirmationDescription`. None had a handler-side `confirmed` check (grep-audited clean).

**Deliberately NOT gated** (reversible/routine — prompt fatigue would erode the safety net): `scale_tare`, `scale_timer_*`, `devices_scan`, `devices_connect_*`, `apply_theme`, `backup_now`, `mqtt_*`, `shots_update`. `profiles_set/clear_auto_load` considered, left out per maintainer scope decision (strong-4 only) — possible later follow-up. `machine_*` already handled (in-app dialog / chat-L2).

## Verification

Qt Creator build **0/0**; full suite **47 suites / 2166 / 0 failed** (direct binaries). No confirmation-flow unit harness exists (`needsChatConfirmation` is private + needs full `McpServer`; same accepted MCP-seam boundary #1219/#1220 established) — **authoritative check is the on-device retry of observe mode + a destructive-tool prompt after this ships**.

## Impact

Until this lands in an installed build, observe mode cannot be set, so the #1219 §9.2 field run and #1220 §8.1 `kScaleStallConfirmMs` calibration stay blocked. Recommend merge → updated v1.7.5 pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)