### PR TITLE
diag(ble): instrument R2 connect path to capture the real timeline

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -539,8 +539,11 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
         // Avoid duplicates
         for (const auto& existing : m_refractometerDevices) {
             if (getDeviceIdentifier(existing) == getDeviceIdentifier(device)) {
-                qDebug().noquote() << QString("[R2-diag] R2 advert dev=%1 ALREADY in discovered list — dedup return, NO refractometerDiscovered emitted")
-                    .arg(getDeviceIdentifier(device));
+                // No log here: onDeviceDiscovered fires on every BLE
+                // advertisement (~100-500 ms); the device is already logged
+                // once on first discovery below. Logging here would flood the
+                // diagnostic timeline this instrumentation exists to keep
+                // readable.
                 return;
             }
         }
@@ -556,8 +559,8 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
                  savedMatch ? QStringLiteral("true") : QStringLiteral("false"),
                  m_userInitiatedScaleScan ? QStringLiteral("true") : QStringLiteral("false"),
                  savedMatch ? QStringLiteral("emit refractometerDiscovered")
-                            : (m_userInitiatedScaleScan ? QStringLiteral("listing only (no auto-connect)")
-                                                         : QStringLiteral("ignored")));
+                            : (m_userInitiatedScaleScan ? QStringLiteral("listed only (no auto-connect)")
+                                                         : QStringLiteral("listed, skip auto-connect (not saved device)")));
         // Auto-connect if this is our saved refractometer
         if (savedMatch) {
             emit refractometerDiscovered(device);
@@ -605,7 +608,7 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
 }
 
 void BLEManager::onScanFinished() {
-    qDebug().noquote() << "[R2-diag] scan cycle finished — clearing scanningForScales/userInitiated flags";
+    qDebug().noquote() << "[R2-diag] scan cycle finished — clearing scanning/scanningForScales/userInitiated flags";
     m_scanning = false;
     m_scanningForScales = false;
     m_userInitiatedScaleScan = false;
@@ -918,7 +921,7 @@ void BLEManager::scanForDevices() {
     // Note: m_disabled is intentionally not checked here — scale and refractometer
     // scanning is allowed in simulator mode so real hardware can be tested against
     // a simulated DE1. Only DE1 BLE (startScan without m_scanningForScales) is suppressed.
-    qDebug().noquote() << QString("[R2-diag] scanForDevices (user-initiated) wasScanning=%1 scanningForScales=%2")
+    qDebug().noquote() << QString("[R2-diag] scanForDevices (user-initiated) scanning=%1 scanningForScales=%2 (read before stopScan)")
         .arg(m_scanning ? QStringLiteral("true") : QStringLiteral("false"),
              m_scanningForScales ? QStringLiteral("true") : QStringLiteral("false"));
     appendScaleLog("Starting device scan...");

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -539,6 +539,8 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
         // Avoid duplicates
         for (const auto& existing : m_refractometerDevices) {
             if (getDeviceIdentifier(existing) == getDeviceIdentifier(device)) {
+                qDebug().noquote() << QString("[R2-diag] R2 advert dev=%1 ALREADY in discovered list — dedup return, NO refractometerDiscovered emitted")
+                    .arg(getDeviceIdentifier(device));
                 return;
             }
         }
@@ -547,9 +549,17 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
         qDebug() << "[BLE] Found refractometer:" << device.name() << "at" << getDeviceIdentifier(device);
         appendScaleLog(QString("Found refractometer: %1 (%2)").arg(device.name(), getDeviceIdentifier(device)));
 
+        const bool savedMatch = !m_savedRefractometerAddress.isEmpty()
+            && deviceIdentifiersMatch(device, m_savedRefractometerAddress);
+        qDebug().noquote() << QString("[R2-diag] R2 advert dev=%1 savedMatch=%2 userInitiatedScan=%3 -> %4")
+            .arg(getDeviceIdentifier(device),
+                 savedMatch ? QStringLiteral("true") : QStringLiteral("false"),
+                 m_userInitiatedScaleScan ? QStringLiteral("true") : QStringLiteral("false"),
+                 savedMatch ? QStringLiteral("emit refractometerDiscovered")
+                            : (m_userInitiatedScaleScan ? QStringLiteral("listing only (no auto-connect)")
+                                                         : QStringLiteral("ignored")));
         // Auto-connect if this is our saved refractometer
-        if (!m_savedRefractometerAddress.isEmpty()
-            && deviceIdentifiersMatch(device, m_savedRefractometerAddress)) {
+        if (savedMatch) {
             emit refractometerDiscovered(device);
         } else if (m_userInitiatedScaleScan) {
             // User scan — show all devices (emit for UI listing only, not auto-connect)
@@ -595,6 +605,7 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
 }
 
 void BLEManager::onScanFinished() {
+    qDebug().noquote() << "[R2-diag] scan cycle finished — clearing scanningForScales/userInitiated flags";
     m_scanning = false;
     m_scanningForScales = false;
     m_userInitiatedScaleScan = false;
@@ -802,6 +813,11 @@ void BLEManager::clearSavedRefractometer() {
 }
 
 void BLEManager::setRefractometerDevice(DiFluidR2* device) {
+    qDebug().noquote() << QString("[R2-diag] setRefractometerDevice old=%1 new=%2")
+        .arg(m_refractometerDevice ? QString::number(reinterpret_cast<quintptr>(m_refractometerDevice), 16)
+                                    : QStringLiteral("none"),
+             device ? QString::number(reinterpret_cast<quintptr>(device), 16)
+                     : QStringLiteral("none"));
     if (m_refractometerDevice) {
         disconnect(m_refractometerDevice, nullptr, this, nullptr);
     }
@@ -814,9 +830,19 @@ void BLEManager::setRefractometerDevice(DiFluidR2* device) {
 }
 
 void BLEManager::tryDirectConnectToRefractometer() {
-    if (m_savedRefractometerAddress.isEmpty() || m_disabled) return;
+    if (m_savedRefractometerAddress.isEmpty() || m_disabled) {
+        qDebug().noquote() << QString("[R2-diag] tryDirectConnectToRefractometer no-op (savedAddrEmpty=%1 disabled=%2)")
+            .arg(m_savedRefractometerAddress.isEmpty() ? QStringLiteral("true") : QStringLiteral("false"),
+                 m_disabled ? QStringLiteral("true") : QStringLiteral("false"));
+        return;
+    }
     // Piggyback on the scale scan infrastructure — set the flag so
     // onDeviceDiscovered processes refractometer advertisements
+    qDebug().noquote() << QString("[R2-diag] tryDirectConnectToRefractometer scanningForScales=%1 scanning=%2 -> %3")
+        .arg(m_scanningForScales ? QStringLiteral("true") : QStringLiteral("false"),
+             m_scanning ? QStringLiteral("true") : QStringLiteral("false"),
+             m_scanningForScales ? QStringLiteral("no-op (scan flag already set)")
+                                  : QStringLiteral("startScan()"));
     if (!m_scanningForScales) {
         m_scanningForScales = true;
         startScan();
@@ -892,6 +918,9 @@ void BLEManager::scanForDevices() {
     // Note: m_disabled is intentionally not checked here — scale and refractometer
     // scanning is allowed in simulator mode so real hardware can be tested against
     // a simulated DE1. Only DE1 BLE (startScan without m_scanningForScales) is suppressed.
+    qDebug().noquote() << QString("[R2-diag] scanForDevices (user-initiated) wasScanning=%1 scanningForScales=%2")
+        .arg(m_scanning ? QStringLiteral("true") : QStringLiteral("false"),
+             m_scanningForScales ? QStringLiteral("true") : QStringLiteral("false"));
     appendScaleLog("Starting device scan...");
     m_scaleConnectionFailed = false;
     m_flowScaleFallbackEmitted = false;  // User-initiated scan resets the dialog guard

--- a/src/ble/refractometers/difluidr2.cpp
+++ b/src/ble/refractometers/difluidr2.cpp
@@ -54,10 +54,10 @@ DiFluidR2::DiFluidR2(ScaleBleTransport* transport, QObject* parent)
         if (!m_transport || !m_characteristicsReady) return;
         m_transport->enableNotifications(Refractometer::DiFluidR2::SERVICE,
                                          Refractometer::DiFluidR2::CHARACTERISTIC);
-        m_connected = true;
-        emit connectedChanged();
         R2_LOG(QString("[R2-diag] connectedChanged -> TRUE (instance=%1)")
                .arg(QString::number(reinterpret_cast<quintptr>(this), 16)));
+        m_connected = true;
+        emit connectedChanged();
         R2_LOG("Connected and ready for measurements");
 
         // Send "get temperature unit" as init handshake (Func=1, Cmd=0, DataLen=0)
@@ -183,9 +183,10 @@ void DiFluidR2::onTransportConnected() {
 }
 
 void DiFluidR2::onTransportDisconnected() {
-    R2_LOG(QString("[R2-diag] connectedChanged -> FALSE (instance=%1) reason=transport-disconnected wasConnected=%2")
-           .arg(QString::number(reinterpret_cast<quintptr>(this), 16),
-                m_connected ? QStringLiteral("true") : QStringLiteral("false")));
+    R2_LOG(QString("[R2-diag] %1 (instance=%2) reason=transport-disconnected")
+           .arg(m_connected ? QStringLiteral("connectedChanged -> FALSE")
+                            : QStringLiteral("connect attempt failed before ready (was not connected)"),
+                QString::number(reinterpret_cast<quintptr>(this), 16)));
     R2_LOG("Transport disconnected");
     m_measurementTimer.stop();
     m_initTimer.stop();
@@ -198,9 +199,10 @@ void DiFluidR2::onTransportDisconnected() {
 }
 
 void DiFluidR2::onTransportError(const QString& message) {
-    R2_WARN(QString("[R2-diag] connectedChanged -> FALSE (instance=%1) reason=transport-error wasConnected=%2")
-            .arg(QString::number(reinterpret_cast<quintptr>(this), 16),
-                 m_connected ? QStringLiteral("true") : QStringLiteral("false")));
+    R2_WARN(QString("[R2-diag] %1 (instance=%2) reason=transport-error")
+            .arg(m_connected ? QStringLiteral("connectedChanged -> FALSE")
+                             : QStringLiteral("connect attempt failed before ready (was not connected)"),
+                 QString::number(reinterpret_cast<quintptr>(this), 16)));
     R2_WARN(QString("Transport error: %1").arg(message));
     emit errorOccurred("DiFluid R2 connection error");
     m_measurementTimer.stop();

--- a/src/ble/refractometers/difluidr2.cpp
+++ b/src/ble/refractometers/difluidr2.cpp
@@ -56,6 +56,8 @@ DiFluidR2::DiFluidR2(ScaleBleTransport* transport, QObject* parent)
                                          Refractometer::DiFluidR2::CHARACTERISTIC);
         m_connected = true;
         emit connectedChanged();
+        R2_LOG(QString("[R2-diag] connectedChanged -> TRUE (instance=%1)")
+               .arg(QString::number(reinterpret_cast<quintptr>(this), 16)));
         R2_LOG("Connected and ready for measurements");
 
         // Send "get temperature unit" as init handshake (Func=1, Cmd=0, DataLen=0)
@@ -174,11 +176,16 @@ void DiFluidR2::requestMeasurement() {
 // === Transport callbacks ===
 
 void DiFluidR2::onTransportConnected() {
+    R2_LOG(QString("[R2-diag] transport connected (instance=%1) — starting service discovery")
+           .arg(QString::number(reinterpret_cast<quintptr>(this), 16)));
     R2_LOG("Transport connected, starting service discovery");
     m_transport->discoverServices();
 }
 
 void DiFluidR2::onTransportDisconnected() {
+    R2_LOG(QString("[R2-diag] connectedChanged -> FALSE (instance=%1) reason=transport-disconnected wasConnected=%2")
+           .arg(QString::number(reinterpret_cast<quintptr>(this), 16),
+                m_connected ? QStringLiteral("true") : QStringLiteral("false")));
     R2_LOG("Transport disconnected");
     m_measurementTimer.stop();
     m_initTimer.stop();
@@ -191,6 +198,9 @@ void DiFluidR2::onTransportDisconnected() {
 }
 
 void DiFluidR2::onTransportError(const QString& message) {
+    R2_WARN(QString("[R2-diag] connectedChanged -> FALSE (instance=%1) reason=transport-error wasConnected=%2")
+            .arg(QString::number(reinterpret_cast<quintptr>(this), 16),
+                 m_connected ? QStringLiteral("true") : QStringLiteral("false")));
     R2_WARN(QString("Transport error: %1").arg(message));
     emit errorOccurred("DiFluid R2 connection error");
     m_measurementTimer.stop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1612,8 +1612,15 @@ int main(int argc, char *argv[])
 
     QObject::connect(&bleManager, &BLEManager::refractometerDiscovered,
                      [&refractometer, &mainController, &engine, &bleManager, &settings](const QBluetoothDeviceInfo& device) {
+        qDebug().noquote() << QString("[R2-diag] refractometerDiscovered dev=%1 existingInstance=%2 existingConnected=%3")
+            .arg(getDeviceIdentifier(device),
+                 refractometer ? QString::number(reinterpret_cast<quintptr>(refractometer.get()), 16)
+                                : QStringLiteral("none"),
+                 (refractometer && refractometer->isConnected()) ? QStringLiteral("true")
+                                                                 : QStringLiteral("false"));
         if (refractometer && refractometer->isConnected()) {
             if (getDeviceIdentifier(device) == settings.savedRefractometerAddress()) {
+                qDebug().noquote() << "[R2-diag] same device already connected — ignoring discovery (no churn)";
                 return;  // Same device already connected — nothing to do
             }
             // Different device selected — continue to cleanup + create
@@ -1622,6 +1629,9 @@ int main(int argc, char *argv[])
         // Clean up old refractometer before replacing — disconnect first (emits
         // signals while pointers are still valid), then clear raw pointer holders
         if (refractometer) {
+            qDebug().noquote() << QString("[R2-diag] tearing down previous DiFluidR2 instance=%1 connected=%2 to recreate")
+                .arg(QString::number(reinterpret_cast<quintptr>(refractometer.get()), 16),
+                     refractometer->isConnected() ? QStringLiteral("true") : QStringLiteral("false"));
             refractometer->disconnectFromDevice();
             mainController.setRefractometer(nullptr);
             bleManager.setRefractometerDevice(nullptr);
@@ -1660,6 +1670,8 @@ int main(int argc, char *argv[])
         QObject::connect(refractometer.get(), &DiFluidR2::logMessage,
                          &bleManager, &BLEManager::appendScaleLog);
 
+        qDebug().noquote() << QString("[R2-diag] created DiFluidR2 instance=%1 connecting to %2")
+            .arg(QString::number(reinterpret_cast<quintptr>(refractometer.get()), 16), device.name());
         qDebug() << "[Refractometer] Created and connecting to" << device.name();
     });
 
@@ -1695,6 +1707,9 @@ int main(int argc, char *argv[])
             qDebug() << "Refractometer reconnect: already connected, stopping retries";
             return;
         }
+        qDebug().noquote() << QString("[R2-diag] reconnect tick attempt=%1 isRefractometerConnected=%2 — will scan")
+            .arg(refractometerReconnectAttempt + 1)
+            .arg(bleManager.isRefractometerConnected() ? QStringLiteral("true") : QStringLiteral("false"));
         qDebug() << "Refractometer reconnect: attempt" << (refractometerReconnectAttempt + 1);
         // Bounded ramp only in the user-visible log (the 60s tail is endless).
         if (refractometerReconnectAttempt < static_cast<int>(reconnectDelays.size())) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1645,6 +1645,8 @@ int main(int argc, char *argv[])
         auto* transport = new QtScaleBleTransport();
 #endif
         refractometer = std::make_unique<DiFluidR2>(transport);
+        qDebug().noquote() << QString("[R2-diag] created DiFluidR2 instance=%1 connecting to %2")
+            .arg(QString::number(reinterpret_cast<quintptr>(refractometer.get()), 16), device.name());
         // The refractometer reuses the scale transport class but is not a
         // scale: a 3rd forced-HIGH BLE link contends with the DE1 + scale and
         // the platform GATT scheduler tears the weakest one (this) down. Keep
@@ -1670,8 +1672,6 @@ int main(int argc, char *argv[])
         QObject::connect(refractometer.get(), &DiFluidR2::logMessage,
                          &bleManager, &BLEManager::appendScaleLog);
 
-        qDebug().noquote() << QString("[R2-diag] created DiFluidR2 instance=%1 connecting to %2")
-            .arg(QString::number(reinterpret_cast<quintptr>(refractometer.get()), 16), device.name());
         qDebug() << "[Refractometer] Created and connecting to" << device.name();
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #1234. The DiFluid R2 still will not hold a connection, and the two prior root-cause hypotheses (forced-HIGH BLE contention; missing keep-alive) were both wrong against the observed repro:

- When the R2 powers on, auto-connect does **not** make the shot-review button flip from "R2 Off" to "Read TDS".
- A **manual** button click connects the R2 and it **stays connected**.

That divergence points at the auto-connect path / UI-state wiring, not idle behaviour or connection priority. Rather than guess a third time, this PR adds targeted, event-driven `[R2-diag]`-tagged logging at every decision point so the next on-device capture *shows* the timeline:

- `refractometerDiscovered` lambda: entry (device, existing instance ptr, connected?), the **teardown** branch (only the *create* was logged before), and the new instance ptr — exposes DiFluidR2 create/destroy churn
- Reconnect-timer tick: attempt # + `isRefractometerConnected`
- `BLEManager::setRefractometerDevice`: old → new instance ptr
- `tryDirectConnectToRefractometer` / `scanForDevices`: which path ran, whether a scan/connect was already in flight (re-entrancy)
- `onDeviceDiscovered` R2 branch: dedup-list early-return vs which gate matched (savedMatch / userInitiated / ignored)
- `onScanFinished`: 15 s scan-cycle boundary + flag clear
- `DiFluidR2`: `connectedChanged` TRUE/FALSE transitions tagged with instance pointer + reason (ready / transport-disconnected / error)

This will definitively answer: does the auto path churn instances, does the UI-facing `refractometerConnected` ever transition, is a scan starting on top of an in-flight connect, and how the manual path differs.

Diagnostic-only — all added lines are logging. The two non-logging hunks are behaviour-preserving (named the existing `savedMatch` condition; brace-wrapped a one-line early return). No functional change; defaults and control flow unchanged.

## Test plan

- [ ] Build + deploy to the Android tablet (SM-X210), DE1 + Decent Scale + R2 all present.
- [ ] Power the R2 on and let auto-connect attempt; then manually click the button. Pull the de1 debug log.
- [ ] `grep [R2-diag]` and read the timeline: instance churn, `setRefractometerDevice` ptr vs the instance that hits `connectedChanged -> TRUE`, scan-vs-connect re-entrancy, auto vs manual path difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)