### PR TITLE
Auto switch back to WiFi primary scale when it returns

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -151,6 +151,7 @@ BLEManager::~BLEManager() {
     if (m_scanning) {
         stopScan();
     }
+    cancelWifiProbe();  // tear down any in-flight WiFi-primary reachability probe
     if (s_instance == this) s_instance = nullptr;
 }
 
@@ -1057,8 +1058,10 @@ void BLEManager::switchToWifiPrimary() {
     // scaleDiscovered emission then (re)creates the WiFi driver and connects via
     // connectToHost()'s cached-IP fast path (the IP we just probed reachable).
     // Arm the connection timer so a surprise failure (e.g. the cached IP was
-    // reassigned between probe and dial) still falls back to BLE via
-    // onScaleConnectionTimeout instead of leaving us on FlowScale.
+    // reassigned between probe and dial) is recovered: onScaleConnectionTimeout
+    // routes into beginWifiFallbackToBleScan() (a BLE scan) rather than leaving
+    // the scale stranded on FlowScale; FlowScale is reached only if that BLE
+    // scan also times out.
     m_wifiFallbackToBleActive = false;
     m_scaleConnectionTimer->start();
     emit disconnectScaleRequested();

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -19,6 +19,7 @@
 #include <QDir>
 #include <QTextStream>
 #include <QDateTime>
+#include <QTcpSocket>
 
 #ifdef Q_OS_ANDROID
 #include <QJniEnvironment>
@@ -977,6 +978,92 @@ void BLEManager::beginWifiFallbackToBleScan() {
     if (!m_scanning) {
         startScan();
     }
+}
+
+void BLEManager::probeWifiPrimaryReachable(const QString& ip) {
+    // Lightweight, NON-disruptive liveness check: a plain TCP connect to the
+    // WiFi scale's cached IP on the HDS web/WS port. It deliberately does NOT
+    // touch the live (BLE backup) scale, so a negative result costs the user
+    // nothing. This is the gate before switchToWifiPrimary(): only drop a working
+    // backup once we know the primary actually answers. (mDNS is the unreliable
+    // path under BLE-coex load, so we dial the cached IP directly.)
+    constexpr int kProbePort = 80;          // HDS serves its web page + WS here
+    constexpr int kProbeTimeoutMs = 3000;
+
+    cancelWifiProbe();  // at most one probe in flight
+
+    if (ip.isEmpty()) {
+        emit wifiPrimaryReachable(false);
+        return;
+    }
+
+    m_wifiProbeSocket = new QTcpSocket(this);
+    m_wifiProbeTimer = new QTimer(this);
+    m_wifiProbeTimer->setSingleShot(true);
+
+    // Resolve the probe exactly once: the first of connect / error / timeout
+    // wins. Members are nulled up front so any later signal (e.g. an error
+    // delivered during abort()) short-circuits instead of emitting twice.
+    auto finish = [this](bool reachable) {
+        if (!m_wifiProbeSocket) return;  // already resolved
+        QTcpSocket* sock = m_wifiProbeSocket;
+        QTimer* timer = m_wifiProbeTimer;
+        m_wifiProbeSocket = nullptr;
+        m_wifiProbeTimer = nullptr;
+        timer->stop();
+        timer->deleteLater();
+        sock->disconnect();   // drop our slots before abort()
+        sock->abort();
+        sock->deleteLater();
+        emit wifiPrimaryReachable(reachable);
+    };
+
+    connect(m_wifiProbeSocket, &QAbstractSocket::connected, this,
+            [finish]() { finish(true); });
+    connect(m_wifiProbeSocket, &QAbstractSocket::errorOccurred, this,
+            [finish](QAbstractSocket::SocketError) { finish(false); });
+    connect(m_wifiProbeTimer, &QTimer::timeout, this, [finish]() { finish(false); });
+
+    appendScaleLog(QString("Probing WiFi primary at %1:%2 (%3 ms)")
+                       .arg(ip).arg(kProbePort).arg(kProbeTimeoutMs));
+    m_wifiProbeTimer->start(kProbeTimeoutMs);
+    m_wifiProbeSocket->connectToHost(ip, static_cast<quint16>(kProbePort));
+}
+
+void BLEManager::cancelWifiProbe() {
+    if (m_wifiProbeTimer) {
+        m_wifiProbeTimer->stop();
+        m_wifiProbeTimer->deleteLater();
+        m_wifiProbeTimer = nullptr;
+    }
+    if (m_wifiProbeSocket) {
+        m_wifiProbeSocket->disconnect();
+        m_wifiProbeSocket->abort();
+        m_wifiProbeSocket->deleteLater();
+        m_wifiProbeSocket = nullptr;
+    }
+}
+
+void BLEManager::switchToWifiPrimary() {
+    if (!m_savedScaleAddress.startsWith(QStringLiteral("wifi:"), Qt::CaseInsensitive)) {
+        return;  // primary isn't a WiFi scale — nothing to switch back to
+    }
+    const QString hostname = m_savedScaleAddress.mid(QStringLiteral("wifi:").size());
+    qDebug() << "BLEManager: WiFi primary reachable again — switching back from backup to" << hostname;
+    appendScaleLog(QString("WiFi primary %1 reachable — switching back from backup").arg(hostname));
+
+    // Drop the current backup scale, then connect the WiFi primary. main.cpp's
+    // disconnectScaleRequested handler tears down the live scale; the
+    // scaleDiscovered emission then (re)creates the WiFi driver and connects via
+    // connectToHost()'s cached-IP fast path (the IP we just probed reachable).
+    // Arm the connection timer so a surprise failure (e.g. the cached IP was
+    // reassigned between probe and dial) still falls back to BLE via
+    // onScaleConnectionTimeout instead of leaving us on FlowScale.
+    m_wifiFallbackToBleActive = false;
+    m_scaleConnectionTimer->start();
+    emit disconnectScaleRequested();
+    m_pendingWifiHostname = hostname;
+    emit scaleDiscovered(QBluetoothDeviceInfo{}, QStringLiteral("decent-wifi"));
 }
 
 void BLEManager::setSavedScaleAddress(const QString& address, const QString& type, const QString& name) {

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -21,6 +21,7 @@ class DiFluidR2;
 class SettingsHardware;
 class WifiScaleDiscovery;
 class TranslationManager;
+class QTcpSocket;
 #if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
 class AppleBtState;
 #endif
@@ -101,6 +102,19 @@ public:
     // (the BLE connect is treated as a temporary substitute, not a permanent
     // primary-scale change).
     bool isWifiFallbackToBleActive() const { return m_wifiFallbackToBleActive; }
+
+    // Proactive WiFi-primary switch-back (driven by main.cpp's idle poll when
+    // we're on the BLE backup but the saved primary is a WiFi scale):
+    //  - probeWifiPrimaryReachable() does a NON-disruptive TCP liveness check of
+    //    the WiFi scale's cached IP:80 (the HDS web/WS port). It never touches the
+    //    live BLE link, so a failed probe leaves the working backup untouched.
+    //    Reports the outcome exactly once via wifiPrimaryReachable().
+    //  - switchToWifiPrimary() drops the current backup scale and connects the
+    //    saved WiFi primary via the cached-IP fast path. Call only after a
+    //    reachable probe (and a re-check that we're still idle on the backup).
+    void probeWifiPrimaryReachable(const QString& ip);
+    void switchToWifiPrimary();
+
     bool hasSavedDE1() const { return !m_savedDE1Address.isEmpty(); }
     bool linuxBleCapabilityMissing() const { return BleCapability::linuxMissing(); }
     QString linuxBleSetcapCommand() const { return BleCapability::linuxSetcapCommand(); }
@@ -383,6 +397,9 @@ signals:
     // timeout and BLEManager has started a BLE scan as a fallback. UI binds
     // this to a toast/banner so the user knows what's happening.
     void wifiUnreachableFallingBackToBle(const QString& hostname);
+    // Result of a probeWifiPrimaryReachable() call (emitted exactly once per
+    // probe). main.cpp switches back to the WiFi primary when reachable==true.
+    void wifiPrimaryReachable(bool reachable);
     void disabledChanged();
     void disconnectScaleRequested();  // Emitted when switching to a different scale, BLE is disabled, or saved scale is cleared
     void refractometersChanged();
@@ -418,6 +435,9 @@ private:
     // first Decent-family scale found. Toast surfaces the fallback to the
     // user. Cleared on the next successful scale connect.
     void beginWifiFallbackToBleScan();
+    // Tear down any in-flight WiFi-primary reachability probe (socket + timeout
+    // timer) without emitting a result. Safe to call when no probe is active.
+    void cancelWifiProbe();
 
 #ifndef Q_OS_IOS
     QBluetoothLocalDevice* m_localDevice = nullptr;
@@ -432,6 +452,11 @@ private:
     QList<QBluetoothDeviceInfo> m_de1Devices;
     QList<ScaleEntry> m_scales;
     WifiScaleDiscovery* m_wifiDiscovery = nullptr;  // Lazy-created on first scanForDevices
+    // Non-disruptive WiFi-primary reachability probe: a per-probe TCP socket +
+    // timeout timer (both owned, recreated each probe and torn down on the first
+    // of connect/error/timeout so exactly one wifiPrimaryReachable() is emitted).
+    QTcpSocket* m_wifiProbeSocket = nullptr;
+    QTimer* m_wifiProbeTimer = nullptr;
     TranslationManager* m_translationManager = nullptr;  // For i18n of user-visible error strings
     // Helper: translate `key` with `fallback`, or just return `fallback` if no
     // TranslationManager has been wired. Use ONLY for user-visible strings

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -108,10 +108,14 @@ public:
     //  - probeWifiPrimaryReachable() does a NON-disruptive TCP liveness check of
     //    the WiFi scale's cached IP:80 (the HDS web/WS port). It never touches the
     //    live BLE link, so a failed probe leaves the working backup untouched.
-    //    Reports the outcome exactly once via wifiPrimaryReachable().
+    //    Reports the outcome via wifiPrimaryReachable() at most once per probe (a
+    //    probe superseded by a later call is cancelled without emitting).
     //  - switchToWifiPrimary() drops the current backup scale and connects the
     //    saved WiFi primary via the cached-IP fast path. Call only after a
     //    reachable probe (and a re-check that we're still idle on the backup).
+    //    Side effects: clears m_wifiFallbackToBleActive and starts
+    //    m_scaleConnectionTimer, so a failed reconnect routes back through the
+    //    WiFi->BLE fallback path.
     void probeWifiPrimaryReachable(const QString& ip);
     void switchToWifiPrimary();
 
@@ -397,8 +401,9 @@ signals:
     // timeout and BLEManager has started a BLE scan as a fallback. UI binds
     // this to a toast/banner so the user knows what's happening.
     void wifiUnreachableFallingBackToBle(const QString& hostname);
-    // Result of a probeWifiPrimaryReachable() call (emitted exactly once per
-    // probe). main.cpp switches back to the WiFi primary when reachable==true.
+    // Result of a probeWifiPrimaryReachable() call (emitted at most once per
+    // probe — zero times if a later probeWifiPrimaryReachable() supersedes it
+    // via cancelWifiProbe()). main.cpp switches to the WiFi primary when reachable.
     void wifiPrimaryReachable(bool reachable);
     void disabledChanged();
     void disconnectScaleRequested();  // Emitted when switching to a different scale, BLE is disabled, or saved scale is cleared

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1284,9 +1284,10 @@ int main(int argc, char *argv[])
 
     // Armed only on the WiFi-primary / BLE-backup combination AND while the
     // machine is in a non-brewing phase. "Non-brewing" = Disconnected (no DE1,
-    // i.e. scale-only debugging), Sleep, Idle, Ready; any active phase
-    // (preheat/preinfusion/pour/steam/hot-water/flush/clean/descale) blocks the
-    // switch so the scale is never disrupted mid-operation.
+    // i.e. scale-only debugging), Sleep, Idle, Ready; ANY other phase (Heating,
+    // EspressoPreheating, Preinfusion, Pouring, Ending, Steaming, HotWater,
+    // Flushing, Refill, Descaling, Cleaning) blocks the switch so the scale is
+    // never disrupted mid-operation.
     auto onWifiBackupAndIdle = [&settings, &physicalScale, &machineState]() -> bool {
         if (!settings.scaleAddress().startsWith(QStringLiteral("wifi:"), Qt::CaseInsensitive))
             return false;                                  // primary isn't WiFi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1270,6 +1270,60 @@ int main(int argc, char *argv[])
         qDebug() << "Scale reconnect: scheduled first retry in" << reconnectDelays[0] << "ms (startup failure)";
     });
 
+    // === Proactive switch-back to the WiFi primary scale ===
+    // When the saved primary is a WiFi scale but we're currently on the BLE
+    // backup (the WiFi->BLE fallback connected after WiFi was unreachable),
+    // periodically check — only while the machine is idle (idle page, never
+    // mid-shot) — whether the WiFi scale is reachable again, and hop back if so.
+    // The check (BLEManager::probeWifiPrimaryReachable → a TCP dial of the cached
+    // IP) is non-disruptive: it never touches the live BLE link, so a failed
+    // check leaves the working backup untouched. This is genuine periodic polling
+    // (for an external availability change), not a timer-as-guard.
+    QTimer wifiPreferTimer;
+    constexpr int kWifiPreferIntervalMs = 30000;  // re-check every 30 s while armed
+
+    // Armed only on the WiFi-primary / BLE-backup combination AND while the
+    // machine is in a non-brewing phase. "Non-brewing" = Disconnected (no DE1,
+    // i.e. scale-only debugging), Sleep, Idle, Ready; any active phase
+    // (preheat/preinfusion/pour/steam/hot-water/flush/clean/descale) blocks the
+    // switch so the scale is never disrupted mid-operation.
+    auto onWifiBackupAndIdle = [&settings, &physicalScale, &machineState]() -> bool {
+        if (!settings.scaleAddress().startsWith(QStringLiteral("wifi:"), Qt::CaseInsensitive))
+            return false;                                  // primary isn't WiFi
+        if (!physicalScale || !physicalScale->isConnected())
+            return false;                                  // nothing connected → reconnect machinery owns it
+        if (physicalScale->type() == QStringLiteral("decent-wifi"))
+            return false;                                  // already on the WiFi primary
+        switch (machineState.phase()) {
+        case MachineState::Phase::Disconnected:
+        case MachineState::Phase::Sleep:
+        case MachineState::Phase::Idle:
+        case MachineState::Phase::Ready:
+            return true;
+        default:
+            return false;                                  // brewing / active — don't switch
+        }
+    };
+
+    QObject::connect(&wifiPreferTimer, &QTimer::timeout,
+                     [&settings, &bleManager, onWifiBackupAndIdle]() {
+        if (!onWifiBackupAndIdle()) return;
+        const QString hostname = settings.scaleAddress().mid(QStringLiteral("wifi:").size());
+        const QString cachedIp = settings.network()->wifiScaleIp(hostname);
+        if (cachedIp.isEmpty()) return;  // no cheap probe target (mDNS is unreliable here) — skip this cycle
+        bleManager.probeWifiPrimaryReachable(cachedIp);
+    });
+    wifiPreferTimer.start(kWifiPreferIntervalMs);
+
+    QObject::connect(&bleManager, &BLEManager::wifiPrimaryReachable,
+                     [&bleManager, onWifiBackupAndIdle](bool reachable) {
+        if (!reachable) return;
+        // Re-validate: up to ~3 s elapsed during the probe, so state may have
+        // changed (a shot started, the user picked a scale, WiFi already back…).
+        if (!onWifiBackupAndIdle()) return;
+        bleManager.switchToWifiPrimary();
+    });
+
     // DE1 auto-reconnect after disconnect. Matches de1app behaviour: on Android it
     // retries essentially forever (99999999 attempts) because the DE1 may be in deep
     // sleep and take a while to become reachable. We use backoff: 5s, 30s, then 60s


### PR DESCRIPTION
## Summary
- While connected to the BLE **backup** (the WiFi→BLE fallback), the app now proactively switches back to the saved **WiFi primary** scale once it's reachable again — instead of staying on the backup until the next disconnect/restart.
- The availability check is **non-disruptive**: a TCP dial of the WiFi scale's cached IP:80 that never touches the live BLE link. Only a positive result triggers the switch, so the working backup never blips while WiFi is still down.
- **Never interrupts a shot:** the check + switch only run while the machine is idle (`Disconnected`/`Sleep`/`Idle`/`Ready`); any active phase blocks it, and idle is re-validated after the ~3 s probe.

## Details
- `BLEManager::probeWifiPrimaryReachable(ip)` — per-probe `QTcpSocket` + timeout; emits `wifiPrimaryReachable(bool)` exactly once (first of connect/error/timeout wins).
- `BLEManager::switchToWifiPrimary()` — drops the backup and connects the WiFi primary via `connectToHost()`'s cached-IP fast path; arms the connection timer so a stale cached IP still falls back to BLE.
- `main.cpp` — a 30 s poll, armed only on the WiFi-primary/BLE-backup combination, gated on idle machine phase.

Independent of #1249 (depends only on the WiFi-scale infrastructure already on `main`). Builds clean (macOS, 0 warnings).

## Test plan
- [ ] WiFi scale as primary; force a WiFi→BLE fallback (power-cycle the scale's WiFi). Confirm it lands on the BLE backup.
- [ ] Bring the WiFi scale back; on the idle page, confirm it switches back to WiFi within ~30 s (log: `Probing WiFi primary…` → `switching back from backup`).
- [ ] Start a shot while on the backup with WiFi available — confirm it does NOT switch mid-shot.
- [ ] With WiFi still down, confirm the BLE backup never blips (no disconnect/reconnect churn from the probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)