### PR TITLE
AI advisor: preserve the message and add Retry on a failed request

### DIFF
--- a/openspec/changes/add-ai-advisor-retry/.openspec.yaml
+++ b/openspec/changes/add-ai-advisor-retry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-21

--- a/openspec/changes/add-ai-advisor-retry/design.md
+++ b/openspec/changes/add-ai-advisor-retry/design.md
@@ -1,0 +1,91 @@
+## Context
+
+The in-app AI advisor runs through `AIConversation` (`src/ai/aiconversation.{h,cpp}`), which dispatches requests via `AIManager::analyzeConversation()` → `AIProvider` (HTTP). The conversation is a `QJsonArray m_messages` of `{role, content, [shotId], [structuredNext]}` turns. The QML chat UI is `qml/components/ConversationOverlay.qml`.
+
+Today's failure path (`aiconversation.cpp:416-433`):
+
+```cpp
+void AIConversation::onAnalysisFailed(const QString& error)
+{
+    if (!m_busy) return;
+    m_busy = false;
+    m_errorMessage = error;
+    if (!m_messages.isEmpty())
+        m_messages.removeLast();   // <-- discards the user's typed turn
+    emit busyChanged();
+    emit historyChanged();
+    emit errorOccurred(error);
+}
+```
+
+The QML send handler (`ConversationOverlay.qml:528-576`) clears the text field synchronously on a successful submit (`text = ""`). So once a request is in flight, the only copy of the user's message lives in `m_messages` — and `onAnalysisFailed` then deletes it. The user sees the error box (`ConversationOverlay.qml:402-420`) but the message is unrecoverable.
+
+`AIProvider` already auto-retries transient HTTP statuses (429/502/503/504) with backoff, but **not** `QNetworkReply::TimeoutError` — timeouts flow straight to `onAnalysisFailed`. `hasHistory()` is `!m_messages.isEmpty()`, so keeping a failed turn flips `hasHistory` true and routes the next send through `followUp()` rather than `ask()`.
+
+**Confirmed real-world failure** (DE1 tablet debug log, session 2026-06-21 11:53):
+
+```
+[322.486] AIConversation: Sending request with 5 messages
+[323.608] WARN "Google Gemini" HTTP 503 - retry 1 in 1000 ms  ("...high demand... Please try again later.")
+[384.157] WARN QIODevice::read (QNetworkReplyHttpImpl): device not open
+[384.211] AIConversation: Request failed: "Request timed out. The AI service may be slow — please try again."
+```
+
+The trigger was a Gemini **HTTP 503** (model overloaded), not a raw network timeout. The provider's built-in auto-retry *did* fire (`retry 1`), but the model stayed overloaded and the request hit the 60s analysis timeout, surfacing the generic "Request timed out" message. The auto-retry could not save it — which is exactly why a **user-initiated** retry (wait, then try again, as the message advises) is the right fix. The failed turn was a follow-up (5 messages), so `onAnalysisFailed` → `removeLast()` deleted the typed question; the conversation's last persisted state was the prior 4-message success, so the lost turn was never saved.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Never silently lose a typed advisor message on a failed request.
+- Let the user re-send the failed message with one tap, no retyping.
+- Keep the provider message stream role-alternating (no two consecutive user turns), which Anthropic's API requires.
+
+**Non-Goals:**
+- Automatic/background retry on timeout (explicit user action only).
+- Editing the failed message before retry (re-send verbatim; typing a new message is the "edit" path).
+- Restoring the cleared text back into the input field (the message lives in history; Retry re-sends from there).
+- A Retry affordance in `AIConversationPanel.qml` (out of scope unless trivial).
+
+## Decisions
+
+**1. Stop discarding the failed turn.** Remove the `m_messages.removeLast()` from `onAnalysisFailed()`. The failed user turn stays as the trailing entry; the message bubble remains visible with the error beneath it. Because conversations are saved only in `onAnalysisComplete()` (success), a failed turn is never persisted — reload behavior is unchanged.
+
+**2. Add `Q_INVOKABLE void retry()`.** It re-dispatches the pending turn:
+
+```cpp
+void AIConversation::retry()
+{
+    if (m_busy) return;
+    if (m_messages.isEmpty()) return;
+    if (m_messages.last().toObject().value("role").toString() != "user") return; // nothing pending
+    m_errorMessage.clear();
+    emit errorOccurred(m_errorMessage); // notify so errorMessage binding refreshes
+    sendRequest();                       // sets busy, trims, re-sends existing m_messages
+}
+```
+
+`retry()` deliberately does **not** call `followUp()` — that would append a duplicate user turn and re-run the rating/bean-correction capture hooks (`followUp` lines 110-133), which already fired on the first submit. It reuses the stored `m_systemPrompt` and `m_messages` as-is.
+
+**3. Drop the orphan user turn in `followUp()`.** At the top of `followUp()` (before the rating hooks read the *prior* assistant message), if the last entry is a user turn, the previous request failed and was preserved — remove it so the new message doesn't create two consecutive user turns:
+
+```cpp
+// A preserved failed turn (last entry is a user message with no assistant reply)
+// is superseded by this new message — drop it to keep roles alternating.
+if (!m_messages.isEmpty() &&
+    m_messages.last().toObject().value("role").toString() == "user") {
+    m_messages.removeLast();
+}
+```
+
+This runs only when the last turn is unanswered; a normal follow-up (last entry = assistant) is untouched. The rating-capture loop already scans backwards for the most-recent *assistant* turn, so removing a trailing *user* turn first does not disturb it.
+
+**4. Expose retry-availability to QML.** Add a read-only `Q_PROPERTY(bool canRetry ...)` (NOTIFY on the existing `historyChanged`/`busyChanged` signals) returning `!m_busy && !m_messages.isEmpty() && lastRole == "user"`. The error `Rectangle` in `ConversationOverlay.qml` already keys off `errorMessage.length > 0 && !busy`; the Retry button binds `visible: conversation.canRetry`. Wired to `conversation.retry()`, internationalized (reuse a `common.button.retry` key if present, else add one), with the standard `Accessible.*` attributes for an interactive control. Lay it out inside the existing error row beside the message text.
+
+**5. Timeouts stay non-auto-retried.** No change to `AIProvider`'s retry policy. Manual retry is sufficient and keeps the user in control; auto-retrying a 60s timeout could double the wait.
+
+## Risks / Trade-offs
+
+- **Stale shotId on the preserved turn.** A failed turn keeps whatever `shotId` was bound to it; `retry()` re-sends the same turn, so the binding stays correct. No special handling needed.
+- **`hasHistory` flips true after a first-question failure.** The next QML send then routes through `followUp()` instead of `ask()`. `followUp()` requires a non-empty `m_systemPrompt`, which `ask()` set before failing — so it works, and the orphan-drop (Decision 3) keeps the stream clean. Verified against `ConversationOverlay.qml:552`.
+- **Double-send guard.** `retry()` and `sendRequest()` both early-return when `m_busy`; the Retry button is hidden while busy (`canRetry` is false), so rapid taps cannot stack requests.
+- **Minimal surface.** Changes are confined to `AIConversation` plus one QML button; no DB, settings, BLE, or provider changes, keeping regression risk low.

--- a/openspec/changes/add-ai-advisor-retry/proposal.md
+++ b/openspec/changes/add-ai-advisor-retry/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+When an AI advisor request fails (e.g. the cloud API times out — Decenza shows "Request timed out. The AI service may be slow — please try again."), `AIConversation::onAnalysisFailed()` deletes the user's message from the conversation, and the QML input field was already cleared on send. The user's typed question is gone with no way to recover it — they must retype the whole thing. There is no retry affordance, so a single transient timeout forces a full re-type.
+
+## What Changes
+
+- On a failed advisor request, **keep** the user's failed turn in the conversation instead of discarding it. The message bubble stays visible and the error is shown beneath it.
+- Add a `retry()` method on `AIConversation` that re-sends the already-stored pending turn (same message, same system prompt) without requiring the user to retype. It clears the prior error, sets busy, and dispatches the request again.
+- Add a **Retry** button to the advisor error UI (`ConversationOverlay.qml`) shown alongside the timeout/error message, wired to `conversation.retry()`.
+- Preserve the role-alternation invariant: if the user instead types a *new* message after a failure (routing through `followUp()`), the stale unanswered user turn is dropped before the new turn is added, so the provider never receives two consecutive user-role messages.
+- No automatic retry on timeout (the network-layer auto-retry for 429/502/503/504 is unchanged); retry is an explicit user action.
+
+## Capabilities
+
+### New Capabilities
+- `advisor-retry-on-failure`: When an AI advisor request fails, the conversation preserves the user's pending turn, exposes an explicit retry that re-sends it, and maintains the message-role-alternation invariant for subsequent sends.
+
+### Modified Capabilities
+<!-- None: advisor-conversation-history covers turn persistence/shotId binding and is not changing its requirements. Failure/retry handling is new behavior. -->
+
+## Impact
+
+- `src/ai/aiconversation.h` / `src/ai/aiconversation.cpp`: stop discarding the failed user turn in `onAnalysisFailed()`; add `Q_INVOKABLE void retry()`; add orphan-user-turn cleanup at the top of `followUp()`. May add a `canRetry`/`hasPendingFailedTurn` read property for the QML to bind the button's visibility/enabled state.
+- `qml/components/ConversationOverlay.qml`: add a Retry button to the existing error `Rectangle` (lines ~402-420), internationalized via `TranslationManager`/`Tr`, with proper `Accessible.*` attributes.
+- No DB schema, BLE, or settings changes. Conversations are only persisted on success, so no failed/orphan turn is ever written to storage — load behavior is unaffected.
+- Optional: `qml/components/AIConversationPanel.qml` surfaces `errorMessage` too; a retry affordance there is out of scope unless trivial.

--- a/openspec/changes/add-ai-advisor-retry/specs/advisor-retry-on-failure/spec.md
+++ b/openspec/changes/add-ai-advisor-retry/specs/advisor-retry-on-failure/spec.md
@@ -1,0 +1,88 @@
+# advisor-retry-on-failure Specification
+
+## ADDED Requirements
+
+### Requirement: A failed advisor request SHALL preserve the user's pending turn
+
+When an in-flight advisor request fails (any error delivered to `AIConversation::onAnalysisFailed`, including network timeout), the conversation SHALL retain the user message that was being sent rather than discarding it. The failed user turn SHALL remain the last entry in `m_messages`, the error text SHALL be exposed via `errorMessage`, and `busy` SHALL be cleared.
+
+A failed request SHALL NOT be persisted to storage — only successful turns are saved — so a preserved failed turn never appears when a conversation is reloaded.
+
+#### Scenario: Timeout keeps the user's message
+
+- **GIVEN** an advisor conversation with a prior user/assistant pair
+- **AND** the user sends a follow-up "Why is this sour?"
+- **WHEN** the request fails with a timeout error
+- **THEN** "Why is this sour?" SHALL remain as the last user turn in the conversation
+- **AND** `errorMessage` SHALL be the failure text
+- **AND** `busy` SHALL be `false`
+
+#### Scenario: First-question failure keeps the message
+
+- **GIVEN** an empty advisor conversation
+- **WHEN** the user's first `ask(...)` request fails
+- **THEN** the user's message SHALL remain in the conversation
+- **AND** the conversation SHALL report `hasHistory == true`
+
+### Requirement: `AIConversation` SHALL expose an explicit `retry()` that re-sends the pending turn
+
+`AIConversation` SHALL provide a `Q_INVOKABLE void retry()` that re-dispatches the last failed turn. `retry()` SHALL be valid only when the conversation is not busy and the last entry in `m_messages` is a user turn (a pending, unanswered turn). When valid, it SHALL clear `errorMessage`, set `busy`, and re-send the existing messages and system prompt without modifying the message history and without requiring the user to retype.
+
+`retry()` SHALL re-use the already-stored message — it SHALL NOT append a new user turn and SHALL NOT re-run the per-follow-up rating/metadata-capture hooks (those already ran when the turn was first submitted).
+
+Retry SHALL be a user-initiated action only; the conversation SHALL NOT automatically retry on timeout. (The network-layer auto-retry for transient HTTP 429/502/503/504 is unchanged and independent.)
+
+#### Scenario: Retry re-sends the same message
+
+- **GIVEN** a conversation whose last turn failed and is preserved as the pending user turn
+- **WHEN** `retry()` is called
+- **THEN** the same message SHALL be re-sent to the AI provider
+- **AND** `errorMessage` SHALL be cleared and `busy` SHALL become `true`
+- **AND** no additional user turn SHALL be appended to the history
+
+#### Scenario: Retry succeeds on the second attempt
+
+- **GIVEN** a preserved failed user turn
+- **WHEN** `retry()` is called and the request succeeds
+- **THEN** the assistant response SHALL be appended after the preserved user turn
+- **AND** the conversation SHALL be saved to storage
+
+#### Scenario: Retry is a no-op when not applicable
+
+- **GIVEN** a conversation that is busy, OR whose last turn is an assistant turn (no pending failure)
+- **WHEN** `retry()` is called
+- **THEN** no request SHALL be sent and the history SHALL be unchanged
+
+### Requirement: Sending a new message after a failure SHALL preserve role alternation
+
+If, after a failure, the user submits a *new* message through `followUp()` instead of retrying, the conversation SHALL drop the stale unanswered user turn before appending the new user message, so the provider never receives two consecutive user-role messages. This cleanup SHALL apply only when the last entry is a user turn; a normal follow-up after a successful turn (last entry is an assistant turn) SHALL NOT remove anything.
+
+#### Scenario: New message replaces the failed pending turn
+
+- **GIVEN** a conversation whose last turn is a preserved failed user message "Why is this sour?"
+- **WHEN** the user submits a new follow-up "Actually, why is it bitter?"
+- **THEN** the stale "Why is this sour?" user turn SHALL be removed
+- **AND** "Actually, why is it bitter?" SHALL be the only trailing user turn sent to the provider
+
+#### Scenario: Normal follow-up is unaffected
+
+- **GIVEN** a conversation whose last turn is an assistant response
+- **WHEN** the user submits a follow-up
+- **THEN** no prior turn SHALL be removed
+- **AND** the new user message SHALL be appended after the assistant turn
+
+### Requirement: The advisor error UI SHALL offer a Retry action
+
+`ConversationOverlay.qml` SHALL present a Retry control together with the error message when a request has failed and a pending user turn exists. Activating it SHALL call `conversation.retry()`. The control SHALL be internationalized via the project's translation mechanism and SHALL carry the accessibility attributes required of interactive elements (`Accessible.role`, `Accessible.name`, `Accessible.focusable`, `Accessible.onPressAction`).
+
+#### Scenario: Retry button appears with the error and re-sends on tap
+
+- **GIVEN** the advisor overlay is showing a timeout error with a preserved pending turn
+- **THEN** a Retry control SHALL be visible alongside the error text
+- **WHEN** the user activates Retry
+- **THEN** `conversation.retry()` SHALL be invoked and the request SHALL be re-sent
+
+#### Scenario: Retry control hidden while busy and when no failure is pending
+
+- **GIVEN** the conversation is busy (request in flight) OR there is no error/pending failed turn
+- **THEN** the Retry control SHALL NOT be shown

--- a/openspec/changes/add-ai-advisor-retry/specs/advisor-retry-on-failure/spec.md
+++ b/openspec/changes/add-ai-advisor-retry/specs/advisor-retry-on-failure/spec.md
@@ -55,7 +55,7 @@ Retry SHALL be a user-initiated action only; the conversation SHALL NOT automati
 
 ### Requirement: Sending a new message after a failure SHALL preserve role alternation
 
-If, after a failure, the user submits a *new* message through `followUp()` instead of retrying, the conversation SHALL drop the stale unanswered user turn before appending the new user message, so the provider never receives two consecutive user-role messages. This cleanup SHALL apply only when the last entry is a user turn; a normal follow-up after a successful turn (last entry is an assistant turn) SHALL NOT remove anything.
+If, after a failure, the user submits a *new* message instead of retrying — via any append-then-send entry point (`followUp()` or `addShotContext()`) — the conversation SHALL drop the stale unanswered user turn before appending the new user message, so the provider never receives two consecutive user-role messages. This cleanup SHALL apply only when the last entry is a user turn; a normal follow-up after a successful turn (last entry is an assistant turn) SHALL NOT remove anything.
 
 #### Scenario: New message replaces the failed pending turn
 

--- a/openspec/changes/add-ai-advisor-retry/tasks.md
+++ b/openspec/changes/add-ai-advisor-retry/tasks.md
@@ -1,0 +1,19 @@
+## 1. Preserve the failed turn and add retry (C++)
+
+- [x] 1.1 In `src/ai/aiconversation.cpp` `onAnalysisFailed()`, remove the `m_messages.removeLast()` block so the failed user turn is kept; leave `errorMessage`/`busy`/signal emission intact.
+- [x] 1.2 Add `Q_INVOKABLE void retry()` (declare in `aiconversation.h`, implement in `.cpp`): early-return when `m_busy`, when `m_messages` is empty, or when the last turn's role is not `"user"`; otherwise clear `m_errorMessage`, emit the error-changed notify, and call `sendRequest()`. Do NOT call `followUp()` or re-run the rating/bean-correction hooks.
+- [x] 1.3 In `followUp()`, before the rating-capture logic, drop a trailing orphan user turn: if the last entry's role is `"user"`, `removeLast()` it (preserves role alternation when the user types a new message instead of retrying).
+- [x] 1.4 Add `Q_PROPERTY(bool canRetry READ canRetry NOTIFY ...)` (notify via a dedicated `canRetryChanged`) returning `!m_busy && !m_messages.isEmpty() && lastRole == "user"`; implement `bool canRetry() const`.
+
+## 2. Retry affordance in the chat UI (QML)
+
+- [x] 2.1 In `qml/components/ConversationOverlay.qml`, add a Retry button to the error `Rectangle` (~lines 402-420), beside the error text; bind `visible`/`enabled` to `conversation.canRetry`.
+- [x] 2.2 Wire the button's activation to `MainController.aiManager.conversation.retry()`.
+- [x] 2.3 Internationalize the label (new `conversation.retry` / `conversation.retry.accessible` keys) and add `Accessible.role`/`Accessible.name`/`Accessible.focusable`/`Accessible.onPressAction`.
+
+## 3. Verify
+
+- [ ] 3.1 Build via Qt Creator (no warnings) and confirm the advisor compiles/links.
+- [ ] 3.2 Manually reproduce a failure (e.g. force a timeout / disconnect network) and confirm: the message stays, the Retry button appears, tapping it re-sends, and a successful retry appends the assistant reply.
+- [ ] 3.3 Confirm typing a new message after a failure does not produce two consecutive user turns (check the request payload / no Anthropic role-alternation error).
+- [ ] 3.4 Confirm a first-question (`ask`) failure is also retryable and that the next normal follow-up after a success is unaffected.

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -399,23 +399,68 @@ Rectangle {
                     }
                 }
 
-                // Error message display
+                // Error message display (with Retry when the failed turn can be re-sent)
                 Rectangle {
-                    visible: MainController.aiManager && MainController.aiManager.conversation &&
-                             MainController.aiManager.conversation.errorMessage.length > 0 &&
-                             !MainController.aiManager.conversation.busy
+                    id: errorBox
+                    readonly property var _conv: MainController.aiManager ? MainController.aiManager.conversation : null
+                    visible: _conv && _conv.errorMessage.length > 0 && !_conv.busy
                     Layout.fillWidth: true
-                    height: Theme.scaled(28)
+                    Layout.preferredHeight: Theme.scaled(36)
                     radius: Theme.scaled(4)
                     color: Qt.rgba(Theme.errorColor.r, Theme.errorColor.g, Theme.errorColor.b, 0.15)
                     border.color: Theme.errorColor
                     border.width: 1
 
-                    Text {
-                        anchors.centerIn: parent
-                        text: MainController.aiManager && MainController.aiManager.conversation ? (MainController.aiManager.conversation.errorMessage || "") : ""
-                        font.pixelSize: Theme.scaled(11)
-                        color: Theme.errorColor
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: Theme.scaled(10)
+                        anchors.rightMargin: Theme.scaled(6)
+                        spacing: Theme.scaled(8)
+
+                        Text {
+                            Layout.fillWidth: true
+                            text: errorBox._conv ? (errorBox._conv.errorMessage || "") : ""
+                            font.pixelSize: Theme.scaled(11)
+                            color: Theme.errorColor
+                            wrapMode: Text.WordWrap
+                            maximumLineCount: 2
+                            elide: Text.ElideRight
+                            verticalAlignment: Text.AlignVCenter
+                        }
+
+                        // Retry: re-sends the preserved failed turn without retyping.
+                        Rectangle {
+                            id: retryButton
+                            visible: errorBox._conv && errorBox._conv.canRetry
+                            Layout.preferredWidth: Theme.scaled(64)
+                            Layout.preferredHeight: Theme.scaled(28)
+                            radius: Theme.scaled(6)
+                            color: Theme.errorColor
+                            border.width: 0
+
+                            Accessible.role: Accessible.Button
+                            Accessible.name: TranslationManager.translate("conversation.retry.accessible", "Retry sending message")
+                            Accessible.focusable: true
+                            Accessible.onPressAction: retryArea.clicked(null)
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: TranslationManager.translate("conversation.retry", "Retry")
+                                font: Theme.bodyFont
+                                color: Theme.primaryContrastColor
+                                Accessible.ignored: true
+                            }
+
+                            MouseArea {
+                                id: retryArea
+                                anchors.fill: parent
+                                enabled: retryButton.visible
+                                onClicked: {
+                                    if (errorBox._conv)
+                                        errorBox._conv.retry()
+                                }
+                            }
+                        }
                     }
                 }
 

--- a/src/ai/aiconversation.cpp
+++ b/src/ai/aiconversation.cpp
@@ -107,6 +107,19 @@ bool AIConversation::followUp(const QString& userMessage)
 
     m_errorMessage.clear();
 
+    // If the previous request failed, its user turn was kept in history (for
+    // retry) and is now the last entry. The user is sending a NEW message
+    // instead of retrying, so drop that stale unanswered turn — otherwise we
+    // would emit two consecutive user-role messages, which providers such as
+    // Anthropic reject. Only applies when the last entry is a user turn; a
+    // normal follow-up after a successful turn ends on an assistant turn and is
+    // untouched. Runs before the rating hook below, which scans for the prior
+    // *assistant* turn and is therefore unaffected by removing a trailing user.
+    if (!m_messages.isEmpty() &&
+        m_messages.last().toObject().value("role").toString() == QStringLiteral("user")) {
+        m_messages.removeLast();
+    }
+
     // Closed-loop rating capture (issue #1055 Layer 1). When the prior
     // assistant turn asked the user about taste AND the reply carries
     // a numeric score, persist that score back to ShotProjection so
@@ -156,6 +169,7 @@ void AIConversation::clearHistory()
     m_errorMessage.clear();
 
     emit historyChanged();
+    emit canRetryChanged();
     emit savedConversationChanged();
     qDebug() << "AIConversation: History cleared for key:" << m_storageKey;
 }
@@ -167,6 +181,7 @@ void AIConversation::resetInMemory()
     m_lastResponse.clear();
     m_errorMessage.clear();
     emit historyChanged();
+    emit canRetryChanged();
 }
 
 void AIConversation::setStorageKey(const QString& key)
@@ -382,6 +397,7 @@ void AIConversation::sendRequest()
 
     m_busy = true;
     emit busyChanged();
+    emit canRetryChanged();
 
     trimHistory();
 
@@ -408,6 +424,7 @@ void AIConversation::onAnalysisComplete(const QString& response)
 
     emit busyChanged();
     emit historyChanged();
+    emit canRetryChanged();
     emit responseReceived(response);
 
     qDebug() << "AIConversation: Response received, history now has" << m_messages.size() << "messages";
@@ -420,16 +437,39 @@ void AIConversation::onAnalysisFailed(const QString& error)
     m_busy = false;
     m_errorMessage = error;
 
-    // Remove the last user message since it failed
-    if (!m_messages.isEmpty()) {
-        m_messages.removeLast();
-    }
-
+    // Keep the failed user turn in history so the user can retry it without
+    // retyping (see openspec/changes/add-ai-advisor-retry). The turn is not
+    // persisted — saveToStorage only runs on success — so a failed turn never
+    // survives a reload.
     emit busyChanged();
     emit historyChanged();
+    emit canRetryChanged();
     emit errorOccurred(error);
 
     qDebug() << "AIConversation: Request failed:" << error;
+}
+
+bool AIConversation::canRetry() const
+{
+    if (m_busy || m_messages.isEmpty())
+        return false;
+    return m_messages.last().toObject().value("role").toString() == QStringLiteral("user");
+}
+
+void AIConversation::retry()
+{
+    if (!canRetry()) {
+        qDebug() << "AIConversation::retry ignored — no pending failed turn (busy:" << m_busy
+                 << "messages:" << m_messages.size() << ")";
+        return;
+    }
+
+    // Re-send the existing pending turn verbatim. Unlike followUp(), this does
+    // not append a new user message and does not re-run the rating/metadata
+    // capture hooks — those already fired when the turn was first submitted.
+    m_errorMessage.clear();
+    emit errorOccurred(m_errorMessage);
+    sendRequest();
 }
 
 QString AIConversation::getConversationText() const

--- a/src/ai/aiconversation.cpp
+++ b/src/ai/aiconversation.cpp
@@ -107,18 +107,11 @@ bool AIConversation::followUp(const QString& userMessage)
 
     m_errorMessage.clear();
 
-    // If the previous request failed, its user turn was kept in history (for
-    // retry) and is now the last entry. The user is sending a NEW message
-    // instead of retrying, so drop that stale unanswered turn — otherwise we
-    // would emit two consecutive user-role messages, which providers such as
-    // Anthropic reject. Only applies when the last entry is a user turn; a
-    // normal follow-up after a successful turn ends on an assistant turn and is
-    // untouched. Runs before the rating hook below, which scans for the prior
-    // *assistant* turn and is therefore unaffected by removing a trailing user.
-    if (!m_messages.isEmpty() &&
-        m_messages.last().toObject().value("role").toString() == QStringLiteral("user")) {
-        m_messages.removeLast();
-    }
+    // The user is sending a NEW message instead of retrying a failed turn, so
+    // drop any stale unanswered turn first (see dropTrailingFailedUserTurn).
+    // Runs before the rating hook below, which scans for the prior *assistant*
+    // turn and is therefore unaffected by removing a trailing user turn.
+    dropTrailingFailedUserTurn();
 
     // Closed-loop rating capture (issue #1055 Layer 1). When the prior
     // assistant turn asked the user about taste AND the reply carries
@@ -387,6 +380,17 @@ void AIConversation::appendAssistantTurnForKey(
     // system prompt isn't needed — only `messages` is read.
 }
 
+void AIConversation::dropTrailingFailedUserTurn()
+{
+    // onAnalysisFailed keeps the failed user turn as the last entry so it can be
+    // retried. A successful turn always ends on an assistant turn, so this only
+    // fires in the failed state — it never discards a legitimate message.
+    if (!m_messages.isEmpty() &&
+        m_messages.last().toObject().value("role").toString() == QStringLiteral("user")) {
+        m_messages.removeLast();
+    }
+}
+
 void AIConversation::sendRequest()
 {
     if (!m_aiManager || !m_aiManager->isConfigured()) {
@@ -560,6 +564,10 @@ void AIConversation::addShotContext(const QString& shotSummary, const QString& s
     if (m_systemPrompt.isEmpty()) {
         m_systemPrompt = multiShotSystemPrompt(beverageType, profileTitle, profileType, profileKbId);
     }
+
+    // Drop any stale unanswered turn from a prior failure before appending this
+    // shot's user message, so we never send two consecutive user-role messages.
+    dropTrailingFailedUserTurn();
 
     // Add the new shot as context with its date/time label
     QString contextMessage = "## Shot (" + shotLabel + ")" +
@@ -953,6 +961,7 @@ void AIConversation::loadFromStorage()
     }
 
     emit historyChanged();
+    emit canRetryChanged();
     emit savedConversationChanged();
     qDebug() << "AIConversation: Loaded conversation with" << m_messages.size() << "messages from key:" << m_storageKey;
 }

--- a/src/ai/aiconversation.h
+++ b/src/ai/aiconversation.h
@@ -252,6 +252,10 @@ private slots:
 
 private:
     void sendRequest();
+    // Drop a trailing unanswered user turn (a turn kept by onAnalysisFailed for
+    // retry) before appending a new user message, so we never send two
+    // consecutive user-role messages. No-op unless the last entry is a user turn.
+    void dropTrailingFailedUserTurn();
     void addUserMessage(const QString& message);
     // Append an assistant message. When `structuredNext` carries a value,
     // it is persisted on the entry as a sibling of `role` and `content`

--- a/src/ai/aiconversation.h
+++ b/src/ai/aiconversation.h
@@ -36,6 +36,7 @@ class AIConversation : public QObject {
     Q_PROPERTY(QString providerName READ providerName NOTIFY providerChanged)
     Q_PROPERTY(int messageCount READ messageCount NOTIFY historyChanged)
     Q_PROPERTY(QString errorMessage READ errorMessage NOTIFY errorOccurred)
+    Q_PROPERTY(bool canRetry READ canRetry NOTIFY canRetryChanged)
     Q_PROPERTY(QString contextLabel READ contextLabel NOTIFY contextLabelChanged)
 
 public:
@@ -47,6 +48,9 @@ public:
     QString providerName() const;
     int messageCount() const { return static_cast<int>(m_messages.size()); }
     QString errorMessage() const { return m_errorMessage; }
+    // True when the last turn is an unanswered user message and no request is
+    // in flight — i.e. the previous request failed and can be re-sent verbatim.
+    bool canRetry() const;
     QString contextLabel() const { return m_contextLabel; }
 
     QString storageKey() const { return m_storageKey; }
@@ -64,6 +68,14 @@ public:
      * Uses the existing system prompt and history
      */
     Q_INVOKABLE bool followUp(const QString& userMessage);
+
+    /**
+     * Re-send the last failed turn. Valid only when canRetry() is true (not
+     * busy, last turn is an unanswered user message). Re-uses the stored
+     * message and system prompt verbatim — does not append a new turn and does
+     * not re-run the per-follow-up rating/metadata-capture hooks.
+     */
+    Q_INVOKABLE void retry();
 
     /**
      * Clear conversation history
@@ -229,6 +241,7 @@ signals:
     void errorOccurred(const QString& error);
     void busyChanged();
     void historyChanged();
+    void canRetryChanged();
     void contextLabelChanged();
     void providerChanged();
     void savedConversationChanged();


### PR DESCRIPTION
## Why

When an AI advisor request fails, the user's typed message is lost with no way to retry. Confirmed on the DE1 tablet (debug log, 2026-06-21 11:53): a Gemini **HTTP 503** ("high demand… please try again later") auto-retried once, then hit the 60s analysis timeout and surfaced *"Request timed out. The AI service may be slow — please try again."* `AIConversation::onAnalysisFailed()` then deleted the user's turn (and the input field was already cleared on send), so the question was gone.

## What changed

- **Keep the failed turn.** `onAnalysisFailed()` no longer calls `removeLast()` — the user message stays in history so it can be re-sent. It's never persisted (save only runs on success), so a failed turn never survives a reload.
- **`AIConversation::retry()`** — re-sends the pending turn verbatim. Unlike `followUp()`, it appends no new turn and does not re-run the rating/bean-capture hooks (those already fired on first submit).
- **Role-alternation safety.** `followUp()` drops a trailing orphan user turn before adding a new message, so providers like Anthropic never receive two consecutive user-role messages.
- **`canRetry` property** (`!busy && last turn is user`) with a dedicated `canRetryChanged` signal emitted at every state transition.
- **UI.** The advisor error box now shows a **Retry** button bound to `canRetry` → `retry()`, internationalized (`conversation.retry` / `conversation.retry.accessible`) with full `Accessible.*` attributes.

No automatic retry on timeout — the network-layer auto-retry for 429/502/503/504 is unchanged; this is an explicit user action. No DB/settings/BLE/provider changes.

## Testing

- [ ] Build in Qt Creator (no warnings).
- [ ] Reproduce a failure (force timeout/disconnect): message stays, Retry appears, tapping re-sends, success appends the reply.
- [ ] Typing a new message after a failure produces no consecutive user turns.
- [ ] A first-question (`ask`) failure is retryable; a normal follow-up after success is unaffected.

OpenSpec change: `add-ai-advisor-retry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)