### PR TITLE
Layout bar polish: alignment fix, item-size option, lower-mid offset/scale, scrollable editor

### DIFF
--- a/qml/components/layout/LayoutBarZone.qml
+++ b/qml/components/layout/LayoutBarZone.qml
@@ -12,6 +12,10 @@ Item {
     property string distribution: "packed"   // packed | equalWidth | spaced
     property string alignment: "center"       // left | center | right
     property string zoneStyle: "standard"     // standard | surface | accentBar
+    // "auto" (bar = compact) or "large" to render widgets in the big center style.
+    property string itemSize: "auto"          // auto | compact | large
+    // Visual scale of the bar's content (matches center zones' scale control).
+    property real zoneScale: 1.0
 
     // Fill modes occupy the full width, so alignment has no effect on them.
     readonly property bool fillWidthMode: distribution === "equalWidth" || distribution === "spaced"
@@ -26,22 +30,42 @@ Item {
     }
     readonly property bool fillRow: fillWidthMode || hasSpacer
 
-    implicitHeight: Theme.bottomBarHeight
-    implicitWidth: itemsRow.implicitWidth
+    // Grow to fit large-style / scaled items; bar height otherwise.
+    implicitHeight: Math.max(Theme.bottomBarHeight, itemsRow.implicitHeight * root.zoneScale)
+    implicitWidth: itemsRow.implicitWidth * root.zoneScale
 
     RowLayout {
         id: itemsRow
         anchors.verticalCenter: parent.verticalCenter
-        anchors.left: (root.fillRow || root.alignment === "left") ? parent.left : undefined
-        anchors.right: (root.fillRow || root.alignment === "right") ? parent.right : undefined
-        anchors.horizontalCenter: (!root.fillRow && root.alignment === "center") ? parent.horizontalCenter : undefined
-        width: root.fillRow ? parent.width : Math.min(implicitWidth, parent.width)
+        anchors.left: parent.left
+        anchors.right: parent.right
         spacing: Theme.spacingMedium
+
+        // Scale the content visually; pin the transform to the alignment edge so
+        // scaled content doesn't drift away from where it's aligned.
+        scale: root.zoneScale
+        transformOrigin: root.alignment === "left" ? Item.Left
+            : (root.alignment === "right" ? Item.Right : Item.Center)
+
+        // Alignment via flexible end-fillers (packed mode only). When the zone is
+        // wider than its content, the visible filler(s) absorb the slack and push
+        // the content group left / center / right. In fill modes (equalWidth /
+        // spaced) or when the user added their own spacer, both fillers are hidden
+        // and the delegates' own fill behaviour governs the row, so alignment has
+        // no effect — matching the documented behaviour.
+        // Leading filler: present for center + right.
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredWidth: 0
+            Layout.minimumWidth: 0
+            visible: !root.fillRow && (root.alignment === "center" || root.alignment === "right")
+        }
 
         Repeater {
             model: root.items
             delegate: LayoutItemDelegate {
                 zoneName: root.zoneName
+                itemSize: root.itemSize
                 zoneTextColor: Theme.zoneTextColor(root.zoneStyle)
                 zoneValueBold: Theme.zoneValueBold(root.zoneStyle)
                 // equalWidth/spaced: every item gets an equal share of the width,
@@ -49,6 +73,14 @@ Item {
                 Layout.fillWidth: modelData.type === "spacer" || root.fillWidthMode
                 Layout.preferredWidth: root.fillWidthMode ? 1 : -1
             }
+        }
+
+        // Trailing filler: present for center + left.
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredWidth: 0
+            Layout.minimumWidth: 0
+            visible: !root.fillRow && (root.alignment === "center" || root.alignment === "left")
         }
     }
 }

--- a/qml/components/layout/LayoutItemDelegate.qml
+++ b/qml/components/layout/LayoutItemDelegate.qml
@@ -16,8 +16,17 @@ Item {
     readonly property string itemType: modelData.type || ""
     readonly property string itemId: modelData.id || ""
 
-    // Is this a bar zone (compact rendering)?
-    readonly property bool isCompact: zoneName.startsWith("top") || zoneName.startsWith("bottom") || zoneName === "statusBar" || zoneName === "lowerMidBar"
+    // Per-zone item-size override ("auto" | "compact" | "large"). "auto" keeps
+    // the zone's natural style (bar zones compact, center zones large); the
+    // others force the widget's compact or large rendering regardless of zone.
+    property string itemSize: "auto"
+
+    // Is this rendered compact (bar style) vs large (center style)?
+    readonly property bool isCompact: {
+        if (root.itemSize === "large") return false
+        if (root.itemSize === "compact") return true
+        return zoneName.startsWith("top") || zoneName.startsWith("bottom") || zoneName === "statusBar" || zoneName === "lowerMidBar"
+    }
 
     // Action button types that get compiled to CustomItem in center zones
     readonly property bool isCompiledType: {

--- a/qml/components/layout/LayoutPreview.qml
+++ b/qml/components/layout/LayoutPreview.qml
@@ -87,6 +87,7 @@ Item {
                         distribution: previewRoot._opt("topLeft", "distribution", "packed")
                         alignment: previewRoot._opt("topLeft", "alignment", "center")
                         zoneStyle: previewRoot._opt("topLeft", "style", "standard")
+                        itemSize: previewRoot._opt("topLeft", "itemSize", "compact")
                     }
                     Item { Layout.fillWidth: true }
                     LayoutBarZone {
@@ -95,6 +96,7 @@ Item {
                         distribution: previewRoot._opt("topRight", "distribution", "packed")
                         alignment: previewRoot._opt("topRight", "alignment", "center")
                         zoneStyle: previewRoot._opt("topRight", "style", "standard")
+                        itemSize: previewRoot._opt("topRight", "itemSize", "compact")
                     }
                 }
             }
@@ -135,8 +137,9 @@ Item {
                 }
             }
 
-            // Lower-mid bar (full-width band above the bottom bar, height-gated)
-            property real lowerMidFullHeight: Theme.scaled(82)
+            // Lower-mid bar (full-width band above the bottom bar, height-gated).
+            // Auto-grows to fit large item-size, matching IdlePage.
+            property real lowerMidFullHeight: Math.max(Theme.scaled(82), lmbPreviewZone.implicitHeight)
             property bool lowerMidVisible: previewRoot._items("lowerMidBar").length > 0
                 && (height - Theme.bottomBarHeight - lowerMidFullHeight) >= Theme.scaled(220)
 
@@ -145,11 +148,13 @@ Item {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.bottom: previewBottomBar.top
+                anchors.bottomMargin: -previewRoot._offset("lowerMidBar")
                 visible: pageArea.lowerMidVisible
                 height: visible ? pageArea.lowerMidFullHeight : 0
                 color: Theme.zoneBackgroundColor(previewRoot._opt("lowerMidBar", "style", "standard"))
 
                 LayoutBarZone {
+                    id: lmbPreviewZone
                     anchors.fill: parent
                     anchors.leftMargin: Theme.spacingMedium
                     anchors.rightMargin: Theme.spacingMedium
@@ -158,6 +163,8 @@ Item {
                     distribution: previewRoot._opt("lowerMidBar", "distribution", "packed")
                     alignment: previewRoot._opt("lowerMidBar", "alignment", "center")
                     zoneStyle: previewRoot._opt("lowerMidBar", "style", "standard")
+                    itemSize: previewRoot._opt("lowerMidBar", "itemSize", "compact")
+                    zoneScale: previewRoot._scale("lowerMidBar")
                 }
             }
 
@@ -167,7 +174,8 @@ Item {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom
-                height: Theme.bottomBarHeight
+                // Auto-grow to fit large item-size, matching IdlePage.
+                height: Math.max(Theme.bottomBarHeight, blPreviewZone.implicitHeight, brPreviewZone.implicitHeight)
                 color: Theme.bottomBarColor
 
                 RowLayout {
@@ -177,21 +185,25 @@ Item {
                     spacing: Theme.spacingMedium
 
                     LayoutBarZone {
+                        id: blPreviewZone
                         zoneName: "bottomLeft"
                         items: previewRoot._items("bottomLeft")
                         Layout.fillHeight: true
                         distribution: previewRoot._opt("bottomLeft", "distribution", "packed")
                         alignment: previewRoot._opt("bottomLeft", "alignment", "center")
                         zoneStyle: previewRoot._opt("bottomLeft", "style", "standard")
+                        itemSize: previewRoot._opt("bottomLeft", "itemSize", "compact")
                     }
                     Item { Layout.fillWidth: true }
                     LayoutBarZone {
+                        id: brPreviewZone
                         zoneName: "bottomRight"
                         items: previewRoot._items("bottomRight")
                         Layout.fillHeight: true
                         distribution: previewRoot._opt("bottomRight", "distribution", "packed")
                         alignment: previewRoot._opt("bottomRight", "alignment", "center")
                         zoneStyle: previewRoot._opt("bottomRight", "style", "standard")
+                        itemSize: previewRoot._opt("bottomRight", "itemSize", "compact")
                     }
                 }
             }

--- a/qml/components/layout/ZoneOptionsPopup.qml
+++ b/qml/components/layout/ZoneOptionsPopup.qml
@@ -17,6 +17,13 @@ Dialog {
     property string distribution: "packed"
     property string alignment: "center"
     property string zoneStyle: "standard"
+    property string itemSize: "compact"
+
+    // Item size (compact bar style vs large center style) applies to the bar
+    // zones that can grow — the status bar stays fixed, and center zones already
+    // render large.
+    readonly property bool canSizeItems: zoneName === "lowerMidBar"
+        || zoneName.indexOf("top") === 0 || zoneName.indexOf("bottom") === 0
 
     function openForZone(name, label) {
         popup.zoneName = name
@@ -24,6 +31,7 @@ Dialog {
         popup.distribution = Settings.network.getZoneOption(name, "distribution", "packed")
         popup.alignment = Settings.network.getZoneOption(name, "alignment", "center")
         popup.zoneStyle = Settings.network.getZoneOption(name, "style", "standard")
+        popup.itemSize = Settings.network.getZoneOption(name, "itemSize", "compact")
         popup.open()
     }
 
@@ -171,6 +179,17 @@ Dialog {
                 { value: "accentBar", label: TranslationManager.translate("layoutEditor.styleAccent", "Accent bar") }
             ]
             onPicked: function(v) { popup.zoneStyle = v; popup.setOption("style", v) }
+        }
+
+        OptionRow {
+            visible: popup.canSizeItems
+            title: TranslationManager.translate("layoutEditor.zoneItemSize", "Item size")
+            current: popup.itemSize
+            choices: [
+                { value: "compact", label: TranslationManager.translate("layoutEditor.itemSizeCompact", "Compact") },
+                { value: "large",   label: TranslationManager.translate("layoutEditor.itemSizeLarge", "Large") }
+            ]
+            onPicked: function(v) { popup.itemSize = v; popup.setOption("itemSize", v) }
         }
 
         // Populate from a built-in preset.

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -99,6 +99,12 @@ Page {
     property real centerTopScale: layoutConfig.scales ? (layoutConfig.scales.centerTop || 1.0) : 1.0
     property real centerMiddleScale: layoutConfig.scales ? (layoutConfig.scales.centerMiddle || 1.0) : 1.0
 
+    // Per-zone item size ("compact" | "large"); bars grow to fit large items.
+    function zoneItemSize(zone) {
+        return (layoutConfig.zoneOptions && layoutConfig.zoneOptions[zone]
+                && layoutConfig.zoneOptions[zone].itemSize) || "compact"
+    }
+
     Component.onCompleted: {
         root.currentPageTitle = TranslationManager.translate("idle.pageTitle", "Idle")
         MainController.bagStorage.requestInventory()
@@ -443,6 +449,7 @@ Page {
             LayoutBarZone {
                 zoneName: "topLeft"
                 items: idlePage.topLeftItems
+                itemSize: idlePage.zoneItemSize("topLeft")
             }
 
             Item { Layout.fillWidth: true }
@@ -450,6 +457,7 @@ Page {
             LayoutBarZone {
                 zoneName: "topRight"
                 items: idlePage.topRightItems
+                itemSize: idlePage.zoneItemSize("topRight")
             }
         }
     }
@@ -894,8 +902,13 @@ Page {
     // viewports; raise the threshold if overlap is seen.
     // ============================================================
     property var lowerMidBarOptions: layoutConfig.zoneOptions ? (layoutConfig.zoneOptions.lowerMidBar || ({})) : ({})
+    // Lower-mid bar position (offset) + scale, matching the center-zone controls.
+    readonly property int lowerMidBarYOffset: layoutConfig.offsets ? (layoutConfig.offsets.lowerMidBar || 0) : 0
+    readonly property real lowerMidBarScale: layoutConfig.scales ? (layoutConfig.scales.lowerMidBar || 1.0) : 1.0
     readonly property bool lowerMidBarHasItems: idlePage.lowerMidBarItems.length > 0
-    readonly property real lowerMidBarFullHeight: Theme.scaled(82)
+    // Auto-grow: the band fits its content (large item-size makes it taller),
+    // never smaller than the standard bar height.
+    readonly property real lowerMidBarFullHeight: Math.max(Theme.scaled(82), lmbZone.implicitHeight)
     readonly property bool lowerMidBarFits:
         (idlePage.height - Theme.statusBarHeight - Theme.bottomBarHeight - lowerMidBarFullHeight) >= Theme.scaled(220)
     readonly property bool lowerMidBarVisible: lowerMidBarHasItems && lowerMidBarFits
@@ -905,11 +918,14 @@ Page {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: bottomBar.top
+        // Negative offset (the editor's "up") lifts the band off the bottom bar.
+        anchors.bottomMargin: -idlePage.lowerMidBarYOffset
         visible: idlePage.lowerMidBarVisible
         height: visible ? idlePage.lowerMidBarFullHeight : 0
         color: Theme.zoneBackgroundColor(idlePage.lowerMidBarOptions.style)
 
         LayoutBarZone {
+            id: lmbZone
             anchors.fill: parent
             anchors.leftMargin: Theme.spacingMedium
             anchors.rightMargin: Theme.spacingMedium
@@ -918,6 +934,8 @@ Page {
             distribution: idlePage.lowerMidBarOptions.distribution || "packed"
             alignment: idlePage.lowerMidBarOptions.alignment || "center"
             zoneStyle: idlePage.lowerMidBarOptions.style || "standard"
+            itemSize: idlePage.lowerMidBarOptions.itemSize || "compact"
+            zoneScale: idlePage.lowerMidBarScale
         }
     }
 
@@ -929,7 +947,8 @@ Page {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        height: Theme.bottomBarHeight
+        // Auto-grow to fit large item-size; standard bar height otherwise.
+        height: Math.max(Theme.bottomBarHeight, blZone.implicitHeight, brZone.implicitHeight)
         color: Theme.bottomBarColor
 
         RowLayout {
@@ -939,16 +958,20 @@ Page {
             spacing: Theme.spacingMedium
 
             LayoutBarZone {
+                id: blZone
                 zoneName: "bottomLeft"
                 items: idlePage.bottomLeftItems
+                itemSize: idlePage.zoneItemSize("bottomLeft")
                 Layout.fillHeight: true
             }
 
             Item { Layout.fillWidth: true }
 
             LayoutBarZone {
+                id: brZone
                 zoneName: "bottomRight"
                 items: idlePage.bottomRightItems
+                itemSize: idlePage.zoneItemSize("bottomRight")
                 Layout.fillHeight: true
             }
         }

--- a/qml/pages/settings/SettingsLayoutTab.qml
+++ b/qml/pages/settings/SettingsLayoutTab.qml
@@ -590,7 +590,7 @@ Item {
                     Layout.fillWidth: true
                 }
 
-                // Live home-screen preview (5:3, matches the device reference aspect)
+                // Live home-screen preview (8:5, matches the 960x600 device reference aspect)
                 Rectangle {
                     id: previewBox
                     Layout.fillWidth: true

--- a/qml/pages/settings/SettingsLayoutTab.qml
+++ b/qml/pages/settings/SettingsLayoutTab.qml
@@ -499,6 +499,9 @@ Item {
                     items: layoutTab.getZoneItems("lowerMidBar")
                     selectedItemId: layoutTab.selectedItemId
                     zoneSelected: layoutTab.selectedZoneName === "lowerMidBar"
+                    showPositionControls: true
+                    yOffset: layoutTab.getZoneYOffset("lowerMidBar")
+                    zoneScale: layoutTab.getZoneScale("lowerMidBar")
 
                     onItemTapped: function(itemId) { layoutTab.onItemTapped(itemId, "lowerMidBar") }
                     onZoneTapped: layoutTab.onZoneTapped("lowerMidBar")
@@ -509,6 +512,11 @@ Item {
                     onAddItemRequested: function(type) { Settings.network.addItem(type, "lowerMidBar") }
                     onEditCustomRequested: function(itemId, zoneName) { layoutTab.openCustomEditor(itemId, zoneName) }
                     onZoneOptionsRequested: layoutTab.openZoneOptions(zoneName, zoneLabel)
+
+                    onMoveUp: Settings.network.setZoneYOffset("lowerMidBar", yOffset - 5)
+                    onMoveDown: Settings.network.setZoneYOffset("lowerMidBar", yOffset + 5)
+                    onScaleUp: Settings.network.setZoneScale("lowerMidBar", zoneScale + 0.05)
+                    onScaleDown: Settings.network.setZoneScale("lowerMidBar", zoneScale - 0.05)
                 }
 
                 // Bottom bar zones
@@ -559,45 +567,58 @@ Item {
             }
         }
 
-        // Right column: pinned live preview (stays visible while editing) + Library
-        ColumnLayout {
+        // Right column: live preview + Library. Scrollable so the Library stays
+        // reachable even when the (large) preview would otherwise push it off.
+        ScrollView {
+            id: rightScroll
             // Roughly an even split so the preview is large enough to be useful.
             Layout.preferredWidth: Math.max(Theme.scaled(380), layoutTab.width * 0.42)
             Layout.minimumWidth: Theme.scaled(340)
             Layout.fillHeight: true
-            spacing: Theme.spacingMedium
+            contentWidth: availableWidth
+            clip: true
 
-            Tr {
-                key: "settings.layout.preview"
-                fallback: "Preview"
-                color: Theme.textColor
-                font: Theme.subtitleFont
-                Layout.fillWidth: true
-            }
+            ColumnLayout {
+                width: rightScroll.availableWidth
+                spacing: Theme.spacingMedium
 
-            // Live home-screen preview (5:3, matches the device reference aspect)
-            Rectangle {
-                Layout.fillWidth: true
-                Layout.preferredHeight: width / 1.6
-                color: Theme.backgroundColor
-                radius: Theme.cardRadius
-                border.color: Theme.borderColor
-                border.width: 1
-                clip: true
-
-                LayoutPreview {
-                    anchors.fill: parent
-                    anchors.margins: Theme.scaled(4)
+                Tr {
+                    key: "settings.layout.preview"
+                    fallback: "Preview"
+                    color: Theme.textColor
+                    font: Theme.subtitleFont
+                    Layout.fillWidth: true
                 }
-            }
 
-            LibraryPanel {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
+                // Live home-screen preview (5:3, matches the device reference aspect)
+                Rectangle {
+                    id: previewBox
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: width / 1.6
+                    color: Theme.backgroundColor
+                    radius: Theme.cardRadius
+                    border.color: Theme.borderColor
+                    border.width: 1
+                    clip: true
 
-                selectedItemId: layoutTab.selectedItemId
-                selectedFromZone: layoutTab.selectedFromZone
-                selectedZoneName: layoutTab.selectedZoneName
+                    LayoutPreview {
+                        anchors.fill: parent
+                        anchors.margins: Theme.scaled(4)
+                    }
+                }
+
+                LibraryPanel {
+                    Layout.fillWidth: true
+                    // Fill the leftover viewport height when there's room; clamp to
+                    // a usable minimum so the whole column scrolls (rather than
+                    // hiding the Library) when the preview is tall.
+                    Layout.preferredHeight: Math.max(Theme.scaled(340),
+                        rightScroll.height - previewBox.height - Theme.scaled(56))
+
+                    selectedItemId: layoutTab.selectedItemId
+                    selectedFromZone: layoutTab.selectedFromZone
+                    selectedZoneName: layoutTab.selectedZoneName
+                }
             }
         }
     }

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -2606,7 +2606,8 @@ QString ShotServer::generateLayoutPage() const
             html += '<div class="zone-card' + (zoneSelected ? ' selected' : '') + '" style="' + (isPairStart || isPairEnd ? 'flex:1' : '') + '" onclick="zoneClick(\'' + zone.key + '\',event)">';
             html += '<div class="zone-header"><span class="zone-title">' + zone.label + '</span>';
 
-            if (zone.hasOffset) {
+            // Center zones plus the lower-mid bar expose position (offset) + scale.
+            if (zone.hasOffset || zone.key === "lowerMidBar") {
                 var offset = 0;
                 if (layoutData && layoutData.offsets && layoutData.offsets[zone.key] !== undefined)
                     offset = layoutData.offsets[zone.key];

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -2640,6 +2640,11 @@ QString ShotServer::generateLayoutPage() const
                 [["left","Left"],["center","Center"],["right","Right"]]);
             html += optSel(zone.key, "style", zopts.style || "standard",
                 [["standard","Standard"],["surface","Surface"],["accentBar","Accent bar"]]);
+            // Item size (compact bar vs large center style) applies to the
+            // growable bar zones — not the fixed status bar or the center zones.
+            if (!zone.hasOffset && zone.key !== "statusBar")
+                html += optSel(zone.key, "itemSize", zopts.itemSize || "compact",
+                    [["compact","Compact"],["large","Large"]]);
             if (zone.key !== "statusBar")
                 html += '<button class="zone-opt-btn" onclick="populateZone(\'' + zone.key + '\',\'brewBar\');event.stopPropagation()">Brew bar</button>';
             if (zone.key === "statusBar")


### PR DESCRIPTION
Follow-ups to the layout editor (composable bar zones), after the Clock widget (#1375) merged.

## Fixes
- **Bar-zone alignment** — packed **Left / Center / Right** now work reliably. The previous packed-mode alignment used an explicit `width` + `anchors.horizontalCenter` combo on the `RowLayout` that fell back to left; replaced with flexible end-filler items. Equal width / Spaced / a user-added Spacer still fill the bar (alignment intentionally ignored there). *(Verified working.)*
- **Scrollable editor right column** — the preview + Library column is now a `ScrollView`, so the Library stays reachable when the preview is large (it was getting pushed out of view). Library fills the leftover height, clamped to a usable minimum.

## Features
- **Item size: Compact / Large zone option** — for the growable bars (top, bottom, lower-mid; the status bar stays fixed). **Large** renders that bar's widgets in the big center style and the bar **auto-grows** its height to fit. Available in the in-app zone-options popup and the web editor.
- **Lower Mid Bar position + scale** — the Lower Mid Bar now has the same inline **↑ ↓ offset** and **− + scale** controls as the center zones, applied on the home screen and reflected in the live preview.

## Where it's wired
`LayoutItemDelegate` (per-zone `itemSize` override of `isCompact`), `LayoutBarZone` (`itemSize` + `zoneScale` + auto-grow height + alignment fillers), `ZoneOptionsPopup`, `IdlePage` (apply offset/scale/item-size + grow top/bottom/lower-mid bars), `LayoutPreview` (mirror all of it), `SettingsLayoutTab` (lower-mid offset/scale controls + scrollable right column), and `shotserver_layout.cpp` (web Item-size selector).

## Testing
- Builds clean (Qt 6.11.1 macOS): all touched QML through qmlcachegen, app links, 0 warnings.
- Alignment fix verified on-device. Item-size/offset/scale to be exercised across the bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)