### PR TITLE
fix(scale): poll Decent WiFi scale status to match BT battery cadence

### DIFF
--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -257,10 +257,14 @@ void DecentScaleWifi::onConnected() {
 
     // Bump to the highest cadence the firmware supports, opt in to events,
     // and seed an initial status frame so battery/firmware_version populate
-    // immediately rather than waiting on the 5 s heartbeat.
+    // immediately. Periodic battery/charging refreshes are driven by
+    // sendKeepAlive() below — the WS firmware does not push status
+    // unsolicited, so we must request it ourselves (matches the BT driver's
+    // ~4-minute battery poll; see decentscale.cpp kBatteryPollHeartbeatTicks).
     send(QStringLiteral("rate 10k"));
     send(QStringLiteral("events on"));
     send(QStringLiteral("status"));
+    m_ticksSinceBatteryPoll = 0;
     // Restore the LCD on every (re)connect. Idempotent on a fresh-connect
     // scale (LCD defaults on); required on a reconnect after the DE1-sleep
     // keepScaleOn=true+WiFi path, where disableLcd() was sent before the WS
@@ -272,6 +276,7 @@ void DecentScaleWifi::onConnected() {
 
 void DecentScaleWifi::onDisconnected() {
     if (m_recognitionTimer) m_recognitionTimer->stop();
+    m_ticksSinceBatteryPoll = 0;
 
     // Classify the disconnect for triage. A genuine transport error means the
     // link dropped under us, so it must read "(unexpected)" regardless of any
@@ -698,9 +703,18 @@ void DecentScaleWifi::setLed(int r, int g, int b) {
 }
 
 void DecentScaleWifi::sendKeepAlive() {
-    // No-op. The 5 s status frame from the scale (after `events on`) plus
-    // TCP-level keepalive cover liveness — an app-level ping would just
-    // be noise on a healthy link. See design.md decision 11.
+    // Liveness itself is covered by TCP keepalive; this hook exists so the
+    // base-class keep-alive timer (30 s) can drive a periodic `status` request,
+    // since the WS firmware no longer auto-pushes status frames. Send `status`
+    // on every kBatteryPollKeepAliveTicks tick (~4 min) — matches the BT
+    // driver's effective battery-poll cadence (see decentscale.cpp's
+    // kBatteryPollHeartbeatTicks). The base-class timer is started in
+    // setConnected(true) and stopped in setConnected(false), so no extra
+    // lifecycle wiring is needed here.
+    if (++m_ticksSinceBatteryPoll >= kBatteryPollKeepAliveTicks) {
+        m_ticksSinceBatteryPoll = 0;
+        send(QStringLiteral("status"));
+    }
 }
 
 void DecentScaleWifi::onError() {

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -154,6 +154,12 @@ private:
 
     static constexpr int kRecognitionTimeoutMs = 5000;
     static constexpr int kWifiButtonFlag = 0x1000;
+    // Battery-poll cadence: every Nth base-class keep-alive tick we request a
+    // `status` frame from the firmware (which no longer auto-pushes status).
+    // Base-class keepAliveTimer ticks at 30 s; 8 ticks → 240 s, matching the
+    // BT driver's effective ~4 min battery poll (kBatteryPollHeartbeatTicks =
+    // 240 × 1 s heartbeat). Reset on each connect cycle.
+    static constexpr int kBatteryPollKeepAliveTicks = 8;
 
     QWebSocket* m_socket = nullptr;
     QTimer* m_recognitionTimer = nullptr;
@@ -206,6 +212,10 @@ private:
     // Consumed-and-cleared in handlePowerFrame; the disconnect path is
     // already classified expected via m_userInitiatedShutdown.
     bool m_powerOffInitiatedByApp = false;
+    // Counts base-class keep-alive ticks since the last `status` request; on
+    // every kBatteryPollKeepAliveTicks tick we re-send `status` so the scale
+    // refreshes battery/charging. Reset in onConnected() and onDisconnected().
+    int m_ticksSinceBatteryPoll = 0;
 
     IpResolver m_ipResolver;     // hostname → cached IP (or empty)
     IpCacheUpdate m_ipCacheUpdate;  // hostname, ip → side-effect

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -168,6 +168,83 @@ private slots:
         QCOMPARE(rx[3], QStringLiteral("display on"));
     }
 
+    // The WS firmware no longer auto-pushes status frames, so the driver
+    // polls by sending `status` on every Nth base-class keep-alive tick.
+    // Cadence must be EXACTLY every 8th call — the BT driver's effective
+    // battery poll is kBatteryPollHeartbeatTicks (240) × 1 s = 240 s, and we
+    // match that with 8 × 30 s = 240 s. Regression guard against off-by-one
+    // (>= vs >, pre- vs post-increment) and against accidental "send every
+    // tick" simplifications that would spam the scale 8× too often.
+    void keepAliveSendsStatusEveryEighthTick() {
+        FakeHdsServer server;
+        DecentScaleWifi driver;
+        connectAndHandshake(driver, server);
+        server.clearReceived();
+
+        // First seven ticks must NOT send anything.
+        for (int i = 0; i < 7; ++i) driver.sendKeepAlive();
+        QTest::qWait(100);  // drain any pending socket writes
+        QCOMPARE(server.received().size(), 0);
+
+        // Eighth tick triggers the poll.
+        driver.sendKeepAlive();
+        QTRY_COMPARE(server.received().size(), 1);
+        QCOMPARE(server.received().last(), QStringLiteral("status"));
+
+        // Cadence repeats: another seven silent, eighth fires.
+        for (int i = 0; i < 7; ++i) driver.sendKeepAlive();
+        QTest::qWait(100);
+        QCOMPARE(server.received().size(), 1);
+        driver.sendKeepAlive();
+        QTRY_COMPARE(server.received().size(), 2);
+        QCOMPARE(server.received().last(), QStringLiteral("status"));
+    }
+
+    // The tick counter must reset on disconnect so a fresh connect cycle
+    // doesn't fire `status` early because of carry-over from the prior
+    // session. Without the onDisconnected() reset, this test would observe a
+    // `status` after only 1 tick on the second connect (8 - 7 prior ticks),
+    // not 8. Covers BOTH reset sites — onConnected() alone would mask the bug.
+    void keepAliveCounterResetsOnReconnect() {
+        FakeHdsServer server;
+        DecentScaleWifi driver;
+        connectAndHandshake(driver, server);
+
+        // Burn 7 ticks on the first connection so any carry-over would be
+        // exactly 1 tick away from firing on reconnect.
+        for (int i = 0; i < 7; ++i) driver.sendKeepAlive();
+
+        // Drop and reconnect.
+        QSignalSpy connSpy(&driver, &ScaleDevice::connectedChanged);
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(QStringLiteral("WebSocket disconnected.*peer close")));
+        server.closeFromServer();
+        QVERIFY(connSpy.wait(2000));
+        QVERIFY(!driver.isConnected());
+
+        // Clear before the second handshake — connectAndHandshake's wait
+        // condition is `received().size() >= 4`, which is already true from
+        // the first session and would let it return before the new handshake
+        // frames actually arrive.
+        server.clearReceived();
+        connectAndHandshake(driver, server);
+        server.clearReceived();
+
+        // After reconnect, the first seven ticks must still be silent.
+        for (int i = 0; i < 7; ++i) driver.sendKeepAlive();
+        QTest::qWait(100);
+        QCOMPARE(server.received().size(), 0);
+
+        driver.sendKeepAlive();
+        QTRY_COMPARE(server.received().size(), 1);
+        QCOMPARE(server.received().last(), QStringLiteral("status"));
+
+        // Driver destructor at scope exit triggers a SECOND DISCONNECTED warn.
+        // init()'s ignoreMessage only suppresses the first; queue another so the
+        // teardown warning doesn't leak through.
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*DISCONNECTED.*"));
+    }
+
     // ==========================================
     // Command surface
     // ==========================================


### PR DESCRIPTION
## Summary
- The Half Decent Scale's WS firmware previously auto-pushed a status frame every 5 s, so the WiFi driver only sent a single \`status\` request at connect time and relied on the push for ongoing battery/charging refreshes. Firmware is changing to no longer push unsolicited — without periodic polling, battery/charging would freeze at the connect-time value for the whole session.
- Drive the poll from the existing base-class \`m_keepAliveTimer\` (30 s tick, already started/stopped by \`setConnected()\`) with a counter: every 8th tick sends \`status\`, yielding a 240 s effective cadence that matches the BT driver's \`kBatteryPollHeartbeatTicks = 240 × 1 s heartbeat\`. No new timer.
- Counter reset on every connect cycle and on disconnect.

## Test plan
- [ ] Confirm initial \`status\` request still fires once on connect (\`tst_DecentScaleWifi::connectSendsRateAndEventsOn\` exercises the four-frame handshake).
- [ ] Leave the scale connected for ~5 minutes with the WS firmware not auto-pushing; verify a single \`status\` frame is received on the wire ~4 min after connect, and that battery_percent / charging propagate to the UI.
- [ ] Verify the counter resets across a reconnect (drop scale, reconnect; the first poll fires 4 min after the new connect, not at the residual tick from the prior session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)