### PR TITLE
Shot start: recipe pill parity + permissive GHC default

### DIFF
--- a/qml/components/layout/items/RecipesItem.qml
+++ b/qml/components/layout/items/RecipesItem.qml
@@ -50,8 +50,10 @@ Item {
             if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled)
                 AccessibilityManager.announce(TranslationManager.translate("machine.notReady", "Machine is not ready"))
         } else {
-            console.log("[recipe pill/compact] starting espresso — recipe=" + recipe.id + " phase=" + MachineState.phase)
-            DE1Device.startEspresso()
+            // Deferred in MainController until the recipe's profile is applied,
+            // so a fast second tap can't pull a shot on the previous profile.
+            console.log("[recipe pill/compact] requesting start — recipe=" + recipe.id + " phase=" + MachineState.phase)
+            MainController.startSelectedRecipeShotWhenApplied()
         }
     }
 

--- a/qml/components/layout/items/RecipesItem.qml
+++ b/qml/components/layout/items/RecipesItem.qml
@@ -26,6 +26,35 @@ Item {
         return null
     }
 
+    // True when the app is allowed to start machine operations on-screen — same
+    // gate as the profile pills (EspressoItem). An active GHC takes exclusive
+    // control, so on-screen starts are only valid headless or in simulation.
+    readonly property bool canStartOperations: DE1Device.isHeadless || DE1Device.simulationMode
+
+    // Two-tap select-then-start, identical to the regular-layout recipe pill
+    // (IdlePage.tryStartRecipe) so both layouts behave the same. Selection is
+    // the synchronous, shared MainController.selectedRecipeId; the first tap
+    // selects (activates), a tap on the already-selected recipe starts the shot.
+    function tryStartRecipe(recipe) {
+        var alreadySelected = (recipe.id === MainController.selectedRecipeId)
+        if (!alreadySelected) {
+            MainController.activateRecipe(recipe.id)  // sets selectedRecipeId synchronously
+            return
+        }
+        if (!root.canStartOperations) {
+            console.log("[recipe pill/compact] start blocked: app cannot start operations (active GHC?) — recipe=" + recipe.id
+                        + " isHeadless=" + DE1Device.isHeadless + " simulationMode=" + DE1Device.simulationMode)
+        } else if (!MachineState.isReady) {
+            console.log("[recipe pill/compact] start blocked: machine not ready — recipe=" + recipe.id
+                        + " phase=" + MachineState.phase)
+            if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled)
+                AccessibilityManager.announce(TranslationManager.translate("machine.notReady", "Machine is not ready"))
+        } else {
+            console.log("[recipe pill/compact] starting espresso — recipe=" + recipe.id + " phase=" + MachineState.phase)
+            DE1Device.startEspresso()
+        }
+    }
+
     // The five most-recently-used non-archived recipes (inventoryReady is
     // MRU-ordered); the full list lives on the Recipes page.
     property var inventoryRecipes: []
@@ -140,7 +169,7 @@ Item {
             var selectedName = ""
             for (var i = 0; i < recipes.length; ++i) {
                 names.push(recipes[i].name)
-                if (recipes[i].id === Settings.dye.activeRecipeId) selectedName = recipes[i].name
+                if (recipes[i].id === MainController.selectedRecipeId) selectedName = recipes[i].name
             }
             var announcement = recipes.length + " " + TranslationManager.translate("idle.accessible.recipes", "recipes") + ": " + names.join(", ")
             if (selectedName !== "") {
@@ -207,7 +236,7 @@ Item {
             selectedIndex: {
                 var list = root.inventoryRecipes
                 for (var i = 0; i < list.length; ++i) {
-                    if (list[i].id === Settings.dye.activeRecipeId) return i
+                    if (list[i].id === MainController.selectedRecipeId) return i
                 }
                 return -1
             }
@@ -215,7 +244,9 @@ Item {
             onPresetSelected: function(index) {
                 var recipe = root.inventoryRecipes[index]
                 if (!recipe) return
-                MainController.activateRecipe(recipe.id)
+                // First tap selects (activates); tapping the selected recipe
+                // again starts the shot — same as the regular-layout pill row.
+                root.tryStartRecipe(recipe)
                 presetPopup.close()
             }
         }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -174,6 +174,33 @@ Page {
         }
     }
 
+    // Recipe pill selection is the synchronous MainController.selectedRecipeId
+    // (shared with the compact RecipesItem so both layouts behave identically —
+    // the recipe analogue of the profile pills' Settings.app.selectedFavoriteProfile).
+    // See tryStartRecipe() below for the two-tap select-then-start handler.
+    function tryStartRecipe(recipe) {
+        var alreadySelected = (recipe.id === MainController.selectedRecipeId)
+        if (!alreadySelected) {
+            MainController.activateRecipe(recipe.id)  // sets selectedRecipeId synchronously
+            return
+        }
+        // Second tap on the selected recipe → start. Log which gate blocks it
+        // (the two gates fail for very different reasons) so a debug log tells
+        // us exactly why a shot did not start.
+        if (!idlePage.canStartOperations) {
+            console.log("[recipe pill] start blocked: app cannot start operations (active GHC?) — recipe=" + recipe.id
+                        + " isHeadless=" + DE1Device.isHeadless + " simulationMode=" + DE1Device.simulationMode)
+        } else if (!MachineState.isReady) {
+            console.log("[recipe pill] start blocked: machine not ready — recipe=" + recipe.id
+                        + " phase=" + MachineState.phase)
+            if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled)
+                AccessibilityManager.announce(TranslationManager.translate("machine.notReady", "Machine is not ready"))
+        } else {
+            console.log("[recipe pill] starting espresso — recipe=" + recipe.id + " phase=" + MachineState.phase)
+            DE1Device.startEspresso()
+        }
+    }
+
     // Track which function's presets are showing (used by center-zone action items)
     property string activePresetFunction: ""  // "", "steam", "espresso", "hotwater", "flush", "beans", "equipment", "recipes"
 
@@ -1041,7 +1068,7 @@ Page {
                     selectedIndex: {
                         var list = idlePage.inventoryRecipes
                         for (var i = 0; i < list.length; ++i) {
-                            if (list[i].id === Settings.dye.activeRecipeId) return i
+                            if (list[i].id === MainController.selectedRecipeId) return i
                         }
                         return -1
                     }
@@ -1049,20 +1076,10 @@ Page {
                     onPresetSelected: function(index) {
                         var recipe = idlePage.inventoryRecipes[index]
                         if (!recipe) return
-                        // Match the profile/espresso pills: first tap activates
-                        // the recipe; tapping the already-active recipe starts
-                        // the shot (when the machine is ready).
-                        if (recipe.id === Settings.dye.activeRecipeId) {
-                            if (MachineState.isReady && idlePage.canStartOperations) {
-                                DE1Device.startEspresso()
-                            } else {
-                                console.log("Cannot start espresso - machine not ready, phase:", MachineState.phase)
-                                if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled)
-                                    AccessibilityManager.announce(TranslationManager.translate("machine.notReady", "Machine is not ready"))
-                            }
-                        } else {
-                            MainController.activateRecipe(recipe.id)
-                        }
+                        // Match the profile/espresso pills: first tap selects the
+                        // recipe (kicks off activation); tapping the selected
+                        // recipe again starts the shot (when ready).
+                        idlePage.tryStartRecipe(recipe)
                     }
                 }
             }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -196,8 +196,10 @@ Page {
             if (typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled)
                 AccessibilityManager.announce(TranslationManager.translate("machine.notReady", "Machine is not ready"))
         } else {
-            console.log("[recipe pill] starting espresso — recipe=" + recipe.id + " phase=" + MachineState.phase)
-            DE1Device.startEspresso()
+            // Deferred in MainController until the recipe's profile is applied,
+            // so a fast second tap can't pull a shot on the previous profile.
+            console.log("[recipe pill] requesting start — recipe=" + recipe.id + " phase=" + MachineState.phase)
+            MainController.startSelectedRecipeShotWhenApplied()
         }
     }
 

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -509,7 +509,9 @@ Page {
                 case "recipes":
                     presets = idlePage.inventoryRecipes.map(function(r) { return { name: r.name } })
                     for (var ri = 0; ri < idlePage.inventoryRecipes.length; ++ri) {
-                        if (idlePage.inventoryRecipes[ri].id === Settings.dye.activeRecipeId) {
+                        // Match the pill highlight (selectedIndex) — the synchronous
+                        // MainController.selectedRecipeId, not the lagging activeRecipeId.
+                        if (idlePage.inventoryRecipes[ri].id === MainController.selectedRecipeId) {
                             selectedName = idlePage.inventoryRecipes[ri].name
                             break
                         }

--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -114,6 +114,11 @@ void DE1Device::onTransportDisconnected() {
     m_lastSawTriggerMs = 0;
     m_lastSawWriteMs = 0;
 
+    // Restore the permissive default so a GHC machine's "false" doesn't carry
+    // into the next connection and block its start buttons until (or unless)
+    // the fresh GHC MMR read returns. setIsHeadless only emits on a change.
+    setIsHeadless(true);
+
     // Clear ShotSettings tracking so a reconnect doesn't compare the DE1's
     // post-reconnect indication against a stale commanded value from the
     // previous session (which would log a spurious drift).
@@ -794,6 +799,15 @@ void DE1Device::requestState(DE1::State state) {
 }
 
 void DE1Device::startEspresso() {
+    // One log for every start surface (profile/recipe pills, MCP, GHC sim): if a
+    // shot fails to start, the debug log shows whether the BLE command was even
+    // issued and the machine state at the time. The gate that can block BEFORE
+    // this point (isHeadless / machine-ready) is logged QML-side.
+    qDebug().noquote() << QString("[BLE DE1] startEspresso: state=%1 headless=%2 sim=%3")
+                              .arg(DE1::stateToString(m_state))
+                              .arg(m_isHeadless ? "yes" : "no")
+                              .arg(m_simulationMode ? "yes" : "no");
+
     writeMMR(DE1::MMR::GHC_MODE, 1);
 
     if (m_state != DE1::State::Idle) {

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -488,7 +488,13 @@ private:
     QMetaObject::Connection m_uploadConnection;
     QTimer m_uploadTimeoutTimer;
     bool m_usbChargerOn = true;  // Default on (safe default like de1app)
-    bool m_isHeadless = false;   // True if app can start operations (GHC not installed or inactive)
+    // True if the app may start operations (no GHC, or a GHC that is present
+    // but inactive). Default TRUE, matching de1app, whose ghc_is_installed
+    // defaults to 0 (ghc_required() == 0 → app can start). Only a positive GHC
+    // read flips this false (see parseMMRResponse). Defaulting false would
+    // brick every start button until the GHC MMR read returns — and forever if
+    // that read is ever slow or dropped.
+    bool m_isHeadless = true;
     int m_refillKitDetected = -1;  // -1=unknown, 0=not detected, 1=detected
 
     // SAW stop latency instrumentation (monotonic ms timestamps)

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1010,6 +1010,11 @@ void MainController::activateRecipe(qint64 recipeId) {
 }
 
 void MainController::setSelectedRecipeId(qint64 recipeId) {
+    // Normalize any non-positive id (activeRecipeId's int default is -1, but the
+    // codebase treats both 0 and negatives as "none" via > 0 guards) to the -1
+    // sentinel, so no path can seed a stray 0 that the pill match would miss.
+    if (recipeId <= 0)
+        recipeId = -1;
     if (m_selectedRecipeId == recipeId)
         return;
     m_selectedRecipeId = recipeId;

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -971,17 +971,28 @@ void MainController::setupRecipeConnections() {
     // both should move the pill highlight. activateRecipe() sets the optimistic
     // lead; this keeps it honest afterwards.
     connect(m_settings->dye(), &SettingsDye::activeRecipeIdChanged, this, [this]() {
-        setSelectedRecipeId(m_settings->dye()->activeRecipeId());
+        if (m_recipeSelection.onActiveRecipeChanged(m_settings->dye()->activeRecipeId()))
+            emit selectedRecipeIdChanged();
     });
     // A FAILED activation never changes activeRecipeId (the connect above won't
-    // fire), so roll the optimistic selection back explicitly — otherwise a
-    // second tap would start a shot for a recipe that never applied.
+    // fire), so the model rolls the optimistic selection back — otherwise a
+    // second tap would start a shot for a recipe that never applied. The same
+    // event also resolves a deferred start armed by startSelectedRecipeShotWhenApplied.
     connect(this, &MainController::recipeActivated, this, [this](qint64 recipeId, bool success) {
-        if (!success && m_selectedRecipeId == recipeId) {
+        const auto o = m_recipeSelection.onActivationResult(
+            recipeId, success, m_settings->dye()->activeRecipeId());
+        if (o.reverted)
             qWarning() << "[recipe] activation failed for" << recipeId
                        << "- reverting selection to active recipe"
                        << m_settings->dye()->activeRecipeId();
-            setSelectedRecipeId(m_settings->dye()->activeRecipeId());
+        if (o.selectedChanged)
+            emit selectedRecipeIdChanged();
+        if (o.fireStart && m_device) {
+            qDebug() << "[recipe] activation applied — pulling the deferred shot for" << recipeId;
+            m_device->startEspresso();
+        } else if (o.fireStart || o.startDropped) {
+            qWarning() << "[recipe] deferred shot not pulled for" << recipeId
+                       << "(success=" << success << "device=" << (m_device != nullptr) << ")";
         }
     });
 
@@ -989,7 +1000,7 @@ void MainController::setupRecipeConnections() {
     // settings already persist on their own — nothing is re-applied; this
     // only restores the pill highlight, cache, and pinned-grind routing).
     const int savedRecipeId = m_settings->dye()->activeRecipeId();
-    m_selectedRecipeId = savedRecipeId > 0 ? savedRecipeId : -1;
+    m_recipeSelection.reset(savedRecipeId);
     if (savedRecipeId > 0)
         m_recipeStorage->requestRecipe(savedRecipeId);
 }
@@ -1000,25 +1011,32 @@ void MainController::activateRecipe(qint64 recipeId) {
         emit recipeActivated(recipeId, false);
         return;
     }
-    // Mark it selected NOW (synchronous), before the async DB read + BLE upload,
-    // so the "tap the selected pill again to start" gesture works on the very
-    // next tap. Confirmed on success / rolled back on failure (see the
+    // Optimistically select it NOW (synchronous), before the async DB read +
+    // BLE upload, so the "tap the selected pill again to start" gesture works on
+    // the very next tap. The model also cancels any deferred start armed for a
+    // different recipe. Confirmed on success / rolled back on failure (see the
     // activeRecipeIdChanged + recipeActivated connects in the constructor).
     qDebug() << "[recipe] activateRecipe" << recipeId << "- selecting + requesting activation";
-    setSelectedRecipeId(recipeId);
+    if (m_recipeSelection.onActivate(recipeId))
+        emit selectedRecipeIdChanged();
     m_recipeStorage->requestRecipeForActivation(recipeId);
 }
 
-void MainController::setSelectedRecipeId(qint64 recipeId) {
-    // Normalize any non-positive id (activeRecipeId's int default is -1, but the
-    // codebase treats both 0 and negatives as "none" via > 0 guards) to the -1
-    // sentinel, so no path can seed a stray 0 that the pill match would miss.
-    if (recipeId <= 0)
-        recipeId = -1;
-    if (m_selectedRecipeId == recipeId)
+void MainController::startSelectedRecipeShotWhenApplied() {
+    if (!m_device)
         return;
-    m_selectedRecipeId = recipeId;
-    emit selectedRecipeIdChanged();
+    switch (m_recipeSelection.requestStart(m_settings->dye()->activeRecipeId())) {
+    case RecipeSelectionModel::StartDecision::StartNow:
+        qDebug() << "[recipe] starting espresso for applied recipe" << m_recipeSelection.selected();
+        m_device->startEspresso();
+        break;
+    case RecipeSelectionModel::StartDecision::Deferred:
+        qDebug() << "[recipe] start armed — waiting for recipe" << m_recipeSelection.selected()
+                 << "to finish applying before pulling the shot";
+        break;
+    case RecipeSelectionModel::StartDecision::None:
+        break;
+    }
 }
 
 void MainController::checkRecipesUpgradeEligibility() {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -965,20 +965,55 @@ void MainController::setupRecipeConnections() {
     connect(m_settings->brew(), &SettingsBrew::waterVesselPresetsChanged, this,
             [this]() { stampActiveRecipeHotWater(); });
 
+    // selectedRecipeId (the synchronous pill-selection marker) follows
+    // activeRecipeId in steady state: a successful activation sets activeRecipeId
+    // (confirming our optimistic lead), and an external deactivation clears it —
+    // both should move the pill highlight. activateRecipe() sets the optimistic
+    // lead; this keeps it honest afterwards.
+    connect(m_settings->dye(), &SettingsDye::activeRecipeIdChanged, this, [this]() {
+        setSelectedRecipeId(m_settings->dye()->activeRecipeId());
+    });
+    // A FAILED activation never changes activeRecipeId (the connect above won't
+    // fire), so roll the optimistic selection back explicitly — otherwise a
+    // second tap would start a shot for a recipe that never applied.
+    connect(this, &MainController::recipeActivated, this, [this](qint64 recipeId, bool success) {
+        if (!success && m_selectedRecipeId == recipeId) {
+            qWarning() << "[recipe] activation failed for" << recipeId
+                       << "- reverting selection to active recipe"
+                       << m_settings->dye()->activeRecipeId();
+            setSelectedRecipeId(m_settings->dye()->activeRecipeId());
+        }
+    });
+
     // Startup restore: the persisted selection survives a restart (the live
     // settings already persist on their own — nothing is re-applied; this
     // only restores the pill highlight, cache, and pinned-grind routing).
     const int savedRecipeId = m_settings->dye()->activeRecipeId();
+    m_selectedRecipeId = savedRecipeId > 0 ? savedRecipeId : -1;
     if (savedRecipeId > 0)
         m_recipeStorage->requestRecipe(savedRecipeId);
 }
 
 void MainController::activateRecipe(qint64 recipeId) {
     if (!m_recipeStorage) {
+        qWarning() << "[recipe] activateRecipe" << recipeId << "- no recipe storage, activation failed";
         emit recipeActivated(recipeId, false);
         return;
     }
+    // Mark it selected NOW (synchronous), before the async DB read + BLE upload,
+    // so the "tap the selected pill again to start" gesture works on the very
+    // next tap. Confirmed on success / rolled back on failure (see the
+    // activeRecipeIdChanged + recipeActivated connects in the constructor).
+    qDebug() << "[recipe] activateRecipe" << recipeId << "- selecting + requesting activation";
+    setSelectedRecipeId(recipeId);
     m_recipeStorage->requestRecipeForActivation(recipeId);
+}
+
+void MainController::setSelectedRecipeId(qint64 recipeId) {
+    if (m_selectedRecipeId == recipeId)
+        return;
+    m_selectedRecipeId = recipeId;
+    emit selectedRecipeIdChanged();
 }
 
 void MainController::checkRecipesUpgradeEligibility() {

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -5,6 +5,7 @@
 #include <QMap>
 #include <QTimer>
 #include "profilemanager.h"
+#include "recipeselectionmodel.h"
 #include "../profile/profile.h"
 #include "../network/visualizeruploader.h"
 #include "../network/visualizerimporter.h"
@@ -151,7 +152,7 @@ public:
     EquipmentStorage* equipmentStorage() const { return m_equipmentStorage; }
     RecipeStorage* recipeStorage() const { return m_recipeStorage; }
     QVariantMap activeRecipe() const { return m_activeRecipe; }
-    qint64 selectedRecipeId() const { return m_selectedRecipeId; }
+    qint64 selectedRecipeId() const { return m_recipeSelection.selected(); }
     UnifiedBeanSearchModel* beanSearch() const { return m_beanSearch; }
     ShotImporter* shotImporter() const { return m_shotImporter; }
     ProfileConverter* profileConverter() const { return m_profileConverter; }
@@ -182,6 +183,16 @@ public:
     // path shared by QML pill taps, MCP recipe_activate, and the web
     // /activate route). Async; terminal status via recipeActivated().
     Q_INVOKABLE void activateRecipe(qint64 recipeId);
+    // Start an espresso shot for the currently SELECTED recipe, but only once
+    // its profile has actually been applied to the machine. If the selected
+    // recipe's activation is already confirmed (activeRecipeId == selectedRecipeId)
+    // the shot starts immediately; if activation is still in flight (the
+    // background DB read + BLE profile upload have not landed) the start is
+    // armed and fires the instant recipeActivated(id, true) arrives — so a fast
+    // second tap can never pull a shot on the previous, not-yet-replaced
+    // profile. A failed activation, or selecting a different recipe, cancels the
+    // armed start. Callers gate on machine-ready / canStartOperations first.
+    Q_INVOKABLE void startSelectedRecipeShotWhenApplied();
     // Leave the recipe (pill deselects). The recipe row itself is unchanged;
     // live settings stay as they are — the user is free-styling now.
     Q_INVOKABLE void deactivateRecipe();
@@ -470,10 +481,11 @@ private:
     // Outstanding write-through stamps whose recipeUpdated echo should not
     // trigger a cache re-read (mirrors SettingsDye::m_pendingSelfWrites).
     int m_pendingRecipeSelfWrites = 0;
-    // Synchronous "user has selected this recipe" marker (see selectedRecipeId
-    // Q_PROPERTY). Leads Settings.dye.activeRecipeId during activation. -1 = none.
-    qint64 m_selectedRecipeId = -1;
-    void setSelectedRecipeId(qint64 recipeId);
+    // Pure state machine behind selectedRecipeId + the deferred recipe-shot
+    // start. MainController only wires it to Qt signals and the device; the
+    // policy (lead/converge/rollback, arm/fire) lives in the header-only model
+    // so it can be unit-tested without linking MainController.
+    RecipeSelectionModel m_recipeSelection;
     // Apply the activation bundle on the main thread (recipeActivationReady).
     void applyActivatedRecipe(qint64 recipeId, const QVariantMap& recipe,
                               qint64 linkedBagId, const QVariantMap& linkedBag);

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -80,7 +80,11 @@ class MainController : public QObject {
     // or a failed activation rolls it back. This is the recipe analogue of the
     // profile pills' synchronous Settings.app.selectedFavoriteProfile, and is
     // the single source of truth shared by the regular (IdlePage) and compact
-    // (RecipesItem) pill rows so both behave identically. -1 = none.
+    // (RecipesItem) pill rows so both behave identically. -1 = none. Under
+    // rapidly interleaved activations it tracks the last-COMPLETED activation,
+    // not necessarily the last tap (same self-healing race as activeRecipe); it
+    // always re-converges to activeRecipeId, so the highlight never ends
+    // disagreeing with the active recipe.
     Q_PROPERTY(qint64 selectedRecipeId READ selectedRecipeId NOTIFY selectedRecipeIdChanged)
     Q_PROPERTY(UnifiedBeanSearchModel* beanSearch READ beanSearch CONSTANT)
     Q_PROPERTY(ShotImporter* shotImporter READ shotImporter CONSTANT)

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -70,6 +70,18 @@ class MainController : public QObject {
     // deactivation. QML reads name/steam fields from here; the id itself
     // lives in Settings.dye.activeRecipeId.
     Q_PROPERTY(QVariantMap activeRecipe READ activeRecipe NOTIFY activeRecipeChanged)
+    // The recipe the user has SELECTED in a pill row — set synchronously the
+    // instant activateRecipe() is called, so the two-tap "select then start"
+    // gesture (tap once to select, tap the selected pill again to pull the
+    // shot) fires on the very next tap without waiting for the async activation
+    // (background DB read + BLE profile upload) to echo back through
+    // Settings.dye.activeRecipeId. Leads activeRecipeId during activation, then
+    // tracks it: a successful activation confirms it, an external deactivation
+    // or a failed activation rolls it back. This is the recipe analogue of the
+    // profile pills' synchronous Settings.app.selectedFavoriteProfile, and is
+    // the single source of truth shared by the regular (IdlePage) and compact
+    // (RecipesItem) pill rows so both behave identically. -1 = none.
+    Q_PROPERTY(qint64 selectedRecipeId READ selectedRecipeId NOTIFY selectedRecipeIdChanged)
     Q_PROPERTY(UnifiedBeanSearchModel* beanSearch READ beanSearch CONSTANT)
     Q_PROPERTY(ShotImporter* shotImporter READ shotImporter CONSTANT)
     Q_PROPERTY(ProfileConverter* profileConverter READ profileConverter CONSTANT)
@@ -135,6 +147,7 @@ public:
     EquipmentStorage* equipmentStorage() const { return m_equipmentStorage; }
     RecipeStorage* recipeStorage() const { return m_recipeStorage; }
     QVariantMap activeRecipe() const { return m_activeRecipe; }
+    qint64 selectedRecipeId() const { return m_selectedRecipeId; }
     UnifiedBeanSearchModel* beanSearch() const { return m_beanSearch; }
     ShotImporter* shotImporter() const { return m_shotImporter; }
     ProfileConverter* profileConverter() const { return m_profileConverter; }
@@ -285,6 +298,7 @@ signals:
     // pill taps, MCP recipe_activate, and the web /activate route.
     void recipeActivated(qint64 recipeId, bool success);
     void activeRecipeChanged();
+    void selectedRecipeIdChanged();
 
     // Recipes-first layout upgrade offer (recipes-idle-layout-upgrade):
     // willCreateStarterRecipe/milkPreselected answer checkRecipesUpgradeEligibility().
@@ -452,6 +466,10 @@ private:
     // Outstanding write-through stamps whose recipeUpdated echo should not
     // trigger a cache re-read (mirrors SettingsDye::m_pendingSelfWrites).
     int m_pendingRecipeSelfWrites = 0;
+    // Synchronous "user has selected this recipe" marker (see selectedRecipeId
+    // Q_PROPERTY). Leads Settings.dye.activeRecipeId during activation. -1 = none.
+    qint64 m_selectedRecipeId = -1;
+    void setSelectedRecipeId(qint64 recipeId);
     // Apply the activation bundle on the main thread (recipeActivationReady).
     void applyActivatedRecipe(qint64 recipeId, const QVariantMap& recipe,
                               qint64 linkedBagId, const QVariantMap& linkedBag);

--- a/src/controllers/recipeselectionmodel.h
+++ b/src/controllers/recipeselectionmodel.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <QtGlobal>
+
+// Pure, dependency-free state machine behind MainController::selectedRecipeId
+// and the deferred recipe-shot start (add-recipes, PR #1470). Extracted from
+// MainController so it can be unit-tested directly — MainController itself is
+// never linked into the test suite (it pulls in nearly the whole app), so the
+// policy lives here and MainController only wires it to Qt signals + the device.
+//
+// selected() is the synchronous "user has chosen this recipe" marker. It leads
+// Settings.dye.activeRecipeId during activation (the async DB read + BLE profile
+// upload) and then converges to it: a successful activation confirms it, an
+// external deactivation clears it, a failed activation rolls it back. -1 = none.
+//
+// The deferred start (requestStart / onActivationResult) ensures a start gesture
+// that arrives before the recipe's profile is actually applied fires only once
+// activation completes — never pulling a shot on the previous, not-yet-replaced
+// profile. Selecting a different recipe cancels an armed start.
+class RecipeSelectionModel {
+public:
+    enum class StartDecision {
+        None,      // nothing selected — ignore
+        StartNow,  // selected recipe already applied — start immediately
+        Deferred,  // selected recipe still applying — armed; fires on completion
+    };
+
+    // Result of onActivationResult, so the caller can emit / log / start.
+    struct Outcome {
+        bool selectedChanged = false;  // emit selectedRecipeIdChanged()
+        bool reverted = false;         // a failed selection was rolled back (log)
+        bool fireStart = false;        // an armed deferred start should now fire
+        bool startDropped = false;     // an armed start was cancelled, not fired (log)
+    };
+
+    qint64 selected() const { return m_selected; }
+    qint64 pendingStart() const { return m_pendingStart; }
+
+    // Startup restore: seed the selection with no side effects.
+    void reset(qint64 activeId) {
+        m_selected = norm(activeId);
+        m_pendingStart = -1;
+    }
+
+    // activateRecipe(): a new selection cancels any armed start for a different
+    // recipe, then optimistically selects id. Returns true if selected changed.
+    bool onActivate(qint64 id) {
+        id = norm(id);
+        if (m_pendingStart > 0 && m_pendingStart != id)
+            m_pendingStart = -1;
+        return setSelected(id);
+    }
+
+    // activeRecipeIdChanged(): follow the confirmed active recipe (success
+    // confirms the lead; external deactivation clears it). Returns true if changed.
+    bool onActiveRecipeChanged(qint64 activeId) {
+        return setSelected(norm(activeId));
+    }
+
+    // A start gesture on the selected recipe: start now if its activation is
+    // already confirmed, else arm a deferred start.
+    StartDecision requestStart(qint64 activeId) {
+        if (m_selected <= 0)
+            return StartDecision::None;
+        if (norm(activeId) == m_selected)
+            return StartDecision::StartNow;
+        m_pendingStart = m_selected;
+        return StartDecision::Deferred;
+    }
+
+    // recipeActivated(id, success): roll back a failed selection and/or resolve
+    // an armed deferred start. Rollback runs first so a failed start can't fire.
+    Outcome onActivationResult(qint64 id, bool success, qint64 activeId) {
+        Outcome o;
+        if (!success && m_selected == id) {
+            o.reverted = true;
+            o.selectedChanged = setSelected(norm(activeId));
+        }
+        if (m_pendingStart > 0 && m_pendingStart == id) {
+            m_pendingStart = -1;  // one-shot: consume regardless of outcome
+            if (success && m_selected == id)
+                o.fireStart = true;
+            else
+                o.startDropped = true;
+        }
+        return o;
+    }
+
+private:
+    static qint64 norm(qint64 id) { return id > 0 ? id : -1; }
+    bool setSelected(qint64 id) {
+        if (m_selected == id)
+            return false;
+        m_selected = id;
+        return true;
+    }
+
+    qint64 m_selected = -1;
+    qint64 m_pendingStart = -1;
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,12 @@ add_decenza_test(tst_drinktypes
     tst_drinktypes.cpp
 )
 
+# --- tst_recipeselectionmodel: pure selection + deferred-start state machine
+# behind MainController::selectedRecipeId (header-only target; PR #1470) ---
+add_decenza_test(tst_recipeselectionmodel
+    tst_recipeselectionmodel.cpp
+)
+
 # --- tst_mcptools_shots_helpers: detectorResults envelope reshape (issue #1012) ---
 add_decenza_test(tst_mcptools_shots_helpers
     tst_mcptools_shots_helpers.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -400,6 +400,18 @@ add_decenza_test(tst_mmrwrite
     ${SIMULATOR_SOURCES}
 )
 
+# --- tst_de1device_headless: GHC "headless" gate default + disconnect reset (#1470) ---
+add_decenza_test(tst_de1device_headless
+    tst_de1device_headless.cpp
+    mocks/MockTransport.h
+    ${CMAKE_SOURCE_DIR}/src/ble/de1transport.h
+    ${BLE_SOURCES}
+    ${PROFILE_SOURCES}
+    ${CORE_SOURCES}
+    ${CONTROLLER_SOURCES}
+    ${SIMULATOR_SOURCES}
+)
+
 # --- tst_de1device_firmware: firmware-update BLE extensions on DE1Device ---
 add_decenza_test(tst_de1device_firmware
     tst_de1device_firmware.cpp

--- a/tests/tst_de1device_headless.cpp
+++ b/tests/tst_de1device_headless.cpp
@@ -1,0 +1,50 @@
+#include <QtTest>
+
+#include "ble/de1device.h"
+#include "mocks/MockTransport.h"
+
+// Guards the GHC "headless" gate default (PR #1470). m_isHeadless means "the
+// app may start operations on-screen". It must default TRUE (matching de1app,
+// whose ghc_is_installed defaults to 0 → ghc_required()==0 → app can start): a
+// false default bricks every start button on the common no-GHC machine until
+// (or unless) the GHC MMR read returns. Only a positive GHC read flips it
+// false, and a disconnect must restore the permissive default so a GHC
+// machine's false cannot bleed into the next connection.
+
+class tst_DE1DeviceHeadless : public QObject {
+    Q_OBJECT
+
+private:
+    struct TestFixture {
+        MockTransport transport;
+        DE1Device device;
+        TestFixture() { device.setTransport(&transport); }
+    };
+
+private slots:
+    void defaultsToHeadless() {
+        // A freshly constructed device (no GHC read yet) must allow app starts.
+        DE1Device device;
+        QCOMPARE(device.isHeadless(), true);
+    }
+
+    void disconnectRestoresHeadless() {
+        TestFixture f;
+        // Simulate a positive GHC read having marked the machine GHC-controlled.
+        f.device.setIsHeadless(false);
+        QCOMPARE(f.device.isHeadless(), false);
+
+        QSignalSpy spy(&f.device, &DE1Device::isHeadlessChanged);
+
+        // A connect/disconnect cycle must restore the permissive default so the
+        // next connection isn't left blocking start until its own GHC read.
+        f.transport.setConnectedSim(true);
+        f.transport.setConnectedSim(false);
+
+        QCOMPARE(f.device.isHeadless(), true);
+        QCOMPARE(spy.count(), 1);  // flipped once (setIsHeadless dedups), not a no-op
+    }
+};
+
+QTEST_MAIN(tst_DE1DeviceHeadless)
+#include "tst_de1device_headless.moc"

--- a/tests/tst_recipeselectionmodel.cpp
+++ b/tests/tst_recipeselectionmodel.cpp
@@ -1,0 +1,142 @@
+#include <QtTest>
+
+#include "controllers/recipeselectionmodel.h"
+
+// Unit tests for the pure selection/deferred-start state machine behind
+// MainController::selectedRecipeId (add-recipes, PR #1470). Extracted from
+// MainController precisely so this logic — the part that can pull a shot on the
+// wrong recipe if it regresses — is testable without linking the whole app.
+
+using SD = RecipeSelectionModel::StartDecision;
+
+class tst_RecipeSelectionModel : public QObject {
+    Q_OBJECT
+
+private slots:
+    void defaultsToNone() {
+        RecipeSelectionModel m;
+        QCOMPARE(m.selected(), qint64(-1));
+        QCOMPARE(m.pendingStart(), qint64(-1));
+    }
+
+    void resetNormalizesNonPositive() {
+        RecipeSelectionModel m;
+        m.reset(7);
+        QCOMPARE(m.selected(), qint64(7));
+        m.reset(0);   // 0 is a de-facto "none" in the codebase's > 0 guards
+        QCOMPARE(m.selected(), qint64(-1));
+        m.reset(-1);
+        QCOMPARE(m.selected(), qint64(-1));
+    }
+
+    void activateSelectsOptimistically() {
+        RecipeSelectionModel m;
+        QVERIFY(m.onActivate(42));            // changed
+        QCOMPARE(m.selected(), qint64(42));
+        QVERIFY(!m.onActivate(42));           // no-op, no change signal
+    }
+
+    void activateNormalizesZero() {
+        RecipeSelectionModel m;
+        m.onActivate(5);
+        QVERIFY(m.onActivate(0));             // 0 -> -1, that IS a change
+        QCOMPARE(m.selected(), qint64(-1));
+    }
+
+    void successConfirmsKeepsSelection() {
+        RecipeSelectionModel m;
+        m.onActivate(42);
+        // applyActivatedRecipe sets activeRecipeId=42 -> activeRecipeIdChanged.
+        QVERIFY(!m.onActiveRecipeChanged(42)); // already 42, no thrash
+        QCOMPARE(m.selected(), qint64(42));
+    }
+
+    void deactivateClearsSelection() {
+        RecipeSelectionModel m;
+        m.onActivate(42);
+        QVERIFY(m.onActiveRecipeChanged(-1));  // deactivate -> cleared
+        QCOMPARE(m.selected(), qint64(-1));
+    }
+
+    void failureRevertsToPriorActive() {
+        RecipeSelectionModel m;
+        m.onActivate(10);
+        m.onActiveRecipeChanged(10);           // 10 is the confirmed active recipe
+        m.onActivate(42);                      // optimistic switch to 42
+        QCOMPARE(m.selected(), qint64(42));
+        // 42's activation fails; activeRecipeId is still 10.
+        const auto o = m.onActivationResult(42, /*success=*/false, /*activeId=*/10);
+        QVERIFY(o.reverted);
+        QVERIFY(o.selectedChanged);
+        QCOMPARE(m.selected(), qint64(10));    // rolled back to the still-active recipe
+        QVERIFY(!o.fireStart);
+    }
+
+    void staleFailureDoesNotClobberNewerSelection() {
+        RecipeSelectionModel m;
+        m.onActivate(1);
+        m.onActivate(2);                       // user moved on to 2 before 1 resolved
+        QCOMPARE(m.selected(), qint64(2));
+        const auto o = m.onActivationResult(1, /*success=*/false, /*activeId=*/-1);
+        QVERIFY(!o.reverted);                  // guard: only reverts if selected == failed id
+        QCOMPARE(m.selected(), qint64(2));     // untouched
+    }
+
+    void startNowWhenAlreadyApplied() {
+        RecipeSelectionModel m;
+        m.onActivate(7);
+        m.onActiveRecipeChanged(7);            // applied
+        QCOMPARE(m.requestStart(/*activeId=*/7), SD::StartNow);
+        QCOMPARE(m.pendingStart(), qint64(-1)); // no defer armed
+    }
+
+    void startDefersWhilePending() {
+        RecipeSelectionModel m;
+        m.onActivate(5);                       // activeId still not 5
+        QCOMPARE(m.requestStart(/*activeId=*/-1), SD::Deferred);
+        QCOMPARE(m.pendingStart(), qint64(5));
+    }
+
+    void deferredStartFiresOnApply() {
+        RecipeSelectionModel m;
+        m.onActivate(5);
+        QCOMPARE(m.requestStart(-1), SD::Deferred);
+        // 5 finishes applying.
+        const auto o = m.onActivationResult(5, /*success=*/true, /*activeId=*/5);
+        QVERIFY(o.fireStart);
+        QVERIFY(!o.startDropped);
+        QCOMPARE(m.pendingStart(), qint64(-1)); // consumed one-shot
+    }
+
+    void deferredStartDroppedOnFailure() {
+        RecipeSelectionModel m;
+        m.onActivate(5);
+        m.requestStart(-1);                    // armed
+        const auto o = m.onActivationResult(5, /*success=*/false, /*activeId=*/-1);
+        QVERIFY(!o.fireStart);
+        QVERIFY(o.startDropped);
+        QCOMPARE(m.pendingStart(), qint64(-1));
+    }
+
+    void reselectCancelsArmedStart() {
+        RecipeSelectionModel m;
+        m.onActivate(3);
+        m.requestStart(-1);                    // armed for 3
+        QCOMPARE(m.pendingStart(), qint64(3));
+        m.onActivate(9);                       // user picks a different recipe
+        QCOMPARE(m.pendingStart(), qint64(-1)); // armed start cancelled
+        // 3's late completion must NOT start a shot.
+        const auto o = m.onActivationResult(3, /*success=*/true, /*activeId=*/3);
+        QVERIFY(!o.fireStart);
+        QVERIFY(!o.startDropped);               // nothing was armed for 3
+    }
+
+    void requestStartNoneWhenNothingSelected() {
+        RecipeSelectionModel m;
+        QCOMPARE(m.requestStart(-1), SD::None);
+        QCOMPARE(m.pendingStart(), qint64(-1));
+    }
+};
+
+QTEST_APPLESS_MAIN(tst_RecipeSelectionModel)
+#include "tst_recipeselectionmodel.moc"


### PR DESCRIPTION
## Problem

A user **without a GHC** reported that starting a shot from the **recipe pill** worked in the simulator but not on real hardware — while the **profile pill** worked in both. Two independent causes.

## 1. Recipe pill start — async selection race

The recipe pill's "tap the selected recipe again to start" gesture tested `Settings.dye.activeRecipeId`, which is only set at the **end** of the async activation pipeline (background DB read + BLE profile upload). On real hardware that echoes back *after* the user's second tap, so the tap re-activated instead of starting. The simulator (no BLE) completed activation instantly and masked the race.

**Fix:** `MainController.selectedRecipeId` — a synchronous, shared selection marker set the instant `activateRecipe()` is called (the recipe analogue of the profile pills' synchronous `Settings.app.selectedFavoriteProfile`). It leads `activeRecipeId` during activation, then tracks it:
- success confirms it,
- external deactivation (ingredient swap) clears it,
- **failed** activation rolls it back — so a second tap can't start a shot for a recipe that never applied.

Both the regular (`IdlePage`) and compact (`RecipesItem`) pill rows now share this one marker and behave identically. The compact popup previously **could not start a shot at all** — it only activated — so this closes a real layout gap.

## 2. GHC gate defaulted to "cannot start"

`m_isHeadless` defaulted to `false` ("app cannot start operations") until the GHC MMR read returned — inverted from de1app, whose `ghc_is_installed` defaults to `0` → `ghc_required()==0` → app can start. A slow or dropped read left **every** start button dead.

**Fix:** default `m_isHeadless = true`, and restore it on disconnect so a GHC machine's `false` can't carry into the next connection. The allowlist **values are unchanged** (`{0,1,2,4}`) — they already match de1app's `ghc_required`; only the default was wrong.

## Parity audit

Every espresso-start affordance was checked. The two pill re-tap paths were the only profile-specific starts with a recipe analogue, and both are now matched. The rest — MiniGHC button, custom `command:startEspresso`, keyboard "E", MCP `machine_start_espresso` — are profile-agnostic (they start the loaded profile, which *is* the active recipe's profile), so they already cover recipes. Profile pages (`ProfileSelectorPage`/`ProfileInfoPage`) never start a shot, exactly like `RecipesPage`.

## Diagnosability

QML `console.log` is captured by `WebDebugLogger`, so a user's debug log now pinpoints failures:
- recipe handlers distinguish the two gates (`app cannot start operations (active GHC?)` vs `machine not ready`),
- `DE1Device::startEspresso()` logs `state/headless/sim` for **every** start surface — the single anchor confirming whether the BLE command was issued.

## Testing

- Build clean (0 errors / 0 warnings).
- `tst_coffeebags`, `tst_recipestorage`, `tst_mcpserver_session`, `tst_mcpserver_protocol` all green (143 tests).
- The race is timing-dependent — **real-hardware verification still needed** (the simulator can't reproduce it): Recipes → tap a recipe → tap it again → shot starts on the second tap, in both regular and compact layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)