### PR TITLE
Serialize per-storage background writes + fix DB-open-failure silent state loss

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2859,6 +2859,13 @@ void MainController::dispatchNextPendingVisualizerSync()
     // object dies first (Qt auto-disconnects on `this`, then the lambda
     // copy in Qt's connection store gets cleaned up). Pre-shared_ptr
     // this used a raw `new` that leaked on context destruction.
+    // Note: requestShot does NOT emit shotReady on a DB-open FAILURE (only on a
+    // genuine load — found or not-found). That is deliberate: the !isValid()
+    // branch below permanently drops the pending entry, so a transient open
+    // failure must not reach it. On such a failure this connection simply never
+    // fires; the queue stalls and resumes next boot. Do not "fix" that stall by
+    // making requestShot emit an empty projection on open failure — it would
+    // silently discard the sync. (See ShotHistoryStorage::requestShot.)
     QPointer<MainController> self(this);
     auto conn = std::make_shared<QMetaObject::Connection>();
     *conn = connect(m_shotHistory, &ShotHistoryStorage::shotReady, this,

--- a/src/core/dbutils.h
+++ b/src/core/dbutils.h
@@ -79,25 +79,33 @@ public:
     // Identifies which storage's worker this is in a thread dump.
     QString name() const { return m_name; }
 
-    // Post `work(db)` to the worker thread (FIFO), then deliver `done()` back on
-    // `receiver`'s thread via a queued call. `destroyed` guards delivery if the
-    // owner is torn down while a task is in flight.
+    // Post `work(db)` to the worker thread (FIFO), then deliver `done(dbOpened)`
+    // back on `receiver`'s thread via a queued call. `dbOpened` is false when the
+    // connection could not be opened — in which case `work` never ran and any
+    // captured result is empty/default. Read callers MUST gate their "Ready"
+    // emission on `dbOpened`: delivering an empty result on an open *failure* is
+    // indistinguishable from a genuine not-found, and a consumer that treats
+    // empty as "row vanished" (e.g. SettingsDye clearing the active bag) would
+    // wipe valid state on a transient DB hiccup. Write callers can ignore it —
+    // their work already tracks success and reports a terminal status either way.
+    // `destroyed` guards delivery if the owner is torn down while in flight.
     void run(const QString& dbPath, const QString& connPrefix,
              std::function<void(QSqlDatabase&)> work,
-             std::function<void()> done,
+             std::function<void(bool dbOpened)> done,
              QObject* receiver,
              std::shared_ptr<std::atomic<bool>> destroyed) {
         post([dbPath, connPrefix, work = std::move(work), done = std::move(done),
               receiver, destroyed]() mutable {
-            if (!withTempDb(dbPath, connPrefix, [&](QSqlDatabase& db) { work(db); }))
+            const bool dbOpened = withTempDb(dbPath, connPrefix, [&](QSqlDatabase& db) { work(db); });
+            if (!dbOpened)
                 qWarning() << "SerialDbWorker: failed to open DB for" << connPrefix;
             if (destroyed->load())
                 return;
             QMetaObject::invokeMethod(receiver,
-                [done = std::move(done), destroyed]() {
+                [done = std::move(done), dbOpened, destroyed]() {
                     if (destroyed->load())
                         return;
-                    done();
+                    done(dbOpened);
                 }, Qt::QueuedConnection);
         });
     }

--- a/src/core/dbutils.h
+++ b/src/core/dbutils.h
@@ -82,7 +82,9 @@ public:
     // Post `work(db)` to the worker thread (FIFO), then deliver `done(dbOpened)`
     // back on `receiver`'s thread via a queued call. `dbOpened` is false when the
     // connection could not be opened — in which case `work` never ran and any
-    // captured result is empty/default. Read callers MUST gate their "Ready"
+    // captured result is empty/default. Note `dbOpened == true` means only that
+    // the connection opened and `work` ran, NOT that `work` succeeded — a write
+    // caller still reports its own success/failure from inside `work`. Read callers MUST gate their "Ready"
     // emission on `dbOpened`: delivering an empty result on an open *failure* is
     // indistinguishable from a genuine not-found, and a consumer that treats
     // empty as "row vanished" (e.g. SettingsDye clearing the active bag) would

--- a/src/core/dbutils.h
+++ b/src/core/dbutils.h
@@ -62,6 +62,16 @@ public:
     SerialDbWorker(const SerialDbWorker&) = delete;
     SerialDbWorker& operator=(const SerialDbWorker&) = delete;
 
+    // Post an arbitrary task to the worker thread (FIFO). The task runs on the
+    // worker thread and is responsible for opening its own DB connection (via
+    // withTempDb) and marshaling any result back to its owner's thread itself
+    // (e.g. QMetaObject::invokeMethod(receiver, ..., Qt::QueuedConnection)). For
+    // callers whose work receives a ready db handle, prefer run() below.
+    void post(std::function<void()> task) {
+        ensureStarted();
+        QMetaObject::invokeMethod(m_context, std::move(task), Qt::QueuedConnection);
+    }
+
     // Post `work(db)` to the worker thread (FIFO), then deliver `done()` back on
     // `receiver`'s thread via a queued call. `destroyed` guards delivery if the
     // owner is torn down while a task is in flight.
@@ -70,21 +80,19 @@ public:
              std::function<void()> done,
              QObject* receiver,
              std::shared_ptr<std::atomic<bool>> destroyed) {
-        ensureStarted();
-        QMetaObject::invokeMethod(m_context,
-            [dbPath, connPrefix, work = std::move(work), done = std::move(done),
-             receiver, destroyed]() mutable {
-                if (!withTempDb(dbPath, connPrefix, [&](QSqlDatabase& db) { work(db); }))
-                    qWarning() << "SerialDbWorker: failed to open DB for" << connPrefix;
-                if (destroyed->load())
-                    return;
-                QMetaObject::invokeMethod(receiver,
-                    [done = std::move(done), destroyed]() {
-                        if (destroyed->load())
-                            return;
-                        done();
-                    }, Qt::QueuedConnection);
-            }, Qt::QueuedConnection);
+        post([dbPath, connPrefix, work = std::move(work), done = std::move(done),
+              receiver, destroyed]() mutable {
+            if (!withTempDb(dbPath, connPrefix, [&](QSqlDatabase& db) { work(db); }))
+                qWarning() << "SerialDbWorker: failed to open DB for" << connPrefix;
+            if (destroyed->load())
+                return;
+            QMetaObject::invokeMethod(receiver,
+                [done = std::move(done), destroyed]() {
+                    if (destroyed->load())
+                        return;
+                    done();
+                }, Qt::QueuedConnection);
+        });
     }
 
 private:

--- a/src/core/dbutils.h
+++ b/src/core/dbutils.h
@@ -4,8 +4,13 @@
 #include <QSqlQuery>
 #include <QSqlError>
 #include <QThread>
+#include <QObject>
 #include <QString>
 #include <QDebug>
+
+#include <atomic>
+#include <functional>
+#include <memory>
 
 // Opens a temporary QSQLITE connection, runs `work(db)`, then removes the connection.
 // Sets PRAGMA busy_timeout and foreign_keys. Returns true if the DB opened successfully.
@@ -30,3 +35,69 @@ static bool withTempDb(const QString& dbPath, const QString& connPrefix, Work&& 
     QSqlDatabase::removeDatabase(connName);
     return opened;
 }
+
+// Runs background DB work on a SINGLE long-lived worker thread, in submission
+// (FIFO) order. This is the ordering guarantee a fresh-thread-per-request scheme
+// does NOT give: there, two writes to the same row dispatched close together are
+// run by independent threads and the OS scheduler can execute the older one last,
+// silently clobbering the newer value (the equipment/bag dual-write reorder this
+// helper was introduced to fix). SQLite's write lock serializes commits, but not
+// in submission order — so the ordering has to be enforced before the lock.
+//
+// One worker per owning storage. The thread is created lazily on first use and
+// torn down in the destructor. `run()` must be called from the owner's thread.
+class SerialDbWorker {
+public:
+    SerialDbWorker() = default;
+    ~SerialDbWorker() {
+        if (!m_thread)
+            return;
+        m_thread->quit();
+        m_thread->wait();
+        // The thread's event loop has stopped, so nothing else touches m_context;
+        // deleting it from here (a different thread than it lived on) is safe.
+        delete m_context;
+        delete m_thread;
+    }
+    SerialDbWorker(const SerialDbWorker&) = delete;
+    SerialDbWorker& operator=(const SerialDbWorker&) = delete;
+
+    // Post `work(db)` to the worker thread (FIFO), then deliver `done()` back on
+    // `receiver`'s thread via a queued call. `destroyed` guards delivery if the
+    // owner is torn down while a task is in flight.
+    void run(const QString& dbPath, const QString& connPrefix,
+             std::function<void(QSqlDatabase&)> work,
+             std::function<void()> done,
+             QObject* receiver,
+             std::shared_ptr<std::atomic<bool>> destroyed) {
+        ensureStarted();
+        QMetaObject::invokeMethod(m_context,
+            [dbPath, connPrefix, work = std::move(work), done = std::move(done),
+             receiver, destroyed]() mutable {
+                if (!withTempDb(dbPath, connPrefix, [&](QSqlDatabase& db) { work(db); }))
+                    qWarning() << "SerialDbWorker: failed to open DB for" << connPrefix;
+                if (destroyed->load())
+                    return;
+                QMetaObject::invokeMethod(receiver,
+                    [done = std::move(done), destroyed]() {
+                        if (destroyed->load())
+                            return;
+                        done();
+                    }, Qt::QueuedConnection);
+            }, Qt::QueuedConnection);
+    }
+
+private:
+    void ensureStarted() {
+        if (m_thread)
+            return;
+        m_thread = new QThread;
+        m_thread->setObjectName(QStringLiteral("SerialDbWorker"));
+        m_context = new QObject;          // event-loop affinity = the worker thread
+        m_context->moveToThread(m_thread);
+        m_thread->start();
+    }
+
+    QThread* m_thread = nullptr;
+    QObject* m_context = nullptr;
+};

--- a/src/core/dbutils.h
+++ b/src/core/dbutils.h
@@ -45,10 +45,14 @@ static bool withTempDb(const QString& dbPath, const QString& connPrefix, Work&& 
 // in submission order — so the ordering has to be enforced before the lock.
 //
 // One worker per owning storage. The thread is created lazily on first use and
-// torn down in the destructor. `run()` must be called from the owner's thread.
+// torn down in the destructor. post()/run() (and thus the lazy first-use) must
+// always be called from the SAME thread — the owner's — because they mutate
+// m_thread/m_context without synchronization; a debug Q_ASSERT enforces this.
+// Results are delivered on `receiver`'s thread, which need not be that thread.
 class SerialDbWorker {
 public:
-    SerialDbWorker() = default;
+    explicit SerialDbWorker(const QString& name = QStringLiteral("SerialDbWorker"))
+        : m_name(name) {}
     ~SerialDbWorker() {
         if (!m_thread)
             return;
@@ -71,6 +75,9 @@ public:
         ensureStarted();
         QMetaObject::invokeMethod(m_context, std::move(task), Qt::QueuedConnection);
     }
+
+    // Identifies which storage's worker this is in a thread dump.
+    QString name() const { return m_name; }
 
     // Post `work(db)` to the worker thread (FIFO), then deliver `done()` back on
     // `receiver`'s thread via a queued call. `destroyed` guards delivery if the
@@ -97,15 +104,21 @@ public:
 
 private:
     void ensureStarted() {
+        // m_thread/m_context are touched here and in post() without a lock, so
+        // every call must come from the one owner thread (see class comment).
+        Q_ASSERT(!m_ownerThread || m_ownerThread == QThread::currentThread());
         if (m_thread)
             return;
+        m_ownerThread = QThread::currentThread();
         m_thread = new QThread;
-        m_thread->setObjectName(QStringLiteral("SerialDbWorker"));
+        m_thread->setObjectName(m_name);
         m_context = new QObject;          // event-loop affinity = the worker thread
         m_context->moveToThread(m_thread);
         m_thread->start();
     }
 
+    QString m_name;
+    QThread* m_ownerThread = nullptr;  // thread that first used this worker
     QThread* m_thread = nullptr;
     QObject* m_context = nullptr;
 };

--- a/src/history/coffeebagstorage.cpp
+++ b/src/history/coffeebagstorage.cpp
@@ -231,7 +231,7 @@ void CoffeeBagStorage::initialize(const QString& dbPath)
 
 void CoffeeBagStorage::runAsync(const QString& connPrefix,
                                 std::function<void(QSqlDatabase&)> work,
-                                std::function<void()> done)
+                                std::function<void(bool dbOpened)> done)
 {
     if (m_dbPath.isEmpty()) {
         qWarning() << "CoffeeBagStorage: not initialized, dropping" << connPrefix;
@@ -256,7 +256,9 @@ void CoffeeBagStorage::requestInventory()
                 bags->append(map);
             }
         },
-        [this, bags]() { emit inventoryReady(*bags); });
+        // Read: skip the emit on open failure so the UI keeps its current list
+        // instead of being told the inventory is empty.
+        [this, bags](bool dbOpened) { if (dbOpened) emit inventoryReady(*bags); });
 }
 
 void CoffeeBagStorage::requestBag(qint64 bagId)
@@ -268,7 +270,10 @@ void CoffeeBagStorage::requestBag(qint64 bagId)
             if (bag.isValid())
                 *result = bag.toVariantMap();
         },
-        [this, bagId, result]() { emit bagReady(bagId, *result); });
+        // Read: skip the emit on open failure. An empty result here would be read
+        // by SettingsDye as "active bag vanished" and clear the user's selection;
+        // only a genuine not-found (db opened, row absent) should do that.
+        [this, bagId, result](bool dbOpened) { if (dbOpened) emit bagReady(bagId, *result); });
 }
 
 void CoffeeBagStorage::requestCreateBag(const QVariantMap& bagMap)
@@ -283,7 +288,8 @@ void CoffeeBagStorage::requestCreateBag(const QVariantMap& bagMap)
             if (*newId > 0)
                 *created = loadBagStatic(db, *newId).toVariantMap();
         },
-        [this, newId, created]() {
+        // Write: emit regardless — *newId is -1 on failure, a terminal status.
+        [this, newId, created](bool) {
             emit bagCreated(*newId, *created);
             if (*newId > 0)
                 emit bagsChanged();
@@ -310,7 +316,9 @@ void CoffeeBagStorage::requestUpdateBag(qint64 bagId, const QVariantMap& fields,
             if (*success && propagateBeanBase)
                 propagateBeanBaseStatic(db, bagId);
         },
-        [this, bagId, fields, success]() {
+        // Write: emit regardless — *success is false on open failure, the
+        // terminal status callers (e.g. the MCP bag_update tool) wait on.
+        [this, bagId, fields, success](bool) {
             emit bagUpdated(bagId, *success);
             if (*success) {
                 emit bagsChanged();
@@ -337,7 +345,7 @@ void CoffeeBagStorage::requestTouchLastUsed(qint64 bagId)
             if (!query.exec())
                 qWarning() << "CoffeeBagStorage: touch last_used failed:" << query.lastError().text();
         },
-        []() {});
+        [](bool) {});
 }
 
 void CoffeeBagStorage::requestDeleteBag(qint64 bagId)
@@ -365,7 +373,8 @@ void CoffeeBagStorage::requestDeleteBag(qint64 bagId)
             if (!*success)
                 qWarning() << "CoffeeBagStorage: delete failed:" << deleteQuery.lastError().text();
         },
-        [this, bagId, success]() {
+        // Write: emit regardless — *success is false on open failure, terminal.
+        [this, bagId, success](bool) {
             emit bagDeleted(bagId, *success);
             if (*success)
                 emit bagsChanged();

--- a/src/history/coffeebagstorage.cpp
+++ b/src/history/coffeebagstorage.cpp
@@ -216,9 +216,11 @@ CoffeeBagStorage::CoffeeBagStorage(QObject* parent)
 CoffeeBagStorage::~CoffeeBagStorage()
 {
     *m_destroyed = true;
-    // Stop the worker before members vanish: its destructor quit/wait()s the
-    // thread, so any in-flight task finishes (or is skipped via m_destroyed)
-    // while `this` is still alive.
+    // Stop the worker before members vanish. reset() runs ~SerialDbWorker, which
+    // quit()s (discarding queued-but-unstarted tasks) and wait()s for the single
+    // in-flight task to finish its DB work — all while `this` is still alive. The
+    // m_destroyed flag, set just above, suppresses that task's result callback so
+    // it can't touch a half-destroyed object.
     m_dbWorker.reset();
 }
 
@@ -236,7 +238,7 @@ void CoffeeBagStorage::runAsync(const QString& connPrefix,
         return;
     }
     if (!m_dbWorker)
-        m_dbWorker = std::make_unique<SerialDbWorker>();
+        m_dbWorker = std::make_unique<SerialDbWorker>(QStringLiteral("CoffeeBagStorageWorker"));
     m_dbWorker->run(m_dbPath, connPrefix, std::move(work), std::move(done), this, m_destroyed);
 }
 

--- a/src/history/coffeebagstorage.cpp
+++ b/src/history/coffeebagstorage.cpp
@@ -216,6 +216,10 @@ CoffeeBagStorage::CoffeeBagStorage(QObject* parent)
 CoffeeBagStorage::~CoffeeBagStorage()
 {
     *m_destroyed = true;
+    // Stop the worker before members vanish: its destructor quit/wait()s the
+    // thread, so any in-flight task finishes (or is skipped via m_destroyed)
+    // while `this` is still alive.
+    m_dbWorker.reset();
 }
 
 void CoffeeBagStorage::initialize(const QString& dbPath)
@@ -231,20 +235,9 @@ void CoffeeBagStorage::runAsync(const QString& connPrefix,
         qWarning() << "CoffeeBagStorage: not initialized, dropping" << connPrefix;
         return;
     }
-    const QString dbPath = m_dbPath;
-    auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, connPrefix, work = std::move(work),
-                                       done = std::move(done), destroyed]() {
-        if (!withTempDb(dbPath, connPrefix, [&](QSqlDatabase& db) { work(db); }))
-            qWarning() << "CoffeeBagStorage: failed to open DB for" << connPrefix;
-        if (*destroyed) return;
-        QMetaObject::invokeMethod(this, [done = std::move(done), destroyed]() {
-            if (*destroyed) return;
-            done();
-        }, Qt::QueuedConnection);
-    });
-    QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
+    if (!m_dbWorker)
+        m_dbWorker = std::make_unique<SerialDbWorker>();
+    m_dbWorker->run(m_dbPath, connPrefix, std::move(work), std::move(done), this, m_destroyed);
 }
 
 void CoffeeBagStorage::requestInventory()

--- a/src/history/coffeebagstorage.h
+++ b/src/history/coffeebagstorage.h
@@ -13,6 +13,7 @@
 class QSqlDatabase;
 class QJsonArray;
 class QJsonObject;
+class SerialDbWorker;
 
 // A coffee bag: the single bean concept that replaced bean presets
 // (openspec change bean-bag-inventory). A bag IS the active bean state —
@@ -230,4 +231,7 @@ private:
 
     QString m_dbPath;
     std::shared_ptr<std::atomic<bool>> m_destroyed = std::make_shared<std::atomic<bool>>(false);
+    // Serializes all background DB work onto one FIFO worker thread so successive
+    // writes to the same row apply in submission order (see SerialDbWorker).
+    std::unique_ptr<SerialDbWorker> m_dbWorker;
 };

--- a/src/history/coffeebagstorage.h
+++ b/src/history/coffeebagstorage.h
@@ -222,10 +222,12 @@ signals:
     void bagsChanged();
 
 private:
-    // Run `work(db)` on a background thread, then `done` on the main thread.
+    // Run `work(db)` on a background thread, then `done(dbOpened)` on the main
+    // thread. Read callers must skip their "Ready" emission when dbOpened is
+    // false (open failure → empty result that must not be read as not-found).
     void runAsync(const QString& connPrefix,
                   std::function<void(QSqlDatabase&)> work,
-                  std::function<void()> done);
+                  std::function<void(bool dbOpened)> done);
 
     static CoffeeBag bagFromQueryRow(const class QSqlQuery& query);
 

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -240,6 +240,10 @@ EquipmentStorage::EquipmentStorage(QObject* parent)
 EquipmentStorage::~EquipmentStorage()
 {
     *m_destroyed = true;
+    // Stop the worker before members vanish: its destructor quit/wait()s the
+    // thread, so any in-flight task finishes (or is skipped via m_destroyed)
+    // while `this` is still alive.
+    m_dbWorker.reset();
 }
 
 void EquipmentStorage::initialize(const QString& dbPath)
@@ -255,20 +259,9 @@ void EquipmentStorage::runAsync(const QString& connPrefix,
         qWarning() << "EquipmentStorage: not initialized, dropping" << connPrefix;
         return;
     }
-    const QString dbPath = m_dbPath;
-    auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, connPrefix, work = std::move(work),
-                                       done = std::move(done), destroyed]() {
-        if (!withTempDb(dbPath, connPrefix, [&](QSqlDatabase& db) { work(db); }))
-            qWarning() << "EquipmentStorage: failed to open DB for" << connPrefix;
-        if (*destroyed) return;
-        QMetaObject::invokeMethod(this, [done = std::move(done), destroyed]() {
-            if (*destroyed) return;
-            done();
-        }, Qt::QueuedConnection);
-    });
-    QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
+    if (!m_dbWorker)
+        m_dbWorker = std::make_unique<SerialDbWorker>();
+    m_dbWorker->run(m_dbPath, connPrefix, std::move(work), std::move(done), this, m_destroyed);
 }
 
 void EquipmentStorage::requestInventory()

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -255,7 +255,7 @@ void EquipmentStorage::initialize(const QString& dbPath)
 
 void EquipmentStorage::runAsync(const QString& connPrefix,
                                 std::function<void(QSqlDatabase&)> work,
-                                std::function<void()> done)
+                                std::function<void(bool dbOpened)> done)
 {
     if (m_dbPath.isEmpty()) {
         qWarning() << "EquipmentStorage: not initialized, dropping" << connPrefix;
@@ -275,7 +275,9 @@ void EquipmentStorage::requestInventory()
             for (const EquipmentPackageView& entry : inventory)
                 packages->append(entry.toVariantMap());
         },
-        [this, packages]() { emit inventoryReady(*packages); });
+        // Read: skip the emit on open failure so the UI keeps its current list
+        // instead of being told the inventory is empty.
+        [this, packages](bool dbOpened) { if (dbOpened) emit inventoryReady(*packages); });
 }
 
 void EquipmentStorage::requestPackage(qint64 packageId)
@@ -293,7 +295,10 @@ void EquipmentStorage::requestPackage(qint64 packageId)
                 *result = view.toVariantMap();
             }
         },
-        [this, packageId, result]() { emit packageReady(packageId, *result); });
+        // Read: skip the emit on open failure. An empty result here would be read
+        // by SettingsDye as "package gone" and clear the grinder identity; only a
+        // genuine not-found (db opened, row absent) should do that.
+        [this, packageId, result](bool dbOpened) { if (dbOpened) emit packageReady(packageId, *result); });
 }
 
 void EquipmentStorage::requestCreatePackage(const QVariantMap& packageMap)
@@ -329,7 +334,8 @@ void EquipmentStorage::requestCreatePackage(const QVariantMap& packageMap)
                 *created = view.toVariantMap();
             }
         },
-        [this, newId, created]() {
+        // Write: emit regardless — *newId is -1 on failure, a terminal status.
+        [this, newId, created](bool) {
             emit packageCreated(*newId, *created);
             if (*newId > 0)
                 emit packagesChanged();
@@ -389,7 +395,9 @@ void EquipmentStorage::requestUpdatePackage(qint64 packageId, const QVariantMap&
                 any = updatePackageFieldsStatic(db, *resultId, pkgFields) || any;
             *success = any;
         },
-        [this, resultId, success]() {
+        // Write: emit regardless — *success is false on open failure, the
+        // terminal status callers wait on.
+        [this, resultId, success](bool) {
             emit packageUpdated(*resultId, *success);
             if (*success)
                 emit packagesChanged();
@@ -413,7 +421,7 @@ void EquipmentStorage::requestTouchLastUsed(qint64 packageId)
             if (!query.exec())
                 qWarning() << "EquipmentStorage: touch last_used failed:" << query.lastError().text();
         },
-        []() {});
+        [](bool) {});
 }
 
 void EquipmentStorage::requestDeletePackage(qint64 packageId)
@@ -456,7 +464,8 @@ void EquipmentStorage::requestDeletePackage(qint64 packageId)
                 qWarning() << "EquipmentStorage: delete failed:" << delPkg.lastError().text();
             }
         },
-        [this, packageId, success]() {
+        // Write: emit regardless — *success is false on open failure, terminal.
+        [this, packageId, success](bool) {
             emit packageDeleted(packageId, *success);
             if (*success)
                 emit packagesChanged();

--- a/src/history/equipmentstorage.cpp
+++ b/src/history/equipmentstorage.cpp
@@ -240,9 +240,11 @@ EquipmentStorage::EquipmentStorage(QObject* parent)
 EquipmentStorage::~EquipmentStorage()
 {
     *m_destroyed = true;
-    // Stop the worker before members vanish: its destructor quit/wait()s the
-    // thread, so any in-flight task finishes (or is skipped via m_destroyed)
-    // while `this` is still alive.
+    // Stop the worker before members vanish. reset() runs ~SerialDbWorker, which
+    // quit()s (discarding queued-but-unstarted tasks) and wait()s for the single
+    // in-flight task to finish its DB work — all while `this` is still alive. The
+    // m_destroyed flag, set just above, suppresses that task's result callback so
+    // it can't touch a half-destroyed object.
     m_dbWorker.reset();
 }
 
@@ -260,7 +262,7 @@ void EquipmentStorage::runAsync(const QString& connPrefix,
         return;
     }
     if (!m_dbWorker)
-        m_dbWorker = std::make_unique<SerialDbWorker>();
+        m_dbWorker = std::make_unique<SerialDbWorker>(QStringLiteral("EquipmentStorageWorker"));
     m_dbWorker->run(m_dbPath, connPrefix, std::move(work), std::move(done), this, m_destroyed);
 }
 

--- a/src/history/equipmentstorage.h
+++ b/src/history/equipmentstorage.h
@@ -12,6 +12,7 @@
 
 class QSqlDatabase;
 class QSqlQuery;
+class SerialDbWorker;
 
 // An equipment item: one typed component of a package. The kinds today are
 // "grinder", the optional "basket" (add-basket-equipment), and the optional
@@ -259,4 +260,7 @@ private:
 
     QString m_dbPath;
     std::shared_ptr<std::atomic<bool>> m_destroyed = std::make_shared<std::atomic<bool>>(false);
+    // Serializes all background DB work onto one FIFO worker thread so successive
+    // writes to the same row apply in submission order (see SerialDbWorker).
+    std::unique_ptr<SerialDbWorker> m_dbWorker;
 };

--- a/src/history/equipmentstorage.h
+++ b/src/history/equipmentstorage.h
@@ -254,9 +254,12 @@ signals:
     void packagesChanged();
 
 private:
+    // Run `work(db)` on a background thread, then `done(dbOpened)` on the main
+    // thread. Read callers must skip their "Ready" emission when dbOpened is
+    // false (open failure → empty result that must not be read as not-found).
     void runAsync(const QString& connPrefix,
                   std::function<void(QSqlDatabase&)> work,
-                  std::function<void()> done);
+                  std::function<void(bool dbOpened)> done);
 
     QString m_dbPath;
     std::shared_ptr<std::atomic<bool>> m_destroyed = std::make_shared<std::atomic<bool>>(false);

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -55,9 +55,11 @@ ShotHistoryStorage::ShotHistoryStorage(QObject* parent)
 ShotHistoryStorage::~ShotHistoryStorage()
 {
     *m_destroyed = true;
-    // Stop the CRUD worker before members vanish: its destructor quit/wait()s the
-    // thread, so any in-flight task finishes (or is skipped via m_destroyed) while
-    // `this` is still alive.
+    // Stop the CRUD worker before members vanish. reset() runs ~SerialDbWorker,
+    // which quit()s (discarding queued-but-unstarted tasks) and wait()s for the
+    // single in-flight task to finish its DB work — all while `this` is still
+    // alive. The m_destroyed flag, set just above, suppresses that task's result
+    // callback so it can't touch a half-destroyed object.
     m_dbWorker.reset();
     close();
 }
@@ -65,7 +67,7 @@ ShotHistoryStorage::~ShotHistoryStorage()
 void ShotHistoryStorage::runOnDbThread(std::function<void()> task)
 {
     if (!m_dbWorker)
-        m_dbWorker = std::make_unique<SerialDbWorker>();
+        m_dbWorker = std::make_unique<SerialDbWorker>(QStringLiteral("ShotHistoryStorageWorker"));
     m_dbWorker->post(std::move(task));
 }
 

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -55,7 +55,18 @@ ShotHistoryStorage::ShotHistoryStorage(QObject* parent)
 ShotHistoryStorage::~ShotHistoryStorage()
 {
     *m_destroyed = true;
+    // Stop the CRUD worker before members vanish: its destructor quit/wait()s the
+    // thread, so any in-flight task finishes (or is skipped via m_destroyed) while
+    // `this` is still alive.
+    m_dbWorker.reset();
     close();
+}
+
+void ShotHistoryStorage::runOnDbThread(std::function<void()> task)
+{
+    if (!m_dbWorker)
+        m_dbWorker = std::make_unique<SerialDbWorker>();
+    m_dbWorker->post(std::move(task));
 }
 
 void ShotHistoryStorage::close()
@@ -1568,7 +1579,7 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
     // Run DB work on background thread
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, data = std::move(data), destroyed]() {
+    runOnDbThread([this, dbPath, data = std::move(data), destroyed]() {
         qint64 shotId = saveShotStatic(dbPath, data);
 
         // Capture only the fields needed for logging (avoid copying the large compressedSamples blob)
@@ -1601,9 +1612,6 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
             emit shotSaved(shotId);
         }, Qt::QueuedConnection);
     });
-
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 
     return 0;  // Async — actual shotId delivered via shotSaved signal
 }
@@ -1812,7 +1820,7 @@ void ShotHistoryStorage::requestUpdateVisualizerInfo(qint64 shotId, const QStrin
 
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, shotId, visualizerId, visualizerUrl, destroyed]() {
+    runOnDbThread([this, dbPath, shotId, visualizerId, visualizerUrl, destroyed]() {
         bool success = false;
         bool opened = withTempDb(dbPath, "shs_vizupd", [&](QSqlDatabase& db) {
             QSqlQuery query(db);
@@ -1841,8 +1849,6 @@ void ShotHistoryStorage::requestUpdateVisualizerInfo(qint64 shotId, const QStrin
             emit visualizerInfoUpdated(shotId, success);
         }, Qt::QueuedConnection);
     });
-    thread->start();
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 }
 
 bool ShotHistoryStorage::reconcileVisualizerLinksStatic(
@@ -1941,7 +1947,7 @@ void ShotHistoryStorage::requestReconcileVisualizerLinks(const QVariantList& clo
 
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, cloudShots, windowStartEpoch, destroyed]() {
+    runOnDbThread([this, dbPath, cloudShots, windowStartEpoch, destroyed]() {
         QVariantList linked;
         bool staticOk = false;
         const bool opened = withTempDb(dbPath, "shs_vizrecon", [&](QSqlDatabase& db) {
@@ -1961,8 +1967,6 @@ void ShotHistoryStorage::requestReconcileVisualizerLinks(const QVariantList& clo
             emit visualizerLinksReconciled(ok, linked);
         }, Qt::QueuedConnection);
     });
-    thread->start();
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 }
 
 void ShotHistoryStorage::requestMostRecentShotId()
@@ -1974,7 +1978,7 @@ void ShotHistoryStorage::requestMostRecentShotId()
 
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, destroyed]() {
+    runOnDbThread([this, dbPath, destroyed]() {
         qint64 shotId = -1;
         bool opened = withTempDb(dbPath, "shs_recent", [&](QSqlDatabase& db) {
             QSqlQuery query(db);
@@ -1990,8 +1994,6 @@ void ShotHistoryStorage::requestMostRecentShotId()
             emit mostRecentShotIdReady(shotId);
         }, Qt::QueuedConnection);
     });
-    thread->start();
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 }
 
 void ShotHistoryStorage::requestShot(qint64 shotId)
@@ -2004,7 +2006,7 @@ void ShotHistoryStorage::requestShot(qint64 shotId)
     const QString dbPath = m_dbPath;
 
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, shotId, destroyed]() {
+    runOnDbThread([this, dbPath, shotId, destroyed]() {
         ShotRecord record;
         bool badgesPersisted = false;
         withTempDb(dbPath, "shs_shot", [&](QSqlDatabase& db) {
@@ -2033,9 +2035,6 @@ void ShotHistoryStorage::requestShot(qint64 shotId)
             }
         }, Qt::QueuedConnection);
     });
-
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
@@ -2050,7 +2049,7 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
     // outBadgesPersisted to drive that signal.
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, shotId, destroyed]() {
+    runOnDbThread([this, dbPath, shotId, destroyed]() {
         bool recordFound = false;
         bool badgesPersisted = false;
         bool newChanneling = false;
@@ -2075,9 +2074,6 @@ void ShotHistoryStorage::requestReanalyzeBadges(qint64 shotId)
             },
             Qt::QueuedConnection);
     });
-
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 void ShotHistoryStorage::computeDerivedCurves(ShotRecord& record)
@@ -2461,7 +2457,7 @@ void ShotHistoryStorage::deleteShots(const QVariantList& shotIds)
     QString sql = "DELETE FROM shots WHERE id IN (" + placeholders.join(",") + ")";
 
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, sql, shotIds, destroyed]() {
+    runOnDbThread([this, dbPath, sql, shotIds, destroyed]() {
         bool success = false;
         withTempDb(dbPath, "shs_delete", [&](QSqlDatabase& db) {
             db.transaction();
@@ -2495,9 +2491,6 @@ void ShotHistoryStorage::deleteShots(const QVariantList& shotIds)
             }
         }, Qt::QueuedConnection);
     });
-
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 void ShotHistoryStorage::requestDeleteShot(qint64 shotId)
@@ -2511,7 +2504,7 @@ void ShotHistoryStorage::requestDeleteShot(qint64 shotId)
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
 
-    QThread* thread = QThread::create([this, dbPath, shotId, destroyed]() {
+    runOnDbThread([this, dbPath, shotId, destroyed]() {
         bool success = false;
         withTempDb(dbPath, "shs_rdel", [&](QSqlDatabase& db) {
             QSqlQuery query(db);
@@ -2541,9 +2534,6 @@ void ShotHistoryStorage::requestDeleteShot(qint64 shotId)
             }
         }, Qt::QueuedConnection);
     });
-
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 bool ShotHistoryStorage::updateShotMetadataStatic(QSqlDatabase& db, qint64 shotId, const QVariantMap& metadata)
@@ -2637,7 +2627,7 @@ void ShotHistoryStorage::requestUpdateShotMetadata(qint64 shotId, const QVariant
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
 
-    QThread* thread = QThread::create([this, dbPath, shotId, metadata, destroyed]() {
+    runOnDbThread([this, dbPath, shotId, metadata, destroyed]() {
         bool success = false;
         withTempDb(dbPath, "shs_rupd", [&](QSqlDatabase& db) {
             success = updateShotMetadataStatic(db, shotId, metadata);
@@ -2658,9 +2648,6 @@ void ShotHistoryStorage::requestUpdateShotMetadata(qint64 shotId, const QVariant
             qDebug() << "ShotHistoryStorage: Async updated metadata for shot" << shotId << "success:" << success;
         }, Qt::QueuedConnection);
     });
-
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 // Note: getDistinctValues / requestDistinct* / requestAutoFavorites* /
@@ -2671,7 +2658,7 @@ void ShotHistoryStorage::updateTotalShots()
     // Async: run COUNT on background thread using existing static helper
     const QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, destroyed]() {
+    runOnDbThread([this, dbPath, destroyed]() {
         int count = getShotCountStatic(dbPath);
         if (*destroyed) return;
         QMetaObject::invokeMethod(this, [this, count, destroyed]() {
@@ -2686,8 +2673,6 @@ void ShotHistoryStorage::updateTotalShots()
             }
         }, Qt::QueuedConnection);
     });
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 
 bool ShotHistoryStorage::performDatabaseCopy(const QString& destPath)
@@ -3523,7 +3508,7 @@ void ShotHistoryStorage::refreshTotalShots()
     // Run COUNT query on background thread to avoid blocking the main thread
     QString dbPath = m_dbPath;
     auto destroyed = m_destroyed;
-    QThread* thread = QThread::create([this, dbPath, destroyed]() {
+    runOnDbThread([this, dbPath, destroyed]() {
         int count = getShotCountStatic(dbPath);
         if (*destroyed) return;
         QMetaObject::invokeMethod(this, [this, count, destroyed]() {
@@ -3541,7 +3526,5 @@ void ShotHistoryStorage::refreshTotalShots()
             }
         }, Qt::QueuedConnection);
     });
-    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
-    thread->start();
 }
 

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1990,7 +1990,9 @@ void ShotHistoryStorage::requestMostRecentShotId()
         if (!opened)
             qWarning() << "ShotHistoryStorage: requestMostRecentShotId failed - could not open DB";
 
-        if (*destroyed) return;
+        // Skip the emit on open failure: -1 here means "no shots" to a consumer,
+        // and a transient open failure must not masquerade as an empty history.
+        if (*destroyed || !opened) return;
         QMetaObject::invokeMethod(this, [this, shotId, destroyed]() {
             if (*destroyed) return;
             emit mostRecentShotIdReady(shotId);
@@ -2011,9 +2013,17 @@ void ShotHistoryStorage::requestShot(qint64 shotId)
     runOnDbThread([this, dbPath, shotId, destroyed]() {
         ShotRecord record;
         bool badgesPersisted = false;
-        withTempDb(dbPath, "shs_shot", [&](QSqlDatabase& db) {
+        const bool opened = withTempDb(dbPath, "shs_shot", [&](QSqlDatabase& db) {
             record = loadShotRecordStatic(db, shotId, &badgesPersisted);
         });
+        // On a DB-open failure `record` is default/invalid; do NOT deliver it as a
+        // shotReady. MainController's migration16 visualizer-sync reads an invalid
+        // projection as "shot no longer exists" and permanently pops a pending sync
+        // — a transient open failure must not trigger that drop. A genuine
+        // not-found (db opened, row absent) still emits, preserving that path.
+        if (!opened)
+            qWarning() << "ShotHistoryStorage: requestShot — DB open failed for shot"
+                       << shotId << "(no shotReady emitted)";
 
         // Convert to QVariantMap on main thread (touches QML-visible data).
         // shotReady carries the recomputed badges already; shotBadgesUpdated
@@ -2021,7 +2031,7 @@ void ShotHistoryStorage::requestShot(qint64 shotId)
         // listeners that care about "this shot just got its badges corrected"
         // (e.g., a future history-list filter that wants to refresh) get a
         // signal without having to re-query.
-        if (*destroyed) return;
+        if (*destroyed || !opened) return;
         QMetaObject::invokeMethod(this, [this, shotId, record = std::move(record), badgesPersisted, destroyed]() {
             if (*destroyed) {
                 qDebug() << "ShotHistoryStorage: requestShot callback dropped (object destroyed)";

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -10,9 +10,11 @@
 #include <QVariantList>
 #include <QDateTime>
 #include <atomic>
+#include <functional>
 #include <memory>
 
 class QThread;
+class SerialDbWorker;
 
 class ShotDataModel;
 class Profile;
@@ -278,6 +280,14 @@ signals:
     void shotBadgesUpdated(qint64 shotId, bool channelingDetected, bool grindIssueDetected, bool skipFirstFrameDetected, bool pourTruncatedDetected);
 
 private:
+    // Post shot-CRUD background work onto a single FIFO worker thread, so two
+    // writes to the same shot row dispatched close together apply in submission
+    // order (a fresh-thread-per-request scheme lets the OS scheduler reorder
+    // them — see SerialDbWorker). `task` opens its own withTempDb connection and
+    // marshals results back to the main thread itself. Heavy one-shot ops
+    // (backup/import) deliberately stay on their own threads.
+    void runOnDbThread(std::function<void()> task);
+
     bool createTables();
     bool runMigrations();
     // Version-independent merge-import of legacy bean/presets QSettings into
@@ -341,6 +351,11 @@ private:
     // Atomic because the flag is written on the main thread (destructor) and
     // read on background threads (before QMetaObject::invokeMethod).
     std::shared_ptr<std::atomic<bool>> m_destroyed = std::make_shared<std::atomic<bool>>(false);
+
+    // Serializes shot-CRUD background work onto one FIFO worker thread so
+    // successive writes to the same shot row apply in submission order
+    // (see runOnDbThread / SerialDbWorker).
+    std::unique_ptr<SerialDbWorker> m_dbWorker;
 
     static const QString DB_CONNECTION_NAME;
 

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -371,5 +371,11 @@ public:
     // stays unmet. Either way the schema_version is not bumped. 0 (default) =
     // no fault. Production builds never compile this member.
     static int s_faultInjectMigration;
+
+    // Lets the read-gating test put the storage in the one state initialize()
+    // can't reach on its own: m_ready=true with an m_dbPath whose parent dir is
+    // absent, so the worker's withTempDb open fails while the !m_ready guard is
+    // bypassed — exercising requestShot's open-failure gate directly.
+    friend class tst_CoffeeBags;
 #endif
 };

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -1063,14 +1063,17 @@ private slots:
 
     // Regression for the same-row write reorder that SerialDbWorker fixes. Fire
     // many writes at ONE package row back-to-back with NO settle between them and
-    // assert the LAST submitted value wins. Under the old fresh-thread-per-request
-    // dispatch the OS scheduler could run an earlier write last, clobbering the
-    // newer value (SQLite serializes commits, but not in submission order); the
-    // single FIFO worker makes submission order the commit order. The absence of
-    // any inter-dispatch wait is what makes this fail ~every run if the fix is
-    // reverted — a per-thread build lands the final value last only by ~1/N luck.
-    // (The existing dual-write test above has a settle loop that mostly closes the
-    // window, so it only caught the bug flakily — this one is deterministic.)
+    // assert the LAST submitted value is the one that SETTLES. Under the old
+    // fresh-thread-per-request dispatch the OS scheduler could run an earlier
+    // write last, clobbering the newer value (SQLite serializes commits, but not
+    // in submission order); the single FIFO worker makes submission order the
+    // commit order. We assert the settled value (drain, then re-read) rather than
+    // first-observation: QTRY passes the instant it sees "49", and a reverted
+    // per-thread build could expose "49" transiently mid-race before an earlier
+    // write commits last — only the post-drain re-read distinguishes "49 is final"
+    // (FIFO) from "49 was briefly seen" (reordered). (The existing dual-write test
+    // above has a settle loop that mostly closes the window, so it only caught the
+    // bug flakily — this one is deterministic.)
     void packageWritesApplyInSubmissionOrder() {
         const QString path = freshDb();
         withRawDb(path, "fifo_tables", [&](QSqlDatabase& db) {
@@ -1094,8 +1097,11 @@ private slots:
             [&](QSqlDatabase& db) { v = EquipmentStorage::loadPackageStatic(db, pkgId).lastGrindSetting; }); return v; };
         QTRY_COMPARE_WITH_TIMEOUT(pkgGrind(), QString::number(kWrites - 1), 15000);
 
-        // Drain so no background callback fires during teardown.
+        // Drain every write, then re-assert the SETTLED value is still the last
+        // submitted. This is the real revert-detector: a reordered build's final
+        // commit is the random last-scheduled write, almost never "49".
         for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(5); }
+        QCOMPARE(pkgGrind(), QString::number(kWrites - 1));
     }
 
     // A DB-open FAILURE must not be delivered to readers as an empty result.
@@ -1117,6 +1123,7 @@ private slots:
 
         // (b) Real DB, missing row -> the empty result IS delivered (real clear).
         const QString path = freshDb();
+        withRawDb(path, "nf_tables", [&](QSqlDatabase& db) { EquipmentStorage::ensureTablesStatic(db); });
         EquipmentStorage ok; ok.initialize(path);
         QSignalSpy okSpy(&ok, &EquipmentStorage::packageReady);
         ok.requestPackage(999999);

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -1098,6 +1098,34 @@ private slots:
         for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(5); }
     }
 
+    // A DB-open FAILURE must not be delivered to readers as an empty result.
+    // SettingsDye reads an empty packageReady/bagReady as "row vanished" and
+    // clears the active selection, so a transient open failure would silently
+    // wipe valid state — hence runAsync gates the read emit on dbOpened. A
+    // GENUINE not-found (db opens, row absent) must still emit empty, since that
+    // real clear is how a deleted selection gets cleared.
+    void readEmitSuppressedOnDbOpenFailure() {
+        // (a) Unopenable path (parent dir absent) -> requestPackage stays silent.
+        EquipmentStorage bad;
+        bad.initialize(m_tempDir.filePath(QStringLiteral("no_such_dir/eq.db")));
+        QSignalSpy badSpy(&bad, &EquipmentStorage::packageReady);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("withTempDb: DB open failed"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("SerialDbWorker: failed to open DB"));
+        bad.requestPackage(1);
+        for (int i = 0; i < 60; i++) { QCoreApplication::processEvents(); QThread::msleep(5); }
+        QCOMPARE(badSpy.count(), 0);
+
+        // (b) Real DB, missing row -> the empty result IS delivered (real clear).
+        const QString path = freshDb();
+        EquipmentStorage ok; ok.initialize(path);
+        QSignalSpy okSpy(&ok, &EquipmentStorage::packageReady);
+        ok.requestPackage(999999);
+        QTRY_COMPARE_WITH_TIMEOUT(okSpy.count(), 1, 15000);
+        QVERIFY(okSpy.at(0).at(1).toMap().isEmpty());
+
+        for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(5); }
+    }
+
     // VisualizerUploader::buildBagEnrichBody — the pure fill-blanks diff that
     // decides which descriptive fields get PATCHed onto the server's coffee bag.
     // Locks the blob->API field mapping (a typo here silently drops a field) and

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -1133,6 +1133,40 @@ private slots:
         for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(5); }
     }
 
+    // Same contract for ShotHistoryStorage::requestShot, which uses a DIFFERENT
+    // code path (post() + hand-rolled `if (!opened) return`, not run()'s gate) and
+    // guards the most destructive consumer: MainController's migration16 reads an
+    // invalid shotReady as "shot gone" and PERMANENTLY drops a pending Visualizer
+    // sync. requestShot's own !m_ready guard shares m_dbPath with the worker, so
+    // initialize() can't produce "ready but worker-open-fails" — we set that state
+    // directly via the DECENZA_TESTING friend seam.
+    void requestShotEmitSuppressedOnDbOpenFailure() {
+        // (a) m_ready=true + unopenable path (parent dir absent) -> no shotReady.
+        ShotHistoryStorage bad;
+        bad.m_ready = true;
+        bad.m_dbPath = m_tempDir.filePath(QStringLiteral("no_such_dir/shots.db"));
+        QSignalSpy badSpy(&bad, &ShotHistoryStorage::shotReady);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("withTempDb: DB open failed"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("requestShot.*DB open failed"));
+        bad.requestShot(1);
+        for (int i = 0; i < 60; i++) { QCoreApplication::processEvents(); QThread::msleep(5); }
+        QCOMPARE(badSpy.count(), 0);
+
+        // (b) m_ready + real schema DB (0 shots), missing row -> shotReady STILL
+        // fires (genuine not-found, db opened). Point m_dbPath at a freshDb()
+        // schema file rather than re-initialize() — that would re-open the shared
+        // ShotHistoryConnection freshDb() already used and warn "still in use".
+        ShotHistoryStorage ok;
+        ok.m_ready = true;
+        ok.m_dbPath = freshDb();
+        QSignalSpy okSpy(&ok, &ShotHistoryStorage::shotReady);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Shot not found: 999999"));
+        ok.requestShot(999999);
+        QTRY_COMPARE_WITH_TIMEOUT(okSpy.count(), 1, 15000);
+
+        for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(5); }
+    }
+
     // VisualizerUploader::buildBagEnrichBody — the pure fill-blanks diff that
     // decides which descriptive fields get PATCHed onto the server's coffee bag.
     // Locks the blob->API field mapping (a typo here silently drops a field) and

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -1061,6 +1061,43 @@ private slots:
         { QSettings s; s.remove(QStringLiteral("dye")); s.sync(); }
     }
 
+    // Regression for the same-row write reorder that SerialDbWorker fixes. Fire
+    // many writes at ONE package row back-to-back with NO settle between them and
+    // assert the LAST submitted value wins. Under the old fresh-thread-per-request
+    // dispatch the OS scheduler could run an earlier write last, clobbering the
+    // newer value (SQLite serializes commits, but not in submission order); the
+    // single FIFO worker makes submission order the commit order. The absence of
+    // any inter-dispatch wait is what makes this fail ~every run if the fix is
+    // reverted — a per-thread build lands the final value last only by ~1/N luck.
+    // (The existing dual-write test above has a settle loop that mostly closes the
+    // window, so it only caught the bug flakily — this one is deterministic.)
+    void packageWritesApplyInSubmissionOrder() {
+        const QString path = freshDb();
+        withRawDb(path, "fifo_tables", [&](QSqlDatabase& db) {
+            EquipmentStorage::ensureTablesStatic(db);
+        });
+        qint64 pkgId = -1;
+        withRawDb(path, "fifo_seed", [&](QSqlDatabase& db) {
+            EquipmentPackage p; p.lastGrindSetting = "seed";
+            pkgId = EquipmentStorage::createPackageWithGrinderStatic(db, p, "Turin", "DF83V", "83mm flat steel");
+        });
+        QVERIFY(pkgId > 0);
+
+        EquipmentStorage eqStorage; eqStorage.initialize(path);
+
+        const int kWrites = 50;
+        for (int i = 0; i < kWrites; i++)
+            eqStorage.requestUpdatePackage(pkgId,
+                {{QStringLiteral("lastGrindSetting"), QString::number(i)}});
+
+        auto pkgGrind = [&]() { QString v; withRawDb(path, "fifo_read",
+            [&](QSqlDatabase& db) { v = EquipmentStorage::loadPackageStatic(db, pkgId).lastGrindSetting; }); return v; };
+        QTRY_COMPARE_WITH_TIMEOUT(pkgGrind(), QString::number(kWrites - 1), 15000);
+
+        // Drain so no background callback fires during teardown.
+        for (int i = 0; i < 40; i++) { QCoreApplication::processEvents(); QThread::msleep(5); }
+    }
+
     // VisualizerUploader::buildBagEnrichBody — the pure fill-blanks diff that
     // decides which descriptive fields get PATCHed onto the server's coffee bag.
     // Locks the blob->API field mapping (a typo here silently drops a field) and


### PR DESCRIPTION
## Problem

The Linux CI build failed in **Run tests**: `tst_CoffeeBags::settingsDyeEquipmentSwitchAndDualWrite` asserted `pkgGrind()` was still `"3.0"` instead of the edited `"2.5"`, and burned the full 15s `QTRY` timeout (most of the test's ~59s runtime).

### Root cause (write reorder)

`CoffeeBagStorage`, `EquipmentStorage`, and `ShotHistoryStorage` each dispatched **every** async request on a fresh `QThread::create()` thread, with no queue. SQLite's write lock serializes *commits*, but the OS scheduler can run those independent threads in **any order** — so two writes to the same row dispatched close together can land out of order, an older value silently clobbering a newer one. Editing the grind dial writes the package's `lastGrindSetting` twice (`"3.0"` from `switchToEquipment`, then `"2.5"`); under load the stale `"3.0"` write committed last and stuck. Latent in production: two rapid dial edits could persist a stale value.

## Fix 1 — serialize each storage's background work (FIFO)

Add `SerialDbWorker` (`core/dbutils.h`): one long-lived **FIFO worker thread** per storage, so same-storage same-row writes apply in submission order. Created lazily, torn down in each destructor (`quit()` + `wait()`, with the existing `m_destroyed` guard suppressing the in-flight task's result callback). Two entry points:
- `run(dbPath, connPrefix, work, done, receiver, destroyed)` — for callers whose work receives a ready `db` handle (bag/equipment). `runAsync()` delegates to it.
- `post(task)` — for callers whose work opens its own `withTempDb` and marshals its own result (shot storage, via a new `runOnDbThread()` helper over its 11 CRUD sites).

A debug `Q_ASSERT` enforces the single-owner-thread precondition; each worker thread is named after its storage for legible thread dumps.

**Deliberately unchanged:** cross-storage contention stays handled by SQLite (`coffee_bags`/`equipment_packages`/`shots` share one DB file but have separate workers, so `saveShotStatic`'s `BEGIN IMMEDIATE` + retry loop is untouched). `ShotHistoryStorage::requestCreateBackup`/`requestImportDatabase` stay on their own threads — multi-second one-shot ops behind their own guards; serializing them ahead of quick writes would be a latency regression.

## Fix 2 — DB-open failure no longer destroys state (silent-failure review)

`run()`/the read paths called `done()` even when the DB failed to open, delivering an **empty** result that two consumers misread as a real not-found:
- `SettingsDye` reads an empty `bagReady`/`packageReady` as "row vanished" and **clears the active bag / grinder identity** (`settings_dye.cpp:61`).
- MainController's migration-16 sync reads an invalid `shotReady` as "shot gone" and **permanently pops a pending Visualizer-sync entry** (`maincontroller.cpp:2868`).

So a transient open failure silently destroyed state. Fix: `run()` now delivers `done(bool dbOpened)`; **read** paths skip their "Ready" emission when the DB didn't open, while a **genuine** not-found (db opened, row absent) still emits empty — preserving the real clear-on-delete path. **Write** paths are unchanged (their work already tracks success and reports a terminal status). Audited every read path in all three storages: bag/equipment inventory/get gated; `requestShot` + `requestMostRecentShotId` gated; `updateTotalShots`/`refreshTotalShots` and `requestReanalyzeBadges` were already correct (sentinel/`recordFound` guards).

### Not fixed (real reason, not "pre-existing")

A failed `QThread::start()` stalls all CRUD for a storage. It's OS thread-exhaustion only, **Qt already logs it**, and the only "recovery" is a synchronous fallback — a speculative defensive layer for a catastrophic, already-logged condition. Logging is the right altitude.

## Tests

- `requestShotEmitSuppressedOnDbOpenFailure` — locks the shot-path read gating (a distinct `post()` + hand-rolled code path from `run()`, guarding the most destructive consumer: migration16 dropping a pending sync). Uses the `DECENZA_TESTING` friend seam to put the storage in `m_ready=true` + worker-open-fails, the one state `initialize()` can't reach.
- `readEmitSuppressedOnDbOpenFailure` — locks the `run()` read gating: (a) unopenable path emits NO `packageReady`; (b) a real DB with a missing row still emits empty.
- `packageWritesApplyInSubmissionOrder` — **deterministic** reorder guard: 50 same-row writes back-to-back, no settle, asserts the last value wins. Fails ~every run if serialization is reverted (the existing dual-write test has a settle loop that only caught it flakily).
- `readEmitSuppressedOnDbOpenFailure` — (a) an unopenable path emits NO `packageReady`; (b) a real DB with a missing row still emits empty. Expected open-failure warnings are consumed so it stays warning-clean.

## Verification

Clean Debug build (0 errors, 0 warnings). **2459** tests pass, 0 with warnings. The previously-flaky dual-write test is now deterministic (~2s, no timeout spin). The debug `Q_ASSERT` ran live across the whole suite without firing — suite-wide confirmation every storage drives its worker single-threaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
