### PR TITLE
feat(scale): request scale debug snapshot from screensaver and MCP

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -3135,7 +3135,7 @@ ApplicationWindow {
         // main.cpp, but reachable on desktop too (the in-app screensaver
         // doesn't transition Qt's app state to Suspended on macOS). No-op
         // for non-Decent-WiFi scales via the base-class virtual.
-        if (typeof ScaleDevice !== "undefined" && ScaleDevice && ScaleDevice.isConnected) {
+        if (ScaleDevice && ScaleDevice.connected) {
             ScaleDevice.requestDebugSnapshot()
         }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -3130,6 +3130,15 @@ ApplicationWindow {
         // Reset sleep counter (stopped state)
         root.sleepCountdownNormal = 0
 
+        // Capture a debug snapshot from the WiFi scale at the screensaver
+        // boundary — same intent as the Qt::ApplicationSuspended hook in
+        // main.cpp, but reachable on desktop too (the in-app screensaver
+        // doesn't transition Qt's app state to Suspended on macOS). No-op
+        // for non-Decent-WiFi scales via the base-class virtual.
+        if (typeof ScaleDevice !== "undefined" && ScaleDevice && ScaleDevice.isConnected) {
+            ScaleDevice.requestDebugSnapshot()
+        }
+
         // Close any open popups to prevent burn-in (Qt Popup renders above the
         // StackView on the overlay layer, so the screensaver can't cover them).
         // Re-queue so they show after wake. screensaverActive is already true,

--- a/src/ble/scaledevice.h
+++ b/src/ble/scaledevice.h
@@ -64,6 +64,7 @@ public slots:
     virtual void wake() {}   // Wake scale from sleep (enable LCD)
     virtual void disableLcd() {}  // Turn off LCD but keep scale powered (for screensaver)
     virtual void sendKeepAlive() {}  // Override to send BLE keepalive (e.g., re-enable notifications)
+    virtual void requestDebugSnapshot() {}  // Ask the scale to send a one-shot full-state debug frame. No-op for scales without debug telemetry; Decent WiFi sends the `debug` text command.
     virtual void disconnectFromScale();  // Disconnect BLE from scale
     void resetFlowCalculation();  // Call after tare to avoid flow rate spikes
 

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -93,9 +93,11 @@ public slots:
     // Ask the scale to send a one-shot {"type":"debug","status":"ok",...}
     // frame with full health state (SoC temps, stall counters, ADC recovery
     // count). The response lands in handleDebugFrame and gets logged verbatim.
-    // Called from main.cpp on app suspend so the scale log has a snapshot of
-    // firmware state captured immediately before the app backgrounds.
-    void requestDebugSnapshot();
+    // Triggered from three places: main.cpp on Qt::ApplicationSuspended (real
+    // OS backgrounding), main.qml's goToScreensaver() (the in-app screensaver,
+    // which Mac never reaches Suspended for), and the MCP tool
+    // devices_request_scale_debug for on-demand triage from the AI/MCP surface.
+    void requestDebugSnapshot() override;
 
 private slots:
     void onConnected();

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -94,9 +94,10 @@ public slots:
     // frame with full health state (SoC temps, stall counters, ADC recovery
     // count). The response lands in handleDebugFrame and gets logged verbatim.
     // Triggered from three places: main.cpp on Qt::ApplicationSuspended (real
-    // OS backgrounding), main.qml's goToScreensaver() (the in-app screensaver,
-    // which Mac never reaches Suspended for), and the MCP tool
-    // devices_request_scale_debug for on-demand triage from the AI/MCP surface.
+    // OS backgrounding); goToScreensaver() in QML (covers the in-app
+    // screensaver path, which macOS never delivers as Qt::ApplicationSuspended);
+    // and the MCP tool devices_request_scale_debug for on-demand triage from
+    // the AI/MCP surface.
     void requestDebugSnapshot() override;
 
 private slots:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2772,21 +2772,20 @@ int main(int argc, char *argv[])
             // also helps by keeping CoreBluetooth alive longer during backgrounding.
             batteryManager.ensureChargerOn();
 
-            // Capture a debug snapshot from the WiFi scale right before we
-            // background. Fire-and-forget: we send the `debug` text command
-            // and don't wait for the reply. On Android the foreground service
-            // keeps the WS and event loop alive long enough that the response
-            // typically lands in handleDebugFrame and gets logged before
-            // backgrounding completes. iOS has no equivalent grace for plain
-            // TCP sockets — `bluetooth-central` background mode is for
-            // CoreBluetooth/BLE only, not WebSocket/TCP — so the WS will be
+            // Capture a debug snapshot from the active scale right before
+            // we background. Fire-and-forget — the request goes on the wire,
+            // the reply (if any) lands in the scale-driver's frame handler.
+            // On Android the foreground service keeps the WS and event loop
+            // alive long enough that the reply usually arrives pre-suspend.
+            // iOS has no equivalent grace for plain TCP sockets — the WS is
             // suspended with the event loop and the reply lands on the next
-            // resume. Either way the request itself is on the wire and costs
-            // nothing.
-            if (auto* wifi = qobject_cast<DecentScaleWifi*>(physicalScale.get())) {
-                if (wifi->isConnected()) {
-                    wifi->requestDebugSnapshot();
-                }
+            // resume. Either way the request itself costs nothing. No-op for
+            // scales without a debug-snapshot command via the base virtual.
+            // The in-app screensaver path is separate — handled directly in
+            // QML's goToScreensaver() since macOS apps never reach Suspended
+            // for an in-app dim/screensaver.
+            if (physicalScale && physicalScale->isConnected()) {
+                physicalScale->requestDebugSnapshot();
             }
         }
         else if (state == Qt::ApplicationActive && wasSuspended) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2777,7 +2777,8 @@ int main(int argc, char *argv[])
             // the reply (if any) lands in the scale-driver's frame handler.
             // On Android the foreground service keeps the WS and event loop
             // alive long enough that the reply usually arrives pre-suspend.
-            // iOS has no equivalent grace for plain TCP sockets — the WS is
+            // iOS has no equivalent grace for plain TCP sockets (CoreBluetooth-
+            // style background modes cover BLE, not WS/TCP), so the WS is
             // suspended with the event loop and the reply lands on the next
             // resume. Either way the request itself costs nothing. No-op for
             // scales without a debug-snapshot command via the base virtual.

--- a/src/mcp/mcptools_devices.cpp
+++ b/src/mcp/mcptools_devices.cpp
@@ -384,7 +384,8 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
         "the Half Decent Scale over WiFi responds — the response is written "
         "to the scale log (visible in debug_get_log) and carries SoC "
         "temperature, weight-ADC stall counters, and the ADC-recovery "
-        "attempt counter. Other scales return success with a no-op note.",
+        "attempt counter. On scales without a debug-frame command the "
+        "request is silently dropped.",
         QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
         [bleManager](const QJsonObject&) -> QJsonObject {
             QJsonObject result;
@@ -397,10 +398,21 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
                 result["error"] = "No scale connected";
                 return result;
             }
-            QMetaObject::invokeMethod(scale, "requestDebugSnapshot", Qt::QueuedConnection);
+            // String-keyed invokeMethod can silently no-op if the slot
+            // disappears in a refactor (rename, lost Q_INVOKABLE / public-slots
+            // visibility). For a diagnostic tool, that's the worst possible
+            // outcome: caller is told "success" while nothing was queued.
+            // Capture the bool so a wiring regression surfaces as an error.
+            const bool queued = QMetaObject::invokeMethod(
+                scale, "requestDebugSnapshot", Qt::QueuedConnection);
+            if (!queued) {
+                result["error"] = "Failed to queue requestDebugSnapshot — "
+                                  "slot not found on active scale driver";
+                return result;
+            }
             result["success"] = true;
             result["message"] = "Debug snapshot requested — check the scale log for the response frame";
             return result;
         },
-        "read");
+        "control");
 }

--- a/src/mcp/mcptools_devices.cpp
+++ b/src/mcp/mcptools_devices.cpp
@@ -2,6 +2,7 @@
 #include "mcptoolregistry.h"
 #include "../ble/blemanager.h"
 #include "../ble/de1device.h"
+#include "../ble/scaledevice.h"
 
 #include <QJsonObject>
 #include <QJsonArray>
@@ -369,4 +370,37 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
             return result;
         },
         "control");
+
+    // devices_request_scale_debug — ask the active scale to emit a full-state
+    // debug frame on the wire. Logged verbatim by handleDebugFrame; useful for
+    // on-demand triage when the AI/MCP layer wants to see firmware-internal
+    // health (SoC temp, ADC stalls, recovery counter) without waiting for an
+    // app-suspend or screensaver event. No-op on non-Decent-WiFi scales (the
+    // base-class virtual is empty); other drivers don't have a debug snapshot
+    // to request.
+    registry->registerTool(
+        "devices_request_scale_debug",
+        "Ask the active scale to emit a debug-state frame. Currently only "
+        "the Half Decent Scale over WiFi responds — the response is written "
+        "to the scale log (visible in debug_get_log) and carries SoC "
+        "temperature, weight-ADC stall counters, and the ADC-recovery "
+        "attempt counter. Other scales return success with a no-op note.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
+        [bleManager](const QJsonObject&) -> QJsonObject {
+            QJsonObject result;
+            if (!bleManager) {
+                result["error"] = "BLE manager not available";
+                return result;
+            }
+            ScaleDevice* scale = bleManager->scaleDevice();
+            if (!scale || !scale->isConnected()) {
+                result["error"] = "No scale connected";
+                return result;
+            }
+            QMetaObject::invokeMethod(scale, "requestDebugSnapshot", Qt::QueuedConnection);
+            result["success"] = true;
+            result["message"] = "Debug snapshot requested — check the scale log for the response frame";
+            return result;
+        },
+        "read");
 }


### PR DESCRIPTION
## Summary

Two new trigger paths for the WiFi-scale debug snapshot that PR #1287 wired up. The suspend-only hook from #1287 is effectively dead on macOS (Qt's app state doesn't transition to \`Suspended\` for the in-app screensaver), so the debug-snapshot path was untested on desktop until now.

- **QML screensaver hook** — \`main.qml::goToScreensaver()\` calls \`ScaleDevice.requestDebugSnapshot()\` when the in-app screensaver activates. Reachable on desktop, harmless on Android/iOS where \`Qt::ApplicationSuspended\` also fires the original main.cpp hook.
- **\`devices_request_scale_debug\` MCP tool** — on-demand debug snapshot from the AI/MCP surface. Triage-only access level (\`read\`), no-op on non-Decent-WiFi scales.

To make both paths reachable through \`ScaleDevice*\` without qobject_cast, promote \`requestDebugSnapshot()\` to a virtual no-op slot on \`ScaleDevice\` and mark the \`DecentScaleWifi\` override accordingly. The existing main.cpp suspend hook is simplified to call the base virtual directly.

## Test plan

- [x] \`tst_DecentScaleWifi\` — all 35 pass with no warnings.
- [x] MCP tool tests (\`tst_McpToolsProfiles\`, \`tst_McpToolsWrite\`, \`tst_McpServerProtocol\`, \`tst_McpServerSession\`) — all 69 pass.
- [ ] On the Mac dev build: trigger the screensaver and confirm \`Debug frame: …\` appears in the scale log within 1-2 s.
- [ ] Via MCP: call \`devices_request_scale_debug\` from a conversation and confirm the same debug-frame line appears in \`debug_get_log\` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)