### PR TITLE
cleanup(shotserver): drop QSslSocket-diagnostic logging, keep isOpen() guard

### DIFF
--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -585,40 +585,19 @@ void ShotServer::onReadyRead()
     if (QTimer* t = m_keepAliveTimers.value(socket))
         t->stop();
 
-    // Diagnostic guard for the "QIODevice::read (QSslSocket): device not open"
+    // Safety net for the "QIODevice::read (QSslSocket): device not open"
     // warning Qt emits when readAll() runs against a closed underlying device.
     // The state guard above catches sockets that fully transitioned to a
     // non-Connected state, but there is a window where state still reads
     // Connected (Qt hasn't propagated the close yet) while the underlying
-    // QIODevice is already closed — `isOpen()` is the stricter check. Look up
-    // existing-pending-request state via constFind BEFORE m_pendingRequests[socket]
-    // below: QHash::operator[] default-inserts a PendingRequest for any missing
-    // key, which would both hide the "no pending request" signal in the
-    // diagnostic AND leak a phantom entry for a socket we're about to remove.
-    //
-    // The qDebug() below is temporary instrumentation for #1295 — peer/state/
-    // age/reqLine let us classify each hit as either a sleep/wake race (old
-    // socket, no pending body) or a mid-request peer teardown. Once the
-    // dominant trigger is known, the logging block goes away and the
-    // isOpen() guard stays (it's load-bearing for the warning either way).
+    // QIODevice is already closed — `isOpen()` is the stricter check. Kept as a
+    // cheap one-line guard: investigation in #1295 confirmed this branch never
+    // fired during ~80 min of active use, and the actual source of the warning
+    // in our log is Qt-internal HTTP/2 teardown elsewhere (the auto-update
+    // checker's hourly request, see QTBUG-129316 / QTBUG-144492). Even though
+    // shotserver wasn't the source we could observe, a future sleep/wake or
+    // abrupt peer teardown could still trip the same race here.
     if (!socket->isOpen()) {
-        const auto it = m_pendingRequests.constFind(socket);
-        const bool hadPending = (it != m_pendingRequests.constEnd());
-        QString reqLine = QStringLiteral("<no pending request>");
-        qint64 ageMs = -1;
-        if (hadPending) {
-            const int eol = static_cast<int>(it->headerData.indexOf('\r'));
-            const QByteArray firstLine = eol > 0 ? it->headerData.left(eol) : it->headerData.left(120);
-            reqLine = QString::fromUtf8(firstLine).left(120);
-            ageMs = it->lastActivity.elapsed();
-        }
-        qDebug().nospace()
-            << "[ShotServer] readyRead on closed socket"
-            << " peer=" << socket->peerAddress().toString() << ":" << socket->peerPort()
-            << " state=" << socket->state()
-            << " hadPending=" << hadPending
-            << " ageMs=" << ageMs
-            << " reqLine=\"" << reqLine << "\"";
         cleanupPendingRequest(socket);
         m_pendingRequests.remove(socket);
         return;

--- a/src/network/shotserver.cpp
+++ b/src/network/shotserver.cpp
@@ -590,13 +590,17 @@ void ShotServer::onReadyRead()
     // The state guard above catches sockets that fully transitioned to a
     // non-Connected state, but there is a window where state still reads
     // Connected (Qt hasn't propagated the close yet) while the underlying
-    // QIODevice is already closed — `isOpen()` is the stricter check. Kept as a
-    // cheap one-line guard: investigation in #1295 confirmed this branch never
-    // fired during ~80 min of active use, and the actual source of the warning
-    // in our log is Qt-internal HTTP/2 teardown elsewhere (the auto-update
-    // checker's hourly request, see QTBUG-129316 / QTBUG-144492). Even though
-    // shotserver wasn't the source we could observe, a future sleep/wake or
-    // abrupt peer teardown could still trip the same race here.
+    // QIODevice is already closed — `isOpen()` is the stricter check.
+    //
+    // Kept defensively even though investigation in #1295 did not observe
+    // shotserver tripping this race in practice; a future sleep/wake or
+    // abrupt peer teardown could still hit it, and one branch costs nothing.
+    //
+    // Note: the warning we actually see in production logs comes from a
+    // different code path — Qt-internal HTTP/2 channel teardown on the
+    // auto-update checker's outbound request, not this server's incoming
+    // socket. See QTBUG-129316 / QTBUG-144492. That source is unrelated to
+    // this guard; don't delete this guard if those bugs close.
     if (!socket->isOpen()) {
         cleanupPendingRequest(socket);
         m_pendingRequests.remove(socket);


### PR DESCRIPTION
## Summary

Follow-up to the now-closed #1295. Investigation conclusively confirmed the shotserver is **not** the source of the `QIODevice::read (QSslSocket): device not open` warning:

- The diagnostic `qDebug()` block added in #1296 ran for ~80 min on Jeff's tablet with active MCP traffic and **fired zero times**.
- During that same window, two of the Qt warnings continued to fire at the **exact post-update-check timing** (~30s after the hourly `UpdateChecker::periodicTimer` request completes).
- Authoritative match against Qt's bug tracker:
  - **[QTBUG-144492](https://bugreports.qt.io/browse/QTBUG-144492)** (P1 Critical, **Closed/Fixed in Qt 6.11.1**) — `[REG] HTTP/2 timeouts`. Reporter's symptom was exactly this warning class plus actual request timeouts. We're on 6.11.1 = the fix version. The serious behavior is fixed; cosmetic warning isn't fully suppressed.
  - **[QTBUG-129316](https://bugreports.qt.io/browse/QTBUG-129316)** (P2, **still Reported / not fixed**) — `QHttp2ProtocolHandler::sendRST_STREAM() attempts to write to closed QIODevice`. Same HTTP/2-channel-vs-closed-socket race, write-side variant.

## What this PR does

Per the cleanup checklist promised in #1295:

- **Removes** the `qDebug()` block + its `constFind` lookup, `headerData` parsing, peer/state/age formatting (~28 lines).
- **Keeps** the `isOpen()` guard (now 5 lines instead of 38). Even though shotserver was never observed tripping the race, a future sleep/wake or abrupt peer teardown could still hit it, and the guard is one branch that costs nothing.
- **Rewords** the inline comment to:
  - Drop the "temporary instrumentation" framing.
  - Attribute the actual source (Qt-internal HTTP/2 teardown, not shotserver).
  - Cross-reference the upstream Qt bugs (`QTBUG-129316`, `QTBUG-144492`) so the next maintainer doesn't reopen the investigation.

## Test plan

- [ ] Build, install.
- [ ] Confirm `[ShotServer] readyRead on closed socket` no longer appears in the debug log.
- [ ] Confirm shotserver still functions normally for incoming MCP + WebUI requests.
- [ ] (Cosmetic note: the Qt `QIODevice::read (QSslSocket): device not open` warning will continue to fire ~hourly from the update checker — this is expected and deliberate per #1295.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)