### PR TITLE
Update Atomheart Eclair timer opcodes to match de1app PR #349

### DIFF
--- a/src/ble/scaledevice.h
+++ b/src/ble/scaledevice.h
@@ -57,8 +57,8 @@ public slots:
     virtual void resetTimer() {}
     // Whether resetTimer() is a true no-side-effect reset (distinct from startTimer/tare).
     // False for scales where resetTimer() has side effects (e.g., DiFluid sends same bytes
-    // as startTimer, Eclair delegates to tare). When false, MachineState sends reset+start
-    // together at extraction start instead of splitting them across the preheating phase.
+    // as startTimer). When false, MachineState sends reset+start together at extraction
+    // start instead of splitting them across the preheating phase.
     virtual bool hasIndependentTimerReset() const { return true; }
     virtual void sleep() { emit sleepCompleted(); }  // Put scale to sleep (battery power saving - full power off)
     virtual void wake() {}   // Wake scale from sleep (enable LCD)

--- a/src/ble/scales/atomhearteclairscale.cpp
+++ b/src/ble/scales/atomhearteclairscale.cpp
@@ -99,13 +99,16 @@ void AtomheartEclairScale::onCharacteristicsDiscoveryFinished(const QBluetoothUu
     m_characteristicsReady = true;
     setConnected(true);
 
-    // de1app uses 200ms delay for Atomheart Eclair
-    ECLAIR_LOG("Scheduling notification enable in 200ms (de1app timing)");
-    QTimer::singleShot(200, this, [this]() {
-        if (!m_transport || !m_characteristicsReady) return;
-        ECLAIR_LOG("Enabling notifications (200ms)");
-        m_transport->enableNotifications(Scale::AtomheartEclair::SERVICE, Scale::AtomheartEclair::STATUS);
-    });
+    // de1app enables weight notifications twice (200ms + 800ms) because the Eclair
+    // sometimes ignores the first enable and never starts streaming weight.
+    ECLAIR_LOG("Scheduling notification enable at 200ms and 800ms (de1app timing)");
+    for (int delayMs : {200, 800}) {
+        QTimer::singleShot(delayMs, this, [this, delayMs]() {
+            if (!m_transport || !m_characteristicsReady) return;
+            ECLAIR_LOG(QString("Enabling notifications (%1ms)").arg(delayMs));
+            m_transport->enableNotifications(Scale::AtomheartEclair::SERVICE, Scale::AtomheartEclair::STATUS);
+        });
+    }
 }
 
 bool AtomheartEclairScale::validateXor(const QByteArray& data) {
@@ -162,14 +165,14 @@ void AtomheartEclairScale::tare() {
 }
 
 void AtomheartEclairScale::startTimer() {
-    sendCommand(QByteArray::fromHex("430101"));
+    sendCommand(QByteArray::fromHex("530101"));
 }
 
 void AtomheartEclairScale::stopTimer() {
-    sendCommand(QByteArray::fromHex("430000"));
+    sendCommand(QByteArray::fromHex("450101"));
 }
 
 void AtomheartEclairScale::resetTimer() {
-    // Eclair resets timer on tare
-    tare();
+    // Eclair has a dedicated timer-reset command (distinct from tare)
+    sendCommand(QByteArray::fromHex("520101"));
 }

--- a/src/ble/scales/atomhearteclairscale.cpp
+++ b/src/ble/scales/atomhearteclairscale.cpp
@@ -99,9 +99,11 @@ void AtomheartEclairScale::onCharacteristicsDiscoveryFinished(const QBluetoothUu
     m_characteristicsReady = true;
     setConnected(true);
 
-    // de1app enables weight notifications twice (200ms + 800ms) because the Eclair
-    // sometimes ignores the first enable and never starts streaming weight.
-    ECLAIR_LOG("Scheduling notification enable at 200ms and 800ms (de1app timing)");
+    // de1app PR #349 enables weight notifications twice (200ms + 800ms) because the
+    // Eclair sometimes ignores the first enable and never starts streaming weight.
+    // Note: these are fire-and-forget — there is no read-back confirming the scale
+    // actually started streaming (see connected-but-silent gap tracked separately).
+    ECLAIR_LOG("Scheduling notification enable at 200ms and 800ms (de1app PR #349 timing)");
     for (int delayMs : {200, 800}) {
         QTimer::singleShot(delayMs, this, [this, delayMs]() {
             if (!m_transport || !m_characteristicsReady) return;
@@ -173,6 +175,6 @@ void AtomheartEclairScale::stopTimer() {
 }
 
 void AtomheartEclairScale::resetTimer() {
-    // Eclair has a dedicated timer-reset command (distinct from tare)
+    // de1app PR #349 gives the Eclair a dedicated timer-reset opcode, distinct from tare
     sendCommand(QByteArray::fromHex("520101"));
 }

--- a/src/ble/scales/atomhearteclairscale.cpp
+++ b/src/ble/scales/atomhearteclairscale.cpp
@@ -31,9 +31,20 @@ AtomheartEclairScale::AtomheartEclairScale(ScaleBleTransport* transport, QObject
         connect(m_transport, &ScaleBleTransport::logMessage,
                 this, &ScaleDevice::logMessage);
     }
+
+    // Watchdog fires if no weight updates arrive after enabling notifications
+    m_watchdogTimer = new QTimer(this);
+    m_watchdogTimer->setSingleShot(true);
+    connect(m_watchdogTimer, &QTimer::timeout, this, &AtomheartEclairScale::onWatchdogTimeout);
+
+    // Tickle timer fires if weight updates stop arriving once streaming
+    m_tickleTimer = new QTimer(this);
+    m_tickleTimer->setSingleShot(true);
+    connect(m_tickleTimer, &QTimer::timeout, this, &AtomheartEclairScale::onTickleTimeout);
 }
 
 AtomheartEclairScale::~AtomheartEclairScale() {
+    stopWatchdog();
     if (m_transport) {
         m_transport->disconnectFromDevice();
     }
@@ -63,11 +74,13 @@ void AtomheartEclairScale::onTransportConnected() {
 
 void AtomheartEclairScale::onTransportDisconnected() {
     ECLAIR_LOG("Transport disconnected");
+    stopWatchdog();
     setConnected(false);
 }
 
 void AtomheartEclairScale::onTransportError(const QString& message) {
     ECLAIR_WARN(QString("Transport error: %1").arg(message));
+    stopWatchdog();
     setConnected(false);
 }
 
@@ -97,20 +110,21 @@ void AtomheartEclairScale::onCharacteristicsDiscoveryFinished(const QBluetoothUu
 
     ECLAIR_LOG("Characteristics discovered");
     m_characteristicsReady = true;
-    setConnected(true);
 
-    // de1app PR #349 enables weight notifications twice (200ms + 800ms) because the
-    // Eclair sometimes ignores the first enable and never starts streaming weight.
-    // Note: these are fire-and-forget — there is no read-back confirming the scale
-    // actually started streaming (see connected-but-silent gap tracked separately).
-    ECLAIR_LOG("Scheduling notification enable at 200ms and 800ms (de1app PR #349 timing)");
-    for (int delayMs : {200, 800}) {
-        QTimer::singleShot(delayMs, this, [this, delayMs]() {
-            if (!m_transport || !m_characteristicsReady) return;
-            ECLAIR_LOG(QString("Enabling notifications (%1ms)").arg(delayMs));
-            m_transport->enableNotifications(Scale::AtomheartEclair::SERVICE, Scale::AtomheartEclair::STATUS);
-        });
-    }
+    // Enable notifications after a 200ms settle (de1app timing), then start the
+    // watchdog. We deliberately do NOT call setConnected(true) here — connected
+    // state is deferred until the first weight frame actually arrives (see
+    // tickleWatchdog), so a scale that never streams weight is reported as not
+    // connected rather than appearing connected-but-stuck-at-0g.
+    ECLAIR_LOG("Scheduling notification enable in 200ms (de1app timing)");
+    QTimer::singleShot(200, this, [this]() {
+        if (!m_transport || !m_characteristicsReady) {
+            ECLAIR_WARN("Transport gone before notification enable");
+            return;
+        }
+        enableNotifications();
+        startWatchdog();
+    });
 }
 
 bool AtomheartEclairScale::validateXor(const QByteArray& data) {
@@ -143,6 +157,9 @@ void AtomheartEclairScale::onCharacteristicChanged(const QBluetoothUuid& charact
                 return;
             }
 
+            // Valid weight frame — feed the watchdog (also flips connected on first frame)
+            tickleWatchdog();
+
             // Weight is 4-byte signed int32 in milligrams (little-endian)
             int32_t weightMg = d[1] | (d[2] << 8) | (d[3] << 16) | (d[4] << 24);
             double weight = weightMg / 1000.0;  // Convert to grams
@@ -157,9 +174,74 @@ void AtomheartEclairScale::sendCommand(const QByteArray& cmd) {
     m_transport->writeCharacteristic(Scale::AtomheartEclair::SERVICE, Scale::AtomheartEclair::CMD, cmd);
 }
 
+void AtomheartEclairScale::enableNotifications() {
+    if (!m_transport || !m_characteristicsReady) {
+        ECLAIR_WARN("enableNotifications() - transport or characteristics not ready");
+        return;
+    }
+    ECLAIR_LOG("Enabling weight notifications on STATUS characteristic");
+    m_transport->enableNotifications(Scale::AtomheartEclair::SERVICE, Scale::AtomheartEclair::STATUS);
+}
+
+void AtomheartEclairScale::startWatchdog() {
+    m_watchdogRetries = 0;
+    m_updatesReceived = false;
+    m_watchdogTimer->start(WATCHDOG_TIMEOUT_MS);
+    ECLAIR_LOG(QString("Started watchdog, waiting for first weight update (timeout: %1ms)").arg(WATCHDOG_TIMEOUT_MS));
+}
+
+void AtomheartEclairScale::tickleWatchdog() {
+    // First valid weight frame — the scale is proven functional, so report connected now.
+    if (!m_updatesReceived) {
+        m_updatesReceived = true;
+        m_watchdogTimer->stop();
+        ECLAIR_LOG("First weight update received, reporting connected");
+        if (!isConnected()) {
+            setConnected(true);
+        }
+    }
+
+    // Restart the no-update timeout; if weight stops streaming we re-enable notifications.
+    m_tickleTimer->start(TICKLE_TIMEOUT_MS);
+}
+
+void AtomheartEclairScale::stopWatchdog() {
+    if (m_watchdogTimer) m_watchdogTimer->stop();
+    if (m_tickleTimer) m_tickleTimer->stop();
+    m_updatesReceived = false;
+    m_watchdogRetries = 0;
+}
+
+void AtomheartEclairScale::onWatchdogTimeout() {
+    if (m_updatesReceived) return;  // Data started arriving, nothing to do
+
+    m_watchdogRetries++;
+    if (m_watchdogRetries >= MAX_WATCHDOG_RETRIES) {
+        ECLAIR_WARN(QString("No weight updates after %1 retries, reporting disconnected").arg(MAX_WATCHDOG_RETRIES));
+        setConnected(false);
+        return;
+    }
+
+    ECLAIR_WARN(QString("No weight updates, re-enabling notifications (retry %1 of %2)")
+                    .arg(m_watchdogRetries).arg(MAX_WATCHDOG_RETRIES));
+    enableNotifications();
+    m_watchdogTimer->start(WATCHDOG_TIMEOUT_MS);
+}
+
+void AtomheartEclairScale::onTickleTimeout() {
+    // Weight was streaming and then stopped — try re-enabling notifications once more.
+    ECLAIR_WARN(QString("No weight updates for %1ms, re-enabling notifications").arg(TICKLE_TIMEOUT_MS));
+    m_updatesReceived = false;
+    m_watchdogRetries = 0;
+    enableNotifications();
+    m_watchdogTimer->start(WATCHDOG_TIMEOUT_MS);
+}
+
 void AtomheartEclairScale::sendKeepAlive() {
     // No keep-alive needed — notifications stay active without periodic CCCD re-writes.
-    // Re-writing the CCCD risks AuthorizationError disconnects.
+    // Re-writing the CCCD risks AuthorizationError disconnects, so the watchdog only
+    // re-enables on missing data (onWatchdogTimeout/onTickleTimeout), never on a timer
+    // while weight is streaming normally.
 }
 
 void AtomheartEclairScale::tare() {

--- a/src/ble/scales/atomhearteclairscale.h
+++ b/src/ble/scales/atomhearteclairscale.h
@@ -19,8 +19,9 @@ public slots:
     void startTimer() override;
     void stopTimer() override;
     void resetTimer() override;
-    // Eclair has a dedicated timer-reset opcode (0x52) distinct from tare, so the base
-    // class default (true) applies — reset/start can be split across the preheating phase.
+    // de1app PR #349 gives the Eclair a dedicated timer-reset opcode (0x52) distinct from
+    // tare, so the base class default (true) applies — reset/start can be split across the
+    // preheating phase.
     void sendKeepAlive() override;
 
 private slots:

--- a/src/ble/scales/atomhearteclairscale.h
+++ b/src/ble/scales/atomhearteclairscale.h
@@ -19,7 +19,8 @@ public slots:
     void startTimer() override;
     void stopTimer() override;
     void resetTimer() override;
-    bool hasIndependentTimerReset() const override { return false; }  // Delegates to tare()
+    // Eclair has a dedicated timer-reset opcode (0x52) distinct from tare, so the base
+    // class default (true) applies — reset/start can be split across the preheating phase.
     void sendKeepAlive() override;
 
 private slots:

--- a/src/ble/scales/atomhearteclairscale.h
+++ b/src/ble/scales/atomhearteclairscale.h
@@ -2,6 +2,7 @@
 
 #include "../scaledevice.h"
 #include "../transport/scalebletransport.h"
+#include <QTimer>
 
 class AtomheartEclairScale : public ScaleDevice {
     Q_OBJECT
@@ -32,13 +33,33 @@ private slots:
     void onServicesDiscoveryFinished();
     void onCharacteristicsDiscoveryFinished(const QBluetoothUuid& serviceUuid);
     void onCharacteristicChanged(const QBluetoothUuid& characteristicUuid, const QByteArray& value);
+    void onWatchdogTimeout();
+    void onTickleTimeout();
 
 private:
     void sendCommand(const QByteArray& cmd);
     bool validateXor(const QByteArray& data);
+    void enableNotifications();
+    void startWatchdog();
+    void tickleWatchdog();
+    void stopWatchdog();
 
     ScaleBleTransport* m_transport = nullptr;
     QString m_name = "Atomheart Eclair";
     bool m_serviceFound = false;
     bool m_characteristicsReady = false;
+
+    // Watchdog: defers connected-state until the first weight frame arrives and
+    // re-enables notifications if weight stops streaming. Without this the scale
+    // can report "connected" while stuck at 0 g, which fools the no-scale shot-abort
+    // safety check. Mirrors VariaAkuScale. Note: re-enabling rewrites the CCCD, which
+    // the Eclair is sensitive to (see sendKeepAlive), so retries only fire on no-data,
+    // never during healthy streaming.
+    QTimer* m_watchdogTimer = nullptr;
+    QTimer* m_tickleTimer = nullptr;
+    int m_watchdogRetries = 0;
+    bool m_updatesReceived = false;
+    static constexpr int WATCHDOG_TIMEOUT_MS = 1000;   // Retry interval when no data yet
+    static constexpr int TICKLE_TIMEOUT_MS = 2000;     // No-update timeout once streaming
+    static constexpr int MAX_WATCHDOG_RETRIES = 5;     // Conservative — Eclair CCCD is touchy
 };

--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -504,9 +504,9 @@ void MachineState::updatePhase() {
             // Normally startTimer() is sent later when extraction begins, separating
             // the two commands by the preheating phase to avoid BLE command contention
             // (WriteWithoutResponse can silently drop back-to-back packets).
-            // Only split for scales with a true independent reset — some scales implement
-            // resetTimer() as tare (Eclair) or send the same bytes as startTimer (DiFluid),
-            // so splitting would cause unwanted side effects during preheating.
+            // Only split for scales with a true independent reset — some scales send the
+            // same bytes for resetTimer() as startTimer() (DiFluid), so splitting would
+            // cause unwanted side effects during preheating.
             // If already flowing (machine skipped preheating), send both now — there
             // won't be a separate extraction-start transition to send startTimer().
             if (m_scale && m_scale->hasIndependentTimerReset()) {


### PR DESCRIPTION
## What

Brings our Atomheart Eclair scale driver in line with [decentespresso/de1app#349](https://github.com/decentespresso/de1app/pull/349), then closes a connected-but-silent reliability gap that review surfaced in the same connect path.

### 1. Timer opcodes (de1app PR #349)

de1app PR #349 reassigned the Eclair's timer command bytes and gave it a dedicated timer-reset opcode (previously reset was an alias for tare). Our driver was still sending the old bytes, so the scale's **onboard timer display** wouldn't reset/start/stop correctly during a shot. (Weight streaming was unaffected.)

| Command | Old bytes | New bytes (PR #349) |
|---|---|---|
| timer_reset | `540101` (tare alias) | `520101` (dedicated) |
| timer_start | `430101` | `530101` |
| timer_stop  | `430000` | `450101` |
| tare | `540101` | `540101` (unchanged) |

`resetTimer()` now sends the dedicated `520101` instead of delegating to `tare()`, so `hasIndependentTimerReset()` returns the base default (`true`) and `MachineState` splits reset/start across preheating like other scales. Fixed the now-stale comments in `scaledevice.h` and `machinestate.cpp` that named Eclair as a tare-delegating scale.

### 2. Connected-state weight-gate + notification watchdog

Previously `setConnected(true)` fired on characteristic discovery — *before* notifications were enabled. If the scale ignored the enable and never streamed weight, the app showed a connected scale stuck at 0 g with no warning and no revert, and a connected-but-silent scale **fools the no-scale shot-abort safety check**.

Ported the proven `VariaAkuScale` pattern:
- `setConnected(true)` is deferred until the **first valid weight frame** arrives.
- A watchdog re-enables notifications (bounded retries) if no weight arrives, then gives up with `setConnected(false)` so the failure is visible.
- A tickle timer re-enables once if a streaming scale goes quiet.

This **supersedes the blind 200ms+800ms double-enable** — retries are now data-driven. Re-enables fire only on missing data, never during healthy streaming, to respect the Eclair's documented CCCD-rewrite sensitivity (`sendKeepAlive`).

## Testing

- Builds clean (0 errors, 0 warnings).
- **Not yet hardware-verified against a physical Eclair.** Two parts need a real scale to validate:
  1. The timer opcodes (`520101`/`530101`/`450101`) — match the upstream PR verbatim but unconfirmed on-device.
  2. The connect-path change (weight-gated connected-state + watchdog) — touches connected-state behavior; should be exercised with a real Eclair to confirm normal connect, no spurious disconnects, and that CCCD re-enable on data loss doesn't trip an AuthorizationError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)