### PR TITLE
fix(hotwater): store water temperature per vessel preset

### DIFF
--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -20,6 +20,7 @@ Page {
             Settings.brew.waterVolume = getCurrentVesselVolume()
             Settings.brew.waterVolumeMode = getCurrentVesselMode()
             Settings.hardware.hotWaterFlowRate = getCurrentVesselFlowRate()
+            Settings.brew.waterTemperature = getCurrentVesselTemperature()
             MainController.applyHotWaterSettings()
             // Tare immediately so display shows 0g instead of current scale weight.
             if (!isVolumeMode) {
@@ -58,12 +59,35 @@ Page {
         return (preset && preset.flowRate !== undefined) ? preset.flowRate : 40
     }
 
-    // Save current vessel with all parameters
-    function saveCurrentVessel(volume, flowRate) {
+    function getCurrentVesselTemperature() {
+        var preset = Settings.brew.getWaterVesselPreset(Settings.brew.selectedWaterVessel)
+        return (preset && preset.temperature !== undefined) ? preset.temperature : Settings.brew.waterTemperature
+    }
+
+    // Save current vessel with all parameters. Temperature defaults to the
+    // current input so callers that only change volume/flow keep the preset's temp.
+    function saveCurrentVessel(volume, flowRate, temperature) {
         var name = getCurrentVesselName()
         if (name) {
-            Settings.brew.updateWaterVesselPreset(Settings.brew.selectedWaterVessel, name, volume, Settings.brew.waterVolumeMode, flowRate)
+            var temp = (temperature !== undefined) ? temperature : temperatureInput.value
+            Settings.brew.updateWaterVesselPreset(Settings.brew.selectedWaterVessel, name, volume, Settings.brew.waterVolumeMode, flowRate, temp)
         }
+    }
+
+    // Select a vessel preset and load all of its parameters into the inputs.
+    // Legacy presets with no stored temperature fall back to the current value.
+    function selectVessel(index, vesselData) {
+        var flow = (vesselData.flowRate !== undefined) ? vesselData.flowRate : 40
+        var temp = (vesselData.temperature !== undefined) ? vesselData.temperature : Settings.brew.waterTemperature
+        Settings.brew.selectedWaterVessel = index
+        volumeInput.value = vesselData.volume
+        flowRateInput.value = flow
+        temperatureInput.value = temp
+        Settings.brew.waterVolume = vesselData.volume
+        Settings.brew.waterVolumeMode = (vesselData.mode || "weight")
+        Settings.hardware.hotWaterFlowRate = flow
+        Settings.brew.waterTemperature = temp
+        MainController.applyHotWaterSettings()
     }
 
     ColumnLayout {
@@ -360,33 +384,15 @@ Page {
                                     Accessible.description: TranslationManager.translate("hotwater.accessibility.presetHint", "Double-tap or long-press to rename.")
                                     Accessible.focusable: true
                                     Accessible.onPressAction: {
-                                        Settings.brew.selectedWaterVessel = vesselDelegate.vesselIndex
-                                        volumeInput.value = modelData.volume
-                                        flowRateInput.value = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
-                                        Settings.brew.waterVolume = modelData.volume
-                                        Settings.brew.waterVolumeMode = (modelData.mode || "weight")
-                                        Settings.hardware.hotWaterFlowRate = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
-                                        MainController.applyHotWaterSettings()
+                                        selectVessel(vesselDelegate.vesselIndex, modelData)
                                     }
 
                                     Keys.onReturnPressed: {
-                                        Settings.brew.selectedWaterVessel = vesselDelegate.vesselIndex
-                                        volumeInput.value = modelData.volume
-                                        flowRateInput.value = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
-                                        Settings.brew.waterVolume = modelData.volume
-                                        Settings.brew.waterVolumeMode = (modelData.mode || "weight")
-                                        Settings.hardware.hotWaterFlowRate = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
-                                        MainController.applyHotWaterSettings()
+                                        selectVessel(vesselDelegate.vesselIndex, modelData)
                                         event.accepted = true
                                     }
                                     Keys.onSpacePressed: {
-                                        Settings.brew.selectedWaterVessel = vesselDelegate.vesselIndex
-                                        volumeInput.value = modelData.volume
-                                        flowRateInput.value = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
-                                        Settings.brew.waterVolume = modelData.volume
-                                        Settings.brew.waterVolumeMode = (modelData.mode || "weight")
-                                        Settings.hardware.hotWaterFlowRate = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
-                                        MainController.applyHotWaterSettings()
+                                        selectVessel(vesselDelegate.vesselIndex, modelData)
                                         event.accepted = true
                                     }
                                     Keys.onLeftPressed: {
@@ -451,13 +457,7 @@ Page {
                                             holdTimer.stop()
                                             if (!moved && !held) {
                                                 // Simple click - select the vessel
-                                                Settings.brew.selectedWaterVessel = vesselDelegate.vesselIndex
-                                                volumeInput.value = modelData.volume
-                                                flowRateInput.value = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
-                                                Settings.brew.waterVolume = modelData.volume
-                                                Settings.brew.waterVolumeMode = (modelData.mode || "weight")
-                                                Settings.hardware.hotWaterFlowRate = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
-                                                MainController.applyHotWaterSettings()
+                                                selectVessel(vesselDelegate.vesselIndex, modelData)
                                             }
                                             vesselPill.Drag.drop()
                                             vesselPresetsRow.draggedIndex = -1
@@ -691,7 +691,7 @@ Page {
 
                     Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3 }
 
-                    // Temperature (global setting)
+                    // Temperature (per-preset)
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(16)
@@ -721,6 +721,7 @@ Page {
                             onValueModified: function(newValue) {
                                 temperatureInput.value = newValue
                                 Settings.brew.waterTemperature = newValue
+                                saveCurrentVessel(volumeInput.value, flowRateInput.value, newValue)
                             }
                             onValueCommitted: MainController.applyHotWaterSettings()
                         }
@@ -921,7 +922,7 @@ Page {
                     onClicked: {
                         Qt.inputMethod.commit()
                         var preset = Settings.brew.getWaterVesselPreset(editingVesselIndex)
-                        Settings.brew.updateWaterVesselPreset(editingVesselIndex, editVesselNameInput.text, preset.volume, preset.mode || "weight", (preset.flowRate !== undefined) ? preset.flowRate : 40)
+                        Settings.brew.updateWaterVesselPreset(editingVesselIndex, editVesselNameInput.text, preset.volume, preset.mode || "weight", (preset.flowRate !== undefined) ? preset.flowRate : 40, (preset.temperature !== undefined) ? preset.temperature : Settings.brew.waterTemperature)
                         editVesselPopup.close()
                     }
                 }
@@ -1034,7 +1035,7 @@ Page {
                     onClicked: {
                         Qt.inputMethod.commit()
                         if (newVesselNameInput.text.length > 0) {
-                            Settings.brew.addWaterVesselPreset(newVesselNameInput.text, 200, "weight", 40)
+                            Settings.brew.addWaterVesselPreset(newVesselNameInput.text, 200, "weight", 40, Settings.brew.waterTemperature)
                             newVesselNameInput.text = ""
                             addVesselDialog.close()
                         }

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -65,7 +65,7 @@ Page {
     }
 
     // Save current vessel with all parameters. Temperature defaults to the
-    // current input so callers that only change volume/flow keep the preset's temp.
+    // current temperature input so callers that only change volume/flow keep it.
     function saveCurrentVessel(volume, flowRate, temperature) {
         var name = getCurrentVesselName()
         if (name) {
@@ -77,6 +77,10 @@ Page {
     // Select a vessel preset and load all of its parameters into the inputs.
     // Legacy presets with no stored temperature fall back to the current value.
     function selectVessel(index, vesselData) {
+        // getWaterVesselPreset() returns an empty {} for an out-of-range index;
+        // bail rather than write undefined volume/mode into Settings.
+        if (!vesselData || vesselData.volume === undefined)
+            return
         var flow = (vesselData.flowRate !== undefined) ? vesselData.flowRate : 40
         var temp = (vesselData.temperature !== undefined) ? vesselData.temperature : Settings.brew.waterTemperature
         Settings.brew.selectedWaterVessel = index
@@ -174,6 +178,7 @@ Page {
                                 Settings.brew.waterVolume = modelData.volume
                                 Settings.brew.waterVolumeMode = (modelData.mode ?? "weight")
                                 Settings.hardware.hotWaterFlowRate = (modelData.flowRate !== undefined) ? modelData.flowRate : 40
+                                Settings.brew.waterTemperature = (modelData.temperature !== undefined) ? modelData.temperature : Settings.brew.waterTemperature
                                 MainController.applyHotWaterSettings()
                             }
                         }
@@ -1036,6 +1041,11 @@ Page {
                         Qt.inputMethod.commit()
                         if (newVesselNameInput.text.length > 0) {
                             Settings.brew.addWaterVesselPreset(newVesselNameInput.text, 200, "weight", 40, Settings.brew.waterTemperature)
+                            // Select the just-added preset (appended at the end) and load its
+                            // values into the inputs, so edits apply to the new preset rather
+                            // than the previously-selected one.
+                            var newIndex = Settings.brew.waterVesselPresets.length - 1
+                            selectVessel(newIndex, Settings.brew.getWaterVesselPreset(newIndex))
                             newVesselNameInput.text = ""
                             addVesselDialog.close()
                         }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -175,9 +175,9 @@ Page {
     Timer { id: idleBeanCaptureTimer; interval: 3500; onTriggered: idlePage.beanCaptureShown = false }
     StableWeightCapture {
         id: beanCapture
-        rawWeight: ScaleDevice.connected ? MachineState.scaleWeight : 0
+        rawWeight: (ScaleDevice && ScaleDevice.connected) ? MachineState.scaleWeight : 0
         cupWeight: Settings.brew.doseCupTareWeight
-        active: ScaleDevice.connected && !ScaleDevice.isFlowScale
+        active: ScaleDevice && ScaleDevice.connected && !ScaleDevice.isFlowScale
                 && idlePage.activePresetFunction !== "steam"
                 && idlePage.activePresetFunction !== "hotwater"
                 && idlePage.activePresetFunction !== "flush"
@@ -227,7 +227,7 @@ Page {
         // empty-pitcher weight (cupWeight) gives net milk, robust to an un-zeroed
         // scale. Auto-capture requires a saved pitcher weight (cupWeight > 0),
         // symmetric with beans requiring a saved dose-cup tare.
-        rawWeight: (ScaleDevice.connected && !ScaleDevice.isFlowScale) ? MachineState.scaleWeight : 0
+        rawWeight: (ScaleDevice && ScaleDevice.connected && !ScaleDevice.isFlowScale) ? MachineState.scaleWeight : 0
         cupWeight: {
             var p = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
             return (p && !p.disabled) ? (p.pitcherWeightG ?? 0) : 0
@@ -241,7 +241,7 @@ Page {
         active: Settings.brew.milkAutoCaptureEnabled
                 && idlePage.activePresetFunction === "steam"
                 && idlePage.StackView.status === StackView.Active
-                && ScaleDevice.connected && !ScaleDevice.isFlowScale
+                && ScaleDevice && ScaleDevice.connected && !ScaleDevice.isFlowScale
         minNet: 50   // nobody steams < 50 g milk; floor also keeps a bean cup from tripping milk capture
         maxNet: 1500
         tolerance: 1.5
@@ -545,7 +545,7 @@ Page {
                     supportLongPress: true
 
                     pillSuffixFn: function(index) {
-                        if (!ScaleDevice.connected || ScaleDevice.isFlowScale) return ""
+                        if (!ScaleDevice || !ScaleDevice.connected || ScaleDevice.isFlowScale) return ""
                         var preset = Settings.brew.steamPitcherPresets[index]
                         if (!preset) return ""
                         var pitcherWeight = preset.pitcherWeightG ?? 0
@@ -571,7 +571,7 @@ Page {
                             // truth in SettingsBrew. Net milk on the scale now, or the last
                             // measured weight if the pitcher was lifted to the wand.
                             var idx = Settings.brew.selectedSteamPitcher
-                            var milk = (ScaleDevice.connected && !ScaleDevice.isFlowScale)
+                            var milk = (ScaleDevice && ScaleDevice.connected && !ScaleDevice.isFlowScale)
                                        ? Settings.brew.netMilkForPitcher(idx, MachineState.scaleWeight) : 0
                             if (milk <= 0)
                                 milk = idlePage.measuredMilkG
@@ -723,7 +723,7 @@ Page {
                     // saved the auto-capture is off, so the readout/prompt stays hidden.
                     Row {
                         anchors.horizontalCenter: parent.horizontalCenter
-                        visible: ScaleDevice.connected && !ScaleDevice.isFlowScale
+                        visible: ScaleDevice && ScaleDevice.connected && !ScaleDevice.isFlowScale
                                  && Settings.brew.doseCupTareWeight > 0
                         spacing: Theme.scaled(8)
 

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -537,7 +537,7 @@ void SettingsBrew::setSelectedWaterCup(int index) {
     }
 }
 
-void SettingsBrew::addWaterVesselPreset(const QString& name, int volume, const QString& mode, int flowRate) {
+void SettingsBrew::addWaterVesselPreset(const QString& name, int volume, const QString& mode, int flowRate, double temperature) {
     QByteArray data = m_settings.value("water/vesselPresets").toByteArray();
     QJsonDocument doc = QJsonDocument::fromJson(data);
     QJsonArray arr = doc.array();
@@ -547,13 +547,14 @@ void SettingsBrew::addWaterVesselPreset(const QString& name, int volume, const Q
     preset["volume"] = volume;
     preset["mode"] = mode;
     preset["flowRate"] = flowRate;
+    preset["temperature"] = temperature;
     arr.append(preset);
 
     m_settings.setValue("water/vesselPresets", QJsonDocument(arr).toJson());
     emit waterVesselPresetsChanged();
 }
 
-void SettingsBrew::updateWaterVesselPreset(int index, const QString& name, int volume, const QString& mode, int flowRate) {
+void SettingsBrew::updateWaterVesselPreset(int index, const QString& name, int volume, const QString& mode, int flowRate, double temperature) {
     QByteArray data = m_settings.value("water/vesselPresets").toByteArray();
     QJsonDocument doc = QJsonDocument::fromJson(data);
     QJsonArray arr = doc.array();
@@ -564,6 +565,7 @@ void SettingsBrew::updateWaterVesselPreset(int index, const QString& name, int v
         preset["volume"] = volume;
         preset["mode"] = mode;
         preset["flowRate"] = flowRate;
+        preset["temperature"] = temperature;
         arr[index] = preset;
 
         m_settings.setValue("water/vesselPresets", QJsonDocument(arr).toJson());

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -185,8 +185,8 @@ public:
     int selectedWaterVessel() const;
     void setSelectedWaterCup(int index);
 
-    Q_INVOKABLE void addWaterVesselPreset(const QString& name, int volume, const QString& mode = "weight", int flowRate = 40);
-    Q_INVOKABLE void updateWaterVesselPreset(int index, const QString& name, int volume, const QString& mode = "weight", int flowRate = 40);
+    Q_INVOKABLE void addWaterVesselPreset(const QString& name, int volume, const QString& mode = "weight", int flowRate = 40, double temperature = 85.0);
+    Q_INVOKABLE void updateWaterVesselPreset(int index, const QString& name, int volume, const QString& mode = "weight", int flowRate = 40, double temperature = 85.0);
     Q_INVOKABLE void removeWaterVesselPreset(int index);
     Q_INVOKABLE void moveWaterVesselPreset(int from, int to);
     Q_INVOKABLE QVariantMap getWaterVesselPreset(int index) const;

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -509,9 +509,14 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
             QJsonArray presets = water["vesselPresets"].toArray();
             for (const QJsonValue& v : presets) {
                 QJsonObject p = v.toObject();
+                // Legacy presets predate the per-preset temperature field; fall back to
+                // the device's current global hot-water temperature (matches the export
+                // side) rather than a hard-coded literal.
+                double presetTemp = p.contains("temperature") ? p["temperature"].toDouble()
+                                                              : settings->brew()->waterTemperature();
                 settings->brew()->addWaterVesselPreset(p["name"].toString(), p["volume"].toInt(),
                                                p["mode"].toString("weight"), p["flowRate"].toInt(40),
-                                               p["temperature"].toDouble(85.0));
+                                               presetTemp);
             }
         }
     }

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -110,6 +110,8 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
         p["volume"] = m["volume"].toInt();
         p["mode"] = m["mode"].toString();
         p["flowRate"] = m["flowRate"].toInt();
+        p["temperature"] = m.contains("temperature") ? m["temperature"].toDouble()
+                                                      : settings->brew()->waterTemperature();
         vesselPresets.append(p);
     }
     water["vesselPresets"] = vesselPresets;
@@ -508,7 +510,8 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
             for (const QJsonValue& v : presets) {
                 QJsonObject p = v.toObject();
                 settings->brew()->addWaterVesselPreset(p["name"].toString(), p["volume"].toInt(),
-                                               p["mode"].toString("weight"), p["flowRate"].toInt(40));
+                                               p["mode"].toString("weight"), p["flowRate"].toInt(40),
+                                               p["temperature"].toDouble(85.0));
             }
         }
     }

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -11,6 +11,8 @@
 #include "core/settings_visualizer.h"
 #include "core/settingsserializer.h"
 #include <QJsonObject>
+#include <QJsonArray>
+#include <QJsonDocument>
 #include <QRegularExpression>
 
 // Test Settings property round-trip and signal emission.
@@ -72,6 +74,8 @@ private:
     int m_origAutoLoadRevertMinutes;
     QString m_origDyeBeanBaseId;
     QString m_origDyeBeanBaseData;
+    double m_origWaterTemperature;
+    QByteArray m_origVesselPresets;
 
 private slots:
 
@@ -91,6 +95,9 @@ private slots:
         m_origAutoLoadRevertMinutes = m_settings.app()->autoLoadRevertMinutes();
         m_origDyeBeanBaseId = m_settings.dye()->dyeBeanBaseId();
         m_origDyeBeanBaseData = m_settings.dye()->dyeBeanBaseData();
+        m_origWaterTemperature = m_settings.brew()->waterTemperature();
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          m_origVesselPresets = raw.value("water/vesselPresets").toByteArray(); }
     }
 
     void cleanup() {
@@ -109,6 +116,10 @@ private slots:
         m_settings.app()->setAutoLoadRevertMinutes(m_origAutoLoadRevertMinutes);
         m_settings.dye()->setDyeBeanBaseId(m_origDyeBeanBaseId);
         m_settings.dye()->setDyeBeanBaseData(m_origDyeBeanBaseData);
+        m_settings.brew()->setWaterTemperature(m_origWaterTemperature);
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          raw.setValue("water/vesselPresets", m_origVesselPresets);
+          raw.sync(); }
     }
 
     // ==========================================
@@ -383,6 +394,52 @@ private slots:
         QVERIFY(SettingsSerializer::importFromJson(&m_settings, bundle));
         QCOMPARE(m_settings.app()->autoLoadProfileFilename(), QString("preferred-profile"));
         QCOMPARE(m_settings.app()->autoLoadRevertMinutes(), 17);
+    }
+
+    void waterVesselPresetTemperatureRoundTrip() {
+        // Per-preset hot-water temperature must survive an export -> import cycle.
+        m_settings.brew()->addWaterVesselPreset("Tea", 250, "weight", 40, 92.0);
+        const int idx = static_cast<int>(m_settings.brew()->waterVesselPresets().size()) - 1;
+
+        QJsonObject bundle = SettingsSerializer::exportToJson(&m_settings, false);
+
+        // Mutate the preset's temperature to confirm import overwrites it.
+        m_settings.brew()->updateWaterVesselPreset(idx, "Tea", 250, "weight", 40, 70.0);
+        QCOMPARE(m_settings.brew()->getWaterVesselPreset(idx)["temperature"].toDouble(), 70.0);
+
+        // importFromJson emits an expected favorites-replacement warning (see
+        // autoLoadBundleRoundTrip) — suppress it for the no-warnings-in-tests rule.
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(QStringLiteral("SettingsSerializer: importFromJson replacing .* favorites")));
+        QVERIFY(SettingsSerializer::importFromJson(&m_settings, bundle));
+
+        QCOMPARE(m_settings.brew()->getWaterVesselPreset(idx)["temperature"].toDouble(), 92.0);
+    }
+
+    void waterVesselPresetLegacyTemperatureFallsBackToGlobal() {
+        // A preset object that predates the per-preset temperature field (no
+        // "temperature" key) must export with the device's current global
+        // hot-water temperature, not 0 — this guards the migration fallback in
+        // SettingsSerializer::exportToJson.
+        QJsonObject legacy;
+        legacy["name"] = "Legacy";
+        legacy["volume"] = 200;
+        legacy["mode"] = "weight";
+        legacy["flowRate"] = 40;
+        QJsonArray arr; arr.append(legacy);
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          raw.setValue("water/vesselPresets", QJsonDocument(arr).toJson());
+          raw.sync(); }
+
+        // Read through a fresh Settings instance so it picks up the raw write
+        // (avoids a stale per-instance QSettings cache).
+        Settings fresh;
+        fresh.brew()->setWaterTemperature(88.0);
+        const QJsonObject bundle = SettingsSerializer::exportToJson(&fresh, false);
+
+        const QJsonArray exported = bundle["water"].toObject()["vesselPresets"].toArray();
+        QCOMPARE(exported.size(), 1);
+        QCOMPARE(exported[0].toObject()["temperature"].toDouble(), 88.0);
     }
 
     // ==========================================


### PR DESCRIPTION
Closes #1398

## Problem

Creating a new hot water profile (vessel preset) and setting a temperature changed the temperature for **all** existing hot water profiles. Each preset stored its own `volume`, `mode`, and `flowRate`, but temperature lived in a single global setting (`water/temperature`) shared by every preset. Switching presets also never restored a per-preset temperature.

## Fix

Make hot water temperature per-preset, mirroring how `volume` already works (each preset persists its own value; the active `Settings.brew.waterTemperature` is loaded from / saved to the selected preset and sent to the machine).

**C++**
- `addWaterVesselPreset` / `updateWaterVesselPreset` gain a `temperature` parameter and persist it in the preset JSON (`src/core/settings_brew.{h,cpp}`).
- Settings export/import round-trips the per-preset temperature (`src/core/settingsserializer.cpp`); legacy presets without the field fall back to the global value on export.

**QML (`qml/pages/HotWaterPage.qml`)**
- New `selectVessel()` helper loads volume/mode/flow **and temperature** from a preset; the four duplicated selection blocks (accessibility press, Return, Space, mouse click) now call it.
- Temperature input, `saveCurrentVessel()`, page activation, add-preset, and rename all carry temperature through.

**Migration:** legacy presets have no `temperature` field, so they fall back to the current value on first load — no surprise jumps for existing users.

## Also included

Guard all `ScaleDevice` references in `qml/pages/IdlePage.qml` with the codebase-standard `ScaleDevice && …` null check. `ScaleDevice` is a context property that reads `null` briefly at startup, which was throwing `TypeError: Cannot read property 'connected' of null` on launch. Verified the rest of the QML tree already guards its `ScaleDevice` access.

## Testing

- Build verified in Qt Creator by the author.
- Manual: switching presets changes the shown/active temperature; editing a temperature only affects the selected preset; new presets start at the current temperature; renaming preserves a preset's temperature; IdlePage TypeErrors no longer appear in the log.