### PR TITLE
wifi-scale: suppress "Scale shut down" dialog when app initiated the power-off

### DIFF
--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -595,8 +595,9 @@ void DecentScaleWifi::sleep() {
     //
     // Mark the imminent power_off echo as app-initiated so handlePowerFrame
     // doesn't pop a "Scale shut down: disabled" dialog at the user. Set
-    // BEFORE the send so a synchronous reply from the firmware (rare but
-    // possible) still sees the flag.
+    // BEFORE the send to keep the assignment+send pair locally correct —
+    // any future caller or mock that delivers the echo synchronously inside
+    // send() still sees the flag set.
     m_powerOffInitiatedByApp = true;
     const bool sent = send(QStringLiteral("{\"command\":\"power\",\"action\":\"off\"}"));
     if (!sent) {
@@ -605,6 +606,14 @@ void DecentScaleWifi::sleep() {
         // dropped power-off command isn't masked by a misleading
         // "drained successfully" log downstream. Common at app exit after a
         // DE1-sleep keepScaleOn=true+WiFi close (socket already in ClosingState).
+        //
+        // Clear the latch locally: no echo will arrive (we didn't send the
+        // command), so if a firmware-initiated power_off (low battery, button)
+        // happens before the next connectToHost() cycle resets it, it must
+        // surface, not be silently suppressed. The connectToHost() reset is
+        // still the backstop for the case where send() succeeded but the
+        // socket dropped before the echo arrived.
+        m_powerOffInitiatedByApp = false;
         WIFI_WARN("sleep(): power-off command not delivered (socket not connected)");
     }
     // BT waits for `characteristicWritten` as a "command left the radio" ack.

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -88,6 +88,11 @@ void DecentScaleWifi::connectToHost(const QString& hostname) {
     m_pendingHostnameFallback = false;
     m_socketErrorThisConnect = false;
     m_lastSocketErrorString.clear();
+    // Reset the app-initiated-power-off latch — if a prior cycle armed it via
+    // sleep() but the firmware echo never arrived (e.g. socket dropped first),
+    // the next connection's first real power_off frame (low battery, button)
+    // must surface, not be silently suppressed.
+    m_powerOffInitiatedByApp = false;
     // New connection cycle — invalidate any in-flight resolve from a prior call.
     ++m_resolveGeneration;
 
@@ -412,6 +417,19 @@ void DecentScaleWifi::handlePowerFrame(const QJsonObject& obj) {
     const QString reasonText = reason.isEmpty()
         ? QString("code %1").arg(reasonCode)
         : reason;
+
+    // If we initiated the power-off ourselves via sleep(), the firmware's
+    // echo back to us is not actionable for the user — suppress the dialog
+    // but still log so the diagnostic trail is intact. Consume-and-clear so
+    // a subsequent firmware-initiated power_off (low battery, button) still
+    // surfaces normally.
+    if (m_powerOffInitiatedByApp) {
+        m_powerOffInitiatedByApp = false;
+        WIFI_LOG(QString("Scale shut down: %1 (code %2) — app-initiated, dialog suppressed")
+                 .arg(reasonText).arg(reasonCode));
+        return;
+    }
+
     WIFI_WARN(QString("Scale shut down: %1 (code %2)").arg(reasonText).arg(reasonCode));
     emit errorOccurred(translateUiString("wifi.scale.error.scaleShutdown",
         "Scale shut down: %1").arg(reasonText));
@@ -574,6 +592,12 @@ void DecentScaleWifi::sleep() {
     // transport's behavior exactly. `soft_sleep on` is the lighter reversible
     // state and is wrong here: leaving the ESP32 radio active while the DE1
     // sleeps drains a battery-only HDS.
+    //
+    // Mark the imminent power_off echo as app-initiated so handlePowerFrame
+    // doesn't pop a "Scale shut down: disabled" dialog at the user. Set
+    // BEFORE the send so a synchronous reply from the firmware (rare but
+    // possible) still sees the flag.
+    m_powerOffInitiatedByApp = true;
     const bool sent = send(QStringLiteral("{\"command\":\"power\",\"action\":\"off\"}"));
     if (!sent) {
         // Caller (app-exit waitLoop, DE1-sleep handler) hangs forever waiting

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -175,6 +175,13 @@ private:
     // (attemptTarget); set in onError only when m_userInitiatedShutdown is false.
     bool m_socketErrorThisConnect = false;
     QString m_lastSocketErrorString;
+    // Set in sleep() when we send the firmware power-off JSON. The scale
+    // echoes back a `power_off` frame (reason "disabled", code 0) on receipt;
+    // without this flag handlePowerFrame would fire a user-facing dialog
+    // saying "Scale shut down: disabled" — noise, because we initiated it.
+    // Consumed-and-cleared in handlePowerFrame; the disconnect path is
+    // already classified expected via m_userInitiatedShutdown.
+    bool m_powerOffInitiatedByApp = false;
 
     IpResolver m_ipResolver;     // hostname → cached IP (or empty)
     IpCacheUpdate m_ipCacheUpdate;  // hostname, ip → side-effect

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -507,6 +507,70 @@ private slots:
         QCOMPARE(connectedSpy.count(), initialConnections + 1);
         QVERIFY(!driver.isConnected());
     }
+
+    // After sleep() has armed the app-initiated-power-off latch, the firmware
+    // echoes back a power_off frame (reason "disabled", code 0). The user
+    // already knows — we just told the scale to power off — so the dialog
+    // (errorOccurred) must be suppressed. The disconnect-classification
+    // bookkeeping (m_userInitiatedShutdown) still fires, and a low-level
+    // INFO log records the event for diagnostics.
+    void appInitiatedPowerOffSuppressesDialog() {
+        FakeHdsServer server;
+        DecentScaleWifi driver;
+        QSignalSpy errorSpy(&driver, &ScaleDevice::errorOccurred);
+        connectAndHandshake(driver, server);
+
+        driver.sleep();  // arms m_powerOffInitiatedByApp
+        QTRY_VERIFY(server.received().contains(
+            QStringLiteral("{\"command\":\"power\",\"action\":\"off\"}")));
+
+        server.sendJson({
+            { "type", "power" },
+            { "event", "power_off" },
+            { "reason", "disabled" },
+            { "reason_code", 0 },
+        });
+        QTest::qWait(50);
+
+        QCOMPARE(errorSpy.count(), 0);  // dialog suppressed
+    }
+
+    // The latch is one-shot: after the app-initiated power_off is consumed,
+    // a subsequent firmware-initiated power_off (low battery, button) must
+    // still surface a dialog. Without explicit clearing, a sleep() whose
+    // echo got lost could silently swallow a real shutdown later.
+    void firmwareInitiatedPowerOffStillDialogsAfterAppInitiated() {
+        FakeHdsServer server;
+        DecentScaleWifi driver;
+        QSignalSpy errorSpy(&driver, &ScaleDevice::errorOccurred);
+        connectAndHandshake(driver, server);
+
+        // First: app-initiated, suppressed.
+        driver.sleep();
+        QTRY_VERIFY(server.received().contains(
+            QStringLiteral("{\"command\":\"power\",\"action\":\"off\"}")));
+        server.sendJson({
+            { "type", "power" },
+            { "event", "power_off" },
+            { "reason", "disabled" },
+            { "reason_code", 0 },
+        });
+        QTest::qWait(50);
+        QCOMPARE(errorSpy.count(), 0);
+
+        // Second: firmware-initiated, must dialog. Latch already cleared by
+        // the first frame's consume-and-clear.
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*Scale shut down: low_battery.*"));
+        server.sendJson({
+            { "type", "power" },
+            { "event", "power_off" },
+            { "reason", "low_battery" },
+            { "reason_code", 3 },
+        });
+        QTest::qWait(50);
+        QCOMPARE(errorSpy.count(), 1);
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_DecentScaleWifi)

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -511,9 +511,7 @@ private slots:
     // After sleep() has armed the app-initiated-power-off latch, the firmware
     // echoes back a power_off frame (reason "disabled", code 0). The user
     // already knows — we just told the scale to power off — so the dialog
-    // (errorOccurred) must be suppressed. The disconnect-classification
-    // bookkeeping (m_userInitiatedShutdown) still fires, and a low-level
-    // INFO log records the event for diagnostics.
+    // (errorOccurred) must be suppressed.
     void appInitiatedPowerOffSuppressesDialog() {
         FakeHdsServer server;
         DecentScaleWifi driver;
@@ -560,6 +558,57 @@ private slots:
 
         // Second: firmware-initiated, must dialog. Latch already cleared by
         // the first frame's consume-and-clear.
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*Scale shut down: low_battery.*"));
+        server.sendJson({
+            { "type", "power" },
+            { "event", "power_off" },
+            { "reason", "low_battery" },
+            { "reason_code", 3 },
+        });
+        QTest::qWait(50);
+        QCOMPARE(errorSpy.count(), 1);
+    }
+
+    // sleep() called while the socket is not connected (common at app exit
+    // after a DE1-sleep keepScaleOn=true+WiFi close — the WS is already in
+    // ClosingState when sleep() runs): the power-off command isn't delivered,
+    // so no firmware echo will arrive. Verify the observable end-to-end
+    // behaviour:
+    //   (a) sleep() still completes (sleepCompleted emitted) so app-exit
+    //       waitLoops don't hang
+    //   (b) the "not delivered" WARN fires for diagnostics
+    //   (c) after reconnecting and receiving a real firmware power_off, the
+    //       dialog still fires — the latch did NOT leak past the failed
+    //       sleep.
+    // Note: this test can't isolate which clear-path did the work — both
+    // sleep()'s self-clear-on-failure AND connectToHost()'s reset would
+    // independently produce (c). Both are present in the implementation as
+    // defense-in-depth; the test only asserts the combined invariant.
+    void sleepWithDisconnectedSocketDoesNotLeakLatch() {
+        DecentScaleWifi driver;
+        QSignalSpy sleepSpy(&driver, &ScaleDevice::sleepCompleted);
+        QSignalSpy errorSpy(&driver, &ScaleDevice::errorOccurred);
+        // No connectAndHandshake() — socket starts in UnconnectedState, so
+        // send() returns false synchronously.
+
+        // sleep() in this branch fires TWO warnings: send()'s own
+        // "send() dropped — socket not connected" (because we never
+        // connected), then sleep()'s "power-off command not delivered".
+        // Order matters for ignoreMessage — first match consumes first
+        // emit.
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*send\\(\\) dropped.*"));
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*power-off command not delivered.*"));
+        driver.sleep();
+        QCOMPARE(sleepSpy.count(), 1);
+        QCOMPARE(errorSpy.count(), 0);
+
+        // Now connect and receive a firmware-initiated power_off — must dialog.
+        FakeHdsServer server;
+        connectAndHandshake(driver, server);
+
         QTest::ignoreMessage(QtWarningMsg,
             QRegularExpression(".*Scale shut down: low_battery.*"));
         server.sendJson({


### PR DESCRIPTION
## Summary

When the DE1 goes to sleep with `keepScaleOn=false`, Decenza calls `DecentScaleWifi::sleep()` which sends `{"command":"power","action":"off"}` to the HDS. The firmware then echoes back a `power_off` frame with `reason: "disabled"` (code 0), and `handlePowerFrame` was treating it as an unexpected event — popping a "Scale shut down" dialog at the user. From the user's perspective this was noise: we knew the scale was about to power off because we just asked it to.

Confirmed live in Jeff's log:
```
[2835.088] [BLE DecentScaleWifi] First 'power' frame this connect: {"type":"power","event":"power_off","reason":"disabled","reason_code":0,"ms":12339844}
[2835.092] WARN  [BLE DecentScaleWifi] Scale shut down: disabled (code 0)
```

## Approach

Track an `m_powerOffInitiatedByApp` one-shot latch:
- **Armed** by `sleep()` right before the send (so a synchronous reply still sees it).
- **Consumed-and-cleared** by `handlePowerFrame` on the next `power_off` frame: log at INFO with a "— app-initiated, dialog suppressed" suffix (diagnostic trail preserved), skip the `errorOccurred` emit.
- **Also cleared** in `connectToHost` so a `sleep()` whose echo got lost (e.g. socket dropped before the firmware could reply) can't silently swallow a real firmware-initiated `power_off` on the next connection.

Genuinely-firmware-initiated `power_off` frames (low battery, button long-press, fault) still surface the dialog as before — the latch is one-shot and only set on app-initiated paths.

The disconnect-classification bookkeeping (`m_userInitiatedShutdown`) is unchanged, so `onDisconnected` still logs `"(expected) — scale power-off: <reason>"`.

## Test plan

Two new tests added; all 22 in `tst_decentscalewifi` pass locally:

- `appInitiatedPowerOffSuppressesDialog` — after `sleep()`, the echoed `{type:power, event:power_off, reason:disabled}` does NOT emit `errorOccurred`.
- `firmwareInitiatedPowerOffStillDialogsAfterAppInitiated` — after an app-initiated power_off is consumed, a subsequent firmware-initiated `low_battery` power_off still surfaces the dialog. Verifies the latch is one-shot, not a permanent mute.

Manual check (next build):
- [ ] DE1-sleep with `keepScaleOn=false` no longer pops a dialog.
- [ ] Manually pulling the scale's battery (or simulating low_battery via firmware) still pops the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)