### PR TITLE
Shot Plan: 'Final yield only' option (hide the profile-default → arrow)

### DIFF
--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -37,6 +37,10 @@ Item {
     // Sentence mode only: render the detail tail on its own line(s) below the
     // sentence (display path — the a11y text stays one joined sentence).
     property bool stacked: false
+    // Yield rendering: when true, show only the effective target yield (e.g.
+    // "40.0g") and suppress the "profileDefault → target" arrow. The default
+    // (false) keeps the arrow, mirroring the temperature-override treatment.
+    property bool yieldTargetOnly: false
     // Wrap budget before eliding: 2 in the full-size widget, 1 in compact bars.
     property int maxLines: 2
 
@@ -63,10 +67,11 @@ Item {
     // --- Per-item segments (empty string = hidden). ---
     // Dose & yield: the shot's target output, plus dose-in (e.g. "18.0g in"). A DELIBERATE yield
     // override (the hasBrewYieldOverride flag, not raw drift — measured dose never exactly matches
-    // the profile's) renders as "36.0 → 40.0g", mirroring the temperature-override treatment.
+    // the profile's) renders as "36.0 → 40.0g", mirroring the temperature-override treatment —
+    // UNLESS yieldTargetOnly is set, in which case only the effective target ("40.0g") shows.
     readonly property string _yieldStr: {
         if (!(_has("doseYield") && targetWeight > 0)) return ""
-        if (Settings.brew.hasBrewYieldOverride && profileYield > 0
+        if (!yieldTargetOnly && Settings.brew.hasBrewYieldOverride && profileYield > 0
                 && Math.abs(targetWeight - profileYield) > 0.1)
             return profileYield.toFixed(1) + " → " + targetWeight.toFixed(1) + "g"
         return targetWeight.toFixed(1) + "g"

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -37,9 +37,8 @@ Item {
     // Sentence mode only: render the detail tail on its own line(s) below the
     // sentence (display path — the a11y text stays one joined sentence).
     property bool stacked: false
-    // Yield rendering: when true, show only the effective target yield (e.g.
-    // "40.0g") and suppress the "profileDefault → target" arrow. The default
-    // (false) keeps the arrow, mirroring the temperature-override treatment.
+    // Yield rendering: when true, suppress the "profileDefault → target" arrow
+    // and show only the effective target — see _yieldStr for the full rule.
     property bool yieldTargetOnly: false
     // Wrap budget before eliding: 2 in the full-size widget, 1 in compact bars.
     property int maxLines: 2
@@ -67,8 +66,9 @@ Item {
     // --- Per-item segments (empty string = hidden). ---
     // Dose & yield: the shot's target output, plus dose-in (e.g. "18.0g in"). A DELIBERATE yield
     // override (the hasBrewYieldOverride flag, not raw drift — measured dose never exactly matches
-    // the profile's) renders as "36.0 → 40.0g", mirroring the temperature-override treatment —
-    // UNLESS yieldTargetOnly is set, in which case only the effective target ("40.0g") shows.
+    // the profile's) renders as "36.0 → 40.0g" — the yield counterpart of the temperature-override
+    // call-out (which uses a delta tag, not an arrow). yieldTargetOnly suppresses the arrow and
+    // shows only the effective target ("40.0g"); with no active override it's a visible no-op.
     readonly property string _yieldStr: {
         if (!(_has("doseYield") && targetWeight > 0)) return ""
         if (!yieldTargetOnly && Settings.brew.hasBrewYieldOverride && profileYield > 0

--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -683,7 +683,8 @@ Dialog {
                     StyledSwitch {
                         // Yield display: ON shows only the effective target yield (e.g. "40.0g");
                         // OFF keeps the "profileDefault → target" arrow (e.g. "36.0 → 40.0g").
-                        // Only affects the Dose & yield item, so disabled when it isn't shown.
+                        // Only affects the Dose & yield item, so disabled when it isn't shown —
+                        // and only visibly differs while a deliberate yield override is active.
                         text: TranslationManager.translate("shotPlanEditor.yieldTargetOnly", "Final yield only (hide profile default)")
                         enabled: popup.shotPlanItems.indexOf("doseYield") !== -1
                         checked: popup.shotPlanYieldTargetOnly

--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -25,6 +25,7 @@ Dialog {
     property var shotPlanItems: []
     property bool shotPlanSentence: true
     property bool shotPlanStacked: false
+    property bool shotPlanYieldTargetOnly: false
     property bool shotPlanShowSteamPlan: true
     // Screen-reader-only reorder fallback (drag has no assistive-tech equivalent).
     readonly property bool _a11yEnabled: typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled
@@ -100,6 +101,7 @@ Dialog {
         shotPlanItems = ShotPlanConfig.itemsFor(props)
         shotPlanSentence = typeof props.shotPlanSentence === "boolean" ? props.shotPlanSentence : true
         shotPlanStacked = props.shotPlanStacked === true
+        shotPlanYieldTargetOnly = props.shotPlanYieldTargetOnly === true
         shotPlanShowSteamPlan = typeof props.shotPlanShowSteamPlan === "boolean" ? props.shotPlanShowSteamPlan : true
         open()
     }
@@ -146,6 +148,7 @@ Dialog {
             var ok = Settings.network.setItemPropertyList(itemId, "shotPlanItems", shotPlanItems)
             ok = Settings.network.setItemProperty(itemId, "shotPlanSentence", shotPlanSentence) && ok
             ok = Settings.network.setItemProperty(itemId, "shotPlanStacked", shotPlanStacked) && ok
+            ok = Settings.network.setItemProperty(itemId, "shotPlanYieldTargetOnly", shotPlanYieldTargetOnly) && ok
             ok = Settings.network.setItemProperty(itemId, "shotPlanShowSteamPlan", shotPlanShowSteamPlan) && ok
             if (!ok)
                 console.warn("ScreensaverEditorPopup: shot plan save failed (item deleted?)", itemId)
@@ -678,6 +681,15 @@ Dialog {
                         onToggled: popup.shotPlanStacked = checked
                     }
                     StyledSwitch {
+                        // Yield display: ON shows only the effective target yield (e.g. "40.0g");
+                        // OFF keeps the "profileDefault → target" arrow (e.g. "36.0 → 40.0g").
+                        // Only affects the Dose & yield item, so disabled when it isn't shown.
+                        text: TranslationManager.translate("shotPlanEditor.yieldTargetOnly", "Final yield only (hide profile default)")
+                        enabled: popup.shotPlanItems.indexOf("doseYield") !== -1
+                        checked: popup.shotPlanYieldTargetOnly
+                        onToggled: popup.shotPlanYieldTargetOnly = checked
+                    }
+                    StyledSwitch {
                         // Page-aware mode: while steaming (or steam selected) the widget swaps to the
                         // steam sentence. The steam side has no further options.
                         text: TranslationManager.translate("shotPlanEditor.showSteamPlan", "Steam plan (while steaming)")
@@ -711,6 +723,7 @@ Dialog {
                             width: Math.min(implicitWidth, parent.width - Theme.spacingSmall * 2)
                             itemOrder: popup.shotPlanItems
                             sentence: popup.shotPlanSentence
+                            yieldTargetOnly: popup.shotPlanYieldTargetOnly
                             stacked: popup.shotPlanStacked
                             // Same sentence gating as ShotPlanItem: no 3-line budget
                             // for fragment mode with a stale stacked flag.

--- a/qml/components/layout/items/ShotPlanItem.qml
+++ b/qml/components/layout/items/ShotPlanItem.qml
@@ -27,6 +27,8 @@ Item {
     // line(s) below the sentence. Compact bar placements ignore it — a bar is
     // a single-line context.
     readonly property bool stacked: modelData.shotPlanStacked === true
+    // Yield: show only the effective target (drop the "profileDefault →" arrow).
+    readonly property bool yieldTargetOnly: modelData.shotPlanYieldTargetOnly === true
     readonly property bool showSteamPlan: modelData.shotPlanShowSteamPlan !== false
 
     // Steam context = steam selected on the idle screen, OR the full steam page, OR the
@@ -90,6 +92,7 @@ Item {
             visible: !root._steamMode && text !== ""
             itemOrder: root.itemOrder
             sentence: root.sentence
+            yieldTargetOnly: root.yieldTargetOnly
             maxLines: 1
             onClicked: root.openBrewSettings()
         }
@@ -118,6 +121,7 @@ Item {
             visible: !root._steamMode && text !== ""
             itemOrder: root.itemOrder
             sentence: root.sentence
+            yieldTargetOnly: root.yieldTargetOnly
             stacked: root.stacked
             // Stacked spends a line on the detail tail — give the sentence +
             // wrapped tail room before eliding. Gated on sentence so a stale

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -2030,6 +2030,12 @@ QString ShotServer::generateLayoutPage() const
                 </div>
                 <div class="ss-slider-row">
                     <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer">
+                        <input type="checkbox" id="spYieldTargetOnly" onchange="spConfigChanged()">
+                        <span style="color:var(--text-secondary)">Final yield only (hide profile default, e.g. "40g" not "36 &#8594; 40g")</span>
+                    </label>
+                </div>
+                <div class="ss-slider-row">
+                    <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer">
                         <input type="checkbox" id="spShowSteamPlan" checked onchange="spConfigChanged()">
                         <span style="color:var(--text-secondary)">Steam plan (while steaming)</span>
                     </label>
@@ -3050,6 +3056,7 @@ QString ShotServer::generateLayoutPage() const
                     spRender();
                     document.getElementById("spSentence").checked = typeof props.shotPlanSentence === "boolean" ? props.shotPlanSentence : true;
                     document.getElementById("spStacked").checked = props.shotPlanStacked === true;
+                    document.getElementById("spYieldTargetOnly").checked = props.shotPlanYieldTargetOnly === true;
                     document.getElementById("spShowSteamPlan").checked = typeof props.shotPlanShowSteamPlan === "boolean" ? props.shotPlanShowSteamPlan : true;
                     spSyncStacked();
                     document.getElementById("ssShotPlanSettings").style.display = "";
@@ -3100,6 +3107,7 @@ QString ShotServer::generateLayoutPage() const
             apiPost("/api/layout/item", {itemId: id, key: "shotPlanItems", value: spItems}, function() {});
             apiPost("/api/layout/item", {itemId: id, key: "shotPlanSentence", value: document.getElementById("spSentence").checked}, function() {});
             apiPost("/api/layout/item", {itemId: id, key: "shotPlanStacked", value: document.getElementById("spStacked").checked}, function() {});
+            apiPost("/api/layout/item", {itemId: id, key: "shotPlanYieldTargetOnly", value: document.getElementById("spYieldTargetOnly").checked}, function() {});
             apiPost("/api/layout/item", {itemId: id, key: "shotPlanShowSteamPlan", value: document.getElementById("spShowSteamPlan").checked}, function() {});
         }
     }

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -2029,7 +2029,7 @@ QString ShotServer::generateLayoutPage() const
                     </label>
                 </div>
                 <div class="ss-slider-row">
-                    <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer">
+                    <label id="spYieldTargetOnlyLabel" style="display:flex;align-items:center;gap:0.5rem;cursor:pointer">
                         <input type="checkbox" id="spYieldTargetOnly" onchange="spConfigChanged()">
                         <span style="color:var(--text-secondary)">Final yield only (hide profile default, e.g. "40g" not "36 &#8594; 40g")</span>
                     </label>
@@ -3059,6 +3059,7 @@ QString ShotServer::generateLayoutPage() const
                     document.getElementById("spYieldTargetOnly").checked = props.shotPlanYieldTargetOnly === true;
                     document.getElementById("spShowSteamPlan").checked = typeof props.shotPlanShowSteamPlan === "boolean" ? props.shotPlanShowSteamPlan : true;
                     spSyncStacked();
+                    spSyncYieldTargetOnly();
                     document.getElementById("ssShotPlanSettings").style.display = "";
                 } else {
                     document.getElementById("ssNoSettings").style.display = "";
@@ -3195,12 +3196,14 @@ QString ShotServer::generateLayoutPage() const
     function spRemove(i) {
         spItems.splice(i, 1);
         spRender();
+        spSyncYieldTargetOnly();
         spConfigChanged();
     }
 
     function spAdd(key) {
         if (spItems.indexOf(key) === -1) spItems.push(key);
         spRender();
+        spSyncYieldTargetOnly();
         spConfigChanged();
     }
 
@@ -3222,6 +3225,16 @@ QString ShotServer::generateLayoutPage() const
     function spSentenceChanged() {
         spSyncStacked();
         spConfigChanged();
+    }
+
+    // "Final yield only" only affects the Dose & yield item — disable and dim
+    // it while that item isn't shown, mirroring the in-app editor.
+    function spSyncYieldTargetOnly() {
+        var on = spItems.indexOf("doseYield") !== -1;
+        document.getElementById("spYieldTargetOnly").disabled = !on;
+        var label = document.getElementById("spYieldTargetOnlyLabel");
+        label.style.opacity = on ? "" : "0.4";
+        label.style.cursor = on ? "pointer" : "default";
     }
 
     function ssSelectMapTexture(value) {


### PR DESCRIPTION
## What

Adds a per-Shot-Plan-widget option **"Final yield only"** that shows just the effective target yield (e.g. `40.0g`) instead of the profile-default → target arrow (e.g. `36.0 → 40.0g`). Default **off**, so existing layouts are unchanged.

## Why

#842 added the yield override arrow to match the temperature treatment, and it's genuinely useful for spotting a deliberate override. But when you brew by ratio (or keep a standing yield override), the profile's static `target_weight` (often 36 g) is just noise next to the number you actually care about — the plan permanently reads `36.0 → 40.0g` and the leading `36.0 →` never changes. This gives people who don't want that a one-tap way to collapse it to the final figure, without removing the arrow for those who like it.

It slots naturally into the per-instance Shot Plan config from #1426 — same editor, same storage pattern as `shotPlanSentence` / `shotPlanStacked`.

## How

New per-instance boolean `shotPlanYieldTargetOnly` (absent / `false` = current behavior):

- **`ShotPlanText.qml`** — `_yieldStr` skips the arrow branch when the flag is set, returning only `targetWeight`. Both the sentence and fragment render paths consume `_yieldStr`, so both honor it.
- **`ShotPlanItem.qml`** — reads `modelData.shotPlanYieldTargetOnly` and passes it to the compact and full `ShotPlanText` instances.
- **`ScreensaverEditorPopup.qml`** (the Shot Plan bespoke editor) — adds the toggle with load/save, wires the live preview, and disables it when the *Dose & yield* item isn't in the plan (nothing to affect).
- **`shotserver_layout.cpp`** — mirrors the toggle in the web layout editor (checkbox + load + save), matching the other `shotPlan*` keys.

## Notes

- Non-breaking: default off; no migration; `setItemProperty` already accepts arbitrary boolean keys.
- Scope: 4 files, +32/−2.
- Build-verified standalone on `main` (Android debug, arm64) — the branch is `main` + this one commit, barista/fork code excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
