### PR TITLE
feat(shotanalysis): skip grind Arm 1 when profile KB resolution is empty

### DIFF
--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -295,11 +295,16 @@ gates** (≥ 5 samples, ≥ 15 s pressurized at ≥ 4 bar) AND none of
 `chokedPuck`, `yieldOvershoot`, or `|delta| > FLOW_DEVIATION_THRESHOLD`
 fires. The 15 s gate is load-bearing here: a healthy sustained pressurized
 pour is what the positive signal actually asserts. The Shot Summary dialog
-emits a `[good]` line "Grind tracked goal during pour" only on
-`verifiedClean = true`, distinct from the prior implicit "no badge fired
-⇒ assume clean" behavior — without it, profiles whose Arm 1 windows lie
-entirely before `pourStart` (simple two-marker Preinfusion + Pour shapes)
-silently pass even when no detector saw any data.
+emits a `[good]` line on `verifiedClean = true`, distinct from the prior
+implicit "no badge fired ⇒ assume clean" behavior — without it, profiles
+whose Arm 1 windows lie entirely before `pourStart` (simple two-marker
+Preinfusion + Pour shapes) silently pass even when no detector saw any
+data. The line text branches on `GrindCheck.sampleCount`: Arm 1 ran and
+saw qualifying samples (`> 0`) ⇒ "Grind tracked goal during pour"; Arm 1
+saw no samples (`== 0`, either because its windows lay outside the pour
+window or because the new `profileKbResolved` gate skipped it) ⇒ "Puck
+sustained healthy pressure during pour" — the honest wording when Arm 2
+alone supplied the verifiedClean signal.
 
 A shot where `hasData = true` but `verifiedClean = false` means the yield
 arm fired (or, if `chokedPuck=false && yieldOvershoot=false`, the flow
@@ -475,7 +480,10 @@ top-to-bottom:
    averaged X mL/s below target — grind may be too fine" ("caution"),
    "Flow averaged X mL/s above target — grind may be too coarse"
    ("caution"), "Grind tracked goal during pour" ("good") when
-   `verifiedClean` is true, or — when the detector had no analyzable
+   `verifiedClean` is true AND Arm 1 saw samples, "Puck sustained
+   healthy pressure during pour" ("good") when `verifiedClean` is true
+   AND Arm 1 saw no samples (Arm 2 supplied the signal alone), or —
+   when the detector had no analyzable
    data on a non-degenerate espresso pour — "Could not analyze grind on
    this profile shape — check flow trend, channeling, and taste
    instead" ("observation"). **Suppressed when `pourTruncated` fires.**

--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -174,9 +174,10 @@ vice versa.
 empty (no exact alias hit, no #1198 longest-boundary-prefix hit, no
 editor-type default hit) — Arm 1 is **skipped entirely**: the flow-mode
 range builder doesn't run, `sampleCount`/`delta` stay zero, and Arm 1
-contributes nothing to `hasData`. Arm 2 (yield-shortfall + sustained-
-pressurized-flow choke) still runs unconditionally — those arms read
-physics-level signals that don't depend on profile shape. The result
+contributes nothing to `hasData`. Arm 2 (choked-puck + yield-shortfall
++ yield-overshoot) still runs unconditionally — those arms read
+physics-level signals (mean pressurized flow, yield ratio) that don't
+depend on profile shape. The result
 projects through the existing `grindCoverage="notAnalyzable"` path when
 Arm 2 also has no data, or `"verified"` when it does. `skipped` stays
 `false`, distinct from the `grind_check_skip` flag's `"skipped"`

--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -168,6 +168,32 @@ returns true when either arm fires. Two arms run **additively**, not as
 fallback — a clean flow-mode preinfusion can hide a pressure-mode choke and
 vice versa.
 
+**Profile-context gate (Arm 1 only).** `analyzeFlowVsGoal` takes a
+`bool profileKbResolved` parameter. When `false` — i.e.
+`ShotSummarizer::matchProfileKey(profileTitle, profileType)` returned
+empty (no exact alias hit, no #1198 longest-boundary-prefix hit, no
+editor-type default hit) — Arm 1 is **skipped entirely**: the flow-mode
+range builder doesn't run, `sampleCount`/`delta` stay zero, and Arm 1
+contributes nothing to `hasData`. Arm 2 (yield-shortfall + sustained-
+pressurized-flow choke) still runs unconditionally — those arms read
+physics-level signals that don't depend on profile shape. The result
+projects through the existing `grindCoverage="notAnalyzable"` path when
+Arm 2 also has no data, or `"verified"` when it does. `skipped` stays
+`false`, distinct from the `grind_check_skip` flag's `"skipped"`
+coverage. Production call sites derive the bool from
+`!profileKbId.isEmpty()` of the resolved id already stored on
+`ShotRecord` / `ShotSaveData` / `ShotSummary`. Direct test callers
+default to `profileKbResolved = true`, preserving the pre-change
+contract. See openspec change `skip-grind-arm1-when-kb-unresolved` for
+the rationale: Arm 1 reads the firmware-reported `flow_goal` series as
+a target the puck should track, but on profiles we have no KB context
+for, that series may be a safety limiter, a ramp-down command, or a
+pump-ramp curve rather than a target — averaging actuals against it
+produces false-positive grind diagnoses. The `grind_check_skip` flag is
+still the way to opt a *known* profile family out of Arm 1 (the
+`advanced-spring-lever` pattern from #1230); the new gate handles
+*unknown* profiles by inferring "no opinion" from the resolver state.
+
 **Arm 1: flow-vs-goal averaging** (the "primary" path).
 
 For each flow-mode phase, builds an inclusive time range:

--- a/openspec/changes/skip-grind-arm1-when-kb-unresolved/.openspec.yaml
+++ b/openspec/changes/skip-grind-arm1-when-kb-unresolved/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/skip-grind-arm1-when-kb-unresolved/design.md
+++ b/openspec/changes/skip-grind-arm1-when-kb-unresolved/design.md
@@ -1,0 +1,108 @@
+## Context
+
+`ShotAnalysis::analyzeFlowVsGoal` (src/ai/shotanalysis.cpp:314) runs two independent arms over an espresso shot's pour window:
+
+- **Arm 1** averages actual flow against the commanded flow goal during flow-mode phases where the goal is stationary (15 % rel across ±0.75 s) and above a minimum threshold (0.3 mL/s). Reports `delta = mean_actual - mean_goal`; `|delta| > 0.4 mL/s` fires the "grind too fine / coarse" badge.
+- **Arm 2** is two sub-arms over pressure-mode phases — a flow-arm (mean pressurized flow < 0.5 mL/s with sustained ≥ 4 bar for ≥ 15 s) and a yield-arm (`finalWeightG / targetWeightG < 0.70`). Either fires `chokedPuck=true`.
+
+Both arms feed `DetectorResults.grindCoverage`, which already has three values defined in `openspec/specs/shot-analysis-pipeline/spec.md`:
+
+- `"verified"` — at least one arm produced data.
+- `"notAnalyzable"` — espresso, non-degenerate pour window, neither arm produced data.
+- `"skipped"` — non-espresso beverage or `grind_check_skip` analysis flag.
+- `""` (omitted) — pourTruncated cascade active or degenerate pour window.
+
+The semantic problem this change addresses: Arm 1 is the only one of the four shot-analysis badges that requires profile context to be meaningful. Arm 1 reads the firmware-reported `flow_goal` series and compares actuals against it. On many profile shapes — lever-decline (flow goal is a safety limiter), dynamic-bloom (flow goal is a ramp-down command), or the first frame of any profile when the SFS bug pushes the pump-ramp transient into a "real" infuse frame — the flow goal is *not* a target the puck is supposed to track, and the comparison produces false positives.
+
+The KB has a per-profile escape valve (`grind_check_skip` analysis flag, exercised by #1230 for `advanced-spring-lever`). But that requires per-profile authoring. For profiles we have *no* knowledge of, we currently still run Arm 1 — that's the population this change targets.
+
+The matchProfileKey resolver path is already established (`src/ai/shotsummarizer_kb.cpp:376`): exact alias → #1198 longest-boundary-prefix → editor-type default → empty. Empty *is* the signal "we have no profile context". The kbId stored on every ShotRecord is either the resolved id or empty, so the signal is already available at every call site of `analyzeShot`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Skip Arm 1 (and only Arm 1) when the profile's KB resolution returned empty.
+- Surface the result through the existing `grindCoverage="notAnalyzable"` path so no new UI strings, no new badge logic, no new prose are introduced. The summary line "Could not analyze grind on this profile shape — …" already exists for this coverage value.
+- Keep Arm 2 (yield-shortfall + sustained-pressurized-flow choke) running on unresolved profiles. Those arms read yield and sustained-pressure mean-flow — physics-level signals that don't depend on profile shape.
+- Keep `pourTruncated`, `skipFirstFrame`, and channeling (with its existing skip flags) running unchanged on unresolved profiles. They catch missing baskets, gushers, the SFS firmware bug, and channeling regardless of profile shape.
+- Preserve existing behaviour for KB-resolved profiles bit-for-bit. No corpus regressions on profiles the resolver knows about.
+
+**Non-Goals:**
+
+- Adding a new analysis flag. The absence of a KB resolution is itself the signal; `grind_check_skip` remains the way to opt a *known* profile out of Arm 1.
+- Changing the projection logic in `src/history/shotbadgeprojection.h`. `grindIssueDetected` still requires `grindHasData` AND a fire condition — that contract is unchanged.
+- Changing the verdict cascade. The existing "Clean shot, but grind could not be evaluated for this profile shape" verdict already covers `grindCoverage="notAnalyzable"`.
+- Changing how live shots are analyzed during extraction. The live path (`ShotSummarizer::summarize(ShotDataModel*)`) runs through the same `analyzeShot` body — extending the signature flows through automatically.
+- Distinguishing "user-created flow profile we don't know" from "renamed variant of a known KB profile". The #1198 prefix resolver already handles the second case; what's left is genuinely unknown profiles, and they all get the same `notAnalyzable` treatment.
+
+## Decisions
+
+### Decision 1: Pass the resolved-or-not bit as an explicit `analyzeShot` parameter, not a sentinel in `analysisFlags`
+
+`analyzeShot` currently takes a `QStringList analysisFlags` populated from `ShotSummarizer::getAnalysisFlags(profileKbId)`. We could overload that list with a synthetic flag like `__unresolved__`, but that pattern would be a magic string in the public API and would mix two distinct concepts: authored-by-KB intent vs. resolver-derived state.
+
+Instead, add `bool profileKbResolved` to `ShotAnalysis::analyzeShot` and `ShotAnalysis::analyzeFlowVsGoal` (default `true` for backward compatibility with direct test callers). Threading the bool stays close to the signal's source — every storage-layer call site already has `profileKbId` in scope and derives the bool with `!profileKbId.isEmpty()`.
+
+**Alternatives considered:**
+- Sentinel flag in `analysisFlags` — rejected as magic-string in a public list whose contract is "KB-authored opt-outs".
+- New field on `AnalysisInputs` (storage-internal struct) — viable but adds a struct round-trip that the live-path entry doesn't share. An explicit parameter is the minimum cross-cut.
+
+### Decision 2: Skip Arm 1's flow-mode-range building when `profileKbResolved=false`, do NOT set `skipped=true`
+
+The `skipped=true` early-return path (line 333) is reserved for "skip the whole grind detector" (non-espresso beverage, `grind_check_skip` flag). It projects to `grindCoverage="skipped"`. That's not what we want here — we want Arm 2 to keep running, and we want the result to project as `"notAnalyzable"` (when Arm 2 also has no data) or `"verified"` (when Arm 2 fires).
+
+Concretely, the implementation gates Arm 1's range-building block (lines 366-405 — the `if (!phases.isEmpty())` flow-mode-range builder) and the averaging block (lines 409-459) on `profileKbResolved`. When false, `flowModeRanges` stays empty, the averaging block is bypassed (it already early-exits when `flowModeRanges.isEmpty()`), and `GrindCheck.delta` / `sampleCount` keep their default zero values. Arm 2 then runs unconditionally as it does today.
+
+`hasData` stays `false` unless Arm 2 fires (chokedPuck, yieldOvershoot, or yieldArm gates passing). `grindCoverage` then projects via the existing rules:
+
+- Arm 2 produced data → `"verified"`.
+- Arm 2 had no data → `"notAnalyzable"`.
+- Pour truncated, beverage skip, or `grind_check_skip` → unchanged.
+
+### Decision 3: Call-site derivation — read it from the same kbId every site already has
+
+All `analyzeShot` call sites already have `profileKbId` in scope (the kbId stored on `ShotRecord` / `ShotSaveData` / `ShotSummary` is either resolved or empty). Add one local at each call site:
+
+```cpp
+const bool profileKbResolved = !profileKbId.isEmpty();
+ShotAnalysis::analyzeShot(..., profileKbResolved);
+```
+
+Three storage call sites (saveShot at shothistorystorage.cpp:1122, loadShotRecordStatic at 1837, convertShotRecord at shothistorystorage_serialize.cpp:121) plus two ShotSummarizer entry points (summarize live at shotsummarizer.cpp:145, summarizeFromHistory at 457). That's it.
+
+**Alternatives considered:**
+- Put the bool on the `AnalysisInputs` struct — would consolidate the storage paths but doesn't help the ShotSummarizer call sites. Keep the parameter explicit for clarity.
+
+### Decision 4: Default the parameter to `true` for direct test callers
+
+`tst_shotanalysis.cpp` constructs synthetic shots and calls `analyzeFlowVsGoal` / `analyzeShot` directly without a KB context. Defaulting `profileKbResolved=true` preserves every existing test's behaviour without modification. New tests that explicitly exercise the `false` path pass it explicitly.
+
+This is also the safe default for any future direct caller — a missing argument means "assume we know the profile and run all detectors", which matches the pre-change contract.
+
+## Risks / Trade-offs
+
+- **[Risk] Loss of legitimate Arm 1 signals on user-created flow-mode profiles we genuinely have no KB for** → Mitigation: Arm 2's yield-shortfall arm (`finalWeightG/targetWeightG < 0.70`) catches the canonical "grind too fine" failure shape (puck choked, yield missed target by 30 %+) regardless of profile context. The signal we're giving up is the more subtle "actual flow tracked goal but came in 0.5 mL/s under" diagnosis on unknown profiles, where we can't be confident the goal is a tracking target at all. The `notAnalyzable` coverage value already exists precisely so consumers can distinguish "verified clean" from "didn't analyze" — the AI advisor's prompt builder and the summary dialog already render that distinction honestly.
+
+- **[Risk] Verdict text shift on existing user shots** → Mitigation: `grindCoverage="notAnalyzable"` already maps to the verdict "Clean shot, but grind could not be evaluated for this profile shape." instead of "Clean shot. Puck held well." (see `tests/tst_shotanalysis.cpp` scenarios for the existing notAnalyzable verdict). Users on unresolved profiles whose previous verdict was "clean and puck held well" will see the more-honest "clean but grind not evaluated" line. This is the *intent* of the existing notAnalyzable infrastructure; this change widens the population that hits it. No surprise to users — the verdict text already exists and was designed for this case.
+
+- **[Risk] Regression-corpus shifts** → Mitigation: most corpus shots (`tests/data/shots/*.json`) carry KB-resolvable profile titles by design (`adaptive_v2_*`, `cremina_*`, `damian_lrv3_*`, `londinium_*`, etc.). Any that don't resolve become a deliberate audit point — surfaced by the shot_eval before/after diff. We accept verdict shifts on those that turn out to be intentional consequences of this change and update the corpus manifest accordingly.
+
+- **[Trade-off] No per-profile granularity for "we know it well enough to run Arm 1"** — a KB entry that exists but doesn't actually contain grind-relevant guidance (e.g. a recipe with only `family` and `prose`, no `expertBand` or analysis flags) still flips `profileKbResolved=true`. That's fine: the absence of `grind_check_skip` is itself the author's "yes, please grade my profile" signal. Authors who decide Arm 1 isn't safe on a known family add the flag (the #1230 pattern).
+
+- **[Trade-off] The "renamed user variants of unknown originals" case stays in the new bucket** — if a user picks an obscure shared community profile (no KB entry) and renames it, neither the exact alias lookup nor the #1198 prefix step resolves. That's the right answer for now; we genuinely have no signal that the renamed title is more analyzable than the unknown original.
+
+## Migration Plan
+
+No schema changes, no data migration. The detectors recompute on every shot load (per `docs/SHOT_REVIEW.md` §4), so:
+
+- Existing shots on KB-resolved profiles: no change.
+- Existing shots on KB-unresolved profiles where Arm 1 was producing a false-positive: re-render with `grindCoverage="notAnalyzable"`, the appropriate observation line, and the "clean but grind not evaluated" verdict (when no other badge fires). No user action required.
+- Existing shots on KB-unresolved profiles where Arm 2 fires: unchanged (Arm 2 already produced the diagnosis).
+- Live shots during extraction: same recompute pipeline; the live `ShotSummarizer::summarize` path takes the new parameter the same way.
+
+Rollback: a one-line revert at each call site restores the previous behaviour. No state was committed; nothing was migrated.
+
+## Open Questions
+
+None at design time. Implementation may surface a fourth `analyzeShot` call site I missed; if so, treat it the same way — derive the bool from `profileKbId.isEmpty()` in scope.

--- a/openspec/changes/skip-grind-arm1-when-kb-unresolved/proposal.md
+++ b/openspec/changes/skip-grind-arm1-when-kb-unresolved/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Grind Arm 1 (flow-vs-goal averaging in `ShotAnalysis::analyzeFlowVsGoal`) only produces a meaningful diagnosis when the profile's flow goal is a target the puck is supposed to track. On many real profiles the flow goal isn't that — it's a safety limiter on lever-decline frames, a firmware-generated ramp-down command on dynamic-bloom frames, or a pump-ramp curve on a first-frame that got swallowed by the BLE skip-first-step bug. Running Arm 1 on those profiles produces false-positive "grind too fine"/"too coarse" badges (#1205: a clean 32.4 g / 29.75 s shot on an Advanced Spring Lever variant landed at mean delta -0.399 mL/s, right on the 0.4 threshold, because the SFS bug pushed the pump-ramp transient into the `infuse` frame Arm 1 reads).
+
+#1230 fixed the specific #1205 report by adding `grind_check_skip` to the `advanced-spring-lever` KB entry, but that path requires per-profile KB authoring. The broader pattern — "Arm 1 needs profile context to be meaningful; we have no profile context here" — affects every user-created profile that doesn't match a KB entry or editor-type default. The trigger for "I have no profile context" already exists in `ShotSummarizer::matchProfileKey`: it returns empty string when neither the exact alias lookup nor the #1198 longest-boundary-prefix step resolves, and no `dflow`/`aflow` editor-type hint is available. We can read that signal directly and degrade Arm 1 to the existing `grindCoverage="notAnalyzable"` path without inventing a new flag.
+
+## What Changes
+
+- `ShotAnalysis::analyzeFlowVsGoal` SHALL accept a new caller-supplied boolean `profileKbResolved` (default `true`). When `false`, the function SHALL skip Arm 1's flow-mode-range construction and flow-vs-goal averaging entirely — `sampleCount` and `delta` stay at their default-zero values, `hasData` stays `false` for Arm 1. Arm 2 (choked-puck + yield-shortfall) runs unchanged.
+- `ShotAnalysis::analyzeShot` SHALL determine `profileKbResolved` from its caller and propagate it to `analyzeFlowVsGoal`. The signal already flows into the analyze path indirectly via `analysisFlags` (today populated from `ShotSummarizer::getAnalysisFlags(profileKbId)`); we extend the same call site to also pass the resolved-or-not bit.
+- The existing `grindCoverage="notAnalyzable"` projection SHALL continue to fire when Arm 1's `hasData=false` AND Arm 2's gate doesn't pass. This change widens the *population* that hits that projection — profiles with no KB resolution now fall into it instead of running Arm 1 on a meaningless flow-goal series — without changing the projection logic itself.
+- The existing `[observation]` summary line "Could not analyze grind on this profile shape — …" SHALL continue to fire on the `notAnalyzable` coverage. No new prose, no new badge.
+- No new analysis flag. The absence of a KB resolution is itself the signal — adding `grind_check_skip` as an authored flag remains the way to opt a *known* profile out of Arm 1 (the #1230 path).
+- Detectors that don't depend on profile shape — `pourTruncated` (peak pressure < 2.5 bar), `skipFirstFrame`, channeling (already gated by `channeling_expected` flag and `shouldSkipChannelingCheck` heuristics), and grind Arm 2 (yield-shortfall and sustained-pressurized-flow choke) — SHALL keep running unchanged on unresolved profiles.
+
+## Capabilities
+
+### New Capabilities
+
+(none — extends the existing shot-analysis-pipeline contract)
+
+### Modified Capabilities
+
+- `shot-analysis-pipeline`: the `grindCoverage="notAnalyzable"` requirement adds a second qualifying precondition — Arm 1 SHALL also be skipped (its `hasData` SHALL remain `false`) when the profile's KB resolution is empty AND no editor-type hint is available, projecting into the same `notAnalyzable` coverage value the existing path already produces.
+
+## Impact
+
+- Code: `src/ai/shotanalysis.h` (add `profileKbResolved` parameter to `analyzeFlowVsGoal` and `analyzeShot`); `src/ai/shotanalysis.cpp` (gate Arm 1's flow-mode-range build on the new flag; thread the parameter through `analyzeShot`); `src/history/shothistorystorage.cpp` (and any other call site of `analyzeShot`) to pass the resolved-or-not bit — derive it from the existing `ShotSummarizer::matchProfileKey(profileTitle, profileType).isEmpty()` call already adjacent to the `getAnalysisFlags` lookup.
+- Tests: extend `tests/tst_shotanalysis.cpp` with three scenarios — (1) `profileKbResolved=false` on a flow-mode shot whose Arm 1 would otherwise fire skips Arm 1 cleanly and projects `grindCoverage="notAnalyzable"`; (2) same shot with `profileKbResolved=true` runs Arm 1 unchanged (no behavioural change for resolved profiles); (3) `profileKbResolved=false` on a yield-shortfall shot still fires the grind badge via Arm 2.
+- Regression corpus (`tests/data/shots/`): inventory which corpus shots are on KB-unresolved profiles and confirm verdict shifts are intentional. Most corpus shots are on KB-known profiles and won't move. Any shift surfaces during the shot_eval before/after diff.
+- Docs: update `docs/SHOT_REVIEW.md` §2.2 "Grind issue" to document the new precondition for the `notAnalyzable` coverage.
+- No BLE, no DB schema, no QML, no settings changes. No user-visible UI change beyond the summary line that already exists.

--- a/openspec/changes/skip-grind-arm1-when-kb-unresolved/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/changes/skip-grind-arm1-when-kb-unresolved/specs/shot-analysis-pipeline/spec.md
@@ -32,7 +32,9 @@ Detectors other than grind SHALL be unaffected by `profileKbResolved`. `pourTrun
 - **AND** Arm 2 SHALL run and set `GrindCheck.hasData = true` AND `GrindCheck.verifiedClean = true`
 - **AND** `DetectorResults.grindCoverage` SHALL equal `"verified"`
 - **AND** `grindIssueDetected` SHALL be `false`
-- **AND** `summaryLines` SHALL contain the existing "Grind tracked goal during pour" `[good]` line
+- **AND** `summaryLines` SHALL contain a `[good]` line whose text is "Puck sustained healthy pressure during pour" (because Arm 1 did not run — `sampleCount == 0` — so the existing "Grind tracked goal during pour" wording would falsely cite a measurement that wasn't taken)
+
+The `[good]` line text SHALL branch on `GrindCheck.sampleCount`: a positive count (Arm 1 ran and confirmed) keeps the existing "Grind tracked goal during pour" wording; a zero count with `verifiedClean == true` (Arm 2 alone verified a sustained pressurized pour) emits "Puck sustained healthy pressure during pour" instead. The `type` (`"good"`) and `kind` (`"grind_clean"`) are unchanged across the two branches.
 
 #### Scenario: Unresolved profile with no Arm 2 data projects as not-analyzable
 

--- a/openspec/changes/skip-grind-arm1-when-kb-unresolved/specs/shot-analysis-pipeline/spec.md
+++ b/openspec/changes/skip-grind-arm1-when-kb-unresolved/specs/shot-analysis-pipeline/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Grind Arm 1 (flow-vs-goal averaging) SHALL be skipped on KB-unresolved profiles
+
+`ShotAnalysis::analyzeShot` and `ShotAnalysis::analyzeFlowVsGoal` SHALL accept a `bool profileKbResolved` parameter (defaulting to `true` for backward compatibility with direct test callers and other in-process invocations). The parameter SHALL be `true` when the profile's KB resolution via `ShotSummarizer::matchProfileKey(profileTitle, profileType)` produced a non-empty id (exact alias hit, #1198 longest-boundary-prefix hit, or editor-type-default hit), and `false` otherwise.
+
+When `profileKbResolved == false`, `analyzeFlowVsGoal` SHALL skip Arm 1 (the flow-vs-goal averaging block over flow-mode phases) entirely. Specifically: the flow-mode-range builder SHALL NOT populate `flowModeRanges`, the sample-averaging loop SHALL NOT run, and `GrindCheck::delta`, `GrindCheck::sampleCount`, and the Arm 1 contribution to `GrindCheck::hasData` SHALL remain at their default-zero / `false` values. The function SHALL NOT set `GrindCheck::skipped = true` — that field remains reserved for the existing non-espresso-beverage and `grind_check_skip` analysis-flag paths whose semantics differ (full grind detector suppression, distinct `grindCoverage = "skipped"` projection).
+
+When `profileKbResolved == false`, Arm 2 (the choked-puck flow-arm and yield-shortfall yield-arm over pressure-mode phases) SHALL continue to run unchanged. The two arms read sustained-pressurized mean flow and `finalWeightG / targetWeightG` — physics-level signals that do not depend on profile shape and remain meaningful on profiles with no KB context.
+
+When `profileKbResolved == true`, both arms SHALL run exactly as they do today. This change SHALL NOT alter behaviour for any KB-resolvable profile (exact alias, #1198 prefix match, or editor-type default).
+
+The existing `grindCoverage` projection rules SHALL apply unchanged. With Arm 1 skipped and Arm 2's outcome driving `GrindCheck::hasData`:
+
+- Arm 2 produced data (its `flowSamples >= 5` AND (`pressurizedDuration >= 15 s` OR yield-shortfall arm fired)) → `grindCoverage = "verified"`.
+- Arm 2 had no data → `grindCoverage = "notAnalyzable"` (for an espresso shot with a non-degenerate pour window).
+- Pour-truncated cascade active → `grindCoverage` omitted, as today.
+
+The existing `[observation]` summary line "Could not analyze grind on this profile shape — …" SHALL fire on the resulting `"notAnalyzable"` coverage value via the existing emission path. No new prose, no new badge, no new verdict text is introduced by this change — the existing notAnalyzable infrastructure already covers the user-visible surface. The existing `verdictCategory = "cleanGrindNotAnalyzable"` SHALL apply when the cascade reaches the terminal "Otherwise" branch with this coverage.
+
+The four quality-badge boolean projections in `src/history/shotbadgeprojection.h` SHALL NOT change. `grindIssueDetected` still requires `grindHasData && (grindChokedPuck || grindYieldOvershoot || |grindFlowDeltaMlPerSec| > FLOW_DEVIATION_THRESHOLD)`. With Arm 1 skipped and Arm 2 silent, `grindHasData` is `false` and `grindIssueDetected` projects to `false` — the false-positive surface this change targets.
+
+Detectors other than grind SHALL be unaffected by `profileKbResolved`. `pourTruncated` (peak-pressure floor), `skipFirstFrame` (phase-marker-based), and channeling (with its existing `channeling_expected` flag and `shouldSkipChannelingCheck` heuristics) SHALL run identically on KB-resolved and KB-unresolved profiles.
+
+#### Scenario: Unresolved profile with a clean Arm 2 result projects as verified-clean
+
+- **GIVEN** an espresso shot on a profile whose title and editor type both fail to resolve via `ShotSummarizer::matchProfileKey` (`profileKbResolved == false`)
+- **AND** the shot's pressure-mode phases produce a healthy pressurized pour (≥ 5 flow samples at ≥ 4 bar, ≥ 15 s pressurized duration, mean pressurized flow ≥ 0.5 mL/s)
+- **AND** `finalWeightG / targetWeightG >= 0.70`
+- **WHEN** `analyzeShot` runs with `profileKbResolved = false`
+- **THEN** Arm 1 SHALL be skipped (`GrindCheck.sampleCount == 0` AND `GrindCheck.delta == 0`)
+- **AND** Arm 2 SHALL run and set `GrindCheck.hasData = true` AND `GrindCheck.verifiedClean = true`
+- **AND** `DetectorResults.grindCoverage` SHALL equal `"verified"`
+- **AND** `grindIssueDetected` SHALL be `false`
+- **AND** `summaryLines` SHALL contain the existing "Grind tracked goal during pour" `[good]` line
+
+#### Scenario: Unresolved profile with no Arm 2 data projects as not-analyzable
+
+- **GIVEN** an espresso shot on a KB-unresolved profile whose pour window is non-degenerate
+- **AND** the pour produces fewer than 5 samples at ≥ 4 bar (Arm 2 flow-arm gate fails on `flowSamples`)
+- **AND** either `targetWeightG == 0` OR `finalWeightG / targetWeightG >= 0.70` (Arm 2 yield-arm also silent)
+- **WHEN** `analyzeShot` runs with `profileKbResolved = false`
+- **THEN** Arm 1 SHALL be skipped (no flow-vs-goal averaging)
+- **AND** Arm 2 SHALL run but produce `hasData == false`
+- **AND** `DetectorResults.grindCoverage` SHALL equal `"notAnalyzable"`
+- **AND** `summaryLines` SHALL contain one `[observation]` entry whose text starts with "Could not analyze grind on this profile shape"
+- **AND** `grindIssueDetected` SHALL be `false`
+- **AND** the verdict cascade's terminal branch SHALL emit "Clean shot, but grind could not be evaluated for this profile shape." with `verdictCategory = "cleanGrindNotAnalyzable"` when no other detector fires
+
+#### Scenario: Unresolved profile with a yield shortfall still fires the grind badge via Arm 2
+
+- **GIVEN** an espresso shot on a KB-unresolved profile
+- **AND** `flowSamples >= 5` AND `targetWeightG > 0` AND `finalWeightG > 0`
+- **AND** `(finalWeightG / targetWeightG) < 0.70` (e.g. 23 g of a 36 g target)
+- **WHEN** `analyzeShot` runs with `profileKbResolved = false`
+- **THEN** Arm 1 SHALL be skipped
+- **AND** Arm 2's yield-shortfall arm SHALL fire (`chokedPuck = true`, `hasData = true`)
+- **AND** `DetectorResults.grindCoverage` SHALL equal `"verified"`
+- **AND** `grindIssueDetected` SHALL be `true`
+- **AND** the existing "Pour produced near-zero flow while pressure held — puck choked" warning SHALL be emitted unchanged
+
+#### Scenario: Resolved profile runs Arm 1 exactly as before
+
+- **GIVEN** an espresso shot on a profile whose title or editor type DOES resolve via `ShotSummarizer::matchProfileKey` (exact alias, #1198 prefix, or editor-type default)
+- **AND** the shot data is otherwise unchanged from a pre-change run
+- **WHEN** `analyzeShot` runs with `profileKbResolved = true`
+- **THEN** Arm 1's flow-mode-range builder, stationarity gate, and averaging loop SHALL execute identically to the pre-change behaviour
+- **AND** `GrindCheck.delta`, `GrindCheck.sampleCount`, `GrindCheck.hasData`, and `DetectorResults.grindCoverage` SHALL all carry the same values they would have on the pre-change build
+
+#### Scenario: Profile-agnostic detectors run on unresolved profiles
+
+- **GIVEN** an espresso shot on a KB-unresolved profile where the puck fails to build pressure (peak pressure < 2.5 bar) OR phase markers show frame 0 was never observed before a non-zero frame at phase.time < 2.0 s
+- **WHEN** `analyzeShot` runs with `profileKbResolved = false`
+- **THEN** `pourTruncated` and/or `skipFirstFrame` SHALL fire identically to the resolved-profile case
+- **AND** the existing badge cascades (pourTruncated dominating channeling/grind; skipFirstFrame independent) SHALL apply unchanged
+
+#### Scenario: Direct test callers default profileKbResolved to true
+
+- **GIVEN** a unit test that calls `ShotAnalysis::analyzeShot(...)` or `ShotAnalysis::analyzeFlowVsGoal(...)` without supplying the new `profileKbResolved` parameter
+- **WHEN** the call executes
+- **THEN** the default value `profileKbResolved = true` SHALL apply
+- **AND** Arm 1 SHALL run with its existing behaviour, preserving every pre-change test scenario without modification

--- a/openspec/changes/skip-grind-arm1-when-kb-unresolved/tasks.md
+++ b/openspec/changes/skip-grind-arm1-when-kb-unresolved/tasks.md
@@ -44,9 +44,9 @@
 
 ## 7. Land
 
-- [ ] 7.1 Run full test suite via Qt Creator MCP (`mcp__qtcreator__run_tests`); expect 0 failures, 0 new warnings.
-- [ ] 7.2 Run `tools/validate_kb.py` (no KB content change, but cheap sanity).
-- [ ] 7.3 Open PR on a feature branch (e.g. `feat/skip-grind-arm1-when-kb-unresolved`) with proposal/design/spec excerpts in the body, the corpus-diff result from section 5, and a closing-keyword link to the openspec change.
-- [ ] 7.4 Run `/pr-review-toolkit:review-pr` on the PR; address any issues it surfaces above the noise floor.
+- [x] 7.1 Run full test suite via Qt Creator MCP (`mcp__qtcreator__run_tests`); expect 0 failures, 0 new warnings.
+- [x] 7.2 Run `tools/validate_kb.py` (no KB content change, but cheap sanity).
+- [x] 7.3 Open PR on a feature branch (e.g. `feat/skip-grind-arm1-when-kb-unresolved`) with proposal/design/spec excerpts in the body, the corpus-diff result from section 5, and a closing-keyword link to the openspec change.
+- [x] 7.4 Run `/pr-review-toolkit:review-pr` on the PR; address any issues it surfaces above the noise floor.
 - [ ] 7.5 After approval/sign-off, `/merge-pr` to squash-merge and delete the branch.
 - [ ] 7.6 Run `/openspec-archive-change skip-grind-arm1-when-kb-unresolved` (or the openspec CLI equivalent) once the PR has landed on `main`.

--- a/openspec/changes/skip-grind-arm1-when-kb-unresolved/tasks.md
+++ b/openspec/changes/skip-grind-arm1-when-kb-unresolved/tasks.md
@@ -1,0 +1,52 @@
+## 1. Signature plumbing
+
+- [x] 1.1 Add `bool profileKbResolved = true` parameter to `ShotAnalysis::analyzeFlowVsGoal` in `src/ai/shotanalysis.h` and `src/ai/shotanalysis.cpp` (default at the declaration; ordered after `finalWeightG` to keep positional callers stable).
+- [x] 1.2 Add `bool profileKbResolved = true` parameter to `ShotAnalysis::analyzeShot` in `src/ai/shotanalysis.h` and `src/ai/shotanalysis.cpp` (default at the declaration; ordered after `expectedFrameCount` and before `expertBand` to fit the existing optional-trailing pattern, OR appended after `expertBand` if the optional-last invariant is load-bearing — pick whichever keeps every existing call site compiling without reorder).
+- [x] 1.3 Thread `profileKbResolved` from `analyzeShot` into its single call of `analyzeFlowVsGoal` (around shotanalysis.cpp:874).
+
+## 2. Arm 1 gating
+
+- [x] 2.1 In `analyzeFlowVsGoal`, gate the flow-mode-range builder block (the `if (!phases.isEmpty())` block at shotanalysis.cpp:368-405) on `profileKbResolved`. When `false`, leave `flowModeRanges` empty.
+- [x] 2.2 Confirm the existing averaging block (shotanalysis.cpp:409-459) already early-exits when `flowModeRanges.isEmpty()`. No additional guard needed there; this is a verify-and-comment step, not a code change.
+- [x] 2.3 Confirm the existing `skipped = true` early-return path (shotanalysis.cpp:333-336) is NOT touched — that path is reserved for non-espresso beverages and the `grind_check_skip` flag, which project to `grindCoverage = "skipped"` not `"notAnalyzable"`. The new gate must leave `skipped = false` so Arm 2 still runs and the projection falls into `notAnalyzable` (when Arm 2 has no data) or `verified` (when it does).
+- [x] 2.4 Add a brief comment on the new gate at the call site explaining why `profileKbResolved = false` widens the population that hits the existing `notAnalyzable` coverage instead of inventing a new state.
+
+## 3. Call-site propagation
+
+- [x] 3.1 `src/ai/shotsummarizer.cpp:145` (`ShotSummarizer::summarize(ShotDataModel*)` live path): derive `const bool profileKbResolved = !summary.profileKbId.isEmpty();` and pass to `analyzeShot`.
+- [x] 3.2 `src/ai/shotsummarizer.cpp:457` (`summarizeFromHistory`): same derivation from `summary.profileKbId`, pass to `analyzeShot`.
+- [x] 3.3 `src/history/shothistorystorage.cpp:1122` (`saveShot`): derive from `data.profileKbId`, pass to `analyzeShot`.
+- [x] 3.4 `src/history/shothistorystorage.cpp:1837` (`loadShotRecordStatic`): derive from `record.profileKbId`, pass to `analyzeShot`.
+- [x] 3.5 `src/history/shothistorystorage_serialize.cpp:121` (`convertShotRecord`): derive from `record.profileKbId`, pass to `analyzeShot`.
+- [x] 3.6 Re-grep for any additional `ShotAnalysis::analyzeShot(` and `ShotAnalysis::analyzeFlowVsGoal(` call sites outside tests; pass the derived flag (or leave defaulting to `true` only when the call is in a context that genuinely has no `profileKbId` and intends "act as if resolved" — comment why).
+
+## 4. Tests
+
+- [x] 4.1 Add `tst_shotanalysis.cpp` scenario `grindArm1_skippedWhenKbUnresolved_armTwoSilentProjectsNotAnalyzable`: build a flow-mode-only shot whose Arm 1 would otherwise fire (mean delta well past 0.4), call `analyzeShot` with `profileKbResolved = false`, assert `GrindCheck.sampleCount == 0`, `GrindCheck.delta == 0`, `GrindCheck.hasData == false`, `DetectorResults.grindCoverage == "notAnalyzable"`, `grindIssueDetected == false`, and the summary line "Could not analyze grind on this profile shape" is present.
+- [x] 4.2 Add scenario `grindArm1_runsWhenKbResolved_preservesPreChangeBehaviour`: same shot as 4.1, but `profileKbResolved = true`. Assert Arm 1 runs and produces the same `delta` and badge outcome it would have on the pre-change build (capture the values from a parallel pre-change run during development; assert exact numbers).
+- [x] 4.3 Add scenario `grindArm1_skipped_armTwoYieldShortfallStillFires`: shot with `flowSamples >= 5`, `targetWeightG = 36`, `finalWeightG = 22`, `profileKbResolved = false`. Assert `chokedPuck == true`, `grindCoverage == "verified"`, `grindIssueDetected == true`, and the yield-shortfall warning line fires.
+- [x] 4.4 Add scenario `grindArm1_defaultsTrueForDirectCallers`: invoke `analyzeShot` without the new parameter, assert Arm 1 runs (sample count > 0 on a shot designed to produce qualifying samples).
+- [x] 4.5 Run the full `tst_shotanalysis` suite via Qt Creator MCP (`mcp__qtcreator__run_tests` scoped to that test class); confirm pre-existing scenarios still pass without modification (the `=true` default preserves their behaviour).
+
+## 5. Regression-corpus diff
+
+- [x] 5.1 Build the `shot_eval` target via Qt Creator MCP (`mcp__qtcreator__build`).
+- [x] 5.2 Run `shot_eval --json tests/data/shots/*.json > /tmp/before.json` on the current build (record the pre-change baseline).
+- [x] 5.3 Apply the code changes from sections 1-3.
+- [x] 5.4 Rebuild `shot_eval`, run `shot_eval --json tests/data/shots/*.json > /tmp/after.json`.
+- [x] 5.5 Diff `before.json` vs `after.json`. Expected: zero shifts on corpus shots whose profile titles resolve via KB (every Adaptive, Cremina, Damian, Londinium, 80s, Malabar, Rao, Classic Italian, E61, Extractamundo entry). Any shift on a non-resolved corpus shot is a deliberate audit point — record the verdict change in the PR body with a one-line justification.
+- [x] 5.6 If any KB-resolved corpus shot shifts, that's a regression — investigate and fix before merge.
+
+## 6. Docs
+
+- [x] 6.1 Update `docs/SHOT_REVIEW.md` §2.2 "Grind issue": document the new `profileKbResolved` precondition for Arm 1, and the resulting `notAnalyzable` projection on KB-unresolved profiles. Cross-reference openspec change `skip-grind-arm1-when-kb-unresolved`.
+- [x] 6.2 Confirm no update needed to `docs/CLAUDE_MD/` reference docs (the change is internal to the shot-analysis pipeline; no contributor-facing convention changes).
+
+## 7. Land
+
+- [ ] 7.1 Run full test suite via Qt Creator MCP (`mcp__qtcreator__run_tests`); expect 0 failures, 0 new warnings.
+- [ ] 7.2 Run `tools/validate_kb.py` (no KB content change, but cheap sanity).
+- [ ] 7.3 Open PR on a feature branch (e.g. `feat/skip-grind-arm1-when-kb-unresolved`) with proposal/design/spec excerpts in the body, the corpus-diff result from section 5, and a closing-keyword link to the openspec change.
+- [ ] 7.4 Run `/pr-review-toolkit:review-pr` on the PR; address any issues it surfaces above the noise floor.
+- [ ] 7.5 After approval/sign-off, `/merge-pr` to squash-merge and delete the branch.
+- [ ] 7.6 Run `/openspec-archive-change skip-grind-arm1-when-kb-unresolved` (or the openspec CLI equivalent) once the PR has landed on `main`.

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -983,14 +983,24 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
         } else {
             d.grindDirection = QStringLiteral("onTarget");
             if (grind.verifiedClean) {
-                // Positive "we saw a healthy pressurized pour and the puck
-                // tracked goal" signal. Today's verdict on lever / two-frame
-                // profiles infers "Clean" from no-data; this line confirms
-                // it from data. Skipped when the detector was silent
-                // (hasData=false), which is handled by the notAnalyzable
-                // branch below.
+                // Positive "we saw a healthy pressurized pour" signal.
+                // Two arms can drive verifiedClean: Arm 1's flow-vs-goal
+                // averaging (sampleCount > 0) OR — on a KB-unresolved
+                // profile where Arm 1 was skipped (openspec
+                // skip-grind-arm1-when-kb-unresolved) — Arm 2's
+                // sustained-pressurized flow gate alone. The line text
+                // honestly names which signal fired so a reader doesn't
+                // mistake an Arm-2-only verify for an Arm-1 measurement
+                // (Arm 1 didn't run; we have no flow-vs-goal observation
+                // to cite). Today's verdict on lever / two-frame
+                // profiles infers "Clean" from no-data; this line
+                // confirms it from data on either path.
                 QVariantMap line;
-                line["text"] = QStringLiteral("Grind tracked goal during pour");
+                if (grind.sampleCount > 0) {
+                    line["text"] = QStringLiteral("Grind tracked goal during pour");
+                } else {
+                    line["text"] = QStringLiteral("Puck sustained healthy pressure during pour");
+                }
                 line["type"] = QStringLiteral("good");
                 line["kind"] = QStringLiteral("grind_clean");
                 lines.append(line);

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -374,8 +374,9 @@ ShotAnalysis::GrindCheck ShotAnalysis::analyzeFlowVsGoal(
     // false-positive grind diagnoses. Leaving flowModeRanges empty here
     // skips the averaging block below; sampleCount and delta stay zero,
     // hasData stays false from Arm 1's perspective. Arm 2 (choked-puck +
-    // yield-shortfall) runs unconditionally — those arms read physics-
-    // level signals that don't depend on profile shape. `skipped` is
+    // yield-shortfall + yield-overshoot) runs unconditionally — those
+    // arms read physics-level signals (mean pressurized flow, yield
+    // ratio) that don't depend on profile shape. `skipped` is
     // deliberately NOT set; the projection then falls into
     // grindCoverage="notAnalyzable" when Arm 2 also has no data, distinct
     // from grind_check_skip's "skipped" coverage. See openspec change

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -320,7 +320,8 @@ ShotAnalysis::GrindCheck ShotAnalysis::analyzeFlowVsGoal(
     const QStringList& analysisFlags,
     const QVector<QPointF>& pressure,
     double targetWeightG,
-    double finalWeightG)
+    double finalWeightG,
+    bool profileKbResolved)
 {
     GrindCheck result;
 
@@ -365,7 +366,21 @@ ShotAnalysis::GrindCheck ShotAnalysis::analyzeFlowVsGoal(
     // sustained "too fine" delta even on clean shots.
     struct Range { double start; double end; };
     QVector<Range> flowModeRanges;
-    if (!phases.isEmpty()) {
+    // Arm 1 (flow-vs-goal averaging) only runs when we have profile context.
+    // When matchProfileKey returned empty (no exact alias, no #1198 prefix
+    // hit, no editor-type default), the "flow goal" series may be a safety
+    // limiter, a ramp-down command, or a pump-ramp curve rather than a
+    // target the puck should track — averaging actuals against it produces
+    // false-positive grind diagnoses. Leaving flowModeRanges empty here
+    // skips the averaging block below; sampleCount and delta stay zero,
+    // hasData stays false from Arm 1's perspective. Arm 2 (choked-puck +
+    // yield-shortfall) runs unconditionally — those arms read physics-
+    // level signals that don't depend on profile shape. `skipped` is
+    // deliberately NOT set; the projection then falls into
+    // grindCoverage="notAnalyzable" when Arm 2 also has no data, distinct
+    // from grind_check_skip's "skipped" coverage. See openspec change
+    // skip-grind-arm1-when-kb-unresolved.
+    if (profileKbResolved && !phases.isEmpty()) {
         // Pump-ramp trim applies to the first flow-mode phase that
         // coincides with pourStart — that's the one where the pump goes
         // from idle to commanded flow. A flow-mode phase that starts
@@ -701,7 +716,8 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
     double targetWeightG,
     double finalWeightG,
     int expectedFrameCount,
-    const std::optional<ExpertBand>& expertBand)
+    const std::optional<ExpertBand>& expertBand,
+    bool profileKbResolved)
 {
     AnalysisResult result;
     QVariantList& lines = result.lines;
@@ -875,7 +891,8 @@ ShotAnalysis::AnalysisResult ShotAnalysis::analyzeShot(
                             pourStart, pourEnd,
                             beverageType, analysisFlags,
                             pressure,
-                            targetWeightG, finalWeightG);
+                            targetWeightG, finalWeightG,
+                            profileKbResolved);
     // Mirror channelingChecked / flowTrendChecked: `checked` reflects whether
     // the detector ran, not whether it was reachable. pourTruncated cascade
     // and the beverage / grind_check_skip skip path both leave grindChecked
@@ -1275,12 +1292,13 @@ QVariantList ShotAnalysis::generateSummary(const QVector<QPointF>& pressure,
                                              double targetWeightG,
                                              double finalWeightG,
                                              int expectedFrameCount,
-                                             const std::optional<ExpertBand>& expertBand)
+                                             const std::optional<ExpertBand>& expertBand,
+                                             bool profileKbResolved)
 {
     return analyzeShot(pressure, flow, weight,
                        conductanceDerivative, phases, beverageType, duration,
                        pressureGoal, flowGoal, analysisFlags,
                        firstFrameConfiguredSeconds, targetWeightG, finalWeightG,
-                       expectedFrameCount, expertBand)
+                       expectedFrameCount, expertBand, profileKbResolved)
         .lines;
 }

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -628,9 +628,10 @@ public:
     // #1198 longest-boundary-prefix, or editor-type default), false otherwise.
     // When false, Arm 1 of the grind detector is skipped — see analyzeFlowVsGoal
     // docstring above for the full contract. Default true preserves pre-change
-    // behaviour for direct callers (tests, future entry points). All five
-    // production call sites derive this from `!profileKbId.isEmpty()` of the
-    // resolved id already stored on the ShotRecord / ShotSaveData / ShotSummary.
+    // behaviour for direct callers (tests, future entry points). Every
+    // production call site of analyzeShot derives this from
+    // `!profileKbId.isEmpty()` of the resolved id already stored on the
+    // shot's carrier struct (ShotRecord / ShotSaveData / ShotSummary).
     static AnalysisResult analyzeShot(const QVector<QPointF>& pressure,
                                        const QVector<QPointF>& flow,
                                        const QVector<QPointF>& weight,

--- a/src/ai/shotanalysis.h
+++ b/src/ai/shotanalysis.h
@@ -381,6 +381,20 @@ public:
     // silent. The yield-overshoot arm has no pressurized-window gate — a
     // gusher by definition can't sustain pressure — so it can fire even
     // when pressure or flow data is empty.
+    //
+    // profileKbResolved gates Arm 1 (flow-vs-goal averaging). When false —
+    // i.e. ShotSummarizer::matchProfileKey returned empty, so we have no
+    // KB or editor-type context for this profile — Arm 1 is skipped
+    // entirely (delta/sampleCount stay zero, hasData contribution stays
+    // false). Arm 2 (choked-puck + yield-shortfall + yield-overshoot)
+    // runs unchanged because its arms read physics-level signals (yield
+    // ratio, sustained-pressurized mean flow) that don't depend on profile
+    // shape. `skipped` stays false so the projection falls into the
+    // existing grindCoverage="notAnalyzable" path when Arm 2 also has no
+    // data — distinct from grind_check_skip's "skipped" coverage. Default
+    // true preserves the pre-change contract for direct test callers and
+    // any future caller that genuinely intends "act as if resolved".
+    // See openspec change skip-grind-arm1-when-kb-unresolved.
     static GrindCheck analyzeFlowVsGoal(const QVector<QPointF>& flow,
                                          const QVector<QPointF>& flowGoal,
                                          const QList<HistoryPhaseMarker>& phases,
@@ -389,7 +403,8 @@ public:
                                          const QStringList& analysisFlags = {},
                                          const QVector<QPointF>& pressure = {},
                                          double targetWeightG = 0.0,
-                                         double finalWeightG = 0.0);
+                                         double finalWeightG = 0.0,
+                                         bool profileKbResolved = true);
 
     // Returns true if the grind direction check flags a meaningful deviation
     // (|delta| > FLOW_DEVIATION_THRESHOLD, chokedPuck fired, or yieldOvershoot
@@ -608,6 +623,14 @@ public:
     // MCP `shots_get_detail` so external agents can read the same
     // signals without parsing prose). All detectors run once and feed
     // both outputs.
+    // profileKbResolved (last parameter): true when the profile's KB resolution
+    // via ShotSummarizer::matchProfileKey produced a non-empty id (exact alias,
+    // #1198 longest-boundary-prefix, or editor-type default), false otherwise.
+    // When false, Arm 1 of the grind detector is skipped — see analyzeFlowVsGoal
+    // docstring above for the full contract. Default true preserves pre-change
+    // behaviour for direct callers (tests, future entry points). All five
+    // production call sites derive this from `!profileKbId.isEmpty()` of the
+    // resolved id already stored on the ShotRecord / ShotSaveData / ShotSummary.
     static AnalysisResult analyzeShot(const QVector<QPointF>& pressure,
                                        const QVector<QPointF>& flow,
                                        const QVector<QPointF>& weight,
@@ -622,7 +645,8 @@ public:
                                        double targetWeightG = 0.0,
                                        double finalWeightG = 0.0,
                                        int expectedFrameCount = -1,
-                                       const std::optional<ExpertBand>& expertBand = std::nullopt);
+                                       const std::optional<ExpertBand>& expertBand = std::nullopt,
+                                       bool profileKbResolved = true);
 
     // Backwards-compatible thin wrapper — equivalent to
     // analyzeShot(...).lines. Existing callers (in-app dialog, AI advisor
@@ -641,5 +665,6 @@ public:
                                          double targetWeightG = 0.0,
                                          double finalWeightG = 0.0,
                                          int expectedFrameCount = -1,
-                                         const std::optional<ExpertBand>& expertBand = std::nullopt);
+                                         const std::optional<ExpertBand>& expertBand = std::nullopt,
+                                         bool profileKbResolved = true);
 };

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -142,13 +142,22 @@ void ShotSummarizer::runShotAnalysisAndPopulate(ShotSummary& summary,
     double targetWeightG,
     int frameCount) const
 {
+    // profileKbResolved gates grind Arm 1. matchProfileKey returns empty
+    // when the profile title and editor type both fail to resolve via
+    // KB alias / #1198 prefix / editor-type default — that's the "we
+    // have no profile context" signal Arm 1 needs to skip on. The kbId
+    // stored on ShotSummary is the resolved id (empty when unresolved),
+    // so we can read the bit directly. See openspec change
+    // skip-grind-arm1-when-kb-unresolved.
+    const bool profileKbResolved = !summary.profileKbId.isEmpty();
     const ShotAnalysis::AnalysisResult analysis = ShotAnalysis::analyzeShot(
         pressure, flow, weight,
         conductanceDerivative, markers,
         summary.beverageType, summary.totalDuration,
         pressureGoal, flowGoal, analysisFlags,
         firstFrameSeconds, targetWeightG, summary.finalWeight,
-        frameCount, expertBandForKbId(summary.profileKbId));
+        frameCount, expertBandForKbId(summary.profileKbId),
+        profileKbResolved);
     summary.summaryLines = analysis.lines;
     summary.pourTruncatedDetected = analysis.detectors.pourTruncated;
 }

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1119,6 +1119,12 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
         // full mapping table and decenza::deriveBadgesFromAnalysis (in
         // history/shotbadgeprojection.h) for the projection rules.
         const AnalysisInputs inputs = prepareAnalysisInputs(data.profileKbId, data.profileJson);
+        // KB-resolved bit gates grind Arm 1 — see openspec change
+        // skip-grind-arm1-when-kb-unresolved. data.profileKbId is empty
+        // when ShotSummarizer::matchProfileKey returned no hit (no exact
+        // alias, no #1198 prefix, no editor-type default), which is the
+        // signal "we have no profile context for Arm 1 to be meaningful".
+        const bool profileKbResolved = !data.profileKbId.isEmpty();
         const auto analysis = ShotAnalysis::analyzeShot(
             tmpRecord.pressure, shotData->flowData(),
             shotData->cumulativeWeightData(),
@@ -1127,7 +1133,8 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
             shotData->pressureGoalData(), shotData->flowGoalData(),
             inputs.analysisFlags, inputs.firstFrameSeconds,
             data.targetWeight, data.finalWeight,
-            inputs.frameCount, inputs.expertBand);
+            inputs.frameCount, inputs.expertBand,
+            profileKbResolved);
         decenza::applyBadgesToTarget(data, analysis.detectors);
     }
 
@@ -1834,6 +1841,13 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     // helper interprets as "all badges false."
     {
         const AnalysisInputs inputs = prepareAnalysisInputs(record.profileKbId, record.profileJson);
+        // KB-resolved bit gates grind Arm 1 — see openspec change
+        // skip-grind-arm1-when-kb-unresolved. record.profileKbId can be
+        // empty either because the saved row predates KB resolution or
+        // because matchProfileKey returned no hit at save time; in both
+        // cases the right answer at recompute-on-load is "we have no
+        // profile context for Arm 1".
+        const bool profileKbResolved = !record.profileKbId.isEmpty();
         auto analysis = ShotAnalysis::analyzeShot(
             record.pressure, record.flow, record.weight,
             record.conductanceDerivative,
@@ -1841,7 +1855,8 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
             record.pressureGoal, record.flowGoal,
             inputs.analysisFlags, inputs.firstFrameSeconds,
             record.targetWeight, record.summary.finalWeight,
-            inputs.frameCount, inputs.expertBand);
+            inputs.frameCount, inputs.expertBand,
+            profileKbResolved);
         decenza::applyBadgesToTarget(record, analysis.detectors);
         // Cache the AnalysisResult on the ShotRecord so convertShotRecord
         // (called next in the requestShot path) doesn't have to re-run

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -118,6 +118,9 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
             analysisPtr = &record.cachedAnalysis.value();
         } else {
             const AnalysisInputs inputs = prepareAnalysisInputs(record.profileKbId, record.profileJson);
+            // KB-resolved bit gates grind Arm 1 — see openspec change
+            // skip-grind-arm1-when-kb-unresolved.
+            const bool profileKbResolved = !record.profileKbId.isEmpty();
             analysisOwned = ShotAnalysis::analyzeShot(
                 record.pressure, record.flow, record.weight,
                 record.conductanceDerivative,
@@ -125,7 +128,8 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
                 record.pressureGoal, record.flowGoal,
                 inputs.analysisFlags, inputs.firstFrameSeconds,
                 record.targetWeight, record.summary.finalWeight,
-                inputs.frameCount, inputs.expertBand);
+                inputs.frameCount, inputs.expertBand,
+                profileKbResolved);
             analysisPtr = &analysisOwned;
         }
         const ShotAnalysis::AnalysisResult& analysis = *analysisPtr;

--- a/tests/data/shots/manifest.json
+++ b/tests/data/shots/manifest.json
@@ -123,10 +123,11 @@
     },
     {
       "file": "gagne_adaptive_clean.json",
-      "description": "Gagné Adaptive Shot — multi-step adaptive profile with scan frames. Clean shot, detector must stay None (no confusion from the scan).",
+      "description": "Gagné Adaptive Shot — multi-step adaptive profile with scan frames. Clean shot, detector must stay None (no confusion from the scan). Profile title 'Gagné/Adaptive Shot 92C vME 7 bar' is a custom variant that does NOT match the 'gagne-adaptive' KB aliases (which list 'Gagné/Adaptive Shot 92C v1.0' etc.) and is therefore unresolvable. Post skip-grind-arm1-when-kb-unresolved this lands in grindCoverage=\"notAnalyzable\" with verdictCategory=\"cleanGrindNotAnalyzable\" — locked in here so any future KB addition that makes 'vME' resolve would flip the verdict back and surface the corpus shift.",
       "expect": {
         "channeling": "None",
-        "pourTruncated": false
+        "pourTruncated": false,
+        "verdictCategory": "cleanGrindNotAnalyzable"
       }
     },
     {

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -561,6 +561,11 @@ private slots:
         QVERIFY(!d.grindVerifiedClean);
         QVERIFY(!badges.grindIssueDetected);
         QCOMPARE(d.grindCoverage, QStringLiteral("notAnalyzable"));
+        // The verdictCategory drives the dialog tint and the structured
+        // MCP output — assert it directly so a future refactor of the
+        // cascade can't silently flip back to "clean" while the lines
+        // list still grep-matches.
+        QCOMPARE(d.verdictCategory, QStringLiteral("cleanGrindNotAnalyzable"));
         QCOMPARE(d.grindFlowDeltaMlPerSec, 0.0);  // Arm 1 didn't run
 
         bool sawObservation = false;

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -680,6 +680,164 @@ private slots:
         QVERIFY(r.delta < -0.4);
     }
 
+    // Arm-2-only verifiedClean on an unresolved profile must emit the
+    // honest "Puck sustained healthy pressure during pour" line, NOT
+    // the legacy "Grind tracked goal during pour" wording (Arm 1 didn't
+    // run, so we'd be citing a measurement that wasn't taken). Guards
+    // the sampleCount-based branch in analyzeShot's [good] line emission.
+    void analyzeShot_unresolvedKb_armTwoVerifiedClean_emitsSustainedPressureLine()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "preinfusion", 0, /*isFlowMode=*/true),
+            phase(8.0, "pour",        1, /*isFlowMode=*/false),
+        };
+        // Pressure ≥ 4 bar for ≥ 15 s with mean flow ≥ 0.5 mL/s and
+        // yield ratio within the clean band — Arm 2's flow-arm gates
+        // pass and verifiedClean fires from Arm 2 alone. Arm 1 is
+        // skipped because profileKbResolved=false.
+        QVector<QPointF> pressure = flatSeries(0.0, 30.0, 8.0);
+        QVector<QPointF> flow = flatSeries(0.0, 30.0, 1.8);
+        QVector<QPointF> pressureGoal = pressure;
+        QVector<QPointF> flowGoal = flatSeries(0.0, 30.0, 1.8);
+        QVector<QPointF> dCdt = flatSeries(0.0, 30.0, 0.0);
+        QVector<QPointF> weight;
+
+        const auto result = ShotAnalysis::analyzeShot(
+            pressure, flow, weight,
+            dCdt, phases, "espresso", 30.0,
+            pressureGoal, flowGoal, /*analysisFlags=*/{},
+            /*firstFrameConfiguredSeconds=*/-1.0,
+            /*targetWeightG=*/36.0, /*finalWeightG=*/36.0,
+            /*expectedFrameCount=*/-1, /*expertBand=*/std::nullopt,
+            /*profileKbResolved=*/false);
+
+        const auto& d = result.detectors;
+        QVERIFY(d.grindHasData);
+        QVERIFY(d.grindVerifiedClean);
+        QCOMPARE(d.grindSampleCount, qsizetype{0});  // Arm 1 didn't run
+        QCOMPARE(d.grindCoverage, QStringLiteral("verified"));
+
+        bool sawSustainedLine = false;
+        bool sawLegacyTrackedLine = false;
+        for (const QVariant& v : result.lines) {
+            const QVariantMap m = v.toMap();
+            const QString text = m["text"].toString();
+            if (m["type"].toString() == QStringLiteral("good")
+                && text.contains("Puck sustained healthy pressure",
+                                 Qt::CaseInsensitive))
+                sawSustainedLine = true;
+            if (text.contains("Grind tracked goal", Qt::CaseInsensitive))
+                sawLegacyTrackedLine = true;
+        }
+        QVERIFY2(sawSustainedLine,
+                 "Arm-2-only verifiedClean must emit the honest sustained-pressure line");
+        QVERIFY2(!sawLegacyTrackedLine,
+                 "Arm-2-only verifiedClean must NOT cite Arm 1's 'tracked goal' wording");
+    }
+
+    // grindCoverage="skipped" path through the full analyzeShot pipeline:
+    // when analysisFlags contains "grind_check_skip", the function
+    // early-returns with GrindCheck::skipped=true, distinct from the new
+    // profileKbResolved=false path (which leaves skipped=false and
+    // projects to "notAnalyzable"). The distinction is load-bearing for
+    // skip-grind-arm1-when-kb-unresolved — a future refactor that
+    // conflates the two paths (e.g. setting skipped=true in the
+    // unresolved branch) would silently regress Arm 2's behaviour on
+    // unresolved profiles. This test pins the "skipped" coverage value
+    // so the distinction stays visible.
+    void analyzeShot_grindCheckSkipFlag_projectsSkippedCoverage()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "preinfusion", 0, /*isFlowMode=*/true),
+            phase(10.0, "pour",       1, /*isFlowMode=*/true),
+        };
+        // Same Arm-1-would-fire shape as the unresolved-KB test. With
+        // grind_check_skip the whole detector short-circuits before
+        // either arm runs.
+        QVector<QPointF> pressure = flatSeries(0.0, 30.0, 3.5);
+        QVector<QPointF> flow = flatSeries(0.0, 30.0, 0.8);
+        QVector<QPointF> pressureGoal = pressure;
+        QVector<QPointF> flowGoal = flatSeries(0.0, 30.0, 1.7);
+        QVector<QPointF> dCdt = flatSeries(0.0, 30.0, 0.0);
+        QVector<QPointF> weight;
+
+        const auto result = ShotAnalysis::analyzeShot(
+            pressure, flow, weight,
+            dCdt, phases, "espresso", 30.0,
+            pressureGoal, flowGoal,
+            QStringList{QStringLiteral("grind_check_skip")},
+            /*firstFrameConfiguredSeconds=*/-1.0,
+            /*targetWeightG=*/36.0, /*finalWeightG=*/30.0);
+
+        const auto& d = result.detectors;
+        QVERIFY(!d.grindHasData);
+        QVERIFY(!d.grindChecked);            // detector explicitly suppressed
+        QCOMPARE(d.grindCoverage, QStringLiteral("skipped"));
+        // verdictCategory must NOT be "cleanGrindNotAnalyzable" — that
+        // value is reserved for the unresolved-KB path.
+        QVERIFY(d.verdictCategory != QStringLiteral("cleanGrindNotAnalyzable"));
+
+        bool sawNotAnalyzableLine = false;
+        for (const QVariant& v : result.lines) {
+            const QVariantMap m = v.toMap();
+            if (m["text"].toString().contains("Could not analyze grind",
+                                              Qt::CaseInsensitive))
+                sawNotAnalyzableLine = true;
+        }
+        QVERIFY2(!sawNotAnalyzableLine,
+                 "grind_check_skip path must NOT emit the notAnalyzable observation");
+    }
+
+    // pourTruncated cascade dominates the unresolved-KB gate: when peak
+    // pressure stays below PRESSURE_FLOOR_BAR, analyzeShot sets
+    // grind = GrindCheck{} unconditionally before the gate is reached.
+    // The profileKbResolved flag is therefore irrelevant on a truncated
+    // shot. Locks in that ordering — a future refactor that gates the
+    // GrindCheck{} short-circuit on profileKbResolved would silently
+    // break the cascade dominator on unresolved profiles.
+    void analyzeShot_pourTruncated_dominatesUnresolvedKbGate()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "preinfusion start", 0, /*isFlowMode=*/true),
+            phase(2.0, "pour",              1, /*isFlowMode=*/true),
+        };
+        // Pressure capped at 0.6 bar — well below PRESSURE_FLOOR_BAR
+        // (2.5), so pourTruncated fires.
+        QVector<QPointF> pressure = flatSeries(0.0, 7.0, 0.6);
+        QVector<QPointF> flow = flatSeries(0.0, 7.0, 7.0);
+        QVector<QPointF> flowGoal = flatSeries(0.0, 7.0, 7.5);
+        QVector<QPointF> dCdt = flatSeries(0.0, 7.0, 0.0);
+        QVector<QPointF> weight;
+
+        const auto result = ShotAnalysis::analyzeShot(
+            pressure, flow, weight,
+            dCdt, phases, "espresso", 7.0,
+            /*pressureGoal=*/{}, flowGoal, /*analysisFlags=*/{},
+            /*firstFrameConfiguredSeconds=*/-1.0,
+            /*targetWeightG=*/32.0, /*finalWeightG=*/36.5,
+            /*expectedFrameCount=*/-1, /*expertBand=*/std::nullopt,
+            /*profileKbResolved=*/false);
+
+        const auto& d = result.detectors;
+        QVERIFY(d.pourTruncated);
+        QCOMPARE(d.verdictCategory, QStringLiteral("puckTruncated"));
+        // pourTruncated cascade zeroes the grind block before the
+        // profileKbResolved gate is even consulted — grindCoverage
+        // stays empty (suppressed) on this path, NOT "notAnalyzable".
+        QVERIFY(d.grindCoverage.isEmpty());
+
+        bool sawNotAnalyzableLine = false;
+        for (const QVariant& v : result.lines) {
+            const QVariantMap m = v.toMap();
+            if (m["text"].toString().contains("Could not analyze grind",
+                                              Qt::CaseInsensitive))
+                sawNotAnalyzableLine = true;
+        }
+        QVERIFY2(!sawNotAnalyzableLine,
+                 "pourTruncated cascade must suppress the notAnalyzable observation "
+                 "regardless of profileKbResolved");
+    }
+
     // 80's Espresso style: preinfusion is flow-mode 7.5 ml/s with a pressure
     // ceiling that exits the frame on "pressure" transition once the puck
     // builds. The trailing samples (pressure limiter engaged → controller
@@ -2109,9 +2267,16 @@ private slots:
     // Grind coverage signal — verified clean: a healthy pressurized pour
     // with no choke / no overshoot / on-target flow must set
     // grindVerifiedClean=true, emit `grindCoverage="verified"`, and append
-    // a [good] line confirming the puck tracked goal. Without this signal
-    // the dialog falls back on inferring "Clean" from no-data, which is
-    // exactly the long-running gap on simple two-marker profiles.
+    // a [good] line confirming the puck behaved. Without this signal the
+    // dialog falls back on inferring "Clean" from no-data, which is
+    // exactly the long-running gap on simple two-marker profiles. The
+    // fixture's flow-mode phase ends at pourStart=8 so Arm 1 sees no
+    // qualifying samples (sampleCount=0); verifiedClean is supplied by
+    // Arm 2's sustained-pressurized-flow gate alone. The [good] line
+    // text therefore SHALL be the honest "Puck sustained healthy
+    // pressure during pour" — NOT the legacy "Grind tracked goal" which
+    // would falsely cite an Arm 1 measurement that wasn't taken. See
+    // openspec change skip-grind-arm1-when-kb-unresolved.
     void analyzeShot_grindCoverage_verifiedCleanEmitsPositiveLine()
     {
         QList<HistoryPhaseMarker> phases{
@@ -2140,6 +2305,7 @@ private slots:
         QVERIFY(d.grindVerifiedClean);
         QVERIFY(!d.grindChokedPuck);
         QVERIFY(!d.grindYieldOvershoot);
+        QCOMPARE(d.grindSampleCount, qsizetype{0});  // Arm 1 saw no samples
         QCOMPARE(d.grindCoverage, QStringLiteral("verified"));
         QCOMPARE(d.verdictCategory, QStringLiteral("clean"));
 
@@ -2147,10 +2313,12 @@ private slots:
         for (const QVariant& v : result.lines) {
             const QVariantMap m = v.toMap();
             if (m["type"].toString() == "good"
-                && m["text"].toString().contains("Grind tracked goal", Qt::CaseInsensitive))
+                && m["text"].toString().contains("Puck sustained healthy pressure",
+                                                 Qt::CaseInsensitive))
                 sawVerifiedLine = true;
         }
-        QVERIFY2(sawVerifiedLine, "verified-clean shot must emit [good] line");
+        QVERIFY2(sawVerifiedLine,
+                 "Arm-2-only verified-clean shot must emit the sustained-pressure [good] line");
     }
 
     // Grind coverage signal — not analyzable: a two-marker profile whose

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -489,6 +489,192 @@ private slots:
                  false);
     }
 
+    // profileKbResolved=false skips Arm 1 entirely. Same shot setup as
+    // flowVsGoal_flowModePourWithDelta_fires (which fires Arm 1 with
+    // delta = -0.9), but with profileKbResolved=false Arm 1's flow-mode-
+    // range builder is gated off — sampleCount and delta stay zero, the
+    // function returns clean defaults, skipped stays false so Arm 2 can
+    // still run on top. Regression for openspec change
+    // skip-grind-arm1-when-kb-unresolved.
+    void flowVsGoal_unresolvedKb_skipsArm1ButLeavesArm2Active()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "Preinfusion", 0, /*isFlowMode=*/true),
+            phase(10.0, "Pour", 1, /*isFlowMode=*/true),
+        };
+        auto flow = flatSeries(10.0, 30.0, 0.8);
+        auto flowGoal = flatSeries(10.0, 30.0, 1.7);
+
+        const auto r = ShotAnalysis::analyzeFlowVsGoal(
+            flow, flowGoal, phases, 10.0, 30.0,
+            /*beverage=*/"", /*analysisFlags=*/{},
+            /*pressure=*/{}, /*targetWeightG=*/0.0, /*finalWeightG=*/0.0,
+            /*profileKbResolved=*/false);
+        QVERIFY(!r.skipped);                 // distinct from grind_check_skip path
+        QVERIFY(!r.hasData);                 // Arm 1 didn't run
+        QCOMPARE(r.sampleCount, qsizetype{0});
+        QCOMPARE(r.delta, 0.0);
+
+        QCOMPARE(ShotAnalysis::detectGrindIssue(flow, flowGoal, phases, 10.0, 30.0),
+                 true);  // unchanged default-true contract still fires
+    }
+
+    // Full pipeline: unresolved KB on a flow-mode shot whose Arm 1 would
+    // otherwise fire (delta -0.9) AND whose pressure stays under 4 bar
+    // (Arm 2 silent) projects to grindCoverage="notAnalyzable" with the
+    // existing observation line and alternate verdict. The badge stays
+    // off. This is the false-positive surface the change targets — a
+    // user-created flow profile with no KB context no longer falsely
+    // accuses grind based on a flow-goal series whose meaning we can't
+    // verify.
+    void analyzeShot_unresolvedKb_armOneSilenced_projectsNotAnalyzable()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "preinfusion", 0, /*isFlowMode=*/true),
+            phase(10.0, "pour",       1, /*isFlowMode=*/true),
+        };
+        // Pressure 3.5 bar everywhere — above pourTruncated (2.5) so the
+        // dominator cascade doesn't fire, below Arm 2's 4 bar gate so
+        // Arm 2 sees no pressurized samples. Without the new gate, Arm 1
+        // would average flow=0.8 vs goal=1.7 across [10.5, 30] and fire
+        // with delta ≈ -0.9.
+        QVector<QPointF> pressure = flatSeries(0.0, 30.0, 3.5);
+        QVector<QPointF> flow = flatSeries(0.0, 30.0, 0.8);
+        QVector<QPointF> pressureGoal = pressure;
+        QVector<QPointF> flowGoal = flatSeries(0.0, 30.0, 1.7);
+        QVector<QPointF> dCdt = flatSeries(0.0, 30.0, 0.0);
+        QVector<QPointF> weight;
+
+        const auto result = ShotAnalysis::analyzeShot(
+            pressure, flow, weight,
+            dCdt, phases, "espresso", 30.0,
+            pressureGoal, flowGoal, /*analysisFlags=*/{},
+            /*firstFrameConfiguredSeconds=*/-1.0,
+            /*targetWeightG=*/36.0, /*finalWeightG=*/30.0,
+            /*expectedFrameCount=*/-1, /*expertBand=*/std::nullopt,
+            /*profileKbResolved=*/false);
+
+        const auto& d = result.detectors;
+        const auto badges = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY(!d.pourTruncated);
+        QVERIFY(!d.grindHasData);
+        QVERIFY(!d.grindVerifiedClean);
+        QVERIFY(!badges.grindIssueDetected);
+        QCOMPARE(d.grindCoverage, QStringLiteral("notAnalyzable"));
+        QCOMPARE(d.grindFlowDeltaMlPerSec, 0.0);  // Arm 1 didn't run
+
+        bool sawObservation = false;
+        bool sawAlternateVerdict = false;
+        for (const QVariant& v : result.lines) {
+            const QVariantMap m = v.toMap();
+            if (m["type"].toString() == "observation"
+                && m["text"].toString().contains("Could not analyze grind", Qt::CaseInsensitive))
+                sawObservation = true;
+            if (m["type"].toString() == "verdict"
+                && m["text"].toString().contains("grind could not be evaluated", Qt::CaseInsensitive))
+                sawAlternateVerdict = true;
+        }
+        QVERIFY2(sawObservation,
+                 "unresolved-KB shot must emit [observation] line via notAnalyzable path");
+        QVERIFY2(sawAlternateVerdict,
+                 "unresolved-KB shot must emit alternate verdict via notAnalyzable path");
+    }
+
+    // Same shot as above, but with profileKbResolved=true: Arm 1 runs
+    // normally and the grind badge fires with delta < -0.4. Locks in the
+    // bit-for-bit "no behaviour change on resolved profiles" contract
+    // alongside its negated sibling test above.
+    void analyzeShot_resolvedKb_armOneRunsAndFires()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "preinfusion", 0, /*isFlowMode=*/true),
+            phase(10.0, "pour",       1, /*isFlowMode=*/true),
+        };
+        QVector<QPointF> pressure = flatSeries(0.0, 30.0, 3.5);
+        QVector<QPointF> flow = flatSeries(0.0, 30.0, 0.8);
+        QVector<QPointF> pressureGoal = pressure;
+        QVector<QPointF> flowGoal = flatSeries(0.0, 30.0, 1.7);
+        QVector<QPointF> dCdt = flatSeries(0.0, 30.0, 0.0);
+        QVector<QPointF> weight;
+
+        const auto result = ShotAnalysis::analyzeShot(
+            pressure, flow, weight,
+            dCdt, phases, "espresso", 30.0,
+            pressureGoal, flowGoal, /*analysisFlags=*/{},
+            /*firstFrameConfiguredSeconds=*/-1.0,
+            /*targetWeightG=*/36.0, /*finalWeightG=*/30.0,
+            /*expectedFrameCount=*/-1, /*expertBand=*/std::nullopt,
+            /*profileKbResolved=*/true);
+
+        const auto& d = result.detectors;
+        const auto badges = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY(d.grindHasData);
+        QVERIFY(d.grindFlowDeltaMlPerSec < -ShotAnalysis::FLOW_DEVIATION_THRESHOLD);
+        QVERIFY(badges.grindIssueDetected);
+        QCOMPARE(d.grindCoverage, QStringLiteral("verified"));
+    }
+
+    // profileKbResolved=false does NOT suppress Arm 2's yield-shortfall
+    // arm. Even on a user-created profile we know nothing about, an
+    // 18g → 22g shot against a 36g target (yield ratio 0.61, below the
+    // 0.70 audit threshold) still fires the grind badge via Arm 2.
+    // Locks in the "we keep the profile-agnostic detectors" half of the
+    // change's contract.
+    void analyzeShot_unresolvedKb_yieldShortfallStillFiresArm2()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "preinfusion", 0, /*isFlowMode=*/true),
+            phase(8.0, "pour",        1, /*isFlowMode=*/false),
+        };
+        // Pressure ≥ 4 bar throughout pour-mode phase so Arm 2 sees
+        // pressurized samples. Duration is short enough that the
+        // flow-arm gate fails (pressurizedDuration < 15s) — only the
+        // yield arm fires. Final 22 g vs target 36 g = 0.61.
+        QVector<QPointF> pressure = flatSeries(0.0, 12.0, 6.0);
+        QVector<QPointF> flow = flatSeries(0.0, 12.0, 1.5);
+        QVector<QPointF> pressureGoal = pressure;
+        QVector<QPointF> flowGoal = flatSeries(0.0, 12.0, 1.5);
+        QVector<QPointF> dCdt = flatSeries(0.0, 12.0, 0.0);
+        QVector<QPointF> weight;
+
+        const auto result = ShotAnalysis::analyzeShot(
+            pressure, flow, weight,
+            dCdt, phases, "espresso", 12.0,
+            pressureGoal, flowGoal, /*analysisFlags=*/{},
+            /*firstFrameConfiguredSeconds=*/-1.0,
+            /*targetWeightG=*/36.0, /*finalWeightG=*/22.0,
+            /*expectedFrameCount=*/-1, /*expertBand=*/std::nullopt,
+            /*profileKbResolved=*/false);
+
+        const auto& d = result.detectors;
+        const auto badges = decenza::deriveBadgesFromAnalysis(d);
+        QVERIFY(d.grindChokedPuck);          // yield-shortfall fired
+        QVERIFY(d.grindHasData);
+        QVERIFY(badges.grindIssueDetected);
+        QCOMPARE(d.grindCoverage, QStringLiteral("verified"));
+    }
+
+    // Direct callers omitting the new parameter get the default-true
+    // contract: Arm 1 runs as before. Guards against accidentally
+    // changing the default-arg value in a future refactor (which would
+    // silently affect every test in this file).
+    void flowVsGoal_defaultProfileKbResolvedIsTrue()
+    {
+        QList<HistoryPhaseMarker> phases{
+            phase(0.0, "Preinfusion", 0, /*isFlowMode=*/true),
+            phase(10.0, "Pour", 1, /*isFlowMode=*/true),
+        };
+        auto flow = flatSeries(10.0, 30.0, 0.8);
+        auto flowGoal = flatSeries(10.0, 30.0, 1.7);
+
+        // No profileKbResolved arg supplied — relies on default.
+        const auto r = ShotAnalysis::analyzeFlowVsGoal(
+            flow, flowGoal, phases, 10.0, 30.0);
+        QVERIFY(r.hasData);                  // Arm 1 ran (default is true)
+        QVERIFY(r.sampleCount > 0);
+        QVERIFY(r.delta < -0.4);
+    }
+
     // 80's Espresso style: preinfusion is flow-mode 7.5 ml/s with a pressure
     // ceiling that exits the frame on "pressure" transition once the puck
     // builds. The trailing samples (pressure limiter engaged → controller

--- a/tests/tst_shotrecord_cache.cpp
+++ b/tests/tst_shotrecord_cache.cpp
@@ -157,7 +157,16 @@ private slots:
 
         ShotRecord recordCached = buildHealthyRecord();
         // Run analyzeShot ourselves (matching what loadShotRecordStatic
-        // would do) and stash the result in cachedAnalysis.
+        // would do) and stash the result in cachedAnalysis. Pass
+        // profileKbResolved derived from the same record.profileKbId the
+        // production fallback path reads — without this the cached path
+        // would silently use the parameter's default (true) while the
+        // fallback path derives false from the empty profileKbId, and
+        // the "fast vs slow are equivalent" invariant this test asserts
+        // would hold only by coincidence (both paths land on the same
+        // lines for this fixture). See openspec change
+        // skip-grind-arm1-when-kb-unresolved.
+        const bool profileKbResolved = !recordCached.profileKbId.isEmpty();
         recordCached.cachedAnalysis = ShotAnalysis::analyzeShot(
             recordCached.pressure, recordCached.flow, recordCached.weight,
             recordCached.conductanceDerivative,
@@ -166,7 +175,8 @@ private slots:
             recordCached.pressureGoal, recordCached.flowGoal,
             /*analysisFlags=*/{}, /*firstFrameSec=*/-1.0,
             recordCached.targetWeight, recordCached.summary.finalWeight,
-            /*expectedFrameCount=*/-1);
+            /*expectedFrameCount=*/-1, /*expertBand=*/std::nullopt,
+            profileKbResolved);
         const QVariantMap cachedResult = ShotHistoryStorage::convertShotRecord(recordCached).toVariantMap();
 
         // summaryLines must match line-for-line.

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -401,6 +401,108 @@ private slots:
     // then feed those into the fast path and confirm the result matches.
     // This catches drift if the fast-path branch is ever modified to do
     // something different than just reading the pre-computed field.
+    // Integration coverage for openspec change
+    // skip-grind-arm1-when-kb-unresolved: the gate inside analyzeFlowVsGoal
+    // is unit-tested in tst_shotanalysis, but the bit that drives it —
+    // `!summary.profileKbId.isEmpty()` derived inside runShotAnalysisAndPopulate —
+    // would silently invert on a missing `!` and slip past the algorithm
+    // tests (they pass profileKbResolved directly as an argument). This
+    // test pins that wire-up. Same curves, two profileKbId values, asserts
+    // opposite grindCoverage projections.
+    //
+    // Shot shape: flow-mode pour with actual=0.8 vs goal=1.7 → delta=-0.9,
+    // well past the 0.4 trigger. Pressure 3.5 bar throughout sits above
+    // pourTruncated's 2.5 floor (cascade dormant) AND below Arm 2's 4-bar
+    // gate (Arm 2 silent on both runs), so Arm 1 is the only thing the
+    // gate can flip. Yield ratio 30/36 = 0.83 keeps the yield-shortfall
+    // arm silent too. With Arm 2 silent, Arm 1 skipped ⇒ "notAnalyzable",
+    // Arm 1 ran ⇒ "verified" (delta past threshold ⇒ grindIssue fires).
+    void summarizeFromHistory_profileKbResolvedThreadsToGate()
+    {
+        auto buildArm1WouldFireShot = []() {
+            QVariantMap shot;
+            shot["beverageType"] = QStringLiteral("espresso");
+            shot["durationSec"] = 30.0;
+            shot["doseWeightG"] = 18.0;
+            shot["finalWeightG"] = 30.0;
+            shot["targetWeightG"] = 36.0;
+
+            QVariantList pressure, flow, flowGoal, temperature, temperatureGoal,
+                         derivative, weight;
+            appendFlat(pressure, 0.0, 30.0, 3.5);
+            appendFlat(flow, 0.0, 30.0, 0.8);
+            appendFlat(flowGoal, 0.0, 30.0, 1.7);
+            appendFlat(temperature, 0.0, 30.0, 92.0);
+            appendFlat(temperatureGoal, 0.0, 30.0, 92.0);
+            appendFlat(derivative, 0.0, 30.0, 0.0);
+            appendFlat(weight, 0.0, 30.0, 30.0);
+
+            QVariantList phases;
+            appendPhase(phases, 0.0,  QStringLiteral("preinfusion"), 0,
+                        /*isFlowMode=*/true);
+            appendPhase(phases, 10.0, QStringLiteral("pour"), 1,
+                        /*isFlowMode=*/true);
+
+            shot["pressure"] = pressure;
+            shot["flow"] = flow;
+            shot["flowGoal"] = flowGoal;
+            shot["pressureGoal"] = QVariantList();
+            shot["temperature"] = temperature;
+            shot["temperatureGoal"] = temperatureGoal;
+            shot["conductanceDerivative"] = derivative;
+            shot["weight"] = weight;
+            shot["phases"] = phases;
+            return shot;
+        };
+
+        ShotSummarizer summarizer;
+
+        // Resolved: profileKbId points at a real KB entry. Arm 1 runs,
+        // delta hits threshold, grindIssue fires, coverage is "verified".
+        QVariantMap resolvedShot = buildArm1WouldFireShot();
+        resolvedShot["profileName"] = QStringLiteral("Adaptive v2");
+        resolvedShot["profileKbId"] = QStringLiteral("adaptive-v2");
+        const ShotSummary resolved = summarizer.summarizeFromHistory(
+            ShotProjection::fromVariantMap(resolvedShot));
+        bool resolvedSawNotAnalyzable = false;
+        for (const QVariant& v : resolved.summaryLines) {
+            const QVariantMap m = v.toMap();
+            if (m["text"].toString().contains(
+                    QStringLiteral("Could not analyze grind"),
+                    Qt::CaseInsensitive))
+                resolvedSawNotAnalyzable = true;
+        }
+        QVERIFY2(!resolvedSawNotAnalyzable,
+                 "resolved profile must NOT emit the notAnalyzable observation");
+
+        // Unresolved: profileKbId is empty. Arm 1 is skipped; with Arm 2
+        // also silent, coverage falls into "notAnalyzable" and the
+        // [observation] line + alternate verdict fire.
+        QVariantMap unresolvedShot = buildArm1WouldFireShot();
+        unresolvedShot["profileName"] = QStringLiteral("Jeff's Custom Profile 47");
+        unresolvedShot["profileKbId"] = QString();
+        const ShotSummary unresolved = summarizer.summarizeFromHistory(
+            ShotProjection::fromVariantMap(unresolvedShot));
+        bool unresolvedSawNotAnalyzable = false;
+        bool unresolvedSawAlternateVerdict = false;
+        for (const QVariant& v : unresolved.summaryLines) {
+            const QVariantMap m = v.toMap();
+            const QString text = m["text"].toString();
+            if (m["type"].toString() == QStringLiteral("observation")
+                && text.contains(QStringLiteral("Could not analyze grind"),
+                                 Qt::CaseInsensitive))
+                unresolvedSawNotAnalyzable = true;
+            if (m["type"].toString() == QStringLiteral("verdict")
+                && text.contains(QStringLiteral("grind could not be evaluated"),
+                                 Qt::CaseInsensitive))
+                unresolvedSawAlternateVerdict = true;
+        }
+        QVERIFY2(unresolvedSawNotAnalyzable,
+                 "unresolved profile must emit the [observation] notAnalyzable line");
+        QVERIFY2(unresolvedSawAlternateVerdict,
+                 "unresolved profile must emit the alternate verdict");
+    }
+
     void summarizeFromHistory_fastAndSlowPathsAgree()
     {
         QVariantMap slowShot = buildHealthyShotMap();

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -647,36 +647,61 @@ EvaluatedShot evaluate(const LoadedShot& s)
 
     // --- App parity (scoped — read this) ---
     // Route through the ONE production analyzeShot with the SAME inputs the
-    // app resolves (analysisFlags + expertBand), instead of the old
-    // empty-flags reimpl that silently diverged on flow_trend_ok
-    // suppression + the expert-band line.
+    // app resolves (analysisFlags + expertBand + profileKbResolved gate),
+    // instead of the old empty-flags reimpl that silently diverged on
+    // flow_trend_ok suppression + the expert-band line.
     //
-    // SCOPE / NOT a general guarantee: this resolves kbId from the title
-    // with an EMPTY editorType, whereas the app's prepareAnalysisInputs
-    // passes the profile's real editorType. matchProfileKey's editor-type
-    // fallback (dflow→d-flow/default, aflow→a-flow) is the resolution path
-    // for *custom-titled* D-Flow/A-Flow profiles that don't title-match a
-    // KB key. For the current tests/data/shots/ corpus this is moot — every
-    // fixture title-matches a KB key directly and carries no profile JSON
-    // (so frameCount/firstFrameSeconds are -1 on BOTH sides) — so for the
-    // corpus the inputs are identical. It is NOT identical for
-    // custom-titled editor profiles (band-fire counts would under-report
-    // vs the app there), and TstShotCorpus validates shot_eval against its
-    // own manifest baseline, NOT against the live app — it cannot, and does
-    // not, assert app↔tool equality. Treat the parity as "corpus-scoped,
-    // title-match path only." (To make it general: carry editorType in
-    // fixtures and thread it here.)
+    // editorType is inferred from the title prefix below (mirroring
+    // Profile::editorType for the D-Flow/A-Flow editor namespaces), so
+    // custom-titled editor profiles ("D-Flow / Malabar") resolve to the
+    // editor-default KB entry the same way the app's prepareAnalysisInputs
+    // does. Pressure/flow/advanced editor types (settings_2a / settings_2b
+    // / advanced) have no title prefix in the canonical convention; their
+    // resolution depends on having profileType in the fixture, which the
+    // current corpus doesn't carry — but those editor types have no
+    // editor-default KB entry, so resolution falls through to "" either
+    // way and the consequence is the same. TstShotCorpus validates
+    // shot_eval against its own manifest baseline, not against the live
+    // app — but the title-prefix inference closes the largest known
+    // divergence (#1198 + skip-grind-arm1-when-kb-unresolved era).
+    // Mirror Profile::editorType's title-prefix inference: a title starting
+    // with "D-Flow" / "A-Flow" identifies the editor namespace, which lets
+    // matchProfileKey's editor-type-default fallback resolve custom-titled
+    // editor profiles ("D-Flow / Malabar") even when no exact alias or
+    // prefix-anchor hit exists. Without this, shot_eval's resolution path
+    // would silently drop those fixtures into the unresolved bucket, and
+    // the new profileKbResolved gate (openspec
+    // skip-grind-arm1-when-kb-unresolved) would skip Arm 1 on them — a
+    // false divergence from production, where Profile::editorType supplies
+    // this hint to prepareAnalysisInputs. Pressure/flow/advanced editor
+    // types don't have a title prefix; they pass through with an empty
+    // hint (no editor-default KB entry to fall back to). The "*"
+    // leading-character convention for renamed copies is honored to mirror
+    // production.
+    QString editorTypeHint;
+    {
+        const QString t = s.profileTitle.startsWith(QLatin1Char('*'))
+            ? s.profileTitle.mid(1) : s.profileTitle;
+        if (t.startsWith(QStringLiteral("D-Flow"), Qt::CaseInsensitive))
+            editorTypeHint = QStringLiteral("dflow");
+        else if (t.startsWith(QStringLiteral("A-Flow"), Qt::CaseInsensitive))
+            editorTypeHint = QStringLiteral("aflow");
+    }
     const QString kbId =
-        ShotSummarizer::computeProfileKbId(s.profileTitle, QString());
+        ShotSummarizer::computeProfileKbId(s.profileTitle, editorTypeHint);
     const QStringList analysisFlags = ShotSummarizer::getAnalysisFlags(kbId);
     const std::optional<ShotAnalysis::ExpertBand> expertBand =
         ShotSummarizer::expertBandForKbId(kbId);
+    // Resolved kbId gates grind Arm 1 on; an unresolved one gates it off.
+    // See openspec change skip-grind-arm1-when-kb-unresolved.
+    const bool profileKbResolved = !kbId.isEmpty();
 
     const ShotAnalysis::AnalysisResult R = ShotAnalysis::analyzeShot(
         s.pressure, s.flow, /*weight=*/{}, s.conductanceDerivative, s.phases,
         s.beverageType, s.durationSec, s.pressureGoal, s.flowGoal,
         analysisFlags, /*firstFrameConfiguredSeconds=*/-1.0,
-        s.targetWeightG, s.yieldG, /*expectedFrameCount=*/-1, expertBand);
+        s.targetWeightG, s.yieldG, /*expectedFrameCount=*/-1, expertBand,
+        profileKbResolved);
 
     const decenza::BadgeFlags badges =
         decenza::deriveBadgesFromAnalysis(R.detectors);

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -651,33 +651,24 @@ EvaluatedShot evaluate(const LoadedShot& s)
     // instead of the old empty-flags reimpl that silently diverged on
     // flow_trend_ok suppression + the expert-band line.
     //
-    // editorType is inferred from the title prefix below (mirroring
-    // Profile::editorType for the D-Flow/A-Flow editor namespaces), so
-    // custom-titled editor profiles ("D-Flow / Malabar") resolve to the
-    // editor-default KB entry the same way the app's prepareAnalysisInputs
-    // does. Pressure/flow/advanced editor types (settings_2a / settings_2b
-    // / advanced) have no title prefix in the canonical convention; their
-    // resolution depends on having profileType in the fixture, which the
-    // current corpus doesn't carry — but those editor types have no
-    // editor-default KB entry, so resolution falls through to "" either
-    // way and the consequence is the same. TstShotCorpus validates
-    // shot_eval against its own manifest baseline, not against the live
-    // app — but the title-prefix inference closes the largest known
-    // divergence (#1198 + skip-grind-arm1-when-kb-unresolved era).
-    // Mirror Profile::editorType's title-prefix inference: a title starting
-    // with "D-Flow" / "A-Flow" identifies the editor namespace, which lets
-    // matchProfileKey's editor-type-default fallback resolve custom-titled
-    // editor profiles ("D-Flow / Malabar") even when no exact alias or
-    // prefix-anchor hit exists. Without this, shot_eval's resolution path
-    // would silently drop those fixtures into the unresolved bucket, and
-    // the new profileKbResolved gate (openspec
-    // skip-grind-arm1-when-kb-unresolved) would skip Arm 1 on them — a
-    // false divergence from production, where Profile::editorType supplies
-    // this hint to prepareAnalysisInputs. Pressure/flow/advanced editor
-    // types don't have a title prefix; they pass through with an empty
-    // hint (no editor-default KB entry to fall back to). The "*"
-    // leading-character convention for renamed copies is honored to mirror
-    // production.
+    // editorType is inferred from the title prefix below — keep in sync
+    // with Profile::editorType (src/profile/profile.cpp:344). A title
+    // starting with "D-Flow" / "A-Flow" identifies the editor namespace,
+    // which lets matchProfileKey's editor-type-default fallback resolve
+    // custom-titled editor profiles ("D-Flow / Malabar") to the editor-
+    // default KB entry the same way prepareAnalysisInputs does in the
+    // live app. Without this, shot_eval would silently drop those
+    // fixtures into the unresolved bucket and the new profileKbResolved
+    // gate (openspec skip-grind-arm1-when-kb-unresolved) would skip
+    // Arm 1 on them — a false divergence from production. The "*"
+    // leading-character convention for renamed copies is honored for
+    // the same reason. Pressure/flow/advanced editor types have no
+    // title prefix in this convention and no editor-default KB entry
+    // either, so they fall through to "" with the same consequence on
+    // both sides. TstShotCorpus validates shot_eval against its own
+    // manifest baseline, not against the live app — but the title-prefix
+    // inference closes the largest known divergence (#1198 +
+    // skip-grind-arm1-when-kb-unresolved era).
     QString editorTypeHint;
     {
         const QString t = s.profileTitle.startsWith(QLatin1Char('*'))


### PR DESCRIPTION
## Why

Grind Arm 1 (flow-vs-goal averaging in `analyzeFlowVsGoal`) is the only one of the four shot-analysis badges that requires profile context to be meaningful. It reads the firmware-reported `flow_goal` series as a target the puck should track and averages actuals against it. On many real profile shapes the goal isn't that — it's a safety limiter on lever-decline frames, a firmware-generated ramp-down command on dynamic-bloom frames, or a pump-ramp curve on a first-frame that got swallowed by the BLE skip-first-step bug. Running Arm 1 on those profiles produces false-positive "grind too fine / coarse" badges (this is exactly what #1205 traced for ChiSaw's clean 32.4 g / 29.75 s Advanced Spring Lever shot — it landed at mean delta -0.399 mL/s, right on the 0.4 threshold).

#1230 fixed the specific #1205 report by adding `grind_check_skip` to one KB entry. This PR generalises: on profiles we have **no** KB context for (`matchProfileKey` returns empty — no exact alias, no #1198 longest-boundary-prefix hit, no editor-type default hit), skip Arm 1 and let the result project through the existing `grindCoverage="notAnalyzable"` infrastructure. The trigger signal already exists at every `analyzeShot` call site as `!profileKbId.isEmpty()` — no new flag, no new prose, no new UI.

## What changes

- New `bool profileKbResolved = true` parameter on `analyzeFlowVsGoal`, `analyzeShot`, and the `generateSummary` wrapper. Default `true` preserves the pre-change contract for direct test callers byte-for-byte.
- `analyzeFlowVsGoal` gates the flow-mode-range builder block on the flag; when `false`, ranges stay empty and the existing averaging block early-exits. `skipped` stays `false` (distinct from `grind_check_skip`'s `"skipped"` coverage) so Arm 2 still runs and the projection falls into `notAnalyzable` when Arm 2 has no data or `verified` when it does.
- Five production call sites (saveShot, loadShotRecordStatic, convertShotRecord, ShotSummarizer::summarize live, summarizeFromHistory) derive the bool from `!profileKbId.isEmpty()` already in scope. The shared `runShotAnalysisAndPopulate` helper handles both ShotSummarizer entry points with one edit.
- `shot_eval` gains title-prefix editor-type inference (D-Flow/A-Flow → dflow/aflow hint) so custom-titled editor profiles like `D-Flow / Malabar` resolve to the dflow editor-default the same way the live app does via `Profile::editorType`. Without this, shot_eval would artificially flag those fixtures as unresolved and the new gate would skip Arm 1 on them — a false divergence from production where `prepareAnalysisInputs` passes the real editorType.

The profile-agnostic detectors (`pourTruncated` from peak-pressure floor, `skipFirstFrame` from phase markers, channeling with its existing `channeling_expected` / `shouldSkipChannelingCheck` heuristics, and grind Arm 2 from yield-shortfall + sustained-pressurized-flow choke) keep running unchanged on unresolved profiles. They catch missing baskets, gushers, the SFS firmware bug, and choked grinds regardless of profile context — the badges we don't want to lose.

## Validation

**Unit tests:** 2191 pass, 0 failed, 0 warnings (was 2186 — added 5 new scenarios covering Arm 1 skip on unresolved, Arm 1 run on resolved, Arm 2 yield-shortfall still fires when unresolved, default-true preservation, and the full analyzeShot projection through `notAnalyzable` coverage).

**shot_eval corpus diff (21 shots):**

- `tests/data/shots/manifest.json --validate`: **21/21 PASS**.
- Side-by-side diff of `shot_eval --json` before vs after this change shows zero shifts on every KB-resolvable corpus shot (Adaptive v2 ×2, Blooming ×2, 80's ×2, Classic Italian ×2, Cremina, Damian LRv3, E61, Extractamundo, Londinium ×2, D-Flow Malabar, D-Flow Q/Q2, Rao Allongé ×2, synthetic puck-failure ×2, adaptive_v2_too_fine_expertband, rao_allonge_too_fine_medianflow).
- **One intentional verdict-text shift** on `gagne_adaptive_clean.json` (title `Gagné/Adaptive Shot 92C vME 7 bar` — a custom-titled variant that doesn't match any KB alias):
  - Before: `verdictCategory: "clean"`, `summaryVerdict: "Verdict: Clean shot. Puck held well."`
  - After: `verdictCategory: "cleanGrindNotAnalyzable"`, `summaryVerdict: "Verdict: Clean shot, but grind could not be evaluated for this profile shape."`
  - Manifest only asserts `channeling: None` + `pourTruncated: false` on this fixture; both unchanged. The verdict shift is the intended behaviour for an unresolved title.

**KB validator:** `tools/validate_kb.py` passes (0 lint warnings — no KB content change in this PR).

## OpenSpec

Change spec lives at `openspec/changes/skip-grind-arm1-when-kb-unresolved/` with proposal, design, spec delta (ADDED requirement against `shot-analysis-pipeline`), and the implementation tasks list. The change will be archived after this PR lands.

## Docs

`docs/SHOT_REVIEW.md` §2.2 documents the new precondition. No `docs/CLAUDE_MD/` changes — the change is internal to the shot-analysis pipeline; no contributor-facing convention changes.

## Recompute-on-load

The detectors recompute on every shot load (per `docs/SHOT_REVIEW.md` §4). Existing shots on KB-unresolved profiles where Arm 1 was producing a false-positive will re-render with `grindCoverage="notAnalyzable"`, the appropriate observation line, and the "clean but grind not evaluated" verdict (when no other badge fires). No user action required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)