### PR TITLE
wifi-scale: fresh QWebSocket per connect attempt

### DIFF
--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -50,21 +50,18 @@ template struct AccessBypass<WsPrivateSocketTag, &QWebSocketPrivate::m_pSocket>;
 
 DecentScaleWifi::DecentScaleWifi(QObject* parent)
     : ScaleDevice(parent)
-    , m_socket(new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this))
+    , m_socket(nullptr)
     , m_recognitionTimer(new QTimer(this))
 {
     m_recognitionTimer->setSingleShot(true);
     connect(m_recognitionTimer, &QTimer::timeout,
             this, &DecentScaleWifi::onRecognitionTimeout);
 
-    connect(m_socket, &QWebSocket::connected,
-            this, &DecentScaleWifi::onConnected);
-    connect(m_socket, &QWebSocket::disconnected,
-            this, &DecentScaleWifi::onDisconnected);
-    connect(m_socket, &QWebSocket::textMessageReceived,
-            this, &DecentScaleWifi::onTextMessageReceived);
-    connect(m_socket, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::errorOccurred),
-            this, &DecentScaleWifi::onError);
+    // Initial socket — recreateSocket() will swap it on every connect attempt,
+    // but we need something non-null in m_socket so the various state guards
+    // (m_socket && m_socket->state() != UnconnectedState in the destructor etc.)
+    // don't crash if the driver is destroyed before its first connect attempt.
+    recreateSocket();
 }
 
 DecentScaleWifi::~DecentScaleWifi() {
@@ -116,11 +113,52 @@ void DecentScaleWifi::attemptTarget(const QString& target, bool isHostname) {
     m_lastSocketErrorString.clear();
     if (isHostname) m_triedHostnameFallback = true;
 
+    // Fresh QWebSocket per attempt — see recreateSocket()'s docstring for
+    // the staleness bug this works around. Cheap (microseconds) and
+    // architecturally correct.
+    recreateSocket();
+
     const QUrl url(QStringLiteral("ws://%1/snapshot").arg(target));
     WIFI_LOG(QString("Connecting to %1 (%2)").arg(
         url.toString(), isHostname ? QStringLiteral("hostname") : QStringLiteral("cached IP")));
     m_socket->open(url);
     m_recognitionTimer->start(kRecognitionTimeoutMs);
+}
+
+void DecentScaleWifi::recreateSocket() {
+    // Stop the recognition timer first: if the old socket was mid-attempt,
+    // the timer's onRecognitionTimeout slot would otherwise fire against
+    // the new socket (the slot calls m_socket->abort() which would kill the
+    // fresh attempt).
+    m_recognitionTimer->stop();
+
+    if (m_socket) {
+        // Detach the old socket's signals from this object so any late-emitted
+        // signals from the dying socket (deferred disconnected/errorOccurred
+        // queued by Qt's event loop) can't run our handlers — which would
+        // mistakenly operate on the NEW m_socket pointer they refer to.
+        m_socket->disconnect(this);
+        // Hard close (abort) before scheduling deletion — close() is graceful
+        // and would queue a close frame that might race the delete. abort()
+        // tears the TCP down immediately. deleteLater defers destruction past
+        // the current event loop tick, which is safe even while signals from
+        // the old socket are unwinding.
+        if (m_socket->state() != QAbstractSocket::UnconnectedState) {
+            m_socket->abort();
+        }
+        m_socket->deleteLater();
+    }
+
+    m_socket = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
+
+    connect(m_socket, &QWebSocket::connected,
+            this, &DecentScaleWifi::onConnected);
+    connect(m_socket, &QWebSocket::disconnected,
+            this, &DecentScaleWifi::onDisconnected);
+    connect(m_socket, &QWebSocket::textMessageReceived,
+            this, &DecentScaleWifi::onTextMessageReceived);
+    connect(m_socket, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::errorOccurred),
+            this, &DecentScaleWifi::onError);
 }
 
 void DecentScaleWifi::attemptHostname() {

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -57,10 +57,13 @@ DecentScaleWifi::DecentScaleWifi(QObject* parent)
     connect(m_recognitionTimer, &QTimer::timeout,
             this, &DecentScaleWifi::onRecognitionTimeout);
 
-    // Initial socket — recreateSocket() will swap it on every connect attempt,
-    // but we need something non-null in m_socket so the various state guards
-    // (m_socket && m_socket->state() != UnconnectedState in the destructor etc.)
-    // don't crash if the driver is destroyed before its first connect attempt.
+    // Initial socket — recreateSocket() will swap it on every connect attempt.
+    // Called here rather than deferring to the first attemptTarget() because
+    // several code paths assume m_socket is non-null without a guard
+    // (e.g. onRecognitionTimeout calls m_socket->abort() directly). The
+    // destructor's own check IS null-safe, so this isn't about destructor
+    // safety — it's about the invariant "m_socket is always live" that the
+    // signal handlers rely on.
     recreateSocket();
 }
 
@@ -133,10 +136,16 @@ void DecentScaleWifi::recreateSocket() {
     m_recognitionTimer->stop();
 
     if (m_socket) {
-        // Detach the old socket's signals from this object so any late-emitted
-        // signals from the dying socket (deferred disconnected/errorOccurred
-        // queued by Qt's event loop) can't run our handlers — which would
-        // mistakenly operate on the NEW m_socket pointer they refer to.
+        // Detach the old socket's signals from this object. These connections
+        // are Qt::AutoConnection → DirectConnection (same thread), so they
+        // fire synchronously, not through the signal queue. The risk we're
+        // guarding against: the underlying QSocketNotifier / QAbstractSocket
+        // may already have a state-change event posted to the event loop
+        // from before we call abort() below. When that event runs, the
+        // dying socket re-emits disconnected/errorOccurred, and without
+        // this disconnect those would invoke onDisconnected/onError against
+        // `this` — which by then references the NEW m_socket, and the stale
+        // event would corrupt the new attempt's state machine.
         m_socket->disconnect(this);
         // Hard close (abort) before scheduling deletion — close() is graceful
         // and would queue a close frame that might race the delete. abort()

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -671,17 +671,54 @@ void DecentScaleWifi::onError() {
     // user. The 503 "another client connected" case handled above is the one
     // socket error we DO surface here, because the retry loop can never resolve it.
     // #1253
+    bool fastFailError = false;
     switch (err) {
     case QAbstractSocket::HostNotFoundError:
     case QAbstractSocket::ConnectionRefusedError:
     case QAbstractSocket::NetworkError:
     case QAbstractSocket::SocketTimeoutError:
         m_userInitiatedShutdown = true;
+        fastFailError = true;
         break;
     default:
         // Other errors fall through — the recognition timeout will catch the
         // case where the WS upgrade hangs without a clean socket error.
         break;
+    }
+
+    // Fast-fail: if a cached-IP attempt fires a fatal transient socket error,
+    // don't sit on the 5 s recognition timer waiting to time out — start the
+    // hostname fallback immediately. The kernel just told us the cached IP
+    // is dead; there's nothing to gain from waiting longer. Real symptom this
+    // addresses: on macOS cold start the network stack may still be warming
+    // up, the cached scale IP isn't routable yet, and the 5 s wait was long
+    // enough for the BLE-scale fallback machinery to also trigger and fail
+    // (CoreBluetooth not powered on), pushing the FlowScale-fallback dialog
+    // at the user before the WiFi scale could simply be retried via hostname.
+    if (fastFailError &&
+        !m_currentTargetIsHostname &&
+        !m_triedHostnameFallback &&
+        !m_pendingHostnameFallback) {
+        WIFI_LOG(QString("Cached IP %1 unreachable (%2) — fast-failing to hostname %3 fallback")
+                 .arg(m_currentTarget, errStr, m_hostname));
+        m_recognitionTimer->stop();
+
+        if (m_socket && m_socket->state() != QAbstractSocket::UnconnectedState) {
+            // Socket is mid-teardown. Use the existing flag mechanism that
+            // onRecognitionTimeout uses: abort to force a clean disconnect,
+            // and onDisconnected sees m_pendingHostnameFallback and runs
+            // attemptHostname() inline once the close completes.
+            m_pendingHostnameFallback = true;
+            m_socket->abort();
+        } else {
+            // Socket has already disconnected (onDisconnected raced ahead of
+            // this onError and went through its normal path without the
+            // pending flag set). Dial the hostname fallback ourselves, queued
+            // to the event loop so signal handlers remain re-entrant-safe.
+            QMetaObject::invokeMethod(this,
+                [this]() { attemptHostname(); },
+                Qt::QueuedConnection);
+        }
     }
 }
 

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -108,6 +108,18 @@ private:
     // options actually took on each platform/router combination. Called from
     // onConnected() once the underlying TCP socket exists.
     void applyTcpQos();
+
+    // Tear down the current m_socket and replace it with a fresh QWebSocket
+    // before each connect attempt. Reusing a single QWebSocket across multiple
+    // open()/abort() cycles surfaces a Qt-internal state-staleness bug where
+    // the next attempt's WS handshake completes against the server, then
+    // immediately closes with peer-close code 1000 + UnknownSocketError(-1)
+    // — likely because Qt's internal close-state/error bookkeeping carries
+    // over from the prior abort(). Observed in production: scale auto-
+    // reconnect loops would fail this way until the scale-type-change path
+    // happened to construct a brand-new DecentScaleWifi (and thus a fresh
+    // QWebSocket), at which point the very next dial succeeded immediately.
+    void recreateSocket();
     void handleSnapshotFrame(const QJsonObject& obj);
     void handleStatusFrame(const QJsonObject& obj);
     void handleButtonFrame(const QJsonObject& obj);

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -6,6 +6,7 @@
 #include <QRegularExpression>
 #include <QJsonObject>
 #include <QJsonDocument>
+#include <QElapsedTimer>
 
 #include "ble/scales/decentscalewifi.h"
 
@@ -619,6 +620,51 @@ private slots:
         });
         QTest::qWait(50);
         QCOMPARE(errorSpy.count(), 1);
+    }
+
+    // When the cached-IP dial fires a fatal transient socket error
+    // (HostNotFoundError, ConnectionRefusedError, NetworkError, SocketTimeoutError),
+    // the driver must NOT sit on the 5 s recognition timer waiting for it to
+    // expire — the kernel just told us the cached IP is dead, so the hostname
+    // fallback should run immediately. The user-visible symptom this prevents
+    // is on macOS cold start: ARP/route stale at .242 → cached-IP connect
+    // fast-fails → without this fix we wait 5 s, during which BLE-fallback
+    // also fails (CoreBluetooth radio not powered on yet), tripping a
+    // FlowScale "no scale" dialog before the WiFi scale could just be retried.
+    //
+    // Test setup: a cached IP that points at a localhost port with no
+    // listener (ConnectionRefusedError fires near-instantly), and a real
+    // FakeHdsServer for the hostname fallback target.
+    void cachedIpFastFailsToHostnameFallback() {
+        FakeHdsServer hostnameServer;
+        DecentScaleWifi driver;
+        // The cached IP resolver returns a port with no listener — connect
+        // will fail fast with ConnectionRefusedError.
+        driver.setIpResolver([](const QString& /*host*/) {
+            return QStringLiteral("127.0.0.1:1");  // Port 1: no listener
+        });
+        QSignalSpy connectedSpy(&hostnameServer, &FakeHdsServer::clientConnected);
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*WebSocket error.*"));
+
+        // Dial via the hostname target (which the FakeHdsServer is listening on).
+        QElapsedTimer timer;
+        timer.start();
+        driver.connectToHost(hostnameServer.host());
+
+        // The hostname-fallback connect must succeed FAR sooner than the 5 s
+        // recognition timeout — give it a generous 2 s budget to absorb CI jitter.
+        // Pre-fix this would have taken ~5 s.
+        QVERIFY(connectedSpy.wait(2000));
+        // Also wait for the driver's handshake messages to land on the server so
+        // setConnected(true) has definitely fired — otherwise init()'s expected
+        // DISCONNECTED warning won't fire at scope exit and the test fails on
+        // "Did not receive any message matching".
+        QTRY_VERIFY_WITH_TIMEOUT(hostnameServer.received().size() >= 4, 2000);
+        const qint64 elapsed = timer.elapsed();
+        QVERIFY2(elapsed < 4000,
+            qPrintable(QString("Hostname fallback took %1 ms — must be far less than "
+                               "the 5 s recognition timeout").arg(elapsed)));
     }
 };
 


### PR DESCRIPTION
## Summary

`DecentScaleWifi` held a single `QWebSocket` for its lifetime and re-used it across every connect attempt (initial cached-IP try, hostname fallback, reconnect cycles, `abort()`-then-retry). Reusing a `QWebSocket` across multiple `open()`/`abort()` cycles surfaces a Qt-internal state-staleness bug: subsequent attempts' WS handshakes complete against the server, then immediately close with peer-close `code 1000` + `UnknownSocketError(-1)` — likely because Qt's internal close-state and error bookkeeping carry over from the prior `abort()`.

Stacks on top of PR #1274 (fast-fail to hostname fallback). #1274 fires the hostname attempt sooner; this PR ensures that hostname attempt uses a fresh socket.

## How we caught it

Reproduced live on a macOS instance this evening: the WiFi scale auto-reconnect loop failed in a tight cycle for several minutes — every attempt got `peer close (code 1000)` + `Unknown error (-1)` within milliseconds of WS handshake completion. Manually invoking `devices_connect_scale` via the Decenza MCP triggered the `Scale type changed from \"decent\" to \"decent-wifi\" - creating new scale` code path, which happens to construct a brand-new `DecentScaleWifi` and thus a fresh `QWebSocket`. The very next dial connected in 93 ms — same IP, same scale, same code path past the constructor, but a fresh socket.

```
[291.789] [BLE DecentScaleWifi] Trying cached IP 192.168.10.242 for hds.local
[291.790] [BLE DecentScaleWifi] Connecting to ws://192.168.10.242/snapshot (cached IP)
[291.883] [BLE DecentScaleWifi] WebSocket connected — peer=192.168.10.242:80 localPort=53860
[291.884] [Scale] \"Half Decent Scale (WiFi)\" CONNECTED
[291.895] [BLE DecentScaleWifi] First 'rate' frame this connect: {...}
```

Conclusive client-side state bug.

## Fix

Add `recreateSocket()` private helper. Call it at the start of `attemptTarget()` so every connect attempt starts from a clean slate. The helper:
1. Stops the recognition timer (it would otherwise fire `m_socket->abort()` against the new socket).
2. Disconnects all signals from the old socket to `this` so any late-emitted/queued signals can't run our handlers and mistakenly reference the new `m_socket`.
3. Aborts the old socket if it's not already `UnconnectedState`, then `deleteLater()`s it.
4. Constructs a fresh `QWebSocket` and re-wires `connected`/`disconnected`/`textMessageReceived`/`errorOccurred`.

Construction overhead is microseconds. Architecturally this matches Qt's general one-shot pattern for transient network resources (`QNetworkReply`, `QHttpMultiPart`, etc.) and eliminates an entire class of state-staleness bugs without diving into Qt's private internals to debug which specific `QWebSocket` member is sticky.

## Test plan

- All 24/24 existing tests pass with zero warnings.
- `cachedIpFastFailsToHostnameFallback` (added in PR #1274) exercises a full cached-IP-attempt → recreate-via-attemptTarget → hostname-attempt cycle. Would have failed if the recreation broke signal wiring.
- Manual verification needed after merge: confirm the auto-reconnect loop on macOS now actually reconnects without requiring the scale-type-change workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)