### PR TITLE
Show a detail line on Bean Base search results to tell duplicates apart

### DIFF
--- a/docs/CLAUDE_MD/BEAN_BASE.md
+++ b/docs/CLAUDE_MD/BEAN_BASE.md
@@ -46,8 +46,8 @@ Entries are QVariantMaps (QML lingua franca; deliberately not a C++ value type).
 | `visualizerCanonicalId` | = id | — | — |
 | `source` | "visualizer" | "beanbase" | — |
 | `roasterName`, `roastName` | ✓ | ✓ | — |
-| `degree, origin, region, producer, variety, process, harvest, tastingNotes` | — | ✓ | ✓ (remapped from Visualizer columns) |
-| `elevation` (display string) | — | — | ✓ |
+| `degree, origin, region, producer, variety, process, harvest, tastingNotes` | ✓ (remapped from Visualizer columns via `kAttrMap`) | ✓ | ✓ (same values; `canonicalDetails` is a local re-emit) |
+| `elevation` (display string) | ✓ | — | ✓ |
 | `link` (roaster product page) | ✓ (from `url`) | ✓ | — |
 | `minElevationM/maxElevationM` (int), `image, beanType, description, tastingTags, generalTags, soldout, available, roasterRegion, roasterCountry` | — | ✓ | — |
 

--- a/qml/components/ChangeBeansDialog.qml
+++ b/qml/components/ChangeBeansDialog.qml
@@ -634,7 +634,10 @@ Dialog {
                                 Text {
                                     Layout.fillWidth: true
                                     visible: text.length > 0
-                                    text: model.roastDate || ""
+                                    // Bean Base rows have no roast date; their detail line
+                                    // (roast level · origin · notes) is what tells the
+                                    // canonical DB's same-name near-duplicates apart.
+                                    text: model.roastDate || model.detail || ""
                                     font: Theme.captionFont
                                     color: Theme.textSecondaryColor
                                     elide: Text.ElideRight
@@ -665,7 +668,9 @@ Dialog {
 
                         AccessibleMouseArea {
                             anchors.fill: parent
-                            accessibleName: resultRow.primaryText + ", " + root.sourceLabel(model.sources, model.tier)
+                            accessibleName: resultRow.primaryText
+                                + (model.detail ? ", " + model.detail : "")
+                                + ", " + root.sourceLabel(model.sources, model.tier)
                                 + (resultRow.isActiveBag
                                     ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                             accessibleItem: resultRow

--- a/qml/components/ChangeBeansDialog.qml
+++ b/qml/components/ChangeBeansDialog.qml
@@ -623,6 +623,8 @@ Dialog {
                                 Text {
                                     Layout.fillWidth: true
                                     text: resultRow.primaryText
+                                    // Bean Base free text — never let AutoText parse it as markup
+                                    textFormat: Text.PlainText
                                     font.family: Theme.bodyFont.family
                                     font.pixelSize: Theme.bodyFont.pixelSize
                                     font.bold: true
@@ -638,6 +640,8 @@ Dialog {
                                     // (roast level · origin · notes) is what tells the
                                     // canonical DB's same-name near-duplicates apart.
                                     text: model.roastDate || model.detail || ""
+                                    // Bean Base free text — never let AutoText parse it as markup
+                                    textFormat: Text.PlainText
                                     font: Theme.captionFont
                                     color: Theme.textSecondaryColor
                                     elide: Text.ElideRight

--- a/src/history/unifiedbeansearchmodel.cpp
+++ b/src/history/unifiedbeansearchmodel.cpp
@@ -3,6 +3,8 @@
 #include "network/beanbaseclient.h"
 #include "core/dbutils.h"
 
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QSqlQuery>
 #include <QSqlError>
 #include <QSqlDatabase>
@@ -285,6 +287,13 @@ QVariantList UnifiedBeanSearchModel::mergeLanes(const QVariantList& inventoryBag
         row["beanBaseId"] = canonicalId;
         row["bagId"] = -1;
         row["detail"] = canonicalDetail(entry);
+        // The full entry, serialized the same way a BeanBaseSearchBar pick
+        // stores it (JSON.stringify(entry)): a bag created from this row must
+        // carry the descriptive blob, not just the canonical id — an id with
+        // an empty blob renders an empty details popup (BagCard's link
+        // backfill then persists `{"link":…}` as the whole blob).
+        const QString entryJson = QString::fromUtf8(
+            QJsonDocument(QJsonObject::fromVariantMap(entry)).toJson(QJsonDocument::Compact));
 
         // Same coffee in history -> single Tier 1 entry, both source labels:
         // grinder/dose from history, canonical identity from Bean Base.
@@ -301,12 +310,17 @@ QVariantList UnifiedBeanSearchModel::mergeLanes(const QVariantList& inventoryBag
             row["doseWeightG"] = h.value("doseWeightG");
             row["yieldOverrideG"] = h.value("yieldOverrideG");
             row["roastLevel"] = h.value("roastLevel");
-            row["beanBaseData"] = h.value("beanBaseData");
+            // History's blob may carry legacy-only fields (CDN image URL,
+            // tasting tags), so keep it when present; the fresh entry covers
+            // shots linked by name whose snapshots predate the blob.
+            const QString histBlob = h.value("beanBaseData").toString();
+            row["beanBaseData"] = histBlob.isEmpty() ? entryJson : histBlob;
             row["lastUsedEpoch"] = h.value("lastUsedEpoch");
             row["tier"] = static_cast<int>(Tier::HistoryCanonical);
             row["sources"] = QStringLiteral("beanbase+history");
             tier1.append(row);
         } else {
+            row["beanBaseData"] = entryJson;
             row["tier"] = static_cast<int>(Tier::CanonicalOnly);
             row["sources"] = QStringLiteral("beanbase");
             tier2.append(row);

--- a/src/history/unifiedbeansearchmodel.cpp
+++ b/src/history/unifiedbeansearchmodel.cpp
@@ -24,6 +24,21 @@ bool matchesQuery(const QVariantMap& row, const QString& query)
         || row.value("coffeeName").toString().contains(query, Qt::CaseInsensitive);
 }
 
+// One-line differentiator for canonical rows. Bean Base holds near-duplicate
+// submissions of the same roaster+name under distinct canonical ids, so
+// roaster+name alone renders identical rows; roast level, origin and tasting
+// notes are the fields that actually vary between them.
+QString canonicalDetail(const QVariantMap& entry)
+{
+    QStringList parts;
+    for (const char* key : {"degree", "origin", "tastingNotes"}) {
+        const QString v = entry.value(QLatin1String(key)).toString().trimmed();
+        if (!v.isEmpty())
+            parts << v;
+    }
+    return parts.join(QStringLiteral(" · "));
+}
+
 } // namespace
 
 UnifiedBeanSearchModel::UnifiedBeanSearchModel(QObject* parent)
@@ -269,6 +284,7 @@ QVariantList UnifiedBeanSearchModel::mergeLanes(const QVariantList& inventoryBag
         row["coffeeName"] = coffee;
         row["beanBaseId"] = canonicalId;
         row["bagId"] = -1;
+        row["detail"] = canonicalDetail(entry);
 
         // Same coffee in history -> single Tier 1 entry, both source labels:
         // grinder/dose from history, canonical identity from Bean Base.
@@ -393,6 +409,7 @@ QVariant UnifiedBeanSearchModel::data(const QModelIndex& index, int role) const
     case FrozenDateRole: return row.value("frozenDate");
     case DefrostDateRole: return row.value("defrostDate");
     case LastUsedEpochRole: return row.value("lastUsedEpoch");
+    case DetailRole: return row.value("detail");
     }
     return QVariant();
 }
@@ -410,5 +427,6 @@ QHash<int, QByteArray> UnifiedBeanSearchModel::roleNames() const
         {FrozenDateRole, "frozenDate"},
         {DefrostDateRole, "defrostDate"},
         {LastUsedEpochRole, "lastUsedEpoch"},
+        {DetailRole, "detail"},
     };
 }

--- a/src/history/unifiedbeansearchmodel.cpp
+++ b/src/history/unifiedbeansearchmodel.cpp
@@ -26,6 +26,22 @@ bool matchesQuery(const QVariantMap& row, const QString& query)
         || row.value("coffeeName").toString().contains(query, Qt::CaseInsensitive);
 }
 
+// A blob whose only key is "link" is BagCard's backfill artifact for a bag
+// that was created without descriptive data (see the entryJson comment in
+// mergeLanes) — it carries nothing the fresh canonical entry doesn't (entries
+// include "link"), so it must not shadow the entry the way a real legacy blob
+// (CDN image URL, tasting tags) legitimately does.
+bool blobIsEffectivelyEmpty(const QString& blob)
+{
+    if (blob.trimmed().isEmpty())
+        return true;
+    const QJsonObject obj = QJsonDocument::fromJson(blob.toUtf8()).object();
+    if (obj.isEmpty())
+        return true;  // unparseable or {}
+    const QStringList keys = obj.keys();
+    return keys.size() == 1 && keys.first() == QLatin1String("link");
+}
+
 // One-line differentiator for canonical rows. Bean Base holds near-duplicate
 // submissions of the same roaster+name under distinct canonical ids, so
 // roaster+name alone renders identical rows; roast level, origin and tasting
@@ -311,10 +327,11 @@ QVariantList UnifiedBeanSearchModel::mergeLanes(const QVariantList& inventoryBag
             row["yieldOverrideG"] = h.value("yieldOverrideG");
             row["roastLevel"] = h.value("roastLevel");
             // History's blob may carry legacy-only fields (CDN image URL,
-            // tasting tags), so keep it when present; the fresh entry covers
-            // shots linked by name whose snapshots predate the blob.
+            // tasting tags), so keep it when it has real content; the fresh
+            // entry covers snapshots that predate the blob AND snapshots
+            // holding only BagCard's `{"link":…}` backfill artifact.
             const QString histBlob = h.value("beanBaseData").toString();
-            row["beanBaseData"] = histBlob.isEmpty() ? entryJson : histBlob;
+            row["beanBaseData"] = blobIsEffectivelyEmpty(histBlob) ? entryJson : histBlob;
             row["lastUsedEpoch"] = h.value("lastUsedEpoch");
             row["tier"] = static_cast<int>(Tier::HistoryCanonical);
             row["sources"] = QStringLiteral("beanbase+history");

--- a/src/history/unifiedbeansearchmodel.h
+++ b/src/history/unifiedbeansearchmodel.h
@@ -76,6 +76,9 @@ public:
         FrozenDateRole,
         DefrostDateRole,
         LastUsedEpochRole,
+        DetailRole,        // Canonical rows only: "roast level · origin · tasting notes",
+                           // the fields that differ between Bean Base's near-duplicate
+                           // submissions of the same roaster+name
     };
     Q_ENUM(Roles)
 

--- a/src/history/unifiedbeansearchmodel.h
+++ b/src/history/unifiedbeansearchmodel.h
@@ -76,9 +76,11 @@ public:
         FrozenDateRole,
         DefrostDateRole,
         LastUsedEpochRole,
-        DetailRole,        // Canonical rows only: "roast level · origin · tasting notes",
+        DetailRole,        // "roast level · origin · tasting notes" — set on rows sourced
+                           // from a Bean Base canonical entry (Tier::HistoryCanonical and
+                           // Tier::CanonicalOnly); empty for every other tier. These are
                            // the fields that differ between Bean Base's near-duplicate
-                           // submissions of the same roaster+name
+                           // submissions of the same roaster+name.
     };
     Q_ENUM(Roles)
 

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -805,7 +805,7 @@ private slots:
     // name under distinct canonical ids, differing only in descriptive attrs.
     // Each must stay its own row (distinct id = distinct pick target) and carry
     // a "detail" line (degree · origin · tastingNotes) so the UI can tell them
-    // apart — the exact bug of identical-looking "Hometown Blend" rows.
+    // apart — the exact bug of identical-looking same-name rows.
     void mergeLanesCanonicalDuplicatesCarryDetail() {
         QVariantList canonical;
         canonical.append(QVariantMap{
@@ -854,11 +854,12 @@ private slots:
         QCOMPARE(merged.size(), 2);
 
         // Tier 1 (canon-Y merged with history): empty history blob falls back
-        // to the serialized entry.
+        // to the serialized entry. The detail line rides on tier 1 rows too.
         QCOMPARE(tierOf(merged[0]), Tier::HistoryCanonical);
         const QVariantMap tier1Blob = QJsonDocument::fromJson(
             merged[0].toMap().value("beanBaseData").toString().toUtf8()).object().toVariantMap();
         QCOMPARE(tier1Blob.value("degree").toString(), QString("Dark"));
+        QCOMPARE(merged[0].toMap().value("detail").toString(), QString("Dark"));
 
         // Tier 2 (canon-X): blob is the entry itself — id, identity, attrs, link.
         QCOMPARE(tierOf(merged[1]), Tier::CanonicalOnly);
@@ -871,6 +872,30 @@ private slots:
         QCOMPARE(tier2Blob.value("origin").toString(), QString("Colombia"));
         QCOMPARE(tier2Blob.value("link").toString(),
                  QString("https://sweetbloomcoffee.com/product/hometown/"));
+    }
+
+    // A history snapshot holding only BagCard's `{"link":…}` backfill artifact
+    // (a bag created while canonical rows carried no blob) must NOT shadow the
+    // fresh entry — otherwise the pre-fix corruption re-persists into every
+    // new bag created from that Tier 1 row.
+    void mergeLanesTier1ReplacesLinkOnlyBlob() {
+        QVariantList canonical;
+        canonical.append(QVariantMap{
+            {"id", "canon-W"}, {"roasterName", "R"}, {"roastName", "W"},
+            {"degree", "Light"}, {"link", "https://roaster.example/w"}});
+        QVariantList history;
+        history.append(QVariantMap{
+            {"roasterName", "R"}, {"coffeeName", "W"}, {"beanBaseId", "canon-W"},
+            {"beanBaseData", "{\"link\":\"https://roaster.example/w\"}"},
+            {"lastUsedEpoch", 100}});
+
+        const QVariantList merged = UnifiedBeanSearchModel::mergeLanes({}, canonical, history, QString());
+        QCOMPARE(merged.size(), 1);
+        QCOMPARE(tierOf(merged[0]), Tier::HistoryCanonical);
+        const QVariantMap blob = QJsonDocument::fromJson(
+            merged[0].toMap().value("beanBaseData").toString().toUtf8()).object().toVariantMap();
+        QCOMPARE(blob.value("degree").toString(), QString("Light"));  // fresh entry won
+        QCOMPARE(blob.value("link").toString(), QString("https://roaster.example/w"));
     }
 
     // Tier 1 keeps a non-empty history blob (it may carry legacy-only fields

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -801,6 +801,36 @@ private slots:
         QCOMPARE(merged[2].toMap().value("coffeeName").toString(), QString("Z"));
     }
 
+    // Bean Base's canonical DB holds near-duplicate submissions: same roaster+
+    // name under distinct canonical ids, differing only in descriptive attrs.
+    // Each must stay its own row (distinct id = distinct pick target) and carry
+    // a "detail" line (degree · origin · tastingNotes) so the UI can tell them
+    // apart — the exact bug of identical-looking "Hometown Blend" rows.
+    void mergeLanesCanonicalDuplicatesCarryDetail() {
+        QVariantList canonical;
+        canonical.append(QVariantMap{
+            {"id", "canon-1"}, {"roasterName", "Sweet Bloom"}, {"roastName", "Hometown"},
+            {"degree", "Medium-light"}, {"origin", "Colombia, Ethiopia"},
+            {"tastingNotes", "Blackberries, Praline"}});
+        canonical.append(QVariantMap{
+            {"id", "canon-2"}, {"roasterName", "Sweet Bloom"}, {"roastName", "Hometown"},
+            {"degree", "Light To Medium"}, {"origin", "Colombia, Ethiopia"},
+            {"tastingNotes", "Blackberries, Cocoa"}});
+        canonical.append(QVariantMap{  // no descriptive attrs at all
+            {"id", "canon-3"}, {"roasterName", "Sweet Bloom"}, {"roastName", "Hometown"}});
+
+        const QVariantList merged = UnifiedBeanSearchModel::mergeLanes({}, canonical, {}, "hometown");
+        QCOMPARE(merged.size(), 3);
+
+        QCOMPARE(merged[0].toMap().value("detail").toString(),
+                 QString("Medium-light · Colombia, Ethiopia · Blackberries, Praline"));
+        QCOMPARE(merged[1].toMap().value("detail").toString(),
+                 QString("Light To Medium · Colombia, Ethiopia · Blackberries, Cocoa"));
+        QCOMPARE(merged[2].toMap().value("detail").toString(), QString());
+        for (const QVariant& v : merged)
+            QCOMPARE(tierOf(v), Tier::CanonicalOnly);
+    }
+
     // Within-tier MRU ordering: two inventory bags out of epoch order must come
     // back most-recently-used first (guards the stable_sort comparator).
     void mergeLanesOrdersByMruWithinTier() {

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -831,6 +831,67 @@ private slots:
             QCOMPARE(tierOf(v), Tier::CanonicalOnly);
     }
 
+    // A bag created from a canonical row must carry the full descriptive blob,
+    // not just the canonical id: with an empty blob the bag renders an empty
+    // details popup, and BagCard's link backfill then persists `{"link":…}` as
+    // the whole blob (the "broken details after adding Hometown" bug).
+    void mergeLanesCanonicalRowsCarryBlob() {
+        QVariantList canonical;
+        canonical.append(QVariantMap{
+            {"id", "canon-X"}, {"roasterName", "Sweet Bloom"}, {"roastName", "Hometown"},
+            {"degree", "Light"}, {"origin", "Colombia"},
+            {"link", "https://sweetbloomcoffee.com/product/hometown/"}});
+        canonical.append(QVariantMap{
+            {"id", "canon-Y"}, {"roasterName", "Sweet Bloom"}, {"roastName", "Other"},
+            {"degree", "Dark"}});
+
+        QVariantList history;  // canon-Y also in history, with an empty blob
+        history.append(QVariantMap{
+            {"roasterName", "Sweet Bloom"}, {"coffeeName", "Other"}, {"beanBaseId", "canon-Y"},
+            {"beanBaseData", ""}, {"lastUsedEpoch", 100}});
+
+        const QVariantList merged = UnifiedBeanSearchModel::mergeLanes({}, canonical, history, QString());
+        QCOMPARE(merged.size(), 2);
+
+        // Tier 1 (canon-Y merged with history): empty history blob falls back
+        // to the serialized entry.
+        QCOMPARE(tierOf(merged[0]), Tier::HistoryCanonical);
+        const QVariantMap tier1Blob = QJsonDocument::fromJson(
+            merged[0].toMap().value("beanBaseData").toString().toUtf8()).object().toVariantMap();
+        QCOMPARE(tier1Blob.value("degree").toString(), QString("Dark"));
+
+        // Tier 2 (canon-X): blob is the entry itself — id, identity, attrs, link.
+        QCOMPARE(tierOf(merged[1]), Tier::CanonicalOnly);
+        const QVariantMap tier2Blob = QJsonDocument::fromJson(
+            merged[1].toMap().value("beanBaseData").toString().toUtf8()).object().toVariantMap();
+        QCOMPARE(tier2Blob.value("id").toString(), QString("canon-X"));
+        QCOMPARE(tier2Blob.value("roastName").toString(), QString("Hometown"));
+        QCOMPARE(tier2Blob.value("roasterName").toString(), QString("Sweet Bloom"));
+        QCOMPARE(tier2Blob.value("degree").toString(), QString("Light"));
+        QCOMPARE(tier2Blob.value("origin").toString(), QString("Colombia"));
+        QCOMPARE(tier2Blob.value("link").toString(),
+                 QString("https://sweetbloomcoffee.com/product/hometown/"));
+    }
+
+    // Tier 1 keeps a non-empty history blob (it may carry legacy-only fields
+    // like a CDN image URL) instead of replacing it with the fresh entry.
+    void mergeLanesTier1PrefersHistoryBlob() {
+        QVariantList canonical;
+        canonical.append(QVariantMap{
+            {"id", "canon-Z"}, {"roasterName", "R"}, {"roastName", "Z"}, {"degree", "Light"}});
+        QVariantList history;
+        history.append(QVariantMap{
+            {"roasterName", "R"}, {"coffeeName", "Z"}, {"beanBaseId", "canon-Z"},
+            {"beanBaseData", "{\"degree\":\"Light\",\"image\":\"https://cdn/legacy.jpg\"}"},
+            {"lastUsedEpoch", 100}});
+
+        const QVariantList merged = UnifiedBeanSearchModel::mergeLanes({}, canonical, history, QString());
+        QCOMPARE(merged.size(), 1);
+        QCOMPARE(tierOf(merged[0]), Tier::HistoryCanonical);
+        QCOMPARE(merged[0].toMap().value("beanBaseData").toString(),
+                 QString("{\"degree\":\"Light\",\"image\":\"https://cdn/legacy.jpg\"}"));
+    }
+
     // Within-tier MRU ordering: two inventory bags out of epoch order must come
     // back most-recently-used first (guards the stable_sort comparator).
     void mergeLanesOrdersByMruWithinTier() {


### PR DESCRIPTION
## Problem

Searching for a bag in the Add Bag dialog can show the same coffee several times with nothing to differentiate the rows. Visualizer's canonical DB genuinely holds near-duplicate submissions — e.g. `?q=hometown` returns three "Sweet Bloom Coffee · Hometown Blend" entries with distinct canonical UUIDs, differing only in roast level, elevation, and tasting notes (one comes from a `hometown-blend-copy` product URL). The dialog row only showed roaster + name, so they rendered identically.

## Fix

- `UnifiedBeanSearchModel::mergeLanes()` now composes a `detail` string on canonical rows (tiers 1–2) from the entry's descriptive blob: **roast level · origin · tasting notes** — the fields that actually vary between duplicates. Exposed as a new `DetailRole`.
- `ChangeBeansDialog.qml` shows it in the existing subtitle slot (where inventory rows show their roast date), and appends it to the row's accessible name so TalkBack/VoiceOver users can tell the rows apart too.

Each duplicate stays its own row on purpose: distinct canonical ids are distinct pick targets, and the detail line is what lets the user choose the right one.

## Testing

- New unit test `mergeLanesCanonicalDuplicatesCarryDetail` pins the composition and that same-name entries stay distinct rows (attrs missing → empty detail, subtitle hidden).
- `tst_CoffeeBags`: 36 passed, 0 failed, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)