### PR TITLE
Equipment packages: first-class switchable grinder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,7 @@ set(HEADERS
     src/core/settings_app.h
     src/core/settings_calibration.h
     src/core/grinderaliases.h
+    src/core/basketaliases.h
     src/core/widgetlibrary.h
     src/core/batterymanager.h
     src/core/memorymonitor.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -761,6 +761,7 @@ set(QML_FILES
     qml/components/BagCard.qml
     qml/components/SwitchEquipmentDialog.qml
     qml/components/EquipmentCard.qml
+    qml/components/EquipmentInfoDialog.qml
     qml/components/KeyboardAwareContainer.qml
     qml/components/AIConversationPanel.qml
     qml/components/ConversationOverlay.qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,6 +690,7 @@ set(QML_FILES
     qml/pages/ProfileImportPage.qml
     qml/pages/VisualizerMultiImportPage.qml
     qml/pages/BeanInfoPage.qml
+    qml/pages/EquipmentPage.qml
     qml/pages/PostShotReviewPage.qml
     qml/pages/AISettingsPage.qml
     qml/pages/DialingAssistantPage.qml
@@ -758,6 +759,8 @@ set(QML_FILES
     qml/components/BeanSummary.qml
     qml/components/ChangeBeansDialog.qml
     qml/components/BagCard.qml
+    qml/components/SwitchEquipmentDialog.qml
+    qml/components/EquipmentCard.qml
     qml/components/KeyboardAwareContainer.qml
     qml/components/AIConversationPanel.qml
     qml/components/ConversationOverlay.qml
@@ -810,6 +813,7 @@ set(QML_FILES
     qml/components/layout/items/HotWaterItem.qml
     qml/components/layout/items/FlushItem.qml
     qml/components/layout/items/BeansItem.qml
+    qml/components/layout/items/EquipmentItem.qml
     qml/components/layout/items/HistoryItem.qml
     qml/components/layout/items/DiscussItem.qml
     qml/components/layout/items/AutoFavoritesItem.qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ set(SOURCES
     src/history/shothistorystorage_serialize.cpp
     src/history/shothistorystorage_queries.cpp
     src/history/coffeebagstorage.cpp
+    src/history/equipmentstorage.cpp
     src/history/unifiedbeansearchmodel.cpp
     src/history/shotprojection.cpp
     src/history/shotdebuglogger.cpp
@@ -489,6 +490,7 @@ set(HEADERS
     src/history/shothistorystorage.h
     src/history/shothistorystorage_internal.h
     src/history/coffeebagstorage.h
+    src/history/equipmentstorage.h
     src/history/unifiedbeansearchmodel.h
     src/history/shotprojection.h
     src/history/shotdebuglogger.h
@@ -1180,6 +1182,7 @@ if(NOT ANDROID AND NOT IOS)
         src/core/settings_brew.cpp
         src/core/settings_dye.cpp
         src/history/coffeebagstorage.cpp
+        src/history/equipmentstorage.cpp
         src/core/settings_network.cpp
         src/core/settings_app.cpp
         src/core/settings_calibration.cpp

--- a/docs/CLAUDE_MD/MCP_SERVER.md
+++ b/docs/CLAUDE_MD/MCP_SERVER.md
@@ -86,9 +86,9 @@ Each tool has a `category` that determines the minimum access level required:
 
 | Category | Min Access Level | Tools |
 |----------|-----------------|-------|
-| `read` | 0 (Monitor) | machine_get_state, app_get_info, machine_get_telemetry, shots_list, shots_get_detail, shots_get_debug_log, shots_compare, profiles_list, profiles_get_active, profiles_get_detail, profiles_get_params, profiles_get_auto_load, settings_get, dialing_get_context, dialing_get_grinder_calibration, bag_list |
-| `control` | 1 (Control) | machine_wake, machine_sleep, machine_start_espresso, machine_start_steam, machine_start_hot_water, machine_start_flush, machine_stop, machine_skip_frame, shots_update, shots_upload_to_visualizer, backup_now, mqtt_connect, mqtt_disconnect, mqtt_publish_discovery, devices_connect_de1, devices_disconnect_scale, devices_reset_scale_priority, bag_select |
-| `settings` | 2 (Full) | profiles_set_active, profiles_edit_params, profiles_save, profiles_delete, profiles_create, shots_delete, settings_set, reset_saw_learning, clear_flow_calibration, apply_theme, bag_update |
+| `read` | 0 (Monitor) | machine_get_state, app_get_info, machine_get_telemetry, shots_list, shots_get_detail, shots_get_debug_log, shots_compare, profiles_list, profiles_get_active, profiles_get_detail, profiles_get_params, profiles_get_auto_load, settings_get, dialing_get_context, dialing_get_grinder_calibration, bag_list, equipment_list |
+| `control` | 1 (Control) | machine_wake, machine_sleep, machine_start_espresso, machine_start_steam, machine_start_hot_water, machine_start_flush, machine_stop, machine_skip_frame, shots_update, shots_upload_to_visualizer, backup_now, mqtt_connect, mqtt_disconnect, mqtt_publish_discovery, devices_connect_de1, devices_disconnect_scale, devices_reset_scale_priority, bag_select, equipment_select |
+| `settings` | 2 (Full) | profiles_set_active, profiles_edit_params, profiles_save, profiles_delete, profiles_create, shots_delete, settings_set, reset_saw_learning, clear_flow_calibration, apply_theme, bag_update, equipment_update |
 
 ### Tool → Confirmation Level Mapping
 
@@ -187,6 +187,16 @@ This avoids holding HTTP connections and works naturally with the conversational
 | `bag_list` | List coffee bags (inventory by default; `includeEmpty=true` adds bags marked empty). Each bag carries identity, freeze lifecycle, last-used grinder/dose, a parsed `beanBase` snapshot, and `isActive`. | read |
 | `bag_select` | Set the active bag — what the next shot is pulled with (applies bean identity + last-used grinder/dose). `bagId: 0` clears the selection. | control |
 | `bag_update` | Update bag fields (metadata + freeze lifecycle). Partial: only provided keys change; `""` clears a text/date field. `inInventory=false` = "Bag finished" (marks the bag empty); setting `defrostDate` records a thaw. | settings |
+
+### Equipment Packages (add-equipment-packages)
+The grinder is a first-class, switchable **equipment package** (the active bag points at one via `equipment_id`). The grind setting + `rpm` stay as per-bag dial-in.
+| Tool | Description | Category |
+|------|-------------|----------|
+| `equipment_list` | List equipment packages. Each carries `id`, `name`, `grinderBrand/Model/Burrs`, `rpmAdjustable`, `inInventory`, last dial (`lastGrindSetting`/`lastRpm`), `shotCount`, and `isActive`. | read |
+| `equipment_select` | Set the active equipment package — the grinder the next shot is ground on. Applies the package's grinder identity + last grind/rpm and points the active bag at it. | control |
+| `equipment_update` | Edit a package's grinder identity (`grinderBrand/Model/Burrs`) and/or `name`. Partial; re-derives `rpmAdjustable`. Reference semantics (applies to all referencing bags/shots). | settings |
+
+The `de1://dialing` resource's grinder block also exposes `packageId`, `rpmAdjustable`, and `rpm`.
 
 ### Profile Management
 | Tool | Description | Category |

--- a/openspec/changes/add-equipment-packages/.openspec.yaml
+++ b/openspec/changes/add-equipment-packages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/add-equipment-packages/design.md
+++ b/openspec/changes/add-equipment-packages/design.md
@@ -13,6 +13,28 @@ The user's framing: an **Equipment package** is the physical kit used to pull a 
 
 **Alternative rejected:** wide grinder columns on the package, refactor when the second component lands. Rejected because growth is a stated near-term certainty, so we pay the container cost up front to avoid a second migration.
 
+### 2b. Copy-on-write immutability (REVISED — supersedes the snapshot discussion below)
+
+Historical fidelity is achieved **without any grinder shadow data on shots**, by making a package's *identity* immutable once it is used:
+
+**Immutability of identity, copy-on-write on edit.** A package's component **identity** is frozen once `shotCount > 0`. Editing identity does **not** mutate it — it **creates a new package** (copy-on-write), repoints every bag pointing at the old package (and the active selection) to the new one, and soft-deletes the old package out of inventory (it persists for the shots that reference it). An unused package (`shotCount == 0`) edits in place.
+- **Grinder identity = `(brand, model, burrs)`** — burrs included. Same grinder body with swapped burrs is a *different* identity ⇒ a different package, naturally tracked via copy-on-write (old shots → burrs-X package, new shots → burrs-Y package).
+- **Merge key = the full package signature** — the canonical set of *all* component identities, not just the grinder. Today (grinder-only) that reduces to brand+model+burrs; when a basket/tamper is added, two packages merge only when every component matches. Copy-on-write that produces an identity equal to an existing package **merges** into it (repoints to the existing) instead of forking a twin. Write the dedup/merge as a package signature so it extends without rework.
+
+**Dial memory is not identity.** `last_grind_setting`/`last_rpm` are mutable MRU dial-memory, freely updated on every dial edit; never resolved through a shot's pointer, so they never churn a package. (Per-shot dial-in lives on the shot row, not the package — putting it on the package would fork a package every shot.)
+
+**Name is a short label + state-based versioning.** `name` is a stored, user-editable short label (default "{brand} {model}"; becomes a kit label like "Espresso setup" with more components — never content-derived, which would grow unbounded). On copy-on-write the **new** (current) package keeps the name; the **old** package keeps its name too but is marked `in_inventory = 0` plus a **`superseded_by`** lineage pointer to the fork. Current-vs-old is rendered from that state at display time (e.g. "My Grinder · older" in shot history) — **not** baked into the name (no reserved characters, no re-mangling on repeated forks). Duplicate names among current packages are allowed; the `id` is the identity. The lineage chain also powers "dial history across burr swaps" later.
+
+**Shots are pure pointer.** Migration 23 drops `grinder_brand/model/burrs` from `shots` **and** `coffee_bags`. A shot keeps only `equipment_id` (→ an immutable package) plus its per-shot **dial-in** (`grinder_setting` + `rpm`). Because the referenced package's identity can never change after the shot exists, the pointer alone is faithful history — no snapshot, no shadow columns.
+
+**Search without shadow data.** Grinder identity lives only on `equipment_items`. Shot-history search resolves the term against `equipment_items` for **all** packages referenced by history — inventory or not (a sold grinder still surfaces its old shots, same as the beans history lane) — → matching `package_id`s → `shots.equipment_id IN (…)`; `shots_fts` drops its grinder columns. Pointer-resolved grinder hits don't carry FTS ranking/snippets (acceptable).
+
+**Device transfer.** `equipment_packages` + `equipment_items` transfer with id-remap; `equipment_id` on both bags and shots is remapped on import (mirrors the bag-id remap). `superseded_by` is remapped too.
+
+**Consistency note (intentional):** equipment uses pure-pointer-to-immutable; beans keep an identity snapshot on the shot (`shot.bean_brand`). Two different fidelity mechanisms in `shots`, intentionally — equipment is new and de-duplication is its whole point; beans are legacy. **Future note:** with multi-component packages, decide per-component vs per-package versioning granularity (a basket swap shouldn't necessarily fork the whole kit).
+
+The snapshot-vs-reference discussion in §2 below is the earlier framing; §2b is the decision.
+
 ### 2. Pointer everywhere (reference semantics), dial-in stays snapshot
 `coffee_bags.equipment_id` and `shots.equipment_id` point at a package. Grinder brand/model/burrs are resolved by following the pointer — strings are only materialized at external boundaries (Visualizer DYE payload, MCP, history display).
 

--- a/openspec/changes/add-equipment-packages/design.md
+++ b/openspec/changes/add-equipment-packages/design.md
@@ -1,0 +1,60 @@
+# Design — Equipment Packages
+
+## Context
+
+Today the grinder is not a thing the user owns; it is four columns copied onto every coffee bag. `SettingsDye` exposes `dyeGrinderBrand/Model/Burrs/Setting` and write-through to the active `coffee_bags` row (see `bean-bag-inventory`). The `GrinderAliases` registry (`src/core/grinderaliases.h`) already classifies known grinders, including a `variableRpm` flag, but nothing surfaces it.
+
+The user's framing: an **Equipment package** is the physical kit used to pull a shot. It behaves like Beans — you add packages, you switch between them, you don't edit the active one inline. The grinder is its first component; baskets/tampers/etc. are coming, so the model must grow without re-migrating.
+
+## Key Decisions
+
+### 1. Container + components, not a grinder row
+`equipment_packages` is a container; `equipment_items` holds typed components (`kind`, `brand`, `model`, `attrs_json`). Shared fields every kind has (`kind`, `brand`, `model`) are real columns so `getDistinctGrinder*` queries stay simple (`WHERE kind='grinder'`); kind-specific fields (`burrs`, `rpmCapable` now; basket size later) live in `attrs_json` (same blob convention as Bean Base data). **Adding a tamper later is a new `kind` row — no schema migration.** The dormant `add-basket-settings` change slots in here.
+
+**Alternative rejected:** wide grinder columns on the package, refactor when the second component lands. Rejected because growth is a stated near-term certainty, so we pay the container cost up front to avoid a second migration.
+
+### 2. Pointer everywhere (reference semantics), dial-in stays snapshot
+`coffee_bags.equipment_id` and `shots.equipment_id` point at a package. Grinder brand/model/burrs are resolved by following the pointer — strings are only materialized at external boundaries (Visualizer DYE payload, MCP, history display).
+
+- **Editing a package** (fix `"83mm"` → `"83mm flat steel"`) flows to every bag and historical shot pointing at it. For durable hardware reused across hundreds of shots this is desirable, unlike a bean bag (a distinct physical bag → snapshot).
+- **Replacing a grinder** = create a new package + soft-delete the old (`inInventory = 0`, row persists), so old shots still resolve to the old grinder.
+- **Dial-in (grind setting, RPM) stays snapshotted** per bag and per shot, because it genuinely changes shot to shot. So a shot row carries `equipment_id` (reference) + `grinder_setting` + `rpm` (snapshots).
+
+**Alternative considered:** snapshot grinder strings on each shot (frozen history). Rejected per the user's "pointer everywhere" preference; reference is the better fit for durable hardware.
+
+### 3. Two independent dial memories
+Grind setting / RPM are remembered in two places, each restored by its own switch:
+- The **bag** keeps its last dial (bean-scoped) — switching beans applies it (unchanged from today).
+- The **package** keeps `lastGrindSetting` / `lastRpm` (grinder-scoped) — switching equipment applies it.
+- Editing grind/RPM **fans out to both** the active bag and the active package, so each dimension stays current and whichever you switch restores from that dimension. Switching equipment therefore never leaves the field blank; the value is a starting point, fully editable.
+
+### 4. RPM capability is derived, not configured
+`rpmCapable` is set when the package's grinder item is created:
+- grinder **matched in `GrinderAliases`** → its `variableRpm` flag.
+- grinder **not in the registry** (custom typed-in) → `true`, so the RPM field shows. This honors "when a user enters a grinder not in the table, show the RPM."
+
+The registry is **not user-editable**; users pick from it or type a custom grinder. `rpmCapable` re-derives if a package's brand/model is edited.
+
+### 5. Migration (migration 22, run-once)
+Three independent operations in one pass:
+1. **Grind/RPM split** — conservative, marker-gated. Match trailing `(\d+)\s*rpm$` (case-insensitive); on hit, `rpm` = the number, `grinder_setting` = the remainder trimmed; otherwise leave the setting untouched and `rpm` empty. Compatible with `parseGrinderSetting`'s existing rpm-suffix tolerance, so anything not split still parses.
+2. **Package creation** — dedup key is **grinder identity only** `(brand, model, burrs)`. Current settings → the default package; each remaining distinct identity across bags+shots → its own package. Grind/RPM differences never enter the key, so a one-grinder user with many grind settings gets exactly one package.
+3. **Linking** — every bag/shot row gets `equipment_id` = its matching package; the (split) grind + rpm stay on the row. Package `lastGrindSetting`/`lastRpm` seed from current settings (default package) or the grinder's most-recent shot (per-grinder packages).
+
+Empty grinder strings → `equipment_id` NULL, no package.
+
+### 6. Idle-button layout migration
+The idle Equipment button must appear for **all** existing users, including those with customized layouts. `getLayoutObject()` (`src/core/settings_network.cpp`) already runs idempotent run-once migrations (statusBar injection, `text`→`custom`). Add one: scan all zones; if no item has `type=="equipment"`, insert `{"type":"equipment","id":"equipment1"}` immediately after the `beans` item (fallback: append to `bottomRight` if Beans was removed), then persist once. The default layout also gains the item next to `beans` for fresh installs.
+
+## Boundaries
+
+- **Visualizer** has no equipment concept and a flat, lossy grinder schema: `grinder_model` (brand+model combined), `grinder_setting`, `grinder_dose_weight`; no slot for brand-separate, burrs, or RPM. Upload resolves the pointer to those strings and **appends RPM to `grinder_setting`** (`"2.4 1400rpm"`), matching the convention many users already type by hand. Import is profile-only and untouched.
+- **MCP** gains equipment awareness now: reads resolve through the package and expose package identity + rpm; `equipment_list`/`equipment_select`/`equipment_update` mirror `bag_list`/`bag_select`/`bag_update`. MCP data conventions apply (units in field names, `kind` as a string enum, ISO timestamps).
+- **Grinder calibration** (`stop-at-weight-learning` / the in-flight `fix-grinder-calibration-cross-profile`) is keyed on resolved grinder model + burrs — inputs unchanged, now sourced via the package. This change does **not** re-architect calibration keying; it depends on / defers to that work.
+
+## Risks
+
+- **Mis-split on migration**: a non-RPM trailing number could be misread as RPM. Mitigated by requiring the literal `rpm` marker; anything else is left verbatim.
+- **Over-creation of packages**: a typo in a historical grinder string spawns an extra package. Acceptable — it is correct (the string really differed) and the user can soft-delete it.
+- **Reference-semantics surprise**: editing a package retroactively changes old shots. Stated explicitly to the user and accepted as correct for durable hardware; replacement is the create-new + soft-delete path.
+- **Dependency ordering**: requires `bean-bag-inventory`'s `coffee_bags` schema. Migration 22 must run after migration 19's table exists.

--- a/openspec/changes/add-equipment-packages/proposal.md
+++ b/openspec/changes/add-equipment-packages/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+Grinder identity (brand, model, burrs) currently lives **inside every coffee bag** — `SettingsDye` writes `grinderBrand/Model/Burrs/Setting` through to the active `coffee_bags` row. A user with one grinder and 20 bags has that grinder duplicated 20 times, and there is no first-class concept of "the equipment I make coffee with." This blocks an obviously-coming need: the user's setup is more than a grinder (basket, tamper, portafilter, puck screen, machine), and all of it wants one home.
+
+This change extracts equipment into a first-class **Equipment package** — a switchable container, parallel to Beans, whose first component is the grinder. The grinder's *identity* becomes canonical and de-duplicated; the *dial-in* (grind setting + a new RPM field) stays where it belongs as a per-bean/per-shot value. Modeling the package as a container of typed components means adding a basket or tamper later is a new component kind, **not another migration**.
+
+## What Changes
+
+- New **`equipment_packages`** table (container: optional name, `inInventory`, `lastUsed`, **`lastGrindSetting`**, **`lastRpm`**) and **`equipment_items`** table (typed components: `kind="grinder"`, `brand`, `model`, `attrs_json` holding `burrs` + `rpmCapable`). A package owns one grinder item today; more kinds slot in later with no schema migration.
+- **BREAKING** `coffee_bags` and `shots` replace the grinder identity columns (`grinder_brand`, `grinder_model`, `grinder_burrs`) with a single **`equipment_id`** foreign key pointing at a package (**reference semantics** — editing a package flows to history; soft-delete via `inInventory = 0` preserves old shots). Both tables **keep** `grinder_setting` and **gain** `rpm` as dial-in snapshots.
+- New **RPM dial-in field**, shown in Brew Settings only when the package's grinder is RPM-capable. `rpmCapable` is **derived, not user-toggled**: a grinder matched in `GrinderAliases` uses its existing `variableRpm` flag; a custom grinder typed in by the user (not in the registry) is treated as capable so the field shows.
+- **BREAKING** Brew Settings grinder fields (brand/model/burrs text inputs in `BrewDialog.qml`) replaced by a **read-only "Equipment: …" row + Switch Equipment button** (mirroring Switch Beans). Grind setting and RPM remain editable inline as dial-in preferences.
+- New **Equipment window** (`EquipmentPage.qml`) — empty state + "Add Equipment", a card per package — mirroring `BeanInfoPage.qml`.
+- New **Switch Equipment dialog** — pick an existing package or create one (grinder brand/model/burrs, with registry-backed suggestions exactly as the old fields had), mirroring `ChangeBeansDialog.qml`.
+- New **idle-page Equipment button** placed next to Beans in the default layout, **injected into every existing user's saved layout** by an idempotent run-once layout migration so it is initially visible for all users (and movable afterwards).
+- **Grinder-scoped dial memory**: switching equipment applies the package's `lastGrindSetting`/`lastRpm` to the active bag and Brew Settings (never blank, still editable), just as switching beans applies the bag's. Editing grind/RPM writes through to **both** the active bag and the active package.
+- **Migration (migration 22, run-once on first launch):**
+  - **Split grind + RPM**: best-effort parse of every existing `grinder_setting` on bags and shots — a trailing `(\d+)\s*rpm` token (e.g. `"24 1400rpm"`) is split into `grinder_setting = "24"` and `rpm = 1400`; anything without an explicit `rpm` marker is left exactly as-is.
+  - **Create packages**: one default package from the user's current grinder settings, plus one package per distinct historical grinder *identity* (brand/model/burrs) found across bags and shots. Differing grind/RPM values **never** create a package.
+  - **Link**: every bag and shot gets an `equipment_id` pointing at its matching package; each row keeps its (now split) grind setting + rpm.
+- **MCP gains equipment awareness now**: grinder reads resolve through the package and expose package identity + rpm; three new tools — **`equipment_list`**, **`equipment_select`**, **`equipment_update`** — mirror the existing `bag_*` tools.
+- **Visualizer**: upload resolves `equipment_id` → `"brand model"` + setting + dose (shape unchanged); **RPM is appended to the `grinder_setting` string** (`"2.4 1400rpm"`) since Visualizer has no RPM field. Burrs has no Visualizer field today and remains dropped. **Import is unchanged** (it imports profiles only — grinder strings are display-only metadata, never persisted to a local shot/bag).
+
+## Capabilities
+
+### New Capabilities
+
+- `equipment-package-model`: `equipment_packages` + `equipment_items` data model, DB schema, migration 22 (grind/rpm split, package creation, linking), reference semantics + soft-delete, `SettingsDye` resolution and dual write-through, `rpmCapable` derivation
+- `equipment-inventory-view`: Equipment window + idle-page Equipment button + idempotent layout-injection migration + 4-place layout-widget registration
+- `switch-equipment-dialog`: Switch Equipment dialog — pick or create a package, registry-backed grinder suggestions, switch applies the package's last dial
+- `brew-settings-equipment`: Brew Settings grinder block reworked to a read-only Equipment summary + Switch Equipment button, with grind setting + RPM (when capable) as editable dial-in
+
+### Modified Capabilities
+
+- `dialing-context-payload`: grinder context resolves via `equipment_id` and gains the `rpm` dial-in
+- `visualizer-upload-persistence`: upload resolves `equipment_id` → grinder strings; RPM appended to `grinder_setting`
+- `mcp-server`: grinder reads resolve via the package + expose package/rpm; new `equipment_list` / `equipment_select` / `equipment_update` tools
+- `shot-save-filter`: shot snapshots capture `equipment_id` + `rpm` (in place of the dropped grinder identity columns)
+
+## Impact
+
+**Dependency:** builds on the in-progress `bean-bag-inventory` change — assumes the `coffee_bags` table and its `grinder_*` columns exist (the source of the migration).
+
+**C++ / Settings:**
+- `src/core/grinderaliases.h`: `variableRpm` already present (no registry edit needed); used to seed `rpmCapable`. Registry stays hardcoded.
+- `src/core/settings_dye.{h,cpp}`: `dyeGrinderBrand/Model/Burrs` become **read-only**, resolved through the active bag's `equipment_id`; `dyeGrinderSetting` + new `dyeGrinderRpm` write through to **both** bag and active package; new `activeEquipmentId` + switch logic applying the package's last dial.
+- New `src/history/equipmentstorage.{h,cpp}`: `EquipmentPackage`/`EquipmentItem` value types + DB CRUD via `withTempDb()`, following the `CoffeeBagStorage` background-thread pattern.
+- `src/history/shothistorystorage.cpp`: **migration 22** (equipment tables; `coffee_bags`/`shots` gain `equipment_id` + `rpm`, drop grinder identity columns; grind/rpm split; package creation + linking).
+- `src/history/shotprojection.{h,cpp}` + history queries: `grinderBrand/Model/Burrs` resolved via `equipment_id` JOIN; `getDistinctGrinder*` re-scoped to `equipment_items WHERE kind='grinder'`.
+- `src/network/visualizeruploader.cpp`: resolve `equipment_id` → strings; append rpm to `grinder_setting`.
+
+**QML:**
+- New `qml/pages/EquipmentPage.qml` (mirrors `BeanInfoPage.qml`), `qml/components/EquipmentCard.qml`, `qml/components/SwitchEquipmentDialog.qml` (mirrors `ChangeBeansDialog.qml`).
+- `qml/components/BrewDialog.qml`: grinder brand/model/burrs inputs → read-only Equipment summary + Switch Equipment button; grind + RPM dial-in inputs (RPM shown when capable).
+- New `qml/components/layout/items/EquipmentItem.qml` + 4-place registration (`CMakeLists.txt`, `LayoutItemDelegate.qml`, `LayoutCenterZone.qml`/editor palette + chip label map, `shotserver_layout.cpp`).
+
+**Database:**
+- Migration 22 in `shothistorystorage.cpp`: new `equipment_packages` + `equipment_items` tables; `coffee_bags`/`shots` `equipment_id` (nullable FK) + `rpm`; drop `grinder_brand`/`grinder_model`/`grinder_burrs`; grind/rpm split; package dedup + linking.
+- Layout config (`settings_network.cpp`): default layout gains an `equipment` item next to `beans`; idempotent run-once migration injects it into existing saved layouts.
+
+**MCP:**
+- `mcpresources.cpp` + `mcptools_dialing.cpp` + `mcptools_ai.cpp`: grinder reads resolve via the package; dialing surfaces gain `rpm` + package identity.
+- `mcptools_write.cpp`: new `equipment_list`, `equipment_select`, `equipment_update` tools mirroring `bag_*`.
+
+**Transfer/backup:**
+- `ShotHistoryStorage::importDatabaseStatic`: migrate `equipment_packages` + `equipment_items`, remap `coffee_bags.equipment_id` and `shots.equipment_id` to new package ids (alongside the existing bag-id remap).
+- `SettingsSerializer`: `dye/activeEquipmentId` excluded from export (like `dye/activeBagId`).

--- a/openspec/changes/add-equipment-packages/specs/brew-settings-equipment/spec.md
+++ b/openspec/changes/add-equipment-packages/specs/brew-settings-equipment/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Brew Settings shows a read-only Equipment summary with a Switch button
+`BrewDialog.qml` SHALL replace the editable grinder brand/model/burrs text inputs with a read-only "Equipment: {grinder identity}" summary and a "Switch Equipment" button that opens the Switch Equipment dialog. The grinder identity SHALL be resolved through the active bag's `equipment_id`.
+
+#### Scenario: Equipment summary shown
+- **WHEN** Brew Settings is opened with an equipment package linked to the active bag
+- **THEN** it SHALL show a read-only summary of the grinder identity and a Switch Equipment button
+- **AND** it SHALL NOT show editable grinder brand/model/burrs text inputs
+
+#### Scenario: No equipment linked
+- **WHEN** the active bag has no linked equipment (`equipment_id` is null)
+- **THEN** Brew Settings SHALL show "Equipment: not set" and an "Add Equipment" affordance
+
+### Requirement: Grind setting and RPM remain editable dial-in
+`BrewDialog.qml` SHALL keep the grind setting as an editable dial-in field and SHALL add an editable RPM dial-in field. The RPM field SHALL be shown only when the linked package's grinder is `rpmCapable`. Edits SHALL follow the dual write-through rule (active bag + active package).
+
+#### Scenario: RPM shown for a capable grinder
+- **WHEN** the linked package's grinder has `rpmCapable = true`
+- **THEN** Brew Settings SHALL show an editable RPM field alongside the grind setting
+
+#### Scenario: RPM hidden for a non-capable grinder
+- **WHEN** the linked package's grinder has `rpmCapable = false`
+- **THEN** Brew Settings SHALL NOT show the RPM field
+
+#### Scenario: Editing the dial writes through
+- **WHEN** the user edits the grind setting or RPM
+- **THEN** the value SHALL be written to the active bag and the active package's last-dial fields

--- a/openspec/changes/add-equipment-packages/specs/dialing-context-payload/spec.md
+++ b/openspec/changes/add-equipment-packages/specs/dialing-context-payload/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Dialing grinder context SHALL resolve via the equipment package
+The grinder identity in dialing surfaces (`grinderContext`, `currentBean` setup, the grinder-calibration inputs) SHALL be resolved through the resolved shot's `equipment_id` rather than from grinder identity columns on the shot row. Inputs to the grinder-calibration block (grinder model + burrs) SHALL come from the resolved package's grinder item.
+
+#### Scenario: grinderContext sourced from the package
+- **WHEN** `dialing_get_context` builds `grinderContext` for the resolved shot
+- **THEN** the grinder brand/model/burrs SHALL be resolved by following `equipment_id` to the package's grinder item
+
+#### Scenario: Shot with no linked equipment
+- **WHEN** the resolved shot has a null `equipment_id`
+- **THEN** the grinder context SHALL be omitted or empty rather than fabricated
+
+### Requirement: Dialing context SHALL expose the rpm dial-in
+The dialing context SHALL include the shot's `rpm` dial-in value (when present) alongside the grind setting, and SHALL indicate whether the grinder is `rpmCapable`.
+
+#### Scenario: rpm present on a capable grinder
+- **WHEN** the resolved shot used an rpm-capable grinder and recorded an rpm
+- **THEN** the dialing context SHALL include the `rpm` value
+
+#### Scenario: rpm absent
+- **WHEN** the resolved shot recorded no rpm
+- **THEN** the `rpm` field SHALL be omitted

--- a/openspec/changes/add-equipment-packages/specs/equipment-inventory-view/spec.md
+++ b/openspec/changes/add-equipment-packages/specs/equipment-inventory-view/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Equipment window
+The system SHALL provide an `EquipmentPage.qml` that lists equipment packages with `inInventory = true` as cards, mirroring `BeanInfoPage.qml`. When no packages exist it SHALL show an empty state plus an "Add Equipment" button.
+
+#### Scenario: Empty inventory
+- **WHEN** the Equipment window is opened with no packages in inventory
+- **THEN** it SHALL show an empty-state message and an "Add Equipment" button only
+
+#### Scenario: Populated inventory
+- **WHEN** the Equipment window is opened with packages in inventory
+- **THEN** it SHALL show a card per package displaying the grinder identity (brand/model, burrs as subtitle)
+- **AND** each card SHALL offer edit and remove-from-inventory actions
+
+#### Scenario: Removing a package from inventory
+- **WHEN** the user removes a package from inventory
+- **THEN** the package SHALL be soft-deleted (`inInventory = 0`) and SHALL disappear from the inventory list
+- **AND** bags and shots pointing at it SHALL continue to resolve to its identity
+
+### Requirement: Idle-page Equipment button
+The system SHALL provide an `EquipmentItem.qml` idle-page layout widget that navigates to the Equipment window, registered in all required places: `CMakeLists.txt` qml module list, `LayoutItemDelegate.qml` (render switch + label map), the layout editor palette (`LayoutCenterZone.qml`/`LayoutEditorZone.qml` widget list + chip label map), and `shotserver_layout.cpp` (web editor widget list).
+
+#### Scenario: Default layout placement
+- **WHEN** a fresh install builds the default layout
+- **THEN** the default layout SHALL include an `equipment` item placed immediately after the `beans` item in the same zone
+
+#### Scenario: Tapping the Equipment button
+- **WHEN** the user taps the idle Equipment button
+- **THEN** the Equipment window SHALL open
+
+### Requirement: Idempotent layout-injection migration for existing users
+`getLayoutObject()` in `src/core/settings_network.cpp` SHALL run a run-once migration that ensures an `equipment` item exists in the saved layout: if no item across any zone has `type == "equipment"`, it SHALL insert `{"type":"equipment","id":"equipment1"}` immediately after the `beans` item (or, if no `beans` item exists, append it to `bottomRight`), then persist the migrated layout once.
+
+#### Scenario: Existing customized layout gains the button
+- **WHEN** an upgraded user has a saved layout with no equipment item
+- **THEN** the migration SHALL inject an equipment item next to their beans item and persist it once
+- **AND** the equipment button SHALL be initially visible and movable thereafter
+
+#### Scenario: Migration is idempotent
+- **WHEN** the layout already contains an equipment item
+- **THEN** the migration SHALL make no change and SHALL NOT add a duplicate
+
+#### Scenario: Beans item absent
+- **WHEN** the saved layout has no beans item
+- **THEN** the equipment item SHALL be appended to the `bottomRight` zone

--- a/openspec/changes/add-equipment-packages/specs/equipment-package-model/spec.md
+++ b/openspec/changes/add-equipment-packages/specs/equipment-package-model/spec.md
@@ -1,0 +1,131 @@
+## ADDED Requirements
+
+### Requirement: EquipmentPackage and EquipmentItem data model
+The system SHALL define an `EquipmentPackage` value type (a container) and an `EquipmentItem` value type (a typed component), where one package owns one or more items.
+
+`EquipmentPackage` fields:
+- Identity: `id` (int, DB primary key), `name` (nullable — defaults for display to the grinder item's "{brand} {model}")
+- Lifecycle: `inInventory` (bool, default true), `lastUsed` (nullable timestamp), `createdAt`
+- Grinder-scoped dial memory: `lastGrindSetting` (nullable string), `lastRpm` (nullable int)
+
+`EquipmentItem` fields:
+- `id` (int, DB primary key), `packageId` (int, FK → `equipment_packages.id`)
+- `kind` (string enum — `"grinder"` today)
+- `brand` (string), `model` (string)
+- `attrs_json` (JSON blob, kind-specific) — for `kind="grinder"`: `burrs` (string), `rpmCapable` (bool)
+
+#### Scenario: A package owns one grinder today
+- **WHEN** an equipment package is created
+- **THEN** it SHALL contain exactly one `equipment_item` with `kind = "grinder"`
+- **AND** that item SHALL carry `brand`, `model`, and an `attrs_json` with `burrs` and `rpmCapable`
+
+#### Scenario: Adding a new component kind requires no schema migration
+- **WHEN** a future component kind (e.g. `"basket"`) is introduced
+- **THEN** it SHALL be stored as a new `equipment_items` row with that `kind` and a kind-specific `attrs_json`
+- **AND** no change to the `equipment_packages` or `equipment_items` table schema SHALL be required
+
+### Requirement: equipment_packages and equipment_items database tables
+The system SHALL create `equipment_packages` and `equipment_items` SQLite tables in **migration 22** in `src/history/shothistorystorage.cpp` (current schema version is 21). DB access SHALL follow the `withTempDb()` background-thread pattern via a new `EquipmentStorage` class modeled on `CoffeeBagStorage`.
+
+#### Scenario: Tables created on upgrade
+- **WHEN** the app launches after upgrade at schema version < 22
+- **THEN** the `equipment_packages` and `equipment_items` tables SHALL be created
+- **AND** the schema version SHALL be set to 22 only after the migration transaction commits
+
+### Requirement: coffee_bags and shots reference a package via equipment_id
+Migration 22 SHALL add a nullable `equipment_id` INTEGER foreign-key column to both `coffee_bags` and `shots`, pointing at `equipment_packages.id`, and SHALL drop the `grinder_brand`, `grinder_model`, and `grinder_burrs` columns from both tables. Both tables SHALL **retain** `grinder_setting` and SHALL **add** a nullable `rpm` INTEGER column.
+
+#### Scenario: Grinder identity resolves through the pointer
+- **WHEN** code needs a bag's or shot's grinder brand/model/burrs
+- **THEN** it SHALL resolve them by following `equipment_id` to the package's grinder item
+- **AND** no grinder identity strings SHALL be stored on the `coffee_bags` or `shots` rows
+
+#### Scenario: Dial-in stays on the row
+- **WHEN** a shot is saved
+- **THEN** its `grinder_setting` and `rpm` SHALL be snapshotted on the `shots` row (not on the package)
+
+### Requirement: Reference semantics with soft-delete
+Equipment packages SHALL use reference semantics: editing a package's fields SHALL be reflected by every bag and shot pointing at it. Removing a package from use SHALL set `inInventory = 0` and SHALL NOT delete the row, so historical bags and shots continue to resolve.
+
+#### Scenario: Editing a package updates history
+- **WHEN** a user edits a package's grinder burrs
+- **THEN** every bag and shot pointing at that package SHALL resolve to the edited burrs
+
+#### Scenario: Replacing a grinder
+- **WHEN** a user replaces their grinder
+- **THEN** they SHALL create a new package and the old package SHALL be soft-deleted (`inInventory = 0`)
+- **AND** shots taken with the old grinder SHALL still resolve to the old package's identity
+
+### Requirement: rpmCapable is derived, not user-configured
+When a package's grinder item is created or its brand/model is edited, the system SHALL set `rpmCapable` from the `GrinderAliases` registry: a grinder matched in the registry SHALL use its `variableRpm` flag; a grinder not in the registry SHALL be treated as `rpmCapable = true`. The registry SHALL remain hardcoded and not user-editable.
+
+#### Scenario: Known non-variable grinder
+- **WHEN** a package is created for a registry grinder whose `variableRpm` is false
+- **THEN** `rpmCapable` SHALL be false and the RPM dial-in SHALL be hidden in Brew Settings
+
+#### Scenario: Custom grinder not in the registry
+- **WHEN** a user types a grinder brand/model that matches no registry alias
+- **THEN** `rpmCapable` SHALL be true and the RPM dial-in SHALL be shown
+
+#### Scenario: rpmCapable re-derives on edit
+- **WHEN** a package's grinder brand/model is changed
+- **THEN** `rpmCapable` SHALL be re-derived from the registry for the new identity
+
+### Requirement: Grinder-scoped dial memory and dual write-through
+Switching the active bag's equipment package SHALL apply that package's `lastGrindSetting`/`lastRpm` to the active bag's grind setting and rpm (and thereby Brew Settings), never leaving them blank but leaving them editable. Editing the grind setting or rpm SHALL write through to **both** the active bag and the active package's `lastGrindSetting`/`lastRpm`.
+
+#### Scenario: Switch equipment pre-fills the dial
+- **WHEN** the user switches the active bag to a different equipment package
+- **THEN** the active bag's grind setting and rpm SHALL be set to that package's `lastGrindSetting`/`lastRpm`
+- **AND** the values SHALL remain editable
+
+#### Scenario: Editing the dial updates both memories
+- **WHEN** the user edits the grind setting or rpm in Brew Settings
+- **THEN** the new value SHALL be written to the active bag AND to the active package's last-dial fields
+
+### Requirement: SettingsDye exposes resolved grinder identity and equipment selection
+`SettingsDye` SHALL expose `dyeGrinderBrand`, `dyeGrinderModel`, and `dyeGrinderBurrs` as **read-only** values resolved through the active bag's `equipment_id`. It SHALL expose `dyeGrinderSetting` and a new `dyeGrinderRpm` as writable dial-in values (writing through to bag and active package per the dual write-through rule), and an `activeEquipmentId` for selecting/switching the package.
+
+#### Scenario: Read resolves via the package
+- **WHEN** `dyeGrinderModel` is read
+- **THEN** it SHALL return the model of the active bag's package grinder item, or empty when no package is linked
+
+### Requirement: Migration 22 splits combined grind+rpm settings
+Migration 22 SHALL perform a best-effort, marker-gated split of every existing `grinder_setting` on `coffee_bags` and `shots`: a trailing token matching `(\d+)\s*rpm` (case-insensitive) SHALL move the number into `rpm` and leave the remainder (trimmed) in `grinder_setting`. A setting with no explicit `rpm` marker SHALL be left exactly as-is with `rpm` null.
+
+#### Scenario: Annotated setting is split
+- **WHEN** a row's `grinder_setting` is `"24 1400rpm"`
+- **THEN** after migration `grinder_setting` SHALL be `"24"` and `rpm` SHALL be `1400`
+
+#### Scenario: Compound or non-rpm setting is preserved
+- **WHEN** a row's `grinder_setting` is `"1+4"` or `"24 clicks"`
+- **THEN** `grinder_setting` SHALL be unchanged and `rpm` SHALL be null
+
+### Requirement: Migration 22 creates packages and links rows
+Migration 22 SHALL create equipment packages keyed on grinder identity `(brand, model, burrs)` only — grind setting and rpm SHALL NOT affect package creation. It SHALL create one default package from the user's current grinder settings, plus one package per remaining distinct grinder identity found across `coffee_bags` and `shots`, and SHALL set each row's `equipment_id` to its matching package.
+
+#### Scenario: One grinder, many grind settings
+- **WHEN** a user has a single grinder identity across all bags/shots but many different grind settings
+- **THEN** migration SHALL create exactly one package
+- **AND** every bag and shot SHALL link to it, retaining its own (split) grind setting and rpm
+
+#### Scenario: Distinct historical grinder
+- **WHEN** some historical bag or shot has a grinder identity different from the current settings
+- **THEN** a separate package SHALL be created for that identity and those rows linked to it
+
+#### Scenario: Empty grinder identity
+- **WHEN** a bag or shot has empty grinder brand/model/burrs
+- **THEN** its `equipment_id` SHALL be NULL and no package SHALL be created for it
+
+#### Scenario: Package last-dial seeding
+- **WHEN** a package is created during migration
+- **THEN** the default package's `lastGrindSetting`/`lastRpm` SHALL seed from the current settings' (split) values
+- **AND** a per-grinder package's `lastGrindSetting`/`lastRpm` SHALL seed from that grinder's most-recent shot
+
+### Requirement: Equipment survives backup restore and device-to-device transfer
+The DB import path (`ShotHistoryStorage::importDatabaseStatic`) SHALL migrate `equipment_packages` and `equipment_items` rows and remap `coffee_bags.equipment_id` and `shots.equipment_id` to the new package ids (alongside the existing bag-id remap). `SettingsSerializer` SHALL exclude `dye/activeEquipmentId` from export.
+
+#### Scenario: Restoring a backup with equipment
+- **WHEN** a backup containing equipment tables is restored
+- **THEN** all packages and items SHALL be imported with new ids
+- **AND** imported bags' and shots' `equipment_id` SHALL point at the corresponding imported packages

--- a/openspec/changes/add-equipment-packages/specs/mcp-server/spec.md
+++ b/openspec/changes/add-equipment-packages/specs/mcp-server/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: MCP grinder reads SHALL resolve via the equipment package
+MCP surfaces that report grinder identity — the `de1://dialing` resource (`mcpresources.cpp`), `dialing_get_context`, `dialing_get_grinder_calibration`, and `ai_advisor_invoke` — SHALL resolve grinder brand/model/burrs through the equipment package (the active bag's package for live snapshots; the resolved shot's `equipment_id` for shot-derived blocks). They SHALL additionally expose the package identity (`id`, display `name`, `rpmAdjustable`) and the `rpm` dial-in. All fields SHALL follow MCP data conventions (units in field names, `kind` as a string enum, ISO-8601 timestamps).
+
+#### Scenario: Dialing resource reports the package
+- **WHEN** the `de1://dialing` resource is read
+- **THEN** the grinder block SHALL include the resolved brand/model/setting plus `rpm` and `rpmAdjustable`, sourced from the active bag's equipment package
+
+### Requirement: equipment_list tool
+The MCP server SHALL provide an `equipment_list` tool (modeled on `bag_list`) returning equipment packages: `id`, display `name`, grinder `brand`/`model`/`burrs`, `rpmAdjustable`, `inInventory`, and the last-used grind setting and `rpm`.
+
+#### Scenario: Listing packages
+- **WHEN** an agent calls `equipment_list`
+- **THEN** it SHALL receive the inventory of equipment packages with the fields above
+
+### Requirement: equipment_select tool
+The MCP server SHALL provide an `equipment_select` tool (modeled on `bag_select`) that sets the active bag's equipment package by id (or clears it with 0). Selecting a package SHALL apply that package's last grind setting / rpm to the active bag per the dual-memory rule.
+
+#### Scenario: Selecting a package
+- **WHEN** an agent calls `equipment_select` with a valid package id
+- **THEN** the active bag's `equipment_id` SHALL be set to that package
+- **AND** the active bag's grind setting and rpm SHALL be set to the package's last-dial values
+
+### Requirement: equipment_update tool
+The MCP server SHALL provide an `equipment_update` tool (modeled on `bag_update`) that edits a package's grinder identity (brand/model/burrs) and SHALL support creating a package. On a brand/model change, `rpmCapable` SHALL re-derive from the registry. Edits use reference semantics (apply to all referencing bags/shots).
+
+#### Scenario: Editing a package
+- **WHEN** an agent calls `equipment_update` changing a package's grinder model
+- **THEN** the package SHALL be updated, `rpmAdjustable` re-derived, and all referencing bags/shots SHALL resolve to the new identity

--- a/openspec/changes/add-equipment-packages/specs/shot-save-filter/spec.md
+++ b/openspec/changes/add-equipment-packages/specs/shot-save-filter/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Shot snapshots SHALL capture equipment_id and rpm
+When a shot is saved, the snapshot SHALL record the active bag's `equipment_id` (the package pointer) and the `rpm` dial-in value, in place of the dropped grinder identity columns. The grind setting SHALL continue to be snapshotted. Grinder brand/model/burrs SHALL NOT be stored on the shot row; they are resolved via `equipment_id` at read time.
+
+#### Scenario: Shot saved with a linked package
+- **WHEN** a shot is saved while the active bag has a linked equipment package
+- **THEN** the shot row SHALL store that package's `equipment_id`, the grind setting, and the rpm
+- **AND** the shot row SHALL NOT store grinder brand/model/burrs strings
+
+#### Scenario: Shot saved with no equipment
+- **WHEN** a shot is saved while the active bag has no linked equipment
+- **THEN** the shot's `equipment_id` SHALL be null and grinder identity SHALL resolve as empty

--- a/openspec/changes/add-equipment-packages/specs/switch-equipment-dialog/spec.md
+++ b/openspec/changes/add-equipment-packages/specs/switch-equipment-dialog/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Switch Equipment dialog
+The system SHALL provide a `SwitchEquipmentDialog.qml` (mirroring `ChangeBeansDialog.qml`) that lets the user pick an existing equipment package or create a new one. It SHALL be openable from the Equipment window ("Add Equipment") and from Brew Settings ("Switch Equipment").
+
+#### Scenario: Pick an existing package
+- **WHEN** the user opens the dialog with packages in inventory
+- **THEN** it SHALL list the packages for selection
+- **AND** selecting one SHALL set it as the active bag's equipment package
+
+#### Scenario: Create a new package
+- **WHEN** the user creates a new package
+- **THEN** the dialog SHALL collect grinder brand, model, and burrs with registry-backed suggestions (the same `knownGrinderBrands`/`knownGrinderModels`/`suggestedBurrs` sources the old Brew Settings grinder fields used, plus distinct values from shot history)
+- **AND** `rpmCapable` SHALL be derived from the registry for the entered identity
+- **AND** the new package SHALL be created and set as the active bag's equipment package
+
+### Requirement: Switching equipment applies the package's last dial
+When a package is selected as the active bag's equipment, the dialog flow SHALL apply that package's `lastGrindSetting`/`lastRpm` to the active bag's grind setting and rpm (per the equipment-package-model dual-memory rule), so Brew Settings reflects a non-blank, editable dial immediately.
+
+#### Scenario: Selecting a package pre-fills the dial
+- **WHEN** the user selects a package whose `lastGrindSetting` is "3.0" and `lastRpm` is 1200
+- **THEN** the active bag's grind setting SHALL become "3.0" and rpm 1200
+- **AND** both SHALL remain editable in Brew Settings
+
+### Requirement: Editing a package from the dialog uses reference semantics
+The dialog SHALL allow editing an existing package's grinder identity. Edits SHALL apply to the package row (reference semantics), so all bags and shots pointing at it resolve to the edited values; `rpmCapable` SHALL re-derive on a brand/model change.
+
+#### Scenario: Editing identity flows to history
+- **WHEN** the user edits a package's grinder model via the dialog
+- **THEN** the package row SHALL be updated and all referencing bags and shots SHALL resolve to the new model

--- a/openspec/changes/add-equipment-packages/specs/visualizer-upload-persistence/spec.md
+++ b/openspec/changes/add-equipment-packages/specs/visualizer-upload-persistence/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Visualizer upload SHALL resolve grinder identity via the equipment package
+The Visualizer upload payload builders in `src/network/visualizeruploader.cpp` SHALL resolve grinder brand/model by following the shot's `equipment_id` to the package's grinder item, then combine them into the single `grinder_model` string Visualizer expects (`"brand model"`). The payload shape SHALL be otherwise unchanged: `grinder_model`, `grinder_setting`, `grinder_dose_weight` (and their `meta.grinder.*` / `settings.*` mirrors). Burrs SHALL remain unsent (Visualizer has no field for it).
+
+#### Scenario: Pointer resolved on upload
+- **WHEN** a shot with a linked equipment package is uploaded
+- **THEN** `grinder_model` SHALL contain the resolved "brand model" string from the package's grinder item
+
+#### Scenario: Shot with no linked equipment
+- **WHEN** a shot has a null `equipment_id`
+- **THEN** the grinder fields SHALL be omitted from the payload rather than sent empty
+
+### Requirement: Visualizer upload SHALL append rpm to the grind setting
+Because Visualizer has no rpm field, when a shot has an rpm dial-in value the uploader SHALL append it to the `grinder_setting` string using the community convention (`"{setting} {rpm}rpm"`, e.g. `"2.4 1400rpm"`). When rpm is absent the `grinder_setting` SHALL be sent unmodified.
+
+#### Scenario: rpm appended
+- **WHEN** a shot has `grinder_setting = "2.4"` and `rpm = 1400`
+- **THEN** the uploaded `grinder_setting` SHALL be `"2.4 1400rpm"`
+
+#### Scenario: no rpm
+- **WHEN** a shot has `grinder_setting = "2.4"` and no rpm
+- **THEN** the uploaded `grinder_setting` SHALL be `"2.4"`
+
+### Requirement: Visualizer profile import SHALL remain unchanged
+Visualizer import (`src/network/visualizerimporter.cpp`) imports profiles only; the `grinder_model`/`grinder_setting` it reads are display-only metadata never persisted to a local shot or bag. This change SHALL NOT add equipment-package creation or `equipment_id` linkage on the import path.
+
+#### Scenario: Import does not create packages
+- **WHEN** a user imports a shared shot's profile from Visualizer
+- **THEN** no equipment package SHALL be created and no local shot/bag SHALL be linked

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -64,8 +64,8 @@
 ## 10. i18n, accessibility, tests
 - [ ] 10.1 Translation keys for Equipment page, dialog, Brew Settings labels, idle button
 - [ ] 10.2 Accessibility on all new interactive elements (roles, names, focus order) per `ACCESSIBILITY.md`
-- [ ] 10.3 Unit tests: grind/rpm split heuristic, package dedup, `rpmCapable` derivation, dual write-through
-- [ ] 10.4 Migration test: representative bag/shot corpus → expected packages + links + split values
+- [x] 10.3 Unit tests (`tst_equipment`): grind/rpm split heuristic, package dedup, `rpmCapable` derivation, package CRUD (14 cases). (Dual write-through is exercised via the live SettingsDye path, not unit-tested.)
+- [x] 10.4 Migration test (`tst_equipment::migrationSplitsAndLinks`): bag/shot corpus → expected packages + links + split values
 - [ ] 10.5 Verify Android build for the DB-migration + layout-migration paths
 
 ## 11. Docs

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -32,9 +32,9 @@
 
 ## 4b. Copy-on-write immutability + pointer-only normalization (REVISED model — see design §2b)
 - [x] 4b.1 Store `name` at package creation (persistent; defaults to "{brand} {model}")
-- [ ] 4b.2 Add `superseded_by` lineage column to `equipment_packages` (nullable FK → the fork's id)
-- [ ] 4b.3 Copy-on-write: editing identity of a package with `shotCount > 0` forks a NEW package, repoints referencing bags + active selection, marks the old `in_inventory = 0` + `superseded_by = new id` (persists for shots). Unused packages edit in place. (`EquipmentStorage` + Switch dialog + MCP `equipment_update`)
-- [ ] 4b.4 Merge on collision: a fork (or create) whose **full package signature** matches an existing package repoints to it instead of duplicating. Signature = all component identities; grinder = brand+model+burrs. Write it to extend to future components.
+- [x] 4b.2 `superseded_by` lineage column on `equipment_packages` (struct + `kCols` + `ensureTablesStatic`)
+- [x] 4b.3 Copy-on-write (`supersedeOrEditGrinderStatic`): identity edit of a used package forks a new one, repoints referencing bags, marks old `in_inventory=0` + `superseded_by`; unused edits in place; `requestUpdatePackage` + MCP `equipment_update` use it and surface the result id. (Switch-dialog active-repoint folds into 4b.5.)
+- [x] 4b.4 Merge on collision: `supersedeOrEditGrinderStatic` repoints to an existing in-inventory package with the same grinder identity instead of duplicating (`findPackageByGrinderIdentityStatic` gained an `excludeId`). Unit-tested in `tst_equipment::copyOnWriteAndMerge`.
 - [ ] 4b.5 `SettingsDye` `dyeGrinderBrand/Model/Burrs` resolve read-only via the active package (async cache, refreshed on bag/package change) — replaces the QSettings cache (this is 3.1 under the revised model)
 - [ ] 4b.6 Grinder search via pointer: shot-history search resolves the term against `equipment_items` for **all** history-referenced packages (inventory or not) → `equipment_id IN (…)`; drop grinder from `shots_fts`; no grinder shadow on shots
 - [ ] 4b.7 Display: render current-vs-superseded from `in_inventory` + `superseded_by` lineage (e.g. "older"/"retired" in shot history); never bake into `name`

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -56,10 +56,10 @@
 - [ ] 8.3 Confirm import path untouched (regression check)
 
 ## 9. MCP
-- [ ] 9.1 Resolve grinder reads via package in `mcpresources.cpp`, `mcptools_dialing.cpp`, `mcptools_ai.cpp`; add `rpm` + `rpmAdjustable` + package identity
-- [ ] 9.2 `equipment_list` tool (mirror `bag_list`)
-- [ ] 9.3 `equipment_select` tool (mirror `bag_select`; applies last-dial)
-- [ ] 9.4 `equipment_update` tool (mirror `bag_update`; create + edit, re-derive `rpmCapable`)
+- [x] 9.1 `de1://dialing` (mcpresources) grinder block gains `rpm` + `rpmAdjustable` + `packageId`. (Shot-derived dialing/ai blocks still read the shot's grinder columns, which remain until migration 23 — no change needed there yet.)
+- [x] 9.2 `equipment_list` tool (mirror `bag_list`; `isActive`, `rpmAdjustable`, last dial)
+- [x] 9.3 `equipment_select` tool (mirror `bag_select`; applies the package's grinder identity + last dial)
+- [x] 9.4 `equipment_update` tool (edit grinder identity/name; re-derives `rpmCapable`)
 
 ## 10. i18n, accessibility, tests
 - [ ] 10.1 Translation keys for Equipment page, dialog, Brew Settings labels, idle button

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -31,18 +31,18 @@
 - [ ] 4.4 **Migration 23**: drop `grinder_brand`/`grinder_model`/`grinder_burrs` from `coffee_bags` and `shots` (SQLite ≥3.35 `DROP COLUMN`) — only after 3.1/4.1/4.2 switch every reader to `equipment_id`; remove those columns from `CoffeeBagStorage::kCols`
 
 ## 5. Equipment window & idle button
-- [ ] 5.1 `EquipmentPage.qml` (mirror `BeanInfoPage.qml`): empty state + Add Equipment + package cards
-- [ ] 5.2 `EquipmentCard.qml`: grinder identity, burrs subtitle, edit + remove-from-inventory actions
-- [ ] 5.3 `EquipmentItem.qml` idle widget + 4-place registration (`CMakeLists.txt`, `LayoutItemDelegate.qml`, editor palette + chip label map, `shotserver_layout.cpp`)
-- [ ] 5.4 Add `equipment` to `defaultLayoutJson()` next to `beans`
-- [ ] 5.5 Idempotent run-once layout-injection migration in `getLayoutObject()` (insert after `beans`, fallback append to `bottomRight`)
-- [ ] 5.6 Register `EquipmentPage` in `main.qml` page stack + page-title map; nav from idle button
+- [x] 5.1 `EquipmentPage.qml` (mirror `BeanInfoPage.qml`): empty state + Add Equipment + package cards
+- [x] 5.2 `EquipmentCard.qml`: grinder identity, burrs subtitle, last-dial + RPM-adjustable captions, edit + remove actions
+- [x] 5.3 `EquipmentItem.qml` idle widget + 4-place registration (`CMakeLists.txt`, `LayoutItemDelegate.qml` switch+compile, `CustomItem.qml` navigate map, `shotserver_layout.cpp` list+labels)
+- [x] 5.4 Add `equipment` to `defaultLayoutJson()` next to `beans`
+- [x] 5.5 Idempotent run-once layout-injection migration in `getLayoutObject()` (insert after `beans`, fallback append to `bottomRight`)
+- [x] 5.6 Register `EquipmentPage` page-title map; nav from idle button + CustomItem `navigate:equipment` (pushed by URL)
 
 ## 6. Switch Equipment dialog
-- [ ] 6.1 `SwitchEquipmentDialog.qml` (mirror `ChangeBeansDialog.qml`): pick existing or create new
-- [ ] 6.2 Registry-backed grinder suggestions (brand/model/burrs) + shot-history distincts
-- [ ] 6.3 Create flow derives `rpmCapable`; select flow applies package last-dial
-- [ ] 6.4 Edit flow (reference semantics, re-derive `rpmCapable`)
+- [~] 6.1 `SwitchEquipmentDialog.qml`: create + edit done; **picking an existing package to switch the active bag pending** (needs `SettingsDye.activeEquipmentId` — Section 3)
+- [x] 6.2 Registry-backed grinder suggestions (brand/model/burrs) + shot-history distincts
+- [~] 6.3 Create flow derives `rpmCapable` (in storage) ✓; **select-applies-last-dial pending** (Section 3)
+- [x] 6.4 Edit flow (reference semantics, re-derive `rpmCapable`)
 
 ## 7. Brew Settings rework
 - [ ] 7.1 `BrewDialog.qml`: replace grinder brand/model/burrs inputs with read-only Equipment summary + Switch Equipment button

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -18,7 +18,7 @@
 - [ ] 2.8 `importDatabaseStatic`: migrate `equipment_packages` + `equipment_items` with id-remap; remap `coffee_bags.equipment_id`, `shots.equipment_id`, and `equipment_packages.superseded_by` on import (replaces the current stopgap that nulls the transferred `equipment_id`)
 
 ## 3. SettingsDye & dial memory
-- [ ] 3.1 `dyeGrinderBrand/Model/Burrs` → read-only, resolved via active bag's `equipment_id` — **deferred** (transitional: still QSettings-backed + bag write-through; identity applied from the package on switch). Required before migration 23 (4.4).
+- [x] 3.1 `dyeGrinderBrand/Model/Burrs` are read-only, resolved from the active package (async via EquipmentStorage `packageReady`); setters are display-cache-only (no bag write-through); `applyActiveBag` drives identity through `setActiveEquipmentId(bag.equipmentId)`. (= 4b.5)
 - [x] 3.2 Add `activeEquipmentId` + `switchToEquipment` that applies the package's `lastGrindSetting`/`lastRpm` and points the active bag at it
 - [x] 3.3 Add `dyeGrinderRpm`; grind setting + rpm edits fan out to BOTH active bag and active package (`writeThroughToActivePackage`)
 - [x] 3.4 `rpmCapable` derivation helper (`EquipmentStorage::deriveRpmCapable`: registry → `variableRpm`; custom → true); re-derived on identity edit in `updateGrinderItemStatic`
@@ -35,7 +35,7 @@
 - [x] 4b.2 `superseded_by` lineage column on `equipment_packages` (struct + `kCols` + `ensureTablesStatic`)
 - [x] 4b.3 Copy-on-write (`supersedeOrEditGrinderStatic`): identity edit of a used package forks a new one, repoints referencing bags, marks old `in_inventory=0` + `superseded_by`; unused edits in place; `requestUpdatePackage` + MCP `equipment_update` use it and surface the result id. (Switch-dialog active-repoint folds into 4b.5.)
 - [x] 4b.4 Merge on collision: `supersedeOrEditGrinderStatic` repoints to an existing in-inventory package with the same grinder identity instead of duplicating (`findPackageByGrinderIdentityStatic` gained an `excludeId`). Unit-tested in `tst_equipment::copyOnWriteAndMerge`.
-- [ ] 4b.5 `SettingsDye` `dyeGrinderBrand/Model/Burrs` resolve read-only via the active package (async cache, refreshed on bag/package change) — replaces the QSettings cache (this is 3.1 under the revised model)
+- [x] 4b.5 `SettingsDye` `dyeGrinderBrand/Model/Burrs` resolve read-only via the active package (async cache, refreshed on bag/package change) — replaces the QSettings cache (this is 3.1 under the revised model)
 - [ ] 4b.6 Grinder search via pointer: shot-history search resolves the term against `equipment_items` for **all** history-referenced packages (inventory or not) → `equipment_id IN (…)`; drop grinder from `shots_fts`; no grinder shadow on shots
 - [ ] 4b.7 Display: render current-vs-superseded from `in_inventory` + `superseded_by` lineage (e.g. "older"/"retired" in shot history); never bake into `name`
 

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -45,10 +45,10 @@
 - [x] 6.4 Edit flow (reference semantics, re-derive `rpmCapable`)
 
 ## 7. Brew Settings rework
-- [ ] 7.1 `BrewDialog.qml`: replace grinder brand/model/burrs inputs with read-only Equipment summary + Switch Equipment button
-- [ ] 7.2 Keep grind setting dial-in; add RPM dial-in shown only when `rpmCapable`
-- [ ] 7.3 Empty-state ("Equipment: not set → Add Equipment")
-- [ ] 7.4 Dial edits use dual write-through
+- [x] 7.1 `BrewDialog.qml`: grinder brand/model/burrs inputs replaced by read-only Equipment summary + burrs line + Switch Equipment button (opens `SwitchEquipmentDialog` picker)
+- [x] 7.2 Grind setting dial-in kept; RPM dial-in added, shown only when `Settings.dye.grinderRpmCapable(...)`
+- [x] 7.3 Empty-state ("Equipment: Not set" + Add button)
+- [x] 7.4 Dial edits use dual write-through (`setDyeGrinderSetting`/`setDyeGrinderRpm`)
 
 ## 8. Visualizer
 - [ ] 8.1 Upload: resolve `equipment_id` → "brand model"; omit when null

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -15,7 +15,7 @@
 - [x] 2.5 Link every bag/shot to its matching package; null `equipment_id` for empty grinder identity
 - [x] 2.6 Seed package `lastGrindSetting`/`lastRpm` (default ← current settings; per-grinder ← grinder's most-recent shot)
 - [x] 2.7 Bump schema version to 22 only after the transaction commits; failure path leaves DB usable (gated on tables+cols+data)
-- [ ] 2.8 `importDatabaseStatic`: migrate equipment tables + remap `coffee_bags.equipment_id` / `shots.equipment_id`
+- [ ] 2.8 `importDatabaseStatic`: migrate `equipment_packages` + `equipment_items` with id-remap; remap `coffee_bags.equipment_id`, `shots.equipment_id`, and `equipment_packages.superseded_by` on import (replaces the current stopgap that nulls the transferred `equipment_id`)
 
 ## 3. SettingsDye & dial memory
 - [ ] 3.1 `dyeGrinderBrand/Model/Burrs` → read-only, resolved via active bag's `equipment_id` — **deferred** (transitional: still QSettings-backed + bag write-through; identity applied from the package on switch). Required before migration 23 (4.4).
@@ -27,8 +27,17 @@
 ## 4. Shot projection & history queries
 - [ ] 4.1 `ShotProjection` resolves grinder brand/model/burrs via `equipment_id` JOIN; add `rpm`
 - [ ] 4.2 Re-scope `getDistinctGrinderBrands/ModelsForBrand/BurrsForModel/SettingsForGrinder` to `equipment_items WHERE kind='grinder'`
-- [ ] 4.3 Shot save captures `equipment_id` + `rpm` (drop grinder identity write)
-- [ ] 4.4 **Migration 23**: drop `grinder_brand`/`grinder_model`/`grinder_burrs` from `coffee_bags` and `shots` (SQLite ≥3.35 `DROP COLUMN`) — only after 3.1/4.1/4.2 switch every reader to `equipment_id`; remove those columns from `CoffeeBagStorage::kCols`
+- [ ] 4.3 Shot save captures `equipment_id` + `rpm` (stops writing grinder identity once columns are dropped)
+- [ ] 4.4 **Migration 23**: drop `grinder_brand`/`grinder_model`/`grinder_burrs` from `coffee_bags` AND `shots` (SQLite ≥3.35 `DROP COLUMN`); remove from `CoffeeBagStorage::kCols`; rework `shots_fts` to drop grinder columns — only after all readers (4.1/4.2/4b) resolve via `equipment_id`
+
+## 4b. Copy-on-write immutability + pointer-only normalization (REVISED model — see design §2b)
+- [x] 4b.1 Store `name` at package creation (persistent; defaults to "{brand} {model}")
+- [ ] 4b.2 Add `superseded_by` lineage column to `equipment_packages` (nullable FK → the fork's id)
+- [ ] 4b.3 Copy-on-write: editing identity of a package with `shotCount > 0` forks a NEW package, repoints referencing bags + active selection, marks the old `in_inventory = 0` + `superseded_by = new id` (persists for shots). Unused packages edit in place. (`EquipmentStorage` + Switch dialog + MCP `equipment_update`)
+- [ ] 4b.4 Merge on collision: a fork (or create) whose **full package signature** matches an existing package repoints to it instead of duplicating. Signature = all component identities; grinder = brand+model+burrs. Write it to extend to future components.
+- [ ] 4b.5 `SettingsDye` `dyeGrinderBrand/Model/Burrs` resolve read-only via the active package (async cache, refreshed on bag/package change) — replaces the QSettings cache (this is 3.1 under the revised model)
+- [ ] 4b.6 Grinder search via pointer: shot-history search resolves the term against `equipment_items` for **all** history-referenced packages (inventory or not) → `equipment_id IN (…)`; drop grinder from `shots_fts`; no grinder shadow on shots
+- [ ] 4b.7 Display: render current-vs-superseded from `in_inventory` + `superseded_by` lineage (e.g. "older"/"retired" in shot history); never bake into `name`
 
 ## 5. Equipment window & idle button
 - [x] 5.1 `EquipmentPage.qml` (mirror `BeanInfoPage.qml`): empty state + Add Equipment + package cards

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -73,7 +73,7 @@
 ## 10. i18n, accessibility, tests
 - [x] 10.1 All new UI strings use `TranslationManager.translate(key, fallback)` / `Tr` with `equipment.*`, `idle.button.equipment`, `brewDialog.equipment*`/`grindLabel`/`rpm*` keys. (English is the fallback; there is no checked-in base JSON — other languages register at runtime.)
 - [x] 10.2 Accessibility on new interactive elements: `AccessibleButton`/`AccessibleMouseArea`/`AccessibleTapHandler`, `Accessible.role/name`, headings on page/dialog titles
-- [x] 10.3 Unit tests (`tst_equipment`): grind/rpm split heuristic, package dedup, `rpmCapable` derivation, package CRUD (14 cases). (Dual write-through is exercised via the live SettingsDye path, not unit-tested.)
+- [x] 10.3 Unit tests: `tst_equipment` (split heuristic + edges, dedup, `rpmCapable`, CRUD, copy-on-write/merge sub-branches, name derivation); `tst_coffeebags::settingsDyeEquipmentSwitchAndDualWrite` (switch applies identity+dial, dual write-through to bag + package); `tst_dbmigration` (migration-22 idempotency + shot equipment_id/rpm round-trip).
 - [x] 10.4 Migration test (`tst_equipment::migrationSplitsAndLinks`): bag/shot corpus → expected packages + links + split values
 - [ ] 10.5 Verify Android build — **pending** (recommended before release). This change has no `#ifdef Q_OS_ANDROID` branches; the DB + layout migrations are platform-agnostic, so the macOS build/tests are representative.
 

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -62,13 +62,13 @@
 - [x] 9.4 `equipment_update` tool (edit grinder identity/name; re-derives `rpmCapable`)
 
 ## 10. i18n, accessibility, tests
-- [ ] 10.1 Translation keys for Equipment page, dialog, Brew Settings labels, idle button
-- [ ] 10.2 Accessibility on all new interactive elements (roles, names, focus order) per `ACCESSIBILITY.md`
+- [x] 10.1 All new UI strings use `TranslationManager.translate(key, fallback)` / `Tr` with `equipment.*`, `idle.button.equipment`, `brewDialog.equipment*`/`grindLabel`/`rpm*` keys. (English is the fallback; there is no checked-in base JSON — other languages register at runtime.)
+- [x] 10.2 Accessibility on new interactive elements: `AccessibleButton`/`AccessibleMouseArea`/`AccessibleTapHandler`, `Accessible.role/name`, headings on page/dialog titles
 - [x] 10.3 Unit tests (`tst_equipment`): grind/rpm split heuristic, package dedup, `rpmCapable` derivation, package CRUD (14 cases). (Dual write-through is exercised via the live SettingsDye path, not unit-tested.)
 - [x] 10.4 Migration test (`tst_equipment::migrationSplitsAndLinks`): bag/shot corpus → expected packages + links + split values
-- [ ] 10.5 Verify Android build for the DB-migration + layout-migration paths
+- [ ] 10.5 Verify Android build — **pending** (recommended before release). This change has no `#ifdef Q_OS_ANDROID` branches; the DB + layout migrations are platform-agnostic, so the macOS build/tests are representative.
 
 ## 11. Docs
-- [ ] 11.1 Update `docs/CLAUDE_MD/RECIPE_PROFILES.md` / relevant domain doc for the equipment-package model
-- [ ] 11.2 Update `docs/CLAUDE_MD/MCP_SERVER.md` with the new equipment tools
-- [ ] 11.3 Note the wiki Manual page for Equipment (user-visible feature)
+- [~] 11.1 Equipment-package model documented in the OpenSpec proposal/design (source of truth); no separate `RECIPE_PROFILES.md` section added
+- [x] 11.2 `docs/CLAUDE_MD/MCP_SERVER.md` updated with the new equipment tools + access levels + dialing fields
+- [ ] 11.3 Wiki Manual page for Equipment — **pending** (user-visible feature; update on release)

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -1,0 +1,74 @@
+# Tasks — Equipment Packages
+
+## 1. Data model & storage
+- [x] 1.1 Define `EquipmentPackage` + `EquipmentItem` value types (`src/history/equipmentstorage.h`)
+- [x] 1.2 New `EquipmentStorage` class: CRUD via `withTempDb()`, background-thread pattern modeled on `CoffeeBagStorage` (`equipmentstorage.{h,cpp}`)
+- [x] 1.3 Single source-of-truth column lists for `equipment_packages` and `equipment_items` (mirror `bagColumnList()` convention) — package uses the descriptor `kCols`; items use a fixed column string + JSON `attrs` blob
+- [x] 1.4 `inInventory` soft-delete + inventory query (index on `(in_inventory, last_used DESC)`)
+- [x] 1.5 Register `EquipmentStorage` with `MainController` and expose to QML (`MainController.equipmentStorage`; attached to `SettingsDye::setEquipmentStorage`; `qmlRegisterUncreatableType`)
+
+## 2. Migration 22 (additive) + Migration 23 (drop columns)
+- [x] 2.1 Create `equipment_packages` + `equipment_items` tables (`EquipmentStorage::ensureTablesStatic`, called by migration 22)
+- [x] 2.2 Add `equipment_id` (nullable FK) + `rpm` (nullable int) to `coffee_bags` and `shots` — **migration 22**. (DROP of `grinder_brand`/`grinder_model`/`grinder_burrs` moved to **migration 23**, after all readers resolve via `equipment_id` — see new task 4.4. Dropping now would break CoffeeBagStorage/shot reads at runtime.)
+- [x] 2.3 Grind/rpm split helper `EquipmentStorage::splitGrindAndRpm`: trailing `(\d+)\s*rpm$` → `rpm` + trimmed `grinder_setting`; non-marker settings verbatim. (Unit test pending — task 10.3.)
+- [x] 2.4 Package creation: default package from current settings + one per distinct `(brand, model, burrs)` across bags+shots; `rpmCapable` seeded from `GrinderAliases` (`migrateFromGrinderColumnsStatic`)
+- [x] 2.5 Link every bag/shot to its matching package; null `equipment_id` for empty grinder identity
+- [x] 2.6 Seed package `lastGrindSetting`/`lastRpm` (default ← current settings; per-grinder ← grinder's most-recent shot)
+- [x] 2.7 Bump schema version to 22 only after the transaction commits; failure path leaves DB usable (gated on tables+cols+data)
+- [ ] 2.8 `importDatabaseStatic`: migrate equipment tables + remap `coffee_bags.equipment_id` / `shots.equipment_id`
+
+## 3. SettingsDye & dial memory
+- [ ] 3.1 `dyeGrinderBrand/Model/Burrs` → read-only, resolved via active bag's `equipment_id`
+- [ ] 3.2 Add `activeEquipmentId` + switch logic that applies the package's `lastGrindSetting`/`lastRpm`
+- [ ] 3.3 Add `dyeGrinderRpm`; grind setting + rpm edits fan out to BOTH active bag and active package
+- [ ] 3.4 `rpmCapable` derivation helper (registry match → `variableRpm`; custom → true); re-derive on identity edit
+- [ ] 3.5 `SettingsSerializer`: exclude `dye/activeEquipmentId` from export
+
+## 4. Shot projection & history queries
+- [ ] 4.1 `ShotProjection` resolves grinder brand/model/burrs via `equipment_id` JOIN; add `rpm`
+- [ ] 4.2 Re-scope `getDistinctGrinderBrands/ModelsForBrand/BurrsForModel/SettingsForGrinder` to `equipment_items WHERE kind='grinder'`
+- [ ] 4.3 Shot save captures `equipment_id` + `rpm` (drop grinder identity write)
+- [ ] 4.4 **Migration 23**: drop `grinder_brand`/`grinder_model`/`grinder_burrs` from `coffee_bags` and `shots` (SQLite ≥3.35 `DROP COLUMN`) — only after 3.1/4.1/4.2 switch every reader to `equipment_id`; remove those columns from `CoffeeBagStorage::kCols`
+
+## 5. Equipment window & idle button
+- [ ] 5.1 `EquipmentPage.qml` (mirror `BeanInfoPage.qml`): empty state + Add Equipment + package cards
+- [ ] 5.2 `EquipmentCard.qml`: grinder identity, burrs subtitle, edit + remove-from-inventory actions
+- [ ] 5.3 `EquipmentItem.qml` idle widget + 4-place registration (`CMakeLists.txt`, `LayoutItemDelegate.qml`, editor palette + chip label map, `shotserver_layout.cpp`)
+- [ ] 5.4 Add `equipment` to `defaultLayoutJson()` next to `beans`
+- [ ] 5.5 Idempotent run-once layout-injection migration in `getLayoutObject()` (insert after `beans`, fallback append to `bottomRight`)
+- [ ] 5.6 Register `EquipmentPage` in `main.qml` page stack + page-title map; nav from idle button
+
+## 6. Switch Equipment dialog
+- [ ] 6.1 `SwitchEquipmentDialog.qml` (mirror `ChangeBeansDialog.qml`): pick existing or create new
+- [ ] 6.2 Registry-backed grinder suggestions (brand/model/burrs) + shot-history distincts
+- [ ] 6.3 Create flow derives `rpmCapable`; select flow applies package last-dial
+- [ ] 6.4 Edit flow (reference semantics, re-derive `rpmCapable`)
+
+## 7. Brew Settings rework
+- [ ] 7.1 `BrewDialog.qml`: replace grinder brand/model/burrs inputs with read-only Equipment summary + Switch Equipment button
+- [ ] 7.2 Keep grind setting dial-in; add RPM dial-in shown only when `rpmCapable`
+- [ ] 7.3 Empty-state ("Equipment: not set → Add Equipment")
+- [ ] 7.4 Dial edits use dual write-through
+
+## 8. Visualizer
+- [ ] 8.1 Upload: resolve `equipment_id` → "brand model"; omit when null
+- [ ] 8.2 Upload: append rpm to `grinder_setting` (`"{setting} {rpm}rpm"`) when rpm present
+- [ ] 8.3 Confirm import path untouched (regression check)
+
+## 9. MCP
+- [ ] 9.1 Resolve grinder reads via package in `mcpresources.cpp`, `mcptools_dialing.cpp`, `mcptools_ai.cpp`; add `rpm` + `rpmAdjustable` + package identity
+- [ ] 9.2 `equipment_list` tool (mirror `bag_list`)
+- [ ] 9.3 `equipment_select` tool (mirror `bag_select`; applies last-dial)
+- [ ] 9.4 `equipment_update` tool (mirror `bag_update`; create + edit, re-derive `rpmCapable`)
+
+## 10. i18n, accessibility, tests
+- [ ] 10.1 Translation keys for Equipment page, dialog, Brew Settings labels, idle button
+- [ ] 10.2 Accessibility on all new interactive elements (roles, names, focus order) per `ACCESSIBILITY.md`
+- [ ] 10.3 Unit tests: grind/rpm split heuristic, package dedup, `rpmCapable` derivation, dual write-through
+- [ ] 10.4 Migration test: representative bag/shot corpus → expected packages + links + split values
+- [ ] 10.5 Verify Android build for the DB-migration + layout-migration paths
+
+## 11. Docs
+- [ ] 11.1 Update `docs/CLAUDE_MD/RECIPE_PROFILES.md` / relevant domain doc for the equipment-package model
+- [ ] 11.2 Update `docs/CLAUDE_MD/MCP_SERVER.md` with the new equipment tools
+- [ ] 11.3 Note the wiki Manual page for Equipment (user-visible feature)

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -27,7 +27,7 @@
 ## 4. Shot projection & history queries
 - [ ] 4.1 `ShotProjection` resolves grinder brand/model/burrs via `equipment_id` JOIN; add `rpm`
 - [ ] 4.2 Re-scope `getDistinctGrinderBrands/ModelsForBrand/BurrsForModel/SettingsForGrinder` to `equipment_items WHERE kind='grinder'`
-- [ ] 4.3 Shot save captures `equipment_id` + `rpm` (stops writing grinder identity once columns are dropped)
+- [x] 4.3 Shot save captures `equipment_id` + `rpm` (ShotMetadata→ShotSaveData→INSERT; ShotRecord/ShotProjection read them back). Still writes the grinder identity snapshot columns until migration 23.
 - [ ] 4.4 **Migration 23**: drop `grinder_brand`/`grinder_model`/`grinder_burrs` from `coffee_bags` AND `shots` (SQLite ≥3.35 `DROP COLUMN`); remove from `CoffeeBagStorage::kCols`; rework `shots_fts` to drop grinder columns — only after all readers (4.1/4.2/4b) resolve via `equipment_id`
 
 ## 4b. Copy-on-write immutability + pointer-only normalization (REVISED model — see design §2b)
@@ -60,9 +60,9 @@
 - [x] 7.4 Dial edits use dual write-through (`setDyeGrinderSetting`/`setDyeGrinderRpm`)
 
 ## 8. Visualizer
-- [ ] 8.1 Upload: resolve `equipment_id` → "brand model"; omit when null
-- [ ] 8.2 Upload: append rpm to `grinder_setting` (`"{setting} {rpm}rpm"`) when rpm present
-- [ ] 8.3 Confirm import path untouched (regression check)
+- [~] 8.1 Upload still sends the grinder identity snapshot strings (present until migration 23); pure-pointer resolution folds into the projection JOIN (4.1)
+- [x] 8.2 Upload appends rpm to `grinder_setting` (`"{setting} {rpm}rpm"`) at all payload sites via `grinderSettingWithRpm`
+- [x] 8.3 Import path untouched (profile-only; no equipment linkage) — confirmed earlier
 
 ## 9. MCP
 - [x] 9.1 `de1://dialing` (mcpresources) grinder block gains `rpm` + `rpmAdjustable` + `packageId`. (Shot-derived dialing/ai blocks still read the shot's grinder columns, which remain until migration 23 — no change needed there yet.)

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -18,11 +18,11 @@
 - [ ] 2.8 `importDatabaseStatic`: migrate equipment tables + remap `coffee_bags.equipment_id` / `shots.equipment_id`
 
 ## 3. SettingsDye & dial memory
-- [ ] 3.1 `dyeGrinderBrand/Model/Burrs` → read-only, resolved via active bag's `equipment_id`
-- [ ] 3.2 Add `activeEquipmentId` + switch logic that applies the package's `lastGrindSetting`/`lastRpm`
-- [ ] 3.3 Add `dyeGrinderRpm`; grind setting + rpm edits fan out to BOTH active bag and active package
-- [ ] 3.4 `rpmCapable` derivation helper (registry match → `variableRpm`; custom → true); re-derive on identity edit
-- [ ] 3.5 `SettingsSerializer`: exclude `dye/activeEquipmentId` from export
+- [ ] 3.1 `dyeGrinderBrand/Model/Burrs` → read-only, resolved via active bag's `equipment_id` — **deferred** (transitional: still QSettings-backed + bag write-through; identity applied from the package on switch). Required before migration 23 (4.4).
+- [x] 3.2 Add `activeEquipmentId` + `switchToEquipment` that applies the package's `lastGrindSetting`/`lastRpm` and points the active bag at it
+- [x] 3.3 Add `dyeGrinderRpm`; grind setting + rpm edits fan out to BOTH active bag and active package (`writeThroughToActivePackage`)
+- [x] 3.4 `rpmCapable` derivation helper (`EquipmentStorage::deriveRpmCapable`: registry → `variableRpm`; custom → true); re-derived on identity edit in `updateGrinderItemStatic`
+- [x] 3.5 `SettingsSerializer`: `dye/activeEquipmentId` excluded from export (field-by-field export never emits it; comment updated)
 
 ## 4. Shot projection & history queries
 - [ ] 4.1 `ShotProjection` resolves grinder brand/model/burrs via `equipment_id` JOIN; add `rpm`
@@ -39,9 +39,9 @@
 - [x] 5.6 Register `EquipmentPage` page-title map; nav from idle button + CustomItem `navigate:equipment` (pushed by URL)
 
 ## 6. Switch Equipment dialog
-- [~] 6.1 `SwitchEquipmentDialog.qml`: create + edit done; **picking an existing package to switch the active bag pending** (needs `SettingsDye.activeEquipmentId` — Section 3)
+- [x] 6.1 `SwitchEquipmentDialog.qml`: create + edit; tapping a card / creating a package switches the active bag via `Settings.dye.switchToEquipment`
 - [x] 6.2 Registry-backed grinder suggestions (brand/model/burrs) + shot-history distincts
-- [~] 6.3 Create flow derives `rpmCapable` (in storage) ✓; **select-applies-last-dial pending** (Section 3)
+- [x] 6.3 Create flow derives `rpmCapable` (in storage); select flow applies the package's last dial
 - [x] 6.4 Edit flow (reference semantics, re-derive `rpmCapable`)
 
 ## 7. Brew Settings rework

--- a/openspec/changes/add-equipment-packages/tasks.md
+++ b/openspec/changes/add-equipment-packages/tasks.md
@@ -15,7 +15,7 @@
 - [x] 2.5 Link every bag/shot to its matching package; null `equipment_id` for empty grinder identity
 - [x] 2.6 Seed package `lastGrindSetting`/`lastRpm` (default ← current settings; per-grinder ← grinder's most-recent shot)
 - [x] 2.7 Bump schema version to 22 only after the transaction commits; failure path leaves DB usable (gated on tables+cols+data)
-- [ ] 2.8 `importDatabaseStatic`: migrate `equipment_packages` + `equipment_items` with id-remap; remap `coffee_bags.equipment_id`, `shots.equipment_id`, and `equipment_packages.superseded_by` on import (replaces the current stopgap that nulls the transferred `equipment_id`)
+- [x] 2.8 `importDatabaseStatic`: migrate `equipment_packages` + `equipment_items` with id-remap; remap `coffee_bags.equipment_id`, `shots.equipment_id`, and `equipment_packages.superseded_by` on import (replaces the current stopgap that nulls the transferred `equipment_id`)
 
 ## 3. SettingsDye & dial memory
 - [x] 3.1 `dyeGrinderBrand/Model/Burrs` are read-only, resolved from the active package (async via EquipmentStorage `packageReady`); setters are display-cache-only (no bag write-through); `applyActiveBag` drives identity through `setActiveEquipmentId(bag.equipmentId)`. (= 4b.5)
@@ -25,10 +25,10 @@
 - [x] 3.5 `SettingsSerializer`: `dye/activeEquipmentId` excluded from export (field-by-field export never emits it; comment updated)
 
 ## 4. Shot projection & history queries
-- [ ] 4.1 `ShotProjection` resolves grinder brand/model/burrs via `equipment_id` JOIN; add `rpm`
-- [ ] 4.2 Re-scope `getDistinctGrinderBrands/ModelsForBrand/BurrsForModel/SettingsForGrinder` to `equipment_items WHERE kind='grinder'`
+- [x] 4.1 `ShotProjection` resolves grinder brand/model/burrs via `equipment_id` JOIN; add `rpm`
+- [x] 4.2 Re-scope `getDistinctGrinderBrands/ModelsForBrand/BurrsForModel/SettingsForGrinder` to `equipment_items WHERE kind='grinder'`
 - [x] 4.3 Shot save captures `equipment_id` + `rpm` (ShotMetadata→ShotSaveData→INSERT; ShotRecord/ShotProjection read them back). Still writes the grinder identity snapshot columns until migration 23.
-- [ ] 4.4 **Migration 23**: drop `grinder_brand`/`grinder_model`/`grinder_burrs` from `coffee_bags` AND `shots` (SQLite ≥3.35 `DROP COLUMN`); remove from `CoffeeBagStorage::kCols`; rework `shots_fts` to drop grinder columns — only after all readers (4.1/4.2/4b) resolve via `equipment_id`
+- [x] 4.4 **Migration 23**: drop `grinder_brand`/`grinder_model`/`grinder_burrs` from `coffee_bags` AND `shots` (SQLite ≥3.35 `DROP COLUMN`); remove from `CoffeeBagStorage::kCols`; rework `shots_fts` to drop grinder columns — only after all readers (4.1/4.2/4b) resolve via `equipment_id`
 
 ## 4b. Copy-on-write immutability + pointer-only normalization (REVISED model — see design §2b)
 - [x] 4b.1 Store `name` at package creation (persistent; defaults to "{brand} {model}")
@@ -36,8 +36,8 @@
 - [x] 4b.3 Copy-on-write (`supersedeOrEditGrinderStatic`): identity edit of a used package forks a new one, repoints referencing bags, marks old `in_inventory=0` + `superseded_by`; unused edits in place; `requestUpdatePackage` + MCP `equipment_update` use it and surface the result id. (Switch-dialog active-repoint folds into 4b.5.)
 - [x] 4b.4 Merge on collision: `supersedeOrEditGrinderStatic` repoints to an existing in-inventory package with the same grinder identity instead of duplicating (`findPackageByGrinderIdentityStatic` gained an `excludeId`). Unit-tested in `tst_equipment::copyOnWriteAndMerge`.
 - [x] 4b.5 `SettingsDye` `dyeGrinderBrand/Model/Burrs` resolve read-only via the active package (async cache, refreshed on bag/package change) — replaces the QSettings cache (this is 3.1 under the revised model)
-- [ ] 4b.6 Grinder search via pointer: shot-history search resolves the term against `equipment_items` for **all** history-referenced packages (inventory or not) → `equipment_id IN (…)`; drop grinder from `shots_fts`; no grinder shadow on shots
-- [ ] 4b.7 Display: render current-vs-superseded from `in_inventory` + `superseded_by` lineage (e.g. "older"/"retired" in shot history); never bake into `name`
+- [x] 4b.6 Grinder search via pointer: shot-history search resolves the term against `equipment_items` for **all** history-referenced packages (inventory or not) → `equipment_id IN (…)`; drop grinder from `shots_fts`; no grinder shadow on shots
+- [x] 4b.7 Display: render current-vs-superseded from `in_inventory` + `superseded_by` lineage (e.g. "older"/"retired" in shot history); never bake into `name`
 
 ## 5. Equipment window & idle button
 - [x] 5.1 `EquipmentPage.qml` (mirror `BeanInfoPage.qml`): empty state + Add Equipment + package cards
@@ -60,7 +60,7 @@
 - [x] 7.4 Dial edits use dual write-through (`setDyeGrinderSetting`/`setDyeGrinderRpm`)
 
 ## 8. Visualizer
-- [~] 8.1 Upload still sends the grinder identity snapshot strings (present until migration 23); pure-pointer resolution folds into the projection JOIN (4.1)
+- [x] 8.1 Upload resolves grinder identity through the projection JOIN (4.1) — the snapshot columns are gone (migration 23); `shotData.grinderBrand/Model/Burrs` are populated from the package's grinder item
 - [x] 8.2 Upload appends rpm to `grinder_setting` (`"{setting} {rpm}rpm"`) at all payload sites via `grinderSettingWithRpm`
 - [x] 8.3 Import path untouched (profile-only; no equipment linkage) — confirmed earlier
 

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -30,11 +30,16 @@ Dialog {
     property double profileTargetWeight: ProfileManager.profileTargetWeight
     property bool targetManuallySet: false
 
-    // Grinder fields
-    property string grinderBrand: ""
-    property string grinderModel: ""
-    property string grinderBurrs: ""
+    // Equipment (read-only, resolved from the active package via SettingsDye) +
+    // the dial-in fields that live in Brew Settings (grind setting + rpm).
+    readonly property string equipmentBrand: Settings.dye.dyeGrinderBrand
+    readonly property string equipmentModel: Settings.dye.dyeGrinderModel
+    readonly property string equipmentBurrs: Settings.dye.dyeGrinderBurrs
+    readonly property bool equipmentRpmCapable: Settings.dye.grinderRpmCapable(equipmentBrand, equipmentModel)
+    readonly property string equipmentLabel:
+        [equipmentBrand, equipmentModel].filter(function(s) { return s.length > 0 }).join(" ")
     property string grindSetting: ""
+    property int grindRpm: 0
 
     // Profile
     property string selectedProfileTitle: ""
@@ -60,44 +65,10 @@ Dialog {
         }
     }
 
-    function getGrinderBrandSuggestions() {
-        var history = MainController.shotHistory ? MainController.shotHistory.getDistinctGrinderBrands() : []
-        var known = Settings.dye.knownGrinderBrands()
-        var merged = history.slice()
-        for (var i = 0; i < known.length; i++) {
-            if (merged.indexOf(known[i]) < 0) merged.push(known[i])
-        }
-        return merged
-    }
-
-    function getGrinderModelSuggestions() {
-        var history = MainController.shotHistory ? MainController.shotHistory.getDistinctGrinderModelsForBrand(root.grinderBrand) : []
-        var known = Settings.dye.knownGrinderModels(root.grinderBrand)
-        var merged = history.slice()
-        for (var i = 0; i < known.length; i++) {
-            if (merged.indexOf(known[i]) < 0) merged.push(known[i])
-        }
-        return merged
-    }
-
-    function getGrinderBurrsSuggestions() {
-        var known = Settings.dye.suggestedBurrs(root.grinderBrand, root.grinderModel)
-        // Non-swappable grinders (e.g. Niche Duo) ship with fixed burrs — don't
-        // pollute the suggestion list with stale history entries from a different
-        // grinder model on the same brand.
-        if (!Settings.dye.isBurrSwappable(root.grinderBrand, root.grinderModel)) {
-            return known
-        }
-        var history = MainController.shotHistory ? MainController.shotHistory.getDistinctGrinderBurrsForModel(root.grinderBrand, root.grinderModel) : []
-        var merged = history.slice()
-        for (var i = 0; i < known.length; i++) {
-            if (merged.indexOf(known[i]) < 0) merged.push(known[i])
-        }
-        return merged
-    }
-
+    // Grinder identity is now chosen via the Switch Equipment dialog, so only the
+    // grind-setting field keeps a suggestion list (scoped to the active grinder).
     function getGrinderSettingSuggestions() {
-        var suggestions = MainController.shotHistory ? MainController.shotHistory.getDistinctGrinderSettingsForGrinder(root.grinderModel) : []
+        var suggestions = MainController.shotHistory ? MainController.shotHistory.getDistinctGrinderSettingsForGrinder(root.equipmentModel) : []
         if (Settings.dye.dyeGrinderSetting.length > 0 && suggestions.indexOf(Settings.dye.dyeGrinderSetting) === -1) {
             suggestions.unshift(Settings.dye.dyeGrinderSetting)
         }
@@ -155,12 +126,12 @@ Dialog {
         profileTargetWeight = ProfileManager.profileTargetWeight
         temperatureValue = Settings.brew.hasTemperatureOverride ? Settings.brew.temperatureOverride : profileTemperature
 
-        // Use DYE fields for dose and grind (source of truth)
+        // Use DYE fields for dose and grind (source of truth). Grinder identity
+        // is read-only here (resolved from the active package); only the dial-in
+        // (grind setting + rpm) is editable.
         doseValue = Settings.dye.dyeBeanWeight > 0 ? Settings.dye.dyeBeanWeight : 18.0
-        grinderBrand = Settings.dye.dyeGrinderBrand
-        grinderModel = Settings.dye.dyeGrinderModel
-        grinderBurrs = Settings.dye.dyeGrinderBurrs
         grindSetting = Settings.dye.dyeGrinderSetting
+        grindRpm = Settings.dye.dyeGrinderRpm
         selectedProfileTitle = ProfileManager.currentProfileName
         originalProfileFilename = Settings.app.currentProfile
         showScaleWarning = false
@@ -169,6 +140,10 @@ Dialog {
         targetValue = Settings.brew.hasBrewYieldOverride ? Settings.brew.brewYieldOverride : profileTargetWeight
         ratio = doseValue > 0 ? targetValue / doseValue : Settings.brew.lastUsedRatio
         targetManuallySet = Settings.brew.hasBrewYieldOverride
+    }
+
+    SwitchEquipmentDialog {
+        id: switchEquipmentDialog
     }
 
     background: Rectangle {
@@ -186,8 +161,7 @@ Dialog {
         inOverlay: true
         textFields: [
             profileInput.textField,
-            grinderBrandInput.textField, grinderModelInput.textField,
-            grinderBurrsInput.textField, grindInput.textField
+            grindInput.textField, rpmInput
         ]
         targetFlickable: brewFlickable
 
@@ -607,13 +581,14 @@ Dialog {
                 }
             }
 
-            // Grinder brand and model
+            // Equipment package (read-only) + Switch Equipment button. Identity
+            // is managed in the Equipment window / Switch dialog, not edited here.
             RowLayout {
                 Layout.fillWidth: true
                 spacing: Theme.scaled(4)
 
                 Text {
-                    text: TranslationManager.translate("brewDialog.grinderLabel", "Grinder:")
+                    text: TranslationManager.translate("brewDialog.equipmentLabel", "Equipment:")
                     font: Theme.bodyFont
                     color: Theme.textSecondaryColor
                     Layout.alignment: Qt.AlignVCenter
@@ -621,46 +596,34 @@ Dialog {
                     Accessible.ignored: true
                 }
 
-                SuggestionField {
-                    id: grinderBrandInput
+                Text {
                     Layout.fillWidth: true
-                    Layout.preferredWidth: Theme.scaled(120)
-                    label: ""
-                    accessibleName: TranslationManager.translate("brewDialog.grinderBrand", "Grinder brand")
-                    text: root.grinderBrand
-                    suggestions: _distinctCacheVersion >= 0 ? root.getGrinderBrandSuggestions() : []
-                    onTextEdited: function(t) { root.grinderBrand = t }
-                    onSuggestionSelected: function(t) {
-                        root.grinderModel = ""
-                        root.grinderBurrs = ""
-                        var models = Settings.dye.knownGrinderModels(t)
-                        if (models.length === 1) {
-                            root.grinderModel = models[0]
-                            var burrs = Settings.dye.suggestedBurrs(t, models[0])
-                            if (burrs.length === 1) root.grinderBurrs = burrs[0]
-                        }
-                    }
+                    text: root.equipmentLabel.length > 0
+                          ? root.equipmentLabel
+                          : TranslationManager.translate("brewDialog.equipmentNotSet", "Not set")
+                    font: Theme.bodyFont
+                    color: root.equipmentLabel.length > 0 ? Theme.textColor : Theme.textSecondaryColor
+                    elide: Text.ElideRight
+                    Accessible.role: Accessible.StaticText
+                    Accessible.name: TranslationManager.translate("brewDialog.equipmentAccessible", "Equipment: %1").arg(
+                        root.equipmentLabel.length > 0 ? root.equipmentLabel
+                        : TranslationManager.translate("brewDialog.equipmentNotSet", "Not set"))
                 }
 
-                SuggestionField {
-                    id: grinderModelInput
-                    Layout.fillWidth: true
-                    Layout.preferredWidth: Theme.scaled(120)
-                    label: ""
-                    accessibleName: TranslationManager.translate("brewDialog.grinderModel", "Grinder model")
-                    text: root.grinderModel
-                    suggestions: _distinctCacheVersion >= 0 ? root.getGrinderModelSuggestions() : []
-                    onTextEdited: function(t) { root.grinderModel = t }
-                    onSuggestionSelected: function(t) {
-                        var burrs = Settings.dye.suggestedBurrs(root.grinderBrand, t)
-                        if (burrs.length === 1) root.grinderBurrs = burrs[0]
-                    }
+                AccessibleButton {
+                    Layout.preferredHeight: Theme.scaled(40)
+                    text: root.equipmentLabel.length > 0
+                          ? TranslationManager.translate("brewDialog.switchEquipment", "Switch")
+                          : TranslationManager.translate("brewDialog.addEquipment", "Add")
+                    accessibleName: TranslationManager.translate("brewDialog.switchEquipmentAccessible", "Switch equipment package")
+                    onClicked: switchEquipmentDialog.openPicker()
                 }
             }
 
-            // Burrs and setting
+            // Burrs (read-only) shown when known
             RowLayout {
                 Layout.fillWidth: true
+                visible: root.equipmentBurrs.length > 0
                 spacing: Theme.scaled(4)
 
                 Text {
@@ -671,23 +634,28 @@ Dialog {
                     Layout.preferredWidth: Theme.scaled(75)
                     Accessible.ignored: true
                 }
-
-                SuggestionField {
-                    id: grinderBurrsInput
+                Text {
                     Layout.fillWidth: true
-                    Layout.preferredWidth: Theme.scaled(120)
-                    label: ""
-                    accessibleName: TranslationManager.translate("brewDialog.grinderBurrs", "Grinder burrs")
-                    text: root.grinderBurrs
-                    suggestions: _distinctCacheVersion >= 0 ? root.getGrinderBurrsSuggestions() : []
-                    onTextEdited: function(t) { root.grinderBurrs = t }
+                    text: root.equipmentBurrs
+                    font: Theme.bodyFont
+                    color: Theme.textColor
+                    elide: Text.ElideRight
+                    Accessible.role: Accessible.StaticText
+                    Accessible.name: TranslationManager.translate("brewDialog.burrsAccessible", "Burrs: %1").arg(root.equipmentBurrs)
                 }
+            }
+
+            // Grind setting (+ rpm when the grinder is rpm-adjustable) — dial-in
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.scaled(4)
 
                 Text {
-                    text: "@"
+                    text: TranslationManager.translate("brewDialog.grindLabel", "Grind:")
                     font: Theme.bodyFont
                     color: Theme.textSecondaryColor
                     Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredWidth: Theme.scaled(75)
                     Accessible.ignored: true
                 }
 
@@ -700,6 +668,25 @@ Dialog {
                     text: root.grindSetting
                     suggestions: _distinctCacheVersion >= 0 ? root.getGrinderSettingSuggestions() : []
                     onTextEdited: function(t) { root.grindSetting = t }
+                }
+
+                Text {
+                    visible: root.equipmentRpmCapable
+                    text: TranslationManager.translate("brewDialog.rpmLabel", "RPM:")
+                    font: Theme.bodyFont
+                    color: Theme.textSecondaryColor
+                    Layout.alignment: Qt.AlignVCenter
+                    Accessible.ignored: true
+                }
+
+                StyledTextField {
+                    id: rpmInput
+                    visible: root.equipmentRpmCapable
+                    Layout.preferredWidth: Theme.scaled(80)
+                    inputMethodHints: Qt.ImhDigitsOnly
+                    text: root.grindRpm > 0 ? String(root.grindRpm) : ""
+                    Accessible.name: TranslationManager.translate("brewDialog.rpmAccessible", "Grinder rpm")
+                    onTextEdited: root.grindRpm = parseInt(text) || 0
                 }
             }
         }
@@ -726,10 +713,8 @@ Dialog {
                     // Use the active bag's dose if available, otherwise default 18g
                     root.doseValue = Settings.dye.dyeBeanWeight > 0 ? Settings.dye.dyeBeanWeight : 18.0
                     root.selectedProfileTitle = ProfileManager.currentProfileName
-                    root.grinderBrand = Settings.dye.dyeGrinderBrand
-                    root.grinderModel = Settings.dye.dyeGrinderModel
-                    root.grinderBurrs = Settings.dye.dyeGrinderBurrs
                     root.grindSetting = Settings.dye.dyeGrinderSetting
+                    root.grindRpm = Settings.dye.dyeGrinderRpm
 
                     // Calculate ratio from profile target weight / dose
                     var profileTarget = ProfileManager.profileTargetWeight
@@ -783,10 +768,10 @@ Dialog {
                 onClicked: {
                     Qt.inputMethod.commit()
                     Settings.brew.lastUsedRatio = root.ratio
-                    Settings.dye.dyeGrinderBrand = root.grinderBrand
-                    Settings.dye.dyeGrinderModel = root.grinderModel
-                    Settings.dye.dyeGrinderBurrs = root.grinderBurrs
+                    // Grinder identity is managed via Switch Equipment; only the
+                    // dial-in (grind setting + rpm) is saved from here.
                     Settings.dye.dyeGrinderSetting = root.grindSetting
+                    Settings.dye.dyeGrinderRpm = root.grindRpm
                     // Use the new activateBrewWithOverrides method
                     ProfileManager.activateBrewWithOverrides(
                         root.doseValue,

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -34,10 +34,10 @@ Dialog {
     // the dial-in fields that live in Brew Settings (grind setting + rpm).
     readonly property string equipmentBrand: Settings.dye.dyeGrinderBrand
     readonly property string equipmentModel: Settings.dye.dyeGrinderModel
-    readonly property string equipmentBurrs: Settings.dye.dyeGrinderBurrs
     readonly property bool equipmentRpmCapable: Settings.dye.grinderRpmCapable(equipmentBrand, equipmentModel)
-    readonly property string equipmentLabel:
-        [equipmentBrand, equipmentModel].filter(function(s) { return s.length > 0 }).join(" ")
+    // Show the package's display name (defaults to "{brand} {model}"), not the
+    // raw grinder identity (add-equipment-packages).
+    readonly property string equipmentLabel: Settings.dye.dyeEquipmentName
     property string grindSetting: ""
     property int grindRpm: 0
 
@@ -144,6 +144,10 @@ Dialog {
 
     SwitchEquipmentDialog {
         id: switchEquipmentDialog
+    }
+
+    EquipmentInfoDialog {
+        id: equipmentInfoDialog
     }
 
     background: Rectangle {
@@ -610,6 +614,15 @@ Dialog {
                         : TranslationManager.translate("brewDialog.equipmentNotSet", "Not set"))
                 }
 
+                // Info: show the active package's full contents.
+                AccessibleButton {
+                    Layout.preferredHeight: Theme.scaled(40)
+                    visible: Settings.dye.activeEquipmentId > 0
+                    icon.source: "qrc:/icons/info.svg"
+                    accessibleName: TranslationManager.translate("equipment.info.button", "Equipment details")
+                    onClicked: equipmentInfoDialog.openFor(Settings.dye.activeEquipmentId)
+                }
+
                 AccessibleButton {
                     Layout.preferredHeight: Theme.scaled(40)
                     text: root.equipmentLabel.length > 0
@@ -617,31 +630,6 @@ Dialog {
                           : TranslationManager.translate("brewDialog.addEquipment", "Add")
                     accessibleName: TranslationManager.translate("brewDialog.switchEquipmentAccessible", "Switch equipment package")
                     onClicked: switchEquipmentDialog.openPicker()
-                }
-            }
-
-            // Burrs (read-only) shown when known
-            RowLayout {
-                Layout.fillWidth: true
-                visible: root.equipmentBurrs.length > 0
-                spacing: Theme.scaled(4)
-
-                Text {
-                    text: TranslationManager.translate("brewDialog.burrsLabel", "Burrs:")
-                    font: Theme.bodyFont
-                    color: Theme.textSecondaryColor
-                    Layout.alignment: Qt.AlignVCenter
-                    Layout.preferredWidth: Theme.scaled(75)
-                    Accessible.ignored: true
-                }
-                Text {
-                    Layout.fillWidth: true
-                    text: root.equipmentBurrs
-                    font: Theme.bodyFont
-                    color: Theme.textColor
-                    elide: Text.ElideRight
-                    Accessible.role: Accessible.StaticText
-                    Accessible.name: TranslationManager.translate("brewDialog.burrsAccessible", "Burrs: %1").arg(root.equipmentBurrs)
                 }
             }
 

--- a/qml/components/ChangeBeansDialog.qml
+++ b/qml/components/ChangeBeansDialog.qml
@@ -58,12 +58,18 @@ Dialog {
     // The bag points at a package via fEquipmentId; brand/model/burrs are the
     // resolved read-only display (refreshed via EquipmentStorage.packageReady).
     property string fGrinderSetting: ""
+    property string fRpm: ""           // grinder rpm dial-in (string form; "" = unset)
     property int fEquipmentId: -1
+    property string fEquipmentName: ""  // package display name (resolved via packageReady)
     property string fEquipmentBrand: ""
     property string fEquipmentModel: ""
     property string fEquipmentBurrs: ""
-    readonly property string fEquipmentLabel:
-        [fEquipmentBrand, fEquipmentModel].filter(function(s){ return s && s.length > 0 }).join(" ")
+    readonly property bool fEquipmentRpmCapable:
+        Settings.dye.grinderRpmCapable(fEquipmentBrand, fEquipmentModel)
+    // Display the package name (defaults to "{brand} {model}").
+    readonly property string fEquipmentLabel: fEquipmentName.length > 0
+        ? fEquipmentName
+        : [fEquipmentBrand, fEquipmentModel].filter(function(s){ return s && s.length > 0 }).join(" ")
     property string fDose: ""         // text form; "" = unset
     property string fYield: ""
     property string fNotes: ""
@@ -185,7 +191,8 @@ Dialog {
         fBeanBaseId = ""; fBeanBaseData = ""
         fLinkDirty = false
         fGrinderSetting = ""
-        fEquipmentId = -1; fEquipmentBrand = ""; fEquipmentModel = ""; fEquipmentBurrs = ""
+        fEquipmentId = -1; fEquipmentName = ""; fEquipmentBrand = ""; fEquipmentModel = ""; fEquipmentBurrs = ""
+        fRpm = ""
         fDose = ""; fYield = ""; fNotes = ""
         fFreeze = false; fFrozenDate = ""; fDefrostDate = ""
         identityKnown = false
@@ -200,9 +207,10 @@ Dialog {
         fBeanBaseData = bag.beanBaseData || ""
         fGrinderSetting = bag.grinderSetting || ""
         fEquipmentId = bag.equipmentId || -1
-        // Resolve the package's grinder identity for the read-only label
-        // (packageReady fills fEquipmentBrand/Model/Burrs below).
-        fEquipmentBrand = ""; fEquipmentModel = ""; fEquipmentBurrs = ""
+        fRpm = (bag.rpm ?? 0) > 0 ? String(bag.rpm) : ""
+        // Resolve the package's name + grinder identity for the read-only label
+        // (packageReady fills fEquipmentName/Brand/Model/Burrs below).
+        fEquipmentName = ""; fEquipmentBrand = ""; fEquipmentModel = ""; fEquipmentBurrs = ""
         if (fEquipmentId > 0 && MainController.equipmentStorage)
             MainController.equipmentStorage.requestPackage(fEquipmentId)
         // toFixed(1) (not String()) so a non-exact double like 37.8 prefills as
@@ -337,6 +345,7 @@ Dialog {
             "beanBaseId": fBeanBaseId,
             "beanBaseData": fBeanBaseData,
             "grinderSetting": fGrinderSetting.trim(),
+            "rpm": parseInt(fRpm) || 0,
             "doseWeightG": parseWeight(fDose),
             "yieldOverrideG": parseWeight(fYield),
             "notes": fNotes,
@@ -390,6 +399,9 @@ Dialog {
                 MainController.equipmentStorage.requestPackage(packageId)
         }
     }
+    EquipmentInfoDialog {
+        id: bagEquipmentInfoDialog
+    }
     Connections {
         target: MainController.equipmentStorage
         // Fills the read-only label for whichever package this bag now points at
@@ -399,6 +411,7 @@ Dialog {
             root.fEquipmentBrand = pkg.grinderBrand || ""
             root.fEquipmentModel = pkg.grinderModel || ""
             root.fEquipmentBurrs = pkg.grinderBurrs || ""
+            root.fEquipmentName = (pkg.name && String(pkg.name).length > 0) ? String(pkg.name) : ""
         }
     }
 
@@ -1059,9 +1072,25 @@ Dialog {
                         }
                     }
 
-                    // Equipment package (read-only identity + re-point button).
-                    // Grinder brand/model/burrs are owned by the package, not the
-                    // bag; tap Switch/Add to point this bag at a different package.
+                    // RPM dial-in — only when the bag's grinder is rpm-adjustable.
+                    FieldRow {
+                        labelKey: "changebeans.form.rpm"
+                        labelFallback: "RPM:"
+                        visible: root.fEquipmentRpmCapable
+
+                        StyledTextField {
+                            Layout.fillWidth: true
+                            text: root.fRpm
+                            inputMethodHints: Qt.ImhDigitsOnly
+                            accessibleName: TranslationManager.translate("changebeans.form.rpm.accessible", "Grinder rpm")
+                            onTextEdited: root.fRpm = text
+                        }
+                    }
+
+                    // Equipment package (read-only NAME + info + re-point button).
+                    // Grinder identity is owned by the package, not the bag; tap
+                    // Switch/Add to point this bag at a different package, or the
+                    // info button to see the package's contents.
                     FieldRow {
                         labelKey: "changebeans.form.equipment"
                         labelFallback: "Equipment:"
@@ -1071,12 +1100,17 @@ Dialog {
                             elide: Text.ElideRight
                             text: root.fEquipmentLabel.length > 0
                                   ? root.fEquipmentLabel
-                                        + (root.fEquipmentBurrs.length > 0 ? " · " + root.fEquipmentBurrs : "")
                                   : TranslationManager.translate("changebeans.form.equipmentNotSet", "Not set")
                             font: Theme.bodyFont
                             color: root.fEquipmentLabel.length > 0 ? Theme.textColor : Theme.textSecondaryColor
                             Accessible.role: Accessible.StaticText
                             Accessible.name: TranslationManager.translate("changebeans.form.equipment", "Equipment:") + " " + text
+                        }
+                        AccessibleButton {
+                            visible: root.fEquipmentId > 0
+                            icon.source: "qrc:/icons/info.svg"
+                            accessibleName: TranslationManager.translate("equipment.info.button", "Equipment details")
+                            onClicked: bagEquipmentInfoDialog.openFor(root.fEquipmentId)
                         }
                         AccessibleButton {
                             text: root.fEquipmentLabel.length > 0

--- a/qml/components/ChangeBeansDialog.qml
+++ b/qml/components/ChangeBeansDialog.qml
@@ -366,6 +366,9 @@ Dialog {
         } else {
             fields["defrostDate"] = ""
             fields["inInventory"] = true
+            // Persist the equipment package picked in the create form too (the
+            // picker row is shown in both modes); <=0 -> NULL via the column hook.
+            fields["equipmentId"] = fEquipmentId
             _awaitingCreate = true
             MainController.bagStorage.requestCreateBag(fields)
         }

--- a/qml/components/ChangeBeansDialog.qml
+++ b/qml/components/ChangeBeansDialog.qml
@@ -53,9 +53,8 @@ Dialog {
     // True when the user linked/unlinked Bean Base in this edit session —
     // Save then propagates the bag's link to all its shots.
     property bool fLinkDirty: false
-    property string fGrinderBrand: ""
-    property string fGrinderModel: ""
-    property string fGrinderBurrs: ""
+    // Grinder identity (brand/model/burrs) is owned by the equipment package, not
+    // the bag (add-equipment-packages); only the grind-setting dial-in stays here.
     property string fGrinderSetting: ""
     property string fDose: ""         // text form; "" = unset
     property string fYield: ""
@@ -177,7 +176,7 @@ Dialog {
         fRoaster = ""; fCoffee = ""; fRoastDate = ""; fRoastLevel = ""
         fBeanBaseId = ""; fBeanBaseData = ""
         fLinkDirty = false
-        fGrinderBrand = ""; fGrinderModel = ""; fGrinderBurrs = ""; fGrinderSetting = ""
+        fGrinderSetting = ""
         fDose = ""; fYield = ""; fNotes = ""
         fFreeze = false; fFrozenDate = ""; fDefrostDate = ""
         identityKnown = false
@@ -190,9 +189,6 @@ Dialog {
         fRoastLevel = bag.roastLevel || ""
         fBeanBaseId = bag.beanBaseId ? String(bag.beanBaseId) : ""
         fBeanBaseData = bag.beanBaseData || ""
-        fGrinderBrand = bag.grinderBrand || ""
-        fGrinderModel = bag.grinderModel || ""
-        fGrinderBurrs = bag.grinderBurrs || ""
         fGrinderSetting = bag.grinderSetting || ""
         // toFixed(1) (not String()) so a non-exact double like 37.8 prefills as
         // "37.8", not "37.800000000000004" — matching the brew-settings format.
@@ -325,9 +321,6 @@ Dialog {
             "roastLevel": fRoastLevel,
             "beanBaseId": fBeanBaseId,
             "beanBaseData": fBeanBaseData,
-            "grinderBrand": fGrinderBrand.trim(),
-            "grinderModel": fGrinderModel.trim(),
-            "grinderBurrs": fGrinderBurrs.trim(),
             "grinderSetting": fGrinderSetting.trim(),
             "doseWeightG": parseWeight(fDose),
             "yieldOverrideG": parseWeight(fYield),
@@ -406,7 +399,6 @@ Dialog {
                                  root.parent ? root.parent.height * 0.9 : mainColumn.implicitHeight)
         textFields: [searchField, roasterInput.textField, coffeeInput.textField, roastDateInput,
                      grindSettingInput, doseInput, yieldInput,
-                     grinderBrandInput, grinderModelInput, grinderBurrsInput,
                      notesInput, frozenDateInput, defrostDateInput]
         targetFlickable: formFlickable
 
@@ -1056,8 +1048,10 @@ Dialog {
                         }
                     }
 
-                    // Notes / grinder hardware — always visible (the "More
-                    // options" expander was removed: it only added a click).
+                    // Notes — always visible. Grinder IDENTITY is no longer edited
+                    // here: it's owned by the Equipment package (add-equipment-
+                    // packages), set via Switch Equipment in Brew Settings. The bag
+                    // keeps only its grind-setting dial-in (above).
                     ColumnLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(10)
@@ -1074,40 +1068,6 @@ Dialog {
                                 onTextEdited: root.fNotes = text
                             }
                         }
-
-                        // Grinder hardware (rarely changes — tucked away)
-                        FieldRow {
-                            labelKey: "changebeans.form.grinder"
-                            labelFallback: "Grinder:"
-
-                            StyledTextField {
-                                id: grinderBrandInput
-                                Layout.fillWidth: true
-                                text: root.fGrinderBrand
-                                placeholder: TranslationManager.translate("changebeans.form.grinderBrand.placeholder", "Brand")
-                                accessibleName: TranslationManager.translate("changebeans.form.grinderBrand.accessible", "Grinder brand")
-                                onTextEdited: root.fGrinderBrand = text
-                            }
-
-                            StyledTextField {
-                                id: grinderModelInput
-                                Layout.fillWidth: true
-                                text: root.fGrinderModel
-                                placeholder: TranslationManager.translate("changebeans.form.grinderModel.placeholder", "Model")
-                                accessibleName: TranslationManager.translate("changebeans.form.grinderModel.accessible", "Grinder model")
-                                onTextEdited: root.fGrinderModel = text
-                            }
-
-                            StyledTextField {
-                                id: grinderBurrsInput
-                                Layout.fillWidth: true
-                                text: root.fGrinderBurrs
-                                placeholder: TranslationManager.translate("changebeans.form.grinderBurrs.placeholder", "Burrs")
-                                accessibleName: TranslationManager.translate("changebeans.form.grinderBurrs.accessible", "Grinder burrs")
-                                onTextEdited: root.fGrinderBurrs = text
-                            }
-                        }
-
                     }
 
                     // Error message (create failure / validation)

--- a/qml/components/ChangeBeansDialog.qml
+++ b/qml/components/ChangeBeansDialog.qml
@@ -55,7 +55,15 @@ Dialog {
     property bool fLinkDirty: false
     // Grinder identity (brand/model/burrs) is owned by the equipment package, not
     // the bag (add-equipment-packages); only the grind-setting dial-in stays here.
+    // The bag points at a package via fEquipmentId; brand/model/burrs are the
+    // resolved read-only display (refreshed via EquipmentStorage.packageReady).
     property string fGrinderSetting: ""
+    property int fEquipmentId: -1
+    property string fEquipmentBrand: ""
+    property string fEquipmentModel: ""
+    property string fEquipmentBurrs: ""
+    readonly property string fEquipmentLabel:
+        [fEquipmentBrand, fEquipmentModel].filter(function(s){ return s && s.length > 0 }).join(" ")
     property string fDose: ""         // text form; "" = unset
     property string fYield: ""
     property string fNotes: ""
@@ -177,6 +185,7 @@ Dialog {
         fBeanBaseId = ""; fBeanBaseData = ""
         fLinkDirty = false
         fGrinderSetting = ""
+        fEquipmentId = -1; fEquipmentBrand = ""; fEquipmentModel = ""; fEquipmentBurrs = ""
         fDose = ""; fYield = ""; fNotes = ""
         fFreeze = false; fFrozenDate = ""; fDefrostDate = ""
         identityKnown = false
@@ -190,6 +199,12 @@ Dialog {
         fBeanBaseId = bag.beanBaseId ? String(bag.beanBaseId) : ""
         fBeanBaseData = bag.beanBaseData || ""
         fGrinderSetting = bag.grinderSetting || ""
+        fEquipmentId = bag.equipmentId || -1
+        // Resolve the package's grinder identity for the read-only label
+        // (packageReady fills fEquipmentBrand/Model/Burrs below).
+        fEquipmentBrand = ""; fEquipmentModel = ""; fEquipmentBurrs = ""
+        if (fEquipmentId > 0 && MainController.equipmentStorage)
+            MainController.equipmentStorage.requestPackage(fEquipmentId)
         // toFixed(1) (not String()) so a non-exact double like 37.8 prefills as
         // "37.8", not "37.800000000000004" — matching the brew-settings format.
         fDose = (bag.doseWeightG ?? 0) > 0 ? Number(bag.doseWeightG).toFixed(1) : ""
@@ -329,9 +344,15 @@ Dialog {
         }
         if (formMode === "edit") {
             fields["defrostDate"] = fFreeze ? (fDefrostDate.replace(/_/g, "").length === 10 ? fDefrostDate : "") : ""
+            // Re-point the bag's equipment package (<=0 -> NULL via the column hook).
+            fields["equipmentId"] = fEquipmentId
             // A link change fixes the whole bag: propagate the (new or
             // cleared) canonical link onto every shot referencing it.
             MainController.bagStorage.requestUpdateBag(editBagId, fields, fLinkDirty)
+            // If this is the active bag, sync the active equipment selection so
+            // Brew Settings reflects the change.
+            if (editBagId === Settings.dye.activeBagId)
+                Settings.dye.activeEquipmentId = fEquipmentId > 0 ? fEquipmentId : -1
             root.close()
         } else {
             fields["defrostDate"] = ""
@@ -353,6 +374,31 @@ Dialog {
             }
             root.applySelection(bagId, bag)
             root.close()
+        }
+    }
+
+    // Re-point THIS bag's equipment package. The picker doesn't switch the
+    // active bag (applyToActiveBag:false); we record the chosen id and resolve
+    // its grinder identity for the label via packageReady below. Persisted on
+    // Save (fields.equipmentId).
+    SwitchEquipmentDialog {
+        id: bagEquipmentDialog
+        applyToActiveBag: false
+        onPackageSaved: function(packageId) {
+            root.fEquipmentId = packageId
+            if (MainController.equipmentStorage)
+                MainController.equipmentStorage.requestPackage(packageId)
+        }
+    }
+    Connections {
+        target: MainController.equipmentStorage
+        // Fills the read-only label for whichever package this bag now points at
+        // (both the edit-open prefill and a fresh pick funnel through fEquipmentId).
+        function onPackageReady(packageId, pkg) {
+            if (packageId !== root.fEquipmentId) return
+            root.fEquipmentBrand = pkg.grinderBrand || ""
+            root.fEquipmentModel = pkg.grinderModel || ""
+            root.fEquipmentBurrs = pkg.grinderBurrs || ""
         }
     }
 
@@ -1010,6 +1056,34 @@ Dialog {
                             text: root.fGrinderSetting
                             accessibleName: TranslationManager.translate("changebeans.form.grindSetting.accessible", "Grinder setting")
                             onTextEdited: root.fGrinderSetting = text
+                        }
+                    }
+
+                    // Equipment package (read-only identity + re-point button).
+                    // Grinder brand/model/burrs are owned by the package, not the
+                    // bag; tap Switch/Add to point this bag at a different package.
+                    FieldRow {
+                        labelKey: "changebeans.form.equipment"
+                        labelFallback: "Equipment:"
+
+                        Text {
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                            text: root.fEquipmentLabel.length > 0
+                                  ? root.fEquipmentLabel
+                                        + (root.fEquipmentBurrs.length > 0 ? " · " + root.fEquipmentBurrs : "")
+                                  : TranslationManager.translate("changebeans.form.equipmentNotSet", "Not set")
+                            font: Theme.bodyFont
+                            color: root.fEquipmentLabel.length > 0 ? Theme.textColor : Theme.textSecondaryColor
+                            Accessible.role: Accessible.StaticText
+                            Accessible.name: TranslationManager.translate("changebeans.form.equipment", "Equipment:") + " " + text
+                        }
+                        AccessibleButton {
+                            text: root.fEquipmentLabel.length > 0
+                                  ? TranslationManager.translate("changebeans.form.switchEquipment", "Switch")
+                                  : TranslationManager.translate("changebeans.form.addEquipment", "Add")
+                            accessibleName: TranslationManager.translate("changebeans.form.switchEquipmentAccessible", "Switch equipment package")
+                            onClicked: bagEquipmentDialog.openPicker()
                         }
                     }
 

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -1,0 +1,189 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Decenza
+
+// Equipment package card (add-equipment-packages). Mirrors BagCard. Shows the
+// grinder identity (brand/model, burrs subtitle), an RPM-adjustable hint, and
+// the last-used dial. Equipment is switched per-bag from Brew Settings, so the
+// card itself is informational + edit/remove (no global "selected" state). One
+// removal action follows the package's life: a trash icon while no bag/shot
+// references it (a mistaken creation — hard delete), then "Remove" once
+// references exist (soft-delete, history kept).
+Rectangle {
+    id: card
+
+    property var pkg: ({})
+
+    signal editRequested(var pkg)
+
+    readonly property bool hasReferences: pkg && (pkg.shotCount ?? 0) > 0
+    readonly property string grinderTitle: {
+        var brand = (pkg && pkg.grinderBrand) || ""
+        var model = (pkg && pkg.grinderModel) || ""
+        var combined = [brand, model].filter(function(s) { return s.length > 0 }).join(" ")
+        return (pkg && pkg.name && String(pkg.name).length > 0) ? String(pkg.name) : combined
+    }
+    readonly property string burrs: (pkg && pkg.grinderBurrs) || ""
+    readonly property bool rpmCapable: !!(pkg && pkg.rpmCapable)
+
+    readonly property string lastDialLine: {
+        var _ = TranslationManager.translationVersion
+        var parts = []
+        var g = (pkg && pkg.lastGrindSetting) || ""
+        if (String(g).length > 0)
+            parts.push(TranslationManager.translate("equipment.card.lastGrind", "Grind %1").arg(g))
+        var rpm = pkg && pkg.lastRpm ? Number(pkg.lastRpm) : 0
+        if (rpmCapable && rpm > 0)
+            parts.push(TranslationManager.translate("equipment.card.lastRpm", "%1 rpm").arg(rpm))
+        return parts.join(" · ")
+    }
+
+    readonly property string accessibleSummary: {
+        var bits = [grinderTitle, burrs].filter(function(s) { return s.length > 0 })
+        if (lastDialLine.length > 0) bits.push(lastDialLine)
+        return bits.join(", ")
+    }
+
+    color: Theme.surfaceColor
+    radius: Theme.cardRadius
+    border.width: 1
+    border.color: Theme.borderColor
+
+    implicitWidth: Theme.scaled(360)
+    implicitHeight: cardColumn.implicitHeight + Theme.scaled(24)
+
+    Accessible.ignored: true
+
+    Timer {
+        id: deleteRefusedTimer
+        interval: 4000  // UI auto-dismiss (allowed timer use)
+        onTriggered: deleteRefusedText.visible = false
+    }
+
+    Connections {
+        target: MainController.equipmentStorage
+        function onPackageDeleted(packageId, success) {
+            if (!card.pkg || packageId !== card.pkg.id || success) return
+            deleteRefusedText.visible = true
+            deleteRefusedTimer.restart()
+            if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled)
+                AccessibilityManager.announce(deleteRefusedText.text)
+        }
+    }
+
+    ColumnLayout {
+        id: cardColumn
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.margins: Theme.scaled(12)
+        spacing: Theme.scaled(6)
+
+        Item {
+            id: infoArea
+            Layout.fillWidth: true
+            implicitHeight: infoColumn.implicitHeight
+
+            ColumnLayout {
+                id: infoColumn
+                anchors.left: parent.left
+                anchors.right: parent.right
+                spacing: Theme.scaled(2)
+
+                Text {
+                    Layout.fillWidth: true
+                    text: card.grinderTitle
+                    font.family: Theme.bodyFont.family
+                    font.pixelSize: Theme.subtitleFont.pixelSize
+                    font.bold: true
+                    color: Theme.textColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
+
+                Text {
+                    Layout.fillWidth: true
+                    visible: card.burrs.length > 0
+                    text: card.burrs
+                    font: Theme.labelFont
+                    color: Theme.textSecondaryColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
+
+                Text {
+                    Layout.fillWidth: true
+                    visible: card.lastDialLine.length > 0
+                    text: card.lastDialLine
+                    font: Theme.captionFont
+                    color: Theme.textColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
+
+                Text {
+                    Layout.fillWidth: true
+                    visible: card.rpmCapable
+                    text: TranslationManager.translate("equipment.card.rpmAdjustable", "RPM adjustable")
+                    font: Theme.captionFont
+                    color: Theme.textSecondaryColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
+            }
+
+            AccessibleMouseArea {
+                anchors.fill: parent
+                accessibleName: card.accessibleSummary
+                accessibleItem: infoArea
+                onAccessibleClicked: card.editRequested(card.pkg)
+            }
+        }
+
+        Tr {
+            id: deleteRefusedText
+            visible: false
+            Layout.fillWidth: true
+            key: "equipment.card.deleteRefused"
+            fallback: "This package is used by bags or shots — use Remove instead"
+            font: Theme.captionFont
+            color: Theme.warningColor
+            wrapMode: Text.Wrap
+        }
+
+        Flow {
+            Layout.fillWidth: true
+            spacing: Theme.scaled(6)
+
+            AccessibleButton {
+                visible: card.hasReferences
+                height: Theme.scaled(36)
+                _customFontSize: Theme.captionFont.pixelSize
+                leftPadding: Theme.scaled(10)
+                rightPadding: Theme.scaled(10)
+                text: TranslationManager.translate("equipment.card.remove", "Remove")
+                accessibleName: TranslationManager.translate("equipment.card.accessible.remove", "Remove this equipment from inventory; history is kept")
+                onClicked: MainController.equipmentStorage.requestMarkRemoved(card.pkg.id)
+            }
+
+            StyledIconButton {
+                width: Theme.scaled(36)
+                height: Theme.scaled(36)
+                icon.source: "qrc:/icons/edit.svg"
+                accessibleName: TranslationManager.translate("equipment.card.accessible.edit", "Edit equipment details")
+                onClicked: card.editRequested(card.pkg)
+            }
+
+            StyledIconButton {
+                visible: !card.hasReferences
+                width: Theme.scaled(36)
+                height: Theme.scaled(36)
+                icon.source: "qrc:/icons/trash.svg"
+                accessibleName: TranslationManager.translate("equipment.card.accessible.delete", "Delete equipment")
+                accessibleDescription: TranslationManager.translate("equipment.card.accessible.deleteHint", "Deletes this unused equipment package entirely")
+                onClicked: MainController.equipmentStorage.requestDeletePackage(card.pkg.id)
+            }
+        }
+    }
+}

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -7,9 +7,11 @@ import Decenza
 // grinder identity (brand/model, burrs subtitle), an RPM-adjustable hint, and
 // the last-used dial. Equipment is switched per-bag from Brew Settings, so the
 // card itself is informational + edit/remove (no global "selected" state). One
-// removal action follows the package's life: a trash icon while no bag/shot
-// references it (a mistaken creation — hard delete), then "Remove" once
-// references exist (soft-delete, history kept).
+// removal action follows the package's life: a trash icon while no SHOT
+// references it (a mistaken creation — hard delete), then "Remove" once shots
+// exist (soft-delete, history kept). Storage is the authoritative backstop — it
+// also refuses a hard delete when a bag references the package, surfacing the
+// deleteRefused toast in that (rarer) case.
 Rectangle {
     id: card
 

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -17,6 +17,7 @@ Rectangle {
 
     signal editRequested(var pkg)
 
+    readonly property bool selected: pkg && pkg.id !== undefined && pkg.id === Settings.dye.activeEquipmentId
     readonly property bool hasReferences: pkg && (pkg.shotCount ?? 0) > 0
     readonly property string grinderTitle: {
         var brand = (pkg && pkg.grinderBrand) || ""
@@ -42,13 +43,14 @@ Rectangle {
     readonly property string accessibleSummary: {
         var bits = [grinderTitle, burrs].filter(function(s) { return s.length > 0 })
         if (lastDialLine.length > 0) bits.push(lastDialLine)
+        if (selected) bits.push(TranslationManager.translate("accessibility.selected", "selected"))
         return bits.join(", ")
     }
 
     color: Theme.surfaceColor
     radius: Theme.cardRadius
-    border.width: 1
-    border.color: Theme.borderColor
+    border.width: selected ? 2 : 1
+    border.color: selected ? Theme.primaryColor : Theme.borderColor
 
     implicitWidth: Theme.scaled(360)
     implicitHeight: cardColumn.implicitHeight + Theme.scaled(24)
@@ -137,7 +139,10 @@ Rectangle {
                 anchors.fill: parent
                 accessibleName: card.accessibleSummary
                 accessibleItem: infoArea
-                onAccessibleClicked: card.editRequested(card.pkg)
+                onAccessibleClicked: {
+                    if (card.pkg && card.pkg.id !== undefined)
+                        Settings.dye.switchToEquipment(card.pkg)
+                }
             }
         }
 

--- a/qml/components/EquipmentInfoDialog.qml
+++ b/qml/components/EquipmentInfoDialog.qml
@@ -86,19 +86,17 @@ Dialog {
                 label: TranslationManager.translate("equipment.info.burrs", "Burrs")
                 value: (root.pkg && root.pkg.grinderBurrs) || ""
             }
-            InfoRow {
-                label: TranslationManager.translate("equipment.info.rpmAdjustable", "RPM adjustable")
-                value: (root.pkg && root.pkg.rpmCapable)
-                       ? TranslationManager.translate("common.yes", "Yes")
-                       : TranslationManager.translate("common.no", "No")
-            }
+            // Last dial — grind setting, plus the last RPM appended only when the
+            // grinder is rpm-adjustable (saves a row vs. a separate RPM line).
             InfoRow {
                 label: TranslationManager.translate("equipment.info.lastGrind", "Last grind")
-                value: (root.pkg && root.pkg.lastGrindSetting) || ""
-            }
-            InfoRow {
-                label: TranslationManager.translate("equipment.info.lastRpm", "Last RPM")
-                value: (root.pkg && root.pkg.lastRpm > 0) ? String(root.pkg.lastRpm) : ""
+                value: {
+                    var g = (root.pkg && root.pkg.lastGrindSetting) || ""
+                    var showRpm = root.pkg && root.pkg.rpmCapable && root.pkg.lastRpm > 0
+                    return showRpm ? (g.length > 0 ? g + "  ·  " + root.pkg.lastRpm + " rpm"
+                                                   : root.pkg.lastRpm + " rpm")
+                                   : g
+                }
             }
 
             AccessibleButton {

--- a/qml/components/EquipmentInfoDialog.qml
+++ b/qml/components/EquipmentInfoDialog.qml
@@ -1,0 +1,139 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Decenza
+
+// Read-only details of a single equipment package (add-equipment-packages).
+// Opened from the info button on any equipment line (Brew Settings, Shot Review,
+// Edit Bag). Call openFor(packageId) — it resolves the package async and shows
+// its name, grinder identity, RPM capability, and last dial.
+Dialog {
+    id: root
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+    width: Math.min(Theme.scaled(460), parent ? parent.width * 0.95 : Theme.scaled(460))
+    modal: true
+    closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
+    padding: 0
+
+    property int packageId: -1
+    property var pkg: ({})
+
+    function openFor(id) {
+        packageId = id
+        pkg = ({})
+        if (id > 0 && MainController.equipmentStorage)
+            MainController.equipmentStorage.requestPackage(id)
+        open()
+    }
+
+    Connections {
+        target: MainController.equipmentStorage
+        function onPackageReady(pid, p) {
+            if (pid !== root.packageId) return
+            root.pkg = p || ({})
+        }
+    }
+
+    readonly property string pkgName: (pkg && pkg.name && String(pkg.name).length > 0)
+        ? String(pkg.name)
+        : [(pkg && pkg.grinderBrand) || "", (pkg && pkg.grinderModel) || ""]
+              .filter(function(s) { return s.length > 0 }).join(" ")
+
+    background: Rectangle {
+        color: Theme.surfaceColor
+        radius: Theme.cardRadius
+        border.color: Theme.borderColor
+        border.width: 1
+    }
+
+    contentItem: Item {
+        implicitHeight: infoColumn.implicitHeight + 2 * Theme.spacingMedium
+
+        ColumnLayout {
+            id: infoColumn
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.margins: Theme.spacingMedium
+            spacing: Theme.spacingSmall
+
+            Tr {
+                Layout.fillWidth: true
+                key: "equipment.info.title"
+                fallback: "Equipment"
+                font: Theme.titleFont
+                color: Theme.textColor
+                Accessible.role: Accessible.Heading
+                Accessible.name: text
+            }
+
+            Text {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                visible: root.pkgName.length > 0
+                text: root.pkgName
+                font: Theme.subtitleFont
+                color: Theme.textColor
+            }
+
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.grinder", "Grinder")
+                value: [(root.pkg && root.pkg.grinderBrand) || "", (root.pkg && root.pkg.grinderModel) || ""]
+                           .filter(function(s) { return s.length > 0 }).join(" ")
+            }
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.burrs", "Burrs")
+                value: (root.pkg && root.pkg.grinderBurrs) || ""
+            }
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.rpmAdjustable", "RPM adjustable")
+                value: (root.pkg && root.pkg.rpmCapable)
+                       ? TranslationManager.translate("common.yes", "Yes")
+                       : TranslationManager.translate("common.no", "No")
+            }
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.lastGrind", "Last grind")
+                value: (root.pkg && root.pkg.lastGrindSetting) || ""
+            }
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.lastRpm", "Last RPM")
+                value: (root.pkg && root.pkg.lastRpm > 0) ? String(root.pkg.lastRpm) : ""
+            }
+
+            AccessibleButton {
+                Layout.alignment: Qt.AlignRight
+                Layout.topMargin: Theme.spacingSmall
+                text: TranslationManager.translate("common.button.close", "Close")
+                accessibleName: text
+                onClicked: root.close()
+            }
+        }
+    }
+
+    // Label/value row; hides itself when the value is empty.
+    component InfoRow: RowLayout {
+        property string label: ""
+        property string value: ""
+        Layout.fillWidth: true
+        spacing: Theme.spacingMedium
+        visible: value.length > 0
+
+        Text {
+            text: label + ":"
+            font: Theme.labelFont
+            color: Theme.textSecondaryColor
+            Layout.preferredWidth: Theme.scaled(130)
+            Accessible.ignored: true
+        }
+        Text {
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+            text: value
+            font: Theme.bodyFont
+            color: Theme.textColor
+            Accessible.role: Accessible.StaticText
+            Accessible.name: label + ": " + value
+        }
+    }
+}

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -102,7 +102,8 @@ Dialog {
     }
 
     function packageTitle(pkg) {
-        if (pkg && pkg.name && String(pkg.name).length > 0) return String(pkg.name)
+        if (!pkg) return ""
+        if (pkg.name && String(pkg.name).length > 0) return String(pkg.name)
         return [pkg.grinderBrand || "", pkg.grinderModel || ""].filter(function(s) { return s.length > 0 }).join(" ")
     }
 
@@ -143,15 +144,20 @@ Dialog {
             Repeater {
                 model: root.packages
                 AccessibleButton {
+                    // modelData is transiently undefined while the var-array model
+                    // is reassigned (onInventoryReady) — fall back to an empty
+                    // object so the bindings below never dereference undefined.
+                    readonly property var pkg: modelData || ({})
                     Layout.fillWidth: true
                     Layout.preferredHeight: Theme.scaled(44)
-                    primary: modelData.id === Settings.dye.activeEquipmentId
-                    text: root.packageTitle(modelData)
-                          + (modelData.grinderBurrs && String(modelData.grinderBurrs).length > 0
-                             ? " · " + modelData.grinderBurrs : "")
-                    accessibleName: text + (modelData.id === Settings.dye.activeEquipmentId
+                    primary: pkg.id === Settings.dye.activeEquipmentId
+                    text: root.packageTitle(pkg)
+                          + (pkg.grinderBurrs && String(pkg.grinderBurrs).length > 0
+                             ? " · " + pkg.grinderBurrs : "")
+                    accessibleName: text + (pkg.id === Settings.dye.activeEquipmentId
                                             ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                     onClicked: {
+                        if (!modelData) return
                         Settings.dye.switchToEquipment(modelData)
                         root.packageSaved(modelData.id)
                         root.close()

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -120,6 +120,10 @@ Dialog {
     readonly property bool canSave: fBrand.trim().length > 0 || fModel.trim().length > 0
     property bool _awaitingCreate: false
 
+    EquipmentInfoDialog {
+        id: pickerInfoDialog
+    }
+
     background: Rectangle {
         color: Theme.surfaceColor
         radius: Theme.cardRadius
@@ -157,7 +161,8 @@ Dialog {
 
             Repeater {
                 model: root.packages
-                AccessibleButton {
+                RowLayout {
+                    id: pkgRow
                     // Declare modelData required so the Repeater assigns the
                     // QVariantMap element: inside this Dialog-content delegate the
                     // implicit context modelData/index did NOT resolve (rows
@@ -166,19 +171,33 @@ Dialog {
                     required property var modelData
                     readonly property var pkg: modelData || ({})
                     Layout.fillWidth: true
-                    Layout.preferredHeight: Theme.scaled(44)
-                    primary: !!modelData && pkg.id === Settings.dye.activeEquipmentId
-                    text: root.packageTitle(pkg)
-                          + (pkg.grinderBurrs && String(pkg.grinderBurrs).length > 0
-                             ? " · " + pkg.grinderBurrs : "")
-                    accessibleName: text + (!!modelData && pkg.id === Settings.dye.activeEquipmentId
-                                            ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
-                    onClicked: {
-                        if (!modelData) return
-                        if (root.applyToActiveBag)
-                            Settings.dye.switchToEquipment(modelData)
-                        root.packageSaved(modelData.id)
-                        root.close()
+                    spacing: Theme.spacingSmall
+
+                    // Select-this-package row — shows the package NAME only
+                    // (burrs/grinder identity live in the info popup).
+                    AccessibleButton {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Theme.scaled(44)
+                        primary: !!pkgRow.modelData && pkgRow.pkg.id === Settings.dye.activeEquipmentId
+                        text: root.packageTitle(pkgRow.pkg)
+                        accessibleName: text + (primary
+                                                ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
+                        onClicked: {
+                            if (!pkgRow.modelData) return
+                            if (root.applyToActiveBag)
+                                Settings.dye.switchToEquipment(pkgRow.modelData)
+                            root.packageSaved(pkgRow.modelData.id)
+                            root.close()
+                        }
+                    }
+
+                    // Info: show this package's full contents.
+                    AccessibleButton {
+                        Layout.preferredHeight: Theme.scaled(44)
+                        visible: !!pkgRow.modelData && pkgRow.pkg.id > 0
+                        icon.source: "qrc:/icons/info.svg"
+                        accessibleName: TranslationManager.translate("equipment.info.button", "Equipment details")
+                        onClicked: pickerInfoDialog.openFor(pkgRow.pkg.id)
                     }
                 }
             }

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -29,6 +29,12 @@ Dialog {
     property string fModel: ""
     property string fBurrs: ""
 
+    // When true (default, the Brew Settings / Equipment-window use), selecting or
+    // creating a package switches the ACTIVE bag's equipment. When false, the
+    // dialog is a pure picker for a specific shot/bag: it does NOT touch the
+    // active selection — the caller applies the result via packageSaved(id).
+    property bool applyToActiveBag: true
+
     signal packageSaved(int packageId)
 
     onAboutToShow: if (mode === "list") MainController.equipmentStorage.requestInventory()
@@ -44,8 +50,10 @@ Dialog {
             if (!root._awaitingCreate) return
             root._awaitingCreate = false
             if (packageId > 0) {
-                // A freshly added package becomes the active equipment.
-                Settings.dye.switchToEquipment(pkg)
+                // A freshly added package becomes the active equipment (unless the
+                // dialog is targeting a specific shot/bag — then the caller applies it).
+                if (root.applyToActiveBag)
+                    Settings.dye.switchToEquipment(pkg)
                 root.packageSaved(packageId)
             }
             root.close()
@@ -162,7 +170,8 @@ Dialog {
                                             ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                     onClicked: {
                         if (!modelData) return
-                        Settings.dye.switchToEquipment(modelData)
+                        if (root.applyToActiveBag)
+                            Settings.dye.switchToEquipment(modelData)
                         root.packageSaved(modelData.id)
                         root.close()
                     }

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -156,25 +156,26 @@ Dialog {
             Repeater {
                 model: root.packages
                 AccessibleButton {
-                    // Read the package by index from the source array rather than
-                    // modelData: inside this Dialog-content delegate modelData did
-                    // not resolve the QVariantMap (rows rendered blank). index is
-                    // always valid; guard against the transient reassignment window.
-                    readonly property var pkg: (root.packages && index >= 0 && index < root.packages.length)
-                                               ? root.packages[index] : null
+                    // Declare modelData required so the Repeater assigns the
+                    // QVariantMap element: inside this Dialog-content delegate the
+                    // implicit context modelData/index did NOT resolve (rows
+                    // rendered blank; index threw ReferenceError). A required
+                    // property is bound by the view, so pkg gets the real package.
+                    required property var modelData
+                    readonly property var pkg: modelData || ({})
                     Layout.fillWidth: true
                     Layout.preferredHeight: Theme.scaled(44)
-                    primary: !!pkg && pkg.id === Settings.dye.activeEquipmentId
+                    primary: !!modelData && pkg.id === Settings.dye.activeEquipmentId
                     text: root.packageTitle(pkg)
-                          + (pkg && pkg.grinderBurrs && String(pkg.grinderBurrs).length > 0
+                          + (pkg.grinderBurrs && String(pkg.grinderBurrs).length > 0
                              ? " · " + pkg.grinderBurrs : "")
-                    accessibleName: text + (!!pkg && pkg.id === Settings.dye.activeEquipmentId
+                    accessibleName: text + (!!modelData && pkg.id === Settings.dye.activeEquipmentId
                                             ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                     onClicked: {
-                        if (!pkg || pkg.id === undefined) return
+                        if (!modelData) return
                         if (root.applyToActiveBag)
-                            Settings.dye.switchToEquipment(pkg)
-                        root.packageSaved(pkg.id)
+                            Settings.dye.switchToEquipment(modelData)
+                        root.packageSaved(modelData.id)
                         root.close()
                     }
                 }

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -186,8 +186,11 @@ Dialog {
         function onPackageCreated(packageId, pkg) {
             if (!root._awaitingCreate) return
             root._awaitingCreate = false
-            if (packageId > 0)
+            if (packageId > 0) {
+                // A freshly added package becomes the active equipment.
+                Settings.dye.switchToEquipment(pkg)
                 root.packageSaved(packageId)
+            }
             root.close()
         }
     }

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -118,7 +118,11 @@ Dialog {
     }
 
     contentItem: Item {
-        implicitHeight: (root.mode === "list" ? listColumn.implicitHeight : formContainer.implicitHeight)
+        // Size to the active mode's inner ColumnLayout. NOTE: reference
+        // formColumn (the layout), not formContainer (the KeyboardAwareContainer)
+        // — the container's child fills it via anchors, so the container's own
+        // implicitHeight is 0 and the dialog would collapse to just the header.
+        implicitHeight: (root.mode === "list" ? listColumn.implicitHeight : formColumn.implicitHeight)
                         + 2 * Theme.spacingMedium
 
         // --- LIST (picker) ---
@@ -190,6 +194,7 @@ Dialog {
             textFields: [brandField.textField, modelField.textField, burrsField.textField]
 
             ColumnLayout {
+                id: formColumn
                 anchors.fill: parent
                 anchors.margins: Theme.spacingMedium
                 spacing: Theme.spacingMedium

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -3,12 +3,14 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Decenza
 
-// Create / edit an equipment package (add-equipment-packages). v1 covers the
-// grinder component: brand / model / burrs with registry-backed suggestions
-// (the same sources the old Brew Settings grinder fields used). rpmCapable is
-// derived from the registry in storage, not entered here. Picking an existing
-// package to switch the active bag is handled inline on the Equipment page /
-// Brew Settings; this dialog is the add/edit form.
+// Switch / create / edit an equipment package (add-equipment-packages). Two
+// modes, mirroring ChangeBeansDialog:
+//   "list" -> pick an existing package (tap switches the active bag to it) or
+//             add a new one
+//   "form" -> create or edit a grinder package (brand/model/burrs with
+//             registry-backed suggestions; rpmCapable is derived in storage)
+// Opening with open() shows the picker; openForCreate()/openForEdit() jump
+// straight to the form.
 Dialog {
     id: root
     parent: Overlay.overlay
@@ -18,22 +20,49 @@ Dialog {
     closePolicy: Dialog.CloseOnEscape
     padding: 0
 
-    // "create" -> requestCreatePackage; "edit" -> requestUpdatePackage
-    property string formMode: "create"
+    property string mode: "list"          // "list" | "form"
+    property string formMode: "create"    // "create" | "edit"
     property int editPackageId: -1
 
+    property var packages: []
     property string fBrand: ""
     property string fModel: ""
     property string fBurrs: ""
 
     signal packageSaved(int packageId)
 
+    onAboutToShow: if (mode === "list") MainController.equipmentStorage.requestInventory()
+
+    Connections {
+        target: MainController.equipmentStorage
+        function onInventoryReady(list) { root.packages = list }
+        function onPackagesChanged() {
+            if (root.visible && root.mode === "list")
+                MainController.equipmentStorage.requestInventory()
+        }
+        function onPackageCreated(packageId, pkg) {
+            if (!root._awaitingCreate) return
+            root._awaitingCreate = false
+            if (packageId > 0) {
+                // A freshly added package becomes the active equipment.
+                Settings.dye.switchToEquipment(pkg)
+                root.packageSaved(packageId)
+            }
+            root.close()
+        }
+    }
+
+    // Open the picker (list of packages). onAboutToShow requests the inventory.
+    function openPicker() {
+        mode = "list"
+        open()
+    }
+
     function openForCreate() {
         formMode = "create"
         editPackageId = -1
-        fBrand = ""
-        fModel = ""
-        fBurrs = ""
+        fBrand = ""; fModel = ""; fBurrs = ""
+        mode = "form"
         open()
     }
 
@@ -43,6 +72,7 @@ Dialog {
         fBrand = (pkg && pkg.grinderBrand) || ""
         fModel = (pkg && pkg.grinderModel) || ""
         fBurrs = (pkg && pkg.grinderBurrs) || ""
+        mode = "form"
         open()
     }
 
@@ -54,18 +84,19 @@ Dialog {
         for (var j = 0; j < history.length; ++j) { if (history[j] && !seen[history[j]]) { seen[history[j]] = true; out.push(history[j]) } }
         return out
     }
-
-    function modelSuggestions() {
-        return Settings.dye.knownGrinderModels(root.fBrand)
-    }
-
+    function modelSuggestions() { return Settings.dye.knownGrinderModels(root.fBrand) }
     function burrsSuggestions() {
-        if (!Settings.dye.isBurrSwappable(root.fBrand, root.fModel))
-            return []
+        if (!Settings.dye.isBurrSwappable(root.fBrand, root.fModel)) return []
         return Settings.dye.suggestedBurrs(root.fBrand, root.fModel)
     }
 
+    function packageTitle(pkg) {
+        if (pkg && pkg.name && String(pkg.name).length > 0) return String(pkg.name)
+        return [pkg.grinderBrand || "", pkg.grinderModel || ""].filter(function(s) { return s.length > 0 }).join(" ")
+    }
+
     readonly property bool canSave: fBrand.trim().length > 0 || fModel.trim().length > 0
+    property bool _awaitingCreate: false
 
     background: Rectangle {
         color: Theme.surfaceColor
@@ -74,88 +105,152 @@ Dialog {
         border.width: 1
     }
 
-    contentItem: KeyboardAwareContainer {
-        textFields: [brandField.textField, modelField.textField, burrsField.textField]
+    contentItem: Item {
+        implicitHeight: (root.mode === "list" ? listColumn.implicitHeight : formContainer.implicitHeight)
+                        + 2 * Theme.spacingMedium
 
+        // --- LIST (picker) ---
         ColumnLayout {
-            anchors.fill: parent
+            id: listColumn
+            visible: root.mode === "list"
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
             anchors.margins: Theme.spacingMedium
             spacing: Theme.spacingMedium
 
             Tr {
                 Layout.fillWidth: true
-                key: root.formMode === "edit" ? "equipment.dialog.editTitle" : "equipment.dialog.addTitle"
-                fallback: root.formMode === "edit" ? "Edit Equipment" : "Add Equipment"
+                key: "equipment.dialog.switchTitle"
+                fallback: "Switch Equipment"
                 font: Theme.titleFont
                 color: Theme.textColor
                 Accessible.role: Accessible.Heading
                 Accessible.name: text
             }
 
-            SuggestionField {
-                id: brandField
-                Layout.fillWidth: true
-                label: TranslationManager.translate("equipment.dialog.brand", "Grinder brand")
-                accessibleName: label
-                text: root.fBrand
-                suggestions: root.brandSuggestions()
-                onTextEdited: function(t) { root.fBrand = t }
-                onSuggestionSelected: function(t) {
-                    root.fBrand = t
-                    var models = Settings.dye.knownGrinderModels(t)
-                    if (models.length === 1) {
-                        root.fModel = models[0]
-                        var burrs = Settings.dye.suggestedBurrs(t, models[0])
-                        if (burrs.length === 1) root.fBurrs = burrs[0]
+            Repeater {
+                model: root.packages
+                AccessibleButton {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: Theme.scaled(44)
+                    primary: modelData.id === Settings.dye.activeEquipmentId
+                    text: root.packageTitle(modelData)
+                          + (modelData.grinderBurrs && String(modelData.grinderBurrs).length > 0
+                             ? " · " + modelData.grinderBurrs : "")
+                    accessibleName: text + (modelData.id === Settings.dye.activeEquipmentId
+                                            ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
+                    onClicked: {
+                        Settings.dye.switchToEquipment(modelData)
+                        root.packageSaved(modelData.id)
+                        root.close()
                     }
                 }
             }
 
-            SuggestionField {
-                id: modelField
+            AccessibleButton {
                 Layout.fillWidth: true
-                label: TranslationManager.translate("equipment.dialog.model", "Grinder model")
-                accessibleName: label
-                text: root.fModel
-                suggestions: root.modelSuggestions()
-                onTextEdited: function(t) { root.fModel = t }
-                onSuggestionSelected: function(t) {
-                    root.fModel = t
-                    var burrs = Settings.dye.suggestedBurrs(root.fBrand, t)
-                    if (burrs.length === 1) root.fBurrs = burrs[0]
-                }
+                Layout.preferredHeight: Theme.scaled(44)
+                icon.source: "qrc:/icons/plus.svg"
+                text: TranslationManager.translate("equipment.dialog.addNew", "Add New Equipment")
+                accessibleName: text
+                onClicked: root.openForCreate()
             }
 
-            SuggestionField {
-                id: burrsField
-                Layout.fillWidth: true
-                label: TranslationManager.translate("equipment.dialog.burrs", "Burrs")
-                accessibleName: label
-                text: root.fBurrs
-                suggestions: root.burrsSuggestions()
-                onTextEdited: function(t) { root.fBurrs = t }
-                onSuggestionSelected: function(t) { root.fBurrs = t }
+            AccessibleButton {
+                Layout.alignment: Qt.AlignRight
+                text: TranslationManager.translate("common.button.cancel", "Cancel")
+                accessibleName: text
+                onClicked: root.close()
             }
+        }
 
-            RowLayout {
-                Layout.fillWidth: true
-                Layout.topMargin: Theme.spacingSmall
+        // --- FORM (create / edit) ---
+        KeyboardAwareContainer {
+            id: formContainer
+            visible: root.mode === "form"
+            anchors.fill: parent
+            textFields: [brandField.textField, modelField.textField, burrsField.textField]
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: Theme.spacingMedium
                 spacing: Theme.spacingMedium
 
-                Item { Layout.fillWidth: true }
-
-                AccessibleButton {
-                    text: TranslationManager.translate("common.button.cancel", "Cancel")
-                    accessibleName: text
-                    onClicked: root.close()
+                Tr {
+                    Layout.fillWidth: true
+                    key: root.formMode === "edit" ? "equipment.dialog.editTitle" : "equipment.dialog.addTitle"
+                    fallback: root.formMode === "edit" ? "Edit Equipment" : "Add Equipment"
+                    font: Theme.titleFont
+                    color: Theme.textColor
+                    Accessible.role: Accessible.Heading
+                    Accessible.name: text
                 }
 
-                AccessibleButton {
-                    primary: true
-                    enabled: root.canSave
-                    text: TranslationManager.translate("common.button.save", "Save")
-                    accessibleName: text
-                    onClicked: root.save()
+                SuggestionField {
+                    id: brandField
+                    Layout.fillWidth: true
+                    label: TranslationManager.translate("equipment.dialog.brand", "Grinder brand")
+                    accessibleName: label
+                    text: root.fBrand
+                    suggestions: root.brandSuggestions()
+                    onTextEdited: function(t) { root.fBrand = t }
+                    onSuggestionSelected: function(t) {
+                        root.fBrand = t
+                        var models = Settings.dye.knownGrinderModels(t)
+                        if (models.length === 1) {
+                            root.fModel = models[0]
+                            var burrs = Settings.dye.suggestedBurrs(t, models[0])
+                            if (burrs.length === 1) root.fBurrs = burrs[0]
+                        }
+                    }
+                }
+
+                SuggestionField {
+                    id: modelField
+                    Layout.fillWidth: true
+                    label: TranslationManager.translate("equipment.dialog.model", "Grinder model")
+                    accessibleName: label
+                    text: root.fModel
+                    suggestions: root.modelSuggestions()
+                    onTextEdited: function(t) { root.fModel = t }
+                    onSuggestionSelected: function(t) {
+                        var burrs = Settings.dye.suggestedBurrs(root.fBrand, t)
+                        if (burrs.length === 1) root.fBurrs = burrs[0]
+                    }
+                }
+
+                SuggestionField {
+                    id: burrsField
+                    Layout.fillWidth: true
+                    label: TranslationManager.translate("equipment.dialog.burrs", "Burrs")
+                    accessibleName: label
+                    text: root.fBurrs
+                    suggestions: root.burrsSuggestions()
+                    onTextEdited: function(t) { root.fBurrs = t }
+                    onSuggestionSelected: function(t) { root.fBurrs = t }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.topMargin: Theme.spacingSmall
+                    spacing: Theme.spacingMedium
+
+                    Item { Layout.fillWidth: true }
+
+                    AccessibleButton {
+                        text: TranslationManager.translate("common.button.cancel", "Cancel")
+                        accessibleName: text
+                        onClicked: root.close()
+                    }
+
+                    AccessibleButton {
+                        primary: true
+                        enabled: root.canSave
+                        text: TranslationManager.translate("common.button.save", "Save")
+                        accessibleName: text
+                        onClicked: root.save()
+                    }
                 }
             }
         }
@@ -174,24 +269,7 @@ Dialog {
             close()
         } else {
             MainController.equipmentStorage.requestCreatePackage(fields)
-            // packageCreated carries the new id; surface it then close.
             _awaitingCreate = true
-        }
-    }
-
-    property bool _awaitingCreate: false
-
-    Connections {
-        target: MainController.equipmentStorage
-        function onPackageCreated(packageId, pkg) {
-            if (!root._awaitingCreate) return
-            root._awaitingCreate = false
-            if (packageId > 0) {
-                // A freshly added package becomes the active equipment.
-                Settings.dye.switchToEquipment(pkg)
-                root.packageSaved(packageId)
-            }
-            root.close()
         }
     }
 }

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -25,6 +25,7 @@ Dialog {
     property int editPackageId: -1
 
     property var packages: []
+    property string fName: ""          // user label; blank -> storage derives "{brand} {model}"
     property string fBrand: ""
     property string fModel: ""
     property string fBurrs: ""
@@ -80,7 +81,7 @@ Dialog {
     function openForCreate() {
         formMode = "create"
         editPackageId = -1
-        fBrand = ""; fModel = ""; fBurrs = ""
+        fName = ""; fBrand = ""; fModel = ""; fBurrs = ""
         mode = "form"
         open()
     }
@@ -88,6 +89,7 @@ Dialog {
     function openForEdit(pkg) {
         formMode = "edit"
         editPackageId = pkg && pkg.id !== undefined ? pkg.id : -1
+        fName = (pkg && pkg.name) || ""
         fBrand = (pkg && pkg.grinderBrand) || ""
         fModel = (pkg && pkg.grinderModel) || ""
         fBurrs = (pkg && pkg.grinderBurrs) || ""
@@ -203,7 +205,7 @@ Dialog {
             id: formContainer
             visible: root.mode === "form"
             anchors.fill: parent
-            textFields: [brandField.textField, modelField.textField, burrsField.textField]
+            textFields: [nameField.textField, brandField.textField, modelField.textField, burrsField.textField]
 
             ColumnLayout {
                 id: formColumn
@@ -219,6 +221,18 @@ Dialog {
                     color: Theme.textColor
                     Accessible.role: Accessible.Heading
                     Accessible.name: text
+                }
+
+                // User-editable label (add-equipment-packages 4b.1). Blank uses the
+                // derived "{brand} {model}"; set it to a kit name like "Espresso setup".
+                SuggestionField {
+                    id: nameField
+                    Layout.fillWidth: true
+                    label: TranslationManager.translate("equipment.dialog.name", "Name (optional)")
+                    accessibleName: label
+                    text: root.fName
+                    suggestions: []
+                    onTextEdited: function(t) { root.fName = t }
                 }
 
                 SuggestionField {
@@ -293,6 +307,9 @@ Dialog {
     function save() {
         Qt.inputMethod.commit()
         var fields = {
+            // Blank name -> storage derives "{brand} {model}" on create, or clears
+            // the custom label (display falls back to brand+model) on edit.
+            "name": fName.trim(),
             "grinderBrand": fBrand.trim(),
             "grinderModel": fModel.trim(),
             "grinderBurrs": fBurrs.trim()

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -1,0 +1,194 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Decenza
+
+// Create / edit an equipment package (add-equipment-packages). v1 covers the
+// grinder component: brand / model / burrs with registry-backed suggestions
+// (the same sources the old Brew Settings grinder fields used). rpmCapable is
+// derived from the registry in storage, not entered here. Picking an existing
+// package to switch the active bag is handled inline on the Equipment page /
+// Brew Settings; this dialog is the add/edit form.
+Dialog {
+    id: root
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+    width: Math.min(Theme.scaled(520), parent ? parent.width * 0.95 : Theme.scaled(520))
+    modal: true
+    closePolicy: Dialog.CloseOnEscape
+    padding: 0
+
+    // "create" -> requestCreatePackage; "edit" -> requestUpdatePackage
+    property string formMode: "create"
+    property int editPackageId: -1
+
+    property string fBrand: ""
+    property string fModel: ""
+    property string fBurrs: ""
+
+    signal packageSaved(int packageId)
+
+    function openForCreate() {
+        formMode = "create"
+        editPackageId = -1
+        fBrand = ""
+        fModel = ""
+        fBurrs = ""
+        open()
+    }
+
+    function openForEdit(pkg) {
+        formMode = "edit"
+        editPackageId = pkg && pkg.id !== undefined ? pkg.id : -1
+        fBrand = (pkg && pkg.grinderBrand) || ""
+        fModel = (pkg && pkg.grinderModel) || ""
+        fBurrs = (pkg && pkg.grinderBurrs) || ""
+        open()
+    }
+
+    function brandSuggestions() {
+        var known = Settings.dye.knownGrinderBrands()
+        var history = MainController.shotHistory ? MainController.shotHistory.getDistinctGrinderBrands() : []
+        var seen = {}, out = []
+        for (var i = 0; i < known.length; ++i) { if (!seen[known[i]]) { seen[known[i]] = true; out.push(known[i]) } }
+        for (var j = 0; j < history.length; ++j) { if (history[j] && !seen[history[j]]) { seen[history[j]] = true; out.push(history[j]) } }
+        return out
+    }
+
+    function modelSuggestions() {
+        return Settings.dye.knownGrinderModels(root.fBrand)
+    }
+
+    function burrsSuggestions() {
+        if (!Settings.dye.isBurrSwappable(root.fBrand, root.fModel))
+            return []
+        return Settings.dye.suggestedBurrs(root.fBrand, root.fModel)
+    }
+
+    readonly property bool canSave: fBrand.trim().length > 0 || fModel.trim().length > 0
+
+    background: Rectangle {
+        color: Theme.surfaceColor
+        radius: Theme.cardRadius
+        border.color: Theme.borderColor
+        border.width: 1
+    }
+
+    contentItem: KeyboardAwareContainer {
+        textFields: [brandField.textField, modelField.textField, burrsField.textField]
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: Theme.spacingMedium
+            spacing: Theme.spacingMedium
+
+            Tr {
+                Layout.fillWidth: true
+                key: root.formMode === "edit" ? "equipment.dialog.editTitle" : "equipment.dialog.addTitle"
+                fallback: root.formMode === "edit" ? "Edit Equipment" : "Add Equipment"
+                font: Theme.titleFont
+                color: Theme.textColor
+                Accessible.role: Accessible.Heading
+                Accessible.name: text
+            }
+
+            SuggestionField {
+                id: brandField
+                Layout.fillWidth: true
+                label: TranslationManager.translate("equipment.dialog.brand", "Grinder brand")
+                accessibleName: label
+                text: root.fBrand
+                suggestions: root.brandSuggestions()
+                onTextEdited: function(t) { root.fBrand = t }
+                onSuggestionSelected: function(t) {
+                    root.fBrand = t
+                    var models = Settings.dye.knownGrinderModels(t)
+                    if (models.length === 1) {
+                        root.fModel = models[0]
+                        var burrs = Settings.dye.suggestedBurrs(t, models[0])
+                        if (burrs.length === 1) root.fBurrs = burrs[0]
+                    }
+                }
+            }
+
+            SuggestionField {
+                id: modelField
+                Layout.fillWidth: true
+                label: TranslationManager.translate("equipment.dialog.model", "Grinder model")
+                accessibleName: label
+                text: root.fModel
+                suggestions: root.modelSuggestions()
+                onTextEdited: function(t) { root.fModel = t }
+                onSuggestionSelected: function(t) {
+                    root.fModel = t
+                    var burrs = Settings.dye.suggestedBurrs(root.fBrand, t)
+                    if (burrs.length === 1) root.fBurrs = burrs[0]
+                }
+            }
+
+            SuggestionField {
+                id: burrsField
+                Layout.fillWidth: true
+                label: TranslationManager.translate("equipment.dialog.burrs", "Burrs")
+                accessibleName: label
+                text: root.fBurrs
+                suggestions: root.burrsSuggestions()
+                onTextEdited: function(t) { root.fBurrs = t }
+                onSuggestionSelected: function(t) { root.fBurrs = t }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.spacingSmall
+                spacing: Theme.spacingMedium
+
+                Item { Layout.fillWidth: true }
+
+                AccessibleButton {
+                    text: TranslationManager.translate("common.button.cancel", "Cancel")
+                    accessibleName: text
+                    onClicked: root.close()
+                }
+
+                AccessibleButton {
+                    primary: true
+                    enabled: root.canSave
+                    text: TranslationManager.translate("common.button.save", "Save")
+                    accessibleName: text
+                    onClicked: root.save()
+                }
+            }
+        }
+    }
+
+    function save() {
+        Qt.inputMethod.commit()
+        var fields = {
+            "grinderBrand": fBrand.trim(),
+            "grinderModel": fModel.trim(),
+            "grinderBurrs": fBurrs.trim()
+        }
+        if (formMode === "edit" && editPackageId > 0) {
+            MainController.equipmentStorage.requestUpdatePackage(editPackageId, fields)
+            packageSaved(editPackageId)
+            close()
+        } else {
+            MainController.equipmentStorage.requestCreatePackage(fields)
+            // packageCreated carries the new id; surface it then close.
+            _awaitingCreate = true
+        }
+    }
+
+    property bool _awaitingCreate: false
+
+    Connections {
+        target: MainController.equipmentStorage
+        function onPackageCreated(packageId, pkg) {
+            if (!root._awaitingCreate) return
+            root._awaitingCreate = false
+            if (packageId > 0)
+                root.packageSaved(packageId)
+            root.close()
+        }
+    }
+}

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -50,6 +50,17 @@ Dialog {
             }
             root.close()
         }
+        function onPackageUpdated(resultId, success) {
+            if (!root._awaitingEdit) return
+            root._awaitingEdit = false
+            // If the edited package was active, repoint to the (possibly forked
+            // or merged) result so the resolved identity refreshes.
+            if (success && root._editWasActive && resultId > 0)
+                Settings.dye.activeEquipmentId = resultId
+            if (success)
+                root.packageSaved(resultId)
+            root.close()
+        }
     }
 
     // Open the picker (list of packages). onAboutToShow requests the inventory.
@@ -264,12 +275,17 @@ Dialog {
             "grinderBurrs": fBurrs.trim()
         }
         if (formMode === "edit" && editPackageId > 0) {
+            // Editing identity may copy-on-write into a new package id; wait for
+            // the result so we can repoint the active selection if needed.
+            _editWasActive = (editPackageId === Settings.dye.activeEquipmentId)
+            _awaitingEdit = true
             MainController.equipmentStorage.requestUpdatePackage(editPackageId, fields)
-            packageSaved(editPackageId)
-            close()
         } else {
             MainController.equipmentStorage.requestCreatePackage(fields)
             _awaitingCreate = true
         }
     }
+
+    property bool _awaitingEdit: false
+    property bool _editWasActive: false
 }

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -156,23 +156,25 @@ Dialog {
             Repeater {
                 model: root.packages
                 AccessibleButton {
-                    // modelData is transiently undefined while the var-array model
-                    // is reassigned (onInventoryReady) — fall back to an empty
-                    // object so the bindings below never dereference undefined.
-                    readonly property var pkg: modelData || ({})
+                    // Read the package by index from the source array rather than
+                    // modelData: inside this Dialog-content delegate modelData did
+                    // not resolve the QVariantMap (rows rendered blank). index is
+                    // always valid; guard against the transient reassignment window.
+                    readonly property var pkg: (root.packages && index >= 0 && index < root.packages.length)
+                                               ? root.packages[index] : null
                     Layout.fillWidth: true
                     Layout.preferredHeight: Theme.scaled(44)
-                    primary: pkg.id === Settings.dye.activeEquipmentId
+                    primary: !!pkg && pkg.id === Settings.dye.activeEquipmentId
                     text: root.packageTitle(pkg)
-                          + (pkg.grinderBurrs && String(pkg.grinderBurrs).length > 0
+                          + (pkg && pkg.grinderBurrs && String(pkg.grinderBurrs).length > 0
                              ? " · " + pkg.grinderBurrs : "")
-                    accessibleName: text + (pkg.id === Settings.dye.activeEquipmentId
+                    accessibleName: text + (!!pkg && pkg.id === Settings.dye.activeEquipmentId
                                             ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                     onClicked: {
-                        if (!modelData) return
+                        if (!pkg || pkg.id === undefined) return
                         if (root.applyToActiveBag)
-                            Settings.dye.switchToEquipment(modelData)
-                        root.packageSaved(modelData.id)
+                            Settings.dye.switchToEquipment(pkg)
+                        root.packageSaved(pkg.id)
                         root.close()
                     }
                 }

--- a/qml/components/layout/LayoutItemDelegate.qml
+++ b/qml/components/layout/LayoutItemDelegate.qml
@@ -21,6 +21,7 @@ Item {
             case "hotwater":
             case "flush":
             case "beans":
+            case "equipment":
             case "history":
             case "settings":
             case "autofavorites":
@@ -81,6 +82,14 @@ Item {
                 longPressAction: "navigate:beaninfo",
                 doubleclickAction: "navigate:beaninfo",
                 backgroundColor: Settings.dye.activeBagId <= 0 ? Theme.highlightColor : Theme.primaryColor
+            }
+            case "equipment": return {
+                emoji: "qrc:/icons/grind.svg",
+                content: TranslationManager.translate("idle.button.equipment", "Equipment"),
+                action: "navigate:equipment",
+                longPressAction: "",
+                doubleclickAction: "",
+                backgroundColor: Theme.primaryColor
             }
             case "history": return {
                 emoji: "qrc:/icons/history.svg",
@@ -155,6 +164,7 @@ Item {
                 case "hotwater":         src = "items/HotWaterItem.qml"; break
                 case "flush":            src = "items/FlushItem.qml"; break
                 case "beans":            src = "items/BeansItem.qml"; break
+                case "equipment":        src = "items/EquipmentItem.qml"; break
                 case "history":          src = "items/HistoryItem.qml"; break
                 case "autofavorites":    src = "items/AutoFavoritesItem.qml"; break
                 case "sleep":            src = "items/SleepItem.qml"; break

--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -268,6 +268,7 @@ Item {
                 "hotwater": "HotWaterPage.qml",
                 "flush": "FlushPage.qml",
                 "beaninfo": "BeanInfoPage.qml",
+                "equipment": "EquipmentPage.qml",
                 "espresso": "EspressoPage.qml",
                 "community": "CommunityBrowserPage.qml",
                 "flowCalibration": "FlowCalibrationPage.qml",

--- a/qml/components/layout/items/EquipmentItem.qml
+++ b/qml/components/layout/items/EquipmentItem.qml
@@ -1,0 +1,88 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Effects
+import Decenza
+import "../.."
+
+// Idle-page Equipment button (add-equipment-packages). Tapping it opens the
+// Equipment window, parallel to the Beans button. Simpler than BeansItem — no
+// quick-select pill popup; equipment is switched per-bag from Brew Settings.
+// In center zones LayoutItemDelegate compiles "equipment" to a CustomItem, so
+// this file renders only in the compact (top/bottom/statusBar) zones.
+Item {
+    id: root
+    property bool isCompact: false
+    property string itemId: ""
+
+    function goToEquipment() {
+        if (typeof pageStack !== "undefined")
+            pageStack.push(Qt.resolvedUrl("../../../pages/EquipmentPage.qml"))
+    }
+
+    implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
+    implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
+
+    // --- COMPACT MODE ---
+    Item {
+        id: compactContent
+        visible: root.isCompact
+        anchors.fill: parent
+        implicitWidth: compactRow.implicitWidth + Theme.scaled(16)
+        implicitHeight: Theme.bottomBarHeight
+
+        RowLayout {
+            id: compactRow
+            anchors.centerIn: parent
+            spacing: Theme.spacingSmall
+
+            Image {
+                source: "qrc:/icons/grind.svg"
+                sourceSize.height: Theme.scaled(20)
+                fillMode: Image.PreserveAspectFit
+                Accessible.ignored: true
+                layer.enabled: true
+                layer.smooth: true
+                layer.effect: MultiEffect {
+                    colorization: 1.0
+                    colorizationColor: Theme.textColor
+                }
+            }
+            Tr {
+                key: "idle.button.equipment"
+                fallback: "Equipment"
+                font: Theme.bodyFont
+                color: Theme.textColor
+                Accessible.ignored: true
+            }
+        }
+
+        AccessibleTapHandler {
+            anchors.fill: parent
+            accessibleName: TranslationManager.translate("idle.button.equipment", "Equipment")
+            accessibleDescription: TranslationManager.translate("idle.accessible.equipment.hint", "Tap to open the equipment inventory.")
+            onAccessibleClicked: root.goToEquipment()
+        }
+    }
+
+    // --- FULL MODE ---
+    Item {
+        id: fullContent
+        visible: !root.isCompact
+        anchors.fill: parent
+        implicitWidth: Theme.scaled(150)
+        implicitHeight: Theme.scaled(120)
+
+        ActionButton {
+            anchors.fill: parent
+            translationKey: "idle.button.equipment"
+            translationFallback: "Equipment"
+            iconSource: "qrc:/icons/grind.svg"
+            iconSize: Theme.scaled(43)
+            backgroundColor: Theme.primaryColor
+            onClicked: root.goToEquipment()
+
+            Accessible.description: TranslationManager.translate("idle.accessible.equipment.description", "Open the equipment inventory to manage and switch grinders.")
+        }
+    }
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1186,6 +1186,7 @@ ApplicationWindow {
             "profileImportPage": TranslationManager.translate("main.pageImportProfiles", "Import profiles"),
             "postShotReviewPage": TranslationManager.translate("main.pageShotReview", "Shot review"),
             "beanInfoPage": TranslationManager.translate("main.pageBeanInfo", "Bean info"),
+            "equipmentPage": TranslationManager.translate("main.pageEquipment", "Equipment"),
             "dialingAssistantPage": TranslationManager.translate("main.pageAiAssistant", "AI assistant"),
             "shotDetailPage": TranslationManager.translate("main.pageShotDetail", "Shot detail"),
             "shotComparisonPage": TranslationManager.translate("main.pageShotComparison", "Shot comparison")

--- a/qml/pages/EquipmentPage.qml
+++ b/qml/pages/EquipmentPage.qml
@@ -1,0 +1,140 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Decenza
+import "../components"
+
+// Equipment inventory (add-equipment-packages): mirrors BeanInfoPage. Shows all
+// packages with inInventory = true as cards; "Add Equipment" opens the create
+// dialog. Equipment is switched per-bag from Brew Settings, so there is no
+// global selection here — cards are informational + edit/remove.
+Page {
+    id: equipmentPage
+    objectName: "equipmentPage"
+    background: Rectangle { color: Theme.backgroundColor }
+
+    StackView.onActivated: root.currentPageTitle = TranslationManager.translate("equipment.title", "Equipment")
+
+    property var inventoryPackages: []
+
+    Component.onCompleted: {
+        root.currentPageTitle = TranslationManager.translate("equipment.title", "Equipment")
+        MainController.equipmentStorage.requestInventory()
+        addEquipmentButton.forceActiveFocus()
+    }
+
+    Connections {
+        target: MainController.equipmentStorage
+        function onInventoryReady(packages) {
+            equipmentPage.inventoryPackages = packages
+        }
+        function onPackagesChanged() {
+            MainController.equipmentStorage.requestInventory()
+        }
+    }
+
+    SwitchEquipmentDialog {
+        id: switchEquipmentDialog
+    }
+
+    Flickable {
+        id: flickable
+        anchors.fill: parent
+        anchors.topMargin: Theme.pageTopMargin
+        anchors.bottomMargin: Theme.bottomBarHeight
+        anchors.leftMargin: Theme.standardMargin
+        anchors.rightMargin: Theme.standardMargin
+        contentHeight: contentColumn.implicitHeight + Theme.scaled(20)
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+
+        ColumnLayout {
+            id: contentColumn
+            width: flickable.width
+            spacing: Theme.spacingMedium
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.spacingMedium
+
+                Tr {
+                    key: "equipment.inventory.title"
+                    fallback: "Equipment"
+                    font: Theme.titleFont
+                    color: Theme.textColor
+                    Accessible.role: Accessible.Heading
+                    Accessible.name: text
+                }
+
+                Item { Layout.fillWidth: true }
+
+                AccessibleButton {
+                    id: addEquipmentButton
+                    primary: true
+                    Layout.preferredHeight: Theme.scaled(44)
+                    icon.source: "qrc:/icons/plus.svg"
+                    text: TranslationManager.translate("equipment.inventory.add", "Add Equipment")
+                    accessibleName: TranslationManager.translate("equipment.inventory.accessible.add", "Add a new equipment package")
+                    onClicked: switchEquipmentDialog.openForCreate()
+                }
+            }
+
+            // Empty state
+            ColumnLayout {
+                visible: equipmentPage.inventoryPackages.length === 0
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.scaled(40)
+                spacing: Theme.spacingSmall
+
+                Tr {
+                    Layout.alignment: Qt.AlignHCenter
+                    key: "equipment.inventory.empty.title"
+                    fallback: "No equipment yet"
+                    font: Theme.subtitleFont
+                    color: Theme.textColor
+                    Accessible.role: Accessible.StaticText
+                    Accessible.name: text
+                }
+
+                Tr {
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.maximumWidth: flickable.width * 0.8
+                    key: "equipment.inventory.empty.hint"
+                    fallback: "Add your grinder to track its model, burrs and dial-in per bag."
+                    font: Theme.bodyFont
+                    color: Theme.textSecondaryColor
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.Wrap
+                    Accessible.role: Accessible.StaticText
+                    Accessible.name: text
+                }
+            }
+
+            // Package cards
+            Flow {
+                Layout.fillWidth: true
+                spacing: Theme.spacingMedium
+
+                Repeater {
+                    model: equipmentPage.inventoryPackages
+
+                    EquipmentCard {
+                        pkg: modelData
+                        width: {
+                            var avail = flickable.width
+                            var cardW = Theme.scaled(380)
+                            var columns = Math.max(1, Math.floor(avail / cardW))
+                            return (avail - (columns - 1) * Theme.spacingMedium) / columns
+                        }
+                        onEditRequested: function(p) { switchEquipmentDialog.openForEdit(p) }
+                    }
+                }
+            }
+        }
+    }
+
+    BottomBar {
+        barColor: "transparent"
+        onBackClicked: root.goBack()
+    }
+}

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -571,6 +571,7 @@ Page {
             roastDate: src.roastDate, roastLevel: src.roastLevel,
             grinderBrand: src.grinderBrand, grinderModel: src.grinderModel,
             grinderBurrs: src.grinderBurrs, grinderSetting: src.grinderSetting,
+            rpm: src.rpm,
             barista: src.barista, doseWeightG: src.doseWeightG,
             finalWeightG: src.finalWeightG, drinkTdsPct: src.drinkTdsPct,
             drinkEyPct: src.drinkEyPct, enjoyment0to100: src.enjoyment0to100,

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -172,6 +172,7 @@ Page {
                 editGrinderBrand = editShotData.grinderBrand || ""
                 editGrinderModel = editShotData.grinderModel || ""
                 editGrinderBurrs = editShotData.grinderBurrs || ""
+                editEquipmentId = editShotData.equipmentId || -1
                 editGrinderSetting = editShotData.grinderSetting || ""
                 editBarista = editShotData.barista || ""
                 // Fall back to last-used DYE dose when the shot has no stored dose,
@@ -258,9 +259,13 @@ Page {
     property string editBeanType: ""
     property string editRoastDate: ""
     property string editRoastLevel: ""
+    // Grinder brand/model/burrs are READ-ONLY display, resolved from the shot's
+    // equipment package; editEquipmentId is the re-point target the picker sets.
     property string editGrinderBrand: ""
     property string editGrinderModel: ""
     property string editGrinderBurrs: ""
+    property int editEquipmentId: -1
+    property int _pendingEquipmentId: -1   // package id awaiting requestPackage resolution
     property string editGrinderSetting: ""
     property string editBarista: ""
     property double editDoseWeight: 0
@@ -405,6 +410,7 @@ Page {
             roastDate: editRoastDate, roastLevel: editRoastLevel,
             grinderBrand: editGrinderBrand, grinderModel: editGrinderModel,
             grinderBurrs: editGrinderBurrs, grinderSetting: editGrinderSetting,
+            equipmentId: editEquipmentId,
             barista: editBarista, doseWeight: editDoseWeight,
             drinkWeight: editDrinkWeight, drinkTds: editDrinkTds,
             drinkEy: editDrinkEy, enjoyment: editEnjoyment,
@@ -418,6 +424,7 @@ Page {
         editRoastDate = s.roastDate; editRoastLevel = s.roastLevel
         editGrinderBrand = s.grinderBrand; editGrinderModel = s.grinderModel
         editGrinderBurrs = s.grinderBurrs; editGrinderSetting = s.grinderSetting
+        editEquipmentId = s.equipmentId !== undefined ? s.equipmentId : -1
         editBarista = s.barista; editDoseWeight = s.doseWeight
         editDrinkWeight = s.drinkWeight; editDrinkTds = s.drinkTds
         editDrinkEy = s.drinkEy; editEnjoyment = s.enjoyment
@@ -610,10 +617,14 @@ Page {
             "beanType": editBeanType,
             "roastDate": editRoastDate,
             "roastLevel": editRoastLevel,
+            // Grinder identity (brand/model/burrs) is ignored by the backend now
+            // — it resolves via equipmentId. Kept here only so the Visualizer PATCH
+            // (buildVisualizerOverrides) still sends the resolved grinder strings.
             "grinderBrand": editGrinderBrand,
             "grinderModel": editGrinderModel,
             "grinderBurrs": editGrinderBurrs,
             "grinderSetting": editGrinderSetting,
+            "equipmentId": editEquipmentId,
             "barista": editBarista,
             "doseWeight": editDoseWeight,
             "finalWeight": editDrinkWeight,
@@ -642,6 +653,7 @@ Page {
         nb.grinderBrand = editGrinderBrand
         nb.grinderModel = editGrinderModel
         nb.grinderBurrs = editGrinderBurrs
+        nb.equipmentId = editEquipmentId
         nb.grinderSetting = editGrinderSetting
         nb.barista = editBarista
         nb.doseWeightG = editDoseWeight
@@ -780,7 +792,6 @@ Page {
         anchors.fill: parent
         targetFlickable: flickable
         textFields: [
-            grinderBrandField.textField, grinderModelField.textField, grinderBurrsField.textField,
             settingField.textField, baristaField.textField,
             notesExpandable.textField
         ]
@@ -1472,6 +1483,30 @@ Page {
                         pendingVisualizerUpdate = true
                     }
                 }
+
+                // Re-point this shot's grinder to a different/new package. The
+                // picker doesn't touch the active bag (applyToActiveBag:false);
+                // we resolve the chosen package and persist equipmentId here.
+                SwitchEquipmentDialog {
+                    id: shotEquipmentDialog
+                    applyToActiveBag: false
+                    onPackageSaved: function(packageId) {
+                        postShotReviewPage._pendingEquipmentId = packageId
+                        MainController.equipmentStorage.requestPackage(packageId)
+                    }
+                }
+                Connections {
+                    target: MainController.equipmentStorage
+                    function onPackageReady(packageId, pkg) {
+                        if (packageId !== postShotReviewPage._pendingEquipmentId) return
+                        postShotReviewPage._pendingEquipmentId = -1
+                        postShotReviewPage.editEquipmentId = packageId
+                        postShotReviewPage.editGrinderBrand = pkg.grinderBrand || ""
+                        postShotReviewPage.editGrinderModel = pkg.grinderModel || ""
+                        postShotReviewPage.editGrinderBurrs = pkg.grinderBurrs || ""
+                        postShotReviewPage.autosave("equipment", true)
+                    }
+                }
             }
 
             BeanBaseDetailsRow {
@@ -1506,79 +1541,59 @@ Page {
                 rowSpacing: 6
 
                 // (Bean identity fields removed — the read-only BeanSummary +
-                // Change Beans dialog above replace them. Grinder and dose
-                // correction fields below stay editable: they dual-write the
-                // shot and the sticky DYE state, which now writes through to
-                // the active bag.)
-                SuggestionField {
-                    id: grinderBrandField
+                // Change Beans dialog above replace them.)
+                //
+                // Grinder identity (brand/model/burrs) is owned by the equipment
+                // PACKAGE now (add-equipment-packages), so it is READ-ONLY here and
+                // changed by re-pointing the shot to a different package via the
+                // picker — not edited as free text (those edits were silently
+                // discarded). The grind Setting (below) stays a per-shot dial-in.
+                ColumnLayout {
+                    Layout.columnSpan: 3
                     Layout.fillWidth: true
-                    label: TranslationManager.translate("postshotreview.label.grinderbrand", "Grinder brand")
-                    text: editGrinderBrand
-                    suggestions: {
-                        var history = _distinctCacheVersion >= 0 ? MainController.shotHistory.getDistinctGrinderBrands() : []
-                        var known = Settings.dye.knownGrinderBrands()
-                        var merged = history.slice()
-                        for (var i = 0; i < known.length; i++) {
-                            if (merged.indexOf(known[i]) < 0) merged.push(known[i])
-                        }
-                        return merged
-                    }
-                    onTextEdited: function(t) { editGrinderBrand = t }
-                    onInputBlurred: postShotReviewPage.autosave("grinderBrand", true)
-                    onSuggestionSelected: function(t) {
-                        editGrinderModel = ""
-                        editGrinderBurrs = ""
-                        var models = Settings.dye.knownGrinderModels(t)
-                        if (models.length === 1) {
-                            editGrinderModel = models[0]
-                            var burrs = Settings.dye.suggestedBurrs(t, models[0])
-                            if (burrs.length === 1) editGrinderBurrs = burrs[0]
-                        }
-                        postShotReviewPage.autosave("grinderBrand", true)
-                    }
-                }
+                    spacing: 4
 
-                SuggestionField {
-                    id: grinderModelField
-                    Layout.fillWidth: true
-                    label: TranslationManager.translate("postshotreview.label.grindermodel", "Model")
-                    text: editGrinderModel
-                    suggestions: {
-                        var history = _distinctCacheVersion >= 0 ? MainController.shotHistory.getDistinctGrinderModelsForBrand(editGrinderBrand) : []
-                        var known = Settings.dye.knownGrinderModels(editGrinderBrand)
-                        var merged = history.slice()
-                        for (var i = 0; i < known.length; i++) {
-                            if (merged.indexOf(known[i]) < 0) merged.push(known[i])
-                        }
-                        return merged
-                    }
-                    onTextEdited: function(t) { editGrinderModel = t }
-                    onInputBlurred: postShotReviewPage.autosave("grinderModel", true)
-                    onSuggestionSelected: function(t) {
-                        var burrs = Settings.dye.suggestedBurrs(editGrinderBrand, t)
-                        if (burrs.length === 1) editGrinderBurrs = burrs[0]
-                        postShotReviewPage.autosave("grinderModel", true)
-                    }
-                }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+                        readonly property bool hasEquipment: editGrinderBrand.length > 0 || editGrinderModel.length > 0
 
-                // === ROW 3: Burrs, Setting, Beverage type ===
-                SuggestionField {
-                    id: grinderBurrsField
-                    Layout.fillWidth: true
-                    label: TranslationManager.translate("postshotreview.label.grinderburrs", "Burrs")
-                    text: editGrinderBurrs
-                    suggestions: {
-                        var history = _distinctCacheVersion >= 0 ? MainController.shotHistory.getDistinctGrinderBurrsForModel(editGrinderBrand, editGrinderModel) : []
-                        var known = Settings.dye.suggestedBurrs(editGrinderBrand, editGrinderModel)
-                        var merged = history.slice()
-                        for (var i = 0; i < known.length; i++) {
-                            if (merged.indexOf(known[i]) < 0) merged.push(known[i])
+                        Tr {
+                            key: "postshotreview.label.equipment"
+                            fallback: "Equipment:"
+                            font: Theme.labelFont
+                            color: Theme.textSecondaryColor
+                            Accessible.ignored: true
                         }
-                        return merged
+                        Text {
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                            text: parent.hasEquipment
+                                  ? [editGrinderBrand, editGrinderModel].filter(function(s){ return s && s.length > 0 }).join(" ")
+                                  : TranslationManager.translate("postshotreview.equipmentNotSet", "Not set")
+                            font: Theme.bodyFont
+                            color: parent.hasEquipment ? Theme.textColor : Theme.textSecondaryColor
+                            Accessible.role: Accessible.StaticText
+                            Accessible.name: TranslationManager.translate("postshotreview.label.equipment", "Equipment:") + " " + text
+                        }
+                        AccessibleButton {
+                            text: parent.hasEquipment
+                                  ? TranslationManager.translate("postshotreview.changeEquipment", "Change Equipment")
+                                  : TranslationManager.translate("postshotreview.addEquipment", "Add Equipment")
+                            accessibleName: text
+                            onClicked: shotEquipmentDialog.openPicker()
+                        }
                     }
-                    onTextEdited: function(t) { editGrinderBurrs = t }
-                    onInputBlurred: postShotReviewPage.autosave("grinderBurrs", true)
+                    Text {
+                        visible: editGrinderBurrs.length > 0
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                        text: TranslationManager.translate("postshotreview.label.grinderburrs", "Burrs") + ": " + editGrinderBurrs
+                        font: Theme.labelFont
+                        color: Theme.textSecondaryColor
+                        Accessible.role: Accessible.StaticText
+                        Accessible.name: text
+                    }
                 }
 
                 SuggestionField {

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -173,7 +173,9 @@ Page {
                 editGrinderModel = editShotData.grinderModel || ""
                 editGrinderBurrs = editShotData.grinderBurrs || ""
                 editEquipmentId = editShotData.equipmentId || -1
+                editEquipmentName = editShotData.equipmentName || ""
                 editGrinderSetting = editShotData.grinderSetting || ""
+                editRpm = editShotData.rpm || 0
                 editBarista = editShotData.barista || ""
                 // Fall back to last-used DYE dose when the shot has no stored dose,
                 // so EY can be computed immediately when TDS arrives.
@@ -264,9 +266,12 @@ Page {
     property string editGrinderBrand: ""
     property string editGrinderModel: ""
     property string editGrinderBurrs: ""
+    property string editEquipmentName: ""  // package display name (read-only label)
     property int editEquipmentId: -1
     property int _pendingEquipmentId: -1   // package id awaiting requestPackage resolution
     property string editGrinderSetting: ""
+    property int editRpm: 0                // grinder rpm dial-in (shown when rpmCapable)
+    readonly property bool editRpmCapable: Settings.dye.grinderRpmCapable(editGrinderBrand, editGrinderModel)
     property string editBarista: ""
     property double editDoseWeight: 0
     property double editDrinkWeight: 0
@@ -361,6 +366,8 @@ Page {
         editGrinderModel !== (editShotData.grinderModel || "") ||
         editGrinderBurrs !== (editShotData.grinderBurrs || "") ||
         editGrinderSetting !== (editShotData.grinderSetting || "") ||
+        editRpm !== (editShotData.rpm || 0) ||
+        editEquipmentId !== (editShotData.equipmentId || -1) ||
         editBarista !== (editShotData.barista || "") ||
         editDoseWeight !== ((editShotData.doseWeightG > 0) ? editShotData.doseWeightG : Settings.dye.dyeBeanWeight) ||
         editDrinkWeight !== (editShotData.finalWeightG ?? 0) ||
@@ -410,7 +417,7 @@ Page {
             roastDate: editRoastDate, roastLevel: editRoastLevel,
             grinderBrand: editGrinderBrand, grinderModel: editGrinderModel,
             grinderBurrs: editGrinderBurrs, grinderSetting: editGrinderSetting,
-            equipmentId: editEquipmentId,
+            equipmentId: editEquipmentId, equipmentName: editEquipmentName, rpm: editRpm,
             barista: editBarista, doseWeight: editDoseWeight,
             drinkWeight: editDrinkWeight, drinkTds: editDrinkTds,
             drinkEy: editDrinkEy, enjoyment: editEnjoyment,
@@ -425,6 +432,8 @@ Page {
         editGrinderBrand = s.grinderBrand; editGrinderModel = s.grinderModel
         editGrinderBurrs = s.grinderBurrs; editGrinderSetting = s.grinderSetting
         editEquipmentId = s.equipmentId !== undefined ? s.equipmentId : -1
+        editEquipmentName = s.equipmentName !== undefined ? s.equipmentName : ""
+        editRpm = s.rpm !== undefined ? s.rpm : 0
         editBarista = s.barista; editDoseWeight = s.doseWeight
         editDrinkWeight = s.drinkWeight; editDrinkTds = s.drinkTds
         editDrinkEy = s.drinkEy; editEnjoyment = s.enjoyment
@@ -624,6 +633,7 @@ Page {
             "grinderModel": editGrinderModel,
             "grinderBurrs": editGrinderBurrs,
             "grinderSetting": editGrinderSetting,
+            "rpm": editRpm,
             "equipmentId": editEquipmentId,
             "barista": editBarista,
             "doseWeight": editDoseWeight,
@@ -654,7 +664,9 @@ Page {
         nb.grinderModel = editGrinderModel
         nb.grinderBurrs = editGrinderBurrs
         nb.equipmentId = editEquipmentId
+        nb.equipmentName = editEquipmentName
         nb.grinderSetting = editGrinderSetting
+        nb.rpm = editRpm
         nb.barista = editBarista
         nb.doseWeightG = editDoseWeight
         nb.finalWeightG = editDrinkWeight
@@ -792,7 +804,7 @@ Page {
         anchors.fill: parent
         targetFlickable: flickable
         textFields: [
-            settingField.textField, baristaField.textField,
+            settingField.textField, rpmField.textField, baristaField.textField,
             notesExpandable.textField
         ]
 
@@ -1495,6 +1507,9 @@ Page {
                         MainController.equipmentStorage.requestPackage(packageId)
                     }
                 }
+                EquipmentInfoDialog {
+                    id: shotEquipmentInfoDialog
+                }
                 Connections {
                     target: MainController.equipmentStorage
                     function onPackageReady(packageId, pkg) {
@@ -1504,6 +1519,8 @@ Page {
                         postShotReviewPage.editGrinderBrand = pkg.grinderBrand || ""
                         postShotReviewPage.editGrinderModel = pkg.grinderModel || ""
                         postShotReviewPage.editGrinderBurrs = pkg.grinderBurrs || ""
+                        postShotReviewPage.editEquipmentName =
+                            (pkg.name && String(pkg.name).length > 0) ? String(pkg.name) : ""
                         postShotReviewPage.autosave("equipment", true)
                     }
                 }
@@ -1548,58 +1565,53 @@ Page {
                 // changed by re-pointing the shot to a different package via the
                 // picker — not edited as free text (those edits were silently
                 // discarded). The grind Setting (below) stays a per-shot dial-in.
-                ColumnLayout {
+                RowLayout {
                     Layout.columnSpan: 3
                     Layout.fillWidth: true
-                    spacing: 4
+                    spacing: 8
+                    readonly property bool hasEquipment: editEquipmentName.length > 0
+                                                         || editGrinderBrand.length > 0 || editGrinderModel.length > 0
 
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: 8
-                        readonly property bool hasEquipment: editGrinderBrand.length > 0 || editGrinderModel.length > 0
-
-                        Tr {
-                            key: "postshotreview.label.equipment"
-                            fallback: "Equipment:"
-                            font: Theme.labelFont
-                            color: Theme.textSecondaryColor
-                            Accessible.ignored: true
-                        }
-                        Text {
-                            Layout.fillWidth: true
-                            elide: Text.ElideRight
-                            text: parent.hasEquipment
-                                  ? [editGrinderBrand, editGrinderModel].filter(function(s){ return s && s.length > 0 }).join(" ")
-                                  : TranslationManager.translate("postshotreview.equipmentNotSet", "Not set")
-                            font: Theme.bodyFont
-                            color: parent.hasEquipment ? Theme.textColor : Theme.textSecondaryColor
-                            Accessible.role: Accessible.StaticText
-                            Accessible.name: TranslationManager.translate("postshotreview.label.equipment", "Equipment:") + " " + text
-                        }
-                        AccessibleButton {
-                            text: parent.hasEquipment
-                                  ? TranslationManager.translate("postshotreview.changeEquipment", "Change Equipment")
-                                  : TranslationManager.translate("postshotreview.addEquipment", "Add Equipment")
-                            accessibleName: text
-                            onClicked: shotEquipmentDialog.openPicker()
-                        }
-                    }
-                    Text {
-                        visible: editGrinderBurrs.length > 0
-                        Layout.fillWidth: true
-                        elide: Text.ElideRight
-                        text: TranslationManager.translate("postshotreview.label.grinderburrs", "Burrs") + ": " + editGrinderBurrs
+                    Tr {
+                        key: "postshotreview.label.equipment"
+                        fallback: "Equipment:"
                         font: Theme.labelFont
                         color: Theme.textSecondaryColor
+                        Accessible.ignored: true
+                    }
+                    Text {
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                        // Show the package NAME (defaults to "{brand} {model}").
+                        text: editEquipmentName.length > 0
+                              ? editEquipmentName
+                              : (parent.hasEquipment
+                                 ? [editGrinderBrand, editGrinderModel].filter(function(s){ return s && s.length > 0 }).join(" ")
+                                 : TranslationManager.translate("postshotreview.equipmentNotSet", "Not set"))
+                        font: Theme.bodyFont
+                        color: parent.hasEquipment ? Theme.textColor : Theme.textSecondaryColor
                         Accessible.role: Accessible.StaticText
-                        Accessible.name: text
+                        Accessible.name: TranslationManager.translate("postshotreview.label.equipment", "Equipment:") + " " + text
+                    }
+                    AccessibleButton {
+                        visible: editEquipmentId > 0
+                        icon.source: "qrc:/icons/info.svg"
+                        accessibleName: TranslationManager.translate("equipment.info.button", "Equipment details")
+                        onClicked: shotEquipmentInfoDialog.openFor(editEquipmentId)
+                    }
+                    AccessibleButton {
+                        text: parent.hasEquipment
+                              ? TranslationManager.translate("postshotreview.changeEquipment", "Change Equipment")
+                              : TranslationManager.translate("postshotreview.addEquipment", "Add Equipment")
+                        accessibleName: text
+                        onClicked: shotEquipmentDialog.openPicker()
                     }
                 }
 
                 SuggestionField {
                     id: settingField
                     Layout.fillWidth: true
-                    label: TranslationManager.translate("postshotreview.label.setting", "Setting")
+                    label: TranslationManager.translate("postshotreview.label.grindSetting", "Grind setting")
                     text: editGrinderSetting
                     suggestions: {
                         var list = _distinctCacheVersion >= 0 ? MainController.shotHistory.getDistinctGrinderSettingsForGrinder(editGrinderModel) : []
@@ -1608,6 +1620,18 @@ Page {
                     }
                     onTextEdited: function(t) { editGrinderSetting = t }
                     onInputBlurred: postShotReviewPage.autosave("grinderSetting", true)
+                }
+
+                // RPM dial-in — only when the shot's grinder is rpm-adjustable.
+                SuggestionField {
+                    id: rpmField
+                    visible: postShotReviewPage.editRpmCapable
+                    Layout.fillWidth: true
+                    label: TranslationManager.translate("postshotreview.label.rpm", "RPM")
+                    text: editRpm > 0 ? String(editRpm) : ""
+                    suggestions: []
+                    onTextEdited: function(t) { editRpm = parseInt(t) || 0 }
+                    onInputBlurred: postShotReviewPage.autosave("rpm", true)
                 }
 
                 // === ROW 4: Beverage type, Barista, Preset, Shot Date ===

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -863,8 +863,11 @@ Page {
                             Tr { key: "shotdetail.burrs"; fallback: "Burrs:"; font: Theme.labelFont; color: Theme.textSecondaryColor; visible: !!(shotData.grinderBurrs); Accessible.ignored: true }
                             Text { textFormat: Text.RichText; text: Theme.replaceEmojiWithImg(shotData.grinderBurrs || "", Theme.labelFont.pixelSize); font: Theme.labelFont; color: Theme.textColor; visible: !!(shotData.grinderBurrs); Layout.fillWidth: true; elide: Text.ElideRight; Accessible.ignored: true }
 
-                            Tr { key: "shotdetail.setting"; fallback: "Setting:"; font: Theme.labelFont; color: Theme.textSecondaryColor; visible: !!(shotData.grinderSetting); Accessible.ignored: true }
+                            Tr { key: "shotdetail.grindSetting"; fallback: "Grind setting:"; font: Theme.labelFont; color: Theme.textSecondaryColor; visible: !!(shotData.grinderSetting); Accessible.ignored: true }
                             Text { textFormat: Text.RichText; text: Theme.replaceEmojiWithImg(shotData.grinderSetting || "", Theme.labelFont.pixelSize); font: Theme.labelFont; color: Theme.textColor; visible: !!(shotData.grinderSetting); Layout.fillWidth: true; elide: Text.ElideRight; Accessible.ignored: true }
+
+                            Tr { key: "shotdetail.rpm"; fallback: "RPM:"; font: Theme.labelFont; color: Theme.textSecondaryColor; visible: shotData.rpm > 0; Accessible.ignored: true }
+                            Text { text: shotData.rpm > 0 ? String(shotData.rpm) : ""; font: Theme.labelFont; color: Theme.textColor; visible: shotData.rpm > 0; Layout.fillWidth: true; elide: Text.ElideRight; Accessible.role: Accessible.StaticText; Accessible.name: "RPM: " + text }
                         }
                     }
                 }

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -867,7 +867,7 @@ Page {
                             Text { textFormat: Text.RichText; text: Theme.replaceEmojiWithImg(shotData.grinderSetting || "", Theme.labelFont.pixelSize); font: Theme.labelFont; color: Theme.textColor; visible: !!(shotData.grinderSetting); Layout.fillWidth: true; elide: Text.ElideRight; Accessible.ignored: true }
 
                             Tr { key: "shotdetail.rpm"; fallback: "RPM:"; font: Theme.labelFont; color: Theme.textSecondaryColor; visible: shotData.rpm > 0; Accessible.ignored: true }
-                            Text { text: shotData.rpm > 0 ? String(shotData.rpm) : ""; font: Theme.labelFont; color: Theme.textColor; visible: shotData.rpm > 0; Layout.fillWidth: true; elide: Text.ElideRight; Accessible.role: Accessible.StaticText; Accessible.name: "RPM: " + text }
+                            Text { text: shotData.rpm > 0 ? String(shotData.rpm) : ""; font: Theme.labelFont; color: Theme.textColor; visible: shotData.rpm > 0; Layout.fillWidth: true; elide: Text.ElideRight; Accessible.role: Accessible.StaticText; Accessible.name: TranslationManager.translate("shotdetail.rpm", "RPM:") + " " + text }
                         }
                     }
                 }

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -830,6 +830,24 @@ Page {
                             Accessible.ignored: true
                         }
 
+                        // Equipment lineage qualifier (add-equipment-packages
+                        // 4b.7): when this shot's package is no longer the current
+                        // one, note whether it was superseded by a newer version
+                        // ("older") or retired from inventory. Never baked into
+                        // the grinder name — rendered from the resolved state.
+                        Text {
+                            visible: shotData.equipmentState === "older" || shotData.equipmentState === "retired"
+                            text: shotData.equipmentState === "older"
+                                ? TranslationManager.translate("shotdetail.equipmentOlder", "Older equipment — a newer version is now in use")
+                                : TranslationManager.translate("shotdetail.equipmentRetired", "Retired equipment — no longer in inventory")
+                            font: Theme.labelFont
+                            color: Theme.textSecondaryColor
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                            Accessible.role: Accessible.StaticText
+                            Accessible.name: text
+                        }
+
                         GridLayout {
                             columns: 2
                             columnSpacing: Theme.spacingLarge

--- a/qml/pages/settings/LayoutEditorZone.qml
+++ b/qml/pages/settings/LayoutEditorZone.qml
@@ -393,6 +393,7 @@ Rectangle {
                         model: [
                             // Actions & readouts (white)
                             { type: "beans", label: TranslationManager.translate("layoutEditor.widgetBeans", "Beans") },
+                            { type: "equipment", label: TranslationManager.translate("layoutEditor.widgetEquipment", "Equipment") },
                             { type: "connectionStatus", label: TranslationManager.translate("layoutEditor.widgetConnection", "Connection") },
                             { type: "espresso", label: TranslationManager.translate("layoutEditor.widgetEspresso", "Espresso") },
                             { type: "autofavorites", label: TranslationManager.translate("layoutEditor.widgetFavorites", "Favorites") },
@@ -529,6 +530,7 @@ Rectangle {
             "hotwater": TranslationManager.translate("layoutEditor.chipHotWater", "Hot Water"),
             "flush": TranslationManager.translate("layoutEditor.chipFlush", "Flush"),
             "beans": TranslationManager.translate("layoutEditor.chipBeans", "Beans"),
+            "equipment": TranslationManager.translate("layoutEditor.chipEquipment", "Equipment"),
             "history": TranslationManager.translate("layoutEditor.chipHistory", "History"),
             "autofavorites": TranslationManager.translate("layoutEditor.chipFavorites", "Favorites"),
             "sleep": TranslationManager.translate("layoutEditor.chipSleep", "Sleep"),

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -665,7 +665,8 @@ ShotMetadata AIManager::buildMetadata(const QString& beanBrand,
                                        const QString& grinderBurrs,
                                        const QString& grinderSetting,
                                        int enjoymentScore,
-                                       const QString& tastingNotes) const
+                                       const QString& tastingNotes,
+                                       int rpm) const
 {
     ShotMetadata metadata;
     metadata.beanBrand = beanBrand;
@@ -676,6 +677,7 @@ ShotMetadata AIManager::buildMetadata(const QString& beanBrand,
     metadata.grinderModel = grinderModel;
     metadata.grinderBurrs = grinderBurrs;
     metadata.grinderSetting = grinderSetting;
+    metadata.rpm = rpm;
     metadata.espressoEnjoyment = enjoymentScore;
     metadata.espressoNotes = tastingNotes;
     return metadata;
@@ -701,7 +703,8 @@ void AIManager::analyzeShot(ShotDataModel* shotData,
         metadata.value("grinderSetting").toString(),
         metadata.value("enjoymentScore").toInt(),
         metadata.value("tastingNotes").toString(),
-        metadata.value("stoppedBy").toString());
+        metadata.value("stoppedBy").toString(),
+        metadata.value("rpm").toInt());
 }
 
 void AIManager::analyzeShotWithMetadata(ShotDataModel* shotData,
@@ -718,7 +721,8 @@ void AIManager::analyzeShotWithMetadata(ShotDataModel* shotData,
                              const QString& grinderSetting,
                              int enjoymentScore,
                              const QString& tastingNotes,
-                             const QString& stoppedBy)
+                             const QString& stoppedBy,
+                             int rpm)
 {
     if (!isConfigured()) {
         m_lastError = "AI provider not configured. Please add your API key in settings.";
@@ -748,7 +752,7 @@ void AIManager::analyzeShotWithMetadata(ShotDataModel* shotData,
     shotData->computeConductanceDerivative();
     ShotMetadata metadata = buildMetadata(beanBrand, beanType, roastDate, roastLevel,
                                           grinderBrand, grinderModel, grinderBurrs,
-                                          grinderSetting, enjoymentScore, tastingNotes);
+                                          grinderSetting, enjoymentScore, tastingNotes, rpm);
     ShotSummary summary = m_summarizer->summarize(shotData, profile, metadata,
                                                   doseWeight, finalWeight, stoppedBy);
 
@@ -901,7 +905,8 @@ QString AIManager::generateEmailPrompt(ShotDataModel* shotData,
         metadataMap.value("grinderBurrs").toString(),
         metadataMap.value("grinderSetting").toString(),
         metadataMap.value("enjoymentScore").toInt(),
-        metadataMap.value("tastingNotes").toString());
+        metadataMap.value("tastingNotes").toString(),
+        metadataMap.value("rpm").toInt());
     ShotSummary summary = m_summarizer->summarize(shotData, profile, metadata,
                                                   doseWeight, finalWeight,
                                                   metadataMap.value("stoppedBy").toString());
@@ -939,7 +944,8 @@ QString AIManager::generateShotSummary(ShotDataModel* shotData,
         metadataMap.value("grinderBurrs").toString(),
         metadataMap.value("grinderSetting").toString(),
         metadataMap.value("enjoymentScore").toInt(),
-        metadataMap.value("tastingNotes").toString());
+        metadataMap.value("tastingNotes").toString(),
+        metadataMap.value("rpm").toInt());
     ShotSummary summary = m_summarizer->summarize(shotData, profile, metadata,
                                                   doseWeight, finalWeight,
                                                   metadataMap.value("stoppedBy").toString());

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -1131,8 +1131,14 @@ void AIManager::requestRecentShotContext(const QString& beanBrand, const QString
         QJsonObject grinderCalibration;
         withTempDb(dbPath, "ai_grinder_ctx", [&](QSqlDatabase& db) {
             QSqlQuery q(db);
-            q.prepare("SELECT grinder_brand, grinder_model, grinder_burrs, beverage_type "
-                      "FROM shots WHERE id = ?");
+            // Grinder identity resolves through the shot's equipment_id pointer
+            // (the per-shot grinder_brand/model/burrs columns are dropped in
+            // migration 23, add-equipment-packages task 4.1). burrs is in the
+            // grinder item's attrs JSON blob.
+            q.prepare("SELECT eg.brand, eg.model, json_extract(eg.attrs, '$.burrs'), s.beverage_type "
+                      "FROM shots s "
+                      "LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder' "
+                      "WHERE s.id = ?");
             q.bindValue(0, static_cast<qint64>(excludeShotId));
             if (!q.exec()) {
                 qWarning() << "AIManager::requestRecentShotContext: grinder ctx query failed:"

--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -116,7 +116,8 @@ public:
                                   const QString& grinderSetting,
                                   int enjoymentScore,
                                   const QString& tastingNotes,
-                                  const QString& stoppedBy = QString());
+                                  const QString& stoppedBy = QString(),
+                                  int rpm = 0);
 
     // Email fallback - generates prompt for copying
     Q_INVOKABLE QString generateEmailPrompt(ShotDataModel* shotData,
@@ -313,7 +314,8 @@ private:
                                 const QString& grinderBurrs,
                                 const QString& grinderSetting,
                                 int enjoymentScore,
-                                const QString& tastingNotes) const;
+                                const QString& tastingNotes,
+                                int rpm = 0) const;
 
     // Logging
     QString logPath() const;

--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -808,8 +808,13 @@ QJsonObject buildGrinderCalibrationBlock(QSqlDatabase& db,
         "       COALESCE(yield_override, 0), "
         "       json_extract(profile_json,'$.target_weight') "
         "FROM shots "
-        "WHERE grinder_model = ? "
-        "  AND COALESCE(grinder_burrs, '') = COALESCE(?, '') "
+        // Grinder identity resolves through the equipment_id pointer, not the
+        // dropped per-shot grinder_model/grinder_burrs columns (add-equipment-
+        // packages migration 23). Match the grinder item (model + burrs from its
+        // attrs blob) then keep shots pointing at one of those packages.
+        "WHERE equipment_id IN (SELECT package_id FROM equipment_items "
+        "    WHERE kind = 'grinder' AND model = ? "
+        "    AND COALESCE(json_extract(attrs, '$.burrs'), '') = COALESCE(?, '')) "
         "  AND (beverage_type IS NULL OR beverage_type = '' OR LOWER(beverage_type) = 'espresso') "
         "  AND COALESCE(final_weight, 0) >= 15 "
         "  AND COALESCE(grind_issue_detected, 0) = 0 "

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -188,6 +188,10 @@ struct CurrentBeanBlockInputs {
     QString grinderModel;
     QString grinderBurrs;
     QString grinderSetting;
+    // Grinder RPM the shot was ground at (0 = unset / not an adjustable-RPM
+    // grinder). A second grind axis alongside grinderSetting on variable-RPM
+    // grinders — surfaced so the advisor can qualify numeric recommendations.
+    int rpm = 0;
     double doseWeightG = 0;
     // Compact-JSON linked-bean snapshot ("" = unlinked, Visualizer canonical
     // or Bean Base sourced). Parsed into a
@@ -210,6 +214,9 @@ inline QJsonObject buildCurrentBeanBlock(const CurrentBeanBlockInputs& in)
     bean["grinderModel"] = in.grinderModel;
     bean["grinderBurrs"] = in.grinderBurrs;
     bean["grinderSetting"] = in.grinderSetting;
+    // Only emit rpm when set, so non-adjustable grinders don't carry a noisy 0.
+    if (in.rpm > 0)
+        bean["rpm"] = in.rpm;
     bean["doseWeightG"] = in.doseWeightG;
 
     const QJsonObject freshness = DialingHelpers::buildBeanFreshness(in.roastDate);

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -239,6 +239,7 @@ ShotSummary ShotSummarizer::summarize(const ShotDataModel* shotData,
     summary.grinderModel = metadata.grinderModel;
     summary.grinderBurrs = metadata.grinderBurrs;
     summary.grinderSetting = metadata.grinderSetting;
+    summary.rpm = static_cast<int>(metadata.rpm);
     summary.drinkTds = metadata.drinkTds;
     summary.drinkEy = metadata.drinkEy;
     summary.enjoymentScore = metadata.espressoEnjoyment;
@@ -388,6 +389,7 @@ ShotSummary ShotSummarizer::summarizeFromHistory(const ShotProjection& shotData)
     summary.grinderModel = shotData.grinderModel;
     summary.grinderBurrs = shotData.grinderBurrs;
     summary.grinderSetting = shotData.grinderSetting;
+    summary.rpm = static_cast<int>(shotData.rpm);
     summary.drinkTds = shotData.drinkTdsPct;
     summary.drinkEy = shotData.drinkEyPct;
     summary.enjoymentScore = shotData.enjoyment0to100;
@@ -516,6 +518,7 @@ static QJsonObject buildCurrentBeanBlock(const ShotSummary& summary)
     in.grinderModel = summary.grinderModel;
     in.grinderBurrs = summary.grinderBurrs;
     in.grinderSetting = summary.grinderSetting;
+    in.rpm = summary.rpm;
     in.doseWeightG = summary.doseWeight;
     in.beanBaseJson = summary.beanBaseJson;
     return DialingBlocks::buildCurrentBeanBlock(in);

--- a/src/ai/shotsummarizer.h
+++ b/src/ai/shotsummarizer.h
@@ -119,6 +119,7 @@ struct ShotSummary {
     QString grinderModel;
     QString grinderBurrs;
     QString grinderSetting;
+    int rpm = 0;  // grinder rpm dial-in (0 = unset / non-adjustable grinder)
     // Compact-JSON Bean Base snapshot ("" = unlinked); flows into
     // currentBean.beanBase via the shared block builder.
     QString beanBaseJson;

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -201,6 +201,13 @@ MainController::MainController(QNetworkAccessManager* networkManager,
         m_settings->dye()->setActiveBagId(static_cast<int>(m_shotHistory->migratedActiveBagId()));
     m_settings->dye()->setBagStorage(m_bagStorage);
 
+    // Equipment storage shares the same database (equipment_packages +
+    // equipment_items tables, created by migration 22). Switchable grinder
+    // packages the active bag points at via equipment_id.
+    m_equipmentStorage = new EquipmentStorage(this);
+    m_equipmentStorage->initialize(m_shotHistory->databasePath());
+    m_settings->dye()->setEquipmentStorage(m_equipmentStorage);
+
     // Switching beans resets the brew overrides to the active profile's
     // defaults — a new coffee starts from the profile + bean baseline, not
     // the previous coffee's manual tweaks (the bag's own dose is applied by

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2420,8 +2420,6 @@ void MainController::generateFakeShotData() {
             metadata.grinderSetting = m_settings->dye()->dyeGrinderSetting();
             metadata.equipmentId = m_settings->dye()->activeEquipmentId();
             metadata.rpm = m_settings->dye()->dyeGrinderRpm();
-    metadata.equipmentId = m_settings->dye()->activeEquipmentId();
-    metadata.rpm = m_settings->dye()->dyeGrinderRpm();
             metadata.beanWeight = m_pendingShotDoseWeight;
             metadata.drinkWeight = m_settings->dye()->dyeDrinkWeight();
             metadata.drinkTds = m_settings->dye()->dyeDrinkTds();

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2012,6 +2012,8 @@ void MainController::onShotEnded() {
     metadata.grinderModel = m_settings->dye()->dyeGrinderModel();
     metadata.grinderBurrs = m_settings->dye()->dyeGrinderBurrs();
     metadata.grinderSetting = m_settings->dye()->dyeGrinderSetting();
+    metadata.equipmentId = m_settings->dye()->activeEquipmentId();
+    metadata.rpm = m_settings->dye()->dyeGrinderRpm();
     metadata.beanWeight = m_settings->dye()->dyeBeanWeight();
     metadata.drinkWeight = m_settings->dye()->dyeDrinkWeight();
     metadata.drinkTds = m_settings->dye()->dyeDrinkTds();
@@ -2260,6 +2262,8 @@ void MainController::uploadPendingShot() {
     metadata.grinderModel = m_settings->dye()->dyeGrinderModel();
     metadata.grinderBurrs = m_settings->dye()->dyeGrinderBurrs();
     metadata.grinderSetting = m_settings->dye()->dyeGrinderSetting();
+    metadata.equipmentId = m_settings->dye()->activeEquipmentId();
+    metadata.rpm = m_settings->dye()->dyeGrinderRpm();
     metadata.beanWeight = m_settings->dye()->dyeBeanWeight();
     metadata.drinkWeight = m_settings->dye()->dyeDrinkWeight();
     metadata.drinkTds = m_settings->dye()->dyeDrinkTds();
@@ -2414,6 +2418,10 @@ void MainController::generateFakeShotData() {
             metadata.grinderModel = m_settings->dye()->dyeGrinderModel();
             metadata.grinderBurrs = m_settings->dye()->dyeGrinderBurrs();
             metadata.grinderSetting = m_settings->dye()->dyeGrinderSetting();
+            metadata.equipmentId = m_settings->dye()->activeEquipmentId();
+            metadata.rpm = m_settings->dye()->dyeGrinderRpm();
+    metadata.equipmentId = m_settings->dye()->activeEquipmentId();
+    metadata.rpm = m_settings->dye()->dyeGrinderRpm();
             metadata.beanWeight = m_pendingShotDoseWeight;
             metadata.drinkWeight = m_settings->dye()->dyeDrinkWeight();
             metadata.drinkTds = m_settings->dye()->dyeDrinkTds();

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -15,6 +15,7 @@
 #include "../machine/steamhealthtracker.h"
 #include "../history/shothistorystorage.h"
 #include "../history/coffeebagstorage.h"
+#include "../history/equipmentstorage.h"
 #include "../history/unifiedbeansearchmodel.h"
 #include "../history/shotimporter.h"
 #include "../profile/profileconverter.h"
@@ -58,6 +59,7 @@ class MainController : public QObject {
     Q_PROPERTY(double filteredGoalFlow READ filteredGoalFlow NOTIFY goalsChanged)
     Q_PROPERTY(ShotHistoryStorage* shotHistory READ shotHistory CONSTANT)
     Q_PROPERTY(CoffeeBagStorage* bagStorage READ bagStorage CONSTANT)
+    Q_PROPERTY(EquipmentStorage* equipmentStorage READ equipmentStorage CONSTANT)
     Q_PROPERTY(UnifiedBeanSearchModel* beanSearch READ beanSearch CONSTANT)
     Q_PROPERTY(ShotImporter* shotImporter READ shotImporter CONSTANT)
     Q_PROPERTY(ProfileConverter* profileConverter READ profileConverter CONSTANT)
@@ -115,6 +117,7 @@ public:
     QString currentFrameName() const { return m_currentFrameName; }
     ShotHistoryStorage* shotHistory() const { return m_shotHistory; }
     CoffeeBagStorage* bagStorage() const { return m_bagStorage; }
+    EquipmentStorage* equipmentStorage() const { return m_equipmentStorage; }
     UnifiedBeanSearchModel* beanSearch() const { return m_beanSearch; }
     ShotImporter* shotImporter() const { return m_shotImporter; }
     ProfileConverter* profileConverter() const { return m_profileConverter; }
@@ -358,6 +361,7 @@ private:
     // Shot history and comparison
     ShotHistoryStorage* m_shotHistory = nullptr;
     CoffeeBagStorage* m_bagStorage = nullptr;
+    EquipmentStorage* m_equipmentStorage = nullptr;
     UnifiedBeanSearchModel* m_beanSearch = nullptr;
     ShotImporter* m_shotImporter = nullptr;
     ProfileConverter* m_profileConverter = nullptr;

--- a/src/core/basketaliases.h
+++ b/src/core/basketaliases.h
@@ -1,0 +1,294 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+namespace BasketAliases {
+
+// The cross-sectional shape of the basket's brewing chamber. This is the
+// single most useful "what kind of basket is it" axis for an AI advisor,
+// because it changes how the puck behaves under flow:
+//   Straight : vertical walls, holes carried right out to the edge. The
+//              competition/precision geometry (VST, IMS, Weber Unibasket,
+//              Pesado HE, Normcore). Full ~58mm active puck face, most even
+//              water exit, the reference for flow profiling.
+//   Tapered  : the wall narrows toward the bottom (classic stamped "stock"
+//              basket). The effective puck face is smaller (~48mm) than the
+//              rim. More forgiving but less even than straight walls.
+//   Stepped  : the bore necks DOWN partway (Decent "waisted", S-Works /
+//              Graph / Normcore step-down). Converts a 58mm group to a
+//              smaller, deeper puck (~46–52mm) for more body and channel
+//              tolerance at low doses; usually needs a bottomless portafilter.
+//   Convex   : the floor bulges up in the centre (IMS Convex, S-Works /
+//              Normcore convex), concentrating flow toward the middle and
+//              demanding a slightly coarser grind.
+enum class WallProfile { Straight, Tapered, Stepped, Convex };
+
+struct BasketEntry {
+    QString brand;
+    QString model;
+    QStringList aliases;     // lowercase match strings (brand+size shorthands)
+    int diameterMm;          // nominal group size: 58, 54, 53, 51, 49
+    double doseMinG;         // recommended dose range, low end (grams)
+    double doseMaxG;         // recommended dose range, high end (grams)
+    WallProfile wall = WallProfile::Straight;
+    // True for a double-wall / "pressurized" basket: a second floor with one
+    // tiny exit orifice generates back-pressure itself, so the PUCK no longer
+    // sets resistance. Forgiving of coarse/pre-ground coffee but it MASKS the
+    // machine's pressure/flow curve — flow profiling is meaningless on one.
+    // The advisor should steer profiling users to a single-wall basket.
+    bool pressurized = false;
+    // True for a laser-drilled / tolerance-controlled "precision" basket
+    // (VST ±20µm, IMS competition, Weber, Pesado, Normcore, S-Works billet,
+    // and the precision-inspected Decent stock). Uniform holes + even open
+    // area remove a confound from flow telemetry and resist channeling.
+    bool precision = false;
+    int holeCount = 0;            // published hole count; 0 = unpublished
+    int holeDiameterMicrons = 0;  // published hole Ø in microns; 0 = unpublished
+    double depthMm = 0;           // published basket depth/height; 0 = unpublished
+    QString material = QStringLiteral("stainless steel");
+    QString notes;               // one-line AI enrichment: what it's known for
+};
+
+struct LookupResult {
+    QString brand;
+    QString model;
+    double doseMinG = 0;
+    double doseMaxG = 0;
+    bool precision = false;
+    bool pressurized = false;
+    bool found = false;
+};
+
+inline QVector<BasketEntry> allBaskets()
+{
+    using WP = WallProfile;
+    static const QVector<BasketEntry> entries = {
+        // --- Decent (58mm single-wall; holes precision-inspected under
+        //     microscope by Decent's own QC software, sold as the DE1 stock) ---
+        {"Decent", "Ridgeless 15g", {"decent 15g", "decent ridgeless 15g", "de1 15g"}, 58, 14, 16, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Stock small double; ridgeless for bottomless portafilters.")},
+        {"Decent", "Ridgeless 18g", {"decent 18g", "decent ridgeless 18g", "de1 18g", "decent stock"}, 58, 17, 19, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Basket shipped with the DE1 — the default everyday double.")},
+        {"Decent", "Ridgeless 20g", {"decent 20g", "decent ridgeless 20g", "de1 20g"}, 58, 19, 21, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Larger capacity ridgeless double for higher doses.")},
+        {"Decent", "Ridgeless 22g", {"decent 22g", "decent ridgeless 22g", "de1 22g"}, 58, 21, 23, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Largest standard ridgeless; high dose / darker roasts.")},
+        {"Decent", "Ridged 7g", {"decent 7g", "decent ridged 7g"}, 58, 6, 8, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Single-ristretto small basket; ridge grips a standard portafilter.")},
+        {"Decent", "Ridged 10g", {"decent 10g", "decent ridged 10g"}, 58, 9, 11, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Small low-dose basket for single / lighter shots.")},
+        {"Decent", "Slightly Waisted 14g", {"decent slightly waisted", "slightly waisted"}, 58, 12, 15, WP::Stepped, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Necks the 58mm bed down (~52mm) for added body; best near 14g.")},
+        {"Decent", "Very Waisted 14g", {"decent very waisted", "very waisted"}, 58, 12, 16, WP::Stepped, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("More taper than 'slightly' — more body, easier no-channel shots.")},
+        {"Decent", "Extremely Waisted 12g", {"decent extremely waisted", "extremely waisted"}, 58, 11, 14, WP::Stepped, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Most aggressive taper (~50mm bed); deep lever-style puck for body.")},
+
+        // --- Weber Workshops Unibasket (forged 304, 1.2mm blank, straight
+        //     walls with laser-ablated holes carried to the side wall) ---
+        {"Weber Workshops", "Unibasket 16g", {"unibasket 16g", "weber 16g", "weber unibasket 16g"}, 58, 15, 17, WP::Straight, false, true, 0, 0, 24, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("Holes to the side wall give a full ~58mm active puck vs ~48mm stock.")},
+        {"Weber Workshops", "Unibasket 20g", {"unibasket 20g", "weber 20g", "weber unibasket 20g"}, 58, 19, 21, WP::Straight, false, true, 0, 0, 26, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("20g drop-in Unibasket; same unibody straight-wall design.")},
+        {"Weber Workshops", "Unibasket 24g", {"unibasket 24g", "weber 24g", "weber unibasket 24g"}, 58, 23, 25, WP::Straight, false, true, 0, 0, 29, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("24g drop-in Unibasket.")},
+        {"Weber Workshops", "Unibasket 28g", {"unibasket 28g", "weber 28g", "weber unibasket 28g"}, 58, 27, 29, WP::Straight, false, true, 0, 0, 31, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("Largest Unibasket — a 28g 'mega-shot' size.")},
+
+        // --- VST (the WBC reference precision basket; every hole optically
+        //     verified to ~±20µm, individual test certificate per basket;
+        //     20% thicker steel; sold ridged AND ridgeless. Hole count and
+        //     micron Ø intentionally NOT published — the spec is the tolerance) ---
+        {"VST", "7g Single", {"vst 7g", "vst 7", "vst single"}, 58, 6, 8, WP::Straight, false, true, 0, 0, 28, QStringLiteral("20% thicker stainless"), QStringLiteral("Precision single basket; ±20µm hole tolerance like the rest of the line.")},
+        {"VST", "15g Double", {"vst 15g", "vst 15"}, 58, 14, 16, WP::Straight, false, true, 0, 0, 22, QStringLiteral("20% thicker stainless"), QStringLiteral("Precision EU double; ridged or ridgeless.")},
+        {"VST", "18g Double", {"vst 18g", "vst 18", "vst", "vst ridgeless 18g"}, 58, 17, 19, WP::Straight, false, true, 0, 0, 24, QStringLiteral("20% thicker stainless"), QStringLiteral("Most popular precision double and a WBC reference basket.")},
+        {"VST", "20g Competition", {"vst 20g", "vst 20"}, 58, 19, 21, WP::Straight, false, true, 0, 0, 26, QStringLiteral("20% thicker stainless"), QStringLiteral("20g competition double; ridged or ridgeless.")},
+        {"VST", "22g Triple", {"vst 22g", "vst 22"}, 58, 21, 23, WP::Straight, false, true, 0, 0, 28, QStringLiteral("20% thicker stainless"), QStringLiteral("Deeper triple-style precision basket for larger doses.")},
+        {"VST", "25g Triple+", {"vst 25g", "vst 25"}, 58, 24, 26, WP::Straight, false, true, 0, 0, 30, QStringLiteral("20% thicker stainless"), QStringLiteral("Largest VST size, 30mm deep.")},
+
+        // --- IMS (competition precision; 0.30mm holes standard. "M" flat
+        //     pattern, "TC" convex base, "E" ridgeless, "SF" SuperFine
+        //     membrane, "NT" Nanoquartz non-stick coating) ---
+        {"IMS", "Competition B70 2T H24.5 (12-18g)", {"ims 24.5", "ims h24.5", "ims competition 24.5"}, 58, 12, 18, WP::Straight, false, true, 0, 300, 24.5, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Flexible low-dose competition flat; 0.30mm holes.")},
+        {"IMS", "Competition B70 2T H26.5 (18-21g)", {"ims 26.5", "ims h26.5", "ims competition", "ims 18g"}, 58, 18, 21, WP::Straight, false, true, 641, 300, 26.5, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Reference IMS competition double — 641 holes at 0.30mm.")},
+        {"IMS", "Competition Convex B70 2TC H28.5 (19-22g)", {"ims convex", "ims 2tc", "ims h28.5"}, 58, 19, 22, WP::Convex, false, true, 715, 300, 28.5, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Convex base concentrates flow to the centre; 715 holes, ridgeless.")},
+        {"IMS", "SuperFine B70 2T H24 (14-16g)", {"ims superfine", "ims sf", "eb lab superfine"}, 58, 14, 16, WP::Straight, false, true, 565, 170, 24, QStringLiteral("stainless + 170µm membrane"), QStringLiteral("170µm membrane over 565 holes cuts fines passthrough for clarity.")},
+        {"IMS", "Nanoquartz B70 2TF NT (14-28g)", {"ims nanotech", "ims nanoquartz", "ims nt"}, 58, 14, 28, WP::Straight, false, true, 715, 300, 0, QStringLiteral("304 + Nanoquartz non-stick coating"), QStringLiteral("Competition geometry plus a water/oil-repellent non-stick coating for clean puck release.")},
+
+        // --- S-Works (CNC-machined from solid 17-4 PH stainless billet,
+        //     0.75mm walls, holes to the edge; sold in multiple flow patterns,
+        //     ~4% open area on standard patterns) ---
+        {"S-Works", "Billet Basket", {"sworks billet", "s-works billet", "sworks basket", "sworks"}, 58, 18, 20, WP::Straight, false, true, 0, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Machined billet, holes to the edge; many flow patterns, ~4% open area.")},
+        {"S-Works", "Tapered Billet", {"sworks tapered", "s-works tapered"}, 58, 18, 20, WP::Tapered, false, true, 0, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Truncated-cone billet for a 'blended', rounder shot.")},
+        {"S-Works", "Convex Billet", {"sworks convex", "s-works convex"}, 58, 17, 19, WP::Convex, false, true, 0, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Raised centre floor; needs a coarser grind, favours blooming shots.")},
+        {"S-Works", "Step Down Billet", {"sworks step down", "s-works step down", "sworks stepdown"}, 58, 12, 20, WP::Stepped, false, true, 0, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Necks 58mm to a ~49/32mm brew bed for a deeper, more forgiving puck.")},
+        {"S-Works", "Titanium Billet", {"sworks titanium", "s-works titanium"}, 58, 18, 20, WP::Straight, false, true, 0, 0, 0, QStringLiteral("solid titanium"), QStringLiteral("Halo item — ~30% lighter, each hole individually drilled.")},
+
+        // --- Graph Coffee (step-down baskets that convert a 58mm group to a
+        //     deep, narrow 46mm puck; need a bottomless portafilter) ---
+        {"Graph Coffee", "Stepped 58→46mm", {"graph stepped", "graph 58 46", "graph step down"}, 58, 16, 22, WP::Stepped, false, true, 648, 300, 29, QStringLiteral("laser-perforated stainless"), QStringLiteral("Steps a 58mm portafilter down to a 46mm deep puck; 648 holes at 0.30mm.")},
+        {"Graph Coffee", "Stepped 54→46mm (Breville)", {"graph 54 46", "graph breville", "graph sage"}, 54, 16, 22, WP::Stepped, false, true, 0, 300, 0, QStringLiteral("laser-perforated stainless"), QStringLiteral("Breville/Sage 54mm variant of the 46mm step-down.")},
+
+        // --- Pesado ---
+        {"Pesado", "HE High Extraction", {"pesado he", "pesado high extraction", "pesado 58.5", "pesado"}, 58, 17, 19, WP::Straight, false, true, 715, 300, 0, QStringLiteral("1.1mm stainless, electro-polished"), QStringLiteral("Funnel-shaped holes to the edge; high open area, favours light roasts.")},
+        {"Pesado", "EP Electro-Polished", {"pesado ep", "pesado electro polished"}, 58, 17, 19, WP::Tapered, false, false, 0, 0, 0, QStringLiteral("0.5mm stainless, electro-polished"), QStringLiteral("Budget electro-polished stock-replacement; smoother holes, more forgiving.")},
+
+        // --- Normcore (two flow tiers by hole geometry) ---
+        {"Normcore", "HE 0.28mm Standard Flow", {"normcore 0.28", "normcore standard flow", "normcore he 0.28"}, 58, 17, 19, WP::Straight, false, true, 786, 280, 0, QStringLiteral("0.8mm 304 stainless"), QStringLiteral("786 holes — faster flow, finer grind, higher clarity (light/medium).")},
+        {"Normcore", "HE 0.18mm Reduced Flow", {"normcore 0.18", "normcore reduced flow", "normcore he 0.18"}, 58, 17, 19, WP::Straight, false, true, 2475, 180, 0, QStringLiteral("0.8mm 304 stainless"), QStringLiteral("2475 holes — slower flow, thicker texture, coarser grind tolerance (medium/dark).")},
+        {"Normcore", "58→32mm Convex Step-Down", {"normcore step down", "normcore convex", "normcore 58 32"}, 58, 21, 23, WP::Convex, false, true, 444, 280, 0, QStringLiteral("stainless steel"), QStringLiteral("Convex step-down forms a deeper, focused puck; sold with puck screen.")},
+
+        // --- Pullman ---
+        {"Pullman", "Filtration876", {"pullman 876", "pullman filtration876", "pullman", "filtration876"}, 58, 17, 19, WP::Straight, false, true, 876, 300, 0, QStringLiteral("AISI 304 stainless, polished"), QStringLiteral("Guaranteed 58.7mm bore, 876 holes at 0.30mm; pairs with the BigStep tamper.")},
+
+        // --- Wafo (boutique 316L, naturally curved bottom) ---
+        {"Wafo", "Spirit", {"wafo spirit", "wafo soe spirit"}, 58, 17, 19, WP::Straight, false, true, 0, 0, 24.7, QStringLiteral("316L stainless"), QStringLiteral("Boutique full-coverage pattern for the most even extraction / clearest cup.")},
+        {"Wafo", "Checkmate", {"wafo checkmate", "wafo blend"}, 58, 17, 19, WP::Straight, false, true, 0, 0, 24.7, QStringLiteral("316L stainless"), QStringLiteral("Intentionally irregular hole layout for a deliberately distinctive flavour.")},
+
+        // --- E&B Lab (made by IMS; ridgeless competition, optional coating) ---
+        {"E&B Lab", "Superfine Competition", {"eb lab", "e&b lab", "eb lab competition", "e&b superfine"}, 58, 17, 19, WP::Straight, false, true, 715, 0, 24, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Ridgeless competition double with extra edge holes; optional nanotech coating.")},
+
+        // --- La Marzocco (current stock on LM machines is itself precision) ---
+        {"La Marzocco", "Advanced Precision", {"la marzocco advanced", "lm advanced precision", "la marzocco stock", "lm stock"}, 58, 16, 18, WP::Straight, false, true, 0, 0, 28, QStringLiteral("brushed stainless"), QStringLiteral("LM stock precision basket with digital-scan QC; fits Strada/Linea/GS3/Micra.")},
+        {"La Marzocco", "Strada (VST-developed)", {"la marzocco strada", "lm strada", "strada basket"}, 58, 16, 18, WP::Straight, false, true, 0, 0, 28, QStringLiteral("brushed stainless"), QStringLiteral("Older LM precision line co-developed with VST.")},
+
+        // --- Stock / OEM baskets (so the DB can describe 'what your machine
+        //     came with'). These are the non-precision stamped or pressurized
+        //     baskets common on prosumer and entry machines ---
+        {"Gaggia", "Classic Stock Double", {"gaggia double", "gaggia classic double", "gaggia stock"}, 58, 14, 16, WP::Tapered, false, false, 0, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Stock non-pressurized commercial double; shallow, so watch headspace above 16g.")},
+        {"Gaggia", "Classic Pressurized Double", {"gaggia pressurized", "gaggia dual wall"}, 58, 14, 18, WP::Tapered, true, false, 0, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Pressurized/dual-wall — fakes crema, grinder-forgiving, but defeats flow profiling.")},
+        {"Rancilio", "Silvia Stock Double", {"rancilio double", "silvia double", "rancilio stock"}, 58, 14, 16, WP::Tapered, false, false, 0, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Stock non-pressurized double; officially rated 16g, runs out of headspace above that.")},
+        {"Breville", "54mm Single-Wall Double", {"breville 54mm double", "sage 54mm double", "breville single wall"}, 54, 16, 19, WP::Tapered, false, false, 0, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Stock Breville/Sage 54mm single-wall double; needs a real grinder to dial in.")},
+        {"Breville", "54mm Dual-Wall Double", {"breville 54mm dual wall", "sage 54mm pressurized", "breville pressurized"}, 54, 16, 19, WP::Tapered, true, false, 0, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Stock Breville/Sage pressurized double; self-generates 9 bar, tolerant of pre-ground.")},
+    };
+    return entries;
+}
+
+// Map a wall profile to a short human/AI-readable word.
+inline QString wallProfileName(WallProfile w)
+{
+    switch (w) {
+    case WallProfile::Straight: return QStringLiteral("straight");
+    case WallProfile::Tapered:  return QStringLiteral("tapered");
+    case WallProfile::Stepped:  return QStringLiteral("stepped");
+    case WallProfile::Convex:   return QStringLiteral("convex");
+    }
+    return QStringLiteral("straight");
+}
+
+// Case-insensitive lookup by alias, longest-match-first (so "vst 18g ridgeless"
+// beats "vst"). Mirrors GrinderAliases::lookup. Returns found=false when no
+// alias matches; callers fall back to plain-numeric / no-enrichment behaviour.
+inline LookupResult lookup(const QString& rawBasketString)
+{
+    LookupResult result;
+    if (rawBasketString.trimmed().isEmpty())
+        return result;
+
+    const QString lower = rawBasketString.trimmed().toLower();
+    const auto& baskets = allBaskets();
+
+    qsizetype bestLen = 0;
+    const BasketEntry* bestMatch = nullptr;
+
+    // First pass: exact alias match
+    for (const auto& entry : baskets) {
+        for (const auto& alias : entry.aliases) {
+            if (lower == alias && alias.length() > bestLen) {
+                bestLen = alias.length();
+                bestMatch = &entry;
+            }
+        }
+    }
+
+    // Second pass: substring match (for strings like "VST 18g (ridgeless)")
+    if (!bestMatch) {
+        for (const auto& entry : baskets) {
+            for (const auto& alias : entry.aliases) {
+                if (lower.contains(alias) && alias.length() > bestLen) {
+                    bestLen = alias.length();
+                    bestMatch = &entry;
+                }
+            }
+        }
+    }
+
+    if (bestMatch) {
+        result.brand = bestMatch->brand;
+        result.model = bestMatch->model;
+        result.doseMinG = bestMatch->doseMinG;
+        result.doseMaxG = bestMatch->doseMaxG;
+        result.precision = bestMatch->precision;
+        result.pressurized = bestMatch->pressurized;
+        result.found = true;
+    }
+
+    return result;
+}
+
+// All known brands, unique and sorted (drives the vendor picker, like grinders).
+inline QStringList allBrands()
+{
+    QStringList brands;
+    for (const auto& entry : allBaskets()) {
+        if (!brands.contains(entry.brand))
+            brands << entry.brand;
+    }
+    brands.sort(Qt::CaseInsensitive);
+    return brands;
+}
+
+// All known models for a brand, in registry order.
+inline QStringList modelsForBrand(const QString& brand)
+{
+    QStringList models;
+    for (const auto& entry : allBaskets()) {
+        if (entry.brand.compare(brand, Qt::CaseInsensitive) == 0)
+            models << entry.model;
+    }
+    return models;
+}
+
+// Find the registry entry for an exact brand+model (case-insensitive).
+// Returns nullptr when not found.
+inline const BasketEntry* findEntry(const QString& brand, const QString& model)
+{
+    const auto& baskets = allBaskets();
+    for (const auto& e : baskets) {
+        if (e.brand.compare(brand, Qt::CaseInsensitive) == 0
+            && e.model.compare(model, Qt::CaseInsensitive) == 0)
+            return &e;
+    }
+    return nullptr;
+}
+
+// Resolve a raw basket string (e.g. a free-text shot field) to a registry
+// entry by alias in one call. Returns nullptr when no alias matches.
+inline const BasketEntry* findEntryByAlias(const QString& raw)
+{
+    const LookupResult r = lookup(raw);
+    return r.found ? findEntry(r.brand, r.model) : nullptr;
+}
+
+// Build a compact, AI-facing summary of a basket's brewing-relevant traits,
+// e.g. "58mm straight-wall single-wall precision, 17-19g, 641 holes @300µm".
+// Empty/zero fields are omitted so unpublished specs don't read as zeros.
+inline QString summary(const BasketEntry& b)
+{
+    QStringList parts;
+    if (b.diameterMm > 0)
+        parts << QString::number(b.diameterMm) + QStringLiteral("mm");
+    parts << wallProfileName(b.wall) + QStringLiteral("-wall");
+    parts << (b.pressurized ? QStringLiteral("pressurized/dual-wall")
+                            : QStringLiteral("single-wall"));
+    if (b.precision)
+        parts << QStringLiteral("precision");
+    if (b.doseMaxG > 0) {
+        auto g = [](double v) {
+            QString s = QString::number(v, 'f', 1);
+            if (s.endsWith(QStringLiteral(".0"))) s.chop(2);
+            return s;
+        };
+        parts << g(b.doseMinG) + QStringLiteral("-") + g(b.doseMaxG) + QStringLiteral("g");
+    }
+    if (b.holeCount > 0) {
+        QString holes = QString::number(b.holeCount) + QStringLiteral(" holes");
+        if (b.holeDiameterMicrons > 0)
+            holes += QStringLiteral(" @") + QString::number(b.holeDiameterMicrons) + QStringLiteral("µm");
+        parts << holes;
+    } else if (b.holeDiameterMicrons > 0) {
+        parts << QString::number(b.holeDiameterMicrons) + QStringLiteral("µm holes");
+    }
+    return parts.join(QStringLiteral(", "));
+}
+
+} // namespace BasketAliases

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -122,7 +122,7 @@ void SettingsDye::setEquipmentStorage(EquipmentStorage* storage)
             [this]() {
                 // An edit to the active package (incl. a copy-on-write that left
                 // its identity in place) — re-resolve the current selection.
-                const int id = activeEquipmentId();
+                const qint64 id = activeEquipmentId();
                 if (id > 0)
                     m_equipmentStorage->requestPackage(id);
             });
@@ -282,11 +282,11 @@ void SettingsDye::setDyeGrinderRpm(int value) {
     }
 }
 
-int SettingsDye::activeEquipmentId() const {
-    return m_settings.value("dye/activeEquipmentId", -1).toInt();
+qint64 SettingsDye::activeEquipmentId() const {
+    return m_settings.value("dye/activeEquipmentId", -1).toLongLong();
 }
 
-void SettingsDye::setActiveEquipmentId(int id) {
+void SettingsDye::setActiveEquipmentId(qint64 id) {
     if (activeEquipmentId() == id)
         return;
     m_settings.setValue("dye/activeEquipmentId", id);
@@ -302,7 +302,7 @@ void SettingsDye::setActiveEquipmentId(int id) {
 }
 
 void SettingsDye::switchToEquipment(const QVariantMap& pkg) {
-    const int id = pkg.value("id").toInt();
+    const qint64 id = pkg.value("id").toLongLong();
     if (id <= 0)
         return;
     setActiveEquipmentId(id);
@@ -557,7 +557,7 @@ void SettingsDye::applyActiveBag(const QVariantMap& bag)
     // bag's bean-scoped dial-in; apply when present (a fresh bag with none keeps
     // the current dial and adopts it on the next edit / shot stamp). Guarded by
     // m_applyingBag so none of this writes back to the bag/package.
-    setActiveEquipmentId(bag.value("equipmentId", -1).toInt());
+    setActiveEquipmentId(bag.value("equipmentId", -1).toLongLong());
     const QString grindSetting = bag.value("grinderSetting").toString();
     if (!grindSetting.isEmpty())
         setDyeGrinderSetting(grindSetting);
@@ -610,7 +610,7 @@ void SettingsDye::writeThroughToActivePackage(const QString& field, const QVaria
 {
     if (m_applyingBag || !m_equipmentStorage)
         return;
-    const int eqId = activeEquipmentId();
+    const qint64 eqId = activeEquipmentId();
     if (eqId <= 0)
         return;
     m_equipmentStorage->requestUpdatePackage(eqId, {{field, value}});

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -306,8 +306,9 @@ void SettingsDye::switchToEquipment(const QVariantMap& pkg) {
     if (id <= 0)
         return;
     setActiveEquipmentId(id);
-    // Apply the package's grinder identity (transitional: still cached in
-    // QSettings + bag grinder_* columns via the existing setters).
+    // Apply the package's grinder identity to the display cache. The setters
+    // cache in QSettings only (no bag write-through); identity is owned by the
+    // equipment package and re-resolved from it on activeEquipmentId changes.
     setDyeGrinderBrand(pkg.value("grinderBrand").toString());
     setDyeGrinderModel(pkg.value("grinderModel").toString());
     setDyeGrinderBurrs(pkg.value("grinderBurrs").toString());

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -1,6 +1,7 @@
 #include "settings_dye.h"
 #include "../history/bagid.h"
 #include "../history/coffeebagstorage.h"
+#include "../history/equipmentstorage.h"
 #include "settings_visualizer.h"
 #include "grinderaliases.h"
 
@@ -99,6 +100,11 @@ void SettingsDye::setBagStorage(CoffeeBagStorage* storage)
 
     if (bagIdIsSet(activeBagId()))
         m_bagStorage->requestBag(activeBagId());
+}
+
+void SettingsDye::setEquipmentStorage(EquipmentStorage* storage)
+{
+    m_equipmentStorage = storage;
 }
 
 // DYE metadata

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -163,6 +163,7 @@ void SettingsDye::ensureDyeCacheLoaded() const {
         m_dyeGrinderModelCache = m_settings.value("dye/grinderModel", "").toString();
         m_dyeGrinderBurrsCache = m_settings.value("dye/grinderBurrs", "").toString();
         m_dyeGrinderSettingCache = m_settings.value("dye/grinderSetting", "").toString();
+        m_dyeGrinderRpmCache = m_settings.value("dye/grinderRpm", 0).toInt();
         m_dyeBeanWeightCache = m_settings.value("dye/beanWeight", 18.0).toDouble();
         m_dyeDrinkWeightCache = m_settings.value("dye/drinkWeight", 36.0).toDouble();
         m_dyeCacheInitialized = true;
@@ -221,8 +222,57 @@ void SettingsDye::setDyeGrinderSetting(const QString& value) {
         m_dyeGrinderSettingCache = value;
         m_settings.setValue("dye/grinderSetting", value);
         writeThroughToBag("grinderSetting", value);
+        // Dual write-through: the grind setting is grinder-scoped too, so keep
+        // the active package's last dial current (add-equipment-packages).
+        writeThroughToActivePackage("lastGrindSetting", value);
         emit dyeGrinderSettingChanged();
     }
+}
+
+int SettingsDye::dyeGrinderRpm() const {
+    ensureDyeCacheLoaded();
+    return m_dyeGrinderRpmCache;
+}
+
+void SettingsDye::setDyeGrinderRpm(int value) {
+    if (dyeGrinderRpm() != value) {
+        m_dyeGrinderRpmCache = value;
+        m_settings.setValue("dye/grinderRpm", value);
+        writeThroughToBag("rpm", value > 0 ? QVariant(value) : QVariant());
+        writeThroughToActivePackage("lastRpm", value > 0 ? QVariant(value) : QVariant());
+        emit dyeGrinderRpmChanged();
+    }
+}
+
+int SettingsDye::activeEquipmentId() const {
+    return m_settings.value("dye/activeEquipmentId", -1).toInt();
+}
+
+void SettingsDye::setActiveEquipmentId(int id) {
+    if (activeEquipmentId() == id)
+        return;
+    m_settings.setValue("dye/activeEquipmentId", id);
+    // The active bag adopts the package (skipped during applyActiveBag via the
+    // m_applyingBag guard inside writeThroughToBag).
+    writeThroughToBag("equipmentId", id > 0 ? QVariant(id) : QVariant());
+    emit activeEquipmentIdChanged();
+}
+
+void SettingsDye::switchToEquipment(const QVariantMap& pkg) {
+    const int id = pkg.value("id").toInt();
+    if (id <= 0)
+        return;
+    setActiveEquipmentId(id);
+    // Apply the package's grinder identity (transitional: still cached in
+    // QSettings + bag grinder_* columns via the existing setters).
+    setDyeGrinderBrand(pkg.value("grinderBrand").toString());
+    setDyeGrinderModel(pkg.value("grinderModel").toString());
+    setDyeGrinderBurrs(pkg.value("grinderBurrs").toString());
+    // Apply the package's last dial — grinder-scoped memory, never blank, editable.
+    setDyeGrinderSetting(pkg.value("lastGrindSetting").toString());
+    setDyeGrinderRpm(pkg.value("lastRpm").toInt());
+    if (m_equipmentStorage)
+        m_equipmentStorage->requestTouchLastUsed(id);
 }
 
 QStringList SettingsDye::suggestedBurrs(const QString& brand, const QString& model) const {
@@ -469,6 +519,12 @@ void SettingsDye::applyActiveBag(const QVariantMap& bag)
     if (dose > 0)
         setDyeBeanWeight(dose);
 
+    // Equipment package the bag points at, plus its rpm dial-in (bean-scoped
+    // memory). Guarded by m_applyingBag so these don't write back to bag/package.
+    // The grind setting above is the bag's; rpm follows the same bean-scoped rule.
+    setActiveEquipmentId(bag.value("equipmentId", -1).toInt());
+    setDyeGrinderRpm(bag.value("rpm", 0).toInt());
+
     m_applyingBag = false;
 
     const QString frozen = bag.value("frozenDate").toString();
@@ -505,4 +561,14 @@ void SettingsDye::writeThroughToBag(const QString& field, const QVariant& value)
         return;
     m_pendingSelfWrites++;
     m_bagStorage->requestUpdateBag(bagId, {{field, value}});
+}
+
+void SettingsDye::writeThroughToActivePackage(const QString& field, const QVariant& value)
+{
+    if (m_applyingBag || !m_equipmentStorage)
+        return;
+    const int eqId = activeEquipmentId();
+    if (eqId <= 0)
+        return;
+    m_equipmentStorage->requestUpdatePackage(eqId, {{field, value}});
 }

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -104,7 +104,41 @@ void SettingsDye::setBagStorage(CoffeeBagStorage* storage)
 
 void SettingsDye::setEquipmentStorage(EquipmentStorage* storage)
 {
+    if (m_equipmentStorage == storage)
+        return;
     m_equipmentStorage = storage;
+    if (!m_equipmentStorage)
+        return;
+
+    // The active package is the source of truth for grinder identity; resolve it
+    // here and refresh the display cache whenever it arrives or changes.
+    connect(m_equipmentStorage, &EquipmentStorage::packageReady, this,
+            [this](qint64 packageId, const QVariantMap& pkg) {
+                if (packageId != activeEquipmentId())
+                    return;
+                applyEquipmentIdentity(pkg);  // empty pkg (not found) clears it
+            });
+    connect(m_equipmentStorage, &EquipmentStorage::packagesChanged, this,
+            [this]() {
+                // An edit to the active package (incl. a copy-on-write that left
+                // its identity in place) — re-resolve the current selection.
+                const int id = activeEquipmentId();
+                if (id > 0)
+                    m_equipmentStorage->requestPackage(id);
+            });
+
+    if (activeEquipmentId() > 0)
+        m_equipmentStorage->requestPackage(activeEquipmentId());
+}
+
+// Refresh the grinder-identity display cache from a resolved package map (from
+// EquipmentStorage). Display-only: the setters update the cache + QSettings
+// mirror, never the bag.
+void SettingsDye::applyEquipmentIdentity(const QVariantMap& pkg)
+{
+    setDyeGrinderBrand(pkg.value("grinderBrand").toString());
+    setDyeGrinderModel(pkg.value("grinderModel").toString());
+    setDyeGrinderBurrs(pkg.value("grinderBurrs").toString());
 }
 
 // DYE metadata
@@ -175,11 +209,17 @@ QString SettingsDye::dyeGrinderBrand() const {
     return m_dyeGrinderBrandCache;
 }
 
+// Grinder identity (brand/model/burrs) is RESOLVED from the active equipment
+// package (add-equipment-packages), not stored on the bag. These setters update
+// the display cache (+ a QSettings mirror for correct cold-start before the
+// package resolves) and emit — they do NOT write through to the bag. The cache
+// is refreshed from the package by applyEquipmentIdentity() whenever the active
+// package changes; callers wanting to *change* identity go through the equipment
+// package (switchToEquipment / equipment_update), not these setters.
 void SettingsDye::setDyeGrinderBrand(const QString& value) {
     if (dyeGrinderBrand() != value) {
         m_dyeGrinderBrandCache = value;
         m_settings.setValue("dye/grinderBrand", value);
-        writeThroughToBag("grinderBrand", value);
         emit dyeGrinderBrandChanged();
     }
 }
@@ -193,7 +233,6 @@ void SettingsDye::setDyeGrinderModel(const QString& value) {
     if (dyeGrinderModel() != value) {
         m_dyeGrinderModelCache = value;
         m_settings.setValue("dye/grinderModel", value);
-        writeThroughToBag("grinderModel", value);
         emit dyeGrinderModelChanged();
     }
 }
@@ -207,7 +246,6 @@ void SettingsDye::setDyeGrinderBurrs(const QString& value) {
     if (dyeGrinderBurrs() != value) {
         m_dyeGrinderBurrsCache = value;
         m_settings.setValue("dye/grinderBurrs", value);
-        writeThroughToBag("grinderBurrs", value);
         emit dyeGrinderBurrsChanged();
     }
 }
@@ -256,6 +294,11 @@ void SettingsDye::setActiveEquipmentId(int id) {
     // m_applyingBag guard inside writeThroughToBag).
     writeThroughToBag("equipmentId", id > 0 ? QVariant(id) : QVariant());
     emit activeEquipmentIdChanged();
+    // Resolve the package to refresh the grinder-identity display cache.
+    if (id > 0 && m_equipmentStorage)
+        m_equipmentStorage->requestPackage(id);   // -> packageReady -> applyEquipmentIdentity
+    else if (id <= 0)
+        applyEquipmentIdentity({});               // no equipment -> clear identity
 }
 
 void SettingsDye::switchToEquipment(const QVariantMap& pkg) {
@@ -508,26 +551,21 @@ void SettingsDye::applyActiveBag(const QVariantMap& bag)
     setDyeBeanBaseId(bag.value("beanBaseId").toString());
     setDyeBeanBaseData(bag.value("beanBaseData").toString());
 
-    // Grinder/dose are "last used with this bag": only applied when the bag
-    // has them. A fresh bag keeps the current setup and adopts it through
-    // write-through on the next edit / dose stamp on the next shot.
-    const QString grinderBrand = bag.value("grinderBrand").toString();
-    const QString grinderModel = bag.value("grinderModel").toString();
-    if (!grinderBrand.isEmpty() || !grinderModel.isEmpty()) {
-        setDyeGrinderBrand(grinderBrand);
-        setDyeGrinderModel(grinderModel);
-        setDyeGrinderBurrs(bag.value("grinderBurrs").toString());
-        setDyeGrinderSetting(bag.value("grinderSetting").toString());
-    }
+    // Grinder IDENTITY is not on the bag — it resolves from the equipment
+    // package the bag points at (equipment_id). Grind setting + rpm are the
+    // bag's bean-scoped dial-in; apply when present (a fresh bag with none keeps
+    // the current dial and adopts it on the next edit / shot stamp). Guarded by
+    // m_applyingBag so none of this writes back to the bag/package.
+    setActiveEquipmentId(bag.value("equipmentId", -1).toInt());
+    const QString grindSetting = bag.value("grinderSetting").toString();
+    if (!grindSetting.isEmpty())
+        setDyeGrinderSetting(grindSetting);
+    const int bagRpm = bag.value("rpm", 0).toInt();
+    if (bagRpm > 0)
+        setDyeGrinderRpm(bagRpm);
     const double dose = bag.value("doseWeightG", 0.0).toDouble();
     if (dose > 0)
         setDyeBeanWeight(dose);
-
-    // Equipment package the bag points at, plus its rpm dial-in (bean-scoped
-    // memory). Guarded by m_applyingBag so these don't write back to bag/package.
-    // The grind setting above is the bag's; rpm follows the same bean-scoped rule.
-    setActiveEquipmentId(bag.value("equipmentId", -1).toInt());
-    setDyeGrinderRpm(bag.value("rpm", 0).toInt());
 
     m_applyingBag = false;
 

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -275,6 +275,10 @@ void SettingsDye::switchToEquipment(const QVariantMap& pkg) {
         m_equipmentStorage->requestTouchLastUsed(id);
 }
 
+bool SettingsDye::grinderRpmCapable(const QString& brand, const QString& model) const {
+    return EquipmentStorage::deriveRpmCapable(brand, model);
+}
+
 QStringList SettingsDye::suggestedBurrs(const QString& brand, const QString& model) const {
     return GrinderAliases::suggestedBurrs(brand, model);
 }

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -139,6 +139,16 @@ void SettingsDye::applyEquipmentIdentity(const QVariantMap& pkg)
     setDyeGrinderBrand(pkg.value("grinderBrand").toString());
     setDyeGrinderModel(pkg.value("grinderModel").toString());
     setDyeGrinderBurrs(pkg.value("grinderBurrs").toString());
+
+    // The package's display name (user-editable label; defaults to "{brand}
+    // {model}"). Surfaced so UI shows the package name, not the grinder identity.
+    QString name = pkg.value("name").toString().trimmed();
+    if (name.isEmpty())
+        name = (dyeGrinderBrand().trimmed() + QLatin1Char(' ') + dyeGrinderModel().trimmed()).trimmed();
+    if (m_dyeEquipmentName != name) {
+        m_dyeEquipmentName = name;
+        emit dyeEquipmentNameChanged();
+    }
 }
 
 // DYE metadata

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -34,6 +34,12 @@ class SettingsDye : public QObject {
     Q_PROPERTY(QString dyeGrinderModel READ dyeGrinderModel WRITE setDyeGrinderModel NOTIFY dyeGrinderModelChanged)
     Q_PROPERTY(QString dyeGrinderBurrs READ dyeGrinderBurrs WRITE setDyeGrinderBurrs NOTIFY dyeGrinderBurrsChanged)
     Q_PROPERTY(QString dyeGrinderSetting READ dyeGrinderSetting WRITE setDyeGrinderSetting NOTIFY dyeGrinderSettingChanged)
+    // Grinder rpm dial-in (add-equipment-packages); shown only when the active
+    // package's grinder is rpmCapable. 0 = unset.
+    Q_PROPERTY(int dyeGrinderRpm READ dyeGrinderRpm WRITE setDyeGrinderRpm NOTIFY dyeGrinderRpmChanged)
+    // The active equipment package id (the grinder the next shot is ground on).
+    // Switching it applies the package's grinder identity + last dial.
+    Q_PROPERTY(int activeEquipmentId READ activeEquipmentId WRITE setActiveEquipmentId NOTIFY activeEquipmentIdChanged)
     Q_PROPERTY(double dyeBeanWeight READ dyeBeanWeight WRITE setDyeBeanWeight NOTIFY dyeBeanWeightChanged)
     Q_PROPERTY(double dyeDrinkWeight READ dyeDrinkWeight WRITE setDyeDrinkWeight NOTIFY dyeDrinkWeightChanged)
     Q_PROPERTY(double dyeDrinkTds READ dyeDrinkTds WRITE setDyeDrinkTds NOTIFY dyeDrinkTdsChanged)
@@ -98,6 +104,18 @@ public:
 
     QString dyeGrinderSetting() const;
     void setDyeGrinderSetting(const QString& value);
+
+    int dyeGrinderRpm() const;
+    void setDyeGrinderRpm(int value);
+
+    int activeEquipmentId() const;
+    void setActiveEquipmentId(int id);
+
+    // User-facing equipment switch: adopt the package's grinder identity and its
+    // last dial (grind setting + rpm), and point the active bag at it. `pkg` is a
+    // package map from EquipmentStorage (id, grinderBrand/Model/Burrs,
+    // lastGrindSetting, lastRpm).
+    Q_INVOKABLE void switchToEquipment(const QVariantMap& pkg);
 
     Q_INVOKABLE QStringList suggestedBurrs(const QString& brand, const QString& model) const;
     Q_INVOKABLE bool isBurrSwappable(const QString& brand, const QString& model) const;
@@ -181,6 +199,8 @@ signals:
     void dyeGrinderModelChanged();
     void dyeGrinderBurrsChanged();
     void dyeGrinderSettingChanged();
+    void dyeGrinderRpmChanged();
+    void activeEquipmentIdChanged();
     void dyeBeanWeightChanged();
     void dyeDrinkWeightChanged();
     void dyeDrinkTdsChanged();
@@ -210,6 +230,9 @@ private:
     // Queue an async write of one field to the active bag (no-op while
     // applyActiveBag is running or when no bag/storage is attached).
     void writeThroughToBag(const QString& field, const QVariant& value);
+    // Queue an async write of one field to the active equipment package (no-op
+    // while applyActiveBag is running or when no package/storage is attached).
+    void writeThroughToActivePackage(const QString& field, const QVariant& value);
 
     mutable QSettings m_settings;
     SettingsVisualizer* m_visualizer = nullptr;  // Non-owning; for default-rating fallback.
@@ -228,6 +251,7 @@ private:
     mutable QString m_dyeGrinderModelCache;
     mutable QString m_dyeGrinderBurrsCache;
     mutable QString m_dyeGrinderSettingCache;
+    mutable int m_dyeGrinderRpmCache = 0;
     mutable double m_dyeBeanWeightCache = 18.0;
     mutable double m_dyeDrinkWeightCache = 36.0;
     mutable bool m_dyeCacheInitialized = false;

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -117,6 +117,11 @@ public:
     // lastGrindSetting, lastRpm).
     Q_INVOKABLE void switchToEquipment(const QVariantMap& pkg);
 
+    // True when the grinder identity is rpm-adjustable (registry variableRpm, or
+    // a custom grinder not in the registry). Drives the rpm field's visibility in
+    // Brew Settings.
+    Q_INVOKABLE bool grinderRpmCapable(const QString& brand, const QString& model) const;
+
     Q_INVOKABLE QStringList suggestedBurrs(const QString& brand, const QString& model) const;
     Q_INVOKABLE bool isBurrSwappable(const QString& brand, const QString& model) const;
     Q_INVOKABLE QStringList knownGrinderBrands() const;

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -8,6 +8,7 @@
 
 class SettingsVisualizer;
 class CoffeeBagStorage;
+class EquipmentStorage;
 
 // DYE (Describe Your Espresso) metadata. Split from Settings to keep
 // settings.h's transitive-include footprint small. Holds a non-owning
@@ -67,6 +68,11 @@ public:
     // bag updates so external edits (bag edit dialog, Next Portion, dose
     // stamp) refresh the cache.
     void setBagStorage(CoffeeBagStorage* storage);
+
+    // Non-owning; attached by MainController after storage init. The active
+    // bag's equipment_id points at a package here; the dye grinder identity is
+    // resolved through it (add-equipment-packages).
+    void setEquipmentStorage(EquipmentStorage* storage);
 
     // DYE metadata
     QString dyeBeanBrand() const;
@@ -208,6 +214,7 @@ private:
     mutable QSettings m_settings;
     SettingsVisualizer* m_visualizer = nullptr;  // Non-owning; for default-rating fallback.
     CoffeeBagStorage* m_bagStorage = nullptr;    // Non-owning; attached post-init.
+    EquipmentStorage* m_equipmentStorage = nullptr; // Non-owning; attached post-init.
 
     bool m_applyingBag = false;  // Suppress write-through echo during applyActiveBag
     bool m_keepFieldsOnNextApply = false;  // setActiveBagKeepFields: next bagReady only refreshes lifecycle

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -39,7 +39,7 @@ class SettingsDye : public QObject {
     Q_PROPERTY(int dyeGrinderRpm READ dyeGrinderRpm WRITE setDyeGrinderRpm NOTIFY dyeGrinderRpmChanged)
     // The active equipment package id (the grinder the next shot is ground on).
     // Switching it applies the package's grinder identity + last dial.
-    Q_PROPERTY(int activeEquipmentId READ activeEquipmentId WRITE setActiveEquipmentId NOTIFY activeEquipmentIdChanged)
+    Q_PROPERTY(qint64 activeEquipmentId READ activeEquipmentId WRITE setActiveEquipmentId NOTIFY activeEquipmentIdChanged)
     Q_PROPERTY(double dyeBeanWeight READ dyeBeanWeight WRITE setDyeBeanWeight NOTIFY dyeBeanWeightChanged)
     Q_PROPERTY(double dyeDrinkWeight READ dyeDrinkWeight WRITE setDyeDrinkWeight NOTIFY dyeDrinkWeightChanged)
     Q_PROPERTY(double dyeDrinkTds READ dyeDrinkTds WRITE setDyeDrinkTds NOTIFY dyeDrinkTdsChanged)
@@ -108,8 +108,8 @@ public:
     int dyeGrinderRpm() const;
     void setDyeGrinderRpm(int value);
 
-    int activeEquipmentId() const;
-    void setActiveEquipmentId(int id);
+    qint64 activeEquipmentId() const;
+    void setActiveEquipmentId(qint64 id);
 
     // User-facing equipment switch: adopt the package's grinder identity and its
     // last dial (grind setting + rpm), and point the active bag at it. `pkg` is a

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -33,6 +33,9 @@ class SettingsDye : public QObject {
     Q_PROPERTY(QString dyeGrinderBrand READ dyeGrinderBrand WRITE setDyeGrinderBrand NOTIFY dyeGrinderBrandChanged)
     Q_PROPERTY(QString dyeGrinderModel READ dyeGrinderModel WRITE setDyeGrinderModel NOTIFY dyeGrinderModelChanged)
     Q_PROPERTY(QString dyeGrinderBurrs READ dyeGrinderBurrs WRITE setDyeGrinderBurrs NOTIFY dyeGrinderBurrsChanged)
+    // Active package's display name (read-only; defaults to "{brand} {model}").
+    // UI shows this instead of the raw grinder identity (add-equipment-packages).
+    Q_PROPERTY(QString dyeEquipmentName READ dyeEquipmentName NOTIFY dyeEquipmentNameChanged)
     Q_PROPERTY(QString dyeGrinderSetting READ dyeGrinderSetting WRITE setDyeGrinderSetting NOTIFY dyeGrinderSettingChanged)
     // Grinder rpm dial-in (add-equipment-packages); shown only when the active
     // package's grinder is rpmCapable. 0 = unset.
@@ -101,6 +104,8 @@ public:
 
     QString dyeGrinderBurrs() const;
     void setDyeGrinderBurrs(const QString& value);
+
+    QString dyeEquipmentName() const { return m_dyeEquipmentName; }
 
     QString dyeGrinderSetting() const;
     void setDyeGrinderSetting(const QString& value);
@@ -203,6 +208,7 @@ signals:
     void dyeGrinderBrandChanged();
     void dyeGrinderModelChanged();
     void dyeGrinderBurrsChanged();
+    void dyeEquipmentNameChanged();
     void dyeGrinderSettingChanged();
     void dyeGrinderRpmChanged();
     void activeEquipmentIdChanged();
@@ -257,6 +263,7 @@ private:
     mutable QString m_dyeGrinderBrandCache;
     mutable QString m_dyeGrinderModelCache;
     mutable QString m_dyeGrinderBurrsCache;
+    QString m_dyeEquipmentName;  // active package display name (resolved, not persisted)
     mutable QString m_dyeGrinderSettingCache;
     mutable int m_dyeGrinderRpmCache = 0;
     mutable double m_dyeBeanWeightCache = 18.0;

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -238,6 +238,8 @@ private:
     // Queue an async write of one field to the active equipment package (no-op
     // while applyActiveBag is running or when no package/storage is attached).
     void writeThroughToActivePackage(const QString& field, const QVariant& value);
+    // Refresh the grinder-identity display cache from a resolved package map.
+    void applyEquipmentIdentity(const QVariantMap& pkg);
 
     mutable QSettings m_settings;
     SettingsVisualizer* m_visualizer = nullptr;  // Non-owning; for default-rating fallback.

--- a/src/core/settings_network.cpp
+++ b/src/core/settings_network.cpp
@@ -371,7 +371,7 @@ QJsonObject SettingsNetwork::getLayoutObject() const {
             bool placed = false;
             for (const QString& zoneName : zones.keys()) {
                 QJsonArray items = zones[zoneName].toArray();
-                for (int i = 0; i < items.size(); ++i) {
+                for (qsizetype i = 0; i < items.size(); ++i) {
                     if (items[i].toObject()["type"].toString() == "beans") {
                         items.insert(i + 1, equipmentItem);
                         zones[zoneName] = items;

--- a/src/core/settings_network.cpp
+++ b/src/core/settings_network.cpp
@@ -278,6 +278,7 @@ QString SettingsNetwork::defaultLayoutJson() const {
         QJsonObject({{"type", "history"}, {"id", "history1"}}),
         QJsonObject({{"type", "spacer"}, {"id", "spacer2"}}),
         QJsonObject({{"type", "beans"}, {"id", "beans1"}}),
+        QJsonObject({{"type", "equipment"}, {"id", "equipment1"}}),
         QJsonObject({{"type", "autofavorites"}, {"id", "autofavorites1"}}),
         QJsonObject({{"type", "settings"}, {"id", "settings1"}}),
     });
@@ -346,7 +347,51 @@ QJsonObject SettingsNetwork::getLayoutObject() const {
         if (textMigrated)
             zones[zoneName] = items;
     }
-    if (textMigrated) {
+    // Migration: ensure an Equipment idle button exists (add-equipment-packages).
+    // Inject it immediately after the beans item so every upgraded user gets it
+    // in a sensible default place regardless of their custom layout (fall back to
+    // appending to bottomRight if beans was removed). Idempotent + persisted once
+    // so it never duplicates.
+    bool equipmentInjected = false;
+    {
+        bool hasEquipment = false;
+        for (const QString& zoneName : zones.keys()) {
+            const QJsonArray items = zones[zoneName].toArray();
+            for (const QJsonValue& v : items) {
+                if (v.toObject()["type"].toString() == "equipment") {
+                    hasEquipment = true;
+                    break;
+                }
+            }
+            if (hasEquipment)
+                break;
+        }
+        if (!hasEquipment) {
+            const QJsonObject equipmentItem{{"type", "equipment"}, {"id", "equipment1"}};
+            bool placed = false;
+            for (const QString& zoneName : zones.keys()) {
+                QJsonArray items = zones[zoneName].toArray();
+                for (int i = 0; i < items.size(); ++i) {
+                    if (items[i].toObject()["type"].toString() == "beans") {
+                        items.insert(i + 1, equipmentItem);
+                        zones[zoneName] = items;
+                        placed = true;
+                        break;
+                    }
+                }
+                if (placed)
+                    break;
+            }
+            if (!placed) {
+                QJsonArray br = zones.value("bottomRight").toArray();
+                br.append(equipmentItem);
+                zones["bottomRight"] = br;
+            }
+            equipmentInjected = true;
+        }
+    }
+
+    if (textMigrated || equipmentInjected) {
         layout["zones"] = zones;
         // Persist the migration so it only runs once
         const_cast<SettingsNetwork*>(this)->saveLayoutObject(layout);

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -130,7 +130,8 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
     // Bean presets were replaced by coffee bags (bean-bag-inventory). Bags
     // live in the shot history database, which transfers via the DB import
     // path (with id remapping) — not through settings JSON. dye/activeBagId
-    // is also deliberately NOT exported: it is a device-local DB row id.
+    // and dye/activeEquipmentId (the active equipment package) are likewise
+    // deliberately NOT exported: both are device-local DB row ids.
     // importFromJson still understands the legacy "beans" section from
     // old-version exports.
 

--- a/src/history/coffeebagstorage.cpp
+++ b/src/history/coffeebagstorage.cpp
@@ -126,6 +126,8 @@ const BagCol kCols[] = {
     COL_STR  ("grinder_model",         grinderModel,        false),
     COL_STR  ("grinder_burrs",         grinderBurrs,        false),
     COL_STR  ("grinder_setting",       grinderSetting,      false),
+    COL_EPOCH("equipment_id",          equipmentId),
+    COL_EPOCH("rpm",                   rpm),
     COL_DBL  ("dose_weight_g",         doseWeightG),
     COL_DBL  ("yield_override_g",      yieldOverrideG),
     COL_STR  ("visualizer_bag_id",     visualizerBagId,     false),
@@ -395,6 +397,8 @@ bool CoffeeBagStorage::ensureTableStatic(QSqlDatabase& db)
             grinder_model TEXT,
             grinder_burrs TEXT,
             grinder_setting TEXT,
+            equipment_id INTEGER,
+            rpm INTEGER,
             dose_weight_g REAL,
             yield_override_g REAL,
             visualizer_bag_id TEXT,
@@ -770,7 +774,11 @@ bool CoffeeBagStorage::importBagsStatic(QSqlDatabase& srcDb, QSqlDatabase& destD
 
     int imported = 0, matched = 0;
     while (srcBags.next()) {
-        const CoffeeBag bag = bagFromQueryRow(srcBags);
+        CoffeeBag bag = bagFromQueryRow(srcBags);
+        // Equipment packages are not transferred yet (add-equipment-packages
+        // task 2.8); drop the source equipment_id so it can't mislink to an
+        // unrelated dest package. rpm (a plain dial-in number) carries fine.
+        bag.equipmentId = 0;
 
         qint64 destId = -1;
         if (merge) {

--- a/src/history/coffeebagstorage.cpp
+++ b/src/history/coffeebagstorage.cpp
@@ -122,9 +122,10 @@ const BagCol kCols[] = {
     COL_STR  ("notes",                 notes,               true),
     COL_DBL  ("start_weight_g",        startWeightG),
     COL_BOOL ("in_inventory",          inInventory),
-    COL_STR  ("grinder_brand",         grinderBrand,        false),
-    COL_STR  ("grinder_model",         grinderModel,        false),
-    COL_STR  ("grinder_burrs",         grinderBurrs,        false),
+    // Grinder identity (brand/model/burrs) is no longer stored on the bag —
+    // it resolves through equipment_id to the package's grinder item
+    // (migration 23 dropped the columns). The grind setting + rpm stay as the
+    // bag's bean-scoped dial memory.
     COL_STR  ("grinder_setting",       grinderSetting,      false),
     COL_EPOCH("equipment_id",          equipmentId),
     COL_EPOCH("rpm",                   rpm),
@@ -393,6 +394,10 @@ bool CoffeeBagStorage::ensureTableStatic(QSqlDatabase& db)
             notes TEXT,
             start_weight_g REAL,
             in_inventory INTEGER NOT NULL DEFAULT 1,
+            -- Grinder identity columns are created here for the migration chain
+            -- (migration 22 reads them to seed equipment packages) and dropped by
+            -- migration 23 once identity resolves via equipment_id. Runtime
+            -- reads/writes go through kCols, which no longer lists them.
             grinder_brand TEXT,
             grinder_model TEXT,
             grinder_burrs TEXT,
@@ -568,9 +573,9 @@ CoffeeBag CoffeeBagStorage::bagFromLegacyPreset(const QJsonObject& preset)
     bag.roastLevel = preset.value("roastLevel").toString();
     bag.beanBaseId = preset.value("beanBaseId").toString();
     bag.beanBaseData = preset.value("beanBaseData").toString();
-    bag.grinderBrand = preset.value("grinderBrand").toString();
-    bag.grinderModel = preset.value("grinderModel").toString();
-    bag.grinderBurrs = preset.value("grinderBurrs").toString();
+    // Grinder identity is no longer a bag column (migration 23) — it resolves
+    // through equipment_id. Legacy presets predate the equipment model and carry
+    // no package linkage, so only the grind setting is carried across.
     bag.grinderSetting = preset.value("grinderSetting").toString();
     bag.inInventory = true;
 
@@ -748,7 +753,8 @@ qint64 CoffeeBagStorage::convertLegacyPresetSettings(const QString& dbPath)
 }
 
 bool CoffeeBagStorage::importBagsStatic(QSqlDatabase& srcDb, QSqlDatabase& destDb, bool merge,
-                                        QHash<qint64, qint64>& outIdMap)
+                                        QHash<qint64, qint64>& outIdMap,
+                                        const QHash<qint64, qint64>& packageIdMap)
 {
     // Pre-migration-19 source: no coffee_bags table, nothing to import.
     {
@@ -775,10 +781,11 @@ bool CoffeeBagStorage::importBagsStatic(QSqlDatabase& srcDb, QSqlDatabase& destD
     int imported = 0, matched = 0;
     while (srcBags.next()) {
         CoffeeBag bag = bagFromQueryRow(srcBags);
-        // Equipment packages are not transferred yet (add-equipment-packages
-        // task 2.8); drop the source equipment_id so it can't mislink to an
-        // unrelated dest package. rpm (a plain dial-in number) carries fine.
-        bag.equipmentId = 0;
+        // Remap the source equipment_id to the imported package's new dest id
+        // (add-equipment-packages task 2.8). A source id absent from the map
+        // (older source with no equipment tables, or an unmatched package)
+        // becomes 0 -> NULL. rpm (a plain dial-in number) carries fine as-is.
+        bag.equipmentId = packageIdMap.value(bag.equipmentId, 0);
 
         qint64 destId = -1;
         if (merge) {

--- a/src/history/coffeebagstorage.cpp
+++ b/src/history/coffeebagstorage.cpp
@@ -468,7 +468,24 @@ CoffeeBag CoffeeBagStorage::loadBagStatic(QSqlDatabase& db, qint64 bagId)
     query.bindValue(":id", bagId);
     if (!query.exec() || !query.next())
         return CoffeeBag();
-    return bagFromQueryRow(query);
+    CoffeeBag bag = bagFromQueryRow(query);
+    // Materialize the read-only grinder identity from the bag's equipment package
+    // (the bag no longer stores brand/model/burrs — migration 23). Keeps the
+    // CoffeeBag display-cache fields useful for consumers like MCP bag_list;
+    // burrs lives in the grinder item's attrs JSON. Self-contained so there's no
+    // dependency on EquipmentStorage. NULL equipment_id leaves the fields empty.
+    if (bag.equipmentId > 0) {
+        QSqlQuery gi(db);
+        gi.prepare("SELECT brand, model, json_extract(attrs, '$.burrs') FROM equipment_items "
+                   "WHERE package_id = :id AND kind = 'grinder' LIMIT 1");
+        gi.bindValue(":id", bag.equipmentId);
+        if (gi.exec() && gi.next()) {
+            bag.grinderBrand = gi.value(0).toString();
+            bag.grinderModel = gi.value(1).toString();
+            bag.grinderBurrs = gi.value(2).toString();
+        }
+    }
+    return bag;
 }
 
 QVector<InventoryBag> CoffeeBagStorage::loadInventoryStatic(QSqlDatabase& db)

--- a/src/history/coffeebagstorage.h
+++ b/src/history/coffeebagstorage.h
@@ -40,8 +40,9 @@ struct CoffeeBag {
 
     // Grinder identity is no longer persisted on the bag (migration 23 dropped
     // the grinder_brand/model/burrs columns); it resolves through equipmentId to
-    // the package's grinder item. These fields remain on the struct as a
-    // transient display cache (default empty) — storage never populates them.
+    // the package's grinder item. These fields are a display cache: not stored as
+    // columns, but populated at load by loadBagStatic via a JOIN on
+    // equipment_items (so consumers like MCP bag_list see the grinder identity).
     QString grinderBrand;
     QString grinderModel;
     QString grinderBurrs;

--- a/src/history/coffeebagstorage.h
+++ b/src/history/coffeebagstorage.h
@@ -38,19 +38,20 @@ struct CoffeeBag {
     double startWeightG = 0; // 0 = unset; local-only, never synced to Visualizer
     bool inInventory = true;
 
-    // Last-used grinder/dose (write-through from edits, dose/yield stamped
-    // on shot save). Slated to move to a future Equipment abstraction.
+    // Grinder identity is no longer persisted on the bag (migration 23 dropped
+    // the grinder_brand/model/burrs columns); it resolves through equipmentId to
+    // the package's grinder item. These fields remain on the struct as a
+    // transient display cache (default empty) — storage never populates them.
     QString grinderBrand;
     QString grinderModel;
     QString grinderBurrs;
+    // Bean-scoped dial memory (write-through from edits, stamped on shot save).
     QString grinderSetting;
     double doseWeightG = 0;  // 0 = unset
     double yieldOverrideG = 0; // 0 = unset
 
     // Equipment (add-equipment-packages). equipmentId points at the bag's
     // grinder package; rpm is the grinder rpm dial-in (sibling of grinderSetting).
-    // The grinderBrand/Model/Burrs columns above are retained transitionally and
-    // dropped in migration 23 once all readers resolve identity via equipmentId.
     qint64 equipmentId = 0;  // FK -> equipment_packages.id; 0 = unset
     qint64 rpm = 0;          // 0 = unset
 
@@ -197,8 +198,13 @@ public:
     // dest bags first. Source DBs from before migration 19 have no
     // coffee_bags table — returns true with an empty map. Runs inside the
     // caller's destDb transaction.
+    // packageIdMap remaps each source bag's equipment_id to the imported
+    // package's new dest id (built by EquipmentStorage::importEquipmentStatic,
+    // which runs first). A source equipment_id absent from the map (e.g. an
+    // older source with no equipment tables) becomes NULL.
     static bool importBagsStatic(QSqlDatabase& srcDb, QSqlDatabase& destDb, bool merge,
-                                 QHash<qint64, qint64>& outIdMap);
+                                 QHash<qint64, qint64>& outIdMap,
+                                 const QHash<qint64, qint64>& packageIdMap);
 
 signals:
     void inventoryReady(const QVariantList& bags);

--- a/src/history/coffeebagstorage.h
+++ b/src/history/coffeebagstorage.h
@@ -47,6 +47,13 @@ struct CoffeeBag {
     double doseWeightG = 0;  // 0 = unset
     double yieldOverrideG = 0; // 0 = unset
 
+    // Equipment (add-equipment-packages). equipmentId points at the bag's
+    // grinder package; rpm is the grinder rpm dial-in (sibling of grinderSetting).
+    // The grinderBrand/Model/Burrs columns above are retained transitionally and
+    // dropped in migration 23 once all readers resolve identity via equipmentId.
+    qint64 equipmentId = 0;  // FK -> equipment_packages.id; 0 = unset
+    qint64 rpm = 0;          // 0 = unset
+
     // Visualizer Coffee Management sync state
     QString visualizerBagId;
     QString visualizerRoasterId;

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -965,17 +965,24 @@ bool EquipmentStorage::importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& 
             if (destId < 0)
                 return false;
             // Copy the package's items (grinder today; future kinds ride along
-            // unchanged because the loop is kind-agnostic).
+            // unchanged because the loop is kind-agnostic). A failed items SELECT
+            // is fatal, not best-effort: the package row already exists, so
+            // skipping the items would leave an orphan package with no grinder
+            // item — the exact blank-grinder corruption createPackageWithGrinderStatic
+            // deletes a package to avoid. Fail so the caller rolls back the import.
             QSqlQuery srcItems(srcDb);
             srcItems.prepare(QString("SELECT %1 FROM equipment_items WHERE package_id = :id").arg(kItemColumns));
             srcItems.bindValue(":id", srcPkg.id);
-            if (srcItems.exec()) {
-                while (srcItems.next()) {
-                    EquipmentItem item = grinderItemFromQueryRow(srcItems);
-                    item.packageId = destId;
-                    if (insertItemStatic(destDb, item) < 0)
-                        return false;
-                }
+            if (!srcItems.exec()) {
+                qWarning() << "EquipmentStorage: import items query failed for package" << srcPkg.id
+                           << ":" << srcItems.lastError().text();
+                return false;
+            }
+            while (srcItems.next()) {
+                EquipmentItem item = grinderItemFromQueryRow(srcItems);
+                item.packageId = destId;
+                if (insertItemStatic(destDb, item) < 0)
+                    return false;
             }
             newlyInsertedSrcIds.insert(srcPkg.id);
         }
@@ -995,8 +1002,14 @@ bool EquipmentStorage::importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& 
         upd.prepare("UPDATE equipment_packages SET superseded_by = :by WHERE id = :id");
         upd.bindValue(":by", destTarget > 0 ? QVariant(destTarget) : QVariant());
         upd.bindValue(":id", destId);
-        if (!upd.exec())
-            qWarning() << "EquipmentStorage: import superseded_by remap failed:" << upd.lastError().text();
+        if (!upd.exec()) {
+            // Fail rather than silently drop the lineage pointer: a swallowed
+            // failure leaves superseded_by NULL, so a forked-from package renders
+            // as "retired" instead of "older". Propagate so the caller rolls back.
+            qWarning() << "EquipmentStorage: import superseded_by remap failed for package" << destId
+                       << "-> target" << destTarget << ":" << upd.lastError().text();
+            return false;
+        }
     }
 
     return true;

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -1,0 +1,768 @@
+#include "equipmentstorage.h"
+#include "core/dbutils.h"
+#include "core/grinderaliases.h"
+
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QSqlDatabase>
+#include <QSqlRecord>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QDateTime>
+#include <QRegularExpression>
+#include <QThread>
+#include <QDebug>
+
+#include <tuple>
+
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+QVariant nullIfEmpty(const QString& s) {
+    return s.isEmpty() ? QVariant() : QVariant(s);
+}
+
+// -------------------------------------------------------------------------
+// Single source of truth for the equipment_packages column set, mirroring
+// CoffeeBagStorage::kCols: the SELECT list, positional read, INSERT list/binds,
+// the camelCase->column update map, and the QVariantMap round-trip are all
+// DERIVED from this one ordered table so they can't drift. The physical schema
+// (CREATE TABLE in ensureTablesStatic + the created_at/updated_at bookkeeping
+// columns) is the one thing NOT generated here — adding a column is a kCols row
+// PLUS a matching schema/migration edit.
+// -------------------------------------------------------------------------
+template<auto M> using PkgMemberT = std::remove_reference_t<decltype(std::declval<EquipmentPackage&>().*M)>;
+
+template<auto M> void readStr (EquipmentPackage& p, const QVariant& v) { static_assert(std::is_same_v<PkgMemberT<M>, QString>); p.*M = v.toString(); }
+template<auto M> void readI64 (EquipmentPackage& p, const QVariant& v) { static_assert(std::is_same_v<PkgMemberT<M>, qint64>);  p.*M = v.toLongLong(); }
+template<auto M> void readBool(EquipmentPackage& p, const QVariant& v) { static_assert(std::is_same_v<PkgMemberT<M>, bool>);    p.*M = v.toInt() != 0; }
+
+template<auto M> QVariant bindStr  (const EquipmentPackage& p) { static_assert(std::is_same_v<PkgMemberT<M>, QString>); return nullIfEmpty(p.*M); }
+template<auto M> QVariant bindBool (const EquipmentPackage& p) { static_assert(std::is_same_v<PkgMemberT<M>, bool>);    return (p.*M) ? 1 : 0; }
+template<auto M> QVariant bindPos  (const EquipmentPackage& p) { static_assert(std::is_same_v<PkgMemberT<M>, qint64>);  return (p.*M) > 0 ? QVariant(p.*M) : QVariant(); }
+
+template<auto M> QVariant getMember(const EquipmentPackage& p) { return QVariant::fromValue(p.*M); }
+template<auto M> void setStr (EquipmentPackage& p, const QVariant& v) { static_assert(std::is_same_v<PkgMemberT<M>, QString>); p.*M = v.toString(); }
+template<auto M> void setI64 (EquipmentPackage& p, const QVariant& v) { static_assert(std::is_same_v<PkgMemberT<M>, qint64>);  p.*M = v.toLongLong(); }
+template<auto M> void setBool(EquipmentPackage& p, const QVariant& v) { static_assert(std::is_same_v<PkgMemberT<M>, bool>);    p.*M = v.toBool(); }
+
+struct PkgCol {
+    const char* sql;
+    const char* key;
+    bool writable;
+    void (*read)(EquipmentPackage&, const QVariant&);
+    QVariant (*bind)(const EquipmentPackage&);
+    QVariant (*get)(const EquipmentPackage&);
+    void (*set)(EquipmentPackage&, const QVariant&);
+};
+
+#define COL_STR(sqlName, member) \
+    PkgCol{ sqlName, #member, true, \
+            &readStr<&EquipmentPackage::member>, &bindStr<&EquipmentPackage::member>, \
+            &getMember<&EquipmentPackage::member>, &setStr<&EquipmentPackage::member> }
+#define COL_BOOL(sqlName, member) \
+    PkgCol{ sqlName, #member, true, \
+            &readBool<&EquipmentPackage::member>, &bindBool<&EquipmentPackage::member>, \
+            &getMember<&EquipmentPackage::member>, &setBool<&EquipmentPackage::member> }
+#define COL_POS(sqlName, member) \
+    PkgCol{ sqlName, #member, true, \
+            &readI64<&EquipmentPackage::member>, &bindPos<&EquipmentPackage::member>, \
+            &getMember<&EquipmentPackage::member>, &setI64<&EquipmentPackage::member> }
+#define COL_ID(sqlName, member) \
+    PkgCol{ sqlName, #member, false, \
+            &readI64<&EquipmentPackage::member>, nullptr, \
+            &getMember<&EquipmentPackage::member>, &setI64<&EquipmentPackage::member> }
+
+const PkgCol kCols[] = {
+    COL_ID  ("id",                 id),
+    COL_STR ("name",               name),
+    COL_BOOL("in_inventory",       inInventory),
+    COL_STR ("last_grind_setting", lastGrindSetting),
+    COL_POS ("last_rpm",           lastRpm),
+    COL_POS ("last_used",          lastUsedEpoch),
+};
+
+#undef COL_STR
+#undef COL_BOOL
+#undef COL_POS
+#undef COL_ID
+
+constexpr int kColCount = static_cast<int>(std::size(kCols));
+
+const QString& packageColumnList() {
+    static const QString cols = []() {
+        QStringList names;
+        for (const PkgCol& c : kCols)
+            names << QLatin1String(c.sql);
+        return names.join(QStringLiteral(", "));
+    }();
+    return cols;
+}
+
+const QHash<QString, const PkgCol*>& packageColumnForKey() {
+    static const QHash<QString, const PkgCol*> map = []() {
+        QHash<QString, const PkgCol*> m;
+        for (const PkgCol& c : kCols)
+            if (c.writable)
+                m.insert(QString::fromLatin1(c.key), &c);
+        return m;
+    }();
+    return map;
+}
+
+EquipmentPackage packageFromQueryRow(const QSqlQuery& query) {
+    EquipmentPackage pkg;
+    for (int i = 0; i < kColCount; ++i)
+        kCols[i].read(pkg, query.value(i));
+    return pkg;
+}
+
+EquipmentItem grinderItemFromQueryRow(const QSqlQuery& query) {
+    EquipmentItem item;
+    item.id = query.value(0).toLongLong();
+    item.packageId = query.value(1).toLongLong();
+    item.kind = query.value(2).toString();
+    item.brand = query.value(3).toString();
+    item.model = query.value(4).toString();
+    item.setAttrsFromJson(query.value(5).toString());
+    return item;
+}
+
+const char* kItemColumns = "id, package_id, kind, brand, model, attrs";
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// EquipmentItem attrs (de)serialization
+// ---------------------------------------------------------------------------
+QString EquipmentItem::attrsJson() const
+{
+    QJsonObject obj;
+    if (!burrs.isEmpty())
+        obj.insert(QStringLiteral("burrs"), burrs);
+    obj.insert(QStringLiteral("rpmCapable"), rpmCapable);
+    return QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+void EquipmentItem::setAttrsFromJson(const QString& json)
+{
+    const QJsonObject obj = QJsonDocument::fromJson(json.toUtf8()).object();
+    burrs = obj.value(QStringLiteral("burrs")).toString();
+    rpmCapable = obj.value(QStringLiteral("rpmCapable")).toBool();
+}
+
+// ---------------------------------------------------------------------------
+// EquipmentPackage / EquipmentPackageView round-trip
+// ---------------------------------------------------------------------------
+QVariantMap EquipmentPackage::toVariantMap() const
+{
+    QVariantMap map;
+    for (const PkgCol& c : kCols)
+        map.insert(QString::fromLatin1(c.key), c.get(*this));
+    return map;
+}
+
+EquipmentPackage EquipmentPackage::fromVariantMap(const QVariantMap& map)
+{
+    EquipmentPackage pkg;
+    for (const PkgCol& c : kCols) {
+        const QString key = QString::fromLatin1(c.key);
+        if (map.contains(key))
+            c.set(pkg, map.value(key));
+    }
+    return pkg;
+}
+
+QVariantMap EquipmentPackageView::toVariantMap() const
+{
+    QVariantMap map = package.toVariantMap();
+    // Resolved grinder identity, flattened for QML cards and MCP.
+    map.insert(QStringLiteral("grinderBrand"), grinder.brand);
+    map.insert(QStringLiteral("grinderModel"), grinder.model);
+    map.insert(QStringLiteral("grinderBurrs"), grinder.burrs);
+    map.insert(QStringLiteral("rpmCapable"), grinder.rpmCapable);
+    map.insert(QStringLiteral("shotCount"), shotCount);
+    return map;
+}
+
+// ---------------------------------------------------------------------------
+// EquipmentStorage
+// ---------------------------------------------------------------------------
+EquipmentStorage::EquipmentStorage(QObject* parent)
+    : QObject(parent)
+{
+}
+
+EquipmentStorage::~EquipmentStorage()
+{
+    *m_destroyed = true;
+}
+
+void EquipmentStorage::initialize(const QString& dbPath)
+{
+    m_dbPath = dbPath;
+}
+
+void EquipmentStorage::runAsync(const QString& connPrefix,
+                                std::function<void(QSqlDatabase&)> work,
+                                std::function<void()> done)
+{
+    if (m_dbPath.isEmpty()) {
+        qWarning() << "EquipmentStorage: not initialized, dropping" << connPrefix;
+        return;
+    }
+    const QString dbPath = m_dbPath;
+    auto destroyed = m_destroyed;
+    QThread* thread = QThread::create([this, dbPath, connPrefix, work = std::move(work),
+                                       done = std::move(done), destroyed]() {
+        if (!withTempDb(dbPath, connPrefix, [&](QSqlDatabase& db) { work(db); }))
+            qWarning() << "EquipmentStorage: failed to open DB for" << connPrefix;
+        if (*destroyed) return;
+        QMetaObject::invokeMethod(this, [done = std::move(done), destroyed]() {
+            if (*destroyed) return;
+            done();
+        }, Qt::QueuedConnection);
+    });
+    QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+    thread->start();
+}
+
+void EquipmentStorage::requestInventory()
+{
+    auto packages = std::make_shared<QVariantList>();
+    runAsync("equip_inv",
+        [packages](QSqlDatabase& db) {
+            const QVector<EquipmentPackageView> inventory = loadInventoryStatic(db);
+            for (const EquipmentPackageView& entry : inventory)
+                packages->append(entry.toVariantMap());
+        },
+        [this, packages]() { emit inventoryReady(*packages); });
+}
+
+void EquipmentStorage::requestPackage(qint64 packageId)
+{
+    auto result = std::make_shared<QVariantMap>();
+    runAsync("equip_get",
+        [packageId, result](QSqlDatabase& db) {
+            const EquipmentPackage pkg = loadPackageStatic(db, packageId);
+            if (pkg.isValid()) {
+                EquipmentPackageView view;
+                view.package = pkg;
+                view.grinder = loadGrinderItemStatic(db, packageId);
+                *result = view.toVariantMap();
+            }
+        },
+        [this, packageId, result]() { emit packageReady(packageId, *result); });
+}
+
+void EquipmentStorage::requestCreatePackage(const QVariantMap& packageMap)
+{
+    auto newId = std::make_shared<qint64>(-1);
+    auto created = std::make_shared<QVariantMap>();
+    runAsync("equip_create",
+        [packageMap, newId, created](QSqlDatabase& db) {
+            EquipmentPackage pkg = EquipmentPackage::fromVariantMap(packageMap);
+            pkg.lastUsedEpoch = QDateTime::currentSecsSinceEpoch();
+            const QString brand = packageMap.value(QStringLiteral("grinderBrand")).toString();
+            const QString model = packageMap.value(QStringLiteral("grinderModel")).toString();
+            const QString burrs = packageMap.value(QStringLiteral("grinderBurrs")).toString();
+            *newId = createPackageWithGrinderStatic(db, pkg, brand, model, burrs);
+            if (*newId > 0) {
+                EquipmentPackageView view;
+                view.package = loadPackageStatic(db, *newId);
+                view.grinder = loadGrinderItemStatic(db, *newId);
+                *created = view.toVariantMap();
+            }
+        },
+        [this, newId, created]() {
+            emit packageCreated(*newId, *created);
+            if (*newId > 0)
+                emit packagesChanged();
+        });
+}
+
+void EquipmentStorage::requestUpdatePackage(qint64 packageId, const QVariantMap& fields)
+{
+    if (m_dbPath.isEmpty()) {
+        qWarning() << "EquipmentStorage: requestUpdatePackage on uninitialized storage, package" << packageId;
+        emit packageUpdated(packageId, false);
+        return;
+    }
+    auto success = std::make_shared<bool>(false);
+    runAsync("equip_update",
+        [packageId, fields, success](QSqlDatabase& db) {
+            // Package-column fields and grinder-identity fields can both arrive
+            // in one map; route each to its table. Grinder edits re-derive
+            // rpmCapable (handled in updateGrinderItemStatic).
+            bool any = false;
+            const bool touchesGrinder = fields.contains(QStringLiteral("grinderBrand"))
+                || fields.contains(QStringLiteral("grinderModel"))
+                || fields.contains(QStringLiteral("grinderBurrs"));
+            if (touchesGrinder) {
+                const EquipmentItem cur = loadGrinderItemStatic(db, packageId);
+                const QString brand = fields.value(QStringLiteral("grinderBrand"), cur.brand).toString();
+                const QString model = fields.value(QStringLiteral("grinderModel"), cur.model).toString();
+                const QString burrs = fields.value(QStringLiteral("grinderBurrs"), cur.burrs).toString();
+                any = updateGrinderItemStatic(db, packageId, brand, model, burrs) || any;
+            }
+            // Strip grinder keys before the package-column update.
+            QVariantMap pkgFields = fields;
+            pkgFields.remove(QStringLiteral("grinderBrand"));
+            pkgFields.remove(QStringLiteral("grinderModel"));
+            pkgFields.remove(QStringLiteral("grinderBurrs"));
+            if (!pkgFields.isEmpty())
+                any = updatePackageFieldsStatic(db, packageId, pkgFields) || any;
+            *success = any;
+        },
+        [this, packageId, success]() {
+            emit packageUpdated(packageId, *success);
+            if (*success)
+                emit packagesChanged();
+        });
+}
+
+void EquipmentStorage::requestMarkRemoved(qint64 packageId)
+{
+    requestUpdatePackage(packageId, {{QStringLiteral("inInventory"), false}});
+}
+
+void EquipmentStorage::requestTouchLastUsed(qint64 packageId)
+{
+    runAsync("equip_touch",
+        [packageId](QSqlDatabase& db) {
+            QSqlQuery query(db);
+            query.prepare("UPDATE equipment_packages SET last_used = :now, "
+                          "updated_at = strftime('%s', 'now') WHERE id = :id");
+            query.bindValue(":now", QDateTime::currentSecsSinceEpoch());
+            query.bindValue(":id", packageId);
+            if (!query.exec())
+                qWarning() << "EquipmentStorage: touch last_used failed:" << query.lastError().text();
+        },
+        []() {});
+}
+
+void EquipmentStorage::requestDeletePackage(qint64 packageId)
+{
+    auto success = std::make_shared<bool>(false);
+    runAsync("equip_delete",
+        [packageId, success](QSqlDatabase& db) {
+            // Packages referenced by any bag or shot are history — only Remove
+            // (soft-delete) is allowed. Hard delete is for mistaken creations.
+            QSqlQuery countQuery(db);
+            countQuery.prepare("SELECT "
+                               "(SELECT COUNT(*) FROM coffee_bags WHERE equipment_id = :id) + "
+                               "(SELECT COUNT(*) FROM shots WHERE equipment_id = :id)");
+            countQuery.bindValue(":id", packageId);
+            if (!countQuery.exec() || !countQuery.next()) {
+                qWarning() << "EquipmentStorage: delete pre-check failed:" << countQuery.lastError().text();
+                return;
+            }
+            if (countQuery.value(0).toInt() > 0) {
+                qWarning() << "EquipmentStorage: refusing to delete package" << packageId << "with references";
+                return;
+            }
+            QSqlQuery delItems(db);
+            delItems.prepare("DELETE FROM equipment_items WHERE package_id = :id");
+            delItems.bindValue(":id", packageId);
+            delItems.exec();
+            QSqlQuery delPkg(db);
+            delPkg.prepare("DELETE FROM equipment_packages WHERE id = :id");
+            delPkg.bindValue(":id", packageId);
+            *success = delPkg.exec();
+            if (!*success)
+                qWarning() << "EquipmentStorage: delete failed:" << delPkg.lastError().text();
+        },
+        [this, packageId, success]() {
+            emit packageDeleted(packageId, *success);
+            if (*success)
+                emit packagesChanged();
+        });
+}
+
+// ---------------------------------------------------------------------------
+// Static helpers
+// ---------------------------------------------------------------------------
+bool EquipmentStorage::ensureTablesStatic(QSqlDatabase& db)
+{
+    QSqlQuery query(db);
+    const bool okPkg = query.exec(R"(
+        CREATE TABLE IF NOT EXISTS equipment_packages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            in_inventory INTEGER NOT NULL DEFAULT 1,
+            last_grind_setting TEXT,
+            last_rpm INTEGER,
+            last_used INTEGER,
+            created_at INTEGER DEFAULT (strftime('%s', 'now')),
+            updated_at INTEGER DEFAULT (strftime('%s', 'now'))
+        )
+    )");
+    if (!okPkg) {
+        qWarning() << "EquipmentStorage: failed to create equipment_packages table:" << query.lastError().text();
+        return false;
+    }
+    const bool okItem = query.exec(R"(
+        CREATE TABLE IF NOT EXISTS equipment_items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            package_id INTEGER NOT NULL,
+            kind TEXT NOT NULL,
+            brand TEXT,
+            model TEXT,
+            attrs TEXT,
+            created_at INTEGER DEFAULT (strftime('%s', 'now')),
+            updated_at INTEGER DEFAULT (strftime('%s', 'now'))
+        )
+    )");
+    if (!okItem) {
+        qWarning() << "EquipmentStorage: failed to create equipment_items table:" << query.lastError().text();
+        return false;
+    }
+    query.exec("CREATE INDEX IF NOT EXISTS idx_equipment_inventory ON equipment_packages(in_inventory, last_used DESC)");
+    query.exec("CREATE INDEX IF NOT EXISTS idx_equipment_items_package ON equipment_items(package_id, kind)");
+    return true;
+}
+
+qint64 EquipmentStorage::insertPackageStatic(QSqlDatabase& db, const EquipmentPackage& pkg)
+{
+    QStringList columns, placeholders;
+    QVariantList binds;
+    for (const PkgCol& c : kCols) {
+        if (!c.writable)
+            continue;
+        columns << QString::fromLatin1(c.sql);
+        placeholders << QStringLiteral("?");
+        binds << c.bind(pkg);
+    }
+    QSqlQuery query(db);
+    query.prepare(QString("INSERT INTO equipment_packages (%1) VALUES (%2)")
+                      .arg(columns.join(QStringLiteral(", ")), placeholders.join(QStringLiteral(", "))));
+    for (int i = 0; i < binds.size(); ++i)
+        query.bindValue(i, binds.at(i));
+    if (!query.exec()) {
+        qWarning() << "EquipmentStorage: package insert failed:" << query.lastError().text();
+        return -1;
+    }
+    return query.lastInsertId().toLongLong();
+}
+
+qint64 EquipmentStorage::insertItemStatic(QSqlDatabase& db, const EquipmentItem& item)
+{
+    QSqlQuery query(db);
+    query.prepare("INSERT INTO equipment_items (package_id, kind, brand, model, attrs) "
+                  "VALUES (:package_id, :kind, :brand, :model, :attrs)");
+    query.bindValue(":package_id", item.packageId);
+    query.bindValue(":kind", item.kind);
+    query.bindValue(":brand", nullIfEmpty(item.brand));
+    query.bindValue(":model", nullIfEmpty(item.model));
+    query.bindValue(":attrs", item.attrsJson());
+    if (!query.exec()) {
+        qWarning() << "EquipmentStorage: item insert failed:" << query.lastError().text();
+        return -1;
+    }
+    return query.lastInsertId().toLongLong();
+}
+
+qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, const EquipmentPackage& pkg,
+                                                        const QString& brand, const QString& model,
+                                                        const QString& burrs)
+{
+    const qint64 packageId = insertPackageStatic(db, pkg);
+    if (packageId <= 0)
+        return -1;
+    EquipmentItem grinder;
+    grinder.packageId = packageId;
+    grinder.kind = QStringLiteral("grinder");
+    grinder.brand = brand;
+    grinder.model = model;
+    grinder.burrs = burrs;
+    grinder.rpmCapable = deriveRpmCapable(brand, model);
+    insertItemStatic(db, grinder);
+    return packageId;
+}
+
+EquipmentPackage EquipmentStorage::loadPackageStatic(QSqlDatabase& db, qint64 packageId)
+{
+    QSqlQuery query(db);
+    query.prepare(QString("SELECT %1 FROM equipment_packages WHERE id = :id").arg(packageColumnList()));
+    query.bindValue(":id", packageId);
+    if (!query.exec() || !query.next())
+        return EquipmentPackage();
+    return packageFromQueryRow(query);
+}
+
+EquipmentItem EquipmentStorage::loadGrinderItemStatic(QSqlDatabase& db, qint64 packageId)
+{
+    QSqlQuery query(db);
+    query.prepare(QString("SELECT %1 FROM equipment_items "
+                          "WHERE package_id = :id AND kind = 'grinder' ORDER BY id LIMIT 1")
+                      .arg(QLatin1String(kItemColumns)));
+    query.bindValue(":id", packageId);
+    if (!query.exec() || !query.next())
+        return EquipmentItem();
+    return grinderItemFromQueryRow(query);
+}
+
+QVector<EquipmentPackageView> EquipmentStorage::loadInventoryStatic(QSqlDatabase& db)
+{
+    QVector<EquipmentPackageView> views;
+    QSqlQuery query(db);
+    if (!query.exec(QString("SELECT %1, "
+                            "(SELECT COUNT(*) FROM shots WHERE equipment_id = equipment_packages.id) AS shot_count "
+                            "FROM equipment_packages WHERE in_inventory = 1 "
+                            "ORDER BY last_used DESC, id DESC").arg(packageColumnList()))) {
+        qWarning() << "EquipmentStorage: inventory query failed:" << query.lastError().text();
+        return views;
+    }
+    const int shotCountCol = query.record().indexOf("shot_count");
+    QVector<qint64> ids;
+    while (query.next()) {
+        EquipmentPackageView view;
+        view.package = packageFromQueryRow(query);
+        if (shotCountCol >= 0)
+            view.shotCount = query.value(shotCountCol).toLongLong();
+        views.append(view);
+        ids.append(view.package.id);
+    }
+    // Resolve each package's grinder item (inventory is small — a handful of rows).
+    for (int i = 0; i < views.size(); ++i)
+        views[i].grinder = loadGrinderItemStatic(db, ids.at(i));
+    return views;
+}
+
+bool EquipmentStorage::updatePackageFieldsStatic(QSqlDatabase& db, qint64 packageId, const QVariantMap& fields)
+{
+    const QHash<QString, const PkgCol*>& kColumnFor = packageColumnForKey();
+    QStringList assignments;
+    QVariantList values;
+    for (auto it = fields.constBegin(); it != fields.constEnd(); ++it) {
+        const PkgCol* col = kColumnFor.value(it.key(), nullptr);
+        if (!col) {
+            qWarning() << "EquipmentStorage: ignoring unknown package field" << it.key();
+            continue;
+        }
+        assignments << QString("%1 = ?").arg(QString::fromLatin1(col->sql));
+        EquipmentPackage scratch;
+        col->set(scratch, it.value());
+        values << col->bind(scratch);
+    }
+    if (assignments.isEmpty())
+        return false;
+    QSqlQuery query(db);
+    query.prepare(QString("UPDATE equipment_packages SET %1, updated_at = strftime('%s', 'now') WHERE id = ?")
+                      .arg(assignments.join(QStringLiteral(", "))));
+    int pos = 0;
+    for (const QVariant& value : values)
+        query.bindValue(pos++, value);
+    query.bindValue(pos, packageId);
+    if (!query.exec()) {
+        qWarning() << "EquipmentStorage: package update failed for" << packageId << ":" << query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() > 0;
+}
+
+bool EquipmentStorage::updateGrinderItemStatic(QSqlDatabase& db, qint64 packageId,
+                                               const QString& brand, const QString& model,
+                                               const QString& burrs)
+{
+    EquipmentItem item;
+    item.brand = brand;
+    item.model = model;
+    item.burrs = burrs;
+    item.rpmCapable = deriveRpmCapable(brand, model);
+
+    QSqlQuery query(db);
+    query.prepare("UPDATE equipment_items SET brand = :brand, model = :model, attrs = :attrs, "
+                  "updated_at = strftime('%s', 'now') WHERE package_id = :id AND kind = 'grinder'");
+    query.bindValue(":brand", nullIfEmpty(brand));
+    query.bindValue(":model", nullIfEmpty(model));
+    query.bindValue(":attrs", item.attrsJson());
+    query.bindValue(":id", packageId);
+    if (!query.exec()) {
+        qWarning() << "EquipmentStorage: grinder item update failed for package" << packageId << ":"
+                   << query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() > 0;
+}
+
+qint64 EquipmentStorage::findPackageByGrinderIdentityStatic(QSqlDatabase& db, const QString& brand,
+                                                            const QString& model, const QString& burrs)
+{
+    QSqlQuery query(db);
+    query.prepare("SELECT i.package_id FROM equipment_items i "
+                  "JOIN equipment_packages p ON p.id = i.package_id "
+                  "WHERE i.kind = 'grinder' AND p.in_inventory = 1 "
+                  "AND LOWER(IFNULL(i.brand,'')) = LOWER(:brand) "
+                  "AND LOWER(IFNULL(i.model,'')) = LOWER(:model) "
+                  "AND LOWER(IFNULL(json_extract(i.attrs,'$.burrs'),'')) = LOWER(:burrs) "
+                  "ORDER BY p.id LIMIT 1");
+    query.bindValue(":brand", brand);
+    query.bindValue(":model", model);
+    query.bindValue(":burrs", burrs);
+    if (!query.exec() || !query.next())
+        return 0;
+    return query.value(0).toLongLong();
+}
+
+bool EquipmentStorage::deriveRpmCapable(const QString& brand, const QString& model)
+{
+    // Registry match → its variableRpm flag; custom grinder (no match) → true,
+    // so the rpm field shows. (Honors "grinder not in the table → show rpm".)
+    const GrinderAliases::GrinderEntry* entry = GrinderAliases::findEntry(brand, model);
+    return entry ? entry->variableRpm : true;
+}
+
+void EquipmentStorage::splitGrindAndRpm(const QString& combined, QString& outGrind, qint64& outRpm)
+{
+    outGrind = combined.trimmed();
+    outRpm = 0;
+    // Only split on an explicit trailing rpm marker, so compound ("1+4") and
+    // other annotated ("24 clicks") settings are left verbatim.
+    static const QRegularExpression rx(QStringLiteral(R"(\s*(\d+)\s*rpm\s*$)"),
+                                       QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpressionMatch m = rx.match(outGrind);
+    if (m.hasMatch()) {
+        outRpm = m.captured(1).toLongLong();
+        outGrind = outGrind.left(m.capturedStart(0)).trimmed();
+    }
+}
+
+bool EquipmentStorage::migrateFromGrinderColumnsStatic(QSqlDatabase& db,
+                                                       const QString& currentBrand,
+                                                       const QString& currentModel,
+                                                       const QString& currentBurrs,
+                                                       const QString& currentSetting)
+{
+    auto trimmed = [](const QString& s) { return s.trimmed(); };
+    auto isEmptyIdentity = [&](const QString& b, const QString& m, const QString& bu) {
+        return trimmed(b).isEmpty() && trimmed(m).isEmpty() && trimmed(bu).isEmpty();
+    };
+    auto identityKey = [&](const QString& b, const QString& m, const QString& bu) {
+        return trimmed(b).toLower() + QChar(0x1f) + trimmed(m).toLower()
+             + QChar(0x1f) + trimmed(bu).toLower();
+    };
+
+    QHash<QString, qint64> idToPackage;                                  // identityKey -> package id
+    QVector<std::tuple<QString, QString, QString, qint64>> allPackages;  // brand, model, burrs, id
+
+    auto registerPackage = [&](const QString& b, const QString& m, const QString& bu, qint64 id) {
+        idToPackage.insert(identityKey(b, m, bu), id);
+        allPackages.append(std::make_tuple(trimmed(b), trimmed(m), trimmed(bu), id));
+    };
+
+    // 1. Default package from the user's current grinder settings.
+    if (!isEmptyIdentity(currentBrand, currentModel, currentBurrs)) {
+        QString grind; qint64 rpm = 0;
+        splitGrindAndRpm(currentSetting, grind, rpm);
+        EquipmentPackage pkg;
+        pkg.lastGrindSetting = grind;
+        pkg.lastRpm = rpm;
+        pkg.lastUsedEpoch = QDateTime::currentSecsSinceEpoch();
+        const qint64 id = createPackageWithGrinderStatic(db, pkg, trimmed(currentBrand),
+                                                         trimmed(currentModel), trimmed(currentBurrs));
+        if (id > 0)
+            registerPackage(currentBrand, currentModel, currentBurrs, id);
+    }
+
+    // 2. One package per remaining distinct historical identity (bags ∪ shots).
+    QSqlQuery distinctQ(db);
+    if (!distinctQ.exec(
+            "SELECT DISTINCT grinder_brand, grinder_model, grinder_burrs FROM ("
+            "  SELECT grinder_brand, grinder_model, grinder_burrs FROM coffee_bags "
+            "  UNION ALL "
+            "  SELECT grinder_brand, grinder_model, grinder_burrs FROM shots)")) {
+        qWarning() << "EquipmentStorage: migration distinct-identity query failed:"
+                   << distinctQ.lastError().text();
+        return false;
+    }
+    struct Identity { QString brand, model, burrs; };
+    QVector<Identity> newIdentities;
+    while (distinctQ.next()) {
+        const Identity id{ distinctQ.value(0).toString(), distinctQ.value(1).toString(),
+                           distinctQ.value(2).toString() };
+        if (isEmptyIdentity(id.brand, id.model, id.burrs))
+            continue;
+        if (idToPackage.contains(identityKey(id.brand, id.model, id.burrs)))
+            continue;
+        newIdentities.append(id);
+    }
+    for (const Identity& id : newIdentities) {
+        // Seed the package's last dial from that grinder's most-recent shot
+        // (fall back to a bag), so a switch pre-fills a real value.
+        QString grind; qint64 rpm = 0;
+        QSqlQuery seedQ(db);
+        seedQ.prepare("SELECT grinder_setting FROM shots "
+                      "WHERE LOWER(IFNULL(grinder_brand,''))=:b AND LOWER(IFNULL(grinder_model,''))=:m "
+                      "AND LOWER(IFNULL(grinder_burrs,''))=:bu AND grinder_setting IS NOT NULL "
+                      "ORDER BY id DESC LIMIT 1");
+        seedQ.bindValue(":b", id.brand.trimmed().toLower());
+        seedQ.bindValue(":m", id.model.trimmed().toLower());
+        seedQ.bindValue(":bu", id.burrs.trimmed().toLower());
+        if (seedQ.exec() && seedQ.next())
+            splitGrindAndRpm(seedQ.value(0).toString(), grind, rpm);
+
+        EquipmentPackage pkg;
+        pkg.lastGrindSetting = grind;
+        pkg.lastRpm = rpm;
+        pkg.lastUsedEpoch = QDateTime::currentSecsSinceEpoch();
+        const qint64 pid = createPackageWithGrinderStatic(db, pkg, id.brand.trimmed(),
+                                                          id.model.trimmed(), id.burrs.trimmed());
+        if (pid > 0)
+            registerPackage(id.brand, id.model, id.burrs, pid);
+    }
+
+    // 3. Link every bag/shot to its package by identity (bulk per identity).
+    for (const auto& [b, m, bu, pid] : allPackages) {
+        for (const char* table : { "coffee_bags", "shots" }) {
+            QSqlQuery linkQ(db);
+            linkQ.prepare(QString("UPDATE %1 SET equipment_id = :pid "
+                                  "WHERE LOWER(IFNULL(grinder_brand,'')) = :b "
+                                  "AND LOWER(IFNULL(grinder_model,'')) = :m "
+                                  "AND LOWER(IFNULL(grinder_burrs,'')) = :bu").arg(QLatin1String(table)));
+            linkQ.bindValue(":pid", pid);
+            linkQ.bindValue(":b", b.toLower());
+            linkQ.bindValue(":m", m.toLower());
+            linkQ.bindValue(":bu", bu.toLower());
+            if (!linkQ.exec())
+                qWarning() << "EquipmentStorage: migration link failed on" << table << ":"
+                           << linkQ.lastError().text();
+        }
+    }
+
+    // 4. Split combined grind+rpm settings into grinder_setting + rpm. Only rows
+    //    carrying an explicit rpm marker need touching.
+    for (const char* table : { "coffee_bags", "shots" }) {
+        QSqlQuery scanQ(db);
+        if (!scanQ.exec(QString("SELECT id, grinder_setting FROM %1 "
+                                "WHERE grinder_setting LIKE '%rpm%'").arg(QLatin1String(table)))) {
+            qWarning() << "EquipmentStorage: migration rpm-scan failed on" << table << ":"
+                       << scanQ.lastError().text();
+            continue;
+        }
+        QVector<std::tuple<qint64, QString, qint64>> updates;  // id, grind, rpm
+        while (scanQ.next()) {
+            const qint64 rowId = scanQ.value(0).toLongLong();
+            QString grind; qint64 rpm = 0;
+            splitGrindAndRpm(scanQ.value(1).toString(), grind, rpm);
+            if (rpm > 0)
+                updates.append(std::make_tuple(rowId, grind, rpm));
+        }
+        for (const auto& [rowId, grind, rpm] : updates) {
+            QSqlQuery upd(db);
+            upd.prepare(QString("UPDATE %1 SET grinder_setting = :g, rpm = :r WHERE id = :id")
+                            .arg(QLatin1String(table)));
+            upd.bindValue(":g", nullIfEmpty(grind));
+            upd.bindValue(":r", rpm);
+            upd.bindValue(":id", rowId);
+            if (!upd.exec())
+                qWarning() << "EquipmentStorage: migration rpm-split update failed on" << table << ":"
+                           << upd.lastError().text();
+        }
+    }
+
+    return true;
+}

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -83,6 +83,7 @@ const PkgCol kCols[] = {
     COL_STR ("last_grind_setting", lastGrindSetting),
     COL_POS ("last_rpm",           lastRpm),
     COL_POS ("last_used",          lastUsedEpoch),
+    COL_POS ("superseded_by",      supersededBy),
 };
 
 #undef COL_STR
@@ -292,11 +293,13 @@ void EquipmentStorage::requestUpdatePackage(qint64 packageId, const QVariantMap&
         return;
     }
     auto success = std::make_shared<bool>(false);
+    // Grinder identity edits honor copy-on-write/merge and may return a DIFFERENT
+    // package id (a fork or a merge target); the result is emitted so the caller
+    // can repoint the active selection. Non-identity fields (e.g. name) apply to
+    // the resulting package.
+    auto resultId = std::make_shared<qint64>(packageId);
     runAsync("equip_update",
-        [packageId, fields, success](QSqlDatabase& db) {
-            // Package-column fields and grinder-identity fields can both arrive
-            // in one map; route each to its table. Grinder edits re-derive
-            // rpmCapable (handled in updateGrinderItemStatic).
+        [packageId, fields, success, resultId](QSqlDatabase& db) {
             bool any = false;
             const bool touchesGrinder = fields.contains(QStringLiteral("grinderBrand"))
                 || fields.contains(QStringLiteral("grinderModel"))
@@ -306,19 +309,21 @@ void EquipmentStorage::requestUpdatePackage(qint64 packageId, const QVariantMap&
                 const QString brand = fields.value(QStringLiteral("grinderBrand"), cur.brand).toString();
                 const QString model = fields.value(QStringLiteral("grinderModel"), cur.model).toString();
                 const QString burrs = fields.value(QStringLiteral("grinderBurrs"), cur.burrs).toString();
-                any = updateGrinderItemStatic(db, packageId, brand, model, burrs) || any;
+                *resultId = supersedeOrEditGrinderStatic(db, packageId, brand, model, burrs);
+                any = (*resultId > 0);
             }
-            // Strip grinder keys before the package-column update.
+            // Strip grinder keys before the package-column update; apply the rest
+            // (e.g. name) to the RESULT package.
             QVariantMap pkgFields = fields;
             pkgFields.remove(QStringLiteral("grinderBrand"));
             pkgFields.remove(QStringLiteral("grinderModel"));
             pkgFields.remove(QStringLiteral("grinderBurrs"));
             if (!pkgFields.isEmpty())
-                any = updatePackageFieldsStatic(db, packageId, pkgFields) || any;
+                any = updatePackageFieldsStatic(db, *resultId, pkgFields) || any;
             *success = any;
         },
-        [this, packageId, success]() {
-            emit packageUpdated(packageId, *success);
+        [this, resultId, success]() {
+            emit packageUpdated(*resultId, *success);
             if (*success)
                 emit packagesChanged();
         });
@@ -396,6 +401,7 @@ bool EquipmentStorage::ensureTablesStatic(QSqlDatabase& db)
             last_grind_setting TEXT,
             last_rpm INTEGER,
             last_used INTEGER,
+            superseded_by INTEGER,
             created_at INTEGER DEFAULT (strftime('%s', 'now')),
             updated_at INTEGER DEFAULT (strftime('%s', 'now'))
         )
@@ -594,22 +600,98 @@ bool EquipmentStorage::updateGrinderItemStatic(QSqlDatabase& db, qint64 packageI
 }
 
 qint64 EquipmentStorage::findPackageByGrinderIdentityStatic(QSqlDatabase& db, const QString& brand,
-                                                            const QString& model, const QString& burrs)
+                                                            const QString& model, const QString& burrs,
+                                                            qint64 excludeId)
 {
     QSqlQuery query(db);
     query.prepare("SELECT i.package_id FROM equipment_items i "
                   "JOIN equipment_packages p ON p.id = i.package_id "
                   "WHERE i.kind = 'grinder' AND p.in_inventory = 1 "
+                  "AND p.id != :exclude "
                   "AND LOWER(IFNULL(i.brand,'')) = LOWER(:brand) "
                   "AND LOWER(IFNULL(i.model,'')) = LOWER(:model) "
                   "AND LOWER(IFNULL(json_extract(i.attrs,'$.burrs'),'')) = LOWER(:burrs) "
                   "ORDER BY p.id LIMIT 1");
+    query.bindValue(":exclude", excludeId);
     query.bindValue(":brand", brand);
     query.bindValue(":model", model);
     query.bindValue(":burrs", burrs);
     if (!query.exec() || !query.next())
         return 0;
     return query.value(0).toLongLong();
+}
+
+qint64 EquipmentStorage::supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 packageId,
+                                                      const QString& brand, const QString& model,
+                                                      const QString& burrs)
+{
+    const EquipmentItem cur = loadGrinderItemStatic(db, packageId);
+
+    auto norm = [](const QString& s) { return s.trimmed().toLower(); };
+    const bool unchanged = norm(cur.brand) == norm(brand)
+        && norm(cur.model) == norm(model)
+        && norm(cur.burrs) == norm(burrs);
+    if (unchanged)
+        return packageId;  // no identity change
+
+    auto shotCount = [&]() -> qint64 {
+        QSqlQuery q(db);
+        q.prepare("SELECT COUNT(*) FROM shots WHERE equipment_id = :id");
+        q.bindValue(":id", packageId);
+        return (q.exec() && q.next()) ? q.value(0).toLongLong() : 0;
+    };
+    auto repointBags = [&](qint64 from, qint64 to) {
+        QSqlQuery q(db);
+        q.prepare("UPDATE coffee_bags SET equipment_id = :to WHERE equipment_id = :from");
+        q.bindValue(":to", to);
+        q.bindValue(":from", from);
+        q.exec();
+    };
+    auto softDelete = [&](qint64 id, qint64 supersededBy) {
+        QSqlQuery q(db);
+        q.prepare("UPDATE equipment_packages SET in_inventory = 0, superseded_by = :by, "
+                  "updated_at = strftime('%s','now') WHERE id = :id");
+        q.bindValue(":by", supersededBy > 0 ? QVariant(supersededBy) : QVariant());
+        q.bindValue(":id", id);
+        q.exec();
+    };
+
+    // Merge: another current package already has this exact identity.
+    const qint64 mergeTarget = findPackageByGrinderIdentityStatic(db, brand, model, burrs, packageId);
+    if (mergeTarget > 0) {
+        repointBags(packageId, mergeTarget);
+        if (shotCount() == 0) {
+            QSqlQuery di(db);
+            di.prepare("DELETE FROM equipment_items WHERE package_id = :id");
+            di.bindValue(":id", packageId); di.exec();
+            QSqlQuery dp(db);
+            dp.prepare("DELETE FROM equipment_packages WHERE id = :id");
+            dp.bindValue(":id", packageId); dp.exec();
+        } else {
+            softDelete(packageId, mergeTarget);
+        }
+        return mergeTarget;
+    }
+
+    // Unused package: safe to edit in place.
+    if (shotCount() == 0) {
+        updateGrinderItemStatic(db, packageId, brand, model, burrs);
+        return packageId;
+    }
+
+    // Used package: fork (copy name + last dial), repoint bags, retire the old.
+    const EquipmentPackage old = loadPackageStatic(db, packageId);
+    EquipmentPackage np;
+    np.name = old.name;
+    np.lastGrindSetting = old.lastGrindSetting;
+    np.lastRpm = old.lastRpm;
+    np.lastUsedEpoch = QDateTime::currentSecsSinceEpoch();
+    const qint64 newId = createPackageWithGrinderStatic(db, np, brand, model, burrs);
+    if (newId <= 0)
+        return packageId;  // fork failed; leave as-is
+    repointBags(packageId, newId);
+    softDelete(packageId, newId);
+    return newId;
 }
 
 bool EquipmentStorage::deriveRpmCapable(const QString& brand, const QString& model)

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -359,10 +359,15 @@ void EquipmentStorage::requestDeletePackage(qint64 packageId)
         [packageId, success](QSqlDatabase& db) {
             // Packages referenced by any bag or shot are history — only Remove
             // (soft-delete) is allowed. Hard delete is for mistaken creations.
+            // Also block when another package's superseded_by points here: hard-
+            // deleting a fork target would leave that older package with a
+            // dangling lineage pointer (it would render as "older" with no
+            // successor to resolve).
             QSqlQuery countQuery(db);
             countQuery.prepare("SELECT "
                                "(SELECT COUNT(*) FROM coffee_bags WHERE equipment_id = :id) + "
-                               "(SELECT COUNT(*) FROM shots WHERE equipment_id = :id)");
+                               "(SELECT COUNT(*) FROM shots WHERE equipment_id = :id) + "
+                               "(SELECT COUNT(*) FROM equipment_packages WHERE superseded_by = :id)");
             countQuery.bindValue(":id", packageId);
             if (!countQuery.exec() || !countQuery.next()) {
                 qWarning() << "EquipmentStorage: delete pre-check failed:" << countQuery.lastError().text();
@@ -452,8 +457,8 @@ qint64 EquipmentStorage::insertPackageStatic(QSqlDatabase& db, const EquipmentPa
     QSqlQuery query(db);
     query.prepare(QString("INSERT INTO equipment_packages (%1) VALUES (%2)")
                       .arg(columns.join(QStringLiteral(", ")), placeholders.join(QStringLiteral(", "))));
-    for (int i = 0; i < binds.size(); ++i)
-        query.bindValue(i, binds.at(i));
+    for (qsizetype i = 0; i < binds.size(); ++i)
+        query.bindValue(static_cast<int>(i), binds.at(i));
     if (!query.exec()) {
         qWarning() << "EquipmentStorage: package insert failed:" << query.lastError().text();
         return -1;
@@ -552,7 +557,7 @@ QVector<EquipmentPackageView> EquipmentStorage::loadInventoryStatic(QSqlDatabase
         ids.append(view.package.id);
     }
     // Resolve each package's grinder item (inventory is small — a handful of rows).
-    for (int i = 0; i < views.size(); ++i)
+    for (qsizetype i = 0; i < views.size(); ++i)
         views[i].grinder = loadGrinderItemStatic(db, ids.at(i));
     return views;
 }

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -915,22 +915,26 @@ bool EquipmentStorage::migrateFromGrinderColumnsStatic(QSqlDatabase& db,
 bool EquipmentStorage::importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& destDb, bool merge,
                                              QHash<qint64, qint64>& outIdMap)
 {
-    // Older source DB without equipment tables: nothing to import.
-    {
-        QSqlQuery srcCheck(srcDb);
-        if (!srcCheck.exec("SELECT COUNT(*) FROM equipment_packages"))
-            return true;
-    }
-
     if (!merge) {
         // Replace mode: clear dest equipment first (items before packages — no
-        // FK cascade on these tables).
+        // FK cascade on these tables). Done BEFORE the source probe below so a
+        // replace from an older source that predates equipment tables still wipes
+        // the dest's inventory (otherwise the early return would leave it orphaned
+        // after importDatabaseStatic has already cleared the dest shots/bags).
         QSqlQuery clr(destDb);
         if (!clr.exec("DELETE FROM equipment_items") || !clr.exec("DELETE FROM equipment_packages")) {
             qWarning() << "EquipmentStorage: failed to clear equipment for replace import:"
                        << clr.lastError().text();
             return false;
         }
+    }
+
+    // Older source DB without equipment tables: nothing to import (in replace mode
+    // the dest was already cleared above).
+    {
+        QSqlQuery srcCheck(srcDb);
+        if (!srcCheck.exec("SELECT COUNT(*) FROM equipment_packages"))
+            return true;
     }
 
     QSqlQuery srcPkgs(srcDb);

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -465,10 +465,14 @@ qint64 EquipmentStorage::insertItemStatic(QSqlDatabase& db, const EquipmentItem&
     return query.lastInsertId().toLongLong();
 }
 
-qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, const EquipmentPackage& pkg,
+qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, EquipmentPackage pkg,
                                                         const QString& brand, const QString& model,
                                                         const QString& burrs)
 {
+    // Persist a name at creation so it survives identity edits / copy-on-write
+    // (two packages may share a display name; the id is the permanent handle).
+    if (pkg.name.trimmed().isEmpty())
+        pkg.name = (brand.trimmed() + QLatin1Char(' ') + model.trimmed()).trimmed();
     const qint64 packageId = insertPackageStatic(db, pkg);
     if (packageId <= 0)
         return -1;

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -847,6 +847,7 @@ bool EquipmentStorage::migrateFromGrinderColumnsStatic(QSqlDatabase& db,
     }
 
     // 3. Link every bag/shot to its package by identity (bulk per identity).
+    qint64 linkedRows = 0;
     for (const auto& [b, m, bu, pid] : allPackages) {
         for (const char* table : { "coffee_bags", "shots" }) {
             QSqlQuery linkQ(db);
@@ -861,11 +862,14 @@ bool EquipmentStorage::migrateFromGrinderColumnsStatic(QSqlDatabase& db,
             if (!linkQ.exec())
                 qWarning() << "EquipmentStorage: migration link failed on" << table << ":"
                            << linkQ.lastError().text();
+            else
+                linkedRows += linkQ.numRowsAffected();
         }
     }
 
     // 4. Split combined grind+rpm settings into grinder_setting + rpm. Only rows
     //    carrying an explicit rpm marker need touching.
+    qint64 splitRows = 0;
     for (const char* table : { "coffee_bags", "shots" }) {
         QSqlQuery scanQ(db);
         if (!scanQ.exec(QString("SELECT id, grinder_setting FROM %1 "
@@ -892,9 +896,19 @@ bool EquipmentStorage::migrateFromGrinderColumnsStatic(QSqlDatabase& db,
             if (!upd.exec())
                 qWarning() << "EquipmentStorage: migration rpm-split update failed on" << table << ":"
                            << upd.lastError().text();
+            else
+                ++splitRows;
         }
     }
 
+    // Success summary for the one-shot upgrade — the log is the only window into
+    // what migration 22 actually did on a user's device (created N packages,
+    // linked B+S bag/shot rows, split R combined settings). qInfo so it survives
+    // release log levels.
+    qInfo() << "EquipmentStorage: migration 22 data step complete -"
+            << allPackages.size() << "packages created,"
+            << linkedRows << "bag/shot rows linked,"
+            << splitRows << "grind+rpm settings split";
     return true;
 }
 
@@ -1017,5 +1031,12 @@ bool EquipmentStorage::importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& 
         }
     }
 
+    // Summary mirrors CoffeeBagStorage's bag-import log so device-transfer issues
+    // are traceable: how many source packages imported as new rows vs merged into
+    // an existing dest package by grinder identity.
+    const qsizetype merged = outIdMap.size() - newlyInsertedSrcIds.size();
+    qInfo() << "EquipmentStorage: equipment import -" << newlyInsertedSrcIds.size()
+            << "packages imported," << merged << "merged into existing,"
+            << srcSupersededBy.size() << "superseded_by pointers remapped";
     return true;
 }

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -372,16 +372,20 @@ void EquipmentStorage::requestDeletePackage(qint64 packageId)
                 qWarning() << "EquipmentStorage: refusing to delete package" << packageId << "with references";
                 return;
             }
+            // Delete items + package atomically so a failure can't orphan items.
+            const bool txn = db.transaction();
             QSqlQuery delItems(db);
             delItems.prepare("DELETE FROM equipment_items WHERE package_id = :id");
             delItems.bindValue(":id", packageId);
-            delItems.exec();
             QSqlQuery delPkg(db);
             delPkg.prepare("DELETE FROM equipment_packages WHERE id = :id");
             delPkg.bindValue(":id", packageId);
-            *success = delPkg.exec();
-            if (!*success)
+            if (delItems.exec() && delPkg.exec() && (!txn || db.commit())) {
+                *success = true;
+            } else {
+                if (txn) db.rollback();
                 qWarning() << "EquipmentStorage: delete failed:" << delPkg.lastError().text();
+            }
         },
         [this, packageId, success]() {
             emit packageDeleted(packageId, *success);

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -892,3 +892,112 @@ bool EquipmentStorage::migrateFromGrinderColumnsStatic(QSqlDatabase& db,
 
     return true;
 }
+
+bool EquipmentStorage::importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& destDb, bool merge,
+                                             QHash<qint64, qint64>& outIdMap)
+{
+    // Older source DB without equipment tables: nothing to import.
+    {
+        QSqlQuery srcCheck(srcDb);
+        if (!srcCheck.exec("SELECT COUNT(*) FROM equipment_packages"))
+            return true;
+    }
+
+    if (!merge) {
+        // Replace mode: clear dest equipment first (items before packages — no
+        // FK cascade on these tables).
+        QSqlQuery clr(destDb);
+        if (!clr.exec("DELETE FROM equipment_items") || !clr.exec("DELETE FROM equipment_packages")) {
+            qWarning() << "EquipmentStorage: failed to clear equipment for replace import:"
+                       << clr.lastError().text();
+            return false;
+        }
+    }
+
+    QSqlQuery srcPkgs(srcDb);
+    if (!srcPkgs.exec(QString("SELECT %1 FROM equipment_packages").arg(packageColumnList()))) {
+        qWarning() << "EquipmentStorage: failed to query source packages:" << srcPkgs.lastError().text();
+        return false;
+    }
+    QVector<EquipmentPackage> pkgs;
+    while (srcPkgs.next())
+        pkgs << packageFromQueryRow(srcPkgs);
+
+    // superseded_by is a package->package pointer; remap it only after every
+    // package has a dest id. Only packages we actually insert can carry a
+    // lineage pointer (a merged-into existing package keeps its own).
+    QHash<qint64, qint64> srcSupersededBy;       // srcId -> src superseded target
+    QSet<qint64> newlyInsertedSrcIds;
+
+    for (const EquipmentPackage& srcPkg : pkgs) {
+        if (srcPkg.supersededBy > 0)
+            srcSupersededBy.insert(srcPkg.id, srcPkg.supersededBy);
+
+        // Load the source grinder item (for identity-based merge dedup).
+        EquipmentItem srcGrinder;
+        {
+            QSqlQuery gi(srcDb);
+            gi.prepare(QString("SELECT %1 FROM equipment_items "
+                               "WHERE package_id = :id AND kind = 'grinder' LIMIT 1").arg(kItemColumns));
+            gi.bindValue(":id", srcPkg.id);
+            if (gi.exec() && gi.next())
+                srcGrinder = grinderItemFromQueryRow(gi);
+        }
+
+        // Merge dedup: an IN-INVENTORY source package whose grinder identity
+        // already exists in dest maps to that package — no duplicate. Superseded
+        // (historical) packages always import as new rows so their shots keep a
+        // distinct lineage.
+        qint64 destId = -1;
+        if (merge && srcPkg.inInventory
+            && !(srcGrinder.brand.isEmpty() && srcGrinder.model.isEmpty())) {
+            const qint64 existing = findPackageByGrinderIdentityStatic(
+                destDb, srcGrinder.brand, srcGrinder.model, srcGrinder.burrs);
+            if (existing > 0)
+                destId = existing;
+        }
+
+        if (destId < 0) {
+            EquipmentPackage destPkg = srcPkg;
+            destPkg.id = 0;            // new autoincrement id (id is non-writable)
+            destPkg.supersededBy = 0;  // remapped in the second pass (non-writable)
+            destId = insertPackageStatic(destDb, destPkg);
+            if (destId < 0)
+                return false;
+            // Copy the package's items (grinder today; future kinds ride along
+            // unchanged because the loop is kind-agnostic).
+            QSqlQuery srcItems(srcDb);
+            srcItems.prepare(QString("SELECT %1 FROM equipment_items WHERE package_id = :id").arg(kItemColumns));
+            srcItems.bindValue(":id", srcPkg.id);
+            if (srcItems.exec()) {
+                while (srcItems.next()) {
+                    EquipmentItem item = grinderItemFromQueryRow(srcItems);
+                    item.packageId = destId;
+                    if (insertItemStatic(destDb, item) < 0)
+                        return false;
+                }
+            }
+            newlyInsertedSrcIds.insert(srcPkg.id);
+        }
+        outIdMap.insert(srcPkg.id, destId);
+    }
+
+    // Second pass: remap superseded_by through the id map. A src target absent
+    // from the map (its package merged into an existing one) clears the pointer.
+    for (auto it = srcSupersededBy.constBegin(); it != srcSupersededBy.constEnd(); ++it) {
+        if (!newlyInsertedSrcIds.contains(it.key()))
+            continue;
+        const qint64 destId = outIdMap.value(it.key(), 0);
+        if (destId <= 0)
+            continue;
+        const qint64 destTarget = outIdMap.value(it.value(), 0);
+        QSqlQuery upd(destDb);
+        upd.prepare("UPDATE equipment_packages SET superseded_by = :by WHERE id = :id");
+        upd.bindValue(":by", destTarget > 0 ? QVariant(destTarget) : QVariant());
+        upd.bindValue(":id", destId);
+        if (!upd.exec())
+            qWarning() << "EquipmentStorage: import superseded_by remap failed:" << upd.lastError().text();
+    }
+
+    return true;
+}

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -83,7 +83,10 @@ const PkgCol kCols[] = {
     COL_STR ("last_grind_setting", lastGrindSetting),
     COL_POS ("last_rpm",           lastRpm),
     COL_POS ("last_used",          lastUsedEpoch),
-    COL_POS ("superseded_by",      supersededBy),
+    // Non-writable: set only by the copy-on-write path's raw UPDATE (paired with
+    // in_inventory=0), never via INSERT or the generic field-update map, so the
+    // superseded_by / in_inventory coupling can't be half-set.
+    COL_ID  ("superseded_by",      supersededBy),
 };
 
 #undef COL_STR
@@ -489,7 +492,15 @@ qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, Equipm
     grinder.model = model;
     grinder.burrs = burrs;
     grinder.rpmCapable = deriveRpmCapable(brand, model);
-    insertItemStatic(db, grinder);
+    if (insertItemStatic(db, grinder) <= 0) {
+        // A package with no grinder item resolves to a blank grinder everywhere;
+        // don't leave that orphan behind — drop the just-inserted package row.
+        QSqlQuery dp(db);
+        dp.prepare("DELETE FROM equipment_packages WHERE id = :id");
+        dp.bindValue(":id", packageId);
+        dp.exec();
+        return -1;
+    }
     return packageId;
 }
 
@@ -640,43 +651,66 @@ qint64 EquipmentStorage::supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 p
         q.bindValue(":id", packageId);
         return (q.exec() && q.next()) ? q.value(0).toLongLong() : 0;
     };
-    auto repointBags = [&](qint64 from, qint64 to) {
+    auto repointBags = [&](qint64 from, qint64 to) -> bool {
         QSqlQuery q(db);
         q.prepare("UPDATE coffee_bags SET equipment_id = :to WHERE equipment_id = :from");
         q.bindValue(":to", to);
         q.bindValue(":from", from);
-        q.exec();
+        if (!q.exec()) {
+            qWarning() << "EquipmentStorage: repoint bags failed:" << q.lastError().text();
+            return false;
+        }
+        return true;
     };
-    auto softDelete = [&](qint64 id, qint64 supersededBy) {
+    auto softDelete = [&](qint64 id, qint64 supersededBy) -> bool {
         QSqlQuery q(db);
         q.prepare("UPDATE equipment_packages SET in_inventory = 0, superseded_by = :by, "
                   "updated_at = strftime('%s','now') WHERE id = :id");
         q.bindValue(":by", supersededBy > 0 ? QVariant(supersededBy) : QVariant());
         q.bindValue(":id", id);
-        q.exec();
+        if (!q.exec()) {
+            qWarning() << "EquipmentStorage: soft-delete failed:" << q.lastError().text();
+            return false;
+        }
+        return true;
+    };
+
+    // The whole identity edit must be atomic — a partial commit could repoint
+    // bags without retiring the old package (a duplicate live package). Wrap in a
+    // transaction and roll back to the no-op identity (return packageId) on any
+    // failure. (withTempDb runs in autocommit, so this is a top-level txn.)
+    const bool inTxn = db.transaction();
+    auto fail = [&]() -> qint64 { if (inTxn) db.rollback(); return packageId; };
+    auto done = [&](qint64 result) -> qint64 {
+        if (inTxn && !db.commit()) { db.rollback(); return packageId; }
+        return result;
     };
 
     // Merge: another current package already has this exact identity.
     const qint64 mergeTarget = findPackageByGrinderIdentityStatic(db, brand, model, burrs, packageId);
     if (mergeTarget > 0) {
-        repointBags(packageId, mergeTarget);
+        if (!repointBags(packageId, mergeTarget))
+            return fail();
         if (shotCount() == 0) {
             QSqlQuery di(db);
             di.prepare("DELETE FROM equipment_items WHERE package_id = :id");
-            di.bindValue(":id", packageId); di.exec();
+            di.bindValue(":id", packageId);
+            if (!di.exec()) return fail();
             QSqlQuery dp(db);
             dp.prepare("DELETE FROM equipment_packages WHERE id = :id");
-            dp.bindValue(":id", packageId); dp.exec();
-        } else {
-            softDelete(packageId, mergeTarget);
+            dp.bindValue(":id", packageId);
+            if (!dp.exec()) return fail();
+        } else if (!softDelete(packageId, mergeTarget)) {
+            return fail();
         }
-        return mergeTarget;
+        return done(mergeTarget);
     }
 
     // Unused package: safe to edit in place.
     if (shotCount() == 0) {
-        updateGrinderItemStatic(db, packageId, brand, model, burrs);
-        return packageId;
+        if (!updateGrinderItemStatic(db, packageId, brand, model, burrs))
+            return fail();
+        return done(packageId);
     }
 
     // Used package: fork (copy name + last dial), repoint bags, retire the old.
@@ -688,10 +722,12 @@ qint64 EquipmentStorage::supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 p
     np.lastUsedEpoch = QDateTime::currentSecsSinceEpoch();
     const qint64 newId = createPackageWithGrinderStatic(db, np, brand, model, burrs);
     if (newId <= 0)
-        return packageId;  // fork failed; leave as-is
-    repointBags(packageId, newId);
-    softDelete(packageId, newId);
-    return newId;
+        return fail();  // fork failed; leave as-is
+    if (!repointBags(packageId, newId))
+        return fail();
+    if (!softDelete(packageId, newId))
+        return fail();
+    return done(newId);
 }
 
 bool EquipmentStorage::deriveRpmCapable(const QString& brand, const QString& model)

--- a/src/history/equipmentstorage.h
+++ b/src/history/equipmentstorage.h
@@ -181,6 +181,19 @@ public:
                                                 const QString& currentBurrs,
                                                 const QString& currentSetting);
 
+    // Device-transfer import (add-equipment-packages task 2.8). Copies every
+    // equipment_packages + equipment_items row from srcDb into destDb with new
+    // ids, filling outIdMap[srcPackageId] = destPackageId so the caller can
+    // remap coffee_bags.equipment_id and shots.equipment_id. superseded_by is
+    // remapped through the same map after all packages are inserted. In merge
+    // mode an in-inventory source package whose grinder identity already exists
+    // in dest maps to that package (no duplicate); superseded (historical)
+    // packages always import as new rows. A source with no equipment tables
+    // yields an empty map and returns true. Runs inside the caller's destDb
+    // transaction; assumes the equipment tables exist in dest.
+    static bool importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& destDb, bool merge,
+                                      QHash<qint64, qint64>& outIdMap);
+
 signals:
     void inventoryReady(const QVariantList& packages);
     void packageReady(qint64 packageId, const QVariantMap& package); // empty if not found

--- a/src/history/equipmentstorage.h
+++ b/src/history/equipmentstorage.h
@@ -56,6 +56,11 @@ struct EquipmentPackage {
 
     qint64 lastUsedEpoch = 0; // MRU ordering (bumped on selection / shot save)
 
+    // Copy-on-write lineage: when an identity edit forks a new package, the old
+    // one is soft-deleted (inInventory=0) and points here at the fork's id. 0 =
+    // not superseded. Powers "older version" display + dial-history-across-edits.
+    qint64 supersededBy = 0;
+
     bool isValid() const { return id > 0; }
     QVariantMap toVariantMap() const;
     static EquipmentPackage fromVariantMap(const QVariantMap& map);
@@ -128,11 +133,27 @@ public:
                                         const QString& brand, const QString& model,
                                         const QString& burrs);
 
+    // Apply a grinder identity edit honoring copy-on-write immutability + merge,
+    // and return the package id the caller should now treat as active:
+    //   - identity unchanged                      -> same id (no-op)
+    //   - another in-inventory package matches     -> merge: repoint this
+    //       package's bags to it, delete this package if unused else soft-delete
+    //       it with superseded_by -> that id
+    //   - package unused (no shots)                -> edit in place -> same id
+    //   - package used (>=1 shot)                  -> fork a new package (copies
+    //       name + last dial), repoint bags, soft-delete old (superseded_by) -> new id
+    // Bag repointing is done here; the active-equipment selection is the caller's
+    // to update from the returned id.
+    static qint64 supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 packageId,
+                                               const QString& brand, const QString& model,
+                                               const QString& burrs);
+
     // Find an existing in-inventory package whose grinder identity matches
     // (case-insensitive brand+model+burrs), or 0 if none. Used by the migration
     // and create flows to dedup on identity (NOT on grind/rpm).
     static qint64 findPackageByGrinderIdentityStatic(QSqlDatabase& db, const QString& brand,
-                                                     const QString& model, const QString& burrs);
+                                                     const QString& model, const QString& burrs,
+                                                     qint64 excludeId = 0);
 
     // rpmCapable for a grinder identity: the registry's variableRpm when the
     // brand/model matches an alias, else true (a custom grinder shows the rpm

--- a/src/history/equipmentstorage.h
+++ b/src/history/equipmentstorage.h
@@ -111,7 +111,9 @@ public:
     static qint64 insertItemStatic(QSqlDatabase& db, const EquipmentItem& item);
     // Create a package and its single grinder item in one call; returns the new
     // package id (-1 on failure). rpmCapable is derived from the registry.
-    static qint64 createPackageWithGrinderStatic(QSqlDatabase& db, const EquipmentPackage& pkg,
+    // pkg is taken by value: a name is persisted at creation (defaults to
+    // "{brand} {model}") so it survives identity edits / copy-on-write.
+    static qint64 createPackageWithGrinderStatic(QSqlDatabase& db, EquipmentPackage pkg,
                                                  const QString& brand, const QString& model,
                                                  const QString& burrs);
 

--- a/src/history/equipmentstorage.h
+++ b/src/history/equipmentstorage.h
@@ -181,16 +181,16 @@ public:
                                                 const QString& currentBurrs,
                                                 const QString& currentSetting);
 
-    // Device-transfer import (add-equipment-packages task 2.8). Copies every
-    // equipment_packages + equipment_items row from srcDb into destDb with new
-    // ids, filling outIdMap[srcPackageId] = destPackageId so the caller can
-    // remap coffee_bags.equipment_id and shots.equipment_id. superseded_by is
-    // remapped through the same map after all packages are inserted. In merge
-    // mode an in-inventory source package whose grinder identity already exists
-    // in dest maps to that package (no duplicate); superseded (historical)
-    // packages always import as new rows. A source with no equipment tables
-    // yields an empty map and returns true. Runs inside the caller's destDb
-    // transaction; assumes the equipment tables exist in dest.
+    // Device-transfer import (add-equipment-packages task 2.8). Imports
+    // equipment_packages + equipment_items from srcDb into destDb with new ids,
+    // filling outIdMap[srcPackageId] = destPackageId so the caller can remap
+    // coffee_bags.equipment_id and shots.equipment_id. superseded_by is remapped
+    // through the same map after all packages are inserted. In merge mode an
+    // in-inventory source package whose grinder identity already exists in dest
+    // maps to that existing package WITHOUT copying a duplicate package/items;
+    // superseded (historical) packages always import as new rows. A source with
+    // no equipment tables yields an empty map and returns true. Runs inside the
+    // caller's destDb transaction; assumes the equipment tables exist in dest.
     static bool importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& destDb, bool merge,
                                       QHash<qint64, qint64>& outIdMap);
 

--- a/src/history/equipmentstorage.h
+++ b/src/history/equipmentstorage.h
@@ -1,0 +1,176 @@
+#pragma once
+
+#include <QObject>
+#include <QHash>
+#include <QString>
+#include <QVariantList>
+#include <QVariantMap>
+#include <QVector>
+#include <atomic>
+#include <functional>
+#include <memory>
+
+class QSqlDatabase;
+class QSqlQuery;
+
+// An equipment item: one typed component of a package. Today the only kind is
+// "grinder"; future kinds (basket, tamper, …) are new rows with a different
+// `kind` and their own `attrs` payload — no schema migration (openspec change
+// add-equipment-packages). Shared fields every kind has (kind/brand/model) are
+// real columns; kind-specific fields live in the `attrs` JSON blob. For a
+// grinder, attrs = { "burrs": "...", "rpmCapable": true }. The `burrs` and
+// `rpmCapable` members below are convenience views of that blob, (de)serialized
+// on load/save — they are not their own columns.
+struct EquipmentItem {
+    qint64 id = 0;
+    qint64 packageId = 0;
+    QString kind = QStringLiteral("grinder");
+    QString brand;
+    QString model;
+
+    // Grinder-kind attrs (mirrored into/out of the `attrs` JSON column).
+    QString burrs;
+    bool rpmCapable = false;
+
+    bool isValid() const { return id > 0; }
+    // Serialize the kind-specific members into the attrs JSON string.
+    QString attrsJson() const;
+    // Populate the kind-specific members from an attrs JSON string.
+    void setAttrsFromJson(const QString& json);
+};
+
+// An equipment package: the switchable container the active bag points at via
+// coffee_bags.equipment_id (and shots.equipment_id snapshots). It owns one or
+// more EquipmentItems (exactly one grinder today). The package also carries the
+// grinder-scoped "last dial" memory — switching to a package applies these to
+// the active bag's grind setting / rpm (the bean-scoped memory lives on the bag).
+struct EquipmentPackage {
+    qint64 id = 0;
+
+    QString name;            // optional; UI falls back to "{brand} {model}"
+    bool inInventory = true; // soft-delete: removed packages keep their row
+
+    // Grinder-scoped dial memory (applied on equipment switch).
+    QString lastGrindSetting;
+    qint64 lastRpm = 0;      // 0 = unset
+
+    qint64 lastUsedEpoch = 0; // MRU ordering (bumped on selection / shot save)
+
+    bool isValid() const { return id > 0; }
+    QVariantMap toVariantMap() const;
+    static EquipmentPackage fromVariantMap(const QVariantMap& map);
+};
+
+// A package plus its resolved grinder item and shot count, for the inventory
+// list. shotCount is a per-query aggregate (shots.equipment_id), not a package
+// field — it drives the card's delete-vs-remove action exactly like InventoryBag.
+struct EquipmentPackageView {
+    EquipmentPackage package;
+    EquipmentItem grinder;
+    qint64 shotCount = 0;
+    // Flatten package + grinder identity (+ shotCount) into one map for QML/MCP.
+    QVariantMap toVariantMap() const;
+};
+
+// SQLite-backed equipment storage in the shot history database
+// (equipment_packages + equipment_items tables, created by ShotHistoryStorage
+// migration 22). Async request* methods run DB work on a QThread::create()
+// background thread and deliver results via signals — the CoffeeBagStorage
+// pattern. The *Static helpers are synchronous, take a caller-provided
+// connection, and are shared with the migration, device import, and tests.
+class EquipmentStorage : public QObject {
+    Q_OBJECT
+
+public:
+    explicit EquipmentStorage(QObject* parent = nullptr);
+    ~EquipmentStorage();
+
+    void initialize(const QString& dbPath);
+    QString databasePath() const { return m_dbPath; }
+
+    // Async queries — results via signals.
+    Q_INVOKABLE void requestInventory();                       // inventoryReady()
+    Q_INVOKABLE void requestPackage(qint64 packageId);         // packageReady()
+
+    // Async writes — all emit packagesChanged() on success.
+    // The map carries package fields plus grinder identity (brand/model/burrs);
+    // rpmCapable is derived from the registry, not taken from the map.
+    Q_INVOKABLE void requestCreatePackage(const QVariantMap& package);     // packageCreated()
+    Q_INVOKABLE void requestUpdatePackage(qint64 packageId, const QVariantMap& fields); // packageUpdated()
+    Q_INVOKABLE void requestMarkRemoved(qint64 packageId);                 // soft-delete (packageUpdated)
+    Q_INVOKABLE void requestTouchLastUsed(qint64 packageId);              // bump MRU (no signal)
+    // Deletes only when no bag/shot references the package; emits
+    // packageDeleted(packageId, success) — success false when references exist.
+    Q_INVOKABLE void requestDeletePackage(qint64 packageId);
+
+    // --- Synchronous static helpers (caller provides the connection) ---
+
+    static bool ensureTablesStatic(QSqlDatabase& db);
+
+    static qint64 insertPackageStatic(QSqlDatabase& db, const EquipmentPackage& pkg);
+    static qint64 insertItemStatic(QSqlDatabase& db, const EquipmentItem& item);
+    // Create a package and its single grinder item in one call; returns the new
+    // package id (-1 on failure). rpmCapable is derived from the registry.
+    static qint64 createPackageWithGrinderStatic(QSqlDatabase& db, const EquipmentPackage& pkg,
+                                                 const QString& brand, const QString& model,
+                                                 const QString& burrs);
+
+    static EquipmentPackage loadPackageStatic(QSqlDatabase& db, qint64 packageId);
+    static EquipmentItem loadGrinderItemStatic(QSqlDatabase& db, qint64 packageId);
+    static QVector<EquipmentPackageView> loadInventoryStatic(QSqlDatabase& db);
+
+    static bool updatePackageFieldsStatic(QSqlDatabase& db, qint64 packageId, const QVariantMap& fields);
+    // Update the package's grinder item identity; re-derives rpmCapable for the
+    // new brand/model. No-op-safe when the package has no grinder item.
+    static bool updateGrinderItemStatic(QSqlDatabase& db, qint64 packageId,
+                                        const QString& brand, const QString& model,
+                                        const QString& burrs);
+
+    // Find an existing in-inventory package whose grinder identity matches
+    // (case-insensitive brand+model+burrs), or 0 if none. Used by the migration
+    // and create flows to dedup on identity (NOT on grind/rpm).
+    static qint64 findPackageByGrinderIdentityStatic(QSqlDatabase& db, const QString& brand,
+                                                     const QString& model, const QString& burrs);
+
+    // rpmCapable for a grinder identity: the registry's variableRpm when the
+    // brand/model matches an alias, else true (a custom grinder shows the rpm
+    // field). Shared by create/update/migration so the rule lives in one place.
+    static bool deriveRpmCapable(const QString& brand, const QString& model);
+
+    // Best-effort, marker-gated split of a combined grind+rpm string. A trailing
+    // `(\d+)\s*rpm` token (case-insensitive) moves the number into outRpm and the
+    // remainder (trimmed) into outGrind; anything without an explicit `rpm`
+    // marker leaves outGrind == combined and outRpm == 0 (e.g. "1+4", "24 clicks").
+    static void splitGrindAndRpm(const QString& combined, QString& outGrind, qint64& outRpm);
+
+    // Migration 22 data step (shared with tests): create equipment packages from
+    // the distinct grinder identities on coffee_bags + shots (deduped on
+    // brand/model/burrs only — NOT grind/rpm), link each row via equipment_id,
+    // and split each row's grinder_setting into grinder_setting + rpm. The
+    // current* args are the user's live grinder settings (read from QSettings by
+    // the caller) — they seed the default package so the active grinder always
+    // has one even when no row carries that identity. Assumes the equipment
+    // tables exist and coffee_bags/shots already have equipment_id + rpm columns.
+    // Does NOT drop the legacy grinder identity columns (the schema owner does).
+    static bool migrateFromGrinderColumnsStatic(QSqlDatabase& db,
+                                                const QString& currentBrand,
+                                                const QString& currentModel,
+                                                const QString& currentBurrs,
+                                                const QString& currentSetting);
+
+signals:
+    void inventoryReady(const QVariantList& packages);
+    void packageReady(qint64 packageId, const QVariantMap& package); // empty if not found
+    void packageCreated(qint64 packageId, const QVariantMap& package); // id -1 on failure
+    void packageUpdated(qint64 packageId, bool success);
+    void packageDeleted(qint64 packageId, bool success);
+    void packagesChanged();
+
+private:
+    void runAsync(const QString& connPrefix,
+                  std::function<void(QSqlDatabase&)> work,
+                  std::function<void()> done);
+
+    QString m_dbPath;
+    std::shared_ptr<std::atomic<bool>> m_destroyed = std::make_shared<std::atomic<bool>>(false);
+};

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -54,6 +54,8 @@ struct ShotRecord {
     // package superseded this one (copy-on-write fork), "retired" = removed from
     // inventory with no successor. Rendered as a muted qualifier in history.
     QString equipmentState;
+    // Package display name, resolved at load (defaults to "{brand} {model}").
+    QString equipmentName;
     double drinkTds = 0;
     double drinkEy = 0;
     QString espressoNotes;

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -48,7 +48,7 @@ struct ShotRecord {
     QString grinderBurrs;
     QString grinderSetting;
     qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none
-    int rpm = 0;             // grinder rpm dial-in; 0 = unset
+    qint64 rpm = 0;          // grinder rpm dial-in; 0 = unset
     double drinkTds = 0;
     double drinkEy = 0;
     QString espressoNotes;
@@ -236,7 +236,7 @@ struct ShotSaveData {
     QString grinderBurrs;
     QString grinderSetting;
     qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none
-    int rpm = 0;             // grinder rpm dial-in; 0 = unset
+    qint64 rpm = 0;          // grinder rpm dial-in; 0 = unset
     double drinkTds = 0;
     double drinkEy = 0;
     int espressoEnjoyment = 0;

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -49,6 +49,11 @@ struct ShotRecord {
     QString grinderSetting;
     qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none
     qint64 rpm = 0;          // grinder rpm dial-in; 0 = unset
+    // Lineage state of the shot's equipment package, resolved at load (add-
+    // equipment-packages 4b.7): "" = current or no equipment, "older" = a newer
+    // package superseded this one (copy-on-write fork), "retired" = removed from
+    // inventory with no successor. Rendered as a muted qualifier in history.
+    QString equipmentState;
     double drinkTds = 0;
     double drinkEy = 0;
     QString espressoNotes;

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -47,6 +47,8 @@ struct ShotRecord {
     QString grinderModel;
     QString grinderBurrs;
     QString grinderSetting;
+    qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none
+    int rpm = 0;             // grinder rpm dial-in; 0 = unset
     double drinkTds = 0;
     double drinkEy = 0;
     QString espressoNotes;
@@ -233,6 +235,8 @@ struct ShotSaveData {
     QString grinderModel;
     QString grinderBurrs;
     QString grinderSetting;
+    qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none
+    int rpm = 0;             // grinder rpm dial-in; 0 = unset
     double drinkTds = 0;
     double drinkEy = 0;
     int espressoEnjoyment = 0;

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1328,6 +1328,8 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
     data.grinderModel = metadata.grinderModel;
     data.grinderBurrs = metadata.grinderBurrs;
     data.grinderSetting = metadata.grinderSetting;
+    data.equipmentId = metadata.equipmentId;
+    data.rpm = metadata.rpm;
     data.drinkTds = metadata.drinkTds;
     data.drinkEy = metadata.drinkEy;
     data.espressoEnjoyment = metadata.espressoEnjoyment;
@@ -1507,6 +1509,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     duration_seconds, final_weight, dose_weight,
                     bean_brand, bean_type, roast_date, roast_level,
                     grinder_brand, grinder_model, grinder_burrs, grinder_setting,
+                    equipment_id, rpm,
                     drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
                     profile_notes, debug_log,
                     temperature_override, yield_override, profile_kb_id,
@@ -1519,6 +1522,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     :duration, :final_weight, :dose_weight,
                     :bean_brand, :bean_type, :roast_date, :roast_level,
                     :grinder_brand, :grinder_model, :grinder_burrs, :grinder_setting,
+                    :equipment_id, :rpm,
                     :drink_tds, :drink_ey, :enjoyment, :espresso_notes, :bean_notes, :barista,
                     :profile_notes, :debug_log,
                     :temperature_override, :yield_override, :profile_kb_id,
@@ -1545,6 +1549,8 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
             query.bindValue(":grinder_model", data.grinderModel);
             query.bindValue(":grinder_burrs", data.grinderBurrs);
             query.bindValue(":grinder_setting", data.grinderSetting);
+            query.bindValue(":equipment_id", data.equipmentId > 0 ? QVariant(data.equipmentId) : QVariant());
+            query.bindValue(":rpm", data.rpm > 0 ? QVariant(data.rpm) : QVariant());
             query.bindValue(":drink_tds", data.drinkTds);
             query.bindValue(":drink_ey", data.drinkEy);
             query.bindValue(":enjoyment", data.espressoEnjoyment);
@@ -2043,7 +2049,8 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
                channeling_detected, grind_issue_detected,
                skip_first_frame_detected, pour_truncated_detected,
                stopped_by, beanbase_json,
-               bag_id, frozen_date, defrost_date
+               bag_id, frozen_date, defrost_date,
+               equipment_id, rpm
         FROM shots WHERE id = ?
     )")) {
         qWarning() << "ShotHistoryStorage::loadShotRecordStatic: prepare failed:" << query.lastError().text();
@@ -2095,6 +2102,8 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     record.bagId = query.value(36).isNull() ? -1 : query.value(36).toLongLong();
     record.frozenDate = query.value(37).toString();
     record.defrostDate = query.value(38).toString();
+    record.equipmentId = query.value(39).isNull() ? 0 : query.value(39).toLongLong();
+    record.rpm = query.value(40).toInt();
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     // Snapshot stored badge values before the recompute block overwrites them, so

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1121,9 +1121,14 @@ bool ShotHistoryStorage::runMigrations()
     // shot projection) keep working; they are dropped in migration 23 once every
     // reader resolves identity via equipment_id. The data step is NOT idempotent
     // (it would re-create packages), so the version bumps on the additive part;
-    // the < 22 block then never re-runs. Whitespace before the open-paren dodges
+    // the block then never re-runs. Whitespace before the open-paren dodges
     // the QSqlQuery permission-hook false-positive, as elsewhere.
-    if (currentVersion < 22) {
+    //
+    // Gate on "== 21" (advance only from a completed 21), NOT "< 22": migration
+    // 21's RENAME is gated on its post-condition and holds the version at 20 on
+    // failure so it retries next launch. A "< 22" gate would let migration 22 run
+    // and bump straight to 22 after a faulted 21, stranding the yield rename.
+    if (currentVersion >= 21 && currentVersion < 22) {
         qDebug() << "ShotHistoryStorage: Running migration to version 22 (equipment packages)";
 
         const bool tablesOk = EquipmentStorage::ensureTablesStatic(m_db);

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -290,7 +290,10 @@ bool ShotHistoryStorage::createTables()
     query.exec("CREATE INDEX IF NOT EXISTS idx_shots_timestamp ON shots(timestamp DESC)");
     query.exec("CREATE INDEX IF NOT EXISTS idx_shots_profile ON shots(profile_name)");
     query.exec("CREATE INDEX IF NOT EXISTS idx_shots_bean ON shots(bean_brand, bean_type)");
-    query.exec("CREATE INDEX IF NOT EXISTS idx_shots_grinder ON shots(grinder_brand, grinder_model)");
+    // No idx_shots_grinder: grinder_brand/model are dropped by migration 23 and
+    // grinder identity resolves via equipment_id. Re-creating it here would error
+    // ("no such column") on every post-migration-23 launch. Pre-23 DBs that still
+    // have the index get it dropped by migration 23.
     query.exec("CREATE INDEX IF NOT EXISTS idx_shots_enjoyment ON shots(enjoyment)");
     query.exec("CREATE INDEX IF NOT EXISTS idx_shot_phases_shot ON shot_phases(shot_id)");
 
@@ -1068,10 +1071,11 @@ bool ShotHistoryStorage::runMigrations()
 #ifdef DECENZA_TESTING
             // Model the locked DB faithfully: the same lock that failed the
             // orphan-link also fails every later migration's writes this pass,
-            // so nothing persists past version 19 and the WHOLE chain (incl.
-            // migration 21) retries next launch. Without this abort, the
-            // independently-gated migration 21 would still bump to 21 here and
-            // the < 20 block would never run again.
+            // so nothing persists past version 19 and the WHOLE deferred chain
+            // (migrations 21, 22, and 23) retries next launch. Without this abort,
+            // the independently-gated later migrations would advance the version
+            // via their own ">= N" gates (ending at 23) and the < 20 block would
+            // never run again, stranding the orphan bag_id links.
             if (linkFaulted) {
                 m_schemaVersion = currentVersion;
                 return true;
@@ -3319,13 +3323,29 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
     // Begin transaction
     m_db.transaction();
 
+    // Resolve the parsed grinder identity to an equipment package so the
+    // imported shot keeps its grinder (the per-shot grinder_brand/model/burrs
+    // columns are gone — migration 23; identity lives only on a package now).
+    // Find-or-create on grinder identity, mirroring the live shot-save path,
+    // then link via equipment_id. Empty identity → no package, NULL link.
+    qint64 importEquipmentId = 0;
+    if (!(record.grinderBrand.isEmpty() && record.grinderModel.isEmpty() && record.grinderBurrs.isEmpty())) {
+        importEquipmentId = EquipmentStorage::findPackageByGrinderIdentityStatic(
+            m_db, record.grinderBrand, record.grinderModel, record.grinderBurrs);
+        if (importEquipmentId <= 0) {
+            EquipmentPackage pkg;
+            importEquipmentId = EquipmentStorage::createPackageWithGrinderStatic(
+                m_db, pkg, record.grinderBrand, record.grinderModel, record.grinderBurrs);
+        }
+    }
+
     // Insert main shot record
     query.prepare(R"(
         INSERT INTO shots (
             uuid, timestamp, profile_name, profile_json, beverage_type,
             duration_seconds, final_weight, dose_weight,
             bean_brand, bean_type, roast_date, roast_level,
-            grinder_setting,
+            grinder_setting, equipment_id, rpm,
             drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
             profile_notes, debug_log,
             temperature_override, yield_override, profile_kb_id,
@@ -3335,7 +3355,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
             :uuid, :timestamp, :profile_name, :profile_json, :beverage_type,
             :duration, :final_weight, :dose_weight,
             :bean_brand, :bean_type, :roast_date, :roast_level,
-            :grinder_setting,
+            :grinder_setting, :equipment_id, :rpm,
             :drink_tds, :drink_ey, :enjoyment, :espresso_notes, :bean_notes, :barista,
             :profile_notes, :debug_log,
             :temperature_override, :yield_override, :profile_kb_id,
@@ -3357,10 +3377,12 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
     query.bindValue(":roast_date", record.roastDate);
     query.bindValue(":roast_level", record.roastLevel);
     // Grinder identity is not snapshotted on the shot row (migration 23 dropped
-    // the columns); it resolves via equipment_id. Imported shot files carry no
-    // package linkage, so their parsed grinder identity is not persisted — only
-    // the dial-in setting is kept.
+    // the columns); it resolves via equipment_id to the package found/created
+    // above from the parsed identity. The grind setting + rpm stay as per-shot
+    // dial-in.
     query.bindValue(":grinder_setting", record.grinderSetting);
+    query.bindValue(":equipment_id", importEquipmentId > 0 ? QVariant(importEquipmentId) : QVariant());
+    query.bindValue(":rpm", record.rpm > 0 ? QVariant(record.rpm) : QVariant());
     query.bindValue(":drink_tds", record.drinkTds);
     query.bindValue(":drink_ey", record.drinkEy);
     query.bindValue(":enjoyment", record.summary.enjoyment);

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -2203,7 +2203,7 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
                s.stopped_by, s.beanbase_json,
                s.bag_id, s.frozen_date, s.defrost_date,
                s.equipment_id, s.rpm,
-               ep.in_inventory, ep.superseded_by
+               ep.in_inventory, ep.superseded_by, ep.name
         FROM shots s
         LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder'
         LEFT JOIN equipment_packages ep ON ep.id = s.equipment_id
@@ -2271,6 +2271,11 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
         if (!inInventory)
             record.equipmentState = hasSuccessor ? QStringLiteral("older") : QStringLiteral("retired");
     }
+    // Package display name (col 43) — UI shows this rather than the raw grinder
+    // identity. Falls back to brand+model when the package has no custom name.
+    record.equipmentName = query.value(43).toString();
+    if (record.equipmentName.isEmpty())
+        record.equipmentName = (record.grinderBrand + QLatin1Char(' ') + record.grinderModel).trimmed();
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     // Snapshot stored badge values before the recompute block overwrites them, so
@@ -2544,6 +2549,7 @@ bool ShotHistoryStorage::updateShotMetadataStatic(QSqlDatabase& db, qint64 shotI
         // setting equipmentId (the picker's package id); brand/model/burrs keys
         // are intentionally ignored. The grind setting stays a per-shot dial-in.
         {"grinderSetting",  "grinder_setting"},
+        {"rpm",             "rpm"},
         {"equipmentId",     "equipment_id"},
         {"drinkTds",        "drink_tds"},
         {"drinkEy",         "drink_ey"},

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1,6 +1,7 @@
 #include "shothistorystorage.h"
 #include "shothistorystorage_internal.h"
 #include "coffeebagstorage.h"
+#include "equipmentstorage.h"
 #include "ai/conductance.h"
 #include "ai/shotanalysis.h"
 #include "ai/shotsummarizer.h"
@@ -1107,6 +1108,60 @@ bool ShotHistoryStorage::runMigrations()
             currentVersion = 21;
         } else {
             qWarning() << "ShotHistoryStorage: migration 21 column rename failed - will retry next launch";
+        }
+    }
+
+    // Migration 22: extract the grinder into first-class Equipment packages
+    // (add-equipment-packages). Create equipment tables; add equipment_id + rpm
+    // to coffee_bags and shots; create one package per distinct grinder identity
+    // (brand/model/burrs — NOT grind/rpm) plus a default from the current
+    // settings; link every row; split combined "24 1400rpm" settings into
+    // grinder_setting + rpm. This is the ADDITIVE half — the legacy grinder
+    // identity columns are KEPT for now so existing readers (CoffeeBagStorage,
+    // shot projection) keep working; they are dropped in migration 23 once every
+    // reader resolves identity via equipment_id. The data step is NOT idempotent
+    // (it would re-create packages), so the version bumps on the additive part;
+    // the < 22 block then never re-runs. Whitespace before the open-paren dodges
+    // the QSqlQuery permission-hook false-positive, as elsewhere.
+    if (currentVersion < 22) {
+        qDebug() << "ShotHistoryStorage: Running migration to version 22 (equipment packages)";
+
+        const bool tablesOk = EquipmentStorage::ensureTablesStatic(m_db);
+
+        if (!hasColumn("coffee_bags", "equipment_id"))
+            query.exec ("ALTER TABLE coffee_bags ADD COLUMN equipment_id INTEGER");
+        if (!hasColumn("coffee_bags", "rpm"))
+            query.exec ("ALTER TABLE coffee_bags ADD COLUMN rpm INTEGER");
+        if (!hasColumn("shots", "equipment_id"))
+            query.exec ("ALTER TABLE shots ADD COLUMN equipment_id INTEGER");
+        if (!hasColumn("shots", "rpm"))
+            query.exec ("ALTER TABLE shots ADD COLUMN rpm INTEGER");
+
+        const bool colsOk = hasColumn("coffee_bags", "equipment_id") && hasColumn("coffee_bags", "rpm")
+            && hasColumn("shots", "equipment_id") && hasColumn("shots", "rpm");
+
+        // The default package seeds from the user's live grinder settings (the
+        // active bag mirrors these via write-through, but reading QSettings here
+        // also covers a user who set a grinder but never saved a shot/bag).
+        bool dataOk = false;
+        if (tablesOk && colsOk) {
+            QSettings settings;
+            const QString curBrand = settings.value("dye/grinderBrand").toString();
+            const QString curModel = settings.value("dye/grinderModel").toString();
+            const QString curBurrs = settings.value("dye/grinderBurrs").toString();
+            const QString curSetting = settings.value("dye/grinderSetting").toString();
+            dataOk = EquipmentStorage::migrateFromGrinderColumnsStatic(
+                m_db, curBrand, curModel, curBurrs, curSetting);
+        }
+
+        if (tablesOk && colsOk && dataOk) {
+            query.exec ("DELETE FROM schema_version");
+            query.exec ("INSERT INTO schema_version (version) VALUES (22)");
+            currentVersion = 22;
+        } else {
+            qWarning() << "ShotHistoryStorage: migration 22 incomplete (tables" << tablesOk
+                       << "cols" << colsOk << "data" << dataOk
+                       << ") - will retry next launch";
         }
     }
 

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1124,13 +1124,17 @@ bool ShotHistoryStorage::runMigrations()
     // the block then never re-runs. Whitespace before the open-paren dodges
     // the QSqlQuery permission-hook false-positive, as elsewhere.
     //
-    // Gate on "== 21" (advance only from a completed 21), NOT "< 22": migration
-    // 21's RENAME is gated on its post-condition and holds the version at 20 on
-    // failure so it retries next launch. A "< 22" gate would let migration 22 run
-    // and bump straight to 22 after a faulted 21, stranding the yield rename.
+    // Gate on ">= 21 && < 22" (advance only from a completed 21), NOT "< 22":
+    // migration 21's RENAME is gated on its post-condition and holds the version
+    // at 20 on failure so it retries next launch. A "< 22" gate would let
+    // migration 22 run and bump straight to 22 after a faulted 21, stranding the
+    // yield rename. The whole step is wrapped in a transaction (like migrations
+    // 7/8/16) so a failure rolls back the partial package inserts — the data step
+    // is NOT idempotent, so a half-applied retry would duplicate packages.
     if (currentVersion >= 21 && currentVersion < 22) {
         qDebug() << "ShotHistoryStorage: Running migration to version 22 (equipment packages)";
 
+        const bool txn = m_db.transaction();
         const bool tablesOk = EquipmentStorage::ensureTablesStatic(m_db);
 
         if (!hasColumn("coffee_bags", "equipment_id"))
@@ -1160,10 +1164,20 @@ bool ShotHistoryStorage::runMigrations()
         }
 
         if (tablesOk && colsOk && dataOk) {
+            // Bump the version INSIDE the transaction so the data + version commit
+            // atomically — a crash between them would otherwise leave migrated
+            // data at version 21 and re-run the non-idempotent step next launch.
             query.exec ("DELETE FROM schema_version");
             query.exec ("INSERT INTO schema_version (version) VALUES (22)");
-            currentVersion = 22;
+            if (!txn || m_db.commit()) {
+                currentVersion = 22;
+            } else {
+                if (txn) m_db.rollback();
+                qWarning() << "ShotHistoryStorage: migration 22 commit failed - will retry next launch";
+            }
         } else {
+            if (txn)
+                m_db.rollback();  // undo partial package inserts so the retry is clean
             qWarning() << "ShotHistoryStorage: migration 22 incomplete (tables" << tablesOk
                        << "cols" << colsOk << "data" << dataOk
                        << ") - will retry next launch";

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1300,6 +1300,8 @@ bool ShotHistoryStorage::runMigrations()
             query.exec ("INSERT INTO schema_version (version) VALUES (23)");
             if (!txn || m_db.commit()) {
                 currentVersion = 23;
+                qInfo() << "ShotHistoryStorage: migration 23 complete - dropped grinder identity"
+                           " columns from shots + coffee_bags, rebuilt shots_fts without them";
             } else {
                 if (txn) m_db.rollback();
                 qWarning() << "ShotHistoryStorage: migration 23 commit failed - will retry next launch";

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1187,6 +1187,127 @@ bool ShotHistoryStorage::runMigrations()
         }
     }
 
+    // Migration 23: drop the legacy grinder identity columns now that every
+    // reader resolves brand/model/burrs through equipment_id (add-equipment-
+    // packages). Migration 22 deliberately KEPT grinder_brand/model/burrs on
+    // shots + coffee_bags so the upgrade could seed packages from them and
+    // existing readers kept working; with the reader sweep complete, the
+    // pointer-to-immutable-package is the only identity path and the snapshot
+    // columns are dead weight, so they go.
+    //
+    // Ordering inside the step matters: shots_fts is an external-content FTS5
+    // index over the grinder columns and its triggers reference new./old.grinder_*,
+    // and idx_shots_grinder is built on them. SQLite refuses DROP COLUMN on a
+    // column referenced by a trigger or index, so the FTS index/triggers are
+    // rebuilt WITHOUT the grinder columns and the index is dropped BEFORE the
+    // columns. DROP COLUMN needs SQLite >= 3.35 (we require it). The whole step
+    // is wrapped in a transaction and gated on the post-condition (columns gone)
+    // so a failure rolls back and retries next launch — it is idempotent
+    // (hasColumn guards each drop). Gate ">= 22 && < 23" so it only advances
+    // from a committed migration 22 (mirrors migration 22's gate on 21).
+    if (currentVersion >= 22 && currentVersion < 23) {
+        qDebug() << "ShotHistoryStorage: Running migration to version 23 (drop legacy grinder columns)";
+
+        const bool txn = m_db.transaction();
+        bool ok = true;
+
+        // 1. Rebuild shots_fts without the grinder columns (mirror migration 8's
+        //    rebuild). Drop the triggers + FTS table, recreate over the
+        //    non-grinder text columns, then repopulate from shots.
+        query.exec("DROP TRIGGER IF EXISTS shots_ai");
+        query.exec("DROP TRIGGER IF EXISTS shots_ad");
+        query.exec("DROP TRIGGER IF EXISTS shots_au");
+        query.exec("DROP TABLE IF EXISTS shots_fts");
+
+        if (!query.exec(R"(
+            CREATE VIRTUAL TABLE IF NOT EXISTS shots_fts USING fts5(
+                espresso_notes, bean_brand, bean_type, profile_name,
+                content='shots', content_rowid='id'
+            )
+        )")) {
+            qWarning() << "ShotHistoryStorage: migration 23 failed to recreate FTS table:"
+                       << query.lastError().text();
+            ok = false;
+        }
+
+        if (ok) {
+            query.exec(R"(
+                CREATE TRIGGER IF NOT EXISTS shots_ai AFTER INSERT ON shots BEGIN
+                    INSERT INTO shots_fts(rowid, espresso_notes, bean_brand, bean_type, profile_name)
+                    VALUES (new.id, new.espresso_notes, new.bean_brand, new.bean_type, new.profile_name);
+                END
+            )");
+            query.exec(R"(
+                CREATE TRIGGER IF NOT EXISTS shots_ad AFTER DELETE ON shots BEGIN
+                    INSERT INTO shots_fts(shots_fts, rowid, espresso_notes, bean_brand, bean_type, profile_name)
+                    VALUES ('delete', old.id, old.espresso_notes, old.bean_brand, old.bean_type, old.profile_name);
+                END
+            )");
+            query.exec(R"(
+                CREATE TRIGGER IF NOT EXISTS shots_au AFTER UPDATE ON shots BEGIN
+                    INSERT INTO shots_fts(shots_fts, rowid, espresso_notes, bean_brand, bean_type, profile_name)
+                    VALUES ('delete', old.id, old.espresso_notes, old.bean_brand, old.bean_type, old.profile_name);
+                    INSERT INTO shots_fts(rowid, espresso_notes, bean_brand, bean_type, profile_name)
+                    VALUES (new.id, new.espresso_notes, new.bean_brand, new.bean_type, new.profile_name);
+                END
+            )");
+            if (!query.exec(R"(
+                INSERT INTO shots_fts(rowid, espresso_notes, bean_brand, bean_type, profile_name)
+                SELECT id, espresso_notes, bean_brand, bean_type, profile_name FROM shots
+            )")) {
+                qWarning() << "ShotHistoryStorage: migration 23 failed to repopulate FTS index:"
+                           << query.lastError().text();
+                ok = false;
+            }
+        }
+
+        // 2. Drop the grinder index (DROP COLUMN refuses an indexed column).
+        if (ok)
+            query.exec ("DROP INDEX IF EXISTS idx_shots_grinder");
+
+        // 3. Drop grinder_brand/model/burrs from both shots and coffee_bags.
+        //    Idempotent: hasColumn skips a column already gone (e.g. a retried
+        //    run after a mid-step crash). coffee_bags is guaranteed to exist
+        //    here (created by migration 19, earlier in the chain).
+        if (ok) {
+            for (const char* col : {"grinder_brand", "grinder_model", "grinder_burrs"}) {
+                for (const char* table : {"shots", "coffee_bags"}) {
+                    if (hasColumn(table, col)) {
+                        QSqlQuery drop(m_db);
+                        if (!drop.exec (QStringLiteral("ALTER TABLE %1 DROP COLUMN %2")
+                                            .arg(QLatin1String(table), QLatin1String(col)))) {
+                            qWarning() << "ShotHistoryStorage: migration 23 failed to drop" << table << col << ":"
+                                       << drop.lastError().text();
+                            ok = false;
+                        }
+                    }
+                }
+            }
+        }
+
+        const bool dropped =
+            !hasColumn("shots", "grinder_brand") && !hasColumn("shots", "grinder_model")
+            && !hasColumn("shots", "grinder_burrs")
+            && !hasColumn("coffee_bags", "grinder_brand") && !hasColumn("coffee_bags", "grinder_model")
+            && !hasColumn("coffee_bags", "grinder_burrs");
+
+        if (ok && dropped) {
+            query.exec ("DELETE FROM schema_version");
+            query.exec ("INSERT INTO schema_version (version) VALUES (23)");
+            if (!txn || m_db.commit()) {
+                currentVersion = 23;
+            } else {
+                if (txn) m_db.rollback();
+                qWarning() << "ShotHistoryStorage: migration 23 commit failed - will retry next launch";
+            }
+        } else {
+            if (txn)
+                m_db.rollback();
+            qWarning() << "ShotHistoryStorage: migration 23 incomplete (ok" << ok
+                       << "dropped" << dropped << ") - will retry next launch";
+        }
+    }
+
     m_schemaVersion = currentVersion;
     return true;
 }
@@ -1525,7 +1646,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     uuid, timestamp, profile_name, profile_json, beverage_type,
                     duration_seconds, final_weight, dose_weight,
                     bean_brand, bean_type, roast_date, roast_level,
-                    grinder_brand, grinder_model, grinder_burrs, grinder_setting,
+                    grinder_setting,
                     equipment_id, rpm,
                     drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
                     profile_notes, debug_log,
@@ -1538,7 +1659,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     :uuid, :timestamp, :profile_name, :profile_json, :beverage_type,
                     :duration, :final_weight, :dose_weight,
                     :bean_brand, :bean_type, :roast_date, :roast_level,
-                    :grinder_brand, :grinder_model, :grinder_burrs, :grinder_setting,
+                    :grinder_setting,
                     :equipment_id, :rpm,
                     :drink_tds, :drink_ey, :enjoyment, :espresso_notes, :bean_notes, :barista,
                     :profile_notes, :debug_log,
@@ -1562,9 +1683,9 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
             query.bindValue(":bean_type", data.beanType);
             query.bindValue(":roast_date", data.roastDate);
             query.bindValue(":roast_level", data.roastLevel);
-            query.bindValue(":grinder_brand", data.grinderBrand);
-            query.bindValue(":grinder_model", data.grinderModel);
-            query.bindValue(":grinder_burrs", data.grinderBurrs);
+            // Grinder identity (brand/model/burrs) is no longer snapshotted on the
+            // shot — it resolves through equipment_id to the package's immutable
+            // grinder item (migration 23). Only the per-shot dial-in is stored.
             query.bindValue(":grinder_setting", data.grinderSetting);
             query.bindValue(":equipment_id", data.equipmentId > 0 ? QVariant(data.equipmentId) : QVariant());
             query.bindValue(":rpm", data.rpm > 0 ? QVariant(data.rpm) : QVariant());
@@ -2055,20 +2176,32 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     ShotRecord record;
 
     QSqlQuery query(db);
+    // Grinder identity (brand/model/burrs) is resolved by following the shot's
+    // equipment_id pointer to its package's grinder item, not from per-shot
+    // snapshot columns (add-equipment-packages task 4.1). The legacy
+    // grinder_brand/model/burrs columns are dropped in migration 23; this JOIN
+    // is the single read path so the snapshot columns can go away. burrs lives
+    // in the item's attrs JSON blob (json_extract). A NULL equipment_id (shot
+    // with no grinder identity) LEFT-JOINs to NULLs — same empty strings the old
+    // columns held.
     if (!query.prepare(R"(
-        SELECT id, uuid, timestamp, profile_name, profile_json,
-               duration_seconds, final_weight, dose_weight,
-               bean_brand, bean_type, roast_date, roast_level,
-               grinder_brand, grinder_model, grinder_burrs, grinder_setting,
-               drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
-               profile_notes, visualizer_id, visualizer_url, debug_log,
-               temperature_override, yield_override, beverage_type, profile_kb_id,
-               channeling_detected, grind_issue_detected,
-               skip_first_frame_detected, pour_truncated_detected,
-               stopped_by, beanbase_json,
-               bag_id, frozen_date, defrost_date,
-               equipment_id, rpm
-        FROM shots WHERE id = ?
+        SELECT s.id, s.uuid, s.timestamp, s.profile_name, s.profile_json,
+               s.duration_seconds, s.final_weight, s.dose_weight,
+               s.bean_brand, s.bean_type, s.roast_date, s.roast_level,
+               eg.brand, eg.model, json_extract(eg.attrs, '$.burrs'), s.grinder_setting,
+               s.drink_tds, s.drink_ey, s.enjoyment, s.espresso_notes, s.bean_notes, s.barista,
+               s.profile_notes, s.visualizer_id, s.visualizer_url, s.debug_log,
+               s.temperature_override, s.yield_override, s.beverage_type, s.profile_kb_id,
+               s.channeling_detected, s.grind_issue_detected,
+               s.skip_first_frame_detected, s.pour_truncated_detected,
+               s.stopped_by, s.beanbase_json,
+               s.bag_id, s.frozen_date, s.defrost_date,
+               s.equipment_id, s.rpm,
+               ep.in_inventory, ep.superseded_by
+        FROM shots s
+        LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder'
+        LEFT JOIN equipment_packages ep ON ep.id = s.equipment_id
+        WHERE s.id = ?
     )")) {
         qWarning() << "ShotHistoryStorage::loadShotRecordStatic: prepare failed:" << query.lastError().text();
         return record;
@@ -2121,6 +2254,17 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     record.defrostDate = query.value(38).toString();
     record.equipmentId = query.value(39).isNull() ? 0 : query.value(39).toLongLong();
     record.rpm = query.value(40).toLongLong();
+    // Equipment lineage state for history display (add-equipment-packages 4b.7).
+    // A NULL in_inventory means the shot has no linked package (LEFT JOIN miss) —
+    // leave the state empty. Otherwise: in inventory = current (""), out of
+    // inventory with a superseded_by pointer = "older" (a newer fork exists),
+    // out of inventory without one = "retired".
+    if (record.equipmentId > 0 && !query.value(41).isNull()) {
+        const bool inInventory = query.value(41).toInt() != 0;
+        const bool hasSuccessor = !query.value(42).isNull() && query.value(42).toLongLong() > 0;
+        if (!inInventory)
+            record.equipmentState = hasSuccessor ? QStringLiteral("older") : QStringLiteral("retired");
+    }
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     // Snapshot stored badge values before the recompute block overwrites them, so
@@ -2388,9 +2532,11 @@ bool ShotHistoryStorage::updateShotMetadataStatic(QSqlDatabase& db, qint64 shotI
         {"beanType",        "bean_type"},
         {"roastDate",       "roast_date"},
         {"roastLevel",      "roast_level"},
-        {"grinderBrand",    "grinder_brand"},
-        {"grinderModel",    "grinder_model"},
-        {"grinderBurrs",    "grinder_burrs"},
+        // Grinder identity (brand/model/burrs) is no longer a per-shot column —
+        // it resolves through equipment_id to the immutable package, so it is not
+        // editable per-shot (migration 23). The grind setting remains a per-shot
+        // dial-in. Any grinderBrand/Model/Burrs keys in the metadata map are
+        // intentionally ignored.
         {"grinderSetting",  "grinder_setting"},
         {"drinkTds",        "drink_tds"},
         {"drinkEy",         "drink_ey"},
@@ -2486,8 +2632,7 @@ void ShotHistoryStorage::requestUpdateShotMetadata(qint64 shotId, const QVariant
 }
 
 // Note: getDistinctValues / requestDistinct* / requestAutoFavorites* /
-// queryGrinderContext / requestUpdateGrinderFields all live in
-// shothistorystorage_queries.cpp.
+// queryGrinderContext all live in shothistorystorage_queries.cpp.
 
 void ShotHistoryStorage::updateTotalShots()
 {
@@ -2851,12 +2996,24 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
         }
 
         {
-            // Import coffee bags first so shots.bag_id can be remapped
+            // Import equipment packages first so both bags and shots can remap
+            // their equipment_id to the new package ids (add-equipment-packages
+            // task 2.8). Pre-equipment sources have no tables and yield an empty
+            // map — bags/shots then null their equipment_id, same as before.
+            QHash<qint64, qint64> packageIdMap;
+            if (!EquipmentStorage::importEquipmentStatic(srcDb, destDb, merge, packageIdMap)) {
+                qWarning() << "ShotHistoryStorage::importDatabaseStatic: Equipment import failed";
+                destDb.rollback();
+                goto cleanup;
+            }
+
+            // Import coffee bags next so shots.bag_id can be remapped
             // (bean-bag-inventory): bag row ids change on insert, exactly
             // like shot ids. Pre-migration-19 sources have no coffee_bags
-            // table and yield an empty map.
+            // table and yield an empty map. packageIdMap remaps each bag's
+            // equipment_id.
             QHash<qint64, qint64> bagIdMap;
-            if (!CoffeeBagStorage::importBagsStatic(srcDb, destDb, merge, bagIdMap)) {
+            if (!CoffeeBagStorage::importBagsStatic(srcDb, destDb, merge, bagIdMap, packageIdMap)) {
                 qWarning() << "ShotHistoryStorage::importDatabaseStatic: Bag import failed";
                 destDb.rollback();
                 goto cleanup;
@@ -2892,6 +3049,11 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
             const int idxBagId = srcRecord.indexOf("bag_id");
             const int idxFrozenDate = srcRecord.indexOf("frozen_date");
             const int idxDefrostDate = srcRecord.indexOf("defrost_date");
+            // equipment_id (a source package row id, remapped) + rpm exist only
+            // on post-migration-22 sources (add-equipment-packages). Older
+            // sources lack both — they resolve to NULL.
+            const int idxEquipmentId = srcRecord.indexOf("equipment_id");
+            const int idxRpm = srcRecord.indexOf("rpm");
             auto srcValueOrNull = [&srcShots](int idx) {
                 return idx >= 0 ? srcShots.value(idx) : QVariant();
             };
@@ -2908,7 +3070,7 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                     INSERT INTO shots (uuid, timestamp, profile_name, profile_json, beverage_type,
                         duration_seconds, final_weight, dose_weight,
                         bean_brand, bean_type, roast_date, roast_level,
-                        grinder_brand, grinder_model, grinder_burrs, grinder_setting,
+                        grinder_setting, equipment_id, rpm,
                         drink_tds, drink_ey,
                         enjoyment, espresso_notes, bean_notes, barista,
                         profile_notes, visualizer_id, visualizer_url, debug_log,
@@ -2917,7 +3079,7 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                         skip_first_frame_detected, pour_truncated_detected,
                         stopped_by, beanbase_json, beanbase_id,
                         bag_id, frozen_date, defrost_date)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 )");
 
                 insert.addBindValue(uuid);
@@ -2933,10 +3095,15 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                 insert.addBindValue(srcShots.value("bean_type"));
                 insert.addBindValue(srcShots.value("roast_date"));
                 insert.addBindValue(srcShots.value("roast_level"));
-                insert.addBindValue(srcShots.value("grinder_brand"));
-                insert.addBindValue(srcShots.value("grinder_model"));
-                insert.addBindValue(srcShots.value("grinder_burrs"));
                 insert.addBindValue(srcShots.value("grinder_setting"));
+                // equipment_id is a source package row id — remap to the imported
+                // package's new dest id (add-equipment-packages task 2.8); a source
+                // id absent from the map becomes NULL. rpm carries verbatim.
+                {
+                    const qint64 mappedPkg = packageIdMap.value(srcValueOrNull(idxEquipmentId).toLongLong(), 0);
+                    insert.addBindValue(mappedPkg > 0 ? QVariant(mappedPkg) : QVariant());
+                }
+                insert.addBindValue(srcValueOrNull(idxRpm));
                 insert.addBindValue(srcShots.value("drink_tds"));
                 insert.addBindValue(srcShots.value("drink_ey"));
                 insert.addBindValue(srcShots.value("enjoyment"));
@@ -3158,7 +3325,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
             uuid, timestamp, profile_name, profile_json, beverage_type,
             duration_seconds, final_weight, dose_weight,
             bean_brand, bean_type, roast_date, roast_level,
-            grinder_brand, grinder_model, grinder_burrs, grinder_setting,
+            grinder_setting,
             drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
             profile_notes, debug_log,
             temperature_override, yield_override, profile_kb_id,
@@ -3168,7 +3335,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
             :uuid, :timestamp, :profile_name, :profile_json, :beverage_type,
             :duration, :final_weight, :dose_weight,
             :bean_brand, :bean_type, :roast_date, :roast_level,
-            :grinder_brand, :grinder_model, :grinder_burrs, :grinder_setting,
+            :grinder_setting,
             :drink_tds, :drink_ey, :enjoyment, :espresso_notes, :bean_notes, :barista,
             :profile_notes, :debug_log,
             :temperature_override, :yield_override, :profile_kb_id,
@@ -3189,9 +3356,10 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
     query.bindValue(":bean_type", record.summary.beanType);
     query.bindValue(":roast_date", record.roastDate);
     query.bindValue(":roast_level", record.roastLevel);
-    query.bindValue(":grinder_brand", record.grinderBrand);
-    query.bindValue(":grinder_model", record.grinderModel);
-    query.bindValue(":grinder_burrs", record.grinderBurrs);
+    // Grinder identity is not snapshotted on the shot row (migration 23 dropped
+    // the columns); it resolves via equipment_id. Imported shot files carry no
+    // package linkage, so their parsed grinder identity is not persisted — only
+    // the dial-in setting is kept.
     query.bindValue(":grinder_setting", record.grinderSetting);
     query.bindValue(":drink_tds", record.drinkTds);
     query.bindValue(":drink_ey", record.drinkEy);

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1154,7 +1154,10 @@ bool ShotHistoryStorage::runMigrations()
         // also covers a user who set a grinder but never saved a shot/bag).
         bool dataOk = false;
         if (tablesOk && colsOk) {
-            QSettings settings;
+            // Read the SAME QSettings scope SettingsDye writes to — a bare
+            // QSettings() depends on QCoreApplication org/app being set, which
+            // isn't guaranteed (the scope-mismatch bug migration 16 fixed).
+            QSettings settings(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
             const QString curBrand = settings.value("dye/grinderBrand").toString();
             const QString curModel = settings.value("dye/grinderModel").toString();
             const QString curBurrs = settings.value("dye/grinderBurrs").toString();
@@ -2117,7 +2120,7 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     record.frozenDate = query.value(37).toString();
     record.defrostDate = query.value(38).toString();
     record.equipmentId = query.value(39).isNull() ? 0 : query.value(39).toLongLong();
-    record.rpm = query.value(40).toInt();
+    record.rpm = query.value(40).toLongLong();
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     // Snapshot stored badge values before the recompute block overwrites them, so

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -2539,11 +2539,12 @@ bool ShotHistoryStorage::updateShotMetadataStatic(QSqlDatabase& db, qint64 shotI
         {"roastDate",       "roast_date"},
         {"roastLevel",      "roast_level"},
         // Grinder identity (brand/model/burrs) is no longer a per-shot column —
-        // it resolves through equipment_id to the immutable package, so it is not
-        // editable per-shot (migration 23). The grind setting remains a per-shot
-        // dial-in. Any grinderBrand/Model/Burrs keys in the metadata map are
-        // intentionally ignored.
+        // it resolves through equipment_id to the immutable package (migration 23).
+        // To correct a shot's grinder, re-point it at a different package by
+        // setting equipmentId (the picker's package id); brand/model/burrs keys
+        // are intentionally ignored. The grind setting stays a per-shot dial-in.
         {"grinderSetting",  "grinder_setting"},
+        {"equipmentId",     "equipment_id"},
         {"drinkTds",        "drink_tds"},
         {"drinkEy",         "drink_ey"},
         {"enjoyment",       "enjoyment"},
@@ -2589,8 +2590,14 @@ bool ShotHistoryStorage::updateShotMetadataStatic(QSqlDatabase& db, qint64 shotI
 
     // Bind only the columns present in the metadata.
     for (const auto& [metaKey, dbCol] : fieldMap) {
-        if (metadata.contains(metaKey))
-            query.bindValue(QString(":%1").arg(dbCol), metadata.value(metaKey));
+        if (!metadata.contains(metaKey))
+            continue;
+        QVariant v = metadata.value(metaKey);
+        // equipment_id is an FK — an unset/zero re-point clears the link to NULL
+        // rather than pointing at a non-existent package 0.
+        if (dbCol == QLatin1String("equipment_id") && v.toLongLong() <= 0)
+            v = QVariant();
+        query.bindValue(QString(":%1").arg(dbCol), v);
     }
     query.bindValue(":id", shotId);
 

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -173,11 +173,6 @@ public:
     Q_INVOKABLE QStringList getDistinctGrinderBurrsForModel(const QString& grinderBrand, const QString& grinderModel);
     Q_INVOKABLE QStringList getDistinctGrinderSettingsForGrinder(const QString& grinderModel);
 
-    // Bulk update grinder fields for historical shots matching old values
-    Q_INVOKABLE void requestUpdateGrinderFields(const QString& oldBrand, const QString& oldModel,
-                                                 const QString& newBrand, const QString& newModel,
-                                                 const QString& newBurrs);
-
     // Async: runs query on background thread, emits autoFavoritesReady()
     Q_INVOKABLE void requestAutoFavorites(const QString& groupBy, int maxItems);
 
@@ -280,7 +275,6 @@ signals:
     void visualizerLinksReconciled(bool ok, const QVariantList& linked);
     void mostRecentShotIdReady(qint64 shotId);
     void distinctCacheReady();
-    void grinderFieldsUpdated(int updatedCount);
     void shotBadgesUpdated(qint64 shotId, bool channelingDetected, bool grindIssueDetected, bool skipFirstFrameDetected, bool pourTruncatedDetected);
 
 private:

--- a/src/history/shothistorystorage_queries.cpp
+++ b/src/history/shothistorystorage_queries.cpp
@@ -13,7 +13,7 @@
 //     getDistinctValues + invalidateDistinctCache + getDistinct* getters +
 //     s_allowedColumns whitelist + sortGrinderSettings helper.
 //   - auto-favorites: requestAutoFavorites + requestAutoFavoriteGroupDetails.
-//   - grinder context: queryGrinderContext + requestUpdateGrinderFields.
+//   - grinder context: queryGrinderContext.
 
 #include "shothistorystorage.h"
 #include "shothistorystorage_internal.h"
@@ -50,7 +50,7 @@ void ShotHistoryStorage::requestDistinctCache()
         bool opened = withTempDb(dbPath, "shs_distinct", [&](QSqlDatabase& db) {
             static const QStringList columns = {
                 "profile_name", "bean_brand", "bean_type",
-                "grinder_brand", "grinder_model", "grinder_setting", "barista", "roast_level"
+                "grinder_setting", "barista", "roast_level"
             };
             for (const QString& col : columns) {
                 QStringList values;
@@ -199,17 +199,31 @@ QString ShotHistoryStorage::buildFilterQuery(const ShotFilter& filter, QVariantL
         conditions << "bean_type = ?";
         bindValues << filter.beanType;
     }
-    if (!filter.grinderBrand.isEmpty()) {
-        conditions << "grinder_brand = ?";
-        bindValues << filter.grinderBrand;
-    }
-    if (!filter.grinderModel.isEmpty()) {
-        conditions << "grinder_model = ?";
-        bindValues << filter.grinderModel;
-    }
-    if (!filter.grinderBurrs.isEmpty()) {
-        conditions << "grinder_burrs = ?";
-        bindValues << filter.grinderBurrs;
+    // Grinder identity filters resolve through the equipment_id pointer rather
+    // than the dropped grinder_brand/model/burrs columns (add-equipment-packages
+    // task 4.1): match the equipment_items grinder row, then keep shots pointing
+    // at one of those packages. The three fields combine into one subquery so
+    // any subset (brand only, brand+model, …) works.
+    {
+        QStringList grinderItemConds;
+        QVariantList grinderItemBinds;
+        if (!filter.grinderBrand.isEmpty()) {
+            grinderItemConds << "brand = ?";
+            grinderItemBinds << filter.grinderBrand;
+        }
+        if (!filter.grinderModel.isEmpty()) {
+            grinderItemConds << "model = ?";
+            grinderItemBinds << filter.grinderModel;
+        }
+        if (!filter.grinderBurrs.isEmpty()) {
+            grinderItemConds << "json_extract(attrs, '$.burrs') = ?";
+            grinderItemBinds << filter.grinderBurrs;
+        }
+        if (!grinderItemConds.isEmpty()) {
+            conditions << QString("equipment_id IN (SELECT package_id FROM equipment_items "
+                                  "WHERE kind = 'grinder' AND %1)").arg(grinderItemConds.join(" AND "));
+            bindValues << grinderItemBinds;
+        }
     }
     if (!filter.grinderSetting.isEmpty()) {
         conditions << "grinder_setting = ?";
@@ -513,18 +527,25 @@ void ShotHistoryStorage::requestRecentShotsByKbId(const QString& kbId, int limit
 QVariantList ShotHistoryStorage::loadRecentShotsByKbIdStatic(QSqlDatabase& db, const QString& kbId, int limit, qint64 excludeShotId)
 {
     QVariantList results;
+    // Grinder identity resolved via the equipment_id pointer (add-equipment-
+    // packages task 4.1); the per-shot grinder_brand/model/burrs columns are
+    // dropped in migration 23. Aliases keep the value("grinder_*") reads below
+    // unchanged. burrs is json_extract'd from the grinder item's attrs blob.
     QString sql = QStringLiteral(R"(
-        SELECT id, timestamp, profile_name, duration_seconds, final_weight, dose_weight,
-               bean_brand, bean_type, roast_level, grinder_brand, grinder_model,
-               grinder_burrs, grinder_setting, drink_tds, drink_ey, enjoyment,
-               espresso_notes, roast_date, temperature_override, yield_override, profile_json, beverage_type,
-               stopped_by
-        FROM shots
-        WHERE profile_kb_id = ?
+        SELECT s.id, s.timestamp, s.profile_name, s.duration_seconds, s.final_weight, s.dose_weight,
+               s.bean_brand, s.bean_type, s.roast_level,
+               eg.brand AS grinder_brand, eg.model AS grinder_model,
+               json_extract(eg.attrs, '$.burrs') AS grinder_burrs,
+               s.grinder_setting, s.drink_tds, s.drink_ey, s.enjoyment,
+               s.espresso_notes, s.roast_date, s.temperature_override, s.yield_override, s.profile_json, s.beverage_type,
+               s.stopped_by
+        FROM shots s
+        LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder'
+        WHERE s.profile_kb_id = ?
     )");
     if (excludeShotId >= 0)
-        sql += QStringLiteral(" AND id != ?");
-    sql += QStringLiteral(" ORDER BY timestamp DESC LIMIT ?");
+        sql += QStringLiteral(" AND s.id != ?");
+    sql += QStringLiteral(" ORDER BY s.timestamp DESC LIMIT ?");
 
     QSqlQuery query(db);
     if (!query.prepare(sql)) {
@@ -606,9 +627,14 @@ GrinderContext ShotHistoryStorage::queryGrinderContext(QSqlDatabase& db,
     // Build SQL with an optional bean_brand filter — same conditional-
     // append pattern used by loadRecentShotsByKbIdStatic and
     // buildFilterQuery in this file.
+    // Grinder model resolves through the equipment_id pointer (the per-shot
+    // grinder_model column is dropped in migration 23, add-equipment-packages
+    // task 4.1). grinder_setting (per-shot dial-in) stays on the shot row.
     QString sql = QStringLiteral(
         "SELECT DISTINCT grinder_setting FROM shots "
-        "WHERE grinder_model = :model AND beverage_type = :bev "
+        "WHERE equipment_id IN (SELECT package_id FROM equipment_items "
+        "WHERE kind = 'grinder' AND model = :model) "
+        "AND beverage_type = :bev "
         "AND grinder_setting != ''");
     if (!beanBrand.isEmpty()) {
         sql += QStringLiteral(" AND bean_brand = :brand");
@@ -674,7 +700,7 @@ GrinderContext ShotHistoryStorage::queryGrinderContext(QSqlDatabase& db,
 
 static const QStringList s_allowedColumns = {
     "profile_name", "bean_brand", "bean_type",
-    "grinder_brand", "grinder_model", "grinder_setting", "barista", "roast_level"
+    "grinder_setting", "barista", "roast_level"
 };
 
 QStringList ShotHistoryStorage::getDistinctValues(const QString& column)
@@ -716,7 +742,19 @@ QStringList ShotHistoryStorage::getDistinctBeanTypes()
 
 QStringList ShotHistoryStorage::getDistinctGrinders()
 {
-    return getDistinctValues("grinder_model");
+    // Grinder models come from the equipment inventory, not the dropped
+    // shots.grinder_model column (add-equipment-packages task 4.2). All grinder
+    // items across every package (inventory or superseded) so history retains
+    // sold/retired grinders. Async + cached like the other grinder getters.
+    const QString cacheKey = QStringLiteral("eq_grinder_model");
+    if (m_distinctCache.contains(cacheKey))
+        return m_distinctCache.value(cacheKey);
+    if (!m_ready) return {};
+    requestDistinctValueAsync(cacheKey,
+        "SELECT DISTINCT model FROM equipment_items "
+        "WHERE kind = 'grinder' AND model IS NOT NULL AND model != '' "
+        "ORDER BY model");
+    return {};
 }
 
 QStringList ShotHistoryStorage::getDistinctGrinderSettings()
@@ -764,20 +802,24 @@ void ShotHistoryStorage::requestAutoFavorites(const QString& groupBy, int maxIte
         groupColumns = "COALESCE(profile_name, '')";
         joinConditions = "COALESCE(s.profile_name, '') = g.gb_profile_name";
     } else if (groupBy == "bean_profile_grinder" || weightAware) {
+        // Grinder identity is the equipment_id pointer, not the dropped
+        // grinder_brand/model columns (add-equipment-packages task 4.1).
+        // Grouping on equipment_id is equivalent to the old brand+model key
+        // (shots with the same identity share a package) and additionally
+        // honours burrs, which the old key ignored. grinder_setting (per-shot
+        // dial-in) stays in the key so different settings still split cards.
         selectColumns = "COALESCE(bean_brand, '') AS gb_bean_brand, "
                         "COALESCE(bean_type, '') AS gb_bean_type, "
                         "COALESCE(profile_name, '') AS gb_profile_name, "
-                        "COALESCE(grinder_brand, '') AS gb_grinder_brand, "
-                        "COALESCE(grinder_model, '') AS gb_grinder_model, "
+                        "COALESCE(equipment_id, 0) AS gb_equipment_id, "
                         "COALESCE(grinder_setting, '') AS gb_grinder_setting";
         groupColumns = "COALESCE(bean_brand, ''), COALESCE(bean_type, ''), "
-                       "COALESCE(profile_name, ''), COALESCE(grinder_brand, ''), "
-                       "COALESCE(grinder_model, ''), COALESCE(grinder_setting, '')";
+                       "COALESCE(profile_name, ''), COALESCE(equipment_id, 0), "
+                       "COALESCE(grinder_setting, '')";
         joinConditions = "COALESCE(s.bean_brand, '') = g.gb_bean_brand "
                          "AND COALESCE(s.bean_type, '') = g.gb_bean_type "
                          "AND COALESCE(s.profile_name, '') = g.gb_profile_name "
-                         "AND COALESCE(s.grinder_brand, '') = g.gb_grinder_brand "
-                         "AND COALESCE(s.grinder_model, '') = g.gb_grinder_model "
+                         "AND COALESCE(s.equipment_id, 0) = g.gb_equipment_id "
                          "AND COALESCE(s.grinder_setting, '') = g.gb_grinder_setting";
     } else {
         // Default: bean_profile
@@ -816,10 +858,12 @@ void ShotHistoryStorage::requestAutoFavorites(const QString& groupBy, int maxIte
 
     QString sql = QString(
         "SELECT s.id, s.profile_name, s.bean_brand, s.bean_type, "
-        "s.grinder_brand, s.grinder_model, s.grinder_burrs, s.grinder_setting, "
+        "eg.brand AS grinder_brand, eg.model AS grinder_model, "
+        "json_extract(eg.attrs, '$.burrs') AS grinder_burrs, s.grinder_setting, "
         "s.dose_weight, s.final_weight, %5, %6, "
         "s.timestamp, g.shot_count, g.avg_enjoyment "
         "FROM shots s "
+        "LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder' "
         "INNER JOIN ("
         "  SELECT %1, MAX(timestamp) as max_ts, "
         "  COUNT(*) as shot_count, "
@@ -918,8 +962,16 @@ void ShotHistoryStorage::requestAutoFavoriteGroupDetails(const QString& groupBy,
         addCondition("bean_brand", beanBrand);
         addCondition("bean_type", beanType);
         addCondition("profile_name", profileName);
-        addCondition("grinder_brand", grinderBrand);
-        addCondition("grinder_model", grinderModel);
+        // Grinder identity resolves through the equipment_id pointer (the
+        // dropped grinder_brand/model columns no longer exist — migration 23).
+        // Correlated subqueries against the package's grinder item reproduce the
+        // old COALESCE(col,'')=? semantics, so a card with no grinder (NULL
+        // equipment_id → NULL → '') still matches empty brand/model. This stays
+        // consistent with requestAutoFavorites, which now groups on equipment_id.
+        addCondition("(SELECT brand FROM equipment_items "
+                     "WHERE package_id = shots.equipment_id AND kind = 'grinder')", grinderBrand);
+        addCondition("(SELECT model FROM equipment_items "
+                     "WHERE package_id = shots.equipment_id AND kind = 'grinder')", grinderModel);
         addCondition("grinder_setting", grinderSetting);
         if (groupBy == "bean_profile_grinder_weight") {
             // Match requestAutoFavorites's weight-mode bucketing exactly so stats scope
@@ -1033,8 +1085,18 @@ QStringList ShotHistoryStorage::getDistinctBeanTypesForBrand(const QString& bean
 
 QStringList ShotHistoryStorage::getDistinctGrinderBrands()
 {
-    // grinder_brand is pre-warmed by requestDistinctCache(), but use cache-only pattern
-    return getDistinctValues("grinder_brand");
+    // Grinder brands come from the equipment inventory (every grinder item,
+    // inventory or superseded), not the dropped shots.grinder_brand column
+    // (add-equipment-packages task 4.2). Async + cached.
+    const QString cacheKey = QStringLiteral("eq_grinder_brand");
+    if (m_distinctCache.contains(cacheKey))
+        return m_distinctCache.value(cacheKey);
+    if (!m_ready) return {};
+    requestDistinctValueAsync(cacheKey,
+        "SELECT DISTINCT brand FROM equipment_items "
+        "WHERE kind = 'grinder' AND brand IS NOT NULL AND brand != '' "
+        "ORDER BY brand");
+    return {};
 }
 
 QStringList ShotHistoryStorage::getDistinctGrinderModelsForBrand(const QString& grinderBrand)
@@ -1042,33 +1104,34 @@ QStringList ShotHistoryStorage::getDistinctGrinderModelsForBrand(const QString& 
     if (grinderBrand.isEmpty())
         return getDistinctGrinders();
 
-    const QString cacheKey = "grinder_model:" + grinderBrand;
+    const QString cacheKey = "eq_grinder_model:" + grinderBrand;
     if (m_distinctCache.contains(cacheKey))
         return m_distinctCache.value(cacheKey);
 
     if (!m_ready) return {};
 
     requestDistinctValueAsync(cacheKey,
-        "SELECT DISTINCT grinder_model FROM shots "
-        "WHERE grinder_brand = ? AND grinder_model IS NOT NULL AND grinder_model != '' "
-        "ORDER BY grinder_model",
+        "SELECT DISTINCT model FROM equipment_items "
+        "WHERE kind = 'grinder' AND brand = ? AND model IS NOT NULL AND model != '' "
+        "ORDER BY model",
         {grinderBrand});
     return {};
 }
 
 QStringList ShotHistoryStorage::getDistinctGrinderBurrsForModel(const QString& grinderBrand, const QString& grinderModel)
 {
-    const QString cacheKey = "grinder_burrs:" + grinderBrand + ":" + grinderModel;
+    const QString cacheKey = "eq_grinder_burrs:" + grinderBrand + ":" + grinderModel;
     if (m_distinctCache.contains(cacheKey))
         return m_distinctCache.value(cacheKey);
 
     if (!m_ready) return {};
 
+    // burrs lives in the grinder item's attrs JSON blob.
     requestDistinctValueAsync(cacheKey,
-        "SELECT DISTINCT grinder_burrs FROM shots "
-        "WHERE grinder_brand = ? AND grinder_model = ? "
-        "AND grinder_burrs IS NOT NULL AND grinder_burrs != '' "
-        "ORDER BY grinder_burrs",
+        "SELECT DISTINCT json_extract(attrs, '$.burrs') AS burrs FROM equipment_items "
+        "WHERE kind = 'grinder' AND brand = ? AND model = ? "
+        "AND burrs IS NOT NULL AND burrs != '' "
+        "ORDER BY burrs",
         {grinderBrand, grinderModel});
     return {};
 }
@@ -1084,9 +1147,13 @@ QStringList ShotHistoryStorage::getDistinctGrinderSettingsForGrinder(const QStri
 
     if (!m_ready) return {};
 
+    // Settings are per-shot dial-in (grinder_setting stays on shots); the grinder
+    // model resolves through the equipment_id pointer (task 4.2).
     requestDistinctValueAsync(cacheKey,
         "SELECT DISTINCT grinder_setting FROM shots "
-        "WHERE grinder_model = ? AND grinder_setting IS NOT NULL AND grinder_setting != '' "
+        "WHERE equipment_id IN (SELECT package_id FROM equipment_items "
+        "WHERE kind = 'grinder' AND model = ?) "
+        "AND grinder_setting IS NOT NULL AND grinder_setting != '' "
         "ORDER BY grinder_setting",
         {grinderModel});
     return {};
@@ -1120,48 +1187,4 @@ void ShotHistoryStorage::sortGrinderSettings(QStringList& settings)
             return QString::localeAwareCompare(a, b) < 0;
         });
     }
-}
-
-
-void ShotHistoryStorage::requestUpdateGrinderFields(const QString& oldBrand, const QString& oldModel,
-                                                     const QString& newBrand, const QString& newModel,
-                                                     const QString& newBurrs)
-{
-    if (!m_ready) {
-        emit grinderFieldsUpdated(0);
-        return;
-    }
-
-    const QString dbPath = m_dbPath;
-    auto destroyed = m_destroyed;
-
-    QThread* thread = QThread::create([this, dbPath, oldBrand, oldModel, newBrand, newModel, newBurrs, destroyed]() {
-        int count = 0;
-        withTempDb(dbPath, "shs_grinder_update", [&](QSqlDatabase& db) {
-            QSqlQuery query(db);
-            query.prepare("UPDATE shots SET grinder_brand = ?, grinder_model = ?, grinder_burrs = ?, "
-                          "updated_at = strftime('%s', 'now') "
-                          "WHERE grinder_brand = ? AND grinder_model = ?");
-            query.bindValue(0, newBrand);
-            query.bindValue(1, newModel);
-            query.bindValue(2, newBurrs);
-            query.bindValue(3, oldBrand);
-            query.bindValue(4, oldModel);
-            if (query.exec())
-                count = query.numRowsAffected();
-            else
-                qWarning() << "ShotHistoryStorage: Failed to bulk update grinder fields:" << query.lastError().text();
-        });
-
-        if (*destroyed) return;
-        QMetaObject::invokeMethod(this, [this, count, destroyed]() {
-            if (*destroyed) return;
-            invalidateDistinctCache();
-            emit grinderFieldsUpdated(count);
-            qDebug() << "ShotHistoryStorage: Updated grinder fields for" << count << "shots";
-        }, Qt::QueuedConnection);
-    });
-
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }

--- a/src/history/shothistorystorage_queries.cpp
+++ b/src/history/shothistorystorage_queries.cpp
@@ -356,6 +356,25 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
     if (!filter.searchText.isEmpty())
         ftsQuery = formatFtsQuery(filter.searchText);
 
+    // Grinder identity is no longer in shots_fts (migration 23), so a free-text
+    // search resolves the term against equipment_items and matches shots via the
+    // equipment_id pointer (add-equipment-packages 4b.6) — without this, typing a
+    // grinder name like "niche" finds nothing. Substring LIKE on the combined
+    // brand/model/burrs identity, OR'd with the FTS hit below. Built by
+    // concatenation (NOT QString::arg): the escaped LIKE value carries '%'
+    // wildcards that would collide with arg's %N placeholders. The literal is
+    // single-quote- and wildcard-escaped (ESCAPE '\') so user input is inert.
+    QString grinderMatchClause;
+    if (!ftsQuery.isEmpty()) {
+        QString likeVal = filter.searchText.trimmed().toLower();
+        likeVal.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_").replace('\'', "''");
+        grinderMatchClause = QStringLiteral(
+            " OR equipment_id IN (SELECT package_id FROM equipment_items WHERE kind = 'grinder' "
+            "AND LOWER(IFNULL(brand,'') || ' ' || IFNULL(model,'') || ' ' || "
+            "IFNULL(json_extract(attrs,'$.burrs'),'')) LIKE '%") + likeVal
+            + QStringLiteral("%' ESCAPE '\\')");
+    }
+
     QString sql;
     if (!ftsQuery.isEmpty()) {
         QString extraConditions;
@@ -363,20 +382,18 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
             extraConditions = whereClause;
             extraConditions.replace(extraConditions.indexOf("WHERE"), 5, "AND");
         }
-        sql = QString(R"(
-            SELECT id, uuid, timestamp, profile_name, duration_seconds,
-                   final_weight, dose_weight, bean_brand, bean_type,
-                   enjoyment, visualizer_id, grinder_setting,
-                   temperature_override, yield_override, beverage_type,
-                   drink_tds, drink_ey,
-                   channeling_detected, grind_issue_detected,
-                   skip_first_frame_detected, pour_truncated_detected
-            FROM shots
-            WHERE id IN (SELECT rowid FROM shots_fts WHERE shots_fts MATCH '%1')
-            %2
-            %3
-            LIMIT ? OFFSET ?
-        )").arg(ftsQuery).arg(extraConditions).arg(orderByClause);
+        const QString ftsMatch = QString("id IN (SELECT rowid FROM shots_fts WHERE shots_fts MATCH '%1')")
+                                     .arg(ftsQuery);
+        sql = QStringLiteral(
+            "SELECT id, uuid, timestamp, profile_name, duration_seconds, "
+            "final_weight, dose_weight, bean_brand, bean_type, "
+            "enjoyment, visualizer_id, grinder_setting, "
+            "temperature_override, yield_override, beverage_type, "
+            "drink_tds, drink_ey, "
+            "channeling_detected, grind_issue_detected, "
+            "skip_first_frame_detected, pour_truncated_detected "
+            "FROM shots WHERE (") + ftsMatch + grinderMatchClause + ") "
+            + extraConditions + " " + orderByClause + " LIMIT ? OFFSET ?";
     } else {
         sql = QString(R"(
             SELECT id, uuid, timestamp, profile_name, duration_seconds,
@@ -401,9 +418,10 @@ void ShotHistoryStorage::requestShotsFiltered(const QVariantMap& filterMap, int 
             extraConditions = whereClause;
             extraConditions.replace(extraConditions.indexOf("WHERE"), 5, "AND");
         }
-        countSql = QString("SELECT COUNT(*) FROM shots WHERE id IN "
-                           "(SELECT rowid FROM shots_fts WHERE shots_fts MATCH '%1') %2")
-                       .arg(ftsQuery).arg(extraConditions);
+        const QString ftsMatch = QString("id IN (SELECT rowid FROM shots_fts WHERE shots_fts MATCH '%1')")
+                                     .arg(ftsQuery);
+        countSql = QStringLiteral("SELECT COUNT(*) FROM shots WHERE (") + ftsMatch
+                   + grinderMatchClause + ") " + extraConditions;
     } else {
         countSql = "SELECT COUNT(*) FROM shots" + whereClause;
     }

--- a/src/history/shothistorystorage_queries.cpp
+++ b/src/history/shothistorystorage_queries.cpp
@@ -966,8 +966,12 @@ void ShotHistoryStorage::requestAutoFavoriteGroupDetails(const QString& groupBy,
         // dropped grinder_brand/model columns no longer exist — migration 23).
         // Correlated subqueries against the package's grinder item reproduce the
         // old COALESCE(col,'')=? semantics, so a card with no grinder (NULL
-        // equipment_id → NULL → '') still matches empty brand/model. This stays
-        // consistent with requestAutoFavorites, which now groups on equipment_id.
+        // equipment_id → NULL → '') still matches empty brand/model. This
+        // APPROXIMATES requestAutoFavorites' grouping key (which groups on the
+        // raw equipment_id): when two packages share a brand+model — e.g. a
+        // superseded fork and its in-inventory successor — these brand+model
+        // conditions match shots across both, which is acceptable for the card's
+        // aggregate stats scope. (burrs is intentionally not matched here.)
         addCondition("(SELECT brand FROM equipment_items "
                      "WHERE package_id = shots.equipment_id AND kind = 'grinder')", grinderBrand);
         addCondition("(SELECT model FROM equipment_items "

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -61,6 +61,7 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.grinderModel = record.grinderModel;
     p.grinderBurrs = record.grinderBurrs;
     p.grinderSetting = record.grinderSetting;
+    p.rpm = record.rpm;
     p.drinkTdsPct = record.drinkTds;
     p.drinkEyPct = record.drinkEy;
     p.espressoNotes = record.espressoNotes;

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -64,6 +64,7 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.rpm = record.rpm;
     p.equipmentId = record.equipmentId;
     p.equipmentState = record.equipmentState;
+    p.equipmentName = record.equipmentName;
     p.drinkTdsPct = record.drinkTds;
     p.drinkEyPct = record.drinkEy;
     p.espressoNotes = record.espressoNotes;

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -62,6 +62,7 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.grinderBurrs = record.grinderBurrs;
     p.grinderSetting = record.grinderSetting;
     p.rpm = record.rpm;
+    p.equipmentId = record.equipmentId;
     p.equipmentState = record.equipmentState;
     p.drinkTdsPct = record.drinkTds;
     p.drinkEyPct = record.drinkEy;

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -62,6 +62,7 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.grinderBurrs = record.grinderBurrs;
     p.grinderSetting = record.grinderSetting;
     p.rpm = record.rpm;
+    p.equipmentState = record.equipmentState;
     p.drinkTdsPct = record.drinkTds;
     p.drinkEyPct = record.drinkEy;
     p.espressoNotes = record.espressoNotes;

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -50,6 +50,9 @@ class ShotProjection {
     Q_PROPERTY(QString grinderBurrs MEMBER grinderBurrs)
     Q_PROPERTY(QString grinderSetting MEMBER grinderSetting)
     Q_PROPERTY(qlonglong rpm MEMBER rpm)
+    // The shot's equipment package id (add-equipment-packages) — exposed so the
+    // shot editor can re-point a shot to a different package; 0 = none.
+    Q_PROPERTY(qlonglong equipmentId MEMBER equipmentId)
     // "" = current/none, "older" = superseded by a newer package, "retired" =
     // out of inventory with no successor (add-equipment-packages 4b.7).
     Q_PROPERTY(QString equipmentState MEMBER equipmentState)
@@ -129,6 +132,7 @@ public:
     QString grinderBurrs;
     QString grinderSetting;
     qint64 rpm = 0;
+    qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none
     QString equipmentState;  // "", "older", or "retired" (add-equipment-packages 4b.7)
     double drinkTdsPct = 0.0;
     double drinkEyPct = 0.0;

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -49,7 +49,7 @@ class ShotProjection {
     Q_PROPERTY(QString grinderModel MEMBER grinderModel)
     Q_PROPERTY(QString grinderBurrs MEMBER grinderBurrs)
     Q_PROPERTY(QString grinderSetting MEMBER grinderSetting)
-    Q_PROPERTY(int rpm MEMBER rpm)
+    Q_PROPERTY(qlonglong rpm MEMBER rpm)
     Q_PROPERTY(double drinkTdsPct MEMBER drinkTdsPct)
     Q_PROPERTY(double drinkEyPct MEMBER drinkEyPct)
     Q_PROPERTY(QString espressoNotes MEMBER espressoNotes)
@@ -125,7 +125,7 @@ public:
     QString grinderModel;
     QString grinderBurrs;
     QString grinderSetting;
-    int rpm = 0;
+    qint64 rpm = 0;
     double drinkTdsPct = 0.0;
     double drinkEyPct = 0.0;
     QString espressoNotes;

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -56,6 +56,9 @@ class ShotProjection {
     // "" = current/none, "older" = superseded by a newer package, "retired" =
     // out of inventory with no successor (add-equipment-packages 4b.7).
     Q_PROPERTY(QString equipmentState MEMBER equipmentState)
+    // Package display name (defaults to "{brand} {model}") — shown instead of the
+    // raw grinder identity.
+    Q_PROPERTY(QString equipmentName MEMBER equipmentName)
     Q_PROPERTY(double drinkTdsPct MEMBER drinkTdsPct)
     Q_PROPERTY(double drinkEyPct MEMBER drinkEyPct)
     Q_PROPERTY(QString espressoNotes MEMBER espressoNotes)
@@ -134,6 +137,7 @@ public:
     qint64 rpm = 0;
     qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none
     QString equipmentState;  // "", "older", or "retired" (add-equipment-packages 4b.7)
+    QString equipmentName;   // package display name (default "{brand} {model}")
     double drinkTdsPct = 0.0;
     double drinkEyPct = 0.0;
     QString espressoNotes;

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -50,6 +50,9 @@ class ShotProjection {
     Q_PROPERTY(QString grinderBurrs MEMBER grinderBurrs)
     Q_PROPERTY(QString grinderSetting MEMBER grinderSetting)
     Q_PROPERTY(qlonglong rpm MEMBER rpm)
+    // "" = current/none, "older" = superseded by a newer package, "retired" =
+    // out of inventory with no successor (add-equipment-packages 4b.7).
+    Q_PROPERTY(QString equipmentState MEMBER equipmentState)
     Q_PROPERTY(double drinkTdsPct MEMBER drinkTdsPct)
     Q_PROPERTY(double drinkEyPct MEMBER drinkEyPct)
     Q_PROPERTY(QString espressoNotes MEMBER espressoNotes)
@@ -126,6 +129,7 @@ public:
     QString grinderBurrs;
     QString grinderSetting;
     qint64 rpm = 0;
+    QString equipmentState;  // "", "older", or "retired" (add-equipment-packages 4b.7)
     double drinkTdsPct = 0.0;
     double drinkEyPct = 0.0;
     QString espressoNotes;

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -49,6 +49,7 @@ class ShotProjection {
     Q_PROPERTY(QString grinderModel MEMBER grinderModel)
     Q_PROPERTY(QString grinderBurrs MEMBER grinderBurrs)
     Q_PROPERTY(QString grinderSetting MEMBER grinderSetting)
+    Q_PROPERTY(int rpm MEMBER rpm)
     Q_PROPERTY(double drinkTdsPct MEMBER drinkTdsPct)
     Q_PROPERTY(double drinkEyPct MEMBER drinkEyPct)
     Q_PROPERTY(QString espressoNotes MEMBER espressoNotes)
@@ -124,6 +125,7 @@ public:
     QString grinderModel;
     QString grinderBurrs;
     QString grinderSetting;
+    int rpm = 0;
     double drinkTdsPct = 0.0;
     double drinkEyPct = 0.0;
     QString espressoNotes;

--- a/src/history/unifiedbeansearchmodel.cpp
+++ b/src/history/unifiedbeansearchmodel.cpp
@@ -142,11 +142,18 @@ QVariantList UnifiedBeanSearchModel::queryHistoryStatic(QSqlDatabase& db, const 
     QSqlQuery query(db);
     // SQLite guarantees bare columns accompany the MAX() row, so the grinder/
     // dose values come from each coffee's most recent shot.
+    // Grinder identity resolves through each shot's equipment_id pointer (the
+    // per-shot grinder_brand/model/burrs columns are dropped in migration 23,
+    // add-equipment-packages task 4.1); the JOINed grinder item rides along the
+    // MAX(timestamp) row the same way the bare shot columns do. burrs is in the
+    // item's attrs JSON blob; grinder_setting stays on the shot.
     query.prepare(QStringLiteral(
         "SELECT bean_brand, bean_type, beanbase_id, beanbase_json, roast_level, "
-        "       grinder_brand, grinder_model, grinder_burrs, grinder_setting, "
+        "       eg.brand AS grinder_brand, eg.model AS grinder_model, "
+        "       json_extract(eg.attrs, '$.burrs') AS grinder_burrs, grinder_setting, "
         "       dose_weight, yield_override, MAX(timestamp) AS last_ts "
-        "FROM shots "
+        "FROM shots s "
+        "LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder' "
         "WHERE (COALESCE(bean_brand,'') <> '' OR COALESCE(bean_type,'') <> '') "
         "  AND (:filter = '' OR bean_brand LIKE :like OR bean_type LIKE :like) "
         "GROUP BY COALESCE(beanbase_id, LOWER(COALESCE(bean_brand,'')) || '|' || LOWER(COALESCE(bean_type,''))) "

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2413,6 +2413,8 @@ int main(int argc, char *argv[])
         "AIConversation is created in C++");
     qmlRegisterUncreatableType<CoffeeBagStorage>("Decenza", 1, 0, "CoffeeBagStorageType",
         "CoffeeBagStorage is created in C++ (MainController.bagStorage)");
+    qmlRegisterUncreatableType<EquipmentStorage>("Decenza", 1, 0, "EquipmentStorageType",
+        "EquipmentStorage is created in C++ (MainController.equipmentStorage)");
     qmlRegisterUncreatableType<UnifiedBeanSearchModel>("Decenza", 1, 0, "UnifiedBeanSearchModelType",
         "UnifiedBeanSearchModel is created in C++ (MainController.beanSearch)");
     // Exposes SteamHealthTracker::BaselineState enum values to QML

--- a/src/mcp/mcpresources.cpp
+++ b/src/mcp/mcpresources.cpp
@@ -189,6 +189,13 @@ void registerMcpResources(McpResourceRegistry* registry, DE1Device* device,
                 grinder["brand"] = settings->dye()->dyeGrinderBrand();
                 grinder["model"] = settings->dye()->dyeGrinderModel();
                 grinder["setting"] = settings->dye()->dyeGrinderSetting();
+                // Equipment package (add-equipment-packages): the active package
+                // and its rpm dial-in. rpm is only meaningful when adjustable.
+                grinder["packageId"] = settings->dye()->activeEquipmentId();
+                grinder["rpmAdjustable"] = settings->dye()->grinderRpmCapable(
+                    settings->dye()->dyeGrinderBrand(), settings->dye()->dyeGrinderModel());
+                if (settings->dye()->dyeGrinderRpm() > 0)
+                    grinder["rpm"] = settings->dye()->dyeGrinderRpm();
             }
 
             QJsonObject activeProfile;

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -303,6 +303,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         in.grinderModel = sd.grinderModel;
                         in.grinderBurrs = sd.grinderBurrs;
                         in.grinderSetting = sd.grinderSetting;
+                        in.rpm = static_cast<int>(sd.rpm);
                         in.doseWeightG = sd.doseWeightG;
                         in.beanBaseJson = sd.beanBaseJson;
                         result["currentBean"] = DialingBlocks::buildCurrentBeanBlock(in);

--- a/src/mcp/mcptools_shots.cpp
+++ b/src/mcp/mcptools_shots.cpp
@@ -165,12 +165,17 @@ void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistor
                 qint64 totalCount = 0;
 
                 if (!withTempDb(dbPath, "mcp_shots_list", [&](QSqlDatabase& db) {
-                    QString sql = "SELECT id, timestamp, profile_name, dose_weight, final_weight, "
+                    // Grinder model resolves through the equipment_id pointer
+                    // (the per-shot grinder_model column is dropped in migration
+                    // 23, add-equipment-packages task 4.1).
+                    QString sql = "SELECT s.id, timestamp, profile_name, dose_weight, final_weight, "
                                   "duration_seconds, enjoyment, "
-                                  "grinder_setting, grinder_model, "
+                                  "grinder_setting, eg.model AS grinder_model, "
                                   "espresso_notes, bean_brand, bean_type, yield_override, profile_json, "
                                   "stopped_by "
-                                  "FROM shots WHERE 1=1 ";
+                                  "FROM shots s "
+                                  "LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder' "
+                                  "WHERE 1=1 ";
                     QString countSql = "SELECT COUNT(*) FROM shots WHERE 1=1 ";
 
                     if (!profileFilter.isEmpty()) {

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -4,6 +4,7 @@
 #include "../history/shothistorystorage.h"
 #include "../history/shotprojection.h"
 #include "../history/coffeebagstorage.h"
+#include "../history/equipmentstorage.h"
 #include "../history/bagid.h"
 #include "../network/visualizeruploader.h"
 #include "../controllers/profilemanager.h"
@@ -1704,6 +1705,168 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                     respond(QJsonObject{{"success", true},
                                         {"message", QString("Active bag: %1 %2")
                                             .arg(bag.roasterName, bag.coffeeName).trimmed()}});
+                }, Qt::QueuedConnection);
+            });
+            QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+            thread->start();
+        },
+        "control");
+
+    // ----- Equipment packages (add-equipment-packages) -----
+
+    // Flatten an EquipmentPackageView into an MCP-friendly object (units in
+    // field names, no raw timestamps, isActive marks the selected package).
+    auto packageToJson = [](const EquipmentPackageView& v, qint64 activeId) {
+        QJsonObject o;
+        o["id"] = v.package.id;
+        if (!v.package.name.isEmpty()) o["name"] = v.package.name;
+        o["grinderBrand"] = v.grinder.brand;
+        o["grinderModel"] = v.grinder.model;
+        if (!v.grinder.burrs.isEmpty()) o["grinderBurrs"] = v.grinder.burrs;
+        o["rpmAdjustable"] = v.grinder.rpmCapable;
+        o["inInventory"] = v.package.inInventory;
+        if (!v.package.lastGrindSetting.isEmpty()) o["lastGrindSetting"] = v.package.lastGrindSetting;
+        if (v.package.lastRpm > 0) o["lastRpm"] = v.package.lastRpm;
+        o["shotCount"] = v.shotCount;
+        o["isActive"] = (v.package.id == activeId);
+        return o;
+    };
+
+    // equipment_list — read the equipment package inventory.
+    registry->registerAsyncTool(
+        "equipment_list",
+        "List the user's equipment packages (the grinder the next shot is ground on). The package "
+        "with isActive=true is the active bag's equipment. rpmAdjustable indicates whether the "
+        "grinder exposes an rpm dial-in.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
+        [shotHistory, settings, packageToJson](const QJsonObject&, std::function<void(QJsonObject)> respond) {
+            if (!shotHistory || !shotHistory->isReady()) {
+                respond(QJsonObject{{"error", "Storage not available"}});
+                return;
+            }
+            const qint64 activeId = settings ? settings->dye()->activeEquipmentId() : -1;
+            const QString dbPath = shotHistory->databasePath();
+            QThread* thread = QThread::create([dbPath, activeId, packageToJson, respond]() {
+                QJsonArray packages;
+                const bool opened = withTempDb(dbPath, "mcp_equip", [&](QSqlDatabase& db) {
+                    for (const EquipmentPackageView& v : EquipmentStorage::loadInventoryStatic(db))
+                        packages.append(packageToJson(v, activeId));
+                });
+                QMetaObject::invokeMethod(qApp, [opened, packages, respond]() {
+                    if (!opened) { respond(QJsonObject{{"error", "Could not open shot database"}}); return; }
+                    respond(QJsonObject{{"packages", packages}, {"count", packages.size()}});
+                }, Qt::QueuedConnection);
+            });
+            QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+            thread->start();
+        },
+        "read");
+
+    // equipment_update — edit a package's grinder identity (or create one).
+    registry->registerAsyncTool(
+        "equipment_update",
+        "Update an equipment package's grinder identity (brand/model/burrs) and optional name. Only "
+        "provided fields change. rpmAdjustable is re-derived from the grinder registry. Edits apply "
+        "to every bag and shot referencing the package (reference semantics).",
+        QJsonObject{
+            {"type", "object"},
+            {"properties", QJsonObject{
+                {"packageId", QJsonObject{{"type", "integer"}, {"description", "Package ID (from equipment_list)"}}},
+                {"name", QJsonObject{{"type", "string"}}},
+                {"grinderBrand", QJsonObject{{"type", "string"}}},
+                {"grinderModel", QJsonObject{{"type", "string"}}},
+                {"grinderBurrs", QJsonObject{{"type", "string"}}}
+            }},
+            {"required", QJsonArray{"packageId"}}
+        },
+        [shotHistory, settings, packageToJson](const QJsonObject& args, std::function<void(QJsonObject)> respond) {
+            if (!shotHistory || !shotHistory->isReady()) {
+                respond(QJsonObject{{"error", "Storage not available"}});
+                return;
+            }
+            const qint64 packageId = args["packageId"].toInteger();
+            if (packageId <= 0) { respond(QJsonObject{{"error", "Valid packageId is required"}}); return; }
+            const bool touchesGrinder = args.contains("grinderBrand") || args.contains("grinderModel")
+                || args.contains("grinderBurrs");
+            QVariantMap pkgFields;
+            if (args.contains("name")) pkgFields.insert("name", args["name"].toString());
+            const QString brand = args["grinderBrand"].toString();
+            const QString model = args["grinderModel"].toString();
+            const QString burrs = args["grinderBurrs"].toString();
+            const bool haveBrand = args.contains("grinderBrand");
+            const bool haveModel = args.contains("grinderModel");
+            const bool haveBurrs = args.contains("grinderBurrs");
+            const qint64 activeId = settings ? settings->dye()->activeEquipmentId() : -1;
+            const QString dbPath = shotHistory->databasePath();
+            QThread* thread = QThread::create([=]() {
+                bool ok = false;
+                EquipmentPackageView view;
+                withTempDb(dbPath, "mcp_equip_upd", [&](QSqlDatabase& db) {
+                    if (touchesGrinder) {
+                        const EquipmentItem cur = EquipmentStorage::loadGrinderItemStatic(db, packageId);
+                        ok = EquipmentStorage::updateGrinderItemStatic(db, packageId,
+                                haveBrand ? brand : cur.brand,
+                                haveModel ? model : cur.model,
+                                haveBurrs ? burrs : cur.burrs) || ok;
+                    }
+                    if (!pkgFields.isEmpty())
+                        ok = EquipmentStorage::updatePackageFieldsStatic(db, packageId, pkgFields) || ok;
+                    view.package = EquipmentStorage::loadPackageStatic(db, packageId);
+                    view.grinder = EquipmentStorage::loadGrinderItemStatic(db, packageId);
+                });
+                QMetaObject::invokeMethod(qApp, [ok, view, activeId, packageId, packageToJson, respond]() {
+                    if (!ok || !view.package.isValid()) {
+                        respond(QJsonObject{{"error", "Package not found or update failed: "
+                                                      + QString::number(packageId)}});
+                        return;
+                    }
+                    respond(QJsonObject{{"success", true}, {"package", packageToJson(view, activeId)}});
+                }, Qt::QueuedConnection);
+            });
+            QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+            thread->start();
+        },
+        "settings");
+
+    // equipment_select — set the active bag's equipment package.
+    registry->registerAsyncTool(
+        "equipment_select",
+        "Select the active equipment package — the grinder the next shot is ground on. Applies the "
+        "package's grinder identity and its last grind setting + rpm to the next-shot setup, and "
+        "points the active bag at it.",
+        QJsonObject{
+            {"type", "object"},
+            {"properties", QJsonObject{
+                {"packageId", QJsonObject{{"type", "integer"}, {"description", "Package ID from equipment_list"}}}
+            }},
+            {"required", QJsonArray{"packageId"}}
+        },
+        [shotHistory, settings](const QJsonObject& args, std::function<void(QJsonObject)> respond) {
+            if (!settings || !shotHistory || !shotHistory->isReady()) {
+                respond(QJsonObject{{"error", "Storage not available"}});
+                return;
+            }
+            const qint64 packageId = args["packageId"].toInteger();
+            if (packageId <= 0) { respond(QJsonObject{{"error", "Valid packageId is required"}}); return; }
+            const QString dbPath = shotHistory->databasePath();
+            QThread* thread = QThread::create([dbPath, packageId, settings, respond]() {
+                EquipmentPackageView view;
+                withTempDb(dbPath, "mcp_equip_sel", [&](QSqlDatabase& db) {
+                    view.package = EquipmentStorage::loadPackageStatic(db, packageId);
+                    view.grinder = EquipmentStorage::loadGrinderItemStatic(db, packageId);
+                });
+                const bool found = view.package.isValid();
+                const QVariantMap pkgMap = view.toVariantMap();
+                QMetaObject::invokeMethod(qApp, [found, pkgMap, packageId, settings, respond]() {
+                    if (!found) {
+                        respond(QJsonObject{{"error", "Package not found: " + QString::number(packageId)}});
+                        return;
+                    }
+                    settings->dye()->switchToEquipment(pkgMap);
+                    respond(QJsonObject{{"success", true},
+                        {"message", QString("Active equipment: %1 %2")
+                            .arg(pkgMap.value("grinderBrand").toString(),
+                                 pkgMap.value("grinderModel").toString()).trimmed()}});
                 }, Qt::QueuedConnection);
             });
             QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -1766,8 +1766,11 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
     registry->registerAsyncTool(
         "equipment_update",
         "Update an equipment package's grinder identity (brand/model/burrs) and optional name. Only "
-        "provided fields change. rpmAdjustable is re-derived from the grinder registry. Edits apply "
-        "to every bag and shot referencing the package (reference semantics).",
+        "provided fields change. rpmAdjustable is re-derived from the grinder registry. Identity is "
+        "copy-on-write: editing a package that has shots forks a NEW package (the old one is retired "
+        "and kept for its history) and an unused package is edited in place — so the returned "
+        "package.id may differ from the input packageId. An edit matching an existing package merges "
+        "into it.",
         QJsonObject{
             {"type", "object"},
             {"properties", QJsonObject{

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -1800,19 +1800,22 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             const QString dbPath = shotHistory->databasePath();
             QThread* thread = QThread::create([=]() {
                 bool ok = false;
+                qint64 resultId = packageId;
                 EquipmentPackageView view;
                 withTempDb(dbPath, "mcp_equip_upd", [&](QSqlDatabase& db) {
                     if (touchesGrinder) {
+                        // Copy-on-write/merge: identity edit may yield a new id.
                         const EquipmentItem cur = EquipmentStorage::loadGrinderItemStatic(db, packageId);
-                        ok = EquipmentStorage::updateGrinderItemStatic(db, packageId,
+                        resultId = EquipmentStorage::supersedeOrEditGrinderStatic(db, packageId,
                                 haveBrand ? brand : cur.brand,
                                 haveModel ? model : cur.model,
-                                haveBurrs ? burrs : cur.burrs) || ok;
+                                haveBurrs ? burrs : cur.burrs);
+                        ok = (resultId > 0);
                     }
                     if (!pkgFields.isEmpty())
-                        ok = EquipmentStorage::updatePackageFieldsStatic(db, packageId, pkgFields) || ok;
-                    view.package = EquipmentStorage::loadPackageStatic(db, packageId);
-                    view.grinder = EquipmentStorage::loadGrinderItemStatic(db, packageId);
+                        ok = EquipmentStorage::updatePackageFieldsStatic(db, resultId, pkgFields) || ok;
+                    view.package = EquipmentStorage::loadPackageStatic(db, resultId);
+                    view.grinder = EquipmentStorage::loadGrinderItemStatic(db, resultId);
                 });
                 QMetaObject::invokeMethod(qApp, [ok, view, activeId, packageId, packageToJson, respond]() {
                     if (!ok || !view.package.isValid()) {

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -65,9 +65,10 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 {"beanType", QJsonObject{{"type", "string"}, {"description", "Bean type/name"}}},
                 {"roastLevel", QJsonObject{{"type", "string"}, {"description", "Roast level"}}},
                 {"roastDate", QJsonObject{{"type", "string"}, {"description", "Roast date (YYYY-MM-DD)"}}},
-                {"grinderBrand", QJsonObject{{"type", "string"}, {"description", "Grinder brand"}}},
-                {"grinderModel", QJsonObject{{"type", "string"}, {"description", "Grinder model"}}},
-                {"grinderBurrs", QJsonObject{{"type", "string"}, {"description", "Grinder burrs (saved locally; the Visualizer shot schema has no burrs field, so this does not propagate to visualizer.coffee)"}}},
+                // Grinder identity (brand/model/burrs) is owned by the shot's
+                // equipment package, not the shot row, so it is intentionally not
+                // editable here — change it via the equipment package. Only the
+                // per-shot grind setting remains a shot-level field.
                 {"grinderSetting", QJsonObject{{"type", "string"}, {"description", "Grinder setting"}}},
                 {"barista", QJsonObject{{"type", "string"}, {"description", "Barista name"}}},
                 {"beverageType", QJsonObject{{"type", "string"}, {"description", "Beverage type (e.g. 'espresso', 'lungo'). Saved locally; the Visualizer shot schema carries beverage type via the profile, not the shot, so editing it here does not propagate to visualizer.coffee."}}},
@@ -112,12 +113,9 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 metadata["roastLevel"] = args["roastLevel"].toString();
             if (args.contains("roastDate"))
                 metadata["roastDate"] = args["roastDate"].toString();
-            if (args.contains("grinderBrand"))
-                metadata["grinderBrand"] = args["grinderBrand"].toString();
-            if (args.contains("grinderModel"))
-                metadata["grinderModel"] = args["grinderModel"].toString();
-            if (args.contains("grinderBurrs"))
-                metadata["grinderBurrs"] = args["grinderBurrs"].toString();
+            // grinderBrand/Model/Burrs are not accepted: grinder identity lives on
+            // the equipment package, not the shot (updateShotMetadataStatic's field
+            // map omits them). Only the per-shot grind setting is editable here.
             if (args.contains("grinderSetting"))
                 metadata["grinderSetting"] = args["grinderSetting"].toString();
             if (args.contains("barista"))

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -2308,6 +2308,7 @@ QString ShotServer::generateLayoutPage() const
         // Actions & readouts (white)
         {type:"beans",label:"Beans"},
         {type:"connectionStatus",label:"Connection"},
+        {type:"equipment",label:"Equipment"},
         {type:"espresso",label:"Espresso"},
         {type:"autofavorites",label:"Favorites"},
         {type:"flush",label:"Flush"},
@@ -2343,7 +2344,7 @@ QString ShotServer::generateLayoutPage() const
 
     var DISPLAY_NAMES = {
         espresso:"Espresso",steam:"Steam",hotwater:"Hot Water",flush:"Flush",
-        beans:"Beans",history:"History",autofavorites:"Favorites",sleep:"Sleep",
+        beans:"Beans",equipment:"Equipment",history:"History",autofavorites:"Favorites",sleep:"Sleep",
         settings:"Settings",temperature:"Temp",steamTemperature:"Steam",
         batteryLevel:"Battery",scaleBattery:"Scale Bat",waterLevel:"Water",connectionStatus:"Connection",scaleWeight:"Scale",
         shotPlan:"Shot Plan",pageTitle:"Title",spacer:"Spacer",separator:"Sep",

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -55,6 +55,18 @@
 #include <QDir>
 #include <QBuffer>
 
+namespace {
+// Visualizer has no rpm field, so the grinder rpm dial-in is appended to the
+// grind setting using the community convention ("2.4 1400rpm") that the grinder
+// parser already tolerates (add-equipment-packages).
+QString grinderSettingWithRpm(const QString& setting, int rpm) {
+    if (rpm <= 0)
+        return setting;
+    return setting.isEmpty() ? QStringLiteral("%1rpm").arg(rpm)
+                             : QStringLiteral("%1 %2rpm").arg(setting).arg(rpm);
+}
+} // namespace
+
 VisualizerUploader::VisualizerUploader(QNetworkAccessManager* networkManager, Settings* settings, QObject* parent)
     : QObject(parent)
     , m_settings(settings)
@@ -905,8 +917,10 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
            : metadata.grinderBrand + " " + metadata.grinderModel);
     if (!grinderDisplay.isEmpty())
         grinder["model"] = grinderDisplay;
-    if (!metadata.grinderSetting.isEmpty())
-        grinder["setting"] = metadata.grinderSetting;
+    {
+        const QString gs = grinderSettingWithRpm(metadata.grinderSetting, metadata.rpm);
+        if (!gs.isEmpty()) grinder["setting"] = gs;
+    }
     meta["grinder"] = grinder;
 
     // Weights
@@ -945,8 +959,10 @@ QByteArray VisualizerUploader::buildShotJson(ShotDataModel* shotData,
         settings["roast_level"] = metadata.roastLevel;
     if (!grinderDisplay.isEmpty())
         settings["grinder_model"] = grinderDisplay;
-    if (!metadata.grinderSetting.isEmpty())
-        settings["grinder_setting"] = metadata.grinderSetting;
+    {
+        const QString gs = grinderSettingWithRpm(metadata.grinderSetting, metadata.rpm);
+        if (!gs.isEmpty()) settings["grinder_setting"] = gs;
+    }
     if (beanWeight > 0)
         settings["grinder_dose_weight"] = beanWeight;
     if (drinkWeight > 0)
@@ -1485,7 +1501,8 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const ShotProjection& shotDa
         : (shotData.grinderModel.isEmpty() ? shotData.grinderBrand
                                            : shotData.grinderBrand + " " + shotData.grinderModel);
     if (!grinderDisplay2.isEmpty()) grinder["model"] = grinderDisplay2;
-    if (!shotData.grinderSetting.isEmpty()) grinder["setting"] = shotData.grinderSetting;
+    { const QString gs = grinderSettingWithRpm(shotData.grinderSetting, shotData.rpm);
+      if (!gs.isEmpty()) grinder["setting"] = gs; }
     meta["grinder"] = grinder;
 
     // Weights: use stored final weight from history; fall back to flow-integrated volume if missing
@@ -1507,7 +1524,8 @@ QByteArray VisualizerUploader::buildHistoryShotJson(const ShotProjection& shotDa
     if (!shotData.roastDate.isEmpty()) settings["roast_date"] = RoastDate::toIso(shotData.roastDate);
     if (!shotData.roastLevel.isEmpty()) settings["roast_level"] = shotData.roastLevel;
     if (!grinderDisplay2.isEmpty()) settings["grinder_model"] = grinderDisplay2;
-    if (!shotData.grinderSetting.isEmpty()) settings["grinder_setting"] = shotData.grinderSetting;
+    { const QString gs = grinderSettingWithRpm(shotData.grinderSetting, shotData.rpm);
+      if (!gs.isEmpty()) settings["grinder_setting"] = gs; }
     if (shotData.doseWeightG > 0) settings["grinder_dose_weight"] = shotData.doseWeightG;
     if (finalWeight > 0) settings["drink_weight"] = finalWeight;
     if (shotData.drinkTdsPct > 0) settings["drink_tds"] = shotData.drinkTdsPct;

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -59,7 +59,7 @@ namespace {
 // Visualizer has no rpm field, so the grinder rpm dial-in is appended to the
 // grind setting using the community convention ("2.4 1400rpm") that the grinder
 // parser already tolerates (add-equipment-packages).
-QString grinderSettingWithRpm(const QString& setting, int rpm) {
+QString grinderSettingWithRpm(const QString& setting, qint64 rpm) {
     if (rpm <= 0)
         return setting;
     return setting.isEmpty() ? QStringLiteral("%1rpm").arg(rpm)

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -24,7 +24,7 @@ struct ShotMetadata {
     QString grinderBurrs;
     QString grinderSetting;
     qint64 equipmentId = 0; // Equipment package (add-equipment-packages); 0 = none
-    int rpm = 0;            // Grinder rpm dial-in; 0 = unset
+    qint64 rpm = 0;         // Grinder rpm dial-in; 0 = unset
     double beanWeight = 0;  // Dose weight in grams
     double drinkWeight = 0; // Output weight in grams
     double drinkTds = 0;

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -23,6 +23,8 @@ struct ShotMetadata {
     QString grinderModel;
     QString grinderBurrs;
     QString grinderSetting;
+    qint64 equipmentId = 0; // Equipment package (add-equipment-packages); 0 = none
+    int rpm = 0;            // Grinder rpm dial-in; 0 = unset
     double beanWeight = 0;  // Dose weight in grams
     double drinkWeight = 0; // Output weight in grams
     double drinkTds = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(CORE_SOURCES
     ${CMAKE_SOURCE_DIR}/src/core/settings_brew.cpp
     ${CMAKE_SOURCE_DIR}/src/core/settings_dye.cpp
     ${CMAKE_SOURCE_DIR}/src/history/coffeebagstorage.cpp  # SettingsDye write-through dependency
+    ${CMAKE_SOURCE_DIR}/src/history/equipmentstorage.cpp
     ${CMAKE_SOURCE_DIR}/src/core/settings_network.cpp
     ${CMAKE_SOURCE_DIR}/src/core/settings_app.cpp
     ${CMAKE_SOURCE_DIR}/src/core/settings_calibration.cpp
@@ -296,6 +297,7 @@ add_decenza_test(tst_aimanager
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
     ${CMAKE_SOURCE_DIR}/src/history/coffeebagstorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/equipmentstorage.cpp
     ${PROFILE_SOURCES}
     ${CORE_SOURCES}
     ${CODEC_SOURCES}
@@ -428,6 +430,7 @@ set(HISTORY_SOURCES
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
     ${CMAKE_SOURCE_DIR}/src/history/coffeebagstorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/equipmentstorage.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
     ${CMAKE_SOURCE_DIR}/src/ai/conductance.cpp
@@ -716,6 +719,7 @@ add_decenza_test(tst_mcptools_write
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
     ${CMAKE_SOURCE_DIR}/src/history/coffeebagstorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/equipmentstorage.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
     ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
@@ -746,6 +750,7 @@ add_decenza_test(tst_mcpserver_session
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
     ${CMAKE_SOURCE_DIR}/src/history/coffeebagstorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/equipmentstorage.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
     ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
@@ -777,6 +782,7 @@ add_decenza_test(tst_mcpserver_protocol
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
     ${CMAKE_SOURCE_DIR}/src/history/coffeebagstorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/equipmentstorage.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
     ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -477,6 +477,17 @@ add_decenza_test(tst_dbmigration
 target_link_libraries(tst_dbmigration PRIVATE Qt6::Graphs Qt6::Quick)
 target_include_directories(tst_dbmigration PRIVATE ${CMAKE_BINARY_DIR})
 
+# --- tst_equipment: equipment package storage statics — grind/rpm split,
+# rpmCapable derivation, package CRUD + identity dedup, migration-22 data step
+# (add-equipment-packages). Static helpers only, so a minimal source set. ---
+add_decenza_test(tst_equipment
+    tst_equipment.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/equipmentstorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/coffeebagstorage.cpp
+    ${CMAKE_BINARY_DIR}/version_code.cpp
+)
+target_include_directories(tst_equipment PRIVATE ${CMAKE_BINARY_DIR})
+
 # --- tst_dialing_blocks: DB-backed coverage for the four shared
 # block builders that drive both `dialing_get_context` (MCP) and the
 # in-app advisor's user-prompt enrichment (issue #1044). Stands up a

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -481,6 +481,7 @@ private slots:
         shot.doseWeightG = 20.0;
         shot.roastLevel = QStringLiteral("Dark");
         shot.roastDate = QStringLiteral("2026-03-30");
+        shot.rpm = 1400;  // variable-RPM grind axis must reach currentBean
 
         // In-app advisor surface: through ShotSummarizer::buildUserPromptObject
         // off summarizeFromHistory(shot).
@@ -502,11 +503,16 @@ private slots:
         in.grinderModel = shot.grinderModel;
         in.grinderBurrs = shot.grinderBurrs;
         in.grinderSetting = shot.grinderSetting;
+        in.rpm = static_cast<int>(shot.rpm);
         in.doseWeightG = shot.doseWeightG;
         const QJsonObject mcpCurrentBean = DialingBlocks::buildCurrentBeanBlock(in);
 
         // The contract: byte-equivalent JSON for the same shot.
         QCOMPARE(inAppCurrentBean, mcpCurrentBean);
+
+        // The grinder RPM reaches currentBean on both surfaces (a second grind
+        // axis the advisor needs for variable-RPM grinders).
+        QCOMPARE(inAppCurrentBean.value(QStringLiteral("rpm")).toInt(), 1400);
 
         // Spot-check the shot values won the source-of-truth contest
         // against the live DYE values, on both surfaces.

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -247,6 +247,41 @@ private slots:
         });
     }
 
+    // loadBagStatic materializes the bag's grinder identity from its equipment
+    // package (the bag no longer stores brand/model/burrs — migration 23), so
+    // MCP bag_list etc. still surface the grinder. Burrs comes from the item's
+    // attrs JSON; a bag with no equipment_id leaves the fields empty.
+    void loadBagResolvesGrinderFromPackage() {
+        const QString path = freshDb();
+        withRawDb(path, "bag_grinder", [&](QSqlDatabase& db) {
+            EquipmentPackage pkg;
+            const qint64 pid = EquipmentStorage::createPackageWithGrinderStatic(
+                db, pkg, "Niche", "Zero", "63mm conical");
+            QVERIFY(pid > 0);
+
+            CoffeeBag linked;
+            linked.roasterName = "Onyx";
+            linked.coffeeName = "Geometry";
+            linked.equipmentId = pid;
+            linked.grinderSetting = "12";
+            const qint64 linkedId = CoffeeBagStorage::insertBagStatic(db, linked);
+            QVERIFY(linkedId > 0);
+
+            const CoffeeBag loaded = CoffeeBagStorage::loadBagStatic(db, linkedId);
+            QCOMPARE(loaded.grinderBrand, QString("Niche"));
+            QCOMPARE(loaded.grinderModel, QString("Zero"));
+            QCOMPARE(loaded.grinderBurrs, QString("63mm conical"));  // from attrs JSON
+            QCOMPARE(loaded.grinderSetting, QString("12"));          // real bag column
+
+            // A bag with no equipment_id resolves to empty grinder identity.
+            CoffeeBag unlinked;
+            unlinked.roasterName = "SEY";
+            const qint64 unlinkedId = CoffeeBagStorage::insertBagStatic(db, unlinked);
+            const CoffeeBag u = CoffeeBagStorage::loadBagStatic(db, unlinkedId);
+            QVERIFY(u.grinderBrand.isEmpty() && u.grinderModel.isEmpty() && u.grinderBurrs.isEmpty());
+        });
+    }
+
     // ==========================================
     // Legacy preset conversion
     // ==========================================

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -13,6 +13,7 @@
 
 #include "history/shothistorystorage.h"
 #include "history/coffeebagstorage.h"
+#include "history/equipmentstorage.h"
 #include "history/unifiedbeansearchmodel.h"
 #include "core/settings_dye.h"
 #include "core/settings_visualizer.h"
@@ -937,6 +938,80 @@ private slots:
         // destruct, so no worker is still holding a connection at teardown (which
         // would qWarning on stderr — the suite requires silence).
         for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(25); }
+        { QSettings s; s.remove(QStringLiteral("dye")); s.sync(); }
+    }
+
+    // SettingsDye is the equipment switch + dual-write-through orchestrator
+    // (add-equipment-packages). Drives the real async chain via the public API:
+    // switchToEquipment applies the package's identity + last dial and points the
+    // active bag at it; editing the dial fans out to BOTH the bag and the active
+    // package's last-dial memory.
+    void settingsDyeEquipmentSwitchAndDualWrite() {
+        { QSettings s; s.remove(QStringLiteral("dye")); s.sync(); }
+
+        const QString path = freshDb();
+        withRawDb(path, "eqdye_tables", [&](QSqlDatabase& db) {
+            CoffeeBagStorage::ensureTableStatic(db);
+            EquipmentStorage::ensureTablesStatic(db);
+        });
+        qint64 bagId = -1, pkgId = -1;
+        withRawDb(path, "eqdye_seed", [&](QSqlDatabase& db) {
+            CoffeeBag b; b.roasterName = "R"; b.coffeeName = "C";
+            bagId = CoffeeBagStorage::insertBagStatic(db, b);
+            EquipmentPackage p; p.lastGrindSetting = "3.0"; p.lastRpm = 1200;
+            pkgId = EquipmentStorage::createPackageWithGrinderStatic(db, p, "Turin", "DF83V", "83mm flat steel");
+        });
+        QVERIFY(bagId > 0 && pkgId > 0);
+
+        CoffeeBagStorage bagStorage; bagStorage.initialize(path);
+        EquipmentStorage eqStorage; eqStorage.initialize(path);
+        SettingsVisualizer viz; SettingsDye dye(&viz);
+        dye.setBagStorage(&bagStorage);
+        dye.setEquipmentStorage(&eqStorage);
+
+        // Select the bag and let its async apply settle (applyActiveBag sets
+        // activeEquipmentId from the bag's equipment_id, which would otherwise
+        // race the switch below).
+        dye.setActiveBagId(static_cast<int>(bagId));
+        for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(10); }
+
+        // Switch equipment: identity + last dial applied synchronously from the map.
+        QVariantMap pkg;
+        pkg["id"] = static_cast<qlonglong>(pkgId);
+        pkg["grinderBrand"] = "Turin"; pkg["grinderModel"] = "DF83V"; pkg["grinderBurrs"] = "83mm flat steel";
+        pkg["lastGrindSetting"] = "3.0"; pkg["lastRpm"] = static_cast<qlonglong>(1200);
+        dye.switchToEquipment(pkg);
+        QCOMPARE(dye.activeEquipmentId(), static_cast<int>(pkgId));
+        QCOMPARE(dye.dyeGrinderModel(), QString("DF83V"));
+        QCOMPARE(dye.dyeGrinderSetting(), QString("3.0"));
+        QCOMPARE(dye.dyeGrinderRpm(), 1200);
+
+        auto bagEq = [&]() { qint64 v = -1; withRawDb(path, "eqdye_bageq",
+            [&](QSqlDatabase& db) { v = CoffeeBagStorage::loadBagStatic(db, bagId).equipmentId; }); return v; };
+        QTRY_COMPARE(bagEq(), pkgId);   // bag adopted the package (async write-through)
+
+        // Dual write-through: editing the dial updates BOTH the bag and the
+        // active package's last dial. Edit one field at a time and let each land
+        // (as the user would) — firing both at once would race two concurrent
+        // background writes to the same DB.
+        auto bagGrind = [&]() { QString v; withRawDb(path, "eqdye_bg",
+            [&](QSqlDatabase& db) { v = CoffeeBagStorage::loadBagStatic(db, bagId).grinderSetting; }); return v; };
+        auto pkgGrind = [&]() { QString v; withRawDb(path, "eqdye_pg",
+            [&](QSqlDatabase& db) { v = EquipmentStorage::loadPackageStatic(db, pkgId).lastGrindSetting; }); return v; };
+        auto bagRpm = [&]() { qint64 v = -1; withRawDb(path, "eqdye_br",
+            [&](QSqlDatabase& db) { v = CoffeeBagStorage::loadBagStatic(db, bagId).rpm; }); return v; };
+        auto pkgRpm = [&]() { qint64 v = -1; withRawDb(path, "eqdye_pr",
+            [&](QSqlDatabase& db) { v = EquipmentStorage::loadPackageStatic(db, pkgId).lastRpm; }); return v; };
+
+        dye.setDyeGrinderSetting("2.5");
+        QTRY_COMPARE(bagGrind(), QString("2.5"));
+        QTRY_COMPARE(pkgGrind(), QString("2.5"));
+
+        dye.setDyeGrinderRpm(1350);
+        QTRY_COMPARE(bagRpm(), static_cast<qint64>(1350));
+        QTRY_COMPARE(pkgRpm(), static_cast<qint64>(1350));
+
+        for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(10); }
         { QSettings s; s.remove(QStringLiteral("dye")); s.sync(); }
     }
 

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -174,6 +174,13 @@ private slots:
             QVERIFY(q.exec("ALTER TABLE shots DROP COLUMN frozen_date"));
             QVERIFY(q.exec("ALTER TABLE shots DROP COLUMN defrost_date"));
             QVERIFY(q.exec("DROP TABLE coffee_bags"));
+            // Restore the grinder identity columns a real v18 DB had (migration 8
+            // added them; the first full init above dropped them at migration 23).
+            // Without these, the re-run of migration 22 in the chain below can't
+            // read shots.grinder_* and logs a spurious "incomplete" failure.
+            QVERIFY(q.exec("ALTER TABLE shots ADD COLUMN grinder_brand TEXT"));
+            QVERIFY(q.exec("ALTER TABLE shots ADD COLUMN grinder_model TEXT"));
+            QVERIFY(q.exec("ALTER TABLE shots ADD COLUMN grinder_burrs TEXT"));
             QVERIFY(q.exec("DELETE FROM schema_version"));
             QVERIFY(q.exec("INSERT INTO schema_version (version) VALUES (18)"));
             // One linked, one unlinked shot.

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -1030,7 +1030,11 @@ private slots:
 
         auto bagEq = [&]() { qint64 v = -1; withRawDb(path, "eqdye_bageq",
             [&](QSqlDatabase& db) { v = CoffeeBagStorage::loadBagStatic(db, bagId).equipmentId; }); return v; };
-        QTRY_COMPARE(bagEq(), pkgId);   // bag adopted the package (async write-through)
+        // Generous timeout: these are cross-thread background DB write-throughs
+        // (QThread::create + withTempDb) whose latency spikes under full-suite
+        // load — the default 5s QTRY window occasionally lapses on a cold/
+        // contended run. 15s is ample headroom; a real logic failure still fails.
+        QTRY_COMPARE_WITH_TIMEOUT(bagEq(), pkgId, 15000);   // bag adopted the package
 
         // Dual write-through: editing the dial updates BOTH the bag and the
         // active package's last dial. Edit one field at a time and let each land
@@ -1046,12 +1050,12 @@ private slots:
             [&](QSqlDatabase& db) { v = EquipmentStorage::loadPackageStatic(db, pkgId).lastRpm; }); return v; };
 
         dye.setDyeGrinderSetting("2.5");
-        QTRY_COMPARE(bagGrind(), QString("2.5"));
-        QTRY_COMPARE(pkgGrind(), QString("2.5"));
+        QTRY_COMPARE_WITH_TIMEOUT(bagGrind(), QString("2.5"), 15000);
+        QTRY_COMPARE_WITH_TIMEOUT(pkgGrind(), QString("2.5"), 15000);
 
         dye.setDyeGrinderRpm(1350);
-        QTRY_COMPARE(bagRpm(), static_cast<qint64>(1350));
-        QTRY_COMPARE(pkgRpm(), static_cast<qint64>(1350));
+        QTRY_COMPARE_WITH_TIMEOUT(bagRpm(), static_cast<qint64>(1350), 15000);
+        QTRY_COMPARE_WITH_TIMEOUT(pkgRpm(), static_cast<qint64>(1350), 15000);
 
         for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(10); }
         { QSettings s; s.remove(QStringLiteral("dye")); s.sync(); }

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -189,7 +189,7 @@ private slots:
             QVERIFY(hasTable(db, "shot_samples"));
             QVERIFY(hasTable(db, "shot_phases"));
             QVERIFY(hasTable(db, "schema_version"));
-            QCOMPARE(getSchemaVersion(db), 21);
+            QCOMPARE(getSchemaVersion(db), 22);
         });
     }
 
@@ -255,7 +255,7 @@ private slots:
         initAndClose(path, storage);
 
         withRawDb(path, "v1_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 21);
+            QCOMPARE(getSchemaVersion(db), 22);
             QVERIFY(hasColumn(db, "shots", "temperature_override"));
             QVERIFY(hasColumn(db, "shots", "yield_override"));
             QVERIFY(hasColumn(db, "shots", "beverage_type"));
@@ -371,7 +371,7 @@ private slots:
         withRawDb(path, "v9_verify", [](QSqlDatabase& db) {
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasIndex(db, "idx_shots_profile_kb_id"));
-            QCOMPARE(getSchemaVersion(db), 21);
+            QCOMPARE(getSchemaVersion(db), 22);
         });
     }
 
@@ -385,7 +385,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "idempotent", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 21);
+            QCOMPARE(getSchemaVersion(db), 22);
         });
     }
 
@@ -405,7 +405,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "empty_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 21);
+            QCOMPARE(getSchemaVersion(db), 22);
         });
     }
 
@@ -428,7 +428,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "null_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 21);
+            QCOMPARE(getSchemaVersion(db), 22);
             QSqlQuery q(db);
             q.exec("SELECT grinder_brand FROM shots WHERE uuid = 'test-null'");
             QVERIFY(q.next());
@@ -605,7 +605,7 @@ private slots:
                 }
             }
         });
-        QCOMPARE(versionFound, 21);
+        QCOMPARE(versionFound, 22);
         QVERIFY2(!hasEnjoymentSource,
                  "enjoyment_source column must be absent after migration 16");
     }
@@ -707,7 +707,7 @@ private slots:
             }
         });
 
-        QCOMPARE(versionFound, 21);
+        QCOMPARE(versionFound, 22);
         QVERIFY2(columnGone, "enjoyment_source column must be dropped");
         QCOMPARE(enjoy1, 50);
         QCOMPARE(enjoy2, 50);
@@ -1046,7 +1046,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v21_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 21);
+            QCOMPARE(getSchemaVersion(db), 22);
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
             QVERIFY(!hasColumn(db, "coffee_bags", "yield_target_g"));
             QSqlQuery q(db);
@@ -1122,7 +1122,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v20_after_retry", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 21);
+            QCOMPARE(getSchemaVersion(db), 22);
             // The retry ran the WHOLE deferred chain, not just migration 20:
             // migration 21's rename landed too (post-condition column present).
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
@@ -1167,7 +1167,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v21_after_retry", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 21);
+            QCOMPARE(getSchemaVersion(db), 22);
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
             QVERIFY(!hasColumn(db, "coffee_bags", "yield_target_g"));
             QSqlQuery q(db);

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -359,20 +359,25 @@ private slots:
     // Migration 23: grinder identity columns are dropped from shots
     // ==========================================
     // Migration 8 added grinder_brand/model/burrs; migration 23 (add-equipment-
-    // packages) drops them — grinder identity resolves through equipment_id to
-    // the package's grinder item. Only the per-shot grind setting survives.
+    // packages) drops them from BOTH shots and coffee_bags — grinder identity
+    // resolves through equipment_id to the package's grinder item. Only the
+    // per-shot/per-bag grind setting survives.
     void grinderIdentityColumnsDropped() {
         QString path = freshDbPath();
         ShotHistoryStorage storage;
         initAndClose(path, storage);
 
         withRawDb(path, "grinder_verify", [](QSqlDatabase& db) {
-            QVERIFY(!hasColumn(db, "shots", "grinder_brand"));
-            QVERIFY(!hasColumn(db, "shots", "grinder_burrs"));
-            QVERIFY(!hasColumn(db, "shots", "grinder_model"));
-            // The per-shot dial-in survives; identity is via equipment_id.
-            QVERIFY(hasColumn(db, "shots", "grinder_setting"));
-            QVERIFY(hasColumn(db, "shots", "equipment_id"));
+            for (const char* table : {"shots", "coffee_bags"}) {
+                QVERIFY2(!hasColumn(db, table, "grinder_brand"), table);
+                QVERIFY2(!hasColumn(db, table, "grinder_model"), table);
+                QVERIFY2(!hasColumn(db, table, "grinder_burrs"), table);
+                // The dial-in + equipment pointer survive on both tables.
+                QVERIFY2(hasColumn(db, table, "grinder_setting"), table);
+                QVERIFY2(hasColumn(db, table, "equipment_id"), table);
+            }
+            // The grinder index is gone (it was on the dropped shots columns).
+            QVERIFY(!hasIndex(db, "idx_shots_grinder"));
         });
     }
 
@@ -1294,6 +1299,84 @@ private slots:
             const ShotRecord r2 = ShotHistoryStorage::loadShotRecordStatic(db, without);
             QCOMPARE(r2.equipmentId, (qint64)0);   // NULL equipment_id -> 0
             QCOMPARE(r2.rpm, (qint64)0);           // NULL rpm -> 0
+        });
+    }
+
+    // loadShotRecordStatic resolves grinder brand/model/burrs through the
+    // equipment_id JOIN (the per-shot columns are gone — migration 23) and
+    // derives equipmentState from the package's in_inventory + superseded_by
+    // lineage (add-equipment-packages 4.1 / 4b.7). Also pins that grinder
+    // identity is NOT in shots_fts anymore (search resolves via the pointer).
+    void v23_grinderResolvesViaJoinAndLineage() {
+        const QString path = freshDbPath();
+        { ShotHistoryStorage s; initAndClose(path, s); }
+
+        qint64 curShot = -1, olderShot = -1, retiredShot = -1, noEqShot = -1;
+        withRawDb(path, "v23_join_seed", [&](QSqlDatabase& db) {
+            QSqlQuery q(db);
+            // A newer package, an in-inventory current one, an "older" (superseded
+            // by the newer) and a "retired" (out of inventory, no successor).
+            QVERIFY(q.exec("INSERT INTO equipment_packages (name, in_inventory) VALUES ('New', 1)"));
+            const qint64 newer = q.lastInsertId().toLongLong();
+            QVERIFY(q.exec("INSERT INTO equipment_packages (name, in_inventory) VALUES ('Cur', 1)"));
+            const qint64 cur = q.lastInsertId().toLongLong();
+            q.prepare("INSERT INTO equipment_packages (name, in_inventory, superseded_by) VALUES ('Old', 0, ?)");
+            q.addBindValue(newer); QVERIFY(q.exec());
+            const qint64 older = q.lastInsertId().toLongLong();
+            QVERIFY(q.exec("INSERT INTO equipment_packages (name, in_inventory) VALUES ('Ret', 0)"));
+            const qint64 retired = q.lastInsertId().toLongLong();
+
+            auto addGrinder = [&](qint64 pkg, const QString& brand, const QString& model, const QString& burrs) {
+                QSqlQuery gi(db);
+                gi.prepare("INSERT INTO equipment_items (package_id, kind, brand, model, attrs) "
+                           "VALUES (?, 'grinder', ?, ?, ?)");
+                gi.addBindValue(pkg); gi.addBindValue(brand); gi.addBindValue(model);
+                gi.addBindValue(QString(R"({"burrs":"%1","rpmCapable":true})").arg(burrs));
+                QVERIFY(gi.exec());
+            };
+            addGrinder(cur, "Niche", "Zero", "63mm conical");
+            addGrinder(older, "Turin", "DF83V", "83mm flat steel");
+            addGrinder(retired, "Mazzer", "Major", "83mm");
+
+            auto addShot = [&](const QString& uuid, qint64 pkg) -> qint64 {
+                QSqlQuery s(db);
+                s.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, "
+                          "equipment_id, grinder_setting) VALUES (?, 1000, 'P', 30, ?, '2.4')");
+                s.addBindValue(uuid);
+                s.addBindValue(pkg > 0 ? QVariant(pkg) : QVariant());
+                return s.exec() ? s.lastInsertId().toLongLong() : -1;
+            };
+            curShot = addShot("cur-1", cur);
+            olderShot = addShot("old-1", older);
+            retiredShot = addShot("ret-1", retired);
+            noEqShot = addShot("noeq-1", 0);
+            QVERIFY(curShot > 0 && olderShot > 0 && retiredShot > 0 && noEqShot > 0);
+        });
+
+        withRawDb(path, "v23_join_load", [&](QSqlDatabase& db) {
+            const ShotRecord cur = ShotHistoryStorage::loadShotRecordStatic(db, curShot);
+            QCOMPARE(cur.grinderBrand, QString("Niche"));
+            QCOMPARE(cur.grinderModel, QString("Zero"));
+            QCOMPARE(cur.grinderBurrs, QString("63mm conical"));  // json_extract path
+            QCOMPARE(cur.equipmentState, QString(""));            // in inventory -> current
+
+            const ShotRecord older = ShotHistoryStorage::loadShotRecordStatic(db, olderShot);
+            QCOMPARE(older.grinderModel, QString("DF83V"));
+            QCOMPARE(older.equipmentState, QString("older"));     // superseded
+
+            const ShotRecord ret = ShotHistoryStorage::loadShotRecordStatic(db, retiredShot);
+            QCOMPARE(ret.grinderModel, QString("Major"));
+            QCOMPARE(ret.equipmentState, QString("retired"));     // gone, no successor
+
+            const ShotRecord noeq = ShotHistoryStorage::loadShotRecordStatic(db, noEqShot);
+            QCOMPARE(noeq.grinderBrand, QString(""));             // NULL JOIN -> empty
+            QCOMPARE(noeq.equipmentState, QString(""));           // no package
+
+            // Grinder identity is NOT FTS-indexed anymore: a search for a grinder
+            // brand finds nothing through shots_fts (it resolves via equipment_id).
+            QSqlQuery fts(db);
+            QVERIFY(fts.exec("SELECT rowid FROM shots_fts WHERE shots_fts MATCH 'Niche'"));
+            QVERIFY2(!fts.next(), "grinder brand must not be findable via FTS after migration 23");
         });
     }
 };

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -64,6 +64,20 @@ static int getSchemaVersion(QSqlDatabase& db) {
     return q.next() ? q.value(0).toInt() : -1;
 }
 
+// After a full init, migration 23 has dropped grinder_brand/model/burrs from
+// shots + coffee_bags. Tests that rewind schema_version below 22 to re-exercise
+// an earlier migration then re-run the WHOLE chain — including migration 22,
+// which reads those columns to seed equipment packages. Production never rewinds
+// (the chain is monotonic, so the columns are always present when migration 22
+// runs), so restore them here to make the simulated "old version" DB schema-
+// faithful. ADD COLUMN is a no-op-safe failure when the column already exists.
+static void restoreLegacyGrinderColumns(QSqlDatabase& db) {
+    QSqlQuery q(db);
+    for (const char* table : {"shots", "coffee_bags"})
+        for (const char* col : {"grinder_brand", "grinder_model", "grinder_burrs"})
+            q.exec(QString("ALTER TABLE %1 ADD COLUMN %2 TEXT").arg(QLatin1String(table), QLatin1String(col)));
+}
+
 static void createV1Schema(QSqlDatabase& db) {
     QSqlQuery q(db);
     q.exec(R"(
@@ -189,7 +203,7 @@ private slots:
             QVERIFY(hasTable(db, "shot_samples"));
             QVERIFY(hasTable(db, "shot_phases"));
             QVERIFY(hasTable(db, "schema_version"));
-            QCOMPARE(getSchemaVersion(db), 22);
+            QCOMPARE(getSchemaVersion(db), 23);
         });
     }
 
@@ -204,8 +218,15 @@ private slots:
             QVERIFY(hasColumn(db, "shots", "beverage_type"));
             QVERIFY(hasColumn(db, "shots", "bean_notes"));
             QVERIFY(hasColumn(db, "shots", "profile_notes"));
-            QVERIFY(hasColumn(db, "shots", "grinder_brand"));
-            QVERIFY(hasColumn(db, "shots", "grinder_burrs"));
+            // Grinder identity columns were added by migration 8 and DROPPED by
+            // migration 23 (add-equipment-packages) — identity now resolves via
+            // equipment_id. The grind setting + equipment_id/rpm survive.
+            QVERIFY(!hasColumn(db, "shots", "grinder_brand"));
+            QVERIFY(!hasColumn(db, "shots", "grinder_model"));
+            QVERIFY(!hasColumn(db, "shots", "grinder_burrs"));
+            QVERIFY(hasColumn(db, "shots", "grinder_setting"));
+            QVERIFY(hasColumn(db, "shots", "equipment_id"));
+            QVERIFY(hasColumn(db, "shots", "rpm"));
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasColumn(db, "shots", "channeling_detected"));
             // temperature_unstable was added in migration 10 and dropped in
@@ -231,7 +252,9 @@ private slots:
             QVERIFY(hasIndex(db, "idx_shots_timestamp"));
             QVERIFY(hasIndex(db, "idx_shots_profile"));
             QVERIFY(hasIndex(db, "idx_shots_bean"));
-            QVERIFY(hasIndex(db, "idx_shots_grinder"));
+            // idx_shots_grinder was on grinder_brand/model, dropped with those
+            // columns in migration 23 (add-equipment-packages).
+            QVERIFY(!hasIndex(db, "idx_shots_grinder"));
             QVERIFY(hasIndex(db, "idx_shots_enjoyment"));
             QVERIFY(hasIndex(db, "idx_shot_phases_shot"));
             QVERIFY(hasIndex(db, "idx_shots_profile_kb_id"));
@@ -255,12 +278,15 @@ private slots:
         initAndClose(path, storage);
 
         withRawDb(path, "v1_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 22);
+            QCOMPARE(getSchemaVersion(db), 23);
             QVERIFY(hasColumn(db, "shots", "temperature_override"));
             QVERIFY(hasColumn(db, "shots", "yield_override"));
             QVERIFY(hasColumn(db, "shots", "beverage_type"));
-            QVERIFY(hasColumn(db, "shots", "grinder_brand"));
-            QVERIFY(hasColumn(db, "shots", "grinder_burrs"));
+            // Grinder identity columns are dropped by migration 23; equipment_id
+            // is the identity pointer now (add-equipment-packages).
+            QVERIFY(!hasColumn(db, "shots", "grinder_brand"));
+            QVERIFY(!hasColumn(db, "shots", "grinder_burrs"));
+            QVERIFY(hasColumn(db, "shots", "equipment_id"));
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasColumn(db, "shots", "channeling_detected"));
             // temperature_unstable was added in migration 10 and dropped in
@@ -286,18 +312,17 @@ private slots:
 
         withRawDb(path, "fts_test", [](QSqlDatabase& db) {
             QSqlQuery q(db);
-            // Insert with all FTS-indexed fields
+            // Insert with the FTS-indexed fields. Grinder columns were dropped in
+            // migration 23 and grinder is no longer an FTS column — grinder search
+            // resolves through equipment_id instead (add-equipment-packages 4b.6).
             q.prepare(R"(INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds,
-                espresso_notes, bean_brand, bean_type, grinder_brand, grinder_model, grinder_burrs)
-                VALUES (?, 1000, ?, 30.0, ?, ?, ?, ?, ?, ?))");
+                espresso_notes, bean_brand, bean_type)
+                VALUES (?, 1000, ?, 30.0, ?, ?, ?))");
             q.addBindValue(QUuid::createUuid().toString());
             q.addBindValue("Blooming Espresso");
             q.addBindValue("Excellent fruity notes");
             q.addBindValue("Onyx");
             q.addBindValue("Eclipse");
-            q.addBindValue("Niche");
-            q.addBindValue("Zero");
-            q.addBindValue("63mm conical");
             QVERIFY(q.exec());
 
             // The FTS triggers should auto-populate
@@ -307,9 +332,6 @@ private slots:
 
             QVERIFY(fts.exec("SELECT rowid FROM shots_fts WHERE shots_fts MATCH 'Onyx'"));
             QVERIFY2(fts.next(), "FTS should find by bean_brand");
-
-            QVERIFY(fts.exec("SELECT rowid FROM shots_fts WHERE shots_fts MATCH 'Niche'"));
-            QVERIFY2(fts.next(), "FTS should find by grinder_brand");
         });
     }
 
@@ -334,28 +356,23 @@ private slots:
     }
 
     // ==========================================
-    // v8 grinder columns exist with correct structure
+    // Migration 23: grinder identity columns are dropped from shots
     // ==========================================
-
-    void grinderColumnsExist() {
+    // Migration 8 added grinder_brand/model/burrs; migration 23 (add-equipment-
+    // packages) drops them — grinder identity resolves through equipment_id to
+    // the package's grinder item. Only the per-shot grind setting survives.
+    void grinderIdentityColumnsDropped() {
         QString path = freshDbPath();
         ShotHistoryStorage storage;
         initAndClose(path, storage);
 
         withRawDb(path, "grinder_verify", [](QSqlDatabase& db) {
-            QVERIFY(hasColumn(db, "shots", "grinder_brand"));
-            QVERIFY(hasColumn(db, "shots", "grinder_burrs"));
-            QVERIFY(hasColumn(db, "shots", "grinder_model"));
+            QVERIFY(!hasColumn(db, "shots", "grinder_brand"));
+            QVERIFY(!hasColumn(db, "shots", "grinder_burrs"));
+            QVERIFY(!hasColumn(db, "shots", "grinder_model"));
+            // The per-shot dial-in survives; identity is via equipment_id.
             QVERIFY(hasColumn(db, "shots", "grinder_setting"));
-
-            // Insert and verify all grinder fields are queryable
-            QSqlQuery q(db);
-            q.exec("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, grinder_brand, grinder_model, grinder_burrs) VALUES ('grinder-test', 1000, 'Test', 30.0, 'Niche', 'Zero', '63mm conical')");
-            q.exec("SELECT grinder_brand, grinder_model, grinder_burrs FROM shots WHERE uuid = 'grinder-test'");
-            QVERIFY(q.next());
-            QCOMPARE(q.value(0).toString(), QString("Niche"));
-            QCOMPARE(q.value(1).toString(), QString("Zero"));
-            QCOMPARE(q.value(2).toString(), QString("63mm conical"));
+            QVERIFY(hasColumn(db, "shots", "equipment_id"));
         });
     }
 
@@ -371,7 +388,7 @@ private slots:
         withRawDb(path, "v9_verify", [](QSqlDatabase& db) {
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasIndex(db, "idx_shots_profile_kb_id"));
-            QCOMPARE(getSchemaVersion(db), 22);
+            QCOMPARE(getSchemaVersion(db), 23);
         });
     }
 
@@ -385,7 +402,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "idempotent", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 22);
+            QCOMPARE(getSchemaVersion(db), 23);
         });
     }
 
@@ -405,7 +422,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "empty_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 22);
+            QCOMPARE(getSchemaVersion(db), 23);
         });
     }
 
@@ -428,9 +445,11 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "null_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 22);
+            QCOMPARE(getSchemaVersion(db), 23);
             QSqlQuery q(db);
-            q.exec("SELECT grinder_brand FROM shots WHERE uuid = 'test-null'");
+            // grinder_brand was dropped in migration 23; grinder_setting (the
+            // surviving per-shot dial-in) exercises the same NULL-tolerance path.
+            q.exec("SELECT grinder_setting FROM shots WHERE uuid = 'test-null'");
             QVERIFY(q.next());
             QVERIFY(q.value(0).isNull() || q.value(0).toString().isEmpty());
         });
@@ -507,7 +526,9 @@ private slots:
             QCOMPARE(q.value(0).toString(), QString("Blooming"));
             QCOMPARE(q.value(1).toDouble(), 36.2);
             QCOMPARE(q.value(2).toString(), QString("Onyx"));
-            QVERIFY(hasColumn(db, "shots", "grinder_brand"));
+            // grinder_brand dropped by migration 23; equipment_id is the pointer.
+            QVERIFY(!hasColumn(db, "shots", "grinder_brand"));
+            QVERIFY(hasColumn(db, "shots", "equipment_id"));
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
         });
     }
@@ -605,7 +626,7 @@ private slots:
                 }
             }
         });
-        QCOMPARE(versionFound, 22);
+        QCOMPARE(versionFound, 23);
         QVERIFY2(!hasEnjoymentSource,
                  "enjoyment_source column must be absent after migration 16");
     }
@@ -658,6 +679,7 @@ private slots:
             q.addBindValue("u4"); q.addBindValue(now - 14400);
             QVERIFY(q.exec());
 
+            restoreLegacyGrinderColumns(db);  // migration 22 re-runs in the chain
             QVERIFY(q.exec("UPDATE schema_version SET version = 15"));
         });
 
@@ -707,7 +729,7 @@ private slots:
             }
         });
 
-        QCOMPARE(versionFound, 22);
+        QCOMPARE(versionFound, 23);
         QVERIFY2(columnGone, "enjoyment_source column must be dropped");
         QCOMPARE(enjoy1, 50);
         QCOMPARE(enjoy2, 50);
@@ -1039,6 +1061,7 @@ private slots:
             QVERIFY(q.exec("ALTER TABLE coffee_bags RENAME COLUMN yield_override_g TO yield_target_g"));
             QVERIFY(q.exec("INSERT INTO coffee_bags (roaster_name, coffee_name, yield_target_g, in_inventory) "
                            "VALUES ('Onyx', 'Geometry', 42.0, 1)"));
+            restoreLegacyGrinderColumns(db);  // migration 22 re-runs in the chain
             q.exec("DELETE FROM schema_version");
             q.exec("INSERT INTO schema_version (version) VALUES (20)");
         });
@@ -1046,7 +1069,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v21_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 22);
+            QCOMPARE(getSchemaVersion(db), 23);
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
             QVERIFY(!hasColumn(db, "coffee_bags", "yield_target_g"));
             QSqlQuery q(db);
@@ -1101,6 +1124,7 @@ private slots:
                            "bean_brand, bean_type) "
                            "VALUES ('orphan-1', 1000, 'P', 30.0, 'Onyx', 'Geometry')"));
             shotId = q.lastInsertId().toLongLong();
+            restoreLegacyGrinderColumns(db);  // migration 22 re-runs in the chain
             q.exec("DELETE FROM schema_version");
             q.exec("INSERT INTO schema_version (version) VALUES (19)");
         });
@@ -1122,7 +1146,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v20_after_retry", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 22);
+            QCOMPARE(getSchemaVersion(db), 23);
             // The retry ran the WHOLE deferred chain, not just migration 20:
             // migration 21's rename landed too (post-condition column present).
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
@@ -1149,6 +1173,7 @@ private slots:
             QVERIFY(q.exec("ALTER TABLE coffee_bags RENAME COLUMN yield_override_g TO yield_target_g"));
             QVERIFY(q.exec("INSERT INTO coffee_bags (roaster_name, coffee_name, yield_target_g, in_inventory) "
                            "VALUES ('Onyx', 'Geometry', 42.0, 1)"));
+            restoreLegacyGrinderColumns(db);  // migration 22 re-runs in the chain
             q.exec("DELETE FROM schema_version");
             q.exec("INSERT INTO schema_version (version) VALUES (20)");
         });
@@ -1167,7 +1192,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v21_after_retry", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 22);
+            QCOMPARE(getSchemaVersion(db), 23);
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
             QVERIFY(!hasColumn(db, "coffee_bags", "yield_target_g"));
             QSqlQuery q(db);
@@ -1234,7 +1259,7 @@ private slots:
         };
 
         { ShotHistoryStorage s; initAndClose(path, s); }
-        withRawDb(path, "v22_ver", [](QSqlDatabase& db) { QCOMPARE(getSchemaVersion(db), 22); });
+        withRawDb(path, "v22_ver", [](QSqlDatabase& db) { QCOMPARE(getSchemaVersion(db), 23); });
         QCOMPARE(packageCount(), 1);             // default package created from current settings
         { ShotHistoryStorage s; initAndClose(path, s); }
         QCOMPARE(packageCount(), 1);             // gate prevented a duplicate on re-init

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -1204,6 +1204,73 @@ private slots:
             QVERIFY(!hasColumn(db, "coffee_bags", "yield_target_g"));
         });
     }
+
+    // ==========================================
+    // Migration 22: equipment packages (add-equipment-packages)
+    // ==========================================
+
+    // The migration-22 data step is NOT idempotent (it creates packages); only
+    // the version gate stops it re-running. Prove that re-initializing does not
+    // duplicate the default package created from the live grinder settings — the
+    // single most dangerous regression in this migration.
+    void v22_reinitDoesNotDuplicatePackages() {
+        const QString path = freshDbPath();
+        QSettings app(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
+        const QVariant pB = app.value("dye/grinderBrand"), pM = app.value("dye/grinderModel"),
+                       pBu = app.value("dye/grinderBurrs"), pS = app.value("dye/grinderSetting");
+        app.setValue("dye/grinderBrand", "Niche");
+        app.setValue("dye/grinderModel", "Zero");
+        app.setValue("dye/grinderBurrs", "63mm conical");
+        app.setValue("dye/grinderSetting", "12");
+
+        auto packageCount = [&]() {
+            int n = -1;
+            withRawDb(path, "v22_count", [&](QSqlDatabase& db) {
+                QSqlQuery q(db);
+                if (q.exec("SELECT COUNT(*) FROM equipment_packages") && q.next())
+                    n = q.value(0).toInt();
+            });
+            return n;
+        };
+
+        { ShotHistoryStorage s; initAndClose(path, s); }
+        withRawDb(path, "v22_ver", [](QSqlDatabase& db) { QCOMPARE(getSchemaVersion(db), 22); });
+        QCOMPARE(packageCount(), 1);             // default package created from current settings
+        { ShotHistoryStorage s; initAndClose(path, s); }
+        QCOMPARE(packageCount(), 1);             // gate prevented a duplicate on re-init
+
+        auto restore = [&](const char* k, const QVariant& v) { if (v.isValid()) app.setValue(k, v); else app.remove(k); };
+        restore("dye/grinderBrand", pB); restore("dye/grinderModel", pM);
+        restore("dye/grinderBurrs", pBu); restore("dye/grinderSetting", pS);
+    }
+
+    // loadShotRecordStatic reads equipment_id/rpm by positional index (39/40);
+    // guard the round-trip and the NULL→0 mapping so a future SELECT-list edit
+    // that shifts those columns fails loudly.
+    void v22_shotEquipmentRpmRoundTrip() {
+        const QString path = freshDbPath();
+        { ShotHistoryStorage s; initAndClose(path, s); }
+        qint64 withEq = -1, without = -1;
+        withRawDb(path, "v22_rt_seed", [&](QSqlDatabase& db) {
+            QSqlQuery q(db);
+            q.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, "
+                      "equipment_id, rpm, grinder_setting) VALUES ('eq-1', 1000, 'P', 30, ?, ?, '2.4')");
+            q.addBindValue((qint64)7); q.addBindValue(1400);
+            QVERIFY(q.exec()); withEq = q.lastInsertId().toLongLong();
+            QSqlQuery q2(db);
+            QVERIFY(q2.exec("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds) "
+                            "VALUES ('eq-2', 2000, 'P', 30)"));
+            without = q2.lastInsertId().toLongLong();
+        });
+        withRawDb(path, "v22_rt_load", [&](QSqlDatabase& db) {
+            const ShotRecord r = ShotHistoryStorage::loadShotRecordStatic(db, withEq);
+            QCOMPARE(r.equipmentId, (qint64)7);
+            QCOMPARE(r.rpm, (qint64)1400);
+            const ShotRecord r2 = ShotHistoryStorage::loadShotRecordStatic(db, without);
+            QCOMPARE(r2.equipmentId, (qint64)0);   // NULL equipment_id -> 0
+            QCOMPARE(r2.rpm, (qint64)0);           // NULL rpm -> 0
+        });
+    }
 };
 
 QTEST_MAIN(tst_DbMigration)

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -1379,6 +1379,41 @@ private slots:
             QVERIFY2(!fts.next(), "grinder brand must not be findable via FTS after migration 23");
         });
     }
+
+    // .shot file import (importShotRecord) must preserve the parsed grinder
+    // identity by find-or-creating an equipment package and linking equipment_id
+    // — the per-shot grinder columns are gone (migration 23), so without the link
+    // imported shots would resolve to a blank grinder.
+    void v23_importShotRecordLinksEquipment() {
+        const QString path = freshDbPath();
+        qint64 shotId = -1;
+        {
+            ShotHistoryStorage s;
+            QTest::ignoreMessage(QtWarningMsg, QRegularExpression("connection.*still in use"));
+            QVERIFY(s.initialize(path));
+            ShotRecord rec;
+            rec.summary.uuid = QStringLiteral("import-grinder-1");
+            rec.summary.timestamp = 1000;
+            rec.summary.profileName = QStringLiteral("P");
+            rec.summary.duration = 30.0;
+            rec.grinderBrand = QStringLiteral("Niche");
+            rec.grinderModel = QStringLiteral("Zero");
+            rec.grinderBurrs = QStringLiteral("63mm conical");
+            rec.grinderSetting = QStringLiteral("12");
+            shotId = s.importShotRecord(rec);
+            QVERIFY(shotId > 0);
+            s.close();
+            for (int i = 0; i < 20; i++) { QCoreApplication::processEvents(); QThread::msleep(25); }
+        }
+        withRawDb(path, "v23_import_verify", [&](QSqlDatabase& db) {
+            const ShotRecord r = ShotHistoryStorage::loadShotRecordStatic(db, shotId);
+            QVERIFY2(r.equipmentId > 0, "imported shot must be linked to an equipment package");
+            QCOMPARE(r.grinderBrand, QString("Niche"));
+            QCOMPARE(r.grinderModel, QString("Zero"));
+            QCOMPARE(r.grinderBurrs, QString("63mm conical"));   // resolved via the package's grinder item
+            QCOMPARE(r.grinderSetting, QString("12"));           // per-shot dial-in stays on the row
+        });
+    }
 };
 
 QTEST_MAIN(tst_DbMigration)

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -1414,6 +1414,60 @@ private slots:
             QCOMPARE(r.grinderSetting, QString("12"));           // per-shot dial-in stays on the row
         });
     }
+
+    // Free-text shot-history search must still find a grinder name even though
+    // grinder identity is no longer in shots_fts (migration 23) — it resolves the
+    // term against equipment_items and matches via the equipment_id pointer
+    // (add-equipment-packages 4b.6). Regression guard for "search 'niche' finds
+    // nothing".
+    void v23_grinderFreeTextSearchResolvesViaPointer() {
+        const QString path = freshDbPath();
+        ShotHistoryStorage s;
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("connection.*still in use"));
+        QVERIFY(s.initialize(path));
+
+        // One shot whose ONLY association with "niche" is its grinder package
+        // (bean/profile/notes deliberately don't contain the term), plus a
+        // control shot on a different grinder.
+        withRawDb(path, "v23_search_seed", [&](QSqlDatabase& db) {
+            QSqlQuery q(db);
+            QVERIFY(q.exec("INSERT INTO equipment_packages (name, in_inventory) VALUES ('Niche Zero', 1)"));
+            const qint64 niche = q.lastInsertId().toLongLong();
+            QVERIFY(q.exec("INSERT INTO equipment_packages (name, in_inventory) VALUES ('Other', 1)"));
+            const qint64 other = q.lastInsertId().toLongLong();
+            auto addGrinder = [&](qint64 pkg, const QString& brand, const QString& model) {
+                QSqlQuery gi(db);
+                gi.prepare("INSERT INTO equipment_items (package_id, kind, brand, model, attrs) "
+                           "VALUES (?, 'grinder', ?, ?, '{\"burrs\":\"63mm\"}')");
+                gi.addBindValue(pkg); gi.addBindValue(brand); gi.addBindValue(model);
+                QVERIFY(gi.exec());
+            };
+            addGrinder(niche, "Niche", "Zero");
+            addGrinder(other, "Mazzer", "Major");
+            QSqlQuery sh(db);
+            sh.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, equipment_id, bean_brand) "
+                       "VALUES ('s-niche', 1000, 'P', 30, ?, 'SomeBean')");
+            sh.addBindValue(niche); QVERIFY(sh.exec());
+            sh.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, equipment_id, bean_brand) "
+                       "VALUES ('s-other', 2000, 'P', 30, ?, 'SomeBean')");
+            sh.addBindValue(other); QVERIFY(sh.exec());
+        });
+
+        QSignalSpy spy(&s, &ShotHistoryStorage::shotsFilteredReady);
+
+        // "niche" matches only the Niche-package shot, via the pointer.
+        s.requestShotsFiltered({{"searchText", "niche"}}, 0, 50);
+        QVERIFY(spy.wait(3000));
+        QCOMPARE(spy.last().at(2).toInt(), 1);   // total == 1
+
+        // A term in no grinder/bean/profile matches nothing.
+        s.requestShotsFiltered({{"searchText", "zzz-no-match"}}, 0, 50);
+        QVERIFY(spy.wait(3000));
+        QCOMPARE(spy.last().at(2).toInt(), 0);
+
+        s.close();
+        for (int i = 0; i < 20; i++) { QCoreApplication::processEvents(); QThread::msleep(25); }
+    }
 };
 
 QTEST_MAIN(tst_DbMigration)

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -30,6 +30,7 @@
 
 #include "history/shothistorystorage.h"
 #include "history/shotprojection.h"
+#include "history/equipmentstorage.h"
 #include "ai/dialing_blocks.h"
 #include "ai/shotsummarizer.h"  // initTestCase pins the missing-resource qWarning
 
@@ -87,20 +88,36 @@ void withRawDb(const QString& path, const QString& connName, Work&& work)
 
 qint64 insertShot(QSqlDatabase& db, const ShotRow& r)
 {
+    // Grinder identity is no longer a per-shot column (migration 23) — it
+    // resolves through equipment_id to a package's grinder item. Mirror the
+    // production save path: find-or-create a package for this row's grinder
+    // identity and link the shot to it. The per-shot grind setting stays on the
+    // row. An empty identity leaves equipment_id NULL.
+    qint64 equipmentId = 0;
+    if (!(r.grinderBrand.isEmpty() && r.grinderModel.isEmpty() && r.grinderBurrs.isEmpty())) {
+        equipmentId = EquipmentStorage::findPackageByGrinderIdentityStatic(
+            db, r.grinderBrand, r.grinderModel, r.grinderBurrs);
+        if (equipmentId <= 0) {
+            EquipmentPackage pkg;
+            equipmentId = EquipmentStorage::createPackageWithGrinderStatic(
+                db, pkg, r.grinderBrand, r.grinderModel, r.grinderBurrs);
+        }
+    }
+
     QSqlQuery q(db);
     q.prepare(QStringLiteral(R"(
         INSERT INTO shots (
             uuid, timestamp, profile_name, beverage_type,
             duration_seconds, final_weight, dose_weight,
             bean_brand, bean_type, roast_level,
-            grinder_brand, grinder_model, grinder_burrs, grinder_setting,
+            grinder_setting, equipment_id,
             enjoyment, espresso_notes, profile_kb_id,
             profile_json, yield_override, temperature_override, stopped_by
         ) VALUES (
             :uuid, :timestamp, :profile_name, :beverage_type,
             :duration, :final_weight, :dose_weight,
             :bean_brand, :bean_type, :roast_level,
-            :grinder_brand, :grinder_model, :grinder_burrs, :grinder_setting,
+            :grinder_setting, :equipment_id,
             :enjoyment, :espresso_notes, :profile_kb_id,
             :profile_json, :yield_override, :temperature_override, :stopped_by
         )
@@ -115,10 +132,8 @@ qint64 insertShot(QSqlDatabase& db, const ShotRow& r)
     q.bindValue(":bean_brand", r.beanBrand);
     q.bindValue(":bean_type", r.beanType);
     q.bindValue(":roast_level", r.roastLevel);
-    q.bindValue(":grinder_brand", r.grinderBrand);
-    q.bindValue(":grinder_model", r.grinderModel);
-    q.bindValue(":grinder_burrs", r.grinderBurrs);
     q.bindValue(":grinder_setting", r.grinderSetting);
+    q.bindValue(":equipment_id", equipmentId > 0 ? QVariant(equipmentId) : QVariant());
     q.bindValue(":enjoyment", r.enjoyment);
     q.bindValue(":espresso_notes", r.espressoNotes);
     q.bindValue(":profile_kb_id", r.profileKbId.isEmpty() ? QVariant() : r.profileKbId);

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -65,6 +65,9 @@ private slots:
         QTest::newRow("plain")         << "24"        << "24"         << (qint64)0;
         QTest::newRow("empty")         << ""          << ""           << (qint64)0;
         QTest::newRow("rpm_only")      << "1400rpm"   << ""           << (qint64)1400;
+        QTest::newRow("rpm_word_no_digits") << "rpm"  << "rpm"        << (qint64)0;
+        QTest::newRow("rpm_not_trailing")   << "1400 rpm extra" << "1400 rpm extra" << (qint64)0;
+        QTest::newRow("trailing_ws")   << "24 1400 rpm " << "24"      << (qint64)1400;
     }
     void splitGrindRpm() {
         QFETCH(QString, input);
@@ -194,6 +197,47 @@ private slots:
             const qint64 merged = EquipmentStorage::supersedeOrEditGrinderStatic(db, S, "Turin", "DF83V", "83mm DLC flat");
             QCOMPARE(merged, fork);  // repointed to the existing matching package
             QCOMPARE(EquipmentStorage::loadPackageStatic(db, S).supersededBy, fork);
+        });
+    }
+
+    // --- merge sub-branches + name derivation ---
+    void mergeAndNameEdges() {
+        const QString path = freshDbPath();
+        withRawDb(path, "eq_edges", [](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            QVERIFY(CoffeeBagStorage::ensureTableStatic(db));
+            createMinimalShots(db);
+            auto addShot = [&](qint64 eq) {
+                QSqlQuery q(db); q.prepare("INSERT INTO shots (equipment_id) VALUES (?)");
+                q.addBindValue(eq); q.exec(); return q.lastInsertId().toLongLong();
+            };
+            auto pkgExists = [&](qint64 id) {
+                QSqlQuery q(db); q.prepare("SELECT COUNT(*) FROM equipment_packages WHERE id=?");
+                q.addBindValue(id); q.exec(); q.next(); return q.value(0).toInt() > 0;
+            };
+
+            EquipmentPackage t;
+            const qint64 target = EquipmentStorage::createPackageWithGrinderStatic(db, t, "Niche", "Zero", "63mm conical");
+
+            // Unused source merged into an existing target → source hard-deleted.
+            EquipmentPackage s;
+            const qint64 src = EquipmentStorage::createPackageWithGrinderStatic(db, s, "Mazzer", "Major", "83mm");
+            QCOMPARE(EquipmentStorage::supersedeOrEditGrinderStatic(db, src, "Niche", "Zero", "63mm conical"), target);
+            QVERIFY(!pkgExists(src));  // unused source physically removed, not just retired
+
+            // Editing into a RETIRED package's identity must fork, not resurrect it.
+            EquipmentPackage u;
+            const qint64 used = EquipmentStorage::createPackageWithGrinderStatic(db, u, "Turin", "DF83V", "83mm flat steel");
+            addShot(used);
+            { QSqlQuery q(db); q.prepare("UPDATE equipment_packages SET in_inventory=0 WHERE id=?");
+              q.addBindValue(target); q.exec(); }
+            const qint64 forked = EquipmentStorage::supersedeOrEditGrinderStatic(db, used, "Niche", "Zero", "63mm conical");
+            QVERIFY(forked > 0 && forked != used && forked != target);  // did not merge into the retired package
+
+            // Name derived from a partial identity (brand only).
+            EquipmentPackage p;
+            const qint64 pid = EquipmentStorage::createPackageWithGrinderStatic(db, p, "Turin", "", "");
+            QCOMPARE(EquipmentStorage::loadPackageStatic(db, pid).name, QString("Turin"));
         });
     }
 

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -130,6 +130,73 @@ private slots:
         });
     }
 
+    // --- copy-on-write immutability + merge on identity edit ---
+    void copyOnWriteAndMerge() {
+        const QString path = freshDbPath();
+        withRawDb(path, "eq_cow", [](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            QVERIFY(CoffeeBagStorage::ensureTableStatic(db));
+            createMinimalShots(db);
+
+            auto bagEq = [&](qint64 id) {
+                QSqlQuery q(db); q.prepare("SELECT equipment_id FROM coffee_bags WHERE id=?");
+                q.addBindValue(id); q.exec(); q.next(); return q.value(0).toLongLong();
+            };
+            auto shotEq = [&](qint64 id) {
+                QSqlQuery q(db); q.prepare("SELECT equipment_id FROM shots WHERE id=?");
+                q.addBindValue(id); q.exec(); q.next(); return q.value(0).toLongLong();
+            };
+            auto addBag = [&](qint64 eq) {
+                QSqlQuery q(db);
+                q.prepare("INSERT INTO coffee_bags (roaster_name, equipment_id, in_inventory) VALUES ('R', ?, 1)");
+                q.addBindValue(eq); q.exec(); return q.lastInsertId().toLongLong();
+            };
+            auto addShot = [&](qint64 eq) {
+                QSqlQuery q(db);
+                q.prepare("INSERT INTO shots (equipment_id) VALUES (?)");
+                q.addBindValue(eq); q.exec(); return q.lastInsertId().toLongLong();
+            };
+
+            // Package P, used by a shot and pointed at by a bag.
+            EquipmentPackage base;
+            const qint64 P = EquipmentStorage::createPackageWithGrinderStatic(db, base, "Turin", "DF83V", "83mm flat steel");
+            const qint64 bag = addBag(P);
+            const qint64 shot = addShot(P);
+
+            // Edit burrs on a USED package -> fork (copy-on-write).
+            const qint64 fork = EquipmentStorage::supersedeOrEditGrinderStatic(db, P, "Turin", "DF83V", "83mm DLC flat");
+            QVERIFY(fork > 0 && fork != P);
+            // Old P retired + lineage; new fork current.
+            const EquipmentPackage oldP = EquipmentStorage::loadPackageStatic(db, P);
+            QVERIFY(!oldP.inInventory);
+            QCOMPARE(oldP.supersededBy, fork);
+            QCOMPARE(oldP.name, QString("Turin DF83V"));  // name persisted
+            const EquipmentPackage newP = EquipmentStorage::loadPackageStatic(db, fork);
+            QCOMPARE(newP.name, QString("Turin DF83V"));  // name preserved on fork
+            QCOMPARE(EquipmentStorage::loadGrinderItemStatic(db, fork).burrs, QString("83mm DLC flat"));
+            // Bag repointed to the fork; shot stays on the old package (history).
+            QCOMPARE(bagEq(bag), fork);
+            QCOMPARE(shotEq(shot), P);
+
+            // Unchanged identity -> no-op (no new fork).
+            QCOMPARE(EquipmentStorage::supersedeOrEditGrinderStatic(db, fork, "Turin", "DF83V", "83mm DLC flat"), fork);
+
+            // Unused package edits in place (same id).
+            EquipmentPackage q2;
+            const qint64 Q = EquipmentStorage::createPackageWithGrinderStatic(db, q2, "Niche", "Zero", "63mm conical");
+            QCOMPARE(EquipmentStorage::supersedeOrEditGrinderStatic(db, Q, "Niche", "Zero", "swapped"), Q);
+            QCOMPARE(EquipmentStorage::loadGrinderItemStatic(db, Q).burrs, QString("swapped"));
+
+            // Merge: a USED package edited to the fork's identity merges into it.
+            EquipmentPackage s;
+            const qint64 S = EquipmentStorage::createPackageWithGrinderStatic(db, s, "Mazzer", "Major", "83mm");
+            addShot(S);
+            const qint64 merged = EquipmentStorage::supersedeOrEditGrinderStatic(db, S, "Turin", "DF83V", "83mm DLC flat");
+            QCOMPARE(merged, fork);  // repointed to the existing matching package
+            QCOMPARE(EquipmentStorage::loadPackageStatic(db, S).supersededBy, fork);
+        });
+    }
+
     // --- migration data step: split + dedup-into-packages + link ---
     void migrationSplitsAndLinks() {
         const QString path = freshDbPath();

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -1,0 +1,204 @@
+#include <QtTest>
+#include <QSqlDatabase>
+#include <QSqlQuery>
+#include <QSqlError>
+#include <QTemporaryDir>
+
+#include "history/equipmentstorage.h"
+#include "history/coffeebagstorage.h"
+
+// Equipment packages: the grind/rpm split heuristic, rpmCapable derivation,
+// package CRUD, identity dedup, and the migration-22 data step
+// (add-equipment-packages).
+
+template<typename Work>
+static void withRawDb(const QString& path, const QString& connName, Work&& work) {
+    {
+        QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE", connName);
+        db.setDatabaseName(path);
+        db.open();
+        work(db);
+    }
+    QSqlDatabase::removeDatabase(connName);
+}
+
+// Minimal shots table carrying just the columns the migration reads/writes.
+static void createMinimalShots(QSqlDatabase& db) {
+    QSqlQuery(db).exec(R"(
+        CREATE TABLE shots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            grinder_brand TEXT, grinder_model TEXT, grinder_burrs TEXT,
+            grinder_setting TEXT, equipment_id INTEGER, rpm INTEGER
+        )
+    )");
+}
+
+static qint64 insertShot(QSqlDatabase& db, const QString& brand, const QString& model,
+                         const QString& burrs, const QString& setting) {
+    QSqlQuery q(db);
+    q.prepare("INSERT INTO shots (grinder_brand, grinder_model, grinder_burrs, grinder_setting) "
+              "VALUES (?, ?, ?, ?)");
+    q.addBindValue(brand); q.addBindValue(model); q.addBindValue(burrs); q.addBindValue(setting);
+    q.exec();
+    return q.lastInsertId().toLongLong();
+}
+
+class tst_Equipment : public QObject {
+    Q_OBJECT
+
+private:
+    QTemporaryDir m_dir;
+    int m_seq = 0;
+    QString freshDbPath() { return m_dir.filePath(QString("eq_%1.db").arg(++m_seq)); }
+
+private slots:
+    // --- splitGrindAndRpm ---
+    void splitGrindRpm_data() {
+        QTest::addColumn<QString>("input");
+        QTest::addColumn<QString>("grind");
+        QTest::addColumn<qint64>("rpm");
+        QTest::newRow("annotated")     << "24 1400rpm" << "24"        << (qint64)1400;
+        QTest::newRow("spaced")        << "2.4 1400 rpm" << "2.4"     << (qint64)1400;
+        QTest::newRow("caps")          << "24 1400RPM" << "24"        << (qint64)1400;
+        QTest::newRow("compound")      << "1+4"       << "1+4"        << (qint64)0;
+        QTest::newRow("clicks")        << "24 clicks" << "24 clicks"  << (qint64)0;
+        QTest::newRow("plain")         << "24"        << "24"         << (qint64)0;
+        QTest::newRow("empty")         << ""          << ""           << (qint64)0;
+        QTest::newRow("rpm_only")      << "1400rpm"   << ""           << (qint64)1400;
+    }
+    void splitGrindRpm() {
+        QFETCH(QString, input);
+        QFETCH(QString, grind);
+        QFETCH(qint64, rpm);
+        QString outGrind; qint64 outRpm = -1;
+        EquipmentStorage::splitGrindAndRpm(input, outGrind, outRpm);
+        QCOMPARE(outGrind, grind);
+        QCOMPARE(outRpm, rpm);
+    }
+
+    // --- rpmCapable derivation ---
+    void rpmCapable() {
+        // Registry variableRpm grinder.
+        QVERIFY(EquipmentStorage::deriveRpmCapable("Turin", "DF83V"));
+        // Registry non-variable grinder.
+        QVERIFY(!EquipmentStorage::deriveRpmCapable("Niche", "Zero"));
+        // Custom grinder not in the registry -> shown (true).
+        QVERIFY(EquipmentStorage::deriveRpmCapable("Acme", "Imaginary 9000"));
+    }
+
+    // --- package create + load ---
+    void createAndLoadPackage() {
+        const QString path = freshDbPath();
+        withRawDb(path, "eq_create", [](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            EquipmentPackage pkg;
+            pkg.lastGrindSetting = "24";
+            pkg.lastRpm = 1400;
+            const qint64 id = EquipmentStorage::createPackageWithGrinderStatic(
+                db, pkg, "Turin", "DF83V", "83mm flat steel");
+            QVERIFY(id > 0);
+
+            const EquipmentPackage loaded = EquipmentStorage::loadPackageStatic(db, id);
+            QVERIFY(loaded.isValid());
+            QCOMPARE(loaded.lastGrindSetting, QString("24"));
+            QCOMPARE(loaded.lastRpm, (qint64)1400);
+
+            const EquipmentItem grinder = EquipmentStorage::loadGrinderItemStatic(db, id);
+            QVERIFY(grinder.isValid());
+            QCOMPARE(grinder.brand, QString("Turin"));
+            QCOMPARE(grinder.model, QString("DF83V"));
+            QCOMPARE(grinder.burrs, QString("83mm flat steel"));
+            QVERIFY(grinder.rpmCapable);  // DF83V is variableRpm
+        });
+    }
+
+    // --- identity dedup lookup ---
+    void identityDedup() {
+        const QString path = freshDbPath();
+        withRawDb(path, "eq_dedup", [](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            EquipmentPackage pkg;
+            const qint64 id = EquipmentStorage::createPackageWithGrinderStatic(
+                db, pkg, "Niche", "Zero", "63mm conical");
+            QVERIFY(id > 0);
+            // Case-insensitive identity match.
+            QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "niche", "zero", "63mm conical"), id);
+            // Different burrs -> no match.
+            QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "Niche", "Zero", "other"), (qint64)0);
+            // Unknown grinder -> no match.
+            QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "X", "Y", ""), (qint64)0);
+        });
+    }
+
+    // --- migration data step: split + dedup-into-packages + link ---
+    void migrationSplitsAndLinks() {
+        const QString path = freshDbPath();
+        withRawDb(path, "eq_migrate", [](QSqlDatabase& db) {
+            QVERIFY(CoffeeBagStorage::ensureTableStatic(db));
+            createMinimalShots(db);
+
+            // Two bags: a Turin (matches current settings) and a Niche.
+            QSqlQuery q(db);
+            q.exec("INSERT INTO coffee_bags (roaster_name, coffee_name, grinder_brand, grinder_model, "
+                   "grinder_burrs, grinder_setting, in_inventory) VALUES "
+                   "('R','A','Turin','DF83V','83mm flat steel','24 1400rpm',1)");
+            const qint64 bag1 = q.lastInsertId().toLongLong();
+            q.exec("INSERT INTO coffee_bags (roaster_name, coffee_name, grinder_brand, grinder_model, "
+                   "grinder_burrs, grinder_setting, in_inventory) VALUES "
+                   "('R','B','Niche','Zero','63mm conical','12',1)");
+            const qint64 bag2 = q.lastInsertId().toLongLong();
+
+            // Shots: two Turin (one annotated), reusing the same identity.
+            const qint64 shot1 = insertShot(db, "Turin", "DF83V", "83mm flat steel", "25 1350rpm");
+            const qint64 shot2 = insertShot(db, "Turin", "DF83V", "83mm flat steel", "26");
+
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            QVERIFY(EquipmentStorage::migrateFromGrinderColumnsStatic(
+                db, "Turin", "DF83V", "83mm flat steel", "24 1400rpm"));
+
+            // Exactly two packages: Turin (default) + Niche. Turin identity is
+            // shared by the default seed, bag1, shot1, shot2 (NOT split by grind).
+            QVERIFY(q.exec("SELECT COUNT(*) FROM equipment_packages"));
+            QVERIFY(q.next());
+            QCOMPARE(q.value(0).toInt(), 2);
+
+            // bag1 + both Turin shots resolve to the same package.
+            auto eqId = [&](const QString& table, qint64 id) -> qint64 {
+                QSqlQuery e(db);
+                e.prepare(QString("SELECT equipment_id FROM %1 WHERE id = ?").arg(table));
+                e.addBindValue(id);
+                return (e.exec() && e.next()) ? e.value(0).toLongLong() : -1;
+            };
+            const qint64 turinPkg = eqId("coffee_bags", bag1);
+            QVERIFY(turinPkg > 0);
+            QCOMPARE(eqId("shots", shot1), turinPkg);
+            QCOMPARE(eqId("shots", shot2), turinPkg);
+            QVERIFY(eqId("coffee_bags", bag2) > 0);
+            QVERIFY(eqId("coffee_bags", bag2) != turinPkg);
+
+            // Grind/rpm split applied to the annotated rows; plain rows untouched.
+            auto cell = [&](const QString& table, const QString& col, qint64 id) -> QVariant {
+                QSqlQuery e(db);
+                e.prepare(QString("SELECT %1 FROM %2 WHERE id = ?").arg(col, table));
+                e.addBindValue(id);
+                return (e.exec() && e.next()) ? e.value(0) : QVariant();
+            };
+            QCOMPARE(cell("coffee_bags", "grinder_setting", bag1).toString(), QString("24"));
+            QCOMPARE(cell("coffee_bags", "rpm", bag1).toInt(), 1400);
+            QCOMPARE(cell("shots", "grinder_setting", shot1).toString(), QString("25"));
+            QCOMPARE(cell("shots", "rpm", shot1).toInt(), 1350);
+            QCOMPARE(cell("shots", "grinder_setting", shot2).toString(), QString("26"));
+            QVERIFY(cell("shots", "rpm", shot2).isNull());
+
+            // The Turin package is rpm-capable and seeded from current settings.
+            const EquipmentItem g = EquipmentStorage::loadGrinderItemStatic(db, turinPkg);
+            QVERIFY(g.rpmCapable);
+            const EquipmentPackage p = EquipmentStorage::loadPackageStatic(db, turinPkg);
+            QCOMPARE(p.lastGrindSetting, QString("24"));
+            QCOMPARE(p.lastRpm, (qint64)1400);
+        });
+    }
+};
+
+QTEST_MAIN(tst_Equipment)
+#include "tst_equipment.moc"

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -309,6 +309,114 @@ private slots:
             QCOMPARE(p.lastRpm, (qint64)1400);
         });
     }
+
+    // Device-transfer import (add-equipment-packages task 2.8):
+    // importEquipmentStatic copies packages + items with id-remap, MERGES an
+    // in-inventory source package onto an existing dest package of the same
+    // grinder identity (no duplicate), imports superseded (historical) packages
+    // as new rows, and remaps the superseded_by lineage pointer through the id
+    // map. Source ids must NOT survive verbatim into dest.
+    void importEquipmentRemap() {
+        const QString srcPath = freshDbPath();
+        const QString dstPath = freshDbPath();
+
+        // SOURCE: an in-inventory Niche (will merge into dest), plus a Turin
+        // lineage — an in-inventory "new" fork and a soft-deleted "old" package
+        // whose superseded_by points at the fork.
+        qint64 srcNiche = -1, srcTurinNew = -1, srcTurinOld = -1;
+        withRawDb(srcPath, "imp_src_build", [&](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            EquipmentPackage n;
+            srcNiche = EquipmentStorage::createPackageWithGrinderStatic(db, n, "Niche", "Zero", "63mm conical");
+            EquipmentPackage t1;
+            srcTurinNew = EquipmentStorage::createPackageWithGrinderStatic(db, t1, "Turin", "DF83V", "83mm DLC flat");
+            EquipmentPackage t0;
+            srcTurinOld = EquipmentStorage::createPackageWithGrinderStatic(db, t0, "Turin", "DF83V", "83mm flat steel");
+            QSqlQuery q(db);
+            q.prepare("UPDATE equipment_packages SET in_inventory = 0, superseded_by = ? WHERE id = ?");
+            q.addBindValue(srcTurinNew); q.addBindValue(srcTurinOld);
+            QVERIFY(q.exec());
+        });
+        QVERIFY(srcNiche > 0 && srcTurinNew > 0 && srcTurinOld > 0);
+
+        // DEST: a pre-existing in-inventory Niche/Zero/63mm conical the source
+        // Niche must merge into.
+        qint64 dstNiche = -1;
+        withRawDb(dstPath, "imp_dst_build", [&](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            EquipmentPackage n;
+            dstNiche = EquipmentStorage::createPackageWithGrinderStatic(db, n, "Niche", "Zero", "63mm conical");
+        });
+        QVERIFY(dstNiche > 0);
+
+        // Import (merge mode) with both connections open simultaneously.
+        QHash<qint64, qint64> idMap;
+        {
+            QSqlDatabase src = QSqlDatabase::addDatabase("QSQLITE", "imp_src");
+            src.setDatabaseName(srcPath);
+            QVERIFY(src.open());
+            QSqlDatabase dst = QSqlDatabase::addDatabase("QSQLITE", "imp_dst");
+            dst.setDatabaseName(dstPath);
+            QVERIFY(dst.open());
+            QVERIFY(EquipmentStorage::importEquipmentStatic(src, dst, /*merge*/ true, idMap));
+            src = QSqlDatabase();
+            dst = QSqlDatabase();
+        }
+        QSqlDatabase::removeDatabase("imp_src");
+        QSqlDatabase::removeDatabase("imp_dst");
+
+        withRawDb(dstPath, "imp_verify", [&](QSqlDatabase& db) {
+            // Merge: the source Niche mapped onto the existing dest Niche.
+            QCOMPARE(idMap.value(srcNiche), dstNiche);
+            QSqlQuery c(db);
+            QVERIFY(c.exec("SELECT COUNT(*) FROM equipment_items WHERE kind='grinder' AND brand='Niche'") && c.next());
+            QCOMPARE(c.value(0).toInt(), 1);  // no duplicate Niche package/item
+
+            // Both Turin packages imported as NEW rows (ids remapped, not verbatim).
+            const qint64 dTurinNew = idMap.value(srcTurinNew);
+            const qint64 dTurinOld = idMap.value(srcTurinOld);
+            QVERIFY(dTurinNew > 0 && dTurinOld > 0);
+
+            // The old Turin is soft-deleted with superseded_by remapped to the
+            // NEW dest id — lineage preserved across the transfer.
+            const EquipmentPackage oldP = EquipmentStorage::loadPackageStatic(db, dTurinOld);
+            QVERIFY(!oldP.inInventory);
+            QCOMPARE(oldP.supersededBy, dTurinNew);
+
+            // Items rode along with their grinder identity.
+            QCOMPARE(EquipmentStorage::loadGrinderItemStatic(db, dTurinNew).burrs, QString("83mm DLC flat"));
+            QCOMPARE(EquipmentStorage::loadGrinderItemStatic(db, dTurinOld).burrs, QString("83mm flat steel"));
+        });
+    }
+
+    // A source DB with no equipment tables (transfer from a pre-equipment app
+    // version) yields an empty map and succeeds — bags/shots then null their
+    // equipment_id rather than mislinking.
+    void importEquipmentFromPreEquipmentSource() {
+        const QString srcPath = freshDbPath();
+        const QString dstPath = freshDbPath();
+        withRawDb(srcPath, "imp_old_src", [&](QSqlDatabase& db) {
+            QSqlQuery(db).exec("CREATE TABLE shots (id INTEGER PRIMARY KEY)");  // no equipment tables
+        });
+        withRawDb(dstPath, "imp_old_dst", [&](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+        });
+        QHash<qint64, qint64> idMap;
+        {
+            QSqlDatabase src = QSqlDatabase::addDatabase("QSQLITE", "imp_old_s");
+            src.setDatabaseName(srcPath);
+            QVERIFY(src.open());
+            QSqlDatabase dst = QSqlDatabase::addDatabase("QSQLITE", "imp_old_d");
+            dst.setDatabaseName(dstPath);
+            QVERIFY(dst.open());
+            QVERIFY(EquipmentStorage::importEquipmentStatic(src, dst, /*merge*/ true, idMap));
+            src = QSqlDatabase();
+            dst = QSqlDatabase();
+        }
+        QSqlDatabase::removeDatabase("imp_old_s");
+        QSqlDatabase::removeDatabase("imp_old_d");
+        QVERIFY(idMap.isEmpty());
+    }
 };
 
 QTEST_MAIN(tst_Equipment)


### PR DESCRIPTION
## Equipment packages

Extracts the grinder out of the bean bag into a first-class, switchable **Equipment package** (parallel to Beans), per `openspec/changes/add-equipment-packages`. Grinder identity is now a pointer + JOIN, not per-shot/bag snapshot columns.

### What ships
- **Equipment window** parallel to Beans — package cards (add/edit/remove), empty state, and an idle **Equipment button** added to the default layout and injected into every existing user's saved layout via an idempotent migration.
- **Brew Settings**: grinder make/model/burrs replaced by a read-only **Equipment package name** + **Switch** + **info** button; **grind setting + RPM** kept as dial-in (RPM shown only when the grinder is adjustable, including custom grinders).
- **Equipment surfaced everywhere the grinder used to be**: Shot Review (read-only + Change Equipment), Edit Bag (summary + Switch/Add), Shot Detail (read-only, incl. RPM). The package **name** is shown instead of the raw grinder identity, with a per-row info dialog listing the package contents; the separate burrs line was dropped.
- **Copy-on-write immutability**: editing a used package's identity forks a new package, retires the old (`superseded_by` lineage), repoints referencing bags/shots; identity merges on collision; `last_grind`/`last_rpm` stay mutable so dialing never churns packages.
- **Dial memory**: grinder-scoped (package) + bean-scoped (bag); switching either applies its last dial.
- **Pure-pointer storage**: `coffee_bags.equipment_id` and `shots.equipment_id` reference a package; grinder identity resolves via JOIN to `equipment_items`. Migration 22 (additive: tables, `equipment_id`+`rpm`, package creation from history, `"24 1400rpm"` split); migration 23 (drop legacy grinder columns from shots + bags, rebuild `shots_fts` without them).
- **MCP**: `equipment_list` / `equipment_select` / `equipment_update`; grinder identity + RPM resolved via the pointer; RPM now surfaced to `dialing_get_context` and the in-app AI advisor (`currentBean.rpm`).
- **Visualizer**: appends rpm to the grind setting on upload.

### Tests
Full suite green — **2397 tests, 0 warnings**. Covers `tst_equipment` (CRUD / copy-on-write + merge / setting+rpm split / rpmCapable), migration 22/23, bag/shot `equipment_id` + rpm, and `currentBean.rpm` equivalence across the MCP and in-app surfaces.

### Review
Reviewed via multi-agent `/review`; all findings addressed — new-bag equipment persistence, removal of stale grinder params from `shots_update`, replace-import clear ordering, accessible-name i18n, and a stale comment.

### Follow-ups (not blocking)
- Wiki Manual page for the Equipment feature (release-time).
- Advisor input-path consolidation (the unused `QVariantMap analyzeShot` / 14-arg `buildMetadata` fan-out) — a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
