### PR TITLE
fix: skip saving cleaning/descale/calibrate shots to the local DB

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1841,12 +1841,14 @@ void MainController::onShotEnded() {
         return;
     }
 
-    // Skip saving for cleaning/maintenance profile types — they are not espresso shots
+    // Machine maintenance cycles must not pollute shot history or post-shot review.
+    // Same three types are excluded in visualizeruploader.cpp and mcptools_write.cpp — keep in sync.
     if (m_profileManager) {
         const QString beverageType = m_profileManager->currentProfile().beverageType();
         if (beverageType == QLatin1String("cleaning") || beverageType == QLatin1String("descale") || beverageType == QLatin1String("calibrate")) {
             if (m_shotDebugLogger)
                 m_shotDebugLogger->stopCapture();
+            m_extractionStarted = false;
             return;
         }
     }

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1841,6 +1841,16 @@ void MainController::onShotEnded() {
         return;
     }
 
+    // Skip saving for cleaning/maintenance profile types — they are not espresso shots
+    if (m_profileManager) {
+        const QString beverageType = m_profileManager->currentProfile().beverageType();
+        if (beverageType == QLatin1String("cleaning") || beverageType == QLatin1String("descale") || beverageType == QLatin1String("calibrate")) {
+            if (m_shotDebugLogger)
+                m_shotDebugLogger->stopCapture();
+            return;
+        }
+    }
+
     // Use extraction end time (excludes SAW settling phase) for accurate duration.
     // extractionDuration() is set for all shots (SAW and non-SAW) in endShot().
     // Falls back to rawTime only if timing controller is unavailable.


### PR DESCRIPTION
## Summary

- Cleaning, descale, and calibrate profile types are not espresso shots and should not appear in shot history
- The Visualizer uploader already filtered these on upload; the save path in `onShotEnded()` now applies the same `beverageType` check so they are never written to the local database in the first place
- Stops the debug logger cleanly before returning, matching the existing early-exit pattern

## Test plan

- [ ] Run a cleaning cycle — verify no shot appears in Shot History
- [ ] Pull a normal espresso shot — verify it saves as usual
- [ ] Confirm existing cleaning shots in history are unaffected (already deleted manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)