### PR TITLE
Bean-bag-inventory follow-up fixes (AI context, idle UI, Add Bag dialog, a11y, log cleanup)

### DIFF
--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -301,6 +301,19 @@ QtObject {
     readonly property font valueFont: Qt.font({ pixelSize: scaled(Settings.theme.customFontSizes.valueSize || 48), bold: true })
     readonly property font timerFont: Qt.font({ pixelSize: scaled(Settings.theme.customFontSizes.timerSize || 72), bold: true })
 
+    // Real monospace family per platform. "monospace" is NOT a registered font
+    // family on macOS/iOS/Windows — using it triggers a slow font-alias scan and
+    // a Qt warning at startup. Resolve to a family that actually exists. Always
+    // use Theme.monoFontFamily for monospaced text, never the literal "monospace".
+    readonly property string monoFontFamily: {
+        switch (Qt.platform.os) {
+            case "osx":
+            case "ios": return "Menlo"
+            case "windows": return "Consolas"
+            default: return "monospace"  // android / linux: the generic resolves
+        }
+    }
+
     // Scaled dimensions
     readonly property int buttonRadius: scaled(12)
     readonly property int cardRadius: scaled(16)

--- a/qml/components/BeanBaseDetailsPopup.qml
+++ b/qml/components/BeanBaseDetailsPopup.qml
@@ -42,10 +42,18 @@ Popup {
         border.width: 1
     }
 
-    Accessible.role: Accessible.Dialog
-    Accessible.name: TranslationManager.translate("beanbase.details.title", "Bean details")
-
     contentItem: Flickable {
+        // Accessible.* must attach to an Item (Popup is not one), so the dialog
+        // role/name live on the content Flickable, not the Popup root.
+        Accessible.role: Accessible.Dialog
+        // Announce WHICH bean this is, not just a generic title — the identity
+        // Texts below are Accessible.ignored so they aren't read twice.
+        Accessible.name: {
+            var title = TranslationManager.translate("beanbase.details.title", "Bean details")
+            var parts = [root.fieldOrEmpty("roastName"), root.fieldOrEmpty("roasterName")]
+                .filter(function(p) { return p.length > 0 })
+            return parts.length > 0 ? title + ": " + parts.join(", ") : title
+        }
         contentHeight: contentColumn.implicitHeight
         clip: true
         boundsBehavior: Flickable.StopAtBounds
@@ -71,6 +79,7 @@ Popup {
                         font.pixelSize: Theme.scaled(18)
                         font.bold: true
                         wrapMode: Text.WordWrap
+                        Accessible.ignored: true  // in the dialog name
                     }
                     Text {
                         Layout.fillWidth: true
@@ -78,6 +87,7 @@ Popup {
                         color: Theme.textSecondaryColor
                         font.pixelSize: Theme.scaled(14)
                         wrapMode: Text.WordWrap
+                        Accessible.ignored: true  // in the dialog name
                     }
                 }
 
@@ -212,6 +222,7 @@ Popup {
                 text: TranslationManager.translate("beanbase.details.viewAtRoaster", "View at roaster")
                 color: Theme.primaryColor
                 font.pixelSize: Theme.scaled(13)
+                Accessible.ignored: true  // accessibleItem; node carried by AccessibleMouseArea
 
                 AccessibleMouseArea {
                     anchors.fill: parent

--- a/qml/components/BeanBaseSearchBar.qml
+++ b/qml/components/BeanBaseSearchBar.qml
@@ -108,6 +108,7 @@ Item {
             color: Theme.successColor
             font.pixelSize: Theme.scaled(12)
             font.bold: true
+            Accessible.ignored: true  // status conveyed by the unlink/view buttons
         }
 
         Text {
@@ -116,6 +117,9 @@ Item {
             text: TranslationManager.translate("beaninfo.beanbase.unlink", "Unlink")
             color: Theme.primaryColor
             font.pixelSize: Theme.scaled(12)
+            // accessibleItem of the AccessibleMouseArea below — ignore this Text
+            // node so it doesn't overlap the button node (BagCard infoArea pattern).
+            Accessible.ignored: true
 
             AccessibleMouseArea {
                 anchors.fill: parent
@@ -135,6 +139,7 @@ Item {
             text: TranslationManager.translate("beaninfo.beanbase.openUrl", "View at roaster")
             color: Theme.primaryColor
             font.pixelSize: Theme.scaled(12)
+            Accessible.ignored: true  // accessibleItem; node carried by AccessibleMouseArea
 
             AccessibleMouseArea {
                 anchors.fill: parent

--- a/qml/components/BeanBaseSearchBar.qml
+++ b/qml/components/BeanBaseSearchBar.qml
@@ -37,7 +37,14 @@ Item {
     property string errorToken: ""
     property var results: []
 
+    // Screen reader (TalkBack/VoiceOver) active. A Qt Popup can't trap focus, so
+    // in this mode the typing dropdown is suppressed and the results are offered
+    // through a focus-trapping SelectionDialog opened from a labelled button —
+    // same dual-path SuggestionField uses for its own typing popup.
+    readonly property bool _accessibilityMode: typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled
+
     implicitHeight: headerRow.height + Theme.scaled(2) + searchInput.height
+        + (a11yResultsButton.visible ? a11yResultsButton.height + Theme.scaled(4) : 0)
 
     // The query string whose results we're waiting for (stale-result guard).
     property string _pendingQuery: ""
@@ -220,7 +227,15 @@ Item {
             // _openOnResult covers programmatic prefillAndSearch (no focus yet).
             if (searchInput.activeFocus || root._openOnResult) {
                 root._openOnResult = false
-                resultsPopup.open()
+                if (root._accessibilityMode) {
+                    // Screen-reader path: announce so the user knows to open the
+                    // navigable results dialog from the button below the field.
+                    if (entries.length > 0)
+                        AccessibilityManager.announce(entries.length + " "
+                            + TranslationManager.translate("beaninfo.beanbase.resultsAvailable", "bean results available"))
+                } else {
+                    resultsPopup.open()
+                }
             }
         }
 
@@ -236,7 +251,7 @@ Item {
             root.results = []
             root.errorToken = status
             root.searchState = "error"
-            if (searchInput.activeFocus) resultsPopup.open()
+            if (searchInput.activeFocus && !root._accessibilityMode) resultsPopup.open()
         }
     }
 
@@ -347,6 +362,43 @@ Item {
                     }
                     return TranslationManager.translate("beaninfo.beanbase.noMatches", "No matches — your bean may not be in the community database yet")
                 }
+            }
+        }
+    }
+
+    // --- Accessibility path (screen reader active) ---
+    // The Popup above can't trap TalkBack focus; a labelled button opens the
+    // results in a focus-trapping SelectionDialog instead.
+    AccessibleButton {
+        id: a11yResultsButton
+        visible: root._accessibilityMode && root.results.length > 0 && !root.linked
+        anchors.left: searchInput.left
+        anchors.right: searchInput.right
+        anchors.top: searchInput.bottom
+        anchors.topMargin: Theme.scaled(4)
+        height: Theme.scaled(44)
+        text: TranslationManager.translate("beaninfo.beanbase.openResults", "Show bean results")
+        accessibleName: root.results.length + " "
+            + TranslationManager.translate("beaninfo.beanbase.resultsAvailable", "bean results available")
+        onClicked: resultsDialog.open()
+    }
+
+    SelectionDialog {
+        id: resultsDialog
+        title: TranslationManager.translate("beaninfo.beanbase.resultsTitle", "Bean Base results")
+        options: root.results.map(function(r) {
+            return r.roastName + " (" + r.roasterName + ")"
+                + (r.soldout ? " — " + TranslationManager.translate("beaninfo.beanbase.soldout", "sold out") : "")
+        })
+        emptyStateText: TranslationManager.translate("beaninfo.beanbase.noMatches", "No matches — your bean may not be in the community database yet")
+        onSelected: function(index, value) {
+            var entry = root.results[index]
+            if (entry) {
+                root.entrySelected(entry)
+                Qt.callLater(function() {
+                    root.forceActiveFocus()
+                    Qt.inputMethod.hide()
+                })
             }
         }
     }

--- a/qml/components/ChangeBeansDialog.qml
+++ b/qml/components/ChangeBeansDialog.qml
@@ -194,8 +194,10 @@ Dialog {
         fGrinderModel = bag.grinderModel || ""
         fGrinderBurrs = bag.grinderBurrs || ""
         fGrinderSetting = bag.grinderSetting || ""
-        fDose = (bag.doseWeightG ?? 0) > 0 ? String(bag.doseWeightG) : ""
-        fYield = (bag.yieldOverrideG ?? 0) > 0 ? String(bag.yieldOverrideG) : ""
+        // toFixed(1) (not String()) so a non-exact double like 37.8 prefills as
+        // "37.8", not "37.800000000000004" — matching the brew-settings format.
+        fDose = (bag.doseWeightG ?? 0) > 0 ? Number(bag.doseWeightG).toFixed(1) : ""
+        fYield = (bag.yieldOverrideG ?? 0) > 0 ? Number(bag.yieldOverrideG).toFixed(1) : ""
     }
 
     // Tier 1-4 search result -> creation form. Roast date is ALWAYS blank and
@@ -287,11 +289,11 @@ Dialog {
             if (root.context === "inventory") {
                 // "Add New Bag" → picking an existing inventory bag means
                 // "another bag of the same coffee" (e.g. a fresh purchase):
-                // open the creation form pre-filled from it, identity
-                // editable, roast date blank. A separate bag is created —
-                // two bags of one coffee, with their own dates/freeze, is
-                // expected and fine.
-                openSaveAsFromBag(row)
+                // open the creation form pre-filled from it with the bean
+                // identity LOCKED — same as picking a History result — and the
+                // roast date blank. A separate bag is created; two bags of one
+                // coffee, with their own dates/freeze, is expected and fine.
+                openFormFromResult(row)
             } else {
                 // Switching contexts (brew / idle / post-shot / historical):
                 // pick the existing bag, no new row.
@@ -301,20 +303,6 @@ Dialog {
         } else {
             openFormFromResult(row)
         }
-    }
-
-    // Pre-fill the creation form from an existing bag (identity, link,
-    // grinder, dose, notes), roast date blank, all fields editable so the
-    // user can adjust before saving the new bag.
-    function openSaveAsFromBag(row) {
-        resetForm()
-        formMode = "create"
-        editBagId = -1
-        prefillFromBag(row)
-        fRoastDate = ""
-        fNotes = row.notes || ""
-        identityKnown = false
-        mode = "form"
     }
 
     function parseWeight(text) {
@@ -619,7 +607,7 @@ Dialog {
                         AccessibleMouseArea {
                             anchors.fill: parent
                             accessibleName: resultRow.primaryText + ", " + root.sourceLabel(model.sources, model.tier)
-                                + (model.tier === 0 && model.bagId === Settings.dye.activeBagId
+                                + (resultRow.isActiveBag
                                     ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                             accessibleItem: resultRow
                             onAccessibleClicked: {

--- a/qml/components/ColorEditor.qml
+++ b/qml/components/ColorEditor.qml
@@ -210,7 +210,7 @@ Item {
                 Text {
                     text: Math.round(currentVal)
                     color: Theme.textColor
-                    font.family: "monospace"
+                    font.family: Theme.monoFontFamily
                     font.pixelSize: Theme.labelFont.pixelSize
                     Layout.preferredWidth: Theme.scaled(30)
                     horizontalAlignment: Text.AlignRight

--- a/qml/components/CrashReportDialog.qml
+++ b/qml/components/CrashReportDialog.qml
@@ -175,7 +175,7 @@ Dialog {
                         TextArea {
                             readOnly: true
                             text: crashLog
-                            font.family: "monospace"
+                            font.family: Theme.monoFontFamily
                             font.pixelSize: Theme.scaled(10)
                             color: Theme.textColor
                             wrapMode: TextArea.Wrap

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -10,7 +10,16 @@ Text {
     elide: Text.ElideRight
     horizontalAlignment: Text.AlignHCenter
     font: Theme.bodyFont
-    color: mouseArea.pressed ? Theme.accentColor : Theme.textSecondaryColor
+    // Highlight (espresso-button yellow) whenever a brew override is in effect —
+    // temperature or yield differs from the active profile's default — so the
+    // summary signals "this isn't the plain profile/preset". Mirrors the exact
+    // override conditions used to build the text below.
+    readonly property bool _overrideActive:
+        (Settings.brew.hasTemperatureOverride && Math.abs(overrideTemp - profileTemp) > 0.1)
+        || (Settings.brew.hasBrewYieldOverride && profileYield > 0
+            && Math.abs(targetWeight - profileYield) > 0.1)
+    color: mouseArea.pressed ? Theme.accentColor
+         : (_overrideActive ? Theme.highlightColor : Theme.textSecondaryColor)
 
     // Visibility flags — all default true except roastDate
     property bool showProfile: true

--- a/qml/components/StyledTextField.qml
+++ b/qml/components/StyledTextField.qml
@@ -29,19 +29,12 @@ TextField {
     // Show the keyboard only then — not when TalkBack explore-by-touch gives focus.
     // Non-accessibility mode: still activate the field so VoiceOver/switch-access work.
     Accessible.onPressAction: {
-        // [a11y-dbg] TEMP (#1300) — remove before merge
-        console.log("[a11y-dbg] onPressAction (double-tap) field='"
-                    + (accessibleName || placeholder) + "' a11yMode=" + _accessibilityMode)
         if (_accessibilityMode) {
             _a11yActivated = true
         }
         control.forceActiveFocus()
         Qt.inputMethod.show()
     }
-
-    // [a11y-dbg] TEMP (#1300) — confirms user edits reach QML (Claim 2 echo). Remove before merge.
-    onTextEdited: console.log("[a11y-dbg] textEdited field='"
-                              + (accessibleName || placeholder) + "' len=" + text.length)
 
     // When TalkBack cursor lands on the field, Qt gives it activeFocus and auto-shows
     // the keyboard. In accessibility mode, suppress this so the user can hear the
@@ -51,15 +44,7 @@ TextField {
     Connections {
         target: control
         function onActiveFocusChanged() {
-            // [a11y-dbg] TEMP (#1300) — remove before merge
-            console.log("[a11y-dbg] focusChanged field='" + (control.accessibleName || control.placeholder)
-                        + "' activeFocus=" + control.activeFocus
-                        + " a11yMode=" + control._accessibilityMode
-                        + " a11yActivated=" + control._a11yActivated
-                        + " imeVisible=" + Qt.inputMethod.visible)
             if (control.activeFocus && control._accessibilityMode && !control._a11yActivated) {
-                console.log("[a11y-dbg] -> suppressing keyboard (inputMethod.hide) for '"
-                            + (control.accessibleName || control.placeholder) + "'")
                 Qt.inputMethod.hide()
             }
             if (!control.activeFocus) {

--- a/qml/components/layout/items/BeansItem.qml
+++ b/qml/components/layout/items/BeansItem.qml
@@ -140,9 +140,16 @@ Item {
     }
 
     // --- BAG PILL POPUP ---
-    Popup {
+    // Dialog (not Popup) so TalkBack can trap focus inside the pill list — a Qt
+    // Popup leaks focus and the pills are unreachable by swipe. modal traps
+    // focus; dim:false keeps it looking like a dropdown, header/footer:null
+    // strip the Dialog chrome so it renders like the old bare popup.
+    Dialog {
         id: presetPopup
-        modal: false
+        modal: true
+        dim: false
+        header: null
+        footer: null
         padding: Theme.spacingMedium
         closePolicy: Popup.CloseOnPressOutside
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -27,21 +27,6 @@ ApplicationWindow {
     leftPadding: 0
     rightPadding: 0
 
-    // [a11y-dbg] TEMP diagnostic for issue #1300 — remove before merge.
-    // Logs every soft-keyboard show/hide and which item is focused, so we can
-    // reproduce the TalkBack "keyboard opens on focus / focus trap" on the tablet.
-    // If `IME visible=true` appears right after a field gains focus WITHOUT a
-    // preceding onPressAction (double-tap), that is the trap reproduced.
-    Connections {
-        target: Qt.inputMethod
-        function onVisibleChanged() {
-            console.log("[a11y-dbg] IME visible=" + Qt.inputMethod.visible
-                        + " a11yEnabled=" + (typeof AccessibilityManager !== "undefined"
-                                             && AccessibilityManager.enabled)
-                        + " focusItem=" + root.activeFocusItem)
-        }
-    }
-
     // Debug flag to force live view on operation pages (for development)
     property bool debugLiveView: false
 
@@ -2354,7 +2339,7 @@ ApplicationWindow {
                     readOnly: true
                     selectByMouse: true
                     wrapMode: TextEdit.Wrap
-                    font.family: "monospace"
+                    font.family: Theme.monoFontFamily
                     font.pixelSize: Theme.bodyFont.pixelSize
                     color: Theme.textColor
 
@@ -2461,7 +2446,7 @@ ApplicationWindow {
                     readOnly: true
                     selectByMouse: true
                     wrapMode: TextEdit.Wrap
-                    font.family: "monospace"
+                    font.family: Theme.monoFontFamily
                     font.pixelSize: Theme.bodyFont.pixelSize
                     color: Theme.textColor
 

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -1047,7 +1047,7 @@ Page {
 
                 TextArea {
                     text: shotData.debugLog || TranslationManager.translate("shotdetail.nodebuglog", "No debug log available")
-                    font.family: "monospace"
+                    font.family: Theme.monoFontFamily
                     font.pixelSize: Theme.scaled(12)
                     color: Theme.textColor
                     readOnly: true

--- a/qml/pages/settings/AddLanguagePage.qml
+++ b/qml/pages/settings/AddLanguagePage.qml
@@ -119,7 +119,7 @@ Page {
                         Text {
                             text: modelData.code.toUpperCase()
                             font.pixelSize: Theme.scaled(14)
-                            font.family: "monospace"
+                            font.family: Theme.monoFontFamily
                             font.bold: true
                             color: langMouseArea.pressed ? Theme.primaryContrastColor : Theme.primaryColor
                             Layout.preferredWidth: Theme.scaled(30)

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -624,7 +624,7 @@ Item {
                                 readOnly: true
                                 color: Theme.textSecondaryColor
                                 font.pixelSize: Theme.scaled(11)
-                                font.family: "monospace"
+                                font.family: Theme.monoFontFamily
                                 wrapMode: Text.Wrap
                                 background: null
                                 text: ""
@@ -810,7 +810,7 @@ Item {
                                 readOnly: true
                                 color: Theme.textSecondaryColor
                                 font.pixelSize: Theme.scaled(11)
-                                font.family: "monospace"
+                                font.family: Theme.monoFontFamily
                                 wrapMode: Text.Wrap
                                 background: null
                                 text: ""
@@ -1803,7 +1803,7 @@ Item {
                                     readOnly: true
                                     color: Theme.textSecondaryColor
                                     font.pixelSize: Theme.scaled(11)
-                                    font.family: "monospace"
+                                    font.family: Theme.monoFontFamily
                                     wrapMode: Text.Wrap
                                     background: null
                                     text: ""

--- a/qml/pages/settings/SettingsHistoryDataTab.qml
+++ b/qml/pages/settings/SettingsHistoryDataTab.qml
@@ -1648,7 +1648,7 @@ KeyboardAwareContainer {
                                 anchors.centerIn: parent
                                 text: totpSetupDialog.totpSecret
                                 color: Theme.textColor
-                                font.family: "monospace"
+                                font.family: Theme.monoFontFamily
                                 font.pixelSize: Theme.scaled(11)
                                 font.bold: true
 

--- a/qml/pages/settings/SettingsHomeAutomationTab.qml
+++ b/qml/pages/settings/SettingsHomeAutomationTab.qml
@@ -412,21 +412,21 @@ KeyboardAwareContainer {
                                 text: TranslationManager.translate("settings.homeautomation.apiState", "GET /api/state - Machine state")
                                 color: Theme.textSecondaryColor
                                 font.pixelSize: Theme.scaled(10)
-                                font.family: "monospace"
+                                font.family: Theme.monoFontFamily
                             }
 
                             Text {
                                 text: TranslationManager.translate("settings.homeautomation.apiTelemetry", "GET /api/telemetry - All sensor data")
                                 color: Theme.textSecondaryColor
                                 font.pixelSize: Theme.scaled(10)
-                                font.family: "monospace"
+                                font.family: Theme.monoFontFamily
                             }
 
                             Text {
                                 text: TranslationManager.translate("settings.homeautomation.apiCommand", "POST /api/command - Send wake/sleep")
                                 color: Theme.textSecondaryColor
                                 font.pixelSize: Theme.scaled(10)
-                                font.family: "monospace"
+                                font.family: Theme.monoFontFamily
                             }
 
                             Text {

--- a/qml/pages/settings/SettingsThemesTab.qml
+++ b/qml/pages/settings/SettingsThemesTab.qml
@@ -256,7 +256,7 @@ KeyboardAwareContainer {
                                 id: hexField
                                 Layout.preferredWidth: Theme.scaled(120)
                                 text: themesTab.colorToHex(selectedColorValue)
-                                font.family: "monospace"
+                                font.family: Theme.monoFontFamily
                                 font.pixelSize: Theme.bodyFont.pixelSize
                                 inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
 

--- a/src/mcp/mcpresources.cpp
+++ b/src/mcp/mcpresources.cpp
@@ -166,8 +166,8 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                     bean["bagId"] = settings->dye()->activeBagId();
                 // Days out of the freezer, not a raw date: the AI shouldn't have
                 // to do date math (and may not reliably know today's date). This
-                // is the freshness clock the user already sees ("Def Nd" in
-                // BeanSummary). Omitted when there's no defrost date, it's
+                // is the freshness clock the user already sees (the "Def %1d"
+                // line in BeanSummary). Omitted when there's no defrost date, it's
                 // unparseable, or it's in the future.
                 const QString defrostDate = settings->dye()->activeBagDefrostDate();
                 if (!defrostDate.isEmpty()) {

--- a/src/mcp/mcpresources.cpp
+++ b/src/mcp/mcpresources.cpp
@@ -164,8 +164,20 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                 bean["type"] = settings->dye()->dyeBeanType();
                 if (bagIdIsSet(settings->dye()->activeBagId()))
                     bean["bagId"] = settings->dye()->activeBagId();
-                if (!settings->dye()->activeBagDefrostDate().isEmpty())
-                    bean["defrostDate"] = settings->dye()->activeBagDefrostDate();
+                // Days out of the freezer, not a raw date: the AI shouldn't have
+                // to do date math (and may not reliably know today's date). This
+                // is the freshness clock the user already sees ("Def Nd" in
+                // BeanSummary). Omitted when there's no defrost date, it's
+                // unparseable, or it's in the future.
+                const QString defrostDate = settings->dye()->activeBagDefrostDate();
+                if (!defrostDate.isEmpty()) {
+                    const QDate def = QDate::fromString(defrostDate.left(10), Qt::ISODate);
+                    if (def.isValid()) {
+                        const qint64 daysOut = def.daysTo(QDate::currentDate());
+                        if (daysOut >= 0)
+                            bean["daysOutOfFreezer"] = daysOut;
+                    }
+                }
                 // Normalize roast date to ISO 8601 if parseable, otherwise pass through as user text
                 QString rawDate = settings->dye()->dyeRoastDate();
                 QDate parsed = QDate::fromString(rawDate, Qt::ISODate);


### PR DESCRIPTION
A batch of small post-merge fixes for the bean-bag-inventory feature, combined into one PR to amortize review.

## AI / MCP
- **`daysOutOfFreezer`** — the live dialing context (`decenza://dialing/current_context`) now sends the computed days-out-of-freezer integer instead of a raw `defrostDate` ISO string the AI would have to do date math on.

## Idle UI
- **Brew-override highlight** — the idle shot-plan summary (`ShotPlanText`) now turns espresso-button yellow when a temperature or yield override is active, reusing the same conditions that render its `→` override arrows.

## Add Bag dialog
- Picking an **in-inventory** result now opens the **locked-identity** form (same as a History pick) instead of editable roaster/coffee.
- **Yield override** prefills clean (`37.8`, not `37.800000000000004`) via `toFixed(1)`.

## Accessibility
- `BeanBaseDetailsPopup`: `Accessible.*` moved off the non-Item `Popup` root onto its content Flickable (fixes a runtime warning); the dialog announces the bean identity; overlapping `accessibleItem` Texts ignored.
- `BeanBaseSearchBar`: ignored overlapping Texts; **added the dual-path** — sighted users keep the typing dropdown, screen-reader users get a labelled button → focus-trapping `SelectionDialog` of the results (a Qt `Popup` can't trap TalkBack focus).
- `BeansItem` bag-pill popup: `Popup` → `Dialog{modal}` so TalkBack can trap focus on the pills (`dim:false` + `header/footer:null` keep the dropdown look).
- `ChangeBeansDialog`: result-row "selected" suffix now uses the resolved `resultRow.isActiveBag`.

## Cleanup
- Removed the leftover `[a11y-dbg]` TEMP diagnostics (#1300) that flooded the log.
- Resolved a real **monospace font family** (`Theme.monoFontFamily`) instead of the missing `"monospace"` that triggered a 55 ms font-alias scan + warning at startup.

## Verification
Each change built clean via Qt Creator (0 warnings). UI/behaviour verified on-device; a11y changes need TalkBack/VoiceOver to fully confirm.

## Known follow-ups (not in this PR)
- The legacy migration-16 Visualizer re-PATCH sends a localized roast date (`MM.DD.YYYY`) instead of ISO — pre-existing, flagged.
- `[R2-diag]` refractometer logging is verbose (every ~60 s) — kept (intentional instrumentation); could be gated behind a verbose flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)