### PR TITLE
fix(ble): keep DE1 reconnect counter across failed retries (#1309)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1503,9 +1503,28 @@ int main(int argc, char *argv[])
             if (settings.machineAddress().isEmpty()) {
                 qDebug() << "DE1 reconnect: no saved address — skipping auto-reconnect";
             } else if (!de1ReconnectTimer.isActive()) {
-                de1ReconnectAttempt = 0;
-                de1ReconnectTimer.start(5000);  // First retry after 5s
-                qDebug() << "DE1 reconnect: scheduled first retry in 5000 ms";
+                // Distinguish a fresh disconnect (attempt counter is 0) from a
+                // mid-schedule retry attempt that failed (counter > 0). Resetting
+                // unconditionally meant every failed retry restarted the 5 s
+                // schedule, so the backoff never escalated and the "retries
+                // exhausted" branch was dead code — the loop hammered the radio
+                // every ~35 s forever (see issue #1309). The timer-callback also
+                // schedules the next interval, but its singleShot can be consumed
+                // by an "already connecting" early-return when a still-pending
+                // attempt is in flight; this path is the fallback that keeps the
+                // schedule advancing when that race happens.
+                if (de1ReconnectAttempt == 0) {
+                    de1ReconnectTimer.start(5000);  // Fresh disconnect — first retry after 5s
+                    qDebug() << "DE1 reconnect: scheduled first retry in 5000 ms";
+                } else if (de1ReconnectAttempt < kDE1MaxReconnectAttempts) {
+                    const int delay = de1ReconnectAttempt == 1 ? 30000 : 60000;
+                    de1ReconnectTimer.start(delay);
+                    qDebug() << "DE1 reconnect: attempt" << de1ReconnectAttempt
+                             << "failed, next retry in" << delay << "ms";
+                } else {
+                    qDebug() << "DE1 reconnect: retries exhausted after"
+                             << de1ReconnectAttempt << "attempts";
+                }
             }
         }
     });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1506,13 +1506,16 @@ int main(int argc, char *argv[])
                 // Distinguish a fresh disconnect (attempt counter is 0) from a
                 // mid-schedule retry attempt that failed (counter > 0). Resetting
                 // unconditionally meant every failed retry restarted the 5 s
-                // schedule, so the backoff never escalated and the "retries
-                // exhausted" branch was dead code — the loop hammered the radio
-                // every ~35 s forever (see issue #1309). The timer-callback also
-                // schedules the next interval, but its singleShot can be consumed
-                // by an "already connecting" early-return when a still-pending
-                // attempt is in flight; this path is the fallback that keeps the
-                // schedule advancing when that race happens.
+                // schedule, so the backoff never escalated past attempt 1 — and
+                // the "retries exhausted" branch was dead code because the
+                // counter never reached the cap (see issue #1309).
+                //
+                // After the fix this branch is the primary scheduler for every
+                // retry after the first: on each failed attempt the timer-
+                // callback's "already connecting" early-return (line 1430-1432)
+                // bails without rescheduling, then a later connecting→disconnected
+                // emission lands here while the timer is idle and advances the
+                // schedule to the next backoff step.
                 if (de1ReconnectAttempt == 0) {
                     de1ReconnectTimer.start(5000);  // Fresh disconnect — first retry after 5s
                     qDebug() << "DE1 reconnect: scheduled first retry in 5000 ms";


### PR DESCRIPTION
## Summary

- The DE1 auto-reconnect schedule was supposed to escalate `5s → 30s → 10×60s` and then stop after 12 attempts (~10.5 min). Instead every retry logged `attempt 1 of 12` and the loop spun forever — the `retries exhausted` branch was dead code.
- Root cause is in [src/main.cpp:1494](https://github.com/Kulitorum/Decenza/blob/main/src/main.cpp#L1494): when a retry attempt failed (`Connecting → Unconnected` via the QLE supervision timeout), the `connectedChanged` handler's `wasActive → inactive` branch unconditionally reset `de1ReconnectAttempt = 0` and restarted the 5s timer. That reset is correct for "we were connected and dropped" but was also firing for "a mid-schedule retry just failed", so the schedule never advanced past the first rung.
- Fix: distinguish a fresh disconnect (`de1ReconnectAttempt == 0`) from a mid-schedule retry failure (counter > 0). Fresh disconnect keeps the 5s first-retry behaviour; mid-schedule failure continues the backoff at the appropriate interval and surfaces the exhausted case. The timer-callback's own schedule-next logic is left in place; this branch is the fallback that keeps the counter advancing when the singleShot is consumed by an `already connecting` early-return racing the supervision timeout.

## Scope

This is *not* a fix for the underlying BLE-stack wedge that triggers the reconnect loop in [#1309](https://github.com/Kulitorum/Decenza/issues/1309) — that's a separate problem (likely Android BT stack on the LingenOS P80X tablet that needs a tablet reboot to recover). What this PR fixes:

- The schedule now actually escalates per the documented backoff.
- After ~10.5 min the loop stops hammering the radio instead of spinning forever.
- The debug log stops being misleading (`attempt 1 of 12` x ∞ → real attempt counts).

## Evidence

From the [#1309 debug log](https://github.com/user-attachments/files/28680122/debug.zip), the cycle repeats every ~30 s:

```
[363665.957] [BLE DE1] Write timeout, retrying 1/10 (uuid=0000a006)
...
[363691.099] [BLE DE1] Controller disconnected
[363691.096] DE1 reconnect: scheduled first retry in 5000 ms
[363695.957] DE1 reconnect: attempt 1 of 12
[363725.957] DE1 reconnect: already connected/connecting, stopping retries
[363726.059] [BLE DE1] !!! CONTROLLER ERROR: ConnectionError (state=Unconnected) !!!
[363726.099] DE1 reconnect: scheduled first retry in 5000 ms   <-- reset, attempt back to 0
[363730.958] DE1 reconnect: attempt 1 of 12                     <-- and again
... forever
```

## Test plan

- [x] App + all tests build clean (macOS Debug, 0 errors / 0 warnings via Qt Creator).
- [ ] Manual: simulate a DE1 disconnect (e.g. turn off the machine while connected), watch the log to verify attempts now increment 1 → 2 → 3 ... and the schedule moves through 5s → 30s → 60s.
- [ ] Manual: verify exhausted log line fires after attempt 12.
- [ ] Manual: verify app resume / autoWake / scale-discovered paths still work (they explicitly reset `de1ReconnectAttempt = 0` before starting, so they compose correctly with the new branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)