### PR TITLE
fix(android): catch DeadObjectException, not just DeadSystemException (#1227)

### DIFF
--- a/android/src/io/github/kulitorum/decenza_de1/DecenzaActivity.java
+++ b/android/src/io/github/kulitorum/decenza_de1/DecenzaActivity.java
@@ -65,16 +65,28 @@ public class DecenzaActivity extends QtActivity {
         super.onDestroy();
     }
 
-    // Catches both DeadObjectException (the common case: the Bluetooth GATT
-    // binder/process died — toggled off, OEM power policy, driver hiccup) and
-    // its subclass DeadSystemException (system_server died — deep sleep, OEM
-    // power management). Qt's QtBluetoothLE.executeWriteJob doesn't wrap the
+    // Catches three closely-related dead-binder cases:
+    //   1. DeadObjectException — the common case: a remote Bluetooth binder
+    //      we were writing to died (BT toggled off, OEM power policy, driver
+    //      hiccup). Covered by `instanceof DeadObjectException`. (Issue #1227)
+    //   2. DeadSystemException — system_server died. Subclass of
+    //      DeadObjectException so the same `instanceof` covers it.
+    //   3. DeadSystemRuntimeException — the API 31+ unchecked variant of
+    //      case 2. **Despite the name, it does NOT extend DeadObjectException**
+    //      (it extends RuntimeException directly), and is typically thrown
+    //      without a DeadObjectException in its cause chain, so the
+    //      `instanceof` check misses it. We fall back to a class-name
+    //      substring match to cover it. (Was caught by the original
+    //      `contains("DeadSystem")` filter in PR #544 / issue #538.)
+    // Qt's QtBluetoothLE.executeWriteJob doesn't wrap the
     // BluetoothGatt.writeCharacteristic binder call in try/catch (verified
     // through Qt 6.11.1), so the RuntimeException it raises lands here.
-    // Issues #189 (v1.5.0) and #1227 (v1.7.3).
+    // Issues #189 (v1.5.0), #538 (v1.4.x DeadSystemRuntimeException),
+    // #1227 (v1.7.3 DeadObjectException).
     private static boolean isDeadObjectException(Throwable t) {
         while (t != null) {
-            if (t instanceof DeadObjectException) {
+            if (t instanceof DeadObjectException
+                    || t.getClass().getName().contains("DeadSystem")) {
                 return true;
             }
             t = t.getCause();

--- a/android/src/io/github/kulitorum/decenza_de1/DecenzaActivity.java
+++ b/android/src/io/github/kulitorum/decenza_de1/DecenzaActivity.java
@@ -2,6 +2,7 @@ package io.github.kulitorum.decenza_de1;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.DeadObjectException;
 import android.util.Log;
 
 import org.qtproject.qt.android.bindings.QtActivity;
@@ -64,9 +65,16 @@ public class DecenzaActivity extends QtActivity {
         super.onDestroy();
     }
 
-    private static boolean isDeadSystemException(Throwable t) {
+    // Catches both DeadObjectException (the common case: the Bluetooth GATT
+    // binder/process died — toggled off, OEM power policy, driver hiccup) and
+    // its subclass DeadSystemException (system_server died — deep sleep, OEM
+    // power management). Qt's QtBluetoothLE.executeWriteJob doesn't wrap the
+    // BluetoothGatt.writeCharacteristic binder call in try/catch (verified
+    // through Qt 6.11.1), so the RuntimeException it raises lands here.
+    // Issues #189 (v1.5.0) and #1227 (v1.7.3).
+    private static boolean isDeadObjectException(Throwable t) {
         while (t != null) {
-            if (t.getClass().getName().contains("DeadSystem")) {
+            if (t instanceof DeadObjectException) {
                 return true;
             }
             t = t.getCause();
@@ -78,16 +86,18 @@ public class DecenzaActivity extends QtActivity {
         defaultHandler = Thread.getDefaultUncaughtExceptionHandler();
 
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
-            // DeadSystemException means Android's Bluetooth system service died
-            // (deep sleep, OEM power management, system_server crash).
-            // Create a flag file so the C++ side can detect it and trigger BLE
-            // recovery (disconnect + reconnect). This fires on any thread — we
-            // don't filter by thread name since DeadSystemException only occurs
-            // when Android system services die, which always affects BLE.
-            // Don't crash the app — the rest of the app is fine, only BLE is dead.
-            if (isDeadSystemException(throwable)) {
-                Log.w(TAG, "DeadSystemException on thread " + thread.getName()
-                        + " — Bluetooth system died, signaling BLE recovery");
+            // A DeadObjectException means the remote Bluetooth binder we
+            // were writing to died (toggled off, OEM power-managed away,
+            // GATT proxy unbound) — or, in the DeadSystemException subclass
+            // case, system_server itself died. In all of these the BLE
+            // handler thread is gone but the UI thread and the rest of the
+            // app are fine, so we drop a flag file for the C++ side to
+            // observe and trigger reconnect (see main.cpp ble recovery
+            // timer), and explicitly do NOT call defaultHandler — the
+            // process must stay alive.
+            if (isDeadObjectException(throwable)) {
+                Log.w(TAG, "DeadObjectException on thread " + thread.getName()
+                        + " — BLE binder died, signaling BLE recovery");
                 try {
                     File flagFile = new File(getFilesDir(), "ble_dead_system");
                     flagFile.createNewFile();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -866,11 +866,12 @@ int main(int argc, char *argv[])
         "idleGc", "()V");
     idleGcTimer->start();
 
-    // BLE dead system recovery: Android's Bluetooth system service can die
-    // (DeadSystemException) during deep sleep or OEM power management.
-    // When this happens, the Qt BLE handler thread dies but the app keeps running.
-    // The Java crash handler writes a flag file; we check for it every 10 seconds
-    // and trigger BLE reconnection if found.
+    // BLE dead-binder recovery: when the Bluetooth GATT binder/process dies
+    // (toggled off, OEM power policy, GATT proxy unbound) Qt's BLE handler
+    // thread raises a DeadObjectException (or its DeadSystemException
+    // subclass if system_server itself died). The Java crash handler catches
+    // both, keeps the app alive, and writes a flag file; we poll for it
+    // every 10 s and trigger BLE reconnection if found. Issues #189, #1227.
     auto* bleRecoveryTimer = new QTimer();
     bleRecoveryTimer->setInterval(10000);
     QObject::connect(bleRecoveryTimer, &QTimer::timeout,
@@ -882,7 +883,7 @@ int main(int argc, char *argv[])
         if (!flagFile.exists())
             return;
 
-        qWarning() << "BLE recovery: DeadSystemException detected, triggering reconnect";
+        qWarning() << "BLE recovery: dead BLE binder detected, triggering reconnect";
         flagFile.remove();
 
         // The BLE handler thread is dead — Qt's QLowEnergyController won't emit


### PR DESCRIPTION
Closes #1227.

## What

Widens the Java uncaught-exception handler from catching only `DeadSystemException` to catching its parent `DeadObjectException` as well. Same swallow-the-crash + write `ble_dead_system` flag + let the C++ recovery timer reconnect — just covers the much more common case.

## Why

#1227 (v1.7.3) reports the same crash stack as the already-closed #189 (v1.5.0): Qt's `QtBluetoothLE.executeWriteJob` (line 1699 in both reports) calls `BluetoothGatt.writeCharacteristic` without a `try/catch` around the binder transact. When the BLE binder is dead at write time, the `RuntimeException` it raises bubbles up the `QtBluetoothLEHandlerThread` and crashes the JVM. I verified this is **still unfixed in Qt 6.11.1** by reading `~/Qt/6.11.1/Src/qtconnectivity/.../QtBluetoothLE.java:1693-1700` — no `try/catch`. The Qt move from 6.10.3 → 6.11.1 in v1.7.5 therefore does not fix this.

The earlier fix (existing on `main`) installed a global Java `UncaughtExceptionHandler` that catches `DeadSystemException` specifically, drops the `ble_dead_system` flag, and skips `defaultHandler` so the process stays alive. The `bleRecoveryTimer` in `main.cpp` polls the flag and forces a reconnect. But `DeadSystemException` is the *rare* case (system_server died) — it's a **subclass** of `DeadObjectException`. The common case (Bluetooth toggled off, OEM power policy unbinds GATT, driver hiccup) throws the plain parent class and slipped through the substring filter, hence #1227.

## Change

- `DecenzaActivity.java`: rename `isDeadSystemException` → `isDeadObjectException`; replace the class-name substring match with `instanceof DeadObjectException` (the idiomatic check that covers both parent and subclass); update the comment and log message.
- `src/main.cpp`: comment + log message updated to describe the broader cause. Flag filename (`ble_dead_system`) unchanged so the C++ ↔ Java contract is preserved.

## Why not fix Qt instead

Filing/landing the Qt fix is the durable solution and worth doing upstream, but it can't reach users this release. This app-side swallow is the same shape we already have for the subclass case, and the C++ recovery pathway is already proven for it.

## Test plan

- [ ] On Android, with Decenza connected to a DE1, toggle Bluetooth off mid-shot. Expected: no JVM crash; logcat shows `DeadObjectException on thread … — BLE binder died, signaling BLE recovery`; the app stays alive; C++ recovery log fires within ~10s.
- [ ] Confirm the existing `DeadSystemException` path still works (it's a subclass — `instanceof` still matches).
- [ ] No change in behavior for non-`DeadObjectException` crashes (they still go to the crash-report writer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)