### PR TITLE
fix: normalize roast_date to ISO at every Visualizer upload site

### DIFF
--- a/src/network/roastdate.h
+++ b/src/network/roastdate.h
@@ -15,7 +15,8 @@
 // (app/models/concerns/date_parseable.rb). A dot-separated localized string is
 // therefore parsed correctly only when it matches the viewer's date setting,
 // and is otherwise misread or dropped. An unambiguous dash-separated ISO date
-// always misses every (dotted) strptime format and takes the Date.parse
+// always misses the strptime path (Visualizer's UI only offers dot-separated
+// formats: dd.mm.yyyy / mm.dd.yyyy / yyyy.mm.dd) and takes the Date.parse
 // fallback, resolving identically for every user — which keeps Coffee
 // Management's (roaster, name, parsed-date) bag matching correct.
 //
@@ -29,8 +30,8 @@ namespace RoastDate {
 inline bool localePrefersMonthFirst()
 {
     const QString fmt = QLocale().dateFormat(QLocale::ShortFormat);
-    const int mPos = fmt.indexOf(QLatin1Char('M'));
-    const int dPos = fmt.indexOf(QLatin1Char('d'));
+    const qsizetype mPos = fmt.indexOf(QLatin1Char('M'));
+    const qsizetype dPos = fmt.indexOf(QLatin1Char('d'));
     if (mPos < 0 || dPos < 0)
         return true;  // no order to read — default to month-first
     return mPos < dPos;

--- a/src/network/roastdate.h
+++ b/src/network/roastdate.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <QString>
+#include <QDate>
+#include <QLocale>
+#include <QRegularExpression>
+
+// Normalize a stored roast-date string to ISO yyyy-MM-dd for the Visualizer
+// payload. New (bean-bag) shots already store ISO, but legacy pre-bag shots
+// stored the user's *display* format (e.g. US "12.15.2025"), and the
+// migration-16 enjoyment re-sync ships those strings verbatim.
+//
+// Visualizer parses roast_date server-side with Date.strptime(user's Visualizer
+// date format) and only falls back to a lenient Date.parse on failure
+// (app/models/concerns/date_parseable.rb). A dot-separated localized string is
+// therefore parsed correctly only when it matches the viewer's date setting,
+// and is otherwise misread or dropped. An unambiguous dash-separated ISO date
+// always misses every (dotted) strptime format and takes the Date.parse
+// fallback, resolving identically for every user — which keeps Coffee
+// Management's (roaster, name, parsed-date) bag matching correct.
+//
+// Header-only + pure so the uploader and tests share one definition without
+// link-time coupling (mirrors BeanBaseBlob).
+namespace RoastDate {
+
+// True iff the active locale writes the month before the day (US "MM/DD").
+// Used only to disambiguate a numeric date that parses validly under *both*
+// orders — the same order the legacy display string was originally written in.
+inline bool localePrefersMonthFirst()
+{
+    const QString fmt = QLocale().dateFormat(QLocale::ShortFormat);
+    const int mPos = fmt.indexOf(QLatin1Char('M'));
+    const int dPos = fmt.indexOf(QLatin1Char('d'));
+    if (mPos < 0 || dPos < 0)
+        return true;  // no order to read — default to month-first
+    return mPos < dPos;
+}
+
+// Coerce `raw` to ISO yyyy-MM-dd, or return it unchanged when it isn't a date
+// we can confidently parse. Handles 3-part numeric dates separated by '/', '.',
+// or '-'. A 4-digit leading group is read year-first (unambiguous). Otherwise
+// the trailing group must be a 4-digit year and the lead two groups are
+// month/day: when only one order yields a valid calendar date we take it, and
+// when both do (e.g. 01.02.2025) we fall back to the locale's component order.
+inline QString toIso(const QString& raw)
+{
+    const QString s = raw.trimmed();
+    if (s.isEmpty())
+        return raw;
+
+    static const QRegularExpression re(
+        QStringLiteral("^(\\d{1,4})[\\/.\\-](\\d{1,2})[\\/.\\-](\\d{1,4})$"));
+    const QRegularExpressionMatch m = re.match(s);
+    if (!m.hasMatch())
+        return raw;  // not a recognizable numeric date — leave it alone
+
+    const int g1 = m.captured(1).toInt();
+    const int g2 = m.captured(2).toInt();
+    const int g3 = m.captured(3).toInt();
+
+    // Year-first (yyyy-MM-dd / yyyy.MM.dd / yyyy/MM/dd) — unambiguous.
+    if (m.captured(1).size() == 4) {
+        const QDate d(g1, g2, g3);
+        return d.isValid() ? d.toString(Qt::ISODate) : raw;
+    }
+
+    // Day/month-first: require a 4-digit trailing year to stay unambiguous.
+    if (m.captured(3).size() != 4)
+        return raw;
+    const QDate monthFirst(g3, g1, g2);  // g1=MM, g2=DD
+    const QDate dayFirst(g3, g2, g1);    // g1=DD, g2=MM
+
+    if (monthFirst.isValid() && dayFirst.isValid())
+        return (localePrefersMonthFirst() ? monthFirst : dayFirst).toString(Qt::ISODate);
+    if (monthFirst.isValid())
+        return monthFirst.toString(Qt::ISODate);
+    if (dayFirst.isValid())
+        return dayFirst.toString(Qt::ISODate);
+    return raw;  // neither order is a real calendar date
+}
+
+}  // namespace RoastDate

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -1839,6 +1839,10 @@ void VisualizerUploader::addBagDescriptiveFields(QJsonObject& body, const QVaria
         if (!value.isEmpty())
             body[QLatin1String(key)] = value;
     };
+    // No RoastDate::toIso() here, unlike the shot paths: a CoffeeBag's roastDate
+    // is ISO yyyy-MM-dd by construction (ChangeBeansDialog only stores a 10-char
+    // yyyy-mm-dd), and findRemoteBag compares this same raw value against the
+    // server's roast_date — normalizing only one side would break that match.
     setIf("roast_date", bag.value("roastDate").toString());
     setIf("roast_level", bag.value("roastLevel").toString());
     setIf("frozen_date", bag.value("frozenDate").toString());

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -24,6 +24,7 @@
 
 #include "visualizeruploader.h"
 #include "beanbase_blob.h"
+#include "roastdate.h"
 #include "../history/coffeebagstorage.h"
 #include "../core/dbutils.h"
 #include "../models/shotdatamodel.h"
@@ -319,7 +320,14 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
     setStr("bean_brand", &ShotProjection::beanBrand);
     setStr("bean_type", &ShotProjection::beanType);
     setStr("roast_level", &ShotProjection::roastLevel);
-    setStr("roast_date", &ShotProjection::roastDate);
+    // roast_date is the one field that can carry a legacy non-ISO display
+    // string (the migration-16 back-sync drains pre-bag shots through this
+    // PATCH), so normalize it here rather than via the generic setStr. Empty
+    // still clears to null; an unparseable value passes through unchanged.
+    {
+        const QString iso = RoastDate::toIso(shotData.roastDate);
+        shotObj["roast_date"] = iso.isEmpty() ? QJsonValue(QJsonValue::Null) : QJsonValue(iso);
+    }
     setDouble("bean_weight", &ShotProjection::doseWeightG);
     setDouble("drink_weight", &ShotProjection::finalWeightG);
     // Combine brand + model for visualizer (no separate brand field in API)
@@ -856,7 +864,7 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
     if (!metadata.beanType.isEmpty())
         bean["type"] = metadata.beanType;
     if (!metadata.roastDate.isEmpty())
-        bean["roast_date"] = metadata.roastDate;
+        bean["roast_date"] = RoastDate::toIso(metadata.roastDate);
     if (!metadata.roastLevel.isEmpty())
         bean["roast_level"] = metadata.roastLevel;
     meta["bean"] = bean;
@@ -915,7 +923,7 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
     if (!metadata.beanType.isEmpty())
         settings["bean_type"] = metadata.beanType;
     if (!metadata.roastDate.isEmpty())
-        settings["roast_date"] = metadata.roastDate;
+        settings["roast_date"] = RoastDate::toIso(metadata.roastDate);
     if (!metadata.roastLevel.isEmpty())
         settings["roast_level"] = metadata.roastLevel;
     if (!grinderDisplay.isEmpty())
@@ -1438,7 +1446,7 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const ShotProjection& shotDa
     QJsonObject bean;
     if (!shotData.beanBrand.isEmpty()) bean["brand"] = shotData.beanBrand;
     if (!shotData.beanType.isEmpty()) bean["type"] = shotData.beanType;
-    if (!shotData.roastDate.isEmpty()) bean["roast_date"] = shotData.roastDate;
+    if (!shotData.roastDate.isEmpty()) bean["roast_date"] = RoastDate::toIso(shotData.roastDate);
     if (!shotData.roastLevel.isEmpty()) bean["roast_level"] = shotData.roastLevel;
     meta["bean"] = bean;
 
@@ -1475,7 +1483,7 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const ShotProjection& shotDa
     QJsonObject settings;
     if (!shotData.beanBrand.isEmpty()) settings["bean_brand"] = shotData.beanBrand;
     if (!shotData.beanType.isEmpty()) settings["bean_type"] = shotData.beanType;
-    if (!shotData.roastDate.isEmpty()) settings["roast_date"] = shotData.roastDate;
+    if (!shotData.roastDate.isEmpty()) settings["roast_date"] = RoastDate::toIso(shotData.roastDate);
     if (!shotData.roastLevel.isEmpty()) settings["roast_level"] = shotData.roastLevel;
     if (!grinderDisplay2.isEmpty()) settings["grinder_model"] = grinderDisplay2;
     if (!shotData.grinderSetting.isEmpty()) settings["grinder_setting"] = shotData.grinderSetting;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -176,6 +176,11 @@ add_decenza_test(tst_shotprojection
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
 )
 
+# --- tst_roastdate: RoastDate::toIso() roast-date normalizer (header-only) ---
+add_decenza_test(tst_roastdate
+    tst_roastdate.cpp
+)
+
 # --- tst_settings: Settings persistence and defaults ---
 add_decenza_test(tst_settings
     tst_settings.cpp

--- a/tests/tst_roastdate.cpp
+++ b/tests/tst_roastdate.cpp
@@ -1,0 +1,106 @@
+#include <QTest>
+#include <QLocale>
+
+#include "network/roastdate.h"
+
+// Guards RoastDate::toIso() — the roast-date normalizer applied at the
+// Visualizer payload boundary. New bean-bag shots are already ISO; legacy
+// pre-bag shots carry the user's display format (e.g. US "12.15.2025"), which
+// the migration-16 re-sync would otherwise ship verbatim. The tricky parts are
+// year-position detection and the locale tie-break on genuinely ambiguous
+// numeric dates, so those get explicit coverage.
+class TstRoastDate : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+
+    void iso_passesThroughCanonical();
+    void yearFirst_separators_normalize();
+    void usDisplay_unambiguous_normalize();
+    void dayFirst_unambiguous_normalize();
+    void ambiguous_resolvesByLocale();
+    void unparseable_passThrough_data();
+    void unparseable_passThrough();
+    void whitespace_trimmedThenParsed();
+
+private:
+    QLocale m_saved;
+};
+
+void TstRoastDate::init()
+{
+    m_saved = QLocale();
+    // Pin a month-first locale so non-locale tests are deterministic.
+    QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));
+}
+
+void TstRoastDate::cleanup()
+{
+    QLocale::setDefault(m_saved);
+}
+
+void TstRoastDate::iso_passesThroughCanonical()
+{
+    QCOMPARE(RoastDate::toIso(QStringLiteral("2025-12-15")), QStringLiteral("2025-12-15"));
+    QCOMPARE(RoastDate::toIso(QStringLiteral("2025-01-02")), QStringLiteral("2025-01-02"));
+}
+
+void TstRoastDate::yearFirst_separators_normalize()
+{
+    QCOMPARE(RoastDate::toIso(QStringLiteral("2025/12/15")), QStringLiteral("2025-12-15"));
+    QCOMPARE(RoastDate::toIso(QStringLiteral("2025.12.15")), QStringLiteral("2025-12-15"));
+}
+
+void TstRoastDate::usDisplay_unambiguous_normalize()
+{
+    // The actual legacy shape: US MM.DD.YYYY with dots, day > 12.
+    QCOMPARE(RoastDate::toIso(QStringLiteral("12.15.2025")), QStringLiteral("2025-12-15"));
+    QCOMPARE(RoastDate::toIso(QStringLiteral("12/15/2025")), QStringLiteral("2025-12-15"));
+    QCOMPARE(RoastDate::toIso(QStringLiteral("1/2/2025")), QStringLiteral("2025-01-02"));
+}
+
+void TstRoastDate::dayFirst_unambiguous_normalize()
+{
+    // Month 15 is impossible, so only day-first parses — locale is irrelevant.
+    QCOMPARE(RoastDate::toIso(QStringLiteral("15.12.2025")), QStringLiteral("2025-12-15"));
+    QCOMPARE(RoastDate::toIso(QStringLiteral("31/01/2025")), QStringLiteral("2025-01-31"));
+}
+
+void TstRoastDate::ambiguous_resolvesByLocale()
+{
+    // 01.02.2025 parses validly both ways — the locale order decides.
+    QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));  // M/d
+    QCOMPARE(RoastDate::toIso(QStringLiteral("01.02.2025")), QStringLiteral("2025-01-02"));
+
+    QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedKingdom));  // d/M
+    QCOMPARE(RoastDate::toIso(QStringLiteral("01.02.2025")), QStringLiteral("2025-02-01"));
+}
+
+void TstRoastDate::unparseable_passThrough_data()
+{
+    QTest::addColumn<QString>("input");
+    QTest::newRow("empty") << QString();
+    QTest::newRow("text month") << QStringLiteral("December 2025");
+    QTest::newRow("year only") << QStringLiteral("2025");
+    QTest::newRow("garbage") << QStringLiteral("not a date");
+    QTest::newRow("two digit year") << QStringLiteral("12.15.25");
+    QTest::newRow("invalid both orders") << QStringLiteral("13.13.2025");
+    QTest::newRow("iso datetime") << QStringLiteral("2025-12-15T10:00:00");
+}
+
+void TstRoastDate::unparseable_passThrough()
+{
+    QFETCH(QString, input);
+    QCOMPARE(RoastDate::toIso(input), input);
+}
+
+void TstRoastDate::whitespace_trimmedThenParsed()
+{
+    QCOMPARE(RoastDate::toIso(QStringLiteral("  2025-12-15  ")), QStringLiteral("2025-12-15"));
+}
+
+QTEST_MAIN(TstRoastDate)
+#include "tst_roastdate.moc"

--- a/tests/tst_roastdate.cpp
+++ b/tests/tst_roastdate.cpp
@@ -46,6 +46,7 @@ void TstRoastDate::iso_passesThroughCanonical()
 {
     QCOMPARE(RoastDate::toIso(QStringLiteral("2025-12-15")), QStringLiteral("2025-12-15"));
     QCOMPARE(RoastDate::toIso(QStringLiteral("2025-01-02")), QStringLiteral("2025-01-02"));
+    QCOMPARE(RoastDate::toIso(QStringLiteral("2024-02-29")), QStringLiteral("2024-02-29"));  // leap day
 }
 
 void TstRoastDate::yearFirst_separators_normalize()
@@ -56,10 +57,10 @@ void TstRoastDate::yearFirst_separators_normalize()
 
 void TstRoastDate::usDisplay_unambiguous_normalize()
 {
-    // The actual legacy shape: US MM.DD.YYYY with dots, day > 12.
+    // The actual legacy shape: US MM.DD.YYYY with dots. Unambiguous because the
+    // day component exceeds 12, so month-first is the only valid calendar parse.
     QCOMPARE(RoastDate::toIso(QStringLiteral("12.15.2025")), QStringLiteral("2025-12-15"));
     QCOMPARE(RoastDate::toIso(QStringLiteral("12/15/2025")), QStringLiteral("2025-12-15"));
-    QCOMPARE(RoastDate::toIso(QStringLiteral("1/2/2025")), QStringLiteral("2025-01-02"));
 }
 
 void TstRoastDate::dayFirst_unambiguous_normalize()
@@ -67,16 +68,21 @@ void TstRoastDate::dayFirst_unambiguous_normalize()
     // Month 15 is impossible, so only day-first parses — locale is irrelevant.
     QCOMPARE(RoastDate::toIso(QStringLiteral("15.12.2025")), QStringLiteral("2025-12-15"));
     QCOMPARE(RoastDate::toIso(QStringLiteral("31/01/2025")), QStringLiteral("2025-01-31"));
+    QCOMPARE(RoastDate::toIso(QStringLiteral("29.02.2024")), QStringLiteral("2024-02-29"));  // leap day, day-first
 }
 
 void TstRoastDate::ambiguous_resolvesByLocale()
 {
-    // 01.02.2025 parses validly both ways — the locale order decides.
+    // Both groups <= 12, so both orders are valid calendar dates and the locale
+    // order (the order the legacy display string was written in) decides.
+    // Single-digit "1/2/2025" is equally ambiguous despite looking US-shaped.
     QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));  // M/d
     QCOMPARE(RoastDate::toIso(QStringLiteral("01.02.2025")), QStringLiteral("2025-01-02"));
+    QCOMPARE(RoastDate::toIso(QStringLiteral("1/2/2025")), QStringLiteral("2025-01-02"));
 
     QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedKingdom));  // d/M
     QCOMPARE(RoastDate::toIso(QStringLiteral("01.02.2025")), QStringLiteral("2025-02-01"));
+    QCOMPARE(RoastDate::toIso(QStringLiteral("1/2/2025")), QStringLiteral("2025-02-01"));
 }
 
 void TstRoastDate::unparseable_passThrough_data()
@@ -89,6 +95,10 @@ void TstRoastDate::unparseable_passThrough_data()
     QTest::newRow("two digit year") << QStringLiteral("12.15.25");
     QTest::newRow("invalid both orders") << QStringLiteral("13.13.2025");
     QTest::newRow("iso datetime") << QStringLiteral("2025-12-15T10:00:00");
+    // Year-first shape but not a real calendar date: must pass through, never
+    // get silently mangled or cleared (exercises the isValid() guard).
+    QTest::newRow("year-first bad month") << QStringLiteral("2025-13-01");
+    QTest::newRow("year-first bad day") << QStringLiteral("2025.02.30");
 }
 
 void TstRoastDate::unparseable_passThrough()


### PR DESCRIPTION
## Problem

Legacy pre-bag shots stored `roast_date` in the user's **display** format (e.g. US `12.15.2025`). The migration-16 enjoyment re-sync drains those shots and ships the localized string verbatim through the Visualizer **PATCH** path.

Verified against the Visualizer source ([`miharekar/visualizer`](https://github.com/miharekar/visualizer)): the server parses `roast_date` with `Date.strptime(string, user.date_format_string)` and only falls back to a lenient `Date.parse` ([`date_parseable.rb`](https://github.com/miharekar/visualizer/blob/main/app/models/concerns/date_parseable.rb)). The three user formats are all **dot**-separated (`%d.%m.%Y` default, `%m.%d.%Y`, `%Y.%m.%d` — [`user.rb:9`](https://github.com/miharekar/visualizer/blob/main/app/models/user.rb#L9)). A dotted localized string therefore parses correctly **only when it matches the viewer's setting**, and is otherwise misread or dropped — breaking Coffee Management's `(roaster, name, parsed-date)` bag matching ([`coffee_bag.rb:41`](https://github.com/miharekar/visualizer/blob/main/app/models/coffee_bag.rb#L41)).

## Fix

A dash-separated **ISO `yyyy-MM-dd`** misses every (dotted) `strptime` format and always takes the unambiguous `Date.parse` fallback — resolving identically for **every** user regardless of their date setting. So normalize to ISO at the upload boundary.

- New header-only `RoastDate::toIso()` (`src/network/roastdate.h`) — mirrors `BeanBaseBlob`: pure, no link-time coupling, so the uploader and tests share one definition.
- Applied at all five shot-payload sites: `buildShotJson` (live POST), `buildHistoryShotJson` (history POST), and **`updateShotOnVisualizer`** (the migration-16 back-sync PATCH — the path that motivated the fix).
- Bean-bag `CoffeeBag` paths left **raw**: that column is a real `date` and the snapshot is ISO by construction; the dedup-compare round-trips ISO↔ISO.

### Normalizer behavior

Canonicalizes ISO and year-first numeric dates; picks the only valid order when one is impossible (`30.03.2026` → `2026-03-30`); falls back to the **locale component order** on genuine ambiguity (`01.02.2025` — the order the legacy string was written in); passes anything unparseable through unchanged.

## Tests

`tests/tst_roastdate.cpp` — 15 cases (ISO passthrough, separators, US/day-first/locale-ambiguous, unparseable passthrough). All pass. macOS Debug build clean (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)