### PR TITLE
Move Gemini AI provider to 3.5 Flash

### DIFF
--- a/docs/CLAUDE_MD/AI_ADVISOR.md
+++ b/docs/CLAUDE_MD/AI_ADVISOR.md
@@ -18,7 +18,7 @@
 |----------|-------|---------|------|
 | Anthropic | Claude Sonnet 4.6 | Explicit `cache_control` on system prompt. 5-min TTL, ~90% discount on cached input | Cloud |
 | OpenAI | GPT-4.1 | Automatic for prefixes >1024 tokens. ~50% discount | Cloud |
-| Google Gemini | 3.5 Flash | Not implemented (supports explicit Context Caching API with longer TTL) | Cloud |
+| Google Gemini | 3.5 Flash | Implicit caching automatic (stable system prompt sent first); explicit Context Caching not implemented | Cloud |
 | OpenRouter | User-selected | Passes through to underlying provider | Cloud |
 | Ollama | User-selected | N/A — local, no cost | Local/free |
 

--- a/docs/CLAUDE_MD/AI_ADVISOR.md
+++ b/docs/CLAUDE_MD/AI_ADVISOR.md
@@ -18,7 +18,7 @@
 |----------|-------|---------|------|
 | Anthropic | Claude Sonnet 4.6 | Explicit `cache_control` on system prompt. 5-min TTL, ~90% discount on cached input | Cloud |
 | OpenAI | GPT-4.1 | Automatic for prefixes >1024 tokens. ~50% discount | Cloud |
-| Google Gemini | 2.5 Flash | Not implemented (supports explicit Context Caching API with longer TTL) | Cloud |
+| Google Gemini | 3.5 Flash | Not implemented (supports explicit Context Caching API with longer TTL) | Cloud |
 | OpenRouter | User-selected | Passes through to underlying provider | Cloud |
 | Ollama | User-selected | N/A — local, no cost | Local/free |
 

--- a/docs/kb_sources/UNIVERSAL_GRIND_SETTING.md
+++ b/docs/kb_sources/UNIVERSAL_GRIND_SETTING.md
@@ -499,7 +499,7 @@ for per-user baseline comparisons (see §5).
 ### In-App AI Advisor
 
 Built-in advisor (`src/ai/`) with 5 pluggable providers (Claude Sonnet 4.6, GPT-4.1,
-Gemini 2.5 Flash, OpenRouter, Ollama). Supports multi-turn conversations with persistent
+Gemini 3.5 Flash, OpenRouter, Ollama). Supports multi-turn conversations with persistent
 storage (5 slots keyed by bean + profile), dial-in history injection (last 5 same-profile
 shots), and provider-specific prompt caching.
 

--- a/src/ai/aiprovider.cpp
+++ b/src/ai/aiprovider.cpp
@@ -625,13 +625,14 @@ void GeminiProvider::sendRequest(const QJsonObject& requestBody)
     req.setRawHeader("x-goog-api-key", m_apiKey.toUtf8());
     req.setTransferTimeout(ANALYSIS_TIMEOUT_MS);
 
-    // Disable thinking tokens — espresso advice doesn't need extended reasoning
-    // and thinking output billing (~$3.50/MTok) dwarfs standard output ($0.60/MTok).
+    // Gemini 3.x ignores the 2.5-era integer thinkingBudget; it needs the thinkingLevel
+    // enum, else thinking defaults to "medium" (billed at the $9/MTok output rate).
     QJsonObject bodyWithConfig = requestBody;
     QJsonObject thinkingConfig;
-    thinkingConfig["thinkingBudget"] = 0;
+    thinkingConfig["thinkingLevel"] = "minimal";
     QJsonObject generationConfig;
     generationConfig["thinkingConfig"] = thinkingConfig;
+    generationConfig["maxOutputTokens"] = 1024;  // also bounds thinking tokens; matches other providers
     bodyWithConfig["generationConfig"] = generationConfig;
 
     m_retryFn = [this, requestBody]() { sendRequest(requestBody); };
@@ -759,6 +760,12 @@ void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
         emit analysisFailed("Gemini error: " + errorMsg);
         return;
     }
+
+    const QJsonObject usage = root["usageMetadata"].toObject();
+    qInfo() << "Gemini usage — prompt:" << usage["promptTokenCount"].toInt()
+            << "thoughts:" << usage["thoughtsTokenCount"].toInt()
+            << "output:" << usage["candidatesTokenCount"].toInt()
+            << "total:" << usage["totalTokenCount"].toInt();
 
     QJsonArray candidates = root["candidates"].toArray();
     if (candidates.isEmpty()) {

--- a/src/ai/aiprovider.h
+++ b/src/ai/aiprovider.h
@@ -174,8 +174,8 @@ private:
     void sendRequest(const QJsonObject& requestBody);
 
     QString m_apiKey;
-    static constexpr const char* MODEL = "gemini-2.5-flash";
-    static constexpr const char* MODEL_DISPLAY = "2.5 Flash";
+    static constexpr const char* MODEL = "gemini-3.5-flash";
+    static constexpr const char* MODEL_DISPLAY = "3.5 Flash";
     QString apiUrl() const;
 };
 


### PR DESCRIPTION
## Summary
- Bump the Google AI provider from `gemini-2.5-flash` to `gemini-3.5-flash` (`src/ai/aiprovider.h`), the frontier-class Flash model from Google I/O 2026.
- **Fix thinking control for 3.x**: the 2.5-era `thinkingBudget: 0` is silently ignored on 3.5, defaulting thinking to `medium` — billed at the $9/MTok output rate. Switch to `thinkingConfig.thinkingLevel: "minimal"`.
- **Cap output**: add `maxOutputTokens: 1024` (which also bounds thinking tokens), matching the budget the other providers already use.
- **Measure, don't guess**: log `usageMetadata` (prompt / thoughts / output / total token counts) on each analysis.
- Update display string + doc references; note that implicit caching is automatic on Gemini.

## Why
- 2.5 Flash is a generation-plus behind; 3.5 Flash delivers near-flagship reasoning at Flash latency, at ~half the cost of the Anthropic option (Sonnet 4.6). Users bring their own key, so cost lands on the end user.
- The thinking fix is the high-leverage part: left on the old knob, `medium` thinking would inflate per-analysis cost ~1.4–2.3× (thinking tokens bill at the output rate). `minimal` keeps spend on the visible answer.
- Implicit caching is automatic for 2.5+/3.x and we already send the stable system prompt first, so we bank that discount for free. Explicit Context Caching is intentionally **not** implemented — its hourly storage fee + lifecycle complexity don't pay off for sporadic, per-user, BYO-key usage.

## Test plan
- [ ] Build in Qt Creator.
- [ ] Settings → AI → Google Gemini → enter key → Test Connection → expect "Connected to Gemini successfully".
- [ ] Run a shot analysis with the Gemini provider; confirm a complete (non-truncated) response renders.
- [ ] Check logs for the `Gemini usage —` line and confirm `thoughts:` is ~0 (verifies `thinkingLevel: "minimal"` is honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)