### PR TITLE
[a11y-dbg] TEMP: logging to reproduce TalkBack text-field issues (#1300)

### DIFF
--- a/qml/components/StyledTextField.qml
+++ b/qml/components/StyledTextField.qml
@@ -29,12 +29,19 @@ TextField {
     // Show the keyboard only then — not when TalkBack explore-by-touch gives focus.
     // Non-accessibility mode: still activate the field so VoiceOver/switch-access work.
     Accessible.onPressAction: {
+        // [a11y-dbg] TEMP (#1300) — remove before merge
+        console.log("[a11y-dbg] onPressAction (double-tap) field='"
+                    + (accessibleName || placeholder) + "' a11yMode=" + _accessibilityMode)
         if (_accessibilityMode) {
             _a11yActivated = true
         }
         control.forceActiveFocus()
         Qt.inputMethod.show()
     }
+
+    // [a11y-dbg] TEMP (#1300) — confirms user edits reach QML (Claim 2 echo). Remove before merge.
+    onTextEdited: console.log("[a11y-dbg] textEdited field='"
+                              + (accessibleName || placeholder) + "' len=" + text.length)
 
     // When TalkBack cursor lands on the field, Qt gives it activeFocus and auto-shows
     // the keyboard. In accessibility mode, suppress this so the user can hear the
@@ -44,7 +51,15 @@ TextField {
     Connections {
         target: control
         function onActiveFocusChanged() {
+            // [a11y-dbg] TEMP (#1300) — remove before merge
+            console.log("[a11y-dbg] focusChanged field='" + (control.accessibleName || control.placeholder)
+                        + "' activeFocus=" + control.activeFocus
+                        + " a11yMode=" + control._accessibilityMode
+                        + " a11yActivated=" + control._a11yActivated
+                        + " imeVisible=" + Qt.inputMethod.visible)
             if (control.activeFocus && control._accessibilityMode && !control._a11yActivated) {
+                console.log("[a11y-dbg] -> suppressing keyboard (inputMethod.hide) for '"
+                            + (control.accessibleName || control.placeholder) + "'")
                 Qt.inputMethod.hide()
             }
             if (!control.activeFocus) {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -27,6 +27,21 @@ ApplicationWindow {
     leftPadding: 0
     rightPadding: 0
 
+    // [a11y-dbg] TEMP diagnostic for issue #1300 — remove before merge.
+    // Logs every soft-keyboard show/hide and which item is focused, so we can
+    // reproduce the TalkBack "keyboard opens on focus / focus trap" on the tablet.
+    // If `IME visible=true` appears right after a field gains focus WITHOUT a
+    // preceding onPressAction (double-tap), that is the trap reproduced.
+    Connections {
+        target: Qt.inputMethod
+        function onVisibleChanged() {
+            console.log("[a11y-dbg] IME visible=" + Qt.inputMethod.visible
+                        + " a11yEnabled=" + (typeof AccessibilityManager !== "undefined"
+                                             && AccessibilityManager.enabled)
+                        + " focusItem=" + root.activeFocusItem)
+        }
+    }
+
     // Debug flag to force live view on operation pages (for development)
     property bool debugLiveView: false
 


### PR DESCRIPTION
## Purpose

**Diagnostic only — not for merge as-is.** Temporary `console.log` tracing (all tagged `[a11y-dbg]`) to reproduce and pin down the two TalkBack text-field problems reported in #1300 on a real device:

- **Claim 1** — keyboard opens the instant a field gets accessibility focus (focus trap); can't swipe past.
- **Claim 2** — no spoken feedback while typing/deleting (no character echo).

The reporter has confirmed **Enable Accessibility is ON**, so the existing `StyledTextField` keyboard-suppression is already engaged for him yet Claim 1 still occurs — this logging is to determine whether it's a show/hide race or a field not covered by `StyledTextField`.

## What it adds

- **`qml/main.qml`** — global `Qt.inputMethod.onVisibleChanged` watcher logging keyboard show/hide + the focused item. Catches *any* field (including non-`StyledTextField`) and reveals whether the keyboard shows on explore-focus.
- **`qml/components/StyledTextField.qml`** — logs focus changes (`activeFocus` / `a11yMode` / `a11yActivated` / `imeVisible`), when the `inputMethod.hide()` suppression fires, the double-tap `onPressAction`, and `textEdited` (confirms edits reach QML for Claim 2).

## How to read the log (grep `[a11y-dbg]`)

- `focusChanged … activeFocus=true a11yMode=true a11yActivated=false` → `-> suppressing keyboard (inputMethod.hide)` = suppression fired.
- A following `IME visible=true` with no preceding `onPressAction` = keyboard won the **race** despite hide() → confirms the `activeFocusOnPress` fix is needed.
- A keyboard show with only a global `IME visible=true focusItem=…` line and no `focusChanged` = field is not a `StyledTextField`; `focusItem=` names the type to fix.
- `textEdited …` on typing + TalkBack silence = Claim 2 is the Qt platform echo gap (addressed separately by the qtbase patch).

## After repro

Revert this PR (or strip the `[a11y-dbg]` lines) once the trace is captured. The actual fixes land separately:
- Claim 1: race-free `activeFocusOnPress` change app-side (+ upstream qtdeclarative).
- Claim 2: qtbase Android platform-plugin patch (custom `.so`) + upstream Gerrit.

Builds clean (macOS, 0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)