### PR TITLE
Shot plan: per-instance display format (Sentence / Compact / Stacked / Plain)

### DIFF
--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -159,13 +159,63 @@ Item {
         return parts.join(sep)
     }
 
+    // "plain" format: a fixed, dot-free two-line recipe template — IGNORES the per-field toggles.
+    //   Line 1: "Brew <yield> of <beverage> from <dose> grams of <roaster> <coffee> coffee beans"
+    //   Line 2: "(Use <profile> at <temp>)"
+    // Single output weight (no "36.0 → 41.8" arrow), no · separators. blockSep joins the two lines
+    // (a line break for display, ". " for the spoken/a11y string so it reads as two sentences).
+    function _buildPlain(fmt, blockSep) {
+        var _ = TranslationManager.translationVersion
+        void(Settings.app.temperatureUnit)
+        // A cleaning/descale run still takes precedence — no recipe, just the warning.
+        if (_isCleaning) {
+            return (profileName.length > 0)
+                ? TranslationManager.translate("shotplan.sentenceCleaning", "Cleaning run with %1 — no coffee in the portafilter!").arg(fmt(profileName, true))
+                : TranslationManager.translate("shotplan.cleaningNoProfile", "Cleaning run — no coffee in the portafilter!")
+        }
+        // Line 1 — brew + (optional) bean clause.
+        var yieldTxt = (targetWeight > 0) ? (targetWeight.toFixed(1) + "g") : ""
+        var line1 = (yieldTxt !== "")
+            ? TranslationManager.translate("shotplan.plain.brew", "Brew %1 of %2").arg(fmt(yieldTxt, true)).arg(fmt(_beverage, false))
+            : TranslationManager.translate("shotplan.plain.brewNoYield", "Brew %1").arg(fmt(_beverage, false))
+        if (dose > 0) {
+            var beans = []
+            if (roasterBrand.length > 0) beans.push(roasterBrand)
+            if (coffeeName.length > 0) beans.push(coffeeName)
+            var beanName = beans.join(" ")
+            var doseTxt = dose.toFixed(1)
+            line1 += " " + (beanName !== ""
+                ? TranslationManager.translate("shotplan.plain.fromBeans", "from %1 grams of %2 coffee beans").arg(fmt(doseTxt, true)).arg(fmt(beanName, true))
+                : TranslationManager.translate("shotplan.plain.fromBeansNoName", "from %1 grams of coffee beans").arg(fmt(doseTxt, true)))
+        }
+        // Line 2 — profile + (optional) override-aware temperature.
+        var tempTxt = (profileTemp > 0)
+            ? ProfileManager.temperatureDisplay(profileTemp, Settings.brew.hasTemperatureOverride, overrideTemp) : ""
+        var line2 = ""
+        if (profileName.length > 0) {
+            line2 = (tempTxt !== "")
+                ? TranslationManager.translate("shotplan.plain.useAt", "(Use %1 at %2)").arg(fmt(profileName, true)).arg(fmt(tempTxt, true))
+                : TranslationManager.translate("shotplan.plain.use", "(Use %1)").arg(fmt(profileName, true))
+        }
+        return (line2 !== "") ? (line1 + blockSep + line2) : line1
+    }
+
     // Plain: for the accessibility label + `visible: text !== ""`. Always joined with dots so a screen
     // reader hears one clean sentence regardless of the visual format.
-    readonly property string text: _build(function(v, live) { return _argSafe(v) }, "  ·  ", "  ·  ")
+    readonly property string text: root.format === "plain"
+        ? _buildPlain(function(v, live) { return _argSafe(v) }, ". ")
+        : _build(function(v, live) { return _argSafe(v) }, "  ·  ", "  ·  ")
     // Rich: same content, live values bolded, all HTML-escaped; joined with Theme.bulletSep.
-    // "stacked" breaks the sentence and its details onto separate lines. A cleaning/descale notice is
-    // bolded WHOLE — it's a warning, not a plan.
+    // "stacked" breaks the sentence and its details onto separate lines; "plain" is its own template.
+    // A cleaning/descale notice is bolded WHOLE — it's a warning, not a plan.
     readonly property string _rich: {
+        if (root.format === "plain") {
+            var p = _buildPlain(function(v, live) {
+                var e = Theme.escapeHtml(_argSafe(v))
+                return live ? ("<b>" + e + "</b>") : e
+            }, "<br>")
+            return (_isCleaning && p !== "") ? ("<b>" + p + "</b>") : p
+        }
         var r = _build(function(v, live) {
             var e = Theme.escapeHtml(_argSafe(v))
             return live ? ("<b>" + e + "</b>") : e
@@ -210,8 +260,8 @@ Item {
             textFormat: Text.StyledText
             font: Theme.bodyFont
             color: root._color
-            wrapMode: root.format === "stacked" ? Text.Wrap : Text.NoWrap
-            maximumLineCount: root.format === "stacked" ? 3 : 1
+            wrapMode: (root.format === "stacked" || root.format === "plain") ? Text.Wrap : Text.NoWrap
+            maximumLineCount: root.format === "plain" ? 4 : (root.format === "stacked" ? 3 : 1)
             elide: Text.ElideRight
             Accessible.ignored: true
         }

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -177,7 +177,11 @@ Item {
         : (_isCleaning ? Theme.errorColor
                        : (_tempOverride ? Theme.highlightColor : Theme.textColor))
 
-    implicitWidth: row.implicitWidth
+    // Report the NATURAL width (icon + spacing + text's own implicitWidth), NOT row.implicitWidth —
+    // which would track planText's CAPPED width and ratchet the tile ever-smaller (it feeds back through
+    // availableWidth: root.width and can never re-expand). The visual cap on planText.width still fixes the
+    // bleed-off; decoupling the implicit here is what lets the tile grow back.
+    implicitWidth: Theme.scaled(20) + Theme.spacingSmall + planText.implicitWidth
     implicitHeight: row.implicitHeight
 
     Row {

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -15,6 +15,15 @@ Item {
 
     signal clicked()
 
+    // Display format (per-instance, chosen in the layout editor): "sentence" (default — the full
+    // "Brew … using … at …" line), "compact" (short ·-separated fragments, no sentence), or "stacked"
+    // (sentence on the first line, the details wrapping onto following lines — never truncated).
+    property string format: "sentence"
+    // The width the widget has to render in (ShotPlanItem passes the tile width). 0 = unconstrained
+    // (natural size, legacy behaviour). When >0 the text is capped to it so it wraps/elides instead of
+    // silently overflowing the tile.
+    property real availableWidth: 0
+
     // Visibility flags (passed through by ShotPlanItem) — one per Shot Plan display option:
     // Profile & temperature, Roaster, Coffee, Grind (+ RPM), Roast date, Dose & yield. Each toggles
     // its segment both in the sentence/tail and in the fallback fragment list.
@@ -100,8 +109,10 @@ Item {
     // `_rich` (display), so they can NEVER drift. fmt(value, live) formats one value: plain %-escapes,
     // rich HTML-escapes and bolds live values. Core sentence is profile + temp (plus yield when the
     // profile has a target weight); enabled extras (dose, roaster, coffee, grind, roast date) trail
-    // after it, else it degrades to a fragment list.
-    function _build(fmt, sep) {
+    // after it, else it degrades to a fragment list. blockSep separates the core sentence from its
+    // trailing details — the same `sep` for one-line formats, a line break for "stacked"; "compact"
+    // skips the sentence entirely (fragment list).
+    function _build(fmt, sep, blockSep) {
         var _ = TranslationManager.translationVersion
         // Cleaning/descale run — beans are the enemy here. Short sentence, no
         // dose/bean tail, and the warning rides along into the a11y label too.
@@ -118,7 +129,7 @@ Item {
             : (grindSize.length > 0 ? TranslationManager.translate("shotplan.grind", "grind %1").arg(fmt(_grindStr, true))
                                     : fmt(_grindStr, true))
         var roasted = (_roastDateStr !== "") ? TranslationManager.translate("shotplan.roasted", "roasted %1").arg(fmt(_roastDateStr, true)) : ""
-        if (_profileStr !== "" && _tempStr !== "") {
+        if (root.format !== "compact" && _profileStr !== "" && _tempStr !== "") {
             // Yield is legitimately absent for profiles with no target weight (filter,
             // tea, …) — keep the sentence form so the beverage word survives, instead of
             // dropping to the beverage-less fragment list. Separate full template (not
@@ -134,7 +145,7 @@ Item {
             if (_coffeeStr !== "") tail.push(fmt(_coffeeStr, true))
             if (grind !== "") tail.push(grind)
             if (roasted !== "") tail.push(roasted)
-            return tail.length > 0 ? (s + sep + tail.join(sep)) : s
+            return tail.length > 0 ? (s + blockSep + tail.join(sep)) : s
         }
         var parts = []
         if (dose !== "") parts.push(dose)
@@ -148,15 +159,17 @@ Item {
         return parts.join(sep)
     }
 
-    // Plain: for the accessibility label + `visible: text !== ""`.
-    readonly property string text: _build(function(v, live) { return _argSafe(v) }, "  ·  ")
-    // Rich: same content, live values bolded, all HTML-escaped; the styled bold safe-dot · separator.
-    // A cleaning/descale notice is bolded WHOLE — it's a warning, not a plan.
+    // Plain: for the accessibility label + `visible: text !== ""`. Always joined with dots so a screen
+    // reader hears one clean sentence regardless of the visual format.
+    readonly property string text: _build(function(v, live) { return _argSafe(v) }, "  ·  ", "  ·  ")
+    // Rich: same content, live values bolded, all HTML-escaped; joined with Theme.bulletSep.
+    // "stacked" breaks the sentence and its details onto separate lines. A cleaning/descale notice is
+    // bolded WHOLE — it's a warning, not a plan.
     readonly property string _rich: {
         var r = _build(function(v, live) {
             var e = Theme.escapeHtml(_argSafe(v))
             return live ? ("<b>" + e + "</b>") : e
-        }, Theme.bulletSep)
+        }, Theme.bulletSep, root.format === "stacked" ? "<br>" : Theme.bulletSep)
         return (_isCleaning && r !== "") ? ("<b>" + r + "</b>") : r
     }
 
@@ -184,10 +197,17 @@ Item {
         Text {
             id: planText
             anchors.verticalCenter: parent.verticalCenter
+            // Cap to the available width (tile width minus the icon + spacing) only when it would
+            // otherwise overflow; shorter text keeps its natural width so the Row stays centred.
+            width: root.availableWidth > 0
+                   ? Math.min(implicitWidth, Math.max(0, root.availableWidth - Theme.scaled(20) - Theme.spacingSmall))
+                   : implicitWidth
             text: root._rich
             textFormat: Text.StyledText
             font: Theme.bodyFont
             color: root._color
+            wrapMode: root.format === "stacked" ? Text.Wrap : Text.NoWrap
+            maximumLineCount: root.format === "stacked" ? 3 : 1
             elide: Text.ElideRight
             Accessible.ignored: true
         }

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -16,8 +16,9 @@ Item {
     signal clicked()
 
     // Display format (per-instance, chosen in the layout editor): "sentence" (default — the full
-    // "Brew … using … at …" line), "compact" (short ·-separated fragments, no sentence), or "stacked"
-    // (sentence on the first line, the details wrapping onto following lines — never truncated).
+    // "Brew … using … at …" line), "compact" (short ·-separated fragments, no sentence), "stacked"
+    // (sentence on line 1, details wrapping onto following lines), or "plain" (a dot-free recipe
+    // sentence that IGNORES the per-field toggles). Long plans wrap up to 3 lines, then truncate.
     property string format: "sentence"
     // The width the widget has to render in (ShotPlanItem passes the tile width). 0 = unconstrained
     // (natural size, legacy behaviour). When >0 the text is capped to it so it wraps/elides instead of
@@ -110,7 +111,8 @@ Item {
     // rich HTML-escapes and bolds live values. Core sentence is profile + temp (plus yield when the
     // profile has a target weight); enabled extras (dose, roaster, coffee, grind, roast date) trail
     // after it, else it degrades to a fragment list. blockSep separates the core sentence from its
-    // trailing details — the same `sep` for one-line formats, a line break for "stacked"; "compact"
+    // trailing details — the same `sep` for one-line formats, a line break for "stacked" on the DISPLAY
+    // path only (the a11y `text` always passes dots, so the spoken string stays one sentence); "compact"
     // skips the sentence entirely (fragment list).
     function _build(fmt, sep, blockSep) {
         var _ = TranslationManager.translationVersion
@@ -160,9 +162,10 @@ Item {
     }
 
     // "plain" format: a single, dot-free recipe sentence — IGNORES the per-field toggles.
-    //   "Pull a <yield> espresso shot using <dose> grams of <roaster> <coffee> coffee beans"
-    // Single output weight (no "36.0 → 41.8" arrow), no · separators, no profile/temp line — the user
-    // keeps profile & temperature on the brew bar below. blockSep is unused (single line).
+    //   "Pull a <yield> coffee shot using <dose> grams of <roaster> <coffee> coffee beans"
+    // "coffee" (not a beverage-specific word) so it reads sensibly for any coffee profile. Single output
+    // weight (no "36.0 → 41.8" arrow), no · separators, no profile/temp line — the user keeps profile &
+    // temperature on the brew bar below. blockSep is unused (single line).
     function _buildPlain(fmt, blockSep) {
         var _ = TranslationManager.translationVersion
         // A cleaning/descale run still takes precedence — no recipe, just the warning.
@@ -173,8 +176,8 @@ Item {
         }
         var yieldTxt = (targetWeight > 0) ? (targetWeight.toFixed(1) + "g") : ""
         var line = (yieldTxt !== "")
-            ? TranslationManager.translate("shotplan.plain.pull", "Pull a %1 espresso shot").arg(fmt(yieldTxt, true))
-            : TranslationManager.translate("shotplan.plain.pullNoYield", "Pull an espresso shot")
+            ? TranslationManager.translate("shotplan.plain.pull", "Pull a %1 coffee shot").arg(fmt(yieldTxt, true))
+            : TranslationManager.translate("shotplan.plain.pullNoYield", "Pull a coffee shot")
         if (dose > 0) {
             var beans = []
             if (roasterBrand.length > 0) beans.push(roasterBrand)

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -18,7 +18,9 @@ Item {
     // Display format (per-instance, chosen in the layout editor): "sentence" (default — the full
     // "Brew … using … at …" line), "compact" (short ·-separated fragments, no sentence), "stacked"
     // (sentence on line 1, details wrapping onto following lines), or "plain" (a dot-free recipe
-    // sentence that IGNORES the per-field toggles). Long plans wrap up to 3 lines, then truncate.
+    // sentence that IGNORES the per-field toggles). Only "stacked"/"plain" wrap (up to 3 lines, then
+    // truncate); "sentence"/"compact" stay one line and elide. Multi-line formats suit center/growable
+    // zones — in a fixed-height bar (status/lower-mid) a 3-line plan overflows, so pick them there advisedly.
     property string format: "sentence"
     // The width the widget has to render in (ShotPlanItem passes the tile width). 0 = unconstrained
     // (natural size, legacy behaviour). When >0 the text is capped to it so it wraps/elides instead of

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -159,45 +159,33 @@ Item {
         return parts.join(sep)
     }
 
-    // "plain" format: a fixed, dot-free two-line recipe template — IGNORES the per-field toggles.
-    //   Line 1: "Brew <yield> of <beverage> from <dose> grams of <roaster> <coffee> coffee beans"
-    //   Line 2: "(Use <profile> at <temp>)"
-    // Single output weight (no "36.0 → 41.8" arrow), no · separators. blockSep joins the two lines
-    // (a line break for display, ". " for the spoken/a11y string so it reads as two sentences).
+    // "plain" format: a single, dot-free recipe sentence — IGNORES the per-field toggles.
+    //   "Pull a <yield> espresso shot using <dose> grams of <roaster> <coffee> coffee beans"
+    // Single output weight (no "36.0 → 41.8" arrow), no · separators, no profile/temp line — the user
+    // keeps profile & temperature on the brew bar below. blockSep is unused (single line).
     function _buildPlain(fmt, blockSep) {
         var _ = TranslationManager.translationVersion
-        void(Settings.app.temperatureUnit)
         // A cleaning/descale run still takes precedence — no recipe, just the warning.
         if (_isCleaning) {
             return (profileName.length > 0)
                 ? TranslationManager.translate("shotplan.sentenceCleaning", "Cleaning run with %1 — no coffee in the portafilter!").arg(fmt(profileName, true))
                 : TranslationManager.translate("shotplan.cleaningNoProfile", "Cleaning run — no coffee in the portafilter!")
         }
-        // Line 1 — brew + (optional) bean clause.
         var yieldTxt = (targetWeight > 0) ? (targetWeight.toFixed(1) + "g") : ""
-        var line1 = (yieldTxt !== "")
-            ? TranslationManager.translate("shotplan.plain.brew", "Brew %1 of %2").arg(fmt(yieldTxt, true)).arg(fmt(_beverage, false))
-            : TranslationManager.translate("shotplan.plain.brewNoYield", "Brew %1").arg(fmt(_beverage, false))
+        var line = (yieldTxt !== "")
+            ? TranslationManager.translate("shotplan.plain.pull", "Pull a %1 espresso shot").arg(fmt(yieldTxt, true))
+            : TranslationManager.translate("shotplan.plain.pullNoYield", "Pull an espresso shot")
         if (dose > 0) {
             var beans = []
             if (roasterBrand.length > 0) beans.push(roasterBrand)
             if (coffeeName.length > 0) beans.push(coffeeName)
             var beanName = beans.join(" ")
             var doseTxt = dose.toFixed(1)
-            line1 += " " + (beanName !== ""
-                ? TranslationManager.translate("shotplan.plain.fromBeans", "from %1 grams of %2 coffee beans").arg(fmt(doseTxt, true)).arg(fmt(beanName, true))
-                : TranslationManager.translate("shotplan.plain.fromBeansNoName", "from %1 grams of coffee beans").arg(fmt(doseTxt, true)))
+            line += " " + (beanName !== ""
+                ? TranslationManager.translate("shotplan.plain.usingBeans", "using %1 grams of %2 coffee beans").arg(fmt(doseTxt, true)).arg(fmt(beanName, true))
+                : TranslationManager.translate("shotplan.plain.usingBeansNoName", "using %1 grams of coffee beans").arg(fmt(doseTxt, true)))
         }
-        // Line 2 — profile + (optional) override-aware temperature.
-        var tempTxt = (profileTemp > 0)
-            ? ProfileManager.temperatureDisplay(profileTemp, Settings.brew.hasTemperatureOverride, overrideTemp) : ""
-        var line2 = ""
-        if (profileName.length > 0) {
-            line2 = (tempTxt !== "")
-                ? TranslationManager.translate("shotplan.plain.useAt", "(Use %1 at %2)").arg(fmt(profileName, true)).arg(fmt(tempTxt, true))
-                : TranslationManager.translate("shotplan.plain.use", "(Use %1)").arg(fmt(profileName, true))
-        }
-        return (line2 !== "") ? (line1 + blockSep + line2) : line1
+        return line
     }
 
     // Plain: for the accessibility label + `visible: text !== ""`. Always joined with dots so a screen
@@ -260,8 +248,12 @@ Item {
             textFormat: Text.StyledText
             font: Theme.bodyFont
             color: root._color
+            // Centre every (wrapped) line so a multi-line plan reads as a tidy centred block, not left-ragged.
+            horizontalAlignment: Text.AlignHCenter
             wrapMode: (root.format === "stacked" || root.format === "plain") ? Text.Wrap : Text.NoWrap
-            maximumLineCount: root.format === "plain" ? 4 : (root.format === "stacked" ? 3 : 1)
+            maximumLineCount: root.format === "plain" ? 3 : (root.format === "stacked" ? 3 : 1)
+            // A touch of line spacing so wrapped plans (plain/stacked) don't feel cramped.
+            lineHeight: (root.format === "plain" || root.format === "stacked") ? 1.2 : 1.0
             elide: Text.ElideRight
             Accessible.ignored: true
         }

--- a/qml/components/SteamPlanText.qml
+++ b/qml/components/SteamPlanText.qml
@@ -107,7 +107,9 @@ Item {
         return live ? ("<b>" + e + "</b>") : e
     }, Theme.bulletSep)
 
-    implicitWidth: row.implicitWidth
+    // Report the NATURAL width, not row.implicitWidth (which would track the capped text width and
+    // ratchet the tile smaller each layout, never re-expanding). See ShotPlanText for the full rationale.
+    implicitWidth: Theme.scaled(20) + Theme.spacingSmall + planText.implicitWidth
     implicitHeight: row.implicitHeight
 
     // Always wrapped by ShotPlanItem, which already exposes the a11y node for the plan.
@@ -131,6 +133,7 @@ Item {
         }
 
         Text {
+            id: planText
             anchors.verticalCenter: parent.verticalCenter
             // Cap to the available width only when the text would overflow; shorter text keeps its
             // natural width so the centred Row is unaffected.

--- a/qml/components/SteamPlanText.qml
+++ b/qml/components/SteamPlanText.qml
@@ -11,6 +11,11 @@ import "../"
 Item {
     id: root
 
+    // Mirrors ShotPlanText: "sentence"/"compact" render the same short line; "stacked" lets it wrap.
+    // availableWidth (the tile width from ShotPlanItem) caps the text so it never overflows the tile.
+    property string format: "sentence"
+    property real availableWidth: 0
+
     // The currently selected steam pitcher preset. getSteamPitcherPreset() is Q_INVOKABLE, so the
     // binding must ALSO read steamPitcherPresets to re-run when the selected pitcher is renamed,
     // disabled, or recalibrated without the selection index itself changing.
@@ -127,10 +132,17 @@ Item {
 
         Text {
             anchors.verticalCenter: parent.verticalCenter
+            // Cap to the available width only when the text would overflow; shorter text keeps its
+            // natural width so the centred Row is unaffected.
+            width: root.availableWidth > 0
+                   ? Math.min(implicitWidth, Math.max(0, root.availableWidth - Theme.scaled(20) - Theme.spacingSmall))
+                   : implicitWidth
             text: root._rich
             textFormat: Text.StyledText
             font: Theme.bodyFont
             color: Theme.textColor
+            wrapMode: root.format === "stacked" ? Text.Wrap : Text.NoWrap
+            maximumLineCount: root.format === "stacked" ? 3 : 1
             elide: Text.ElideRight
             Accessible.ignored: true
         }

--- a/qml/components/SteamPlanText.qml
+++ b/qml/components/SteamPlanText.qml
@@ -11,8 +11,9 @@ import "../"
 Item {
     id: root
 
-    // Mirrors ShotPlanText: "sentence"/"compact" render the same short line; "stacked" lets it wrap.
-    // availableWidth (the tile width from ShotPlanItem) caps the text so it never overflows the tile.
+    // Mirrors ShotPlanText's `format`, but steam has no per-format template: sentence/compact/plain
+    // all render the same short line; only "stacked" lets it wrap. availableWidth (the tile width
+    // from ShotPlanItem) caps the text so it never overflows the tile.
     property string format: "sentence"
     property real availableWidth: 0
 
@@ -144,6 +145,8 @@ Item {
             textFormat: Text.StyledText
             font: Theme.bodyFont
             color: Theme.textColor
+            // Centre wrapped ("stacked") lines to match ShotPlanText, so steam wraps as a centred block.
+            horizontalAlignment: Text.AlignHCenter
             wrapMode: root.format === "stacked" ? Text.Wrap : Text.NoWrap
             maximumLineCount: root.format === "stacked" ? 3 : 1
             elide: Text.ElideRight

--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -336,8 +336,9 @@ Dialog {
             spacing: Theme.spacingSmall
             visible: popup.itemType === "shotPlan"
 
-            // Layout format: how the plan is arranged — a full sentence, short chips, or a
-            // sentence with the details stacked below (so long plans never get truncated).
+            // Layout format: how the plan is arranged — a full sentence, short chips, a sentence with
+            // the details stacked below, or a plain toggle-free recipe sentence. Long plans wrap (up
+            // to 3 lines). The per-field toggles below are disabled for "plain" (it ignores them).
             Text {
                 text: TranslationManager.translate("shotPlanEditor.layout", "Layout")
                 font: Theme.labelFont
@@ -385,17 +386,22 @@ Dialog {
                 }
             }
 
+            // Per-field visibility toggles — disabled (greyed) for "plain", which uses a fixed
+            // template and ignores them, so toggling here would silently have no effect.
             StyledSwitch {
+                enabled: popup.shotPlanFormat !== "plain"
                 text: TranslationManager.translate("shotPlanEditor.showProfile", "Profile & temperature")
                 checked: popup.shotPlanShowProfile
                 onToggled: popup.shotPlanShowProfile = checked
             }
             StyledSwitch {
+                enabled: popup.shotPlanFormat !== "plain"
                 text: TranslationManager.translate("shotPlanEditor.showRoaster", "Roaster")
                 checked: popup.shotPlanShowRoaster
                 onToggled: popup.shotPlanShowRoaster = checked
             }
             StyledSwitch {
+                enabled: popup.shotPlanFormat !== "plain"
                 text: TranslationManager.translate("shotPlanEditor.showCoffee", "Coffee")
                 checked: popup.shotPlanShowCoffee
                 onToggled: popup.shotPlanShowCoffee = checked
@@ -403,16 +409,19 @@ Dialog {
             StyledSwitch {
                 // New key (not the old shotPlanEditor.showGrind "Coffee (grind)") so stale
                 // translations of the old combined label can't mislabel the narrowed toggle.
+                enabled: popup.shotPlanFormat !== "plain"
                 text: TranslationManager.translate("shotPlanEditor.showGrindRpm", "Grind")
                 checked: popup.shotPlanShowGrind
                 onToggled: popup.shotPlanShowGrind = checked
             }
             StyledSwitch {
+                enabled: popup.shotPlanFormat !== "plain"
                 text: TranslationManager.translate("shotPlanEditor.showRoastDate", "Roast date")
                 checked: popup.shotPlanShowRoastDate
                 onToggled: popup.shotPlanShowRoastDate = checked
             }
             StyledSwitch {
+                enabled: popup.shotPlanFormat !== "plain"
                 text: TranslationManager.translate("shotPlanEditor.showDoseYield", "Dose & yield")
                 checked: popup.shotPlanShowDoseYield
                 onToggled: popup.shotPlanShowDoseYield = checked

--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -23,7 +23,7 @@ Dialog {
     property bool shotPlanShowRoastDate: false
     property bool shotPlanShowDoseYield: true
     property bool shotPlanShowSteamPlan: true
-    property string shotPlanFormat: "sentence"   // "sentence" | "compact" | "stacked"
+    property string shotPlanFormat: "sentence"   // "sentence" | "compact" | "stacked" | "plain"
 
     readonly property bool hasSettings: itemType === "screensaverFlipClock" || itemType === "screensaverShotMap" || itemType === "lastShot" || itemType === "shotPlan"
 
@@ -53,7 +53,7 @@ Dialog {
         shotPlanShowRoastDate = typeof props.shotPlanShowRoastDate === "boolean" ? props.shotPlanShowRoastDate : false
         shotPlanShowDoseYield = typeof props.shotPlanShowDoseYield === "boolean" ? props.shotPlanShowDoseYield : true
         shotPlanShowSteamPlan = typeof props.shotPlanShowSteamPlan === "boolean" ? props.shotPlanShowSteamPlan : true
-        shotPlanFormat = (props.shotPlanFormat === "compact" || props.shotPlanFormat === "stacked") ? props.shotPlanFormat : "sentence"
+        shotPlanFormat = (props.shotPlanFormat === "compact" || props.shotPlanFormat === "stacked" || props.shotPlanFormat === "plain") ? props.shotPlanFormat : "sentence"
         open()
     }
 
@@ -351,7 +351,8 @@ Dialog {
                     model: [
                         { value: "sentence", label: TranslationManager.translate("shotPlanEditor.formatSentence", "Sentence") },
                         { value: "compact",  label: TranslationManager.translate("shotPlanEditor.formatCompact", "Compact") },
-                        { value: "stacked",  label: TranslationManager.translate("shotPlanEditor.formatStacked", "Stacked") }
+                        { value: "stacked",  label: TranslationManager.translate("shotPlanEditor.formatStacked", "Stacked") },
+                        { value: "plain",    label: TranslationManager.translate("shotPlanEditor.formatPlain", "Plain") }
                     ]
 
                     Rectangle {

--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -23,6 +23,7 @@ Dialog {
     property bool shotPlanShowRoastDate: false
     property bool shotPlanShowDoseYield: true
     property bool shotPlanShowSteamPlan: true
+    property string shotPlanFormat: "sentence"   // "sentence" | "compact" | "stacked"
 
     readonly property bool hasSettings: itemType === "screensaverFlipClock" || itemType === "screensaverShotMap" || itemType === "lastShot" || itemType === "shotPlan"
 
@@ -52,6 +53,7 @@ Dialog {
         shotPlanShowRoastDate = typeof props.shotPlanShowRoastDate === "boolean" ? props.shotPlanShowRoastDate : false
         shotPlanShowDoseYield = typeof props.shotPlanShowDoseYield === "boolean" ? props.shotPlanShowDoseYield : true
         shotPlanShowSteamPlan = typeof props.shotPlanShowSteamPlan === "boolean" ? props.shotPlanShowSteamPlan : true
+        shotPlanFormat = (props.shotPlanFormat === "compact" || props.shotPlanFormat === "stacked") ? props.shotPlanFormat : "sentence"
         open()
     }
 
@@ -92,6 +94,7 @@ Dialog {
             Settings.network.setItemProperty(itemId, "shotPlanShowRoastDate", shotPlanShowRoastDate)
             Settings.network.setItemProperty(itemId, "shotPlanShowDoseYield", shotPlanShowDoseYield)
             Settings.network.setItemProperty(itemId, "shotPlanShowSteamPlan", shotPlanShowSteamPlan)
+            Settings.network.setItemProperty(itemId, "shotPlanFormat", shotPlanFormat)
         }
         saved()
         close()
@@ -332,6 +335,54 @@ Dialog {
             Layout.fillWidth: true
             spacing: Theme.spacingSmall
             visible: popup.itemType === "shotPlan"
+
+            // Layout format: how the plan is arranged — a full sentence, short chips, or a
+            // sentence with the details stacked below (so long plans never get truncated).
+            Text {
+                text: TranslationManager.translate("shotPlanEditor.layout", "Layout")
+                font: Theme.labelFont
+                color: Theme.textSecondaryColor
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.spacingSmall
+
+                Repeater {
+                    model: [
+                        { value: "sentence", label: TranslationManager.translate("shotPlanEditor.formatSentence", "Sentence") },
+                        { value: "compact",  label: TranslationManager.translate("shotPlanEditor.formatCompact", "Compact") },
+                        { value: "stacked",  label: TranslationManager.translate("shotPlanEditor.formatStacked", "Stacked") }
+                    ]
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        height: Theme.scaled(32)
+                        radius: Theme.scaled(6)
+                        color: popup.shotPlanFormat === modelData.value ? Theme.primaryColor : "transparent"
+                        border.color: popup.shotPlanFormat === modelData.value ? Theme.primaryColor : Theme.borderColor
+                        border.width: 1
+
+                        Accessible.role: Accessible.Button
+                        Accessible.name: modelData.label + (popup.shotPlanFormat === modelData.value ? ", selected" : "")
+                        Accessible.focusable: true
+                        Accessible.onPressAction: shotPlanFormatArea.clicked(null)
+
+                        Text {
+                            anchors.centerIn: parent
+                            text: modelData.label
+                            font: Theme.captionFont
+                            color: popup.shotPlanFormat === modelData.value ? Theme.primaryContrastColor : Theme.textColor
+                            Accessible.ignored: true
+                        }
+
+                        MouseArea {
+                            id: shotPlanFormatArea
+                            anchors.fill: parent
+                            onClicked: popup.shotPlanFormat = modelData.value
+                        }
+                    }
+                }
+            }
 
             StyledSwitch {
                 text: TranslationManager.translate("shotPlanEditor.showProfile", "Profile & temperature")

--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -337,8 +337,9 @@ Dialog {
             visible: popup.itemType === "shotPlan"
 
             // Layout format: how the plan is arranged — a full sentence, short chips, a sentence with
-            // the details stacked below, or a plain toggle-free recipe sentence. Long plans wrap (up
-            // to 3 lines). The per-field toggles below are disabled for "plain" (it ignores them).
+            // the details stacked below, or a plain toggle-free recipe sentence. Only "stacked"/"plain"
+            // wrap (up to 3 lines); the others stay one line and elide. The per-field toggles below are
+            // disabled for "plain" (it ignores them).
             Text {
                 text: TranslationManager.translate("shotPlanEditor.layout", "Layout")
                 font: Theme.labelFont

--- a/qml/components/layout/items/ShotPlanItem.qml
+++ b/qml/components/layout/items/ShotPlanItem.qml
@@ -23,7 +23,8 @@ Item {
     readonly property bool showDoseYield: modelData.shotPlanShowDoseYield !== false
     readonly property bool showSteamPlan: modelData.shotPlanShowSteamPlan !== false
     // Display format: "sentence" (default) | "compact" | "stacked" | "plain". Picked in the layout
-    // editor; a wider/taller shape lets long plans wrap instead of truncating.
+    // editor. Only "stacked"/"plain" wrap (up to 3 lines) when the tile is taller; "sentence"/"compact"
+    // stay one line and elide. (Multi-line formats suit center/growable zones — see ShotPlanText.)
     readonly property string format: modelData.shotPlanFormat || "sentence"
 
     // Steam context = steam selected on the idle screen, OR the full steam page, OR the

--- a/qml/components/layout/items/ShotPlanItem.qml
+++ b/qml/components/layout/items/ShotPlanItem.qml
@@ -22,8 +22,8 @@ Item {
     readonly property bool showRoastDate: modelData.shotPlanShowRoastDate === true
     readonly property bool showDoseYield: modelData.shotPlanShowDoseYield !== false
     readonly property bool showSteamPlan: modelData.shotPlanShowSteamPlan !== false
-    // Display format: "sentence" (default) | "compact" | "stacked". Fixes the run-on/truncation
-    // by letting the user pick a shape that fits their tile.
+    // Display format: "sentence" (default) | "compact" | "stacked" | "plain". Picked in the layout
+    // editor; a wider/taller shape lets long plans wrap instead of truncating.
     readonly property string format: modelData.shotPlanFormat || "sentence"
 
     // Steam context = steam selected on the idle screen, OR the full steam page, OR the

--- a/qml/components/layout/items/ShotPlanItem.qml
+++ b/qml/components/layout/items/ShotPlanItem.qml
@@ -22,6 +22,9 @@ Item {
     readonly property bool showRoastDate: modelData.shotPlanShowRoastDate === true
     readonly property bool showDoseYield: modelData.shotPlanShowDoseYield !== false
     readonly property bool showSteamPlan: modelData.shotPlanShowSteamPlan !== false
+    // Display format: "sentence" (default) | "compact" | "stacked". Fixes the run-on/truncation
+    // by letting the user pick a shape that fits their tile.
+    readonly property string format: modelData.shotPlanFormat || "sentence"
 
     // Steam context = steam selected on the idle screen, OR the full steam page, OR the
     // machine actively steaming. Theme.currentPageObjectName (set by main.qml's
@@ -79,6 +82,8 @@ Item {
             id: compactShotPlan
             anchors.centerIn: parent
             visible: !root._steamMode && text !== ""
+            format: root.format
+            availableWidth: root.width
             showProfile: root.showProfile
             showRoaster: root.showRoaster
             showCoffee: root.showCoffee
@@ -91,6 +96,8 @@ Item {
             id: compactSteamPlan
             anchors.centerIn: parent
             visible: root._steamMode && text !== ""
+            format: root.format
+            availableWidth: root.width
         }
     }
 
@@ -106,6 +113,8 @@ Item {
             id: fullShotPlan
             anchors.centerIn: parent
             visible: !root._steamMode && text !== ""
+            format: root.format
+            availableWidth: root.width
             showProfile: root.showProfile
             showRoaster: root.showRoaster
             showCoffee: root.showCoffee
@@ -118,6 +127,8 @@ Item {
             id: fullSteamPlan
             anchors.centerIn: parent
             visible: root._steamMode && text !== ""
+            format: root.format
+            availableWidth: root.width
         }
     }
 }

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -3056,6 +3056,7 @@ QString ShotServer::generateLayoutPage() const
                     document.getElementById("spShowDoseYield").checked = typeof props.shotPlanShowDoseYield === "boolean" ? props.shotPlanShowDoseYield : true;
                     document.getElementById("spShowSteamPlan").checked = typeof props.shotPlanShowSteamPlan === "boolean" ? props.shotPlanShowSteamPlan : true;
                     document.getElementById("spFormat").value = (props.shotPlanFormat === "compact" || props.shotPlanFormat === "stacked" || props.shotPlanFormat === "plain") ? props.shotPlanFormat : "sentence";
+                    (function(){ var spPlain = document.getElementById("spFormat").value === "plain"; ["spShowProfile","spShowRoaster","spShowCoffee","spShowGrind","spShowRoastDate","spShowDoseYield"].forEach(function(cid){ document.getElementById(cid).disabled = spPlain; }); })();
                     document.getElementById("ssShotPlanSettings").style.display = "";
                 } else {
                     document.getElementById("ssNoSettings").style.display = "";
@@ -3098,6 +3099,11 @@ QString ShotServer::generateLayoutPage() const
             apiPost("/api/layout/item", {itemId: id, key: "shotShowLabels", value: showLabels}, function() {});
             apiPost("/api/layout/item", {itemId: id, key: "shotShowPhaseLabels", value: showPhaseLabels}, function() {});
         } else if (ssEditingType === "shotPlan") {
+            // "plain" uses a fixed template and ignores the per-field toggles — grey them out so a
+            // change there can't silently do nothing. Runs here because the format <select> shares
+            // this onchange (spToggleChanged).
+            var spPlain = document.getElementById("spFormat").value === "plain";
+            ["spShowProfile","spShowRoaster","spShowCoffee","spShowGrind","spShowRoastDate","spShowDoseYield"].forEach(function(cid){ document.getElementById(cid).disabled = spPlain; });
             apiPost("/api/layout/item", {itemId: id, key: "shotPlanShowProfile", value: document.getElementById("spShowProfile").checked}, function() {});
             apiPost("/api/layout/item", {itemId: id, key: "shotPlanShowRoaster", value: document.getElementById("spShowRoaster").checked}, function() {});
             apiPost("/api/layout/item", {itemId: id, key: "shotPlanShowCoffee", value: document.getElementById("spShowCoffee").checked}, function() {});

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -1959,6 +1959,7 @@ QString ShotServer::generateLayoutPage() const
                         <option value="sentence">Sentence</option>
                         <option value="compact">Compact</option>
                         <option value="stacked">Stacked</option>
+                        <option value="plain">Plain</option>
                     </select>
                 </div>
                 <div class="section-label">Visible elements</div>
@@ -3054,7 +3055,7 @@ QString ShotServer::generateLayoutPage() const
                     document.getElementById("spShowRoastDate").checked = typeof props.shotPlanShowRoastDate === "boolean" ? props.shotPlanShowRoastDate : false;
                     document.getElementById("spShowDoseYield").checked = typeof props.shotPlanShowDoseYield === "boolean" ? props.shotPlanShowDoseYield : true;
                     document.getElementById("spShowSteamPlan").checked = typeof props.shotPlanShowSteamPlan === "boolean" ? props.shotPlanShowSteamPlan : true;
-                    document.getElementById("spFormat").value = (props.shotPlanFormat === "compact" || props.shotPlanFormat === "stacked") ? props.shotPlanFormat : "sentence";
+                    document.getElementById("spFormat").value = (props.shotPlanFormat === "compact" || props.shotPlanFormat === "stacked" || props.shotPlanFormat === "plain") ? props.shotPlanFormat : "sentence";
                     document.getElementById("ssShotPlanSettings").style.display = "";
                 } else {
                     document.getElementById("ssNoSettings").style.display = "";

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -1953,6 +1953,14 @@ QString ShotServer::generateLayoutPage() const
             </div>
 
             <div id="ssShotPlanSettings" style="display:none">
+                <div class="section-label">Layout</div>
+                <div class="ss-slider-row">
+                    <select id="spFormat" onchange="spToggleChanged()" style="width:100%;padding:0.4rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px">
+                        <option value="sentence">Sentence</option>
+                        <option value="compact">Compact</option>
+                        <option value="stacked">Stacked</option>
+                    </select>
+                </div>
                 <div class="section-label">Visible elements</div>
                 <div class="ss-slider-row">
                     <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer">
@@ -3046,6 +3054,7 @@ QString ShotServer::generateLayoutPage() const
                     document.getElementById("spShowRoastDate").checked = typeof props.shotPlanShowRoastDate === "boolean" ? props.shotPlanShowRoastDate : false;
                     document.getElementById("spShowDoseYield").checked = typeof props.shotPlanShowDoseYield === "boolean" ? props.shotPlanShowDoseYield : true;
                     document.getElementById("spShowSteamPlan").checked = typeof props.shotPlanShowSteamPlan === "boolean" ? props.shotPlanShowSteamPlan : true;
+                    document.getElementById("spFormat").value = (props.shotPlanFormat === "compact" || props.shotPlanFormat === "stacked") ? props.shotPlanFormat : "sentence";
                     document.getElementById("ssShotPlanSettings").style.display = "";
                 } else {
                     document.getElementById("ssNoSettings").style.display = "";
@@ -3095,6 +3104,7 @@ QString ShotServer::generateLayoutPage() const
             apiPost("/api/layout/item", {itemId: id, key: "shotPlanShowRoastDate", value: document.getElementById("spShowRoastDate").checked}, function() {});
             apiPost("/api/layout/item", {itemId: id, key: "shotPlanShowDoseYield", value: document.getElementById("spShowDoseYield").checked}, function() {});
             apiPost("/api/layout/item", {itemId: id, key: "shotPlanShowSteamPlan", value: document.getElementById("spShowSteamPlan").checked}, function() {});
+            apiPost("/api/layout/item", {itemId: id, key: "shotPlanFormat", value: document.getElementById("spFormat").value}, function() {});
         }
     }
 


### PR DESCRIPTION
Adds a per-instance **format** option to the Shot Plan widget, chosen in the layout editor (native gear + web editor), so users can pick how the plan reads:

- **Sentence** (default) — unchanged; existing widgets render byte-identically.
- **Compact** — short `·`-separated fragments, no sentence.
- **Stacked** — sentence on line 1, details wrap onto following lines.
- **Plain** — a dot-free recipe line (e.g. *"Pull a 41.8g coffee shot using 19.0 grams of Olympia Blooming Espresso coffee beans"*); it ignores the per-field toggles, which grey out when Plain is selected.

Also included:
- **Overflow fix** — the text is width-capped to the tile, so long plans wrap/elide instead of bleeding past the widget.
- **Implicit-width fix** — the widget reports its *natural* (uncapped) width, so the tile can't ratchet ever-smaller through the `availableWidth: root.width` feedback loop.
- Wired identically in the native `ScreensaverEditorPopup` (segmented control) and the web editor (`<select id="spFormat">`), persisted per-instance as `shotPlanFormat` and validated to the four values on both load paths (defaults to `sentence`).

**Default unchanged:** the `sentence` output is byte-identical to current — the new `blockSep` collapses to the existing separator on the non-stacked path.

**Known limitation (disclosed):** `stacked`/`plain` are the first multi-line formats. The fixed-height status / lower-mid bars don't clip, so a 3-line plan placed there can overflow into neighbours — they're best in the center / growable zones. A follow-up could add `clip: true` to those two fixed bar containers; I left that out to keep this PR to the plan files and avoid touching zone layout. Happy to add it if you'd prefer.

Reviewed with the full `pr-review-toolkit:review-pr` suite to convergence over two rounds — code, silent-failure, comments, type-design, and test-coverage. No test added: the seven existing per-instance `shotPlanShow*` keys are likewise unpinned, and this rides the same generic `setItemProperty` mechanism (view-layer QML with no C++ test seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
