### PR TITLE
Fix Recipes page not re-applying an already-active recipe after edit

### DIFF
--- a/qml/pages/RecipesPage.qml
+++ b/qml/pages/RecipesPage.qml
@@ -212,7 +212,7 @@ Page {
             repointPicker.open()
         }
         onPlanClicked: {
-            if (!card.archivedCard && card.recipe.id !== Settings.dye.activeRecipeId)
+            if (!card.archivedCard)
                 MainController.activateRecipe(card.recipe.id)
         }
 
@@ -268,8 +268,7 @@ Page {
             accessibleName: TranslationManager.translate("recipes.accessible.activate", "Activate recipe %1").arg(card.recipe.name || "")
             accessibleItem: card
             onAccessibleClicked: {
-                if (card.recipe.id !== Settings.dye.activeRecipeId)
-                    MainController.activateRecipe(card.recipe.id)
+                MainController.activateRecipe(card.recipe.id)
             }
         }
 


### PR DESCRIPTION
## Summary
- `RecipesPage.qml` skipped `MainController.activateRecipe()` when the tapped recipe's id already matched `Settings.dye.activeRecipeId`, treating "already selected" as "already applied."
- Editing a recipe's profile/grind/bean while it's the active recipe only refreshes the internal `m_activeRecipe` cache (via `recipeUpdated`/`recipeReady`) — it never re-pushes those values into the live `ProfileManager`/`SettingsDye` state the Shot Plan reads.
- Re-tapping the edited (still-active) recipe on the Recipes page was therefore a silent no-op, so the Shot Plan stayed stale until switching profiles deactivated the recipe first (only then did a re-tap actually run a real activation).
- `activateRecipe()`/`applyActivatedRecipe()` are already fully idempotent — they always re-read the recipe row and re-apply every stage (profile, bag, grind, dose/yield/temp, steam, hot water) — so dropping the guard is safe, and brings `RecipesPage.qml` in line with `RecipesItem.qml`/`IdlePage.qml`, which already call `activateRecipe()` unconditionally.

Fixes #1466

## Test plan
- [ ] In the Recipe editor, edit the profile/grind/bean of the currently active recipe and save.
- [ ] Go to the Recipes page and tap the same (still-active) recipe's plan area.
- [ ] Confirm the Shot Plan on the home screen updates immediately to the new profile/bean/grind, without needing to switch to a different profile first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
