### PR TITLE
fix(ble): reject DiFluid R2 out-of-range TDS sentinel before it is saved

### DIFF
--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -231,6 +231,13 @@ Page {
     // Real espresso TDS is 5–22%; below 3.0% is a calibration or empty cuvette.
     readonly property real kMinimumPlausibleTds: 3.0
 
+    // Above the R2's physical measurement range it's a device error sentinel,
+    // not a reading (the R2 emitted raw 0xFFE5 → 655.09% during a failed
+    // measurement and it was autosaved onto a shot). Symmetric with
+    // kMinimumPlausibleTds so the physical R2 Start button and the "Read TDS"
+    // button — both of which arrive via onTdsChanged — are gated identically.
+    readonly property real kMaximumPlausibleTds: 35.0
+
     // Gate by visibility so device-initiated R2 readings between shots don't
     // land on whichever shot happens to be loaded.
     //
@@ -253,6 +260,13 @@ Page {
             if (tds < postShotReviewPage.kMinimumPlausibleTds) {
                 console.debug("[PostShotReview] R2 tds", tds.toFixed(2),
                     "dropped: below threshold", postShotReviewPage.kMinimumPlausibleTds,
+                    "shotId=", editShotId,
+                    "wasMeasuring=", (typeof Refractometer !== "undefined" && Refractometer) ? Refractometer.measuring : false)
+                return
+            }
+            if (tds > postShotReviewPage.kMaximumPlausibleTds) {
+                console.debug("[PostShotReview] R2 tds", tds.toFixed(2),
+                    "dropped: above threshold", postShotReviewPage.kMaximumPlausibleTds,
                     "shotId=", editShotId,
                     "wasMeasuring=", (typeof Refractometer !== "undefined" && Refractometer) ? Refractometer.measuring : false)
                 return

--- a/src/ble/refractometers/difluidr2.cpp
+++ b/src/ble/refractometers/difluidr2.cpp
@@ -19,6 +19,14 @@
 static constexpr uint8_t PACKET_HEADER = 0xDF;
 static constexpr int PACKET_MIN_LENGTH = 6;  // header(2) + func(1) + cmd(1) + datalen(1) + checksum(1)
 
+// DiFluid R2 hardware measurement ceiling (TDS %). Real coffee never approaches
+// this. When a measurement fails mid-flight the R2 emits an out-of-range
+// sentinel in the TDS field — observed as raw 0xFFE5 (65509 → 655.09%) one
+// packet before an `R2 error class=0 code=2` storm — which used to flow
+// through as a real reading and get autosaved onto the shot. Anything above
+// this is a failed measurement, not a value.
+static constexpr double MAX_PLAUSIBLE_TDS = 35.0;
+
 DiFluidR2::DiFluidR2(ScaleBleTransport* transport, QObject* parent)
     : QObject(parent)
     , m_transport(transport)
@@ -321,31 +329,17 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
         case 2: {
             // TDS result: Data1-2 = concentration * 100 (Data3-6 = refractive index, not parsed)
             if (dataLen < 3) return;
-            uint16_t tdsRaw = static_cast<uint16_t>(
+            quint16 tdsRaw = static_cast<quint16>(
                 (static_cast<uint8_t>(packet[6]) << 8) | static_cast<uint8_t>(packet[7]));
-            m_tds = tdsRaw / 100.0;
-            R2_LOG(QString("TDS: %1% (raw=%2)").arg(m_tds, 0, 'f', 2).arg(tdsRaw));
-            emit tdsChanged(m_tds);
-            emit measurementComplete();
-            m_measurementTimer.stop();
-            m_measuring = false;
-            emit measuringChanged();
+            emitTdsResult(tdsRaw, /*isAverage=*/false);
             break;
         }
         case 3: {
             // Average result: same format as pack 2
             if (dataLen < 3) return;
-            uint16_t tdsRaw = static_cast<uint16_t>(
+            quint16 tdsRaw = static_cast<quint16>(
                 (static_cast<uint8_t>(packet[6]) << 8) | static_cast<uint8_t>(packet[7]));
-            double avgTds = tdsRaw / 100.0;
-            R2_LOG(QString("Average TDS: %1% (raw=%2)").arg(avgTds, 0, 'f', 2).arg(tdsRaw));
-            // Use average as the final TDS
-            m_tds = avgTds;
-            emit tdsChanged(m_tds);
-            emit measurementComplete();
-            m_measurementTimer.stop();
-            m_measuring = false;
-            emit measuringChanged();
+            emitTdsResult(tdsRaw, /*isAverage=*/true);
             break;
         }
         case 4: {
@@ -361,6 +355,36 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
         // Non-action responses (device info, settings)
         R2_LOG(QString("Response: Func=%1 Cmd=%2").arg(func).arg(cmd));
     }
+}
+
+void DiFluidR2::emitTdsResult(quint16 tdsRaw, bool isAverage) {
+    const double tds = tdsRaw / 100.0;
+    const QString label = isAverage ? QStringLiteral("Average TDS")
+                                     : QStringLiteral("TDS");
+
+    // The R2's failure sentinel lands in the same field as a real reading and
+    // passes the checksum (it's a well-formed packet). The only thing that
+    // distinguishes it is being physically impossible — gate on that. This is
+    // the single chokepoint for every TDS that can reach a consumer: the app's
+    // "Read TDS" button (single test → pack 2), the physical R2 Start button
+    // (streamed pack 2), and the averaged result (pack 3) all arrive here.
+    if (tds > MAX_PLAUSIBLE_TDS) {
+        R2_WARN(QString("%1 out of range: %2% (raw=%3) — ignoring")
+                    .arg(label).arg(tds, 0, 'f', 2).arg(tdsRaw));
+        emit errorOccurred("R2 reported an out-of-range value");
+        m_measurementTimer.stop();
+        m_measuring = false;
+        emit measuringChanged();
+        return;
+    }
+
+    m_tds = tds;
+    R2_LOG(QString("%1: %2% (raw=%3)").arg(label).arg(tds, 0, 'f', 2).arg(tdsRaw));
+    emit tdsChanged(m_tds);
+    emit measurementComplete();
+    m_measurementTimer.stop();
+    m_measuring = false;
+    emit measuringChanged();
 }
 
 bool DiFluidR2::validateChecksum(const QByteArray& packet) const {

--- a/src/ble/refractometers/difluidr2.h
+++ b/src/ble/refractometers/difluidr2.h
@@ -17,9 +17,11 @@ class ScaleBleTransport;
  * Service 0x00FF, characteristic 0xAA01.
  *
  * Emits tdsChanged on every completed measurement, including device-initiated
- * ones (physical button on the R2, idle polls). Physically-impossible readings
- * (the R2's out-of-range error sentinel) are dropped here so they can never be
- * persisted; consumers must still gate by context (which shot is loaded).
+ * ones (the physical button on the R2). Physically-impossible readings (the
+ * R2's out-of-range error sentinel, above MAX_PLAUSIBLE_TDS) are dropped here
+ * so they can never be persisted. This is the only validation the driver does:
+ * the sub-threshold lower-bound plausibility filter (sub-3%) and context
+ * gating (which shot is loaded) remain the consumer's responsibility.
  */
 class DiFluidR2 : public QObject {
     Q_OBJECT

--- a/src/ble/refractometers/difluidr2.h
+++ b/src/ble/refractometers/difluidr2.h
@@ -17,8 +17,9 @@ class ScaleBleTransport;
  * Service 0x00FF, characteristic 0xAA01.
  *
  * Emits tdsChanged on every completed measurement, including device-initiated
- * ones (physical button on the R2, idle polls). Consumers must gate by context
- * and validate the value before persisting.
+ * ones (physical button on the R2, idle polls). Physically-impossible readings
+ * (the R2's out-of-range error sentinel) are dropped here so they can never be
+ * persisted; consumers must still gate by context (which shot is loaded).
  */
 class DiFluidR2 : public QObject {
     Q_OBJECT
@@ -67,6 +68,11 @@ private slots:
 
 private:
     void handlePacket(const QByteArray& packet);
+    // Shared TDS result path for pack 2 (single test — used by both the app's
+    // "Read TDS" button and the physical R2 Start button) and pack 3 (average).
+    // Applies the out-of-range sanity gate so every consumer-bound TDS is
+    // validated identically regardless of which path produced it.
+    void emitTdsResult(quint16 tdsRaw, bool isAverage);
     bool validateChecksum(const QByteArray& packet) const;
     void sendCommand(const QByteArray& cmd);
 

--- a/tests/tst_difluidr2.cpp
+++ b/tests/tst_difluidr2.cpp
@@ -207,6 +207,62 @@ private slots:
         QCOMPARE(completeSpy.count(), 1);
     }
 
+    // === Out-of-range sentinel rejection (regression) ===
+    //
+    // Field incident: a failed R2 measurement put raw 0xFFE5 (65509 → 655.09%)
+    // in the TDS field one packet before an `R2 error class=0 code=2` storm.
+    // The well-formed-but-impossible value passed the checksum, was emitted as
+    // a real reading, and got autosaved onto the shot (EY 1342.9%). It must
+    // never reach a consumer. Pack 2 is shared by the app "Read TDS" button
+    // (single test) and the physical R2 Start button, so one gate covers both.
+
+    void rejectsImplausiblyHighTds() {
+        DiFluidR2 r2(nullptr);
+        QSignalSpy tdsSpy(&r2, &DiFluidR2::tdsChanged);
+        QSignalSpy completeSpy(&r2, &DiFluidR2::measurementComplete);
+        QSignalSpy errorSpy(&r2, &DiFluidR2::errorOccurred);
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             QRegularExpression("TDS out of range.*raw=65509"));
+        r2.handlePacket(buildTdsPacket(655.09));  // raw = 65509 = 0xFFE5
+
+        QCOMPARE(tdsSpy.count(), 0);
+        QCOMPARE(completeSpy.count(), 0);
+        QCOMPARE(errorSpy.count(), 1);
+        QVERIFY(!r2.isMeasuring());
+        QCOMPARE(r2.tds(), 0.0);  // m_tds left untouched, no garbage retained
+    }
+
+    void rejectsImplausiblyHighAverageTds() {
+        // Same gate must apply to the averaged result (pack 3).
+        DiFluidR2 r2(nullptr);
+        QSignalSpy tdsSpy(&r2, &DiFluidR2::tdsChanged);
+        QSignalSpy completeSpy(&r2, &DiFluidR2::measurementComplete);
+        QSignalSpy errorSpy(&r2, &DiFluidR2::errorOccurred);
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             QRegularExpression("Average TDS out of range"));
+        r2.handlePacket(buildAverageTdsPacket(655.09));
+
+        QCOMPARE(tdsSpy.count(), 0);
+        QCOMPARE(completeSpy.count(), 0);
+        QCOMPARE(errorSpy.count(), 1);
+        QVERIFY(!r2.isMeasuring());
+    }
+
+    void acceptsTdsAtTopOfDeviceRange() {
+        // 30% is unusually strong but within the R2's physical range — the
+        // guard must not reject real (if rare) readings.
+        DiFluidR2 r2(nullptr);
+        QSignalSpy tdsSpy(&r2, &DiFluidR2::tdsChanged);
+
+        r2.handlePacket(buildTdsPacket(30.00));
+
+        QCOMPARE(tdsSpy.count(), 1);
+        QCOMPARE(tdsSpy.at(0).at(0).toDouble(), 30.00);
+        QCOMPARE(r2.tds(), 30.00);
+    }
+
     // === Temperature packet parsing ===
 
     void parseTemperaturePacket() {


### PR DESCRIPTION
## Problem

A coffee's TDS was saved as **655.09 %** (EY **1342.9 %**) on a shot. Investigation via the device debug log showed the DiFluid R2 emits an **out-of-range error sentinel** in the TDS field when a measurement fails mid-flight:

```
[296.409] TDS: 10.39% (raw=1039)      ← valid
[300.770] TDS: 10.28% (raw=1028)      ← valid
[305.106] Temperature: prism=27.9°C tank=39.7°C   ← tank temp spikes
[305.121] TDS: 655.09% (raw=65509)    ← garbage sentinel (0xFFE5)
[308.916] WARN [BLE DiFluidR2] R2 error: class=0 code=2   ← device errored
```

The `/100` scaling is **correct** (1039 → 10.39%); the bug is that the well-formed-but-impossible sentinel packet (`raw=0xFFE5`) passed the checksum, was emitted as a real reading, and got autosaved onto the shot.

Why the app's "Read TDS" button looked fine while the physical R2 Start button didn't: the button does a clean single test that finishes before the failure; the physical-button stream included the failure sentinel. **Both paths share the same `case 2` parser**, and the consumer guard in `PostShotReviewPage.onTdsChanged` only had a *lower* bound (`kMinimumPlausibleTds = 3.0`), so the inflated value sailed through.

## Fix

- Route pack 2 (single test — the app **Read TDS** button *and* the physical **R2 Start** button) and pack 3 (average) through one shared `emitTdsResult()` helper that drops any TDS above the device's physical range (`MAX_PLAUSIBLE_TDS = 35 %`). One chokepoint → **identical behaviour on both ingestion paths**, which was the explicit requirement.
- Mirror it with a symmetric `kMaximumPlausibleTds` in `PostShotReviewPage.onTdsChanged` (the documented consumer-validation point), so a garbage value cannot be persisted by either the C++ or QML layer.
- Valid readings (including unusually strong but in-range ones) and the existing low/zero path are unchanged.

## Tests

`tests/tst_difluidr2.cpp`:
- `rejectsImplausiblyHighTds` — exact field sentinel (raw 65509) on pack 2: no `tdsChanged`/`measurementComplete`, `errorOccurred` emitted, not measuring, `m_tds` untouched.
- `rejectsImplausiblyHighAverageTds` — same for pack 3.
- `acceptsTdsAtTopOfDeviceRange` — 30 % still passes (no over-rejection).

Run the `tst_DiFluidR2` suite in Qt Creator (BUILD_TESTS=ON) to verify.

## Note on the streamed-intermediate behaviour

The physical-button path autosaves every streamed reading; with the sentinel rejected, the last *valid* reading (≈10.28 % here) stays — correct and within 0.1 % of the clean app-button re-read (10.38 %). A "wait for Test finished before accepting" gate was deliberately **not** added: we have no log of a *successful* device-Start's finish signal, so gating risks regressing the working physical-button workflow, and the range guard already fully eliminates the reported bug on both paths. Can be revisited if a successful device-Start log is captured.

The affected shot's stored value was separately corrected (TDS 10.38 %, EY 21.3 %) out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)