### PR TITLE
fix(scale): WiFi sleep matches BT semantics, and close WS during DE1 sleep

### DIFF
--- a/openspec/changes/add-wifi-scale-support/design.md
+++ b/openspec/changes/add-wifi-scale-support/design.md
@@ -187,13 +187,11 @@ The BLE driver carries machinery that exists to work around GATT-layer quirks an
 
 Decision:
 
-- WiFi `sleep()` → `m_socket.sendTextMessage("{\"command\":\"power\",\"action\":\"off\"}")`, the HDS firmware's equivalent of BT `0A 02 00`. Emits `sleepCompleted` immediately after the send call returns.
-- The BLE driver waits for `characteristicWritten` before emitting `sleepCompleted` ([decentscale.cpp:362-364](src/ble/scales/decentscale.cpp:362)). The semantic intent of that wait is "we confirmed the bytes left our radio." On WiFi, `sendTextMessage` returning is the precise analog (the TCP write went out). We do not wait for the firmware's status-ack JSON form — that would change the latency profile vs BLE.
-- If the socket is not open, emit `sleepCompleted` anyway (matches the BLE driver's "transport unavailable → emit immediately" fallback at [decentscale.cpp:358-361](src/ble/scales/decentscale.cpp:358)).
+- WiFi `sleep()` → `send("{\"command\":\"power\",\"action\":\"off\"}")`, the HDS firmware's equivalent of BT `0A 02 00`. Emits `sleepCompleted` unconditionally after the send attempt returns, so callers (app-exit waitLoop, DE1-sleep handler) don't hang waiting for an ack that won't come.
+- The BLE driver waits for `characteristicWritten` before emitting `sleepCompleted` ([decentscale.cpp:362-364](src/ble/scales/decentscale.cpp:362)). The semantic intent of that wait is "we confirmed the bytes left our radio." On WiFi, `send()` returning success (socket was in `ConnectedState`) is the precise analog (the TCP write entered the kernel buffer). We do not wait for the firmware's status-ack JSON form — that would change the latency profile vs BLE.
+- If the socket is not in `ConnectedState` (e.g., `ClosingState` from a prior graceful close, or never-opened), `send()` returns false. `sleep()` emits `sleepCompleted` anyway — matching the BLE driver's "transport unavailable → emit immediately" early-return at [decentscale.cpp:358-361](src/ble/scales/decentscale.cpp:358) — and logs a WARN so the dropped power-off command is diagnosable rather than hidden behind a misleading "drained successfully" downstream log.
 - WiFi `wake()` sends `"soft_sleep off"` then `"display on"` — the reversible-park complement (`soft_sleep on/off`), useful between explicit user actions but **not** what `sleep()` issues.
 - `"soft_sleep on"` remains a lighter, reversible park state on the firmware side. It is intentionally NOT what `sleep()` sends — it does not match BT's `0A 02 00` semantics and leaves the ESP32 radio active, draining a battery-only HDS while the DE1 is asleep.
-
-Historical note: this decision was reversed during implementation of [PR #1265](https://github.com/Kulitorum/Decenza/pull/1265). The original spec chose `"soft_sleep on"` for `sleep()` based on a misreading of BT `0A 02 00`'s reversibility (incorrectly attributing `disableLcd()`'s behavior to `sleep()`). The corrected mapping above is what ships.
 
 ### 13. Charging state — small `ScaleDevice` interface extension
 

--- a/openspec/changes/add-wifi-scale-support/design.md
+++ b/openspec/changes/add-wifi-scale-support/design.md
@@ -100,7 +100,7 @@ The HDS WebSocket protocol (`Kulitorum/openscale` README) exposes every command 
 | `resetTimer()` | `03 0B 02 00` | `"timer reset"` (text) | Silent |
 | `wake()` | `03 0A 01 01 00 01` | `"display on"` (and `"soft_sleep off"` if currently soft-sleeping) | Silent |
 | `disableLcd()` | `03 0A 00 00` | `"display off"` (text) | Silent |
-| `sleep()` → emits `sleepCompleted` | `03 0A 02 00`, waits for `characteristicWritten` ack | `"soft_sleep on"` (text), emit `sleepCompleted` immediately after `sendTextMessage` returns nonzero (write-succeeded analog) | See decision 12 |
+| `sleep()` → emits `sleepCompleted` | `03 0A 02 00`, waits for `characteristicWritten` ack | `{"command":"power","action":"off"}` (text), emit `sleepCompleted` immediately after the send call returns (write-succeeded analog) | See decision 12 |
 | `setLed(r,g,b)` | `03 0A r g b` | `"led <r> <g> <b>"` (text) | Silent |
 | Battery (0..100%) | LED-response packet byte `[4]` | `status` frame `battery_percent` | Pull at connect (request `status`) + on every 5 s heartbeat |
 | Charging | LED-response packet `[4] == 0xFF` (currently encoded lossily as battery=100) | `status` frame `charging` (explicit bool) | See decision 13 |
@@ -183,16 +183,17 @@ The BLE driver carries machinery that exists to work around GATT-layer quirks an
 
 ### 12. `sleep()` ↔ `sleepCompleted` semantics on WiFi
 
-`ScaleDevice::sleep()` is documented as "Put scale to sleep (battery power saving - full power off)" but the BLE driver's implementation uses `03 0A 02 00` which actually **disables LCD and pauses the scale loop** — it's reversible via a subsequent `wake()` ([decentscale.cpp:355-379](src/ble/scales/decentscale.cpp:355)). So the real semantics are "scale-side power saving, reversible."
+`ScaleDevice::sleep()` is documented as "Put scale to sleep (battery power saving - full power off)" and the BLE driver's `03 0A 02 00` is in fact the firmware-level power-off — the scale's radio drops and the scale requires a physical button press to wake again. The earlier reading of `0A 02 00` as a reversible LCD-off-plus-pause was wrong: that's what `disableLcd()`'s `0A 00 00` does, which is explicitly contrasted with `sleep()` in [decentscale.cpp:383-388](src/ble/scales/decentscale.cpp:383) ("This is different from sleep() which powers off the scale completely"). The same logical "sleep" gesture should produce the same outcome on the scale regardless of transport.
 
-The matching WiFi command is `"soft_sleep on"`, NOT `"power off"` (which would be irreversible and drop the WS link). Decision:
+Decision:
 
-- WiFi `sleep()` → `m_socket.sendTextMessage("soft_sleep on")`, then **immediately emit `sleepCompleted`** once the send call returns a positive byte count.
-- The BLE driver waits for `characteristicWritten` before emitting `sleepCompleted` ([decentscale.cpp:362-364](src/ble/scales/decentscale.cpp:362)). The semantic intent of that wait is "we confirmed the bytes left our radio." On WiFi, `sendTextMessage` returning a nonzero byte count is the precise analog (the TCP write went out). We do not wait for the firmware's status-ack JSON form — that would change the latency profile vs BLE.
-- If `sendTextMessage` returns 0 (socket not in `Open` state), emit `sleepCompleted` anyway (matches the BLE driver's "transport unavailable → emit immediately" fallback at [decentscale.cpp:358-361](src/ble/scales/decentscale.cpp:358)).
-- WiFi `wake()` sends `"display on"` AND `"soft_sleep off"`. Order: `soft_sleep off` first (restore sensor power + scale loop), then `display on` (restore OLED). Two TCP-ordered writes.
+- WiFi `sleep()` → `m_socket.sendTextMessage("{\"command\":\"power\",\"action\":\"off\"}")`, the HDS firmware's equivalent of BT `0A 02 00`. Emits `sleepCompleted` immediately after the send call returns.
+- The BLE driver waits for `characteristicWritten` before emitting `sleepCompleted` ([decentscale.cpp:362-364](src/ble/scales/decentscale.cpp:362)). The semantic intent of that wait is "we confirmed the bytes left our radio." On WiFi, `sendTextMessage` returning is the precise analog (the TCP write went out). We do not wait for the firmware's status-ack JSON form — that would change the latency profile vs BLE.
+- If the socket is not open, emit `sleepCompleted` anyway (matches the BLE driver's "transport unavailable → emit immediately" fallback at [decentscale.cpp:358-361](src/ble/scales/decentscale.cpp:358)).
+- WiFi `wake()` sends `"soft_sleep off"` then `"display on"` — the reversible-park complement (`soft_sleep on/off`), useful between explicit user actions but **not** what `sleep()` issues.
+- `"soft_sleep on"` remains a lighter, reversible park state on the firmware side. It is intentionally NOT what `sleep()` sends — it does not match BT's `0A 02 00` semantics and leaves the ESP32 radio active, draining a battery-only HDS while the DE1 is asleep.
 
-`power off` (irreversible full power-off) is **not** wired to any `ScaleDevice` virtual today. It would be a new capability — not in scope here. If someone later adds a "shut down scale" UI button, that's the command it would send.
+Historical note: this decision was reversed during implementation of [PR #1265](https://github.com/Kulitorum/Decenza/pull/1265). The original spec chose `"soft_sleep on"` for `sleep()` based on a misreading of BT `0A 02 00`'s reversibility (incorrectly attributing `disableLcd()`'s behavior to `sleep()`). The corrected mapping above is what ships.
 
 ### 13. Charging state — small `ScaleDevice` interface extension
 

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -170,10 +170,12 @@ void DecentScaleWifi::onConnected() {
     send(QStringLiteral("rate 10k"));
     send(QStringLiteral("events on"));
     send(QStringLiteral("status"));
-    // Restore the LCD on every (re)connect — mirrors the BT wake() that fires
-    // post-discovery in onCharacteristicsDiscoveryFinished. Idempotent on a
-    // scale whose LCD was already on; required when the previous DE1-sleep
-    // path turned it off and then closed the WS.
+    // Restore the LCD on every (re)connect. Idempotent on a fresh-connect
+    // scale (LCD defaults on); required on a reconnect after the DE1-sleep
+    // keepScaleOn=true+WiFi path, where disableLcd() was sent before the WS
+    // was gracefully closed. Not a full wake(): soft_sleep off isn't needed
+    // here because sleep() (which would have soft-slept) wasn't called on
+    // that path — only the LCD was disabled.
     send(QStringLiteral("display on"));
 }
 
@@ -435,9 +437,19 @@ int DecentScaleWifi::encodeButton(int buttonNumber, int pressCode) {
     return kWifiButtonFlag | ((buttonNumber & 0xF) << 8) | (pressCode & 0xFF);
 }
 
-void DecentScaleWifi::send(const QString& text) {
-    if (!m_socket) return;
+bool DecentScaleWifi::send(const QString& text) {
+    if (!m_socket || m_socket->state() != QAbstractSocket::ConnectedState) {
+        // Qt's sendTextMessage silently returns 0 bytes when the socket isn't
+        // ConnectedState (ClosingState, UnconnectedState, mid-handshake), with
+        // no errorOccurred signal — so without this check, commands queued
+        // during teardown would vanish without trace. Most observed at app
+        // exit when the DE1-sleep handler already initiated a graceful close.
+        WIFI_WARN(QStringLiteral("send() dropped — socket not connected: %1")
+                  .arg(text.left(80)));
+        return false;
+    }
     m_socket->sendTextMessage(text);
+    return true;
 }
 
 void DecentScaleWifi::tare()       { send(QStringLiteral("tare")); }
@@ -458,10 +470,18 @@ void DecentScaleWifi::sleep() {
     // transport's behavior exactly. `soft_sleep on` is the lighter reversible
     // state and is wrong here: leaving the ESP32 radio active while the DE1
     // sleeps drains a battery-only HDS.
-    send(QStringLiteral("{\"command\":\"power\",\"action\":\"off\"}"));
+    const bool sent = send(QStringLiteral("{\"command\":\"power\",\"action\":\"off\"}"));
+    if (!sent) {
+        // Caller (app-exit waitLoop, DE1-sleep handler) hangs forever waiting
+        // for sleepCompleted, so emit unconditionally — but warn so the
+        // dropped power-off command isn't masked by a misleading
+        // "drained successfully" log downstream. Common at app exit after a
+        // DE1-sleep keepScaleOn=true+WiFi close (socket already in ClosingState).
+        WIFI_WARN("sleep(): power-off command not delivered (socket not connected)");
+    }
     // BT waits for `characteristicWritten` as a "command left the radio" ack.
-    // The WS analog is sendTextMessage returning, which already happened above.
-    // Emit immediately to match BT's intent.
+    // The WS analog is send() returning success above. Emit immediately to
+    // match BT's intent.
     emit sleepCompleted();
 }
 

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -170,6 +170,11 @@ void DecentScaleWifi::onConnected() {
     send(QStringLiteral("rate 10k"));
     send(QStringLiteral("events on"));
     send(QStringLiteral("status"));
+    // Restore the LCD on every (re)connect — mirrors the BT wake() that fires
+    // post-discovery in onCharacteristicsDiscoveryFinished. Idempotent on a
+    // scale whose LCD was already on; required when the previous DE1-sleep
+    // path turned it off and then closed the WS.
+    send(QStringLiteral("display on"));
 }
 
 void DecentScaleWifi::onDisconnected() {

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -448,10 +448,15 @@ void DecentScaleWifi::wake() {
 }
 
 void DecentScaleWifi::sleep() {
-    send(QStringLiteral("soft_sleep on"));
-    // BLE driver waits for characteristicWritten as the "command left the
-    // radio" ack. The WS analog is sendTextMessage returning — already
-    // happened above. Emit immediately to match BLE's intent.
+    // Firmware-level power off — the WS analog of BT's `0A 02 00`. The scale
+    // must be physically woken via its button afterward; this matches the BT
+    // transport's behavior exactly. `soft_sleep on` is the lighter reversible
+    // state and is wrong here: leaving the ESP32 radio active while the DE1
+    // sleeps drains a battery-only HDS.
+    send(QStringLiteral("{\"command\":\"power\",\"action\":\"off\"}"));
+    // BT waits for `characteristicWritten` as a "command left the radio" ack.
+    // The WS analog is sendTextMessage returning, which already happened above.
+    // Emit immediately to match BT's intent.
     emit sleepCompleted();
 }
 

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -91,7 +91,13 @@ private slots:
     void onRecognitionTimeout();
 
 private:
-    void send(const QString& text);
+    // Send a command text frame over the WS. Returns true on success, false
+    // when the socket is not in ConnectedState — Qt's sendTextMessage silently
+    // drops in that case (returns 0 bytes, no signal, no log), so the helper
+    // checks state and emits a WARN so dropped commands are diagnosable.
+    // Most callers ignore the return value; sleep() uses it to decide whether
+    // to log a delivery failure for the power-off command.
+    bool send(const QString& text);
     void handleSnapshotFrame(const QJsonObject& obj);
     void handleStatusFrame(const QJsonObject& obj);
     void handleButtonFrame(const QJsonObject& obj);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2691,9 +2691,21 @@ int main(int argc, char *argv[])
     });
 
     // Manage scale power state when the DE1 sleeps/wakes.
-    //   keepScaleOn=true  (default): send disableLcd() only — BLE stays connected,
-    //                                LCD re-enables via wake() on resume.
-    //   keepScaleOn=false: send sleep() then drop the BLE link once the write
+    //   keepScaleOn=true  (default): send disableLcd(). On BT the link stays
+    //                                connected and LCD re-enables via wake() on
+    //                                resume. On WiFi we additionally close the
+    //                                WS (after disableLcd) so the tablet's WiFi
+    //                                radio can park during DE1 sleep — there's
+    //                                no reason to keep a chatty TCP session
+    //                                open to the scale while the app is idle,
+    //                                and Android's WiFi power-save reliably
+    //                                kills the radio anyway (HDS AsyncTCP then
+    //                                reaps us at 30 s of unacked data, leaving
+    //                                a stale dirty disconnect). LCD comes back
+    //                                on via DecentScaleWifi::onConnected's
+    //                                "display on" when the WS reconnects on
+    //                                DE1 wake.
+    //   keepScaleOn=false: send sleep() then drop the link once the write
     //                      completes. Matches de1app's default for battery-only
     //                      scales. Auto-reconnect is suppressed via
     //                      scaleAutoReconnectSuppressed until the DE1 wakes.
@@ -2713,6 +2725,17 @@ int main(int argc, char *argv[])
                 if (settings.keepScaleOn()) {
                     qDebug() << "DE1 going to sleep - disabling scale LCD (keepScaleOn=true)";
                     physicalScale->disableLcd();
+                    // WiFi only: also gracefully close the WS so the tablet's
+                    // WiFi radio can park and the HDS doesn't reap us mid-sleep.
+                    // BT stays connected — the BLE radio doesn't have the same
+                    // idle-park pathology, and BT users have years of expecting
+                    // the link to survive the screensaver. See comment above
+                    // and DecentScaleWifi::onConnected for the LCD-restore.
+                    if (physicalScale->type() == QStringLiteral("decent-wifi")) {
+                        qDebug() << "DE1 sleep + WiFi scale - closing WS for the sleep interval";
+                        scaleAutoReconnectSuppressed = true;
+                        physicalScale->disconnectFromScale();
+                    }
                 } else {
                     qDebug() << "DE1 going to sleep - putting scale to sleep and disconnecting (keepScaleOn=false)";
                     // Suppress the reconnect timer that connectedChanged would
@@ -2733,10 +2756,11 @@ int main(int argc, char *argv[])
                 physicalScale->wake();
             } else if (scaleAutoReconnectSuppressed
                        && !settings.scaleAddress().isEmpty()) {
-                // keepScaleOn=false path: we deliberately disconnected on DE1
-                // sleep and suppressed the auto-reconnect. Re-arm the reconnect
-                // sequence now that the DE1 is back.
-                qDebug() << "DE1 woke up - re-arming scale reconnect (keepScaleOn=false)";
+                // We deliberately disconnected on DE1 sleep and suppressed the
+                // auto-reconnect — either via keepScaleOn=false (any transport)
+                // or via the keepScaleOn=true + WiFi graceful-close path above.
+                // Re-arm the reconnect sequence now that the DE1 is back.
+                qDebug() << "DE1 woke up - re-arming scale reconnect";
                 scaleAutoReconnectSuppressed = false;
                 // USB primary reconnects via UsbScaleManager, not this BLE/WiFi timer.
                 if (!scaleReconnectTimer.isActive()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1279,7 +1279,7 @@ int main(int argc, char *argv[])
             return;
         }
         if (scaleAutoReconnectSuppressed) {
-            qDebug() << "Scale reconnect (startup): suppressed (keepScaleOn=false), skipping";
+            qDebug() << "Scale reconnect (startup): suppressed (deliberate DE1-sleep disconnect), skipping";
             return;
         }
         if (scaleReconnectTimer.isActive()) {
@@ -1701,11 +1701,13 @@ int main(int argc, char *argv[])
                 emit bleManager.scaleDisconnected();
                 qDebug() << "Scale disconnected - switched to FlowScale";
                 // Start auto-reconnect if we have a saved scale address, unless
-                // the disconnect was a deliberate one from the DE1-sleep path
-                // (keepScaleOn=false). In that case the DE1-wake handler
-                // re-arms the reconnect.
+                // the disconnect was a deliberate one from a DE1-sleep path —
+                // either keepScaleOn=false on any transport, or keepScaleOn=true
+                // on WiFi (which gracefully closes the WS so the radio can park,
+                // see main.cpp's DE1-sleep handler below). In either case the
+                // DE1-wake handler re-arms the reconnect.
                 if (scaleAutoReconnectSuppressed) {
-                    qDebug() << "Scale disconnect was deliberate (keepScaleOn=false) - auto-reconnect suppressed until DE1 wakes";
+                    qDebug() << "Scale disconnect was deliberate (DE1-sleep) - auto-reconnect suppressed until DE1 wakes";
                 } else if (!settings.scaleAddress().isEmpty()
                            && !settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
                     // USB primary reconnects via UsbScaleManager, not this BLE/WiFi timer.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2698,12 +2698,12 @@ int main(int argc, char *argv[])
     //                                resume. On WiFi we additionally close the
     //                                WS (after disableLcd) so the tablet's WiFi
     //                                radio can park during DE1 sleep — there's
-    //                                no reason to keep a chatty TCP session
-    //                                open to the scale while the app is idle,
-    //                                and Android's WiFi power-save reliably
-    //                                kills the radio anyway (HDS AsyncTCP then
-    //                                reaps us at 30 s of unacked data, leaving
-    //                                a stale dirty disconnect). LCD comes back
+    //                                no reason to keep a live TCP session open
+    //                                to the scale while the app is idle, and
+    //                                Android's WiFi power-save reliably kills
+    //                                the radio anyway (HDS AsyncTCP then reaps
+    //                                us at 30 s of unacked data, leaving a
+    //                                stale dirty disconnect). LCD comes back
     //                                on via DecentScaleWifi::onConnected's
     //                                "display on" when the WS reconnects on
     //                                DE1 wake.
@@ -2753,7 +2753,17 @@ int main(int argc, char *argv[])
                 }
             }
         } else if (phase == MachineState::Phase::Idle) {
-            if (physicalScale && physicalScale->isConnected()) {
+            if (physicalScale && physicalScale->isConnected()
+                && !scaleAutoReconnectSuppressed) {
+                // The scale stayed connected through DE1 sleep (keepScaleOn=true
+                // on BT, or keepScaleOn=true+WiFi where the reconnect already
+                // landed before this phase change fired). LCD was turned off by
+                // disableLcd() — restore it. Skip wake() when
+                // scaleAutoReconnectSuppressed is set: a fresh reconnect's
+                // onConnected() will send `display on` itself, and a stray
+                // wake() during the suppressed window would send a redundant
+                // soft_sleep off + display on pair on a scale that was never
+                // soft-slept.
                 qDebug() << "DE1 woke up - waking scale LCD";
                 physicalScale->wake();
             } else if (scaleAutoReconnectSuppressed

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -100,14 +100,14 @@ class tst_DecentScaleWifi : public QObject {
 
 private:
     // Wait for the driver to connect to the fake server and the initial
-    // handshake messages ("rate 10k", "events on", "status") to arrive.
-    // QTRY_VERIFY actively polls so the timeout absorbs scheduler jitter
-    // between client `connected` and server `textMessageReceived`.
+    // handshake messages ("rate 10k", "events on", "status", "display on") to
+    // arrive. QTRY_VERIFY actively polls so the timeout absorbs scheduler
+    // jitter between client `connected` and server `textMessageReceived`.
     void connectAndHandshake(DecentScaleWifi& driver, FakeHdsServer& server) {
         QSignalSpy connectedSpy(&server, &FakeHdsServer::clientConnected);
         driver.connectToHost(server.host());
         QVERIFY(connectedSpy.wait(2000));
-        QTRY_VERIFY_WITH_TIMEOUT(server.received().size() >= 3, 2000);
+        QTRY_VERIFY_WITH_TIMEOUT(server.received().size() >= 4, 2000);
     }
 
 private slots:
@@ -153,11 +153,17 @@ private slots:
         DecentScaleWifi driver;
         connectAndHandshake(driver, server);
 
-        // After handshake, received() carries exactly the three setup frames in order.
+        // After handshake, received() carries the four setup frames in order.
+        // The "display on" frame restores LCD state on reconnect after the
+        // DE1-sleep keepScaleOn=true+WiFi graceful-close path turned it off;
+        // dropping it from onConnected() would silently leave the scale dark
+        // every time the DE1 wakes — this assertion is the regression guard.
         const QStringList rx = server.received();
+        QCOMPARE(rx.size(), 4);
         QCOMPARE(rx[0], QStringLiteral("rate 10k"));
         QCOMPARE(rx[1], QStringLiteral("events on"));
         QCOMPARE(rx[2], QStringLiteral("status"));
+        QCOMPARE(rx[3], QStringLiteral("display on"));
     }
 
     // ==========================================
@@ -204,7 +210,7 @@ private slots:
         QCOMPARE(server.received()[2], QStringLiteral("display on"));
     }
 
-    void sleepSendsSoftSleepOnAndEmitsSleepCompleted() {
+    void sleepSendsPowerOffAndEmitsSleepCompleted() {
         FakeHdsServer server;
         DecentScaleWifi driver;
         QSignalSpy sleepSpy(&driver, &ScaleDevice::sleepCompleted);
@@ -212,7 +218,14 @@ private slots:
         server.clearReceived();
 
         driver.sleep();
-        QTRY_VERIFY(server.received().contains(QStringLiteral("soft_sleep on")));
+        // sleep() must send the firmware power-off JSON, the WS analog of BT's
+        // 0A 02 00 — NOT soft_sleep on, which is wake()'s reversible-park
+        // complement and leaves the ESP32 radio active draining a battery-only
+        // HDS. The negative assertion guards against a revert to the earlier
+        // wrong mapping.
+        QTRY_VERIFY(server.received().contains(
+            QStringLiteral("{\"command\":\"power\",\"action\":\"off\"}")));
+        QVERIFY(!server.received().contains(QStringLiteral("soft_sleep on")));
         QCOMPARE(sleepSpy.count(), 1);
     }
 
@@ -414,7 +427,7 @@ private slots:
         QSignalSpy connectedSpy(&server, &FakeHdsServer::clientConnected);
         driver.connectToHost(QStringLiteral("hds.local"));
         QVERIFY(connectedSpy.wait(2000));
-        QTRY_VERIFY_WITH_TIMEOUT(server.received().size() >= 3, 2000);
+        QTRY_VERIFY_WITH_TIMEOUT(server.received().size() >= 4, 2000);
 
         // Send a snapshot so recognition fires.
         server.sendJson({{ "grams", 25.66 }, { "ms", 12345 }});
@@ -456,7 +469,7 @@ private slots:
         QVERIFY(realConnectedSpy.wait(8000));  // 5s timeout + fallback margin
 
         // Now the fallback (hostname) is active — send a snapshot so it validates.
-        QTRY_VERIFY_WITH_TIMEOUT(real.received().size() >= 3, 2000);
+        QTRY_VERIFY_WITH_TIMEOUT(real.received().size() >= 4, 2000);
         real.sendJson({{ "grams", 12.34 }, { "ms", 1000 }});
         QSignalSpy weightSpy(&driver, &ScaleDevice::weightChanged);
         QVERIFY(weightSpy.wait(500));


### PR DESCRIPTION
Two related changes to align WiFi scale lifecycle with BT semantics:

## 1. `DecentScaleWifi::sleep()` does firmware-level power-off (matches BT)

WiFi was sending \`soft_sleep on\` — the lighter reversible park state. BT \`DecentScale::sleep()\` sends \`0A 02 00\`, the firmware-level power-off that requires a physical button press to wake. Same logical "sleep" gesture should produce the same outcome on the scale regardless of transport.

Replaced with \`{\"command\":\"power\",\"action\":\"off\"}\` (HDS firmware's equivalent of \`0A 02 00\`).

**Practical impact**: on a battery-only HDS, \`soft_sleep on\` left the ESP32 radio active to maintain the WS, draining the battery while the DE1 was asleep. The new command fully powers the scale down.

The three existing call sites that invoke \`physicalScale->sleep()\` polymorphically are unchanged and now get matched behavior on both transports:
- App exit (\`main.cpp:2823\`)
- \`keepScaleOn=false\` on DE1 sleep (\`main.cpp:2727\`)
- MCP / MQTT \`machine_sleep\` (\`main.cpp:2689\`)

## 2. Graceful WS close on DE1 sleep when \`keepScaleOn=true\` (WiFi only)

No reason to hold an active TCP session open to the HDS while the app is idle. Android's WiFi power-save reliably parks the radio anyway, and the HDS's AsyncTCP 30 s ACK timeout then reaps us — leaving a stale dirty disconnect that the app only notices on DE1 wake when it tries to send the LCD-on command.

Under \`keepScaleOn=true\` (the default), the DE1-sleep path on WiFi now:
1. Calls \`disableLcd()\` (sends \`display off\`, unchanged).
2. Sets \`scaleAutoReconnectSuppressed = true\`.
3. Calls \`disconnectFromScale()\` (graceful WS close).

**BT is unchanged**: the BLE link stays connected through DE1 sleep, matching long-established behavior. BLE doesn't have the same idle-link pathology.

DE1 wake routes through the existing \`scaleAutoReconnectSuppressed\` branch (now shared by both \`keepScaleOn=false\` and the new \`keepScaleOn=true\`+WiFi path) to re-arm \`scaleReconnectTimer\`. \`DecentScaleWifi::onConnected()\` now sends \`display on\` post-handshake — idempotent on a scale whose LCD is already on, required to restore LCD after the DE1-sleep close.

## Test plan

- [x] Build clean (Qt 6.11.1, macOS Debug): 0 errors, 0 warnings, all unit tests link.
- [ ] WiFi scale + MCP \`machine_sleep\` → scale powers off, WS drops, requires button press to wake.
- [ ] WiFi scale + \`keepScaleOn=false\` + DE1 sleep → scale powers off, WS drops, button press to wake.
- [ ] WiFi scale + \`keepScaleOn=true\` (default) + DE1 sleep → \`display off\` lands, WS closes gracefully, scale stays powered. DE1 wake → WS reconnects automatically, LCD restored.
- [ ] BT scale (any \`keepScaleOn\`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)