### PR TITLE
Rename espresso layout button to Profiles + dedicated profile icon

### DIFF
--- a/qml/components/layout/LayoutItemDelegate.qml
+++ b/qml/components/layout/LayoutItemDelegate.qml
@@ -60,8 +60,8 @@ Item {
 
         switch (type) {
             case "espresso": return {
-                emoji: "qrc:/icons/espresso.svg",
-                content: TranslationManager.translate("idle.button.espresso", "Espresso"),
+                emoji: "qrc:/icons/profile.svg",
+                content: TranslationManager.translate("idle.button.profiles", "Profiles"),
                 action: "togglePreset:espresso",
                 longPressAction: "navigate:profiles",
                 doubleclickAction: "navigate:profiles",
@@ -100,7 +100,7 @@ Item {
                 backgroundColor: Settings.dye.activeBagId <= 0 ? Theme.highlightColor : Theme.primaryColor
             }
             case "recipes": return {
-                emoji: "qrc:/icons/pin.svg",
+                emoji: "qrc:/icons/espresso.svg",
                 content: TranslationManager.translate("idle.button.recipes", "Recipes"),
                 action: "togglePreset:recipes",
                 // "recipeList" (drink recipes) — the bare "recipes" navigate

--- a/qml/components/layout/items/EspressoItem.qml
+++ b/qml/components/layout/items/EspressoItem.qml
@@ -68,7 +68,7 @@ Item {
             spacing: Theme.spacingSmall
 
             Image {
-                source: "qrc:/icons/espresso.svg"
+                source: "qrc:/icons/profile.svg"
                 sourceSize.height: Theme.scaled(20)
                 fillMode: Image.PreserveAspectFit
                 opacity: DE1Device.guiEnabled ? 1.0 : 0.5
@@ -81,8 +81,8 @@ Item {
                 }
             }
             Tr {
-                key: "idle.button.espresso"
-                fallback: "Espresso"
+                key: "idle.button.profiles"
+                fallback: "Profiles"
                 font: Theme.bodyFont
                 color: !DE1Device.guiEnabled ? Theme.textSecondaryColor
                        : (root.isActive ? Theme.accentColor : Theme.textColor)
@@ -95,7 +95,7 @@ Item {
             enabled: DE1Device.guiEnabled
             supportLongPress: true
             supportDoubleClick: true
-            accessibleName: TranslationManager.translate("idle.button.espresso", "Espresso")
+            accessibleName: TranslationManager.translate("idle.button.profiles", "Profiles")
                             + (root.isActive ? ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
             accessibleDescription: TranslationManager.translate("idle.accessible.espresso.hint", "Tap to toggle presets. Double-tap or long-press to select profile.")
             onAccessibleClicked: root.togglePresets()

--- a/qml/components/layout/items/RecipesItem.qml
+++ b/qml/components/layout/items/RecipesItem.qml
@@ -85,7 +85,7 @@ Item {
             spacing: Theme.spacingSmall
 
             Image {
-                source: "qrc:/icons/pin.svg"
+                source: "qrc:/icons/espresso.svg"
                 sourceSize.height: Theme.scaled(20)
                 fillMode: Image.PreserveAspectFit
                 Accessible.ignored: true

--- a/qml/components/library/LibraryItemCard.qml
+++ b/qml/components/library/LibraryItemCard.qml
@@ -145,8 +145,8 @@ Rectangle {
     function compileActionType(type) {
         switch (type) {
             case "espresso": return {
-                emoji: "qrc:/icons/espresso.svg",
-                content: "Espresso",
+                emoji: "qrc:/icons/profile.svg",
+                content: "Profiles",
                 action: "togglePreset:espresso",
                 backgroundColor: String(Theme.primaryColor)
             }

--- a/resources/icons/profile.svg
+++ b/resources/icons/profile.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 20h18"/>
+  <path d="M3 16C5.5 16 6.5 6 9 6C11.5 6 12.5 13 15 14C17 14.8 19 15 21 15"/>
+</svg>

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -27,6 +27,7 @@
         <file>icons/sleep.svg</file>
         <file>icons/sparkle.svg</file>
         <file>icons/pin.svg</file>
+        <file>icons/profile.svg</file>
         <file>icons/hide-keyboard.svg</file>
         <file>icons/battery-0.svg</file>
         <file>icons/battery-25.svg</file>

--- a/src/core/settings_network.cpp
+++ b/src/core/settings_network.cpp
@@ -724,7 +724,7 @@ struct WidgetCatalogEntry {
 const QVector<WidgetCatalogEntry>& widgetCatalogTable() {
     static const QVector<WidgetCatalogEntry> kCatalog = {
         // Actions (0)
-        { "espresso",      0, "layoutEditor.widgetEspresso",  "Espresso",  "layoutEditor.chipEspresso",  "Espresso",  "", true },
+        { "espresso",      0, "layoutEditor.widgetProfiles",  "Profiles",  "layoutEditor.chipProfiles",  "Profiles",  "", true },
         { "steam",         0, "layoutEditor.widgetSteam",     "Steam",     "layoutEditor.chipSteam",     "Steam",     "", true },
         { "hotwater",      0, "layoutEditor.widgetHotWater",  "Hot Water", "layoutEditor.chipHotWater",  "Hot Water", "", true },
         { "flush",         0, "layoutEditor.widgetFlush",     "Flush",     "layoutEditor.chipFlush",     "Flush",     "", true },


### PR DESCRIPTION
## Summary
- The espresso layout widget now labels itself **Profiles** everywhere it shows a name: compact bar item, compiled center-zone button, library preview card, and the widget catalog table (which drives the in-app palette, editor chips, and web layout editor). With drink recipes split out into their own widget, this button's job is selecting/starting a profile, not "espresso".
- New translation keys (`idle.button.profiles`, `layoutEditor.widgetProfiles`, `layoutEditor.chipProfiles`) so translated languages fall back to the new English text; the shared `idle.button.espresso` key is untouched and still serves the Mini GHC start button and shot-plan beverage text, which genuinely mean espresso.
- **Icon swap**: the Recipes widget takes over the espresso cup icon, and the Profiles button gets a new dedicated `profile.svg` — a pressure-profile curve over a baseline, matching the icon set's stroke style and visually distinct from `Graph.svg` (axes + zigzag). The pin icon keeps its existing auto-load-marker meaning in the profile selector.
- The persisted widget type stays `"espresso"`, so saved layouts and library items are unaffected.

## Testing
- Not built locally; QML label/icon changes are direct string/source swaps, and the catalog row change follows the existing table shape. The new SVG is registered in `resources.qrc`, so palette/web-editor changes need a rebuild to appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)