### PR TITLE
fix(profile): repair Visualizer-import espresso_temperature leak (93°C)

### DIFF
--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -1131,21 +1131,32 @@ void ProfileManager::loadProfile(const QString& profileName) {
         }
     }
 
-    // One-time on-disk repair: if fromJson had to clamp a bogus stored
-    // espresso_temperature back into the frame range (e.g. a stale 93 baked in by an
-    // older Visualizer import — see Profile::fromJson), persist the corrected value so
-    // the profile is repaired exactly once instead of re-healed on every load. Skip
-    // read-only/built-in profiles (qrc, can't and needn't be rewritten).
+    // One-time on-disk repair: if fromJson had to re-derive a missing or
+    // stale-default espresso_temperature from the frames (e.g. the 93.0 default
+    // baked in by an older Visualizer import — see Profile::fromJson), persist the
+    // corrected value so the profile is repaired exactly once instead of re-healed
+    // on every load. Skip read-only/built-in profiles (qrc, can't and needn't be
+    // rewritten).
     if (found && m_currentProfile.espressoTemperatureHealed() && !m_currentProfile.isReadOnly()) {
+        bool writable = false;
         bool repaired = false;
         if (m_profileStorage && m_profileStorage->isConfigured()
             && m_profileStorage->profileExists(resolvedName)) {
+            writable = true;
             repaired = m_profileStorage->writeProfile(resolvedName, m_currentProfile.toJsonString());
         } else if (!path.isEmpty() && !path.startsWith(QLatin1Char(':'))) {
+            writable = true;
             repaired = m_currentProfile.saveToFile(path);
         }
-        if (repaired)
+        if (repaired) {
             qInfo() << "ProfileManager::loadProfile: repaired stale espresso_temperature on disk for" << resolvedName;
+        } else if (writable) {
+            // Write failed: the in-memory value is corrected, but the heal will run
+            // again on the next load. Surface it so a persistent failure (read-only
+            // FS, permissions, full disk) isn't invisible.
+            qWarning() << "ProfileManager::loadProfile: failed to persist espresso_temperature repair for"
+                       << resolvedName << "- corrected in memory only, will retry on next load";
+        }
     }
 
     // Save current profile as previous before switching (only if new profile was found)

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -1131,6 +1131,23 @@ void ProfileManager::loadProfile(const QString& profileName) {
         }
     }
 
+    // One-time on-disk repair: if fromJson had to clamp a bogus stored
+    // espresso_temperature back into the frame range (e.g. a stale 93 baked in by an
+    // older Visualizer import — see Profile::fromJson), persist the corrected value so
+    // the profile is repaired exactly once instead of re-healed on every load. Skip
+    // read-only/built-in profiles (qrc, can't and needn't be rewritten).
+    if (found && m_currentProfile.espressoTemperatureHealed() && !m_currentProfile.isReadOnly()) {
+        bool repaired = false;
+        if (m_profileStorage && m_profileStorage->isConfigured()
+            && m_profileStorage->profileExists(resolvedName)) {
+            repaired = m_profileStorage->writeProfile(resolvedName, m_currentProfile.toJsonString());
+        } else if (!path.isEmpty() && !path.startsWith(QLatin1Char(':'))) {
+            repaired = m_currentProfile.saveToFile(path);
+        }
+        if (repaired)
+            qInfo() << "ProfileManager::loadProfile: repaired stale espresso_temperature on disk for" << resolvedName;
+    }
+
     // Save current profile as previous before switching (only if new profile was found)
     if (found && !m_baseProfileName.isEmpty() && m_baseProfileName != resolvedName)
         m_previousProfileName = m_baseProfileName;

--- a/src/profile/profile.cpp
+++ b/src/profile/profile.cpp
@@ -434,6 +434,15 @@ Profile Profile::fromJson(const QJsonDocument& doc) {
     Profile profile;
     QJsonObject obj = doc.object();
 
+    // Snapshot key presence BEFORE any obj[...] access. QJsonObject's non-const
+    // operator[] inserts a null member as a side effect of the reads below, after
+    // which obj.contains("espresso_temperature") is always true — so the
+    // absent-key reconciliation further down must consult this snapshot, not
+    // obj.contains(). (This insertion is exactly what silently broke Visualizer
+    // imports: their JSON omits espresso_temperature, but the dead contains-guard
+    // let the 93.0 default leak through and get saved. See below.)
+    const bool hadEspressoTemperature = obj.contains(QStringLiteral("espresso_temperature"));
+
     profile.setTitle(obj["title"].toString("Default"));
     profile.m_author = obj["author"].toString();
     // Support both legacy "profile_notes" (old Decenza) and current "notes" (de1app) keys
@@ -556,13 +565,46 @@ Profile Profile::fromJson(const QJsonDocument& doc) {
         }
     }
 
-    // Default espresso_temperature from first frame only when the JSON omits it,
-    // so we never store NaN/0. Otherwise the top-level value is authoritative at
-    // load time — it can legitimately differ from steps[0].temperature (e.g. a
-    // cooler group preheat target paired with a hotter preinfusion ramp).
-    // (regenerateFromRecipe resyncs it from frames after recipe regeneration.)
-    if (!obj.contains("espresso_temperature") && !profile.m_steps.isEmpty()) {
-        profile.m_espressoTemperature = profile.m_steps.first().temperature;
+    // Reconcile espresso_temperature against the frames, which are the source of
+    // truth for what the machine actually brews. The top-level scalar stays
+    // authoritative when the author set it — it may legitimately differ from
+    // steps[0] (a cooler group preheat target paired with a hotter preinfusion ramp,
+    // as on the D-Flow / A-Flow built-ins; see PR #961). Two cases need repair:
+    //
+    //   1. Key absent → derive from the first frame. Visualizer's
+    //      /profile?format=json omits espresso_temperature entirely (per-step temps
+    //      only). Before this, the obj[...] side-effect insertion above defeated the
+    //      old `!obj.contains()` guard, so the 93.0 default leaked through and was
+    //      saved to disk — the actual Visualizer-import bug.
+    //   2. Key present but equal to the bare 93.0 default AND outside the frame
+    //      range → the fingerprint of a profile imported (and saved) while case 1
+    //      was broken. Re-derive from the first frame so already-stored victims are
+    //      repaired on load. A genuinely authored scalar is a real brew temp inside
+    //      the frames, so this never touches the intentional-divergence case above.
+    //
+    // m_espressoTemperatureHealed flags either repair so callers can persist it once
+    // (see ProfileManager::loadProfile). (regenerateFromRecipe resyncs from frames
+    // after recipe regeneration.)
+    if (!profile.m_steps.isEmpty()) {
+        double minTemp = profile.m_steps.first().temperature;
+        double maxTemp = minTemp;
+        for (const ProfileFrame& step : profile.m_steps) {
+            minTemp = qMin(minTemp, step.temperature);
+            maxTemp = qMax(maxTemp, step.temperature);
+        }
+        constexpr double kDefaultTemp = 93.0;  // matches m_espressoTemperature / jsonToDouble fallback
+        const bool leakedDefault = hadEspressoTemperature
+            && qFuzzyCompare(profile.m_espressoTemperature, kDefaultTemp)
+            && (kDefaultTemp > maxTemp + 0.1 || kDefaultTemp < minTemp - 0.1);
+        if (!hadEspressoTemperature || leakedDefault) {
+            if (leakedDefault) {
+                qDebug() << "Profile::fromJson: replacing leaked 93.0 default espresso_temperature"
+                         << "(frames" << minTemp << ".." << maxTemp << ") with first-frame temp for"
+                         << profile.m_title;
+            }
+            profile.m_espressoTemperature = profile.m_steps.first().temperature;
+            profile.m_espressoTemperatureHealed = true;
+        }
     }
 
     // De1app defaults NumberOfPreinfuseFrames to 0 when the field is missing

--- a/src/profile/profile.h
+++ b/src/profile/profile.h
@@ -63,10 +63,11 @@ public:
     double espressoTemperature() const { return m_espressoTemperature; }
     void setEspressoTemperature(double temp) { m_espressoTemperature = temp; }
 
-    // True when fromJson() had to clamp a stored espresso_temperature that fell
-    // outside the frame temperature range back into it (e.g. a stale 93 baked in
-    // by an older Visualizer import). Transient (not serialized) — lets callers
-    // persist the repair once. See Profile::fromJson / ProfileManager::loadProfile.
+    // True when fromJson() re-derived espresso_temperature from the first frame
+    // because the stored value was missing, or was the bare 93.0 default sitting
+    // outside the frame range (a stale Visualizer import). Transient (not
+    // serialized) — lets callers persist the repair once. See Profile::fromJson /
+    // ProfileManager::loadProfile.
     bool espressoTemperatureHealed() const { return m_espressoTemperatureHealed; }
 
     // Temperature presets for quick adjustment (de1app feature)
@@ -274,7 +275,7 @@ private:
 
     // Temperature
     double m_espressoTemperature = 93.0;
-    bool m_espressoTemperatureHealed = false;  // transient; set by fromJson() when clamped, not serialized
+    bool m_espressoTemperatureHealed = false;  // transient; set by fromJson() when re-derived from frames, not serialized
     QList<double> m_temperaturePresets = {88.0, 90.0, 93.0, 96.0};
 
     // Recommended dose

--- a/src/profile/profile.h
+++ b/src/profile/profile.h
@@ -63,6 +63,12 @@ public:
     double espressoTemperature() const { return m_espressoTemperature; }
     void setEspressoTemperature(double temp) { m_espressoTemperature = temp; }
 
+    // True when fromJson() had to clamp a stored espresso_temperature that fell
+    // outside the frame temperature range back into it (e.g. a stale 93 baked in
+    // by an older Visualizer import). Transient (not serialized) — lets callers
+    // persist the repair once. See Profile::fromJson / ProfileManager::loadProfile.
+    bool espressoTemperatureHealed() const { return m_espressoTemperatureHealed; }
+
     // Temperature presets for quick adjustment (de1app feature)
     QList<double> temperaturePresets() const { return m_temperaturePresets; }
     void setTemperaturePresets(const QList<double>& presets) { m_temperaturePresets = presets; }
@@ -268,6 +274,7 @@ private:
 
     // Temperature
     double m_espressoTemperature = 93.0;
+    bool m_espressoTemperatureHealed = false;  // transient; set by fromJson() when clamped, not serialized
     QList<double> m_temperaturePresets = {88.0, 90.0, 93.0, 96.0};
 
     // Recommended dose

--- a/tests/tst_profile.cpp
+++ b/tests/tst_profile.cpp
@@ -177,6 +177,72 @@ private slots:
         QCOMPARE(p.steps()[0].pressure, 9.0);
     }
 
+    // ===== espresso_temperature reconciliation against frames =====
+
+    // Build an advanced (settings_2c) profile JSON with the given top-level
+    // espresso_temperature handling and frame temps. If includeScalar is false the
+    // top-level key is omitted entirely (mirrors Visualizer's /profile?format=json).
+    static QJsonObject makeTempProfileJson(bool includeScalar, double scalar,
+                                           const QList<double>& frameTemps) {
+        QJsonObject obj;
+        obj["title"] = "Temp Profile";
+        obj["legacy_profile_type"] = "settings_2c";
+        if (includeScalar)
+            obj["espresso_temperature"] = scalar;
+        QJsonArray steps;
+        for (double t : frameTemps) {
+            QJsonObject frame;
+            frame["name"] = "f";
+            frame["temperature"] = t;
+            frame["pump"] = "flow";
+            frame["flow"] = 2.0;
+            frame["seconds"] = 10.0;
+            steps.append(frame);
+        }
+        obj["steps"] = steps;
+        return obj;
+    }
+
+    void espressoTemperatureAbsentDerivesFromFirstFrame() {
+        // Visualizer's /profile?format=json omits the top-level espresso_temperature
+        // entirely — the scalar must come from the first frame, never the bare 93.0
+        // default. (Regression guard: the obj[...] insertion side-effect previously
+        // defeated the absent-key path, so the 93.0 default leaked through.)
+        Profile p = Profile::fromJson(QJsonDocument(
+            makeTempProfileJson(/*includeScalar=*/false, 0.0, {84.0, 79.0, 52.0})));
+        QCOMPARE(p.espressoTemperature(), 84.0);
+        QVERIFY(p.espressoTemperatureHealed());
+    }
+
+    void espressoTemperatureLeakedDefaultIsRepaired() {
+        // An already-stored victim of the import bug: espresso_temperature is the
+        // bare 93.0 default sitting above an 84/79/52 profile. Re-derived from the
+        // first frame on load so it can be repaired on disk once.
+        Profile p = Profile::fromJson(QJsonDocument(
+            makeTempProfileJson(/*includeScalar=*/true, 93.0, {84.0, 79.0, 52.0})));
+        QCOMPARE(p.espressoTemperature(), 84.0);
+        QVERIFY(p.espressoTemperatureHealed());
+    }
+
+    void espressoTemperatureAuthoredAboveFramesIsAuthoritative() {
+        // Authored divergence (NOT the 93.0 default): a cool preheat frame paired
+        // with a hotter scalar. Even above the frame range it must be left alone —
+        // the semantic #961 locked in. Only the exact-93.0-default fingerprint heals.
+        Profile p = Profile::fromJson(QJsonDocument(
+            makeTempProfileJson(/*includeScalar=*/true, 90.0, {88.0, 88.0})));
+        QCOMPARE(p.espressoTemperature(), 90.0);
+        QVERIFY(!p.espressoTemperatureHealed());
+    }
+
+    void espressoTemperatureDefaultWithinFramesIsKept() {
+        // A genuine 93°C profile: scalar is 93.0 but the frames actually reach it,
+        // so it is in range and must NOT be treated as a leaked default.
+        Profile p = Profile::fromJson(QJsonDocument(
+            makeTempProfileJson(/*includeScalar=*/true, 93.0, {90.0, 93.0, 91.0})));
+        QCOMPARE(p.espressoTemperature(), 93.0);
+        QVERIFY(!p.espressoTemperatureHealed());
+    }
+
     // ===== Nested exit conditions (de1app v2 format) =====
 
     void jsonNestedExitPressureOver() {

--- a/tests/tst_profile.cpp
+++ b/tests/tst_profile.cpp
@@ -243,6 +243,29 @@ private slots:
         QVERIFY(!p.espressoTemperatureHealed());
     }
 
+    void espressoTemperatureStringEncodedDefaultIsRepaired() {
+        // de1app/Visualizer serialize numbers as strings. A leaked "93.00" default
+        // must still be recognised and repaired after jsonToDouble parses it.
+        QJsonObject obj = makeTempProfileJson(/*includeScalar=*/false, 0.0, {84.0, 79.0, 52.0});
+        obj["espresso_temperature"] = QString("93.00");
+        Profile p = Profile::fromJson(QJsonDocument(obj));
+        QCOMPARE(p.espressoTemperature(), 84.0);
+        QVERIFY(p.espressoTemperatureHealed());
+    }
+
+    void espressoTemperatureRepairRoundTripDoesNotReheal() {
+        // The "repaired once" contract: a healed profile, serialized via toJson and
+        // reparsed, comes back with the key present and in range — so it must NOT
+        // heal again (no infinite re-write loop on disk).
+        Profile healed = Profile::fromJson(QJsonDocument(
+            makeTempProfileJson(/*includeScalar=*/true, 93.0, {84.0, 79.0, 52.0})));
+        QVERIFY(healed.espressoTemperatureHealed());
+
+        Profile reloaded = Profile::fromJson(healed.toJson());
+        QCOMPARE(reloaded.espressoTemperature(), 84.0);
+        QVERIFY(!reloaded.espressoTemperatureHealed());
+    }
+
     // ===== Nested exit conditions (de1app v2 format) =====
 
     void jsonNestedExitPressureOver() {


### PR DESCRIPTION
## Problem

A user's profile imported from Visualizer (Resistor Doosra) displayed **93°C** in the shot-plan widget while the profile actually brews at **84 → 79 → drop**. The number also fed MCP/AI dialing advice, Visualizer re-uploads, and the temperature-override delta baseline.

Root cause: Visualizer's `/profile?format=json` **omits the top-level `espresso_temperature`** (per-step temps only). `Profile::fromJson` was supposed to fall back to the first frame in that case, but the guard `!obj.contains("espresso_temperature")` was **dead** — the earlier `jsonToDouble(obj["espresso_temperature"], 93.0)` read uses `QJsonObject`'s non-const `operator[]`, which **inserts a null member as a side effect**, so `contains()` was always true by the time the guard ran.

[#961](https://github.com/Kulitorum/Decenza/pull/961) removed the `else`-branch that had been masking this, so **since Apr 30 every Visualizer import let the `93.0` default leak through and get saved to disk.**

## Brewing impact

None on the extraction — the **frames** are uploaded verbatim and govern the shot, so affected shots brewed at the intended temperatures. The leak only mislabels the profile, sets the idle/ready preheat target a few degrees high, feeds a wrong baseline to the override delta ([`profilemanager.cpp:1567`](https://github.com/Kulitorum/Decenza/blob/main/src/controllers/profilemanager.cpp)), and skews AI/MCP advice and re-uploads.

## Fix

- **Snapshot key presence before any `obj[...]` access** so the absent-key path works again → derive the scalar from the first frame.
- **Repair already-stored victims:** a present scalar equal to the bare `93.0` default *and* outside the frame range is re-derived from the first frame. An authored scalar (a real brew temp within the frames) is left authoritative — preserving the intentional-divergence semantics #961 locked in (both its regression tests still pass).
- **`ProfileManager::loadProfile` persists the repair to storage once**, so each profile is fixed on disk on first load rather than re-healed on every parse.
- **Regression tests** for: absent key, leaked-default repair, authored out-of-range (kept authoritative), and a genuine in-range 93.

## Testing

- macOS Debug build: clean (0 warnings).
- Full autotest suite: **2463 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)