### PR TITLE
Fix iOS build: guard usbScaleManager capture in scaleDiscovered handler

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1440,7 +1440,11 @@ int main(int argc, char *argv[])
 
     // Connect to any supported scale when discovered
     QObject::connect(&bleManager, &BLEManager::scaleDiscovered,
-                     [&physicalScale, &flowScale, &machineState, &mainController, &engine, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &scaleAutoReconnectSuppressed, &translationManager, &usbScaleManager](const QBluetoothDeviceInfo& device, const QString& type) {
+                     [&physicalScale, &flowScale, &machineState, &mainController, &engine, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &scaleAutoReconnectSuppressed, &translationManager
+#ifndef Q_OS_IOS
+                     , &usbScaleManager
+#endif
+                     ](const QBluetoothDeviceInfo& device, const QString& type) {
 #ifndef Q_OS_IOS
         // Tear down an active USB scale FIRST (before touching physicalScale).
         // The single-scale invariant covers BLE/WiFi via physicalScale, but the


### PR DESCRIPTION
## Summary
- #1261 added `&usbScaleManager` to the `BLEManager::scaleDiscovered` lambda capture list unconditionally, but `usbScaleManager` is only declared under `#ifndef Q_OS_IOS` (iOS has no USB scale support). The lambda *body* using it was already guarded; the *capture* was not, so iOS failed to compile (`use of undeclared identifier 'usbScaleManager'`).
- PRs don't run the iOS workflow (only tag pushes do), so this surfaced when the v1.7.5 pre-release tag was rebuilt.
- Fix: wrap the capture in `#ifndef Q_OS_IOS`, matching the existing idiom used by the `de1Device` connectedChanged handler's `&usbManager` capture (lines 1397–1401).

## Test plan
- [x] macOS build clean (Qt Creator, 0 errors / 0 warnings)
- [x] iOS compile verified via CI test build on this branch (run 26347321865 — success)
- [x] No behavior change off-iOS (capture unchanged; only iOS excludes it to match the already-guarded body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)