### PR TITLE
CI: standalone cache pruning + Android gradle/ccache speedups

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -102,7 +102,25 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: android-arm64
-          max-size: 500M
+          # At 500M the cache sat at 99.8% full and evicted at save time
+          # (a full build is ~600 objects ≈ one cache-full). 1G fits in the
+          # repo cache budget now that prune-caches.yml keeps 1 copy/group.
+          max-size: 1G
+
+      # androiddeployqt's "Creating APK" step otherwise downloads the full
+      # gradle distribution and re-resolves every dependency on each run
+      # (~1m14s of the job). Stable key: an exact hit skips re-saving, so
+      # this entry never accumulates timestamped copies. The Qt version
+      # pins the gradle/AGP generation — bump the key with Qt upgrades.
+      - name: Cache Gradle (androiddeployqt)
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-android-qt6.11.1-${{ hashFiles('android/build.gradle') }}
+          restore-keys: |
+            gradle-android-qt6.11.1-
 
       - name: Configure ccache for CI
         run: ccache --set-config=compiler_check=content

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -78,7 +78,7 @@ jobs:
           modules: 'qtquick3d qtshadertools qtgraphs qtconnectivity qtmultimedia qtpositioning qtspeech qtwebsockets qtimageformats qtcanvaspainter'
           # Qt-for-iOS caching is intentionally disabled. The iOS Qt cache is too
           # large to coexist with the other platforms under GitHub's 10 GB per-repo
-          # cache cap: even after the "Prune stale ccache caches" step (macos-release.yml)
+          # cache cap: even after stale-ccache pruning (now prune-caches.yml)
           # trimmed the duplicate ccache piles to ~7.3 GB, re-enabling iOS Qt caching
           # was MEASURED at 3.96 GB for the single qt-ios cache entry (it barely
           # compresses), pushing the store to 10.53 GB — over the cap and back into

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -326,51 +326,7 @@ jobs:
         run: |
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
 
-      - name: Prune stale ccache caches
-        if: always()
-        continue-on-error: true  # never fail a release over cache housekeeping
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -uo pipefail
-          # ccache-action / sccache write a NEW timestamp-suffixed cache entry every
-          # build (GH caches are immutable, so the action can't update in place — it
-          # finds the latest via prefix restore-keys). Old copies are never cleaned,
-          # so 5-6 stale copies of each platform's ccache pile up (~9 GB) and push the
-          # repo past GitHub's 10 GB cap, triggering LRU eviction of still-useful
-          # Qt/ccache entries and causing cold builds. macOS is the slowest build, so
-          # by the time this final step runs the faster *other* platforms have already
-          # saved their fresh caches and we can prune their old copies in one pass.
-          # macOS's OWN cache is saved by ccache-action's post-job step, which runs
-          # AFTER all main steps — so it does not exist yet at prune time and is never
-          # at risk of deletion here; the current macOS entry lands afterward. (This
-          # is why KEEP must stay >= 2: the live build's macOS copy is not yet counted,
-          # so KEEP=1 would over-prune the macOS group.)
-          #
-          # Keep the newest 2 copies of each ccache/sccache prefix (grouped per ref so
-          # a main-scoped entry survives a newer tag-push build), delete the rest.
-          # qt-*/openssl-* use stable keys (no timestamp suffix) and are excluded by
-          # the regex filter — they are exactly the caches we want to keep restorable.
-          # gh's built-in --jq does not accept --arg/--argjson, so pipe to real jq.
-          KEEP=2
-          TS='-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$'
-          gh cache list --repo "$GITHUB_REPOSITORY" --limit 500 \
-            --json id,key,createdAt,ref \
-            | jq -r --argjson keep "$KEEP" --arg ts "$TS" '
-                map(select(.key | test($ts)))
-                | group_by((.key | sub($ts; "")) + "@@" + .ref)
-                | map(sort_by(.createdAt) | reverse | .[$keep:])
-                | flatten
-                | .[] | "\(.id)\t\(.key)"
-              ' \
-            | while IFS=$'\t' read -r id key; do
-                [ -n "$id" ] || continue
-                if gh cache delete "$id" --repo "$GITHUB_REPOSITORY"; then
-                  echo "- deleted \`$key\` (id $id)" >> "$GITHUB_STEP_SUMMARY"
-                else
-                  echo "::warning::Failed to delete cache $key (id $id)"
-                fi
-              done
-          gh api "repos/$GITHUB_REPOSITORY/actions/cache/usage" --jq \
-            '"Remaining: \(.active_caches_count) caches, \((.active_caches_size_in_bytes/1073741824)*100|round/100) GB / 10 GB cap"' \
-            >> "$GITHUB_STEP_SUMMARY" || true
+      # Stale-ccache pruning moved to its own workflow (prune-caches.yml): as a
+      # final step here it ran before this build's own post-job ccache save and
+      # relied on macOS being the slowest build — no longer true (Linux x64
+      # outlasts it), which left 3 stale copies for late-finishing platforms.

--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -1,0 +1,103 @@
+name: Prune stale compiler caches
+
+# ccache-action / sccache write a NEW timestamp-suffixed cache entry every
+# build (GH caches are immutable, so the action can't update in place — it
+# finds the latest via prefix restore-keys). Old copies are never cleaned up,
+# so stale copies of each platform's compiler cache pile up and push the repo
+# toward GitHub's 10 GB cap, triggering LRU eviction of still-useful Qt/ccache
+# entries and causing cold builds.
+#
+# This used to be a final step inside macos-release.yml, on the assumption that
+# macOS was the slowest build so every other platform had already saved its
+# fresh cache by prune time. That stopped holding (Linux x64 now outlasts
+# macOS), and the in-build prune could never see the running build's own cache
+# (ccache-action saves in a post-job step), so it had to keep 2 copies per
+# group and still left 3 copies for any platform finishing after macOS.
+#
+# As a standalone workflow triggered when a build workflow completes — and
+# skipping while any build is still in progress or queued — every fresh cache
+# is already saved when we prune, so keeping exactly 1 copy per (prefix, ref)
+# group is safe. The last build to finish re-triggers us, so the skip never
+# strands stale entries.
+
+on:
+  workflow_run:
+    workflows:
+      - 'Android APK Build'
+      - 'iOS App Store Build'
+      - 'macOS Build'
+      - 'Windows Build'
+      - 'Linux AppImage Build'
+      - 'Linux ARM64 AppImage Build'
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  actions: write  # gh cache delete / gh run list
+
+concurrency:
+  group: prune-caches
+  cancel-in-progress: true
+
+jobs:
+  prune:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Skip while builds are running
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          # If any build workflow is still queued or running, its compiler
+          # cache hasn't been saved yet — pruning now would repeat the old
+          # in-build prune's blind spot. Skip; the completion of that run
+          # fires this workflow again.
+          BUILD_WORKFLOWS='Android APK Build|iOS App Store Build|macOS Build|Windows Build|Linux AppImage Build|Linux ARM64 AppImage Build'
+          ACTIVE=$(gh run list --repo "$GITHUB_REPOSITORY" --limit 100 \
+            --json workflowName,status \
+            --jq '[.[] | select((.status == "in_progress" or .status == "queued"))
+                        | .workflowName] | unique | .[]' \
+            | grep -cE "^($BUILD_WORKFLOWS)$" || true)
+          if [ "${ACTIVE:-0}" -gt 0 ]; then
+            echo "$ACTIVE build workflow(s) still active — skipping prune."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No build workflows active — pruning."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prune stale ccache/sccache entries
+        if: ${{ steps.gate.outputs.skip == 'false' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          # Keep the newest copy of each timestamped ccache/sccache prefix,
+          # grouped per ref so a main-scoped entry survives a newer tag-push
+          # build. qt-*/openssl-* use stable keys (no timestamp suffix) and are
+          # excluded by the regex filter — they are exactly the caches we want
+          # to keep restorable. gh's built-in --jq does not accept --arg /
+          # --argjson, so pipe to real jq.
+          KEEP=1
+          TS='-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z$'
+          gh cache list --repo "$GITHUB_REPOSITORY" --limit 500 \
+            --json id,key,createdAt,ref \
+            | jq -r --argjson keep "$KEEP" --arg ts "$TS" '
+                map(select(.key | test($ts)))
+                | group_by((.key | sub($ts; "")) + "@@" + .ref)
+                | map(sort_by(.createdAt) | reverse | .[$keep:])
+                | flatten
+                | .[] | "\(.id)\t\(.key)"
+              ' \
+            | while IFS=$'\t' read -r id key; do
+                [ -n "$id" ] || continue
+                if gh cache delete "$id" --repo "$GITHUB_REPOSITORY"; then
+                  echo "- deleted \`$key\` (id $id)" >> "$GITHUB_STEP_SUMMARY"
+                else
+                  echo "::warning::Failed to delete cache $key (id $id)"
+                fi
+              done
+          gh api "repos/$GITHUB_REPOSITORY/actions/cache/usage" --jq \
+            '"Remaining: \(.active_caches_count) caches, \((.active_caches_size_in_bytes/1073741824)*100|round/100) GB / 10 GB cap"' \
+            >> "$GITHUB_STEP_SUMMARY" || true

--- a/.github/workflows/prune-caches.yml
+++ b/.github/workflows/prune-caches.yml
@@ -30,6 +30,13 @@ on:
       - 'Linux AppImage Build'
       - 'Linux ARM64 AppImage Build'
     types: [completed]
+  # Nearly all builds run on TAG pushes, and GitHub's docs don't clearly
+  # guarantee workflow_run fires for tag-triggered runs (no `branches:`
+  # filter here, so it should — but field reports show this edge being
+  # flaky). The daily cron is the guaranteed fallback: pruning is
+  # idempotent and takes seconds, so a redundant pass is free.
+  schedule:
+    - cron: '17 3 * * *'
   workflow_dispatch:
 
 permissions:

--- a/docs/CLAUDE_MD/CI_CD.md
+++ b/docs/CLAUDE_MD/CI_CD.md
@@ -17,7 +17,7 @@ All workflows have concurrency controls — if the same workflow triggers twice 
 
 On tag push: all workflows bump version code and build. All except iOS upload to GitHub Release; iOS uploads to App Store Connect instead. On `workflow_dispatch`: build only, no version bump, no upload (unless explicitly opted in).
 
-**Cache pruning:** `prune-caches.yml` fires whenever a build workflow completes; it skips while any build is still queued/running (the last one to finish re-triggers it), then deletes all but the newest copy of each timestamped ccache/sccache entry per (prefix, ref). Stable-keyed `qt-*`/`openssl-*` caches are never touched. This keeps the repo's cache store (10 GB GitHub cap) from filling with stale compiler-cache generations; it replaced the old KEEP=2 prune step inside `macos-release.yml`, which ran before late-finishing builds (and macOS itself) had saved their fresh caches.
+**Cache pruning:** `prune-caches.yml` fires whenever a build workflow completes (plus a daily cron fallback, since `workflow_run` for tag-triggered runs is an under-documented edge); it skips while any build is still queued/running (the last one to finish re-triggers it), then deletes all but the newest copy of each timestamped ccache/sccache entry per (prefix, ref). Stable-keyed `qt-*`/`openssl-*` caches are never touched. This keeps the repo's cache store (10 GB GitHub cap) from filling with stale compiler-cache generations; it replaced the old KEEP=2 prune step inside `macos-release.yml`, which ran before late-finishing builds (and macOS itself) had saved their fresh caches.
 
 ### Quick commands
 ```bash

--- a/docs/CLAUDE_MD/CI_CD.md
+++ b/docs/CLAUDE_MD/CI_CD.md
@@ -17,6 +17,8 @@ All workflows have concurrency controls — if the same workflow triggers twice 
 
 On tag push: all workflows bump version code and build. All except iOS upload to GitHub Release; iOS uploads to App Store Connect instead. On `workflow_dispatch`: build only, no version bump, no upload (unless explicitly opted in).
 
+**Cache pruning:** `prune-caches.yml` fires whenever a build workflow completes; it skips while any build is still queued/running (the last one to finish re-triggers it), then deletes all but the newest copy of each timestamped ccache/sccache entry per (prefix, ref). Stable-keyed `qt-*`/`openssl-*` caches are never touched. This keeps the repo's cache store (10 GB GitHub cap) from filling with stale compiler-cache generations; it replaced the old KEEP=2 prune step inside `macos-release.yml`, which ran before late-finishing builds (and macOS itself) had saved their fresh caches.
+
 ### Quick commands
 ```bash
 # Trigger individual TEST builds (no upload, no version bump)


### PR DESCRIPTION
## Problem

**Pruning:** The "Prune stale ccache caches" step lived at the end of `macos-release.yml` with `KEEP=2`, built on two assumptions that no longer hold:

1. **It runs before the macOS build's own cache is saved** (ccache-action saves in a post-job step), which is why it had to keep 2 copies — leaving macOS itself at a steady state of **3 copies** (currently 1291 + 1180 + 1052 MB = 3.5 GB for that one group).
2. **"macOS is the slowest build."** Linux x64 (11.4 min) now finishes after macOS (10 min), so its fresh cache also lands after the prune — Linux steady-states at 3 copies too.

Result: the repo cache sits at **9.24 GB of the 10 GB cap**, with ~4.3 GB of it stale duplicates, risking LRU eviction of the main-scoped Qt caches (the ones `warm-main-cache.yml` exists to protect).

**Android build:** the "Creating APK" step downloads the full gradle distribution and re-resolves all dependencies on every run (~1m14s), and the Android ccache is at 99.8% of its 500M limit, evicting at save time.

## Fix

New `prune-caches.yml`:
- Triggers on `workflow_run: completed` for each of the 6 build workflows, plus a **daily cron fallback** (nearly all builds run on tag pushes, and `workflow_run` firing for tag-triggered runs is an under-documented edge), plus manual dispatch.
- Skips while any build workflow is still queued/in progress — the last one to finish re-triggers it, so nothing is stranded.
- Keeps exactly **1 copy** per (timestamped-prefix, ref) group; by prune time every fresh cache is already saved. Stable-keyed `qt-*`/`openssl-*` entries are untouched, same as before.
- Reports deletions + remaining usage in the step summary.

The old step in `macos-release.yml` is removed (breadcrumb comment left), the iOS comment reference updated, and `docs/CLAUDE_MD/CI_CD.md` documents the new workflow.

Android (`android-release.yml`):
- **Gradle cache** (`~/.gradle/{caches,wrapper}`) under a stable Qt-versioned key — an exact hit skips re-saving, so it never accumulates copies. Saves ~1 min/run.
- **ccache `max-size: 1G`** — removes save-time eviction (one full build ≈ one 500M cache-full).

Expected steady state: ~**5.5 GB** of the 10 GB cap; Android job from ~6.2 min toward ~4.5–5 min.

Note: `workflow_run`/cron triggers only take effect once this file is on `main`; the prune can be run immediately after merge via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)