### PR TITLE
Revert iOS Qt caching — 3.96 GB cache exceeds the 10 GB cap

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -76,16 +76,18 @@ jobs:
           target: 'ios'
           arch: 'ios'
           modules: 'qtquick3d qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtimageformats qtcanvaspainter'
-          # Qt-for-iOS caching was previously disabled because the iOS Qt install
-          # (~4.2 GB on disk) pushed the repo past GitHub's 10 GB cache budget and
-          # forced LRU eviction to thrash the other 5 platforms' Qt/ccache entries.
-          # That budget pressure is now resolved: the "Prune stale ccache caches"
-          # step in macos-release.yml keeps the store bounded (~6-7 GB steady state),
-          # so caching iOS Qt is affordable and saves ~4-5 min of cold Qt download
-          # per iOS build. If budget pressure ever returns, the prune step will
-          # surface it — re-evaluate then rather than disabling this again blindly.
-          cache: true
-          cache-key-prefix: 'qt-ios-v1'
+          # Qt-for-iOS caching is intentionally disabled. The iOS Qt cache is too
+          # large to coexist with the other platforms under GitHub's 10 GB per-repo
+          # cache cap: even after the "Prune stale ccache caches" step (macos-release.yml)
+          # trimmed the duplicate ccache piles to ~7.3 GB, re-enabling iOS Qt caching
+          # was MEASURED at 3.96 GB for the single qt-ios cache entry (it barely
+          # compresses), pushing the store to 10.53 GB — over the cap and back into
+          # LRU-eviction thrash. See the experiment in PR #1383 (re-enable) and its
+          # revert. iOS is our least cache-critical build, so it pays the ~5 min cold
+          # Qt-install cost to keep windows/macos/linux/android Qt caches resident.
+          # Do NOT re-enable without first shrinking the iOS Qt cache (e.g. trimming
+          # unused modules) so the total stays comfortably under 10 GB.
+          cache: false
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2.23


### PR DESCRIPTION
## What

Reverts the iOS Qt caching re-enabled in #1383 (`cache: false` restored).

## Why — measured result

#1383 hypothesized that the prune step (#1382) had freed enough cache budget to cache iOS Qt. We seeded it on a `v1.8.1` rebuild and measured the actual sizes:

- The single **`qt-ios-v1` cache = 3.96 GB** (Qt libs barely compress; the ~1–1.5 GB estimate was wrong).
- Total cache store went **7.26 GB → 10.53 GB — over GitHub's 10 GB cap**, re-introducing the LRU-eviction thrash the original `cache: false` comment warned about.

The iOS build's Install Qt step *would* drop from ~315s to ~20s with the cache, but the budget cost isn't affordable at the current cache footprint. Reverting restores the known-good ~7.3 GB store with healthy headroom; iOS keeps paying the ~5 min cold Qt install (it's the least cache-critical build).

The comment now records the measured numbers and says not to re-enable without first shrinking the iOS Qt cache (e.g. trimming unused modules) so the total stays comfortably under 10 GB.

## Follow-up

The orphaned 3.96 GB `qt-ios-v1` cache entry will be deleted manually so the store drops back under the cap immediately (it would otherwise linger until LRU/7-day eviction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)