### PR TITLE
Fix label clipping regression in new Recipe/Stop-at rows (BrewDialog)

### DIFF
--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -510,7 +510,7 @@ Dialog {
                 font: Theme.bodyFont
                 color: Theme.textSecondaryColor
                 Layout.alignment: Qt.AlignVCenter
-                Layout.preferredWidth: Theme.scaled(75)
+                Layout.minimumWidth: Theme.scaled(75)
                 Accessible.ignored: true
             }
 
@@ -986,7 +986,7 @@ Dialog {
                         font: Theme.bodyFont
                         color: Theme.textSecondaryColor
                         Layout.alignment: Qt.AlignVCenter
-                        Layout.preferredWidth: Theme.scaled(75)
+                        Layout.minimumWidth: Theme.scaled(75)
                         Accessible.ignored: true  // Label for sighted users; input has accessibleName
                     }
 


### PR DESCRIPTION
## Summary
- The `recipe-aware-brew-settings` merge (just landed on `main`) added two new label rows to `BrewDialog.qml` — "Recipe:" and "Stop at:" — using the same fixed `Layout.preferredWidth(75)` label-column pattern that #1475 just fixed everywhere else in this file (#1469).
- Switches both to `Layout.minimumWidth` so they don't reintroduce the same Windows label/value collision.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>