### PR TITLE
Bump version to 1.8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(Decenza VERSION 1.8.0 LANGUAGES CXX)
+project(Decenza VERSION 1.8.1 LANGUAGES CXX)
 
 message(STATUS "Developer note: executable target is now 'Decenza'. If Qt Creator shows 'No executable specified', re-run CMake and select the 'Decenza' Run configuration.")
 


### PR DESCRIPTION
Bumps the display version to 1.8.1 ahead of the v1.8.1 pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)