### PR TITLE
refactor: three type-invariant cleanups from bean-bag-inventory review

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2166,7 +2166,7 @@ void MainController::onShotEnded() {
             // rather than a manual edit). Independent of save success:
             // a failed stamp is logged inside storage and never blocks the
             // shot save. No user prompt (bean-bag-inventory).
-            if (m_bagStorage && metadata.bagId > 0) {
+            if (m_bagStorage && bagIdIsSet(metadata.bagId)) {
                 QVariantMap stamp;
                 if (doseWeight > 0)
                     stamp.insert(QStringLiteral("doseWeightG"), doseWeight);

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -1,4 +1,5 @@
 #include "settings_dye.h"
+#include "../history/bagid.h"
 #include "../history/coffeebagstorage.h"
 #include "settings_visualizer.h"
 #include "grinderaliases.h"
@@ -385,7 +386,7 @@ void SettingsDye::setActiveBagId(int bagId) {
     m_settings.setValue("dye/activeBagId", bagId);
     emit activeBagIdChanged();
 
-    if (bagId <= 0) {
+    if (!bagIdIsSet(bagId)) {
         // No bag selected: bean identity goes silent. Grinder/dose globals
         // stay — the physical grinder didn't change.
         m_applyingBag = true;
@@ -413,7 +414,7 @@ void SettingsDye::setActiveBagKeepFields(int bagId)
 {
     if (activeBagId() == bagId)
         return;
-    if (bagId <= 0) {
+    if (!bagIdIsSet(bagId)) {
         // Caller is about to set its own field values — just drop the bag
         // link without the identity-clearing that setActiveBagId(-1) does.
         m_settings.setValue("dye/activeBagId", -1);
@@ -494,7 +495,7 @@ void SettingsDye::writeThroughToBag(const QString& field, const QVariant& value)
     if (m_applyingBag || !m_bagStorage)
         return;
     const int bagId = activeBagId();
-    if (bagId <= 0)
+    if (!bagIdIsSet(bagId))
         return;
     m_pendingSelfWrites++;
     m_bagStorage->requestUpdateBag(bagId, {{field, value}});

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -97,7 +97,7 @@ void SettingsDye::setBagStorage(CoffeeBagStorage* storage)
                     m_bagStorage->requestBag(bagId);
             });
 
-    if (activeBagId() > 0)
+    if (bagIdIsSet(activeBagId()))
         m_bagStorage->requestBag(activeBagId());
 }
 

--- a/src/history/bagid.h
+++ b/src/history/bagid.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QtGlobal>
+
+// Canonical coffee-bag-id sentinel — the SINGLE definition of the "is this a
+// real coffee_bags row reference?" threshold.
+//
+// A bag id is a coffee_bags row id. The sentinel for "no bag" is bagId <= 0
+// (or a NULL shots.bag_id column, which the DB read maps to -1); the struct
+// default is -1. A positive id references a real bag.
+//
+// This one predicate is shared by every site that asks the question: the
+// per-shot snapshot fields (ShotRecord / ShotSaveData / ShotMetadata /
+// ShotProjection — the last exposes it to QML as ShotProjection::hasBag()),
+// the active-bag selection (SettingsDye), bag-id tool inputs (MCP), and the
+// search-model tier invariant. Call bagIdIsSet() instead of hand-rolling
+// > 0 / != -1 so the boundary can't drift — a stray >= 0 would treat the
+// phantom id 0 as a real bag and leak it into uploads.
+constexpr bool bagIdIsSet(qint64 bagId) { return bagId > 0; }

--- a/src/history/bagid.h
+++ b/src/history/bagid.h
@@ -7,7 +7,9 @@
 //
 // A bag id is a coffee_bags row id. The sentinel for "no bag" is bagId <= 0
 // (or a NULL shots.bag_id column, which the DB read maps to -1); the struct
-// default is -1. A positive id references a real bag.
+// default is -1. A positive id references a real bag. This predicate is the
+// read side — it accepts the whole "no bag" class; -1 is the canonical value
+// to WRITE for "none" (struct defaults, the "clear selection" path).
 //
 // This one predicate is shared by every site that asks the question: the
 // per-shot snapshot fields (ShotRecord / ShotSaveData / ShotMetadata /

--- a/src/history/coffeebagstorage.cpp
+++ b/src/history/coffeebagstorage.cpp
@@ -44,9 +44,11 @@ QVariant nullIfZero(double v) {
 // columns, which kCols does not model) and the migrations. Adding a column is a
 // kCols row here PLUS a matching schema/migration edit there.
 //
-// `shotCount` is intentionally NOT in this table: it is a transient field fed
-// by loadInventoryStatic's subquery alias, not a coffee_bags column. The two
-// places that round-trip it (toVariantMap/fromVariantMap) handle it explicitly.
+// `shotCount` is intentionally NOT in this table, and not a CoffeeBag field at
+// all: it is a per-query aggregate fed by loadInventoryStatic's subquery alias.
+// It rides on InventoryBag (the inventory loader's return type) and is injected
+// into the variant map by requestInventory, so toVariantMap/fromVariantMap stay
+// pure column round-trips.
 //
 // Per-column behaviour is parameterised on the CoffeeBag member pointer so the
 // member is named exactly once per row (via the COL_* macros below). The
@@ -186,7 +188,6 @@ QVariantMap CoffeeBag::toVariantMap() const
     QVariantMap map;
     for (const BagCol& c : kCols)
         map.insert(QString::fromLatin1(c.key), c.get(*this));
-    map.insert(QStringLiteral("shotCount"), shotCount);  // transient, not a column
     return map;
 }
 
@@ -201,8 +202,6 @@ CoffeeBag CoffeeBag::fromVariantMap(const QVariantMap& map)
         if (map.contains(key))
             c.set(bag, map.value(key));
     }
-    if (map.contains(QStringLiteral("shotCount")))  // transient, not a column
-        bag.shotCount = map.value(QStringLiteral("shotCount")).toLongLong();
     return bag;
 }
 
@@ -250,9 +249,14 @@ void CoffeeBagStorage::requestInventory()
     auto bags = std::make_shared<QVariantList>();
     runAsync("bags_inv",
         [bags](QSqlDatabase& db) {
-            const QVector<CoffeeBag> inventory = loadInventoryStatic(db);
-            for (const CoffeeBag& bag : inventory)
-                bags->append(bag.toVariantMap());
+            const QVector<InventoryBag> inventory = loadInventoryStatic(db);
+            for (const InventoryBag& entry : inventory) {
+                // shotCount is an inventory-only aggregate, not a CoffeeBag
+                // field — inject it into the map the QML card reads.
+                QVariantMap map = entry.bag.toVariantMap();
+                map.insert(QStringLiteral("shotCount"), entry.shotCount);
+                bags->append(map);
+            }
         },
         [this, bags]() { emit inventoryReady(*bags); });
 }
@@ -458,9 +462,9 @@ CoffeeBag CoffeeBagStorage::loadBagStatic(QSqlDatabase& db, qint64 bagId)
     return bagFromQueryRow(query);
 }
 
-QVector<CoffeeBag> CoffeeBagStorage::loadInventoryStatic(QSqlDatabase& db)
+QVector<InventoryBag> CoffeeBagStorage::loadInventoryStatic(QSqlDatabase& db)
 {
-    QVector<CoffeeBag> bags;
+    QVector<InventoryBag> bags;
     QSqlQuery query(db);
     // shot_count subquery feeds the card's single delete-vs-finished action:
     // a bag nothing references is a mistaken creation (trash); one with
@@ -476,10 +480,11 @@ QVector<CoffeeBag> CoffeeBagStorage::loadInventoryStatic(QSqlDatabase& db)
     // silently depends on the bag column count.
     const int shotCountCol = query.record().indexOf("shot_count");
     while (query.next()) {
-        CoffeeBag bag = bagFromQueryRow(query);
+        InventoryBag entry;
+        entry.bag = bagFromQueryRow(query);
         if (shotCountCol >= 0)
-            bag.shotCount = query.value(shotCountCol).toLongLong();
-        bags.append(bag);
+            entry.shotCount = query.value(shotCountCol).toLongLong();
+        bags.append(entry);
     }
     return bags;
 }

--- a/src/history/coffeebagstorage.h
+++ b/src/history/coffeebagstorage.h
@@ -53,14 +53,20 @@ struct CoffeeBag {
 
     qint64 lastUsedEpoch = 0; // bumped on selection and shot save (MRU ordering)
 
-    // Transient: number of shots referencing this bag. Populated by
-    // loadInventoryStatic's subquery only (not a coffee_bags column) —
-    // drives the card's delete-vs-finished action. 0 from other loaders.
-    qint64 shotCount = 0;
-
     bool isValid() const { return id > 0; }
     QVariantMap toVariantMap() const;
     static CoffeeBag fromVariantMap(const QVariantMap& map);
+};
+
+// An inventory row: a bag plus its shot count. The count is NOT a CoffeeBag
+// field — it is a per-query aggregate (a subquery on shots.bag_id) that only
+// the inventory listing computes, and it drives the card's delete-vs-finished
+// action (0 shots = mistaken creation, trashable; >0 = history, "Bag finished").
+// Keeping it out of CoffeeBag makes "this count is inventory-view-only" a type
+// fact: the other loaders return bare CoffeeBags and can't expose a stale 0.
+struct InventoryBag {
+    CoffeeBag bag;
+    qint64 shotCount = 0;
 };
 
 // SQLite-backed bag storage in the shot history database (coffee_bags table,
@@ -107,7 +113,7 @@ public:
 
     static qint64 insertBagStatic(QSqlDatabase& db, const CoffeeBag& bag);
     static CoffeeBag loadBagStatic(QSqlDatabase& db, qint64 bagId);
-    static QVector<CoffeeBag> loadInventoryStatic(QSqlDatabase& db);
+    static QVector<InventoryBag> loadInventoryStatic(QSqlDatabase& db);
     // Update only the columns named in `fields` (camelCase CoffeeBag keys).
     static bool updateBagFieldsStatic(QSqlDatabase& db, qint64 bagId, const QVariantMap& fields);
 

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -9,6 +9,7 @@
 #include <optional>
 
 #include "ai/shotanalysis.h"
+#include "history/bagid.h"
 
 // Lightweight shot summary for list display
 struct HistoryShotSummary {
@@ -61,9 +62,9 @@ struct ShotRecord {
     QString beanBaseJson;
 
     // Coffee bag snapshot (bean-bag-inventory, migration 19): the bag this
-    // shot was pulled with and its freeze lifecycle at shot time. Sentinel
-    // rule (canonical — see ShotProjection): bagId <= 0 (or a NULL column)
-    // means "no bag / pre-bag shot". Default -1; the DB read maps NULL to -1.
+    // shot was pulled with and its freeze lifecycle at shot time. "No bag /
+    // pre-bag shot" sentinel is bagId <= 0 (default -1; the DB read maps NULL
+    // to -1) — see bagIdIsSet() in bagid.h.
     qint64 bagId = -1;
     QString frozenDate;
     QString defrostDate;
@@ -246,8 +247,8 @@ struct ShotSaveData {
     // edited or deleted.
     QString beanBaseJson;
 
-    // Coffee bag snapshot (bean-bag-inventory): see ShotRecord. Sentinel rule:
-    // bagId <= 0 == no bag. Default -1.
+    // Coffee bag snapshot (bean-bag-inventory): see ShotRecord. "No bag" when
+    // !bagIdIsSet(bagId) (bagId <= 0). Default -1.
     qint64 bagId = -1;
     QString frozenDate;
     QString defrostDate;

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -61,8 +61,9 @@ struct ShotRecord {
     QString beanBaseJson;
 
     // Coffee bag snapshot (bean-bag-inventory, migration 19): the bag this
-    // shot was pulled with (-1/0 = none or pre-bag shot) and its freeze
-    // lifecycle at shot time.
+    // shot was pulled with and its freeze lifecycle at shot time. Sentinel
+    // rule (canonical — see ShotProjection): bagId <= 0 (or a NULL column)
+    // means "no bag / pre-bag shot". Default -1; the DB read maps NULL to -1.
     qint64 bagId = -1;
     QString frozenDate;
     QString defrostDate;
@@ -245,7 +246,8 @@ struct ShotSaveData {
     // edited or deleted.
     QString beanBaseJson;
 
-    // Coffee bag snapshot (bean-bag-inventory): see ShotRecord.
+    // Coffee bag snapshot (bean-bag-inventory): see ShotRecord. Sentinel rule:
+    // bagId <= 0 == no bag. Default -1.
     qint64 bagId = -1;
     QString frozenDate;
     QString defrostDate;

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1487,7 +1487,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                 const QString canonicalId = BeanBaseBlob::canonicalId(data.beanBaseJson);
                 query.bindValue(":beanbase_id", canonicalId.isEmpty() ? QVariant() : canonicalId);
             }
-            query.bindValue(":bag_id", data.bagId > 0 ? QVariant(data.bagId) : QVariant());
+            query.bindValue(":bag_id", bagIdIsSet(data.bagId) ? QVariant(data.bagId) : QVariant());
             query.bindValue(":frozen_date", data.frozenDate.isEmpty() ? QVariant() : data.frozenDate);
             query.bindValue(":defrost_date", data.defrostDate.isEmpty() ? QVariant() : data.defrostDate);
 

--- a/src/history/shotprojection.cpp
+++ b/src/history/shotprojection.cpp
@@ -57,7 +57,7 @@ QVariantMap ShotProjection::toVariantMap() const
         m["beanBaseJson"] = beanBaseJson;
     // Coffee bag snapshot — sparse-emit like the other optional fields:
     // pre-bag shots and unfrozen beans simply omit them.
-    if (bagId > 0)
+    if (hasBag())
         m["bagId"] = bagId;
     if (!frozenDate.isEmpty())
         m["frozenDate"] = frozenDate;

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -22,6 +22,8 @@
 #include <QVariantMap>
 #include <QJsonObject>
 
+#include "history/bagid.h"
+
 struct ShotRecord;
 
 class ShotProjection {
@@ -64,10 +66,9 @@ class ShotProjection {
     Q_PROPERTY(QString beanBaseJson MEMBER beanBaseJson)
     // Coffee bag snapshot (bean-bag-inventory): the bag this shot was pulled
     // with and the beans' freeze lifecycle at shot time (ISO dates, "" = unset).
-    // Sentinel rule (canonical across ShotRecord/ShotSaveData/ShotMetadata/
-    // ShotProjection and the nullable shots.bag_id column): bagId <= 0 (or a
-    // NULL column) means "no bag". Default is -1; the DB read maps NULL to -1.
-    // Use hasBag() instead of reinventing > 0 / != -1 at each call site.
+    // "No bag" sentinel is bagId <= 0 (default -1; the DB read maps NULL to -1)
+    // — see bagIdIsSet() in bagid.h for the canonical rule; hasBag() is the
+    // ShotProjection-typed form.
     Q_PROPERTY(qint64 bagId MEMBER bagId)
     Q_PROPERTY(QString frozenDate MEMBER frozenDate)
     Q_PROPERTY(QString defrostDate MEMBER defrostDate)
@@ -174,9 +175,9 @@ public:
     // is the cheapest reliable way to detect that.
     bool isValid() const { return id != 0; }
 
-    // Canonical "is this shot linked to a coffee bag?" test (see the bagId
-    // sentinel rule above). Q_INVOKABLE so QML can ask the same question.
-    Q_INVOKABLE bool hasBag() const { return bagId > 0; }
+    // "Is this shot linked to a coffee bag?" — the ShotProjection-typed form of
+    // the shared bagIdIsSet() predicate. Q_INVOKABLE so QML can ask the same.
+    Q_INVOKABLE bool hasBag() const { return bagIdIsSet(bagId); }
 
     // Build the legacy QVariantMap shape — same keys, same nested types as the
     // pre-Q_GADGET convertShotRecord() return value. Today's only callers are

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -63,8 +63,11 @@ class ShotProjection {
     Q_PROPERTY(QString profileKbId MEMBER profileKbId)
     Q_PROPERTY(QString beanBaseJson MEMBER beanBaseJson)
     // Coffee bag snapshot (bean-bag-inventory): the bag this shot was pulled
-    // with (-1 = none / pre-bag shot) and the beans' freeze lifecycle at
-    // shot time (ISO dates, "" = unset).
+    // with and the beans' freeze lifecycle at shot time (ISO dates, "" = unset).
+    // Sentinel rule (canonical across ShotRecord/ShotSaveData/ShotMetadata/
+    // ShotProjection and the nullable shots.bag_id column): bagId <= 0 (or a
+    // NULL column) means "no bag". Default is -1; the DB read maps NULL to -1.
+    // Use hasBag() instead of reinventing > 0 / != -1 at each call site.
     Q_PROPERTY(qint64 bagId MEMBER bagId)
     Q_PROPERTY(QString frozenDate MEMBER frozenDate)
     Q_PROPERTY(QString defrostDate MEMBER defrostDate)
@@ -170,6 +173,10 @@ public:
     // returns a default-constructed ShotProjection on lookup failure; isValid()
     // is the cheapest reliable way to detect that.
     bool isValid() const { return id != 0; }
+
+    // Canonical "is this shot linked to a coffee bag?" test (see the bagId
+    // sentinel rule above). Q_INVOKABLE so QML can ask the same question.
+    Q_INVOKABLE bool hasBag() const { return bagId > 0; }
 
     // Build the legacy QVariantMap shape — same keys, same nested types as the
     // pre-Q_GADGET convertShotRecord() return value. Today's only callers are

--- a/src/history/unifiedbeansearchmodel.h
+++ b/src/history/unifiedbeansearchmodel.h
@@ -8,6 +8,8 @@
 #include <atomic>
 #include <memory>
 
+#include "history/bagid.h"
+
 class QSqlDatabase;
 class BeanBaseClient;
 class CoffeeBagStorage;
@@ -55,11 +57,12 @@ public:
     };
     Q_ENUM(Tier)
 
-    // Cross-role invariant: a positive bag id is exclusive to Inventory-tier
+    // Cross-role invariant: a real (set) bag id is exclusive to Inventory-tier
     // rows (every other tier carries bagId == -1). Expressed in enum terms so
-    // mergeLanes and the tests can assert it directly.
+    // mergeLanes and the tests can assert it directly. Shares the bag-id
+    // threshold with bagIdIsSet() so the two can't drift.
     static constexpr bool bagIdInvariantHolds(Tier tier, qint64 bagId) {
-        return bagId <= 0 || tier == Tier::Inventory;
+        return !bagIdIsSet(bagId) || tier == Tier::Inventory;
     }
 
     enum Roles {

--- a/src/mcp/mcpresources.cpp
+++ b/src/mcp/mcpresources.cpp
@@ -5,6 +5,7 @@
 #include "../machine/machinestate.h"
 #include "../controllers/profilemanager.h"
 #include "../history/shothistorystorage.h"
+#include "../history/bagid.h"
 #include "../core/memorymonitor.h"
 #include "../core/settings.h"
 #include "../core/settings_dye.h"
@@ -161,7 +162,7 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                 // bag without needing a separate lookup.
                 bean["brand"] = settings->dye()->dyeBeanBrand();
                 bean["type"] = settings->dye()->dyeBeanType();
-                if (settings->dye()->activeBagId() > 0)
+                if (bagIdIsSet(settings->dye()->activeBagId()))
                     bean["bagId"] = settings->dye()->activeBagId();
                 if (!settings->dye()->activeBagDefrostDate().isEmpty())
                     bean["defrostDate"] = settings->dye()->activeBagDefrostDate();

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -4,6 +4,7 @@
 #include "../history/shothistorystorage.h"
 #include "../history/shotprojection.h"
 #include "../history/coffeebagstorage.h"
+#include "../history/bagid.h"
 #include "../network/visualizeruploader.h"
 #include "../controllers/profilemanager.h"
 #include "../core/settings.h"
@@ -1565,7 +1566,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 return;
             }
             const qint64 bagId = args["bagId"].toInteger();
-            if (bagId <= 0) {
+            if (!bagIdIsSet(bagId)) {
                 respond(QJsonObject{{"error", "Valid bagId is required"}});
                 return;
             }
@@ -1676,7 +1677,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 return;
             }
             const qint64 bagId = args["bagId"].toInteger();
-            if (bagId <= 0) {
+            if (!bagIdIsSet(bagId)) {
                 QMetaObject::invokeMethod(qApp, [settings, respond]() {
                     settings->dye()->setActiveBagId(-1);
                     respond(QJsonObject{{"success", true}, {"message", "Bean selection cleared"}});

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -430,7 +430,7 @@ void VisualizerUploader::testConnection()
 {
     // Re-detect Coffee Management on the next upload — the user may have
     // toggled it (or switched accounts) since the last probe.
-    m_cmState = CmState::Unknown;
+    setCmState(CmState::Unknown);
 
     QString username = m_settings->value("visualizer/username", "").toString();
     QString password = m_settings->value("visualizer/password", "").toString();
@@ -1540,6 +1540,25 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const ShotProjection& shotDa
 // server-side from the bag.
 // ===================================================================
 
+static const char* cmStateName(VisualizerUploader::CmState state)
+{
+    switch (state) {
+    case VisualizerUploader::CmState::Unknown:            return "Unknown";
+    case VisualizerUploader::CmState::Active:             return "Active";
+    case VisualizerUploader::CmState::NoCoffeeManagement: return "NoCoffeeManagement";
+    case VisualizerUploader::CmState::PremiumNoCm:        return "PremiumNoCm";
+    }
+    return "?";
+}
+
+void VisualizerUploader::setCmState(CmState state)
+{
+    if (m_cmState == state)
+        return;
+    qDebug() << "Visualizer CM: state" << cmStateName(m_cmState) << "->" << cmStateName(state);
+    m_cmState = state;
+}
+
 QNetworkRequest VisualizerUploader::makeApiJsonRequest(const QString& path) const
 {
     QNetworkRequest request{QUrl(QStringLiteral("https://visualizer.coffee") + path)};
@@ -1642,13 +1661,13 @@ void VisualizerUploader::probeCmState(const QString& visualizerShotId, const QSt
         reply->deleteLater();
         const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         if (status == 200) {
-            m_cmState = CmState::Active;
+            setCmState(CmState::Active);
             qDebug() << "Visualizer CM: probe confirmed Coffee Management ACTIVE";
             onCmActive();
         } else if (status == 400) {
             // params.expect found no permitted key — coffee_bag_id is only
             // permitted when coffee_management_enabled. Definitive negative.
-            m_cmState = CmState::PremiumNoCm;
+            setCmState(CmState::PremiumNoCm);
             qDebug() << "Visualizer CM: probe says Coffee Management is OFF (canonical-only mode)";
         } else {
             // 401/429/5xx/network — transient; never cache a negative. Warn (not
@@ -1719,7 +1738,7 @@ void VisualizerUploader::resolveRoasterId(const QString& roasterName, const QStr
                                .object().value("id").toString());
             } else if (status == 403) {
                 // Bag/roaster CRUD is premium-gated: a 403 means not premium.
-                m_cmState = CmState::NoCoffeeManagement;
+                setCmState(CmState::NoCoffeeManagement);
                 qDebug() << "Visualizer CM: roaster create 403 - account is not premium";
             } else {
                 qDebug() << "Visualizer CM: roaster create failed (HTTP" << status << ")";
@@ -1856,7 +1875,7 @@ void VisualizerUploader::createRemoteBag(const QString& visualizerShotId, const 
                 probeCmState(visualizerShotId, bagUuid, []() {});
             }
         } else if (status == 403) {
-            m_cmState = CmState::NoCoffeeManagement;
+            setCmState(CmState::NoCoffeeManagement);
             qDebug() << "Visualizer CM: bag create 403 - account is not premium";
         } else {
             qDebug() << "Visualizer CM: bag create failed (HTTP" << status << ")";
@@ -1888,7 +1907,7 @@ void VisualizerUploader::linkShotToBag(const QString& visualizerShotId, const QS
         } else if (status == 400) {
             // coffee_bag_id alone + dropped param = CM turned off since the
             // last probe; converge without retry noise.
-            m_cmState = CmState::PremiumNoCm;
+            setCmState(CmState::PremiumNoCm);
             qDebug() << "Visualizer CM: link rejected - Coffee Management now OFF";
         } else {
             qDebug() << "Visualizer CM: shot link failed (HTTP" << status << ") - retry next upload";
@@ -1996,7 +2015,7 @@ void VisualizerUploader::patchRemoteBag(const QVariantMap& bag, const QString& r
                 persistBagSyncIds(localBagId, bagUuid, roasterId);
         } else if (status == 403) {
             // Bag CRUD is premium-gated: a 403 means not premium.
-            m_cmState = CmState::NoCoffeeManagement;
+            setCmState(CmState::NoCoffeeManagement);
             qDebug() << "Visualizer CM: bag update 403 - account is not premium";
         } else if (status == 404) {
             // The remote bag was deleted on visualizer.coffee; our id is stale.

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -36,10 +36,10 @@ struct ShotMetadata {
     QString beanBaseJson;
 
     // Active coffee bag snapshot (bean-bag-inventory): the bag the shot was
-    // pulled with and its freeze lifecycle at shot time. Sentinel rule
-    // (canonical — see ShotProjection): bagId <= 0 == no bag. Default -1. The
-    // dates record the beans' thermal history permanently, even after the
-    // bag's defrostDate moves on to the next portion.
+    // pulled with and its freeze lifecycle at shot time. "No bag" sentinel is
+    // bagId <= 0 (default -1) — see bagIdIsSet() in bagid.h. The dates record
+    // the beans' thermal history permanently, even after the bag's defrostDate
+    // moves on to the next portion.
     qint64 bagId = -1;
     QString frozenDate;   // ISO yyyy-MM-dd, "" = not frozen
     QString defrostDate;  // ISO yyyy-MM-dd, "" = not defrosted

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -36,7 +36,8 @@ struct ShotMetadata {
     QString beanBaseJson;
 
     // Active coffee bag snapshot (bean-bag-inventory): the bag the shot was
-    // pulled with (-1 = no bag) and its freeze lifecycle at shot time. The
+    // pulled with and its freeze lifecycle at shot time. Sentinel rule
+    // (canonical — see ShotProjection): bagId <= 0 == no bag. Default -1. The
     // dates record the beans' thermal history permanently, even after the
     // bag's defrostDate moves on to the next portion.
     qint64 bagId = -1;
@@ -228,6 +229,12 @@ private:
     void persistBagSyncIds(qint64 localBagId, const QString& visualizerBagId,
                            const QString& visualizerRoasterId);
     QNetworkRequest makeApiJsonRequest(const QString& path) const;
+
+    // Single mutation point for m_cmState — every CM-probe transition flows
+    // through here so there is one place to log old->new. The CM probing is
+    // notoriously fiddly to debug; reads still use m_cmState / cmState()
+    // directly. No-op when the state is unchanged.
+    void setCmState(CmState state);
 
     Settings* m_settings;
     QNetworkAccessManager* m_networkManager;

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -433,11 +433,11 @@ private slots:
             fresh.coffeeName = "Bag";
             CoffeeBagStorage::insertBagStatic(db, fresh);
 
-            const QVector<CoffeeBag> inventory = CoffeeBagStorage::loadInventoryStatic(db);
+            const QVector<InventoryBag> inventory = CoffeeBagStorage::loadInventoryStatic(db);
             QCOMPARE(inventory.size(), 2);
             QHash<QString, qint64> countByRoaster;
-            for (const CoffeeBag& bag : inventory)
-                countByRoaster.insert(bag.roasterName, bag.shotCount);
+            for (const InventoryBag& entry : inventory)
+                countByRoaster.insert(entry.bag.roasterName, entry.shotCount);
             QCOMPARE(countByRoaster.value("Used"), qint64(2));
             QCOMPARE(countByRoaster.value("Fresh"), qint64(0));
         });
@@ -494,7 +494,7 @@ private slots:
         storage.initialize(path);
         qint64 usedBagId = -1, freshBagId = -1;
         withRawDb(path, "delete_ids", [&](QSqlDatabase& db) {
-            usedBagId = CoffeeBagStorage::loadInventoryStatic(db).first().id;
+            usedBagId = CoffeeBagStorage::loadInventoryStatic(db).first().bag.id;
             CoffeeBag fresh;
             fresh.roasterName = "Mistake";
             fresh.coffeeName = "Bag";

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -443,6 +443,45 @@ private slots:
         });
     }
 
+    void requestInventoryInjectsShotCountIntoMap() {
+        // shotCount is no longer a CoffeeBag field: requestInventory injects it
+        // into the variant map the QML card reads. Assert that C++->QML contract
+        // through the async signal, not just the loader struct (the field could
+        // be present on InventoryBag yet dropped from the emitted map).
+        const QString path = freshDb();
+        withRawDb(path, "inv_map", [&](QSqlDatabase& db) {
+            CoffeeBag used;
+            used.roasterName = "Used";
+            used.coffeeName = "Bag";
+            const qint64 usedId = CoffeeBagStorage::insertBagStatic(db, used);
+            insertShot(db, "Used", "Bag", 1000, QString(), usedId);
+            insertShot(db, "Used", "Bag", 1001, QString(), usedId);
+            CoffeeBag fresh;
+            fresh.roasterName = "Fresh";
+            fresh.coffeeName = "Bag";
+            CoffeeBagStorage::insertBagStatic(db, fresh);
+        });
+
+        CoffeeBagStorage storage;
+        storage.initialize(path);
+        QSignalSpy readySpy(&storage, &CoffeeBagStorage::inventoryReady);
+        storage.requestInventory();
+        QTRY_COMPARE(readySpy.count(), 1);
+
+        const QVariantList bags = readySpy.at(0).at(0).toList();
+        QCOMPARE(bags.size(), 2);
+        QHash<QString, qint64> countByRoaster;
+        for (const QVariant& v : bags) {
+            const QVariantMap map = v.toMap();
+            QVERIFY2(map.contains(QStringLiteral("shotCount")),
+                     "inventory map must carry the injected shotCount key");
+            countByRoaster.insert(map.value(QStringLiteral("roasterName")).toString(),
+                                  map.value(QStringLiteral("shotCount")).toLongLong());
+        }
+        QCOMPARE(countByRoaster.value("Used"), qint64(2));
+        QCOMPARE(countByRoaster.value("Fresh"), qint64(0));
+    }
+
     void findBagForShotPrefersLinkThenIdentity() {
         const QString path = freshDb();
         withRawDb(path, "findbag", [&](QSqlDatabase& db) {

--- a/tests/tst_shotprojection.cpp
+++ b/tests/tst_shotprojection.cpp
@@ -22,6 +22,8 @@ private slots:
     void coerce_plainMap_reconstructsValidProjection();
     void coerce_emptyVariant_yieldsInvalidProjection();
     void coerce_nonMapScalar_yieldsInvalidProjection();
+    void hasBag_followsSentinelRule();
+    void toVariantMap_sparseEmitsBagIdOnlyWhenPresent();
 };
 
 static ShotProjection makeSampleShot()
@@ -98,6 +100,42 @@ void TstShotProjection::coerce_nonMapScalar_yieldsInvalidProjection()
         QRegularExpression("ShotProjection::coerce: empty/non-map arg.*"));
     const ShotProjection result = ShotProjection::coerce(QVariant(QStringLiteral("not a shot")));
     QVERIFY(!result.isValid());
+}
+
+// hasBag() is the canonical "no bag" sentinel test (bagId <= 0 == none). The
+// boundary matters: -1 (struct default), 0 (the NULL-mapped column value), and
+// any positive id are all live values, and a future drift to >= 0 / != -1 would
+// leak a phantom bagId into the Visualizer payload.
+void TstShotProjection::hasBag_followsSentinelRule()
+{
+    ShotProjection p = makeSampleShot();
+
+    p.bagId = -1;  // struct default / explicit "none"
+    QVERIFY(!p.hasBag());
+    p.bagId = 0;   // NULL column maps here under the sentinel rule
+    QVERIFY(!p.hasBag());
+    p.bagId = 1;   // smallest real bag id
+    QVERIFY(p.hasBag());
+    p.bagId = 974;
+    QVERIFY(p.hasBag());
+}
+
+// toVariantMap() sparse-emits bagId: present only when hasBag(), so a no-bag
+// shot never serializes a misleading bagId: 0 / -1 into the QML/MCP/upload map.
+void TstShotProjection::toVariantMap_sparseEmitsBagIdOnlyWhenPresent()
+{
+    ShotProjection p = makeSampleShot();
+
+    p.bagId = -1;
+    QVERIFY2(!p.toVariantMap().contains(QStringLiteral("bagId")),
+             "no-bag shot (-1) must omit the bagId key");
+    p.bagId = 0;
+    QVERIFY2(!p.toVariantMap().contains(QStringLiteral("bagId")),
+             "no-bag shot (0) must omit the bagId key");
+    p.bagId = 42;
+    const QVariantMap withBag = p.toVariantMap();
+    QVERIFY(withBag.contains(QStringLiteral("bagId")));
+    QCOMPARE(withBag.value(QStringLiteral("bagId")).toLongLong(), qint64(42));
 }
 
 QTEST_APPLESS_MAIN(TstShotProjection)


### PR DESCRIPTION
Three small, independent follow-ups from the [#1327](https://github.com/Kulitorum/Decenza/pull/1327) review, plus a review-driven 4th. Each turns a "by convention" rule into a hard type/structural fact. No behavior change.

## 1. `shotCount` off `CoffeeBag` → `InventoryBag`
`CoffeeBag::shotCount` was a transient member populated **only** by `loadInventoryStatic`'s `shots.bag_id` subquery — it read a misleading `0` from `loadBagStatic`, `importBagsStatic`, etc. It's now a field on a new `struct InventoryBag { CoffeeBag bag; qint64 shotCount; }`, the inventory loader's return type. So "this count is inventory-view-only" is a type fact, not a comment.
- `loadInventoryStatic` returns `QVector<InventoryBag>`
- `requestInventory` injects `shotCount` into the variant map the inventory card (`BagCard.qml`) reads, so `toVariantMap`/`fromVariantMap` stay pure column round-trips (clean fit with the merged kCols metadata-table refactor #1330)

## 2. One documented `bagId` sentinel + shared `bagIdIsSet()` predicate
The "no bag" sentinel was inconsistently described as `-1` and `0` across `ShotRecord` / `ShotSaveData` / `ShotMetadata` / `ShotProjection` and the nullable DB column. Settled on one rule — **`bagId <= 0` (or NULL) == none**, default `-1`.
- New `bagid.h`: `constexpr bool bagIdIsSet(qint64)` — the single definition of the threshold.
- `ShotProjection::hasBag()` delegates to it; the four structs' comments point at it as canonical.
- Migrated every hand-rolled check (`maincontroller`, `shothistorystorage`, `settings_dye` ×3, `mcptools_write` ×2, `unifiedbeansearchmodel::bagIdInvariantHolds`) to the shared predicate so the boundary can't drift.

## 3. Single `setCmState()` choke point in `VisualizerUploader`
`m_cmState` was mutated via ~7 scattered `m_cmState = …` assignments. All now route through one private `setCmState(CmState)` that logs each `old -> new` transition — a single place to instrument the notoriously fiddly CM probing. No transition table; reads are unchanged.

## 4. Test coverage (from review)
- `tst_shotprojection`: `hasBag()` across the `-1 / 0 / >0` boundary, and `toVariantMap` sparse-emits `bagId` only when set.
- `tst_coffeebags`: `requestInventory` injects `shotCount` into the emitted map — the C++→QML contract the `InventoryBag` split relocated — asserted via the `inventoryReady` signal, not the loader struct.

## Verification
- Build: **0 errors, 0 warnings** (Qt Creator, Qt 6.11.1 Debug)
- Full test suite: **2320 passed, 0 failed, 0 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)