### PR TITLE
Ratio quick-select on the home screen + editable presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,6 +760,7 @@ set(QML_FILES
     qml/components/BeanBaseDetailsRow.qml
     qml/components/BeanSummary.qml
     qml/components/ChangeBeansDialog.qml
+    qml/components/RatioPresetDialog.qml
     qml/components/BagCard.qml
     qml/components/SwitchEquipmentDialog.qml
     qml/components/EquipmentCard.qml

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -90,6 +90,35 @@ Dialog {
     property bool showScaleWarning: false
     property bool lowDoseWarning: doseValue < 3 || showScaleWarning
 
+    // Bean auto-capture: when the dose cup (with beans) rests stable on the scale,
+    // lock the net dose, ding, and show a confirmation. Same net-dose math as the
+    // "Get from scale" button; re-arms when the cup is removed / the load changes.
+    property bool beanCaptureVisible: false
+    property string beanCaptureText: ""
+    Timer { id: beanCaptureTimer; interval: 3500; onTriggered: root.beanCaptureVisible = false }
+    StableWeightCapture {
+        id: beanCapture
+        weight: ScaleDevice.connected ? Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) : 0
+        active: root.visible && ScaleDevice.connected && !ScaleDevice.isFlowScale
+        minWeight: 5
+        maxWeight: 45
+        tolerance: 0.5
+        stableMs: 2500
+        onStableCaptured: function(net) {
+            root.showScaleWarning = false
+            root.targetManuallySet = false
+            root.doseValue = net
+            root.beanCaptureText = TranslationManager.translate("brewDialog.doseCaptured", "Dose set: %1g").arg(net.toFixed(1))
+            root.beanCaptureVisible = true
+            beanCaptureTimer.restart()
+            if (typeof AccessibilityManager !== "undefined") {
+                AccessibilityManager.playCaptureDing()
+                if (AccessibilityManager.enabled)
+                    AccessibilityManager.announce(root.beanCaptureText)
+            }
+        }
+    }
+
     // Recalculate target when dose or ratio changes (unless manually overridden)
     onDoseValueChanged: {
         if (!targetManuallySet) {
@@ -334,6 +363,29 @@ Dialog {
                 }
             }
 
+            // Dose-captured confirmation (auto-dismiss after a few seconds)
+            Rectangle {
+                Layout.fillWidth: true
+                visible: root.beanCaptureVisible
+                color: Theme.surfaceColor
+                border.width: 1
+                border.color: Theme.primaryColor
+                radius: Theme.scaled(8)
+                implicitHeight: beanCaptureLabel.implicitHeight + Theme.scaled(24)
+                Text {
+                    id: beanCaptureLabel
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.margins: Theme.scaled(12)
+                    text: root.beanCaptureText
+                    font: Theme.bodyFont
+                    color: Theme.primaryColor
+                    horizontalAlignment: Text.AlignHCenter
+                    Accessible.ignored: true
+                }
+            }
+
             // Temperature input
             ColumnLayout {
                 Layout.fillWidth: true
@@ -450,11 +502,12 @@ Dialog {
                     accessibleName: TranslationManager.translate("brewDialog.getDoseFromScale", "Get dose from scale")
                     primary: true
                     onClicked: {
-                        var scaleWeight = MachineState.scaleWeight
-                        if (scaleWeight >= 3) {
+                        // Net beans = scale reading minus the stored dosing-cup tare (0 if unset)
+                        var net = MachineState.scaleWeight - Settings.brew.doseCupTareWeight
+                        if (net >= 3) {
                             root.showScaleWarning = false
                             root.targetManuallySet = false  // Reset manual flag
-                            root.doseValue = scaleWeight
+                            root.doseValue = net
                         } else {
                             // Show warning but don't change dose
                             root.showScaleWarning = true
@@ -475,6 +528,52 @@ Dialog {
                 Layout.leftMargin: Theme.scaled(75) + Theme.scaled(8)
                 Accessible.role: Accessible.StaticText
                 Accessible.name: TranslationManager.translate("brewDialog.profileRecommendedDose", "Profile recommended dose: %1 grams").arg(ProfileManager.profileRecommendedDose.toFixed(1))
+            }
+
+            // Dose cup section: shows the stored empty-cup weight and lets you
+            // adjust it (type or +/-) or re-weigh it. Subtracted from "Get from
+            // scale" so the dose is net beans. Set once; no per-shot taring.
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.scaled(8)
+
+                Text {
+                    text: TranslationManager.translate("brewDialog.cupTareLabel", "Dose cup:")
+                    font: Theme.bodyFont
+                    color: Theme.textSecondaryColor
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredWidth: Theme.scaled(75)
+                    Accessible.ignored: true
+                }
+
+                ValueInput {
+                    id: cupTareInput
+                    Layout.fillWidth: true
+                    value: Settings.brew.doseCupTareWeight
+                    from: 0
+                    to: 100
+                    stepSize: 0.1
+                    decimals: 1
+                    suffix: "g"
+                    valueColor: Theme.weightColor
+                    accentColor: Theme.weightColor
+                    accessibleName: TranslationManager.translate("brewDialog.doseCupWeight", "Dose cup weight")
+                    onValueModified: function(newValue) {
+                        Settings.brew.doseCupTareWeight = newValue
+                    }
+                }
+
+                AccessibleButton {
+                    Layout.preferredHeight: Theme.scaled(44)
+                    text: TranslationManager.translate("brewDialog.weighCup", "Weigh")
+                    accessibleName: TranslationManager.translate("brewDialog.weighEmptyCup", "Weigh empty cup from scale")
+                    primary: true
+                    onClicked: {
+                        var w = MachineState.scaleWeight
+                        if (w > 0)
+                            Settings.brew.doseCupTareWeight = w
+                    }
+                }
             }
 
             // Ratio input

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -779,6 +779,72 @@ Dialog {
                     onTextEdited: root.grindRpm = parseInt(text) || 0
                 }
             }
+
+            // --- Home-screen ratio quick-select presets. Rarely changed, so
+            // they sit at the bottom. These three values are what the
+            // home-screen ratio button offers as Ristretto / Normale / Lungo. ---
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.scaled(12)
+                Layout.preferredHeight: 1
+                color: Theme.borderColor
+            }
+            Text {
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.scaled(4)
+                text: TranslationManager.translate("brewDialog.ratioPresetsHeader", "Home-screen ratio presets")
+                font: Theme.bodyFont
+                color: Theme.textColor
+            }
+            Text {
+                Layout.fillWidth: true
+                text: TranslationManager.translate("brewDialog.ratioPresetsHint", "The three quick-select ratios offered by the home-screen ratio button.")
+                font: Theme.captionFont
+                color: Theme.textSecondaryColor
+                wrapMode: Text.WordWrap
+            }
+            Repeater {
+                model: [
+                    { rlabel: TranslationManager.translate("ratio.ristretto.name", "Ristretto"), idx: 1 },
+                    { rlabel: TranslationManager.translate("ratio.normale.name", "Normale"), idx: 2 },
+                    { rlabel: TranslationManager.translate("ratio.lungo.name", "Lungo"), idx: 3 }
+                ]
+                delegate: RowLayout {
+                    required property var modelData
+                    Layout.fillWidth: true
+                    spacing: Theme.scaled(8)
+                    Text {
+                        text: modelData.rlabel
+                        font: Theme.bodyFont
+                        color: Theme.textSecondaryColor
+                        Layout.preferredWidth: Theme.scaled(90)
+                        Accessible.ignored: true
+                    }
+                    Text {
+                        text: "1:"
+                        font: Theme.bodyFont
+                        color: Theme.textColor
+                        Accessible.ignored: true
+                    }
+                    ValueInput {
+                        Layout.fillWidth: true
+                        from: 0.5
+                        to: 6.0
+                        stepSize: 0.1
+                        decimals: 1
+                        accentColor: Theme.primaryColor
+                        accessibleName: modelData.rlabel + " " + TranslationManager.translate("brewDialog.ratioWord", "ratio")
+                        value: modelData.idx === 1 ? Settings.brew.ratioPreset1
+                             : modelData.idx === 2 ? Settings.brew.ratioPreset2
+                             : Settings.brew.ratioPreset3
+                        onValueModified: function(newValue) {
+                            if (modelData.idx === 1) Settings.brew.ratioPreset1 = newValue
+                            else if (modelData.idx === 2) Settings.brew.ratioPreset2 = newValue
+                            else Settings.brew.ratioPreset3 = newValue
+                        }
+                    }
+                }
+            }
         }
 
         // Buttons

--- a/qml/components/RatioPresetDialog.qml
+++ b/qml/components/RatioPresetDialog.qml
@@ -1,0 +1,267 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Decenza
+
+// Quick coffee:water ratio chooser, opened from the home-screen status bar.
+// Offers the three classic styles (Ristretto 1:1, Normale 1:2, Lungo 1:3),
+// applies the pick to Settings.brew.lastUsedRatio (and recomputes the yield
+// override from the current dose so it takes effect on the next shot), and
+// includes a short "about ratios" help panel. Descriptions are original but
+// the ratio styles/learning are adapted from La Marzocco Home's article
+// "Brew Ratios Around the World" (credited in the footer).
+Dialog {
+    id: root
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+    width: Math.min(Theme.scaled(520), parent ? parent.width * 0.95 : Theme.scaled(520))
+    height: Math.min(contentCol.implicitHeight + Theme.scaled(40), parent ? parent.height * 0.92 : Theme.scaled(640))
+    modal: true
+    closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
+    padding: 0
+
+    property bool showHelp: false
+    readonly property double currentRatio: Settings.brew.lastUsedRatio
+
+    // The three classic styles. `desc` are our own words, informed by the
+    // La Marzocco article credited below.
+    readonly property var presets: [
+        { ratio: Settings.brew.ratioPreset1, key: "ratio.ristretto", name: "Ristretto",
+          desc: "Short & concentrated — syrupy and heavy-bodied with intense flavour. Cuts through milk; suits darker roasts." },
+        { ratio: Settings.brew.ratioPreset2, key: "ratio.normale", name: "Normale",
+          desc: "The modern specialty standard — balanced body and clarity with higher extraction. Flatters lighter roasts and single origins." },
+        { ratio: Settings.brew.ratioPreset3, key: "ratio.lungo", name: "Lungo",
+          desc: "Long & lighter — brighter clarity and less body, so individual tasting notes show through. Closer to filter coffee." }
+    ]
+
+    function applyRatio(r) {
+        Settings.brew.lastUsedRatio = r
+        // Keep the stop-at-weight target consistent with the new ratio when a
+        // dose is known (same math the bean auto-capture uses).
+        if (Settings.dye.dyeBeanWeight > 0)
+            Settings.brew.brewYieldOverride = Settings.dye.dyeBeanWeight * r
+        root.close()
+    }
+
+    background: Rectangle {
+        color: Theme.surfaceColor
+        radius: Theme.cardRadius
+        border.width: 1
+        border.color: Theme.borderColor
+    }
+
+    contentItem: Flickable {
+        contentWidth: width
+        contentHeight: contentCol.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+        ColumnLayout {
+            id: contentCol
+            width: parent.width
+            spacing: Theme.spacingMedium
+
+            // --- Header ---
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.spacingLarge
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                spacing: Theme.scaled(2)
+                Text {
+                    text: TranslationManager.translate("ratio.dialog.title", "Brew Ratio")
+                    color: Theme.textColor
+                    font.pixelSize: Theme.scaled(24); font.bold: true
+                }
+                Text {
+                    text: TranslationManager.translate("ratio.dialog.subtitle", "Coffee : water — tap a style to use it")
+                    color: Theme.textSecondaryColor
+                    font: Theme.labelFont
+                }
+            }
+
+            // --- Ratio style cards ---
+            Repeater {
+                model: root.presets
+                delegate: Rectangle {
+                    id: card
+                    required property var modelData
+                    readonly property bool isCurrent: Math.abs(root.currentRatio - modelData.ratio) < 0.05
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.spacingLarge
+                    Layout.rightMargin: Theme.spacingLarge
+                    Layout.preferredHeight: cardCol.implicitHeight + Theme.spacingMedium * 2
+                    radius: Theme.buttonRadius
+                    color: cardMa.pressed ? Qt.darker(Theme.backgroundColor, 1.1) : Theme.backgroundColor
+                    border.width: isCurrent ? 2 : 1
+                    border.color: isCurrent ? Theme.primaryColor : Theme.borderColor
+
+                    Accessible.role: Accessible.Button
+                    Accessible.name: TranslationManager.translate(modelData.key + ".name", modelData.name)
+                                     + " 1:" + modelData.ratio.toFixed(1)
+                                     + (isCurrent ? ", " + TranslationManager.translate("ratio.current", "current") : "")
+                    Accessible.focusable: true
+                    Accessible.onPressAction: cardMa.clicked(null)
+
+                    ColumnLayout {
+                        id: cardCol
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.leftMargin: Theme.spacingMedium
+                        anchors.rightMargin: Theme.spacingMedium
+                        spacing: Theme.scaled(2)
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: Theme.spacingSmall
+                            Text {
+                                text: TranslationManager.translate(modelData.key + ".name", modelData.name)
+                                color: Theme.textColor
+                                font.pixelSize: Theme.scaled(19); font.bold: true
+                            }
+                            Text {
+                                text: "1:" + modelData.ratio.toFixed(1)
+                                color: Theme.primaryColor
+                                font.pixelSize: Theme.scaled(19); font.bold: true
+                            }
+                            Item { Layout.fillWidth: true }
+                            Text {
+                                visible: card.isCurrent
+                                text: TranslationManager.translate("ratio.current", "current").toUpperCase()
+                                color: Theme.primaryColor
+                                font: Theme.captionFont
+                            }
+                        }
+                        Text {
+                            Layout.fillWidth: true
+                            text: TranslationManager.translate(modelData.key + ".desc", modelData.desc)
+                            color: Theme.textSecondaryColor
+                            font: Theme.captionFont
+                            wrapMode: Text.WordWrap
+                        }
+                    }
+
+                    MouseArea {
+                        id: cardMa
+                        anchors.fill: parent
+                        onClicked: root.applyRatio(modelData.ratio)
+                    }
+                }
+            }
+
+            // --- Footnote: finer control lives in Espresso Setup ---
+            Text {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                text: TranslationManager.translate("ratio.footnote", "For finer control, adjust the dose and target in Espresso Setup.")
+                color: Theme.textSecondaryColor
+                font: Theme.captionFont
+                wrapMode: Text.WordWrap
+            }
+
+            // --- "About brew ratios" toggle ---
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                Layout.preferredHeight: Theme.scaled(40)
+                radius: Theme.buttonRadius
+                color: helpMa.pressed ? Qt.darker(Theme.backgroundColor, 1.1) : "transparent"
+                border.width: 1
+                border.color: Theme.borderColor
+                Accessible.role: Accessible.Button
+                Accessible.name: TranslationManager.translate("ratio.help.button", "About brew ratios")
+                Accessible.focusable: true
+                Accessible.onPressAction: helpMa.clicked(null)
+                Text {
+                    anchors.centerIn: parent
+                    text: (root.showHelp ? "– " : "+ ") + TranslationManager.translate("ratio.help.button", "About brew ratios")
+                    color: Theme.primaryColor
+                    font: Theme.labelFont
+                }
+                MouseArea { id: helpMa; anchors.fill: parent; onClicked: root.showHelp = !root.showHelp }
+            }
+
+            // --- Help body (collapsible) ---
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                visible: root.showHelp
+                spacing: Theme.spacingSmall
+                Text {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("ratio.help.intro",
+                        "Brew ratio is the weight of coffee in vs. espresso out. A lower ratio (1:1) is shorter, thicker and more intense; a higher ratio (1:3) is longer, lighter and clearer. Dose stays the same — only the yield changes.")
+                    color: Theme.textColor
+                    font: Theme.captionFont
+                    wrapMode: Text.WordWrap
+                }
+                Text {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("ratio.help.regional",
+                        "Tastes differ by region: 1:1 ristrettos (popularised in Seattle), the traditional ~1:3 Italian shot, and the modern specialty 1:2 normale.")
+                    color: Theme.textSecondaryColor
+                    font: Theme.captionFont
+                    wrapMode: Text.WordWrap
+                }
+            }
+
+            // --- Attribution (always shown) ---
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                spacing: 0
+                Text {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("ratio.attribution",
+                        "Ratio styles adapted from “Brew Ratios Around the World,” Ben Blake & Scott Callender — La Marzocco Home (2014).")
+                    color: Theme.textSecondaryColor
+                    font: Theme.captionFont
+                    wrapMode: Text.WordWrap
+                }
+                Text {
+                    id: articleLink
+                    text: TranslationManager.translate("ratio.readArticle", "Read the full article")
+                    color: Theme.primaryColor
+                    font: Theme.captionFont
+                    Accessible.role: Accessible.Link
+                    Accessible.name: text
+                    Accessible.focusable: true
+                    Accessible.onPressAction: linkMa.clicked(null)
+                    MouseArea {
+                        id: linkMa
+                        anchors.fill: parent
+                        onClicked: Qt.openUrlExternally("https://home.lamarzoccousa.com/brew-ratios-around-world/")
+                    }
+                }
+            }
+
+            // --- Close ---
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                Layout.bottomMargin: Theme.spacingLarge
+                Layout.preferredHeight: Theme.scaled(48)
+                radius: Theme.buttonRadius
+                color: closeMa.pressed ? Qt.darker(Theme.primaryColor, 1.15) : Theme.primaryColor
+                Accessible.role: Accessible.Button
+                Accessible.name: TranslationManager.translate("common.button.close", "Close")
+                Accessible.focusable: true
+                Accessible.onPressAction: closeMa.clicked(null)
+                Text {
+                    anchors.centerIn: parent
+                    text: TranslationManager.translate("common.button.close", "Close")
+                    color: Theme.primaryContrastColor
+                    font: Theme.bodyFont
+                }
+                MouseArea { id: closeMa; anchors.fill: parent; onClicked: root.close() }
+            }
+        }
+    }
+}

--- a/qml/components/layout/LayoutCenterZone.qml
+++ b/qml/components/layout/LayoutCenterZone.qml
@@ -48,7 +48,15 @@ Item {
         }
         return false
     }
-    readonly property real scaledSpacing: Theme.scaled(10) * zoneScale
+    // Gap between center-zone widgets. Bumped from 10 -> 18 so the status
+    // readouts (temperature / water level / machine status) aren't cramped.
+    readonly property real scaledSpacing: Theme.scaled(18) * zoneScale
+
+    // Spread items across the full width (instead of clustering them centered)
+    // for the status readout row and the profile/dose row, so they sit at
+    // left / middle / right rather than bunched in the middle.
+    readonly property bool distributeItems:
+        (zoneName === "centerStatus" || zoneName === "centerMiddle") && !hasSpacer
     readonly property real availableWidth: width - Theme.scaled(20) * zoneScale -
         (buttonCount > 1 ? (buttonCount - 1) * scaledSpacing : 0)
     readonly property real buttonWidth: buttonCount > 0
@@ -67,14 +75,20 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         spacing: root.scaledSpacing
 
-        // Auto-centering spacer (hides when user has their own spacers)
-        Item { Layout.fillWidth: true; visible: !root.hasSpacer }
+        // Auto-centering spacer (hides when user has their own spacers, or when
+        // the zone distributes items across the full width)
+        Item { Layout.fillWidth: true; visible: !root.hasSpacer && !root.distributeItems }
 
         Repeater {
             model: root.items
             delegate: LayoutItemDelegate {
                 zoneName: root.zoneName
                 Layout.preferredWidth: {
+                    // Distribute mode: every item gets an equal-width cell (base 0
+                    // + equal fillWidth share), independent of its text width, so
+                    // the content centers in exact thirds/halves (e.g. water level
+                    // lands on screen-center regardless of how wide its text is).
+                    if (root.distributeItems) return 0
                     // Flip clock: interpolate between buttonWidth and wide based on clockScale
                     if (modelData.type === "screensaverFlipClock") {
                         var s = typeof modelData.clockScale === "number" ? modelData.clockScale : 1.0
@@ -94,11 +108,12 @@ Item {
                     return root.buttonWidth
                 }
                 Layout.preferredHeight: modelData.type === "spacer" ? -1 : root.buttonHeight
-                Layout.fillWidth: modelData.type === "spacer"
+                Layout.fillWidth: modelData.type === "spacer" || root.distributeItems
             }
         }
 
-        // Auto-centering spacer (hides when user has their own spacers)
-        Item { Layout.fillWidth: true; visible: !root.hasSpacer }
+        // Auto-centering spacer (hides when user has their own spacers, or when
+        // the zone distributes items across the full width)
+        Item { Layout.fillWidth: true; visible: !root.hasSpacer && !root.distributeItems }
     }
 }

--- a/qml/components/layout/items/ShotPlanItem.qml
+++ b/qml/components/layout/items/ShotPlanItem.qml
@@ -18,12 +18,15 @@ Item {
     implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
     implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
 
-    Accessible.role: Accessible.Button
+    // In full mode the Profile/Dose buttons below are individually accessible, so
+    // only expose this wrapper as a button in compact (bar) mode.
+    Accessible.role: root.isCompact ? Accessible.Button : Accessible.NoRole
     Accessible.name: {
-        var plan = compactShotPlan.text || fullShotPlan.text || ""
+        if (!root.isCompact) return ""
+        var plan = compactShotPlan.text || ""
         return plan ? "Shot plan: " + plan + ". Tap to edit" : "Shot plan"
     }
-    Accessible.focusable: true
+    Accessible.focusable: root.isCompact
 
     // --- COMPACT MODE ---
     Item {
@@ -46,25 +49,149 @@ Item {
         }
     }
 
-    // --- FULL MODE ---
+    // --- FULL MODE: two setup buttons, each centered in its half. Left opens the
+    // Espresso-Shot setup (brew/dose dialog), right opens the Milk-Steaming setup
+    // (steam page) directly — no long-press needed. White-fill, blue-text, rounded. ---
     Item {
         id: fullContent
         visible: !root.isCompact
         anchors.fill: parent
-        implicitWidth: fullShotPlan.implicitWidth
-        implicitHeight: fullShotPlan.implicitHeight
+        implicitWidth: espressoSetupBtn.implicitWidth + profileChooseBtn.implicitWidth + steamSetupBtn.implicitWidth + Theme.spacingLarge * 2
+        implicitHeight: Math.max(espressoSetupBtn.implicitHeight, profileChooseBtn.implicitHeight, steamSetupBtn.implicitHeight)
 
-        ShotPlanText {
-            id: fullShotPlan
-            anchors.centerIn: parent
-            visible: text !== ""
-            showProfile: root.showProfile
-            showRoaster: root.showRoaster
-            showGrind: root.showGrind
-            showRoastDate: root.showRoastDate
-            showDoseYield: root.showDoseYield
-            onClicked: brewDialog.open()
+        // Espresso-Shot Setup -> left third; opens the brew/dose dialog
+        Rectangle {
+            id: espressoSetupBtn
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.horizontalCenterOffset: -parent.width / 3
+            anchors.verticalCenter: parent.verticalCenter
+            implicitWidth: espressoNameTr.implicitWidth + Theme.spacingLarge * 1.5
+            implicitHeight: espressoNameTr.implicitHeight + espressoSubText.implicitHeight + Theme.spacingMedium
+            radius: Theme.buttonRadius
+            color: espressoMa.pressed ? Qt.darker(Theme.primaryContrastColor, 1.08) : Theme.primaryContrastColor
+            border.width: 1
+            border.color: Theme.primaryColor
+
+            Accessible.role: Accessible.Button
+            Accessible.name: TranslationManager.translate("idle.button.espressoSetup", "Espresso-Shot Setup")
+            Accessible.focusable: true
+            Accessible.onPressAction: espressoMa.clicked(null)
+
+            Column {
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.right: parent.right
+                spacing: 0
+                Tr {
+                    id: espressoNameTr
+                    key: "idle.button.espressoSetup"; fallback: "Espresso-Shot Setup"
+                    color: Theme.primaryColor; font: Theme.bodyFont
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                }
+                Text {
+                    id: espressoSubText
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                    text: {
+                        var d = Settings.dye.dyeBeanWeight
+                        var t = ProfileManager.targetWeight
+                        return (d > 0 && t > 0) ? d.toFixed(1) + " → " + t.toFixed(1) + " g" : ""
+                    }
+                    visible: text !== ""
+                    color: Theme.textSecondaryColor; font: Theme.labelFont
+                }
+            }
+            MouseArea { id: espressoMa; anchors.fill: parent; onClicked: brewDialog.open() }
         }
+
+        // Choose Espresso Profile -> center; opens the profile selector
+        Rectangle {
+            id: profileChooseBtn
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            implicitWidth: profileNameTr.implicitWidth + Theme.spacingLarge * 1.5
+            implicitHeight: profileNameTr.implicitHeight + profileSubText.implicitHeight + Theme.spacingMedium
+            radius: Theme.buttonRadius
+            color: profileMa.pressed ? Qt.darker(Theme.primaryContrastColor, 1.08) : Theme.primaryContrastColor
+            border.width: 1
+            border.color: Theme.primaryColor
+
+            Accessible.role: Accessible.Button
+            Accessible.name: TranslationManager.translate("idle.button.chooseProfile", "Choose Espresso Profile")
+            Accessible.focusable: true
+            Accessible.onPressAction: profileMa.clicked(null)
+
+            Column {
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.right: parent.right
+                spacing: 0
+                Tr {
+                    id: profileNameTr
+                    key: "idle.button.chooseProfile"; fallback: "Choose Espresso Profile"
+                    color: Theme.primaryColor; font: Theme.bodyFont
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                }
+                Text {
+                    id: profileSubText
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                    text: ProfileManager.currentProfileName
+                    visible: text !== ""
+                    color: Theme.textSecondaryColor; font: Theme.labelFont
+                    elide: Text.ElideRight
+                }
+            }
+            MouseArea { id: profileMa; anchors.fill: parent; onClicked: root.openProfileChooser() }
+        }
+
+        // Milk-Steaming Setup -> right third; opens the steam page (no long-press)
+        Rectangle {
+            id: steamSetupBtn
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.horizontalCenterOffset: parent.width / 3
+            anchors.verticalCenter: parent.verticalCenter
+            implicitWidth: steamNameTr.implicitWidth + Theme.spacingLarge * 1.5
+            implicitHeight: steamNameTr.implicitHeight + steamSubText.implicitHeight + Theme.spacingMedium
+            radius: Theme.buttonRadius
+            color: steamMa.pressed ? Qt.darker(Theme.primaryContrastColor, 1.08) : Theme.primaryContrastColor
+            border.width: 1
+            border.color: Theme.primaryColor
+
+            Accessible.role: Accessible.Button
+            Accessible.name: TranslationManager.translate("idle.button.steamSetup", "Milk-Steaming Setup")
+            Accessible.focusable: true
+            Accessible.onPressAction: steamMa.clicked(null)
+
+            Column {
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.right: parent.right
+                spacing: 0
+                Tr {
+                    id: steamNameTr
+                    key: "idle.button.steamSetup"; fallback: "Milk-Steaming Setup"
+                    color: Theme.primaryColor; font: Theme.bodyFont
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                }
+                Text {
+                    id: steamSubText
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                    text: Math.round(Settings.brew.steamTemperature) + "°C"
+                    color: Theme.textSecondaryColor; font: Theme.labelFont
+                }
+            }
+            MouseArea { id: steamMa; anchors.fill: parent; onClicked: root.openSteamSetup() }
+        }
+    }
+
+    // Open the steam page (same target as long-pressing a steam pitcher pill).
+    function openSteamSetup() {
+        if (typeof pageStack !== "undefined" && pageStack)
+            pageStack.push(Qt.resolvedUrl("../../../pages/SteamPage.qml"))
+    }
+    // Open the profile selector to change the espresso profile.
+    function openProfileChooser() {
+        if (typeof pageStack !== "undefined" && pageStack)
+            pageStack.push(Qt.resolvedUrl("../../../pages/ProfileSelectorPage.qml"))
     }
 
     BrewDialog {

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -361,12 +361,16 @@ Page {
     // Top info section (from layout topLeft/topRight zones)
     // ============================================================
     ColumnLayout {
+        id: topInfoSection
+        // Empty by default (the top stats live in the global status bar). Hidden
+        // when empty so its reserved bar-height doesn't push everything down.
+        visible: idlePage.topLeftItems.length > 0 || idlePage.topRightItems.length > 0
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.margins: Theme.standardMargin
-        anchors.topMargin: Theme.pageTopMargin
-        spacing: Theme.scaled(20)
+        anchors.topMargin: Theme.statusBarHeight + Theme.scaled(8)
+        spacing: 0
 
         RowLayout {
             Layout.alignment: Qt.AlignHCenter
@@ -386,25 +390,43 @@ Page {
         }
     }
 
+    // Thin high-contrast line directly beneath the global status bar — its bottom
+    // border. Pinned at the status bar's height so it sits flush under the top
+    // stats row regardless of the (often empty) topLeft/topRight zones.
+    Rectangle {
+        id: topStatsBorder
+        anchors.top: parent.top
+        anchors.topMargin: Theme.statusBarHeight
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: Theme.scaled(2)
+        color: Theme.primaryColor
+    }
+
     // ============================================================
     // Center content (from layout centerTop/centerMiddle zones)
     // ============================================================
     ColumnLayout {
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: Theme.scaled(50)
+        // Anchored just below the status-bar border line so it grows DOWNWARD when
+        // the preset row appears — the four main buttons stay put and never slide
+        // behind the top status header.
+        anchors.top: topStatsBorder.bottom
+        anchors.topMargin: Theme.scaled(12)
         anchors.leftMargin: Theme.standardMargin
         anchors.rightMargin: Theme.standardMargin
         spacing: Theme.scaled(20)
 
-        // Status readouts (temp, water level, connection)
+        // Status readouts (temp, water level, connection) — hidden: the same
+        // info is already shown in the top status bar, so the large center
+        // duplicates just crowded the home screen.
         LayoutCenterZone {
             Layout.fillWidth: true
             Layout.topMargin: idlePage.centerStatusYOffset
             zoneName: "centerStatus"
             items: idlePage.centerStatusItems
-            visible: idlePage.centerStatusItems.length > 0
+            visible: false
             zoneScale: idlePage.centerStatusScale
         }
 
@@ -830,9 +852,114 @@ Page {
     }
 
     // ============================================================
+    // Brew status row (across the bottom, above the action bar)
+    // ============================================================
+    Rectangle {
+        id: brewStatusBar
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: bottomBar.top
+        height: Theme.scaled(82)
+        // High-contrast: light background with blue text so the stats stand out.
+        color: Theme.primaryContrastColor
+
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: Theme.spacingMedium
+            anchors.rightMargin: Theme.spacingMedium
+            spacing: Theme.spacingSmall
+
+            // Current espresso profile
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1   // equal cells regardless of content width
+                spacing: 0
+                Tr { key: "idle.status.profile"; fallback: "Profile"; color: Theme.primaryColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter; elide: Text.ElideRight }
+                Text {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    elide: Text.ElideRight
+                    text: ProfileManager.currentProfileName || "—"
+                    color: Theme.primaryColor; font.pixelSize: Theme.scaled(21); font.bold: true
+                }
+            }
+
+            // Live net scale weight (context-aware: net milk in steam mode, else net beans)
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: 0
+                Tr { key: "idle.status.scale"; fallback: "Scale"; color: Theme.primaryColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter }
+                Text {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    text: {
+                        if (!ScaleDevice.connected) return "—"
+                        var net
+                        if (idlePage.activePresetFunction === "steam") {
+                            var p = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+                            var pw = (p && !p.disabled) ? (p.pitcherWeightG ?? 0) : 0
+                            net = Math.max(0, MachineState.scaleWeight - pw)
+                        } else {
+                            net = Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight)
+                        }
+                        return net.toFixed(1) + " g"
+                    }
+                    color: Theme.primaryColor; font.pixelSize: Theme.scaled(21); font.bold: true
+                }
+            }
+
+            // Current coffee:water ratio setting
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: 0
+                Tr { key: "idle.status.ratio"; fallback: "Ratio"; color: Theme.primaryColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter }
+                Text {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    text: "1:" + Settings.brew.lastUsedRatio.toFixed(1)
+                    color: Theme.primaryColor; font.pixelSize: Theme.scaled(21); font.bold: true
+                }
+            }
+
+            // Beans measured indicator (+ amount)
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: 0
+                Tr { key: "idle.status.beans"; fallback: "Beans"; color: Theme.primaryColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter }
+                Text {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    text: Settings.dye.dyeBeanWeight > 0 ? Settings.dye.dyeBeanWeight.toFixed(1) + " g"
+                                                        : TranslationManager.translate("idle.status.none", "—")
+                    color: Theme.primaryColor; font.pixelSize: Theme.scaled(21); font.bold: true
+                }
+            }
+
+            // Milk measured indicator (+ amount)
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: 0
+                Tr { key: "idle.status.milk"; fallback: "Milk"; color: Theme.primaryColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter }
+                Text {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    text: idlePage.measuredMilkG > 0 ? idlePage.measuredMilkG.toFixed(1) + " g"
+                                                     : TranslationManager.translate("idle.status.none", "—")
+                    color: Theme.primaryColor; font.pixelSize: Theme.scaled(21); font.bold: true
+                }
+            }
+        }
+    }
+
+    // ============================================================
     // Bottom bar (from layout bottomLeft/bottomRight zones)
     // ============================================================
     Rectangle {
+        id: bottomBar
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -183,6 +183,70 @@ Page {
         }
     }
 
+    // Idle milk auto-capture: while the steam presets are showing on the home
+    // screen and the selected pitcher is calibrated (has a reference milk weight),
+    // rest the milk pitcher on the scale -> lock the steam time proportionally,
+    // ding, and show a confirmation. This is the steam equivalent of the bean
+    // auto-capture above; the dedicated Steam page has its own copy.
+    property bool milkCaptureShown: false
+    property string milkCaptureText: ""
+    // Last milk weight measured this session (for the bottom status row). 0 = none yet.
+    property real measuredMilkG: 0
+    Timer { id: idleMilkCaptureTimer; interval: 3500; onTriggered: idlePage.milkCaptureShown = false }
+    StableWeightCapture {
+        id: idleMilkCapture
+        weight: {
+            if (!ScaleDevice.connected || ScaleDevice.isFlowScale) return 0
+            var p = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+            if (!p || p.disabled) return 0
+            var pw = p.pitcherWeightG ?? 0
+            var milk = pw > 0 ? (MachineState.scaleWeight - pw) : MachineState.scaleWeight
+            return (milk > 20 && milk < 1500) ? milk : 0
+        }
+        active: idlePage.activePresetFunction === "steam"
+                && ScaleDevice.connected && !ScaleDevice.isFlowScale
+        minWeight: 20
+        tolerance: 1.5
+        stableMs: 2500
+        onStableCaptured: function(milk) {
+            idlePage.measuredMilkG = milk  // record measured milk for the status row
+            var p = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+            if (!p || p.disabled) return
+            var calib = p.calibMilkG ?? 0
+            if (calib <= 0) return  // preset not calibrated (no reference milk) — nothing to lock
+            var t = Math.max(5, Math.min(120, Math.round(p.duration * (milk / calib))))
+            Settings.brew.steamTimeout = t
+            idlePage.milkCaptureText = TranslationManager.translate("idle.steamCaptured", "Steam time: %1s for %2g milk").arg(t).arg(milk.toFixed(0))
+            idlePage.milkCaptureShown = true
+            idleMilkCaptureTimer.restart()
+            if (typeof AccessibilityManager !== "undefined") {
+                AccessibilityManager.playCaptureDing()
+                if (AccessibilityManager.enabled)
+                    AccessibilityManager.announce(idlePage.milkCaptureText)
+            }
+        }
+    }
+
+    // Transient confirmation banner for the milk-weight capture (auto-dismiss).
+    Rectangle {
+        visible: idlePage.milkCaptureShown
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: Theme.scaled(12)
+        z: 2000
+        width: milkBannerLabel.implicitWidth + Theme.scaled(32)
+        height: milkBannerLabel.implicitHeight + Theme.scaled(20)
+        radius: Theme.cardRadius
+        color: Theme.primaryColor
+        Text {
+            id: milkBannerLabel
+            anchors.centerIn: parent
+            text: idlePage.milkCaptureText
+            color: Theme.primaryContrastColor
+            font: Theme.bodyFont
+        }
+    }
+
     // Small flashing reminder shown while a cup of beans or a pitcher of milk is
     // settling on the scale (something is on the scale but the capture hasn't
     // fired yet). Disappears the instant it captures (the bell rings).
@@ -195,7 +259,9 @@ Page {
         horizontalAlignment: Text.AlignHCenter
         readonly property bool beansSettling: beanCapture.active && !beanCapture.isCaptured
                                               && beanCapture.weight >= beanCapture.minWeight
-        visible: beansSettling
+        readonly property bool milkSettling: idleMilkCapture.active && !idleMilkCapture.isCaptured
+                                            && idleMilkCapture.weight >= idleMilkCapture.minWeight
+        visible: beansSettling || milkSettling
         text: TranslationManager.translate("scale.waitForBell", "Wait for the bell before you take it off the scale")
         color: Theme.warningColor
         font: Theme.labelFont
@@ -400,6 +466,7 @@ Page {
                     selectedIndex: Settings.brew.selectedSteamPitcher
                     pillSuffixMaxWidth: Theme.scaled(60)  // Reserve ~"(1234g)" worth of width
                     pillSuffixVersion: steamPresetLoader.steamPillSuffixVersion
+                    supportLongPress: true
 
                     pillSuffixFn: function(index) {
                         if (!ScaleDevice.connected || ScaleDevice.isFlowScale) return ""
@@ -424,7 +491,30 @@ Page {
                             return
                         }
                         if (preset) {
-                            Settings.brew.steamTimeout = preset.duration
+                            // Weight-scaled steaming (DSx2-style): if this pitcher is
+                            // calibrated (a reference milk weight is paired with its
+                            // duration), scale the steam time by the actual milk weight
+                            // so it auto-stops proportionally.
+                            var calibMilk = preset.calibMilkG ?? 0
+                            if (calibMilk > 0 && ScaleDevice.connected && !ScaleDevice.isFlowScale) {
+                                var pitcherWt = preset.pitcherWeightG ?? 0
+                                // Net milk = scale - saved pitcher weight, or the raw
+                                // reading if the user tared the scale instead.
+                                var milk = pitcherWt > 0 ? (MachineState.scaleWeight - pitcherWt)
+                                                         : MachineState.scaleWeight
+                                // If milk isn't on the scale right now (e.g. lifted to the
+                                // wand), fall back to the last measured weight so the time
+                                // still scales.
+                                if (!(milk > 20 && milk < 1500))
+                                    milk = idlePage.measuredMilkG
+                                if (milk > 20 && milk < 1500)
+                                    Settings.brew.steamTimeout = Math.max(5, Math.min(120,
+                                        Math.round(preset.duration * milk / calibMilk)))
+                                else
+                                    Settings.brew.steamTimeout = preset.duration  // no milk measured yet
+                            } else {
+                                Settings.brew.steamTimeout = preset.duration  // not calibrated → fixed
+                            }
                             Settings.brew.steamFlow = preset.flow !== undefined ? preset.flow : 150
                         }
                         MainController.applySteamSettings()
@@ -438,6 +528,14 @@ Page {
                                     AccessibilityManager.announce(TranslationManager.translate("machine.notReady", "Machine is not ready"))
                             }
                         }
+                    }
+
+                    // Long-press a pitcher to open the steam page settings, where you
+                    // set the duration and tap Calibrate (with milk on the scale) to
+                    // teach this pitcher its milk-weight -> steam-time reference.
+                    onPresetLongPressed: function(index) {
+                        Settings.brew.selectedSteamPitcher = index
+                        pageStack.push(Qt.resolvedUrl("SteamPage.qml"))
                     }
                 }
             }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -357,6 +357,11 @@ Page {
         id: idleBrewDialog
     }
 
+    // Quick coffee:water ratio chooser (opened from the bottom status bar)
+    RatioPresetDialog {
+        id: ratioPresetDialog
+    }
+
     // ============================================================
     // Top info section (from layout topLeft/topRight zones)
     // ============================================================
@@ -909,17 +914,32 @@ Page {
                 }
             }
 
-            // Current coffee:water ratio setting
+            // Coffee:water ratio — tappable quick-select button (opens the ratio chooser)
             ColumnLayout {
                 Layout.fillWidth: true
                 Layout.preferredWidth: 1
-                spacing: 0
+                spacing: Theme.scaled(2)
                 Tr { key: "idle.status.ratio"; fallback: "Ratio"; color: Theme.primaryColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter }
-                Text {
-                    Layout.fillWidth: true
-                    horizontalAlignment: Text.AlignHCenter
-                    text: "1:" + Settings.brew.lastUsedRatio.toFixed(1)
-                    color: Theme.primaryColor; font.pixelSize: Theme.scaled(21); font.bold: true
+                Rectangle {
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredWidth: ratioValueText.implicitWidth + Theme.spacingMedium * 2
+                    Layout.preferredHeight: Theme.scaled(32)
+                    radius: height / 2
+                    color: ratioBtnMa.pressed ? Qt.darker(Theme.primaryColor, 1.15) : Theme.primaryColor
+                    Accessible.role: Accessible.Button
+                    Accessible.name: TranslationManager.translate("idle.ratio.button", "Brew ratio")
+                                     + " 1:" + Settings.brew.lastUsedRatio.toFixed(1) + ". "
+                                     + TranslationManager.translate("idle.ratio.tapToChange", "Tap to change")
+                    Accessible.focusable: true
+                    Accessible.onPressAction: ratioBtnMa.clicked(null)
+                    Text {
+                        id: ratioValueText
+                        anchors.centerIn: parent
+                        text: "1:" + Settings.brew.lastUsedRatio.toFixed(1)
+                        color: Theme.primaryContrastColor
+                        font.pixelSize: Theme.scaled(20); font.bold: true
+                    }
+                    MouseArea { id: ratioBtnMa; anchors.fill: parent; onClicked: ratioPresetDialog.open() }
                 }
             }
 

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -148,6 +148,65 @@ Page {
     // Track which function's presets are showing (used by center-zone action items)
     property string activePresetFunction: ""  // "", "steam", "espresso", "hotwater", "flush", "beans", "equipment"
 
+    // Idle bean auto-capture: when the dose cup (with beans) rests stable on the
+    // scale, set the dose + stop-at-weight (same as the "Weigh beans" button),
+    // ding, and confirm on the button text. Active on the plain home screen and
+    // in espresso/beans mode (NOT while showing steam/hot-water/flush presets,
+    // where the scale is for milk/water), and bounded to a dose-plausible weight
+    // (<= 45 g net) so a milk pitcher or water vessel never trips it.
+    property bool beanCaptureShown: false
+    property string beanCaptureText: ""
+    Timer { id: idleBeanCaptureTimer; interval: 3500; onTriggered: idlePage.beanCaptureShown = false }
+    StableWeightCapture {
+        id: beanCapture
+        weight: ScaleDevice.connected ? Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) : 0
+        active: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                && idlePage.activePresetFunction !== "steam"
+                && idlePage.activePresetFunction !== "hotwater"
+                && idlePage.activePresetFunction !== "flush"
+        minWeight: 5
+        maxWeight: 45
+        tolerance: 0.5
+        stableMs: 2500
+        onStableCaptured: function(net) {
+            if (net < 3) return
+            Settings.dye.dyeBeanWeight = net
+            Settings.brew.brewYieldOverride = net * Settings.brew.lastUsedRatio
+            idlePage.beanCaptureText = TranslationManager.translate("idle.doseCaptured", "Dose set: %1g").arg(net.toFixed(1))
+            idlePage.beanCaptureShown = true
+            idleBeanCaptureTimer.restart()
+            if (typeof AccessibilityManager !== "undefined") {
+                AccessibilityManager.playCaptureDing()
+                if (AccessibilityManager.enabled)
+                    AccessibilityManager.announce(idlePage.beanCaptureText)
+            }
+        }
+    }
+
+    // Small flashing reminder shown while a cup of beans or a pitcher of milk is
+    // settling on the scale (something is on the scale but the capture hasn't
+    // fired yet). Disappears the instant it captures (the bell rings).
+    Text {
+        id: waitForBellHint
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: Theme.scaled(70)
+        z: 1500
+        horizontalAlignment: Text.AlignHCenter
+        readonly property bool beansSettling: beanCapture.active && !beanCapture.isCaptured
+                                              && beanCapture.weight >= beanCapture.minWeight
+        visible: beansSettling
+        text: TranslationManager.translate("scale.waitForBell", "Wait for the bell before you take it off the scale")
+        color: Theme.warningColor
+        font: Theme.labelFont
+        SequentialAnimation on opacity {
+            running: waitForBellHint.visible
+            loops: Animation.Infinite
+            NumberAnimation { to: 0.25; duration: 450 }
+            NumberAnimation { to: 1.0; duration: 450 }
+        }
+    }
+
     // Auto-tare scale and announce presets when activePresetFunction changes
     onActivePresetFunctionChanged: {
         // Auto-tare when steam pills appear so the scale starts at 0
@@ -493,6 +552,49 @@ Page {
                                     profileFilename: Settings.app.currentProfile,
                                     profileName: ProfileManager.currentProfileName
                                 })
+                            }
+                        }
+                    }
+
+                    // Bean weight: weigh the dose from the scale (minus the stored
+                    // dose-cup tare) and apply it — sets the dose and the stop-at-weight
+                    // (dose x ratio) only; temperature and grind are left untouched. The
+                    // button shows a live preview of the net beans on the scale.
+                    Row {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        visible: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                        spacing: Theme.scaled(8)
+
+                        // Small, unobtrusive live net-weight readout. Beans now
+                        // auto-capture when stable, so this is a readout (not a
+                        // button) — it shows the live net beans and briefly flashes
+                        // the captured dose in the accent color.
+                        Text {
+                            id: weighBeansText
+                            horizontalAlignment: Text.AlignHCenter
+                            // True while prompting the user to place beans (nothing on
+                            // the scale yet) — this state gently blinks.
+                            readonly property bool showingPlacePrompt: !idlePage.beanCaptureShown
+                                && Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) < 1
+                            text: {
+                                if (idlePage.beanCaptureShown)
+                                    return idlePage.beanCaptureText
+                                var net = Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight)
+                                if (net >= 1)
+                                    return net.toFixed(1) + " g " + TranslationManager.translate("idle.label.onScale", "on scale")
+                                return TranslationManager.translate("idle.label.placeBeansOnScale", "Place Beans on Scale") + "\n"
+                                     + TranslationManager.translate("idle.label.placeBeansHint", "(and wait for the beep before removing)")
+                            }
+                            color: idlePage.beanCaptureShown ? Theme.primaryColor : Theme.textSecondaryColor
+                            font.pixelSize: Theme.scaled(14)
+                            Accessible.role: Accessible.StaticText
+                            Accessible.name: text
+                            onShowingPlacePromptChanged: if (!showingPlacePrompt) opacity = 1.0
+                            SequentialAnimation on opacity {
+                                running: weighBeansText.showingPlacePrompt
+                                loops: Animation.Infinite
+                                NumberAnimation { to: 0.45; duration: 800 }
+                                NumberAnimation { to: 1.0; duration: 800 }
                             }
                         }
                     }

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -747,6 +747,28 @@ Page {
                         color: isSteamHeating ? Theme.warningColor : (isPuffing ? Theme.secondaryColor : Theme.primaryColor)
                     }
                 }
+
+                // Purge button on the live steaming view — stops steam and triggers
+                // the DE1 steam-wand purge.
+                Rectangle {
+                    visible: isSteaming
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    width: Theme.scaled(150)
+                    height: Theme.scaled(48)
+                    radius: Theme.buttonRadius
+                    color: livePurgeMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                    Accessible.role: Accessible.Button
+                    Accessible.name: TranslationManager.translate("steam.accessible.purge", "Purge the steam wand")
+                    Accessible.focusable: true
+                    Accessible.onPressAction: livePurgeMa.clicked(null)
+                    Tr {
+                        anchors.centerIn: parent
+                        key: "steam.label.purge"; fallback: "Purge"
+                        color: Theme.primaryContrastColor; font: Theme.bodyFont
+                        Accessible.ignored: true
+                    }
+                    MouseArea { id: livePurgeMa; anchors.fill: parent; onClicked: DE1Device.requestIdle() }
+                }
             }
 
             Item { Layout.fillHeight: true }
@@ -1255,9 +1277,20 @@ Page {
                 color: Theme.surfaceColor
                 radius: Theme.cardRadius
 
-                ColumnLayout {
+                Flickable {
+                    id: editorFlick
                     anchors.fill: parent
                     anchors.margins: Theme.scaled(16)
+                    contentWidth: width
+                    contentHeight: editorColumn.implicitHeight
+                    clip: true
+                    boundsBehavior: Flickable.StopAtBounds
+                    flickableDirection: Flickable.VerticalFlick
+                    ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+                ColumnLayout {
+                    id: editorColumn
+                    width: editorFlick.width
                     spacing: Theme.scaled(8)
 
                     // Centered placeholder when the selected preset is an "Off" pill —
@@ -1266,7 +1299,7 @@ Page {
                     Item {
                         visible: steamPage.currentPitcherDisabled
                         Layout.fillWidth: true
-                        Layout.fillHeight: true
+                        Layout.preferredHeight: Theme.scaled(160)
 
                         Tr {
                             anchors.centerIn: parent
@@ -1277,6 +1310,32 @@ Page {
                             horizontalAlignment: Text.AlignHCenter
                         }
                     }
+
+                    // Purge: clear water / condensation from the steam wand.
+                    RowLayout {
+                        Layout.fillWidth: true
+                        visible: !steamPage.currentPitcherDisabled
+                        Item { Layout.fillWidth: true }
+                        Rectangle {
+                            Layout.preferredWidth: Theme.scaled(150)
+                            Layout.preferredHeight: Theme.scaled(48)
+                            radius: Theme.buttonRadius
+                            color: purgeMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                            Accessible.role: Accessible.Button
+                            Accessible.name: TranslationManager.translate("steam.accessible.purge", "Purge the steam wand")
+                            Accessible.focusable: true
+                            Accessible.onPressAction: purgeMa.clicked(null)
+                            Tr {
+                                anchors.centerIn: parent
+                                key: "steam.label.purge"; fallback: "Purge"
+                                color: Theme.primaryContrastColor; font: Theme.bodyFont
+                                Accessible.ignored: true
+                            }
+                            MouseArea { id: purgeMa; anchors.fill: parent; onClicked: DE1Device.requestIdle() }
+                        }
+                    }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
 
                     // Duration (per-pitcher, auto-saves)
                     RowLayout {
@@ -1520,6 +1579,84 @@ Page {
                         }
                     }
 
+                    // Milk pitcher section: the empty-pitcher weight for the selected
+                    // preset. Shows the saved value and lets you adjust it (type or +/-).
+                    // Used to work out milk weight (scale - pitcher) and, when a preset
+                    // is calibrated, to scale the steam time. Re-weigh via the Weight
+                    // row's Save button below.
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(16)
+                        visible: !steamPage.currentPitcherDisabled
+
+                        Column {
+                            spacing: Theme.scaled(4)
+                            Tr {
+                                key: "steam.label.pitcherWeight"
+                                fallback: "Milk pitcher"
+                                color: Theme.textColor
+                                font.pixelSize: Theme.scaled(24)
+                                Accessible.ignored: true
+                            }
+                            Tr {
+                                key: "steam.hint.pitcherWeight"
+                                fallback: "Empty pitcher weight"
+                                color: Theme.textSecondaryColor
+                                font: Theme.labelFont
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        ValueInput {
+                            id: pitcherWeightInput
+                            Layout.preferredWidth: Theme.scaled(150)
+                            from: 0
+                            to: 1000
+                            stepSize: 0.1
+                            decimals: 1
+                            suffix: " g"
+                            value: {
+                                var _ = Settings.brew.steamPitcherPresets
+                                var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+                                return preset ? (preset.pitcherWeightG ?? 0) : 0
+                            }
+                            valueColor: Theme.weightColor
+                            accessibleName: TranslationManager.translate("steam.label.pitcherWeight", "Milk pitcher weight")
+                            onValueModified: function(newValue) {
+                                Settings.brew.setSteamPitcherWeight(Settings.brew.selectedSteamPitcher, newValue)
+                            }
+                        }
+
+                        // Weigh the empty pitcher now on the scale.
+                        Rectangle {
+                            id: pitcherWeighBtn
+                            visible: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                            readonly property bool btnEnabled: MachineState.scaleWeight > 0
+                            opacity: btnEnabled ? 1.0 : 0.4
+                            width: Theme.scaled(84); height: Theme.scaled(44)
+                            radius: Theme.cardRadius
+                            color: pitcherWeighMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                            Accessible.role: Accessible.Button
+                            Accessible.name: TranslationManager.translate("steam.accessible.weighPitcher", "Weigh empty pitcher from the scale")
+                            Accessible.focusable: true
+                            Accessible.onPressAction: pitcherWeighMa.clicked(null)
+                            Tr {
+                                anchors.centerIn: parent
+                                key: "steam.label.weigh"; fallback: "Weigh"
+                                color: Theme.primaryContrastColor; font: Theme.bodyFont
+                                Accessible.ignored: true
+                            }
+                            MouseArea {
+                                id: pitcherWeighMa
+                                anchors.fill: parent
+                                enabled: pitcherWeighBtn.btnEnabled
+                                onClicked: Settings.brew.setSteamPitcherWeight(
+                                    Settings.brew.selectedSteamPitcher, MachineState.scaleWeight)
+                            }
+                        }
+                    }
+
                     Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
 
                     // Weight — pitcher tare calibration per preset
@@ -1669,7 +1806,7 @@ Page {
                         }
                     }
 
-                    Item { Layout.fillHeight: true }
+                }
                 }
             }
         }

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -31,7 +31,7 @@ Page {
                 MainController.turnOffSteamHeater()
             } else {
                 // Sync Settings with selected preset
-                Settings.brew.steamTimeout = getCurrentPitcherDuration()
+                steamPage.syncSteamTimeout()
                 Settings.brew.steamFlow = getCurrentPitcherFlow()
                 // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
                 // startSteamHeating clears steamDisabled flag automatically
@@ -128,7 +128,7 @@ Page {
                 // onStateChanged->startSteamHeating picks it up and writes it
                 // (the DE1's commanded state between sessions is idle anyway,
                 // so the lag is invisible).
-                Settings.brew.steamTimeout = getCurrentPitcherDuration()
+                steamPage.syncSteamTimeout()
                 Settings.brew.steamFlow = getCurrentPitcherFlow()
                 if (!Settings.brew.keepSteamHeaterOn) {
                     console.log("SteamPage: Turning off steam heater (keepSteamHeaterOn=false)")
@@ -181,6 +181,69 @@ Page {
         if (name && !isCurrentPitcherDisabled()) {
             Settings.brew.updateSteamPitcherPreset(Settings.brew.selectedSteamPitcher, name, duration, flow)
         }
+    }
+
+    // --- Weight-scaled steaming (calibrated presets) -------------------------
+    // Milk now on the scale = (pitcher + milk) minus the saved empty-pitcher
+    // weight. Returns 0 unless a sane amount of milk is actually on the scale.
+    function currentMeasuredMilk() {
+        if (!ScaleDevice.connected) return 0
+        var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        if (!preset || preset.disabled) return 0
+        var pitcherWt = preset.pitcherWeightG ?? 0
+        // If an empty-pitcher weight is saved, net milk = scale - pitcher.
+        // Otherwise assume the user tared the scale with the empty pitcher, so
+        // the live reading is already net milk.
+        var milk = pitcherWt > 0 ? (MachineState.scaleWeight - pitcherWt)
+                                 : MachineState.scaleWeight
+        return (milk > 20 && milk < 1500) ? milk : 0
+    }
+
+    // If this preset is calibrated (a reference milk weight is paired with its
+    // duration) and milk is on the scale, return the duration scaled to the
+    // actual milk weight. Returns 0 when scaling doesn't apply, so callers fall
+    // back to the preset's fixed duration.
+    function scaledSteamTimeout() {
+        var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        if (!preset || preset.disabled) return 0
+        var calibMilk = preset.calibMilkG ?? 0
+        if (calibMilk <= 0) return 0
+        var milk = currentMeasuredMilk()
+        if (milk <= 0) return 0
+        var scaled = Math.round(preset.duration * (milk / calibMilk))
+        return Math.max(5, Math.min(120, scaled))
+    }
+
+    // Steam time (s) for a specific captured milk weight, using the selected
+    // preset's reference-milk -> duration baseline. Returns 0 when the preset
+    // isn't calibrated (no reference milk set).
+    function steamTimeForMilk(milk) {
+        var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        if (!preset || preset.disabled) return 0
+        var calibMilk = preset.calibMilkG ?? 0
+        if (calibMilk <= 0 || milk <= 0) return 0
+        return Math.max(5, Math.min(120, Math.round(preset.duration * (milk / calibMilk))))
+    }
+
+    // Selected preset's reference milk weight (the baseline paired with its duration).
+    function getCurrentPitcherCalibMilk() {
+        var _ = Settings.brew.steamPitcherPresets  // track changes so the field refreshes after Weigh
+        var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        return (preset && !preset.disabled) ? (preset.calibMilkG ?? 0) : 0
+    }
+
+    // Sync steamTimeout to the selected preset WITHOUT clobbering a weight-scaled
+    // value. If milk is on the scale now, use the scaled time. If the preset is
+    // calibrated but milk isn't on the scale (e.g. lifted to the wand / arriving
+    // from the home-screen steam flow), keep the current steamTimeout — it was
+    // already scaled from the measured milk. Only fall back to the fixed reference
+    // duration when the preset isn't calibrated.
+    function syncSteamTimeout() {
+        var live = scaledSteamTimeout()
+        if (live > 0)
+            Settings.brew.steamTimeout = live
+        else if (getCurrentPitcherCalibMilk() <= 0)
+            Settings.brew.steamTimeout = getCurrentPitcherDuration()
     }
 
     // Steam view mode: "timer" (default) or "chart"
@@ -417,7 +480,7 @@ Page {
                                         return
                                     }
                                     var flow = modelData.flow !== undefined ? modelData.flow : 150
-                                    Settings.brew.steamTimeout = modelData.duration
+                                    Settings.brew.steamTimeout = scaledSteamTimeout() > 0 ? scaledSteamTimeout() : modelData.duration
                                     Settings.brew.steamFlow = flow
                                     if (!isSteaming) {
                                         MainController.startSteamHeating("live-pitcher-click")
@@ -993,7 +1056,7 @@ Page {
                                         var flow = modelData.flow !== undefined ? modelData.flow : 150
                                         durationSlider.value = modelData.duration
                                         flowSlider.value = flow
-                                        Settings.brew.steamTimeout = modelData.duration
+                                        Settings.brew.steamTimeout = scaledSteamTimeout() > 0 ? scaledSteamTimeout() : modelData.duration
                                         Settings.brew.steamFlow = flow
                                         MainController.startSteamHeating(reason)
                                     }
@@ -1301,6 +1364,117 @@ Page {
 
                     Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
 
+                    // Reference milk weight: the baseline paired with this preset's
+                    // duration for weight-timed steaming. steamTime = duration ×
+                    // (measuredMilk / referenceMilk). 0 disables weight scaling.
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(16)
+                        visible: !steamPage.currentPitcherDisabled
+
+                        Column {
+                            Tr {
+                                key: "steam.label.referenceMilk"
+                                fallback: "Reference milk"
+                                color: Theme.textColor
+                                font.pixelSize: Theme.scaled(24)
+                            }
+                            Tr {
+                                key: "steam.hint.referenceMilk"
+                                fallback: "0 = off. Steam time scales with milk weight."
+                                color: Theme.textSecondaryColor
+                                font: Theme.labelFont
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        ValueInput {
+                            id: refMilkInput
+                            Layout.preferredWidth: Theme.scaled(150)
+                            from: 0
+                            to: 1500
+                            stepSize: 0.1
+                            decimals: 1
+                            suffix: " g"
+                            value: getCurrentPitcherCalibMilk()
+                            valueColor: Theme.primaryColor
+                            accessibleName: TranslationManager.translate("steam.label.referenceMilk", "Reference milk weight")
+                            KeyNavigation.tab: steamTempSlider
+                            KeyNavigation.backtab: flowSlider
+                            onValueModified: function(newValue) {
+                                refMilkInput.value = newValue
+                                Settings.brew.setSteamPitcherCalibration(Settings.brew.selectedSteamPitcher, newValue)
+                            }
+                        }
+
+                        // Weigh the milk now on the scale and use it as the reference.
+                        // Needs the empty-pitcher weight set (so net milk is known).
+                        Rectangle {
+                            id: refMilkWeighBtn
+                            visible: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                            readonly property bool btnEnabled: steamPage.currentMeasuredMilk() > 0
+                            opacity: btnEnabled ? 1.0 : 0.4
+                            width: Theme.scaled(84); height: Theme.scaled(44)
+                            radius: Theme.cardRadius
+                            color: refMilkWeighMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                            Accessible.role: Accessible.Button
+                            Accessible.name: TranslationManager.translate("steam.accessible.setRefMilk", "Set reference milk from the scale")
+                            Accessible.focusable: true
+                            Accessible.onPressAction: refMilkWeighMa.clicked(null)
+                            Tr {
+                                anchors.centerIn: parent
+                                key: "steam.label.weigh"; fallback: "Weigh"
+                                color: Theme.primaryContrastColor; font: Theme.bodyFont
+                                Accessible.ignored: true
+                            }
+                            MouseArea {
+                                id: refMilkWeighMa
+                                anchors.fill: parent
+                                enabled: refMilkWeighBtn.btnEnabled
+                                onClicked: Settings.brew.setSteamPitcherCalibration(
+                                    Settings.brew.selectedSteamPitcher, steamPage.currentMeasuredMilk())
+                            }
+                        }
+                    }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
+
+                    // Live expected steam time for the milk currently on the scale
+                    // (only when the preset is calibrated and milk is present).
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(16)
+                        visible: !steamPage.currentPitcherDisabled
+                                 && ScaleDevice.connected && !ScaleDevice.isFlowScale
+                                 && steamPage.scaledSteamTimeout() > 0
+
+                        Column {
+                            Tr {
+                                key: "steam.label.expectedSteamTime"
+                                fallback: "Expected steam time"
+                                color: Theme.textColor
+                                font.pixelSize: Theme.scaled(24)
+                            }
+                            Text {
+                                text: TranslationManager.translate("steam.hint.forMilkOnScale", "for %1 g milk on scale").arg(steamPage.currentMeasuredMilk().toFixed(0))
+                                color: Theme.textSecondaryColor
+                                font: Theme.labelFont
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        Text {
+                            text: steamPage.scaledSteamTimeout() + " s"
+                            color: Theme.primaryColor
+                            font.pixelSize: Theme.scaled(28)
+                            font.bold: true
+                        }
+                    }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled && ScaleDevice.connected && !ScaleDevice.isFlowScale && steamPage.scaledSteamTimeout() > 0 }
+
                     // Temperature (global setting)
                     RowLayout {
                         Layout.fillWidth: true
@@ -1374,6 +1548,20 @@ Page {
                                     if (saved > 0)
                                         return TranslationManager.translate("steam.hint.pitcherWeightSaved", "Pitcher") + ": " + saved.toFixed(0) + "g"
                                     return TranslationManager.translate("steam.hint.pitcherWeightNone", "No pitcher weight saved")
+                                }
+                                Accessible.ignored: true
+                            }
+                            Text {
+                                color: Theme.textSecondaryColor
+                                font: Theme.labelFont
+                                visible: text.length > 0
+                                text: {
+                                    var _ = Settings.brew.steamPitcherPresets
+                                    var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+                                    var cal = preset ? (preset.calibMilkG ?? 0) : 0
+                                    if (cal > 0)
+                                        return TranslationManager.translate("steam.hint.weightTimed", "Weight-timed") + ": " + cal.toFixed(0) + "g → " + preset.duration + "s"
+                                    return ""
                                 }
                                 Accessible.ignored: true
                             }
@@ -1474,6 +1662,10 @@ Page {
                                     }
                                 }
                             }
+
+                            // (Weight-timed calibration is now set explicitly via the
+                            // "Reference milk" field in the editor rows above, rather than
+                            // a live Calibrate button.)
                         }
                     }
 
@@ -1483,6 +1675,87 @@ Page {
         }
 
         Item { Layout.fillHeight: true; visible: isSteaming || steamSoftStopped }
+    }
+
+    // Weight-timed steaming: auto-capture the milk weight while it rests on the
+    // scale (before steaming). When the net milk holds steady ~2.5s, lock the
+    // steam time proportional to it, ding, and show a confirmation. The value
+    // stays locked while you lift the pitcher to steam (the detector re-arms only
+    // when the pitcher is removed or the load changes). This is a programmatic
+    // write to steamTimeout, so it never bakes the scaled value into the preset.
+    StableWeightCapture {
+        id: milkCapture
+        weight: steamPage.currentMeasuredMilk()  // net milk = scale - saved pitcher weight
+        active: !isSteaming && !steamSoftStopped
+                && ScaleDevice.connected && !ScaleDevice.isFlowScale
+        minWeight: 20
+        tolerance: 1.5
+        stableMs: 2500
+        onStableCaptured: function(milk) {
+            var t = steamPage.steamTimeForMilk(milk)
+            if (t <= 0)
+                return  // preset not calibrated (no reference milk) — nothing to lock
+            Settings.brew.steamTimeout = t
+            steamPage.captureBannerText =
+                TranslationManager.translate("steam.capture.locked", "Steam time set: %1s for %2g milk")
+                    .arg(t).arg(milk.toFixed(0))
+            steamPage.captureBannerVisible = true
+            captureBannerTimer.restart()
+            if (typeof AccessibilityManager !== "undefined") {
+                AccessibilityManager.playCaptureDing()
+                if (AccessibilityManager.enabled)
+                    AccessibilityManager.announce(steamPage.captureBannerText)
+            }
+        }
+    }
+
+    // Confirmation banner shown briefly after a milk-weight capture (auto-dismiss).
+    property string captureBannerText: ""
+    property bool   captureBannerVisible: false
+    Timer { id: captureBannerTimer; interval: 3500; onTriggered: steamPage.captureBannerVisible = false }
+
+    Rectangle {
+        visible: steamPage.captureBannerVisible
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: Theme.scaled(12)
+        z: 1000
+        width: bannerLabel.implicitWidth + Theme.scaled(32)
+        height: bannerLabel.implicitHeight + Theme.scaled(20)
+        radius: Theme.cardRadius
+        color: Theme.primaryColor
+        opacity: steamPage.captureBannerVisible ? 1.0 : 0.0
+        Behavior on opacity { NumberAnimation { duration: 180 } }
+        Text {
+            id: bannerLabel
+            anchors.centerIn: parent
+            text: steamPage.captureBannerText
+            color: Theme.primaryContrastColor
+            font: Theme.bodyFont
+        }
+    }
+
+    // Small flashing reminder while the milk pitcher is settling on the scale
+    // (something is on the scale but the capture hasn't fired yet). Disappears
+    // the instant it captures (the bell rings).
+    Text {
+        id: steamWaitForBellHint
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: Theme.scaled(70)
+        z: 1000
+        horizontalAlignment: Text.AlignHCenter
+        visible: milkCapture.active && !milkCapture.isCaptured
+                 && milkCapture.weight >= milkCapture.minWeight
+        text: TranslationManager.translate("scale.waitForBell", "Wait for the bell before you take it off the scale")
+        color: Theme.warningColor
+        font: Theme.labelFont
+        SequentialAnimation on opacity {
+            running: steamWaitForBellHint.visible
+            loops: Animation.Infinite
+            NumberAnimation { to: 0.25; duration: 450 }
+            NumberAnimation { to: 1.0; duration: 450 }
+        }
     }
 
     // Accessibility: announce scale weight at intervals while weighing milk (settings view, not steaming)

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -114,6 +114,18 @@ void SettingsBrew::setLastUsedRatio(double ratio) {
     }
 }
 
+double SettingsBrew::doseCupTareWeight() const {
+    return m_settings.value("espresso/doseCupTareWeight", 0.0).toDouble();
+}
+
+void SettingsBrew::setDoseCupTareWeight(double weight) {
+    if (weight < 0) weight = 0;  // a tare is never negative
+    if (doseCupTareWeight() != weight) {
+        m_settings.setValue("espresso/doseCupTareWeight", weight);
+        emit doseCupTareWeightChanged();
+    }
+}
+
 // Steam
 
 double SettingsBrew::steamTemperature() const {

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -126,6 +126,39 @@ void SettingsBrew::setDoseCupTareWeight(double weight) {
     }
 }
 
+double SettingsBrew::ratioPreset1() const {
+    return m_settings.value("espresso/ratioPreset1", 1.0).toDouble();
+}
+void SettingsBrew::setRatioPreset1(double r) {
+    if (r < 0.5) r = 0.5; else if (r > 6.0) r = 6.0;
+    if (ratioPreset1() != r) {
+        m_settings.setValue("espresso/ratioPreset1", r);
+        emit ratioPreset1Changed();
+    }
+}
+
+double SettingsBrew::ratioPreset2() const {
+    return m_settings.value("espresso/ratioPreset2", 2.0).toDouble();
+}
+void SettingsBrew::setRatioPreset2(double r) {
+    if (r < 0.5) r = 0.5; else if (r > 6.0) r = 6.0;
+    if (ratioPreset2() != r) {
+        m_settings.setValue("espresso/ratioPreset2", r);
+        emit ratioPreset2Changed();
+    }
+}
+
+double SettingsBrew::ratioPreset3() const {
+    return m_settings.value("espresso/ratioPreset3", 3.0).toDouble();
+}
+void SettingsBrew::setRatioPreset3(double r) {
+    if (r < 0.5) r = 0.5; else if (r > 6.0) r = 6.0;
+    if (ratioPreset3() != r) {
+        m_settings.setValue("espresso/ratioPreset3", r);
+        emit ratioPreset3Changed();
+    }
+}
+
 // Steam
 
 double SettingsBrew::steamTemperature() const {

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -321,6 +321,24 @@ void SettingsBrew::setSteamPitcherWeight(int index, double weightG) {
     }
 }
 
+void SettingsBrew::setSteamPitcherCalibration(int index, double calibMilkG) {
+    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
+    QJsonDocument doc = QJsonDocument::fromJson(data);
+    QJsonArray arr = doc.array();
+
+    if (index >= 0 && index < static_cast<int>(arr.size())) {
+        QJsonObject preset = arr[index].toObject();
+        if (calibMilkG > 0) {
+            preset["calibMilkG"] = calibMilkG;
+        } else {
+            preset.remove("calibMilkG");  // 0 / negative clears the calibration
+        }
+        arr[index] = preset;
+        m_settings.setValue("steam/pitcherPresets", QJsonDocument(arr).toJson());
+        emit steamPitcherPresetsChanged();
+    }
+}
+
 QVariantMap SettingsBrew::getSteamPitcherPreset(int index) const {
     QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
     QJsonDocument doc = QJsonDocument::fromJson(data);

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -16,6 +16,9 @@ class SettingsBrew : public QObject {
     Q_PROPERTY(double espressoTemperature READ espressoTemperature WRITE setEspressoTemperature NOTIFY espressoTemperatureChanged)
     Q_PROPERTY(double targetWeight READ targetWeight WRITE setTargetWeight NOTIFY targetWeightChanged)
     Q_PROPERTY(double lastUsedRatio READ lastUsedRatio WRITE setLastUsedRatio NOTIFY lastUsedRatioChanged)
+    // Dose cup tare: empty weight of the dosing vessel, subtracted from the scale
+    // reading in "Get from scale" so the dose is net beans. Default 0 = no tare.
+    Q_PROPERTY(double doseCupTareWeight READ doseCupTareWeight WRITE setDoseCupTareWeight NOTIFY doseCupTareWeightChanged)
 
     // Steam
     Q_PROPERTY(double steamTemperature READ steamTemperature WRITE setSteamTemperature NOTIFY steamTemperatureChanged)
@@ -72,6 +75,9 @@ public:
 
     double lastUsedRatio() const;
     void setLastUsedRatio(double ratio);
+
+    double doseCupTareWeight() const;
+    void setDoseCupTareWeight(double weight);
 
     // Steam
     double steamTemperature() const;
@@ -176,6 +182,7 @@ signals:
     void espressoTemperatureChanged();
     void targetWeightChanged();
     void lastUsedRatioChanged();
+    void doseCupTareWeightChanged();
     void steamTemperatureChanged();
     void steamTimeoutChanged();
     void steamFlowChanged();

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -19,6 +19,11 @@ class SettingsBrew : public QObject {
     // Dose cup tare: empty weight of the dosing vessel, subtracted from the scale
     // reading in "Get from scale" so the dose is net beans. Default 0 = no tare.
     Q_PROPERTY(double doseCupTareWeight READ doseCupTareWeight WRITE setDoseCupTareWeight NOTIFY doseCupTareWeightChanged)
+    // Home-screen quick-select brew-ratio presets (Ristretto / Normale / Lungo).
+    // User-tweakable in Espresso Setup; shown on the home-screen ratio chooser.
+    Q_PROPERTY(double ratioPreset1 READ ratioPreset1 WRITE setRatioPreset1 NOTIFY ratioPreset1Changed)
+    Q_PROPERTY(double ratioPreset2 READ ratioPreset2 WRITE setRatioPreset2 NOTIFY ratioPreset2Changed)
+    Q_PROPERTY(double ratioPreset3 READ ratioPreset3 WRITE setRatioPreset3 NOTIFY ratioPreset3Changed)
 
     // Steam
     Q_PROPERTY(double steamTemperature READ steamTemperature WRITE setSteamTemperature NOTIFY steamTemperatureChanged)
@@ -78,6 +83,13 @@ public:
 
     double doseCupTareWeight() const;
     void setDoseCupTareWeight(double weight);
+
+    double ratioPreset1() const;
+    void setRatioPreset1(double r);
+    double ratioPreset2() const;
+    void setRatioPreset2(double r);
+    double ratioPreset3() const;
+    void setRatioPreset3(double r);
 
     // Steam
     double steamTemperature() const;
@@ -186,6 +198,9 @@ signals:
     void targetWeightChanged();
     void lastUsedRatioChanged();
     void doseCupTareWeightChanged();
+    void ratioPreset1Changed();
+    void ratioPreset2Changed();
+    void ratioPreset3Changed();
     void steamTemperatureChanged();
     void steamTimeoutChanged();
     void steamFlowChanged();

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -110,6 +110,9 @@ public:
     Q_INVOKABLE void moveSteamPitcherPreset(int from, int to);
     Q_INVOKABLE QVariantMap getSteamPitcherPreset(int index) const;
     Q_INVOKABLE void setSteamPitcherWeight(int index, double weightG);
+    // Weight-scaled steaming: pair a reference milk weight with this preset's
+    // duration. At steam time the duration is scaled by the actual milk weight.
+    Q_INVOKABLE void setSteamPitcherCalibration(int index, double calibMilkG);
 
     // Hot water
     double waterTemperature() const;


### PR DESCRIPTION
Quick-select coffee-to-water ratio from the home screen, with user-editable presets.

- The bottom stat bar's **Ratio** value becomes a tappable pill → opens a **Brew Ratio** chooser with three one-tap styles: **Ristretto / Normale / Lungo**. Picking one sets the ratio *and* recomputes the yield target from the current dose (same math as the bean auto-capture).
- The three preset **values** are editable at the bottom of **Espresso Setup** (e.g. set them to 1:1.5 / 1:2.6 / 1:3.7) — three new persistent settings (`ratioPreset1/2/3`, clamped 0.5–6.0). The home-screen chooser follows them live.
- An expandable **"About brew ratios"** help panel.
- **Attribution:** the ratio-style descriptions are adapted from "[Brew Ratios Around the World](https://home.lamarzoccousa.com/brew-ratios-around-world/)" by Ben Blake & Scott Callender — La Marzocco Home (2014), credited in-dialog with a link. The text is our own wording; only the styles/learning are theirs.

**Files:** new `qml/components/RatioPresetDialog.qml`, `qml/pages/IdlePage.qml`, `qml/components/BrewDialog.qml`, `src/core/settings_brew.{h,cpp}`, `CMakeLists.txt`.

---
**📦 Stacked PR — review/merge in dependency order.** This group builds on yesterday's stack:

Yesterday: #1349 → #1350 → #1351 → #1352 → #1353 (weight-dialing + home rework)
This morning: **#1359 (ratio) → #1360 (last-steam) → #1361 (top-bar)**

Each builds on the previous; a PR's file-diff narrows to just its own feature once the earlier ones merge. Full background + the community fork: https://github.com/loganross2001/Decenza-community-fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)
