### PR TITLE
perf(scale): faster reconnect after DE1 wake (200 ms vs 5 s first attempt)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2845,7 +2845,17 @@ int main(int argc, char *argv[])
                     if (!scaleReconnectTimer.isActive()
                         && !settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) {
                         scaleReconnectAttempt = 0;
-                        scaleReconnectTimer.start(reconnectDelays[0]);
+                        // Short first-attempt delay for the wake-from-sleep path:
+                        // the WiFi scale is known alive (we closed the WS ourselves
+                        // and the HDS is still up), and a powered-off BT scale will
+                        // fail this attempt quickly and fall into the normal
+                        // reconnectDelays backoff for retry #2 onward. The full 5 s
+                        // default (reconnectDelays[0]) was sized for unexpected
+                        // drops where the radio/firmware might need to settle —
+                        // neither applies here. Saves ~4.8 s of perceived
+                        // "scale disconnected" UI time after DE1 wake.
+                        constexpr int kWakeReconnectFirstAttemptMs = 200;
+                        scaleReconnectTimer.start(kWakeReconnectFirstAttemptMs);
                     }
                 } else {
                     // Neither branch fired: scale exists but is mid-reconnect


### PR DESCRIPTION
## Summary

User-visible: WiFi scale "connected" indicator now reappears in ~0.5 s after DE1 wake instead of ~5 s.

## Diagnosis

In the v1.7.5 build 3412 session at DE1 Sleep→Idle:
- \`+14.224\` \`DE1 woke up - re-arming scale reconnect\`
- \`+18.976\` \`Scale reconnect: attempt 1\` (5 s wait)
- \`+19.343\` WebSocket connected (367 ms after attempt 1)

The 5 s gap was \`reconnectDelays[0]\` — designed for unexpected drops where the radio or firmware needs settling time. On the wake-from-sleep path neither applies: the WiFi scale was disconnected by us (graceful close) and the HDS is still up.

## Change

The wake handler's reconnect-arming site now uses 200 ms instead of \`reconnectDelays[0]\`. Other sites that arm the first reconnect (connectedChanged fallback, disconnectScaleRequested, startup) keep the 5 s default.

For a BT scale that's powered off (\`keepScaleOn=false\` + button not pressed), the 200 ms attempt fails fast, then \`reconnectDelays[1]=30 s\` kicks in for retry #2 — identical schedule to today after the first attempt.

## Test plan

- [x] Build clean (Qt 6.11.1, macOS Debug): 0 errors, 0 warnings.
- [ ] On real DE1 + HDS WiFi: sleep DE1 → wake DE1 → scale reconnects within ~0.5 s of the wake event (vs ~5 s before).
- [ ] On BT \`keepScaleOn=false\`: sleep DE1 → wake DE1 → first attempt fails fast (scale is off), next retry at +30 s — unchanged from today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)