### PR TITLE
log(de1): name GHC status 7 ("active") instead of "unknown (7)"

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -624,6 +624,10 @@ void DE1Device::parseMMRResponse(const QByteArray& data) {
     if (address == 0x80381C) {
         uint8_t ghcStatus = d[4];
 
+        // de1app does not enumerate ghc_is_installed values either; only its
+        // ghc_required() allowlist {0,1,2,4} is authoritative. Value 7 is the
+        // common "GHC active" code on modern DE1+ hardware (and the default in
+        // de1app's simulation files). Treat it the same as 3 here.
         QString statusName;
         switch (ghcStatus) {
             case 0: statusName = "not installed"; break;
@@ -631,6 +635,7 @@ void DE1Device::parseMMRResponse(const QByteArray& data) {
             case 2: statusName = "inactive"; break;
             case 3: statusName = "active"; break;
             case 4: statusName = "debug"; break;
+            case 7: statusName = "active"; break;
             default: statusName = QString("unknown (%1)").arg(ghcStatus); break;
         }
 


### PR DESCRIPTION
## Summary
- The GHC handler in `DE1Device::parseMMRResponse` enumerated values 0–4 and treated everything else as `unknown (N)`. Live on pcb=1.3 / v1352, the DE1 reports `ghc_is_installed = 7`, producing log lines like `GHC status: unknown (7) → app CANNOT start operations`.
- 7 is the common "GHC active" code on modern DE1+ hardware. All three de1app simulation files (`simulated_{1,2,3}.shot`) default `ghc_is_installed 7`, and de1app's `ghc_required()` returns 1 for 7 (same conclusion as Decenza's `canStartFromApp = (status in {0,1,2,4})`).
- Add `case 7: statusName = "active"` (same label as 3) so the log line reads sensibly. `canStartFromApp` behaviour is unchanged — 7 still means "GHC has start authority, app cannot start operations", which matches both de1app and live behaviour on a GHC machine.

## Test plan
- [ ] After the next build, connect to a real DE1+ with an active GHC and confirm the debug log shows `GHC status: active → app CANNOT start operations` instead of `unknown (7) → ...`.
- [ ] Confirm starting espresso/flush/steam from the GHC still works (no change expected; logic path is identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)