### PR TITLE
fix: eliminate the shot-save database lock (BEGIN IMMEDIATE)

### DIFF
--- a/src/core/dbutils.h
+++ b/src/core/dbutils.h
@@ -5,45 +5,7 @@
 #include <QSqlError>
 #include <QThread>
 #include <QString>
-#include <QStringList>
-#include <QHash>
-#include <QMutex>
-#include <QDateTime>
 #include <QDebug>
-
-// --- DB-lock diagnostics (temporary, investigate/shot-save-db-lock) ---------
-// Every background DB op goes through withTempDb, so a registry of currently
-// open connections lets us name whoever holds the write lock when another
-// connection (e.g. shs_save) gets SQLITE_BUSY. Logs nothing on its own — a
-// caller dumps dbDiagActiveConnections() only when it actually hits a lock.
-namespace dbdiag {
-inline QMutex& mutex() { static QMutex m; return m; }
-inline QHash<QString, qint64>& active() { static QHash<QString, qint64> a; return a; }
-inline void noteOpen(const QString& name) {
-    QMutexLocker lock(&mutex());
-    active().insert(name, QDateTime::currentMSecsSinceEpoch());
-}
-inline void noteClose(const QString& name) {
-    QMutexLocker lock(&mutex());
-    active().remove(name);
-}
-}  // namespace dbdiag
-
-// Snapshot of withTempDb connections open right now, excluding any whose name
-// starts with `excludePrefix` (the caller's own). Each entry shows how long it
-// has been open, so a long-lived holder stands out. Call this from a lock-error
-// path to identify the concurrent writer.
-inline QString dbDiagActiveConnections(const QString& excludePrefix = QString()) {
-    QMutexLocker lock(&dbdiag::mutex());
-    const qint64 now = QDateTime::currentMSecsSinceEpoch();
-    QStringList parts;
-    for (auto it = dbdiag::active().constBegin(); it != dbdiag::active().constEnd(); ++it) {
-        if (!excludePrefix.isEmpty() && it.key().startsWith(excludePrefix))
-            continue;
-        parts << QStringLiteral("%1 (open %2ms)").arg(it.key()).arg(now - it.value());
-    }
-    return parts.isEmpty() ? QStringLiteral("<none>") : parts.join(QStringLiteral(", "));
-}
 
 // Opens a temporary QSQLITE connection, runs `work(db)`, then removes the connection.
 // Sets PRAGMA busy_timeout and foreign_keys. Returns true if the DB opened successfully.
@@ -62,9 +24,7 @@ static bool withTempDb(const QString& dbPath, const QString& connPrefix, Work&& 
             QSqlQuery(db).exec("PRAGMA busy_timeout = 5000");
             QSqlQuery(db).exec("PRAGMA foreign_keys = ON");
             opened = true;
-            dbdiag::noteOpen(connName);
             work(db);
-            dbdiag::noteClose(connName);
         }
     }
     QSqlDatabase::removeDatabase(connName);

--- a/src/core/dbutils.h
+++ b/src/core/dbutils.h
@@ -5,7 +5,45 @@
 #include <QSqlError>
 #include <QThread>
 #include <QString>
+#include <QStringList>
+#include <QHash>
+#include <QMutex>
+#include <QDateTime>
 #include <QDebug>
+
+// --- DB-lock diagnostics (temporary, investigate/shot-save-db-lock) ---------
+// Every background DB op goes through withTempDb, so a registry of currently
+// open connections lets us name whoever holds the write lock when another
+// connection (e.g. shs_save) gets SQLITE_BUSY. Logs nothing on its own — a
+// caller dumps dbDiagActiveConnections() only when it actually hits a lock.
+namespace dbdiag {
+inline QMutex& mutex() { static QMutex m; return m; }
+inline QHash<QString, qint64>& active() { static QHash<QString, qint64> a; return a; }
+inline void noteOpen(const QString& name) {
+    QMutexLocker lock(&mutex());
+    active().insert(name, QDateTime::currentMSecsSinceEpoch());
+}
+inline void noteClose(const QString& name) {
+    QMutexLocker lock(&mutex());
+    active().remove(name);
+}
+}  // namespace dbdiag
+
+// Snapshot of withTempDb connections open right now, excluding any whose name
+// starts with `excludePrefix` (the caller's own). Each entry shows how long it
+// has been open, so a long-lived holder stands out. Call this from a lock-error
+// path to identify the concurrent writer.
+inline QString dbDiagActiveConnections(const QString& excludePrefix = QString()) {
+    QMutexLocker lock(&dbdiag::mutex());
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    QStringList parts;
+    for (auto it = dbdiag::active().constBegin(); it != dbdiag::active().constEnd(); ++it) {
+        if (!excludePrefix.isEmpty() && it.key().startsWith(excludePrefix))
+            continue;
+        parts << QStringLiteral("%1 (open %2ms)").arg(it.key()).arg(now - it.value());
+    }
+    return parts.isEmpty() ? QStringLiteral("<none>") : parts.join(QStringLiteral(", "));
+}
 
 // Opens a temporary QSQLITE connection, runs `work(db)`, then removes the connection.
 // Sets PRAGMA busy_timeout and foreign_keys. Returns true if the DB opened successfully.
@@ -24,7 +62,9 @@ static bool withTempDb(const QString& dbPath, const QString& connPrefix, Work&& 
             QSqlQuery(db).exec("PRAGMA busy_timeout = 5000");
             QSqlQuery(db).exec("PRAGMA foreign_keys = ON");
             opened = true;
+            dbdiag::noteOpen(connName);
             work(db);
+            dbdiag::noteClose(connName);
         }
     }
     QSqlDatabase::removeDatabase(connName);

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1577,8 +1577,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
             if (attemptSave(locked) || !locked)
                 break;
             qWarning() << "ShotHistoryStorage: shot save hit a transient lock, retrying ("
-                       << attempt << "of 4) - other DB connections open now:"
-                       << dbDiagActiveConnections(QStringLiteral("shs_save"));
+                       << attempt << "of 4)";
             QThread::msleep(static_cast<unsigned long>(50 * attempt));
         }
     });

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1427,9 +1427,16 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
         auto attemptSave = [&](bool& locked) -> bool {
             shotId = -1;
             locked = false;
-            if (!db.transaction()) {
-                locked = isLockError(db.lastError());
-                qWarning() << "ShotHistoryStorage: Failed to start transaction:" << db.lastError().text();
+            // BEGIN IMMEDIATE takes the write lock up front. db.transaction()'s plain
+            // BEGIN is DEFERRED — it acquires a read lock first, so the INSERT then has
+            // to upgrade while a concurrent writer (e.g. the post-shot bags_update bag
+            // stamp) holds the lock, and SQLite returns SQLITE_BUSY immediately without
+            // waiting out busy_timeout (deadlock avoidance). With IMMEDIATE the busy
+            // handler rides out the brief writer, so the lock no longer surfaces.
+            QSqlQuery beginQuery(db);
+            if (!beginQuery.exec(QStringLiteral("BEGIN IMMEDIATE"))) {
+                locked = isLockError(beginQuery.lastError());
+                qWarning() << "ShotHistoryStorage: Failed to start transaction:" << beginQuery.lastError().text();
                 return false;
             }
 
@@ -1509,7 +1516,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                 locked = isLockError(query.lastError());
                 qWarning() << "ShotHistoryStorage: Failed to insert shot:" << query.lastError().text()
                            << "(sqlite code" << query.lastError().nativeErrorCode() << ")";
-                db.rollback();
+                QSqlQuery(db).exec(QStringLiteral("ROLLBACK"));
                 return false;
             }
 
@@ -1524,7 +1531,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
             if (!query.exec()) {
                 locked = isLockError(query.lastError());
                 qWarning() << "ShotHistoryStorage: Failed to insert samples:" << query.lastError().text();
-                db.rollback();
+                QSqlQuery(db).exec(QStringLiteral("ROLLBACK"));
                 shotId = -1;
                 return false;
             }
@@ -1544,13 +1551,14 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                 query.exec();  // Non-critical if markers fail
             }
 
-            if (!db.commit()) {
-                // COMMIT can lose a WAL write-write race even when both INSERTs
-                // succeeded — classify it so the attempt is retried, not reported
-                // as a saved shot that never landed.
-                locked = isLockError(db.lastError());
-                qWarning() << "ShotHistoryStorage: Failed to commit shot:" << db.lastError().text();
-                db.rollback();
+            QSqlQuery commitQuery(db);
+            if (!commitQuery.exec(QStringLiteral("COMMIT"))) {
+                // COMMIT can still lose a race even when both INSERTs succeeded —
+                // classify it so the attempt is retried, not reported as a saved shot
+                // that never landed.
+                locked = isLockError(commitQuery.lastError());
+                qWarning() << "ShotHistoryStorage: Failed to commit shot:" << commitQuery.lastError().text();
+                QSqlQuery(db).exec(QStringLiteral("ROLLBACK"));
                 shotId = -1;
                 return false;
             }

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1417,11 +1417,11 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                 || e.text().contains(QLatin1String("locked"), Qt::CaseInsensitive)
                 || e.text().contains(QLatin1String("busy"), Qt::CaseInsensitive);
         };
-        // A transient SQLITE_BUSY/locked from a concurrent writer (the
-        // reconciliation drain, daily backup, WAL checkpoint) must not drop a
-        // real shot. busy_timeout covers most contention, but a WAL write-write
-        // race can still surface as "database is locked" — retry the whole
-        // transaction a few times before giving up.
+        // A transient SQLITE_BUSY/locked from a concurrent writer (the post-shot
+        // bags_update stamp, reconciliation drain, daily backup, WAL checkpoint)
+        // must not drop a real shot. BEGIN IMMEDIATE (below) lets busy_timeout
+        // absorb that contention; the retry loop is a backstop for the rare case a
+        // writer is held past busy_timeout — retry the transaction before giving up.
         // attemptSave runs one full INSERT transaction. Returns true on commit;
         // on a lock-induced failure it sets `locked` so the caller retries.
         auto attemptSave = [&](bool& locked) -> bool {
@@ -1551,16 +1551,24 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                 query.exec();  // Non-critical if markers fail
             }
 
+            // COMMIT. On a transient lock SQLite keeps the transaction staged, so
+            // retry the COMMIT itself rather than rolling back — a ROLLBACK here
+            // would discard the inserted row + sample blob + phase markers and force
+            // the outer loop to redo the whole insert. (Rare in WAL after BEGIN
+            // IMMEDIATE; only a non-lock error or exhausting the commit retries
+            // falls through to ROLLBACK + a full-transaction retry.)
             QSqlQuery commitQuery(db);
-            if (!commitQuery.exec(QStringLiteral("COMMIT"))) {
-                // COMMIT can still lose a race even when both INSERTs succeeded —
-                // classify it so the attempt is retried, not reported as a saved shot
-                // that never landed.
-                locked = isLockError(commitQuery.lastError());
-                qWarning() << "ShotHistoryStorage: Failed to commit shot:" << commitQuery.lastError().text();
-                QSqlQuery(db).exec(QStringLiteral("ROLLBACK"));
-                shotId = -1;
-                return false;
+            for (int commitTry = 1; !commitQuery.exec(QStringLiteral("COMMIT")); ++commitTry) {
+                const bool commitLocked = isLockError(commitQuery.lastError());
+                if (!commitLocked || commitTry >= 4) {
+                    locked = commitLocked;
+                    qWarning() << "ShotHistoryStorage: Failed to commit shot:"
+                               << commitQuery.lastError().text();
+                    QSqlQuery(db).exec(QStringLiteral("ROLLBACK"));
+                    shotId = -1;
+                    return false;
+                }
+                QThread::msleep(static_cast<unsigned long>(50 * commitTry));
             }
 
             // Checkpoint WAL

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1507,7 +1507,8 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
 
             if (!query.exec()) {
                 locked = isLockError(query.lastError());
-                qWarning() << "ShotHistoryStorage: Failed to insert shot:" << query.lastError().text();
+                qWarning() << "ShotHistoryStorage: Failed to insert shot:" << query.lastError().text()
+                           << "(sqlite code" << query.lastError().nativeErrorCode() << ")";
                 db.rollback();
                 return false;
             }
@@ -1568,7 +1569,8 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
             if (attemptSave(locked) || !locked)
                 break;
             qWarning() << "ShotHistoryStorage: shot save hit a transient lock, retrying ("
-                       << attempt << "of 4)";
+                       << attempt << "of 4) - other DB connections open now:"
+                       << dbDiagActiveConnections(QStringLiteral("shs_save"));
             QThread::msleep(static_cast<unsigned long>(50 * attempt));
         }
     });


### PR DESCRIPTION
## Symptom
Every shot save logged `ShotHistoryStorage: Failed to insert shot: "database is locked"` and recovered on retry 1 — a lock on **100% of saves**, masked only by the retry added in #1334.

## Root cause (confirmed with temporary instrumentation, then removed)
At shot end, `MainController::onShotEnded` dispatches the background `shs_save` INSERT and then, on the very next line, dispatches the dose/yield/`lastUsed` bag stamp via `CoffeeBagStorage::requestUpdateBag` → a second background `withTempDb` UPDATE (`bags_update`). Two background writers hit the same WAL `shots.db` at once.

The save used `db.transaction()` = a plain `BEGIN` (**DEFERRED**): it takes a read lock first, so the INSERT then has to *upgrade* to the write lock while `bags_update` holds it, and SQLite returns `SQLITE_BUSY` (code 5) **immediately** — deadlock avoidance skips the busy handler, so the connection's `busy_timeout=5000` never engages.

A diagnostic build confirmed it verbatim:
```
Failed to insert shot: "database is locked …" (sqlite code "5")
shot save hit a transient lock, retrying (1 of 4) - other DB connections open now: "bags_update_… (open 4ms)"
```

## Fix
Switch the save transaction to **`BEGIN IMMEDIATE`**, which acquires the write lock up front while holding no other lock — so the busy handler engages and `busy_timeout` rides out the brief (~4 ms) concurrent writer. The lock no longer surfaces; verified with a clean save (`Saving shot` → `Saved shot N`, no warning).

The retry loop + commit/transaction lock-classification from #1334 stay as a **quiet backstop** (covers the pathological case of a writer held longer than `busy_timeout`, so a shot is never dropped). The temporary per-`withTempDb` connection registry used to find the culprit was removed; the lightweight sqlite-native-code line in the failure log is kept.

## Testing
- Storage tests pass: `tst_coffeebags` 30, `tst_dbmigration` 28, `tst_shotrecord_cache` 7.
- Verified live: shot saves now log no lock/retry warning (previously every shot did).

🤖 Generated with [Claude Code](https://claude.com/claude-code)