### PR TITLE
Refine baskets DB: 58mm-only + relative flow class for AI

### DIFF
--- a/src/core/basketaliases.h
+++ b/src/core/basketaliases.h
@@ -47,6 +47,9 @@ enum class WallProfile { Straight, Tapered, Stepped, Convex };
 // change across baskets, not a magnitude. Reliable magnitude comes from the
 // user's own per-basket shot history (equipment_id linkage + grind learning),
 // not from a spec number.
+// Compared for equality only (e.g. `flow != Standard` in summary());
+// declaration order is NOT load-bearing — don't rely on Restrictive <
+// Standard < Open as an ordered scale.
 enum class FlowRate { Restrictive, Standard, Open };
 
 struct BasketEntry {

--- a/src/core/basketaliases.h
+++ b/src/core/basketaliases.h
@@ -23,30 +23,50 @@ namespace BasketAliases {
 //   Convex   : the floor bulges up in the centre (IMS Convex, S-Works /
 //              Normcore convex), concentrating flow toward the middle and
 //              demanding a slightly coarser grind.
+// Note: every basket here is single-wall. Pressurized / dual-wall baskets are
+// deliberately excluded — they self-regulate back-pressure and defeat the
+// DE1's flow/pressure profiling, so they have no place on a Decent machine.
 enum class WallProfile { Straight, Tapered, Stepped, Convex };
+
+// How freely the basket passes water at a FIXED grind — the relative flow
+// characteristic. This is the cross-basket knowledge an AI advisor wants: it
+// can't be read off a single shot (flow on a fixed basket is constant), but it
+// lets the advisor reason when a user SWITCHES baskets or wants to recreate a
+// shot on different gear. e.g. a Weber Unibasket (Open) flows faster than a
+// Decent stock double (Standard) at the same grind, so moving to it means
+// grinding a touch finer to hold the same shot time.
+//   Restrictive : finer filtration / lower open area, slower flow (IMS
+//                 SuperFine 170µm, Normcore 0.18mm 'reduced flow', stock
+//                 stamped baskets).
+//   Standard    : a typical good precision basket (Decent, VST, IMS, most).
+//                 The reference point.
+//   Open        : holes carried to the edge / high open area / full-coverage
+//                 patterns, noticeably faster (Weber Unibasket, Pesado HE,
+//                 Wafo Spirit).
+// This is intentionally COARSE — it gives the AI the DIRECTION of a grind
+// change across baskets, not a magnitude. Reliable magnitude comes from the
+// user's own per-basket shot history (equipment_id linkage + grind learning),
+// not from a spec number.
+enum class FlowRate { Restrictive, Standard, Open };
 
 struct BasketEntry {
     QString brand;
     QString model;
     QStringList aliases;     // lowercase match strings (brand+size shorthands)
-    int diameterMm;          // nominal group size: 58, 54, 53, 51, 49
+    int diameterMm;          // nominal group size — always 58 for the DE1
     double doseMinG;         // recommended dose range, low end (grams)
     double doseMaxG;         // recommended dose range, high end (grams)
     WallProfile wall = WallProfile::Straight;
-    // True for a double-wall / "pressurized" basket: a second floor with one
-    // tiny exit orifice generates back-pressure itself, so the PUCK no longer
-    // sets resistance. Forgiving of coarse/pre-ground coffee but it MASKS the
-    // machine's pressure/flow curve — flow profiling is meaningless on one.
-    // The advisor should steer profiling users to a single-wall basket.
-    bool pressurized = false;
     // True for a laser-drilled / tolerance-controlled "precision" basket
     // (VST ±20µm, IMS competition, Weber, Pesado, Normcore, S-Works billet,
     // and the precision-inspected Decent stock). Uniform holes + even open
-    // area remove a confound from flow telemetry and resist channeling.
+    // area give repeatable shots and remove a confound from flow telemetry;
+    // stock-stamped baskets vary, so "same grind, different time" may be the
+    // basket rather than the user.
     bool precision = false;
+    FlowRate flow = FlowRate::Standard;  // relative flow at a fixed grind
     int holeCount = 0;            // published hole count; 0 = unpublished
     int holeDiameterMicrons = 0;  // published hole Ø in microns; 0 = unpublished
-    double depthMm = 0;           // published basket depth/height; 0 = unpublished
     QString material = QStringLiteral("stainless steel");
     QString notes;               // one-line AI enrichment: what it's known for
 };
@@ -57,98 +77,101 @@ struct LookupResult {
     double doseMinG = 0;
     double doseMaxG = 0;
     bool precision = false;
-    bool pressurized = false;
+    FlowRate flow = FlowRate::Standard;
     bool found = false;
 };
 
 inline QVector<BasketEntry> allBaskets()
 {
     using WP = WallProfile;
+    using FR = FlowRate;
     static const QVector<BasketEntry> entries = {
         // --- Decent (58mm single-wall; holes precision-inspected under
         //     microscope by Decent's own QC software, sold as the DE1 stock) ---
-        {"Decent", "Ridgeless 15g", {"decent 15g", "decent ridgeless 15g", "de1 15g"}, 58, 14, 16, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Stock small double; ridgeless for bottomless portafilters.")},
-        {"Decent", "Ridgeless 18g", {"decent 18g", "decent ridgeless 18g", "de1 18g", "decent stock"}, 58, 17, 19, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Basket shipped with the DE1 — the default everyday double.")},
-        {"Decent", "Ridgeless 20g", {"decent 20g", "decent ridgeless 20g", "de1 20g"}, 58, 19, 21, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Larger capacity ridgeless double for higher doses.")},
-        {"Decent", "Ridgeless 22g", {"decent 22g", "decent ridgeless 22g", "de1 22g"}, 58, 21, 23, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Largest standard ridgeless; high dose / darker roasts.")},
-        {"Decent", "Ridged 7g", {"decent 7g", "decent ridged 7g"}, 58, 6, 8, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Single-ristretto small basket; ridge grips a standard portafilter.")},
-        {"Decent", "Ridged 10g", {"decent 10g", "decent ridged 10g"}, 58, 9, 11, WP::Straight, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Small low-dose basket for single / lighter shots.")},
-        {"Decent", "Slightly Waisted 14g", {"decent slightly waisted", "slightly waisted"}, 58, 12, 15, WP::Stepped, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Necks the 58mm bed down (~52mm) for added body; best near 14g.")},
-        {"Decent", "Very Waisted 14g", {"decent very waisted", "very waisted"}, 58, 12, 16, WP::Stepped, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("More taper than 'slightly' — more body, easier no-channel shots.")},
-        {"Decent", "Extremely Waisted 12g", {"decent extremely waisted", "extremely waisted"}, 58, 11, 14, WP::Stepped, false, true, 0, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Most aggressive taper (~50mm bed); deep lever-style puck for body.")},
+        {"Decent", "Ridgeless 15g", {"decent 15g", "decent ridgeless 15g", "de1 15g"}, 58, 14, 16, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Stock small double; ridgeless for bottomless portafilters.")},
+        {"Decent", "Ridgeless 18g", {"decent 18g", "decent ridgeless 18g", "de1 18g", "decent stock"}, 58, 17, 19, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Basket shipped with the DE1 — the default everyday double.")},
+        {"Decent", "Ridgeless 20g", {"decent 20g", "decent ridgeless 20g", "de1 20g"}, 58, 19, 21, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Larger capacity ridgeless double for higher doses.")},
+        {"Decent", "Ridgeless 22g", {"decent 22g", "decent ridgeless 22g", "de1 22g"}, 58, 21, 23, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Largest standard ridgeless; high dose / darker roasts.")},
+        {"Decent", "Ridged 7g", {"decent 7g", "decent ridged 7g"}, 58, 6, 8, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Single-ristretto small basket; ridge grips a standard portafilter.")},
+        {"Decent", "Ridged 10g", {"decent 10g", "decent ridged 10g"}, 58, 9, 11, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Small low-dose basket for single / lighter shots.")},
+        {"Decent", "Slightly Waisted 14g", {"decent slightly waisted", "slightly waisted"}, 58, 12, 15, WP::Stepped, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Necks the 58mm bed down (~52mm) for added body; best near 14g.")},
+        {"Decent", "Very Waisted 14g", {"decent very waisted", "very waisted"}, 58, 12, 16, WP::Stepped, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("More taper than 'slightly' — more body, easier no-channel shots.")},
+        {"Decent", "Extremely Waisted 12g", {"decent extremely waisted", "extremely waisted"}, 58, 11, 14, WP::Stepped, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Most aggressive taper (~50mm bed); deep lever-style puck for body.")},
 
         // --- Weber Workshops Unibasket (forged 304, 1.2mm blank, straight
-        //     walls with laser-ablated holes carried to the side wall) ---
-        {"Weber Workshops", "Unibasket 16g", {"unibasket 16g", "weber 16g", "weber unibasket 16g"}, 58, 15, 17, WP::Straight, false, true, 0, 0, 24, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("Holes to the side wall give a full ~58mm active puck vs ~48mm stock.")},
-        {"Weber Workshops", "Unibasket 20g", {"unibasket 20g", "weber 20g", "weber unibasket 20g"}, 58, 19, 21, WP::Straight, false, true, 0, 0, 26, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("20g drop-in Unibasket; same unibody straight-wall design.")},
-        {"Weber Workshops", "Unibasket 24g", {"unibasket 24g", "weber 24g", "weber unibasket 24g"}, 58, 23, 25, WP::Straight, false, true, 0, 0, 29, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("24g drop-in Unibasket.")},
-        {"Weber Workshops", "Unibasket 28g", {"unibasket 28g", "weber 28g", "weber unibasket 28g"}, 58, 27, 29, WP::Straight, false, true, 0, 0, 31, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("Largest Unibasket — a 28g 'mega-shot' size.")},
+        //     walls with laser-ablated holes carried to the side wall — the
+        //     reason it flows faster than a tapered stock basket) ---
+        {"Weber Workshops", "Unibasket 16g", {"unibasket 16g", "weber 16g", "weber unibasket 16g"}, 58, 15, 17, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("Holes to the side wall give a full ~58mm active puck vs ~48mm stock — flows faster.")},
+        {"Weber Workshops", "Unibasket 20g", {"unibasket 20g", "weber 20g", "weber unibasket 20g"}, 58, 19, 21, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("20g drop-in Unibasket; same unibody straight-wall, full-active-area design.")},
+        {"Weber Workshops", "Unibasket 24g", {"unibasket 24g", "weber 24g", "weber unibasket 24g"}, 58, 23, 25, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("24g drop-in Unibasket.")},
+        {"Weber Workshops", "Unibasket 28g", {"unibasket 28g", "weber 28g", "weber unibasket 28g"}, 58, 27, 29, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("Largest Unibasket — a 28g 'mega-shot' size.")},
 
         // --- VST (the WBC reference precision basket; every hole optically
         //     verified to ~±20µm, individual test certificate per basket;
         //     20% thicker steel; sold ridged AND ridgeless. Hole count and
         //     micron Ø intentionally NOT published — the spec is the tolerance) ---
-        {"VST", "7g Single", {"vst 7g", "vst 7", "vst single"}, 58, 6, 8, WP::Straight, false, true, 0, 0, 28, QStringLiteral("20% thicker stainless"), QStringLiteral("Precision single basket; ±20µm hole tolerance like the rest of the line.")},
-        {"VST", "15g Double", {"vst 15g", "vst 15"}, 58, 14, 16, WP::Straight, false, true, 0, 0, 22, QStringLiteral("20% thicker stainless"), QStringLiteral("Precision EU double; ridged or ridgeless.")},
-        {"VST", "18g Double", {"vst 18g", "vst 18", "vst", "vst ridgeless 18g"}, 58, 17, 19, WP::Straight, false, true, 0, 0, 24, QStringLiteral("20% thicker stainless"), QStringLiteral("Most popular precision double and a WBC reference basket.")},
-        {"VST", "20g Competition", {"vst 20g", "vst 20"}, 58, 19, 21, WP::Straight, false, true, 0, 0, 26, QStringLiteral("20% thicker stainless"), QStringLiteral("20g competition double; ridged or ridgeless.")},
-        {"VST", "22g Triple", {"vst 22g", "vst 22"}, 58, 21, 23, WP::Straight, false, true, 0, 0, 28, QStringLiteral("20% thicker stainless"), QStringLiteral("Deeper triple-style precision basket for larger doses.")},
-        {"VST", "25g Triple+", {"vst 25g", "vst 25"}, 58, 24, 26, WP::Straight, false, true, 0, 0, 30, QStringLiteral("20% thicker stainless"), QStringLiteral("Largest VST size, 30mm deep.")},
+        {"VST", "7g Single", {"vst 7g", "vst 7", "vst single"}, 58, 6, 8, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("20% thicker stainless"), QStringLiteral("Precision single basket; ±20µm hole tolerance like the rest of the line.")},
+        {"VST", "15g Double", {"vst 15g", "vst 15"}, 58, 14, 16, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("20% thicker stainless"), QStringLiteral("Precision EU double; ridged or ridgeless.")},
+        {"VST", "18g Double", {"vst 18g", "vst 18", "vst", "vst ridgeless 18g"}, 58, 17, 19, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("20% thicker stainless"), QStringLiteral("Most popular precision double and a WBC reference basket.")},
+        {"VST", "20g Competition", {"vst 20g", "vst 20"}, 58, 19, 21, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("20% thicker stainless"), QStringLiteral("20g competition double; ridged or ridgeless.")},
+        {"VST", "22g Triple", {"vst 22g", "vst 22"}, 58, 21, 23, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("20% thicker stainless"), QStringLiteral("Deeper triple-style precision basket for larger doses.")},
+        {"VST", "25g Triple+", {"vst 25g", "vst 25"}, 58, 24, 26, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("20% thicker stainless"), QStringLiteral("Largest VST size.")},
 
         // --- IMS (competition precision; 0.30mm holes standard. "M" flat
         //     pattern, "TC" convex base, "E" ridgeless, "SF" SuperFine
         //     membrane, "NT" Nanoquartz non-stick coating) ---
-        {"IMS", "Competition B70 2T H24.5 (12-18g)", {"ims 24.5", "ims h24.5", "ims competition 24.5"}, 58, 12, 18, WP::Straight, false, true, 0, 300, 24.5, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Flexible low-dose competition flat; 0.30mm holes.")},
-        {"IMS", "Competition B70 2T H26.5 (18-21g)", {"ims 26.5", "ims h26.5", "ims competition", "ims 18g"}, 58, 18, 21, WP::Straight, false, true, 641, 300, 26.5, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Reference IMS competition double — 641 holes at 0.30mm.")},
-        {"IMS", "Competition Convex B70 2TC H28.5 (19-22g)", {"ims convex", "ims 2tc", "ims h28.5"}, 58, 19, 22, WP::Convex, false, true, 715, 300, 28.5, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Convex base concentrates flow to the centre; 715 holes, ridgeless.")},
-        {"IMS", "SuperFine B70 2T H24 (14-16g)", {"ims superfine", "ims sf", "eb lab superfine"}, 58, 14, 16, WP::Straight, false, true, 565, 170, 24, QStringLiteral("stainless + 170µm membrane"), QStringLiteral("170µm membrane over 565 holes cuts fines passthrough for clarity.")},
-        {"IMS", "Nanoquartz B70 2TF NT (14-28g)", {"ims nanotech", "ims nanoquartz", "ims nt"}, 58, 14, 28, WP::Straight, false, true, 715, 300, 0, QStringLiteral("304 + Nanoquartz non-stick coating"), QStringLiteral("Competition geometry plus a water/oil-repellent non-stick coating for clean puck release.")},
+        {"IMS", "Competition B70 2T H24.5 (12-18g)", {"ims 24.5", "ims h24.5", "ims competition 24.5"}, 58, 12, 18, WP::Straight, true, FR::Standard, 0, 300, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Flexible low-dose competition flat; 0.30mm holes.")},
+        {"IMS", "Competition B70 2T H26.5 (18-21g)", {"ims 26.5", "ims h26.5", "ims competition", "ims 18g"}, 58, 18, 21, WP::Straight, true, FR::Standard, 641, 300, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Reference IMS competition double — 641 holes at 0.30mm.")},
+        {"IMS", "Competition Convex B70 2TC H28.5 (19-22g)", {"ims convex", "ims 2tc", "ims h28.5"}, 58, 19, 22, WP::Convex, true, FR::Standard, 715, 300, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Convex base concentrates flow to the centre; 715 holes, ridgeless.")},
+        {"IMS", "SuperFine B70 2T H24 (14-16g)", {"ims superfine", "ims sf", "eb lab superfine"}, 58, 14, 16, WP::Straight, true, FR::Restrictive, 565, 170, QStringLiteral("stainless + 170µm membrane"), QStringLiteral("170µm membrane over 565 holes cuts fines passthrough — finer filtration, slower flow.")},
+        {"IMS", "Nanoquartz B70 2TF NT (14-28g)", {"ims nanotech", "ims nanoquartz", "ims nt"}, 58, 14, 28, WP::Straight, true, FR::Standard, 715, 300, QStringLiteral("304 + Nanoquartz non-stick coating"), QStringLiteral("Competition geometry plus a water/oil-repellent non-stick coating for clean puck release.")},
 
         // --- S-Works (CNC-machined from solid 17-4 PH stainless billet,
-        //     0.75mm walls, holes to the edge; sold in multiple flow patterns,
-        //     ~4% open area on standard patterns) ---
-        {"S-Works", "Billet Basket", {"sworks billet", "s-works billet", "sworks basket", "sworks"}, 58, 18, 20, WP::Straight, false, true, 0, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Machined billet, holes to the edge; many flow patterns, ~4% open area.")},
-        {"S-Works", "Tapered Billet", {"sworks tapered", "s-works tapered"}, 58, 18, 20, WP::Tapered, false, true, 0, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Truncated-cone billet for a 'blended', rounder shot.")},
-        {"S-Works", "Convex Billet", {"sworks convex", "s-works convex"}, 58, 17, 19, WP::Convex, false, true, 0, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Raised centre floor; needs a coarser grind, favours blooming shots.")},
-        {"S-Works", "Step Down Billet", {"sworks step down", "s-works step down", "sworks stepdown"}, 58, 12, 20, WP::Stepped, false, true, 0, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Necks 58mm to a ~49/32mm brew bed for a deeper, more forgiving puck.")},
-        {"S-Works", "Titanium Billet", {"sworks titanium", "s-works titanium"}, 58, 18, 20, WP::Straight, false, true, 0, 0, 0, QStringLiteral("solid titanium"), QStringLiteral("Halo item — ~30% lighter, each hole individually drilled.")},
+        //     0.75mm walls, holes to the edge; each model is ALSO sold in
+        //     Reduced / Standard / High flow hole patterns, so the flow class
+        //     below is the default — the user's chosen pattern can shift it) ---
+        {"S-Works", "Billet Basket", {"sworks billet", "s-works billet", "sworks basket", "sworks"}, 58, 18, 20, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Machined billet, holes to the edge; sold in Reduced/Standard/High flow patterns (~4% open area standard).")},
+        {"S-Works", "Tapered Billet", {"sworks tapered", "s-works tapered"}, 58, 18, 20, WP::Tapered, true, FR::Standard, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Truncated-cone billet for a 'blended', rounder shot.")},
+        {"S-Works", "Convex Billet", {"sworks convex", "s-works convex"}, 58, 17, 19, WP::Convex, true, FR::Standard, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Raised centre floor; needs a coarser grind, favours blooming shots.")},
+        {"S-Works", "Step Down Billet", {"sworks step down", "s-works step down", "sworks stepdown"}, 58, 12, 20, WP::Stepped, true, FR::Standard, 0, 0, QStringLiteral("17-4 PH stainless billet"), QStringLiteral("Necks 58mm to a ~49/32mm brew bed for a deeper, more forgiving puck.")},
+        {"S-Works", "Step Down Stamped", {"sworks step down stamped", "s-works stamped", "sworks stamped step down"}, 58, 12, 20, WP::Stepped, false, FR::Standard, 600, 0, QStringLiteral("304 stainless, stamped"), QStringLiteral("Budget ~$30 stamped step-down; 58mm necks to a 50mm brew bed (~600 holes).")},
+        {"S-Works", "Titanium Billet", {"sworks titanium", "s-works titanium"}, 58, 18, 20, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("solid titanium"), QStringLiteral("Halo item — ~30% lighter, each hole individually drilled.")},
 
         // --- Graph Coffee (step-down baskets that convert a 58mm group to a
         //     deep, narrow 46mm puck; need a bottomless portafilter) ---
-        {"Graph Coffee", "Stepped 58→46mm", {"graph stepped", "graph 58 46", "graph step down"}, 58, 16, 22, WP::Stepped, false, true, 648, 300, 29, QStringLiteral("laser-perforated stainless"), QStringLiteral("Steps a 58mm portafilter down to a 46mm deep puck; 648 holes at 0.30mm.")},
-        {"Graph Coffee", "Stepped 54→46mm (Breville)", {"graph 54 46", "graph breville", "graph sage"}, 54, 16, 22, WP::Stepped, false, true, 0, 300, 0, QStringLiteral("laser-perforated stainless"), QStringLiteral("Breville/Sage 54mm variant of the 46mm step-down.")},
+        {"Graph Coffee", "Stepped 58→46mm", {"graph stepped", "graph 58 46", "graph step down"}, 58, 16, 22, WP::Stepped, true, FR::Standard, 648, 300, QStringLiteral("laser-perforated stainless"), QStringLiteral("Steps a 58mm portafilter down to a 46mm deep puck; 648 holes at 0.30mm.")},
 
         // --- Pesado ---
-        {"Pesado", "HE High Extraction", {"pesado he", "pesado high extraction", "pesado 58.5", "pesado"}, 58, 17, 19, WP::Straight, false, true, 715, 300, 0, QStringLiteral("1.1mm stainless, electro-polished"), QStringLiteral("Funnel-shaped holes to the edge; high open area, favours light roasts.")},
-        {"Pesado", "EP Electro-Polished", {"pesado ep", "pesado electro polished"}, 58, 17, 19, WP::Tapered, false, false, 0, 0, 0, QStringLiteral("0.5mm stainless, electro-polished"), QStringLiteral("Budget electro-polished stock-replacement; smoother holes, more forgiving.")},
+        {"Pesado", "HE High Extraction", {"pesado he", "pesado high extraction", "pesado 58.5", "pesado"}, 58, 17, 19, WP::Straight, true, FR::Open, 715, 300, QStringLiteral("1.1mm stainless, electro-polished"), QStringLiteral("Funnel-shaped holes to the edge; high open area, faster flow, favours light roasts.")},
+        {"Pesado", "EP Electro-Polished", {"pesado ep", "pesado electro polished"}, 58, 17, 19, WP::Tapered, false, FR::Standard, 0, 0, QStringLiteral("0.5mm stainless, electro-polished"), QStringLiteral("Budget electro-polished stock-replacement; smoother holes, more forgiving.")},
 
         // --- Normcore (two flow tiers by hole geometry) ---
-        {"Normcore", "HE 0.28mm Standard Flow", {"normcore 0.28", "normcore standard flow", "normcore he 0.28"}, 58, 17, 19, WP::Straight, false, true, 786, 280, 0, QStringLiteral("0.8mm 304 stainless"), QStringLiteral("786 holes — faster flow, finer grind, higher clarity (light/medium).")},
-        {"Normcore", "HE 0.18mm Reduced Flow", {"normcore 0.18", "normcore reduced flow", "normcore he 0.18"}, 58, 17, 19, WP::Straight, false, true, 2475, 180, 0, QStringLiteral("0.8mm 304 stainless"), QStringLiteral("2475 holes — slower flow, thicker texture, coarser grind tolerance (medium/dark).")},
-        {"Normcore", "58→32mm Convex Step-Down", {"normcore step down", "normcore convex", "normcore 58 32"}, 58, 21, 23, WP::Convex, false, true, 444, 280, 0, QStringLiteral("stainless steel"), QStringLiteral("Convex step-down forms a deeper, focused puck; sold with puck screen.")},
+        {"Normcore", "HE 0.28mm Standard Flow", {"normcore 0.28", "normcore standard flow", "normcore he 0.28"}, 58, 17, 19, WP::Straight, true, FR::Standard, 786, 280, QStringLiteral("0.8mm 304 stainless"), QStringLiteral("786 holes — Normcore's faster-flow tier; finer grind, higher clarity (light/medium).")},
+        {"Normcore", "HE 0.18mm Reduced Flow", {"normcore 0.18", "normcore reduced flow", "normcore he 0.18"}, 58, 17, 19, WP::Straight, true, FR::Restrictive, 2475, 180, QStringLiteral("0.8mm 304 stainless"), QStringLiteral("2475 holes — slower 'reduced flow' tier; thicker texture, coarser grind tolerance (medium/dark).")},
+        {"Normcore", "58→32mm Convex Step-Down", {"normcore step down", "normcore convex", "normcore 58 32"}, 58, 21, 23, WP::Convex, true, FR::Standard, 444, 280, QStringLiteral("stainless steel"), QStringLiteral("Convex step-down forms a deeper, focused puck; sold with puck screen.")},
 
         // --- Pullman ---
-        {"Pullman", "Filtration876", {"pullman 876", "pullman filtration876", "pullman", "filtration876"}, 58, 17, 19, WP::Straight, false, true, 876, 300, 0, QStringLiteral("AISI 304 stainless, polished"), QStringLiteral("Guaranteed 58.7mm bore, 876 holes at 0.30mm; pairs with the BigStep tamper.")},
+        {"Pullman", "Filtration876", {"pullman 876", "pullman filtration876", "pullman", "filtration876"}, 58, 17, 19, WP::Straight, true, FR::Standard, 876, 300, QStringLiteral("AISI 304 stainless, polished"), QStringLiteral("Guaranteed 58.7mm bore, 876 holes at 0.30mm; pairs with the BigStep tamper.")},
 
         // --- Wafo (boutique 316L, naturally curved bottom) ---
-        {"Wafo", "Spirit", {"wafo spirit", "wafo soe spirit"}, 58, 17, 19, WP::Straight, false, true, 0, 0, 24.7, QStringLiteral("316L stainless"), QStringLiteral("Boutique full-coverage pattern for the most even extraction / clearest cup.")},
-        {"Wafo", "Checkmate", {"wafo checkmate", "wafo blend"}, 58, 17, 19, WP::Straight, false, true, 0, 0, 24.7, QStringLiteral("316L stainless"), QStringLiteral("Intentionally irregular hole layout for a deliberately distinctive flavour.")},
+        {"Wafo", "Spirit", {"wafo spirit", "wafo soe spirit"}, 58, 17, 19, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("316L stainless"), QStringLiteral("Boutique full-coverage pattern — shortest flow path, the most even extraction / clearest cup.")},
+        {"Wafo", "Checkmate", {"wafo checkmate", "wafo blend"}, 58, 17, 19, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("316L stainless"), QStringLiteral("Intentionally irregular hole layout for a deliberately distinctive flavour.")},
 
         // --- E&B Lab (made by IMS; ridgeless competition, optional coating) ---
-        {"E&B Lab", "Superfine Competition", {"eb lab", "e&b lab", "eb lab competition", "e&b superfine"}, 58, 17, 19, WP::Straight, false, true, 715, 0, 24, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Ridgeless competition double with extra edge holes; optional nanotech coating.")},
+        {"E&B Lab", "Superfine Competition", {"eb lab", "e&b lab", "eb lab competition", "e&b superfine"}, 58, 17, 19, WP::Straight, true, FR::Standard, 715, 0, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Ridgeless competition double with extra edge holes; optional nanotech coating.")},
 
         // --- La Marzocco (current stock on LM machines is itself precision) ---
-        {"La Marzocco", "Advanced Precision", {"la marzocco advanced", "lm advanced precision", "la marzocco stock", "lm stock"}, 58, 16, 18, WP::Straight, false, true, 0, 0, 28, QStringLiteral("brushed stainless"), QStringLiteral("LM stock precision basket with digital-scan QC; fits Strada/Linea/GS3/Micra.")},
-        {"La Marzocco", "Strada (VST-developed)", {"la marzocco strada", "lm strada", "strada basket"}, 58, 16, 18, WP::Straight, false, true, 0, 0, 28, QStringLiteral("brushed stainless"), QStringLiteral("Older LM precision line co-developed with VST.")},
+        {"La Marzocco", "Advanced Precision", {"la marzocco advanced", "lm advanced precision", "la marzocco stock", "lm stock"}, 58, 16, 18, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("brushed stainless"), QStringLiteral("LM stock precision basket with digital-scan QC; fits Strada/Linea/GS3/Micra.")},
+        {"La Marzocco", "Strada (VST-developed)", {"la marzocco strada", "lm strada", "strada basket"}, 58, 16, 18, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("brushed stainless"), QStringLiteral("Older LM precision line co-developed with VST.")},
 
-        // --- Stock / OEM baskets (so the DB can describe 'what your machine
-        //     came with'). These are the non-precision stamped or pressurized
-        //     baskets common on prosumer and entry machines ---
-        {"Gaggia", "Classic Stock Double", {"gaggia double", "gaggia classic double", "gaggia stock"}, 58, 14, 16, WP::Tapered, false, false, 0, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Stock non-pressurized commercial double; shallow, so watch headspace above 16g.")},
-        {"Gaggia", "Classic Pressurized Double", {"gaggia pressurized", "gaggia dual wall"}, 58, 14, 18, WP::Tapered, true, false, 0, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Pressurized/dual-wall — fakes crema, grinder-forgiving, but defeats flow profiling.")},
-        {"Rancilio", "Silvia Stock Double", {"rancilio double", "silvia double", "rancilio stock"}, 58, 14, 16, WP::Tapered, false, false, 0, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Stock non-pressurized double; officially rated 16g, runs out of headspace above that.")},
-        {"Breville", "54mm Single-Wall Double", {"breville 54mm double", "sage 54mm double", "breville single wall"}, 54, 16, 19, WP::Tapered, false, false, 0, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Stock Breville/Sage 54mm single-wall double; needs a real grinder to dial in.")},
-        {"Breville", "54mm Dual-Wall Double", {"breville 54mm dual wall", "sage 54mm pressurized", "breville pressurized"}, 54, 16, 19, WP::Tapered, true, false, 0, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Stock Breville/Sage pressurized double; self-generates 9 bar, tolerant of pre-ground.")},
+        // --- MHW-3BOMBER (widely-sold budget precision basket; the common
+        //     VST/IMS alternative on Amazon. Brand states 58.5mm, 872 holes,
+        //     straight-flat bottom; hole Ø not brand-published) ---
+        {"MHW-3BOMBER", "Filter Basket DEX", {"mhw 3bomber", "mhw3bomber", "3bomber", "mhw dex", "bomber dex"}, 58, 15, 22, WP::Straight, true, FR::Standard, 872, 0, QStringLiteral("AISI 304 stainless"), QStringLiteral("Budget 58.5mm precision basket, 872 laser-cut holes; sold in 15/18/20/22g.")},
+
+        // --- Generic / unbranded catch-all (for a no-name or stock basket;
+        //     non-precision stamped, smaller open area → slower, variable) ---
+        {"Generic", "Other / Unbranded", {"generic basket", "stock basket", "stock double", "stamped basket", "unbranded basket"}, 58, 14, 18, WP::Tapered, false, FR::Restrictive, 0, 0, QStringLiteral("stamped stainless"), QStringLiteral("Unbranded single-wall stamped basket; non-precision, smaller open area, hole pattern varies basket-to-basket.")},
     };
     return entries;
 }
@@ -163,6 +186,17 @@ inline QString wallProfileName(WallProfile w)
     case WallProfile::Convex:   return QStringLiteral("convex");
     }
     return QStringLiteral("straight");
+}
+
+// Map a flow class to a short human/AI-readable word.
+inline QString flowRateName(FlowRate f)
+{
+    switch (f) {
+    case FlowRate::Restrictive: return QStringLiteral("restrictive");
+    case FlowRate::Standard:    return QStringLiteral("standard");
+    case FlowRate::Open:        return QStringLiteral("open");
+    }
+    return QStringLiteral("standard");
 }
 
 // Case-insensitive lookup by alias, longest-match-first (so "vst 18g ridgeless"
@@ -208,7 +242,7 @@ inline LookupResult lookup(const QString& rawBasketString)
         result.doseMinG = bestMatch->doseMinG;
         result.doseMaxG = bestMatch->doseMaxG;
         result.precision = bestMatch->precision;
-        result.pressurized = bestMatch->pressurized;
+        result.flow = bestMatch->flow;
         result.found = true;
     }
 
@@ -260,18 +294,19 @@ inline const BasketEntry* findEntryByAlias(const QString& raw)
 }
 
 // Build a compact, AI-facing summary of a basket's brewing-relevant traits,
-// e.g. "58mm straight-wall single-wall precision, 17-19g, 641 holes @300µm".
-// Empty/zero fields are omitted so unpublished specs don't read as zeros.
+// e.g. "58mm straight-wall precision, open flow, 17-19g, 641 holes @300µm".
+// Empty/zero fields are omitted so unpublished specs don't read as zeros, and
+// the "standard" flow class is omitted (it's the unremarkable default).
 inline QString summary(const BasketEntry& b)
 {
     QStringList parts;
     if (b.diameterMm > 0)
         parts << QString::number(b.diameterMm) + QStringLiteral("mm");
     parts << wallProfileName(b.wall) + QStringLiteral("-wall");
-    parts << (b.pressurized ? QStringLiteral("pressurized/dual-wall")
-                            : QStringLiteral("single-wall"));
     if (b.precision)
         parts << QStringLiteral("precision");
+    if (b.flow != FlowRate::Standard)
+        parts << flowRateName(b.flow) + QStringLiteral(" flow");
     if (b.doseMaxG > 0) {
         auto g = [](double v) {
             QString s = QString::number(v, 'f', 1);

--- a/src/core/basketaliases.h
+++ b/src/core/basketaliases.h
@@ -293,8 +293,9 @@ inline const BasketEntry* findEntryByAlias(const QString& raw)
     return r.found ? findEntry(r.brand, r.model) : nullptr;
 }
 
-// Build a compact, AI-facing summary of a basket's brewing-relevant traits,
-// e.g. "58mm straight-wall precision, open flow, 17-19g, 641 holes @300µm".
+// Build a compact, AI-facing summary of a basket's brewing-relevant traits.
+// e.g. the Pesado HE row renders as:
+//   "58mm, straight-wall, precision, open flow, 17-19g, 715 holes @300µm".
 // Empty/zero fields are omitted so unpublished specs don't read as zeros, and
 // the "standard" flow class is omitted (it's the unremarkable default).
 inline QString summary(const BasketEntry& b)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,12 @@ add_decenza_test(tst_dialing_helpers
     tst_dialing_helpers.cpp
 )
 
+# --- tst_basketaliases: basket registry data-integrity + lookup/summary
+# helpers (header-only target; mirrors the untested GrinderAliases sibling) ---
+add_decenza_test(tst_basketaliases
+    tst_basketaliases.cpp
+)
+
 # --- tst_mcptools_shots_helpers: detectorResults envelope reshape (issue #1012) ---
 add_decenza_test(tst_mcptools_shots_helpers
     tst_mcptools_shots_helpers.cpp

--- a/tests/tst_basketaliases.cpp
+++ b/tests/tst_basketaliases.cpp
@@ -1,0 +1,280 @@
+// Tests for the BasketAliases registry (src/core/basketaliases.h).
+//
+// Two kinds of coverage:
+//   1. Data-integrity sweep over allBaskets() — the registry is a long
+//      positional aggregate-init table, so a transposed/typo'd field compiles
+//      silently. These assertions catch that class of bug at test time.
+//   2. Pure helper logic — lookup() longest-match resolution + substring
+//      fallback, and summary() string formatting (the flow-omit, hole, and
+//      dose-trim rules). Formatting cases use CONSTRUCTED entries, not registry
+//      rows, so they don't break when the basket data is refined.
+
+#include <QTest>
+#include <QSet>
+#include "core/basketaliases.h"
+
+using namespace BasketAliases;
+
+class TstBasketAliases : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // Data integrity
+    void everyEntry_is58mm();
+    void everyEntry_hasSaneDoseRange();
+    void everyEntry_hasNonNegativeHoleSpecs();
+    void everyEntry_hasBrandAndModel();
+    void everyAlias_isLowercaseAndNonEmpty();
+    void aliases_areUniqueAcrossEntries();
+
+    // lookup()
+    void lookup_emptyOrWhitespace_returnsNotFound();
+    void lookup_unknown_returnsNotFound();
+    void lookup_exactAlias_resolves();
+    void lookup_substringFallback_resolves();
+    void lookup_longestMatchWins_acrossEntries();
+
+    // summary()
+    void summary_standardFlow_omitsFlowToken();
+    void summary_openFlow_includesFlowToken();
+    void summary_noHoleData_omitsHoleClause();
+    void summary_micronsOnly_rendersMicronHoles();
+    void summary_countAndMicrons_rendersBoth();
+    void summary_trimsDoseDecimals();
+    void summary_fullExample_matchesDocstring();
+
+    // brand/model surface + round-trip
+    void allBrands_uniqueAndSorted();
+    void findEntryByAlias_roundTrips();
+};
+
+// ---- Data integrity -------------------------------------------------------
+
+void TstBasketAliases::everyEntry_is58mm()
+{
+    for (const auto& b : allBaskets())
+        QVERIFY2(b.diameterMm == 58,
+                 qPrintable(QStringLiteral("%1 %2 is not 58mm").arg(b.brand, b.model)));
+}
+
+void TstBasketAliases::everyEntry_hasSaneDoseRange()
+{
+    for (const auto& b : allBaskets()) {
+        const QString id = QStringLiteral("%1 %2").arg(b.brand, b.model);
+        QVERIFY2(b.doseMinG > 0, qPrintable(id + QStringLiteral(": doseMinG must be > 0")));
+        QVERIFY2(b.doseMinG <= b.doseMaxG, qPrintable(id + QStringLiteral(": doseMinG > doseMaxG")));
+    }
+}
+
+void TstBasketAliases::everyEntry_hasNonNegativeHoleSpecs()
+{
+    for (const auto& b : allBaskets()) {
+        const QString id = QStringLiteral("%1 %2").arg(b.brand, b.model);
+        QVERIFY2(b.holeCount >= 0, qPrintable(id + QStringLiteral(": negative holeCount")));
+        QVERIFY2(b.holeDiameterMicrons >= 0, qPrintable(id + QStringLiteral(": negative holeDiameterMicrons")));
+    }
+}
+
+void TstBasketAliases::everyEntry_hasBrandAndModel()
+{
+    for (const auto& b : allBaskets()) {
+        QVERIFY(!b.brand.trimmed().isEmpty());
+        QVERIFY2(!b.model.trimmed().isEmpty(),
+                 qPrintable(QStringLiteral("%1 has empty model").arg(b.brand)));
+    }
+}
+
+void TstBasketAliases::everyAlias_isLowercaseAndNonEmpty()
+{
+    // lookup() lowercases its input, so an uppercase alias would never match.
+    for (const auto& b : allBaskets()) {
+        for (const auto& alias : b.aliases) {
+            const QString id = QStringLiteral("%1 %2 alias '%3'").arg(b.brand, b.model, alias);
+            QVERIFY2(!alias.trimmed().isEmpty(), qPrintable(id + QStringLiteral(" is empty")));
+            QVERIFY2(alias == alias.toLower(), qPrintable(id + QStringLiteral(" is not lowercase")));
+        }
+    }
+}
+
+void TstBasketAliases::aliases_areUniqueAcrossEntries()
+{
+    // A duplicated alias would make longest-match lookup order-dependent.
+    QSet<QString> seen;
+    for (const auto& b : allBaskets()) {
+        for (const auto& alias : b.aliases) {
+            QVERIFY2(!seen.contains(alias),
+                     qPrintable(QStringLiteral("duplicate alias '%1' (in %2 %3)").arg(alias, b.brand, b.model)));
+            seen.insert(alias);
+        }
+    }
+}
+
+// ---- lookup() -------------------------------------------------------------
+
+void TstBasketAliases::lookup_emptyOrWhitespace_returnsNotFound()
+{
+    QVERIFY(!lookup(QString()).found);
+    QVERIFY(!lookup(QStringLiteral("")).found);
+    QVERIFY(!lookup(QStringLiteral("   ")).found);
+}
+
+void TstBasketAliases::lookup_unknown_returnsNotFound()
+{
+    QVERIFY(!lookup(QStringLiteral("totally-not-a-basket-zzz")).found);
+}
+
+void TstBasketAliases::lookup_exactAlias_resolves()
+{
+    const auto r = lookup(QStringLiteral("vst 18g"));
+    QVERIFY(r.found);
+    QCOMPARE(r.brand, QStringLiteral("VST"));
+    QCOMPARE(r.model, QStringLiteral("18g Double"));
+}
+
+void TstBasketAliases::lookup_substringFallback_resolves()
+{
+    // No exact alias equals this; the second (contains) pass should still hit.
+    const auto r = lookup(QStringLiteral("VST 18g (ridgeless)"));
+    QVERIFY(r.found);
+    QCOMPARE(r.brand, QStringLiteral("VST"));
+    QCOMPARE(r.model, QStringLiteral("18g Double"));
+}
+
+void TstBasketAliases::lookup_longestMatchWins_acrossEntries()
+{
+    // "pesado" -> HE High Extraction; "pesado ep" -> EP Electro-Polished.
+    // A string containing both must resolve to the LONGER alias (EP).
+    const auto ep = lookup(QStringLiteral("my pesado ep basket"));
+    QVERIFY(ep.found);
+    QCOMPARE(ep.brand, QStringLiteral("Pesado"));
+    QCOMPARE(ep.model, QStringLiteral("EP Electro-Polished"));
+
+    // Bare "pesado" still resolves to the HE entry.
+    const auto he = lookup(QStringLiteral("pesado"));
+    QVERIFY(he.found);
+    QCOMPARE(he.model, QStringLiteral("HE High Extraction"));
+}
+
+// ---- summary() ------------------------------------------------------------
+
+void TstBasketAliases::summary_standardFlow_omitsFlowToken()
+{
+    BasketEntry b{};
+    b.diameterMm = 58;
+    b.wall = WallProfile::Straight;
+    b.flow = FlowRate::Standard;
+    b.doseMinG = 18;
+    b.doseMaxG = 20;
+    const QString s = summary(b);
+    QVERIFY2(!s.contains(QStringLiteral("flow")), qPrintable(s));
+    QCOMPARE(s, QStringLiteral("58mm, straight-wall, 18-20g"));
+}
+
+void TstBasketAliases::summary_openFlow_includesFlowToken()
+{
+    BasketEntry b{};
+    b.diameterMm = 58;
+    b.flow = FlowRate::Open;
+    b.doseMinG = 17;
+    b.doseMaxG = 19;
+    QVERIFY(summary(b).contains(QStringLiteral("open flow")));
+}
+
+void TstBasketAliases::summary_noHoleData_omitsHoleClause()
+{
+    BasketEntry b{};
+    b.diameterMm = 58;
+    b.doseMinG = 18;
+    b.doseMaxG = 20;
+    b.holeCount = 0;
+    b.holeDiameterMicrons = 0;
+    QVERIFY(!summary(b).contains(QStringLiteral("hole")));
+}
+
+void TstBasketAliases::summary_micronsOnly_rendersMicronHoles()
+{
+    BasketEntry b{};
+    b.diameterMm = 58;
+    b.doseMinG = 18;
+    b.doseMaxG = 20;
+    b.holeCount = 0;
+    b.holeDiameterMicrons = 300;
+    const QString um = QString(QChar(0x00B5)) + QStringLiteral("m");  // "µm"
+    QVERIFY2(summary(b).endsWith(QStringLiteral("300") + um + QStringLiteral(" holes")),
+             qPrintable(summary(b)));
+}
+
+void TstBasketAliases::summary_countAndMicrons_rendersBoth()
+{
+    BasketEntry b{};
+    b.diameterMm = 58;
+    b.doseMinG = 18;
+    b.doseMaxG = 21;
+    b.holeCount = 641;
+    b.holeDiameterMicrons = 300;
+    const QString um = QString(QChar(0x00B5)) + QStringLiteral("m");
+    QVERIFY2(summary(b).endsWith(QStringLiteral("641 holes @300") + um), qPrintable(summary(b)));
+}
+
+void TstBasketAliases::summary_trimsDoseDecimals()
+{
+    BasketEntry b{};
+    b.diameterMm = 58;
+    b.doseMinG = 14;
+    b.doseMaxG = 16;
+    const QString s = summary(b);
+    QVERIFY2(s.contains(QStringLiteral("14-16g")), qPrintable(s));
+    QVERIFY2(!s.contains(QStringLiteral(".0")), qPrintable(s));
+}
+
+void TstBasketAliases::summary_fullExample_matchesDocstring()
+{
+    // The exact rendering the summary() docstring promises for the Pesado HE row.
+    BasketEntry b{};
+    b.diameterMm = 58;
+    b.wall = WallProfile::Straight;
+    b.precision = true;
+    b.flow = FlowRate::Open;
+    b.doseMinG = 17;
+    b.doseMaxG = 19;
+    b.holeCount = 715;
+    b.holeDiameterMicrons = 300;
+    const QString um = QString(QChar(0x00B5)) + QStringLiteral("m");
+    QCOMPARE(summary(b),
+             QStringLiteral("58mm, straight-wall, precision, open flow, 17-19g, 715 holes @300") + um);
+}
+
+// ---- brand/model surface --------------------------------------------------
+
+void TstBasketAliases::allBrands_uniqueAndSorted()
+{
+    const QStringList brands = allBrands();
+    QVERIFY(!brands.isEmpty());
+
+    // Unique
+    QCOMPARE(QSet<QString>(brands.cbegin(), brands.cend()).size(), brands.size());
+
+    // Sorted case-insensitively (the order allBrands() promises)
+    QStringList sortedCopy = brands;
+    sortedCopy.sort(Qt::CaseInsensitive);
+    QCOMPARE(brands, sortedCopy);
+}
+
+void TstBasketAliases::findEntryByAlias_roundTrips()
+{
+    const BasketEntry* e = findEntryByAlias(QStringLiteral("decent stock"));
+    QVERIFY(e != nullptr);
+    QCOMPARE(e->brand, QStringLiteral("Decent"));
+    QCOMPARE(e->model, QStringLiteral("Ridgeless 18g"));
+
+    // Composition contract: findEntryByAlias agrees with lookup().
+    const auto r = lookup(QStringLiteral("decent stock"));
+    QVERIFY(r.found);
+    QCOMPARE(e->brand, r.brand);
+    QCOMPARE(e->model, r.model);
+}
+
+QTEST_APPLESS_MAIN(TstBasketAliases)
+
+#include "tst_basketaliases.moc"


### PR DESCRIPTION
Builds on the baskets registry (`src/core/basketaliases.h`) shipped in #1341, refining it toward two goals: **better data for the AI advisor** and **helping a user recreate a shot across equipment changes**.

## What changed
- **Scoped to 58mm only** (the DE1 group size): removed the 54mm Breville baskets and the Graph 54→46mm step-down. Step-downs that fit a 58mm group (S-Works, Graph 58→46, Decent waisted, Normcore convex) stay.
- **Added a relative `FlowRate` class** — `Restrictive` / `Standard` / `Open` — the cross-basket "how fast does it flow at a fixed grind" signal. It can't be read off a single shot (flow on a fixed basket is constant), but it lets the advisor reason when a user **switches baskets**: e.g. a Weber Unibasket (`Open`, holes to the edge) flows faster than a Decent stock double (`Standard`), so moving to it means grinding a touch finer. Deliberately coarse — it gives the *direction* of a grind change, not a magnitude (magnitude comes from per-basket shot history).
- **Removed `pressurized` entirely** (field, entry, and bucket): dual-wall baskets self-regulate back-pressure and defeat the DE1's flow/pressure profiling, so they have no place on a Decent machine.
- **Dropped `depthMm`** (redundant with dose range).
- **Added** MHW-3BOMBER DEX and the budget S-Works Step Down Stamped; **replaced** off-machine stock entries (Gaggia/Rancilio) with a single `Generic` catch-all.

## Flow-class assignments
- **Open** (holes-to-edge / full-coverage): Weber Unibasket 16/20/24/28g, Pesado HE, Wafo Spirit
- **Restrictive** (fine filtration / low open area): IMS SuperFine (170µm), Normcore 0.18mm Reduced Flow, Generic
- **Standard**: everything else (35)

Design note: `flow` means filtration openness (the holes); step-down *geometry* is carried orthogonally by `wall = Stepped`.

## Scope / testing
- **44 entries, all 58mm.** Header-only data file (`BasketAliases` namespace, mirrors `GrinderAliases`).
- **No consumers wired yet** — the SettingsDye bridge, vendor→model picker UI, and MCP/dialing-context exposure are follow-ups. Nothing `#include`s this header, so there's no behavior change and nothing new to compile in the app build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)