### PR TITLE
Instrument DiFluid R2 to diagnose Brix-vs-TDS readings

### DIFF
--- a/src/ble/refractometers/difluidr2.cpp
+++ b/src/ble/refractometers/difluidr2.cpp
@@ -73,6 +73,16 @@ DiFluidR2::DiFluidR2(ScaleBleTransport* transport, QObject* parent)
         initCmd.append(static_cast<char>(checksum));
         R2_LOG(QString("Sending init query: %1").arg(QString(initCmd.toHex(' '))));
         sendCommand(initCmd);
+
+        // Instrumentation: identify the unit. Per DiFluid's official protocolR2.md, a
+        // genuine R2 Extract (model "DFT-R102") transmits coffee *TDS* in pack 2, while
+        // Brix-only variants (R2 PU/PP) and rebrands/clones transmit *Brix* in the same
+        // "concentration" field — which we'd then mislabel as TDS. Logging the model
+        // string lets us tell them apart when a reading looks like Brix, not TDS.
+        // These are fixed DataLen=0 queries straight from the spec (checksum baked in).
+        R2_LOG("Querying device model + firmware (instrumentation)");
+        sendCommand(QByteArray::fromHex("DFDF000100BF"));  // Get Device Model (Func 0, Cmd 1)
+        sendCommand(QByteArray::fromHex("DFDF000200C0"));  // Get Firmware Version (Func 0, Cmd 2)
     });
 
     if (m_transport) {
@@ -285,8 +295,33 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
         return;
     }
 
+    // Func 0 = Device Info: decode the model/firmware strings for instrumentation.
+    // Model "DFT-R102" == genuine R2 Extract (transmits coffee TDS); anything else is a
+    // Brix variant / rebrand and the pack-2 concentration field is Brix, not TDS.
+    if (func == 0) {
+        const QByteArray data = packet.mid(5, dataLen);
+        if (cmd == 1) {  // Device Model
+            m_deviceModel = QString::fromLatin1(data);
+            R2_LOG(QString("Device model: \"%1\"%2")
+                       .arg(m_deviceModel,
+                            m_deviceModel == QLatin1String("DFT-R102")
+                                ? QStringLiteral(" (genuine R2 Extract — concentration = TDS)")
+                                : QStringLiteral(" (NOT a standard R2 Extract — concentration may be Brix, not TDS)")));
+        } else if (cmd == 2) {  // Firmware Version
+            R2_LOG(QString("Firmware version: \"%1\"").arg(QString::fromLatin1(data)));
+        } else {
+            R2_LOG(QString("Device info response: Cmd=%1 data=%2")
+                       .arg(cmd).arg(QString(data.toHex(' '))));
+        }
+        return;
+    }
+
     // Func 3 = Device Action (test results)
     if (func == 3) {
+        // Instrumentation: full raw bytes of every result packet, so a Brix-vs-TDS
+        // mismatch (concentration field vs. the refractive index) is diagnosable from logs.
+        R2_LOG(QString("Action packet raw: %1").arg(QString(packet.toHex(' '))));
+
         if (cmd == 254) {
             // Error response
             uint8_t errClass = dataLen > 0 ? static_cast<uint8_t>(packet[5]) : 0;
@@ -339,10 +374,11 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
             break;
         }
         case 2: {
-            // TDS result: Data1-2 = concentration * 100 (Data3-6 = refractive index, not parsed)
+            // TDS result: Data1-2 = concentration * 100, Data3-6 = refractive index * 100000
             if (dataLen < 3) return;
             quint16 tdsRaw = static_cast<quint16>(
                 (static_cast<uint8_t>(packet[6]) << 8) | static_cast<uint8_t>(packet[7]));
+            logRefractiveIndex(packet, dataLen);
             emitTdsResult(tdsRaw, /*isAverage=*/false);
             break;
         }
@@ -351,6 +387,7 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
             if (dataLen < 3) return;
             quint16 tdsRaw = static_cast<quint16>(
                 (static_cast<uint8_t>(packet[6]) << 8) | static_cast<uint8_t>(packet[7]));
+            logRefractiveIndex(packet, dataLen);
             emitTdsResult(tdsRaw, /*isAverage=*/true);
             break;
         }
@@ -397,6 +434,21 @@ void DiFluidR2::emitTdsResult(quint16 tdsRaw, bool isAverage) {
     m_measurementTimer.stop();
     m_measuring = false;
     emit measuringChanged();
+}
+
+void DiFluidR2::logRefractiveIndex(const QByteArray& packet, quint8 dataLen) {
+    // Data3-6 (packet bytes 8..11) = refractive index * 100000. Caller already verified
+    // the packet holds dataLen data bytes, so bytes 8..11 are in range when dataLen >= 7.
+    if (dataLen < 7) {
+        R2_LOG("No refractive index in packet (short packet / older firmware)");
+        return;
+    }
+    quint32 riRaw = (static_cast<quint32>(static_cast<uint8_t>(packet[8])) << 24)
+                  | (static_cast<quint32>(static_cast<uint8_t>(packet[9])) << 16)
+                  | (static_cast<quint32>(static_cast<uint8_t>(packet[10])) << 8)
+                  | static_cast<quint32>(static_cast<uint8_t>(packet[11]));
+    R2_LOG(QString("Refractive index: %1 (raw=%2)")
+               .arg(riRaw / 100000.0, 0, 'f', 5).arg(riRaw));
 }
 
 bool DiFluidR2::validateChecksum(const QByteArray& packet) const {

--- a/src/ble/refractometers/difluidr2.h
+++ b/src/ble/refractometers/difluidr2.h
@@ -63,6 +63,10 @@ private:
     // Applies the out-of-range sanity gate so every consumer-bound TDS is
     // validated identically regardless of which path produced it.
     void emitTdsResult(quint16 tdsRaw, bool isAverage);
+    // Instrumentation: log the refractive index (Data3-6) carried alongside the
+    // concentration in pack 2/3. RI is the device's ground-truth optical reading and
+    // the cross-check for whether the concentration field is coffee TDS or raw Brix.
+    void logRefractiveIndex(const QByteArray& packet, quint8 dataLen);
     bool validateChecksum(const QByteArray& packet) const;
     void sendCommand(const QByteArray& cmd);
 
@@ -72,6 +76,7 @@ private:
 
     ScaleBleTransport* m_transport = nullptr;
     QString m_name = "DiFluid R2";
+    QString m_deviceModel;  // From Get-Device-Model query; "DFT-R102" == genuine R2 Extract
     bool m_connected = false;
     bool m_serviceFound = false;
     bool m_characteristicsReady = false;

--- a/tests/tst_difluidr2.cpp
+++ b/tests/tst_difluidr2.cpp
@@ -57,6 +57,27 @@ private:
         return buildR2Packet(0x03, 0x00, data);
     }
 
+    // Build a full TDS packet incl. refractive index: PackNo=2,
+    // Data1-2 = tds*100, Data3-6 = ri*100000 (big-endian)
+    static QByteArray buildTdsPacketWithRi(double tds, double ri) {
+        uint16_t tdsRaw = static_cast<uint16_t>(qRound(tds * 100.0));
+        uint32_t riRaw = static_cast<uint32_t>(qRound(ri * 100000.0));
+        QByteArray data;
+        data.append(static_cast<char>(0x02));  // PackNo = 2 (TDS result)
+        data.append(static_cast<char>((tdsRaw >> 8) & 0xFF));
+        data.append(static_cast<char>(tdsRaw & 0xFF));
+        data.append(static_cast<char>((riRaw >> 24) & 0xFF));
+        data.append(static_cast<char>((riRaw >> 16) & 0xFF));
+        data.append(static_cast<char>((riRaw >> 8) & 0xFF));
+        data.append(static_cast<char>(riRaw & 0xFF));
+        return buildR2Packet(0x03, 0x00, data);
+    }
+
+    // Build a device-model response: Func=0, Cmd=1, Data = ASCII model string
+    static QByteArray buildDeviceModelPacket(const QByteArray& model) {
+        return buildR2Packet(0x00, 0x01, model);
+    }
+
     // Build a temperature packet: Func=3, Cmd=0, PackNo=1
     // Prism temp = tempC * 10, tank temp = tempC * 10
     static QByteArray buildTemperaturePacket(double tempC) {
@@ -205,6 +226,40 @@ private slots:
         QCOMPARE(tdsSpy.at(0).at(0).toDouble(), 9.25);
         QCOMPARE(r2.tds(), 9.25);
         QCOMPARE(completeSpy.count(), 1);
+    }
+
+    // === Instrumentation: refractive index + device model (Brix-vs-TDS diagnosis) ===
+
+    // A full pack-2 with the refractive-index sub-field still parses TDS correctly,
+    // and the RI is logged for cross-checking whether concentration is TDS or Brix.
+    void parseTdsPacketWithRefractiveIndex() {
+        DiFluidR2 r2(nullptr);
+        QSignalSpy tdsSpy(&r2, &DiFluidR2::tdsChanged);
+
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression("Refractive index: 1\\.35520 \\(raw=135520\\)"));
+        r2.handlePacket(buildTdsPacketWithRi(8.50, 1.35520));
+
+        QCOMPARE(tdsSpy.count(), 1);
+        QCOMPARE(tdsSpy.at(0).at(0).toDouble(), 8.50);
+        QCOMPARE(r2.tds(), 8.50);
+    }
+
+    // Genuine R2 Extract reports model "DFT-R102" — logged as TDS-bearing.
+    void parseDeviceModelGenuineExtract() {
+        DiFluidR2 r2(nullptr);
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression("Device model: \"DFT-R102\".*genuine R2 Extract"));
+        r2.handlePacket(buildDeviceModelPacket("DFT-R102"));
+    }
+
+    // Any other model (Brix variant / rebrand / clone) is flagged so a Brix-as-TDS
+    // reading is diagnosable from the log.
+    void parseDeviceModelNonExtractFlagged() {
+        DiFluidR2 r2(nullptr);
+        QTest::ignoreMessage(QtDebugMsg,
+            QRegularExpression("Device model: \"ATOM-R2X\".*NOT a standard R2 Extract"));
+        r2.handlePacket(buildDeviceModelPacket("ATOM-R2X"));
     }
 
     // === Out-of-range sentinel rejection (regression) ===


### PR DESCRIPTION
## Why

A user's R2-class refractometer reported **TDS 14.76%** to Decenza while its own screen showed **12.48%** — ratio 0.846, exactly the coffee **Brix→TDS** factor. Decenza was recording the device's raw **Brix** as TDS, which also inflated the EY shown in Visualizer.

Per DiFluid's official [protocolR2.md](https://github.com/DiFluid/difluid-sdk-demo/blob/master/docs/protocolR2.md), a **genuine R2 Extract** (model `DFT-R102`) transmits coffee **TDS** in the pack-2 concentration field. But the R2 family also includes **Brix-only variants** (R2 PU/PP) and **rebrands/clones** that share the *same* `0xDF` protocol and BLE UUIDs and transmit raw **Brix** in that same field — which Decenza then mislabels as TDS. Cross-checked against the DiFluid SDK and the [Sabotage1/r2-connector](https://github.com/Sabotage1/r2-connector) bridge: neither applies a coefficient either, so **genuine Extracts are correct** and only non-conformant units are affected — this is not a systemic all-R2 bug.

## What this does

Adds the instrumentation needed to tell a genuine Extract from a Brix-sending unit **from a single log capture**, before committing to a fix:

- **Device-model query on connect** — `Get Device Model` (Func 0/Cmd 1) + `Get Firmware` (Cmd 2). Decodes and logs the model string, flagging anything that isn't `DFT-R102` as a possible Brix unit.
- **Refractive-index parsing** — the `Data3-6` RI field we previously discarded is now parsed and logged. RI is the device's ground-truth optical reading, so it's the cross-check for whether the concentration field is TDS or Brix.
- **Raw packet hex dump** — every Func-3 result packet's full bytes are logged.

**No behavior change to TDS values** — this is purely diagnostic. Once we have a reading + model string from the reporter, we'll decide the fix (model-based handling, a Brix coefficient, or surfacing a "not a TDS refractometer" warning).

## Testing

- Builds clean (0 errors, 0 warnings).
- 3 new unit tests (RI parsing, genuine-Extract detection, non-Extract flagging); full suite **32/32 pass**.
- Not hardware-verified — the model query and RI offsets come straight from the official protocol spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)