### PR TITLE
diag(scale): log Decent Scale firmware version on connect

### DIFF
--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -69,6 +69,10 @@ void DecentScale::onTransportDisconnected() {
     }
     m_consecutiveChecksumFailures = 0;
     m_checksumDisabled = false;
+    // Re-log the firmware version on the next connect — the LED-response
+    // packet only arrives periodically, but capturing it fresh per connect
+    // is what makes the line useful for triage.
+    m_firmwareVersion.clear();
     setConnected(false);
 }
 
@@ -211,6 +215,30 @@ void DecentScale::parseWeightData(const QByteArray& data) {
             setBatteryLevel(battByte);
         } else if (battByte == 0xFF) {
             setBatteryLevel(100);  // Charging — report as full
+        }
+        // Firmware version: bytes [5-6], encoded per openscale (HDS)
+        // include/ble.h:730-731 — byte [5] is BCD-packed major (00..99),
+        // byte [6] is (minor << 4) | patch where minor and patch are
+        // each a nibble (0..15). Source `FW: 3.0.9` → wire 0x03 0x09.
+        // Log the parsed triple plus raw bytes for unambiguous triage.
+        // Log once per connect; a subsequent packet reporting a different
+        // value warn-logs the transition (shouldn't happen on a live
+        // scale — a change would itself be diagnostic).
+        const int major = ((d[5] >> 4) & 0x0F) * 10 + (d[5] & 0x0F);
+        const int minor = (d[6] >> 4) & 0x0F;
+        const int patch = d[6] & 0x0F;
+        const QString version = QStringLiteral("%1.%2.%3 (raw 0x%4 0x%5)")
+            .arg(major).arg(minor).arg(patch)
+            .arg(d[5], 2, 16, QLatin1Char('0'))
+            .arg(d[6], 2, 16, QLatin1Char('0'));
+        if (m_firmwareVersion != version) {
+            if (m_firmwareVersion.isEmpty()) {
+                DECENT_LOG(QString("Firmware version: %1").arg(version));
+            } else {
+                DECENT_WARN(QString("Firmware version changed mid-connect: %1 -> %2")
+                            .arg(m_firmwareVersion, version));
+            }
+            m_firmwareVersion = version;
         }
     } else if (command == 0xAA) {
         // Button pressed

--- a/src/ble/scales/decentscale.h
+++ b/src/ble/scales/decentscale.h
@@ -64,6 +64,10 @@ private:
     int m_watchdogRetries = 0;
     int m_consecutiveChecksumFailures = 0;
     bool m_checksumDisabled = false;
+    // Firmware version captured from the first LED-response packet of each
+    // connect (bytes [5-6] of cmd=0x0A, header=0x03). Empty until captured;
+    // cleared in onTransportDisconnected so the next connect re-logs it.
+    QString m_firmwareVersion;
     QTimer* m_heartbeatTimer = nullptr;
     QTimer* m_watchdogTimer = nullptr;
 };

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -180,6 +180,76 @@ private slots:
     }
 
     // ==========================================
+    // DecentScale: firmware version logging
+    // ==========================================
+
+    // Build a 7-byte LED-response packet (cmd=0x0A, header=0x03) with the
+    // given battery byte and openscale-encoded firmware version. Mirrors
+    // openscale include/ble.h:730-731: verHigh = BCD(major), verLow =
+    // (minor << 4) | patch. LED responses carry no checksum.
+    static QByteArray buildDecentLedResponse(uint8_t battery, int major, int minor, int patch) {
+        QByteArray pkt(7, 0);
+        pkt[0] = 0x03;
+        pkt[1] = 0x0A;
+        pkt[2] = 0x00;
+        pkt[3] = 0x00;
+        pkt[4] = static_cast<char>(battery);
+        pkt[5] = static_cast<char>(((major / 10) << 4) | (major % 10));
+        pkt[6] = static_cast<char>((minor << 4) | patch);
+        return pkt;
+    }
+
+    void decentFirmwareVersionLoggedOnceOnFirstLedResponse() {
+        // Current openscale source (include/config.h:29) is `FW: 3.0.9` →
+        // wire bytes 0x03 0x09. Verify we decode that exactly, and that
+        // we suppress identical follow-ups so periodic LED responses
+        // don't churn the log.
+        DecentScale scale(nullptr);
+        auto pkt = buildDecentLedResponse(50, 3, 0, 9);
+        QCOMPARE(static_cast<uint8_t>(pkt[5]), uint8_t(0x03));
+        QCOMPARE(static_cast<uint8_t>(pkt[6]), uint8_t(0x09));
+
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Firmware version: 3\\.0\\.9 \\(raw 0x03 0x09\\).*"));
+        scale.onCharacteristicChanged(Scale::Decent::READ, pkt);
+
+        // A second identical packet must NOT re-log (ignoreMessage matches
+        // exactly one occurrence; a second log would fail the test).
+        scale.onCharacteristicChanged(Scale::Decent::READ, pkt);
+    }
+
+    void decentFirmwareVersionBcdMajor() {
+        // Verify BCD decode of a major >= 10 — major=12, minor=3, patch=4
+        // packs to verHigh=0x12, verLow=0x34. Catches a naive `d[5]` (raw
+        // byte) decode that would mis-render as "18.3.4".
+        DecentScale scale(nullptr);
+        auto pkt = buildDecentLedResponse(80, 12, 3, 4);
+        QCOMPARE(static_cast<uint8_t>(pkt[5]), uint8_t(0x12));
+        QCOMPARE(static_cast<uint8_t>(pkt[6]), uint8_t(0x34));
+
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Firmware version: 12\\.3\\.4 \\(raw 0x12 0x34\\).*"));
+        scale.onCharacteristicChanged(Scale::Decent::READ, pkt);
+    }
+
+    void decentFirmwareVersionChangeWarns() {
+        // A subsequent LED response carrying a different version is itself
+        // diagnostic (shouldn't happen on real hardware) — warn-log the
+        // transition rather than silently overwriting.
+        DecentScale scale(nullptr);
+        auto pkt1 = buildDecentLedResponse(50, 3, 0, 9);
+        auto pkt2 = buildDecentLedResponse(50, 3, 1, 0);
+
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Firmware version: 3\\.0\\.9.*"));
+        scale.onCharacteristicChanged(Scale::Decent::READ, pkt1);
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*Firmware version changed mid-connect.*3\\.0\\.9.*3\\.1\\.0.*"));
+        scale.onCharacteristicChanged(Scale::Decent::READ, pkt2);
+    }
+
+    // ==========================================
     // DecentScale: error handling
     // ==========================================
 

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -159,8 +159,12 @@ private slots:
         DecentScale scale(nullptr);
         QSignalSpy spy(&scale, &ScaleDevice::batteryLevelChanged);
 
-        // Battery response: cmd=0x0A, d4=75 (battery%), rest=0
-        auto pkt = buildDecentPacket(0x0A, 0x00, 0x00, 75, 0x00);
+        // LED-response packet (battery 75%, firmware bytes zero). The
+        // helper sets bytes [5-6] to 0x00 0x00 so the firmware-version
+        // logger emits "Firmware version: 0.0.0 (raw 0x00 0x00)" — ignored
+        // here so it doesn't pollute test output.
+        QTest::ignoreMessage(QtDebugMsg, QRegularExpression(".*Firmware version:.*"));
+        auto pkt = buildDecentLedResponse(75, 0, 0, 0);
         scale.onCharacteristicChanged(Scale::Decent::READ, pkt);
 
         QVERIFY(spy.count() >= 1);
@@ -171,8 +175,9 @@ private slots:
         DecentScale scale(nullptr);
         QSignalSpy spy(&scale, &ScaleDevice::batteryLevelChanged);
 
-        // Battery charging: d4=0xFF -> 100%
-        auto pkt = buildDecentPacket(0x0A, 0x00, 0x00, 0xFF, 0x00);
+        // Battery charging: d4=0xFF -> 100%.
+        QTest::ignoreMessage(QtDebugMsg, QRegularExpression(".*Firmware version:.*"));
+        auto pkt = buildDecentLedResponse(0xFF, 0, 0, 0);
         scale.onCharacteristicChanged(Scale::Decent::READ, pkt);
 
         QVERIFY(spy.count() >= 1);
@@ -201,21 +206,38 @@ private slots:
 
     void decentFirmwareVersionLoggedOnceOnFirstLedResponse() {
         // Current openscale source (include/config.h:29) is `FW: 3.0.9` →
-        // wire bytes 0x03 0x09. Verify we decode that exactly, and that
-        // we suppress identical follow-ups so periodic LED responses
-        // don't churn the log.
+        // wire bytes 0x03 0x09. Verify the exact decode, and verify
+        // mechanically (via QSignalSpy on logMessage — see SCALE_LOG in
+        // scalelogging.h, which emits logMessage alongside qDebug) that
+        // the second identical packet does NOT re-log.
         DecentScale scale(nullptr);
         auto pkt = buildDecentLedResponse(50, 3, 0, 9);
         QCOMPARE(static_cast<uint8_t>(pkt[5]), uint8_t(0x03));
         QCOMPARE(static_cast<uint8_t>(pkt[6]), uint8_t(0x09));
 
+        QSignalSpy logSpy(&scale, &ScaleDevice::logMessage);
+
         QTest::ignoreMessage(QtDebugMsg,
             QRegularExpression(".*Firmware version: 3\\.0\\.9 \\(raw 0x03 0x09\\).*"));
         scale.onCharacteristicChanged(Scale::Decent::READ, pkt);
 
-        // A second identical packet must NOT re-log (ignoreMessage matches
-        // exactly one occurrence; a second log would fail the test).
+        // Count "Firmware version" log emissions after the first packet —
+        // exactly one expected.
+        const auto firmwareLogCount = [&logSpy]() {
+            int n = 0;
+            for (const auto& args : logSpy) {
+                if (args.value(0).toString().contains(QStringLiteral("Firmware version:")))
+                    ++n;
+            }
+            return n;
+        };
+        QCOMPARE(firmwareLogCount(), 1);
+
+        // Second identical packet: no new "Firmware version" log line. If
+        // dedup regresses, this QCOMPARE fires (and the unsuppressed qDebug
+        // would also appear in test output).
         scale.onCharacteristicChanged(Scale::Decent::READ, pkt);
+        QCOMPARE(firmwareLogCount(), 1);
     }
 
     void decentFirmwareVersionBcdMajor() {
@@ -379,20 +401,17 @@ private slots:
     }
 
     void decentLedResponseSkipsChecksum() {
-        // LED response (0x0A) has no checksum — should parse regardless of byte 6
+        // LED-response (cmd 0x0A) has no checksum — bytes [5-6] carry the
+        // BCD-encoded firmware version, NOT a checksum, and the parser must
+        // accept the packet regardless of what those bytes happen to be.
         DecentScale scale(nullptr);
         QSignalSpy spy(&scale, &ScaleDevice::batteryLevelChanged);
 
-        // Build LED response with arbitrary byte 6 (firmware version, not checksum)
-        QByteArray pkt(7, 0);
-        pkt[0] = 0x03;
-        pkt[1] = 0x0A;
-        pkt[2] = 0x00;  // weight hi
-        pkt[3] = 0x00;  // weight lo
-        pkt[4] = static_cast<char>(60);   // battery 60%
-        pkt[5] = 0x01;  // firmware version hi
-        pkt[6] = 0x02;  // firmware version lo (NOT a checksum)
-
+        // FW: 1.0.2 → wire 0x01 0x02. The exact value doesn't matter for
+        // this test — the point is that byte 6 is not validated as a XOR
+        // checksum of bytes 0-5 (which it would fail).
+        QTest::ignoreMessage(QtDebugMsg, QRegularExpression(".*Firmware version:.*"));
+        auto pkt = buildDecentLedResponse(60, 1, 0, 2);
         scale.onCharacteristicChanged(Scale::Decent::READ, pkt);
 
         QVERIFY(spy.count() >= 1);


### PR DESCRIPTION
## Summary
- On the first LED-response packet (cmd `0x0A`, header `0x03`) of each scale connect, parse bytes [5-6] and log `Firmware version: M.m.p (raw 0xHH 0xLL)`. Encoding mirrors openscale `include/ble.h:730-731` — byte [5] is BCD-packed major (00..99), byte [6] is `(minor << 4) | patch` (each nibble 0..15). Current openscale source `FW: 3.0.9` → wire `0x03 0x09`.
- Identical follow-up packets are deduped (the LED response fires every battery/keep-alive cycle); a mid-connect version change `DECENT_WARN`s the transition. `m_firmwareVersion` clears on transport disconnect so the next connect re-captures fresh.
- No Settings or MCP surface yet — diagnostic logging only. We can add a `scaleFirmwareVersion` property later if useful.

## Why
Triaging the scale BT dropout in #1176 turned up a gap: we never captured the scale firmware revision anywhere, despite the wire packet carrying it on every keep-alive. Next `debug.zip` from any reporter will have one line answering "what firmware is the scale on?" without asking them to open Decent's app.

## Test plan
- [x] Three new `tst_ScaleProtocol` cases pass (Qt Creator MCP run, all 2198 tests green):
  - `decentFirmwareVersionLoggedOnceOnFirstLedResponse` — `FW: 3.0.9` round-trips to wire `0x03 0x09` and the second identical packet does not re-log.
  - `decentFirmwareVersionBcdMajor` — `major=12` packs to `0x12` (not `0x0C`); catches a naive raw-byte decode.
  - `decentFirmwareVersionChangeWarns` — mid-connect `3.0.9 → 3.1.0` warn-logs the transition.
- [x] Full Qt Creator build: 0 errors, 0 warnings.
- [ ] On-device: connect a Decent Scale (HDS) and confirm one `[BLE DecentScale] Firmware version: …` line per connect, no churn from periodic LED responses.

Relates to #1176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)