### PR TITLE
Add baskets to equipment packages (identity, picker, AI/MCP)

### DIFF
--- a/openspec/changes/add-basket-equipment/.openspec.yaml
+++ b/openspec/changes/add-basket-equipment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/add-basket-equipment/design.md
+++ b/openspec/changes/add-basket-equipment/design.md
@@ -1,0 +1,150 @@
+# Design — Basket as an Equipment Component
+
+## Context
+
+`add-equipment-packages` modeled a package as a container of typed `EquipmentItem`
+rows keyed by `kind`, with the grinder as the only kind today and the explicit
+intent that baskets/tampers slot in as new kinds with no schema migration. PR #1344
+landed `BasketAliases` — a curated, AI-first basket DB — with no consumers. This
+change connects the two. The driving goal is reproducibility ("what gear made this
+coffee") and AI dialing help, not dose management.
+
+## Decision 1 — Basket lives *inside* the package (two baskets = two packages)
+
+**Chosen:** the basket is a second `equipment_items` row owned by the package, and
+it participates in the package's identity. Rejected alternatives: (B) basket as an
+independent switchable axis with its own `shots.basket_id`; (C) basket on the
+coffee bag.
+
+**Why:**
+- **Reproducibility is free.** `shots.equipment_id` already snapshots the package,
+  so capturing the package's basket needs **no new shot column and no migration**.
+  B and C both add a snapshot column + migration to buy only a cleaner inventory
+  list — a poor trade against the north star.
+- **Dial memory becomes `(grinder + basket)`-scoped**, which is more correct: a
+  restrictive basket wants a finer grind, so remembering the dial per gear-combo is
+  the right behavior, and it falls out of the package owning both.
+- It is what the storage was explicitly designed for and what the user asked for.
+
+**Accepted cost:** N grinders × M baskets is combinatorial. Mitigated because most
+users run 1–3 baskets, the existing MRU + identity-dedup machinery surfaces the
+recent combo, the basket is **optional** (grinder-only packages remain valid), and
+inventory cards can group by grinder later if the list gets noisy. Each distinct
+combo genuinely *is* a distinct reproducible config.
+
+## Decision 2 — Identity widens to `(grinder + basket)`; CoW inherits it
+
+The copy-on-write engine dedups/forks on package identity. Today that key is the
+grinder's `brand/model/burrs`. It widens to include the basket's `brand/model`
+(with "no basket" as a real, distinct value):
+
+```
+  switch basket on a USED package ──► fork a new package (copy-on-write)
+  switch back to a prior combo    ──► dedup matches → select the old package
+  edit basket on an UNUSED package ─► edit in place
+```
+
+No new control flow — only the comparison key in `findPackageBy…IdentityStatic`
+and `supersedeOrEdit…Static` grows. This is the whole of the storage-engine change.
+
+## Decision 3 — Basket specs are derived at read time, not cached
+
+A grinder item stores `burrs` (user free-text) + `rpmCapable` (derived). A basket
+has **no** free-text sub-field — its identity *is* `brand + model` — and every spec
+(wall profile, relative flow, precision, dose range, material) is a pure function of
+that identity via `BasketAliases::findEntry()`. So the basket item persists only
+`kind/brand/model` with an empty `attrs`, and resolution derives the specs on load
+(mirroring `rpmCapable` derivation). A custom/off-registry basket is a bare name
+with unknown specs — acceptable; the advisor simply gets less to reason with.
+
+Rejected: caching specs in `attrs` at write time. It duplicates the registry,
+risks drift when the curated DB is refined (as #1344 just did), and buys nothing —
+the lookup is a cheap in-memory vector scan.
+
+## Decision 4 — The model picker needs a differentiator subtitle (new primitive)
+
+The picker is **vendor-first, two-level** (brand → model): size lives in the model
+name ("Ridgeless 18g"), so there is no third level analogous to the grinder's burrs.
+But a bare-string model list is **insufficient**, proven by two real cases in the
+shipped DB:
+
+- **S-Works (6 models)** — Convex/Tapered/Step-Down/Stamped/Titanium billets are
+  jargon; the name alone doesn't tell a user what differs. Differentiator: wall
+  profile + material.
+- **Decent (10 models, the trap)** — *Slightly* Waisted **14g** and *Very* Waisted
+  **14g** have the **same dose** (overlapping 12–15g / 12–16g ranges); only the
+  taper *degree* separates them. A subtitle that echoed dose would leave them
+  indistinguishable. Differentiator: effective bed Ø + body.
+
+This yields two regimes within one brand:
+
+| Within-brand differentiator | Subtitle should lead with |
+|---|---|
+| dose-indexed (Decent Ridgeless 15/18/20/22) | dose (already in the name; subtitle is confirmatory) |
+| taper-degree (Decent Waisted trio) | effective bed Ø + body — **never** dose |
+| wall/material (S-Works billets) | wall profile + material |
+
+**Decision:** the model row renders `name` + a **differentiator subtitle** sourced
+from `summary()`. Baseline: render `summary()` uniformly (safe everywhere, never
+hides the differentiator). Optimization (polish, not required): order the subtitle
+to lead with whatever varies within the brand. `SuggestionField` is extended to
+optionally accept `[{value, description}]`; the brand level stays a plain typeahead
+(~15 vendor names need no subtitle).
+
+**Optional refinement:** group a brand's models by sub-family (Decent →
+`Ridgeless / Ridged / Waisted`; S-Works → billet shapes / stamped). Decent at 10 is
+the count ceiling and the brand that earns grouping; it also gives the Waisted
+adjectives a shared scale. Not required for v1.
+
+## Decision 5 — AI context: fold the basket into `currentBean`
+
+The basket is pure identity + derived specs; unlike `grinderContext` it has no
+"observed settings" to aggregate across history. So it folds into the existing
+`currentBean` block (which already carries grinder identity) rather than a separate
+`basketContext` block:
+
+```jsonc
+"currentBean": {
+  // …existing bean + grinder fields…
+  "basket": {
+    "brand": "Weber Workshops",
+    "model": "Unibasket 18g",
+    "wallProfile": "straight",      // human-readable string, not a code
+    "relativeFlow": "open",         // THE cross-basket signal
+    "precision": true,
+    "doseRangeG": { "min": 17, "max": 19 }
+  }
+}
+```
+
+- **`relativeFlow` leads the reasoning value.** It is coarse and directional by
+  design (Restrictive/Standard/Open) — it gives the advisor the *direction* of a
+  grind change across baskets, never a magnitude. Reliable magnitude still comes
+  from the user's own per-combo shot history (the `equipment_id` linkage), not a
+  spec number.
+- **`doseRangeG` enables a sanity signal** — the advisor can flag "22 g in a basket
+  rated 17–19 g." Cheap, high-value, uniquely enabled by this data.
+- Omit the whole sub-object when the package has no basket or the basket is custom
+  (unknown specs) rather than fabricating fields.
+
+## Relationship to `add-basket-settings`
+
+`add-basket-settings` is a stale pre-equipment-packages proposal framing the basket
+as the home for *dose*. This change deliberately does **not** take that on: dose
+ownership stays with the bean/recipe per the current architecture, and the basket's
+dose *range* here is a read-only advisory only. `add-basket-settings` should be
+archived/withdrawn or re-scoped to "default dose" separately; it is not a dependency.
+
+## Risks / Open Questions
+
+- **S-Works flow-pattern SKUs.** The "Billet Basket" entry collapses
+  Reduced/Standard/High flow into its notes, exposing only `Standard`. If users own
+  different flow patterns, those arguably deserve separate registry entries — which
+  would make the differentiator subtitle *mandatory* to tell them apart. DB-owner
+  call (the data was just refined in #1344); the subtitle design makes that
+  granularity survivable but this change does not edit the data.
+- **Auto-name of a grinder+basket package.** The package name default is
+  `"{brand} {model}"` (grinder). Whether the card title should incorporate the
+  basket ("DF64 · VST 18g") or keep grinder-as-title with the basket on a sub-line
+  is a display choice settled in `equipment-inventory-view`; the lean is
+  grinder-title + basket sub-line (mirrors burrs).

--- a/openspec/changes/add-basket-equipment/proposal.md
+++ b/openspec/changes/add-basket-equipment/proposal.md
@@ -1,0 +1,128 @@
+## Why
+
+Equipment packages (`add-equipment-packages`) shipped the grinder as a package's
+first component and were explicitly built to take more component kinds with **no
+schema migration** — the `EquipmentItem.kind` axis and the "future kinds (basket,
+tamper, …)" note in `equipmentstorage.h`. A recent PR (#1344) landed a curated,
+AI-first basket database (`src/core/basketaliases.h`: 31 entries, `WallProfile`,
+relative `FlowRate`, dose ranges, a `summary()` prose helper) — but it has **zero
+consumers**. It is a foundation waiting to be wired.
+
+This change wires baskets in as the package's **second component kind**. The goal
+is narrow and concrete: let a user record *which basket they used* so a shot can be
+reproduced, and feed that basket's identity + physical characteristics to the AI
+advisor and MCP so dialing advice can reason across baskets. The single most
+valuable AI signal — the **relative flow class** — cannot be read off one shot
+(flow on a fixed basket is constant) but lets the advisor steer a grind change when
+a user switches baskets or recreates a shot on different gear.
+
+The basket is part of the package's **identity**: two baskets = two packages. This
+is the user's explicit decision and the clean one — it makes `shots.equipment_id`
+capture the grinder *and* basket for free (no new shot column), and makes the
+package's "last dial" memory `(grinder + basket)`-scoped, which is *more* correct
+(a restrictive basket wants a finer grind).
+
+This supersedes the dose-centric framing of the stale `add-basket-settings`
+proposal: dose ownership stays with the bean/recipe per the existing architecture;
+this change is about basket *identity as equipment*, not dose.
+
+## What Changes
+
+- **Basket as an optional second `equipment_items` row** (`kind="basket"`, `brand`,
+  `model`, near-empty `attrs`). A package owns at most one basket item; a package
+  may have **no** basket (backward-compatible — every existing package is
+  grinder-only, and many users won't set one). No DB schema migration: the
+  `equipment_items` table already supports new kinds.
+- **Basket specs are derived, not stored.** Wall profile, relative flow, precision,
+  dose range, material all resolve from `BasketAliases::findEntry(brand, model)` at
+  read time — exactly how the grinder item derives `rpmCapable`. A *custom*
+  (off-registry) basket is a name with unknown specs. The basket `attrs` blob has
+  no free-text sub-field analogous to the grinder's `burrs`.
+- **Package identity widens from `(grinder)` to `(grinder + basket)`.** The
+  copy-on-write dedup/fork engine (`findPackageBy…IdentityStatic`,
+  `supersedeOrEdit…Static`) compares the basket identity too, so switching a basket
+  on a used package forks a new package, and switching back to a prior combo dedups
+  to the existing one. "No basket" is a distinct identity value.
+- **Switch Equipment dialog gains a basket section** — a **vendor-first, two-level**
+  (brand → model) picker mirroring the grinder flow, backed by new
+  `SettingsDye.knownBasketBrands()` / `knownBasketModels(brand)` registry bridges.
+  Basket selection is **optional** (a "no basket" / clear choice exists).
+- **New suggestion-row primitive: a differentiator subtitle.** Basket models within
+  a brand are similar (S-Works' Convex/Tapered/Stamped billets; Decent's *two*
+  "14g" Waisted siblings whose doses overlap), so the model row MUST render a
+  second line carrying the axis that actually separates siblings (from
+  `summary()`), never a bare name and never a mere dose echo. `SuggestionField` is
+  extended to optionally accept `[{value, description}]` and render the subtitle.
+- **Equipment window surfaces the basket** — `EquipmentCard` shows a basket line
+  (below the grinder/burrs), and `EquipmentInfoDialog` adds a basket `InfoRow`.
+- **Dialing context gains a basket sub-object** — `currentBean` (and the shot
+  snapshot it resolves through `equipment_id`) gains
+  `basket: { brand, model, wallProfile, relativeFlow, precision, doseRangeG }`,
+  resolved through the package's basket item. The relative flow class leads; the
+  dose range enables a "dosing outside this basket's rated range" sanity signal.
+- **MCP equipment surfaces expose the basket** — the `equipment_*` tools read and
+  write the basket identity alongside the grinder, and dialing tools include the
+  basket sub-object. Field naming follows the MCP unit/string conventions
+  (`doseRangeG`, human-readable `wallProfile` / `relativeFlow` strings, never codes).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `equipment-package-model`: basket as an optional second `equipment_items` kind;
+  identity widened to `(grinder + basket)` for dedup/copy-on-write; specs
+  derive-at-read from `BasketAliases`; `SettingsDye` basket resolution + bridge
+  methods.
+- `switch-equipment-dialog`: optional vendor-first two-level basket picker; the
+  differentiator-subtitle suggestion row; optional family grouping within a brand.
+- `equipment-inventory-view`: `EquipmentCard` + `EquipmentInfoDialog` render the
+  package's basket.
+- `dialing-context-payload`: `currentBean`/shot resolution gains a basket
+  sub-object (identity + derived specs); dose-range sanity exposure.
+- `mcp-server`: `equipment_*` tools read/write the basket; dialing tools surface
+  the basket sub-object, following MCP data conventions.
+
+## Impact
+
+**Dependency:** builds on `add-equipment-packages` (the `equipment_packages` /
+`equipment_items` tables, `EquipmentStorage`, `SettingsDye` equipment resolution,
+`SwitchEquipmentDialog`, `EquipmentCard`/`EquipmentInfoDialog`). No new tables and
+no schema migration — only new `equipment_items` rows of a new kind.
+
+**C++ / core:**
+- `src/core/basketaliases.h`: gains the consumers it was built for (no data edit
+  required; an optional `summary()`-style differentiator helper may be added).
+- `src/core/settings_dye.{h,cpp}`: `knownBasketBrands()` / `knownBasketModels(brand)`
+  Q_INVOKABLE bridges; `dyeBasketBrand/Model` (+ derived display) resolved through
+  the active package's basket item; switch/create/update carry the basket identity.
+- `src/history/equipmentstorage.{h,cpp}`: create/update write an optional
+  `kind="basket"` item; `findPackageBy…IdentityStatic` / `supersedeOrEdit…Static`
+  widen the dedup/fork key to include the basket; `EquipmentPackageView` /
+  `toVariantMap()` resolve and flatten the basket item; device-import copies basket
+  items.
+- `src/history/shotprojection.{h,cpp}` + history queries: resolve basket identity +
+  derived specs via the `equipment_id` JOIN (no new shot column — the snapshot is
+  already the package).
+
+**QML:**
+- `qml/components/SwitchEquipmentDialog.qml`: optional basket brand/model section.
+- `qml/components/SuggestionField.qml`: optional per-suggestion description subtitle.
+- `qml/components/EquipmentCard.qml` + `qml/components/EquipmentInfoDialog.qml`:
+  basket line / `InfoRow`.
+- New translation keys (`equipment.dialog.basketBrand`, `…basketModel`,
+  `equipment.card.basket`, `equipment.info.basket`), accessibility attributes.
+
+**AI / MCP:**
+- `src/ai/dialing_blocks.{h,cpp}`: `currentBean` block gains the basket sub-object;
+  optional dose-range sanity field.
+- `src/mcp/mcptools_dialing.cpp` + the `equipment_*` write tools: surface and accept
+  the basket identity following MCP unit/string conventions.
+
+## Non-Goals
+
+- **Dose ownership.** Dose stays bean/recipe-scoped; the basket's dose *range* is a
+  read-only advisory signal only.
+- **Visualizer upload.** Visualizer has no basket field; upload shape is unchanged.
+- **Pressurized / dual-wall baskets.** Deliberately excluded from the registry (they
+  defeat DE1 flow/pressure profiling).
+- **Tamper / portafilter / puck screen.** Future kinds; out of scope here.

--- a/openspec/changes/add-basket-equipment/specs/dialing-context-payload/spec.md
+++ b/openspec/changes/add-basket-equipment/specs/dialing-context-payload/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Dialing context SHALL expose the basket via the equipment package
+The dialing context SHALL include a `basket` sub-object in the `currentBean` block
+(and in the shot snapshot it resolves), populated through the package's basket item
+via `equipment_id` — there SHALL be no separate shot-level basket column. The
+sub-object SHALL carry `brand`, `model`, and the registry-derived `wallProfile`,
+`relativeFlow`, `precision`, and `doseRangeG`. When the resolved package has no
+basket, or the basket is custom with unknown specs, the absent fields SHALL be
+omitted rather than fabricated.
+
+#### Scenario: Basket sub-object present
+- **WHEN** the resolved shot's package has a registry basket
+- **THEN** `currentBean.basket` SHALL include brand, model, wallProfile, relativeFlow, precision, and doseRangeG
+
+#### Scenario: No basket on the package
+- **WHEN** the resolved shot's package has no basket item
+- **THEN** the `basket` sub-object SHALL be omitted
+
+#### Scenario: Custom basket with unknown specs
+- **WHEN** the resolved basket does not match the registry
+- **THEN** `currentBean.basket` SHALL include brand/model and omit the unknown derived spec fields
+
+### Requirement: Relative flow class SHALL be expressed as a directional string
+The basket's `relativeFlow` SHALL be a human-readable string
+(`"restrictive"` / `"standard"` / `"open"`), conveying the direction of a
+cross-basket grind change, not a magnitude. The payload SHALL NOT present it as an
+ordered numeric scale.
+
+#### Scenario: Flow class string
+- **WHEN** the basket sub-object is emitted
+- **THEN** `relativeFlow` SHALL be one of the directional strings, not a numeric code
+
+### Requirement: Dose range SHALL be available as an advisory sanity signal
+The basket sub-object SHALL expose the basket's recommended dose range
+(`doseRangeG: { min, max }`) so the advisor can flag a dose that falls outside the
+basket's rated range. This is advisory only and SHALL NOT change dose ownership
+(dose remains bean/recipe-scoped).
+
+#### Scenario: Dose outside the rated range is detectable
+- **WHEN** the shot's dose is above the basket's `doseRangeG.max`
+- **THEN** the payload SHALL carry the range such that the advisor can detect the mismatch

--- a/openspec/changes/add-basket-equipment/specs/equipment-inventory-view/spec.md
+++ b/openspec/changes/add-basket-equipment/specs/equipment-inventory-view/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: The equipment card SHALL display the package's basket
+`EquipmentCard` SHALL show the package's basket on its own line (below the grinder
+title / burrs), using the same typography and secondary-color convention as the
+burrs line. When a package has no basket, the basket line SHALL be omitted (not
+shown blank). The grinder SHALL remain the card title; the basket SHALL be a
+subordinate line.
+
+#### Scenario: Card with a basket
+- **WHEN** a package has a basket item
+- **THEN** the card SHALL render a basket line showing the basket brand + model
+
+#### Scenario: Card with no basket
+- **WHEN** a package has no basket item
+- **THEN** the card SHALL omit the basket line entirely
+
+### Requirement: The equipment info dialog SHALL include the basket
+`EquipmentInfoDialog` SHALL add a basket `InfoRow` (label + value) showing the
+basket identity, placed with the other equipment rows. When no basket is set, the
+row SHALL be omitted.
+
+#### Scenario: Info dialog shows the basket
+- **WHEN** the info dialog opens for a package with a basket
+- **THEN** it SHALL include a basket row showing the basket brand + model

--- a/openspec/changes/add-basket-equipment/specs/equipment-package-model/spec.md
+++ b/openspec/changes/add-basket-equipment/specs/equipment-package-model/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: A package MAY own an optional basket component
+An equipment package SHALL be able to own at most one `equipment_items` row of
+`kind="basket"` (`brand`, `model`), in addition to its grinder item. A package with
+no basket item SHALL remain valid (grinder-only packages, including all packages
+that predate this change, are unaffected). Adding a basket SHALL NOT require a DB
+schema migration — it is a new row of an existing kind.
+
+#### Scenario: Package created with a grinder and a basket
+- **WHEN** a package is created with a grinder identity and a basket identity
+- **THEN** the package SHALL own one `kind="grinder"` item and one `kind="basket"` item
+- **AND** the package view SHALL resolve and expose both
+
+#### Scenario: Package created with no basket
+- **WHEN** a package is created with a grinder identity and no basket
+- **THEN** the package SHALL own only the grinder item
+- **AND** the package view SHALL expose an empty/absent basket without error
+
+### Requirement: Basket specs SHALL be derived from the registry, not stored
+The basket item SHALL persist only `kind`, `brand`, and `model` (empty `attrs`).
+Its physical characteristics — wall profile, relative flow class, precision flag,
+dose range, material — SHALL be derived at read time from
+`BasketAliases::findEntry(brand, model)`, mirroring how the grinder item derives
+`rpmCapable`. A basket whose identity does not match the registry (a custom basket)
+SHALL resolve with unknown specs and SHALL NOT block creation.
+
+#### Scenario: Registry basket resolves specs
+- **WHEN** a package's basket item is `{brand: "VST", model: "18g"}` and that entry exists in the registry
+- **THEN** resolving the package SHALL expose the registry's wall profile, relative flow, precision, dose range, and material
+
+#### Scenario: Custom basket resolves with unknown specs
+- **WHEN** a package's basket item does not match any registry entry
+- **THEN** resolving the package SHALL expose the basket brand/model with specs marked unknown/absent rather than fabricated
+
+### Requirement: Package identity SHALL include the basket
+The package identity used for dedup and copy-on-write SHALL be the tuple of the
+grinder identity (`brand/model/burrs`) **and** the basket identity (`brand/model`),
+where "no basket" is a distinct identity value. Two packages that share a grinder
+but differ in basket (or in basket-vs-no-basket) SHALL be distinct packages.
+
+#### Scenario: Switching basket on a used package forks
+- **WHEN** a package that has recorded shots has its basket changed to a different basket
+- **THEN** a new package SHALL be forked under copy-on-write (the old package preserved, `supersededBy` set), exactly as for a grinder identity edit
+
+#### Scenario: Switching back to a prior combo dedups
+- **WHEN** the user returns to a previously used grinder+basket combination
+- **THEN** the existing matching package SHALL be selected rather than a duplicate created
+
+#### Scenario: Editing basket on an unused package edits in place
+- **WHEN** a package with no recorded shots has its basket changed
+- **THEN** the package SHALL be edited in place (same id, no fork)
+
+### Requirement: SettingsDye SHALL bridge the basket registry and resolve the active basket
+`SettingsDye` SHALL expose `knownBasketBrands()` and `knownBasketModels(brand)`
+(registry-backed, plus distinct values from history where applicable) for the
+picker, and SHALL resolve the active package's basket identity for display. The
+basket identity SHALL be carried through create/update/switch alongside the grinder
+identity.
+
+#### Scenario: Basket suggestions sourced from the registry
+- **WHEN** the picker requests basket brands, then models for a chosen brand
+- **THEN** `knownBasketBrands()` SHALL return the registry's sorted unique brands
+- **AND** `knownBasketModels(brand)` SHALL return that brand's models
+
+### Requirement: Device import SHALL carry basket items
+Device-to-device equipment import SHALL copy `kind="basket"` items alongside grinder
+items when importing packages, preserving the package's basket identity in the
+destination.
+
+#### Scenario: Imported package retains its basket
+- **WHEN** a package with a basket item is imported from a source database
+- **THEN** the destination package SHALL own an equivalent basket item

--- a/openspec/changes/add-basket-equipment/specs/mcp-server/spec.md
+++ b/openspec/changes/add-basket-equipment/specs/mcp-server/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Equipment MCP tools SHALL read and write the basket identity
+The MCP `equipment_*` tools SHALL include the package's basket identity
+(`brand`, `model`) in equipment reads, and SHALL accept an optional basket identity
+when creating or updating a package, alongside the grinder identity. Omitting the
+basket SHALL leave a package grinder-only. Basket edits SHALL flow through the same
+package-identity (dedup/fork) rules as grinder edits.
+
+#### Scenario: Equipment read includes the basket
+- **WHEN** an MCP equipment read resolves a package that has a basket
+- **THEN** the response SHALL include the basket brand and model
+
+#### Scenario: Equipment write sets a basket
+- **WHEN** an MCP equipment write supplies a basket identity
+- **THEN** the package SHALL gain a `kind="basket"` item subject to the identity rules
+
+### Requirement: MCP basket fields SHALL follow the data conventions
+Basket fields exposed over MCP SHALL follow the project MCP conventions: dose range
+named with its unit (`doseRangeG`), and `wallProfile` / `relativeFlow` / `precision`
+expressed as human-readable strings/booleans rather than numeric codes. Derived
+specs SHALL be omitted when unknown (custom basket) rather than zero-filled.
+
+#### Scenario: Basket specs are LLM-legible
+- **WHEN** the MCP dialing context emits the basket sub-object
+- **THEN** `wallProfile` and `relativeFlow` SHALL be readable strings and the dose range SHALL be unit-suffixed (`doseRangeG`)

--- a/openspec/changes/add-basket-equipment/specs/switch-equipment-dialog/spec.md
+++ b/openspec/changes/add-basket-equipment/specs/switch-equipment-dialog/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: The dialog SHALL offer an optional vendor-first basket picker
+The Switch Equipment dialog SHALL provide a basket section, mirroring the grinder
+flow, that is **vendor-first and two-level**: the user picks a basket brand, then a
+basket model (size is part of the model name; there is no third level analogous to
+burrs). Basket selection SHALL be **optional** — the dialog SHALL provide a clear
+"no basket" choice, and a package MAY be created or saved with no basket.
+
+#### Scenario: Pick a basket brand then model
+- **WHEN** the user opens the basket section and selects a brand
+- **THEN** the model field SHALL offer that brand's models from `knownBasketModels(brand)`
+- **AND** selecting a model SHALL set the package's basket identity
+
+#### Scenario: Create a package without a basket
+- **WHEN** the user leaves the basket section empty (or clears it)
+- **THEN** the package SHALL be created/saved with a grinder item and no basket item
+
+### Requirement: The basket model row SHALL render a differentiator subtitle
+The basket model picker SHALL render, per suggestion, a second line (derived from
+the basket's `summary()`) describing the axis that distinguishes siblings, not a
+bare model name — because basket models within a brand are often similar and may
+share a dose. The subtitle SHALL surface the functional differentiator (e.g. wall
+profile / effective bed diameter / material), and SHALL NOT reduce to a mere dose
+echo where dose does not distinguish the models.
+
+#### Scenario: Same-dose siblings remain distinguishable
+- **WHEN** a brand offers two models with overlapping dose ranges that differ only by another axis (e.g. two "14g" stepped baskets differing in taper degree)
+- **THEN** each model row SHALL display a subtitle that distinguishes them by that axis (e.g. effective bed diameter / body), not by dose alone
+
+#### Scenario: Jargon model names are explained
+- **WHEN** a brand offers models whose names are jargon (e.g. "Convex Billet", "Tapered Billet")
+- **THEN** each model row SHALL display a subtitle conveying the wall profile and material
+
+### Requirement: SuggestionField SHALL support an optional per-suggestion description
+`SuggestionField` SHALL accept suggestions as either plain strings (current
+behavior, used by the brand level and existing grinder fields) or `{value,
+description}` entries, rendering the description as a secondary line in the dropdown
+row. Accessibility metadata SHALL incorporate the description so it is announced.
+
+#### Scenario: Description rendered and announced
+- **WHEN** suggestions are provided as `{value, description}` entries
+- **THEN** each dropdown row SHALL show the value and its description
+- **AND** the row's accessible name/description SHALL include the description text
+
+### Requirement: Editing the basket honors package identity semantics
+Adding, changing, or clearing the basket on an existing package SHALL apply the
+package-identity rules from the equipment-package-model capability (fork on a used
+package, edit-in-place on an unused one, dedup to an existing matching combo).
+
+#### Scenario: Changing the basket on a used package
+- **WHEN** the user changes the basket of a package that has recorded shots and saves
+- **THEN** the dialog flow SHALL result in the forked/deduped package per the identity rules, and set it active

--- a/openspec/changes/add-basket-equipment/tasks.md
+++ b/openspec/changes/add-basket-equipment/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — Add Basket Equipment
+
+## 1. Storage model (equipment-package-model)
+- [x] 1.1 Extend create/update in `equipmentstorage.{h,cpp}` to write an optional `kind="basket"` item (`brand`, `model`, empty `attrs`)
+- [x] 1.2 Widen `findPackageByGrinderIdentityStatic` (and rename/generalize) + `supersedeOrEditGrinderStatic` dedup/fork key to include the basket identity; treat "no basket" as a distinct value
+- [x] 1.3 Resolve the basket item in `EquipmentPackageView` / `toVariantMap()`; derive specs via `BasketAliases::findEntry()` at read time (do not store specs)
+- [x] 1.4 Carry basket items through `importEquipmentStatic` (device transfer)
+- [x] 1.5 Add `SettingsDye` bridges: `knownBasketBrands()`, `knownBasketModels(brand)`, active-basket resolution + display properties; thread basket identity through switch/create/update
+- [x] 1.6 Unit tests: optional basket, identity widening (fork/dedup/edit-in-place), derive-at-read — `basketOptionalAndDerive` + `basketIdentityWidening` in `tst_equipment.cpp` (23 pass). Import path is the same kind-agnostic copy loop + widened dedup, exercised indirectly.
+
+## 2. Registry helper (basketaliases.h)
+- [x] 2.1 Add a differentiator/`summary()`-style helper producing the model-row subtitle string (lead with the within-brand differentiating axis where feasible) — used existing `BasketAliases::summary()` as the baseline (design-endorsed); exposed via `SettingsDye::basketModelSummary()`. Lead-ordering polish deferred.
+
+## 3. Picker UI (switch-equipment-dialog)
+- [x] 3.1 Extend `SuggestionField` with an optional `descriptions` (value→subtitle) map rendered as a second row + folded into accessibility (lower-risk than a full `{value,description}` refactor; string filter/select logic untouched)
+- [x] 3.2 Add the optional vendor-first two-level basket section to `SwitchEquipmentDialog` (brand typeahead, model rows with differentiator subtitle; clearing brand+model = no basket)
+- [ ] 3.3 (Optional) group a brand's models by sub-family (Decent: Ridgeless/Ridged/Waisted) — deferred (design-marked optional)
+- [x] 3.4 Translation keys + accessibility attributes for the basket fields (inline `TranslationManager.translate` with fallbacks; accessibleName set)
+
+## 4. Inventory view (equipment-inventory-view)
+- [x] 4.1 `EquipmentCard`: basket sub-line (omit when none), grinder stays the title
+- [x] 4.2 `EquipmentInfoDialog`: basket `InfoRow` + details row (omit when none/custom)
+
+## 5. Shot resolution + AI/MCP (dialing-context-payload, mcp-server)
+- [x] 5.1 Resolve basket identity via the `equipment_id` JOIN — `ShotRecord` + `ShotProjection` gain basketBrand/Model; `loadShotRecordStatic` LEFT JOINs `equipment_items` kind='basket'; `convertShotRecord` copies them (no new shot column)
+- [x] 5.2 `dialing_blocks`: `currentBean` gains the `basket` sub-object (brand/model/wallProfile/relativeFlow/precision/doseRangeG), specs derived from `BasketAliases`; omitted when absent, identity-only for custom
+- [x] 5.3 Expose `doseRangeG` ({min,max}) for the dose-outside-range sanity signal
+- [x] 5.4 MCP `equipment_*` tools: `equipment_list`/`equipment_update`/`equipment_select` read + accept the optional basket identity; dialing surfaces the basket sub-object per unit/string conventions
+- [x] 5.5 `relativeFlow`/`wallProfile` emit as human-readable strings (from `BasketAliases::flowRateName`/`wallProfileName`)
+
+## 6. Verification
+- [x] 6.1 Quick compile check via Qt Creator MCP — app + all test targets build clean (0 errors, 0 warnings); equipment/coffeebags/dialing_blocks/mcptools_write/shotsummarizer/dbmigration suites all pass
+- [ ] 6.2 Manual: create grinder+basket package, switch basket (fork), switch back (dedup), grinder-only package; confirm card/info display — needs the running app (covered logically by unit tests)
+- [ ] 6.3 Confirm dialing context JSON carries the basket sub-object (and omits it when no basket / custom) — needs the running app + a shot with a basketed package
+
+## 7. Housekeeping
+- [x] 7.1 Archive the stale `add-basket-settings` proposal (dose-centric; superseded) — moved to `archive/2026-06-19-add-basket-settings`, marked OBSOLETE

--- a/openspec/changes/archive/2026-06-19-add-basket-settings/proposal.md
+++ b/openspec/changes/archive/2026-06-19-add-basket-settings/proposal.md
@@ -1,6 +1,12 @@
 # Change: Add Basket Settings
 
-**Status: AWAITING USER FEEDBACK** - Discussion with users in progress before finalizing.
+**Status: OBSOLETE — superseded by `add-basket-equipment` (2026-06-19).** This
+proposal framed the basket as the home for *dose*. That framing predates the
+equipment-packages work; the basket is now modeled as an equipment component
+(identity, for reproducibility + AI dialing), and dose ownership stays
+bean/recipe-scoped. The open questions below were resolved there: users do switch
+baskets (two baskets = two packages), and the basket lives in the Switch Equipment
+dialog. Archived without implementation.
 
 ## Why
 

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -51,8 +51,8 @@ Rectangle {
 
     readonly property string accessibleSummary: {
         var bits = [grinderTitle, burrs].filter(function(s) { return s.length > 0 })
-        if (basketLine.length > 0) bits.push(basketLine)
         if (lastDialLine.length > 0) bits.push(lastDialLine)
+        if (basketLine.length > 0) bits.push(basketLine)
         if (selected) bits.push(TranslationManager.translate("accessibility.selected", "selected"))
         return bits.join(", ")
     }
@@ -126,20 +126,22 @@ Rectangle {
 
                 Text {
                     Layout.fillWidth: true
-                    visible: card.basketLine.length > 0
-                    text: card.basketLine
-                    font: Theme.labelFont
-                    color: Theme.textSecondaryColor
-                    elide: Text.ElideRight
-                    Accessible.ignored: true
-                }
-
-                Text {
-                    Layout.fillWidth: true
                     visible: card.lastDialLine.length > 0
                     text: card.lastDialLine
                     font: Theme.captionFont
                     color: Theme.textColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
+
+                // Basket last: it's separate equipment, so keep the grinder identity
+                // (title + burrs) and its dial (grind) contiguous above it.
+                Text {
+                    Layout.fillWidth: true
+                    visible: card.basketLine.length > 0
+                    text: card.basketLine
+                    font: Theme.labelFont
+                    color: Theme.textSecondaryColor
                     elide: Text.ElideRight
                     Accessible.ignored: true
                 }

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -29,6 +29,13 @@ Rectangle {
     }
     readonly property string burrs: (pkg && pkg.grinderBurrs) || ""
     readonly property bool rpmCapable: !!(pkg && pkg.rpmCapable)
+    // Basket identity line (add-basket-equipment); empty when the package has none.
+    readonly property string basketLine: {
+        var _ = TranslationManager.translationVersion
+        var b = [(pkg && pkg.basketBrand) || "", (pkg && pkg.basketModel) || ""]
+                .filter(function(s) { return s.length > 0 }).join(" ")
+        return b.length > 0 ? TranslationManager.translate("equipment.card.basket", "Basket: %1").arg(b) : ""
+    }
 
     readonly property string lastDialLine: {
         var _ = TranslationManager.translationVersion
@@ -44,6 +51,7 @@ Rectangle {
 
     readonly property string accessibleSummary: {
         var bits = [grinderTitle, burrs].filter(function(s) { return s.length > 0 })
+        if (basketLine.length > 0) bits.push(basketLine)
         if (lastDialLine.length > 0) bits.push(lastDialLine)
         if (selected) bits.push(TranslationManager.translate("accessibility.selected", "selected"))
         return bits.join(", ")
@@ -118,20 +126,20 @@ Rectangle {
 
                 Text {
                     Layout.fillWidth: true
-                    visible: card.lastDialLine.length > 0
-                    text: card.lastDialLine
-                    font: Theme.captionFont
-                    color: Theme.textColor
+                    visible: card.basketLine.length > 0
+                    text: card.basketLine
+                    font: Theme.labelFont
+                    color: Theme.textSecondaryColor
                     elide: Text.ElideRight
                     Accessible.ignored: true
                 }
 
                 Text {
                     Layout.fillWidth: true
-                    visible: card.rpmCapable
-                    text: TranslationManager.translate("equipment.card.rpmAdjustable", "RPM adjustable")
+                    visible: card.lastDialLine.length > 0
+                    text: card.lastDialLine
                     font: Theme.captionFont
-                    color: Theme.textSecondaryColor
+                    color: Theme.textColor
                     elide: Text.ElideRight
                     Accessible.ignored: true
                 }

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -4,8 +4,8 @@ import QtQuick.Layouts
 import Decenza
 
 // Equipment package card (add-equipment-packages). Mirrors BagCard. Shows the
-// grinder identity (brand/model, burrs subtitle), an RPM-adjustable hint, and
-// the last-used dial. Equipment is switched per-bag from Brew Settings, so the
+// grinder identity (brand/model, burrs subtitle), the last-used dial, and the
+// basket line (add-basket-equipment). Equipment is switched per-bag from Brew Settings, so the
 // card itself is informational + edit/remove (no global "selected" state). One
 // removal action follows the package's life: a trash icon while no SHOT
 // references it (a mistaken creation — hard delete), then "Remove" once shots

--- a/qml/components/EquipmentInfoDialog.qml
+++ b/qml/components/EquipmentInfoDialog.qml
@@ -86,6 +86,18 @@ Dialog {
                 label: TranslationManager.translate("equipment.info.burrs", "Burrs")
                 value: (root.pkg && root.pkg.grinderBurrs) || ""
             }
+            // Basket identity + its registry summary (add-basket-equipment). Both
+            // rows self-hide when the package has no basket; the details row also
+            // hides for a custom (off-registry) basket with no resolved specs.
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.basket", "Basket")
+                value: [(root.pkg && root.pkg.basketBrand) || "", (root.pkg && root.pkg.basketModel) || ""]
+                           .filter(function(s) { return s.length > 0 }).join(" ")
+            }
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.basketDetails", "Basket details")
+                value: (root.pkg && root.pkg.basketSummary) || ""
+            }
             // Last dial — grind setting, plus the last RPM appended only when the
             // grinder is rpm-adjustable (saves a row vs. a separate RPM line).
             InfoRow {

--- a/qml/components/EquipmentInfoDialog.qml
+++ b/qml/components/EquipmentInfoDialog.qml
@@ -86,18 +86,6 @@ Dialog {
                 label: TranslationManager.translate("equipment.info.burrs", "Burrs")
                 value: (root.pkg && root.pkg.grinderBurrs) || ""
             }
-            // Basket identity + its registry summary (add-basket-equipment). Both
-            // rows self-hide when the package has no basket; the details row also
-            // hides for a custom (off-registry) basket with no resolved specs.
-            InfoRow {
-                label: TranslationManager.translate("equipment.info.basket", "Basket")
-                value: [(root.pkg && root.pkg.basketBrand) || "", (root.pkg && root.pkg.basketModel) || ""]
-                           .filter(function(s) { return s.length > 0 }).join(" ")
-            }
-            InfoRow {
-                label: TranslationManager.translate("equipment.info.basketDetails", "Basket details")
-                value: (root.pkg && root.pkg.basketSummary) || ""
-            }
             // Last dial — grind setting, plus the last RPM appended only when the
             // grinder is rpm-adjustable (saves a row vs. a separate RPM line).
             InfoRow {
@@ -109,6 +97,18 @@ Dialog {
                                                    : root.pkg.lastRpm + " rpm")
                                    : g
                 }
+            }
+            // Basket last — separate equipment, so it follows the grinder identity +
+            // its dial. Both rows self-hide when the package has no basket; the
+            // details row also hides for a custom basket with no resolved specs.
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.basket", "Basket")
+                value: [(root.pkg && root.pkg.basketBrand) || "", (root.pkg && root.pkg.basketModel) || ""]
+                           .filter(function(s) { return s.length > 0 }).join(" ")
+            }
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.basketDetails", "Basket details")
+                value: (root.pkg && root.pkg.basketSummary) || ""
             }
 
             AccessibleButton {

--- a/qml/components/SuggestionField.qml
+++ b/qml/components/SuggestionField.qml
@@ -10,6 +10,12 @@ Item {
     property string label: ""
     property string text: ""
     property var suggestions: []  // List of existing values from database
+    // Optional value -> differentiator subtitle map. When a suggestion's value is
+    // a key here, the dropdown row renders that subtitle on a second line (and
+    // folds it into the row's accessible name). Empty by default — suggestions
+    // stay plain strings, so filtering/selection are unchanged. Used by the basket
+    // model picker to keep similar models legible (add-basket-equipment).
+    property var descriptions: ({})
     property string accessibleName: ""  // Explicit accessible name for screen readers (overrides label)
     property alias textField: textInput  // Expose internal text input for KeyboardAwareContainer registration
 
@@ -405,19 +411,41 @@ Item {
             delegate: ItemDelegate {
                 id: suggestionDelegate
                 width: suggestionList.width
-                height: Theme.scaled(44)
+                // Taller rows when a differentiator subtitle is shown so both lines fit.
+                height: suggestionDelegate.itemDesc.length > 0 ? Theme.scaled(58) : Theme.scaled(44)
                 highlighted: index === suggestionList.currentIndex
 
                 // Store reference to avoid scope issues
                 property string itemText: modelData
+                // Optional differentiator subtitle for this value (empty when none).
+                property string itemDesc: root.descriptions && root.descriptions[modelData] !== undefined
+                                          ? String(root.descriptions[modelData]) : ""
 
-                contentItem: Text {
-                    text: suggestionDelegate.itemText
-                    color: Theme.textColor
-                    font.pixelSize: Theme.scaled(18)
-                    verticalAlignment: Text.AlignVCenter
-                    leftPadding: Theme.scaled(12)
+                contentItem: Column {
+                    spacing: Theme.scaled(1)
+                    Text {
+                        text: suggestionDelegate.itemText
+                        color: Theme.textColor
+                        font.pixelSize: Theme.scaled(18)
+                        leftPadding: Theme.scaled(12)
+                        width: suggestionDelegate.width - Theme.scaled(12)
+                        elide: Text.ElideRight
+                    }
+                    Text {
+                        visible: suggestionDelegate.itemDesc.length > 0
+                        text: suggestionDelegate.itemDesc
+                        color: Theme.textSecondaryColor
+                        font.pixelSize: Theme.scaled(13)
+                        leftPadding: Theme.scaled(12)
+                        width: suggestionDelegate.width - Theme.scaled(12)
+                        elide: Text.ElideRight
+                    }
                 }
+
+                Accessible.role: Accessible.Button
+                Accessible.name: suggestionDelegate.itemDesc.length > 0
+                                 ? suggestionDelegate.itemText + ", " + suggestionDelegate.itemDesc
+                                 : suggestionDelegate.itemText
 
                 background: Rectangle {
                     color: highlighted || hovered ? Theme.primaryColor : "transparent"

--- a/qml/components/SuggestionField.qml
+++ b/qml/components/SuggestionField.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Effects
+import QtQuick.Window
 import Decenza
 
 // Autocomplete text field that shows filtered suggestions as you type
@@ -387,7 +388,24 @@ Item {
     Popup {
         id: suggestionPopup
         x: textInput.x
-        y: textInput.y + textInput.height
+        // Open below the field by default, but flip ABOVE when there isn't room
+        // below (the field can sit low in a scrollable form / near the screen
+        // bottom, where a downward popup runs off-screen and its rows can't be
+        // reached or scrolled). Mirrors the BeansItem pill-popup placement.
+        y: {
+            var _v = visible  // re-evaluate on open — mapToItem is not reactive
+            var below = textInput.y + textInput.height
+            var win = root.Window.window
+            if (win) {
+                var fieldTopGlobal = textInput.mapToItem(null, 0, 0).y
+                var fieldBottomGlobal = fieldTopGlobal + textInput.height
+                var spaceBelow = win.height - fieldBottomGlobal
+                var spaceAbove = fieldTopGlobal
+                if (implicitHeight + Theme.scaled(4) > spaceBelow && spaceAbove > spaceBelow)
+                    return textInput.y - implicitHeight - Theme.scaled(2)
+            }
+            return below
+        }
         width: textInput.width
         implicitHeight: Math.min(suggestionList.contentHeight + 2, Theme.scaled(250))
         padding: 1

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -29,6 +29,9 @@ Dialog {
     property string fBrand: ""
     property string fModel: ""
     property string fBurrs: ""
+    // Optional basket identity (add-basket-equipment). Blank brand+model = no basket.
+    property string fBasketBrand: ""
+    property string fBasketModel: ""
 
     // When true (default, the Brew Settings / Equipment-window use), selecting or
     // creating a package switches the ACTIVE bag's equipment. When false, the
@@ -38,7 +41,9 @@ Dialog {
 
     signal packageSaved(int packageId)
 
-    onAboutToShow: if (mode === "list") MainController.equipmentStorage.requestInventory()
+    // Always load the inventory: the list mode renders it, and the form mode
+    // checks the entered identity against it to block creating a duplicate.
+    onAboutToShow: MainController.equipmentStorage.requestInventory()
 
     Connections {
         target: MainController.equipmentStorage
@@ -81,7 +86,16 @@ Dialog {
     function openForCreate() {
         formMode = "create"
         editPackageId = -1
-        fName = ""; fBrand = ""; fModel = ""; fBurrs = ""
+        // Seed from the currently active package — people reuse most of the same
+        // gear, so pre-filling the grinder + basket means they only change what
+        // actually differs (often just the basket) instead of re-entering it all.
+        // Name stays blank so storage derives a fresh "{brand} {model}".
+        fName = ""
+        fBrand = Settings.dye.dyeGrinderBrand || ""
+        fModel = Settings.dye.dyeGrinderModel || ""
+        fBurrs = Settings.dye.dyeGrinderBurrs || ""
+        fBasketBrand = Settings.dye.dyeBasketBrand || ""
+        fBasketModel = Settings.dye.dyeBasketModel || ""
         mode = "form"
         open()
     }
@@ -93,6 +107,8 @@ Dialog {
         fBrand = (pkg && pkg.grinderBrand) || ""
         fModel = (pkg && pkg.grinderModel) || ""
         fBurrs = (pkg && pkg.grinderBurrs) || ""
+        fBasketBrand = (pkg && pkg.basketBrand) || ""
+        fBasketModel = (pkg && pkg.basketModel) || ""
         mode = "form"
         open()
     }
@@ -111,13 +127,50 @@ Dialog {
         return Settings.dye.suggestedBurrs(root.fBrand, root.fModel)
     }
 
+    // Basket pickers (add-basket-equipment): vendor-first, two-level. The model
+    // level carries a differentiator subtitle from the registry summary so similar
+    // models within a brand (e.g. S-Works billets, Decent waisted siblings) stay
+    // legible. No history fallback — baskets are a curated registry only.
+    function basketBrandSuggestions() { return Settings.dye.knownBasketBrands() }
+    function basketModelSuggestions() { return Settings.dye.knownBasketModels(root.fBasketBrand) }
+    function basketModelDescriptions() {
+        var out = {}
+        var models = Settings.dye.knownBasketModels(root.fBasketBrand)
+        for (var i = 0; i < models.length; ++i)
+            out[models[i]] = Settings.dye.basketModelSummary(root.fBasketBrand, models[i])
+        return out
+    }
+
     function packageTitle(pkg) {
         if (!pkg) return ""
         if (pkg.name && String(pkg.name).length > 0) return String(pkg.name)
         return [pkg.grinderBrand || "", pkg.grinderModel || ""].filter(function(s) { return s.length > 0 }).join(" ")
     }
 
-    readonly property bool canSave: fBrand.trim().length > 0 || fModel.trim().length > 0
+    // The id of an existing in-inventory package whose FULL identity (grinder +
+    // basket) matches the form, or -1. Mirrors the storage dedup key so the UI
+    // can't create a duplicate — the same gear is one package, not many. The
+    // package being edited is excluded (an unchanged edit isn't a "duplicate").
+    readonly property int duplicateOfId: {
+        var gb = fBrand.trim().toLowerCase(), gm = fModel.trim().toLowerCase()
+        var gbu = fBurrs.trim().toLowerCase()
+        var bb = fBasketBrand.trim().toLowerCase(), bm = fBasketModel.trim().toLowerCase()
+        for (var i = 0; i < packages.length; ++i) {
+            var p = packages[i]
+            if (!p || p.id === undefined) continue
+            if (editPackageId > 0 && p.id === editPackageId) continue
+            if (String(p.grinderBrand || "").trim().toLowerCase() === gb
+                && String(p.grinderModel || "").trim().toLowerCase() === gm
+                && String(p.grinderBurrs || "").trim().toLowerCase() === gbu
+                && String(p.basketBrand || "").trim().toLowerCase() === bb
+                && String(p.basketModel || "").trim().toLowerCase() === bm)
+                return p.id
+        }
+        return -1
+    }
+
+    readonly property bool canSave: (fBrand.trim().length > 0 || fModel.trim().length > 0)
+                                    && duplicateOfId < 0
     property bool _awaitingCreate: false
 
     EquipmentInfoDialog {
@@ -132,12 +185,21 @@ Dialog {
     }
 
     contentItem: Item {
+        id: contentRoot
         // Size to the active mode's inner ColumnLayout. NOTE: reference
         // formColumn (the layout), not formContainer (the KeyboardAwareContainer)
         // — the container's child fills it via anchors, so the container's own
         // implicitHeight is 0 and the dialog would collapse to just the header.
-        implicitHeight: (root.mode === "list" ? listColumn.implicitHeight : formColumn.implicitHeight)
-                        + 2 * Theme.spacingMedium
+        //
+        // Form mode is CAPPED at a fraction of the screen and the fields scroll
+        // inside (a grinder+basket package has enough fields to overflow a short
+        // screen); the pinned header keeps Cancel/Save reachable without scrolling.
+        readonly property real formCap: (root.parent ? root.parent.height : Theme.scaled(640)) * 0.85
+        readonly property real formNatural: formHeader.implicitHeight + fieldsColumn.implicitHeight
+                                            + 3 * Theme.spacingMedium
+        implicitHeight: root.mode === "list"
+                        ? listColumn.implicitHeight + 2 * Theme.spacingMedium
+                        : Math.min(formNatural, formCap)
 
         // --- LIST (picker) ---
         ColumnLayout {
@@ -224,7 +286,8 @@ Dialog {
             id: formContainer
             visible: root.mode === "form"
             anchors.fill: parent
-            textFields: [nameField.textField, brandField.textField, modelField.textField, burrsField.textField]
+            textFields: [nameField.textField, brandField.textField, modelField.textField, burrsField.textField,
+                         basketBrandField.textField, basketModelField.textField]
 
             ColumnLayout {
                 id: formColumn
@@ -232,78 +295,23 @@ Dialog {
                 anchors.margins: Theme.spacingMedium
                 spacing: Theme.spacingMedium
 
-                Tr {
-                    Layout.fillWidth: true
-                    key: root.formMode === "edit" ? "equipment.dialog.editTitle" : "equipment.dialog.addTitle"
-                    fallback: root.formMode === "edit" ? "Edit Equipment" : "Add Equipment"
-                    font: Theme.titleFont
-                    color: Theme.textColor
-                    Accessible.role: Accessible.Heading
-                    Accessible.name: text
-                }
-
-                // User-editable label (add-equipment-packages 4b.1). Blank uses the
-                // derived "{brand} {model}"; set it to a kit name like "Espresso setup".
-                SuggestionField {
-                    id: nameField
-                    Layout.fillWidth: true
-                    label: TranslationManager.translate("equipment.dialog.name", "Name (optional)")
-                    accessibleName: label
-                    text: root.fName
-                    suggestions: []
-                    onTextEdited: function(t) { root.fName = t }
-                }
-
-                SuggestionField {
-                    id: brandField
-                    Layout.fillWidth: true
-                    label: TranslationManager.translate("equipment.dialog.brand", "Grinder brand")
-                    accessibleName: label
-                    text: root.fBrand
-                    suggestions: root.brandSuggestions()
-                    onTextEdited: function(t) { root.fBrand = t }
-                    onSuggestionSelected: function(t) {
-                        root.fBrand = t
-                        var models = Settings.dye.knownGrinderModels(t)
-                        if (models.length === 1) {
-                            root.fModel = models[0]
-                            var burrs = Settings.dye.suggestedBurrs(t, models[0])
-                            if (burrs.length === 1) root.fBurrs = burrs[0]
-                        }
-                    }
-                }
-
-                SuggestionField {
-                    id: modelField
-                    Layout.fillWidth: true
-                    label: TranslationManager.translate("equipment.dialog.model", "Grinder model")
-                    accessibleName: label
-                    text: root.fModel
-                    suggestions: root.modelSuggestions()
-                    onTextEdited: function(t) { root.fModel = t }
-                    onSuggestionSelected: function(t) {
-                        var burrs = Settings.dye.suggestedBurrs(root.fBrand, t)
-                        if (burrs.length === 1) root.fBurrs = burrs[0]
-                    }
-                }
-
-                SuggestionField {
-                    id: burrsField
-                    Layout.fillWidth: true
-                    label: TranslationManager.translate("equipment.dialog.burrs", "Burrs")
-                    accessibleName: label
-                    text: root.fBurrs
-                    suggestions: root.burrsSuggestions()
-                    onTextEdited: function(t) { root.fBurrs = t }
-                    onSuggestionSelected: function(t) { root.fBurrs = t }
-                }
-
+                // Pinned header: title on the left, Cancel/Save on the right of the
+                // same line so they stay reachable while the fields scroll below.
                 RowLayout {
+                    id: formHeader
                     Layout.fillWidth: true
-                    Layout.topMargin: Theme.spacingSmall
                     spacing: Theme.spacingMedium
 
-                    Item { Layout.fillWidth: true }
+                    Tr {
+                        Layout.fillWidth: true
+                        key: root.formMode === "edit" ? "equipment.dialog.editTitle" : "equipment.dialog.addTitle"
+                        fallback: root.formMode === "edit" ? "Edit Equipment" : "Add Equipment"
+                        font: Theme.titleFont
+                        color: Theme.textColor
+                        elide: Text.ElideRight
+                        Accessible.role: Accessible.Heading
+                        Accessible.name: text
+                    }
 
                     AccessibleButton {
                         text: TranslationManager.translate("common.button.cancel", "Cancel")
@@ -319,6 +327,125 @@ Dialog {
                         onClicked: root.save()
                     }
                 }
+
+                // Explains the disabled Save when the entered gear already exists
+                // (e.g. the create form was pre-filled and nothing was changed yet).
+                Text {
+                    Layout.fillWidth: true
+                    visible: root.duplicateOfId > 0
+                    text: TranslationManager.translate("equipment.dialog.duplicate",
+                              "You already have this exact equipment — change something to make it distinct.")
+                    font: Theme.captionFont
+                    color: Theme.warningColor
+                    wrapMode: Text.Wrap
+                    Accessible.role: Accessible.StaticText
+                    Accessible.name: text
+                }
+
+                // Scrollable field area — a grinder+basket package has enough fields
+                // to overflow a short screen.
+                ScrollView {
+                    id: formScroll
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    clip: true
+                    ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+
+                    ColumnLayout {
+                        id: fieldsColumn
+                        width: formScroll.availableWidth
+                        spacing: Theme.spacingMedium
+
+                        // User-editable label (add-equipment-packages 4b.1). Blank uses the
+                        // derived "{brand} {model}"; set it to a kit name like "Espresso setup".
+                        SuggestionField {
+                            id: nameField
+                            Layout.fillWidth: true
+                            label: TranslationManager.translate("equipment.dialog.name", "Name (optional)")
+                            accessibleName: label
+                            text: root.fName
+                            suggestions: []
+                            onTextEdited: function(t) { root.fName = t }
+                        }
+
+                        SuggestionField {
+                            id: brandField
+                            Layout.fillWidth: true
+                            label: TranslationManager.translate("equipment.dialog.brand", "Grinder brand")
+                            accessibleName: label
+                            text: root.fBrand
+                            suggestions: root.brandSuggestions()
+                            onTextEdited: function(t) { root.fBrand = t }
+                            onSuggestionSelected: function(t) {
+                                root.fBrand = t
+                                var models = Settings.dye.knownGrinderModels(t)
+                                if (models.length === 1) {
+                                    root.fModel = models[0]
+                                    var burrs = Settings.dye.suggestedBurrs(t, models[0])
+                                    if (burrs.length === 1) root.fBurrs = burrs[0]
+                                }
+                            }
+                        }
+
+                        SuggestionField {
+                            id: modelField
+                            Layout.fillWidth: true
+                            label: TranslationManager.translate("equipment.dialog.model", "Grinder model")
+                            accessibleName: label
+                            text: root.fModel
+                            suggestions: root.modelSuggestions()
+                            onTextEdited: function(t) { root.fModel = t }
+                            onSuggestionSelected: function(t) {
+                                var burrs = Settings.dye.suggestedBurrs(root.fBrand, t)
+                                if (burrs.length === 1) root.fBurrs = burrs[0]
+                            }
+                        }
+
+                        SuggestionField {
+                            id: burrsField
+                            Layout.fillWidth: true
+                            label: TranslationManager.translate("equipment.dialog.burrs", "Burrs")
+                            accessibleName: label
+                            text: root.fBurrs
+                            suggestions: root.burrsSuggestions()
+                            onTextEdited: function(t) { root.fBurrs = t }
+                            onSuggestionSelected: function(t) { root.fBurrs = t }
+                        }
+
+                        // --- Basket (optional) — vendor-first, two-level (add-basket-equipment) ---
+                        SuggestionField {
+                            id: basketBrandField
+                            Layout.fillWidth: true
+                            label: TranslationManager.translate("equipment.dialog.basketBrand", "Basket brand (optional)")
+                            accessibleName: label
+                            text: root.fBasketBrand
+                            suggestions: root.basketBrandSuggestions()
+                            onTextEdited: function(t) {
+                                // Changing the brand invalidates the model (it belongs to a brand).
+                                if (t !== root.fBasketBrand) root.fBasketModel = ""
+                                root.fBasketBrand = t
+                            }
+                            onSuggestionSelected: function(t) {
+                                root.fBasketBrand = t
+                                var models = Settings.dye.knownBasketModels(t)
+                                if (models.length === 1) root.fBasketModel = models[0]
+                            }
+                        }
+
+                        SuggestionField {
+                            id: basketModelField
+                            Layout.fillWidth: true
+                            label: TranslationManager.translate("equipment.dialog.basketModel", "Basket model")
+                            accessibleName: label
+                            text: root.fBasketModel
+                            suggestions: root.basketModelSuggestions()
+                            // Differentiator subtitle keeps similar models legible.
+                            descriptions: root.basketModelDescriptions()
+                            onTextEdited: function(t) { root.fBasketModel = t }
+                            onSuggestionSelected: function(t) { root.fBasketModel = t }
+                        }
+                    }
+                }
             }
         }
     }
@@ -331,7 +458,10 @@ Dialog {
             "name": fName.trim(),
             "grinderBrand": fBrand.trim(),
             "grinderModel": fModel.trim(),
-            "grinderBurrs": fBurrs.trim()
+            "grinderBurrs": fBurrs.trim(),
+            // Blank basket brand+model -> no basket (storage clears any existing one).
+            "basketBrand": fBasketBrand.trim(),
+            "basketModel": fBasketModel.trim()
         }
         if (formMode === "edit" && editPackageId > 0) {
             // Editing identity may copy-on-write into a new package id; wait for

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -15,7 +15,7 @@ Dialog {
     id: root
     parent: Overlay.overlay
     anchors.centerIn: parent
-    width: Math.min(Theme.scaled(520), parent ? parent.width * 0.95 : Theme.scaled(520))
+    width: Math.min(Theme.scaled(720), parent ? parent.width * 0.95 : Theme.scaled(720))
     modal: true
     closePolicy: Dialog.CloseOnEscape
     padding: 0
@@ -368,36 +368,46 @@ Dialog {
                             onTextEdited: function(t) { root.fName = t }
                         }
 
-                        SuggestionField {
-                            id: brandField
+                        // Grinder brand + model share a row — both short and related, so
+                        // pairing them halves the form height (the burr name below is long
+                        // and keeps its own full-width line).
+                        RowLayout {
                             Layout.fillWidth: true
-                            label: TranslationManager.translate("equipment.dialog.brand", "Grinder brand")
-                            accessibleName: label
-                            text: root.fBrand
-                            suggestions: root.brandSuggestions()
-                            onTextEdited: function(t) { root.fBrand = t }
-                            onSuggestionSelected: function(t) {
-                                root.fBrand = t
-                                var models = Settings.dye.knownGrinderModels(t)
-                                if (models.length === 1) {
-                                    root.fModel = models[0]
-                                    var burrs = Settings.dye.suggestedBurrs(t, models[0])
-                                    if (burrs.length === 1) root.fBurrs = burrs[0]
+                            spacing: Theme.spacingMedium
+
+                            SuggestionField {
+                                id: brandField
+                                Layout.fillWidth: true
+                                Layout.preferredWidth: 1
+                                label: TranslationManager.translate("equipment.dialog.brand", "Grinder brand")
+                                accessibleName: label
+                                text: root.fBrand
+                                suggestions: root.brandSuggestions()
+                                onTextEdited: function(t) { root.fBrand = t }
+                                onSuggestionSelected: function(t) {
+                                    root.fBrand = t
+                                    var models = Settings.dye.knownGrinderModels(t)
+                                    if (models.length === 1) {
+                                        root.fModel = models[0]
+                                        var burrs = Settings.dye.suggestedBurrs(t, models[0])
+                                        if (burrs.length === 1) root.fBurrs = burrs[0]
+                                    }
                                 }
                             }
-                        }
 
-                        SuggestionField {
-                            id: modelField
-                            Layout.fillWidth: true
-                            label: TranslationManager.translate("equipment.dialog.model", "Grinder model")
-                            accessibleName: label
-                            text: root.fModel
-                            suggestions: root.modelSuggestions()
-                            onTextEdited: function(t) { root.fModel = t }
-                            onSuggestionSelected: function(t) {
-                                var burrs = Settings.dye.suggestedBurrs(root.fBrand, t)
-                                if (burrs.length === 1) root.fBurrs = burrs[0]
+                            SuggestionField {
+                                id: modelField
+                                Layout.fillWidth: true
+                                Layout.preferredWidth: 1
+                                label: TranslationManager.translate("equipment.dialog.model", "Grinder model")
+                                accessibleName: label
+                                text: root.fModel
+                                suggestions: root.modelSuggestions()
+                                onTextEdited: function(t) { root.fModel = t }
+                                onSuggestionSelected: function(t) {
+                                    var burrs = Settings.dye.suggestedBurrs(root.fBrand, t)
+                                    if (burrs.length === 1) root.fBurrs = burrs[0]
+                                }
                             }
                         }
 
@@ -412,37 +422,45 @@ Dialog {
                             onSuggestionSelected: function(t) { root.fBurrs = t }
                         }
 
-                        // --- Basket (optional) — vendor-first, two-level (add-basket-equipment) ---
-                        SuggestionField {
-                            id: basketBrandField
+                        // --- Basket (optional) — vendor-first, two-level (add-basket-equipment).
+                        //     Brand + model share a row, mirroring the grinder pair above.
+                        RowLayout {
                             Layout.fillWidth: true
-                            label: TranslationManager.translate("equipment.dialog.basketBrand", "Basket brand (optional)")
-                            accessibleName: label
-                            text: root.fBasketBrand
-                            suggestions: root.basketBrandSuggestions()
-                            onTextEdited: function(t) {
-                                // Changing the brand invalidates the model (it belongs to a brand).
-                                if (t !== root.fBasketBrand) root.fBasketModel = ""
-                                root.fBasketBrand = t
-                            }
-                            onSuggestionSelected: function(t) {
-                                root.fBasketBrand = t
-                                var models = Settings.dye.knownBasketModels(t)
-                                if (models.length === 1) root.fBasketModel = models[0]
-                            }
-                        }
+                            spacing: Theme.spacingMedium
 
-                        SuggestionField {
-                            id: basketModelField
-                            Layout.fillWidth: true
-                            label: TranslationManager.translate("equipment.dialog.basketModel", "Basket model")
-                            accessibleName: label
-                            text: root.fBasketModel
-                            suggestions: root.basketModelSuggestions()
-                            // Differentiator subtitle keeps similar models legible.
-                            descriptions: root.basketModelDescriptions()
-                            onTextEdited: function(t) { root.fBasketModel = t }
-                            onSuggestionSelected: function(t) { root.fBasketModel = t }
+                            SuggestionField {
+                                id: basketBrandField
+                                Layout.fillWidth: true
+                                Layout.preferredWidth: 1
+                                label: TranslationManager.translate("equipment.dialog.basketBrand", "Basket brand (optional)")
+                                accessibleName: label
+                                text: root.fBasketBrand
+                                suggestions: root.basketBrandSuggestions()
+                                onTextEdited: function(t) {
+                                    // Changing the brand invalidates the model (it belongs to a brand).
+                                    if (t !== root.fBasketBrand) root.fBasketModel = ""
+                                    root.fBasketBrand = t
+                                }
+                                onSuggestionSelected: function(t) {
+                                    root.fBasketBrand = t
+                                    var models = Settings.dye.knownBasketModels(t)
+                                    if (models.length === 1) root.fBasketModel = models[0]
+                                }
+                            }
+
+                            SuggestionField {
+                                id: basketModelField
+                                Layout.fillWidth: true
+                                Layout.preferredWidth: 1
+                                label: TranslationManager.translate("equipment.dialog.basketModel", "Basket model")
+                                accessibleName: label
+                                text: root.fBasketModel
+                                suggestions: root.basketModelSuggestions()
+                                // Differentiator subtitle keeps similar models legible.
+                                descriptions: root.basketModelDescriptions()
+                                onTextEdited: function(t) { root.fBasketModel = t }
+                                onSuggestionSelected: function(t) { root.fBasketModel = t }
+                            }
                         }
                     }
                 }

--- a/qml/components/layout/LayoutItemDelegate.qml
+++ b/qml/components/layout/LayoutItemDelegate.qml
@@ -86,9 +86,9 @@ Item {
             case "equipment": return {
                 emoji: "qrc:/icons/grind.svg",
                 content: TranslationManager.translate("idle.button.equipment", "Equipment"),
-                action: "navigate:equipment",
-                longPressAction: "",
-                doubleclickAction: "",
+                action: "togglePreset:equipment",
+                longPressAction: "navigate:equipment",
+                doubleclickAction: "navigate:equipment",
                 backgroundColor: Theme.primaryColor
             }
             case "history": return {

--- a/qml/components/layout/items/EquipmentItem.qml
+++ b/qml/components/layout/items/EquipmentItem.qml
@@ -2,26 +2,73 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Effects
+import QtQuick.Window
 import Decenza
 import "../.."
 
-// Idle-page Equipment button (add-equipment-packages). Tapping it opens the
-// Equipment window, parallel to the Beans button. Simpler than BeansItem — no
-// quick-select pill popup; equipment is switched per-bag from Brew Settings.
-// In center zones LayoutItemDelegate compiles "equipment" to a CustomItem, so
-// this file renders only in the compact (top/bottom/statusBar) zones.
+// Idle-page Equipment button (add-equipment-packages). Mirrors BeansItem: a tap
+// shows the recently-used equipment packages as quick-switch pills (inline pills
+// in center zones, a dropdown popup in compact bars), and a double-tap or
+// long-press opens the full Equipment window. In center zones LayoutItemDelegate
+// compiles "equipment" to a CustomItem (action togglePreset:equipment +
+// navigate:equipment on long/double), so this file renders only in the compact
+// (top/bottom/statusBar) zones.
 Item {
     id: root
     property bool isCompact: false
     property string itemId: ""
 
-    function goToEquipment() {
-        if (typeof pageStack !== "undefined")
-            pageStack.push(Qt.resolvedUrl("../../../pages/EquipmentPage.qml"))
+    property var idlePage: {
+        var p = root.parent
+        while (p) {
+            if (p.objectName === "idlePage") return p
+            p = p.parent
+        }
+        return null
+    }
+
+    // Recently-used equipment packages shown as pills. Capped to the 5 most
+    // recently used (inventoryReady is MRU-ordered); the full inventory lives on
+    // the Equipment page.
+    property var inventoryEquipment: []
+
+    function equipmentLabel(pkg) {
+        if (!pkg) return ""
+        if (pkg.name && String(pkg.name).length > 0) return String(pkg.name)
+        return [pkg.grinderBrand || "", pkg.grinderModel || ""]
+                .filter(function(s) { return s.length > 0 }).join(" ")
+    }
+
+    Component.onCompleted: MainController.equipmentStorage.requestInventory()
+
+    Connections {
+        target: MainController.equipmentStorage
+        function onInventoryReady(packages) {
+            root.inventoryEquipment = packages.slice(0, 5)
+        }
+        function onPackagesChanged() {
+            MainController.equipmentStorage.requestInventory()
+        }
     }
 
     implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
     implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
+
+    function togglePresets() {
+        if (root.inventoryEquipment.length === 0) {
+            goToEquipment()
+        } else if (root.isCompact) {
+            presetPopup.visible ? presetPopup.close() : presetPopup.open()
+        } else if (root.idlePage) {
+            root.idlePage.activePresetFunction =
+                (root.idlePage.activePresetFunction === "equipment") ? "" : "equipment"
+        }
+    }
+
+    function goToEquipment() {
+        if (typeof pageStack !== "undefined")
+            pageStack.push(Qt.resolvedUrl("../../../pages/EquipmentPage.qml"))
+    }
 
     // --- COMPACT MODE ---
     Item {
@@ -59,9 +106,13 @@ Item {
 
         AccessibleTapHandler {
             anchors.fill: parent
+            supportLongPress: true
+            supportDoubleClick: true
             accessibleName: TranslationManager.translate("idle.button.equipment", "Equipment")
-            accessibleDescription: TranslationManager.translate("idle.accessible.equipment.hint", "Tap to open the equipment inventory.")
-            onAccessibleClicked: root.goToEquipment()
+            accessibleDescription: TranslationManager.translate("idle.accessible.equipment.hint", "Tap to switch equipment. Double-tap or long-press for the equipment inventory.")
+            onAccessibleClicked: root.togglePresets()
+            onAccessibleDoubleClicked: root.goToEquipment()
+            onAccessibleLongPressed: root.goToEquipment()
         }
     }
 
@@ -80,9 +131,104 @@ Item {
             iconSource: "qrc:/icons/grind.svg"
             iconSize: Theme.scaled(43)
             backgroundColor: Theme.primaryColor
-            onClicked: root.goToEquipment()
+            supportDoubleClick: true
+            onClicked: root.togglePresets()
+            onPressAndHold: root.goToEquipment()
+            onDoubleClicked: root.goToEquipment()
 
-            Accessible.description: TranslationManager.translate("idle.accessible.equipment.description", "Open the equipment inventory to manage and switch grinders.")
+            Accessible.description: TranslationManager.translate("idle.accessible.equipment.description", "Switch the equipment for your next shot. Double-tap or long-press for the equipment inventory.")
+        }
+    }
+
+    // --- EQUIPMENT PILL POPUP (compact mode) ---
+    // Dialog (not Popup) so TalkBack can trap focus inside the pill list, mirroring
+    // BeansItem. modal traps focus; dim:false keeps the dropdown look; header/footer
+    // null strip the Dialog chrome.
+    Dialog {
+        id: presetPopup
+        modal: true
+        dim: false
+        header: null
+        footer: null
+        padding: Theme.spacingMedium
+        closePolicy: Popup.CloseOnPressOutside
+
+        onOpened: {
+            if (typeof AccessibilityManager === "undefined" || !AccessibilityManager.enabled) return
+            var pkgs = root.inventoryEquipment
+            if (pkgs.length === 0) return
+            var names = []
+            var selectedName = ""
+            for (var i = 0; i < pkgs.length; ++i) {
+                names.push(root.equipmentLabel(pkgs[i]))
+                if (pkgs[i].id === Settings.dye.activeEquipmentId) selectedName = root.equipmentLabel(pkgs[i])
+            }
+            var announcement = pkgs.length + " " + TranslationManager.translate("idle.accessible.equipmentPackages", "equipment packages") + ": " + names.join(", ")
+            if (selectedName !== "") {
+                announcement += ". " + selectedName + " " + TranslationManager.translate("idle.accessible.isSelected", "is selected")
+            }
+            AccessibilityManager.announce(announcement)
+        }
+
+        width: {
+            var win = root.Window.window
+            var w = Theme.scaled(600) + 2 * padding
+            return win ? Math.min(w, win.width) : w
+        }
+
+        y: {
+            var _v = visible // Force re-evaluation when popup opens (mapToItem is not reactive)
+            var win = root.Window.window
+            if (win) {
+                var globalY = root.mapToItem(null, 0, 0).y
+                var spaceBelow = win.height - globalY - root.height - Theme.spacingSmall
+                var spaceAbove = globalY - Theme.spacingSmall
+                if (height > spaceBelow && spaceAbove > spaceBelow)
+                    return -height - Theme.spacingSmall
+            }
+            return parent.height + Theme.spacingSmall
+        }
+
+        x: {
+            var _v = visible // Force re-evaluation when popup opens (mapToItem is not reactive)
+            var win = root.Window.window
+            if (win) {
+                var globalX = root.mapToItem(null, 0, 0).x
+                var centered = -width / 2 + parent.width / 2
+                if (globalX + centered + width > win.width)
+                    centered = win.width - globalX - width
+                if (globalX + centered < 0)
+                    centered = -globalX
+                return centered
+            }
+            return -width / 2 + parent.width / 2
+        }
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.cardRadius
+            border.color: Theme.borderColor
+            border.width: 1
+        }
+
+        contentItem: PresetPillRow {
+            id: equipmentPillRow
+            maxWidth: Theme.scaled(600)
+            presets: root.inventoryEquipment.map(function(p) { return { name: root.equipmentLabel(p) } })
+            selectedIndex: {
+                var list = root.inventoryEquipment
+                for (var i = 0; i < list.length; ++i) {
+                    if (list[i].id === Settings.dye.activeEquipmentId) return i
+                }
+                return -1
+            }
+
+            onPresetSelected: function(index) {
+                var pkg = root.inventoryEquipment[index]
+                if (!pkg) return
+                Settings.dye.switchToEquipment(pkg)
+                presetPopup.close()
+            }
         }
     }
 }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -97,6 +97,7 @@ Page {
     Component.onCompleted: {
         root.currentPageTitle = TranslationManager.translate("idle.pageTitle", "Idle")
         MainController.bagStorage.requestInventory()
+        MainController.equipmentStorage.requestInventory()
     }
 
     // Inventory bags for the beans pill row (bean-bag-inventory: pills are
@@ -121,8 +122,31 @@ Page {
         }
     }
 
+    // Equipment packages for the equipment pill row (add-basket-equipment): pills
+    // are packages, selection is activeEquipmentId. Capped to the 5 most recently
+    // used (inventoryReady is MRU-ordered); the full inventory lives on the
+    // Equipment page.
+    property var inventoryEquipment: []
+
+    function equipmentLabel(pkg) {
+        if (!pkg) return ""
+        if (pkg.name && String(pkg.name).length > 0) return String(pkg.name)
+        return [pkg.grinderBrand || "", pkg.grinderModel || ""]
+                .filter(function(s) { return s.length > 0 }).join(" ")
+    }
+
+    Connections {
+        target: MainController.equipmentStorage
+        function onInventoryReady(packages) {
+            idlePage.inventoryEquipment = packages.slice(0, 5)
+        }
+        function onPackagesChanged() {
+            MainController.equipmentStorage.requestInventory()
+        }
+    }
+
     // Track which function's presets are showing (used by center-zone action items)
-    property string activePresetFunction: ""  // "", "steam", "espresso", "hotwater", "flush", "beans"
+    property string activePresetFunction: ""  // "", "steam", "espresso", "hotwater", "flush", "beans", "equipment"
 
     // Auto-tare scale and announce presets when activePresetFunction changes
     onActivePresetFunctionChanged: {
@@ -165,6 +189,15 @@ Page {
                     for (var bi = 0; bi < idlePage.inventoryBags.length; ++bi) {
                         if (idlePage.inventoryBags[bi].id === Settings.dye.activeBagId) {
                             selectedName = idlePage.bagLabel(idlePage.inventoryBags[bi])
+                            break
+                        }
+                    }
+                    break
+                case "equipment":
+                    presets = idlePage.inventoryEquipment.map(function(p) { return { name: idlePage.equipmentLabel(p) } })
+                    for (var ei = 0; ei < idlePage.inventoryEquipment.length; ++ei) {
+                        if (idlePage.inventoryEquipment[ei].id === Settings.dye.activeEquipmentId) {
+                            selectedName = idlePage.equipmentLabel(idlePage.inventoryEquipment[ei])
                             break
                         }
                     }
@@ -277,6 +310,7 @@ Page {
                     case "hotwater": return hotWaterPresetLoader
                     case "flush": return flushPresetLoader
                     case "beans": return beanPresetLoader
+                    case "equipment": return equipmentPresetLoader
                     default: return steamPresetLoader
                 }
             }
@@ -554,6 +588,31 @@ Page {
                         var bag = idlePage.inventoryBags[index]
                         if (!bag) return
                         Settings.dye.activeBagId = bag.id
+                    }
+                }
+            }
+
+            Loader {
+                id: equipmentPresetLoader
+                width: parent.width
+                anchors.horizontalCenter: parent.horizontalCenter
+                active: activePresetFunction === "equipment"
+                visible: active
+                sourceComponent: PresetPillRow {
+                    maxWidth: equipmentPresetLoader.width
+                    presets: idlePage.inventoryEquipment.map(function(p) { return { name: idlePage.equipmentLabel(p) } })
+                    selectedIndex: {
+                        var list = idlePage.inventoryEquipment
+                        for (var i = 0; i < list.length; ++i) {
+                            if (list[i].id === Settings.dye.activeEquipmentId) return i
+                        }
+                        return -1
+                    }
+
+                    onPresetSelected: function(index) {
+                        var pkg = idlePage.inventoryEquipment[index]
+                        if (!pkg) return
+                        Settings.dye.switchToEquipment(pkg)
                     }
                 }
             }

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -2,6 +2,7 @@
 
 #include "dialing_helpers.h"  // buildBeanFreshness — composed inside buildCurrentBeanBlock
 #include "aiconversation.h"   // HistoricalAssistantTurn — input to buildRecentAdviceBlock
+#include "../core/basketaliases.h"  // basket spec derivation inside buildCurrentBeanBlock
 
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -187,6 +188,11 @@ struct CurrentBeanBlockInputs {
     QString grinderBrand;
     QString grinderModel;
     QString grinderBurrs;
+    // Basket identity (resolved via the shot's equipment_id; empty = no basket).
+    // Specs (wall/flow/precision/dose range) are DERIVED here from BasketAliases,
+    // not passed in — the caller supplies identity only (add-basket-equipment).
+    QString basketBrand;
+    QString basketModel;
     QString grinderSetting;
     // Grinder RPM the shot was ground at (0 = unset / not an adjustable-RPM
     // grinder). A second grind axis alongside grinderSetting on variable-RPM
@@ -218,6 +224,30 @@ inline QJsonObject buildCurrentBeanBlock(const CurrentBeanBlockInputs& in)
     if (in.rpm > 0)
         bean["rpm"] = in.rpm;
     bean["doseWeightG"] = in.doseWeightG;
+
+    // Basket sub-object (add-basket-equipment). Identity always when present;
+    // registry-derived specs only when the basket matches BasketAliases (a custom
+    // off-registry basket carries identity alone). relativeFlow is the key
+    // cross-basket signal — a directional word, not an ordered scale — and the
+    // dose range lets the advisor flag a dose outside the basket's rating.
+    if (!in.basketBrand.isEmpty() || !in.basketModel.isEmpty()) {
+        QJsonObject basket;
+        basket["brand"] = in.basketBrand;
+        basket["model"] = in.basketModel;
+        if (const BasketAliases::BasketEntry* e =
+                BasketAliases::findEntry(in.basketBrand, in.basketModel)) {
+            basket["wallProfile"] = BasketAliases::wallProfileName(e->wall);
+            basket["relativeFlow"] = BasketAliases::flowRateName(e->flow);
+            basket["precision"] = e->precision;
+            if (e->doseMaxG > 0) {
+                QJsonObject dose;
+                dose["min"] = e->doseMinG;
+                dose["max"] = e->doseMaxG;
+                basket["doseRangeG"] = dose;
+            }
+        }
+        bean["basket"] = basket;
+    }
 
     const QJsonObject freshness = DialingHelpers::buildBeanFreshness(in.roastDate);
     if (!freshness.isEmpty())

--- a/src/core/basketaliases.h
+++ b/src/core/basketaliases.h
@@ -4,6 +4,9 @@
 #include <QStringList>
 #include <QVector>
 
+#include <algorithm>
+#include <utility>
+
 namespace BasketAliases {
 
 // The cross-sectional shape of the basket's brewing chamber. This is the
@@ -91,23 +94,33 @@ inline QVector<BasketEntry> allBaskets()
     static const QVector<BasketEntry> entries = {
         // --- Decent (58mm single-wall; holes precision-inspected under
         //     microscope by Decent's own QC software, sold as the DE1 stock) ---
-        {"Decent", "Ridgeless 15g", {"decent 15g", "decent ridgeless 15g", "de1 15g"}, 58, 14, 16, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Stock small double; ridgeless for bottomless portafilters.")},
-        {"Decent", "Ridgeless 18g", {"decent 18g", "decent ridgeless 18g", "de1 18g", "decent stock"}, 58, 17, 19, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Basket shipped with the DE1 — the default everyday double.")},
-        {"Decent", "Ridgeless 20g", {"decent 20g", "decent ridgeless 20g", "de1 20g"}, 58, 19, 21, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Larger capacity ridgeless double for higher doses.")},
-        {"Decent", "Ridgeless 22g", {"decent 22g", "decent ridgeless 22g", "de1 22g"}, 58, 21, 23, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Largest standard ridgeless; high dose / darker roasts.")},
-        {"Decent", "Ridged 7g", {"decent 7g", "decent ridged 7g"}, 58, 6, 8, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Single-ristretto small basket; ridge grips a standard portafilter.")},
-        {"Decent", "Ridged 10g", {"decent 10g", "decent ridged 10g"}, 58, 9, 11, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Small low-dose basket for single / lighter shots.")},
-        {"Decent", "Slightly Waisted 14g", {"decent slightly waisted", "slightly waisted"}, 58, 12, 15, WP::Stepped, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Necks the 58mm bed down (~52mm) for added body; best near 14g.")},
-        {"Decent", "Very Waisted 14g", {"decent very waisted", "very waisted"}, 58, 12, 16, WP::Stepped, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("More taper than 'slightly' — more body, easier no-channel shots.")},
-        {"Decent", "Extremely Waisted 12g", {"decent extremely waisted", "extremely waisted"}, 58, 11, 14, WP::Stepped, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Most aggressive taper (~50mm bed); deep lever-style puck for body.")},
+        {"Decent", "15g Ridgeless", {"decent 15g", "decent ridgeless 15g", "de1 15g"}, 58, 14, 16, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Stock small double; ridgeless for bottomless portafilters.")},
+        {"Decent", "18g Ridgeless", {"decent 18g", "decent ridgeless 18g", "de1 18g", "decent stock"}, 58, 17, 19, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Basket shipped with the DE1 — the default everyday double.")},
+        {"Decent", "20g Ridgeless", {"decent 20g", "decent ridgeless 20g", "de1 20g"}, 58, 19, 21, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Larger capacity ridgeless double for higher doses.")},
+        {"Decent", "22g Ridgeless", {"decent 22g", "decent ridgeless 22g", "de1 22g"}, 58, 21, 23, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Largest standard ridgeless; high dose / darker roasts.")},
+        {"Decent", "7g Ridged", {"decent 7g", "decent ridged 7g"}, 58, 6, 8, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Single-ristretto small basket; ridge grips a standard portafilter.")},
+        {"Decent", "10g Ridged", {"decent 10g", "decent ridged 10g"}, 58, 9, 11, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Small low-dose basket for single / lighter shots.")},
+        // Ridged (spouted-portafilter) versions of the standard doubles — same
+        // straight-wall precision geometry as the ridgeless ones, with a ridge so
+        // they seat in a standard (non-bottomless) portafilter. Discontinued / no
+        // longer on the Decent site, but in wide use.
+        {"Decent", "15g Ridged", {"decent ridged 15g", "decent 15g ridged"}, 58, 14, 16, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Ridged small double for a standard portafilter (discontinued).")},
+        {"Decent", "18g Ridged", {"decent ridged 18g", "decent 18g ridged"}, 58, 17, 19, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Ridged version of the everyday double for a standard portafilter (discontinued).")},
+        {"Decent", "20g Ridged", {"decent ridged 20g", "decent 20g ridged"}, 58, 19, 21, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Ridged larger-capacity double for a standard portafilter (discontinued).")},
+        {"Decent", "22g Ridged", {"decent ridged 22g", "decent 22g ridged"}, 58, 21, 23, WP::Straight, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Ridged high-dose double for a standard portafilter (discontinued).")},
+        {"Decent", "14g Slightly Waisted", {"decent slightly waisted", "slightly waisted"}, 58, 12, 15, WP::Stepped, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Necks the 58mm bed down (~52mm) for added body; best near 14g.")},
+        {"Decent", "14g Very Waisted", {"decent very waisted", "very waisted"}, 58, 12, 16, WP::Stepped, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("More taper than 'slightly' — more body, easier no-channel shots.")},
+        {"Decent", "12g Extremely Waisted", {"decent extremely waisted", "extremely waisted"}, 58, 11, 14, WP::Stepped, true, FR::Standard, 0, 0, QStringLiteral("stainless steel"), QStringLiteral("Most aggressive taper (~50mm bed); deep lever-style puck for body.")},
 
         // --- Weber Workshops Unibasket (forged 304, 1.2mm blank, straight
         //     walls with laser-ablated holes carried to the side wall — the
-        //     reason it flows faster than a tapered stock basket) ---
-        {"Weber Workshops", "Unibasket 16g", {"unibasket 16g", "weber 16g", "weber unibasket 16g"}, 58, 15, 17, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("Holes to the side wall give a full ~58mm active puck vs ~48mm stock — flows faster.")},
-        {"Weber Workshops", "Unibasket 20g", {"unibasket 20g", "weber 20g", "weber unibasket 20g"}, 58, 19, 21, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("20g drop-in Unibasket; same unibody straight-wall, full-active-area design.")},
-        {"Weber Workshops", "Unibasket 24g", {"unibasket 24g", "weber 24g", "weber unibasket 24g"}, 58, 23, 25, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("24g drop-in Unibasket.")},
-        {"Weber Workshops", "Unibasket 28g", {"unibasket 28g", "weber 28g", "weber unibasket 28g"}, 58, 27, 29, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("Largest Unibasket — a 28g 'mega-shot' size.")},
+        //     reason it flows faster than a tapered stock basket). The Unifilter
+        //     is a unibody portafilter with that same basket machined in. ---
+        {"Weber Workshops", "16g Unibasket", {"unibasket 16g", "weber 16g", "weber unibasket 16g"}, 58, 15, 17, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("Holes to the side wall give a full ~58mm active puck vs ~48mm stock — flows faster.")},
+        {"Weber Workshops", "20g Unibasket", {"unibasket 20g", "weber 20g", "weber unibasket 20g"}, 58, 19, 21, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("20g drop-in Unibasket; same unibody straight-wall, full-active-area design.")},
+        {"Weber Workshops", "20g Unifilter", {"unifilter", "weber unifilter", "weber unibody portafilter"}, 58, 18, 22, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, unibody"), QStringLiteral("Unibody portafilter with the Unibasket machined in (no removable basket); laser-ablated holes to the side wall, 18-22g, 20g standard.")},
+        {"Weber Workshops", "24g Unibasket", {"unibasket 24g", "weber 24g", "weber unibasket 24g"}, 58, 23, 25, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("24g drop-in Unibasket.")},
+        {"Weber Workshops", "28g Unibasket", {"unibasket 28g", "weber 28g", "weber unibasket 28g"}, 58, 27, 29, WP::Straight, true, FR::Open, 0, 0, QStringLiteral("forged 304 stainless, 1.2mm"), QStringLiteral("Largest Unibasket — a 28g 'mega-shot' size.")},
 
         // --- VST (the WBC reference precision basket; every hole optically
         //     verified to ~±20µm, individual test certificate per basket;
@@ -123,11 +136,11 @@ inline QVector<BasketEntry> allBaskets()
         // --- IMS (competition precision; 0.30mm holes standard. "M" flat
         //     pattern, "TC" convex base, "E" ridgeless, "SF" SuperFine
         //     membrane, "NT" Nanoquartz non-stick coating) ---
-        {"IMS", "Competition B70 2T H24.5 (12-18g)", {"ims 24.5", "ims h24.5", "ims competition 24.5"}, 58, 12, 18, WP::Straight, true, FR::Standard, 0, 300, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Flexible low-dose competition flat; 0.30mm holes.")},
-        {"IMS", "Competition B70 2T H26.5 (18-21g)", {"ims 26.5", "ims h26.5", "ims competition", "ims 18g"}, 58, 18, 21, WP::Straight, true, FR::Standard, 641, 300, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Reference IMS competition double — 641 holes at 0.30mm.")},
-        {"IMS", "Competition Convex B70 2TC H28.5 (19-22g)", {"ims convex", "ims 2tc", "ims h28.5"}, 58, 19, 22, WP::Convex, true, FR::Standard, 715, 300, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Convex base concentrates flow to the centre; 715 holes, ridgeless.")},
-        {"IMS", "SuperFine B70 2T H24 (14-16g)", {"ims superfine", "ims sf", "eb lab superfine"}, 58, 14, 16, WP::Straight, true, FR::Restrictive, 565, 170, QStringLiteral("stainless + 170µm membrane"), QStringLiteral("170µm membrane over 565 holes cuts fines passthrough — finer filtration, slower flow.")},
-        {"IMS", "Nanoquartz B70 2TF NT (14-28g)", {"ims nanotech", "ims nanoquartz", "ims nt"}, 58, 14, 28, WP::Straight, true, FR::Standard, 715, 300, QStringLiteral("304 + Nanoquartz non-stick coating"), QStringLiteral("Competition geometry plus a water/oil-repellent non-stick coating for clean puck release.")},
+        {"IMS", "12-18g Competition B70 2T H24.5", {"ims 24.5", "ims h24.5", "ims competition 24.5"}, 58, 12, 18, WP::Straight, true, FR::Standard, 0, 300, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Flexible low-dose competition flat; 0.30mm holes.")},
+        {"IMS", "18-21g Competition B70 2T H26.5", {"ims 26.5", "ims h26.5", "ims competition", "ims 18g"}, 58, 18, 21, WP::Straight, true, FR::Standard, 641, 300, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Reference IMS competition double — 641 holes at 0.30mm.")},
+        {"IMS", "19-22g Competition Convex B70 2TC H28.5", {"ims convex", "ims 2tc", "ims h28.5"}, 58, 19, 22, WP::Convex, true, FR::Standard, 715, 300, QStringLiteral("AISI 304, electropolished"), QStringLiteral("Convex base concentrates flow to the centre; 715 holes, ridgeless.")},
+        {"IMS", "14-16g SuperFine B70 2T H24", {"ims superfine", "ims sf", "eb lab superfine"}, 58, 14, 16, WP::Straight, true, FR::Restrictive, 565, 170, QStringLiteral("stainless + 170µm membrane"), QStringLiteral("170µm membrane over 565 holes cuts fines passthrough — finer filtration, slower flow.")},
+        {"IMS", "14-28g Nanoquartz B70 2TF NT", {"ims nanotech", "ims nanoquartz", "ims nt"}, 58, 14, 28, WP::Straight, true, FR::Standard, 715, 300, QStringLiteral("304 + Nanoquartz non-stick coating"), QStringLiteral("Competition geometry plus a water/oil-repellent non-stick coating for clean puck release.")},
 
         // --- S-Works (CNC-machined from solid 17-4 PH stainless billet,
         //     0.75mm walls, holes to the edge; each model is ALSO sold in
@@ -264,14 +277,21 @@ inline QStringList allBrands()
     return brands;
 }
 
-// All known models for a brand, in registry order.
+// All known models for a brand, sorted by dose size ascending (smallest first).
+// Model names lead with their size, so a size-ordered list reads as a clean
+// numeric progression in the picker; ties keep registry order (stable sort).
 inline QStringList modelsForBrand(const QString& brand)
 {
-    QStringList models;
+    std::vector<std::pair<double, QString>> rows;
     for (const auto& entry : allBaskets()) {
         if (entry.brand.compare(brand, Qt::CaseInsensitive) == 0)
-            models << entry.model;
+            rows.emplace_back(entry.doseMinG, entry.model);
     }
+    std::stable_sort(rows.begin(), rows.end(),
+                     [](const auto& a, const auto& b) { return a.first < b.first; });
+    QStringList models;
+    for (const auto& r : rows)
+        models << r.second;
     return models;
 }
 

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -4,6 +4,7 @@
 #include "../history/equipmentstorage.h"
 #include "settings_visualizer.h"
 #include "grinderaliases.h"
+#include "basketaliases.h"
 
 #include <QtMath>
 #include <QDebug>
@@ -148,6 +149,19 @@ void SettingsDye::applyEquipmentIdentity(const QVariantMap& pkg)
     if (m_dyeEquipmentName != name) {
         m_dyeEquipmentName = name;
         emit dyeEquipmentNameChanged();
+    }
+
+    // Basket identity + registry summary (resolved from the package; empty when
+    // the package has no basket or it's a custom off-registry basket).
+    const QString basketBrand = pkg.value("basketBrand").toString();
+    const QString basketModel = pkg.value("basketModel").toString();
+    const QString basketSummary = pkg.value("basketSummary").toString();
+    if (m_dyeBasketBrand != basketBrand || m_dyeBasketModel != basketModel
+        || m_dyeBasketSummary != basketSummary) {
+        m_dyeBasketBrand = basketBrand;
+        m_dyeBasketModel = basketModel;
+        m_dyeBasketSummary = basketSummary;
+        emit dyeBasketChanged();
     }
 }
 
@@ -325,6 +339,19 @@ void SettingsDye::switchToEquipment(const QVariantMap& pkg) {
     // Apply the package's last dial — grinder-scoped memory, never blank, editable.
     setDyeGrinderSetting(pkg.value("lastGrindSetting").toString());
     setDyeGrinderRpm(pkg.value("lastRpm").toInt());
+    // Refresh the basket display cache immediately (the async packageReady ->
+    // applyEquipmentIdentity will re-confirm it). The picker's pkg map carries the
+    // resolved basket identity + summary from EquipmentPackageView::toVariantMap.
+    const QString basketBrand = pkg.value("basketBrand").toString();
+    const QString basketModel = pkg.value("basketModel").toString();
+    const QString basketSummary = pkg.value("basketSummary").toString();
+    if (m_dyeBasketBrand != basketBrand || m_dyeBasketModel != basketModel
+        || m_dyeBasketSummary != basketSummary) {
+        m_dyeBasketBrand = basketBrand;
+        m_dyeBasketModel = basketModel;
+        m_dyeBasketSummary = basketSummary;
+        emit dyeBasketChanged();
+    }
     if (m_equipmentStorage)
         m_equipmentStorage->requestTouchLastUsed(id);
 }
@@ -347,6 +374,20 @@ QStringList SettingsDye::knownGrinderBrands() const {
 
 QStringList SettingsDye::knownGrinderModels(const QString& brand) const {
     return GrinderAliases::modelsForBrand(brand);
+}
+
+QStringList SettingsDye::knownBasketBrands() const {
+    return BasketAliases::allBrands();
+}
+
+QStringList SettingsDye::knownBasketModels(const QString& brand) const {
+    return BasketAliases::modelsForBrand(brand);
+}
+
+QString SettingsDye::basketModelSummary(const QString& brand, const QString& model) const {
+    if (const BasketAliases::BasketEntry* e = BasketAliases::findEntry(brand, model))
+        return BasketAliases::summary(*e);
+    return QString();
 }
 
 double SettingsDye::dyeBeanWeight() const {

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -36,6 +36,14 @@ class SettingsDye : public QObject {
     // Active package's display name (read-only; defaults to "{brand} {model}").
     // UI shows this instead of the raw grinder identity (add-equipment-packages).
     Q_PROPERTY(QString dyeEquipmentName READ dyeEquipmentName NOTIFY dyeEquipmentNameChanged)
+    // Active package's basket identity (read-only; empty when none). Basket is
+    // part of the package identity, not a per-shot dial, so these are resolved
+    // from the active package like dyeEquipmentName (add-basket-equipment).
+    Q_PROPERTY(QString dyeBasketBrand READ dyeBasketBrand NOTIFY dyeBasketChanged)
+    Q_PROPERTY(QString dyeBasketModel READ dyeBasketModel NOTIFY dyeBasketChanged)
+    // One-line registry summary of the active basket (wall/flow/precision/dose),
+    // empty for none or a custom off-registry basket.
+    Q_PROPERTY(QString dyeBasketSummary READ dyeBasketSummary NOTIFY dyeBasketChanged)
     Q_PROPERTY(QString dyeGrinderSetting READ dyeGrinderSetting WRITE setDyeGrinderSetting NOTIFY dyeGrinderSettingChanged)
     // Grinder rpm dial-in (add-equipment-packages); shown only when the active
     // package's grinder is rpmCapable. 0 = unset.
@@ -107,6 +115,10 @@ public:
 
     QString dyeEquipmentName() const { return m_dyeEquipmentName; }
 
+    QString dyeBasketBrand() const { return m_dyeBasketBrand; }
+    QString dyeBasketModel() const { return m_dyeBasketModel; }
+    QString dyeBasketSummary() const { return m_dyeBasketSummary; }
+
     QString dyeGrinderSetting() const;
     void setDyeGrinderSetting(const QString& value);
 
@@ -131,6 +143,13 @@ public:
     Q_INVOKABLE bool isBurrSwappable(const QString& brand, const QString& model) const;
     Q_INVOKABLE QStringList knownGrinderBrands() const;
     Q_INVOKABLE QStringList knownGrinderModels(const QString& brand) const;
+
+    // Basket registry bridges for the vendor-first picker (add-basket-equipment).
+    Q_INVOKABLE QStringList knownBasketBrands() const;
+    Q_INVOKABLE QStringList knownBasketModels(const QString& brand) const;
+    // Differentiator subtitle for a basket model row (registry summary), e.g.
+    // "straight-wall, precision, open flow, 17-19g". Empty for a custom basket.
+    Q_INVOKABLE QString basketModelSummary(const QString& brand, const QString& model) const;
 
     double dyeBeanWeight() const;
     void setDyeBeanWeight(double value);
@@ -209,6 +228,7 @@ signals:
     void dyeGrinderModelChanged();
     void dyeGrinderBurrsChanged();
     void dyeEquipmentNameChanged();
+    void dyeBasketChanged();
     void dyeGrinderSettingChanged();
     void dyeGrinderRpmChanged();
     void activeEquipmentIdChanged();
@@ -264,6 +284,9 @@ private:
     mutable QString m_dyeGrinderModelCache;
     mutable QString m_dyeGrinderBurrsCache;
     QString m_dyeEquipmentName;  // active package display name (resolved, not persisted)
+    QString m_dyeBasketBrand;    // active package basket identity (resolved, not persisted)
+    QString m_dyeBasketModel;
+    QString m_dyeBasketSummary;  // registry summary of the active basket (resolved)
     mutable QString m_dyeGrinderSettingCache;
     mutable int m_dyeGrinderRpmCache = 0;
     mutable double m_dyeBeanWeightCache = 18.0;

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -148,7 +148,7 @@ public:
     Q_INVOKABLE QStringList knownBasketBrands() const;
     Q_INVOKABLE QStringList knownBasketModels(const QString& brand) const;
     // Differentiator subtitle for a basket model row (registry summary), e.g.
-    // "straight-wall, precision, open flow, 17-19g". Empty for a custom basket.
+    // "58mm, straight-wall, precision, open flow, 17-19g". Empty for a custom basket.
     Q_INVOKABLE QString basketModelSummary(const QString& brand, const QString& model) const;
 
     double dyeBeanWeight() const;

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -1,6 +1,7 @@
 #include "equipmentstorage.h"
 #include "core/dbutils.h"
 #include "core/grinderaliases.h"
+#include "core/basketaliases.h"
 
 #include <QSqlQuery>
 #include <QSqlError>
@@ -144,6 +145,10 @@ const char* kItemColumns = "id, package_id, kind, brand, model, attrs";
 // ---------------------------------------------------------------------------
 QString EquipmentItem::attrsJson() const
 {
+    // Only the grinder kind carries attrs (burrs + rpmCapable). A basket's specs
+    // are derived from BasketAliases at read time, so it persists an empty blob.
+    if (kind != QStringLiteral("grinder"))
+        return QStringLiteral("{}");
     QJsonObject obj;
     if (!burrs.isEmpty())
         obj.insert(QStringLiteral("burrs"), burrs);
@@ -188,6 +193,23 @@ QVariantMap EquipmentPackageView::toVariantMap() const
     map.insert(QStringLiteral("grinderModel"), grinder.model);
     map.insert(QStringLiteral("grinderBurrs"), grinder.burrs);
     map.insert(QStringLiteral("rpmCapable"), grinder.rpmCapable);
+    // Resolved basket identity (empty when the package has no basket) plus its
+    // registry-derived specs. Specs are NOT stored — they are looked up here from
+    // BasketAliases::findEntry, so a curated-DB refinement flows to every package.
+    // A custom (off-registry) basket resolves to identity only (specs omitted).
+    map.insert(QStringLiteral("basketBrand"), basket.brand);
+    map.insert(QStringLiteral("basketModel"), basket.model);
+    if (!basket.brand.isEmpty() || !basket.model.isEmpty()) {
+        if (const BasketAliases::BasketEntry* e =
+                BasketAliases::findEntry(basket.brand, basket.model)) {
+            map.insert(QStringLiteral("basketWallProfile"), BasketAliases::wallProfileName(e->wall));
+            map.insert(QStringLiteral("basketRelativeFlow"), BasketAliases::flowRateName(e->flow));
+            map.insert(QStringLiteral("basketPrecision"), e->precision);
+            map.insert(QStringLiteral("basketDoseMinG"), e->doseMinG);
+            map.insert(QStringLiteral("basketDoseMaxG"), e->doseMaxG);
+            map.insert(QStringLiteral("basketSummary"), BasketAliases::summary(*e));
+        }
+    }
     map.insert(QStringLiteral("shotCount"), shotCount);
     return map;
 }
@@ -256,6 +278,7 @@ void EquipmentStorage::requestPackage(qint64 packageId)
                 EquipmentPackageView view;
                 view.package = pkg;
                 view.grinder = loadGrinderItemStatic(db, packageId);
+                view.basket = loadBasketItemStatic(db, packageId);
                 *result = view.toVariantMap();
             }
         },
@@ -273,11 +296,22 @@ void EquipmentStorage::requestCreatePackage(const QVariantMap& packageMap)
             const QString brand = packageMap.value(QStringLiteral("grinderBrand")).toString();
             const QString model = packageMap.value(QStringLiteral("grinderModel")).toString();
             const QString burrs = packageMap.value(QStringLiteral("grinderBurrs")).toString();
-            *newId = createPackageWithGrinderStatic(db, pkg, brand, model, burrs);
+            const QString basketBrand = packageMap.value(QStringLiteral("basketBrand")).toString();
+            const QString basketModel = packageMap.value(QStringLiteral("basketModel")).toString();
+            // Dedup backstop: if an in-inventory package already has this exact
+            // full identity (grinder + basket), return it instead of inserting a
+            // duplicate. The dialog blocks this in the UI too, but the storage is
+            // the authoritative guard against duplicate gear (we don't want dups).
+            const qint64 existing = findPackageByGrinderIdentityStatic(db, brand, model, burrs, 0,
+                                                                       basketBrand, basketModel);
+            *newId = existing > 0
+                ? existing
+                : createPackageWithGrinderStatic(db, pkg, brand, model, burrs, basketBrand, basketModel);
             if (*newId > 0) {
                 EquipmentPackageView view;
                 view.package = loadPackageStatic(db, *newId);
                 view.grinder = loadGrinderItemStatic(db, *newId);
+                view.basket = loadBasketItemStatic(db, *newId);
                 *created = view.toVariantMap();
             }
         },
@@ -304,23 +338,33 @@ void EquipmentStorage::requestUpdatePackage(qint64 packageId, const QVariantMap&
     runAsync("equip_update",
         [packageId, fields, success, resultId](QSqlDatabase& db) {
             bool any = false;
+            // Identity = grinder (brand/model/burrs) + basket (brand/model). An
+            // edit to EITHER side runs through the copy-on-write engine; the
+            // untouched side is defaulted from the current items so it is preserved.
             const bool touchesGrinder = fields.contains(QStringLiteral("grinderBrand"))
                 || fields.contains(QStringLiteral("grinderModel"))
                 || fields.contains(QStringLiteral("grinderBurrs"));
-            if (touchesGrinder) {
+            const bool touchesBasket = fields.contains(QStringLiteral("basketBrand"))
+                || fields.contains(QStringLiteral("basketModel"));
+            if (touchesGrinder || touchesBasket) {
                 const EquipmentItem cur = loadGrinderItemStatic(db, packageId);
+                const EquipmentItem curBasket = loadBasketItemStatic(db, packageId);
                 const QString brand = fields.value(QStringLiteral("grinderBrand"), cur.brand).toString();
                 const QString model = fields.value(QStringLiteral("grinderModel"), cur.model).toString();
                 const QString burrs = fields.value(QStringLiteral("grinderBurrs"), cur.burrs).toString();
-                *resultId = supersedeOrEditGrinderStatic(db, packageId, brand, model, burrs);
+                const QString bBrand = fields.value(QStringLiteral("basketBrand"), curBasket.brand).toString();
+                const QString bModel = fields.value(QStringLiteral("basketModel"), curBasket.model).toString();
+                *resultId = supersedeOrEditStatic(db, packageId, brand, model, burrs, bBrand, bModel);
                 any = (*resultId > 0);
             }
-            // Strip grinder keys before the package-column update; apply the rest
+            // Strip identity keys before the package-column update; apply the rest
             // (e.g. name) to the RESULT package.
             QVariantMap pkgFields = fields;
             pkgFields.remove(QStringLiteral("grinderBrand"));
             pkgFields.remove(QStringLiteral("grinderModel"));
             pkgFields.remove(QStringLiteral("grinderBurrs"));
+            pkgFields.remove(QStringLiteral("basketBrand"));
+            pkgFields.remove(QStringLiteral("basketModel"));
             if (!pkgFields.isEmpty())
                 any = updatePackageFieldsStatic(db, *resultId, pkgFields) || any;
             *success = any;
@@ -485,7 +529,9 @@ qint64 EquipmentStorage::insertItemStatic(QSqlDatabase& db, const EquipmentItem&
 
 qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, EquipmentPackage pkg,
                                                         const QString& brand, const QString& model,
-                                                        const QString& burrs)
+                                                        const QString& burrs,
+                                                        const QString& basketBrand,
+                                                        const QString& basketModel)
 {
     // Persist a name at creation so it survives identity edits / copy-on-write
     // (two packages may share a display name; the id is the permanent handle).
@@ -494,6 +540,12 @@ qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, Equipm
     const qint64 packageId = insertPackageStatic(db, pkg);
     if (packageId <= 0)
         return -1;
+    auto dropPackage = [&]() {
+        QSqlQuery dp(db);
+        dp.prepare("DELETE FROM equipment_packages WHERE id = :id");
+        dp.bindValue(":id", packageId);
+        dp.exec();
+    };
     EquipmentItem grinder;
     grinder.packageId = packageId;
     grinder.kind = QStringLiteral("grinder");
@@ -504,11 +556,26 @@ qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, Equipm
     if (insertItemStatic(db, grinder) <= 0) {
         // A package with no grinder item resolves to a blank grinder everywhere;
         // don't leave that orphan behind — drop the just-inserted package row.
-        QSqlQuery dp(db);
-        dp.prepare("DELETE FROM equipment_packages WHERE id = :id");
-        dp.bindValue(":id", packageId);
-        dp.exec();
+        dropPackage();
         return -1;
+    }
+    // Optional basket item. A failure here is fatal too: a half-built package
+    // (grinder but a dropped basket the caller asked for) would silently lose the
+    // basket identity, so roll the whole package back.
+    if (!basketBrand.trimmed().isEmpty() || !basketModel.trimmed().isEmpty()) {
+        EquipmentItem basket;
+        basket.packageId = packageId;
+        basket.kind = QStringLiteral("basket");
+        basket.brand = basketBrand.trimmed();
+        basket.model = basketModel.trimmed();
+        if (insertItemStatic(db, basket) <= 0) {
+            QSqlQuery di(db);
+            di.prepare("DELETE FROM equipment_items WHERE package_id = :id");
+            di.bindValue(":id", packageId);
+            di.exec();
+            dropPackage();
+            return -1;
+        }
     }
     return packageId;
 }
@@ -535,6 +602,63 @@ EquipmentItem EquipmentStorage::loadGrinderItemStatic(QSqlDatabase& db, qint64 p
     return grinderItemFromQueryRow(query);
 }
 
+EquipmentItem EquipmentStorage::loadBasketItemStatic(QSqlDatabase& db, qint64 packageId)
+{
+    QSqlQuery query(db);
+    query.prepare(QString("SELECT %1 FROM equipment_items "
+                          "WHERE package_id = :id AND kind = 'basket' ORDER BY id LIMIT 1")
+                      .arg(QLatin1String(kItemColumns)));
+    query.bindValue(":id", packageId);
+    if (!query.exec() || !query.next())
+        return EquipmentItem();  // invalid (id == 0): no basket
+    return grinderItemFromQueryRow(query);  // generic item read (kind/brand/model)
+}
+
+bool EquipmentStorage::setBasketItemStatic(QSqlDatabase& db, qint64 packageId,
+                                           const QString& brand, const QString& model)
+{
+    const QString b = brand.trimmed();
+    const QString m = model.trimmed();
+    const EquipmentItem cur = loadBasketItemStatic(db, packageId);
+    const bool wantNone = b.isEmpty() && m.isEmpty();
+
+    if (wantNone) {
+        if (!cur.isValid())
+            return false;  // nothing to clear
+        QSqlQuery del(db);
+        del.prepare("DELETE FROM equipment_items WHERE package_id = :id AND kind = 'basket'");
+        del.bindValue(":id", packageId);
+        if (!del.exec()) {
+            qWarning() << "EquipmentStorage: basket clear failed for package" << packageId << ":"
+                       << del.lastError().text();
+            return false;
+        }
+        return del.numRowsAffected() > 0;
+    }
+
+    if (cur.isValid()) {
+        QSqlQuery upd(db);
+        upd.prepare("UPDATE equipment_items SET brand = :brand, model = :model, attrs = '{}', "
+                    "updated_at = strftime('%s', 'now') WHERE package_id = :id AND kind = 'basket'");
+        upd.bindValue(":brand", nullIfEmpty(b));
+        upd.bindValue(":model", nullIfEmpty(m));
+        upd.bindValue(":id", packageId);
+        if (!upd.exec()) {
+            qWarning() << "EquipmentStorage: basket update failed for package" << packageId << ":"
+                       << upd.lastError().text();
+            return false;
+        }
+        return upd.numRowsAffected() > 0;
+    }
+
+    EquipmentItem basket;
+    basket.packageId = packageId;
+    basket.kind = QStringLiteral("basket");
+    basket.brand = b;
+    basket.model = m;
+    return insertItemStatic(db, basket) > 0;
+}
+
 QVector<EquipmentPackageView> EquipmentStorage::loadInventoryStatic(QSqlDatabase& db)
 {
     QVector<EquipmentPackageView> views;
@@ -556,9 +680,12 @@ QVector<EquipmentPackageView> EquipmentStorage::loadInventoryStatic(QSqlDatabase
         views.append(view);
         ids.append(view.package.id);
     }
-    // Resolve each package's grinder item (inventory is small — a handful of rows).
-    for (qsizetype i = 0; i < views.size(); ++i)
+    // Resolve each package's grinder + (optional) basket item (inventory is small
+    // — a handful of rows).
+    for (qsizetype i = 0; i < views.size(); ++i) {
         views[i].grinder = loadGrinderItemStatic(db, ids.at(i));
+        views[i].basket = loadBasketItemStatic(db, ids.at(i));
+    }
     return views;
 }
 
@@ -621,8 +748,14 @@ bool EquipmentStorage::updateGrinderItemStatic(QSqlDatabase& db, qint64 packageI
 
 qint64 EquipmentStorage::findPackageByGrinderIdentityStatic(QSqlDatabase& db, const QString& brand,
                                                             const QString& model, const QString& burrs,
-                                                            qint64 excludeId)
+                                                            qint64 excludeId,
+                                                            const QString& basketBrand,
+                                                            const QString& basketModel)
 {
+    // Full-identity match: grinder brand/model/burrs AND the package's basket
+    // brand/model. The basket is matched via correlated subqueries so that a
+    // package with NO basket item resolves to '' and matches empty basket params
+    // ("no basket" is a distinct, matchable identity value).
     QSqlQuery query(db);
     query.prepare("SELECT i.package_id FROM equipment_items i "
                   "JOIN equipment_packages p ON p.id = i.package_id "
@@ -631,11 +764,20 @@ qint64 EquipmentStorage::findPackageByGrinderIdentityStatic(QSqlDatabase& db, co
                   "AND LOWER(IFNULL(i.brand,'')) = LOWER(:brand) "
                   "AND LOWER(IFNULL(i.model,'')) = LOWER(:model) "
                   "AND LOWER(IFNULL(json_extract(i.attrs,'$.burrs'),'')) = LOWER(:burrs) "
+                  // IFNULL on the bind side too: a grinder-only caller passes a null
+                  // QString, which binds as SQL NULL — without IFNULL the '' = NULL
+                  // comparison is NULL (never true) and no-basket packages stop matching.
+                  "AND LOWER(IFNULL((SELECT b.brand FROM equipment_items b "
+                  "  WHERE b.package_id = p.id AND b.kind = 'basket' ORDER BY b.id LIMIT 1),'')) = LOWER(IFNULL(:bbrand,'')) "
+                  "AND LOWER(IFNULL((SELECT b.model FROM equipment_items b "
+                  "  WHERE b.package_id = p.id AND b.kind = 'basket' ORDER BY b.id LIMIT 1),'')) = LOWER(IFNULL(:bmodel,'')) "
                   "ORDER BY p.id LIMIT 1");
     query.bindValue(":exclude", excludeId);
     query.bindValue(":brand", brand);
     query.bindValue(":model", model);
     query.bindValue(":burrs", burrs);
+    query.bindValue(":bbrand", basketBrand.trimmed());
+    query.bindValue(":bmodel", basketModel.trimmed());
     if (!query.exec() || !query.next())
         return 0;
     return query.value(0).toLongLong();
@@ -645,12 +787,26 @@ qint64 EquipmentStorage::supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 p
                                                       const QString& brand, const QString& model,
                                                       const QString& burrs)
 {
+    // Grinder-only edit: preserve the package's current basket identity.
+    const EquipmentItem curBasket = loadBasketItemStatic(db, packageId);
+    return supersedeOrEditStatic(db, packageId, brand, model, burrs,
+                                 curBasket.brand, curBasket.model);
+}
+
+qint64 EquipmentStorage::supersedeOrEditStatic(QSqlDatabase& db, qint64 packageId,
+                                               const QString& brand, const QString& model,
+                                               const QString& burrs,
+                                               const QString& basketBrand, const QString& basketModel)
+{
     const EquipmentItem cur = loadGrinderItemStatic(db, packageId);
+    const EquipmentItem curBasket = loadBasketItemStatic(db, packageId);
 
     auto norm = [](const QString& s) { return s.trimmed().toLower(); };
     const bool unchanged = norm(cur.brand) == norm(brand)
         && norm(cur.model) == norm(model)
-        && norm(cur.burrs) == norm(burrs);
+        && norm(cur.burrs) == norm(burrs)
+        && norm(curBasket.brand) == norm(basketBrand)
+        && norm(curBasket.model) == norm(basketModel);
     if (unchanged)
         return packageId;  // no identity change
 
@@ -695,8 +851,9 @@ qint64 EquipmentStorage::supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 p
         return result;
     };
 
-    // Merge: another current package already has this exact identity.
-    const qint64 mergeTarget = findPackageByGrinderIdentityStatic(db, brand, model, burrs, packageId);
+    // Merge: another current package already has this exact full identity.
+    const qint64 mergeTarget = findPackageByGrinderIdentityStatic(db, brand, model, burrs, packageId,
+                                                                  basketBrand, basketModel);
     if (mergeTarget > 0) {
         if (!repointBags(packageId, mergeTarget))
             return fail();
@@ -715,10 +872,14 @@ qint64 EquipmentStorage::supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 p
         return done(mergeTarget);
     }
 
-    // Unused package: safe to edit in place.
+    // Unused package: safe to edit in place (both grinder and basket items).
     if (shotCount() == 0) {
         if (!updateGrinderItemStatic(db, packageId, brand, model, burrs))
             return fail();
+        // setBasketItemStatic returns false when there's nothing to change (e.g.
+        // the basket was already correct), which is not a failure here — the
+        // grinder edit above already confirmed the identity changed.
+        setBasketItemStatic(db, packageId, basketBrand, basketModel);
         return done(packageId);
     }
 
@@ -729,7 +890,8 @@ qint64 EquipmentStorage::supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 p
     np.lastGrindSetting = old.lastGrindSetting;
     np.lastRpm = old.lastRpm;
     np.lastUsedEpoch = QDateTime::currentSecsSinceEpoch();
-    const qint64 newId = createPackageWithGrinderStatic(db, np, brand, model, burrs);
+    const qint64 newId = createPackageWithGrinderStatic(db, np, brand, model, burrs,
+                                                        basketBrand, basketModel);
     if (newId <= 0)
         return fail();  // fork failed; leave as-is
     if (!repointBags(packageId, newId))
@@ -956,7 +1118,7 @@ bool EquipmentStorage::importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& 
         if (srcPkg.supersededBy > 0)
             srcSupersededBy.insert(srcPkg.id, srcPkg.supersededBy);
 
-        // Load the source grinder item (for identity-based merge dedup).
+        // Load the source grinder + basket items (for full-identity merge dedup).
         EquipmentItem srcGrinder;
         {
             QSqlQuery gi(srcDb);
@@ -966,16 +1128,18 @@ bool EquipmentStorage::importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& 
             if (gi.exec() && gi.next())
                 srcGrinder = grinderItemFromQueryRow(gi);
         }
+        EquipmentItem srcBasket = loadBasketItemStatic(srcDb, srcPkg.id);
 
-        // Merge dedup: an IN-INVENTORY source package whose grinder identity
-        // already exists in dest maps to that package — no duplicate. Superseded
-        // (historical) packages always import as new rows so their shots keep a
-        // distinct lineage.
+        // Merge dedup: an IN-INVENTORY source package whose FULL identity (grinder
+        // + basket) already exists in dest maps to that package — no duplicate.
+        // Superseded (historical) packages always import as new rows so their
+        // shots keep a distinct lineage.
         qint64 destId = -1;
         if (merge && srcPkg.inInventory
             && !(srcGrinder.brand.isEmpty() && srcGrinder.model.isEmpty())) {
             const qint64 existing = findPackageByGrinderIdentityStatic(
-                destDb, srcGrinder.brand, srcGrinder.model, srcGrinder.burrs);
+                destDb, srcGrinder.brand, srcGrinder.model, srcGrinder.burrs, 0,
+                srcBasket.brand, srcBasket.model);
             if (existing > 0)
                 destId = existing;
         }

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -544,7 +544,13 @@ qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, Equipm
         QSqlQuery dp(db);
         dp.prepare("DELETE FROM equipment_packages WHERE id = :id");
         dp.bindValue(":id", packageId);
-        dp.exec();
+        // On the direct (non-transactional) create path a failed cleanup here
+        // would orphan the package row; log it so an incomplete rollback is
+        // visible rather than silent. (In the fork path the outer transaction
+        // rolls it back regardless.)
+        if (!dp.exec())
+            qWarning() << "EquipmentStorage: rollback drop of package" << packageId
+                       << "failed (possible orphan):" << dp.lastError().text();
     };
     EquipmentItem grinder;
     grinder.packageId = packageId;
@@ -572,7 +578,9 @@ qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, Equipm
             QSqlQuery di(db);
             di.prepare("DELETE FROM equipment_items WHERE package_id = :id");
             di.bindValue(":id", packageId);
-            di.exec();
+            if (!di.exec())
+                qWarning() << "EquipmentStorage: rollback delete of items for package" << packageId
+                           << "failed (possible orphan):" << di.lastError().text();
             dropPackage();
             return -1;
         }
@@ -622,9 +630,15 @@ bool EquipmentStorage::setBasketItemStatic(QSqlDatabase& db, qint64 packageId,
     const EquipmentItem cur = loadBasketItemStatic(db, packageId);
     const bool wantNone = b.isEmpty() && m.isEmpty();
 
+    // Return contract: true on success OR when no change is needed (the basket is
+    // already in the desired state); false ONLY on a genuine SQL failure. This
+    // distinction matters — a caller inside a transaction (supersedeOrEditStatic's
+    // edit-in-place branch) must roll back on a real write error but must NOT
+    // treat a benign no-op as failure. A successful statement that affects 0 rows
+    // is success, not failure, so we don't gate on numRowsAffected().
     if (wantNone) {
         if (!cur.isValid())
-            return false;  // nothing to clear
+            return true;  // already has no basket — desired state reached, nothing to do
         QSqlQuery del(db);
         del.prepare("DELETE FROM equipment_items WHERE package_id = :id AND kind = 'basket'");
         del.bindValue(":id", packageId);
@@ -633,7 +647,7 @@ bool EquipmentStorage::setBasketItemStatic(QSqlDatabase& db, qint64 packageId,
                        << del.lastError().text();
             return false;
         }
-        return del.numRowsAffected() > 0;
+        return true;
     }
 
     if (cur.isValid()) {
@@ -648,7 +662,7 @@ bool EquipmentStorage::setBasketItemStatic(QSqlDatabase& db, qint64 packageId,
                        << upd.lastError().text();
             return false;
         }
-        return upd.numRowsAffected() > 0;
+        return true;
     }
 
     EquipmentItem basket;
@@ -876,10 +890,11 @@ qint64 EquipmentStorage::supersedeOrEditStatic(QSqlDatabase& db, qint64 packageI
     if (shotCount() == 0) {
         if (!updateGrinderItemStatic(db, packageId, brand, model, burrs))
             return fail();
-        // setBasketItemStatic returns false when there's nothing to change (e.g.
-        // the basket was already correct), which is not a failure here — the
-        // grinder edit above already confirmed the identity changed.
-        setBasketItemStatic(db, packageId, basketBrand, basketModel);
+        // A false return is a genuine SQL failure (a no-op returns true), so roll
+        // back rather than commit a half-applied identity (grinder changed, basket
+        // write failed) — this edit runs inside the transaction opened above.
+        if (!setBasketItemStatic(db, packageId, basketBrand, basketModel))
+            return fail();
         return done(packageId);
     }
 

--- a/src/history/equipmentstorage.h
+++ b/src/history/equipmentstorage.h
@@ -148,6 +148,9 @@ public:
     // Set the package's basket identity: update the existing basket item, insert
     // one when none exists, or delete it when brand+model are both empty (the
     // "no basket" state). No grinder analogue — a package's basket is optional.
+    // Returns true on success OR when no change is needed (basket already in the
+    // desired state); false ONLY on a genuine SQL failure, so a caller inside a
+    // transaction can roll back on a real error without tripping on a benign no-op.
     static bool setBasketItemStatic(QSqlDatabase& db, qint64 packageId,
                                     const QString& brand, const QString& model);
 

--- a/src/history/equipmentstorage.h
+++ b/src/history/equipmentstorage.h
@@ -13,14 +13,17 @@
 class QSqlDatabase;
 class QSqlQuery;
 
-// An equipment item: one typed component of a package. Today the only kind is
-// "grinder"; future kinds (basket, tamper, …) are new rows with a different
-// `kind` and their own `attrs` payload — no schema migration (openspec change
-// add-equipment-packages). Shared fields every kind has (kind/brand/model) are
-// real columns; kind-specific fields live in the `attrs` JSON blob. For a
-// grinder, attrs = { "burrs": "...", "rpmCapable": true }. The `burrs` and
-// `rpmCapable` members below are convenience views of that blob, (de)serialized
-// on load/save — they are not their own columns.
+// An equipment item: one typed component of a package. The kinds today are
+// "grinder" and the optional "basket" (add-basket-equipment); future kinds
+// (tamper, …) are new rows with a different `kind` and their own `attrs` payload
+// — no schema migration (openspec change add-equipment-packages). Shared fields
+// every kind has (kind/brand/model) are real columns; kind-specific fields live
+// in the `attrs` JSON blob. For a grinder, attrs = { "burrs": "...",
+// "rpmCapable": true }. The `burrs` and `rpmCapable` members below are
+// convenience views of that blob, (de)serialized on load/save — they are not
+// their own columns. A basket has NO kind-specific attrs: its identity is
+// brand+model and every spec (wall/flow/precision/dose) is derived from
+// BasketAliases at read time, so a basket item carries an empty attrs blob.
 struct EquipmentItem {
     qint64 id = 0;
     qint64 packageId = 0;
@@ -28,7 +31,8 @@ struct EquipmentItem {
     QString brand;
     QString model;
 
-    // Grinder-kind attrs (mirrored into/out of the `attrs` JSON column).
+    // Grinder-kind attrs (mirrored into/out of the `attrs` JSON column). Only
+    // written/read when kind == "grinder"; a basket item leaves these unset.
     QString burrs;
     bool rpmCapable = false;
 
@@ -66,14 +70,18 @@ struct EquipmentPackage {
     static EquipmentPackage fromVariantMap(const QVariantMap& map);
 };
 
-// A package plus its resolved grinder item and shot count, for the inventory
-// list. shotCount is a per-query aggregate (shots.equipment_id), not a package
-// field — it drives the card's delete-vs-remove action exactly like InventoryBag.
+// A package plus its resolved grinder item, optional basket item, and shot
+// count, for the inventory list. shotCount is a per-query aggregate
+// (shots.equipment_id), not a package field — it drives the card's
+// delete-vs-remove action exactly like InventoryBag. `basket` is invalid
+// (id == 0) when the package has no basket.
 struct EquipmentPackageView {
     EquipmentPackage package;
     EquipmentItem grinder;
+    EquipmentItem basket;
     qint64 shotCount = 0;
-    // Flatten package + grinder identity (+ shotCount) into one map for QML/MCP.
+    // Flatten package + grinder identity + basket identity/derived specs
+    // (+ shotCount) into one map for QML/MCP.
     QVariantMap toVariantMap() const;
 };
 
@@ -114,16 +122,21 @@ public:
 
     static qint64 insertPackageStatic(QSqlDatabase& db, const EquipmentPackage& pkg);
     static qint64 insertItemStatic(QSqlDatabase& db, const EquipmentItem& item);
-    // Create a package and its single grinder item in one call; returns the new
-    // package id (-1 on failure). rpmCapable is derived from the registry.
-    // pkg is taken by value: a name is persisted at creation (defaults to
+    // Create a package, its single grinder item, and (optionally) a basket item in
+    // one call; returns the new package id (-1 on failure). rpmCapable is derived
+    // from the registry. An empty basketBrand+basketModel creates a grinder-only
+    // package. pkg is taken by value: a name is persisted at creation (defaults to
     // "{brand} {model}") so it survives identity edits / copy-on-write.
     static qint64 createPackageWithGrinderStatic(QSqlDatabase& db, EquipmentPackage pkg,
                                                  const QString& brand, const QString& model,
-                                                 const QString& burrs);
+                                                 const QString& burrs,
+                                                 const QString& basketBrand = QString(),
+                                                 const QString& basketModel = QString());
 
     static EquipmentPackage loadPackageStatic(QSqlDatabase& db, qint64 packageId);
     static EquipmentItem loadGrinderItemStatic(QSqlDatabase& db, qint64 packageId);
+    // The package's basket item, or an invalid item (id == 0) when none.
+    static EquipmentItem loadBasketItemStatic(QSqlDatabase& db, qint64 packageId);
     static QVector<EquipmentPackageView> loadInventoryStatic(QSqlDatabase& db);
 
     static bool updatePackageFieldsStatic(QSqlDatabase& db, qint64 packageId, const QVariantMap& fields);
@@ -132,9 +145,14 @@ public:
     static bool updateGrinderItemStatic(QSqlDatabase& db, qint64 packageId,
                                         const QString& brand, const QString& model,
                                         const QString& burrs);
+    // Set the package's basket identity: update the existing basket item, insert
+    // one when none exists, or delete it when brand+model are both empty (the
+    // "no basket" state). No grinder analogue — a package's basket is optional.
+    static bool setBasketItemStatic(QSqlDatabase& db, qint64 packageId,
+                                    const QString& brand, const QString& model);
 
-    // Apply a grinder identity edit honoring copy-on-write immutability + merge,
-    // and return the package id the caller should now treat as active:
+    // Apply a grinder+basket identity edit honoring copy-on-write immutability +
+    // merge, and return the package id the caller should now treat as active:
     //   - identity unchanged                      -> same id (no-op)
     //   - another in-inventory package matches     -> merge: repoint this
     //       package's bags to it, delete this package if unused else soft-delete
@@ -142,18 +160,29 @@ public:
     //   - package unused (no shots)                -> edit in place -> same id
     //   - package used (>=1 shot)                  -> fork a new package (copies
     //       name + last dial), repoint bags, soft-delete old (superseded_by) -> new id
-    // Bag repointing is done here; the active-equipment selection is the caller's
-    // to update from the returned id.
+    // Identity is the full (grinder brand/model/burrs + basket brand/model) tuple;
+    // "no basket" is a distinct value. Bag repointing is done here; the
+    // active-equipment selection is the caller's to update from the returned id.
+    static qint64 supersedeOrEditStatic(QSqlDatabase& db, qint64 packageId,
+                                        const QString& brand, const QString& model,
+                                        const QString& burrs,
+                                        const QString& basketBrand, const QString& basketModel);
+    // Grinder-only convenience: edit the grinder identity while PRESERVING the
+    // package's current basket. Thin wrapper over supersedeOrEditStatic used by
+    // callers that don't touch the basket (MCP grinder edit, tests).
     static qint64 supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 packageId,
                                                const QString& brand, const QString& model,
                                                const QString& burrs);
 
-    // Find an existing in-inventory package whose grinder identity matches
-    // (case-insensitive brand+model+burrs), or 0 if none. Used by the migration
-    // and create flows to dedup on identity (NOT on grind/rpm).
+    // Find an existing in-inventory package whose full identity matches
+    // (case-insensitive grinder brand+model+burrs AND basket brand+model, where
+    // empty basket params match a package with no basket), or 0 if none. Used by
+    // the migration and create/edit flows to dedup on identity (NOT on grind/rpm).
     static qint64 findPackageByGrinderIdentityStatic(QSqlDatabase& db, const QString& brand,
                                                      const QString& model, const QString& burrs,
-                                                     qint64 excludeId = 0);
+                                                     qint64 excludeId = 0,
+                                                     const QString& basketBrand = QString(),
+                                                     const QString& basketModel = QString());
 
     // rpmCapable for a grinder identity: the registry's variableRpm when the
     // brand/model matches an alias, else true (a custom grinder shows the rpm

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -46,6 +46,10 @@ struct ShotRecord {
     QString grinderBrand;
     QString grinderModel;
     QString grinderBurrs;
+    // Basket identity resolved via equipment_id (add-basket-equipment); empty when
+    // the package has no basket.
+    QString basketBrand;
+    QString basketModel;
     QString grinderSetting;
     qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none
     qint64 rpm = 0;          // grinder rpm dial-in; 0 = unset

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -2203,9 +2203,11 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
                s.stopped_by, s.beanbase_json,
                s.bag_id, s.frozen_date, s.defrost_date,
                s.equipment_id, s.rpm,
-               ep.in_inventory, ep.superseded_by, ep.name
+               ep.in_inventory, ep.superseded_by, ep.name,
+               eb.brand, eb.model
         FROM shots s
         LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder'
+        LEFT JOIN equipment_items eb ON eb.package_id = s.equipment_id AND eb.kind = 'basket'
         LEFT JOIN equipment_packages ep ON ep.id = s.equipment_id
         WHERE s.id = ?
     )")) {
@@ -2276,6 +2278,11 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     record.equipmentName = query.value(43).toString();
     if (record.equipmentName.isEmpty())
         record.equipmentName = (record.grinderBrand + QLatin1Char(' ') + record.grinderModel).trimmed();
+    // Basket identity (cols 44/45) resolved through equipment_id (add-basket-
+    // equipment); empty when the package has no basket. Specs are derived
+    // downstream from BasketAliases, never stored.
+    record.basketBrand = query.value(44).toString();
+    record.basketModel = query.value(45).toString();
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     // Snapshot stored badge values before the recompute block overwrites them, so

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -60,6 +60,8 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.grinderBrand = record.grinderBrand;
     p.grinderModel = record.grinderModel;
     p.grinderBurrs = record.grinderBurrs;
+    p.basketBrand = record.basketBrand;
+    p.basketModel = record.basketModel;
     p.grinderSetting = record.grinderSetting;
     p.rpm = record.rpm;
     p.equipmentId = record.equipmentId;

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -48,6 +48,11 @@ class ShotProjection {
     Q_PROPERTY(QString grinderBrand MEMBER grinderBrand)
     Q_PROPERTY(QString grinderModel MEMBER grinderModel)
     Q_PROPERTY(QString grinderBurrs MEMBER grinderBurrs)
+    // Basket identity resolved via the shot's equipment_id (add-basket-equipment);
+    // empty when the package has no basket. Specs are derived downstream from
+    // BasketAliases, not stored here.
+    Q_PROPERTY(QString basketBrand MEMBER basketBrand)
+    Q_PROPERTY(QString basketModel MEMBER basketModel)
     Q_PROPERTY(QString grinderSetting MEMBER grinderSetting)
     Q_PROPERTY(qlonglong rpm MEMBER rpm)
     // The shot's equipment package id (add-equipment-packages) — exposed so the
@@ -133,6 +138,8 @@ public:
     QString grinderBrand;
     QString grinderModel;
     QString grinderBurrs;
+    QString basketBrand;
+    QString basketModel;
     QString grinderSetting;
     qint64 rpm = 0;
     qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -302,6 +302,8 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         in.grinderBrand = sd.grinderBrand;
                         in.grinderModel = sd.grinderModel;
                         in.grinderBurrs = sd.grinderBurrs;
+                        in.basketBrand = sd.basketBrand;
+                        in.basketModel = sd.basketModel;
                         in.grinderSetting = sd.grinderSetting;
                         in.rpm = static_cast<int>(sd.rpm);
                         in.doseWeightG = sd.doseWeightG;

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -5,6 +5,7 @@
 #include "../history/shotprojection.h"
 #include "../history/coffeebagstorage.h"
 #include "../history/equipmentstorage.h"
+#include "../core/basketaliases.h"
 #include "../history/bagid.h"
 #include "../network/visualizeruploader.h"
 #include "../controllers/profilemanager.h"
@@ -1722,6 +1723,24 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
         o["grinderModel"] = v.grinder.model;
         if (!v.grinder.burrs.isEmpty()) o["grinderBurrs"] = v.grinder.burrs;
         o["rpmAdjustable"] = v.grinder.rpmCapable;
+        // Basket identity + registry-derived specs (add-basket-equipment). Emitted
+        // only when the package has a basket; specs only when it matches the
+        // registry (a custom basket carries identity alone). Units/strings follow
+        // MCP conventions (doseRangeG, human-readable wallProfile/relativeFlow).
+        if (!v.basket.brand.isEmpty() || !v.basket.model.isEmpty()) {
+            QJsonObject basket;
+            basket["brand"] = v.basket.brand;
+            basket["model"] = v.basket.model;
+            if (const BasketAliases::BasketEntry* e =
+                    BasketAliases::findEntry(v.basket.brand, v.basket.model)) {
+                basket["wallProfile"] = BasketAliases::wallProfileName(e->wall);
+                basket["relativeFlow"] = BasketAliases::flowRateName(e->flow);
+                basket["precision"] = e->precision;
+                if (e->doseMaxG > 0)
+                    basket["doseRangeG"] = QJsonObject{{"min", e->doseMinG}, {"max", e->doseMaxG}};
+            }
+            o["basket"] = basket;
+        }
         o["inInventory"] = v.package.inInventory;
         if (!v.package.lastGrindSetting.isEmpty()) o["lastGrindSetting"] = v.package.lastGrindSetting;
         if (v.package.lastRpm > 0) o["lastRpm"] = v.package.lastRpm;
@@ -1763,12 +1782,13 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
     // equipment_update — edit a package's grinder identity (or create one).
     registry->registerAsyncTool(
         "equipment_update",
-        "Update an equipment package's grinder identity (brand/model/burrs) and optional name. Only "
-        "provided fields change. rpmAdjustable is re-derived from the grinder registry. Identity is "
-        "copy-on-write: editing a package that has shots forks a NEW package (the old one is retired "
-        "and kept for its history) and an unused package is edited in place — so the returned "
-        "package.id may differ from the input packageId. An edit matching an existing package merges "
-        "into it.",
+        "Update an equipment package's grinder identity (brand/model/burrs), optional basket identity "
+        "(basketBrand/basketModel — pass both empty to remove the basket), and optional name. Only "
+        "provided fields change. rpmAdjustable is re-derived from the grinder registry; basket specs "
+        "are derived from the basket registry. Identity (grinder AND basket) is copy-on-write: editing "
+        "a package that has shots forks a NEW package (the old one is retired and kept for its history) "
+        "and an unused package is edited in place — so the returned package.id may differ from the "
+        "input packageId. An edit matching an existing package merges into it.",
         QJsonObject{
             {"type", "object"},
             {"properties", QJsonObject{
@@ -1776,7 +1796,9 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 {"name", QJsonObject{{"type", "string"}}},
                 {"grinderBrand", QJsonObject{{"type", "string"}}},
                 {"grinderModel", QJsonObject{{"type", "string"}}},
-                {"grinderBurrs", QJsonObject{{"type", "string"}}}
+                {"grinderBurrs", QJsonObject{{"type", "string"}}},
+                {"basketBrand", QJsonObject{{"type", "string"}}},
+                {"basketModel", QJsonObject{{"type", "string"}}}
             }},
             {"required", QJsonArray{"packageId"}}
         },
@@ -1789,6 +1811,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             if (packageId <= 0) { respond(QJsonObject{{"error", "Valid packageId is required"}}); return; }
             const bool touchesGrinder = args.contains("grinderBrand") || args.contains("grinderModel")
                 || args.contains("grinderBurrs");
+            const bool touchesBasket = args.contains("basketBrand") || args.contains("basketModel");
             QVariantMap pkgFields;
             if (args.contains("name")) pkgFields.insert("name", args["name"].toString());
             const QString brand = args["grinderBrand"].toString();
@@ -1797,6 +1820,10 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             const bool haveBrand = args.contains("grinderBrand");
             const bool haveModel = args.contains("grinderModel");
             const bool haveBurrs = args.contains("grinderBurrs");
+            const QString basketBrand = args["basketBrand"].toString();
+            const QString basketModel = args["basketModel"].toString();
+            const bool haveBasketBrand = args.contains("basketBrand");
+            const bool haveBasketModel = args.contains("basketModel");
             const qint64 activeId = settings ? settings->dye()->activeEquipmentId() : -1;
             const QString dbPath = shotHistory->databasePath();
             QThread* thread = QThread::create([=]() {
@@ -1804,19 +1831,25 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 qint64 resultId = packageId;
                 EquipmentPackageView view;
                 withTempDb(dbPath, "mcp_equip_upd", [&](QSqlDatabase& db) {
-                    if (touchesGrinder) {
-                        // Copy-on-write/merge: identity edit may yield a new id.
+                    if (touchesGrinder || touchesBasket) {
+                        // Copy-on-write/merge over the full (grinder + basket)
+                        // identity; an untouched side defaults from the current
+                        // items so it is preserved. May yield a new id.
                         const EquipmentItem cur = EquipmentStorage::loadGrinderItemStatic(db, packageId);
-                        resultId = EquipmentStorage::supersedeOrEditGrinderStatic(db, packageId,
+                        const EquipmentItem curBasket = EquipmentStorage::loadBasketItemStatic(db, packageId);
+                        resultId = EquipmentStorage::supersedeOrEditStatic(db, packageId,
                                 haveBrand ? brand : cur.brand,
                                 haveModel ? model : cur.model,
-                                haveBurrs ? burrs : cur.burrs);
+                                haveBurrs ? burrs : cur.burrs,
+                                haveBasketBrand ? basketBrand : curBasket.brand,
+                                haveBasketModel ? basketModel : curBasket.model);
                         ok = (resultId > 0);
                     }
                     if (!pkgFields.isEmpty())
                         ok = EquipmentStorage::updatePackageFieldsStatic(db, resultId, pkgFields) || ok;
                     view.package = EquipmentStorage::loadPackageStatic(db, resultId);
                     view.grinder = EquipmentStorage::loadGrinderItemStatic(db, resultId);
+                    view.basket = EquipmentStorage::loadBasketItemStatic(db, resultId);
                 });
                 QMetaObject::invokeMethod(qApp, [ok, view, activeId, packageId, packageToJson, respond]() {
                     if (!ok || !view.package.isValid()) {
@@ -1858,6 +1891,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 withTempDb(dbPath, "mcp_equip_sel", [&](QSqlDatabase& db) {
                     view.package = EquipmentStorage::loadPackageStatic(db, packageId);
                     view.grinder = EquipmentStorage::loadGrinderItemStatic(db, packageId);
+                    view.basket = EquipmentStorage::loadBasketItemStatic(db, packageId);
                 });
                 const bool found = view.package.isValid();
                 const QVariantMap pkgMap = view.toVariantMap();

--- a/tests/tst_basketaliases.cpp
+++ b/tests/tst_basketaliases.cpp
@@ -266,7 +266,7 @@ void TstBasketAliases::findEntryByAlias_roundTrips()
     const BasketEntry* e = findEntryByAlias(QStringLiteral("decent stock"));
     QVERIFY(e != nullptr);
     QCOMPARE(e->brand, QStringLiteral("Decent"));
-    QCOMPARE(e->model, QStringLiteral("Ridgeless 18g"));
+    QCOMPARE(e->model, QStringLiteral("18g Ridgeless"));
 
     // Composition contract: findEntryByAlias agrees with lookup().
     const auto r = lookup(QStringLiteral("decent stock"));

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -1338,6 +1338,16 @@ private slots:
             addGrinder(older, "Turin", "DF83V", "83mm flat steel");
             addGrinder(retired, "Mazzer", "Major", "83mm");
 
+            // Basket on the current package only — pins the loadShotRecordStatic
+            // basket JOIN, which reads eb.brand/eb.model by POSITIONAL index
+            // (cols 44/45). A future SELECT-list edit that shifts those columns
+            // would silently mis-resolve the basket; this assertion catches it.
+            QSqlQuery bi(db);
+            bi.prepare("INSERT INTO equipment_items (package_id, kind, brand, model, attrs) "
+                       "VALUES (?, 'basket', 'Decent', '18g Ridgeless', '{}')");
+            bi.addBindValue(cur);
+            QVERIFY(bi.exec());
+
             auto addShot = [&](const QString& uuid, qint64 pkg) -> qint64 {
                 QSqlQuery s(db);
                 s.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, "
@@ -1358,10 +1368,13 @@ private slots:
             QCOMPARE(cur.grinderBrand, QString("Niche"));
             QCOMPARE(cur.grinderModel, QString("Zero"));
             QCOMPARE(cur.grinderBurrs, QString("63mm conical"));  // json_extract path
+            QCOMPARE(cur.basketBrand, QString("Decent"));         // cols 44/45 JOIN
+            QCOMPARE(cur.basketModel, QString("18g Ridgeless"));
             QCOMPARE(cur.equipmentState, QString(""));            // in inventory -> current
 
             const ShotRecord older = ShotHistoryStorage::loadShotRecordStatic(db, olderShot);
             QCOMPARE(older.grinderModel, QString("DF83V"));
+            QCOMPARE(older.basketBrand, QString(""));             // no basket item -> empty
             QCOMPARE(older.equipmentState, QString("older"));     // superseded
 
             const ShotRecord ret = ShotHistoryStorage::loadShotRecordStatic(db, retiredShot);
@@ -1370,6 +1383,7 @@ private slots:
 
             const ShotRecord noeq = ShotHistoryStorage::loadShotRecordStatic(db, noEqShot);
             QCOMPARE(noeq.grinderBrand, QString(""));             // NULL JOIN -> empty
+            QCOMPARE(noeq.basketBrand, QString(""));              // NULL JOIN -> empty basket
             QCOMPARE(noeq.equipmentState, QString(""));           // no package
 
             // Grinder identity is NOT FTS-indexed anymore: a search for a grinder

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -2540,6 +2540,42 @@ private slots:
         QVERIFY(!DialingBlocks::buildCurrentBeanBlock(in).contains("beanBase"));
     }
 
+    // add-basket-equipment: this helper produces the currentBean.basket payload
+    // for BOTH dialing_get_context (MCP) and the in-app advisor, so it is the
+    // single point that proves basket info reaches the AI. Identity + registry-
+    // derived specs when present; omitted when absent; identity-only for a custom
+    // (off-registry) basket — never fabricated specs.
+    void basketBlockEmitsIdentityAndDerivedSpecs()
+    {
+        DialingBlocks::CurrentBeanBlockInputs in;
+        in.beanBrand = "Saka";
+        // No basket -> no sub-object.
+        QVERIFY(!DialingBlocks::buildCurrentBeanBlock(in).contains("basket"));
+
+        // Registry basket -> identity + derived specs (human-readable strings).
+        in.basketBrand = "Weber Workshops";
+        in.basketModel = "20g Unibasket";
+        const QJsonObject bean = DialingBlocks::buildCurrentBeanBlock(in);
+        QVERIFY(bean.contains("basket"));
+        const QJsonObject b = bean["basket"].toObject();
+        QCOMPARE(b["brand"].toString(), QString("Weber Workshops"));
+        QCOMPARE(b["model"].toString(), QString("20g Unibasket"));
+        QCOMPARE(b["wallProfile"].toString(), QString("straight"));
+        QCOMPARE(b["relativeFlow"].toString(), QString("open"));  // the key cross-basket signal
+        QCOMPARE(b["precision"].toBool(), true);
+        QVERIFY(b.contains("doseRangeG"));
+        QCOMPARE(b["doseRangeG"].toObject()["max"].toDouble(), 21.0);
+
+        // Custom (off-registry) basket -> identity only, derived specs omitted.
+        in.basketBrand = "Acme";
+        in.basketModel = "Mystery Basket";
+        const QJsonObject custom = DialingBlocks::buildCurrentBeanBlock(in)["basket"].toObject();
+        QCOMPARE(custom["brand"].toString(), QString("Acme"));
+        QVERIFY(!custom.contains("wallProfile"));
+        QVERIFY(!custom.contains("relativeFlow"));
+        QVERIFY(!custom.contains("doseRangeG"));
+    }
+
     // beanbase_json is read by POSITIONAL index in loadShotRecordStatic — a
     // future column inserted mid-SELECT would silently shift the read and
     // every consumer would treat the garbage as "unlinked". Round-trip via

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -253,6 +253,23 @@ private slots:
             QVERIFY(g0 > 0);
             QVERIFY(!EquipmentStorage::loadBasketItemStatic(db, g0).isValid());
 
+            // Regression: a grinder-only lookup (basket params default to a NULL
+            // QString) MUST find a no-basket package. Without the bind-side
+            // IFNULL(:bbrand,'') in findPackageByGrinderIdentityStatic the null
+            // binds as SQL NULL, '' = NULL is never true, and the package is missed
+            // — re-creating it as a duplicate. Pin the fix here (basketIdentityWidening
+            // can't: its packages all have baskets, so it returns 0 either way).
+            QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "Niche", "Zero", "63mm conical"), g0);
+
+            // setBasketItemStatic inserts when the package has no basket yet, and a
+            // clear on an already-basketless package is a success no-op (true), not
+            // a failure (the return-contract the edit-in-place rollback depends on).
+            QVERIFY(EquipmentStorage::setBasketItemStatic(db, g0, "", ""));  // no-op -> true
+            QVERIFY(EquipmentStorage::setBasketItemStatic(db, g0, "VST", "18g"));  // insert -> true
+            QCOMPARE(EquipmentStorage::loadBasketItemStatic(db, g0).model, QString("18g"));
+            QVERIFY(EquipmentStorage::setBasketItemStatic(db, g0, "", ""));  // clear existing -> true
+            QVERIFY(!EquipmentStorage::loadBasketItemStatic(db, g0).isValid());
+
             // Package with a registry basket (created in one call).
             EquipmentPackage p1;
             const qint64 g1 = EquipmentStorage::createPackageWithGrinderStatic(
@@ -483,6 +500,51 @@ private slots:
             QCOMPARE(EquipmentStorage::loadGrinderItemStatic(db, dTurinNew).burrs, QString("83mm DLC flat"));
             QCOMPARE(EquipmentStorage::loadGrinderItemStatic(db, dTurinOld).burrs, QString("83mm flat steel"));
         });
+    }
+
+    // Import dedup keys on the FULL identity (grinder + basket): a source package
+    // merges into a dest package only when BOTH match. Same grinder + DIFFERENT
+    // basket must NOT merge, or the basket identity is silently lost in transfer.
+    void importEquipmentBasketDedup() {
+        const QString srcPath = freshDbPath();
+        const QString dstPath = freshDbPath();
+
+        qint64 srcDiff = -1, srcSame = -1;
+        withRawDb(srcPath, "impb_src", [&](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            EquipmentPackage a, b;
+            srcDiff = EquipmentStorage::createPackageWithGrinderStatic(db, a, "Niche", "Zero", "63mm", "VST", "18g");
+            srcSame = EquipmentStorage::createPackageWithGrinderStatic(db, b, "Mazzer", "Major", "83mm", "VST", "18g");
+        });
+        QVERIFY(srcDiff > 0 && srcSame > 0);
+
+        qint64 dstDiff = -1, dstSame = -1;
+        withRawDb(dstPath, "impb_dst", [&](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            EquipmentPackage a, b;
+            // Same grinder as srcDiff but a DIFFERENT basket -> must stay distinct.
+            dstDiff = EquipmentStorage::createPackageWithGrinderStatic(db, a, "Niche", "Zero", "63mm", "Weber", "20g Unibasket");
+            // Same grinder AND basket as srcSame -> must merge.
+            dstSame = EquipmentStorage::createPackageWithGrinderStatic(db, b, "Mazzer", "Major", "83mm", "VST", "18g");
+        });
+        QVERIFY(dstDiff > 0 && dstSame > 0);
+
+        QHash<qint64, qint64> idMap;
+        {
+            QSqlDatabase src = QSqlDatabase::addDatabase("QSQLITE", "impb_s");
+            src.setDatabaseName(srcPath); QVERIFY(src.open());
+            QSqlDatabase dst = QSqlDatabase::addDatabase("QSQLITE", "impb_d");
+            dst.setDatabaseName(dstPath); QVERIFY(dst.open());
+            QVERIFY(EquipmentStorage::importEquipmentStatic(src, dst, /*merge*/ true, idMap));
+            src = QSqlDatabase(); dst = QSqlDatabase();
+        }
+        QSqlDatabase::removeDatabase("impb_s");
+        QSqlDatabase::removeDatabase("impb_d");
+
+        // Different basket -> imported as a NEW dest package, NOT merged onto dstDiff.
+        QVERIFY(idMap.value(srcDiff) > 0 && idMap.value(srcDiff) != dstDiff);
+        // Same grinder + basket -> merged onto the existing dest package.
+        QCOMPARE(idMap.value(srcSame), dstSame);
     }
 
     // A source DB with no equipment tables (transfer from a pre-equipment app

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -241,6 +241,102 @@ private slots:
         });
     }
 
+    // --- basket: optional second item + derive-at-read + setBasketItemStatic ---
+    void basketOptionalAndDerive() {
+        const QString path = freshDbPath();
+        withRawDb(path, "eq_basket", [](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+
+            // Grinder-only package: no basket item.
+            EquipmentPackage p0;
+            const qint64 g0 = EquipmentStorage::createPackageWithGrinderStatic(db, p0, "Niche", "Zero", "63mm conical");
+            QVERIFY(g0 > 0);
+            QVERIFY(!EquipmentStorage::loadBasketItemStatic(db, g0).isValid());
+
+            // Package with a registry basket (created in one call).
+            EquipmentPackage p1;
+            const qint64 g1 = EquipmentStorage::createPackageWithGrinderStatic(
+                db, p1, "Turin", "DF83V", "83mm flat steel", "Decent", "18g Ridgeless");
+            QVERIFY(g1 > 0);
+            const EquipmentItem b = EquipmentStorage::loadBasketItemStatic(db, g1);
+            QVERIFY(b.isValid());
+            QCOMPARE(b.kind, QString("basket"));
+            QCOMPARE(b.brand, QString("Decent"));
+            QCOMPARE(b.model, QString("18g Ridgeless"));
+
+            // Derive-at-read: the view's variant map carries REGISTRY specs (the
+            // basket item itself stores none).
+            EquipmentPackageView v;
+            v.package = EquipmentStorage::loadPackageStatic(db, g1);
+            v.grinder = EquipmentStorage::loadGrinderItemStatic(db, g1);
+            v.basket = b;
+            const QVariantMap m = v.toVariantMap();
+            QCOMPARE(m.value("basketBrand").toString(), QString("Decent"));
+            QCOMPARE(m.value("basketWallProfile").toString(), QString("straight"));
+            QVERIFY(m.value("basketPrecision").toBool());
+            QVERIFY(m.value("basketDoseMaxG").toDouble() > 0);
+
+            // A custom (off-registry) basket resolves to identity only — no specs.
+            EquipmentPackage p2;
+            const qint64 g2 = EquipmentStorage::createPackageWithGrinderStatic(
+                db, p2, "Niche", "Zero", "63mm", "Acme", "Imaginary Basket");
+            EquipmentPackageView v2;
+            v2.package = EquipmentStorage::loadPackageStatic(db, g2);
+            v2.grinder = EquipmentStorage::loadGrinderItemStatic(db, g2);
+            v2.basket = EquipmentStorage::loadBasketItemStatic(db, g2);
+            const QVariantMap m2 = v2.toVariantMap();
+            QCOMPARE(m2.value("basketBrand").toString(), QString("Acme"));
+            QVERIFY(!m2.contains("basketWallProfile"));  // unknown specs omitted
+
+            // setBasketItemStatic: clear removes the item; set re-adds.
+            QVERIFY(EquipmentStorage::setBasketItemStatic(db, g1, "", ""));
+            QVERIFY(!EquipmentStorage::loadBasketItemStatic(db, g1).isValid());
+            QVERIFY(EquipmentStorage::setBasketItemStatic(db, g1, "VST", "18g"));
+            QCOMPARE(EquipmentStorage::loadBasketItemStatic(db, g1).model, QString("18g"));
+        });
+    }
+
+    // --- basket participates in package identity (dedup + copy-on-write) ---
+    void basketIdentityWidening() {
+        const QString path = freshDbPath();
+        withRawDb(path, "eq_basket_id", [](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            QVERIFY(CoffeeBagStorage::ensureTableStatic(db));
+            createMinimalShots(db);
+            auto addShot = [&](qint64 eq) {
+                QSqlQuery q(db); q.prepare("INSERT INTO shots (equipment_id) VALUES (?)");
+                q.addBindValue(eq); q.exec(); return q.lastInsertId().toLongLong();
+            };
+
+            // Same grinder, different basket → distinct packages.
+            EquipmentPackage a, bp;
+            const qint64 A = EquipmentStorage::createPackageWithGrinderStatic(db, a, "Turin", "DF83V", "83mm", "VST", "18g");
+            const qint64 B = EquipmentStorage::createPackageWithGrinderStatic(db, bp, "Turin", "DF83V", "83mm", "Weber", "Unibasket 18g");
+            QVERIFY(A > 0 && B > 0 && A != B);
+
+            // Full-identity dedup: grinder AND basket must match.
+            QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "Turin", "DF83V", "83mm", 0, "VST", "18g"), A);
+            // Same grinder, wrong basket → not A.
+            QVERIFY(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "Turin", "DF83V", "83mm", 0, "VST", "20g") != A);
+            // "No basket" is a distinct identity: grinder-only query matches neither.
+            QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "Turin", "DF83V", "83mm"), (qint64)0);
+
+            // Changing the basket on a USED package forks (copy-on-write).
+            addShot(A);
+            const qint64 fork = EquipmentStorage::supersedeOrEditStatic(db, A, "Turin", "DF83V", "83mm", "IMS", "Competition 18g");
+            QVERIFY(fork > 0 && fork != A);
+            QCOMPARE(EquipmentStorage::loadBasketItemStatic(db, fork).brand, QString("IMS"));
+            QCOMPARE(EquipmentStorage::loadPackageStatic(db, A).supersededBy, fork);
+
+            // The grinder-only wrapper PRESERVES the basket.
+            EquipmentPackage cpk;
+            const qint64 C = EquipmentStorage::createPackageWithGrinderStatic(db, cpk, "Mazzer", "Major", "83mm", "VST", "20g");
+            const qint64 c2 = EquipmentStorage::supersedeOrEditGrinderStatic(db, C, "Mazzer", "Major V2", "83mm");
+            QCOMPARE(c2, C);  // unused → edit in place
+            QCOMPARE(EquipmentStorage::loadBasketItemStatic(db, C).model, QString("20g"));  // basket preserved
+        });
+    }
+
     // --- migration data step: split + dedup-into-packages + link ---
     void migrationSplitsAndLinks() {
         const QString path = freshDbPath();


### PR DESCRIPTION
Wires the curated basket database (`BasketAliases`, #1344) into equipment packages as an optional **second component kind** — so a shot records *which basket* it used (reproducibility) and the AI advisor can reason about basket flow when dialing. Two baskets = two packages: the basket is part of the package identity.

Builds on the equipment-packages work (#1341). No DB schema migration — baskets are a new `equipment_items` kind.

## Storage / model
- Optional `kind="basket"` item (brand/model, empty attrs). Specs — wall profile, relative flow, precision, dose range — are **derived from the registry at read time**, never stored (mirrors `rpmCapable`). Custom off-registry baskets resolve to identity only.
- Package identity widens `(grinder)` → `(grinder + basket)`; copy-on-write dedup/fork compares the basket too, with "no basket" a distinct value. `supersedeOrEditStatic` generalizes the grinder-only path (kept as a wrapper).
- Shot basket resolves via the `equipment_id` JOIN (`ShotRecord`/`ShotProjection`) — **no new shot column**. Device import carries basket items and dedups on full identity.

## UI
- `SwitchEquipmentDialog`: optional **vendor-first, two-level** basket picker. `SuggestionField` gains a **differentiator-subtitle** row so similar models (S-Works billets, Decent's two 14g waisted siblings) stay legible.
- `EquipmentCard` / `EquipmentInfoDialog` show the basket.
- Edit dialog: **Cancel/Save pinned to the title row**, fields scroll (a grinder+basket package overflowed short screens). **Add Equipment pre-fills from the active package** so you only change what differs; **Save is blocked when the exact gear already exists** (UI guard + storage backstop) — no duplicate packages.
- The **Equipment idle tile now mirrors Beans**: tap shows recently-used equipment as quick-switch pills (inline in center zones, popup in compact bars); double-tap / long-press opens the Equipment window.
- Removed the "RPM adjustable" line from the equipment card.

## AI / MCP
- `currentBean` gains a `basket` sub-object: brand/model + derived `wallProfile`, `relativeFlow` (the key cross-basket signal, a directional string), `precision`, `doseRangeG` (dose-out-of-range sanity). Omitted when absent; identity-only for custom baskets.
- `equipment_*` MCP tools read and write the basket identity, following the unit/string conventions.

## Basket DB
- Model names lead with size and sort by size (e.g. `18g Ridgeless`).
- Added the discontinued Decent **ridged** 15/18/20/22g doubles.
- Added the **Weber Workshops Unifilter** (unibody portafilter with an integrated basket).

## Notes
- Supersedes the stale, dose-centric `add-basket-settings` proposal (archived in this PR).
- OpenSpec change: `openspec/changes/add-basket-equipment/` (proposal, design, specs, tasks).

## Testing
- `tst_equipment` 23/23 (added `basketOptionalAndDerive`, `basketIdentityWidening`), `tst_basketaliases` 22/22, plus coffeebags/dialing_blocks/mcptools_write/dbmigration suites pass. App + all test targets build clean (0 warnings).
- Not yet exercised in the running app — manual verification of the dialog layout, idle-tile pills, and live dialing JSON is the remaining step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)