### PR TITLE
fix(steam): keep user on steam page until health warning is dismissed (#1302)

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1911,13 +1911,26 @@ ApplicationWindow {
         }
     }
 
+    // When a post-session dialog (e.g. SteamHealthTracker scaleBuildupWarning)
+    // takes over from the completion overlay, this flag is set so completionTimer
+    // no-ops when it fires. The page's Dialog.onClosed drives navigation explicitly.
+    // If the page is destroyed before the dialog closes, the timer still fires once
+    // and is inert — the user is on whatever page replaced steamPage, so no further
+    // navigation is needed. The flag clears on the next showCompletion() or
+    // finishCompletion() so subsequent operations aren't suppressed.
+    property bool _completionSuspendedForDialog: false
+
     Timer {
         id: completionTimer
         interval: 1500  // 1.5s: short enough not to feel slow (reduced from 3s per user feedback)
-        onTriggered: finishCompletion()
+        onTriggered: {
+            if (_completionSuspendedForDialog) return
+            finishCompletion()
+        }
     }
 
     function showCompletion(message, type) {
+        _completionSuspendedForDialog = false
         completionMessage = message
         completionType = type
         completionPending = true
@@ -1925,17 +1938,18 @@ ApplicationWindow {
         completionTimer.restart()
     }
 
-    // Hide the completion overlay and stop its timer without navigating. Used
-    // when an operation page wants to hold the user on the page (e.g. a steam
-    // health warning dialog opened post-session and must be acknowledged).
-    // The page is responsible for calling finishCompletion() later.
+    // Hide the completion overlay and mark the timer's onTriggered as inert.
+    // Used when an operation page needs to hold the user on the page while a
+    // post-session modal dialog is up. The page is responsible for calling
+    // finishCompletion() from the dialog's onClosed.
     function suspendCompletionForDialog() {
-        completionTimer.stop()
+        _completionSuspendedForDialog = true
         completionPending = false
         completionOverlay.opacity = 0
     }
 
     function finishCompletion() {
+        _completionSuspendedForDialog = false
         completionPending = false
         completionOverlay.opacity = 0
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1914,25 +1914,7 @@ ApplicationWindow {
     Timer {
         id: completionTimer
         interval: 1500  // 1.5s: short enough not to feel slow (reduced from 3s per user feedback)
-        onTriggered: {
-            completionPending = false
-            completionOverlay.opacity = 0
-
-            // Return to saved page if set, otherwise go to idlePage
-            if (root.returnToPageName === "postShotReviewPage") {
-                var shotId = root.returnToShotId > 0 ? root.returnToShotId : MainController.lastSavedShotId
-                pageStack.replace(null, idlePage)
-                pageStack.push(postShotReviewPage, { editShotId: shotId })
-            } else {
-                if (pageStack.currentItem && pageStack.currentItem.objectName !== "idlePage") {
-                    pageStack.replace(null, idlePage)
-                }
-            }
-
-            // Clear return-to tracking
-            root.returnToPageName = ""
-            root.returnToShotId = 0
-        }
+        onTriggered: finishCompletion()
     }
 
     function showCompletion(message, type) {
@@ -1941,6 +1923,36 @@ ApplicationWindow {
         completionPending = true
         completionOverlay.opacity = 1  // Instant (Behavior disabled when opacity is 0)
         completionTimer.restart()
+    }
+
+    // Hide the completion overlay and stop its timer without navigating. Used
+    // when an operation page wants to hold the user on the page (e.g. a steam
+    // health warning dialog opened post-session and must be acknowledged).
+    // The page is responsible for calling finishCompletion() later.
+    function suspendCompletionForDialog() {
+        completionTimer.stop()
+        completionPending = false
+        completionOverlay.opacity = 0
+    }
+
+    function finishCompletion() {
+        completionPending = false
+        completionOverlay.opacity = 0
+
+        // Return to saved page if set, otherwise go to idlePage
+        if (root.returnToPageName === "postShotReviewPage") {
+            var shotId = root.returnToShotId > 0 ? root.returnToShotId : MainController.lastSavedShotId
+            pageStack.replace(null, idlePage)
+            pageStack.push(postShotReviewPage, { editShotId: shotId })
+        } else {
+            if (pageStack.currentItem && pageStack.currentItem.objectName !== "idlePage") {
+                pageStack.replace(null, idlePage)
+            }
+        }
+
+        // Clear return-to tracking
+        root.returnToPageName = ""
+        root.returnToShotId = 0
     }
 
     // Save current page info before navigating to operation pages (steam/flush/water)

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -213,16 +213,31 @@ Page {
         function onDescaleWarning() {
             steamWarningDialog.warningMessage = TranslationManager.translate("steam.warning.descale",
                 "Your machine may need descaling. Steam pressure was consistently too high.")
-            steamWarningDialog.open()
+            openPostSessionWarning()
         }
         function onTemperatureWarning(message) {
             steamWarningDialog.warningMessage = message
-            steamWarningDialog.open()
+            openPostSessionWarning()
         }
         function onScaleBuildupWarning(message) {
             steamWarningDialog.warningMessage = message
-            steamWarningDialog.open()
+            openPostSessionWarning()
         }
+    }
+
+    // The three SteamHealthTracker post-session signals above fire after the
+    // session ends, which is the same moment main.qml's completion overlay is
+    // counting down to navigate back to idle (#1302). If we let that timer
+    // fire, the dialog gets destroyed mid-display along with this page. Hide
+    // the completion overlay, stop its timer, and trigger navigation only
+    // once the user acknowledges the warning.
+    property bool _completionDeferredForWarning: false
+    function openPostSessionWarning() {
+        if (typeof root !== "undefined" && root.suspendCompletionForDialog) {
+            root.suspendCompletionForDialog()
+            _completionDeferredForWarning = true
+        }
+        steamWarningDialog.open()
     }
 
     // Post-session warning dialog
@@ -236,6 +251,14 @@ Page {
         width: Math.min(parent.width * 0.85, Theme.scaled(360))
         padding: Theme.spacingMedium
         onOpened: warningOkButton.forceActiveFocus()
+        onClosed: {
+            if (_completionDeferredForWarning) {
+                _completionDeferredForWarning = false
+                if (typeof root !== "undefined" && root.finishCompletion) {
+                    root.finishCompletion()
+                }
+            }
+        }
 
         background: Rectangle {
             color: Theme.surfaceColor

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -99,6 +99,12 @@ Page {
             // latch at the first sample of the new session, so if the new
             // session also trips a threshold, the banner will re-show.
             warningVisible = false
+            // Same for the post-session modal warning. A new session takes
+            // precedence; the dialog's onClosed checks isSteaming and skips
+            // the navigation back to idle so we stay on the steam page.
+            if (steamWarningDialog.opened) {
+                steamWarningDialog.close()
+            }
             // Preset reset runs in the else branch (at session end), not here.
             // Resetting at session start meant Settings was stale during the
             // window between state=Steam (when main.qml's onStateChanged fires
@@ -211,32 +217,37 @@ Page {
             warningVisible = true
         }
         function onDescaleWarning() {
-            steamWarningDialog.warningMessage = TranslationManager.translate("steam.warning.descale",
-                "Your machine may need descaling. Steam pressure was consistently too high.")
-            openPostSessionWarning()
+            openPostSessionWarning(TranslationManager.translate("steam.warning.descale",
+                "Your machine may need descaling. Steam pressure was consistently too high."))
         }
         function onTemperatureWarning(message) {
-            steamWarningDialog.warningMessage = message
-            openPostSessionWarning()
+            openPostSessionWarning(message)
         }
         function onScaleBuildupWarning(message) {
-            steamWarningDialog.warningMessage = message
-            openPostSessionWarning()
+            openPostSessionWarning(message)
         }
     }
 
     // The three SteamHealthTracker post-session signals above fire after the
     // session ends, which is the same moment main.qml's completion overlay is
     // counting down to navigate back to idle (#1302). If we let that timer
-    // fire, the dialog gets destroyed mid-display along with this page. Hide
-    // the completion overlay, stop its timer, and trigger navigation only
-    // once the user acknowledges the warning.
-    property bool _completionDeferredForWarning: false
-    function openPostSessionWarning() {
-        if (typeof root !== "undefined" && root.suspendCompletionForDialog) {
-            root.suspendCompletionForDialog()
-            _completionDeferredForWarning = true
+    // navigate, the dialog gets destroyed mid-display along with this page.
+    // Suspend the completion overlay and let Dialog.onClosed drive the
+    // navigation once the user acknowledges the warning.
+    //
+    // checkTrend() can emit both the pressure and the temperature trend warning
+    // in the same call. Dialog.open() on an already-open Dialog is a no-op, so
+    // simply setting warningMessage would silently drop the second message —
+    // concatenate instead so the user sees every warning that was emitted.
+    function openPostSessionWarning(msg) {
+        if (steamWarningDialog.opened) {
+            if (steamWarningDialog.warningMessage.indexOf(msg) < 0) {
+                steamWarningDialog.warningMessage += "\n\n" + msg
+            }
+            return
         }
+        steamWarningDialog.warningMessage = msg
+        root.suspendCompletionForDialog()
         steamWarningDialog.open()
     }
 
@@ -252,12 +263,11 @@ Page {
         padding: Theme.spacingMedium
         onOpened: warningOkButton.forceActiveFocus()
         onClosed: {
-            if (_completionDeferredForWarning) {
-                _completionDeferredForWarning = false
-                if (typeof root !== "undefined" && root.finishCompletion) {
-                    root.finishCompletion()
-                }
-            }
+            // If a new session started while the dialog was up (user hit the
+            // hardware GHC button while still acknowledging the prior session's
+            // warning), don't navigate to idle — they're steaming again.
+            if (isSteaming) return
+            root.finishCompletion()
         }
 
         background: Rectangle {


### PR DESCRIPTION
## Summary

- Fixes [#1302](https://github.com/Kulitorum/Decenza/issues/1302) — post-session "Steam Warning" dialog flashes briefly then disappears before the user can read it.
- Root cause: the `completionTimer` in `main.qml` (1.5s after Steam→Idle) calls `pageStack.replace(null, idlePage)`, destroying `SteamPage` and its child `steamWarningDialog`. `SteamHealthTracker::checkTrend()` emits `scaleBuildupWarning` ~140ms after Steam→Idle, so the dialog opens with only the remainder of the 1.5s window before the page is yanked.
- Fix: when one of the three post-session warnings (`descaleWarning`, `temperatureWarning`, `scaleBuildupWarning`) opens the dialog, hide the completion overlay and stop its timer. Run the navigation only from the dialog's `onClosed` handler, so the user stays on `SteamPage` until they tap OK.

## Implementation

- `main.qml`: split `completionTimer.onTriggered` body into a reusable `finishCompletion()`; add `suspendCompletionForDialog()` that hides the overlay and stops the timer.
- `SteamPage.qml`: route the three SteamHealthTracker post-session signals through `openPostSessionWarning()`, which calls `suspendCompletionForDialog()` before `open()`. The dialog's `onClosed` then calls `finishCompletion()` so navigation to idle still happens — just on the user's acknowledgment rather than a fixed timer.
- The live banner (`pressureTooHigh` / `temperatureTooHigh`) is unchanged — it fires mid-session, not at end-of-session, so it doesn't hit this race.

## Test plan

- [ ] Reproduce the original bug on `main` by simulating a high-pressure steam trend session (block tip + steam ≥5 sessions) and confirm the warning vanishes when "Steam Complete" navigates back.
- [ ] On this branch, repeat: the completion overlay should disappear once the dialog opens, the dialog stays until tapped, and tapping OK returns to the idle page.
- [ ] Verify a normal steam session with no warning still shows "Steam Complete" and navigates to idle after 1.5s as before.
- [ ] Verify the live banner (pressure spike mid-session) still appears and persists in the banner area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)