### PR TITLE
fix(kb): suppress grind badge on Advanced Spring Lever family (#1205)

### DIFF
--- a/resources/ai/profile_knowledge.json
+++ b/resources/ai/profile_knowledge.json
@@ -278,7 +278,7 @@
       "id": "advanced-spring-lever",
       "displayName": "Advanced Spring Lever",
       "alsoMatches": ["Weiss advanced spring lever"],
-      "analysisFlags": ["flow_trend_ok"],
+      "analysisFlags": ["flow_trend_ok", "grind_check_skip"],
       "family": "lever-decline",
       "prose": "By John Weiss (JW). Spring-lever emulation with an added flow-limit safety valve: fill → rise to 9 bar → declining pressure → if the puck erodes too fast (flow exceeds the limiter) it switches to 1.5 ml/s flow-controlled extraction to prevent gushing. The Weiss variant uses 90°C (vs 88°C) and is tuned slightly differently; JW updated this to ASL2 with refined step transitions. Expected curves: 9 bar peak then gradual decline; flow stays moderate; if a flow-control step kicks in (pressure drop then stabilization) that is the safety valve working — not a problem. A pressure notch/dip at a consistent point during extraction is a SIGN OF PROPER DIAL-IN, not a flaw (JW: \"I actually aim for that result\"). Temperature 88°C (Advanced), 90°C (Weiss); ~35–45s; 18g→32g. All roasts — the flow-recovery step makes these tolerant of grind variation; good when unsure if the puck will channel. Use \"Advanced spring lever\" (not \"Weiss advanced spring lever\") — the Weiss variant has a known skip-first-step bug. DO NOT flag the flow-control recovery step, or a pressure notch/dip during extraction — the former is the designed choke-rescue, the latter signals correct dial-in."
     },


### PR DESCRIPTION
## Context

[#1205](https://github.com/Kulitorum/Decenza/issues/1205) — ChiSaw reported the grind-issue badge firing on a clean 29 s / 32.4 g shot on `Advanced spring lever for SFSB` with a Graph 46 mm basket. His hypothesis was that the extra basket headspace was confusing the detector. The actual mechanism is different and lives in two existing systems.

## Why the badge fires today

Walking ChiSaw's `shot672.json` through `analyzeFlowVsGoal` by hand against the live thresholds (`FLOW_DEVIATION_THRESHOLD = 0.4`, `GRIND_PUMP_RAMP_SKIP_SEC = 0.5`, `FLOW_GOAL_STATIONARY_REL = 0.15`):

- The profile's deliberate 2 s `"sfs bug"` throwaway first frame got swallowed by the BLE skip-first-step bug it was meant to mitigate (`FRAME CHANGE: -1 -> 1` at +26 ms, cumulative water at t=2.5 s is 5.4 mL not the 16 mL it would be if frame 0 had run).
- That leaves the full pump ramp (3 → 8 mL/s over ~2.5 s) inside the `"infuse"` frame Arm 1 reads.
- The 0.5 s pump-ramp trim isn't enough; the stationarity gate starts admitting samples at t=1.5 s where the goal looks "stationary" (10 % rise across ±0.75 s) but the pump hasn't caught up. Mean delta lands at **-0.399 mL/s**, right on the 0.4 threshold.

So the badge is firing on a real numerical signal, not a bug — but it's a signal that doesn't mean what the badge says on this profile family.

## Why this change is correct

The KB entry for `advanced-spring-lever` already says, in prose:

> the flow-recovery step makes these tolerant of grind variation ... DO NOT flag the flow-control recovery step ... A pressure notch/dip at a consistent point during extraction is a SIGN OF PROPER DIAL-IN, not a flaw

The author intent was always for grind-flagging to be subdued on this family. The entry just carried `flow_trend_ok` (gates the flow-trend prose line) and not `grind_check_skip` (early-returns `analyzeFlowVsGoal` at `shotanalysis.cpp:333`).

This PR adds `grind_check_skip` to the existing `analysisFlags`. The [#1198](https://github.com/Kulitorum/Decenza/pull/1198) prefix resolver carries the flag to every renamed variant (`Advanced spring lever for SFSB`, `ASL Jeff`, anyone's `Advanced spring lever - <bean>`) for free — no per-variant authoring needed.

## What this trades

- Gives up the legitimate "yield < 70 % of target" Arm 2 signal on this family too. We could later split into `grind_arm1_skip` vs `grind_check_skip` if a real shot shows up where Arm 2 would have helped on this family, but I'd not pre-build it.
- Does not affect any other detector (`pourTruncated`, `channeling`, `skipFirstFrame` still run unchanged).

## Validation

- `tools/validate_kb.py` → OK, 0 lint warnings.
- No corpus shot in `tests/data/shots/` is an Advanced Spring Lever, so no regression assertions shift.
- Full test run: **2186 passed, 0 failed, 0 warnings, 0 skipped**.
- Recompute-on-load means ChiSaw's existing shot 672 will stop showing the badge as soon as he opens it after upgrading; no manual re-analyze needed.

## Follow-up

[#1205](https://github.com/Kulitorum/Decenza/issues/1205) raised the broader question: "for profiles where we have no KB, maybe we should not do badges or shot summary." That's a separate change tracked in conversation — default grind Arm 1 to skipped (with a `grindCoverage="notAnalyzable"` summary line) when KB resolution returns empty AND no editor-type hint, leaving the profile-agnostic detectors (`pourTruncated`, `skipFirstFrame`, grind Arm 2 yield-shortfall) running. Will open as a follow-up after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)