### PR TITLE
feat(scale): Android NsdManager-based mDNS for WiFi scale

### DIFF
--- a/android/src/io/github/kulitorum/decenza_de1/WifiScaleNsdHelper.java
+++ b/android/src/io/github/kulitorum/decenza_de1/WifiScaleNsdHelper.java
@@ -1,0 +1,215 @@
+package io.github.kulitorum.decenza_de1;
+
+import android.content.Context;
+import android.net.nsd.NsdManager;
+import android.net.nsd.NsdServiceInfo;
+import android.net.wifi.WifiManager;
+import android.util.Log;
+
+import org.qtproject.qt.android.QtNative;
+
+import java.net.InetAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Android helper for discovering the Half Decent Scale's WiFi endpoint.
+ *
+ * Why this exists: Android's stock resolver (getaddrinfo via QHostInfo) does
+ * NOT do mDNS reliably for ".local" names — Qt's hostname lookup will return
+ * NXDOMAIN. We use NsdManager (the Android-blessed NSD/mDNS API) to discover
+ * _http._tcp services, match the one whose instance name matches the requested
+ * hostname (e.g. "hds"), resolve it to an InetAddress, and hand the IP string
+ * back to the Qt caller.
+ *
+ * The caller (WifiScaleDiscovery on Android) MUST run discoverHdsBlocking on
+ * a non-UI thread — the method blocks on a CountDownLatch up to `timeoutMs`.
+ *
+ * Multicast lock: Android's WiFi driver filters multicast frames by default,
+ * even with CHANGE_WIFI_MULTICAST_STATE declared in the manifest. We acquire
+ * a WifiManager.MulticastLock for the duration of the discovery and release
+ * it when finished. The lock is reference-counted, so nested acquires are
+ * safe and only the matching release lowers the count.
+ */
+public class WifiScaleNsdHelper {
+    private static final String TAG = "DecenzaWifiNsd";
+
+    // openscale firmware advertises an _http._tcp service. We compare the
+    // service instance name to the bare hostname stem (e.g. "hds" for
+    // "hds.local") case-insensitively.
+    private static final String SERVICE_TYPE = "_http._tcp.";
+
+    // Multicast lock is a single shared instance keyed by class — Android's
+    // setReferenceCounted(true) means nested probes do the right thing.
+    private static WifiManager.MulticastLock sMulticastLock = null;
+
+    /**
+     * Acquire (or re-acquire) the WiFi multicast lock. Idempotent: the underlying
+     * MulticastLock is reference-counted, so each acquire must be paired with
+     * exactly one release. Returns true on success, false if the WifiManager is
+     * unavailable (the caller can still try discovery — sometimes works, but
+     * usually returns nothing).
+     */
+    public static synchronized boolean acquireMulticastLock() {
+        try {
+            Context ctx = QtNative.getContext();
+            if (ctx == null) {
+                Log.w(TAG, "acquireMulticastLock: no QtNative context");
+                return false;
+            }
+            if (sMulticastLock == null) {
+                WifiManager wm = (WifiManager) ctx.getApplicationContext()
+                    .getSystemService(Context.WIFI_SERVICE);
+                if (wm == null) {
+                    Log.w(TAG, "acquireMulticastLock: WifiManager unavailable");
+                    return false;
+                }
+                sMulticastLock = wm.createMulticastLock("DecenzaWifiScaleMdns");
+                sMulticastLock.setReferenceCounted(true);
+            }
+            sMulticastLock.acquire();
+            Log.d(TAG, "acquireMulticastLock: held");
+            return true;
+        } catch (Exception e) {
+            Log.w(TAG, "acquireMulticastLock failed: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /** Release one reference on the multicast lock. Safe to call if not held. */
+    public static synchronized void releaseMulticastLock() {
+        try {
+            if (sMulticastLock != null && sMulticastLock.isHeld()) {
+                sMulticastLock.release();
+                Log.d(TAG, "releaseMulticastLock: released");
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "releaseMulticastLock failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Blocking mDNS resolution for the Half Decent Scale.
+     *
+     * Discovers _http._tcp services on the local network, picks the first one
+     * whose instance name matches `hostnameStem` (case-insensitive — strip
+     * ".local" before passing), resolves it to an IP, and returns the IP as
+     * a string. Returns empty string on timeout, no match, or any error.
+     *
+     * Caller must be off the Android main thread (this blocks).
+     *
+     * @param hostnameStem  bare hostname without ".local" (e.g. "hds")
+     * @param timeoutMs     overall budget for discover + resolve
+     * @return dotted-quad IP string, or "" on failure
+     */
+    public static String discoverHdsBlocking(final String hostnameStem, final int timeoutMs) {
+        final Context ctx = QtNative.getContext();
+        if (ctx == null) {
+            Log.w(TAG, "discoverHdsBlocking: no QtNative context");
+            return "";
+        }
+
+        final NsdManager nsd = (NsdManager) ctx.getApplicationContext()
+            .getSystemService(Context.NSD_SERVICE);
+        if (nsd == null) {
+            Log.w(TAG, "discoverHdsBlocking: NsdManager unavailable");
+            return "";
+        }
+
+        final boolean lockHeld = acquireMulticastLock();
+        final CountDownLatch done = new CountDownLatch(1);
+        final AtomicReference<String> result = new AtomicReference<>("");
+        // Track outstanding resolves so we can short-circuit once we have one.
+        final AtomicInteger resolvesInFlight = new AtomicInteger(0);
+        final AtomicReference<NsdManager.DiscoveryListener> listenerRef = new AtomicReference<>();
+
+        try {
+            final NsdManager.DiscoveryListener discoveryListener = new NsdManager.DiscoveryListener() {
+                @Override
+                public void onDiscoveryStarted(String serviceType) {
+                    Log.d(TAG, "onDiscoveryStarted: " + serviceType);
+                }
+
+                @Override
+                public void onServiceFound(NsdServiceInfo serviceInfo) {
+                    final String name = serviceInfo.getServiceName();
+                    Log.d(TAG, "onServiceFound: " + name);
+                    if (name == null) return;
+                    // NsdManager mangles the instance name on Android — it may
+                    // arrive percent-escaped (e.g. "hds\\032(2)") for collisions.
+                    // Match prefix to be tolerant.
+                    if (!name.toLowerCase().startsWith(hostnameStem.toLowerCase())) {
+                        return;
+                    }
+                    resolvesInFlight.incrementAndGet();
+                    nsd.resolveService(serviceInfo, new NsdManager.ResolveListener() {
+                        @Override
+                        public void onResolveFailed(NsdServiceInfo info, int errorCode) {
+                            Log.d(TAG, "onResolveFailed: " + info.getServiceName()
+                                + " errorCode=" + errorCode);
+                            if (resolvesInFlight.decrementAndGet() == 0
+                                && result.get().isEmpty()) {
+                                // No outstanding resolves and still no result;
+                                // discovery may still find more. Don't latch yet.
+                            }
+                        }
+
+                        @Override
+                        public void onServiceResolved(NsdServiceInfo info) {
+                            final InetAddress host = info.getHost();
+                            if (host == null) {
+                                Log.d(TAG, "onServiceResolved: null host");
+                                resolvesInFlight.decrementAndGet();
+                                return;
+                            }
+                            final String ip = host.getHostAddress();
+                            Log.d(TAG, "onServiceResolved: " + info.getServiceName()
+                                + " -> " + ip);
+                            // First winner takes it; latch the caller.
+                            if (result.compareAndSet("", ip == null ? "" : ip)) {
+                                done.countDown();
+                            }
+                            resolvesInFlight.decrementAndGet();
+                        }
+                    });
+                }
+
+                @Override public void onServiceLost(NsdServiceInfo serviceInfo) {}
+                @Override public void onDiscoveryStopped(String serviceType) {}
+                @Override
+                public void onStartDiscoveryFailed(String serviceType, int errorCode) {
+                    Log.w(TAG, "onStartDiscoveryFailed: " + errorCode);
+                    done.countDown();  // unblock caller — nothing will come
+                }
+                @Override
+                public void onStopDiscoveryFailed(String serviceType, int errorCode) {
+                    Log.w(TAG, "onStopDiscoveryFailed: " + errorCode);
+                }
+            };
+            listenerRef.set(discoveryListener);
+
+            nsd.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener);
+
+            // Block up to timeoutMs for the first successful resolve.
+            done.await(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            Log.w(TAG, "discoverHdsBlocking failed: " + e.getMessage());
+        } finally {
+            try {
+                if (listenerRef.get() != null) {
+                    nsd.stopServiceDiscovery(listenerRef.get());
+                }
+            } catch (Exception ignored) {}
+            if (lockHeld) {
+                releaseMulticastLock();
+            }
+        }
+
+        final String ip = result.get();
+        Log.d(TAG, "discoverHdsBlocking(" + hostnameStem + "): "
+            + (ip.isEmpty() ? "no match" : ip));
+        return ip;
+    }
+}

--- a/android/src/io/github/kulitorum/decenza_de1/WifiScaleNsdHelper.java
+++ b/android/src/io/github/kulitorum/decenza_de1/WifiScaleNsdHelper.java
@@ -36,14 +36,62 @@ import java.util.concurrent.atomic.AtomicReference;
 public class WifiScaleNsdHelper {
     private static final String TAG = "DecenzaWifiNsd";
 
-    // openscale firmware advertises an _http._tcp service. We compare the
-    // service instance name to the bare hostname stem (e.g. "hds" for
-    // "hds.local") case-insensitively.
+    // The Half Decent Scale (genuine Decent firmware — official thinner v2
+    // scale, NOT a third-party openscale/ESP32 clone) advertises an _http._tcp
+    // service. We compare the service instance name to the bare hostname stem
+    // (e.g. "hds" for "hds.local") case-insensitively.
     private static final String SERVICE_TYPE = "_http._tcp.";
 
     // Multicast lock is a single shared instance keyed by class — Android's
     // setReferenceCounted(true) means nested probes do the right thing.
     private static WifiManager.MulticastLock sMulticastLock = null;
+
+    // Tracks the in-flight discovery so subsequent probes (or a C++-driven
+    // cancel) can tear it down BEFORE issuing a new discoverServices() call.
+    // Android only permits one active DiscoveryListener per service type per
+    // NsdManager instance; a second concurrent discoverServices() with the
+    // same SERVICE_TYPE fires onStartDiscoveryFailed(FAILURE_ALREADY_ACTIVE)
+    // on the new listener, which would silently break rapid re-scans.
+    private static final Object sDiscoveryLock = new Object();
+    private static volatile ActiveDiscovery sActiveDiscovery = null;
+
+    private static final class ActiveDiscovery {
+        final NsdManager nsd;
+        final NsdManager.DiscoveryListener listener;
+        final CountDownLatch done;
+        ActiveDiscovery(NsdManager nsd, NsdManager.DiscoveryListener listener,
+                        CountDownLatch done) {
+            this.nsd = nsd;
+            this.listener = listener;
+            this.done = done;
+        }
+    }
+
+    /**
+     * Stop any in-flight NSD discovery started by this helper. Safe to call
+     * when no discovery is active. Used by the C++ side's cancelInFlight()
+     * (via JNI) to release the DiscoveryListener registration eagerly,
+     * preventing FAILURE_ALREADY_ACTIVE on the next probe.
+     */
+    public static void cancelDiscovery() {
+        final ActiveDiscovery active;
+        synchronized (sDiscoveryLock) {
+            active = sActiveDiscovery;
+            sActiveDiscovery = null;
+        }
+        if (active == null) return;
+        try {
+            active.nsd.stopServiceDiscovery(active.listener);
+            Log.d(TAG, "cancelDiscovery: stopped listener");
+        } catch (Exception e) {
+            // stopServiceDiscovery throws IllegalArgumentException if the
+            // listener was never successfully registered (e.g. discoverServices
+            // threw or onStartDiscoveryFailed already fired). Benign.
+            Log.d(TAG, "cancelDiscovery: stop threw (benign): " + e.getMessage());
+        }
+        // Unblock the worker so it returns promptly.
+        active.done.countDown();
+    }
 
     /**
      * Acquire (or re-acquire) the WiFi multicast lock. Idempotent: the underlying
@@ -118,10 +166,23 @@ public class WifiScaleNsdHelper {
             return "";
         }
 
+        // Any prior probe must surrender its DiscoveryListener before we
+        // register a new one for SERVICE_TYPE, otherwise Android emits
+        // FAILURE_ALREADY_ACTIVE on our discoverServices() call.
+        cancelDiscovery();
+
         final boolean lockHeld = acquireMulticastLock();
         final CountDownLatch done = new CountDownLatch(1);
         final AtomicReference<String> result = new AtomicReference<>("");
-        // Track outstanding resolves so we can short-circuit once we have one.
+        // Strict single-flight gate around resolveService(). API 28-33's
+        // NsdManager only permits ONE outstanding resolve per NsdManager
+        // instance — a concurrent call throws IllegalArgumentException
+        // ("listener already in use") and kills the binder thread. The
+        // three-arg Executor variant of resolveService that supports
+        // concurrent resolves was added in API 34, which is above our
+        // minSdk. Gating to one outstanding resolve at a time is the
+        // correct fix; we re-open the gate on each callback so a later
+        // onServiceFound match can still be resolved if the first one fails.
         final AtomicInteger resolvesInFlight = new AtomicInteger(0);
         final AtomicReference<NsdManager.DiscoveryListener> listenerRef = new AtomicReference<>();
 
@@ -143,17 +204,23 @@ public class WifiScaleNsdHelper {
                     if (!name.toLowerCase().startsWith(hostnameStem.toLowerCase())) {
                         return;
                     }
-                    resolvesInFlight.incrementAndGet();
-                    nsd.resolveService(serviceInfo, new NsdManager.ResolveListener() {
+                    // Single-flight gate: skip if a resolve is already
+                    // outstanding. The gate is re-opened on either callback
+                    // below so another match can be retried.
+                    if (!resolvesInFlight.compareAndSet(0, 1)) {
+                        Log.d(TAG, "onServiceFound: resolve already in flight, deferring " + name);
+                        return;
+                    }
+                    // Two-arg resolveService is deprecated in API 34 in favour
+                    // of a three-arg Executor variant, but we still target the
+                    // two-arg form for compatibility with minSdk 28.
+                    @SuppressWarnings("deprecation")
+                    final NsdManager.ResolveListener resolveListener = new NsdManager.ResolveListener() {
                         @Override
                         public void onResolveFailed(NsdServiceInfo info, int errorCode) {
                             Log.d(TAG, "onResolveFailed: " + info.getServiceName()
                                 + " errorCode=" + errorCode);
-                            if (resolvesInFlight.decrementAndGet() == 0
-                                && result.get().isEmpty()) {
-                                // No outstanding resolves and still no result;
-                                // discovery may still find more. Don't latch yet.
-                            }
+                            resolvesInFlight.set(0);  // re-open gate for a retry
                         }
 
                         @Override
@@ -161,19 +228,21 @@ public class WifiScaleNsdHelper {
                             final InetAddress host = info.getHost();
                             if (host == null) {
                                 Log.d(TAG, "onServiceResolved: null host");
-                                resolvesInFlight.decrementAndGet();
+                                resolvesInFlight.set(0);
                                 return;
                             }
                             final String ip = host.getHostAddress();
                             Log.d(TAG, "onServiceResolved: " + info.getServiceName()
                                 + " -> " + ip);
-                            // First winner takes it; latch the caller.
-                            if (result.compareAndSet("", ip == null ? "" : ip)) {
+                            // First non-empty winner takes it; latch the caller.
+                            if (ip != null && !ip.isEmpty()
+                                && result.compareAndSet("", ip)) {
                                 done.countDown();
                             }
-                            resolvesInFlight.decrementAndGet();
+                            resolvesInFlight.set(0);
                         }
-                    });
+                    };
+                    nsd.resolveService(serviceInfo, resolveListener);
                 }
 
                 @Override public void onServiceLost(NsdServiceInfo serviceInfo) {}
@@ -190,6 +259,12 @@ public class WifiScaleNsdHelper {
             };
             listenerRef.set(discoveryListener);
 
+            // Publish before discoverServices so a parallel cancelDiscovery()
+            // call can find and stop us. The order matters: register first,
+            // then start — never the reverse.
+            synchronized (sDiscoveryLock) {
+                sActiveDiscovery = new ActiveDiscovery(nsd, discoveryListener, done);
+            }
             nsd.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener);
 
             // Block up to timeoutMs for the first successful resolve.
@@ -197,6 +272,15 @@ public class WifiScaleNsdHelper {
         } catch (Exception e) {
             Log.w(TAG, "discoverHdsBlocking failed: " + e.getMessage());
         } finally {
+            // Clear our slot from the active-discovery tracker, but only if
+            // it's still pointing at OUR listener — a concurrent probe may
+            // have replaced it via cancelDiscovery + new ActiveDiscovery.
+            synchronized (sDiscoveryLock) {
+                if (sActiveDiscovery != null
+                    && sActiveDiscovery.listener == listenerRef.get()) {
+                    sActiveDiscovery = null;
+                }
+            }
             try {
                 if (listenerRef.get() != null) {
                     nsd.stopServiceDiscovery(listenerRef.get());

--- a/src/network/wifiscalediscovery.cpp
+++ b/src/network/wifiscalediscovery.cpp
@@ -4,16 +4,32 @@
 #include <QTimer>
 #include <QDebug>
 
+#ifdef Q_OS_ANDROID
+#include <QCoreApplication>
+#include <QJniObject>
+#include <QMetaObject>
+#include <QPointer>
+#include <QRunnable>
+#include <QThreadPool>
+#endif
+
 WifiScaleDiscovery::WifiScaleDiscovery(QObject* parent)
     : QObject(parent)
     , m_timeoutTimer(new QTimer(this))
 {
     m_timeoutTimer->setSingleShot(true);
     connect(m_timeoutTimer, &QTimer::timeout, this, [this]() {
+#ifdef Q_OS_ANDROID
+        if (!m_androidInFlight) return;
+        qDebug() << "[WifiScaleDiscovery] NSD probe timed out for" << m_currentHostname;
+        cancelInFlight();
+        emit probeFinished();
+#else
         if (m_lookupId == -1) return;
         qDebug() << "[WifiScaleDiscovery] mDNS lookup timed out for" << m_currentHostname;
         cancelInFlight();
         emit probeFinished();
+#endif
     });
 }
 
@@ -25,9 +41,68 @@ void WifiScaleDiscovery::probe(const QString& hostname, int timeoutMs) {
     cancelInFlight();
 
     m_currentHostname = hostname;
-    qDebug() << "[WifiScaleDiscovery] mDNS lookup for" << hostname
+    qDebug() << "[WifiScaleDiscovery] lookup for" << hostname
              << "(timeout" << timeoutMs << "ms)";
 
+#ifdef Q_OS_ANDROID
+    // Android's stock resolver (getaddrinfo) does NOT do mDNS for .local
+    // names. Use the NsdManager JNI helper instead, on a worker thread so
+    // we don't block the Qt event loop while it sits in a CountDownLatch.
+    m_androidInFlight = true;
+    const int generation = ++m_androidGeneration;
+
+    // Strip ".local" for the service-instance match in Java.
+    QString stem = hostname;
+    if (stem.endsWith(QStringLiteral(".local"), Qt::CaseInsensitive)) {
+        stem.chop(QStringLiteral(".local").size());
+    }
+
+    QPointer<WifiScaleDiscovery> self(this);
+    const QString stemForWorker = stem;
+    const QString hostnameForWorker = hostname;
+    const int timeoutForWorker = timeoutMs;
+
+    auto runnable = QRunnable::create([self, stemForWorker, hostnameForWorker,
+                                       timeoutForWorker, generation]() {
+        // Runs on a QThreadPool worker thread — JNI calls are allowed off the
+        // main thread, and the Java helper blocks on a CountDownLatch.
+        QJniObject stemJ = QJniObject::fromString(stemForWorker);
+        QJniObject ipJ = QJniObject::callStaticObjectMethod(
+            "io/github/kulitorum/decenza_de1/WifiScaleNsdHelper",
+            "discoverHdsBlocking",
+            "(Ljava/lang/String;I)Ljava/lang/String;",
+            stemJ.object<jstring>(),
+            jint(timeoutForWorker));
+        const QString ip = ipJ.isValid() ? ipJ.toString() : QString();
+
+        // Post the result back to the Qt thread that owns this object. If the
+        // object was destroyed in the meantime, the lambda is a no-op (the
+        // QPointer is null). If the probe was cancelled/timed out, generation
+        // won't match and we drop the result.
+        QMetaObject::invokeMethod(qApp, [self, hostnameForWorker, ip, generation]() {
+            if (!self) return;
+            if (generation != self->m_androidGeneration) return;
+            if (!self->m_androidInFlight) return;
+
+            self->m_androidInFlight = false;
+            self->m_timeoutTimer->stop();
+
+            if (ip.isEmpty()) {
+                qDebug() << "[WifiScaleDiscovery] NSD lookup failed for" << hostnameForWorker;
+                emit self->probeFinished();
+                return;
+            }
+            qDebug() << "[WifiScaleDiscovery] NSD found" << hostnameForWorker
+                     << "->" << ip;
+            emit self->scaleFound(hostnameForWorker, ip);
+            emit self->probeFinished();
+        }, Qt::QueuedConnection);
+    });
+    runnable->setAutoDelete(true);
+    QThreadPool::globalInstance()->start(runnable);
+
+    m_timeoutTimer->start(timeoutMs);
+#else
     m_lookupId = QHostInfo::lookupHost(hostname, this,
         [this](const QHostInfo& info) {
             // Late callback after cancel/timeout — drop it.
@@ -50,9 +125,21 @@ void WifiScaleDiscovery::probe(const QString& hostname, int timeoutMs) {
         });
 
     m_timeoutTimer->start(timeoutMs);
+#endif
 }
 
 void WifiScaleDiscovery::cancelInFlight() {
+#ifdef Q_OS_ANDROID
+    if (m_androidInFlight) {
+        // Best-effort cancel: bumping the generation makes the worker's
+        // posted result drop on arrival. We cannot synchronously interrupt
+        // the Java CountDownLatch, but Android will tear down the NSD
+        // discovery when stopServiceDiscovery() runs in the helper's
+        // finally block at the end of the timeout.
+        ++m_androidGeneration;
+        m_androidInFlight = false;
+    }
+#endif
     if (m_lookupId != -1) {
         QHostInfo::abortHostLookup(m_lookupId);
         m_lookupId = -1;

--- a/src/network/wifiscalediscovery.cpp
+++ b/src/network/wifiscalediscovery.cpp
@@ -131,13 +131,21 @@ void WifiScaleDiscovery::probe(const QString& hostname, int timeoutMs) {
 void WifiScaleDiscovery::cancelInFlight() {
 #ifdef Q_OS_ANDROID
     if (m_androidInFlight) {
-        // Best-effort cancel: bumping the generation makes the worker's
-        // posted result drop on arrival. We cannot synchronously interrupt
-        // the Java CountDownLatch, but Android will tear down the NSD
-        // discovery when stopServiceDiscovery() runs in the helper's
-        // finally block at the end of the timeout.
+        // Two-part cancel:
+        //  1. Bump the generation so any worker result that arrives on the
+        //     Qt thread after this point is discarded by the equality check
+        //     in the queued lambda.
+        //  2. Call into the Java helper to stop the active NsdManager
+        //     DiscoveryListener registration and count down the worker's
+        //     CountDownLatch immediately. Without this eager teardown,
+        //     a rapid second probe() would hit FAILURE_ALREADY_ACTIVE
+        //     because Android only permits one listener per service type
+        //     per NsdManager instance.
         ++m_androidGeneration;
         m_androidInFlight = false;
+        QJniObject::callStaticMethod<void>(
+            "io/github/kulitorum/decenza_de1/WifiScaleNsdHelper",
+            "cancelDiscovery", "()V");
     }
 #endif
     if (m_lookupId != -1) {

--- a/src/network/wifiscalediscovery.h
+++ b/src/network/wifiscalediscovery.h
@@ -12,8 +12,12 @@ class QTimer;
  *
  * On a successful resolution emits scaleFound(hostname, resolvedAddress)
  * followed by probeFinished(). On timeout / NotFound emits only
- * probeFinished(). Calling probe() while a lookup is in flight cancels
- * the previous lookup before starting a new one.
+ * probeFinished(). Calling probe() while a lookup is in flight starts a
+ * new lookup; the previous lookup's result will be dropped. On non-Android
+ * the previous QHostInfo lookup is also synchronously aborted; on Android
+ * the previous NSD discovery is torn down via WifiScaleNsdHelper.cancelDiscovery()
+ * (the Java worker thread is unblocked but cannot be synchronously joined —
+ * the result, when it eventually arrives, is dropped via a generation check).
  */
 class WifiScaleDiscovery : public QObject {
     Q_OBJECT

--- a/src/network/wifiscalediscovery.h
+++ b/src/network/wifiscalediscovery.h
@@ -36,7 +36,13 @@ public:
     /**
      * True iff a probe is currently in flight.
      */
-    bool isProbing() const { return m_lookupId != -1; }
+    bool isProbing() const {
+#ifdef Q_OS_ANDROID
+        return m_androidInFlight;
+#else
+        return m_lookupId != -1;
+#endif
+    }
 
 signals:
     void scaleFound(const QString& hostname, const QString& resolvedAddress);
@@ -45,7 +51,15 @@ signals:
 private:
     void cancelInFlight();
 
-    int m_lookupId = -1;
+    int m_lookupId = -1;  // QHostInfo lookup id on non-Android paths
     QString m_currentHostname;
     QTimer* m_timeoutTimer = nullptr;
+
+#ifdef Q_OS_ANDROID
+    // Android uses NsdManager via a JNI helper on a worker thread instead of
+    // QHostInfo (the stock resolver doesn't do mDNS). A monotonically
+    // increasing generation lets us drop late callbacks after cancel/timeout.
+    bool m_androidInFlight = false;
+    int m_androidGeneration = 0;
+#endif
 };


### PR DESCRIPTION
## Summary

- Adds Android-specific path for resolving the Half Decent Scale's WiFi endpoint, fixing the v1.7.5 gap where mDNS auto-discovery silently failed on Android and the app fell back to BLE.
- New Java helper acquires a `WifiManager.MulticastLock` at runtime (the `CHANGE_WIFI_MULTICAST_STATE` manifest perm alone is not enough — Android filters multicast frames without an active lock) and uses `NsdManager.discoverServices()` for `_http._tcp` to find the scale by service-instance name, then resolves to an IP.
- `WifiScaleDiscovery::probe()` gets an `#ifdef Q_OS_ANDROID` branch that runs the blocking JNI call on a `QThreadPool` worker and posts back to the Qt thread via `QMetaObject::invokeMethod` with a generation counter so late callbacks after cancel/timeout get dropped.
- No public API change. Desktop/iOS paths untouched. `tst_WifiScaleDiscovery` and `tst_DecentScaleWifi` both still pass (22/22).

This is the follow-up flagged in the openspec proposal (`6.3.1: Add a Kotlin helper ... wrapping NsdManager.resolveService`) — written in Java to match the existing `BleHelper.java` / `AndroidUsbScale.java` pattern rather than adding the Kotlin toolchain.

## Test plan

- [x] macOS build via Qt Creator: 0 errors, 0 warnings
- [x] `tst_WifiScaleDiscovery` + `tst_DecentScaleWifi`: 22/22 pass
- [ ] **Android device verification (required before merge):**
  - Install the APK on an Android device on the same WiFi as a powered HDS
  - Open Settings → Connections → Scan for scales
  - Confirm the HDS appears with a "(WiFi)" suffix and connects
  - Confirm tare, weight readings, and disconnect behave like the BLE driver
  - Confirm `adb logcat` shows `DecenzaWifiNsd` log lines: `acquireMulticastLock: held`, `onServiceFound: hds`, `onServiceResolved: hds -> <ip>`
- [ ] Bonus: turn off the scale's WiFi mid-session and confirm WiFi→BLE fallback still works (BLEManager's fallback path is unchanged but worth one cycle).

## Notes

- The Java helper matches services case-insensitively by name prefix (`hds*`) — so collision-renamed instances (`hds (2)`, `hds-2`, etc.) still match.
- `MulticastLock` is reference-counted, so nested probes do the right thing — each `acquire()` is paired with exactly one `release()` in the `finally` block.
- If the user's network has multiple `_http._tcp` advertisers (printer, IoT hub), they'll be enumerated by `onServiceFound` but skipped by the name filter — only an HDS-named instance gets resolved. We could further harden this by also pinging the WebSocket endpoint, but that's premature optimization until we see a false-match report in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)