### PR TITLE
Add a Celsius/Fahrenheit temperature display option

### DIFF
--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -207,6 +207,19 @@ QtObject {
         return _truncateWithEllipsis(text, cap)
     }
 
+    // --- Temperature unit (display/entry only; storage stays Celsius) ---
+    function tempIsFahrenheit() { return Settings.app.temperatureUnit === "fahrenheit" }
+    function tempUnitSuffix() { return tempIsFahrenheit() ? "°F" : "°C" }
+    function cToDisplay(celsius) { return tempIsFahrenheit() ? (celsius * 9 / 5 + 32) : celsius }
+    function displayToC(value) { return tempIsFahrenheit() ? ((value - 32) * 5 / 9) : value }
+    // A temperature DELTA/offset scales only (no +32 origin shift): +4°C = +7.2°F.
+    function cDeltaToDisplay(deltaCelsius) { return tempIsFahrenheit() ? (deltaCelsius * 9 / 5) : deltaCelsius }
+    function displayToCDelta(deltaValue) { return tempIsFahrenheit() ? (deltaValue * 5 / 9) : deltaValue }
+    function formatTemperature(celsius, decimals) {
+        var d = (decimals === undefined) ? 0 : decimals
+        return cToDisplay(celsius).toFixed(d) + tempUnitSuffix()
+    }
+
     // Helper function to scale values
     function scaled(value) { return Math.round(value * scale) }
 

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -388,19 +388,22 @@ Dialog {
                     ValueInput {
                         id: tempInput
                         Layout.fillWidth: true
+                        // The offset is entered/shown in the user's unit (a delta scales
+                        // ×9/5 for °F, no origin shift); stored back as a Celsius delta.
                         readonly property real delta: root.temperatureValue - root.profileTemperature
-                        value: delta
-                        from: 70 - root.profileTemperature
-                        to: 100 - root.profileTemperature
+                        readonly property real displayDelta: Theme.cDeltaToDisplay(delta)
+                        value: displayDelta
+                        from: Theme.cDeltaToDisplay(70 - root.profileTemperature)
+                        to: Theme.cDeltaToDisplay(100 - root.profileTemperature)
                         stepSize: 1
                         decimals: 0
                         suffix: "°"
-                        displayText: (delta > 0 ? "+" : "") + delta.toFixed(0) + "°"
+                        displayText: (displayDelta > 0 ? "+" : "") + displayDelta.toFixed(0) + "°"
                         valueColor: Math.abs(delta) > 0.1 ? Theme.temperatureColor : Theme.textSecondaryColor
                         accentColor: Theme.temperatureColor
                         accessibleName: TranslationManager.translate("brewDialog.brewTempDelta", "Brew temperature offset")
                         onValueModified: function(newValue) {
-                            root.temperatureValue = root.profileTemperature + newValue
+                            root.temperatureValue = root.profileTemperature + Theme.displayToCDelta(newValue)
                         }
                     }
 
@@ -430,8 +433,13 @@ Dialog {
                     id: tempSubtext
                     readonly property bool tempPending: Math.abs(root.temperatureValue - root.profileTemperature) > 0.1
                     visible: root.profileTemperature > 0
-                    text: TranslationManager.translate("brewDialog.profileTempStructure", "Profile: %1")
-                        .arg(ProfileManager.temperatureDisplay(root.profileTemperature, tempPending, root.temperatureValue))
+                    text: {
+                        // temperatureDisplay() reads the C/F unit in C++ (not a QML-
+                        // capturable dependency), so read it here to re-evaluate on switch.
+                        void(Settings.app.temperatureUnit)
+                        return TranslationManager.translate("brewDialog.profileTempStructure", "Profile: %1")
+                            .arg(ProfileManager.temperatureDisplay(root.profileTemperature, tempPending, root.temperatureValue))
+                    }
                     font.family: Theme.bodyFont.family
                     font.pixelSize: Theme.scaled(14)
                     font.italic: true

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -40,6 +40,10 @@ Text {
     property double targetWeight: ProfileManager.targetWeight
 
     text: {
+        // temperatureDisplay() reads Settings.app.temperatureUnit in C++, which QML
+        // can't capture as a binding dependency — reference it here so the shot-plan
+        // widget re-renders when the user toggles °C/°F.
+        void(Settings.app.temperatureUnit)
         var parts = []
         if (showProfile && profileName) {
             // Adaptive temperature rendering (single / list / ellipsis + delta tag).

--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -172,8 +172,8 @@ Item {
         if (!text) return ""
         var result = sanitizeHtml(text)
         // Machine
-        result = result.replace(/%TEMP%/g, typeof DE1Device !== "undefined" ? DE1Device.temperature.toFixed(1) : "—")
-        result = result.replace(/%STEAM_TEMP%/g, typeof DE1Device !== "undefined" ? DE1Device.steamTemperature.toFixed(0) + "\u00B0" : "—")
+        result = result.replace(/%TEMP%/g, typeof DE1Device !== "undefined" ? Theme.cToDisplay(DE1Device.temperature).toFixed(1) : "—")
+        result = result.replace(/%STEAM_TEMP%/g, typeof DE1Device !== "undefined" ? Theme.cToDisplay(DE1Device.steamTemperature).toFixed(0) + "\u00B0" : "—")
         result = result.replace(/%PRESSURE%/g, typeof DE1Device !== "undefined" ? DE1Device.pressure.toFixed(1) : "—")
         result = result.replace(/%FLOW%/g, typeof DE1Device !== "undefined" ? DE1Device.flow.toFixed(1) : "—")
         result = result.replace(/%WATER%/g, typeof DE1Device !== "undefined" ? DE1Device.waterLevel.toFixed(0) : "—")
@@ -188,7 +188,7 @@ Item {
         // Profile (ProfileManager)
         result = result.replace(/%TARGET_WEIGHT%/g, typeof ProfileManager !== "undefined" ? ProfileManager.targetWeight.toFixed(1) : "—")
         result = result.replace(/%PROFILE%/g, typeof ProfileManager !== "undefined" ? ProfileManager.currentProfileName : "—")
-        result = result.replace(/%TARGET_TEMP%/g, typeof ProfileManager !== "undefined" ? ProfileManager.profileTargetTemperature.toFixed(1) : "—")
+        result = result.replace(/%TARGET_TEMP%/g, typeof ProfileManager !== "undefined" ? Theme.cToDisplay(ProfileManager.profileTargetTemperature).toFixed(1) : "—")
         result = result.replace(/%RATIO%/g, typeof ProfileManager !== "undefined" ? ProfileManager.brewByRatio.toFixed(1) : "—")
         result = result.replace(/%DOSE%/g, typeof ProfileManager !== "undefined" ? ProfileManager.brewByRatioDose.toFixed(1) : "—")
         // Scale device

--- a/qml/components/layout/items/SteamTemperatureItem.qml
+++ b/qml/components/layout/items/SteamTemperatureItem.qml
@@ -24,8 +24,8 @@ Item {
     implicitHeight: isCompact ? compactContent.implicitHeight : fullContent.implicitHeight
 
     Accessible.role: Accessible.StaticText
-    Accessible.name: "Steam temperature: " + root.currentTemp.toFixed(0) +
-                     " degrees, target: " + root.targetTemp.toFixed(0) + " degrees"
+    Accessible.name: "Steam temperature: " + Theme.cToDisplay(root.currentTemp).toFixed(0) +
+                     " degrees, target: " + Theme.cToDisplay(root.targetTemp).toFixed(0) + " degrees"
     Accessible.focusable: true
 
     // --- COMPACT MODE (bar / status bar rendering) ---
@@ -52,7 +52,7 @@ Item {
             Text {
                 id: compactTemp
                 anchors.verticalCenter: parent.verticalCenter
-                text: DE1Device.connected ? root.currentTemp.toFixed(0) + "\u00B0C" : "\u2014"
+                text: DE1Device.connected ? Theme.formatTemperature(root.currentTemp, 0) : "\u2014"
                 color: root.readoutColor
                 font: Theme.bodyFont
             }
@@ -64,8 +64,8 @@ Item {
             onClicked: {
                 if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
                     AccessibilityManager.announceLabel(
-                        "Steam temperature: " + root.currentTemp.toFixed(0) +
-                        " degrees, target: " + root.targetTemp.toFixed(0) + " degrees")
+                        "Steam temperature: " + Theme.cToDisplay(root.currentTemp).toFixed(0) +
+                        " degrees, target: " + Theme.cToDisplay(root.targetTemp).toFixed(0) + " degrees")
                 }
             }
         }
@@ -96,13 +96,13 @@ Item {
                 Layout.alignment: Qt.AlignHCenter
                 spacing: Theme.scaled(4)
                 Text {
-                    text: DE1Device.connected ? root.currentTemp.toFixed(0) + "\u00B0C" : "\u2014"
+                    text: DE1Device.connected ? Theme.formatTemperature(root.currentTemp, 0) : "\u2014"
                     color: root.readoutColor
                     font: Theme.valueFont
                 }
                 Text {
                     anchors.baseline: parent.children[0].baseline
-                    text: "/ " + root.targetTemp.toFixed(0) + "\u00B0C"
+                    text: "/ " + Theme.formatTemperature(root.targetTemp, 0)
                     color: Theme.textSecondaryColor
                     font.family: Theme.valueFont.family
                     font.pixelSize: Theme.valueFont.pixelSize / 2
@@ -122,8 +122,8 @@ Item {
             onClicked: {
                 if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
                     AccessibilityManager.announceLabel(
-                        "Steam temperature: " + root.currentTemp.toFixed(0) +
-                        " degrees, target: " + root.targetTemp.toFixed(0) + " degrees")
+                        "Steam temperature: " + Theme.cToDisplay(root.currentTemp).toFixed(0) +
+                        " degrees, target: " + Theme.cToDisplay(root.targetTemp).toFixed(0) + " degrees")
                 }
             }
         }

--- a/qml/components/layout/items/TemperatureItem.qml
+++ b/qml/components/layout/items/TemperatureItem.qml
@@ -28,7 +28,7 @@ Item {
 
     Accessible.role: Accessible.StaticText
     Accessible.name: {
-        var text = "Group temperature: " + DE1Device.temperature.toFixed(1) + " degrees, target: " + root.effectiveTargetTemp.toFixed(0) + " degrees"
+        var text = "Group temperature: " + Theme.cToDisplay(DE1Device.temperature).toFixed(1) + " degrees, target: " + Theme.cToDisplay(root.effectiveTargetTemp).toFixed(0) + " degrees"
         if (root.isRealOverride) text += " (override active)"
         return text
     }
@@ -58,7 +58,7 @@ Item {
             Text {
                 id: compactTemp
                 anchors.verticalCenter: parent.verticalCenter
-                text: DE1Device.temperature.toFixed(1) + "\u00B0C"
+                text: Theme.formatTemperature(DE1Device.temperature, 1)
                 color: root.readoutColor
                 font: Theme.bodyFont
                 Accessible.ignored: true
@@ -71,7 +71,7 @@ Item {
             onClicked: {
                 MachineState.tareScale()
                 if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
-                    var announcement = "Group temperature: " + DE1Device.temperature.toFixed(1) + " degrees, target: " + root.effectiveTargetTemp.toFixed(0) + " degrees"
+                    var announcement = "Group temperature: " + Theme.cToDisplay(DE1Device.temperature).toFixed(1) + " degrees, target: " + Theme.cToDisplay(root.effectiveTargetTemp).toFixed(0) + " degrees"
                     if (root.isRealOverride) announcement += " (override active)"
                     AccessibilityManager.announceLabel(announcement)
                 }
@@ -104,14 +104,14 @@ Item {
                 Layout.alignment: Qt.AlignHCenter
                 spacing: Theme.scaled(4)
                 Text {
-                    text: DE1Device.temperature.toFixed(1) + "\u00B0C"
+                    text: Theme.formatTemperature(DE1Device.temperature, 1)
                     color: root.readoutColor
                     font: Theme.valueFont
                     Accessible.ignored: true
                 }
                 Text {
                     anchors.baseline: parent.children[0].baseline
-                    text: "/ " + root.effectiveTargetTemp.toFixed(1) + "\u00B0C"
+                    text: "/ " + Theme.formatTemperature(root.effectiveTargetTemp, 1)
                     color: root.isRealOverride ? Theme.accentColor : Theme.textSecondaryColor
                     font.family: Theme.valueFont.family
                     font.pixelSize: Theme.valueFont.pixelSize / 2
@@ -143,7 +143,7 @@ Item {
             anchors.fill: parent
             onClicked: {
                 if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
-                    var announcement = "Group temperature: " + DE1Device.temperature.toFixed(1) + " degrees, target: " + root.effectiveTargetTemp.toFixed(0) + " degrees"
+                    var announcement = "Group temperature: " + Theme.cToDisplay(DE1Device.temperature).toFixed(1) + " degrees, target: " + Theme.cToDisplay(root.effectiveTargetTemp).toFixed(0) + " degrees"
                     if (root.isRealOverride) announcement += " (override active)"
                     AccessibilityManager.announceLabel(announcement)
                 }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -3190,9 +3190,14 @@ ApplicationWindow {
         cleaned = cleaned.replace(/\.(json|tcl|txt)$/i, "")
         // Replace underscores and hyphens with spaces
         cleaned = cleaned.replace(/[_-]/g, " ")
-        // Expand units for natural speech
+        // Expand units for natural speech. Both the °C/°F symbols and a bare "88C"
+        // (common in Celsius-authored profile names like gagne_88C) always denote
+        // their own unit regardless of the display setting, so map them literally —
+        // the app's own converted read-outs always emit an explicit "°F"/"°C", never
+        // a bare number+C, so this never mislabels a converted value.
+        cleaned = cleaned.replace(/°F/g, " degrees Fahrenheit")
         cleaned = cleaned.replace(/°C/g, " degrees Celsius")
-        cleaned = cleaned.replace(/(\d)\s*C\b/g, "$1 degrees Celsius")  // "72C" -> "72 degrees Celsius"
+        cleaned = cleaned.replace(/(\d)\s*C\b/g, "$1 degrees Celsius")  // bare "88C" (Celsius-authored)
         cleaned = cleaned.replace(/(\d)\s*ml\b/gi, "$1 milliliters")
         cleaned = cleaned.replace(/(\d)\s*g\b/g, "$1 grams")
         cleaned = cleaned.replace(/(\d)\s*bar\b/gi, "$1 bar")

--- a/qml/pages/DescalingPage.qml
+++ b/qml/pages/DescalingPage.qml
@@ -601,7 +601,7 @@ Page {
                             Text {
                                 Layout.alignment: Qt.AlignHCenter
                                 property real temp: typeof DE1Device.steamTemperature === 'number' ? DE1Device.steamTemperature : 0
-                                text: temp.toFixed(0) + "°C"
+                                text: Theme.formatTemperature(temp, 0)
                                 font.pixelSize: Theme.scaled(36)
                                 font.weight: Font.Bold
                                 color: temp >= 60 ? Theme.errorColor : Theme.primaryColor

--- a/qml/pages/EspressoPage.qml
+++ b/qml/pages/EspressoPage.qml
@@ -41,7 +41,7 @@ Page {
             case 3: // Flow
                 return "Flow: " + DE1Device.flow.toFixed(1) + " milliliters per second"
             case 4: // Temperature
-                return "Temperature: " + DE1Device.temperature.toFixed(1) + " degrees"
+                return "Temperature: " + Theme.cToDisplay(DE1Device.temperature).toFixed(1) + " degrees"
             case 5: // Weight and/or Volume
                 var parts = []
                 if (MachineState.targetWeight > 0) parts.push(TranslationManager.translate("espresso.accessible.weight", "Weight:") + " " + espressoPage.currentWeight.toFixed(1) + " " + TranslationManager.translate("espresso.accessible.of", "of") + " " + MachineState.targetWeight.toFixed(0) + " " + TranslationManager.translate("espresso.accessible.grams", "grams"))
@@ -850,18 +850,17 @@ Page {
                 spacing: Theme.scaled(2)
 
                 Accessible.role: Accessible.StaticText
-                Accessible.name: TranslationManager.translate("espresso.accessible.temperature", "Temperature:") + " " + DE1Device.temperature.toFixed(1) + " " + TranslationManager.translate("espresso.accessible.degrees", "degrees")
+                Accessible.name: TranslationManager.translate("espresso.accessible.temperature", "Temperature:") + " " + Theme.cToDisplay(DE1Device.temperature).toFixed(1) + " " + TranslationManager.translate("espresso.accessible.degrees", "degrees")
 
                 Text {
-                    text: DE1Device.temperature.toFixed(1)
+                    text: Theme.cToDisplay(DE1Device.temperature).toFixed(1)
                     color: Theme.temperatureColor
                     font.pixelSize: Theme.scaled(28)
                     font.weight: Font.Medium
                     Accessible.ignored: true
                 }
-                Tr {
-                    key: "espresso.unit.celsius"
-                    fallback: "°C"
+                Text {
+                    text: Theme.tempUnitSuffix()
                     color: Theme.textSecondaryColor
                     font: Theme.captionFont
                     Accessible.ignored: true

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -713,20 +713,23 @@ Page {
                         ValueInput {
                             id: temperatureInput
                             Layout.preferredWidth: Theme.scaled(180)
-                            value: Settings.brew.waterTemperature
-                            from: 40
-                            to: 100
+                            // Stored in Celsius; shown and entered in the user's unit.
+                            value: Theme.cToDisplay(Settings.brew.waterTemperature)
+                            from: Theme.cToDisplay(40)
+                            to: Theme.cToDisplay(100)
                             stepSize: 1
-                            suffix: "°C"
+                            suffix: Theme.tempUnitSuffix()
                             valueColor: Theme.temperatureColor
                             accessibleName: TranslationManager.translate("hotwater.label.temperature", "Temperature")
                             KeyNavigation.tab: flowRateInput
                             KeyNavigation.backtab: volumeInput
 
                             onValueModified: function(newValue) {
-                                temperatureInput.value = newValue
-                                Settings.brew.waterTemperature = newValue
-                                saveCurrentVessel(volumeInput.value, flowRateInput.value, newValue)
+                                // Convert the entered display value back to Celsius for storage;
+                                // the bound value re-derives from the setting via cToDisplay.
+                                var celsius = Theme.displayToC(newValue)
+                                Settings.brew.waterTemperature = celsius
+                                saveCurrentVessel(volumeInput.value, flowRateInput.value, celsius)
                             }
                             onValueCommitted: MainController.applyHotWaterSettings()
                         }
@@ -797,7 +800,7 @@ Page {
         }
         Rectangle { width: 1; height: Theme.scaled(30); color: hotWaterBottomBar.contentColor; opacity: 0.3 }
         Text {
-            text: temperatureInput.value.toFixed(0) + "°C"
+            text: temperatureInput.value.toFixed(0) + Theme.tempUnitSuffix()
             color: hotWaterBottomBar.contentColor
             font: Theme.bodyFont
         }

--- a/qml/pages/ProfileEditorPage.qml
+++ b/qml/pages/ProfileEditorPage.qml
@@ -59,7 +59,7 @@ Page {
             } else {
                 parts.push(step.pressure.toFixed(2) + " bar")
             }
-            parts.push(step.temperature.toFixed(0) + " degrees")
+            parts.push(Theme.cToDisplay(step.temperature).toFixed(0) + " degrees")
             parts.push(step.seconds.toFixed(0) + " seconds")
             parts.push(step.transition === "smooth" ? "smooth transition" : "fast transition")
         } else {
@@ -77,7 +77,7 @@ Page {
                 }
             }
             if (step.temperature !== prev.temperature) {
-                parts.push(step.temperature.toFixed(0) + " degrees")
+                parts.push(Theme.cToDisplay(step.temperature).toFixed(0) + " degrees")
             }
             if (step.seconds !== prev.seconds) {
                 parts.push(step.seconds.toFixed(0) + " seconds")
@@ -346,8 +346,8 @@ Page {
                             text: {
                                 stepVersion
                                 if (!profile) return TranslationManager.translate("profileEditor.settings", "Settings")
-                                var temp = profile.steps.length > 0 ? profile.steps[0].temperature.toFixed(0) : "93"
-                                return TranslationManager.translate("profileEditor.settings", "Settings") + " (" + temp + "\u00B0C)"
+                                var temp = profile.steps.length > 0 ? Theme.formatTemperature(profile.steps[0].temperature, 0) : Theme.formatTemperature(93, 0)
+                                return TranslationManager.translate("profileEditor.settings", "Settings") + " (" + temp + ")"
                             }
                             accessibleName: TranslationManager.translate("profileEditor.openProfileSettings", "Open profile settings")
                             onClicked: profileSettingsPopup.open()
@@ -480,18 +480,20 @@ Page {
                 RowLayout { Layout.fillWidth: true
                     Text { text: TranslationManager.translate("profileEditor.allTemps", "All temps"); font: Theme.captionFont; color: Theme.textSecondaryColor }
                     Item { Layout.fillWidth: true }
-                    Text { text: stepVersion >= 0 && profile && profile.steps.length > 0 ? profile.steps[0].temperature.toFixed(1) + "\u00B0C" : "93.0\u00B0C"; font.family: Theme.captionFont.family; font.pixelSize: Theme.captionFont.pixelSize; font.bold: true; color: Theme.temperatureColor }
+                    Text { text: stepVersion >= 0 && profile && profile.steps.length > 0 ? Theme.formatTemperature(profile.steps[0].temperature, 1) : Theme.formatTemperature(93.0, 1); font.family: Theme.captionFont.family; font.pixelSize: Theme.captionFont.pixelSize; font.bold: true; color: Theme.temperatureColor }
                 }
                 ValueInput {
                     Layout.fillWidth: true; valueColor: Theme.temperatureColor
-                    accessibleName: TranslationManager.translate("profileEditor.globalTemperature", "Global temperature"); from: 70; to: 100; stepSize: 0.1; suffix: " °C"
-                    value: { stepVersion; return profile && profile.steps.length > 0 ? profile.steps[0].temperature : 93 }
+                    accessibleName: TranslationManager.translate("profileEditor.globalTemperature", "Global temperature"); from: Theme.cToDisplay(70); to: Theme.cToDisplay(100); stepSize: 0.1; suffix: Theme.tempUnitSuffix()
+                    // Stored in Celsius; shown and entered in the user's unit.
+                    value: { stepVersion; return Theme.cToDisplay(profile && profile.steps.length > 0 ? profile.steps[0].temperature : 93) }
                     // onValueModified mutates the profile per adjustment tick so the UI
                     // reflects the change live; onValueCommitted fires the BLE upload
                     // once on release instead of per tick.
                     onValueModified: function(newValue) {
                         if (profile && profile.steps.length > 0) {
-                            var rounded = Math.round(newValue * 10) / 10
+                            // newValue is in the display unit; convert to Celsius for storage.
+                            var rounded = Math.round(Theme.displayToC(newValue) * 10) / 10
                             var delta = rounded - profile.steps[0].temperature
                             for (var i = 0; i < profile.steps.length; i++) {
                                 profile.steps[i].temperature += delta
@@ -591,11 +593,12 @@ Page {
                 ValueInput {
                     Layout.preferredWidth: Theme.scaled(160); valueColor: Theme.temperatureColor
                     accessibleName: TranslationManager.translate("profileEditor.preheatTankAccessible", "Preheat water tank temperature")
-                    from: 0; to: 45; stepSize: 1; suffix: " °C"
-                    value: { stepVersion; return profile ? (profile.tank_desired_water_temperature ?? 0) : 0 }
+                    from: Theme.cToDisplay(0); to: Theme.cToDisplay(45); stepSize: 1; suffix: Theme.tempUnitSuffix()
+                    // Stored in Celsius; shown and entered in the user's unit.
+                    value: { stepVersion; return Theme.cToDisplay(profile ? (profile.tank_desired_water_temperature ?? 0) : 0) }
                     onValueModified: function(newValue) {
                         if (profile) {
-                            profile.tank_desired_water_temperature = Math.round(newValue)
+                            profile.tank_desired_water_temperature = Math.round(Theme.displayToC(newValue))
                         }
                     }
                     onValueCommitted: uploadProfile()
@@ -1221,7 +1224,7 @@ Page {
                 }
 
                 // Temperature
-                ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("profileEditor.stepTemperature", "Step temperature"); from: 70; to: 100; stepSize: 0.1; suffix: " °C"; value: stepVersion >= 0 && step ? step.temperature : 93; onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].temperature = Math.round(newValue * 10) / 10 } }; onValueCommitted: uploadProfile() }
+                ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("profileEditor.stepTemperature", "Step temperature"); from: Theme.cToDisplay(70); to: Theme.cToDisplay(100); stepSize: 0.1; suffix: Theme.tempUnitSuffix(); value: Theme.cToDisplay(stepVersion >= 0 && step ? step.temperature : 93); onValueModified: function(newValue) { if (profile && selectedStepIndex >= 0) { profile.steps[selectedStepIndex].temperature = Math.round(Theme.displayToC(newValue) * 10) / 10 } }; onValueCommitted: uploadProfile() }
 
                 // Sensor toggle
                 Text { text: TranslationManager.translate("profileEditor.sensor", "Sensor"); font: Theme.captionFont; color: Theme.textSecondaryColor }

--- a/qml/pages/ProfileInfoPage.qml
+++ b/qml/pages/ProfileInfoPage.qml
@@ -160,7 +160,7 @@ Page {
                             color: Theme.textSecondaryColor
                         }
                         Text {
-                            text: profileData ? (profileData.espresso_temperature || 0).toFixed(1) + " °C" : "-"
+                            text: profileData ? Theme.cToDisplay(profileData.espresso_temperature || 0).toFixed(1) + " " + Theme.tempUnitSuffix() : "-"
                             font: Theme.bodyFont
                             color: Theme.textColor
                         }

--- a/qml/pages/RecipeEditorPage.qml
+++ b/qml/pages/RecipeEditorPage.qml
@@ -426,7 +426,7 @@ Page {
 
                             // Temp
                             Text { text: TranslationManager.translate("recipeEditor.infuseTemp", "Temp"); font: Theme.captionFont; color: Theme.temperatureColor }
-                            ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("recipeEditor.infuseTemperature", "Infuse temperature"); from: 80; to: 100; stepSize: 0.1; suffix: " °C"; value: val(recipe.fillTemperature, 88); onValueModified: function(newValue) { updateRecipe("fillTemperature", Math.round(newValue * 10) / 10) } }
+                            ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("recipeEditor.infuseTemperature", "Infuse temperature"); from: Theme.cToDisplay(80); to: Theme.cToDisplay(100); stepSize: 0.1; suffix: Theme.tempUnitSuffix(); value: Theme.cToDisplay(val(recipe.fillTemperature, 88)); onValueModified: function(newValue) { updateRecipe("fillTemperature", Math.round(Theme.displayToC(newValue) * 10) / 10) } }
 
                             // Pressure
                             Text { text: TranslationManager.translate("recipeEditor.infusePressureLabel", "Pressure"); font: Theme.captionFont; color: Theme.pressureColor }
@@ -486,7 +486,7 @@ Page {
 
                             // Temp
                             Text { text: TranslationManager.translate("recipeEditor.pourTemp", "Temp"); font: Theme.captionFont; color: Theme.temperatureColor }
-                            ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("recipeEditor.pourTemperature", "Pour temperature"); from: 80; to: 100; stepSize: 0.1; suffix: " °C"; value: val(recipe.pourTemperature, 93); onValueModified: function(newValue) { updateRecipe("pourTemperature", Math.round(newValue * 10) / 10) } }
+                            ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("recipeEditor.pourTemperature", "Pour temperature"); from: Theme.cToDisplay(80); to: Theme.cToDisplay(100); stepSize: 0.1; suffix: Theme.tempUnitSuffix(); value: Theme.cToDisplay(val(recipe.pourTemperature, 93)); onValueModified: function(newValue) { updateRecipe("pourTemperature", Math.round(Theme.displayToC(newValue) * 10) / 10) } }
 
                             // Grouped: flow, pressure, and time (ramp time for A-Flow)
                             Item {

--- a/qml/pages/SimpleProfileEditorPage.qml
+++ b/qml/pages/SimpleProfileEditorPage.qml
@@ -336,7 +336,7 @@ Page {
                                 Item { Layout.fillWidth: true }
 
                                 Text {
-                                    text: val(recipe.pourTemperature, 90).toFixed(1) + "\u00B0C"
+                                    text: Theme.formatTemperature(val(recipe.pourTemperature, 90), 1)
                                     font.family: Theme.bodyFont.family
                                     font.pixelSize: Theme.bodyFont.pixelSize
                                     font.bold: true
@@ -378,9 +378,10 @@ Page {
                                 id: profileTempSlider
                                 Layout.fillWidth: true; valueColor: Theme.temperatureColor
                                 accessibleName: TranslationManager.translate("simpleProfileEditor.profileTemperature", "Profile temperature")
-                                from: 70; to: 100; stepSize: 0.1; suffix: " °C"
-                                value: val(recipe.pourTemperature, 90)
-                                onValueModified: function(newValue) { updateProfileTemp(Math.round(newValue * 10) / 10) }
+                                from: Theme.cToDisplay(70); to: Theme.cToDisplay(100); stepSize: 0.1; suffix: Theme.tempUnitSuffix()
+                                // Stored in Celsius; shown and entered in the user's unit.
+                                value: Theme.cToDisplay(val(recipe.pourTemperature, 90))
+                                onValueModified: function(newValue) { updateProfileTemp(Math.round(Theme.displayToC(newValue) * 10) / 10) }
                             }
 
                             // Dose
@@ -419,7 +420,7 @@ Page {
                                         radius: Theme.scaled(12); color: Qt.rgba(Theme.temperatureColor.r, Theme.temperatureColor.g, Theme.temperatureColor.b, 0.15)
                                         Accessible.role: Accessible.Button; Accessible.name: TranslationManager.translate("simpleProfileEditor.editPreinfuseTemperature", "Edit preinfuse temperature"); Accessible.focusable: true
                                         Accessible.onPressAction: tempPreinfuseArea.clicked(null)
-                                        Text { id: tempPreinfuseLabel; anchors.centerIn: parent; text: stepTemp("tempStart").toFixed(1) + "/" + stepTemp("tempPreinfuse").toFixed(1) + "\u00B0C"; font.family: Theme.captionFont.family; font.pixelSize: Theme.captionFont.pixelSize; color: Theme.temperatureColor; Accessible.ignored: true }
+                                        Text { id: tempPreinfuseLabel; anchors.centerIn: parent; text: Theme.cToDisplay(stepTemp("tempStart")).toFixed(1) + "/" + Theme.formatTemperature(stepTemp("tempPreinfuse"), 1); font.family: Theme.captionFont.family; font.pixelSize: Theme.captionFont.pixelSize; color: Theme.temperatureColor; Accessible.ignored: true }
                                         MouseArea { id: tempPreinfuseArea; anchors.fill: parent; onClicked: tempStepsDialog.open() }
                                     }
                                 }
@@ -465,7 +466,7 @@ Page {
                                         radius: Theme.scaled(12); color: Qt.rgba(Theme.temperatureColor.r, Theme.temperatureColor.g, Theme.temperatureColor.b, 0.15)
                                         Accessible.role: Accessible.Button; Accessible.name: TranslationManager.translate("simpleProfileEditor.editHoldTemperature", "Edit hold temperature"); Accessible.focusable: true
                                         Accessible.onPressAction: tempHoldArea.clicked(null)
-                                        Text { id: tempHoldLabel; anchors.centerIn: parent; text: stepTemp("tempHold").toFixed(1) + "\u00B0C"; font.family: Theme.captionFont.family; font.pixelSize: Theme.captionFont.pixelSize; color: Theme.temperatureColor; Accessible.ignored: true }
+                                        Text { id: tempHoldLabel; anchors.centerIn: parent; text: Theme.formatTemperature(stepTemp("tempHold"), 1); font.family: Theme.captionFont.family; font.pixelSize: Theme.captionFont.pixelSize; color: Theme.temperatureColor; Accessible.ignored: true }
                                         MouseArea { id: tempHoldArea; anchors.fill: parent; onClicked: tempStepsDialog.open() }
                                     }
                                 }
@@ -533,7 +534,7 @@ Page {
                                         radius: Theme.scaled(12); color: Qt.rgba(Theme.temperatureColor.r, Theme.temperatureColor.g, Theme.temperatureColor.b, 0.15)
                                         Accessible.role: Accessible.Button; Accessible.name: TranslationManager.translate("simpleProfileEditor.editDeclineTemperature", "Edit decline temperature"); Accessible.focusable: true
                                         Accessible.onPressAction: tempDeclineArea.clicked(null)
-                                        Text { id: tempDeclineLabel; anchors.centerIn: parent; text: stepTemp("tempDecline").toFixed(1) + "\u00B0C"; font.family: Theme.captionFont.family; font.pixelSize: Theme.captionFont.pixelSize; color: Theme.temperatureColor; Accessible.ignored: true }
+                                        Text { id: tempDeclineLabel; anchors.centerIn: parent; text: Theme.formatTemperature(stepTemp("tempDecline"), 1); font.family: Theme.captionFont.family; font.pixelSize: Theme.captionFont.pixelSize; color: Theme.temperatureColor; Accessible.ignored: true }
                                         MouseArea { id: tempDeclineArea; anchors.fill: parent; onClicked: tempStepsDialog.open() }
                                     }
                                 }
@@ -755,9 +756,9 @@ Page {
                         Layout.fillWidth: true
                         Text { text: tr("start", "Start"); font: Theme.bodyFont; color: Theme.textColor }
                         Item { Layout.fillWidth: true }
-                        Text { text: val(recipe.tempStart, 90).toFixed(1) + "\u00B0C"; font.family: Theme.bodyFont.family; font.pixelSize: Theme.bodyFont.pixelSize; font.bold: true; color: Theme.temperatureColor }
+                        Text { text: Theme.formatTemperature(val(recipe.tempStart, 90), 1); font.family: Theme.bodyFont.family; font.pixelSize: Theme.bodyFont.pixelSize; font.bold: true; color: Theme.temperatureColor }
                     }
-                    ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("simpleProfileEditor.startTemperature", "Start temperature"); from: 70; to: 100; stepSize: 0.1; suffix: " °C"; value: val(recipe.tempStart, 90); onValueModified: function(newValue) { updateRecipe("tempStart", Math.round(newValue * 10) / 10) } }
+                    ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("simpleProfileEditor.startTemperature", "Start temperature"); from: Theme.cToDisplay(70); to: Theme.cToDisplay(100); stepSize: 0.1; suffix: Theme.tempUnitSuffix(); value: Theme.cToDisplay(val(recipe.tempStart, 90)); onValueModified: function(newValue) { updateRecipe("tempStart", Math.round(Theme.displayToC(newValue) * 10) / 10) } }
                 }
 
                 // 1: Preinfuse
@@ -768,9 +769,9 @@ Page {
                         Layout.fillWidth: true
                         Text { text: "1: " + tr("preinfuse", "Preinfuse"); font: Theme.bodyFont; color: Theme.textColor }
                         Item { Layout.fillWidth: true }
-                        Text { text: val(recipe.tempPreinfuse, 90).toFixed(1) + "\u00B0C"; font.family: Theme.bodyFont.family; font.pixelSize: Theme.bodyFont.pixelSize; font.bold: true; color: Theme.temperatureColor }
+                        Text { text: Theme.formatTemperature(val(recipe.tempPreinfuse, 90), 1); font.family: Theme.bodyFont.family; font.pixelSize: Theme.bodyFont.pixelSize; font.bold: true; color: Theme.temperatureColor }
                     }
-                    ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("simpleProfileEditor.preinfuseTemperature", "Preinfuse temperature"); from: 70; to: 100; stepSize: 0.1; suffix: " °C"; value: val(recipe.tempPreinfuse, 90); onValueModified: function(newValue) { updateRecipe("tempPreinfuse", Math.round(newValue * 10) / 10) } }
+                    ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("simpleProfileEditor.preinfuseTemperature", "Preinfuse temperature"); from: Theme.cToDisplay(70); to: Theme.cToDisplay(100); stepSize: 0.1; suffix: Theme.tempUnitSuffix(); value: Theme.cToDisplay(val(recipe.tempPreinfuse, 90)); onValueModified: function(newValue) { updateRecipe("tempPreinfuse", Math.round(Theme.displayToC(newValue) * 10) / 10) } }
                 }
 
                 // 2: Hold / Rise and Hold
@@ -781,9 +782,9 @@ Page {
                         Layout.fillWidth: true
                         Text { text: isFlow ? ("2: " + tr("hold", "Hold")) : ("2: " + tr("riseAndHold", "Rise and Hold")); font: Theme.bodyFont; color: Theme.textColor }
                         Item { Layout.fillWidth: true }
-                        Text { text: val(recipe.tempHold, 90).toFixed(1) + "\u00B0C"; font.family: Theme.bodyFont.family; font.pixelSize: Theme.bodyFont.pixelSize; font.bold: true; color: Theme.temperatureColor }
+                        Text { text: Theme.formatTemperature(val(recipe.tempHold, 90), 1); font.family: Theme.bodyFont.family; font.pixelSize: Theme.bodyFont.pixelSize; font.bold: true; color: Theme.temperatureColor }
                     }
-                    ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: isFlow ? TranslationManager.translate("simpleProfileEditor.holdTemperature", "Hold temperature") : TranslationManager.translate("simpleProfileEditor.riseAndHoldTemperature", "Rise and hold temperature"); from: 70; to: 100; stepSize: 0.1; suffix: " °C"; value: val(recipe.tempHold, 90); onValueModified: function(newValue) { updateRecipe("tempHold", Math.round(newValue * 10) / 10) } }
+                    ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: isFlow ? TranslationManager.translate("simpleProfileEditor.holdTemperature", "Hold temperature") : TranslationManager.translate("simpleProfileEditor.riseAndHoldTemperature", "Rise and hold temperature"); from: Theme.cToDisplay(70); to: Theme.cToDisplay(100); stepSize: 0.1; suffix: Theme.tempUnitSuffix(); value: Theme.cToDisplay(val(recipe.tempHold, 90)); onValueModified: function(newValue) { updateRecipe("tempHold", Math.round(Theme.displayToC(newValue) * 10) / 10) } }
                 }
 
                 // 3: Decline
@@ -794,9 +795,9 @@ Page {
                         Layout.fillWidth: true
                         Text { text: "3: " + tr("decline", "Decline"); font: Theme.bodyFont; color: Theme.textColor }
                         Item { Layout.fillWidth: true }
-                        Text { text: val(recipe.tempDecline, 90).toFixed(1) + "\u00B0C"; font.family: Theme.bodyFont.family; font.pixelSize: Theme.bodyFont.pixelSize; font.bold: true; color: Theme.temperatureColor }
+                        Text { text: Theme.formatTemperature(val(recipe.tempDecline, 90), 1); font.family: Theme.bodyFont.family; font.pixelSize: Theme.bodyFont.pixelSize; font.bold: true; color: Theme.temperatureColor }
                     }
-                    ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("simpleProfileEditor.declineTemperature", "Decline temperature"); from: 70; to: 100; stepSize: 0.1; suffix: " °C"; value: val(recipe.tempDecline, 90); onValueModified: function(newValue) { updateRecipe("tempDecline", Math.round(newValue * 10) / 10) } }
+                    ValueInput { Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("simpleProfileEditor.declineTemperature", "Decline temperature"); from: Theme.cToDisplay(70); to: Theme.cToDisplay(100); stepSize: 0.1; suffix: Theme.tempUnitSuffix(); value: Theme.cToDisplay(val(recipe.tempDecline, 90)); onValueModified: function(newValue) { updateRecipe("tempDecline", Math.round(Theme.displayToC(newValue) * 10) / 10) } }
                 }
 
                 AccessibleButton {

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -35,7 +35,9 @@ Page {
                 steamPage.syncSteamTimeout()
                 Settings.brew.steamFlow = getCurrentPitcherFlow()
                 Settings.brew.steamTemperature = getCurrentPitcherTemperature()
-                steamTempSlider.value = getCurrentPitcherTemperature()
+                // steamTempSlider.value re-derives from Settings.brew.steamTemperature
+                // via its cToDisplay binding — no imperative write (that would freeze
+                // the binding at an untagged display-unit snapshot).
                 // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
                 // startSteamHeating clears steamDisabled flag automatically
                 MainController.startSteamHeating("steampage-activated")
@@ -234,7 +236,10 @@ Page {
     function saveCurrentPitcher(duration, flow, temperature) {
         var name = getCurrentPitcherName()
         if (name && !isCurrentPitcherDisabled()) {
-            var temp = (temperature !== undefined) ? temperature : steamTempSlider.value
+            // temperature (when provided) is Celsius; otherwise fall back to the
+            // stored (Celsius) steam temperature — never the display widget, whose
+            // value carries no unit tag once read imperatively.
+            var temp = (temperature !== undefined) ? temperature : Settings.brew.steamTemperature
             Settings.brew.updateSteamPitcherPreset(Settings.brew.selectedSteamPitcher, name, duration, flow, temp)
         }
     }
@@ -763,7 +768,7 @@ Page {
                         // Show temperature during heating, countdown during puffing, time during steaming
                         text: {
                             if (isSteamHeating) {
-                                return Math.round(currentSteamTemp) + "°C / " + Math.round(targetSteamTemp) + "°C"
+                                return Theme.formatTemperature(currentSteamTemp, 0) + " / " + Theme.formatTemperature(targetSteamTemp, 0)
                             } else if (isPuffing && root.steamAutoFlushCountdown > 0) {
                                 return root.steamAutoFlushCountdown.toFixed(1) + "s / " + Settings.brew.steamAutoFlushSeconds + "s"
                             } else {
@@ -948,7 +953,7 @@ Page {
                     Text {
                         text: {
                             if (isSteamHeating) {
-                                return Math.round(currentSteamTemp) + "°C / " + Math.round(targetSteamTemp) + "°C"
+                                return Theme.formatTemperature(currentSteamTemp, 0) + " / " + Theme.formatTemperature(targetSteamTemp, 0)
                             } else if (isPuffing && root.steamAutoFlushCountdown > 0) {
                                 return root.steamAutoFlushCountdown.toFixed(1) + "s / " + Settings.brew.steamAutoFlushSeconds + "s"
                             } else {
@@ -968,7 +973,7 @@ Page {
                     }
 
                     Text {
-                        text: Math.round(currentSteamTemp) + "°C"
+                        text: Theme.formatTemperature(currentSteamTemp, 0)
                         color: Theme.temperatureColor
                         font: Theme.subtitleFont
                         Accessible.ignored: true
@@ -1110,7 +1115,7 @@ Page {
 
                     // Temperature display
                     Text {
-                        text: currentSteamTemp.toFixed(0) + " / " + targetSteamTemp.toFixed(0) + "°C"
+                        text: Theme.cToDisplay(currentSteamTemp).toFixed(0) + " / " + Theme.formatTemperature(targetSteamTemp, 0)
                         color: Theme.textSecondaryColor
                         font.pixelSize: Theme.scaled(14)
                     }
@@ -1555,22 +1560,28 @@ Page {
                         ValueInput {
                             id: steamTempSlider
                             Layout.preferredWidth: Theme.scaled(180)
-                            from: 120
-                            to: 170
+                            from: Theme.cToDisplay(120)
+                            to: Theme.cToDisplay(170)
                             stepSize: 1
                             decimals: 0
-                            suffix: "°C"
-                            value: Settings.brew.steamTemperature
+                            suffix: Theme.tempUnitSuffix()
+                            // Stored in Celsius; shown and entered in the user's unit.
+                            value: Theme.cToDisplay(Settings.brew.steamTemperature)
                             valueColor: Theme.temperatureColor
                             accessibleName: TranslationManager.translate("steam.label.temperature", "Steam Temperature")
                             KeyNavigation.tab: pitcherWeightInput
                             KeyNavigation.backtab: flowSlider
                             onValueModified: function(newValue) {
-                                steamTempSlider.value = newValue
-                                saveCurrentPitcher(durationSlider.value, flowSlider.value, newValue)
+                                // newValue is in the display unit. Write through in Celsius;
+                                // the value binding re-derives from Settings.brew.steamTemperature
+                                // (updated via saveCurrentPitcher's preset-changed signal), so we
+                                // never imperatively write the slider — that would freeze its
+                                // binding at an untagged display-unit snapshot.
+                                saveCurrentPitcher(durationSlider.value, flowSlider.value, Theme.displayToC(newValue))
                             }
                             onValueCommitted: function(newValue) {
-                                MainController.setSteamTemperatureImmediate(newValue)
+                                // Convert the entered display value back to Celsius for storage.
+                                MainController.setSteamTemperatureImmediate(Theme.displayToC(newValue))
                             }
                         }
                     }
@@ -2155,7 +2166,7 @@ Page {
         }
         Rectangle { width: 1; height: Theme.scaled(30); color: Theme.primaryContrastColor; opacity: 0.3 }
         Text {
-            text: steamTempSlider.value.toFixed(0) + "°C"
+            text: steamTempSlider.value.toFixed(0) + Theme.tempUnitSuffix()
             color: Theme.primaryContrastColor
             font: Theme.bodyFont
         }
@@ -2444,7 +2455,7 @@ Page {
             // sets selectedSteamPitcher, so the subsequent startSteamHeating/
             // applySteamSettings push the per-pitcher temperature to the machine.
             var temp = getCurrentPitcherTemperature()
-            steamTempSlider.value = temp
+            // Slider re-derives from steamTemperature via its cToDisplay binding.
             Settings.brew.steamTemperature = temp
         }
         function onSteamPitcherPresetsChanged() {
@@ -2455,7 +2466,7 @@ Page {
             // applySteamSettings (back-navigation, keepSteamHeaterOn) pushes the
             // current value rather than a stale one.
             var temp = getCurrentPitcherTemperature()
-            steamTempSlider.value = temp
+            // Slider re-derives from steamTemperature via its cToDisplay binding.
             Settings.brew.steamTemperature = temp
         }
     }

--- a/qml/pages/settings/SettingsCalibrationTab.qml
+++ b/qml/pages/settings/SettingsCalibrationTab.qml
@@ -542,7 +542,7 @@ Item {
 
                                 Text {
                                     text: TranslationManager.translate("settings.calibration.steamTemperature", "Temperature") +
-                                          ": " + SteamHealthTracker.currentTemperature.toFixed(0) + "°C"
+                                          ": " + Theme.formatTemperature(SteamHealthTracker.currentTemperature, 0)
                                     color: {
                                         var range = SteamHealthTracker.temperatureThreshold - SteamHealthTracker.baselineTemperature
                                         if (range <= 0) return Theme.textColor
@@ -560,8 +560,8 @@ Item {
                                 Item { Layout.fillWidth: true }
 
                                 Text {
-                                    text: SteamHealthTracker.baselineTemperature.toFixed(0) + " — " +
-                                          SteamHealthTracker.temperatureThreshold.toFixed(0) + "°C"
+                                    text: Theme.cToDisplay(SteamHealthTracker.baselineTemperature).toFixed(0) + " — " +
+                                          Theme.formatTemperature(SteamHealthTracker.temperatureThreshold, 0)
                                     color: Theme.textSecondaryColor
                                     font.family: Theme.bodyFont.family
                                     font.pixelSize: Theme.scaled(11)
@@ -760,7 +760,10 @@ Item {
 
                 // Heater idle temperature
                 Text { text: TranslationManager.translate("settings.calibration.heaterIdleTemp", "Heater idle temperature"); font: Theme.captionFont; color: Theme.temperatureColor }
-                ValueInput { id: heaterIdleTempSlider; Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("settings.calibration.heaterIdleTemp", "Heater idle temperature"); from: 0; to: 990; stepSize: 5; displayText: (value / 10).toFixed(1) + "\u00B0C"; rangeText: "0.0\u00B0C \u2014 99.0\u00B0C"; value: Settings.hardware.heaterIdleTemp; onValueModified: function(newValue) { Settings.hardware.heaterIdleTemp = Math.round(newValue) }; KeyNavigation.tab: heaterWarmupFlowSlider; KeyNavigation.backtab: doneButton }
+                // Slider mechanics stay in the internal scaled-integer space (value = \u00B0C \u00D7 10,
+                // 0\u2013990). Only the human-readable \u00B0C/\u00B0F label is unit-converted: value/10 is the
+                // Celsius reading, fed through cToDisplay; the stored scaled int is untouched.
+                ValueInput { id: heaterIdleTempSlider; Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("settings.calibration.heaterIdleTemp", "Heater idle temperature"); from: 0; to: 990; stepSize: 5; displayText: Theme.cToDisplay(value / 10).toFixed(1) + Theme.tempUnitSuffix(); rangeText: Theme.formatTemperature(0, 1) + " \u2014 " + Theme.formatTemperature(99, 1); value: Settings.hardware.heaterIdleTemp; onValueModified: function(newValue) { Settings.hardware.heaterIdleTemp = Math.round(newValue) }; KeyNavigation.tab: heaterWarmupFlowSlider; KeyNavigation.backtab: doneButton }
 
                 // Heater warmup flow rate
                 Text { text: TranslationManager.translate("settings.calibration.heaterWarmupFlow", "Heater warmup flow rate"); font: Theme.captionFont; color: Theme.flowColor }
@@ -777,7 +780,11 @@ Item {
                 // Fan temperature threshold: 0 = "Always on" (fan runs continuously,
                 // matching DE1 firmware default); 1–60 suppresses fan below that temp.
                 Text { text: TranslationManager.translate("settings.calibration.fanThreshold", "Fan temperature threshold"); font: Theme.captionFont; color: Theme.temperatureColor }
-                ValueInput { id: fanThresholdSlider; Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("settings.calibration.fanThreshold", "Fan temperature threshold"); from: 0; to: 60; stepSize: 1; displayText: value === 0 ? TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on") : value + "°C"; rangeText: TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on") + " — 60°C"; value: Settings.hardware.fanThreshold; onValueModified: function(newValue) { Settings.hardware.fanThreshold = Math.round(newValue) }; KeyNavigation.tab: defaultsButton; KeyNavigation.backtab: heaterTestTimeoutSlider }
+                // The slider value stays in Celsius: 0 is the "Always on" sentinel (0°C == 32°F,
+                // so a unit-converted from/to would make the sentinel unreachable in Fahrenheit).
+                // Only the displayed threshold label is unit-converted (cToDisplay(value)); the
+                // stored Celsius value and the 0 sentinel are untouched.
+                ValueInput { id: fanThresholdSlider; Layout.fillWidth: true; valueColor: Theme.temperatureColor; accessibleName: TranslationManager.translate("settings.calibration.fanThreshold", "Fan temperature threshold"); from: 0; to: 60; stepSize: 1; displayText: value === 0 ? TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on") : Theme.formatTemperature(value, 0); rangeText: TranslationManager.translate("settings.calibration.fanAlwaysOn", "Always on") + " — " + Theme.formatTemperature(60, 0); value: Settings.hardware.fanThreshold; onValueModified: function(newValue) { Settings.hardware.fanThreshold = Math.round(newValue) }; KeyNavigation.tab: defaultsButton; KeyNavigation.backtab: heaterTestTimeoutSlider }
 
                 Rectangle { Layout.fillWidth: true; height: 1; color: Theme.borderColor }
 

--- a/qml/pages/settings/SettingsMachineTab.qml
+++ b/qml/pages/settings/SettingsMachineTab.qml
@@ -268,7 +268,7 @@ KeyboardAwareContainer {
 
                         Text {
                             property real temp: typeof DE1Device.steamTemperature === 'number' ? DE1Device.steamTemperature : 0
-                            text: TranslationManager.translate("settings.preferences.current", "Current:") + " " + temp.toFixed(0) + "°C"
+                            text: TranslationManager.translate("settings.preferences.current", "Current:") + " " + Theme.formatTemperature(temp, 0)
                             color: Theme.textSecondaryColor
                             font.family: Theme.bodyFont.family
                             font.pixelSize: Theme.scaled(12)
@@ -1088,6 +1088,55 @@ KeyboardAwareContainer {
                                 accessibleName: TranslationManager.translate("settings.options.showInMl", "Show in milliliters")
                                 onToggled: {
                                     Settings.app.waterLevelDisplayUnit = checked ? "ml" : "percent"
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Temperature display unit (Celsius / Fahrenheit). Storage stays Celsius;
+                // this only changes how temps are shown and entered across the app.
+                Rectangle {
+                    id: temperatureUnitCard
+                    objectName: "temperatureUnit"
+                    Layout.fillWidth: true
+                    implicitHeight: tempUnitContent.implicitHeight + Theme.scaled(30)
+                    color: Theme.surfaceColor
+                    radius: Theme.cardRadius
+
+                    ColumnLayout {
+                        id: tempUnitContent
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        anchors.margins: Theme.scaled(15)
+                        spacing: Theme.scaled(8)
+
+                        Text {
+                            text: TranslationManager.translate("settings.options.temperatureUnit", "Temperature unit")
+                            color: Theme.textColor
+                            font.family: Theme.bodyFont.family
+                            font.pixelSize: Theme.scaled(16)
+                            font.bold: true
+                        }
+
+                        RowLayout {
+                            Layout.fillWidth: true
+
+                            Text {
+                                Layout.fillWidth: true
+                                text: TranslationManager.translate("settings.options.showInFahrenheit", "Show temperatures in Fahrenheit (°F)")
+                                color: Theme.textColor
+                                font.family: Theme.bodyFont.family
+                                font.pixelSize: Theme.scaled(14)
+                                wrapMode: Text.WordWrap
+                            }
+
+                            StyledSwitch {
+                                checked: Settings.app.temperatureUnit === "fahrenheit"
+                                accessibleName: TranslationManager.translate("settings.options.showInFahrenheitAccessible", "Show temperatures in Fahrenheit")
+                                onToggled: {
+                                    Settings.app.temperatureUnit = checked ? "fahrenheit" : "celsius"
                                 }
                             }
                         }

--- a/src/controllers/profilemanager.cpp
+++ b/src/controllers/profilemanager.cpp
@@ -2719,7 +2719,9 @@ QString ProfileManager::temperatureDisplay(double anchorTemp, bool hasOverride,
     temps.reserve(static_cast<qsizetype>(m_currentProfile.steps().size()));
     for (const ProfileFrame& f : m_currentProfile.steps())
         temps.append(f.temperature);
-    return TemperatureDisplay::format(temps, anchorTemp, hasOverride, overrideTemp);
+    const bool fahrenheit = m_settings && m_settings->app()
+        && m_settings->app()->temperatureUnit() == QLatin1String("fahrenheit");
+    return TemperatureDisplay::format(temps, anchorTemp, hasOverride, overrideTemp, fahrenheit);
 }
 
 void ProfileManager::migrateProfileFolders() {

--- a/src/core/settings_app.cpp
+++ b/src/core/settings_app.cpp
@@ -479,6 +479,27 @@ void SettingsApp::setWaterLevelDisplayUnit(const QString& unit) {
     }
 }
 
+// Temperature display unit. Default Celsius; all internal storage stays Celsius.
+QString SettingsApp::temperatureUnit() const {
+    return m_settings.value("display/temperatureUnit", "celsius").toString();
+}
+
+void SettingsApp::setTemperatureUnit(const QString& unit) {
+    // Normalise + whitelist so a malformed value (e.g. from an imported settings
+    // file during device-to-device migration) can't be stored and silently
+    // re-exported as garbage. Anything outside {celsius, fahrenheit} degrades to
+    // celsius — loudly, not silently.
+    QString normalized = unit.trimmed().toLower();
+    if (normalized != QLatin1String("celsius") && normalized != QLatin1String("fahrenheit")) {
+        qWarning() << "SettingsApp: invalid temperatureUnit" << unit << "- coercing to celsius";
+        normalized = QStringLiteral("celsius");
+    }
+    if (temperatureUnit() != normalized) {
+        m_settings.setValue("display/temperatureUnit", normalized);
+        emit temperatureUnitChanged();
+    }
+}
+
 int SettingsApp::waterRefillPoint() const {
     return m_settings.value("water/refillPoint", 5).toInt();
 }

--- a/src/core/settings_app.h
+++ b/src/core/settings_app.h
@@ -57,6 +57,7 @@ class SettingsApp : public QObject {
 
     // Water level / refill
     Q_PROPERTY(QString waterLevelDisplayUnit READ waterLevelDisplayUnit WRITE setWaterLevelDisplayUnit NOTIFY waterLevelDisplayUnitChanged)
+    Q_PROPERTY(QString temperatureUnit READ temperatureUnit WRITE setTemperatureUnit NOTIFY temperatureUnitChanged)
 
     // Water refill level (mm threshold for refill warning, sent to machine)
     Q_PROPERTY(int waterRefillPoint READ waterRefillPoint WRITE setWaterRefillPoint NOTIFY waterRefillPointChanged)
@@ -140,6 +141,11 @@ public:
     // Water level / refill
     QString waterLevelDisplayUnit() const;
     void setWaterLevelDisplayUnit(const QString& unit);
+
+    // Temperature display unit ("celsius" or "fahrenheit"). Storage stays Celsius;
+    // this only affects display/entry.
+    QString temperatureUnit() const;
+    void setTemperatureUnit(const QString& unit);
     int waterRefillPoint() const;
     void setWaterRefillPoint(int mm);
     int refillKitOverride() const;
@@ -180,6 +186,7 @@ signals:
     void firmwareNightlyChannelChanged();
     void dailyBackupHourChanged();
     void waterLevelDisplayUnitChanged();
+    void temperatureUnitChanged();
     void waterRefillPointChanged();
     void refillKitOverrideChanged();
     void developerTranslationUploadChanged();

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -198,6 +198,7 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
     // runtime state (e.g. dimmed during screensaver) that would cause the
     // importing device to inherit an inappropriate brightness level (#495)
     ui["waterLevelDisplayUnit"] = settings->app()->waterLevelDisplayUnit();
+    ui["temperatureUnit"] = settings->app()->temperatureUnit();
 
     // Custom font sizes
     QJsonObject fontSizes;
@@ -647,6 +648,7 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         if (ui.contains("skin")) settings->theme()->setSkin(ui["skin"].toString());
         // screenBrightness intentionally skipped on import — device-local runtime state (#495)
         if (ui.contains("waterLevelDisplayUnit")) settings->app()->setWaterLevelDisplayUnit(ui["waterLevelDisplayUnit"].toString());
+        if (ui.contains("temperatureUnit")) settings->app()->setTemperatureUnit(ui["temperatureUnit"].toString());
 
         if (ui.contains("customFontSizes")) {
             QVariantMap sizes;

--- a/src/profile/temperaturedisplay.cpp
+++ b/src/profile/temperaturedisplay.cpp
@@ -19,7 +19,6 @@ QString deltaTag(double delta) {
     return sign + num(std::fabs(delta)) + QStringLiteral("°"); // °
 }
 
-const QString kDegC    = QStringLiteral("°C");   // °C
 const QString kListSep = QStringLiteral(" · ");   // separates the two distinct temps; a SPACED mid-dot (a comma reads as a decimal point, a tight "·" / slash read as a decimal / fraction)
 const QString kEllip   = QStringLiteral("…");     // …
 
@@ -41,18 +40,24 @@ int distinctCount(const QVector<double>& stepTemps) {
 }
 
 QString format(const QVector<double>& stepTemps, double anchorTemp,
-               bool hasOverride, double overrideTemp) {
+               bool hasOverride, double overrideTemp, bool fahrenheit) {
+    // Display-unit conversion: absolute temps shift origin (×9/5 +32); a delta/offset
+    // scales only (×9/5). Storage is always Celsius; this is display-only.
+    const auto disp = [fahrenheit](double c) { return fahrenheit ? (c * 9.0 / 5.0 + 32.0) : c; };
+    const auto dispDelta = [fahrenheit](double d) { return fahrenheit ? (d * 9.0 / 5.0) : d; };
+    const QString suffix = fahrenheit ? QStringLiteral("°F") : QStringLiteral("°C");
+
     const double delta = hasOverride ? (overrideTemp - anchorTemp) : 0.0;
     // Show the override as the OFFSET that will be applied to every step (e.g.
     // "+1°"), not as recomputed per-step values. This expresses "all steps +1°"
     // directly and never recomputes/misrepresents a "first temp". Suppressed when
     // the delta rounds to zero.
     const QString tag = (hasOverride && std::fabs(delta) >= 0.05)
-        ? QStringLiteral(" ") + deltaTag(delta) : QString();
+        ? QStringLiteral(" ") + deltaTag(dispDelta(delta)) : QString();
 
     // The base is the profile's own temperature(s), unshifted.
     if (stepTemps.isEmpty())
-        return num(anchorTemp) + kDegC + tag;
+        return num(disp(anchorTemp)) + suffix + tag;
 
     // Distinct values in first-seen (trajectory) order.
     QVector<double> distinct;
@@ -67,11 +72,11 @@ QString format(const QVector<double>& stepTemps, double anchorTemp,
 
     QString base;
     if (distinct.size() <= 1)
-        base = num(stepTemps.first()) + kDegC;                                   // N=1: single value
+        base = num(disp(stepTemps.first())) + suffix;                                       // N=1: single value
     else if (distinct.size() == 2)
-        base = num(distinct[0]) + kListSep + num(distinct[1]) + kDegC;           // N=2: spaced mid-dot list
+        base = num(disp(distinct[0])) + kListSep + num(disp(distinct[1])) + suffix;         // N=2: spaced mid-dot list
     else
-        base = num(stepTemps.first()) + kEllip + num(stepTemps.last()) + kDegC;  // N>=3: first…last
+        base = num(disp(stepTemps.first())) + kEllip + num(disp(stepTemps.last())) + suffix; // N>=3: first…last
     return base + tag;
 }
 

--- a/src/profile/temperaturedisplay.h
+++ b/src/profile/temperaturedisplay.h
@@ -15,9 +15,11 @@
 // When an override is active a signed delta tag is appended ("90 · 88°C +1°"),
 // expressing "all steps +1°" directly rather than recomputing per-step values.
 //
+// The `fahrenheit` argument converts the values and swaps the unit symbol to °F
+// (the numeric examples above are the default Celsius rendering).
 // Logic lives here (not in QML) so it is unit-testable; the output carries no
-// translatable words (only numbers, °C, separators and the delta tag), so the
-// callers compose any surrounding labels.
+// translatable words (only numbers, the °C/°F unit symbol, separators and the
+// delta tag), so the callers compose any surrounding labels.
 namespace TemperatureDisplay {
 
 // Number of distinct temperatures among the frames (within 0.05°C tolerance).
@@ -30,7 +32,9 @@ int distinctCount(const QVector<double>& stepTemps);
 //                 stepTemps is empty
 //   hasOverride – whether a brew temperature override is active
 //   overrideTemp– the active override value (ignored when !hasOverride)
+//   fahrenheit  – when true the (Celsius) inputs are converted to °F for display
+//                 (absolute ×9/5+32, delta ×9/5) and the unit symbol becomes °F
 QString format(const QVector<double>& stepTemps, double anchorTemp,
-               bool hasOverride, double overrideTemp);
+               bool hasOverride, double overrideTemp, bool fahrenheit = false);
 
 } // namespace TemperatureDisplay

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -75,6 +75,7 @@ private:
     QString m_origDyeBeanBaseId;
     QString m_origDyeBeanBaseData;
     double m_origWaterTemperature;
+    QString m_origTemperatureUnit;
     QByteArray m_origVesselPresets;
     QByteArray m_origPitcherPresets;
 
@@ -97,6 +98,7 @@ private slots:
         m_origDyeBeanBaseId = m_settings.dye()->dyeBeanBaseId();
         m_origDyeBeanBaseData = m_settings.dye()->dyeBeanBaseData();
         m_origWaterTemperature = m_settings.brew()->waterTemperature();
+        m_origTemperatureUnit = m_settings.app()->temperatureUnit();
         { QSettings raw("DecentEspresso", "DE1Qt");
           m_origVesselPresets = raw.value("water/vesselPresets").toByteArray();
           m_origPitcherPresets = raw.value("steam/pitcherPresets").toByteArray(); }
@@ -119,6 +121,7 @@ private slots:
         m_settings.dye()->setDyeBeanBaseId(m_origDyeBeanBaseId);
         m_settings.dye()->setDyeBeanBaseData(m_origDyeBeanBaseData);
         m_settings.brew()->setWaterTemperature(m_origWaterTemperature);
+        m_settings.app()->setTemperatureUnit(m_origTemperatureUnit);
         { QSettings raw("DecentEspresso", "DE1Qt");
           raw.setValue("water/vesselPresets", m_origVesselPresets);
           raw.setValue("steam/pitcherPresets", m_origPitcherPresets);
@@ -417,6 +420,62 @@ private slots:
         QVERIFY(SettingsSerializer::importFromJson(&m_settings, bundle));
 
         QCOMPARE(m_settings.brew()->getWaterVesselPreset(idx)["temperature"].toDouble(), 92.0);
+    }
+
+    void temperatureUnitRoundTrip() {
+        // The display temperature unit must survive an export -> import cycle. The
+        // serializer's export/import key strings are hand-mirrored, so a typo on
+        // either side would silently drop the setting during device-to-device
+        // migration — this asserts both sides agree.
+        m_settings.app()->setTemperatureUnit("fahrenheit");
+        QCOMPARE(m_settings.app()->temperatureUnit(), QString("fahrenheit"));
+
+        const QJsonObject bundle = SettingsSerializer::exportToJson(&m_settings, false);
+
+        // Mutate to confirm import actually overwrites it (not a silent no-op).
+        m_settings.app()->setTemperatureUnit("celsius");
+        QCOMPARE(m_settings.app()->temperatureUnit(), QString("celsius"));
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(QStringLiteral("SettingsSerializer: importFromJson replacing .* favorites")));
+        QVERIFY(SettingsSerializer::importFromJson(&m_settings, bundle));
+
+        QCOMPARE(m_settings.app()->temperatureUnit(), QString("fahrenheit"));
+    }
+
+    void temperatureUnitSetterRejectsGarbage() {
+        // setTemperatureUnit whitelists {celsius, fahrenheit}: it normalises case and
+        // whitespace to a valid value, and coerces anything else to celsius (loudly)
+        // so imported garbage can't persist or re-export.
+        m_settings.app()->setTemperatureUnit("celsius");
+        // Case/whitespace normalise to a valid value — no warning, stored lowercased.
+        m_settings.app()->setTemperatureUnit("  Fahrenheit ");
+        QCOMPARE(m_settings.app()->temperatureUnit(), QString("fahrenheit"));
+        // An unknown unit coerces to celsius, with a warning.
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(QStringLiteral("invalid temperatureUnit")));
+        m_settings.app()->setTemperatureUnit("kelvin");
+        QCOMPARE(m_settings.app()->temperatureUnit(), QString("celsius"));
+    }
+
+    void temperatureUnitEmitsOnChangeOnly() {
+        // The setter's `if (temperatureUnit() != normalized)` guard must emit exactly
+        // once on a real change and stay silent on a no-op set.
+        m_settings.app()->setTemperatureUnit("celsius");
+        QSignalSpy spy(m_settings.app(), &SettingsApp::temperatureUnitChanged);
+        m_settings.app()->setTemperatureUnit("fahrenheit");   // change -> 1 emit
+        QCOMPARE(spy.count(), 1);
+        m_settings.app()->setTemperatureUnit("fahrenheit");   // no-op -> no further emit
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void temperatureUnitDefaultIsCelsius() {
+        // On fresh state (key absent) the getter default must be "celsius".
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          raw.remove("display/temperatureUnit");
+          raw.sync(); }
+        QCOMPARE(m_settings.app()->temperatureUnit(), QString("celsius"));
+        // cleanup() restores the original via m_origTemperatureUnit.
     }
 
     void waterVesselPresetLegacyTemperatureFallsBackToGlobal() {

--- a/tests/tst_temperaturedisplay.cpp
+++ b/tests/tst_temperaturedisplay.cpp
@@ -7,6 +7,7 @@ using namespace TemperatureDisplay;
 
 // Text literals used by the formatter, mirrored here so the test reads clearly.
 static const QString DEG   = QStringLiteral("°C");
+static const QString DEGF  = QStringLiteral("°F");
 static const QString SEP   = QStringLiteral(" · ");
 static const QString ELLIP = QStringLiteral("…");
 
@@ -109,6 +110,51 @@ private slots:
     void fractionalFormatting() {
         QCOMPARE(format({88.5, 93}, 88.5, false, 0),
                  QStringLiteral("88.5") + SEP + QStringLiteral("93") + DEG);
+    }
+
+    // ===== Fahrenheit conversion (fahrenheit = true) =====
+    // Absolute values convert ×9/5+32; the delta tag scales ×9/5 (no +32 shift);
+    // the sub-threshold suppression stays keyed in Celsius. These guard the classic
+    // C/F trap where a refactor funnelling absolute + delta through one converter
+    // would render "+33.8°" instead of "+1.8°".
+    void fahrenheitSingleAbsolute() {
+        // 93°C → 199.4°F
+        QCOMPARE(format({93, 93}, 93, false, 0, true), QStringLiteral("199.4") + DEGF);
+    }
+    void fahrenheitDeltaScalesNotShifts() {
+        // 90°C → 194°F; delta +1°C → +1.8°F (scaled, not +33.8°)
+        QCOMPARE(format({90, 90, 90}, 90, true, 91, true),
+                 QStringLiteral("194") + DEGF + QStringLiteral(" +1.8°"));
+    }
+    void fahrenheitNegativeDelta() {
+        // 90,85 → 194,185; delta -2°C → -3.6°F
+        QCOMPARE(format({90, 85}, 90, true, 88, true),
+                 QStringLiteral("194") + SEP + QStringLiteral("185") + DEGF + QStringLiteral(" -3.6°"));
+    }
+    void fahrenheitTwoListConvertsBoth() {
+        // 88,93 → 190.4,199.4
+        QCOMPARE(format({88, 93}, 88, false, 0, true),
+                 QStringLiteral("190.4") + SEP + QStringLiteral("199.4") + DEGF);
+    }
+    void fahrenheitEllipsisConvertsBothEndpoints() {
+        // 84…52 → 183.2…125.6
+        QCOMPARE(format({84, 79, 52}, 84, false, 0, true),
+                 QStringLiteral("183.2") + ELLIP + QStringLiteral("125.6") + DEGF);
+    }
+    void fahrenheitEmptyFallsBackToAnchor() {
+        // empty → anchor 93 → 199.4°F; delta +1°C → +1.8°F
+        QCOMPARE(format({}, 93, true, 94, true),
+                 QStringLiteral("199.4") + DEGF + QStringLiteral(" +1.8°"));
+    }
+    void fahrenheitSuppressionGateStaysCelsius() {
+        // 0.04°C delta (= 0.072°F) is below the Celsius suppression threshold → no tag,
+        // even though 0.072 would exceed a naive 0.05°F gate.
+        QCOMPARE(format({90, 90}, 90, true, 90.04, true), QStringLiteral("194") + DEGF);
+    }
+    void fahrenheitDefaultArgMatchesFalse() {
+        // the fahrenheit=false default must behave exactly like explicit false
+        QCOMPARE(format({88, 93}, 88, true, 90),
+                 format({88, 93}, 88, true, 90, false));
     }
 };
 


### PR DESCRIPTION
## Summary

Adds a **Celsius / Fahrenheit** display option (default Celsius). All temperatures stay **stored in Celsius**; only display and entry convert. Integrates with the shared temperature formatter introduced in #1392.

## Why

Users outside Celsius regions want to read and enter temperatures in Fahrenheit. The DE1 protocol and all stored data are Celsius, so this is purely a display/entry layer — no data-format change.

## Core

**`SettingsApp` (`settings_app.h/.cpp`, `settingsserializer.cpp`)**
- New `Q_PROPERTY(QString temperatureUnit … NOTIFY temperatureUnitChanged)` (values `"celsius"` / `"fahrenheit"`, default `"celsius"`, stored under `display/temperatureUnit`). Serialised in export/import.

**`Theme.qml` helpers (reactive — they read the setting, which has a NOTIFY)**
- `tempIsFahrenheit()`, `tempUnitSuffix()` → `"°C"`/`"°F"`.
- `cToDisplay(c)` / `displayToC(v)` — absolute conversion (×9/5 +32).
- `cDeltaToDisplay(d)` / `displayToCDelta(d)` — **delta** conversion (×9/5, **no** +32 origin shift; a +4 °C offset is a +7.2 °F offset). Used by the brew-dialog temperature offset control.
- `formatTemperature(c, decimals)` → "92°C" / "198°F".

**`SettingsMachineTab.qml`** — a "Temperature unit" toggle in Settings → Machine.

## Integration with #1392 (shared temperature formatter)

#1392 introduced `TemperatureDisplay::format()` (used by the shot plan and Brew Settings dialog via `ProfileManager.temperatureDisplay`) and made the brew-temp control a **delta** ("+4°").

- **`src/profile/temperaturedisplay.{h,cpp}`**: added a `bool fahrenheit = false` parameter to `format()`. Absolute temps convert via ×9/5+32, the override delta tag via ×9/5, and the suffix becomes °F/°C. The function **stays pure** — the unit is passed in, not read from `Settings` inside it (preserving unit-testability). The default argument keeps existing callers/tests compiling.
- **`src/controllers/profilemanager.cpp`**: `temperatureDisplay()` reads `Settings.app.temperatureUnit()` and passes the flag, so QML callers get unit-aware output without changing their calls.
- **`BrewDialog.qml`**: the temperature **delta** control now displays/accepts the offset in the chosen unit (bounds and value via `cDeltaToDisplay`, stored back via `displayToCDelta`); the "Profile:" line reads `Settings.app.temperatureUnit` so it re-evaluates on toggle (the C++ formatter's unit read isn't a QML-capturable dependency).

## Display & input sites converted

- **Read-outs:** home temperature + steam-temperature widgets, espresso page, profile info, descaling steam readout, hot water, the `%TEMP%`/`%STEAM_TEMP%`/`%TARGET_TEMP%` custom-widget variables, and screen-reader speech ("degrees Fahrenheit" in `main.qml`).
- **Inputs (round-trip):** brew dialog, profile editor (global/step/preheat), simple-profile editor (all stages), recipe editor, hot water, steam-temp slider. Each shows/accepts in the unit and stores Celsius (`displayToC` on write, `cToDisplay` on bounds/value).
- **Calibration sliders** (`SettingsCalibrationTab.qml`): the heater-idle slider stores a scaled integer (°C×10) and the fan-threshold has a `0` = "always on" sentinel — these convert the **displayed label only**, leaving the slider mechanics in Celsius so calibration storage and the sentinel are unaffected.

## Testing

On-device: toggle the unit and every converted read-out updates live; entering a value in °F stores the correct Celsius (verified round-trip by toggling back); the brew-dialog offset reads/accepts in °F (a +4 °C offset shows +7°F); calibration sliders show °F labels without changing stored calibration.

## Notes for the reviewer

- Storage stays Celsius throughout; this is display/entry only.
- Out-of-scope (left Celsius, not regressions): graph axes, shot-history/comparison tables, and `DescalingPage`'s prose "80-100°C" instruction literal — possible follow-ups.
- Built on top of #1392 (already in `main`); touches `temperaturedisplay`/`profilemanager`/`BrewDialog`. Also touches `CustomItem.qml` and `main.qml`, in different sections from the UI-presentation and action-button PRs — independent (no stacking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
