### PR TITLE
log(ble): surface force=true MMR keepalive writes (#1309)

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1262,25 +1262,31 @@ void DE1Device::writeMMR(uint32_t address, uint32_t value,
         return;
     }
 
-    // Log the dispatched write. force=true + unchanged is tagged "keepalive"
-    // instead of "write" so it's still trivially grep-filterable when the noise
-    // matters, but the BatteryManager's 60 s USB-charger refresh is now visible
-    // in bug reports. Without this, a wedge log shows a 5 s "Write timeout" out
-    // of nowhere because the write that actually started the timeout never
-    // logged anything (see #1309). For writeMMRVerified retries the caller
-    // already logs "[MMR] verify retry" before invoking writeMMR, so the retry
-    // BLE write is still traceable without a duplicate log here.
+    // Log the dispatched write. Three tags so grep counts stay accurate:
+    //   "[MMR] write:"       — value changed since the last write to this addr.
+    //   "[MMR] retry-write:" — writeMMRVerified retry (force=true + unchanged
+    //                          because the cache holds the expected value, and
+    //                          reason carries the "-retry" suffix).
+    //   "[MMR] keepalive:"   — force=true + unchanged from any other caller.
+    //                          In practice that's only BatteryManager's 60 s
+    //                          USB-charger refresh.
+    // Before this split a wedge log showed a 5 s "Write timeout" out of nowhere
+    // because the write that actually started the timeout never logged anything
+    // (see #1309). The retry sub-tag also keeps a `grep keepalive` count of
+    // charger refreshes from being polluted by verify retries.
+    QString tag;
     if (!valueUnchanged) {
-        qDebug().noquote() << QString("[MMR] write: 0x%1 = %2%3")
-            .arg(address, 6, 16, QLatin1Char('0'))
-            .arg(value)
-            .arg(reasonSuffix);
+        tag = QStringLiteral("write");
+    } else if (reason.endsWith(QStringLiteral("-retry"))) {
+        tag = QStringLiteral("retry-write");
     } else {
-        qDebug().noquote() << QString("[MMR] keepalive: 0x%1 = %2%3")
-            .arg(address, 6, 16, QLatin1Char('0'))
-            .arg(value)
-            .arg(reasonSuffix);
+        tag = QStringLiteral("keepalive");
     }
+    qDebug().noquote() << QString("[MMR] %1: 0x%2 = %3%4")
+        .arg(tag)
+        .arg(address, 6, 16, QLatin1Char('0'))
+        .arg(value)
+        .arg(reasonSuffix);
 
     m_lastMMRValues.insert(address, value);
     m_transport->write(DE1::Characteristic::WRITE_TO_MMR, buildMMRPayload(address, value));

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -1262,13 +1262,21 @@ void DE1Device::writeMMR(uint32_t address, uint32_t value,
         return;
     }
 
-    // Log only when the value changes. force=true + unchanged is intentionally
-    // silent: the USB charger keepalive fires every 60 s at the same value and
-    // was the dominant source of log noise. For writeMMRVerified retries the
-    // caller already logs "[MMR] verify retry" before invoking writeMMR, so
-    // the retry BLE write is still traceable without a duplicate log here.
+    // Log the dispatched write. force=true + unchanged is tagged "keepalive"
+    // instead of "write" so it's still trivially grep-filterable when the noise
+    // matters, but the BatteryManager's 60 s USB-charger refresh is now visible
+    // in bug reports. Without this, a wedge log shows a 5 s "Write timeout" out
+    // of nowhere because the write that actually started the timeout never
+    // logged anything (see #1309). For writeMMRVerified retries the caller
+    // already logs "[MMR] verify retry" before invoking writeMMR, so the retry
+    // BLE write is still traceable without a duplicate log here.
     if (!valueUnchanged) {
         qDebug().noquote() << QString("[MMR] write: 0x%1 = %2%3")
+            .arg(address, 6, 16, QLatin1Char('0'))
+            .arg(value)
+            .arg(reasonSuffix);
+    } else {
+        qDebug().noquote() << QString("[MMR] keepalive: 0x%1 = %2%3")
             .arg(address, 6, 16, QLatin1Char('0'))
             .arg(value)
             .arg(reasonSuffix);


### PR DESCRIPTION
## Summary

`writeMMR` previously logged nothing when `force=true` and the value was unchanged. That case exists exclusively for the BatteryManager USB-charger refresh (60 s cadence, `force=true` to beat the DE1's 10-min auto-revert timeout). Silencing it kept the log clean — at the cost of making bug reports unreadable. The [#1309](https://github.com/Kulitorum/Decenza/issues/1309) wedge log shows a 5 s `Write timeout` line out of nowhere, because the write that *triggered* it never logged anything. We spent half a debugging session figuring out what was sent.

This PR tags the previously-silent path as `[MMR] keepalive` (instead of `[MMR] write`). Same payload, distinct prefix so it stays trivially grep-filterable when the noise isn't wanted:

```
grep -v '\[MMR\] keepalive' debug.log     # original quiet behavior
grep '\[MMR\]' debug.log                  # see every write including keepalives
```

Volume: 1 line per minute per connected session — ~1440 lines/day, ~14 % of the #1309 log over 4 days. Manageable.

## Test plan

- [x] App + all tests build clean (macOS Debug, 0/0).
- [ ] Manual: connect a DE1. After a steady-state idle period, verify a `[MMR] keepalive: 0x803854 = X [setUsbChargerOn]` line appears once a minute.
- [ ] Manual: toggle the charger state (e.g. cross the 65 % threshold). Verify the *state-change* write still shows as `[MMR] write:` (not keepalive), and subsequent unchanged refreshes show as `[MMR] keepalive:`.

## Related

- [#1311](https://github.com/Kulitorum/Decenza/pull/1311) — DE1 reconnect counter reset fix (orthogonal).
- [#1312](https://github.com/Kulitorum/Decenza/pull/1312) — Pause BLE scans during screensaver (probably hold; see the PR discussion).
- Diagnostic intent: make the next #1309-shaped report tell us exactly what was on the wire in the 5 s before the timeout, so we can stop guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)