### PR TITLE
fix(scale): silence Decent Scale connection-error dialogs

### DIFF
--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -45,7 +45,7 @@ DecentScale::~DecentScale() {
 
 void DecentScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        DECENT_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -80,7 +80,6 @@ void DecentScale::onTransportDisconnected() {
 
 void DecentScale::onTransportError(const QString& message) {
     DECENT_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("Scale connection error");
     setConnected(false);
 }
 
@@ -93,7 +92,6 @@ void DecentScale::onServiceDiscovered(const QBluetoothUuid& uuid) {
 void DecentScale::onServicesDiscoveryFinished() {
     if (!m_serviceFound) {
         DECENT_WARN("Decent Scale service not found");
-        emit errorOccurred("Decent Scale service not found");
         m_transport->disconnectFromDevice();
         return;
     }


### PR DESCRIPTION
## Summary
- Remove the three \`emit errorOccurred(...)\` calls in \`DecentScale\` that surfaced as the modal "Connection Error" dialog. They were not gated by \`Settings.showScaleDialogs\` (which only protects the "No Scale Found" / "Scale Disconnected" notices), so transient BLE drops popped a dialog on every reconnect cycle.
- Each path still logs via \`DECENT_WARN\` (transport error, missing service, missing transport), and \`setConnected(false)\` / \`disconnectFromDevice()\` behavior is unchanged — auto-reconnect runs normally.
- If the scale stays gone long enough that reconnect gives up, the existing \`onFlowScaleFallback()\` path still surfaces "No Scale Found", which **is** gated by the scale-alerts toggle.

## Test plan
- [ ] Power-cycle the Decent Scale mid-idle: confirm no "Connection Error" dialog, scale auto-reconnects.
- [ ] Walk the scale out of range until reconnect gives up: confirm "No Scale Found" dialog appears (when alerts enabled) and is suppressed when the toggle is off.
- [ ] Check \`decent_scale.log\` shows \`Transport error: ...\` lines for the events that previously dialoged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)