### PR TITLE
wifi-scale: drop scale-error modal paths; existing dialogs are enough

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1301,10 +1301,8 @@ ApplicationWindow {
         // wrong instruction.
         Tr { id: trEnableLocation;     key: "main.dialog.enableLocation.title";  fallback: "Enable Location";    visible: false }
         Tr { id: trEnableBluetooth;    key: "main.dialog.enableBluetooth.title"; fallback: "Enable Bluetooth";   visible: false }
-        // Generic title for non-permission errors. Transport-neutral because this
-        // dialog also surfaces WiFi-scale errors (e.g. "WiFi scale not found"),
-        // which are NOT Bluetooth errors. The Location / Bluetooth-permission cases
-        // above keep their specific titles.
+        // Generic title for non-permission errors. The Location /
+        // Bluetooth-permission cases above keep their specific titles.
         Tr { id: trBleErrorGeneric;    key: "main.dialog.bleError.title";        fallback: "Connection Error";   visible: false }
         Tr { id: trErrorPrefix;        key: "common.accessibility.errorPrefix";  fallback: "Error:";             visible: false }
 

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -445,10 +445,10 @@ void DecentScaleWifi::handlePowerFrame(const QJsonObject& obj) {
     if (event != QStringLiteral("power_off")) return;
 
     // Reject malformed power_off frames that omit BOTH the reason string and
-    // the numeric reason code — without either, we can't tell the user why
-    // the scale is going down, and marking the disconnect as "expected" would
-    // hide a potentially-real failure. Let the following unexpected disconnect
-    // log surface so it's diagnosable.
+    // the numeric reason code — without either, we have no diagnostic detail
+    // to log, and marking the disconnect as "expected" would hide a
+    // potentially-real failure. Let the following unexpected disconnect log
+    // surface so it's diagnosable.
     if (reason.isEmpty() && reasonCode == -1) {
         WIFI_WARN("Malformed power_off frame (no reason or reason_code) — "
                   "treating as unexpected disconnect");
@@ -711,9 +711,10 @@ void DecentScaleWifi::onError() {
     // abandoned — BLEManager's per-connect connection timer (onScaleConnectionTimeout)
     // is the backstop: it retries, recovers a still-booting scale, and for a
     // genuinely-gone scale emits the FlowScale-fallback notice that informs the
-    // user. The 503 "another client connected" case handled above is the one
-    // socket error we DO surface here, because the retry loop can never resolve it.
-    // #1253
+    // user. The 503 case handled above takes the same route — drop the link,
+    // let the reconnect ladder retry, fall back to the standard notice if the
+    // cap stays saturated. No socket-error path in this function surfaces a
+    // modal of its own.
     bool fastFailError = false;
     switch (err) {
     case QAbstractSocket::HostNotFoundError:
@@ -763,11 +764,4 @@ void DecentScaleWifi::onError() {
                 Qt::QueuedConnection);
         }
     }
-}
-
-QString DecentScaleWifi::translateUiString(const QString& key, const QString& fallback) const {
-    if (m_uiTranslator) {
-        return m_uiTranslator(key, fallback);
-    }
-    return fallback;
 }

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -465,21 +465,18 @@ void DecentScaleWifi::handlePowerFrame(const QJsonObject& obj) {
         ? QString("code %1").arg(reasonCode)
         : reason;
 
-    // If we initiated the power-off ourselves via sleep(), the firmware's
-    // echo back to us is not actionable for the user — suppress the dialog
-    // but still log so the diagnostic trail is intact. Consume-and-clear so
-    // a subsequent firmware-initiated power_off (low battery, button) still
-    // surfaces normally.
+    // Consume-and-clear the app-initiated flag so the next firmware-initiated
+    // power_off still logs with full detail. We don't surface a dialog either
+    // way — the existing "Scale Disconnected" notice (only after reconnect
+    // gives up) is the user-facing signal.
     if (m_powerOffInitiatedByApp) {
         m_powerOffInitiatedByApp = false;
-        WIFI_LOG(QString("Scale shut down: %1 (code %2) — app-initiated, dialog suppressed")
+        WIFI_LOG(QString("Scale shut down: %1 (code %2) — app-initiated")
                  .arg(reasonText).arg(reasonCode));
         return;
     }
 
     WIFI_WARN(QString("Scale shut down: %1 (code %2)").arg(reasonText).arg(reasonCode));
-    emit errorOccurred(translateUiString("wifi.scale.error.scaleShutdown",
-        "Scale shut down: %1").arg(reasonText));
 }
 
 void DecentScaleWifi::handleRateFrame(const QJsonObject& obj) {
@@ -641,7 +638,7 @@ void DecentScaleWifi::sleep() {
     // sleeps drains a battery-only HDS.
     //
     // Mark the imminent power_off echo as app-initiated so handlePowerFrame
-    // doesn't pop a "Scale shut down: disabled" dialog at the user. Set
+    // logs at LOG level (we already know about it) rather than WARN. Set
     // BEFORE the send to keep the assignment+send pair locally correct —
     // any future caller or mock that delivers the echo synchronously inside
     // send() still sees the flag set.
@@ -688,13 +685,12 @@ void DecentScaleWifi::onError() {
     const QString errStr = m_socket ? m_socket->errorString() : QStringLiteral("<no socket>");
     WIFI_WARN(QString("WebSocket error: %1 (code %2)").arg(errStr).arg(static_cast<int>(err)));
 
-    // 503 detection — firmware refuses additional clients past its cap. Qt's
-    // WebSocket error path surfaces this in errorString(). Treated as an expected
-    // refusal (we surface a modal), so it must NOT be recorded as a transport
-    // error — return before the transport-error capture below.
+    // 503 detection — firmware refuses additional clients past its cap. Treat
+    // as an expected refusal so it isn't recorded as a transport error, but
+    // don't surface a modal: HDS firmware now allows multiple concurrent
+    // clients, so a 503 in practice means the cap is briefly saturated and the
+    // standard "Scale Disconnected" / FlowScale fallback notice is sufficient.
     if (errStr.contains(QStringLiteral("503"))) {
-        emit errorOccurred(translateUiString("wifi.scale.error.serverBusy",
-            "Another client is connected to the scale"));
         m_userInitiatedShutdown = true;
         return;
     }

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -59,16 +59,6 @@ public:
     void setIpResolver(IpResolver resolver) { m_ipResolver = std::move(resolver); }
     void setIpCacheUpdate(IpCacheUpdate cb) { m_ipCacheUpdate = std::move(cb); }
 
-    // Optional UI-string translator — when set, user-visible error strings
-    // (those emitted via errorOccurred) are translated via stable i18n keys
-    // with the English text as fallback. Scale debug-log lines (WIFI_LOG /
-    // WIFI_WARN) stay in English — they're diagnostic, not user-facing.
-    // Decoupled from TranslationManager as a std::function so tests can link
-    // this driver without pulling in the full Settings/TranslationManager
-    // stack — matches the IpResolver / IpCacheUpdate pattern above.
-    using UiTranslator = std::function<QString(const QString& key, const QString& fallback)>;
-    void setUiTranslator(UiTranslator translator) { m_uiTranslator = std::move(translator); }
-
 public slots:
     void tare() override;
     void startTimer() override;
@@ -197,9 +187,4 @@ private:
 
     IpResolver m_ipResolver;     // hostname → cached IP (or empty)
     IpCacheUpdate m_ipCacheUpdate;  // hostname, ip → side-effect
-
-    UiTranslator m_uiTranslator;  // empty by default → falls back to English
-    // Translate `key` with `fallback`. Returns fallback if no UI translator
-    // is set. Use ONLY for user-visible strings (errorOccurred payloads).
-    QString translateUiString(const QString& key, const QString& fallback) const;
 };

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -189,8 +189,8 @@ private:
     QString m_lastSocketErrorString;
     // Set in sleep() when we send the firmware power-off JSON. The scale
     // echoes back a `power_off` frame (reason "disabled", code 0) on receipt;
-    // without this flag handlePowerFrame would fire a user-facing dialog
-    // saying "Scale shut down: disabled" — noise, because we initiated it.
+    // this flag lets handlePowerFrame log the echo at LOG level (app-initiated)
+    // instead of WARN (firmware-initiated, e.g. low battery / physical button).
     // Consumed-and-cleared in handlePowerFrame; the disconnect path is
     // already classified expected via m_userInitiatedShutdown.
     bool m_powerOffInitiatedByApp = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1472,7 +1472,7 @@ int main(int argc, char *argv[])
 
     // Connect to any supported scale when discovered
     QObject::connect(&bleManager, &BLEManager::scaleDiscovered,
-                     [&physicalScale, &flowScale, &machineState, &mainController, &engine, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &scaleAutoReconnectSuppressed, &scaleLcdRestorePending, &translationManager
+                     [&physicalScale, &flowScale, &machineState, &mainController, &engine, &bleManager, &settings, &timingController, &de1Device, &weightProcessor, &scaleReconnectTimer, &scaleReconnectAttempt, &reconnectDelays, &scaleAutoReconnectSuppressed, &scaleLcdRestorePending
 #ifndef Q_OS_IOS
                      , &usbScaleManager
 #endif
@@ -1543,9 +1543,6 @@ int main(int argc, char *argv[])
                         });
                         wifi->setIpCacheUpdate([&settings](const QString& host, const QString& ip) {
                             settings.network()->setWifiScaleIp(host, ip);
-                        });
-                        wifi->setUiTranslator([&translationManager](const QString& key, const QString& fallback) {
-                            return translationManager.translate(key, fallback);
                         });
                         wifi->connectToHost(bleManager.pendingWifiHostname());
                     }
@@ -1769,9 +1766,6 @@ int main(int argc, char *argv[])
                 });
                 wifi->setIpCacheUpdate([&settings](const QString& host, const QString& ip) {
                     settings.network()->setWifiScaleIp(host, ip);
-                });
-                wifi->setUiTranslator([&translationManager](const QString& key, const QString& fallback) {
-                    return translationManager.translate(key, fallback);
                 });
                 wifi->connectToHost(hostname);
             }

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -510,9 +510,9 @@ private slots:
     }
 
     // After sleep() has armed the app-initiated-power-off latch, the firmware
-    // echoes back a power_off frame (reason "disabled", code 0). The user
-    // already knows — we just told the scale to power off — so the dialog
-    // (errorOccurred) must be suppressed.
+    // echoes back a power_off frame (reason "disabled", code 0). No
+    // errorOccurred should ever fire (the dialog path was removed — see the
+    // method-level comment in handlePowerFrame); kept as a regression guard.
     void appInitiatedPowerOffSuppressesDialog() {
         FakeHdsServer server;
         DecentScaleWifi driver;
@@ -536,15 +536,16 @@ private slots:
 
     // The latch is one-shot: after the app-initiated power_off is consumed,
     // a subsequent firmware-initiated power_off (low battery, button) must
-    // still surface a dialog. Without explicit clearing, a sleep() whose
-    // echo got lost could silently swallow a real shutdown later.
+    // log at WARN level (not LOG). ignoreMessage on the WARN regex is what
+    // enforces the level — if the latch leaked, the second frame would log
+    // at LOG and the ignoreMessage would go unmatched, failing the test.
     void firmwareInitiatedPowerOffStillDialogsAfterAppInitiated() {
         FakeHdsServer server;
         DecentScaleWifi driver;
         QSignalSpy errorSpy(&driver, &ScaleDevice::errorOccurred);
         connectAndHandshake(driver, server);
 
-        // First: app-initiated, suppressed.
+        // First: app-initiated.
         driver.sleep();
         QTRY_VERIFY(server.received().contains(
             QStringLiteral("{\"command\":\"power\",\"action\":\"off\"}")));
@@ -555,10 +556,8 @@ private slots:
             { "reason_code", 0 },
         });
         QTest::qWait(50);
-        QCOMPARE(errorSpy.count(), 0);
 
-        // Second: firmware-initiated, must dialog. Latch already cleared by
-        // the first frame's consume-and-clear.
+        // Second: firmware-initiated — must log at WARN (latch cleared).
         QTest::ignoreMessage(QtWarningMsg,
             QRegularExpression(".*Scale shut down: low_battery.*"));
         server.sendJson({
@@ -568,7 +567,7 @@ private slots:
             { "reason_code", 3 },
         });
         QTest::qWait(50);
-        QCOMPARE(errorSpy.count(), 1);
+        QCOMPARE(errorSpy.count(), 0);  // dialog path removed in both cases
     }
 
     // sleep() called while the socket is not connected (common at app exit
@@ -580,8 +579,9 @@ private slots:
     //       waitLoops don't hang
     //   (b) the "not delivered" WARN fires for diagnostics
     //   (c) after reconnecting and receiving a real firmware power_off, the
-    //       dialog still fires — the latch did NOT leak past the failed
-    //       sleep.
+    //       WARN-level log still fires — the latch did NOT leak past the
+    //       failed sleep (a leaked latch would demote the log to LOG and the
+    //       ignoreMessage below would go unmatched, failing the test).
     // Note: this test can't isolate which clear-path did the work — both
     // sleep()'s self-clear-on-failure AND connectToHost()'s reset would
     // independently produce (c). Both are present in the implementation as
@@ -606,7 +606,7 @@ private slots:
         QCOMPARE(sleepSpy.count(), 1);
         QCOMPARE(errorSpy.count(), 0);
 
-        // Now connect and receive a firmware-initiated power_off — must dialog.
+        // Now connect and receive a firmware-initiated power_off — must log at WARN.
         FakeHdsServer server;
         connectAndHandshake(driver, server);
 
@@ -619,7 +619,7 @@ private slots:
             { "reason_code", 3 },
         });
         QTest::qWait(50);
-        QCOMPARE(errorSpy.count(), 1);
+        QCOMPARE(errorSpy.count(), 0);  // dialog path removed
     }
 
     // When the cached-IP dial fires a fatal transient socket error

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -531,7 +531,7 @@ private slots:
         });
         QTest::qWait(50);
 
-        QCOMPARE(errorSpy.count(), 0);  // dialog suppressed
+        QCOMPARE(errorSpy.count(), 0);  // errorOccurred not emitted (dialog path removed)
     }
 
     // The latch is one-shot: after the app-initiated power_off is consumed,
@@ -539,7 +539,7 @@ private slots:
     // log at WARN level (not LOG). ignoreMessage on the WARN regex is what
     // enforces the level — if the latch leaked, the second frame would log
     // at LOG and the ignoreMessage would go unmatched, failing the test.
-    void firmwareInitiatedPowerOffStillDialogsAfterAppInitiated() {
+    void firmwareInitiatedPowerOffStillWarnsAfterAppInitiated() {
         FakeHdsServer server;
         DecentScaleWifi driver;
         QSignalSpy errorSpy(&driver, &ScaleDevice::errorOccurred);


### PR DESCRIPTION
## Summary

The 1.7.5 WiFi-scale work introduced two new user-facing modals via `bleErrorDialog`:

- **"Scale shut down: \<reason\>"** — fired on a firmware-initiated `power_off` frame (low battery, physical button)
- **"Another client is connected to the scale"** — fired on a WebSocket 503 from HDS firmware

Neither is actionable:

- A firmware power_off already drives the existing **Scale Disconnected** notice when auto-reconnect gives up — the new modal is a duplicate.
- HDS firmware now allows multiple concurrent clients, so a 503 just means the cap is briefly saturated. The original single-connection design was short-lived.

Both got removed. `bleErrorDialog` itself stays — it's still the right surface for genuine BLE permission/adapter problems (Bluetooth off, Location off, permission denied).

The app-initiated power-off latch (`m_powerOffInitiatedByApp`) is retained but now selects `WIFI_LOG` vs `WIFI_WARN` log level for the power_off echo (instead of selecting "dialog or no dialog").

### Scale dialog inventory after this change

| Dialog | Trigger | Gated by `Settings.showScaleDialogs` |
|---|---|---|
| **No Scale Found** | Saved scale never connected at startup | ✅ |
| **Scale Disconnected** | Previously-connected scale dropped + reconnect gave up | ✅ |
| **Shot Stopped — scale not connected** | User pressed Start with scale offline (action-feedback, not nag) | n/a |
| **Add WiFi Scale** | User-invoked in Settings → Connections | n/a |
| **Known Scales** picker | User-invoked | n/a |

## Test plan

- [ ] Power-cycle the WiFi scale (or pull its battery) mid-session → no "Scale shut down" modal; "Scale Disconnected" appears only once reconnect actually gives up
- [ ] Connect a second client to the HDS while the app is already connected → no "Another client is connected" modal
- [ ] Confirm a real BLE permission denial (deny Bluetooth on macOS / disable Location on Android) still pops `bleErrorDialog` with the correct title
- [ ] Run `tst_decentscalewifi` — all power-frame / 503 tests still pass with `errorSpy.count() == 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)