### PR TITLE
Custom widget: bean-metadata tokens (%ROASTER%, %COFFEE%, %ROAST_DATE%, %BREW_TEMP%, %YIELD%)

### DIFF
--- a/qml/components/layout/CustomEditorPopup.qml
+++ b/qml/components/layout/CustomEditorPopup.qml
@@ -155,6 +155,11 @@ Dialog {
         result = result.replace(/%SCALE%/g, "Lunar")
         result = result.replace(/%GRIND%/g, "1.8.0")
         result = result.replace(/%GRINDER%/g, "Niche Zero")
+        result = result.replace(/%ROASTER%/g, "Olympia Coffee")
+        result = result.replace(/%COFFEE%/g, "Big Truck")
+        result = result.replace(/%ROAST_DATE%/g, "2026-06-20")
+        result = result.replace(/%BREW_TEMP%/g, "93.0")
+        result = result.replace(/%YIELD%/g, "36.0 → 40.0g")
         result = result.replace(/%MACHINE_READY%/g, "Ready")
         result = result.replace(/%MACHINE_READY_COLOR%/g, Theme.successColor)
         result = result.replace(/%CONNECTED%/g, "Online")
@@ -1216,6 +1221,11 @@ Dialog {
         { token: "%DOSE%", label: TranslationManager.translate("customeditor.var.dose", "Dose (g)") },
         { token: "%GRIND%", label: TranslationManager.translate("customeditor.var.grind", "Grind Setting") },
         { token: "%GRINDER%", label: TranslationManager.translate("customeditor.var.grinder", "Grinder Model") },
+        { token: "%ROASTER%", label: TranslationManager.translate("customeditor.var.roaster", "Roaster") },
+        { token: "%COFFEE%", label: TranslationManager.translate("customeditor.var.coffee", "Coffee") },
+        { token: "%ROAST_DATE%", label: TranslationManager.translate("customeditor.var.roastDate", "Roast Date") },
+        { token: "%BREW_TEMP%", label: TranslationManager.translate("customeditor.var.brewTemp", "Brew Temp") },
+        { token: "%YIELD%", label: TranslationManager.translate("customeditor.var.yield", "Yield (g)") },
         { token: "%MACHINE_READY%", label: TranslationManager.translate("customeditor.var.machineReady", "Ready/Not ready") },
         { token: "%MACHINE_READY_COLOR%", label: TranslationManager.translate("customeditor.var.readyColor", "Ready Color") },
         { token: "%CONNECTED%", label: TranslationManager.translate("customeditor.var.connected", "Online/Offline") },

--- a/qml/components/layout/CustomEditorPopup.qml
+++ b/qml/components/layout/CustomEditorPopup.qml
@@ -158,7 +158,7 @@ Dialog {
         result = result.replace(/%ROASTER%/g, "Olympia Coffee")
         result = result.replace(/%COFFEE%/g, "Big Truck")
         result = result.replace(/%ROAST_DATE%/g, "2026-06-20")
-        result = result.replace(/%BREW_TEMP%/g, "93.0")
+        result = result.replace(/%BREW_TEMP%/g, "93.0°C")
         result = result.replace(/%YIELD%/g, "36.0 → 40.0g")
         result = result.replace(/%MACHINE_READY%/g, "Ready")
         result = result.replace(/%MACHINE_READY_COLOR%/g, Theme.successColor)

--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -94,6 +94,8 @@ Item {
         || content.indexOf("%TARGET_TEMP%") >= 0
         || content.indexOf("%RATIO%") >= 0
         || content.indexOf("%DOSE%") >= 0
+        || content.indexOf("%BREW_TEMP%") >= 0
+        || content.indexOf("%YIELD%") >= 0
 
     readonly property bool _needsScaleDevice: content.indexOf("%SCALE%") >= 0
         || content.indexOf("%SCALE_CONNECTED%") >= 0
@@ -101,6 +103,9 @@ Item {
 
     readonly property bool _needsSettingsData: content.indexOf("%GRIND%") >= 0
         || content.indexOf("%GRINDER%") >= 0
+        || content.indexOf("%ROASTER%") >= 0
+        || content.indexOf("%COFFEE%") >= 0
+        || content.indexOf("%ROAST_DATE%") >= 0
 
     // Variable substitution - only tracks the live properties this item actually uses.
     // Items showing static values (e.g. %PROFILE%) no longer re-evaluate at 5 Hz.
@@ -123,14 +128,22 @@ Item {
         }
         if (_needsControllerData && typeof ProfileManager !== "undefined") {
             void(ProfileManager.targetWeight); void(ProfileManager.currentProfileName)
-            void(ProfileManager.profileTargetTemperature)
+            void(ProfileManager.profileTargetTemperature); void(ProfileManager.profileTargetWeight)
             void(ProfileManager.brewByRatio); void(ProfileManager.brewByRatioDose)
+            // Override-aware %BREW_TEMP%/%YIELD%: the override flags live on Settings.brew, and the
+            // C/F unit read inside temperatureDisplay() is C++-side (invisible to bindings).
+            if (typeof Settings !== "undefined") {
+                void(Settings.app.temperatureUnit)
+                void(Settings.brew.hasTemperatureOverride); void(Settings.brew.temperatureOverride)
+                void(Settings.brew.hasBrewYieldOverride)
+            }
         }
         if (_needsScaleDevice && typeof ScaleDevice !== "undefined" && ScaleDevice) {
             void(ScaleDevice.name); void(ScaleDevice.connected)
         }
         if (_needsSettingsData && typeof Settings !== "undefined") {
             void(Settings.dye.dyeGrinderSetting); void(Settings.dye.dyeGrinderModel)
+            void(Settings.dye.dyeBeanBrand); void(Settings.dye.dyeBeanType); void(Settings.dye.dyeRoastDate)
         }
         return substituteVariables(_c)
     }
@@ -196,6 +209,28 @@ Item {
         // Grinder
         result = result.replace(/%GRIND%/g, typeof Settings !== "undefined" && Settings.dye.dyeGrinderSetting ? Settings.dye.dyeGrinderSetting : "—")
         result = result.replace(/%GRINDER%/g, typeof Settings !== "undefined" && Settings.dye.dyeGrinderModel ? Settings.dye.dyeGrinderModel : "—")
+        // Beans (DYE metadata)
+        result = result.replace(/%ROASTER%/g, typeof Settings !== "undefined" && Settings.dye.dyeBeanBrand ? Settings.dye.dyeBeanBrand : "—")
+        result = result.replace(/%COFFEE%/g, typeof Settings !== "undefined" && Settings.dye.dyeBeanType ? Settings.dye.dyeBeanType : "—")
+        result = result.replace(/%ROAST_DATE%/g, typeof Settings !== "undefined" && Settings.dye.dyeRoastDate ? Settings.dye.dyeRoastDate : "—")
+        // Override-aware brew temp + yield (mirror the Shot Plan: temperatureDisplay follows C/F and the
+        // override; yield shows "profile → override" with an arrow when a deliberate yield override is set).
+        if (result.indexOf("%BREW_TEMP%") >= 0) {
+            var _pTemp = typeof ProfileManager !== "undefined" ? ProfileManager.profileTargetTemperature : 0
+            var _hasTO = typeof Settings !== "undefined" && Settings.brew.hasTemperatureOverride
+            var _oTemp = _hasTO ? Settings.brew.temperatureOverride : _pTemp
+            result = result.replace(/%BREW_TEMP%/g, (typeof ProfileManager !== "undefined" && _pTemp > 0)
+                ? ProfileManager.temperatureDisplay(_pTemp, _hasTO, _oTemp) : "—")
+        }
+        if (result.indexOf("%YIELD%") >= 0) {
+            var _pYield = typeof ProfileManager !== "undefined" ? ProfileManager.profileTargetWeight : 0
+            var _tWeight = typeof ProfileManager !== "undefined" ? ProfileManager.targetWeight : 0
+            var _hasYO = typeof Settings !== "undefined" && Settings.brew.hasBrewYieldOverride
+            var _yieldStr = (_hasYO && _pYield > 0 && Math.abs(_tWeight - _pYield) > 0.1)
+                ? (_pYield.toFixed(1) + " → " + _tWeight.toFixed(1) + "g")
+                : (_tWeight > 0 ? (_tWeight.toFixed(1) + "g") : "—")
+            result = result.replace(/%YIELD%/g, _yieldStr)
+        }
         // Machine ready status
         var machineReady = typeof MachineState !== "undefined" && MachineState.isReady
         result = result.replace(/%MACHINE_READY%/g, machineReady ? TranslationManager.translate("customitem.status.ready", "Ready") : TranslationManager.translate("customitem.status.notReady", "Not ready"))

--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -187,7 +187,9 @@ Item {
         // Escape a text VALUE for the RichText render, and use a function replacer so the value's own
         // $-patterns ($&, $$, $1) aren't interpreted by String.replace. Mirrors ShotPlanText's safe
         // substitution. Numeric/arrow tokens can share it harmlessly; NOT for markup-emitting tokens.
-        function _subText(res, re, value) { var safe = Theme.escapeHtml(value); return res.replace(re, function() { return safe }) }
+        // Also neutralize % (→ &#37;, still renders as "%") so a value literally containing a later
+        // token — e.g. a bean named "%MACHINE_CONNECTED%" — can't be re-expanded by a later replace.
+        function _subText(res, re, value) { var safe = Theme.escapeHtml(value).replace(/%/g, "&#37;"); return res.replace(re, function() { return safe }) }
         // Machine
         result = result.replace(/%TEMP%/g, typeof DE1Device !== "undefined" ? Theme.cToDisplay(DE1Device.temperature).toFixed(1) : "—")
         result = result.replace(/%STEAM_TEMP%/g, typeof DE1Device !== "undefined" ? Theme.cToDisplay(DE1Device.steamTemperature).toFixed(0) + "\u00B0" : "—")

--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -184,6 +184,10 @@ Item {
     function substituteVariables(text) {
         if (!text) return ""
         var result = sanitizeHtml(text)
+        // Escape a text VALUE for the RichText render, and use a function replacer so the value's own
+        // $-patterns ($&, $$, $1) aren't interpreted by String.replace. Mirrors ShotPlanText's safe
+        // substitution. Numeric/arrow tokens can share it harmlessly; NOT for markup-emitting tokens.
+        function _subText(res, re, value) { var safe = Theme.escapeHtml(value); return res.replace(re, function() { return safe }) }
         // Machine
         result = result.replace(/%TEMP%/g, typeof DE1Device !== "undefined" ? Theme.cToDisplay(DE1Device.temperature).toFixed(1) : "—")
         result = result.replace(/%STEAM_TEMP%/g, typeof DE1Device !== "undefined" ? Theme.cToDisplay(DE1Device.steamTemperature).toFixed(0) + "\u00B0" : "—")
@@ -200,26 +204,27 @@ Item {
         result = result.replace(/%PREINFUSION_VOLUME%/g, typeof MachineState !== "undefined" ? MachineState.preinfusionVolume.toFixed(0) : "—")
         // Profile (ProfileManager)
         result = result.replace(/%TARGET_WEIGHT%/g, typeof ProfileManager !== "undefined" ? ProfileManager.targetWeight.toFixed(1) : "—")
-        result = result.replace(/%PROFILE%/g, typeof ProfileManager !== "undefined" ? ProfileManager.currentProfileName : "—")
+        result = _subText(result, /%PROFILE%/g, typeof ProfileManager !== "undefined" ? ProfileManager.currentProfileName : "—")
         result = result.replace(/%TARGET_TEMP%/g, typeof ProfileManager !== "undefined" ? Theme.cToDisplay(ProfileManager.profileTargetTemperature).toFixed(1) : "—")
         result = result.replace(/%RATIO%/g, typeof ProfileManager !== "undefined" ? ProfileManager.brewByRatio.toFixed(1) : "—")
         result = result.replace(/%DOSE%/g, typeof ProfileManager !== "undefined" ? ProfileManager.brewByRatioDose.toFixed(1) : "—")
         // Scale device
-        result = result.replace(/%SCALE%/g, typeof ScaleDevice !== "undefined" && ScaleDevice ? ScaleDevice.name : "—")
+        result = _subText(result, /%SCALE%/g, typeof ScaleDevice !== "undefined" && ScaleDevice ? ScaleDevice.name : "—")
         // Grinder
-        result = result.replace(/%GRIND%/g, typeof Settings !== "undefined" && Settings.dye.dyeGrinderSetting ? Settings.dye.dyeGrinderSetting : "—")
-        result = result.replace(/%GRINDER%/g, typeof Settings !== "undefined" && Settings.dye.dyeGrinderModel ? Settings.dye.dyeGrinderModel : "—")
+        result = _subText(result, /%GRIND%/g, typeof Settings !== "undefined" && Settings.dye.dyeGrinderSetting ? Settings.dye.dyeGrinderSetting : "—")
+        result = _subText(result, /%GRINDER%/g, typeof Settings !== "undefined" && Settings.dye.dyeGrinderModel ? Settings.dye.dyeGrinderModel : "—")
         // Beans (DYE metadata)
-        result = result.replace(/%ROASTER%/g, typeof Settings !== "undefined" && Settings.dye.dyeBeanBrand ? Settings.dye.dyeBeanBrand : "—")
-        result = result.replace(/%COFFEE%/g, typeof Settings !== "undefined" && Settings.dye.dyeBeanType ? Settings.dye.dyeBeanType : "—")
-        result = result.replace(/%ROAST_DATE%/g, typeof Settings !== "undefined" && Settings.dye.dyeRoastDate ? Settings.dye.dyeRoastDate : "—")
+        result = _subText(result, /%ROASTER%/g, typeof Settings !== "undefined" && Settings.dye.dyeBeanBrand ? Settings.dye.dyeBeanBrand : "—")
+        result = _subText(result, /%COFFEE%/g, typeof Settings !== "undefined" && Settings.dye.dyeBeanType ? Settings.dye.dyeBeanType : "—")
+        result = _subText(result, /%ROAST_DATE%/g, typeof Settings !== "undefined" && Settings.dye.dyeRoastDate ? Settings.dye.dyeRoastDate : "—")
         // Override-aware brew temp + yield (mirror the Shot Plan: temperatureDisplay follows C/F and the
-        // override; yield shows "profile → override" with an arrow when a deliberate yield override is set).
+        // override; yield shows "profile → override" with an arrow only when a deliberate yield override is
+        // set AND differs from the profile yield by more than 0.1 g).
         if (result.indexOf("%BREW_TEMP%") >= 0) {
             var _pTemp = typeof ProfileManager !== "undefined" ? ProfileManager.profileTargetTemperature : 0
             var _hasTO = typeof Settings !== "undefined" && Settings.brew.hasTemperatureOverride
             var _oTemp = _hasTO ? Settings.brew.temperatureOverride : _pTemp
-            result = result.replace(/%BREW_TEMP%/g, (typeof ProfileManager !== "undefined" && _pTemp > 0)
+            result = _subText(result, /%BREW_TEMP%/g, (typeof ProfileManager !== "undefined" && _pTemp > 0)
                 ? ProfileManager.temperatureDisplay(_pTemp, _hasTO, _oTemp) : "—")
         }
         if (result.indexOf("%YIELD%") >= 0) {
@@ -229,7 +234,7 @@ Item {
             var _yieldStr = (_hasYO && _pYield > 0 && Math.abs(_tWeight - _pYield) > 0.1)
                 ? (_pYield.toFixed(1) + " → " + _tWeight.toFixed(1) + "g")
                 : (_tWeight > 0 ? (_tWeight.toFixed(1) + "g") : "—")
-            result = result.replace(/%YIELD%/g, _yieldStr)
+            result = _subText(result, /%YIELD%/g, _yieldStr)
         }
         // Machine ready status
         var machineReady = typeof MachineState !== "undefined" && MachineState.isReady

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -3829,6 +3829,8 @@ QString ShotServer::generateLayoutPage() const
             .replace(/%TARGET_WEIGHT%/g,"36.0").replace(/%PROFILE%/g,"Adaptive v2")
             .replace(/%TARGET_TEMP%/g,"93.0").replace(/%RATIO%/g,"2.0")
             .replace(/%DOSE%/g,"18.0").replace(/%SCALE%/g,"Lunar")
+            .replace(/%ROASTER%/g,"Olympia Coffee").replace(/%COFFEE%/g,"Big Truck")
+            .replace(/%ROAST_DATE%/g,"2026-06-20").replace(/%BREW_TEMP%/g,"93.0°C").replace(/%YIELD%/g,"36.0 → 40.0g")
             .replace(/%MACHINE_READY%/g,"Ready").replace(/%MACHINE_READY_COLOR%/g,"#18c37e")
             .replace(/%CONNECTED%/g,"Online").replace(/%CONNECTED_COLOR%/g,"#18c37e")
             .replace(/%DEVICES%/g,"Machine + Scale")
@@ -3938,6 +3940,8 @@ QString ShotServer::generateLayoutPage() const
         "%WATER%":"78","%WATER_ML%":"850","%WEIGHT%":"36.2","%SHOT_TIME%":"28.5",
         "%TARGET_WEIGHT%":"36.0","%VOLUME%":"42","%PROFILE%":"Profile","%STATE%":"Idle",
         "%TARGET_TEMP%":"93.0","%SCALE%":"Scale","%RATIO%":"2.0","%DOSE%":"18.0",
+        "%ROASTER%":"Olympia Coffee","%COFFEE%":"Big Truck","%ROAST_DATE%":"2026-06-20",
+        "%BREW_TEMP%":"93.0°C","%YIELD%":"36.0 → 40.0g",
         "%TIME%":"12:30","%DATE%":"2025-01-15",
         "%MACHINE_READY%":"Ready","%MACHINE_READY_COLOR%":"#00cc6d",
         "%CONNECTED%":"Online","%CONNECTED_COLOR%":"#00cc6d","%DEVICES%":"Machine",

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -1861,6 +1861,11 @@ QString ShotServer::generateLayoutPage() const
                             <div class="var-item" onclick="insertVar('%DATE%')">Date</div>
                             <div class="var-item" onclick="insertVar('%RATIO%')">Ratio</div>
                             <div class="var-item" onclick="insertVar('%DOSE%')">Dose</div>
+                            <div class="var-item" onclick="insertVar('%ROASTER%')">Roaster</div>
+                            <div class="var-item" onclick="insertVar('%COFFEE%')">Coffee</div>
+                            <div class="var-item" onclick="insertVar('%ROAST_DATE%')">Roast Date</div>
+                            <div class="var-item" onclick="insertVar('%BREW_TEMP%')">Brew Temp</div>
+                            <div class="var-item" onclick="insertVar('%YIELD%')">Yield</div>
                             <div class="var-item" onclick="insertVar('%MACHINE_READY%')">Ready</div>
                             <div class="var-item" onclick="insertVar('%MACHINE_READY_COLOR%')">Ready Clr</div>
                             <div class="var-item" onclick="insertVar('%CONNECTED%')">Online</div>


### PR DESCRIPTION
Adds five metadata tokens to the **Custom widget**'s `%TOKEN%` template, so a user can compose their own shot summary alongside the existing `%PROFILE%`/`%DOSE%`/`%GRINDER%`/… tokens:

- **`%ROASTER%`** — the bean's roaster (DYE `dyeBeanBrand`)
- **`%COFFEE%`** — the coffee name (`dyeBeanType`)
- **`%ROAST_DATE%`** — the roast date (`dyeRoastDate`)
- **`%BREW_TEMP%`** — the brew temperature, **override-aware** (via `ProfileManager.temperatureDisplay` — follows the °C/°F unit and a temperature override), mirroring the Shot Plan
- **`%YIELD%`** — the target output weight, **override-aware** (shows `profile → target` with an arrow only on a deliberate yield override >0.1 g)

Each falls back to `—` when its field is empty. Wired through all the usual surfaces: the substitution in `substituteVariables()`, the native editor palette + preview (`CustomEditorPopup`), and the web layout editor's palette **and** its two preview maps (`shotserver_layout`). Reactivity is tracked via the existing `_needsControllerData`/`_needsSettingsData` gates so a `%ROASTER%`-only widget refreshes on bean changes without joining the 5 Hz machine-telemetry path.

**Escaping/robustness:** `%ROASTER%`/`%COFFEE%`/`%ROAST_DATE%` are user/Bean-Base strings rendered in a `Text.RichText`, so they're now escaped via a `_subText` helper (`Theme.escapeHtml` + a function replacer so a value's `$&`/`$$` isn't reinterpreted, + `%`→`&#37;` so a value can't smuggle another token). Since I was in that function, I routed the pre-existing free-text siblings (`%PROFILE%`/`%GRINDER%`/`%SCALE%`/`%GRIND%`) through it too — they shared the same latent issue. The intentional-markup tokens (`%MACHINE_CONNECTED%` `<img>`, `%*_COLOR%`) are deliberately left raw.

Reviewed with the full `pr-review-toolkit:review-pr` suite to convergence over two rounds — code, silent-failure, comments, type-design, and test-coverage. No test added: `substituteVariables()` is QML-embedded JS with no C++ QTest seam, and the ~20 existing tokens are likewise untested; `%BREW_TEMP%`'s real logic is covered via the tested `temperatureDisplay()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
