### PR TITLE
fix(refractometer): show "R1 Off" when paired model is a DiFluid R1

### DIFF
--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -852,11 +852,13 @@ Page {
                     }
                 }
 
-                // Read TDS button (R2 refractometer)
+                // Read TDS button (DiFluid R1 / R2 refractometer)
                 Rectangle {
                     id: readTdsButton
                     property bool refConnected: BLEManager.refractometerConnected
                     property bool refMeasuring: refConnected && typeof Refractometer !== "undefined" && Refractometer && Refractometer.measuring
+                    // R1 advertises with names starting "DFT_TDJ_*" (see DiFluidR1::isR1Device).
+                    property bool isR1: (Settings.savedRefractometerName || "").toLowerCase().indexOf("dft_tdj") === 0
                     visible: Settings.savedRefractometerAddress !== ""
                     Layout.preferredWidth: Theme.scaled(80)
                     Layout.preferredHeight: Theme.scaled(36)
@@ -871,7 +873,11 @@ Page {
                     Text {
                         anchors.centerIn: parent
                         text: {
-                            if (!readTdsButton.refConnected) return TranslationManager.translate("postshotreview.refractometer.off", "R2 Off")
+                            if (!readTdsButton.refConnected) {
+                                return readTdsButton.isR1
+                                    ? TranslationManager.translate("postshotreview.refractometer.r1off", "R1 Off")
+                                    : TranslationManager.translate("postshotreview.refractometer.r2off", "R2 Off")
+                            }
                             if (readTdsButton.refMeasuring) return TranslationManager.translate("postshotreview.refractometer.measuring", "...")
                             return TranslationManager.translate("postshotreview.refractometer.readTds", "Read TDS")
                         }


### PR DESCRIPTION
## Summary

- The disconnected-refractometer button on the post-shot review page was hardcoded to "R2 Off" from before R1 support landed in [#1308](https://github.com/Kulitorum/Decenza/pull/1308). Users with a DiFluid R1 paired saw the wrong model name whenever the device was asleep.
- Detect R1 vs R2 from the saved BLE advertised name using the same `"DFT_TDJ"` prefix check `DiFluidR1::isR1Device` uses in [src/ble/refractometers/difluidr1.cpp:128](https://github.com/Kulitorum/Decenza/blob/main/src/ble/refractometers/difluidr1.cpp#L128), and split the translation key into `r1off` / `r2off`.

Reported by a tester with an R1.

## Test plan

- [ ] With an R1 paired and disconnected, the post-shot review button reads "R1 Off"
- [ ] With an R2 paired and disconnected, the button still reads "R2 Off"
- [ ] When connected, the button still reads "Read TDS" / "..." while measuring

🤖 Generated with [Claude Code](https://claude.com/claude-code)