### PR TITLE
ci: re-enable Qt-for-iOS caching (saves ~4-5 min/iOS build)

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -76,15 +76,16 @@ jobs:
           target: 'ios'
           arch: 'ios'
           modules: 'qtquick3d qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtimageformats qtcanvaspainter'
-          # Qt-for-iOS caching is intentionally disabled. The iOS Qt install
-          # is ~4.2 GB — over half the 10 GB per-repo Actions cache budget —
-          # and its presence forced GitHub's LRU eviction to thrash the
-          # other 5 platforms' Qt caches (and the ccache entries), making
-          # every release slower. iOS is our least release-critical build,
-          # so it pays the cold Qt-install cost (a few extra minutes) to
-          # keep windows/macos/linux/android Qt caches resident. Re-enable
-          # only if the budget pressure is otherwise resolved.
-          cache: false
+          # Qt-for-iOS caching was previously disabled because the iOS Qt install
+          # (~4.2 GB on disk) pushed the repo past GitHub's 10 GB cache budget and
+          # forced LRU eviction to thrash the other 5 platforms' Qt/ccache entries.
+          # That budget pressure is now resolved: the "Prune stale ccache caches"
+          # step in macos-release.yml keeps the store bounded (~6-7 GB steady state),
+          # so caching iOS Qt is affordable and saves ~4-5 min of cold Qt download
+          # per iOS build. If budget pressure ever returns, the prune step will
+          # surface it — re-evaluate then rather than disabling this again blindly.
+          cache: true
+          cache-key-prefix: 'qt-ios-v1'
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2.23


### PR DESCRIPTION
## Why

The iOS build's **Install Qt** step takes **~288s (4.8 min)** every run, while every other platform restores Qt from cache in 8–25s:

| Build | Install Qt |
|---|---|
| **iOS** | **288s — uncached** |
| macOS | 25s |
| Linux ARM64 | 19s |
| Windows | 16s |
| Linux | 15s |
| Android | 8s |

iOS Qt caching was deliberately disabled (`cache: false`) because the ~4.2 GB install pushed the repo past GitHub's 10 GB cache cap and forced LRU eviction to thrash the other 5 platforms' Qt/ccache entries. The comment left an explicit escape hatch: *"Re-enable only if the budget pressure is otherwise resolved."*

That pressure is now resolved by the **Prune stale ccache caches** step (#1382): the store dropped 11.5 GB → 7.26 GB and sits at ~6–7 GB steady state, with the prune actively keeping it bounded.

## Change

- `cache: true` + `cache-key-prefix: 'qt-ios-v1'` on the iOS Install Qt step (matches the `qt-<platform>-vN` convention used by the other 5 workflows).
- Updated the comment to reflect the resolved budget and to note that the prune step will surface any future pressure.

## Expected effect

~4–5 min off each iOS build after the first (cache-seeding) run. The iOS Qt cache compresses to ~1–1.5 GB (the other Qt caches are 400–660 MB), which fits the current headroom; if it ever re-pressures the budget, the prune step makes it visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)