### PR TITLE
fix(ble): never bounce the scale mid-shot on connection-priority backoff (#1176)

### DIFF
--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -399,6 +399,14 @@ void QtScaleBleTransport::onScaleFeedResumed(qint64 gapMs) {
             QStringLiteral("scale-feed-stall"), gapSec));
 }
 
+void QtScaleBleTransport::setShotActive(bool active) {
+    // Set by MachineState (main.cpp): true from EspressoPreheating through
+    // shot end. Only gates the teardown decision in triggerScaleBackoff();
+    // detection itself is unaffected. Silent — the backoff log states the
+    // shot state when it matters.
+    m_shotActive = active;
+}
+
 void QtScaleBleTransport::logWouldBackoff(const QString& reason,
                                           const QString& triggerKind,
                                           double stallSec) {
@@ -421,31 +429,49 @@ void QtScaleBleTransport::triggerScaleBackoff(const char* reason,
     // app run (no loop, no re-trigger by any scale).
     // WARN-level: this is the headline event for log-based field validation.
     warn(QString("Scale connection-priority BACKOFF triggered: %1 — skipping "
-                 "HIGH and reconnecting the scale at BALANCED")
+                 "HIGH for subsequent scale connections")
              .arg(QString::fromUtf8(reason)));
     // Latch the decision app-run-wide so every scale (incl. one connected
     // after a scale-type change, which builds a fresh transport+detector)
-    // skips HIGH for the rest of this run. In-memory only; cleared on restart.
+    // skips HIGH for the rest of this run; epoch-persisted (#1220) so the
+    // next launch also starts at BALANCED. In-memory part cleared on restart.
     if (auto* mgr = BLEManager::instance()) {
         mgr->latchScaleSkipHighPriority(triggerKind);
         warn(QStringLiteral("Scale connection-priority: app-run skip-HIGH latch "
              "SET (trigger=%1) — all scales will run at BALANCED until app "
              "restart or MCP reset").arg(triggerKind));
     }
-    // Tear down the link, then emit disconnected() explicitly.
-    // disconnectFromDevice() calls m_controller->disconnect(), which severs
-    // ALL Qt signals from the controller — that alone is sufficient to
-    // guarantee onControllerDisconnected() never fires on this path, in ANY
-    // controller state, so disconnectFromDevice() does NOT emit disconnected()
-    // here. (Separately, for a fully-discovered scale in DiscoveredState the
-    // inner m_controller->disconnectFromDevice() is also skipped, so the BLE
-    // peer isn't explicitly notified — a distinct fact, NOT the reason the
-    // signal is missing.) We must therefore emit disconnected() ourselves —
-    // unconditionally, regardless of state — honouring the ScaleBleTransport
-    // contract, so the scale driver reaches setConnected(false) →
-    // ScaleDevice::connectedChanged, which the existing scale auto-reconnect
-    // (main.cpp) is gated on. Without it the backoff would be a permanent
-    // scale drop instead of a reconnect-at-BALANCED.
+
+    // #1176: NEVER tear down the scale link mid-shot. A disconnect+reconnect
+    // during preheat/extraction loses several seconds of weight — that bounce
+    // itself caused some of the very shot failures this feature was meant to
+    // prevent — and BALANCED cannot rescue the in-progress shot anyway (it
+    // only helps the *next* connection). So if a shot is in progress, latch
+    // only and let BALANCED take effect at the next natural (re)connect.
+    // scale-feed-stall is by construction always in-shot (WeightProcessor
+    // only confirms during extraction/preheat); force-treat it as in-shot
+    // even if the queued shotEnded raced ahead of the queued confirm.
+    const bool inShot =
+        m_shotActive || triggerKind == QStringLiteral("scale-feed-stall");
+    if (inShot) {
+        warn(QStringLiteral("Scale connection-priority: shot in progress — NOT "
+             "bouncing the scale mid-shot; skip-HIGH latched, BALANCED applies "
+             "at the next natural scale (re)connect (trigger=%1)")
+             .arg(triggerKind));
+        return;
+    }
+
+    // Idle / between shots: safe to bounce now so the upcoming shot starts at
+    // BALANCED. disconnectFromDevice() calls m_controller->disconnect(), which
+    // severs ALL Qt signals from the controller — sufficient to guarantee
+    // onControllerDisconnected() never fires on this path in ANY controller
+    // state, so disconnectFromDevice() does NOT emit disconnected() here. We
+    // therefore emit disconnected() ourselves so the scale driver reaches
+    // setConnected(false) → ScaleDevice::connectedChanged, which the existing
+    // scale auto-reconnect (main.cpp) is gated on. Without it the backoff
+    // would be a permanent scale drop instead of a reconnect-at-BALANCED.
+    warn(QStringLiteral("Scale connection-priority: idle — reconnecting the "
+         "scale now at BALANCED (trigger=%1)").arg(triggerKind));
     disconnectFromDevice();
     emit disconnected();
 }

--- a/src/ble/transport/qtscalebletransport.h
+++ b/src/ble/transport/qtscalebletransport.h
@@ -47,6 +47,7 @@ public slots:
     void onScaleFeedStalled(qint64 gapMs) override;
     void onScaleFeedStallConfirmed(qint64 gapMs) override;
     void onScaleFeedResumed(qint64 gapMs) override;
+    void setShotActive(bool active) override;
 
 private slots:
     void onControllerConnected();
@@ -86,6 +87,10 @@ private:
     QString m_deviceName;
     QString m_deviceId;  // UUID on iOS, address on other platforms - for duplicate detection
     bool m_connected = false;
+    // True from EspressoPreheating through shot end (fed by MachineState in
+    // main.cpp). Gates triggerScaleBackoff(): defer the teardown while a shot
+    // is in progress, bounce only when idle. #1176.
+    bool m_shotActive = false;
 
     // Connection-priority backoff. Pure decision logic in a Qt-free helper
     // (unit-tested in isolation); it lives on this transport, which persists

--- a/src/ble/transport/scalebletransport.h
+++ b/src/ble/transport/scalebletransport.h
@@ -129,6 +129,12 @@ public slots:
     // resumed on its own. `gapMs` is the measured silent duration. Default
     // no-op; only QtScaleBleTransport logs it (observe mode).
     virtual void onScaleFeedResumed(qint64 gapMs) { Q_UNUSED(gapMs); }
+    // Espresso-cycle bracket (#1176): true from EspressoPreheating through
+    // shot end, false at idle/between shots. QtScaleBleTransport uses it so a
+    // backoff DEFERS the skip-HIGH teardown while a shot is in progress (latch
+    // only, apply at the next natural reconnect) instead of bouncing the scale
+    // mid-shot; an idle backoff still reconnects immediately. Default no-op.
+    virtual void setShotActive(bool active) { Q_UNUSED(active); }
 
 signals:
     /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1448,6 +1448,22 @@ int main(int argc, char *argv[])
             QObject::connect(&weightProcessor, &WeightProcessor::scaleFeedStallConfirmed,
                              scaleTransport, &ScaleBleTransport::onScaleFeedStallConfirmed,
                              Qt::QueuedConnection);
+            // #1176: tell the transport when an espresso cycle is in progress
+            // (EspressoPreheating → shot end) so a triggered backoff DEFERS
+            // the skip-HIGH teardown instead of bouncing the scale mid-shot;
+            // an idle backoff still reconnects immediately. MachineState and
+            // the transport are both main-thread → AutoConnection (same
+            // rationale as the de1LinkFault wiring above). scaleTransport is
+            // the context object so these auto-disconnect on a scale-type
+            // change. No-op for transports keeping the base virtual no-op.
+            QObject::connect(&machineState, &MachineState::espressoCycleStarted,
+                             scaleTransport, [scaleTransport]() {
+                                 scaleTransport->setShotActive(true);
+                             });
+            QObject::connect(&machineState, &MachineState::shotEnded,
+                             scaleTransport, [scaleTransport]() {
+                                 scaleTransport->setShotActive(false);
+                             });
         }
 
         // When physical scale connects/disconnects, switch between physical and FlowScale


### PR DESCRIPTION
## Problem

`QtScaleBleTransport::triggerScaleBackoff()` unconditionally did `disconnectFromDevice()` + `emit disconnected()` to reconnect the scale at BALANCED. The `scale-feed-stall` trigger fires **only during a shot** (WeightProcessor confirms only while `(m_active || m_preheatActive) && m_tareComplete`), so that path always tore the scale down **mid-shot** — losing several seconds of weight during preinfusion/pour. That bounce itself produced some of GCDE-VER1's failures on builds 3388–3392, and BALANCED can't rescue the in-progress shot anyway (it only helps the *next* connection). The 4-month corpus also showed genuine stalls self-recover before the SAW target, so mid-shot action was never beneficial.

## Change

`triggerScaleBackoff()` now **always latches** skip-HIGH (epoch-persisted via #1220) and then gates the teardown on shot state:

- **Shot in progress** → latch only, **no teardown**. BALANCED applies at the next natural (re)connect — the model the observe-mode path already uses. `scale-feed-stall` is always treated as in-shot (it is, by construction) even if a queued `shotEnded` raced ahead of the queued confirm.
- **Idle / between shots** → bounce now, as before. The `de1-fault-cluster` trigger *can* fire with no shot running (e.g. clustered controller errors shortly after connect — seen in GCDE-VER1's log at uptime 24.8 s); reconnecting then is safe and gets the upcoming shot onto BALANCED.

Shot state is fed from `MachineState::espressoCycleStarted` (entering `EspressoPreheating`) → `shotEnded`, wired to a new `ScaleBleTransport::setShotActive()` slot. Base class default is a no-op (CoreBluetooth / iOS-macOS unaffected); only `QtScaleBleTransport` acts. Same-thread `AutoConnection`, `scaleTransport` as context object so the connections auto-disconnect on a scale-type change (consistent with the existing `de1LinkFault` wiring).

## Why this is safe (data-backed)

- Post-#1224 the false `scale-feed-stall` triggers are essentially gone (`recentObserveEvents: []` on the A9+), so enforce rarely fires at all.
- When a stall is genuine, it self-recovered before the SAW target across the 4-month corpus — no mid-shot action was ever needed.
- The mid-shot teardown can't rescue the current shot on any hardware tier; deferring still captures 100% of any real BALANCED benefit for subsequent connections. So this is strictly better on good *and* weak hardware, independent of the still-open weak-HW contention question.

## Verification

- Qt Creator build: succeeded, 0 errors, 0 warnings.
- Detector decision logic untouched (`BlePriorityDetector` / `tst_scaleblepriority` unaffected); only the teardown timing in the transport glue changed. No transport-level unit harness exists (needs Qt BLE), so this is build- + log-verified.

Relates to #1176, #1185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)