### PR TITLE
feat(scale): parse session_info + log debug frames for Decent WiFi scale

### DIFF
--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -446,10 +446,11 @@ void DecentScaleWifi::handleStatusFrame(const QJsonObject& obj) {
 // protocol_version) and the boot-cause (reset_reason) into its own session_info
 // frame, sent unsolicited right after the WS handshake; the live status frame
 // no longer carries firmware_version / protocol_version. Older firmware put
-// them in status — handleStatusFrame still reads them there. Both paths assign
-// to the same m_firmwareVersion / m_loggedProtoVersion members with
-// change-detection, so a transitional firmware that sends both shapes only
-// logs once.
+// firmware_version and protocol_version in status — handleStatusFrame still
+// reads them there. For those two fields both paths assign to the same
+// m_firmwareVersion / m_loggedProtoVersion members with change-detection, so
+// a transitional firmware that sends both shapes only logs each once.
+// reset_reason has no legacy counterpart in status and is session_info-only.
 void DecentScaleWifi::handleSessionInfoFrame(const QJsonObject& obj) {
     onRecognizedAsHds();
 
@@ -479,13 +480,22 @@ void DecentScaleWifi::handleSessionInfoFrame(const QJsonObject& obj) {
     // reset_reason is the scale's boot-cause for the current session (e.g.
     // "poweron", "brownout", "watchdog"). Useful for triage — a watchdog reset
     // mid-session that we recover from looks identical at the WS layer to a
-    // user power-cycling the scale; reset_reason disambiguates them.
+    // user power-cycling the scale; reset_reason disambiguates them. Mirror
+    // firmware_version's severity policy: log the initial value at debug
+    // level (this is just the connect-time boot cause, informational), and
+    // warn-log any mid-connect change (the scale silently rebooted under us
+    // — that's an anomaly worth a triage line).
     const QJsonValue rr = obj.value(QStringLiteral("reset_reason"));
     if (rr.isString()) {
         const QString reason = rr.toString();
         if (!reason.isEmpty() && m_lastResetReason != reason) {
+            if (m_lastResetReason.isEmpty()) {
+                WIFI_LOG(QString("Scale reset reason: %1").arg(reason));
+            } else {
+                WIFI_WARN(QString("Scale reset reason changed mid-connect: %1 -> %2")
+                          .arg(m_lastResetReason, reason));
+            }
             m_lastResetReason = reason;
-            WIFI_LOG(QString("Scale reset reason: %1").arg(reason));
         }
     }
 }

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -330,6 +330,7 @@ void DecentScaleWifi::onDisconnected() {
     // Clear per-connect state so the next connect re-captures it fresh.
     m_firmwareVersion.clear();
     m_loggedProtoVersion = -1;
+    m_lastResetReason.clear();
     m_loggedFrameShapes.clear();
     m_lastPowerEventReason.clear();
     m_lastPowerEventCode = -1;
@@ -378,6 +379,8 @@ void DecentScaleWifi::onTextMessageReceived(const QString& message) {
 
     if (type == QStringLiteral("status")) {
         handleStatusFrame(obj);
+    } else if (type == QStringLiteral("session_info")) {
+        handleSessionInfoFrame(obj);
     } else if (type == QStringLiteral("button")) {
         handleButtonFrame(obj);
     } else if (type == QStringLiteral("power")) {
@@ -433,6 +436,54 @@ void DecentScaleWifi::handleStatusFrame(const QJsonObject& obj) {
         if (v != m_loggedProtoVersion) {
             m_loggedProtoVersion = v;
             WIFI_LOG(QString("Protocol version: %1").arg(v));
+        }
+    }
+}
+
+// Newer firmware separates connect-time identity (firmware_version,
+// protocol_version) and the boot-cause (reset_reason) into its own session_info
+// frame, sent unsolicited right after the WS handshake; the live status frame
+// no longer carries firmware_version / protocol_version. Older firmware put
+// them in status — handleStatusFrame still reads them there. Both paths assign
+// to the same m_firmwareVersion / m_loggedProtoVersion members with
+// change-detection, so a transitional firmware that sends both shapes only
+// logs once.
+void DecentScaleWifi::handleSessionInfoFrame(const QJsonObject& obj) {
+    onRecognizedAsHds();
+
+    const QJsonValue fwv = obj.value(QStringLiteral("firmware_version"));
+    if (fwv.isString()) {
+        const QString version = fwv.toString();
+        if (!version.isEmpty() && m_firmwareVersion != version) {
+            if (m_firmwareVersion.isEmpty()) {
+                WIFI_LOG(QString("Firmware version: %1").arg(version));
+            } else {
+                WIFI_WARN(QString("Firmware version changed mid-connect: %1 -> %2")
+                          .arg(m_firmwareVersion, version));
+            }
+            m_firmwareVersion = version;
+        }
+    }
+
+    const QJsonValue pv = obj.value(QStringLiteral("protocol_version"));
+    if (pv.isDouble()) {
+        const int v = pv.toInt();
+        if (v != m_loggedProtoVersion) {
+            m_loggedProtoVersion = v;
+            WIFI_LOG(QString("Protocol version: %1").arg(v));
+        }
+    }
+
+    // reset_reason is the scale's boot-cause for the current session (e.g.
+    // "poweron", "brownout", "watchdog"). Useful for triage — a watchdog reset
+    // mid-session that we recover from looks identical at the WS layer to a
+    // user power-cycling the scale; reset_reason disambiguates them.
+    const QJsonValue rr = obj.value(QStringLiteral("reset_reason"));
+    if (rr.isString()) {
+        const QString reason = rr.toString();
+        if (!reason.isEmpty() && m_lastResetReason != reason) {
+            m_lastResetReason = reason;
+            WIFI_LOG(QString("Scale reset reason: %1").arg(reason));
         }
     }
 }

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -381,6 +381,8 @@ void DecentScaleWifi::onTextMessageReceived(const QString& message) {
         handleStatusFrame(obj);
     } else if (type == QStringLiteral("session_info")) {
         handleSessionInfoFrame(obj);
+    } else if (type == QStringLiteral("debug")) {
+        handleDebugFrame(obj);
     } else if (type == QStringLiteral("button")) {
         handleButtonFrame(obj);
     } else if (type == QStringLiteral("power")) {
@@ -486,6 +488,21 @@ void DecentScaleWifi::handleSessionInfoFrame(const QJsonObject& obj) {
             WIFI_LOG(QString("Scale reset reason: %1").arg(reason));
         }
     }
+}
+
+// Debug frames carry firmware-internal health telemetry. Two shapes arrive
+// here:
+//   • Event-driven (unprompted, after `events on`): {"type":"debug",
+//     "event":"stall_start"|"stall_end"|"adc_recovery"|"temp_peak", ...}.
+//   • Full-state snapshot (response to a "debug" request — see
+//     requestDebugSnapshot()): {"type":"debug","status":"ok","soc_temp_c":...,
+//     "weight_stalled":..., "stall_count":..., ...}.
+// Log each verbatim — the firmware decides what to send, and a compact
+// one-line dump is the cheapest way to surface every signal for triage. We
+// don't filter or shape further until we know which fields actually matter.
+void DecentScaleWifi::handleDebugFrame(const QJsonObject& obj) {
+    const QByteArray json = QJsonDocument(obj).toJson(QJsonDocument::Compact);
+    WIFI_LOG(QString("Debug frame: %1").arg(QString::fromUtf8(json)));
 }
 
 void DecentScaleWifi::handleButtonFrame(const QJsonObject& obj) {
@@ -744,6 +761,10 @@ void DecentScaleWifi::sleep() {
     // The WS analog is send() returning success above. Emit immediately to
     // match BT's intent.
     emit sleepCompleted();
+}
+
+void DecentScaleWifi::requestDebugSnapshot() {
+    send(QStringLiteral("debug"));
 }
 
 void DecentScaleWifi::setLed(int r, int g, int b) {

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -90,6 +90,12 @@ public slots:
     void sendKeepAlive() override;
     void disconnectFromScale() override;
     void setLed(int r, int g, int b);
+    // Ask the scale to send a one-shot {"type":"debug","status":"ok",...}
+    // frame with full health state (SoC temps, stall counters, ADC recovery
+    // count). The response lands in handleDebugFrame and gets logged verbatim.
+    // Called from main.cpp on app suspend so the scale log has a snapshot of
+    // firmware state captured immediately before the app backgrounds.
+    void requestDebugSnapshot();
 
 private slots:
     void onConnected();
@@ -133,6 +139,7 @@ private:
     void handleSnapshotFrame(const QJsonObject& obj);
     void handleStatusFrame(const QJsonObject& obj);
     void handleSessionInfoFrame(const QJsonObject& obj);
+    void handleDebugFrame(const QJsonObject& obj);
     void handleButtonFrame(const QJsonObject& obj);
     void handlePowerFrame(const QJsonObject& obj);
     void handleRateFrame(const QJsonObject& obj);

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -132,6 +132,7 @@ private:
     void recreateSocket();
     void handleSnapshotFrame(const QJsonObject& obj);
     void handleStatusFrame(const QJsonObject& obj);
+    void handleSessionInfoFrame(const QJsonObject& obj);
     void handleButtonFrame(const QJsonObject& obj);
     void handlePowerFrame(const QJsonObject& obj);
     void handleRateFrame(const QJsonObject& obj);
@@ -175,8 +176,14 @@ private:
     int m_resolveGeneration = 0;
 
     QString m_name = QStringLiteral("Half Decent Scale (WiFi)");
-    QString m_firmwareVersion;   // cached per-connect; cleared on disconnect
-    int m_loggedProtoVersion = -1;  // protocol version last logged this connect; reset on disconnect
+    // firmware_version, protocol_version, and reset_reason all arrive in the
+    // session_info frame on every connect (newer firmware) and previously rode
+    // along in the status frame (older firmware still does). Cached per-connect
+    // so the same value arriving twice (e.g. status + session_info on a
+    // transitional firmware) doesn't spam the log; cleared on disconnect.
+    QString m_firmwareVersion;
+    int m_loggedProtoVersion = -1;
+    QString m_lastResetReason;
     // One sample of each distinct non-snapshot frame "type" is logged per
     // connect (see onTextMessageReceived) so the firmware's actual WS surface
     // is visible — notably whether it ever sends a status frame carrying

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2771,6 +2771,19 @@ int main(int argc, char *argv[])
             // before iOS can tear down CoreBluetooth. The bluetooth-central background mode
             // also helps by keeping CoreBluetooth alive longer during backgrounding.
             batteryManager.ensureChargerOn();
+
+            // Capture a debug snapshot from the WiFi scale right before we
+            // background. The scale WS stays connected through suspension on
+            // platforms with sufficient grace (Android foreground service, iOS
+            // bluetooth-central background mode), so the response usually lands
+            // in handleDebugFrame and gets logged before the event loop is
+            // frozen. If it doesn't, the request is still on the wire and
+            // costs nothing — and the answer arrives on the next resume.
+            if (auto* wifi = qobject_cast<DecentScaleWifi*>(physicalScale.get())) {
+                if (wifi->isConnected()) {
+                    wifi->requestDebugSnapshot();
+                }
+            }
         }
         else if (state == Qt::ApplicationActive && wasSuspended) {
             qDebug() << "App resumed from suspended state";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2773,12 +2773,16 @@ int main(int argc, char *argv[])
             batteryManager.ensureChargerOn();
 
             // Capture a debug snapshot from the WiFi scale right before we
-            // background. The scale WS stays connected through suspension on
-            // platforms with sufficient grace (Android foreground service, iOS
-            // bluetooth-central background mode), so the response usually lands
-            // in handleDebugFrame and gets logged before the event loop is
-            // frozen. If it doesn't, the request is still on the wire and
-            // costs nothing — and the answer arrives on the next resume.
+            // background. Fire-and-forget: we send the `debug` text command
+            // and don't wait for the reply. On Android the foreground service
+            // keeps the WS and event loop alive long enough that the response
+            // typically lands in handleDebugFrame and gets logged before
+            // backgrounding completes. iOS has no equivalent grace for plain
+            // TCP sockets — `bluetooth-central` background mode is for
+            // CoreBluetooth/BLE only, not WebSocket/TCP — so the WS will be
+            // suspended with the event loop and the reply lands on the next
+            // resume. Either way the request itself is on the wire and costs
+            // nothing.
             if (auto* wifi = qobject_cast<DecentScaleWifi*>(physicalScale.get())) {
                 if (wifi->isConnected()) {
                     wifi->requestDebugSnapshot();

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -371,6 +371,50 @@ private slots:
         QTest::qWait(50);
     }
 
+    // session_info is the new firmware's connect-time identity frame — it
+    // carries firmware_version, protocol_version, and reset_reason. The live
+    // status frame on new firmware no longer carries firmware_version /
+    // protocol_version, so without parsing session_info the scale log would
+    // never capture them on connect.
+    void sessionInfoFrameLogsFirmwareProtocolAndResetReason() {
+        FakeHdsServer server;
+        DecentScaleWifi driver;
+        connectAndHandshake(driver, server);
+
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Firmware version: FW: 3\\.0\\.9.*"));
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Protocol version: 1.*"));
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Scale reset reason: poweron.*"));
+        server.sendJson({
+            { "type", "session_info" },
+            { "firmware_version", "FW: 3.0.9" },
+            { "protocol_version", 1 },
+            { "reset_reason", "poweron" },
+        });
+        QTest::qWait(50);
+
+        // Re-sending the same session_info must not re-log — change-detection
+        // gates each field. Any further qDebug here would fail the test because
+        // no further ignoreMessage is queued.
+        server.sendJson({
+            { "type", "session_info" },
+            { "firmware_version", "FW: 3.0.9" },
+            { "protocol_version", 1 },
+            { "reset_reason", "poweron" },
+        });
+        QTest::qWait(50);
+
+        // A mid-connect reset_reason CHANGE must surface (a watchdog-induced
+        // reset mid-session is exactly what reset_reason exists to disambiguate
+        // from a clean power-cycle).
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Scale reset reason: watchdog.*"));
+        server.sendJson({{ "type", "session_info" }, { "reset_reason", "watchdog" }});
+        QTest::qWait(50);
+    }
+
     // Regression: the real firmware's status frame ALSO carries a `grams` field
     // (openscale README). Snapshots are distinguished by the ABSENCE of `type`,
     // so a status-with-grams must still reach the status handler — keying on the

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -415,6 +415,50 @@ private slots:
         QTest::qWait(50);
     }
 
+    // Debug frames (both event-driven and request-response shapes) are logged
+    // verbatim so every signal the firmware sends is captured in the scale
+    // log. We don't filter by event type — the firmware decides what's worth
+    // sending, and a one-line JSON dump is the cheapest triage surface.
+    void debugFramesAreLoggedVerbatim() {
+        FakeHdsServer server;
+        DecentScaleWifi driver;
+        connectAndHandshake(driver, server);
+
+        // Event-driven shape.
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Debug frame:.*\"event\":\"stall_start\".*\"stall_count\":1.*"));
+        server.sendJson({
+            { "type", "debug" }, { "event", "stall_start" },
+            { "stall_count", 1 }, { "last_stall_temp_c", 42.1 },
+        });
+        QTest::qWait(50);
+
+        // Full-state response shape (what requestDebugSnapshot() pulls back).
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Debug frame:.*\"soc_temp_c\":32\\.3.*\"weight_stalled\":false.*"));
+        server.sendJson({
+            { "type", "debug" }, { "status", "ok" },
+            { "soc_temp_c", 32.3 }, { "soc_temp_max_c", 32.3 },
+            { "weight_stalled", false }, { "stall_count", 0 },
+            { "adc_recovery_count", 0 }, { "ms", 29104 },
+        });
+        QTest::qWait(50);
+    }
+
+    // requestDebugSnapshot() sends the `debug` text command, which the
+    // firmware answers with a full-state debug frame. The app-suspend hook in
+    // main.cpp calls this so the scale log captures firmware state right
+    // before the app backgrounds.
+    void requestDebugSnapshotSendsDebugCommand() {
+        FakeHdsServer server;
+        DecentScaleWifi driver;
+        connectAndHandshake(driver, server);
+        server.clearReceived();
+
+        driver.requestDebugSnapshot();
+        QTRY_VERIFY(server.received().contains(QStringLiteral("debug")));
+    }
+
     // Regression: the real firmware's status frame ALSO carries a `grams` field
     // (openscale README). Snapshots are distinguished by the ABSENCE of `type`,
     // so a status-with-grams must still reach the status handler — keying on the

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -406,11 +406,12 @@ private slots:
         });
         QTest::qWait(50);
 
-        // A mid-connect reset_reason CHANGE must surface (a watchdog-induced
-        // reset mid-session is exactly what reset_reason exists to disambiguate
-        // from a clean power-cycle).
-        QTest::ignoreMessage(QtDebugMsg,
-            QRegularExpression(".*Scale reset reason: watchdog.*"));
+        // A mid-connect reset_reason CHANGE must surface at WARN (a
+        // watchdog-induced reset mid-session is exactly what reset_reason
+        // exists to disambiguate from a clean power-cycle), mirroring
+        // firmware_version's mid-connect-change severity.
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(".*Scale reset reason changed mid-connect: poweron -> watchdog.*"));
         server.sendJson({{ "type", "session_info" }, { "reset_reason", "watchdog" }});
         QTest::qWait(50);
     }
@@ -888,6 +889,35 @@ private slots:
             { "type", "status" },
             { "battery_percent", 80 },
             { "firmware_version", "FW: 3.0.9" },
+        });
+        QVERIFY(recognizedSpy.wait(500));
+        QCOMPARE(recognizedSpy.count(), 1);
+    }
+
+    // session_info is a new HDS-identifying frame on newer firmware: it
+    // arrives unprompted right after the WS handshake and carries
+    // firmware_version + protocol_version + reset_reason. It must trigger
+    // recognition on its own — if it doesn't, a manual "Add WiFi Scale" entry
+    // against a scale that sends session_info before any snapshot or status
+    // (which can happen since session_info is unsolicited) would dead-end at
+    // the 5 s recognition timeout.
+    void recognizedAsHdsFiresOnFirstSessionInfoFrame() {
+        FakeHdsServer server;
+        DecentScaleWifi driver;
+        QSignalSpy recognizedSpy(&driver, &DecentScaleWifi::recognizedAsHds);
+        connectAndHandshake(driver, server);
+
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Firmware version: FW: 3\\.0\\.9.*"));
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Protocol version: 1.*"));
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression(".*Scale reset reason: poweron.*"));
+        server.sendJson({
+            { "type", "session_info" },
+            { "firmware_version", "FW: 3.0.9" },
+            { "protocol_version", 1 },
+            { "reset_reason", "poweron" },
         });
         QVERIFY(recognizedSpy.wait(500));
         QCOMPARE(recognizedSpy.count(), 1);


### PR DESCRIPTION
## Summary

Two related fixes for the Decent WiFi scale driver, grouped so they land together.

### 1. Parse `session_info` frames (commit 1)

Newer HDS firmware moved `firmware_version` and `protocol_version` out of the live `status` frame and into a dedicated `session_info` frame sent unsolicited once per connect; it also added a new `reset_reason` field there. Confirmed in production logs from the test tablet today.

- New `handleSessionInfoFrame()` captures `firmware_version` and `protocol_version` with the same change-detection logic used for status, and logs `reset_reason` (`poweron` / `brownout` / `watchdog` / …) so a watchdog reset mid-session is distinguishable from a clean power-cycle at triage time.
- Old-firmware status-frame parsing for `firmware_version` / `protocol_version` left in place. Both paths assign to the same members, so a transitional firmware that emits both shapes only logs once.
- `m_lastResetReason` cleared on disconnect alongside the other per-connect state.

### 2. Log debug frames + request snapshot on app suspend (commit 2)

The HDS firmware sends debug-event frames unprompted once `events on` is opted into (`stall_start` / `stall_end` / `adc_recovery` / `temp_peak`), and responds to a `debug` text command with a full-state snapshot (`soc_temp_c`, `soc_temp_max_c`, `weight_stalled`, `stall_count`, `last_stall_ms`, `last_stall_temp_c`, `adc_recovery_count`, `ms`).

- `handleDebugFrame()` logs each debug frame verbatim as compact JSON. Both shapes land here and get one log line carrying every field — no filtering, since we don't yet know which fields matter most.
- New `DecentScaleWifi::requestDebugSnapshot()` sends the `debug` text command.
- `main.cpp`'s existing `applicationStateChanged → Qt::ApplicationSuspended` hook calls it (qobject_cast guard so other scale types are a no-op) so the scale log captures firmware state immediately before the app backgrounds.

## Test plan

- [x] `tst_DecentScaleWifi` — all 34 tests pass with no warnings.
- New tests in this PR:
  - `sessionInfoFrameLogsFirmwareProtocolAndResetReason` — first-log, re-send-silent, mid-connect-change.
  - `debugFramesAreLoggedVerbatim` — covers both the event-driven and request-response debug-frame shapes.
  - `requestDebugSnapshotSendsDebugCommand` — verifies the suspend-time request sends the `debug` text command.
- [ ] On a real tablet: connect a WiFi HDS, confirm scale log shows `Firmware version: …`, `Protocol version: …`, `Scale reset reason: …` once per connect (from session_info on new firmware, from status on old firmware).
- [ ] Background the app and confirm the scale log shows `Debug frame: {"type":"debug","status":"ok",…}` capturing the full firmware state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)