### PR TITLE
fix(scale): recover lost WiFi scale connection without user intervention

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -893,14 +893,25 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
             && m_savedScaleType == QStringLiteral("decent-wifi")
             && scaleType == QStringLiteral("decent");
 
-        // Auto-connect rules:
-        //   • Saved primary → always auto-connect (even on user-initiated scans).
-        //     The user's "Scan" tap when their scale is offline is itself a
-        //     "please reconnect" — the original "don't hijack the user's pick"
-        //     concern doesn't apply when the found scale IS what they previously
-        //     chose as primary. This restores the natural "scan got my scale
-        //     back" flow that was previously only reachable via an awkward
-        //     BT-then-WiFi switch dance.
+        // Auto-connect rules (BLE path — WiFi has its own handler in
+        // the WifiScaleDiscovery::scaleFound lambda further down):
+        //   • Saved BLE primary → always auto-connect (even on user-initiated
+        //     scans). The user's "Scan" tap when their scale is offline is
+        //     itself a "please reconnect" — the original "don't hijack the
+        //     user's pick" concern doesn't apply when the found scale IS what
+        //     they previously chose as primary. The companion "don't silently
+        //     re-save a forgotten scale via addKnownScale()" concern is also
+        //     inert here: the scale is already saved, so the re-save is a
+        //     no-op against the same record. This restores the natural "scan
+        //     got my scale back" flow that was previously only reachable via
+        //     an awkward BT-then-WiFi switch dance.
+        //
+        //     Note: this rule only fires for BLE primaries. When the saved
+        //     primary is `wifi:hostname`, deviceIdentifiersMatch can never
+        //     return true here (BLE devices don't carry hostnames), so a
+        //     WiFi-primary user scanning while looking at BLE devices falls
+        //     through to the list-only branch. The WiFi handler below mirrors
+        //     this rule for the WiFi-primary case.
         //   • WiFi→BLE fallback candidate → auto-connect (the #440-violating
         //     "accept a Decent BLE scale as a substitute" path; opt-in via the
         //     m_wifiFallbackToBleActive gate).
@@ -1196,6 +1207,13 @@ void BLEManager::beginWifiFallbackToBleScan() {
             m_flowScaleFallbackEmitted = true;
             emit flowScaleFallback();
         }
+        // Honor the scaleRetryNeeded contract: this is a connection-failure
+        // give-up that must re-arm the retry ladder, just like the equivalent
+        // branch in onScaleConnectionTimeout. Without this, a user with a
+        // saved WiFi scale offline AND Bluetooth disabled would be stuck on
+        // FlowScale until they manually re-engaged — the exact bug class this
+        // PR is fixing.
+        emit scaleRetryNeeded();
         return;
     }
 

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -893,43 +893,40 @@ void BLEManager::onDeviceDiscovered(const QBluetoothDeviceInfo& device) {
             && m_savedScaleType == QStringLiteral("decent-wifi")
             && scaleType == QStringLiteral("decent");
 
-        // A user-initiated scan only POPULATES the discovered list (m_scales,
-        // above) for the user to choose from — it must NOT auto-connect. Auto-
-        // connecting here would grab the first scale found (hijacking the user's
-        // pick — e.g. connecting the BLE Decent scale when the user wants the
-        // WiFi one) and, via the scaleDiscovered handler's unconditional
-        // addKnownScale(), silently re-save a scale the user just forgot. So a
-        // forgotten scale would reappear on the next scan. Explicit selection
-        // from the list goes through connectToScale(), which emits its own
-        // scaleDiscovered.
-        if (m_userInitiatedScaleScan) {
-            return;
-        }
+        // Auto-connect rules:
+        //   • Saved primary → always auto-connect (even on user-initiated scans).
+        //     The user's "Scan" tap when their scale is offline is itself a
+        //     "please reconnect" — the original "don't hijack the user's pick"
+        //     concern doesn't apply when the found scale IS what they previously
+        //     chose as primary. This restores the natural "scan got my scale
+        //     back" flow that was previously only reachable via an awkward
+        //     BT-then-WiFi switch dance.
+        //   • WiFi→BLE fallback candidate → auto-connect (the #440-violating
+        //     "accept a Decent BLE scale as a substitute" path; opt-in via the
+        //     m_wifiFallbackToBleActive gate).
+        //   • Anything else during a user-initiated scan → list only, don't
+        //     hijack the user's pick. The user explicitly selects via the UI
+        //     (connectToScale()).
+        //   • Anything else in a background scan → ignore (no auto-connect to
+        //     non-primaries — #440 — and don't silently re-save a scale the
+        //     user just forgot via the scaleDiscovered handler's
+        //     addKnownScale()/setPrimaryScale()).
+        const bool matchesSaved = !m_savedScaleAddress.isEmpty()
+            && deviceIdentifiersMatch(device, m_savedScaleAddress);
 
-        // Auto-reconnect path: only connect to the saved primary scale — #440:
-        // don't let a nearby non-primary scale hijack auto-reconnect — unless
-        // this is the WiFi-to-BLE fallback accepting a Decent BLE substitute.
-        if (!isFallbackCandidate) {
-            // With no saved primary (e.g. the user just forgot the scale) there
-            // is nothing to auto-reconnect to. Leave the scale in the discovered
-            // list (appended above) for explicit selection, but do NOT emit —
-            // emitting auto-connects and, via the scaleDiscovered handler's
-            // addKnownScale()/setPrimaryScale(), silently re-saves the scale the
-            // user just forgot. It would then reappear as a Known Device on the
-            // next *background* scan (refractometer/DE1 scan, startup probe) and,
-            // because buildCombinedModel filters Known Devices out of the
-            // discovered list, never show up there again — so "Forget" appears
-            // not to stick. Explicit selection from the list goes through
-            // connectToScale(), which emits its own scaleDiscovered.
+        if (!isFallbackCandidate && !matchesSaved) {
+            if (m_userInitiatedScaleScan) {
+                // User is choosing — leave the discovered scale in the list
+                // for explicit selection. (Appended to m_scales above.)
+                return;
+            }
             if (m_savedScaleAddress.isEmpty()) {
                 appendScaleLog(QString("No saved scale — listing %1 for manual selection (no auto-connect)")
                                .arg(device.name()));
                 return;
             }
-            if (!deviceIdentifiersMatch(device, m_savedScaleAddress)) {
-                appendScaleLog(QString("Ignoring non-primary scale: %1 (%2)").arg(device.name(), getDeviceIdentifier(device)));
-                return;
-            }
+            appendScaleLog(QString("Ignoring non-primary scale: %1 (%2)").arg(device.name(), getDeviceIdentifier(device)));
+            return;
         }
 
         if (isFallbackCandidate) {
@@ -1169,6 +1166,16 @@ void BLEManager::onScaleConnectionTimeout() {
         appendScaleLog("Scale not found - using FlowScale");
         emit flowScaleFallback();
     }
+
+    // Always emit the retry-arm signal — even when the dialog gate has
+    // already fired. flowScaleFallback is the dialog trigger (gated to one
+    // shot per saved-scale cycle so the "No Scale Found" notice doesn't
+    // re-pop on every retry); scaleRetryNeeded is the retry-ladder trigger
+    // and must keep firing. Without this, a WiFi→BLE fallback whose own
+    // BLE attempt also times out used to fall into a silent dead end: the
+    // reconnect timer in main.cpp had been stopped by the scale-type
+    // change, and there was no signal that re-armed it.
+    emit scaleRetryNeeded();
 }
 
 void BLEManager::beginWifiFallbackToBleScan() {
@@ -1602,13 +1609,13 @@ void BLEManager::ensureWifiDiscovery() {
                 qDebug() << "[BLE] WiFi scale already in discovered list — not re-adding";
             }
 
-            // Auto-connect when the discovered scale matches the saved primary
-            // AND we're not in a user-initiated scan (where the user is choosing
-            // explicitly — list only, don't auto-connect). Covers both paths:
-            // saved-scale direct-wake on app start AND a spontaneous scan that
-            // happens to find the saved scale.
-            if (!m_userInitiatedScaleScan
-                    && !m_savedScaleAddress.isEmpty()
+            // Auto-connect when the discovered scale matches the saved primary,
+            // including during user-initiated scans. Matching the saved primary
+            // is itself the anti-hijack guard — see the matching reasoning on
+            // the BLE path in onDeviceDiscovered. Covers both paths:
+            // saved-scale direct-wake on app start AND a spontaneous (or
+            // user-initiated) scan that happens to find the saved scale.
+            if (!m_savedScaleAddress.isEmpty()
                     && address.compare(m_savedScaleAddress, Qt::CaseInsensitive) == 0) {
                 m_pendingWifiHostname = hostname;
                 emit scaleDiscovered(QBluetoothDeviceInfo{}, QStringLiteral("decent-wifi"));

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -458,7 +458,8 @@ signals:
     void errorOccurred(const QString& error);
     void de1LogMessage(const QString& message);
     void scaleLogMessage(const QString& message);
-    void flowScaleFallback();  // Emitted when no physical scale found, using FlowScale
+    void flowScaleFallback();  // Emitted when no physical scale found, using FlowScale (gated to fire once per saved-scale cycle so the "No Scale Found" dialog doesn't re-show on every retry)
+    void scaleRetryNeeded();   // Emitted on EVERY connection-failure path (including the post-WiFi→BLE-fallback give-up), regardless of the flowScaleFallback gate, so the persistent reconnect ladder in main.cpp survives the scale-type-change timer stop. Don't bind UI to this — it's for re-arming the retry timer only.
     void scaleDisconnected();  // Emitted when physical scale disconnects
     void scaleConnected();     // Emitted when a physical scale (re)connects — lets the UI dismiss the scale-disconnect / no-scale notice
     void scanStarted();  // Emitted when BLE scan actually begins

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1318,6 +1318,31 @@ int main(int argc, char *argv[])
         qDebug() << "Scale reconnect: scheduled first retry in" << reconnectDelays[0] << "ms (startup failure)";
     });
 
+    // Re-arm the reconnect ladder on EVERY scale-connection failure, not just
+    // the first one. flowScaleFallback above is gated to fire once per saved-
+    // scale cycle (so the "No Scale Found" dialog doesn't re-pop on every
+    // retry), but the retry timer itself must survive the WiFi→BLE-fallback
+    // failure case: the scale-type change in that path stops scaleReconnectTimer
+    // (see "Scale reconnect: timer stopped due to scale type change" below),
+    // and without this signal there was no path to start it back up. The
+    // timer's own slot self-perpetuates once running, so we just need to start
+    // it once per failure cycle — the slot will keep it going. Uses the long-
+    // tail delay (60 s) because the immediate failure has already happened;
+    // hammering harder would just churn the WiFi radio.
+    QObject::connect(&bleManager, &BLEManager::scaleRetryNeeded,
+                     [&settings, &bleManager, &scaleReconnectTimer, &scaleReconnectAttempt,
+                      &reconnectDelays, &scaleAutoReconnectSuppressed]() {
+        if (settings.scaleAddress().isEmpty()) return;
+        if (settings.scaleAddress().startsWith(QStringLiteral("usb:"), Qt::CaseInsensitive)) return;
+        if (scaleAutoReconnectSuppressed) return;
+        if (scaleReconnectTimer.isActive()) return;
+        scaleReconnectAttempt = static_cast<int>(reconnectDelays.size()) - 1;
+        scaleReconnectTimer.start(reconnectDelays.back());
+        bleManager.appendScaleLog(QString("Scheduling reconnect in %1 s (retry after failure)")
+                                  .arg(reconnectDelays.back() / 1000));
+        qDebug() << "Scale reconnect: scheduled retry in" << reconnectDelays.back() << "ms (after failure)";
+    });
+
     // === Proactive switch-back to the WiFi primary scale ===
     // When the saved primary is a WiFi scale but we're currently on the BLE
     // backup (the WiFi->BLE fallback connected after WiFi was unreachable),


### PR DESCRIPTION
## Summary

Two interacting bugs that left the WiFi scale stuck "disconnected" for ~9 minutes in a real-world log, recoverable only by manually switching scales (BT → WiFi). The scale was reachable on the network the entire time.

### (1) User-initiated scan refused to auto-connect to the saved primary

\`BLEManager::onDeviceDiscovered\` (BLE path) and the WiFi \`scaleFound\` handler both gated auto-connect on \`!m_userInitiatedScaleScan\`. The original anti-hijack concern (don't grab the first non-primary scale found) only applies to non-primary scales — matching the saved primary is itself the anti-hijack guard, and a user's "Scan" tap when their scale is offline is a "please reconnect" intent.

Restructured both paths so the user-scan guard runs *after* the saved-primary match check:
- Saved primary discovered → auto-connect (any scan source).
- WiFi→BLE fallback candidate → auto-connect (existing #440-violating opt-in).
- Anything else during a user scan → list-only.
- Anything else in a background scan → ignore.

### (2) Reconnect ladder died after WiFi→BLE fallback failed

\`flowScaleFallback\` is intentionally gated to one shot per saved-scale cycle (otherwise the "No Scale Found" dialog re-pops on every retry). The reconnect timer in \`main.cpp\` was only armed via that signal, so when the WiFi→BLE fallback also failed:

1. \`scaleReconnectTimer\` had been stopped by the scale-type change (\`"Scale reconnect: timer stopped due to scale type change"\`).
2. The second \`onScaleConnectionTimeout\` hit the fall-through, but \`m_flowScaleFallbackEmitted\` was already \`true\` → no \`flowScaleFallback\` emission → timer stayed stopped.
3. Auto-recovery dead-ended.

Added a separate \`scaleRetryNeeded\` signal that fires unconditionally from the same fall-through, paired with a small re-arm handler in main.cpp. The timer's own slot self-perpetuates once started, so this only kicks it off once per failure cycle — at the long-tail 60 s delay (immediate hammering is wasteful since the failure just happened). Saved primary is then retried until it comes back online.

## Test plan

- [ ] Repro the log scenario: start the app while the WiFi scale is in deep sleep (radio off), let the WiFi→BLE fallback fail, then leave the app idle. Within ~60 s of the scale's WiFi coming back, the app should auto-connect — no manual switch required.
- [ ] User scan with no scale connected: confirm the WiFi scale auto-connects as soon as it's discovered (instead of just appearing in the list).
- [ ] User scan with a different scale picker intent: confirm non-primary scales still appear in the list without auto-connecting.
- [ ] Forget scale → background scan should NOT silently re-save (same as before — guarded by the empty-saved-address check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)