### PR TITLE
fix(steam): per-pitcher temperature + MCP preset control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,7 @@ set(SOURCES
     src/mcp/mcptools_shots.cpp
     src/mcp/mcptools_profiles.cpp
     src/mcp/mcptools_settings.cpp
+    src/mcp/mcptools_presets.cpp
     src/mcp/mcptools_beansearch.cpp
     src/mcp/mcptools_dialing.cpp
     src/ai/dialing_blocks.cpp

--- a/docs/CLAUDE_MD/MCP_SERVER.md
+++ b/docs/CLAUDE_MD/MCP_SERVER.md
@@ -86,9 +86,9 @@ Each tool has a `category` that determines the minimum access level required:
 
 | Category | Min Access Level | Tools |
 |----------|-----------------|-------|
-| `read` | 0 (Monitor) | machine_get_state, app_get_info, machine_get_telemetry, shots_list, shots_get_detail, shots_get_debug_log, shots_compare, profiles_list, profiles_get_active, profiles_get_detail, profiles_get_params, profiles_get_auto_load, settings_get, dialing_get_context, dialing_get_grinder_calibration, bag_list, equipment_list |
-| `control` | 1 (Control) | machine_wake, machine_sleep, machine_start_espresso, machine_start_steam, machine_start_hot_water, machine_start_flush, machine_stop, machine_skip_frame, shots_update, shots_upload_to_visualizer, backup_now, mqtt_connect, mqtt_disconnect, mqtt_publish_discovery, devices_connect_de1, devices_disconnect_scale, devices_reset_scale_priority, bag_select, equipment_select |
-| `settings` | 2 (Full) | profiles_set_active, profiles_edit_params, profiles_save, profiles_delete, profiles_create, profiles_rename, shots_delete, settings_set, reset_saw_learning, clear_flow_calibration, apply_theme, bag_update, equipment_update |
+| `read` | 0 (Monitor) | machine_get_state, app_get_info, machine_get_telemetry, shots_list, shots_get_detail, shots_get_debug_log, shots_compare, profiles_list, profiles_get_active, profiles_get_detail, profiles_get_params, profiles_get_auto_load, settings_get, dialing_get_context, dialing_get_grinder_calibration, bag_list, equipment_list, steam_pitcher_list, water_vessel_list |
+| `control` | 1 (Control) | machine_wake, machine_sleep, machine_start_espresso, machine_start_steam, machine_start_hot_water, machine_start_flush, machine_stop, machine_skip_frame, shots_update, shots_upload_to_visualizer, backup_now, mqtt_connect, mqtt_disconnect, mqtt_publish_discovery, devices_connect_de1, devices_disconnect_scale, devices_reset_scale_priority, bag_select, equipment_select, steam_pitcher_select, water_vessel_select |
+| `settings` | 2 (Full) | profiles_set_active, profiles_edit_params, profiles_save, profiles_delete, profiles_create, profiles_rename, shots_delete, settings_set, reset_saw_learning, clear_flow_calibration, apply_theme, bag_update, equipment_update, steam_pitcher_add, steam_pitcher_update, steam_pitcher_delete, water_vessel_add, water_vessel_update, water_vessel_delete |
 
 ### Tool → Confirmation Level Mapping
 
@@ -229,6 +229,21 @@ The `de1://dialing` resource's grinder block also exposes `packageId`, `rpmAdjus
 | `mqtt_connect` | Connect to the configured MQTT broker. | control |
 | `mqtt_disconnect` | Disconnect from the MQTT broker. | control |
 | `mqtt_publish_discovery` | Publish Home Assistant MQTT discovery messages. Requires connected broker. | control |
+
+### Steam & Hot Water Presets
+Steam pitcher / hot-water vessel presets each carry their own duration/flow/volume and a **per-preset temperature**. `*_select` switches the active preset and applies it to the machine (like `bag_select`/`equipment_select`); `*_add` appends and selects the new preset; updates are partial (only provided fields change, and editing the selected preset re-applies it). Units are human-readable (temperatureC, flowMlPerSec, durationSec, volumeMl) — the store keeps steam flow in hundredths and water flow in tenths of mL/s, converted in the tool layer.
+| Tool | Description | Category |
+|------|-------------|----------|
+| `steam_pitcher_list` | List steam pitcher presets (name, durationSec, flowMlPerSec, temperatureC; pitcherWeightG/calibMilkG when calibrated; disabled "Off" presets carry only name+disabled) plus `selectedIndex`. | read |
+| `steam_pitcher_add` | Add a steam pitcher preset and select it. Optional durationSec/flowMlPerSec/temperatureC (temperature defaults to the current global steam temperature); `disabled=true` adds an "Off" preset that turns the heater off. | settings |
+| `steam_pitcher_update` | Update a pitcher by index — partial; unspecified fields keep their values. Editing the selected pitcher re-applies it to the machine. Disabled presets can't be edited (delete + re-add). | settings |
+| `steam_pitcher_delete` | Delete a steam pitcher preset by index. | settings |
+| `steam_pitcher_select` | Switch the active pitcher by index; applies its duration/flow/temperature to the machine. | control |
+| `water_vessel_list` | List hot water vessel presets (name, volumeMl, mode "weight"/"volume", flowMlPerSec, temperatureC) plus `selectedIndex`. | read |
+| `water_vessel_add` | Add a hot water vessel preset and select it. Optional volumeMl/mode/flowMlPerSec/temperatureC (temperature defaults to the current global hot water temperature). | settings |
+| `water_vessel_update` | Update a vessel by index — partial. Editing the selected vessel re-applies it to the machine. | settings |
+| `water_vessel_delete` | Delete a hot water vessel preset by index. | settings |
+| `water_vessel_select` | Switch the active vessel by index; applies its volume/mode/flow/temperature to the machine. | control |
 
 ### Devices & Scale
 | Tool | Description | Category |

--- a/qml/components/layout/items/SteamItem.qml
+++ b/qml/components/layout/items/SteamItem.qml
@@ -230,6 +230,7 @@ Item {
                     if (preset) {
                         Settings.brew.steamTimeout = preset.duration
                         Settings.brew.steamFlow = preset.flow !== undefined ? preset.flow : 150
+                        Settings.brew.steamTemperature = (preset.temperature !== undefined) ? preset.temperature : Settings.brew.steamTemperature
                     }
                     MainController.applySteamSettings()
 

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -578,6 +578,7 @@ Page {
                             var t = Settings.brew.scaledSteamTime(idx, milk)
                             Settings.brew.steamTimeout = t > 0 ? t : preset.duration  // 0 → fixed duration
                             Settings.brew.steamFlow = preset.flow !== undefined ? preset.flow : 150
+                            Settings.brew.steamTemperature = (preset.temperature !== undefined) ? preset.temperature : Settings.brew.steamTemperature
                         }
                         MainController.applySteamSettings()
 

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -2450,7 +2450,13 @@ Page {
         function onSteamPitcherPresetsChanged() {
             durationSlider.value = getCurrentPitcherDuration()
             flowSlider.value = getCurrentPitcherFlow()
-            steamTempSlider.value = getCurrentPitcherTemperature()
+            // Keep the active steam temperature in sync (not just the slider) when the
+            // selected pitcher is edited from anywhere — e.g. via MCP — so a later
+            // applySteamSettings (back-navigation, keepSteamHeaterOn) pushes the
+            // current value rather than a stale one.
+            var temp = getCurrentPitcherTemperature()
+            steamTempSlider.value = temp
+            Settings.brew.steamTemperature = temp
         }
     }
 }

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -34,6 +34,8 @@ Page {
                 // Sync Settings with selected preset
                 steamPage.syncSteamTimeout()
                 Settings.brew.steamFlow = getCurrentPitcherFlow()
+                Settings.brew.steamTemperature = getCurrentPitcherTemperature()
+                steamTempSlider.value = getCurrentPitcherTemperature()
                 // Start heating steam heater (ignores keepSteamHeaterOn - user wants to steam)
                 // startSteamHeating clears steamDisabled flag automatically
                 MainController.startSteamHeating("steampage-activated")
@@ -208,6 +210,14 @@ Page {
         return (preset.flow !== undefined) ? preset.flow : 150
     }
 
+    // Per-pitcher steam temperature. Disabled ("Off") presets and legacy presets
+    // with no stored temperature fall back to the current global steam temperature.
+    function getCurrentPitcherTemperature() {
+        var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+        if (!preset || preset.disabled) return Settings.brew.steamTemperature
+        return (preset.temperature !== undefined) ? preset.temperature : Settings.brew.steamTemperature
+    }
+
     function getCurrentPitcherName() {
         var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
         return preset ? preset.name : ""
@@ -221,10 +231,11 @@ Page {
     // Save current pitcher with new values. No-op for disabled presets — their
     // duration/flow are meaningless, and writing them via updateSteamPitcherPreset
     // would let slider drags silently bake values into the saved JSON.
-    function saveCurrentPitcher(duration, flow) {
+    function saveCurrentPitcher(duration, flow, temperature) {
         var name = getCurrentPitcherName()
         if (name && !isCurrentPitcherDisabled()) {
-            Settings.brew.updateSteamPitcherPreset(Settings.brew.selectedSteamPitcher, name, duration, flow)
+            var temp = (temperature !== undefined) ? temperature : steamTempSlider.value
+            Settings.brew.updateSteamPitcherPreset(Settings.brew.selectedSteamPitcher, name, duration, flow, temp)
         }
     }
 
@@ -234,7 +245,7 @@ Page {
 
     // Net milk currently on the scale for the selected pitcher (0 if none/invalid).
     function currentMeasuredMilk() {
-        if (!ScaleDevice.connected) return 0
+        if (!ScaleDevice || !ScaleDevice.connected) return 0
         return Settings.brew.netMilkForPitcher(Settings.brew.selectedSteamPitcher, MachineState.scaleWeight)
     }
 
@@ -1556,6 +1567,7 @@ Page {
                             KeyNavigation.backtab: flowSlider
                             onValueModified: function(newValue) {
                                 steamTempSlider.value = newValue
+                                saveCurrentPitcher(durationSlider.value, flowSlider.value, newValue)
                             }
                             onValueCommitted: function(newValue) {
                                 MainController.setSteamTemperatureImmediate(newValue)
@@ -2408,7 +2420,9 @@ Page {
                         Qt.inputMethod.commit()
                         if (newPitcherName.text.trim() !== "") {
                             var presetCount = Settings.brew.steamPitcherPresets.length
-                            Settings.brew.addSteamPitcherPreset(newPitcherName.text.trim(), 30, 150)
+                            Settings.brew.addSteamPitcherPreset(newPitcherName.text.trim(), 30, 150, Settings.brew.steamTemperature)
+                            // Selecting the new preset fires onSelectedSteamPitcherChanged,
+                            // which loads its temperature into the slider/active temp.
                             Settings.brew.selectedSteamPitcher = presetCount
                             newPitcherName.text = ""
                             addPitcherDialog.close()
@@ -2425,10 +2439,18 @@ Page {
         function onSelectedSteamPitcherChanged() {
             durationSlider.value = getCurrentPitcherDuration()
             flowSlider.value = getCurrentPitcherFlow()
+            // Load the newly-selected pitcher's temperature into both the slider and
+            // the active steam temperature. This runs synchronously when a pill tap
+            // sets selectedSteamPitcher, so the subsequent startSteamHeating/
+            // applySteamSettings push the per-pitcher temperature to the machine.
+            var temp = getCurrentPitcherTemperature()
+            steamTempSlider.value = temp
+            Settings.brew.steamTemperature = temp
         }
         function onSteamPitcherPresetsChanged() {
             durationSlider.value = getCurrentPitcherDuration()
             flowSlider.value = getCurrentPitcherFlow()
+            steamTempSlider.value = getCurrentPitcherTemperature()
         }
     }
 }

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -294,7 +294,7 @@ void SettingsBrew::setSelectedSteamCup(int index) {
     }
 }
 
-void SettingsBrew::addSteamPitcherPreset(const QString& name, int duration, int flow) {
+void SettingsBrew::addSteamPitcherPreset(const QString& name, int duration, int flow, double temperature) {
     QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
     QJsonDocument doc = QJsonDocument::fromJson(data);
     QJsonArray arr = doc.array();
@@ -303,6 +303,7 @@ void SettingsBrew::addSteamPitcherPreset(const QString& name, int duration, int 
     preset["name"] = name;
     preset["duration"] = duration;
     preset["flow"] = flow;
+    preset["temperature"] = temperature;
     arr.append(preset);
 
     m_settings.setValue("steam/pitcherPresets", QJsonDocument(arr).toJson());
@@ -323,16 +324,17 @@ void SettingsBrew::addSteamPitcherPresetDisabled(const QString& name) {
     emit steamPitcherPresetsChanged();
 }
 
-void SettingsBrew::updateSteamPitcherPreset(int index, const QString& name, int duration, int flow) {
+void SettingsBrew::updateSteamPitcherPreset(int index, const QString& name, int duration, int flow, double temperature) {
     QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
     QJsonDocument doc = QJsonDocument::fromJson(data);
     QJsonArray arr = doc.array();
 
     if (index >= 0 && index < static_cast<int>(arr.size())) {
-        QJsonObject preset = arr[index].toObject();  // Read existing to preserve pitcherWeightG
+        QJsonObject preset = arr[index].toObject();  // Read existing to preserve pitcherWeightG / calibMilkG
         preset["name"] = name;
         preset["duration"] = duration;
         preset["flow"] = flow;
+        preset["temperature"] = temperature;
         arr[index] = preset;
 
         m_settings.setValue("steam/pitcherPresets", QJsonDocument(arr).toJson());

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -136,9 +136,9 @@ public:
     int selectedSteamPitcher() const;
     void setSelectedSteamCup(int index);
 
-    Q_INVOKABLE void addSteamPitcherPreset(const QString& name, int duration, int flow);
+    Q_INVOKABLE void addSteamPitcherPreset(const QString& name, int duration, int flow, double temperature = 160.0);
     Q_INVOKABLE void addSteamPitcherPresetDisabled(const QString& name);
-    Q_INVOKABLE void updateSteamPitcherPreset(int index, const QString& name, int duration, int flow);
+    Q_INVOKABLE void updateSteamPitcherPreset(int index, const QString& name, int duration, int flow, double temperature = 160.0);
     Q_INVOKABLE void removeSteamPitcherPreset(int index);
     Q_INVOKABLE void moveSteamPitcherPreset(int from, int to);
     Q_INVOKABLE QVariantMap getSteamPitcherPreset(int index) const;

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -82,6 +82,12 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
         p["name"] = m["name"].toString();
         p["duration"] = m["duration"].toInt();
         p["flow"] = m["flow"].toInt();
+        // Per-pitcher steam temperature; legacy presets (and pre-temperature
+        // backups) fall back to the current global steam temperature. Disabled
+        // presets carry no temperature — the heater is off for them.
+        if (!m.value("disabled").toBool())
+            p["temperature"] = m.contains("temperature") ? m["temperature"].toDouble()
+                                                         : settings->brew()->steamTemperature();
         // The weight-based-steaming feature is keyed on these, so they must round-trip.
         if (m.contains("pitcherWeightG")) p["pitcherWeightG"] = m["pitcherWeightG"].toDouble();
         if (m.contains("calibMilkG")) p["calibMilkG"] = m["calibMilkG"].toDouble();
@@ -439,7 +445,12 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
                 if (disabled) {
                     settings->brew()->addSteamPitcherPresetDisabled(p["name"].toString());
                 } else {
-                    settings->brew()->addSteamPitcherPreset(p["name"].toString(), p["duration"].toInt(), p["flow"].toInt());
+                    // Legacy presets predate the per-pitcher temperature field; fall
+                    // back to the device's current global steam temperature.
+                    const double presetTemp = p.contains("temperature") ? p["temperature"].toDouble()
+                                                                        : settings->brew()->steamTemperature();
+                    settings->brew()->addSteamPitcherPreset(p["name"].toString(), p["duration"].toInt(),
+                                                            p["flow"].toInt(), presetTemp);
                 }
                 // Restore weight + milk calibration ONLY for an enabled preset whose
                 // add actually appended one entry — never onto a disabled preset, nor

--- a/src/mcp/mcpserver.cpp
+++ b/src/mcp/mcpserver.cpp
@@ -28,6 +28,7 @@ void registerMachineTools(McpToolRegistry* registry, DE1Device* device,
 void registerShotTools(McpToolRegistry* registry, ShotHistoryStorage* shotHistory);
 class ProfileManager;
 void registerProfileTools(McpToolRegistry* registry, ProfileManager* profileManager, Settings* settings);
+void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainController* mainController);
 class AccessibilityManager;
 class ScreensaverVideoManager;
 class TranslationManager;
@@ -155,6 +156,7 @@ void McpServer::registerAllTools()
     registerMachineTools(m_toolRegistry, m_device, m_machineState, m_mainController, m_profileManager);
     registerShotTools(m_toolRegistry, m_shotHistory);
     registerProfileTools(m_toolRegistry, m_profileManager, m_settings);
+    registerPresetsTools(m_toolRegistry, m_settings, m_mainController);
     registerSettingsReadTools(m_toolRegistry, m_settings, m_accessibilityManager,
                               m_screensaverManager, m_translationManager, m_batteryManager,
                               m_mainController ? m_mainController->aiManager() : nullptr);

--- a/src/mcp/mcptools_presets.cpp
+++ b/src/mcp/mcptools_presets.cpp
@@ -1,0 +1,380 @@
+// MCP tools for steam-pitcher and hot-water-vessel preset CRUD + selection.
+//
+// Units follow the MCP data conventions (see docs/CLAUDE_MD/MCP_SERVER.md):
+// temperatures in °C, flow in mL/s, durations in seconds, volumes in mL,
+// weights in grams. The underlying SettingsBrew store keeps steam flow in
+// hundredths of mL/s and water flow rate in tenths of mL/s; the conversions
+// live here so the MCP surface stays human-readable.
+
+#include "mcptoolregistry.h"
+#include "../core/settings.h"
+#include "../core/settings_brew.h"
+#include "../core/settings_hardware.h"
+#include "../controllers/maincontroller.h"
+
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QVariantMap>
+#include <cmath>
+
+namespace {
+
+// Stored-unit <-> mL/s conversions.
+constexpr double kSteamFlowScale = 100.0;  // steam preset "flow" is hundredths of mL/s
+constexpr double kWaterFlowScale = 10.0;   // water preset "flowRate" is tenths of mL/s
+
+QJsonObject steamPitcherToJson(const QVariantMap& m, double globalTempC)
+{
+    QJsonObject o;
+    o["name"] = m.value("name").toString();
+    const bool disabled = m.value("disabled").toBool();
+    if (disabled) {
+        // "Off" preset — heater stays off, so no duration/flow/temperature.
+        o["disabled"] = true;
+        return o;
+    }
+    o["durationSec"] = m.value("duration").toInt();
+    o["flowMlPerSec"] = m.value("flow").toDouble() / kSteamFlowScale;
+    o["temperatureC"] = m.contains("temperature") ? m.value("temperature").toDouble() : globalTempC;
+    if (m.contains("pitcherWeightG")) o["pitcherWeightG"] = m.value("pitcherWeightG").toDouble();
+    if (m.contains("calibMilkG")) o["calibMilkG"] = m.value("calibMilkG").toDouble();
+    return o;
+}
+
+QJsonObject waterVesselToJson(const QVariantMap& m, double globalTempC)
+{
+    QJsonObject o;
+    o["name"] = m.value("name").toString();
+    o["volumeMl"] = m.value("volume").toInt();
+    o["mode"] = m.contains("mode") ? m.value("mode").toString() : QStringLiteral("weight");
+    o["flowMlPerSec"] = (m.contains("flowRate") ? m.value("flowRate").toDouble() : 40.0) / kWaterFlowScale;
+    o["temperatureC"] = m.contains("temperature") ? m.value("temperature").toDouble() : globalTempC;
+    return o;
+}
+
+bool indexInRange(int index, qsizetype count)
+{
+    return index >= 0 && index < static_cast<int>(count);
+}
+
+const QJsonObject kConfirmedProp{
+    {"confirmed", QJsonObject{{"type", "boolean"},
+        {"description", "Set to true after the user confirms this action in chat"}}}};
+
+} // namespace
+
+void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainController* mainController)
+{
+    // Apply a steam pitcher's stored parameters to the active steam settings and
+    // push them to the machine — the non-UI equivalent of selecting the pitcher
+    // on the Steam page. Used by select and by add (which auto-selects).
+    auto applySteamPitcher = [settings, mainController](int index) {
+        if (!settings) return;
+        const QVariantMap p = settings->brew()->getSteamPitcherPreset(index);
+        if (p.value("disabled").toBool()) {
+            if (mainController) mainController->turnOffSteamHeater();
+            return;
+        }
+        settings->brew()->setSteamTimeout(p.value("duration").toInt());
+        settings->brew()->setSteamFlow(p.value("flow").toInt());
+        settings->brew()->setSteamTemperature(p.contains("temperature")
+            ? p.value("temperature").toDouble() : settings->brew()->steamTemperature());
+        if (mainController) mainController->applySteamSettings();
+    };
+
+    // Likewise for a hot water vessel.
+    auto applyWaterVessel = [settings, mainController](int index) {
+        if (!settings) return;
+        const QVariantMap p = settings->brew()->getWaterVesselPreset(index);
+        settings->brew()->setWaterVolume(p.value("volume").toInt());
+        settings->brew()->setWaterVolumeMode(p.contains("mode") ? p.value("mode").toString()
+                                                                 : QStringLiteral("weight"));
+        settings->hardware()->setHotWaterFlowRate(p.contains("flowRate") ? p.value("flowRate").toInt() : 40);
+        settings->brew()->setWaterTemperature(p.contains("temperature")
+            ? p.value("temperature").toDouble() : settings->brew()->waterTemperature());
+        if (mainController) mainController->applyHotWaterSettings();
+    };
+
+    // ---------------------------------------------------------------------
+    // Steam pitcher presets
+    // ---------------------------------------------------------------------
+
+    registry->registerTool(
+        "steam_pitcher_list",
+        "List all steam pitcher presets and which one is currently selected. Each preset has a "
+        "name, durationSec, flowMlPerSec and temperatureC (per-pitcher steam temperature). "
+        "Disabled \"Off\" presets only carry name + disabled. pitcherWeightG / calibMilkG appear "
+        "when the pitcher has been weighed / calibrated for weight-scaled steaming.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
+        [settings](const QJsonObject&) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) { result["error"] = "Settings unavailable"; return result; }
+            const double globalTemp = settings->brew()->steamTemperature();
+            QJsonArray presets;
+            const QVariantList list = settings->brew()->steamPitcherPresets();
+            for (const QVariant& v : list)
+                presets.append(steamPitcherToJson(v.toMap(), globalTemp));
+            result["presets"] = presets;
+            result["selectedIndex"] = settings->brew()->selectedSteamPitcher();
+            result["count"] = static_cast<int>(list.size());
+            return result;
+        },
+        "read");
+
+    registry->registerTool(
+        "steam_pitcher_add",
+        "Add a new steam pitcher preset and select it. Provide a name; durationSec, flowMlPerSec "
+        "and temperatureC are optional (default 30s / 1.5 mL/s / 160°C). Set disabled=true to add "
+        "an \"Off\" preset that turns the steam heater off (other fields are ignored).",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{
+            {"name", QJsonObject{{"type", "string"}, {"description", "Display name for the pitcher preset"}}},
+            {"durationSec", QJsonObject{{"type", "integer"}, {"description", "Steam duration in seconds (default 30)"}}},
+            {"flowMlPerSec", QJsonObject{{"type", "number"}, {"description", "Steam flow rate in mL/s (default 1.5)"}}},
+            {"temperatureC", QJsonObject{{"type", "number"}, {"description", "Steam temperature in °C (default 160)"}}},
+            {"disabled", QJsonObject{{"type", "boolean"}, {"description", "Add an \"Off\" preset (heater off). Other fields ignored."}}},
+            {"confirmed", kConfirmedProp.value("confirmed")}
+        }}, {"required", QJsonArray{"name"}}},
+        [settings, applySteamPitcher](const QJsonObject& args) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) { result["error"] = "Settings unavailable"; return result; }
+            const QString name = args.value("name").toString().trimmed();
+            if (name.isEmpty()) { result["error"] = "name is required"; return result; }
+            if (args.value("disabled").toBool()) {
+                settings->brew()->addSteamPitcherPresetDisabled(name);
+            } else {
+                const int duration = args.contains("durationSec") ? args.value("durationSec").toInt() : 30;
+                const int flow = args.contains("flowMlPerSec")
+                    ? static_cast<int>(std::lround(args.value("flowMlPerSec").toDouble() * kSteamFlowScale)) : 150;
+                const double temp = args.contains("temperatureC")
+                    ? args.value("temperatureC").toDouble() : settings->brew()->steamTemperature();
+                settings->brew()->addSteamPitcherPreset(name, duration, flow, temp);
+            }
+            const int newIndex = static_cast<int>(settings->brew()->steamPitcherPresets().size()) - 1;
+            settings->brew()->setSelectedSteamCup(newIndex);
+            applySteamPitcher(newIndex);
+            result["success"] = true;
+            result["selectedIndex"] = newIndex;
+            return result;
+        },
+        "settings");
+
+    registry->registerTool(
+        "steam_pitcher_update",
+        "Update an existing steam pitcher preset by index. Only the fields you pass are changed; "
+        "the rest keep their current values. Disabled \"Off\" presets cannot be edited — delete "
+        "and re-add instead.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{
+            {"index", QJsonObject{{"type", "integer"}, {"description", "Index of the preset (from steam_pitcher_list)"}}},
+            {"name", QJsonObject{{"type", "string"}, {"description", "New name"}}},
+            {"durationSec", QJsonObject{{"type", "integer"}, {"description", "New steam duration in seconds"}}},
+            {"flowMlPerSec", QJsonObject{{"type", "number"}, {"description", "New steam flow rate in mL/s"}}},
+            {"temperatureC", QJsonObject{{"type", "number"}, {"description", "New steam temperature in °C"}}},
+            {"confirmed", kConfirmedProp.value("confirmed")}
+        }}, {"required", QJsonArray{"index"}}},
+        [settings](const QJsonObject& args) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) { result["error"] = "Settings unavailable"; return result; }
+            const int index = args.value("index").toInt();
+            const QVariantList list = settings->brew()->steamPitcherPresets();
+            if (!indexInRange(index, list.size())) { result["error"] = "index out of range"; return result; }
+            const QVariantMap existing = settings->brew()->getSteamPitcherPreset(index);
+            if (existing.value("disabled").toBool()) {
+                result["error"] = "Cannot edit a disabled (Off) pitcher; delete and re-add it";
+                return result;
+            }
+            const QString name = args.contains("name") ? args.value("name").toString() : existing.value("name").toString();
+            const int duration = args.contains("durationSec") ? args.value("durationSec").toInt() : existing.value("duration").toInt();
+            const int flow = args.contains("flowMlPerSec")
+                ? static_cast<int>(std::lround(args.value("flowMlPerSec").toDouble() * kSteamFlowScale))
+                : existing.value("flow").toInt();
+            const double temp = args.contains("temperatureC")
+                ? args.value("temperatureC").toDouble()
+                : (existing.contains("temperature") ? existing.value("temperature").toDouble()
+                                                     : settings->brew()->steamTemperature());
+            settings->brew()->updateSteamPitcherPreset(index, name, duration, flow, temp);
+            result["success"] = true;
+            return result;
+        },
+        "settings");
+
+    registry->registerTool(
+        "steam_pitcher_delete",
+        "Delete a steam pitcher preset by index.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{
+            {"index", QJsonObject{{"type", "integer"}, {"description", "Index of the preset to delete"}}},
+            {"confirmed", kConfirmedProp.value("confirmed")}
+        }}, {"required", QJsonArray{"index"}}},
+        [settings](const QJsonObject& args) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) { result["error"] = "Settings unavailable"; return result; }
+            const int index = args.value("index").toInt();
+            if (!indexInRange(index, settings->brew()->steamPitcherPresets().size())) {
+                result["error"] = "index out of range"; return result;
+            }
+            settings->brew()->removeSteamPitcherPreset(index);
+            result["success"] = true;
+            return result;
+        },
+        "settings");
+
+    registry->registerTool(
+        "steam_pitcher_select",
+        "Select (switch to) a steam pitcher preset by index. Its duration, flow and per-pitcher "
+        "temperature become active and are sent to the machine.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{
+            {"index", QJsonObject{{"type", "integer"}, {"description", "Index of the preset to select"}}},
+            {"confirmed", kConfirmedProp.value("confirmed")}
+        }}, {"required", QJsonArray{"index"}}},
+        [settings, applySteamPitcher](const QJsonObject& args) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) { result["error"] = "Settings unavailable"; return result; }
+            const int index = args.value("index").toInt();
+            if (!indexInRange(index, settings->brew()->steamPitcherPresets().size())) {
+                result["error"] = "index out of range"; return result;
+            }
+            settings->brew()->setSelectedSteamCup(index);
+            applySteamPitcher(index);
+            result["success"] = true;
+            result["selectedIndex"] = index;
+            return result;
+        },
+        "settings");
+
+    // ---------------------------------------------------------------------
+    // Hot water vessel presets
+    // ---------------------------------------------------------------------
+
+    registry->registerTool(
+        "water_vessel_list",
+        "List all hot water vessel presets and which one is currently selected. Each preset has a "
+        "name, volumeMl, mode (\"weight\" or \"volume\"), flowMlPerSec and temperatureC "
+        "(per-vessel hot water temperature).",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
+        [settings](const QJsonObject&) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) { result["error"] = "Settings unavailable"; return result; }
+            const double globalTemp = settings->brew()->waterTemperature();
+            QJsonArray presets;
+            const QVariantList list = settings->brew()->waterVesselPresets();
+            for (const QVariant& v : list)
+                presets.append(waterVesselToJson(v.toMap(), globalTemp));
+            result["presets"] = presets;
+            result["selectedIndex"] = settings->brew()->selectedWaterVessel();
+            result["count"] = static_cast<int>(list.size());
+            return result;
+        },
+        "read");
+
+    registry->registerTool(
+        "water_vessel_add",
+        "Add a new hot water vessel preset and select it. Provide a name; volumeMl, mode, "
+        "flowMlPerSec and temperatureC are optional (default 200 mL / weight / 4.0 mL/s / 85°C).",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{
+            {"name", QJsonObject{{"type", "string"}, {"description", "Display name for the vessel preset"}}},
+            {"volumeMl", QJsonObject{{"type", "integer"}, {"description", "Target volume in mL (default 200)"}}},
+            {"mode", QJsonObject{{"type", "string"}, {"description", "\"weight\" or \"volume\" (default weight)"}}},
+            {"flowMlPerSec", QJsonObject{{"type", "number"}, {"description", "Hot water flow rate in mL/s (default 4.0)"}}},
+            {"temperatureC", QJsonObject{{"type", "number"}, {"description", "Hot water temperature in °C (default 85)"}}},
+            {"confirmed", kConfirmedProp.value("confirmed")}
+        }}, {"required", QJsonArray{"name"}}},
+        [settings, applyWaterVessel](const QJsonObject& args) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) { result["error"] = "Settings unavailable"; return result; }
+            const QString name = args.value("name").toString().trimmed();
+            if (name.isEmpty()) { result["error"] = "name is required"; return result; }
+            const int volume = args.contains("volumeMl") ? args.value("volumeMl").toInt() : 200;
+            const QString mode = args.contains("mode") ? args.value("mode").toString() : QStringLiteral("weight");
+            const int flowRate = args.contains("flowMlPerSec")
+                ? static_cast<int>(std::lround(args.value("flowMlPerSec").toDouble() * kWaterFlowScale)) : 40;
+            const double temp = args.contains("temperatureC")
+                ? args.value("temperatureC").toDouble() : settings->brew()->waterTemperature();
+            settings->brew()->addWaterVesselPreset(name, volume, mode, flowRate, temp);
+            const int newIndex = static_cast<int>(settings->brew()->waterVesselPresets().size()) - 1;
+            settings->brew()->setSelectedWaterCup(newIndex);
+            applyWaterVessel(newIndex);
+            result["success"] = true;
+            result["selectedIndex"] = newIndex;
+            return result;
+        },
+        "settings");
+
+    registry->registerTool(
+        "water_vessel_update",
+        "Update an existing hot water vessel preset by index. Only the fields you pass are changed; "
+        "the rest keep their current values.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{
+            {"index", QJsonObject{{"type", "integer"}, {"description", "Index of the preset (from water_vessel_list)"}}},
+            {"name", QJsonObject{{"type", "string"}, {"description", "New name"}}},
+            {"volumeMl", QJsonObject{{"type", "integer"}, {"description", "New target volume in mL"}}},
+            {"mode", QJsonObject{{"type", "string"}, {"description", "\"weight\" or \"volume\""}}},
+            {"flowMlPerSec", QJsonObject{{"type", "number"}, {"description", "New hot water flow rate in mL/s"}}},
+            {"temperatureC", QJsonObject{{"type", "number"}, {"description", "New hot water temperature in °C"}}},
+            {"confirmed", kConfirmedProp.value("confirmed")}
+        }}, {"required", QJsonArray{"index"}}},
+        [settings](const QJsonObject& args) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) { result["error"] = "Settings unavailable"; return result; }
+            const int index = args.value("index").toInt();
+            const QVariantList list = settings->brew()->waterVesselPresets();
+            if (!indexInRange(index, list.size())) { result["error"] = "index out of range"; return result; }
+            const QVariantMap existing = settings->brew()->getWaterVesselPreset(index);
+            const QString name = args.contains("name") ? args.value("name").toString() : existing.value("name").toString();
+            const int volume = args.contains("volumeMl") ? args.value("volumeMl").toInt() : existing.value("volume").toInt();
+            const QString mode = args.contains("mode") ? args.value("mode").toString()
+                : (existing.contains("mode") ? existing.value("mode").toString() : QStringLiteral("weight"));
+            const int flowRate = args.contains("flowMlPerSec")
+                ? static_cast<int>(std::lround(args.value("flowMlPerSec").toDouble() * kWaterFlowScale))
+                : (existing.contains("flowRate") ? existing.value("flowRate").toInt() : 40);
+            const double temp = args.contains("temperatureC")
+                ? args.value("temperatureC").toDouble()
+                : (existing.contains("temperature") ? existing.value("temperature").toDouble()
+                                                     : settings->brew()->waterTemperature());
+            settings->brew()->updateWaterVesselPreset(index, name, volume, mode, flowRate, temp);
+            result["success"] = true;
+            return result;
+        },
+        "settings");
+
+    registry->registerTool(
+        "water_vessel_delete",
+        "Delete a hot water vessel preset by index.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{
+            {"index", QJsonObject{{"type", "integer"}, {"description", "Index of the preset to delete"}}},
+            {"confirmed", kConfirmedProp.value("confirmed")}
+        }}, {"required", QJsonArray{"index"}}},
+        [settings](const QJsonObject& args) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) { result["error"] = "Settings unavailable"; return result; }
+            const int index = args.value("index").toInt();
+            if (!indexInRange(index, settings->brew()->waterVesselPresets().size())) {
+                result["error"] = "index out of range"; return result;
+            }
+            settings->brew()->removeWaterVesselPreset(index);
+            result["success"] = true;
+            return result;
+        },
+        "settings");
+
+    registry->registerTool(
+        "water_vessel_select",
+        "Select (switch to) a hot water vessel preset by index. Its volume, mode, flow and "
+        "per-vessel temperature become active and are sent to the machine.",
+        QJsonObject{{"type", "object"}, {"properties", QJsonObject{
+            {"index", QJsonObject{{"type", "integer"}, {"description", "Index of the preset to select"}}},
+            {"confirmed", kConfirmedProp.value("confirmed")}
+        }}, {"required", QJsonArray{"index"}}},
+        [settings, applyWaterVessel](const QJsonObject& args) -> QJsonObject {
+            QJsonObject result;
+            if (!settings) { result["error"] = "Settings unavailable"; return result; }
+            const int index = args.value("index").toInt();
+            if (!indexInRange(index, settings->brew()->waterVesselPresets().size())) {
+                result["error"] = "index out of range"; return result;
+            }
+            settings->brew()->setSelectedWaterCup(index);
+            applyWaterVessel(index);
+            result["success"] = true;
+            result["selectedIndex"] = index;
+            return result;
+        },
+        "settings");
+}

--- a/src/mcp/mcptools_presets.cpp
+++ b/src/mcp/mcptools_presets.cpp
@@ -71,6 +71,7 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
     auto applySteamPitcher = [settings, mainController](int index) {
         if (!settings) return;
         const QVariantMap p = settings->brew()->getSteamPitcherPreset(index);
+        if (p.isEmpty()) return;  // out-of-range index returns an empty map
         if (p.value("disabled").toBool()) {
             if (mainController) mainController->turnOffSteamHeater();
             return;
@@ -86,6 +87,7 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
     auto applyWaterVessel = [settings, mainController](int index) {
         if (!settings) return;
         const QVariantMap p = settings->brew()->getWaterVesselPreset(index);
+        if (p.isEmpty()) return;  // out-of-range index returns an empty map
         settings->brew()->setWaterVolume(p.value("volume").toInt());
         settings->brew()->setWaterVolumeMode(p.contains("mode") ? p.value("mode").toString()
                                                                  : QStringLiteral("weight"));
@@ -124,13 +126,14 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
     registry->registerTool(
         "steam_pitcher_add",
         "Add a new steam pitcher preset and select it. Provide a name; durationSec, flowMlPerSec "
-        "and temperatureC are optional (default 30s / 1.5 mL/s / 160°C). Set disabled=true to add "
-        "an \"Off\" preset that turns the steam heater off (other fields are ignored).",
+        "and temperatureC are optional (default 30s / 1.5 mL/s; temperature defaults to the current "
+        "global steam temperature). Set disabled=true to add an \"Off\" preset that turns the steam "
+        "heater off (other fields are ignored).",
         QJsonObject{{"type", "object"}, {"properties", QJsonObject{
             {"name", QJsonObject{{"type", "string"}, {"description", "Display name for the pitcher preset"}}},
             {"durationSec", QJsonObject{{"type", "integer"}, {"description", "Steam duration in seconds (default 30)"}}},
             {"flowMlPerSec", QJsonObject{{"type", "number"}, {"description", "Steam flow rate in mL/s (default 1.5)"}}},
-            {"temperatureC", QJsonObject{{"type", "number"}, {"description", "Steam temperature in °C (default 160)"}}},
+            {"temperatureC", QJsonObject{{"type", "number"}, {"description", "Steam temperature in °C (defaults to the current global steam temperature)"}}},
             {"disabled", QJsonObject{{"type", "boolean"}, {"description", "Add an \"Off\" preset (heater off). Other fields ignored."}}},
             {"confirmed", kConfirmedProp.value("confirmed")}
         }}, {"required", QJsonArray{"name"}}},
@@ -171,7 +174,7 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
             {"temperatureC", QJsonObject{{"type", "number"}, {"description", "New steam temperature in °C"}}},
             {"confirmed", kConfirmedProp.value("confirmed")}
         }}, {"required", QJsonArray{"index"}}},
-        [settings](const QJsonObject& args) -> QJsonObject {
+        [settings, applySteamPitcher](const QJsonObject& args) -> QJsonObject {
             QJsonObject result;
             if (!settings) { result["error"] = "Settings unavailable"; return result; }
             const int index = args.value("index").toInt();
@@ -192,6 +195,9 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
                 : (existing.contains("temperature") ? existing.value("temperature").toDouble()
                                                      : settings->brew()->steamTemperature());
             settings->brew()->updateSteamPitcherPreset(index, name, duration, flow, temp);
+            // If we edited the active pitcher, re-apply so the live steam settings
+            // (and the machine) reflect the change immediately.
+            if (index == settings->brew()->selectedSteamPitcher()) applySteamPitcher(index);
             result["success"] = true;
             return result;
         },
@@ -238,7 +244,7 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
             result["selectedIndex"] = index;
             return result;
         },
-        "settings");
+        "control");  // switching the active pitcher, like bag_select / equipment_select
 
     // ---------------------------------------------------------------------
     // Hot water vessel presets
@@ -268,13 +274,14 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
     registry->registerTool(
         "water_vessel_add",
         "Add a new hot water vessel preset and select it. Provide a name; volumeMl, mode, "
-        "flowMlPerSec and temperatureC are optional (default 200 mL / weight / 4.0 mL/s / 85°C).",
+        "flowMlPerSec and temperatureC are optional (default 200 mL / weight / 4.0 mL/s; "
+        "temperature defaults to the current global hot water temperature).",
         QJsonObject{{"type", "object"}, {"properties", QJsonObject{
             {"name", QJsonObject{{"type", "string"}, {"description", "Display name for the vessel preset"}}},
             {"volumeMl", QJsonObject{{"type", "integer"}, {"description", "Target volume in mL (default 200)"}}},
             {"mode", QJsonObject{{"type", "string"}, {"description", "\"weight\" or \"volume\" (default weight)"}}},
             {"flowMlPerSec", QJsonObject{{"type", "number"}, {"description", "Hot water flow rate in mL/s (default 4.0)"}}},
-            {"temperatureC", QJsonObject{{"type", "number"}, {"description", "Hot water temperature in °C (default 85)"}}},
+            {"temperatureC", QJsonObject{{"type", "number"}, {"description", "Hot water temperature in °C (defaults to the current global hot water temperature)"}}},
             {"confirmed", kConfirmedProp.value("confirmed")}
         }}, {"required", QJsonArray{"name"}}},
         [settings, applyWaterVessel](const QJsonObject& args) -> QJsonObject {
@@ -311,7 +318,7 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
             {"temperatureC", QJsonObject{{"type", "number"}, {"description", "New hot water temperature in °C"}}},
             {"confirmed", kConfirmedProp.value("confirmed")}
         }}, {"required", QJsonArray{"index"}}},
-        [settings](const QJsonObject& args) -> QJsonObject {
+        [settings, applyWaterVessel](const QJsonObject& args) -> QJsonObject {
             QJsonObject result;
             if (!settings) { result["error"] = "Settings unavailable"; return result; }
             const int index = args.value("index").toInt();
@@ -330,6 +337,9 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
                 : (existing.contains("temperature") ? existing.value("temperature").toDouble()
                                                      : settings->brew()->waterTemperature());
             settings->brew()->updateWaterVesselPreset(index, name, volume, mode, flowRate, temp);
+            // If we edited the active vessel, re-apply so the live hot water settings
+            // (and the machine) reflect the change immediately.
+            if (index == settings->brew()->selectedWaterVessel()) applyWaterVessel(index);
             result["success"] = true;
             return result;
         },
@@ -376,5 +386,5 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
             result["selectedIndex"] = index;
             return result;
         },
-        "settings");
+        "control");  // switching the active vessel, like bag_select / equipment_select
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -761,6 +761,39 @@ add_decenza_test(tst_mcptools_write
 target_link_libraries(tst_mcptools_write PRIVATE Qt6::Graphs Qt6::Quick Qt6::TextToSpeech Qt6::Multimedia paho-mqtt3a-static)
 target_include_directories(tst_mcptools_write PRIVATE ${CMAKE_BINARY_DIR})
 
+# --- tst_mcptools_presets: steam-pitcher / water-vessel preset MCP tools ---
+# (unit conversions, partial-update merge, apply-on-select). MainController is
+# passed null; CONTROLLER_SOURCES is linked only to satisfy its referenced symbols.
+find_package(Qt6 REQUIRED COMPONENTS TextToSpeech Multimedia)
+add_decenza_test(tst_mcptools_presets
+    tst_mcptools_presets.cpp
+    ${MCP_MOC_HEADERS}
+    ${CMAKE_SOURCE_DIR}/src/mcp/mcptools_presets.cpp
+    ${PROFILEMANAGER_SOURCES}
+    ${CMAKE_SOURCE_DIR}/src/core/accessibilitymanager.cpp
+    ${CMAKE_SOURCE_DIR}/src/screensaver/screensavervideomanager.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/translationmanager.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/batterymanager.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_internal.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_serialize.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_queries.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/coffeebagstorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/equipmentstorage.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotprojection.h
+    ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
+    ${BLE_SOURCES}
+    ${PROFILE_SOURCES}
+    ${CORE_SOURCES}
+    ${MACHINE_SOURCES}
+    ${CONTROLLER_SOURCES}
+    ${SIMULATOR_SOURCES}
+    ${CMAKE_BINARY_DIR}/version_code.cpp
+)
+target_link_libraries(tst_mcptools_presets PRIVATE Qt6::Graphs Qt6::Quick Qt6::TextToSpeech Qt6::Multimedia paho-mqtt3a-static)
+target_include_directories(tst_mcptools_presets PRIVATE ${CMAKE_BINARY_DIR})
+
 # --- tst_mcpserver_session: Session management, ping, subscribe/unsubscribe ---
 # Uses real mcpserver.cpp but stubs out tool/resource registration functions
 # to avoid linking mcptools_*.cpp and their heavy transitive deps.

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -40,6 +40,7 @@ class AIManager;
 void registerMachineTools(McpToolRegistry*, DE1Device*, MachineState*, MainController*, ProfileManager*) {}
 void registerShotTools(McpToolRegistry*, ShotHistoryStorage*) {}
 void registerProfileTools(McpToolRegistry*, ProfileManager*, Settings*) {}
+void registerPresetsTools(McpToolRegistry*, Settings*, MainController*) {}
 void registerSettingsReadTools(McpToolRegistry*, Settings*, AccessibilityManager*, ScreensaverVideoManager*, TranslationManager*, BatteryManager*, AIManager*) {}
 void registerDialingTools(McpToolRegistry*, MainController*, ProfileManager*, ShotHistoryStorage*, Settings*) {}
 void registerControlTools(McpToolRegistry*, DE1Device*, MachineState*, ProfileManager*, MainController*, Settings*) {}

--- a/tests/tst_mcpserver_session.cpp
+++ b/tests/tst_mcpserver_session.cpp
@@ -30,6 +30,7 @@ class AIManager;
 void registerMachineTools(McpToolRegistry*, DE1Device*, MachineState*, MainController*, ProfileManager*) {}
 void registerShotTools(McpToolRegistry*, ShotHistoryStorage*) {}
 void registerProfileTools(McpToolRegistry*, ProfileManager*, Settings*) {}
+void registerPresetsTools(McpToolRegistry*, Settings*, MainController*) {}
 void registerSettingsReadTools(McpToolRegistry*, Settings*, AccessibilityManager*, ScreensaverVideoManager*, TranslationManager*, BatteryManager*, AIManager*) {}
 void registerDialingTools(McpToolRegistry*, MainController*, ProfileManager*, ShotHistoryStorage*, Settings*) {}
 void registerControlTools(McpToolRegistry*, DE1Device*, MachineState*, ProfileManager*, MainController*, Settings*) {}

--- a/tests/tst_mcptools_presets.cpp
+++ b/tests/tst_mcptools_presets.cpp
@@ -1,0 +1,188 @@
+#include <QtTest>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QSettings>
+
+#include "core/settings.h"
+#include "core/settings_brew.h"
+#include "mcp/mcptoolregistry.h"
+#include "ai/aimanager.h"
+#include "controllers/maincontroller.h"
+
+// The test passes a null MainController, so its implementation (and aimanager.cpp)
+// isn't linked. Define the handful of symbols mcptools_presets.cpp references so the
+// test links; the apply-to-machine paths are null-guarded and never call these.
+QVariantList AIManager::availableModels(const QString&) const { return {}; }
+void MainController::applySteamSettings() {}
+void MainController::applyHotWaterSettings() {}
+void MainController::turnOffSteamHeater() {}
+
+// Implemented in src/mcp/mcptools_presets.cpp.
+void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainController* mainController);
+
+// Exercises the steam-pitcher and hot-water-vessel MCP tools: unit conversions
+// (steam flow ×100, water flow ×10), partial-update merge (editing one field must
+// not clobber the others), apply-on-select / apply-on-update writing the active
+// settings, and the error guards.
+class tst_McpToolsPresets : public QObject {
+    Q_OBJECT
+
+    Settings m_settings;
+    McpToolRegistry m_registry;
+
+    // Raw preset-store snapshot, restored in cleanup so the dev machine's real
+    // steam/water presets aren't disturbed by the test.
+    QByteArray m_origPitcherPresets;
+    QByteArray m_origVesselPresets;
+    int m_origSelectedSteam = 0;
+    int m_origSelectedWater = 0;
+
+    QJsonObject call(const QString& name, const QJsonObject& args, int accessLevel = 2) {
+        QString err;
+        QJsonObject r = m_registry.callTool(name, args, accessLevel, err);
+        if (!err.isEmpty()) r.insert("callError", err);
+        return r;
+    }
+
+private slots:
+    void initTestCase() {
+        registerPresetsTools(&m_registry, &m_settings, nullptr);
+    }
+
+    void init() {
+        QSettings raw("DecentEspresso", "DE1Qt");
+        m_origPitcherPresets = raw.value("steam/pitcherPresets").toByteArray();
+        m_origVesselPresets = raw.value("water/vesselPresets").toByteArray();
+        m_origSelectedSteam = m_settings.brew()->selectedSteamPitcher();
+        m_origSelectedWater = m_settings.brew()->selectedWaterVessel();
+    }
+
+    void cleanup() {
+        QSettings raw("DecentEspresso", "DE1Qt");
+        raw.setValue("steam/pitcherPresets", m_origPitcherPresets);
+        raw.setValue("water/vesselPresets", m_origVesselPresets);
+        raw.sync();
+        m_settings.brew()->setSelectedSteamCup(m_origSelectedSteam);
+        m_settings.brew()->setSelectedWaterCup(m_origSelectedWater);
+    }
+
+    // --- steam ---------------------------------------------------------------
+
+    void steamAddConvertsFlowAndReportsBack() {
+        QJsonObject add = call("steam_pitcher_add",
+            {{"name", "Conv"}, {"durationSec", 28}, {"flowMlPerSec", 1.5}, {"temperatureC", 134.0}});
+        QVERIFY(add["success"].toBool());
+        const int idx = add["selectedIndex"].toInt();
+
+        // Stored in hundredths of mL/s.
+        QCOMPARE(m_settings.brew()->getSteamPitcherPreset(idx)["flow"].toInt(), 150);
+        QCOMPARE(m_settings.brew()->getSteamPitcherPreset(idx)["temperature"].toDouble(), 134.0);
+
+        // list reports mL/s.
+        QJsonArray presets = call("steam_pitcher_list", {})["presets"].toArray();
+        QJsonObject p = presets[idx].toObject();
+        QCOMPARE(p["flowMlPerSec"].toDouble(), 1.5);
+        QCOMPARE(p["durationSec"].toInt(), 28);
+        QCOMPARE(p["temperatureC"].toDouble(), 134.0);
+    }
+
+    void steamPartialUpdatePreservesOtherFields() {
+        QJsonObject add = call("steam_pitcher_add",
+            {{"name", "Edit"}, {"durationSec", 40}, {"flowMlPerSec", 1.2}, {"temperatureC", 145.0}});
+        const int idx = add["selectedIndex"].toInt();
+
+        // Change only the temperature.
+        QVERIFY(call("steam_pitcher_update", {{"index", idx}, {"temperatureC", 150.0}})["success"].toBool());
+
+        QVariantMap p = m_settings.brew()->getSteamPitcherPreset(idx);
+        QCOMPARE(p["temperature"].toDouble(), 150.0);
+        QCOMPARE(p["duration"].toInt(), 40);   // unchanged
+        QCOMPARE(p["flow"].toInt(), 120);      // unchanged (1.2 mL/s)
+        QCOMPARE(p["name"].toString(), QString("Edit"));
+    }
+
+    void steamSelectAppliesTemperatureToActive() {
+        const int a = call("steam_pitcher_add", {{"name", "A"}, {"temperatureC", 130.0}})["selectedIndex"].toInt();
+        call("steam_pitcher_add", {{"name", "B"}, {"temperatureC", 150.0}});  // now selected, active = 150
+        QCOMPARE(m_settings.brew()->steamTemperature(), 150.0);
+
+        QVERIFY(call("steam_pitcher_select", {{"index", a}}, /*control*/ 1)["success"].toBool());
+        QCOMPARE(m_settings.brew()->steamTemperature(), 130.0);  // apply-on-select
+    }
+
+    void steamUpdateOfSelectedReappliesActive() {
+        const int a = call("steam_pitcher_add", {{"name", "Sel"}, {"temperatureC", 128.0}})["selectedIndex"].toInt();
+        QCOMPARE(m_settings.brew()->steamTemperature(), 128.0);
+        QVERIFY(call("steam_pitcher_update", {{"index", a}, {"temperatureC", 137.0}})["success"].toBool());
+        QCOMPARE(m_settings.brew()->steamTemperature(), 137.0);  // re-applied because it's selected
+    }
+
+    void steamUpdateDisabledRejected() {
+        const int before = m_settings.brew()->steamPitcherPresets().size();
+        call("steam_pitcher_add", {{"name", "Off"}, {"disabled", true}});
+        const int idx = m_settings.brew()->steamPitcherPresets().size() - 1;
+        QVERIFY(idx >= before);
+        QJsonObject r = call("steam_pitcher_update", {{"index", idx}, {"temperatureC", 150.0}});
+        QVERIFY(!r["success"].toBool());
+        QVERIFY(r.contains("error"));
+    }
+
+    void steamUpdateOutOfRangeErrors() {
+        QJsonObject r = call("steam_pitcher_update", {{"index", 9999}, {"temperatureC", 150.0}});
+        QVERIFY(!r["success"].toBool());
+        QCOMPARE(r["error"].toString(), QString("index out of range"));
+    }
+
+    void steamAddRequiresName() {
+        QJsonObject r = call("steam_pitcher_add", {{"name", "   "}});
+        QVERIFY(r.contains("error"));
+    }
+
+    // --- water ---------------------------------------------------------------
+
+    void waterAddConvertsFlowAndReportsBack() {
+        QJsonObject add = call("water_vessel_add",
+            {{"name", "WConv"}, {"volumeMl", 150}, {"flowMlPerSec", 4.0}, {"temperatureC", 79.0}, {"mode", "volume"}});
+        QVERIFY(add["success"].toBool());
+        const int idx = add["selectedIndex"].toInt();
+
+        QCOMPARE(m_settings.brew()->getWaterVesselPreset(idx)["flowRate"].toInt(), 40);  // tenths of mL/s
+        QJsonObject p = call("water_vessel_list", {})["presets"].toArray()[idx].toObject();
+        QCOMPARE(p["flowMlPerSec"].toDouble(), 4.0);
+        QCOMPARE(p["volumeMl"].toInt(), 150);
+        QCOMPARE(p["mode"].toString(), QString("volume"));
+        QCOMPARE(p["temperatureC"].toDouble(), 79.0);
+    }
+
+    void waterPartialUpdatePreservesOtherFields() {
+        QJsonObject add = call("water_vessel_add",
+            {{"name", "WEdit"}, {"volumeMl", 250}, {"flowMlPerSec", 3.0}, {"temperatureC", 86.0}});
+        const int idx = add["selectedIndex"].toInt();
+
+        QVERIFY(call("water_vessel_update", {{"index", idx}, {"temperatureC", 90.0}})["success"].toBool());
+
+        QVariantMap p = m_settings.brew()->getWaterVesselPreset(idx);
+        QCOMPARE(p["temperature"].toDouble(), 90.0);
+        QCOMPARE(p["volume"].toInt(), 250);    // unchanged
+        QCOMPARE(p["flowRate"].toInt(), 30);   // unchanged (3.0 mL/s)
+    }
+
+    void waterSelectAppliesToActive() {
+        const int a = call("water_vessel_add", {{"name", "WA"}, {"temperatureC", 74.0}, {"volumeMl", 120}})["selectedIndex"].toInt();
+        call("water_vessel_add", {{"name", "WB"}, {"temperatureC", 95.0}});  // selected, active = 95
+        QCOMPARE(m_settings.brew()->waterTemperature(), 95.0);
+
+        QVERIFY(call("water_vessel_select", {{"index", a}}, /*control*/ 1)["success"].toBool());
+        QCOMPARE(m_settings.brew()->waterTemperature(), 74.0);
+        QCOMPARE(m_settings.brew()->waterVolume(), 120);
+    }
+
+    void waterDeleteOutOfRangeErrors() {
+        QJsonObject r = call("water_vessel_delete", {{"index", 9999}});
+        QVERIFY(!r["success"].toBool());
+        QCOMPARE(r["error"].toString(), QString("index out of range"));
+    }
+};
+
+QTEST_GUILESS_MAIN(tst_McpToolsPresets)
+#include "tst_mcptools_presets.moc"

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -76,6 +76,7 @@ private:
     QString m_origDyeBeanBaseData;
     double m_origWaterTemperature;
     QByteArray m_origVesselPresets;
+    QByteArray m_origPitcherPresets;
 
 private slots:
 
@@ -97,7 +98,8 @@ private slots:
         m_origDyeBeanBaseData = m_settings.dye()->dyeBeanBaseData();
         m_origWaterTemperature = m_settings.brew()->waterTemperature();
         { QSettings raw("DecentEspresso", "DE1Qt");
-          m_origVesselPresets = raw.value("water/vesselPresets").toByteArray(); }
+          m_origVesselPresets = raw.value("water/vesselPresets").toByteArray();
+          m_origPitcherPresets = raw.value("steam/pitcherPresets").toByteArray(); }
     }
 
     void cleanup() {
@@ -119,6 +121,7 @@ private slots:
         m_settings.brew()->setWaterTemperature(m_origWaterTemperature);
         { QSettings raw("DecentEspresso", "DE1Qt");
           raw.setValue("water/vesselPresets", m_origVesselPresets);
+          raw.setValue("steam/pitcherPresets", m_origPitcherPresets);
           raw.sync(); }
     }
 
@@ -440,6 +443,47 @@ private slots:
         const QJsonArray exported = bundle["water"].toObject()["vesselPresets"].toArray();
         QCOMPARE(exported.size(), 1);
         QCOMPARE(exported[0].toObject()["temperature"].toDouble(), 88.0);
+    }
+
+    void steamPitcherPresetTemperatureRoundTrip() {
+        // Per-pitcher steam temperature must survive an export -> import cycle.
+        m_settings.brew()->addSteamPitcherPreset("Latte", 45, 150, 135.0);
+        const int idx = static_cast<int>(m_settings.brew()->steamPitcherPresets().size()) - 1;
+
+        QJsonObject bundle = SettingsSerializer::exportToJson(&m_settings, false);
+
+        // Mutate the preset's temperature to confirm import overwrites it.
+        m_settings.brew()->updateSteamPitcherPreset(idx, "Latte", 45, 150, 120.0);
+        QCOMPARE(m_settings.brew()->getSteamPitcherPreset(idx)["temperature"].toDouble(), 120.0);
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(QStringLiteral("SettingsSerializer: importFromJson replacing .* favorites")));
+        QVERIFY(SettingsSerializer::importFromJson(&m_settings, bundle));
+
+        QCOMPARE(m_settings.brew()->getSteamPitcherPreset(idx)["temperature"].toDouble(), 135.0);
+    }
+
+    void steamPitcherLegacyTemperatureFallsBackToGlobal() {
+        // A pitcher preset that predates the per-pitcher temperature field (no
+        // "temperature" key) must export with the device's current global steam
+        // temperature, not 0 — guards the migration fallback in exportToJson.
+        QJsonObject legacy;
+        legacy["name"] = "Legacy";
+        legacy["duration"] = 30;
+        legacy["flow"] = 150;
+        QJsonArray arr; arr.append(legacy);
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          raw.setValue("steam/pitcherPresets", QJsonDocument(arr).toJson());
+          raw.sync(); }
+
+        // Read through a fresh Settings instance so it picks up the raw write.
+        Settings fresh;
+        fresh.brew()->setSteamTemperature(142.0);
+        const QJsonObject bundle = SettingsSerializer::exportToJson(&fresh, false);
+
+        const QJsonArray exported = bundle["steam"].toObject()["pitcherPresets"].toArray();
+        QCOMPARE(exported.size(), 1);
+        QCOMPARE(exported[0].toObject()["temperature"].toDouble(), 142.0);
     }
 
     // ==========================================


### PR DESCRIPTION
Closes #1402

## Problem

Steam temperature was a single global setting (`steam/temperature`) shared by **every** pitcher preset, while presets stored `duration`/`flow`/`pitcherWeightG`/`calibMilkG` per-preset. So changing the steam temp changed it for all pitchers, and selecting a pitcher never restored a per-pitcher temperature — the same structural bug just fixed for hot water vessel presets ([#1399](https://github.com/Kulitorum/Decenza/pull/1399)).

## Fix

Make steam temperature per-pitcher, mirroring the hot-water fix. `Settings.brew.steamTemperature` stays the "active" value sent to the machine; it's loaded from / saved to the selected pitcher.

**C++**
- `addSteamPitcherPreset` / `updateSteamPitcherPreset` gain a `temperature` param, stored in the preset JSON. Disabled "Off" presets carry no temperature (heater off).
- `settingsserializer` round-trips per-pitcher temperature, with the legacy-preset → global steam temperature fallback (export and import symmetric).

**QML**
- `SteamPage`: `getCurrentPitcherTemperature()` + the selected-pitcher `Connections` block load the pitcher's temperature into the slider and the active steam temperature, so the subsequent `startSteamHeating`/`applySteamSettings` push the per-pitcher value. The temperature slider saves back into the preset; creating a pitcher seeds + selects it; page activation syncs the temperature.
- `IdlePage` / `SteamItem` pitcher selection apply the preset's temperature before `applySteamSettings`.
- Null-guard `ScaleDevice` in `SteamPage.currentMeasuredMilk` (touched file).

## Behaviour note

Unlike the instant hot-water tap, the steam boiler has thermal mass — making temperature per-pitcher means switching pitchers re-commands a different boiler target, so the boiler re-heats/cools on each switch. That's the intended trade for per-pitcher control. "Off" presets are unaffected.

## Testing

- Build clean (0 errors, 0 warnings) in Qt Creator.
- `tst_settings`: **36 passed, 0 failed**, including new `steamPitcherPresetTemperatureRoundTrip` and `steamPitcherLegacyTemperatureFallsBackToGlobal` (plus the existing water equivalents).
- Runtime UX verification (per-pitcher temp loads on selection / persists per pitcher) pending in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR: MCP control of pitcher / vessel presets

Exposes the steam-pitcher and hot-water-vessel presets over MCP (depends on the per-preset `temperature` field above), so they can be managed and switched programmatically:

- `steam_pitcher_list` / `_add` / `_update` / `_delete` / `_select`
- `water_vessel_list` / `_add` / `_update` / `_delete` / `_select`

Conventions: °C / mL/s / s / mL with units in field names; the store's hundredths-of-mL/s (steam) and tenths-of-mL/s (water) are converted in the tool layer. Mutating tools are category `settings`; lists are `read`; updates are partial. **Select** (and **add**, which auto-selects) apply the preset's parameters to the active settings and push to the machine via `MainController`, matching the QML selection handlers.

**Verified live via MCP** against the running app: full CRUD on both domains, per-preset temperatures independent (editing one leaves others unchanged), and apply-on-select reflected in `settings_get`. Build clean; `tst_mcpserver_protocol` 34/34 and `tst_mcpserver_session` 16/16 pass.