### PR TITLE
connections: replace Known Scales picker with a proper ComboBox

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1157,7 +1157,18 @@ Item {
                                     border.width: 1
                                 }
 
-                                // Closed-state content: live status dot + name + transport badge + chevron.
+                                // Custom indicator (chevron) replacing the default
+                                // so we don't end up with two stacked chevrons.
+                                indicator: Text {
+                                    x: scalePicker.width - width - Theme.scaled(10)
+                                    y: (scalePicker.height - height) / 2
+                                    text: "\u25BC"
+                                    font.pixelSize: Theme.scaled(10)
+                                    color: Theme.textSecondaryColor
+                                }
+
+                                // Closed-state content: live status dot + name + transport badge.
+                                // The chevron is drawn by `indicator` above.
                                 contentItem: RowLayout {
                                     spacing: Theme.scaled(6)
 
@@ -1197,6 +1208,7 @@ Item {
                                         height: Theme.scaled(18)
                                         radius: Theme.scaled(9)
                                         color: Qt.rgba(Theme.accentColor.r, Theme.accentColor.g, Theme.accentColor.b, 0.22)
+                                        Layout.rightMargin: Theme.scaled(24)
                                         Text {
                                             id: badgeText
                                             anchors.centerIn: parent
@@ -1205,14 +1217,6 @@ Item {
                                             font.pixelSize: Theme.scaled(10)
                                             font.bold: true
                                         }
-                                    }
-
-                                    Text {
-                                        Layout.rightMargin: Theme.scaled(10)
-                                        text: "\u25BC"
-                                        font.pixelSize: Theme.scaled(10)
-                                        color: Theme.textSecondaryColor
-                                        Accessible.ignored: true
                                     }
                                 }
 
@@ -1278,7 +1282,9 @@ Item {
                                     topPadding: Theme.scaled(4)
                                     bottomPadding: Theme.scaled(4)
                                     // Cap visible height at `visibleRows`; longer lists scroll.
-                                    height: Math.min(scalePicker.count, scalePicker.visibleRows) * scalePicker.rowHeight
+                                    // Drive sizing off the model length directly — ComboBox.count
+                                    // can lag behind a QVariantList model after refresh.
+                                    height: Math.min(Settings.knownScales.length, scalePicker.visibleRows) * scalePicker.rowHeight
                                             + topPadding + bottomPadding
 
                                     contentItem: ListView {

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1147,11 +1147,18 @@ Item {
 
                                 onActivated: function(index) {
                                     var scales = Settings.knownScales
-                                    if (index < 0 || index >= scales.length) return
+                                    if (index < 0 || index >= scales.length) {
+                                        // TOCTOU: scan/forget mutated the model between
+                                        // the user's tap and this handler. Log so we can
+                                        // tell this apart from a no-op re-select.
+                                        console.warn("scalePicker: stale activated index", index,
+                                                     "model length", scales.length)
+                                        return
+                                    }
                                     var scale = scales[index]
                                     if (scale.isPrimary) return
                                     Settings.setPrimaryScale(scale.address)
-                                    BLEManager.setSavedScaleAddress(scale.address, scale.type, scale.name)
+                                    BLEManager.setSavedScaleAddress(scale.address, scale.type, scale["name"])
                                     BLEManager.connectToSavedScale()
                                 }
 
@@ -1233,8 +1240,17 @@ Item {
                                     height: scalePicker.rowHeight
                                     highlighted: scalePicker.highlightedIndex === index
 
+                                    // `modelData["name"]` (bracket form) bypasses
+                                    // QML's reserved-property lookup on `name`
+                                    // — defensive per docs/CLAUDE_MD/QML_GOTCHAS.md
+                                    // even though QVariantMap-backed models work
+                                    // with dot notation in practice.
+                                    readonly property string _label:
+                                        modelData["name"] || modelData.type ||
+                                        TranslationManager.translate("settings.bluetooth.unknownScale", "Unknown scale")
+
                                     Accessible.role: Accessible.Button
-                                    Accessible.name: (modelData.name || modelData.type)
+                                    Accessible.name: _label
                                                      + " " + scalePicker.transportLabel(modelData.type)
                                                      + (modelData.isPrimary
                                                         ? ", " + TranslationManager.translate("connections.primary", "primary")
@@ -1255,7 +1271,7 @@ Item {
 
                                         Text {
                                             Layout.fillWidth: true
-                                            text: modelData.name || modelData.type
+                                            text: scaleRowDelegate._label
                                             color: Theme.textColor
                                             font.pixelSize: Theme.scaled(13)
                                             font.bold: modelData.isPrimary

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1287,9 +1287,23 @@ Item {
                                     }
                                 }
 
-                                popup: Popup {
+                                // Use a Dialog (not Popup) so TalkBack can trap
+                                // focus inside the dropdown list and navigate
+                                // rows. Dialog inherits from Popup, so it's a
+                                // drop-in for ComboBox.popup. We position it
+                                // exactly where the Popup used to render, with
+                                // no header/footer/buttons, so the visual is
+                                // unchanged — only the accessibility tree
+                                // changes (TalkBack sees a modal it can enter).
+                                // See ACCESSIBILITY.md "Popup for selection lists".
+                                popup: Dialog {
                                     y: scalePicker.height
                                     width: scalePicker.width
+                                    modal: true
+                                    header: null
+                                    footer: null
+                                    standardButtons: Dialog.NoButton
+                                    closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
                                     // Pin paddings so the style can't override them
                                     // and silently eat into the visible row count.
                                     leftPadding: 0
@@ -1302,8 +1316,17 @@ Item {
                                     height: Math.min(Settings.knownScales.length, scalePicker.visibleRows) * scalePicker.rowHeight
                                             + topPadding + bottomPadding
 
+                                    // Move keyboard focus into the list when the
+                                    // dropdown opens so TalkBack/VoiceOver lands
+                                    // on the first row (or the current primary)
+                                    // instead of leaving focus on the ComboBox.
+                                    onOpened: scaleDropdownList.forceActiveFocus()
+
                                     contentItem: ListView {
+                                        id: scaleDropdownList
                                         clip: true
+                                        focus: true
+                                        keyNavigationEnabled: true
                                         model: scalePicker.popup.visible ? scalePicker.delegateModel : null
                                         currentIndex: scalePicker.highlightedIndex
                                         ScrollIndicator.vertical: ScrollIndicator {}

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1092,82 +1092,203 @@ Item {
                             Layout.fillWidth: true
                             spacing: Theme.scaled(8)
 
-                            // Primary scale display / picker button
-                            Rectangle {
+                            // Primary scale picker \u2014 proper Qt ComboBox so the
+                            // affordance always matches the behavior. The popup
+                            // is capped at 3 visible rows; longer lists scroll
+                            // inline instead of opening a separate dialog.
+                            ComboBox {
+                                id: scalePicker
                                 Layout.fillWidth: true
-                                height: Theme.scaled(36)
-                                radius: Theme.scaled(6)
-                                color: Qt.rgba(Theme.accentColor.r, Theme.accentColor.g, Theme.accentColor.b, 0.12)
-                                border.color: Theme.accentColor
-                                border.width: 1
+                                Layout.preferredHeight: Theme.scaled(36)
 
-                                Accessible.role: Accessible.Button
-                                Accessible.name: {
+                                readonly property int rowHeight: Theme.scaled(40)
+                                readonly property int visibleRows: 3
+
+                                function indexOfPrimary() {
                                     var scales = Settings.knownScales
                                     for (var i = 0; i < scales.length; i++) {
-                                        if (scales[i].isPrimary) {
-                                            var label = scales[i].name || scales[i].type
-                                            if (scales.length > 1)
-                                                return label + ". " + TranslationManager.translate("settings.bluetooth.tapToChange", "Tap to change")
-                                            return label
-                                        }
+                                        if (scales[i].isPrimary) return i
                                     }
-                                    return TranslationManager.translate("settings.bluetooth.selectScale", "Select scale")
+                                    return -1
                                 }
-                                Accessible.focusable: true
-                                Accessible.onPressAction: scalePickerArea.clicked(null)
+                                function primaryLabel() {
+                                    var scales = Settings.knownScales
+                                    for (var i = 0; i < scales.length; i++) {
+                                        if (scales[i].isPrimary)
+                                            return scales[i].name || scales[i].type
+                                    }
+                                    return TranslationManager.translate("settings.bluetooth.noScale", "No scale selected")
+                                }
+                                function transportLabel(typeId) {
+                                    if (!typeId) return ""
+                                    if (typeId === "decent-wifi") return "WiFi"
+                                    if (typeId === "decent-usb") return "USB"
+                                    return "BLE"
+                                }
 
-                                RowLayout {
-                                    anchors.fill: parent
-                                    anchors.leftMargin: Theme.scaled(10)
-                                    anchors.rightMargin: Theme.scaled(10)
+                                model: Settings.knownScales
+                                currentIndex: indexOfPrimary()
+
+                                // Re-sync when the underlying list (or which one is primary) changes.
+                                Connections {
+                                    target: Settings
+                                    function onKnownScalesChanged() {
+                                        scalePicker.currentIndex = scalePicker.indexOfPrimary()
+                                    }
+                                }
+
+                                Accessible.role: Accessible.ComboBox
+                                Accessible.name: primaryLabel()
+
+                                onActivated: function(index) {
+                                    var scales = Settings.knownScales
+                                    if (index < 0 || index >= scales.length) return
+                                    var scale = scales[index]
+                                    if (scale.isPrimary) return
+                                    Settings.setPrimaryScale(scale.address)
+                                    BLEManager.setSavedScaleAddress(scale.address, scale.type, scale.name)
+                                    BLEManager.connectToSavedScale()
+                                }
+
+                                background: Rectangle {
+                                    radius: Theme.scaled(6)
+                                    color: Qt.rgba(Theme.accentColor.r, Theme.accentColor.g, Theme.accentColor.b, 0.12)
+                                    border.color: Theme.accentColor
+                                    border.width: 1
+                                }
+
+                                // Closed-state content: live status dot + name + transport badge + chevron.
+                                contentItem: RowLayout {
                                     spacing: Theme.scaled(6)
 
-                                    Image {
-                                        source: "qrc:/icons/star.svg"
-                                        sourceSize.width: Theme.scaled(14)
-                                        sourceSize.height: Theme.scaled(14)
+                                    Rectangle {
+                                        Layout.leftMargin: Theme.scaled(10)
+                                        width: Theme.scaled(8)
+                                        height: Theme.scaled(8)
+                                        radius: Theme.scaled(4)
+                                        color: (ScaleDevice && ScaleDevice.connected)
+                                               ? Theme.successColor
+                                               : Theme.textSecondaryColor
                                         Accessible.ignored: true
                                     }
 
                                     Text {
-                                        text: {
-                                            // Show the human-readable name when present; fall back to
-                                            // the internal type code only when the saved scale has no
-                                            // name (older entries from before user-friendly naming).
-                                            // The prior implementation appended "(<type>)" to the name
-                                            // whenever they differed, producing ugly "Decent Scale (WiFi)
-                                            // (decent-wifi)" labels for the WiFi variant.
-                                            var scales = Settings.knownScales
-                                            for (var i = 0; i < scales.length; i++) {
-                                                if (scales[i].isPrimary)
-                                                    return scales[i].name || scales[i].type
-                                            }
-                                            return TranslationManager.translate("settings.bluetooth.noScale", "No scale selected")
-                                        }
+                                        Layout.fillWidth: true
+                                        text: scalePicker.primaryLabel()
                                         color: Theme.textColor
                                         font.pixelSize: Theme.scaled(13)
                                         font.bold: true
-                                        Layout.fillWidth: true
                                         elide: Text.ElideRight
+                                        verticalAlignment: Text.AlignVCenter
                                         Accessible.ignored: true
                                     }
 
+                                    Rectangle {
+                                        property string badge: {
+                                            var scales = Settings.knownScales
+                                            for (var i = 0; i < scales.length; i++) {
+                                                if (scales[i].isPrimary)
+                                                    return scalePicker.transportLabel(scales[i].type)
+                                            }
+                                            return ""
+                                        }
+                                        visible: badge.length > 0
+                                        width: badgeText.implicitWidth + Theme.scaled(10)
+                                        height: Theme.scaled(18)
+                                        radius: Theme.scaled(9)
+                                        color: Qt.rgba(Theme.accentColor.r, Theme.accentColor.g, Theme.accentColor.b, 0.22)
+                                        Text {
+                                            id: badgeText
+                                            anchors.centerIn: parent
+                                            text: parent.badge
+                                            color: Theme.accentColor
+                                            font.pixelSize: Theme.scaled(10)
+                                            font.bold: true
+                                        }
+                                    }
+
                                     Text {
+                                        Layout.rightMargin: Theme.scaled(10)
                                         text: "\u25BC"
                                         font.pixelSize: Theme.scaled(10)
                                         color: Theme.textSecondaryColor
-                                        visible: Settings.knownScales.length > 1
                                         Accessible.ignored: true
                                     }
                                 }
 
-                                MouseArea {
-                                    id: scalePickerArea
-                                    anchors.fill: parent
-                                    onClicked: {
-                                        if (Settings.knownScales.length > 1)
-                                            knownScaleDialog.open()
+                                // Per-row delegate: star (filled on primary) + name + transport badge.
+                                delegate: ItemDelegate {
+                                    width: scalePicker.width
+                                    height: scalePicker.rowHeight
+                                    highlighted: scalePicker.highlightedIndex === index
+
+                                    contentItem: RowLayout {
+                                        spacing: Theme.scaled(8)
+
+                                        Image {
+                                            source: "qrc:/icons/star.svg"
+                                            sourceSize.width: Theme.scaled(14)
+                                            sourceSize.height: Theme.scaled(14)
+                                            opacity: modelData.isPrimary ? 1.0 : 0.25
+                                            Accessible.ignored: true
+                                        }
+
+                                        Text {
+                                            Layout.fillWidth: true
+                                            text: modelData.name || modelData.type
+                                            color: Theme.textColor
+                                            font.pixelSize: Theme.scaled(13)
+                                            font.bold: modelData.isPrimary
+                                            elide: Text.ElideRight
+                                            verticalAlignment: Text.AlignVCenter
+                                        }
+
+                                        Rectangle {
+                                            property string badge: scalePicker.transportLabel(modelData.type)
+                                            visible: badge.length > 0
+                                            width: rowBadgeText.implicitWidth + Theme.scaled(10)
+                                            height: Theme.scaled(18)
+                                            radius: Theme.scaled(9)
+                                            color: Qt.rgba(Theme.accentColor.r, Theme.accentColor.g, Theme.accentColor.b, 0.2)
+                                            Text {
+                                                id: rowBadgeText
+                                                anchors.centerIn: parent
+                                                text: parent.badge
+                                                color: Theme.accentColor
+                                                font.pixelSize: Theme.scaled(10)
+                                                font.bold: true
+                                            }
+                                        }
+                                    }
+
+                                    background: Rectangle {
+                                        color: highlighted
+                                               ? Qt.rgba(Theme.accentColor.r, Theme.accentColor.g, Theme.accentColor.b, 0.18)
+                                               : "transparent"
+                                    }
+                                }
+
+                                popup: Popup {
+                                    y: scalePicker.height
+                                    width: scalePicker.width
+                                    padding: 1
+                                    // Cap visible height at `visibleRows`; longer lists scroll.
+                                    height: Math.min(scalePicker.count, scalePicker.visibleRows) * scalePicker.rowHeight
+                                            + topPadding + bottomPadding
+
+                                    contentItem: ListView {
+                                        clip: true
+                                        implicitHeight: contentHeight
+                                        model: scalePicker.popup.visible ? scalePicker.delegateModel : null
+                                        currentIndex: scalePicker.highlightedIndex
+                                        ScrollIndicator.vertical: ScrollIndicator {}
+                                    }
+
+                                    background: Rectangle {
+                                        radius: Theme.scaled(6)
+                                        color: Theme.surfaceColor
+                                        border.color: Theme.accentColor
+                                        border.width: 1
                                     }
                                 }
                             }
@@ -1663,41 +1784,4 @@ Item {
         }
     }
 
-    // Known scales picker dialog
-    SelectionDialog {
-        id: knownScaleDialog
-        title: TranslationManager.translate("settings.bluetooth.knownScales", "Known Scales")
-        options: {
-            // Use human-readable name when present; fall back to type only
-            // when the saved scale has no name (older saved entries from
-            // before user-friendly naming). Don't append the type code to
-            // names that already convey the transport (e.g. avoid the
-            // "Decent Scale (WiFi) (decent-wifi)" double-paren label).
-            var scales = Settings.knownScales
-            var labels = []
-            for (var i = 0; i < scales.length; i++) {
-                labels.push(scales[i].name || scales[i].type)
-            }
-            return labels
-        }
-        currentIndex: {
-            var scales = Settings.knownScales
-            for (var i = 0; i < scales.length; i++) {
-                if (scales[i].isPrimary) return i
-            }
-            return -1
-        }
-        onSelected: function(index, value) {
-            var scales = Settings.knownScales
-            if (index >= 0 && index < scales.length) {
-                var scale = scales[index]
-                if (scale.isPrimary) return  // re-selected the current primary — nothing to switch
-                Settings.setPrimaryScale(scale.address)
-                BLEManager.setSavedScaleAddress(scale.address, scale.type, scale.name)
-                // Actually switch the live connection to the chosen scale, so the
-                // "Connected:" status updates instead of staying on the old one.
-                BLEManager.connectToSavedScale()
-            }
-        }
-    }
 }

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1101,7 +1101,7 @@ Item {
                                 Layout.fillWidth: true
                                 Layout.preferredHeight: Theme.scaled(36)
 
-                                readonly property int rowHeight: Theme.scaled(40)
+                                readonly property int rowHeight: Theme.scaled(44)
                                 readonly property int visibleRows: 3
 
                                 function indexOfPrimary() {
@@ -1271,14 +1271,18 @@ Item {
                                 popup: Popup {
                                     y: scalePicker.height
                                     width: scalePicker.width
-                                    padding: 1
+                                    // Pin paddings so the style can't override them
+                                    // and silently eat into the visible row count.
+                                    leftPadding: 0
+                                    rightPadding: 0
+                                    topPadding: Theme.scaled(4)
+                                    bottomPadding: Theme.scaled(4)
                                     // Cap visible height at `visibleRows`; longer lists scroll.
                                     height: Math.min(scalePicker.count, scalePicker.visibleRows) * scalePicker.rowHeight
                                             + topPadding + bottomPadding
 
                                     contentItem: ListView {
                                         clip: true
-                                        implicitHeight: contentHeight
                                         model: scalePicker.popup.visible ? scalePicker.delegateModel : null
                                         currentIndex: scalePicker.highlightedIndex
                                         ScrollIndicator.vertical: ScrollIndicator {}

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1141,6 +1141,9 @@ Item {
                                 Accessible.role: Accessible.ComboBox
                                 Accessible.name: primaryLabel()
                                 Accessible.focusable: true
+                                // TalkBack double-tap "activate" → open the
+                                // dropdown. Mirrors the StyledComboBox pattern.
+                                Accessible.onPressAction: if (!scalePicker.popup.visible) scalePicker.popup.open()
 
                                 onActivated: function(index) {
                                     var scales = Settings.knownScales
@@ -1318,9 +1321,12 @@ Item {
 
                                     // Move keyboard focus into the list when the
                                     // dropdown opens so TalkBack/VoiceOver lands
-                                    // on the first row (or the current primary)
-                                    // instead of leaving focus on the ComboBox.
-                                    onOpened: scaleDropdownList.forceActiveFocus()
+                                    // on the highlighted row (the primary on
+                                    // first open) instead of leaving focus on
+                                    // the ComboBox. Defer via Qt.callLater so
+                                    // the delegate items are guaranteed to be
+                                    // realized before focus is requested.
+                                    onOpened: Qt.callLater(scaleDropdownList.forceActiveFocus)
 
                                     contentItem: ListView {
                                         id: scaleDropdownList

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -969,7 +969,8 @@ Item {
                         }
                     }
 
-                    // Connected BLE scale name + battery
+                    // Connected scale name + battery (transport-agnostic; the
+                    // header above already routes BLE/WiFi/USB through this same row).
                     RowLayout {
                         Layout.fillWidth: true
                         visible: ScaleDevice && ScaleDevice.connected && !ScaleDevice.isFlowScale
@@ -1139,6 +1140,7 @@ Item {
 
                                 Accessible.role: Accessible.ComboBox
                                 Accessible.name: primaryLabel()
+                                Accessible.focusable: true
 
                                 onActivated: function(index) {
                                     var scales = Settings.knownScales
@@ -1223,9 +1225,19 @@ Item {
 
                                 // Per-row delegate: star (filled on primary) + name + transport badge.
                                 delegate: ItemDelegate {
+                                    id: scaleRowDelegate
                                     width: scalePicker.width
                                     height: scalePicker.rowHeight
                                     highlighted: scalePicker.highlightedIndex === index
+
+                                    Accessible.role: Accessible.Button
+                                    Accessible.name: (modelData.name || modelData.type)
+                                                     + " " + scalePicker.transportLabel(modelData.type)
+                                                     + (modelData.isPrimary
+                                                        ? ", " + TranslationManager.translate("connections.primary", "primary")
+                                                        : "")
+                                    Accessible.focusable: true
+                                    Accessible.onPressAction: scaleRowDelegate.clicked()
 
                                     contentItem: RowLayout {
                                         spacing: Theme.scaled(8)
@@ -1246,6 +1258,7 @@ Item {
                                             font.bold: modelData.isPrimary
                                             elide: Text.ElideRight
                                             verticalAlignment: Text.AlignVCenter
+                                            Accessible.ignored: true
                                         }
 
                                         Rectangle {
@@ -1255,6 +1268,7 @@ Item {
                                             height: Theme.scaled(18)
                                             radius: Theme.scaled(9)
                                             color: Qt.rgba(Theme.accentColor.r, Theme.accentColor.g, Theme.accentColor.b, 0.2)
+                                            Accessible.ignored: true
                                             Text {
                                                 id: rowBadgeText
                                                 anchors.centerIn: parent

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1157,18 +1157,12 @@ Item {
                                     border.width: 1
                                 }
 
-                                // Custom indicator (chevron) replacing the default
-                                // so we don't end up with two stacked chevrons.
-                                indicator: Text {
-                                    x: scalePicker.width - width - Theme.scaled(10)
-                                    y: (scalePicker.height - height) / 2
-                                    text: "\u25BC"
-                                    font.pixelSize: Theme.scaled(10)
-                                    color: Theme.textSecondaryColor
-                                }
+                                // Suppress the default style indicator entirely
+                                // and draw a single chevron at the end of the
+                                // contentItem layout, so there's only one arrow.
+                                indicator: Item { width: 0; height: 0 }
 
-                                // Closed-state content: live status dot + name + transport badge.
-                                // The chevron is drawn by `indicator` above.
+                                // Closed-state content: live status dot + name + transport badge + chevron.
                                 contentItem: RowLayout {
                                     spacing: Theme.scaled(6)
 
@@ -1208,7 +1202,6 @@ Item {
                                         height: Theme.scaled(18)
                                         radius: Theme.scaled(9)
                                         color: Qt.rgba(Theme.accentColor.r, Theme.accentColor.g, Theme.accentColor.b, 0.22)
-                                        Layout.rightMargin: Theme.scaled(24)
                                         Text {
                                             id: badgeText
                                             anchors.centerIn: parent
@@ -1217,6 +1210,14 @@ Item {
                                             font.pixelSize: Theme.scaled(10)
                                             font.bold: true
                                         }
+                                    }
+
+                                    Text {
+                                        Layout.rightMargin: Theme.scaled(10)
+                                        text: "\u25BC"
+                                        font.pixelSize: Theme.scaled(10)
+                                        color: Theme.textSecondaryColor
+                                        Accessible.ignored: true
                                     }
                                 }
 


### PR DESCRIPTION
## Summary
- Replaces the custom rectangle + hidden `SelectionDialog` picker on the Connections settings page with a real Qt `ComboBox`. The previous control looked like a status indicator (red-bordered card, star icon) but was actually a dropdown trigger — and only when `knownScales.length > 1` (the chevron was conditional). The refractometer row right beneath it used a nearly identical visual but wasn't interactive at all, which made the picker even more confusing.
- The closed control now shows: live connection dot · primary scale name · transport badge (`BLE` / `WiFi` / `USB`) · always-present chevron.
- The popup is capped at **3 visible rows**, with a `ScrollIndicator` for longer lists — works cleanly when the user has 5+ saved scales without opening a modal dialog.
- Per-row delegate: filled star on the primary, dimmed star on others, name, transport badge.
- Same selection wiring as before: `Settings.setPrimaryScale` + `BLEManager.setSavedScaleAddress` + `connectToSavedScale`. The standalone `knownScaleDialog` `SelectionDialog` is deleted.

## Test plan
- [ ] With 0 saved scales: Known Devices section stays hidden (unchanged behavior).
- [ ] With 1 saved scale: ComboBox shows the scale, chevron present; tapping opens a popup with one entry that re-selecting is a no-op.
- [ ] With 2–4 saved scales: popup shows all rows, no scrolling.
- [ ] With 5+ saved scales: popup shows 3 rows and scrolls; star indicator clearly marks the primary.
- [ ] Selecting a non-primary row promotes it: closed control updates, `Connected:` status switches over to the new scale.
- [ ] `Forget` removes the primary and the ComboBox re-syncs to the next primary (existing behavior preserved).
- [ ] Mixed transports: badge reads `WiFi` for `decent-wifi`, `USB` for `decent-usb`, `BLE` for everything else.
- [ ] Refractometer row below still renders and Forget still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)