### PR TITLE
Fix stale migration-30 schema_version expectations in tst_coffeebags

### DIFF
--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -865,7 +865,7 @@ private slots:
             QCOMPARE(q.value(0).toInt(), 0);  // existing rows default to 0
             QVERIFY(q.exec("SELECT version FROM schema_version"));
             QVERIFY(q.next());
-            QCOMPARE(q.value(0).toInt(), 29);  // chain runs on to the latest (recipes bag_id)
+            QCOMPARE(q.value(0).toInt(), 30);  // chain runs on to the latest (recipe-owned grind)
         });
     }
 
@@ -1146,7 +1146,7 @@ private slots:
             QSqlQuery q(db);
             QVERIFY(q.exec("SELECT version FROM schema_version"));
             QVERIFY(q.next());
-            QCOMPARE(q.value(0).toInt(), 29);  // chain runs on to the latest (recipes bag_id)
+            QCOMPARE(q.value(0).toInt(), 30);  // chain runs on to the latest (recipe-owned grind)
         });
     }
 
@@ -1179,7 +1179,7 @@ private slots:
             QSqlQuery q(db);
             QVERIFY(q.exec("SELECT version FROM schema_version"));
             QVERIFY(q.next());
-            QCOMPARE(q.value(0).toInt(), 29);  // chain runs on to the latest (recipes bag_id)
+            QCOMPARE(q.value(0).toInt(), 30);  // chain runs on to the latest (recipe-owned grind)
             // The repaired table is writable — insertRecipeStatic binds
             // rpm_pinned unconditionally, so it would fail wholesale if the
             // ALTER hadn't landed.


### PR DESCRIPTION
## Summary
- Root cause of the Linux CI failure on the current v2.0.0 pre-release rebuild: `tst_coffeebags.cpp` had three tests hardcoding `schema_version == 29` as "the latest" after re-running the migration chain from an older snapshot.
- PR #1472 added migration 30 (recipe-owned grind) without updating these three assertions, so CTest failed with `Actual: 30, Expected: 29` in all three.
- Linux is the only release workflow that runs the test suite (`BUILD_TESTS=ON` + ctest), which is why only that platform's build failed while Windows/macOS/Android/iOS/Linux-ARM64 all succeeded.
- Updates all three to expect 30 and refreshes the stale comment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>