### PR TITLE
Auto-recover wedged Android BLE stack by power-cycling the adapter (#1309)

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -100,6 +100,28 @@ BLEManager::BLEManager(QObject* parent)
         }
     });
 
+    // Fail-safe for the BLE-stack-wedge adapter power-cycle (#1309): if
+    // powerOff() never reports HostPoweredOff (so the host-mode handler never
+    // calls powerOn()), force the adapter back on here so a wedged radio is
+    // never left switched off. Normally stopped by the HostConnectable event
+    // before it fires. Single-shot — not a logic guard, a last-resort re-enable.
+    m_adapterRecoverySafetyTimer = new QTimer(this);
+    m_adapterRecoverySafetyTimer->setSingleShot(true);
+    m_adapterRecoverySafetyTimer->setInterval(kAdapterRecoverySafetyMs);
+    connect(m_adapterRecoverySafetyTimer, &QTimer::timeout, this, [this]() {
+#ifndef Q_OS_IOS
+        if (!m_adapterRecoveryInFlight || !m_localDevice) return;
+        qWarning() << "BLEManager: adapter did not report powered-off within"
+                   << (kAdapterRecoverySafetyMs / 1000) << "s — forcing power-on (#1309)";
+        m_localDevice->powerOn();
+        // Clear in-flight so a future wedge can still trigger recovery even if
+        // the HostConnectable event for this cycle is also missed.
+        m_adapterRecoveryInFlight = false;
+        m_wedgeSince = QDateTime();
+        emit bleStackRecovered();
+#endif
+    });
+
     // Eagerly run the Linux capability check so any qWarning lands early in
     // startup logs; subsequent calls hit the cached result.
     (void) BleCapability::linuxMissing();
@@ -147,7 +169,119 @@ bool BLEManager::isBluetoothAvailable() const
 void BLEManager::onHostModeStateChanged(QBluetoothLocalDevice::HostMode mode)
 {
     qDebug() << "BLEManager: Bluetooth host mode changed to" << mode;
+
+#ifndef Q_OS_IOS
+    // Drive the wedge-recovery power-cycle off observed adapter transitions
+    // rather than a fixed delay (the adapter takes a variable time to power
+    // down): once we see it actually off, turn it back on; once it's back on,
+    // re-arm the reconnect paths. (#1309)
+    if (m_adapterRecoveryInFlight && m_localDevice) {
+        if (mode == QBluetoothLocalDevice::HostPoweredOff) {
+            qDebug() << "BLEManager: adapter powered off during recovery — powering back on (#1309)";
+            m_localDevice->powerOn();
+        } else {
+            // HostConnectable / HostDiscoverable — adapter is back up.
+            m_adapterRecoverySafetyTimer->stop();
+            m_adapterRecoveryInFlight = false;
+            m_wedgeSince = QDateTime();
+            m_lastDe1FaultTime = QDateTime();  // stale faults shouldn't re-trip immediately
+            qDebug() << "BLEManager: adapter powered back on — re-arming DE1 + scale reconnect (#1309)";
+            emit bleStackRecovered();          // main.cpp resets the DE1 reconnect budget + retries
+            if (!m_savedScaleAddress.isEmpty())
+                tryDirectConnectToScale();     // scale side re-arm
+        }
+    }
+#endif
+
     emit bluetoothAvailableChanged();
+}
+
+void BLEManager::noteDe1Connected(bool connected)
+{
+    m_de1Connected = connected;
+    if (connected) {
+        // A working DE1 link means the stack is healthy — clear any wedge state.
+        m_anyBleSuccessThisSession = true;
+        m_wedgeSince = QDateTime();
+        m_lastDe1FaultTime = QDateTime();
+    }
+}
+
+void BLEManager::onDe1LinkFault(const QString& kind)
+{
+    // de1LinkFault fires only on genuine controller errors, never on plain
+    // device-absence — so this timestamp is the load-bearing "stack in trouble"
+    // signal the wedge detector keys off.
+    m_lastDe1FaultTime = QDateTime::currentDateTime();
+    evaluateBleWedge(QStringLiteral("de1-fault:%1").arg(kind));
+}
+
+void BLEManager::evaluateBleWedge(const QString& reason)
+{
+    // The wedge fingerprint (#1309): a saved DE1 that won't connect, throwing
+    // controller faults, WHILE the physical scale also can't connect. A single
+    // absent device never satisfies all three — only a stack that's failing
+    // every link does. m_scaleDevice is always the physical scale (FlowScale is
+    // never assigned here), so its disconnected state is real, not a fallback.
+    const bool scaleConnected = m_scaleDevice && m_scaleDevice->isConnected();
+    const bool de1FaultFresh = m_lastDe1FaultTime.isValid()
+        && m_lastDe1FaultTime.msecsTo(QDateTime::currentDateTime()) <= kWedgeFaultFreshnessMs;
+
+    const bool wedgeSuspected = hasSavedDE1() && !m_de1Connected
+                                && de1FaultFresh && !scaleConnected;
+
+    if (!wedgeSuspected) {
+        m_wedgeSince = QDateTime();  // condition broken — reset the confirm window
+        return;
+    }
+
+    const QDateTime now = QDateTime::currentDateTime();
+    if (!m_wedgeSince.isValid()) {
+        m_wedgeSince = now;  // start of a sustained-wedge window
+        return;
+    }
+    if (m_wedgeSince.msecsTo(now) >= kWedgeConfirmMs) {
+        maybeRecoverWedgedStack(reason);
+    }
+}
+
+void BLEManager::maybeRecoverWedgedStack(const QString& reason)
+{
+#ifndef Q_OS_ANDROID
+    // Only Android exhibits the wedge, and it's the only platform where a
+    // non-privileged app can cycle the adapter. Elsewhere this is a no-op —
+    // the existing "Try toggling Bluetooth off/on" error guidance stands.
+    Q_UNUSED(reason);
+    return;
+#else
+    if (m_disabled || !m_localDevice) return;
+    if (m_adapterRecoveryInFlight) return;
+    // Respect a user-disabled adapter: if they turned Bluetooth off, leave it off.
+    if (m_localDevice->hostMode() == QBluetoothLocalDevice::HostPoweredOff) return;
+
+    const QDateTime now = QDateTime::currentDateTime();
+    if (m_lastAdapterRecovery.isValid()
+        && m_lastAdapterRecovery.msecsTo(now) < kAdapterRecoveryBackoffMs) {
+        qDebug() << "BLEManager: BLE stack still appears wedged (" << reason
+                 << ") but within recovery backoff — not cycling adapter yet (#1309)";
+        return;
+    }
+
+    m_adapterRecoveryInFlight = true;
+    m_lastAdapterRecovery = now;
+    m_adapterRecoveryCount++;
+    m_wedgeSince = QDateTime();
+    qWarning() << "BLEManager: BLE stack appears wedged (" << reason
+               << ") — power-cycling Bluetooth adapter, recovery #" << m_adapterRecoveryCount
+               << "this session (#1309)";
+    appendScaleLog(QStringLiteral("BLE stack wedged — auto power-cycling Bluetooth adapter (#1309)"));
+    emit bleStackRecoveryStarted();
+
+    // powerOff() is async; the host-mode handler powers it back on once it sees
+    // HostPoweredOff, and the safety timer re-enables it if that event never lands.
+    m_adapterRecoverySafetyTimer->start();
+    m_localDevice->powerOff();
+#endif
 }
 
 void BLEManager::ensureDiscoveryAgent() {
@@ -1126,6 +1260,7 @@ void BLEManager::onScaleConnectedChanged() {
         m_lastScanErrorShown.clear();       // Healthy state — allow a future fresh scan error to pop again
         m_anyBleSuccessThisSession = true;  // Permission proven good (WiFi scales hit this too — see note below)
         m_flowScaleFallbackEmitted = false;  // Allow dialog again if scale disconnects and reconnect fails
+        m_wedgeSince = QDateTime();          // A connecting scale proves the stack isn't wedged (#1309)
         if (m_scaleConnectionFailed) {
             m_scaleConnectionFailed = false;
             emit scaleConnectionFailedChanged();
@@ -1199,6 +1334,12 @@ void BLEManager::onScaleConnectionTimeout() {
     m_manualWifiConnect = false;
 
     qWarning() << "BLEManager: Scale connection timeout - not found";
+
+    // Heartbeat for the BLE-stack-wedge detector (#1309): a scale that keeps
+    // failing to connect is one half of the wedge fingerprint. The detector
+    // only acts if the DE1 is also down and recently faulting, so a merely
+    // absent scale here can't trigger an adapter cycle on its own.
+    evaluateBleWedge(QStringLiteral("scale-timeout"));
 
     // Manual "Add WiFi Scale" entry that didn't validate (no HDS frame within
     // the connection-timer window): surface a clear, user-visible error and

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -204,7 +204,18 @@ void BLEManager::noteDe1Connected(bool connected)
         m_anyBleSuccessThisSession = true;
         m_wedgeSince = QDateTime();
         m_lastDe1FaultTime = QDateTime();
+        m_lastDe1ErrorShown.clear();  // Healthy again — allow a future DE1 error to surface
     }
+}
+
+void BLEManager::onDe1Error(const QString& error)
+{
+    // Debounce: the reconnect ladder emits the same "Connection error" on every
+    // failed attempt (~once/60s during a wedge), so show each distinct message
+    // only once until the DE1 reconnects. Mirrors the onScanError debounce.
+    if (error.isEmpty() || error == m_lastDe1ErrorShown) return;
+    m_lastDe1ErrorShown = error;
+    emit errorOccurred(error);
 }
 
 void BLEManager::onDe1LinkFault(const QString& kind)

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -100,25 +100,35 @@ BLEManager::BLEManager(QObject* parent)
         }
     });
 
-    // Fail-safe for the BLE-stack-wedge adapter power-cycle (#1309): if
-    // powerOff() never reports HostPoweredOff (so the host-mode handler never
-    // calls powerOn()), force the adapter back on here so a wedged radio is
-    // never left switched off. Normally stopped by the HostConnectable event
-    // before it fires. Single-shot — not a logic guard, a last-resort re-enable.
+    // Fail-safe watchdog for the BLE-stack-wedge adapter power-cycle (#1309).
+    // The cycle is normally event-driven (HostPoweredOff → powerOn() →
+    // HostConnectable → done); this timer guards each leg in case the OS never
+    // delivers the expected host-mode transition, so we never silently strand
+    // the radio off. It re-checks the ACTUAL adapter state and finalises
+    // accordingly — it does not blindly assume success. Single-shot, re-armed
+    // for the power-on leg; not a logic guard, a last-resort verifier.
     m_adapterRecoverySafetyTimer = new QTimer(this);
     m_adapterRecoverySafetyTimer->setSingleShot(true);
     m_adapterRecoverySafetyTimer->setInterval(kAdapterRecoverySafetyMs);
     connect(m_adapterRecoverySafetyTimer, &QTimer::timeout, this, [this]() {
 #ifndef Q_OS_IOS
         if (!m_adapterRecoveryInFlight || !m_localDevice) return;
-        qWarning() << "BLEManager: adapter did not report powered-off within"
-                   << (kAdapterRecoverySafetyMs / 1000) << "s — forcing power-on (#1309)";
-        m_localDevice->powerOn();
-        // Clear in-flight so a future wedge can still trigger recovery even if
-        // the HostConnectable event for this cycle is also missed.
-        m_adapterRecoveryInFlight = false;
-        m_wedgeSince = QDateTime();
-        emit bleStackRecovered();
+        const bool adapterOff = m_localDevice->hostMode() == QBluetoothLocalDevice::HostPoweredOff;
+        if (adapterOff) {
+            // Either powerOff() never reported HostPoweredOff, or the power-on
+            // leg never brought it back. Make one more attempt to re-enable, then
+            // let finishAdapterRecovery(false) surface it — never leave BT off.
+            qWarning() << "BLEManager: adapter still powered off"
+                       << (kAdapterRecoverySafetyMs / 1000) << "s into recovery — forcing power-on (#1309)";
+            m_localDevice->powerOn();
+            finishAdapterRecovery(false);
+        } else {
+            // Adapter is on but we missed the HostConnectable event (or powerOff
+            // was a no-op and it was never actually off). Treat as recovered.
+            qWarning() << "BLEManager: recovery watchdog — adapter is on without an explicit "
+                          "HostConnectable event; treating as recovered (#1309)";
+            finishAdapterRecovery(true);
+        }
 #endif
     });
 
@@ -177,23 +187,54 @@ void BLEManager::onHostModeStateChanged(QBluetoothLocalDevice::HostMode mode)
     // re-arm the reconnect paths. (#1309)
     if (m_adapterRecoveryInFlight && m_localDevice) {
         if (mode == QBluetoothLocalDevice::HostPoweredOff) {
+            // Power-off leg done — bring it back up, and re-arm the watchdog so
+            // the power-ON leg is itself covered (powerOn never landing must not
+            // leave the radio off).
+            m_recoverySawPoweredOff = true;
             qDebug() << "BLEManager: adapter powered off during recovery — powering back on (#1309)";
             m_localDevice->powerOn();
+            m_adapterRecoverySafetyTimer->start();
         } else {
             // HostConnectable / HostDiscoverable — adapter is back up.
-            m_adapterRecoverySafetyTimer->stop();
-            m_adapterRecoveryInFlight = false;
-            m_wedgeSince = QDateTime();
-            m_lastDe1FaultTime = QDateTime();  // stale faults shouldn't re-trip immediately
-            qDebug() << "BLEManager: adapter powered back on — re-arming DE1 + scale reconnect (#1309)";
-            emit bleStackRecovered();          // main.cpp resets the DE1 reconnect budget + retries
-            if (!m_savedScaleAddress.isEmpty())
-                tryDirectConnectToScale();     // scale side re-arm
+            finishAdapterRecovery(true);
         }
     }
 #endif
 
     emit bluetoothAvailableChanged();
+}
+
+void BLEManager::finishAdapterRecovery(bool adapterOn)
+{
+#ifndef Q_OS_IOS
+    m_adapterRecoverySafetyTimer->stop();
+    m_adapterRecoveryInFlight = false;
+    m_recoverySawPoweredOff = false;
+    m_wedgeSince = QDateTime();
+
+    if (adapterOn) {
+        m_recoveryLeftAdapterOff = false;
+        m_lastDe1FaultTime = QDateTime();  // stale faults shouldn't re-trip immediately
+        qDebug() << "BLEManager: adapter recovered — re-arming DE1 + scale reconnect (#1309)";
+        emit bleStackRecovered();          // main.cpp resets the DE1 reconnect budget + retries
+        if (!m_savedScaleAddress.isEmpty())
+            tryDirectConnectToScale();     // scale side re-arm
+    } else {
+        // We could not bring the radio back up. Flag it (so the next attempt
+        // powers it on instead of treating OFF as user intent) and tell the
+        // user — do NOT emit bleStackRecovered(), the stack is not recovered.
+        m_recoveryLeftAdapterOff = true;
+        qWarning() << "BLEManager: automatic Bluetooth restart did not bring the adapter "
+                      "back up — asking the user to toggle it manually (#1309)";
+        appendScaleLog(QStringLiteral("Auto Bluetooth restart failed — adapter still off (#1309)"));
+        emit errorOccurred(translateUiString(
+            QStringLiteral("ble.error.bluetoothRestartFailed"),
+            QStringLiteral("Decenza tried to restart Bluetooth but it's still off. "
+                           "Please turn Bluetooth off and on in your device settings.")));
+    }
+#else
+    Q_UNUSED(adapterOn);
+#endif
 }
 
 void BLEManager::noteDe1Connected(bool connected)
@@ -267,8 +308,23 @@ void BLEManager::maybeRecoverWedgedStack(const QString& reason)
 #else
     if (m_disabled || !m_localDevice) return;
     if (m_adapterRecoveryInFlight) return;
-    // Respect a user-disabled adapter: if they turned Bluetooth off, leave it off.
-    if (m_localDevice->hostMode() == QBluetoothLocalDevice::HostPoweredOff) return;
+    if (m_localDevice->hostMode() == QBluetoothLocalDevice::HostPoweredOff) {
+        // Adapter is off. If a PRIOR recovery cycle of ours left it off, keep
+        // trying to power it back on (subject to backoff) rather than mistaking
+        // our own failure for a deliberate user power-off. If the user turned it
+        // off, m_recoveryLeftAdapterOff is false and we respect that — leave it.
+        if (m_recoveryLeftAdapterOff) {
+            const QDateTime t = QDateTime::currentDateTime();
+            if (!m_lastAdapterRecovery.isValid()
+                || m_lastAdapterRecovery.msecsTo(t) >= kAdapterRecoveryBackoffMs) {
+                m_lastAdapterRecovery = t;
+                qWarning() << "BLEManager: adapter still off from a prior failed recovery — "
+                              "retrying power-on (#1309)";
+                m_localDevice->powerOn();
+            }
+        }
+        return;
+    }
 
     const QDateTime now = QDateTime::currentDateTime();
     if (m_lastAdapterRecovery.isValid()
@@ -279,6 +335,7 @@ void BLEManager::maybeRecoverWedgedStack(const QString& reason)
     }
 
     m_adapterRecoveryInFlight = true;
+    m_recoverySawPoweredOff = false;
     m_lastAdapterRecovery = now;
     m_adapterRecoveryCount++;
     m_wedgeSince = QDateTime();

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -458,6 +458,14 @@ public slots:
     // a recent fault is a reliable "the stack is in trouble" signal, not mere
     // device absence.
     void onDe1LinkFault(const QString& kind);
+    // Surface a DE1 BLE error to the UI. DE1Device::errorOccurred was previously
+    // a dead-end signal — nothing consumed it — so DE1 connection problems
+    // (including the "service not found … try toggling Bluetooth off/on" hint)
+    // never reached the user; only scale + scan errors did. Forwarded here so
+    // the same QML error dialog shows DE1 faults too, debounced to once per
+    // distinct message until the DE1 next connects (the reconnect ladder would
+    // otherwise pop the same "Connection error" dialog every ~60s).
+    void onDe1Error(const QString& error);
     Q_INVOKABLE void scanForDevices();  // User-initiated scan for DE1, scales, and refractometers
     Q_INVOKABLE void startScan();  // Start scanning for DE1 and scales
     void stopScan();
@@ -645,6 +653,11 @@ private:
     // would re-fire the same error toast indefinitely. We pop a given error
     // string at most once between successful connects.
     QString m_lastScanErrorShown;
+    // Same debounce, for DE1 errors forwarded via onDe1Error(): show each
+    // distinct message at most once until the DE1 connects (cleared in
+    // noteDe1Connected()). Separate from m_lastScanErrorShown so a DE1 fault
+    // and a scan error don't suppress each other.
+    QString m_lastDe1ErrorShown;
     // True once ANY BLE device (DE1 or scale) has been successfully seen this
     // session. Used to suppress transient QBluetoothDeviceDiscoveryAgent
     // MissingPermissionsError reports that fire on macOS Tahoe + Qt 6.11

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -588,6 +588,13 @@ private:
     // dialog on 33+). No-op on other platforms. Respects a user-disabled
     // adapter and a per-cycle backoff.
     void maybeRecoverWedgedStack(const QString& reason);
+    // Terminate an in-flight adapter power-cycle. `adapterOn` == the adapter is
+    // confirmed back up: clears recovery state, re-arms DE1 + scale reconnect,
+    // and emits bleStackRecovered(). `adapterOn` == false means we could not
+    // bring the radio back: we surface an actionable error (never leave BT off
+    // silently) and flag it so the next attempt powers it on rather than
+    // mistaking it for a user-disabled adapter — and we do NOT claim recovery.
+    void finishAdapterRecovery(bool adapterOn);
     // True for ≥45s of sustained both-links-down + recent DE1 controller fault
     // before we treat it as a wedge — avoids cycling on a one-off blip.
     static constexpr int kWedgeConfirmMs = 45 * 1000;
@@ -685,9 +692,11 @@ private:
     QDateTime m_lastDe1FaultTime;           // Last DE1 controller fault (onDe1LinkFault)
     QDateTime m_wedgeSince;                 // When the wedge condition first held (invalid = not currently wedged)
     bool m_adapterRecoveryInFlight = false; // A powerOff→powerOn cycle is underway
+    bool m_recoverySawPoweredOff = false;   // powerOff took effect; now awaiting power-on
+    bool m_recoveryLeftAdapterOff = false;  // A cycle ended with the adapter still off (our doing, not the user's)
     QDateTime m_lastAdapterRecovery;        // For the inter-cycle backoff
     int m_adapterRecoveryCount = 0;         // Diagnostic: cycles this session
-    QTimer* m_adapterRecoverySafetyTimer = nullptr;  // Fail-safe re-power-on
+    QTimer* m_adapterRecoverySafetyTimer = nullptr;  // Fail-safe watchdog for each power-cycle leg
 
     // Saved scale for direct wake connection
     QString m_savedScaleAddress;

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -123,6 +123,17 @@ public:
     void switchToWifiPrimary();
 
     bool hasSavedDE1() const { return !m_savedDE1Address.isEmpty(); }
+
+    // BLE-stack-wedge recovery (#1309). On some tablets (Teclast P80X) the
+    // Android BLE stack wedges so every connect fails — DE1 and scale alike —
+    // and survives even an app restart; only cycling the Bluetooth adapter
+    // off/on clears it. main.cpp feeds the detector its two inputs:
+    //  - noteDe1Connected(): the DE1 link's connected state (BLEManager doesn't
+    //    own DE1Device, so it can't observe this directly).
+    //  - onDe1LinkFault(): controller-error faults re-emitted by DE1Device.
+    // See onDe1LinkFault()/onScaleConnectionTimeout() for the discriminator and
+    // maybeRecoverWedgedStack() for the Android-only adapter power-cycle.
+    void noteDe1Connected(bool connected);
     bool linuxBleCapabilityMissing() const { return BleCapability::linuxMissing(); }
     QString linuxBleSetcapCommand() const { return BleCapability::linuxSetcapCommand(); }
 
@@ -440,6 +451,13 @@ public slots:
     // main.cpp. See #1176 — scale heartbeat writes that race DE1 char discovery
     // fail with CharacteristicWriteError on weaker radios (Samsung Tab A8).
     void setDe1ServiceDiscoveryActive(bool active);
+    // DE1 controller-error fault, re-emitted from DE1Device::de1LinkFault. Feeds
+    // the BLE-stack-wedge detector (#1309). These faults fire ONLY for real
+    // controller errors (Connection/Authorization/RemoteHostClosed/write-failed)
+    // — an absent or sleeping DE1 produces a watchdog timeout with no fault — so
+    // a recent fault is a reliable "the stack is in trouble" signal, not mere
+    // device absence.
+    void onDe1LinkFault(const QString& kind);
     Q_INVOKABLE void scanForDevices();  // User-initiated scan for DE1, scales, and refractometers
     Q_INVOKABLE void startScan();  // Start scanning for DE1 and scales
     void stopScan();
@@ -503,6 +521,12 @@ signals:
     void refractometerDiscovered(const QBluetoothDeviceInfo& device);
     void disconnectRefractometerRequested();
     void linuxBlueZCacheHintNeeded();  // Request the BlueZ-cache recovery dialog (Linux, caps OK).
+    // Emitted when an automatic BLE-adapter power-cycle begins / completes
+    // (#1309). main.cpp uses bleStackRecovered() to reset the DE1 reconnect
+    // budget and kick a fresh reconnect once the adapter is back, mirroring the
+    // AutoWake re-arm path. bleStackRecoveryStarted() is informational (UI/log).
+    void bleStackRecoveryStarted();
+    void bleStackRecovered();
 
 
 private slots:
@@ -544,6 +568,30 @@ private:
     // Tear down any in-flight WiFi-primary reachability probe (socket + timeout
     // timer) without emitting a result. Safe to call when no probe is active.
     void cancelWifiProbe();
+
+    // --- BLE-stack-wedge auto-recovery (#1309) ---------------------------------
+    // Re-evaluate whether the BLE stack is wedged and, if so, trigger an adapter
+    // power-cycle. Called from the two failure heartbeats (de1LinkFault and the
+    // scale connection timeout). `reason` is for the debug log only.
+    void evaluateBleWedge(const QString& reason);
+    // Power-cycle the Bluetooth adapter to clear a wedged stack. Android-only
+    // (the only platform with the wedge, and the only one where a non-privileged
+    // app can toggle the adapter — silently on API ≤ 32, via a system consent
+    // dialog on 33+). No-op on other platforms. Respects a user-disabled
+    // adapter and a per-cycle backoff.
+    void maybeRecoverWedgedStack(const QString& reason);
+    // True for ≥45s of sustained both-links-down + recent DE1 controller fault
+    // before we treat it as a wedge — avoids cycling on a one-off blip.
+    static constexpr int kWedgeConfirmMs = 45 * 1000;
+    // A DE1 controller fault older than this no longer counts as "the stack is
+    // in trouble". Sized above the slow DE1 reconnect cadence (main.cpp) so a
+    // persistently-wedged stack stays flagged between slow retries.
+    static constexpr int kWedgeFaultFreshnessMs = 7 * 60 * 1000;
+    // Minimum gap between automatic adapter power-cycles.
+    static constexpr int kAdapterRecoveryBackoffMs = 5 * 60 * 1000;
+    // Fail-safe: if powerOff() never reports HostPoweredOff, force powerOn()
+    // after this so a wedged adapter is never left switched off.
+    static constexpr int kAdapterRecoverySafetyMs = 10 * 1000;
 
 #ifndef Q_OS_IOS
     QBluetoothLocalDevice* m_localDevice = nullptr;
@@ -618,6 +666,15 @@ private:
     // attempt or a successful connect stops any stale pending abort.
     QTimer* m_scaleDirectAbortTimer = nullptr;
     bool m_de1ServiceDiscoveryActive = false;
+
+    // --- BLE-stack-wedge auto-recovery state (#1309) ---------------------------
+    bool m_de1Connected = false;            // Fed by noteDe1Connected() from main.cpp
+    QDateTime m_lastDe1FaultTime;           // Last DE1 controller fault (onDe1LinkFault)
+    QDateTime m_wedgeSince;                 // When the wedge condition first held (invalid = not currently wedged)
+    bool m_adapterRecoveryInFlight = false; // A powerOff→powerOn cycle is underway
+    QDateTime m_lastAdapterRecovery;        // For the inter-cycle backoff
+    int m_adapterRecoveryCount = 0;         // Diagnostic: cycles this session
+    QTimer* m_adapterRecoverySafetyTimer = nullptr;  // Fail-safe re-power-on
 
     // Saved scale for direct wake connection
     QString m_savedScaleAddress;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1416,10 +1416,17 @@ int main(int argc, char *argv[])
     // DE1 auto-reconnect after disconnect. Matches de1app behaviour: on Android it
     // retries essentially forever (99999999 attempts) because the DE1 may be in deep
     // sleep and take a while to become reachable. We use backoff: 5s, 30s, then 60s
-    // repeated. After 12 total attempts (5s + 30s + 10×60s ≈ 10.5 min) we stop —
-    // the DE1 is likely powered off, and we'd just be wasting BLE scans. The user
-    // can wake it manually or the app resume handler will retry.
-    constexpr int kDE1MaxReconnectAttempts = 12;  // 5s + 30s + 10*60s = ~10.5 min
+    // repeated for the first 12 attempts (5s + 30s + 10×60s ≈ 10.5 min), then drop to
+    // a slow background retry that continues indefinitely.
+    //
+    // We deliberately do NOT give up permanently (#1309): the original code stopped
+    // after 12 attempts, which left a DE1 unreachable for ~22h in a real log — a
+    // screensaver/screen-tap wake fired one connect but couldn't restart the dead
+    // ladder. A slow forever-retry costs one connect attempt per 5 min (negligible)
+    // and (a) reconnects a DE1 that was simply powered off for >10 min and (b) keeps
+    // the BLE-stack-wedge detector fed so its adapter power-cycle stays viable.
+    constexpr int kDE1MaxReconnectAttempts = 12;     // 5s + 30s + 10*60s = ~10.5 min of fast retries
+    constexpr int kDE1SlowReconnectMs = 5 * 60 * 1000;  // then every 5 min, forever
 
     QObject::connect(&de1ReconnectTimer, &QTimer::timeout,
                      [&bleManager, &de1Device, &settings, &de1ReconnectAttempt, &de1ReconnectTimer]() {
@@ -1431,7 +1438,9 @@ int main(int argc, char *argv[])
             qDebug() << "DE1 reconnect: already connected/connecting, stopping retries";
             return;
         }
-        de1ReconnectAttempt++;
+        // Clamp the counter at the cap so it doesn't grow without bound across
+        // days of slow retries; once capped we stay on the slow tier.
+        if (de1ReconnectAttempt < kDE1MaxReconnectAttempts) de1ReconnectAttempt++;
         qDebug() << "DE1 reconnect: attempt" << de1ReconnectAttempt << "of" << kDE1MaxReconnectAttempts;
         bleManager.tryDirectConnectToDE1();
 
@@ -1441,7 +1450,9 @@ int main(int argc, char *argv[])
             int delay = de1ReconnectAttempt == 1 ? 30000 : 60000;
             de1ReconnectTimer.start(delay);
         } else {
-            qDebug() << "DE1 reconnect: retries exhausted after" << de1ReconnectAttempt << "attempts";
+            qDebug() << "DE1 reconnect: fast retries exhausted — slow background retry in"
+                     << kDE1SlowReconnectMs << "ms";
+            de1ReconnectTimer.start(kDE1SlowReconnectMs);
         }
     });
 
@@ -1451,6 +1462,25 @@ int main(int argc, char *argv[])
     QObject::connect(&de1Device, &DE1Device::connectingChanged,
                      [&de1Device, &de1WasActive]() {
         if (de1Device.isConnecting()) de1WasActive = true;
+    });
+
+    // Feed DE1 controller faults to the BLE-stack-wedge detector (#1309). This
+    // is separate from the dual-HIGH scale-transport wiring below (which only
+    // exists when a BLE scale is present) — the wedge detector must hear faults
+    // regardless of whether a scale transport was ever created.
+    QObject::connect(&de1Device, &DE1Device::de1LinkFault,
+                     &bleManager, &BLEManager::onDe1LinkFault);
+
+    // After an automatic adapter power-cycle clears a wedged stack, reset the
+    // DE1 reconnect budget and kick a fresh attempt immediately — mirrors the
+    // AutoWake re-arm path. Without this the slow-tier timer would wait up to
+    // 5 min before retrying a stack that's now healthy. (#1309)
+    QObject::connect(&bleManager, &BLEManager::bleStackRecovered,
+                     [&de1Device, &de1ReconnectTimer, &de1ReconnectAttempt]() {
+        if (de1Device.isConnected() || de1Device.isConnecting()) return;
+        de1ReconnectAttempt = 0;
+        de1ReconnectTimer.start(500);
+        qDebug() << "DE1 reconnect: BLE stack recovered — restarting reconnect ladder (#1309)";
     });
 
     // When DE1 connects or disconnects, manage reconnect timer.
@@ -1473,6 +1503,8 @@ int main(int argc, char *argv[])
                      ]() {
         const bool isConnected = de1Device.isConnected();
         const bool isActive = isConnected || de1Device.isConnecting();
+        // Feed the BLE-stack-wedge detector the DE1 link state (#1309).
+        bleManager.noteDe1Connected(isConnected);
         if (!de1WasActive && !isActive) {
             return;  // Spurious inactive→inactive emission — ignore
         }
@@ -1525,8 +1557,10 @@ int main(int argc, char *argv[])
                     qDebug() << "DE1 reconnect: attempt" << de1ReconnectAttempt
                              << "failed, next retry in" << delay << "ms";
                 } else {
-                    qDebug() << "DE1 reconnect: retries exhausted after"
-                             << de1ReconnectAttempt << "attempts";
+                    // Don't give up permanently (#1309) — fall to the slow tier.
+                    de1ReconnectTimer.start(kDE1SlowReconnectMs);
+                    qDebug() << "DE1 reconnect: fast retries exhausted — slow background retry in"
+                             << kDE1SlowReconnectMs << "ms";
                 }
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1471,6 +1471,13 @@ int main(int argc, char *argv[])
     QObject::connect(&de1Device, &DE1Device::de1LinkFault,
                      &bleManager, &BLEManager::onDe1LinkFault);
 
+    // Surface DE1 BLE errors to the UI. DE1Device::errorOccurred had no consumer,
+    // so DE1 connection problems (incl. the "try toggling Bluetooth off/on" hint)
+    // never reached the user — only scale/scan errors did. onDe1Error debounces
+    // so the reconnect ladder doesn't re-pop the same dialog. (#1309)
+    QObject::connect(&de1Device, &DE1Device::errorOccurred,
+                     &bleManager, &BLEManager::onDe1Error);
+
     // After an automatic adapter power-cycle clears a wedged stack, reset the
     // DE1 reconnect budget and kick a fresh attempt immediately — mirrors the
     // AutoWake re-arm path. Without this the slow-tier timer would wait up to


### PR DESCRIPTION
## Problem

Issue [#1309](https://github.com/Kulitorum/Decenza/issues/1309): on Teclast P80X tablets the app loses BLE connection to the DE1 (and scale) after some uptime, and the **only** thing that recovers it is toggling the tablet's Bluetooth off/on — both reporters do this by hand.

Analysis of the latest debug log (build 3443, `debug.zip`):
- The Android BLE stack **wedges**: every connect fails for *both* the DE1 and the scale. The DE1 was dead for ~22h while the scale retried **1,381 times** in vain.
- It **survives an app restart** — session 3 in the log only recovers after a `HostPoweredOff → HostConnectable` adapter cycle. So the fault lives in the OS BLE stack, below the app.
- The DE1 reconnect ladder also **gave up permanently** after 12 attempts and a screensaver/screen-tap wake couldn't restart it.

Both reporters run **API ≤ 32** (mcastaldelli: Android 9 / API 28; Churator: Android 12L / API 32 GSI), where a non-privileged app can still cycle the adapter silently. `BLUETOOTH_ADMIN` + `BLUETOOTH_CONNECT` are already in the manifest.

## Fix

**Detector** (`BLEManager`) — treat the stack as wedged only when, sustained for ≥45s:
- a saved DE1 won't connect **and** is throwing controller-error faults, **and**
- the physical scale also can't connect.

`de1LinkFault` fires *only* on real controller errors (`ConnectionError`/`AuthorizationError`/`RemoteHostClosed`/`write-failed`); an absent or sleeping device produces a watchdog timeout with **no** fault. That three-way fingerprint keeps a powered-off machine from ever triggering a needless cycle.

**Recovery** (Android only) — `powerOff()` → on observed `HostPoweredOff` `powerOn()` → on `HostConnectable` re-arm DE1 + scale reconnect. Driven off real adapter transitions, with:
- a 5-min per-cycle backoff,
- a 10s fail-safe that re-enables the radio if the power-off event is missed (never leave BT off),
- respect for a user-disabled adapter (skip if `HostPoweredOff`).

On non-Android platforms the recovery action is a no-op (the existing "Try toggling Bluetooth off/on" guidance stands); iOS can't observe/toggle the adapter at all.

**Also**: the DE1 reconnect ladder no longer gives up permanently after 12 attempts — it falls to a slow 5-min background retry indefinitely. This reconnects a DE1 that was simply off for >10 min *and* keeps the detector fed so recovery stays viable. `bleStackRecovered()` resets the budget and retries immediately once the adapter is back.

## Testing

- Builds clean (Qt Creator, 0 errors / 0 warnings).
- Logic-reviewed against the build-3443 log timeline. Needs on-device confirmation on a P80X — once merged into a beta, ask @mcastaldelli / @Churator to confirm the connection self-heals without manually toggling Bluetooth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)