### PR TITLE
fix(scale): silence connection-error dialogs for remaining scales + DiFluid R2

### DIFF
--- a/src/ble/refractometers/difluidr2.cpp
+++ b/src/ble/refractometers/difluidr2.cpp
@@ -114,7 +114,7 @@ bool DiFluidR2::isR2Device(const QString& name) {
 
 void DiFluidR2::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        R2_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -204,7 +204,6 @@ void DiFluidR2::onTransportError(const QString& message) {
                              : QStringLiteral("connect attempt failed before ready (was not connected)"),
                  QString::number(reinterpret_cast<quintptr>(this), 16)));
     R2_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("DiFluid R2 connection error");
     m_measurementTimer.stop();
     m_initTimer.stop();
     m_connected = false;
@@ -228,7 +227,6 @@ void DiFluidR2::onServicesDiscoveryFinished() {
     if (!m_serviceFound) {
         R2_WARN(QString("DiFluid R2 service %1 not found!")
                     .arg(Refractometer::DiFluidR2::SERVICE.toString()));
-        emit errorOccurred("DiFluid R2 service not found");
         return;
     }
     m_transport->discoverCharacteristics(Refractometer::DiFluidR2::SERVICE);

--- a/src/ble/scales/acaiascale.cpp
+++ b/src/ble/scales/acaiascale.cpp
@@ -53,7 +53,7 @@ void AcaiaScale::stopAllTimers() {
 
 void AcaiaScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        ACAIA_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -99,7 +99,6 @@ void AcaiaScale::onTransportError(const QString& message) {
     ACAIA_WARN(QString("Transport error: %1").arg(message));
     stopAllTimers();
     m_isConnecting = false;
-    emit errorOccurred("Acaia scale connection error");
     setConnected(false);
 }
 
@@ -133,7 +132,6 @@ void AcaiaScale::onServicesDiscoveryFinished() {
         ACAIA_LOG("Using IPS protocol");
     } else {
         ACAIA_WARN("No compatible service found!");
-        emit errorOccurred("No compatible Acaia service found");
         return;
     }
 

--- a/src/ble/scales/acaiascale.cpp
+++ b/src/ble/scales/acaiascale.cpp
@@ -208,7 +208,6 @@ void AcaiaScale::onInitTimer() {
         ACAIA_WARN(QString("Init sequence failed after %1 retries").arg(MAX_IDENT_RETRIES));
         m_initTimer->stop();
         m_isConnecting = false;
-        emit errorOccurred("Scale not responding to ident");
         return;
     }
 

--- a/src/ble/scales/atomhearteclairscale.cpp
+++ b/src/ble/scales/atomhearteclairscale.cpp
@@ -41,7 +41,7 @@ AtomheartEclairScale::~AtomheartEclairScale() {
 
 void AtomheartEclairScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        ECLAIR_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -68,7 +68,6 @@ void AtomheartEclairScale::onTransportDisconnected() {
 
 void AtomheartEclairScale::onTransportError(const QString& message) {
     ECLAIR_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("Atomheart Eclair scale connection error");
     setConnected(false);
 }
 
@@ -84,7 +83,6 @@ void AtomheartEclairScale::onServicesDiscoveryFinished() {
     ECLAIR_LOG(QString("Service discovery finished, service found: %1").arg(m_serviceFound));
     if (!m_serviceFound) {
         ECLAIR_WARN(QString("Atomheart Eclair service %1 not found!").arg(Scale::AtomheartEclair::SERVICE.toString()));
-        emit errorOccurred("Atomheart Eclair service not found");
         return;
     }
     m_transport->discoverCharacteristics(Scale::AtomheartEclair::SERVICE);

--- a/src/ble/scales/bookooscale.cpp
+++ b/src/ble/scales/bookooscale.cpp
@@ -43,7 +43,7 @@ BookooScale::~BookooScale() {
 
 void BookooScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        BOOKOO_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -92,7 +92,6 @@ void BookooScale::onServicesDiscoveryFinished() {
 
     if (!m_serviceFound) {
         BOOKOO_WARN(QString("Service %1 not found!").arg(Scale::Bookoo::SERVICE.toString()));
-        emit errorOccurred("Bookoo service not found");
         return;
     }
 

--- a/src/ble/scales/difluidscale.cpp
+++ b/src/ble/scales/difluidscale.cpp
@@ -41,7 +41,7 @@ DifluidScale::~DifluidScale() {
 
 void DifluidScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        DIFLUID_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -68,7 +68,6 @@ void DifluidScale::onTransportDisconnected() {
 
 void DifluidScale::onTransportError(const QString& message) {
     DIFLUID_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("Difluid scale connection error");
     setConnected(false);
 }
 
@@ -84,7 +83,6 @@ void DifluidScale::onServicesDiscoveryFinished() {
     DIFLUID_LOG(QString("Service discovery finished, service found: %1").arg(m_serviceFound));
     if (!m_serviceFound) {
         DIFLUID_WARN(QString("DiFluid service %1 not found!").arg(Scale::DiFluid::SERVICE.toString()));
-        emit errorOccurred("Difluid service not found");
         return;
     }
     m_transport->discoverCharacteristics(Scale::DiFluid::SERVICE);

--- a/src/ble/scales/eurekaprecisascale.cpp
+++ b/src/ble/scales/eurekaprecisascale.cpp
@@ -41,7 +41,7 @@ EurekaPrecisaScale::~EurekaPrecisaScale() {
 
 void EurekaPrecisaScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        EUREKA_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -68,7 +68,6 @@ void EurekaPrecisaScale::onTransportDisconnected() {
 
 void EurekaPrecisaScale::onTransportError(const QString& message) {
     EUREKA_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("Eureka Precisa scale connection error");
     setConnected(false);
 }
 
@@ -84,7 +83,6 @@ void EurekaPrecisaScale::onServicesDiscoveryFinished() {
     EUREKA_LOG(QString("Service discovery finished, service found: %1").arg(m_serviceFound));
     if (!m_serviceFound) {
         EUREKA_WARN(QString("Eureka Precisa service %1 not found!").arg(Scale::Generic::SERVICE.toString()));
-        emit errorOccurred("Eureka Precisa service not found");
         return;
     }
     m_transport->discoverCharacteristics(Scale::Generic::SERVICE);

--- a/src/ble/scales/felicitascale.cpp
+++ b/src/ble/scales/felicitascale.cpp
@@ -41,7 +41,7 @@ FelicitaScale::~FelicitaScale() {
 
 void FelicitaScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        FELICITA_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -68,7 +68,6 @@ void FelicitaScale::onTransportDisconnected() {
 
 void FelicitaScale::onTransportError(const QString& message) {
     FELICITA_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("Felicita scale connection error");
     setConnected(false);
 }
 
@@ -84,7 +83,6 @@ void FelicitaScale::onServicesDiscoveryFinished() {
     FELICITA_LOG(QString("Service discovery finished, service found: %1").arg(m_serviceFound));
     if (!m_serviceFound) {
         FELICITA_WARN(QString("Felicita service %1 not found!").arg(Scale::Felicita::SERVICE.toString()));
-        emit errorOccurred("Felicita service not found");
         return;
     }
     m_transport->discoverCharacteristics(Scale::Felicita::SERVICE);

--- a/src/ble/scales/hiroiascale.cpp
+++ b/src/ble/scales/hiroiascale.cpp
@@ -41,7 +41,7 @@ HiroiaScale::~HiroiaScale() {
 
 void HiroiaScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        HIROIA_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -68,7 +68,6 @@ void HiroiaScale::onTransportDisconnected() {
 
 void HiroiaScale::onTransportError(const QString& message) {
     HIROIA_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("Hiroia Jimmy scale connection error");
     setConnected(false);
 }
 
@@ -84,7 +83,6 @@ void HiroiaScale::onServicesDiscoveryFinished() {
     HIROIA_LOG(QString("Service discovery finished, service found: %1").arg(m_serviceFound));
     if (!m_serviceFound) {
         HIROIA_WARN(QString("Hiroia Jimmy service %1 not found!").arg(Scale::HiroiaJimmy::SERVICE.toString()));
-        emit errorOccurred("Hiroia Jimmy service not found");
         return;
     }
     m_transport->discoverCharacteristics(Scale::HiroiaJimmy::SERVICE);

--- a/src/ble/scales/skalescale.cpp
+++ b/src/ble/scales/skalescale.cpp
@@ -41,7 +41,7 @@ SkaleScale::~SkaleScale() {
 
 void SkaleScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        SKALE_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -68,7 +68,6 @@ void SkaleScale::onTransportDisconnected() {
 
 void SkaleScale::onTransportError(const QString& message) {
     SKALE_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("Skale connection error");
     setConnected(false);
 }
 
@@ -84,7 +83,6 @@ void SkaleScale::onServicesDiscoveryFinished() {
     SKALE_LOG(QString("Service discovery finished, service found: %1").arg(m_serviceFound));
     if (!m_serviceFound) {
         SKALE_WARN(QString("Skale service %1 not found!").arg(Scale::Skale::SERVICE.toString()));
-        emit errorOccurred("Skale service not found");
         return;
     }
     m_transport->discoverCharacteristics(Scale::Skale::SERVICE);

--- a/src/ble/scales/smartchefscale.cpp
+++ b/src/ble/scales/smartchefscale.cpp
@@ -41,7 +41,7 @@ SmartChefScale::~SmartChefScale() {
 
 void SmartChefScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        SMARTCHEF_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -68,7 +68,6 @@ void SmartChefScale::onTransportDisconnected() {
 
 void SmartChefScale::onTransportError(const QString& message) {
     SMARTCHEF_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("SmartChef scale connection error");
     setConnected(false);
 }
 
@@ -84,7 +83,6 @@ void SmartChefScale::onServicesDiscoveryFinished() {
     SMARTCHEF_LOG(QString("Service discovery finished, service found: %1").arg(m_serviceFound));
     if (!m_serviceFound) {
         SMARTCHEF_WARN(QString("SmartChef service %1 not found!").arg(Scale::Generic::SERVICE.toString()));
-        emit errorOccurred("SmartChef service not found");
         return;
     }
     m_transport->discoverCharacteristics(Scale::Generic::SERVICE);

--- a/src/ble/scales/timemorescale.cpp
+++ b/src/ble/scales/timemorescale.cpp
@@ -66,7 +66,7 @@ TimemoreScale::~TimemoreScale() {
 
 void TimemoreScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        TIMEMORE_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -93,7 +93,6 @@ void TimemoreScale::onTransportDisconnected() {
 
 void TimemoreScale::onTransportError(const QString& message) {
     TIMEMORE_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("Timemore scale connection error");
     setConnected(false);
 }
 
@@ -109,7 +108,6 @@ void TimemoreScale::onServicesDiscoveryFinished() {
     TIMEMORE_LOG(QString("Service discovery finished, service found: %1").arg(m_serviceFound));
     if (!m_serviceFound) {
         TIMEMORE_WARN(QString("Timemore service %1 not found!").arg(Scale::Generic::SERVICE.toString()));
-        emit errorOccurred("Timemore service not found");
         return;
     }
     m_transport->discoverCharacteristics(Scale::Generic::SERVICE);

--- a/src/ble/scales/variaakuscale.cpp
+++ b/src/ble/scales/variaakuscale.cpp
@@ -51,7 +51,7 @@ VariaAkuScale::~VariaAkuScale() {
 
 void VariaAkuScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     if (!m_transport) {
-        emit errorOccurred("No transport available");
+        VARIA_WARN("connectToDevice called with no transport");
         return;
     }
 
@@ -79,7 +79,6 @@ void VariaAkuScale::onTransportDisconnected() {
 
 void VariaAkuScale::onTransportError(const QString& message) {
     VARIA_WARN(QString("Transport error: %1").arg(message));
-    emit errorOccurred("Varia Aku scale connection error");
     setConnected(false);
 }
 
@@ -97,7 +96,6 @@ void VariaAkuScale::onServicesDiscoveryFinished() {
 
     if (!m_serviceFound) {
         VARIA_WARN(QString("Varia Aku service %1 not found!").arg(Scale::VariaAku::SERVICE.toString()));
-        emit errorOccurred("Varia Aku service not found");
         return;
     }
 

--- a/src/ble/scales/variaakuscale.cpp
+++ b/src/ble/scales/variaakuscale.cpp
@@ -189,7 +189,6 @@ void VariaAkuScale::onWatchdogTimeout() {
     if (m_watchdogRetries >= MAX_WATCHDOG_RETRIES) {
         VARIA_WARN(QString("No weight updates after %1 retries, giving up").arg(MAX_WATCHDOG_RETRIES));
         setConnected(false);
-        emit errorOccurred("Varia Aku scale not sending weight updates");
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1615,11 +1615,13 @@ int main(int argc, char *argv[])
         bleManager.setScaleDevice(physicalScale.get());
 
         // Forward scale-level error messages to BLEManager::errorOccurred, which
-        // main.qml wires to the error dialog. Transient WiFi connect-failures (mDNS
-        // miss, host-not-found, connection-refused — the scale is just booting) are
-        // log-only inside DecentScaleWifi (see #1253), so what reaches here is an
-        // ACTIONABLE error worth showing unconditionally — e.g. WiFi 503 "Another
-        // client is connected to the scale", which the retry loop can't resolve.
+        // main.qml wires to the error dialog. Transient connect-failures are log-only
+        // inside the drivers — BLE transport/service-discovery errors (#1285, #1292)
+        // and WiFi mDNS-miss / host-not-found / 503 retries (#1253). What reaches
+        // here is an ACTIONABLE error worth showing unconditionally — e.g. WiFi 503
+        // "Another client is connected to the scale" that the retry loop can't
+        // resolve, or a measurement-side condition from a refractometer ("No liquid
+        // detected", "Beyond range").
         QObject::connect(physicalScale.get(), &ScaleDevice::errorOccurred,
                          &bleManager, &BLEManager::errorOccurred);
 


### PR DESCRIPTION
## Summary

Follow-up to [#1285](https://github.com/Kulitorum/Decenza/pull/1285), which silenced the same modal "Connection Error" dialogs but only for the Decent Scale.

The identical `errorOccurred` emits were added across **all 11 scale drivers** by the Nordic BLE refactor in 8ca9da33, plus the DiFluid R2 refractometer driver. They are ungated by the scale-alerts toggle and surface on every transient BLE hiccup — annoying and repetitive. This PR applies the same fix to the remaining 10 scale drivers and the DiFluid R2.

For each driver, the connect-phase `errorOccurred` emits are dropped (keeping the existing `<BRAND>_WARN` logging):

- `errorOccurred("No transport available")` in `connectToDevice()` → replaced with `<BRAND>_WARN("connectToDevice called with no transport")`
- `errorOccurred("<Brand>... connection error")` in `onTransportError()` → dropped (transport-error WARN already logs)
- `errorOccurred("<Brand>... service not found")` in `onServicesDiscoveryFinished()` → dropped (service-not-found WARN already logs)

Drivers touched: Acaia, Atomheart Eclair, Bookoo, Difluid (Microbalance), Eureka Precisa, Felicita, Hiroia Jimmy, Skale, SmartChef, Timemore, Varia Aku, DiFluid R2 refractometer.

(Bookoo's `onTransportError` already had no emit — it intentionally keeps the connection alive on transport errors per its CCCD-tolerance comment — so only the other two paths apply there.)

Also dropped two post-handshake emits that were initially kept but are equally noisy:

- Acaia `"Scale not responding to ident"` (fires after 10 ident retries fail) — `setConnected(false)` + WARN log is enough
- Varia Aku `"scale not sending weight updates"` — `setConnected(false)` on the line above already triggers a `scaleDisconnected` dialog, so the emit was producing a **second** modal for the same event

After these changes, no BLE scale driver emits `errorOccurred` on transient/recoverable connect-phase noise. The forwarder comment at `main.cpp:1617-1624` has been updated to reflect the new contract.

If the scale stays gone, the existing (gated) "No Scale Found" path still surfaces.

## Left in place (different conditions)

- DiFluid R2 measurement-side emits — `"No liquid detected"`, `"Beyond range"`, `"R2 reported an out-of-range value"`, etc. These are meaningful device-reported conditions about the actual measurement, not BLE connect noise.
- DecentScaleWifi 503 / unrecoverable errors — already log-only for transient WiFi failures per #1253; the surviving emits are actionable (e.g. "Another client is connected to the scale").

## Test plan

- [x] macOS debug build clean (no errors, no warnings)
- [ ] Verify on Android tablet: trigger a transient BLE failure on a non-Decent scale (e.g. Skale) and confirm no modal pops up
- [ ] Confirm the gated "No Scale Found" path still appears when a scale is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)