### PR TITLE
Shot plan: profile-less "recipe" sentence when the Profile item is hidden

### DIFF
--- a/openspec/specs/plan-widgets/spec.md
+++ b/openspec/specs/plan-widgets/spec.md
@@ -25,7 +25,13 @@ The seven display items are: Profile (`profile`), Temperature (`temperature`), R
 - profile + temperature, no yield → "Brew {beverage}, using {profile} at {temperature}"
 - yield + profile, Temperature item absent → "Brew {yield} of {beverage}, using {profile}"
 - profile only → "Brew {beverage}, using {profile}"
-- Profile item absent (or no profile name available) → the sentence has no anchor; the text SHALL render in fragment format regardless of the Sentence style option.
+
+Profile item absent (or no profile name available) → the sentence has no profile anchor, so it falls back to the profile-less "recipe" sentence: the scaffold instead consumes the Dose & yield, Temperature, Roaster, and Coffee items (wherever they sit in the list) together with the beverage word, and only the Grind and Roast date items SHALL trail after it as a separator-joined tail in item-list order. The beverage word SHALL always anchor this sentence, so Sentence style SHALL NOT degrade to fragment format while it is ON — regardless of which other items are present:
+
+- yield + temperature + dose + roaster + coffee → "Brew {yield} of {beverage} at {temperature} from {dose} of {roaster} {coffee}"
+- yield only, no temperature/dose/roaster/coffee → "Brew {yield} of {beverage}"
+- no yield, dose present, no roaster/coffee → "Brew {beverage} from {dose}"
+- no yield, no dose, roaster + coffee only → "Brew {beverage} from {roaster} {coffee}"
 
 The beverage word SHALL follow the current profile's `beverage_type`: "Espresso" for espresso (and unset), "tea" for tea types, and "coffee" for any other coffee beverage (filter, pourover, …). A cleaning or descale profile SHALL replace the plan entirely — in both formats — with a cleaning notice carrying a do-not-load-coffee warning, rendered bold in the error (red) color with no item segments.
 
@@ -51,10 +57,15 @@ The plain (accessibility) text and the rich (displayed) text SHALL be produced b
 - **WHEN** Sentence style is ON and the item list contains `profile` and `doseYield` but not `temperature`
 - **THEN** the sentence reads "Brew {yield} of {beverage}, using {profile}" with no temperature anywhere
 
-#### Scenario: Profile chip removed falls back to fragments
+#### Scenario: Profile chip removed renders the profile-less recipe sentence
 
-- **WHEN** Sentence style is ON and the item list is `["doseYield", "temperature", "coffee"]` (no `profile`)
-- **THEN** the plan renders as separator-joined fragments in list order, with no sentence scaffolding
+- **WHEN** Sentence style is ON and the item list is `["temperature", "coffee"]` (no `profile`, no `doseYield`)
+- **THEN** the plan renders "Brew {beverage} at {temperature} from {coffee}" — a sentence anchored on the beverage word, not a fragment list
+
+#### Scenario: No profile loaded renders the profile-less recipe sentence even with the Profile chip shown
+
+- **WHEN** Sentence style is ON, the item list includes `profile`, but no profile is currently loaded (no profile name available)
+- **THEN** the plan renders the profile-less recipe sentence, exactly as if the Profile chip had been removed
 
 #### Scenario: Filter profile says coffee, not espresso
 

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -4,12 +4,15 @@ import "../"
 
 // The brew summary for the home screen. Content is driven by an ordered item
 // list (`itemOrder`) and a `sentence` toggle:
-//  - sentence ON: "Brew 36.0g of Espresso, using <profile> at 92°C" — the
-//    scaffold consumes doseYield's yield, profile, and temperature (wherever
-//    they sit in the order; sentence word order belongs to the translated
-//    template), and everything else — including doseYield's dose-in fragment —
-//    trails after it in list order. Without the profile item (or a profile
-//    name) the sentence has no anchor and rendering falls back to fragments.
+//  - sentence ON, profile shown: "Brew 36.0g of Espresso, using <profile> at
+//    92°C" — the scaffold consumes doseYield's yield, profile, and temperature
+//    (wherever they sit in the order; sentence word order belongs to the
+//    translated template), and everything else — including doseYield's dose-in
+//    fragment — trails after it in list order.
+//  - sentence ON, profile NOT shown: the profile-less "recipe" sentence —
+//    "Brew 40.0g of Espresso at 92°C from 18.0g of <Roaster> <Bean>" — anchored
+//    on the beverage word. Dose, roaster and coffee are consumed into it; only
+//    grind/roastDate trail. Driven by the same chips (drop Profile to get it).
 //  - sentence OFF: every item renders as a separator-joined fragment, in list
 //    order.
 //  - stacked ON (sentence mode only, display path only): the detail tail
@@ -167,6 +170,53 @@ Item {
                 }
             }
             return tail.length > 0 ? (s + blockSep + tail.join(sep)) : s
+        }
+
+        // Recipe sentence — the profile-less anchor. When Sentence is on but the
+        // profile item isn't shown, the plan reads as the recipe itself:
+        // "Brew 40.0g of Espresso at 92°C from 18.0g of <Roaster> <Bean>". Dose,
+        // roaster and coffee are CONSUMED into the sentence (they don't also trail
+        // as fragments); only grind/roastDate trail after. Each piece stays gated
+        // by its item's presence via the _xStr getters, so the chips still drive
+        // what shows. The beverage word is always present, so this never degrades
+        // to a fragment list while Sentence is on. Built by appending translatable
+        // clauses (at %/from %) onto the head — English word order; the a11y and
+        // rich paths share this builder so they can't drift.
+        if (sentence) {
+            var beans = ""
+            if (_roasterStr !== "" && _coffeeStr !== "")
+                beans = fmt(_roasterStr, true) + " " + fmt(_coffeeStr, true)
+            else if (_roasterStr !== "")
+                beans = fmt(_roasterStr, true)
+            else if (_coffeeStr !== "")
+                beans = fmt(_coffeeStr, true)
+
+            var r = (_yieldStr !== "")
+                ? TranslationManager.translate("shotplan.recipe.head", "Brew %1 of %2")
+                    .arg(fmt(_yieldStr, true)).arg(fmt(_beverage, false))
+                : TranslationManager.translate("shotplan.recipe.headNoYield", "Brew %1")
+                    .arg(fmt(_beverage, false))
+            if (_tempStr !== "")
+                r = TranslationManager.translate("shotplan.recipe.atTemp", "%1 at %2")
+                    .arg(r).arg(fmt(_tempStr, true))
+            if (_doseStr !== "" && beans !== "")
+                r = TranslationManager.translate("shotplan.recipe.fromDoseBeans", "%1 from %2 of %3")
+                    .arg(r).arg(fmt(_doseStr, true)).arg(beans)
+            else if (_doseStr !== "")
+                r = TranslationManager.translate("shotplan.recipe.fromDose", "%1 from %2")
+                    .arg(r).arg(fmt(_doseStr, true))
+            else if (beans !== "")
+                r = TranslationManager.translate("shotplan.recipe.fromBeans", "%1 from %2")
+                    .arg(r).arg(beans)
+
+            var rtail = []
+            for (var k = 0; k < order.length; k++) {
+                switch (order[k]) {
+                case "grind":     if (grind !== "") rtail.push(grind); break
+                case "roastDate": if (roasted !== "") rtail.push(roasted); break
+                }
+            }
+            return rtail.length > 0 ? (r + blockSep + rtail.join(sep)) : r
         }
 
         // Fragment format: every present item, in list order.

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -9,10 +9,11 @@ import "../"
 //    (wherever they sit in the order; sentence word order belongs to the
 //    translated template), and everything else — including doseYield's dose-in
 //    fragment — trails after it in list order.
-//  - sentence ON, profile NOT shown: the profile-less "recipe" sentence —
-//    "Brew 40.0g of Espresso at 92°C from 18.0g of <Roaster> <Bean>" — anchored
-//    on the beverage word. Dose, roaster and coffee are consumed into it; only
-//    grind/roastDate trail. Driven by the same chips (drop Profile to get it).
+//  - sentence ON, no profile anchor (item removed, or no profile name
+//    available): the profile-less "recipe" sentence — "Brew 40.0g of Espresso
+//    at 92°C from 18.0g of <Roaster> <Bean>" — anchored on the beverage word.
+//    Dose, temperature, roaster and coffee are consumed into it; only
+//    grind/roastDate trail.
 //  - sentence OFF: every item renders as a separator-joined fragment, in list
 //    order.
 //  - stacked ON (sentence mode only, display path only): the detail tail
@@ -172,16 +173,18 @@ Item {
             return tail.length > 0 ? (s + blockSep + tail.join(sep)) : s
         }
 
-        // Recipe sentence — the profile-less anchor. When Sentence is on but the
-        // profile item isn't shown, the plan reads as the recipe itself:
-        // "Brew 40.0g of Espresso at 92°C from 18.0g of <Roaster> <Bean>". Dose,
-        // roaster and coffee are CONSUMED into the sentence (they don't also trail
-        // as fragments); only grind/roastDate trail after. Each piece stays gated
-        // by its item's presence via the _xStr getters, so the chips still drive
-        // what shows. The beverage word is always present, so this never degrades
-        // to a fragment list while Sentence is on. Built by appending translatable
-        // clauses (at %/from %) onto the head — English word order; the a11y and
-        // rich paths share this builder so they can't drift.
+        // Recipe sentence — the profile-less anchor. Reached when Sentence is on
+        // but there's no profile anchor (item removed, or no profile name
+        // available), so the plan reads as the recipe itself: "Brew 40.0g of
+        // Espresso at 92°C from 18.0g of <Roaster> <Bean>". Dose, temperature,
+        // roaster and coffee are CONSUMED into the sentence (they don't also
+        // trail as fragments); only grind/roastDate trail after. Each piece
+        // stays gated by its item's presence via the _xStr getters, so the
+        // chips still drive what shows. The beverage word is always present,
+        // so this never degrades to a fragment list while Sentence is on.
+        // Built by appending translatable clauses (at %/from %) onto the head —
+        // English word order; the a11y and rich paths share this builder so
+        // they can't drift.
         if (sentence) {
             var beans = ""
             if (_roasterStr !== "" && _coffeeStr !== "")

--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -658,11 +658,12 @@ Dialog {
                     }
 
                     StyledSwitch {
-                        // ON: the "Brew … of Espresso, using … at …" scaffold (its own word
-                        // order) with the remaining items trailing in chip order. OFF: all
-                        // items as separator-joined fragments in chip order. With the
-                        // Profile chip removed the sentence has no anchor, so ON renders
-                        // fragments too — the preview makes that visible.
+                        // ON, Profile shown: the "Brew … of Espresso, using … at …" scaffold
+                        // (its own word order) with the remaining items trailing in chip order.
+                        // ON, Profile removed: the profile-less "recipe" sentence — "Brew 40.0g
+                        // of Espresso at 92°C from 18.0g of <Roaster> <Bean>" — consuming dose/
+                        // roaster/coffee. OFF: all items as separator-joined fragments in chip
+                        // order. The preview reflects each case live.
                         text: TranslationManager.translate("shotPlanEditor.sentenceStyle", "Sentence style")
                         checked: popup.shotPlanSentence
                         onToggled: popup.shotPlanSentence = checked

--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -658,12 +658,13 @@ Dialog {
                     }
 
                     StyledSwitch {
-                        // ON, Profile shown: the "Brew … of Espresso, using … at …" scaffold
-                        // (its own word order) with the remaining items trailing in chip order.
-                        // ON, Profile removed: the profile-less "recipe" sentence — "Brew 40.0g
-                        // of Espresso at 92°C from 18.0g of <Roaster> <Bean>" — consuming dose/
-                        // roaster/coffee. OFF: all items as separator-joined fragments in chip
-                        // order. The preview reflects each case live.
+                        // ON, profile anchor available (Profile shown with a profile loaded):
+                        // the "Brew … of Espresso, using … at …" scaffold (its own word order)
+                        // with the remaining items trailing in chip order. ON, no profile anchor
+                        // (Profile removed, or none loaded): the profile-less "recipe" sentence —
+                        // "Brew 40.0g of Espresso at 92°C from 18.0g of <Roaster> <Bean>" —
+                        // consuming dose/temperature/roaster/coffee. OFF: all items as separator-
+                        // joined fragments in chip order. The preview reflects each case live.
                         text: TranslationManager.translate("shotPlanEditor.sentenceStyle", "Sentence style")
                         checked: popup.shotPlanSentence
                         onToggled: popup.shotPlanSentence = checked

--- a/qml/components/layout/items/ShotPlanItem.qml
+++ b/qml/components/layout/items/ShotPlanItem.qml
@@ -122,8 +122,8 @@ Item {
             // Stacked spends a line on the detail tail — give the sentence +
             // wrapped tail room before eliding. Gated on sentence so a stale
             // stacked flag (saved on, Sentence later turned off) doesn't widen
-            // fragment mode's budget. (The profile-anchor fragment fallback
-            // still gets the extra line — harmless, just a wider wrap budget.)
+            // fragment mode's budget. (The profile-less recipe sentence needs
+            // this extra line too — its detail tail stacks the same way.)
             maxLines: root.stacked && root.sentence ? 3 : 2
             onClicked: root.openBrewSettings()
         }


### PR DESCRIPTION
## What

Adds a **profile-less "recipe" sentence** to the Shot Plan widget. When **Sentence style** is on but the **Profile** item is not in the shown-items list, the plan now reads as the recipe itself:

> **Brew 40.0g of Espresso at 92°C from 18.0g of Onyx Monarch**

instead of collapsing to a dotted fragment list.

## Why

The sentence scaffold added in #1426 anchors on the profile name — `"Brew … using <profile> at …"`. That anchor is a hard requirement: `_build()` gates the whole sentence on `sentence && _profileStr !== ""`, so the moment you **remove the Profile chip** (a perfectly reasonable choice — many people don't want the profile name in their plan), the sentence silently degrades to fragments (`40.0g · 92°C · Onyx · Monarch`). Turning **Sentence style** on then does nothing, which reads as a bug.

This gives the sentence a second anchor — the beverage word, which is always present — so "Sentence on" always yields a sentence, and the recipe reads naturally without the profile name.

## How

New branch in `ShotPlanText._build()` for `sentence && _profileStr === ""`:

- **Anchor** on the beverage word (`_beverage`, always non-empty): `Brew {yield} of {beverage}` (or `Brew {beverage}` with no yield).
- **Consume** dose, roaster and coffee **into** the sentence — `… at {temp} from {dose} of {roaster} {bean}` — so they no longer *also* trail as fragments. Only `grind`/`roastDate` trail after.
- **Each clause stays gated by its item chip** via the existing `_yieldStr`/`_tempStr`/`_doseStr`/`_roasterStr`/`_coffeeStr` getters, so the shown-items list still drives exactly what appears. Degrades cleanly with any piece missing (no dangling "from"/"of"):
  - no temp → *Brew 40.0g of Espresso from 18.0g of Onyx Monarch*
  - no beans → *Brew 40.0g of Espresso at 92°C from 18.0g*
  - no dose → *Brew 40.0g of Espresso at 92°C*
  - no yield → *Brew Espresso at 92°C from 18.0g of Onyx Monarch*
- Built by appending translatable clauses (`shotplan.recipe.*`) onto the head; the a11y (`text`) and rich (bolded) paths share the one `_build` builder, so they can't drift. User values pass through the existing `_argSafe` + `Theme.escapeHtml`, same as the profile-shown branch.

The profile-**shown** branch is unchanged — this only adds behavior for the case that previously fell through to fragments.

## Notes for reviewers

- **Visibility:** the root is `visible: text !== ""`. Previously, sentence-on + profile-hidden + every other item also hidden could produce an empty string and hide the widget; the recipe branch now always renders at least "Brew Espresso", so that (degenerate) configuration becomes visible. Intended — "Sentence on" should never be silently blank.
- **i18n word order:** the recipe is assembled by appending `at %`/`from %` clauses, which bakes in English clause order (a translator can reorder *within* a clause but not move the temp/dose clauses relative to the verb, unlike the single-template profile-shown branch). Deliberate tradeoff to keep the combinatorial template count down; happy to switch to full per-combo templates if you'd prefer.

Only the Shot Plan widget is affected. No new files, imports, or C++.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
