### PR TITLE
Don't flag 'First step skipped' when frame 0 exited on its own exit condition

### DIFF
--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -343,7 +343,16 @@ other reason). Consumers wanting "verified clean" specifically must read
 ### 2.3 Skip first frame
 
 `detectSkipFirstFrame` operates on phase markers only — no curves needed. Two
-distinct branches inside one function, picked from the marker stream:
+distinct branches inside one function, picked from the marker stream.
+
+**Exit-condition guard (checked first).** Before either branch, if the first
+non-zero frame's marker `transitionReason` is `"pressure"`, `"flow"`, or
+`"weight"`, the detector returns `false` — frame 0 exited on its own exit
+condition, so it executed as designed and was not skipped. DE1 preinfusion/fill
+frames routinely exit far earlier than their configured max duration (that is
+their purpose), and without this guard the duration checks below flag them as
+"skipped." Only a `"time"` or empty (old-data) reason falls through to the
+branches. This mirrors how `detectGrind` already uses `transitionReason`.
 
 **FW-bug branch** — frame 0 was never observed before a non-zero frame:
 returns `phase.time < 2.0`. The 2-second window matches the de1app Tcl

--- a/docs/SHOT_REVIEW.md
+++ b/docs/SHOT_REVIEW.md
@@ -347,12 +347,16 @@ distinct branches inside one function, picked from the marker stream.
 
 **Exit-condition guard (checked first).** Before either branch, if the first
 non-zero frame's marker `transitionReason` is `"pressure"`, `"flow"`, or
-`"weight"`, the detector returns `false` — frame 0 exited on its own exit
-condition, so it executed as designed and was not skipped. DE1 preinfusion/fill
-frames routinely exit far earlier than their configured max duration (that is
-their purpose), and without this guard the duration checks below flag them as
-"skipped." Only a `"time"` or empty (old-data) reason falls through to the
-branches. This mirrors how `detectGrind` already uses `transitionReason`.
+`"weight"` (case-insensitive), the detector returns `false` — the preceding
+frame exited on its own confirmed exit condition, so it executed as designed and
+was not skipped. DE1 preinfusion/fill frames routinely exit far earlier than
+their configured max duration (that is their purpose), and without this guard the
+duration checks below flag them as "skipped." These reasons are recorded only for
+a *confirmed* sensor exit — `MainController` records an unconfirmed exit as
+`"time"` rather than guessing — so a match here is a genuine target-met exit.
+Only a `"time"` or empty (old-data) reason falls through to the branches. This
+uses the same `transitionReason` signal `analyzeFlowVsGoal` (the grind detector,
+`detectGrindIssue`) already reads.
 
 **FW-bug branch** — frame 0 was never observed before a non-zero frame:
 returns `phase.time < 2.0`. The 2-second window matches the de1app Tcl

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -677,18 +677,21 @@ bool ShotAnalysis::detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
             continue;
         }
 
-        // A first frame that exited on its OWN exit condition (a pressure/flow/
-        // weight target) executed as designed — it was not skipped. DE1
-        // preinfusion/fill frames routinely exit early, long before their
+        // A first frame that exited on its OWN confirmed exit condition (a
+        // pressure/flow/weight target) executed as designed — it was not skipped.
+        // DE1 preinfusion/fill frames routinely exit early, long before their
         // configured max duration, which is exactly what they are meant to do.
-        // The marker for the first non-zero frame records WHY frame 0 exited;
-        // only a time-based or unknown early-out can indicate a genuinely
-        // skipped or too-short first step. (Same transitionReason signal the
-        // grind detector already relies on.) Old data has an empty reason and
-        // falls through to the duration checks below, preserving prior behaviour.
-        if (phase.transitionReason == QStringLiteral("pressure")
-                || phase.transitionReason == QStringLiteral("flow")
-                || phase.transitionReason == QStringLiteral("weight"))
+        // The first non-zero frame's marker records why the PRECEDING frame
+        // exited; only a time-based or empty/unknown reason can indicate a
+        // genuinely skipped or too-short first step. (Same transitionReason
+        // signal analyzeFlowVsGoal — called by detectGrindIssue — reads.) These
+        // reasons are only recorded when the sensor exit is CONFIRMED (see
+        // MainController: an unconfirmed exit is recorded as "time", not guessed),
+        // so a match here means a real target-met exit. Old data has an empty
+        // reason and falls through to the duration checks below, unchanged.
+        if (phase.transitionReason.compare(QStringLiteral("pressure"), Qt::CaseInsensitive) == 0
+                || phase.transitionReason.compare(QStringLiteral("flow"), Qt::CaseInsensitive) == 0
+                || phase.transitionReason.compare(QStringLiteral("weight"), Qt::CaseInsensitive) == 0)
             return false;
 
         // FW-bug branch: frame 0 was never observed before a non-zero frame.

--- a/src/ai/shotanalysis.cpp
+++ b/src/ai/shotanalysis.cpp
@@ -677,6 +677,20 @@ bool ShotAnalysis::detectSkipFirstFrame(const QList<HistoryPhaseMarker>& phases,
             continue;
         }
 
+        // A first frame that exited on its OWN exit condition (a pressure/flow/
+        // weight target) executed as designed — it was not skipped. DE1
+        // preinfusion/fill frames routinely exit early, long before their
+        // configured max duration, which is exactly what they are meant to do.
+        // The marker for the first non-zero frame records WHY frame 0 exited;
+        // only a time-based or unknown early-out can indicate a genuinely
+        // skipped or too-short first step. (Same transitionReason signal the
+        // grind detector already relies on.) Old data has an empty reason and
+        // falls through to the duration checks below, preserving prior behaviour.
+        if (phase.transitionReason == QStringLiteral("pressure")
+                || phase.transitionReason == QStringLiteral("flow")
+                || phase.transitionReason == QStringLiteral("weight"))
+            return false;
+
         // FW-bug branch: frame 0 was never observed before a non-zero frame.
         // Mirror the de1app Tcl plugin's hard 2 s window — that plugin polls
         // during extraction and can only catch it before t=2 s, so for parity

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -2700,13 +2700,17 @@ void MainController::onShotSampleReceived(const ShotSample& sample) {
                     // Exit condition configured but time ran out first
                     transitionReason = QStringLiteral("time");
                 } else {
-                    // Condition was configured, values near threshold - machine likely triggered it
-                    transitionReason = prevFrame.exitType.contains(QStringLiteral("pressure"))
-                        ? QStringLiteral("pressure") : QStringLiteral("flow");
+                    // Exit condition was configured, but the sensor threshold was NOT
+                    // confirmed above and time did not expire — so we cannot attribute the
+                    // exit to a real pressure/flow trigger. Record "time" (the frame advanced
+                    // without a confirmed sensor reason) rather than GUESS a sensor exit that
+                    // consumers trust as ground truth (the skip-first-frame guard and the
+                    // grind detector both suppress/trim on a confirmed pressure/flow reason).
+                    transitionReason = QStringLiteral("time");
                     qDebug() << "MainController: Frame" << prevFrameIndex
-                             << "exit reason ambiguous - exitType:" << prevFrame.exitType
+                             << "exit reason unconfirmed - exitType:" << prevFrame.exitType
                              << "pressure:" << m_lastPressure << "flow:" << m_lastFlow
-                             << "inferred:" << transitionReason;
+                             << "recorded as time";
                 }
             } else {
                 // No exit condition configured - frame ended by time

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -175,6 +175,34 @@ private slots:
         expectSkipDetection({
             phase(0.0, "Pour", 1),
         }, 3, /*firstFrameConfiguredSeconds=*/2.0, true);
+
+        // Exit-condition guard: a first frame that exited on its OWN confirmed
+        // pressure/flow/weight target executed as designed even if very short —
+        // it must NOT flag. Without the guard the short-first-step branch
+        // (0.3 < cutoff) false-positives on every early-exiting preinfusion frame.
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "Fill", 0),
+            phase(0.3, "Pour", 1, /*isFlowMode=*/false, /*transitionReason=*/"pressure"),
+        }, 3, false);
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "Fill", 0),
+            phase(0.3, "Pour", 1, false, "flow"),
+        }, 3, false);
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "Fill", 0),
+            phase(0.3, "Pour", 1, false, "weight"),
+        }, 3, false);
+
+        // Guard is reason-SPECIFIC, not a blanket suppress: a genuinely-too-short
+        // first frame that advanced on "time" (no confirmed sensor exit) still flags.
+        expectSkipDetection({
+            phase(0.0, "Start", 0),
+            phase(0.0, "Fill", 0),
+            phase(0.3, "Pour", 1, false, "time"),
+        }, 3, true);
     }
 
     // buildChannelingWindows ---------------------------------------------


### PR DESCRIPTION
## Don't flag "First step skipped" when frame 0 exited on its own condition

**The bug:** `detectSkipFirstFrame` flags a first frame that runs shorter than half its *configured* max duration — but it never checks *why* the frame ended. DE1 preinfusion/fill frames are designed to exit early on their exit condition (a pressure/flow/weight target), long before their configured max. So a preinfusion frame set to e.g. 8 s that correctly exits at ~1.2 s on its pressure target gets flagged "First step skipped" **every shot**, even though it executed exactly as designed. Fully reproducible for any profile whose first frame has an exit condition.

**The fix:** the first non-zero frame's marker already records `transitionReason` (the reason the preceding frame exited). Gate the detector on it — a `pressure`/`flow`/`weight` exit means frame 0 met its own target and was *not* skipped. Only a `time`/empty (old-data) reason falls through to the existing duration checks. Mirrors the signal `analyzeFlowVsGoal` already uses; recompute-on-load is preserved (`transitionReason` is persisted).

**Coupled change worth your attention — `maincontroller.cpp` transition-reason inference:** the detector can only trust `transitionReason` if `pressure`/`flow`/`weight` always means a *confirmed* sensor exit. Today the ambiguous `else` (exit configured, but neither threshold confirmed nor time expired) **guesses** `pressure`/`flow` from `exitType` (it logs "ambiguous"). That guess, treated as truth, would let the new guard suppress a *genuinely* too-short frame. So this PR changes that ambiguous case to record **`"time"`** instead of a guessed sensor reason.

This is a **shared-semantics change** — `transitionReason` is also read by `detectGrindIssue`/`analyzeFlowVsGoal`, the shot models, the graph marker letters, and the AI summarizer. I traced them all: `"time"` is already a valid, handled value everywhere (no blank letters, no missed grind-trim — the trim only fires on *confirmed* pressure), and the full suite stays green (89/89). The one honest tradeoff: the ambiguous case is often a real sensor exit delayed by BLE sample lag, so it will now show **"Time exit"** in the UI/summarizer where it previously showed a (usually-correct) pressure/flow guess. That's cosmetic and logged — versus the old behavior, which *silently suppressed a real defect*.

If you'd prefer to keep the UI's sensor-exit labeling, a cleaner alternative is a distinct `"unconfirmed"` reason (flags identically in the guard, but the UI/summarizer can render it as an inferred sensor exit rather than "Time exit"). Happy to switch to that — your call on your data model.

**Tests:** added rows to `skipFirstFrameDetection()` — a 0.3 s first frame with `pressure`/`flow`/`weight` → not flagged; with `time` → still flagged (proves the gate is reason-specific, not a blanket off-switch). `docs/SHOT_REVIEW.md` §2.3 updated. Ran the full `pr-review-toolkit` suite (code/silent-failure/comments/types/tests) to convergence.
