### PR TITLE
AI advisor: label curated KB profile knowledge with its display name

### DIFF
--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -1211,24 +1211,25 @@ QString ShotSummarizer::shotAnalysisSystemPrompt(const QString& beverageType, co
         resolvedKbId = matchProfileKey(s_profileKnowledge, profileTitle, profileType);
     }
     if (!resolvedKbId.isEmpty() && s_profileKnowledge.contains(resolvedKbId)) {
-        const ProfileKnowledge& pk = s_profileKnowledge.value(resolvedKbId);
+        const auto pk = s_profileKnowledge.value(resolvedKbId);
         // Name the KB entry explicitly (issue #1459): without a label here,
-        // this prose sat directly below the "Available Profiles" catalog
-        // with nothing tying it to a specific catalog line, and the model
-        // picked a plausible-sounding catalog name by matching the
-        // DESCRIBED characteristics (e.g. attributing Allongé's "constant
-        // ~4.5 ml/s flow, low pressure" to TurboTurbo, which shares that
-        // description) instead of the shot's actual profile. The KB entry
-        // name is a FAMILY label, not the shot's own title — a custom or
-        // renamed profile (e.g. a bean-prefixed title) can resolve to this
-        // family while having a different display name in `result.profile.title`.
+        // this prose was indistinguishable from any other catalog entry's
+        // description, and the model picked a plausible-sounding catalog
+        // name by matching the DESCRIBED characteristics (e.g. attributing
+        // Allongé's "constant ~4.5 ml/s flow, low pressure" to TurboTurbo,
+        // which shares that description) instead of the shot's actual
+        // profile. `pk.name` is the matched KB entry's canonical display
+        // name, NOT the shot's own title, and NOT its `family` tag (the
+        // `[family: ...]` cluster used elsewhere for switching guidance) —
+        // a custom or renamed profile can resolve to this KB entry while
+        // having a different title in `result.profile.title`.
         base += QStringLiteral("\n\n## Current Profile Knowledge: ") + pk.name + QStringLiteral("\n\n"
-            "The following is curated knowledge about the profile FAMILY used in this shot, matched by "
-            "recipe/title. This is a family label, not necessarily the shot's own profile name — the "
+            "The following is curated knowledge about the profile matched to this shot. The heading above "
+            "is the matched KB entry's canonical name, not necessarily the shot's own profile name — the "
             "shot's actual title is `result.profile.title` (or the \"Profile:\" line in the prompt); "
-            "if the user renamed or customized the profile, that title may differ from the family name "
-            "above. Always refer to the shot by its ACTUAL title when talking to the user, never by this "
-            "KB family name. Use this knowledge to understand what is INTENTIONAL behavior vs. what "
+            "if the user renamed or customized the profile, that title may differ from the name above. "
+            "Always refer to the shot by its ACTUAL title when talking to the user, never by this KB "
+            "entry's name. Use this knowledge to understand what is INTENTIONAL behavior vs. what "
             "indicates a problem.\n\n")
             + pk.content;
     }

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -1205,21 +1205,32 @@ QString ShotSummarizer::shotAnalysisSystemPrompt(const QString& beverageType, co
 
     // Look up profile-specific knowledge by KB ID (computed from title/alias matching),
     // falling back to fuzzy title/editorType matching for shots without a stored KB ID
-    QString profileSection;
-    if (!profileKbId.isEmpty()) {
-        loadProfileKnowledge();
-        if (s_profileKnowledge.contains(profileKbId)) {
-            profileSection = s_profileKnowledge.value(profileKbId).content;
-        }
+    QString resolvedKbId = profileKbId;
+    loadProfileKnowledge();
+    if (resolvedKbId.isEmpty() || !s_profileKnowledge.contains(resolvedKbId)) {
+        resolvedKbId = matchProfileKey(s_profileKnowledge, profileTitle, profileType);
     }
-    if (profileSection.isEmpty()) {
-        profileSection = findProfileSection(profileTitle, profileType);
-    }
-    if (!profileSection.isEmpty()) {
-        base += QStringLiteral("\n\n## Current Profile Knowledge\n\n"
-            "The following is curated knowledge about the specific profile used in this shot. "
-            "Use this to understand what is INTENTIONAL behavior vs. what indicates a problem.\n\n")
-            + profileSection;
+    if (!resolvedKbId.isEmpty() && s_profileKnowledge.contains(resolvedKbId)) {
+        const ProfileKnowledge& pk = s_profileKnowledge.value(resolvedKbId);
+        // Name the KB entry explicitly (issue #1459): without a label here,
+        // this prose sat directly below the "Available Profiles" catalog
+        // with nothing tying it to a specific catalog line, and the model
+        // picked a plausible-sounding catalog name by matching the
+        // DESCRIBED characteristics (e.g. attributing Allongé's "constant
+        // ~4.5 ml/s flow, low pressure" to TurboTurbo, which shares that
+        // description) instead of the shot's actual profile. The KB entry
+        // name is a FAMILY label, not the shot's own title — a custom or
+        // renamed profile (e.g. a bean-prefixed title) can resolve to this
+        // family while having a different display name in `result.profile.title`.
+        base += QStringLiteral("\n\n## Current Profile Knowledge: ") + pk.name + QStringLiteral("\n\n"
+            "The following is curated knowledge about the profile FAMILY used in this shot, matched by "
+            "recipe/title. This is a family label, not necessarily the shot's own profile name — the "
+            "shot's actual title is `result.profile.title` (or the \"Profile:\" line in the prompt); "
+            "if the user renamed or customized the profile, that title may differ from the family name "
+            "above. Always refer to the shot by its ACTUAL title when talking to the user, never by this "
+            "KB family name. Use this knowledge to understand what is INTENTIONAL behavior vs. what "
+            "indicates a problem.\n\n")
+            + pk.content;
     }
 
     return base;

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -250,9 +250,28 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                         profileKnowledge = ShotSummarizer::shotAnalysisSystemPrompt(
                             bevType, profileTitle, profileType, dbResult.profileKbId);
                     } else {
-                        profileKnowledge = ShotSummarizer::profileKnowledgeForKbId(dbResult.profileKbId);
-                        if (profileKnowledge.isEmpty())
-                            profileKnowledge = ShotSummarizer::findProfileSection(profileTitle, profileType);
+                        // Resolve the KB id once so the content and its name label
+                        // stay attached to the same entry (issue #1459: unlabeled KB
+                        // prose let the model attribute another catalog profile's
+                        // name to this shot's actual profile).
+                        QString resolvedKbId = dbResult.profileKbId;
+                        profileKnowledge = ShotSummarizer::profileKnowledgeForKbId(resolvedKbId);
+                        if (profileKnowledge.isEmpty()) {
+                            resolvedKbId = ShotSummarizer::computeProfileKbId(profileTitle, profileType);
+                            profileKnowledge = ShotSummarizer::profileKnowledgeForKbId(resolvedKbId);
+                        }
+                        if (!profileKnowledge.isEmpty()) {
+                            const QString kbName = ShotSummarizer::canonicalNameForKbId(resolvedKbId);
+                            if (!kbName.isEmpty()) {
+                                profileKnowledge = QStringLiteral("## Current Profile Knowledge: ") + kbName
+                                    + QStringLiteral("\n\n"
+                                        "Family label, not necessarily this shot's own profile name — see "
+                                        "`result.profile.title` for the shot's actual title and refer to the "
+                                        "shot by that title when talking to the user, never by this KB family "
+                                        "name.\n\n")
+                                    + profileKnowledge;
+                            }
+                        }
 
                         // Compact guardrail only (espresso-only — the full
                         // catalog is espresso-centric, so filter/pour-over

--- a/src/mcp/mcptools_dialing.cpp
+++ b/src/mcp/mcptools_dialing.cpp
@@ -251,9 +251,9 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                             bevType, profileTitle, profileType, dbResult.profileKbId);
                     } else {
                         // Resolve the KB id once so the content and its name label
-                        // stay attached to the same entry (issue #1459: unlabeled KB
-                        // prose let the model attribute another catalog profile's
-                        // name to this shot's actual profile).
+                        // stay attached to the same entry — see shotAnalysisSystemPrompt's
+                        // "## Current Profile Knowledge" block above for why the label
+                        // is required (issue #1459).
                         QString resolvedKbId = dbResult.profileKbId;
                         profileKnowledge = ShotSummarizer::profileKnowledgeForKbId(resolvedKbId);
                         if (profileKnowledge.isEmpty()) {
@@ -265,10 +265,10 @@ void registerDialingTools(McpToolRegistry* registry, MainController* mainControl
                             if (!kbName.isEmpty()) {
                                 profileKnowledge = QStringLiteral("## Current Profile Knowledge: ") + kbName
                                     + QStringLiteral("\n\n"
-                                        "Family label, not necessarily this shot's own profile name — see "
-                                        "`result.profile.title` for the shot's actual title and refer to the "
-                                        "shot by that title when talking to the user, never by this KB family "
-                                        "name.\n\n")
+                                        "This heading is the matched KB entry's canonical name, not "
+                                        "necessarily this shot's own profile name — see `result.profile.title` "
+                                        "for the shot's actual title and refer to the shot by that title when "
+                                        "talking to the user, never by this KB entry's name.\n\n")
                                     + profileKnowledge;
                             }
                         }

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -885,6 +885,36 @@ private slots:
                  "system prompt must point at currentBean as canonical bean/grinder identity surface");
     }
 
+    // Issue #1459: the "Current Profile Knowledge" section used to inject
+    // the matched KB entry's prose with no name attached, so the model
+    // sometimes attributed a DIFFERENT catalog profile's name to the
+    // shot's actual profile (e.g. calling a Rao Allongé shot "TurboTurbo"
+    // because the two profiles' curated descriptions read similarly). The
+    // section header must now name the matched entry explicitly, and the
+    // resolved name must come from the SAME entry as the injected content.
+    void shotAnalysisSystemPrompt_labelsCurrentProfileKnowledgeWithMatchedName()
+    {
+        const QString prompt = ShotSummarizer::shotAnalysisSystemPrompt(
+            QStringLiteral("espresso"), QStringLiteral("Rao Allongé"),
+            QString(), QString());
+        QVERIFY2(prompt.contains(QStringLiteral("## Current Profile Knowledge: Allonge")),
+                 "section header must carry the matched KB entry's own display name");
+        QVERIFY2(!prompt.contains(QStringLiteral("## Current Profile Knowledge: TurboTurbo")),
+                 "an Allongé-matched shot's section must not be headed with an unrelated profile's name");
+        // "TurboTurbo" legitimately appears elsewhere (the cross-profile
+        // catalog lists every KB profile by name) — only the section
+        // header identifying THIS shot's matched entry is under test here.
+
+        // A custom/renamed title (bean-prefixed, no exact/prefix alias match)
+        // must not silently fall back to an unlabeled or mismatched section —
+        // it should simply carry no KB section, never someone else's name.
+        const QString unmatchedPrompt = ShotSummarizer::shotAnalysisSystemPrompt(
+            QStringLiteral("espresso"), QStringLiteral("Yirgacheffe G2 - My Custom Blend"),
+            QString(), QString());
+        QVERIFY2(!unmatchedPrompt.contains(QStringLiteral("## Current Profile Knowledge:")),
+                 "an unresolvable custom title must not fabricate a KB name label");
+    }
+
     // Openspec optimize-dialing-context-payload, task 10.5: Standalone vs
     // HistoryBlock render modes differ ONLY in the two top-level header
     // lines (`## Shot Summary` and `## Detector Observations`). Body


### PR DESCRIPTION
## Summary
- Fixes #1459 — the AI advisor described a shot's actual profile using the *content* of the correct KB entry (e.g. Rao Allongé's "constant ~4.5 ml/s flow, low pressure" characteristics) but attributed it to a different, wrong catalog profile name (e.g. "TurboTurbo")
- Root cause: `ShotSummarizer::shotAnalysisSystemPrompt()`'s `## Current Profile Knowledge` section injected the matched KB entry's curated prose with no display name attached, directly below a catalog listing ~19 other named profiles with similar-sounding descriptions — nothing tied the unlabeled prose to a specific catalog line, so the model had to guess which name to use and sometimes guessed wrong
- Both the full system-prompt path (in-app advisor + MCP `dialing_get_context`/`ai_advisor_invoke`) and the MCP "lite" per-call branch in `mcptools_dialing.cpp` now prepend an explicit `## Current Profile Knowledge: <display name>` header, plus a note that the label is a KB *family* name and may differ from the shot's own (possibly custom/renamed) profile title

## Test plan
- [x] `mcp__qtcreator__build` — succeeded, 0 errors, 0 warnings
- [x] `mcp__qtcreator__run_tests` on `tst_ShotSummarizer`, `TstDialingBlocks`, `tst_AIManager` — 206 passed, 0 failed, 0 warnings
- [ ] Manual: verify a shot with a custom-titled profile (bean-name-prefixed, e.g. "Yirgacheffe G2 - Rao Allongé 90") no longer gets mislabeled by the AI advisor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
