### PR TITLE
fix(scale): pause Decent Scale battery poll while LCD is off

### DIFF
--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -75,6 +75,7 @@ void DecentScale::onTransportDisconnected() {
     m_firmwareVersion.clear();
     m_lastBatteryByte = -1;
     m_ticksSinceBatteryPoll = 0;
+    m_lcdOn = true;
     setConnected(false);
 }
 
@@ -402,6 +403,7 @@ void DecentScale::wake() {
     // Command 0A 01 01 00 01 enables LCD (grams mode)
     // Must match official de1app: 03 0A 01 01 00 01 [xor]
     sendCommand(QByteArray::fromHex("0A01010001"));
+    m_lcdOn = true;
 
     // Restart heartbeat and watchdog if they were stopped by sleep()
     if (m_characteristicsReady) {
@@ -415,6 +417,7 @@ void DecentScale::disableLcd() {
     // This is different from sleep() which powers off the scale completely
     DECENT_LOG("Disabling LCD (scale stays powered)");
     sendCommand(QByteArray::fromHex("0A0000"));
+    m_lcdOn = false;
 }
 
 void DecentScale::sendHeartbeat() {
@@ -436,8 +439,13 @@ void DecentScale::startHeartbeat() {
             // as battery — heartbeat alone never produces this reply.
             if (++m_ticksSinceBatteryPoll >= kBatteryPollHeartbeatTicks) {
                 m_ticksSinceBatteryPoll = 0;
-                DECENT_LOG("Polling battery (display-on refresh)");
-                sendCommand(QByteArray::fromHex("0A01010001"));
+                if (m_lcdOn) {
+                    DECENT_LOG("Polling battery (display-on refresh)");
+                    sendCommand(QByteArray::fromHex("0A01010001"));
+                }
+                // else: LCD intentionally off (DE1 sleep, keepScaleOn=true).
+                // Skip the poll — the display-on command would relight the
+                // LCD. Battery resumes refreshing when wake() is called.
             }
         });
     }

--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -388,6 +388,7 @@ void DecentScale::resetTimer() {
 void DecentScale::sleep() {
     stopWatchdog();
     stopHeartbeat();
+    m_lcdOn = false;
     if (!m_transport || !m_characteristicsReady) {
         emit sleepCompleted();
         return;
@@ -443,9 +444,7 @@ void DecentScale::startHeartbeat() {
                     DECENT_LOG("Polling battery (display-on refresh)");
                     sendCommand(QByteArray::fromHex("0A01010001"));
                 }
-                // else: LCD intentionally off (DE1 sleep, keepScaleOn=true).
-                // Skip the poll — the display-on command would relight the
-                // LCD. Battery resumes refreshing when wake() is called.
+                // else: skip poll while LCD is off — see m_lcdOn.
             }
         });
     }

--- a/src/ble/scales/decentscale.h
+++ b/src/ble/scales/decentscale.h
@@ -67,8 +67,10 @@ private:
     // periodic re-polling the value goes stale; piggyback on the 1 s
     // heartbeat tick — every Nth tick re-send display-on, the scale's reply
     // refreshes battery. ~4 minutes is a comfortable middle of the 3-5 min
-    // range Jeff asked for, and the heartbeat already stops when the scale
-    // sleeps (sleep() calls stopHeartbeat) so polling auto-pauses too.
+    // range Jeff asked for. The poll auto-pauses when the scale is asleep
+    // (sleep() calls stopHeartbeat) and is also gated on m_lcdOn so that
+    // disableLcd() (DE1 sleep + keepScaleOn=true) doesn't relight the LCD
+    // every ~4 min — see #1279 and the disableLcd() regression follow-up.
     static constexpr int kBatteryPollHeartbeatTicks = 240;
 
     ScaleBleTransport* m_transport = nullptr;
@@ -95,4 +97,10 @@ private:
     QTimer* m_heartbeatTimer = nullptr;
     QTimer* m_watchdogTimer = nullptr;
     bool m_heartbeatsPaused = false;
+    // disableLcd() clears this; wake() sets it. The periodic battery poll
+    // re-sends the display-on command (same bytes as wake()), so if it fires
+    // while LCD is off (DE1 asleep, keepScaleOn=true) it lights the LCD back
+    // up ~4 min into the user's sleep period. Gate the poll on this flag —
+    // the regular heartbeat keeps running so the BLE link stays alive.
+    bool m_lcdOn = true;
 };

--- a/src/ble/scales/decentscale.h
+++ b/src/ble/scales/decentscale.h
@@ -70,7 +70,7 @@ private:
     // range Jeff asked for. The poll auto-pauses when the scale is asleep
     // (sleep() calls stopHeartbeat) and is also gated on m_lcdOn so that
     // disableLcd() (DE1 sleep + keepScaleOn=true) doesn't relight the LCD
-    // every ~4 min — see #1279 and the disableLcd() regression follow-up.
+    // every ~4 min — see #1279.
     static constexpr int kBatteryPollHeartbeatTicks = 240;
 
     ScaleBleTransport* m_transport = nullptr;
@@ -97,10 +97,6 @@ private:
     QTimer* m_heartbeatTimer = nullptr;
     QTimer* m_watchdogTimer = nullptr;
     bool m_heartbeatsPaused = false;
-    // disableLcd() clears this; wake() sets it. The periodic battery poll
-    // re-sends the display-on command (same bytes as wake()), so if it fires
-    // while LCD is off (DE1 asleep, keepScaleOn=true) it lights the LCD back
-    // up ~4 min into the user's sleep period. Gate the poll on this flag —
-    // the regular heartbeat keeps running so the BLE link stays alive.
+    // Gates the periodic battery poll — see kBatteryPollHeartbeatTicks above.
     bool m_lcdOn = true;
 };

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -29,12 +29,15 @@ public:
     void discoverCharacteristics(const QBluetoothUuid&) override {}
     void enableNotifications(const QBluetoothUuid&, const QBluetoothUuid&) override { m_notifyEnableCount++; }
     void writeCharacteristic(const QBluetoothUuid&, const QBluetoothUuid&,
-                             const QByteArray&, WriteType = WriteType::WithResponse) override {}
+                             const QByteArray& value, WriteType = WriteType::WithResponse) override {
+        m_writes.append(value);
+    }
     void readCharacteristic(const QBluetoothUuid&, const QBluetoothUuid&) override {}
     bool isConnected() const override { return true; }
 
     int m_notifyEnableCount = 0;
     int m_disconnectCount = 0;
+    QList<QByteArray> m_writes;
 };
 
 class tst_ScaleProtocol : public QObject {
@@ -685,6 +688,37 @@ private slots:
 
         QCOMPARE(transport->m_notifyEnableCount, 0);
         QCOMPARE(transport->m_disconnectCount, 0);
+    }
+
+    // Regression for #1317: with the LCD intentionally off (disableLcd() — the
+    // DE1-sleep + keepScaleOn=true path) the ~4-min battery refresh must NOT
+    // re-send the display-on command, which is the same byte sequence wake()
+    // uses and would silently relight the LCD ~4 min into the user's sleep.
+    void batteryPollSuppressedAfterDisableLcd() {
+        auto* transport = new MockScaleBleTransport;
+        DecentScale scale(transport);
+
+        scale.m_characteristicsReady = true;
+        scale.startHeartbeat();
+        scale.disableLcd();
+
+        // Drop everything written so far (the disableLcd 0A0000 packet) so the
+        // assertion below sees only what the next heartbeat tick produces.
+        transport->m_writes.clear();
+        // Seed the tick counter so one heartbeat tick crosses the battery-poll
+        // boundary — avoids a ~240 s real-time wait.
+        scale.m_ticksSinceBatteryPoll = DecentScale::kBatteryPollHeartbeatTicks - 1;
+
+        // One heartbeat fires.
+        QTest::qWait(1100);
+
+        // The only payload in this window that should NOT appear is the
+        // display-on packet (0x03 0x0A 0x01 0x01 0x00 0x01 [xor]) — that's
+        // the bug. Heartbeat (0x03 0x0A 0x03 0xFF 0xFF [xor]) is fine.
+        for (const auto& w : std::as_const(transport->m_writes)) {
+            QVERIFY2(!w.contains(QByteArray::fromHex("0A01010001")),
+                     "Battery poll fired while LCD was off — would relight LCD");
+        }
     }
 
     void wakeRestartsWatchdog() {


### PR DESCRIPTION
## Summary

A user reports their Decent Scale V3 powers itself back on ~5 min after tapping **Sleep** in Decenza (USB-powered, no batteries). Regression from v1.7.6.

**Root cause:** The ~4 min periodic battery refresh added in [#1279](https://github.com/Kulitorum/Decenza/pull/1279) re-sends the display-on command `0A 01 01 00 01` — the same byte sequence `DecentScale::wake()` uses to light the LCD. When the user taps Sleep with the default `keepScaleOn=true`, [main.cpp:3011](src/main.cpp:3011) calls `disableLcd()` (`0A 00 00`), which turns the LCD off but leaves the 1 s heartbeat (and its battery poll) running. About 4 minutes later the battery poll fires the display-on command and the LCD comes back on by itself — matching the reporter's "~5 minutes."

#1279's design comment noted the poll auto-pauses because `sleep()` calls `stopHeartbeat()`. That's true for `keepScaleOn=false`; the default `keepScaleOn=true` path goes through `disableLcd()`, which the analysis missed.

**Fix:** Gate the battery-poll branch on a new `m_lcdOn` flag (set in `wake()`, cleared in `disableLcd()`, reset on disconnect). The 1 s heartbeat itself keeps running so the BLE link stays alive; battery refreshes resume the next time `wake()` runs.

## Test plan

- [ ] Pair Decent Scale V3 (BT), default settings (`keepScaleOn=true`)
- [ ] Tap **Sleep** in Decenza
- [ ] Confirm scale LCD goes dark and **stays dark** for >5 minutes
- [ ] Wake DE1; confirm scale LCD lights up and weight reporting resumes
- [ ] With `keepScaleOn=false`: tap Sleep → scale fully powers off + disconnects (unchanged behavior)
- [ ] Existing `tst_scaleprotocol` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)