### PR TITLE
Don't nag on transient scale disconnects; clearer wording

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1417,12 +1417,21 @@ ApplicationWindow {
             root.scaleDropPending = true
         }
         function onScaleConnected() {
-            // Scale (re)connected — clear the pending-drop state and dismiss any
-            // FlowScale notice (open or queued) so a recovered drop leaves no trace.
+            // Scale (re)connected — clear the pending-drop state and dismiss the
+            // open scale-disconnect / no-scale notice so a recovered drop leaves no
+            // trace. Queued-but-unshown popups are purged by the ScaleDevice
+            // reconnect handler ("Discard stale scale popups…" below), so we don't
+            // duplicate removeQueuedScalePopups() here.
             root.scaleDropPending = false
             if (scaleDisconnectedDialog.opened) scaleDisconnectedDialog.close()
             if (flowScaleDialog.opened) flowScaleDialog.close()
-            removeQueuedScalePopups()
+        }
+        function onDisconnectScaleRequested() {
+            // A deliberate scale switch/forget ends the mid-session-drop context, so
+            // the next FlowScale fallback isn't mislabeled "Scale Disconnected" for a
+            // freshly-selected (never-connected) scale. disconnectScaleRequested
+            // fires from connectToScale / clearSavedScale / setDisabled.
+            root.scaleDropPending = false
         }
     }
 
@@ -1445,7 +1454,7 @@ ApplicationWindow {
         }
 
         Tr { id: trNoScaleFoundTitle; key: "main.dialog.noScaleFound.title"; fallback: "No Scale Found"; visible: false }
-        Tr { id: trNoScaleFoundAnnounce; key: "main.dialog.noScaleFound.announce"; fallback: "No Bluetooth scale detected. Using estimated weight from flow measurement."; visible: false }
+        Tr { id: trNoScaleFoundAnnounce; key: "main.dialog.noScaleFound.announce"; fallback: "No scale detected. Using estimated weight from flow measurement."; visible: false }
 
         onOpened: {
             if (AccessibilityManager.enabled) {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -615,6 +615,11 @@ ApplicationWindow {
 
     // Defer scale dialogs until machine reaches Ready (event-driven, not timer-based)
     property bool scaleDialogDeferred: false
+    // True while a previously-connected scale is disconnected (a mid-session
+    // drop). Set on scaleDisconnected, cleared on scaleConnected. Lets us defer
+    // the "Scale Disconnected" notice until a reconnect actually FAILS
+    // (flowScaleFallback), so a transient drop that auto-reconnects never nags.
+    property bool scaleDropPending: false
 
     // Shared translation strings for dialog buttons
     Tr { id: trCommonOk; key: "common.button.ok"; fallback: "OK"; visible: false }
@@ -1393,15 +1398,31 @@ ApplicationWindow {
             if (!Settings.showScaleDialogs) return
             // Don't nag if a USB scale is connected — it satisfies the requirement (not available on iOS)
             if (Qt.platform.os !== "ios" && UsbScaleManager.scaleConnected) return
-            if (screensaverActive) { queuePopup("flowScale"); return }
-            if (root.scaleDialogDeferred) { queuePopup("flowScale"); return }
-            flowScaleDialog.open()
+            // This fires only after a (re)connect attempt has actually given up,
+            // so it's the right moment to notify. A mid-session drop
+            // (scaleDropPending) shows the "Scale Disconnected" notice; a
+            // never-connected startup shows "No scale detected".
+            var popupId = root.scaleDropPending ? "scaleDisconnected" : "flowScale"
+            var dialog = root.scaleDropPending ? scaleDisconnectedDialog : flowScaleDialog
+            if (screensaverActive) { queuePopup(popupId); return }
+            if (root.scaleDialogDeferred) { queuePopup(popupId); return }
+            dialog.open()
         }
         function onScaleDisconnected() {
-            if (!Settings.showScaleDialogs) return
-            if (screensaverActive) { queuePopup("scaleDisconnected"); return }
-            if (root.scaleDialogDeferred) { queuePopup("scaleDisconnected"); return }
-            scaleDisconnectedDialog.open()
+            // Don't nag on the disconnect itself — a transient drop (e.g. the
+            // WiFi WebSocket dropping on screensaver wake) auto-reconnects within
+            // seconds. Just record it; onFlowScaleFallback() surfaces the notice
+            // only if the reconnect actually gives up, and onScaleConnected()
+            // clears this + dismisses the notice once the scale is back.
+            root.scaleDropPending = true
+        }
+        function onScaleConnected() {
+            // Scale (re)connected — clear the pending-drop state and dismiss any
+            // FlowScale notice (open or queued) so a recovered drop leaves no trace.
+            root.scaleDropPending = false
+            if (scaleDisconnectedDialog.opened) scaleDisconnectedDialog.close()
+            if (flowScaleDialog.opened) flowScaleDialog.close()
+            removeQueuedScalePopups()
         }
     }
 
@@ -1444,7 +1465,7 @@ ApplicationWindow {
 
             Tr {
                 key: "main.dialog.noScaleFound.message"
-                fallback: "No Bluetooth scale was detected.\n\nUsing estimated weight from DE1 flow measurement instead.\n\nYou can search for your scale in Settings → Connections."
+                fallback: "No scale was detected.\n\nUsing estimated weight from DE1 flow measurement instead.\n\nYou can search for your scale in Settings → Connections."
                 wrapMode: Text.Wrap
                 width: parent.width
                 font: Theme.bodyFont
@@ -1498,7 +1519,7 @@ ApplicationWindow {
 
             Tr {
                 key: "main.dialog.scaleDisconnected.message"
-                fallback: "Your Bluetooth scale has disconnected.\n\nUsing estimated weight from DE1 flow measurement until the scale reconnects.\n\nCheck that your scale is powered on and in range."
+                fallback: "Your scale has disconnected.\n\nUsing estimated weight from DE1 flow measurement until the scale reconnects.\n\nCheck that your scale is powered on and in range."
                 wrapMode: Text.Wrap
                 width: parent.width
                 font: Theme.bodyFont

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -901,7 +901,7 @@ void BLEManager::onScaleConnectedChanged() {
             emit scaleConnectionFailedChanged();
         }
         qDebug() << "BLEManager: Scale connected";
-        emit scaleConnected();  // UI auto-dismisses any FlowScale "scale disconnected" notice
+        emit scaleConnected();  // UI auto-dismisses the scale-disconnect / no-scale notice on reconnect
     } else {
         // Scale disconnected - notify UI immediately
         qDebug() << "BLEManager: Scale disconnected";

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -901,6 +901,7 @@ void BLEManager::onScaleConnectedChanged() {
             emit scaleConnectionFailedChanged();
         }
         qDebug() << "BLEManager: Scale connected";
+        emit scaleConnected();  // UI auto-dismisses any FlowScale "scale disconnected" notice
     } else {
         // Scale disconnected - notify UI immediately
         qDebug() << "BLEManager: Scale disconnected";

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -396,6 +396,7 @@ signals:
     void scaleLogMessage(const QString& message);
     void flowScaleFallback();  // Emitted when no physical scale found, using FlowScale
     void scaleDisconnected();  // Emitted when physical scale disconnects
+    void scaleConnected();     // Emitted when a physical scale (re)connects — lets the UI dismiss a FlowScale notice
     void scanStarted();  // Emitted when BLE scan actually begins
     // Emitted when a saved WiFi scale fails to connect within the connection
     // timeout and BLEManager has started a BLE scan as a fallback. UI binds

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -396,7 +396,7 @@ signals:
     void scaleLogMessage(const QString& message);
     void flowScaleFallback();  // Emitted when no physical scale found, using FlowScale
     void scaleDisconnected();  // Emitted when physical scale disconnects
-    void scaleConnected();     // Emitted when a physical scale (re)connects — lets the UI dismiss a FlowScale notice
+    void scaleConnected();     // Emitted when a physical scale (re)connects — lets the UI dismiss the scale-disconnect / no-scale notice
     void scanStarted();  // Emitted when BLE scan actually begins
     // Emitted when a saved WiFi scale fails to connect within the connection
     // timeout and BLEManager has started a BLE scan as a fallback. UI binds


### PR DESCRIPTION
## Summary
- The FlowScale "Scale Disconnected" notice no longer pops on **every** disconnect. A transient drop — e.g. the WiFi WebSocket dropping on screensaver wake, which auto-reconnects in ~5 s — used to immediately open a modal that then sat there, already stale, until manually dismissed.
- The notice is now surfaced only when a (re)connect attempt **actually gives up** (via `flowScaleFallback`), and it **auto-dismisses** the moment the scale reconnects (new `BLEManager::scaleConnected` signal).
- Wording is now transport-neutral — it previously said "**Bluetooth** scale" even for WiFi scales.

## Behavior
- Transient drop that reconnects in seconds → **no dialog at all**.
- Genuine failure → notice appears after the reconnect attempts give up; a mid-session drop shows "Your scale has disconnected", a startup-with-no-scale shows "No scale was detected".
- A reconnect at any point closes the notice (and removes a queued one), so a recovered drop leaves no trace.

This came out of an on-device report: putting the app to sleep and waking it popped "Scale Disconnected" even though the WiFi scale was fine — the log showed the WebSocket dropping on wake and the cached-IP reconnect restoring it ~5 s later, with the modal left stale.

Independent of #1250 (touches the pre-existing FlowScale-fallback dialog on `main`).

## Test plan
- [ ] WiFi scale connected; sleep the app (screensaver) and wake it — confirm NO "Scale Disconnected" modal (the WS blip auto-reconnects).
- [ ] Power the scale off entirely — confirm the notice appears only after the reconnect attempts give up, with transport-neutral wording.
- [ ] Bring the scale back while the notice is showing — confirm it auto-dismisses.
- [ ] Startup with a saved-but-absent scale still shows "No scale was detected".

🤖 Generated with [Claude Code](https://claude.com/claude-code)