### PR TITLE
saw: preserve settled weight when cup is lifted mid-settle (#1280)

### DIFF
--- a/docs/CLAUDE_MD/SAW_LEARNING.md
+++ b/docs/CLAUDE_MD/SAW_LEARNING.md
@@ -156,9 +156,10 @@ Before issue [#1280](https://github.com/Kulitorum/Decenza/issues/1280), `m_weigh
 
 The cup-removed branch now applies this fallback chain to restore `m_weight`:
 
-1. **Last clean settling avg** — the value captured by the stability gate above. This is the truth when at least one stable sample was observed (the common case for any settle that lasted long enough for the user to lift the cup).
-2. **`m_weightAtStop` floor** — if no clean avg was ever observed (cup lifted before the window filled), raise `m_weight` to at least the SAW trigger weight. Post-stop drip can only add weight; persisting a value below the trigger weight is physically impossible.
-3. **Unchanged** — if the fallback can't help (no SAW trigger captured, or `m_weight` already above stop weight), leave it as today's value.
+1. **Last clean settling avg, if plausible** — the value captured by the stability gate above, **provided its overshoot above `m_weightAtStop` does not exceed `MAX_PLAUSIBLE_POST_STOP_DRIP_G = 5 g`**. Real drip is 0.5–3 g; a "stable" reading 10+ g above the trigger weight is almost certainly a scale fault (freeze, drift, sensor glitch), not a settled cup weight.
+2. **Scale-fault snap-to-trigger** — if the clean avg was captured but failed the plausibility check, treat the entire post-stop weight stream as corrupted and set `m_weight = m_weightAtStop`. The corpus scan found one such shot where the scale froze at ~75 g during settling on a ~40 g target; without this guard the fix would amplify the glitch from "recorded yield wrong" to "recorded yield very wrong".
+3. **`m_weightAtStop` floor** — if no clean avg was ever observed (cup lifted before the window filled), raise `m_weight` to at least the SAW trigger weight. Post-stop drip can only add weight; persisting a value below the trigger weight is physically impossible.
+4. **Unchanged** — if the fallback can't help (no SAW trigger captured, or `m_weight` already above stop weight with no implausible clean-avg signal), leave it as today's value.
 
 Learning is still skipped on the cup-removed path — corruption of the post-stop drip measurement is the only reason this branch exists. The fallback only affects the persisted `finalWeightG` (and therefore the AI advisor's `yieldG`, the visualizer export, and `DyeSettings::dyeDrinkWeight`).
 

--- a/docs/CLAUDE_MD/SAW_LEARNING.md
+++ b/docs/CLAUDE_MD/SAW_LEARNING.md
@@ -132,6 +132,40 @@ Median rejects single outliers but does not detect the case where the user chang
 
 A new profile starting from `sensorLag(scaleType) + 0.1 s` will be off until 3 shots populate its history (one batch). With `globalSawBootstrapLag`, it starts from "what we have learned about this user's machine on this scale across their other profiles" — a much closer prior. Flow cal uses the same idea (median of espresso per-profile multipliers) and it noticeably reduces the cold-start error.
 
+## Settling and final-weight capture
+
+After SAW fires the stop command, [`ShotTimingController`](../../src/controllers/shottimingcontroller.cpp) runs a settling state machine that watches the scale stabilize. The cup gains a bit more weight from post-stop drip (typically 0.5–1.5 g) before reaching its true final weight, and learning needs both `m_weightAtStop` (the trigger weight) and the settled value (`m_weight`) to compute drip and update the model.
+
+### Stability gate and clean-avg capture
+
+Each settling sample is added to a 6-sample rolling window. The "stable enough to commit" gate fires when all three hold:
+
+- `avgDrift < SETTLING_AVG_THRESHOLD` (0.3 g) — window mean has stopped shifting
+- `weight ≤ avg + SETTLING_ABOVE_AVG_MARGIN` (0.2 g) — current reading has caught up to the mean (drip has effectively stopped)
+- `avg ≥ m_weightAtStop − 0.5` — the average isn't still recovering from pump-vibration artifacts
+
+Once the gate has held for `SETTLING_STABLE_MS = 1000 ms`, `onSettlingComplete` writes `m_weight = avg` and the learning point is committed.
+
+Every time the gate condition is satisfied (even before the 1000 ms accumulates), the avg is also captured into `m_lastCleanSettlingAvg`. This is the last-known-good settled value — held in reserve for the cup-lift case below.
+
+### Final-weight on cup removal
+
+If the user lifts the cup before settling completes, the cup-removal detector fires on a >20 g drop (single-step OR cumulative-from-peak). The handler **skips learning** (a corrupted weight stream can't teach the predictor) but the shot still needs a `finalWeightG` to persist.
+
+Before issue [#1280](https://github.com/Kulitorum/Decenza/issues/1280), `m_weight` was left at whatever value the last accepted sample had. In practice that was often a *cup-lift spike artifact* that squeaked past the 20 g cup-removal threshold — e.g. shot 5470 persisted `38.5 g` even though the cup had actually settled at `42.3 g` for ~700 ms and SAW had correctly stopped at `41.2 g`. The AI advisor then reasoned from `yield=38.5, target=42` and invented a "you stopped manually" narrative.
+
+The cup-removed branch now applies this fallback chain to restore `m_weight`:
+
+1. **Last clean settling avg** — the value captured by the stability gate above. This is the truth when at least one stable sample was observed (the common case for any settle that lasted long enough for the user to lift the cup).
+2. **`m_weightAtStop` floor** — if no clean avg was ever observed (cup lifted before the window filled), raise `m_weight` to at least the SAW trigger weight. Post-stop drip can only add weight; persisting a value below the trigger weight is physically impossible.
+3. **Unchanged** — if the fallback can't help (no SAW trigger captured, or `m_weight` already above stop weight), leave it as today's value.
+
+Learning is still skipped on the cup-removed path — corruption of the post-stop drip measurement is the only reason this branch exists. The fallback only affects the persisted `finalWeightG` (and therefore the AI advisor's `yieldG`, the visualizer export, and `DyeSettings::dyeDrinkWeight`).
+
+### Offline replay
+
+`./shot_eval --settling ~/shot_corpus/*.json` parses the `app.data.debug_log` embedded in each saved shot and replays the settling sample stream offline, printing `recorded` (today's `finalWeightG`) vs `postFix` (what the new fallback chain would persist). Useful for scanning a personal shot corpus for affected shots — most rows will print equal values; cup-lift-mid-settle shots surface with a `***` flag.
+
 ## User Experience
 
 - **Default ON, automatic** — there is no setting; SAW learning is always on.
@@ -173,9 +207,12 @@ A user who hits "Reset all" gets a clean slate (legacy + new keys both wiped) an
 
 - [src/core/settings.h](../../src/core/settings.h) / [src/core/settings.cpp](../../src/core/settings.cpp) — schema, batch accumulator, read-path fallback chain, bootstrap recompute. The new public API mirrors flow cal: `sawLearnedLagFor`, `getExpectedDripFor`, `sawLearningEntriesFor`, `sawModelSource`, `resetSawLearningForProfile`, `globalSawBootstrapLag`, `addSawLearningPoint(…, profileFilename)`.
 - [src/main.cpp](../../src/main.cpp) — wires `ProfileManager::baseProfileName()` into the WeightProcessor snapshot path and the `sawLearningComplete` handler, and emits the per-shot `model:` / `accuracy:` log lines.
+- [src/controllers/shottimingcontroller.cpp](../../src/controllers/shottimingcontroller.cpp) — settling state machine, stability gate, `m_lastCleanSettlingAvg` capture, cup-removed fallback chain (#1280).
 - [qml/pages/settings/SettingsCalibrationTab.qml](../../qml/pages/settings/SettingsCalibrationTab.qml) — Calibration tab UI changes (source suffix, per-profile reset).
 - [src/mcp/mcptools_control.cpp](../../src/mcp/mcptools_control.cpp) — `reset_saw_learning_for_profile` tool.
 - [tests/tst_saw_settings.cpp](../../tests/tst_saw_settings.cpp) — per-pair isolation, batch commit at N=3, dispersion-rejection, bootstrap recompute, fallback chain, reset behaviour, legacy-path preservation.
+- [tests/tst_settling.cpp](../../tests/tst_settling.cpp) — settling-state-machine tests including the #1280 cup-lift-mid-settle regression replays.
+- [tools/shot_eval/main.cpp](../../tools/shot_eval/main.cpp) — `--settling` mode for offline replay against a saved shot corpus.
 
 ## Related
 

--- a/docs/CLAUDE_MD/SAW_LEARNING.md
+++ b/docs/CLAUDE_MD/SAW_LEARNING.md
@@ -146,7 +146,7 @@ Each settling sample is added to a 6-sample rolling window. The "stable enough t
 
 Once the gate has held for `SETTLING_STABLE_MS = 1000 ms`, `onSettlingComplete` writes `m_weight = avg` and the learning point is committed.
 
-Every time the gate condition is satisfied (even before the 1000 ms accumulates), the avg is also captured into `m_lastCleanSettlingAvg`. This is the last-known-good settled value — held in reserve for the cup-lift case below.
+After the gate has held *continuously* for `SETTLING_CLEAN_CAPTURE_MS = 250 ms` (≈ 3 consecutive samples at typical scale rates), each subsequent gate-firing sample also writes the avg into `m_lastCleanSettlingAvg` — the last-known-good settled value held in reserve for the cup-lift case below. The 250 ms minimum filters out single-sample transients where the rolling avg fortuitously satisfies the gate amid noisy settling (a corpus scan of 953 shots found 2/953 such false-positive transients without this guard).
 
 ### Final-weight on cup removal
 

--- a/openspec/changes/preserve-settled-weight-on-cup-lift/design.md
+++ b/openspec/changes/preserve-settled-weight-on-cup-lift/design.md
@@ -1,0 +1,74 @@
+## Context
+
+`ShotTimingController` runs a settling state machine after SAW fires the stop command, sampling the scale at ~4–10 Hz and tracking when the cup's weight stabilizes. Two stable-completion paths exist: sample-driven (`onWeightSample` once the rolling window flattens for `SETTLING_STABLE_MS = 1000 ms`) and timer-driven (`onDisplayTimerTick` BLE-silence override after 2 s of no samples).
+
+When the cup is lifted before settling completes, a cup-removal heuristic at [`shottimingcontroller.cpp:210–211`](../../src/controllers/shottimingcontroller.cpp) catches the final big drop and aborts learning. But it does NOT undo the damage already done by transient cup-lift artifacts. `ShotDataModel` has spike rejection (>10 g/s); `ShotTimingController` does not — every settling sample is written to `m_weight`. Then `MainController::onShotEnded` reads `m_timingController->currentWeight()` as `finalWeightG` for the saved record.
+
+For shot 5470 the sequence was:
+
+```
+clean settling (~700 ms stable at 42.3 g)
+  → m_weight = 42.5, m_lastSettlingAvg = 42.3
+cup lift starts (within ~150 ms of the stable plateau, before SETTLING_STABLE_MS)
+  → samples 44, 48.4, 51 arrive (TC accepts all; m_weight = 51, peak = 51)
+  → sample 38.5 arrives (drop is under 20 g threshold, accepted; m_weight = 38.5)
+  → sample −28 arrives (drop > 20 g from m_weight = 38.5; cup-removed fires)
+  → cup-removed handler early-returns with m_weight = 38.5
+```
+
+`m_weight = 38.5` then propagates into `finalWeightG`, the saved shot record, `DyeSettings::dyeDrinkWeight`, the visualizer export, and the AI advisor's `yieldG` field.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist a `finalWeightG` that reflects what was actually in the cup at the moment the user lifted it.
+- Make the standalone "analyze this shot" prompt carry `stoppedBy` so LLMs do not invent stop-reason narratives when `yieldG` looks short.
+- Add regression coverage for the cup-lift-mid-settle path so this bug cannot silently return.
+
+**Non-Goals:**
+
+- Backfilling existing under-reported shots in shot history (the recorded value is what it is; future shots get the correct value).
+- Restoring SAW learning on cup-lifted shots (cup removal still corrupts the drip measurement; we keep `m_sawTriggeredThisShot = false` as today).
+- Changing the cup-removal detection thresholds.
+- Mirroring `ShotDataModel`'s 10 g/s spike rejection in `ShotTimingController` — a much larger blast radius that could reject legitimate "delayed splat" samples.
+
+## Decisions
+
+### Decision: Capture the last clean rolling-window avg, not a spike-rejected stream
+
+**Rationale:** The settling code already computes a rolling-window average and a "stable enough" gate (`avgDrift < SETTLING_AVG_THRESHOLD && !avgBelowStop && !weightAboveAvg`). When that gate is satisfied, the avg by definition reflects a settled cup. Tracking that value separately as `m_lastCleanSettlingAvg` and restoring it on cup-removed gives us the truth for free.
+
+**Alternative considered:** Apply `ShotDataModel`'s `> 10 g/s` spike rejection to `ShotTimingController`'s settling path so cup-lift spikes never update `m_weight` in the first place. Rejected — the rate threshold was tuned for SDM's role and the surface area of the change is much larger. A legitimate splat or scale recovery sample could be wrongly rejected. The bug only manifests on the cup-removed path, so the surgical fix lives there.
+
+**Alternative considered:** Just floor at `m_weightAtStop` (always raise `m_weight` to at least `m_weightAtStop` on cup removed). Rejected as primary path — simpler but loses ~1 g of post-stop drip that actually landed. Kept as the secondary fallback when no clean avg was ever observed.
+
+### Decision: Capture in BOTH `onWeightSample` and `onDisplayTimerTick` stable branches
+
+**Rationale:** Settling has two completion paths (sample-driven and BLE-silence). The cup-removed handler can only fire from `onWeightSample` (a new sample is required to detect removal), so technically capturing in `onWeightSample` is sufficient for the bug at hand. But the stable branch in `onDisplayTimerTick` ALSO writes `m_weight = avg` at line 437 when it finalizes — for symmetry and to avoid a class of "wrong source for `m_lastCleanSettlingAvg` if the BLE-silence path ever drives cup-removed in a future change", capture in both. Costs one line.
+
+### Decision: Reset `m_lastCleanSettlingAvg` in BOTH `startShot()` and `startSettlingTimer()`
+
+**Rationale:** `startSettlingTimer()` resets all other settling-related members, but it's only called on SAW shots. A non-SAW shot that runs immediately after a SAW shot bypasses `startSettlingTimer()` entirely. The new field is gated by `if (m_sawSettling)` so it can't leak into a non-SAW shot's recorded weight, but defensive reset at every shot boundary keeps the state machine clean and predictable. Belt-and-suspenders.
+
+### Decision: Live and saved summarize paths must produce identical `stoppedBy`
+
+**Rationale:** `MainController` already classifies `stoppedBy` from authoritative C++ state ([line 2050](../../src/controllers/maincontroller.cpp)) and persists it on the shot record. The live summarize path (called from the post-shot review page) needs the same value. Re-deriving it inside `summarize` would risk drift between the two derivations. Cleanest: have `MainController` pass the already-resolved string into `summarize()`. The saved path reads `ShotProjection.stoppedBy` directly from the DB — same value either way.
+
+### Decision: `stoppedBy` allowlist matches `dialing_blocks.cpp`
+
+The standalone block emits `stoppedBy` only when the value is `"manual"`, `"weight"`, or `"volume"` — same gating as [`src/ai/dialing_blocks.cpp:121-124`](../../src/ai/dialing_blocks.cpp). Omitting `"profileEnd"` and `""` matches the rubric at [`shotsummarizer.cpp:1405`](../../src/ai/shotsummarizer.cpp) which already documents how the model should treat the field's absence (profile-end vs DE1 hardware button — the BLE protocol cannot distinguish).
+
+## Risks
+
+- **`weightAboveAvg` gate could be bypassed by a very slow cup lift.** The gate requires `weight ≤ avg + SETTLING_ABOVE_AVG_MARGIN (0.2 g)`. At lift rates above ~0.8 g/sample (3–8 g/s at scale rates) the gate fires reliably. Hand lifts are physically faster than that, and the 20 g cup-removal threshold catches anything slower within ~10–20 samples regardless. No realistic scenario where `m_lastCleanSettlingAvg` gets polluted by a slow lift.
+- **A shot that lifts the cup before `SETTLING_WINDOW_SIZE = 6` samples are accumulated** has no clean avg to fall back on. The `m_weightAtStop` floor catches it (drip can only add, so finalWeight ≥ SAW trigger weight). For shot 5470 this isn't the case (user had ~700 ms of stable readings first), but the fallback chain handles it.
+- **`stoppedBy` field becomes load-bearing for the standalone block.** If `MainController` ever forgets to pass it, the field silently disappears. Mitigated by: defaulting to empty (matches today's behavior), and the test for this requirement will assert the field is present for known-SAW shots.
+
+## Migration
+
+None. No schema changes. No setting added. Existing recorded shots keep their under-reported `finalWeightG`. Shots pulled after the fix ships record the correct value.
+
+## Open Questions
+
+- Should the offline `settling_replay` tool be added to `tests/data/shots/manifest.json` validation so shot 5470 lives in the regression corpus as a fixture? **Defer** — manifest format expects detector verdicts, not finalWeight assertions; adding a new manifest schema for this one case feels heavy. The unit test covers the same invariant.

--- a/openspec/changes/preserve-settled-weight-on-cup-lift/proposal.md
+++ b/openspec/changes/preserve-settled-weight-on-cup-lift/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Issue [#1280](https://github.com/Kulitorum/Decenza/issues/1280): the AI advisor gave Mark a self-contradictory dial-in recommendation, claiming "you stopped manually at 38.5g when the target was 42g" and suggesting a coarser grind despite a fast 17 s duration. Mark did not stop the shot — SAW correctly stopped at 41.2 g and the cup settled at 42.3 g for ~700 ms before he lifted it. But the shot record persisted `finalWeightG = 38.5`, so the advisor reasoned from bad data.
+
+Root cause is in `ShotTimingController::onWeightSample()` settling branch: cup-lift spike artifacts (44, 48.4, 51, then a 38.5 down-step) pollute `m_weight` before the cup-removed detector fires on the final ≥20 g drop. The cup-removed branch then preserves `m_weight` as documented, but that value is now a poisoned post-spike artifact rather than the real settled weight.
+
+A secondary issue compounds it: the standalone "analyze this shot" JSON block sent to LLMs omits `stoppedBy`, so when `yieldG` looks short the model is free to invent "you stopped manually" framing. The field already exists on dial-in surfaces (`bestRecentShot`, `dialInSessions`) via `dialing_blocks.cpp` but not on the standalone shot block.
+
+## What Changes
+
+- **`ShotTimingController`**: track the last *clean* rolling-window average during settling (only updated when the existing stability conditions hold). On cup-removed, restore `m_weight` to that value if present; else floor at `m_weightAtStop` (drip can only add); else leave as-is. Reset the new state on both `startShot()` and `startSettlingTimer()`.
+- **`ShotSummarizer`**: add `stoppedBy` to `ShotSummary`, populate from the same source `MainController` uses (live) and from `ShotProjection.stoppedBy` (saved), emit in the standalone shot block with the same `{manual, weight, volume}` allowlist `dialing_blocks.cpp` uses.
+- **Documentation**: add a "Settling and final-weight capture" section to `docs/CLAUDE_MD/SAW_LEARNING.md`.
+- **Tests**: add a unit test in `tests/tst_settling.cpp` that replays shot 5470's settling sample stream and asserts `currentWeight()` ≈ 42.3 g (fails today, returns 38.5 g).
+- **Tools**: add `tools/settling_replay/` — a small CLI that parses `app.data.debug_log` from any saved shot JSON, replays the settling samples through the controller, and prints before/after `finalWeight` so the fix can be validated against a personal shot corpus.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `stop-at-weight-learning`: new requirement defining how `finalWeightG` is captured at shot end — clean settle uses the settled rolling-window average; cup-lifted-mid-settle falls back to the last clean average, then to `m_weightAtStop` as a physical floor.
+- `advisor-user-prompt`: new requirement that the standalone shot JSON block carries `stoppedBy` when the saved value is in the same `{manual, weight, volume}` allowlist used on dialing-context surfaces.
+
+## Impact
+
+- **`src/controllers/shottimingcontroller.{h,cpp}`** — new `m_lastCleanSettlingAvg` member, capture in two stable-branch sites (`onWeightSample`, `onDisplayTimerTick`), restore in cup-removed handler, reset in `startShot()` + `startSettlingTimer()`.
+- **`src/ai/shotsummarizer.{h,cpp}`** — new `stoppedBy` field on `ShotSummary`; populated in `summarize` (live path) and `summarizeFromHistory` (saved path); emitted in `buildShotBlock`.
+- **`src/controllers/maincontroller.cpp`** — pass the already-resolved `stoppedBy` string into `m_summarizer->summarize()` so the live path and saved path produce identical values for the same shot.
+- **`tests/tst_settling.cpp`** — new test `cupLiftMidSettlePreservesLastStableAvg`.
+- **`tools/settling_replay/`** — new offline CLI, wired into the desktop-only `tools/` block in root `CMakeLists.txt`.
+- **`docs/CLAUDE_MD/SAW_LEARNING.md`** — new section.
+- No BLE protocol changes, no setting added, no schema migration, no shot-data backfill (existing under-reported shots remain as-recorded; the fix applies only to shots pulled after deploy).

--- a/openspec/changes/preserve-settled-weight-on-cup-lift/specs/advisor-user-prompt/spec.md
+++ b/openspec/changes/preserve-settled-weight-on-cup-lift/specs/advisor-user-prompt/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Standalone shot block carries stoppedBy
+
+The standalone shot JSON block emitted by `ShotSummarizer::buildShotBlock` (as part of the `shot` field on `buildUserPromptObject`'s output) SHALL include `stoppedBy` when the saved value is one of `"manual"`, `"weight"`, or `"volume"`. This mirrors the field's allowlist on dialing-context surfaces (`bestRecentShot`, `dialInSessions[].history`), giving the LLM a stop-reason anchor on every shot-analysis prompt rather than only on dial-in surfaces.
+
+The allowlist intentionally omits `"profileEnd"` and the empty string. The system-prompt rubric already documents how the model should treat an absent field (profile-end vs DE1 hardware button — the BLE protocol cannot distinguish), and emitting `"profileEnd"` explicitly would conflict with the rubric's "ABSENT" branch.
+
+#### Scenario: SAW-stopped shot emits stoppedBy: "weight"
+
+- **GIVEN** a `ShotSummary` with `stoppedBy = "weight"` (SAW or QML weight-stop fallback)
+- **WHEN** `buildShotBlock(summary)` runs
+- **THEN** the returned JSON SHALL contain `stoppedBy: "weight"`
+
+#### Scenario: Manually-stopped shot emits stoppedBy: "manual"
+
+- **GIVEN** a `ShotSummary` with `stoppedBy = "manual"` (user tapped Stop on the QML page)
+- **WHEN** `buildShotBlock(summary)` runs
+- **THEN** the returned JSON SHALL contain `stoppedBy: "manual"`
+
+#### Scenario: Volume-stopped shot emits stoppedBy: "volume"
+
+- **GIVEN** a `ShotSummary` with `stoppedBy = "volume"` (SAV)
+- **WHEN** `buildShotBlock(summary)` runs
+- **THEN** the returned JSON SHALL contain `stoppedBy: "volume"`
+
+#### Scenario: Profile-end shot omits the field
+
+- **GIVEN** a `ShotSummary` with `stoppedBy = "profileEnd"` OR empty
+- **WHEN** `buildShotBlock(summary)` runs
+- **THEN** the returned JSON SHALL NOT contain a `stoppedBy` key

--- a/openspec/changes/preserve-settled-weight-on-cup-lift/specs/stop-at-weight-learning/spec.md
+++ b/openspec/changes/preserve-settled-weight-on-cup-lift/specs/stop-at-weight-learning/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Final Weight Capture After Settling
+
+The system SHALL persist `finalWeightG` as the cup's stable settled weight at shot end, even when the user lifts the cup before the settling timer declares stability. The `ShotTimingController` SHALL track the most recent clean rolling-window average — one observed while the existing stability gate (window full, `avgDrift < SETTLING_AVG_THRESHOLD`, `weight ≤ avg + SETTLING_ABOVE_AVG_MARGIN`, `avg ≥ m_weightAtStop − 0.5`) holds — and use it as the cup-removal fallback for `m_weight`.
+
+#### Scenario: Clean settle uses the settled rolling-window average
+
+- **WHEN** settling completes via `SETTLING_STABLE_MS` accumulation or the BLE-silence override timer
+- **THEN** `finalWeightG` SHALL be the rolling-window average at the moment of completion (existing behavior, unchanged)
+
+#### Scenario: Cup lifted mid-settle falls back to the last clean average
+
+- **GIVEN** the controller has observed at least one clean rolling average (the stability gate above held on at least one settling sample)
+- **WHEN** the cup-removal detector fires during settling
+- **THEN** `m_weight` SHALL be restored to that last clean average
+- **AND** `finalWeightG` SHALL equal that value when persisted by `MainController::onShotEnded`
+
+#### Scenario: Cup lifted before any clean average is observed
+
+- **GIVEN** the cup is lifted before the rolling window has filled OR before any sample satisfied the stability gate
+- **WHEN** the cup-removal detector fires AND `m_weightAtStop > 0` AND `m_weight < m_weightAtStop`
+- **THEN** `m_weight` SHALL be raised to `m_weightAtStop` (post-stop drip can only add weight; an observed value below the SAW trigger weight is a measurement artifact)
+
+#### Scenario: Cup-removal fallback state resets between shots
+
+- **WHEN** a new shot starts (via `startShot()`) or a new settling cycle begins (via `startSettlingTimer()`)
+- **THEN** the `m_lastCleanSettlingAvg` tracker SHALL be reset to 0 so a value from a prior shot cannot leak into the current shot's recorded weight

--- a/openspec/changes/preserve-settled-weight-on-cup-lift/specs/stop-at-weight-learning/spec.md
+++ b/openspec/changes/preserve-settled-weight-on-cup-lift/specs/stop-at-weight-learning/spec.md
@@ -11,10 +11,18 @@ The system SHALL persist `finalWeightG` as the cup's stable settled weight at sh
 
 #### Scenario: Cup lifted mid-settle falls back to the last clean average
 
-- **GIVEN** the controller has observed at least one clean rolling average (the stability gate above held on at least one settling sample)
+- **GIVEN** the stability gate above has held *continuously* for at least `SETTLING_CLEAN_CAPTURE_MS` (250 ms; approximately 3 consecutive samples at typical scale rates)
+- **AND** the controller has captured that last clean average into `m_lastCleanSettlingAvg`
 - **WHEN** the cup-removal detector fires during settling
 - **THEN** `m_weight` SHALL be restored to that last clean average
 - **AND** `finalWeightG` SHALL equal that value when persisted by `MainController::onShotEnded`
+
+#### Scenario: Transient gate-fires during a noisy settle do not pollute the fallback
+
+- **GIVEN** settling samples whose rolling-window average transiently satisfies the stability gate but breaks again within a single sample (the gate's `m_settlingAvgStableSince` clock resets before `SETTLING_CLEAN_CAPTURE_MS` accumulates)
+- **WHEN** the cup-removal detector fires during settling
+- **THEN** `m_lastCleanSettlingAvg` SHALL still be zero
+- **AND** the fallback chain SHALL fall through to the `m_weightAtStop` floor scenario below
 
 #### Scenario: Cup lifted before any clean average is observed
 

--- a/openspec/changes/preserve-settled-weight-on-cup-lift/specs/stop-at-weight-learning/spec.md
+++ b/openspec/changes/preserve-settled-weight-on-cup-lift/specs/stop-at-weight-learning/spec.md
@@ -24,6 +24,13 @@ The system SHALL persist `finalWeightG` as the cup's stable settled weight at sh
 - **THEN** `m_lastCleanSettlingAvg` SHALL still be zero
 - **AND** the fallback chain SHALL fall through to the `m_weightAtStop` floor scenario below
 
+#### Scenario: Implausible clean average is rejected as scale fault
+
+- **GIVEN** a captured `m_lastCleanSettlingAvg` whose overshoot above `m_weightAtStop` exceeds `MAX_PLAUSIBLE_POST_STOP_DRIP_G` (5 g; real drip is typically 0.5–3 g, even slow-flow profiles stay under 5 g)
+- **WHEN** the cup-removal detector fires during settling
+- **THEN** the system SHALL treat the post-stop weight stream as corrupted (scale freeze, drift, or sensor glitch)
+- **AND** `finalWeightG` SHALL snap to `m_weightAtStop` (the only physically defensible minimum-truth value), regardless of whether `m_weight` is currently above or below it
+
 #### Scenario: Cup lifted before any clean average is observed
 
 - **GIVEN** the cup is lifted before the rolling window has filled OR before any sample satisfied the stability gate

--- a/openspec/changes/preserve-settled-weight-on-cup-lift/tasks.md
+++ b/openspec/changes/preserve-settled-weight-on-cup-lift/tasks.md
@@ -1,0 +1,60 @@
+## 1. Regression test from shot 5470 (red)
+
+- [ ] 1.1 Add `cupLiftMidSettlePreservesLastStableAvg` to `tests/tst_settling.cpp` that constructs `ShotTimingController`, fires `onSawTriggered(41.2, 2.5, 42.0)`, calls `endShot()`, then replays the 19-sample stream extracted from `[SAW] Settling:` log lines for shot 5470: `41.5, 41.7, 42.0, 42.2, 42.3×7, 42.4×2, 42.5, 44, 48.4, 51, 38.5, −28`.
+- [ ] 1.2 Assert the final `tc.currentWeight()` is between 41.5 and 43.0 g (target ≈ 42.3) and that `isSawSettling()` is false. Use `QTest::ignoreMessage` for the `[SAW] Cup removed during settling` warning the cup-removed branch emits.
+- [ ] 1.3 Run `ctest -R settling` and confirm the new test FAILS before any code fix (returns ~38.5 g).
+
+## 2. ShotTimingController: capture + restore clean settling avg
+
+- [ ] 2.1 Add `double m_lastCleanSettlingAvg = 0.0;` to `src/controllers/shottimingcontroller.h` near `m_lastSettlingAvg`.
+- [ ] 2.2 In `src/controllers/shottimingcontroller.cpp` `onWeightSample` settling branch, inside the existing `if (avgDrift < SETTLING_AVG_THRESHOLD && !avgBelowStop && !weightAboveAvg)` block (around line 293), capture `m_lastCleanSettlingAvg = avg;` before `m_settlingAvgStableSince = now;`.
+- [ ] 2.3 Mirror the same capture inside the corresponding stable branch in `onDisplayTimerTick` (around line 421+) for symmetry.
+- [ ] 2.4 In the cup-removed branch of `onWeightSample` (lines 210–226), before the existing `return;`, restore `m_weight` using the fallback chain: clean avg → stop-weight floor → unchanged. Update the existing NOTE comment to describe the new behavior.
+- [ ] 2.5 Reset `m_lastCleanSettlingAvg = 0.0` in `startSettlingTimer()` (around line 466+).
+- [ ] 2.6 Reset `m_lastCleanSettlingAvg = 0.0` in `startShot()` alongside the existing `m_settlingPeakWeight = 0.0` reset (around line 111).
+- [ ] 2.7 Re-run `ctest -R settling` and confirm the new test now passes (returns ≈ 42.3 g).
+
+## 3. ShotSummarizer: plumb stoppedBy into standalone shot block
+
+- [ ] 3.1 Add `QString stoppedBy;` to `ShotSummary` in `src/ai/shotsummarizer.h` (in the cluster of shot-VARIABLE fields).
+- [ ] 3.2 Update `ShotSummarizer::summarize(...)` signature to accept an optional `const QString& stoppedBy = QString()` parameter and populate `summary.stoppedBy` from it.
+- [ ] 3.3 Update `summarizeFromHistory(...)` to populate `summary.stoppedBy` from `shotData.stoppedBy`.
+- [ ] 3.4 In `buildShotBlock` (line 684+), after the existing field emissions, add:
+  ```cpp
+  if (summary.stoppedBy == QStringLiteral("manual")
+      || summary.stoppedBy == QStringLiteral("weight")
+      || summary.stoppedBy == QStringLiteral("volume"))
+      shot["stoppedBy"] = summary.stoppedBy;
+  ```
+- [ ] 3.5 Update all `MainController` callers of `m_summarizer->summarize(...)` to pass the already-resolved `stoppedBy` (the same value persisted via `m_shotHistory->saveShot(... stoppedBy)`).
+- [ ] 3.6 Add a focused test in `tests/tst_shotsummarizer.cpp` that verifies the standalone shot block carries `stoppedBy: "weight"` for a SAW-stopped shot and omits the field for `stoppedBy == "profileEnd"` or empty.
+
+## 4. Documentation
+
+- [ ] 4.1 Add a new section "Settling and final-weight capture" to `docs/CLAUDE_MD/SAW_LEARNING.md` between the existing "Algorithm Details" and "User Experience" sections. Document the rolling-window stability gate, the `m_lastCleanSettlingAvg` capture, and the fallback chain on cup removal.
+- [ ] 4.2 Update the SAW_LEARNING.md "Files" section to mention the cup-removed fallback alongside the existing references.
+
+## 5. Offline replay tool
+
+- [ ] 5.1 Create `tools/settling_replay/main.cpp`: parse a shot JSON file, extract `app.data.debug_log` (or accept a raw debug log file as input), regex out `[SAW] Settling: <weight> g` lines and the `[SAW] Stop triggered: weight=<x>` line, instantiate a `ShotTimingController`, fire `onSawTriggered(stopWeight, 2.0, target)`, call `endShot()`, then replay each weight sample through `onWeightSample`, and print `<file>: stopWeight=<x>  preFinalWeight=<old>  postFinalWeight=<new>`.
+- [ ] 5.2 Wire the tool into the desktop-only `tools/` block in the root `CMakeLists.txt` (follow the existing `shot_eval` pattern).
+- [ ] 5.3 Add a brief README at `tools/settling_replay/README.md` explaining usage.
+- [ ] 5.4 Run the tool against `shot5470.json` and confirm `postFinalWeight ≈ 42.3` (vs `preFinalWeight = 38.5`).
+- [ ] 5.5 Run the tool against `~/shot_corpus/*.json`. Most shots should print equal pre/post values (no cup-lift-mid-settle). Inspect any flips to confirm they are legitimate improvements, not regressions.
+
+## 6. OpenSpec validation
+
+- [ ] 6.1 `openspec validate preserve-settled-weight-on-cup-lift --strict` passes.
+
+## 7. Build + regression sweep
+
+- [ ] 7.1 Build via Qt Creator MCP (Debug, with `BUILD_TESTS=ON`).
+- [ ] 7.2 Run full test suite: `ctest --output-on-failure`. All existing tests pass.
+- [ ] 7.3 Run `ctest -R shot_corpus_regression`. Detector verdicts unchanged (expected — detectors do not read `TC.currentWeight`).
+- [ ] 7.4 Lint: review the diff for stray includes, `qDebug` left in for development, etc.
+
+## 8. Review and PR
+
+- [ ] 8.1 Open PR linking issue [#1280](https://github.com/Kulitorum/Decenza/issues/1280). Summary: shot 5470 root cause + before/after `finalWeight` numbers + validation evidence.
+- [ ] 8.2 Run `/pr-review-toolkit:review-pr`.
+- [ ] 8.3 After deploy, ask Mark to pull a fresh shot and confirm the advisor no longer claims "stopped manually" framing on SAW-stopped shots.

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -655,7 +655,9 @@ void AIManager::analyzeShot(ShotDataModel* shotData,
                              double finalWeight,
                              const QVariantMap& metadata)
 {
-    // Extract metadata from QVariantMap (QML-friendly)
+    // Extract metadata from QVariantMap (QML-friendly).
+    // #1280: `stoppedBy` is optional; absent values produce an empty
+    // string which buildShotBlock then omits per its allowlist.
     analyzeShotWithMetadata(shotData, profile, doseWeight, finalWeight,
         metadata.value("beanBrand").toString(),
         metadata.value("beanType").toString(),
@@ -666,7 +668,8 @@ void AIManager::analyzeShot(ShotDataModel* shotData,
         metadata.value("grinderBurrs").toString(),
         metadata.value("grinderSetting").toString(),
         metadata.value("enjoymentScore").toInt(),
-        metadata.value("tastingNotes").toString());
+        metadata.value("tastingNotes").toString(),
+        metadata.value("stoppedBy").toString());
 }
 
 void AIManager::analyzeShotWithMetadata(ShotDataModel* shotData,
@@ -682,7 +685,8 @@ void AIManager::analyzeShotWithMetadata(ShotDataModel* shotData,
                              const QString& grinderBurrs,
                              const QString& grinderSetting,
                              int enjoymentScore,
-                             const QString& tastingNotes)
+                             const QString& tastingNotes,
+                             const QString& stoppedBy)
 {
     if (!isConfigured()) {
         m_lastError = "AI provider not configured. Please add your API key in settings.";
@@ -713,7 +717,8 @@ void AIManager::analyzeShotWithMetadata(ShotDataModel* shotData,
     ShotMetadata metadata = buildMetadata(beanBrand, beanType, roastDate, roastLevel,
                                           grinderBrand, grinderModel, grinderBurrs,
                                           grinderSetting, enjoymentScore, tastingNotes);
-    ShotSummary summary = m_summarizer->summarize(shotData, profile, metadata, doseWeight, finalWeight);
+    ShotSummary summary = m_summarizer->summarize(shotData, profile, metadata,
+                                                  doseWeight, finalWeight, stoppedBy);
 
     // Build prompts (select system prompt based on beverage type + profile knowledge)
     // profileKbId is the direct knowledge base key; profileType is the fallback for custom titles
@@ -865,7 +870,9 @@ QString AIManager::generateEmailPrompt(ShotDataModel* shotData,
         metadataMap.value("grinderSetting").toString(),
         metadataMap.value("enjoymentScore").toInt(),
         metadataMap.value("tastingNotes").toString());
-    ShotSummary summary = m_summarizer->summarize(shotData, profile, metadata, doseWeight, finalWeight);
+    ShotSummary summary = m_summarizer->summarize(shotData, profile, metadata,
+                                                  doseWeight, finalWeight,
+                                                  metadataMap.value("stoppedBy").toString());
 
     QString systemPrompt = ShotSummarizer::shotAnalysisSystemPrompt(
         summary.beverageType, summary.profileTitle, summary.profileType, summary.profileKbId);
@@ -901,7 +908,9 @@ QString AIManager::generateShotSummary(ShotDataModel* shotData,
         metadataMap.value("grinderSetting").toString(),
         metadataMap.value("enjoymentScore").toInt(),
         metadataMap.value("tastingNotes").toString());
-    ShotSummary summary = m_summarizer->summarize(shotData, profile, metadata, doseWeight, finalWeight);
+    ShotSummary summary = m_summarizer->summarize(shotData, profile, metadata,
+                                                  doseWeight, finalWeight,
+                                                  metadataMap.value("stoppedBy").toString());
 
     return m_summarizer->buildUserPrompt(summary);
 }

--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -90,7 +90,12 @@ public:
                                   double finalWeight,
                                   const QVariantMap& metadata);
 
-    // Full version for C++ callers
+    // Full version for C++ callers. `stoppedBy` (#1280) is the same
+    // classification MainController persists to the shot record; pass
+    // it through so the live-path AI prompt carries the stop-reason
+    // anchor the standalone shot block already supports. QML callers
+    // include the same value in the analyzeShot() QVariantMap under
+    // key "stoppedBy".
     void analyzeShotWithMetadata(ShotDataModel* shotData,
                                   const Profile* profile,
                                   double doseWeight,
@@ -104,7 +109,8 @@ public:
                                   const QString& grinderBurrs,
                                   const QString& grinderSetting,
                                   int enjoymentScore,
-                                  const QString& tastingNotes);
+                                  const QString& tastingNotes,
+                                  const QString& stoppedBy = QString());
 
     // Email fallback - generates prompt for copying
     Q_INVOKABLE QString generateEmailPrompt(ShotDataModel* shotData,

--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -90,12 +90,13 @@ public:
                                   double finalWeight,
                                   const QVariantMap& metadata);
 
-    // Full version for C++ callers. `stoppedBy` (#1280) is the same
-    // classification MainController persists to the shot record; pass
-    // it through so the live-path AI prompt carries the stop-reason
-    // anchor the standalone shot block already supports. QML callers
-    // include the same value in the analyzeShot() QVariantMap under
-    // key "stoppedBy".
+    // Full version for C++ callers. `stoppedBy` (field introduced by
+    // #1161 on ShotProjection; wired through this entry point by #1280)
+    // is the same classification MainController persists to the shot
+    // record — pass it through so the live-path AI prompt carries the
+    // stop-reason anchor the standalone shot block already supports.
+    // QML callers include the same value in the analyzeShot()
+    // QVariantMap under key "stoppedBy".
     void analyzeShotWithMetadata(ShotDataModel* shotData,
                                   const Profile* profile,
                                   double doseWeight,

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -166,9 +166,11 @@ ShotSummary ShotSummarizer::summarize(const ShotDataModel* shotData,
                                        const Profile* profile,
                                        const ShotMetadata& metadata,
                                        double doseWeight,
-                                       double finalWeight) const
+                                       double finalWeight,
+                                       const QString& stoppedBy) const
 {
     ShotSummary summary;
+    summary.stoppedBy = stoppedBy;
 
     if (!shotData) {
         return summary;
@@ -388,6 +390,7 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
     summary.drinkEy = shotData.drinkEyPct;
     summary.enjoymentScore = shotData.enjoyment0to100;
     summary.tastingNotes = shotData.espressoNotes;
+    summary.stoppedBy = shotData.stoppedBy;  // #1280: forwarded into buildShotBlock
 
     // Convert curve data
     summary.pressureCurve = variantListToPoints(shotData.pressure);
@@ -693,6 +696,15 @@ static QJsonObject buildShotBlock(const ShotSummary& summary)
     // bounded values. Mirrors `dialing_get_context.bestRecentShot.enjoyment0to100`.
     if (summary.enjoymentScore > 0) shot["enjoyment0to100"] = summary.enjoymentScore;
     if (!summary.tastingNotes.isEmpty()) shot["notes"] = summary.tastingNotes;
+    // #1280: stop-reason anchor. Allowlist matches dialing_blocks.cpp so the
+    // standalone shot block carries the same field set as bestRecentShot /
+    // dialInSessions[].history. "profileEnd" and empty are intentionally
+    // omitted — the rubric at line 1405 documents how the model should treat
+    // an absent field (profile-end vs DE1 hardware button).
+    if (summary.stoppedBy == QStringLiteral("manual")
+        || summary.stoppedBy == QStringLiteral("weight")
+        || summary.stoppedBy == QStringLiteral("volume"))
+        shot["stoppedBy"] = summary.stoppedBy;
     const QJsonObject overallPeaks = buildOverallPeaksBlock(summary);
     if (!overallPeaks.isEmpty()) shot["overallPeaks"] = overallPeaks;
     const QJsonArray phases = buildPhasesBlock(summary);

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -390,7 +390,10 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
     summary.drinkEy = shotData.drinkEyPct;
     summary.enjoymentScore = shotData.enjoyment0to100;
     summary.tastingNotes = shotData.espressoNotes;
-    summary.stoppedBy = shotData.stoppedBy;  // #1280: forwarded into buildShotBlock
+    // ShotProjection.stoppedBy was introduced by #1161 (see
+    // shotprojection.h:127); #1280 added the forwarding into buildShotBlock
+    // so the standalone shot prompt carries the stop-reason anchor too.
+    summary.stoppedBy = shotData.stoppedBy;
 
     // Convert curve data
     summary.pressureCurve = variantListToPoints(shotData.pressure);

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -699,8 +699,9 @@ static QJsonObject buildShotBlock(const ShotSummary& summary)
     // #1280: stop-reason anchor. Allowlist matches dialing_blocks.cpp so the
     // standalone shot block carries the same field set as bestRecentShot /
     // dialInSessions[].history. "profileEnd" and empty are intentionally
-    // omitted — the rubric at line 1405 documents how the model should treat
-    // an absent field (profile-end vs DE1 hardware button).
+    // omitted — the system prompt's "stoppedBy → is the yield a real outcome
+    // or a user choice?" rubric documents how the model should treat an
+    // absent field (profile-end vs DE1 hardware button).
     if (summary.stoppedBy == QStringLiteral("manual")
         || summary.stoppedBy == QStringLiteral("weight")
         || summary.stoppedBy == QStringLiteral("volume"))

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -123,6 +123,14 @@ struct ShotSummary {
     double drinkEy = 0;
     int enjoymentScore = 0;
     QString tastingNotes;
+
+    // Why the shot ended (#1161 surface, #1280 prompt anchor): one of
+    // "weight" | "volume" | "manual" | "profileEnd" | "". Emitted into the
+    // standalone shot JSON block only when the value is in the
+    // {manual, weight, volume} allowlist — same gating as dialing_blocks.cpp,
+    // so the LLM has a stop-reason anchor instead of inventing one when
+    // yieldG looks short.
+    QString stoppedBy;
 };
 
 class ShotSummarizer : public QObject {
@@ -131,12 +139,16 @@ class ShotSummarizer : public QObject {
 public:
     explicit ShotSummarizer(QObject* parent = nullptr);
 
-    // Main summarization method
+    // Main summarization method. `stoppedBy` is the same classification
+    // MainController persists to the shot record (#1161, line ~2050); pass
+    // it in so the live and saved paths surface identical stop-reason
+    // anchors in the standalone shot JSON block.
     ShotSummary summarize(const ShotDataModel* shotData,
                           const Profile* profile,
                           const ShotMetadata& metadata,
                           double doseWeight,
-                          double finalWeight) const;
+                          double finalWeight,
+                          const QString& stoppedBy = QString()) const;
 
     // Summarize from historical shot data (typed projection from database)
     ShotSummary summarizeFromHistory(const ShotProjection& shotData) const;

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -225,15 +225,35 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
             // both the actual settle weight and the SAW trigger weight).
             //
             // Fallback chain:
-            //   1. last clean settling avg (the truth, when settling had
-            //      time to register at least one stable sample)
+            //   1. last clean settling avg, ONLY if it's within
+            //      MAX_PLAUSIBLE_POST_STOP_DRIP_G of m_weightAtStop. A
+            //      huge overshoot is almost always a scale fault, not a
+            //      real settled value (corpus scan revealed one such shot
+            //      where the scale froze at ~75 g during settling on a
+            //      ~40 g target — restoring that reading would amplify
+            //      the glitch instead of correcting it).
             //   2. m_weightAtStop floor — post-stop drip can only ADD
             //      weight, so persisting a value below the SAW trigger
-            //      weight is physically impossible
+            //      weight is physically impossible.
             //   3. leave m_weight as-is (cup lifted before either signal
-            //      was observable; this is the legacy behavior)
-            if (m_lastCleanSettlingAvg > 0.0) {
+            //      was observable; this is the legacy behavior).
+            const bool haveCleanAvg = m_lastCleanSettlingAvg > 0.0;
+            const bool cleanAvgPlausible =
+                haveCleanAvg
+                && (m_weightAtStop <= 0.0
+                    || (m_lastCleanSettlingAvg - m_weightAtStop)
+                           <= MAX_PLAUSIBLE_POST_STOP_DRIP_G);
+            if (cleanAvgPlausible) {
                 m_weight = m_lastCleanSettlingAvg;
+            } else if (haveCleanAvg && m_weightAtStop > 0.0) {
+                // The clean avg captured an implausibly large overshoot
+                // (>5 g above SAW trigger) — almost certainly a scale
+                // fault (freeze, drift, sensor glitch). m_weight at the
+                // moment of cup-removal is part of that same corrupt
+                // stream, so snap finalWeight back to the SAW trigger
+                // weight regardless of whether m_weight is currently
+                // above or below it.
+                m_weight = m_weightAtStop;
             } else if (m_weightAtStop > 0.0 && m_weight < m_weightAtStop) {
                 m_weight = m_weightAtStop;
             }

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -313,13 +313,19 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
 
             if (avgDrift < SETTLING_AVG_THRESHOLD && !avgBelowStop && !weightAboveAvg) {
                 // Average is stable and current weight is within it - check how long.
-                // Capture the clean avg now so we can fall back to it if the user
-                // lifts the cup before SETTLING_STABLE_MS elapses (issue #1280).
-                m_lastCleanSettlingAvg = avg;
                 if (m_settlingAvgStableSince == 0)
                     m_settlingAvgStableSince = now;
 
                 qint64 avgStableMs = now - m_settlingAvgStableSince;
+                // Capture the clean avg only after the gate has held continuously
+                // for SETTLING_CLEAN_CAPTURE_MS (#1280). Capturing on every gate
+                // fire (the original PR-1282 attempt) over-fired on noisy/oscillating
+                // settles where the window avg transiently satisfied the gate at
+                // values nowhere near the true cup weight; corpus-scan of 953 real
+                // shots showed 4 false-positive captures vs 2 legitimate recoveries
+                // before this guard was added.
+                if (avgStableMs >= SETTLING_CLEAN_CAPTURE_MS)
+                    m_lastCleanSettlingAvg = avg;
                 if (avgStableMs >= SETTLING_STABLE_MS) {
                     qDebug() << "[SAW] Weight settled by avg at" << QString::number(avg, 'f', 1)
                              << "g (avg stable for" << avgStableMs << "ms, current:" << weight << "g)";

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -230,19 +230,24 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
             // updated m_weight here, then a 38.5 g down-step landed below
             // both the actual settle weight and the SAW trigger weight).
             //
-            // Fallback chain:
-            //   1. last clean settling avg, ONLY if it's within
-            //      MAX_PLAUSIBLE_POST_STOP_DRIP_G of m_weightAtStop. A
-            //      huge overshoot is almost always a scale fault, not a
-            //      real settled value (corpus scan revealed one such shot
-            //      where the scale froze at ~75 g during settling on a
-            //      ~40 g target — restoring that reading would amplify
-            //      the glitch instead of correcting it).
-            //   2. m_weightAtStop floor — post-stop drip can only ADD
-            //      weight, so persisting a value below the SAW trigger
-            //      weight is physically impossible.
-            //   3. leave m_weight as-is (cup lifted before either signal
-            //      was observable; this is the legacy behavior).
+            // Fallback chain (4 branches; SAW_LEARNING.md has the full version):
+            //   1. last clean settling avg, ONLY if its overshoot above
+            //      m_weightAtStop is ≤ MAX_PLAUSIBLE_POST_STOP_DRIP_G.
+            //      Real drip is 0.5–3 g.
+            //   2. SCALE-FAULT snap to m_weightAtStop — fires when a
+            //      clean avg WAS captured but its overshoot is too large
+            //      to be physical (corpus scan revealed one shot where the
+            //      scale froze at ~75 g on a ~40 g target). Both the
+            //      captured avg AND the current m_weight came from the
+            //      same corrupt stream, so restoring either would amplify
+            //      the glitch — fall back to the SAW trigger weight.
+            //   3. m_weightAtStop FLOOR — fires when NO clean avg was
+            //      captured AND m_weight is below the SAW trigger weight.
+            //      Post-stop drip can only ADD weight, so persisting a
+            //      value below the trigger is physically impossible.
+            //   4. leave m_weight as-is (cup lifted before any signal was
+            //      observable AND m_weight is at/above stop weight — the
+            //      legacy behavior).
             const bool haveCleanAvg = m_lastCleanSettlingAvg > 0.0;
             const bool cleanAvgPlausible =
                 haveCleanAvg
@@ -374,9 +379,9 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
                 // for SETTLING_CLEAN_CAPTURE_MS (#1280). Capturing on every gate
                 // fire (the original PR-1282 attempt) over-fired on noisy/oscillating
                 // settles where the window avg transiently satisfied the gate at
-                // values nowhere near the true cup weight; corpus-scan of 953 real
-                // shots showed 4 false-positive captures vs 2 legitimate recoveries
-                // before this guard was added.
+                // values nowhere near the true cup weight; corpus-scan of 953
+                // real shots found 2 such false-positive transients vs 2
+                // legitimate recoveries before this guard was added.
                 if (avgStableMs >= SETTLING_CLEAN_CAPTURE_MS) {
                     // Log the FIRST capture each settling cycle (m_lastCleanSettlingAvg
                     // is reset to 0 at startShot/startSettlingTimer). Subsequent gate
@@ -530,6 +535,12 @@ void ShotTimingController::onDisplayTimerTick()
                     m_settlingAvgStableSince = 0;
                 } else {
                     qDebug() << "[SAW] Weight settled by avg at" << QString::number(avg, 'f', 1) << "g (detected by timer)";
+                    // #1280: mirror the onWeightSample capture so the
+                    // BLE-silence completion path also records the last
+                    // clean avg. Cup-removed only fires from onWeightSample
+                    // today, so this is a future-safety capture matching
+                    // the design contract in design.md.
+                    m_lastCleanSettlingAvg = avg;
                     m_weight = avg;
                     m_settlingTimer.stop();
                     onSettlingComplete();

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -109,6 +109,7 @@ void ShotTimingController::startShot()
     m_lastStableWeight = 0.0;
     m_lastWeightChangeTime = 0;
     m_settlingPeakWeight = 0.0;
+    m_lastCleanSettlingAvg = 0.0;
 
     // Reset tare state (will be set to Complete when tare() is called)
     m_tareState = TareState::Idle;
@@ -214,9 +215,29 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
                        << "peak:" << m_settlingPeakWeight << ") - skipping learning";
             // Cup removal corrupts weight data — bypass learning entirely
             // but still emit signals so the shot is saved.
-            // NOTE: m_weight is intentionally NOT updated here. It retains the last
-            // valid pre-removal reading so the saved shot preserves the correct
-            // final weight. The corrupted `weight` parameter is discarded.
+            //
+            // Restore m_weight to the last clean rolling-window avg so the
+            // saved finalWeightG reflects what was actually in the cup. The
+            // pre-removal m_weight is often a spike-artifact value that
+            // squeaked past the 20 g cup-removal threshold (e.g. shot 5470,
+            // issue #1280, where ShotDataModel-rejected up-spikes still
+            // updated m_weight here, then a 38.5 g down-step landed below
+            // both the actual settle weight and the SAW trigger weight).
+            //
+            // Fallback chain:
+            //   1. last clean settling avg (the truth, when settling had
+            //      time to register at least one stable sample)
+            //   2. m_weightAtStop floor — post-stop drip can only ADD
+            //      weight, so persisting a value below the SAW trigger
+            //      weight is physically impossible
+            //   3. leave m_weight as-is (cup lifted before either signal
+            //      was observable; this is the legacy behavior)
+            if (m_lastCleanSettlingAvg > 0.0) {
+                m_weight = m_lastCleanSettlingAvg;
+            } else if (m_weightAtStop > 0.0 && m_weight < m_weightAtStop) {
+                m_weight = m_weightAtStop;
+            }
+
             m_sawTriggeredThisShot = false;  // Prevent stale SAW state on next operation
             m_sawSettling = false;
             m_settlingTimer.stop();
@@ -291,7 +312,10 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
             bool weightAboveAvg = (weight > avg + SETTLING_ABOVE_AVG_MARGIN);
 
             if (avgDrift < SETTLING_AVG_THRESHOLD && !avgBelowStop && !weightAboveAvg) {
-                // Average is stable and current weight is within it - check how long
+                // Average is stable and current weight is within it - check how long.
+                // Capture the clean avg now so we can fall back to it if the user
+                // lifts the cup before SETTLING_STABLE_MS elapses (issue #1280).
+                m_lastCleanSettlingAvg = avg;
                 if (m_settlingAvgStableSince == 0)
                     m_settlingAvgStableSince = now;
 
@@ -474,6 +498,7 @@ void ShotTimingController::startSettlingTimer()
     m_settlingWindowCount = 0;
     m_settlingWindowIndex = 0;
     m_lastSettlingAvg = m_weight;
+    m_lastCleanSettlingAvg = 0.0;  // No clean avg yet this cycle (#1280)
     m_settlingAvgStableSince = 0;
     m_lastDripOngoingLogMs = 0;  // Allow first "drip ongoing" log immediately
 

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -208,6 +208,12 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
         // 1. Single-step dramatic drop (>20g decrease from current)
         // 2. Cumulative drop >20g below peak weight (catches multi-step removal
         //    where no single step exceeds 20g)
+        //
+        // NOTE: cup-removed detection AND the fallback chain below are
+        // mirrored in tools/shot_eval/main.cpp `analyzeShotSettling()` for
+        // offline corpus replay. There is no compile-time link enforcing
+        // parity — when changing thresholds or the fallback ordering here,
+        // update the offline tool to match.
         bool cupRemoved = (m_weight > 20.0 && weight < m_weight - 20.0) ||
                           (m_settlingPeakWeight > 20.0 && weight < m_settlingPeakWeight - 20.0);
         if (cupRemoved) {
@@ -243,19 +249,46 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
                 && (m_weightAtStop <= 0.0
                     || (m_lastCleanSettlingAvg - m_weightAtStop)
                            <= MAX_PLAUSIBLE_POST_STOP_DRIP_G);
+            // Each branch logs which fallback fired so the per-shot debug
+            // log records why finalWeight is what it is — without this the
+            // four paths are indistinguishable at post-mortem.
             if (cleanAvgPlausible) {
+                qDebug().nospace()
+                    << "[SAW] Cup-removed: restored finalWeight to clean avg "
+                    << QString::number(m_lastCleanSettlingAvg, 'f', 1)
+                    << " g (was " << QString::number(m_weight, 'f', 1) << " g)";
                 m_weight = m_lastCleanSettlingAvg;
             } else if (haveCleanAvg && m_weightAtStop > 0.0) {
                 // The clean avg captured an implausibly large overshoot
-                // (>5 g above SAW trigger) — almost certainly a scale
-                // fault (freeze, drift, sensor glitch). m_weight at the
-                // moment of cup-removal is part of that same corrupt
-                // stream, so snap finalWeight back to the SAW trigger
-                // weight regardless of whether m_weight is currently
-                // above or below it.
+                // (>MAX_PLAUSIBLE_POST_STOP_DRIP_G above SAW trigger) —
+                // almost certainly a scale fault (freeze, drift, sensor
+                // glitch). m_weight at the moment of cup-removal is part
+                // of that same corrupt stream, so snap finalWeight back to
+                // the SAW trigger weight regardless of whether m_weight is
+                // currently above or below it.
+                qWarning().nospace()
+                    << "[SAW] Cup-removed: clean avg "
+                    << QString::number(m_lastCleanSettlingAvg, 'f', 1)
+                    << " g rejected as scale fault (overshoot "
+                    << QString::number(m_lastCleanSettlingAvg - m_weightAtStop, 'f', 1)
+                    << " g > " << MAX_PLAUSIBLE_POST_STOP_DRIP_G
+                    << " g over SAW trigger "
+                    << QString::number(m_weightAtStop, 'f', 1)
+                    << " g) — snapping finalWeight to SAW trigger";
                 m_weight = m_weightAtStop;
             } else if (m_weightAtStop > 0.0 && m_weight < m_weightAtStop) {
+                qDebug().nospace()
+                    << "[SAW] Cup-removed: floored finalWeight at SAW trigger "
+                    << QString::number(m_weightAtStop, 'f', 1)
+                    << " g (was " << QString::number(m_weight, 'f', 1)
+                    << " g, no clean avg captured)";
                 m_weight = m_weightAtStop;
+            } else {
+                qDebug().nospace()
+                    << "[SAW] Cup-removed: no fallback applied (m_weight="
+                    << QString::number(m_weight, 'f', 1) << " g, m_weightAtStop="
+                    << QString::number(m_weightAtStop, 'f', 1) << " g, haveCleanAvg="
+                    << haveCleanAvg << ")";
             }
 
             m_sawTriggeredThisShot = false;  // Prevent stale SAW state on next operation
@@ -344,8 +377,21 @@ void ShotTimingController::onWeightSample(double weight, double flowRate, double
                 // values nowhere near the true cup weight; corpus-scan of 953 real
                 // shots showed 4 false-positive captures vs 2 legitimate recoveries
                 // before this guard was added.
-                if (avgStableMs >= SETTLING_CLEAN_CAPTURE_MS)
+                if (avgStableMs >= SETTLING_CLEAN_CAPTURE_MS) {
+                    // Log the FIRST capture each settling cycle (m_lastCleanSettlingAvg
+                    // is reset to 0 at startShot/startSettlingTimer). Subsequent gate
+                    // fires keep updating the value silently — logging every one would
+                    // be redundant with the per-sample `[SAW] Settling:` line.
+                    if (m_lastCleanSettlingAvg <= 0.0) {
+                        qDebug().nospace()
+                            << "[SAW] First clean-avg capture at "
+                            << QString::number(avg, 'f', 1)
+                            << " g (gate held " << avgStableMs
+                            << " ms, SAW trigger "
+                            << QString::number(m_weightAtStop, 'f', 1) << " g)";
+                    }
                     m_lastCleanSettlingAvg = avg;
+                }
                 if (avgStableMs >= SETTLING_STABLE_MS) {
                     qDebug() << "[SAW] Weight settled by avg at" << QString::number(avg, 'f', 1)
                              << "g (avg stable for" << avgStableMs << "ms, current:" << weight << "g)";

--- a/src/controllers/shottimingcontroller.h
+++ b/src/controllers/shottimingcontroller.h
@@ -163,6 +163,15 @@ private:
     static constexpr int SETTLING_WINDOW_SIZE = 6;         // ~1.5s of samples at ~4Hz
     static constexpr double SETTLING_AVG_THRESHOLD = 0.3;  // Max avg drift to declare stable (g)
     static constexpr int SETTLING_STABLE_MS = 1000;        // How long avg must be stable (ms)
+    // Minimum time the stability gate must hold continuously before
+    // m_lastCleanSettlingAvg is captured (#1280). Filters out transient
+    // gate-fires during noisy/oscillating settles — a single sample whose
+    // window avg happens to satisfy the gate must NOT be persisted as a
+    // "clean" value to fall back to on cup-removal. 250 ms ≈ 3 consecutive
+    // samples at the typical ~100 ms scale cadence; shorter than
+    // SETTLING_STABLE_MS so the fallback still applies to a 700 ms plateau
+    // (Mark's #1280 case) without waiting for full settlement.
+    static constexpr int SETTLING_CLEAN_CAPTURE_MS = 250;
     static constexpr double SETTLING_ABOVE_AVG_MARGIN = 0.2; // Current weight must be within this of avg to declare stable (g)
     static constexpr int SETTLING_SILENCE_OVERRIDE_MS = 2000; // If weight unchanged for this long, declare stable regardless of avg margin
     double m_settlingWindow[SETTLING_WINDOW_SIZE] = {};

--- a/src/controllers/shottimingcontroller.h
+++ b/src/controllers/shottimingcontroller.h
@@ -159,8 +159,11 @@ private:
     double m_settlingPeakWeight = 0.0; // Peak weight seen during settling (for cup removal detection)
 
     // Rolling average for settling stability detection
-    // Tolerates oscillations by checking if the average weight has stopped drifting
-    static constexpr int SETTLING_WINDOW_SIZE = 6;         // ~1.5s of samples at ~4Hz
+    // Tolerates oscillations by checking if the average weight has stopped drifting.
+    // Scale cadences vary 4–10 Hz across supported hardware (Decent v1 ~4 Hz, most
+    // WiFi/v2 scales ~10 Hz); window size is chosen to absorb at least one full
+    // BLE drop-out without losing the trend.
+    static constexpr int SETTLING_WINDOW_SIZE = 6;         // 6-sample circular buffer
     static constexpr double SETTLING_AVG_THRESHOLD = 0.3;  // Max avg drift to declare stable (g)
     static constexpr int SETTLING_STABLE_MS = 1000;        // How long avg must be stable (ms)
     // Minimum time the stability gate must hold continuously before
@@ -188,8 +191,10 @@ private:
     double m_lastSettlingAvg = 0.0;
     // Most recent rolling-window avg observed while the stability gate held
     // (drift < SETTLING_AVG_THRESHOLD, weight ≤ avg + SETTLING_ABOVE_AVG_MARGIN,
-    // avg ≥ m_weightAtStop − 0.5). Used as the cup-removal fallback for
-    // m_weight when the user lifts the cup before SETTLING_STABLE_MS elapses.
+    // avg ≥ m_weightAtStop − 0.5) AND the gate had been holding for at least
+    // SETTLING_CLEAN_CAPTURE_MS — see that constant for the rationale behind
+    // the time gate. Used as the cup-removal fallback for m_weight when the
+    // user lifts the cup before SETTLING_STABLE_MS elapses.
     // 0 ⇒ no clean avg has been observed yet this settling cycle.
     double m_lastCleanSettlingAvg = 0.0;
     qint64 m_settlingAvgStableSince = 0; // When the rolling avg stopped drifting

--- a/src/controllers/shottimingcontroller.h
+++ b/src/controllers/shottimingcontroller.h
@@ -169,6 +169,12 @@ private:
     int m_settlingWindowCount = 0;
     int m_settlingWindowIndex = 0;
     double m_lastSettlingAvg = 0.0;
+    // Most recent rolling-window avg observed while the stability gate held
+    // (drift < SETTLING_AVG_THRESHOLD, weight ≤ avg + SETTLING_ABOVE_AVG_MARGIN,
+    // avg ≥ m_weightAtStop − 0.5). Used as the cup-removal fallback for
+    // m_weight when the user lifts the cup before SETTLING_STABLE_MS elapses.
+    // 0 ⇒ no clean avg has been observed yet this settling cycle.
+    double m_lastCleanSettlingAvg = 0.0;
     qint64 m_settlingAvgStableSince = 0; // When the rolling avg stopped drifting
     qint64 m_lastDripOngoingLogMs = 0;   // Throttle "drip still ongoing" log to 1/sec
 

--- a/src/controllers/shottimingcontroller.h
+++ b/src/controllers/shottimingcontroller.h
@@ -172,6 +172,14 @@ private:
     // SETTLING_STABLE_MS so the fallback still applies to a 700 ms plateau
     // (Mark's #1280 case) without waiting for full settlement.
     static constexpr int SETTLING_CLEAN_CAPTURE_MS = 250;
+    // Maximum physically plausible post-stop drip (#1280 follow-up). Real
+    // drip is typically 0.5–3 g, even slow-flow profiles stay under ~5 g.
+    // A "stable" rolling avg more than this far above m_weightAtStop is
+    // almost certainly a scale fault (frozen reading, glitch) rather than
+    // a settled cup weight — corpus scan revealed one shot where the
+    // scale froze at ~75 g during settling on a ~40 g target. Reject the
+    // recovery in those cases and fall through to the m_weightAtStop floor.
+    static constexpr double MAX_PLAUSIBLE_POST_STOP_DRIP_G = 5.0;
     static constexpr double SETTLING_ABOVE_AVG_MARGIN = 0.2; // Current weight must be within this of avg to declare stable (g)
     static constexpr int SETTLING_SILENCE_OVERRIDE_MS = 2000; // If weight unchanged for this long, declare stable regardless of avg margin
     double m_settlingWindow[SETTLING_WINDOW_SIZE] = {};

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -215,16 +215,27 @@ private slots:
 
         // Sample stream extracted verbatim from shot 5470's debug log
         // (`[SAW] Settling: <w> g` lines + the final cup-gone reading).
-        const QList<double> samples = {
+        // The stable-plateau samples are fed with QTest::qWait(30) so the
+        // controller's m_settlingAvgStableSince clock accumulates past
+        // SETTLING_CLEAN_CAPTURE_MS (250 ms). Without the wait the test runs
+        // in microseconds and the clean-avg gate never fires.
+        const QList<double> stableSamples = {
             41.5, 41.7, 42.0, 42.2,
             42.3, 42.3, 42.3, 42.3, 42.3, 42.3, 42.3,
             42.4, 42.4, 42.5,
-            44.0, 48.4, 51.0,   // cup-lift upward spikes
-            38.5,               // down-step within cup-removal threshold
-            -28.0               // cup gone — triggers cup-removed branch
         };
-        for (double w : samples)
+        for (double w : stableSamples) {
             tc.onWeightSample(w, 0.5);
+            QTest::qWait(50);  // ~50 ms × 14 samples = 700 ms; gate must
+                                // cross SETTLING_CLEAN_CAPTURE_MS = 250 ms
+        }
+        // Cup-lift artifacts and removal — run fast, the gate should have
+        // already captured the clean avg from the plateau above.
+        tc.onWeightSample(44.0, 0.5);
+        tc.onWeightSample(48.4, 0.5);
+        tc.onWeightSample(51.0, 0.5);
+        tc.onWeightSample(38.5, 0.5);
+        tc.onWeightSample(-28.0, 0.5);
 
         QVERIFY2(!tc.isSawSettling(),
                  "Cup-removed branch should have fired and exited settling");
@@ -233,6 +244,51 @@ private slots:
                      "Expected ~42.3 g (last clean settled avg), got %1 g — "
                      "the cup-lift spike artifacts polluted m_weight")
                      .arg(tc.currentWeight(), 0, 'f', 2)));
+    }
+
+    void cupLiftAfterNoisyPlateauDoesNotCaptureTransients_1280() {
+        // Regression guard for the corpus-scan finding (PR #1282 review):
+        // shots whose scale was wobbly throughout settling had no real
+        // plateau, but the rolling-window avg occasionally satisfied the
+        // gate transiently. The original capture rule (fire on every
+        // gate match) over-applied the fallback in those cases. With
+        // SETTLING_CLEAN_CAPTURE_MS = 250 ms, a single transient gate
+        // fire MUST NOT update m_lastCleanSettlingAvg — verified by
+        // inspecting the private member via DECENZA_TESTING friend access.
+        DE1Device device;
+        ShotTimingController tc(&device);
+
+        tc.startShot();
+        tc.onSawTriggered(35.0, 2.5, 36.0);
+        tc.endShot();
+        QVERIFY(tc.isSawSettling());
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("Cup removed during settling"));
+
+        // Wobbly samples — the rolling avg may briefly satisfy the gate
+        // but no plateau ever holds for 250 ms. Feed with NO qWait so
+        // m_settlingAvgStableSince never accumulates wall-clock time.
+        const QList<double> noisy = {
+            34.5, 36.0, 33.8, 35.2, 36.4, 33.2, 35.9, 34.0, 36.1, 33.5,
+            45.3,   // cup-lift starts; spike accepted (under 20 g step)
+            44.2, 41.1, 38.4,
+            10.0    // 35.3 g drop from peak 45.3 — cup-removed fires
+        };
+        for (double w : noisy)
+            tc.onWeightSample(w, 0.5);
+
+        QVERIFY(!tc.isSawSettling());
+        // Core invariant: no transient gate fire was promoted to a
+        // captured clean avg. Without SETTLING_CLEAN_CAPTURE_MS, this
+        // would have been set to whatever the rolling avg was at the
+        // single fortuitous moment the gate happened to fire (~34.9 g
+        // for this stream, but could be 47-56 g in corpus shots 908/909).
+        QVERIFY2(tc.m_lastCleanSettlingAvg == 0.0,
+                 qPrintable(QString(
+                     "Transient single-sample gate fires must NOT update "
+                     "m_lastCleanSettlingAvg, got %1 g")
+                     .arg(tc.m_lastCleanSettlingAvg, 0, 'f', 2)));
     }
 
     void cupLiftBeforeAnyCleanAvgFloorsAtStopWeight() {

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -191,6 +191,87 @@ private slots:
         QVERIFY(tc.isSawSettling());
     }
 
+    void cupLiftMidSettlePreservesLastStableAvg_1280() {
+        // Issue #1280: shot 5470. SAW correctly stopped at 41.2 g and the cup
+        // settled at ~42.3 g for ~700 ms, but the user lifted the cup before
+        // SETTLING_STABLE_MS elapsed. Cup-lift produced scale spike artifacts
+        // (44, 48.4, 51) that ShotTimingController accepted (unlike ShotDataModel
+        // which spike-rejects), then a 38.5 down-step that squeaked under the
+        // 20 g cup-removal threshold, then the final cup-gone -28 reading.
+        // Before this fix, m_weight ended at 38.5 — the AI advisor saw
+        // {yield: 38.5, target: 42} and invented a "you stopped manually"
+        // narrative. The fix preserves the last clean rolling avg (~42.3 g) on
+        // the cup-removed path so finalWeightG reflects what was in the cup.
+        DE1Device device;
+        ShotTimingController tc(&device);
+
+        tc.startShot();
+        tc.onSawTriggered(41.2, 2.5, 42.0);
+        tc.endShot();
+        QVERIFY(tc.isSawSettling());
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("Cup removed during settling"));
+
+        // Sample stream extracted verbatim from shot 5470's debug log
+        // (`[SAW] Settling: <w> g` lines + the final cup-gone reading).
+        const QList<double> samples = {
+            41.5, 41.7, 42.0, 42.2,
+            42.3, 42.3, 42.3, 42.3, 42.3, 42.3, 42.3,
+            42.4, 42.4, 42.5,
+            44.0, 48.4, 51.0,   // cup-lift upward spikes
+            38.5,               // down-step within cup-removal threshold
+            -28.0               // cup gone — triggers cup-removed branch
+        };
+        for (double w : samples)
+            tc.onWeightSample(w, 0.5);
+
+        QVERIFY2(!tc.isSawSettling(),
+                 "Cup-removed branch should have fired and exited settling");
+        QVERIFY2(tc.currentWeight() > 41.5 && tc.currentWeight() < 43.0,
+                 qPrintable(QString(
+                     "Expected ~42.3 g (last clean settled avg), got %1 g — "
+                     "the cup-lift spike artifacts polluted m_weight")
+                     .arg(tc.currentWeight(), 0, 'f', 2)));
+    }
+
+    void cupLiftBeforeAnyCleanAvgFloorsAtStopWeight() {
+        // Edge case: cup lifted before any settling sample satisfies the
+        // stability gate (no clean rolling avg captured). Then a sequence of
+        // small drops walks m_weight below m_weightAtStop before the final
+        // big drop trips cup-removal. Without the floor, m_weight would
+        // persist BELOW the SAW trigger weight — physically impossible since
+        // post-stop drip can only add weight.
+        DE1Device device;
+        ShotTimingController tc(&device);
+
+        tc.startShot();
+        tc.onSawTriggered(40.0, 3.0, 42.0);
+        tc.endShot();
+        QVERIFY(tc.isSawSettling());
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("Cup removed during settling"));
+
+        // Cup wobble samples: each step is under the 20 g cup-removal threshold
+        // (relative to the previous m_weight), so each individual sample is
+        // accepted. m_weight ends up at 25 g (below stop weight 40) before the
+        // final -10 trips cup-removal via the peak-drop arm (peak=42, -10 < 22).
+        tc.onWeightSample(42.0, 0.5);   // m_weight = 42, peak = 42
+        tc.onWeightSample(36.0, 0.5);   // delta -6 < 20, accepted; m_weight = 36
+        tc.onWeightSample(30.0, 0.5);   // delta -6 < 20, accepted; m_weight = 30
+        tc.onWeightSample(25.0, 0.5);   // delta -5 < 20, accepted; m_weight = 25 (< 40)
+        tc.onWeightSample(-10.0, 0.5);  // cup-removed via peak arm (-10 < 42 - 20)
+
+        QVERIFY(!tc.isSawSettling());
+        QVERIFY2(tc.currentWeight() >= 40.0,
+                 qPrintable(QString(
+                     "Expected floor at m_weightAtStop (40.0 g), got %1 g — "
+                     "post-stop drip can only add weight; persisting a value "
+                     "below the SAW trigger weight is physically impossible")
+                     .arg(tc.currentWeight(), 0, 'f', 2)));
+    }
+
     void sawLearningCompleteFiresBeforeShotProcessingReady() {
         // SAW_LEARNING.md requires the [SAW] accuracy / accumulated / committed lines
         // to land in the per-shot debug log. shotProcessingReady triggers stopCapture

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -244,6 +244,13 @@ private slots:
                      "Expected ~42.3 g (last clean settled avg), got %1 g — "
                      "the cup-lift spike artifacts polluted m_weight")
                      .arg(tc.currentWeight(), 0, 'f', 2)));
+        // #1161 invariant: the cup-removed branch clears
+        // m_sawTriggeredThisShot but must NOT clear m_stopAtWeightTriggered
+        // — otherwise MainController::onShotEnded would misclassify this
+        // cup-lifted SAW shot as "profileEnd" instead of "weight".
+        QVERIFY2(tc.wasSawTriggered(),
+                 "Cup-removed path must preserve wasSawTriggered() == true "
+                 "so the saved shot's stoppedBy classification stays 'weight'");
     }
 
     void cupLiftAfterNoisyPlateauDoesNotCaptureTransients_1280() {

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -316,10 +316,11 @@ private slots:
         // Simulate a frozen-scale fault: a long run of identical samples
         // at 74.8 g (35+ g above stop weight). The gate fires once the
         // rolling window fills (SETTLING_WINDOW_SIZE = 6) and then
-        // consecutively. Need enough samples × qWait that the
-        // post-window-fill interval exceeds SETTLING_CLEAN_CAPTURE_MS
-        // (250 ms): 15 samples × 50 ms = ~9 post-fill intervals × 50 ms
-        // = 450 ms, comfortably above the capture threshold.
+        // consecutively. We need the post-window-fill cumulative qWait
+        // to exceed SETTLING_CLEAN_CAPTURE_MS (250 ms): 15 samples × 50 ms
+        // = 750 ms total wall time; subtracting the first 6 samples that
+        // fill the window leaves 9 post-fill intervals × 50 ms = 450 ms,
+        // comfortably above the 250 ms capture threshold.
         for (int i = 0; i < 15; ++i) {
             tc.onWeightSample(74.8, 0.0);
             QTest::qWait(50);
@@ -381,6 +382,89 @@ private slots:
                      "Expected floor at m_weightAtStop (40.0 g), got %1 g — "
                      "post-stop drip can only add weight; persisting a value "
                      "below the SAW trigger weight is physically impossible")
+                     .arg(tc.currentWeight(), 0, 'f', 2)));
+    }
+
+    void cleanAvgClearedBetweenShots_1280() {
+        // Regression guard for the cross-shot reset invariant. The fix
+        // resets m_lastCleanSettlingAvg = 0.0 in both startShot() and
+        // startSettlingTimer(); if either reset is ever removed during
+        // refactoring, a clean avg captured during shot N could leak into
+        // shot N+1's cup-removal handler — silently overwriting the new
+        // shot's finalWeight with the prior shot's value.
+        DE1Device device;
+        ShotTimingController tc(&device);
+
+        // Shot N: capture a clean avg via the same QTest::qWait pattern
+        // the _1280 plateau test uses.
+        tc.startShot();
+        tc.onSawTriggered(35.0, 2.5, 36.0);
+        tc.endShot();
+        for (int i = 0; i < 14; ++i) {
+            tc.onWeightSample(36.0, 0.5);
+            QTest::qWait(50);
+        }
+        QVERIFY2(tc.m_lastCleanSettlingAvg > 0.0,
+                 "Capture gate should have fired on the plateau");
+
+        // Start shot N+1 — this must reset the captured value.
+        tc.startShot();
+        QCOMPARE(tc.m_lastCleanSettlingAvg, 0.0);
+
+        // Re-confirm the reset also happens when settling starts (covers
+        // the path where startShot() ran but settling didn't yet).
+        tc.m_lastCleanSettlingAvg = 99.9;
+        tc.onSawTriggered(35.0, 2.5, 36.0);
+        tc.endShot();  // triggers startSettlingTimer()
+        QCOMPARE(tc.m_lastCleanSettlingAvg, 0.0);
+    }
+
+    void cleanAvgSurvivesPostCaptureGateFailure_1280() {
+        // Regression guard for the "captured then disturbed" sequence
+        // Mark's shot 5470 actually had: settling plateau holds for
+        // hundreds of ms (capture fires), THEN the cup-lift artifacts
+        // arrive (gate fails for each spike sample). The captured value
+        // MUST survive that gate failure — otherwise a "tighten the gate"
+        // refactor that clears m_lastCleanSettlingAvg on every gate-fail
+        // would silently break the actual bug class the fix targets.
+        DE1Device device;
+        ShotTimingController tc(&device);
+
+        tc.startShot();
+        tc.onSawTriggered(41.2, 2.5, 42.0);
+        tc.endShot();
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("Cup removed during settling"));
+
+        // Establish the captured value with a stable plateau.
+        for (int i = 0; i < 14; ++i) {
+            tc.onWeightSample(42.3, 0.5);
+            QTest::qWait(50);
+        }
+        const double capturedAvg = tc.m_lastCleanSettlingAvg;
+        QVERIFY2(capturedAvg > 41.0 && capturedAvg < 43.0,
+                 "Plateau should produce a clean avg near 42.3 g");
+
+        // Now feed a few "gate failure" samples that do NOT trigger
+        // cup-removal (deltas under 20 g). Each one should reset
+        // m_settlingAvgStableSince via weightAboveAvg but MUST NOT clear
+        // m_lastCleanSettlingAvg.
+        tc.onWeightSample(44.0, 0.5);  // delta +1.7 from 42.3; weightAboveAvg trips
+        tc.onWeightSample(48.4, 0.5);  // delta +4.4; weightAboveAvg trips
+        tc.onWeightSample(51.0, 0.5);  // delta +2.6; weightAboveAvg trips
+        QCOMPARE(tc.m_lastCleanSettlingAvg, capturedAvg);
+
+        // Cup-removed via single-step drop from 51 to 20 (delta 31 > 20).
+        tc.onWeightSample(20.0, 0.5);
+
+        QVERIFY(!tc.isSawSettling());
+        QVERIFY2(std::abs(tc.currentWeight() - capturedAvg) < 0.1,
+                 qPrintable(QString(
+                     "After post-capture gate failure, cup-removed must "
+                     "restore the pre-disruption captured avg (%1 g), "
+                     "got %2 g")
+                     .arg(capturedAvg, 0, 'f', 2)
                      .arg(tc.currentWeight(), 0, 'f', 2)));
     }
 

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -291,6 +291,62 @@ private slots:
                      .arg(tc.m_lastCleanSettlingAvg, 0, 'f', 2)));
     }
 
+    void implausibleCleanAvgIsRejectedAsScaleFault_1280() {
+        // Regression guard for the corpus-scan finding (PR #1282 review):
+        // shot 825 had a scale fault — the cup-on-scale reading froze at
+        // ~75 g for hundreds of milliseconds on a ~40 g target shot. The
+        // stability gate held continuously (gate is purely a window-drift
+        // check, can't tell a real settle from a frozen reading), so
+        // m_lastCleanSettlingAvg got captured at the glitch value.
+        // MAX_PLAUSIBLE_POST_STOP_DRIP_G rejects any captured avg whose
+        // overshoot above m_weightAtStop exceeds physical reality
+        // (real drip is 0.5–3 g, never tens of grams). On rejection the
+        // fallback chain falls through to the m_weightAtStop floor.
+        DE1Device device;
+        ShotTimingController tc(&device);
+
+        tc.startShot();
+        tc.onSawTriggered(39.5, 2.5, 40.0);
+        tc.endShot();
+        QVERIFY(tc.isSawSettling());
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression("Cup removed during settling"));
+
+        // Simulate a frozen-scale fault: a long run of identical samples
+        // at 74.8 g (35+ g above stop weight). The gate fires once the
+        // rolling window fills (SETTLING_WINDOW_SIZE = 6) and then
+        // consecutively. Need enough samples × qWait that the
+        // post-window-fill interval exceeds SETTLING_CLEAN_CAPTURE_MS
+        // (250 ms): 15 samples × 50 ms = ~9 post-fill intervals × 50 ms
+        // = 450 ms, comfortably above the capture threshold.
+        for (int i = 0; i < 15; ++i) {
+            tc.onWeightSample(74.8, 0.0);
+            QTest::qWait(50);
+        }
+        // Confirm the capture did happen (we DON'T want to silently rely
+        // on the capture gate having filtered it — the plausibility cap
+        // is the layer being tested).
+        QVERIFY2(tc.m_lastCleanSettlingAvg > 70.0,
+                 "Capture gate should have fired on the frozen plateau");
+
+        // Cup-removal trigger: a big drop.
+        tc.onWeightSample(20.0, 0.5);
+
+        QVERIFY(!tc.isSawSettling());
+        // Expected: clean avg (74.8) was rejected because 74.8 - 39.5 = 35.3 g
+        // exceeds MAX_PLAUSIBLE_POST_STOP_DRIP_G (5.0). The entire post-stop
+        // stream is corrupt (m_weight was 74.8 too), so finalWeight snaps
+        // back to the SAW trigger weight (39.5 g) — the only physically
+        // defensible minimum-truth value we have for this shot.
+        QVERIFY2(std::abs(tc.currentWeight() - 39.5) < 0.5,
+                 qPrintable(QString(
+                     "Implausible clean avg (35+ g overshoot) must snap "
+                     "finalWeight to m_weightAtStop (39.5 g), got %1 g — "
+                     "restoring the glitch value would AMPLIFY the bug")
+                     .arg(tc.currentWeight(), 0, 'f', 2)));
+    }
+
     void cupLiftBeforeAnyCleanAvgFloorsAtStopWeight() {
         // Edge case: cup lifted before any settling sample satisfies the
         // stability gate (no clean rolling avg captured). Then a sequence of

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -1470,6 +1470,76 @@ private slots:
         QVERIFY2(prompt.contains(QStringLiteral("Conversational metadata corrections")),
                  "System prompt must teach the bean-correction acknowledgement rule");
     }
+
+    // -------------------------------------------------------------
+    // #1280: standalone shot block carries stoppedBy so the LLM has a
+    // stop-reason anchor instead of inventing "you stopped manually"
+    // when yieldG looks short. Allowlist mirrors dialing_blocks.cpp.
+    // -------------------------------------------------------------
+    void buildUserPrompt_shotBlock_carriesStoppedByWeight()
+    {
+        QVariantMap shot = makeHealthyShotMap();
+        shot["stoppedBy"] = QStringLiteral("weight");
+        ShotSummarizer summarizer;
+        const ShotSummary summary =
+            summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
+
+        const QString prompt = summarizer.buildUserPrompt(summary);
+        const QJsonObject payload = QJsonDocument::fromJson(prompt.toUtf8()).object();
+        const QJsonObject shotBlock = payload.value(QStringLiteral("shot")).toObject();
+        QCOMPARE(shotBlock.value(QStringLiteral("stoppedBy")).toString(),
+                 QStringLiteral("weight"));
+    }
+
+    void buildUserPrompt_shotBlock_carriesStoppedByManual()
+    {
+        QVariantMap shot = makeHealthyShotMap();
+        shot["stoppedBy"] = QStringLiteral("manual");
+        ShotSummarizer summarizer;
+        const ShotSummary summary =
+            summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
+
+        const QString prompt = summarizer.buildUserPrompt(summary);
+        const QJsonObject shotBlock = QJsonDocument::fromJson(prompt.toUtf8()).object()
+            .value(QStringLiteral("shot")).toObject();
+        QCOMPARE(shotBlock.value(QStringLiteral("stoppedBy")).toString(),
+                 QStringLiteral("manual"));
+    }
+
+    void buildUserPrompt_shotBlock_omitsStoppedByForProfileEnd()
+    {
+        // profileEnd is intentionally omitted from the allowlist — the
+        // rubric at shotsummarizer.cpp:1405 documents that an ABSENT field
+        // means "ran to completion OR DE1 hardware button". Emitting
+        // "profileEnd" explicitly would conflict with that absence semantics.
+        QVariantMap shot = makeHealthyShotMap();
+        shot["stoppedBy"] = QStringLiteral("profileEnd");
+        ShotSummarizer summarizer;
+        const ShotSummary summary =
+            summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
+
+        const QString prompt = summarizer.buildUserPrompt(summary);
+        const QJsonObject shotBlock = QJsonDocument::fromJson(prompt.toUtf8()).object()
+            .value(QStringLiteral("shot")).toObject();
+        QVERIFY2(!shotBlock.contains(QStringLiteral("stoppedBy")),
+                 "profileEnd must NOT serialize to the standalone shot block — "
+                 "the rubric documents absent-field semantics that conflict with it");
+    }
+
+    void buildUserPrompt_shotBlock_omitsStoppedByWhenEmpty()
+    {
+        QVariantMap shot = makeHealthyShotMap();
+        // No stoppedBy key set — projection field defaults to empty string.
+        ShotSummarizer summarizer;
+        const ShotSummary summary =
+            summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
+
+        const QString prompt = summarizer.buildUserPrompt(summary);
+        const QJsonObject shotBlock = QJsonDocument::fromJson(prompt.toUtf8()).object()
+            .value(QStringLiteral("shot")).toObject();
+        QVERIFY2(!shotBlock.contains(QStringLiteral("stoppedBy")),
+                 "empty stoppedBy must not emit the field");
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_ShotSummarizer)

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -1509,9 +1509,10 @@ private slots:
     void buildUserPrompt_shotBlock_omitsStoppedByForProfileEnd()
     {
         // profileEnd is intentionally omitted from the allowlist — the
-        // rubric at shotsummarizer.cpp:1405 documents that an ABSENT field
-        // means "ran to completion OR DE1 hardware button". Emitting
-        // "profileEnd" explicitly would conflict with that absence semantics.
+        // system prompt's "stoppedBy → real outcome or user choice?" rubric
+        // documents that an ABSENT field means "ran to completion OR DE1
+        // hardware button". Emitting "profileEnd" explicitly would conflict
+        // with that absence semantics.
         QVariantMap shot = makeHealthyShotMap();
         shot["stoppedBy"] = QStringLiteral("profileEnd");
         ShotSummarizer summarizer;
@@ -1539,6 +1540,67 @@ private slots:
             .value(QStringLiteral("shot")).toObject();
         QVERIFY2(!shotBlock.contains(QStringLiteral("stoppedBy")),
                  "empty stoppedBy must not emit the field");
+    }
+
+    void buildUserPrompt_shotBlock_carriesStoppedByVolume()
+    {
+        // The third allowlist case: SAV (stop-at-volume) shots. Without
+        // a dedicated test, a future refactor that converts the three
+        // string comparisons in buildShotBlock into a QSet<QString> and
+        // accidentally lists only {manual, weight} would slip past the
+        // existing two cases.
+        QVariantMap shot = makeHealthyShotMap();
+        shot["stoppedBy"] = QStringLiteral("volume");
+        ShotSummarizer summarizer;
+        const ShotSummary summary =
+            summarizer.summarizeFromHistory(ShotProjection::fromVariantMap(shot));
+
+        const QString prompt = summarizer.buildUserPrompt(summary);
+        const QJsonObject shotBlock = QJsonDocument::fromJson(prompt.toUtf8()).object()
+            .value(QStringLiteral("shot")).toObject();
+        QCOMPARE(shotBlock.value(QStringLiteral("stoppedBy")).toString(),
+                 QStringLiteral("volume"));
+    }
+
+    void summarize_livePath_carriesStoppedByThroughBuildShotBlock_1280()
+    {
+        // The live `summarize(...)` overload accepts a defaulted `stoppedBy`
+        // parameter (currently passed only from MainController-equivalent
+        // callers post-#1280). Tests for the allowlist behavior on the
+        // saved-shot path exist above; this test guards against the two
+        // paths diverging — if a future refactor changes how the live
+        // path populates `ShotSummary::stoppedBy`, the same allowlist
+        // and serialization must still apply.
+        ShotDataModel model;
+        std::vector<LiveSample> samples;
+        for (double t = 0.0; t <= 8.0; t += 0.1) {
+            samples.push_back({
+                /*t=*/t, /*pressure=*/2.0, /*flow=*/2.0,
+                /*temperature=*/93.0, /*pressureGoal=*/0.0, /*flowGoal=*/2.0,
+                /*temperatureGoal=*/93.0, /*isFlowMode=*/true});
+        }
+        for (double t = 8.0 + 0.1; t <= 28.0 + 1e-9; t += 0.1) {
+            samples.push_back({
+                /*t=*/t, /*pressure=*/9.0, /*flow=*/2.0,
+                /*temperature=*/93.0, /*pressureGoal=*/9.0, /*flowGoal=*/0.0,
+                /*temperatureGoal=*/93.0, /*isFlowMode=*/false});
+        }
+        populateLiveShot(&model, samples,
+            {{0.0, QStringLiteral("Preinfusion"), 0, true},
+             {8.0, QStringLiteral("Pour"), 1, false}},
+            /*finalWeight=*/36.0);
+
+        ShotMetadata metadata;
+        ShotSummarizer summarizer;
+        const ShotSummary summary = summarizer.summarize(&model, /*profile=*/nullptr,
+            metadata, /*doseWeight=*/18.0, /*finalWeight=*/36.0,
+            /*stoppedBy=*/QStringLiteral("weight"));
+
+        const QString prompt = summarizer.buildUserPrompt(summary);
+        const QJsonObject shotBlock = QJsonDocument::fromJson(prompt.toUtf8()).object()
+            .value(QStringLiteral("shot")).toObject();
+        QCOMPARE(shotBlock.value(QStringLiteral("stoppedBy")).toString(),
+                 QStringLiteral("weight"));
     }
 };
 

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -833,6 +833,13 @@ SettlingReport analyzeShotSettling(const QString& path, const QJsonObject& root)
     double curWeight = 0.0;
     double peakWeight = 0.0;
     bool cupRemovedFired = false;
+    int consecutiveStableFires = 0;
+    // ShotTimingController's SETTLING_CLEAN_CAPTURE_MS = 250 at ~100 ms per
+    // sample ≈ 3 consecutive stable samples before lastCleanAvg can be
+    // captured. Keeping the offline mirror in sync with production prevents
+    // the tool from reporting "phantom recoveries" on shots whose rolling
+    // avg only transiently met the gate amid noisy settling.
+    constexpr int MIN_CONSECUTIVE_STABLE_FIRES = 3;
 
     // Walk every line. Stop accumulating samples after cup-removal so the
     // post-removal artifacts (which the production code wouldn't see — it
@@ -880,7 +887,11 @@ SettlingReport analyzeShotSettling(const QString& path, const QJsonObject& root)
         const bool avgBelowStop = (r.stopWeight > 0 && avg < r.stopWeight - 0.5);
         const bool weightAboveAvg = (weight > avg + SETTLING_ABOVE_AVG_MARGIN);
         if (drift < SETTLING_AVG_THRESHOLD && !avgBelowStop && !weightAboveAvg) {
-            r.lastCleanAvg = avg;
+            ++consecutiveStableFires;
+            if (consecutiveStableFires >= MIN_CONSECUTIVE_STABLE_FIRES)
+                r.lastCleanAvg = avg;
+        } else {
+            consecutiveStableFires = 0;
         }
     }
 

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -730,6 +730,224 @@ EvaluatedShot evaluate(const LoadedShot& s)
     return ev;
 }
 
+// ---------------------------------------------------------------------------
+// Settling replay (#1280): offline analyzer that reproduces
+// ShotTimingController's settling stability gate against a saved shot's
+// embedded `app.data.debug_log`. Reports the recorded yield, the value the
+// fixed cup-removed handler would persist, and surfaces shots where the
+// recorded value differs from the actual settled weight.
+//
+// Mirrors src/controllers/shottimingcontroller.cpp constants:
+//   SETTLING_WINDOW_SIZE = 6
+//   SETTLING_AVG_THRESHOLD = 0.3 g
+//   SETTLING_ABOVE_AVG_MARGIN = 0.2 g
+//   cup-removal: >20 g single-step drop OR >20 g cumulative drop from peak
+// The stable-branch capture mirrors the same condition (drift below
+// threshold, weight close to avg, avg at/above stop weight).
+// ---------------------------------------------------------------------------
+struct SettlingReport {
+    QString path;
+    QString id;
+    bool hasDebugLog = false;
+    bool hasSawTrigger = false;
+    double stopWeight = 0.0;        // SAW trigger weight from `[SAW] Stop triggered:`
+    double recordedYieldG = 0.0;    // meta.out / totals.weight.last() — what's persisted today
+    double lastCleanAvg = 0.0;      // last rolling-window avg that passed the stability gate
+    double preFixWeight = 0.0;      // what m_weight ends up as in today's code
+    double postFixWeight = 0.0;     // what m_weight would be under the #1280 fallback chain
+    bool cupRemoved = false;        // saw `[SAW] Cup removed during settling`
+    int settlingSamples = 0;
+    QString note;                   // human-readable summary
+};
+
+QString extractDebugLog(const QJsonObject& root)
+{
+    const QJsonObject app = root.value(QStringLiteral("app")).toObject();
+    const QJsonObject data = app.value(QStringLiteral("data")).toObject();
+    return data.value(QStringLiteral("debug_log")).toString();
+}
+
+// Parse a single `[SAW] Settling: "<w>" g delta: "..." avg: "<a>" drift: "<d>" stable: <s> ms`
+// line. Returns false if the line doesn't match. Drift is informational only
+// here — we recompute the stability conditions ourselves so the offline
+// analyzer's gate matches what ShotTimingController would have evaluated
+// even if the log's printed drift was rounded.
+bool parseSettlingLine(const QString& line, double* outWeight, double* outAvg, double* outDrift)
+{
+    // Custom raw-string delimiter `RX(...)RX` so the regex's own `)` chars
+    // inside capture groups don't terminate the literal early.
+    static const QRegularExpression rx(
+        QStringLiteral(R"RX(\[SAW\] Settling:\s*"([-\d.]+)"\s*g\s+delta:\s*"[-\d.]+"\s+avg:\s*"([-\d.]+)"\s+drift:\s*"([-\d.]+)")RX"));
+    const auto m = rx.match(line);
+    if (!m.hasMatch()) return false;
+    *outWeight = m.captured(1).toDouble();
+    *outAvg = m.captured(2).toDouble();
+    *outDrift = m.captured(3).toDouble();
+    return true;
+}
+
+bool parseStopTriggered(const QString& line, double* outWeight)
+{
+    // Two variants in the log: `[SAW-Worker] Stop triggered: weight= X` and
+    // `[SAW] Stop triggered: weight= X`. The bare `[SAW]` form is the one
+    // ShotTimingController emits via onSawTriggered() — that's the value
+    // m_weightAtStop captures. Prefer it.
+    static const QRegularExpression rx(
+        QStringLiteral(R"RX(\[SAW\] Stop triggered:\s*weight=\s*([-\d.]+))RX"));
+    const auto m = rx.match(line);
+    if (!m.hasMatch()) return false;
+    *outWeight = m.captured(1).toDouble();
+    return true;
+}
+
+SettlingReport analyzeShotSettling(const QString& path, const QJsonObject& root)
+{
+    SettlingReport r;
+    r.path = path;
+
+    // Recorded yield: prefer meta.out (the persisted finalWeightG), fall
+    // back to totals.weight.last() so visualizer-format shots still resolve.
+    const QJsonObject meta = root.value(QStringLiteral("meta")).toObject();
+    r.recordedYieldG = toDouble(meta.value(QStringLiteral("out")));
+    if (r.recordedYieldG <= 0.0) {
+        const QJsonArray w = root.value(QStringLiteral("totals")).toObject()
+            .value(QStringLiteral("weight")).toArray();
+        if (!w.isEmpty()) r.recordedYieldG = toDouble(w.last());
+    }
+    r.id = meta.value(QStringLiteral("shot")).toObject().value(QStringLiteral("uuid")).toString();
+    if (r.id.isEmpty()) r.id = QFileInfo(path).baseName();
+
+    const QString log = extractDebugLog(root);
+    if (log.isEmpty()) {
+        r.note = QStringLiteral("no embedded debug_log (visualizer-format shot?)");
+        return r;
+    }
+    r.hasDebugLog = true;
+
+    // State mirroring ShotTimingController during the settling window.
+    constexpr int   SETTLING_WINDOW_SIZE      = 6;
+    constexpr double SETTLING_AVG_THRESHOLD   = 0.3;
+    constexpr double SETTLING_ABOVE_AVG_MARGIN = 0.2;
+    constexpr double CUP_REMOVED_DROP_G       = 20.0;
+
+    double curWeight = 0.0;
+    double peakWeight = 0.0;
+    bool cupRemovedFired = false;
+
+    // Walk every line. Stop accumulating samples after cup-removal so the
+    // post-removal artifacts (which the production code wouldn't see — it
+    // returns at cup-removed) don't pollute the offline view either.
+    const QStringList lines = log.split(QLatin1Char('\n'));
+    for (const QString& line : lines) {
+        if (!r.hasSawTrigger) {
+            double w = 0.0;
+            if (parseStopTriggered(line, &w)) {
+                r.stopWeight = w;
+                r.hasSawTrigger = true;
+                curWeight = 0.0;
+                peakWeight = 0.0;
+                continue;
+            }
+        }
+        if (line.contains(QStringLiteral("Cup removed during settling"))) {
+            cupRemovedFired = true;
+            r.cupRemoved = true;
+            break;
+        }
+        if (!r.hasSawTrigger) continue;
+        double weight = 0.0, avg = 0.0, drift = 0.0;
+        if (!parseSettlingLine(line, &weight, &avg, &drift)) continue;
+
+        // Mirror cup-removal trigger (before m_weight updates) — if it fires
+        // here, the production code would early-return; stop sampling.
+        const bool wouldFireRemoval =
+            (curWeight > CUP_REMOVED_DROP_G && weight < curWeight - CUP_REMOVED_DROP_G) ||
+            (peakWeight > CUP_REMOVED_DROP_G && weight < peakWeight - CUP_REMOVED_DROP_G);
+        if (wouldFireRemoval) {
+            cupRemovedFired = true;
+            r.cupRemoved = true;
+            break;
+        }
+
+        if (weight > peakWeight) peakWeight = weight;
+        curWeight = weight;
+        ++r.settlingSamples;
+
+        // Stability gate — capture the avg only when all three conditions
+        // hold (matches src/controllers/shottimingcontroller.cpp line 313).
+        // Window-fill check approximated by sample count.
+        if (r.settlingSamples < SETTLING_WINDOW_SIZE) continue;
+        const bool avgBelowStop = (r.stopWeight > 0 && avg < r.stopWeight - 0.5);
+        const bool weightAboveAvg = (weight > avg + SETTLING_ABOVE_AVG_MARGIN);
+        if (drift < SETTLING_AVG_THRESHOLD && !avgBelowStop && !weightAboveAvg) {
+            r.lastCleanAvg = avg;
+        }
+    }
+
+    r.preFixWeight = curWeight;
+
+    // Apply the #1280 fallback chain. Only matters on cup-removal — clean
+    // settles already write `m_weight = avg` via onSettlingComplete and the
+    // recorded yield is unchanged.
+    r.postFixWeight = curWeight;
+    if (cupRemovedFired) {
+        if (r.lastCleanAvg > 0.0) {
+            r.postFixWeight = r.lastCleanAvg;
+        } else if (r.stopWeight > 0.0 && curWeight < r.stopWeight) {
+            r.postFixWeight = r.stopWeight;
+        }
+    }
+
+    if (!r.hasSawTrigger)         r.note = QStringLiteral("no SAW trigger in log (non-SAW shot)");
+    else if (!cupRemovedFired)    r.note = QStringLiteral("clean settle");
+    else if (r.lastCleanAvg > 0.0) r.note = QStringLiteral("cup-lifted — recovered last clean avg");
+    else if (r.stopWeight > 0.0 && curWeight < r.stopWeight) r.note = QStringLiteral("cup-lifted — floored at stop weight");
+    else                          r.note = QStringLiteral("cup-lifted — no recovery available");
+
+    return r;
+}
+
+void printSettlingTable(const QList<SettlingReport>& rows, QTextStream& out)
+{
+    out << QStringLiteral("%1  %2  %3  %4  %5  %6  %7  %8\n")
+               .arg("file", -32)
+               .arg("stopW", 6)
+               .arg("recorded", 8)
+               .arg("preFix", 6)
+               .arg("postFix", 7)
+               .arg("Δ", 6)
+               .arg("cupLift", 7)
+               .arg("note");
+    out << QString(120, '-') << '\n';
+    int affected = 0;
+    double totalDelta = 0.0;
+    for (const auto& r : rows) {
+        const QString file = QFileInfo(r.path).fileName().left(32);
+        if (!r.hasSawTrigger) {
+            out << QStringLiteral("%1  %2\n").arg(file, -32).arg(r.note);
+            continue;
+        }
+        const double delta = r.postFixWeight - r.preFixWeight;
+        if (std::abs(delta) >= 0.05) {
+            ++affected;
+            totalDelta += delta;
+        }
+        const QString flag = (std::abs(delta) >= 0.05) ? QStringLiteral("***") : QString();
+        out << QStringLiteral("%1  %2  %3  %4  %5  %6  %7  %8 %9\n")
+                   .arg(file, -32)
+                   .arg(r.stopWeight, 6, 'f', 1)
+                   .arg(r.recordedYieldG, 8, 'f', 1)
+                   .arg(r.preFixWeight, 6, 'f', 1)
+                   .arg(r.postFixWeight, 7, 'f', 1)
+                   .arg(delta, 6, 'f', 1)
+                   .arg(r.cupRemoved ? "yes" : "no", 7)
+                   .arg(r.note, flag);
+    }
+    out << '\n'
+        << QStringLiteral("Summary: %1 shots scanned, %2 affected by #1280 fix, total Δ=%3 g\n")
+               .arg(rows.size()).arg(affected).arg(totalDelta, 0, 'f', 1);
+}
+
 void expandInputPaths(const QStringList& inputs, QStringList& files)
 {
     for (const auto& p : inputs) {
@@ -883,12 +1101,25 @@ int main(int argc, char** argv)
         "the sole input. See tests/data/shots/manifest.json for format.",
         "manifest");
     parser.addOption(validateOpt);
+    QCommandLineOption settlingOpt("settling",
+        "Settling-replay mode (#1280). Parses each shot's embedded "
+        "app.data.debug_log and reports the SAW stop weight, recorded "
+        "yield, today's m_weight at cup-removal, and the value the #1280 "
+        "fallback chain would persist. Useful for scanning a personal shot "
+        "corpus for cup-lift-mid-settle cases. Mutually exclusive with "
+        "--validate.");
+    parser.addOption(settlingOpt);
     parser.process(app);
 
     const QStringList inputs = parser.positionalArguments();
     const bool validating = parser.isSet(validateOpt);
+    const bool settlingMode = parser.isSet(settlingOpt);
     if (inputs.isEmpty() && !validating) {
         parser.showHelp(1);
+    }
+    if (validating && settlingMode) {
+        QTextStream(stderr) << "--validate and --settling are mutually exclusive\n";
+        return 1;
     }
 
     QTextStream out(stdout);
@@ -999,6 +1230,27 @@ int main(int argc, char** argv)
     if (files.isEmpty()) {
         QTextStream(stderr) << "no input files found\n";
         return 1;
+    }
+
+    if (settlingMode) {
+        QList<SettlingReport> rows;
+        rows.reserve(files.size());
+        for (const auto& f : files) {
+            QFile file(f);
+            if (!file.open(QIODevice::ReadOnly)) {
+                QTextStream(stderr) << "skip " << f << ": cannot open\n";
+                continue;
+            }
+            QJsonParseError pe;
+            const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &pe);
+            if (!doc.isObject()) {
+                QTextStream(stderr) << "skip " << f << ": " << pe.errorString() << '\n';
+                continue;
+            }
+            rows.append(analyzeShotSettling(f, doc.object()));
+        }
+        printSettlingTable(rows, out);
+        return 0;
     }
 
     QList<EvaluatedShot> results;

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -899,11 +899,23 @@ SettlingReport analyzeShotSettling(const QString& path, const QJsonObject& root)
 
     // Apply the #1280 fallback chain. Only matters on cup-removal — clean
     // settles already write `m_weight = avg` via onSettlingComplete and the
-    // recorded yield is unchanged.
+    // recorded yield is unchanged. The plausibility cap mirrors
+    // ShotTimingController's MAX_PLAUSIBLE_POST_STOP_DRIP_G.
+    constexpr double MAX_PLAUSIBLE_POST_STOP_DRIP_G = 5.0;
     r.postFixWeight = curWeight;
+    bool cleanAvgRejected = false;
     if (cupRemovedFired) {
-        if (r.lastCleanAvg > 0.0) {
+        const bool haveCleanAvg = r.lastCleanAvg > 0.0;
+        const bool cleanAvgPlausible =
+            haveCleanAvg
+            && (r.stopWeight <= 0.0
+                || (r.lastCleanAvg - r.stopWeight) <= MAX_PLAUSIBLE_POST_STOP_DRIP_G);
+        if (cleanAvgPlausible) {
             r.postFixWeight = r.lastCleanAvg;
+        } else if (haveCleanAvg && r.stopWeight > 0.0) {
+            // Implausible clean avg = scale fault; snap to SAW trigger.
+            cleanAvgRejected = true;
+            r.postFixWeight = r.stopWeight;
         } else if (r.stopWeight > 0.0 && curWeight < r.stopWeight) {
             r.postFixWeight = r.stopWeight;
         }
@@ -911,6 +923,7 @@ SettlingReport analyzeShotSettling(const QString& path, const QJsonObject& root)
 
     if (!r.hasSawTrigger)         r.note = QStringLiteral("no SAW trigger in log (non-SAW shot)");
     else if (!cupRemovedFired)    r.note = QStringLiteral("clean settle");
+    else if (cleanAvgRejected)    r.note = QStringLiteral("cup-lifted — clean avg rejected (likely scale fault)");
     else if (r.lastCleanAvg > 0.0) r.note = QStringLiteral("cup-lifted — recovered last clean avg");
     else if (r.stopWeight > 0.0 && curWeight < r.stopWeight) r.note = QStringLiteral("cup-lifted — floored at stop weight");
     else                          r.note = QStringLiteral("cup-lifted — no recovery available");

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -749,9 +749,14 @@ EvaluatedShot evaluate(const LoadedShot& s)
 // The stable-branch capture mirrors the same condition (drift below
 // threshold, weight close to avg, avg at/above stop weight).
 //
+// SETTLING_STABLE_MS (1000 ms) is intentionally NOT mirrored: this tool
+// only replays the cup-removal fallback chain, not the full settlement
+// path that fires onSettlingComplete via the 1-second stability gate.
+//
 // IMPORTANT: when production changes any of the above constants or the
-// cup-removed fallback chain (shottimingcontroller.cpp:240+), update this
-// mirror to match — there is no compile-time link enforcing parity.
+// cup-removed fallback chain (shottimingcontroller.cpp's cup-removed
+// branch), update this mirror to match — there is no compile-time link
+// enforcing parity.
 // ---------------------------------------------------------------------------
 struct SettlingReport {
     QString path;
@@ -889,8 +894,10 @@ SettlingReport analyzeShotSettling(const QString& path, const QJsonObject& root)
         ++r.settlingSamples;
 
         // Stability gate — capture the avg only when all three conditions
-        // hold (matches src/controllers/shottimingcontroller.cpp line 313).
-        // Window-fill check approximated by sample count.
+        // hold. Mirrors the `if (avgDrift < SETTLING_AVG_THRESHOLD &&
+        // !avgBelowStop && !weightAboveAvg)` check in
+        // ShotTimingController::onWeightSample. Window-fill check
+        // approximated by sample count.
         if (r.settlingSamples < SETTLING_WINDOW_SIZE) continue;
         const bool avgBelowStop = (r.stopWeight > 0 && avg < r.stopWeight - 0.5);
         const bool weightAboveAvg = (weight > avg + SETTLING_ABOVE_AVG_MARGIN);

--- a/tools/shot_eval/main.cpp
+++ b/tools/shot_eval/main.cpp
@@ -742,8 +742,16 @@ EvaluatedShot evaluate(const LoadedShot& s)
 //   SETTLING_AVG_THRESHOLD = 0.3 g
 //   SETTLING_ABOVE_AVG_MARGIN = 0.2 g
 //   cup-removal: >20 g single-step drop OR >20 g cumulative drop from peak
+//   SETTLING_CLEAN_CAPTURE_MS = 250 ms (mirrored here as
+//     MIN_CONSECUTIVE_STABLE_FIRES = 3 — sample-count approximation, see
+//     comment at the declaration for the trade-off vs scale-rate variation)
+//   MAX_PLAUSIBLE_POST_STOP_DRIP_G = 5.0 g (implausibility cap)
 // The stable-branch capture mirrors the same condition (drift below
 // threshold, weight close to avg, avg at/above stop weight).
+//
+// IMPORTANT: when production changes any of the above constants or the
+// cup-removed fallback chain (shottimingcontroller.cpp:240+), update this
+// mirror to match — there is no compile-time link enforcing parity.
 // ---------------------------------------------------------------------------
 struct SettlingReport {
     QString path;


### PR DESCRIPTION
## Summary

Fixes [#1280](https://github.com/Kulitorum/Decenza/issues/1280). Mark's TurboTurbo 42 shot 5470 was SAW-stopped on target (cup settled at 42.3 g for ~700 ms) but persisted `finalWeightG=38.5g` because cup-lift spike artifacts polluted `m_weight` before the cup-removed detector fired. The AI advisor then reasoned from `{yield: 38.5, target: 42}` and invented a "you stopped manually" framing, self-contradicting on grind direction (fast time → finer, low flow → coarser).

### Root cause (from the debug log)

```
SAW Stop triggered: weight=41.2, target=42
Settling: 41.5, 41.7, 42.0, 42.2, 42.3×7, 42.4×2, 42.5  ← stable plateau ~700 ms
                                                          (just shy of SETTLING_STABLE_MS=1000 ms)
Then the cup is lifted:
Settling: 44, 48.4, 51   ← ShotDataModel rejects these spikes;
                            ShotTimingController accepts all three → m_weight=51
Settling: 38.5           ← under cup-removal threshold relative to 51; accepted → m_weight=38.5
Settling: -28            ← cup-removed branch finally fires, but m_weight already poisoned
[SAW] Cup removed during settling — skipping learning
Saved shot 5470: finalWeightG=38.5
```

### Fix

1. **`ShotTimingController` tracks the last clean rolling-window avg.** Only updated when the existing stability gate holds (`avgDrift < 0.3`, `weight ≤ avg + 0.2`, `avg ≥ m_weightAtStop − 0.5`). On cup-removed, restore `m_weight` via the fallback chain: clean avg → `m_weightAtStop` floor (drip only adds) → unchanged.
2. **`ShotSummarizer::buildShotBlock` emits `stoppedBy`** on the standalone shot JSON block when the value is in the `{manual, weight, volume}` allowlist — same gating already used by `dialing_blocks.cpp` on dial-in surfaces. Gives the LLM a stop-reason anchor on sub-target shots instead of leaving it free to hallucinate.
3. **`shot_eval --settling`** — new offline mode that parses the embedded `app.data.debug_log` from saved shots and reports pre/post-fix `finalWeight` for each. Useful for scanning a personal shot corpus.

### Validation against shot 5470 via the new tool

```
$ shot_eval --settling shot5470.json
file                               stopW  recorded  preFix  postFix       Δ  cupLift  note
shot5470.json                       41.2      38.5    38.5     42.4     3.9      yes  cup-lifted — recovered last clean avg ***
```

Recovers the actual settled weight (42.4 g) instead of the spike-artifact value (38.5 g).

## Test plan

- [x] New `tst_Settling::cupLiftMidSettlePreservesLastStableAvg_1280` — replays shot 5470's exact sample stream and asserts `currentWeight()` ≈ 42.3 g. Was red before the fix (`got 38.50 g`).
- [x] New `tst_Settling::cupLiftBeforeAnyCleanAvgFloorsAtStopWeight` — exercises the `m_weightAtStop` fallback path when no clean avg is observable.
- [x] Four new `tst_ShotSummarizer` tests covering the `stoppedBy` allowlist (`weight` and `manual` emit; `profileEnd` and empty omit).
- [x] Full `ctest` suite — 51/51 pass, 2250 individual test cases.
- [x] `shot_eval --validate tests/data/shots/manifest.json` — 21/21 detector regressions unchanged (fix is orthogonal to detector logic).
- [ ] On-device manual confirmation: pull a sub-target shot, lift the cup as soon as the stop overlay appears, confirm Shot Detail page yield matches what the scale read at lift.

## OpenSpec

`changes/preserve-settled-weight-on-cup-lift/` — amends `stop-at-weight-learning` (settle → finalWeight contract) and `advisor-user-prompt` (`stoppedBy` on standalone shot block). `openspec validate --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)