### PR TITLE
Brew-bar widget polish: live milk, suppressible ratio, self-identifying compact scale (#1379)

### DIFF
--- a/openspec/changes/fix-brew-bar-widget-polish/.openspec.yaml
+++ b/openspec/changes/fix-brew-bar-widget-polish/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/fix-brew-bar-widget-polish/design.md
+++ b/openspec/changes/fix-brew-bar-widget-polish/design.md
@@ -1,0 +1,65 @@
+## Context
+
+The composable bars ([#1368](https://github.com/Kulitorum/Decenza/issues/1368) / [#1369](https://github.com/Kulitorum/Decenza/issues/1369)) introduced a family of small readout widgets — `doseWeight`, `milkWeight`, `ratioQuickSelect`, `scaleWeight` — rendered into configurable zones (`lowerMidBar`, status bar, bottom bars) by `LayoutBarZone` → `LayoutItemDelegate` → the per-type `*Item.qml`. Per-instance options (`dataMode`, `displayMode`, `color`) are stored via `Settings.network.setItemProperty` and edited in `ScaleWeightEditorPopup.qml` (in-app) and `shotserver_layout.cpp` (web). Field testing ([#1379](https://github.com/Kulitorum/Decenza/issues/1379)) found four polish issues, all confined to these widgets. This change fixes them without touching the zone/storage architecture.
+
+Key existing wiring relevant here:
+- `MilkWeightItem.qml` binds only to `Settings.brew.lastSteamMilkG` (last *committed* session). The live in-session value already exists as `sessionMeasuredMilkG` on the app root (`main.qml`), written from `IdlePage`/`SteamPage` during steaming and committed to `lastSteamMilkG` at session end.
+- `ScaleWeightItem.weightText()` appends `" 1:" + ProfileManager.brewByRatio` whenever `ProfileManager.brewByRatioActive`, unconditionally.
+- The seeded status-bar preset `csb_scale` already uses `displayMode: "icon"`; the seeded lower-mid-bar preset `lmb_scale` uses `dataMode: "contextAware"` but leaves `displayMode` unset (→ dot + number, no label).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Milk widget gives live feedback during a steam, falling back to the committed value when idle.
+- Scale widget's `1:X.X` suffix is suppressible per instance, defaulting to today's behaviour.
+- A compact `scaleWeight` is identifiable as a scale reading without its full-mode label.
+- Lower-mid bar widgets never overlap (item 4 — lands after a repro is available).
+
+**Non-Goals:**
+- No new `Settings` properties or domain objects (per-instance options use the existing item-property mechanism).
+- No change to the zone model, storage format, or migration path.
+- No behaviour change to existing layouts except where a user opts into `showRatio`.
+- Not redesigning the readout widgets or the ratio pill.
+- The lower-mid bar overlap (#1379 item 4) stays in this change but lands after items 1–3, once a concrete repro is available (see Decision 4).
+
+## Decisions
+
+### 1. Milk widget reads the live session value with a committed-value fallback
+
+`MilkWeightItem` will source its value from the app-root `sessionMeasuredMilkG` when greater than zero, otherwise `Settings.brew.lastSteamMilkG` — exactly the precedence the issue suggests and the same source `SteamPage` already uses (`Window.window.sessionMeasuredMilkG`). Access is via `root.Window.window.sessionMeasuredMilkG` (the widget is not always a descendant of a page), guarded for the case where `Window.window` or the property is absent so the widget degrades to the committed value and never errors.
+
+- **Alternative — add a new `liveMilkG` settings property:** rejected. The live value already exists on the window root; duplicating it into `Settings` adds state to keep in sync for no benefit, and violates "prefer fewer settings / smarter defaults."
+
+### 2. `showRatio` is a per-instance boolean, default-on
+
+Add a `showRatio` property to `scaleWeight` read from `modelData` (defaulting to `true` to preserve current behaviour) and gate the `" 1:" + ratio` suffix in `weightText()` on it. Surface a toggle in `ScaleWeightEditorPopup.qml` and the web editor widget list. This matches the established `dataMode`/`displayMode` per-instance pattern exactly.
+
+- **Alternative — auto-suppress when a `ratioQuickSelect`/status-bar ratio is present in the same layout:** rejected. Cross-widget awareness is fragile (which zones count? what about the status bar on another page?) and surprising; an explicit per-instance toggle is predictable and consistent with the other scale options.
+- **Alternative — global setting:** rejected per "settings go in their place, prefer fewer" — and a per-instance toggle is strictly more flexible (one scale can show the ratio while another hides it).
+
+### 3. Compact `scaleWeight` self-identifies via the existing `icon` display mode
+
+Rather than introduce a new label setting, make the compact scale recognizable through the `icon` `displayMode` (scale icon ahead of the value), which the widget already supports. The fix is to seed the self-identifying presentation where the layout system places a compact scale by default — i.e. the `lmb_scale` preset gains `displayMode: "icon"`, matching the status bar's `csb_scale`. Existing user layouts keep their stored `displayMode` untouched.
+
+- **Alternative — add a short always-on text label to compact mode:** rejected as the default. It adds horizontal width pressure in already-tight bars and duplicates the icon's job; the issue offers it only as an "or." The icon default is lighter and consistent with sibling widgets (`temperature`, `machineStatus`) that use icon mode in compact zones.
+- **Alternative — flip the global compact default from `text` to `icon`:** rejected. That would change every existing compact `scaleWeight` instance, breaking "default preserves current behaviour"; seeding the preset only affects newly-created/default layouts.
+
+### 4. Lower-mid bar overlap — reproduce from the screenshots, then fix the layout, not with a timer/guard
+
+The reported overlap (size controls + "Ratio" label + ratio pill stacking) must be reproduced from the issue's screenshots before committing to a fix; it lands after items 1–3 within this change. Candidate mechanisms, in order of suspicion:
+- **`LayoutBarZone` scale + anchored row interaction:** `itemsRow` is anchored `left`/`right` *and* carries a `scale` transform with an alignment-pinned `transformOrigin`. A non-default `zoneScale` scales content around an edge while the row stays anchored full-width, which can push scaled children over neighbours. Likely fix: drive width from content (`implicitWidth`) under scale rather than anchoring full-width while scaling, or apply scale to a properly-sized inner container.
+- **`RatioQuickSelectItem` internal sizing:** its `ColumnLayout` uses `anchors.centerIn: parent; width: parent.width` while reporting `implicitWidth: col.implicitWidth`; if the delegate allocates less than implicit width, the centered pill can overflow its cell.
+- **Vertical collision (most likely):** the reported "size buttons" don't map to any lower-mid bar widget in the palette, which hints at a collision between the lower-mid bar and the in-page preset/size row — driven by `anchors.bottomMargin: -lowerMidBarYOffset` and the `lowerMidBarFits` clearance — rather than intra-zone overlap.
+
+The fix will be event-/layout-driven (correct sizing and transform origin), never a timer or post-hoc nudge, per project conventions. The screenshots decide which mechanism applies — this is the open question below.
+
+## Risks / Trade-offs
+
+- **[#4 root cause unconfirmed without the screenshots]** → Treat reproduction as the first task; do not ship a speculative layout change. The spec states the invariant ("no overlap"); the design lists hypotheses rather than asserting one. (This repo has a history of mis-rooted layout/visual diagnoses — verify before fixing.)
+- **[Live milk could flicker between live and committed values at session boundaries]** → Precedence is strict (live > 0 wins; else committed), and `sessionMeasuredMilkG` is reset to 0 on session end/ pitcher change in existing code, so the fallback is deterministic, not racy.
+- **[Seeding `displayMode: "icon"` on `lmb_scale` only affects new/default layouts]** → Accepted and intended: existing layouts must not silently change. Users on older layouts can opt into icon mode via the instance editor.
+- **[Web editor and in-app editor must agree on the new `showRatio` control]** → Add it to both in the same change (the "single source of truth for configurable widget types" requirement already governs this); tasks cover both sites.
+
+## Open Questions
+
+- Does issue #4 reproduce as intra-zone overlap (within `LayoutBarZone`) or as the lower-mid bar colliding with the in-page size/preset row? The screenshots from the issue author will decide which of the two fix paths in Decision 4 applies. Until then the spec's invariant holds regardless of mechanism.

--- a/openspec/changes/fix-brew-bar-widget-polish/proposal.md
+++ b/openspec/changes/fix-brew-bar-widget-polish/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The newly-shipped composable lower-mid bar and status bar ([#1368](https://github.com/Kulitorum/Decenza/issues/1368) / [#1369](https://github.com/Kulitorum/Decenza/issues/1369)) work well, but field testing surfaced four small rough edges in the brew/status readout widgets ([#1379](https://github.com/Kulitorum/Decenza/issues/1379)): the milk widget never shows live milk, the scale widget repeats the ratio that's already shown elsewhere, a compact scale reading has no label or icon to identify it, and the lower-mid bar's contents can overlap in some states. Each is confined to the item widgets and degrades the polish of a feature users are seeing for the first time.
+
+> **Rollout note:** Items 1–3 ship first. Item 4 (lower-mid bar overlap) is blocked on the reporter's screenshots — inspection alone can't disambiguate intra-zone overlap from a vertical collision with the in-page preset row — so it stays open within this change until a concrete repro is available. The change is not archived and the issue is not closed until item 4 lands.
+
+## What Changes
+
+- **Live milk readout** — the `milkWeight` widget shows the in-session measured milk (`sessionMeasuredMilkG`) while steaming, falling back to the last committed session weight (`Settings.brew.lastSteamMilkG`) when idle, so it gives live feedback during a steam instead of staying "—" until a session ends.
+- **Suppressible ratio on the scale widget** — the `scaleWeight` widget gains a per-instance `showRatio` option so its `1:X.X` suffix can be turned off where the ratio is already shown by a ratio pill or the status bar, ending the 2–3× duplication.
+- **Self-explanatory compact scale** — a `scaleWeight` widget rendered in a compact/bar zone identifies itself (its full "Scale Weight" label is full-mode only today, leaving compact instances as a bare dot + number), so the number is recognizable at a glance.
+- **No overlap in the lower-mid bar** — the lower-mid bar lays its widgets out without the size buttons, "Ratio" label, and ratio pill stacking on top of each other in some states. _(Blocked on screenshots; lands after items 1–3.)_
+
+## Capabilities
+
+### New Capabilities
+
+_None — all changes refine existing widget/zone behaviour._
+
+### Modified Capabilities
+
+- `layout-brew-widgets`: the measured-milk widget reflects live in-session milk while steaming, not only the last completed session.
+- `layout-widget-instance-config`: the `scaleWeight` widget gains a per-instance `showRatio` toggle (default preserves today's behaviour), and its compact rendering becomes self-identifying.
+- `layout-lower-mid-bar-zone`: the zone renders its widgets without overlap across the affected states. _(Deferred within this change — see rollout note.)_
+
+## Impact
+
+- QML widgets: `qml/components/layout/items/MilkWeightItem.qml`, `ScaleWeightItem.qml`.
+- Instance editor: `qml/components/layout/ScaleWeightEditorPopup.qml` (and its web-editor counterpart in `src/.../shotserver_layout.cpp`) gain the `showRatio` control.
+- Zone rendering: `qml/components/layout/LayoutBarZone.qml` and/or `RatioQuickSelectItem.qml` for the overlap fix (item 4, pending repro).
+- No new Settings properties, no BLE/protocol changes, no migration. Existing layouts render unchanged except where a user opts into the new `showRatio` setting.

--- a/openspec/changes/fix-brew-bar-widget-polish/specs/layout-brew-widgets/spec.md
+++ b/openspec/changes/fix-brew-bar-widget-polish/specs/layout-brew-widgets/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Measured milk widget
+
+The layout palette SHALL provide a `milkWeight` widget that displays the measured milk weight. While a steam session is in progress and a live in-session milk measurement is available, the widget SHALL display that live value; otherwise it SHALL display the most recent committed session weight (`Settings.brew.lastSteamMilkG`). This lets the widget give live feedback during steaming instead of remaining at the last completed session's value.
+
+#### Scenario: Live milk while steaming
+
+- **WHEN** a steam session is in progress and a live in-session milk weight greater than zero is available
+- **THEN** the widget SHALL display that live in-session weight in grams
+
+#### Scenario: Milk has been measured (idle)
+
+- **WHEN** no live in-session milk weight is available and a committed milk weight greater than zero exists
+- **THEN** the widget SHALL display the committed milk weight in grams
+
+#### Scenario: No milk measured or weight-timed steaming absent
+
+- **WHEN** no live and no committed milk weight is available (including when the weight-timed-steaming feature is not present)
+- **THEN** the widget SHALL display a placeholder ("—") and SHALL NOT error

--- a/openspec/changes/fix-brew-bar-widget-polish/specs/layout-lower-mid-bar-zone/spec.md
+++ b/openspec/changes/fix-brew-bar-widget-polish/specs/layout-lower-mid-bar-zone/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Lower-mid-bar widgets do not overlap
+
+The `lowerMidBar` zone SHALL lay out its widgets so they never visually overlap or stack on top of one another, across the zone's supported distribution, alignment, item-size, and scale states. In particular, a size-selecting control, a "Ratio" label, and a ratio pill placed together in the bar SHALL each occupy their own space and remain legible.
+
+#### Scenario: No overlap across layout states
+
+- **WHEN** the `lowerMidBar` zone renders one or more widgets in any supported distribution / alignment / item-size / scale combination
+- **THEN** each widget SHALL occupy a distinct, non-overlapping region of the bar
+
+#### Scenario: Size controls, ratio label, and ratio pill are distinct
+
+- **WHEN** the `lowerMidBar` contains size-selecting controls together with a "Ratio" label and ratio pill
+- **THEN** all three SHALL be laid out side by side without stacking on top of each other
+- **AND** each SHALL remain fully visible and legible
+
+#### Scenario: Scaled content stays within the bar
+
+- **WHEN** the `lowerMidBar` zone applies a non-default content scale
+- **THEN** the scaled widgets SHALL remain aligned to the zone and SHALL NOT overlap neighbouring widgets

--- a/openspec/changes/fix-brew-bar-widget-polish/specs/layout-widget-instance-config/spec.md
+++ b/openspec/changes/fix-brew-bar-widget-polish/specs/layout-widget-instance-config/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Configurable ratio suffix for the scale weight widget
+
+The `scaleWeight` widget SHALL gain a per-instance `showRatio` boolean property controlling whether its weight reading is suffixed with the active brew-by-ratio value (`1:X.X`). The default SHALL preserve the widget's current behaviour (suffix shown when brew-by-ratio is active), so existing layouts are unchanged. When `showRatio` is disabled, the widget SHALL show only the weight (and its unit), letting layouts that already surface the ratio elsewhere — a `ratioQuickSelect` pill or the status bar — avoid showing it 2–3 times.
+
+#### Scenario: Default preserves current behaviour
+
+- **WHEN** a `scaleWeight` widget has no `showRatio` set (existing layouts)
+- **THEN** it SHALL append the `1:X.X` ratio whenever brew-by-ratio is active, exactly as it does today
+
+#### Scenario: Ratio suppressed
+
+- **WHEN** `showRatio` is disabled on a `scaleWeight` instance and brew-by-ratio is active
+- **THEN** the widget SHALL display only the weight and its unit, with no `1:X.X` suffix
+
+#### Scenario: Ratio suffix irrelevant when not brewing by ratio
+
+- **WHEN** brew-by-ratio is not active
+- **THEN** the widget SHALL display only the weight regardless of the `showRatio` setting
+
+#### Scenario: Option is selected in the editor
+
+- **WHEN** a user opens a `scaleWeight` instance in either editor
+- **THEN** the editor SHALL present a control to toggle the ratio suffix
+- **AND** the chosen value SHALL persist for that instance only
+
+### Requirement: Compact scale weight widget is self-identifying
+
+A `scaleWeight` widget rendered in a compact/bar zone SHALL be visually identifiable as a scale reading without relying on its full-mode "Scale Weight" label. The widget SHALL convey its identity through its existing `icon` display mode (a scale icon ahead of the value), and the seeded bar presets that place a compact `scaleWeight` SHALL default it to a self-identifying presentation. This SHALL NOT introduce a new user-facing setting beyond the existing `displayMode`.
+
+#### Scenario: Compact scale shows an identifying icon
+
+- **WHEN** a `scaleWeight` widget is rendered in a compact/bar zone with `displayMode` set to `icon`
+- **THEN** it SHALL render a scale icon ahead of the value so the number is recognizable as a scale weight
+
+#### Scenario: Seeded bar presets are self-identifying
+
+- **WHEN** the layout system seeds a bar zone that includes a compact `scaleWeight` widget
+- **THEN** that seeded instance SHALL default to a self-identifying presentation (icon ahead of the value)
+
+#### Scenario: Existing instances are unaffected
+
+- **WHEN** an existing layout already contains a compact `scaleWeight` widget with its own `displayMode`
+- **THEN** that instance SHALL continue to render according to its stored mode, unchanged

--- a/openspec/changes/fix-brew-bar-widget-polish/tasks.md
+++ b/openspec/changes/fix-brew-bar-widget-polish/tasks.md
@@ -1,0 +1,31 @@
+## 1. Live milk readout (#1)
+
+- [x] 1.1 In `qml/components/layout/items/MilkWeightItem.qml`, source the value from `root.Window.window.sessionMeasuredMilkG` when > 0, else `Settings.brew.lastSteamMilkG`, else "—"; guard for missing `Window.window`/property so it never errors.
+- [x] 1.2 Update the `Accessible.name` to reflect the displayed (live-or-committed) value. (Already binds `valueText`, which now reflects the live-or-committed value.)
+- [ ] 1.3 Verify: while steaming, the widget tracks the live milk on the scale; when idle it shows the last committed session weight; with no data it shows "—".
+
+## 2. Suppressible ratio on the scale widget (#2)
+
+- [x] 2.1 In `qml/components/layout/items/ScaleWeightItem.qml`, add a per-instance `showRatio` property read from `modelData` defaulting to `true`; gate the `" 1:" + ratio` suffix in `weightText()` on it.
+- [x] 2.2 Add a "Show ratio" toggle to `qml/components/layout/ScaleWeightEditorPopup.qml`, persisting via `Settings.network.setItemProperty(itemId, "showRatio", …)` and loading the current value in `openForItem`. (Also threaded the value through `SettingsLayoutTab.qml`'s caller.)
+- [x] 2.3 Add the `showRatio` control to the web editor's scaleWeight options in `src/network/shotserver_layout.cpp`.
+- [x] 2.4 Add the i18n key(s) for the new toggle label (e.g. `layoutEditor.scaleShowRatio`) with an English fallback. (Inline `TranslationManager.translate` fallbacks; no separate registry exists, matching sibling keys.)
+- [ ] 2.5 Verify: default instances still show `1:X.X` when brewing by ratio; disabling `showRatio` hides only the suffix and persists per instance across restart.
+
+## 3. Self-identifying compact scale (#3)
+
+- [x] 3.1 Seed `displayMode: "icon"` on the `lmb_scale` preset in `qml/components/layout/ZoneOptionsPopup.qml` (line ~46).
+- [x] 3.2 Seed the same `displayMode: "icon"` on the `lmb_scale` preset in `src/network/shotserver_layout.cpp` (line ~347) so the in-app and web seeds match.
+- [ ] 3.3 Verify: a freshly-seeded lower-mid bar shows the compact scale with its scale icon ahead of the value; existing layouts with a stored `displayMode` are unchanged.
+
+## 4. Lower-mid bar overlap (#4)
+
+- [ ] 4.1 Reproduce the overlap from the issue screenshots; determine whether it is intra-zone (`LayoutBarZone`) or a vertical collision with the in-page size/preset row, and record which. **BLOCKED:** screenshots not attached to the issue; inspection alone can't disambiguate (the "size buttons" don't map to any lower-mid bar widget, hinting at a vertical collision). Awaiting screenshots before fixing — see design Open Questions.
+- [ ] 4.2 Apply the layout fix per the determined cause (e.g. correct `LayoutBarZone` scale/transform-origin vs. anchored-width interaction, or `RatioQuickSelectItem` width binding, or the height-gating clearance) — event/layout-driven, no timers or post-hoc nudges.
+- [ ] 4.3 Verify: size controls, the "Ratio" label, and the ratio pill render side by side without stacking across distribution/alignment/item-size/scale states.
+
+## 5. Validation
+
+- [x] 5.1 Quick compile check via Qt Creator MCP (build the matched project). (Clean build: 0 errors, 0 warnings; all touched QML AOT-compiled, `shotserver_layout.cpp` linked.)
+- [ ] 5.2 Confirm no new QML TypeErrors/warnings in the running app log for the touched widgets. (Pending a real-app launch by the user.)
+- [x] 5.3 Run `openspec validate fix-brew-bar-widget-polish --strict` and resolve any issues. (Valid.)

--- a/qml/components/layout/ScaleWeightEditorPopup.qml
+++ b/qml/components/layout/ScaleWeightEditorPopup.qml
@@ -11,11 +11,13 @@ Dialog {
     property string itemId: ""
     property string dataMode: ""
     property string displayMode: "text"
+    property bool showRatio: true
 
-    function openForItem(id, mode, display, color) {
+    function openForItem(id, mode, display, color, ratio) {
         popup.itemId = id
         popup.dataMode = (mode && mode.length > 0) ? mode : "gross"
         popup.displayMode = (display && display.length > 0) ? display : "text"
+        popup.showRatio = (ratio === undefined) ? true : ratio
         colorPicker.colorChoice = (color && color.length > 0) ? color : "default"
         popup.open()
     }
@@ -28,6 +30,11 @@ Dialog {
     function pickDisplay(mode) {
         popup.displayMode = mode
         Settings.network.setItemProperty(popup.itemId, "displayMode", mode)
+    }
+
+    function setShowRatio(v) {
+        popup.showRatio = v
+        Settings.network.setItemProperty(popup.itemId, "showRatio", v)
     }
 
     readonly property var displayChoices: [
@@ -130,6 +137,30 @@ Dialog {
                     }
                     MouseArea { id: dispMa; anchors.fill: parent; onClicked: popup.pickDisplay(modelData.value) }
                 }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacingMedium
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+                Text {
+                    text: TranslationManager.translate("layoutEditor.scaleShowRatio", "Show ratio")
+                    color: Theme.textColor
+                    font: Theme.bodyFont
+                }
+                Text {
+                    text: TranslationManager.translate("layoutEditor.scaleShowRatioHint", "Off = weight only, no 1:X.X suffix")
+                    color: Theme.textSecondaryColor
+                    font: Theme.captionFont
+                }
+            }
+            StyledSwitch {
+                accessibleName: TranslationManager.translate("layoutEditor.scaleShowRatio", "Show ratio")
+                checked: popup.showRatio
+                onToggled: popup.setShowRatio(checked)
             }
         }
 

--- a/qml/components/layout/ZoneOptionsPopup.qml
+++ b/qml/components/layout/ZoneOptionsPopup.qml
@@ -43,7 +43,7 @@ Dialog {
     function populateBrewBar() {
         var items = [
             { type: "profileName",      id: "lmb_profile" },
-            { type: "scaleWeight",      id: "lmb_scale", dataMode: "contextAware" },
+            { type: "scaleWeight",      id: "lmb_scale", dataMode: "contextAware", displayMode: "icon" },
             { type: "ratioQuickSelect", id: "lmb_ratio" },
             { type: "doseWeight",       id: "lmb_dose" },
             { type: "milkWeight",       id: "lmb_milk" }

--- a/qml/components/layout/items/MilkWeightItem.qml
+++ b/qml/components/layout/items/MilkWeightItem.qml
@@ -1,9 +1,12 @@
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Window
 import Decenza
 
-// Layout widget: last measured milk weight (composable-brew-bar).
-// Shows Settings.brew.lastSteamMilkG; "—" when none recorded.
+// Layout widget: measured milk weight (composable-brew-bar).
+// Shows the live in-session milk while steaming (sessionMeasuredMilkG on the
+// window root) and falls back to the last committed session weight
+// (Settings.brew.lastSteamMilkG); "—" when neither is available.
 Item {
     id: root
     property bool isCompact: false
@@ -12,9 +15,15 @@ Item {
     property bool zoneValueBold: false
 
     readonly property string labelText: TranslationManager.translate("idle.status.milk", "Milk")
-    readonly property string valueText: Settings.brew.lastSteamMilkG > 0
-                                        ? Settings.brew.lastSteamMilkG.toFixed(1) + " g"
-                                        : "—"
+    // Live in-session milk (set during steaming, reset to 0 at session end /
+    // pitcher change). 0 when the window or property is unavailable — guarded so
+    // the widget degrades to the committed value and never errors.
+    readonly property double liveMilkG: {
+        var win = root.Window.window
+        return (win && win.sessionMeasuredMilkG > 0) ? win.sessionMeasuredMilkG : 0
+    }
+    readonly property double milkG: liveMilkG > 0 ? liveMilkG : Settings.brew.lastSteamMilkG
+    readonly property string valueText: milkG > 0 ? milkG.toFixed(1) + " g" : "—"
 
     implicitWidth: col.implicitWidth
     implicitHeight: col.implicitHeight

--- a/qml/components/layout/items/ScaleWeightItem.qml
+++ b/qml/components/layout/items/ScaleWeightItem.qml
@@ -19,6 +19,12 @@ Item {
     // connected-dot + value) or "icon" (a scale icon ahead of the value).
     readonly property string displayMode: (modelData && modelData.displayMode) ? modelData.displayMode : "text"
 
+    // Per-instance "show ratio" toggle: when brew-by-ratio is active the weight
+    // is suffixed with "1:X.X". Defaults to true (today's behaviour); set false
+    // to suppress where the ratio is already shown elsewhere (ratio pill / status
+    // bar).
+    readonly property bool showRatio: (modelData && modelData.showRatio !== undefined) ? modelData.showRatio : true
+
     function _pitcherWeight() {
         var p = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
         return (p && !p.disabled) ? (p.pitcherWeightG ?? 0) : 0
@@ -104,7 +110,7 @@ Item {
     function weightText() {
         var weight = root.displayedWeight().toFixed(1)
         var suffix = root.isFlowScale ? "g~" : "g"
-        if (ProfileManager.brewByRatioActive) {
+        if (root.showRatio && ProfileManager.brewByRatioActive) {
             return weight + suffix + " 1:" + ProfileManager.brewByRatio.toFixed(1)
         }
         return weight + suffix

--- a/qml/pages/settings/SettingsLayoutTab.qml
+++ b/qml/pages/settings/SettingsLayoutTab.qml
@@ -125,7 +125,8 @@ Item {
         if (type.startsWith("screensaver") || type === "lastShot" || type === "shotPlan") {
             screensaverEditorPopup.openForItem(itemId, zoneName, props)
         } else if (type === "scaleWeight") {
-            scaleWeightEditorPopup.openForItem(itemId, props.dataMode || "", props.displayMode || "", props.color || "")
+            scaleWeightEditorPopup.openForItem(itemId, props.dataMode || "", props.displayMode || "", props.color || "",
+                props.showRatio !== undefined ? props.showRatio : true)
         } else if (type === "machineStatus" || type === "temperature" || type === "steamTemperature" || type === "waterLevel" || type === "clock") {
             displayModeEditorPopup.openForItem(itemId, props.displayMode || "", props.color || "")
         } else if (type === "sleep") {

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -344,7 +344,7 @@ void ShotServer::handleLayoutApi(QTcpSocket* socket, const QString& method, cons
         if (preset == "brewBar") {
             QVariantList items;
             items.append(QVariantMap{{"type", "profileName"}, {"id", "lmb_profile"}});
-            items.append(QVariantMap{{"type", "scaleWeight"}, {"id", "lmb_scale"}, {"dataMode", "contextAware"}});
+            items.append(QVariantMap{{"type", "scaleWeight"}, {"id", "lmb_scale"}, {"dataMode", "contextAware"}, {"displayMode", "icon"}});
             items.append(QVariantMap{{"type", "ratioQuickSelect"}, {"id", "lmb_ratio"}});
             items.append(QVariantMap{{"type", "doseWeight"}, {"id", "lmb_dose"}});
             items.append(QVariantMap{{"type", "milkWeight"}, {"id", "lmb_milk"}});
@@ -2716,6 +2716,12 @@ QString ShotServer::generateLayoutPage() const
                         html += '<option value="' + modes[mm][0] + '"' + msel + '>' + modes[mm][1] + '</option>';
                     }
                     html += '</select>';
+                    // Show-ratio toggle: suppress the redundant 1:X.X suffix.
+                    var sr = (item.showRatio === undefined) ? true : item.showRatio;
+                    html += '<select class="chip-mode" onchange="setShowRatio(\'' + item.id + '\',this.value===\'1\')" onclick="event.stopPropagation()">';
+                    html += '<option value="1"' + (sr ? ' selected' : '') + '>Ratio on</option>';
+                    html += '<option value="0"' + (!sr ? ' selected' : '') + '>Ratio off</option>';
+                    html += '</select>';
                 }
                 // Inline display-mode selector for selected readout chips.
                 if (isSel && READOUT_TYPES.indexOf(item.type) !== -1) {
@@ -2927,6 +2933,12 @@ QString ShotServer::generateLayoutPage() const
 
     function setShowIcon(itemId, show) {
         apiPost("/api/layout/item", {itemId: itemId, key: "showIcon", value: show}, function() {
+            loadLayout();
+        });
+    }
+
+    function setShowRatio(itemId, show) {
+        apiPost("/api/layout/item", {itemId: itemId, key: "showRatio", value: show}, function() {
             loadLayout();
         });
     }


### PR DESCRIPTION
Field-test polish for the composable lower-mid/status bars, addressing **items 1–3** of #1379. Each fix is confined to the readout item widgets; no new settings, no migration, existing layouts render unchanged except where a user opts into the new `showRatio` toggle.

## What's in this PR

### 1. Live milk readout
`MilkWeightItem` now shows the live in-session milk (`sessionMeasuredMilkG` on the window root) while steaming, falling back to the last committed session weight (`Settings.brew.lastSteamMilkG`) when idle. Previously it bound only to the committed value, so it stayed `—` until a session ended and never reflected milk on the scale during measurement. Guarded for a missing `Window.window`/property so it degrades to the committed value and never errors.

### 2. Suppressible ratio on the scale widget
`scaleWeight` gains a per-instance **`showRatio`** boolean (default `true`, preserving today's behaviour). When off, the widget shows only the weight — no `1:X.X` suffix — for layouts that already surface the ratio via a `ratioQuickSelect` pill or the status bar (where it was appearing 2–3×). Editable in both editors:
- In-app: a "Show ratio" switch in `ScaleWeightEditorPopup`.
- Web: a Ratio on/off selector on the scaleWeight chip in `shotserver_layout.cpp`.

### 3. Self-identifying compact scale
The seeded lower-mid-bar `lmb_scale` preset now defaults to `displayMode: "icon"` (matching the status bar's `csb_scale`), so a compact scale reads as a scale weight via its icon instead of a bare dot + number. Seeded in both the in-app (`ZoneOptionsPopup`) and web (`shotserver_layout.cpp`) populate paths. **Existing layouts with a stored `displayMode` are unaffected.**

## Deferred — item 4 (lower-mid bar overlap)
Issue #1379 also reports the size buttons / "Ratio" label / ratio pill overlapping in some states. That is **not** in this PR: it's blocked on the reporter's screenshots, and inspection alone can't disambiguate intra-zone overlap from a vertical collision with the in-page preset row (the reported "size buttons" don't map to any lower-mid bar widget, which hints at the latter). It stays tracked in the openspec change; the issue stays open and the change un-archived until item 4 lands.

## Testing
- Clean Qt Creator build: 0 errors, 0 warnings; all touched QML AOT-compiled, `shotserver_layout.cpp` linked.
- Runtime verification (live-milk during steam, ratio toggle persistence, seeded icon) pending a real-app launch.

Planned via OpenSpec change `fix-brew-bar-widget-polish` (included in this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)