### PR TITLE
fix(update): re-prompt when build bumps within the same release tag

### DIFF
--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -313,9 +313,21 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
     bool wasBeta = m_latestIsBeta;
     m_latestIsBeta = release["prerelease"].toBool();
 
-    // Reset prompt flag when a new release is discovered so the user gets
-    // notified once for each new version (but not repeatedly for the same one)
-    if (m_releaseTag != tagName) {
+    // Extract build number from release notes (look for "Build: XXXX" or "Build XXXX")
+    int newBuildNumber = 0;
+    QRegularExpression buildRe(R"(Build[:\s]+(\d+))", QRegularExpression::CaseInsensitiveOption);
+    QRegularExpressionMatch buildMatch = buildRe.match(body);
+    if (buildMatch.hasMatch()) {
+        newBuildNumber = buildMatch.captured(1).toInt();
+    } else {
+        // Fallback: extract from APK filename pattern (Decenza_X.Y.Z.apk where Z might be build)
+        newBuildNumber = extractBuildNumber(tagName);
+    }
+
+    // Reset prompt flag when a new release OR a new build of the same tag is
+    // discovered, so the user gets notified once per build (CI publishes
+    // multiple builds under the same vX.Y.Z tag).
+    if (m_releaseTag != tagName || m_latestBuildNumber != newBuildNumber) {
         m_updatePromptShown = false;
         // Invalidate cached APK from previous version. Don't delete the file —
         // a PackageInstaller session may still be streaming from it. The cache
@@ -329,16 +341,7 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
     m_releaseTag = tagName;
     m_latestVersion = tagName.startsWith("v") ? tagName.mid(1) : tagName;
     m_releaseNotes = body;
-
-    // Extract build number from release notes (look for "Build: XXXX" or "Build XXXX")
-    QRegularExpression buildRe(R"(Build[:\s]+(\d+))", QRegularExpression::CaseInsensitiveOption);
-    QRegularExpressionMatch buildMatch = buildRe.match(body);
-    if (buildMatch.hasMatch()) {
-        m_latestBuildNumber = buildMatch.captured(1).toInt();
-    } else {
-        // Fallback: extract from APK filename pattern (Decenza_X.Y.Z.apk where Z might be build)
-        m_latestBuildNumber = extractBuildNumber(tagName);
-    }
+    m_latestBuildNumber = newBuildNumber;
 
     emit latestVersionChanged();
     emit latestVersionCodeChanged();


### PR DESCRIPTION
## Summary
- The update-available dialog was deduped by GitHub release tag (`v1.7.6`), so when CI rebuilt the same tag with a higher `Build:` number, the periodic checker logged `newer=true` for hours but never re-fired the modal.
- Reset `m_updatePromptShown` when either the tag **or** the parsed build number changes, so the user gets one prompt per build.

## Why
On main, [`UpdateChecker::parseReleaseInfo`](src/core/updatechecker.cpp) only reset the prompt flag when `m_releaseTag != tagName`. A live device sitting on `1.7.6` build 3432 saw `latestBuild=3433` at 07:31, then `3433` again at 08:31 and 09:31 — all `newer=true`, all silent. The Settings → About chip updates fine, but the modal never re-opens.

Repro from a real log:
```
[255601] UpdateChecker: current="1.7.6" build=3432 latest="1.7.6" latestBuild=3433 newer=true tag="v1.7.6"
[259201] UpdateChecker: current="1.7.6" build=3432 latest="1.7.6" latestBuild=3433 newer=true tag="v1.7.6"
[262801] UpdateChecker: current="1.7.6" build=3432 latest="1.7.6" latestBuild=3433 newer=true tag="v1.7.6"
```

## Test plan
- [x] Local build clean (Qt Creator MCP, 0 errors / 0 warnings)
- [ ] Manual: install a build, hand-edit the GitHub release body's `Build: NNNN` to a higher number, wait for the next hourly periodic check, confirm the dialog opens
- [ ] Tag-change path still works (bump VERSION → new vX.Y.Z release → dialog opens once)
- [ ] Dismiss → next periodic check (same build) does NOT re-prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)