### PR TITLE
Fix readout widget colors all rendering white

### DIFF
--- a/qml/components/layout/WidgetColor.qml
+++ b/qml/components/layout/WidgetColor.qml
@@ -1,5 +1,6 @@
 pragma Singleton
 import QtQuick
+import Decenza // for the Theme singleton — without this, Theme is undefined here
 
 // Per-instance color override for readout layout widgets (clock, temperature,
 // steam temp, water level, machine status, scale weight). "default" (or unset)


### PR DESCRIPTION
## Problem
After #1377, the per-instance color picker on readout widgets showed **all swatches white** (including "Default", which should be gray), and choosing a named color rendered the widget white instead of the color.

## Cause
`qml/components/layout/WidgetColor.qml` is a QML-module singleton but only had `import QtQuick`. The `Theme` singleton is a **QML module type** that needs `import Decenza` to be in scope — unlike `Settings`/`TranslationManager`, which are C++ context globals available without an import. So `Theme` was `undefined` inside the singleton, every `resolve()`/`swatch()` returned `undefined`, and QML's color property fell back to white.

This is why it slipped through: the C++ build compiles clean either way (the failure is a runtime `ReferenceError` only hit when the picker opens / a non-default color resolves), and `resolve("default", fallback)` short-circuits before touching `Theme`, so widgets at their default color looked fine.

## Fix
Add `import Decenza` to `WidgetColor.qml`, matching the existing `SettingsTabs.qml` and `DecenzaGraphsTheme.qml` singletons that reference module types.

## Testing
- Qt Creator build: succeeded, 0 warnings.
- Verified the picker swatches and applied colors render correctly in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)