### PR TITLE
Polish StableWeightCapture ding + comments (follow-up to #1349)

### DIFF
--- a/qml/components/StableWeightCapture.qml
+++ b/qml/components/StableWeightCapture.qml
@@ -8,9 +8,10 @@ import QtQuick
 // the load is removed (drops below `removeThreshold`) or changes materially from
 // the captured value (so topping up milk / re-dosing beans re-captures).
 //
-// Detection is driven by `weight` changes; a slow poll Timer additionally
-// re-checks elapsed stability time so a scale that streams a perfectly constant
-// value still captures. The poll is genuinely periodic, not a guard timer.
+// Detection is driven by `weight` changes; a 150 ms poll Timer additionally
+// re-runs the check while arming, so a scale that streams a perfectly constant
+// (non-jittering) value still reaches `stableMs` and graduates. The poll stops
+// once captured.
 Item {
     id: root
 

--- a/src/core/accessibilitymanager.cpp
+++ b/src/core/accessibilitymanager.cpp
@@ -248,8 +248,8 @@ void AccessibilityManager::initDingSound()
 {
     if (m_dingSound)
         return;  // already loaded
-    // Weight-capture confirmation ding — full volume, independent of the tick /
-    // accessibility volume since it is a general UI cue.
+    // Weight-capture confirmation ding — near-full volume (0.9), independent of
+    // the tick / accessibility volume since it is a general UI cue.
     m_dingSound = new QSoundEffect(this);
     m_dingSound->setSource(QUrl("qrc:/sounds/ding.wav"));
     m_dingSound->setVolume(0.9);
@@ -259,7 +259,10 @@ void AccessibilityManager::playCaptureDing()
 {
     if (m_shuttingDown) return;
     initDingSound();  // no-op after the first call / startup pre-load
-    if (m_dingSound)
+    // Gate on Ready like playTick() — playing during the async load window (or on
+    // a failed load) is a silent no-op, so don't bother. The startup pre-load
+    // means this is almost always Ready by the first capture.
+    if (m_dingSound && m_dingSound->status() == QSoundEffect::Ready)
         m_dingSound->play();
 }
 


### PR DESCRIPTION
Small follow-up to the merged #1349 foundation, applying the trivial, unambiguous items from that review. **No behavior change for anyone** — the capture/ding path still has no callers, and the one runtime change (`playCaptureDing` guard) sits in a function nothing invokes yet.

## Changes
- **`playCaptureDing()` — gate on `QSoundEffect::Ready`.** Matches the existing `playTick()` pattern. Playing during the async load window (or after a failed load) is a silent no-op anyway, so this makes it a deliberate skip rather than an unexplained one.
- **`initDingSound()` comment fix.** Said "full volume" but the code sets `setVolume(0.9)` → reworded to "near-full volume (0.9)".
- **`StableWeightCapture.qml` poll-Timer comment.** Reworded to describe the mechanism (the 150 ms poll re-runs the check while arming so a perfectly constant, non-jittering stream still reaches `stableMs`; it stops once captured) instead of asserting "not a guard timer."

## Deliberately *not* changed
The `minWeight: 20` / `rearmDelta: 6` defaults. Those are product-tuning calls (e.g. `rearmDelta` controls whether a small in-place bean top-up re-captures), flagged for the original author as inline questions on #1349 rather than patched here. `minWeight`'s default doesn't even affect the #1350 callers, which override it to 5.

## Verification
Builds clean in Qt Creator (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)