### PR TITLE
fix(scale): drive stall detector by sample arrival, not value change (#1176)

### DIFF
--- a/src/ble/scaledevice.cpp
+++ b/src/ble/scaledevice.cpp
@@ -31,6 +31,10 @@ void ScaleDevice::setSimulationMode(bool enabled) {
         m_weight = 0.0;
         m_flowRate = 0.0;
         m_batteryLevel = 85;
+        // Keep the liveness contract intact: every weight value this layer
+        // publishes also goes out on weightSampleReceived (the stall detector
+        // and SAW path listen only to that, never weightChanged). #1176.
+        emit weightSampleReceived(m_weight);
         emit weightChanged(m_weight);
         emit flowRateChanged(m_flowRate);
         emit batteryLevelChanged(m_batteryLevel);

--- a/src/ble/scaledevice.cpp
+++ b/src/ble/scaledevice.cpp
@@ -83,6 +83,11 @@ void ScaleDevice::setConnected(bool connected) {
 }
 
 void ScaleDevice::setWeight(double weight) {
+    // Unconditional: a sample arrived. Drives the scale-feed stall detector and
+    // SAW de-jitter, which must track sample arrival, not value change (#1176).
+    emit weightSampleReceived(weight);
+    // Deduped: only on a genuine value change. Drives the `weight` Q_PROPERTY,
+    // QML bindings and MQTT — a constant reading must not churn those.
     if (m_weight != weight) {
         m_weight = weight;
         emit weightChanged(weight);

--- a/src/ble/scaledevice.cpp
+++ b/src/ble/scaledevice.cpp
@@ -86,8 +86,9 @@ void ScaleDevice::setWeight(double weight) {
     // Unconditional: a sample arrived. Drives the scale-feed stall detector and
     // SAW de-jitter, which must track sample arrival, not value change (#1176).
     emit weightSampleReceived(weight);
-    // Deduped: only on a genuine value change. Drives the `weight` Q_PROPERTY,
-    // QML bindings and MQTT — a constant reading must not churn those.
+    // Deduped: only on a genuine value change. Drives the `weight` Q_PROPERTY
+    // and QML bindings (and onScaleWeightChanged, which feeds MQTT) — a
+    // constant reading must not churn those.
     if (m_weight != weight) {
         m_weight = weight;
         emit weightChanged(weight);

--- a/src/ble/scaledevice.h
+++ b/src/ble/scaledevice.h
@@ -70,10 +70,14 @@ public slots:
 signals:
     void connectedChanged();
     void weightChanged(double weight);
-    // Liveness signal: emitted for EVERY accepted weight sample, including ones
-    // whose value equals the previous reading. weightChanged is intentionally
-    // deduped (drives the `weight` Q_PROPERTY / QML bindings / MQTT — a constant
-    // value must not churn those). But the scale-feed stall detector and SAW
+    // Liveness signal: emitted for every weight sample that passes through
+    // setWeight() — including ones whose value equals the previous reading.
+    // (Synthetic resets that emit weightChanged directly, e.g.
+    // setSimulationMode(), are not device samples and deliberately do not emit
+    // this.) weightChanged is intentionally deduped (drives the `weight`
+    // Q_PROPERTY / QML bindings, and onScaleWeightChanged which feeds MQTT — a
+    // constant value must not churn those). But the scale-feed stall detector
+    // and SAW
     // de-jitter need sample *arrival*, not value *change*: a healthy scale
     // reporting a constant weight (a static cup through DE1 preheat) is
     // otherwise indistinguishable from a dead feed and trips a false stall →

--- a/src/ble/scaledevice.h
+++ b/src/ble/scaledevice.h
@@ -70,14 +70,12 @@ public slots:
 signals:
     void connectedChanged();
     void weightChanged(double weight);
-    // Liveness signal: emitted for every weight sample that passes through
-    // setWeight() — including ones whose value equals the previous reading.
-    // (Synthetic resets that emit weightChanged directly, e.g.
-    // setSimulationMode(), are not device samples and deliberately do not emit
-    // this.) weightChanged is intentionally deduped (drives the `weight`
-    // Q_PROPERTY / QML bindings, and onScaleWeightChanged which feeds MQTT — a
-    // constant value must not churn those). But the scale-feed stall detector
-    // and SAW
+    // Liveness signal: emitted for every weight value this layer publishes —
+    // every setWeight() sample including unchanged repeats, plus the synthetic
+    // setSimulationMode() reset. weightChanged is intentionally deduped (drives
+    // the `weight` Q_PROPERTY / QML bindings, and onScaleWeightChanged which
+    // feeds MQTT — a constant value must not churn those). But the scale-feed
+    // stall detector and SAW
     // de-jitter need sample *arrival*, not value *change*: a healthy scale
     // reporting a constant weight (a static cup through DE1 preheat) is
     // otherwise indistinguishable from a dead feed and trips a false stall →

--- a/src/ble/scaledevice.h
+++ b/src/ble/scaledevice.h
@@ -70,6 +70,16 @@ public slots:
 signals:
     void connectedChanged();
     void weightChanged(double weight);
+    // Liveness signal: emitted for EVERY accepted weight sample, including ones
+    // whose value equals the previous reading. weightChanged is intentionally
+    // deduped (drives the `weight` Q_PROPERTY / QML bindings / MQTT — a constant
+    // value must not churn those). But the scale-feed stall detector and SAW
+    // de-jitter need sample *arrival*, not value *change*: a healthy scale
+    // reporting a constant weight (a static cup through DE1 preheat) is
+    // otherwise indistinguishable from a dead feed and trips a false stall →
+    // mid-shot connection-priority backoff / ruined shot. See #1176, #1185.
+    // WeightProcessor::processWeight is wired to THIS, never weightChanged.
+    void weightSampleReceived(double weight);
     void flowRateChanged(double rate);
     void batteryLevelChanged(int level);
     void buttonPressed(int button);

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -46,6 +46,12 @@ void WeightProcessor::processWeight(double weight)
     } else {
         m_consecutiveRejections = 0;
     }
+    // Captured before the overwrite below: pre-#1176, a sample equal to the
+    // previous one was dropped by ScaleDevice's weightChanged dedup, so a
+    // static-weight window (empty cup through DE1 EspressoPreheating) starved
+    // this slot and tripped a false scale-feed stall. Such samples now arrive
+    // via weightSampleReceived; see the diagnostic after the de-jitter block.
+    const bool sampleValueUnchanged = m_hasLastWeight && weight == m_lastRawWeight;
     m_hasLastWeight = true;
     m_lastRawWeight = weight;
 
@@ -64,6 +70,25 @@ void WeightProcessor::processWeight(double weight)
 
     qint64 sinceLast = m_lastWallClockMs > 0 ? (wallClock - m_lastWallClockMs) : -1;
     m_lastWallClockMs = wallClock;
+
+    // #1176 liveness diagnostic. An unchanged-value sample during a shot's
+    // static window (classically an empty cup through EspressoPreheating)
+    // would, pre-fix, have been swallowed by ScaleDevice's weightChanged
+    // dedup — the feed looked dead and a false scale-feed stall fired. It now
+    // reaches us via weightSampleReceived. Log it (throttled ~2s, shot context
+    // only) so the fix is provable from a field debug log without needing the
+    // recorded weight curve. Event-based throttle (no timer): gated on sample
+    // arrival + the injected wall clock.
+    if (sampleValueUnchanged && (m_active || m_preheatActive) && m_tareComplete
+        && (m_lastConstantSampleLogMs == 0
+            || wallClock - m_lastConstantSampleLogMs >= 2000)) {
+        m_lastConstantSampleLogMs = wallClock;
+        qInfo().noquote()
+            << "[ScaleFeed] alive: constant weight"
+            << QString::number(weight, 'f', 1)
+            << "g still streaming via weightSampleReceived"
+            << "(pre-#1176 this static window read as a stalled feed)";
+    }
 
     // Scale-feed liveness: a genuine (non-spike) sample arrived, so the feed
     // is alive again — clear the stall flag so a later stall in this shot can
@@ -433,6 +458,7 @@ void WeightProcessor::startExtraction()
     m_settleCount = 0;
     m_lastTareWarnMs = 0;
     m_lastLowFlowLogMs = 0;
+    m_lastConstantSampleLogMs = 0;
     m_flowBecameValidLogged = false;
     m_untaredCupSignalled = false;
     m_lastWallClockMs = 0;
@@ -485,6 +511,7 @@ void WeightProcessor::resetForRetare()
     m_uncalibratedBatchWarned = false;  // Timestamps cleared — de-jitter needs recalibration
     m_lastTareWarnMs = 0;
     m_lastLowFlowLogMs = 0;
+    m_lastConstantSampleLogMs = 0;
     m_flowBecameValidLogged = false;
     qDebug() << "[SAW-Worker] Reset for auto-retare";
 }

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -170,6 +170,9 @@ private:
     // Log throttle timestamps — reset each shot so warnings are never suppressed at shot start
     qint64 m_lastTareWarnMs = 0;
     qint64 m_lastLowFlowLogMs = 0;
+    // Throttle for the #1176 constant-weight liveness diagnostic, logged off
+    // the unconditional weightSampleReceived path. 0 = not logged this shot.
+    qint64 m_lastConstantSampleLogMs = 0;
     bool m_flowBecameValidLogged = false;  // Log once when flowShort transitions 0→valid
     bool m_untaredCupSignalled = false;   // Fire untaredCupDetected only once per extraction
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -587,7 +587,7 @@ int main(int argc, char *argv[])
 
     // Scale → WeightProcessor (main → worker, auto QueuedConnection)
     // Initially connected to FlowScale; reconnected when physical scale is found
-    QObject::connect(&flowScale, &ScaleDevice::weightChanged,
+    QObject::connect(&flowScale, &ScaleDevice::weightSampleReceived,
                      &weightProcessor, &WeightProcessor::processWeight);
 
     // WeightProcessor → DE1Device: stop-at-weight.
@@ -1357,7 +1357,7 @@ int main(int argc, char *argv[])
                 machineState.setScale(&flowScale);  // Switch to FlowScale first
                 timingController.setScale(&flowScale);
                 // Reconnect FlowScale to WeightProcessor temporarily
-                QObject::connect(&flowScale, &ScaleDevice::weightChanged,
+                QObject::connect(&flowScale, &ScaleDevice::weightSampleReceived,
                                  &weightProcessor, &WeightProcessor::processWeight);
                 bleManager.setScaleDevice(nullptr);  // Clear BLEManager's reference
                 physicalScale.reset();  // Now safe to delete old scale
@@ -1400,7 +1400,7 @@ int main(int argc, char *argv[])
         // Disconnect FlowScale from graph and weight processor
         QObject::disconnect(&flowScale, &ScaleDevice::weightChanged,
                             &mainController, &MainController::onScaleWeightChanged);
-        QObject::disconnect(&flowScale, &ScaleDevice::weightChanged,
+        QObject::disconnect(&flowScale, &ScaleDevice::weightSampleReceived,
                             &weightProcessor, &WeightProcessor::processWeight);
 
         // Connect physical scale weight updates to MainController (permanent for scale lifetime).
@@ -1468,10 +1468,10 @@ int main(int argc, char *argv[])
                 // Disconnect FlowScale from graph and weight processor
                 QObject::disconnect(&flowScale, &ScaleDevice::weightChanged,
                                     &mainController, &MainController::onScaleWeightChanged);
-                QObject::disconnect(&flowScale, &ScaleDevice::weightChanged,
+                QObject::disconnect(&flowScale, &ScaleDevice::weightSampleReceived,
                                     &weightProcessor, &WeightProcessor::processWeight);
                 // Connect physical scale to weight processor
-                QObject::connect(physicalScale.get(), &ScaleDevice::weightChanged,
+                QObject::connect(physicalScale.get(), &ScaleDevice::weightSampleReceived,
                                  &weightProcessor, &WeightProcessor::processWeight);
                 // Notify MQTT
                 if (mainController.mqttClient()) {
@@ -1485,12 +1485,12 @@ int main(int argc, char *argv[])
                 timingController.setScale(&flowScale);
                 engine.rootContext()->setContextProperty("ScaleDevice", &flowScale);
                 // Disconnect physical scale from weight processor
-                QObject::disconnect(physicalScale.get(), &ScaleDevice::weightChanged,
+                QObject::disconnect(physicalScale.get(), &ScaleDevice::weightSampleReceived,
                                     &weightProcessor, &WeightProcessor::processWeight);
                 // Reconnect FlowScale to graph and weight processor
                 QObject::connect(&flowScale, &ScaleDevice::weightChanged,
                                  &mainController, &MainController::onScaleWeightChanged);
-                QObject::connect(&flowScale, &ScaleDevice::weightChanged,
+                QObject::connect(&flowScale, &ScaleDevice::weightSampleReceived,
                                  &weightProcessor, &WeightProcessor::processWeight);
                 // Notify MQTT
                 if (mainController.mqttClient()) {
@@ -1539,11 +1539,11 @@ int main(int argc, char *argv[])
             // Disconnect first to avoid duplicate connections if connectedChanged fires during reset().
             QObject::disconnect(&flowScale, &ScaleDevice::weightChanged,
                                 &mainController, &MainController::onScaleWeightChanged);
-            QObject::disconnect(&flowScale, &ScaleDevice::weightChanged,
+            QObject::disconnect(&flowScale, &ScaleDevice::weightSampleReceived,
                                 &weightProcessor, &WeightProcessor::processWeight);
             QObject::connect(&flowScale, &ScaleDevice::weightChanged,
                              &mainController, &MainController::onScaleWeightChanged);
-            QObject::connect(&flowScale, &ScaleDevice::weightChanged,
+            QObject::connect(&flowScale, &ScaleDevice::weightSampleReceived,
                              &weightProcessor, &WeightProcessor::processWeight);
             // Notify MQTT that scale is disconnected
             if (mainController.mqttClient()) {
@@ -1727,13 +1727,13 @@ int main(int argc, char *argv[])
         // Disconnect FlowScale from graph and weight processor
         QObject::disconnect(&flowScale, &ScaleDevice::weightChanged,
                             &mainController, &MainController::onScaleWeightChanged);
-        QObject::disconnect(&flowScale, &ScaleDevice::weightChanged,
+        QObject::disconnect(&flowScale, &ScaleDevice::weightSampleReceived,
                             &weightProcessor, &WeightProcessor::processWeight);
 
         // Connect USB scale weight updates
         QObject::connect(usbScale, &ScaleDevice::weightChanged,
                          &mainController, &MainController::onScaleWeightChanged);
-        QObject::connect(usbScale, &ScaleDevice::weightChanged,
+        QObject::connect(usbScale, &ScaleDevice::weightSampleReceived,
                          &weightProcessor, &WeightProcessor::processWeight);
 
         // Save USB scale as the active scale type (so Settings panel shows it)
@@ -1756,7 +1756,7 @@ int main(int argc, char *argv[])
         if (usbScaleManager.scale()) {
             QObject::disconnect(usbScaleManager.scale(), &ScaleDevice::weightChanged,
                                 &mainController, &MainController::onScaleWeightChanged);
-            QObject::disconnect(usbScaleManager.scale(), &ScaleDevice::weightChanged,
+            QObject::disconnect(usbScaleManager.scale(), &ScaleDevice::weightSampleReceived,
                                 &weightProcessor, &WeightProcessor::processWeight);
         }
 
@@ -1773,7 +1773,7 @@ int main(int argc, char *argv[])
             // Reconnect FlowScale
             QObject::connect(&flowScale, &ScaleDevice::weightChanged,
                              &mainController, &MainController::onScaleWeightChanged);
-            QObject::connect(&flowScale, &ScaleDevice::weightChanged,
+            QObject::connect(&flowScale, &ScaleDevice::weightSampleReceived,
                              &weightProcessor, &WeightProcessor::processWeight);
             qDebug() << "[USB Scale] Lost — falling back to FlowScale";
         }
@@ -2061,7 +2061,7 @@ int main(int argc, char *argv[])
         }
 
         // Reconnect WeightProcessor from FlowScale to SimulatedScale for espresso SAW
-        QObject::disconnect(&flowScale, &ScaleDevice::weightChanged,
+        QObject::disconnect(&flowScale, &ScaleDevice::weightSampleReceived,
                             &weightProcessor, &WeightProcessor::processWeight);
 
         // Helper: apply current simulatedScaleEnabled state.
@@ -2074,14 +2074,14 @@ int main(int argc, char *argv[])
                 QObject::connect(&de1Simulator, &DE1Simulator::scaleWeightChanged,
                                  &simulatedScale, &SimulatedScale::setSimulatedWeight,
                                  Qt::UniqueConnection);
-                QObject::connect(&simulatedScale, &ScaleDevice::weightChanged,
+                QObject::connect(&simulatedScale, &ScaleDevice::weightSampleReceived,
                                  &weightProcessor, &WeightProcessor::processWeight,
                                  Qt::UniqueConnection);
             } else {
                 simulatedScale.simulateDisconnection();
                 QObject::disconnect(&de1Simulator, &DE1Simulator::scaleWeightChanged,
                                     &simulatedScale, &SimulatedScale::setSimulatedWeight);
-                QObject::disconnect(&simulatedScale, &ScaleDevice::weightChanged,
+                QObject::disconnect(&simulatedScale, &ScaleDevice::weightSampleReceived,
                                     &weightProcessor, &WeightProcessor::processWeight);
             }
         };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -483,6 +483,15 @@ add_decenza_test(tst_weightprocessor
     ${CMAKE_SOURCE_DIR}/src/machine/weightprocessor.cpp
 )
 
+# --- tst_scalefeedliveness: stall detector driven by sample arrival, not value
+# change — a constant weight must not trip a false stall (#1176/#1185) ---
+add_decenza_test(tst_scalefeedliveness
+    tst_scalefeedliveness.cpp
+    mocks/MockScaleDevice.h
+    ${CMAKE_SOURCE_DIR}/src/ble/scaledevice.cpp
+    ${CMAKE_SOURCE_DIR}/src/machine/weightprocessor.cpp
+)
+
 # --- tst_scaleblepriority: connection-priority backoff decision logic (#1093/#1176) ---
 # BlePriorityDetector is header-only and Qt-free — no extra sources to link.
 add_decenza_test(tst_scaleblepriority

--- a/tests/tst_scalefeedliveness.cpp
+++ b/tests/tst_scalefeedliveness.cpp
@@ -29,7 +29,7 @@ class tst_ScaleFeedLiveness : public QObject {
         wp.setWallClock([this] { return m_clock; });
         wp.configure(36.0, 1, none, none, none, false, 0.38);
         wp.startExtraction();          // sets m_active=true, m_tareComplete=false,
-                                       // m_lastWallClockMs=0
+                                       // m_lastWallClockMs=0, resets stall tracking
         wp.setTareComplete(true);      // must follow startExtraction()
     }
 
@@ -112,5 +112,5 @@ private slots:
     }
 };
 
-QTEST_MAIN(tst_ScaleFeedLiveness)
+QTEST_GUILESS_MAIN(tst_ScaleFeedLiveness)
 #include "tst_scalefeedliveness.moc"

--- a/tests/tst_scalefeedliveness.cpp
+++ b/tests/tst_scalefeedliveness.cpp
@@ -1,0 +1,116 @@
+#include <QtTest>
+#include <QSignalSpy>
+#include <QVector>
+
+#include "ble/scaledevice.h"
+#include "machine/weightprocessor.h"
+#include "mocks/MockScaleDevice.h"
+
+// Regression coverage for the #1176 / #1185 root cause.
+//
+// The scale-feed stall detector (and SAW de-jitter) must be driven by sample
+// *arrival*, not value *change*. ScaleDevice::weightChanged is deduped (it
+// backs the `weight` Q_PROPERTY / QML / MQTT, which must not churn on a
+// constant reading). Before the fix, WeightProcessor::processWeight was wired
+// to weightChanged, so a healthy scale reporting a constant weight through the
+// EspressoPreheating dwell looked identical to a dead feed → false SUSPECTED →
+// CONFIRMED stall → mid-shot connection-priority backoff (scale bounce /
+// ruined shot). The fix adds ScaleDevice::weightSampleReceived (unconditional)
+// and points the processing pipeline at it.
+//
+// Uses an injectable fake clock — no real-time waits.
+class tst_ScaleFeedLiveness : public QObject {
+    Q_OBJECT
+
+    qint64 m_clock = 1000000;  // arbitrary fake-clock origin (ms)
+
+    void configureActiveShot(WeightProcessor& wp) {
+        const QVector<double> none;
+        wp.setWallClock([this] { return m_clock; });
+        wp.configure(36.0, 1, none, none, none, false, 0.38);
+        wp.startExtraction();          // sets m_active=true, m_tareComplete=false,
+                                       // m_lastWallClockMs=0
+        wp.setTareComplete(true);      // must follow startExtraction()
+    }
+
+private slots:
+
+    void init() { m_clock = 1000000; }
+
+    // The fix contract, at the ScaleDevice chokepoint: every accepted sample
+    // emits weightSampleReceived; weightChanged stays deduped.
+    void sampleSignalFiresEvenWhenValueUnchanged() {
+        MockScaleDevice scale;
+        QSignalSpy sampleSpy(&scale, &ScaleDevice::weightSampleReceived);
+        QSignalSpy changeSpy(&scale, &ScaleDevice::weightChanged);
+
+        scale.mockSetWeight(0.0);   // equals default m_weight → no value change
+        scale.mockSetWeight(0.0);
+        scale.mockSetWeight(0.0);
+        QCOMPARE(sampleSpy.count(), 3);   // liveness: every sample
+        QCOMPARE(changeSpy.count(), 0);   // dedup: nothing changed
+
+        scale.mockSetWeight(1.5);   // genuine change
+        scale.mockSetWeight(1.5);   // unchanged again
+        QCOMPARE(sampleSpy.count(), 5);
+        QCOMPARE(changeSpy.count(), 1);
+    }
+
+    // Regression: a constant weight stream through a 15 s preheat-style dwell,
+    // wired the FIXED way (weightSampleReceived → processWeight), must NOT trip
+    // any scale-feed stall — the scale is alive, it just isn't changing.
+    void constantWeightOnSampleSignalDoesNotStall() {
+        MockScaleDevice scale;
+        WeightProcessor wp;
+        configureActiveShot(wp);
+        QObject::connect(&scale, &ScaleDevice::weightSampleReceived,
+                         &wp, &WeightProcessor::processWeight);
+
+        QSignalSpy suspected(&wp, &WeightProcessor::scaleFeedStalled);
+        QSignalSpy confirmed(&wp, &WeightProcessor::scaleFeedStallConfirmed);
+
+        // 15 s: scale at 10 Hz reporting a dead-static 0.0 g, DE1 telemetry
+        // tick (setCurrentFrame) at ~5 Hz — exactly the #1176 EspressoPreheating
+        // window. kScaleStaleMs=2000, kScaleStallConfirmMs=6000.
+        for (int i = 0; i < 150; ++i) {
+            scale.mockSetWeight(0.0);
+            if (i % 2 == 0) wp.setCurrentFrame(0);
+            m_clock += 100;
+        }
+
+        QCOMPARE(suspected.count(), 0);
+        QCOMPARE(confirmed.count(), 0);
+    }
+
+    // Contrast: the SAME constant feed wired the OLD way (deduped
+    // weightChanged) MUST still confirm a false stall. This keeps the exact
+    // #1176 failure reproducible so a future rewiring to weightChanged can't
+    // silently regress.
+    void constantWeightOnChangedSignalStillStalls() {
+        MockScaleDevice scale;
+        WeightProcessor wp;
+        configureActiveShot(wp);
+        QObject::connect(&scale, &ScaleDevice::weightChanged,
+                         &wp, &WeightProcessor::processWeight);
+
+        // Prime once with a changing reading so m_lastWallClockMs is set
+        // (mirrors the real first/tare reading before the static dwell).
+        scale.mockSetWeight(0.2);
+        m_clock += 100;
+
+        QSignalSpy confirmed(&wp, &WeightProcessor::scaleFeedStallConfirmed);
+
+        for (int i = 0; i < 150; ++i) {
+            scale.mockSetWeight(0.2);   // unchanged → weightChanged never fires
+            if (i % 2 == 0) wp.setCurrentFrame(0);
+            m_clock += 100;
+        }
+
+        QVERIFY2(confirmed.count() >= 1,
+                 "deduped weightChanged wiring must still reproduce the #1176 "
+                 "false stall — otherwise this regression test proves nothing");
+    }
+};
+
+QTEST_MAIN(tst_ScaleFeedLiveness)
+#include "tst_scalefeedliveness.moc"


### PR DESCRIPTION
## Root cause of #1176 — found, and it's a one-line app bug

The scale-feed stall detector + SAW de-jitter were fed by `ScaleDevice::weightChanged`, which is **deduped**:

```cpp
void ScaleDevice::setWeight(double weight) {
    if (m_weight != weight) {        // unchanged value is silently dropped
        m_weight = weight;
        emit weightChanged(weight);
    }
}
```

The dedup is correct for what `weightChanged` backs — the `weight` Q_PROPERTY, QML bindings, MQTT — none of which should churn on a constant reading. But `WeightProcessor::processWeight` (the stall/liveness + SAW input) was wired to the **same** deduped signal.

So a perfectly healthy scale reporting a **constant** weight through the DE1 `EspressoPreheating` dwell (a static cup at `0.0 g`) emits **zero** `weightChanged` signals → `processWeight` never runs → `m_lastWallClockMs` goes stale → the DE1-tick stall evaluator (`setCurrentFrame → checkScaleFeedStall`) sees a growing gap → **SUSPECTED → CONFIRMED → mid-shot connection-priority backoff** (scale bounce / ruined shot, e.g. GCDE-VER1's `finalWeightG=0.3`). This is exactly #1176, and the symptom the #1185/#1219/#1220 backoff machinery was chasing.

### Why it's *here*, not Qt / Android / scale firmware (all checked)

- **Qt Android path:** `QtBluetoothLE.java` `handleOnCharacteristicChanged` → `QLowEnergyControllerPrivateAndroid::characteristicChanged` emits **unconditionally** — no value comparison, no dedup.
- **Android:** `BluetoothGattCallback.onCharacteristicChanged` fires per notification and does not coalesce identical GATT notifications.
- **Decent driver:** `DecentScale::parseWeightData` → `setWeight()` with no unchanged-value skip.
- `ScaleDevice::setWeight`'s `!=` guard is the **only** suppressor in the entire chain — and the reporter reflashed the scale firmware with **no change**, consistent with the suppression being app-side.

This also explains every prior observation: "always during preheating" (only long static-zero dwell), the drift-vs-static discriminator across the 4-month corpus + today's shots, independence from connection-priority era (no-HIGH / silently-broken-HIGH / dual-HIGH) and from read-after-write, and GCDE-VER1's latest build still failing with both links BALANCED from boot.

## The fix

- Add `ScaleDevice::weightSampleReceived(double)` — emitted **unconditionally** for every accepted sample.
- Repoint **all 16** `WeightProcessor::processWeight` connect/disconnect sites in `main.cpp` (physical / flow / USB / simulated) to it.
- Leave `weightChanged` deduped for the **13** `onScaleWeightChanged` / MQTT / UI sites — bindings still don't churn on a constant reading.

Minimal, root-cause, correct layer (`ScaleDevice` — covers all scale types); no new setting, no timer, no firmware change. Makes the spurious scale-feed-stall trigger effectively impossible, which retires the enforce/mid-shot-bounce path for this cause (it was treating a symptom of this `!=` filter).

## Tests

`tests/tst_scalefeedliveness.cpp`:
1. `sampleSignalFiresEvenWhenValueUnchanged` — the `setWeight` emit contract (sample fires every time; changed deduped).
2. `constantWeightOnSampleSignalDoesNotStall` — 15 s static `0.0` on the fixed wiring trips no SUSPECTED/CONFIRMED.
3. `constantWeightOnChangedSignalStillStalls` — same feed on the old wiring still confirms the #1176 false stall, so a regression to the wrong signal can't pass silently.

Not built here (project convention: builds run in Qt Creator). Needs `-DBUILD_TESTS=ON`; run `tst_scalefeedliveness`.

Relates to #1176, #1185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)