### PR TITLE
Bean auto-capture: virtual-zero dose weighing (reworks #1350)

### DIFF
--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Effects
 import Decenza
 
 Dialog {
@@ -99,10 +100,9 @@ Dialog {
     // stays armed across this dialog opening/closing, so a cup already weighed on
     // the home screen is NOT re-captured (no second ding) when you open settings.
     // The capture writes the canonical dyeBeanWeight; this watcher reflects it into
-    // the editable dose whenever a capture lands while THIS dialog is open. (There
-    // are several BrewDialog instances — idle, ShotPlan tile, ScaleWeight tile — so
-    // each one self-updates rather than the capture targeting a specific instance.)
-    // The manual "Get from scale" button below covers the no-dose-cup case.
+    // the editable dose whenever a capture lands while the dialog is open (rather
+    // than the capture poking doseValue directly). The manual "Get from scale"
+    // button below covers the no-dose-cup case.
     Connections {
         target: Settings.dye
         enabled: root.visible
@@ -551,6 +551,39 @@ Dialog {
                     enabled: MachineState.scaleWeight - root.scaleVirtualZero > 0
                     onClicked: Settings.brew.doseCupTareWeight = MachineState.scaleWeight - root.scaleVirtualZero
                 }
+
+                // Bell toggle: enable/disable the confirmation ding on auto-capture.
+                Item {
+                    Layout.preferredWidth: Theme.scaled(36)
+                    Layout.preferredHeight: Theme.scaled(36)
+                    Layout.alignment: Qt.AlignVCenter
+
+                    Image {
+                        id: dingBell
+                        anchors.centerIn: parent
+                        source: Settings.brew.doseCaptureSoundEnabled ? "qrc:/icons/bell.svg" : "qrc:/icons/bell-off.svg"
+                        height: Theme.scaled(20)
+                        sourceSize.height: Theme.scaled(40)
+                        fillMode: Image.PreserveAspectFit
+                        layer.enabled: true
+                        layer.smooth: true
+                        layer.effect: MultiEffect {
+                            colorization: 1.0
+                            colorizationColor: Settings.brew.doseCaptureSoundEnabled ? Theme.primaryColor : Theme.textSecondaryColor
+                        }
+                        Accessible.ignored: true
+                    }
+
+                    AccessibleMouseArea {
+                        anchors.fill: parent
+                        accessibleRole: Accessible.CheckBox
+                        accessibleChecked: Settings.brew.doseCaptureSoundEnabled
+                        accessibleName: Settings.brew.doseCaptureSoundEnabled
+                            ? TranslationManager.translate("brewDialog.captureSoundOn", "Capture sound on")
+                            : TranslationManager.translate("brewDialog.captureSoundOff", "Capture sound off")
+                        onAccessibleClicked: Settings.brew.doseCaptureSoundEnabled = !Settings.brew.doseCaptureSoundEnabled
+                    }
+                }
             }
 
             // Ratio input
@@ -777,7 +810,9 @@ Dialog {
                     root.temperatureValue = root.profileTemperature
                     root.profileTargetWeight = ProfileManager.profileTargetWeight
 
-                    // Use the active bag's dose if available, otherwise default 18g
+                    // Reset the dose to the active bag's dose (the bean's remembered
+                    // weight), otherwise default 18 g. (Working-vs-bag dose separation
+                    // is a follow-up change.)
                     root.doseValue = Settings.dye.dyeBeanWeight > 0 ? Settings.dye.dyeBeanWeight : 18.0
                     root.selectedProfileTitle = ProfileManager.currentProfileName
                     root.grindSetting = Settings.dye.dyeGrinderSetting

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -90,6 +90,35 @@ Dialog {
     property bool showScaleWarning: false
     property bool lowDoseWarning: doseValue < 3 || showScaleWarning
 
+    // Bean auto-capture: when the dose cup (with beans) rests stable on the scale,
+    // lock the net dose, ding, and show a confirmation. Same net-dose math as the
+    // "Get from scale" button; re-arms when the cup is removed / the load changes.
+    property bool beanCaptureVisible: false
+    property string beanCaptureText: ""
+    Timer { id: beanCaptureTimer; interval: 3500; onTriggered: root.beanCaptureVisible = false }
+    StableWeightCapture {
+        id: beanCapture
+        weight: ScaleDevice.connected ? Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) : 0
+        active: root.visible && ScaleDevice.connected && !ScaleDevice.isFlowScale
+        minWeight: 5
+        maxWeight: 45
+        tolerance: 0.5
+        stableMs: 2500
+        onStableCaptured: function(net) {
+            root.showScaleWarning = false
+            root.targetManuallySet = false
+            root.doseValue = net
+            root.beanCaptureText = TranslationManager.translate("brewDialog.doseCaptured", "Dose set: %1g").arg(net.toFixed(1))
+            root.beanCaptureVisible = true
+            beanCaptureTimer.restart()
+            if (typeof AccessibilityManager !== "undefined") {
+                AccessibilityManager.playCaptureDing()
+                if (AccessibilityManager.enabled)
+                    AccessibilityManager.announce(root.beanCaptureText)
+            }
+        }
+    }
+
     // Recalculate target when dose or ratio changes (unless manually overridden)
     onDoseValueChanged: {
         if (!targetManuallySet) {
@@ -334,6 +363,29 @@ Dialog {
                 }
             }
 
+            // Dose-captured confirmation (auto-dismiss after a few seconds)
+            Rectangle {
+                Layout.fillWidth: true
+                visible: root.beanCaptureVisible
+                color: Theme.surfaceColor
+                border.width: 1
+                border.color: Theme.primaryColor
+                radius: Theme.scaled(8)
+                implicitHeight: beanCaptureLabel.implicitHeight + Theme.scaled(24)
+                Text {
+                    id: beanCaptureLabel
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.margins: Theme.scaled(12)
+                    text: root.beanCaptureText
+                    font: Theme.bodyFont
+                    color: Theme.primaryColor
+                    horizontalAlignment: Text.AlignHCenter
+                    Accessible.ignored: true
+                }
+            }
+
             // Temperature input
             ColumnLayout {
                 Layout.fillWidth: true
@@ -450,11 +502,12 @@ Dialog {
                     accessibleName: TranslationManager.translate("brewDialog.getDoseFromScale", "Get dose from scale")
                     primary: true
                     onClicked: {
-                        var scaleWeight = MachineState.scaleWeight
-                        if (scaleWeight >= 3) {
+                        // Net beans = scale reading minus the stored dosing-cup tare (0 if unset)
+                        var net = MachineState.scaleWeight - Settings.brew.doseCupTareWeight
+                        if (net >= 3) {
                             root.showScaleWarning = false
                             root.targetManuallySet = false  // Reset manual flag
-                            root.doseValue = scaleWeight
+                            root.doseValue = net
                         } else {
                             // Show warning but don't change dose
                             root.showScaleWarning = true
@@ -475,6 +528,52 @@ Dialog {
                 Layout.leftMargin: Theme.scaled(75) + Theme.scaled(8)
                 Accessible.role: Accessible.StaticText
                 Accessible.name: TranslationManager.translate("brewDialog.profileRecommendedDose", "Profile recommended dose: %1 grams").arg(ProfileManager.profileRecommendedDose.toFixed(1))
+            }
+
+            // Dose cup section: shows the stored empty-cup weight and lets you
+            // adjust it (type or +/-) or re-weigh it. Subtracted from "Get from
+            // scale" so the dose is net beans. Set once; no per-shot taring.
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.scaled(8)
+
+                Text {
+                    text: TranslationManager.translate("brewDialog.cupTareLabel", "Dose cup:")
+                    font: Theme.bodyFont
+                    color: Theme.textSecondaryColor
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredWidth: Theme.scaled(75)
+                    Accessible.ignored: true
+                }
+
+                ValueInput {
+                    id: cupTareInput
+                    Layout.fillWidth: true
+                    value: Settings.brew.doseCupTareWeight
+                    from: 0
+                    to: 100
+                    stepSize: 0.1
+                    decimals: 1
+                    suffix: "g"
+                    valueColor: Theme.weightColor
+                    accentColor: Theme.weightColor
+                    accessibleName: TranslationManager.translate("brewDialog.doseCupWeight", "Dose cup weight")
+                    onValueModified: function(newValue) {
+                        Settings.brew.doseCupTareWeight = newValue
+                    }
+                }
+
+                AccessibleButton {
+                    Layout.preferredHeight: Theme.scaled(44)
+                    text: TranslationManager.translate("brewDialog.weighCup", "Weigh")
+                    accessibleName: TranslationManager.translate("brewDialog.weighEmptyCup", "Weigh empty cup from scale")
+                    primary: true
+                    onClicked: {
+                        var w = MachineState.scaleWeight
+                        if (w > 0)
+                            Settings.brew.doseCupTareWeight = w
+                    }
+                }
             }
 
             // Ratio input

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -21,6 +21,11 @@ Dialog {
     property double temperatureValue: ProfileManager.profileTargetTemperature
     property double profileTemperature: ProfileManager.profileTargetTemperature
 
+    // Empty-scale virtual zero, fed from IdlePage's bean capture. Lets "Weigh" store
+    // the cup as a delta (reading - virtualZero) so a non-zeroed scale doesn't bake an
+    // offset into the saved cup weight.
+    property real scaleVirtualZero: 0
+
     // Dose value (editable, default 18g)
     property double doseValue: 18.0
     property double ratio: Settings.brew.lastUsedRatio
@@ -90,31 +95,21 @@ Dialog {
     property bool showScaleWarning: false
     property bool lowDoseWarning: doseValue < 3 || showScaleWarning
 
-    // Bean auto-capture: when the dose cup (with beans) rests stable on the scale,
-    // lock the net dose, ding, and show a confirmation. Same net-dose math as the
-    // "Get from scale" button; re-arms when the cup is removed / the load changes.
-    property bool beanCaptureVisible: false
-    property string beanCaptureText: ""
-    Timer { id: beanCaptureTimer; interval: 3500; onTriggered: root.beanCaptureVisible = false }
-    StableWeightCapture {
-        id: beanCapture
-        weight: ScaleDevice.connected ? Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) : 0
-        active: root.visible && ScaleDevice.connected && !ScaleDevice.isFlowScale
-        minWeight: 5
-        maxWeight: 45
-        tolerance: 0.5
-        stableMs: 2500
-        onStableCaptured: function(net) {
-            root.showScaleWarning = false
-            root.targetManuallySet = false
-            root.doseValue = net
-            root.beanCaptureText = TranslationManager.translate("brewDialog.doseCaptured", "Dose set: %1g").arg(net.toFixed(1))
-            root.beanCaptureVisible = true
-            beanCaptureTimer.restart()
-            if (typeof AccessibilityManager !== "undefined") {
-                AccessibilityManager.playCaptureDing()
-                if (AccessibilityManager.enabled)
-                    AccessibilityManager.announce(root.beanCaptureText)
+    // Bean auto-capture lives in IdlePage as a single, persistent detector — it
+    // stays armed across this dialog opening/closing, so a cup already weighed on
+    // the home screen is NOT re-captured (no second ding) when you open settings.
+    // The capture writes the canonical dyeBeanWeight; this watcher reflects it into
+    // the editable dose whenever a capture lands while THIS dialog is open. (There
+    // are several BrewDialog instances — idle, ShotPlan tile, ScaleWeight tile — so
+    // each one self-updates rather than the capture targeting a specific instance.)
+    // The manual "Get from scale" button below covers the no-dose-cup case.
+    Connections {
+        target: Settings.dye
+        enabled: root.visible
+        function onDyeBeanWeightChanged() {
+            if (root.visible && Settings.dye.dyeBeanWeight > 0) {
+                root.targetManuallySet = false
+                root.doseValue = Settings.dye.dyeBeanWeight
             }
         }
     }
@@ -363,29 +358,6 @@ Dialog {
                 }
             }
 
-            // Dose-captured confirmation (auto-dismiss after a few seconds)
-            Rectangle {
-                Layout.fillWidth: true
-                visible: root.beanCaptureVisible
-                color: Theme.surfaceColor
-                border.width: 1
-                border.color: Theme.primaryColor
-                radius: Theme.scaled(8)
-                implicitHeight: beanCaptureLabel.implicitHeight + Theme.scaled(24)
-                Text {
-                    id: beanCaptureLabel
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.margins: Theme.scaled(12)
-                    text: root.beanCaptureText
-                    font: Theme.bodyFont
-                    color: Theme.primaryColor
-                    horizontalAlignment: Text.AlignHCenter
-                    Accessible.ignored: true
-                }
-            }
-
             // Temperature input
             ColumnLayout {
                 Layout.fillWidth: true
@@ -498,12 +470,17 @@ Dialog {
 
                 AccessibleButton {
                     Layout.preferredHeight: Theme.scaled(44)
+                    // With a dose cup saved, beans auto-capture when stable, so the
+                    // manual grab is redundant — hide it. With no cup (tare 0) auto-
+                    // capture is off, so this is the only way to pull dose from scale.
+                    visible: Settings.brew.doseCupTareWeight <= 0
                     text: TranslationManager.translate("brewDialog.getFromScale", "Get from scale")
                     accessibleName: TranslationManager.translate("brewDialog.getDoseFromScale", "Get dose from scale")
                     primary: true
                     onClicked: {
-                        // Net beans = scale reading minus the stored dosing-cup tare (0 if unset)
-                        var net = MachineState.scaleWeight - Settings.brew.doseCupTareWeight
+                        // Net beans = reading minus the empty-scale virtual zero and the
+                        // stored cup tare (0 here, since this button only shows with no cup).
+                        var net = MachineState.scaleWeight - root.scaleVirtualZero - Settings.brew.doseCupTareWeight
                         if (net >= 3) {
                             root.showScaleWarning = false
                             root.targetManuallySet = false  // Reset manual flag
@@ -568,11 +545,11 @@ Dialog {
                     text: TranslationManager.translate("brewDialog.weighCup", "Weigh")
                     accessibleName: TranslationManager.translate("brewDialog.weighEmptyCup", "Weigh empty cup from scale")
                     primary: true
-                    onClicked: {
-                        var w = MachineState.scaleWeight
-                        if (w > 0)
-                            Settings.brew.doseCupTareWeight = w
-                    }
+                    // Store the cup as a delta from the empty-scale virtual zero, so a
+                    // non-zeroed scale doesn't inflate the saved weight. Disabled (dimmed)
+                    // until the cup is actually on the scale, so the button can't no-op.
+                    enabled: MachineState.scaleWeight - root.scaleVirtualZero > 0
+                    onClicked: Settings.brew.doseCupTareWeight = MachineState.scaleWeight - root.scaleVirtualZero
                 }
             }
 

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -508,8 +508,10 @@ Dialog {
             }
 
             // Dose cup section: shows the stored empty-cup weight and lets you
-            // adjust it (type or +/-) or re-weigh it. Subtracted from "Get from
-            // scale" so the dose is net beans. Set once; no per-shot taring.
+            // adjust it (type or +/-) or re-weigh it. With a cup saved, its weight is
+            // subtracted by the auto-capture detector (net = load − virtualZero −
+            // cupTare); "Get from scale" only appears when no cup is saved. Set once;
+            // no per-shot taring.
             RowLayout {
                 Layout.fillWidth: true
                 spacing: Theme.scaled(8)

--- a/qml/components/StableWeightCapture.qml
+++ b/qml/components/StableWeightCapture.qml
@@ -74,7 +74,9 @@ Item {
 
         if (!_seeded) {
             // Establish the first virtual zero only from a STABLE reading, so a
-            // transient or an already-loaded scale at startup can't become the zero.
+            // transient (jittering) reading can't become the zero. A load left on the
+            // scale at startup can still be adopted as the baseline; taring the scale
+            // (which calls reset()) re-establishes it from the true empty reading.
             if (_settled(now, baselineMs)) {
                 _virtualZero = rawWeight
                 _seeded = true

--- a/qml/components/StableWeightCapture.qml
+++ b/qml/components/StableWeightCapture.qml
@@ -1,77 +1,107 @@
 import QtQuick
 
-// Event-driven stable-weight detector for auto-capturing a scale reading.
+// Delta-based stable-weight capture with an auto-tracked "virtual zero".
 //
-// The parent binds `weight` to a net value (e.g. scaleWeight - tare). When that
-// value holds within `tolerance` of a candidate for `stableMs`, this emits
-// stableCaptured(grams) exactly once and latches. It re-arms automatically when
-// the load is removed (drops below `removeThreshold`) or changes materially from
-// the captured value (so topping up milk / re-dosing beans re-captures).
+// Instead of trusting the scale's absolute zero, it watches the *empty* scale,
+// adopts its settled reading as a virtual zero (any value, including negative),
+// and then measures a placed load relative to that. The net dose is
+// (load - virtualZero) - cupWeight, so it is robust to an un-zeroed or drifting
+// scale at dose time. Capture only emits once a cup weight is saved
+// (cupWeight > 0); the virtual zero keeps tracking even before then so a "weigh
+// the cup" action can subtract the same baseline.
 //
-// Detection is driven by `weight` changes; a 150 ms poll Timer additionally
-// re-runs the check while arming, so a scale that streams a perfectly constant
-// (non-jittering) value still reaches `stableMs` and graduates. The poll stops
-// once captured.
+// Detection is driven by `rawWeight` changes; a 150 ms poll re-runs the check
+// while armed so a perfectly constant (non-jittering) stream still graduates.
 Item {
     id: root
 
     // --- Inputs (parent may override) ---
-    property real weight: 0           // net weight to watch
-    property bool active: true        // only detect while true
-    property real minWeight: 20       // ignore readings below this (noise / empty)
-    property real maxWeight: 100000   // ignore readings above this (e.g. wrong vessel)
-    property real tolerance: 1.0      // ± grams treated as "the same reading"
-    property int  stableMs: 2500      // must hold this long to count as stable
-    property real removeThreshold: 5  // below this = load removed -> re-arm
-    property real rearmDelta: 6        // change this much from captured value -> re-arm
+    property real rawWeight: 0      // absolute scale reading (NOT pre-tared; may be < 0)
+    property bool active: true      // only detect while true
+    property real cupWeight: 0      // saved empty-cup weight, subtracted from the load
+    property real minNet: 5         // ignore net doses below this (noise)
+    property real maxNet: 45        // ignore net doses above this (wrong vessel)
+    property real tolerance: 0.5    // ± grams treated as "the same reading"
+    property int  stableMs: 2500    // a loaded weight must hold this long to capture a dose
+    property int  baselineMs: 1000  // an empty scale must hold this long to (re)adopt the zero
+    property real loadThreshold: 3  // rise above the virtual zero that means "load placed"
+    property real rearmDelta: 6     // net change after capture that re-arms in place
 
     // --- Outputs ---
+    readonly property real virtualZero: _virtualZero
+    readonly property bool loadPresent: _seeded && (rawWeight - _virtualZero) >= loadThreshold
+    readonly property real netWeight: loadPresent ? (rawWeight - _virtualZero - cupWeight) : 0
     readonly property bool isCaptured: _captured
-    readonly property real capturedValue: _capturedValue
 
     signal stableCaptured(real grams)
 
-    property bool   _captured: false
-    property real   _capturedValue: 0
-    property real   _candidate: NaN
-    property double _candidateSince: 0
+    property real    _virtualZero: 0
+    property bool    _seeded: false
+    property bool    _captured: false
+    property real    _capturedNet: 0
+    property real    _cand: NaN
+    property double  _candSince: 0
 
     function reset() {
+        _seeded = false
         _captured = false
-        _capturedValue = 0
-        _candidate = NaN
+        _capturedNet = 0
+        _cand = NaN
     }
 
     onActiveChanged: if (!active) reset()
-    onWeightChanged: _evaluate()
+    onRawWeightChanged: _evaluate()
+
+    // True once rawWeight has held within tolerance for `dwell` ms; otherwise it
+    // (re)seeds the candidate run and returns false.
+    function _settled(now, dwell) {
+        if (isNaN(_cand) || Math.abs(rawWeight - _cand) > tolerance) {
+            _cand = rawWeight
+            _candSince = now
+            return false
+        }
+        return (now - _candSince) >= dwell
+    }
 
     function _evaluate() {
         if (!active)
             return
 
-        if (_captured) {
-            // Re-arm only if the load was removed or materially changed.
-            if (weight < removeThreshold || Math.abs(weight - _capturedValue) > rearmDelta)
-                reset()
-            else
-                return
-        }
-
-        if (weight < minWeight || weight > maxWeight) {
-            _candidate = NaN
-            return
-        }
-
         var now = Date.now()
-        if (isNaN(_candidate) || Math.abs(weight - _candidate) > tolerance) {
-            _candidate = weight
-            _candidateSince = now
+
+        if (!_seeded) {
+            // Establish the first virtual zero only from a STABLE reading, so a
+            // transient or an already-loaded scale at startup can't become the zero.
+            if (_settled(now, baselineMs)) {
+                _virtualZero = rawWeight
+                _seeded = true
+            }
             return
         }
-        if (now - _candidateSince >= stableMs) {
-            _captured = true
-            _capturedValue = weight
-            stableCaptured(weight)
+
+        var net = rawWeight - _virtualZero - cupWeight
+
+        if (_captured) {                                   // re-arm: removed OR materially changed
+            if ((rawWeight - _virtualZero) < loadThreshold
+                || Math.abs(net - _capturedNet) > rearmDelta) {
+                _captured = false
+                _cand = NaN
+            }
+            return
+        }
+
+        if ((rawWeight - _virtualZero) < loadThreshold) {  // empty: re-adopt the zero (baselineMs)
+            if (_settled(now, baselineMs))                 // so an un-zeroed/drifting baseline stays good
+                _virtualZero = rawWeight
+            return
+        }
+
+        if (_settled(now, stableMs)) {                     // load held long enough: capture net
+            if (cupWeight > 0 && net >= minNet && net <= maxNet) {
+                _captured = true
+                _capturedNet = net
+                stableCaptured(net)
+            }
         }
     }
 

--- a/qml/components/StableWeightCapture.qml
+++ b/qml/components/StableWeightCapture.qml
@@ -10,8 +10,9 @@ import QtQuick
 // (cupWeight > 0); the virtual zero keeps tracking even before then so a "weigh
 // the cup" action can subtract the same baseline.
 //
-// Detection is driven by `rawWeight` changes; a 150 ms poll re-runs the check
-// while armed so a perfectly constant (non-jittering) stream still graduates.
+// Detection is driven by `rawWeight` changes; a 150 ms poll also re-runs the check
+// while active and uncaptured, so a perfectly constant (non-jittering) stream still
+// advances through both baseline seeding and load stabilization.
 Item {
     id: root
 
@@ -43,6 +44,8 @@ Item {
     property double  _candSince: 0
 
     function reset() {
+        // _virtualZero intentionally kept: _seeded=false forces re-adoption from the
+        // next stable empty reading (gated by _seeded), so the old value is never used.
         _seeded = false
         _captured = false
         _capturedNet = 0

--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -339,12 +339,8 @@ Item {
                         BLEManager.scanForDevices()
                     break
                 case "brewSettings":
-                    var bp = root.parent
-                    while (bp) {
-                        if (bp.objectName === "idlePage") break
-                        bp = bp.parent
-                    }
-                    if (bp && bp.idleBrewDialog) bp.idleBrewDialog.open()
+                    var bwin = Window.window
+                    if (bwin && bwin.openBrewSettings) bwin.openBrewSettings()
                     break
                 case "toggleCharging":
                     if (typeof BatteryManager !== "undefined")

--- a/qml/components/layout/items/ScaleWeightItem.qml
+++ b/qml/components/layout/items/ScaleWeightItem.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Window
 import Decenza
 import "../.."
 
@@ -12,18 +13,12 @@ Item {
     property bool scaleConnected: ScaleDevice && ScaleDevice.connected
     property bool accessibilityEnabled: typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled
 
-    // Open the single shared Brew Settings dialog owned by IdlePage (it is wired
-    // with the scale's virtual zero). Walk up to the page rather than hosting a
-    // private BrewDialog per tile. No-op outside the idle page (e.g. layout editor).
+    // Open the single global Brew Settings dialog (hosted at the app root) via the
+    // window, so this works wherever the tile is placed — including the persistent
+    // status bar, which is not a descendant of IdlePage.
     function openBrewSettings() {
-        var p = root.parent
-        while (p) {
-            if (p.objectName === "idlePage") {
-                if (p.idleBrewDialog) p.idleBrewDialog.open()
-                return
-            }
-            p = p.parent
-        }
+        var win = root.Window.window
+        if (win && win.openBrewSettings) win.openBrewSettings()
     }
 
     // Scale warning: saved BLE scale not connected or connection failed, or app fell back to simulated scale

--- a/qml/components/layout/items/ScaleWeightItem.qml
+++ b/qml/components/layout/items/ScaleWeightItem.qml
@@ -12,6 +12,20 @@ Item {
     property bool scaleConnected: ScaleDevice && ScaleDevice.connected
     property bool accessibilityEnabled: typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled
 
+    // Open the single shared Brew Settings dialog owned by IdlePage (it is wired
+    // with the scale's virtual zero). Walk up to the page rather than hosting a
+    // private BrewDialog per tile. No-op outside the idle page (e.g. layout editor).
+    function openBrewSettings() {
+        var p = root.parent
+        while (p) {
+            if (p.objectName === "idlePage") {
+                if (p.idleBrewDialog) p.idleBrewDialog.open()
+                return
+            }
+            p = p.parent
+        }
+    }
+
     // Scale warning: saved BLE scale not connected or connection failed, or app fell back to simulated scale
     // Don't warn if a USB scale is connected — it satisfies the "have a real scale" requirement (not available on iOS)
     property bool showScaleWarning: (!root.scaleConnected || root.isFlowScale)
@@ -203,7 +217,7 @@ Item {
                 if (tapCount >= 2) {
                     tapCount = 0
                     singleTapTimer.stop()
-                    scaleBrewDialog.open()
+                    root.openBrewSettings()
                 } else {
                     singleTapTimer.restart()
                 }
@@ -215,7 +229,7 @@ Item {
             interval: 600
             onTriggered: {
                 scaleMouseArea.longPressTriggered = true
-                scaleBrewDialog.open()
+                root.openBrewSettings()
             }
         }
 
@@ -303,10 +317,5 @@ Item {
                     MachineState.tareScale()
             }
         }
-    }
-
-    // Brew settings dialog (temperature, dose, grind, ratio, yield)
-    BrewDialog {
-        id: scaleBrewDialog
     }
 }

--- a/qml/components/layout/items/ShotPlanItem.qml
+++ b/qml/components/layout/items/ShotPlanItem.qml
@@ -15,6 +15,20 @@ Item {
     readonly property bool showRoastDate: modelData.shotPlanShowRoastDate === true
     readonly property bool showDoseYield: modelData.shotPlanShowDoseYield !== false
 
+    // Open the single shared Brew Settings dialog owned by IdlePage (it is wired
+    // with the scale's virtual zero). Walk up to the page rather than hosting a
+    // private BrewDialog per tile. No-op outside the idle page (e.g. layout editor).
+    function openBrewSettings() {
+        var p = root.parent
+        while (p) {
+            if (p.objectName === "idlePage") {
+                if (p.idleBrewDialog) p.idleBrewDialog.open()
+                return
+            }
+            p = p.parent
+        }
+    }
+
     implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
     implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
 
@@ -42,7 +56,7 @@ Item {
             showGrind: root.showGrind
             showRoastDate: root.showRoastDate
             showDoseYield: root.showDoseYield
-            onClicked: brewDialog.open()
+            onClicked: root.openBrewSettings()
         }
     }
 
@@ -63,11 +77,7 @@ Item {
             showGrind: root.showGrind
             showRoastDate: root.showRoastDate
             showDoseYield: root.showDoseYield
-            onClicked: brewDialog.open()
+            onClicked: root.openBrewSettings()
         }
-    }
-
-    BrewDialog {
-        id: brewDialog
     }
 }

--- a/qml/components/layout/items/ShotPlanItem.qml
+++ b/qml/components/layout/items/ShotPlanItem.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Window
 import Decenza
 import "../.."
 
@@ -15,18 +16,12 @@ Item {
     readonly property bool showRoastDate: modelData.shotPlanShowRoastDate === true
     readonly property bool showDoseYield: modelData.shotPlanShowDoseYield !== false
 
-    // Open the single shared Brew Settings dialog owned by IdlePage (it is wired
-    // with the scale's virtual zero). Walk up to the page rather than hosting a
-    // private BrewDialog per tile. No-op outside the idle page (e.g. layout editor).
+    // Open the single global Brew Settings dialog (hosted at the app root) via the
+    // window, so this works wherever the tile is placed — including the persistent
+    // status bar, which is not a descendant of IdlePage.
     function openBrewSettings() {
-        var p = root.parent
-        while (p) {
-            if (p.objectName === "idlePage") {
-                if (p.idleBrewDialog) p.idleBrewDialog.open()
-                return
-            }
-            p = p.parent
-        }
+        var win = root.Window.window
+        if (win && win.openBrewSettings) win.openBrewSettings()
     }
 
     implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -39,6 +39,19 @@ ApplicationWindow {
     // Flag to open BrewDialog when IdlePage becomes active (set by AutoFavoritesPage)
     property bool pendingBrewDialog: false
 
+    // Single, global Brew Settings dialog — reachable from anywhere via
+    // root.openBrewSettings() (home-screen content, the persistent status bar, the
+    // "Open Brew Settings" action, layout previews). Lives at the root, not inside
+    // IdlePage (a transient StackView Component), so the status-bar tiles can open
+    // it regardless of the current page. scaleVirtualZero is sourced from the live
+    // idle page's bean capture when it's the current page, else 0.
+    function openBrewSettings() { globalBrewDialog.open() }
+    BrewDialog {
+        id: globalBrewDialog
+        scaleVirtualZero: (pageStack.currentItem && pageStack.currentItem.objectName === "idlePage")
+                          ? pageStack.currentItem.scaleVirtualZero : 0
+    }
+
     // Track page to return to after steam/flush/water operations complete
     // This allows returning to postShotReviewPage instead of always going to idlePage
     property string returnToPageName: ""

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -42,14 +42,19 @@ ApplicationWindow {
     // Single, global Brew Settings dialog — reachable from anywhere via
     // root.openBrewSettings() (home-screen content, the persistent status bar, the
     // "Open Brew Settings" action, layout previews). Lives at the root, not inside
-    // IdlePage (a transient StackView Component), so the status-bar tiles can open
-    // it regardless of the current page. scaleVirtualZero is sourced from the live
-    // idle page's bean capture when it's the current page, else 0.
-    function openBrewSettings() { globalBrewDialog.open() }
+    // IdlePage (a StackView page, whose children can't be reached from the status
+    // bar outside the stack), so any host can open it regardless of the current page.
+    // scaleVirtualZero is snapshotted from the live idle page's bean capture at open
+    // time (else 0) — a fixed snapshot, not a live binding, so it can't jump to 0 if
+    // the app navigates away from Idle while the dialog is open.
+    function openBrewSettings() {
+        globalBrewDialog.scaleVirtualZero =
+            (pageStack.currentItem && pageStack.currentItem.objectName === "idlePage")
+                ? pageStack.currentItem.scaleVirtualZero : 0
+        globalBrewDialog.open()
+    }
     BrewDialog {
         id: globalBrewDialog
-        scaleVirtualZero: (pageStack.currentItem && pageStack.currentItem.objectName === "idlePage")
-                          ? pageStack.currentItem.scaleVirtualZero : 0
     }
 
     // Track page to return to after steam/flush/water operations complete

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -148,28 +148,37 @@ Page {
     // Track which function's presets are showing (used by center-zone action items)
     property string activePresetFunction: ""  // "", "steam", "espresso", "hotwater", "flush", "beans", "equipment"
 
-    // Idle bean auto-capture: when the dose cup (with beans) rests stable on the
-    // scale, set the dose + stop-at-weight (same as the "Weigh beans" button),
-    // ding, and confirm on the button text. Active on the plain home screen and
-    // in espresso/beans mode (NOT while showing steam/hot-water/flush presets,
-    // where the scale is for milk/water), and bounded to a dose-plausible weight
-    // (<= 45 g net) so a milk pitcher or water vessel never trips it.
+    // Idle bean auto-capture: tracks a virtual zero off the empty scale, then when
+    // the dose cup (with beans) rests stable it sets the dose (dyeBeanWeight) and
+    // stop-at-weight (brewYieldOverride = dose x lastUsedRatio), dings, and confirms
+    // on the readout. Net dose = (load - virtualZero) - cupWeight, so it is robust to
+    // an un-zeroed/drifting scale. The baseline tracks even with no cup saved (so the
+    // "Weigh" button can reuse it); all user-visible behaviour and the actual capture
+    // stay gated on a saved cup (doseCupTareWeight > 0). Stays armed whether or not the
+    // brew dialog is open — one persistent latch means an already-weighed cup is not
+    // re-captured on open/close. Only on home/espresso mode (NOT steam/hot-water/flush,
+    // where the scale is for milk/water).
     property bool beanCaptureShown: false
     property string beanCaptureText: ""
     Timer { id: idleBeanCaptureTimer; interval: 3500; onTriggered: idlePage.beanCaptureShown = false }
     StableWeightCapture {
         id: beanCapture
-        weight: ScaleDevice.connected ? Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) : 0
+        rawWeight: ScaleDevice.connected ? MachineState.scaleWeight : 0
+        cupWeight: Settings.brew.doseCupTareWeight
         active: ScaleDevice.connected && !ScaleDevice.isFlowScale
                 && idlePage.activePresetFunction !== "steam"
                 && idlePage.activePresetFunction !== "hotwater"
                 && idlePage.activePresetFunction !== "flush"
-        minWeight: 5
-        maxWeight: 45
+        minNet: 5
+        maxNet: 45
         tolerance: 0.5
         stableMs: 2500
         onStableCaptured: function(net) {
-            if (net < 3) return
+            // net is always >= minNet (5 g) here — no extra floor needed.
+            // Always write the canonical dose + yield. Any open BrewDialog reflects
+            // it via its own dyeBeanWeight watcher — there are several BrewDialog
+            // instances (idle, ShotPlan tile, ScaleWeight tile), so we can't push to
+            // one specific one here.
             Settings.dye.dyeBeanWeight = net
             Settings.brew.brewYieldOverride = net * Settings.brew.lastUsedRatio
             idlePage.beanCaptureText = TranslationManager.translate("idle.doseCaptured", "Dose set: %1g").arg(net.toFixed(1))
@@ -183,6 +192,13 @@ Page {
         }
     }
 
+    // When the scale is zeroed/tared, the old virtual zero is stale (it would
+    // double-count the offset that was just removed) — re-establish the baseline.
+    Connections {
+        target: MachineState
+        function onTareCompleted() { beanCapture.reset() }
+    }
+
     // Small flashing reminder shown while a cup of beans or a pitcher of milk is
     // settling on the scale (something is on the scale but the capture hasn't
     // fired yet). Disappears the instant it captures (the bell rings).
@@ -193,8 +209,14 @@ Page {
         anchors.topMargin: Theme.scaled(70)
         z: 1500
         horizontalAlignment: Text.AlignHCenter
+        // Only while a load sits in the capture window with a cup saved. Outside
+        // [minNet, maxNet] no capture will ever fire, so don't tell the user to wait
+        // for a bell that can't ring (a too-heavy cup or the wrong vessel).
         readonly property bool beansSettling: beanCapture.active && !beanCapture.isCaptured
-                                              && beanCapture.weight >= beanCapture.minWeight
+                                              && Settings.brew.doseCupTareWeight > 0
+                                              && beanCapture.loadPresent
+                                              && beanCapture.netWeight >= beanCapture.minNet
+                                              && beanCapture.netWeight <= beanCapture.maxNet
         visible: beansSettling
         text: TranslationManager.translate("scale.waitForBell", "Wait for the bell before you take it off the scale")
         color: Theme.warningColor
@@ -289,6 +311,9 @@ Page {
     // Brew dialog opened from shot plan line
     BrewDialog {
         id: idleBrewDialog
+        // Share the page's tracked empty-scale baseline so "Weigh" can store the cup
+        // as a delta (offset-free), matching how the dose is measured.
+        scaleVirtualZero: beanCapture.virtualZero
     }
 
     // ============================================================
@@ -556,13 +581,14 @@ Page {
                         }
                     }
 
-                    // Bean weight: weigh the dose from the scale (minus the stored
-                    // dose-cup tare) and apply it — sets the dose and the stop-at-weight
-                    // (dose x ratio) only; temperature and grind are left untouched. The
-                    // button shows a live preview of the net beans on the scale.
+                    // Bean weight: live net-weight readout for the auto-capture above
+                    // (net = load minus the virtual zero and the saved cup). Only shown
+                    // once a dose-cup tare is saved (doseCupTareWeight > 0); with no cup
+                    // saved the auto-capture is off, so the readout/prompt stays hidden.
                     Row {
                         anchors.horizontalCenter: parent.horizontalCenter
                         visible: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                                 && Settings.brew.doseCupTareWeight > 0
                         spacing: Theme.scaled(8)
 
                         // Small, unobtrusive live net-weight readout. Beans now
@@ -572,16 +598,15 @@ Page {
                         Text {
                             id: weighBeansText
                             horizontalAlignment: Text.AlignHCenter
-                            // True while prompting the user to place beans (nothing on
+                            // True while prompting the user to place beans (no load on
                             // the scale yet) — this state gently blinks.
                             readonly property bool showingPlacePrompt: !idlePage.beanCaptureShown
-                                && Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) < 1
+                                && !beanCapture.loadPresent
                             text: {
                                 if (idlePage.beanCaptureShown)
                                     return idlePage.beanCaptureText
-                                var net = Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight)
-                                if (net >= 1)
-                                    return net.toFixed(1) + " g " + TranslationManager.translate("idle.label.onScale", "on scale")
+                                if (beanCapture.loadPresent)
+                                    return beanCapture.netWeight.toFixed(1) + " g " + TranslationManager.translate("idle.label.onScale", "on scale")
                                 return TranslationManager.translate("idle.label.placeBeansOnScale", "Place Beans on Scale") + "\n"
                                      + TranslationManager.translate("idle.label.placeBeansHint", "(and wait for the beep before removing)")
                             }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -8,7 +8,9 @@ import "../components/layout"
 Page {
     id: idlePage
     objectName: "idlePage"
-    property alias idleBrewDialog: idleBrewDialog
+    // Exposed so the global Brew Settings dialog (main.qml) can source the live
+    // empty-scale virtual zero while this is the current page.
+    readonly property real scaleVirtualZero: beanCapture.virtualZero
     background: Rectangle { color: Theme.backgroundColor }
 
     // True when the app is allowed to start machine operations on-screen.
@@ -21,7 +23,7 @@ Page {
         root.currentPageTitle = TranslationManager.translate("idle.pageTitle", "Idle")
         if (root.pendingBrewDialog) {
             root.pendingBrewDialog = false
-            idleBrewDialog.open()
+            root.openBrewSettings()
         }
     }
 
@@ -150,8 +152,9 @@ Page {
 
     // Idle bean auto-capture: tracks a virtual zero off the empty scale, then when
     // the dose cup (with beans) rests stable it sets the dose (dyeBeanWeight) and
-    // stop-at-weight (brewYieldOverride = dose x lastUsedRatio), dings, and confirms
-    // on the readout. Net dose = (load - virtualZero) - cupWeight, so it is robust to
+    // stop-at-weight (brewYieldOverride = dose x lastUsedRatio), optionally dings
+    // (if doseCaptureSoundEnabled), and confirms on the readout. Net dose =
+    // (load - virtualZero) - cupWeight, so it is robust to
     // an un-zeroed/drifting scale. The baseline tracks even with no cup saved (so the
     // "Weigh" button can reuse it); all user-visible behaviour and the actual capture
     // stay gated on a saved cup (doseCupTareWeight > 0). Stays armed whether or not the
@@ -198,9 +201,9 @@ Page {
         function onTareCompleted() { beanCapture.reset() }
     }
 
-    // Small flashing reminder shown while a cup of beans or a pitcher of milk is
-    // settling on the scale (something is on the scale but the capture hasn't
-    // fired yet). Disappears the instant it captures (the bell rings).
+    // Small flashing reminder shown while a dose cup of beans is settling on the
+    // scale (a load is present but stable-capture hasn't fired yet). Disappears the
+    // instant capture completes; a ding plays then only if doseCaptureSoundEnabled.
     Text {
         id: waitForBellHint
         anchors.horizontalCenter: parent.horizontalCenter
@@ -305,14 +308,6 @@ Page {
         enabled: activePresetFunction !== "" &&
                  !(typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled)
         onClicked: activePresetFunction = ""
-    }
-
-    // Brew dialog opened from shot plan line
-    BrewDialog {
-        id: idleBrewDialog
-        // Share the page's tracked empty-scale baseline so "Weigh" can store the cup
-        // as a delta (offset-free), matching how the dose is measured.
-        scaleVirtualZero: beanCapture.virtualZero
     }
 
     // ============================================================

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -148,6 +148,65 @@ Page {
     // Track which function's presets are showing (used by center-zone action items)
     property string activePresetFunction: ""  // "", "steam", "espresso", "hotwater", "flush", "beans", "equipment"
 
+    // Idle bean auto-capture: when the dose cup (with beans) rests stable on the
+    // scale, set the dose + stop-at-weight (same as the "Weigh beans" button),
+    // ding, and confirm on the button text. Active on the plain home screen and
+    // in espresso/beans mode (NOT while showing steam/hot-water/flush presets,
+    // where the scale is for milk/water), and bounded to a dose-plausible weight
+    // (<= 45 g net) so a milk pitcher or water vessel never trips it.
+    property bool beanCaptureShown: false
+    property string beanCaptureText: ""
+    Timer { id: idleBeanCaptureTimer; interval: 3500; onTriggered: idlePage.beanCaptureShown = false }
+    StableWeightCapture {
+        id: beanCapture
+        weight: ScaleDevice.connected ? Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) : 0
+        active: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                && idlePage.activePresetFunction !== "steam"
+                && idlePage.activePresetFunction !== "hotwater"
+                && idlePage.activePresetFunction !== "flush"
+        minWeight: 5
+        maxWeight: 45
+        tolerance: 0.5
+        stableMs: 2500
+        onStableCaptured: function(net) {
+            if (net < 3) return
+            Settings.dye.dyeBeanWeight = net
+            Settings.brew.brewYieldOverride = net * Settings.brew.lastUsedRatio
+            idlePage.beanCaptureText = TranslationManager.translate("idle.doseCaptured", "Dose set: %1g").arg(net.toFixed(1))
+            idlePage.beanCaptureShown = true
+            idleBeanCaptureTimer.restart()
+            if (typeof AccessibilityManager !== "undefined") {
+                AccessibilityManager.playCaptureDing()
+                if (AccessibilityManager.enabled)
+                    AccessibilityManager.announce(idlePage.beanCaptureText)
+            }
+        }
+    }
+
+    // Small flashing reminder shown while a cup of beans or a pitcher of milk is
+    // settling on the scale (something is on the scale but the capture hasn't
+    // fired yet). Disappears the instant it captures (the bell rings).
+    Text {
+        id: waitForBellHint
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: Theme.scaled(70)
+        z: 1500
+        horizontalAlignment: Text.AlignHCenter
+        readonly property bool beansSettling: beanCapture.active && !beanCapture.isCaptured
+                                              && beanCapture.weight >= beanCapture.minWeight
+        visible: beansSettling
+        text: TranslationManager.translate("scale.waitForBell", "Wait for the bell before you take it off the scale")
+        color: Theme.warningColor
+        font: Theme.labelFont
+        SequentialAnimation on opacity {
+            running: waitForBellHint.visible
+            loops: Animation.Infinite
+            NumberAnimation { to: 0.25; duration: 450 }
+            NumberAnimation { to: 1.0; duration: 450 }
+        }
+    }
+
     // Auto-tare scale and announce presets when activePresetFunction changes
     onActivePresetFunctionChanged: {
         // Auto-tare when steam pills appear so the scale starts at 0
@@ -493,6 +552,49 @@ Page {
                                     profileFilename: Settings.app.currentProfile,
                                     profileName: ProfileManager.currentProfileName
                                 })
+                            }
+                        }
+                    }
+
+                    // Bean weight: weigh the dose from the scale (minus the stored
+                    // dose-cup tare) and apply it — sets the dose and the stop-at-weight
+                    // (dose x ratio) only; temperature and grind are left untouched. The
+                    // button shows a live preview of the net beans on the scale.
+                    Row {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        visible: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                        spacing: Theme.scaled(8)
+
+                        // Small, unobtrusive live net-weight readout. Beans now
+                        // auto-capture when stable, so this is a readout (not a
+                        // button) — it shows the live net beans and briefly flashes
+                        // the captured dose in the accent color.
+                        Text {
+                            id: weighBeansText
+                            horizontalAlignment: Text.AlignHCenter
+                            // True while prompting the user to place beans (nothing on
+                            // the scale yet) — this state gently blinks.
+                            readonly property bool showingPlacePrompt: !idlePage.beanCaptureShown
+                                && Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) < 1
+                            text: {
+                                if (idlePage.beanCaptureShown)
+                                    return idlePage.beanCaptureText
+                                var net = Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight)
+                                if (net >= 1)
+                                    return net.toFixed(1) + " g " + TranslationManager.translate("idle.label.onScale", "on scale")
+                                return TranslationManager.translate("idle.label.placeBeansOnScale", "Place Beans on Scale") + "\n"
+                                     + TranslationManager.translate("idle.label.placeBeansHint", "(and wait for the beep before removing)")
+                            }
+                            color: idlePage.beanCaptureShown ? Theme.primaryColor : Theme.textSecondaryColor
+                            font.pixelSize: Theme.scaled(14)
+                            Accessible.role: Accessible.StaticText
+                            Accessible.name: text
+                            onShowingPlacePromptChanged: if (!showingPlacePrompt) opacity = 1.0
+                            SequentialAnimation on opacity {
+                                running: weighBeansText.showingPlacePrompt
+                                loops: Animation.Infinite
+                                NumberAnimation { to: 0.45; duration: 800 }
+                                NumberAnimation { to: 1.0; duration: 800 }
                             }
                         }
                     }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -175,17 +175,16 @@ Page {
         stableMs: 2500
         onStableCaptured: function(net) {
             // net is always >= minNet (5 g) here — no extra floor needed.
-            // Always write the canonical dose + yield. Any open BrewDialog reflects
-            // it via its own dyeBeanWeight watcher — there are several BrewDialog
-            // instances (idle, ShotPlan tile, ScaleWeight tile), so we can't push to
-            // one specific one here.
+            // Always write the canonical dose + yield. The shared Brew Settings
+            // dialog reflects it via its dyeBeanWeight watcher while it is open.
             Settings.dye.dyeBeanWeight = net
             Settings.brew.brewYieldOverride = net * Settings.brew.lastUsedRatio
             idlePage.beanCaptureText = TranslationManager.translate("idle.doseCaptured", "Dose set: %1g").arg(net.toFixed(1))
             idlePage.beanCaptureShown = true
             idleBeanCaptureTimer.restart()
             if (typeof AccessibilityManager !== "undefined") {
-                AccessibilityManager.playCaptureDing()
+                if (Settings.brew.doseCaptureSoundEnabled)
+                    AccessibilityManager.playCaptureDing()
                 if (AccessibilityManager.enabled)
                     AccessibilityManager.announce(idlePage.beanCaptureText)
             }
@@ -611,7 +610,7 @@ Page {
                                      + TranslationManager.translate("idle.label.placeBeansHint", "(and wait for the beep before removing)")
                             }
                             color: idlePage.beanCaptureShown ? Theme.primaryColor : Theme.textSecondaryColor
-                            font.pixelSize: Theme.scaled(14)
+                            font: Theme.labelFont
                             Accessible.role: Accessible.StaticText
                             Accessible.name: text
                             onShowingPlacePromptChanged: if (!showingPlacePrompt) opacity = 1.0

--- a/resources/icons/bell-off.svg
+++ b/resources/icons/bell-off.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+  <path d="M18.63 13A17.89 17.89 0 0 1 18 8"/>
+  <path d="M6.26 6.26A5.86 5.86 0 0 0 6 8c0 7-3 9-3 9h14"/>
+  <path d="M18 8a6 6 0 0 0-9.33-5"/>
+  <line x1="1" y1="1" x2="23" y2="23"/>
+</svg>

--- a/resources/icons/bell.svg
+++ b/resources/icons/bell.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+  <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+</svg>

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -15,6 +15,8 @@
         <file>splash/splash4.png</file>
         <file>splash/splash5.png</file>
         <!-- Icons -->
+        <file>icons/bell.svg</file>
+        <file>icons/bell-off.svg</file>
         <file alias="icons/espresso.svg">icons/espresso 8mm.svg</file>
         <file>icons/steam.svg</file>
         <file>icons/water.svg</file>

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -114,6 +114,18 @@ void SettingsBrew::setLastUsedRatio(double ratio) {
     }
 }
 
+double SettingsBrew::doseCupTareWeight() const {
+    return m_settings.value("espresso/doseCupTareWeight", 0.0).toDouble();
+}
+
+void SettingsBrew::setDoseCupTareWeight(double weight) {
+    if (weight < 0) weight = 0;  // a tare is never negative
+    if (doseCupTareWeight() != weight) {
+        m_settings.setValue("espresso/doseCupTareWeight", weight);
+        emit doseCupTareWeightChanged();
+    }
+}
+
 // Steam
 
 double SettingsBrew::steamTemperature() const {

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -126,6 +126,17 @@ void SettingsBrew::setDoseCupTareWeight(double weight) {
     }
 }
 
+bool SettingsBrew::doseCaptureSoundEnabled() const {
+    return m_settings.value("espresso/doseCaptureSoundEnabled", false).toBool();
+}
+
+void SettingsBrew::setDoseCaptureSoundEnabled(bool enabled) {
+    if (doseCaptureSoundEnabled() != enabled) {
+        m_settings.setValue("espresso/doseCaptureSoundEnabled", enabled);
+        emit doseCaptureSoundEnabledChanged();
+    }
+}
+
 // Steam
 
 double SettingsBrew::steamTemperature() const {

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -16,6 +16,9 @@ class SettingsBrew : public QObject {
     Q_PROPERTY(double espressoTemperature READ espressoTemperature WRITE setEspressoTemperature NOTIFY espressoTemperatureChanged)
     Q_PROPERTY(double targetWeight READ targetWeight WRITE setTargetWeight NOTIFY targetWeightChanged)
     Q_PROPERTY(double lastUsedRatio READ lastUsedRatio WRITE setLastUsedRatio NOTIFY lastUsedRatioChanged)
+    // Dose cup tare: empty weight of the dosing vessel, subtracted from the scale
+    // reading in "Get from scale" so the dose is net beans. Default 0 = no tare.
+    Q_PROPERTY(double doseCupTareWeight READ doseCupTareWeight WRITE setDoseCupTareWeight NOTIFY doseCupTareWeightChanged)
 
     // Steam
     Q_PROPERTY(double steamTemperature READ steamTemperature WRITE setSteamTemperature NOTIFY steamTemperatureChanged)
@@ -72,6 +75,9 @@ public:
 
     double lastUsedRatio() const;
     void setLastUsedRatio(double ratio);
+
+    double doseCupTareWeight() const;
+    void setDoseCupTareWeight(double weight);
 
     // Steam
     double steamTemperature() const;
@@ -176,6 +182,7 @@ signals:
     void espressoTemperatureChanged();
     void targetWeightChanged();
     void lastUsedRatioChanged();
+    void doseCupTareWeightChanged();
     void steamTemperatureChanged();
     void steamTimeoutChanged();
     void steamFlowChanged();

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -19,6 +19,9 @@ class SettingsBrew : public QObject {
     // Dose cup tare: empty weight of the dosing vessel, subtracted from the scale
     // reading in "Get from scale" so the dose is net beans. Default 0 = no tare.
     Q_PROPERTY(double doseCupTareWeight READ doseCupTareWeight WRITE setDoseCupTareWeight NOTIFY doseCupTareWeightChanged)
+    // Whether the confirmation "ding" plays when a bean dose auto-captures. Default
+    // off — not everyone wants the sound; toggled by the bell on the Dose cup row.
+    Q_PROPERTY(bool doseCaptureSoundEnabled READ doseCaptureSoundEnabled WRITE setDoseCaptureSoundEnabled NOTIFY doseCaptureSoundEnabledChanged)
 
     // Steam
     Q_PROPERTY(double steamTemperature READ steamTemperature WRITE setSteamTemperature NOTIFY steamTemperatureChanged)
@@ -78,6 +81,9 @@ public:
 
     double doseCupTareWeight() const;
     void setDoseCupTareWeight(double weight);
+
+    bool doseCaptureSoundEnabled() const;
+    void setDoseCaptureSoundEnabled(bool enabled);
 
     // Steam
     double steamTemperature() const;
@@ -183,6 +189,7 @@ signals:
     void targetWeightChanged();
     void lastUsedRatioChanged();
     void doseCupTareWeightChanged();
+    void doseCaptureSoundEnabledChanged();
     void steamTemperatureChanged();
     void steamTimeoutChanged();
     void steamFlowChanged();

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -58,6 +58,7 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
     espresso["temperature"] = settings->brew()->espressoTemperature();
     espresso["targetWeight"] = settings->brew()->targetWeight();
     espresso["lastUsedRatio"] = settings->brew()->lastUsedRatio();
+    espresso["doseCupTareWeight"] = settings->brew()->doseCupTareWeight();
     root["espresso"] = espresso;
 
     // Steam settings
@@ -399,6 +400,7 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         if (espresso.contains("temperature")) settings->brew()->setEspressoTemperature(espresso["temperature"].toDouble());
         if (espresso.contains("targetWeight")) settings->brew()->setTargetWeight(espresso["targetWeight"].toDouble());
         if (espresso.contains("lastUsedRatio")) settings->brew()->setLastUsedRatio(espresso["lastUsedRatio"].toDouble());
+        if (espresso.contains("doseCupTareWeight")) settings->brew()->setDoseCupTareWeight(espresso["doseCupTareWeight"].toDouble());
     }
 
     // Steam settings

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -59,6 +59,7 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
     espresso["targetWeight"] = settings->brew()->targetWeight();
     espresso["lastUsedRatio"] = settings->brew()->lastUsedRatio();
     espresso["doseCupTareWeight"] = settings->brew()->doseCupTareWeight();
+    espresso["doseCaptureSoundEnabled"] = settings->brew()->doseCaptureSoundEnabled();
     root["espresso"] = espresso;
 
     // Steam settings
@@ -401,6 +402,7 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         if (espresso.contains("targetWeight")) settings->brew()->setTargetWeight(espresso["targetWeight"].toDouble());
         if (espresso.contains("lastUsedRatio")) settings->brew()->setLastUsedRatio(espresso["lastUsedRatio"].toDouble());
         if (espresso.contains("doseCupTareWeight")) settings->brew()->setDoseCupTareWeight(espresso["doseCupTareWeight"].toDouble());
+        if (espresso.contains("doseCaptureSoundEnabled")) settings->brew()->setDoseCaptureSoundEnabled(espresso["doseCaptureSoundEnabled"].toBool());
     }
 
     // Steam settings

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -58,6 +58,7 @@ private:
 
     // Saved originals — restored in cleanup() regardless of test outcome
     double m_origTargetWeight;
+    double m_origDoseCupTare;
     double m_origSteamTemp;
     QString m_origScaleAddress;
     QString m_origThemeMode;
@@ -75,6 +76,7 @@ private slots:
     void init() {
         // Save all originals before each test
         m_origTargetWeight = m_settings.brew()->targetWeight();
+        m_origDoseCupTare = m_settings.brew()->doseCupTareWeight();
         m_origSteamTemp = m_settings.brew()->steamTemperature();
         m_origScaleAddress = m_settings.scaleAddress();
         m_origThemeMode = m_settings.theme()->themeMode();
@@ -91,6 +93,7 @@ private slots:
     void cleanup() {
         // Restore all originals after each test (runs even on assertion failure)
         m_settings.brew()->setTargetWeight(m_origTargetWeight);
+        m_settings.brew()->setDoseCupTareWeight(m_origDoseCupTare);
         m_settings.brew()->setSteamTemperature(m_origSteamTemp);
         m_settings.setScaleAddress(m_origScaleAddress);
         m_settings.theme()->setThemeMode(m_origThemeMode);
@@ -111,6 +114,18 @@ private slots:
     void targetWeightRoundTrip() {
         m_settings.brew()->setTargetWeight(42.5);
         QCOMPARE(m_settings.brew()->targetWeight(), 42.5);
+    }
+
+    void doseCupTareWeightRoundTrip() {
+        m_settings.brew()->setDoseCupTareWeight(12.5);
+        QCOMPARE(m_settings.brew()->doseCupTareWeight(), 12.5);
+    }
+
+    void doseCupTareWeightClampsNegativeToZero() {
+        // Setter clamps below 0 — a negative tare would otherwise inflate the
+        // computed net dose. 0 is the "no cup / feature off" sentinel.
+        m_settings.brew()->setDoseCupTareWeight(-5.0);
+        QCOMPARE(m_settings.brew()->doseCupTareWeight(), 0.0);
     }
 
     void steamTemperatureRoundTrip() {

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -59,6 +59,7 @@ private:
     // Saved originals — restored in cleanup() regardless of test outcome
     double m_origTargetWeight;
     double m_origDoseCupTare;
+    bool m_origDoseCaptureSound;
     double m_origSteamTemp;
     QString m_origScaleAddress;
     QString m_origThemeMode;
@@ -77,6 +78,7 @@ private slots:
         // Save all originals before each test
         m_origTargetWeight = m_settings.brew()->targetWeight();
         m_origDoseCupTare = m_settings.brew()->doseCupTareWeight();
+        m_origDoseCaptureSound = m_settings.brew()->doseCaptureSoundEnabled();
         m_origSteamTemp = m_settings.brew()->steamTemperature();
         m_origScaleAddress = m_settings.scaleAddress();
         m_origThemeMode = m_settings.theme()->themeMode();
@@ -94,6 +96,7 @@ private slots:
         // Restore all originals after each test (runs even on assertion failure)
         m_settings.brew()->setTargetWeight(m_origTargetWeight);
         m_settings.brew()->setDoseCupTareWeight(m_origDoseCupTare);
+        m_settings.brew()->setDoseCaptureSoundEnabled(m_origDoseCaptureSound);
         m_settings.brew()->setSteamTemperature(m_origSteamTemp);
         m_settings.setScaleAddress(m_origScaleAddress);
         m_settings.theme()->setThemeMode(m_origThemeMode);
@@ -126,6 +129,13 @@ private slots:
         // computed net dose. 0 is the "no cup / feature off" sentinel.
         m_settings.brew()->setDoseCupTareWeight(-5.0);
         QCOMPARE(m_settings.brew()->doseCupTareWeight(), 0.0);
+    }
+
+    void doseCaptureSoundEnabledRoundTrip() {
+        m_settings.brew()->setDoseCaptureSoundEnabled(true);
+        QCOMPARE(m_settings.brew()->doseCaptureSoundEnabled(), true);
+        m_settings.brew()->setDoseCaptureSoundEnabled(false);
+        QCOMPARE(m_settings.brew()->doseCaptureSoundEnabled(), false);
     }
 
     void steamTemperatureRoundTrip() {


### PR DESCRIPTION
Reworked, hardware-validated bean auto-capture (supersedes #1350; builds on @loganross2001's original work and its foundation #1349). Rebased onto current `main` (includes #1357).

## What it does
Set your dose cup of beans on the scale; when it settles, the app sets the dose (and stop-at-weight = dose × ratio) and shows it — no buttons. Set the empty-cup weight once via **Weigh**; default 0 means the feature is off.

## Core: virtual-zero delta model
Tracks an empty-scale **virtual zero** (any value, incl. negative) and measures `net = (load − virtualZero) − cupWeight`, so an un-zeroed or drifting scale still gives the correct dose. **Validated on-device** (macOS, Half Decent Scale) down to a **−356 g** baseline — capture still produced the correct net dose. Includes stable seed, re-zero on removal/drift, and re-zero on `tareCompleted`.

## Fixes from the #1350 review
- No coherent default / wrong-dose on tare 0 → gated on a saved cup.
- Heavy cup never captures → plausibility gate on **net** beans, not gross (the 122 g Niche steel cup works).
- "Wait for the bell" forever → hint bounded to `[minNet, maxNet]`.
- Double-ding / re-capture on opening brew settings → one persistent capture, latch survives open/close.
- Dose not updating in an open brew-settings window → canonical `dyeBeanWeight` write + a watcher in BrewDialog.
- Manual button redundancy → "Get from scale" shows only when no cup saved.
- "Weigh" silent no-op / offset baked in → stores the cup as an offset-free delta, disabled until the cup is on the scale.
- Tare lost on backup/migration → `doseCupTareWeight` added to the serializer.

## Follow-on changes (from review + review testing)
- **One shared Brew Settings dialog.** The Shot Plan and Scale Weight home-screen tiles now open the single `BrewDialog` owned by IdlePage (via an `openBrewSettings()` parent-walk), instead of each hosting its own copy. Fixes the virtual-zero Weigh/Get-from-scale offset only reaching the idle instance, and deletes two duplicate dialogs.
- **Capture ding is opt-in.** New `SettingsBrew.doseCaptureSoundEnabled` (default **off**, serialized), toggled by a **bell icon** on the Dose cup row (`bell.svg`/`bell-off.svg`). The spoken accessibility announcement is unaffected.
- Readout uses `Theme.labelFont` (no hardcoded size).

## Verification
Builds clean (0 warnings). Settings tests pass (`doseCupTareWeight`, `doseCaptureSoundEnabled` round-trip + clamp). Extensively tested on the macOS build against a real scale: normal capture, negative/non-zeroed baseline, tap/jostle immunity, one-ding-per-placement across dialog open/close, live dose update in the dialog, and the shared dialog from all three entry points.

## Deferred to a follow-up
Separating the **working dose** from the **bag's remembered dose** (so an un-shot override doesn't stick to the bag — bag dose updates only on a completed shot or an explicit most-recent-shot edit). Tracked separately; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)