### PR TITLE
Rework add-remote-mcp-connector openspec for zero-infrastructure Tail…

### DIFF
--- a/openspec/changes/add-remote-mcp-connector/design.md
+++ b/openspec/changes/add-remote-mcp-connector/design.md
@@ -1,223 +1,229 @@
 ## Context
 
-The existing MCP server (`src/mcp/mcpserver.cpp`) speaks Streamable
-HTTP + SSE on the LAN with no auth. Users reach it from Claude Desktop
-via the `mcp-remote` bridge. Claude and OpenAI mobile apps cannot use
-`mcp-remote`; their "custom connector" UIs expect a remote MCP URL that
-is HTTPS, speaks Streamable HTTP, and authenticates via OAuth 2.1 with
-PKCE and Dynamic Client Registration (DCR), per the current MCP auth
-spec.
+The MCP server (`src/mcp/mcpserver.cpp`) speaks Streamable HTTP at
+protocol `2025-11-25` on the LAN with no auth. Claude and ChatGPT
+mobile apps can only use a "custom connector" whose URL is fetched
+**by the vendor's cloud backend** — the phone never dials the server
+directly. So LAN reachability, tailnet-only reachability, and
+phone-side VPNs are all irrelevant; the endpoint must be public HTTPS
+with a valid certificate.
 
-Two hard problems: (a) an espresso machine on a home Wi-Fi is not
-publicly reachable, (b) running an OAuth AS inside a Qt app is
-non-trivial.
+Hard constraints for this revision:
+
+1. **Zero developer-run infrastructure.** Decenza is free; nothing in
+   this change may create recurring cost or an operations burden.
+2. Primary deployment target is **Decenza on an Android tablet**
+   (typically a dedicated, plugged-in, screen-on device next to the
+   machine).
 
 ## Goals / Non-Goals
 
 - **Goals**
-  - Claude mobile and ChatGPT mobile can add Decenza as a custom
-    connector with no desktop intermediary.
-  - No regression for existing `mcp-remote` users.
-  - User controls what scopes each client gets; can revoke.
+  - Claude mobile (iOS/Android) and ChatGPT mobile can add Decenza as
+    a custom connector with no desktop intermediary and no
+    developer-run service.
+  - Stable connector URL (survives app restart, reboot, IP change,
+    CGNAT).
+  - No regression for LAN / `mcp-remote` users.
+  - User can revoke remote access instantly.
 - **Non-Goals**
-  - Multi-user / multi-tenant auth. The device owner is the only
-    principal.
-  - Federation with external IdPs (Google, Apple). The device *is* the
-    AS.
-  - A general-purpose reverse-tunnel product. Relay is narrow: MCP
-    JSON-RPC only.
+  - OAuth / per-client identity and scopes. Without an AS there is one
+    principal: whoever holds the capability URL.
+  - Multi-user / multi-tenant auth.
+  - A general-purpose reverse tunnel. The public surface is the MCP
+    route only.
 
 ## Decisions
 
-### 1. Decenza is its own OAuth Authorization Server, federating to Google/Microsoft for identity
+### 1. Capability URL instead of OAuth
 
-Claude and ChatGPT mobile connectors require Dynamic Client
-Registration (RFC 7591). Google and Microsoft do not expose open DCR —
-apps must be pre-registered per client in their developer console. So
-we cannot simply point connectors at `accounts.google.com`. Decenza
-therefore runs its own AS, but defers *identity* to Google/Microsoft
-via standard OIDC.
+claude.ai custom connectors treat OAuth as optional: if the server
+never returns a `401` challenge, the connector runs unauthenticated.
+(OAuth client ID/secret are optional "advanced settings"; verified
+against Anthropic's connector docs, July 2026.)
 
-Alternatives considered:
+So authorization is an unguessable URL path:
 
-- **Fully managed AS that supports DCR + social login** (Auth0, Clerk,
-  WorkOS, Keycloak). Cleanest security story but mandates a cloud
-  account for every user even for LAN use, and DCR is a paid tier on
-  most providers.
-- **Decenza AS with a device-only passcode, no IdP**. Simplest, but
-  makes the tablet itself the only auth factor — a stolen tablet is a
-  stolen machine. Rejected in favor of mandatory IdP login.
-- **Chosen**: Decenza AS + mandatory Google/Microsoft OIDC at consent
-  time. No passwords stored on device, stolen-tablet risk is bounded
-  by the IdP account.
+```
+https://<host>/mcp/<token>        token = 128-bit CSPRNG, base64url
+```
 
-**Flow**: `/authorize` → Decenza shows "Sign in with Google /
-Microsoft" → browser completes OIDC auth code + PKCE against the IdP →
-Decenza verifies the `id_token` signature via the IdP's JWKS, checks
-`iss`, `aud`, `exp`, and matches `sub` (preferred) or `email` against
-the configured device owner → shows consent dialog on device → on
-approve, issues Decenza's own access token (unrelated to the IdP
-token).
+- Wrong/missing token → `404` with no body that reveals an MCP server
+  exists. Constant-time comparison. Per-source rate limit on failures
+  (brute force is cryptographically hopeless at 128 bits; the limit
+  is defense-in-depth and log hygiene).
+- **Rotation is revocation**: Settings has one "rotate" action; the
+  old URL dies instantly, the UI shows the new URL/QR and reminds the
+  user to update the connector on claude.ai.
+- Trade-off, stated honestly: the MCP auth spec discourages secrets
+  in URLs because URLs land in logs and proxies. Accepted here
+  because (a) the alternative — an internet-facing OAuth 2.1 AS
+  written in Qt/C++ — is a far larger attack surface than a static
+  token, (b) the TLS hop is end-to-end through the tunnel vendors so
+  only Anthropic's backend and the tunnel vendor see the path, and
+  (c) blast radius is bounded by `mcpAccessLevel` and the in-app
+  confirmation dialog for machine-start operations.
+- Existing LAN behavior (`/mcp`, no token) is unchanged and never
+  reachable through the remote surface.
 
-JWT access tokens signed with a per-device Ed25519 key; public key
-published at the AS metadata endpoint. Refresh tokens are opaque and
-stored server-side (on the device) so revoke is immediate. IdP tokens
-are verified and discarded — Decenza does not hold IdP refresh tokens.
+**Alternative rejected — on-device OAuth 2.1 AS + IdP federation**
+(the earlier draft): ~2+ weeks of security-critical C++, DCR, JWKS,
+consent flows… none of it required by the connector platforms for a
+single-owner device. If per-client scopes are ever genuinely needed,
+revisit; the capability-URL scheme doesn't preclude adding OAuth
+later (a `401` challenge simply starts being emitted).
 
-**Non-goal for this change**: a device-only passcode fallback for
-users who refuse a Google/Microsoft account. Deferred until a user
-actually asks.
+### 2. Isolated remote surface
 
-### 2. Two reachability options: relay (Option A) and DuckDNS+UPnP (Option B)
+Tunnels terminate at a **dedicated loopback listener** (its own port,
+owned by `McpRemoteAccess`) that routes *only*
+`POST/GET/DELETE /mcp/<token>` and returns `404` for everything else.
+ShotServer's web editor, REST API, and data-migration endpoints are
+never exposed publicly, and a future ShotServer route can't
+accidentally leak into the remote surface. The listener forwards
+in-process to the same `McpServer` dispatch the LAN path uses, with a
+session flag marking the session remote (for the status UI and rate
+limiting).
 
-Connector URLs are fetched by Anthropic/OpenAI's cloud backends, not
-by the user's phone — so the URL must be publicly reachable. Tailscale
-Funnel and Cloudflare Tunnel are ruled out on Android (Decenza's
-primary platform). Two options ship in this change:
+### 3. Reachability: embedded tsnet + Funnel (A, primary), embedded ngrok (B, deferred), BYO URL (C, fallback)
 
-**Option A — Decenza relay (recommended)**
-Extend the existing `decenza-shotmap` backend (`api.decenza.coffee`).
-The device keeps its existing outbound WebSocket; the relay exposes an
-HTTP endpoint that bridges MCP JSON-RPC to the WebSocket using a
-DynamoDB correlation-ID pattern. The OAuth AS runs on the relay
-(Lambda) and validates tokens using the device's stored public key —
-the device never runs an internet-facing HTTP listener.
+Mode A is the flagship: the driving user already runs Tailscale, so
+account friction is zero for them, and it is the strongest option on
+merits (stable free URL, managed certs, CGNAT-immune, no metered
+tier). Mode C ships alongside because it costs almost nothing beyond
+the shared core. Mode B waits for demand.
 
-Pros: works on Android and all other platforms regardless of NAT/CGNAT;
-infrastructure already exists and is maintained; near-zero incremental
-cost on the existing Lambda stack; device attack surface is zero.
+**Mode A — tsnet/libtailscale + Funnel (primary).**
+The earlier draft ruled out "Tailscale Funnel on Android" — correct
+for the *Tailscale app* (still true; tailscale/tailscale#17071 open),
+wrong for the *library*. `tsnet` embeds via gomobile and is exactly
+what the official Android client is built on:
 
-Cons: dependency on `api.decenza.coffee` uptime (LAN path stays
-functional if relay is down); dual-repo change (Decenza + shotmap).
+- Userspace netstack: no `VpnService`, so no conflict with a user's
+  real VPN, no root, and no Android VPN-slot fight.
+- `ListenFunnel()` yields a public HTTPS listener at
+  `https://<node>.<tailnet>.ts.net` — stable name, CGNAT-immune,
+  cert issued/renewed by Tailscale, free plan, no metered tier.
+- Login flow: tsnet surfaces an auth URL → show as QR/link; user
+  approves once. Funnel additionally needs the one-time
+  funnel-attribute approval, also surfaced as a URL.
+- Funnel constraint: public ports limited to 443/8443/10000 (we need
+  one); throughput is modest (MCP JSON is tiny).
+- Costs: ~20–30 MB APK (Go runtime), Funnel is beta, the Go wrapper
+  is a new build artifact (small Go lib → AAR via gomobile, checked
+  into `libs/` or built in CI).
 
-**Option B — DuckDNS + UPnP + Let's Encrypt (on-device)**
-For users who prefer no relay dependency. Device handles DDNS, UPnP
-port mapping, ACME cert issuance, and runs the OAuth AS and HTTPS
-listener directly.
+**Mode A is multi-platform.** One Go wrapper codebase, per-platform
+build outputs:
 
-Pros: no external dependency, fully self-contained.
+| Platform | Build output | Notes |
+|---|---|---|
+| Android | AAR via gomobile | Primary target, ships first |
+| Windows/macOS/Linux | `c-shared` library (`.dll`/`.dylib`/`.so`) | Plain cgo; tsnet's userspace netstack coexists with an installed Tailscale client (no TUN conflict). Desktop users with the official client can alternatively just run `tailscale funnel` themselves = Mode C |
+| iOS | xcframework via gomobile | Feasible (the official iOS app is built on libtailscale); no Network Extension entitlement needed since we don't route device traffic, so its memory cap doesn't apply. Sequenced last |
 
-Cons: ~25–45% of users will be behind CGNAT or have UPnP disabled
-and silently fail; our OAuth AS is directly internet-facing; ACME
-renewal logic is ~1 week of additional work; security surface is larger.
+The C API surface (`Up/Down/Status/LoginURL/FunnelURL`) is identical
+everywhere; only packaging differs. CI builds the artifacts per
+platform (Go toolchain added to the relevant workflows).
 
-**Why DuckDNS** (over No-IP / Dynu / others): its TXT-update API is a
-single GET call (`/update?domains=...&token=...&txt=...`), requires no
-SDK, and has been the standard ACME DNS-01 backend for home users for
-~a decade.
+**Mode B — ngrok agent SDK (deferred).** `ngrok-java` runs on Android. Free
+account + free static domain → stable URL, TLS at ngrok's edge.
+Smaller than tsnet, not beta. Caveats: free-tier bandwidth caps
+(fine for JSON), and ngrok's browser-warning interstitial — served
+only to browser-like user agents; **must verify during
+implementation** that Anthropic's MCP client passes through, else
+Mode B ships disabled.
 
-The relay architecture variant `AS-on-Relay` noted previously is now
-the actual Option A design — not a variant.
+**Mode C — BYO public URL (fallback).** A base-URL setting + docs.
+Covers power users (existing Tailscale/cloudflared on any home box,
+forwarding to the tablet's LAN IP), covers iOS/desktop builds of
+Decenza, and is the fallback whenever A breaks. Nearly free: the
+remote listener + token work is shared, the "tunnel" is the user's
+problem. It also unblocks testing the whole flow before the tsnet
+wrapper lands — a Funnel on any machine on the same tailnet can
+front the tablet in the meantime.
 
-### 3. IdP sign-in in the browser, scope consent on the device
+**Rejected reachability options:**
 
-The OAuth `/authorize` endpoint redirects the connector's browser tab
-to Google/Microsoft for sign-in. On return, Decenza verifies the
-`id_token` and then parks the flow, showing "Check your Decenza
-device screen to approve" in the browser while a QML dialog on the
-machine asks the owner to allow/deny the requested scopes. This splits
-the two concerns cleanly: the browser handles identity (where the
-user expects to type their Google/Microsoft password), the device
-handles authorization (where the user can physically see their
-espresso machine).
+- **Decenza relay** (`api.decenza.coffee` + Lambda/DynamoDB bridge):
+  violates the no-developer-infrastructure constraint. (A Cloudflare
+  Workers free-tier relay would be $0/month but is still
+  developer-operated; rejected for ops burden, kept in mind as a
+  future premium feature.)
+- **DuckDNS + UPnP + ACME direct exposure**: 25–45% silent failure
+  (CGNAT / UPnP disabled), ~1 week of ACME work, device itself
+  becomes internet-facing. Strictly dominated by A/B.
+- **Cloudflare quick tunnels**: free and accountless but the URL
+  rotates per launch — useless for a connector configured once on
+  claude.ai. (Named tunnels require the user to own a domain; that
+  recipe goes in the Mode C docs instead.)
+- **DuckDNS + Cloudflare combined**: structurally impossible —
+  Cloudflare tunnels/proxying require the hostname's zone in the
+  user's Cloudflare account; `duckdns.org` isn't delegable, and
+  DuckDNS can't point at an ephemeral quick-tunnel host (SNI/Host
+  routing, no cert).
+- **Tailscale Android app alongside Decenza**: still no Funnel
+  support in the app; requires the VPN slot; rejected.
 
-Client registration metadata (`client_id` → Google/Microsoft OAuth app)
-ships with the build; per-user IdP secrets are not required because we
-use the PKCE public-client flow against the IdP.
+### 4. Access control and confirmations unchanged
 
-**Cost**: both IdPs are free for our usage. Google Cloud OAuth clients
-cost nothing to create; requesting only `openid`/`email`/`profile`
-avoids Google's "sensitive scope" verification process entirely and
-has no user cap in production. Microsoft Entra app registration is
-free, including multi-tenant apps that accept personal accounts via
-the `common` endpoint. The only ongoing obligation is keeping the
-OAuth consent-screen metadata (homepage URL, privacy policy URL)
-current.
+`mcpAccessLevel` (read/control/full) and `mcpConfirmationLevel` apply
+to remote sessions identically to LAN sessions — same tool-dispatch
+gates, same in-app `McpConfirmDialog` for machine-start operations
+(the held-response pattern works through tunnels; 15 s dialog timeout
+is well under tunnel idle timeouts). Remote sessions count toward the
+same session and rate limits.
 
-### 4. Scope model mirrors existing access levels
+### 5. Android reliability
 
-We already have `Settings::mcpAccessLevel` (0=read, 1=control, 2=full).
-Map 1:1 to `mcp:read`, `mcp:control`, `mcp:full`. No new authorization
-model; OAuth just gates which level a given client is allowed to ask
-for.
+The tunnel client lives in the app process. Decenza tablets are
+typically plugged in and screen-on (the app already keeps the screen
+awake), so Doze is a corner case, not the common case. Still:
+
+- Run tunnel maintenance off the main thread; reconnect with backoff
+  on network change (`QNetworkInformation`).
+- Surface a clear status ("Public URL active / reconnecting / off")
+  in Settings; never pretend the URL works while the tunnel is down.
+- If the app is backgrounded and Android kills connectivity, the
+  connector fails closed (Anthropic's backend gets a timeout). No
+  FCM wake-up is possible without a relay — documented limitation.
 
 ## Risks / Trade-offs
 
-- **CGNAT excludes some users entirely** → Detect at setup and refuse
-  clearly; point to the future paid relay.
-- **UPnP is flaky** → First-class error messages when mapping fails;
-  document manual port forwarding as a follow-up.
-- **Direct internet exposure of the AS** → Narrow surface (PKCE-only,
-  no passwords, no implicit), rate limiting on `/oauth/*` and `/mcp`,
-  unit tests per RFC 7636 §4.6 vectors, external review before ship.
-- **ACME renewal failure silently breaks remote MCP** → Alert in the
-  UI 20+ days before expiry if renewal hasn't succeeded.
-- **Token storage on a jailbroken/rooted device** → QtKeychain where
-  available; document that remote MCP is only as secure as the device.
-- **Protocol churn** → MCP auth spec is young. Keep version negotiation
-  permissive and log unknown fields rather than rejecting.
+- **Token in URL** → mitigations in Decision 1; document plainly.
+- **APK size (+20–30 MB, Mode A)** → gate the tsnet dependency so
+  builds without it remain possible; evaluate Play Store dynamic
+  feature module if size complaints materialize.
+- **Funnel is beta / Tailscale policy changes** → Mode B and C exist;
+  mode switching is a settings change, not a migration.
+- **ngrok interstitial or free-tier changes** → verify early (task
+  4.1); Mode B is optional to ship.
+- **Vendor account friction** (Tailscale/ngrok sign-up) → one-time,
+  QR-assisted; still far less friction than DuckDNS+UPnP or a
+  desktop bridge.
+- **Protocol churn on the connector side** → the MCP server already
+  negotiates three protocol versions; nothing here touches protocol.
 
 ## Migration Plan
 
-1. Ship behind a feature flag (`remoteMcpEnabled`, default off).
-2. Beta with willing users via the existing pre-release channel.
-3. GA after one release cycle with no auth-related bugs.
-4. `mcp-remote`/LAN path remains supported indefinitely — it's the
-   local dev story.
-
-Rollback: flipping `remoteMcpEnabled` off releases the UPnP mapping,
-rebinds the listener to loopback, and stops DDNS updates. No data
-migration.
-
-## Open-Source Dependencies
-
-| Concern | Library | License | Role |
-|---|---|---|---|
-| JWT sign/verify, JWKS | [`jwt-cpp`](https://github.com/Thalhammer/jwt-cpp) (header-only) | MIT | Access-token signing (Ed25519), IdP `id_token` verification, JWKS caching |
-| OIDC client (Google/Microsoft PKCE) | `QtNetworkAuth` (`QOAuth2AuthorizationCodeFlow`) | LGPLv3 / commercial (already in our Qt install) | Browser-based sign-in against the IdP |
-| WebSocket (relay) | `QWebSocket` (Qt Network) | LGPLv3 / commercial (already in) | Outbound WSS to relay |
-| Reference AS (if relay on Workers) | [`cloudflare/workers-oauth-provider`](https://github.com/cloudflare/workers-oauth-provider) | MIT | Off-device AS covering OAuth 2.1 + RFC 8414/9728/7591 + CIMD — used only if the relay also terminates auth |
-| Reverse tunnel (BYO) | [Cloudflare Tunnel](https://github.com/cloudflare/cloudflared) / Tailscale Funnel | Apache-2.0 / BSD-3 | User-side tunnel for `tunnel` mode; no code in our repo |
-| Test vectors | RFC 7636 §4.6 (PKCE), OIDF conformance suite | — | Validate our AS |
-
-Nothing in the C++/Qt ecosystem implements an embeddable OAuth 2.1 AS
-with DCR/CIMD — verified via a spec-level survey as of 2026. We write
-that piece; `jwt-cpp` removes the crypto work. The existing
-`hkr04/cpp-mcp` and `GopherSecurity/gopher-mcp` C++ SDKs do not cover
-the auth surface, so we continue with our in-tree `McpServer`.
-
-## Architecture Variant: AS-on-Relay
-
-A late-discovered alternative is to run the OAuth AS **at the relay**
-rather than on the device, using `workers-oauth-provider` on Cloudflare
-Workers. The device becomes a pure resource server: it only validates
-bearer tokens (JWT verified against the relay's JWKS) and enforces
-scope → access-level mapping. All of §2 (OAuth AS endpoints,
-registration, consent redirect) moves off-device.
-
-Trade-offs vs. on-device AS:
-
-- **Pro**: removes the riskiest C++ code from the device; leverages a
-  maintained OSS AS; consent can still be proxied to the device via a
-  polling endpoint.
-- **Pro**: aligns with where DCR/CIMD traffic naturally lands (public
-  HTTPS).
-- **Con**: hard dependency on the Decenza relay for authentication —
-  the BYO-tunnel mode would need to ship its own AS or fall back to
-  CIMD-only with a pre-registered Claude/OpenAI client list.
-- **Con**: Cloudflare Workers lock-in for the AS implementation, or
-  we port `workers-oauth-provider` to a neutral runtime (several
-  community ports exist but none battle-tested).
-
-Recommendation: **prototype both**. If the on-device AS takes >2 weeks
-or hits security-review blockers, switch to AS-on-Relay for production
-and keep the on-device AS as the BYO-tunnel fallback.
+1. Ship the shared core (capability token + isolated listener) with
+   Mode C (BYO URL) behind the `remoteMcpEnabled` toggle (default
+   off) — this immediately enables the Tailscale-on-another-box
+   setup, so the end-to-end Claude-mobile flow is testable on a real
+   tailnet before any Go code lands.
+2. Ship Mode A (embedded tsnet + Funnel) as the headline feature.
+3. Mode B (ngrok) only after the interstitial check passes and
+   non-tailnet users ask for it.
+3. Rollback = toggle off: tunnels stop, remote listener closes,
+   token stays stored. No data migration in either direction.
+4. The earlier draft's relay/OAuth work was never started; nothing to
+   unwind.
 
 ## Open Questions
 
-- Do we want per-tool scopes (e.g. `mcp:shots:read`) or is the
-  three-level model enough? Start with three; split later if needed.
-- Refresh-token lifetime: 30 d vs 90 d. Leaning 30 d with sliding
-  renewal.
-- Relay hosting: Cloudflare Workers + Durable Objects vs a small Fly
-  app. Decided separately; doesn't affect the on-device spec.
+- Package tsnet wrapper as a prebuilt AAR checked into the repo vs
+  built in CI (Go toolchain in the Android workflow)?
+- Should rotate-token also be exposed as an MCP tool (self-serve
+  "lock out other clients"), or Settings-only? Leaning Settings-only.
+- Do we want a second, read-only token (share "monitor my machine"
+  without control)? Deferred; needs per-token access levels.

--- a/openspec/changes/add-remote-mcp-connector/proposal.md
+++ b/openspec/changes/add-remote-mcp-connector/proposal.md
@@ -1,130 +1,133 @@
-# Change: Upgrade MCP server for Claude & OpenAI custom connectors
+# Change: Zero-infrastructure remote MCP for Claude / ChatGPT mobile connectors
 
 ## Why
-Decenza's MCP server today listens on plain HTTP on the LAN with no
-authentication. Claude (claude.ai / Claude mobile) and OpenAI (ChatGPT
-custom connectors) can only talk to an MCP endpoint that is:
 
-1. Reachable on the public internet over HTTPS,
-2. Speaks the current **Streamable HTTP** transport (protocol
-   `2025-06-18`),
-3. Authenticates the caller via **OAuth 2.1** with PKCE and
-   **Dynamic Client Registration** (RFC 7591), advertised through
-   `.well-known/oauth-protected-resource` and
-   `.well-known/oauth-authorization-server`.
+Decenza's MCP server listens on plain HTTP on the LAN. Claude
+(claude.ai / Claude mobile) and ChatGPT custom connectors dial the MCP
+endpoint **from the vendor's cloud backend, not from the user's
+phone** — so the endpoint must be reachable on the public internet
+over HTTPS with a valid certificate. Today the only bridge is
+`mcp-remote` on a desktop on the same LAN, which excludes the mobile
+apps entirely.
 
-Meeting those three gates unlocks using Decenza's MCP from the Claude
-and ChatGPT **mobile** apps (and desktop/web), which is the whole point
-— today you have to run `mcp-remote` on a laptop on the same LAN.
+Two constraints shape this revision (superseding the earlier draft of
+this change):
+
+1. **No developer-run service.** Decenza is a free app; a relay
+   (previous Option A) adds ongoing cost and operational burden.
+   Every reachability option must run on-device or on infrastructure
+   the *user* owns (free tiers of Tailscale / ngrok, or their own
+   tunnel).
+2. **OAuth is not actually required.** Verified against claude.ai's
+   connector documentation: the OAuth client ID/secret are *optional*
+   advanced settings. A server that never returns a `401` challenge is
+   connected unauthenticated. That removes the largest work item of
+   the earlier draft (an on-device OAuth 2.1 AS with DCR and
+   Google/Microsoft OIDC federation) in favour of a capability URL.
+
+The MCP protocol side is already done: the server speaks Streamable
+HTTP at protocol `2025-11-25` (with `2025-06-18` / `2025-03-26`
+fallbacks) since change `update-mcp-protocol-2025-11-25`.
 
 ## What Changes
 
-- **BREAKING**: Bump supported MCP protocol version to `2025-06-18`
-  (Streamable HTTP). Keep `2025-03-26` as a fallback for existing
-  `mcp-remote` users; drop `2024-11-05`.
-- Add an **OAuth 2.1 authorization server** inside Decenza that
-  **federates identity to Google and Microsoft** via OIDC:
-  - Authorization Code + PKCE (S256) only; no implicit, no client_secret flow.
-  - Dynamic Client Registration endpoint (`/oauth/register`) per RFC 7591
-    so Claude/OpenAI can self-register without the user copy-pasting
-    client IDs. (Google/Microsoft don't support open DCR, which is why
-    Decenza must be the AS rather than pointing connectors directly at
-    them.)
-  - Before issuing a code, the user signs in with Google or Microsoft.
-    Decenza verifies the OIDC `id_token` and checks the `sub`/`email`
-    against the device owner configured in Settings. A mismatch is a
-    hard deny.
-  - Token endpoint issuing short-lived (1 h) access tokens + refresh
-    tokens, scoped to the configured MCP access level.
-  - Consent screen rendered in the QML app on the device after
-    successful IdP sign-in ("Claude is requesting access to your
-    espresso machine — Read / Control / Full").
-  - Metadata documents at `/.well-known/oauth-protected-resource` and
-    `/.well-known/oauth-authorization-server`.
-- First-run setup for remote MCP: user picks Google or Microsoft, signs
-  in once, and that identity becomes the device owner. Identity is
-  required — there is no device-only passcode fallback in this change
-  (tracked as a follow-up if users request it).
-- Require `Authorization: Bearer <token>` on every MCP request once
-  remote mode is enabled; return `401` with `WWW-Authenticate: Bearer
-  resource_metadata="..."` per MCP auth spec so clients discover the
-  AS.
-- Add a **public-reachability** story. The connector URL must be
-  reachable from Anthropic/OpenAI's cloud backends — LAN-only and
-  tailnet-only options don't work (Tailscale Funnel is also ruled out
-  because it doesn't support Android). Two options are offered in
-  Settings → Remote MCP:
+- **Capability-URL authentication.** A remote request is authorized by
+  an unguessable path segment: `https://<host>/mcp/<token>` where
+  `<token>` is a 128-bit random value generated on-device. Wrong or
+  missing token → `404` (indistinguishable from no server). The user
+  can rotate the token at any time from Settings (rotation is the
+  revocation story). Comparison is constant-time; failed attempts are
+  rate-limited per source.
+- **Isolated remote surface.** Remote reachability modes forward to a
+  dedicated loopback listener that serves **only** the tokenized MCP
+  route. The rest of ShotServer (web layout editor, REST endpoints,
+  data-migration API) is never exposed publicly.
+- **Three reachability modes**, selectable in Settings → Remote MCP.
+  Mode A is the primary, flagship path of this change (the device
+  owner driving this change already runs a tailnet, and it is the
+  strongest zero-cost option overall); Mode C is a near-free fallback
+  that shares all the core work; Mode B is deferred until demand and
+  a compatibility check justify it:
 
-  **Option A — Decenza relay (recommended, works everywhere)**
-  Extend the existing `api.decenza.coffee` infrastructure
-  (AWS Lambda + API Gateway WebSocket, already running for Pocket)
-  with an MCP proxy endpoint. The device keeps its existing outbound
-  WebSocket open; Claude/OpenAI hit
-  `https://api.decenza.coffee/v1/mcp/<device-id>`. No port-forwarding,
-  no CGNAT issue, no extra software required.
-  - New Lambda `mcpProxy.ts`: validates Bearer JWT, looks up the
-    device's WebSocket connection ID in DynamoDB, forwards the MCP
-    JSON-RPC with a correlation ID, polls DynamoDB for the response
-    (up to 25 s), returns it as HTTP JSON.
-  - New WebSocket message actions `mcp_request` / `mcp_response` in
-    the existing `wsMessage.ts`.
-  - OAuth AS Lambdas (`oauthAuthorize`, `oauthToken`, `oauthRegister`,
-    `oauthRevoke`) added to the same stack; device generates a
-    per-device Ed25519 keypair and publishes its public key to the
-    relay's JWKS endpoint at setup time.
-  - Infrastructure cost: pennies/month on an already-running stack.
-    If this becomes a premium feature later, a subscription can be
-    added without changing the architecture.
+  **Mode A — Embedded Tailscale (tsnet) + Funnel (primary).**
+  Embed `tsnet`/libtailscale (the library the official Android client
+  is built on) via gomobile. It runs in userspace (its own netstack —
+  no `VpnService`, no conflict with other VPNs, no root). The app
+  joins the user's tailnet as its own node and calls `ListenFunnel()`
+  to get a stable public HTTPS URL
+  (`https://decenza.<tailnet>.ts.net/mcp/<token>`) with a Let's
+  Encrypt cert provisioned and renewed by Tailscale. Free plan,
+  no domain purchase, CGNAT-immune, no bandwidth-metered tier.
+  Cost: ~20–30 MB APK size for the Go runtime; Funnel is still
+  labeled beta; one-time account + funnel-attribute approval.
 
-  **Option B — DuckDNS + UPnP + Let's Encrypt (no relay dependency)**
-  For users who prefer no third-party relay. The device handles
-  everything locally:
-  1. User registers a DuckDNS subdomain + token.
-  2. Decenza keeps the A/AAAA record current on network change.
-  3. Decenza opens port 443 via UPnP (fallback NAT-PMP) and
-     detects CGNAT — if behind CGNAT, refuses and suggests Option A.
-  4. Decenza obtains a Let's Encrypt cert via ACME DNS-01 and renews
-     30 days before expiry.
-  5. The OAuth AS and HTTPS listener run entirely on-device at
-     `https://<subdomain>.duckdns.org`.
-- Settings UI:
-  - Toggle "Enable remote MCP (Claude / ChatGPT)".
-  - Shows the public URL to paste into the connector setup.
-  - Shows a QR code for mobile connector setup.
-  - Lists authorized clients with last-used timestamp and a revoke
-    button.
-- Scope model: map OAuth scopes to existing MCP access levels
-  (`mcp:read`, `mcp:control`, `mcp:full`) so the consent screen can show
-  meaningful choices instead of all-or-nothing.
+  **Mode B — Embedded ngrok (deferred).** Embed the ngrok agent SDK
+  (`ngrok-java`, Android-compatible). User pastes the authtoken from
+  their free ngrok account; the free tier includes one static domain,
+  so the connector URL is stable. Smaller binary than tsnet and not
+  beta; caveats are free-tier bandwidth limits and the browser-UA
+  interstitial (must verify Anthropic's backend passes through —
+  non-browser user agents do). Not scheduled until Mode A has shipped
+  and users without a tailnet ask for an alternative.
+
+  **Mode C — Bring-your-own URL (fallback).** A settings field for
+  a public base URL plus documentation. Users who already run
+  Tailscale, cloudflared, or any reverse proxy on *any* box at home
+  (the tunnel need not run on the tablet — it forwards to the
+  tablet's LAN IP) can connect Claude mobile with zero new
+  infrastructure code. This mode is also the escape hatch for
+  platforms where embedding a tunnel is impractical.
+
+- **Settings UI** (Remote MCP section):
+  - Enable toggle + mode selector (Tailscale / ngrok / Custom URL).
+  - Connection status and the full connector URL, with a copy button
+    and a QR code for configuring the connector on claude.ai.
+  - "Rotate token" action (invalidates the old URL immediately).
+  - Mode-specific setup: Tailscale login link/QR + Funnel approval
+    status; ngrok authtoken + static domain fields; custom base URL
+    field.
+- **Access control**: the existing `mcpAccessLevel` /
+  `mcpConfirmationLevel` settings govern remote sessions exactly as
+  they do LAN sessions, including the in-app confirmation dialog for
+  machine-start operations. Per-client scopes are deferred (without
+  OAuth there is no client identity to bind them to).
+
+### Explicitly removed from the earlier draft
+
+- **Decenza relay on `api.decenza.coffee`** (violates constraint 1).
+- **On-device OAuth 2.1 AS, Dynamic Client Registration,
+  Google/Microsoft OIDC federation** (unnecessary per constraint 2).
+- **DuckDNS + UPnP + Let's Encrypt direct exposure** — rejected:
+  25–45% silent failure on CGNAT/disabled UPnP, ~1 week of ACME work,
+  and it makes the device itself internet-facing. Modes A/B achieve
+  the same result with none of that. Revisit only on user demand.
+- **Protocol version bump** — already shipped separately.
 
 ## Impact
 
-- **Affected specs**: `mcp-server` (new capability — no spec exists yet;
-  this proposal introduces the first formal spec for the MCP surface,
-  limited to remote-connector concerns).
+- **Affected specs**: `mcp-server` (remote-connector concerns only).
 - **Affected code**:
-  - `src/mcp/mcpserver.{h,cpp}` — transport upgrade, auth middleware,
-    protocol version bump.
-  - `src/mcp/` — new `mcpoauth.{h,cpp}` (on-device AS, used by Option
-    B and for keypair management in Option A), `mcpidpclient.{h,cpp}`
-    (Google/Microsoft OIDC), `mcprelayclient.{h,cpp}` (Option A:
-    outbound WebSocket to `api.decenza.coffee`), `mcpduckdns.{h,cpp}`
-    (Option B: DDNS + ACME DNS-01), `mcpupnp.{h,cpp}` (Option B: UPnP
-    IGD + CGNAT detection).
-  - `src/core/settings.{h,cpp}` — remote-MCP toggle, mode (relay /
-    duckdns), DuckDNS credentials, current public URL, cert + keys,
-    registered clients, refresh tokens (QtKeychain / encrypted
-    QSettings).
-  - `qml/pages/SettingsPage.qml` + new `RemoteMcpTab.qml` and
-    `McpConsentDialog.qml`.
-  - **decenza-shotmap repo**: new Lambdas (`mcpProxy.ts`,
-    `oauthAuthorize.ts`, `oauthToken.ts`, `oauthRegister.ts`,
-    `oauthRevoke.ts`), new DynamoDB tables (oauth tokens, registered
-    clients), Terraform updates.
-- **Security**: first time the app accepts unauthenticated inbound
-  connections from the internet. All new endpoints must be covered by
-  the OAuth gate; the pre-existing localhost HTTP listener stays
-  unauthenticated but is bound to loopback only when remote mode is
-  on.
-- **User impact**: existing `mcp-remote` users keep working (LAN + no
-  auth stays the default). Remote mode is opt-in.
+  - `src/mcp/mcpremoteaccess.{h,cpp}` — new: coordinator (token
+    lifecycle, mode switching, remote-only loopback listener / route
+    gating, status signals for QML).
+  - `src/mcp/mcptunnel_tsnet.{h,cpp}` + `libs/tsnet-wrapper/` — new:
+    thin JNI/gomobile wrapper around a small Go library exposing
+    up/down/status/loginURL/funnel state.
+  - `src/mcp/mcptunnel_ngrok.{h,cpp}` — new: ngrok SDK binding.
+  - `src/network/shotserver.cpp` — route gating for the remote
+    listener (only `/mcp/<token>` served).
+  - `src/core/settings_network.{h,cpp}` — new properties (enabled,
+    mode, token, ngrok authtoken/domain, custom URL); token and
+    authtoken stored via QtKeychain where available.
+  - `qml/pages/settings/SettingsAITab.qml` (or new `RemoteMcpTab.qml`)
+    + QR code display component.
+  - `android/` — gradle packaging for the tsnet AAR (Mode A).
+- **Not affected**: no changes to any backend repo; no new cloud
+  infrastructure; LAN `mcp-remote` path unchanged.
+- **Security**: the public surface is a single tokenized MCP route
+  behind the tunnel vendor's TLS. The token-in-URL trade-off (URLs
+  appear in logs) is accepted for this threat model and mitigated by
+  rotation, rate limiting, and the existing access-level +
+  confirmation gates. See design.md.
+- **User impact**: existing LAN/`mcp-remote` users unaffected. Remote
+  mode is opt-in and defaults off.

--- a/openspec/changes/add-remote-mcp-connector/specs/mcp-server/spec.md
+++ b/openspec/changes/add-remote-mcp-connector/specs/mcp-server/spec.md
@@ -1,182 +1,150 @@
 ## ADDED Requirements
 
-### Requirement: Streamable HTTP Protocol Version
+### Requirement: Capability-URL Authorization for Remote Access
 
-The MCP server SHALL advertise `2025-06-18` as its preferred protocol
-version and SHALL accept `2025-03-26` as a fallback. Earlier versions
-(e.g. `2024-11-05`) SHALL be rejected.
+When remote MCP is enabled, the remote surface SHALL authorize
+requests solely by an unguessable capability token carried as a URL
+path segment (`/mcp/<token>`), where the token is a 128-bit
+cryptographically random value generated on-device. Token comparison
+SHALL be constant-time. Requests with a missing or non-matching token
+SHALL receive a bare HTTP `404` that does not reveal that an MCP
+server exists.
 
-#### Scenario: Client requests current version
-- **WHEN** a client sends `initialize` with `protocolVersion: "2025-06-18"`
-- **THEN** the server responds with `protocolVersion: "2025-06-18"`
+#### Scenario: Valid token
+- **WHEN** a client POSTs a JSON-RPC request to `/mcp/<token>` with the current token
+- **THEN** the request is dispatched to the MCP server and handled normally
 
-#### Scenario: Client requests legacy version
-- **WHEN** a client sends `initialize` with `protocolVersion: "2024-11-05"`
-- **THEN** the server responds with an error indicating the version is unsupported and lists the supported versions
+#### Scenario: Wrong token
+- **WHEN** a client POSTs to `/mcp/<other>` where `<other>` is not the current token
+- **THEN** the server returns `404` with no MCP-identifying headers or body
 
-### Requirement: OAuth 2.1 Protected Resource
+#### Scenario: Missing token
+- **WHEN** a client POSTs to `/mcp` on the remote surface
+- **THEN** the server returns `404`
 
-When remote MCP is enabled, every `/mcp` request SHALL carry a valid
-`Authorization: Bearer <token>` header. Requests without a token, or
-with an expired/revoked token, SHALL receive HTTP `401` with a
-`WWW-Authenticate: Bearer resource_metadata="<url>"` header pointing
-to the protected-resource metadata document.
+### Requirement: Token Rotation as Revocation
 
-#### Scenario: Unauthenticated request
-- **WHEN** a client POSTs to `/mcp` without an `Authorization` header and remote MCP is enabled
-- **THEN** the server returns `401` with `WWW-Authenticate: Bearer resource_metadata="https://<host>/.well-known/oauth-protected-resource"`
+The settings UI SHALL provide a rotate-token action. Rotation SHALL
+generate a fresh token, immediately close all active remote MCP
+sessions, and cause requests bearing the previous token to receive
+`404`. The UI SHALL display the new connector URL and QR code after
+rotation.
 
-#### Scenario: Expired access token
-- **WHEN** a client presents an access token whose `exp` claim is in the past
-- **THEN** the server returns `401` with `WWW-Authenticate: Bearer error="invalid_token"`
+#### Scenario: User rotates the token
+- **WHEN** the user confirms the rotate-token action
+- **THEN** a request using the old token returns `404` within one second and active remote sessions are terminated
 
-#### Scenario: Valid token with sufficient scope
-- **WHEN** a client presents a valid token with scope `mcp:control` and calls a control-level tool
-- **THEN** the server executes the tool and returns the result
+#### Scenario: New URL shown
+- **WHEN** rotation completes
+- **THEN** the settings UI displays the connector URL containing the new token, with copy and QR affordances
 
-#### Scenario: Valid token with insufficient scope
-- **WHEN** a client presents a valid token with scope `mcp:read` and calls a control-level tool
-- **THEN** the server returns a JSON-RPC error with code `-32002` and message indicating insufficient scope
+### Requirement: Isolated Remote Surface
 
-### Requirement: OAuth Authorization Server Metadata
+The remote reachability path SHALL terminate at a dedicated listener
+that serves only the tokenized MCP route (`POST`, `GET`, `DELETE` on
+`/mcp/<token>`). All other paths and methods on the remote surface
+SHALL return `404`. No other ShotServer route (web layout editor,
+REST endpoints, data-migration API) SHALL be reachable through the
+remote surface.
 
-The server SHALL publish RFC 8414 metadata at
-`/.well-known/oauth-authorization-server` and RFC 9728 protected-resource
-metadata at `/.well-known/oauth-protected-resource`, both reachable
-without authentication.
+#### Scenario: Non-MCP route via tunnel
+- **WHEN** a request arrives on the remote surface for any other path (e.g. `/layout`, `/api/shots`)
+- **THEN** the server returns `404`
 
-#### Scenario: AS metadata discovery
-- **WHEN** a client GETs `/.well-known/oauth-authorization-server`
-- **THEN** the response is `200` JSON containing `issuer`, `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `revocation_endpoint`, `code_challenge_methods_supported: ["S256"]`, and `scopes_supported: ["mcp:read","mcp:control","mcp:full"]`
+#### Scenario: LAN surface unchanged
+- **WHEN** a LAN client uses the existing local `/mcp` endpoint
+- **THEN** behavior is unchanged by remote mode being enabled or disabled
 
-#### Scenario: Protected-resource metadata discovery
-- **WHEN** a client GETs `/.well-known/oauth-protected-resource`
-- **THEN** the response is `200` JSON containing `resource` (the MCP endpoint URL) and `authorization_servers` (a list containing the device's AS issuer)
+### Requirement: Remote Sessions Honor Existing MCP Gates
 
-### Requirement: Dynamic Client Registration
+Remote MCP sessions SHALL be subject to the same `mcpAccessLevel`
+filtering, `mcpConfirmationLevel` confirmation flows (including the
+in-app dialog for machine-start operations), session limits, and
+rate limits as LAN sessions.
 
-The server SHALL accept RFC 7591 client registration at
-`/oauth/register` without prior credentials, and SHALL return a unique
-`client_id` for each registration.
+#### Scenario: Access level enforced remotely
+- **WHEN** `mcpAccessLevel` is Monitor Only and a remote client calls a control-category tool
+- **THEN** the call is rejected identically to the LAN behavior
 
-#### Scenario: New client registers
-- **WHEN** a client POSTs `{"client_name":"Claude","redirect_uris":["https://claude.ai/api/mcp/auth_callback"]}` to `/oauth/register`
-- **THEN** the server returns `201` with a JSON body containing `client_id`, the echoed `redirect_uris`, and `token_endpoint_auth_method: "none"`
+#### Scenario: In-app confirmation over the tunnel
+- **WHEN** `mcpConfirmationLevel` requires confirmation and a remote client calls `machine_start_espresso`
+- **THEN** the on-device confirmation dialog is shown and the held response resolves per the user's choice or the dialog timeout
 
-### Requirement: Authorization Code with PKCE
+### Requirement: Failed-Token Rate Limiting
 
-The `/oauth/authorize` endpoint SHALL require PKCE with method `S256`
-and SHALL reject requests with a missing or non-`S256`
-`code_challenge_method`. The `/oauth/token` endpoint SHALL verify
-`code_verifier` against the stored `code_challenge`.
+The remote surface SHALL rate-limit requests that fail token
+validation, per source, and SHALL log failures without echoing the
+attempted path.
 
-#### Scenario: Authorize without PKCE
-- **WHEN** a client GETs `/oauth/authorize` without `code_challenge`
-- **THEN** the server redirects to the client's `redirect_uri` with `error=invalid_request`
+#### Scenario: Repeated bad tokens
+- **WHEN** a source exceeds the failed-token limit
+- **THEN** further requests from that source are dropped or delayed for the limit window
 
-#### Scenario: Token exchange with wrong verifier
-- **WHEN** a client POSTs to `/oauth/token` with a `code_verifier` that does not match the stored challenge
-- **THEN** the server returns `400` with `error=invalid_grant`
+### Requirement: Reachability Mode — Embedded Tailscale Funnel
 
-### Requirement: Federated Identity via Google or Microsoft
+In Tailscale mode, the app SHALL run an embedded tsnet node
+(userspace, no system VPN interface) that joins the user's tailnet
+and exposes the remote surface via Tailscale Funnel at a stable
+`https://<node>.<tailnet>.ts.net` URL with a certificate managed by
+Tailscale. Setup SHALL surface the tsnet login URL (link and QR) and
+any required Funnel-approval URL. Disabling remote MCP SHALL bring
+the tsnet listener down; an explicit forget action SHALL wipe the
+tsnet node state.
 
-Before showing the on-device consent dialog, `/oauth/authorize` SHALL
-redirect the user to Google or Microsoft for OIDC sign-in and SHALL
-verify the returned `id_token` (`iss`, `aud`, `exp`, signature via the
-IdP's JWKS). The authenticated `sub` SHALL match the device owner
-configured for that IdP; a mismatch SHALL deny the request.
+#### Scenario: First-time Tailscale setup
+- **WHEN** the user selects Tailscale mode and enables remote MCP with no prior tsnet state
+- **THEN** the UI shows the tailnet login URL as link and QR and reports status until the node is authorized and Funnel is active
 
-#### Scenario: First-time device owner setup
-- **WHEN** the user enables remote MCP and completes Google or Microsoft sign-in during first-run setup
-- **THEN** the device stores the IdP issuer and `sub` as the device owner identity
+#### Scenario: Funnel active
+- **WHEN** the tsnet node is authorized and Funnel is enabled
+- **THEN** the UI displays the stable connector URL `https://<node>.<tailnet>.ts.net/mcp/<token>` and requests to it reach the remote surface
 
-#### Scenario: Authorized owner signs in
-- **WHEN** a connector initiates `/oauth/authorize` and the user signs in with the IdP matching the stored device owner
-- **THEN** the flow proceeds to the on-device consent dialog
+#### Scenario: Network change
+- **WHEN** the device changes networks while Tailscale mode is active
+- **THEN** the tsnet node reconnects automatically and the connector URL remains unchanged
 
-#### Scenario: Wrong account signs in
-- **WHEN** the IdP returns a valid `id_token` whose `sub` does not match the stored device owner
-- **THEN** the server redirects to the client's `redirect_uri` with `error=access_denied` and logs the mismatch
+#### Scenario: Forget tailnet
+- **WHEN** the user invokes the forget action
+- **THEN** the tsnet state directory is wiped and re-enabling requires a fresh tailnet login
 
-#### Scenario: Invalid id_token signature
-- **WHEN** the IdP callback returns an `id_token` that fails JWKS signature verification
-- **THEN** the server redirects with `error=access_denied` and does not show the consent dialog
+### Requirement: Reachability Mode — Bring-Your-Own URL
 
-### Requirement: On-Device User Consent
+In custom-URL mode, the user SHALL provide an `https://` base URL
+that they have arranged to forward to the device's remote listener.
+The UI SHALL compose and display the full connector URL
+(`<base>/mcp/<token>`) with copy and QR affordances. The app SHALL
+NOT attempt to manage the user's tunnel.
 
-The device SHALL display a consent dialog on its own screen after
-successful IdP sign-in and before `/oauth/authorize` returns a code,
-showing the requesting client's name, its redirect URI host, and the
-requested scopes. The authorization request SHALL only complete on
-explicit user approval.
+#### Scenario: Custom URL configured
+- **WHEN** the user enters `https://coffee.example.ts.net` as the base URL
+- **THEN** the UI displays connector URL `https://coffee.example.ts.net/mcp/<token>` with copy and QR
 
-#### Scenario: User approves
-- **WHEN** the consent dialog is shown and the user taps Allow
-- **THEN** the server completes the authorization redirect with a valid `code`
+#### Scenario: Non-HTTPS rejected
+- **WHEN** the user enters an `http://` base URL
+- **THEN** the value is rejected with a validation message
 
-#### Scenario: User denies
-- **WHEN** the consent dialog is shown and the user taps Deny
-- **THEN** the server redirects to the client's `redirect_uri` with `error=access_denied`
+### Requirement: Remote Access Status Visibility
 
-#### Scenario: Consent times out
-- **WHEN** the consent dialog has been visible for more than 120 seconds with no response
-- **THEN** the server treats the request as denied and redirects with `error=access_denied`
+The settings UI SHALL show the live state of the remote surface
+(`off`, `starting`, `active`, `reconnecting`, `error`) and SHALL NOT
+display the connector URL as usable while the underlying tunnel is
+down.
 
-### Requirement: Relay Mode Reachability (Option A)
+#### Scenario: Tunnel drops
+- **WHEN** the active tunnel disconnects
+- **THEN** the status changes from `active` to `reconnecting` (or `error`) and the UI reflects that the URL is currently unreachable
 
-In relay mode, the Decenza app SHALL maintain an outbound WebSocket
-connection to `wss://api.decenza.coffee` and SHALL handle inbound
-`mcp_request` messages by dispatching to the in-process MCP server and
-returning results via `mcp_response`. The relay's HTTPS endpoint
-(`https://api.decenza.coffee/v1/mcp/<device-id>`) SHALL be used as the
-OAuth `issuer` and `resource` values.
+### Requirement: Remote MCP Disable Semantics
 
-#### Scenario: Relay connected, MCP request arrives
-- **WHEN** a valid MCP JSON-RPC request arrives at the relay HTTP endpoint with a valid Bearer token
-- **THEN** the relay forwards it to the device WebSocket, the device processes it, returns `mcp_response`, and the relay returns the result to the HTTP caller within 25 seconds
+Disabling remote MCP SHALL stop all tunnels, close the remote
+listener, and terminate remote sessions. The capability token SHALL
+be retained so re-enabling does not invalidate an already-configured
+connector.
 
-#### Scenario: Device offline
-- **WHEN** a MCP request arrives at the relay but the device has no active WebSocket connection
-- **THEN** the relay returns `503 Device Offline`
+#### Scenario: Toggle off
+- **WHEN** the user disables remote MCP
+- **THEN** in-flight remote sessions are closed, the remote listener stops, and the public URL ceases to resolve to the app
 
-#### Scenario: Remote MCP disabled
-- **WHEN** remote MCP is disabled
-- **THEN** the device SHALL close its relay WebSocket and the relay SHALL return `503` for any further requests to that device's endpoint
-
-### Requirement: DuckDNS + UPnP Reachability (Option B)
-
-In DuckDNS mode, the server SHALL expose itself directly using a
-user-registered DuckDNS subdomain, a UPnP-mapped port 443, and a
-Let's Encrypt certificate via ACME DNS-01. The
-`https://<subdomain>.duckdns.org` URL SHALL be used as the OAuth
-`issuer` and `resource` values.
-
-#### Scenario: Fully configured
-- **WHEN** remote MCP is enabled in DuckDNS mode with valid credentials, active UPnP mapping, and a non-expired cert
-- **THEN** the settings UI displays the DuckDNS URL and the HTTPS listener is bound on port 443
-
-#### Scenario: CGNAT detected
-- **WHEN** the UPnP-reported external IP does not match the outbound probe IP
-- **THEN** the server SHALL refuse to enable remote MCP and the UI SHALL suggest switching to relay mode
-
-#### Scenario: UPnP unavailable
-- **WHEN** no IGD device responds to SSDP discovery within 5 seconds
-- **THEN** the server SHALL refuse to enable remote MCP and the UI SHALL display instructions to enable UPnP or switch to relay mode
-
-#### Scenario: ACME renewal
-- **WHEN** the installed cert is within 30 days of expiry
-- **THEN** the server SHALL attempt ACME renewal via DuckDNS DNS-01; on success the new cert SHALL be hot-swapped without dropping connections
-
-#### Scenario: Remote MCP disabled
-- **WHEN** remote MCP is disabled
-- **THEN** the HTTPS listener SHALL stop, the UPnP mapping SHALL be released, and DDNS updates SHALL cease
-
-### Requirement: Client Revocation
-
-The settings UI SHALL list every registered client with its last-used
-timestamp and SHALL provide a revoke action that immediately
-invalidates all refresh and access tokens issued to that client.
-
-#### Scenario: User revokes a client
-- **WHEN** the user taps Revoke on a listed client
-- **THEN** subsequent MCP requests carrying any token previously issued to that client return `401 invalid_token` within one second
+#### Scenario: Re-enable
+- **WHEN** the user re-enables remote MCP in the same mode
+- **THEN** the previous connector URL (same host, same token) works again without reconfiguring claude.ai

--- a/openspec/changes/add-remote-mcp-connector/tasks.md
+++ b/openspec/changes/add-remote-mcp-connector/tasks.md
@@ -1,81 +1,106 @@
-## 1. Transport upgrade
+## 1. Remote surface + capability token (shared by all modes)
 
-- [ ] 1.1 Bump supported MCP protocol versions in `McpServer::handleInitialize` to `{"2025-06-18", "2025-03-26"}`; drop `2024-11-05`.
-- [ ] 1.2 Verify Streamable HTTP behavior against `2025-06-18` spec (single `/mcp` endpoint, `Mcp-Session-Id` header, JSON + SSE content negotiation).
-- [ ] 1.3 Bind the existing plain-HTTP listener to loopback only when remote mode is enabled.
+- [ ] 1.1 Add `src/mcp/mcpremoteaccess.{h,cpp}`: coordinator owning the
+      remote loopback listener, token lifecycle, mode switching, and
+      status (`off | starting | active | reconnecting | error`)
+      exposed to QML.
+- [ ] 1.2 Dedicated loopback listener that serves **only**
+      `POST/GET/DELETE /mcp/<token>`; every other path/method returns
+      a bare `404`. Forward matching requests in-process to
+      `McpServer` dispatch, with the session flagged remote.
+- [ ] 1.3 Token: 128-bit CSPRNG, base64url, generated on first enable;
+      constant-time comparison; "rotate token" slot that closes
+      active remote sessions immediately.
+- [ ] 1.4 Per-source rate limit on failed-token requests; log at
+      warning level without echoing the attempted path.
+- [ ] 1.5 Settings (in `settings_network`): `remoteMcpEnabled`
+      (default false), `remoteMcpMode` (tailscale | ngrok | custom),
+      `remoteMcpToken`, `remoteMcpCustomBaseUrl`, ngrok
+      authtoken/domain. Token + ngrok authtoken via QtKeychain when
+      available, AES-GCM-encrypted QSettings fallback.
+- [ ] 1.6 Remote sessions respect existing `mcpAccessLevel`,
+      `mcpConfirmationLevel`, session caps, and rate limits (verify —
+      no new gates, no bypasses).
 
-## 2. OAuth 2.1 authorization server
+## 2. Mode C — BYO public URL (ships first)
 
-- [ ] 2.1 Add `src/mcp/mcpoauth.{h,cpp}` implementing `/oauth/authorize`, `/oauth/token`, `/oauth/register`, `/oauth/revoke`.
-- [ ] 2.2 Enforce PKCE S256; reject missing/invalid `code_verifier`.
-- [ ] 2.3 Issue JWT access tokens (1 h) + opaque refresh tokens; sign with per-device key stored in QtKeychain.
-- [ ] 2.4 Serve `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`.
-- [ ] 2.5 Add `Authorization: Bearer` middleware in `McpServer::handleRequest`; unauthenticated requests return `401` with `WWW-Authenticate: Bearer resource_metadata="<url>"`.
-- [ ] 2.6 Map scopes → access levels (`mcp:read`→0, `mcp:control`→1, `mcp:full`→2); enforce at tool-dispatch time.
+- [ ] 2.1 Custom base URL field; validate `https://` scheme; display
+      the composed connector URL `<base>/mcp/<token>`.
+- [ ] 2.2 QR code + copy button for the connector URL.
+- [ ] 2.3 Docs: recipes for Tailscale Funnel on a home box,
+      cloudflared named tunnel (user-owned domain), generic reverse
+      proxy — all forwarding to the tablet's LAN IP + remote port.
 
-## 2a. Identity federation (Google / Microsoft OIDC)
+## 3. Mode A — Embedded Tailscale (tsnet) + Funnel
 
-- [ ] 2a.1 Register Decenza OAuth apps in Google Cloud Console and Microsoft Entra; ship `client_id`s in build config.
-- [ ] 2a.2 Add `src/mcp/mcpidpclient.{h,cpp}`: OIDC discovery, JWKS fetch + caching, PKCE auth-code flow against the IdP, `id_token` verification (`iss`, `aud`, `exp`, signature).
-- [ ] 2a.3 `/oauth/authorize` redirects to the IdP first; on callback, verifies `id_token` before showing the device consent dialog.
-- [ ] 2a.4 First-run setup captures device owner `sub` + `email` per IdP; store in `Settings`.
-- [ ] 2a.5 Reject authorization if the signed-in `sub` doesn't match the stored device owner for that IdP; return `error=access_denied` with a log line naming the mismatch.
-- [ ] 2a.6 Discard IdP access/refresh tokens after `id_token` verification — Decenza does not persist IdP tokens.
+- [ ] 3.1 Minimal Go library wrapping tsnet: `Up(stateDir)`, `Down()`,
+      `Status()`, `LoginURL()`, `FunnelURL()`, `ListenFunnel` →
+      forward to the loopback remote listener. Build as AAR via
+      gomobile; decide prebuilt-in-repo vs CI-built (open question).
+- [ ] 3.2 `src/mcp/mcptunnel_tsnet.{h,cpp}`: JNI binding, lifecycle,
+      state persistence dir, reconnect on network change
+      (`QNetworkInformation`), off-main-thread.
+- [ ] 3.3 Setup flow in Settings: show tsnet login URL as QR/link;
+      poll status until node is authorized; surface the
+      funnel-attribute approval URL when Tailscale requires it.
+- [ ] 3.4 Display resulting stable URL
+      `https://<node>.<tailnet>.ts.net/mcp/<token>`; verify cert
+      provisioning end-to-end.
+- [ ] 3.5 Gradle packaging; gate behind a CMake option so non-tsnet
+      builds still link; measure APK size delta.
+- [ ] 3.6 Logout/disable: `Down()`, wipe tsnet state dir on explicit
+      "forget this tailnet".
+- [ ] 3.7 Desktop (Windows/macOS/Linux): build the same Go wrapper as
+      a `c-shared` library, link via the identical C API; verify
+      coexistence with an installed Tailscale client.
+- [ ] 3.8 iOS: gomobile xcframework build of the same wrapper;
+      sequenced after Android + desktop ship.
 
-## 3. Consent UI
+## 4. Mode B — Embedded ngrok
 
-- [ ] 3.1 New `qml/components/McpConsentDialog.qml` showing client name, redirect URI host, requested scopes.
-- [ ] 3.2 Signal from `McpOAuth` → `MainController` → QML; resolve with allow/deny back to the pending `/oauth/authorize` request.
-- [ ] 3.3 Auto-dismiss after 2 min with implicit deny.
-
-## 4a. Option A — Decenza relay (decenza-shotmap repo)
-
-- [ ] 4a.1 **MCP proxy Lambda** (`backend/lambdas/mcpProxy.ts`):
-  - Validate `Authorization: Bearer` JWT against the requesting device's stored public key.
-  - Look up active WebSocket `connection_id` for the device in DynamoDB.
-  - If device not connected, return `503 Device Offline`.
-  - Write a pending `mcp_request` record to DynamoDB (`MCP_PENDING#<correlation_id>`), call `sendToConnection` to forward the MCP JSON-RPC body.
-  - Poll DynamoDB for `mcp_response` record every 200 ms, up to 25 s (API Gateway HTTP has 29 s timeout). Return 504 on timeout.
-  - Delete pending + response records after use.
-- [ ] 4a.2 **WebSocket message actions** in `wsMessage.ts`:
-  - `mcp_request`: relay-to-device; device receives full MCP JSON-RPC body + `correlation_id`.
-  - `mcp_response`: device-to-relay; handler writes `mcp_response` record to DynamoDB keyed by `correlation_id`.
-- [ ] 4a.3 **OAuth AS Lambdas**: `oauthAuthorize.ts`, `oauthToken.ts`, `oauthRegister.ts`, `oauthRevoke.ts`. Store clients + tokens in new DynamoDB table. Validate tokens using per-device public key (published by device at registration).
-- [ ] 4a.4 **Device keypair registration**: on first relay-mode enable, device generates Ed25519 keypair, calls `POST /v1/mcp/register-device` with `device_id` + public key + pairing token (re-uses existing pairing auth). Relay stores public key in DynamoDB.
-- [ ] 4a.5 **Terraform**: new DynamoDB tables (`mcp_pending`, `oauth_clients`, `oauth_tokens`), new Lambda + HTTP API Gateway routes (`/v1/mcp/{device_id}`, `/v1/oauth/*`, `/.well-known/oauth-*`).
-- [ ] 4a.6 **Decenza app relay client** (`src/mcp/mcprelayclient.{h,cpp}`): maintain outbound WSS to `wss://api.decenza.coffee` in relay mode; handle `mcp_request` messages by dispatching to `McpServer` in-process and writing the response back via `mcp_response`.
-
-## 4b. Option B — DuckDNS + UPnP + Let's Encrypt (on-device, no relay)
-
-- [ ] 4b.1 DuckDNS setup wizard: prompt for subdomain + API token; verify by calling `https://www.duckdns.org/update`.
-- [ ] 4b.2 Periodic IP refresh (hourly + on network change) posting to DuckDNS with backoff on failure.
-- [ ] 4b.3 UPnP IGD port mapping for external 443 → internal 443. Minimal SSDP + IGD:1/IGD:2 SOAP client (~200–300 LOC). Fall back to NAT-PMP.
-- [ ] 4b.4 CGNAT detection: compare UPnP `GetExternalIPAddress` against an outbound probe. On mismatch, disable and suggest Option A.
-- [ ] 4b.5 ACME v2 DNS-01 client (DuckDNS): account key generation, order → TXT challenge → finalize, cert download, renewal 30 days before expiry.
-- [ ] 4b.6 HTTPS listener on 443 using issued cert; bind `0.0.0.0` only after CGNAT check passes.
-- [ ] 4b.7 Release UPnP mapping cleanly on shutdown / disable.
+- [ ] 4.1 **Spike first**: confirm Anthropic's connector backend is
+      not blocked by ngrok's free-tier browser interstitial. If
+      blocked, mark Mode B not-shippable and stop here.
+- [ ] 4.2 Integrate `ngrok-java` (Android); authtoken + static domain
+      fields in Settings; tunnel to the remote loopback listener.
+- [ ] 4.3 Reconnect/backoff on network change; status surfacing.
 
 ## 5. Settings UI
 
-- [ ] 5.1 New `qml/pages/settings/RemoteMcpTab.qml` with enable toggle, mode selector (relay | tunnel), public URL display, QR code.
-- [ ] 5.2 Authorized clients list with last-used timestamp and revoke button (revokes refresh token + all access tokens for that client).
-- [ ] 5.3 i18n keys under `settings.remoteMcp.*`.
-- [ ] 5.4 Accessibility review (consent dialog, toggle, list delegates per CLAUDE.md rules).
+- [ ] 5.1 Remote MCP section (extend `SettingsAITab.qml` MCP section
+      or new `RemoteMcpTab.qml`): enable toggle, mode selector
+      (tap-to-open dialog per accessibility rules, not ComboBox),
+      per-mode setup fields, status line, connector URL + QR + copy,
+      rotate-token button with confirm dialog.
+- [ ] 5.2 Setup guidance text: where to paste the URL on claude.ai
+      (Settings → Connectors → Add custom connector) and note that
+      mobile apps sync connectors from claude.ai.
+- [ ] 5.3 i18n keys under `settings.remoteMcp.*`; all text via
+      `TranslationManager`/`Tr`.
+- [ ] 5.4 Accessibility pass per `ACCESSIBILITY.md` (toggle, dialog,
+      QR alt text, status announcements).
 
-## 6. Persistence
+## 6. Tests
 
-- [ ] 6.1 Extend `Settings` with `remoteMcpEnabled`, `remoteMcpMode`, `remoteMcpPublicUrl`, `remoteMcpDeviceId`.
-- [ ] 6.2 Store registered clients + refresh tokens in QtKeychain when available; fall back to `QSettings` with AES-GCM using a device key.
+- [ ] 6.1 Unit: token generation/rotation, constant-time compare,
+      remote-listener route gating (non-MCP path → 404, wrong token →
+      404, valid token → dispatched).
+- [ ] 6.2 Unit: remote session honors access level + confirmation
+      level (reuse existing MCP test fixtures).
+- [ ] 6.3 Unit: failed-token rate limiting.
+- [ ] 6.4 Integration: `initialize` → `tools/list` → `tools/call`
+      through the remote listener via loopback.
+- [ ] 6.5 Manual QA: add connector on claude.ai web, verify it
+      appears and works in Claude iOS and Claude Android; exercise a
+      control tool with confirmation dialog through the tunnel;
+      rotate token and confirm the old URL dies.
 
-## 7. Tests
+## 7. Documentation
 
-- [ ] 7.1 Unit tests for OAuth flow (PKCE happy path, bad verifier, expired code, refresh).
-- [ ] 7.2 Unit tests for scope → access-level mapping.
-- [ ] 7.3 Integration test: full `initialize` → `tools/list` over Streamable HTTP with Bearer auth using a test AS.
-- [ ] 7.4 Manual QA: connect from Claude mobile and ChatGPT mobile custom connector; verify consent, tool call, revoke.
-
-## 8. Documentation
-
-- [ ] 8.1 Update `docs/CLAUDE_MD/MCP_SERVER.md` with remote-connector setup steps (both relay and BYO tunnel).
-- [ ] 8.2 Add screenshots of consent dialog and settings tab.
-- [ ] 8.3 Note security model: what scopes grant, where tokens live, how to revoke.
+- [ ] 7.1 Update `docs/CLAUDE_MD/MCP_SERVER.md`: remote access
+      section (modes, token model, isolated surface, limitations —
+      no wake-from-doze, tunnel-vendor dependency).
+- [ ] 7.2 Wiki manual page: end-user setup walkthrough per mode with
+      screenshots (claude.ai connector config + mobile).
+- [ ] 7.3 Security note: what the capability URL grants, why rotation
+      is revocation, interaction with access/confirmation levels.


### PR DESCRIPTION
…scale-first design

Supersedes the relay + OAuth 2.1 AS draft:
- Capability-URL auth (128-bit token in path) replaces the on-device OAuth AS + Google/Microsoft OIDC federation — claude.ai custom connectors accept unauthenticated servers, so OAuth is unnecessary
- Reachability: embedded Tailscale tsnet + Funnel as the primary mode (multi-platform: AAR/c-shared/xcframework from one Go wrapper), BYO public URL as fallback, embedded ngrok deferred
- Removed: Decenza relay (developer-run infra), DuckDNS+UPnP+ACME direct exposure, protocol bump (already shipped as 2025-11-25)
- New: isolated remote listener serving only the tokenized MCP route, token rotation as revocation, failed-token rate limiting


Claude-Session: https://claude.ai/code/session_01YBTXMB31bTMfqGuMdQFyjj