### PR TITLE
android: lifecycle-gate battery polling; capture ART abort message in crash reports

### DIFF
--- a/src/core/batterymanager.cpp
+++ b/src/core/batterymanager.cpp
@@ -111,8 +111,8 @@ void BatteryManager::setChargingMode(int mode) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 void BatteryManager::checkBattery() {
-    // See m_appActive: skip while the app is suspended/backgrounded so we don't
-    // race Android's Activity teardown with a JNI battery-status read.
+    // See m_appActive: nothing useful to poll while suspended, and it keeps
+    // JNI battery reads out of the suspend window.
     if (!m_appActive)
         return;
 

--- a/src/core/batterymanager.cpp
+++ b/src/core/batterymanager.cpp
@@ -111,6 +111,11 @@ void BatteryManager::setChargingMode(int mode) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 void BatteryManager::checkBattery() {
+    // See m_appActive: skip while the app is suspended/backgrounded so we don't
+    // race Android's Activity teardown with a JNI battery-status read.
+    if (!m_appActive)
+        return;
+
     int newPercent = readPlatformBatteryPercent();
 
     if (newPercent != m_batteryPercent) {

--- a/src/core/batterymanager.cpp
+++ b/src/core/batterymanager.cpp
@@ -33,6 +33,17 @@ BatteryManager::BatteryManager(QObject* parent)
 // Setup
 // ─────────────────────────────────────────────────────────────────────────────
 
+void BatteryManager::setAppActive(bool active) {
+    if (m_appActive == active)
+        return;
+    m_appActive = active;
+    // One line per transition so the gap in the periodic battery telemetry is
+    // attributable from the log — a silently gated poll is indistinguishable
+    // from a frozen event loop otherwise.
+    qDebug() << "BatteryManager: poll" << (active ? "re-armed (app no longer suspended)"
+                                                  : "gated (app suspended)");
+}
+
 void BatteryManager::setDE1Device(DE1Device* device) {
     m_device = device;
 
@@ -41,6 +52,9 @@ void BatteryManager::setDE1Device(DE1Device* device) {
     // sit for up to a minute with its USB port in the wrong state — on at 70 % when we
     // want it off, for example. We only act on the rising edge (isConnected == true);
     // the disconnect edge is handled by the early return in applySmartCharging().
+    // If the DE1 reconnects while the app is suspended this apply is gated (see
+    // m_appActive) — resume re-runs checkBattery(), and the DE1's 10-minute
+    // auto-enable keeps the tablet charging in the interim.
     connect(device, &DE1Device::connectedChanged, this, [this]() {
         if (m_device && m_device->isConnected())
             checkBattery();

--- a/src/core/batterymanager.h
+++ b/src/core/batterymanager.h
@@ -84,9 +84,9 @@ public:
     // the tablet can charge while the app is not running. Matches de1app behaviour.
     void ensureChargerOn();
 
-    // Call from the applicationStateChanged handler. While inactive, checkBattery()
-    // becomes a no-op — see m_appActive for why.
-    void setAppActive(bool active) { m_appActive = active; }
+    // Call from the applicationStateChanged handler: false on Suspended, true on
+    // any other state. While false, checkBattery() is a no-op — see m_appActive.
+    void setAppActive(bool active);
 
 public slots:
     // Change the smart charging mode and apply it immediately. Persists to QSettings.
@@ -128,13 +128,23 @@ private:
     // cadence regardless of app lifecycle state, so its callback can land after
     // applicationStateChanged reports Suspended but before Android freezes the
     // event loop. There's nothing useful for the poll to do in that window:
-    // ensureChargerOn() has already forced the DE1 USB port ON (the terminal
-    // safe state, which the DE1's 10-minute auto-enable keeps asserted), the UI
-    // isn't visible, and main.cpp re-runs checkBattery() on resume. Skipping
-    // also avoids doing JNI work while suspended — the poll's JNI allocation is
-    // where crash #1408 surfaced (though the abort there was ART's global-ref
-    // table filling up over hours, i.e. a leak elsewhere; this gate removes the
-    // suspended-poll trigger, it does not fix such a leak).
+    // ensureChargerOn() runs later in the same suspend handler — before the
+    // event loop can deliver a gated tick — and commands the DE1 USB port ON
+    // when the DE1 is connected (when it isn't, the DE1's own 10-minute
+    // auto-enable restores the port by itself); the UI isn't visible; and
+    // main.cpp re-runs checkBattery() on resume. Skipping also keeps JNI work
+    // out of the suspend window — the poll's JNI allocation is where crash
+    // #1408 surfaced (its stack aborts inside ART's AddGlobalRef, whose FATAL
+    // path is global-ref table overflow, i.e. a slow leak elsewhere; the gate
+    // removes the suspended-poll trigger, it does not fix such a leak).
+    //
+    // main.cpp re-arms the gate on ANY non-Suspended state, not just Active —
+    // a resume can land on Inactive and stay there (split-screen with the
+    // other window focused, focus-stealing overlays), and a gate that waits
+    // for the literal Active transition would strand the poll off while the
+    // app is visible: battery display frozen and, worse, smart charging no
+    // longer reasserting port-OFF, so the DE1's 10-minute auto-enable would
+    // quietly charge the tablet past the configured ceiling.
     bool m_appActive = true;
 
     int  m_batteryPercent = 100;

--- a/src/core/batterymanager.h
+++ b/src/core/batterymanager.h
@@ -124,16 +124,17 @@ private:
     Settings*  m_settings = nullptr;
     QTimer     m_checkTimer;  // Fires every 60 s to run checkBattery()
 
-    // Guards checkBattery() against running while Android is tearing down the
-    // Activity. m_checkTimer keeps ticking on its own 60 s cadence regardless of
-    // app lifecycle state, so its callback can land after applicationStateChanged
-    // reports Suspended but before the process actually stops. On Android,
-    // readPlatformBatteryPercent() calls into JNI (QtNative.getContext(),
-    // registerReceiver()); doing that while the Activity/Context is mid-destroy
-    // makes ART hard-abort (SIGABRT in JavaVMExt::AddGlobalRef) instead of
-    // failing gracefully. main.cpp clears this synchronously in the same
-    // single-threaded event loop the timer fires on, so it's set before any
-    // timeout event processed afterward can reach readPlatformBatteryPercent().
+    // Suspend gate for the poll. m_checkTimer keeps ticking on its own 60 s
+    // cadence regardless of app lifecycle state, so its callback can land after
+    // applicationStateChanged reports Suspended but before Android freezes the
+    // event loop. There's nothing useful for the poll to do in that window:
+    // ensureChargerOn() has already forced the DE1 USB port ON (the terminal
+    // safe state, which the DE1's 10-minute auto-enable keeps asserted), the UI
+    // isn't visible, and main.cpp re-runs checkBattery() on resume. Skipping
+    // also avoids doing JNI work while suspended — the poll's JNI allocation is
+    // where crash #1408 surfaced (though the abort there was ART's global-ref
+    // table filling up over hours, i.e. a leak elsewhere; this gate removes the
+    // suspended-poll trigger, it does not fix such a leak).
     bool m_appActive = true;
 
     int  m_batteryPercent = 100;

--- a/src/core/batterymanager.h
+++ b/src/core/batterymanager.h
@@ -84,6 +84,10 @@ public:
     // the tablet can charge while the app is not running. Matches de1app behaviour.
     void ensureChargerOn();
 
+    // Call from the applicationStateChanged handler. While inactive, checkBattery()
+    // becomes a no-op — see m_appActive for why.
+    void setAppActive(bool active) { m_appActive = active; }
+
 public slots:
     // Change the smart charging mode and apply it immediately. Persists to QSettings.
     void setChargingMode(int mode);
@@ -119,6 +123,18 @@ private:
     DE1Device* m_device   = nullptr;
     Settings*  m_settings = nullptr;
     QTimer     m_checkTimer;  // Fires every 60 s to run checkBattery()
+
+    // Guards checkBattery() against running while Android is tearing down the
+    // Activity. m_checkTimer keeps ticking on its own 60 s cadence regardless of
+    // app lifecycle state, so its callback can land after applicationStateChanged
+    // reports Suspended but before the process actually stops. On Android,
+    // readPlatformBatteryPercent() calls into JNI (QtNative.getContext(),
+    // registerReceiver()); doing that while the Activity/Context is mid-destroy
+    // makes ART hard-abort (SIGABRT in JavaVMExt::AddGlobalRef) instead of
+    // failing gracefully. main.cpp clears this synchronously in the same
+    // single-threaded event loop the timer fires on, so it's set before any
+    // timeout event processed afterward can reach readPlatformBatteryPercent().
+    bool m_appActive = true;
 
     int  m_batteryPercent = 100;
     bool m_isCharging     = true;

--- a/src/core/crashhandler.cpp
+++ b/src/core/crashhandler.cpp
@@ -20,6 +20,9 @@
 #include <unwind.h>
 #include <dlfcn.h>
 #include <cxxabi.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <time.h>
 #endif
 
 #if (defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)) || defined(Q_OS_MACOS) || defined(Q_OS_IOS)
@@ -36,6 +39,12 @@
 static char s_crashLogPath[512] = {0};
 static char s_debugLogPath[512] = {0};
 static char s_lastDebugMessage[4096] = {0};
+
+#ifdef Q_OS_ANDROID
+// "--pid=<N>" argument for logcat, precomputed in install() so the signal
+// handler never has to format it.
+static char s_logcatPidArg[32] = {0};
+#endif
 
 // Store recent debug messages for context
 static QtMessageHandler s_previousHandler = nullptr;
@@ -104,6 +113,52 @@ static void writeBacktraceToFile(FILE* f)
             fprintf(f, "  #%zu: %p\n", i, buffer[i]);
         }
     }
+}
+
+// Append the tail of this process's logcat to the crash log. The point is the
+// abort message: when ART kills us (JNI errors like global reference table
+// overflow, CheckJNI failures), it logs the FATAL reason — and for ref-table
+// overflow, a dump of the table's dominant classes — to logd *before* raising
+// SIGABRT. Our own qDebug log never sees that text, so without this section a
+// SIGABRT-from-ART report shows where we were, but not why ART aborted (#1408).
+//
+// An app may always read its own logs (logd filters by UID, no READ_LOGS
+// needed). fork() in a signal handler is not strictly async-signal-safe, but
+// the child only calls dup2/execl (both AS-safe) and the rest of this crash
+// handler already relies on far less safe machinery (stdio, demangling).
+static void appendLogcatTailToFile(FILE* f)
+{
+    fprintf(f, "\nSystem log tail (logcat, includes ART abort message if any):\n");
+    // Flush stdio before the child writes to the shared file description so
+    // output doesn't interleave out of order.
+    fflush(f);
+
+    pid_t child = fork();
+    if (child == 0) {
+        dup2(fileno(f), STDOUT_FILENO);
+        dup2(fileno(f), STDERR_FILENO);
+        execl("/system/bin/logcat", "logcat", "-d", "-t", "200",
+              s_logcatPidArg, static_cast<char*>(nullptr));
+        _exit(127);
+    }
+    if (child < 0) {
+        fprintf(f, "  (fork failed, no logcat capture)\n");
+        return;
+    }
+
+    // Bounded wait: logcat -d exits almost immediately, but never let a wedged
+    // child hang the crash handler. ~3 s cap, then kill and move on.
+    for (int i = 0; i < 60; ++i) {
+        int status = 0;
+        pid_t r = waitpid(child, &status, WNOHANG);
+        if (r == child || r < 0)
+            return;
+        struct timespec ts = {0, 50 * 1000 * 1000};  // 50 ms
+        nanosleep(&ts, nullptr);
+    }
+    kill(child, SIGKILL);
+    waitpid(child, nullptr, 0);
+    fprintf(f, "  (logcat timed out after 3s)\n");
 }
 #endif
 
@@ -200,6 +255,12 @@ void CrashHandler::writeCrashLog(int signal, const char* signalName)
     fprintf(f, "\nBacktrace: not available on this platform\n");
 #endif
 
+#ifdef Q_OS_ANDROID
+    // Only into crash.log (which becomes the report's "Crash Log" section) —
+    // not into the debug.log copy below, whose tail is submitted separately.
+    appendLogcatTailToFile(f);
+#endif
+
     fprintf(f, "\n=== END CRASH REPORT ===\n");
     fflush(f);
     fclose(f);
@@ -260,6 +321,10 @@ void CrashHandler::install()
     QString debugPath = dataPath + "/debug.log";
     QByteArray debugPathBytes = debugPath.toUtf8();
     strncpy(s_debugLogPath, debugPathBytes.constData(), sizeof(s_debugLogPath) - 1);
+
+#ifdef Q_OS_ANDROID
+    snprintf(s_logcatPidArg, sizeof(s_logcatPidArg), "--pid=%d", getpid());
+#endif
 
     qDebug() << "CrashHandler: Installing signal handlers, crash log path:" << logPath;
 

--- a/src/core/crashhandler.cpp
+++ b/src/core/crashhandler.cpp
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <sys/wait.h>
 #include <time.h>
+#include <errno.h>
 #endif
 
 #if (defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)) || defined(Q_OS_MACOS) || defined(Q_OS_IOS)
@@ -124,19 +125,26 @@ static void writeBacktraceToFile(FILE* f)
 //
 // An app may always read its own logs (logd filters by UID, no READ_LOGS
 // needed). fork() in a signal handler is not strictly async-signal-safe, but
-// the child only calls dup2/execl (both AS-safe) and the rest of this crash
-// handler already relies on far less safe machinery (stdio, demangling).
+// between fork and exec the child calls only dup2/execl/_exit (all AS-safe;
+// the fd is captured before the fork) and the rest of this crash handler
+// already relies on far less safe machinery (stdio, demangling).
+//
+// Every outcome writes a distinct marker line: this section exists to explain
+// crashes, so an empty section must be attributable (exec denied vs. logd
+// rotated this pid out vs. capture killed) rather than read as "no entries".
 static void appendLogcatTailToFile(FILE* f)
 {
     fprintf(f, "\nSystem log tail (logcat, includes ART abort message if any):\n");
     // Flush stdio before the child writes to the shared file description so
     // output doesn't interleave out of order.
     fflush(f);
+    const int outFd = fileno(f);
+    const off_t startOffset = lseek(outFd, 0, SEEK_CUR);
 
     pid_t child = fork();
     if (child == 0) {
-        dup2(fileno(f), STDOUT_FILENO);
-        dup2(fileno(f), STDERR_FILENO);
+        if (dup2(outFd, STDOUT_FILENO) < 0 || dup2(outFd, STDERR_FILENO) < 0)
+            _exit(126);
         execl("/system/bin/logcat", "logcat", "-d", "-t", "200",
               s_logcatPidArg, static_cast<char*>(nullptr));
         _exit(127);
@@ -151,14 +159,38 @@ static void appendLogcatTailToFile(FILE* f)
     for (int i = 0; i < 60; ++i) {
         int status = 0;
         pid_t r = waitpid(child, &status, WNOHANG);
-        if (r == child || r < 0)
+        if (r == child) {
+            if (WIFEXITED(status) && WEXITSTATUS(status) == 127)
+                fprintf(f, "  (logcat exec failed — no capture)\n");
+            else if (WIFEXITED(status) && WEXITSTATUS(status) == 126)
+                fprintf(f, "  (dup2 failed in capture child — no capture)\n");
+            else if (WIFSIGNALED(status))
+                fprintf(f, "  (logcat died on signal %d)\n", WTERMSIG(status));
+            else if (lseek(outFd, 0, SEEK_CUR) == startOffset)
+                fprintf(f, "  (logcat ran but wrote nothing — entries for this pid may have rotated out of logd)\n");
+            else
+                fprintf(f, "  (end of logcat tail)\n");
             return;
+        }
+        if (r < 0) {
+            // ECHILD (e.g. SIGCHLD set to SIG_IGN elsewhere in the process):
+            // we can no longer observe the child, so make sure it isn't still
+            // writing into this file while we finish the report.
+            kill(child, SIGKILL);
+            fprintf(f, "  (waitpid failed, errno=%d — log tail above may be incomplete)\n", errno);
+            return;
+        }
         struct timespec ts = {0, 50 * 1000 * 1000};  // 50 ms
         nanosleep(&ts, nullptr);
     }
+    // Timed out. Kill and reap best-effort only — a blocking waitpid here could
+    // hang the whole crash handler on a child stuck in uninterruptible sleep,
+    // which on a distressed device is exactly when this code runs.
     kill(child, SIGKILL);
-    waitpid(child, nullptr, 0);
-    fprintf(f, "  (logcat timed out after 3s)\n");
+    struct timespec ts = {0, 50 * 1000 * 1000};  // 50 ms
+    nanosleep(&ts, nullptr);
+    waitpid(child, nullptr, WNOHANG);
+    fprintf(f, "  (logcat killed after 3s — output above may be truncated or missing)\n");
 }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2949,9 +2949,9 @@ int main(int argc, char *argv[])
         if (state == Qt::ApplicationSuspended) {
             wasSuspended = true;
 
-            // Stop BatteryManager's periodic JNI battery reads before anything else.
-            // Its 60 s poll timer isn't tied to app lifecycle, so it can otherwise fire
-            // while Android is mid-teardown of the Activity/Context and crash (issue #1408).
+            // Gate BatteryManager's periodic poll while suspended. Its 60 s timer
+            // isn't tied to app lifecycle, so it can otherwise keep firing JNI
+            // battery reads in the background (see m_appActive in batterymanager.h).
             batteryManager.setAppActive(false);
 
 #ifdef Q_OS_ANDROID

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2946,13 +2946,13 @@ int main(int argc, char *argv[])
         }
         qDebug() << "[AppState] applicationStateChanged ->" << name;
 
+        // Gate BatteryManager's poll while suspended; re-arm on any other state
+        // so a missed Active transition can't strand it (see m_appActive in
+        // batterymanager.h for the full rationale).
+        batteryManager.setAppActive(state != Qt::ApplicationSuspended);
+
         if (state == Qt::ApplicationSuspended) {
             wasSuspended = true;
-
-            // Gate BatteryManager's periodic poll while suspended. Its 60 s timer
-            // isn't tied to app lifecycle, so it can otherwise keep firing JNI
-            // battery reads in the background (see m_appActive in batterymanager.h).
-            batteryManager.setAppActive(false);
 
 #ifdef Q_OS_ANDROID
             // Disable accessibility bridge before surface is destroyed.
@@ -2987,7 +2987,6 @@ int main(int argc, char *argv[])
         else if (state == Qt::ApplicationActive && wasSuspended) {
             qDebug() << "App resumed from suspended state";
             wasSuspended = false;
-            batteryManager.setAppActive(true);
 
 #ifdef Q_OS_ANDROID
             // Re-enable accessibility bridge now that the EGL surface is valid again

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2949,6 +2949,11 @@ int main(int argc, char *argv[])
         if (state == Qt::ApplicationSuspended) {
             wasSuspended = true;
 
+            // Stop BatteryManager's periodic JNI battery reads before anything else.
+            // Its 60 s poll timer isn't tied to app lifecycle, so it can otherwise fire
+            // while Android is mid-teardown of the Activity/Context and crash (issue #1408).
+            batteryManager.setAppActive(false);
+
 #ifdef Q_OS_ANDROID
             // Disable accessibility bridge before surface is destroyed.
             // Prevents deadlock between QtAndroidAccessibility::runInObjectContext()
@@ -2982,6 +2987,7 @@ int main(int argc, char *argv[])
         else if (state == Qt::ApplicationActive && wasSuspended) {
             qDebug() << "App resumed from suspended state";
             wasSuspended = false;
+            batteryManager.setAppActive(true);
 
 #ifdef Q_OS_ANDROID
             // Re-enable accessibility bridge now that the EGL surface is valid again


### PR DESCRIPTION
## Summary

Follow-up work on the crash in #1408 (SIGABRT in `BatteryManager::readPlatformBatteryPercent()` via JNI). Two parts:

### 1. Crash reports now capture the ART abort message (the real diagnostic gap)

Re-analysis of the #1408 backtrace: the abort fires from a `LOG(FATAL)` **inside** `art::JavaVMExt::AddGlobalRef` (frame 7, with `LogMessage::~LogMessage` → `Runtime::Abort` above it). The only FATAL path in that function is **global reference table overflow** (max=51200). JNI global refs are VM-level, not Activity-level — Activity teardown cannot make `AddGlobalRef` abort, so the initial "JNI during suspend teardown" theory doesn't hold.

The numbers point at a slow global-ref leak over the 12.3 h session: the battery poll's ~8 refs/cycle are released properly (≤6k even if fully leaked), while the screensaver logged **397 video transitions**, each destroying/recreating the MediaCodec-backed MediaPlayer — ~125 leaked refs per cycle would land exactly at the 51,200 cap. The battery poll was just the allocation that hit the full table; the suspend timing was coincidental.

We can't verify this from the existing report because ART writes the FATAL reason **and a ref-table dump naming the dominant class** to logd before raising SIGABRT — and our crash reports never captured it. Now the Android signal handler appends `logcat -d -t 200 --pid=<us>` to `crash.log` (fork + execl; the child only calls dup2/execl; bounded 3 s wait; apps can always read their own logs). `crash.log` flows verbatim into the auto-reported issue's "Crash Log" section, so **the next occurrence of this crash will name its own cause**, including the leaking class.

### 2. BatteryManager suspend gate (kept, reframed as hygiene)

`BatteryManager`'s 60 s poll timer isn't lifecycle-aware, so it kept firing JNI battery reads after `Qt::ApplicationSuspended`. There's nothing useful to poll then: `ensureChargerOn()` has already forced the DE1 USB port ON (and the DE1's 10-min auto-enable keeps it there), and resume re-runs `checkBattery()` immediately. New `setAppActive()` gate, cleared first thing on suspend, restored on resume. This removes the suspended-poll trigger seen in #1408 but is **not** claimed to fix the underlying abort — comments corrected accordingly.

## Notes for review

- Not reproducible locally (unknown reporter, older release v1.7.6), hence the emphasis on self-diagnosing reports.
- `fork()` in a signal handler isn't strictly async-signal-safe, but the child does only AS-safe calls, and the existing handler already uses stdio/demangling/malloc — this doesn't lower the bar.
- The logcat section goes only into `crash.log`, not the `debug.log` copy (whose tail is submitted separately) — no duplication.
- New code is all `#ifdef Q_OS_ANDROID`; macOS build verifies nothing of it → needs a CI Android test build before merge.

## Test plan

- [x] Builds clean via Qt Creator (0 errors, 0 warnings)
- [ ] CI Android test build (`android-release.yml`, no upload)
- [ ] Next auto-reported Android SIGABRT should include the "System log tail" section with ART's abort message

Related to #1408 (deliberately not "Fixes" — the suspected global-ref leak is still at large; the next report will confirm or refute it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)