### PR TITLE
Fix Android build: use JNI for adapter power-cycle (powerOff() missing on Android) (#1309)

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -120,7 +120,7 @@ BLEManager::BLEManager(QObject* parent)
             // let finishAdapterRecovery(false) surface it — never leave BT off.
             qWarning() << "BLEManager: adapter still powered off"
                        << (kAdapterRecoverySafetyMs / 1000) << "s into recovery — forcing power-on (#1309)";
-            m_localDevice->powerOn();
+            setAdapterPower(true);
             finishAdapterRecovery(false);
         } else {
             // Adapter is on but we missed the HostConnectable event (or powerOff
@@ -192,7 +192,7 @@ void BLEManager::onHostModeStateChanged(QBluetoothLocalDevice::HostMode mode)
             // leave the radio off).
             m_recoverySawPoweredOff = true;
             qDebug() << "BLEManager: adapter powered off during recovery — powering back on (#1309)";
-            m_localDevice->powerOn();
+            setAdapterPower(true);
             m_adapterRecoverySafetyTimer->start();
         } else {
             // HostConnectable / HostDiscoverable — adapter is back up.
@@ -202,6 +202,30 @@ void BLEManager::onHostModeStateChanged(QBluetoothLocalDevice::HostMode mode)
 #endif
 
     emit bluetoothAvailableChanged();
+}
+
+void BLEManager::setAdapterPower(bool on)
+{
+#if defined(Q_OS_ANDROID)
+    // Qt's QBluetoothLocalDevice has no powerOff() on Android (and powerOn()
+    // shows the system consent dialog), so drive the framework adapter directly.
+    // BluetoothAdapter.disable()/enable() are silent on API ≤ 32 and no-ops on
+    // 33+; BLUETOOTH_ADMIN/BLUETOOTH_CONNECT are declared in the manifest.
+    // Qt still observes the resulting state change and emits hostModeStateChanged.
+    QJniObject adapter = QJniObject::callStaticObjectMethod(
+        "android/bluetooth/BluetoothAdapter", "getDefaultAdapter",
+        "()Landroid/bluetooth/BluetoothAdapter;");
+    if (!adapter.isValid()) {
+        qWarning() << "BLEManager: no BluetoothAdapter — cannot" << (on ? "enable" : "disable") << "(#1309)";
+        return;
+    }
+    adapter.callMethod<jboolean>(on ? "enable" : "disable");
+#else
+    // Wedge recovery is Android-only (maybeRecoverWedgedStack returns early
+    // elsewhere), and QBluetoothLocalDevice has no portable powerOff() — it
+    // exists on neither Android nor macOS in this Qt build. No-op everywhere else.
+    Q_UNUSED(on);
+#endif
 }
 
 void BLEManager::finishAdapterRecovery(bool adapterOn)
@@ -320,7 +344,7 @@ void BLEManager::maybeRecoverWedgedStack(const QString& reason)
                 m_lastAdapterRecovery = t;
                 qWarning() << "BLEManager: adapter still off from a prior failed recovery — "
                               "retrying power-on (#1309)";
-                m_localDevice->powerOn();
+                setAdapterPower(true);
             }
         }
         return;
@@ -348,7 +372,7 @@ void BLEManager::maybeRecoverWedgedStack(const QString& reason)
     // powerOff() is async; the host-mode handler powers it back on once it sees
     // HostPoweredOff, and the safety timer re-enables it if that event never lands.
     m_adapterRecoverySafetyTimer->start();
-    m_localDevice->powerOff();
+    setAdapterPower(false);
 #endif
 }
 

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -595,12 +595,12 @@ private:
     // silently) and flag it so the next attempt powers it on rather than
     // mistaking it for a user-disabled adapter — and we do NOT claim recovery.
     void finishAdapterRecovery(bool adapterOn);
-    // Turn the Bluetooth adapter on/off for the wedge power-cycle. Platform-split:
-    // on Android, QBluetoothLocalDevice has NO powerOff() (only powerOn(), which
-    // also routes through a consent dialog), so we toggle the framework adapter
-    // directly via JNI — BluetoothAdapter.disable()/enable(), the silent path on
-    // API ≤ 32. On other desktop platforms QBluetoothLocalDevice::powerOff()/
-    // powerOn() exist and are used. No-op where unsupported.
+    // Turn the Bluetooth adapter on/off for the wedge power-cycle. Android-only:
+    // QBluetoothLocalDevice has NO powerOff() (it exists on neither Android nor
+    // macOS in this Qt build; powerOn() also routes through a consent dialog), so
+    // we toggle the framework adapter directly via JNI — BluetoothAdapter
+    // .disable()/enable(), the silent path on API ≤ 32. No-op on every other
+    // platform (wedge recovery is Android-only — see maybeRecoverWedgedStack).
     void setAdapterPower(bool on);
     // True for ≥45s of sustained both-links-down + recent DE1 controller fault
     // before we treat it as a wedge — avoids cycling on a one-off blip.

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -595,6 +595,13 @@ private:
     // silently) and flag it so the next attempt powers it on rather than
     // mistaking it for a user-disabled adapter — and we do NOT claim recovery.
     void finishAdapterRecovery(bool adapterOn);
+    // Turn the Bluetooth adapter on/off for the wedge power-cycle. Platform-split:
+    // on Android, QBluetoothLocalDevice has NO powerOff() (only powerOn(), which
+    // also routes through a consent dialog), so we toggle the framework adapter
+    // directly via JNI — BluetoothAdapter.disable()/enable(), the silent path on
+    // API ≤ 32. On other desktop platforms QBluetoothLocalDevice::powerOff()/
+    // powerOn() exist and are used. No-op where unsupported.
+    void setAdapterPower(bool on);
     // True for ≥45s of sustained both-links-down + recent DE1 controller fault
     // before we treat it as a wedge — avoids cycling on a one-off blip.
     static constexpr int kWedgeConfirmMs = 45 * 1000;


### PR DESCRIPTION
## Problem

The v1.7.6 Android release build [failed to compile](https://github.com/Kulitorum/Decenza/actions/runs/27512391228):

```
src/ble/blemanager.cpp: error: no member named 'powerOff' in 'QBluetoothLocalDevice'; did you mean 'powerOn'?
```

`QBluetoothLocalDevice::powerOff()` exists on **neither Android nor macOS** in Qt 6.11 — only `powerOn()`. The macOS quick-compile passed because the original `powerOff()` call sat inside the `Q_OS_ANDROID` branch, which Mac never compiles. The #1309 wedge-recovery merged with a broken Android build; the other 5 platforms built fine, so the released APK is stale (no #1309 fix) until this lands.

## Fix

Add `BLEManager::setAdapterPower(bool)`:
- **Android**: toggle the framework adapter directly via JNI — `BluetoothAdapter.getDefaultAdapter().disable()/enable()` (the silent path on API ≤32, no-op on 33+; `BLUETOOTH_ADMIN`/`BLUETOOTH_CONNECT` already declared). Same `QJniObject` pattern as `openBluetoothSettings()`. This is also more correct than Qt's `powerOn()`, which routes through a consent dialog.
- **Other platforms**: no-op (wedge recovery is Android-only; `maybeRecoverWedgedStack` returns early off-Android).

All recovery call sites route through the helper. Qt still observes the adapter state and emits `hostModeStateChanged`, so the event-driven recovery state machine is unchanged.

## Testing

- macOS: compiles clean (Qt Creator).
- **Android: GitHub CI build green** ([run 27512746169](https://github.com/Kulitorum/Decenza/actions/runs/27512746169)) — the part the macOS compile can't verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)