### PR TITLE
Make USB scale a selectable device (not auto-connecting)

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -18,6 +18,7 @@
 #include <QStandardPaths>
 #include <QDir>
 #include <QTextStream>
+#include <algorithm>
 #include <QDateTime>
 #include <QTcpSocket>
 
@@ -552,8 +553,17 @@ void BLEManager::connectToSavedScale() {
 
     // USB saved-scale switch: USB needs neither Bluetooth nor a direct-wake. Hand
     // off to UsbScaleManager (usbConnectRequested) and skip the BLE guards below.
-    // It connects only if the USB scale is currently available (plugged in).
     if (m_savedScaleAddress.startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
+        // Bail BEFORE dropping the live scale if the USB scale isn't currently
+        // plugged in: UsbScaleManager::connectToScale() no-ops when nothing is
+        // available, which would otherwise strand the user on FlowScale with no
+        // feedback. The USB entry is present in m_scales only while probe-confirmed.
+        const bool usbPresent = std::any_of(m_scales.cbegin(), m_scales.cend(),
+            [](const ScaleEntry& e) { return e.transport == QStringLiteral("usb"); });
+        if (!usbPresent) {
+            appendScaleLog(QStringLiteral("USB scale switch ignored — scale not plugged in"));
+            return;
+        }
         if (m_scaleDevice && m_scaleDevice->isConnected())
             emit disconnectScaleRequested();
         emit usbConnectRequested();

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -450,7 +450,12 @@ void BLEManager::connectToScale(const QString& address) {
             emit disconnectScaleRequested();
         }
 
-        if (entry.transport == QStringLiteral("wifi")) {
+        if (entry.transport == QStringLiteral("usb")) {
+            // USB connect is owned by UsbScaleManager: it creates + opens the
+            // UsbDecentScale and emits its own scaleDiscovered. Don't emit
+            // scaleDiscovered here (no QBluetoothDeviceInfo / factory path).
+            emit usbConnectRequested();
+        } else if (entry.transport == QStringLiteral("wifi")) {
             // Strip the "wifi:" prefix to get the bare hostname.
             m_pendingWifiHostname = address.mid(QStringLiteral("wifi:").size());
             emit scaleDiscovered(QBluetoothDeviceInfo{}, entry.type);
@@ -460,6 +465,45 @@ void BLEManager::connectToScale(const QString& address) {
         return;
     }
     qWarning() << "Scale not found in discovered list:" << address;
+}
+
+void BLEManager::setUsbScaleAvailable(bool available, const QString& name) {
+    // Synthetic USB scale row, mirroring the WiFi entry. Stable address so
+    // it can be the saved primary across plug/unplug and app restarts.
+    const QString kUsbAddress = QStringLiteral("usb:decent");
+
+    // Find any existing USB entry.
+    qsizetype existing = -1;
+    for (qsizetype i = 0; i < m_scales.size(); ++i) {
+        if (m_scales[i].transport == QStringLiteral("usb")) {
+            existing = i;
+            break;
+        }
+    }
+
+    if (available) {
+        if (existing >= 0) {
+            // Refresh the display name only.
+            if (m_scales[existing].name != name) {
+                m_scales[existing].name = name;
+                emit scalesChanged();
+            }
+            return;
+        }
+        ScaleEntry entry;
+        entry.type = QStringLiteral("decent-usb");
+        entry.transport = QStringLiteral("usb");
+        entry.name = name;
+        entry.address = kUsbAddress;
+        m_scales.append(entry);
+        appendScaleLog(QString("Found %1 (%2)").arg(entry.name, entry.address));
+        emit scalesChanged();
+    } else {
+        if (existing < 0) return;  // Nothing to remove.
+        m_scales.removeAt(existing);
+        appendScaleLog(QStringLiteral("USB scale unplugged"));
+        emit scalesChanged();
+    }
 }
 
 void BLEManager::connectToWifiScale(const QString& hostnameOrIp) {
@@ -505,6 +549,16 @@ void BLEManager::connectToSavedScale() {
     // the saved primary. Goes through tryDirectConnectToScale() — the direct-wake
     // path — so it works even when the chosen scale isn't in the discovered list.
     if (m_savedScaleAddress.isEmpty() || m_savedScaleType.isEmpty()) return;
+
+    // USB saved-scale switch: USB needs neither Bluetooth nor a direct-wake. Hand
+    // off to UsbScaleManager (usbConnectRequested) and skip the BLE guards below.
+    // It connects only if the USB scale is currently available (plugged in).
+    if (m_savedScaleAddress.startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
+        if (m_scaleDevice && m_scaleDevice->isConnected())
+            emit disconnectScaleRequested();
+        emit usbConnectRequested();
+        return;
+    }
 
     // Bail BEFORE dropping the working scale if the new connect can't proceed —
     // otherwise we'd disconnect the current scale and tryDirectConnectToScale()
@@ -1502,6 +1556,16 @@ void BLEManager::tryDirectConnectToScale() {
         m_scaleConnectionTimer->start();            // Fires onScaleConnectionTimeout if WiFi doesn't connect
         m_pendingWifiHostname = hostname;
         emit scaleDiscovered(QBluetoothDeviceInfo{}, QStringLiteral("decent-wifi"));
+        return;
+    }
+
+    // USB saved-scale path: NOT a BLE address — the USB scale is owned by
+    // UsbScaleManager and reconnects via main.cpp's usbScaleAvailable handler
+    // (which connects when the saved primary is "usb:decent"). Don't fall
+    // through to the BLE connect/scan below — "usb:decent" is not a MAC.
+    if (m_savedScaleAddress.startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
+        qDebug() << "BLEManager: tryDirectConnectToScale - saved scale is USB; "
+                    "reconnect handled by UsbScaleManager";
         return;
     }
 

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -357,6 +357,15 @@ public:
     ScaleDevice* scaleDevice() const { return m_scaleDevice; }
     void setScaleDevice(ScaleDevice* scale);
 
+    // Add (available==true) or remove (available==false) a synthetic USB scale
+    // entry in the discovered-scales list so it shows up as a selectable row,
+    // exactly like the WiFi synthetic entry. The entry uses the STABLE address
+    // "usb:decent" (transport "usb", type "decent-usb"). Selecting it routes
+    // through connectToScale()'s usb branch → usbConnectRequested(); the actual
+    // open is done by UsbScaleManager, not here. Driven by main.cpp from
+    // UsbScaleManager::usbScaleAvailable/Unavailable.
+    void setUsbScaleAvailable(bool available, const QString& name);
+
     // Scale address management
     Q_INVOKABLE void setSavedScaleAddress(const QString& address, const QString& type, const QString& name);
     Q_INVOKABLE void clearSavedScale();
@@ -412,6 +421,11 @@ signals:
     // and the routing hostname lives in pendingWifiHostname() — the main.cpp
     // handler reads it after the factory creates the scale.
     void scaleDiscovered(const QBluetoothDeviceInfo& device, const QString& type);
+    // Emitted when the user selects the synthetic USB scale entry (transport
+    // "usb") in the discovered list. Unlike BLE/WiFi this does NOT carry a
+    // device — the USB connect goes through UsbScaleManager::connectToScale(),
+    // which creates + opens the UsbDecentScale and emits its own scaleDiscovered.
+    void usbConnectRequested();
     void errorOccurred(const QString& error);
     void de1LogMessage(const QString& message);
     void scaleLogMessage(const QString& message);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1265,6 +1265,12 @@ int main(int argc, char *argv[])
             qDebug() << "Scale reconnect (startup): no saved address, skipping";
             return;
         }
+        // USB scales reconnect via UsbScaleManager (usbScaleAvailable), not this
+        // BLE/WiFi timer. Arming it would fire once and self-terminate at the
+        // timeout guard — skip arming entirely.
+        if (settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
+            return;
+        }
         if (scaleAutoReconnectSuppressed) {
             qDebug() << "Scale reconnect (startup): suppressed (keepScaleOn=false), skipping";
             return;
@@ -1689,7 +1695,9 @@ int main(int argc, char *argv[])
                 // re-arms the reconnect.
                 if (scaleAutoReconnectSuppressed) {
                     qDebug() << "Scale disconnect was deliberate (keepScaleOn=false) - auto-reconnect suppressed until DE1 wakes";
-                } else if (!settings.scaleAddress().isEmpty()) {
+                } else if (!settings.scaleAddress().isEmpty()
+                           && !settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
+                    // USB primary reconnects via UsbScaleManager, not this BLE/WiFi timer.
                     scaleReconnectAttempt = 0;
                     scaleReconnectTimer.start(reconnectDelays[0]);
                     qDebug() << "Scale reconnect: scheduled first retry in" << reconnectDelays[0] << "ms";
@@ -2638,8 +2646,10 @@ int main(int argc, char *argv[])
             scaleAutoReconnectSuppressed = false;
             if (physicalScale && physicalScale->isConnected()) {
                 qDebug() << "App resumed - scale still connected";
-            } else if (!settings.scaleAddress().isEmpty() && !scaleReconnectTimer.isActive()) {
-                // Scale disconnected while suspended - restart reconnect sequence
+            } else if (!settings.scaleAddress().isEmpty() && !scaleReconnectTimer.isActive()
+                       && !settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
+                // Scale disconnected while suspended - restart reconnect sequence.
+                // USB primary reconnects via UsbScaleManager, not this BLE/WiFi timer.
                 scaleReconnectAttempt = 0;
                 scaleReconnectTimer.start(reconnectDelays[0]);
                 qDebug() << "App resumed - starting scale reconnect sequence";
@@ -2717,7 +2727,9 @@ int main(int argc, char *argv[])
                 // sequence now that the DE1 is back.
                 qDebug() << "DE1 woke up - re-arming scale reconnect (keepScaleOn=false)";
                 scaleAutoReconnectSuppressed = false;
-                if (!scaleReconnectTimer.isActive()) {
+                // USB primary reconnects via UsbScaleManager, not this BLE/WiFi timer.
+                if (!scaleReconnectTimer.isActive()
+                    && !settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
                     scaleReconnectAttempt = 0;
                     scaleReconnectTimer.start(reconnectDelays[0]);
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1424,7 +1424,22 @@ int main(int argc, char *argv[])
 
     // Connect to any supported scale when discovered
     QObject::connect(&bleManager, &BLEManager::scaleDiscovered,
-                     [&physicalScale, &flowScale, &machineState, &mainController, &engine, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &scaleAutoReconnectSuppressed, &translationManager](const QBluetoothDeviceInfo& device, const QString& type) {
+                     [&physicalScale, &flowScale, &machineState, &mainController, &engine, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &scaleAutoReconnectSuppressed, &translationManager, &usbScaleManager](const QBluetoothDeviceInfo& device, const QString& type) {
+#ifndef Q_OS_IOS
+        // Tear down an active USB scale FIRST (before touching physicalScale).
+        // The single-scale invariant covers BLE/WiFi via physicalScale, but the
+        // USB scale lives in UsbScaleManager — without this, switching from a
+        // connected USB scale to BLE/WiFi would leave BOTH feeding weight into
+        // WeightProcessor/MainController. disconnectScale() keeps the USB scale
+        // AVAILABLE (it's still plugged in) — we're switching away, not losing it.
+        if (usbScaleManager.scale()) {
+            QObject::disconnect(usbScaleManager.scale(), &ScaleDevice::weightChanged,
+                                &mainController, &MainController::onScaleWeightChanged);
+            QObject::disconnect(usbScaleManager.scale(), &ScaleDevice::weightSampleReceived,
+                                &weightProcessor, &WeightProcessor::processWeight);
+            usbScaleManager.disconnectScale();
+        }
+#endif
         // Single-scale invariant: at most one physical scale is connected at a
         // time (a different scale type replaces the old one below, never runs
         // alongside it). This caps concurrent forced-HIGH BLE links at two —
@@ -1933,14 +1948,15 @@ int main(int argc, char *argv[])
         QObject::connect(usbScale, &ScaleDevice::weightSampleReceived,
                          &weightProcessor, &WeightProcessor::processWeight);
 
-        // Save USB scale as the active scale type (so Settings panel shows it)
-        settings.setScaleType(usbScale->name());
-        settings.setScaleName(usbScale->name());
-
-        // Register in the known-scales registry + as primary, exactly like BLE
-        // and WiFi, using the stable USB identifier "usb:decent". This makes the
-        // USB scale auto-reconnect on a future startup when it's still the saved
-        // primary (see the usbScaleAvailable handler below).
+        // Register in the known-scales registry + set as primary, using the
+        // stable USB identifier "usb:decent". addKnownScale + setPrimaryScale
+        // write the correct scale type ("decent-usb") and display name into
+        // Settings, so the Settings panel shows it and it auto-reconnects on a
+        // future startup when it's still the saved primary (see the
+        // usbScaleAvailable handler below). Note this ALWAYS sets the USB scale
+        // as primary — unlike the BLE/WiFi scaleDiscovered handler, which gates
+        // the primary write on the WiFi→BLE fallback flag. There is no USB
+        // fallback path, so selecting USB is always an explicit primary choice.
         const QString kUsbScaleAddress = QStringLiteral("usb:decent");
         const QString kUsbScaleType = QStringLiteral("decent-usb");
         const QString kUsbScaleName = QStringLiteral("Half Decent Scale (USB)");
@@ -1959,7 +1975,7 @@ int main(int argc, char *argv[])
     // When USB scale lost: fall back to FlowScale (or BLE scale if available)
     QObject::connect(&usbScaleManager, &UsbScaleManager::scaleLost,
                      [&physicalScale, &flowScale, &machineState, &mainController, &engine,
-                      &timingController, &weightProcessor, &usbScaleManager]() {
+                      &timingController, &weightProcessor, &usbScaleManager, &bleManager]() {
         // Disconnect the USB scale's weight signals
         if (usbScaleManager.scale()) {
             QObject::disconnect(usbScaleManager.scale(), &ScaleDevice::weightChanged,
@@ -1984,6 +2000,12 @@ int main(int argc, char *argv[])
             QObject::connect(&flowScale, &ScaleDevice::weightSampleReceived,
                              &weightProcessor, &WeightProcessor::processWeight);
             qDebug() << "[USB Scale] Lost — falling back to FlowScale";
+            // Surface a "scale disconnected" UI notice — same as the BLE/WiFi
+            // disconnect path (see the connectedChanged handler that emits this
+            // when a physical scale drops to FlowScale). Only on the FlowScale
+            // fallback: falling back to a still-connected BLE scale is a switch,
+            // not a disconnect, so it shouldn't flash a "disconnected" notice.
+            emit bleManager.scaleDisconnected();
         }
 
         // Notify MQTT

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1937,6 +1937,17 @@ int main(int argc, char *argv[])
         settings.setScaleType(usbScale->name());
         settings.setScaleName(usbScale->name());
 
+        // Register in the known-scales registry + as primary, exactly like BLE
+        // and WiFi, using the stable USB identifier "usb:decent". This makes the
+        // USB scale auto-reconnect on a future startup when it's still the saved
+        // primary (see the usbScaleAvailable handler below).
+        const QString kUsbScaleAddress = QStringLiteral("usb:decent");
+        const QString kUsbScaleType = QStringLiteral("decent-usb");
+        const QString kUsbScaleName = QStringLiteral("Half Decent Scale (USB)");
+        settings.addKnownScale(kUsbScaleAddress, kUsbScaleType, kUsbScaleName);
+        settings.setPrimaryScale(kUsbScaleAddress);
+        bleManager.setSavedScaleAddress(kUsbScaleAddress, kUsbScaleType, kUsbScaleName);
+
         // Notify MQTT
         if (mainController.mqttClient()) {
             mainController.mqttClient()->onScaleConnectedChanged(true);
@@ -1979,6 +1990,31 @@ int main(int argc, char *argv[])
         if (mainController.mqttClient()) {
             mainController.mqttClient()->onScaleConnectedChanged(false);
         }
+    });
+
+    // USB scale presence (probe-confirmed, NOT connected): list it as a
+    // selectable entry, exactly like a discovered BLE/WiFi scale. Auto-connect
+    // ONLY when the USB scale is the saved primary — otherwise just list it so
+    // the same scale can be tested over Bluetooth/WiFi.
+    QObject::connect(&usbScaleManager, &UsbScaleManager::usbScaleAvailable,
+                     [&bleManager, &usbScaleManager, &settings]() {
+        bleManager.setUsbScaleAvailable(true, QStringLiteral("Half Decent Scale (USB)"));
+        if (settings.scaleAddress() == QStringLiteral("usb:decent")) {
+            qDebug() << "[USB Scale] Available and is saved primary — auto-connecting";
+            usbScaleManager.connectToScale();
+        } else {
+            qDebug() << "[USB Scale] Available — listed as selectable (not auto-connecting)";
+        }
+    });
+    QObject::connect(&usbScaleManager, &UsbScaleManager::usbScaleUnavailable,
+                     [&bleManager]() {
+        bleManager.setUsbScaleAvailable(false, QStringLiteral("Half Decent Scale (USB)"));
+    });
+
+    // User selected the USB entry in the discovered list: connect it.
+    QObject::connect(&bleManager, &BLEManager::usbConnectRequested,
+                     [&usbScaleManager]() {
+        usbScaleManager.connectToScale();
     });
 
     // Forward USB scale manager log messages

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1219,6 +1219,16 @@ int main(int argc, char *argv[])
             qDebug() << "Scale reconnect: no saved scale address, stopping retries";
             return;
         }
+        // USB scales are owned by UsbScaleManager and reconnect via its
+        // usbScaleAvailable handler — NOT this BLE/WiFi direct-wake timer.
+        // tryDirectConnectToScale() early-returns for "usb:" addresses, so
+        // re-arming here would spin forever (and resetScaleConnectionState()
+        // below would needlessly stop the BLE connection timer each tick).
+        // Stop the timer when the saved scale is USB.
+        if (settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
+            qDebug() << "Scale reconnect: saved scale is USB — handled by UsbScaleManager, stopping retries";
+            return;
+        }
         qDebug() << "Scale reconnect: attempt" << (scaleReconnectAttempt + 1);
         // Only surface the bounded ramp in the user-visible scale log; the
         // 60s tail repeats forever, so logging it there would grow unbounded

--- a/src/usb/usbscalemanager.cpp
+++ b/src/usb/usbscalemanager.cpp
@@ -33,6 +33,63 @@ bool UsbScaleManager::isScaleConnected() const
     return m_scale != nullptr;
 }
 
+void UsbScaleManager::setScaleAvailable(bool available)
+{
+    if (m_scaleAvailable == available) return;
+    m_scaleAvailable = available;
+    if (available) {
+        emit usbScaleAvailable();
+    } else {
+        emit usbScaleUnavailable();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Connect on demand (selection / saved-primary auto-reconnect)
+// ---------------------------------------------------------------------------
+
+void UsbScaleManager::connectToScale()
+{
+    if (m_scale) return;            // Already connected
+    if (!m_scaleAvailable) {
+        qDebug() << "[USB Scale] connectToScale() called but no scale available";
+        return;
+    }
+
+#ifdef Q_OS_ANDROID
+    // Re-validate presence; the JNI side still owns the (probe-opened) connection.
+    if (!AndroidUsbScaleHelper::hasDevice()) {
+        qWarning() << "[USB Scale] connectToScale(): device no longer present";
+        setScaleAvailable(false);
+        return;
+    }
+    if (!AndroidUsbScaleHelper::hasPermission()) {
+        qWarning() << "[USB Scale] connectToScale(): no USB permission";
+        return;
+    }
+
+    qDebug() << "[USB Scale] Connecting (Android)";
+    emit logMessage(QStringLiteral("[USB Scale] Connecting"));
+
+    m_scale = new UsbDecentScale(this);
+    m_scale->open();
+#else
+    if (m_confirmedPortName.isEmpty()) {
+        qWarning() << "[USB Scale] connectToScale(): no confirmed port";
+        return;
+    }
+
+    qDebug() << "[USB Scale] Connecting on" << m_confirmedPortName;
+    emit logMessage(QStringLiteral("[USB Scale] Connecting on %1").arg(m_confirmedPortName));
+
+    m_scale = new UsbDecentScale(this);
+    m_scale->open(m_confirmedPortName);
+#endif
+
+    emit scaleConnectedChanged();
+    emit scaleDiscovered(m_scale);
+}
+
 // ---------------------------------------------------------------------------
 // Polling control
 // ---------------------------------------------------------------------------
@@ -102,8 +159,21 @@ void UsbScaleManager::onPollTimerTickAndroid()
         // Close the JNI USB connection (UsbDecentScale::close() delegates this to us)
         AndroidUsbScaleHelper::close();
 
+        setScaleAvailable(false);
         emit scaleLost();
         emit scaleConnectedChanged();
+        return;
+    }
+
+    // Available-but-not-connected scale unplugged: drop availability and release
+    // the JNI connection held open since the probe confirmed.
+    if (!m_scale && m_scaleAvailable && !devicePresent) {
+        qDebug() << "[USB Scale] Available scale unplugged before connect";
+        emit logMessage(QStringLiteral("[USB Scale] Scale unplugged"));
+        AndroidUsbScaleHelper::close();
+        m_androidPermissionRequested = false;
+        m_hasLoggedInitialPorts = false;
+        setScaleAvailable(false);
         return;
     }
 
@@ -114,8 +184,9 @@ void UsbScaleManager::onPollTimerTickAndroid()
         return;
     }
 
-    if (m_scale) return;           // Already connected
-    if (m_androidProbing) return;  // Already probing
+    if (m_scale) return;            // Already connected
+    if (m_scaleAvailable) return;   // Already confirmed + listed; awaiting selection
+    if (m_androidProbing) return;   // Already probing
     if (!devicePresent) {
         m_androidPermissionRequested = false;
         m_hasLoggedInitialPorts = false;
@@ -204,14 +275,13 @@ void UsbScaleManager::onAndroidProbeRead()
                 qDebug() << "[USB Scale] Scale confirmed! Got weight packet";
                 emit logMessage(QStringLiteral("[USB Scale] Half Decent Scale confirmed"));
 
-                // Stop probe timers but DON'T close — UsbDecentScale will use it
+                // Stop probe timers but DON'T close — connectToScale() reuses
+                // the JNI connection when the user selects the USB entry.
                 cleanupAndroidProbe(false);
 
-                m_scale = new UsbDecentScale(this);
-                m_scale->open();
-
-                emit scaleConnectedChanged();
-                emit scaleDiscovered(m_scale);
+                // Record availability only — do NOT auto-connect. main.cpp lists
+                // it as selectable and connects on selection / saved-primary.
+                setScaleAvailable(true);
                 return;
             }
         }
@@ -302,9 +372,21 @@ void UsbScaleManager::onPollTimerTickDesktop()
 
         m_scale->deleteLater();
         m_scale = nullptr;
+        m_confirmedPortName.clear();
 
+        setScaleAvailable(false);
         emit scaleLost();
         emit scaleConnectedChanged();
+    }
+
+    // Available-but-not-connected scale unplugged: its confirmed port is gone.
+    if (!m_scale && m_scaleAvailable && !m_confirmedPortName.isEmpty()
+        && !currentPorts.contains(m_confirmedPortName)) {
+        qDebug() << "[USB Scale] Available scale unplugged before connect:" << m_confirmedPortName;
+        emit logMessage(QStringLiteral("[USB Scale] Scale unplugged"));
+        m_confirmedPortName.clear();
+        m_hasLoggedInitialPorts = false;
+        setScaleAvailable(false);
     }
 
     // Check if probing port disappeared
@@ -316,8 +398,9 @@ void UsbScaleManager::onPollTimerTickDesktop()
 
     m_knownPorts = currentPorts;
 
-    // Probe new candidates (one at a time)
-    if (!m_probePort && !candidatePorts.isEmpty() && !m_scale) {
+    // Probe new candidates (one at a time). Skip while a scale is already
+    // connected OR available (single-scale invariant — don't grab a second).
+    if (!m_probePort && !candidatePorts.isEmpty() && !m_scale && !m_scaleAvailable) {
         probePort(candidatePorts.first());
     }
 }
@@ -394,13 +477,13 @@ void UsbScaleManager::onProbeReadyRead()
                 emit logMessage(QStringLiteral("[USB Scale] Half Decent Scale found on %1")
                                     .arg(confirmedPort));
 
+                // Close the probe port — connectToScale() reopens it on demand.
                 cleanupProbe();
 
-                m_scale = new UsbDecentScale(this);
-                m_scale->open(confirmedPort);
-
-                emit scaleConnectedChanged();
-                emit scaleDiscovered(m_scale);
+                // Record availability only — do NOT auto-connect. main.cpp lists
+                // it as selectable and connects on selection / saved-primary.
+                m_confirmedPortName = confirmedPort;
+                setScaleAvailable(true);
                 return;
             }
         }

--- a/src/usb/usbscalemanager.cpp
+++ b/src/usb/usbscalemanager.cpp
@@ -132,6 +132,12 @@ bool UsbScaleManager::teardownConnectedScale()
 {
     if (!m_scale) return false;     // Already torn down — idempotent
 
+    // Drop the Android connectedChanged watchdog (wired in connectToScale) BEFORE
+    // close() below: close() emits connectedChanged synchronously, which would
+    // otherwise re-enter this function and double-free m_scale. No-op on desktop
+    // (no such connection exists there).
+    disconnect(m_scale, &ScaleDevice::connectedChanged, this, nullptr);
+
     // Emit scaleLost() FIRST, while m_scale is still valid: main.cpp's handler
     // calls scale() to unwire the weight signals. Nulling before the emit would
     // make those disconnects dead (the signals would keep feeding a stale scale).
@@ -143,7 +149,8 @@ bool UsbScaleManager::teardownConnectedScale()
 
 #ifdef Q_OS_ANDROID
     m_androidPermissionRequested = false;
-    // Close the JNI USB connection (UsbDecentScale::close() delegates this to us)
+    // Close the JNI USB connection — UsbDecentScale::close() deliberately does
+    // NOT (UsbScaleManager owns the JNI connection lifecycle).
     AndroidUsbScaleHelper::close();
 #else
     m_confirmedPortName.clear();
@@ -166,6 +173,11 @@ void UsbScaleManager::disconnectScale()
     // stays selectable; reselecting it calls connectToScale() again.
     qDebug() << "[USB Scale] Disconnecting (switching to another scale)";
     emit logMessage(QStringLiteral("[USB Scale] Disconnected (switched to another scale)"));
+
+    // Drop the Android connectedChanged watchdog before close() — same re-entrancy
+    // hazard as teardownConnectedScale(): close() emits connectedChanged, which the
+    // watchdog would turn into a teardownConnectedScale() re-entry. No-op on desktop.
+    disconnect(m_scale, &ScaleDevice::connectedChanged, this, nullptr);
 
     m_scale->close();
     m_scale->deleteLater();

--- a/src/usb/usbscalemanager.cpp
+++ b/src/usb/usbscalemanager.cpp
@@ -86,8 +86,98 @@ void UsbScaleManager::connectToScale()
     m_scale->open(m_confirmedPortName);
 #endif
 
+    // open() can fail (port grabbed by another app, JNI open refused). If it did,
+    // the scale never connected — don't emit scaleDiscovered (that would wire a
+    // dead object and, on desktop, leave m_confirmedPortName/m_knownPorts pinned
+    // so polling never re-probes the still-plugged-in scale). Instead, tear the
+    // half-open scale down and re-enable recovery so the next poll re-confirms it.
+    if (!m_scale->isConnected()) {
+        qWarning() << "[USB Scale] open() failed — scale did not connect";
+        emit logMessage(QStringLiteral("[USB Scale] Connect failed — retrying discovery"));
+        m_scale->deleteLater();
+        m_scale = nullptr;
+#ifdef Q_OS_ANDROID
+        // Release the JNI connection so the next poll re-probes from scratch.
+        AndroidUsbScaleHelper::close();
+#else
+        // Drop the confirmed port from the known set so onPollTimerTickDesktop's
+        // candidate filter (!m_knownPorts.contains(port)) re-probes it next tick.
+        m_knownPorts.remove(m_confirmedPortName);
+        m_confirmedPortName.clear();
+#endif
+        setScaleAvailable(false);
+        return;
+    }
+
+#ifdef Q_OS_ANDROID
+    // Recover from a stale-but-enumerated connection: on Android the device can
+    // stay plugged in while its serial link silently dies (no port-disappear
+    // event for the poll to catch). Watch the scale's connected state and tear
+    // it down when it drops. Guarded on m_scale so it stays idempotent with the
+    // poll-based unplug detection in onPollTimerTickAndroid.
+    connect(m_scale, &ScaleDevice::connectedChanged, this, [this] {
+        if (m_scale && !m_scale->isConnected()) {
+            qWarning() << "[USB Scale] Connection dropped (device still enumerated)";
+            emit logMessage(QStringLiteral("[USB Scale] Connection lost"));
+            teardownConnectedScale();
+        }
+    });
+#endif
+
     emit scaleConnectedChanged();
     emit scaleDiscovered(m_scale);
+}
+
+bool UsbScaleManager::teardownConnectedScale()
+{
+    if (!m_scale) return false;     // Already torn down — idempotent
+
+    // Emit scaleLost() FIRST, while m_scale is still valid: main.cpp's handler
+    // calls scale() to unwire the weight signals. Nulling before the emit would
+    // make those disconnects dead (the signals would keep feeding a stale scale).
+    emit scaleLost();
+
+    m_scale->close();
+    m_scale->deleteLater();
+    m_scale = nullptr;
+
+#ifdef Q_OS_ANDROID
+    m_androidPermissionRequested = false;
+    // Close the JNI USB connection (UsbDecentScale::close() delegates this to us)
+    AndroidUsbScaleHelper::close();
+#else
+    m_confirmedPortName.clear();
+#endif
+    m_hasLoggedInitialPorts = false;
+
+    setScaleAvailable(false);
+    emit scaleConnectedChanged();
+    return true;
+}
+
+void UsbScaleManager::disconnectScale()
+{
+    if (!m_scale) return;           // Nothing connected — no-op
+
+    // Switching away to a BLE/WiFi scale: the USB scale is still physically
+    // plugged in, so this is NOT a loss. Deliberately do NOT emit scaleLost()
+    // and do NOT touch m_scaleAvailable — we only stop feeding the USB weight so
+    // the new primary scale doesn't double-feed WeightProcessor. The USB entry
+    // stays selectable; reselecting it calls connectToScale() again.
+    qDebug() << "[USB Scale] Disconnecting (switching to another scale)";
+    emit logMessage(QStringLiteral("[USB Scale] Disconnected (switched to another scale)"));
+
+    m_scale->close();
+    m_scale->deleteLater();
+    m_scale = nullptr;
+
+#ifdef Q_OS_ANDROID
+    // Release the JNI connection; the device stays enumerated, so the next poll
+    // re-probes and re-confirms availability without changing m_scaleAvailable here.
+    AndroidUsbScaleHelper::close();
+#endif
+
+    emit scaleConnectedChanged();
 }
 
 // ---------------------------------------------------------------------------
@@ -150,18 +240,10 @@ void UsbScaleManager::onPollTimerTickAndroid()
     if (m_scale && !devicePresent) {
         qWarning() << "[USB Scale] Connected scale disappeared";
         emit logMessage(QStringLiteral("[USB Scale] Scale disconnected"));
-
-        m_scale->close();
-        m_scale->deleteLater();
-        m_scale = nullptr;
-        m_androidPermissionRequested = false;
-
-        // Close the JNI USB connection (UsbDecentScale::close() delegates this to us)
-        AndroidUsbScaleHelper::close();
-
-        setScaleAvailable(false);
-        emit scaleLost();
-        emit scaleConnectedChanged();
+        // teardownConnectedScale() emits scaleLost() while m_scale is still
+        // valid (so main.cpp can unwire weight signals), then deletes + nulls
+        // it, releases the JNI connection, and clears availability.
+        teardownConnectedScale();
         return;
     }
 
@@ -369,14 +451,12 @@ void UsbScaleManager::onPollTimerTickDesktop()
         // Scale already disconnected itself (port error)
         qWarning() << "[USB Scale] Scale port lost";
         emit logMessage(QStringLiteral("[USB Scale] Scale disconnected"));
-
-        m_scale->deleteLater();
-        m_scale = nullptr;
-        m_confirmedPortName.clear();
-
-        setScaleAvailable(false);
-        emit scaleLost();
-        emit scaleConnectedChanged();
+        // teardownConnectedScale() emits scaleLost() while m_scale is still
+        // valid (so main.cpp can unwire weight signals), then deletes + nulls
+        // it, clears m_confirmedPortName + m_hasLoggedInitialPorts, and drops
+        // availability — matching the Android path and the available-unplugged
+        // branch below.
+        teardownConnectedScale();
     }
 
     // Available-but-not-connected scale unplugged: its confirmed port is gone.

--- a/src/usb/usbscalemanager.h
+++ b/src/usb/usbscalemanager.h
@@ -49,6 +49,13 @@ public:
     // on startup when the USB scale is the saved primary.
     Q_INVOKABLE void connectToScale();
 
+    // Tear down an active USB scale connection WITHOUT marking it lost. Used when
+    // the user switches to a BLE/WiFi scale: the USB scale is still plugged in
+    // (m_scaleAvailable stays true, no scaleLost()), we just stop feeding its
+    // weight so the new scale doesn't double-feed WeightProcessor. No-op if no
+    // scale is connected.
+    void disconnectScale();
+
 signals:
     void scaleConnectedChanged();
     void scaleDiscovered(UsbDecentScale* scale);
@@ -71,6 +78,15 @@ private:
     // NOT necessarily connected). Drives usbScaleAvailable/Unavailable.
     bool m_scaleAvailable = false;
     void setScaleAvailable(bool available);
+
+    // Shared teardown for a connected scale that has gone away (poll-detected
+    // unplug OR connectedChanged → disconnected). Emits scaleLost() while
+    // m_scale is still valid (main.cpp's handler reads scale() to unwire weight
+    // signals), THEN deletes + nulls it, releases the platform connection, and
+    // marks the scale unavailable. Idempotent: no-op when m_scale is already
+    // null, so the poll detector and the connectedChanged handler can't
+    // double-fire. Returns true if it actually tore a scale down.
+    bool teardownConnectedScale();
 
 #ifdef Q_OS_ANDROID
     void onPollTimerTickAndroid();

--- a/src/usb/usbscalemanager.h
+++ b/src/usb/usbscalemanager.h
@@ -18,9 +18,13 @@ class UsbDecentScale;
  * On Android: uses JNI (AndroidUsbScaleHelper).
  * On desktop: uses QSerialPortInfo.
  *
- * When the scale is confirmed (receives valid weight packets),
- * creates a UsbDecentScale and emits scaleDiscovered().
- * When unplugged, emits scaleLost().
+ * When the scale is confirmed (receives valid weight packets), it is recorded
+ * as AVAILABLE and emits usbScaleAvailable() — it does NOT auto-connect, so it
+ * can be tested over Bluetooth/WiFi instead. The discovered-devices list shows
+ * it as a selectable entry; selecting it (or auto-reconnect when it's the saved
+ * primary) calls connectToScale(), which creates a UsbDecentScale, opens it, and
+ * emits scaleDiscovered() to wire it active.
+ * When unplugged, emits usbScaleUnavailable() (and scaleLost() if connected).
  */
 class UsbScaleManager : public QObject {
     Q_OBJECT
@@ -32,15 +36,28 @@ public:
     ~UsbScaleManager() override;
 
     bool isScaleConnected() const;
+    bool isScaleAvailable() const { return m_scaleAvailable; }
     UsbDecentScale* scale() const { return m_scale; }
 
     void startPolling();
     void stopPolling();
 
+    // Create + open the UsbDecentScale for the currently-available USB scale and
+    // emit scaleDiscovered() so main.cpp wires it active. No-op if no scale is
+    // available or one is already connected. Called when the user selects the
+    // USB entry in the discovered list (via BLEManager::usbConnectRequested) or
+    // on startup when the USB scale is the saved primary.
+    Q_INVOKABLE void connectToScale();
+
 signals:
     void scaleConnectedChanged();
     void scaleDiscovered(UsbDecentScale* scale);
     void scaleLost();
+    // Probe-confirmed presence (NOT a connection): the USB scale is plugged in
+    // and answered with a valid weight packet. main.cpp lists it as a selectable
+    // entry and auto-connects only when it's the saved primary.
+    void usbScaleAvailable();
+    void usbScaleUnavailable();
     void logMessage(const QString& message);
 
 private slots:
@@ -50,6 +67,10 @@ private:
     QTimer m_pollTimer;
     UsbDecentScale* m_scale = nullptr;
     bool m_hasLoggedInitialPorts = false;
+    // True once a scale has been probe-confirmed and is still plugged in (but
+    // NOT necessarily connected). Drives usbScaleAvailable/Unavailable.
+    bool m_scaleAvailable = false;
+    void setScaleAvailable(bool available);
 
 #ifdef Q_OS_ANDROID
     void onPollTimerTickAndroid();
@@ -75,6 +96,9 @@ private:
     QTimer* m_probeTimer = nullptr;
     QSerialPortInfo m_probingPortInfo;
     QByteArray m_probeBuffer;
+    // Port name confirmed by the last successful probe; reopened by
+    // connectToScale() when the user selects the USB entry. Cleared on unplug.
+    QString m_confirmedPortName;
 #endif
 
     static constexpr int POLL_INTERVAL_MS = 2000;


### PR DESCRIPTION
## Summary
Reworks the USB Half Decent Scale to behave like the BLE and WiFi scales: when detected it appears as a **selectable entry** in the device list instead of auto-connecting (which pre-empted testing the same scale over Bluetooth/WiFi). This supersedes the closed #1259 toggle-gating approach.

- **`UsbScaleManager`**: probe-confirm now records *availability* (`usbScaleAvailable`) instead of opening the scale. `connectToScale()` opens it on demand — on user selection, or auto-reconnect when it's the saved primary. Unplug clears availability (and emits `scaleLost` if connected). Single-scale invariant preserved (won't re-probe while available/connected).
- **`BLEManager`**: `setUsbScaleAvailable()` adds/removes a synthetic `"usb:decent"` entry in `discoveredScales`, mirroring the WiFi `"wifi:<host>"` entry. `connectToScale()`'s `usb` branch emits `usbConnectRequested()`. `connectToSavedScale()` / `tryDirectConnectToScale()` skip the BLE machinery for `usb:` addresses (it's not a MAC).
- **`main.cpp`**: lists USB on availability, auto-connects **only** when `usb:decent` is the saved primary, routes selection → `connectToScale()`, and registers USB via `addKnownScale`/`setPrimaryScale` on connect — so it joins Known Devices and reconnects on next launch like BLE/WiFi.
- **No QML changes** — the discovered-list + `connectToScale` path is transport-generic.

## Test plan
- [x] Builds clean (Qt 6.11.1, macOS, 0 warnings)
- [x] `tst_decentscalewifi` 20/20 (shared BLEManager paths unaffected)
- [ ] Desktop: plug in USB scale → appears in Scan/device list, does **not** auto-connect; select it → connects + shows in Known Devices
- [ ] With USB as saved primary → auto-reconnects on next launch
- [ ] With a BT/WiFi scale connected, the USB scale stays listed (not grabbed)
- [ ] Unplug → removed from list / falls back to BT/WiFi/FlowScale

🤖 Generated with [Claude Code](https://claude.com/claude-code)