### PR TITLE
Shot Map: reconcile privacy disclosures with actual behavior (stays opt-out)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -10,7 +10,7 @@ Decenza is an open-source application for controlling Decent Espresso DE1 machin
 
 The app runs on your device and stores your settings, shot history, and preferences locally. It does not send data to us automatically for the core espresso-machine functionality.
 
-However, Decenza has a number of **optional network features**, several of which reach the internet. Some of these send an approximate location or a random per-install identifier. They are documented in full below. Except where noted, these features only transmit data when you enable them or explicitly trigger the action.
+However, Decenza has a number of **optional network features**, several of which reach the internet. Some of these send an approximate location or a random per-install identifier. They are documented in full below. Most transmit data only when you enable them or explicitly trigger the action. The one exception is the **Shot Map**, which is **on by default** and sends your approximate location — you can turn it off in Settings → Machine (see below).
 
 ## Network Connections
 
@@ -18,9 +18,9 @@ The following is a complete list of the servers Decenza can contact and why:
 
 - **Your DE1 espresso machine** and **Bluetooth scale** — local Bluetooth only; no internet.
 
-- **Shot Map** (`api.decenza.coffee`) — **optional, off by default.** If you turn on the Shot Map, then on every shot the app POSTs your coarse location (rounded to ~11 km / ~7 miles), the profile name, and the app version to decenza.coffee to plot anonymous shots on a community map. No account is used. Turning this feature on is what enables location acquisition (see *Location* below).
+- **Shot Map** (`api.decenza.coffee`) — **on by default; can be turned off in Settings → Machine.** On every completed shot, the app POSTs your coarse location (rounded to ~11 km / ~7 miles), the profile name, and the app version to decenza.coffee to plot anonymous shots on a community map. No account is used and the data is not linked to your identity. Because it is on by default, the app acquires an approximate location fix (see *Location* below) unless you turn the Shot Map off. On iOS, location acquisition first requires you to grant the system location permission, which the app requests explaining it is for the shot map.
 
-- **Location & reverse geocoding** (`nominatim.openstreetmap.org`) — the app only acquires a location fix and looks up your city/country name (via OpenStreetMap's Nominatim service) when a location-consuming feature is enabled — currently the Shot Map. If no such feature is on, no location fix is taken and nothing is sent to Nominatim. The location OS permission is also required for Bluetooth scanning on mobile, but scanning does **not** cause a location fix or any network request.
+- **Location & reverse geocoding** (`nominatim.openstreetmap.org`) — the app acquires an approximate location fix and looks up your city/country name (via OpenStreetMap's Nominatim service) for the Shot Map, which is on by default. On iOS this happens only after you grant the system location permission (the app prompts, explaining it is for the shot map); on Android the location permission already granted for Bluetooth scanning is reused. If you turn the Shot Map off, no location fix is taken and nothing is sent to Nominatim. Bluetooth scanning itself does **not** cause a location fix or any network request.
 
 - **Weather** (`open-meteo.com`, `api.weather.gov` / NWS, `api.met.no` / MET Norway) — if you add the Weather widget to a layout, the app sends your approximate coordinates to a weather provider (chosen by region) to fetch a local forecast. Weather uses whatever location another feature has already obtained; it does not itself acquire a new fix.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,38 +1,58 @@
 # Privacy Policy for Decenza
 
-**Last updated: January 15, 2025**
+**Last updated: July 2026**
 
 ## Overview
 
-Decenza is an open-source application for controlling Decent Espresso DE1 machines. We are committed to protecting your privacy.
+Decenza is an open-source application for controlling Decent Espresso DE1 machines. We are committed to protecting your privacy and to being transparent about every network connection the app can make.
 
 ## Data Collection
 
-**We do not collect any personal data.**
+The app runs on your device and stores your settings, shot history, and preferences locally. It does not send data to us automatically for the core espresso-machine functionality.
 
-The app operates entirely on your device and communicates only with:
-- Your DE1 espresso machine (via Bluetooth)
-- Your Bluetooth scale (if connected)
-- Visualizer.coffee (only if you enable this feature)
-- AI providers (only if you enable AI analysis and provide your own API key)
+However, Decenza has a number of **optional network features**, several of which reach the internet. Some of these send an approximate location or a random per-install identifier. They are documented in full below. Except where noted, these features only transmit data when you enable them or explicitly trigger the action.
+
+## Network Connections
+
+The following is a complete list of the servers Decenza can contact and why:
+
+- **Your DE1 espresso machine** and **Bluetooth scale** — local Bluetooth only; no internet.
+
+- **Shot Map** (`api.decenza.coffee`) — **optional, off by default.** If you turn on the Shot Map, then on every shot the app POSTs your coarse location (rounded to ~11 km / ~7 miles), the profile name, and the app version to decenza.coffee to plot anonymous shots on a community map. No account is used. Turning this feature on is what enables location acquisition (see *Location* below).
+
+- **Location & reverse geocoding** (`nominatim.openstreetmap.org`) — the app only acquires a location fix and looks up your city/country name (via OpenStreetMap's Nominatim service) when a location-consuming feature is enabled — currently the Shot Map. If no such feature is on, no location fix is taken and nothing is sent to Nominatim. The location OS permission is also required for Bluetooth scanning on mobile, but scanning does **not** cause a location fix or any network request.
+
+- **Weather** (`open-meteo.com`, `api.weather.gov` / NWS, `api.met.no` / MET Norway) — if you add the Weather widget to a layout, the app sends your approximate coordinates to a weather provider (chosen by region) to fetch a local forecast. Weather uses whatever location another feature has already obtained; it does not itself acquire a new fix.
+
+- **Automatic update check** (`api.github.com`) — **optional, off by default.** When enabled, the app periodically GETs the public GitHub releases list for this repository to see whether a newer version exists. This is a plain read of public release metadata; no personal data is sent.
+
+- **Crash reporter** (`api.decenza.coffee/v1/crash-report`) — **user-submitted only.** If the app crashes, you may choose to submit a crash report (log tail plus any notes you type). It is sent to decenza.coffee, which files a GitHub issue. Nothing is sent unless you press submit.
+
+- **Widget / layout Library sharing** (`api.decenza.coffee/v1/library`) — **user-initiated.** When you upload a widget/layout, browse, or download from the community library, requests are sent to decenza.coffee. These requests include an `X-Device-Id` header containing a random UUID generated once per installation (used for anonymous authentication and to let you manage your own uploads). This UUID is not tied to your identity.
+
+- **Visualizer.coffee** (optional) — if you enable shot uploads, your shot data, metadata, and approximate location (if location is enabled) are sent to visualizer.coffee. See their privacy policy at https://visualizer.coffee.
+
+- **AI analysis** (optional) — if you enable AI shot analysis, shot data is sent to the AI provider you configure (OpenAI, Anthropic, Google, OpenRouter, or a local/Ollama endpoint) using your own API key. Data handling is governed by your chosen provider's policy.
+
+- **Translations** (`api.decenza.coffee`) — if you download an additional UI language, the language list and language file are fetched from decenza.coffee.
+
+- **Remote control relay** (`wss://ws.decenza.coffee`) — if you enable remote access, the app opens a websocket to a relay server so you can control the machine from another device. Only active when enabled.
+
+- **DE1 firmware & screensaver downloads** — firmware images and optional screensaver videos are downloaded from their respective sources when you use those features.
+
+## Local Web Server (LAN)
+
+Decenza can run an optional on-device web server so you can view/edit settings from a browser on your local network. The settings page never returns your stored secret values (API keys, Visualizer/MQTT credentials): configured secrets are shown redacted, and a saved value is only overwritten when you type a new one. Settings backups taken over this web server exclude those secret values as well (API keys plus Visualizer/MQTT usernames and passwords).
 
 ## Permissions
 
-The app requests the following permissions:
-
-- **Bluetooth** - Required to communicate with your DE1 machine and Bluetooth scales
-- **Location** - Required by mobile OS for Bluetooth scanning. Also used optionally to tag shots with your approximate location (~11km / ~7 miles accuracy) for the shot map feature
-- **Internet** - Used for optional features: Visualizer.coffee uploads, AI analysis, and screensaver video downloads
+- **Bluetooth** — communicate with your DE1 machine and Bluetooth scales.
+- **Location** — required by the mobile OS for Bluetooth scanning; also used, only when you enable a location feature such as the Shot Map, to tag shots with your approximate location (~11 km / ~7 miles).
+- **Internet** — used for the optional network features listed above.
 
 ## Data Storage
 
-All settings, shot history, and preferences are stored locally on your device. No data is transmitted to us or any third party unless you explicitly enable optional features.
-
-## Third-Party Services
-
-**Visualizer.coffee** (optional) - If you enable shot uploads, your shot data, metadata, and approximate location (if enabled) are sent to visualizer.coffee. Please refer to their privacy policy at https://visualizer.coffee for how they handle your data.
-
-**AI Analysis** (optional) - If you enable AI shot analysis, shot data is sent to your configured AI provider (OpenAI, Anthropic, or others) using your own API key. Data handling is governed by your chosen provider's privacy policy.
+All settings, shot history, and preferences are stored locally on your device. No data is transmitted to us or any third party except through the optional features described above.
 
 ## Open Source
 

--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -7,7 +7,25 @@
     <key>NSPrivacyTrackingDomains</key>
     <array/>
     <key>NSPrivacyCollectedDataTypes</key>
-    <array/>
+    <array>
+        <!-- Coarse location (rounded to ~11 km) is sent to api.decenza.coffee
+             when the Shot Map feature is enabled, to plot anonymous shots on a
+             community map. Not linked to the user's identity and not used for
+             tracking. -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeCoarseLocation</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                <string>NSPrivacyCollectedDataTypePurposeOther</string>
+            </array>
+        </dict>
+    </array>
     <key>NSPrivacyAccessedAPITypes</key>
     <array>
         <!-- QSettings uses NSUserDefaults on iOS -->

--- a/src/network/shotreporter.cpp
+++ b/src/network/shotreporter.cpp
@@ -31,7 +31,7 @@ ShotReporter::ShotReporter(QNetworkAccessManager* networkManager, Settings* sett
 
     // Load enabled state from settings
     if (m_settings) {
-        m_enabled = m_settings->value("shotmap/enabled", false).toBool();
+        m_enabled = m_settings->value("shotmap/enabled", true).toBool();
     }
 }
 

--- a/src/network/shotreporter.cpp
+++ b/src/network/shotreporter.cpp
@@ -31,7 +31,7 @@ ShotReporter::ShotReporter(QNetworkAccessManager* networkManager, Settings* sett
 
     // Load enabled state from settings
     if (m_settings) {
-        m_enabled = m_settings->value("shotmap/enabled", true).toBool();
+        m_enabled = m_settings->value("shotmap/enabled", false).toBool();
     }
 }
 


### PR DESCRIPTION
## What
The Shot Map **remains on by default (opt-out)** — this PR does not change that behavior. Instead it makes the privacy disclosures accurate.

- **PRIVACY.md** rewritten to list every network connection the app can make, and to describe the Shot Map honestly as **on by default**, what it sends (coarse location rounded to ~11 km, profile name, app version to `api.decenza.coffee`), and how to turn it off (Settings → Machine). Drops the old inaccurate blanket claim "We do not collect any personal data."
- **ios/PrivacyInfo.xcprivacy** now declares `NSPrivacyCollectedDataTypeCoarseLocation` (not linked to identity, not used for tracking; App Functionality + Other purposes). The manifest previously declared an empty `NSPrivacyCollectedDataTypes`, which contradicted the coarse location the app sends and the App Store Connect nutrition label (which already lists Coarse Location).

## Why
The original inconsistency — `shotreporter.cpp` defaulting `shotmap/enabled` to `true` while `maincontroller.cpp` read it as `false` — looked like a bug, but the intended behavior is opt-out. Rather than flip the default, the fix is to make the disclosures match reality:
- On iOS, location access already requires the user to grant the system permission prompt (BLE does not grant location on iOS), and the prompt string explains it is for the shot map — so there is an affirmative consent step.
- The privacy manifest was the one artifact out of sync; it now matches the nutrition label and actual behavior.

No behavior change. Docs and privacy manifest only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)