### PR TITLE
Bean Base: fix review findings from #1322

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,7 @@ set(SOURCES
     src/mcp/mcptools_shots.cpp
     src/mcp/mcptools_profiles.cpp
     src/mcp/mcptools_settings.cpp
+    src/mcp/mcptools_beansearch.cpp
     src/mcp/mcptools_dialing.cpp
     src/ai/dialing_blocks.cpp
     src/mcp/mcptools_control.cpp
@@ -478,6 +479,7 @@ set(HEADERS
     src/network/visualizeruploader.h
     src/network/visualizerimporter.h
     src/network/beanbaseclient.h
+    src/network/beanbase_blob.h
     src/ai/aimanager.h
     src/ai/aiprovider.h
     src/ai/conductance.h

--- a/docs/CLAUDE_MD/BEAN_BASE.md
+++ b/docs/CLAUDE_MD/BEAN_BASE.md
@@ -34,6 +34,22 @@ BeanBaseSearchBar (BeanInfoPage)            Settings → Visualizer → Bean Bas
 
 `BeanBaseClient::search()` hits Visualizer's open `GET /canonical/autocomplete_coffee_bags?q=` (keyless, substring + multi-word; internal endpoint — parse defensively, expect drift). Entries carry `visualizerCanonicalId` (UUID) = the identity stored locally and sent on shot PATCH (`shot[canonical_coffee_bag_id]`, accepted for all users) so the same bag id lands in both systems. `fetchCanonicalDetails()` runs the two-stage flow (`autocomplete_roasters` → `require_roaster=true&canonical_roaster_id=`) for the attribute payload. `searchBeanBase()` keeps the Bean Base API contract (whole words, key, quota) for optional extras. MCP tool: `bean_search` (canonical + per-result enrichment).
 
+## The entry / blob vocabulary (schema of record)
+
+Entries are QVariantMaps (QML lingua franca; deliberately not a C++ value type). Keys, by producer:
+
+| Key | canonical (`search()`) | Bean Base (`searchBeanBase()`) | enrichment (`canonicalDetails`) |
+|---|---|---|---|
+| `id` (opaque string; **non-empty = linked**) | UUID | integer-as-string | — |
+| `visualizerCanonicalId` | = id | — | — |
+| `source` | "visualizer" | "beanbase" | — |
+| `roasterName`, `roastName` | ✓ | ✓ | — |
+| `degree, origin, region, producer, variety, process, harvest, tastingNotes` | — | ✓ | ✓ (remapped from Visualizer columns) |
+| `elevation` (display string) | — | — | ✓ |
+| `minElevationM/maxElevationM` (int), `link, image, beanType, description, tastingTags, generalTags, soldout, available, roasterRegion, roasterCountry` | — | ✓ | — |
+
+The blob = one entry JSON-compacted. `src/network/beanbase_blob.h` is the C++ definition of "linked" (`isLinked`: parses + non-empty `id`) and of the uploader's canonical id (`canonicalId`); QML mirrors it via `bean.id !== ""` checks. A misspelled key reads as `undefined`/`""` with no diagnostics — check this table before adding readers.
+
 ## UI rules
 
 - Search bar (`BeanBaseSearchBar.qml`) is always visible — search is keyless since the canonical switch. Label is the verbatim branding "Search Loffee Labs Bean Base" (untranslated).

--- a/docs/CLAUDE_MD/BEAN_BASE.md
+++ b/docs/CLAUDE_MD/BEAN_BASE.md
@@ -6,8 +6,11 @@ Canonical coffee-database integration: users link beans to Loffee Labs Bean Base
 
 ```
 BeanBaseSearchBar (BeanInfoPage)            Settings → Visualizer → Bean Base
-   └─ MainController.beanbase ──────────────── SettingsBeanBase (beanbase/apiKey)
-        BeanBaseClient (src/network/beanbaseclient.{h,cpp})
+   └─ MainController.beanbase                  SettingsBeanBase (beanbase/apiKey
+        BeanBaseClient                           — gates ONLY testApiKey/
+          ├─ search() → visualizer.coffee          searchBeanBase, not the bar)
+          │    canonical autocomplete (keyless)
+          └─ searchBeanBase() → loffeelabs.com (key; unused in production)
    user picks entry → DYE link state (SettingsDye: dyeBeanBaseId/RoasterId/Data)
         ├─ bean presets carry the link (apply/save/rename handled)
         └─ shot save snapshots the blob → shots.beanbase_json (migration 18)
@@ -22,7 +25,7 @@ BeanBaseSearchBar (BeanInfoPage)            Settings → Visualizer → Bean Bas
 
 - Base `https://loffeelabs.com/api/v2`, auth `Authorization: Bearer <key>` (per-user free keys from loffeelabs.com/developers). Public: `/roasters /origins /varieties /processes` (`{"data":[…]}`).
 - `GET /beans` returns `{"meta":{…,"remainingQuota"},"beans":[…]}` — wrapper key is `beans`, NOT `data`. `id` is a JSON number (we store it as an opaque string).
-- **Search matches whole words only** — no prefix matching, no wildcards, no term-AND. The empty state teaches this.
+- **Search matches whole words only** — no prefix matching, no wildcards, no term-AND. (Relevant only to `searchBeanBase()`; the UI's canonical search is substring, so nothing needs to teach it.)
 - **Free tier omits `image`, `tasting-tag`, `general-tag`, `soldout`, `available`** (supporter-tier-gated per the query-builder source). UI photo slots collapse gracefully and light up with no code changes if the tier exposes them.
 - Quota counts beans returned (2,000/day free; our 25-result searches ≈ 80 fresh searches/day). Rate limit 1 req/3 s. Both return 429 — `classify429()` splits them by body text so quota exhaustion says "resets tomorrow", not "try again shortly".
 - Client enforces the budget: 800 ms debounce, 3 s sent-floor (latest-wins queue), session cache by normalized query, in-flight abort on supersede.
@@ -38,7 +41,7 @@ BeanBaseSearchBar (BeanInfoPage)            Settings → Visualizer → Bean Bas
 - The link is always correctable: Unlink works without a key; typing while linked re-enters search; edit mode rewrites the *shot's* snapshot (`requestUpdateShotMetadata` carries `beanBaseJson`).
 - Details surfaces: `BeanBaseDetailsRow`/`BeanBaseDetailsPopup` on BeanInfoPage (live DYE state), PostShotReviewPage + ShotDetailPage (per-shot snapshot). Zero footprint when the blob is empty.
 
-## Visualizer linkage (Tier 3 — pending, see design.md § Context 9)
+## Visualizer linkage (shot PATCH shipped; bag CRUD / id-resolution pending — design.md § Context 9)
 
 From the open-source `miharekar/visualizer` repo: `canonical_coffee_bags.id` is a Visualizer UUID; the Bean Base integer lives in `loffee_labs_id` — **no API resolves one to the other today**, so canonical linkage needs a small upstream addition. Bag CRUD is at `/api/coffee_bags` (writes premium-gated); shot PATCH accepts `shot[canonical_coffee_bag_id]` (all users) and `shot[coffee_bag_id]` (coffee management enabled, auto-fills bean fields server-side).
 

--- a/qml/components/BeanBaseSearchBar.qml
+++ b/qml/components/BeanBaseSearchBar.qml
@@ -3,9 +3,9 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Decenza
 
-// "Search Loffee Labs Bean Base" — async autocomplete against the Bean Base
-// API via MainController.beanbase (debounce + rate limit + cache live in C++,
-// so every keystroke may safely call search()).
+// "Search Loffee Labs Bean Base" — async autocomplete against Visualizer's
+// canonical coffee-bag endpoint (keyless) via MainController.beanbase;
+// debounce + cache live in C++, so every keystroke may safely call search().
 //
 // Purely presentational: emits entrySelected(entry) / unlinkRequested() and
 // renders the linked indicator; the parent owns applying fields and storing
@@ -166,7 +166,7 @@ Item {
 
         Keys.onEscapePressed: { resultsPopup.close(); focus = false }
 
-        // Busy spinner while a request is in flight or rate-limit-queued
+        // Busy spinner while a request is in flight or debounce-queued
         BusyIndicator {
             anchors.right: parent.right
             anchors.rightMargin: Theme.scaled(8)
@@ -188,11 +188,18 @@ Item {
             if (query.toLowerCase() !== root._pendingQuery) return
             root.results = entries
             root.searchState = "idle"
-            if (searchInput.activeFocus && entries.length >= 0) resultsPopup.open()
+            if (searchInput.activeFocus) resultsPopup.open()  // Open even when empty: the no-matches message lives in the popup
         }
 
         function onSearchFailed(query, status) {
             if (query.toLowerCase() !== root._pendingQuery) return
+            // Superseded = a newer query (possibly from another consumer of
+            // the shared client) replaced this one; not an error, just stop
+            // the spinner and wait for the newer answer.
+            if (status === "superseded") {
+                root.searchState = "idle"
+                return
+            }
             root.results = []
             root.errorToken = status
             root.searchState = "error"
@@ -271,13 +278,18 @@ Item {
                 font.pixelSize: Theme.scaled(14)
                 text: {
                     if (root.searchState === "error") {
+                        // invalid/ratelimited/quota are unreachable from the
+                        // keyless canonical path — kept as defensive cover
+                        // for a future searchBeanBase()-backed mode.
                         if (root.errorToken === "invalid")
                             return TranslationManager.translate("beaninfo.beanbase.errorInvalid", "Invalid API key — check Settings")
                         if (root.errorToken === "ratelimited")
                             return TranslationManager.translate("beaninfo.beanbase.errorRateLimited", "Searching too fast — pause a moment and try again")
                         if (root.errorToken === "quota")
                             return TranslationManager.translate("beaninfo.beanbase.errorQuota", "Daily Bean Base limit reached — search resumes tomorrow")
-                        return TranslationManager.translate("beaninfo.beanbase.errorNetwork", "Could not reach Bean Base")
+                        if (root.errorToken === "parse")
+                            return TranslationManager.translate("beaninfo.beanbase.errorParse", "Bean search is temporarily unavailable")
+                        return TranslationManager.translate("beaninfo.beanbase.errorNetwork", "Could not reach the bean database")
                     }
                     return TranslationManager.translate("beaninfo.beanbase.noMatches", "No matches — your bean may not be in the community database yet")
                 }

--- a/qml/pages/BeanInfoPage.qml
+++ b/qml/pages/BeanInfoPage.qml
@@ -722,10 +722,8 @@ Page {
                     font.bold: true
                 }
 
-                // Bean Base search — only rendered when the user has an API
-                // key (discovery lives in Settings), or when an existing link
-                // must stay visible/correctable. Free-text entry below stays
-                // the primary path; most beans are not in Bean Base.
+                // Bean Base search. Free-text entry below stays the primary
+                // path; most beans are not in the community database.
                 BeanBaseSearchBar {
                     id: beanBaseSearchBar
                     Layout.columnSpan: 2
@@ -750,7 +748,6 @@ Page {
                             if (entry.degree) editRoastLevel = entry.degree
                         } else {
                             Settings.dye.dyeBeanBaseId = String(entry.id)
-                            Settings.dye.dyeBeanBaseRoasterId = entry.roasterId !== undefined ? String(entry.roasterId) : ""
                             Settings.dye.dyeBeanBaseData = json
                             if (entry.roasterName) Settings.dye.dyeBeanBrand = entry.roasterName
                             if (entry.roastName) Settings.dye.dyeBeanType = entry.roastName
@@ -791,7 +788,11 @@ Page {
                     target: MainController.beanbase
                     function onCanonicalDetails(canonicalId, attrs) {
                         if (!beanBaseLinked || activeBeanBase.id !== canonicalId) return
-                        var merged = JSON.parse(activeBeanBaseJson)
+                        // beanBaseLinked already implies the blob parsed, but
+                        // that invariant lives two bindings away — match the
+                        // sibling parse sites' defensiveness.
+                        var merged
+                        try { merged = JSON.parse(activeBeanBaseJson) } catch (e) { return }
                         for (var k in attrs) merged[k] = attrs[k]
                         var json = JSON.stringify(merged)
                         if (isEditMode) {

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -189,7 +189,8 @@ struct CurrentBeanBlockInputs {
     QString grinderBurrs;
     QString grinderSetting;
     double doseWeightG = 0;
-    // Compact-JSON Bean Base snapshot ("" = unlinked). Parsed into a
+    // Compact-JSON linked-bean snapshot ("" = unlinked, Visualizer canonical
+    // or Bean Base sourced). Parsed into a
     // `beanBase` sub-object so the advisor sees structured origin/variety/
     // process/tasting data instead of just free-text brand+name strings.
     QString beanBaseJson;
@@ -239,6 +240,9 @@ inline QJsonObject buildCurrentBeanBlock(const CurrentBeanBlockInputs& in)
         put("roastLevel", "degree");          // Bean Base's richer string, e.g. "Light To Medium-light"
         put("roastedFor", "beanType");        // "Espresso" | "Filter" | "Omni"
         put("harvest", "harvest");
+        // Canonical-sourced blobs carry a single `elevation` display string;
+        // Bean Base-sourced blobs carry numeric min/max. Pass through both.
+        put("elevation", "elevation");
         const int loM = src.value(QLatin1String("minElevationM")).toInt();
         const int hiM = src.value(QLatin1String("maxElevationM")).toInt();
         if (loM > 0) bb["minElevationM"] = loM;

--- a/src/core/settings_beanbase.h
+++ b/src/core/settings_beanbase.h
@@ -7,7 +7,10 @@
 // Loffee Labs Bean Base (loffeelabs.com) integration credentials. Split from
 // Settings to keep settings.h's transitive-include footprint small, the same
 // way every other Settings<Domain> is. Holds the per-user Bean Base API key
-// used by BeanBaseClient for authenticated `GET /beans` searches.
+// used by BeanBaseClient for authenticated `GET /beans` requests. NOTE: the
+// UI search bar and the `bean_search` MCP tool are KEYLESS (Visualizer
+// canonical autocomplete) — this key only gates the optional Bean Base API
+// path (testApiKey, searchBeanBase).
 //
 // Each user supplies their own free key (1 req/3 s, 2,000 beans/day) from
 // loffeelabs.com — there is no app-bundled key. The key is a sensitive

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -1,4 +1,5 @@
 #include "settings_dye.h"
+#include "../network/beanbase_blob.h"
 #include "settings_visualizer.h"
 #include "grinderaliases.h"
 
@@ -376,7 +377,11 @@ void SettingsDye::addBeanPreset(const QString& name, const QString& brand, const
     // The add dialog saves the CURRENT bean — when the passed identity matches
     // the live DYE state, carry its Bean Base link (empty when unlinked, the
     // common free-text case).
-    if (brand == dyeBeanBrand() && type == dyeBeanType() && !dyeBeanBaseId().isEmpty()) {
+    // BeanBaseBlob::isLinked also rejects a CORRUPT blob — without it a
+    // corrupt dyeBeanBaseData (which reads as "unlinked" everywhere else)
+    // would still be copied into the new preset alongside its stale id.
+    if (brand == dyeBeanBrand() && type == dyeBeanType()
+        && BeanBaseBlob::isLinked(dyeBeanBaseData())) {
         preset["beanBaseId"] = dyeBeanBaseId();
         preset["beanBaseData"] = dyeBeanBaseData();
     }
@@ -416,7 +421,7 @@ void SettingsDye::updateBeanPreset(int index, const QString& name, const QString
         // (e.g. renaming a preset that isn't the active bean) preserve the
         // row's existing link, like showOnIdle above.
         if (brand == dyeBeanBrand() && type == dyeBeanType()) {
-            if (!dyeBeanBaseId().isEmpty()) {
+            if (BeanBaseBlob::isLinked(dyeBeanBaseData())) {
                 preset["beanBaseId"] = dyeBeanBaseId();
                 preset["beanBaseData"] = dyeBeanBaseData();
             }

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -304,17 +304,6 @@ void SettingsDye::setDyeBeanBaseId(const QString& value) {
     }
 }
 
-QString SettingsDye::dyeBeanBaseRoasterId() const {
-    return m_settings.value("dye/beanBaseRoasterId", "").toString();
-}
-
-void SettingsDye::setDyeBeanBaseRoasterId(const QString& value) {
-    if (dyeBeanBaseRoasterId() != value) {
-        m_settings.setValue("dye/beanBaseRoasterId", value);
-        emit dyeBeanBaseRoasterIdChanged();
-    }
-}
-
 QString SettingsDye::dyeBeanBaseData() const {
     return m_settings.value("dye/beanBaseData", "").toString();
 }
@@ -328,7 +317,6 @@ void SettingsDye::setDyeBeanBaseData(const QString& value) {
 
 void SettingsDye::clearBeanBaseLink() {
     setDyeBeanBaseId(QString());
-    setDyeBeanBaseRoasterId(QString());
     setDyeBeanBaseData(QString());
 }
 
@@ -390,7 +378,6 @@ void SettingsDye::addBeanPreset(const QString& name, const QString& brand, const
     // common free-text case).
     if (brand == dyeBeanBrand() && type == dyeBeanType() && !dyeBeanBaseId().isEmpty()) {
         preset["beanBaseId"] = dyeBeanBaseId();
-        preset["beanBaseRoasterId"] = dyeBeanBaseRoasterId();
         preset["beanBaseData"] = dyeBeanBaseData();
     }
     arr.append(preset);
@@ -431,12 +418,10 @@ void SettingsDye::updateBeanPreset(int index, const QString& name, const QString
         if (brand == dyeBeanBrand() && type == dyeBeanType()) {
             if (!dyeBeanBaseId().isEmpty()) {
                 preset["beanBaseId"] = dyeBeanBaseId();
-                preset["beanBaseRoasterId"] = dyeBeanBaseRoasterId();
                 preset["beanBaseData"] = dyeBeanBaseData();
             }
         } else if (existing.contains("beanBaseId")) {
             preset["beanBaseId"] = existing["beanBaseId"];
-            preset["beanBaseRoasterId"] = existing["beanBaseRoasterId"];
             preset["beanBaseData"] = existing["beanBaseData"];
         }
         arr[index] = preset;
@@ -570,7 +555,6 @@ void SettingsDye::applyBeanPreset(int index) {
     // Bean Base link follows the preset — an unlinked preset clears any
     // leftover link from the previous bean.
     setDyeBeanBaseId(preset.value("beanBaseId").toString());
-    setDyeBeanBaseRoasterId(preset.value("beanBaseRoasterId").toString());
     setDyeBeanBaseData(preset.value("beanBaseData").toString());
 }
 

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -41,7 +41,6 @@ class SettingsDye : public QObject {
     // consumers (shot snapshot, Visualizer upload, AI advisor) read it as a
     // unit, so it is deliberately NOT split into per-attribute properties.
     Q_PROPERTY(QString dyeBeanBaseId READ dyeBeanBaseId WRITE setDyeBeanBaseId NOTIFY dyeBeanBaseIdChanged)
-    Q_PROPERTY(QString dyeBeanBaseRoasterId READ dyeBeanBaseRoasterId WRITE setDyeBeanBaseRoasterId NOTIFY dyeBeanBaseRoasterIdChanged)
     Q_PROPERTY(QString dyeBeanBaseData READ dyeBeanBaseData WRITE setDyeBeanBaseData NOTIFY dyeBeanBaseDataChanged)
 
     // Bean presets
@@ -115,9 +114,6 @@ public:
     QString dyeBeanBaseId() const;
     void setDyeBeanBaseId(const QString& value);
 
-    QString dyeBeanBaseRoasterId() const;
-    void setDyeBeanBaseRoasterId(const QString& value);
-
     QString dyeBeanBaseData() const;
     void setDyeBeanBaseData(const QString& value);
 
@@ -180,7 +176,6 @@ signals:
     void dyeBaristaChanged();
     void dyeShotDateTimeChanged();
     void dyeBeanBaseIdChanged();
-    void dyeBeanBaseRoasterIdChanged();
     void dyeBeanBaseDataChanged();
     void beanPresetsChanged();
     void selectedBeanPresetChanged();

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -303,7 +303,6 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
     dye["barista"] = settings->dye()->dyeBarista();
     dye["shotDateTime"] = settings->dye()->dyeShotDateTime();
     dye["beanBaseId"] = settings->dye()->dyeBeanBaseId();
-    dye["beanBaseRoasterId"] = settings->dye()->dyeBeanBaseRoasterId();
     dye["beanBaseData"] = settings->dye()->dyeBeanBaseData();
     root["dye"] = dye;
 
@@ -736,7 +735,6 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         if (dye.contains("barista")) settings->dye()->setDyeBarista(dye["barista"].toString());
         if (dye.contains("shotDateTime")) settings->dye()->setDyeShotDateTime(dye["shotDateTime"].toString());
         if (dye.contains("beanBaseId")) settings->dye()->setDyeBeanBaseId(dye["beanBaseId"].toString());
-        if (dye.contains("beanBaseRoasterId")) settings->dye()->setDyeBeanBaseRoasterId(dye["beanBaseRoasterId"].toString());
         if (dye.contains("beanBaseData")) settings->dye()->setDyeBeanBaseData(dye["beanBaseData"].toString());
     }
 

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -55,8 +55,9 @@ struct ShotRecord {
     QString visualizerId;
     QString visualizerUrl;
 
-    // Compact-JSON snapshot of the linked Bean Base entry at shot time
-    // (empty = unlinked / pre-migration-18 shot). See ShotSaveData::beanBaseJson.
+    // Compact-JSON linked-bean snapshot at shot time ("" = unlinked /
+    // pre-migration-18 shot) — Visualizer canonical or Bean Base sourced;
+    // see docs/CLAUDE_MD/BEAN_BASE.md and ShotSaveData::beanBaseJson.
     QString beanBaseJson;
 
     // Time-series data (lazily loaded)
@@ -231,9 +232,10 @@ struct ShotSaveData {
     QString profileNotes;
     QString debugLog;
 
-    // Compact-JSON snapshot of the linked Bean Base entry at shot time
-    // (empty = unlinked, the common free-text case). Snapshotted per shot so
-    // history stays accurate after the preset is edited or deleted.
+    // Compact-JSON linked-bean snapshot at shot time ("" = unlinked, the
+    // common free-text case) — Visualizer canonical or Bean Base sourced.
+    // Snapshotted per shot so history stays accurate after the preset is
+    // edited or deleted.
     QString beanBaseJson;
 
     // AI knowledge base ID (e.g. "d-flow", "blooming espresso") — computed at save time

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -928,22 +928,32 @@ bool ShotHistoryStorage::runMigrations()
     }
 
     // Migration 18: beanbase_json column (add-bean-base-integration).
-    // Compact-JSON snapshot of the Loffee Labs Bean Base entry the shot was
-    // pulled with — origin, variety, process, tasting tags, image/product
-    // URLs, etc. Snapshotted at save time so history stays accurate after
-    // the preset is edited or deleted. NULL = unlinked bean (the common
-    // free-text case). Additive TEXT column, NULL default; old code that
-    // never SELECTs it is unaffected. Whitespace before the open-paren
-    // dodges the QSqlQuery permission-hook false-positive, as elsewhere.
+    // Compact-JSON snapshot of the linked bean entry (Visualizer canonical
+    // or Bean Base sourced — see docs/CLAUDE_MD/BEAN_BASE.md) the shot was
+    // pulled with: id, roaster, origin, variety, process, etc. Snapshotted
+    // at save time so history stays accurate after the preset is edited or
+    // deleted. NULL = unlinked bean (the common free-text case). Additive
+    // TEXT column, NULL default; old code that never SELECTs it is
+    // unaffected. Whitespace before the open-paren dodges the QSqlQuery
+    // permission-hook false-positive, as elsewhere.
     if (currentVersion < 18) {
         qDebug() << "ShotHistoryStorage: Running migration to version 18 (beanbase_json)";
 
         if (!hasColumn("shots", "beanbase_json"))
             query.exec ("ALTER TABLE shots ADD COLUMN beanbase_json TEXT");
 
-        query.exec ("DELETE FROM schema_version");
-        query.exec ("INSERT INTO schema_version (version) VALUES (18)");
-        currentVersion = 18;
+        // Check-before-bump (migration-15 precedent): saveShotStatic's INSERT
+        // names this column unconditionally, so recording version 18 without
+        // the column would permanently break shot saving. On failure the
+        // version stays < 18 and the ALTER retries next launch.
+        if (hasColumn("shots", "beanbase_json")) {
+            query.exec ("DELETE FROM schema_version");
+            query.exec ("INSERT INTO schema_version (version) VALUES (18)");
+            currentVersion = 18;
+        } else {
+            qWarning() << "ShotHistoryStorage: migration 18 failed to add beanbase_json:"
+                       << query.lastError().text() << "- will retry next launch";
+        }
     }
 
     m_schemaVersion = currentVersion;

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -128,7 +128,8 @@ public:
     QString stoppedBy;  // #1161: "weight"|"volume"|"manual"|"profileEnd"|""
     QString profileJson;
     QString profileKbId;
-    // Compact-JSON Bean Base snapshot ("" = unlinked); see ShotRecord::beanBaseJson.
+    // Compact-JSON linked-bean snapshot ("" = unlinked) — Visualizer canonical
+    // or Bean Base sourced; see ShotRecord::beanBaseJson.
     QString beanBaseJson;
 
     bool channelingDetected = false;

--- a/src/mcp/mcptools_ai.cpp
+++ b/src/mcp/mcptools_ai.cpp
@@ -473,7 +473,7 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
                     gather->entries = entries.mid(0, 5);
                     if (gather->entries.isEmpty()) { gather->finish(); return; }
                     gather->pendingDetails = static_cast<int>(gather->entries.size());
-                    gather->grace.start(4000);
+                    gather->grace.start(4000);  // Shorter window for enrichment only.
                     for (const QVariant& v : std::as_const(gather->entries))
                         client->fetchCanonicalDetails(v.toMap());
                 });
@@ -500,10 +500,17 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
                 [gather](const QString& q, const QString& status) {
                     if (gather->responded || q.compare(gather->query, Qt::CaseInsensitive) != 0) return;
                     gather->responded = true;
-                    gather->respond(QJsonObject{
-                        {"error", "Could not reach the bean database"}, {"status", status}});
+                    const QString msg = status == QStringLiteral("superseded")
+                        ? QStringLiteral("Search superseded by a concurrent search — retry")
+                        : QStringLiteral("Could not reach the bean database");
+                    gather->respond(QJsonObject{{"error", msg}, {"status", status}});
                     gather->deleteLater();
                 });
+            // Overall deadline armed BEFORE the search: the client is shared
+            // with the Beans-page bar, and a superseded/aborted query may
+            // produce no signal at all — without this the tool call would
+            // hang forever and leak the gather.
+            gather->grace.start(20000);
             client->search(query);
         },
         "read");

--- a/src/mcp/mcptools_ai.cpp
+++ b/src/mcp/mcptools_ai.cpp
@@ -32,6 +32,8 @@
 // Ollama path.
 static constexpr int kAdvisorMcpTimeoutMs = 135 * 1000;
 
+void registerBeanSearchTool(McpToolRegistry* registry, BeanBaseClient* client);
+
 void registerAITools(McpToolRegistry* registry, MainController* mainController)
 {
     // ai_advisor_invoke — registered at "control" tier (matches the
@@ -398,120 +400,5 @@ void registerAITools(McpToolRegistry* registry, MainController* mainController)
         },
         "control");
 
-    // bean_search — read-only canonical coffee lookup via Visualizer's
-    // open autocomplete (keyless, substring matching). Returns the canonical
-    // UUID that both Decenza and visualizer.coffee store, with attributes
-    // enriched per result via the two-stage canonical flow. Pairs with
-    // shots_update's `beanBase` arg: search here, then link a shot.
-    registry->registerAsyncTool(
-        "bean_search",
-        "Search the community coffee database (Visualizer canonical beans, mirrored from Loffee "
-        "Labs Bean Base) by roaster or bean name. Substring and multi-word matching — no API key "
-        "or account needed. Returns canonical bean entries: id (the canonical UUID shared with "
-        "visualizer.coffee), roasterName, roastName, plus origin/variety/process/roast level/"
-        "tasting notes when known. Pass a chosen result object as shots_update's beanBase "
-        "argument to link a shot to its bean.",
-        QJsonObject{
-            {"type", "object"},
-            {"properties", QJsonObject{
-                {"query", QJsonObject{{"type", "string"},
-                    {"description", "Search term(s) — roaster and/or bean name; partial words OK"}}}
-            }},
-            {"required", QJsonArray{"query"}}
-        },
-        [mainController](const QJsonObject& args, std::function<void(QJsonObject)> respond) {
-            BeanBaseClient* client = mainController ? mainController->beanbase() : nullptr;
-            if (!client) {
-                respond(QJsonObject{{"error", "Bean search client not available"}});
-                return;
-            }
-            const QString query = args["query"].toString().trimmed();
-            if (query.length() < 2) {
-                respond(QJsonObject{{"error", "query must be at least 2 characters"}});
-                return;
-            }
-
-            // Bridge object: gathers the search result, then best-effort
-            // attribute enrichment for the top results, then responds once —
-            // when every enrichment reported or the grace timer fires.
-            // Parented to the client so app teardown cleans it up.
-            class Gather : public QObject {
-            public:
-                std::function<void(QJsonObject)> respond;
-                QString query;
-                QVariantList entries;
-                int pendingDetails = 0;
-                bool responded = false;
-                QTimer grace;
-
-                void finish() {
-                    if (responded) return;
-                    responded = true;
-                    respond(QJsonObject{
-                        {"query", query},
-                        {"count", entries.size()},
-                        {"results", QJsonArray::fromVariantList(entries)},
-                        {"hint", entries.isEmpty()
-                            ? "No matches — the bean may not be in the community database yet."
-                            : "To link a shot to one of these beans, pass the chosen result object as shots_update's beanBase argument."}
-                    });
-                    deleteLater();
-                }
-            };
-            auto* gather = new Gather;
-            gather->setParent(client);
-            gather->respond = respond;
-            gather->query = query;
-            gather->grace.setSingleShot(true);
-            QObject::connect(&gather->grace, &QTimer::timeout, gather, [gather]() { gather->finish(); });
-
-            QObject::connect(client, &BeanBaseClient::searchResults, gather,
-                [client, gather](const QString& q, const QVariantList& entries) {
-                    if (gather->responded || q.compare(gather->query, Qt::CaseInsensitive) != 0) return;
-                    // Cap for the LLM; each entry gets a best-effort
-                    // attribute fetch (keyless, roaster UUID cached).
-                    gather->entries = entries.mid(0, 5);
-                    if (gather->entries.isEmpty()) { gather->finish(); return; }
-                    gather->pendingDetails = static_cast<int>(gather->entries.size());
-                    gather->grace.start(4000);  // Shorter window for enrichment only.
-                    for (const QVariant& v : std::as_const(gather->entries))
-                        client->fetchCanonicalDetails(v.toMap());
-                });
-            QObject::connect(client, &BeanBaseClient::canonicalDetails, gather,
-                [gather](const QString& canonicalId, const QVariantMap& attrs) {
-                    if (gather->responded) return;
-                    bool matched = false;
-                    for (QVariant& v : gather->entries) {
-                        QVariantMap m = v.toMap();
-                        if (m.value(QStringLiteral("id")).toString() == canonicalId) {
-                            for (auto it = attrs.constBegin(); it != attrs.constEnd(); ++it)
-                                m.insert(it.key(), it.value());
-                            v = m;
-                            matched = true;
-                            break;
-                        }
-                    }
-                    // Only count OUR entries down — the signal is shared with
-                    // the Beans-page consumer. Silent enrichment failures are
-                    // covered by the grace timer.
-                    if (matched && --gather->pendingDetails <= 0) gather->finish();
-                });
-            QObject::connect(client, &BeanBaseClient::searchFailed, gather,
-                [gather](const QString& q, const QString& status) {
-                    if (gather->responded || q.compare(gather->query, Qt::CaseInsensitive) != 0) return;
-                    gather->responded = true;
-                    const QString msg = status == QStringLiteral("superseded")
-                        ? QStringLiteral("Search superseded by a concurrent search — retry")
-                        : QStringLiteral("Could not reach the bean database");
-                    gather->respond(QJsonObject{{"error", msg}, {"status", status}});
-                    gather->deleteLater();
-                });
-            // Overall deadline armed BEFORE the search: the client is shared
-            // with the Beans-page bar, and a superseded/aborted query may
-            // produce no signal at all — without this the tool call would
-            // hang forever and leak the gather.
-            gather->grace.start(20000);
-            client->search(query);
-        },
-        "read");
+    registerBeanSearchTool(registry, mainController ? mainController->beanbase() : nullptr);
 }

--- a/src/mcp/mcptools_beansearch.cpp
+++ b/src/mcp/mcptools_beansearch.cpp
@@ -1,0 +1,130 @@
+// bean_search MCP tool. Lives in its own translation unit (not
+// mcptools_ai.cpp) so tests can link it against a fake-server-backed
+// BeanBaseClient without dragging in MainController/AIManager.
+#include "mcptoolregistry.h"
+#include "../network/beanbaseclient.h"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QTimer>
+
+// bean_search — read-only canonical coffee lookup via Visualizer's
+// open autocomplete (keyless, substring matching). Returns the canonical
+// UUID that both Decenza and visualizer.coffee store, with attributes
+// enriched per result via the two-stage canonical flow. Pairs with
+// shots_update's `beanBase` arg: search here, then link a shot.
+// Standalone (not folded into registerAITools) so tests can register it
+// against a fake-server-backed BeanBaseClient without a MainController.
+void registerBeanSearchTool(McpToolRegistry* registry, BeanBaseClient* client)
+{
+    registry->registerAsyncTool(
+        "bean_search",
+        "Search the community coffee database (Visualizer canonical beans, mirrored from Loffee "
+        "Labs Bean Base) by roaster or bean name. Substring and multi-word matching — no API key "
+        "or account needed. Returns canonical bean entries: id (the canonical UUID shared with "
+        "visualizer.coffee), roasterName, roastName, plus origin/variety/process/roast level/"
+        "tasting notes when known. Pass a chosen result object as shots_update's beanBase "
+        "argument to link a shot to its bean.",
+        QJsonObject{
+            {"type", "object"},
+            {"properties", QJsonObject{
+                {"query", QJsonObject{{"type", "string"},
+                    {"description", "Search term(s) — roaster and/or bean name; partial words OK"}}}
+            }},
+            {"required", QJsonArray{"query"}}
+        },
+        [client](const QJsonObject& args, std::function<void(QJsonObject)> respond) {
+            if (!client) {
+                respond(QJsonObject{{"error", "Bean search client not available"}});
+                return;
+            }
+            const QString query = args["query"].toString().trimmed();
+            if (query.length() < 2) {
+                respond(QJsonObject{{"error", "query must be at least 2 characters"}});
+                return;
+            }
+
+            // Bridge object: gathers the search result, then best-effort
+            // attribute enrichment for the top results, then responds once —
+            // when every enrichment reported or the grace timer fires.
+            // Parented to the client so app teardown cleans it up.
+            class Gather : public QObject {
+            public:
+                std::function<void(QJsonObject)> respond;
+                QString query;
+                QVariantList entries;
+                int pendingDetails = 0;
+                bool responded = false;
+                QTimer grace;
+
+                void finish() {
+                    if (responded) return;
+                    responded = true;
+                    respond(QJsonObject{
+                        {"query", query},
+                        {"count", entries.size()},
+                        {"results", QJsonArray::fromVariantList(entries)},
+                        {"hint", entries.isEmpty()
+                            ? "No matches — the bean may not be in the community database yet."
+                            : "To link a shot to one of these beans, pass the chosen result object as shots_update's beanBase argument."}
+                    });
+                    deleteLater();
+                }
+            };
+            auto* gather = new Gather;
+            gather->setParent(client);
+            gather->respond = respond;
+            gather->query = query;
+            gather->grace.setSingleShot(true);
+            QObject::connect(&gather->grace, &QTimer::timeout, gather, [gather]() { gather->finish(); });
+
+            QObject::connect(client, &BeanBaseClient::searchResults, gather,
+                [client, gather](const QString& q, const QVariantList& entries) {
+                    if (gather->responded || q.compare(gather->query, Qt::CaseInsensitive) != 0) return;
+                    // Cap for the LLM; each entry gets a best-effort
+                    // attribute fetch (keyless, roaster UUID cached).
+                    gather->entries = entries.mid(0, 5);
+                    if (gather->entries.isEmpty()) { gather->finish(); return; }
+                    gather->pendingDetails = static_cast<int>(gather->entries.size());
+                    gather->grace.start(4000);  // Shorter window for enrichment only.
+                    for (const QVariant& v : std::as_const(gather->entries))
+                        client->fetchCanonicalDetails(v.toMap());
+                });
+            QObject::connect(client, &BeanBaseClient::canonicalDetails, gather,
+                [gather](const QString& canonicalId, const QVariantMap& attrs) {
+                    if (gather->responded) return;
+                    bool matched = false;
+                    for (QVariant& v : gather->entries) {
+                        QVariantMap m = v.toMap();
+                        if (m.value(QStringLiteral("id")).toString() == canonicalId) {
+                            for (auto it = attrs.constBegin(); it != attrs.constEnd(); ++it)
+                                m.insert(it.key(), it.value());
+                            v = m;
+                            matched = true;
+                            break;
+                        }
+                    }
+                    // Only count OUR entries down — the signal is shared with
+                    // the Beans-page consumer. Silent enrichment failures are
+                    // covered by the grace timer.
+                    if (matched && --gather->pendingDetails <= 0) gather->finish();
+                });
+            QObject::connect(client, &BeanBaseClient::searchFailed, gather,
+                [gather](const QString& q, const QString& status) {
+                    if (gather->responded || q.compare(gather->query, Qt::CaseInsensitive) != 0) return;
+                    gather->responded = true;
+                    const QString msg = status == QStringLiteral("superseded")
+                        ? QStringLiteral("Search superseded by a concurrent search — retry")
+                        : QStringLiteral("Could not reach the bean database");
+                    gather->respond(QJsonObject{{"error", msg}, {"status", status}});
+                    gather->deleteLater();
+                });
+            // Overall deadline armed BEFORE the search: the client is shared
+            // with the Beans-page bar, and a superseded/aborted query may
+            // produce no signal at all — without this the tool call would
+            // hang forever and leak the gather.
+            gather->grace.start(20000);
+            client->search(query);
+        },
+        "read");
+}

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -95,10 +95,14 @@ static void reshapeBeanBase(QJsonObject& obj)
 {
     if (!obj.contains("beanBaseJson"))
         return;
-    const QJsonDocument doc = QJsonDocument::fromJson(
-        obj.take("beanBaseJson").toString().toUtf8());
+    const QString raw = obj.take("beanBaseJson").toString();
+    const QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
     if (doc.isObject() && !doc.object().isEmpty())
         obj["beanBase"] = doc.object();
+    else if (!raw.isEmpty())
+        // Corruption tripwire — sparse-emit makes a bad blob look "unlinked"
+        // at every consumer; leave one trace.
+        qWarning() << "MCP: corrupt beanBaseJson on shot" << obj.value("id");
 }
 
 void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistory)

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -127,8 +127,21 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             if (args.contains("beanBase")) {
                 // Snapshot semantics: we store the data, not a reference —
                 // an empty object clears the link, anything else is saved
-                // verbatim as the shot's compact-JSON snapshot.
+                // verbatim as the shot's compact-JSON snapshot. Guard the
+                // coercion footguns: a STRING here (classic LLM mistake)
+                // would silently coerce to {} = the clear sentinel, turning
+                // "link this bean" into "unlink" with a success response.
+                if (!args["beanBase"].isObject()) {
+                    respond(QJsonObject{{"error",
+                        "beanBase must be a JSON object (pass {} to clear the link)"}});
+                    return;
+                }
                 const QJsonObject bean = args["beanBase"].toObject();
+                if (!bean.isEmpty() && bean.value("id").toVariant().toString().isEmpty()) {
+                    respond(QJsonObject{{"error",
+                        "beanBase object must carry a non-empty id (from bean_search or another shot's beanBase)"}});
+                    return;
+                }
                 metadata["beanBaseJson"] = bean.isEmpty()
                     ? QString()
                     : QString::fromUtf8(QJsonDocument(bean).toJson(QJsonDocument::Compact));

--- a/src/network/beanbase_blob.h
+++ b/src/network/beanbase_blob.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+
+// Helpers over the compact-JSON linked-bean snapshot ("the blob") — the one
+// string carried by SettingsDye::dyeBeanBaseData, preset rows,
+// shots.beanbase_json, and the ShotMetadata/ShotSaveData/ShotRecord/
+// ShotProjection beanBaseJson fields. Header-only so the uploader, settings,
+// and tests share one definition without link-time coupling.
+namespace BeanBaseBlob {
+
+// True iff the blob parses to a non-empty JSON object carrying a non-empty
+// `id` — the single definition of "this string represents a linked bean".
+// "" (unlinked, the common case) is simply not linked, not corrupt.
+inline bool isLinked(const QString& blob)
+{
+    if (blob.isEmpty())
+        return false;
+    const QJsonObject obj = QJsonDocument::fromJson(blob.toUtf8()).object();
+    return !obj.value(QStringLiteral("id")).toVariant().toString().isEmpty();
+}
+
+// Visualizer canonical UUID for shot PATCH linkage, or "" when the blob is
+// empty, corrupt, or Bean-Base-sourced without a canonical id. The emit-only
+// contract lives on this emptiness: callers must NOT write the key (let
+// alone null it) when this returns "" — the user may have linked the bag in
+// Visualizer's own UI.
+inline QString canonicalId(const QString& blob)
+{
+    if (blob.isEmpty())
+        return QString();
+    return QJsonDocument::fromJson(blob.toUtf8())
+        .object().value(QStringLiteral("visualizerCanonicalId")).toString();
+}
+
+}  // namespace BeanBaseBlob

--- a/src/network/beanbaseclient.cpp
+++ b/src/network/beanbaseclient.cpp
@@ -32,6 +32,11 @@ constexpr int kSearchResultLimit = 25;  // Well under the 50/call free-tier cap.
 // debounce + session cache keep usage polite.
 constexpr int kCanonicalDebounceMs = 350;
 
+// Stalled-connection guard on every request (matches shotserver/aiprovider).
+// Surfaces as OperationCanceledError; handlers distinguish our own
+// supersede-abort (reply already detached) from a timeout (still active).
+constexpr int kTransferTimeoutMs = 15000;
+
 // Minimal entity decode for attribute values in the autocomplete fragment
 // (Rails-escaped: amp/lt/gt/quot/#39 cover what names/URLs contain).
 QString htmlUnescape(QString s) {
@@ -94,9 +99,13 @@ int toIntLoose(const QJsonValue& v) {
 QString classify429(const QByteArray& body) {
     const QString error = QJsonDocument::fromJson(body)
                               .object().value(QStringLiteral("error")).toString();
-    return error.contains(QStringLiteral("rate limit"), Qt::CaseInsensitive)
-        ? QStringLiteral("ratelimited")
-        : QStringLiteral("quota");
+    // Match both phrasings positively; an UNRECOGNIZED body (proxy error page,
+    // upstream copy change) defaults to the recoverable reading — telling a
+    // user "done for today" on a transient 429 makes them give up for a day.
+    if (error.contains(QStringLiteral("quota"), Qt::CaseInsensitive)
+        || error.contains(QStringLiteral("daily"), Qt::CaseInsensitive))
+        return QStringLiteral("quota");
+    return QStringLiteral("ratelimited");
 }
 }  // namespace
 
@@ -145,6 +154,7 @@ void BeanBaseClient::testApiKey() {
     // A 1-bean fetch is the cheapest authenticated call; 200 proves the key works.
     QNetworkRequest request{QUrl(QStringLiteral("%1/beans?limit=1").arg(m_baseUrl))};
     request.setRawHeader("Authorization", QByteArray("Bearer ") + key.toUtf8());
+    request.setTransferTimeout(kTransferTimeoutMs);
 
     QNetworkReply* reply = m_networkManager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
@@ -194,6 +204,12 @@ void BeanBaseClient::search(const QString& query) {
         return;
     }
 
+    // Latest-wins on a SHARED client (Beans page + MCP): tell the displaced
+    // query's consumer it will never get an answer, so nothing waits forever
+    // (MCP gather, search-bar spinner).
+    if (!m_pendingCanonicalQuery.isEmpty()
+        && m_pendingCanonicalQuery.compare(trimmed, Qt::CaseInsensitive) != 0)
+        emit searchFailed(m_pendingCanonicalQuery, QStringLiteral("superseded"));
     m_pendingCanonicalQuery = trimmed;
     m_canonicalDebounceTimer.start();
 }
@@ -204,6 +220,9 @@ void BeanBaseClient::doSendCanonicalSearch(const QString& query) {
         return;
     }
     if (m_activeCanonicalReply) {
+        // Aborting the in-flight request: its handler stays silent for the
+        // abort itself, so emit the never-coming-answer signal here.
+        emit searchFailed(m_activeCanonicalQuery, QStringLiteral("superseded"));
         m_activeCanonicalReply->abort();
         m_activeCanonicalReply.clear();
     }
@@ -213,18 +232,37 @@ void BeanBaseClient::doSendCanonicalSearch(const QString& query) {
     urlQuery.addQueryItem(QStringLiteral("q"), query);
     url.setQuery(urlQuery);
 
-    QNetworkReply* reply = m_networkManager->get(QNetworkRequest(url));
+    QNetworkRequest request{url};
+    request.setTransferTimeout(kTransferTimeoutMs);
+    QNetworkReply* reply = m_networkManager->get(request);
     m_activeCanonicalReply = reply;
+    m_activeCanonicalQuery = query;
     connect(reply, &QNetworkReply::finished, this, [this, reply, query]() {
         reply->deleteLater();
-        if (m_activeCanonicalReply == reply)
+        const bool wasActive = (m_activeCanonicalReply == reply);
+        if (wasActive)
             m_activeCanonicalReply.clear();
-        if (reply->error() == QNetworkReply::OperationCanceledError)
+        if (reply->error() == QNetworkReply::OperationCanceledError) {
+            // Our own supersede-abort already emitted; a transfer TIMEOUT
+            // (reply still active) has not — report it.
+            if (wasActive)
+                emit searchFailed(query, QStringLiteral("network"));
             return;
+        }
 
         const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         if (reply->error() == QNetworkReply::NoError && status == 200) {
-            const QVariantList entries = parseCanonicalAutocomplete(reply->readAll());
+            const QByteArray body = reply->readAll();
+            const QVariantList entries = parseCanonicalAutocomplete(body);
+            // Markup-drift tripwire: rows present but none parsed means OUR
+            // attribute scraping broke, not that the bean is missing. Without
+            // this, every user sees a plausible "No matches" forever.
+            if (entries.isEmpty() && body.contains("<li")) {
+                qWarning() << "BeanBaseClient: canonical fragment contained rows but none parsed"
+                              " — markup drift? First 200 bytes:" << body.left(200);
+                emit searchFailed(query, QStringLiteral("parse"));
+                return;
+            }
             m_canonicalCache.insert(query.toLower(), entries);
             emit searchResults(query, entries);
         } else {
@@ -252,11 +290,13 @@ void BeanBaseClient::fetchCanonicalDetails(const QVariantMap& entry) {
     q.addQueryItem(QStringLiteral("q"), roasterName);
     url.setQuery(q);
 
-    QNetworkReply* reply = m_networkManager->get(QNetworkRequest(url));
+    QNetworkRequest request{url};
+    request.setTransferTimeout(kTransferTimeoutMs);
+    QNetworkReply* reply = m_networkManager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply, entry, roasterName]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError)
-            return;  // Best-effort enrichment: fail silently.
+            return;  // Best-effort enrichment: transient failures stay silent.
         // Exact-name match (Visualizer itself keys canonical roasters by name).
         const QVariantList roasters = parseCanonicalAutocomplete(reply->readAll());
         for (const QVariant& v : roasters) {
@@ -269,6 +309,19 @@ void BeanBaseClient::fetchCanonicalDetails(const QVariantMap& entry) {
                 return;
             }
         }
+        // No exact match. A single candidate IS the answer (the query was the
+        // roaster's name); use it rather than failing enrichment for this
+        // roaster forever. Anything else is a systematic mismatch worth a
+        // log line — it's the difference between "best-effort" and
+        // "broke months ago and nobody can tell".
+        if (roasters.size() == 1) {
+            const QString uuid = roasters.first().toMap().value(QStringLiteral("id")).toString();
+            m_roasterUuidCache.insert(roasterName.toLower(), uuid);
+            fetchCanonicalPayload(uuid, entry);
+            return;
+        }
+        qWarning() << "BeanBaseClient: enrichment skipped — no exact roaster match for"
+                   << roasterName << "(" << roasters.size() << "candidates)";
     });
 }
 
@@ -283,14 +336,18 @@ void BeanBaseClient::fetchCanonicalPayload(const QString& roasterUuid, const QVa
     q.addQueryItem(QStringLiteral("canonical_roaster_id"), roasterUuid);
     url.setQuery(q);
 
-    QNetworkReply* reply = m_networkManager->get(QNetworkRequest(url));
+    QNetworkRequest request{url};
+    request.setTransferTimeout(kTransferTimeoutMs);
+    QNetworkReply* reply = m_networkManager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply, canonicalId]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError)
-            return;
+            return;  // Best-effort: transient failures stay silent.
         const QVariantMap attrs = parseCanonicalPayload(reply->readAll(), canonicalId);
         if (!attrs.isEmpty())
             emit canonicalDetails(canonicalId, attrs);
+        else
+            qWarning() << "BeanBaseClient: enrichment payload missing/unparseable for" << canonicalId;
     });
 }
 
@@ -299,7 +356,7 @@ void BeanBaseClient::sendQueuedSearch() {
         return;
 
     // Respect the 1-request-per-3 s free-tier window: if we sent recently,
-    // park the query until the window clears (a newer search() replaces it).
+    // park the query until the window clears (a newer searchBeanBase() replaces it).
     if (m_sinceLastSend.isValid()) {
         const qint64 elapsed = m_sinceLastSend.elapsed();
         if (elapsed < kMinSendGapMs) {
@@ -340,18 +397,24 @@ void BeanBaseClient::doSendSearch(const QString& query) {
     QNetworkRequest request{url};
     request.setRawHeader("Authorization", QByteArray("Bearer ") + key.toUtf8());
 
+    request.setTransferTimeout(kTransferTimeoutMs);
     m_sinceLastSend.restart();
     QNetworkReply* reply = m_networkManager->get(request);
     m_activeSearchReply = reply;
 
     connect(reply, &QNetworkReply::finished, this, [this, reply, query]() {
         reply->deleteLater();
-        if (m_activeSearchReply == reply)
+        const bool wasActive = (m_activeSearchReply == reply);
+        if (wasActive)
             m_activeSearchReply.clear();
 
-        // Superseded request aborted by doSendSearch — drop silently.
-        if (reply->error() == QNetworkReply::OperationCanceledError)
+        // Superseded request aborted by doSendSearch — drop silently; a
+        // transfer TIMEOUT (reply still active) is a real failure.
+        if (reply->error() == QNetworkReply::OperationCanceledError) {
+            if (wasActive)
+                emit searchFailed(query, QStringLiteral("network"));
             return;
+        }
 
         const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         if (reply->error() == QNetworkReply::NoError && status == 200) {
@@ -391,8 +454,11 @@ QVariantList BeanBaseClient::parseBeans(const QByteArray& responseBody) {
         const QJsonObject bean = v.toObject();
 
         QVariantMap entry;
-        // The id is kept as an opaque string: the user guide says "numerical"
-        // but the live format is unverified (design.md § Open Questions).
+        // Path discriminant — canonical entries carry source:"visualizer";
+        // every entry self-identifies so shape divergence is checkable.
+        entry[QStringLiteral("source")] = QStringLiteral("beanbase");
+        // The id is kept as an opaque string (confirmed numeric on the live
+        // API, June 2026).
         entry[QStringLiteral("id")] = toIdString(bean.value(QStringLiteral("id")));
         entry[QStringLiteral("roasterName")] = bean.value(QStringLiteral("roaster")).toString();
         entry[QStringLiteral("roastName")] = bean.value(QStringLiteral("roast-name")).toString();

--- a/src/network/beanbaseclient.h
+++ b/src/network/beanbaseclient.h
@@ -13,7 +13,9 @@ class QNetworkAccessManager;
 class QNetworkReply;
 class Settings;
 
-// Client for the Loffee Labs Bean Base API (loffeelabs.com).
+// Client for bean lookup, two paths: Visualizer's canonical autocomplete
+// (primary, keyless — see search()) and the Loffee Labs Bean Base API
+// (optional, key-gated — see searchBeanBase()).
 //
 // Endpoints (base https://loffeelabs.com/api/v2, confirmed June 2026 — see
 // openspec/changes/add-bean-base-integration/design.md):
@@ -30,10 +32,11 @@ class Settings;
 //     accumulated),
 //   - session-lifetime response cache keyed by normalized query (a repeated
 //     query never re-spends quota).
-// These windows are wall-clock requirements imposed by the external API's
-// rate contract — inherently temporal, like polling or heartbeats, not
-// event-suppression guards — which is why QTimer is the correct tool here
-// despite the project's no-timers-as-guards rule.
+// Those Bean Base windows are wall-clock requirements imposed by the external
+// API's rate contract — inherently temporal, like polling or heartbeats, not
+// event-suppression guards — which is why QTimer is the correct tool there
+// despite the project's no-timers-as-guards rule. (The canonical path's
+// 350 ms debounce is plain type-ahead coalescing; no external contract.)
 class BeanBaseClient : public QObject {
     Q_OBJECT
 
@@ -67,10 +70,12 @@ public:
     // enrichment is best-effort on top of an already-stored link.
     Q_INVOKABLE void fetchCanonicalDetails(const QVariantMap& entry);
 
-    // MCP path (`bean_base_search` tool): the Bean Base API proper.
-    // Debounced 800 ms with the documented 1-req/3 s floor and daily quota;
-    // whole-word matching; requires the user's API key. Same
-    // searchResults/searchFailed signals (filter by query echo).
+    // The Bean Base API proper — currently UNUSED in production (kept for
+    // optional key-gated enrichment; the UI and the `bean_search` MCP tool
+    // both use the canonical search() above). Debounced 800 ms with the
+    // documented 1-req/3 s floor and daily quota; whole-word matching;
+    // requires the user's API key. Same searchResults/searchFailed signals
+    // (filter by query echo).
     Q_INVOKABLE void searchBeanBase(const QString& query);
 
     // Test seams: redirect requests at a local fake server. Production code
@@ -134,6 +139,7 @@ private:
     QTimer m_canonicalDebounceTimer;
     QString m_pendingCanonicalQuery;
     QPointer<QNetworkReply> m_activeCanonicalReply;
+    QString m_activeCanonicalQuery;  // Query of the in-flight canonical reply.
 
     // Session caches: normalized query -> parsed entries; roaster name -> UUID.
     QHash<QString, QVariantList> m_cache;           // Bean Base

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -23,6 +23,7 @@
 //     local state — including local clears. Issue #1150 / migration 16.
 
 #include "visualizeruploader.h"
+#include "beanbase_blob.h"
 #include "../models/shotdatamodel.h"
 #include "../core/settings.h"
 #include "../core/settings_visualizer.h"
@@ -339,13 +340,12 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
     // when present: never null it out, since the user may have linked the
     // bag in Visualizer's own UI.
     if (!shotData.beanBaseJson.isEmpty()) {
-        const QJsonDocument bbDoc = QJsonDocument::fromJson(shotData.beanBaseJson.toUtf8());
         // A NON-EMPTY blob that fails to parse is corruption, not "unlinked" —
         // every consumer degrades identically/silently, so log it here at the
         // upload chokepoint where it would otherwise vanish without a trace.
-        if (!bbDoc.isObject())
+        if (!QJsonDocument::fromJson(shotData.beanBaseJson.toUtf8()).isObject())
             qWarning() << "VisualizerUploader: corrupt beanBaseJson on shot" << shotData.id;
-        const QString canonicalId = bbDoc.object().value(QStringLiteral("visualizerCanonicalId")).toString();
+        const QString canonicalId = BeanBaseBlob::canonicalId(shotData.beanBaseJson);
         if (!canonicalId.isEmpty())
             shotObj["canonical_coffee_bag_id"] = canonicalId;
     }

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -339,8 +339,13 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
     // when present: never null it out, since the user may have linked the
     // bag in Visualizer's own UI.
     if (!shotData.beanBaseJson.isEmpty()) {
-        const QJsonObject bb = QJsonDocument::fromJson(shotData.beanBaseJson.toUtf8()).object();
-        const QString canonicalId = bb.value(QStringLiteral("visualizerCanonicalId")).toString();
+        const QJsonDocument bbDoc = QJsonDocument::fromJson(shotData.beanBaseJson.toUtf8());
+        // A NON-EMPTY blob that fails to parse is corruption, not "unlinked" —
+        // every consumer degrades identically/silently, so log it here at the
+        // upload chokepoint where it would otherwise vanish without a trace.
+        if (!bbDoc.isObject())
+            qWarning() << "VisualizerUploader: corrupt beanBaseJson on shot" << shotData.id;
+        const QString canonicalId = bbDoc.object().value(QStringLiteral("visualizerCanonicalId")).toString();
         if (!canonicalId.isEmpty())
             shotObj["canonical_coffee_bag_id"] = canonicalId;
     }

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -30,9 +30,9 @@ struct ShotMetadata {
     int espressoEnjoyment = 0;  // 0-100
     QString espressoNotes;
     QString barista;
-    // Compact-JSON snapshot of the linked Bean Base entry (empty when the
-    // bean is unlinked — the common free-text case). Persisted per shot so
-    // history stays accurate even after the preset is edited or deleted.
+    // Compact-JSON linked-bean snapshot ("" = unlinked, the common free-text
+    // case) — Visualizer canonical or Bean Base sourced. Persisted per shot
+    // so history stays accurate even after the preset is edited or deleted.
     QString beanBaseJson;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -193,6 +193,8 @@ add_decenza_test(tst_saw_settings
 add_decenza_test(tst_beanbaseclient
     tst_beanbaseclient.cpp
     ${CMAKE_SOURCE_DIR}/src/network/beanbaseclient.cpp
+    ${CMAKE_SOURCE_DIR}/src/mcp/mcptools_beansearch.cpp
+    ${CMAKE_SOURCE_DIR}/src/mcp/mcptoolregistry.h
     ${CORE_SOURCES}
 )
 

--- a/tests/tst_beanbaseclient.cpp
+++ b/tests/tst_beanbaseclient.cpp
@@ -159,9 +159,11 @@ private slots:
         QCOMPARE(server.requestCount(), 0);
     }
 
-    // ==========================================
-    // search(): debounce, rate limit, cache
-    // ==========================================
+    // ====================================================
+    // searchBeanBase(): debounce, rate limit, cache
+    // (the Bean Base API path — search() is canonical, see
+    // canonicalSearchFlow below)
+    // ====================================================
 
     void searchDebounceCoalescesKeystrokes() {
         FakeBeanBaseServer server;

--- a/tests/tst_beanbaseclient.cpp
+++ b/tests/tst_beanbaseclient.cpp
@@ -6,8 +6,14 @@
 #include <QNetworkAccessManager>
 
 #include "network/beanbaseclient.h"
+#include "network/beanbase_blob.h"
 #include "core/settings.h"
 #include "core/settings_beanbase.h"
+#include "mcp/mcptoolregistry.h"
+
+// Registered standalone (mcptools_ai.cpp) precisely so this suite can drive
+// the bean_search gather bridge without a MainController.
+void registerBeanSearchTool(McpToolRegistry* registry, BeanBaseClient* client);
 
 // Minimal canned-response HTTP server for driving BeanBaseClient. Serves the
 // configured status + body to every request, records request lines so tests
@@ -23,14 +29,21 @@ public:
                 connect(sock, &QTcpSocket::readyRead, this, [this, sock]() {
                     const QByteArray req = sock->readAll();
                     const int lineEnd = req.indexOf("\r\n");
-                    m_requestLines.append(QString::fromUtf8(
-                        lineEnd > 0 ? req.left(lineEnd) : req));
+                    const QString line = QString::fromUtf8(
+                        lineEnd > 0 ? req.left(lineEnd) : req);
+                    m_requestLines.append(line);
+                    // Per-path routing (two-stage canonical flow tests);
+                    // falls back to the single canned response.
+                    QByteArray body = m_responseBody;
+                    for (const auto& [pathPart, pathBody] : m_pathBodies) {
+                        if (line.contains(pathPart)) { body = pathBody; break; }
+                    }
                     const QByteArray resp =
                         "HTTP/1.1 " + m_statusLine + "\r\n"
                         "Content-Type: application/json\r\n"
-                        "Content-Length: " + QByteArray::number(m_responseBody.size()) + "\r\n"
+                        "Content-Length: " + QByteArray::number(body.size()) + "\r\n"
                         "Connection: close\r\n"
-                        "\r\n" + m_responseBody;
+                        "\r\n" + body;
                     sock->write(resp);
                     sock->disconnectFromHost();
                 });
@@ -50,6 +63,12 @@ public:
         m_responseBody = body;
     }
 
+    // Route requests whose request line contains pathPart to a distinct body
+    // (first match wins; checked in insertion order).
+    void respondForPath(const QString& pathPart, const QByteArray& body) {
+        m_pathBodies.append({pathPart, body});
+    }
+
     int requestCount() const { return m_requestLines.size(); }
     QStringList requestLines() const { return m_requestLines; }
 
@@ -60,6 +79,7 @@ private:
     // braces inside "..." and silently drops every class declared after one,
     // which breaks the test class's vtable at link time.
     QByteArray m_responseBody = "{\"data\":[]}";
+    QList<QPair<QString, QByteArray>> m_pathBodies;
     QStringList m_requestLines;
 };
 
@@ -374,6 +394,122 @@ private slots:
         QCOMPARE(BeanBaseClient::parseBeans("not json").size(), 0);
         QCOMPARE(BeanBaseClient::parseBeans("{\"data\":\"oops\"}").size(), 0);
         QCOMPARE(BeanBaseClient::parseBeans("{\"data\":[42,\"x\"]}").size(), 0);
+    }
+    // ====================================================
+    // Two-stage enrichment, gather bridge, blob helpers
+    // (review follow-up for #1322)
+    // ====================================================
+
+    void fetchCanonicalDetailsTwoStageFlow() {
+        FakeBeanBaseServer server;
+        server.respondForPath("autocomplete_roasters",
+            "<div><li role=\"option\" data-autocomplete-value=\"roaster-uuid-1\" "
+            "data-roaster=\"Prodigal Coffee\" data-roaster-website=\"https://getprodigal.com/\">"
+            "Prodigal Coffee</li></div>");
+        server.respondForPath("require_roaster=true",
+            "<div><li role=\"option\" data-autocomplete-value=\"bag-uuid-1\" "
+            "data-roaster=\"Prodigal Coffee\" data-coffee-bag=\"Milk Blend\">Milk Blend"
+            "<div data-coffee-bag-payload-value=\"{&quot;roast_level&quot;:&quot;Light&quot;,"
+            "&quot;country&quot;:&quot;Brazil&quot;,&quot;processing&quot;:&quot;Natural&quot;}\">"
+            "</div></li></div>");
+        BeanBaseClient client(&m_nam, &m_settings);
+        client.setVisualizerBaseUrl(server.baseUrl());
+
+        QVariantMap entry;
+        entry["id"] = "bag-uuid-1";
+        entry["roasterName"] = "Prodigal Coffee";
+        entry["roastName"] = "Milk Blend";
+
+        QSignalSpy spy(&client, &BeanBaseClient::canonicalDetails);
+        client.fetchCanonicalDetails(entry);
+        QVERIFY(spy.wait(4000));
+        QCOMPARE(spy.first().at(0).toString(), QString("bag-uuid-1"));
+        const QVariantMap attrs = spy.first().at(1).toMap();
+        QCOMPARE(attrs["degree"].toString(), QString("Light"));     // roast_level remapped
+        QCOMPARE(attrs["origin"].toString(), QString("Brazil"));    // country remapped
+        QCOMPARE(attrs["process"].toString(), QString("Natural"));  // processing remapped
+        QCOMPARE(server.requestCount(), 2);  // roaster lookup + scoped payload fetch
+
+        // Second enrichment for the same roaster: UUID cached, ONE request.
+        QVariantMap entry2 = entry;
+        entry2["id"] = "bag-uuid-1";  // same bag again (cache only covers roaster)
+        client.fetchCanonicalDetails(entry2);
+        QVERIFY(spy.wait(4000));
+        QCOMPARE(server.requestCount(), 3);
+    }
+
+    void beanSearchToolRespondsViaGraceWhenEnrichmentStalls() {
+        // The canned single-li response has NO payload div, so enrichment
+        // never emits canonicalDetails — the tool must still respond, via
+        // the 4 s enrichment grace window. This is the worst failure mode
+        // (hang) pinned to "responds with identity-only results".
+        FakeBeanBaseServer server;
+        server.respondWith("200 OK",
+            "<div><li role=\"option\" data-autocomplete-value=\"abc-123\" "
+            "data-roaster=\"Prodigal Coffee\" data-coffee-bag=\"Milk Blend\">x</li></div>");
+        BeanBaseClient client(&m_nam, &m_settings);
+        client.setVisualizerBaseUrl(server.baseUrl());
+
+        McpToolRegistry registry;
+        registerBeanSearchTool(&registry, &client);
+
+        QString error;
+        QJsonObject result;
+        bool responded = false;
+        registry.callAsyncTool("bean_search", QJsonObject{{"query", "milk blend"}}, 2, error,
+            [&](const QJsonObject& r) { result = r; responded = true; });
+        QVERIFY2(error.isEmpty(), qPrintable(error));
+
+        QElapsedTimer timer; timer.start();
+        while (!responded && timer.elapsed() < 8000)
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+        QVERIFY(responded);
+        QCOMPARE(result["count"].toInt(), 1);
+        QCOMPARE(result["results"].toArray().first().toObject()["id"].toString(),
+                 QString("abc-123"));
+    }
+
+    void beanSearchToolReportsSupersededInsteadOfHanging() {
+        FakeBeanBaseServer server;
+        server.respondWith("200 OK", "<div></div>");
+        BeanBaseClient client(&m_nam, &m_settings);
+        client.setVisualizerBaseUrl(server.baseUrl());
+
+        McpToolRegistry registry;
+        registerBeanSearchTool(&registry, &client);
+
+        QString error;
+        QJsonObject result;
+        bool responded = false;
+        registry.callAsyncTool("bean_search", QJsonObject{{"query", "ethiopia"}}, 2, error,
+            [&](const QJsonObject& r) { result = r; responded = true; });
+        QVERIFY2(error.isEmpty(), qPrintable(error));
+
+        // A concurrent consumer (the Beans-page bar) displaces the debounced
+        // query before it is ever sent — the tool must NOT hang.
+        client.search("colombia");
+
+        QElapsedTimer timer; timer.start();
+        while (!responded && timer.elapsed() < 8000)
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+        QVERIFY(responded);
+        QCOMPARE(result["status"].toString(), QString("superseded"));
+    }
+
+    void blobHelpersDefineLinkedAndCanonicalId() {
+        // BeanBaseBlob is THE definition of "linked" / "has canonical id" —
+        // the uploader's emit-only contract rides on canonicalId() == "".
+        QVERIFY(!BeanBaseBlob::isLinked(QString()));
+        QVERIFY(!BeanBaseBlob::isLinked("not json"));
+        QVERIFY(!BeanBaseBlob::isLinked("{\"origin\":\"Colombia\"}"));   // no id
+        QVERIFY(BeanBaseBlob::isLinked("{\"id\":\"abc\"}"));
+        QVERIFY(BeanBaseBlob::isLinked("{\"id\":31754}"));                 // numeric id
+
+        QCOMPARE(BeanBaseBlob::canonicalId(QString()), QString());
+        QCOMPARE(BeanBaseBlob::canonicalId("garbage"), QString());
+        QCOMPARE(BeanBaseBlob::canonicalId("{\"id\":\"31754\"}"), QString());  // Bean Base source: no canonical
+        QCOMPARE(BeanBaseBlob::canonicalId(
+            "{\"id\":\"abc\",\"visualizerCanonicalId\":\"abc\"}"), QString("abc"));
     }
 };
 

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -166,7 +166,7 @@ private slots:
             QVERIFY(hasTable(db, "shot_samples"));
             QVERIFY(hasTable(db, "shot_phases"));
             QVERIFY(hasTable(db, "schema_version"));
-            QCOMPARE(getSchemaVersion(db), 17);
+            QCOMPARE(getSchemaVersion(db), 18);
         });
     }
 
@@ -192,6 +192,7 @@ private slots:
             QVERIFY(hasColumn(db, "shots", "skip_first_frame_detected"));
             QVERIFY(hasColumn(db, "shots", "pour_truncated_detected"));
             QVERIFY(hasColumn(db, "shots", "stopped_by"));  // migration 17 (#1161)
+            QVERIFY(hasColumn(db, "shots", "beanbase_json"));  // migration 18 (bean base)
             QVERIFY(hasColumn(db, "shot_phases", "transition_reason"));
         });
     }
@@ -231,7 +232,7 @@ private slots:
         initAndClose(path, storage);
 
         withRawDb(path, "v1_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 17);
+            QCOMPARE(getSchemaVersion(db), 18);
             QVERIFY(hasColumn(db, "shots", "temperature_override"));
             QVERIFY(hasColumn(db, "shots", "yield_override"));
             QVERIFY(hasColumn(db, "shots", "beverage_type"));
@@ -246,6 +247,7 @@ private slots:
             QVERIFY(hasColumn(db, "shots", "skip_first_frame_detected"));
             QVERIFY(hasColumn(db, "shots", "pour_truncated_detected"));
             QVERIFY(hasColumn(db, "shots", "stopped_by"));  // migration 17 (#1161)
+            QVERIFY(hasColumn(db, "shots", "beanbase_json"));  // migration 18 (bean base)
             QVERIFY(hasColumn(db, "shot_phases", "transition_reason"));
         });
     }
@@ -346,7 +348,7 @@ private slots:
         withRawDb(path, "v9_verify", [](QSqlDatabase& db) {
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasIndex(db, "idx_shots_profile_kb_id"));
-            QCOMPARE(getSchemaVersion(db), 17);
+            QCOMPARE(getSchemaVersion(db), 18);
         });
     }
 
@@ -360,7 +362,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "idempotent", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 17);
+            QCOMPARE(getSchemaVersion(db), 18);
         });
     }
 
@@ -380,7 +382,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "empty_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 17);
+            QCOMPARE(getSchemaVersion(db), 18);
         });
     }
 
@@ -403,7 +405,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "null_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 17);
+            QCOMPARE(getSchemaVersion(db), 18);
             QSqlQuery q(db);
             q.exec("SELECT grinder_brand FROM shots WHERE uuid = 'test-null'");
             QVERIFY(q.next());
@@ -580,7 +582,7 @@ private slots:
                 }
             }
         });
-        QCOMPARE(versionFound, 17);
+        QCOMPARE(versionFound, 18);
         QVERIFY2(!hasEnjoymentSource,
                  "enjoyment_source column must be absent after migration 16");
     }
@@ -682,7 +684,7 @@ private slots:
             }
         });
 
-        QCOMPARE(versionFound, 17);
+        QCOMPARE(versionFound, 18);
         QVERIFY2(columnGone, "enjoyment_source column must be dropped");
         QCOMPARE(enjoy1, 50);
         QCOMPARE(enjoy2, 50);

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -2482,6 +2482,100 @@ private slots:
         QVERIFY(!ShotSummarizer::expertBandForKbId(junk).has_value());
         QVERIFY(ShotSummarizer::profileKnowledgeForKbId(junk).isEmpty());
     }
+    // =====================================================================
+    // Bean Base snapshot: advisor remap + DB round-trip (review follow-up)
+    // =====================================================================
+
+    // The blob-key -> advisor-key remap IS the advisor contract: a silent
+    // rename upstream would empty currentBean.beanBase with no failure
+    // anywhere (the builder omits empty values by design). Pin it.
+    void beanBaseBlockRemapsBlobKeys()
+    {
+        DialingBlocks::CurrentBeanBlockInputs in;
+        in.beanBrand = "Prodigal Coffee";
+        in.beanType = "Milk Blend";
+        in.beanBaseJson = QStringLiteral(
+            "{\"id\":\"abc-123\",\"tastingNotes\":\"Orange, Honeycomb\","
+            "\"degree\":\"Light To Medium-light\",\"beanType\":\"Espresso\","
+            "\"origin\":\"Brazil, Colombia\",\"process\":\"Natural\","
+            "\"elevation\":\"1100-1200 m\","
+            "\"minElevationM\":1100,\"maxElevationM\":1200}");
+
+        const QJsonObject bean = DialingBlocks::buildCurrentBeanBlock(in);
+        QVERIFY(bean.contains("beanBase"));
+        const QJsonObject bb = bean["beanBase"].toObject();
+        QCOMPARE(bb["roasterTastingNotes"].toString(), QString("Orange, Honeycomb"));
+        QCOMPARE(bb["roastLevel"].toString(), QString("Light To Medium-light"));
+        QCOMPARE(bb["roastedFor"].toString(), QString("Espresso"));
+        QCOMPARE(bb["origin"].toString(), QString("Brazil, Colombia"));
+        QCOMPARE(bb["process"].toString(), QString("Natural"));
+        QCOMPARE(bb["elevation"].toString(), QString("1100-1200 m"));
+        QCOMPARE(bb["minElevationM"].toInt(), 1100);
+        QCOMPARE(bb["maxElevationM"].toInt(), 1200);
+    }
+
+    void beanBaseBlockOmittedWhenEmptyOrGarbage()
+    {
+        DialingBlocks::CurrentBeanBlockInputs in;
+        in.beanBrand = "X";
+        QVERIFY(!DialingBlocks::buildCurrentBeanBlock(in).contains("beanBase"));
+        in.beanBaseJson = "not json";
+        QVERIFY(!DialingBlocks::buildCurrentBeanBlock(in).contains("beanBase"));
+        in.beanBaseJson = "{\"tastingNotes\":\"\",\"minElevationM\":0}";
+        QVERIFY(!DialingBlocks::buildCurrentBeanBlock(in).contains("beanBase"));
+    }
+
+    // beanbase_json is read by POSITIONAL index in loadShotRecordStatic — a
+    // future column inserted mid-SELECT would silently shift the read and
+    // every consumer would treat the garbage as "unlinked". Round-trip via
+    // the production write path (updateShotMetadataStatic) pins the index,
+    // the sparse-emit contract, the ""-clears contract, and partial-update
+    // preservation in one go.
+    void beanBaseJsonDbRoundTripAndClear()
+    {
+        const QString dbPath = freshDbPath();
+        initAndClose(dbPath);
+
+        const QString blob = QStringLiteral(
+            "{\"id\":\"abc-123\",\"visualizerCanonicalId\":\"abc-123\","
+            "\"roasterName\":\"Prodigal Coffee\",\"origin\":\"Colombia\"}");
+
+        withRawDb(dbPath, "beanbase_roundtrip", [&](QSqlDatabase& db) {
+            const qint64 id = insertShot(db, ShotRow{
+                .uuid = "uuid-bb", .timestamp = QDateTime::currentSecsSinceEpoch(),
+                .profileName = "D-Flow", .profileKbId = "kb-dflow",
+                .duration = 28.0, .finalWeight = 36.0, .doseWeight = 18.0,
+                .grinderSetting = "5.0", .enjoyment = 0
+            });
+            QVERIFY(id > 0);
+
+            // Unlinked: empty field, sparse-emit omits the key.
+            ShotRecord rec = ShotHistoryStorage::loadShotRecordStatic(db, id);
+            QCOMPARE(rec.beanBaseJson, QString());
+            QVERIFY(!projectionForShot(db, id).toVariantMap().contains("beanBaseJson"));
+
+            // Link via the production edit path; byte-identical round-trip.
+            QVERIFY(ShotHistoryStorage::updateShotMetadataStatic(
+                db, id, {{"beanBaseJson", blob}}));
+            rec = ShotHistoryStorage::loadShotRecordStatic(db, id);
+            QCOMPARE(rec.beanBaseJson, blob);
+            QCOMPARE(projectionForShot(db, id).toVariantMap()
+                         .value("beanBaseJson").toString(), blob);
+
+            // Partial update of an unrelated field preserves the snapshot.
+            QVERIFY(ShotHistoryStorage::updateShotMetadataStatic(
+                db, id, {{"enjoyment", 80}}));
+            rec = ShotHistoryStorage::loadShotRecordStatic(db, id);
+            QCOMPARE(rec.beanBaseJson, blob);
+
+            // "" clears (the unlink-in-edit-mode / MCP {} contract).
+            QVERIFY(ShotHistoryStorage::updateShotMetadataStatic(
+                db, id, {{"beanBaseJson", QString()}}));
+            rec = ShotHistoryStorage::loadShotRecordStatic(db, id);
+            QCOMPARE(rec.beanBaseJson, QString());
+            QVERIFY(!projectionForShot(db, id).toVariantMap().contains("beanBaseJson"));
+        });
+    }
 };
 
 QTEST_GUILESS_MAIN(TstDialingBlocks)

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -70,7 +70,6 @@ private:
     int m_origAutoLoadRevertMinutes;
     QString m_origBeanBaseApiKey;
     QString m_origDyeBeanBaseId;
-    QString m_origDyeBeanBaseRoasterId;
     QString m_origDyeBeanBaseData;
 
 private slots:
@@ -89,7 +88,6 @@ private slots:
         m_origAutoLoadRevertMinutes = m_settings.app()->autoLoadRevertMinutes();
         m_origBeanBaseApiKey = m_settings.beanbase()->beanBaseApiKey();
         m_origDyeBeanBaseId = m_settings.dye()->dyeBeanBaseId();
-        m_origDyeBeanBaseRoasterId = m_settings.dye()->dyeBeanBaseRoasterId();
         m_origDyeBeanBaseData = m_settings.dye()->dyeBeanBaseData();
     }
 
@@ -107,7 +105,6 @@ private slots:
         m_settings.app()->setAutoLoadRevertMinutes(m_origAutoLoadRevertMinutes);
         m_settings.beanbase()->setBeanBaseApiKey(m_origBeanBaseApiKey);
         m_settings.dye()->setDyeBeanBaseId(m_origDyeBeanBaseId);
-        m_settings.dye()->setDyeBeanBaseRoasterId(m_origDyeBeanBaseRoasterId);
         m_settings.dye()->setDyeBeanBaseData(m_origDyeBeanBaseData);
     }
 
@@ -199,15 +196,12 @@ private slots:
 
     void dyeBeanBaseLinkRoundTripAndClear() {
         m_settings.dye()->setDyeBeanBaseId("5188");
-        m_settings.dye()->setDyeBeanBaseRoasterId("42");
         m_settings.dye()->setDyeBeanBaseData("{\"id\":\"5188\",\"origin\":\"Colombia\"}");
         QCOMPARE(m_settings.dye()->dyeBeanBaseId(), QString("5188"));
-        QCOMPARE(m_settings.dye()->dyeBeanBaseRoasterId(), QString("42"));
         QVERIFY(m_settings.dye()->dyeBeanBaseData().contains("Colombia"));
 
         m_settings.dye()->clearBeanBaseLink();
         QCOMPARE(m_settings.dye()->dyeBeanBaseId(), QString());
-        QCOMPARE(m_settings.dye()->dyeBeanBaseRoasterId(), QString());
         QCOMPARE(m_settings.dye()->dyeBeanBaseData(), QString());
     }
 
@@ -219,7 +213,6 @@ private slots:
         m_settings.dye()->setDyeBeanBrand("Prodigal Coffee");
         m_settings.dye()->setDyeBeanType("Buenos Aires");
         m_settings.dye()->setDyeBeanBaseId("5188");
-        m_settings.dye()->setDyeBeanBaseRoasterId("42");
         m_settings.dye()->setDyeBeanBaseData("{\"id\":\"5188\"}");
         m_settings.dye()->addBeanPreset("__test_linked__", "Prodigal Coffee", "Buenos Aires",
                                         "", "", "", "", "", "", "");
@@ -241,7 +234,6 @@ private slots:
         // Re-applying the linked preset restores the link.
         m_settings.dye()->applyBeanPreset(linkedIdx);
         QCOMPARE(m_settings.dye()->dyeBeanBaseId(), QString("5188"));
-        QCOMPARE(m_settings.dye()->dyeBeanBaseRoasterId(), QString("42"));
 
         // Cleanup (remove by name — indices shift after each removal).
         m_settings.dye()->setSelectedBeanPreset(-1);
@@ -259,7 +251,6 @@ private slots:
         m_settings.dye()->setDyeBeanBrand("Roaster A");
         m_settings.dye()->setDyeBeanType("Bean A");
         m_settings.dye()->setDyeBeanBaseId("111");
-        m_settings.dye()->setDyeBeanBaseRoasterId("11");
         m_settings.dye()->setDyeBeanBaseData("{\"id\":\"111\"}");
         m_settings.dye()->addBeanPreset("__test_rename__", "Roaster A", "Bean A",
                                         "", "", "", "", "", "", "");
@@ -289,6 +280,21 @@ private slots:
         m_settings.dye()->removeBeanPreset(m_settings.dye()->findBeanPresetByName("__test_renamed__"));
         m_settings.dye()->setDyeBeanBrand(origBrand);
         m_settings.dye()->setDyeBeanType(origType);
+    }
+
+    void dyeBeanBaseLinkSurvivesExportImport() {
+        // Backup/restore must carry the link (per-shot snapshots survive
+        // regardless, but the live DYE link should too).
+        m_settings.dye()->setDyeBeanBaseId("abc-123");
+        m_settings.dye()->setDyeBeanBaseData("{\"id\":\"abc-123\"}");
+        const QJsonObject exported = SettingsSerializer::exportToJson(&m_settings, false);
+
+        m_settings.dye()->clearBeanBaseLink();
+        QCOMPARE(m_settings.dye()->dyeBeanBaseId(), QString());
+
+        SettingsSerializer::importFromJson(&m_settings, exported);
+        QCOMPARE(m_settings.dye()->dyeBeanBaseId(), QString("abc-123"));
+        QCOMPARE(m_settings.dye()->dyeBeanBaseData(), QString("{\"id\":\"abc-123\"}"));
     }
 
     void beanBaseApiKeyExcludedFromNonSensitiveExport() {


### PR DESCRIPTION
## Summary

Follow-up to #1322, addressing the five-agent review of merge ec0dd69a. **Please review before merging** — nothing here is time-critical; main builds and all 2,329 tests pass with this branch.

### Critical fixes
- **`tst_dbmigration` was red on main** (8 failures — migration 18 shipped without updating the suite). Assertions bumped to v18 + `beanbase_json` column checks added. The "51/51 green" claims on #1322 only covered the two Bean Base suites; this PR's verification ran the full suite (2,329 tests).
- **`bean_search` MCP hang/leak**: grace deadline now armed *before* the search; `BeanBaseClient` emits `searchFailed(query, "superseded")` when a shared-client query is displaced, so neither the MCP gather nor the search-bar spinner can wait forever.
- **Migration 18 hardened**: version bumps only when the column verifiably exists (migration-15 precedent) — a failed ALTER retries next launch instead of permanently breaking shot saves.

### Important fixes
- 15 s transfer timeouts on all BeanBaseClient requests (timeout ≠ supersede-abort).
- `shots_update` rejects a non-object `beanBase` (string input previously coerced to `{}` = the clear sentinel — "link this bean" silently became "unlink") and non-empty objects without an `id`.
- Systematic enrichment failures now log (`qWarning`) instead of vanishing; roaster lookup gains a single-candidate fallback; canonical markup drift surfaces as "Bean search is temporarily unavailable" instead of a permanent fake "No matches".
- Unknown 429 bodies default to the recoverable "rate limited" message, not "quota — resumes tomorrow".
- Dead `dyeBeanBaseRoasterId` plumbing removed (never populated; roaster joins are by name).

### New tests
- DB round-trip pinning the positional SELECT index, sparse-emit, `""`-clears, and partial-update preservation (via the production `updateShotMetadataStatic` path).
- Advisor remap contract (`tastingNotes→roasterTastingNotes` etc.) + garbage/empty negatives.
- Serializer import round-trip for the DYE link.

### Polish
`source:"beanbase"` discriminant, advisor `elevation` passthrough, corrupt-blob tripwires at the uploader/MCP chokepoints, and the comment-rot batch from the mid-flight pivot (6 self-contradicting comments fixed, BEAN_BASE.md diagram corrected).

### Verification
Full test suite via Qt Creator: **2,329 passed, 0 failed** (previously 14/22 in tst_dbmigration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)