### PR TITLE
fix(ble): keep scale connection-priority machinery off the refractometer link

### DIFF
--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -263,6 +263,17 @@ void QtScaleBleTransport::onControllerConnected() {
     QT_TRANSPORT_LOG("Controller connected!");
     m_connected = true;
 
+    if (!m_connectionPriorityManaged) {
+        // Non-scale link (refractometer): leave the connection at the
+        // platform-default interval and arm no DE1-fault / feed-stall
+        // detection. Forcing a third HIGH link here contends with the DE1 +
+        // scale and the GATT scheduler tears this (weakest) link down.
+        QT_TRANSPORT_LOG("Connection-priority: unmanaged link (non-scale) — "
+                         "staying at platform default, no detection armed");
+        emit connected();
+        return;
+    }
+
     // Connection-priority for the scale link (dual-HIGH BLE contention,
     // #1093/#1176). The DE1 always requests HIGH; the scale also requests
     // HIGH UNLESS a backoff was triggered earlier this app run, in which case
@@ -322,6 +333,7 @@ void QtScaleBleTransport::onControllerConnected() {
 }
 
 void QtScaleBleTransport::onDe1LinkFault(const QString& kind) {
+    if (!m_connectionPriorityManaged) return;  // non-scale link, no detection
     // Primary signal: a DE1-link fault clustered shortly after the scale
     // requested HIGH is the dual-HIGH contention signature (#1093/#1176).
     const bool fired = m_priority.onDe1Fault(nowMs());
@@ -344,6 +356,7 @@ void QtScaleBleTransport::onDe1LinkFault(const QString& kind) {
 }
 
 void QtScaleBleTransport::onScaleFeedStalled(qint64 gapMs) {
+    if (!m_connectionPriorityManaged) return;  // non-scale link, no detection
     // SUSPECTED stall only — this no longer drives the backoff (a transient
     // blip that self-recovers must NOT latch). It is the observe/diagnostic
     // breadcrumb; the latch trigger is onScaleFeedStallConfirmed below. The
@@ -357,6 +370,7 @@ void QtScaleBleTransport::onScaleFeedStalled(qint64 gapMs) {
 }
 
 void QtScaleBleTransport::onScaleFeedStallConfirmed(qint64 gapMs) {
+    if (!m_connectionPriorityManaged) return;  // non-scale link, no detection
     // CONFIRMED stall — persisted past kScaleStallConfirmMs with no recovery
     // (the transient/false shape never reaches here). THIS is the real
     // backstop trigger (the actual #1176 shot-1151 case is a sustained dead
@@ -384,6 +398,7 @@ void QtScaleBleTransport::onScaleFeedStallConfirmed(qint64 gapMs) {
 }
 
 void QtScaleBleTransport::onScaleFeedResumed(qint64 gapMs) {
+    if (!m_connectionPriorityManaged) return;  // non-scale link, no detection
     // Observe-only recovery evidence: a SUSPECTED stall came back on its own
     // before it could confirm — so with confirmation it would NOT have backed
     // off. Recording the recovered gap here is also the calibration data for

--- a/src/ble/transport/qtscalebletransport.h
+++ b/src/ble/transport/qtscalebletransport.h
@@ -37,6 +37,7 @@ public:
     bool isConnected() const override;
 
     void setSkipHighPriority(bool skip) override { m_priority.setSkipHighPriority(skip); }
+    void setConnectionPriorityManaged(bool managed) override { m_connectionPriorityManaged = managed; }
 
 public slots:
     // Connection-priority detection (#1093/#1176). Correlated against the
@@ -91,6 +92,12 @@ private:
     // main.cpp). Gates triggerScaleBackoff(): defer the teardown while a shot
     // is in progress, bounce only when idle. #1176.
     bool m_shotActive = false;
+
+    // False when this transport drives a non-scale link (refractometer): the
+    // connection-priority enforcement and scale-feed-stall detection are
+    // scale-only and would destabilize / log-spam a device that never sends
+    // weight. Default true keeps every scale path unchanged.
+    bool m_connectionPriorityManaged = true;
 
     // Connection-priority backoff. Pure decision logic in a Qt-free helper
     // (unit-tested in isolation); it lives on this transport, which persists

--- a/src/ble/transport/scalebletransport.h
+++ b/src/ble/transport/scalebletransport.h
@@ -104,7 +104,7 @@ public:
      * When set, the transport must NOT request CONNECTION_PRIORITY_HIGH on
      * (re)connect, leaving the link at the platform-default BALANCED interval.
      * Session-scoped, in-memory only. Default no-op (only QtScaleBleTransport
-     * — Android — implements it; CoreBluetooth is unaffected).
+     * — Android/desktop — implements it; CoreBluetooth is unaffected).
      */
     virtual void setSkipHighPriority(bool skip) { Q_UNUSED(skip); }
 
@@ -117,7 +117,8 @@ public:
      * (the refractometer) down mid-discovery. Pass false for non-scale links so
      * the connection stays at the platform-default interval with no DE1-fault /
      * feed-stall detection armed. Default no-op (only QtScaleBleTransport —
-     * Android/desktop — runs this machinery; CoreBluetooth never forces HIGH).
+     * Android/desktop — runs this machinery; the CoreBluetooth transport does
+     * not request connection priority).
      */
     virtual void setConnectionPriorityManaged(bool managed) { Q_UNUSED(managed); }
 

--- a/src/ble/transport/scalebletransport.h
+++ b/src/ble/transport/scalebletransport.h
@@ -108,6 +108,19 @@ public:
      */
     virtual void setSkipHighPriority(bool skip) { Q_UNUSED(skip); }
 
+    /**
+     * Scope the connection-priority + scale-feed-stall machinery to actual
+     * scales. A refractometer reuses this transport class but is NOT a scale:
+     * it never produces weight samples, and forcing its link to
+     * CONNECTION_PRIORITY_HIGH adds a third HIGH connection that contends with
+     * the DE1 + scale — the platform GATT scheduler then tears the weakest link
+     * (the refractometer) down mid-discovery. Pass false for non-scale links so
+     * the connection stays at the platform-default interval with no DE1-fault /
+     * feed-stall detection armed. Default no-op (only QtScaleBleTransport —
+     * Android/desktop — runs this machinery; CoreBluetooth never forces HIGH).
+     */
+    virtual void setConnectionPriorityManaged(bool managed) { Q_UNUSED(managed); }
+
 public slots:
     /**
      * Detection inputs wired in main.cpp from the (stable) DE1Device and the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1358,7 +1358,15 @@ int main(int argc, char *argv[])
     // Connect to any supported scale when discovered
     QObject::connect(&bleManager, &BLEManager::scaleDiscovered,
                      [&physicalScale, &flowScale, &machineState, &mainController, &engine, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &scaleAutoReconnectSuppressed](const QBluetoothDeviceInfo& device, const QString& type) {
-        // Don't connect if we already have a connected scale
+        // Single-scale invariant: at most one physical scale is connected at a
+        // time (a different scale type replaces the old one below, never runs
+        // alongside it). This caps concurrent forced-HIGH BLE links at two —
+        // DE1 + scale — the proven-good #1097 baseline. Connecting a second
+        // scale simultaneously would make it a third HIGH link and reintroduce
+        // the GATT-scheduler contention that tears the weakest link down (the
+        // refractometer fix relies on this same 2-link ceiling). If
+        // simultaneous multi-scale is ever added, the non-primary link must
+        // stay BALANCED / unmanaged like the refractometer transport.
         if (physicalScale && physicalScale->isConnected()) {
             return;
         }
@@ -1627,6 +1635,11 @@ int main(int argc, char *argv[])
         auto* transport = new QtScaleBleTransport();
 #endif
         refractometer = std::make_unique<DiFluidR2>(transport);
+        // The refractometer reuses the scale transport class but is not a
+        // scale: a 3rd forced-HIGH BLE link contends with the DE1 + scale and
+        // the platform GATT scheduler tears the weakest one (this) down. Keep
+        // the scale connection-priority / feed-stall machinery off this link.
+        transport->setConnectionPriorityManaged(false);
         refractometer->connectToDevice(device);
 
         // Wire to MainController for TDS → Settings pipeline


### PR DESCRIPTION
## Summary

The DiFluid R2 refractometer reuses `QtScaleBleTransport` but is **not** a scale. On every connect it was forced to `CONNECTION_PRIORITY_HIGH`, adding a *third* HIGH BLE link alongside the DE1 and scale. On the Android tablet the GATT scheduler then tore the weakest link (the R2) down mid service-discovery (`CONTROLLER ERROR: ConnectionError (state=Unconnected)`, ~6 s in), so the R2 never stayed connected and the shot-review button never flipped to **"Read TDS"** — even though auto-connect was firing correctly. Diagnosed from the on-device debug log: every R2 controller-connect was immediately followed by `Scale connection-priority: OBSERVE mode — forcing HIGH`, then a teardown.

Changes:
- New `setConnectionPriorityManaged(bool)` on the `ScaleBleTransport` interface — default **no-op**, so scales and the CoreBluetooth (macOS/iOS) path are untouched.
- `QtScaleBleTransport` gains `m_connectionPriorityManaged` (default `true`). When `false`, `onControllerConnected()` skips the connection-priority request (no forced HIGH) and arms no DE1-fault / feed-stall detection, while still emitting `connected()` so service discovery proceeds normally. The four scale-stall / DE1-fault slots also early-return, so that machinery can never touch a non-scale link.
- The refractometer marks its transport non-scale right after construction in `main.cpp`.
- Documents the single-scale invariant in `main.cpp` so a future *simultaneous* multi-scale change doesn't silently reintroduce the same >2 forced-HIGH link contention.

Scales are byte-for-byte unchanged (flag defaults `true`). +49/-1, additive.

## Test plan

- [ ] Build + deploy to the Android tablet (Samsung SM-X210).
- [ ] Power on the DiFluid R2 from the shot-review page; confirm log now shows `Connection-priority: unmanaged link (non-scale) — staying at platform default` instead of `Scale connection-priority: OBSERVE mode — forcing HIGH`.
- [ ] R2 reaches `[BLE DiFluidR2] Connected and ready for measurements` and **stays** (no recurring `CONTROLLER ERROR: ConnectionError`); shot-review button flips to "Read TDS" and remains.
- [ ] Take a TDS reading; confirm it lands on the shot.
- [ ] Regression: a normal espresso shot still logs `Requesting CONNECTION_PRIORITY_HIGH on scale` and SAW stops accurately (scale path unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)