### PR TITLE
Steam: global seconds-per-gram weight calibration (pitcher-agnostic)

### DIFF
--- a/qml/components/SteamPlanText.qml
+++ b/qml/components/SteamPlanText.qml
@@ -46,10 +46,11 @@ Item {
     }
 
     // Target milk for the plan: the weight just measured this session (after the bell) if
-    // there is one, else the pitcher's calibrated reference, else the last measured milk.
+    // there is one, else the last measured milk. (The old per-pitcher calibMilkG is no
+    // longer consulted — weight-timing is now a global rate, and calibMilkG has no UI
+    // left to edit, so it would freeze the plan on a stale reference weight.)
     readonly property real _targetMilk: {
         if (_sessionMilk > 0) return _sessionMilk
-        if (_preset && (_preset.calibMilkG || 0) > 0) return _preset.calibMilkG
         return Settings.brew.lastSteamMilkG || 0
     }
     // The SELECTED preset's effective time (scaled when weight-timing has milk to work

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -273,13 +273,6 @@ Page {
         return Settings.brew.scaledSteamTime(Settings.brew.selectedSteamPitcher, milk)
     }
 
-    // Selected preset's reference milk weight (the baseline paired with its duration).
-    function getCurrentPitcherCalibMilk() {
-        var _ = Settings.brew.steamPitcherPresets  // track changes so the field refreshes after Weigh
-        var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
-        return (preset && !preset.disabled) ? (preset.calibMilkG ?? 0) : 0
-    }
-
     // True once a milk capture has scaled steamTimeout for the CURRENT pitcher
     // selection. syncSteamTimeout() preserves that scaled value while the pitcher
     // is lifted to the wand, but a stale value (e.g. after switching pitcher) is
@@ -345,10 +338,11 @@ Page {
         if (milk <= 0) milk = capturedMilkForScaling()   // pitcher lifted: use the captured milk
         var scaled = steamTimeForMilk(milk)
         if (scaled > 0) steamPage.steamTimeoutScaled = true
-        // Write the shared scaled-or-base resolution — UNLESS this selection was
-        // already scaled from measured milk and the pitcher is merely lifted
-        // (calibrated preset, nothing on the scale): keep that value.
-        if (scaled > 0 || getCurrentPitcherCalibMilk() <= 0 || !steamPage.steamTimeoutScaled) {
+        // Write the shared scaled-or-base resolution — UNLESS steaming is weight-
+        // calibrated (global rate > 0) and this selection was already scaled from
+        // measured milk and the pitcher is merely lifted (nothing on the scale):
+        // keep that value.
+        if (scaled > 0 || Settings.brew.steamSecondsPerGram <= 0 || !steamPage.steamTimeoutScaled) {
             Settings.brew.steamTimeout = Settings.brew.effectiveSteamDurationSec(
                 Settings.brew.selectedSteamPitcher, milk)
         }
@@ -1687,9 +1681,9 @@ Page {
                             valueColor: Theme.weightColor
                             accessibleName: TranslationManager.translate("steam.label.pitcherWeight", "Milk pitcher weight")
                             // tareBtn lives in the scale-gated sub-row; skip straight to
-                            // the reference-milk field when no scale is connected so Tab
+                            // the steam-rate field when no scale is connected so Tab
                             // never lands on a hidden element.
-                            KeyNavigation.tab: (steamPage.realScaleConnected) ? tareBtn : refMilkInput
+                            KeyNavigation.tab: (steamPage.realScaleConnected) ? tareBtn : steamRateInput
                             KeyNavigation.backtab: steamTempSlider
                             onValueModified: function(newValue) {
                                 Settings.brew.setSteamPitcherWeight(Settings.brew.selectedSteamPitcher, newValue)
@@ -1765,7 +1759,7 @@ Page {
                                 Accessible.onPressAction: savePitcherWtMa.clicked(null)
                                 Keys.onReturnPressed: { savePitcherWtMa.clicked(null); event.accepted = true }
                                 Keys.onSpacePressed:  { savePitcherWtMa.clicked(null); event.accepted = true }
-                                KeyNavigation.tab: refMilkInput
+                                KeyNavigation.tab: steamRateInput
                                 KeyNavigation.backtab: tareBtn
 
                                 Text {
@@ -1834,127 +1828,87 @@ Page {
 
                     Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
 
-                    // Reference milk weight: the baseline paired with this preset's
-                    // duration for weight-timed steaming. steamTime = duration ×
-                    // (measuredMilk / referenceMilk). 0 disables weight scaling.
-                    RowLayout {
+                    // ── Steam rate calibration (GLOBAL — applies to every pitcher).
+                    // One "seconds per gram of milk" replaces the old per-pitcher
+                    // reference-milk scaling: calibrate once, every pitcher (same steam
+                    // flow) finishes at the same temperature. Shows the current rate,
+                    // a "Calibrate from last steam" button, and a manual ± adjust. ──
+                    ColumnLayout {
+                        id: steamRateSection
                         Layout.fillWidth: true
-                        spacing: Theme.scaled(16)
+                        spacing: Theme.scaled(8)
                         visible: !steamPage.currentPitcherDisabled
-
-                        Column {
-                            Tr {
-                                key: "steam.label.referenceMilk"
-                                fallback: "Reference milk"
-                                color: Theme.textColor
-                                font.pixelSize: Theme.scaled(24)
-                            }
-                            Tr {
-                                key: "steam.hint.referenceMilk"
-                                fallback: "The milk weight the duration above is tuned for. Other amounts scale from it. 0 = off."
-                                color: Theme.textSecondaryColor
-                                font: Theme.labelFont
-                            }
-                        }
-
-                        Item { Layout.fillWidth: true }
-
-                        ValueInput {
-                            id: refMilkInput
-                            Layout.preferredWidth: Theme.scaled(150)
-                            from: 0
-                            to: 1500
-                            stepSize: 0.1
-                            decimals: 1
-                            suffix: " g"
-                            value: getCurrentPitcherCalibMilk()
-                            valueColor: Theme.primaryColor
-                            accessibleName: TranslationManager.translate("steam.label.referenceMilk", "Reference milk weight")
-                            KeyNavigation.tab: pitcherRepeater.count > 0 ? pitcherRepeater.itemAt(0).focusTarget : addPitcherButton
-                            // savePitcherWeightBtn is in the scale-gated sub-row; fall back
-                            // to the always-visible field when no scale is connected.
-                            KeyNavigation.backtab: (steamPage.realScaleConnected) ? savePitcherWeightBtn : pitcherWeightInput
-                            onValueModified: function(newValue) {
-                                // Don't reassign value here — it would break the declarative
-                                // binding to getCurrentPitcherCalibMilk(), so a later "Use as
-                                // baseline"/Weigh update wouldn't refresh the field. The setter
-                                // writes through and the reactive getter re-evaluates the binding.
-                                Settings.brew.setSteamPitcherCalibration(Settings.brew.selectedSteamPitcher, newValue)
-                            }
-                        }
-
-                        // Weigh the milk now on the scale and use it as the reference.
-                        // Requires a saved empty-pitcher weight (net milk = scale - pitcher).
-                        Rectangle {
-                            id: refMilkWeighBtn
-                            visible: steamPage.realScaleConnected
-                            readonly property bool btnEnabled: steamPage.currentMeasuredMilk() > 0
-                            opacity: btnEnabled ? 1.0 : 0.4
-                            width: Theme.scaled(84); height: Theme.scaled(44)
-                            radius: Theme.cardRadius
-                            color: refMilkWeighMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
-                            Accessible.role: Accessible.Button
-                            Accessible.name: TranslationManager.translate("steam.accessible.setRefMilk", "Set reference milk from the scale")
-                            Accessible.focusable: true
-                            Accessible.onPressAction: refMilkWeighMa.clicked(null)
-                            Tr {
-                                anchors.centerIn: parent
-                                key: "steam.label.weigh"; fallback: "Weigh"
-                                color: Theme.primaryContrastColor; font: Theme.bodyFont
-                                Accessible.ignored: true
-                            }
-                            MouseArea {
-                                id: refMilkWeighMa
-                                anchors.fill: parent
-                                enabled: refMilkWeighBtn.btnEnabled
-                                onClicked: Settings.brew.setSteamPitcherCalibration(
-                                    Settings.brew.selectedSteamPitcher, steamPage.currentMeasuredMilk())
-                            }
-                        }
-                    }
-
-                    Rectangle { Layout.fillWidth: true; height: 1; color: Theme.textSecondaryColor; opacity: 0.3; visible: !steamPage.currentPitcherDisabled }
-
-                    // Adopt the last actual steam session (milk + time) as this
-                    // pitcher's reference baseline — sets reference milk AND duration.
-                    RowLayout {
-                        id: useLastSteamRow
-                        Layout.fillWidth: true
-                        visible: !steamPage.currentPitcherDisabled
-                        spacing: Theme.scaled(12)
+                        readonly property bool calibrated: Settings.brew.steamSecondsPerGram > 0
                         readonly property bool hasLast: Settings.brew.lastSteamMilkG > 0 && Settings.brew.lastSteamTimeS > 0
 
-                        Column {
-                            Tr {
-                                key: "steam.lastSteam.title"
-                                fallback: "Calibrate from your last steam"
-                                color: Theme.textColor
-                                font.pixelSize: Theme.scaled(20)
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: Theme.scaled(16)
+
+                            Column {
+                                Tr {
+                                    key: "steam.rate.title"
+                                    fallback: "Steam rate"
+                                    color: Theme.textColor
+                                    font.pixelSize: Theme.scaled(24)
+                                }
+                                Text {
+                                    text: steamRateSection.calibrated
+                                          ? TranslationManager.translate("steam.rate.value", "%1 sec per gram of milk")
+                                                .arg(Settings.brew.steamSecondsPerGram.toFixed(2))
+                                          : TranslationManager.translate("steam.rate.uncalibrated", "Not yet calibrated — weight-timed steaming is off until you calibrate.")
+                                    color: Theme.textSecondaryColor
+                                    font: Theme.labelFont
+                                }
                             }
+
+                            Item { Layout.fillWidth: true }
+
+                            ValueInput {
+                                id: steamRateInput
+                                Layout.preferredWidth: Theme.scaled(170)
+                                from: 0
+                                to: 2.0
+                                stepSize: 0.01
+                                decimals: 2
+                                suffix: TranslationManager.translate("steam.rate.suffix", " s/g")
+                                value: Settings.brew.steamSecondsPerGram
+                                valueColor: Theme.primaryColor
+                                accessibleName: TranslationManager.translate("steam.rate.title", "Steam rate seconds per gram")
+                                KeyNavigation.tab: pitcherRepeater.count > 0 ? pitcherRepeater.itemAt(0).focusTarget : addPitcherButton
+                                KeyNavigation.backtab: (steamPage.realScaleConnected) ? savePitcherWeightBtn : pitcherWeightInput
+                                onValueModified: function(newValue) {
+                                    Settings.brew.steamSecondsPerGram = newValue
+                                }
+                            }
+                        }
+
+                        // Calibrate from the last actual steam session (milk + time) —
+                        // derives the global seconds-per-gram and turns weight-timing on.
+                        RowLayout {
+                            id: useLastSteamRow
+                            Layout.fillWidth: true
+                            spacing: Theme.scaled(12)
+
                             Text {
-                                text: useLastSteamRow.hasLast
-                                      ? TranslationManager.translate("steam.lastSteam.values", "Last steam: %1 g milk → %2 s — sets duration + reference")
+                                Layout.fillWidth: true
+                                text: steamRateSection.hasLast
+                                      ? TranslationManager.translate("steam.lastSteam.valuesGlobal", "Last steam: %1 g milk → %2 s")
                                             .arg(Settings.brew.lastSteamMilkG.toFixed(0)).arg(Math.round(Settings.brew.lastSteamTimeS))
                                       : TranslationManager.translate("steam.lastSteam.none", "Steam a weighed pitcher to your liking first, then come back here.")
                                 color: Theme.textSecondaryColor
                                 font: Theme.labelFont
+                                wrapMode: Text.WordWrap
                             }
-                        }
 
-                        Item { Layout.fillWidth: true }
-
-                        AccessibleButton {
-                            Layout.preferredHeight: Theme.scaled(44)
-                            text: TranslationManager.translate("steam.lastSteam.use", "Use last steam")
-                            accessibleName: TranslationManager.translate("steam.lastSteam.useAccessible", "Use last steam session as this pitcher's duration and reference milk")
-                            primary: true
-                            enabled: useLastSteamRow.hasLast
-                            onClicked: {
-                                var idx = Settings.brew.selectedSteamPitcher
-                                var p = Settings.brew.getSteamPitcherPreset(idx)
-                                if (!p || p.disabled) return
-                                Settings.brew.updateSteamPitcherPreset(idx, p.name, Math.round(Settings.brew.lastSteamTimeS), p.flow ?? 150)
-                                Settings.brew.setSteamPitcherCalibration(idx, Settings.brew.lastSteamMilkG)
+                            AccessibleButton {
+                                Layout.preferredHeight: Theme.scaled(44)
+                                text: TranslationManager.translate("steam.lastSteam.use", "Use last steam")
+                                accessibleName: TranslationManager.translate("steam.lastSteam.useAccessibleGlobal", "Calibrate the global steam rate from your last steam session")
+                                primary: true
+                                enabled: steamRateSection.hasLast
+                                onClicked: Settings.brew.calibrateSteamFromReference(
+                                    Settings.brew.lastSteamMilkG, Settings.brew.lastSteamTimeS)
                             }
                         }
                     }
@@ -2145,6 +2099,9 @@ Page {
             font: Theme.bodyFont
         }
     }
+
+    // (During-steam coaching banner is provided by upstream's LiveCoachingBanner
+    // near the top of this page, gated on Settings.app.steamCoachVisualEnabled.)
 
     // Small flashing reminder while the milk pitcher is settling on the scale
     // (something is on the scale but the capture hasn't fired yet). Disappears

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -1649,19 +1649,21 @@ Page {
                                 font: Theme.labelFont
                                 visible: text.length > 0
                                 text: {
-                                    // Track preset + global-rate changes so the hint recomputes.
+                                    // Preview the weight-timed steam at your last measured milk, under
+                                    // the current global rate. Tracks preset + global-rate + last-milk
+                                    // changes so it recomputes. Only shown while weight-timing is actually
+                                    // active (auto-capture on AND a global rate calibrated) and there IS a
+                                    // last measured milk — in that regime effectiveSteamDurationSec returns
+                                    // the weight-scaled time, so the hint matches real behaviour. Driven by
+                                    // the live lastSteamMilkG (not the retired per-preset calibMilkG, which
+                                    // has no UI left to edit and would freeze on a stale value).
                                     var _ = Settings.brew.steamPitcherPresets
                                     var __ = Settings.brew.steamSecondsPerGram
+                                    var ___ = Settings.brew.lastSteamMilkG
                                     var idx = Settings.brew.selectedSteamPitcher
-                                    var preset = Settings.brew.getSteamPitcherPreset(idx)
-                                    var cal = preset ? (preset.calibMilkG ?? 0) : 0
-                                    // Only show while weight-timing is actually active (auto-capture on
-                                    // AND a global rate calibrated). In that regime effectiveSteamDurationSec
-                                    // == the weight-scaled time, so the hint matches real behaviour. Gating
-                                    // this way avoids rendering pre-migration fixed-duration math driven by a
-                                    // vestigial per-preset calibMilkG (which has no UI left to clear).
-                                    if (cal > 0 && Settings.brew.milkAutoCaptureEnabled && Settings.brew.steamSecondsPerGram > 0)
-                                        return TranslationManager.translate("steam.hint.weightTimed", "Weight-timed") + ": " + cal.toFixed(0) + "g → " + Settings.brew.effectiveSteamDurationSec(idx, cal) + "s"
+                                    var milk = Settings.brew.lastSteamMilkG
+                                    if (milk > 0 && Settings.brew.milkAutoCaptureEnabled && Settings.brew.steamSecondsPerGram > 0)
+                                        return TranslationManager.translate("steam.hint.weightTimed", "Weight-timed") + ": " + milk.toFixed(0) + "g → " + Settings.brew.effectiveSteamDurationSec(idx, milk) + "s"
                                     return ""
                                 }
                                 Accessible.ignored: true

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -1649,12 +1649,19 @@ Page {
                                 font: Theme.labelFont
                                 visible: text.length > 0
                                 text: {
-                                    // Track preset changes via steamPitcherPresetsChanged
+                                    // Track preset + global-rate changes so the hint recomputes.
                                     var _ = Settings.brew.steamPitcherPresets
-                                    var preset = Settings.brew.getSteamPitcherPreset(Settings.brew.selectedSteamPitcher)
+                                    var __ = Settings.brew.steamSecondsPerGram
+                                    var idx = Settings.brew.selectedSteamPitcher
+                                    var preset = Settings.brew.getSteamPitcherPreset(idx)
                                     var cal = preset ? (preset.calibMilkG ?? 0) : 0
-                                    if (cal > 0)
-                                        return TranslationManager.translate("steam.hint.weightTimed", "Weight-timed") + ": " + cal.toFixed(0) + "g → " + preset.duration + "s"
+                                    // Only show while weight-timing is actually active (auto-capture on
+                                    // AND a global rate calibrated). In that regime effectiveSteamDurationSec
+                                    // == the weight-scaled time, so the hint matches real behaviour. Gating
+                                    // this way avoids rendering pre-migration fixed-duration math driven by a
+                                    // vestigial per-preset calibMilkG (which has no UI left to clear).
+                                    if (cal > 0 && Settings.brew.milkAutoCaptureEnabled && Settings.brew.steamSecondsPerGram > 0)
+                                        return TranslationManager.translate("steam.hint.weightTimed", "Weight-timed") + ": " + cal.toFixed(0) + "g → " + Settings.brew.effectiveSteamDurationSec(idx, cal) + "s"
                                     return ""
                                 }
                                 Accessible.ignored: true
@@ -1881,6 +1888,18 @@ Page {
                                     Settings.brew.steamSecondsPerGram = newValue
                                 }
                             }
+                        }
+
+                        // Honest framing: one global rate across all pitchers is a
+                        // simplification, since presets still carry independent flow/temp.
+                        Tr {
+                            key: "steam.rate.note"
+                            fallback: "Simplification: the rate is calibrated once and applied to every pitcher. Presets can still carry their own flow and temperature, so this is a simpler mental model rather than an exact physical guarantee."
+                            Layout.fillWidth: true
+                            color: Theme.textSecondaryColor
+                            font: Theme.labelFont
+                            opacity: 0.85
+                            wrapMode: Text.WordWrap
                         }
 
                         // Calibrate from the last actual steam session (milk + time) —

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -68,6 +68,34 @@ SettingsBrew::SettingsBrew(QObject* parent)
         m_settings.setValue("flush/presets", QJsonDocument(defaults).toJson());
     }
 
+    // One-time migration: weight-timed steaming is now a GLOBAL seconds-per-gram
+    // rate (same steam flow on every pitcher) instead of per-pitcher reference milk.
+    // Existing calibrated users had (calibMilkG, duration) stored per preset; seed
+    // the global rate from the first preset that has both so they aren't reset. Runs
+    // after the preset-seeding block above so the presets are present. Done in the
+    // ctor (not the getter) to avoid a const getter mutating QSettings mid-read.
+    //
+    // Gated by a run-once SENTINEL, not by "rate <= 0" — legacy calibMilkG is left in
+    // place (other readers still use it), so a bare "rate <= 0" guard would re-seed the
+    // old rate every launch and silently undo a user who deliberately uncalibrated
+    // (the new ± control allows 0).
+    if (!m_settings.value("steam/steamRateMigrated", false).toBool()) {
+        if (m_settings.value("steam/steamSecondsPerGram", 0.0).toDouble() <= 0.0) {
+            QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
+            QJsonArray arr = QJsonDocument::fromJson(data).array();
+            for (const QJsonValue& v : arr) {
+                QJsonObject preset = v.toObject();
+                double calibMilk = preset.value("calibMilkG").toDouble(0.0);
+                double duration  = preset.value("duration").toDouble(0.0);
+                if (calibMilk > 0.0 && duration > 0.0) {
+                    m_settings.setValue("steam/steamSecondsPerGram", duration / calibMilk);
+                    break;  // first calibrated preset wins
+                }
+            }
+        }
+        m_settings.setValue("steam/steamRateMigrated", true);
+    }
+
     // Load persistent brew overrides into the cache (Settings used to do this).
     m_hasTemperatureOverride = m_settings.value("brew/hasTemperatureOverride", false).toBool();
     if (m_hasTemperatureOverride) {
@@ -202,6 +230,25 @@ void SettingsBrew::setLastSteamTimeS(double s) {
         m_settings.setValue("steam/lastSteamTimeS", s);
         emit lastSteamTimeSChanged();
     }
+}
+
+double SettingsBrew::steamSecondsPerGram() const {
+    return m_settings.value("steam/steamSecondsPerGram", 0.0).toDouble();
+}
+void SettingsBrew::setSteamSecondsPerGram(double secPerGram) {
+    if (secPerGram < 0) secPerGram = 0;  // 0 = uncalibrated; never negative
+    if (!qFuzzyCompare(1.0 + steamSecondsPerGram(), 1.0 + secPerGram)) {
+        m_settings.setValue("steam/steamSecondsPerGram", secPerGram);
+        emit steamSecondsPerGramChanged();
+    }
+}
+
+void SettingsBrew::calibrateSteamFromReference(double milkG, double timeSec) {
+    if (milkG <= 0.0 || timeSec <= 0.0) return;  // guarded — need both to derive a rate
+    setSteamSecondsPerGram(timeSec / milkG);
+    // Weight-timed steaming is off by default; calibrating is the explicit opt-in,
+    // mirroring the old per-pitcher setSteamPitcherCalibration behaviour.
+    setMilkAutoCaptureEnabled(true);
 }
 
 bool SettingsBrew::doseCaptureSoundEnabled() const {
@@ -448,10 +495,12 @@ int SettingsBrew::scaledSteamTime(int index, double milkG) const {
     if (!milkAutoCaptureEnabled()) return 0;  // toggle gates ALL weight scaling, not just auto-capture
     QVariantMap p = getSteamPitcherPreset(index);
     if (p.isEmpty() || p.value("disabled").toBool()) return 0;
-    double calibMilk = p.value("calibMilkG", 0.0).toDouble();
-    double duration  = p.value("duration", 0.0).toDouble();
-    if (calibMilk <= 0.0 || duration <= 0.0 || milkG <= 0.0) return 0;
-    return qBound(5, qRound(duration * (milkG / calibMilk)), 120);
+    if (milkG <= 0.0) return 0;
+    // Pitcher-agnostic: one global seconds-per-gram rate for every pitcher (same
+    // steam flow), no longer reads the per-preset calibMilkG/duration for scaling.
+    double secPerGram = steamSecondsPerGram();
+    if (secPerGram <= 0.0) return 0;  // uncalibrated
+    return qBound(5, qRound(secPerGram * milkG), 120);
 }
 
 int SettingsBrew::effectiveSteamDurationSec(int index, double milkG) const {

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -69,29 +69,25 @@ SettingsBrew::SettingsBrew(QObject* parent)
     }
 
     // One-time migration: weight-timed steaming is now a GLOBAL seconds-per-gram
-    // rate (same steam flow on every pitcher) instead of per-pitcher reference milk.
-    // Existing calibrated users had (calibMilkG, duration) stored per preset; seed
-    // the global rate from the first preset that has both so they aren't reset. Runs
-    // after the preset-seeding block above so the presets are present. Done in the
-    // ctor (not the getter) to avoid a const getter mutating QSettings mid-read.
+    // rate instead of per-pitcher reference milk. The rate assumes a consistent
+    // steam flow across pitchers (presets may still override flow — see the honest
+    // note in the SteamPage UI); it is a simpler one-calibration model, not a
+    // physical guarantee. Existing calibrated users had (calibMilkG, duration)
+    // stored per preset; seed the global rate from the first preset that has both
+    // so they aren't reset. Runs after the preset-seeding block above so the presets
+    // are present. Done in the ctor (not the getter) to avoid a const getter mutating
+    // QSettings mid-read.
     //
-    // Gated by a run-once SENTINEL, not by "rate <= 0" — legacy calibMilkG is left in
-    // place (other readers still use it), so a bare "rate <= 0" guard would re-seed the
-    // old rate every launch and silently undo a user who deliberately uncalibrated
-    // (the new ± control allows 0).
+    // The run-once gate is the SENTINEL, not a "rate <= 0" check. Legacy calibMilkG
+    // is left in storage (old backups still carry it, and it re-seeds the rate on
+    // import — see importFromJson), so a bare "rate <= 0" guard would re-seed the old
+    // rate every launch and silently undo a user who deliberately uncalibrated (the
+    // new ± control allows 0). The inner "rate <= 0" check below is a one-time
+    // don't-clobber-an-existing-rate guard, distinct from the run-once gate.
     if (!m_settings.value("steam/steamRateMigrated", false).toBool()) {
         if (m_settings.value("steam/steamSecondsPerGram", 0.0).toDouble() <= 0.0) {
-            QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-            QJsonArray arr = QJsonDocument::fromJson(data).array();
-            for (const QJsonValue& v : arr) {
-                QJsonObject preset = v.toObject();
-                double calibMilk = preset.value("calibMilkG").toDouble(0.0);
-                double duration  = preset.value("duration").toDouble(0.0);
-                if (calibMilk > 0.0 && duration > 0.0) {
-                    m_settings.setValue("steam/steamSecondsPerGram", duration / calibMilk);
-                    break;  // first calibrated preset wins
-                }
-            }
+            double seeded = deriveSteamRateFromLegacyPresets();
+            if (seeded > 0.0) m_settings.setValue("steam/steamSecondsPerGram", seeded);
         }
         m_settings.setValue("steam/steamRateMigrated", true);
     }
@@ -249,6 +245,29 @@ void SettingsBrew::calibrateSteamFromReference(double milkG, double timeSec) {
     // Weight-timed steaming is off by default; calibrating is the explicit opt-in,
     // mirroring the old per-pitcher setSteamPitcherCalibration behaviour.
     setMilkAutoCaptureEnabled(true);
+}
+
+double SettingsBrew::deriveSteamRateFromLegacyPresets() const {
+    // Recover a global seconds-per-gram rate from the pre-migration per-pitcher
+    // (calibMilkG, duration): the first preset carrying both wins. Returns 0 when no
+    // preset was calibrated. Shared by the one-time ctor migration and the backup-
+    // import re-seed so both derive the rate identically.
+    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
+    QJsonArray arr = QJsonDocument::fromJson(data).array();
+    for (const QJsonValue& v : arr) {
+        QJsonObject preset = v.toObject();
+        double calibMilk = preset.value("calibMilkG").toDouble(0.0);
+        double duration  = preset.value("duration").toDouble(0.0);
+        if (calibMilk > 0.0 && duration > 0.0) return duration / calibMilk;
+    }
+    return 0.0;
+}
+
+void SettingsBrew::seedSteamRateFromLegacyPresets() {
+    // Only seed a positive derived rate — never clobber the caller's rate with 0 when
+    // no legacy calibration is present. Goes through the setter so QML is notified.
+    double seeded = deriveSteamRateFromLegacyPresets();
+    if (seeded > 0.0) setSteamSecondsPerGram(seeded);
 }
 
 bool SettingsBrew::doseCaptureSoundEnabled() const {
@@ -496,8 +515,9 @@ int SettingsBrew::scaledSteamTime(int index, double milkG) const {
     QVariantMap p = getSteamPitcherPreset(index);
     if (p.isEmpty() || p.value("disabled").toBool()) return 0;
     if (milkG <= 0.0) return 0;
-    // Pitcher-agnostic: one global seconds-per-gram rate for every pitcher (same
-    // steam flow), no longer reads the per-preset calibMilkG/duration for scaling.
+    // One global seconds-per-gram rate for every pitcher (assumes a consistent steam
+    // flow — a simplification, not a physical guarantee; see the SteamPage note). No
+    // longer reads the per-preset calibMilkG/duration for scaling.
     double secPerGram = steamSecondsPerGram();
     if (secPerGram <= 0.0) return 0;  // uncalibrated
     return qBound(5, qRound(secPerGram * milkG), 120);

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -40,7 +40,8 @@ class SettingsBrew : public QObject {
     Q_PROPERTY(double lastSteamMilkG READ lastSteamMilkG WRITE setLastSteamMilkG NOTIFY lastSteamMilkGChanged)
     Q_PROPERTY(double lastSteamTimeS READ lastSteamTimeS WRITE setLastSteamTimeS NOTIFY lastSteamTimeSChanged)
     // Global weight-timed steam rate (seconds of steam per gram of milk). One
-    // calibration for every pitcher (same steam flow), replacing per-pitcher
+    // calibration for every pitcher (assumes a consistent steam flow — a
+    // simplification, not a physical guarantee), replacing per-pitcher
     // reference-milk scaling. 0 = uncalibrated. Clamped >= 0.
     Q_PROPERTY(double steamSecondsPerGram READ steamSecondsPerGram WRITE setSteamSecondsPerGram NOTIFY steamSecondsPerGramChanged)
 
@@ -129,6 +130,11 @@ public:
     // timeSec / milkG. Guarded (both > 0). Turns weight-timed steaming on, matching
     // the old per-pitcher calibrate opt-in.
     Q_INVOKABLE void calibrateSteamFromReference(double milkG, double timeSec);
+    // Derive a global rate from the legacy per-pitcher (calibMilkG, duration) — first
+    // calibrated preset wins, 0 if none. Shared by the ctor migration and the backup-
+    // import re-seed. seed…() applies it (positive only) through the setter.
+    double deriveSteamRateFromLegacyPresets() const;
+    void seedSteamRateFromLegacyPresets();
 
     // Steam
     double steamTemperature() const;

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -39,6 +39,10 @@ class SettingsBrew : public QObject {
     // setup can adopt them as a new reference baseline.
     Q_PROPERTY(double lastSteamMilkG READ lastSteamMilkG WRITE setLastSteamMilkG NOTIFY lastSteamMilkGChanged)
     Q_PROPERTY(double lastSteamTimeS READ lastSteamTimeS WRITE setLastSteamTimeS NOTIFY lastSteamTimeSChanged)
+    // Global weight-timed steam rate (seconds of steam per gram of milk). One
+    // calibration for every pitcher (same steam flow), replacing per-pitcher
+    // reference-milk scaling. 0 = uncalibrated. Clamped >= 0.
+    Q_PROPERTY(double steamSecondsPerGram READ steamSecondsPerGram WRITE setSteamSecondsPerGram NOTIFY steamSecondsPerGramChanged)
 
     // Steam
     Q_PROPERTY(double steamTemperature READ steamTemperature WRITE setSteamTemperature NOTIFY steamTemperatureChanged)
@@ -118,6 +122,13 @@ public:
     void setLastSteamMilkG(double g);
     double lastSteamTimeS() const;
     void setLastSteamTimeS(double s);
+
+    double steamSecondsPerGram() const;
+    void setSteamSecondsPerGram(double secPerGram);
+    // Calibrate the global steam rate from one observed steam: secPerGram =
+    // timeSec / milkG. Guarded (both > 0). Turns weight-timed steaming on, matching
+    // the old per-pitcher calibrate opt-in.
+    Q_INVOKABLE void calibrateSteamFromReference(double milkG, double timeSec);
 
     // Steam
     double steamTemperature() const;
@@ -253,6 +264,7 @@ signals:
     void doseCaptureSoundEnabledChanged();
     void lastSteamMilkGChanged();
     void lastSteamTimeSChanged();
+    void steamSecondsPerGramChanged();
     void steamTemperatureChanged();
     void steamTimeoutChanged();
     void steamFlowChanged();

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -74,6 +74,7 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
     steam["twoTapStop"] = settings->hardware()->steamTwoTapStop();
     steam["selectedPitcher"] = settings->brew()->selectedSteamPitcher();
     steam["milkAutoCaptureEnabled"] = settings->brew()->milkAutoCaptureEnabled();
+    steam["steamSecondsPerGram"] = settings->brew()->steamSecondsPerGram();
 
     // Steam pitcher presets
     QJsonArray pitcherPresets;
@@ -488,6 +489,7 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         // calibrated preset clobber a backup where the user had the feature OFF.
         // The serialized value must win.
         if (steam.contains("milkAutoCaptureEnabled")) settings->brew()->setMilkAutoCaptureEnabled(steam["milkAutoCaptureEnabled"].toBool());
+        if (steam.contains("steamSecondsPerGram")) settings->brew()->setSteamSecondsPerGram(steam["steamSecondsPerGram"].toDouble());
         // Apply the selected pitcher AFTER any preset rebuild (and regardless of
         // whether this JSON carried a presets array) — setting it mid-rebuild would
         // leave it clamped to a stale index. Out-of-range is dropped with a log.

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -489,7 +489,17 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         // calibrated preset clobber a backup where the user had the feature OFF.
         // The serialized value must win.
         if (steam.contains("milkAutoCaptureEnabled")) settings->brew()->setMilkAutoCaptureEnabled(steam["milkAutoCaptureEnabled"].toBool());
-        if (steam.contains("steamSecondsPerGram")) settings->brew()->setSteamSecondsPerGram(steam["steamSecondsPerGram"].toDouble());
+        if (steam.contains("steamSecondsPerGram")) {
+            settings->brew()->setSteamSecondsPerGram(steam["steamSecondsPerGram"].toDouble());
+        } else {
+            // Pre-migration backup: no global rate stored, but restored presets may
+            // carry the old per-pitcher (calibMilkG, duration). Re-derive the rate the
+            // same way the one-time ctor migration does, so weight-timed steaming
+            // survives a cross-version restore instead of silently reverting to base
+            // duration with milkAutoCapture still shown ON. Positive-only, so a backup
+            // with no calibrated preset leaves the rate untouched.
+            settings->brew()->seedSteamRateFromLegacyPresets();
+        }
         // Apply the selected pitcher AFTER any preset rebuild (and regardless of
         // whether this JSON carried a presets array) — setting it mid-rebuild would
         // leave it clamped to a stale index. Out-of-range is dropped with a log.

--- a/src/mcp/mcptools_presets.cpp
+++ b/src/mcp/mcptools_presets.cpp
@@ -115,8 +115,10 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
         "steam_pitcher_list",
         "List all steam pitcher presets and which one is currently selected. Each preset has a "
         "name, durationSec, flowMlPerSec and temperatureC (per-pitcher steam temperature). "
-        "Disabled \"Off\" presets only carry name + disabled. pitcherWeightG / calibMilkG appear "
-        "when the pitcher has been weighed / calibrated for weight-scaled steaming.",
+        "Disabled \"Off\" presets only carry name + disabled. pitcherWeightG is the saved "
+        "empty-pitcher weight (for net-milk capture). calibMilkG is a legacy per-pitcher "
+        "reference weight, no longer used for scaling — weight-timed steaming now uses a single "
+        "global rate (steamSecondsPerGram in settings), not per-pitcher calibration.",
         QJsonObject{{"type", "object"}, {"properties", QJsonObject{}}},
         [settings](const QJsonObject&) -> QJsonObject {
             QJsonObject result;

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -98,6 +98,7 @@ private:
     QByteArray m_origVesselPresets;
     QByteArray m_origPitcherPresets;
     bool m_origMilkAutoCapture;
+    double m_origSteamSecPerGram;
     int m_origActiveRecipeId;
 
 private slots:
@@ -123,6 +124,8 @@ private slots:
         // Mutated directly by the effectiveSteamDurationSec tests AND as a side effect of
         // setSteamPitcherCalibration (calibrating re-enables weight-timed steaming).
         m_origMilkAutoCapture = m_settings.brew()->milkAutoCaptureEnabled();
+        // Weight-timed scaling is now driven by a GLOBAL seconds-per-gram rate.
+        m_origSteamSecPerGram = m_settings.brew()->steamSecondsPerGram();
         { QSettings raw("DecentEspresso", "DE1Qt");
           m_origVesselPresets = raw.value("water/vesselPresets").toByteArray();
           m_origPitcherPresets = raw.value("steam/pitcherPresets").toByteArray(); }
@@ -148,6 +151,7 @@ private slots:
         m_settings.brew()->setWaterTemperature(m_origWaterTemperature);
         m_settings.app()->setTemperatureUnit(m_origTemperatureUnit);
         m_settings.brew()->setMilkAutoCaptureEnabled(m_origMilkAutoCapture);
+        m_settings.brew()->setSteamSecondsPerGram(m_origSteamSecPerGram);
         { QSettings raw("DecentEspresso", "DE1Qt");
           raw.setValue("water/vesselPresets", m_origVesselPresets);
           raw.setValue("steam/pitcherPresets", m_origPitcherPresets);
@@ -566,15 +570,16 @@ private slots:
     }
 
     void effectiveSteamDurationSecClampsScaledTime() {
-        // The scaled path is clamped to [5,120]s; a huge milk-to-calibration ratio
-        // must cap at 120, not program a multi-minute steam.
+        // The scaled path is clamped to [5,120]s; a large rate × milk product
+        // must cap at 120, not program a multi-minute steam. Scaling is now the
+        // GLOBAL seconds-per-gram rate, not per-pitcher reference milk.
         m_settings.brew()->addSteamPitcherPreset("Jug", 30, 150, 135.0);
         const int idx = static_cast<int>(m_settings.brew()->steamPitcherPresets().size()) - 1;
-        m_settings.brew()->setSteamPitcherCalibration(idx, 100.0);  // also enables the toggle
+        m_settings.brew()->calibrateSteamFromReference(100.0, 30.0);  // 0.30 s/g; also enables the toggle
 
-        // Unclamped: 30 * (600/100) = 180 → clamped to 120.
+        // Unclamped: 0.30 * 600 = 180 → clamped to 120.
         QCOMPARE(m_settings.brew()->effectiveSteamDurationSec(idx, 600.0), 120);
-        // Floor: 30 * (10/100) = 3 → clamped to 5, not a blink-and-miss 3s steam.
+        // Floor: 0.30 * 10 = 3 → clamped to 5, not a blink-and-miss 3s steam.
         QCOMPARE(m_settings.brew()->effectiveSteamDurationSec(idx, 10.0), 5);
     }
 
@@ -591,14 +596,13 @@ private slots:
     }
 
     void effectiveSteamDurationSecUsesScaledTimeWhenAvailable() {
-        // Weight-timed steaming ON + calibrated preset + positive milk: the scaled
+        // Weight-timed steaming ON + a global rate + positive milk: the scaled
         // value wins over the base duration (the PR's core new behavior).
-        m_settings.brew()->setMilkAutoCaptureEnabled(true);
         m_settings.brew()->addSteamPitcherPreset("Latte", 30, 150, 135.0);
         const int idx = static_cast<int>(m_settings.brew()->steamPitcherPresets().size()) - 1;
-        m_settings.brew()->setSteamPitcherCalibration(idx, 200.0);
+        m_settings.brew()->calibrateSteamFromReference(200.0, 30.0);  // 0.15 s/g; also enables the toggle
 
-        // duration * (milk / calibMilk) = 30 * (400/200) = 60
+        // secPerGram * milk = 0.15 * 400 = 60 (pitcher-agnostic; base 30s is ignored).
         QCOMPARE(m_settings.brew()->effectiveSteamDurationSec(idx, 400.0), 60);
     }
 

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -635,13 +635,146 @@ private slots:
     }
 
     void effectiveSteamDurationSecFallsBackWhenUncalibrated() {
-        // Weight-timing on but no calibration recorded: scaledSteamTime() yields 0
-        // (calibMilkG <= 0), so the base duration must be used, not 0.
+        // Weight-timing on but no global rate recorded: scaledSteamTime() yields 0
+        // (steamSecondsPerGram <= 0), so the base duration must be used, not 0. Set
+        // the rate to 0 explicitly so the test exercises the uncalibrated gate rather
+        // than relying on the ambient store value.
         m_settings.brew()->setMilkAutoCaptureEnabled(true);
+        m_settings.brew()->setSteamSecondsPerGram(0.0);
         m_settings.brew()->addSteamPitcherPreset("Cortado", 20, 150, 135.0);
         const int idx = static_cast<int>(m_settings.brew()->steamPitcherPresets().size()) - 1;
 
         QCOMPARE(m_settings.brew()->effectiveSteamDurationSec(idx, 300.0), 20);
+    }
+
+    void steamSecondsPerGramClampsNegativeToZero() {
+        // A negative rate is nonsensical; the setter must clamp it to 0 (uncalibrated).
+        m_settings.brew()->setSteamSecondsPerGram(-1.0);
+        QCOMPARE(m_settings.brew()->steamSecondsPerGram(), 0.0);
+    }
+
+    void steamSecondsPerGramEmitsOnChangeOnly() {
+        // NOTIFY fires once on a real change and stays silent on a no-op re-set.
+        m_settings.brew()->setSteamSecondsPerGram(0.10);
+        QSignalSpy spy(m_settings.brew(), &SettingsBrew::steamSecondsPerGramChanged);
+        m_settings.brew()->setSteamSecondsPerGram(0.20);   // change -> 1 emit
+        QCOMPARE(spy.count(), 1);
+        m_settings.brew()->setSteamSecondsPerGram(0.20);   // no-op -> no further emit
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void calibrateSteamFromReferenceSetsRateAndEnables() {
+        // The happy path: rate = timeSec / milkG, and weight-timing is turned on as the
+        // explicit calibrate opt-in.
+        m_settings.brew()->setMilkAutoCaptureEnabled(false);
+        m_settings.brew()->setSteamSecondsPerGram(0.0);
+        m_settings.brew()->calibrateSteamFromReference(200.0, 30.0);  // 0.15 s/g
+        QCOMPARE(m_settings.brew()->steamSecondsPerGram(), 0.15);
+        QVERIFY(m_settings.brew()->milkAutoCaptureEnabled());
+    }
+
+    void calibrateSteamFromReferenceGuardsNonPositive() {
+        // With either argument non-positive the call is a no-op — no divide-by-zero
+        // rate, and (critically) it must NOT enable weight-timing off a bad calibration.
+        m_settings.brew()->setMilkAutoCaptureEnabled(false);
+        m_settings.brew()->setSteamSecondsPerGram(0.0);
+        m_settings.brew()->calibrateSteamFromReference(0.0, 30.0);    // no milk
+        m_settings.brew()->calibrateSteamFromReference(200.0, 0.0);   // no time
+        QCOMPARE(m_settings.brew()->steamSecondsPerGram(), 0.0);
+        QVERIFY(!m_settings.brew()->milkAutoCaptureEnabled());
+    }
+
+    void steamSecondsPerGramRoundTrip() {
+        // The global rate must survive an export -> import cycle (it's the whole
+        // weight-timed-steam calibration — losing it on a device migration would
+        // silently disable the feature).
+        m_settings.brew()->setSteamSecondsPerGram(0.22);
+        QJsonObject bundle = SettingsSerializer::exportToJson(&m_settings, false);
+
+        m_settings.brew()->setSteamSecondsPerGram(0.99);   // mutate to prove import overwrites
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(QStringLiteral("SettingsSerializer: importFromJson replacing .* favorites")));
+        QVERIFY(SettingsSerializer::importFromJson(&m_settings, bundle));
+
+        QCOMPARE(m_settings.brew()->steamSecondsPerGram(), 0.22);
+    }
+
+    void steamRateMigrationSeedsFromLegacyPreset() {
+        // The one-time ctor migration seeds the global rate from the FIRST legacy
+        // preset carrying both (calibMilkG, duration). Snapshot the run-once sentinel
+        // because cleanup() doesn't restore it.
+        bool origMigrated;
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          origMigrated = raw.value("steam/steamRateMigrated", false).toBool(); }
+
+        QJsonArray arr;
+        { QJsonObject p; p["name"] = "Small"; p["duration"] = 30; p["flow"] = 150; p["calibMilkG"] = 200; arr.append(p); }
+        { QJsonObject p; p["name"] = "Large"; p["duration"] = 40; p["flow"] = 150; p["calibMilkG"] = 100; arr.append(p); }
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          raw.setValue("steam/pitcherPresets", QJsonDocument(arr).toJson());
+          raw.remove("steam/steamSecondsPerGram");             // uncalibrated global rate
+          raw.setValue("steam/steamRateMigrated", false);      // allow the one-time seed to run
+          raw.sync(); }
+
+        // A fresh Settings runs the migration in SettingsBrew's ctor. First preset wins:
+        // 30/200 = 0.15, not the second's 40/100 = 0.40.
+        Settings fresh;
+        QCOMPARE(fresh.brew()->steamSecondsPerGram(), 0.15);
+
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          raw.setValue("steam/steamRateMigrated", origMigrated);
+          raw.sync(); }
+        // cleanup() restores steam/pitcherPresets + steamSecondsPerGram.
+    }
+
+    void steamRateMigrationSentinelPreventsReseed() {
+        // A calibrated legacy preset is present, but the sentinel says migration already
+        // ran and the user deliberately left the rate at 0 (via the ± control). The ctor
+        // must NOT re-seed — this is why the gate is the sentinel, not "rate <= 0".
+        bool origMigrated;
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          origMigrated = raw.value("steam/steamRateMigrated", false).toBool(); }
+
+        QJsonArray arr;
+        { QJsonObject p; p["name"] = "Small"; p["duration"] = 30; p["flow"] = 150; p["calibMilkG"] = 200; arr.append(p); }
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          raw.setValue("steam/pitcherPresets", QJsonDocument(arr).toJson());
+          raw.setValue("steam/steamSecondsPerGram", 0.0);      // deliberately uncalibrated
+          raw.setValue("steam/steamRateMigrated", true);       // already migrated
+          raw.sync(); }
+
+        Settings fresh;
+        QCOMPARE(fresh.brew()->steamSecondsPerGram(), 0.0);
+
+        { QSettings raw("DecentEspresso", "DE1Qt");
+          raw.setValue("steam/steamRateMigrated", origMigrated);
+          raw.sync(); }
+    }
+
+    void steamRateImportReseedsFromLegacyBackup() {
+        // A pre-migration backup carries per-pitcher calibMilkG but NO steamSecondsPerGram
+        // key. Import must re-derive the global rate from the restored presets, so
+        // weight-timed steaming survives a cross-version restore instead of coming back
+        // dead (auto-capture ON, rate 0). Guards the reseed branch in importFromJson.
+        QJsonObject bundle = SettingsSerializer::exportToJson(&m_settings, false);
+        QJsonObject steam = bundle["steam"].toObject();
+        // Deterministic single legacy preset; strip the global-rate key to mimic an old
+        // backup, and mark weight-timing ON as a pre-PR calibrated backup would.
+        QJsonArray presets;
+        { QJsonObject p; p["name"] = "Legacy"; p["duration"] = 30; p["flow"] = 150; p["temperature"] = 135; p["calibMilkG"] = 200; presets.append(p); }
+        steam["pitcherPresets"] = presets;
+        steam["milkAutoCaptureEnabled"] = true;
+        steam.remove("steamSecondsPerGram");
+        bundle["steam"] = steam;
+
+        m_settings.brew()->setSteamSecondsPerGram(0.0);   // clear so the reseed is observable
+
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(QStringLiteral("SettingsSerializer: importFromJson replacing .* favorites")));
+        QVERIFY(SettingsSerializer::importFromJson(&m_settings, bundle));
+
+        // duration / calibMilkG = 30 / 200 = 0.15.
+        QCOMPARE(m_settings.brew()->steamSecondsPerGram(), 0.15);
     }
 
     void steamPitcherLegacyTemperatureFallsBackToGlobal() {


### PR DESCRIPTION
## What

Replaces the **per-pitcher** weight-timed steam calibration with a **single global "seconds per gram of milk"** rate. Calibrate once; every pitcher then finishes at the same temperature regardless of milk volume.

## Why

Today each steam-pitcher preset carries its own `calibMilkG` + `duration`, and the stop time is `duration × (milk / calibMilkG)` — **per pitcher**. So calibrating the large pitcher does nothing for the small one; switch pitchers and the calibration is effectively gone. Yet the section's own help text already promises *"calibrate once — a small or large pitcher both finish at the same temperature."* The copy describes the desired behavior; the implementation didn't deliver it.

Physically, steam time to bring milk to temperature is driven by **milk mass** (× ΔT ÷ steam power) — so at a consistent steam flow, **seconds-per-gram is the same across pitchers**. A single global rate is both simpler and what the feature already claims to do.

## How

- New `Settings.brew.steamSecondsPerGram` (default 0 = uncalibrated), serialized for portability.
- `scaledSteamTime()` now returns `qBound(5, qRound(secPerGram × milkG), 120)`, keeping the existing gates (weight-timing enabled, preset not disabled, milk present, rate set). No longer reads per-preset `calibMilkG`/`duration` for scaling.
- `calibrateSteamFromReference(milkG, timeSec)` sets `rate = timeSec / milkG`. The SteamPage **"Use last steam"** button calls it with the last session's measured milk + steam time (calibrate straight from a good pour); a manual ± control is also provided.
- **One-time, sentinel-guarded migration** seeds the global rate from an existing calibrated preset (`duration / calibMilkG`) so upgraders keep their calibration. The sentinel (`steam/steamRateMigrated`), not `rate <= 0`, is the guard — so a user who deliberately sets the rate (including to 0) is never re-seeded.
- The per-pitcher `calibMilkG` / `setSteamPitcherCalibration` are **left in place** — no longer used for scaling, but still read by display code (the steam-plan hint); freshly-calibrated users (`calibMilkG == 0`) degrade gracefully there.
- SteamPage UI: the per-pitcher "Reference milk" stepper is replaced by a global rate readout + manual adjust + "Use last steam". The master weight-timing toggle is unchanged.

Theme tokens + i18n + accessibility throughout; unit tests updated to drive the global rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note for reviewers

The migration is one-time (sentinel `steam/steamRateMigrated`) and runs at construction. Restoring an **old, pre-feature backup** afterward brings back per-preset `calibMilkG` but won't re-run the seed, so `steamSecondsPerGram` stays 0 (weight-timing off until re-calibrated). It degrades safely — base duration is used, no crash — and the "Weight-timed: Xg→Ys" hint still renders from the restored `calibMilkG`. Flagging as a design edge, not a defect; happy to add an import-time re-seed if you'd prefer.
