### PR TITLE
Fix Windows label clipping + installer icons (#1469, #1467)

### DIFF
--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -42,6 +42,11 @@ LZMAUseSeparateProcess=yes
 ; Visual settings
 WizardStyle=modern
 SetupIconFile=..\resources\icons\decenza.ico
+; Without this, Inno Setup shows a generic icon for the Start Menu "Uninstall"
+; shortcut and the Control Panel > Programs and Features entry, even though
+; the app's own exe already has the logo embedded (see CMakeLists.txt
+; QT_WIN_RC_ICONS). (#1467)
+UninstallDisplayIcon={app}\{#TargetName}.exe
 
 ; Privileges
 PrivilegesRequired=lowest
@@ -71,6 +76,13 @@ Name: "{autodesktop}\{#TargetProduct}"; Filename: "{app}\{#TargetName}.exe"; Tas
 [Run]
 ; Install VC++ Runtime (silently, only if needed)
 Filename: "{tmp}\{#VcRedistFile}"; Parameters: "/install /quiet /norestart"; StatusMsg: "{cm:InstallingVCRedist}"; Flags: waituntilterminated skipifsilent
+
+; Windows caches exe/shortcut icons per-user (IconCache.db) — updating over an
+; older install can otherwise leave Explorer/Start Menu/Programs and Features
+; showing a stale generic icon even though the new exe has the logo embedded
+; and UninstallDisplayIcon is now set above. ie4uinit is Microsoft's own
+; built-in tool for invalidating that cache. (#1467)
+Filename: "{sys}\ie4uinit.exe"; Parameters: "-ClearIconCache"; Flags: runhidden waituntilterminated
 
 ; Option to launch after install
 Filename: "{app}\{#TargetName}.exe"; Description: "{cm:LaunchProgram,{#StringChange(TargetProduct, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -356,7 +356,7 @@ Dialog {
                 font: Theme.bodyFont
                 color: Theme.textSecondaryColor
                 Layout.alignment: Qt.AlignVCenter
-                Layout.preferredWidth: Theme.scaled(75)
+                Layout.minimumWidth: Theme.scaled(75)
                 Accessible.ignored: true
             }
 
@@ -390,7 +390,7 @@ Dialog {
                 font: Theme.bodyFont
                 color: Theme.textSecondaryColor
                 Layout.alignment: Qt.AlignVCenter
-                Layout.preferredWidth: Theme.scaled(75)
+                Layout.minimumWidth: Theme.scaled(75)
                 Accessible.ignored: true
             }
 
@@ -563,7 +563,7 @@ Dialog {
                     font: Theme.bodyFont
                     color: Theme.textSecondaryColor
                     Layout.alignment: Qt.AlignVCenter
-                    Layout.preferredWidth: Theme.scaled(75)
+                    Layout.minimumWidth: Theme.scaled(75)
                     Accessible.ignored: true  // Label for sighted users; input has accessibleName
                 }
 
@@ -641,7 +641,7 @@ Dialog {
                     font: Theme.bodyFont
                     color: Theme.textSecondaryColor
                     Layout.alignment: Qt.AlignVCenter
-                    Layout.preferredWidth: Theme.scaled(75)
+                    Layout.minimumWidth: Theme.scaled(75)
                     Accessible.ignored: true
                 }
 
@@ -717,7 +717,7 @@ Dialog {
                     text: TranslationManager.translate("brewDialog.ratioLabel2", "Ratio:")
                     font: Theme.bodyFont
                     color: Theme.textSecondaryColor
-                    Layout.preferredWidth: Theme.scaled(75)
+                    Layout.minimumWidth: Theme.scaled(75)
                     Accessible.ignored: true  // Label for sighted users; input has accessibleName
                 }
 
@@ -888,7 +888,7 @@ Dialog {
                     font: Theme.bodyFont
                     color: Theme.textSecondaryColor
                     Layout.alignment: Qt.AlignVCenter
-                    Layout.preferredWidth: Theme.scaled(75)
+                    Layout.minimumWidth: Theme.scaled(75)
                     Accessible.ignored: true
                 }
 

--- a/qml/components/ChangeBeansDialog.qml
+++ b/qml/components/ChangeBeansDialog.qml
@@ -1779,7 +1779,7 @@ Dialog {
         }
     }
 
-    // Labelled form row: fixed-width label + caller-supplied controls
+    // Labelled form row: shared-width label + caller-supplied controls
     component FieldRow: RowLayout {
         property string labelKey: ""
         property string labelFallback: ""
@@ -1795,7 +1795,13 @@ Dialog {
             font: Theme.bodyFont
             color: Theme.textSecondaryColor
             Layout.alignment: Qt.AlignVCenter
-            Layout.preferredWidth: Theme.scaled(85)
+            // "Equipment:" is the widest label used through this row (see
+            // BrewDialog.qml's equivalent row), so let it size to its content
+            // (min = the shared 85px column) rather than a fixed 85px that
+            // clips it and lets the value butt right against it — this is
+            // what happens on Windows, where Segoe UI renders it wider than
+            // Roboto/San Francisco do at the same pixel size.
+            Layout.minimumWidth: Theme.scaled(85)
             Accessible.ignored: true
         }
     }

--- a/qml/components/EquipmentInfoDialog.qml
+++ b/qml/components/EquipmentInfoDialog.qml
@@ -153,7 +153,12 @@ Dialog {
             text: label + ":"
             font: Theme.labelFont
             color: Theme.textSecondaryColor
-            Layout.preferredWidth: Theme.scaled(130)
+            // Fixed preferred width would clip/collide with the value when a
+            // label renders wider than expected (long translation, or a
+            // platform font with wider glyph metrics) — minimumWidth lets it
+            // grow instead. See ChangeBeansDialog.qml FieldRow / BrewDialog.qml
+            // (issue #1469).
+            Layout.minimumWidth: Theme.scaled(130)
             Accessible.ignored: true
         }
         Text {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <QQmlContext>
 #include <QQuickStyle>
 #include <QQuickWindow>
+#include <QScreen>
 #include <QSettings>
 #include <QIcon>
 #include <QTimer>
@@ -356,6 +357,18 @@ int main(int argc, char *argv[])
     // Bluetooth classes are constructed.
     BtLogFilter::install();
 
+#ifdef Q_OS_WIN
+    // Windows expresses monitor scaling as a percentage (100/125/150/175/200%),
+    // which Qt converts to a fractional device pixel ratio (e.g. 150% -> 1.5).
+    // Non-integer ratios are Qt's own documented cause of layout/text overflow
+    // and sizing artifacts (see doc.qt.io/qt-6/highdpi.html) — and 125%/150%
+    // are common Windows laptop defaults, unlike macOS/Android's integer-ratio
+    // scaling. Round to the nearest whole multiple so every pixel-based
+    // Theme.scaled() computation lands on integer device pixels. Must be set
+    // before QApplication is constructed. (#1469)
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor);
+#endif
+
     QApplication app(argc, argv);
 
 #ifdef Q_OS_MACOS
@@ -413,6 +426,19 @@ int main(int argc, char *argv[])
     qDebug() << "Platform:" << QSysInfo::prettyProductName().simplified()
              << "arch:" << QSysInfo::currentCpuArchitecture()
              << "kernel:" << QSysInfo::kernelType() << QSysInfo::kernelVersion();
+    if (QScreen *screen = QGuiApplication::primaryScreen()) {
+        // Windows expresses monitor scaling as a percentage (100/125/150%...),
+        // which Qt turns into a devicePixelRatio that can be fractional unless
+        // setHighDpiScaleFactorRoundingPolicy() rounds it — logged here so a
+        // reporter's debug log actually shows what scale/DPI their box ran at
+        // instead of us guessing (font/layout overflow reports, e.g. #1469).
+        qDebug() << "Display:" << screen->name()
+                 << "devicePixelRatio:" << screen->devicePixelRatio()
+                 << "logicalDPI:" << screen->logicalDotsPerInch()
+                 << "physicalDPI:" << screen->physicalDotsPerInch()
+                 << "geometry:" << screen->geometry()
+                 << "availableGeometry:" << screen->availableGeometry();
+    }
 #ifdef Q_OS_ANDROID
     {
         jint sdkInt = QJniObject::getStaticField<jint>("android/os/Build$VERSION", "SDK_INT");


### PR DESCRIPTION
## Summary

**#1469 (Windows font/layout display issues)** — investigated the ~23 screenshots in the issue; this PR addresses the confirmed, root-caused part of it:

- Fixed the "label text collides with its value" bug seen in the Edit Bag / New Bag dialogs ("EquipmentTurin DF83V") and the Brew Settings dialog ("Dose cup:" colon clipped). Root cause: several shared label components (`ChangeBeansDialog.qml`'s `FieldRow`, six rows in `BrewDialog.qml`, `EquipmentInfoDialog.qml`'s `InfoRow`) size their label column with a fixed `Layout.preferredWidth` and no `elide`. That's fine until a platform's substituted font (Segoe UI on Windows) renders the label wider than the column — the value then butts right up against it with no gap, since the RowLayout still positions the next sibling at the fixed offset. One row in `BrewDialog.qml` ("Equipment:") already had this exact fix (`Layout.minimumWidth`, with a comment explaining why); this PR applies the same fix to the other six rows plus the two other shared components that had the same gap.
- Added Windows DPI diagnostics to startup logging (`devicePixelRatio`, logical/physical DPI, screen geometry) — the app previously logged nothing about display scale, making it impossible to confirm or rule out DPI-scaling causes from a reporter's debug log.
- Set `setHighDpiScaleFactorRoundingPolicy(RoundPreferFloor)` on Windows. Qt's own docs call out fractional device pixel ratios (from Windows' very common 125%/150% scaling, vs. macOS/Android's integer-ratio scaling) as a documented cause of layout/text overflow artifacts. This is a plausible contributor to the remaining unconfirmed symptoms in #1469 (right-edge overflow, scrollbar overlapping content, a popup rendering at a different scale than its parent page) — flagging honestly that this part is well-sourced but not proven the way the label-clipping fix is; the new DPI logging will let us confirm from the next Windows debug log.
- Still open / not addressed in this PR: a vertical-collapse overlap in Shot Review's bean-base row, and a few one-off layout quirks (see issue for details) — no confirmed root cause yet for those.

**#1467 (Windows installer icon)**
- The exe itself has had the logo embedded since March (`QT_WIN_RC_ICONS` in `CMakeLists.txt`), so if the reporter still sees a generic icon there it's most likely Windows' icon cache showing a stale entry from an older install.
- The Start Menu "Uninstall" shortcut and Control Panel > Programs and Features entry, however, were genuinely missing an icon — `installer/setup.iss` never set `UninstallDisplayIcon`. Fixed.
- Added a post-install `ie4uinit.exe -ClearIconCache` step so a stale Windows icon cache doesn't mask this fix on upgrade installs going forward.

## Test plan
- [ ] Windows: install via the updated installer, confirm Start Menu "Uninstall Decenza" and Control Panel > Programs and Features show the logo (not a generic icon)
- [ ] Windows: open Edit Bag / New Bag / Brew Settings dialogs, confirm labels no longer collide with values
- [ ] Windows: check a fresh debug log for the new `Display:` line (devicePixelRatio / DPI / geometry)
- [ ] Sanity-check macOS/Android builds are unaffected (label fix is cross-platform safe; DPI policy change is Windows-only via `#ifdef Q_OS_WIN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)