### PR TITLE
Eliminate orphaned known scales

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1125,9 +1125,7 @@ Item {
                                         if (scales[i].isPrimary) {
                                             BLEManager.clearSavedScale()
                                             Settings.removeKnownScale(scales[i].address)
-                                            // removeKnownScale auto-promotes the next
-                                            // remaining scale (if any) to primary. Sync
-                                            // BLEManager to the new primary and reconnect.
+                                            // Reconnect BLEManager to whichever scale is now primary.
                                             var remaining = Settings.knownScales
                                             for (var j = 0; j < remaining.length; j++) {
                                                 if (remaining[j].isPrimary) {

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1125,6 +1125,19 @@ Item {
                                         if (scales[i].isPrimary) {
                                             BLEManager.clearSavedScale()
                                             Settings.removeKnownScale(scales[i].address)
+                                            // removeKnownScale auto-promotes the next
+                                            // remaining scale (if any) to primary. Sync
+                                            // BLEManager to the new primary and reconnect.
+                                            var remaining = Settings.knownScales
+                                            for (var j = 0; j < remaining.length; j++) {
+                                                if (remaining[j].isPrimary) {
+                                                    BLEManager.setSavedScaleAddress(remaining[j].address,
+                                                                                    remaining[j].type,
+                                                                                    remaining[j].name)
+                                                    BLEManager.connectToSavedScale()
+                                                    break
+                                                }
+                                            }
                                             return
                                         }
                                     }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -247,37 +247,36 @@ Settings::Settings(QObject* parent)
         m_settings.setValue("knownScales/migrated", true);
     }
 
-    // Orphan-scale invariant: every entry in knownScales must be selectable
-    // (i.e. exactly one is primary). An orphan — a stored scale with no
-    // matching primaryAddress — is invisible in the Known Devices picker AND
-    // filtered out of the discovery list, so the user can't reach it. Older
-    // versions could leave one behind by clearing primary on remove without
-    // promoting a replacement. Heal it here on launch.
+    // Invariant: if knownScales is non-empty, primaryAddress must match one
+    // of its entries. An orphan (stored entry with no matching primary) is
+    // invisible in the Known Devices picker AND filtered out of discovery,
+    // so the user can't reach it. Heal on launch.
     {
         const qsizetype scalesCount = m_settings.beginReadArray("knownScales/scales");
-        QString firstAddress, firstType, firstName;
+        QString promoteAddress, promoteType, promoteName;
         QSet<QString> addresses;
         for (qsizetype i = 0; i < scalesCount; ++i) {
             m_settings.setArrayIndex(static_cast<int>(i));
             const QString a = m_settings.value("address").toString();
+            if (a.isEmpty()) continue;
             addresses.insert(a.toLower());
-            if (i == 0) {
-                firstAddress = a;
-                firstType = m_settings.value("type").toString();
-                firstName = m_settings.value("name").toString();
+            if (promoteAddress.isEmpty()) {
+                promoteAddress = a;
+                promoteType = m_settings.value("type").toString();
+                promoteName = m_settings.value("name").toString();
             }
         }
         m_settings.endArray();
 
-        if (scalesCount > 0) {
+        if (!promoteAddress.isEmpty()) {
             const QString primary = m_settings.value("knownScales/primaryAddress").toString();
             if (primary.isEmpty() || !addresses.contains(primary.toLower())) {
-                m_settings.setValue("knownScales/primaryAddress", firstAddress);
-                m_settings.setValue("scale/address", firstAddress);
-                m_settings.setValue("scale/type", firstType);
-                m_settings.setValue("scale/name", firstName);
+                m_settings.setValue("knownScales/primaryAddress", promoteAddress);
+                m_settings.setValue("scale/address", promoteAddress);
+                m_settings.setValue("scale/type", promoteType);
+                m_settings.setValue("scale/name", promoteName);
                 qDebug() << "Settings: Repaired orphaned known scale — promoted"
-                         << firstName << firstAddress << "to primary";
+                         << promoteName << promoteAddress << "to primary";
             }
         }
     }
@@ -445,10 +444,7 @@ void Settings::removeKnownScale(const QString& address) {
 
     if (wasPrimary) {
         if (!scales.isEmpty()) {
-            // Auto-promote the first remaining scale. Every entry in
-            // knownScales must be selectable — otherwise the removed primary
-            // leaves an orphan that the picker can't reach and that the
-            // discovery list silently filters out.
+            // Auto-promote so knownScales never holds an unreachable orphan.
             QVariantMap next = scales.first().toMap();
             const QString nextAddr = next["address"].toString();
             m_settings.setValue("knownScales/primaryAddress", nextAddr);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -443,20 +443,22 @@ void Settings::removeKnownScale(const QString& address) {
     writeKnownScales(scales);
 
     if (wasPrimary) {
-        if (!scales.isEmpty()) {
-            // Auto-promote so knownScales never holds an unreachable orphan.
-            QVariantMap next = scales.first().toMap();
-            const QString nextAddr = next["address"].toString();
-            m_settings.setValue("knownScales/primaryAddress", nextAddr);
-            setScaleAddress(nextAddr);
-            setScaleType(next["type"].toString());
-            setScaleName(next["name"].toString());
-        } else {
-            m_settings.setValue("knownScales/primaryAddress", QString());
-            setScaleAddress(QString());
-            setScaleType(QString());
-            setScaleName(QString());
+        // Auto-promote the first remaining entry with a non-empty address so
+        // knownScales never holds an unreachable orphan.
+        QString nextAddr, nextType, nextName;
+        for (const QVariant& v : scales) {
+            QVariantMap s = v.toMap();
+            const QString a = s["address"].toString();
+            if (a.isEmpty()) continue;
+            nextAddr = a;
+            nextType = s["type"].toString();
+            nextName = s["name"].toString();
+            break;
         }
+        m_settings.setValue("knownScales/primaryAddress", nextAddr);
+        setScaleAddress(nextAddr);
+        setScaleType(nextType);
+        setScaleName(nextName);
         emit knownScalesChanged();
     }
 }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -26,6 +26,7 @@
 #include <QGuiApplication>
 #include <QStyleHints>
 #include <QDesktopServices>
+#include <QSet>
 
 #ifdef Q_OS_IOS
 #include "screensaver/iosbrightness.h"
@@ -246,6 +247,41 @@ Settings::Settings(QObject* parent)
         m_settings.setValue("knownScales/migrated", true);
     }
 
+    // Orphan-scale invariant: every entry in knownScales must be selectable
+    // (i.e. exactly one is primary). An orphan — a stored scale with no
+    // matching primaryAddress — is invisible in the Known Devices picker AND
+    // filtered out of the discovery list, so the user can't reach it. Older
+    // versions could leave one behind by clearing primary on remove without
+    // promoting a replacement. Heal it here on launch.
+    {
+        const qsizetype scalesCount = m_settings.beginReadArray("knownScales/scales");
+        QString firstAddress, firstType, firstName;
+        QSet<QString> addresses;
+        for (qsizetype i = 0; i < scalesCount; ++i) {
+            m_settings.setArrayIndex(static_cast<int>(i));
+            const QString a = m_settings.value("address").toString();
+            addresses.insert(a.toLower());
+            if (i == 0) {
+                firstAddress = a;
+                firstType = m_settings.value("type").toString();
+                firstName = m_settings.value("name").toString();
+            }
+        }
+        m_settings.endArray();
+
+        if (scalesCount > 0) {
+            const QString primary = m_settings.value("knownScales/primaryAddress").toString();
+            if (primary.isEmpty() || !addresses.contains(primary.toLower())) {
+                m_settings.setValue("knownScales/primaryAddress", firstAddress);
+                m_settings.setValue("scale/address", firstAddress);
+                m_settings.setValue("scale/type", firstType);
+                m_settings.setValue("scale/name", firstName);
+                qDebug() << "Settings: Repaired orphaned known scale — promoted"
+                         << firstName << firstAddress << "to primary";
+            }
+        }
+    }
+
     // Theme initial state is now resolved inside SettingsTheme
 
     // Generate MCP API key on first run (avoids const_cast in the getter)
@@ -408,13 +444,23 @@ void Settings::removeKnownScale(const QString& address) {
     writeKnownScales(scales);
 
     if (wasPrimary) {
-        // Clear primary — if there are remaining scales, don't auto-promote
-        m_settings.setValue("knownScales/primaryAddress", QString());
-        // Also clear legacy scale/address so existing code stays in sync
-        setScaleAddress(QString());
-        setScaleType(QString());
-        setScaleName(QString());
-        // Re-emit so QML sees the cleared primaryScaleAddress
+        if (!scales.isEmpty()) {
+            // Auto-promote the first remaining scale. Every entry in
+            // knownScales must be selectable — otherwise the removed primary
+            // leaves an orphan that the picker can't reach and that the
+            // discovery list silently filters out.
+            QVariantMap next = scales.first().toMap();
+            const QString nextAddr = next["address"].toString();
+            m_settings.setValue("knownScales/primaryAddress", nextAddr);
+            setScaleAddress(nextAddr);
+            setScaleType(next["type"].toString());
+            setScaleName(next["name"].toString());
+        } else {
+            m_settings.setValue("knownScales/primaryAddress", QString());
+            setScaleAddress(QString());
+            setScaleType(QString());
+            setScaleName(QString());
+        }
         emit knownScalesChanged();
     }
 }


### PR DESCRIPTION
## Summary

- Forgetting the primary scale used to leave any other known scales as orphans: no primary set, picker hidden, and the discovery list silently filtered them out — so the user couldn't reach the orphan or rediscover it via scan.
- `Settings::removeKnownScale` now auto-promotes the first remaining scale to primary when the current primary is removed. The QML Forget handler syncs `BLEManager` to the new primary and calls `connectToSavedScale()`, so the live connection follows the promotion.
- Startup invariant repair: if `knownScales` is non-empty but `primaryAddress` is empty or doesn't point into the list, the first entry is promoted on launch. This heals any orphan persisted by older builds (e.g. Jeff's current state where a BT scale was hidden after forgetting the WiFi primary).

## Why it matters

Repro: pair a BT scale, pair a WiFi scale (becomes primary), tap Forget. Before this change, BT scale stays in `knownScales` with no primary; Known Devices shows "No scale selected" with no chevron; a fresh scan finds the BT scale but the discovery list filters it as "known". The user has no way to recover except clearing app data.

After: tap Forget → BT scale auto-promotes to primary, Known Devices shows "Decent Scale", you can use it or tap Forget again to remove it cleanly (then a scan rediscovers it). Existing orphan states are repaired automatically on next launch.

## Test plan

- [ ] Build on Android, verify it compiles
- [ ] With current orphan state (BT scale hidden): launch app → BT scale appears as primary in Known Devices (look for `Settings: Repaired orphaned known scale` log line)
- [ ] Pair two scales (BT + WiFi), Forget primary → other scale becomes primary and connects
- [ ] Pair one scale, Forget → Known Devices section hides, scan rediscovers the scale
- [ ] No regression in WiFi→BLE fallback path (saved primary preserved when `m_wifiFallbackToBleActive`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)