### PR TITLE
fix(ble): pause Decent scale heartbeat during DE1 BLE discovery (#1176)

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -2,6 +2,7 @@
 #include "blecapability.h"
 #include "scaledevice.h"
 #include "protocol/de1characteristics.h"
+#include "scales/decentscale.h"
 #include "scales/scalefactory.h"
 #include "refractometers/difluidr2.h"
 #include "../core/settings_hardware.h"
@@ -1026,6 +1027,20 @@ void BLEManager::setScaleDevice(ScaleDevice* scale) {
         // Connect scale's debug log to our logging system
         connect(m_scaleDevice, &ScaleDevice::logMessage,
                 this, &BLEManager::appendScaleLog);
+        // Push current DE1-discovery state immediately so a scale that connects
+        // mid-discovery (e.g. after the gate timed out) starts in the right
+        // pause state instead of waiting for the next edge.
+        if (auto* ds = qobject_cast<DecentScale*>(m_scaleDevice)) {
+            ds->setHeartbeatsPaused(m_de1ServiceDiscoveryActive);
+        }
+    }
+}
+
+void BLEManager::setDe1ServiceDiscoveryActive(bool active) {
+    if (m_de1ServiceDiscoveryActive == active) return;
+    m_de1ServiceDiscoveryActive = active;
+    if (auto* ds = qobject_cast<DecentScale*>(m_scaleDevice)) {
+        ds->setHeartbeatsPaused(active);
     }
 }
 

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -404,6 +404,12 @@ public slots:
     // Called by main.cpp when the DE1's direct-wake connection resolves
     // (connected, or the attempt ended).
     void onDe1ConnectionSettled();
+    // Track whether the DE1 transport is in BLE service+characteristic discovery
+    // and forward the state to a co-resident DecentScale so its heartbeat pauses
+    // for the duration. Wired from DE1Device::serviceDiscoveryActiveChanged in
+    // main.cpp. See #1176 — scale heartbeat writes that race DE1 char discovery
+    // fail with CharacteristicWriteError on weaker radios (Samsung Tab A8).
+    void setDe1ServiceDiscoveryActive(bool active);
     Q_INVOKABLE void scanForDevices();  // User-initiated scan for DE1, scales, and refractometers
     Q_INVOKABLE void startScan();  // Start scanning for DE1 and scales
     void stopScan();
@@ -536,6 +542,7 @@ private:
     bool m_scaleConnectionFailed = false;
     ScaleDevice* m_scaleDevice = nullptr;
     QTimer* m_scaleConnectionTimer = nullptr;
+    bool m_de1ServiceDiscoveryActive = false;
 
     // Saved scale for direct wake connection
     QString m_savedScaleAddress;

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -252,6 +252,7 @@ void BleTransport::disconnect() {
     }
     m_characteristics.clear();
     m_characteristicsReady = false;
+    setServiceDiscoveryActive(false);
 
     if (m_controller) {
         m_controller->disconnectFromDevice();
@@ -399,6 +400,7 @@ void BleTransport::onControllerDisconnected() {
     m_writeTimeoutTimer.stop();
     m_commandTimer.stop();
     m_characteristicsReady = false;
+    setServiceDiscoveryActive(false);
 
     if (!m_disconnectedEmittedForAttempt) {
         m_disconnectedEmittedForAttempt = true;
@@ -489,6 +491,12 @@ void BleTransport::onControllerError(QLowEnergyController::Error error) {
     }
 #endif
 
+    // A controller error during discovery would otherwise leave
+    // m_serviceDiscoveryActive stuck at true (BlueZ does not always fire a
+    // stateChanged→Unconnected after UnknownRemoteDeviceError). Reset here so
+    // peer scales aren't held in pause forever after a connect-time failure.
+    setServiceDiscoveryActive(false);
+
     // Synthesize disconnected() so the upper layer treats the attempt as
     // terminated. Without this, DE1Device::m_connecting stays true forever
     // after a connect-time error like UnknownRemoteDeviceError, and the
@@ -564,6 +572,7 @@ void BleTransport::onServiceDiscovered(const QBluetoothUuid& uuid) {
                 }
             }, qc);
             log("Starting characteristic discovery for DE1 service");
+            setServiceDiscoveryActive(true);
             m_service->discoverDetails();
         } else {
             warn("ERROR: createServiceObject() returned null for DE1 service UUID");
@@ -601,6 +610,8 @@ void BleTransport::onServiceStateChanged(QLowEnergyService::ServiceState state) 
         setupService();
         m_characteristicsReady = true;
         log(QString("Characteristics ready: %1 registered").arg(m_characteristics.size()));
+        // Discovery window closed — peer scales can resume normal write traffic.
+        setServiceDiscoveryActive(false);
         subscribeAll();
 
 #ifdef Q_OS_ANDROID
@@ -636,6 +647,12 @@ void BleTransport::onCharacteristicWritten(const QLowEnergyCharacteristic& c, co
 }
 
 // -- Private helpers --
+
+void BleTransport::setServiceDiscoveryActive(bool active) {
+    if (m_serviceDiscoveryActive == active) return;
+    m_serviceDiscoveryActive = active;
+    emit serviceDiscoveryActiveChanged(active);
+}
 
 void BleTransport::log(const QString& message) {
     QString msg = QString("[BLE DE1] ") + message;

--- a/src/ble/bletransport.h
+++ b/src/ble/bletransport.h
@@ -68,9 +68,9 @@ private:
     void log(const QString& message);
     void warn(const QString& message);
     // Update m_serviceDiscoveryActive and emit serviceDiscoveryActiveChanged()
-    // only on transitions. Coalesces the three reset call sites (chars-ready,
-    // disconnect, controller-error) so the signal cleanly brackets one discovery
-    // window per attempt.
+    // only on transitions. Coalesces the four reset call sites (chars-ready,
+    // disconnect(), onControllerDisconnected(), onControllerError()) so the
+    // signal cleanly brackets one discovery window per attempt.
     void setServiceDiscoveryActive(bool active);
     bool setupController(const QBluetoothDeviceInfo& device);
     void setupService();

--- a/src/ble/bletransport.h
+++ b/src/ble/bletransport.h
@@ -67,6 +67,11 @@ private slots:
 private:
     void log(const QString& message);
     void warn(const QString& message);
+    // Update m_serviceDiscoveryActive and emit serviceDiscoveryActiveChanged()
+    // only on transitions. Coalesces the three reset call sites (chars-ready,
+    // disconnect, controller-error) so the signal cleanly brackets one discovery
+    // window per attempt.
+    void setServiceDiscoveryActive(bool active);
     bool setupController(const QBluetoothDeviceInfo& device);
     void setupService();
     void writeCharacteristic(const QBluetoothUuid& uuid, const QByteArray& data);
@@ -76,6 +81,10 @@ private:
     QLowEnergyService* m_service = nullptr;
     QMap<QBluetoothUuid, QLowEnergyCharacteristic> m_characteristics;
     bool m_characteristicsReady = false;
+    // True while discoverDetails() is in flight (service+characteristic
+    // discovery window). Used to gate serviceDiscoveryActiveChanged() emissions
+    // so consumers don't see false→false on the disconnect path.
+    bool m_serviceDiscoveryActive = false;
     // True once disconnected() has been emitted for the current connection
     // attempt (either via Qt's native signal on a Connected→Disconnected
     // transition, or synthesized by us when a connection attempt fails and

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -359,6 +359,16 @@ void DE1Device::disconnect() {
     m_lastSawWriteMs = 0;
 
     if (m_transport) {
+        // Defensive false-edge for the discovery-active forwarding before we
+        // sever the transport's signals below. BleTransport::disconnect()
+        // calls setServiceDiscoveryActive(false) too, but it runs *after*
+        // QObject::disconnect() drops the forwarding wire, so its emission
+        // would never reach BLEManager — leaving m_de1ServiceDiscoveryActive
+        // stuck true and the DecentScale heartbeat paused indefinitely if
+        // the disconnect lands mid-discovery (e.g. USB takeover). The
+        // BLEManager slot has an equality guard so a redundant false→false
+        // is a no-op when no discovery was active.
+        emit serviceDiscoveryActiveChanged(false);
         // Disconnect signals FIRST to prevent re-entrant emissions
         // (BleTransport::disconnect() emits disconnected(), which would
         // trigger onTransportDisconnected() and double-emit our signals)

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -66,6 +66,8 @@ void DE1Device::setTransport(DE1Transport* transport) {
                 this, &DE1Device::errorOccurred);
         connect(m_transport, &DE1Transport::de1LinkFault,
                 this, &DE1Device::de1LinkFault);
+        connect(m_transport, &DE1Transport::serviceDiscoveryActiveChanged,
+                this, &DE1Device::serviceDiscoveryActiveChanged);
         connect(m_transport, &DE1Transport::logMessage,
                 this, &DE1Device::logMessage);
     }

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -320,6 +320,10 @@ signals:
     // write-failed / connection-teardown). Re-emitted here so consumers bind
     // once to the stable DE1Device and survive transport swaps.
     void de1LinkFault(const QString& kind);
+    // Forwarded from the DE1 transport: BLE service+characteristic discovery
+    // window. Re-emitted here so BLEManager binds once to the stable
+    // DE1Device. See DE1Transport::serviceDiscoveryActiveChanged for purpose.
+    void serviceDiscoveryActiveChanged(bool active);
     void simulationModeChanged();
     void guiEnabledChanged();
     void usbChargerOnChanged();

--- a/src/ble/de1transport.h
+++ b/src/ble/de1transport.h
@@ -138,6 +138,17 @@ signals:
     void de1LinkFault(const QString& kind);
 
     /**
+     * Emitted while the transport is in BLE service + characteristic discovery —
+     * a high-burst window where the local BLE controller is saturated and any
+     * write to a co-resident peer (e.g. a scale on the same adapter) will fail
+     * with CharacteristicWriteError on weaker radios (Samsung Tab A8, #1176).
+     * Consumers (BLEManager → DecentScale heartbeat) pause non-essential scale
+     * writes for the duration. Serial transports never emit this — there is no
+     * radio contention to coordinate around.
+     */
+    void serviceDiscoveryActiveChanged(bool active);
+
+    /**
      * Emitted for debug/diagnostic logging.
      * @param message Log text to be captured by ShotDebugLogger.
      */

--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -398,13 +398,25 @@ void DecentScale::startHeartbeat() {
         m_heartbeatTimer = new QTimer(this);
         m_heartbeatTimer->setInterval(1000);  // Every 1 second like de1app
         connect(m_heartbeatTimer, &QTimer::timeout, this, [this]() {
-            if (m_characteristicsReady) {
+            if (m_characteristicsReady && !m_heartbeatsPaused) {
                 sendHeartbeat();
             }
         });
     }
     DECENT_LOG("Starting heartbeat timer");
     m_heartbeatTimer->start();
+}
+
+void DecentScale::setHeartbeatsPaused(bool paused) {
+    if (m_heartbeatsPaused == paused) return;
+    m_heartbeatsPaused = paused;
+    // Lifted out of the macro arg: SCALE_LOG concatenates with `+`, which binds
+    // tighter than `?:`, so an inline ternary would parse as
+    // `(QString + bool) ? "..." : "..."` and fail to compile.
+    const QString msg = paused
+        ? QStringLiteral("Pausing heartbeats — DE1 BLE discovery in progress")
+        : QStringLiteral("Resuming heartbeats — DE1 BLE discovery complete");
+    DECENT_LOG(msg);
 }
 
 void DecentScale::stopHeartbeat() {

--- a/src/ble/scales/decentscale.h
+++ b/src/ble/scales/decentscale.h
@@ -25,6 +25,13 @@ public slots:
     void wake() override;
     void disableLcd() override;
     void setLed(int r, int g, int b);
+    // Pause the periodic 1 s heartbeat while DE1 BLE service/char discovery is
+    // in flight. Driven by BLEManager off the DE1 transport's
+    // serviceDiscoveryActiveChanged() signal. The Decent Scale tolerates
+    // skipped heartbeats fine (next tick covers it); a heartbeat write that
+    // races DE1 char discovery, however, fails with CharacteristicWriteError
+    // and disconnects the scale on weaker radios (#1176).
+    void setHeartbeatsPaused(bool paused);
 
 private slots:
     void onTransportConnected();
@@ -70,4 +77,5 @@ private:
     QString m_firmwareVersion;
     QTimer* m_heartbeatTimer = nullptr;
     QTimer* m_watchdogTimer = nullptr;
+    bool m_heartbeatsPaused = false;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1157,6 +1157,13 @@ int main(int argc, char *argv[])
     QObject::connect(&de1Device, &DE1Device::logMessage,
                      &bleManager, &BLEManager::de1LogMessage);
 
+    // Forward the DE1 BLE service+characteristic discovery window so BLEManager
+    // can pause the scale heartbeat during it (#1176 mid-discovery scale drop on
+    // Tab A8). DE1Device re-emits this from whichever transport is current, so
+    // we bind once and don't need to rewire on transport swaps.
+    QObject::connect(&de1Device, &DE1Device::serviceDiscoveryActiveChanged,
+                     &bleManager, &BLEManager::setDe1ServiceDiscoveryActive);
+
 #ifndef Q_OS_IOS
     // When USB DE1 discovered: disconnect BLE, switch to USB transport
     QObject::connect(&usbManager, &USBManager::de1Discovered,


### PR DESCRIPTION
## Summary

Decent Scale was disconnecting mid-startup on Samsung Tab A8 (#1176) even after the persistent dual-HIGH-incapable latch dropped both links to BALANCED. Root cause: when DE1 reconnects and runs service+characteristic discovery (~3 s burst), the local BLE controller is saturated, and a scale heartbeat write landing in that window fails with `CharacteristicWriteError` and the scale drops.

In the user's log (session 3 in `debug-2.log`):
- +14.1 s scale CONNECTED at BALANCED
- +19.0 s DE1 reconnect attempt 1 → DE1 char discovery +20.8 → +23.7 s
- **+22.8 s scale `CharacteristicWriteError` storm → DISCONNECTED** (a heartbeat collided with DE1 char discovery)
- Repeated at +38 s and +143 s on subsequent DE1 traffic windows

## Fix

`BleTransport` (DE1) now brackets its `discoverDetails()` window with a `serviceDiscoveryActiveChanged(bool)` signal. `DE1Device` forwards it; `BLEManager` tracks the state and forwards to a co-resident `DecentScale` via `setHeartbeatsPaused(bool)`. The periodic 1 s heartbeat skips for the duration of DE1 discovery — the next tick resumes once chars are ready. The Decent Scale tolerates skipped heartbeats fine; what it doesn't tolerate is a write storm under controller contention.

Wake-sequence writes (LCD, CCCD enables) are deliberately unaffected — they happen before any DE1 reconnect on this code path (gated by the existing `m_de1DirectConnectInFlight` serializer), and gating them would risk losing the timing-sensitive de1app pattern.

Reset paths (controller-error, `onControllerDisconnected`, `disconnect()`) also clear the flag so the scale doesn't stay paused forever after a connect-time DE1 failure.

## What I considered and rejected

- **Move the existing gate's release from "Connected" to "chars ready"** — turned out to be a no-op. `BleTransport::isConnected()` already requires `m_characteristicsReady`, so the gate already releases at chars-ready (`src/ble/bletransport.cpp:293-299`).
- **Cap-cancel on reconnect-exhausted** — practically a no-op in this log. The cap is a 15 s backstop; the natural `wasActive && !isActive` release fires within ~10–13 s on every failed DE1 attempt.
- **Slow DE1 char discovery / per-write retries on the scale** — the writes aren't lost, the link is. Retrying just extends the storm.

## Test plan

- [x] Build clean (Qt Creator, macOS Debug): 0 errors, 0 warnings, all unit tests link.
- [ ] Field verification on @GCDE-VER1's Tab A8 (cold-DE1 startup on next beta after CI runs).

Signatures to watch for in the new debug log:
- `[BLE DecentScale] Pausing heartbeats — DE1 BLE discovery in progress` appears once per DE1 reconnect.
- `[BLE DecentScale] Resuming heartbeats — DE1 BLE discovery complete` follows within ~3 s.
- Zero `CharacteristicWriteError` on the scale in the first 60 s.

Closes/addresses comments in #1176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)