### PR TITLE
fix(post-shot-review): silence rating-row recursive-rearrange warning

### DIFF
--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -1080,7 +1080,13 @@ Page {
                     fallback: "How was this shot?"
                     color: Theme.textColor
                     font: Theme.bodyFont
-                    Layout.preferredWidth: Math.min(implicitWidth, parent.width * 0.45)
+                    // Cap on a stable upstream width (the page) instead of `parent.width`.
+                    // `parent` is the RowLayout, whose width depends on this child's
+                    // preferred size — that mutual dependency tripped Qt Quick Layouts'
+                    // "recursive rearrange" guard 4×/session in production logs. Binding
+                    // to postShotReviewPage.width breaks the cycle; the label still sizes
+                    // to its implicitWidth, capped to ~45% of the page.
+                    Layout.maximumWidth: postShotReviewPage.width * 0.45
                     Accessible.ignored: true
                 }
 

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -1080,12 +1080,13 @@ Page {
                     fallback: "How was this shot?"
                     color: Theme.textColor
                     font: Theme.bodyFont
-                    // Cap on a stable upstream width (the page) instead of `parent.width`.
-                    // `parent` is the RowLayout, whose width depends on this child's
-                    // preferred size — that mutual dependency tripped Qt Quick Layouts'
-                    // "recursive rearrange" guard 4×/session in production logs. Binding
-                    // to postShotReviewPage.width breaks the cycle; the label still sizes
-                    // to its implicitWidth, capped to ~45% of the page.
+                    // Cap on an ancestor whose width does not depend on this label,
+                    // instead of `parent.width`. `parent` is the RowLayout, whose width
+                    // depends on this child's preferred size — that mutual dependency
+                    // tripped Qt Quick Layouts' "recursive rearrange" guard in
+                    // production. Binding to postShotReviewPage.width breaks the cycle;
+                    // the label still sizes to its implicitWidth, capped to ~45% of
+                    // the page.
                     Layout.maximumWidth: postShotReviewPage.width * 0.45
                     Accessible.ignored: true
                 }


### PR DESCRIPTION
## Summary
- Live debug log from today shows `QML RowLayout: Detected recursive rearrange. Aborting after two iterations` firing 4× per session at `PostShotReviewPage.qml:1004` (8 occurrences across the two morning sessions on Jeff's tablet).
- Root cause: the rating-row label binds `Layout.preferredWidth: Math.min(implicitWidth, parent.width * 0.45)`. `parent` is the RowLayout, whose width depends on this child's preferred size — Qt Quick Layouts catches the cycle and aborts the second pass.
- User-visible impact is mild (wasted layout work, occasional flicker before Qt's fallback settles), but it's a real warning on every page load and easy to silence.
- Fix: bind the cap to `postShotReviewPage.width` instead of `parent.width`. The page width is set by the StackView, independent of the rating row, so the cycle breaks. Switched from `preferredWidth: Math.min(implicit, cap)` to `maximumWidth: cap` — the label still sizes to its implicit width, just capped.

The effective cap is a hair larger than before because page width includes the flickable's standard side margins, so 0.45 × page > 0.45 × row. Imperceptible for the English label; if a translation pushed it, the cap rarely kicked in to begin with.

## Test plan
- [ ] Load Post-Shot Review on any shot.
- [ ] Confirm the "How was this shot?" label still sits to the left of the rating slider with the same proportions as before.
- [ ] Watch logs while opening the page: the recursive-rearrange warning should no longer appear.
- [ ] Edit a field on the page; warning still absent after the page re-lays out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)