### PR TITLE
fix(visualizer): coerce QVariant base shot so post-shot edits aren't silently dropped

### DIFF
--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -637,11 +637,12 @@ Page {
         if (!Settings.visualizer.visualizerAutoUpdate) return
         if (!MainController.visualizer) return
         // Only PATCH already-uploaded shots. Initial uploads are owned by the
-        // shot-completion auto-upload flow and the manual button. editShotData is
-        // a plain-JS clone here (clonePersistedShot, after badges/save); the C++
-        // method takes QVariant and runs ShotProjection::coerce(), so the clone
-        // is accepted — passing a const ShotProjection& used to throw and
-        // silently drop the PATCH.
+        // shot-completion auto-upload flow and the manual button. editShotData may
+        // be a plain-JS clone (clonePersistedShot, after badges/save) or the raw
+        // gadget (untouched since onShotReady); the C++ method takes QVariant and
+        // runs ShotProjection::coerce(), which accepts both — passing a
+        // const ShotProjection& used to throw on the clone and silently drop the
+        // PATCH.
         if (!_visualizerId) return
         pendingVisualizerUpdate = false
         _patchInFlight = true
@@ -1791,16 +1792,18 @@ Page {
                         // stay in sync as fields evolve.
                         var patchOverrides = buildVisualizerOverrides()
                         _patchInFlight = true
-                        // editShotData may be a plain-JS clone (badges/save); the
-                        // C++ method takes QVariant and coerces it, so id/duration/
-                        // frame arrays survive. Edited fields ride in patchOverrides.
+                        // editShotData may be a plain-JS clone (badges/save) or the
+                        // raw gadget; the C++ method takes QVariant and coerces it,
+                        // so id/duration/frame arrays survive either way. Edited
+                        // fields ride in patchOverrides.
                         MainController.visualizer.updateShotOnVisualizerWithOverrides(
                             _visualizerId, editShotData, patchOverrides)
                     } else {
-                        // First upload: pass editShotData (a clone after badges/save)
-                        // plus current edit-field overrides. The C++ method takes
-                        // QVariant and coerces via ShotProjection::coerce(), so id,
-                        // durationSec, and frame arrays survive isValid().
+                        // First upload: pass editShotData (a clone after badges/save,
+                        // or the raw gadget if untouched) plus current edit-field
+                        // overrides. The C++ method takes QVariant and coerces via
+                        // ShotProjection::coerce(), so id, durationSec, and frame
+                        // arrays survive isValid().
                         var uploadOverrides = buildVisualizerOverrides()
                         _firstUploadInFlight = true
                         MainController.visualizer.uploadShotFromHistoryWithOverrides(

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -636,12 +636,12 @@ Page {
         if (!pendingVisualizerUpdate) return
         if (!Settings.visualizer.visualizerAutoUpdate) return
         if (!MainController.visualizer) return
-        // Only PATCH already-uploaded shots. A first-POST path here is unsafe:
-        // by the time this runs, saveEditedShot has replaced editShotData via
-        // Object.assign, dropping Q_GADGET fields (id, durationSec, frame arrays)
-        // — uploadShotFromHistory would silently fail isValid() and the failure
-        // can't be surfaced because the page is destroyed. Initial uploads are
-        // owned by the shot-completion auto-upload flow and the manual button.
+        // Only PATCH already-uploaded shots. Initial uploads are owned by the
+        // shot-completion auto-upload flow and the manual button. editShotData is
+        // a plain-JS clone here (clonePersistedShot, after badges/save); the C++
+        // method takes QVariant and runs ShotProjection::coerce(), so the clone
+        // is accepted — passing a const ShotProjection& used to throw and
+        // silently drop the PATCH.
         if (!_visualizerId) return
         pendingVisualizerUpdate = false
         _patchInFlight = true
@@ -1791,15 +1791,16 @@ Page {
                         // stay in sync as fields evolve.
                         var patchOverrides = buildVisualizerOverrides()
                         _patchInFlight = true
+                        // editShotData may be a plain-JS clone (badges/save); the
+                        // C++ method takes QVariant and coerces it, so id/duration/
+                        // frame arrays survive. Edited fields ride in patchOverrides.
                         MainController.visualizer.updateShotOnVisualizerWithOverrides(
                             _visualizerId, editShotData, patchOverrides)
                     } else {
-                        // First upload: pass editShotData directly (preserves id,
-                        // durationSec, and frame arrays) and supply current edit-field
-                        // values as overrides. Object.assign({}, editShotData, ...) does
-                        // not work here — Q_GADGET properties are non-enumerable in V4,
-                        // so Object.assign silently drops them, leaving id=0 and causing
-                        // isValid() to fail.
+                        // First upload: pass editShotData (a clone after badges/save)
+                        // plus current edit-field overrides. The C++ method takes
+                        // QVariant and coerces via ShotProjection::coerce(), so id,
+                        // durationSec, and frame arrays survive isValid().
                         var uploadOverrides = buildVisualizerOverrides()
                         _firstUploadInFlight = true
                         MainController.visualizer.uploadShotFromHistoryWithOverrides(

--- a/src/history/shotprojection.cpp
+++ b/src/history/shotprojection.cpp
@@ -84,6 +84,13 @@ QJsonObject ShotProjection::toJsonObject() const
     return QJsonObject::fromVariantMap(toVariantMap());
 }
 
+ShotProjection ShotProjection::coerce(const QVariant& v)
+{
+    if (v.userType() == qMetaTypeId<ShotProjection>())
+        return v.value<ShotProjection>();
+    return ShotProjection::fromVariantMap(v.toMap());
+}
+
 ShotProjection ShotProjection::fromVariantMap(const QVariantMap& m)
 {
     ShotProjection p;

--- a/src/history/shotprojection.cpp
+++ b/src/history/shotprojection.cpp
@@ -1,6 +1,7 @@
 #include "shotprojection.h"
 
 #include <QMetaType>
+#include <QDebug>
 
 QVariantMap ShotProjection::toVariantMap() const
 {
@@ -88,7 +89,16 @@ ShotProjection ShotProjection::coerce(const QVariant& v)
 {
     if (v.userType() == qMetaTypeId<ShotProjection>())
         return v.value<ShotProjection>();
-    return ShotProjection::fromVariantMap(v.toMap());
+    const QVariantMap m = v.toMap();
+    // An empty map means QML/C++ passed null/undefined or a non-map scalar — the
+    // result is a default (invalid, id=0) ShotProjection that callers reject via
+    // isValid(). Log it so a future arg-shape regression is debuggable instead of
+    // surfacing only as a generic "No shot data available". Matches the diagnostic
+    // in AIManager::coerceShot() (#1298).
+    if (m.isEmpty())
+        qWarning() << "ShotProjection::coerce: empty/non-map arg (type"
+                   << v.typeName() << ") — result will be invalid";
+    return ShotProjection::fromVariantMap(m);
 }
 
 ShotProjection ShotProjection::fromVariantMap(const QVariantMap& m)

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -178,6 +178,19 @@ public:
     // PostShotReviewPage's onShotBadgesUpdated — still satisfy the parameter.
     static ShotProjection fromVariantMap(const QVariantMap& map);
 
+    // Coerce a QVariant arg (from a Q_INVOKABLE taking `const QVariant&`) into a
+    // ShotProjection, accepting BOTH shapes QML may hand across the boundary:
+    //   - a genuine ShotProjection gadget (e.g. the raw shotReady() wrapper), or
+    //   - a plain JS object → QVariantMap (e.g. PostShotReviewPage's
+    //     clonePersistedShot result after a badge update / metadata edit).
+    // The registered QVariantMap→ShotProjection metatype converter does NOT
+    // reliably engage on the Qt 6.11 QML→C++ invokable argument-binding path
+    // (it throws "Could not convert argument from [object Object] to
+    // ShotProjection"), so invokables that may receive an edited/cloned shot
+    // take `const QVariant&` and coerce here instead. Same approach as
+    // AIManager's coerceShot() (#1298).
+    static ShotProjection coerce(const QVariant& v);
+
     // Register the QVariantMap → ShotProjection converter. Call once at
     // application startup (main.cpp). Idempotent across calls.
     static void registerMetaTypeConverters();

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -174,8 +174,9 @@ public:
     // methods that take `const ShotProjection&`: a registered QMetaType
     // converter (see registerMetaTypeConverters() called once at startup)
     // routes QVariantMap → ShotProjection through this method, so QML callers
-    // passing a JS object — including the Object.assign-produced object in
-    // PostShotReviewPage's onShotBadgesUpdated — still satisfy the parameter.
+    // passing a JS object — including the plain-JS clone produced by
+    // PostShotReviewPage's clonePersistedShot (used in onShotBadgesUpdated and
+    // saveEditedShot) — still satisfy the parameter.
     static ShotProjection fromVariantMap(const QVariantMap& map);
 
     // Coerce a QVariant arg (from a Q_INVOKABLE taking `const QVariant&`) into a

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -215,7 +215,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                             qInfo() << "MCP shots_update: auto-updating visualizer shot" << visualizerId
                                     << "for local shot id" << shotId;
                             visualizerUploader->updateShotOnVisualizerWithOverrides(
-                                visualizerId, vizShot, vizOverrides);
+                                visualizerId, QVariant::fromValue(vizShot), vizOverrides);
                         } else {
                             skipReason = QString("failed to reload shot %1 for visualizer PATCH").arg(shotId);
                             qWarning() << "MCP shots_update:" << skipReason;
@@ -351,7 +351,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                         // Empty overrides — the projection loaded from DB already
                         // carries the user's current metadata (notes, ratings, bean
                         // info, etc.), so no edit-field overlay is needed.
-                        visualizerUploader->uploadShotFromHistoryWithOverrides(shot, QVariantMap{});
+                        visualizerUploader->uploadShotFromHistoryWithOverrides(QVariant::fromValue(shot), QVariantMap{});
                         respond(QJsonObject{
                             {"success", true},
                             {"uploadTriggered", true},

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -174,9 +174,9 @@ void VisualizerUploader::uploadShotFromHistory(const ShotProjection& shotData)
 }
 
 void VisualizerUploader::uploadShotFromHistoryWithOverrides(
-    const ShotProjection& baseShot, const QVariantMap& overrides)
+    const QVariant& baseShot, const QVariantMap& overrides)
 {
-    ShotProjection shot = baseShot;
+    ShotProjection shot = ShotProjection::coerce(baseShot);
     auto applyStr    = [&](QString       ShotProjection::*f, const char* k) {
         auto it = overrides.find(QLatin1String(k));
         if (it != overrides.end()) shot.*f = it->toString();
@@ -213,10 +213,10 @@ void VisualizerUploader::uploadShotFromHistoryWithOverrides(
 
 void VisualizerUploader::updateShotOnVisualizerWithOverrides(
     const QString& visualizerId,
-    const ShotProjection& baseShot,
+    const QVariant& baseShot,
     const QVariantMap& overrides)
 {
-    ShotProjection shot = baseShot;
+    ShotProjection shot = ShotProjection::coerce(baseShot);
     auto applyStr    = [&](QString       ShotProjection::*f, const char* k) {
         auto it = overrides.find(QLatin1String(k));
         if (it != overrides.end()) shot.*f = it->toString();

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -177,6 +177,10 @@ void VisualizerUploader::uploadShotFromHistoryWithOverrides(
     const QVariant& baseShot, const QVariantMap& overrides)
 {
     ShotProjection shot = ShotProjection::coerce(baseShot);
+    if (!shot.isValid()) {
+        emit uploadFailed("No shot data available");
+        return;
+    }
     auto applyStr    = [&](QString       ShotProjection::*f, const char* k) {
         auto it = overrides.find(QLatin1String(k));
         if (it != overrides.end()) shot.*f = it->toString();
@@ -217,6 +221,13 @@ void VisualizerUploader::updateShotOnVisualizerWithOverrides(
     const QVariantMap& overrides)
 {
     ShotProjection shot = ShotProjection::coerce(baseShot);
+    // updateShotOnVisualizer below only guards on visualizerId, not validity, so
+    // catch a coerce miss here — otherwise a PATCH could go out with id=0 /
+    // durationSec=0 / empty curves.
+    if (!shot.isValid()) {
+        emit uploadFailed("No shot data available");
+        return;
+    }
     auto applyStr    = [&](QString       ShotProjection::*f, const char* k) {
         auto it = overrides.find(QLatin1String(k));
         if (it != overrides.end()) shot.*f = it->toString();

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -73,18 +73,21 @@ public:
     // pass a QQmlValueTypeWrapper as ShotProjection, but Object.assign on a
     // Q_GADGET yields a plain object that omits id/durationSec/frames, causing
     // isValid() to fail silently with no UI feedback.
+    // baseShot is QVariant (not const ShotProjection&) so a QML caller can pass
+    // an edited/cloned shot (plain JS object) as well as a raw gadget — see
+    // ShotProjection::coerce(). C++ callers wrap with QVariant::fromValue(shot).
     Q_INVOKABLE void uploadShotFromHistoryWithOverrides(
-        const ShotProjection& baseShot, const QVariantMap& overrides);
+        const QVariant& baseShot, const QVariantMap& overrides);
 
     // Update metadata on an already-uploaded shot (PATCH to visualizer.coffee)
     Q_INVOKABLE void updateShotOnVisualizer(const QString& visualizerId, const ShotProjection& shotData);
 
-    // PATCH with overrides applied on top of a base ShotProjection.
-    // Pass the Q_GADGET directly so fields not present in overrides (notably profileName)
-    // are taken from the original shot record rather than left empty.
+    // PATCH with overrides applied on top of a base shot. Fields not present in
+    // overrides (notably profileName) are taken from the base record rather than
+    // left empty. baseShot is QVariant for the same reason as above (coerce()).
     Q_INVOKABLE void updateShotOnVisualizerWithOverrides(
         const QString& visualizerId,
-        const ShotProjection& baseShot,
+        const QVariant& baseShot,
         const QVariantMap& overrides);
 
     // Test connection with current credentials

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -68,14 +68,14 @@ public:
     // ShotHistoryStorage::convertShotRecord).
     Q_INVOKABLE void uploadShotFromHistory(const ShotProjection& shotData);
 
-    // Upload with metadata overrides applied on top of a base ShotProjection.
-    // Use from QML instead of Object.assign({}, editShotData, overrides): V4 can
-    // pass a QQmlValueTypeWrapper as ShotProjection, but Object.assign on a
-    // Q_GADGET yields a plain object that omits id/durationSec/frames, causing
-    // isValid() to fail silently with no UI feedback.
+    // Upload with metadata overrides applied on top of a base shot.
     // baseShot is QVariant (not const ShotProjection&) so a QML caller can pass
-    // an edited/cloned shot (plain JS object) as well as a raw gadget — see
-    // ShotProjection::coerce(). C++ callers wrap with QVariant::fromValue(shot).
+    // EITHER a raw ShotProjection gadget OR an edited/cloned shot (a plain JS
+    // object, e.g. clonePersistedShot's output) — ShotProjection::coerce()
+    // accepts both. This is why a plain object is now a supported input rather
+    // than something to avoid: coerce() reconstructs id/durationSec/frames that
+    // a bare Object.assign on a Q_GADGET would have dropped (causing isValid()
+    // to fail silently). C++ callers wrap with QVariant::fromValue(shot).
     Q_INVOKABLE void uploadShotFromHistoryWithOverrides(
         const QVariant& baseShot, const QVariantMap& overrides);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -166,6 +166,15 @@ add_decenza_test(tst_recipeparams
     ${CMAKE_SOURCE_DIR}/src/profile/recipeparams.cpp
 )
 
+# --- tst_shotprojection: ShotProjection::coerce() (QVariant → gadget) ---
+# shotprojection.h listed explicitly so AUTOMOC generates the Q_GADGET
+# meta-object (ShotProjection::staticMetaObject), required for QVariant::fromValue.
+add_decenza_test(tst_shotprojection
+    tst_shotprojection.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
+)
+
 # --- tst_settings: Settings persistence and defaults ---
 add_decenza_test(tst_settings
     tst_settings.cpp

--- a/tests/tst_shotprojection.cpp
+++ b/tests/tst_shotprojection.cpp
@@ -1,0 +1,99 @@
+#include <QTest>
+#include <QVariant>
+#include <QVariantMap>
+#include <QVariantList>
+
+#include "history/shotprojection.h"
+
+// Guards ShotProjection::coerce() — the conversion that lets Q_INVOKABLE
+// uploaders take `const QVariant&` and accept BOTH shapes QML hands across the
+// boundary: a genuine ShotProjection gadget, and a plain JS object (QVariantMap)
+// produced by PostShotReviewPage's clonePersistedShot after a badge update or a
+// metadata edit. Passing the clone to a `const ShotProjection&` parameter threw
+// "Could not convert argument from [object Object] to ShotProjection" on the
+// Qt 6.11 QML→C++ argument-binding path, silently dropping the visualizer PATCH.
+class TstShotProjection : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void coerce_gadgetVariant_passesThroughIntact();
+    void coerce_plainMap_reconstructsValidProjection();
+    void coerce_emptyVariant_yieldsInvalidProjection();
+    void coerce_nonMapScalar_yieldsInvalidProjection();
+};
+
+static ShotProjection makeSampleShot()
+{
+    ShotProjection p;
+    p.id = 974;
+    p.uuid = QStringLiteral("1923cf99-922a-4da5-9da0-ffbb81ba6cf5");
+    p.profileName = QStringLiteral("D-Flow / Q");
+    p.durationSec = 19.568;
+    p.finalWeightG = 34.8;
+    p.doseWeightG = 18.0;
+    p.beanBrand = QStringLiteral("Saka");
+    p.beanType = QStringLiteral("Gran Bar");
+    p.enjoyment0to100 = 75;
+    p.visualizerId = QStringLiteral("2767d127-a166-41a2-a3db-dc7d8834a2d6");
+    p.pressure = QVariantList{0.0, 6.0, 9.0};
+    p.flow = QVariantList{0.0, 1.8, 1.8};
+    return p;
+}
+
+// A genuine gadget wrapped in QVariant (the raw shotReady() shape, and what the
+// C++ MCP callers pass via QVariant::fromValue) must round-trip unchanged.
+void TstShotProjection::coerce_gadgetVariant_passesThroughIntact()
+{
+    const ShotProjection original = makeSampleShot();
+    const QVariant v = QVariant::fromValue(original);
+
+    const ShotProjection result = ShotProjection::coerce(v);
+
+    QVERIFY(result.isValid());
+    QCOMPARE(result.id, original.id);
+    QCOMPARE(result.profileName, original.profileName);
+    QCOMPARE(result.durationSec, original.durationSec);
+    QCOMPARE(result.visualizerId, original.visualizerId);
+    QCOMPARE(result.pressure.size(), original.pressure.size());
+    QCOMPARE(result.enjoyment0to100, original.enjoyment0to100);
+}
+
+// The regression case: a plain QVariantMap (what a QML JS object marshals to —
+// e.g. clonePersistedShot's output) must reconstruct a valid projection with
+// id / durationSec / curve arrays intact, so isValid() passes and the upload
+// is not silently dropped.
+void TstShotProjection::coerce_plainMap_reconstructsValidProjection()
+{
+    const ShotProjection sample = makeSampleShot();
+    const QVariantMap map = sample.toVariantMap();
+    const QVariant v(map);  // a QVariantMap, NOT a ShotProjection gadget
+
+    QVERIFY(v.userType() != qMetaTypeId<ShotProjection>());
+
+    const ShotProjection result = ShotProjection::coerce(v);
+
+    QVERIFY2(result.isValid(), "coerced clone must be valid (id != 0)");
+    QCOMPARE(result.id, sample.id);
+    QCOMPARE(result.profileName, sample.profileName);
+    QCOMPARE(result.durationSec, sample.durationSec);
+    QCOMPARE(result.visualizerId, sample.visualizerId);
+    QCOMPARE(result.pressure.size(), sample.pressure.size());
+}
+
+void TstShotProjection::coerce_emptyVariant_yieldsInvalidProjection()
+{
+    const ShotProjection result = ShotProjection::coerce(QVariant());
+    QVERIFY(!result.isValid());
+    QCOMPARE(result.id, qint64(0));
+}
+
+void TstShotProjection::coerce_nonMapScalar_yieldsInvalidProjection()
+{
+    const ShotProjection result = ShotProjection::coerce(QVariant(QStringLiteral("not a shot")));
+    QVERIFY(!result.isValid());
+}
+
+QTEST_APPLESS_MAIN(TstShotProjection)
+
+#include "tst_shotprojection.moc"

--- a/tests/tst_shotprojection.cpp
+++ b/tests/tst_shotprojection.cpp
@@ -2,6 +2,7 @@
 #include <QVariant>
 #include <QVariantMap>
 #include <QVariantList>
+#include <QRegularExpression>
 
 #include "history/shotprojection.h"
 
@@ -83,6 +84,9 @@ void TstShotProjection::coerce_plainMap_reconstructsValidProjection()
 
 void TstShotProjection::coerce_emptyVariant_yieldsInvalidProjection()
 {
+    // coerce() logs a diagnostic on empty/non-map input — assert it fires.
+    QTest::ignoreMessage(QtWarningMsg,
+        QRegularExpression("ShotProjection::coerce: empty/non-map arg.*"));
     const ShotProjection result = ShotProjection::coerce(QVariant());
     QVERIFY(!result.isValid());
     QCOMPARE(result.id, qint64(0));
@@ -90,6 +94,8 @@ void TstShotProjection::coerce_emptyVariant_yieldsInvalidProjection()
 
 void TstShotProjection::coerce_nonMapScalar_yieldsInvalidProjection()
 {
+    QTest::ignoreMessage(QtWarningMsg,
+        QRegularExpression("ShotProjection::coerce: empty/non-map arg.*"));
     const ShotProjection result = ShotProjection::coerce(QVariant(QStringLiteral("not a shot")));
     QVERIFY(!result.isValid());
 }


### PR DESCRIPTION
## Problem

Found while reviewing a debug log (build 3429 / v1.7.6). Editing a shot's metadata on the Post-Shot Review page and then leaving the page (or tapping Re-Upload) **silently fails to sync the edit to visualizer.coffee** — no error shown, because the page is being torn down.

Captured on the auto-update-on-destruction path (shot 976 → Steam):

```
PostShotReview: auto-updating visualizer shot 2767d127-… for shot id 976
WARN "Could not convert argument 1 from [object Object] to ShotProjection"
     maybeAutoUpdateVisualizer@PostShotReviewPage.qml:649
WARN TypeError: Passing incompatible arguments to C++ functions from JavaScript is not allowed.
```

## Root cause

`updateShotOnVisualizerWithOverrides()` and `uploadShotFromHistoryWithOverrides()` took `const ShotProjection&`. From QML the page passes `editShotData`, which is replaced by a **plain-JS clone** (`clonePersistedShot`) on the first quality-badge update *and* on every `saveEditedShot()`. A plain JS object does not convert to the `ShotProjection` Q_GADGET on the Qt 6.11 QML→C++ invokable argument-binding path — the registered `QVariantMap → ShotProjection` metatype converter doesn't engage there — so the call throws and the network request never fires.

Because the badge recompute happens on load, `editShotData` is a clone almost immediately, so this affected effectively every edit-then-sync.

This is the **same root cause and fix shape as #1298** (AI Advice/Discuss buttons dead after editing a shot), which switched `buildShotAnalysisProseForShot` to `QVariant` + a `coerceShot()` helper.

## Fix (C++ / QVariant)

- Add `ShotProjection::coerce(const QVariant&)` — accepts a genuine gadget **or** a plain `QVariantMap`, mirroring `AIManager::coerceShot()`. Canonical converter now lives on the type.
- Change both uploader methods to take `const QVariant& baseShot` and run `coerce()`.
- C++ callers (`mcptools_write`) wrap with `QVariant::fromValue()`.
- QML passes `editShotData` unchanged — the QML diff is comment-only now.
- Add `tst_shotprojection` covering `coerce()` for both shapes + invalid input.

## Testing

- App builds clean (0 errors, 0 warnings).
- `tst_shotprojection` passes (gadget passthrough, plain-map reconstruction, empty/invalid → invalid projection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)