### PR TITLE
Add Clock widget (time readout) with text/icon modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -846,6 +846,7 @@ set(QML_FILES
     qml/components/layout/items/BatteryLevelItem.qml
     qml/components/layout/items/ScaleBatteryItem.qml
     qml/components/layout/items/MiniGHCItem.qml
+    qml/components/layout/items/ClockItem.qml
     qml/components/layout/CustomEditorPopup.qml
     qml/components/layout/ZoneOptionsPopup.qml
     qml/components/layout/ScaleWeightEditorPopup.qml

--- a/qml/components/layout/LayoutCenterZone.qml
+++ b/qml/components/layout/LayoutCenterZone.qml
@@ -26,6 +26,7 @@ Item {
             case "scaleWeight":
             case "weather":
             case "ghcSimulator":
+            case "clock":
                 return true
             default:
                 return false

--- a/qml/components/layout/LayoutItemDelegate.qml
+++ b/qml/components/layout/LayoutItemDelegate.qml
@@ -177,6 +177,7 @@ Item {
                 case "settings":         src = "items/SettingsItem.qml"; break
                 case "temperature":      src = "items/TemperatureItem.qml"; break
                 case "waterLevel":       src = "items/WaterLevelItem.qml"; break
+                case "clock":            src = "items/ClockItem.qml"; break
                 // connectionStatus merged into machineStatus (alias): the machine
                 // status shows the phase and "Disconnected" when offline, replacing
                 // the old binary Online/Offline widget.

--- a/qml/components/layout/items/ClockItem.qml
+++ b/qml/components/layout/items/ClockItem.qml
@@ -1,0 +1,110 @@
+import QtQuick
+import QtQuick.Layouts
+import Decenza
+import "../.."
+
+// Current-time readout. Like the other status readouts it supports a per-instance
+// display mode: "text" (default) or "icon" (a clock icon ahead of the time).
+// Respects the 12/24-hour setting and updates every second.
+Item {
+    id: root
+    property bool isCompact: false
+    property string itemId: ""
+    property var modelData: ({})
+
+    readonly property string displayMode: (modelData && modelData.displayMode) ? modelData.displayMode : "text"
+
+    // Re-evaluated each second by the timer below.
+    property string timeText: ""
+    function _refresh() {
+        var now = new Date()
+        timeText = Qt.formatTime(now, Settings.app.use12HourTime ? "h:mmap" : "hh:mm")
+    }
+
+    Timer {
+        interval: 1000
+        running: root.visible
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: root._refresh()
+    }
+    Component.onCompleted: root._refresh()
+
+    implicitWidth: isCompact ? compactContent.implicitWidth : fullContent.implicitWidth
+    implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
+
+    Accessible.role: Accessible.StaticText
+    Accessible.name: TranslationManager.translate("clock.accessible.label", "Time:") + " " + root.timeText
+    Accessible.focusable: true
+
+    // --- COMPACT MODE (bar rendering) ---
+    Item {
+        id: compactContent
+        visible: root.isCompact
+        anchors.fill: parent
+        implicitWidth: compactRow.implicitWidth
+        implicitHeight: compactRow.implicitHeight
+
+        Row {
+            id: compactRow
+            anchors.centerIn: parent
+            spacing: Theme.scaled(6)
+
+            ThemedIcon {
+                anchors.verticalCenter: parent.verticalCenter
+                visible: root.displayMode === "icon"
+                source: "qrc:/icons/clock.svg"
+                iconSize: Theme.scaled(20)
+                color: Theme.textColor
+            }
+
+            Text {
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.timeText
+                color: Theme.textColor
+                font: Theme.bodyFont
+                Accessible.ignored: true
+            }
+        }
+    }
+
+    // --- FULL MODE (center rendering) ---
+    Item {
+        id: fullContent
+        visible: !root.isCompact
+        anchors.fill: parent
+        implicitWidth: fullColumn.implicitWidth
+        implicitHeight: fullColumn.implicitHeight
+
+        ColumnLayout {
+            id: fullColumn
+            anchors.centerIn: parent
+            spacing: Theme.spacingSmall
+
+            ThemedIcon {
+                Layout.alignment: Qt.AlignHCenter
+                visible: root.displayMode === "icon"
+                source: "qrc:/icons/clock.svg"
+                iconSize: Theme.scaled(28)
+                color: Theme.textColor
+            }
+
+            Text {
+                Layout.alignment: Qt.AlignHCenter
+                text: root.timeText
+                color: Theme.textColor
+                font: Theme.valueFont
+                Accessible.ignored: true
+            }
+
+            Tr {
+                Layout.alignment: Qt.AlignHCenter
+                key: "idle.label.clock"
+                fallback: "Time"
+                color: Theme.textSecondaryColor
+                font: Theme.labelFont
+                Accessible.ignored: true
+            }
+        }
+    }
+}

--- a/qml/components/layout/items/ClockItem.qml
+++ b/qml/components/layout/items/ClockItem.qml
@@ -4,7 +4,8 @@ import Decenza
 import "../.."
 
 // Current-time readout. Like the other status readouts it supports a per-instance
-// display mode: "text" (default) or "icon" (a clock icon ahead of the time).
+// display mode: "text" (default) or "icon" (a clock icon shown with the time —
+// beside it in a bar, above it in center zones).
 // Respects the 12/24-hour setting and updates every second.
 Item {
     id: root
@@ -18,7 +19,10 @@ Item {
     property string timeText: ""
     function _refresh() {
         var now = new Date()
-        timeText = Qt.formatTime(now, Settings.app.use12HourTime ? "h:mmap" : "hh:mm")
+        // 24-hour branch uses HH (explicit 0-23) to match the other dedicated
+        // clocks (ScreensaverPage, ShotMapScreensaver). hh without an am/pm
+        // specifier is equivalent, but HH is unambiguous.
+        timeText = Qt.formatTime(now, Settings.app.use12HourTime ? "h:mmap" : "HH:mm")
     }
 
     Timer {

--- a/qml/pages/settings/LayoutEditorZone.qml
+++ b/qml/pages/settings/LayoutEditorZone.qml
@@ -691,7 +691,7 @@ Rectangle {
             "screensaverShotMap": TranslationManager.translate("layoutEditor.chipMap", "Map"),
             "quit": TranslationManager.translate("layoutEditor.chipQuit", "Quit"),
             "discuss": TranslationManager.translate("layoutEditor.chipDiscuss", "Discuss"),
-            "clock": TranslationManager.translate("layoutEditor.chipClock2", "Clock")
+            "clock": TranslationManager.translate("layoutEditor.chipTime", "Time")
         }
         return names[type] || type
     }

--- a/qml/pages/settings/LayoutEditorZone.qml
+++ b/qml/pages/settings/LayoutEditorZone.qml
@@ -491,6 +491,7 @@ Rectangle {
                                 { type: "milkWeight", cat: 1, label: TranslationManager.translate("layoutEditor.widgetMilkWeight", "Milk Weight") },
                                 { type: "ratioQuickSelect", cat: 1, label: TranslationManager.translate("layoutEditor.widgetRatioQuickSelect", "Ratio Quick-Select") },
                                 { type: "shotPlan", cat: 1, label: TranslationManager.translate("layoutEditor.widgetShotPlan", "Shot Plan") },
+                                { type: "clock", cat: 1, label: TranslationManager.translate("layoutEditor.widgetClock", "Clock") },
                                 // Utility (2)
                                 { type: "custom", cat: 2, label: TranslationManager.translate("layoutEditor.widgetCustom", "Custom") },
                                 { type: "pageTitle", cat: 2, label: TranslationManager.translate("layoutEditor.widgetPageTitle", "Page Title") },
@@ -689,7 +690,8 @@ Rectangle {
             "screensaverAttractor": TranslationManager.translate("layoutEditor.chipAttractor", "Attractor"),
             "screensaverShotMap": TranslationManager.translate("layoutEditor.chipMap", "Map"),
             "quit": TranslationManager.translate("layoutEditor.chipQuit", "Quit"),
-            "discuss": TranslationManager.translate("layoutEditor.chipDiscuss", "Discuss")
+            "discuss": TranslationManager.translate("layoutEditor.chipDiscuss", "Discuss"),
+            "clock": TranslationManager.translate("layoutEditor.chipClock2", "Clock")
         }
         return names[type] || type
     }

--- a/qml/pages/settings/SettingsLayoutTab.qml
+++ b/qml/pages/settings/SettingsLayoutTab.qml
@@ -126,7 +126,7 @@ Item {
             screensaverEditorPopup.openForItem(itemId, zoneName, props)
         } else if (type === "scaleWeight") {
             scaleWeightEditorPopup.openForItem(itemId, props.dataMode || "", props.displayMode || "")
-        } else if (type === "machineStatus" || type === "temperature" || type === "steamTemperature" || type === "waterLevel") {
+        } else if (type === "machineStatus" || type === "temperature" || type === "steamTemperature" || type === "waterLevel" || type === "clock") {
             displayModeEditorPopup.openForItem(itemId, props.displayMode || "")
         } else if (type === "sleep") {
             sleepEditorPopup.openForItem(itemId,

--- a/resources/icons/clock.svg
+++ b/resources/icons/clock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="9"/>
+  <path d="M12 7v5l3.5 2"/>
+</svg>

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -69,6 +69,7 @@
         <file>icons/warning.svg</file>
         <file>icons/more-vertical.svg</file>
         <file>icons/grid.svg</file>
+        <file>icons/clock.svg</file>
         <!-- Coffee Cup (3D-rendered layers for CupFillView) -->
         <file>CoffeeCup/BackGround.png</file>
         <file>CoffeeCup/Mask.png</file>

--- a/src/core/settings_network.cpp
+++ b/src/core/settings_network.cpp
@@ -295,6 +295,8 @@ QString SettingsNetwork::defaultLayoutJson() const {
         QJsonObject({{"type", "scaleWeight"}, {"id", "scale_sb1"}, {"displayMode", "icon"}}),
         QJsonObject({{"type", "separator"}, {"id", "sep_sb3"}}),
         QJsonObject({{"type", "machineStatus"}, {"id", "conn_sb1"}, {"displayMode", "icon"}}),
+        QJsonObject({{"type", "separator"}, {"id", "sep_sb4"}}),
+        QJsonObject({{"type", "clock"}, {"id", "clock_sb1"}, {"displayMode", "icon"}}),
     });
     // Lower-mid bar: optional, general-purpose full-width band above the bottom
     // action bar. Empty by default so it reserves no space and changes nothing
@@ -604,6 +606,7 @@ bool SettingsNetwork::typeHasOptions(const QString& type) {
         QStringLiteral("temperature"),
         QStringLiteral("steamTemperature"),
         QStringLiteral("waterLevel"),
+        QStringLiteral("clock"),
         QStringLiteral("lastShot"),
     };
     return kConfigurable.contains(type);

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -2447,7 +2447,7 @@ QString ShotServer::generateLayoutPage() const
         discuss:"Discuss",
         ghcSimulator:"Mini GHC",
         machineStatus:"Machine",
-        clock:"Clock"
+        clock:"Time"
     };
 
     var ACTIONS = [

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -2418,6 +2418,7 @@ QString ShotServer::generateLayoutPage() const
         {type:"milkWeight",cat:1,label:"Milk Weight"},
         {type:"ratioQuickSelect",cat:1,label:"Ratio Quick-Select"},
         {type:"shotPlan",cat:1,label:"Shot Plan"},
+        {type:"clock",cat:1,label:"Clock"},
         // Utility (2)
         {type:"custom",cat:2,label:"Custom",special:true},
         {type:"pageTitle",cat:2,label:"Page Title",special:true},
@@ -2445,7 +2446,8 @@ QString ShotServer::generateLayoutPage() const
         lastShot:"Last Shot",
         discuss:"Discuss",
         ghcSimulator:"Mini GHC",
-        machineStatus:"Machine"
+        machineStatus:"Machine",
+        clock:"Clock"
     };
 
     var ACTIONS = [
@@ -2536,7 +2538,7 @@ QString ShotServer::generateLayoutPage() const
     function typeHasOptions(type) {
         if (type.indexOf("screensaver") === 0) return true;
         return ["custom","scaleWeight","shotPlan","sleep","machineStatus",
-                "temperature","steamTemperature","waterLevel","lastShot"].indexOf(type) >= 0;
+                "temperature","steamTemperature","waterLevel","clock","lastShot"].indexOf(type) >= 0;
     }
 
     // Persistent "has options" indicator drawn on configurable chips.
@@ -2696,7 +2698,7 @@ QString ShotServer::generateLayoutPage() const
                     html += '</select>';
                 }
                 // Inline display-mode selector for selected readout chips.
-                if (isSel && (item.type === "machineStatus" || item.type === "temperature" || item.type === "steamTemperature" || item.type === "scaleWeight" || item.type === "waterLevel")) {
+                if (isSel && (item.type === "machineStatus" || item.type === "temperature" || item.type === "steamTemperature" || item.type === "scaleWeight" || item.type === "waterLevel" || item.type === "clock")) {
                     var disp = item.displayMode || "text";
                     var dispModes = [["text","Text"],["icon","Icon"]];
                     html += '<select class="chip-mode" onchange="setDisplayMode(\'' + item.id + '\',this.value)" onclick="event.stopPropagation()">';

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -397,7 +397,7 @@ private slots:
     void typeHasOptionsAllowlist() {
         const QStringList configurable = {
             "custom", "scaleWeight", "shotPlan", "sleep", "machineStatus",
-            "temperature", "steamTemperature", "waterLevel", "lastShot"
+            "temperature", "steamTemperature", "waterLevel", "clock", "lastShot"
         };
         for (const QString& t : configurable)
             QVERIFY2(SettingsNetwork::typeHasOptions(t), qPrintable("expected configurable: " + t));


### PR DESCRIPTION
Adds a first-class **Clock** widget to the home-screen layout system — a current-time readout usable in the status bar or any zone, with the same text/icon display modes as the other readouts.

## What's included
- **`ClockItem.qml`** — shows the current time, updates each second, and respects the 12/24-hour setting (`Settings.app.use12HourTime`). Uses the **same** format string as the `%TIME%` custom variable (`h:mmap` / `hh:mm`); the Flip Clock screensaver reads the same setting, so all three stay consistent.
- **Per-instance display mode** — `text` (default) or `icon` (a clock glyph ahead of the time, new `clock.svg`), so it looks good on the status line and in center zones.
- **Registered everywhere** per the widget checklist: `CMakeLists.txt`, `LayoutItemDelegate` routing, in-app picker (Readouts) + chip-label map, web `WIDGET_TYPES` + `DISPLAY_NAMES`, `LayoutCenterZone` auto-size list, `resources.qrc`.
- **Configurable in both editors** — added to `typeHasOptions` (C++ + the web JS mirror) and the display-mode routing (in-app gear → Text/Icon; web inline selector).
- **Default layout** — clock (icon mode) added to the far right of the status bar. Existing saved layouts are untouched; users there add it from Readouts → Clock.

## Testing
- Builds clean (Qt 6.11.1 macOS): C++ recompiled, `ClockItem` through qmlcachegen, app + tests link, 0 warnings.
- `tst_settings`: `typeHasOptions` allowlist test updated to include `clock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)