### PR TITLE
chore(release): bump version to 1.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(Decenza VERSION 1.7.6 LANGUAGES CXX)
+project(Decenza VERSION 1.8.0 LANGUAGES CXX)
 
 message(STATUS "Developer note: executable target is now 'Decenza'. If Qt Creator shows 'No executable specified', re-run CMake and select the 'Decenza' Run configuration.")
 


### PR DESCRIPTION
Bumps the display version 1.7.6 → 1.8.0 for the stable 1.8.0 release.

Ships the #1309 Android BLE-stack-wedge auto-recovery (field-confirmed working on both P80X reporters) plus the full 1.7.6 beta content (Bean Bag Inventory, Bean Base integration, and the other fixes that were never promoted to stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)