### PR TITLE
Steam: enable milk weight auto-capture by default

### DIFF
--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -160,7 +160,12 @@ void SettingsBrew::setDoseCupTareWeight(double weight) {
 }
 
 bool SettingsBrew::milkAutoCaptureEnabled() const {
-    return m_settings.value("steam/milkAutoCaptureEnabled", false).toBool();  // off by default; calibrating turns it on
+    // On by default so milk auto-capture mirrors bean dose-capture (which activates
+    // as soon as a dose-cup tare is saved). It still does nothing until a pitcher
+    // weight is saved (capture needs cupWeight > 0) and a reference milk is set
+    // (scaledSteamTime() returns 0 otherwise), so default-on only removes a redundant
+    // manual toggle. Users can still turn it off to stop the scale changing steam time.
+    return m_settings.value("steam/milkAutoCaptureEnabled", true).toBool();
 }
 void SettingsBrew::setMilkAutoCaptureEnabled(bool enabled) {
     if (milkAutoCaptureEnabled() != enabled) {
@@ -411,8 +416,8 @@ void SettingsBrew::setSteamPitcherCalibration(int index, double calibMilkG) {
         arr[index] = preset;
         m_settings.setValue("steam/pitcherPresets", QJsonDocument(arr).toJson());
         emit steamPitcherPresetsChanged();
-        // Weight-timed steaming is off by default; setting a reference is the explicit
-        // opt-in, so calibrating turns it on. Clearing the reference leaves it as-is.
+        // Weight-timed steaming is on by default; setting a reference is the explicit
+        // reference for scaling. Clearing the reference leaves the toggle as-is.
         if (calibMilkG > 0)
             setMilkAutoCaptureEnabled(true);
     }

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -25,8 +25,8 @@ class SettingsBrew : public QObject {
     // reading in "Get from scale" so the dose is net beans. Default 0 = no tare.
     Q_PROPERTY(double doseCupTareWeight READ doseCupTareWeight WRITE setDoseCupTareWeight NOTIFY doseCupTareWeightChanged)
     // Master toggle for weight-timed steaming (UI label "Weight-timed steaming").
-    // When off, steam time is never scaled from milk weight. Default OFF; setting a
-    // pitcher's reference milk (setSteamPitcherCalibration) turns it on automatically.
+    // When off, steam time is never scaled from milk weight. Default ON, mirroring bean
+    // dose-capture; it stays inert until a pitcher weight and reference milk are saved.
     Q_PROPERTY(bool milkAutoCaptureEnabled READ milkAutoCaptureEnabled WRITE setMilkAutoCaptureEnabled NOTIFY milkAutoCaptureEnabledChanged)
     // Whether the confirmation "ding" plays when a dose/milk auto-captures. Default
     // off — toggled by the bell on the Dose cup row.


### PR DESCRIPTION
## Summary

Flip the default of `milkAutoCaptureEnabled` (weight-timed steaming / milk weight auto-capture) from **off** to **on**, so milk auto-capture mirrors how bean dose-capture already behaves.

## Why

Bean dose-capture activates as soon as a dose-cup tare is saved — no separate opt-in. Milk auto-capture required an extra manual toggle, so the milk-weighing prompts and weight-scaled steam time never appeared for most users even after they'd set up a pitcher. Making the default consistent with beans removes that redundant step.

## Changes & reasoning

**`src/core/settings_brew.cpp`**
- `milkAutoCaptureEnabled()` default changed `false → true`.
- **Why it's safe:** default-on is inert until both preconditions hold — a saved empty-pitcher weight (`cupWeight > 0`, required by `StableWeightCapture` before it captures) and a calibrated reference milk (`scaledSteamTime()` returns 0 without one). So nothing auto-changes the steam stop time until the user has actually set up a pitcher; the flag can still be turned off to disable weight scaling.
- Updated the explanatory comments (here and at the persist-reference logic) that previously described the old "off by default" behaviour.

**`src/core/settings_brew.h`**
- Updated the `Q_PROPERTY` declaration comment for `milkAutoCaptureEnabled` (it still said "Default OFF", which would now contradict the implementation).

## Testing

With a calibrated pitcher: selecting Steam now surfaces the milk-weighing prompt and weight-scaled steam time without a separate toggle. With no pitcher set up, behaviour is unchanged (inert).

## Notes for the reviewer

- One-line functional change plus comment corrections so the property's own documentation matches its default. Calibrating a pitcher already set this flag, so for set-up users the effective behaviour is unchanged; this only helps users who saved a pitcher weight but hadn't flipped the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
