### PR TITLE
fix: live shot graph caps out at ~180s on filter profiles

### DIFF
--- a/src/models/shotdatamodel.h
+++ b/src/models/shotdatamodel.h
@@ -169,5 +169,5 @@ private:
     double m_weightAtStop = 0.0;     // Weight when stop was triggered
 
     static constexpr int FLUSH_INTERVAL_MS = 33;  // Chart update timer (~30fps); batches BLE and scale samples
-    static constexpr int INITIAL_CAPACITY = 600;  // Pre-allocate for 2min at 5Hz
+    static constexpr int INITIAL_CAPACITY = 6000;  // Pre-allocate for 10min at 10Hz (scale rate) — covers filter profiles
 };

--- a/src/models/shotdatamodel.h
+++ b/src/models/shotdatamodel.h
@@ -169,5 +169,5 @@ private:
     double m_weightAtStop = 0.0;     // Weight when stop was triggered
 
     static constexpr int FLUSH_INTERVAL_MS = 33;  // Chart update timer (~30fps); batches BLE and scale samples
-    static constexpr int INITIAL_CAPACITY = 6000;  // Pre-allocate for 10min at 10Hz (scale rate) — covers filter profiles
+    static constexpr int INITIAL_CAPACITY = 6000;  // Pre-allocate for 10min at 10Hz (WiFi scale rate; BLE ~5Hz) — covers filter profiles
 };

--- a/src/rendering/fastlinerenderer.cpp
+++ b/src/rendering/fastlinerenderer.cpp
@@ -150,7 +150,7 @@ QSGNode* FastLineRenderer::updatePaintNode(QSGNode* node, UpdatePaintNodeData*) 
 
             // Convert data points to pixel coordinates in a temp buffer
             struct Pt { float x, y; };
-            QVarLengthArray<Pt, 1024> px(m_pointCount);
+            QVarLengthArray<Pt, MAX_POINTS> px(m_pointCount);
             for (int i = 0; i < m_pointCount; ++i) {
                 px[i].x = static_cast<float>((m_points[i].x() - m_minX) * scaleX);
                 px[i].y = h - static_cast<float>((m_points[i].y() - m_minY) * scaleY);

--- a/src/rendering/fastlinerenderer.cpp
+++ b/src/rendering/fastlinerenderer.cpp
@@ -1,4 +1,5 @@
 #include "fastlinerenderer.h"
+#include <QDebug>
 #include <cmath>
 
 FastLineRenderer::FastLineRenderer(QQuickItem* parent)
@@ -66,16 +67,26 @@ void FastLineRenderer::appendPoint(double x, double y) {
         m_pointCount++;
         m_geometryDirty = true;
         update();
+    } else if (!m_overflowLogged) {
+        qWarning() << "FastLineRenderer: MAX_POINTS (" << MAX_POINTS
+                   << ") reached — further points will be discarded."
+                      " Increase MAX_POINTS if shots regularly exceed 10 minutes.";
+        m_overflowLogged = true;
     }
 }
 
 void FastLineRenderer::clear() {
     m_pointCount = 0;
+    m_overflowLogged = false;
     m_geometryDirty = true;
     update();
 }
 
 void FastLineRenderer::setPoints(const QVector<QPointF>& points) {
+    if (points.size() > MAX_POINTS)
+        qWarning() << "FastLineRenderer::setPoints: received" << points.size()
+                   << "points, truncating to MAX_POINTS (" << MAX_POINTS << ")."
+                      " Increase MAX_POINTS if shots regularly exceed 10 minutes.";
     m_pointCount = static_cast<int>(qMin(points.size(), qsizetype(MAX_POINTS)));
     m_points = points;
     if (m_points.size() > MAX_POINTS)

--- a/src/rendering/fastlinerenderer.h
+++ b/src/rendering/fastlinerenderer.h
@@ -18,7 +18,7 @@ class FastLineRenderer : public QQuickItem {
     Q_PROPERTY(double maxY READ maxY WRITE setMaxY NOTIFY maxYChanged)
 
 public:
-    static constexpr int MAX_POINTS = 6000;  // 10 min at 10Hz (scale rate) — covers espresso and filter profiles
+    static constexpr int MAX_POINTS = 6000;  // 10 min at 10Hz (WiFi scale rate; BLE scale ~5Hz in practice) — covers espresso and filter profiles
 
     explicit FastLineRenderer(QQuickItem* parent = nullptr);
 
@@ -63,5 +63,6 @@ private:
     double m_minX = 0, m_maxX = 1, m_minY = 0, m_maxY = 1;
     bool m_geometryDirty = true;
     bool m_materialDirty = true;
+    bool m_overflowLogged = false;
 
 };

--- a/src/rendering/fastlinerenderer.h
+++ b/src/rendering/fastlinerenderer.h
@@ -18,7 +18,7 @@ class FastLineRenderer : public QQuickItem {
     Q_PROPERTY(double maxY READ maxY WRITE setMaxY NOTIFY maxYChanged)
 
 public:
-    static constexpr int MAX_POINTS = 700;  // 2 min at 5Hz + margin
+    static constexpr int MAX_POINTS = 6000;  // 10 min at 10Hz (scale rate) — covers espresso and filter profiles
 
     explicit FastLineRenderer(QQuickItem* parent = nullptr);
 


### PR DESCRIPTION
## Summary

- `FastLineRenderer::MAX_POINTS` was 700 (sized for "2 min at 5Hz"), causing the live graph to silently stop drawing new data points at ~180s on longer filter extractions
- The scale sends weight data at 10Hz (the real limiting rate), so raised `MAX_POINTS` to 6000 — 10 min × 10Hz
- Also raised `ShotDataModel::INITIAL_CAPACITY` from 600 → 6000 to match, and updated the `QVarLengthArray` stack hint in the hot render path

## Root cause

`appendPoint()` silently drops new points once `m_pointCount >= MAX_POINTS`. The DE1 sends samples at ~5Hz, but BLE timing on Android averages ~3.9Hz in practice: 700 ÷ 3.9 ≈ 180s. `rawTime` kept ticking and the axis kept expanding, but no new graph data was drawn. The full shot data was always recorded correctly (ShotDataModel has no cap), which is why the post-shot history graph was unaffected.

## Test plan

- [ ] Pull and build
- [ ] Pull a filter shot (e.g. Filter 3 profile) past 3 minutes — confirm the live graph continues updating beyond 180s
- [ ] Confirm a normal espresso shot graph still works correctly
- [ ] Confirm post-shot review graph unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)