### PR TITLE
Add puck prep to equipment packages (3rd component kind)

### DIFF
--- a/openspec/changes/add-puckprep-equipment/.openspec.yaml
+++ b/openspec/changes/add-puckprep-equipment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/add-puckprep-equipment/design.md
+++ b/openspec/changes/add-puckprep-equipment/design.md
@@ -50,14 +50,18 @@ rollup (`none` | `light` | `thorough`) at read time, exactly as basket specs are
 derived from the registry (here the "registry" is a pure function, no table):
 
 ```
-  distribution = wdt      ? "thorough"
-               : shaker   ? "light"
-               :            "none"
+  distribution = (wdt || shaker) ? "thorough"   // equal weight — NOT ranked
+               : rdt             ? "light"       // anti-static only, not active distribution
+               :                   "none"
 ```
 
-WDT and shaker are the puck-*distribution* techniques, so the rollup keys on them;
-`rdt` / `puckScreen` / `paperFilter` are separate flags the advisor reads
-individually (rdt's mild anti-clump help is noted but kept out of the rollup to
+WDT and shaker are both deliberate puck-*distribution* techniques and are weighted
+**equally** — which is "better" is genuinely contested (a good shaker / needle
+distributor matches or beats mediocre WDT), so the rollup must NOT rank one above
+the other; it answers "did the user actively distribute, or is this dump-and-tamp?".
+`rdt` (anti-static declumping) counts as `light` on its own; `puckScreen` /
+`paperFilter` are separate flags the advisor reads individually (kept out of the
+rollup to
 keep it legible). Rationale for derive-at-read: the rollup logic lives in one place,
 can be tuned (or extended when *sift* lands) without touching stored data, and the
 advisor always sees a current interpretation.
@@ -139,9 +143,10 @@ extend that test to cover the puckprep column(s) too.
 
 ## Risks / Open questions
 
-- **Rollup tuning.** The `wdt→thorough / shaker→light` mapping is a judgment call;
-  it lives in one derive-at-read function so it's cheap to revise (and must be
-  revisited when *sift* lands).
+- **Rollup tuning.** The mapping is a judgment call; it lives in one derive-at-read
+  function so it's cheap to revise (and must be revisited when *sift* lands). WDT and
+  shaker are weighted equally on purpose — ranking either above the other would bake a
+  contested opinion into advice the AI then acts on.
 - **Checklist legibility.** Five bare checkboxes risk reading as clutter; grouping
   or a one-line "Puck prep" header keeps it scannable (UI detail, not architecture).
 - **Explicit-none vs unknown** (Decision 5) — the only semantic the v1 model gives up.

--- a/openspec/changes/add-puckprep-equipment/design.md
+++ b/openspec/changes/add-puckprep-equipment/design.md
@@ -1,0 +1,147 @@
+# Design — Puck Prep as an Equipment Component
+
+## Context
+
+`add-basket-equipment` (merged, #1345) made the equipment package a switchable
+bundle of typed `EquipmentItem` kinds (grinder + optional basket) with copy-on-write
+identity and a `currentBean` sub-object feeding the AI advisor. Puck prep is the
+next kind. The driving goal is the same as basket's: reproducibility + AI dialing
+help. The novelty is that puck prep is **technique**, not a branded object — so it
+reuses the storage/identity/AI machinery but breaks the vendor-picker UI and the
+brand/model identity shape.
+
+## Decision 1 — Package-identity placement (not per-shot)
+
+**Chosen:** puck prep is a component of the package, at the **identity** level
+(like basket) — a distinct prep is a distinct package, switched/forked the same way.
+Rejected: per-shot capture ("did you WDT *this* pull?").
+
+**Why:** the user's framing — "most people use only one or two preps and switch
+between them using packages." A package already means "the gear I used"; extending
+it to "the gear + prep routine I used" is the natural unit. Per-shot would be more
+diagnostically precise but adds friction on every shot and plumbing we don't need
+for the 1–2-routine reality. Cost accepted: the combinatorial grid grows to
+grinder × basket × prep, but each axis is small (1–3), and MRU + dedup keep the
+inventory list sane — the same bargain basket struck.
+
+## Decision 2 — Identity is a normalized flag-set (the one real delta)
+
+Grinder identity is `brand/model/burrs`; basket is `brand/model`. Puck prep has no
+string identity — it is the **set of ticked flags**. So the copy-on-write
+dedup/fork comparison normalizes the config to a canonical form and compares that:
+
+```
+  config { wdt:true, shaker:true, puckScreen:false, paperFilter:false, rdt:false }
+     │  normalize (fixed key order / sorted true-flags / bitmask)
+     ▼
+  canonical "shaker,wdt"   →  compared for dedup & "unchanged?" checks
+  no puckprep item         →  canonical ""  (a distinct, matchable value)
+```
+
+This is a small helper (serialize the flags canonically), not new architecture. The
+identity-widening otherwise inherits everything basket built: toggle a flag on a
+*used* package → fork; switch back to a prior combo → dedup; edit an *unused*
+package → in place.
+
+## Decision 3 — Derive the `distribution` rollup at read time
+
+Store only the booleans on the item (`attrs`). Compute the **`distribution`**
+rollup (`none` | `light` | `thorough`) at read time, exactly as basket specs are
+derived from the registry (here the "registry" is a pure function, no table):
+
+```
+  distribution = wdt      ? "thorough"
+               : shaker   ? "light"
+               :            "none"
+```
+
+WDT and shaker are the puck-*distribution* techniques, so the rollup keys on them;
+`rdt` / `puckScreen` / `paperFilter` are separate flags the advisor reads
+individually (rdt's mild anti-clump help is noted but kept out of the rollup to
+keep it legible). Rationale for derive-at-read: the rollup logic lives in one place,
+can be tuned (or extended when *sift* lands) without touching stored data, and the
+advisor always sees a current interpretation.
+
+## Decision 4 — Checkbox UI, not a vendor picker
+
+The Edit Equipment form's grinder/basket sections are `SuggestionField` vendor
+pickers. Puck prep is a **row of labeled checkboxes** — a new small primitive
+(a labeled `CheckBox` with `Accessible.role: CheckBox` + checked-state name). It
+drops into the two-column form layout added in the basket PR. No `descriptions`
+subtitle, no registry lookups, no flip-up dropdown — it's the simplest section in
+the form.
+
+## Decision 5 — All-unchecked = no puck-prep item (optional, like basket)
+
+A package with every box unchecked persists **no** `kind="puckprep"` item (mirrors
+basket-clear when brand+model are empty). Setting any flag upserts the item;
+clearing the last flag deletes it. The `currentBean.puckPrep` sub-object is omitted
+when there is no item.
+
+**Known nuance (deferred):** this collapses "I deliberately do *no* prep" and "I
+haven't recorded my prep" into the same absent state. The explicit-none case is
+arguably the *strongest* "add WDT" signal for the advisor, but distinguishing it
+needs an explicit "puck prep: none" affordance that's awkward with bare checkboxes.
+v1 accepts the collapse; a later refinement could add an explicit toggle.
+
+## Decision 6 — Content scope (lean checklist) + deferred follow-ons
+
+Five flags, chosen by AI-dialing value (does knowing it change the advice?):
+
+| Flag | Advisor use | Tier |
+|---|---|---|
+| `wdt` | channeled + no WDT → "WDT is the #1 fix"; + WDT → don't re-suggest it | high |
+| `shaker` | same distribution axis as WDT (clump-breaking) | high |
+| `paperFilter` | muddy cup / bottom channeling → "try a bottom paper" | moderate |
+| `rdt` | clumpy/static grind, inconsistent dose → "spritz" | moderate |
+| `puckScreen` | mostly cleanliness; keeps the advisor from misreading flow startup | low-moderate |
+
+**Deferred follow-ons (additive, no migration):**
+- **Tamper** — base shape (flat / convex / ripple) is a real *functional* axis
+  (edge-vs-center extraction bias, fit-to-basket → edge channeling), distinct from
+  the AI-noise of tamper *brand*. Adds as one enum field on the puckprep item.
+- **Sift** — a 6th boolean, distinct from shaker. Adds as one flag; the
+  `distribution` rollup folds it in.
+
+**Excluded as AI-noise:** tamp pressure (settled physics past full compaction),
+nutation, dosing funnel, and any *brand* strings — including these just trains users
+to record data the advisor can't use.
+
+## Decision 7 — AI consumption: the channeling branch
+
+The payoff. The channeling detector reports *that* a shot channeled; `puckPrep`
+tells the advisor what to do:
+
+```jsonc
+"puckPrep": { "wdt": true, "shaker": true, "puckScreen": true,
+              "paperFilter": false, "rdt": false, "distribution": "thorough" }
+```
+
+```
+  channeling detected
+       ├─ distribution none/light  → "Add WDT or a shaker — biggest lever here"
+       └─ distribution thorough    → "Prep's solid; it's grind/dose/basket — go finer"
+                                       ↑ the valuable branch: don't tell a meticulous
+                                         WDT-er to "try WDT"
+```
+
+`paperFilter` / `puckScreen` are read individually for their specific cases. The
+sub-object is omitted (not fabricated) when the package has no puck prep.
+
+## Shot resolution (mind the positional columns)
+
+The shot's puck prep resolves via the `equipment_id` JOIN, like basket — a new
+`LEFT JOIN equipment_items ep ... kind='puckprep'` in `loadShotRecordStatic`, its
+`attrs` read and the flags parsed. **Append** the new selected column(s) after the
+basket columns (44/45) and update the positional reads carefully — this is exactly
+the silent column-shift the basket PR added a `tst_dbmigration` regression for;
+extend that test to cover the puckprep column(s) too.
+
+## Risks / Open questions
+
+- **Rollup tuning.** The `wdt→thorough / shaker→light` mapping is a judgment call;
+  it lives in one derive-at-read function so it's cheap to revise (and must be
+  revisited when *sift* lands).
+- **Checklist legibility.** Five bare checkboxes risk reading as clutter; grouping
+  or a one-line "Puck prep" header keeps it scannable (UI detail, not architecture).
+- **Explicit-none vs unknown** (Decision 5) — the only semantic the v1 model gives up.

--- a/openspec/changes/add-puckprep-equipment/proposal.md
+++ b/openspec/changes/add-puckprep-equipment/proposal.md
@@ -1,0 +1,100 @@
+## Why
+
+Equipment packages (`add-equipment-packages`) and baskets (`add-basket-equipment`,
+merged in #1345) established the package as a switchable bundle of typed component
+kinds (grinder, basket) with copy-on-write identity. **Puck prep** is the next
+user-requested kind.
+
+It does not fit the grinder/basket mold — it is not a branded object with a
+vendor → model identity. It is the user's **distribution / prep routine** (WDT,
+shaker, …). It earns a place because it is the one input the channeling detector
+*cannot get from telemetry*: the detector ([docs/SHOT_REVIEW.md](docs/SHOT_REVIEW.md))
+reports *that* a shot channeled; puck prep tells the advisor whether to blame
+**prep** or **grind/dose**. That is the same role `relativeFlow` played for baskets
+— the signal the AI can't infer and must be told.
+
+Most people run one or two prep routines and switch them by switching packages, so
+puck prep is modeled at the **package-identity level** like basket: a distinct prep
+is a distinct package, reached by the same fork/dedup machinery.
+
+## What Changes
+
+- **Puck prep as an optional `kind="puckprep"` `equipment_items` row.** Its `attrs`
+  is a small **checklist config**: `{ wdt, shaker, puckScreen, paperFilter, rdt }`
+  (all booleans). No brand/model, no registry, **no schema migration** — the
+  `equipment_items` kind axis already supports it.
+- **Package identity widens** `(grinder + basket)` → `(grinder + basket + puckprep)`.
+  The copy-on-write dedup/fork engine compares the puck-prep config too; "no puck
+  prep" is a distinct identity value. Because this identity is a **flag-set** rather
+  than a brand/model string, the comparison normalizes the config to a canonical
+  form (the one true delta from the basket pattern).
+- **Derived `distribution` rollup** (`none` | `light` | `thorough`) computed at
+  read time as a pure function of the flags (WDT → thorough, shaker → light, else
+  none). No registry — mirrors how basket specs are derived, not stored.
+- **Edit Equipment form gains a puck-prep CHECKBOX section** — a new UI primitive in
+  the form (not a `SuggestionField` vendor picker). All-unchecked = no puck-prep
+  item (optional, like basket).
+- **`currentBean` gains a `puckPrep` sub-object** (the flags + the `distribution`
+  rollup) for the advisor. The rollup flips channeling advice between "fix your
+  prep" and "prep is solid → look at grind/dose/basket."
+- **`equipment_*` MCP tools** read and write the puck-prep flags; the equipment
+  **card** and **info dialog** show the prep.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `equipment-package-model`: optional `kind="puckprep"` item; identity widened to
+  `(grinder + basket + puckprep)` compared as a normalized flag-set; `distribution`
+  rollup derived at read; `SettingsDye` puck-prep bridge.
+- `switch-equipment-dialog`: optional puck-prep **checkbox** section; all-unchecked
+  = no puck prep; edits honor package-identity (fork/dedup) semantics.
+- `equipment-inventory-view`: `EquipmentCard` + `EquipmentInfoDialog` render the
+  package's puck prep.
+- `dialing-context-payload`: `currentBean` gains a `puckPrep` sub-object (flags +
+  derived `distribution`), omitted when the package has no puck prep.
+- `mcp-server`: `equipment_*` tools read/write the puck-prep flags following MCP
+  conventions.
+
+## Impact
+
+**Dependency:** builds on `add-equipment-packages` + `add-basket-equipment` (the
+`equipment_packages` / `equipment_items` tables, `EquipmentStorage` identity engine,
+`SettingsDye` resolution, `SwitchEquipmentDialog`, `EquipmentCard`/`EquipmentInfoDialog`,
+the `currentBean` builder, the `equipment_*` MCP tools). No new tables, no schema
+migration — a new `equipment_items` row of a new kind.
+
+**C++ / core:**
+- `src/history/equipmentstorage.{h,cpp}`: write/read an optional `kind="puckprep"`
+  item (flags in `attrs`); widen the dedup/fork identity to include the normalized
+  puck-prep config; resolve + flatten it (with the derived `distribution`) in
+  `EquipmentPackageView::toVariantMap`; carry puckprep items through device import.
+- `src/core/settings_dye.{h,cpp}`: `dyePuckPrep*` display resolution; thread the
+  flags through switch/create/update.
+- `src/ai/dialing_blocks.h`: `currentBean` gains the `puckPrep` sub-object + the
+  `distribution` derivation.
+- `src/history/shothistorystorage*.{cpp,h}` + `shotprojection.h`: resolve the
+  puck-prep flags via the `equipment_id` JOIN (new `LEFT JOIN equipment_items`
+  for `kind='puckprep'`; append columns after the basket join — mind the positional
+  reads, the spot the basket PR's regression test guards).
+- `src/mcp/mcptools_write.cpp` + `mcptools_dialing.cpp`: surface/accept the flags.
+
+**QML:**
+- `qml/components/SwitchEquipmentDialog.qml`: a puck-prep checkbox section (a small
+  reusable labeled-checkbox row), in the two-column form layout.
+- `qml/components/EquipmentCard.qml` + `EquipmentInfoDialog.qml`: a puck-prep line/row.
+- New translation keys; accessibility (`Accessible.role: CheckBox`, names/state).
+
+## Non-Goals / Future Follow-ons
+
+- **Tamper** (base shape: flat / convex / ripple — a functional axis the advisor can
+  use for edge-vs-center reasoning). Deferred per the user; additive later as one
+  enum field on the puck-prep item.
+- **Sift** (a 6th flag, distinct from shaker). Additive later as one more boolean.
+- **Per-shot puck-prep capture.** Puck prep is a package-level *routine*, not a
+  per-shot field. (More accurate but more friction; out of scope.)
+- **Tamp pressure, nutation, dosing funnel, tool brands.** AI-noise — excluded so
+  users aren't trained to record data the advisor can't act on.
+- **Explicit "I do no prep" vs "not recorded."** v1 collapses all-unchecked to "no
+  puck-prep item" (omitted from AI context). The distinction is a possible later
+  refinement (see design.md).

--- a/openspec/changes/add-puckprep-equipment/proposal.md
+++ b/openspec/changes/add-puckprep-equipment/proposal.md
@@ -29,7 +29,7 @@ is a distinct package, reached by the same fork/dedup machinery.
   than a brand/model string, the comparison normalizes the config to a canonical
   form (the one true delta from the basket pattern).
 - **Derived `distribution` rollup** (`none` | `light` | `thorough`) computed at
-  read time as a pure function of the flags (WDT → thorough, shaker → light, else
+  read time as a pure function of the flags (WDT or shaker → thorough, else RDT → light, else
   none). No registry — mirrors how basket specs are derived, not stored.
 - **Edit Equipment form gains a puck-prep CHECKBOX section** — a new UI primitive in
   the form (not a `SuggestionField` vendor picker). All-unchecked = no puck-prep

--- a/openspec/changes/add-puckprep-equipment/specs/dialing-context-payload/spec.md
+++ b/openspec/changes/add-puckprep-equipment/specs/dialing-context-payload/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Dialing context SHALL expose puck prep via the equipment package
+The dialing context SHALL include a `puckPrep` sub-object in the `currentBean` block
+(and in the shot snapshot it resolves), populated through the package's puck-prep
+item via `equipment_id` — there SHALL be no separate shot-level puck-prep column.
+The sub-object SHALL carry the set boolean flags and the derived `distribution`
+rollup. When the resolved package has no puck-prep item, the `puckPrep` sub-object
+SHALL be omitted rather than fabricated.
+
+#### Scenario: Puck-prep sub-object present
+- **WHEN** the resolved shot's package has a puck-prep item
+- **THEN** `currentBean.puckPrep` SHALL include the set flags and `distribution`
+
+#### Scenario: No puck prep on the package
+- **WHEN** the resolved shot's package has no puck-prep item
+- **THEN** the `puckPrep` sub-object SHALL be omitted
+
+### Requirement: The distribution rollup SHALL be a human-readable directional string
+The `distribution` rollup SHALL be one of the human-readable strings
+`"none"` / `"light"` / `"thorough"`, conveying the amount of distribution effort so
+the advisor can branch its channeling guidance. It SHALL NOT be a numeric code.
+
+#### Scenario: Distribution string emitted
+- **WHEN** the puck-prep sub-object is emitted
+- **THEN** `distribution` SHALL be one of `"none"`, `"light"`, or `"thorough"`

--- a/openspec/changes/add-puckprep-equipment/specs/equipment-inventory-view/spec.md
+++ b/openspec/changes/add-puckprep-equipment/specs/equipment-inventory-view/spec.md
@@ -14,10 +14,12 @@ lines. When a package has no puck prep, the line SHALL be omitted (not shown bla
 - **THEN** the card SHALL omit the puck-prep line entirely
 
 ### Requirement: The equipment info dialog SHALL include the puck prep
-`EquipmentInfoDialog` SHALL include the package's puck prep — the set flags and the
-derived `distribution` — placed after the grinder / basket / dial rows. Rows SHALL
-self-hide when the package has no puck prep.
+`EquipmentInfoDialog` SHALL include the package's puck prep — the set flags only —
+placed after the grinder / basket / dial rows. The row SHALL self-hide when the
+package has no puck prep. The derived `distribution` rollup SHALL NOT be shown — it
+is an AI-only signal (advisor + MCP) and is kept out of all user-visible surfaces.
 
-#### Scenario: Info dialog shows puck prep
+#### Scenario: Info dialog shows puck-prep flags, not distribution
 - **WHEN** the info dialog opens for a package with puck prep
-- **THEN** it SHALL show the set flags and the derived distribution
+- **THEN** it SHALL show the set flags
+- **AND** it SHALL NOT show the derived distribution

--- a/openspec/changes/add-puckprep-equipment/specs/equipment-inventory-view/spec.md
+++ b/openspec/changes/add-puckprep-equipment/specs/equipment-inventory-view/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: The equipment card SHALL display the package's puck prep
+`EquipmentCard` SHALL show the package's puck prep on its own line (a compact
+summary of the set flags, e.g. "WDT · Shaker"), below the existing grinder / basket
+lines. When a package has no puck prep, the line SHALL be omitted (not shown blank).
+
+#### Scenario: Card with puck prep
+- **WHEN** a package has a puck-prep item with flags set
+- **THEN** the card SHALL render a puck-prep line summarizing the set flags
+
+#### Scenario: Card with no puck prep
+- **WHEN** a package has no puck-prep item
+- **THEN** the card SHALL omit the puck-prep line entirely
+
+### Requirement: The equipment info dialog SHALL include the puck prep
+`EquipmentInfoDialog` SHALL include the package's puck prep — the set flags and the
+derived `distribution` — placed after the grinder / basket / dial rows. Rows SHALL
+self-hide when the package has no puck prep.
+
+#### Scenario: Info dialog shows puck prep
+- **WHEN** the info dialog opens for a package with puck prep
+- **THEN** it SHALL show the set flags and the derived distribution

--- a/openspec/changes/add-puckprep-equipment/specs/equipment-package-model/spec.md
+++ b/openspec/changes/add-puckprep-equipment/specs/equipment-package-model/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: A package MAY own an optional puck-prep component
+A package SHALL be able to own at most one `equipment_items` row of
+`kind="puckprep"`, whose `attrs` is a checklist config of boolean flags
+(`wdt`, `shaker`, `puckScreen`, `paperFilter`, `rdt`). It SHALL have no brand/model.
+A package with no puck-prep item SHALL remain valid (it is optional, like the
+basket). Adding puck prep SHALL NOT require a DB schema migration — it is a new
+row of an existing kind.
+
+#### Scenario: Package with puck prep
+- **WHEN** a package is created/edited with one or more puck-prep flags set
+- **THEN** the package SHALL own one `kind="puckprep"` item carrying those flags
+
+#### Scenario: All flags unchecked = no puck-prep item
+- **WHEN** a package's puck prep has every flag cleared
+- **THEN** the package SHALL own no `kind="puckprep"` item (the item is deleted / not created)
+- **AND** the package SHALL remain valid
+
+### Requirement: The distribution rollup SHALL be derived, not stored
+The puck-prep item SHALL persist only its boolean flags. A `distribution` rollup
+(`none` | `light` | `thorough`) SHALL be derived at read time as a pure function of
+the flags (WDT → thorough; else shaker → light; else none), never stored. Adjusting
+the rollup logic SHALL NOT require any data change.
+
+#### Scenario: Distribution derived from flags
+- **WHEN** a package's puck prep has `wdt` set
+- **THEN** resolving the package SHALL expose `distribution = "thorough"`
+
+#### Scenario: Shaker without WDT
+- **WHEN** a package's puck prep has `shaker` set and `wdt` cleared
+- **THEN** resolving the package SHALL expose `distribution = "light"`
+
+### Requirement: Package identity SHALL include the normalized puck-prep config
+The package identity used for dedup and copy-on-write SHALL include the puck-prep
+config, compared as a NORMALIZED flag-set (canonical, order-independent), where "no
+puck prep" is a distinct identity value. Two packages identical in grinder + basket
+but differing in puck-prep flags SHALL be distinct packages.
+
+#### Scenario: Toggling a flag on a used package forks
+- **WHEN** a package that has recorded shots has a puck-prep flag toggled
+- **THEN** a new package SHALL be forked under copy-on-write (old preserved, `supersededBy` set), exactly as for a grinder or basket identity edit
+
+#### Scenario: Returning to a prior prep dedups
+- **WHEN** the user returns to a previously used grinder + basket + puck-prep combination
+- **THEN** the existing matching package SHALL be selected rather than a duplicate created
+
+#### Scenario: Order-independent comparison
+- **WHEN** two puck-prep configs set the same flags in any internal order
+- **THEN** they SHALL compare as the same identity
+
+### Requirement: SettingsDye SHALL resolve and bridge the active puck prep
+`SettingsDye` SHALL expose the active package's puck-prep flags (and derived
+`distribution`) for display, and SHALL carry the flags through create/update/switch
+alongside the grinder and basket identity.
+
+#### Scenario: Active puck prep resolved
+- **WHEN** the active package has a puck-prep item
+- **THEN** `SettingsDye` SHALL expose its flags and the derived `distribution`
+
+### Requirement: Device import SHALL carry puck-prep items
+Device-to-device equipment import SHALL copy `kind="puckprep"` items alongside
+grinder and basket items, and SHALL include the puck-prep config in the full-identity
+merge-dedup match.
+
+#### Scenario: Imported package retains its puck prep
+- **WHEN** a package with a puck-prep item is imported from a source database
+- **THEN** the destination package SHALL own an equivalent puck-prep item
+
+#### Scenario: Same gear, different prep does not merge on import
+- **WHEN** a source and dest package share grinder + basket but differ in puck-prep flags
+- **THEN** the import SHALL NOT merge them (the source imports as a distinct package)

--- a/openspec/changes/add-puckprep-equipment/specs/equipment-package-model/spec.md
+++ b/openspec/changes/add-puckprep-equipment/specs/equipment-package-model/spec.md
@@ -20,7 +20,8 @@ row of an existing kind.
 ### Requirement: The distribution rollup SHALL be derived, not stored
 The puck-prep item SHALL persist only its boolean flags. A `distribution` rollup
 (`none` | `light` | `thorough`) SHALL be derived at read time as a pure function of
-the flags (WDT → thorough; else shaker → light; else none), never stored. Adjusting
+the flags (WDT or shaker → thorough; else RDT → light; else none — WDT and shaker
+weighted equally, not ranked), never stored. Adjusting
 the rollup logic SHALL NOT require any data change.
 
 #### Scenario: Distribution derived from flags

--- a/openspec/changes/add-puckprep-equipment/specs/mcp-server/spec.md
+++ b/openspec/changes/add-puckprep-equipment/specs/mcp-server/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Equipment MCP tools SHALL read and write the puck-prep flags
+The MCP `equipment_*` tools SHALL include the package's puck-prep flags (and the
+derived `distribution`) in equipment reads, and SHALL accept the optional puck-prep
+flags when creating or updating a package, alongside the grinder and basket
+identity. Omitting them SHALL leave the package without puck prep. Puck-prep edits
+SHALL flow through the same package-identity (dedup/fork) rules as grinder/basket edits.
+
+#### Scenario: Equipment read includes puck prep
+- **WHEN** an MCP equipment read resolves a package that has puck prep
+- **THEN** the response SHALL include the set flags and the derived `distribution`
+
+#### Scenario: Equipment write sets puck prep
+- **WHEN** an MCP equipment write supplies one or more puck-prep flags
+- **THEN** the package SHALL gain a `kind="puckprep"` item subject to the identity rules
+
+### Requirement: MCP puck-prep fields SHALL follow the data conventions
+Puck-prep fields exposed over MCP SHALL follow the project MCP conventions: boolean
+flags with self-describing names (`wdt`, `shaker`, `puckScreen`, `paperFilter`,
+`rdt`) and a human-readable `distribution` string rather than a numeric code.
+
+#### Scenario: Puck-prep fields are LLM-legible
+- **WHEN** the MCP dialing context emits the puck-prep sub-object
+- **THEN** the flags SHALL be booleans and `distribution` SHALL be a readable string

--- a/openspec/changes/add-puckprep-equipment/specs/switch-equipment-dialog/spec.md
+++ b/openspec/changes/add-puckprep-equipment/specs/switch-equipment-dialog/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: The dialog SHALL offer an optional puck-prep checkbox section
+The Switch Equipment dialog SHALL provide a puck-prep section rendered as a row of
+labeled checkboxes (`WDT`, `Shaker`, `Puck screen`, `Bottom paper filter`, `RDT`),
+NOT a vendor picker. The section SHALL be optional — leaving every box unchecked
+SHALL create/save a package with no puck-prep item.
+
+#### Scenario: Set puck-prep flags
+- **WHEN** the user ticks `WDT` and `Shaker` and saves
+- **THEN** the package SHALL carry a puck-prep item with those flags set and the others cleared
+
+#### Scenario: Create a package with no puck prep
+- **WHEN** the user leaves every puck-prep box unchecked
+- **THEN** the package SHALL be created/saved with no puck-prep item
+
+### Requirement: Puck-prep checkboxes SHALL be accessible
+Each puck-prep checkbox SHALL expose an accessible role of CheckBox, an accessible
+name, and its checked state to assistive technology.
+
+#### Scenario: Checkbox announced with state
+- **WHEN** a screen reader focuses a puck-prep checkbox
+- **THEN** it SHALL announce the checkbox label and whether it is checked
+
+### Requirement: Editing puck prep SHALL honor package-identity semantics
+Changing the puck-prep flags on an existing package SHALL apply the package-identity
+rules (fork on a used package, edit-in-place on an unused one, dedup to an existing
+matching grinder + basket + puck-prep combination).
+
+#### Scenario: Changing puck prep on a used package
+- **WHEN** the user changes a puck-prep flag on a package that has recorded shots and saves
+- **THEN** the dialog flow SHALL result in the forked/deduped package per the identity rules, and set it active

--- a/openspec/changes/add-puckprep-equipment/tasks.md
+++ b/openspec/changes/add-puckprep-equipment/tasks.md
@@ -1,0 +1,33 @@
+# Tasks — Add Puck Prep Equipment
+
+## 1. Storage model (equipment-package-model)
+- [x] 1.1 Extend create/update in `equipmentstorage.{h,cpp}` to write an optional `kind="puckprep"` item (flags in `attrs`); `setPuckPrepItemStatic` upserts on any flag set, deletes when all clear
+- [x] 1.2 Widen the dedup/fork identity (`findPackageBy…IdentityStatic`, `supersedeOrEditStatic`) to include the NORMALIZED puck-prep config; "no puck prep" is a distinct value, comparison is order-independent
+- [x] 1.3 Resolve the puck-prep item in `EquipmentPackageView` / `toVariantMap()`; derive the `distribution` rollup at read time (pure function of flags)
+- [x] 1.4 Carry puck-prep items through `importEquipmentStatic` + the full-identity merge-dedup match
+- [x] 1.5 `SettingsDye` bridge: active puck-prep flags + derived `distribution` display; thread flags through switch/create/update
+- [x] 1.6 Unit tests: optional puck prep, identity widening (fork/dedup/edit-in-place, order-independence), all-clear deletes the item, derive-at-read, import dedup (same gear + different prep must NOT merge)
+
+## 2. Shot resolution + AI/MCP (dialing-context-payload, mcp-server)
+- [x] 2.1 Resolve puck-prep flags via the `equipment_id` JOIN in `shotprojection`/`shothistory_types`/`loadShotRecordStatic` (new `LEFT JOIN equipment_items` `kind='puckprep'`; APPEND columns after the basket ones; update positional reads)
+- [x] 2.2 Extend the `tst_dbmigration` JOIN regression to pin the new puck-prep column position (guards the silent column-shift the basket PR flagged)
+- [x] 2.3 `dialing_blocks`: add the `puckPrep` sub-object to `currentBean` (flags + `distribution`); omit when absent
+- [x] 2.4 MCP `equipment_*` tools: read + accept the optional puck-prep flags; dialing tools surface the sub-object per conventions
+- [x] 2.5 `tst_dialing_blocks`: pin the `currentBean.puckPrep` payload (present / omitted / distribution derivation)
+
+## 3. Picker UI (switch-equipment-dialog)
+- [x] 3.1 Add a reusable labeled-checkbox row primitive (accessible `CheckBox` role + checked-state name)
+- [x] 3.2 Add the optional puck-prep checkbox section to `SwitchEquipmentDialog` (WDT, Shaker, Puck screen, Bottom paper filter, RDT) in the two-column form layout; all-unchecked = no puck prep
+- [x] 3.3 Translation keys + accessibility for the puck-prep section
+
+## 4. Inventory view (equipment-inventory-view)
+- [x] 4.1 `EquipmentCard`: puck-prep summary line (omit when none)
+- [x] 4.2 `EquipmentInfoDialog`: puck-prep rows (flags + distribution; omit when none)
+
+## 5. Verification
+- [x] 5.1 Quick compile check via Qt Creator MCP; run equipment / dbmigration / dialing_blocks / mcptools_write suites
+- [ ] 5.2 Live (simulation) end-to-end: set puck-prep flags on a package via `equipment_update`, pull a simulated shot on it, confirm `dialing_get_context` carries `currentBean.puckPrep` with the right `distribution`; clean up
+
+## 6. Follow-ons (NOT in this change — tracked here)
+- [ ] 6.1 Tamper (base shape flat/convex/ripple) as one enum field on the puck-prep item
+- [ ] 6.2 Sift as a 6th flag (folds into the `distribution` rollup)

--- a/openspec/changes/add-puckprep-equipment/tasks.md
+++ b/openspec/changes/add-puckprep-equipment/tasks.md
@@ -26,7 +26,7 @@
 
 ## 5. Verification
 - [x] 5.1 Quick compile check via Qt Creator MCP; run equipment / dbmigration / dialing_blocks / mcptools_write suites
-- [ ] 5.2 Live (simulation) end-to-end: set puck-prep flags on a package via `equipment_update`, pull a simulated shot on it, confirm `dialing_get_context` carries `currentBean.puckPrep` with the right `distribution`; clean up
+- [~] 5.2 Live (simulation) end-to-end. WRITE path confirmed live — `equipment_list` shows `puckPrep` (flags + derived `distribution`) on the active Niche Zero package, set via the UI. DIALING path covered by the `buildCurrentBeanBlock` unit test (the shared helper `dialing_get_context` uses). The live-shot leg (pull a simulated shot → confirm `currentBean.puckPrep`) was declined by the user, so left as a manual check.
 
 ## 6. Follow-ons (NOT in this change — tracked here)
 - [ ] 6.1 Tamper (base shape flat/convex/ripple) as one enum field on the puck-prep item

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -36,6 +36,20 @@ Rectangle {
                 .filter(function(s) { return s.length > 0 }).join(" ")
         return b.length > 0 ? TranslationManager.translate("equipment.card.basket", "Basket: %1").arg(b) : ""
     }
+    // Puck-prep summary line (add-puckprep-equipment); empty when the package has
+    // none. Shows the short labels of the set flags, e.g. "Prep: WDT · Shaker".
+    readonly property string puckPrepLine: {
+        var _ = TranslationManager.translationVersion
+        if (!pkg) return ""
+        var labels = []
+        if (pkg.puckPrep_wdt) labels.push(TranslationManager.translate("equipment.dialog.puckWdt", "WDT"))
+        if (pkg.puckPrep_shaker) labels.push(TranslationManager.translate("equipment.dialog.puckShaker", "Shaker"))
+        if (pkg.puckPrep_puckScreen) labels.push(TranslationManager.translate("equipment.dialog.puckScreen", "Puck screen"))
+        if (pkg.puckPrep_paperFilter) labels.push(TranslationManager.translate("equipment.dialog.puckPaper", "Bottom paper filter"))
+        if (pkg.puckPrep_rdt) labels.push(TranslationManager.translate("equipment.dialog.puckRdt", "RDT (spritz)"))
+        return labels.length > 0
+            ? TranslationManager.translate("equipment.card.puckPrep", "Prep: %1").arg(labels.join(" · ")) : ""
+    }
 
     readonly property string lastDialLine: {
         var _ = TranslationManager.translationVersion
@@ -53,6 +67,7 @@ Rectangle {
         var bits = [grinderTitle, burrs].filter(function(s) { return s.length > 0 })
         if (lastDialLine.length > 0) bits.push(lastDialLine)
         if (basketLine.length > 0) bits.push(basketLine)
+        if (puckPrepLine.length > 0) bits.push(puckPrepLine)
         if (selected) bits.push(TranslationManager.translate("accessibility.selected", "selected"))
         return bits.join(", ")
     }
@@ -134,12 +149,22 @@ Rectangle {
                     Accessible.ignored: true
                 }
 
-                // Basket last: it's separate equipment, so keep the grinder identity
-                // (title + burrs) and its dial (grind) contiguous above it.
+                // Basket + puck prep last: separate equipment, so keep the grinder
+                // identity (title + burrs) and its dial (grind) contiguous above them.
                 Text {
                     Layout.fillWidth: true
                     visible: card.basketLine.length > 0
                     text: card.basketLine
+                    font: Theme.labelFont
+                    color: Theme.textSecondaryColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
+
+                Text {
+                    Layout.fillWidth: true
+                    visible: card.puckPrepLine.length > 0
+                    text: card.puckPrepLine
                     font: Theme.labelFont
                     color: Theme.textSecondaryColor
                     elide: Text.ElideRight

--- a/qml/components/EquipmentInfoDialog.qml
+++ b/qml/components/EquipmentInfoDialog.qml
@@ -124,16 +124,11 @@ Dialog {
                 label: TranslationManager.translate("equipment.info.basketDetails", "Basket details")
                 value: (root.pkg && root.pkg.basketSummary) || ""
             }
-            // Puck prep — the set flags + the derived distribution. Both rows
-            // self-hide when the package has no puck prep.
+            // Puck prep — the set flags. The derived `distribution` rollup is an
+            // AI-only signal (advisor + MCP) and is deliberately NOT shown here.
             InfoRow {
                 label: TranslationManager.translate("equipment.info.puckPrep", "Puck prep")
                 value: root.puckPrepSummary
-            }
-            InfoRow {
-                label: TranslationManager.translate("equipment.info.puckDistribution", "Distribution")
-                value: root.puckPrepSummary.length > 0
-                       ? ((root.pkg && root.pkg.puckPrepDistribution) || "") : ""
             }
 
             AccessibleButton {

--- a/qml/components/EquipmentInfoDialog.qml
+++ b/qml/components/EquipmentInfoDialog.qml
@@ -40,6 +40,20 @@ Dialog {
         : [(pkg && pkg.grinderBrand) || "", (pkg && pkg.grinderModel) || ""]
               .filter(function(s) { return s.length > 0 }).join(" ")
 
+    // Puck-prep set flags as a "WDT · Shaker" summary (add-puckprep-equipment),
+    // empty when the package has no puck prep.
+    readonly property string puckPrepSummary: {
+        var _ = TranslationManager.translationVersion
+        if (!pkg) return ""
+        var labels = []
+        if (pkg.puckPrep_wdt) labels.push(TranslationManager.translate("equipment.dialog.puckWdt", "WDT"))
+        if (pkg.puckPrep_shaker) labels.push(TranslationManager.translate("equipment.dialog.puckShaker", "Shaker"))
+        if (pkg.puckPrep_puckScreen) labels.push(TranslationManager.translate("equipment.dialog.puckScreen", "Puck screen"))
+        if (pkg.puckPrep_paperFilter) labels.push(TranslationManager.translate("equipment.dialog.puckPaper", "Bottom paper filter"))
+        if (pkg.puckPrep_rdt) labels.push(TranslationManager.translate("equipment.dialog.puckRdt", "RDT (spritz)"))
+        return labels.join(" · ")
+    }
+
     background: Rectangle {
         color: Theme.surfaceColor
         radius: Theme.cardRadius
@@ -109,6 +123,17 @@ Dialog {
             InfoRow {
                 label: TranslationManager.translate("equipment.info.basketDetails", "Basket details")
                 value: (root.pkg && root.pkg.basketSummary) || ""
+            }
+            // Puck prep — the set flags + the derived distribution. Both rows
+            // self-hide when the package has no puck prep.
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.puckPrep", "Puck prep")
+                value: root.puckPrepSummary
+            }
+            InfoRow {
+                label: TranslationManager.translate("equipment.info.puckDistribution", "Distribution")
+                value: root.puckPrepSummary.length > 0
+                       ? ((root.pkg && root.pkg.puckPrepDistribution) || "") : ""
             }
 
             AccessibleButton {

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -34,7 +34,10 @@ Dialog {
     property string fBasketModel: ""
     // Optional puck-prep flags (add-puckprep-equipment). All false = no puck prep.
     property var fPuck: ({ wdt: false, shaker: false, puckScreen: false, paperFilter: false, rdt: false })
-    // The checkbox rows, in display order (key + label).
+    // The checkbox rows, in display order (key + label). The KEY SET here must stay
+    // in sync with C++ PuckPrep::flagKeys() (core/puckprep.h): puckCanonical() below
+    // builds the dedup string from these keys and compares it against the C++-stored
+    // canonical, so a key added/renamed in one place must change in both.
     readonly property var puckPrepRows: [
         { key: "wdt",         label: TranslationManager.translate("equipment.dialog.puckWdt", "WDT") },
         { key: "shaker",      label: TranslationManager.translate("equipment.dialog.puckShaker", "Shaker") },

--- a/qml/components/SwitchEquipmentDialog.qml
+++ b/qml/components/SwitchEquipmentDialog.qml
@@ -32,6 +32,35 @@ Dialog {
     // Optional basket identity (add-basket-equipment). Blank brand+model = no basket.
     property string fBasketBrand: ""
     property string fBasketModel: ""
+    // Optional puck-prep flags (add-puckprep-equipment). All false = no puck prep.
+    property var fPuck: ({ wdt: false, shaker: false, puckScreen: false, paperFilter: false, rdt: false })
+    // The checkbox rows, in display order (key + label).
+    readonly property var puckPrepRows: [
+        { key: "wdt",         label: TranslationManager.translate("equipment.dialog.puckWdt", "WDT") },
+        { key: "shaker",      label: TranslationManager.translate("equipment.dialog.puckShaker", "Shaker") },
+        { key: "puckScreen",  label: TranslationManager.translate("equipment.dialog.puckScreen", "Puck screen") },
+        { key: "paperFilter", label: TranslationManager.translate("equipment.dialog.puckPaper", "Bottom paper filter") },
+        { key: "rdt",         label: TranslationManager.translate("equipment.dialog.puckRdt", "RDT (spritz)") }
+    ]
+
+    // Parse a canonical "shaker,wdt" string into the fPuck flag object.
+    function puckFromCanonical(canon) {
+        var keys = (canon || "").split(",")
+        return {
+            wdt: keys.indexOf("wdt") >= 0,
+            shaker: keys.indexOf("shaker") >= 0,
+            puckScreen: keys.indexOf("puckScreen") >= 0,
+            paperFilter: keys.indexOf("paperFilter") >= 0,
+            rdt: keys.indexOf("rdt") >= 0
+        }
+    }
+    // Set one puck flag (QML can't mutate a single key of a var object in place).
+    function setPuck(key, on) {
+        var p = {}
+        for (var k in root.fPuck) p[k] = root.fPuck[k]
+        p[key] = on
+        root.fPuck = p
+    }
 
     // When true (default, the Brew Settings / Equipment-window use), selecting or
     // creating a package switches the ACTIVE bag's equipment. When false, the
@@ -96,6 +125,7 @@ Dialog {
         fBurrs = Settings.dye.dyeGrinderBurrs || ""
         fBasketBrand = Settings.dye.dyeBasketBrand || ""
         fBasketModel = Settings.dye.dyeBasketModel || ""
+        fPuck = puckFromCanonical(Settings.dye.dyePuckPrepCanonical || "")
         mode = "form"
         open()
     }
@@ -109,6 +139,13 @@ Dialog {
         fBurrs = (pkg && pkg.grinderBurrs) || ""
         fBasketBrand = (pkg && pkg.basketBrand) || ""
         fBasketModel = (pkg && pkg.basketModel) || ""
+        fPuck = {
+            wdt: !!(pkg && pkg.puckPrep_wdt),
+            shaker: !!(pkg && pkg.puckPrep_shaker),
+            puckScreen: !!(pkg && pkg.puckPrep_puckScreen),
+            paperFilter: !!(pkg && pkg.puckPrep_paperFilter),
+            rdt: !!(pkg && pkg.puckPrep_rdt)
+        }
         mode = "form"
         open()
     }
@@ -147,14 +184,25 @@ Dialog {
         return [pkg.grinderBrand || "", pkg.grinderModel || ""].filter(function(s) { return s.length > 0 }).join(" ")
     }
 
+    // Canonical puck-prep string for the form (sorted set flags, like C++
+    // PuckPrep::canonical) — the dedup identity and the save payload key.
+    function puckCanonical() {
+        var on = []
+        for (var i = 0; i < puckPrepRows.length; ++i)
+            if (fPuck[puckPrepRows[i].key]) on.push(puckPrepRows[i].key)
+        on.sort()
+        return on.join(",")
+    }
+
     // The id of an existing in-inventory package whose FULL identity (grinder +
-    // basket) matches the form, or -1. Mirrors the storage dedup key so the UI
-    // can't create a duplicate — the same gear is one package, not many. The
-    // package being edited is excluded (an unchanged edit isn't a "duplicate").
+    // basket + puck prep) matches the form, or -1. Mirrors the storage dedup key
+    // so the UI can't create a duplicate — the same gear is one package, not many.
+    // The package being edited is excluded (an unchanged edit isn't a "duplicate").
     readonly property int duplicateOfId: {
         var gb = fBrand.trim().toLowerCase(), gm = fModel.trim().toLowerCase()
         var gbu = fBurrs.trim().toLowerCase()
         var bb = fBasketBrand.trim().toLowerCase(), bm = fBasketModel.trim().toLowerCase()
+        var pc = puckCanonical()
         for (var i = 0; i < packages.length; ++i) {
             var p = packages[i]
             if (!p || p.id === undefined) continue
@@ -163,7 +211,8 @@ Dialog {
                 && String(p.grinderModel || "").trim().toLowerCase() === gm
                 && String(p.grinderBurrs || "").trim().toLowerCase() === gbu
                 && String(p.basketBrand || "").trim().toLowerCase() === bb
-                && String(p.basketModel || "").trim().toLowerCase() === bm)
+                && String(p.basketModel || "").trim().toLowerCase() === bm
+                && String(p.puckPrepCanonical || "") === pc)
                 return p.id
         }
         return -1
@@ -462,6 +511,35 @@ Dialog {
                                 onSuggestionSelected: function(t) { root.fBasketModel = t }
                             }
                         }
+
+                        // --- Puck prep (optional) — checkbox flags (add-puckprep-equipment).
+                        //     All unchecked = no puck prep. ---
+                        Text {
+                            Layout.fillWidth: true
+                            Layout.topMargin: Theme.spacingSmall
+                            text: TranslationManager.translate("equipment.dialog.puckPrep", "Puck prep (optional)")
+                            color: Theme.textColor
+                            font.pixelSize: Theme.scaled(14)
+                        }
+
+                        GridLayout {
+                            Layout.fillWidth: true
+                            columns: 2
+                            columnSpacing: Theme.spacingMedium
+                            rowSpacing: Theme.spacingSmall
+
+                            Repeater {
+                                model: root.puckPrepRows
+                                StyledSwitch {
+                                    required property var modelData
+                                    Layout.fillWidth: true
+                                    text: modelData.label
+                                    accessibleName: modelData.label
+                                    checked: !!root.fPuck[modelData.key]
+                                    onToggled: root.setPuck(modelData.key, checked)
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -481,6 +559,10 @@ Dialog {
             "basketBrand": fBasketBrand.trim(),
             "basketModel": fBasketModel.trim()
         }
+        // Puck-prep flags as namespaced keys (storage builds the canonical form;
+        // all-false clears any existing puck prep).
+        for (var i = 0; i < puckPrepRows.length; ++i)
+            fields["puckPrep_" + puckPrepRows[i].key] = !!fPuck[puckPrepRows[i].key]
         if (formMode === "edit" && editPackageId > 0) {
             // Editing identity may copy-on-write into a new package id; wait for
             // the result so we can repoint the active selection if needed.

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -3,6 +3,7 @@
 #include "dialing_helpers.h"  // buildBeanFreshness — composed inside buildCurrentBeanBlock
 #include "aiconversation.h"   // HistoricalAssistantTurn — input to buildRecentAdviceBlock
 #include "../core/basketaliases.h"  // basket spec derivation inside buildCurrentBeanBlock
+#include "../core/puckprep.h"       // puck-prep flags + distribution inside buildCurrentBeanBlock
 
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -193,6 +194,10 @@ struct CurrentBeanBlockInputs {
     // not passed in — the caller supplies identity only (add-basket-equipment).
     QString basketBrand;
     QString basketModel;
+    // Puck-prep canonical flag string (resolved via the shot's equipment_id; empty
+    // = no puck prep). The individual flags + the derived `distribution` rollup are
+    // computed here from PuckPrep, not passed in (add-puckprep-equipment).
+    QString puckPrep;
     QString grinderSetting;
     // Grinder RPM the shot was ground at (0 = unset / not an adjustable-RPM
     // grinder). A second grind axis alongside grinderSetting on variable-RPM
@@ -247,6 +252,18 @@ inline QJsonObject buildCurrentBeanBlock(const CurrentBeanBlockInputs& in)
             }
         }
         bean["basket"] = basket;
+    }
+
+    // Puck-prep sub-object (add-puckprep-equipment). The set flags plus the derived
+    // `distribution` rollup — the signal the advisor branches its channeling
+    // guidance on ("none/light → fix prep" vs "thorough → grind/dose"). Omitted
+    // when the package has no puck prep.
+    if (!in.puckPrep.isEmpty()) {
+        QJsonObject puck;
+        for (const QString& k : PuckPrep::flagKeys())
+            puck[k] = PuckPrep::has(in.puckPrep, k);
+        puck["distribution"] = PuckPrep::distribution(in.puckPrep);
+        bean["puckPrep"] = puck;
     }
 
     const QJsonObject freshness = DialingHelpers::buildBeanFreshness(in.roastDate);

--- a/src/core/puckprep.h
+++ b/src/core/puckprep.h
@@ -43,18 +43,37 @@ inline QString canonical(const QVariantMap& flags)
     return on.join(QLatin1Char(','));
 }
 
-// The flag keys enabled in a canonical string.
+// The flag keys present in a string. Tokens are trimmed and empties skipped, so a
+// canonical string parses cleanly and a sloppily-spaced one (e.g. a hand-edited DB
+// row) still yields the right keys — recanonical() relies on this.
 inline QStringList setFlags(const QString& canon)
 {
-    const QString c = canon.trimmed();
-    if (c.isEmpty())
-        return {};
-    return c.split(QLatin1Char(','), Qt::SkipEmptyParts);
+    QStringList out;
+    for (const QString& part : canon.split(QLatin1Char(','), Qt::SkipEmptyParts)) {
+        const QString t = part.trimmed();
+        if (!t.isEmpty())
+            out << t;
+    }
+    return out;
 }
 
 inline bool has(const QString& canon, const QString& key)
 {
     return setFlags(canon).contains(key);
+}
+
+// Normalize an arbitrary flag string back to canonical form: keep only the known
+// flag keys that are present, re-sorted and comma-joined; drop unknown tokens.
+// Idempotent for an already-canonical string. The storage layer runs every
+// incoming puck-prep string through this so the stored `model` value is ALWAYS
+// canonical — making "the puckprep identity is canonical" a true invariant enforced
+// at the persistence boundary, not merely a convention the callers must remember.
+inline QString recanonical(const QString& s)
+{
+    QVariantMap flags;
+    for (const QString& k : flagKeys())
+        flags.insert(k, has(s, k));
+    return canonical(flags);
 }
 
 // True when a field map carries any puck-prep flag (namespaced "puckPrep_<key>",

--- a/src/core/puckprep.h
+++ b/src/core/puckprep.h
@@ -18,6 +18,9 @@ namespace PuckPrep {
 
 // The recorded flags, in DISPLAY order (the form renders them in this order). The
 // stored canonical identity is these keys SORTED, so it is order-independent.
+// MIRROR: the QML SwitchEquipmentDialog.qml `puckPrepRows` keys + its puckCanonical()
+// must match this set — a key added/renamed here has to change there too (the dialog
+// builds its dedup string independently and compares it to the C++-stored canonical).
 inline const QStringList& flagKeys()
 {
     static const QStringList keys = {

--- a/src/core/puckprep.h
+++ b/src/core/puckprep.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVariantMap>
+
+// Puck-prep technique flags for an equipment package (add-puckprep-equipment).
+//
+// Unlike grinder/basket, puck prep has no vendor → model identity — it is the set
+// of distribution/prep techniques the user ticks (WDT, shaker, …). The package's
+// puck-prep IDENTITY is therefore the SET of enabled flags, stored as a canonical
+// (sorted, comma-joined) string in the puckprep item's `model` column — which lets
+// it reuse the exact brand/model identity machinery (dedup correlated-subquery
+// match, optional upsert/delete) that grinder and basket use. The individual flags
+// and the derived `distribution` rollup are reconstructed from that string at read
+// time; nothing puck-prep-specific is stored in `attrs`.
+namespace PuckPrep {
+
+// The recorded flags, in DISPLAY order (the form renders them in this order). The
+// stored canonical identity is these keys SORTED, so it is order-independent.
+inline const QStringList& flagKeys()
+{
+    static const QStringList keys = {
+        QStringLiteral("wdt"),
+        QStringLiteral("shaker"),
+        QStringLiteral("puckScreen"),
+        QStringLiteral("paperFilter"),
+        QStringLiteral("rdt"),
+    };
+    return keys;
+}
+
+// Canonical identity string for a flag map: the SET flag keys, sorted and
+// comma-joined. "" = no puck prep. Order-independent by construction, so two maps
+// that enable the same flags produce the same string (the dedup/fork key).
+inline QString canonical(const QVariantMap& flags)
+{
+    QStringList on;
+    for (const QString& k : flagKeys())
+        if (flags.value(k).toBool())
+            on << k;
+    on.sort();
+    return on.join(QLatin1Char(','));
+}
+
+// The flag keys enabled in a canonical string.
+inline QStringList setFlags(const QString& canon)
+{
+    const QString c = canon.trimmed();
+    if (c.isEmpty())
+        return {};
+    return c.split(QLatin1Char(','), Qt::SkipEmptyParts);
+}
+
+inline bool has(const QString& canon, const QString& key)
+{
+    return setFlags(canon).contains(key);
+}
+
+// True when a field map carries any puck-prep flag (namespaced "puckPrep_<key>",
+// the form the QML dialog / MCP send and EquipmentPackageView::toVariantMap emits).
+inline bool mapTouches(const QVariantMap& map)
+{
+    for (const QString& k : flagKeys())
+        if (map.contains(QStringLiteral("puckPrep_") + k))
+            return true;
+    return false;
+}
+
+// Canonical string for the result of applying a field map's "puckPrep_<key>"
+// overrides on top of a current canonical string. Flags absent from the map keep
+// their current value, so a PARTIAL update (e.g. an MCP call setting only `wdt`)
+// preserves the rest; the full-form case (all flags present) sets the exact state.
+inline QString canonicalMerged(const QString& currentCanon, const QVariantMap& map)
+{
+    QVariantMap flags;
+    for (const QString& k : flagKeys()) {
+        bool v = has(currentCanon, k);
+        const QString pk = QStringLiteral("puckPrep_") + k;
+        if (map.contains(pk))
+            v = map.value(pk).toBool();
+        flags.insert(k, v);
+    }
+    return canonical(flags);
+}
+
+// Derived distribution rollup (the signal the AI advisor reads to branch its
+// channeling guidance). WDT is the gold-standard distribution technique, shaker a
+// lighter one; the other flags (rdt/puckScreen/paperFilter) are read individually
+// and do not move the rollup. Pure function of the canonical string — never stored.
+inline QString distribution(const QString& canon)
+{
+    if (has(canon, QStringLiteral("wdt")))
+        return QStringLiteral("thorough");
+    if (has(canon, QStringLiteral("shaker")))
+        return QStringLiteral("light");
+    return QStringLiteral("none");
+}
+
+} // namespace PuckPrep

--- a/src/core/puckprep.h
+++ b/src/core/puckprep.h
@@ -85,14 +85,19 @@ inline QString canonicalMerged(const QString& currentCanon, const QVariantMap& m
 }
 
 // Derived distribution rollup (the signal the AI advisor reads to branch its
-// channeling guidance). WDT is the gold-standard distribution technique, shaker a
-// lighter one; the other flags (rdt/puckScreen/paperFilter) are read individually
-// and do not move the rollup. Pure function of the canonical string — never stored.
+// channeling guidance). WDT and shaker are BOTH deliberate distribution techniques
+// and are weighted EQUALLY — which is "better" is genuinely contested (a good
+// shaker / needle distributor matches or beats mediocre WDT, and WDT quality is
+// highly technique-dependent), so the rollup does not rank them; it answers "did
+// the user actively distribute, or is this dump-and-tamp?". RDT alone is
+// anti-static declumping, not active distribution, so it counts as light. The
+// other flags (puckScreen/paperFilter) are read individually and do not move the
+// rollup. Pure function of the canonical string — never stored.
 inline QString distribution(const QString& canon)
 {
-    if (has(canon, QStringLiteral("wdt")))
+    if (has(canon, QStringLiteral("wdt")) || has(canon, QStringLiteral("shaker")))
         return QStringLiteral("thorough");
-    if (has(canon, QStringLiteral("shaker")))
+    if (has(canon, QStringLiteral("rdt")))
         return QStringLiteral("light");
     return QStringLiteral("none");
 }

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -163,6 +163,12 @@ void SettingsDye::applyEquipmentIdentity(const QVariantMap& pkg)
         m_dyeBasketSummary = basketSummary;
         emit dyeBasketChanged();
     }
+
+    const QString puckCanon = pkg.value("puckPrepCanonical").toString();
+    if (m_dyePuckPrepCanonical != puckCanon) {
+        m_dyePuckPrepCanonical = puckCanon;
+        emit dyePuckPrepChanged();
+    }
 }
 
 // DYE metadata
@@ -351,6 +357,11 @@ void SettingsDye::switchToEquipment(const QVariantMap& pkg) {
         m_dyeBasketModel = basketModel;
         m_dyeBasketSummary = basketSummary;
         emit dyeBasketChanged();
+    }
+    const QString puckCanon = pkg.value("puckPrepCanonical").toString();
+    if (m_dyePuckPrepCanonical != puckCanon) {
+        m_dyePuckPrepCanonical = puckCanon;
+        emit dyePuckPrepChanged();
     }
     if (m_equipmentStorage)
         m_equipmentStorage->requestTouchLastUsed(id);

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -41,6 +41,10 @@ class SettingsDye : public QObject {
     // from the active package like dyeEquipmentName (add-basket-equipment).
     Q_PROPERTY(QString dyeBasketBrand READ dyeBasketBrand NOTIFY dyeBasketChanged)
     Q_PROPERTY(QString dyeBasketModel READ dyeBasketModel NOTIFY dyeBasketChanged)
+    // Active package's puck-prep canonical flag string (e.g. "shaker,wdt"; empty =
+    // none), resolved from the active package (add-puckprep-equipment). The Edit
+    // Equipment form prefills its checkboxes from this when adding new gear.
+    Q_PROPERTY(QString dyePuckPrepCanonical READ dyePuckPrepCanonical NOTIFY dyePuckPrepChanged)
     // One-line registry summary of the active basket (wall/flow/precision/dose),
     // empty for none or a custom off-registry basket.
     Q_PROPERTY(QString dyeBasketSummary READ dyeBasketSummary NOTIFY dyeBasketChanged)
@@ -118,6 +122,7 @@ public:
     QString dyeBasketBrand() const { return m_dyeBasketBrand; }
     QString dyeBasketModel() const { return m_dyeBasketModel; }
     QString dyeBasketSummary() const { return m_dyeBasketSummary; }
+    QString dyePuckPrepCanonical() const { return m_dyePuckPrepCanonical; }
 
     QString dyeGrinderSetting() const;
     void setDyeGrinderSetting(const QString& value);
@@ -229,6 +234,7 @@ signals:
     void dyeGrinderBurrsChanged();
     void dyeEquipmentNameChanged();
     void dyeBasketChanged();
+    void dyePuckPrepChanged();
     void dyeGrinderSettingChanged();
     void dyeGrinderRpmChanged();
     void activeEquipmentIdChanged();
@@ -287,6 +293,7 @@ private:
     QString m_dyeBasketBrand;    // active package basket identity (resolved, not persisted)
     QString m_dyeBasketModel;
     QString m_dyeBasketSummary;  // registry summary of the active basket (resolved)
+    QString m_dyePuckPrepCanonical;  // active package puck-prep canonical string (resolved)
     mutable QString m_dyeGrinderSettingCache;
     mutable int m_dyeGrinderRpmCache = 0;
     mutable double m_dyeBeanWeightCache = 18.0;

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -892,7 +892,9 @@ qint64 EquipmentStorage::findPackageByGrinderIdentityStatic(QSqlDatabase& db, co
                   "AND LOWER(IFNULL((SELECT b.model FROM equipment_items b "
                   "  WHERE b.package_id = p.id AND b.kind = 'basket' ORDER BY b.id LIMIT 1),'')) = LOWER(IFNULL(:bmodel,'')) "
                   // Puck-prep identity is the canonical flag string in the puckprep
-                  // item's `model` column (already normalized, so a plain match).
+                  // item's `model` column. Stored values are always canonical (the
+                  // write path re-canonicalizes), and the bind below is too, so a
+                  // plain '=' is a correct full-identity match.
                   "AND IFNULL((SELECT pp.model FROM equipment_items pp "
                   "  WHERE pp.package_id = p.id AND pp.kind = 'puckprep' ORDER BY pp.id LIMIT 1),'') = IFNULL(:puck,'') "
                   "ORDER BY p.id LIMIT 1");
@@ -902,7 +904,9 @@ qint64 EquipmentStorage::findPackageByGrinderIdentityStatic(QSqlDatabase& db, co
     query.bindValue(":burrs", burrs);
     query.bindValue(":bbrand", basketBrand.trimmed());
     query.bindValue(":bmodel", basketModel.trimmed());
-    query.bindValue(":puck", puckPrep.trimmed());
+    // Re-canonicalize the query arg so an unsorted/non-canonical caller still matches
+    // the canonical stored value (the compare is a plain '=', not order-aware).
+    query.bindValue(":puck", PuckPrep::recanonical(puckPrep));
     if (!query.exec() || !query.next())
         return 0;
     return query.value(0).toLongLong();
@@ -929,13 +933,19 @@ qint64 EquipmentStorage::supersedeOrEditStatic(QSqlDatabase& db, qint64 packageI
     const EquipmentItem curBasket = loadBasketItemStatic(db, packageId);
     const EquipmentItem curPuck = loadPuckPrepItemStatic(db, packageId);
 
+    // Canonicalize the target puck prep once so the unchanged-check and the merge
+    // lookup compare like-for-like against the (always-canonical) stored value — an
+    // unsorted/non-canonical arg would otherwise read as a change and spuriously
+    // fork. The setter/create below re-canonicalize again (idempotent), harmlessly.
+    const QString puck = PuckPrep::recanonical(puckPrep);
+
     auto norm = [](const QString& s) { return s.trimmed().toLower(); };
     const bool unchanged = norm(cur.brand) == norm(brand)
         && norm(cur.model) == norm(model)
         && norm(cur.burrs) == norm(burrs)
         && norm(curBasket.brand) == norm(basketBrand)
         && norm(curBasket.model) == norm(basketModel)
-        && curPuck.model.trimmed() == puckPrep.trimmed();  // canonical already normalized
+        && curPuck.model == puck;  // both canonical
     if (unchanged)
         return packageId;  // no identity change
 
@@ -982,7 +992,7 @@ qint64 EquipmentStorage::supersedeOrEditStatic(QSqlDatabase& db, qint64 packageI
 
     // Merge: another current package already has this exact full identity.
     const qint64 mergeTarget = findPackageByGrinderIdentityStatic(db, brand, model, burrs, packageId,
-                                                                  basketBrand, basketModel, puckPrep);
+                                                                  basketBrand, basketModel, puck);
     if (mergeTarget > 0) {
         if (!repointBags(packageId, mergeTarget))
             return fail();
@@ -1010,7 +1020,7 @@ qint64 EquipmentStorage::supersedeOrEditStatic(QSqlDatabase& db, qint64 packageI
         // the transaction opened above.
         if (!setBasketItemStatic(db, packageId, basketBrand, basketModel))
             return fail();
-        if (!setPuckPrepItemStatic(db, packageId, puckPrep))
+        if (!setPuckPrepItemStatic(db, packageId, puck))
             return fail();
         return done(packageId);
     }
@@ -1023,7 +1033,7 @@ qint64 EquipmentStorage::supersedeOrEditStatic(QSqlDatabase& db, qint64 packageI
     np.lastRpm = old.lastRpm;
     np.lastUsedEpoch = QDateTime::currentSecsSinceEpoch();
     const qint64 newId = createPackageWithGrinderStatic(db, np, brand, model, burrs,
-                                                        basketBrand, basketModel, puckPrep);
+                                                        basketBrand, basketModel, puck);
     if (newId <= 0)
         return fail();  // fork failed; leave as-is
     if (!repointBags(packageId, newId))
@@ -1301,7 +1311,7 @@ bool EquipmentStorage::importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& 
             while (srcItems.next()) {
                 EquipmentItem item = grinderItemFromQueryRow(srcItems);
                 item.packageId = destId;
-                if (insertItemStatic(destDb, item) < 0)
+                if (insertItemStatic(destDb, item) <= 0)  // consistent with the create path
                     return false;
             }
             newlyInsertedSrcIds.insert(srcPkg.id);

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -214,11 +214,15 @@ QVariantMap EquipmentPackageView::toVariantMap() const
     // Resolved puck prep: the canonical flag string lives in the item's `model`
     // column; reconstruct the individual booleans + the derived distribution from
     // it (PuckPrep). Emitted only when the package has a puckprep item.
+    // Flags (for the card/info display + the dialog edit prefill) and the canonical
+    // string (for the dialog dedup check + SettingsDye prefill). The derived
+    // `distribution` rollup is NOT emitted here — it's an AI-only signal, computed
+    // for the dialing context (buildCurrentBeanBlock) and the MCP equipment tools,
+    // and deliberately kept out of anything user-visible.
     const QString puckCanon = puckPrep.model;
     if (!puckCanon.isEmpty()) {
         for (const QString& k : PuckPrep::flagKeys())
             map.insert(QStringLiteral("puckPrep_") + k, PuckPrep::has(puckCanon, k));
-        map.insert(QStringLiteral("puckPrepDistribution"), PuckPrep::distribution(puckCanon));
         map.insert(QStringLiteral("puckPrepCanonical"), puckCanon);
     }
     map.insert(QStringLiteral("shotCount"), shotCount);

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -2,6 +2,7 @@
 #include "core/dbutils.h"
 #include "core/grinderaliases.h"
 #include "core/basketaliases.h"
+#include "core/puckprep.h"
 
 #include <QSqlQuery>
 #include <QSqlError>
@@ -210,6 +211,16 @@ QVariantMap EquipmentPackageView::toVariantMap() const
             map.insert(QStringLiteral("basketSummary"), BasketAliases::summary(*e));
         }
     }
+    // Resolved puck prep: the canonical flag string lives in the item's `model`
+    // column; reconstruct the individual booleans + the derived distribution from
+    // it (PuckPrep). Emitted only when the package has a puckprep item.
+    const QString puckCanon = puckPrep.model;
+    if (!puckCanon.isEmpty()) {
+        for (const QString& k : PuckPrep::flagKeys())
+            map.insert(QStringLiteral("puckPrep_") + k, PuckPrep::has(puckCanon, k));
+        map.insert(QStringLiteral("puckPrepDistribution"), PuckPrep::distribution(puckCanon));
+        map.insert(QStringLiteral("puckPrepCanonical"), puckCanon);
+    }
     map.insert(QStringLiteral("shotCount"), shotCount);
     return map;
 }
@@ -279,6 +290,7 @@ void EquipmentStorage::requestPackage(qint64 packageId)
                 view.package = pkg;
                 view.grinder = loadGrinderItemStatic(db, packageId);
                 view.basket = loadBasketItemStatic(db, packageId);
+                view.puckPrep = loadPuckPrepItemStatic(db, packageId);
                 *result = view.toVariantMap();
             }
         },
@@ -298,20 +310,23 @@ void EquipmentStorage::requestCreatePackage(const QVariantMap& packageMap)
             const QString burrs = packageMap.value(QStringLiteral("grinderBurrs")).toString();
             const QString basketBrand = packageMap.value(QStringLiteral("basketBrand")).toString();
             const QString basketModel = packageMap.value(QStringLiteral("basketModel")).toString();
-            // Dedup backstop: if an in-inventory package already has this exact
-            // full identity (grinder + basket), return it instead of inserting a
-            // duplicate. The dialog blocks this in the UI too, but the storage is
+            const QString puckPrep = PuckPrep::canonicalMerged(QString(), packageMap);
+            // Dedup backstop: if an in-inventory package already has this exact full
+            // identity (grinder + basket + puck prep), return it instead of inserting
+            // a duplicate. The dialog blocks this in the UI too, but the storage is
             // the authoritative guard against duplicate gear (we don't want dups).
             const qint64 existing = findPackageByGrinderIdentityStatic(db, brand, model, burrs, 0,
-                                                                       basketBrand, basketModel);
+                                                                       basketBrand, basketModel, puckPrep);
             *newId = existing > 0
                 ? existing
-                : createPackageWithGrinderStatic(db, pkg, brand, model, burrs, basketBrand, basketModel);
+                : createPackageWithGrinderStatic(db, pkg, brand, model, burrs,
+                                                 basketBrand, basketModel, puckPrep);
             if (*newId > 0) {
                 EquipmentPackageView view;
                 view.package = loadPackageStatic(db, *newId);
                 view.grinder = loadGrinderItemStatic(db, *newId);
                 view.basket = loadBasketItemStatic(db, *newId);
+                view.puckPrep = loadPuckPrepItemStatic(db, *newId);
                 *created = view.toVariantMap();
             }
         },
@@ -338,23 +353,27 @@ void EquipmentStorage::requestUpdatePackage(qint64 packageId, const QVariantMap&
     runAsync("equip_update",
         [packageId, fields, success, resultId](QSqlDatabase& db) {
             bool any = false;
-            // Identity = grinder (brand/model/burrs) + basket (brand/model). An
-            // edit to EITHER side runs through the copy-on-write engine; the
-            // untouched side is defaulted from the current items so it is preserved.
+            // Identity = grinder (brand/model/burrs) + basket (brand/model) + puck
+            // prep (flag-set). An edit to ANY side runs through the copy-on-write
+            // engine; untouched sides default from the current items so they're
+            // preserved.
             const bool touchesGrinder = fields.contains(QStringLiteral("grinderBrand"))
                 || fields.contains(QStringLiteral("grinderModel"))
                 || fields.contains(QStringLiteral("grinderBurrs"));
             const bool touchesBasket = fields.contains(QStringLiteral("basketBrand"))
                 || fields.contains(QStringLiteral("basketModel"));
-            if (touchesGrinder || touchesBasket) {
+            const bool touchesPuckPrep = PuckPrep::mapTouches(fields);
+            if (touchesGrinder || touchesBasket || touchesPuckPrep) {
                 const EquipmentItem cur = loadGrinderItemStatic(db, packageId);
                 const EquipmentItem curBasket = loadBasketItemStatic(db, packageId);
+                const EquipmentItem curPuck = loadPuckPrepItemStatic(db, packageId);
                 const QString brand = fields.value(QStringLiteral("grinderBrand"), cur.brand).toString();
                 const QString model = fields.value(QStringLiteral("grinderModel"), cur.model).toString();
                 const QString burrs = fields.value(QStringLiteral("grinderBurrs"), cur.burrs).toString();
                 const QString bBrand = fields.value(QStringLiteral("basketBrand"), curBasket.brand).toString();
                 const QString bModel = fields.value(QStringLiteral("basketModel"), curBasket.model).toString();
-                *resultId = supersedeOrEditStatic(db, packageId, brand, model, burrs, bBrand, bModel);
+                const QString puck = PuckPrep::canonicalMerged(curPuck.model, fields);
+                *resultId = supersedeOrEditStatic(db, packageId, brand, model, burrs, bBrand, bModel, puck);
                 any = (*resultId > 0);
             }
             // Strip identity keys before the package-column update; apply the rest
@@ -365,6 +384,8 @@ void EquipmentStorage::requestUpdatePackage(qint64 packageId, const QVariantMap&
             pkgFields.remove(QStringLiteral("grinderBurrs"));
             pkgFields.remove(QStringLiteral("basketBrand"));
             pkgFields.remove(QStringLiteral("basketModel"));
+            for (const QString& k : PuckPrep::flagKeys())
+                pkgFields.remove(QStringLiteral("puckPrep_") + k);
             if (!pkgFields.isEmpty())
                 any = updatePackageFieldsStatic(db, *resultId, pkgFields) || any;
             *success = any;
@@ -531,7 +552,8 @@ qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, Equipm
                                                         const QString& brand, const QString& model,
                                                         const QString& burrs,
                                                         const QString& basketBrand,
-                                                        const QString& basketModel)
+                                                        const QString& basketModel,
+                                                        const QString& puckPrep)
 {
     // Persist a name at creation so it survives identity edits / copy-on-write
     // (two packages may share a display name; the id is the permanent handle).
@@ -568,6 +590,17 @@ qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, Equipm
     // Optional basket item. A failure here is fatal too: a half-built package
     // (grinder but a dropped basket the caller asked for) would silently lose the
     // basket identity, so roll the whole package back.
+    // Cleanup used by the optional-item failures below: drop the items then the
+    // package so a partial build never persists.
+    auto dropAll = [&]() {
+        QSqlQuery di(db);
+        di.prepare("DELETE FROM equipment_items WHERE package_id = :id");
+        di.bindValue(":id", packageId);
+        if (!di.exec())
+            qWarning() << "EquipmentStorage: rollback delete of items for package" << packageId
+                       << "failed (possible orphan):" << di.lastError().text();
+        dropPackage();
+    };
     if (!basketBrand.trimmed().isEmpty() || !basketModel.trimmed().isEmpty()) {
         EquipmentItem basket;
         basket.packageId = packageId;
@@ -575,13 +608,20 @@ qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, Equipm
         basket.brand = basketBrand.trimmed();
         basket.model = basketModel.trimmed();
         if (insertItemStatic(db, basket) <= 0) {
-            QSqlQuery di(db);
-            di.prepare("DELETE FROM equipment_items WHERE package_id = :id");
-            di.bindValue(":id", packageId);
-            if (!di.exec())
-                qWarning() << "EquipmentStorage: rollback delete of items for package" << packageId
-                           << "failed (possible orphan):" << di.lastError().text();
-            dropPackage();
+            dropAll();
+            return -1;
+        }
+    }
+    // Optional puck-prep item: the canonical flag string lives in the `model`
+    // column (brand empty); empty string = no puck prep. Fatal on failure, like
+    // the basket, so a requested config is never silently dropped.
+    if (!puckPrep.trimmed().isEmpty()) {
+        EquipmentItem puck;
+        puck.packageId = packageId;
+        puck.kind = QStringLiteral("puckprep");
+        puck.model = puckPrep.trimmed();
+        if (insertItemStatic(db, puck) <= 0) {
+            dropAll();
             return -1;
         }
     }
@@ -673,6 +713,61 @@ bool EquipmentStorage::setBasketItemStatic(QSqlDatabase& db, qint64 packageId,
     return insertItemStatic(db, basket) > 0;
 }
 
+EquipmentItem EquipmentStorage::loadPuckPrepItemStatic(QSqlDatabase& db, qint64 packageId)
+{
+    QSqlQuery query(db);
+    query.prepare(QString("SELECT %1 FROM equipment_items "
+                          "WHERE package_id = :id AND kind = 'puckprep' ORDER BY id LIMIT 1")
+                      .arg(QLatin1String(kItemColumns)));
+    query.bindValue(":id", packageId);
+    if (!query.exec() || !query.next())
+        return EquipmentItem();  // invalid (id == 0): no puck prep
+    return grinderItemFromQueryRow(query);  // generic read; canonical flags in `model`
+}
+
+bool EquipmentStorage::setPuckPrepItemStatic(QSqlDatabase& db, qint64 packageId,
+                                             const QString& puckPrep)
+{
+    const QString canon = puckPrep.trimmed();
+    const EquipmentItem cur = loadPuckPrepItemStatic(db, packageId);
+
+    // Same return contract as setBasketItemStatic: true on success/no-op, false
+    // ONLY on a genuine SQL failure (so the edit-in-place caller can roll back).
+    if (canon.isEmpty()) {
+        if (!cur.isValid())
+            return true;  // already no puck prep — desired state, nothing to do
+        QSqlQuery del(db);
+        del.prepare("DELETE FROM equipment_items WHERE package_id = :id AND kind = 'puckprep'");
+        del.bindValue(":id", packageId);
+        if (!del.exec()) {
+            qWarning() << "EquipmentStorage: puckprep clear failed for package" << packageId << ":"
+                       << del.lastError().text();
+            return false;
+        }
+        return true;
+    }
+
+    if (cur.isValid()) {
+        QSqlQuery upd(db);
+        upd.prepare("UPDATE equipment_items SET brand = NULL, model = :model, attrs = '{}', "
+                    "updated_at = strftime('%s', 'now') WHERE package_id = :id AND kind = 'puckprep'");
+        upd.bindValue(":model", canon);
+        upd.bindValue(":id", packageId);
+        if (!upd.exec()) {
+            qWarning() << "EquipmentStorage: puckprep update failed for package" << packageId << ":"
+                       << upd.lastError().text();
+            return false;
+        }
+        return true;
+    }
+
+    EquipmentItem puck;
+    puck.packageId = packageId;
+    puck.kind = QStringLiteral("puckprep");
+    puck.model = canon;
+    return insertItemStatic(db, puck) > 0;
+}
+
 QVector<EquipmentPackageView> EquipmentStorage::loadInventoryStatic(QSqlDatabase& db)
 {
     QVector<EquipmentPackageView> views;
@@ -699,6 +794,7 @@ QVector<EquipmentPackageView> EquipmentStorage::loadInventoryStatic(QSqlDatabase
     for (qsizetype i = 0; i < views.size(); ++i) {
         views[i].grinder = loadGrinderItemStatic(db, ids.at(i));
         views[i].basket = loadBasketItemStatic(db, ids.at(i));
+        views[i].puckPrep = loadPuckPrepItemStatic(db, ids.at(i));
     }
     return views;
 }
@@ -764,12 +860,16 @@ qint64 EquipmentStorage::findPackageByGrinderIdentityStatic(QSqlDatabase& db, co
                                                             const QString& model, const QString& burrs,
                                                             qint64 excludeId,
                                                             const QString& basketBrand,
-                                                            const QString& basketModel)
+                                                            const QString& basketModel,
+                                                            const QString& puckPrep)
 {
     // Full-identity match: grinder brand/model/burrs AND the package's basket
-    // brand/model. The basket is matched via correlated subqueries so that a
-    // package with NO basket item resolves to '' and matches empty basket params
-    // ("no basket" is a distinct, matchable identity value).
+    // brand/model AND its puckprep canonical flag string. Each optional component
+    // is matched via correlated subqueries so a package LACKING it resolves to ''
+    // and matches an empty param ("no basket" / "no puck prep" are distinct,
+    // matchable identity values). IFNULL on the bind side too: a caller omitting a
+    // component passes a null QString → SQL NULL, and without IFNULL the '' = NULL
+    // comparison is NULL (never true) and component-less packages stop matching.
     QSqlQuery query(db);
     query.prepare("SELECT i.package_id FROM equipment_items i "
                   "JOIN equipment_packages p ON p.id = i.package_id "
@@ -778,13 +878,14 @@ qint64 EquipmentStorage::findPackageByGrinderIdentityStatic(QSqlDatabase& db, co
                   "AND LOWER(IFNULL(i.brand,'')) = LOWER(:brand) "
                   "AND LOWER(IFNULL(i.model,'')) = LOWER(:model) "
                   "AND LOWER(IFNULL(json_extract(i.attrs,'$.burrs'),'')) = LOWER(:burrs) "
-                  // IFNULL on the bind side too: a grinder-only caller passes a null
-                  // QString, which binds as SQL NULL — without IFNULL the '' = NULL
-                  // comparison is NULL (never true) and no-basket packages stop matching.
                   "AND LOWER(IFNULL((SELECT b.brand FROM equipment_items b "
                   "  WHERE b.package_id = p.id AND b.kind = 'basket' ORDER BY b.id LIMIT 1),'')) = LOWER(IFNULL(:bbrand,'')) "
                   "AND LOWER(IFNULL((SELECT b.model FROM equipment_items b "
                   "  WHERE b.package_id = p.id AND b.kind = 'basket' ORDER BY b.id LIMIT 1),'')) = LOWER(IFNULL(:bmodel,'')) "
+                  // Puck-prep identity is the canonical flag string in the puckprep
+                  // item's `model` column (already normalized, so a plain match).
+                  "AND IFNULL((SELECT pp.model FROM equipment_items pp "
+                  "  WHERE pp.package_id = p.id AND pp.kind = 'puckprep' ORDER BY pp.id LIMIT 1),'') = IFNULL(:puck,'') "
                   "ORDER BY p.id LIMIT 1");
     query.bindValue(":exclude", excludeId);
     query.bindValue(":brand", brand);
@@ -792,6 +893,7 @@ qint64 EquipmentStorage::findPackageByGrinderIdentityStatic(QSqlDatabase& db, co
     query.bindValue(":burrs", burrs);
     query.bindValue(":bbrand", basketBrand.trimmed());
     query.bindValue(":bmodel", basketModel.trimmed());
+    query.bindValue(":puck", puckPrep.trimmed());
     if (!query.exec() || !query.next())
         return 0;
     return query.value(0).toLongLong();
@@ -801,26 +903,30 @@ qint64 EquipmentStorage::supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 p
                                                       const QString& brand, const QString& model,
                                                       const QString& burrs)
 {
-    // Grinder-only edit: preserve the package's current basket identity.
+    // Grinder-only edit: preserve the package's current basket + puck prep.
     const EquipmentItem curBasket = loadBasketItemStatic(db, packageId);
+    const EquipmentItem curPuck = loadPuckPrepItemStatic(db, packageId);
     return supersedeOrEditStatic(db, packageId, brand, model, burrs,
-                                 curBasket.brand, curBasket.model);
+                                 curBasket.brand, curBasket.model, curPuck.model);
 }
 
 qint64 EquipmentStorage::supersedeOrEditStatic(QSqlDatabase& db, qint64 packageId,
                                                const QString& brand, const QString& model,
                                                const QString& burrs,
-                                               const QString& basketBrand, const QString& basketModel)
+                                               const QString& basketBrand, const QString& basketModel,
+                                               const QString& puckPrep)
 {
     const EquipmentItem cur = loadGrinderItemStatic(db, packageId);
     const EquipmentItem curBasket = loadBasketItemStatic(db, packageId);
+    const EquipmentItem curPuck = loadPuckPrepItemStatic(db, packageId);
 
     auto norm = [](const QString& s) { return s.trimmed().toLower(); };
     const bool unchanged = norm(cur.brand) == norm(brand)
         && norm(cur.model) == norm(model)
         && norm(cur.burrs) == norm(burrs)
         && norm(curBasket.brand) == norm(basketBrand)
-        && norm(curBasket.model) == norm(basketModel);
+        && norm(curBasket.model) == norm(basketModel)
+        && curPuck.model.trimmed() == puckPrep.trimmed();  // canonical already normalized
     if (unchanged)
         return packageId;  // no identity change
 
@@ -867,7 +973,7 @@ qint64 EquipmentStorage::supersedeOrEditStatic(QSqlDatabase& db, qint64 packageI
 
     // Merge: another current package already has this exact full identity.
     const qint64 mergeTarget = findPackageByGrinderIdentityStatic(db, brand, model, burrs, packageId,
-                                                                  basketBrand, basketModel);
+                                                                  basketBrand, basketModel, puckPrep);
     if (mergeTarget > 0) {
         if (!repointBags(packageId, mergeTarget))
             return fail();
@@ -886,14 +992,16 @@ qint64 EquipmentStorage::supersedeOrEditStatic(QSqlDatabase& db, qint64 packageI
         return done(mergeTarget);
     }
 
-    // Unused package: safe to edit in place (both grinder and basket items).
+    // Unused package: safe to edit in place (grinder + basket + puckprep items).
     if (shotCount() == 0) {
         if (!updateGrinderItemStatic(db, packageId, brand, model, burrs))
             return fail();
         // A false return is a genuine SQL failure (a no-op returns true), so roll
-        // back rather than commit a half-applied identity (grinder changed, basket
-        // write failed) — this edit runs inside the transaction opened above.
+        // back rather than commit a half-applied identity — these edits run inside
+        // the transaction opened above.
         if (!setBasketItemStatic(db, packageId, basketBrand, basketModel))
+            return fail();
+        if (!setPuckPrepItemStatic(db, packageId, puckPrep))
             return fail();
         return done(packageId);
     }
@@ -906,7 +1014,7 @@ qint64 EquipmentStorage::supersedeOrEditStatic(QSqlDatabase& db, qint64 packageI
     np.lastRpm = old.lastRpm;
     np.lastUsedEpoch = QDateTime::currentSecsSinceEpoch();
     const qint64 newId = createPackageWithGrinderStatic(db, np, brand, model, burrs,
-                                                        basketBrand, basketModel);
+                                                        basketBrand, basketModel, puckPrep);
     if (newId <= 0)
         return fail();  // fork failed; leave as-is
     if (!repointBags(packageId, newId))
@@ -1144,17 +1252,18 @@ bool EquipmentStorage::importEquipmentStatic(QSqlDatabase& srcDb, QSqlDatabase& 
                 srcGrinder = grinderItemFromQueryRow(gi);
         }
         EquipmentItem srcBasket = loadBasketItemStatic(srcDb, srcPkg.id);
+        EquipmentItem srcPuck = loadPuckPrepItemStatic(srcDb, srcPkg.id);
 
         // Merge dedup: an IN-INVENTORY source package whose FULL identity (grinder
-        // + basket) already exists in dest maps to that package — no duplicate.
-        // Superseded (historical) packages always import as new rows so their
-        // shots keep a distinct lineage.
+        // + basket + puck prep) already exists in dest maps to that package — no
+        // duplicate. Superseded (historical) packages always import as new rows so
+        // their shots keep a distinct lineage.
         qint64 destId = -1;
         if (merge && srcPkg.inInventory
             && !(srcGrinder.brand.isEmpty() && srcGrinder.model.isEmpty())) {
             const qint64 existing = findPackageByGrinderIdentityStatic(
                 destDb, srcGrinder.brand, srcGrinder.model, srcGrinder.burrs, 0,
-                srcBasket.brand, srcBasket.model);
+                srcBasket.brand, srcBasket.model, srcPuck.model);
             if (existing > 0)
                 destId = existing;
         }

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -617,13 +617,15 @@ qint64 EquipmentStorage::createPackageWithGrinderStatic(QSqlDatabase& db, Equipm
         }
     }
     // Optional puck-prep item: the canonical flag string lives in the `model`
-    // column (brand empty); empty string = no puck prep. Fatal on failure, like
-    // the basket, so a requested config is never silently dropped.
-    if (!puckPrep.trimmed().isEmpty()) {
+    // column (brand empty); empty string = no puck prep. Re-canonicalized so the
+    // stored value is always canonical (the dedup compares it with a plain '=').
+    // Fatal on failure, like the basket, so a requested config is never silently dropped.
+    const QString puckCanon = PuckPrep::recanonical(puckPrep);
+    if (!puckCanon.isEmpty()) {
         EquipmentItem puck;
         puck.packageId = packageId;
         puck.kind = QStringLiteral("puckprep");
-        puck.model = puckPrep.trimmed();
+        puck.model = puckCanon;
         if (insertItemStatic(db, puck) <= 0) {
             dropAll();
             return -1;
@@ -732,7 +734,10 @@ EquipmentItem EquipmentStorage::loadPuckPrepItemStatic(QSqlDatabase& db, qint64 
 bool EquipmentStorage::setPuckPrepItemStatic(QSqlDatabase& db, qint64 packageId,
                                              const QString& puckPrep)
 {
-    const QString canon = puckPrep.trimmed();
+    // Re-canonicalize so the stored `model` is always canonical regardless of the
+    // caller (the identity dedup compares it with a plain '='), and unknown tokens
+    // are dropped.
+    const QString canon = PuckPrep::recanonical(puckPrep);
     const EquipmentItem cur = loadPuckPrepItemStatic(db, packageId);
 
     // Same return contract as setBasketItemStatic: true on success/no-op, false

--- a/src/history/equipmentstorage.h
+++ b/src/history/equipmentstorage.h
@@ -14,16 +14,18 @@ class QSqlDatabase;
 class QSqlQuery;
 
 // An equipment item: one typed component of a package. The kinds today are
-// "grinder" and the optional "basket" (add-basket-equipment); future kinds
-// (tamper, …) are new rows with a different `kind` and their own `attrs` payload
-// — no schema migration (openspec change add-equipment-packages). Shared fields
-// every kind has (kind/brand/model) are real columns; kind-specific fields live
-// in the `attrs` JSON blob. For a grinder, attrs = { "burrs": "...",
-// "rpmCapable": true }. The `burrs` and `rpmCapable` members below are
-// convenience views of that blob, (de)serialized on load/save — they are not
-// their own columns. A basket has NO kind-specific attrs: its identity is
-// brand+model and every spec (wall/flow/precision/dose) is derived from
-// BasketAliases at read time, so a basket item carries an empty attrs blob.
+// "grinder", the optional "basket" (add-basket-equipment), and the optional
+// "puckprep" (add-puckprep-equipment); future kinds (tamper, …) are new rows with
+// a different `kind` and their own `attrs` payload — no schema migration (openspec
+// change add-equipment-packages). Shared fields every kind has (kind/brand/model)
+// are real columns; kind-specific fields live in the `attrs` JSON blob. For a
+// grinder, attrs = { "burrs": "...", "rpmCapable": true }. The `burrs` and
+// `rpmCapable` members below are convenience views of that blob, (de)serialized on
+// load/save — they are not their own columns. A basket has NO kind-specific attrs:
+// its identity is brand+model and every spec is derived from BasketAliases at read
+// time. A puckprep item stores its canonical flag string (PuckPrep::canonical) in
+// the `model` column and an empty attrs blob; its flags + derived `distribution`
+// are reconstructed from that string at read time (see core/puckprep.h).
 struct EquipmentItem {
     qint64 id = 0;
     qint64 packageId = 0;
@@ -79,9 +81,10 @@ struct EquipmentPackageView {
     EquipmentPackage package;
     EquipmentItem grinder;
     EquipmentItem basket;
+    EquipmentItem puckPrep;  // invalid (id == 0) when the package has no puck prep
     qint64 shotCount = 0;
-    // Flatten package + grinder identity + basket identity/derived specs
-    // (+ shotCount) into one map for QML/MCP.
+    // Flatten package + grinder identity + basket identity/derived specs +
+    // puck-prep flags/derived distribution (+ shotCount) into one map for QML/MCP.
     QVariantMap toVariantMap() const;
 };
 
@@ -131,12 +134,16 @@ public:
                                                  const QString& brand, const QString& model,
                                                  const QString& burrs,
                                                  const QString& basketBrand = QString(),
-                                                 const QString& basketModel = QString());
+                                                 const QString& basketModel = QString(),
+                                                 const QString& puckPrep = QString());
 
     static EquipmentPackage loadPackageStatic(QSqlDatabase& db, qint64 packageId);
     static EquipmentItem loadGrinderItemStatic(QSqlDatabase& db, qint64 packageId);
     // The package's basket item, or an invalid item (id == 0) when none.
     static EquipmentItem loadBasketItemStatic(QSqlDatabase& db, qint64 packageId);
+    // The package's puckprep item (canonical flag string in `model`), or an invalid
+    // item (id == 0) when none.
+    static EquipmentItem loadPuckPrepItemStatic(QSqlDatabase& db, qint64 packageId);
     static QVector<EquipmentPackageView> loadInventoryStatic(QSqlDatabase& db);
 
     static bool updatePackageFieldsStatic(QSqlDatabase& db, qint64 packageId, const QVariantMap& fields);
@@ -153,9 +160,16 @@ public:
     // transaction can roll back on a real error without tripping on a benign no-op.
     static bool setBasketItemStatic(QSqlDatabase& db, qint64 packageId,
                                     const QString& brand, const QString& model);
+    // Set the package's puck-prep identity from a canonical flag string
+    // (PuckPrep::canonical): update the existing puckprep item, insert one when
+    // none exists, or delete it when the string is empty ("no puck prep"). Same
+    // return contract as setBasketItemStatic — false ONLY on a genuine SQL failure.
+    static bool setPuckPrepItemStatic(QSqlDatabase& db, qint64 packageId,
+                                      const QString& puckPrep);
 
-    // Apply a grinder+basket identity edit honoring copy-on-write immutability +
-    // merge, and return the package id the caller should now treat as active:
+    // Apply a grinder+basket+puckprep identity edit honoring copy-on-write
+    // immutability + merge, and return the package id the caller should now treat
+    // as active:
     //   - identity unchanged                      -> same id (no-op)
     //   - another in-inventory package matches     -> merge: repoint this
     //       package's bags to it, delete this package if unused else soft-delete
@@ -163,29 +177,33 @@ public:
     //   - package unused (no shots)                -> edit in place -> same id
     //   - package used (>=1 shot)                  -> fork a new package (copies
     //       name + last dial), repoint bags, soft-delete old (superseded_by) -> new id
-    // Identity is the full (grinder brand/model/burrs + basket brand/model) tuple;
-    // "no basket" is a distinct value. Bag repointing is done here; the
-    // active-equipment selection is the caller's to update from the returned id.
+    // Identity is the full (grinder brand/model/burrs + basket brand/model +
+    // puckprep canonical flag string) tuple; "no basket" / "no puck prep" are
+    // distinct values. Bag repointing is done here; the active-equipment selection
+    // is the caller's to update from the returned id.
     static qint64 supersedeOrEditStatic(QSqlDatabase& db, qint64 packageId,
                                         const QString& brand, const QString& model,
                                         const QString& burrs,
-                                        const QString& basketBrand, const QString& basketModel);
+                                        const QString& basketBrand, const QString& basketModel,
+                                        const QString& puckPrep);
     // Grinder-only convenience: edit the grinder identity while PRESERVING the
-    // package's current basket. Thin wrapper over supersedeOrEditStatic used by
-    // callers that don't touch the basket (MCP grinder edit, tests).
+    // package's current basket + puck prep. Thin wrapper over supersedeOrEditStatic
+    // used by callers that don't touch them (MCP grinder edit, tests).
     static qint64 supersedeOrEditGrinderStatic(QSqlDatabase& db, qint64 packageId,
                                                const QString& brand, const QString& model,
                                                const QString& burrs);
 
     // Find an existing in-inventory package whose full identity matches
-    // (case-insensitive grinder brand+model+burrs AND basket brand+model, where
-    // empty basket params match a package with no basket), or 0 if none. Used by
-    // the migration and create/edit flows to dedup on identity (NOT on grind/rpm).
+    // (case-insensitive grinder brand+model+burrs AND basket brand+model AND
+    // puckprep canonical string, where empty params match a package lacking that
+    // component), or 0 if none. Used by the migration and create/edit flows to
+    // dedup on identity (NOT on grind/rpm).
     static qint64 findPackageByGrinderIdentityStatic(QSqlDatabase& db, const QString& brand,
                                                      const QString& model, const QString& burrs,
                                                      qint64 excludeId = 0,
                                                      const QString& basketBrand = QString(),
-                                                     const QString& basketModel = QString());
+                                                     const QString& basketModel = QString(),
+                                                     const QString& puckPrep = QString());
 
     // rpmCapable for a grinder identity: the registry's variableRpm when the
     // brand/model matches an alias, else true (a custom grinder shows the rpm

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -50,6 +50,9 @@ struct ShotRecord {
     // the package has no basket.
     QString basketBrand;
     QString basketModel;
+    // Puck-prep canonical flag string resolved via equipment_id
+    // (add-puckprep-equipment); empty when the package has no puck prep.
+    QString puckPrep;
     QString grinderSetting;
     qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none
     qint64 rpm = 0;          // grinder rpm dial-in; 0 = unset

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -2204,10 +2204,12 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
                s.bag_id, s.frozen_date, s.defrost_date,
                s.equipment_id, s.rpm,
                ep.in_inventory, ep.superseded_by, ep.name,
-               eb.brand, eb.model
+               eb.brand, eb.model,
+               epp.model
         FROM shots s
         LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder'
         LEFT JOIN equipment_items eb ON eb.package_id = s.equipment_id AND eb.kind = 'basket'
+        LEFT JOIN equipment_items epp ON epp.package_id = s.equipment_id AND epp.kind = 'puckprep'
         LEFT JOIN equipment_packages ep ON ep.id = s.equipment_id
         WHERE s.id = ?
     )")) {
@@ -2283,6 +2285,10 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     // downstream from BasketAliases, never stored.
     record.basketBrand = query.value(44).toString();
     record.basketModel = query.value(45).toString();
+    // Puck-prep canonical flag string (col 46) resolved through equipment_id
+    // (add-puckprep-equipment); empty when the package has no puck prep. Flags +
+    // distribution are derived downstream (core/puckprep.h), never stored.
+    record.puckPrep = query.value(46).toString();
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     // Snapshot stored badge values before the recompute block overwrites them, so

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -62,6 +62,7 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.grinderBurrs = record.grinderBurrs;
     p.basketBrand = record.basketBrand;
     p.basketModel = record.basketModel;
+    p.puckPrep = record.puckPrep;
     p.grinderSetting = record.grinderSetting;
     p.rpm = record.rpm;
     p.equipmentId = record.equipmentId;

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -53,6 +53,9 @@ class ShotProjection {
     // BasketAliases, not stored here.
     Q_PROPERTY(QString basketBrand MEMBER basketBrand)
     Q_PROPERTY(QString basketModel MEMBER basketModel)
+    // Puck-prep canonical flag string (add-puckprep-equipment); flags +
+    // distribution derived downstream from core/puckprep.h.
+    Q_PROPERTY(QString puckPrep MEMBER puckPrep)
     Q_PROPERTY(QString grinderSetting MEMBER grinderSetting)
     Q_PROPERTY(qlonglong rpm MEMBER rpm)
     // The shot's equipment package id (add-equipment-packages) — exposed so the
@@ -140,6 +143,7 @@ public:
     QString grinderBurrs;
     QString basketBrand;
     QString basketModel;
+    QString puckPrep;
     QString grinderSetting;
     qint64 rpm = 0;
     qint64 equipmentId = 0;  // FK -> equipment_packages.id (add-equipment-packages); 0 = none

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -304,6 +304,7 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         in.grinderBurrs = sd.grinderBurrs;
                         in.basketBrand = sd.basketBrand;
                         in.basketModel = sd.basketModel;
+                        in.puckPrep = sd.puckPrep;
                         in.grinderSetting = sd.grinderSetting;
                         in.rpm = static_cast<int>(sd.rpm);
                         in.doseWeightG = sd.doseWeightG;

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -6,6 +6,7 @@
 #include "../history/coffeebagstorage.h"
 #include "../history/equipmentstorage.h"
 #include "../core/basketaliases.h"
+#include "../core/puckprep.h"
 #include "../history/bagid.h"
 #include "../network/visualizeruploader.h"
 #include "../controllers/profilemanager.h"
@@ -1741,6 +1742,16 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             }
             o["basket"] = basket;
         }
+        // Puck prep (add-puckprep-equipment): the set flags + derived distribution,
+        // reconstructed from the canonical string in the item's model column.
+        // Emitted only when the package has puck prep.
+        if (!v.puckPrep.model.isEmpty()) {
+            QJsonObject puck;
+            for (const QString& k : PuckPrep::flagKeys())
+                puck[k] = PuckPrep::has(v.puckPrep.model, k);
+            puck["distribution"] = PuckPrep::distribution(v.puckPrep.model);
+            o["puckPrep"] = puck;
+        }
         o["inInventory"] = v.package.inInventory;
         if (!v.package.lastGrindSetting.isEmpty()) o["lastGrindSetting"] = v.package.lastGrindSetting;
         if (v.package.lastRpm > 0) o["lastRpm"] = v.package.lastRpm;
@@ -1783,12 +1794,14 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
     registry->registerAsyncTool(
         "equipment_update",
         "Update an equipment package's grinder identity (brand/model/burrs), optional basket identity "
-        "(basketBrand/basketModel — pass both empty to remove the basket), and optional name. Only "
-        "provided fields change. rpmAdjustable is re-derived from the grinder registry; basket specs "
-        "are derived from the basket registry. Identity (grinder AND basket) is copy-on-write: editing "
-        "a package that has shots forks a NEW package (the old one is retired and kept for its history) "
-        "and an unused package is edited in place — so the returned package.id may differ from the "
-        "input packageId. An edit matching an existing package merges into it.",
+        "(basketBrand/basketModel — pass both empty to remove the basket), optional puck-prep flags "
+        "(puckPrep: { wdt, shaker, puckScreen, paperFilter, rdt } — set all false to remove puck prep), "
+        "and optional name. Only provided fields change. rpmAdjustable is re-derived from the grinder "
+        "registry; basket specs from the basket registry; puck-prep distribution from the flags. "
+        "Identity (grinder AND basket AND puck prep) is copy-on-write: editing a package that has shots "
+        "forks a NEW package (the old one is retired and kept for its history) and an unused package is "
+        "edited in place — so the returned package.id may differ from the input packageId. An edit "
+        "matching an existing package merges into it.",
         QJsonObject{
             {"type", "object"},
             {"properties", QJsonObject{
@@ -1798,7 +1811,16 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 {"grinderModel", QJsonObject{{"type", "string"}}},
                 {"grinderBurrs", QJsonObject{{"type", "string"}}},
                 {"basketBrand", QJsonObject{{"type", "string"}}},
-                {"basketModel", QJsonObject{{"type", "string"}}}
+                {"basketModel", QJsonObject{{"type", "string"}}},
+                {"puckPrep", QJsonObject{{"type", "object"},
+                    {"description", "Puck-prep technique flags; provided flags override, others keep their value"},
+                    {"properties", QJsonObject{
+                        {"wdt", QJsonObject{{"type", "boolean"}}},
+                        {"shaker", QJsonObject{{"type", "boolean"}}},
+                        {"puckScreen", QJsonObject{{"type", "boolean"}}},
+                        {"paperFilter", QJsonObject{{"type", "boolean"}}},
+                        {"rdt", QJsonObject{{"type", "boolean"}}}
+                    }}}}
             }},
             {"required", QJsonArray{"packageId"}}
         },
@@ -1824,6 +1846,15 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             const QString basketModel = args["basketModel"].toString();
             const bool haveBasketBrand = args.contains("basketBrand");
             const bool haveBasketModel = args.contains("basketModel");
+            // Puck-prep flag overrides as a "puckPrep_<key>" map for canonicalMerged.
+            const bool touchesPuckPrep = args.contains("puckPrep");
+            QVariantMap puckOverrides;
+            if (touchesPuckPrep) {
+                const QJsonObject pp = args["puckPrep"].toObject();
+                for (const QString& k : PuckPrep::flagKeys())
+                    if (pp.contains(k))
+                        puckOverrides.insert(QStringLiteral("puckPrep_") + k, pp.value(k).toBool());
+            }
             const qint64 activeId = settings ? settings->dye()->activeEquipmentId() : -1;
             const QString dbPath = shotHistory->databasePath();
             QThread* thread = QThread::create([=]() {
@@ -1831,18 +1862,20 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 qint64 resultId = packageId;
                 EquipmentPackageView view;
                 withTempDb(dbPath, "mcp_equip_upd", [&](QSqlDatabase& db) {
-                    if (touchesGrinder || touchesBasket) {
-                        // Copy-on-write/merge over the full (grinder + basket)
-                        // identity; an untouched side defaults from the current
+                    if (touchesGrinder || touchesBasket || touchesPuckPrep) {
+                        // Copy-on-write/merge over the full (grinder + basket + puck
+                        // prep) identity; an untouched side defaults from the current
                         // items so it is preserved. May yield a new id.
                         const EquipmentItem cur = EquipmentStorage::loadGrinderItemStatic(db, packageId);
                         const EquipmentItem curBasket = EquipmentStorage::loadBasketItemStatic(db, packageId);
+                        const EquipmentItem curPuck = EquipmentStorage::loadPuckPrepItemStatic(db, packageId);
                         resultId = EquipmentStorage::supersedeOrEditStatic(db, packageId,
                                 haveBrand ? brand : cur.brand,
                                 haveModel ? model : cur.model,
                                 haveBurrs ? burrs : cur.burrs,
                                 haveBasketBrand ? basketBrand : curBasket.brand,
-                                haveBasketModel ? basketModel : curBasket.model);
+                                haveBasketModel ? basketModel : curBasket.model,
+                                PuckPrep::canonicalMerged(curPuck.model, puckOverrides));
                         ok = (resultId > 0);
                     }
                     if (!pkgFields.isEmpty())
@@ -1850,6 +1883,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                     view.package = EquipmentStorage::loadPackageStatic(db, resultId);
                     view.grinder = EquipmentStorage::loadGrinderItemStatic(db, resultId);
                     view.basket = EquipmentStorage::loadBasketItemStatic(db, resultId);
+                    view.puckPrep = EquipmentStorage::loadPuckPrepItemStatic(db, resultId);
                 });
                 QMetaObject::invokeMethod(qApp, [ok, view, activeId, packageId, packageToJson, respond]() {
                     if (!ok || !view.package.isValid()) {
@@ -1892,6 +1926,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                     view.package = EquipmentStorage::loadPackageStatic(db, packageId);
                     view.grinder = EquipmentStorage::loadGrinderItemStatic(db, packageId);
                     view.basket = EquipmentStorage::loadBasketItemStatic(db, packageId);
+                    view.puckPrep = EquipmentStorage::loadPuckPrepItemStatic(db, packageId);
                 });
                 const bool found = view.package.isValid();
                 const QVariantMap pkgMap = view.toVariantMap();

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -1348,6 +1348,15 @@ private slots:
             bi.addBindValue(cur);
             QVERIFY(bi.exec());
 
+            // Puck prep on the current package — pins the loadShotRecordStatic
+            // puckprep JOIN, which reads epp.model by POSITIONAL index (col 46).
+            // The canonical flag string lives in the item's `model` column.
+            QSqlQuery pi(db);
+            pi.prepare("INSERT INTO equipment_items (package_id, kind, brand, model, attrs) "
+                       "VALUES (?, 'puckprep', NULL, 'shaker,wdt', '{}')");
+            pi.addBindValue(cur);
+            QVERIFY(pi.exec());
+
             auto addShot = [&](const QString& uuid, qint64 pkg) -> qint64 {
                 QSqlQuery s(db);
                 s.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, "
@@ -1370,6 +1379,7 @@ private slots:
             QCOMPARE(cur.grinderBurrs, QString("63mm conical"));  // json_extract path
             QCOMPARE(cur.basketBrand, QString("Decent"));         // cols 44/45 JOIN
             QCOMPARE(cur.basketModel, QString("18g Ridgeless"));
+            QCOMPARE(cur.puckPrep, QString("shaker,wdt"));        // col 46 JOIN
             QCOMPARE(cur.equipmentState, QString(""));            // in inventory -> current
 
             const ShotRecord older = ShotHistoryStorage::loadShotRecordStatic(db, olderShot);
@@ -1384,6 +1394,7 @@ private slots:
             const ShotRecord noeq = ShotHistoryStorage::loadShotRecordStatic(db, noEqShot);
             QCOMPARE(noeq.grinderBrand, QString(""));             // NULL JOIN -> empty
             QCOMPARE(noeq.basketBrand, QString(""));              // NULL JOIN -> empty basket
+            QCOMPARE(noeq.puckPrep, QString(""));                 // NULL JOIN -> empty puck prep
             QCOMPARE(noeq.equipmentState, QString(""));           // no package
 
             // Grinder identity is NOT FTS-indexed anymore: a search for a grinder

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -2596,15 +2596,19 @@ private slots:
         QCOMPARE(p["puckScreen"].toBool(), false);
         QCOMPARE(p["paperFilter"].toBool(), false);
         QCOMPARE(p["rdt"].toBool(), false);
-        QCOMPARE(p["distribution"].toString(), QString("thorough"));  // WDT → thorough
+        QCOMPARE(p["distribution"].toString(), QString("thorough"));
 
-        // Shaker without WDT → light; a non-distribution flag alone → none.
+        // Shaker alone is ALSO thorough — equal weight with WDT, not ranked below it.
         in.puckPrep = "shaker";
         QCOMPARE(DialingBlocks::buildCurrentBeanBlock(in)["puckPrep"].toObject()["distribution"].toString(),
-                 QString("light"));
+                 QString("thorough"));
+        // A non-distribution flag alone → none; RDT alone (anti-static) → light.
         in.puckPrep = "puckScreen";
         QCOMPARE(DialingBlocks::buildCurrentBeanBlock(in)["puckPrep"].toObject()["distribution"].toString(),
                  QString("none"));
+        in.puckPrep = "rdt";
+        QCOMPARE(DialingBlocks::buildCurrentBeanBlock(in)["puckPrep"].toObject()["distribution"].toString(),
+                 QString("light"));
     }
 
     // beanbase_json is read by POSITIONAL index in loadShotRecordStatic — a

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -2576,6 +2576,37 @@ private slots:
         QVERIFY(!custom.contains("doseRangeG"));
     }
 
+    // add-puckprep-equipment: the puckPrep sub-object carries the set flags + the
+    // derived distribution rollup the advisor branches channeling guidance on;
+    // omitted when the package has no puck prep.
+    void puckPrepBlockEmitsFlagsAndDistribution()
+    {
+        DialingBlocks::CurrentBeanBlockInputs in;
+        in.beanBrand = "Saka";
+        // No puck prep -> no sub-object.
+        QVERIFY(!DialingBlocks::buildCurrentBeanBlock(in).contains("puckPrep"));
+
+        // Canonical flag string -> flags + derived distribution.
+        in.puckPrep = "shaker,wdt";
+        const QJsonObject bean = DialingBlocks::buildCurrentBeanBlock(in);
+        QVERIFY(bean.contains("puckPrep"));
+        const QJsonObject p = bean["puckPrep"].toObject();
+        QCOMPARE(p["wdt"].toBool(), true);
+        QCOMPARE(p["shaker"].toBool(), true);
+        QCOMPARE(p["puckScreen"].toBool(), false);
+        QCOMPARE(p["paperFilter"].toBool(), false);
+        QCOMPARE(p["rdt"].toBool(), false);
+        QCOMPARE(p["distribution"].toString(), QString("thorough"));  // WDT → thorough
+
+        // Shaker without WDT → light; a non-distribution flag alone → none.
+        in.puckPrep = "shaker";
+        QCOMPARE(DialingBlocks::buildCurrentBeanBlock(in)["puckPrep"].toObject()["distribution"].toString(),
+                 QString("light"));
+        in.puckPrep = "puckScreen";
+        QCOMPARE(DialingBlocks::buildCurrentBeanBlock(in)["puckPrep"].toObject()["distribution"].toString(),
+                 QString("none"));
+    }
+
     // beanbase_json is read by POSITIONAL index in loadShotRecordStatic — a
     // future column inserted mid-SELECT would silently shift the read and
     // every consumer would treat the garbage as "unlinked". Round-trip via

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -456,6 +456,9 @@ private slots:
 
             // Full-identity dedup keys on puck prep too.
             QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "Turin", "DF83V", "83mm", 0, QString(), QString(), "wdt"), A);
+            // An UNSORTED query arg still matches the canonical-stored value (the
+            // lookup re-canonicalizes its bind), so dedup can't be defeated by order.
+            QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "Turin", "DF83V", "83mm", 0, QString(), QString(), "wdt,shaker"), B);
             // "No puck prep" is a distinct value: a grinder+basket-only query matches neither.
             QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "Turin", "DF83V", "83mm"), (qint64)0);
 

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -366,9 +366,10 @@ private slots:
         };
         QCOMPARE(canon(true, true, false, false, false), QString("shaker,wdt"));
         QCOMPARE(canon(false, false, false, false, false), QString(""));
-        QCOMPARE(PuckPrep::distribution("shaker,wdt"), QString("thorough"));  // wdt wins
-        QCOMPARE(PuckPrep::distribution("shaker"), QString("light"));
-        QCOMPARE(PuckPrep::distribution("puckScreen"), QString("none"));     // no wdt/shaker
+        QCOMPARE(PuckPrep::distribution("shaker,wdt"), QString("thorough"));
+        QCOMPARE(PuckPrep::distribution("shaker"), QString("thorough"));     // shaker == WDT (equal weight)
+        QCOMPARE(PuckPrep::distribution("rdt"), QString("light"));           // anti-static only
+        QCOMPARE(PuckPrep::distribution("puckScreen"), QString("none"));     // no active distribution
 
         const QString path = freshDbPath();
         withRawDb(path, "eq_puck", [&](QSqlDatabase& db) {

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -6,6 +6,7 @@
 
 #include "history/equipmentstorage.h"
 #include "history/coffeebagstorage.h"
+#include "core/puckprep.h"
 
 // Equipment packages: the grind/rpm split heuristic, rpmCapable derivation,
 // package CRUD, identity dedup, and the migration-22 data step
@@ -340,7 +341,7 @@ private slots:
 
             // Changing the basket on a USED package forks (copy-on-write).
             addShot(A);
-            const qint64 fork = EquipmentStorage::supersedeOrEditStatic(db, A, "Turin", "DF83V", "83mm", "IMS", "Competition 18g");
+            const qint64 fork = EquipmentStorage::supersedeOrEditStatic(db, A, "Turin", "DF83V", "83mm", "IMS", "Competition 18g", QString());
             QVERIFY(fork > 0 && fork != A);
             QCOMPARE(EquipmentStorage::loadBasketItemStatic(db, fork).brand, QString("IMS"));
             QCOMPARE(EquipmentStorage::loadPackageStatic(db, A).supersededBy, fork);
@@ -351,6 +352,102 @@ private slots:
             const qint64 c2 = EquipmentStorage::supersedeOrEditGrinderStatic(db, C, "Mazzer", "Major V2", "83mm");
             QCOMPARE(c2, C);  // unused → edit in place
             QCOMPARE(EquipmentStorage::loadBasketItemStatic(db, C).model, QString("20g"));  // basket preserved
+        });
+    }
+
+    // --- puck prep: canonical helper, optional item, derive-at-read, set contract ---
+    void puckPrepOptionalAndDerive() {
+        // Canonical is order-independent + sorted (the identity key).
+        auto canon = [](bool wdt, bool shaker, bool puckScreen, bool paper, bool rdt) {
+            QVariantMap m;
+            m["wdt"] = wdt; m["shaker"] = shaker; m["puckScreen"] = puckScreen;
+            m["paperFilter"] = paper; m["rdt"] = rdt;
+            return PuckPrep::canonical(m);
+        };
+        QCOMPARE(canon(true, true, false, false, false), QString("shaker,wdt"));
+        QCOMPARE(canon(false, false, false, false, false), QString(""));
+        QCOMPARE(PuckPrep::distribution("shaker,wdt"), QString("thorough"));  // wdt wins
+        QCOMPARE(PuckPrep::distribution("shaker"), QString("light"));
+        QCOMPARE(PuckPrep::distribution("puckScreen"), QString("none"));     // no wdt/shaker
+
+        const QString path = freshDbPath();
+        withRawDb(path, "eq_puck", [&](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+
+            // Create a package with puck prep in one call.
+            EquipmentPackage p1;
+            const qint64 g1 = EquipmentStorage::createPackageWithGrinderStatic(
+                db, p1, "Turin", "DF83V", "83mm", QString(), QString(), "shaker,wdt");
+            QVERIFY(g1 > 0);
+            const EquipmentItem pp = EquipmentStorage::loadPuckPrepItemStatic(db, g1);
+            QVERIFY(pp.isValid());
+            QCOMPARE(pp.kind, QString("puckprep"));
+            QCOMPARE(pp.model, QString("shaker,wdt"));  // canonical in `model`
+
+            // Derive-at-read: the view map carries the flags + distribution.
+            EquipmentPackageView v;
+            v.package = EquipmentStorage::loadPackageStatic(db, g1);
+            v.grinder = EquipmentStorage::loadGrinderItemStatic(db, g1);
+            v.puckPrep = pp;
+            const QVariantMap m = v.toVariantMap();
+            QCOMPARE(m.value("puckPrep_wdt").toBool(), true);
+            QCOMPARE(m.value("puckPrep_shaker").toBool(), true);
+            QCOMPARE(m.value("puckPrep_puckScreen").toBool(), false);
+            QCOMPARE(m.value("puckPrepDistribution").toString(), QString("thorough"));
+            QCOMPARE(m.value("puckPrepCanonical").toString(), QString("shaker,wdt"));
+
+            // Grinder-only package: no puckprep item; map omits the fields.
+            EquipmentPackage p0;
+            const qint64 g0 = EquipmentStorage::createPackageWithGrinderStatic(db, p0, "Niche", "Zero", "63mm");
+            QVERIFY(!EquipmentStorage::loadPuckPrepItemStatic(db, g0).isValid());
+
+            // setPuckPrepItemStatic: insert, no-op-clear (true), update, clear.
+            QVERIFY(EquipmentStorage::setPuckPrepItemStatic(db, g0, ""));        // no-op → true
+            QVERIFY(EquipmentStorage::setPuckPrepItemStatic(db, g0, "wdt"));     // insert → true
+            QCOMPARE(EquipmentStorage::loadPuckPrepItemStatic(db, g0).model, QString("wdt"));
+            QVERIFY(EquipmentStorage::setPuckPrepItemStatic(db, g0, "rdt,wdt")); // update → true
+            QCOMPARE(EquipmentStorage::loadPuckPrepItemStatic(db, g0).model, QString("rdt,wdt"));
+            QVERIFY(EquipmentStorage::setPuckPrepItemStatic(db, g0, ""));        // clear → true
+            QVERIFY(!EquipmentStorage::loadPuckPrepItemStatic(db, g0).isValid());
+        });
+    }
+
+    // --- puck prep participates in package identity (dedup + copy-on-write) ---
+    void puckPrepIdentityWidening() {
+        const QString path = freshDbPath();
+        withRawDb(path, "eq_puck_id", [](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            QVERIFY(CoffeeBagStorage::ensureTableStatic(db));
+            createMinimalShots(db);
+            auto addShot = [&](qint64 eq) {
+                QSqlQuery q(db); q.prepare("INSERT INTO shots (equipment_id) VALUES (?)");
+                q.addBindValue(eq); q.exec(); return q.lastInsertId().toLongLong();
+            };
+
+            // Same grinder, different puck prep → distinct packages.
+            EquipmentPackage a, b;
+            const qint64 A = EquipmentStorage::createPackageWithGrinderStatic(db, a, "Turin", "DF83V", "83mm", QString(), QString(), "wdt");
+            const qint64 B = EquipmentStorage::createPackageWithGrinderStatic(db, b, "Turin", "DF83V", "83mm", QString(), QString(), "shaker,wdt");
+            QVERIFY(A > 0 && B > 0 && A != B);
+
+            // Full-identity dedup keys on puck prep too.
+            QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "Turin", "DF83V", "83mm", 0, QString(), QString(), "wdt"), A);
+            // "No puck prep" is a distinct value: a grinder+basket-only query matches neither.
+            QCOMPARE(EquipmentStorage::findPackageByGrinderIdentityStatic(db, "Turin", "DF83V", "83mm"), (qint64)0);
+
+            // Changing puck prep on a USED package forks.
+            addShot(A);
+            const qint64 fork = EquipmentStorage::supersedeOrEditStatic(db, A, "Turin", "DF83V", "83mm", QString(), QString(), "rdt,wdt");
+            QVERIFY(fork > 0 && fork != A);
+            QCOMPARE(EquipmentStorage::loadPuckPrepItemStatic(db, fork).model, QString("rdt,wdt"));
+            QCOMPARE(EquipmentStorage::loadPackageStatic(db, A).supersededBy, fork);
+
+            // The grinder-only wrapper PRESERVES puck prep.
+            EquipmentPackage cpk;
+            const qint64 C = EquipmentStorage::createPackageWithGrinderStatic(db, cpk, "Mazzer", "Major", "83mm", QString(), QString(), "wdt");
+            const qint64 c2 = EquipmentStorage::supersedeOrEditGrinderStatic(db, C, "Mazzer", "Major V2", "83mm");
+            QCOMPARE(c2, C);  // unused → edit in place
+            QCOMPARE(EquipmentStorage::loadPuckPrepItemStatic(db, C).model, QString("wdt"));  // preserved
         });
     }
 

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -371,6 +371,27 @@ private slots:
         QCOMPARE(PuckPrep::distribution("rdt"), QString("light"));           // anti-static only
         QCOMPARE(PuckPrep::distribution("puckScreen"), QString("none"));     // no active distribution
 
+        // recanonical: idempotent, re-sorts an unsorted string, drops unknown tokens.
+        QCOMPARE(PuckPrep::recanonical("shaker,wdt"), QString("shaker,wdt"));
+        QCOMPARE(PuckPrep::recanonical("wdt,shaker"), QString("shaker,wdt"));   // re-sorted
+        QCOMPARE(PuckPrep::recanonical("wdt,bogus, shaker "), QString("shaker,wdt")); // unknown dropped
+        QCOMPARE(PuckPrep::recanonical(""), QString(""));
+
+        // canonicalMerged: partial overrides on a current string keep the untouched
+        // flags — the load-bearing data-preservation path for partial (MCP/dialog)
+        // edits. A regression here silently wipes a user's other flags.
+        auto over = [](const QString& key, bool v) { QVariantMap m; m["puckPrep_" + key] = v; return m; };
+        QCOMPARE(PuckPrep::canonicalMerged("shaker,wdt", over("paperFilter", true)),
+                 QString("paperFilter,shaker,wdt"));               // added, re-sorted, others kept
+        QCOMPARE(PuckPrep::canonicalMerged("shaker,wdt", over("wdt", false)),
+                 QString("shaker"));                               // one cleared, rest kept
+        QCOMPARE(PuckPrep::canonicalMerged("", over("wdt", true)), QString("wdt"));  // from empty
+        QCOMPARE(PuckPrep::canonicalMerged("rdt,wdt", QVariantMap()), QString("rdt,wdt")); // empty map = no change
+        // mapTouches gates the edit: a puckPrep_* key trips it; unrelated keys / {} don't.
+        QVERIFY(PuckPrep::mapTouches(over("wdt", true)));
+        QVERIFY(!PuckPrep::mapTouches(QVariantMap{{"basketBrand", "VST"}}));
+        QVERIFY(!PuckPrep::mapTouches(QVariantMap()));
+
         const QString path = freshDbPath();
         withRawDb(path, "eq_puck", [&](QSqlDatabase& db) {
             QVERIFY(EquipmentStorage::ensureTablesStatic(db));
@@ -385,7 +406,8 @@ private slots:
             QCOMPARE(pp.kind, QString("puckprep"));
             QCOMPARE(pp.model, QString("shaker,wdt"));  // canonical in `model`
 
-            // Derive-at-read: the view map carries the flags + distribution.
+            // Derive-at-read: the view map carries the flags + canonical string
+            // (distribution is AI-only and excluded — asserted below).
             EquipmentPackageView v;
             v.package = EquipmentStorage::loadPackageStatic(db, g1);
             v.grinder = EquipmentStorage::loadGrinderItemStatic(db, g1);
@@ -450,7 +472,59 @@ private slots:
             const qint64 c2 = EquipmentStorage::supersedeOrEditGrinderStatic(db, C, "Mazzer", "Major V2", "83mm");
             QCOMPARE(c2, C);  // unused → edit in place
             QCOMPARE(EquipmentStorage::loadPuckPrepItemStatic(db, C).model, QString("wdt"));  // preserved
+
+            // Partial edit through the same storage path requestUpdatePackage / the
+            // MCP equipment_update use (canonicalMerged): a single-flag override on an
+            // unused package preserves the rest.
+            EquipmentPackage dpk;
+            const qint64 D = EquipmentStorage::createPackageWithGrinderStatic(db, dpk, "Niche", "Zero", "63mm", QString(), QString(), "shaker,wdt");
+            const QString merged = PuckPrep::canonicalMerged(EquipmentStorage::loadPuckPrepItemStatic(db, D).model,
+                                                             QVariantMap{{"puckPrep_paperFilter", true}});
+            QCOMPARE(EquipmentStorage::supersedeOrEditStatic(db, D, "Niche", "Zero", "63mm", QString(), QString(), merged), D);
+            QCOMPARE(EquipmentStorage::loadPuckPrepItemStatic(db, D).model, QString("paperFilter,shaker,wdt"));
         });
+    }
+
+    // --- puck prep in device-transfer dedup: same gear + same prep merges,
+    //     same gear + different prep stays distinct (no basket either side). ---
+    void puckPrepImportDedup() {
+        const QString srcPath = freshDbPath();
+        const QString dstPath = freshDbPath();
+
+        qint64 srcDiff = -1, srcSame = -1;
+        withRawDb(srcPath, "impp_src", [&](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            EquipmentPackage a, b;
+            srcDiff = EquipmentStorage::createPackageWithGrinderStatic(db, a, "Niche", "Zero", "63mm", QString(), QString(), "wdt");
+            srcSame = EquipmentStorage::createPackageWithGrinderStatic(db, b, "Mazzer", "Major", "83mm", QString(), QString(), "shaker,wdt");
+        });
+        QVERIFY(srcDiff > 0 && srcSame > 0);
+
+        qint64 dstDiff = -1, dstSame = -1;
+        withRawDb(dstPath, "impp_dst", [&](QSqlDatabase& db) {
+            QVERIFY(EquipmentStorage::ensureTablesStatic(db));
+            EquipmentPackage a, b;
+            dstDiff = EquipmentStorage::createPackageWithGrinderStatic(db, a, "Niche", "Zero", "63mm", QString(), QString(), "shaker"); // diff prep
+            dstSame = EquipmentStorage::createPackageWithGrinderStatic(db, b, "Mazzer", "Major", "83mm", QString(), QString(), "shaker,wdt"); // same
+        });
+        QVERIFY(dstDiff > 0 && dstSame > 0);
+
+        QHash<qint64, qint64> idMap;
+        {
+            QSqlDatabase src = QSqlDatabase::addDatabase("QSQLITE", "impp_s");
+            src.setDatabaseName(srcPath); QVERIFY(src.open());
+            QSqlDatabase dst = QSqlDatabase::addDatabase("QSQLITE", "impp_d");
+            dst.setDatabaseName(dstPath); QVERIFY(dst.open());
+            QVERIFY(EquipmentStorage::importEquipmentStatic(src, dst, /*merge*/ true, idMap));
+            src = QSqlDatabase(); dst = QSqlDatabase();
+        }
+        QSqlDatabase::removeDatabase("impp_s");
+        QSqlDatabase::removeDatabase("impp_d");
+
+        // Different prep -> imported as a NEW dest package, not merged onto dstDiff.
+        QVERIFY(idMap.value(srcDiff) > 0 && idMap.value(srcDiff) != dstDiff);
+        // Same grinder + same prep -> merged onto the existing dest package.
+        QCOMPARE(idMap.value(srcSame), dstSame);
     }
 
     // --- migration data step: split + dedup-into-packages + link ---

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -394,8 +394,9 @@ private slots:
             QCOMPARE(m.value("puckPrep_wdt").toBool(), true);
             QCOMPARE(m.value("puckPrep_shaker").toBool(), true);
             QCOMPARE(m.value("puckPrep_puckScreen").toBool(), false);
-            QCOMPARE(m.value("puckPrepDistribution").toString(), QString("thorough"));
             QCOMPARE(m.value("puckPrepCanonical").toString(), QString("shaker,wdt"));
+            // distribution is AI-only — deliberately NOT in the QML-facing map.
+            QVERIFY(!m.contains("puckPrepDistribution"));
 
             // Grinder-only package: no puckprep item; map omits the fields.
             EquipmentPackage p0;


### PR DESCRIPTION
Adds **puck prep** as the equipment package's third optional component kind (after grinder and basket), following the same machinery — so a shot records the user's distribution/prep routine for reproducibility, and the AI advisor gets the one channeling input it can't read from telemetry.

Implements OpenSpec change `add-puckprep-equipment` (explored + designed in-session). Builds on the merged grinder (#1341) and basket (#1345) work. No schema migration.

## The twist vs. basket
Puck prep has **no vendor→model identity** — it's a set of technique flags. They're stored as a **canonical sorted flag-string** (e.g. `"shaker,wdt"`) in the item's `model` column, which lets it reuse the exact brand/model identity machinery (correlated-subquery dedup, optional upsert/delete). Flags + a derived `distribution` rollup are reconstructed at read time ([core/puckprep.h](src/core/puckprep.h)).

## Storage / identity
- Optional `kind="puckprep"` item; identity widens `(grinder+basket)` → `(grinder+basket+puckprep)`, compared as the normalized flag-string. "No puck prep" is a distinct, matchable value. Order-independent by construction (canonical is sorted).
- `distribution` rollup (`none`/`light`/`thorough`) derived at read (WDT→thorough, shaker→light), never stored. Threaded through create / update / fork / merge / device-import.

## Shot + AI/MCP
- Resolved via the `equipment_id` JOIN (new **col 46**, appended after the basket cols). `ShotRecord`/`ShotProjection` gain `puckPrep`.
- `currentBean` gains a `puckPrep` sub-object (the set flags + `distribution`) — the signal the advisor branches channeling guidance on: *none/light → "fix prep first (WDT/shaker)"* vs *thorough → "prep's solid, it's grind/dose."*
- `equipment_*` MCP tools read and write the flags (a `puckPrep: { wdt, shaker, … }` object on `equipment_update`).

## UI
- `SwitchEquipmentDialog`: optional puck-prep **checkbox grid** (reuses the accessible `StyledSwitch`; all-unchecked = no puck prep; prefilled from the active package; folded into the duplicate-Save guard).
- `EquipmentCard` + `EquipmentInfoDialog` show the prep (summary line / rows).

## Follow-ons (documented, not in this PR)
- **Tamper** base shape (flat/convex/ripple) — one enum field on the item.
- **Sift** — a 6th flag folding into the `distribution` rollup.

## Testing
- `tst_equipment` 24→26 (`puckPrepOptionalAndDerive`, `puckPrepIdentityWidening` — canonical/order-independence, optional, derive-at-read, fork/dedup/edit-in-place/preserve, set-contract).
- `tst_dialing_blocks` 53→54 (`currentBean.puckPrep` present/omitted/distribution).
- `tst_dbmigration` JOIN test extended to pin **col 46** (guards the silent column-shift the basket review caught).
- App + all test targets build clean (0 warnings); coffeebags/mcptools_write/basketaliases green.
- **Not yet run live** — the simulation end-to-end (set flags → pull a shot → confirm `currentBean.puckPrep`) needs the new build deployed; tracked as task 5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)