### PR TITLE
log(de1): mirror UI-only events to qDebug for post-hoc diagnosis

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -626,6 +626,7 @@ void DE1Device::parseMMRResponse(const QByteArray& data) {
             .arg(statusName)
             .arg(canStartFromApp ? "CAN" : "CANNOT");
 
+        qDebug().noquote() << logMsg;
         emit logMessage(logMsg);
 
         if (m_isHeadless != canStartFromApp) {
@@ -689,6 +690,7 @@ void DE1Device::parseMMRResponse(const QByteArray& data) {
         QString statusName = detected ? "detected" : "not detected";
 
         QString logMsg = QString("Refill kit: %1").arg(statusName);
+        qDebug().noquote() << logMsg;
         emit logMessage(logMsg);
 
         if (m_refillKitDetected != detected) {
@@ -1436,6 +1438,7 @@ void DE1Device::setWaterRefillLevel(int refillPointMm) {
     data.append(BinaryCodec::encodeShortBE(BinaryCodec::encodeU16P8(0)));
     data.append(BinaryCodec::encodeShortBE(BinaryCodec::encodeU16P8(static_cast<double>(refillPointMm))));
 
+    qDebug() << "[WaterLevels] write: StartFillLevel =" << refillPointMm << "mm";
     m_transport->write(DE1::Characteristic::WATER_LEVELS, data);
 }
 

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -400,6 +400,15 @@ void DE1Device::parseStateInfo(const QByteArray& data) {
     bool stateChanged = (newState != m_state);
     bool subStateChanged = (newSubState != m_subState);
 
+    if (stateChanged) {
+        qDebug().noquote() << QString("[Phase] %1 → %2 (water raw=%3 mm, displayed=%4 mm, %5 ml)")
+            .arg(DE1::stateToString(m_state))
+            .arg(DE1::stateToString(newState))
+            .arg(m_waterLevelMm - 5.0, 0, 'f', 1)
+            .arg(m_waterLevelMm, 0, 'f', 1)
+            .arg(m_waterLevelMl);
+    }
+
     m_state = newState;
     m_subState = newSubState;
 
@@ -505,6 +514,10 @@ void DE1Device::parseWaterLevel(const QByteArray& data) {
     // Only emit when water level changes by at least 0.5% or ml changes
     if (qAbs(m_waterLevel - m_lastEmittedWaterLevel) >= 0.5
         || m_waterLevelMl != m_lastEmittedWaterLevelMl) {
+        qDebug().noquote() << QString("[WaterLevel] raw=%1 mm displayed=%2 mm %3 ml")
+            .arg(rawMm, 0, 'f', 1)
+            .arg(m_waterLevelMm, 0, 'f', 1)
+            .arg(m_waterLevelMl);
         m_lastEmittedWaterLevel = m_waterLevel;
         m_lastEmittedWaterLevelMl = m_waterLevelMl;
         emit waterLevelChanged();


### PR DESCRIPTION
## Summary
- The 0x80385C (refill kit) and 0x80381C (GHC) MMR-read handlers in `DE1Device::parseMMRData()` emit their status via `logMessage`, which is wired to `BLEManager::de1LogMessage` (the BLE connection screen). That signal is **not** routed to qDebug, so events the user sees live in the UI ("Refill kit: detected", "GHC status: …") leave no trace in the persisted debug log — making post-hoc diagnosis blind to whether the kit was detected or what the GHC reported.
- `DE1Device::setWaterRefillLevel()` had no logging at all, so there was no record of the StartFillLevel mm value sent on the WaterLevels characteristic.
- Add `qDebug()` calls alongside the existing emits for both MMR handlers, plus a one-liner in `setWaterRefillLevel()` showing the mm value written.

Motivated by a real diagnostic session: machine entered Refill phase with the tank visibly full, and the log showed no "Refill kit:" line — leading to a misdiagnosis until the user pointed out the UI did say "detected". The signal was working; the persistence wasn't.

## Test plan
- [ ] Build and connect to DE1; confirm `Refill kit: detected` (or `not detected`) appears in the debug log on connect
- [ ] Confirm `GHC status: …` appears in the debug log on connect
- [ ] Confirm `[WaterLevels] write: StartFillLevel = N mm` appears whenever the refill-point setting changes or kit-detect transitions
- [ ] Connection-screen UI log still shows all three messages (the UI signal path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)