### PR TITLE
Rename WiFi scale to Half Decent Scale (WiFi)

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -1417,7 +1417,7 @@ void BLEManager::ensureWifiDiscovery() {
                 ScaleEntry entry;
                 entry.type = QStringLiteral("decent-wifi");
                 entry.transport = QStringLiteral("wifi");
-                entry.name = QStringLiteral("Decent Scale (WiFi)");
+                entry.name = QStringLiteral("Half Decent Scale (WiFi)");
                 entry.address = address;
                 m_scales.append(entry);
                 qDebug() << "[BLE] Added WiFi scale to discovered list; m_scales count=" << m_scales.size();

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -130,7 +130,7 @@ private:
     // or disconnect superseded it while the worker thread was in flight.
     int m_resolveGeneration = 0;
 
-    QString m_name = QStringLiteral("Decent Scale (WiFi)");
+    QString m_name = QStringLiteral("Half Decent Scale (WiFi)");
     QString m_firmwareVersion;   // cached per-connect; cleared on disconnect
     int m_loggedProtoVersion = -1;  // protocol version last logged this connect; reset on disconnect
     // One sample of each distinct non-snapshot frame "type" is logged per

--- a/src/ble/scales/scalefactory.cpp
+++ b/src/ble/scales/scalefactory.cpp
@@ -181,7 +181,7 @@ std::unique_ptr<ScaleDevice> ScaleFactory::createScale(const QBluetoothDeviceInf
 QString ScaleFactory::scaleTypeName(ScaleType type) {
     switch (type) {
         case ScaleType::DecentScale: return "Decent Scale";
-        case ScaleType::DecentScaleWifi: return "Decent Scale (WiFi)";
+        case ScaleType::DecentScaleWifi: return "Half Decent Scale (WiFi)";
         case ScaleType::Acaia: return "Acaia";
         case ScaleType::AcaiaPyxis: return "Acaia Pyxis";
         case ScaleType::Felicita: return "Felicita";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1502,7 +1502,7 @@ int main(int argc, char *argv[])
         const QString hostname = isWifi ? bleManager.pendingWifiHostname() : QString();
         const QString deviceId = isWifi ? (QStringLiteral("wifi:") + hostname)
                                          : getDeviceIdentifier(device);
-        const QString displayName = isWifi ? QStringLiteral("Decent Scale (WiFi)")
+        const QString displayName = isWifi ? QStringLiteral("Half Decent Scale (WiFi)")
                                             : device.name();
         // Always track this scale in the known-scales list (useful for the
         // multi-scale picker and per-scale state).


### PR DESCRIPTION
## Summary
- Renames the WiFi transport of the Half Decent Scale from **"Decent Scale (WiFi)"** to **"Half Decent Scale (WiFi)"**, matching the USB label ("Half Decent Scale (USB)").
- Updated all four runtime sources of the name:
  - `DecentScaleWifi::m_name` (live driver name)
  - `BLEManager` discovered-scales entry
  - `main.cpp` known-scale display name (passed to `addKnownScale`)
  - `ScaleFactory::scaleTypeName`
- Existing persisted known-scale entries refresh their name on the next WiFi connect (`addKnownScale` dedups by address and updates the name).

## Test plan
- [x] Builds clean (Qt 6.11.1, macOS, 0 warnings)
- [ ] Connect the scale over WiFi → status badge, Known Scales list, and toasts show "Half Decent Scale (WiFi)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)