### PR TITLE
revert(scale): drop debug-snapshot + session_info — firmware no longer supports them

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -3130,15 +3130,6 @@ ApplicationWindow {
         // Reset sleep counter (stopped state)
         root.sleepCountdownNormal = 0
 
-        // Capture a debug snapshot from the WiFi scale at the screensaver
-        // boundary — same intent as the Qt::ApplicationSuspended hook in
-        // main.cpp, but reachable on desktop too (the in-app screensaver
-        // doesn't transition Qt's app state to Suspended on macOS). No-op
-        // for non-Decent-WiFi scales via the base-class virtual.
-        if (ScaleDevice && ScaleDevice.connected) {
-            ScaleDevice.requestDebugSnapshot()
-        }
-
         // Close any open popups to prevent burn-in (Qt Popup renders above the
         // StackView on the overlay layer, so the screensaver can't cover them).
         // Re-queue so they show after wake. screensaverActive is already true,

--- a/src/ble/scaledevice.h
+++ b/src/ble/scaledevice.h
@@ -64,7 +64,6 @@ public slots:
     virtual void wake() {}   // Wake scale from sleep (enable LCD)
     virtual void disableLcd() {}  // Turn off LCD but keep scale powered (for screensaver)
     virtual void sendKeepAlive() {}  // Override to send BLE keepalive (e.g., re-enable notifications)
-    virtual void requestDebugSnapshot() {}  // Ask the scale to send a one-shot full-state debug frame. No-op for scales without debug telemetry; Decent WiFi sends the `debug` text command.
     virtual void disconnectFromScale();  // Disconnect BLE from scale
     void resetFlowCalculation();  // Call after tare to avoid flow rate spikes
 

--- a/src/ble/scales/decentscalewifi.cpp
+++ b/src/ble/scales/decentscalewifi.cpp
@@ -330,7 +330,6 @@ void DecentScaleWifi::onDisconnected() {
     // Clear per-connect state so the next connect re-captures it fresh.
     m_firmwareVersion.clear();
     m_loggedProtoVersion = -1;
-    m_lastResetReason.clear();
     m_loggedFrameShapes.clear();
     m_lastPowerEventReason.clear();
     m_lastPowerEventCode = -1;
@@ -379,10 +378,6 @@ void DecentScaleWifi::onTextMessageReceived(const QString& message) {
 
     if (type == QStringLiteral("status")) {
         handleStatusFrame(obj);
-    } else if (type == QStringLiteral("session_info")) {
-        handleSessionInfoFrame(obj);
-    } else if (type == QStringLiteral("debug")) {
-        handleDebugFrame(obj);
     } else if (type == QStringLiteral("button")) {
         handleButtonFrame(obj);
     } else if (type == QStringLiteral("power")) {
@@ -440,79 +435,6 @@ void DecentScaleWifi::handleStatusFrame(const QJsonObject& obj) {
             WIFI_LOG(QString("Protocol version: %1").arg(v));
         }
     }
-}
-
-// Newer firmware separates connect-time identity (firmware_version,
-// protocol_version) and the boot-cause (reset_reason) into its own session_info
-// frame, sent unsolicited right after the WS handshake; the live status frame
-// no longer carries firmware_version / protocol_version. Older firmware put
-// firmware_version and protocol_version in status — handleStatusFrame still
-// reads them there. For those two fields both paths assign to the same
-// m_firmwareVersion / m_loggedProtoVersion members with change-detection, so
-// a transitional firmware that sends both shapes only logs each once.
-// reset_reason has no legacy counterpart in status and is session_info-only.
-void DecentScaleWifi::handleSessionInfoFrame(const QJsonObject& obj) {
-    onRecognizedAsHds();
-
-    const QJsonValue fwv = obj.value(QStringLiteral("firmware_version"));
-    if (fwv.isString()) {
-        const QString version = fwv.toString();
-        if (!version.isEmpty() && m_firmwareVersion != version) {
-            if (m_firmwareVersion.isEmpty()) {
-                WIFI_LOG(QString("Firmware version: %1").arg(version));
-            } else {
-                WIFI_WARN(QString("Firmware version changed mid-connect: %1 -> %2")
-                          .arg(m_firmwareVersion, version));
-            }
-            m_firmwareVersion = version;
-        }
-    }
-
-    const QJsonValue pv = obj.value(QStringLiteral("protocol_version"));
-    if (pv.isDouble()) {
-        const int v = pv.toInt();
-        if (v != m_loggedProtoVersion) {
-            m_loggedProtoVersion = v;
-            WIFI_LOG(QString("Protocol version: %1").arg(v));
-        }
-    }
-
-    // reset_reason is the scale's boot-cause for the current session (e.g.
-    // "poweron", "brownout", "watchdog"). Useful for triage — a watchdog reset
-    // mid-session that we recover from looks identical at the WS layer to a
-    // user power-cycling the scale; reset_reason disambiguates them. Mirror
-    // firmware_version's severity policy: log the initial value at debug
-    // level (this is just the connect-time boot cause, informational), and
-    // warn-log any mid-connect change (the scale silently rebooted under us
-    // — that's an anomaly worth a triage line).
-    const QJsonValue rr = obj.value(QStringLiteral("reset_reason"));
-    if (rr.isString()) {
-        const QString reason = rr.toString();
-        if (!reason.isEmpty() && m_lastResetReason != reason) {
-            if (m_lastResetReason.isEmpty()) {
-                WIFI_LOG(QString("Scale reset reason: %1").arg(reason));
-            } else {
-                WIFI_WARN(QString("Scale reset reason changed mid-connect: %1 -> %2")
-                          .arg(m_lastResetReason, reason));
-            }
-            m_lastResetReason = reason;
-        }
-    }
-}
-
-// Debug frames carry firmware-internal health telemetry. Two shapes arrive
-// here:
-//   • Event-driven (unprompted, after `events on`): {"type":"debug",
-//     "event":"stall_start"|"stall_end"|"adc_recovery"|"temp_peak", ...}.
-//   • Full-state snapshot (response to a "debug" request — see
-//     requestDebugSnapshot()): {"type":"debug","status":"ok","soc_temp_c":...,
-//     "weight_stalled":..., "stall_count":..., ...}.
-// Log each verbatim — the firmware decides what to send, and a compact
-// one-line dump is the cheapest way to surface every signal for triage. We
-// don't filter or shape further until we know which fields actually matter.
-void DecentScaleWifi::handleDebugFrame(const QJsonObject& obj) {
-    const QByteArray json = QJsonDocument(obj).toJson(QJsonDocument::Compact);
-    WIFI_LOG(QString("Debug frame: %1").arg(QString::fromUtf8(json)));
 }
 
 void DecentScaleWifi::handleButtonFrame(const QJsonObject& obj) {
@@ -771,10 +693,6 @@ void DecentScaleWifi::sleep() {
     // The WS analog is send() returning success above. Emit immediately to
     // match BT's intent.
     emit sleepCompleted();
-}
-
-void DecentScaleWifi::requestDebugSnapshot() {
-    send(QStringLiteral("debug"));
 }
 
 void DecentScaleWifi::setLed(int r, int g, int b) {

--- a/src/ble/scales/decentscalewifi.h
+++ b/src/ble/scales/decentscalewifi.h
@@ -90,15 +90,6 @@ public slots:
     void sendKeepAlive() override;
     void disconnectFromScale() override;
     void setLed(int r, int g, int b);
-    // Ask the scale to send a one-shot {"type":"debug","status":"ok",...}
-    // frame with full health state (SoC temps, stall counters, ADC recovery
-    // count). The response lands in handleDebugFrame and gets logged verbatim.
-    // Triggered from three places: main.cpp on Qt::ApplicationSuspended (real
-    // OS backgrounding); goToScreensaver() in QML (covers the in-app
-    // screensaver path, which macOS never delivers as Qt::ApplicationSuspended);
-    // and the MCP tool devices_request_scale_debug for on-demand triage from
-    // the AI/MCP surface.
-    void requestDebugSnapshot() override;
 
 private slots:
     void onConnected();
@@ -141,8 +132,6 @@ private:
     void recreateSocket();
     void handleSnapshotFrame(const QJsonObject& obj);
     void handleStatusFrame(const QJsonObject& obj);
-    void handleSessionInfoFrame(const QJsonObject& obj);
-    void handleDebugFrame(const QJsonObject& obj);
     void handleButtonFrame(const QJsonObject& obj);
     void handlePowerFrame(const QJsonObject& obj);
     void handleRateFrame(const QJsonObject& obj);
@@ -186,14 +175,11 @@ private:
     int m_resolveGeneration = 0;
 
     QString m_name = QStringLiteral("Half Decent Scale (WiFi)");
-    // firmware_version, protocol_version, and reset_reason all arrive in the
-    // session_info frame on every connect (newer firmware) and previously rode
-    // along in the status frame (older firmware still does). Cached per-connect
-    // so the same value arriving twice (e.g. status + session_info on a
-    // transitional firmware) doesn't spam the log; cleared on disconnect.
+    // firmware_version and protocol_version arrive in the status frame.
+    // Cached per-connect so the same value arriving repeatedly doesn't spam
+    // the log; cleared on disconnect.
     QString m_firmwareVersion;
     int m_loggedProtoVersion = -1;
-    QString m_lastResetReason;
     // One sample of each distinct non-snapshot frame "type" is logged per
     // connect (see onTextMessageReceived) so the firmware's actual WS surface
     // is visible — notably whether it ever sends a status frame carrying

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2796,23 +2796,6 @@ int main(int argc, char *argv[])
             // before iOS can tear down CoreBluetooth. The bluetooth-central background mode
             // also helps by keeping CoreBluetooth alive longer during backgrounding.
             batteryManager.ensureChargerOn();
-
-            // Capture a debug snapshot from the active scale right before
-            // we background. Fire-and-forget — the request goes on the wire,
-            // the reply (if any) lands in the scale-driver's frame handler.
-            // On Android the foreground service keeps the WS and event loop
-            // alive long enough that the reply usually arrives pre-suspend.
-            // iOS has no equivalent grace for plain TCP sockets (CoreBluetooth-
-            // style background modes cover BLE, not WS/TCP), so the WS is
-            // suspended with the event loop and the reply lands on the next
-            // resume. Either way the request itself costs nothing. No-op for
-            // scales without a debug-snapshot command via the base virtual.
-            // The in-app screensaver path is separate — handled directly in
-            // QML's goToScreensaver() since macOS apps never reach Suspended
-            // for an in-app dim/screensaver.
-            if (physicalScale && physicalScale->isConnected()) {
-                physicalScale->requestDebugSnapshot();
-            }
         }
         else if (state == Qt::ApplicationActive && wasSuspended) {
             qDebug() << "App resumed from suspended state";

--- a/src/mcp/mcptools_devices.cpp
+++ b/src/mcp/mcptools_devices.cpp
@@ -2,7 +2,6 @@
 #include "mcptoolregistry.h"
 #include "../ble/blemanager.h"
 #include "../ble/de1device.h"
-#include "../ble/scaledevice.h"
 
 #include <QJsonObject>
 #include <QJsonArray>
@@ -367,51 +366,6 @@ void registerDeviceTools(McpToolRegistry* registry, BLEManager* bleManager, DE1D
             bleManager->clearSavedScale();
             result["success"] = true;
             result["message"] = "Scale disconnected and forgotten";
-            return result;
-        },
-        "control");
-
-    // devices_request_scale_debug — ask the active scale to emit a full-state
-    // debug frame on the wire. Logged verbatim by handleDebugFrame; useful for
-    // on-demand triage when the AI/MCP layer wants to see firmware-internal
-    // health (SoC temp, ADC stalls, recovery counter) without waiting for an
-    // app-suspend or screensaver event. No-op on non-Decent-WiFi scales (the
-    // base-class virtual is empty); other drivers don't have a debug snapshot
-    // to request.
-    registry->registerTool(
-        "devices_request_scale_debug",
-        "Ask the active scale to emit a debug-state frame. Currently only "
-        "the Half Decent Scale over WiFi responds — the response is written "
-        "to the scale log (visible in debug_get_log) and carries SoC "
-        "temperature, weight-ADC stall counters, and the ADC-recovery "
-        "attempt counter. On scales without a debug-frame command the "
-        "request is silently dropped.",
-        QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
-        [bleManager](const QJsonObject&) -> QJsonObject {
-            QJsonObject result;
-            if (!bleManager) {
-                result["error"] = "BLE manager not available";
-                return result;
-            }
-            ScaleDevice* scale = bleManager->scaleDevice();
-            if (!scale || !scale->isConnected()) {
-                result["error"] = "No scale connected";
-                return result;
-            }
-            // String-keyed invokeMethod can silently no-op if the slot
-            // disappears in a refactor (rename, lost Q_INVOKABLE / public-slots
-            // visibility). For a diagnostic tool, that's the worst possible
-            // outcome: caller is told "success" while nothing was queued.
-            // Capture the bool so a wiring regression surfaces as an error.
-            const bool queued = QMetaObject::invokeMethod(
-                scale, "requestDebugSnapshot", Qt::QueuedConnection);
-            if (!queued) {
-                result["error"] = "Failed to queue requestDebugSnapshot — "
-                                  "slot not found on active scale driver";
-                return result;
-            }
-            result["success"] = true;
-            result["message"] = "Debug snapshot requested — check the scale log for the response frame";
             return result;
         },
         "control");

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -371,95 +371,6 @@ private slots:
         QTest::qWait(50);
     }
 
-    // session_info is the new firmware's connect-time identity frame — it
-    // carries firmware_version, protocol_version, and reset_reason. The live
-    // status frame on new firmware no longer carries firmware_version /
-    // protocol_version, so without parsing session_info the scale log would
-    // never capture them on connect.
-    void sessionInfoFrameLogsFirmwareProtocolAndResetReason() {
-        FakeHdsServer server;
-        DecentScaleWifi driver;
-        connectAndHandshake(driver, server);
-
-        QTest::ignoreMessage(QtDebugMsg,
-            QRegularExpression(".*Firmware version: FW: 3\\.0\\.9.*"));
-        QTest::ignoreMessage(QtDebugMsg,
-            QRegularExpression(".*Protocol version: 1.*"));
-        QTest::ignoreMessage(QtDebugMsg,
-            QRegularExpression(".*Scale reset reason: poweron.*"));
-        server.sendJson({
-            { "type", "session_info" },
-            { "firmware_version", "FW: 3.0.9" },
-            { "protocol_version", 1 },
-            { "reset_reason", "poweron" },
-        });
-        QTest::qWait(50);
-
-        // Re-sending the same session_info must not re-log — change-detection
-        // gates each field. Any further qDebug here would fail the test because
-        // no further ignoreMessage is queued.
-        server.sendJson({
-            { "type", "session_info" },
-            { "firmware_version", "FW: 3.0.9" },
-            { "protocol_version", 1 },
-            { "reset_reason", "poweron" },
-        });
-        QTest::qWait(50);
-
-        // A mid-connect reset_reason CHANGE must surface at WARN (a
-        // watchdog-induced reset mid-session is exactly what reset_reason
-        // exists to disambiguate from a clean power-cycle), mirroring
-        // firmware_version's mid-connect-change severity.
-        QTest::ignoreMessage(QtWarningMsg,
-            QRegularExpression(".*Scale reset reason changed mid-connect: poweron -> watchdog.*"));
-        server.sendJson({{ "type", "session_info" }, { "reset_reason", "watchdog" }});
-        QTest::qWait(50);
-    }
-
-    // Debug frames (both event-driven and request-response shapes) are logged
-    // verbatim so every signal the firmware sends is captured in the scale
-    // log. We don't filter by event type — the firmware decides what's worth
-    // sending, and a one-line JSON dump is the cheapest triage surface.
-    void debugFramesAreLoggedVerbatim() {
-        FakeHdsServer server;
-        DecentScaleWifi driver;
-        connectAndHandshake(driver, server);
-
-        // Event-driven shape.
-        QTest::ignoreMessage(QtDebugMsg,
-            QRegularExpression(".*Debug frame:.*\"event\":\"stall_start\".*\"stall_count\":1.*"));
-        server.sendJson({
-            { "type", "debug" }, { "event", "stall_start" },
-            { "stall_count", 1 }, { "last_stall_temp_c", 42.1 },
-        });
-        QTest::qWait(50);
-
-        // Full-state response shape (what requestDebugSnapshot() pulls back).
-        QTest::ignoreMessage(QtDebugMsg,
-            QRegularExpression(".*Debug frame:.*\"soc_temp_c\":32\\.3.*\"weight_stalled\":false.*"));
-        server.sendJson({
-            { "type", "debug" }, { "status", "ok" },
-            { "soc_temp_c", 32.3 }, { "soc_temp_max_c", 32.3 },
-            { "weight_stalled", false }, { "stall_count", 0 },
-            { "adc_recovery_count", 0 }, { "ms", 29104 },
-        });
-        QTest::qWait(50);
-    }
-
-    // requestDebugSnapshot() sends the `debug` text command, which the
-    // firmware answers with a full-state debug frame. The app-suspend hook in
-    // main.cpp calls this so the scale log captures firmware state right
-    // before the app backgrounds.
-    void requestDebugSnapshotSendsDebugCommand() {
-        FakeHdsServer server;
-        DecentScaleWifi driver;
-        connectAndHandshake(driver, server);
-        server.clearReceived();
-
-        driver.requestDebugSnapshot();
-        QTRY_VERIFY(server.received().contains(QStringLiteral("debug")));
-    }
-
     // Regression: the real firmware's status frame ALSO carries a `grams` field
     // (openscale README). Snapshots are distinguished by the ABSENCE of `type`,
     // so a status-with-grams must still reach the status handler — keying on the
@@ -889,35 +800,6 @@ private slots:
             { "type", "status" },
             { "battery_percent", 80 },
             { "firmware_version", "FW: 3.0.9" },
-        });
-        QVERIFY(recognizedSpy.wait(500));
-        QCOMPARE(recognizedSpy.count(), 1);
-    }
-
-    // session_info is a new HDS-identifying frame on newer firmware: it
-    // arrives unprompted right after the WS handshake and carries
-    // firmware_version + protocol_version + reset_reason. It must trigger
-    // recognition on its own — if it doesn't, a manual "Add WiFi Scale" entry
-    // against a scale that sends session_info before any snapshot or status
-    // (which can happen since session_info is unsolicited) would dead-end at
-    // the 5 s recognition timeout.
-    void recognizedAsHdsFiresOnFirstSessionInfoFrame() {
-        FakeHdsServer server;
-        DecentScaleWifi driver;
-        QSignalSpy recognizedSpy(&driver, &DecentScaleWifi::recognizedAsHds);
-        connectAndHandshake(driver, server);
-
-        QTest::ignoreMessage(QtDebugMsg,
-            QRegularExpression(".*Firmware version: FW: 3\\.0\\.9.*"));
-        QTest::ignoreMessage(QtDebugMsg,
-            QRegularExpression(".*Protocol version: 1.*"));
-        QTest::ignoreMessage(QtDebugMsg,
-            QRegularExpression(".*Scale reset reason: poweron.*"));
-        server.sendJson({
-            { "type", "session_info" },
-            { "firmware_version", "FW: 3.0.9" },
-            { "protocol_version", 1 },
-            { "reset_reason", "poweron" },
         });
         QVERIFY(recognizedSpy.wait(500));
         QCOMPARE(recognizedSpy.count(), 1);


### PR DESCRIPTION
## Summary

- Removes the client-side debug-snapshot + `session_info` surface added in #1287 and #1289. The shipping HDS firmware (per `../openscale/README.md`) no longer defines a `debug` text command or `session_info` / `debug` frame types — `firmware_version` and `protocol_version` are back in the `status` frame.
- Without this, `requestDebugSnapshot()` would send a `debug` text command the current firmware rejects as `unknown_command`, and the typed-frame router would carry dead branches for frame types the firmware never sends.

## Scope

- `DecentScaleWifi`: drop `handleDebugFrame`, `handleSessionInfoFrame`, the `debug` / `session_info` router branches, the `m_lastResetReason` member, and the `requestDebugSnapshot()` slot. Status-frame parsing of `firmware_version` / `protocol_version` is unchanged.
- `ScaleDevice`: drop the `requestDebugSnapshot()` base virtual.
- MCP: remove the `devices_request_scale_debug` tool.
- `main.cpp`: drop the `Qt::ApplicationSuspended` debug-snapshot call site.
- `qml/main.qml`: drop the `goToScreensaver()` debug-snapshot call site.
- Tests: drop the three debug/session_info test methods and the `recognizedAsHdsFiresOnFirstSessionInfoFrame` regression.

## Test plan

- [x] Local build clean (Qt Creator MCP — 0 errors, 0 warnings)
- [x] `tst_DecentScaleWifi` — 31/31 passed, 0 warnings
- [ ] Spot-check on Jeff's HDS: confirm status frame still logs firmware_version + protocol_version once per connect; confirm no `unknown_command` error frame in the scale log

🤖 Generated with [Claude Code](https://claude.com/claude-code)