### PR TITLE
Add manual WiFi-scale entry as an mDNS-discovery fallback

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -193,6 +193,131 @@ Item {
         }
     }
 
+    // Add WiFi Scale Dialog — enter an IP address or mDNS name to connect a
+    // WiFi scale that isn't being advertised/discovered right now.
+    Dialog {
+        id: addWifiScaleDialog
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        modal: true
+        closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
+        width: Math.min((parent ? parent.width : Theme.scaled(420)) * 0.85, Theme.scaled(420))
+        padding: 0
+
+        onOpened: {
+            wifiScaleHostField.text = ""
+            wifiScaleHostField.forceActiveFocus()
+        }
+
+        function submitWifiScale() {
+            Qt.inputMethod.commit()  // flush in-progress IME word before reading text
+            var host = wifiScaleHostField.text.trim()
+            if (host.length === 0)
+                return
+            addWifiScaleDialog.close()
+            BLEManager.connectToWifiScale(host)
+        }
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
+            border.color: Theme.primaryContrastColor
+            border.width: 1
+        }
+
+        contentItem: KeyboardAwareContainer {
+            id: wifiScaleKbContainer
+            inOverlay: true
+            textFields: [wifiScaleHostField]
+            targetFlickable: wifiScaleFlick
+            implicitWidth: addWifiScaleDialog.availableWidth
+            implicitHeight: Math.min(wifiScaleCol.implicitHeight,
+                                     addWifiScaleDialog.parent ? addWifiScaleDialog.parent.height * 0.9
+                                                               : wifiScaleCol.implicitHeight)
+
+            Flickable {
+                id: wifiScaleFlick
+                anchors.fill: parent
+                contentHeight: wifiScaleCol.implicitHeight + wifiScaleKbContainer.estimatedKeyboardHeight
+                contentWidth: parent.width
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+                flickableDirection: Flickable.VerticalFlick
+
+                ColumnLayout {
+                    id: wifiScaleCol
+                    width: parent.width
+                    spacing: 0
+
+                    // Title
+                    Text {
+                        Layout.fillWidth: true
+                        Layout.topMargin: Theme.scaled(20)
+                        Layout.bottomMargin: Theme.scaled(15)
+                        text: TranslationManager.translate("settings.bluetooth.addWifiScaleTitle", "Add WiFi Scale")
+                        color: Theme.textColor
+                        font.pixelSize: Theme.scaled(16)
+                        font.bold: true
+                        horizontalAlignment: Text.AlignHCenter
+                    }
+
+                    // Instructions
+                    Text {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Theme.scaled(20)
+                        Layout.rightMargin: Theme.scaled(20)
+                        text: TranslationManager.translate("settings.bluetooth.addWifiScaleInstructions",
+                              "Enter the scale's IP address or name.")
+                        color: Theme.textColor
+                        font.pixelSize: Theme.scaled(14)
+                        wrapMode: Text.Wrap
+                    }
+
+                    // IP / name input
+                    StyledTextField {
+                        id: wifiScaleHostField
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Theme.scaled(20)
+                        Layout.rightMargin: Theme.scaled(20)
+                        Layout.topMargin: Theme.scaled(12)
+                        placeholder: TranslationManager.translate("settings.bluetooth.addWifiScalePlaceholder", "192.168.1.50 or hds.local")
+                        accessibleName: TranslationManager.translate("settings.bluetooth.addWifiScaleField", "WiFi scale IP address or name")
+                        inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
+                        Keys.onReturnPressed: addWifiScaleDialog.submitWifiScale()
+                        Keys.onEnterPressed: addWifiScaleDialog.submitWifiScale()
+                    }
+
+                    // Buttons row
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.topMargin: Theme.scaled(20)
+                        Layout.bottomMargin: Theme.scaled(15)
+                        Layout.leftMargin: Theme.scaled(20)
+                        Layout.rightMargin: Theme.scaled(20)
+                        spacing: Theme.scaled(12)
+
+                        Item { Layout.fillWidth: true }
+
+                        AccessibleButton {
+                            text: TranslationManager.translate("common.cancel", "Cancel")
+                            accessibleName: TranslationManager.translate("common.cancel", "Cancel")
+                            subtle: true
+                            onClicked: addWifiScaleDialog.close()
+                        }
+
+                        AccessibleButton {
+                            text: TranslationManager.translate("settings.bluetooth.connect", "Connect")
+                            accessibleName: TranslationManager.translate("settings.bluetooth.addWifiScaleConnect", "Connect to WiFi scale")
+                            primary: true
+                            enabled: wifiScaleHostField.text.trim().length > 0
+                            onClicked: addWifiScaleDialog.submitWifiScale()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     RowLayout {
         anchors.fill: parent
         spacing: Theme.spacingMedium
@@ -1365,6 +1490,27 @@ Item {
                             fallback: "No devices found"
                             visible: parent.count === 0
                             color: Theme.textSecondaryColor
+                        }
+                    }
+
+                    // Manual WiFi-scale entry — a quiet fallback for when mDNS
+                    // discovery doesn't surface the scale. Rarely needed, so it's
+                    // a low-emphasis link rather than a button next to Scan.
+                    Tr {
+                        Layout.fillWidth: true
+                        key: "settings.bluetooth.addWifiScaleLink"
+                        fallback: "Scale not found? Add a WiFi scale by IP…"
+                        color: Theme.accentColor
+                        font.pixelSize: Theme.scaled(12)
+                        horizontalAlignment: Text.AlignHCenter
+                        topPadding: Theme.scaled(8)
+                        bottomPadding: Theme.scaled(4)
+                        Accessible.ignored: true  // AccessibleMouseArea carries the a11y node
+
+                        AccessibleMouseArea {
+                            anchors.fill: parent
+                            accessibleName: TranslationManager.translate("settings.bluetooth.addWifiScaleAccessible", "Add a WiFi scale by IP address or name")
+                            onAccessibleClicked: addWifiScaleDialog.open()
                         }
                     }
 

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -462,6 +462,33 @@ void BLEManager::connectToScale(const QString& address) {
     qWarning() << "Scale not found in discovered list:" << address;
 }
 
+void BLEManager::connectToWifiScale(const QString& hostnameOrIp) {
+    QString host = hostnameOrIp.trimmed();
+    if (host.isEmpty()) return;
+
+    // A bare name with no dot is an mDNS hostname missing its suffix — append
+    // ".local" so it resolves (matches the discovery default "hds.local"). IPs
+    // and already-dotted/qualified names pass through unchanged.
+    if (!host.contains(QLatin1Char('.')))
+        host += QStringLiteral(".local");
+
+    appendScaleLog(QString("Connecting to WiFi scale at %1...").arg(host));
+
+    // Drop any currently-connected scale first: main.cpp's scaleDiscovered
+    // handler early-returns while a scale is connected. Its disconnectScaleRequested
+    // handler runs synchronously and clears m_scaleDevice before we emit below.
+    if (m_scaleDevice && m_scaleDevice->isConnected())
+        emit disconnectScaleRequested();
+
+    // Same connect path as a discovered WiFi scale (connectToScale's wifi branch),
+    // minus the discovered-list lookup: set the pending hostname and emit
+    // scaleDiscovered with the WiFi type. main.cpp creates the DecentScaleWifi
+    // driver, wires the IP-cache callbacks, dials connectToHost(host), and on a
+    // successful connect saves it to Known Devices + as the primary scale.
+    m_pendingWifiHostname = host;
+    emit scaleDiscovered(QBluetoothDeviceInfo{}, QStringLiteral("decent-wifi"));
+}
+
 void BLEManager::connectToSavedScale() {
     // Switch the live connection to the current saved primary (the caller sets it
     // via setSavedScaleAddress immediately before). The Known Devices picker uses

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -472,7 +472,7 @@ void BLEManager::connectToWifiScale(const QString& hostnameOrIp) {
     if (!host.contains(QLatin1Char('.')))
         host += QStringLiteral(".local");
 
-    appendScaleLog(QString("Connecting to WiFi scale at %1...").arg(host));
+    appendScaleLog(QString("Adding WiFi scale at %1...").arg(host));
 
     // Drop any currently-connected scale first: main.cpp's scaleDiscovered
     // handler early-returns while a scale is connected. Its disconnectScaleRequested
@@ -480,11 +480,20 @@ void BLEManager::connectToWifiScale(const QString& hostnameOrIp) {
     if (m_scaleDevice && m_scaleDevice->isConnected())
         emit disconnectScaleRequested();
 
-    // Same connect path as a discovered WiFi scale (connectToScale's wifi branch),
-    // minus the discovered-list lookup: set the pending hostname and emit
-    // scaleDiscovered with the WiFi type. main.cpp creates the DecentScaleWifi
-    // driver, wires the IP-cache callbacks, dials connectToHost(host), and on a
-    // successful connect saves it to Known Devices + as the primary scale.
+    // Arm the connection timer so a wrong/unreachable host is caught by
+    // onScaleConnectionTimeout. WiFi socket errors are otherwise log-only (#1253),
+    // so without this a bad address fails with NO user feedback. m_manualWifiConnect
+    // makes that timeout report "Not found" directly instead of starting a WiFi→BLE
+    // fallback scan — the user asked for a specific WiFi address, so we don't
+    // silently switch transports. Then take the same emit path as a discovered WiFi
+    // scale (connectToScale's wifi branch), minus the discovered-list lookup: set
+    // the pending hostname and emit scaleDiscovered with the WiFi type. main.cpp
+    // creates the DecentScaleWifi driver, wires the IP-cache callbacks, dials
+    // connectToHost(host), and records it in Known Devices + as primary when the
+    // connect starts (as with any scale connect — not gated on connect success).
+    m_manualWifiConnect = true;
+    m_wifiFallbackToBleActive = false;
+    m_scaleConnectionTimer->start();
     m_pendingWifiHostname = host;
     emit scaleDiscovered(QBluetoothDeviceInfo{}, QStringLiteral("decent-wifi"));
 }
@@ -963,6 +972,7 @@ void BLEManager::onScaleConnectedChanged() {
         m_directConnectInProgress = false;
         m_directConnectAddress.clear();
         m_wifiFallbackToBleActive = false;  // Reset for the next saved-scale cycle
+        m_manualWifiConnect = false;        // Manual WiFi add resolved (connected)
         m_lastScanErrorShown.clear();       // Healthy state — allow a future fresh scan error to pop again
         m_anyBleSuccessThisSession = true;  // Permission proven good (WiFi scales hit this too — see note below)
         m_flowScaleFallbackEmitted = false;  // Allow dialog again if scale disconnects and reconnect fails
@@ -989,14 +999,20 @@ void BLEManager::onScaleConnectionTimeout() {
         return;  // Connection raced in — nothing to do.
     }
 
+    // Consume the manual-add marker: a manually-typed WiFi address reports
+    // "Not found" directly (below) rather than silently switching to a BLE scan.
+    const bool manualWifiAttempt = m_manualWifiConnect;
+    m_manualWifiConnect = false;
+
     qWarning() << "BLEManager: Scale connection timeout - not found";
 
     // WiFi-saved scale that didn't connect → fall back to a BLE scan for the
     // same physical scale family. Don't go straight to FlowScale yet — we owe
     // the user one more reasonable attempt before giving up. Only run the
     // fallback once per saved-scale cycle (the `!m_wifiFallbackToBleActive`
-    // guard prevents a second fallback if the BLE scan itself times out).
-    if (!m_wifiFallbackToBleActive
+    // guard prevents a second fallback if the BLE scan itself times out). A
+    // manual "Add WiFi Scale" attempt opts out — it surfaces "Not found" instead.
+    if (!manualWifiAttempt && !m_wifiFallbackToBleActive
             && m_savedScaleAddress.startsWith(QStringLiteral("wifi:"), Qt::CaseInsensitive)) {
         beginWifiFallbackToBleScan();
         return;
@@ -1445,6 +1461,10 @@ void BLEManager::tryDirectConnectToScale() {
         qDebug() << "BLEManager: tryDirectConnectToScale - scale already connected";
         return;
     }
+
+    // This is a saved-scale (re)connect, not a manual "Add WiFi Scale" attempt —
+    // so a timeout here should take the normal WiFi→BLE fallback path.
+    m_manualWifiConnect = false;
 
     // Direct wake strategy:
     // 1. Try direct connection to saved address (may wake sleeping scales that respond to connect requests)

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -335,10 +335,13 @@ public:
     // Connect to a WiFi scale by a manually-entered IP or mDNS name (the "Add
     // WiFi Scale" dialog), without requiring it to be in the discovered list. A
     // bare name with no dot gets ".local" appended (matching the discovery
-    // default "hds.local"); IPs and dotted names pass through. Drives the same
-    // path discovered WiFi scales use — on a successful connect main.cpp saves it
-    // to Known Devices and as the primary scale; a failed connect surfaces an
-    // error and saves nothing.
+    // default "hds.local"); IPs and dotted names pass through. Arms the connection
+    // timer so a wrong/unreachable host fails visibly ("Not found" + FlowScale
+    // notice) instead of silently — WiFi socket errors are otherwise log-only
+    // (#1253). Unlike a saved WiFi scale this does NOT fall back to a BLE scan on
+    // failure (the user asked for a specific WiFi address). As with any scale
+    // connect, main.cpp records it in Known Devices + as primary when the connect
+    // is initiated, not on success.
     Q_INVOKABLE void connectToWifiScale(const QString& hostnameOrIp);
     // Switch the LIVE connection to the current saved primary scale (set via
     // setSavedScaleAddress just before calling). If a scale is connected it is
@@ -491,6 +494,13 @@ private:
     // auto-connect to a discovered Decent BLE scale even though the saved
     // address is a WiFi one. Cleared once a scale connects.
     bool m_wifiFallbackToBleActive = false;
+    // True while a manually-entered WiFi scale (connectToWifiScale, the "Add WiFi
+    // Scale" dialog) connect attempt is pending. Tells onScaleConnectionTimeout to
+    // report "Not found" directly instead of starting a WiFi→BLE fallback scan —
+    // the user asked for a specific WiFi address, so we don't silently switch
+    // transports. Set when the attempt starts; cleared on connect success, on
+    // timeout (consumed), and reset when a non-manual reconnect begins.
+    bool m_manualWifiConnect = false;
     // Debounces user-visible scan-error popups. Without this, repeated scan
     // attempts (refractometer auto-reconnect ticks, scale reconnect retries)
     // would re-fire the same error toast indefinitely. We pop a given error

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -332,6 +332,14 @@ public:
     Q_INVOKABLE QBluetoothDeviceInfo getScaleDeviceInfo(const QString& address) const;
     Q_INVOKABLE QString getScaleType(const QString& address) const;
     Q_INVOKABLE void connectToScale(const QString& address);  // Manual scale selection
+    // Connect to a WiFi scale by a manually-entered IP or mDNS name (the "Add
+    // WiFi Scale" dialog), without requiring it to be in the discovered list. A
+    // bare name with no dot gets ".local" appended (matching the discovery
+    // default "hds.local"); IPs and dotted names pass through. Drives the same
+    // path discovered WiFi scales use — on a successful connect main.cpp saves it
+    // to Known Devices and as the primary scale; a failed connect surfaces an
+    // error and saves nothing.
+    Q_INVOKABLE void connectToWifiScale(const QString& hostnameOrIp);
     // Switch the LIVE connection to the current saved primary scale (set via
     // setSavedScaleAddress just before calling). If a scale is connected it is
     // disconnected first, then the saved primary is direct-woken (BLE) /


### PR DESCRIPTION
## Summary
- Adds a quiet **"Scale not found? Add a WiFi scale by IP…"** link below the discovered-devices list on the Connections settings page. It opens a small dialog to enter an **IP address or mDNS name**.
- A **rarely-used fallback** for when mDNS discovery doesn't surface the WiFi scale (Half Decent Scale is dual-transport BLE/WiFi) — deliberately low-prominence (a link, not a button competing with "Scan for Devices").

## Behavior
- **Success** → the scale connects, the status line shows **"Connected"**, and — like every scale connect — it is recorded in Known Devices and set as the primary scale.
- **Failure** (wrong/unreachable host) → the connection timer fires and the status line shows **"Not found"** with the FlowScale notice. WiFi socket errors are otherwise log-only (#1253), so arming the timer is what makes failures visible.
- A manual add does **not** fall back to a BLE scan (unlike a saved WiFi scale) — it targets a specific WiFi address, so it reports "Not found" rather than silently switching transports.

## Details
- **C++** (`src/ble/blemanager.{h,cpp}`): `connectToWifiScale()` normalizes input (a bare name with no dot → `<name>.local`), drops any current scale, **arms `m_scaleConnectionTimer`**, and emits `scaleDiscovered(default, "decent-wifi")` so `main.cpp`'s existing handler creates the `DecentScaleWifi` driver, wires the IP-cache callbacks, and dials `connectToHost()`. An `m_manualWifiConnect` marker (set on the attempt, consumed on timeout, cleared on connect, reset on a normal reconnect) tells `onScaleConnectionTimeout` to report "Not found" instead of starting the WiFi→BLE fallback.
- **QML** (`SettingsConnectionsTab.qml`): a low-emphasis `Tr` link with `AccessibleMouseArea`, plus a modal `Dialog` (single `StyledTextField`, Cancel/Connect; Enter submits; Connect disabled until non-empty; `KeyboardAwareContainer` for soft-keyboard handling).

## Review notes
Reviewed via `/pr-review-toolkit:review-pr` (code quality, comments, silent failures). The review caught a real **silent-failure** — `connectToWifiScale` didn't arm the connection timer, so a bad host gave no feedback — fixed in the second commit. It also flagged a doc comment that wrongly claimed the scale is "saved only on success"; corrected (the save is eager on connect-initiate, matching the discovered-scale path). **Known limitation:** a typo'd host is still recorded as primary (same as tapping a discovered scale that later goes offline) — candidate for a follow-up if it proves annoying.

## Test plan
- [ ] Compiles cleanly (verified locally via Qt Creator — 0 errors/warnings).
- [ ] On a tablet: with the WiFi scale powered, tap the link → enter its IP → Connect → scale connects, shows "Connected", appears under Known Devices as primary.
- [ ] Enter an mDNS name (`hds.local`, and a bare `hds`) → connects via resolution.
- [ ] Enter a bad/unreachable IP → after the connection timeout, status shows **"Not found"** + FlowScale notice; **no** BLE scan is started; no stray scale grabbed.
- [ ] Soft keyboard does not cover the input field; Cancel / tap-outside / Esc dismiss without connecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)