### PR TITLE
Advisor: order grind/ratio before temperature for sour/bitter shots

### DIFF
--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -1312,6 +1312,8 @@ The "Common Espresso Patterns" section below tells you the **direction** of grin
 
 ## Common Espresso Patterns
 
+**Lever ordering.** Grind and ratio are the primary espresso levers — settle those first. Temperature is a smaller, later adjustment; don't reach for it to fix sourness or bitterness until grind and ratio are dialed. (Exception: when a profile was deliberately built around a specific temperature, respect the author's intent — see "Profile Intent is the Reference Frame" below.)
+
 ### The Gusher
 - **Symptoms**: Very fast shot (<20s), flow way above target, thin/watery taste
 - **Cause**: Grind too coarse or severe channeling
@@ -1329,13 +1331,13 @@ The "Common Espresso Patterns" section below tells you the **direction** of grin
 
 ### The Sour Shot
 - **Symptoms**: Bright acidity, thin body, tea-like, possibly underextracted
-- **Possible causes**: Temperature too low, ratio too short, shot too fast
-- **Fix**: Increase temp 2°C, or pull longer, or grind finer (one at a time!)
+- **Possible causes**: Ratio too short, shot too fast, grind too coarse (temperature too low is a secondary cause)
+- **Fix**: Grind finer, or pull longer (tighten the ratio) — settle those first; raise temp 2°C only after (one at a time!). But if grinding finer makes the shot channel or choke, finer extracts *less* — go coarser instead.
 
 ### The Bitter Shot
 - **Symptoms**: Harsh, astringent, dry finish, overextracted
-- **Possible causes**: Temperature too high, ratio too long, shot too slow
-- **Fix**: Decrease temp 2°C, or cut shot earlier, or grind coarser
+- **Possible causes**: Ratio too long, shot too slow, grind too fine (temperature too high is a secondary cause)
+- **Fix**: Grind coarser, or cut the shot earlier — settle those first; drop temp 2°C only after (one at a time!)
 
 ### The Hollow Shot
 - **Symptoms**: Lacks body, feels empty in the middle, thin mouthfeel
@@ -1444,11 +1446,11 @@ The data shows the same format as espresso shots — phase breakdown with pressu
 
 ### Bitter / Harsh
 - **Cause**: Over-extraction or water too hot
-- **Fix**: Reduce temperature, grind slightly coarser, or reduce brew time
+- **Fix**: Grind slightly coarser, or reduce brew time; reduce temperature 2-3°C only after
 
 ### Sour / Sharp Acidity
 - **Cause**: Under-extraction
-- **Fix**: Increase temperature, grind finer, or extend brew time
+- **Fix**: Grind finer, or extend brew time; increase temperature 2-3°C only after
 
 ### Muddy / Lacking Clarity
 - **Cause**: Too many fines (grinder-dependent) or channeling through the puck

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -1312,7 +1312,7 @@ The "Common Espresso Patterns" section below tells you the **direction** of grin
 
 ## Common Espresso Patterns
 
-**Lever ordering.** Grind and ratio are the primary espresso levers — settle those first. Temperature is a smaller, later adjustment; don't reach for it to fix sourness or bitterness until grind and ratio are dialed. (Exception: when a profile was deliberately built around a specific temperature, respect the author's intent — see "Profile Intent is the Reference Frame" below.)
+**Lever ordering.** Grind and ratio are the primary espresso levers — settle those first. Temperature is a smaller, later adjustment; don't reach for it to fix sourness or bitterness until grind and ratio are dialed. (Exception: when a profile was deliberately built around a specific temperature, respect the author's intent — see the "Profile Intent is the Reference Frame" note.)
 
 ### The Gusher
 - **Symptoms**: Very fast shot (<20s), flow way above target, thin/watery taste
@@ -1332,7 +1332,7 @@ The "Common Espresso Patterns" section below tells you the **direction** of grin
 ### The Sour Shot
 - **Symptoms**: Bright acidity, thin body, tea-like, possibly underextracted
 - **Possible causes**: Ratio too short, shot too fast, grind too coarse (temperature too low is a secondary cause)
-- **Fix**: Grind finer, or pull longer (tighten the ratio) — settle those first; raise temp 2°C only after (one at a time!). But if grinding finer makes the shot channel or choke, finer extracts *less* — go coarser instead.
+- **Fix**: Grind finer, or pull longer (lengthen the ratio) — settle those first; raise temp 2°C only after (one at a time!). But if the finer grind *itself* makes the shot channel, finer extracts *less* — go coarser instead.
 
 ### The Bitter Shot
 - **Symptoms**: Harsh, astringent, dry finish, overextracted

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -1312,7 +1312,7 @@ The "Common Espresso Patterns" section below tells you the **direction** of grin
 
 ## Common Espresso Patterns
 
-**Lever ordering.** Grind and ratio are the primary espresso levers — settle those first. Temperature is a smaller, later adjustment; don't reach for it to fix sourness or bitterness until grind and ratio are dialed. (Exception: when a profile was deliberately built around a specific temperature, respect the author's intent — see the "Profile Intent is the Reference Frame" note.)
+**Lever ordering.** Grind and ratio are the primary espresso levers — settle those first. Temperature is a smaller, later adjustment; don't reach for it to fix sourness or bitterness until grind and ratio are dialed. (Exception: when the profile's description calls out temperature as central to its design, respect the author's intent — see the "Profile Intent is the Reference Frame" note.)
 
 ### The Gusher
 - **Symptoms**: Very fast shot (<20s), flow way above target, thin/watery taste
@@ -1332,12 +1332,13 @@ The "Common Espresso Patterns" section below tells you the **direction** of grin
 ### The Sour Shot
 - **Symptoms**: Bright acidity, thin body, tea-like, possibly underextracted
 - **Possible causes**: Ratio too short, shot too fast, grind too coarse (temperature too low is a secondary cause)
-- **Fix**: Grind finer, or pull longer (lengthen the ratio) — settle those first; raise temp 2°C only after (one at a time!). But if the finer grind *itself* makes the shot channel, finer extracts *less* — go coarser instead.
+- **Fix**: One change at a time! Grind finer, or pull longer (lengthen the ratio) — settle those first; raise temp 2°C only after.
+- **Caveat**: If channeling appears *after* going finer, re-check puck prep first (see The Channeler); if it persists, step back to the previous grind setting — past that point, finer extracts *less*.
 
 ### The Bitter Shot
 - **Symptoms**: Harsh, astringent, dry finish, overextracted
 - **Possible causes**: Ratio too long, shot too slow, grind too fine (temperature too high is a secondary cause)
-- **Fix**: Grind coarser, or cut the shot earlier — settle those first; drop temp 2°C only after (one at a time!)
+- **Fix**: One change at a time! Grind coarser, or cut the shot earlier — settle those first; drop temp 2°C only after.
 
 ### The Hollow Shot
 - **Symptoms**: Lacks body, feels empty in the middle, thin mouthfeel
@@ -1436,13 +1437,15 @@ The data shows the same format as espresso shots — phase breakdown with pressu
 
 ## Common Filter Issues
 
+**Lever ordering.** Grind and brew time are the primary levers here too — settle those first; temperature 2-3°C adjustments come after. (Exceptions: when the profile's design pins the grind — see the grind-advice rule above — or its description calls out temperature as central, follow the profile's intent per the "Profile Intent is the Reference Frame" note.)
+
 ### Astringent / Dry Finish
 - **Cause**: Over-extraction, often from too fine a grind or too high a temperature
-- **Fix**: Grind coarser or reduce temperature 2-3°C
+- **Fix**: Grind coarser; reduce temperature 2-3°C only after
 
 ### Thin / Watery / Hollow
 - **Cause**: Under-extraction from too coarse a grind, too low temperature, or insufficient contact time
-- **Fix**: Grind finer or increase temperature 2-3°C
+- **Fix**: Grind finer, or extend contact time; increase temperature 2-3°C only after
 
 ### Bitter / Harsh
 - **Cause**: Over-extraction or water too hot
@@ -1543,6 +1546,8 @@ double ShotSummarizer::calculateMin(const QVector<QPointF>& data, double startTi
 
 QString ShotSummarizer::sharedCorePhilosophy()
 {
+    // The bolded title "Profile Intent is the Reference Frame" is referenced verbatim
+    // by the "Lever ordering" notes in espressoSystemPrompt() and filterSystemPrompt().
     return QStringLiteral(R"(## Core Philosophy
 
 **Taste is King.** Numbers are tools to understand taste, not goals in themselves. A shot that tastes great with "wrong" numbers is a great shot. A shot with "perfect" numbers that tastes bad needs fixing.


### PR DESCRIPTION
## Order grind/ratio before temperature for sour/bitter shots

The dialing advisor's "Common Espresso Patterns" told it to reach for **temperature first** on a sour or bitter shot — the Sour Shot fix literally led with *"Increase temp 2°C, or pull longer, or grind finer."* Grind and ratio are the primary espresso levers; temperature is a smaller, later adjustment. This reorders the four temp-first fixes to lead with grind/ratio and demotes temperature to a later step.

**What changed (prompt text only, `src/ai/shotsummarizer.cpp`):**
- Reordered the **Sour Shot**, **Bitter Shot**, **Bitter/Harsh**, and **Sour/Sharp Acidity** fixes to lead with grind/ratio; temperature "only after."
- Added a short **"Lever ordering"** note under Common Espresso Patterns.
- Folded a channeling **guard-rail** into the Sour fix: *if the finer grind itself makes the shot channel, finer extracts less — go coarser instead* (the Matter 2020 non-monotonic result).
- Added the missing `(one at a time!)` to the Bitter fix.

**Framed as ordering, not a prohibition.** It explicitly defers to a profile deliberately built around a specific temperature ("Profile Intent is the Reference Frame") — so temperature-designed profiles are unaffected. Backed by both standard dial-in practice and the temperature sensory study (Nature *Sci Rep* 2020: no appreciable sensory effect at fixed TDS/EY).

Ran the review-pr suite (code-reviewer + comment-analyzer) to convergence — it caught a backwards ratio gloss and a stale cross-reference, both fixed. No logic touched.

*Companion note:* I also explored adding a computed days-off-roast number to the `beanFreshness` block, but the block already carries the roast/thaw dates + an aging instruction, and baking a day-count into a cached prompt risks staleness — so I left it out. Happy to revisit if you'd want it.
