### PR TITLE
Live coaching (during-shot): real-time on-device cues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ set(SOURCES
     src/ai/aiprovider.cpp
     src/ai/aiconversation.cpp
     src/ai/conductance.cpp
+    src/ai/liveshotcoach.cpp
     src/ai/shotanalysis.cpp
     src/ai/shotsummarizer.cpp
     src/ai/shotsummarizer_kb.cpp
@@ -489,6 +490,7 @@ set(HEADERS
     src/ai/aimanager.h
     src/ai/aiprovider.h
     src/ai/conductance.h
+    src/ai/liveshotcoach.h
     src/ai/shotanalysis.h
     src/ai/shotsummarizer.h
     src/history/shothistory_types.h
@@ -734,6 +736,7 @@ set(QML_FILES
 	qml/components/BrewDialog.qml
     qml/components/CircularGauge.qml
     qml/components/ConnectionIndicator.qml
+    qml/components/LiveCoachingBanner.qml
     qml/components/FavoritesListView.qml
     qml/components/PresetPillRow.qml
     qml/components/ValueInput.qml

--- a/qml/components/LiveCoachingBanner.qml
+++ b/qml/components/LiveCoachingBanner.qml
@@ -1,0 +1,117 @@
+import QtQuick
+import QtQuick.Layouts
+import Decenza
+
+// Live coaching banner. Binds to a live-coach service passed in via `coach`
+// (LiveShotCoach on the espresso page, LiveSteamCoach on the steam page) and
+// shows one short calm cue at a time while an operation runs. Fades in when a
+// cue is active, auto-dismisses after a few seconds (UI auto-dismiss timer is
+// allowed), and tints by severity using Theme tokens. Voice is gated on the
+// user's existing extractionAnnouncements preference so we don't double-announce.
+Item {
+    id: banner
+
+    // The live coach service to bind to (QML-marshalable Q_PROPERTYs: cueText /
+    // cueSeverity / cueActive / cueSpeak). Passed in by each mount so this banner
+    // is reusable across the espresso and steam pages without referencing any
+    // page-specific service directly.
+    property var coach: null
+
+    // Feature gate, passed in by each mount (each page has its own on/off pref).
+    // Named coachEnabled (not `enabled`) to avoid shadowing the built-in Item.enabled.
+    property bool coachEnabled: true
+
+    // Gate: feature pref + an actually-active cue + not yet auto-dismissed.
+    readonly property bool shouldShow: coachEnabled
+                                       && coach
+                                       && coach.cueActive
+                                       && !dismissed
+
+    // Set true by the auto-dismiss timer; reset whenever a new cue arrives.
+    property bool dismissed: false
+
+    // Severity -> Theme color token (no hardcoded colors).
+    function severityColor(severity) {
+        if (severity === "positive") return Theme.successColor
+        if (severity === "caution") return Theme.warningColor
+        return Theme.textColor  // "info"
+    }
+
+    implicitHeight: pill.height
+    height: shouldShow ? implicitHeight : 0
+    visible: opacity > 0.01
+    opacity: shouldShow ? 1.0 : 0.0
+    Behavior on opacity { NumberAnimation { duration: 220 } }
+
+    Accessible.role: Accessible.StaticText
+    Accessible.name: coach ? coach.cueText : ""
+
+    // React to cue changes: re-arm the auto-dismiss timer, and speak if asked.
+    Connections {
+        target: banner.coach
+        function onCueChanged() {
+            if (!banner.coach.cueActive)
+                return
+            banner.dismissed = false
+            if (banner.coachEnabled) {
+                dismissTimer.restart()
+                // Speak only when the service flagged this cue AND the user has
+                // extraction announcements enabled (reuse that pref so we respect
+                // their choice and don't double-announce).
+                if (banner.coach.cueSpeak
+                        && AccessibilityManager.extractionAnnouncementsEnabled) {
+                    // Assertive (interrupt) only for urgent cautions.
+                    var urgent = banner.coach.cueSeverity === "caution"
+                    AccessibilityManager.announce(banner.coach.cueText, urgent)
+                }
+            }
+        }
+    }
+
+    // UI auto-dismiss (allowed by the no-timers-as-guards rule).
+    Timer {
+        id: dismissTimer
+        interval: 5000
+        repeat: false
+        onTriggered: banner.dismissed = true
+    }
+
+    Rectangle {
+        id: pill
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: Math.min(parent.width, cueRow.implicitWidth + Theme.spacingMedium * 2)
+        height: cueRow.implicitHeight + Theme.spacingSmall * 2
+        radius: Theme.cardRadius
+        color: Qt.darker(Theme.surfaceColor, 1.15)
+        border.width: Theme.scaled(2)
+        border.color: banner.severityColor(banner.coach ? banner.coach.cueSeverity : "info")
+
+        RowLayout {
+            id: cueRow
+            anchors.centerIn: parent
+            spacing: Theme.spacingSmall
+
+            // Severity dot.
+            Rectangle {
+                Layout.alignment: Qt.AlignVCenter
+                width: Theme.scaled(10)
+                height: Theme.scaled(10)
+                radius: width / 2
+                color: banner.severityColor(banner.coach ? banner.coach.cueSeverity : "info")
+                Accessible.ignored: true
+            }
+
+            Text {
+                id: cueLabel
+                Layout.alignment: Qt.AlignVCenter
+                text: banner.coach ? banner.coach.cueText : ""
+                color: Theme.textColor
+                font.family: Theme.bodyFont.family
+                font.pixelSize: Theme.bodyFont.pixelSize
+                font.weight: Font.Medium
+                elide: Text.ElideRight
+                Accessible.ignored: true  // banner-level Accessible.name carries it
+            }
+        }
+    }
+}

--- a/qml/pages/EspressoPage.qml
+++ b/qml/pages/EspressoPage.qml
@@ -587,6 +587,24 @@ Page {
         }
     }
 
+    // During-shot live coaching cue banner — below the phase/status row, above
+    // the info bar. Only present while a shot is running.
+    LiveCoachingBanner {
+        id: liveCoachingBanner
+        z: 10
+        anchors.top: statusBanner.bottom
+        anchors.topMargin: Theme.spacingSmall
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.leftMargin: Theme.spacingMedium
+        anchors.rightMargin: Theme.spacingMedium
+        coach: MainController.liveShotCoach
+        coachEnabled: Settings.app.liveCoachingEnabled
+        // No outer visible binding: the banner self-gates on an active cue via its
+        // internal shouldShow/opacity (cues only fire during a shot), so it can run
+        // its own 220 ms fade-out at shot end instead of being cut off by a phase flip.
+    }
+
     // Stop button for headless machines (prominently placed above info bar)
     Rectangle {
         id: espressoStopButton

--- a/qml/pages/settings/SettingsLanguageTab.qml
+++ b/qml/pages/settings/SettingsLanguageTab.qml
@@ -570,6 +570,38 @@ Item {
                         }
                     }
 
+                    // Visual during-shot live coaching cues. Separate from the
+                    // voice toggle above (which only gates spoken cues); this
+                    // controls the on-screen banner and works without TTS.
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(8)
+
+                        Tr {
+                            key: "settings.accessibility.liveCoachingEnable"
+                            fallback: "Live Coaching Cues"
+                            color: Theme.textColor
+                            font.pixelSize: Theme.scaled(14)
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        StyledSwitch {
+                            checked: Settings.app.liveCoachingEnabled
+                            accessibleName: TranslationManager.translate("settings.accessibility.liveCoachingEnable", "Live Coaching Cues")
+                            onCheckedChanged: Settings.app.liveCoachingEnabled = checked
+                        }
+                    }
+
+                    Tr {
+                        Layout.fillWidth: true
+                        key: "settings.accessibility.liveCoachingDesc"
+                        fallback: "Short on-screen tips while a shot runs (e.g. running fast, possible channeling)"
+                        color: Theme.textSecondaryColor
+                        font.pixelSize: Theme.scaled(11)
+                        wrapMode: Text.WordWrap
+                    }
+
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(8)

--- a/src/ai/liveshotcoach.cpp
+++ b/src/ai/liveshotcoach.cpp
@@ -1,0 +1,262 @@
+#include "liveshotcoach.h"
+
+#include <QtGlobal>
+#include <cmath>
+
+#include "../ble/de1device.h"
+#include "../core/translationmanager.h"
+#include "../machine/machinestate.h"
+
+// All user-visible / spoken strings go through TranslationManager so they are
+// translatable (CLAUDE.md i18n rule). Falls back to the English source when no
+// TranslationManager has been injected.
+QString LiveShotCoach::tr_(const char* key, const char* fallback) const {
+    if (m_translationManager)
+        return m_translationManager->translate(QString::fromUtf8(key),
+                                               QString::fromUtf8(fallback));
+    return QString::fromUtf8(fallback);
+}
+
+LiveShotCoach::LiveShotCoach(DE1Device* device, MachineState* machineState,
+                             QObject* parent)
+    : QObject(parent)
+    , m_device(device)
+    , m_machineState(machineState)
+{
+    if (m_device) {
+        connect(m_device, &DE1Device::shotSampleReceived,
+                this, &LiveShotCoach::onShotSampleReceived);
+    }
+    if (m_machineState) {
+        connect(m_machineState, &MachineState::phaseChanged,
+                this, &LiveShotCoach::onPhaseChanged);
+        connect(m_machineState, &MachineState::scaleWeightChanged,
+                this, &LiveShotCoach::onScaleWeightChanged);
+    }
+}
+
+bool LiveShotCoach::isFlowPhase(MachineState::Phase phase) {
+    return phase == MachineState::Phase::Preinfusion
+        || phase == MachineState::Phase::Pouring
+        || phase == MachineState::Phase::Ending;
+}
+
+void LiveShotCoach::onPhaseChanged() {
+    if (!m_machineState)
+        return;
+    const MachineState::Phase phase = m_machineState->phase();
+    const bool nowInShot = isFlowPhase(phase);
+
+    if (nowInShot && !m_shotActive) {
+        // Shot just started: clear any stale state from a previous shot.
+        resetState();
+        m_shotActive = true;
+    } else if (!nowInShot && m_shotActive) {
+        // Shot ended (idle / steaming / etc.): silence and reset.
+        m_shotActive = false;
+        resetState();
+        return;
+    }
+
+    // Phase milestone: announce the preinfusion -> pour transition once. Calm,
+    // informational, not spoken (avoids competing with the more useful cues).
+    if (m_shotActive && phase == MachineState::Phase::Pouring && !m_firedPourStarted) {
+        m_firedPourStarted = true;
+        const double shotTime = m_machineState->shotTime();
+        emitCue(QStringLiteral("pour-started"),
+                tr_("liveCoach.cue.pourStarted", "Pouring — flow building"),
+                QStringLiteral("info"), /*speak=*/false, shotTime);
+    }
+}
+
+void LiveShotCoach::onShotSampleReceived(const ShotSample& sample) {
+    if (!m_shotActive || !m_machineState)
+        return;
+
+    const double shotTime = m_machineState->shotTime();
+    if (sample.groupPressure > m_peakPressure)
+        m_peakPressure = sample.groupPressure;
+    if (sample.setPressureGoal > PRESSURE_FLOOR_BAR)
+        m_sawPressureGoal = true;   // this profile targets espresso-level pressure
+
+    pushSample(shotTime, sample.groupPressure, sample.groupFlow,
+               sample.setFlowGoal, sample.setPressureGoal);
+    evaluate(shotTime);
+}
+
+void LiveShotCoach::onScaleWeightChanged() {
+    // The on-pace cue is driven off the scale; re-evaluate when weight updates
+    // so it can fire even between BLE shot samples. Cheap: evaluate() is O(window),
+    // and the window is constant-bounded (~WINDOW_SEC at ~5 Hz).
+    if (!m_shotActive || !m_machineState)
+        return;
+    evaluate(m_machineState->shotTime());
+}
+
+void LiveShotCoach::pushSample(double shotTime, double pressure, double flow,
+                               double goalFlow, double goalPressure) {
+    m_window.append(Sample{shotTime, pressure, flow, goalFlow, goalPressure});
+    // Drop samples older than WINDOW_SEC (O(n) left-shift, but n is tiny — a few
+    // samples at ~5 Hz over WINDOW_SEC — so cost is negligible).
+    const double cutoff = shotTime - WINDOW_SEC;
+    qsizetype drop = 0;
+    while (drop < m_window.size() && m_window[drop].t < cutoff)
+        ++drop;
+    if (drop > 0)
+        m_window.remove(0, drop);
+}
+
+void LiveShotCoach::evaluate(double shotTime) {
+    if (!m_machineState)
+        return;
+    const MachineState::Phase phase = m_machineState->phase();
+
+    // --- Detector 1 (highest priority): low pressure / no puck. ---
+    // Well into the pour, if peak pressure never crossed the floor the puck
+    // likely never seated. Mirrors ShotAnalysis::detectPourTruncated's concept
+    // (pressure-only, PRESSURE_FLOOR_BAR) but on the partial live curve.
+    if (!m_firedNoPuck && shotTime > POUR_SETTLE_SEC
+        && m_sawPressureGoal          // espresso only — non-espresso runs low legitimately
+        && (phase == MachineState::Phase::Pouring
+            || phase == MachineState::Phase::Ending)
+        && m_peakPressure < PRESSURE_FLOOR_BAR) {
+        m_firedNoPuck = true;
+        emitCue(QStringLiteral("no-puck"),
+                tr_("liveCoach.cue.noPuck", "Low pressure — did the puck seat?"),
+                QStringLiteral("caution"), /*speak=*/true, shotTime);
+        return;
+    }
+
+    // --- Detector 2: channeling proxy. ---
+    // A sharp flow rise while pressure stays flat/falling during a pressure-
+    // controlled phase. Conservative live PROXY (the real dC/dt detector is
+    // post-shot only). Requires a clear jump across the rolling window.
+    if (!m_firedChanneling && shotTime > POUR_SETTLE_SEC
+        && phase == MachineState::Phase::Pouring
+        && m_window.size() >= 3) {
+        const Sample& first = m_window.first();
+        const Sample& last = m_window.last();
+        const bool pressureControlled = last.goalPressure > PRESSURE_FLOOR_BAR;
+        const double flowRise = last.flow - first.flow;
+        const double pressureChange = last.pressure - first.pressure;
+        if (pressureControlled
+            && flowRise > CHANNELING_FLOW_JUMP
+            && pressureChange < CHANNELING_PRESSURE_FLAT) {
+            m_firedChanneling = true;
+            emitCue(QStringLiteral("channeling"),
+                    tr_("liveCoach.cue.channeling", "Possible channeling"),
+                    QStringLiteral("caution"), /*speak=*/true, shotTime);
+            return;
+        }
+    }
+
+    // --- Detector 3: fast/slow flow vs goal. ---
+    // Rolling avg of (flow - goalFlow) over the window during the pour.
+    // |delta| > threshold -> running fast (bright) or slow (tight).
+    // Fires at most once per shot to stay calm. Restricted to Pouring:
+    // flow into a dry puck during Preinfusion routinely deviates from goal,
+    // and because this is a one-shot latch, firing there would suppress the
+    // legitimate pour-phase cue for the rest of the shot (same reason
+    // detector 2 restricts to Pouring).
+    if (!m_firedFlow && shotTime > POUR_SETTLE_SEC
+        && phase == MachineState::Phase::Pouring
+        && !m_window.isEmpty()) {
+        double sumDelta = 0.0;
+        qsizetype n = 0;
+        for (const Sample& s : m_window) {
+            if (s.goalFlow > 0.1) {  // only meaningful when there's a flow target
+                sumDelta += (s.flow - s.goalFlow);
+                ++n;
+            }
+        }
+        if (n >= 3) {
+            const double avgDelta = sumDelta / static_cast<double>(n);
+            if (avgDelta > FLOW_DEVIATION_THRESHOLD) {
+                m_firedFlow = true;
+                emitCue(QStringLiteral("flow-fast"),
+                        tr_("liveCoach.cue.flowFast",
+                            "Running fast — this'll come in bright"),
+                        QStringLiteral("info"), /*speak=*/true, shotTime);
+                return;
+            }
+            if (avgDelta < -FLOW_DEVIATION_THRESHOLD) {
+                m_firedFlow = true;
+                emitCue(QStringLiteral("flow-slow"),
+                        tr_("liveCoach.cue.flowSlow", "Running slow — tight puck"),
+                        QStringLiteral("info"), /*speak=*/true, shotTime);
+                return;
+            }
+        }
+    }
+
+    // --- Detector 4 (positive): on pace to target weight. ---
+    // From scale flow rate + scale weight vs target. Fires once, only when the
+    // scale is actually flowing and we're not basically done.
+    if (!m_firedOnPace && shotTime > POUR_SETTLE_SEC
+        && phase == MachineState::Phase::Pouring) {
+        const double target = m_machineState->targetWeight();
+        const double weight = m_machineState->scaleWeight();
+        const double flowGps = m_machineState->scaleFlowRate();
+        const double remaining = target - weight;
+        if (target > 0.0 && flowGps > ONPACE_MIN_FLOW_GPS
+            && remaining > ONPACE_MIN_REMAINING_G) {
+            const int secsToGo = static_cast<int>(std::round(remaining / flowGps));
+            if (secsToGo >= 1 && secsToGo <= 30) {
+                m_firedOnPace = true;
+                const QString text =
+                    tr_("liveCoach.cue.onPace", "On pace — about %1s to %2g")
+                        .arg(secsToGo)
+                        .arg(QString::number(target, 'f', 0));
+                emitCue(QStringLiteral("on-pace"), text,
+                        QStringLiteral("positive"), /*speak=*/false, shotTime);
+                return;
+            }
+        }
+    }
+}
+
+void LiveShotCoach::emitCue(const QString& id, const QString& text,
+                            const QString& severity, bool speak, double shotTime) {
+    // Dedupe: don't re-publish a cue that is already the active one.
+    if (m_cueActive && id == m_activeCueId)
+        return;
+
+    // Spoken-cue spacing: gate voice on shot-time elapsed since the last spoken
+    // cue (clock-based, not a guard Timer). Visual cue still shows.
+    bool willSpeak = speak;
+    if (willSpeak && (shotTime - m_lastSpokenShotTime) < MIN_SPOKEN_SPACING_SEC)
+        willSpeak = false;
+    if (willSpeak)
+        m_lastSpokenShotTime = shotTime;
+
+    m_activeCueId = id;
+    m_cueText = text;
+    m_cueSeverity = severity;
+    m_cueSpeak = willSpeak;
+    m_cueActive = true;
+    emit cueChanged();
+}
+
+void LiveShotCoach::clearCue() {
+    if (!m_cueActive && m_cueText.isEmpty())
+        return;
+    m_cueActive = false;
+    m_cueSpeak = false;
+    m_cueText.clear();
+    m_cueSeverity.clear();
+    m_activeCueId.clear();
+    emit cueChanged();
+}
+
+void LiveShotCoach::resetState() {
+    m_window.clear();
+    m_peakPressure = 0.0;
+    m_sawPressureGoal = false;
+    m_firedNoPuck = false;
+    m_firedChanneling = false;
+    m_firedFlow = false;
+    m_firedOnPace = false;
+    m_firedPourStarted = false;
+    m_lastSpokenShotTime = -1000.0;
+    clearCue();
+}

--- a/src/ai/liveshotcoach.h
+++ b/src/ai/liveshotcoach.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+#include "../machine/machinestate.h"
+
+class DE1Device;
+class TranslationManager;
+struct ShotSample;
+
+// During-shot live coaching cues — a LOCAL, real-time "reflex" layer that
+// comments on the espresso shot AS IT RUNS. This is deliberately NOT the AI
+// advisor (which is post-shot, network-backed): LiveShotCoach runs cheap C++
+// analysis on the live telemetry stream (~5 Hz) and emits at most one short,
+// calm cue at a time. It favors silence over false alarms — most shots get
+// zero or one cue.
+//
+// It reuses only the cheap, partial-curve-safe detector concepts from
+// ShotAnalysis (the pressure-floor "no puck" check and the flow-vs-goal delta).
+// ShotAnalysis::analyzeShot() is post-shot only (it needs the full curve and a
+// Gaussian-smoothed conductance derivative) and is never called here; channeling
+// uses a conservative live PROXY instead of the real dC/dt detector.
+//
+// Cues are exposed to QML as individual marshalable Q_PROPERTYs (QString / bool)
+// — never a struct return — so a banner can bind directly.
+class LiveShotCoach : public QObject {
+    Q_OBJECT
+
+    // QML-marshalable cue surface. The banner binds to these directly.
+    // cueSeverity is one of "positive" | "info" | "caution".
+    Q_PROPERTY(QString cueText READ cueText NOTIFY cueChanged)
+    Q_PROPERTY(QString cueSeverity READ cueSeverity NOTIFY cueChanged)
+    Q_PROPERTY(bool cueActive READ cueActive NOTIFY cueChanged)
+    Q_PROPERTY(bool cueSpeak READ cueSpeak NOTIFY cueChanged)
+
+public:
+    explicit LiveShotCoach(DE1Device* device, MachineState* machineState,
+                           QObject* parent = nullptr);
+
+    // Optional — used to translate cue text. Without it cues fall back to the
+    // English source strings. Mirrors AccessibilityManager::setTranslationManager.
+    void setTranslationManager(TranslationManager* translationManager) {
+        m_translationManager = translationManager;
+    }
+
+    QString cueText() const { return m_cueText; }
+    QString cueSeverity() const { return m_cueSeverity; }
+    bool cueActive() const { return m_cueActive; }
+    bool cueSpeak() const { return m_cueSpeak; }
+
+    // --- Detector thresholds (mirror the post-shot ShotAnalysis concepts) ---
+    // Flow-vs-goal deviation that flags a fast/slow pour. Same value as
+    // ShotAnalysis::FLOW_DEVIATION_THRESHOLD (the post-shot grind detector).
+    static constexpr double FLOW_DEVIATION_THRESHOLD = 0.4;   // mL/s
+    // Peak pressure floor below which the puck likely never seated. Same value
+    // as ShotAnalysis::PRESSURE_FLOOR_BAR.
+    static constexpr double PRESSURE_FLOOR_BAR = 2.5;          // bar
+    // Channeling proxy: a sharp flow rise while pressure is flat/declining
+    // during a pressure-controlled phase. Conservative — requires a clear jump.
+    static constexpr double CHANNELING_FLOW_JUMP = 1.0;        // mL/s over the window
+    static constexpr double CHANNELING_PRESSURE_FLAT = 0.15;   // bar — pressure must be ~flat/falling
+    // On-pace cue: only speak it once, well into the pour, when we have a real
+    // scale flow rate and a target.
+    static constexpr double ONPACE_MIN_FLOW_GPS = 0.5;        // g/s — scale must be actually flowing
+    static constexpr double ONPACE_MIN_REMAINING_G = 3.0;     // don't fire when basically done
+
+    // Rolling window length (seconds of shot time) for the flow-vs-goal and
+    // channeling-proxy averages.
+    static constexpr double WINDOW_SEC = 3.0;
+    // How far into a flow-relevant phase before flow-vs-goal / no-puck fire.
+    static constexpr double POUR_SETTLE_SEC = 3.0;
+    // Minimum shot-time spacing between SPOKEN cues (clock-based, not a guard
+    // timer — measured against the live sample clock / shotTime).
+    static constexpr double MIN_SPOKEN_SPACING_SEC = 8.0;
+
+signals:
+    // Single change signal for the whole cue surface — cueText / cueSeverity /
+    // cueActive / cueSpeak always change together (one emitCue / clearCue call).
+    void cueChanged();
+
+private slots:
+    void onShotSampleReceived(const ShotSample& sample);
+    void onPhaseChanged();
+    void onScaleWeightChanged();
+
+private:
+    // Append one telemetry point into the rolling window and drop stale ones.
+    void pushSample(double shotTime, double pressure, double flow,
+                    double goalFlow, double goalPressure);
+    // Run all detectors against the current rolling state. Picks at most one
+    // cue (priority order) and publishes it via emitCue().
+    void evaluate(double shotTime);
+    // Publish a cue. Deduped by `id` (won't re-emit the same cue id while it's
+    // still the active cue). `speak` is honored only if enough shot-time has
+    // elapsed since the last spoken cue (event/clock-based spacing).
+    void emitCue(const QString& id, const QString& text,
+                 const QString& severity, bool speak, double shotTime);
+    // Clear the active cue and all rolling/governor state. Called on shot
+    // start and shot end (phase transitions to/from a flow phase / idle).
+    void resetState();
+    void clearCue();
+
+    static bool isFlowPhase(MachineState::Phase phase);
+
+    DE1Device* m_device = nullptr;
+    MachineState* m_machineState = nullptr;
+    TranslationManager* m_translationManager = nullptr;
+
+    // Translate a cue string via the injected TranslationManager, or fall back
+    // to the English source when none is set.
+    QString tr_(const char* key, const char* fallback) const;
+
+    // Published cue state (mirrors the Q_PROPERTYs).
+    QString m_cueText;
+    QString m_cueSeverity;
+    bool m_cueActive = false;
+    bool m_cueSpeak = false;
+
+    // Governor: the id of the currently-published cue (dedupe key) and the
+    // shot-time of the last SPOKEN cue (spacing is measured against the live
+    // sample clock, never a guard Timer).
+    QString m_activeCueId;
+    double m_lastSpokenShotTime = -1000.0;
+
+    // Tracks whether we are currently inside a shot (a flow phase). Toggled by
+    // phase transitions; used to reset cleanly at shot start/end.
+    bool m_shotActive = false;
+
+    // Rolling window over recent samples (kept tiny: ~WINDOW_SEC at 5 Hz).
+    struct Sample {
+        double t = 0.0;          // shot time (s)
+        double pressure = 0.0;   // bar
+        double flow = 0.0;       // mL/s (group flow)
+        double goalFlow = 0.0;   // mL/s
+        double goalPressure = 0.0; // bar
+    };
+    QVector<Sample> m_window;
+
+    // Peak group pressure seen this shot (for the no-puck check).
+    double m_peakPressure = 0.0;
+    // True once the profile targets espresso-level pressure (goal pressure crossed
+    // the floor). Gates the no-puck cue so it never fires on non-espresso profiles
+    // (filter/pourover/tea) that legitimately run below the pressure floor — those
+    // don't target pressure, so this stays false and the cue is suppressed.
+    // Conscious trade-off: a pure flow-profiled espresso never sets a pressure goal,
+    // so no-puck is also suppressed there (a blind spot) — but the failure mode is
+    // silence, matching the coach's silence-over-false-alarms design. A universal
+    // gate would need the profile's beverage type, which isn't plumbed to the coach.
+    bool m_sawPressureGoal = false;
+    // One-shot latches so each detector fires at most once per shot.
+    bool m_firedNoPuck = false;
+    bool m_firedChanneling = false;
+    bool m_firedFlow = false;
+    bool m_firedOnPace = false;
+    // Phase-milestone latch: announce the preinfusion->pour transition once.
+    bool m_firedPourStarted = false;
+};

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -73,6 +73,11 @@ MainController::MainController(QNetworkAccessManager* networkManager,
     // Create ProfileManager — owns all profile lifecycle operations
     m_profileManager = new ProfileManager(m_settings, m_device, m_machineState, m_profileStorage, this);
 
+    // Create LiveShotCoach — local, real-time during-shot coaching cues.
+    // Subscribes itself to DE1Device::shotSampleReceived and MachineState
+    // phase/scale-weight changes, reusing the same refs MainController holds.
+    m_liveShotCoach = new LiveShotCoach(m_device, m_machineState, this);
+
     // Connect to shot sample updates
     if (m_device) {
         connect(m_device, &DE1Device::shotSampleReceived,

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -10,6 +10,7 @@
 #include "../network/visualizerimporter.h"
 #include "../network/beanbaseclient.h"
 #include "../ai/aimanager.h"
+#include "../ai/liveshotcoach.h"
 #include "../models/shotdatamodel.h"
 #include "../models/steamdatamodel.h"
 #include "../machine/steamhealthtracker.h"
@@ -41,6 +42,7 @@ class ProfileStorage;
 class ShotDebugLogger;
 class LocationProvider;
 class ShotTimingController;
+class TranslationManager;
 struct ShotSample;
 
 class MainController : public QObject {
@@ -51,6 +53,7 @@ class MainController : public QObject {
     Q_PROPERTY(VisualizerImporter* visualizerImporter READ visualizerImporter CONSTANT)
     Q_PROPERTY(BeanBaseClient* beanbase READ beanbase CONSTANT)
     Q_PROPERTY(AIManager* aiManager READ aiManager CONSTANT)
+    Q_PROPERTY(LiveShotCoach* liveShotCoach READ liveShotCoach CONSTANT)
     Q_PROPERTY(ShotDataModel* shotDataModel READ shotDataModel CONSTANT)
     Q_PROPERTY(SteamDataModel* steamDataModel READ steamDataModel CONSTANT)
     Q_PROPERTY(SteamHealthTracker* steamHealthTracker READ steamHealthTracker CONSTANT)
@@ -93,6 +96,10 @@ public:
     BeanBaseClient* beanbase() const { return m_beanbase; }
     ProfileStorage* profileStorage() const { return m_profileStorage; }
     AIManager* aiManager() const { return m_aiManager; }
+    LiveShotCoach* liveShotCoach() const { return m_liveShotCoach; }
+    void setTranslationManager(TranslationManager* tm) {
+        if (m_liveShotCoach) m_liveShotCoach->setTranslationManager(tm);
+    }
     void setAiManager(AIManager* aiManager) {
         m_aiManager = aiManager;
         if (m_aiManager && m_shotHistory)
@@ -301,6 +308,7 @@ private:
     VisualizerImporter* m_visualizerImporter = nullptr;
     BeanBaseClient* m_beanbase = nullptr;
     AIManager* m_aiManager = nullptr;
+    LiveShotCoach* m_liveShotCoach = nullptr;
     ShotTimingController* m_timingController = nullptr;
     BLEManager* m_bleManager = nullptr;
     FlowScale* m_flowScale = nullptr;  // Shadow FlowScale for comparison logging

--- a/src/core/settings_app.cpp
+++ b/src/core/settings_app.cpp
@@ -562,6 +562,17 @@ void SettingsApp::setScreenCaptureEnabled(bool enabled) {
     }
 }
 
+bool SettingsApp::liveCoachingEnabled() const {
+    return m_settings.value("espresso/liveCoachingEnabled", true).toBool();
+}
+
+void SettingsApp::setLiveCoachingEnabled(bool enabled) {
+    if (liveCoachingEnabled() != enabled) {
+        m_settings.setValue("espresso/liveCoachingEnabled", enabled);
+        emit liveCoachingEnabledChanged();
+    }
+}
+
 // Device identity
 QString SettingsApp::deviceId() const {
     QString id = m_settings.value("device/uuid").toString();

--- a/src/core/settings_app.h
+++ b/src/core/settings_app.h
@@ -71,6 +71,12 @@ class SettingsApp : public QObject {
     Q_PROPERTY(bool simulatedScaleEnabled READ simulatedScaleEnabled WRITE setSimulatedScaleEnabled NOTIFY simulatedScaleEnabledChanged)
     Q_PROPERTY(bool screenCaptureEnabled READ screenCaptureEnabled WRITE setScreenCaptureEnabled NOTIFY screenCaptureEnabledChanged)
 
+    // During-shot live coaching cues. When true (default), the LiveShotCoach
+    // service's short calm cues are shown in a banner on the espresso page
+    // while a shot runs. Voice for those cues is gated separately by the
+    // existing AccessibilityManager extractionAnnouncements* prefs.
+    Q_PROPERTY(bool liveCoachingEnabled READ liveCoachingEnabled WRITE setLiveCoachingEnabled NOTIFY liveCoachingEnabledChanged)
+
 public:
     explicit SettingsApp(QObject* parent = nullptr);
 
@@ -157,6 +163,10 @@ public:
     bool screenCaptureEnabled() const;
     void setScreenCaptureEnabled(bool enabled);
 
+    // During-shot live coaching cues
+    bool liveCoachingEnabled() const;
+    void setLiveCoachingEnabled(bool enabled);
+
     // Device identity (stable UUID for server communication)
     Q_INVOKABLE QString deviceId() const;
 
@@ -187,6 +197,7 @@ signals:
     void hideGhcSimulatorChanged();
     void simulatedScaleEnabledChanged();
     void screenCaptureEnabledChanged();
+    void liveCoachingEnabledChanged();
 
 private:
     mutable QSettings m_settings;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -608,6 +608,7 @@ int main(int argc, char *argv[])
     MainController mainController(&sharedNetworkManager, &settings, &de1Device, &machineState, &shotDataModel, &profileStorage);
     mainController.setSteamDataModel(&steamDataModel);
     mainController.setSteamHealthTracker(&steamHealthTracker);
+    mainController.setTranslationManager(&translationManager);  // for LiveShotCoach cue i18n
     checkpoint("MainController");
 
     // Publishes machine phase/temp/last-shot to platform-shared storage for


### PR DESCRIPTION
## Live coaching (during-shot): real-time on-device cues

Adds a local **"reflex" layer** that comments on an espresso shot **as it runs** — one short, calm line at a time. This is deliberately *not* the AI advisor (which stays post-shot and network-backed): there are **no AI calls, no network, and no DB in the hot path**. Most shots get zero or one cue; it favours silence over false alarms.

### What it does
`LiveShotCoach` (`src/ai/liveshotcoach.{h,cpp}`) subscribes to `DE1Device::shotSampleReceived` (~5 Hz) and `MachineState` phase/scale-weight, and runs cheap checks on the **partial** live curve:

- **Low pressure / no puck** — peak pressure never crosses the floor (2.5 bar).
- **Channeling proxy** — a sharp flow rise while pressure stays flat during a pressure phase (a conservative live proxy; the real dC/dt detector is post-shot only and is never called here).
- **Fast / slow flow vs goal** — rolling average of `flow − goalFlow` during the pour.
- **On pace to target** — from scale flow rate + weight vs target (a positive, encouraging cue).
- **Phase milestone** — the preinfusion→pour transition.

Cues are exposed to QML as individual marshalable `Q_PROPERTY`s (`cueText` / `cueSeverity` / `cueActive` / `cueSpeak`) — never a struct return — so the banner binds directly.

### Presentation & voice
`LiveCoachingBanner.qml` shows one calm line, tinted by severity using Theme tokens, and fades out on its own. Voice reuses the **existing** `AccessibilityManager` extraction-announcement preference, so it never double-announces and respects the user's TTS choice. `Settings.app.liveCoachingEnabled` (default on) gates the banner, with a toggle in Settings → Accessibility.

### Design notes
- The cue **governor** is event/clock-based (dedupe by cue id; spoken-cue spacing measured against `shotTime`), **not** a guard `Timer` — per the project's no-timers-as-guards rule. The only timer is the banner's UI auto-dismiss.
- All strings go through `TranslationManager`; the banner uses only Theme tokens.

### Notes for review
- Independent PR off the latest `main` (no stacking). It shares one **new** file — `qml/components/LiveCoachingBanner.qml` — with the companion steam-coaching PR; the file is **byte-identical** on both branches (the banner takes `coach`/`enabled` as properties), so an add/add merge resolves cleanly.
- Verified: clean macOS build (app + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
