### PR TITLE
diag(shotserver): classify "QSslSocket: device not open" warnings (#1295)

### DIFF
--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -585,6 +585,44 @@ void ShotServer::onReadyRead()
     if (QTimer* t = m_keepAliveTimers.value(socket))
         t->stop();
 
+    // Diagnostic guard for the "QIODevice::read (QSslSocket): device not open"
+    // warning Qt emits when readAll() runs against a closed underlying device.
+    // The state guard above catches sockets that fully transitioned to a
+    // non-Connected state, but there is a window where state still reads
+    // Connected (Qt hasn't propagated the close yet) while the underlying
+    // QIODevice is already closed — `isOpen()` is the stricter check. Look up
+    // existing-pending-request state BEFORE m_pendingRequests[socket] below,
+    // which would auto-insert a fresh entry and erase the "no pending" signal.
+    //
+    // The qDebug() below is temporary instrumentation for #1295 — peer/state/
+    // age/reqLine let us classify each hit as either a sleep/wake race (old
+    // socket, no pending body) or a mid-request peer teardown. Once the
+    // dominant trigger is known, the logging block goes away and the
+    // isOpen() guard stays (it's load-bearing for the warning either way).
+    // Cleanup checklist lives in #1295.
+    if (!socket->isOpen()) {
+        const auto it = m_pendingRequests.constFind(socket);
+        const bool hadPending = (it != m_pendingRequests.constEnd());
+        QString reqLine = QStringLiteral("<no pending request>");
+        qint64 ageMs = -1;
+        if (hadPending) {
+            const int eol = static_cast<int>(it->headerData.indexOf('\r'));
+            const QByteArray firstLine = eol > 0 ? it->headerData.left(eol) : it->headerData.left(120);
+            reqLine = QString::fromUtf8(firstLine).left(120);
+            ageMs = it->lastActivity.elapsed();
+        }
+        qDebug().nospace()
+            << "[ShotServer] readyRead on closed socket"
+            << " peer=" << socket->peerAddress().toString() << ":" << socket->peerPort()
+            << " state=" << socket->state()
+            << " hadPending=" << hadPending
+            << " ageMs=" << ageMs
+            << " reqLine=\"" << reqLine << "\"";
+        cleanupPendingRequest(socket);
+        m_pendingRequests.remove(socket);
+        return;
+    }
+
     try {
         PendingRequest& pending = m_pendingRequests[socket];
         pending.lastActivity.start();

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -591,15 +591,16 @@ void ShotServer::onReadyRead()
     // non-Connected state, but there is a window where state still reads
     // Connected (Qt hasn't propagated the close yet) while the underlying
     // QIODevice is already closed — `isOpen()` is the stricter check. Look up
-    // existing-pending-request state BEFORE m_pendingRequests[socket] below,
-    // which would auto-insert a fresh entry and erase the "no pending" signal.
+    // existing-pending-request state via constFind BEFORE m_pendingRequests[socket]
+    // below: QHash::operator[] default-inserts a PendingRequest for any missing
+    // key, which would both hide the "no pending request" signal in the
+    // diagnostic AND leak a phantom entry for a socket we're about to remove.
     //
     // The qDebug() below is temporary instrumentation for #1295 — peer/state/
     // age/reqLine let us classify each hit as either a sleep/wake race (old
     // socket, no pending body) or a mid-request peer teardown. Once the
     // dominant trigger is known, the logging block goes away and the
     // isOpen() guard stays (it's load-bearing for the warning either way).
-    // Cleanup checklist lives in #1295.
     if (!socket->isOpen()) {
         const auto it = m_pendingRequests.constFind(socket);
         const bool hadPending = (it != m_pendingRequests.constEnd());


### PR DESCRIPTION
## Summary

Partial fix + diagnostic for #1295. The Qt warning `QIODevice::read (QSslSocket): device not open` has been firing ~5×/day in the debug log, **including overnight when no client should be active** (rules out "purely caused by MCP traffic").

Audit ruled out every other `QSslSocket` reader in `src/` — the only direct one is `ShotServer::onReadyRead` at `shotserver.cpp:593`. Every other `readAll()` in the codebase is on a `QNetworkReply` (buffers internally, doesn't trigger this warning).

The existing state guard at `:575` only catches sockets that have fully transitioned to a non-`Connected` state. There's a narrower window where state still reads `Connected` while the underlying `QIODevice::isOpen()` has already flipped `false` — that's where `readAll()` fires the warning. The author already documented the sleep/wake hazard in the inline comment but did not add the stricter `isOpen()` check.

## What this PR does (intentionally partial)

- **Adds an `isOpen()` guard** before the `readAll()`. This silences the Qt warning as a side effect — when the device isn't open, we skip the read, clean up, and return.
- **Adds one `qDebug()` line per would-have-fired hit**, tagged `[ShotServer]`, carrying `peer`, `state`, `hadPending`, `ageMs`, and `reqLine`. The combination distinguishes:
  - **sleep/wake race**: old socket (`ageMs` large), no pending request body — fits the overnight count
  - **abrupt peer teardown**: recent socket, pending body with a recognizable URL — fits the daytime count
  - or some **third source** we haven't predicted yet
- Looks up the pending-request state via `constFind` **before** the `m_pendingRequests[socket]` reference below, so a fresh hit doesn't auto-insert an empty entry that would always report `hadPending=true`.

## What this PR explicitly does NOT do

- Doesn't decide whether the dominant trigger is sleep/wake vs. peer teardown — that's what the diagnostic is for.
- Doesn't remove the logging block. That's the cleanup step in #1295 once we have data.

## Cleanup path

Tracked in #1295. Once we have a day or two of data classifying each hit:

- [ ] Remove the `qDebug() << "[ShotServer] readyRead on closed socket" ...` block.
- [ ] Keep the `isOpen()` guard (load-bearing for the warning regardless of cause).
- [ ] Update or remove the comment block once the dominant trigger is known.

## Test plan

- [ ] Build, install. Use the app normally for a day (including putting the tablet to sleep + waking).
- [ ] Pull the debug log; grep for `[ShotServer] readyRead on closed socket`.
- [ ] Confirm: zero occurrences of the bare Qt `QIODevice::read (QSslSocket): device not open` warning remain (our guard intercepts them).
- [ ] Classify the `[ShotServer]` lines by `hadPending` / `ageMs` and report back on #1295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)