### PR TITLE
Fix Recipes-first upgrade replacing Profiles instead of swapping it

### DIFF
--- a/src/core/settings_network.cpp
+++ b/src/core/settings_network.cpp
@@ -716,11 +716,8 @@ void SettingsNetwork::applyRecipesFirstUpgrade() {
     static const QSet<QString> kCenterZones = {
         QStringLiteral("centerTop"), QStringLiteral("centerMiddle"), QStringLiteral("centerStatus")
     };
-    static const QSet<QString> kBarZones = {
-        QStringLiteral("topLeft"), QStringLiteral("topRight"),
-        QStringLiteral("bottomLeft"), QStringLiteral("bottomRight")
-    };
 
+    // Does any zone in `zoneNames` hold a widget of `type`?
     auto zoneSetContainsType = [&zones](const QSet<QString>& zoneNames, const QLatin1String& type) {
         for (const QString& zoneName : zoneNames) {
             const QJsonArray items = zones.value(zoneName).toArray();
@@ -730,8 +727,18 @@ void SettingsNetwork::applyRecipesFirstUpgrade() {
         }
         return false;
     };
+    // Does ANY zone hold a widget of `type` — including the unclassified
+    // lowerMidBar/statusBar bands that are neither "center" nor "bar"?
+    auto layoutContainsType = [&zones](const QLatin1String& type) {
+        for (const QString& zoneName : zones.keys()) {
+            const QJsonArray items = zones.value(zoneName).toArray();
+            for (const QJsonValue& v : items)
+                if (v.toObject()["type"].toString() == type)
+                    return true;
+        }
+        return false;
+    };
 
-    const bool espressoInBar = zoneSetContainsType(kBarZones, QLatin1String("espresso"));
     const bool espressoInCenter = zoneSetContainsType(kCenterZones, QLatin1String("espresso"));
 
     // Swap Recipes into the Profiles (espresso) button's center slot and move
@@ -740,17 +747,21 @@ void SettingsNetwork::applyRecipesFirstUpgrade() {
     // their Recipes button) elsewhere, so both are left untouched.
     //
     // The swap RELOCATES the existing Recipes button into the Profiles slot
-    // rather than only inserting one when none exists. getLayoutObject() (called
-    // above) always leaves a Recipes button via the passive add-recipes
-    // injection — by default immediately left of Profiles — so the former
-    // "insert only if !hasRecipes" guard was dead code: a user whose Recipes
-    // button lived anywhere but the center (e.g. the bottom bar) had Profiles
-    // pulled out of the center with nothing put in its place.
+    // rather than only inserting one when none exists — the fix for the former
+    // "insert only if !hasRecipes" guard, which was dead code: by the time this
+    // ran, getLayoutObject() (called above) had already injected a Recipes
+    // button (by default immediately left of Profiles), so hasRecipes was always
+    // true. A user whose Recipes button lived anywhere but the center (e.g. the
+    // bottom bar) thus had Profiles pulled out with nothing put in its place.
+    // Correctness no longer depends on that injection: the recipesItem default
+    // below drops a Recipes button into the slot even if none is found; an
+    // existing button is reused only to carry its id/options across.
     if (espressoInCenter) {
         // Pull every existing Recipes item out (dedupe), remembering one to
         // reuse so its id and any per-instance options survive. Removing them
-        // first keeps the Profiles index we find next correct even when a
-        // Recipes item shared the same center zone.
+        // all first — rather than overwriting Profiles in place and leaving the
+        // others — is what guarantees exactly one Recipes button remains when a
+        // Recipes item already shares Profiles' center zone.
         QJsonObject recipesItem{{"type", "recipes"}, {"id", "recipes1"}};
         bool haveRecipesItem = false;
         for (const QString& zoneName : zones.keys()) {
@@ -786,9 +797,11 @@ void SettingsNetwork::applyRecipesFirstUpgrade() {
         }
 
         // Relocate Profiles to the bottom bar — after Equipment, falling back to
-        // before Settings, then to appending — unless it already exists in a bar
-        // zone (nothing to relocate, and no duplicate is created).
-        if (!espressoInBar) {
+        // before Settings, then to appending — but only if the swap left no
+        // Profiles button anywhere else: a bar copy, one the user parked in
+        // lowerMidBar/statusBar, or a second center zone all count, so a
+        // duplicate is never created.
+        if (!layoutContainsType(QLatin1String("espresso"))) {
             const QJsonObject espressoItem{{"type", "espresso"}, {"id", "espresso1"}};
             QJsonArray br = zones.value("bottomRight").toArray();
             int insertAt = -1;

--- a/src/core/settings_network.cpp
+++ b/src/core/settings_network.cpp
@@ -721,84 +721,95 @@ void SettingsNetwork::applyRecipesFirstUpgrade() {
         QStringLiteral("bottomLeft"), QStringLiteral("bottomRight")
     };
 
-    bool espressoInBar = false;
-    for (const QString& zoneName : kBarZones) {
-        const QJsonArray items = zones.value(zoneName).toArray();
-        for (const QJsonValue& v : items) {
-            if (v.toObject()["type"].toString() == QLatin1String("espresso")) {
-                espressoInBar = true;
-                break;
-            }
-        }
-        if (espressoInBar) break;
-    }
-
-    bool espressoRemovedFromCenter = false;
-    QString espressoZone;
-    int espressoIndex = -1;
-    for (const QString& zoneName : kCenterZones) {
-        QJsonArray items = zones.value(zoneName).toArray();
-        for (qsizetype i = 0; i < items.size(); ++i) {
-            if (items[i].toObject()["type"].toString() == QLatin1String("espresso")) {
-                espressoZone = zoneName;
-                espressoIndex = static_cast<int>(i);
-                items.removeAt(i);
-                zones[zoneName] = items;
-                espressoRemovedFromCenter = true;
-                break;
-            }
-        }
-        if (espressoRemovedFromCenter) break;
-    }
-
-    // Insert Recipes at the espresso button's former center position, but only
-    // if it removed an espresso item from the center and no Recipes item
-    // exists anywhere yet (the pre-existing add-recipes injection may already
-    // have placed one).
-    if (espressoRemovedFromCenter) {
-        bool hasRecipes = false;
-        for (const QString& zoneName : zones.keys()) {
+    auto zoneSetContainsType = [&zones](const QSet<QString>& zoneNames, const QLatin1String& type) {
+        for (const QString& zoneName : zoneNames) {
             const QJsonArray items = zones.value(zoneName).toArray();
-            for (const QJsonValue& v : items) {
-                if (v.toObject()["type"].toString() == QLatin1String("recipes")) {
-                    hasRecipes = true;
-                    break;
-                }
-            }
-            if (hasRecipes) break;
+            for (const QJsonValue& v : items)
+                if (v.toObject()["type"].toString() == type)
+                    return true;
         }
-        if (!hasRecipes) {
-            QJsonArray items = zones.value(espressoZone).toArray();
-            const int insertAt = qBound(0, espressoIndex, static_cast<int>(items.size()));
-            items.insert(insertAt, QJsonObject{{"type", "recipes"}, {"id", "recipes1"}});
-            zones[espressoZone] = items;
-        }
-    }
+        return false;
+    };
 
-    // Relocate the espresso item to the bottom bar — after Equipment, falling
-    // back to before Settings, then to appending — unless it's already in a
-    // bar zone (nothing to relocate, and no duplicate is created).
-    if (espressoRemovedFromCenter && !espressoInBar) {
-        const QJsonObject espressoItem{{"type", "espresso"}, {"id", "espresso1"}};
-        QJsonArray br = zones.value("bottomRight").toArray();
-        int insertAt = -1;
-        for (qsizetype i = 0; i < br.size(); ++i) {
-            if (br[i].toObject()["type"].toString() == QLatin1String("equipment")) {
-                insertAt = static_cast<int>(i) + 1;
-                break;
+    const bool espressoInBar = zoneSetContainsType(kBarZones, QLatin1String("espresso"));
+    const bool espressoInCenter = zoneSetContainsType(kCenterZones, QLatin1String("espresso"));
+
+    // Swap Recipes into the Profiles (espresso) button's center slot and move
+    // Profiles down to the bottom bar. This runs only when Profiles actually
+    // sits in a center zone; otherwise the user has already placed it (and
+    // their Recipes button) elsewhere, so both are left untouched.
+    //
+    // The swap RELOCATES the existing Recipes button into the Profiles slot
+    // rather than only inserting one when none exists. getLayoutObject() (called
+    // above) always leaves a Recipes button via the passive add-recipes
+    // injection — by default immediately left of Profiles — so the former
+    // "insert only if !hasRecipes" guard was dead code: a user whose Recipes
+    // button lived anywhere but the center (e.g. the bottom bar) had Profiles
+    // pulled out of the center with nothing put in its place.
+    if (espressoInCenter) {
+        // Pull every existing Recipes item out (dedupe), remembering one to
+        // reuse so its id and any per-instance options survive. Removing them
+        // first keeps the Profiles index we find next correct even when a
+        // Recipes item shared the same center zone.
+        QJsonObject recipesItem{{"type", "recipes"}, {"id", "recipes1"}};
+        bool haveRecipesItem = false;
+        for (const QString& zoneName : zones.keys()) {
+            QJsonArray items = zones.value(zoneName).toArray();
+            bool changed = false;
+            for (qsizetype i = items.size() - 1; i >= 0; --i) {
+                if (items[i].toObject()["type"].toString() == QLatin1String("recipes")) {
+                    if (!haveRecipesItem) {
+                        recipesItem = items[i].toObject();
+                        haveRecipesItem = true;
+                    }
+                    items.removeAt(i);
+                    changed = true;
+                }
             }
+            if (changed) zones[zoneName] = items;
         }
-        if (insertAt < 0) {
-            for (qsizetype i = 0; i < br.size(); ++i) {
-                if (br[i].toObject()["type"].toString() == QLatin1String("settings")) {
-                    insertAt = static_cast<int>(i);
+
+        // Replace the (still-present) Profiles button in place with Recipes, so
+        // Recipes lands at Profiles' exact former center position.
+        for (const QString& zoneName : kCenterZones) {
+            QJsonArray items = zones.value(zoneName).toArray();
+            bool done = false;
+            for (qsizetype i = 0; i < items.size(); ++i) {
+                if (items[i].toObject()["type"].toString() == QLatin1String("espresso")) {
+                    items[i] = recipesItem;
+                    zones[zoneName] = items;
+                    done = true;
                     break;
                 }
             }
+            if (done) break;
         }
-        if (insertAt < 0) insertAt = static_cast<int>(br.size());
-        br.insert(insertAt, espressoItem);
-        zones["bottomRight"] = br;
+
+        // Relocate Profiles to the bottom bar — after Equipment, falling back to
+        // before Settings, then to appending — unless it already exists in a bar
+        // zone (nothing to relocate, and no duplicate is created).
+        if (!espressoInBar) {
+            const QJsonObject espressoItem{{"type", "espresso"}, {"id", "espresso1"}};
+            QJsonArray br = zones.value("bottomRight").toArray();
+            int insertAt = -1;
+            for (qsizetype i = 0; i < br.size(); ++i) {
+                if (br[i].toObject()["type"].toString() == QLatin1String("equipment")) {
+                    insertAt = static_cast<int>(i) + 1;
+                    break;
+                }
+            }
+            if (insertAt < 0) {
+                for (qsizetype i = 0; i < br.size(); ++i) {
+                    if (br[i].toObject()["type"].toString() == QLatin1String("settings")) {
+                        insertAt = static_cast<int>(i);
+                        break;
+                    }
+                }
+            }
+            if (insertAt < 0) insertAt = static_cast<int>(br.size());
+            br.insert(insertAt, espressoItem);
+            zones["bottomRight"] = br;
+        }
     }
 
     // Remove every Auto-Favorites item, wherever the user placed it.

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -1151,6 +1151,42 @@ private slots:
         net->setLayoutConfiguration(orig);
     }
 
+    // Regression: a customized user whose Recipes button already lives OUTSIDE
+    // the center (here, in the bottom bar) with Profiles (espresso) in the
+    // center. The upgrade must MOVE that existing Recipes button into the
+    // Profiles slot — not leave the center row short — and relocate Profiles to
+    // the bar. The old "insert Recipes only if none exists anywhere" guard
+    // wrongly skipped the center placement because a Recipes button was present
+    // (in the bar), so Profiles was pulled out with nothing put in its place.
+    void applyRecipesFirstUpgradeMovesExistingBarRecipesIntoEspressoSlot() {
+        SettingsNetwork* net = m_settings.network();
+        const QString orig = net->layoutConfiguration();
+
+        net->setLayoutConfiguration(QStringLiteral(
+            "{\"version\":1,\"zones\":{"
+            "\"centerTop\":["
+            "{\"type\":\"espresso\",\"id\":\"espresso1\"},"
+            "{\"type\":\"steam\",\"id\":\"steam1\"},"
+            "{\"type\":\"hotwater\",\"id\":\"hotwater1\"}],"
+            "\"bottomRight\":["
+            "{\"type\":\"history\",\"id\":\"history1\"},"
+            "{\"type\":\"recipes\",\"id\":\"recipes1\"},"
+            "{\"type\":\"equipment\",\"id\":\"equipment1\"},"
+            "{\"type\":\"settings\",\"id\":\"settings1\"}]"
+            "}}"));
+
+        net->applyRecipesFirstUpgrade();
+
+        // Recipes moved from the bar into Profiles' former center slot; exactly
+        // one Recipes button exists; Profiles relocated after Equipment.
+        QCOMPARE(typesOf(net->getZoneItems("centerTop")),
+                 QStringList({"recipes", "steam", "hotwater"}));
+        QCOMPARE(typesOf(net->getZoneItems("bottomRight")),
+                 QStringList({"history", "equipment", "espresso", "settings"}));
+
+        net->setLayoutConfiguration(orig);
+    }
+
     void applyRecipesFirstUpgradeLeavesEspressoAlreadyInBar() {
         SettingsNetwork* net = m_settings.network();
         const QString orig = net->layoutConfiguration();

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -29,6 +29,16 @@ static QStringList typesOf(const QVariantList& items) {
     return result;
 }
 
+// File-scope helper: the ordered list of "id" values in a getZoneItems()
+// result — used to prove an item was MOVED (its id carried over) rather than
+// discarded and recreated with a fresh default id.
+static QStringList idsOf(const QVariantList& items) {
+    QStringList result;
+    for (const QVariant& v : items)
+        result << v.toMap().value("id").toString();
+    return result;
+}
+
 // File-scope helper (Q_OBJECT moc rejects nested structs in test classes).
 // Snapshot + clear the Known Devices store so a test owns it for the
 // duration, and restore on scope exit. Settings exposes addKnownScale /
@@ -1162,6 +1172,9 @@ private slots:
         SettingsNetwork* net = m_settings.network();
         const QString orig = net->layoutConfiguration();
 
+        // The bar Recipes button carries a distinctive id so the assertions can
+        // tell a genuine MOVE (id preserved) from a discard-and-recreate (which
+        // would produce the code's default "recipes1").
         net->setLayoutConfiguration(QStringLiteral(
             "{\"version\":1,\"zones\":{"
             "\"centerTop\":["
@@ -1170,7 +1183,7 @@ private slots:
             "{\"type\":\"hotwater\",\"id\":\"hotwater1\"}],"
             "\"bottomRight\":["
             "{\"type\":\"history\",\"id\":\"history1\"},"
-            "{\"type\":\"recipes\",\"id\":\"recipes1\"},"
+            "{\"type\":\"recipes\",\"id\":\"recipesKept\"},"
             "{\"type\":\"equipment\",\"id\":\"equipment1\"},"
             "{\"type\":\"settings\",\"id\":\"settings1\"}]"
             "}}"));
@@ -1183,6 +1196,71 @@ private slots:
                  QStringList({"recipes", "steam", "hotwater"}));
         QCOMPARE(typesOf(net->getZoneItems("bottomRight")),
                  QStringList({"history", "equipment", "espresso", "settings"}));
+        // The existing button was MOVED (its id survived), not recreated.
+        QCOMPARE(idsOf(net->getZoneItems("centerTop")).value(0), QStringLiteral("recipesKept"));
+
+        net->setLayoutConfiguration(orig);
+    }
+
+    // Multiple Recipes buttons across zones (a reachable hand-edited state):
+    // the transform must dedupe to exactly one, landed in Profiles' slot, with
+    // no stray copy left in any bar/other zone.
+    void applyRecipesFirstUpgradeDedupesMultipleRecipes() {
+        SettingsNetwork* net = m_settings.network();
+        const QString orig = net->layoutConfiguration();
+
+        net->setLayoutConfiguration(QStringLiteral(
+            "{\"version\":1,\"zones\":{"
+            "\"centerTop\":["
+            "{\"type\":\"espresso\",\"id\":\"espresso1\"},"
+            "{\"type\":\"steam\",\"id\":\"steam1\"}],"
+            "\"bottomLeft\":[{\"type\":\"recipes\",\"id\":\"recipesA\"}],"
+            "\"bottomRight\":["
+            "{\"type\":\"recipes\",\"id\":\"recipesB\"},"
+            "{\"type\":\"equipment\",\"id\":\"equipment1\"},"
+            "{\"type\":\"settings\",\"id\":\"settings1\"}]"
+            "}}"));
+
+        net->applyRecipesFirstUpgrade();
+
+        // Exactly one Recipes button remains, in the Profiles slot; none linger
+        // in either bar zone.
+        QCOMPARE(typesOf(net->getZoneItems("centerTop")),
+                 QStringList({"recipes", "steam"}));
+        QVERIFY(!typesOf(net->getZoneItems("bottomLeft")).contains("recipes"));
+        QCOMPARE(typesOf(net->getZoneItems("bottomRight")),
+                 QStringList({"equipment", "espresso", "settings"}));
+
+        net->setLayoutConfiguration(orig);
+    }
+
+    // A Profiles copy parked in the unclassified lowerMidBar band (neither a
+    // center nor a bar zone) must not cause a duplicate: the center Profiles is
+    // swapped to Recipes, but since a Profiles button still exists (in
+    // lowerMidBar) none is appended to the bottom bar.
+    void applyRecipesFirstUpgradeNoDuplicateWhenProfilesInLowerMidBar() {
+        SettingsNetwork* net = m_settings.network();
+        const QString orig = net->layoutConfiguration();
+
+        net->setLayoutConfiguration(QStringLiteral(
+            "{\"version\":1,\"zones\":{"
+            "\"centerTop\":["
+            "{\"type\":\"espresso\",\"id\":\"espresso_center\"},"
+            "{\"type\":\"steam\",\"id\":\"steam1\"}],"
+            "\"lowerMidBar\":[{\"type\":\"espresso\",\"id\":\"espresso_lmb\"}],"
+            "\"bottomRight\":["
+            "{\"type\":\"history\",\"id\":\"history1\"},"
+            "{\"type\":\"equipment\",\"id\":\"equipment1\"},"
+            "{\"type\":\"settings\",\"id\":\"settings1\"}]"
+            "}}"));
+
+        net->applyRecipesFirstUpgrade();
+
+        QCOMPARE(typesOf(net->getZoneItems("centerTop")), QStringList({"recipes", "steam"}));
+        QCOMPARE(typesOf(net->getZoneItems("lowerMidBar")), QStringList({"espresso"}));
+        // No Profiles appended to the bar — exactly one Profiles button total.
+        QCOMPARE(typesOf(net->getZoneItems("bottomRight")),
+                 QStringList({"history", "equipment", "settings"}));
 
         net->setLayoutConfiguration(orig);
     }


### PR DESCRIPTION
## Problem

The one-time **Recipes-first layout upgrade** (#1453) was meant to swap the **Recipes** button into the **Profiles** button's center slot and relocate **Profiles** to its new default position in the bottom bar. Instead, for many customized layouts it **pulled Profiles out of the center and put nothing in its place** — Profiles looked deleted rather than moved. Reported from a real 2.0 upgrade.

## Root cause

`applyRecipesFirstUpgrade()` reads the layout via `getLayoutObject()`, which itself runs (and persists) the **passive add-recipes injection migration** before returning. So a Recipes button *always* exists by the time the transform runs.

The transform's step to "insert Recipes at the Profiles slot" was guarded by `if (!hasRecipes)` — making it **dead code**. Any user whose Recipes button lived **outside the center** (e.g. the bottom bar, which is the injection's own fallback position) had Profiles removed from the center with no Recipes placed there.

## Fix

When Profiles (`espresso`) sits in a center zone:
- **Relocate the existing Recipes button** into Profiles' exact former slot (deduping extras, preserving the item's id / per-instance options), instead of only inserting when none exists.
- Then move Profiles to its new default bottom-bar home (after Equipment → before Settings → append).

When Profiles isn't in the center, leave both it and the Recipes button untouched (unchanged behavior).

## Tests

- New regression test `applyRecipesFirstUpgradeMovesExistingBarRecipesIntoEspressoSlot` covering the previously-broken case (Recipes in the bottom bar, Profiles in the center).
- All existing upgrade-transform tests (pristine full-reset, surgical-preserve, inserts-at-position, already-in-bar, both-center-and-bar, autofavorites strip, idempotent) still hold.

## Verification

CI `linux-release` (`-DBUILD_TESTS=ON` + `ctest`) dispatched on this branch with `upload_to_release=false`.

## Note

This repairs the transform for **future** upgrades. Devices that already ran the buggy upgrade have `layout/recipesUpgradeOffered = true` and won't be re-offered — their layout needs a manual fix or reset-to-default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)