### PR TITLE
Share one EquipmentCard renderer across Shot Detail, Review, Inventory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -762,6 +762,7 @@ set(QML_FILES
     qml/components/BagCard.qml
     qml/components/SwitchEquipmentDialog.qml
     qml/components/EquipmentCard.qml
+    qml/components/EquipmentSummary.qml
     qml/components/EquipmentInfoDialog.qml
     qml/components/KeyboardAwareContainer.qml
     qml/components/AIConversationPanel.qml

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -4,9 +4,10 @@ import QtQuick.Layouts
 import Decenza
 
 // Equipment package card (add-equipment-packages). Mirrors BagCard. Shows the
-// grinder identity (brand/model, burrs subtitle), the last-used dial, and the
-// basket line (add-basket-equipment). Equipment is switched per-bag from Brew Settings, so the
-// card itself is informational + edit/remove (no global "selected" state). One
+// package identity via the shared EquipmentSummary renderer (grinder, dial,
+// basket, puck prep), then adds the inventory chrome. Equipment is switched
+// per-bag from Brew Settings, so the card itself is informational + edit/remove
+// (no global "selected" state). One
 // removal action follows the package's life: a trash icon while no SHOT
 // references it (a mistaken creation — hard delete), then "Remove" once shots
 // exist (soft-delete, history kept). Storage is the authoritative backstop — it

--- a/qml/components/EquipmentCard.qml
+++ b/qml/components/EquipmentCard.qml
@@ -21,56 +21,6 @@ Rectangle {
 
     readonly property bool selected: pkg && pkg.id !== undefined && pkg.id === Settings.dye.activeEquipmentId
     readonly property bool hasReferences: pkg && (pkg.shotCount ?? 0) > 0
-    readonly property string grinderTitle: {
-        var brand = (pkg && pkg.grinderBrand) || ""
-        var model = (pkg && pkg.grinderModel) || ""
-        var combined = [brand, model].filter(function(s) { return s.length > 0 }).join(" ")
-        return (pkg && pkg.name && String(pkg.name).length > 0) ? String(pkg.name) : combined
-    }
-    readonly property string burrs: (pkg && pkg.grinderBurrs) || ""
-    readonly property bool rpmCapable: !!(pkg && pkg.rpmCapable)
-    // Basket identity line (add-basket-equipment); empty when the package has none.
-    readonly property string basketLine: {
-        var _ = TranslationManager.translationVersion
-        var b = [(pkg && pkg.basketBrand) || "", (pkg && pkg.basketModel) || ""]
-                .filter(function(s) { return s.length > 0 }).join(" ")
-        return b.length > 0 ? TranslationManager.translate("equipment.card.basket", "Basket: %1").arg(b) : ""
-    }
-    // Puck-prep summary line (add-puckprep-equipment); empty when the package has
-    // none. Shows the short labels of the set flags, e.g. "Prep: WDT · Shaker".
-    readonly property string puckPrepLine: {
-        var _ = TranslationManager.translationVersion
-        if (!pkg) return ""
-        var labels = []
-        if (pkg.puckPrep_wdt) labels.push(TranslationManager.translate("equipment.dialog.puckWdt", "WDT"))
-        if (pkg.puckPrep_shaker) labels.push(TranslationManager.translate("equipment.dialog.puckShaker", "Shaker"))
-        if (pkg.puckPrep_puckScreen) labels.push(TranslationManager.translate("equipment.dialog.puckScreen", "Puck screen"))
-        if (pkg.puckPrep_paperFilter) labels.push(TranslationManager.translate("equipment.dialog.puckPaper", "Bottom paper filter"))
-        if (pkg.puckPrep_rdt) labels.push(TranslationManager.translate("equipment.dialog.puckRdt", "RDT (spritz)"))
-        return labels.length > 0
-            ? TranslationManager.translate("equipment.card.puckPrep", "Prep: %1").arg(labels.join(" · ")) : ""
-    }
-
-    readonly property string lastDialLine: {
-        var _ = TranslationManager.translationVersion
-        var parts = []
-        var g = (pkg && pkg.lastGrindSetting) || ""
-        if (String(g).length > 0)
-            parts.push(TranslationManager.translate("equipment.card.lastGrind", "Grind %1").arg(g))
-        var rpm = pkg && pkg.lastRpm ? Number(pkg.lastRpm) : 0
-        if (rpmCapable && rpm > 0)
-            parts.push(TranslationManager.translate("equipment.card.lastRpm", "%1 rpm").arg(rpm))
-        return parts.join(" · ")
-    }
-
-    readonly property string accessibleSummary: {
-        var bits = [grinderTitle, burrs].filter(function(s) { return s.length > 0 })
-        if (lastDialLine.length > 0) bits.push(lastDialLine)
-        if (basketLine.length > 0) bits.push(basketLine)
-        if (puckPrepLine.length > 0) bits.push(puckPrepLine)
-        if (selected) bits.push(TranslationManager.translate("accessibility.selected", "selected"))
-        return bits.join(", ")
-    }
 
     color: Theme.surfaceColor
     radius: Theme.cardRadius
@@ -110,71 +60,31 @@ Rectangle {
         Item {
             id: infoArea
             Layout.fillWidth: true
-            implicitHeight: infoColumn.implicitHeight
+            implicitHeight: summary.implicitHeight
 
-            ColumnLayout {
-                id: infoColumn
+            // Shared identity rendering (grinder/basket/puck prep). The package map
+            // exposes the canonical puck-prep string as `puckPrepCanonical`.
+            EquipmentSummary {
+                id: summary
                 anchors.left: parent.left
                 anchors.right: parent.right
-                spacing: Theme.scaled(2)
-
-                Text {
-                    Layout.fillWidth: true
-                    text: card.grinderTitle
-                    font.family: Theme.bodyFont.family
-                    font.pixelSize: Theme.subtitleFont.pixelSize
-                    font.bold: true
-                    color: Theme.textColor
-                    elide: Text.ElideRight
-                    Accessible.ignored: true
-                }
-
-                Text {
-                    Layout.fillWidth: true
-                    visible: card.burrs.length > 0
-                    text: card.burrs
-                    font: Theme.labelFont
-                    color: Theme.textSecondaryColor
-                    elide: Text.ElideRight
-                    Accessible.ignored: true
-                }
-
-                Text {
-                    Layout.fillWidth: true
-                    visible: card.lastDialLine.length > 0
-                    text: card.lastDialLine
-                    font: Theme.captionFont
-                    color: Theme.textColor
-                    elide: Text.ElideRight
-                    Accessible.ignored: true
-                }
-
-                // Basket + puck prep last: separate equipment, so keep the grinder
-                // identity (title + burrs) and its dial (grind) contiguous above them.
-                Text {
-                    Layout.fillWidth: true
-                    visible: card.basketLine.length > 0
-                    text: card.basketLine
-                    font: Theme.labelFont
-                    color: Theme.textSecondaryColor
-                    elide: Text.ElideRight
-                    Accessible.ignored: true
-                }
-
-                Text {
-                    Layout.fillWidth: true
-                    visible: card.puckPrepLine.length > 0
-                    text: card.puckPrepLine
-                    font: Theme.labelFont
-                    color: Theme.textSecondaryColor
-                    elide: Text.ElideRight
-                    Accessible.ignored: true
-                }
+                grinderName: (card.pkg && card.pkg.name) ? String(card.pkg.name) : ""
+                grinderBrand: (card.pkg && card.pkg.grinderBrand) || ""
+                grinderModel: (card.pkg && card.pkg.grinderModel) || ""
+                grinderBurrs: (card.pkg && card.pkg.grinderBurrs) || ""
+                grindSetting: (card.pkg && card.pkg.lastGrindSetting) || ""
+                rpm: (card.pkg && card.pkg.lastRpm) ? Number(card.pkg.lastRpm) : 0
+                rpmCapable: !!(card.pkg && card.pkg.rpmCapable)
+                basketBrand: (card.pkg && card.pkg.basketBrand) || ""
+                basketModel: (card.pkg && card.pkg.basketModel) || ""
+                puckPrepCanonical: (card.pkg && card.pkg.puckPrepCanonical) || ""
             }
 
             AccessibleMouseArea {
                 anchors.fill: parent
-                accessibleName: card.accessibleSummary
+                accessibleName: card.selected
+                    ? summary.accessibleSummary + ", " + TranslationManager.translate("accessibility.selected", "selected")
+                    : summary.accessibleSummary
                 accessibleItem: infoArea
                 onAccessibleClicked: {
                     if (card.pkg && card.pkg.id !== undefined)

--- a/qml/components/EquipmentSummary.qml
+++ b/qml/components/EquipmentSummary.qml
@@ -1,0 +1,160 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Decenza
+
+// Read-only presentational core for an equipment package (add-equipment-packages).
+// The single source of truth for how a package's identity renders: grinder title,
+// burrs subtitle, last-dial line, basket line, and puck-prep line. Used by the
+// inventory EquipmentCard (which adds the selected border + action buttons around
+// it) and by the read-only Shot Detail / Post-Shot Review pages.
+//
+// Inputs are NORMALIZED SCALARS, not a package or shot object, so either shape can
+// feed it. Puck prep is taken as the CANONICAL comma-joined flag string (see
+// src/core/puckprep.h) — a package exposes it as `puckPrepCanonical`, a shot as
+// `puckPrep` — so one code path renders both. equipmentState carries the
+// "older"/"retired" lineage qualifier in shot contexts (empty for live packages).
+ColumnLayout {
+    id: summary
+
+    property string grinderName: ""   // resolved display name; falls back to brand+model
+    property string grinderBrand: ""
+    property string grinderModel: ""
+    property string grinderBurrs: ""
+    property string grindSetting: ""
+    property int rpm: 0
+    property bool rpmCapable: false
+    property string basketBrand: ""
+    property string basketModel: ""
+    property string puckPrepCanonical: ""
+    property string equipmentState: ""  // "", "older", "retired"
+
+    spacing: Theme.scaled(2)
+
+    readonly property string title: {
+        var combined = [grinderBrand, grinderModel]
+            .filter(function(s) { return s.length > 0 }).join(" ")
+        return grinderName.length > 0 ? grinderName : combined
+    }
+
+    // Puck-prep set flags as a "WDT · Shaker" summary, parsed from the canonical
+    // string. MIRRORS PuckPrep::flagKeys() display order (src/core/puckprep.h).
+    readonly property var _puckFlags: puckPrepCanonical.split(",")
+    function _hasPuck(key) { return _puckFlags.indexOf(key) >= 0 }
+
+    readonly property string basketLine: {
+        var _ = TranslationManager.translationVersion
+        var b = [basketBrand, basketModel]
+            .filter(function(s) { return s.length > 0 }).join(" ")
+        return b.length > 0 ? TranslationManager.translate("equipment.card.basket", "Basket: %1").arg(b) : ""
+    }
+
+    readonly property string puckPrepLine: {
+        var _ = TranslationManager.translationVersion
+        var labels = []
+        if (_hasPuck("wdt")) labels.push(TranslationManager.translate("equipment.dialog.puckWdt", "WDT"))
+        if (_hasPuck("shaker")) labels.push(TranslationManager.translate("equipment.dialog.puckShaker", "Shaker"))
+        if (_hasPuck("puckScreen")) labels.push(TranslationManager.translate("equipment.dialog.puckScreen", "Puck screen"))
+        if (_hasPuck("paperFilter")) labels.push(TranslationManager.translate("equipment.dialog.puckPaper", "Bottom paper filter"))
+        if (_hasPuck("rdt")) labels.push(TranslationManager.translate("equipment.dialog.puckRdt", "RDT (spritz)"))
+        return labels.length > 0
+            ? TranslationManager.translate("equipment.card.puckPrep", "Prep: %1").arg(labels.join(" · ")) : ""
+    }
+
+    readonly property string lastDialLine: {
+        var _ = TranslationManager.translationVersion
+        var parts = []
+        if (String(grindSetting).length > 0)
+            parts.push(TranslationManager.translate("equipment.card.lastGrind", "Grind %1").arg(grindSetting))
+        if (rpmCapable && rpm > 0)
+            parts.push(TranslationManager.translate("equipment.card.lastRpm", "%1 rpm").arg(rpm))
+        return parts.join(" · ")
+    }
+
+    // Lineage qualifier text — only meaningful when equipmentState is set.
+    readonly property string lineageText: {
+        var _ = TranslationManager.translationVersion
+        if (equipmentState === "older")
+            return TranslationManager.translate("shotdetail.equipmentOlder", "Older equipment — a newer version is now in use")
+        if (equipmentState === "retired")
+            return TranslationManager.translate("shotdetail.equipmentRetired", "Retired equipment — no longer in inventory")
+        return ""
+    }
+
+    readonly property string accessibleSummary: {
+        var bits = [title, grinderBurrs].filter(function(s) { return s.length > 0 })
+        if (lastDialLine.length > 0) bits.push(lastDialLine)
+        if (basketLine.length > 0) bits.push(basketLine)
+        if (puckPrepLine.length > 0) bits.push(puckPrepLine)
+        if (lineageText.length > 0) bits.push(lineageText)
+        return bits.join(", ")
+    }
+
+    // Lineage qualifier first (shot contexts): notes when this shot's package is
+    // superseded ("older") or gone ("retired"). Never baked into the name.
+    Text {
+        Layout.fillWidth: true
+        visible: summary.lineageText.length > 0
+        text: summary.lineageText
+        font: Theme.labelFont
+        color: Theme.textSecondaryColor
+        wrapMode: Text.WordWrap
+        Accessible.ignored: true
+    }
+
+    Text {
+        Layout.fillWidth: true
+        textFormat: Text.RichText
+        text: Theme.replaceEmojiWithImg(summary.title, Theme.subtitleFont.pixelSize)
+        font.family: Theme.bodyFont.family
+        font.pixelSize: Theme.subtitleFont.pixelSize
+        font.bold: true
+        color: Theme.textColor
+        elide: Text.ElideRight
+        Accessible.ignored: true
+    }
+
+    Text {
+        Layout.fillWidth: true
+        visible: summary.grinderBurrs.length > 0
+        textFormat: Text.RichText
+        text: Theme.replaceEmojiWithImg(summary.grinderBurrs, Theme.labelFont.pixelSize)
+        font: Theme.labelFont
+        color: Theme.textSecondaryColor
+        elide: Text.ElideRight
+        Accessible.ignored: true
+    }
+
+    Text {
+        Layout.fillWidth: true
+        visible: summary.lastDialLine.length > 0
+        text: summary.lastDialLine
+        font: Theme.captionFont
+        color: Theme.textColor
+        elide: Text.ElideRight
+        Accessible.ignored: true
+    }
+
+    // Basket + puck prep last: separate equipment, so keep the grinder identity
+    // (title + burrs) and its dial contiguous above them.
+    Text {
+        Layout.fillWidth: true
+        visible: summary.basketLine.length > 0
+        textFormat: Text.RichText
+        text: Theme.replaceEmojiWithImg(summary.basketLine, Theme.labelFont.pixelSize)
+        font: Theme.labelFont
+        color: Theme.textSecondaryColor
+        elide: Text.ElideRight
+        Accessible.ignored: true
+    }
+
+    Text {
+        Layout.fillWidth: true
+        visible: summary.puckPrepLine.length > 0
+        text: summary.puckPrepLine
+        font: Theme.labelFont
+        color: Theme.textSecondaryColor
+        wrapMode: Text.WordWrap
+        Accessible.ignored: true
+    }
+}

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -680,6 +680,12 @@ Page {
         nb.grinderBurrs = editGrinderBurrs
         nb.equipmentId = editEquipmentId
         nb.equipmentName = editEquipmentName
+        // Basket + puck prep are display-only but kept in sync so editShotData
+        // stays a faithful mirror after a re-point (resolved from equipmentId on
+        // the next load; copied here for the in-memory clone's consistency).
+        nb.basketBrand = editBasketBrand
+        nb.basketModel = editBasketModel
+        nb.puckPrep = editPuckPrep
         nb.grinderSetting = editGrinderSetting
         nb.rpm = editRpm
         nb.barista = editBarista
@@ -1579,14 +1585,15 @@ Page {
                 // PACKAGE now (add-equipment-packages), so it is READ-ONLY here and
                 // changed by re-pointing the shot to a different package via the
                 // picker — not edited as free text (those edits were silently
-                // discarded). The grind Setting (below) stays a per-shot dial-in.
+                // discarded).
                 // Equipment identity card (grinder + basket + puck prep), styled
                 // like the inventory EquipmentCard and sharing its EquipmentSummary
                 // renderer. The grind setting + RPM are omitted here — they are the
                 // per-shot dial-in edited in the fields just below, so echoing them
                 // read-only would only duplicate. Re-point via the Change Equipment
-                // button (the inventory card's Remove slot); all details live on the
-                // card, so there is no separate info button.
+                // button (occupying the same action-button row the inventory card
+                // uses); all details live on the card, so there is no separate info
+                // button.
                 Rectangle {
                     id: equipmentCard
                     Layout.columnSpan: 3
@@ -1635,7 +1642,7 @@ Page {
                             Accessible.ignored: true
                         }
                         AccessibleButton {
-                            height: Theme.scaled(36)
+                            Layout.preferredHeight: Theme.scaled(36)
                             _customFontSize: Theme.captionFont.pixelSize
                             leftPadding: Theme.scaled(10)
                             rightPadding: Theme.scaled(10)

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -174,6 +174,11 @@ Page {
                 editGrinderBurrs = editShotData.grinderBurrs || ""
                 editEquipmentId = editShotData.equipmentId || -1
                 editEquipmentName = editShotData.equipmentName || ""
+                // Basket + puck prep are display-only here (owned by the package,
+                // re-pointed via the picker) but shown in the equipment card.
+                editBasketBrand = editShotData.basketBrand || ""
+                editBasketModel = editShotData.basketModel || ""
+                editPuckPrep = editShotData.puckPrep || ""
                 editGrinderSetting = editShotData.grinderSetting || ""
                 editRpm = editShotData.rpm || 0
                 editBarista = editShotData.barista || ""
@@ -269,6 +274,11 @@ Page {
     property string editEquipmentName: ""  // package display name (read-only label)
     property int editEquipmentId: -1
     property int _pendingEquipmentId: -1   // package id awaiting requestPackage resolution
+    // Basket + puck prep: read-only display, resolved from the package like the
+    // grinder identity; shown in the equipment card, never edited as free text.
+    property string editBasketBrand: ""
+    property string editBasketModel: ""
+    property string editPuckPrep: ""       // canonical puck-prep flag string
     property string editGrinderSetting: ""
     property int editRpm: 0                // grinder rpm dial-in (shown when rpmCapable)
     readonly property bool editRpmCapable: Settings.dye.grinderRpmCapable(editGrinderBrand, editGrinderModel)
@@ -418,6 +428,7 @@ Page {
             grinderBrand: editGrinderBrand, grinderModel: editGrinderModel,
             grinderBurrs: editGrinderBurrs, grinderSetting: editGrinderSetting,
             equipmentId: editEquipmentId, equipmentName: editEquipmentName, rpm: editRpm,
+            basketBrand: editBasketBrand, basketModel: editBasketModel, puckPrep: editPuckPrep,
             barista: editBarista, doseWeight: editDoseWeight,
             drinkWeight: editDrinkWeight, drinkTds: editDrinkTds,
             drinkEy: editDrinkEy, enjoyment: editEnjoyment,
@@ -433,6 +444,9 @@ Page {
         editGrinderBurrs = s.grinderBurrs; editGrinderSetting = s.grinderSetting
         editEquipmentId = s.equipmentId !== undefined ? s.equipmentId : -1
         editEquipmentName = s.equipmentName !== undefined ? s.equipmentName : ""
+        editBasketBrand = s.basketBrand !== undefined ? s.basketBrand : ""
+        editBasketModel = s.basketModel !== undefined ? s.basketModel : ""
+        editPuckPrep = s.puckPrep !== undefined ? s.puckPrep : ""
         editRpm = s.rpm !== undefined ? s.rpm : 0
         editBarista = s.barista; editDoseWeight = s.doseWeight
         editDrinkWeight = s.drinkWeight; editDrinkTds = s.drinkTds
@@ -1508,9 +1522,6 @@ Page {
                         MainController.equipmentStorage.requestPackage(packageId)
                     }
                 }
-                EquipmentInfoDialog {
-                    id: shotEquipmentInfoDialog
-                }
                 Connections {
                     target: MainController.equipmentStorage
                     function onPackageReady(packageId, pkg) {
@@ -1520,6 +1531,9 @@ Page {
                         postShotReviewPage.editGrinderBrand = pkg.grinderBrand || ""
                         postShotReviewPage.editGrinderModel = pkg.grinderModel || ""
                         postShotReviewPage.editGrinderBurrs = pkg.grinderBurrs || ""
+                        postShotReviewPage.editBasketBrand = pkg.basketBrand || ""
+                        postShotReviewPage.editBasketModel = pkg.basketModel || ""
+                        postShotReviewPage.editPuckPrep = pkg.puckPrepCanonical || ""
                         postShotReviewPage.editEquipmentName =
                             (pkg.name && String(pkg.name).length > 0) ? String(pkg.name) : ""
                         postShotReviewPage.autosave("equipment", true)
@@ -1566,46 +1580,71 @@ Page {
                 // changed by re-pointing the shot to a different package via the
                 // picker — not edited as free text (those edits were silently
                 // discarded). The grind Setting (below) stays a per-shot dial-in.
-                RowLayout {
+                // Equipment identity card (grinder + basket + puck prep), styled
+                // like the inventory EquipmentCard and sharing its EquipmentSummary
+                // renderer. The grind setting + RPM are omitted here — they are the
+                // per-shot dial-in edited in the fields just below, so echoing them
+                // read-only would only duplicate. Re-point via the Change Equipment
+                // button (the inventory card's Remove slot); all details live on the
+                // card, so there is no separate info button.
+                Rectangle {
+                    id: equipmentCard
                     Layout.columnSpan: 3
                     Layout.fillWidth: true
-                    spacing: 8
+                    Layout.preferredHeight: equipmentCardColumn.implicitHeight + Theme.scaled(24)
                     readonly property bool hasEquipment: editEquipmentName.length > 0
                                                          || editGrinderBrand.length > 0 || editGrinderModel.length > 0
+                    color: Theme.surfaceColor
+                    radius: Theme.cardRadius
+                    border.width: 1
+                    border.color: Theme.borderColor
+                    Accessible.role: Accessible.Grouping
+                    Accessible.name: TranslationManager.translate("postshotreview.label.equipment", "Equipment:")
+                        + " " + (hasEquipment ? equipmentSummary.accessibleSummary
+                                              : TranslationManager.translate("postshotreview.equipmentNotSet", "Not set"))
 
-                    Tr {
-                        key: "postshotreview.label.equipment"
-                        fallback: "Equipment:"
-                        font: Theme.labelFont
-                        color: Theme.textSecondaryColor
-                        Accessible.ignored: true
-                    }
-                    Text {
-                        Layout.fillWidth: true
-                        elide: Text.ElideRight
-                        // Show the package NAME (defaults to "{brand} {model}").
-                        text: editEquipmentName.length > 0
-                              ? editEquipmentName
-                              : (parent.hasEquipment
-                                 ? [editGrinderBrand, editGrinderModel].filter(function(s){ return s && s.length > 0 }).join(" ")
-                                 : TranslationManager.translate("postshotreview.equipmentNotSet", "Not set"))
-                        font: Theme.bodyFont
-                        color: parent.hasEquipment ? Theme.textColor : Theme.textSecondaryColor
-                        Accessible.role: Accessible.StaticText
-                        Accessible.name: TranslationManager.translate("postshotreview.label.equipment", "Equipment:") + " " + text
-                    }
-                    AccessibleButton {
-                        visible: editEquipmentId > 0
-                        icon.source: "qrc:/icons/info.svg"
-                        accessibleName: TranslationManager.translate("equipment.info.button", "Equipment details")
-                        onClicked: shotEquipmentInfoDialog.openFor(editEquipmentId)
-                    }
-                    AccessibleButton {
-                        text: parent.hasEquipment
-                              ? TranslationManager.translate("postshotreview.changeEquipment", "Change Equipment")
-                              : TranslationManager.translate("postshotreview.addEquipment", "Add Equipment")
-                        accessibleName: text
-                        onClicked: shotEquipmentDialog.openPicker()
+                    ColumnLayout {
+                        id: equipmentCardColumn
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        anchors.margins: Theme.scaled(12)
+                        spacing: Theme.scaled(6)
+
+                        EquipmentSummary {
+                            id: equipmentSummary
+                            Layout.fillWidth: true
+                            visible: equipmentCard.hasEquipment
+                            grinderName: editEquipmentName || ""
+                            grinderBrand: editGrinderBrand
+                            grinderModel: editGrinderModel
+                            grinderBurrs: editGrinderBurrs
+                            basketBrand: editBasketBrand
+                            basketModel: editBasketModel
+                            puckPrepCanonical: editPuckPrep
+                        }
+                        Text {
+                            Layout.fillWidth: true
+                            visible: !equipmentCard.hasEquipment
+                            elide: Text.ElideRight
+                            text: TranslationManager.translate("postshotreview.equipmentNotSet", "Not set")
+                            font.family: Theme.bodyFont.family
+                            font.pixelSize: Theme.subtitleFont.pixelSize
+                            font.bold: true
+                            color: Theme.textSecondaryColor
+                            Accessible.ignored: true
+                        }
+                        AccessibleButton {
+                            height: Theme.scaled(36)
+                            _customFontSize: Theme.captionFont.pixelSize
+                            leftPadding: Theme.scaled(10)
+                            rightPadding: Theme.scaled(10)
+                            text: equipmentCard.hasEquipment
+                                  ? TranslationManager.translate("postshotreview.changeEquipment", "Change Equipment")
+                                  : TranslationManager.translate("postshotreview.addEquipment", "Add Equipment")
+                            accessibleName: text
+                            onClicked: shotEquipmentDialog.openPicker()
+                        }
                     }
                 }
 

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -802,20 +802,25 @@ Page {
                     }
                 }
 
-                // Grinder info card
+                // Equipment info card (grinder + basket + puck prep). Shares the
+                // EquipmentSummary renderer with the inventory card and the
+                // post-shot review page, fed from the shot's resolved fields.
                 Rectangle {
                     Layout.fillWidth: true
                     Layout.preferredWidth: 1  // Equal weight
-                    Layout.preferredHeight: grinderColumn.height + Theme.spacingLarge
+                    Layout.preferredHeight: equipmentColumn.height + Theme.spacingLarge
                     Layout.alignment: Qt.AlignTop
                     color: Theme.surfaceColor
                     radius: Theme.cardRadius
-                    visible: !!(shotData.grinderBrand || shotData.grinderModel || shotData.grinderBurrs || shotData.grinderSetting)
+                    visible: !!(shotData.grinderBrand || shotData.grinderModel || shotData.grinderBurrs
+                                || shotData.grinderSetting || shotData.basketBrand || shotData.basketModel
+                                || shotData.puckPrep || shotData.equipmentName || shotData.rpm > 0)
                     Accessible.role: Accessible.Grouping
-                    Accessible.name: TranslationManager.translate("shotdetail.grinder", "Grinder")
+                    Accessible.name: TranslationManager.translate("shotdetail.equipment", "Equipment")
+                                     + ": " + equipmentSummary.accessibleSummary
 
                     ColumnLayout {
-                        id: grinderColumn
+                        id: equipmentColumn
                         anchors.left: parent.left
                         anchors.right: parent.right
                         anchors.top: parent.top
@@ -823,51 +828,27 @@ Page {
                         spacing: Theme.spacingSmall
 
                         Tr {
-                            key: "shotdetail.grinder"
-                            fallback: "Grinder"
+                            key: "shotdetail.equipment"
+                            fallback: "Equipment"
                             font: Theme.subtitleFont
                             color: Theme.textColor
                             Accessible.ignored: true
                         }
 
-                        // Equipment lineage qualifier (add-equipment-packages
-                        // 4b.7): when this shot's package is no longer the current
-                        // one, note whether it was superseded by a newer version
-                        // ("older") or retired from inventory. Never baked into
-                        // the grinder name — rendered from the resolved state.
-                        Text {
-                            visible: shotData.equipmentState === "older" || shotData.equipmentState === "retired"
-                            text: shotData.equipmentState === "older"
-                                ? TranslationManager.translate("shotdetail.equipmentOlder", "Older equipment — a newer version is now in use")
-                                : TranslationManager.translate("shotdetail.equipmentRetired", "Retired equipment — no longer in inventory")
-                            font: Theme.labelFont
-                            color: Theme.textSecondaryColor
-                            wrapMode: Text.WordWrap
+                        EquipmentSummary {
+                            id: equipmentSummary
                             Layout.fillWidth: true
-                            Accessible.role: Accessible.StaticText
-                            Accessible.name: text
-                        }
-
-                        GridLayout {
-                            columns: 2
-                            columnSpacing: Theme.spacingLarge
-                            rowSpacing: Theme.spacingSmall
-                            Layout.fillWidth: true
-
-                            Tr { key: "shotdetail.brand"; fallback: "Brand:"; font: Theme.labelFont; color: Theme.textSecondaryColor; visible: !!(shotData.grinderBrand); Accessible.ignored: true }
-                            Text { textFormat: Text.RichText; text: Theme.replaceEmojiWithImg(shotData.grinderBrand || "", Theme.labelFont.pixelSize); font: Theme.labelFont; color: Theme.textColor; visible: !!(shotData.grinderBrand); Layout.fillWidth: true; elide: Text.ElideRight; Accessible.ignored: true }
-
-                            Tr { key: "shotdetail.model"; fallback: "Model:"; font: Theme.labelFont; color: Theme.textSecondaryColor; visible: !!(shotData.grinderModel); Accessible.ignored: true }
-                            Text { textFormat: Text.RichText; text: Theme.replaceEmojiWithImg(shotData.grinderModel || "", Theme.labelFont.pixelSize); font: Theme.labelFont; color: Theme.textColor; visible: !!(shotData.grinderModel); Layout.fillWidth: true; elide: Text.ElideRight; Accessible.ignored: true }
-
-                            Tr { key: "shotdetail.burrs"; fallback: "Burrs:"; font: Theme.labelFont; color: Theme.textSecondaryColor; visible: !!(shotData.grinderBurrs); Accessible.ignored: true }
-                            Text { textFormat: Text.RichText; text: Theme.replaceEmojiWithImg(shotData.grinderBurrs || "", Theme.labelFont.pixelSize); font: Theme.labelFont; color: Theme.textColor; visible: !!(shotData.grinderBurrs); Layout.fillWidth: true; elide: Text.ElideRight; Accessible.ignored: true }
-
-                            Tr { key: "shotdetail.grindSetting"; fallback: "Grind setting:"; font: Theme.labelFont; color: Theme.textSecondaryColor; visible: !!(shotData.grinderSetting); Accessible.ignored: true }
-                            Text { textFormat: Text.RichText; text: Theme.replaceEmojiWithImg(shotData.grinderSetting || "", Theme.labelFont.pixelSize); font: Theme.labelFont; color: Theme.textColor; visible: !!(shotData.grinderSetting); Layout.fillWidth: true; elide: Text.ElideRight; Accessible.ignored: true }
-
-                            Tr { key: "shotdetail.rpm"; fallback: "RPM:"; font: Theme.labelFont; color: Theme.textSecondaryColor; visible: shotData.rpm > 0; Accessible.ignored: true }
-                            Text { text: shotData.rpm > 0 ? String(shotData.rpm) : ""; font: Theme.labelFont; color: Theme.textColor; visible: shotData.rpm > 0; Layout.fillWidth: true; elide: Text.ElideRight; Accessible.role: Accessible.StaticText; Accessible.name: TranslationManager.translate("shotdetail.rpm", "RPM:") + " " + text }
+                            grinderName: shotData.equipmentName || ""
+                            grinderBrand: shotData.grinderBrand || ""
+                            grinderModel: shotData.grinderModel || ""
+                            grinderBurrs: shotData.grinderBurrs || ""
+                            grindSetting: shotData.grinderSetting || ""
+                            rpm: shotData.rpm || 0
+                            rpmCapable: shotData.rpm > 0
+                            basketBrand: shotData.basketBrand || ""
+                            basketModel: shotData.basketModel || ""
+                            puckPrepCanonical: shotData.puckPrep || ""
+                            equipmentState: shotData.equipmentState || ""
                         }
                     }
                 }


### PR DESCRIPTION
## Why

The **Shot Detail** window only showed the **grinder** (brand/model/burrs/grind/RPM), and the **Post-Shot Review** page showed only the equipment package **name** as plain text — even though a shot now belongs to a full equipment package that also carries a **basket** and **puck-prep** techniques (#1341/#1345/#1346). The same "render an equipment package" logic was also duplicated between `EquipmentCard` and the grinder box.

## What

Extract the presentational core into a new read-only **`EquipmentSummary.qml`** — the single source of truth for how a package's identity renders (grinder title, burrs, last-dial line, basket line, puck-prep line, the older/retired lineage qualifier, and `accessibleSummary`). It takes **normalized scalars** and reads puck prep from the **canonical flag string**, so a package (`puckPrepCanonical`) and a shot (`puckPrep`) feed one code path.

- **`EquipmentCard.qml`** now wraps `EquipmentSummary`, keeping its inventory chrome (selected border, Edit/Remove/Delete, tap-to-switch, delete-refused toast). ~50 lines of duplicated line-builders removed.
- **`ShotDetailPage.qml`** — the "Grinder" box becomes a full "Equipment" card (grinder + basket + puck prep), fed from the shot's resolved fields; visibility broadened so basket/puck-only shots still show it.
- **`PostShotReviewPage.qml`** — the bare package name is replaced by a bordered card matching the inventory card, with "Change/Add Equipment" in the bottom (Remove) slot. The per-shot grind/RPM dial line is **omitted** (those are edited in the fields just below), and the now-redundant info button + its `EquipmentInfoDialog` instance are dropped. Added display-only `editBasketBrand/Model` + `editPuckPrep`, wired through load, the re-point handler, and capture/restore so a live equipment swap updates the card.

No C++ changes — the data was already on the `ShotProjection` gadget and the package map.

Out of scope: `EquipmentInfoDialog.qml` keeps its deliberately different modal label/value table (noted as a follow-up).

## Testing

- Qt Creator build clean (0 errors / 0 warnings); `qmlcachegen` compiles all three QML files.
- Verified in the running app: Shot Review now shows the full equipment card (Niche Zero · 63mm Mazzer Kony conical · Basket: Decent 18g Ridged · Prep: Shaker · Puck screen · RDT). Inventory card unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)