### PR TITLE
Add profile Rename (actions menu + MCP, in-place title rename)

### DIFF
--- a/docs/CLAUDE_MD/MCP_SERVER.md
+++ b/docs/CLAUDE_MD/MCP_SERVER.md
@@ -88,7 +88,7 @@ Each tool has a `category` that determines the minimum access level required:
 |----------|-----------------|-------|
 | `read` | 0 (Monitor) | machine_get_state, app_get_info, machine_get_telemetry, shots_list, shots_get_detail, shots_get_debug_log, shots_compare, profiles_list, profiles_get_active, profiles_get_detail, profiles_get_params, profiles_get_auto_load, settings_get, dialing_get_context, dialing_get_grinder_calibration, bag_list, equipment_list |
 | `control` | 1 (Control) | machine_wake, machine_sleep, machine_start_espresso, machine_start_steam, machine_start_hot_water, machine_start_flush, machine_stop, machine_skip_frame, shots_update, shots_upload_to_visualizer, backup_now, mqtt_connect, mqtt_disconnect, mqtt_publish_discovery, devices_connect_de1, devices_disconnect_scale, devices_reset_scale_priority, bag_select, equipment_select |
-| `settings` | 2 (Full) | profiles_set_active, profiles_edit_params, profiles_save, profiles_delete, profiles_create, shots_delete, settings_set, reset_saw_learning, clear_flow_calibration, apply_theme, bag_update, equipment_update |
+| `settings` | 2 (Full) | profiles_set_active, profiles_edit_params, profiles_save, profiles_delete, profiles_create, profiles_rename, shots_delete, settings_set, reset_saw_learning, clear_flow_calibration, apply_theme, bag_update, equipment_update |
 
 ### Tool → Confirmation Level Mapping
 
@@ -108,6 +108,7 @@ Two confirmation mechanisms are used depending on where the user is:
 | profiles_save | **Confirm** | Confirm | Chat |
 | profiles_delete | **Confirm** | Confirm | Chat |
 | profiles_create | **Confirm** | Confirm | Chat |
+| profiles_rename | **Confirm** | Confirm | Chat |
 | shots_delete | **Confirm** | Confirm | Chat |
 | settings_set | **Confirm** | Confirm | Chat |
 | shots_update | No confirm | No confirm | — |
@@ -210,6 +211,7 @@ The `de1://dialing` resource's grinder block also exposes `packageId`, `rpmAdjus
 | `profiles_save` | Save the current (modified) profile to disk. Without this, edits are active on the machine but lost if another profile is loaded. Optionally provide filename + title for Save As. | settings |
 | `profiles_delete` | Delete a user/downloaded profile. For built-in profiles, removes local overrides and reverts to the original built-in version. | settings |
 | `profiles_create` | Create a new blank profile with a given editor type (dflow, aflow, pressure, flow, advanced) and title. Uses the same creation functions as the QML UI. | settings |
+| `profiles_rename` | Rename a user/downloaded profile in place — changes only the display title, keeps the filename so favorites/auto-load/selected references stay valid. Built-in profiles are read-only and rejected (use `profiles_save` Save As to copy). | settings |
 | `profiles_get_auto_load` | Get the configured auto-load profile filename, title, and revert-minutes. Returns `filename: ""` and the current `revertMinutes` when no auto-load is set. | read |
 | `profiles_set_auto_load` | Pin a profile as the auto-load target (reloads on app start, DE1 wake, and after N idle minutes on the Idle page). Validates filename existence + Selected-list membership. Accepts optional `revertMinutes` (0..60). | settings |
 | `profiles_clear_auto_load` | Disable auto-load by clearing the pinned filename. Preserves the configured `revertMinutes`. | settings |

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -1499,7 +1499,9 @@ Page {
 
                     Keys.onReturnPressed: {
                         Qt.inputMethod.commit()
-                        if (renameProfileNameField.displayText.trim() !== "") {
+                        // Mirror the button's enabled condition so Enter on an
+                        // empty or unchanged title is a no-op without surprises.
+                        if (renameProfileButton.enabled) {
                             renameProfileButton.clicked()
                         }
                     }

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -897,6 +897,21 @@ Page {
                 }
             }
 
+            // Rename profile (user/downloaded only — built-ins are read-only)
+            AccessibleButton {
+                visible: !profileActionsDialog.profileIsBuiltIn
+                Layout.fillWidth: true
+                Layout.preferredHeight: visible ? Theme.scaled(40) : 0
+                text: TranslationManager.translate("profileselector.menu.rename", "Rename Profile")
+                accessibleName: TranslationManager.translate("profileselector.accessible.rename_profile", "Rename profile")
+                onClicked: {
+                    profileActionsDialog.close()
+                    renameProfileDialog.profileFilename = profileActionsDialog.profileFilename
+                    renameProfileDialog.currentTitle = profileActionsDialog.profileTitle
+                    renameProfileDialog.open()
+                }
+            }
+
             // Set / Disable Auto-Load (Selected-list only)
             AccessibleButton {
                 visible: profileActionsDialog.viewIsSelectedList || profileActionsDialog.profileIsSelected
@@ -1390,6 +1405,140 @@ Page {
                                     copyProfileDialog.close()
                                 } else {
                                     profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.copy_failed", "Failed to copy profile"))
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Item { implicitHeight: Theme.scaled(8) }
+            }
+        }
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.scaled(8)
+            border.color: Theme.borderColor
+        }
+    }
+
+    // Rename profile dialog
+    Dialog {
+        id: renameProfileDialog
+        anchors.centerIn: parent
+        width: Theme.scaled(400)
+        padding: 0
+        modal: true
+
+        property string profileFilename: ""
+        property string currentTitle: ""
+
+        onAboutToShow: {
+            renameProfileNameField.text = currentTitle
+            renameProfileNameField.forceActiveFocus()
+            renameProfileNameField.selectAll()
+        }
+
+        header: Item {
+            implicitHeight: Theme.scaled(50)
+
+            Text {
+                anchors.left: parent.left
+                anchors.leftMargin: Theme.scaled(20)
+                anchors.verticalCenter: parent.verticalCenter
+                text: TranslationManager.translate("profileselector.renameProfile.title", "Rename Profile")
+                font: Theme.titleFont
+                color: Theme.textColor
+            }
+
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 1
+                color: Theme.borderColor
+            }
+        }
+
+        contentItem: KeyboardAwareContainer {
+            inOverlay: true
+            textFields: [renameProfileNameField]
+            implicitHeight: renameProfileColumn.implicitHeight
+            implicitWidth: renameProfileColumn.implicitWidth
+
+            // Accessible.* must attach to an Item-derived object; Dialog
+            // (a Popup) is not one, so the dialog semantics live on its
+            // contentItem instead.
+            Accessible.role: Accessible.Dialog
+            Accessible.name: TranslationManager.translate("profileselector.renameProfile.title", "Rename Profile")
+
+            ColumnLayout {
+                id: renameProfileColumn
+                anchors.fill: parent
+                spacing: Theme.scaled(12)
+
+                Item { implicitHeight: Theme.scaled(8) }
+
+                Text {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.scaled(20)
+                    Layout.rightMargin: Theme.scaled(20)
+                    text: TranslationManager.translate("profileselector.renameProfile.label", "Enter a new name:")
+                    color: Theme.textColor
+                    font: Theme.bodyFont
+                    wrapMode: Text.Wrap
+                }
+
+                StyledTextField {
+                    id: renameProfileNameField
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.scaled(20)
+                    Layout.rightMargin: Theme.scaled(20)
+                    Layout.preferredHeight: Theme.scaled(44)
+                    placeholder: TranslationManager.translate("profileselector.renameProfile.placeholder", "Profile name")
+
+                    Keys.onReturnPressed: {
+                        Qt.inputMethod.commit()
+                        if (renameProfileNameField.displayText.trim() !== "") {
+                            renameProfileButton.clicked()
+                        }
+                    }
+                }
+
+                Item { implicitHeight: Theme.scaled(8) }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Theme.scaled(20)
+                    Layout.rightMargin: Theme.scaled(20)
+                    spacing: Theme.scaled(12)
+
+                    Item { Layout.fillWidth: true }
+
+                    AccessibleButton {
+                        text: TranslationManager.translate("common.button.cancel", "Cancel")
+                        accessibleName: TranslationManager.translate("common.accessibility.cancel", "Cancel")
+                        Layout.preferredHeight: Theme.scaled(40)
+                        onClicked: renameProfileDialog.close()
+                    }
+
+                    AccessibleButton {
+                        id: renameProfileButton
+                        text: TranslationManager.translate("profileselector.renameProfile.button", "Rename")
+                        accessibleName: TranslationManager.translate("profileselector.renameProfile.accessible", "Rename profile")
+                        primary: true
+                        enabled: renameProfileNameField.displayText.trim() !== ""
+                                 && renameProfileNameField.displayText.trim() !== renameProfileDialog.currentTitle
+                        Layout.preferredHeight: Theme.scaled(40)
+                        onClicked: {
+                            Qt.inputMethod.commit()
+                            var newTitle = renameProfileNameField.text.trim()
+                            if (newTitle !== "" && newTitle !== renameProfileDialog.currentTitle) {
+                                if (ProfileManager.renameProfile(renameProfileDialog.profileFilename, newTitle)) {
+                                    profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.profile_renamed", "Profile renamed"))
+                                    renameProfileDialog.close()
+                                } else {
+                                    profileSelectorPage.showToast(TranslationManager.translate("profileselector.toast.rename_failed", "Failed to rename profile"))
                                 }
                             }
                         }

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -1962,8 +1962,99 @@ bool ProfileManager::duplicateProfile(const QString& sourceFilename, const QStri
         }
         refreshProfiles();
     }
-    
+
     return success;
+}
+
+bool ProfileManager::renameProfile(const QString& filename, const QString& newTitle) {
+    const QString trimmedTitle = newTitle.trimmed();
+    if (trimmedTitle.isEmpty()) {
+        qWarning() << "ProfileManager::renameProfile: empty title for" << filename;
+        return false;
+    }
+
+    // Renaming changes only the title and keeps the filename (matching the
+    // advanced editor's in-place rename), so all filename-keyed references stay
+    // valid. Pure built-in profiles are read-only resources — refuse them here
+    // and gate the menu item to non-built-in profiles, like Delete.
+    ProfileSource source = ProfileSource::BuiltIn;
+    bool found = false;
+    for (const ProfileInfo& info : m_allProfiles) {
+        if (info.filename == filename) {
+            source = info.source;
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        qWarning() << "ProfileManager::renameProfile: unknown profile" << filename;
+        return false;
+    }
+    if (source == ProfileSource::BuiltIn) {
+        qWarning() << "ProfileManager::renameProfile: cannot rename built-in profile" << filename;
+        return false;
+    }
+
+    // Load the profile JSON (ProfileStorage → user → downloaded), mirroring loadProfile().
+    QString jsonContent;
+    if (m_profileStorage && m_profileStorage->isConfigured()) {
+        jsonContent = m_profileStorage->readProfile(filename);
+    }
+    if (jsonContent.isEmpty()) {
+        QFile userFile(userProfilesPath() + "/" + filename + ".json");
+        if (userFile.open(QIODevice::ReadOnly))
+            jsonContent = QString::fromUtf8(userFile.readAll());
+    }
+    if (jsonContent.isEmpty()) {
+        QFile downloadedFile(downloadedProfilesPath() + "/" + filename + ".json");
+        if (downloadedFile.open(QIODevice::ReadOnly))
+            jsonContent = QString::fromUtf8(downloadedFile.readAll());
+    }
+    if (jsonContent.isEmpty()) {
+        qWarning() << "ProfileManager::renameProfile: could not load profile" << filename;
+        return false;
+    }
+
+    // Profile::loadFromJsonString returns a default profile on parse failure, so
+    // verify the JSON is well-formed before trusting it (matches duplicateProfile).
+    QJsonParseError parseErr;
+    QJsonDocument doc = QJsonDocument::fromJson(jsonContent.toUtf8(), &parseErr);
+    if (parseErr.error != QJsonParseError::NoError || !doc.isObject()) {
+        qWarning() << "ProfileManager::renameProfile: malformed JSON for" << filename
+                   << parseErr.errorString();
+        return false;
+    }
+
+    Profile renamed = Profile::loadFromJsonString(jsonContent);
+    renamed.setTitle(trimmedTitle);
+
+    // Write back to the SAME filename (ProfileStorage → local fallback).
+    bool success = false;
+    if (m_profileStorage && m_profileStorage->isConfigured()) {
+        success = m_profileStorage->writeProfile(filename, renamed.toJsonString());
+    }
+    if (!success) {
+        success = renamed.saveToFile(userProfilesPath() + "/" + filename + ".json");
+    }
+    if (!success) {
+        qWarning() << "ProfileManager::renameProfile: failed to write" << filename;
+        return false;
+    }
+
+    // Favorites store the display title alongside the filename — keep it in sync.
+    if (m_settings && m_settings->app()->isFavoriteProfile(filename)) {
+        m_settings->app()->updateFavoriteProfile(filename, filename, trimmedTitle);
+    }
+
+    // If the renamed profile is the one currently loaded, update the live copy so
+    // editor/idle headers reflect the new name immediately.
+    if (m_baseProfileName == filename) {
+        m_currentProfile.setTitle(trimmedTitle);
+        emit currentProfileChanged();
+    }
+
+    refreshProfiles();
+    return true;
 }
 
 

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -2042,8 +2042,13 @@ bool ProfileManager::renameProfile(const QString& filename, const QString& newTi
     }
 
     // Favorites store the display title alongside the filename — keep it in sync.
+    // The profile JSON is already written at this point, so a sync miss would
+    // leave the favorites list showing a stale title; surface it rather than
+    // swallow it (the preceding isFavoriteProfile guard makes it near-unreachable).
     if (m_settings && m_settings->app()->isFavoriteProfile(filename)) {
-        m_settings->app()->updateFavoriteProfile(filename, filename, trimmedTitle);
+        if (!m_settings->app()->updateFavoriteProfile(filename, filename, trimmedTitle)) {
+            qWarning() << "ProfileManager::renameProfile: favorite title sync failed for" << filename;
+        }
     }
 
     // If the renamed profile is the one currently loaded, update the live copy so

--- a/src/controllers/profilemanager.h
+++ b/src/controllers/profilemanager.h
@@ -171,6 +171,10 @@ public slots:
     Q_INVOKABLE bool saveProfile(const QString& filename);
     Q_INVOKABLE bool saveProfileAs(const QString& filename, const QString& title);
     Q_INVOKABLE bool duplicateProfile(const QString& sourceFilename, const QString& newTitle);
+    // Rename in place: changes only the profile's display title, keeping the same
+    // filename (so favorites/auto-load/selected references stay valid). Built-in
+    // profiles are read-only resources and cannot be renamed — use Copy instead.
+    Q_INVOKABLE bool renameProfile(const QString& filename, const QString& newTitle);
 
     // Communication-failure dialog support.
     bool de1CommunicationFailure() const { return m_de1CommunicationFailure; }

--- a/src/mcp/mcptools_profiles.cpp
+++ b/src/mcp/mcptools_profiles.cpp
@@ -594,6 +594,67 @@ void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileMana
         },
         "settings");
 
+    // profiles_rename
+    registry->registerTool(
+        "profiles_rename",
+        "Rename a user or downloaded profile in place. Changes only the profile's display title and "
+        "keeps the same filename, so favorites, auto-load, and the selected list stay intact. "
+        "Built-in profiles are read-only and cannot be renamed — use profiles_save with a new "
+        "filename/title to make an editable copy instead.",
+        QJsonObject{
+            {"type", "object"},
+            {"properties", QJsonObject{
+                {"filename", QJsonObject{{"type", "string"}, {"description", "Profile filename to rename (without .json)"}}},
+                {"title", QJsonObject{{"type", "string"}, {"description", "New display title for the profile"}}},
+                {"confirmed", QJsonObject{{"type", "boolean"}, {"description", "Set to true after user confirms this action in chat"}}}
+            }},
+            {"required", QJsonArray{"filename", "title"}}
+        },
+        [profileManager](const QJsonObject& args) -> QJsonObject {
+            QJsonObject result;
+            if (!profileManager) {
+                result["error"] = "Controller not available";
+                return result;
+            }
+
+            QString filename = args["filename"].toString();
+            QString newTitle = args["title"].toString().trimmed();
+            if (filename.isEmpty()) {
+                result["error"] = "filename is required";
+                return result;
+            }
+            if (newTitle.isEmpty()) {
+                result["error"] = "title is required";
+                return result;
+            }
+
+            if (!profileManager->profileExists(filename)) {
+                result["error"] = "Profile not found: " + filename;
+                return result;
+            }
+
+            if (profileManager->isBuiltInFilename(filename)) {
+                result["error"] = "Cannot rename built-in profile '" + filename +
+                    "'. Built-in profiles are read-only — use profiles_save with a new "
+                    "filename/title to make an editable copy instead.";
+                result["filename"] = filename;
+                return result;
+            }
+
+            // Tool handlers run on the main thread (via ShotServer), so call directly
+            bool success = profileManager->renameProfile(filename, newTitle);
+            if (success) {
+                result["success"] = true;
+                result["message"] = "Profile renamed to: " + newTitle;
+                result["filename"] = filename;
+                result["title"] = newTitle;
+            } else {
+                result["error"] = "Failed to rename profile: " + filename;
+            }
+            return result;
+        },
+        "settings");
+
     // profiles_create
     registry->registerTool(
         "profiles_create",

--- a/tests/tst_mcptools_profiles.cpp
+++ b/tests/tst_mcptools_profiles.cpp
@@ -247,6 +247,40 @@ private slots:
         QJsonObject result = f.callTool("profiles_get_detail", {{"filename", ""}});
         QVERIFY(result.contains("error"));
     }
+
+    // ===== profiles_rename =====
+
+    void renameRequiresFilename()
+    {
+        McpTestFixture f;
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
+
+        QJsonObject result = f.callTool("profiles_rename", {{"filename", ""}, {"title", "New Name"}});
+        QVERIFY(result.contains("error"));
+        QVERIFY(!result.contains("success"));
+    }
+
+    void renameRequiresTitle()
+    {
+        McpTestFixture f;
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
+
+        // Whitespace-only title trims to empty and must be rejected.
+        QJsonObject result = f.callTool("profiles_rename", {{"filename", "some_profile"}, {"title", "   "}});
+        QVERIFY(result.contains("error"));
+        QVERIFY(!result.contains("success"));
+    }
+
+    void renameUnknownProfileReturnsError()
+    {
+        McpTestFixture f;
+        registerProfileTools(&f.registry, &f.profileManager, &f.settings);
+
+        QJsonObject result = f.callTool("profiles_rename",
+                                        {{"filename", "definitely_not_a_real_profile"}, {"title", "New Name"}});
+        QVERIFY(result.contains("error"));
+        QVERIFY(result["error"].toString().contains("not found", Qt::CaseInsensitive));
+    }
 };
 
 QTEST_MAIN(tst_McpToolsProfiles)

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -1439,6 +1439,94 @@ private slots:
         QFile::remove(f.profileManager.userProfilesPath() + "/test_user_copy_xyz.json");
     }
 
+    // === renameProfile (in-place title rename) ===
+
+    void renameProfileChangesTitleKeepsFilename() {
+        McpTestFixture f;
+        loadDFlowProfile(f, "D-Flow / BeforeRename", 37.0);
+        QVERIFY(f.profileManager.saveProfile("rename_test_xyz"));
+
+        bool ok = f.profileManager.renameProfile("rename_test_xyz", "D-Flow / AfterRename");
+
+        QVERIFY(ok);
+        // Filename is unchanged — the same file holds the new title.
+        QString path = f.profileManager.userProfilesPath() + "/rename_test_xyz.json";
+        QVERIFY(QFile::exists(path));
+        // The on-disk title reflects the rename; other fields are preserved.
+        QVariantMap p = f.profileManager.getProfileByFilename("rename_test_xyz");
+        QCOMPARE(p["title"].toString(), QString("D-Flow / AfterRename"));
+        QCOMPARE(p["target_weight"].toDouble(), 37.0);
+
+        QFile::remove(path);
+    }
+
+    void renameProfileUpdatesActiveProfileAndEmitsSignal() {
+        McpTestFixture f;
+        loadDFlowProfile(f, "D-Flow / ActiveBefore");
+        QVERIFY(f.profileManager.saveProfile("rename_active_xyz"));
+        QCOMPARE(f.profileManager.baseProfileName(), "rename_active_xyz");
+
+        QSignalSpy spy(&f.profileManager, &ProfileManager::currentProfileChanged);
+        bool ok = f.profileManager.renameProfile("rename_active_xyz", "D-Flow / ActiveAfter");
+
+        QVERIFY(ok);
+        // The live copy of the active profile reflects the new title immediately.
+        QCOMPARE(f.profileManager.currentProfileName(), QString("D-Flow / ActiveAfter"));
+        QVERIFY(spy.count() >= 1);
+
+        QFile::remove(f.profileManager.userProfilesPath() + "/rename_active_xyz.json");
+    }
+
+    void renameProfileSyncsFavoriteTitle() {
+        McpTestFixture f;
+        loadDFlowProfile(f, "D-Flow / FavBefore");
+        QVERIFY(f.profileManager.saveProfile("rename_fav_xyz"));
+        f.settings.app()->addFavoriteProfile("D-Flow / FavBefore", "rename_fav_xyz");
+        QVERIFY(f.settings.app()->isFavoriteProfile("rename_fav_xyz"));
+
+        bool ok = f.profileManager.renameProfile("rename_fav_xyz", "D-Flow / FavAfter");
+
+        QVERIFY(ok);
+        // Favorite stays keyed by the same filename, with its stored title updated.
+        QVERIFY(f.settings.app()->isFavoriteProfile("rename_fav_xyz"));
+        QString favTitle;
+        const QVariantList favs = f.settings.app()->favoriteProfiles();
+        for (const QVariant& v : favs) {
+            const QVariantMap m = v.toMap();
+            if (m["filename"].toString() == "rename_fav_xyz") {
+                favTitle = m["name"].toString();
+                break;
+            }
+        }
+        QCOMPARE(favTitle, QString("D-Flow / FavAfter"));
+
+        QFile::remove(f.profileManager.userProfilesPath() + "/rename_fav_xyz.json");
+    }
+
+    void renameProfileRejectsEmptyTitle() {
+        McpTestFixture f;
+        loadDFlowProfile(f, "D-Flow / Whitespace");
+        QVERIFY(f.profileManager.saveProfile("rename_empty_xyz"));
+
+        // Whitespace-only title trims to empty and must be rejected.
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("renameProfile"));
+        QVERIFY(!f.profileManager.renameProfile("rename_empty_xyz", "   "));
+
+        QFile::remove(f.profileManager.userProfilesPath() + "/rename_empty_xyz.json");
+    }
+
+    void renameProfileRejectsBuiltIn() {
+        McpTestFixture f;
+        // "default" is a known built-in (read-only QRC resource).
+        if (!f.profileManager.isBuiltInFilename("default")) {
+            QSKIP("No built-in profiles in test binary QRC");
+        }
+        // renameProfile refuses built-in profiles via ProfileSource::BuiltIn —
+        // built-ins are read-only, so they can only be copied, not renamed.
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("renameProfile"));
+        QVERIFY(!f.profileManager.renameProfile("default", "Hacked Title"));
+    }
+
     // === ProfileSaveHelper::compareProfiles() — unified duplicate detection ===
 
     void compareProfilesIdentical() {


### PR DESCRIPTION
## What

Adds a **Rename** action for profiles, in two surfaces:
- **Profile actions menu** on the Profile Selector (alongside Edit and Copy).
- **`profiles_rename` MCP tool** so the AI/remote UI can do the same.

## Why

The advanced frame editor already lets you rename a profile inline (its Profile Settings panel has a Name field). The other three editors — D-Flow/A-Flow (`RecipeEditorPage`) and Pressure/Flow (`SimpleProfileEditorPage`) — only expose naming through **Save As**, which *copies* the profile. This adds a single Rename action that works uniformly for every profile type.

## How

- **`ProfileManager::renameProfile(filename, newTitle)`** — changes only the profile's **display title** and keeps the same **filename**, matching the advanced editor's in-place rename. Favorites, auto-load, and the selected list are all filename-keyed, so those references stay valid with no migration. The favorite's stored title is synced, and if the renamed profile is currently loaded its live copy is updated (+`currentProfileChanged`) so editor/idle headers refresh immediately.
- **QML**: "Rename Profile" menu item + rename dialog in `ProfileSelectorPage.qml`, mirroring the Copy dialog. **Gated to non-built-in profiles** (`visible: !profileIsBuiltIn`), so built-ins — which are read-only resources — never show Rename. Rename button disables on an empty or unchanged name.
- **MCP**: `profiles_rename` (settings access, confirm-gated). Rejects built-in filenames with a message pointing to `profiles_save` (Save As) for an editable copy. Documented in `MCP_SERVER.md`.

## Built-in profiles

Built-ins are read-only, so you **can't rename them — only copy**. The menu item is hidden for built-ins, and the MCP tool returns an error directing to Save As.

## Testing

- Clean compile via Qt Creator (0 errors, 0 warnings).
- `tst_mcptools_profiles` — added argument-guard tests (empty filename, empty/whitespace title, unknown profile). **13 passed, 0 failed.**
- No disk-write unit test for the success path: `renameProfile` writes to the app-data profiles dir, the same reason the sibling `duplicateProfile` has no unit test. Logic closely mirrors `duplicateProfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)