### PR TITLE
wifi-scale: validate IP cache + manual entries; surface mDNS in log; fix primary invariant

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -204,9 +204,24 @@ Item {
         width: Math.min((parent ? parent.width : Theme.scaled(420)) * 0.85, Theme.scaled(420))
         padding: 0
 
+        // mDNS lookup state while the dialog is open. Set by the BLEManager
+        // signals below. The hostname is shown as a one-tap shortcut so the
+        // user doesn't have to type it (or guess between "hds.local" and an IP).
+        property bool mdnsSearching: false
+        property string mdnsHostname: ""
+        property string mdnsIp: ""
+        readonly property bool mdnsFound: mdnsHostname.length > 0
+
         onOpened: {
             wifiScaleHostField.text = ""
             wifiScaleHostField.forceActiveFocus()
+            // Reset prior probe state and kick off a fresh mDNS lookup. If the
+            // scale is on the LAN we offer it as a one-tap option above the
+            // text field, sidestepping the typo-and-bad-IP failure mode entirely.
+            mdnsHostname = ""
+            mdnsIp = ""
+            mdnsSearching = true
+            BLEManager.probeMdnsForManualEntry()
         }
 
         function submitWifiScale() {
@@ -273,6 +288,66 @@ Item {
                         wrapMode: Text.Wrap
                     }
 
+                    // mDNS-discovered scale suggestion. Saves the user from
+                    // typing (and from typos that would fail validation) when
+                    // the scale is responding to mDNS on the LAN.
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Theme.scaled(20)
+                        Layout.rightMargin: Theme.scaled(20)
+                        Layout.topMargin: Theme.scaled(12)
+                        Layout.preferredHeight: visible ? mdnsRow.implicitHeight + Theme.scaled(16) : 0
+                        visible: addWifiScaleDialog.mdnsFound
+                        color: Qt.darker(Theme.accentColor, 1.4)
+                        radius: Theme.scaled(6)
+                        border.color: Theme.accentColor
+                        border.width: 1
+
+                        RowLayout {
+                            id: mdnsRow
+                            anchors.fill: parent
+                            anchors.margins: Theme.scaled(8)
+                            spacing: Theme.scaled(8)
+
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: Theme.scaled(2)
+
+                                Text {
+                                    Layout.fillWidth: true
+                                    text: TranslationManager.translate("settings.bluetooth.mdnsFoundTitle",
+                                                                       "Scale found on this network")
+                                    color: Theme.textColor
+                                    font.pixelSize: Theme.scaled(13)
+                                    font.bold: true
+                                    wrapMode: Text.Wrap
+                                }
+                                Text {
+                                    Layout.fillWidth: true
+                                    text: addWifiScaleDialog.mdnsHostname
+                                        + (addWifiScaleDialog.mdnsIp.length > 0
+                                           ? " (" + addWifiScaleDialog.mdnsIp + ")"
+                                           : "")
+                                    color: Theme.textSecondaryColor
+                                    font.pixelSize: Theme.scaled(12)
+                                    wrapMode: Text.Wrap
+                                }
+                            }
+
+                            AccessibleButton {
+                                text: TranslationManager.translate("settings.bluetooth.mdnsFoundUse", "Use")
+                                accessibleName: TranslationManager.translate("settings.bluetooth.mdnsFoundUseAccessible",
+                                                                              "Use the discovered WiFi scale")
+                                primary: true
+                                onClicked: {
+                                    var host = addWifiScaleDialog.mdnsHostname
+                                    addWifiScaleDialog.close()
+                                    BLEManager.connectToWifiScale(host)
+                                }
+                            }
+                        }
+                    }
+
                     // IP / name input
                     StyledTextField {
                         id: wifiScaleHostField
@@ -315,6 +390,94 @@ Item {
                     }
                 }
             }
+        }
+    }
+
+    // Validation-result dialog for the manual "Add WiFi Scale" flow. Shown when
+    // BLEManager fails to verify that the typed address actually hosts an HDS
+    // scale (timeout without HDS recognition, or socket error). Without this
+    // the user would silently end up with a poisoned saved primary that the
+    // app keeps redialing on every reconnect cycle (see #1281).
+    property string lastManualWifiHost: ""
+    Dialog {
+        id: manualWifiFailedDialog
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        modal: true
+        closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
+        width: Math.min((parent ? parent.width : Theme.scaled(420)) * 0.85, Theme.scaled(420))
+        padding: Theme.scaled(20)
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
+            border.color: Theme.primaryContrastColor
+            border.width: 1
+        }
+
+        contentItem: ColumnLayout {
+            spacing: Theme.scaled(12)
+
+            Text {
+                Layout.fillWidth: true
+                text: TranslationManager.translate("settings.bluetooth.manualWifiFailed.title",
+                                                   "No scale found")
+                color: Theme.textColor
+                font.pixelSize: Theme.scaled(16)
+                font.bold: true
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            Text {
+                Layout.fillWidth: true
+                text: TranslationManager.translate("settings.bluetooth.manualWifiFailed.body",
+                                                   "Couldn't verify a Decent WiFi scale at %1. Check the address and that the scale is on the same network, then try again.").arg(connectionsTab.lastManualWifiHost)
+                color: Theme.textColor
+                font.pixelSize: Theme.scaled(14)
+                wrapMode: Text.Wrap
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.scaled(12)
+
+                Item { Layout.fillWidth: true }
+
+                AccessibleButton {
+                    text: TranslationManager.translate("common.button.ok", "OK")
+                    accessibleName: TranslationManager.translate("common.accessibility.dismissDialog", "Dismiss dialog")
+                    primary: true
+                    onClicked: manualWifiFailedDialog.close()
+                }
+            }
+        }
+    }
+
+    Connections {
+        target: BLEManager
+        function onManualWifiValidationFailed(hostnameOrIp) {
+            connectionsTab.lastManualWifiHost = hostnameOrIp
+            // Don't stack on top of the entry dialog if the user reopened it
+            if (addWifiScaleDialog.opened) addWifiScaleDialog.close()
+            manualWifiFailedDialog.open()
+        }
+        function onManualWifiValidationSucceeded(hostnameOrIp) {
+            // No UX needed — the normal scale-connected indicator handles it.
+            // Close any open entry dialog defensively in case the user reopened it.
+            if (addWifiScaleDialog.opened) addWifiScaleDialog.close()
+        }
+        function onManualWifiMdnsDiscovered(hostname, ip) {
+            // Only surface the suggestion if the user still has the dialog open
+            // and hasn't already started typing — otherwise we'd jump under their
+            // fingers. The field is empty on open, so this catches the common
+            // "just opened the dialog and waiting" case.
+            if (!addWifiScaleDialog.opened) return
+            addWifiScaleDialog.mdnsHostname = hostname
+            addWifiScaleDialog.mdnsIp = ip
+            addWifiScaleDialog.mdnsSearching = false
+        }
+        function onManualWifiMdnsProbeFinished() {
+            addWifiScaleDialog.mdnsSearching = false
         }
     }
 

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -288,6 +288,24 @@ Item {
                         wrapMode: Text.Wrap
                     }
 
+                    // "Searching the network..." indicator shown while the
+                    // mDNS probe is in flight and we haven't found anything
+                    // yet. Replaced by the discovered-scale banner below once
+                    // mdnsFound flips true; hidden entirely once the probe
+                    // finishes without a result.
+                    Text {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Theme.scaled(20)
+                        Layout.rightMargin: Theme.scaled(20)
+                        Layout.topMargin: Theme.scaled(12)
+                        visible: addWifiScaleDialog.mdnsSearching && !addWifiScaleDialog.mdnsFound
+                        text: TranslationManager.translate("settings.bluetooth.mdnsSearching",
+                                                           "Searching the network for a scale...")
+                        color: Theme.textSecondaryColor
+                        font.pixelSize: Theme.scaled(12)
+                        font.italic: true
+                    }
+
                     // mDNS-discovered scale suggestion. Saves the user from
                     // typing (and from typos that would fail validation) when
                     // the scale is responding to mDNS on the LAN.
@@ -467,11 +485,16 @@ Item {
             if (addWifiScaleDialog.opened) addWifiScaleDialog.close()
         }
         function onManualWifiMdnsDiscovered(hostname, ip) {
-            // Only surface the suggestion if the user still has the dialog open
-            // and hasn't already started typing — otherwise we'd jump under their
-            // fingers. The field is empty on open, so this catches the common
-            // "just opened the dialog and waiting" case.
+            // Only surface the suggestion if the user still has the dialog
+            // open AND hasn't started typing — otherwise the banner would
+            // pop in under their fingers, distracting from the address they
+            // were entering. (The field is empty on open, so the common
+            // "opened-and-waiting" case still gets the banner.)
             if (!addWifiScaleDialog.opened) return
+            if (wifiScaleHostField.text.length > 0) {
+                addWifiScaleDialog.mdnsSearching = false
+                return
+            }
             addWifiScaleDialog.mdnsHostname = hostname
             addWifiScaleDialog.mdnsIp = ip
             addWifiScaleDialog.mdnsSearching = false

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -515,10 +515,11 @@ void BLEManager::probeMdnsForManualEntry() {
     // Dedicated mDNS probe for the "Add WiFi Scale" dialog. We keep this
     // separate from m_wifiDiscovery (used by the user-initiated scan / saved-
     // scale rehydration path), because m_wifiDiscovery's scaleFound handler
-    // auto-connects when the discovered hostname matches the saved primary —
-    // we explicitly do NOT want that side effect here. The manual flow's
-    // contract is "tell the user we found a scale and let them choose";
-    // connect happens only when they tap Use.
+    // auto-connects when the discovered hostname matches the saved primary
+    // (and no user-initiated scan is in progress) — we explicitly do NOT
+    // want that side effect here. The manual flow's contract is "tell the
+    // user we found a scale and let them choose"; connect happens only when
+    // they tap Use.
     if (!m_manualEntryDiscovery) {
         m_manualEntryDiscovery = new WifiScaleDiscovery(this);
         // Forward the dedicated probe's diagnostics into the scale debug log too —
@@ -1810,6 +1811,13 @@ void BLEManager::appendScaleLog(const QString& message) {
     QString timestampedMsg = QDateTime::currentDateTime().toString("[hh:mm:ss.zzz] ") + message;
     m_scaleLogMessages.append(timestampedMsg);
     emit scaleLogMessage(message);
+    // Mirror to the system log so the scale narrative is interleaved with
+    // qDebug output from the rest of the app — without this, the scale
+    // debug log lives only in m_scaleLogMessages (rendered into the user-
+    // shareable scale_debug_log.txt) and is invisible during local
+    // development unless the developer is staring at the in-app log view.
+    // Use a stable [Scale] prefix so the line is grep-friendly in stderr.
+    qDebug().noquote() << "[Scale]" << message;
 
     // Keep log size reasonable (last 1000 messages)
     while (m_scaleLogMessages.size() > 1000) {

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -21,7 +21,6 @@
 #include <QTextStream>
 #include <algorithm>
 #include <QDateTime>
-#include <QTcpSocket>
 #include <QWebSocket>
 #include <QJsonDocument>
 #include <QJsonObject>

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -22,6 +22,10 @@
 #include <algorithm>
 #include <QDateTime>
 #include <QTcpSocket>
+#include <QWebSocket>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QUrl>
 
 #ifdef Q_OS_ANDROID
 #include <QJniEnvironment>
@@ -506,6 +510,47 @@ void BLEManager::setUsbScaleAvailable(bool available, const QString& name) {
         appendScaleLog(QStringLiteral("USB scale unplugged"));
         emit scalesChanged();
     }
+}
+
+void BLEManager::probeMdnsForManualEntry() {
+    // Dedicated mDNS probe for the "Add WiFi Scale" dialog. We keep this
+    // separate from m_wifiDiscovery (used by the user-initiated scan / saved-
+    // scale rehydration path), because m_wifiDiscovery's scaleFound handler
+    // auto-connects when the discovered hostname matches the saved primary —
+    // we explicitly do NOT want that side effect here. The manual flow's
+    // contract is "tell the user we found a scale and let them choose";
+    // connect happens only when they tap Use.
+    if (!m_manualEntryDiscovery) {
+        m_manualEntryDiscovery = new WifiScaleDiscovery(this);
+        // Forward the dedicated probe's diagnostics into the scale debug log too —
+        // a user reporting "I clicked Add WiFi Scale but nothing showed up" will
+        // have the mDNS-side reason (timeout vs no-responder vs lookup failure)
+        // captured in the log they share.
+        connect(m_manualEntryDiscovery, &WifiScaleDiscovery::logMessage, this,
+                [this](const QString& msg) {
+            appendScaleLog(QString("[WifiScaleDiscovery/manual] %1").arg(msg));
+        });
+        connect(m_manualEntryDiscovery, &WifiScaleDiscovery::scaleFound, this,
+                [this](const QString& hostname, const QString& resolvedAddress) {
+            // (Result line — the WifiScaleDiscovery logMessage above already
+            // logged the "mDNS resolved …" detail; this is the higher-level
+            // event for the user reading the log top-to-bottom.)
+            appendScaleLog(QString("Manual-entry mDNS found %1 at %2").arg(hostname, resolvedAddress));
+            m_manualEntryFoundThisProbe = true;
+            emit manualWifiMdnsDiscovered(hostname, resolvedAddress);
+        });
+        connect(m_manualEntryDiscovery, &WifiScaleDiscovery::probeFinished, this,
+                [this]() {
+            if (!m_manualEntryFoundThisProbe) {
+                appendScaleLog(QStringLiteral(
+                    "Manual-entry mDNS: no HDS scale responded — user can still type an address"));
+            }
+            emit manualWifiMdnsProbeFinished();
+        });
+    }
+    m_manualEntryFoundThisProbe = false;
+    appendScaleLog(QStringLiteral("Probing mDNS for hds.local (manual entry)..."));
+    m_manualEntryDiscovery->probe();
 }
 
 void BLEManager::connectToWifiScale(const QString& hostnameOrIp) {
@@ -1085,9 +1130,24 @@ void BLEManager::onScaleConnectionTimeout() {
     // Consume the manual-add marker: a manually-typed WiFi address reports
     // "Not found" directly (below) rather than silently switching to a BLE scan.
     const bool manualWifiAttempt = m_manualWifiConnect;
+    const QString manualHost = m_pendingWifiHostname;
     m_manualWifiConnect = false;
 
     qWarning() << "BLEManager: Scale connection timeout - not found";
+
+    // Manual "Add WiFi Scale" entry that didn't validate (no HDS frame within
+    // the connection-timer window): surface a clear, user-visible error and
+    // return BEFORE the FlowScale-fallback path. The typed address was NOT
+    // persisted as the saved primary (main.cpp's scaleDiscovered handler
+    // defers persistence for manual entries until DecentScaleWifi recognizes
+    // the endpoint as HDS — see #1281), so nothing here needs to undo state.
+    // The user can try again with a different address.
+    if (manualWifiAttempt) {
+        appendScaleLog(QString("Manual WiFi scale validation failed for %1").arg(manualHost));
+        emit manualWifiValidationFailed(manualHost);
+        emit disconnectScaleRequested();   // tear down the half-open WiFi driver
+        return;
+    }
 
     // WiFi-saved scale that didn't connect → fall back to a BLE scan for the
     // same physical scale family. Don't go straight to FlowScale yet — we owe
@@ -1152,14 +1212,21 @@ void BLEManager::beginWifiFallbackToBleScan() {
 }
 
 void BLEManager::probeWifiPrimaryReachable(const QString& ip) {
-    // Lightweight, NON-disruptive liveness check: a plain TCP connect to the
-    // WiFi scale's cached IP on the HDS web/WS port. It deliberately does NOT
-    // touch the live (BLE backup) scale, so a negative result costs the user
-    // nothing. This is the gate before switchToWifiPrimary(): only drop a working
-    // backup once we know the primary actually answers. (mDNS is the unreliable
-    // path under BLE-coex load, so we dial the cached IP directly.)
-    constexpr int kProbePort = 80;          // HDS serves its web page + WS here
-    constexpr int kProbeTimeoutMs = 3000;
+    // NON-disruptive HDS identity check: open ws://<ip>/snapshot and require a
+    // valid HDS frame (snapshot or status — both per the openscale WS protocol)
+    // within the timeout. Does NOT touch the live (BLE backup) scale, so a
+    // negative result costs nothing. This is the gate before switchToWifiPrimary():
+    // only drop a working backup once we've VERIFIED the primary IP actually
+    // hosts an HDS scale.
+    //
+    // Earlier this was a bare TCP connect to port 80. That was too permissive:
+    // a home router (or anything on the LAN listening on 80) would accept the
+    // SYN and the probe would falsely report "reachable", which then tore down
+    // the working BLE link to chase a phantom WiFi scale. Real-world symptom:
+    // user manually typed 192.168.1.1 (their gateway) as the scale address; the
+    // app cycled BLE↔WiFi every ~30 s with the gateway answering the probe and
+    // returning HTTP 403 to the WS upgrade. (See #1281.)
+    constexpr int kProbeTimeoutMs = 3500;
 
     cancelWifiProbe();  // at most one probe in flight
 
@@ -1168,18 +1235,18 @@ void BLEManager::probeWifiPrimaryReachable(const QString& ip) {
         return;
     }
 
-    m_wifiProbeSocket = new QTcpSocket(this);
+    m_wifiProbeWebSocket = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
     m_wifiProbeTimer = new QTimer(this);
     m_wifiProbeTimer->setSingleShot(true);
 
-    // Resolve the probe exactly once: the first of connect / error / timeout
-    // wins. Members are nulled up front so any later signal (e.g. an error
-    // delivered during abort()) short-circuits instead of emitting twice.
+    // Resolve the probe exactly once: the first of valid-frame / error / timeout
+    // wins. Members are nulled up front so any later signal short-circuits
+    // instead of emitting twice.
     auto finish = [this](bool reachable) {
-        if (!m_wifiProbeSocket) return;  // already resolved
-        QTcpSocket* sock = m_wifiProbeSocket;
+        if (!m_wifiProbeWebSocket) return;  // already resolved
+        QWebSocket* sock = m_wifiProbeWebSocket;
         QTimer* timer = m_wifiProbeTimer;
-        m_wifiProbeSocket = nullptr;
+        m_wifiProbeWebSocket = nullptr;
         m_wifiProbeTimer = nullptr;
         timer->stop();
         timer->deleteLater();
@@ -1189,16 +1256,33 @@ void BLEManager::probeWifiPrimaryReachable(const QString& ip) {
         emit wifiPrimaryReachable(reachable);
     };
 
-    connect(m_wifiProbeSocket, &QAbstractSocket::connected, this,
-            [finish]() { finish(true); });
-    connect(m_wifiProbeSocket, &QAbstractSocket::errorOccurred, this,
-            [finish](QAbstractSocket::SocketError) { finish(false); });
+    connect(m_wifiProbeWebSocket, &QWebSocket::textMessageReceived, this,
+            [finish](const QString& message) {
+        // Validate the frame is HDS-shaped — same recognition contract as
+        // DecentScaleWifi::onRecognizedAsHds. A snapshot frame has no "type"
+        // and carries a "grams" number; a status frame has type=="status".
+        // Anything else (or non-JSON) means "WS connected to a non-HDS
+        // endpoint" — fail the probe.
+        const QJsonDocument doc = QJsonDocument::fromJson(message.toUtf8());
+        if (!doc.isObject()) { finish(false); return; }
+        const QJsonObject obj = doc.object();
+        const QString type = obj.value(QStringLiteral("type")).toString();
+        const bool isSnapshot = type.isEmpty()
+            && obj.value(QStringLiteral("grams")).isDouble();
+        const bool isStatus = (type == QStringLiteral("status"));
+        finish(isSnapshot || isStatus);
+    });
+    connect(m_wifiProbeWebSocket, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::errorOccurred),
+            this, [finish](QAbstractSocket::SocketError) { finish(false); });
+    connect(m_wifiProbeWebSocket, &QWebSocket::disconnected, this,
+            [finish]() { finish(false); });
     connect(m_wifiProbeTimer, &QTimer::timeout, this, [finish]() { finish(false); });
 
-    appendScaleLog(QString("Probing WiFi primary at %1:%2 (%3 ms)")
-                       .arg(ip).arg(kProbePort).arg(kProbeTimeoutMs));
+    const QUrl url(QStringLiteral("ws://%1/snapshot").arg(ip));
+    appendScaleLog(QString("Probing WiFi primary at %1 (%2 ms, HDS verify)")
+                       .arg(ip).arg(kProbeTimeoutMs));
     m_wifiProbeTimer->start(kProbeTimeoutMs);
-    m_wifiProbeSocket->connectToHost(ip, static_cast<quint16>(kProbePort));
+    m_wifiProbeWebSocket->open(url);
 }
 
 void BLEManager::cancelWifiProbe() {
@@ -1207,11 +1291,11 @@ void BLEManager::cancelWifiProbe() {
         m_wifiProbeTimer->deleteLater();
         m_wifiProbeTimer = nullptr;
     }
-    if (m_wifiProbeSocket) {
-        m_wifiProbeSocket->disconnect();
-        m_wifiProbeSocket->abort();
-        m_wifiProbeSocket->deleteLater();
-        m_wifiProbeSocket = nullptr;
+    if (m_wifiProbeWebSocket) {
+        m_wifiProbeWebSocket->disconnect();
+        m_wifiProbeWebSocket->abort();
+        m_wifiProbeWebSocket->deleteLater();
+        m_wifiProbeWebSocket = nullptr;
     }
 }
 
@@ -1473,6 +1557,14 @@ void BLEManager::scanForDevices() {
 void BLEManager::ensureWifiDiscovery() {
     if (m_wifiDiscovery) return;
     m_wifiDiscovery = new WifiScaleDiscovery(this);
+    // Forward mDNS-layer diagnostics into the user-shareable scale debug log.
+    // Without this, "mDNS lookup timed out" / "no responder" lines lived only
+    // in qDebug output (Qt Creator console / adb logcat), invisible in the log
+    // a user uploads with a bug report.
+    connect(m_wifiDiscovery, &WifiScaleDiscovery::logMessage, this,
+            [this](const QString& msg) {
+        appendScaleLog(QString("[WifiScaleDiscovery] %1").arg(msg));
+    });
     // Single unified handler that handles both code paths (user-initiated
     // scan AND saved-scale direct-wake). Before this consolidation, each
     // call site lazy-created the discovery object with a DIFFERENT lambda

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -21,7 +21,6 @@ class DiFluidR2;
 class SettingsHardware;
 class WifiScaleDiscovery;
 class TranslationManager;
-class QTcpSocket;
 class QWebSocket;
 #if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
 class AppleBtState;

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -22,6 +22,7 @@ class SettingsHardware;
 class WifiScaleDiscovery;
 class TranslationManager;
 class QTcpSocket;
+class QWebSocket;
 #if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
 class AppleBtState;
 #endif
@@ -343,6 +344,18 @@ public:
     // connect, main.cpp records it in Known Devices + as primary when the connect
     // is initiated, not on success.
     Q_INVOKABLE void connectToWifiScale(const QString& hostnameOrIp);
+    // Fire an mDNS probe for the HDS in parallel with the "Add WiFi Scale"
+    // dialog. If the scale is on the LAN, this surfaces it to the user so
+    // they don't have to type its address. Emits manualWifiMdnsDiscovered on
+    // success and (regardless) manualWifiMdnsProbeFinished when done. Safe to
+    // call multiple times; a new probe supersedes any in-flight one.
+    Q_INVOKABLE void probeMdnsForManualEntry();
+    // True while a manual "Add WiFi Scale" attempt is in flight (set by
+    // connectToWifiScale, cleared on connect success or timeout). main.cpp
+    // reads this in the scaleDiscovered handler to defer persisting the typed
+    // address as the saved primary until DecentScaleWifi confirms it's a
+    // real scale (see #1281).
+    bool isManualWifiConnect() const { return m_manualWifiConnect; }
     // Switch the LIVE connection to the current saved primary scale (set via
     // setSavedScaleAddress just before calling). If a scale is connected it is
     // disconnected first, then the saved primary is direct-woken (BLE) /
@@ -443,6 +456,24 @@ signals:
     // timeout and BLEManager has started a BLE scan as a fallback. UI binds
     // this to a toast/banner so the user knows what's happening.
     void wifiUnreachableFallingBackToBle(const QString& hostname);
+    // Emitted when a manual "Add WiFi Scale" connect attempt fails to verify
+    // (timeout without HDS recognition, or socket error before any frame).
+    // The QML layer binds this to a user-visible dialog so a typo / wrong IP
+    // doesn't silently strand the user on a phantom WiFi scale. The address
+    // is NOT persisted as the saved primary in this case (see main.cpp's
+    // scaleDiscovered handler — manual entries defer persistence until the
+    // scale is recognized as HDS).
+    void manualWifiValidationFailed(const QString& hostnameOrIp);
+    // Emitted when a manual "Add WiFi Scale" connect attempt succeeds (the
+    // WS endpoint validated as HDS). main.cpp uses this to commit the deferred
+    // persistence (addKnownScale + setPrimaryScale + setSavedScaleAddress).
+    void manualWifiValidationSucceeded(const QString& hostnameOrIp);
+    // Result of probeMdnsForManualEntry: emitted at most once per probe with
+    // the discovered hostname + IP if an HDS replied to the mDNS query.
+    void manualWifiMdnsDiscovered(const QString& hostname, const QString& ip);
+    // Always fired when probeMdnsForManualEntry finishes (whether or not the
+    // scale was found). QML uses this to drop a "Searching..." indicator.
+    void manualWifiMdnsProbeFinished();
     // Result of a probeWifiPrimaryReachable() call (emitted at most once per
     // probe — zero times if a later probeWifiPrimaryReachable() supersedes it
     // via cancelWifiProbe()). main.cpp switches to the WiFi primary when reachable.
@@ -499,10 +530,22 @@ private:
     QList<QBluetoothDeviceInfo> m_de1Devices;
     QList<ScaleEntry> m_scales;
     WifiScaleDiscovery* m_wifiDiscovery = nullptr;  // Lazy-created on first scanForDevices
-    // Non-disruptive WiFi-primary reachability probe: a per-probe TCP socket +
+    // Dedicated probe instance for the manual "Add WiFi Scale" flow. Keeps the
+    // UX-only mDNS probe separate from m_wifiDiscovery (which carries an
+    // auto-connect-to-saved-primary handler). Lazy-created on first call.
+    WifiScaleDiscovery* m_manualEntryDiscovery = nullptr;
+    // Set true when the current manual-entry probe fires scaleFound; consumed
+    // by probeFinished to decide whether to log "no responder" — the probe
+    // doesn't carry a "found anything" return code, so we have to track it
+    // out of band.
+    bool m_manualEntryFoundThisProbe = false;
+    // Non-disruptive WiFi-primary HDS identity probe: a per-probe WebSocket +
     // timeout timer (both owned, recreated each probe and torn down on the first
-    // of connect/error/timeout so exactly one wifiPrimaryReachable() is emitted).
-    QTcpSocket* m_wifiProbeSocket = nullptr;
+    // of valid-frame / error / timeout so exactly one wifiPrimaryReachable() is
+    // emitted). The probe opens ws://<ip>/snapshot and requires an HDS-shaped
+    // frame within the timeout — a bare TCP connect on port 80 was too permissive
+    // (any LAN device listening on 80 passed it; see probe impl for the bug).
+    QWebSocket* m_wifiProbeWebSocket = nullptr;
     QTimer* m_wifiProbeTimer = nullptr;
     TranslationManager* m_translationManager = nullptr;  // For i18n of user-visible error strings
     // Helper: translate `key` with `fallback`, or just return `fallback` if no

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -105,11 +105,14 @@ public:
 
     // Proactive WiFi-primary switch-back (driven by main.cpp's idle poll when
     // we're on the BLE backup but the saved primary is a WiFi scale):
-    //  - probeWifiPrimaryReachable() does a NON-disruptive TCP liveness check of
-    //    the WiFi scale's cached IP:80 (the HDS web/WS port). It never touches the
-    //    live BLE link, so a failed probe leaves the working backup untouched.
-    //    Reports the outcome via wifiPrimaryReachable() at most once per probe (a
-    //    probe superseded by a later call is cancelled without emitting).
+    //  - probeWifiPrimaryReachable() does a NON-disruptive HDS identity check:
+    //    opens ws://<ip>/snapshot and requires a valid HDS frame (snapshot or
+    //    status) within ~3.5 s. It never touches the live BLE link, so a failed
+    //    probe leaves the working backup untouched. Reports the outcome via
+    //    wifiPrimaryReachable() at most once per probe (a probe superseded by a
+    //    later call is cancelled without emitting). A bare TCP-open on port 80
+    //    is NOT enough — any LAN device listening on 80 (router, printer, NAS)
+    //    would pass that gate; #1281 needed the actual HDS-frame validation.
     //  - switchToWifiPrimary() drops the current backup scale and connects the
     //    saved WiFi primary via the cached-IP fast path. Call only after a
     //    reachable probe (and a re-check that we're still idle on the backup).
@@ -336,12 +339,20 @@ public:
     // WiFi Scale" dialog), without requiring it to be in the discovered list. A
     // bare name with no dot gets ".local" appended (matching the discovery
     // default "hds.local"); IPs and dotted names pass through. Arms the connection
-    // timer so a wrong/unreachable host fails visibly ("Not found" + FlowScale
-    // notice) instead of silently — WiFi socket errors are otherwise log-only
-    // (#1253). Unlike a saved WiFi scale this does NOT fall back to a BLE scan on
-    // failure (the user asked for a specific WiFi address). As with any scale
-    // connect, main.cpp records it in Known Devices + as primary when the connect
-    // is initiated, not on success.
+    // timer so a wrong/unreachable host surfaces as `manualWifiValidationFailed`
+    // (driving the QML "Couldn't verify a scale at <address>" dialog) instead
+    // of silently — WiFi socket errors are otherwise log-only (#1253). Unlike a
+    // saved WiFi scale this does NOT fall back to a BLE scan on failure (the
+    // user asked for a specific WiFi address).
+    //
+    // Unlike BLE or saved-scale WiFi connects, persistence is DEFERRED for
+    // manual entries: main.cpp's scaleDiscovered handler does NOT call
+    // addKnownScale / setPrimaryScale / setSavedScaleAddress at connect
+    // initiation. Instead, those run only after `DecentScaleWifi::recognizedAsHds`
+    // fires (validating that the typed endpoint is really an HDS scale). If
+    // recognition never arrives, `manualWifiValidationFailed` is emitted and
+    // the address is NOT saved as the primary — a typo or wrong IP can't
+    // poison the saved state. (#1281)
     Q_INVOKABLE void connectToWifiScale(const QString& hostnameOrIp);
     // Fire an mDNS probe for the HDS in parallel with the "Add WiFi Scale"
     // dialog. If the scale is on the LAN, this surfaces it to the user so

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -185,6 +185,7 @@ void DecentScaleWifi::attemptHostname() {
     if (m_hostname.endsWith(QStringLiteral(".local"), Qt::CaseInsensitive)) {
         const QString host = m_hostname;
         const int generation = ++m_resolveGeneration;
+        WIFI_LOG(QString("Resolving %1 via mDNS (Android)...").arg(host));
         QPointer<DecentScaleWifi> guard(this);
         QThread* thread = QThread::create([this, guard, host, generation]() {
             const QString ip = MdnsResolver::resolveHostname(host);
@@ -499,17 +500,20 @@ void DecentScaleWifi::onRecognizedAsHds() {
             m_ipCacheUpdate(m_hostname, peerIp);
         }
     }
+
+    emit recognizedAsHds();
 }
 
 void DecentScaleWifi::onRecognitionTimeout() {
     WIFI_WARN(QString("No recognizable HDS frame within %1 ms from %2")
               .arg(kRecognitionTimeoutMs).arg(m_currentTarget));
 
-    // Cached-IP attempt failed validation → fall back to the hostname.
-    // (If we were already on the hostname, we've exhausted options.)
+    // Cached-IP attempt failed validation → evict the bad IP and fall back to
+    // the hostname. (If we were already on the hostname, we've exhausted options.)
     if (!m_currentTargetIsHostname && !m_triedHostnameFallback) {
-        WIFI_LOG(QString("Cached IP %1 didn't validate as HDS — falling back to hostname %2")
+        WIFI_LOG(QString("Cached IP %1 didn't validate as HDS — evicting cache and falling back to hostname %2")
                  .arg(m_currentTarget, m_hostname));
+        if (m_ipCacheUpdate) m_ipCacheUpdate(m_hostname, QString());
         // Hand the fallback off to onDisconnected via an event-driven flag:
         // when the socket-close completes, onDisconnected sees the flag and
         // runs attemptTarget(hostname) inline. No timer-as-guard.
@@ -705,46 +709,33 @@ void DecentScaleWifi::onError() {
         m_lastSocketErrorString = errStr;
     }
 
-    // Classify common socket-level failures. These are all TRANSIENT connect
-    // failures (scale unreachable / refusing / still booting after a power-cycle):
-    // we log them via WIFI_WARN above but do NOT pop a modal. The connect isn't
-    // abandoned — BLEManager's per-connect connection timer (onScaleConnectionTimeout)
-    // is the backstop: it retries, recovers a still-booting scale, and for a
-    // genuinely-gone scale emits the FlowScale-fallback notice that informs the
-    // user. The 503 case handled above takes the same route — drop the link,
-    // let the reconnect ladder retry, fall back to the standard notice if the
-    // cap stays saturated. No socket-error path in this function surfaces a
-    // modal of its own.
-    bool fastFailError = false;
-    switch (err) {
-    case QAbstractSocket::HostNotFoundError:
-    case QAbstractSocket::ConnectionRefusedError:
-    case QAbstractSocket::NetworkError:
-    case QAbstractSocket::SocketTimeoutError:
-        m_userInitiatedShutdown = true;
-        fastFailError = true;
-        break;
-    default:
-        // Other errors fall through — the recognition timeout will catch the
-        // case where the WS upgrade hangs without a clean socket error.
-        break;
-    }
-
-    // Fast-fail: if a cached-IP attempt fires a fatal transient socket error,
-    // don't sit on the 5 s recognition timer waiting to time out — start the
-    // hostname fallback immediately. The kernel just told us the cached IP
-    // is dead; there's nothing to gain from waiting longer. Real symptom this
-    // addresses: on macOS cold start the network stack may still be warming
-    // up, the cached scale IP isn't routable yet, and the 5 s wait was long
-    // enough for the BLE-scale fallback machinery to also trigger and fail
-    // (CoreBluetooth not powered on), pushing the FlowScale-fallback dialog
-    // at the user before the WiFi scale could simply be retried via hostname.
-    if (fastFailError &&
-        !m_currentTargetIsHostname &&
-        !m_triedHostnameFallback &&
-        !m_pendingHostnameFallback) {
-        WIFI_LOG(QString("Cached IP %1 unreachable (%2) — fast-failing to hostname %3 fallback")
+    // Cached-IP attempt failed under us: ANY error (handshake refused like 403,
+    // socket-level HostNotFound/Refused/Network/Timeout, anything else) means
+    // this IP isn't a working HDS endpoint. Evict the cached IP so we don't
+    // dial it again on the next connect cycle (or on the next proactive
+    // switch-back probe), and fall through to a fresh hostname/mDNS lookup.
+    //
+    // Why catch every error class, not just the original "fast-fail" four: a
+    // poisoned cached IP (manually-typed wrong address, DHCP-reassigned to a
+    // router/printer/NAS) commonly produces handshake-layer errors instead of
+    // socket-layer ones — e.g. the home router answers ws://192.168.1.1/snapshot
+    // with HTTP 403, which surfaces here as WebSocketProtocolError /
+    // UnknownSocketError, NOT in {HostNotFound, ConnectionRefused, NetworkError,
+    // SocketTimeoutError}. Without this, the cached-IP attempt would dead-end:
+    // onDisconnected stops the recognition timer, so the only other path that
+    // would have triggered hostname fallback (onRecognitionTimeout) never fires.
+    //
+    // 503 is the one error we DO NOT route here: it's the openscale "client cap
+    // saturated" refusal — the scale is real and the cache is good; the link
+    // is briefly busy. That case is handled above with an early return.
+    const bool cachedIpAttempt = !m_currentTargetIsHostname
+                              && !m_triedHostnameFallback
+                              && !m_pendingHostnameFallback;
+    if (cachedIpAttempt) {
+        WIFI_LOG(QString("Cached IP %1 unreachable (%2) — evicting cache and falling back to hostname %3")
                  .arg(m_currentTarget, errStr, m_hostname));
+        if (m_ipCacheUpdate) m_ipCacheUpdate(m_hostname, QString());
+        m_userInitiatedShutdown = true;
         m_recognitionTimer->stop();
 
         if (m_socket && m_socket->state() != QAbstractSocket::UnconnectedState) {

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -530,9 +530,20 @@ void DecentScaleWifi::onRecognitionTimeout() {
 
     // Hostname attempt also failed recognition — give up THIS attempt. Transient
     // connect failure: log it but don't pop a modal. BLEManager's connection timer
-    // (onScaleConnectionTimeout) is the backstop — it retries, and a genuinely-gone
-    // scale is surfaced by the FlowScale-fallback notice. #1253
+    // (onScaleConnectionTimeout) is the backstop for the saved-scale reconnect
+    // case — it retries, and a genuinely-gone scale is surfaced by the
+    // FlowScale-fallback notice. #1253
+    //
+    // For the MANUAL "Add WiFi Scale" path, the outer connection timer has
+    // already been stopped (onScaleConnectedChanged stops it when setConnected(true)
+    // fires from WS-connect, which happens before recognition), so its
+    // manualWifiValidationFailed emission won't fire. Emit recognitionFailed so
+    // main.cpp's deferred-persistence handler can route the failure to the
+    // user-visible dialog. The signal is only meaningful in the give-up branch
+    // — the cached-IP fallback branch above starts a new attempt, so recognition
+    // could still succeed there. (#1281)
     WIFI_WARN(QStringLiteral("WiFi scale did not respond as HDS — giving up this attempt"));
+    emit recognitionFailed();
     m_userInitiatedShutdown = true;  // mark expected; reconnect owned by main.cpp
     m_socket->abort();  // Same rationale as the fallback path above.
 }

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -738,7 +738,8 @@ void DecentScaleWifi::onError() {
     //
     // 503 is the one error we DO NOT route here: it's the openscale "client cap
     // saturated" refusal — the scale is real and the cache is good; the link
-    // is briefly busy. That case is handled above with an early return.
+    // is briefly busy. That case is handled by the 503 early-return at the
+    // top of this function (the first thing onError checks).
     const bool cachedIpAttempt = !m_currentTargetIsHostname
                               && !m_triedHostnameFallback
                               && !m_pendingHostnameFallback;

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -543,9 +543,18 @@ void DecentScaleWifi::onRecognitionTimeout() {
     // — the cached-IP fallback branch above starts a new attempt, so recognition
     // could still succeed there. (#1281)
     WIFI_WARN(QStringLiteral("WiFi scale did not respond as HDS — giving up this attempt"));
-    emit recognitionFailed();
+    // ORDER MATTERS: write internal state and abort the socket BEFORE emitting
+    // recognitionFailed. The signal's only slot (in main.cpp's deferred-
+    // persistence wiring) emits disconnectScaleRequested synchronously, whose
+    // handler calls physicalScale.reset() — destroying THIS object while we're
+    // still on the call stack of onRecognitionTimeout. Any access to `this`
+    // (m_userInitiatedShutdown, m_socket) after the emit would be a use-after-
+    // free. By writing before the emit, we ensure those mutations complete
+    // while `this` is still alive; the implicit function return after the
+    // emit doesn't touch `this`, so it's safe to be destroyed during the emit.
     m_userInitiatedShutdown = true;  // mark expected; reconnect owned by main.cpp
     m_socket->abort();  // Same rationale as the fallback path above.
+    emit recognitionFailed();  // MUST be last — slot may destroy `this`.
 }
 
 int DecentScaleWifi::encodeButton(int buttonNumber, int pressCode) {

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -179,14 +179,16 @@ private:
     QString m_lastPowerEventReason;
     int m_lastPowerEventCode = -1;
     // Set on intentional shutdown paths so onDisconnected logs the close as
-    // expected and skips noisy follow-up handling. Six sites set this to
+    // expected and skips noisy follow-up handling. Seven sites set this to
     // true: disconnectFromScale (user close), handlePowerFrame (scale told
     // us it's powering down), attemptHostname (Android mDNS resolution found
     // no responder), onRecognitionTimeout fallback branch (cached IP didn't
     // validate → switching to hostname), onRecognitionTimeout give-up branch
-    // (hostname also failed), and onError (503 server-busy and the mapped
-    // socket-error paths). Reconnect itself is owned by main.cpp's
-    // scaleReconnectTimer — this flag does not gate reconnect.
+    // (hostname also failed), onError 503 early-return (server-busy), and
+    // onError cached-IP-eviction branch (any non-503 error on a cached-IP
+    // attempt → evict the cached IP and fall back to hostname; see #1281).
+    // Reconnect itself is owned by main.cpp's scaleReconnectTimer — this flag
+    // does not gate reconnect.
     bool m_userInitiatedShutdown = false;
     // Whether a GENUINE transport error (errorOccurred not caused by our own
     // abort()/close()) fired during this connection. onDisconnected uses it to

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -59,6 +59,14 @@ public:
     void setIpResolver(IpResolver resolver) { m_ipResolver = std::move(resolver); }
     void setIpCacheUpdate(IpCacheUpdate cb) { m_ipCacheUpdate = std::move(cb); }
 
+signals:
+    // Emitted on the first valid HDS frame (snapshot or status) after a
+    // connect attempt — confirms the WS endpoint is actually an HDS scale,
+    // not just any device that accepted the WS upgrade. Used by the manual
+    // "Add WiFi Scale" flow to defer persisting the typed address as the
+    // saved primary until we've verified it's a real scale (see #1281).
+    void recognizedAsHds();
+
 public slots:
     void tare() override;
     void startTimer() override;

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -66,6 +66,18 @@ signals:
     // "Add WiFi Scale" flow to defer persisting the typed address as the
     // saved primary until we've verified it's a real scale (see #1281).
     void recognizedAsHds();
+    // Emitted from onRecognitionTimeout's "give up THIS attempt" branch —
+    // the WS handshake completed (so onConnected fired and setConnected(true)
+    // was signaled) but no HDS frame arrived within kRecognitionTimeoutMs and
+    // there's no further fallback to try. Mutually exclusive with
+    // recognizedAsHds for a given attempt (the recognition timer is stopped by
+    // onRecognizedAsHds, and the cached-IP fallback branch of
+    // onRecognitionTimeout doesn't emit this — only the terminal give-up
+    // branch does). main.cpp wires this for manual "Add WiFi Scale" entries
+    // because BLEManager's outer 20 s connection timer is stopped at
+    // WS-connect time, so without this signal a manual attempt that connects
+    // to a non-HDS WS endpoint dead-ends silently (#1281 follow-up).
+    void recognitionFailed();
 
 public slots:
     void tare() override;

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -28,6 +28,8 @@
 #include <QStyleHints>
 #include <QDesktopServices>
 #include <QSet>
+#include <QMap>
+#include <QPair>
 
 #ifdef Q_OS_IOS
 #include "screensaver/iosbrightness.h"
@@ -249,22 +251,37 @@ Settings::Settings(QObject* parent)
     }
 
     // Invariant: if knownScales is non-empty, primaryAddress must match one
-    // of its entries. An orphan (stored entry with no matching primary) is
-    // invisible in the Known Devices picker AND filtered out of discovery,
-    // so the user can't reach it. Heal on launch.
+    // of its entries, AND the legacy scale/* keys (read by older code paths
+    // and by main.cpp's initial setSavedScaleAddress wiring) must match the
+    // primary. An orphan (stored entry with no matching primary) is invisible
+    // in the Known Devices picker AND filtered out of discovery, so the user
+    // can't reach it. A divergence in the other direction (valid primary but
+    // empty/stale scale/address) is what caused the user-visible bug in #1281
+    // follow-up: QML's startup hook reads primaryScaleAddress and fires
+    // tryDirectConnectToScale, but BLEManager's m_savedScaleAddress is loaded
+    // from scale/address — if the two drifted, the direct-connect dead-ends
+    // with "no saved scale address/type" and the user has to manually re-select
+    // a scale even though Known Devices had multiple entries. Heal both
+    // directions on launch.
     {
         const qsizetype scalesCount = m_settings.beginReadArray("knownScales/scales");
         QString promoteAddress, promoteType, promoteName;
         QSet<QString> addresses;
+        // Indexed by lowercase address → (type, name) so we can look up the
+        // canonical entry for whatever address ends up being primary.
+        QMap<QString, QPair<QString, QString>> entriesByAddress;
         for (qsizetype i = 0; i < scalesCount; ++i) {
             m_settings.setArrayIndex(static_cast<int>(i));
             const QString a = m_settings.value("address").toString();
             if (a.isEmpty()) continue;
+            const QString t = m_settings.value("type").toString();
+            const QString n = m_settings.value("name").toString();
             addresses.insert(a.toLower());
+            entriesByAddress.insert(a.toLower(), {t, n});
             if (promoteAddress.isEmpty()) {
                 promoteAddress = a;
-                promoteType = m_settings.value("type").toString();
-                promoteName = m_settings.value("name").toString();
+                promoteType = t;
+                promoteName = n;
             }
         }
         m_settings.endArray();
@@ -272,12 +289,29 @@ Settings::Settings(QObject* parent)
         if (!promoteAddress.isEmpty()) {
             const QString primary = m_settings.value("knownScales/primaryAddress").toString();
             if (primary.isEmpty() || !addresses.contains(primary.toLower())) {
+                // Primary missing or stale → promote the first known entry.
                 m_settings.setValue("knownScales/primaryAddress", promoteAddress);
                 m_settings.setValue("scale/address", promoteAddress);
                 m_settings.setValue("scale/type", promoteType);
                 m_settings.setValue("scale/name", promoteName);
                 qDebug() << "Settings: Repaired orphaned known scale — promoted"
                          << promoteName << promoteAddress << "to primary";
+            } else {
+                // Primary is valid. Verify legacy scale/* keys match it; sync
+                // if they don't. This is the direction the original heal
+                // missed — a setPrimaryScale() call that didn't write through
+                // to scale/address (because of a code-path bug or older build
+                // state) would leave us in the inconsistent state that breaks
+                // startup auto-connect.
+                const QString legacyAddr = m_settings.value("scale/address").toString();
+                if (legacyAddr.compare(primary, Qt::CaseInsensitive) != 0) {
+                    const auto entry = entriesByAddress.value(primary.toLower());
+                    m_settings.setValue("scale/address", primary);
+                    m_settings.setValue("scale/type", entry.first);
+                    m_settings.setValue("scale/name", entry.second);
+                    qDebug() << "Settings: Repaired scale/address drift — synced legacy keys to primary"
+                             << entry.second << primary;
+                }
             }
         }
     }
@@ -477,6 +511,18 @@ void Settings::addKnownScale(const QString& address, const QString& type, const 
     newScale["isPrimary"] = false;
     scales.append(newScale);
     writeKnownScales(scales);
+
+    // Invariant: a non-empty knownScales list must have exactly one primary.
+    // If no primary is currently set, auto-promote the entry we just added.
+    // The symmetric counterpart to removeKnownScale's auto-promote-next branch:
+    // removing the primary promotes another; adding into an empty-primary state
+    // promotes the new one. Without this, the Known Devices picker can render
+    // with nothing selected even though the user has known scales — they then
+    // have to tap one to "select" it, which is what set primary in the first
+    // place. See discussion under #1281.
+    if (primaryScaleAddress().isEmpty()) {
+        setPrimaryScale(address);
+    }
 }
 
 void Settings::removeKnownScale(const QString& address) {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -489,7 +489,10 @@ void Settings::addKnownScale(const QString& address, const QString& type, const 
     // Read existing scales
     QVariantList scales = knownScales();
 
-    // Check for existing entry — update name/type if found
+    // Check for existing entry — update name/type if found. We fall through
+    // to the invariant repair below in both branches (existing or newly added)
+    // so a re-add of an existing scale also fixes a missing primary.
+    bool alreadyExists = false;
     for (qsizetype i = 0; i < scales.size(); ++i) {
         QVariantMap s = scales[i].toMap();
         if (s["address"].toString().compare(address, Qt::CaseInsensitive) == 0) {
@@ -499,27 +502,34 @@ void Settings::addKnownScale(const QString& address, const QString& type, const 
                 scales[i] = s;
                 writeKnownScales(scales);
             }
-            return;
+            alreadyExists = true;
+            break;
         }
     }
 
-    // Add new scale
-    QVariantMap newScale;
-    newScale["address"] = address;
-    newScale["type"] = id;
-    newScale["name"] = name;
-    newScale["isPrimary"] = false;
-    scales.append(newScale);
-    writeKnownScales(scales);
+    if (!alreadyExists) {
+        QVariantMap newScale;
+        newScale["address"] = address;
+        newScale["type"] = id;
+        newScale["name"] = name;
+        newScale["isPrimary"] = false;
+        scales.append(newScale);
+        writeKnownScales(scales);
+    }
 
     // Invariant: a non-empty knownScales list must have exactly one primary.
-    // If no primary is currently set, auto-promote the entry we just added.
-    // The symmetric counterpart to removeKnownScale's auto-promote-next branch:
-    // removing the primary promotes another; adding into an empty-primary state
-    // promotes the new one. Without this, the Known Devices picker can render
-    // with nothing selected even though the user has known scales — they then
-    // have to tap one to "select" it, which is what set primary in the first
-    // place. See discussion under #1281.
+    // If no primary is currently set, auto-promote this entry — whether we
+    // just added it or it already existed. The original code only ran this
+    // for newly-added entries; the existing-entry early-return left the
+    // invariant unrepaired if primary had been cleared post-startup (rare
+    // but reachable, e.g. via mcptools_devices.cpp's clearSavedScale).
+    //
+    // Symmetric counterpart to removeKnownScale's auto-promote-next branch:
+    // removing the primary promotes another; adding into (or re-adding within)
+    // an empty-primary state promotes one. Without this, the Known Devices
+    // picker can render with nothing selected even though the user has known
+    // scales — they then have to tap one to "select" it, which is what set
+    // primary in the first place. See discussion under #1281.
     if (primaryScaleAddress().isEmpty()) {
         setPrimaryScale(address);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1783,9 +1783,25 @@ int main(int argc, char *argv[])
                     settings.network()->setWifiScaleIp(host, ip);
                 });
                 // For manual entries: commit the deferred persistence ONLY
-                // after the WS endpoint validates as HDS. SingleShotConnection
-                // because we only need the first recognition of this attempt —
-                // a later reconnect's recognition is a normal re-validate.
+                // after the WS endpoint validates as HDS, and surface a
+                // user-visible failure if validation fails. Both connections
+                // are SingleShotConnection because the driver guarantees
+                // recognizedAsHds and recognitionFailed are mutually exclusive
+                // for a given attempt (recognitionTimer is stopped by
+                // onRecognizedAsHds, and the cached-IP fallback branch of
+                // onRecognitionTimeout doesn't emit recognitionFailed — only
+                // the terminal give-up branch does).
+                //
+                // Why this exists at all: the outer 20 s scale-connection timer
+                // in BLEManager is stopped at WS-connect time (it watches for
+                // "ever connected", not "recognized"), so when a manual entry's
+                // WS handshake succeeds but the endpoint sends no HDS frame in
+                // 5 s (a non-HDS WS server, a captive portal, a future bug),
+                // the manualWifiValidationFailed path through
+                // onScaleConnectionTimeout would never fire. Without the
+                // explicit recognitionFailed wiring below, the user would see
+                // the scale appear connected for ~5 s, then disappear, with no
+                // error and no opportunity to retry. (#1281 follow-up.)
                 if (deferPersistence) {
                     QObject::connect(wifi, &DecentScaleWifi::recognizedAsHds,
                                      &bleManager,
@@ -1797,6 +1813,18 @@ int main(int argc, char *argv[])
                         settings.setPrimaryScale(deviceId);
                         bleManager.setSavedScaleAddress(deviceId, type, displayName);
                         emit bleManager.manualWifiValidationSucceeded(hostname);
+                    },
+                    Qt::SingleShotConnection);
+                    QObject::connect(wifi, &DecentScaleWifi::recognitionFailed,
+                                     &bleManager,
+                                     [&bleManager, hostname]() {
+                        qDebug() << "Manual WiFi scale failed HDS recognition:" << hostname;
+                        bleManager.appendScaleLog(
+                            QString("Manual WiFi scale at %1 connected but did not respond as HDS").arg(hostname));
+                        emit bleManager.manualWifiValidationFailed(hostname);
+                        // The driver's onRecognitionTimeout aborts the socket
+                        // itself, so the half-open scale tears down on its
+                        // own; we don't need to emit disconnectScaleRequested here.
                     },
                     Qt::SingleShotConnection);
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1568,9 +1568,15 @@ int main(int argc, char *argv[])
                                          : getDeviceIdentifier(device);
         const QString displayName = isWifi ? QStringLiteral("Half Decent Scale (WiFi)")
                                             : device.name();
-        // Always track this scale in the known-scales list (useful for the
-        // multi-scale picker and per-scale state).
-        settings.addKnownScale(deviceId, type, displayName);
+        // Manual "Add WiFi Scale" entries DEFER persistence until the WS
+        // endpoint actually validates as an HDS scale. Without this, a typo or
+        // a random LAN host (e.g. the user typing their router's IP) would be
+        // silently saved as the primary, then dialed on every reconnect /
+        // proactive switch-back cycle. The commit happens when
+        // DecentScaleWifi::recognizedAsHds fires (first valid HDS frame); if
+        // BLEManager's connection timer trips first, manualWifiValidationFailed
+        // is emitted to the QML layer instead and nothing is persisted. (#1281)
+        const bool deferPersistence = isWifi && bleManager.isManualWifiConnect();
         // BUT preserve the user's chosen primary when this connect is a
         // temporary WiFi→BLE fallback: BLEManager's m_wifiFallbackToBleActive
         // is true only between the WiFi-timeout fallback trigger and the next
@@ -1579,14 +1585,23 @@ int main(int argc, char *argv[])
         // explicitly chose WiFi and the fallback is meant to be temporary, so
         // the next app launch should retry WiFi first.
         const bool isFallbackConnect = !isWifi && bleManager.isWifiFallbackToBleActive();
-        if (!isFallbackConnect) {
-            settings.setPrimaryScale(deviceId);
-            bleManager.setSavedScaleAddress(deviceId, type, displayName);
-        } else {
-            qDebug() << "Scale connected via WiFi-to-BLE fallback — preserving saved WiFi primary"
-                     << settings.scaleAddress();
+        if (deferPersistence) {
+            qDebug() << "Manual WiFi-scale entry — deferring persistence until HDS validation:" << deviceId;
             bleManager.appendScaleLog(
-                QString("WiFi fallback connected to %1 — saved WiFi primary preserved").arg(displayName));
+                QString("Validating manual WiFi scale at %1...").arg(hostname));
+        } else {
+            // Always track this scale in the known-scales list (useful for the
+            // multi-scale picker and per-scale state).
+            settings.addKnownScale(deviceId, type, displayName);
+            if (!isFallbackConnect) {
+                settings.setPrimaryScale(deviceId);
+                bleManager.setSavedScaleAddress(deviceId, type, displayName);
+            } else {
+                qDebug() << "Scale connected via WiFi-to-BLE fallback — preserving saved WiFi primary"
+                         << settings.scaleAddress();
+                bleManager.appendScaleLog(
+                    QString("WiFi fallback connected to %1 — saved WiFi primary preserved").arg(displayName));
+            }
         }
 
         // Switch MachineState and TimingController to use physical scale instead of FlowScale
@@ -1767,6 +1782,24 @@ int main(int argc, char *argv[])
                 wifi->setIpCacheUpdate([&settings](const QString& host, const QString& ip) {
                     settings.network()->setWifiScaleIp(host, ip);
                 });
+                // For manual entries: commit the deferred persistence ONLY
+                // after the WS endpoint validates as HDS. SingleShotConnection
+                // because we only need the first recognition of this attempt —
+                // a later reconnect's recognition is a normal re-validate.
+                if (deferPersistence) {
+                    QObject::connect(wifi, &DecentScaleWifi::recognizedAsHds,
+                                     &bleManager,
+                                     [&settings, &bleManager, deviceId, type, displayName, hostname]() {
+                        qDebug() << "Manual WiFi scale validated as HDS — committing persistence:" << deviceId;
+                        bleManager.appendScaleLog(
+                            QString("Manual WiFi scale at %1 validated as HDS").arg(hostname));
+                        settings.addKnownScale(deviceId, type, displayName);
+                        settings.setPrimaryScale(deviceId);
+                        bleManager.setSavedScaleAddress(deviceId, type, displayName);
+                        emit bleManager.manualWifiValidationSucceeded(hostname);
+                    },
+                    Qt::SingleShotConnection);
+                }
                 wifi->connectToHost(hostname);
             }
         } else {
@@ -2116,10 +2149,38 @@ int main(int argc, char *argv[])
                      &bleManager, &BLEManager::de1LogMessage);
 #endif // !Q_OS_IOS
 
-    // Load saved scale address for direct wake connection
-    QString savedScaleAddr = settings.scaleAddress();
-    QString savedScaleType = settings.scaleType();
-    QString savedScaleName = settings.scaleName();
+    // Load saved scale address for direct wake connection. Read from the
+    // multi-scale-era key (primaryScaleAddress) first and fall back to the
+    // legacy single-scale key (scale/address) — the Settings orphan-heal at
+    // startup keeps them in sync, but read order matters during the heal
+    // window itself, AND the legacy key was the historical source of the
+    // "tryDirectConnectToScale - no saved scale address/type" bug (QML
+    // checked the new key, this load used the old one, and a drift between
+    // them stranded the user with no auto-connect). If primary is set, look
+    // up its full entry from knownScales so we feed BLEManager the correct
+    // type/name without depending on the legacy scale/type and scale/name
+    // keys being in sync.
+    QString savedScaleAddr = settings.primaryScaleAddress();
+    QString savedScaleType;
+    QString savedScaleName;
+    if (!savedScaleAddr.isEmpty()) {
+        for (const QVariant& v : settings.knownScales()) {
+            const QVariantMap s = v.toMap();
+            if (s.value("address").toString().compare(savedScaleAddr, Qt::CaseInsensitive) == 0) {
+                savedScaleType = s.value("type").toString();
+                savedScaleName = s.value("name").toString();
+                break;
+            }
+        }
+    }
+    // Fall back to the legacy keys if primary wasn't set (older builds, or
+    // a fresh install before any scale connect has written the multi-scale
+    // store). The orphan-heal will reconcile this on the next launch.
+    if (savedScaleAddr.isEmpty()) {
+        savedScaleAddr = settings.scaleAddress();
+        savedScaleType = settings.scaleType();
+        savedScaleName = settings.scaleName();
+    }
     if (!savedScaleAddr.isEmpty() && !savedScaleType.isEmpty()) {
         bleManager.setSavedScaleAddress(savedScaleAddr, savedScaleType, savedScaleName);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1323,10 +1323,13 @@ int main(int argc, char *argv[])
     // backup (the WiFi->BLE fallback connected after WiFi was unreachable),
     // periodically check — only while the machine is idle (idle page, never
     // mid-shot) — whether the WiFi scale is reachable again, and hop back if so.
-    // The check (BLEManager::probeWifiPrimaryReachable → a TCP dial of the cached
-    // IP) is non-disruptive: it never touches the live BLE link, so a failed
-    // check leaves the working backup untouched. This is genuine periodic polling
-    // (for an external availability change), not a timer-as-guard.
+    // The check (BLEManager::probeWifiPrimaryReachable → a WebSocket HDS-identity
+    // probe against ws://<cached-ip>/snapshot, requiring a valid HDS frame
+    // within ~3.5 s) is non-disruptive: it never touches the live BLE link, so
+    // a failed check leaves the working backup untouched. A bare TCP-open on
+    // port 80 was the old check; it false-positived against any LAN device on
+    // 80 and triggered the WiFi↔BLE thrash in #1281. This is genuine periodic
+    // polling (for an external availability change), not a timer-as-guard.
     QTimer wifiPreferTimer;
     constexpr int kWifiPreferIntervalMs = 30000;  // re-check every 30 s while armed
 
@@ -1822,9 +1825,18 @@ int main(int argc, char *argv[])
                         bleManager.appendScaleLog(
                             QString("Manual WiFi scale at %1 connected but did not respond as HDS").arg(hostname));
                         emit bleManager.manualWifiValidationFailed(hostname);
-                        // The driver's onRecognitionTimeout aborts the socket
-                        // itself, so the half-open scale tears down on its
-                        // own; we don't need to emit disconnectScaleRequested here.
+                        // The driver's onRecognitionTimeout aborts the WS
+                        // socket, but the DecentScaleWifi object itself stays
+                        // alive as `physicalScale` until something resets the
+                        // unique_ptr. Without this emit, that zombie disconnected
+                        // driver would survive the failed validation — and the
+                        // next reconnect-timer / scaleDiscovered tick would
+                        // re-route into the type-unchanged branch and re-dial
+                        // the unvalidated hostname against the same dead object.
+                        // disconnectScaleRequested's handler clears
+                        // BLEManager's reference and resets physicalScale, so
+                        // the next manual attempt starts from a clean slate.
+                        emit bleManager.disconnectScaleRequested();
                     },
                     Qt::SingleShotConnection);
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2178,10 +2178,11 @@ int main(int argc, char *argv[])
 #endif // !Q_OS_IOS
 
     // Load saved scale address for direct wake connection. Read from the
-    // multi-scale-era key (primaryScaleAddress) first and fall back to the
-    // legacy single-scale key (scale/address) — the Settings orphan-heal at
-    // startup keeps them in sync, but read order matters during the heal
-    // window itself, AND the legacy key was the historical source of the
+    // multi-scale-era key (primaryScaleAddress) first, then fall back to the
+    // legacy single-scale key (scale/address). The Settings orphan-heal in
+    // the Settings constructor already syncs them before we reach this code,
+    // but reading the canonical key directly avoids depending on that sync —
+    // and the legacy key was the historical source of the
     // "tryDirectConnectToScale - no saved scale address/type" bug (QML
     // checked the new key, this load used the old one, and a drift between
     // them stranded the user with no auto-connect). If primary is set, look

--- a/src/network/wifiscalediscovery.cpp
+++ b/src/network/wifiscalediscovery.cpp
@@ -26,11 +26,13 @@ WifiScaleDiscovery::WifiScaleDiscovery(QObject* parent)
         // The generation bump in cancelInFlight() drops any late worker result.
         if (!m_androidInFlight) return;
         qDebug() << "[WifiScaleDiscovery] mDNS probe watchdog fired for" << m_currentHostname;
+        emit logMessage(QStringLiteral("mDNS probe watchdog fired for ") + m_currentHostname);
         cancelInFlight();
         emit probeFinished();
 #else
         if (m_lookupId == -1) return;
         qDebug() << "[WifiScaleDiscovery] mDNS lookup timed out for" << m_currentHostname;
+        emit logMessage(QStringLiteral("mDNS lookup timed out for ") + m_currentHostname);
         cancelInFlight();
         emit probeFinished();
 #endif
@@ -47,6 +49,8 @@ void WifiScaleDiscovery::probe(const QString& hostname, int timeoutMs) {
     m_currentHostname = hostname;
     qDebug() << "[WifiScaleDiscovery] lookup for" << hostname
              << "(timeout" << timeoutMs << "ms)";
+    emit logMessage(QString("mDNS lookup for %1 (timeout %2 ms)")
+                        .arg(hostname).arg(timeoutMs));
 
 #ifdef Q_OS_ANDROID
     // Android's stock resolver (getaddrinfo / QHostInfo) does NOT resolve
@@ -81,11 +85,13 @@ void WifiScaleDiscovery::probe(const QString& hostname, int timeoutMs) {
 
             if (ip.isEmpty()) {
                 qDebug() << "[WifiScaleDiscovery] mDNS lookup failed for" << hostnameForWorker;
+                emit self->logMessage(QStringLiteral("mDNS no responder for ") + hostnameForWorker);
                 emit self->probeFinished();
                 return;
             }
             qDebug() << "[WifiScaleDiscovery] mDNS found" << hostnameForWorker
                      << "->" << ip;
+            emit self->logMessage(QString("mDNS resolved %1 to %2").arg(hostnameForWorker, ip));
             emit self->scaleFound(hostnameForWorker, ip);
             emit self->probeFinished();
         }, Qt::QueuedConnection);
@@ -108,6 +114,8 @@ void WifiScaleDiscovery::probe(const QString& hostname, int timeoutMs) {
             if (info.error() != QHostInfo::NoError || info.addresses().isEmpty()) {
                 qDebug() << "[WifiScaleDiscovery] lookup failed for"
                          << m_currentHostname << "-" << info.errorString();
+                emit logMessage(QString("mDNS lookup failed for %1: %2")
+                                    .arg(m_currentHostname, info.errorString()));
                 emit probeFinished();
                 return;
             }
@@ -115,6 +123,7 @@ void WifiScaleDiscovery::probe(const QString& hostname, int timeoutMs) {
             const QString resolved = info.addresses().first().toString();
             qDebug() << "[WifiScaleDiscovery] found" << m_currentHostname
                      << "->" << resolved;
+            emit logMessage(QString("mDNS resolved %1 to %2").arg(m_currentHostname, resolved));
             emit scaleFound(m_currentHostname, resolved);
             emit probeFinished();
         });

--- a/src/network/wifiscalediscovery.h
+++ b/src/network/wifiscalediscovery.h
@@ -52,6 +52,13 @@ public:
 signals:
     void scaleFound(const QString& hostname, const QString& resolvedAddress);
     void probeFinished();
+    // User-facing diagnostic stream — emitted at probe start, success, timeout,
+    // and lookup failure. BLEManager forwards this to its appendScaleLog so the
+    // user-shareable scale debug log captures what happened at the mDNS layer.
+    // Without it, mDNS-side failures (multicast filtering on the AP, scale not
+    // joining the right SSID, captive-portal redirect) were only visible via
+    // adb logcat / Qt Creator console, never in a user-shared log.
+    void logMessage(const QString& message);
 
 private:
     void cancelInFlight();

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -1,5 +1,6 @@
 #include <QtTest>
 #include <QSignalSpy>
+#include <QPointer>
 #include <QWebSocketServer>
 #include <QWebSocket>
 #include <QHostAddress>
@@ -759,6 +760,50 @@ private slots:
         QVERIFY(failedSpy.wait(8000));
         QCOMPARE(failedSpy.count(), 1);
         QCOMPARE(recognizedSpy.count(), 0);
+    }
+
+    // Regression guard against a use-after-free in onRecognitionTimeout's
+    // give-up branch: the driver MUST mutate its own state (m_userInitiatedShutdown,
+    // m_socket->abort()) BEFORE emitting recognitionFailed. Why: in production
+    // main.cpp wires the signal to a slot that emits disconnectScaleRequested,
+    // whose handler synchronously calls physicalScale.reset() — destroying
+    // `this` while onRecognitionTimeout is still on the stack. Any post-emit
+    // access to a member would be UB. The fix is to do all member writes
+    // first and emit last; this test exercises the destroy-during-emit
+    // pattern so a future re-ordering tripwire is caught by ASan / a flaky
+    // crash here.
+    //
+    // We delete the driver INSIDE the recognitionFailed slot to reproduce
+    // the synchronous-destroy chain. If the driver still touches `this`
+    // after the emit, the read/write is on freed memory.
+    void recognitionFailedSlotMaySafelyDestroyDriver() {
+        SilentServer silent;
+        auto* driver = new DecentScaleWifi();  // raw — we own deletion
+        QPointer<DecentScaleWifi> guard(driver);
+
+        bool slotFired = false;
+        QObject::connect(driver, &DecentScaleWifi::recognitionFailed, this,
+            [&driver, &slotFired]() {
+                slotFired = true;
+                delete driver;       // synchronous destroy — same as production
+                driver = nullptr;    // for hygiene; the test doesn't reuse it
+            },
+            Qt::DirectConnection);   // pin synchronous; AutoConnection would resolve the same way
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*No recognizable HDS frame within.*"));
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*WiFi scale did not respond as HDS.*"));
+
+        driver->connectToHost(silent.host());
+
+        // Wait past the 5 s recognition window for the give-up branch to fire.
+        // If member writes happen AFTER the emit, the test crashes (UAF) or
+        // ASan reports a use-after-free. If the order is correct, the slot
+        // runs cleanly, the object is destroyed exactly once, and we observe
+        // it via the QPointer.
+        QTRY_VERIFY_WITH_TIMEOUT(slotFired, 8000);
+        QVERIFY(guard.isNull());  // QPointer auto-nulls on QObject destruction
     }
 
     void cachedIpFastFailsToHostnameFallback() {

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -635,6 +635,132 @@ private slots:
     // Test setup: a cached IP that points at a localhost port with no
     // listener (ConnectionRefusedError fires near-instantly), and a real
     // FakeHdsServer for the hostname fallback target.
+    // Cached-IP failure must evict the cached entry via m_ipCacheUpdate(host, "")
+    // BEFORE falling back to hostname. Without this, a poisoned cache (manually-
+    // typed wrong IP, DHCP-reassigned to another device) would survive across
+    // reconnect cycles and trigger the WiFi-↔-BLE failover loop in #1281.
+    //
+    // Asserts the FULL sequence of cache writes, not just the final value:
+    // (host, "")  — eviction on cached-IP fail
+    // (host, X)   — fresh IP cached after hostname-fallback success
+    void cachedIpFailureEvictsCacheBeforeFallback() {
+        FakeHdsServer hostnameServer;
+        DecentScaleWifi driver;
+        driver.setIpResolver([](const QString& /*host*/) {
+            // Cached IP points at a port with no listener — instant ConnectionRefused.
+            return QStringLiteral("127.0.0.1:1");
+        });
+        QList<QPair<QString, QString>> cacheWrites;
+        driver.setIpCacheUpdate([&](const QString& host, const QString& ip) {
+            cacheWrites.append({host, ip});
+        });
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*WebSocket error.*"));
+
+        QSignalSpy connectedSpy(&hostnameServer, &FakeHdsServer::clientConnected);
+        driver.connectToHost(hostnameServer.host());
+        QVERIFY(connectedSpy.wait(2000));
+        QTRY_VERIFY_WITH_TIMEOUT(hostnameServer.received().size() >= 4, 2000);
+
+        // Drive recognition on the hostname attempt so the fresh-IP cache write
+        // fires. Without this, the test would only observe the eviction half.
+        hostnameServer.sendJson({{ "grams", 1.0 }, { "ms", 1 }});
+        QSignalSpy weightSpy(&driver, &ScaleDevice::weightChanged);
+        QVERIFY(weightSpy.wait(500));
+
+        // First write must be the eviction (empty IP). Second must be the
+        // fresh peer IP from the successful hostname connect.
+        QTRY_COMPARE_WITH_TIMEOUT(cacheWrites.size(), 2, 1000);
+        QCOMPARE(cacheWrites[0].first, hostnameServer.host());
+        QCOMPARE(cacheWrites[0].second, QString());  // eviction
+        QCOMPARE(cacheWrites[1].first, hostnameServer.host());
+        QVERIFY(!cacheWrites[1].second.isEmpty());   // re-cache with new IP
+    }
+
+    // recognizedAsHds is the single source of truth for "this WS endpoint is
+    // really an HDS scale". main.cpp's manual-entry deferred-persistence flow
+    // commits addKnownScale/setPrimaryScale/setSavedScaleAddress ONLY when
+    // this signal fires. Lock down the contract:
+    //   - Fires on first snapshot frame (no "type", "grams" number)
+    //   - Fires on first status frame (type=="status")
+    //   - Does NOT fire on the WS upgrade alone (no inbound frame yet)
+    //   - Fires at most once per attempt (driver's m_recognized latch)
+    void recognizedAsHdsFiresOnceOnFirstFrame() {
+        FakeHdsServer server;
+        DecentScaleWifi driver;
+        QSignalSpy recognizedSpy(&driver, &DecentScaleWifi::recognizedAsHds);
+        connectAndHandshake(driver, server);
+
+        // WS-upgrade alone (no frame received yet): must NOT have fired.
+        QCOMPARE(recognizedSpy.count(), 0);
+
+        // First snapshot fires it.
+        server.sendJson({{ "grams", 12.34 }, { "ms", 100 }});
+        QVERIFY(recognizedSpy.wait(500));
+        QCOMPARE(recognizedSpy.count(), 1);
+
+        // Subsequent snapshots do NOT re-emit (the m_recognized latch is the
+        // whole point — recognition is per-attempt, not per-frame).
+        server.sendJson({{ "grams", 23.45 }, { "ms", 200 }});
+        server.sendJson({{ "grams", 34.56 }, { "ms", 300 }});
+        QTest::qWait(100);
+        QCOMPARE(recognizedSpy.count(), 1);
+    }
+
+    // The status-frame path also reaches onRecognizedAsHds. Without this,
+    // a scale that happens to send its status frame before any snapshot
+    // (the openscale order on connect — see handshake test: 'rate' then
+    // 'status') would never validate, and manual entries would dead-end.
+    void recognizedAsHdsFiresOnFirstStatusFrame() {
+        FakeHdsServer server;
+        DecentScaleWifi driver;
+        QSignalSpy recognizedSpy(&driver, &DecentScaleWifi::recognizedAsHds);
+        connectAndHandshake(driver, server);
+
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Firmware version: FW: 3\\.0\\.9.*"));
+        server.sendJson({
+            { "type", "status" },
+            { "battery_percent", 80 },
+            { "firmware_version", "FW: 3.0.9" },
+        });
+        QVERIFY(recognizedSpy.wait(500));
+        QCOMPARE(recognizedSpy.count(), 1);
+    }
+
+    // recognitionFailed is the failure counterpart of recognizedAsHds. It
+    // fires from onRecognitionTimeout's terminal "give up THIS attempt"
+    // branch when we've already exhausted the hostname fallback (or were on
+    // it directly) and 5 s passed with no HDS frame.
+    //
+    // Without this signal the manual "Add WiFi Scale" flow has a silent-
+    // failure window: when the WS handshake succeeds (so onConnected fires →
+    // setConnected(true) → the outer 20 s scale-connection-timer is stopped),
+    // but no HDS frame arrives, the validation-failed path through
+    // onScaleConnectionTimeout never runs. The test below exercises exactly
+    // that branch: SilentServer accepts the upgrade and sends nothing.
+    void recognitionFailedFiresOnHostnameGiveUp() {
+        SilentServer silent;
+        DecentScaleWifi driver;
+        QSignalSpy recognizedSpy(&driver, &DecentScaleWifi::recognizedAsHds);
+        QSignalSpy failedSpy(&driver, &DecentScaleWifi::recognitionFailed);
+        // No ipResolver — connectToHost goes straight to attemptHostname,
+        // which sets m_currentTargetIsHostname=true. When the recognition
+        // timer fires we hit the give-up branch, not the cached-IP-fallback
+        // branch.
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*No recognizable HDS frame within.*"));
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*WiFi scale did not respond as HDS.*"));
+
+        driver.connectToHost(silent.host());
+
+        // 5 s recognition window + buffer. recognitionFailed should fire
+        // exactly once; recognizedAsHds should NOT fire (no HDS frame arrived).
+        QVERIFY(failedSpy.wait(8000));
+        QCOMPARE(failedSpy.count(), 1);
+        QCOMPARE(recognizedSpy.count(), 0);
+    }
+
     void cachedIpFastFailsToHostnameFallback() {
         FakeHdsServer hostnameServer;
         DecentScaleWifi driver;

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -377,6 +377,35 @@ private slots:
         QCOMPARE(m_settings.primaryScaleAddress(), QString("AA:BB:CC:DD:EE:FF"));
     }
 
+    // Re-adding an existing known scale must repair the primary invariant
+    // if primary was cleared between the original add and the re-add. main.cpp
+    // calls addKnownScale on every scale connect, so this is the natural
+    // healing path if some other code (clearSavedScale via MCP, a future
+    // migration, a test fixture) left primary empty while the entry still
+    // existed. Without this, the early-return on existing entries would skip
+    // the invariant check and the Known Devices picker would render with
+    // nothing selected even though the list has entries.
+    void addKnownScaleRepairsPrimaryOnReAddOfExistingEntry() {
+        KnownScalesGuard guard(&m_settings);
+
+        // First add — invariant auto-promotes the new entry.
+        m_settings.addKnownScale("AA:BB:CC:DD:EE:01", "decent", "Test Scale");
+        QCOMPARE(m_settings.primaryScaleAddress(), QString("AA:BB:CC:DD:EE:01"));
+
+        // Force the "primary cleared, entry remains" state — unreachable in
+        // normal flow but reproducible at this layer.
+        m_settings.setPrimaryScale(QString());
+        QVERIFY(m_settings.primaryScaleAddress().isEmpty());
+
+        // Re-add the same address — the same call main.cpp makes on every
+        // connect. Pre-fix this hit the early-return path and left primary
+        // empty; post-fix it repairs the invariant.
+        m_settings.addKnownScale("AA:BB:CC:DD:EE:01", "decent", "Test Scale");
+        QCOMPARE(m_settings.primaryScaleAddress(), QString("AA:BB:CC:DD:EE:01"));
+        // Legacy keys are also re-synced via setPrimaryScale's normal path.
+        QCOMPARE(m_settings.scaleAddress(), QString("AA:BB:CC:DD:EE:01"));
+    }
+
     // Settings' startup orphan-heal must repair the BOTH directions of the
     // scale/address ↔ knownScales/primaryAddress relationship:
     //   forward — primary empty / stale → promote first known and write legacy

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -17,6 +17,39 @@
 // the system settings store. Tests save originals in init() and restore in
 // cleanup() (guaranteed to run even if assertions fail mid-test).
 
+// File-scope helper (Q_OBJECT moc rejects nested structs in test classes).
+// Snapshot + clear the Known Devices store so a test owns it for the
+// duration, and restore on scope exit. Settings exposes addKnownScale /
+// removeKnownScale but no bulk reset; the snapshot path covers test
+// isolation without leaking test entries into the user's QSettings store.
+struct KnownScalesGuard {
+    explicit KnownScalesGuard(Settings* s) : m_settings(s) {
+        m_snapshot = s->knownScales();
+        m_origPrimary = s->primaryScaleAddress();
+        for (const QVariant& v : m_snapshot) {
+            s->removeKnownScale(v.toMap()["address"].toString());
+        }
+    }
+    ~KnownScalesGuard() {
+        const QVariantList current = m_settings->knownScales();
+        for (const QVariant& v : current) {
+            m_settings->removeKnownScale(v.toMap()["address"].toString());
+        }
+        for (const QVariant& v : m_snapshot) {
+            const QVariantMap s = v.toMap();
+            m_settings->addKnownScale(s["address"].toString(),
+                                      s["type"].toString(),
+                                      s["name"].toString());
+        }
+        if (!m_origPrimary.isEmpty()) {
+            m_settings->setPrimaryScale(m_origPrimary);
+        }
+    }
+    Settings* m_settings;
+    QVariantList m_snapshot;
+    QString m_origPrimary;
+};
+
 class tst_Settings : public QObject {
     Q_OBJECT
 
@@ -314,6 +347,73 @@ private slots:
         QVERIFY(SettingsSerializer::importFromJson(&m_settings, bundle));
         QCOMPARE(m_settings.app()->autoLoadProfileFilename(), QString("preferred-profile"));
         QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 17);
+    }
+
+    // ==========================================
+    // Known scales: invariant + heal
+    // ==========================================
+
+    // Adding the first known scale into an empty primary state must auto-
+    // promote that entry to primary. Without this, the Known Devices picker
+    // renders with currentIndex == -1 (nothing selected) even though the
+    // list has entries — the user has to tap one to make their selection
+    // "stick" as primary, which is the bug the user observed in #1281.
+    void addKnownScalePromotesToPrimaryWhenNoneSet() {
+        KnownScalesGuard guard(&m_settings);
+        // Guard cleared knownScales; also clear primary so we're in the
+        // empty-primary state.
+        m_settings.setPrimaryScale(QString());
+
+        m_settings.addKnownScale("AA:BB:CC:DD:EE:FF", "decent", "Test Scale");
+
+        QCOMPARE(m_settings.primaryScaleAddress(), QString("AA:BB:CC:DD:EE:FF"));
+        QCOMPARE(m_settings.scaleAddress(), QString("AA:BB:CC:DD:EE:FF"));
+        QCOMPARE(m_settings.scaleType(), QString("decent"));
+        QCOMPARE(m_settings.scaleName(), QString("Test Scale"));
+
+        // Adding a SECOND scale must NOT change primary (the first one's
+        // promotion is sticky; the user explicitly switches via setPrimaryScale).
+        m_settings.addKnownScale("11:22:33:44:55:66", "decent", "Second Scale");
+        QCOMPARE(m_settings.primaryScaleAddress(), QString("AA:BB:CC:DD:EE:FF"));
+    }
+
+    // Settings' startup orphan-heal must repair the BOTH directions of the
+    // scale/address ↔ knownScales/primaryAddress relationship:
+    //   forward — primary empty / stale → promote first known and write legacy
+    //   reverse — primary valid but legacy empty/stale → sync legacy from primary
+    // The reverse case was the actual #1281 follow-up bug. QML's startup hook
+    // gates `tryDirectConnectToScale` on `primaryScaleAddress`, but main.cpp's
+    // BLEManager load (pre-fix) read the legacy `scale/address`. A drift
+    // between the two stranded the user with no auto-connect at startup.
+    void orphanHealRepairsLegacyAddressFromValidPrimary() {
+        KnownScalesGuard guard(&m_settings);
+
+        // Pre-seed: knownScales has an entry, primary points to it, but the
+        // legacy keys are stale/empty (simulates the divergence). Write
+        // directly to QSettings so the heal sees the pre-state on next ctor.
+        QSettings raw("DecentEspresso", "DE1Qt");
+        raw.remove("knownScales/scales");
+        raw.beginWriteArray("knownScales/scales");
+        raw.setArrayIndex(0);
+        raw.setValue("address", "PRIMARY:AA:11");
+        raw.setValue("type", "decent");
+        raw.setValue("name", "Healed Scale");
+        raw.endArray();
+        raw.setValue("knownScales/primaryAddress", "PRIMARY:AA:11");
+        raw.setValue("scale/address", "");
+        raw.setValue("scale/type", "");
+        raw.setValue("scale/name", "");
+        raw.sync();
+
+        // Construct a fresh Settings — the orphan-heal in its constructor
+        // sees the divergence and syncs legacy from primary.
+        Settings healed;
+
+        QCOMPARE(healed.scaleAddress(), QString("PRIMARY:AA:11"));
+        QCOMPARE(healed.scaleType(), QString("decent"));
+        QCOMPARE(healed.scaleName(), QString("Healed Scale"));
+        // primaryScaleAddress unchanged (it was already correct).
+        QCOMPARE(healed.primaryScaleAddress(), QString("PRIMARY:AA:11"));
     }
 };
 


### PR DESCRIPTION
## Summary

Fixes #1281 (WiFi scale stuck in a 30 s WiFi↔BLE failover loop, BLE failover repeatedly clobbered) and a coupled primary-scale state-management bug surfaced during the investigation.

- **Cached-IP validation**: any WS error on a cached-IP attempt (incl. 403 from a poisoned IP — the router) now evicts the cache and falls back to mDNS; recognition timeout also evicts. Today only HostNotFound/Refused/Network/Timeout triggered the fallback, so a 403 dead-ended and re-triggered every cycle.
- **HDS-aware proactive switch-back probe**: was a bare TCP connect on port 80 (router/printer/NAS passed); now opens `ws://<ip>/snapshot` and requires a valid HDS frame within 3.5 s. Stops the 30 s "switch back to WiFi" timer from chasing phantoms.
- **Manual "Add WiFi Scale" entry validates before saving**: persistence is deferred until `DecentScaleWifi::recognizedAsHds` confirms the typed endpoint really is a scale. A typo or wrong IP no longer poisons the saved primary; instead a "Couldn't verify a scale at *<address>*" dialog appears. Opening the dialog also fires an mDNS probe and offers a one-tap "Use" banner if the HDS is on the LAN.
- **mDNS diagnosability**: `WifiScaleDiscovery::logMessage` routes through `appendScaleLog`, so future user-shared debug logs show whether mDNS replied / timed out / hit a multicast issue without adb logcat.
- **Primary-scale invariant**: a non-empty Known Devices list now always has exactly one primary. Fixes the picker-with-nothing-selected state where the user has to manually tap a scale to set primary even though one was previously connected. Three coupled edits: addKnownScale auto-promotes; orphan-heal repairs `scale/address` ← `primaryAddress` drift in both directions; main.cpp startup load prefers `primaryScaleAddress()` over the legacy single-scale key.

## Test plan

- [ ] Power on HDS, open Settings → Connections → Add WiFi Scale. mDNS banner should appear within ~2 s offering hds.local. Tap **Use** → scale connects, banner closes, scale shows as primary.
- [ ] Same dialog, type a wrong IP (e.g. your router's IP). Tap Connect → after ~3-5 s, a "Couldn't verify a scale at <ip>" dialog appears. Saved primary is unchanged. Check `scale_debug_log.txt`: should NOT contain the typed IP under known scales.
- [ ] Simulate the original #1281 bug: in QSettings, set `scale/wifiIp/hds.local` to your router's IP. Launch app. Within one connect cycle the cache should self-evict (log line: `Cached IP X unreachable (…) — evicting cache and falling back to hostname hds.local`) and recover via mDNS.
- [ ] Power off the HDS, open Add WiFi Scale. After ~2-5 s the dialog should NOT show a banner, and `scale_debug_log.txt` should contain `Manual-entry mDNS: no HDS scale responded`.
- [ ] Pair both a WiFi and a BLE Decent scale across two sessions. Confirm primary persists across restarts and the Known Devices picker always shows one selected.
- [ ] Connect a WiFi scale, then plug in USB scale + Decent BLE scale. Switch primary between all three from the picker; each switch should disconnect the previous and connect the new without leaving the picker in a "nothing selected" state.
- [ ] During brewing, do NOT trigger a WiFi-primary switch-back (the proactive probe is idle-only). Verify the new probe doesn't accidentally fire mid-shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)