### PR TITLE
Weight widgets: live net weight that holds the captured value + two scale data modes

### DIFF
--- a/qml/components/layout/ScaleWeightEditorPopup.qml
+++ b/qml/components/layout/ScaleWeightEditorPopup.qml
@@ -46,7 +46,9 @@ Dialog {
         { value: "gross",        label: TranslationManager.translate("layoutEditor.scaleGross", "Gross weight") },
         { value: "netBeans",     label: TranslationManager.translate("layoutEditor.scaleNetBeans", "Net beans (minus dose tare)") },
         { value: "netMilk",      label: TranslationManager.translate("layoutEditor.scaleNetMilk", "Net milk (minus pitcher)") },
-        { value: "contextAware", label: TranslationManager.translate("layoutEditor.scaleContext", "Context-aware (milk while steaming, else beans)") }
+        { value: "contextAware", label: TranslationManager.translate("layoutEditor.scaleContext", "Context-aware (milk while steaming, else beans)") },
+        { value: "beansHold",    label: TranslationManager.translate("layoutEditor.scaleBeansHold", "Beans (live, then hold captured dose)") },
+        { value: "expectedYield", label: TranslationManager.translate("layoutEditor.scaleExpectedYield", "Expected output (dose × ratio)") }
     ]
 
     modal: true

--- a/qml/components/layout/ScaleWeightEditorPopup.qml
+++ b/qml/components/layout/ScaleWeightEditorPopup.qml
@@ -48,7 +48,7 @@ Dialog {
         { value: "netMilk",      label: TranslationManager.translate("layoutEditor.scaleNetMilk", "Net milk (minus pitcher)") },
         { value: "contextAware", label: TranslationManager.translate("layoutEditor.scaleContext", "Context-aware (milk while steaming, else beans)") },
         { value: "beansHold",    label: TranslationManager.translate("layoutEditor.scaleBeansHold", "Beans (live, then hold captured dose)") },
-        { value: "expectedYield", label: TranslationManager.translate("layoutEditor.scaleExpectedYield", "Expected output (dose × ratio)") }
+        { value: "expectedYield", label: TranslationManager.translate("layoutEditor.scaleExpectedYield", "Expected output (target)") }
     ]
 
     modal: true

--- a/qml/components/layout/items/DoseWeightItem.qml
+++ b/qml/components/layout/items/DoseWeightItem.qml
@@ -27,8 +27,13 @@ Item {
     // (the _operating phase gate alone doesn't cover the return-to-Idle window).
     property bool _postExtraction: false
     function _liveNet() { return Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) }
+    // Live net-bean display is valid only with a saved dose-cup tare (else scale − 0 = gross, mislabelled
+    // "beans") AND when the net sits in a plausible dose range — a brew cup's net (≫ any real dose) must not
+    // read as beans. When either fails, valueText falls through to the recorded dyeBeanWeight.
     readonly property bool _loaded: root.scaleConnected
+        && Settings.brew.doseCupTareWeight > 0
         && MachineState.scaleWeight > (Settings.brew.doseCupTareWeight + 0.3)
+        && _liveNet() <= 55
 
     // Live net-bean display only makes sense while dosing. During espresso preheat or
     // an active operation (preinfusion/pour/ending/steam/water/flush) the scale is

--- a/qml/components/layout/items/DoseWeightItem.qml
+++ b/qml/components/layout/items/DoseWeightItem.qml
@@ -3,7 +3,9 @@ import QtQuick.Layouts
 import Decenza
 
 // Layout widget: measured dose weight (composable-brew-bar).
-// Shows Settings.dye.dyeBeanWeight; "—" when no dose recorded.
+// Live-then-hold: shows the live net-bean weight while weighing, freezes the
+// captured dose at the beep, holds it, then falls back to the last recorded
+// dose (Settings.dye.dyeBeanWeight), or "—" when none.
 Item {
     id: root
     property bool isCompact: false
@@ -12,9 +14,71 @@ Item {
     property bool zoneValueBold: false
 
     readonly property string labelText: TranslationManager.translate("idle.status.beans", "Beans")
-    readonly property string valueText: Settings.dye.dyeBeanWeight > 0
-                                        ? Settings.dye.dyeBeanWeight.toFixed(1) + " g"
-                                        : "—"
+
+    // Live-then-hold dose: show the live net-bean weight while a dose is being
+    // weighed, freeze the captured dose once the stable-capture "beep" sets
+    // Settings.dye.dyeBeanWeight, and hold it until a fresh dose is placed on the
+    // scale. Falls back to the last recorded dose when idle. Event-based — no timers.
+    property bool scaleConnected: ScaleDevice && ScaleDevice.connected
+    property real _held: 0
+    property bool _wasEmpty: true
+    // Latched true when a cup sits on the scale during an operation, cleared when the
+    // cup is lifted — suppresses a post-shot brew cup reading as live beans in Idle
+    // (the _operating phase gate alone doesn't cover the return-to-Idle window).
+    property bool _postExtraction: false
+    function _liveNet() { return Math.max(0, MachineState.scaleWeight - Settings.brew.doseCupTareWeight) }
+    readonly property bool _loaded: root.scaleConnected
+        && MachineState.scaleWeight > (Settings.brew.doseCupTareWeight + 0.3)
+
+    // Live net-bean display only makes sense while dosing. During espresso preheat or
+    // an active operation (preinfusion/pour/ending/steam/water/flush) the scale is
+    // measuring the brew cup / milk / water, so a "beans = scale − cup tare" reading
+    // there is a phantom; suppress the live path in those phases (the held/recorded
+    // dose still shows). Preheat is included because the brew cup goes on the scale
+    // then, before Preinfusion flips.
+    readonly property bool _operating:
+        MachineState.phase === MachineStateType.Phase.EspressoPreheating
+        || MachineState.phase === MachineStateType.Phase.Preinfusion
+        || MachineState.phase === MachineStateType.Phase.Pouring
+        || MachineState.phase === MachineStateType.Phase.Ending
+        || MachineState.phase === MachineStateType.Phase.Steaming
+        || MachineState.phase === MachineStateType.Phase.HotWater
+        || MachineState.phase === MachineStateType.Phase.Flushing
+
+    Connections {
+        target: MachineState
+        function onScaleWeightChanged() {
+            if (MachineState.scaleWeight < 1.0) {
+                root._wasEmpty = true            // cup lifted off
+                root._held = 0                   // drop the hold so the idle fallback (dyeBeanWeight) stays fresh
+                root._postExtraction = false     // cup gone -> clear the post-operation latch
+            } else {
+                // A cup on the scale during an operation (pour/steam/…): latch until it's
+                // lifted, so a brew cup left on after the shot doesn't read as live beans.
+                if (root._operating) root._postExtraction = true
+                if (root._wasEmpty && root._liveNet() > 0.3) {
+                    root._held = 0               // a fresh dose is being placed -> go live
+                    root._wasEmpty = false
+                }
+            }
+        }
+    }
+    Connections {
+        target: Settings.dye
+        function onDyeBeanWeightChanged() {
+            // Stable-capture "beep" landed while a dose is on the scale -> hold it.
+            if (Settings.dye.dyeBeanWeight > 0 && root._loaded)
+                root._held = Settings.dye.dyeBeanWeight
+        }
+    }
+
+    readonly property string valueText: {
+        if (root._held > 0) return root._held.toFixed(1) + " g"          // held captured dose
+        if (root._loaded && !root._operating && !root._postExtraction)   // live while weighing (not mid/post-operation)
+            return root._liveNet().toFixed(1) + " g"
+        return Settings.dye.dyeBeanWeight > 0                            // idle: last recorded
+               ? Settings.dye.dyeBeanWeight.toFixed(1) + " g" : "—"
+    }
 
     implicitWidth: col.implicitWidth
     implicitHeight: col.implicitHeight

--- a/qml/components/layout/items/MilkWeightItem.qml
+++ b/qml/components/layout/items/MilkWeightItem.qml
@@ -4,9 +4,10 @@ import QtQuick.Window
 import Decenza
 
 // Layout widget: measured milk weight (composable-brew-bar).
-// Shows the live in-session milk while steaming (sessionMeasuredMilkG on the
-// window root) and falls back to the last committed session weight
-// (Settings.brew.lastSteamMilkG); "—" when neither is available.
+// Shows, in priority order: the captured in-session milk (sessionMeasuredMilkG on
+// the window root), else the live net milk on the scale while steaming
+// (liveNetMilkG = scale − pitcher tare, phase-gated), else the last committed
+// session weight (Settings.brew.lastSteamMilkG); "—" when none is available.
 Item {
     id: root
     property bool isCompact: false
@@ -15,15 +16,39 @@ Item {
     property bool zoneValueBold: false
 
     readonly property string labelText: TranslationManager.translate("idle.status.milk", "Milk")
-    // Live in-session milk (set during steaming, reset to 0 at session end /
-    // pitcher change). 0 when the window or property is unavailable — guarded so
-    // the widget degrades to the committed value and never errors.
-    readonly property double liveMilkG: {
+
+    property bool scaleConnected: ScaleDevice && ScaleDevice.connected
+
+    // Pitcher tare for the selected steam preset (0 when none saved/disabled).
+    function _pitcherWeight() {
+        var p = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        return (p && !p.disabled) ? (p.pitcherWeightG ?? 0) : 0
+    }
+
+    // Captured/committed milk for this session: the auto-captured value held on
+    // the window root (set at capture, reset to 0 at session end / pitcher change).
+    readonly property double sessionMilkG: {
         var win = root.Window.window
         return (win && win.sessionMeasuredMilkG > 0) ? win.sessionMeasuredMilkG : 0
     }
-    readonly property double milkG: liveMilkG > 0 ? liveMilkG : Settings.brew.lastSteamMilkG
-    readonly property string valueText: milkG > 0 ? milkG.toFixed(1) + " g" : "—"
+    // Live net milk on the scale right now (pitcher tare subtracted). Needs a saved
+    // pitcher weight to be meaningful; 0 otherwise.
+    readonly property double liveNetMilkG: {
+        var p = root._pitcherWeight()
+        // Gate on the steam phase: without it, a cup heavier than the saved pitcher
+        // tare sitting on the scale in a non-steam context would show a phantom
+        // "milk" reading (mirrors the steam-phase gate ScaleWeightItem's
+        // contextAware mode already uses).
+        return (root.scaleConnected && p > 0
+                && MachineState.phase === MachineStateType.Phase.Steaming)
+               ? Math.max(0, MachineState.scaleWeight - p) : 0
+    }
+    // Show the captured value once it lands (held), else the live net milk while
+    // the pitcher is on the scale, else the last committed session weight.
+    readonly property double milkG: root.sessionMilkG > 0 ? root.sessionMilkG
+                                    : (root.liveNetMilkG > 0.3 ? root.liveNetMilkG
+                                    : Settings.brew.lastSteamMilkG)
+    readonly property string valueText: root.milkG > 0 ? root.milkG.toFixed(1) + " g" : "—"
 
     implicitWidth: col.implicitWidth
     implicitHeight: col.implicitHeight

--- a/qml/components/layout/items/ScaleWeightItem.qml
+++ b/qml/components/layout/items/ScaleWeightItem.qml
@@ -14,8 +14,9 @@ Item {
     // default), "netBeans" (minus dose-cup tare), "netMilk" (minus pitcher
     // weight), "contextAware" (net milk while steaming, else net beans),
     // "beansHold" (live net beans, then hold the captured dose after the beep),
-    // "expectedYield" (the target output, dose × ratio = ProfileManager.targetWeight;
-    //   a computed value, but currently shown only when a scale is configured).
+    // "expectedYield" (the active stop-at-weight target = ProfileManager.targetWeight: the
+    //   brew-yield override when set — which equals dose × ratio in brew-by-ratio mode — else
+    //   the profile's fixed target weight. Purely computed, so shown even without a scale).
     readonly property string dataMode: (modelData && modelData.dataMode) ? modelData.dataMode : ""
 
     // Per-instance display mode (composable-status-bar): "text" (default, a
@@ -87,16 +88,18 @@ Item {
         if (root.dataMode === "beansHold") {
             // Mirrors DoseWeightItem's live→hold→recorded chain: the frozen captured
             // dose if we have one this cycle; else the live net beans while actually
-            // dosing; else (mid/post-operation, or cup off) the last recorded dose —
-            // never the phantom live scale reading (a brew/milk cup on the scale).
+            // dosing; else (mid/post-operation, cup off, no saved tare, or an implausible
+            // net) the last recorded dose — never the phantom/gross live reading.
             if (root._heldDose > 0) return root._heldDose
-            var net = (root._operating || root._postExtraction)
-                      ? 0 : Math.max(0, w - Settings.brew.doseCupTareWeight)
-            return net > 0.3 ? net : Settings.dye.dyeBeanWeight
+            var live = (root._operating || root._postExtraction || Settings.brew.doseCupTareWeight <= 0)
+                       ? 0 : Math.max(0, w - Settings.brew.doseCupTareWeight)
+            // net > 55 g is a brew cup, not beans; fall through to the recorded dose.
+            return (live > 0.3 && live <= 55) ? live : Settings.dye.dyeBeanWeight
         }
         if (root.dataMode === "expectedYield") {
-            // Target espresso output = dose x ratio (ProfileManager keeps this as
-            // the active stop-at-weight target when brewing by ratio).
+            // The active stop-at-weight target (ProfileManager.targetWeight): the brew-yield
+            // override when one is set — which equals dose × ratio in brew-by-ratio mode —
+            // else the profile's fixed target weight. Purely computed; needs no scale.
             return ProfileManager.targetWeight
         }
         return w
@@ -116,7 +119,9 @@ Item {
 
     // Scale warning: saved BLE scale not connected or connection failed, or app fell back to simulated scale
     // Don't warn if a USB scale is connected — it satisfies the "have a real scale" requirement (not available on iOS)
-    property bool showScaleWarning: (!root.scaleConnected || root.isFlowScale)
+    // "expectedYield" is a purely computed target — it never needs a scale, so never warn for it.
+    property bool showScaleWarning: root.dataMode !== "expectedYield"
+        && (!root.scaleConnected || root.isFlowScale)
         && (BLEManager.scaleConnectionFailed || Settings.primaryScaleAddress !== "")
         && (Qt.platform.os === "ios" || !UsbScaleManager.scaleConnected)
 
@@ -231,7 +236,7 @@ Item {
             id: compactScaleRow
             anchors.centerIn: parent
             spacing: Theme.spacingSmall
-            visible: root.scaleConnected && !root.showScaleWarning
+            visible: (root.scaleConnected || root.dataMode === "expectedYield") && !root.showScaleWarning
 
             ThemedIcon {
                 anchors.verticalCenter: parent.verticalCenter
@@ -273,7 +278,7 @@ Item {
             id: scaleMouseArea
             anchors.fill: parent
             anchors.margins: -Theme.spacingSmall
-            visible: root.scaleConnected && !root.showScaleWarning
+            visible: (root.scaleConnected || root.dataMode === "expectedYield") && !root.showScaleWarning
             cursorShape: Qt.PointingHandCursor
 
             property int tapCount: 0
@@ -372,7 +377,7 @@ Item {
 
             Text {
                 Layout.alignment: Qt.AlignHCenter
-                visible: root.scaleConnected && !root.showScaleWarning
+                visible: (root.scaleConnected || root.dataMode === "expectedYield") && !root.showScaleWarning
                 text: root.weightText()
                 color: root.scaleColor(fullTapArea.pressed)
                 font: Theme.valueFont

--- a/qml/components/layout/items/ScaleWeightItem.qml
+++ b/qml/components/layout/items/ScaleWeightItem.qml
@@ -266,7 +266,9 @@ Item {
         // Disconnected (no saved scale)
         Text {
             anchors.centerIn: parent
+            // expectedYield is a computed target that renders without a scale, so don't also show "--".
             visible: !root.scaleConnected && !root.showScaleWarning && !root.isFlowScale
+                     && root.dataMode !== "expectedYield"
             text: "--"
             color: Theme.textSecondaryColor
             font: Theme.bodyFont
@@ -387,6 +389,7 @@ Item {
             Text {
                 Layout.alignment: Qt.AlignHCenter
                 visible: !root.scaleConnected && !root.showScaleWarning
+                         && root.dataMode !== "expectedYield"
                 text: "--"
                 color: Theme.textSecondaryColor
                 font: Theme.valueFont

--- a/qml/components/layout/items/ScaleWeightItem.qml
+++ b/qml/components/layout/items/ScaleWeightItem.qml
@@ -12,7 +12,10 @@ Item {
 
     // Per-instance data mode (composable-brew-bar): "" / "gross" (raw weight,
     // default), "netBeans" (minus dose-cup tare), "netMilk" (minus pitcher
-    // weight), "contextAware" (net milk while steaming, else net beans).
+    // weight), "contextAware" (net milk while steaming, else net beans),
+    // "beansHold" (live net beans, then hold the captured dose after the beep),
+    // "expectedYield" (the target output, dose × ratio = ProfileManager.targetWeight;
+    //   a computed value, but currently shown only when a scale is configured).
     readonly property string dataMode: (modelData && modelData.dataMode) ? modelData.dataMode : ""
 
     // Per-instance display mode (composable-status-bar): "text" (default, a
@@ -30,7 +33,47 @@ Item {
         return (p && !p.disabled) ? (p.pitcherWeightG ?? 0) : 0
     }
 
+    // "beansHold": show LIVE net beans while dosing, then freeze the captured
+    // dose once a stable capture has set Settings.dye.dyeBeanWeight, holding it
+    // until the cup is lifted (scale returns to ~0), then go live again for the
+    // next dose. Event-based — no timers.
+    property real _heldDose: 0
+    // Latched true when a cup sits on the scale during an operation, cleared when the
+    // cup is lifted — suppresses a post-shot brew cup reading as live beans in Idle.
+    property bool _postExtraction: false
+    Connections {
+        target: Settings.dye
+        function onDyeBeanWeightChanged() {
+            if (root.dataMode === "beansHold" && Settings.dye.dyeBeanWeight > 0
+                    && MachineState.scaleWeight > Settings.brew.doseCupTareWeight)
+                root._heldDose = Settings.dye.dyeBeanWeight
+        }
+    }
+    Connections {
+        target: MachineState
+        function onScaleWeightChanged() {
+            if (root.dataMode !== "beansHold") return
+            if (MachineState.scaleWeight < 1.0) {
+                root._heldDose = 0            // cup lifted -> next dose reads live
+                root._postExtraction = false  // and clear the post-operation latch
+            } else if (root._operating) {
+                root._postExtraction = true   // cup on scale during an op -> latch until lifted
+            }
+        }
+    }
+
     // Apply the per-instance data mode to the raw scale reading.
+    // Operating phases where a live net-beans reading would be a phantom (the scale is
+    // measuring the brew cup / milk / water, not beans). Mirrors DoseWeightItem._operating.
+    readonly property bool _operating:
+        MachineState.phase === MachineStateType.Phase.EspressoPreheating
+        || MachineState.phase === MachineStateType.Phase.Preinfusion
+        || MachineState.phase === MachineStateType.Phase.Pouring
+        || MachineState.phase === MachineStateType.Phase.Ending
+        || MachineState.phase === MachineStateType.Phase.Steaming
+        || MachineState.phase === MachineStateType.Phase.HotWater
+        || MachineState.phase === MachineStateType.Phase.Flushing
+
     function displayedWeight() {
         var w = MachineState.scaleWeight
         if (root.dataMode === "netBeans")
@@ -40,6 +83,21 @@ Item {
         if (root.dataMode === "contextAware") {
             var steaming = MachineState.phase === MachineStateType.Phase.Steaming
             return Math.max(0, w - (steaming ? root._pitcherWeight() : Settings.brew.doseCupTareWeight))
+        }
+        if (root.dataMode === "beansHold") {
+            // Mirrors DoseWeightItem's live→hold→recorded chain: the frozen captured
+            // dose if we have one this cycle; else the live net beans while actually
+            // dosing; else (mid/post-operation, or cup off) the last recorded dose —
+            // never the phantom live scale reading (a brew/milk cup on the scale).
+            if (root._heldDose > 0) return root._heldDose
+            var net = (root._operating || root._postExtraction)
+                      ? 0 : Math.max(0, w - Settings.brew.doseCupTareWeight)
+            return net > 0.3 ? net : Settings.dye.dyeBeanWeight
+        }
+        if (root.dataMode === "expectedYield") {
+            // Target espresso output = dose x ratio (ProfileManager keeps this as
+            // the active stop-at-weight target when brewing by ratio).
+            return ProfileManager.targetWeight
         }
         return w
     }
@@ -109,7 +167,7 @@ Item {
 
     function weightText() {
         var weight = root.displayedWeight().toFixed(1)
-        var suffix = root.isFlowScale ? "g~" : "g"
+        var suffix = (root.isFlowScale && root.dataMode !== "expectedYield") ? "g~" : "g"
         if (root.showRatio && ProfileManager.brewByRatioActive) {
             return weight + suffix + " 1:" + ProfileManager.brewByRatio.toFixed(1)
         }

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -2721,7 +2721,7 @@ QString ShotServer::generateLayoutPage() const
                 // Inline data-mode selector for a selected Scale Weight chip.
                 if (isSel && item.type === "scaleWeight") {
                     var dm = item.dataMode || "gross";
-                    var modes = [["gross","Gross"],["netBeans","Net beans"],["netMilk","Net milk"],["contextAware","Context"]];
+                    var modes = [["gross","Gross"],["netBeans","Net beans"],["netMilk","Net milk"],["contextAware","Context"],["beansHold","Beans (hold)"],["expectedYield","Expected output"]];
                     html += '<select class="chip-mode" onchange="setScaleMode(\'' + item.id + '\',this.value)" onclick="event.stopPropagation()">';
                     for (var mm = 0; mm < modes.length; mm++) {
                         var msel = (dm === modes[mm][0]) ? ' selected' : '';


### PR DESCRIPTION
## Summary

The Dose and Milk weight widgets show a single static number. This PR makes them show the **live net weight while a load is on the scale, then "hold" the value captured when the scale settles** (the beep) — and adds two new data modes to the Scale Weight widget.

## Why

When dosing beans or weighing a milk pitcher, it's useful to watch the live net weight build up, and then have the widget settle on the captured value rather than jumping back to a stored number. This mirrors how the scale-capture flow already behaves elsewhere, but surfaces it on the home-screen widgets.

## Changes & reasoning

**`DoseWeightItem.qml` / `MilkWeightItem.qml` — live → hold**
- While a load is present on the scale, the widget shows the **live net weight** (scale reading minus the saved cup/pitcher tare).
- When the weight stabilises (the capture / "beep"), it **freezes** that captured value and holds it, falling back to the last set/measured value when the scale is empty.
- **Event-based, no timers:** the live/hold transitions are driven by `Connections` on `MachineState.onScaleWeightChanged` / `Settings.dye.onDyeBeanWeightChanged` with boolean/value flags — not a polling or guard timer (per the project's "no timers as guards" rule). A timer would be a fragile heuristic; the capture is a real event.

**`ScaleWeightItem.qml` + `ScaleWeightEditorPopup.qml` — two new data modes**
- `beansHold` — "beans, live then hold the captured dose": same live→hold behaviour as a configurable Scale Weight data mode.
- `expectedYield` — "expected output (dose × ratio)": shows `ProfileManager.targetWeight`, i.e. the target the shot will stop at, rather than a live reading. The `g~` ("approximate live reading") suffix is suppressed for this mode since it's a computed target, not a scale reading.
- Both modes are added to the on-device widget editor (`ScaleWeightEditorPopup`) and the web layout-editor data-mode list (`shotserver_layout.cpp`) so QML and web editors stay in parity.

## Testing

On-device: place a dose cup / milk pitcher → the widget tracks the live net weight → on settle it holds the captured value → lifting the load and re-dosing goes live again. The two new Scale Weight data modes selectable in the layout editor behave as described.

## Notes for the reviewer

- No timers used as guards; no hardcoded colours/sizes; new editor strings are internationalised via `TranslationManager.translate(...)`.
- The re-dose "scale empty" detection uses a small bare weight threshold (`< 1.0 g`) — a physical threshold, not styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
