### PR TITLE
Make Known Devices picker actually switch the connection

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1470,8 +1470,12 @@ Item {
             var scales = Settings.knownScales
             if (index >= 0 && index < scales.length) {
                 var scale = scales[index]
+                if (scale.isPrimary) return  // re-selected the current primary — nothing to switch
                 Settings.setPrimaryScale(scale.address)
                 BLEManager.setSavedScaleAddress(scale.address, scale.type, scale.name)
+                // Actually switch the live connection to the chosen scale, so the
+                // "Connected:" status updates instead of staying on the old one.
+                BLEManager.connectToSavedScale()
             }
         }
     }

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -462,6 +462,28 @@ void BLEManager::connectToScale(const QString& address) {
     qWarning() << "Scale not found in discovered list:" << address;
 }
 
+void BLEManager::connectToSavedScale() {
+    // Switch the live connection to the current saved primary (the caller sets it
+    // via setSavedScaleAddress immediately before). The Known Devices picker uses
+    // this so selecting a scale actually CONNECTS to it rather than only relabeling
+    // the saved primary. Goes through the direct-wake path so it works even when
+    // the chosen scale isn't in the discovered list.
+    if (m_savedScaleAddress.isEmpty()) return;
+
+    // Drop the currently-connected scale first (single-scale invariant) so the new
+    // primary can take over. main.cpp's disconnectScaleRequested handler tears down
+    // the live scale and clears m_scaleDevice, so tryDirectConnectToScale()'s
+    // "already connected" guard won't block the new dial.
+    if (m_scaleDevice && m_scaleDevice->isConnected()) {
+        appendScaleLog(QString("Switching scale to %1")
+                           .arg(m_savedScaleName.isEmpty() ? m_savedScaleAddress : m_savedScaleName));
+        emit disconnectScaleRequested();
+    }
+    m_wifiFallbackToBleActive = false;  // user explicitly chose this scale
+    resetScaleConnectionState();
+    tryDirectConnectToScale();
+}
+
 void BLEManager::startScan() {
     if (m_disabled && !m_scanningForScales) {
         // In simulator mode, suppress DE1 scanning but allow scale/refractometer scans

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -466,13 +466,34 @@ void BLEManager::connectToSavedScale() {
     // Switch the live connection to the current saved primary (the caller sets it
     // via setSavedScaleAddress immediately before). The Known Devices picker uses
     // this so selecting a scale actually CONNECTS to it rather than only relabeling
-    // the saved primary. Goes through the direct-wake path so it works even when
-    // the chosen scale isn't in the discovered list.
-    if (m_savedScaleAddress.isEmpty()) return;
+    // the saved primary. Goes through tryDirectConnectToScale() — the direct-wake
+    // path — so it works even when the chosen scale isn't in the discovered list.
+    if (m_savedScaleAddress.isEmpty() || m_savedScaleType.isEmpty()) return;
 
-    // Drop the currently-connected scale first (single-scale invariant) so the new
-    // primary can take over. main.cpp's disconnectScaleRequested handler tears down
-    // the live scale and clears m_scaleDevice, so tryDirectConnectToScale()'s
+    // Bail BEFORE dropping the working scale if the new connect can't proceed —
+    // otherwise we'd disconnect the current scale and tryDirectConnectToScale()
+    // would then silently early-return, leaving the user on FlowScale with no
+    // feedback. (These mirror tryDirectConnectToScale()'s own guards.)
+    if (m_disabled) {
+        appendScaleLog("Scale switch ignored — simulator mode");
+        return;
+    }
+    if (!isBluetoothAvailable()) {
+        appendScaleLog("Cannot switch scale — Bluetooth is powered off");
+        emit errorOccurred(translateUiString("ble.error.bluetoothPoweredOff",
+                                             "Bluetooth is powered off"));
+        return;
+    }
+
+    // Fresh user-initiated attempt: clear stale failure state so the status line
+    // doesn't flash "Not found" during the new connect (mirrors scanForDevices()).
+    m_scaleConnectionFailed = false;
+    m_flowScaleFallbackEmitted = false;
+    emit scaleConnectionFailedChanged();
+
+    // Drop the currently-connected scale (if any) so the new primary can take over.
+    // main.cpp's disconnectScaleRequested handler runs synchronously (same-thread
+    // direct connection) and clears m_scaleDevice, so tryDirectConnectToScale()'s
     // "already connected" guard won't block the new dial.
     if (m_scaleDevice && m_scaleDevice->isConnected()) {
         appendScaleLog(QString("Switching scale to %1")

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -333,11 +333,14 @@ public:
     Q_INVOKABLE QString getScaleType(const QString& address) const;
     Q_INVOKABLE void connectToScale(const QString& address);  // Manual scale selection
     // Switch the LIVE connection to the current saved primary scale (set via
-    // setSavedScaleAddress just before calling). Drops any currently-connected
-    // scale, then direct-wakes the saved primary (BLE) / cached-IP-connects it
-    // (WiFi) via tryDirectConnectToScale(). Unlike connectToScale() this does
-    // NOT require the scale to be in the discovered list, so the Known Devices
-    // picker can switch to a known scale that isn't currently being scanned.
+    // setSavedScaleAddress just before calling). If a scale is connected it is
+    // disconnected first, then the saved primary is direct-woken (BLE) /
+    // cached-IP-connected (WiFi) via tryDirectConnectToScale(). Unlike
+    // connectToScale() this does NOT require the scale to be in the discovered
+    // list, so the Known Devices picker can switch to a known scale that isn't
+    // currently being scanned. Requires the saved address AND type to be set; if
+    // the switch can't proceed (Bluetooth off / simulator mode) it no-ops with a
+    // log/error and does NOT drop the currently-connected scale.
     Q_INVOKABLE void connectToSavedScale();
 
     ScaleDevice* scaleDevice() const { return m_scaleDevice; }

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -332,6 +332,13 @@ public:
     Q_INVOKABLE QBluetoothDeviceInfo getScaleDeviceInfo(const QString& address) const;
     Q_INVOKABLE QString getScaleType(const QString& address) const;
     Q_INVOKABLE void connectToScale(const QString& address);  // Manual scale selection
+    // Switch the LIVE connection to the current saved primary scale (set via
+    // setSavedScaleAddress just before calling). Drops any currently-connected
+    // scale, then direct-wakes the saved primary (BLE) / cached-IP-connects it
+    // (WiFi) via tryDirectConnectToScale(). Unlike connectToScale() this does
+    // NOT require the scale to be in the discovered list, so the Known Devices
+    // picker can switch to a known scale that isn't currently being scanned.
+    Q_INVOKABLE void connectToSavedScale();
 
     ScaleDevice* scaleDevice() const { return m_scaleDevice; }
     void setScaleDevice(ScaleDevice* scale);


### PR DESCRIPTION
## Summary
- Selecting a scale in **Settings → Connections → Known Devices** previously only changed the saved/primary setting — it never connected, so the **"Connected:"** line stayed on the previously-connected scale (e.g. picking the BLE "Decent Scale" while connected over WiFi kept showing "Decent Scale (WiFi)").
- New `BLEManager::connectToSavedScale()` drops the currently-connected scale and direct-wakes the newly-chosen saved primary (BLE direct-connect / WiFi cached-IP), so the live connection — and the status line — actually switch. It goes through the direct-wake path, so it works for either transport and even when the chosen scale isn't in the current discovered list (unlike `connectToScale()`, which needs a discovered entry).
- The picker's `onSelected` calls it after updating the primary; re-selecting the current primary is a no-op.

This came from an on-device report: selecting the BT scale in the picker left "Connected: Decent Scale (WiFi)" unchanged.

## Test plan
- [ ] With the WiFi scale connected, open Known Devices and pick the BLE "Decent Scale" — confirm it disconnects WiFi, connects BLE, and "Connected:" updates to "Decent Scale".
- [ ] Switch back to the WiFi entry — confirm it reconnects over WiFi and the status updates.
- [ ] Re-select the already-connected primary — confirm no disconnect/reconnect churn.
- [ ] Pick a known scale that wasn't just scanned — confirm it still connects (direct-wake path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)