### PR TITLE
Fix Brew Settings equipment label clipping into the package name

### DIFF
--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -589,14 +589,17 @@ Dialog {
             // is managed in the Equipment window / Switch dialog, not edited here.
             RowLayout {
                 Layout.fillWidth: true
-                spacing: Theme.scaled(4)
+                spacing: Theme.scaled(8)
 
                 Text {
                     text: TranslationManager.translate("brewDialog.equipmentLabel", "Equipment:")
                     font: Theme.bodyFont
                     color: Theme.textSecondaryColor
                     Layout.alignment: Qt.AlignVCenter
-                    Layout.preferredWidth: Theme.scaled(75)
+                    // "Equipment:" is the widest label here, so let it size to its
+                    // content (min = the shared 75px column) rather than a fixed 75px
+                    // that clips it and lets the package name butt right against it.
+                    Layout.minimumWidth: Theme.scaled(75)
                     Accessible.ignored: true
                 }
 


### PR DESCRIPTION
In Brew Settings the **"Equipment:"** label ran right up against the package name (`EquipmentNiche Zero`). All labels in the dialog use a fixed `scaled(75)` column, but "Equipment:" is the widest label, so it overflowed its column and the name butted against it.

Fix: let the equipment label size to its content (minimum = the shared 75px column) instead of a fixed 75px that clips it, and bump the row spacing `4 → 8` for a cleaner gap.

Small UI fix, unrelated to the in-flight basket/puck-prep equipment work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)