### PR TITLE
Simplified home + ratio quick-select (opt-in)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,6 +760,7 @@ set(QML_FILES
     qml/components/BeanBaseDetailsRow.qml
     qml/components/BeanSummary.qml
     qml/components/ChangeBeansDialog.qml
+    qml/components/RatioPresetDialog.qml
     qml/components/BagCard.qml
     qml/components/SwitchEquipmentDialog.qml
     qml/components/EquipmentCard.qml

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -791,6 +791,72 @@ Dialog {
                     onTextEdited: root.grindRpm = parseInt(text) || 0
                 }
             }
+
+            // --- Home-screen ratio quick-select presets. Rarely changed, so
+            // they sit at the bottom. These three values are what the
+            // home-screen ratio button offers as Ristretto / Normale / Lungo. ---
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.scaled(12)
+                Layout.preferredHeight: 1
+                color: Theme.borderColor
+            }
+            Text {
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.scaled(4)
+                text: TranslationManager.translate("brewDialog.ratioPresetsHeader", "Home-screen ratio presets")
+                font: Theme.bodyFont
+                color: Theme.textColor
+            }
+            Text {
+                Layout.fillWidth: true
+                text: TranslationManager.translate("brewDialog.ratioPresetsHint", "The three quick-select ratios offered by the home-screen ratio button.")
+                font: Theme.captionFont
+                color: Theme.textSecondaryColor
+                wrapMode: Text.WordWrap
+            }
+            Repeater {
+                model: [
+                    { rlabel: TranslationManager.translate("ratio.ristretto.name", "Ristretto"), idx: 1 },
+                    { rlabel: TranslationManager.translate("ratio.normale.name", "Normale"), idx: 2 },
+                    { rlabel: TranslationManager.translate("ratio.lungo.name", "Lungo"), idx: 3 }
+                ]
+                delegate: RowLayout {
+                    required property var modelData
+                    Layout.fillWidth: true
+                    spacing: Theme.scaled(8)
+                    Text {
+                        text: modelData.rlabel
+                        font: Theme.bodyFont
+                        color: Theme.textSecondaryColor
+                        Layout.preferredWidth: Theme.scaled(90)
+                        Accessible.ignored: true
+                    }
+                    Text {
+                        text: "1:"
+                        font: Theme.bodyFont
+                        color: Theme.textColor
+                        Accessible.ignored: true
+                    }
+                    ValueInput {
+                        Layout.fillWidth: true
+                        from: 0.5
+                        to: 6.0
+                        stepSize: 0.1
+                        decimals: 1
+                        accentColor: Theme.primaryColor
+                        accessibleName: modelData.rlabel + " " + TranslationManager.translate("brewDialog.ratioWord", "ratio")
+                        value: modelData.idx === 1 ? Settings.brew.ratioPreset1
+                             : modelData.idx === 2 ? Settings.brew.ratioPreset2
+                             : Settings.brew.ratioPreset3
+                        onValueModified: function(newValue) {
+                            if (modelData.idx === 1) Settings.brew.ratioPreset1 = newValue
+                            else if (modelData.idx === 2) Settings.brew.ratioPreset2 = newValue
+                            else Settings.brew.ratioPreset3 = newValue
+                        }
+                    }
+                }
+            }
         }
 
         // Buttons

--- a/qml/components/RatioPresetDialog.qml
+++ b/qml/components/RatioPresetDialog.qml
@@ -1,0 +1,270 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Decenza
+
+// Quick coffee:water ratio chooser, opened from the home-screen status bar.
+// Offers the three classic styles (Ristretto 1:1, Normale 1:2, Lungo 1:3),
+// applies the pick to Settings.brew.lastUsedRatio only (the stop-at-weight target
+// derives from dose × ratio at the proper commit point, not from this dialog), and
+// includes a short "about ratios" help panel. Descriptions are original but
+// the ratio styles/learning are adapted from La Marzocco Home's article
+// "Brew Ratios Around the World" (credited in the footer).
+Dialog {
+    id: root
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+    width: Math.min(Theme.scaled(520), parent ? parent.width * 0.95 : Theme.scaled(520))
+    height: Math.min(contentCol.implicitHeight + Theme.scaled(40), parent ? parent.height * 0.92 : Theme.scaled(640))
+    modal: true
+    closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
+    padding: 0
+
+    property bool showHelp: false
+    readonly property double currentRatio: Settings.brew.lastUsedRatio
+
+    // The three classic styles. `desc` are our own words, informed by the
+    // La Marzocco article credited below.
+    readonly property var presets: [
+        { ratio: Settings.brew.ratioPreset1, key: "ratio.ristretto", name: "Ristretto",
+          desc: "Short & concentrated — syrupy and heavy-bodied with intense flavour. Cuts through milk; suits darker roasts." },
+        { ratio: Settings.brew.ratioPreset2, key: "ratio.normale", name: "Normale",
+          desc: "The modern specialty standard — balanced body and clarity with higher extraction. Flatters lighter roasts and single origins." },
+        { ratio: Settings.brew.ratioPreset3, key: "ratio.lungo", name: "Lungo",
+          desc: "Long & lighter — brighter clarity and less body, so individual tasting notes show through. Closer to filter coffee." }
+    ]
+
+    function applyRatio(r) {
+        // Set ONLY the ratio preference. The stop-at-weight target derives from
+        // dose × ratio at the proper commit point (the bean auto-capture, which has
+        // a freshly measured dose, and Espresso Setup, which recomputes reactively).
+        // We deliberately do NOT poke the persistent brewYieldOverride from a tap:
+        // that would override the profile target from a possibly-default dose and
+        // bypass the per-bag override discipline — the exact anti-pattern flagged
+        // for the bean path.
+        Settings.brew.lastUsedRatio = r
+        root.close()
+    }
+
+    background: Rectangle {
+        color: Theme.surfaceColor
+        radius: Theme.cardRadius
+        border.width: 1
+        border.color: Theme.borderColor
+    }
+
+    contentItem: Flickable {
+        contentWidth: width
+        contentHeight: contentCol.implicitHeight
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+        ColumnLayout {
+            id: contentCol
+            width: parent.width
+            spacing: Theme.spacingMedium
+
+            // --- Header ---
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.spacingLarge
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                spacing: Theme.scaled(2)
+                Text {
+                    text: TranslationManager.translate("ratio.dialog.title", "Brew Ratio")
+                    color: Theme.textColor
+                    font.pixelSize: Theme.scaled(24); font.bold: true
+                }
+                Text {
+                    text: TranslationManager.translate("ratio.dialog.subtitle", "Coffee : water — tap a style to use it")
+                    color: Theme.textSecondaryColor
+                    font: Theme.labelFont
+                }
+            }
+
+            // --- Ratio style cards ---
+            Repeater {
+                model: root.presets
+                delegate: Rectangle {
+                    id: card
+                    required property var modelData
+                    readonly property bool isCurrent: Math.abs(root.currentRatio - modelData.ratio) < 0.05
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.spacingLarge
+                    Layout.rightMargin: Theme.spacingLarge
+                    Layout.preferredHeight: cardCol.implicitHeight + Theme.spacingMedium * 2
+                    radius: Theme.buttonRadius
+                    color: cardMa.pressed ? Qt.darker(Theme.backgroundColor, 1.1) : Theme.backgroundColor
+                    border.width: isCurrent ? 2 : 1
+                    border.color: isCurrent ? Theme.primaryColor : Theme.borderColor
+
+                    Accessible.role: Accessible.Button
+                    Accessible.name: TranslationManager.translate(modelData.key + ".name", modelData.name)
+                                     + " 1:" + modelData.ratio.toFixed(1)
+                                     + (isCurrent ? ", " + TranslationManager.translate("ratio.current", "current") : "")
+                    Accessible.focusable: true
+                    Accessible.onPressAction: cardMa.clicked(null)
+
+                    ColumnLayout {
+                        id: cardCol
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.leftMargin: Theme.spacingMedium
+                        anchors.rightMargin: Theme.spacingMedium
+                        spacing: Theme.scaled(2)
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: Theme.spacingSmall
+                            Text {
+                                text: TranslationManager.translate(modelData.key + ".name", modelData.name)
+                                color: Theme.textColor
+                                font.pixelSize: Theme.scaled(19); font.bold: true
+                            }
+                            Text {
+                                text: "1:" + modelData.ratio.toFixed(1)
+                                color: Theme.primaryColor
+                                font.pixelSize: Theme.scaled(19); font.bold: true
+                            }
+                            Item { Layout.fillWidth: true }
+                            Text {
+                                visible: card.isCurrent
+                                text: TranslationManager.translate("ratio.current", "current").toUpperCase()
+                                color: Theme.primaryColor
+                                font: Theme.captionFont
+                            }
+                        }
+                        Text {
+                            Layout.fillWidth: true
+                            text: TranslationManager.translate(modelData.key + ".desc", modelData.desc)
+                            color: Theme.textSecondaryColor
+                            font: Theme.captionFont
+                            wrapMode: Text.WordWrap
+                        }
+                    }
+
+                    MouseArea {
+                        id: cardMa
+                        anchors.fill: parent
+                        onClicked: root.applyRatio(modelData.ratio)
+                    }
+                }
+            }
+
+            // --- Footnote: finer control lives in Espresso Setup ---
+            Text {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                text: TranslationManager.translate("ratio.footnote", "For finer control, adjust the dose and target in Espresso Setup.")
+                color: Theme.textSecondaryColor
+                font: Theme.captionFont
+                wrapMode: Text.WordWrap
+            }
+
+            // --- "About brew ratios" toggle ---
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                Layout.preferredHeight: Theme.scaled(40)
+                radius: Theme.buttonRadius
+                color: helpMa.pressed ? Qt.darker(Theme.backgroundColor, 1.1) : "transparent"
+                border.width: 1
+                border.color: Theme.borderColor
+                Accessible.role: Accessible.Button
+                Accessible.name: TranslationManager.translate("ratio.help.button", "About brew ratios")
+                Accessible.focusable: true
+                Accessible.onPressAction: helpMa.clicked(null)
+                Text {
+                    anchors.centerIn: parent
+                    text: (root.showHelp ? "– " : "+ ") + TranslationManager.translate("ratio.help.button", "About brew ratios")
+                    color: Theme.primaryColor
+                    font: Theme.labelFont
+                }
+                MouseArea { id: helpMa; anchors.fill: parent; onClicked: root.showHelp = !root.showHelp }
+            }
+
+            // --- Help body (collapsible) ---
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                visible: root.showHelp
+                spacing: Theme.spacingSmall
+                Text {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("ratio.help.intro",
+                        "Brew ratio is the weight of coffee in vs. espresso out. A lower ratio (1:1) is shorter, thicker and more intense; a higher ratio (1:3) is longer, lighter and clearer. Dose stays the same — only the yield changes.")
+                    color: Theme.textColor
+                    font: Theme.captionFont
+                    wrapMode: Text.WordWrap
+                }
+                Text {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("ratio.help.regional",
+                        "Tastes differ by region: 1:1 ristrettos (popularised in Seattle), the traditional ~1:3 Italian shot, and the modern specialty 1:2 normale.")
+                    color: Theme.textSecondaryColor
+                    font: Theme.captionFont
+                    wrapMode: Text.WordWrap
+                }
+            }
+
+            // --- Attribution (always shown) ---
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                spacing: 0
+                Text {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("ratio.attribution",
+                        "Ratio styles adapted from “Brew Ratios Around the World,” Ben Blake & Scott Callender — La Marzocco Home (2014).")
+                    color: Theme.textSecondaryColor
+                    font: Theme.captionFont
+                    wrapMode: Text.WordWrap
+                }
+                Text {
+                    id: articleLink
+                    text: TranslationManager.translate("ratio.readArticle", "Read the full article")
+                    color: Theme.primaryColor
+                    font: Theme.captionFont
+                    Accessible.role: Accessible.Link
+                    Accessible.name: text
+                    Accessible.focusable: true
+                    Accessible.onPressAction: linkMa.clicked(null)
+                    MouseArea {
+                        id: linkMa
+                        anchors.fill: parent
+                        onClicked: Qt.openUrlExternally("https://home.lamarzoccousa.com/brew-ratios-around-world/")
+                    }
+                }
+            }
+
+            // --- Close ---
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.spacingLarge
+                Layout.rightMargin: Theme.spacingLarge
+                Layout.bottomMargin: Theme.spacingLarge
+                Layout.preferredHeight: Theme.scaled(48)
+                radius: Theme.buttonRadius
+                color: closeMa.pressed ? Qt.darker(Theme.primaryColor, 1.15) : Theme.primaryColor
+                Accessible.role: Accessible.Button
+                Accessible.name: TranslationManager.translate("common.button.close", "Close")
+                Accessible.focusable: true
+                Accessible.onPressAction: closeMa.clicked(null)
+                Text {
+                    anchors.centerIn: parent
+                    text: TranslationManager.translate("common.button.close", "Close")
+                    color: Theme.primaryContrastColor
+                    font: Theme.bodyFont
+                }
+                MouseArea { id: closeMa; anchors.fill: parent; onClicked: root.close() }
+            }
+        }
+    }
+}

--- a/qml/components/RatioPresetDialog.qml
+++ b/qml/components/RatioPresetDialog.qml
@@ -36,8 +36,10 @@ Dialog {
 
     function applyRatio(r) {
         // Set ONLY the ratio preference. The stop-at-weight target derives from
-        // dose × ratio at the proper commit point (the bean auto-capture, which has
-        // a freshly measured dose, and Espresso Setup, which recomputes reactively).
+        // dose × ratio at the proper commit point: the bean auto-capture (which has
+        // a freshly measured dose) computes brewYieldOverride = dose × lastUsedRatio.
+        // Espresso Setup shows a ratio derived from the existing dose/target, so a
+        // ratio picked here is not applied retroactively until the next capture.
         // We deliberately do NOT poke the persistent brewYieldOverride from a tap:
         // that would override the profile target from a possibly-default dose and
         // bypass the per-bag override discipline — the exact anti-pattern flagged

--- a/qml/components/layout/LayoutCenterZone.qml
+++ b/qml/components/layout/LayoutCenterZone.qml
@@ -48,7 +48,17 @@ Item {
         }
         return false
     }
-    readonly property real scaledSpacing: Theme.scaled(10) * zoneScale
+    // Gap between center-zone widgets. Widened to 18 only for the distributed
+    // simplified-home rows (so they aren't cramped); every other zone keeps 10.
+    readonly property real scaledSpacing: Theme.scaled(distributeItems ? 18 : 10) * zoneScale
+
+    // Spread items across the full width (instead of clustering them centered) for
+    // the status / profile rows in simplified-home mode, so they sit at left /
+    // middle / right rather than bunched. Only in simplified mode — the default
+    // zone-driven layout keeps its centered clustering.
+    readonly property bool distributeItems:
+        Settings.theme.simplifiedHome
+        && (zoneName === "centerStatus" || zoneName === "centerMiddle") && !hasSpacer
     readonly property real availableWidth: width - Theme.scaled(20) * zoneScale -
         (buttonCount > 1 ? (buttonCount - 1) * scaledSpacing : 0)
     readonly property real buttonWidth: buttonCount > 0
@@ -67,14 +77,20 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         spacing: root.scaledSpacing
 
-        // Auto-centering spacer (hides when user has their own spacers)
-        Item { Layout.fillWidth: true; visible: !root.hasSpacer }
+        // Auto-centering spacer (hides when user has their own spacers, or when
+        // the zone distributes items across the full width)
+        Item { Layout.fillWidth: true; visible: !root.hasSpacer && !root.distributeItems }
 
         Repeater {
             model: root.items
             delegate: LayoutItemDelegate {
                 zoneName: root.zoneName
                 Layout.preferredWidth: {
+                    // Distribute mode: every item gets an equal-width cell (base 0
+                    // + equal fillWidth share), independent of its text width, so
+                    // the content centers in exact thirds/halves (e.g. water level
+                    // lands on screen-center regardless of how wide its text is).
+                    if (root.distributeItems) return 0
                     // Flip clock: interpolate between buttonWidth and wide based on clockScale
                     if (modelData.type === "screensaverFlipClock") {
                         var s = typeof modelData.clockScale === "number" ? modelData.clockScale : 1.0
@@ -94,11 +110,12 @@ Item {
                     return root.buttonWidth
                 }
                 Layout.preferredHeight: modelData.type === "spacer" ? -1 : root.buttonHeight
-                Layout.fillWidth: modelData.type === "spacer"
+                Layout.fillWidth: modelData.type === "spacer" || root.distributeItems
             }
         }
 
-        // Auto-centering spacer (hides when user has their own spacers)
-        Item { Layout.fillWidth: true; visible: !root.hasSpacer }
+        // Auto-centering spacer (hides when user has their own spacers, or when
+        // the zone distributes items across the full width)
+        Item { Layout.fillWidth: true; visible: !root.hasSpacer && !root.distributeItems }
     }
 }

--- a/qml/components/layout/items/ShotPlanItem.qml
+++ b/qml/components/layout/items/ShotPlanItem.qml
@@ -16,6 +16,10 @@ Item {
     readonly property bool showRoastDate: modelData.shotPlanShowRoastDate === true
     readonly property bool showDoseYield: modelData.shotPlanShowDoseYield !== false
 
+    // Simplified-home (opt-in) turns full mode into setup buttons; default full mode
+    // keeps the shot-plan summary text so existing layouts are unchanged.
+    readonly property bool simplifiedHome: Settings.theme.simplifiedHome
+
     // Open the single global Brew Settings dialog (hosted at the app root) via the
     // window, so this works wherever the tile is placed — including the persistent
     // status bar, which is not a descendant of IdlePage.
@@ -27,12 +31,16 @@ Item {
     implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
     implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
 
-    Accessible.role: Accessible.Button
+    // Whole-widget button when it's the tappable summary (compact, or default full
+    // mode). In simplified full mode the individual setup buttons are accessible.
+    readonly property bool summaryButton: root.isCompact || !root.simplifiedHome
+    Accessible.role: summaryButton ? Accessible.Button : Accessible.NoRole
     Accessible.name: {
-        var plan = compactShotPlan.text || fullShotPlan.text || ""
+        if (!summaryButton) return ""
+        var plan = (root.isCompact ? compactShotPlan.text : fullShotPlan.text) || ""
         return plan ? "Shot plan: " + plan + ". Tap to edit" : "Shot plan"
     }
-    Accessible.focusable: true
+    Accessible.focusable: summaryButton
 
     // --- COMPACT MODE ---
     Item {
@@ -60,13 +68,18 @@ Item {
         id: fullContent
         visible: !root.isCompact
         anchors.fill: parent
-        implicitWidth: fullShotPlan.implicitWidth
-        implicitHeight: fullShotPlan.implicitHeight
+        implicitWidth: root.simplifiedHome
+            ? (espressoSetupBtn.implicitWidth + profileChooseBtn.implicitWidth + steamSetupBtn.implicitWidth + Theme.spacingLarge * 2)
+            : fullShotPlan.implicitWidth
+        implicitHeight: root.simplifiedHome
+            ? Math.max(espressoSetupBtn.implicitHeight, profileChooseBtn.implicitHeight, steamSetupBtn.implicitHeight)
+            : fullShotPlan.implicitHeight
 
+        // Default layout: the shot-plan summary text (unchanged behaviour).
         ShotPlanText {
             id: fullShotPlan
             anchors.centerIn: parent
-            visible: text !== ""
+            visible: !root.simplifiedHome && text !== ""
             showProfile: root.showProfile
             showRoaster: root.showRoaster
             showGrind: root.showGrind
@@ -74,5 +87,157 @@ Item {
             showDoseYield: root.showDoseYield
             onClicked: root.openBrewSettings()
         }
+
+        // Simplified home: three setup buttons, each centred in its third. Outlined
+        // (surface fill, accent border) so they stay readable on any theme. Left
+        // opens Espresso Setup, centre the profile selector, right the Steam page.
+
+        // Espresso-Shot Setup -> left third; opens the brew/dose dialog
+        Rectangle {
+            id: espressoSetupBtn
+            visible: root.simplifiedHome
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.horizontalCenterOffset: -parent.width / 3
+            anchors.verticalCenter: parent.verticalCenter
+            implicitWidth: espressoNameTr.implicitWidth + Theme.spacingLarge * 1.5
+            implicitHeight: espressoNameTr.implicitHeight + espressoSubText.implicitHeight + Theme.spacingMedium
+            radius: Theme.buttonRadius
+            color: espressoMa.pressed ? Qt.darker(Theme.surfaceColor, 1.08) : Theme.surfaceColor
+            border.width: 1
+            border.color: Theme.primaryColor
+
+            Accessible.role: Accessible.Button
+            Accessible.name: TranslationManager.translate("idle.button.espressoSetup", "Espresso-Shot Setup")
+            Accessible.focusable: root.simplifiedHome
+            Accessible.onPressAction: espressoMa.clicked(null)
+            activeFocusOnTab: root.simplifiedHome
+            KeyNavigation.tab: profileChooseBtn
+            Keys.onReturnPressed: espressoMa.clicked(null)
+            Keys.onSpacePressed: espressoMa.clicked(null)
+
+            Column {
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.right: parent.right
+                spacing: 0
+                Tr {
+                    id: espressoNameTr
+                    key: "idle.button.espressoSetup"; fallback: "Espresso-Shot Setup"
+                    color: Theme.textColor; font: Theme.bodyFont
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                }
+                Text {
+                    id: espressoSubText
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                    text: {
+                        var d = Settings.dye.dyeBeanWeight
+                        var t = ProfileManager.targetWeight
+                        return (d > 0 && t > 0) ? d.toFixed(1) + " → " + t.toFixed(1) + " g" : ""
+                    }
+                    visible: text !== ""
+                    color: Theme.textSecondaryColor; font: Theme.labelFont
+                }
+            }
+            MouseArea { id: espressoMa; anchors.fill: parent; onClicked: root.openBrewSettings() }
+        }
+
+        // Choose Espresso Profile -> centre; opens the profile selector
+        Rectangle {
+            id: profileChooseBtn
+            visible: root.simplifiedHome
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            implicitWidth: profileNameTr.implicitWidth + Theme.spacingLarge * 1.5
+            implicitHeight: profileNameTr.implicitHeight + profileSubText.implicitHeight + Theme.spacingMedium
+            radius: Theme.buttonRadius
+            color: profileMa.pressed ? Qt.darker(Theme.surfaceColor, 1.08) : Theme.surfaceColor
+            border.width: 1
+            border.color: Theme.primaryColor
+
+            Accessible.role: Accessible.Button
+            Accessible.name: TranslationManager.translate("idle.button.chooseProfile", "Choose Espresso Profile")
+            Accessible.focusable: root.simplifiedHome
+            Accessible.onPressAction: profileMa.clicked(null)
+            activeFocusOnTab: root.simplifiedHome
+            KeyNavigation.tab: steamSetupBtn
+            Keys.onReturnPressed: profileMa.clicked(null)
+            Keys.onSpacePressed: profileMa.clicked(null)
+
+            Column {
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.right: parent.right
+                spacing: 0
+                Tr {
+                    id: profileNameTr
+                    key: "idle.button.chooseProfile"; fallback: "Choose Espresso Profile"
+                    color: Theme.textColor; font: Theme.bodyFont
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                }
+                Text {
+                    id: profileSubText
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                    text: ProfileManager.currentProfileName
+                    visible: text !== ""
+                    color: Theme.textSecondaryColor; font: Theme.labelFont
+                    elide: Text.ElideRight
+                }
+            }
+            MouseArea { id: profileMa; anchors.fill: parent; onClicked: root.openProfileChooser() }
+        }
+
+        // Milk-Steaming Setup -> right third; opens the steam page (no long-press)
+        Rectangle {
+            id: steamSetupBtn
+            visible: root.simplifiedHome
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.horizontalCenterOffset: parent.width / 3
+            anchors.verticalCenter: parent.verticalCenter
+            implicitWidth: steamNameTr.implicitWidth + Theme.spacingLarge * 1.5
+            implicitHeight: steamNameTr.implicitHeight + steamSubText.implicitHeight + Theme.spacingMedium
+            radius: Theme.buttonRadius
+            color: steamMa.pressed ? Qt.darker(Theme.surfaceColor, 1.08) : Theme.surfaceColor
+            border.width: 1
+            border.color: Theme.primaryColor
+
+            Accessible.role: Accessible.Button
+            Accessible.name: TranslationManager.translate("idle.button.steamSetup", "Milk-Steaming Setup")
+            Accessible.focusable: root.simplifiedHome
+            Accessible.onPressAction: steamMa.clicked(null)
+            activeFocusOnTab: root.simplifiedHome
+            Keys.onReturnPressed: steamMa.clicked(null)
+            Keys.onSpacePressed: steamMa.clicked(null)
+
+            Column {
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.right: parent.right
+                spacing: 0
+                Tr {
+                    id: steamNameTr
+                    key: "idle.button.steamSetup"; fallback: "Milk-Steaming Setup"
+                    color: Theme.textColor; font: Theme.bodyFont
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                }
+                Text {
+                    id: steamSubText
+                    width: parent.width; horizontalAlignment: Text.AlignHCenter
+                    text: Math.round(Settings.brew.steamTemperature) + "°C"
+                    color: Theme.textSecondaryColor; font: Theme.labelFont
+                }
+            }
+            MouseArea { id: steamMa; anchors.fill: parent; onClicked: root.openSteamSetup() }
+        }
+    }
+
+    // Open the steam page (same target as long-pressing a steam pitcher pill).
+    function openSteamSetup() {
+        if (typeof pageStack !== "undefined" && pageStack)
+            pageStack.push(Qt.resolvedUrl("../../../pages/SteamPage.qml"))
+    }
+    // Open the profile selector to change the espresso profile.
+    function openProfileChooser() {
+        if (typeof pageStack !== "undefined" && pageStack)
+            pageStack.push(Qt.resolvedUrl("../../../pages/ProfileSelectorPage.qml"))
     }
 }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -149,6 +149,14 @@ Page {
 
     // Track which function's presets are showing (used by center-zone action items)
     property string activePresetFunction: ""  // "", "steam", "espresso", "hotwater", "flush", "beans", "equipment"
+    // Opt-in simplified home composition (fixed brew stat bar + setup buttons).
+    // Default off → the configurable zone-driven layout is used unchanged.
+    readonly property bool simplifiedHome: Settings.theme.simplifiedHome
+
+    // Last milk weight measured this session (for the bottom status row). 0 = none yet.
+    // Populated by the steaming auto-capture feature (not present in this build); stays
+    // 0 here, so the Milk cell in the brew status bar shows "—".
+    property real measuredMilkG: 0
 
     // Idle bean auto-capture: tracks a virtual zero off the empty scale, then when
     // the dose cup (with beans) rests stable it sets the dose (dyeBeanWeight) and
@@ -310,16 +318,28 @@ Page {
         onClicked: activePresetFunction = ""
     }
 
+    // Quick coffee:water ratio chooser (opened from the bottom status bar)
+    RatioPresetDialog {
+        id: ratioPresetDialog
+    }
+
     // ============================================================
     // Top info section (from layout topLeft/topRight zones)
     // ============================================================
     ColumnLayout {
+        id: topInfoSection
+        // In simplified mode the top stats live in the global status bar, so this is
+        // hidden when its zones are empty (to reclaim the reserved height). In the
+        // default zone-driven layout it behaves as before (always shown).
+        visible: !idlePage.simplifiedHome
+                 || idlePage.topLeftItems.length > 0 || idlePage.topRightItems.length > 0
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.margins: Theme.standardMargin
-        anchors.topMargin: Theme.pageTopMargin
-        spacing: Theme.scaled(20)
+        anchors.topMargin: idlePage.simplifiedHome ? (Theme.statusBarHeight + Theme.scaled(8))
+                                                    : Theme.pageTopMargin
+        spacing: idlePage.simplifiedHome ? 0 : Theme.scaled(20)
 
         RowLayout {
             Layout.alignment: Qt.AlignHCenter
@@ -339,25 +359,49 @@ Page {
         }
     }
 
+    // Thin high-contrast line directly beneath the global status bar — its bottom
+    // border. Pinned at the status bar's height so it sits flush under the top
+    // stats row regardless of the (often empty) topLeft/topRight zones.
+    Rectangle {
+        id: topStatsBorder
+        visible: idlePage.simplifiedHome
+        anchors.top: parent.top
+        anchors.topMargin: Theme.statusBarHeight
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: Theme.scaled(2)
+        color: Theme.primaryColor
+    }
+
     // ============================================================
     // Center content (from layout centerTop/centerMiddle zones)
     // ============================================================
     ColumnLayout {
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: Theme.scaled(50)
+        // Simplified: anchored below the status-bar border so it grows DOWNWARD, and
+        // capped at the brew status bar so it can't bleed behind it. Default: the
+        // original vertically-centred placement.
+        anchors.top: idlePage.simplifiedHome ? topStatsBorder.bottom : undefined
+        anchors.topMargin: idlePage.simplifiedHome ? Theme.scaled(12) : 0
+        anchors.bottom: idlePage.simplifiedHome ? brewStatusBar.top : undefined
+        anchors.bottomMargin: idlePage.simplifiedHome ? Theme.scaled(12) : 0
+        anchors.verticalCenter: idlePage.simplifiedHome ? undefined : parent.verticalCenter
+        anchors.verticalCenterOffset: idlePage.simplifiedHome ? 0 : Theme.scaled(50)
         anchors.leftMargin: Theme.standardMargin
         anchors.rightMargin: Theme.standardMargin
         spacing: Theme.scaled(20)
+        clip: idlePage.simplifiedHome
 
-        // Status readouts (temp, water level, connection)
+        // Status readouts (temp, water level, connection). In simplified mode the
+        // same info lives in the top status bar, so this is hidden to avoid crowding;
+        // in the default layout it shows whenever the zone has items.
         LayoutCenterZone {
             Layout.fillWidth: true
             Layout.topMargin: idlePage.centerStatusYOffset
             zoneName: "centerStatus"
             items: idlePage.centerStatusItems
-            visible: idlePage.centerStatusItems.length > 0
+            visible: !idlePage.simplifiedHome && idlePage.centerStatusItems.length > 0
             zoneScale: idlePage.centerStatusScale
         }
 
@@ -751,9 +795,131 @@ Page {
     }
 
     // ============================================================
+    // Brew status row (across the bottom, above the action bar)
+    // ============================================================
+    Rectangle {
+        id: brewStatusBar
+        visible: idlePage.simplifiedHome
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: bottomBar.top
+        height: Theme.scaled(82)
+        // Accent-coloured bar with its guaranteed-contrast text colour, so it stands
+        // out and stays readable on any theme (including dark / custom palettes).
+        color: Theme.primaryColor
+
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: Theme.spacingMedium
+            anchors.rightMargin: Theme.spacingMedium
+            spacing: Theme.spacingSmall
+
+            // Current espresso profile
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1   // equal cells regardless of content width
+                spacing: 0
+                Tr { key: "idle.status.profile"; fallback: "Profile"; color: Theme.primaryContrastColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter; elide: Text.ElideRight }
+                Text {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    elide: Text.ElideRight
+                    text: ProfileManager.currentProfileName || "—"
+                    color: Theme.primaryContrastColor; font.pixelSize: Theme.scaled(21); font.bold: true
+                }
+            }
+
+            // Live net scale weight (context-aware: net milk in steam mode, else net beans)
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: 0
+                Tr { key: "idle.status.scale"; fallback: "Scale"; color: Theme.primaryContrastColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter }
+                Text {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    text: {
+                        if (!ScaleDevice.connected) return "—"
+                        var net
+                        if (idlePage.activePresetFunction === "steam") {
+                            var p = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+                            var pw = (p && !p.disabled) ? (p.pitcherWeightG ?? 0) : 0
+                            net = Math.max(0, MachineState.scaleWeight - pw)
+                        } else {
+                            net = Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight)
+                        }
+                        return net.toFixed(1) + " g"
+                    }
+                    color: Theme.primaryContrastColor; font.pixelSize: Theme.scaled(21); font.bold: true
+                }
+            }
+
+            // Coffee:water ratio — tappable quick-select button (opens the ratio chooser)
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: Theme.scaled(2)
+                Tr { key: "idle.status.ratio"; fallback: "Ratio"; color: Theme.primaryContrastColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter }
+                Rectangle {
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredWidth: ratioValueText.implicitWidth + Theme.spacingMedium * 2
+                    Layout.preferredHeight: Theme.scaled(32)
+                    radius: height / 2
+                    color: ratioBtnMa.pressed ? Qt.darker(Theme.primaryContrastColor, 1.15) : Theme.primaryContrastColor
+                    Accessible.role: Accessible.Button
+                    Accessible.name: TranslationManager.translate("idle.ratio.button", "Brew ratio")
+                                     + " 1:" + Settings.brew.lastUsedRatio.toFixed(1) + ". "
+                                     + TranslationManager.translate("idle.ratio.tapToChange", "Tap to change")
+                    Accessible.focusable: true
+                    Accessible.onPressAction: ratioBtnMa.clicked(null)
+                    Text {
+                        id: ratioValueText
+                        anchors.centerIn: parent
+                        text: "1:" + Settings.brew.lastUsedRatio.toFixed(1)
+                        color: Theme.primaryColor
+                        font.pixelSize: Theme.scaled(20); font.bold: true
+                    }
+                    MouseArea { id: ratioBtnMa; anchors.fill: parent; onClicked: ratioPresetDialog.open() }
+                }
+            }
+
+            // Beans measured indicator (+ amount)
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: 0
+                Tr { key: "idle.status.beans"; fallback: "Beans"; color: Theme.primaryContrastColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter }
+                Text {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    text: Settings.dye.dyeBeanWeight > 0 ? Settings.dye.dyeBeanWeight.toFixed(1) + " g"
+                                                        : TranslationManager.translate("idle.status.none", "—")
+                    color: Theme.primaryContrastColor; font.pixelSize: Theme.scaled(21); font.bold: true
+                }
+            }
+
+            // Milk measured indicator (+ amount)
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: 0
+                Tr { key: "idle.status.milk"; fallback: "Milk"; color: Theme.primaryContrastColor; font: Theme.labelFont; Layout.fillWidth: true; horizontalAlignment: Text.AlignHCenter }
+                Text {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    text: idlePage.measuredMilkG > 0 ? idlePage.measuredMilkG.toFixed(1) + " g"
+                                                     : TranslationManager.translate("idle.status.none", "—")
+                    color: Theme.primaryContrastColor; font.pixelSize: Theme.scaled(21); font.bold: true
+                }
+            }
+        }
+    }
+
+    // ============================================================
     // Bottom bar (from layout bottomLeft/bottomRight zones)
     // ============================================================
     Rectangle {
+        id: bottomBar
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -384,7 +384,7 @@ Page {
         // original vertically-centred placement.
         anchors.top: idlePage.simplifiedHome ? topStatsBorder.bottom : undefined
         anchors.topMargin: idlePage.simplifiedHome ? Theme.scaled(12) : 0
-        anchors.bottom: idlePage.simplifiedHome ? brewStatusBar.top : undefined
+        anchors.bottom: idlePage.simplifiedHome ? simplifiedSetupZone.top : undefined
         anchors.bottomMargin: idlePage.simplifiedHome ? Theme.scaled(12) : 0
         anchors.verticalCenter: idlePage.simplifiedHome ? undefined : parent.verticalCenter
         anchors.verticalCenterOffset: idlePage.simplifiedHome ? 0 : Theme.scaled(50)
@@ -783,7 +783,10 @@ Page {
             }
         }
 
-        // Center middle zone (shot plan, etc.)
+        // Center middle zone (shot plan, etc.). In simplified mode the shot-plan
+        // setup buttons are pinned above the brew status bar instead (see
+        // simplifiedSetupZone) so an open preset row can't push them out of view;
+        // this in-column copy is therefore hidden there.
         LayoutCenterZone {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
@@ -791,7 +794,26 @@ Page {
             zoneName: "centerMiddle"
             items: idlePage.centerMiddleItems
             zoneScale: idlePage.centerMiddleScale
+            visible: !idlePage.simplifiedHome
         }
+    }
+
+    // Simplified-home setup buttons (Profile / Espresso / Steam), pinned in a fixed
+    // slot just above the brew status bar so they stay visible no matter which preset
+    // row is open or how tall the centre content gets. Renders the same centerMiddle
+    // widget (shot plan) that the in-column zone shows in the default layout.
+    LayoutCenterZone {
+        id: simplifiedSetupZone
+        visible: idlePage.simplifiedHome
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.leftMargin: Theme.standardMargin
+        anchors.rightMargin: Theme.standardMargin
+        anchors.bottom: brewStatusBar.top
+        anchors.bottomMargin: Theme.scaled(10)
+        zoneName: "centerMiddle"
+        items: idlePage.centerMiddleItems
+        zoneScale: idlePage.centerMiddleScale
     }
 
     // ============================================================

--- a/qml/pages/settings/SettingsLayoutTab.qml
+++ b/qml/pages/settings/SettingsLayoutTab.qml
@@ -183,6 +183,17 @@ Item {
                     wrapMode: Text.Wrap
                 }
 
+                // Opt-in alternate layout modes (default off). When on, a fixed
+                // simplified home / compact status bar replaces the configurable
+                // zones below — the zone editor still works when they're off.
+                StyledSwitch {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("settings.layout.simplifiedHome", "Use simplified home screen")
+                    accessibleName: text
+                    checked: Settings.theme.simplifiedHome
+                    onToggled: Settings.theme.simplifiedHome = checked
+                }
+
                 // Status Bar zone (visible on all pages)
                 LayoutEditorZone {
                     Layout.fillWidth: true

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -126,10 +126,42 @@ void SettingsBrew::setDoseCupTareWeight(double weight) {
     }
 }
 
+double SettingsBrew::ratioPreset1() const {
+    return m_settings.value("espresso/ratioPreset1", 1.0).toDouble();
+}
+void SettingsBrew::setRatioPreset1(double r) {
+    if (r < 0.5) r = 0.5; else if (r > 6.0) r = 6.0;
+    if (ratioPreset1() != r) {
+        m_settings.setValue("espresso/ratioPreset1", r);
+        emit ratioPreset1Changed();
+    }
+}
+
+double SettingsBrew::ratioPreset2() const {
+    return m_settings.value("espresso/ratioPreset2", 2.0).toDouble();
+}
+void SettingsBrew::setRatioPreset2(double r) {
+    if (r < 0.5) r = 0.5; else if (r > 6.0) r = 6.0;
+    if (ratioPreset2() != r) {
+        m_settings.setValue("espresso/ratioPreset2", r);
+        emit ratioPreset2Changed();
+    }
+}
+
+double SettingsBrew::ratioPreset3() const {
+    return m_settings.value("espresso/ratioPreset3", 3.0).toDouble();
+}
+void SettingsBrew::setRatioPreset3(double r) {
+    if (r < 0.5) r = 0.5; else if (r > 6.0) r = 6.0;
+    if (ratioPreset3() != r) {
+        m_settings.setValue("espresso/ratioPreset3", r);
+        emit ratioPreset3Changed();
+    }
+}
+
 bool SettingsBrew::doseCaptureSoundEnabled() const {
     return m_settings.value("espresso/doseCaptureSoundEnabled", false).toBool();
 }
-
 void SettingsBrew::setDoseCaptureSoundEnabled(bool enabled) {
     if (doseCaptureSoundEnabled() != enabled) {
         m_settings.setValue("espresso/doseCaptureSoundEnabled", enabled);

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -19,9 +19,14 @@ class SettingsBrew : public QObject {
     // Dose cup tare: empty weight of the dosing vessel, subtracted from the scale
     // reading in "Get from scale" so the dose is net beans. Default 0 = no tare.
     Q_PROPERTY(double doseCupTareWeight READ doseCupTareWeight WRITE setDoseCupTareWeight NOTIFY doseCupTareWeightChanged)
-    // Whether the confirmation "ding" plays when a bean dose auto-captures. Default
-    // off — not everyone wants the sound; toggled by the bell on the Dose cup row.
+    // Whether the confirmation "ding" plays when a dose/milk auto-captures. Default
+    // off — toggled by the bell on the Dose cup row.
     Q_PROPERTY(bool doseCaptureSoundEnabled READ doseCaptureSoundEnabled WRITE setDoseCaptureSoundEnabled NOTIFY doseCaptureSoundEnabledChanged)
+    // Home-screen quick-select brew-ratio presets (Ristretto / Normale / Lungo).
+    // User-tweakable in Espresso Setup; shown on the home-screen ratio chooser.
+    Q_PROPERTY(double ratioPreset1 READ ratioPreset1 WRITE setRatioPreset1 NOTIFY ratioPreset1Changed)
+    Q_PROPERTY(double ratioPreset2 READ ratioPreset2 WRITE setRatioPreset2 NOTIFY ratioPreset2Changed)
+    Q_PROPERTY(double ratioPreset3 READ ratioPreset3 WRITE setRatioPreset3 NOTIFY ratioPreset3Changed)
 
     // Steam
     Q_PROPERTY(double steamTemperature READ steamTemperature WRITE setSteamTemperature NOTIFY steamTemperatureChanged)
@@ -84,6 +89,14 @@ public:
 
     bool doseCaptureSoundEnabled() const;
     void setDoseCaptureSoundEnabled(bool enabled);
+
+    double ratioPreset1() const;
+    void setRatioPreset1(double r);
+    double ratioPreset2() const;
+    void setRatioPreset2(double r);
+    double ratioPreset3() const;
+    void setRatioPreset3(double r);
+
 
     // Steam
     double steamTemperature() const;
@@ -190,6 +203,9 @@ signals:
     void lastUsedRatioChanged();
     void doseCupTareWeightChanged();
     void doseCaptureSoundEnabledChanged();
+    void ratioPreset1Changed();
+    void ratioPreset2Changed();
+    void ratioPreset3Changed();
     void steamTemperatureChanged();
     void steamTimeoutChanged();
     void steamFlowChanged();

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -19,7 +19,7 @@ class SettingsBrew : public QObject {
     // Dose cup tare: empty weight of the dosing vessel, subtracted from the scale
     // reading in "Get from scale" so the dose is net beans. Default 0 = no tare.
     Q_PROPERTY(double doseCupTareWeight READ doseCupTareWeight WRITE setDoseCupTareWeight NOTIFY doseCupTareWeightChanged)
-    // Whether the confirmation "ding" plays when a dose/milk auto-captures. Default
+    // Whether the confirmation "ding" plays when a bean dose auto-captures. Default
     // off — toggled by the bell on the Dose cup row.
     Q_PROPERTY(bool doseCaptureSoundEnabled READ doseCaptureSoundEnabled WRITE setDoseCaptureSoundEnabled NOTIFY doseCaptureSoundEnabledChanged)
     // Home-screen quick-select brew-ratio presets (Ristretto / Normale / Lungo).

--- a/src/core/settings_theme.cpp
+++ b/src/core/settings_theme.cpp
@@ -621,6 +621,16 @@ void SettingsTheme::setCurrentPageColors(const QStringList& colors) {
     }
 }
 
+bool SettingsTheme::simplifiedHome() const {
+    return m_settings.value("layout/simplifiedHome", false).toBool();
+}
+void SettingsTheme::setSimplifiedHome(bool enabled) {
+    if (simplifiedHome() != enabled) {
+        m_settings.setValue("layout/simplifiedHome", enabled);
+        emit simplifiedHomeChanged();
+    }
+}
+
 void SettingsTheme::flashThemeColor(const QString& colorName) {
     // Stop any existing flash
     if (m_flashTimer) {

--- a/src/core/settings_theme.h
+++ b/src/core/settings_theme.h
@@ -44,6 +44,11 @@ class SettingsTheme : public QObject {
     // Colors detected on the current page (set from QML tree walker)
     Q_PROPERTY(QStringList currentPageColors READ currentPageColors WRITE setCurrentPageColors NOTIFY currentPageColorsChanged)
 
+    // Alternate layout modes (opt-in; default OFF, so the zone-driven layout system
+    // stays authoritative). When ON, a fixed simplified home / compact status bar is
+    // rendered instead of the configurable zones.
+    Q_PROPERTY(bool simplifiedHome READ simplifiedHome WRITE setSimplifiedHome NOTIFY simplifiedHomeChanged)
+
 public:
     explicit SettingsTheme(QObject* parent = nullptr);
 
@@ -114,6 +119,9 @@ public:
     QStringList currentPageColors() const { return m_currentPageColors; }
     void setCurrentPageColors(const QStringList& colors);
 
+    bool simplifiedHome() const;
+    void setSimplifiedHome(bool enabled);
+
     double screenBrightness() const;
     void setScreenBrightness(double brightness);
 
@@ -135,6 +143,7 @@ signals:
     void flashPhaseChanged();
     void currentPageColorsChanged();
     void screenBrightnessChanged();
+    void simplifiedHomeChanged();
 
 private:
     void updateResolvedMode();

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -60,6 +60,9 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
     espresso["lastUsedRatio"] = settings->brew()->lastUsedRatio();
     espresso["doseCupTareWeight"] = settings->brew()->doseCupTareWeight();
     espresso["doseCaptureSoundEnabled"] = settings->brew()->doseCaptureSoundEnabled();
+    espresso["ratioPreset1"] = settings->brew()->ratioPreset1();
+    espresso["ratioPreset2"] = settings->brew()->ratioPreset2();
+    espresso["ratioPreset3"] = settings->brew()->ratioPreset3();
     root["espresso"] = espresso;
 
     // Steam settings
@@ -208,6 +211,7 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
     QJsonObject theme;
     theme["activeThemeName"] = settings->theme()->activeThemeName();
     theme["themeMode"] = settings->theme()->themeMode();
+    theme["simplifiedHome"] = settings->theme()->simplifiedHome();
 
     // Export active palette as customColors (backward compat) plus both palettes
     QJsonObject customColors;
@@ -403,6 +407,9 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         if (espresso.contains("lastUsedRatio")) settings->brew()->setLastUsedRatio(espresso["lastUsedRatio"].toDouble());
         if (espresso.contains("doseCupTareWeight")) settings->brew()->setDoseCupTareWeight(espresso["doseCupTareWeight"].toDouble());
         if (espresso.contains("doseCaptureSoundEnabled")) settings->brew()->setDoseCaptureSoundEnabled(espresso["doseCaptureSoundEnabled"].toBool());
+        if (espresso.contains("ratioPreset1")) settings->brew()->setRatioPreset1(espresso["ratioPreset1"].toDouble());
+        if (espresso.contains("ratioPreset2")) settings->brew()->setRatioPreset2(espresso["ratioPreset2"].toDouble());
+        if (espresso.contains("ratioPreset3")) settings->brew()->setRatioPreset3(espresso["ratioPreset3"].toDouble());
     }
 
     // Steam settings
@@ -617,6 +624,7 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         QJsonObject theme = json["theme"].toObject();
         if (theme.contains("activeThemeName")) settings->theme()->setActiveThemeName(theme["activeThemeName"].toString());
         if (theme.contains("themeMode")) settings->theme()->setThemeMode(theme["themeMode"].toString());
+        if (theme.contains("simplifiedHome")) settings->theme()->setSimplifiedHome(theme["simplifiedHome"].toBool());
 
         // Restore dual palettes if present (new format)
         if (theme.contains("customColorsDark")) {


### PR DESCRIPTION
## Summary
An optional simplified home composition (fixed brew stat bar + setup buttons) plus a home-screen **ratio quick-select** (Ristretto / Normale / Lungo, editable). **Default OFF** — the zone-driven layout is byte-for-byte unchanged unless enabled in **Settings → Layout → "Use simplified home screen"**.

## What's in it
- New `simplifiedHome` theme setting (default `false`) + a toggle in Settings → Layout.
- When on: a fixed brew stat bar (profile / scale / ratio / beans / milk) and three setup buttons.
- **Ratio quick-select** dialog with editable presets; a tap sets **only** `lastUsedRatio` (it deliberately does not poke the persistent profile target / `brewYieldOverride`).
- Degrades gracefully without the weight-based-steaming PR (the milk cell simply shows "—").

## Independent & tested
- Diffs **only this feature** vs `main`.
- Builds on macOS; reviewed with the pr-review-toolkit; tested on-device.
- Ratio guidance/labels attributed to **La Marzocco**.

Replaces the stacked #1353, #1359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
