### PR TITLE
Fix stale RPM showing in Shot Plan/Recipe Card for non-RPM grinders

### DIFF
--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -101,7 +101,8 @@ Item {
         if (!_has("grind")) return ""
         var parts = []
         if (grindSize.length > 0) parts.push(grindSize)
-        if (Settings.dye.dyeGrinderRpm > 0)
+        if (Settings.dye.dyeGrinderRpm > 0
+                && Settings.dye.grinderRpmCapable(Settings.dye.dyeGrinderBrand, Settings.dye.dyeGrinderModel))
             parts.push(TranslationManager.translate("equipment.card.lastRpm", "%1 rpm").arg(Settings.dye.dyeGrinderRpm))
         return parts.join(" · ")
     }


### PR DESCRIPTION
## Summary
- `ShotPlanText.qml`'s grind string displayed grinder RPM whenever `Settings.dye.dyeGrinderRpm` was nonzero, with no check that the current grinder actually supports RPM.
- That setting persists across equipment switches, so a stale RPM value from a previously-used variable-speed grinder kept showing up in the Shot Plan widget and Recipe Card even after switching to a non-RPM grinder (e.g. Niche Zero).
- Gates the display on `Settings.dye.grinderRpmCapable(brand, model)`, matching the pattern already used correctly in `BrewDialog`, `RecipeWizardPage`, `EquipmentSummary`, `EquipmentInfoDialog`, `ChangeBeansDialog`, and `PostShotReviewPage`.
- Audited every other grind/RPM display site in the QML tree — all already correctly gated, so this was the only fix needed.

## Test plan
- [ ] Build in Qt Creator
- [ ] Switch active equipment to a non-RPM-capable grinder (e.g. Niche Zero) after previously using a variable-speed grinder
- [ ] Confirm RPM no longer appears in the Shot Plan widget or Recipe Card grind line
- [ ] Confirm RPM still appears correctly for RPM-capable grinders

🤖 Generated with [Claude Code](https://claude.com/claude-code)