### PR TITLE
Weight-based steaming: milk auto-capture + steam UX + last-steam baseline

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -534,6 +534,39 @@ ApplicationWindow {
         }
     }
 
+    // Latched by the milk auto-capture (IdlePage/SteamPage) to the milk weight
+    // measured for the upcoming steam session. Committed atomically with the actual
+    // duration when the session ends, so "use as baseline" never adopts a mismatched
+    // (milk, time) pair. 0 = no milk measured this session.
+    property real sessionMeasuredMilkG: 0
+
+    // Save the most recent steam session as an atomic (milk weight, duration) pair
+    // so steam setup can adopt it as a baseline. Both fields are written together at
+    // session end — only when this session actually had a measured milk weight,
+    // otherwise the previous coherent pair is left intact.
+    Connections {
+        target: MachineState
+        property real steamElapsedTracker: 0
+        function onShotTimeChanged() {
+            if (MachineState.phase === MachineStateType.Phase.Steaming)
+                steamElapsedTracker = MachineState.shotTime
+        }
+        function onPhaseChanged() {
+            // A steam session just ended (tracker > 0 means we were steaming, so this
+            // doesn't fire on steam-prep phase changes that haven't started steaming).
+            if (MachineState.phase !== MachineStateType.Phase.Steaming && steamElapsedTracker > 0) {
+                // Commit the (milk, time) pair only for a real session with measured
+                // milk; either way clear the latches so nothing leaks to the next one.
+                if (steamElapsedTracker >= 1 && root.sessionMeasuredMilkG > 0) {
+                    Settings.brew.lastSteamMilkG = root.sessionMeasuredMilkG
+                    Settings.brew.lastSteamTimeS = steamElapsedTracker
+                }
+                steamElapsedTracker = 0
+                root.sessionMeasuredMilkG = 0
+            }
+        }
+    }
+
     // Detect when DE1 enters Steam state (even during heating/FinalHeating substate)
     // This clears steamDisabled BEFORE applySteamSettings runs, so GHC-initiated
     // steaming works correctly even if keepSteamHeaterOn is false

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -539,6 +539,13 @@ ApplicationWindow {
     // duration when the session ends, so "use as baseline" never adopts a mismatched
     // (milk, time) pair. 0 = no milk measured this session.
     property real sessionMeasuredMilkG: 0
+    // The captured milk is specific to the selected pitcher's tare + calibration, so
+    // drop it when the pitcher changes — otherwise a new pitcher's steam could scale to
+    // the previous pitcher's milk.
+    Connections {
+        target: Settings.brew
+        function onSelectedSteamPitcherChanged() { root.sessionMeasuredMilkG = 0 }
+    }
 
     // Save the most recent steam session as an atomic (milk weight, duration) pair
     // so steam setup can adopt it as a baseline. Both fields are written together at

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Window
 import Decenza
 import "../components"
 import "../components/layout"
@@ -201,6 +202,104 @@ Page {
         function onTareCompleted() { beanCapture.reset() }
     }
 
+    // Idle milk auto-capture: while the steam presets are showing on the home
+    // screen and the selected pitcher is calibrated (has a reference milk weight),
+    // rest the milk pitcher on the scale -> lock the steam time proportionally,
+    // ding, and show a confirmation. This is the steam equivalent of the bean
+    // auto-capture above; the dedicated Steam page has its own copy.
+    property bool milkCaptureShown: false
+    property string milkCaptureText: ""
+    // Last milk weight measured this session (for the bottom status row). 0 = none yet.
+    property real measuredMilkG: 0
+    Timer { id: idleMilkCaptureTimer; interval: 3500; onTriggered: idlePage.milkCaptureShown = false }
+    StableWeightCapture {
+        id: idleMilkCapture
+        // Virtual-zero model (same as the bean capture): raw scale reading minus the
+        // empty-pitcher weight (cupWeight) gives net milk, robust to an un-zeroed
+        // scale. Auto-capture requires a saved pitcher weight (cupWeight > 0),
+        // symmetric with beans requiring a saved dose-cup tare.
+        rawWeight: (ScaleDevice.connected && !ScaleDevice.isFlowScale) ? MachineState.scaleWeight : 0
+        cupWeight: {
+            var p = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+            return (p && !p.disabled) ? (p.pitcherWeightG ?? 0) : 0
+        }
+        // Opt-in (Settings.brew.milkAutoCaptureEnabled, default on) and only while
+        // the steam flow is showing — so a stray weight never silently changes the
+        // steam stop time.
+        active: Settings.brew.milkAutoCaptureEnabled
+                && idlePage.activePresetFunction === "steam"
+                && ScaleDevice.connected && !ScaleDevice.isFlowScale
+        minNet: 20
+        maxNet: 1500
+        tolerance: 1.5
+        stableMs: 2500
+        onStableCaptured: function(milk) {
+            idlePage.measuredMilkG = milk  // record measured (net) milk for the status row
+            // Latch the measured milk for the baseline pair (committed atomically with
+            // the duration at session end, in main.qml). Recorded even for an
+            // uncalibrated preset so the very first calibration-bootstrap steam can be
+            // adopted — and never as a half-pair, since the time half is written there.
+            if (Window.window) Window.window.sessionMeasuredMilkG = milk
+            var p = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+            if (!p || p.disabled) return
+            var calib = p.calibMilkG ?? 0
+            if (calib <= 0) return  // preset not calibrated (no reference milk) — nothing to lock
+            var t = Math.max(5, Math.min(120, Math.round(p.duration * (milk / calib))))
+            Settings.brew.steamTimeout = t
+            idlePage.milkCaptureText = TranslationManager.translate("idle.steamCaptured", "Steam time: %1s for %2g milk").arg(t).arg(milk.toFixed(0))
+            idlePage.milkCaptureShown = true
+            idleMilkCaptureTimer.restart()
+            if (typeof AccessibilityManager !== "undefined") {
+                if (Settings.brew.doseCaptureSoundEnabled)
+                    AccessibilityManager.playCaptureDing()
+                if (AccessibilityManager.enabled)
+                    AccessibilityManager.announce(idlePage.milkCaptureText)
+            }
+        }
+    }
+    // Re-zero the milk capture when the scale is tared (same reason as the bean one).
+    Connections {
+        target: MachineState
+        function onTareCompleted() { idleMilkCapture.reset() }
+    }
+
+    // Clear the last measured milk when a steam session ends, so the next steam isn't
+    // scaled from a stale measurement (e.g. the home-screen preset path's fallback).
+    // Phase leaves Steaming only at the true session end (Puffing/Ending stay in the
+    // Steaming phase by machinestate.cpp's load-bearing invariant).
+    Connections {
+        target: MachineState
+        property bool wasSteaming: false
+        function onPhaseChanged() {
+            if (MachineState.phase === MachineStateType.Phase.Steaming)
+                wasSteaming = true
+            else if (wasSteaming) {
+                idlePage.measuredMilkG = 0
+                wasSteaming = false
+            }
+        }
+    }
+
+    // Transient confirmation banner for the milk-weight capture (auto-dismiss).
+    Rectangle {
+        visible: idlePage.milkCaptureShown
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: Theme.scaled(12)
+        z: 2000
+        width: milkBannerLabel.implicitWidth + Theme.scaled(32)
+        height: milkBannerLabel.implicitHeight + Theme.scaled(20)
+        radius: Theme.cardRadius
+        color: Theme.primaryColor
+        Text {
+            id: milkBannerLabel
+            anchors.centerIn: parent
+            text: idlePage.milkCaptureText
+            color: Theme.primaryContrastColor
+            font: Theme.bodyFont
+        }
+    }
+
     // Small flashing reminder shown while a dose cup of beans is settling on the
     // scale (a load is present but stable-capture hasn't fired yet). Disappears the
     // instant capture completes; a ding plays then only if doseCaptureSoundEnabled.
@@ -219,7 +318,12 @@ Page {
                                               && beanCapture.loadPresent
                                               && beanCapture.netWeight >= beanCapture.minNet
                                               && beanCapture.netWeight <= beanCapture.maxNet
-        visible: beansSettling
+        readonly property bool milkSettling: idleMilkCapture.active && !idleMilkCapture.isCaptured
+                                            && idleMilkCapture.cupWeight > 0
+                                            && idleMilkCapture.loadPresent
+                                            && idleMilkCapture.netWeight >= idleMilkCapture.minNet
+                                            && idleMilkCapture.netWeight <= idleMilkCapture.maxNet
+        visible: beansSettling || milkSettling
         text: TranslationManager.translate("scale.waitForBell", "Wait for the bell before you take it off the scale")
         color: Theme.warningColor
         font: Theme.labelFont
@@ -419,6 +523,7 @@ Page {
                     selectedIndex: Settings.brew.selectedSteamPitcher
                     pillSuffixMaxWidth: Theme.scaled(60)  // Reserve ~"(1234g)" worth of width
                     pillSuffixVersion: steamPresetLoader.steamPillSuffixVersion
+                    supportLongPress: true
 
                     pillSuffixFn: function(index) {
                         if (!ScaleDevice.connected || ScaleDevice.isFlowScale) return ""
@@ -443,7 +548,30 @@ Page {
                             return
                         }
                         if (preset) {
-                            Settings.brew.steamTimeout = preset.duration
+                            // Weight-scaled steaming (DSx2-style): if this pitcher is
+                            // calibrated (a reference milk weight is paired with its
+                            // duration), scale the steam time by the actual milk weight
+                            // so it auto-stops proportionally.
+                            var calibMilk = preset.calibMilkG ?? 0
+                            if (calibMilk > 0 && ScaleDevice.connected && !ScaleDevice.isFlowScale) {
+                                var pitcherWt = preset.pitcherWeightG ?? 0
+                                // Net milk = scale - saved pitcher weight, or the raw
+                                // reading if the user tared the scale instead.
+                                var milk = pitcherWt > 0 ? (MachineState.scaleWeight - pitcherWt)
+                                                         : MachineState.scaleWeight
+                                // If milk isn't on the scale right now (e.g. lifted to the
+                                // wand), fall back to the last measured weight so the time
+                                // still scales.
+                                if (!(milk >= 20 && milk <= 1500))
+                                    milk = idlePage.measuredMilkG
+                                if (milk >= 20 && milk <= 1500)
+                                    Settings.brew.steamTimeout = Math.max(5, Math.min(120,
+                                        Math.round(preset.duration * milk / calibMilk)))
+                                else
+                                    Settings.brew.steamTimeout = preset.duration  // no milk measured yet
+                            } else {
+                                Settings.brew.steamTimeout = preset.duration  // not calibrated → fixed
+                            }
                             Settings.brew.steamFlow = preset.flow !== undefined ? preset.flow : 150
                         }
                         MainController.applySteamSettings()
@@ -457,6 +585,14 @@ Page {
                                     AccessibilityManager.announce(TranslationManager.translate("machine.notReady", "Machine is not ready"))
                             }
                         }
+                    }
+
+                    // Long-press a pitcher to open the steam page settings, where you
+                    // set the duration and tap Calibrate (with milk on the scale) to
+                    // teach this pitcher its milk-weight -> steam-time reference.
+                    onPresetLongPressed: function(index) {
+                        Settings.brew.selectedSteamPitcher = index
+                        pageStack.push(Qt.resolvedUrl("SteamPage.qml"))
                     }
                 }
             }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -345,6 +345,9 @@ Page {
         // before the user places the pitcher
         if (activePresetFunction === "steam" && typeof MachineState !== "undefined") {
             MachineState.tareScale()
+            // Fresh steam attempt: drop any milk captured but not consumed by a prior
+            // (abandoned) attempt, so it can't scale this one.
+            if (Window.window) Window.window.sessionMeasuredMilkG = 0
         }
 
         if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled && activePresetFunction !== "") {

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -203,10 +203,11 @@ Page {
     }
 
     // Idle milk auto-capture: while the steam presets are showing on the home
-    // screen and the selected pitcher is calibrated (has a reference milk weight),
-    // rest the milk pitcher on the scale -> lock the steam time proportionally,
-    // ding, and show a confirmation. This is the steam equivalent of the bean
-    // auto-capture above; the dedicated Steam page has its own copy.
+    // screen and the selected pitcher has a saved empty-pitcher weight (cupWeight),
+    // rest the milk pitcher on the scale to record the milk weight. If the pitcher
+    // is ALSO calibrated (has a reference milk weight), the steam time is locked
+    // proportionally with a ding + confirmation. This is the steam equivalent of
+    // the bean auto-capture above; the dedicated Steam page has its own copy.
     property bool milkCaptureShown: false
     property string milkCaptureText: ""
     // Last milk weight measured this session (for the bottom status row). 0 = none yet.

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -247,6 +247,9 @@ Page {
             if (calib <= 0) return  // preset not calibrated (no reference milk) — nothing to lock
             var t = Math.max(5, Math.min(120, Math.round(p.duration * (milk / calib))))
             Settings.brew.steamTimeout = t
+            // Push to the DE1 now (same as the steam-preset selection) so a GHC/auto
+            // steam actually uses the scaled time, not the machine's last-sent value.
+            MainController.applySteamSettings()
             idlePage.milkCaptureText = TranslationManager.translate("idle.steamCaptured", "Steam time: %1s for %2g milk").arg(t).arg(milk.toFixed(0))
             idlePage.milkCaptureShown = true
             idleMilkCaptureTimer.restart()

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -197,12 +197,12 @@ Page {
         if (!ScaleDevice.connected) return 0
         var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
         if (!preset || preset.disabled) return 0
+        // Net milk = scale reading minus the saved empty-pitcher weight. A saved
+        // pitcher weight is REQUIRED (same gate as auto-capture), so there is one
+        // consistent rule and no tare-vs-saved-weight ambiguity to trip over.
         var pitcherWt = preset.pitcherWeightG ?? 0
-        // If an empty-pitcher weight is saved, net milk = scale - pitcher.
-        // Otherwise assume the user tared the scale with the empty pitcher, so
-        // the live reading is already net milk.
-        var milk = pitcherWt > 0 ? (MachineState.scaleWeight - pitcherWt)
-                                 : MachineState.scaleWeight
+        if (pitcherWt <= 0) return 0
+        var milk = MachineState.scaleWeight - pitcherWt
         return (milk >= 20 && milk <= 1500) ? milk : 0
     }
 
@@ -253,28 +253,6 @@ Page {
     Connections {
         target: Settings.brew
         function onSelectedSteamPitcherChanged() { steamPage.steamTimeoutScaled = false }
-    }
-
-    // Confirm before storing the empty-pitcher weight (footgun: weighing a pitcher
-    // that still has milk in it would skew every net-milk reading thereafter).
-    property real pendingPitcherWeight: 0
-    Dialog {
-        id: pitcherWeighConfirm
-        parent: Overlay.overlay
-        anchors.centerIn: parent
-        modal: true
-        width: Math.min(Theme.scaled(380), parent ? parent.width * 0.9 : Theme.scaled(380))
-        standardButtons: Dialog.Save | Dialog.Cancel
-        contentItem: Text {
-            text: TranslationManager.translate("steam.confirmPitcherWeight",
-                "Store %1 g as the empty pitcher weight? Make sure the pitcher is empty (no milk).")
-                .arg(steamPage.pendingPitcherWeight.toFixed(1))
-            wrapMode: Text.WordWrap
-            color: Theme.textColor
-            font: Theme.bodyFont
-            padding: Theme.spacingLarge
-        }
-        onAccepted: Settings.brew.setSteamPitcherWeight(Settings.brew.selectedSteamPitcher, steamPage.pendingPitcherWeight)
     }
 
     function syncSteamTimeout() {
@@ -1681,86 +1659,6 @@ Page {
                             }
                             onValueCommitted: function(newValue) {
                                 MainController.setSteamTemperatureImmediate(newValue)
-                            }
-                        }
-                    }
-
-                    // Milk pitcher section: the empty-pitcher weight for the selected
-                    // preset. Shows the saved value and lets you adjust it (type or +/-).
-                    // Used to work out milk weight (scale - pitcher) and, when a preset
-                    // is calibrated, to scale the steam time. Re-weigh via the Weight
-                    // row's Save button below.
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: Theme.scaled(16)
-                        visible: !steamPage.currentPitcherDisabled
-
-                        Column {
-                            spacing: Theme.scaled(4)
-                            Tr {
-                                key: "steam.label.pitcherWeight"
-                                fallback: "Milk pitcher"
-                                color: Theme.textColor
-                                font.pixelSize: Theme.scaled(24)
-                                Accessible.ignored: true
-                            }
-                            Tr {
-                                key: "steam.hint.pitcherWeight"
-                                fallback: "Empty pitcher weight"
-                                color: Theme.textSecondaryColor
-                                font: Theme.labelFont
-                            }
-                        }
-
-                        Item { Layout.fillWidth: true }
-
-                        ValueInput {
-                            id: pitcherWeightInput
-                            Layout.preferredWidth: Theme.scaled(150)
-                            from: 0
-                            to: 1000
-                            stepSize: 0.1
-                            decimals: 1
-                            suffix: " g"
-                            value: {
-                                var _ = Settings.brew.steamPitcherPresets
-                                var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
-                                return preset ? (preset.pitcherWeightG ?? 0) : 0
-                            }
-                            valueColor: Theme.weightColor
-                            accessibleName: TranslationManager.translate("steam.label.pitcherWeight", "Milk pitcher weight")
-                            onValueModified: function(newValue) {
-                                Settings.brew.setSteamPitcherWeight(Settings.brew.selectedSteamPitcher, newValue)
-                            }
-                        }
-
-                        // Weigh the empty pitcher now on the scale.
-                        Rectangle {
-                            id: pitcherWeighBtn
-                            visible: ScaleDevice.connected && !ScaleDevice.isFlowScale
-                            readonly property bool btnEnabled: MachineState.scaleWeight > 0
-                            opacity: btnEnabled ? 1.0 : 0.4
-                            width: Theme.scaled(84); height: Theme.scaled(44)
-                            radius: Theme.cardRadius
-                            color: pitcherWeighMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
-                            Accessible.role: Accessible.Button
-                            Accessible.name: TranslationManager.translate("steam.accessible.weighPitcher", "Weigh empty pitcher from the scale")
-                            Accessible.focusable: true
-                            Accessible.onPressAction: pitcherWeighMa.clicked(null)
-                            Tr {
-                                anchors.centerIn: parent
-                                key: "steam.label.weigh"; fallback: "Weigh"
-                                color: Theme.primaryContrastColor; font: Theme.bodyFont
-                                Accessible.ignored: true
-                            }
-                            MouseArea {
-                                id: pitcherWeighMa
-                                anchors.fill: parent
-                                enabled: pitcherWeighBtn.btnEnabled
-                                onClicked: {
-                                    steamPage.pendingPitcherWeight = MachineState.scaleWeight
-                                    pitcherWeighConfirm.open()
-                                }
                             }
                         }
                     }

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -248,7 +248,7 @@ Page {
         if (calibMilk <= 0) return 0
         var milk = currentMeasuredMilk()
         if (milk <= 0) return 0
-        var scaled = Math.round(preset.duration * (milk / calibMilk))
+        var scaled = Math.round((preset.duration ?? 0) * (milk / calibMilk))
         return Math.max(5, Math.min(120, scaled))
     }
 
@@ -260,7 +260,7 @@ Page {
         if (!preset || preset.disabled) return 0
         var calibMilk = preset.calibMilkG ?? 0
         if (calibMilk <= 0 || milk <= 0) return 0
-        return Math.max(5, Math.min(120, Math.round(preset.duration * (milk / calibMilk))))
+        return Math.max(5, Math.min(120, Math.round((preset.duration ?? 0) * (milk / calibMilk))))
     }
 
     // Selected preset's reference milk weight (the baseline paired with its duration).
@@ -283,7 +283,10 @@ Page {
     property bool steamTimeoutScaled: false
     Connections {
         target: Settings.brew
-        function onSelectedSteamPitcherChanged() { steamPage.steamTimeoutScaled = false }
+        function onSelectedSteamPitcherChanged() {
+            steamPage.steamTimeoutScaled = false
+            steamPage.lastOnScaleMilk = 0   // captured net milk is pitcher-specific
+        }
     }
 
     // Net milk to scale against once the pitcher is off the scale: prefer the value
@@ -1539,8 +1542,7 @@ Page {
                         }
 
                         // Weigh the milk now on the scale and use it as the reference.
-                        // Works with a saved empty-pitcher weight, or a scale tared with
-                        // the empty pitcher (net milk = the raw reading).
+                        // Requires a saved empty-pitcher weight (net milk = scale - pitcher).
                         Rectangle {
                             id: refMilkWeighBtn
                             visible: ScaleDevice.connected && !ScaleDevice.isFlowScale

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -88,6 +88,21 @@ Page {
         }
     }
 
+    // Last net-milk reading while the pitcher rested on the scale this session, used to
+    // apply the weight-scaled steam time at steam-start even after the pitcher is lifted
+    // to the wand. Decoupled from the auto-capture's settle detector, whose virtual zero
+    // can fail to seed when the loaded pitcher never leaves the scale. Reset at session end.
+    property real lastOnScaleMilk: 0
+    Connections {
+        target: MachineState
+        function onScaleWeightChanged() {
+            if (!steamPage.isSteaming) {
+                var m = steamPage.currentMeasuredMilk()
+                if (m > 0) steamPage.lastOnScaleMilk = m
+            }
+        }
+    }
+
     // Reset state when steaming starts/ends
     onIsSteamingChanged: {
         console.log("SteamPage: isSteaming changed to", isSteaming, "phase=", MachineState.phase, "steamSoftStopped=", steamSoftStopped)
@@ -95,6 +110,19 @@ Page {
             wasSteaming = true
             steamSoftStopped = false
             _lastAnnouncedSteamWeight = 0
+            // Apply the weight-scaled steam time NOW, at steam-start, using the same direct
+            // calc as the "Expected steam time" readout (falling back to the last on-scale
+            // reading once the pitcher is lifted). The auto-capture can't be relied on here,
+            // so this is what actually makes the steam scale. setSteamTimeoutImmediate pushes
+            // it to the DE1 and takes effect even mid-steam.
+            var _scaledNow = steamPage.scaledSteamTimeout()
+            if (_scaledNow <= 0 && steamPage.lastOnScaleMilk > 0)
+                _scaledNow = steamPage.steamTimeForMilk(steamPage.lastOnScaleMilk)
+            if (_scaledNow > 0) {
+                Settings.brew.steamTimeout = _scaledNow
+                steamPage.steamTimeoutScaled = true
+                MainController.setSteamTimeoutImmediate(_scaledNow)
+            }
             // Drop any banner left over from a prior session so it doesn't
             // carry into the new one. SteamHealthTracker re-arms its per-session
             // latch at the first sample of the new session, so if the new
@@ -135,6 +163,7 @@ Page {
                 // duration here instead of reusing this session's scaled time
                 // (otherwise a small pour after a large one would over-steam).
                 steamPage.steamTimeoutScaled = false
+                steamPage.lastOnScaleMilk = 0
                 steamPage.syncSteamTimeout()
                 Settings.brew.steamFlow = getCurrentPitcherFlow()
                 if (!Settings.brew.keepSteamHeaterOn) {

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -116,8 +116,10 @@ Page {
             // so this is what actually makes the steam scale. setSteamTimeoutImmediate pushes
             // it to the DE1 and takes effect even mid-steam.
             var _scaledNow = steamPage.scaledSteamTimeout()
-            if (_scaledNow <= 0 && steamPage.lastOnScaleMilk > 0)
-                _scaledNow = steamPage.steamTimeForMilk(steamPage.lastOnScaleMilk)
+            if (_scaledNow <= 0) {
+                var _cm = steamPage.capturedMilkForScaling()
+                if (_cm > 0) _scaledNow = steamPage.steamTimeForMilk(_cm)
+            }
             if (_scaledNow > 0) {
                 Settings.brew.steamTimeout = _scaledNow
                 steamPage.steamTimeoutScaled = true
@@ -284,8 +286,21 @@ Page {
         function onSelectedSteamPitcherChanged() { steamPage.steamTimeoutScaled = false }
     }
 
+    // Net milk to scale against once the pitcher is off the scale: prefer the value
+    // captured THIS session (set by the home-screen OR steam auto-capture, shared via the
+    // window) and fall back to the last reading seen on the steam page. 0 = none yet.
+    function capturedMilkForScaling() {
+        if (typeof Window !== "undefined" && Window.window && Window.window.sessionMeasuredMilkG > 0)
+            return Window.window.sessionMeasuredMilkG
+        return steamPage.lastOnScaleMilk
+    }
+
     function syncSteamTimeout() {
         var live = scaledSteamTimeout()
+        if (live <= 0) {
+            var cap = capturedMilkForScaling()   // pitcher lifted: use the captured milk
+            if (cap > 0) live = steamTimeForMilk(cap)
+        }
         if (live > 0) {
             Settings.brew.steamTimeout = live
             steamPage.steamTimeoutScaled = true

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -1956,6 +1956,10 @@ Page {
             if (t <= 0)
                 return  // preset not calibrated (no reference milk) — nothing to lock
             Settings.brew.steamTimeout = t
+            // Push to the DE1 now (same as onPresetSelected) — without this the machine
+            // keeps its last-sent timeout, so a GHC-started steam wouldn't use the
+            // scaled value and the steam time appears not to scale.
+            MainController.applySteamSettings()
             steamPage.steamTimeoutScaled = true
             steamPage.captureBannerText =
                 TranslationManager.translate("steam.capture.locked", "Steam time set: %1s for %2g milk")

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -1517,7 +1517,8 @@ Page {
                         }
 
                         // Weigh the milk now on the scale and use it as the reference.
-                        // Needs the empty-pitcher weight set (so net milk is known).
+                        // Works with a saved empty-pitcher weight, or a scale tared with
+                        // the empty pitcher (net milk = the raw reading).
                         Rectangle {
                             id: refMilkWeighBtn
                             visible: ScaleDevice.connected && !ScaleDevice.isFlowScale

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Effects
+import QtQuick.Window
 import Decenza
 import "../components"
 
@@ -31,7 +32,7 @@ Page {
                 MainController.turnOffSteamHeater()
             } else {
                 // Sync Settings with selected preset
-                Settings.brew.steamTimeout = getCurrentPitcherDuration()
+                steamPage.syncSteamTimeout()
                 Settings.brew.steamFlow = getCurrentPitcherFlow()
                 // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
                 // startSteamHeating clears steamDisabled flag automatically
@@ -128,7 +129,13 @@ Page {
                 // onStateChanged->startSteamHeating picks it up and writes it
                 // (the DE1's commanded state between sessions is idle anyway,
                 // so the lag is invisible).
-                Settings.brew.steamTimeout = getCurrentPitcherDuration()
+                //
+                // A fresh capture is required for the next session — clear the
+                // scaled flag so syncSteamTimeout() falls back to the preset
+                // duration here instead of reusing this session's scaled time
+                // (otherwise a small pour after a large one would over-steam).
+                steamPage.steamTimeoutScaled = false
+                steamPage.syncSteamTimeout()
                 Settings.brew.steamFlow = getCurrentPitcherFlow()
                 if (!Settings.brew.keepSteamHeaterOn) {
                     console.log("SteamPage: Turning off steam heater (keepSteamHeaterOn=false)")
@@ -181,6 +188,104 @@ Page {
         if (name && !isCurrentPitcherDisabled()) {
             Settings.brew.updateSteamPitcherPreset(Settings.brew.selectedSteamPitcher, name, duration, flow)
         }
+    }
+
+    // --- Weight-scaled steaming (calibrated presets) -------------------------
+    // Milk now on the scale = (pitcher + milk) minus the saved empty-pitcher
+    // weight. Returns 0 unless a sane amount of milk is actually on the scale.
+    function currentMeasuredMilk() {
+        if (!ScaleDevice.connected) return 0
+        var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        if (!preset || preset.disabled) return 0
+        var pitcherWt = preset.pitcherWeightG ?? 0
+        // If an empty-pitcher weight is saved, net milk = scale - pitcher.
+        // Otherwise assume the user tared the scale with the empty pitcher, so
+        // the live reading is already net milk.
+        var milk = pitcherWt > 0 ? (MachineState.scaleWeight - pitcherWt)
+                                 : MachineState.scaleWeight
+        return (milk >= 20 && milk <= 1500) ? milk : 0
+    }
+
+    // If this preset is calibrated (a reference milk weight is paired with its
+    // duration) and milk is on the scale, return the duration scaled to the
+    // actual milk weight. Returns 0 when scaling doesn't apply, so callers fall
+    // back to the preset's fixed duration.
+    function scaledSteamTimeout() {
+        var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        if (!preset || preset.disabled) return 0
+        var calibMilk = preset.calibMilkG ?? 0
+        if (calibMilk <= 0) return 0
+        var milk = currentMeasuredMilk()
+        if (milk <= 0) return 0
+        var scaled = Math.round(preset.duration * (milk / calibMilk))
+        return Math.max(5, Math.min(120, scaled))
+    }
+
+    // Steam time (s) for a specific captured milk weight, using the selected
+    // preset's reference-milk -> duration baseline. Returns 0 when the preset
+    // isn't calibrated (no reference milk set).
+    function steamTimeForMilk(milk) {
+        var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        if (!preset || preset.disabled) return 0
+        var calibMilk = preset.calibMilkG ?? 0
+        if (calibMilk <= 0 || milk <= 0) return 0
+        return Math.max(5, Math.min(120, Math.round(preset.duration * (milk / calibMilk))))
+    }
+
+    // Selected preset's reference milk weight (the baseline paired with its duration).
+    function getCurrentPitcherCalibMilk() {
+        var _ = Settings.brew.steamPitcherPresets  // track changes so the field refreshes after Weigh
+        var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        return (preset && !preset.disabled) ? (preset.calibMilkG ?? 0) : 0
+    }
+
+    // Sync steamTimeout to the selected preset WITHOUT clobbering a weight-scaled
+    // value. If milk is on the scale now, use the scaled time. If the preset is
+    // calibrated but milk isn't on the scale (e.g. lifted to the wand / arriving
+    // from the home-screen steam flow), keep the current steamTimeout — it was
+    // already scaled from the measured milk. Only fall back to the fixed reference
+    // duration when the preset isn't calibrated.
+    // True once a milk capture has scaled steamTimeout for the CURRENT pitcher
+    // selection. syncSteamTimeout() preserves that scaled value while the pitcher
+    // is lifted to the wand, but a stale value (e.g. after switching pitcher) is
+    // dropped back to the preset's baseline duration instead of being reused.
+    property bool steamTimeoutScaled: false
+    Connections {
+        target: Settings.brew
+        function onSelectedSteamPitcherChanged() { steamPage.steamTimeoutScaled = false }
+    }
+
+    // Confirm before storing the empty-pitcher weight (footgun: weighing a pitcher
+    // that still has milk in it would skew every net-milk reading thereafter).
+    property real pendingPitcherWeight: 0
+    Dialog {
+        id: pitcherWeighConfirm
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        modal: true
+        width: Math.min(Theme.scaled(380), parent ? parent.width * 0.9 : Theme.scaled(380))
+        standardButtons: Dialog.Save | Dialog.Cancel
+        contentItem: Text {
+            text: TranslationManager.translate("steam.confirmPitcherWeight",
+                "Store %1 g as the empty pitcher weight? Make sure the pitcher is empty (no milk).")
+                .arg(steamPage.pendingPitcherWeight.toFixed(1))
+            wrapMode: Text.WordWrap
+            color: Theme.textColor
+            font: Theme.bodyFont
+            padding: Theme.spacingLarge
+        }
+        onAccepted: Settings.brew.setSteamPitcherWeight(Settings.brew.selectedSteamPitcher, steamPage.pendingPitcherWeight)
+    }
+
+    function syncSteamTimeout() {
+        var live = scaledSteamTimeout()
+        if (live > 0) {
+            Settings.brew.steamTimeout = live
+            steamPage.steamTimeoutScaled = true
+        } else if (getCurrentPitcherCalibMilk() <= 0 || !steamPage.steamTimeoutScaled) {
+            Settings.brew.steamTimeout = getCurrentPitcherDuration()
+        }
+        // else: calibrated AND scaled for this selection, pitcher just lifted -> keep it
     }
 
     // Steam view mode: "timer" (default) or "chart"
@@ -417,7 +522,11 @@ Page {
                                         return
                                     }
                                     var flow = modelData.flow !== undefined ? modelData.flow : 150
-                                    Settings.brew.steamTimeout = modelData.duration
+                                    // Compute the (weight-scaled) target ONCE and use it for both the
+                                    // persisted Settings value and the value pushed to the DE1, so the
+                                    // UI countdown target and the firmware TargetSteamLength agree.
+                                    var targetTimeout = scaledSteamTimeout() > 0 ? scaledSteamTimeout() : modelData.duration
+                                    Settings.brew.steamTimeout = targetTimeout
                                     Settings.brew.steamFlow = flow
                                     if (!isSteaming) {
                                         MainController.startSteamHeating("live-pitcher-click")
@@ -439,7 +548,7 @@ Page {
                                         // than elapsed, the DE1 firmware will end the session,
                                         // which is the user's intent when picking a smaller
                                         // preset.
-                                        MainController.setSteamTimeoutImmediate(modelData.duration)
+                                        MainController.setSteamTimeoutImmediate(targetTimeout)
                                         MainController.setSteamFlowImmediate(flow)
                                     }
                                 }
@@ -683,6 +792,28 @@ Page {
                         radius: Theme.scaled(4)
                         color: isSteamHeating ? Theme.warningColor : (isPuffing ? Theme.secondaryColor : Theme.primaryColor)
                     }
+                }
+
+                // Purge button on the live steaming view — stops steam and triggers
+                // the DE1 steam-wand purge.
+                Rectangle {
+                    visible: isSteaming
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    width: Theme.scaled(150)
+                    height: Theme.scaled(48)
+                    radius: Theme.buttonRadius
+                    color: livePurgeMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                    Accessible.role: Accessible.Button
+                    Accessible.name: TranslationManager.translate("steam.accessible.purge", "Purge the steam wand")
+                    Accessible.focusable: true
+                    Accessible.onPressAction: livePurgeMa.clicked(null)
+                    Tr {
+                        anchors.centerIn: parent
+                        key: "steam.label.purge"; fallback: "Purge"
+                        color: Theme.primaryContrastColor; font: Theme.bodyFont
+                        Accessible.ignored: true
+                    }
+                    MouseArea { id: livePurgeMa; anchors.fill: parent; onClicked: DE1Device.requestIdle() }
                 }
             }
 
@@ -993,7 +1124,7 @@ Page {
                                         var flow = modelData.flow !== undefined ? modelData.flow : 150
                                         durationSlider.value = modelData.duration
                                         flowSlider.value = flow
-                                        Settings.brew.steamTimeout = modelData.duration
+                                        Settings.brew.steamTimeout = scaledSteamTimeout() > 0 ? scaledSteamTimeout() : modelData.duration
                                         Settings.brew.steamFlow = flow
                                         MainController.startSteamHeating(reason)
                                     }
@@ -1192,9 +1323,20 @@ Page {
                 color: Theme.surfaceColor
                 radius: Theme.cardRadius
 
-                ColumnLayout {
+                Flickable {
+                    id: editorFlick
                     anchors.fill: parent
                     anchors.margins: Theme.scaled(16)
+                    contentWidth: width
+                    contentHeight: editorColumn.implicitHeight
+                    clip: true
+                    boundsBehavior: Flickable.StopAtBounds
+                    flickableDirection: Flickable.VerticalFlick
+                    ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+                ColumnLayout {
+                    id: editorColumn
+                    width: editorFlick.width
                     spacing: Theme.scaled(8)
 
                     // Centered placeholder when the selected preset is an "Off" pill —
@@ -1203,7 +1345,7 @@ Page {
                     Item {
                         visible: steamPage.currentPitcherDisabled
                         Layout.fillWidth: true
-                        Layout.fillHeight: true
+                        Layout.preferredHeight: Theme.scaled(160)
 
                         Tr {
                             anchors.centerIn: parent
@@ -1214,6 +1356,32 @@ Page {
                             horizontalAlignment: Text.AlignHCenter
                         }
                     }
+
+                    // Purge: clear water / condensation from the steam wand.
+                    RowLayout {
+                        Layout.fillWidth: true
+                        visible: !steamPage.currentPitcherDisabled
+                        Item { Layout.fillWidth: true }
+                        Rectangle {
+                            Layout.preferredWidth: Theme.scaled(150)
+                            Layout.preferredHeight: Theme.scaled(48)
+                            radius: Theme.buttonRadius
+                            color: purgeMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                            Accessible.role: Accessible.Button
+                            Accessible.name: TranslationManager.translate("steam.accessible.purge", "Purge the steam wand")
+                            Accessible.focusable: true
+                            Accessible.onPressAction: purgeMa.clicked(null)
+                            Tr {
+                                anchors.centerIn: parent
+                                key: "steam.label.purge"; fallback: "Purge"
+                                color: Theme.primaryContrastColor; font: Theme.bodyFont
+                                Accessible.ignored: true
+                            }
+                            MouseArea { id: purgeMa; anchors.fill: parent; onClicked: DE1Device.requestIdle() }
+                        }
+                    }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
 
                     // Duration (per-pitcher, auto-saves)
                     RowLayout {
@@ -1301,6 +1469,176 @@ Page {
 
                     Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
 
+                    // Reference milk weight: the baseline paired with this preset's
+                    // duration for weight-timed steaming. steamTime = duration ×
+                    // (measuredMilk / referenceMilk). 0 disables weight scaling.
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(16)
+                        visible: !steamPage.currentPitcherDisabled
+
+                        Column {
+                            Tr {
+                                key: "steam.label.referenceMilk"
+                                fallback: "Reference milk"
+                                color: Theme.textColor
+                                font.pixelSize: Theme.scaled(24)
+                            }
+                            Tr {
+                                key: "steam.hint.referenceMilk"
+                                fallback: "0 = off. Steam time scales with milk weight."
+                                color: Theme.textSecondaryColor
+                                font: Theme.labelFont
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        ValueInput {
+                            id: refMilkInput
+                            Layout.preferredWidth: Theme.scaled(150)
+                            from: 0
+                            to: 1500
+                            stepSize: 0.1
+                            decimals: 1
+                            suffix: " g"
+                            value: getCurrentPitcherCalibMilk()
+                            valueColor: Theme.primaryColor
+                            accessibleName: TranslationManager.translate("steam.label.referenceMilk", "Reference milk weight")
+                            KeyNavigation.tab: steamTempSlider
+                            KeyNavigation.backtab: flowSlider
+                            onValueModified: function(newValue) {
+                                // Don't reassign value here — it would break the declarative
+                                // binding to getCurrentPitcherCalibMilk(), so a later "Use as
+                                // baseline"/Weigh update wouldn't refresh the field. The setter
+                                // writes through and the reactive getter re-evaluates the binding.
+                                Settings.brew.setSteamPitcherCalibration(Settings.brew.selectedSteamPitcher, newValue)
+                            }
+                        }
+
+                        // Weigh the milk now on the scale and use it as the reference.
+                        // Needs the empty-pitcher weight set (so net milk is known).
+                        Rectangle {
+                            id: refMilkWeighBtn
+                            visible: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                            readonly property bool btnEnabled: steamPage.currentMeasuredMilk() > 0
+                            opacity: btnEnabled ? 1.0 : 0.4
+                            width: Theme.scaled(84); height: Theme.scaled(44)
+                            radius: Theme.cardRadius
+                            color: refMilkWeighMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                            Accessible.role: Accessible.Button
+                            Accessible.name: TranslationManager.translate("steam.accessible.setRefMilk", "Set reference milk from the scale")
+                            Accessible.focusable: true
+                            Accessible.onPressAction: refMilkWeighMa.clicked(null)
+                            Tr {
+                                anchors.centerIn: parent
+                                key: "steam.label.weigh"; fallback: "Weigh"
+                                color: Theme.primaryContrastColor; font: Theme.bodyFont
+                                Accessible.ignored: true
+                            }
+                            MouseArea {
+                                id: refMilkWeighMa
+                                anchors.fill: parent
+                                enabled: refMilkWeighBtn.btnEnabled
+                                onClicked: Settings.brew.setSteamPitcherCalibration(
+                                    Settings.brew.selectedSteamPitcher, steamPage.currentMeasuredMilk())
+                            }
+                        }
+                    }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
+
+                    // Adopt the last actual steam session (milk + time) as this
+                    // pitcher's reference baseline — sets reference milk AND duration.
+                    RowLayout {
+                        id: useLastSteamRow
+                        Layout.fillWidth: true
+                        visible: !steamPage.currentPitcherDisabled
+                        spacing: Theme.scaled(12)
+                        readonly property bool hasLast: Settings.brew.lastSteamMilkG > 0 && Settings.brew.lastSteamTimeS > 0
+
+                        Column {
+                            Tr {
+                                key: "steam.lastSteam.title"
+                                fallback: "Baseline from last steam"
+                                color: Theme.textColor
+                                font.pixelSize: Theme.scaled(20)
+                            }
+                            Text {
+                                text: useLastSteamRow.hasLast
+                                      ? TranslationManager.translate("steam.lastSteam.values", "Last: %1 g milk → %2 s")
+                                            .arg(Settings.brew.lastSteamMilkG.toFixed(0)).arg(Math.round(Settings.brew.lastSteamTimeS))
+                                      : TranslationManager.translate("steam.lastSteam.none", "Steam some milk first to record a session.")
+                                color: Theme.textSecondaryColor
+                                font: Theme.labelFont
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        AccessibleButton {
+                            Layout.preferredHeight: Theme.scaled(44)
+                            text: TranslationManager.translate("steam.lastSteam.use", "Use as baseline")
+                            accessibleName: TranslationManager.translate("steam.lastSteam.useAccessible", "Use last steam session as this pitcher's reference baseline")
+                            primary: true
+                            enabled: useLastSteamRow.hasLast
+                            onClicked: {
+                                var idx = Settings.brew.selectedSteamPitcher
+                                var p = Settings.brew.getSteamPitcherPreset(idx)
+                                if (!p || p.disabled) return
+                                Settings.brew.updateSteamPitcherPreset(idx, p.name, Math.round(Settings.brew.lastSteamTimeS), p.flow ?? 150)
+                                Settings.brew.setSteamPitcherCalibration(idx, Settings.brew.lastSteamMilkG)
+                            }
+                        }
+                    }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
+
+                    // Live expected steam time for the milk currently on the scale
+                    // (only when the preset is calibrated and milk is present).
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(16)
+                        visible: !steamPage.currentPitcherDisabled
+                                 && ScaleDevice.connected && !ScaleDevice.isFlowScale
+                                 && steamPage.scaledSteamTimeout() > 0
+
+                        Column {
+                            Tr {
+                                key: "steam.label.expectedSteamTime"
+                                fallback: "Expected steam time"
+                                color: Theme.textColor
+                                font.pixelSize: Theme.scaled(24)
+                            }
+                            Text {
+                                text: TranslationManager.translate("steam.hint.forMilkOnScale", "for %1 g milk on scale").arg(steamPage.currentMeasuredMilk().toFixed(0))
+                                color: Theme.textSecondaryColor
+                                font: Theme.labelFont
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        Text {
+                            text: steamPage.scaledSteamTimeout() + " s"
+                            color: Theme.primaryColor
+                            font.pixelSize: Theme.scaled(28)
+                            font.bold: true
+                        }
+                    }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled && ScaleDevice.connected && !ScaleDevice.isFlowScale && steamPage.scaledSteamTimeout() > 0 }
+
+                    // Auto-capture options (opt-in; default on). Turning this off
+                    // stops the scale from auto-scaling the steam time from milk weight.
+                    StyledSwitch {
+                        Layout.fillWidth: true
+                        text: TranslationManager.translate("steam.autoCaptureMilk", "Auto-capture milk weight")
+                        accessibleName: text
+                        checked: Settings.brew.milkAutoCaptureEnabled
+                        onToggled: Settings.brew.milkAutoCaptureEnabled = checked
+                    }
+
                     // Temperature (global setting)
                     RowLayout {
                         Layout.fillWidth: true
@@ -1346,6 +1684,86 @@ Page {
                         }
                     }
 
+                    // Milk pitcher section: the empty-pitcher weight for the selected
+                    // preset. Shows the saved value and lets you adjust it (type or +/-).
+                    // Used to work out milk weight (scale - pitcher) and, when a preset
+                    // is calibrated, to scale the steam time. Re-weigh via the Weight
+                    // row's Save button below.
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(16)
+                        visible: !steamPage.currentPitcherDisabled
+
+                        Column {
+                            spacing: Theme.scaled(4)
+                            Tr {
+                                key: "steam.label.pitcherWeight"
+                                fallback: "Milk pitcher"
+                                color: Theme.textColor
+                                font.pixelSize: Theme.scaled(24)
+                                Accessible.ignored: true
+                            }
+                            Tr {
+                                key: "steam.hint.pitcherWeight"
+                                fallback: "Empty pitcher weight"
+                                color: Theme.textSecondaryColor
+                                font: Theme.labelFont
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        ValueInput {
+                            id: pitcherWeightInput
+                            Layout.preferredWidth: Theme.scaled(150)
+                            from: 0
+                            to: 1000
+                            stepSize: 0.1
+                            decimals: 1
+                            suffix: " g"
+                            value: {
+                                var _ = Settings.brew.steamPitcherPresets
+                                var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+                                return preset ? (preset.pitcherWeightG ?? 0) : 0
+                            }
+                            valueColor: Theme.weightColor
+                            accessibleName: TranslationManager.translate("steam.label.pitcherWeight", "Milk pitcher weight")
+                            onValueModified: function(newValue) {
+                                Settings.brew.setSteamPitcherWeight(Settings.brew.selectedSteamPitcher, newValue)
+                            }
+                        }
+
+                        // Weigh the empty pitcher now on the scale.
+                        Rectangle {
+                            id: pitcherWeighBtn
+                            visible: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                            readonly property bool btnEnabled: MachineState.scaleWeight > 0
+                            opacity: btnEnabled ? 1.0 : 0.4
+                            width: Theme.scaled(84); height: Theme.scaled(44)
+                            radius: Theme.cardRadius
+                            color: pitcherWeighMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                            Accessible.role: Accessible.Button
+                            Accessible.name: TranslationManager.translate("steam.accessible.weighPitcher", "Weigh empty pitcher from the scale")
+                            Accessible.focusable: true
+                            Accessible.onPressAction: pitcherWeighMa.clicked(null)
+                            Tr {
+                                anchors.centerIn: parent
+                                key: "steam.label.weigh"; fallback: "Weigh"
+                                color: Theme.primaryContrastColor; font: Theme.bodyFont
+                                Accessible.ignored: true
+                            }
+                            MouseArea {
+                                id: pitcherWeighMa
+                                anchors.fill: parent
+                                enabled: pitcherWeighBtn.btnEnabled
+                                onClicked: {
+                                    steamPage.pendingPitcherWeight = MachineState.scaleWeight
+                                    pitcherWeighConfirm.open()
+                                }
+                            }
+                        }
+                    }
+
                     Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
 
                     // Weight — pitcher tare calibration per preset
@@ -1374,6 +1792,20 @@ Page {
                                     if (saved > 0)
                                         return TranslationManager.translate("steam.hint.pitcherWeightSaved", "Pitcher") + ": " + saved.toFixed(0) + "g"
                                     return TranslationManager.translate("steam.hint.pitcherWeightNone", "No pitcher weight saved")
+                                }
+                                Accessible.ignored: true
+                            }
+                            Text {
+                                color: Theme.textSecondaryColor
+                                font: Theme.labelFont
+                                visible: text.length > 0
+                                text: {
+                                    var _ = Settings.brew.steamPitcherPresets
+                                    var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+                                    var cal = preset ? (preset.calibMilkG ?? 0) : 0
+                                    if (cal > 0)
+                                        return TranslationManager.translate("steam.hint.weightTimed", "Weight-timed") + ": " + cal.toFixed(0) + "g → " + preset.duration + "s"
+                                    return ""
                                 }
                                 Accessible.ignored: true
                             }
@@ -1474,15 +1906,126 @@ Page {
                                     }
                                 }
                             }
+
+                            // (Weight-timed calibration is now set explicitly via the
+                            // "Reference milk" field in the editor rows above, rather than
+                            // a live Calibrate button.)
                         }
                     }
 
-                    Item { Layout.fillHeight: true }
+                }
                 }
             }
         }
 
         Item { Layout.fillHeight: true; visible: isSteaming || steamSoftStopped }
+    }
+
+    // Weight-timed steaming: auto-capture the milk weight while it rests on the
+    // scale (before steaming). When the net milk holds steady ~2.5s, lock the
+    // steam time proportional to it, ding, and show a confirmation. The value
+    // stays locked while you lift the pitcher to steam (the detector re-arms only
+    // when the pitcher is removed or the load changes). This is a programmatic
+    // write to steamTimeout, so it never bakes the scaled value into the preset.
+    StableWeightCapture {
+        id: milkCapture
+        // Virtual-zero model: raw scale reading minus the saved empty-pitcher weight
+        // (cupWeight) = net milk, robust to an un-zeroed scale. Auto-capture requires
+        // a saved pitcher weight (cupWeight > 0).
+        rawWeight: (ScaleDevice.connected && !ScaleDevice.isFlowScale) ? MachineState.scaleWeight : 0
+        cupWeight: {
+            var p = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+            return (p && !p.disabled) ? (p.pitcherWeightG ?? 0) : 0
+        }
+        // Opt-in (Settings.brew.milkAutoCaptureEnabled, default on) — disabling it
+        // stops the scale from auto-changing the steam stop time.
+        active: Settings.brew.milkAutoCaptureEnabled
+                && !isSteaming && !steamSoftStopped
+                && ScaleDevice.connected && !ScaleDevice.isFlowScale
+        minNet: 20
+        maxNet: 1500
+        tolerance: 1.5
+        stableMs: 2500
+        onStableCaptured: function(milk) {
+            // Latch the measured milk for the baseline pair (committed atomically with
+            // the duration at session end, in main.qml) — recorded even when the preset
+            // isn't calibrated yet so the calibration-bootstrap steam can be adopted.
+            if (Window.window) Window.window.sessionMeasuredMilkG = milk
+            var t = steamPage.steamTimeForMilk(milk)
+            if (t <= 0)
+                return  // preset not calibrated (no reference milk) — nothing to lock
+            Settings.brew.steamTimeout = t
+            steamPage.steamTimeoutScaled = true
+            steamPage.captureBannerText =
+                TranslationManager.translate("steam.capture.locked", "Steam time set: %1s for %2g milk")
+                    .arg(t).arg(milk.toFixed(0))
+            steamPage.captureBannerVisible = true
+            captureBannerTimer.restart()
+            if (typeof AccessibilityManager !== "undefined") {
+                if (Settings.brew.doseCaptureSoundEnabled)
+                    AccessibilityManager.playCaptureDing()
+                if (AccessibilityManager.enabled)
+                    AccessibilityManager.announce(steamPage.captureBannerText)
+            }
+        }
+    }
+    // Re-zero the milk capture when the scale is tared (so the old offset isn't
+    // double-counted by the virtual-zero baseline).
+    Connections {
+        target: MachineState
+        function onTareCompleted() { milkCapture.reset() }
+    }
+
+    // Confirmation banner shown briefly after a milk-weight capture (auto-dismiss).
+    property string captureBannerText: ""
+    property bool   captureBannerVisible: false
+    Timer { id: captureBannerTimer; interval: 3500; onTriggered: steamPage.captureBannerVisible = false }
+
+    Rectangle {
+        visible: steamPage.captureBannerVisible
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: Theme.scaled(12)
+        z: 1000
+        width: bannerLabel.implicitWidth + Theme.scaled(32)
+        height: bannerLabel.implicitHeight + Theme.scaled(20)
+        radius: Theme.cardRadius
+        color: Theme.primaryColor
+        opacity: steamPage.captureBannerVisible ? 1.0 : 0.0
+        Behavior on opacity { NumberAnimation { duration: 180 } }
+        Text {
+            id: bannerLabel
+            anchors.centerIn: parent
+            text: steamPage.captureBannerText
+            color: Theme.primaryContrastColor
+            font: Theme.bodyFont
+        }
+    }
+
+    // Small flashing reminder while the milk pitcher is settling on the scale
+    // (something is on the scale but the capture hasn't fired yet). Disappears
+    // the instant it captures (the bell rings).
+    Text {
+        id: steamWaitForBellHint
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: Theme.scaled(70)
+        z: 1000
+        horizontalAlignment: Text.AlignHCenter
+        visible: milkCapture.active && !milkCapture.isCaptured
+                 && milkCapture.cupWeight > 0
+                 && milkCapture.loadPresent
+                 && milkCapture.netWeight >= milkCapture.minNet
+                 && milkCapture.netWeight <= milkCapture.maxNet
+        text: TranslationManager.translate("scale.waitForBell", "Wait for the bell before you take it off the scale")
+        color: Theme.warningColor
+        font: Theme.labelFont
+        SequentialAnimation on opacity {
+            running: steamWaitForBellHint.visible
+            loops: Animation.Infinite
+            NumberAnimation { to: 0.25; duration: 450 }
+            NumberAnimation { to: 1.0; duration: 450 }
+        }
     }
 
     // Accessibility: announce scale weight at intervals while weighing milk (settings view, not steaming)

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -126,10 +126,41 @@ void SettingsBrew::setDoseCupTareWeight(double weight) {
     }
 }
 
+bool SettingsBrew::milkAutoCaptureEnabled() const {
+    return m_settings.value("steam/milkAutoCaptureEnabled", true).toBool();
+}
+void SettingsBrew::setMilkAutoCaptureEnabled(bool enabled) {
+    if (milkAutoCaptureEnabled() != enabled) {
+        m_settings.setValue("steam/milkAutoCaptureEnabled", enabled);
+        emit milkAutoCaptureEnabledChanged();
+    }
+}
+
+double SettingsBrew::lastSteamMilkG() const {
+    return m_settings.value("steam/lastSteamMilkG", 0.0).toDouble();
+}
+void SettingsBrew::setLastSteamMilkG(double g) {
+    if (g < 0) g = 0;
+    if (lastSteamMilkG() != g) {
+        m_settings.setValue("steam/lastSteamMilkG", g);
+        emit lastSteamMilkGChanged();
+    }
+}
+
+double SettingsBrew::lastSteamTimeS() const {
+    return m_settings.value("steam/lastSteamTimeS", 0.0).toDouble();
+}
+void SettingsBrew::setLastSteamTimeS(double s) {
+    if (s < 0) s = 0;
+    if (lastSteamTimeS() != s) {
+        m_settings.setValue("steam/lastSteamTimeS", s);
+        emit lastSteamTimeSChanged();
+    }
+}
+
 bool SettingsBrew::doseCaptureSoundEnabled() const {
     return m_settings.value("espresso/doseCaptureSoundEnabled", false).toBool();
 }
-
 void SettingsBrew::setDoseCaptureSoundEnabled(bool enabled) {
     if (doseCaptureSoundEnabled() != enabled) {
         m_settings.setValue("espresso/doseCaptureSoundEnabled", enabled);
@@ -326,6 +357,24 @@ void SettingsBrew::setSteamPitcherWeight(int index, double weightG) {
     if (index >= 0 && index < static_cast<int>(arr.size())) {
         QJsonObject preset = arr[index].toObject();
         preset["pitcherWeightG"] = weightG;
+        arr[index] = preset;
+        m_settings.setValue("steam/pitcherPresets", QJsonDocument(arr).toJson());
+        emit steamPitcherPresetsChanged();
+    }
+}
+
+void SettingsBrew::setSteamPitcherCalibration(int index, double calibMilkG) {
+    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
+    QJsonDocument doc = QJsonDocument::fromJson(data);
+    QJsonArray arr = doc.array();
+
+    if (index >= 0 && index < static_cast<int>(arr.size())) {
+        QJsonObject preset = arr[index].toObject();
+        if (calibMilkG > 0) {
+            preset["calibMilkG"] = calibMilkG;
+        } else {
+            preset.remove("calibMilkG");  // 0 / negative clears the calibration
+        }
         arr[index] = preset;
         m_settings.setValue("steam/pitcherPresets", QJsonDocument(arr).toJson());
         emit steamPitcherPresetsChanged();

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -94,7 +94,6 @@ public:
     bool doseCaptureSoundEnabled() const;
     void setDoseCaptureSoundEnabled(bool enabled);
 
-
     double lastSteamMilkG() const;
     void setLastSteamMilkG(double g);
     double lastSteamTimeS() const;

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -19,9 +19,16 @@ class SettingsBrew : public QObject {
     // Dose cup tare: empty weight of the dosing vessel, subtracted from the scale
     // reading in "Get from scale" so the dose is net beans. Default 0 = no tare.
     Q_PROPERTY(double doseCupTareWeight READ doseCupTareWeight WRITE setDoseCupTareWeight NOTIFY doseCupTareWeightChanged)
-    // Whether the confirmation "ding" plays when a bean dose auto-captures. Default
-    // off — not everyone wants the sound; toggled by the bell on the Dose cup row.
+    // Auto-capture of the milk weight on the steam page / steam flow. Optional and
+    // disableable; when off, steam time is never changed automatically. Default on.
+    Q_PROPERTY(bool milkAutoCaptureEnabled READ milkAutoCaptureEnabled WRITE setMilkAutoCaptureEnabled NOTIFY milkAutoCaptureEnabledChanged)
+    // Whether the confirmation "ding" plays when a dose/milk auto-captures. Default
+    // off — toggled by the bell on the Dose cup row.
     Q_PROPERTY(bool doseCaptureSoundEnabled READ doseCaptureSoundEnabled WRITE setDoseCaptureSoundEnabled NOTIFY doseCaptureSoundEnabledChanged)
+    // Last actual steam session (milk weight + steam time), saved so the steam
+    // setup can adopt them as a new reference baseline.
+    Q_PROPERTY(double lastSteamMilkG READ lastSteamMilkG WRITE setLastSteamMilkG NOTIFY lastSteamMilkGChanged)
+    Q_PROPERTY(double lastSteamTimeS READ lastSteamTimeS WRITE setLastSteamTimeS NOTIFY lastSteamTimeSChanged)
 
     // Steam
     Q_PROPERTY(double steamTemperature READ steamTemperature WRITE setSteamTemperature NOTIFY steamTemperatureChanged)
@@ -82,8 +89,16 @@ public:
     double doseCupTareWeight() const;
     void setDoseCupTareWeight(double weight);
 
+    bool milkAutoCaptureEnabled() const;
+    void setMilkAutoCaptureEnabled(bool enabled);
     bool doseCaptureSoundEnabled() const;
     void setDoseCaptureSoundEnabled(bool enabled);
+
+
+    double lastSteamMilkG() const;
+    void setLastSteamMilkG(double g);
+    double lastSteamTimeS() const;
+    void setLastSteamTimeS(double s);
 
     // Steam
     double steamTemperature() const;
@@ -116,6 +131,9 @@ public:
     Q_INVOKABLE void moveSteamPitcherPreset(int from, int to);
     Q_INVOKABLE QVariantMap getSteamPitcherPreset(int index) const;
     Q_INVOKABLE void setSteamPitcherWeight(int index, double weightG);
+    // Weight-scaled steaming: pair a reference milk weight with this preset's
+    // duration. At steam time the duration is scaled by the actual milk weight.
+    Q_INVOKABLE void setSteamPitcherCalibration(int index, double calibMilkG);
 
     // Hot water
     double waterTemperature() const;
@@ -189,7 +207,10 @@ signals:
     void targetWeightChanged();
     void lastUsedRatioChanged();
     void doseCupTareWeightChanged();
+    void milkAutoCaptureEnabledChanged();
     void doseCaptureSoundEnabledChanged();
+    void lastSteamMilkGChanged();
+    void lastSteamTimeSChanged();
     void steamTemperatureChanged();
     void steamTimeoutChanged();
     void steamFlowChanged();

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -420,7 +420,6 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         if (steam.contains("disabled")) settings->brew()->setSteamDisabled(steam["disabled"].toBool());
         if (steam.contains("autoFlushSeconds")) settings->brew()->setSteamAutoFlushSeconds(steam["autoFlushSeconds"].toInt());
         if (steam.contains("twoTapStop")) settings->hardware()->setSteamTwoTapStop(steam["twoTapStop"].toBool());
-        if (steam.contains("selectedPitcher")) settings->brew()->setSelectedSteamCup(steam["selectedPitcher"].toInt());
         if (steam.contains("milkAutoCaptureEnabled")) settings->brew()->setMilkAutoCaptureEnabled(steam["milkAutoCaptureEnabled"].toBool());
 
         // Import pitcher presets
@@ -434,18 +433,29 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
             QJsonArray presets = steam["pitcherPresets"].toArray();
             for (const QJsonValue& v : presets) {
                 QJsonObject p = v.toObject();
-                if (p["disabled"].toBool()) {
+                const bool disabled = p["disabled"].toBool();
+                const int before = static_cast<int>(settings->brew()->steamPitcherPresets().size());
+                if (disabled) {
                     settings->brew()->addSteamPitcherPresetDisabled(p["name"].toString());
                 } else {
                     settings->brew()->addSteamPitcherPreset(p["name"].toString(), p["duration"].toInt(), p["flow"].toInt());
                 }
-                // Restore the weight + milk calibration the feature depends on (the
-                // just-added preset is appended at the end).
-                int idx = static_cast<int>(settings->brew()->steamPitcherPresets().size()) - 1;
-                if (idx >= 0) {
+                // Restore weight + milk calibration ONLY for an enabled preset whose
+                // add actually appended one entry — never onto a disabled preset, nor
+                // (if a corrupt store no-ops the add) onto the wrong/previous one.
+                const int after = static_cast<int>(settings->brew()->steamPitcherPresets().size());
+                if (!disabled && after == before + 1) {
+                    const int idx = after - 1;
                     if (p.contains("pitcherWeightG")) settings->brew()->setSteamPitcherWeight(idx, p["pitcherWeightG"].toDouble());
                     if (p.contains("calibMilkG")) settings->brew()->setSteamPitcherCalibration(idx, p["calibMilkG"].toDouble());
                 }
+            }
+            // Apply the selected pitcher AFTER the presets are rebuilt — setting it
+            // before the clear/re-add would leave it clamped to a stale index.
+            if (steam.contains("selectedPitcher")) {
+                const int sel = steam["selectedPitcher"].toInt();
+                if (sel >= 0 && sel < static_cast<int>(settings->brew()->steamPitcherPresets().size()))
+                    settings->brew()->setSelectedSteamCup(sel);
             }
         }
     }

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -72,6 +72,7 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
     steam["autoFlushSeconds"] = settings->brew()->steamAutoFlushSeconds();
     steam["twoTapStop"] = settings->hardware()->steamTwoTapStop();
     steam["selectedPitcher"] = settings->brew()->selectedSteamPitcher();
+    steam["milkAutoCaptureEnabled"] = settings->brew()->milkAutoCaptureEnabled();
 
     // Steam pitcher presets
     QJsonArray pitcherPresets;
@@ -81,6 +82,10 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
         p["name"] = m["name"].toString();
         p["duration"] = m["duration"].toInt();
         p["flow"] = m["flow"].toInt();
+        // The weight-based-steaming feature is keyed on these, so they must round-trip.
+        if (m.contains("pitcherWeightG")) p["pitcherWeightG"] = m["pitcherWeightG"].toDouble();
+        if (m.contains("calibMilkG")) p["calibMilkG"] = m["calibMilkG"].toDouble();
+        if (m.contains("disabled")) p["disabled"] = m["disabled"].toBool();
         pitcherPresets.append(p);
     }
     steam["pitcherPresets"] = pitcherPresets;
@@ -416,6 +421,7 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         if (steam.contains("autoFlushSeconds")) settings->brew()->setSteamAutoFlushSeconds(steam["autoFlushSeconds"].toInt());
         if (steam.contains("twoTapStop")) settings->hardware()->setSteamTwoTapStop(steam["twoTapStop"].toBool());
         if (steam.contains("selectedPitcher")) settings->brew()->setSelectedSteamCup(steam["selectedPitcher"].toInt());
+        if (steam.contains("milkAutoCaptureEnabled")) settings->brew()->setMilkAutoCaptureEnabled(steam["milkAutoCaptureEnabled"].toBool());
 
         // Import pitcher presets
         if (steam.contains("pitcherPresets")) {
@@ -428,7 +434,18 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
             QJsonArray presets = steam["pitcherPresets"].toArray();
             for (const QJsonValue& v : presets) {
                 QJsonObject p = v.toObject();
-                settings->brew()->addSteamPitcherPreset(p["name"].toString(), p["duration"].toInt(), p["flow"].toInt());
+                if (p["disabled"].toBool()) {
+                    settings->brew()->addSteamPitcherPresetDisabled(p["name"].toString());
+                } else {
+                    settings->brew()->addSteamPitcherPreset(p["name"].toString(), p["duration"].toInt(), p["flow"].toInt());
+                }
+                // Restore the weight + milk calibration the feature depends on (the
+                // just-added preset is appended at the end).
+                int idx = static_cast<int>(settings->brew()->steamPitcherPresets().size()) - 1;
+                if (idx >= 0) {
+                    if (p.contains("pitcherWeightG")) settings->brew()->setSteamPitcherWeight(idx, p["pitcherWeightG"].toDouble());
+                    if (p.contains("calibMilkG")) settings->brew()->setSteamPitcherCalibration(idx, p["calibMilkG"].toDouble());
+                }
             }
         }
     }

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -450,13 +450,17 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
                     if (p.contains("calibMilkG")) settings->brew()->setSteamPitcherCalibration(idx, p["calibMilkG"].toDouble());
                 }
             }
-            // Apply the selected pitcher AFTER the presets are rebuilt — setting it
-            // before the clear/re-add would leave it clamped to a stale index.
-            if (steam.contains("selectedPitcher")) {
-                const int sel = steam["selectedPitcher"].toInt();
-                if (sel >= 0 && sel < static_cast<int>(settings->brew()->steamPitcherPresets().size()))
-                    settings->brew()->setSelectedSteamCup(sel);
-            }
+        }
+        // Apply the selected pitcher AFTER any preset rebuild (and regardless of
+        // whether this JSON carried a presets array) — setting it mid-rebuild would
+        // leave it clamped to a stale index. Out-of-range is dropped with a log.
+        if (steam.contains("selectedPitcher")) {
+            const int sel = steam["selectedPitcher"].toInt();
+            if (sel >= 0 && sel < static_cast<int>(settings->brew()->steamPitcherPresets().size()))
+                settings->brew()->setSelectedSteamCup(sel);
+            else
+                qWarning() << "SettingsSerializer: imported selectedPitcher" << sel
+                           << "out of range after import; leaving current selection";
         }
     }
 


### PR DESCRIPTION
## Summary
Auto-captures the milk weight from a BLE scale and scales steam time to it, built on the virtual-zero `StableWeightCapture` from #1358. **Opt-out** in Settings; manual entry always remains.

## What's in it
- **Milk auto-capture**, symmetric with bean capture: fires only when an empty-pitcher weight is saved (dormant otherwise). Records the milk weight when the pitcher rests on the scale.
- **Weight-scaled steam time**: scaled proportionally from a per-pitcher reference (milk weight ↔ duration), clamped to [5, 120] s.
- **Steam-page UX**: pitcher-weigh + reference-milk editor, with a confirmation guard against accidentally weighing a non-empty pitcher.
- **Last-steam baseline**: the (milk, time) pair from the last session is saved atomically at session end; "use as baseline" adopts it in steam setup.
- Pitcher weight + calibration round-trip through settings backup/restore.

## Safe by default
- Auto-capture is disableable (`milkAutoCaptureEnabled`); when off, steam time is never changed automatically.

## Independent & tested
- Diffs **only this feature** vs `main`.
- A pr-review-toolkit pass caught and fixed 3 real serializer-import bugs (calibration written onto disabled presets; unverified append index; selection applied before the preset list was rebuilt).
- Builds on macOS; reviewed; tested on-device.
- Weight-timed steaming concept credited to **DSx2 / Damian-AU** (https://github.com/Damian-AU/DSx2); implementation original.

Replaces the stacked #1351, #1352, #1360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
