### PR TITLE
Gate USB Decent scale on the Serial USB toggle

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -657,14 +657,14 @@ Item {
                         Layout.fillWidth: true
                         spacing: 0
                         Text {
-                            text: TranslationManager.translate("connections.usb.serialLabel", "Serial USB (DE1 USB-C)")
+                            text: TranslationManager.translate("connections.usb.serialLabel", "Serial USB (DE1 & Scale)")
                             font.pixelSize: Theme.scaled(14)
                             color: Theme.textColor
                             Accessible.ignored: true
                         }
                         Text {
                             Layout.fillWidth: true
-                            text: TranslationManager.translate("connections.usb.serialDesc", "Poll for USB-connected DE1. Disable to save battery.")
+                            text: TranslationManager.translate("connections.usb.serialDesc", "Poll for a USB-connected DE1 or Half Decent Scale. Disable to save battery, or to use the scale over Bluetooth/WiFi instead.")
                             color: Theme.textSecondaryColor
                             font.pixelSize: Theme.scaled(12)
                             wrapMode: Text.WordWrap
@@ -676,7 +676,7 @@ Item {
 
                     StyledSwitch {
                         checked: Settings.usbSerialEnabled
-                        accessibleName: "Enable serial USB connection for DE1"
+                        accessibleName: "Enable serial USB connection for DE1 and scale"
                         onToggled: Settings.usbSerialEnabled = checked
                     }
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1081,17 +1081,26 @@ int main(int argc, char *argv[])
     checkpoint("Managers wired");
 
 #ifndef Q_OS_IOS
-    // USB serial polling for DE1 is opt-in (off by default) to avoid the 2 s polling
-    // battery drain on devices that never use a USB-C cable to connect to the DE1.
-    if (settings.usbSerialEnabled())
+    // USB serial is opt-in (off by default) to avoid the 2 s polling battery
+    // drain on devices that never use a USB-C cable. The toggle gates BOTH the
+    // DE1 (usbManager) and the Half Decent Scale (usbScaleManager): when off,
+    // neither polls, and a USB scale that is already connected is released so it
+    // falls back to BLE/WiFi/FlowScale — otherwise a USB-tethered scale would
+    // pre-empt testing the same scale over Bluetooth or WiFi.
+    if (settings.usbSerialEnabled()) {
         usbManager.startPolling();
+        usbScaleManager.startPolling();
+    }
     QObject::connect(&settings, &Settings::usbSerialEnabledChanged, [&]() {
-        if (settings.usbSerialEnabled())
+        if (settings.usbSerialEnabled()) {
             usbManager.startPolling();
-        else
+            usbScaleManager.startPolling();
+        } else {
             usbManager.stopPolling();
+            usbScaleManager.stopPolling();
+            usbScaleManager.disconnectScale();  // release a live USB scale → fall back to BLE/WiFi
+        }
     });
-    usbScaleManager.startPolling();
 #endif
 
     AccessibilityManager accessibilityManager;

--- a/src/usb/usbscalemanager.cpp
+++ b/src/usb/usbscalemanager.cpp
@@ -58,6 +58,25 @@ void UsbScaleManager::stopPolling()
 #endif
 }
 
+void UsbScaleManager::disconnectScale()
+{
+    if (!m_scale) return;
+
+    qDebug() << "[USB Scale] Releasing connected scale (USB serial disabled)";
+    emit logMessage(QStringLiteral("[USB Scale] Released (USB serial disabled)"));
+
+    m_scale->close();
+    m_scale->deleteLater();
+    m_scale = nullptr;
+#ifdef Q_OS_ANDROID
+    m_androidPermissionRequested = false;
+    AndroidUsbScaleHelper::close();
+#endif
+
+    emit scaleLost();
+    emit scaleConnectedChanged();
+}
+
 // ---------------------------------------------------------------------------
 // Port polling — dispatches to platform-specific implementation
 // ---------------------------------------------------------------------------

--- a/src/usb/usbscalemanager.h
+++ b/src/usb/usbscalemanager.h
@@ -36,6 +36,11 @@ public:
 
     void startPolling();
     void stopPolling();
+    // Tear down a currently-connected USB scale (if any) and emit scaleLost so
+    // consumers fall back to BLE/WiFi/FlowScale. Used when USB serial is disabled
+    // mid-session; no-op if no scale is connected. (stopPolling only halts
+    // discovery — it does not release an already-connected scale.)
+    void disconnectScale();
 
 signals:
     void scaleConnectedChanged();


### PR DESCRIPTION
## Summary
- The **Serial USB toggle** now gates the USB Half Decent Scale, not just the DE1. Previously `usbScaleManager.startPolling()` ran unconditionally, so a USB-tethered scale always took over via USB even with the toggle off — you couldn't test the same scale over Bluetooth/WiFi without unplugging.
- The USB scale now polls **only when the toggle is on** (matching the DE1's existing `usbManager` gating).
- **Disabling the toggle mid-session releases a live USB scale** — new `UsbScaleManager::disconnectScale()` tears it down and emits `scaleLost`, so the existing handler falls back to BLE / WiFi / FlowScale. (`stopPolling()` alone only halts discovery; it doesn't release a connected scale.)
- Updated the toggle's label/description/accessibility text to reflect it covers the DE1 **and** the scale.

## Test plan
- [x] Builds clean (Qt 6.11.1, macOS, 0 warnings)
- [ ] Desktop: with a Half Decent Scale on USB, turn Serial USB **off** → USB scale releases; connect the same scale over BT/WiFi
- [ ] Turn it back **on** → USB scale reconnects
- [ ] DE1-over-USB gating unchanged

Note: no unit test — `UsbScaleManager` is serial/JNI hardware-bound with no existing test harness; this mirrors the established DE1 `usbManager` toggle pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)