### PR TITLE
Migration16 Visualizer sync: evict permanently-failed (404) queue entries

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -333,9 +333,12 @@ MainController::MainController(QNetworkAccessManager* networkManager,
         m_migration16InFlightVisualizerId.clear();
 
         if (!permanent) {
-            // Transient (offline, 5xx, credentials): leave the entry in
+            // Transient (anything but 404 — see the classification in
+            // VisualizerUploader::onUpdateFinished): leave the entry in
             // the pending list and abort the drain — the queue picks up
             // on the next boot.
+            qDebug() << "MainController: migration16 sync — transient failure ("
+                     << error << "); drain paused until next boot";
             return;
         }
 
@@ -344,7 +347,9 @@ MainController::MainController(QNetworkAccessManager* networkManager,
         // migration 16 queued in good faith. Retrying forever wastes a
         // network round-trip and logs an error on every launch (#1431):
         // evict the entry, clear the dead link on the local shot row so
-        // nothing else trusts it, and continue draining.
+        // nothing else trusts it, and continue draining. The clear is
+        // guarded on the row still holding this exact id, so a link the
+        // user replaced meanwhile (re-upload) is never wiped.
         QSettings s(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
         QJsonArray pending = QJsonDocument::fromJson(
             s.value(QStringLiteral("migration16/pendingVisualizerSync")).toByteArray()).array();
@@ -353,8 +358,8 @@ MainController::MainController(QNetworkAccessManager* networkManager,
             if (entry.value("visualizerId").toString() != visualizerId)
                 continue;
             const qint64 shotId = entry.value("shotId").toVariant().toLongLong();
-            if (shotId > 0 && m_shotHistory && m_shotHistory->isReady())
-                m_shotHistory->requestUpdateVisualizerInfo(shotId, QString(), QString());
+            if (m_shotHistory)
+                m_shotHistory->requestClearStaleVisualizerLink(shotId, visualizerId);
             pending.removeAt(i);
             break;
         }

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -279,8 +279,9 @@ MainController::MainController(QNetworkAccessManager* networkManager,
     // Migration 16 ran inside initialize() above. If it found inferred
     // shots that were uploaded to Visualizer, it queued them in
     // QSettings under migration16/pendingVisualizerSync. Drain that
-    // list now — guarded internally on credentials being available;
-    // failed entries persist for the next boot.
+    // list now — guarded internally on credentials being available.
+    // Transiently-failed entries persist for the next boot; permanently
+    // failed ones (404) are evicted (see updateFailed connect below).
     processPendingVisualizerRatingSync();
 
     // One-time reconciliation: relink shots that were uploaded before
@@ -322,16 +323,49 @@ MainController::MainController(QNetworkAccessManager* networkManager,
         m_migration16InFlightVisualizerId.clear();
         dispatchNextPendingVisualizerSync();
     });
-    connect(m_visualizer, &VisualizerUploader::uploadFailed, this,
-            [this](const QString& /*error*/) {
-        // VisualizerUploader::uploadFailed carries no shot-id correlation, so
-        // we can't tell whether the failure was ours or someone else's. The
-        // safe rule: if a migration16 PATCH is in flight, assume it failed
-        // (the same upload session can't error AND succeed on the network
-        // layer), leave the entry in the pending list, and abort the drain.
-        // A spurious abort just means the queue picks up on next boot.
-        if (m_migration16InFlightVisualizerId.isEmpty()) return;
+    connect(m_visualizer, &VisualizerUploader::updateFailed, this,
+            [this](const QString& visualizerId, bool permanent, const QString& error) {
+        // Same in-flight filter as updateSuccess above: ignore failures
+        // from PATCHes we didn't issue (user edits from the review pages).
+        if (m_migration16InFlightVisualizerId.isEmpty()
+            || visualizerId != m_migration16InFlightVisualizerId)
+            return;
         m_migration16InFlightVisualizerId.clear();
+
+        if (!permanent) {
+            // Transient (offline, 5xx, credentials): leave the entry in
+            // the pending list and abort the drain — the queue picks up
+            // on the next boot.
+            return;
+        }
+
+        // Permanent (HTTP 404): the shot does not exist on Visualizer and
+        // never will — e.g. a bogus placeholder visualizer_id that
+        // migration 16 queued in good faith. Retrying forever wastes a
+        // network round-trip and logs an error on every launch (#1431):
+        // evict the entry, clear the dead link on the local shot row so
+        // nothing else trusts it, and continue draining.
+        QSettings s(QStringLiteral("DecentEspresso"), QStringLiteral("DE1Qt"));
+        QJsonArray pending = QJsonDocument::fromJson(
+            s.value(QStringLiteral("migration16/pendingVisualizerSync")).toByteArray()).array();
+        for (qsizetype i = 0; i < pending.size(); ++i) {
+            const QJsonObject entry = pending[i].toObject();
+            if (entry.value("visualizerId").toString() != visualizerId)
+                continue;
+            const qint64 shotId = entry.value("shotId").toVariant().toLongLong();
+            if (shotId > 0 && m_shotHistory && m_shotHistory->isReady())
+                m_shotHistory->requestUpdateVisualizerInfo(shotId, QString(), QString());
+            pending.removeAt(i);
+            break;
+        }
+        if (pending.isEmpty())
+            s.remove(QStringLiteral("migration16/pendingVisualizerSync"));
+        else
+            s.setValue(QStringLiteral("migration16/pendingVisualizerSync"),
+                       QJsonDocument(pending).toJson(QJsonDocument::Compact));
+        qWarning() << "MainController: migration16 sync — dropping visualizerId"
+                   << visualizerId << "after permanent failure:" << error;
+        dispatchNextPendingVisualizerSync();
     });
 
     // Create shot importer for importing .shot files from DE1 app

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -276,8 +276,10 @@ private:
     // shot's rating to Visualizer so the cloud copy matches the local
     // corrected value. Serial: pops one entry, dispatches the PATCH,
     // resumes from the VisualizerUploader::updateSuccess signal. On
-    // failure (no creds, network error) the entry remains in the list
-    // and retries on next app boot.
+    // transient failure (no creds, network error, 5xx) the entry remains
+    // in the list and retries on next app boot; on permanent failure
+    // (404 — shot gone from Visualizer) the entry is evicted and the
+    // local row's dead visualizer_id cleared (#1431).
     void processPendingVisualizerRatingSync();
     void dispatchNextPendingVisualizerSync();
 
@@ -291,7 +293,7 @@ private:
     void processVisualizerReconciliation();
     // Tracks the visualizerId of the migration16 PATCH currently in
     // flight. Empty string when no migration16 sync is active. Compared
-    // against the visualizerId argument on updateSuccess / uploadFailed
+    // against the visualizerId argument on updateSuccess / updateFailed
     // so other concurrent PATCHes (e.g., from PostShotReviewPage's
     // metadata save) don't pop migration16 entries off the queue or
     // stall the drain. See PR #1155 review note 2.

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -275,11 +275,13 @@ private:
     // Drain the migration16 pending list, re-PATCHing each affected
     // shot's rating to Visualizer so the cloud copy matches the local
     // corrected value. Serial: pops one entry, dispatches the PATCH,
-    // resumes from the VisualizerUploader::updateSuccess signal. On
-    // transient failure (no creds, network error, 5xx) the entry remains
-    // in the list and retries on next app boot; on permanent failure
-    // (404 — shot gone from Visualizer) the entry is evicted and the
-    // local row's dead visualizer_id cleared (#1431).
+    // resumes from VisualizerUploader::updateSuccess — or from a
+    // permanent updateFailed after evicting the entry. On transient
+    // failure (anything but 404) the entry remains in the list and the
+    // drain pauses until the next app boot; on permanent failure (404 —
+    // shot gone from Visualizer) the entry is evicted, the local row's
+    // dead visualizer_id cleared (guarded on still holding that id), and
+    // draining continues (#1431).
     void processPendingVisualizerRatingSync();
     void dispatchNextPendingVisualizerSync();
 

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1853,6 +1853,48 @@ void ShotHistoryStorage::requestUpdateVisualizerInfo(qint64 shotId, const QStrin
     });
 }
 
+void ShotHistoryStorage::requestClearStaleVisualizerLink(qint64 shotId, const QString& staleVisualizerId)
+{
+    if (!m_ready || shotId <= 0 || staleVisualizerId.isEmpty()) {
+        qWarning() << "ShotHistoryStorage: stale visualizer link NOT cleared for shot" << shotId
+                   << "(not ready or bad args) — dead link may remain on the row";
+        return;
+    }
+
+    const QString dbPath = m_dbPath;
+    runOnDbThread([dbPath, shotId, staleVisualizerId]() {
+        bool success = false;
+        int rowsChanged = 0;
+        bool opened = withTempDb(dbPath, "shs_vizclear", [&](QSqlDatabase& db) {
+            QSqlQuery query(db);
+            // The visualizer_id predicate is the guard: no-op if the row's
+            // link was replaced since the stale id was queued.
+            if (!query.prepare("UPDATE shots SET visualizer_id = '', visualizer_url = '', "
+                               "updated_at = strftime('%s', 'now') "
+                               "WHERE id = :id AND visualizer_id = :stale_id")) {
+                qWarning() << "ShotHistoryStorage: Failed to prepare stale link clear:" << query.lastError().text();
+                return;
+            }
+            query.bindValue(":id", shotId);
+            query.bindValue(":stale_id", staleVisualizerId);
+            success = query.exec();
+            if (success)
+                rowsChanged = query.numRowsAffected();
+            else
+                qWarning() << "ShotHistoryStorage: Failed to clear stale visualizer link:" << query.lastError().text();
+        });
+        if (!opened || !success)
+            qWarning() << "ShotHistoryStorage: stale visualizer link clear FAILED for shot" << shotId
+                       << "— dead link" << staleVisualizerId << "remains on the row";
+        else if (rowsChanged > 0)
+            qDebug() << "ShotHistoryStorage: cleared stale visualizer link" << staleVisualizerId
+                     << "on shot" << shotId;
+        else
+            qDebug() << "ShotHistoryStorage: shot" << shotId << "no longer holds visualizer link"
+                     << staleVisualizerId << "— nothing to clear (replaced meanwhile)";
+    });
+}
+
 bool ShotHistoryStorage::reconcileVisualizerLinksStatic(
     QSqlDatabase& db, const QVariantList& cloudShots, qint64 windowStartEpoch,
     QVariantList& outLinked)

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -56,6 +56,15 @@ public:
                                                   const QString& visualizerId,
                                                   const QString& visualizerUrl);
 
+    // Async: clear visualizer_id/visualizer_url on a shot row, but ONLY if the
+    // row still holds `staleVisualizerId` — a guarded clear so a link that was
+    // replaced meanwhile (e.g. the user re-uploaded the shot and the row now
+    // carries a fresh id) is never wiped. Used by MainController's migration16
+    // drain when a PATCH 404s permanently (#1431). Logs the outcome (cleared /
+    // already replaced / failed); fire-and-forget, no completion signal.
+    void requestClearStaleVisualizerLink(qint64 shotId,
+                                         const QString& staleVisualizerId);
+
     // One-time reconciliation backfill (OpenSpec persist-visualizer-id-in-controller).
     // `cloudShots` is the user's Visualizer shot list (each map:
     // {visualizerId, url, clockEpoch}). On a background thread, links

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -289,6 +289,7 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
 {
     if (visualizerId.isEmpty()) {
         emit uploadFailed("No visualizer ID for update");
+        emit updateFailed(visualizerId, false, "No visualizer ID for update");
         return;
     }
 
@@ -300,6 +301,7 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
         m_lastUploadStatus = "No credentials configured";
         emit lastUploadStatusChanged();
         emit uploadFailed("Visualizer credentials not configured");
+        emit updateFailed(visualizerId, false, "Visualizer credentials not configured");
         return;
     }
 
@@ -442,6 +444,11 @@ void VisualizerUploader::onUpdateFinished(QNetworkReply* reply, const QString& v
         m_lastUploadStatus = "Failed: " + errorMsg;
         emit lastUploadStatusChanged();
         emit uploadFailed(errorMsg);
+        // 404 is the one terminal outcome: the shot is gone from (or was
+        // never on) Visualizer, so no retry can ever succeed. Everything
+        // else — offline, 5xx, 401 (fixable credentials), 422 — is worth
+        // retrying on a later boot.
+        emit updateFailed(visualizerId, statusCode == 404, errorMsg);
         qWarning() << "Visualizer: Update failed -" << errorMsg << "Response:" << response;
     }
 

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -249,6 +249,7 @@ void VisualizerUploader::updateShotOnVisualizerWithOverrides(
     // durationSec=0 / empty curves.
     if (!shot.isValid()) {
         emit uploadFailed("No shot data available");
+        emit updateFailed(visualizerId, false, "No shot data available");
         return;
     }
     auto applyStr    = [&](QString       ShotProjection::*f, const char* k) {
@@ -1222,10 +1223,10 @@ bool VisualizerUploader::validateUpload(const QString& beverageType, double dura
         m_lastUploadStatus = QString("Skipped: %1").arg(reason);
         emit lastUploadStatusChanged();
         // Policy skip, not an error — uploadSkipped lets the page clear its
-        // in-flight flags without surfacing a red error or aborting unrelated
-        // listeners (e.g. MainController's migration-16 drain). The page
-        // wraps the reason with a translated "Upload skipped:" prefix; emit
-        // just the reason payload so the C++ "Skipped:" prefix doesn't double up.
+        // in-flight flags without surfacing a red error to UI listeners that
+        // treat uploadFailed as a real failure. The page wraps the reason
+        // with a translated "Upload skipped:" prefix; emit just the reason
+        // payload so the C++ "Skipped:" prefix doesn't double up.
         emit uploadSkipped(reason);
         qDebug() << "Visualizer: Skipping upload for maintenance profile:" << beverageType;
         return false;

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -160,10 +160,18 @@ signals:
     void uploadSucceededForShot(qint64 dbShotId, const QString& visualizerId, const QString& url);
     void updateSuccess(const QString& visualizerId);
     void uploadFailed(const QString& error);
+    // Correlated failure for the PATCH path (updateShotOnVisualizer):
+    // carries the target visualizerId plus whether the failure is
+    // permanent (HTTP 404 — the shot does not exist on Visualizer and
+    // never will), so queue-drain listeners (MainController's migration16
+    // sync, #1431) can evict poison entries instead of retrying them on
+    // every boot. Emitted alongside uploadFailed, which stays
+    // uncorrelated for the UI status listeners.
+    void updateFailed(const QString& visualizerId, bool permanent, const QString& error);
     // Emitted when an upload attempt is rejected by policy rather than
     // an actual failure (maintenance profile, too-short shot). Listeners that
     // track real failure conditions should NOT react to this — in particular
-    // MainController's uploadFailed-based migration-16 abort logic deliberately
+    // MainController's updateFailed-based migration-16 drain logic deliberately
     // ignores skips so a routine policy rejection cannot kill the drain.
     void uploadSkipped(const QString& reason);
     void connectionTestResult(bool success, const QString& message);

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -160,19 +160,20 @@ signals:
     void uploadSucceededForShot(qint64 dbShotId, const QString& visualizerId, const QString& url);
     void updateSuccess(const QString& visualizerId);
     void uploadFailed(const QString& error);
-    // Correlated failure for the PATCH path (updateShotOnVisualizer):
-    // carries the target visualizerId plus whether the failure is
-    // permanent (HTTP 404 — the shot does not exist on Visualizer and
-    // never will), so queue-drain listeners (MainController's migration16
-    // sync, #1431) can evict poison entries instead of retrying them on
-    // every boot. Emitted alongside uploadFailed, which stays
-    // uncorrelated for the UI status listeners.
+    // Correlated failure for the PATCH path (updateShotOnVisualizer and
+    // its WithOverrides wrapper): carries the target visualizerId (empty
+    // only on the no-id guard path) plus whether the failure is permanent
+    // (HTTP 404 — the shot does not exist on Visualizer and never will),
+    // so queue-drain listeners (MainController's migration16 sync, #1431)
+    // can evict poison entries instead of retrying them on every boot.
+    // Emitted alongside uploadFailed, which remains uncorrelated by
+    // design for the UI status listeners.
     void updateFailed(const QString& visualizerId, bool permanent, const QString& error);
     // Emitted when an upload attempt is rejected by policy rather than
-    // an actual failure (maintenance profile, too-short shot). Listeners that
-    // track real failure conditions should NOT react to this — in particular
-    // MainController's updateFailed-based migration-16 drain logic deliberately
-    // ignores skips so a routine policy rejection cannot kill the drain.
+    // an actual failure (maintenance profile, too-short shot). Listeners
+    // that track real failure conditions should NOT react to this. The
+    // migration-16 drain is safe by construction: it listens only to the
+    // PATCH-correlated updateFailed, which upload-policy skips never emit.
     void uploadSkipped(const QString& reason);
     void connectionTestResult(bool success, const QString& message);
     // Reconciliation list fetch results.


### PR DESCRIPTION
Fixes #1431.

## Problem

The `migration16/pendingVisualizerSync` drain kept every failed entry for the next boot. That's correct for transient failures (offline, 5xx, missing credentials), but a 404 "Shot not found" is permanent — the shot doesn't exist on Visualizer and never will. A bogus `visualizer_id` (the `"V1"` placeholder found in the wild) became a poison queue entry: one wasted PATCH and an error log line on every launch, indefinitely, with the rest of the queue stalled behind it.

## Fix

`VisualizerUploader::uploadFailed` carries no shot-id/status correlation, so the drain could only abort conservatively on *any* failure. This PR:

- Adds a correlated `updateFailed(visualizerId, permanent, error)` signal to the PATCH path (`updateShotOnVisualizer` early returns + `onUpdateFinished`), with `permanent = (HTTP 404)`. The existing uncorrelated `uploadFailed` is unchanged, so QML status listeners are unaffected.
- Switches MainController's migration16 drain from `uploadFailed` to `updateFailed`:
  - **Transient** failure: keep the entry, abort the drain (same as before — but now correctly filtered on the in-flight `visualizerId` instead of assuming any failure in the app was ours).
  - **Permanent** (404): pop the entry from the queue, clear the dead `visualizer_id`/`visualizer_url` on the local shot row via `requestUpdateVisualizerInfo(shotId, "", "")` so nothing else trusts it, and continue draining the rest of the queue.

## Notes

- The reconciliation backfill (`processVisualizerReconciliation`) pushes into the same drain queue, so it inherits the fix; its own list-fetch failure path already retries safely without setting the run-once flag.
- The issue's optional suggestion to validate `visualizer_id` format at migration-16 enqueue time was skipped: the migration has already run for existing users, and the 404 eviction covers bogus IDs *and* legitimately-deleted shots generically.
- 401 (fixable credentials) and 422 are deliberately kept transient; only 404 is terminal.

Built successfully (macOS desktop, Qt Creator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)