### PR TITLE
wifi-scale: set DSCP EF + TCP_NODELAY on the WS socket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ find_package(Qt6 REQUIRED COMPONENTS
     Sql
     Positioning
     WebSockets
+    WebSocketsPrivate
     CanvasPainter
 )
 
@@ -570,6 +571,7 @@ target_link_libraries(Decenza PRIVATE
     Qt6::Sql
     Qt6::Positioning
     Qt6::WebSockets
+    Qt6::WebSocketsPrivate
     Qt6::CanvasPainter
 )
 

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -517,14 +517,23 @@ void DecentScaleWifi::applyTcpQos() {
     // accept-but-discard (e.g. some Android OEM stacks for TOS), the read-back
     // value won't match what we wrote — that's diagnostically valuable, so
     // log both regardless.
+    //
+    // For TOS, the exact byte matters (it's the DSCP marker the kernel will
+    // stamp onto every outgoing packet), so log it verbatim. For TCP_NODELAY
+    // we only care whether Nagle is off — some platforms (e.g. macOS) return a
+    // truthy-but-not-1 value from getsockopt(TCP_NODELAY), so booleanize the
+    // read-back instead of printing the raw integer.
     const QVariant tosRead = tcp->socketOption(QAbstractSocket::TypeOfServiceOption);
     const QVariant lowDelayRead = tcp->socketOption(QAbstractSocket::LowDelayOption);
+    const QString lowDelayStr =
+        !lowDelayRead.isValid() ? QStringLiteral("<n/a>")
+        : (lowDelayRead.toInt() != 0 ? QStringLiteral("enabled") : QStringLiteral("disabled"));
 
     WIFI_LOG(QString("applyTcpQos: requested DSCP EF (TOS=0x%1) + TCP_NODELAY; "
-                     "readback TOS=%2 LowDelay=%3")
+                     "readback TOS=%2 TCP_NODELAY=%3")
              .arg(kDscpEfTosByte, 2, 16, QLatin1Char('0'))
              .arg(tosRead.isValid() ? QString::number(tosRead.toInt(), 16) : QStringLiteral("<n/a>"))
-             .arg(lowDelayRead.isValid() ? QString::number(lowDelayRead.toInt()) : QStringLiteral("<n/a>")));
+             .arg(lowDelayStr));
 }
 
 void DecentScaleWifi::tare()       { send(QStringLiteral("tare")); }

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -7,10 +7,18 @@
 #include <QTimer>
 #include <QUrl>
 #include <QAbstractSocket>
+#include <QTcpSocket>
 #include <QHostAddress>
 #include <QThread>
 #include <QPointer>
 #include <algorithm>
+
+// Private headers — reach the QTcpSocket inside QWebSocket so we can set DSCP
+// and TCP_NODELAY (see applyTcpQos). Project already uses Qt private headers
+// elsewhere (QZipReader/QZipWriter) — same pattern, same risks (no API
+// guarantees across Qt versions). Pinned to Qt 6.11.x; revisit on upgrade.
+#include <private/qobject_p.h>
+#include <private/qwebsocket_p.h>
 
 #include "../../network/mdnsresolver.h"
 
@@ -161,8 +169,15 @@ void DecentScaleWifi::disconnectFromScale() {
 }
 
 void DecentScaleWifi::onConnected() {
-    WIFI_LOG("WebSocket connected");
+    const QString peerIp   = m_socket ? m_socket->peerAddress().toString() : QString();
+    const quint16 peerPort = m_socket ? m_socket->peerPort() : 0;
+    const quint16 localPort = m_socket ? m_socket->localPort() : 0;
+    WIFI_LOG(QString("WebSocket connected — peer=%1:%2 localPort=%3")
+             .arg(peerIp).arg(peerPort).arg(localPort));
     setConnected(true);
+
+    // Promote latency-critical traffic to Voice AC via DSCP, and kill Nagle.
+    applyTcpQos();
 
     // Bump to the highest cadence the firmware supports, opt in to events,
     // and seed an initial status frame so battery/firmware_version populate
@@ -450,6 +465,46 @@ bool DecentScaleWifi::send(const QString& text) {
     }
     m_socket->sendTextMessage(text);
     return true;
+}
+
+void DecentScaleWifi::applyTcpQos() {
+    if (!m_socket) {
+        WIFI_WARN(QStringLiteral("applyTcpQos: no QWebSocket — skipping"));
+        return;
+    }
+
+    // Pull the underlying QTcpSocket out of QWebSocketPrivate. Both classes
+    // are private API; the cast pattern (QObjectPrivate::get on the public
+    // object, then downcast to the concrete *Private) is the standard way Qt
+    // itself talks to its d-pointers.
+    auto* d = static_cast<QWebSocketPrivate*>(QObjectPrivate::get(m_socket));
+    QTcpSocket* tcp = d ? d->m_pSocket : nullptr;
+    if (!tcp) {
+        WIFI_WARN(QStringLiteral("applyTcpQos: QWebSocketPrivate has no QTcpSocket — skipping"));
+        return;
+    }
+
+    // DSCP EF (Expedited Forwarding) = 0x2E in the 6-bit DSCP field, which is
+    // 0xB8 when shifted into the 8-bit TOS byte (DSCP occupies the top 6 bits;
+    // the bottom 2 are ECN, left zero). Android/iOS/macOS/Linux/Windows map
+    // this to WMM AC_VO when the AP supports WMM. If the router/AP strips or
+    // ignores DSCP, no harm done — the byte still goes out.
+    constexpr int kDscpEfTosByte = 0xB8;
+    tcp->setSocketOption(QAbstractSocket::TypeOfServiceOption, kDscpEfTosByte);
+    tcp->setSocketOption(QAbstractSocket::LowDelayOption, 1);  // TCP_NODELAY
+
+    // Read back via the same option getters. On platforms that silently
+    // accept-but-discard (e.g. some Android OEM stacks for TOS), the read-back
+    // value won't match what we wrote — that's diagnostically valuable, so
+    // log both regardless.
+    const QVariant tosRead = tcp->socketOption(QAbstractSocket::TypeOfServiceOption);
+    const QVariant lowDelayRead = tcp->socketOption(QAbstractSocket::LowDelayOption);
+
+    WIFI_LOG(QString("applyTcpQos: requested DSCP EF (TOS=0x%1) + TCP_NODELAY; "
+                     "readback TOS=%2 LowDelay=%3")
+             .arg(kDscpEfTosByte, 2, 16, QLatin1Char('0'))
+             .arg(tosRead.isValid() ? QString::number(tosRead.toInt(), 16) : QStringLiteral("<n/a>"))
+             .arg(lowDelayRead.isValid() ? QString::number(lowDelayRead.toInt()) : QStringLiteral("<n/a>")));
 }
 
 void DecentScaleWifi::tare()       { send(QStringLiteral("tare")); }

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -20,6 +20,25 @@
 #include <private/qobject_p.h>
 #include <private/qwebsocket_p.h>
 
+// Access-bypass for QWebSocketPrivate::m_pSocket. The member is declared
+// `private` (not just inside a private header), so we cannot name it
+// directly. [temp.spec]/2 lets explicit template instantiations name
+// otherwise-inaccessible class members through a member-pointer template
+// parameter, exposing them via a friend function. Standards-conforming;
+// preferred over the more common `#define private public` hack (which is UB
+// and varies by compiler).
+namespace {
+template <typename Tag, typename Tag::Type M>
+struct AccessBypass {
+    friend typename Tag::Type get(Tag) { return M; }
+};
+struct WsPrivateSocketTag {
+    using Type = QTcpSocket* QWebSocketPrivate::*;
+    friend Type get(WsPrivateSocketTag);
+};
+template struct AccessBypass<WsPrivateSocketTag, &QWebSocketPrivate::m_pSocket>;
+} // namespace
+
 #include "../../network/mdnsresolver.h"
 
 #define WIFI_LOG(msg)  SCALE_LOG("DecentScaleWifi", msg)
@@ -473,12 +492,13 @@ void DecentScaleWifi::applyTcpQos() {
         return;
     }
 
-    // Pull the underlying QTcpSocket out of QWebSocketPrivate. Both classes
-    // are private API; the cast pattern (QObjectPrivate::get on the public
-    // object, then downcast to the concrete *Private) is the standard way Qt
-    // itself talks to its d-pointers.
+    // Pull the underlying QTcpSocket out of QWebSocketPrivate. The cast
+    // pattern (QObjectPrivate::get on the public object, then downcast to the
+    // concrete *Private) is the standard way Qt itself talks to its
+    // d-pointers; reaching the `private` m_pSocket member uses the
+    // AccessBypass trick defined at file scope above.
     auto* d = static_cast<QWebSocketPrivate*>(QObjectPrivate::get(m_socket));
-    QTcpSocket* tcp = d ? d->m_pSocket : nullptr;
+    QTcpSocket* tcp = d ? d->*get(WsPrivateSocketTag{}) : nullptr;
     if (!tcp) {
         WIFI_WARN(QStringLiteral("applyTcpQos: QWebSocketPrivate has no QTcpSocket — skipping"));
         return;

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -16,7 +16,11 @@
 // Private headers — reach the QTcpSocket inside QWebSocket so we can set DSCP
 // and TCP_NODELAY (see applyTcpQos). Project already uses Qt private headers
 // elsewhere (QZipReader/QZipWriter) — same pattern, same risks (no API
-// guarantees across Qt versions). Pinned to Qt 6.11.x; revisit on upgrade.
+// guarantees across Qt versions). On a Qt upgrade, re-verify:
+//   1. `QWebSocketPrivate::m_pSocket` still exists and is still a `QTcpSocket*`
+//      (used by AccessBypass below; a type/name change → compile error here).
+//   2. `QWebSocketPrivate` still derives from `QObjectPrivate` so
+//      `static_cast<QWebSocketPrivate*>(QObjectPrivate::get(...))` is well-formed.
 #include <private/qobject_p.h>
 #include <private/qwebsocket_p.h>
 
@@ -495,8 +499,10 @@ void DecentScaleWifi::applyTcpQos() {
     // Pull the underlying QTcpSocket out of QWebSocketPrivate. The cast
     // pattern (QObjectPrivate::get on the public object, then downcast to the
     // concrete *Private) is the standard way Qt itself talks to its
-    // d-pointers; reaching the `private` m_pSocket member uses the
-    // AccessBypass trick defined at file scope above.
+    // d-pointers; reaching the `private` m_pSocket member uses
+    // `AccessBypass<WsPrivateSocketTag, &QWebSocketPrivate::m_pSocket>` defined
+    // at file scope above, with `get(WsPrivateSocketTag{})` returning the
+    // member pointer that the `->*` then applies to d.
     auto* d = static_cast<QWebSocketPrivate*>(QObjectPrivate::get(m_socket));
     QTcpSocket* tcp = d ? d->*get(WsPrivateSocketTag{}) : nullptr;
     if (!tcp) {
@@ -516,7 +522,8 @@ void DecentScaleWifi::applyTcpQos() {
     // Read back via the same option getters. On platforms that silently
     // accept-but-discard (e.g. some Android OEM stacks for TOS), the read-back
     // value won't match what we wrote — that's diagnostically valuable, so
-    // log both regardless.
+    // log both regardless, and escalate to WARN on mismatch so a support
+    // workflow grepping for warnings can see when QoS didn't take.
     //
     // For TOS, the exact byte matters (it's the DSCP marker the kernel will
     // stamp onto every outgoing packet), so log it verbatim. For TCP_NODELAY
@@ -525,15 +532,28 @@ void DecentScaleWifi::applyTcpQos() {
     // read-back instead of printing the raw integer.
     const QVariant tosRead = tcp->socketOption(QAbstractSocket::TypeOfServiceOption);
     const QVariant lowDelayRead = tcp->socketOption(QAbstractSocket::LowDelayOption);
+
+    const int tosReadInt = tosRead.isValid() ? tosRead.toInt() : -1;
+    const bool tosOk = (tosReadInt == kDscpEfTosByte);
+    const bool nodelayOk = lowDelayRead.isValid() && lowDelayRead.toInt() != 0;
+    const QString tosStr =
+        tosReadInt < 0 ? QStringLiteral("<n/a>") : QString::number(tosReadInt, 16);
     const QString lowDelayStr =
         !lowDelayRead.isValid() ? QStringLiteral("<n/a>")
-        : (lowDelayRead.toInt() != 0 ? QStringLiteral("enabled") : QStringLiteral("disabled"));
+        : (nodelayOk ? QStringLiteral("enabled") : QStringLiteral("disabled"));
 
-    WIFI_LOG(QString("applyTcpQos: requested DSCP EF (TOS=0x%1) + TCP_NODELAY; "
-                     "readback TOS=%2 TCP_NODELAY=%3")
-             .arg(kDscpEfTosByte, 2, 16, QLatin1Char('0'))
-             .arg(tosRead.isValid() ? QString::number(tosRead.toInt(), 16) : QStringLiteral("<n/a>"))
-             .arg(lowDelayStr));
+    const QString line = QString("applyTcpQos: requested DSCP EF (TOS=0x%1) + TCP_NODELAY; "
+                                 "readback TOS=%2 TCP_NODELAY=%3")
+                         .arg(kDscpEfTosByte, 2, 16, QLatin1Char('0'))
+                         .arg(tosStr).arg(lowDelayStr);
+    if (tosOk && nodelayOk) {
+        WIFI_LOG(line);
+    } else {
+        WIFI_WARN(QString("%1 — kernel did not honor request (tosOk=%2 nodelayOk=%3)")
+                  .arg(line)
+                  .arg(tosOk ? QStringLiteral("yes") : QStringLiteral("no"))
+                  .arg(nodelayOk ? QStringLiteral("yes") : QStringLiteral("no")));
+    }
 }
 
 void DecentScaleWifi::tare()       { send(QStringLiteral("tare")); }

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -98,6 +98,16 @@ private:
     // Most callers ignore the return value; sleep() uses it to decide whether
     // to log a delivery failure for the power-off command.
     bool send(const QString& text);
+
+    // Reaches into QWebSocketPrivate via the private header to set socket
+    // options on the underlying QTcpSocket: TCP_NODELAY (LowDelayOption) and
+    // DSCP EF (TypeOfServiceOption=0xB8). On Wi-Fi, DSCP→WMM mapping promotes
+    // EF/CS5/CS6 to the Voice AC, which has the shortest backoff timers. The
+    // intent is to tighten the round-trip distribution for time-critical
+    // commands (mainly stop-at-weight). Logs the outcome so we can verify the
+    // options actually took on each platform/router combination. Called from
+    // onConnected() once the underlying TCP socket exists.
+    void applyTcpQos();
     void handleSnapshotFrame(const QJsonObject& obj);
     void handleStatusFrame(const QJsonObject& obj);
     void handleButtonFrame(const QJsonObject& obj);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -493,7 +493,11 @@ add_decenza_test(tst_decentscalewifi
     ${CMAKE_SOURCE_DIR}/src/ble/scales/decentscalewifi.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/scales/scaletypeids.cpp
 )
-target_link_libraries(tst_decentscalewifi PRIVATE Qt6::WebSockets)
+target_link_libraries(tst_decentscalewifi PRIVATE
+    Qt6::WebSockets
+    Qt6::WebSocketsPrivate
+    Qt6::CorePrivate
+)
 
 # --- tst_wifiscalediscovery: mDNS probe service ---
 add_decenza_test(tst_wifiscalediscovery


### PR DESCRIPTION
## Summary

Reach into `QWebSocketPrivate` via the private header to grab the underlying `QTcpSocket`, then set:
- `TypeOfServiceOption = 0xB8` — DSCP EF (Expedited Forwarding). On Wi-Fi this maps to WMM AC_VO, the highest-priority Access Category, which has the shortest backoff timers.
- `LowDelayOption = 1` — disables Nagle's algorithm (`TCP_NODELAY`) so single-command frames go out immediately instead of waiting for additional bytes or an ACK.

Plus connect-time diagnostic logging: `peer=<ip>:<port> localPort=<n>` on connect, and an `applyTcpQos:` line showing both the requested bytes and the read-back values so we can verify per-platform whether the kernel actually honored the option (some Android OEM stacks silently discard TOS settings — read-back is the only way to know).

## Motivation

Side-by-side `[SAW-Latency]` sampling on a real DE1+ showed BT mean 49 ms σ 9 ms vs WiFi mean 75 ms σ 31 ms, with a 118 ms outlier on a single shot. The mean delta (~26 ms) is mostly absorbed by SAW learning (no measurable accuracy gap), but the **variance** is 3× higher on WiFi. DSCP+TCP_NODELAY targets the variance specifically: priority queueing on contended Wi-Fi reduces the tail, and TCP_NODELAY removes Nagle as a possible head-of-line villain for the single-frame commands HDS uses.

(Note that `[SAW-Latency]` measures the DE1 BLE leg, not the scale-WS leg directly. This change targets the scale-WS leg which still affects end-to-end overshoot via stale weight reads.)

## Approach: Qt private header

`QWebSocket` exposes no public socket-option API. The only in-process route is `<private/qwebsocket_p.h>` + `<private/qobject_p.h>`, then `static_cast<QWebSocketPrivate*>(QObjectPrivate::get(m_socket))->m_pSocket`. Same pattern as our existing `QZipReader`/`QZipWriter` use; `CorePrivate` was already linked. Added `Qt6::WebSocketsPrivate` to CMakeLists.

Risk: private headers carry no API-compatibility guarantee. Pinned to Qt 6.11.x like the rest of the build; revisit on Qt upgrades.

## Test plan

- [ ] Build and connect to HDS via WiFi. Confirm new log lines appear:
  - `WebSocket connected — peer=<ip>:<port> localPort=<n>`
  - `applyTcpQos: requested DSCP EF (TOS=0xb8) + TCP_NODELAY; readback TOS=... LowDelay=...`
- [ ] Verify that read-back values match what was requested (or note any platforms that silently discard).
- [ ] Pull a handful of shots on D-Flow / Q with the WiFi scale and compare `[SAW-Latency]` distribution against the pre-PR baseline. Aim: tighter σ; mean may or may not move.
- [ ] No regression on BT-scale shots (this PR only touches `DecentScaleWifi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)