### PR TITLE
fix(water): suppress refill warnings when refill kit is active

### DIFF
--- a/qml/components/layout/items/WaterLevelItem.qml
+++ b/qml/components/layout/items/WaterLevelItem.qml
@@ -10,13 +10,20 @@ Item {
 
     property bool showMl: Settings.app.waterLevelDisplayUnit === "ml"
 
-    // Margin = mm of water above the user's configured refill threshold.
+    // Margin = mm of water above the effective refill threshold.
     // waterLevelMm = rawSensorMm + 5mm offset (sensor mounted above intake).
     // waterRefillPoint is in raw sensor mm (sent to firmware as-is).
-    // So: margin = waterLevelMm - sensorOffset - waterRefillPoint = rawSensorMm - waterRefillPoint.
-    // "Refill" appears at margin <= 0, i.e. when raw water level reaches the user's setting.
+    // So: margin = waterLevelMm - sensorOffset - effectiveRefillPoint = rawSensorMm - effectiveRefillPoint.
+    // "Refill" appears at margin <= 0, i.e. when raw water level reaches the threshold.
+    //
+    // When the refill kit is active, the effective threshold drops to 3mm (the slider
+    // floor) so the kit's normal top-up cycle doesn't trip a spurious warning. Matches
+    // MainController::applyWaterRefillLevel().
     readonly property real sensorOffset: 5.0
-    readonly property real margin: DE1Device.waterLevelMm - sensorOffset - Settings.app.waterRefillPoint
+    readonly property bool refillKitActive: Settings.app.refillKitOverride === 1 ||
+                                            (Settings.app.refillKitOverride === 2 && DE1Device.refillKitDetected === 1)
+    readonly property real effectiveRefillPoint: refillKitActive ? 3 : Settings.app.waterRefillPoint
+    readonly property real margin: DE1Device.waterLevelMm - sensorOffset - effectiveRefillPoint
     readonly property string warningState: {
         // No warning when disconnected — waterLevelMm initializes to 0.0 which would
         // falsely trigger "critical" on every startup until the first BLE update arrives.

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -95,12 +95,18 @@ MainController::MainController(QNetworkAccessManager* networkManager,
                 this, &MainController::applyWaterRefillLevel);
     }
 
-    // Apply refill kit override when setting changes or when kit detection completes
+    // Apply refill kit override when setting changes or when kit detection completes.
+    // Kit state also gates the effective refill level (see applyWaterRefillLevel), so
+    // re-send the refill level on those transitions too.
     if (m_settings && m_device) {
         connect(m_settings->app(), &SettingsApp::refillKitOverrideChanged,
                 this, &MainController::applyRefillKitOverride);
+        connect(m_settings->app(), &SettingsApp::refillKitOverrideChanged,
+                this, &MainController::applyWaterRefillLevel);
         connect(m_device, &DE1Device::refillKitDetectedChanged,
                 this, &MainController::applyRefillKitOverride);
+        connect(m_device, &DE1Device::refillKitDetectedChanged,
+                this, &MainController::applyWaterRefillLevel);
     }
 
     // Apply flow calibration multiplier when setting changes
@@ -914,7 +920,17 @@ void MainController::applyAllSettings() {
 void MainController::applyWaterRefillLevel() {
     if (!m_device || !m_device->isConnected() || !m_settings) return;
 
-    m_device->setWaterRefillLevel(m_settings->app()->waterRefillPoint());
+    // When the refill kit is active (forced on, or auto-detected), the kit keeps the
+    // reservoir topped up — so suppress the firmware-side "Refill" phase by sending the
+    // slider's floor value (3mm). Stays low enough that an actual kit failure still
+    // triggers Refill phase as a fallback. The user's stored waterRefillPoint is
+    // preserved untouched and resumes whenever the kit is forced off.
+    const int override = m_settings->app()->refillKitOverride();
+    const bool kitActive = (override == 1) ||
+                           (override == 2 && m_device->refillKitDetected() == 1);
+    const int effective = kitActive ? 3 : m_settings->app()->waterRefillPoint();
+
+    m_device->setWaterRefillLevel(effective);
 }
 
 void MainController::applyRefillKitOverride() {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -922,12 +922,18 @@ void MainController::applyWaterRefillLevel() {
 
     // When the refill kit is active (forced on, or auto-detected), the kit keeps the
     // reservoir topped up — so suppress the firmware-side "Refill" phase by sending the
-    // slider's floor value (3mm). Stays low enough that an actual kit failure still
-    // triggers Refill phase as a fallback. The user's stored waterRefillPoint is
-    // preserved untouched and resumes whenever the kit is forced off.
-    const int override = m_settings->app()->refillKitOverride();
-    const bool kitActive = (override == 1) ||
-                           (override == 2 && m_device->refillKitDetected() == 1);
+    // slider's floor value (3mm). If the reservoir does run nearly empty (e.g. kit
+    // failure), the firmware will still raise Refill once raw level reaches 3mm. The
+    // user's stored waterRefillPoint is preserved untouched and resumes whenever the
+    // kit is forced off.
+    //
+    // In auto-detect mode (override == 2), refillKitDetected starts at -1 until the
+    // MMR read completes, so the first apply on connect uses the user's stored value;
+    // a follow-up write fires from refillKitDetectedChanged once detection resolves.
+    // Don't try to gate this on `detected != -1` — that would break the Force-Off path.
+    const int kitOverride = m_settings->app()->refillKitOverride();
+    const bool kitActive = (kitOverride == 1) ||
+                           (kitOverride == 2 && m_device->refillKitDetected() == 1);
     const int effective = kitActive ? 3 : m_settings->app()->waterRefillPoint();
 
     m_device->setWaterRefillLevel(effective);
@@ -936,9 +942,9 @@ void MainController::applyWaterRefillLevel() {
 void MainController::applyRefillKitOverride() {
     if (!m_device || !m_device->isConnected() || !m_settings) return;
 
-    int override = m_settings->app()->refillKitOverride();
     // Values match de1app: 0=force off, 1=force on, 2=auto-detect
-    m_device->setRefillKitPresent(override);
+    int kitOverride = m_settings->app()->refillKitOverride();
+    m_device->setRefillKitPresent(kitOverride);
 }
 
 void MainController::applyFlowCalibration() {


### PR DESCRIPTION
## Summary

- Reported by a refill-kit user: with the kit attached they still see the "Refill" warning, and they can't change the threshold because the **Water Refill Threshold** card is hidden by `SettingsMachineTab.qml:1105-1109` when the kit is active. The stored `waterRefillPoint` (5mm on my machine) is still being sent to firmware and is still driving `WaterLevelItem`'s on-screen pulsing warning, even though the kit is supposed to handle refills.
- This PR keeps the threshold card hidden but introduces an **effective** refill threshold that drops to 3mm (the existing slider floor) whenever the kit is active. Result: the kit's normal top-up cycle never trips the warning, but if the kit actually fails and the reservoir empties, the warning still fires as a safety fallback. The user's stored `waterRefillPoint` is preserved untouched in settings and resumes whenever the kit override is set to Force Off.

## Why 3mm

- Slider floor in `SettingsMachineTab.qml:1137` (`from: 3`), so it's a value the firmware has always seen.
- The kit's existing malfunction warning already uses a 10mm sentinel (`SettingsMachineTab.qml:1054`), so 3mm sits safely below the kit's normal operating range.

## Changes

- `src/controllers/maincontroller.cpp`
  - `applyWaterRefillLevel()` now computes the effective value (3mm when kit active, else stored setting) before sending to firmware.
  - Re-apply on `refillKitOverrideChanged` and `refillKitDetectedChanged` so kit transitions take effect without the user re-editing the setting.
- `qml/components/layout/items/WaterLevelItem.qml`
  - `margin` now uses the same effective threshold so the on-screen warning matches firmware behavior.

The "kit active" condition mirrors the existing definition in `SettingsMachineTab.qml:969-970` (Force On, or Auto + detected).

## Test plan

- [ ] With refill kit attached and Auto override (default), confirm the on-screen WaterLevelItem no longer flashes "Refill" during normal operation.
- [ ] Confirm the firmware no longer enters Refill phase / shows the modal "Refill Water Tank" dialog during normal kit operation.
- [ ] Set Refill Kit override to Force Off → confirm the threshold card returns and the original stored value is used again.
- [ ] Drain reservoir below 3mm with kit attached → confirm warning still fires (safety fallback).
- [ ] Without a refill kit attached, confirm threshold UI and behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)