### PR TITLE
Remote MCP Mode A: embedded Tailscale (tsnet + Funnel)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,11 @@ option(ENABLE_ASAN "Enable Address Sanitizer" OFF)
 # Optional features (Quick3D not available on all platforms, e.g. Raspberry Pi)
 option(ENABLE_QUICK3D "Enable Qt Quick3D for 3D screensavers" ON)
 
+# Embedded Tailscale (tsnet + Funnel) for the Remote MCP connector Mode A.
+# Pulls prebuilt libtailscale artifacts from the fork (no Go toolchain needed).
+# Default OFF: normal builds are unaffected; Mode C (BYO URL) always works.
+option(ENABLE_TSNET "Embed Tailscale (tsnet) for the remote MCP connector" OFF)
+
 # Qt 6 modules - core required components
 find_package(Qt6 REQUIRED COMPONENTS
     Core
@@ -335,6 +340,7 @@ set(SOURCES
     src/network/shotserver_ai.cpp
     src/mcp/mcpserver.cpp
     src/mcp/mcpremoteaccess.cpp
+    src/mcp/mcptunnel_tsnet.cpp
     src/mcp/mcptools_machine.cpp
     src/mcp/mcptools_shots.cpp
     src/mcp/mcptools_profiles.cpp
@@ -603,6 +609,16 @@ target_link_libraries(Decenza PRIVATE
     Qt6::WebSocketsPrivate
     Qt6::CanvasPainter
 )
+
+# Embedded Tailscale (Remote MCP Mode A). mcptunnel_tsnet.cpp is always compiled
+# (as a stub when disabled) so McpRemoteAccess can reference it unconditionally;
+# only when ENABLE_TSNET is on do we pull the prebuilt lib, define the feature
+# macro, and link it.
+if(ENABLE_TSNET)
+    include(${CMAKE_SOURCE_DIR}/cmake/tsnet.cmake)
+    target_compile_definitions(Decenza PRIVATE DECENZA_ENABLE_TSNET)
+    decenza_link_tsnet(Decenza)
+endif()
 
 # Link SerialPort only on desktop (not available on Android/iOS)
 if(NOT ANDROID AND NOT IOS)

--- a/cmake/tsnet.cmake
+++ b/cmake/tsnet.cmake
@@ -53,6 +53,10 @@ endif()
 if(APPLE AND NOT IOS)
     set(TSNET_INCLUDE_DIR "${_tsnet_extract}/libtailscale-macos/include" CACHE PATH "" FORCE)
     set(_tsnet_lib "${_tsnet_extract}/libtailscale-macos/libtailscale.a")
+    if(NOT EXISTS "${_tsnet_lib}")
+        message(FATAL_ERROR "tsnet: libtailscale.a missing after extract "
+                            "(delete ${TSNET_DOWNLOAD_DIR} to re-download): ${_tsnet_lib}")
+    endif()
     function(decenza_link_tsnet tgt)
         target_include_directories(${tgt} PRIVATE "${TSNET_INCLUDE_DIR}")
         # The Go static archive needs the darwin system frameworks tsnet uses.
@@ -70,6 +74,10 @@ elseif(IOS)
     # under ios-arm64_x86_64-simulator if a simulator build is ever wired up.
     set(TSNET_INCLUDE_DIR "${_tsnet_xcf}/ios-arm64/Headers" CACHE PATH "" FORCE)
     set(_tsnet_lib "${_tsnet_xcf}/ios-arm64/libtailscale_ios.a")
+    if(NOT EXISTS "${_tsnet_lib}")
+        message(FATAL_ERROR "tsnet: iOS libtailscale_ios.a missing after extract "
+                            "(delete ${TSNET_DOWNLOAD_DIR} to re-download): ${_tsnet_lib}")
+    endif()
     function(decenza_link_tsnet tgt)
         target_include_directories(${tgt} PRIVATE "${TSNET_INCLUDE_DIR}")
         target_link_libraries(${tgt} PRIVATE

--- a/cmake/tsnet.cmake
+++ b/cmake/tsnet.cmake
@@ -1,0 +1,96 @@
+# Pulls in prebuilt libtailscale artifacts from the Decenza fork
+# (skialpine/libtailscale) so Mode A of the Remote MCP connector (embedded
+# Tailscale + Funnel) can be built WITHOUT a Go toolchain. Enabled by
+# -DENABLE_TSNET=ON; a no-op otherwise.
+#
+# Exposes:
+#   TSNET_INCLUDE_DIR         directory containing tailscale.h
+#   decenza_link_tsnet(<tgt>) links the prebuilt library + platform frameworks
+#
+# The pinned release + per-artifact SHA-256 come from the release manifest.json.
+# Bump TSNET_TAG (and the hashes) to adopt a newer libtailscale build.
+
+set(TSNET_TAG "decenza-v1.94.1-1" CACHE STRING "libtailscale prebuilt release tag")
+set(TSNET_BASE_URL "https://github.com/skialpine/libtailscale/releases/download/${TSNET_TAG}")
+set(TSNET_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/tsnet-${TSNET_TAG}")
+
+# Per-platform artifact + expected SHA-256 (from manifest.json).
+if(IOS)
+    set(_tsnet_zip "libtailscale-ios.zip")
+    set(_tsnet_sha "3edb45778be4117c8a034bae43da8f5b566c50f43596c197d0c4da983abdc427")
+elseif(ANDROID)
+    set(_tsnet_zip "libtailscale-android.zip")
+    set(_tsnet_sha "e43497b13de23ccabd90487a9bb2c2d8dbc7f3d6d492ebfdbbf0965016505f4c")
+elseif(APPLE)
+    set(_tsnet_zip "libtailscale-macos.zip")
+    set(_tsnet_sha "b2a9041cb271af56dea6d9050927beb335d4eeff7427d44632c31c206f283f78")
+else()
+    message(FATAL_ERROR "ENABLE_TSNET: no prebuilt libtailscale artifact for this platform yet "
+                        "(supported: macOS, Android, iOS). Use Mode C (BYO URL) instead.")
+endif()
+
+set(_tsnet_archive "${TSNET_DOWNLOAD_DIR}/${_tsnet_zip}")
+set(_tsnet_extract "${TSNET_DOWNLOAD_DIR}/extracted")
+
+if(NOT EXISTS "${_tsnet_extract}/.stamp")
+    message(STATUS "tsnet: downloading ${_tsnet_zip} from ${TSNET_TAG}")
+    file(DOWNLOAD "${TSNET_BASE_URL}/${_tsnet_zip}" "${_tsnet_archive}"
+         EXPECTED_HASH "SHA256=${_tsnet_sha}"
+         STATUS _dl_status
+         SHOW_PROGRESS)
+    list(GET _dl_status 0 _dl_code)
+    if(NOT _dl_code EQUAL 0)
+        list(GET _dl_status 1 _dl_msg)
+        message(FATAL_ERROR "tsnet: download of ${_tsnet_zip} failed: ${_dl_msg}")
+    endif()
+    file(REMOVE_RECURSE "${_tsnet_extract}")
+    file(MAKE_DIRECTORY "${_tsnet_extract}")
+    file(ARCHIVE_EXTRACT INPUT "${_tsnet_archive}" DESTINATION "${_tsnet_extract}")
+    file(TOUCH "${_tsnet_extract}/.stamp")
+endif()
+
+# Resolve the include dir + platform-specific link target.
+if(APPLE AND NOT IOS)
+    set(TSNET_INCLUDE_DIR "${_tsnet_extract}/libtailscale-macos/include" CACHE PATH "" FORCE)
+    set(_tsnet_lib "${_tsnet_extract}/libtailscale-macos/libtailscale.a")
+    function(decenza_link_tsnet tgt)
+        target_include_directories(${tgt} PRIVATE "${TSNET_INCLUDE_DIR}")
+        # The Go static archive needs the darwin system frameworks tsnet uses.
+        target_link_libraries(${tgt} PRIVATE
+            "${_tsnet_lib}"
+            "-framework CoreFoundation"
+            "-framework Security"
+            "-framework SystemConfiguration"
+            resolv)
+    endfunction()
+
+elseif(IOS)
+    set(_tsnet_xcf "${_tsnet_extract}/libtailscale.xcframework")
+    # Device slice (App Store / device builds). Simulator slice lives alongside
+    # under ios-arm64_x86_64-simulator if a simulator build is ever wired up.
+    set(TSNET_INCLUDE_DIR "${_tsnet_xcf}/ios-arm64/Headers" CACHE PATH "" FORCE)
+    set(_tsnet_lib "${_tsnet_xcf}/ios-arm64/libtailscale_ios.a")
+    function(decenza_link_tsnet tgt)
+        target_include_directories(${tgt} PRIVATE "${TSNET_INCLUDE_DIR}")
+        target_link_libraries(${tgt} PRIVATE
+            "${_tsnet_lib}"
+            "-framework CoreFoundation"
+            "-framework Security"
+            "-framework Network")
+    endfunction()
+
+elseif(ANDROID)
+    set(TSNET_INCLUDE_DIR "${_tsnet_extract}/libtailscale-android/include" CACHE PATH "" FORCE)
+    set(_tsnet_so "${_tsnet_extract}/libtailscale-android/jniLibs/${CMAKE_ANDROID_ARCH_ABI}/libtailscale.so")
+    if(NOT EXISTS "${_tsnet_so}")
+        message(FATAL_ERROR "tsnet: no Android .so for ABI ${CMAKE_ANDROID_ARCH_ABI}")
+    endif()
+    # Bundle the .so into the APK for the active ABI so androiddeployqt ships it.
+    set(ANDROID_EXTRA_LIBS "${ANDROID_EXTRA_LIBS};${_tsnet_so}" CACHE STRING "" FORCE)
+    function(decenza_link_tsnet tgt)
+        target_include_directories(${tgt} PRIVATE "${TSNET_INCLUDE_DIR}")
+        target_link_libraries(${tgt} PRIVATE "${_tsnet_so}")
+    endfunction()
+endif()
+
+message(STATUS "tsnet: enabled (${TSNET_TAG}) — include: ${TSNET_INCLUDE_DIR}")

--- a/qml/pages/settings/SettingsAITab.qml
+++ b/qml/pages/settings/SettingsAITab.qml
@@ -1084,11 +1084,29 @@ KeyboardAwareContainer {
 
                         Tr {
                             key: "settings.ai.remoteMcp.setupGuidance"
-                            fallback: "On claude.ai, go to Settings → Connectors → Add custom connector and paste this URL. Mobile Claude apps sync connectors from claude.ai automatically."
+                            fallback: "Add this as a custom connector in Claude, then paste the URL above (leave the OAuth fields blank). Mobile Claude apps sync connectors automatically."
                             color: Theme.textSecondaryColor
                             font.pixelSize: Theme.scaled(11)
                             wrapMode: Text.WordWrap
                             Layout.fillWidth: true
+                        }
+                        Text {
+                            text: TranslationManager.translate("settings.ai.remoteMcp.openClaudeConnectors", "Open Connectors on claude.ai ↗")
+                            color: Theme.accentColor
+                            font.pixelSize: Theme.scaled(12)
+                            font.underline: true
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                            Accessible.role: Accessible.Link
+                            Accessible.name: TranslationManager.translate("settings.ai.remoteMcp.openClaudeConnectorsAccessible", "Open the Connectors settings page on claude.ai in your browser")
+                            Accessible.focusable: true
+                            MouseArea {
+                                id: claudeConnectorsArea
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: Qt.openUrlExternally("https://claude.ai/settings/connectors")
+                            }
+                            Accessible.onPressAction: claudeConnectorsArea.clicked(null)
                         }
                     }
 
@@ -1111,8 +1129,11 @@ KeyboardAwareContainer {
                                 return TranslationManager.translate("settings.ai.remoteMcp.status.off", "Off")
                             }
                         }
-                        color: RemoteMcpAccess.statusString === "error" ? Theme.errorColor : Theme.textSecondaryColor
+                        color: RemoteMcpAccess.statusString === "error" ? Theme.errorColor
+                             : RemoteMcpAccess.statusString === "active" ? Theme.successColor
+                             : Theme.textSecondaryColor
                         font.pixelSize: Theme.scaled(12)
+                        font.bold: RemoteMcpAccess.statusString === "active"
                         wrapMode: Text.WordWrap
                     }
 

--- a/qml/pages/settings/SettingsAITab.qml
+++ b/qml/pages/settings/SettingsAITab.qml
@@ -839,10 +839,86 @@ KeyboardAwareContainer {
                     spacing: Theme.scaled(10)
                     visible: Settings.mcp.mcpEnabled && Settings.mcp.remoteMcpEnabled
 
+                    // Reachability mode selector
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(6)
+
+                        Tr {
+                            key: "settings.ai.remoteMcp.modeLabel"
+                            fallback: "How is it reachable?"
+                            color: Theme.textColor
+                            font.pixelSize: Theme.scaled(13)
+                            font.bold: true
+                        }
+
+                        Repeater {
+                            model: [
+                                {
+                                    mode: "custom",
+                                    label: TranslationManager.translate("settings.ai.remoteMcp.mode.custom", "Custom URL (bring your own)"),
+                                    detail: TranslationManager.translate("settings.ai.remoteMcp.mode.customDesc", "You run a reverse proxy / tunnel that forwards to this device."),
+                                    enabled: true
+                                },
+                                {
+                                    mode: "tailscale",
+                                    label: TranslationManager.translate("settings.ai.remoteMcp.mode.tailscale", "Tailscale (built-in)"),
+                                    detail: RemoteMcpAccess.tunnelAvailable
+                                        ? TranslationManager.translate("settings.ai.remoteMcp.mode.tailscaleDesc", "Join your tailnet and expose a public Funnel URL — no other setup.")
+                                        : TranslationManager.translate("settings.ai.remoteMcp.mode.tailscaleUnavailable", "Not included in this build."),
+                                    enabled: RemoteMcpAccess.tunnelAvailable
+                                }
+                            ]
+                            delegate: Rectangle {
+                                id: modeDelegate
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: modeCol.implicitHeight + Theme.scaled(16)
+                                radius: Theme.scaled(6)
+                                opacity: modelData.enabled ? 1.0 : 0.5
+                                color: Settings.mcp.remoteMcpMode === modelData.mode ? Qt.rgba(Theme.primaryColor.r, Theme.primaryColor.g, Theme.primaryColor.b, 0.15) : "transparent"
+                                border.color: Settings.mcp.remoteMcpMode === modelData.mode ? Theme.primaryColor : Theme.borderColor
+                                border.width: 1
+                                Accessible.ignored: true
+
+                                ColumnLayout {
+                                    id: modeCol
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    anchors.margins: Theme.scaled(12)
+                                    spacing: Theme.scaled(2)
+                                    Text {
+                                        text: modelData.label
+                                        color: Theme.textColor
+                                        font.pixelSize: Theme.scaled(13)
+                                        font.bold: true
+                                        Accessible.ignored: true
+                                    }
+                                    Text {
+                                        text: modelData.detail
+                                        color: Theme.textSecondaryColor
+                                        font.pixelSize: Theme.scaled(11)
+                                        wrapMode: Text.WordWrap
+                                        Layout.fillWidth: true
+                                        Accessible.ignored: true
+                                    }
+                                }
+                                AccessibleMouseArea {
+                                    anchors.fill: parent
+                                    enabled: modelData.enabled
+                                    accessibleName: modelData.label + ". " + modelData.detail
+                                    accessibleItem: modeDelegate
+                                    onAccessibleClicked: if (modelData.enabled) Settings.mcp.remoteMcpMode = modelData.mode
+                                }
+                            }
+                        }
+                    }
+
                     // Public base URL (Mode C — bring your own)
                     ColumnLayout {
                         Layout.fillWidth: true
                         spacing: Theme.scaled(4)
+                        visible: Settings.mcp.remoteMcpMode === "custom"
 
                         Tr {
                             key: "settings.ai.remoteMcp.baseUrlLabel"
@@ -881,6 +957,72 @@ KeyboardAwareContainer {
                             font.pixelSize: Theme.scaled(11)
                             wrapMode: Text.WordWrap
                             Layout.fillWidth: true
+                        }
+                    }
+
+                    // Tailscale login (Mode A) — shown while the embedded node is
+                    // waiting for the user to authorize it.
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(8)
+                        visible: Settings.mcp.remoteMcpMode === "tailscale"
+                            && RemoteMcpAccess.loginUrl.length > 0
+
+                        Tr {
+                            key: "settings.ai.remoteMcp.tailscaleLoginLabel"
+                            fallback: "Sign in to Tailscale"
+                            color: Theme.textColor
+                            font.pixelSize: Theme.scaled(13)
+                            font.bold: true
+                        }
+                        Tr {
+                            key: "settings.ai.remoteMcp.tailscaleLoginHint"
+                            fallback: "Open this link (or scan the code) to authorize this device on your tailnet. You may also need to approve Funnel for it in the Tailscale admin console."
+                            color: Theme.textSecondaryColor
+                            font.pixelSize: Theme.scaled(11)
+                            wrapMode: Text.WordWrap
+                            Layout.fillWidth: true
+                        }
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: Theme.scaled(8)
+                            Text {
+                                Layout.fillWidth: true
+                                text: RemoteMcpAccess.loginUrl
+                                color: Theme.accentColor
+                                font.pixelSize: Theme.scaled(12)
+                                wrapMode: Text.WrapAnywhere
+                                Accessible.role: Accessible.Link
+                                Accessible.name: TranslationManager.translate("settings.ai.remoteMcp.tailscaleLoginAccessible", "Open Tailscale login page")
+                                Accessible.focusable: true
+                                MouseArea {
+                                    id: tsLoginArea
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: Qt.openUrlExternally(RemoteMcpAccess.loginUrl)
+                                }
+                                Accessible.onPressAction: tsLoginArea.clicked(null)
+                            }
+                            AccessibleButton {
+                                text: TranslationManager.translate("common.button.copy", "Copy")
+                                accessibleName: TranslationManager.translate("settings.ai.remoteMcp.tailscaleLoginCopy", "Copy Tailscale login URL")
+                                onClicked: MainController.copyToClipboard(RemoteMcpAccess.loginUrl)
+                            }
+                        }
+                        Rectangle {
+                            Layout.alignment: Qt.AlignHCenter
+                            width: Theme.scaled(180)
+                            height: Theme.scaled(180)
+                            color: "#ffffff"
+                            radius: Theme.scaled(8)
+                            Accessible.role: Accessible.Graphic
+                            Accessible.name: TranslationManager.translate("settings.ai.remoteMcp.tailscaleLoginQr", "QR code of the Tailscale login URL")
+                            QrCode {
+                                anchors.fill: parent
+                                anchors.margins: Theme.scaled(8)
+                                value: RemoteMcpAccess.loginUrl
+                                Accessible.ignored: true
+                            }
                         }
                     }
 

--- a/qml/pages/settings/SettingsAITab.qml
+++ b/qml/pages/settings/SettingsAITab.qml
@@ -1098,7 +1098,9 @@ KeyboardAwareContainer {
                         text: {
                             switch (RemoteMcpAccess.statusString) {
                             case "active":
-                                return TranslationManager.translate("settings.ai.remoteMcp.status.active", "Active — listening on port %1").arg(RemoteMcpAccess.listenPort)
+                                return Settings.mcp.remoteMcpMode === "tailscale"
+                                    ? TranslationManager.translate("settings.ai.remoteMcp.status.activeTailscale", "Active — public Funnel URL ready")
+                                    : TranslationManager.translate("settings.ai.remoteMcp.status.active", "Active — listening on port %1").arg(RemoteMcpAccess.listenPort)
                             case "starting":
                                 return TranslationManager.translate("settings.ai.remoteMcp.status.starting", "Starting…")
                             case "reconnecting":
@@ -1112,6 +1114,18 @@ KeyboardAwareContainer {
                         color: RemoteMcpAccess.statusString === "error" ? Theme.errorColor : Theme.textSecondaryColor
                         font.pixelSize: Theme.scaled(12)
                         wrapMode: Text.WordWrap
+                    }
+
+                    // One-time Tailscale setup — opens a step-by-step popup. Hidden
+                    // once the connector is active (setup is done), so it doesn't
+                    // linger after everything is working.
+                    AccessibleButton {
+                        visible: Settings.mcp.remoteMcpMode === "tailscale"
+                            && RemoteMcpAccess.statusString !== "active"
+                        text: TranslationManager.translate("settings.ai.remoteMcp.tailscaleSetupButton", "Set up Tailscale Funnel (one-time)…")
+                        accessibleName: TranslationManager.translate("settings.ai.remoteMcp.tailscaleSetupAccessible", "Open Tailscale Funnel setup instructions")
+                        warning: RemoteMcpAccess.statusString === "error"
+                        onClicked: tailscaleSetupDialog.open()
                     }
 
                     // Rotate token (revokes the current URL)
@@ -1306,6 +1320,153 @@ KeyboardAwareContainer {
                         RemoteMcpAccess.rotateToken()
                         rotateTokenDialog.close()
                         AccessibilityManager.announce(TranslationManager.translate("settings.ai.remoteMcp.rotated", "Token rotated. New connector URL generated."))
+                    }
+                }
+            }
+        }
+    }
+
+    // Step-by-step Tailscale Funnel setup instructions.
+    Dialog {
+        id: tailscaleSetupDialog
+        parent: Overlay.overlay
+        anchors.centerIn: parent
+        width: Math.min(parent ? parent.width - Theme.scaled(32) : Theme.scaled(480), Theme.scaled(520))
+        modal: true
+        closePolicy: Dialog.CloseOnEscape | Dialog.CloseOnPressOutside
+
+        readonly property string aclSnippet:
+            '"nodeAttrs": [\n  { "target": ["autogroup:member"], "attr": ["funnel"] },\n],'
+
+        onOpened: AccessibilityManager.announce(tsSetupTitle.text)
+
+        background: Rectangle {
+            color: Theme.surfaceColor
+            radius: Theme.scaled(12)
+            border.color: Theme.borderColor
+            border.width: 1
+        }
+
+        contentItem: Flickable {
+            implicitHeight: Math.min(tsSetupCol.implicitHeight,
+                tailscaleSetupDialog.parent ? tailscaleSetupDialog.parent.height - Theme.scaled(120) : Theme.scaled(560))
+            contentHeight: tsSetupCol.implicitHeight
+            clip: true
+            boundsBehavior: Flickable.StopAtBounds
+
+            ColumnLayout {
+                id: tsSetupCol
+                width: parent.width
+                spacing: Theme.scaled(12)
+
+                Text {
+                    id: tsSetupTitle
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("settings.ai.remoteMcp.setup.title", "Set up Tailscale Funnel")
+                    color: Theme.textColor
+                    font.family: Theme.subtitleFont.family
+                    font.pixelSize: Theme.subtitleFont.pixelSize
+                    font.bold: true
+                    wrapMode: Text.WordWrap
+                }
+                Text {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("settings.ai.remoteMcp.setup.intro", "A one-time setup on your Tailscale account lets Decenza expose a public URL for AI connectors. Do both steps in the Tailscale admin console — then come back, Decenza connects automatically (no restart).")
+                    color: Theme.textSecondaryColor
+                    font.pixelSize: Theme.scaled(12)
+                    wrapMode: Text.WordWrap
+                }
+
+                // Step 1 — HTTPS certificates
+                Tr {
+                    key: "settings.ai.remoteMcp.setup.step1"
+                    fallback: "1.  Enable HTTPS certificates"
+                    color: Theme.textColor
+                    font.pixelSize: Theme.scaled(13)
+                    font.bold: true
+                }
+                Text {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("settings.ai.remoteMcp.setup.step1body", "On the DNS page, scroll to the bottom and turn on “HTTPS Certificates”.")
+                    color: Theme.textSecondaryColor
+                    font.pixelSize: Theme.scaled(12)
+                    wrapMode: Text.WordWrap
+                }
+                AccessibleButton {
+                    text: TranslationManager.translate("settings.ai.remoteMcp.setup.openDns", "Open DNS settings ↗")
+                    accessibleName: TranslationManager.translate("settings.ai.remoteMcp.setup.openDnsAccessible", "Open Tailscale DNS settings in browser")
+                    onClicked: Qt.openUrlExternally("https://login.tailscale.com/admin/dns")
+                }
+
+                // Step 2 — Funnel node attribute
+                Tr {
+                    key: "settings.ai.remoteMcp.setup.step2"
+                    fallback: "2.  Allow Funnel for this device"
+                    color: Theme.textColor
+                    font.pixelSize: Theme.scaled(13)
+                    font.bold: true
+                }
+                Text {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("settings.ai.remoteMcp.setup.step2body", "Open Access controls and click “JSON editor” at the top. On the right, open the “Funnel” panel and click “Add Funnel to policy”, then Save (the red button). No typing needed.")
+                    color: Theme.textSecondaryColor
+                    font.pixelSize: Theme.scaled(12)
+                    wrapMode: Text.WordWrap
+                }
+                Text {
+                    Layout.fillWidth: true
+                    text: TranslationManager.translate("settings.ai.remoteMcp.setup.step2fallback", "Don’t see it? Paste this rule after the first “{” in the JSON editor instead, then Save:")
+                    color: Theme.textSecondaryColor
+                    font.pixelSize: Theme.scaled(11)
+                    font.italic: true
+                    wrapMode: Text.WordWrap
+                }
+                Rectangle {
+                    Layout.fillWidth: true
+                    color: Theme.backgroundColor
+                    border.color: Theme.borderColor
+                    border.width: 1
+                    radius: Theme.scaled(6)
+                    Layout.preferredHeight: tsSnippetText.implicitHeight + Theme.scaled(16)
+                    Text {
+                        id: tsSnippetText
+                        anchors.fill: parent
+                        anchors.margins: Theme.scaled(8)
+                        text: tailscaleSetupDialog.aclSnippet
+                        color: Theme.textColor
+                        font.family: "monospace"
+                        font.pixelSize: Theme.scaled(11)
+                        wrapMode: Text.WrapAnywhere
+                        Accessible.name: TranslationManager.translate("settings.ai.remoteMcp.setup.snippetAccessible", "Tailscale ACL rule to grant Funnel")
+                    }
+                }
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.scaled(8)
+                    AccessibleButton {
+                        text: TranslationManager.translate("settings.ai.remoteMcp.setup.copyRule", "Copy rule")
+                        accessibleName: TranslationManager.translate("settings.ai.remoteMcp.setup.copyRuleAccessible", "Copy the Tailscale Funnel ACL rule to clipboard")
+                        onClicked: {
+                            MainController.copyToClipboard(tailscaleSetupDialog.aclSnippet)
+                            AccessibilityManager.announce(TranslationManager.translate("settings.ai.remoteMcp.setup.copied", "Rule copied"))
+                        }
+                    }
+                    AccessibleButton {
+                        text: TranslationManager.translate("settings.ai.remoteMcp.setup.openAcls", "Open Access controls ↗")
+                        accessibleName: TranslationManager.translate("settings.ai.remoteMcp.setup.openAclsAccessible", "Open Tailscale access controls in browser")
+                        onClicked: Qt.openUrlExternally("https://login.tailscale.com/admin/acls")
+                    }
+                }
+
+                Item { Layout.fillHeight: true; Layout.minimumHeight: Theme.scaled(4) }
+                RowLayout {
+                    Layout.fillWidth: true
+                    Item { Layout.fillWidth: true }
+                    AccessibleButton {
+                        text: TranslationManager.translate("common.button.done", "Done")
+                        accessibleName: TranslationManager.translate("common.button.done", "Done")
+                        primary: true
+                        onClicked: tailscaleSetupDialog.close()
                     }
                 }
             }

--- a/src/mcp/mcpremoteaccess.cpp
+++ b/src/mcp/mcpremoteaccess.cpp
@@ -1,6 +1,7 @@
 #include "mcpremoteaccess.h"
 
 #include "mcpserver.h"
+#include "mcptunnel_tsnet.h"
 #include "../core/settings_mcp.h"
 
 #include <QTcpServer>
@@ -8,6 +9,8 @@
 #include <QTimer>
 #include <QHostAddress>
 #include <QUrl>
+#include <QStandardPaths>
+#include <QDir>
 
 McpRemoteAccess::McpRemoteAccess(QObject* parent)
     : QObject(parent)
@@ -22,6 +25,7 @@ McpRemoteAccess::McpRemoteAccess(QObject* parent)
 
 McpRemoteAccess::~McpRemoteAccess()
 {
+    stopTunnel();   // brings the embedded node down (joins its worker) if running
     stopListener();
 }
 
@@ -88,15 +92,33 @@ QString McpRemoteAccess::connectorUrl() const
         return base + QStringLiteral("/mcp/") + m_settings->remoteMcpToken();
     }
 
-    // Embedded-tunnel modes (tailscale / ngrok) compose their URL from the
-    // tunnel's assigned hostname, which is not available until those modes are
-    // implemented. Report no URL rather than a misleading one.
+    // Mode A (Tailscale): the Funnel FQDN comes from the embedded node once it is
+    // up. Empty until then (login pending / Funnel not yet approved).
+    if (mode == QString::fromLatin1(SettingsMcp::ModeTailscale)) {
+        if (!m_tunnel || m_tunnel->certDomain().isEmpty())
+            return QString();
+        return QStringLiteral("https://") + m_tunnel->certDomain()
+               + QStringLiteral("/mcp/") + m_settings->remoteMcpToken();
+    }
+
+    // ngrok (Mode B) not implemented yet.
     return QString();
+}
+
+QString McpRemoteAccess::loginUrl() const
+{
+    return m_tunnel ? m_tunnel->authUrl() : QString();
+}
+
+bool McpRemoteAccess::tunnelAvailable()
+{
+    return McpTunnelTsnet::isAvailable();
 }
 
 void McpRemoteAccess::refresh()
 {
     if (!m_settings) {
+        stopTunnel();
         stopListener();
         setStatus(Off);
         return;
@@ -104,34 +126,56 @@ void McpRemoteAccess::refresh()
 
     const bool wantOn = m_settings->mcpEnabled() && m_settings->remoteMcpEnabled();
     if (!wantOn) {
+        stopTunnel();
         stopListener();
         setStatus(Off);
         emit connectorUrlChanged();
         return;
     }
 
-    // Phase 1 wires Mode C only. Other modes accept the setting but cannot yet
-    // stand up a tunnel, so surface a clear error instead of a silent no-op.
     const QString mode = m_settings->remoteMcpMode();
-    if (mode != QString::fromLatin1(SettingsMcp::ModeCustom)) {
-        stopListener();
-        setStatus(Error, QStringLiteral("Mode '%1' is not available in this build yet").arg(mode));
+
+    // Mode C (BYO URL): LAN-routable listener, an off-box proxy fronts it.
+    if (mode == QString::fromLatin1(SettingsMcp::ModeCustom)) {
+        stopTunnel();
+        startListener(/*bindLoopbackOnly=*/false);
         emit connectorUrlChanged();
         return;
     }
 
-    startListener();
+    // Mode A (Tailscale): loopback listener + embedded node that Funnels to it.
+    if (mode == QString::fromLatin1(SettingsMcp::ModeTailscale)) {
+        if (!McpTunnelTsnet::isAvailable()) {
+            stopListener();
+            setStatus(Error, QStringLiteral("This build was not compiled with Tailscale support"));
+            emit connectorUrlChanged();
+            return;
+        }
+        startListener(/*bindLoopbackOnly=*/true);
+        if (m_status == Error)
+            return;  // listener failed to bind
+        startTunnel();
+        emit connectorUrlChanged();
+        return;
+    }
+
+    // ngrok (Mode B) not implemented yet.
+    stopTunnel();
+    stopListener();
+    setStatus(Error, QStringLiteral("Mode '%1' is not available in this build yet").arg(mode));
     emit connectorUrlChanged();
 }
 
-void McpRemoteAccess::startListener()
+void McpRemoteAccess::startListener(bool bindLoopbackOnly)
 {
     const quint16 port = m_settings ? static_cast<quint16>(m_settings->remoteMcpPort()) : 8890;
+    const QHostAddress bindAddr = bindLoopbackOnly ? QHostAddress(QHostAddress::LocalHost)
+                                                   : QHostAddress(QHostAddress::Any);
 
     if (m_listener && m_listener->isListening()) {
-        if (m_listener->serverPort() == port)
-            return;  // already serving the right port
-        stopListener();  // port changed — rebind
+        if (m_listener->serverPort() == port && m_listener->serverAddress() == bindAddr)
+            return;  // already serving the right port + interface
+        stopListener();  // port or bind changed — rebind
     }
 
     setStatus(Starting);
@@ -147,18 +191,68 @@ void McpRemoteAccess::startListener()
     // the next settings change.
     m_reaper->start();
 
-    // Mode C: an off-box reverse proxy on the LAN forwards to the tablet's LAN
-    // IP + this port, so the listener must be routable, not loopback-only. It
-    // still serves only the tokenized MCP route (route gating in routeRequest),
-    // so no other ShotServer surface is exposed. Embedded-tunnel modes will bind
-    // loopback instead.
-    if (!m_listener->listen(QHostAddress::Any, port)) {
+    // Mode C binds a routable interface so an off-box reverse proxy can reach it;
+    // Mode A binds loopback (the embedded tsnet node proxies from 127.0.0.1). The
+    // listener still serves only the tokenized MCP route (route gating in
+    // routeRequest), so no other ShotServer surface is ever exposed.
+    if (!m_listener->listen(bindAddr, port)) {
         setStatus(Error, QStringLiteral("Could not listen on port %1: %2")
                             .arg(port).arg(m_listener->errorString()));
         return;
     }
 
-    setStatus(Active);
+    // Mode C: listener up is as "active" as we can verify (the off-box proxy is
+    // the user's responsibility). Mode A: stay Starting — the embedded tunnel's
+    // state (login → running) drives the real status via onTunnelStateChanged().
+    if (!bindLoopbackOnly)
+        setStatus(Active);
+}
+
+void McpRemoteAccess::startTunnel()
+{
+    if (!McpTunnelTsnet::isAvailable() || !m_settings)
+        return;
+    if (!m_tunnel) {
+        m_tunnel = new McpTunnelTsnet(this);
+        connect(m_tunnel, &McpTunnelTsnet::stateChanged, this, &McpRemoteAccess::onTunnelStateChanged);
+        connect(m_tunnel, &McpTunnelTsnet::certDomainChanged, this, &McpRemoteAccess::connectorUrlChanged);
+        connect(m_tunnel, &McpTunnelTsnet::authUrlChanged, this, &McpRemoteAccess::loginUrlChanged);
+    }
+    const QString stateDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+                             + QStringLiteral("/tsnet");
+    // Node name → Funnel subdomain. Fixed "decenza" for a stable URL across restarts.
+    m_tunnel->start(stateDir, QStringLiteral("decenza"),
+                    static_cast<quint16>(m_settings->remoteMcpPort()));
+}
+
+void McpRemoteAccess::stopTunnel()
+{
+    if (m_tunnel)
+        m_tunnel->stop();
+}
+
+void McpRemoteAccess::onTunnelStateChanged()
+{
+    if (!m_tunnel)
+        return;
+    switch (m_tunnel->state()) {
+    case McpTunnelTsnet::NeedsLogin:
+        // Surface the login URL (loginUrl property) and keep status "starting".
+        setStatus(Starting, QStringLiteral("Waiting for Tailscale login"));
+        break;
+    case McpTunnelTsnet::Starting:
+        setStatus(Starting, QStringLiteral("Connecting to Tailscale"));
+        break;
+    case McpTunnelTsnet::Running:
+        setStatus(Active);
+        break;
+    case McpTunnelTsnet::Error:
+        setStatus(Error, m_tunnel->lastError());
+        break;
+    case McpTunnelTsnet::Stopped:
+        break;
+    }
+    emit connectorUrlChanged();
 }
 
 void McpRemoteAccess::stopListener()
@@ -471,11 +565,15 @@ void McpRemoteAccess::onReaperTick()
             ++it;
     }
 
-    // Recover from a dropped listener (e.g. interface flap) while still enabled.
+    // Recover from a dropped listener (e.g. interface flap) while still enabled,
+    // rebinding with the correct interface for the active mode.
     if (m_settings && m_settings->mcpEnabled() && m_settings->remoteMcpEnabled()
-        && m_settings->remoteMcpMode() == QString::fromLatin1(SettingsMcp::ModeCustom)
         && m_listener && !m_listener->isListening()) {
-        setStatus(Reconnecting);
-        startListener();
+        const QString mode = m_settings->remoteMcpMode();
+        const bool loopback = (mode == QString::fromLatin1(SettingsMcp::ModeTailscale));
+        if (loopback || mode == QString::fromLatin1(SettingsMcp::ModeCustom)) {
+            setStatus(Reconnecting);
+            startListener(loopback);
+        }
     }
 }

--- a/src/mcp/mcpremoteaccess.cpp
+++ b/src/mcp/mcpremoteaccess.cpp
@@ -12,6 +12,9 @@
 #include <QStandardPaths>
 #include <QDir>
 #include <QSysInfo>
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
 
 McpRemoteAccess::McpRemoteAccess(QObject* parent)
     : QObject(parent)
@@ -94,9 +97,10 @@ QString McpRemoteAccess::connectorUrl() const
     }
 
     // Mode A (Tailscale): the Funnel FQDN comes from the embedded node once it is
-    // up. Empty until then (login pending / Funnel not yet approved).
+    // up — but only surface the URL once a real public-reachability probe has
+    // confirmed it actually works (login done, HTTPS certs on, Funnel granted).
     if (mode == QString::fromLatin1(SettingsMcp::ModeTailscale)) {
-        if (!m_tunnel || m_tunnel->certDomain().isEmpty())
+        if (!m_tunnel || m_tunnel->certDomain().isEmpty() || !m_funnelReachable)
             return QString();
         return QStringLiteral("https://") + m_tunnel->certDomain()
                + QStringLiteral("/mcp/") + m_settings->remoteMcpToken();
@@ -245,6 +249,8 @@ void McpRemoteAccess::startTunnel()
 
 void McpRemoteAccess::stopTunnel()
 {
+    stopReachabilityProbe();
+    m_funnelReachable = false;
     if (m_tunnel)
         m_tunnel->stop();
 }
@@ -256,21 +262,90 @@ void McpRemoteAccess::onTunnelStateChanged()
     switch (m_tunnel->state()) {
     case McpTunnelTsnet::NeedsLogin:
         // Surface the login URL (loginUrl property) and keep status "starting".
+        m_funnelReachable = false;
+        stopReachabilityProbe();
         setStatus(Starting, QStringLiteral("Waiting for Tailscale login"));
         break;
     case McpTunnelTsnet::Starting:
+        m_funnelReachable = false;
+        stopReachabilityProbe();
         setStatus(Starting, QStringLiteral("Connecting to Tailscale"));
         break;
     case McpTunnelTsnet::Running:
-        setStatus(Active);
+        // The node is up and Funnel is configured locally, but that is NOT proof
+        // the public URL works. Stay "starting" and probe the real Funnel URL;
+        // onReachability… flips to Active only once it responds.
+        if (m_funnelReachable) {
+            setStatus(Active);
+        } else {
+            setStatus(Starting, QStringLiteral("Verifying public reachability…"));
+            startReachabilityProbe();
+        }
         break;
     case McpTunnelTsnet::Error:
+        m_funnelReachable = false;
+        stopReachabilityProbe();
         setStatus(Error, m_tunnel->lastError());
         break;
     case McpTunnelTsnet::Stopped:
+        m_funnelReachable = false;
+        stopReachabilityProbe();
         break;
     }
     emit connectorUrlChanged();
+}
+
+void McpRemoteAccess::startReachabilityProbe()
+{
+    if (!m_reachProbe) {
+        m_reachProbe = new QNetworkAccessManager(this);
+        m_reachTimer = new QTimer(this);
+        m_reachTimer->setInterval(6000);
+        connect(m_reachTimer, &QTimer::timeout, this, &McpRemoteAccess::doReachabilityProbe);
+    }
+    if (!m_reachTimer->isActive())
+        m_reachTimer->start();
+    doReachabilityProbe();  // probe immediately, don't wait a full interval
+}
+
+void McpRemoteAccess::stopReachabilityProbe()
+{
+    if (m_reachTimer)
+        m_reachTimer->stop();
+    m_probeInFlight = false;
+}
+
+void McpRemoteAccess::doReachabilityProbe()
+{
+    if (m_probeInFlight || !m_reachProbe || !m_tunnel || !m_settings)
+        return;
+    const QString domain = m_tunnel->certDomain();
+    if (domain.isEmpty())
+        return;
+
+    // Fetch the real connector URL over the public internet. It leaves this
+    // machine, hits the Funnel edge, and routes back to the loopback listener —
+    // so any HTTP response (a GET yields 405 from McpServer) proves the whole
+    // public path works. Using the tokenized path avoids the failed-token
+    // limiter. GET (no SSE) creates no MCP session.
+    const QString url = QStringLiteral("https://") + domain
+                        + QStringLiteral("/mcp/") + m_settings->remoteMcpToken();
+    QNetworkRequest req{QUrl(url)};
+    req.setTransferTimeout(10000);
+    m_probeInFlight = true;
+    QNetworkReply* reply = m_reachProbe->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        m_probeInFlight = false;
+        const bool gotHttpResponse =
+            reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).isValid();
+        reply->deleteLater();
+        if (gotHttpResponse && !m_funnelReachable) {
+            m_funnelReachable = true;
+            stopReachabilityProbe();
+            setStatus(Active);
+            emit connectorUrlChanged();
+        }
+    });
 }
 
 void McpRemoteAccess::stopListener()

--- a/src/mcp/mcpremoteaccess.cpp
+++ b/src/mcp/mcpremoteaccess.cpp
@@ -11,6 +11,7 @@
 #include <QUrl>
 #include <QStandardPaths>
 #include <QDir>
+#include <QSysInfo>
 
 McpRemoteAccess::McpRemoteAccess(QObject* parent)
     : QObject(parent)
@@ -220,8 +221,25 @@ void McpRemoteAccess::startTunnel()
     }
     const QString stateDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
                              + QStringLiteral("/tsnet");
-    // Node name → Funnel subdomain. Fixed "decenza" for a stable URL across restarts.
-    m_tunnel->start(stateDir, QStringLiteral("decenza"),
+    // Node name → Funnel subdomain. Include the machine hostname so multiple
+    // Decenza instances on one tailnet get distinct, recognisable node names
+    // (and distinct Funnel URLs). Tailscale node names allow only [a-z0-9-];
+    // sanitise the host and trim stray hyphens.
+    QString host = QSysInfo::machineHostName().toLower();
+    // Drop any domain suffix (e.g. macOS returns "name.local") — keep just the
+    // first label so the node is "decenza-<hostname>", not "…-local".
+    const qsizetype dot = host.indexOf('.');
+    if (dot > 0)
+        host = host.left(dot);
+    for (QChar& c : host) {
+        if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-'))
+            c = '-';
+    }
+    while (host.startsWith('-')) host.remove(0, 1);
+    while (host.endsWith('-')) host.chop(1);
+    const QString nodeName = host.isEmpty() ? QStringLiteral("decenza")
+                                            : QStringLiteral("decenza-") + host;
+    m_tunnel->start(stateDir, nodeName,
                     static_cast<quint16>(m_settings->remoteMcpPort()));
 }
 

--- a/src/mcp/mcpremoteaccess.cpp
+++ b/src/mcp/mcpremoteaccess.cpp
@@ -303,6 +303,11 @@ void McpRemoteAccess::startReachabilityProbe()
         m_reachTimer->setInterval(6000);
         connect(m_reachTimer, &QTimer::timeout, this, &McpRemoteAccess::doReachabilityProbe);
     }
+    // New probing session: any in-flight reply from a previous session becomes
+    // stale (its generation no longer matches) and is ignored on completion.
+    ++m_probeGeneration;
+    m_probeFailCount = 0;
+    m_probeInFlight = false;
     if (!m_reachTimer->isActive())
         m_reachTimer->start();
     doReachabilityProbe();  // probe immediately, don't wait a full interval
@@ -310,6 +315,7 @@ void McpRemoteAccess::startReachabilityProbe()
 
 void McpRemoteAccess::stopReachabilityProbe()
 {
+    ++m_probeGeneration;   // drop any in-flight reply
     if (m_reachTimer)
         m_reachTimer->stop();
     m_probeInFlight = false;
@@ -333,17 +339,41 @@ void McpRemoteAccess::doReachabilityProbe()
     QNetworkRequest req{QUrl(url)};
     req.setTransferTimeout(10000);
     m_probeInFlight = true;
+    const quint64 gen = m_probeGeneration;
     QNetworkReply* reply = m_reachProbe->get(req);
-    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
-        m_probeInFlight = false;
+    connect(reply, &QNetworkReply::finished, this, [this, reply, gen]() {
         const bool gotHttpResponse =
             reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).isValid();
+        const QString errStr = reply->errorString();
         reply->deleteLater();
-        if (gotHttpResponse && !m_funnelReachable) {
-            m_funnelReachable = true;
-            stopReachabilityProbe();
-            setStatus(Active);
-            emit connectorUrlChanged();
+        // Ignore a reply from a superseded probing session (disable / mode
+        // switch / tunnel restart happened while this was in flight) — it must
+        // not flip status to Active.
+        if (gen != m_probeGeneration)
+            return;
+        m_probeInFlight = false;
+
+        if (gotHttpResponse) {
+            m_probeFailCount = 0;
+            if (!m_funnelReachable) {
+                m_funnelReachable = true;
+                stopReachabilityProbe();
+                setStatus(Active);
+                emit connectorUrlChanged();
+            }
+            return;
+        }
+
+        // No HTTP response: DNS not published, no route, TLS/timeout. Common
+        // cause is Funnel not granted for this node yet. Keep probing (it
+        // recovers once granted), but after a grace window surface an actionable
+        // error instead of an unbounded "Verifying…".
+        qWarning() << "McpRemoteAccess: Funnel reachability probe failed:" << errStr;
+        if (++m_probeFailCount >= 5 && m_status != Error) {
+            setStatus(Error, QStringLiteral(
+                "Public Funnel URL isn't reachable yet. Make sure Funnel is enabled for this "
+                "device in the Tailscale admin console (see “Set up Tailscale Funnel”). "
+                "This clears automatically once it's reachable."));
         }
     });
 }

--- a/src/mcp/mcpremoteaccess.h
+++ b/src/mcp/mcpremoteaccess.h
@@ -12,6 +12,7 @@ class QTcpSocket;
 class QTimer;
 class McpServer;
 class SettingsMcp;
+class McpTunnelTsnet;
 
 // Coordinator for the remote MCP connector (public-internet reachability for
 // Claude / ChatGPT mobile custom connectors). Owns a dedicated TCP listener,
@@ -39,6 +40,11 @@ class McpRemoteAccess : public QObject {
     Q_PROPERTY(QString statusDetail READ statusDetail NOTIFY statusChanged)
     Q_PROPERTY(QString connectorUrl READ connectorUrl NOTIFY connectorUrlChanged)
     Q_PROPERTY(int listenPort READ listenPort NOTIFY statusChanged)
+    // Tailscale (Mode A) interactive login URL — non-empty only while the
+    // embedded node is waiting for the user to authorize it. Surface as QR/link.
+    Q_PROPERTY(QString loginUrl READ loginUrl NOTIFY loginUrlChanged)
+    // Whether embedded-tunnel modes (Mode A) are compiled into this build.
+    Q_PROPERTY(bool tunnelAvailable READ tunnelAvailable CONSTANT)
 
 public:
     enum Status {
@@ -65,6 +71,8 @@ public:
     // a mode whose tunnel URL is not yet known).
     QString connectorUrl() const;
     int listenPort() const;
+    QString loginUrl() const;
+    static bool tunnelAvailable();
 
     // Re-evaluate settings (enabled / mode / port) and start, stop, or restart
     // the listener accordingly. Safe to call repeatedly.
@@ -77,15 +85,23 @@ public:
 signals:
     void statusChanged();
     void connectorUrlChanged();
+    void loginUrlChanged();
 
 private slots:
     void onNewConnection();
     void onReadyRead();
     void onSocketDisconnected();
     void onReaperTick();
+    void onTunnelStateChanged();
 
 private:
-    void startListener();
+    // bindLoopbackOnly: embedded tunnels (Mode A) proxy from 127.0.0.1, so the
+    // listener binds loopback; Mode C needs a LAN-routable bind for an off-box
+    // proxy. Returns true if the listener is (now) up on the requested port.
+    void startListener(bool bindLoopbackOnly);
+    // Start / stop the embedded Tailscale node for Mode A.
+    void startTunnel();
+    void stopTunnel();
     void stopListener();
     void setStatus(Status status, const QString& detail = QString());
     void closeAllSockets();
@@ -109,6 +125,7 @@ private:
     McpServer* m_mcpServer = nullptr;
     SettingsMcp* m_settings = nullptr;
     QTcpServer* m_listener = nullptr;
+    McpTunnelTsnet* m_tunnel = nullptr;   // embedded Tailscale node (Mode A)
     QTimer* m_reaper = nullptr;
 
     Status m_status = Off;

--- a/src/mcp/mcpremoteaccess.h
+++ b/src/mcp/mcpremoteaccess.h
@@ -13,6 +13,8 @@ class QTimer;
 class McpServer;
 class SettingsMcp;
 class McpTunnelTsnet;
+class QNetworkAccessManager;
+class QNetworkReply;
 
 // Coordinator for the remote MCP connector (public-internet reachability for
 // Claude / ChatGPT mobile custom connectors). Owns a dedicated TCP listener,
@@ -102,6 +104,14 @@ private:
     // Start / stop the embedded Tailscale node for Mode A.
     void startTunnel();
     void stopTunnel();
+
+    // Mode A public-reachability probe: actually fetch the Funnel connector URL
+    // from the app and only treat the connector as Active once it responds — the
+    // tunnel's local "funnel configured" signal is NOT proof the public path
+    // works (needs HTTPS certs + Funnel granted server-side).
+    void startReachabilityProbe();
+    void stopReachabilityProbe();
+    void doReachabilityProbe();
     void stopListener();
     void setStatus(Status status, const QString& detail = QString());
     void closeAllSockets();
@@ -126,6 +136,10 @@ private:
     SettingsMcp* m_settings = nullptr;
     QTcpServer* m_listener = nullptr;
     McpTunnelTsnet* m_tunnel = nullptr;   // embedded Tailscale node (Mode A)
+    QNetworkAccessManager* m_reachProbe = nullptr;  // Mode A reachability probe
+    QTimer* m_reachTimer = nullptr;
+    bool m_funnelReachable = false;       // last probe confirmed the public URL works
+    bool m_probeInFlight = false;
     QTimer* m_reaper = nullptr;
 
     Status m_status = Off;

--- a/src/mcp/mcpremoteaccess.h
+++ b/src/mcp/mcpremoteaccess.h
@@ -99,7 +99,7 @@ private slots:
 private:
     // bindLoopbackOnly: embedded tunnels (Mode A) proxy from 127.0.0.1, so the
     // listener binds loopback; Mode C needs a LAN-routable bind for an off-box
-    // proxy. Returns true if the listener is (now) up on the requested port.
+    // proxy. On a bind failure it sets status Error (callers check m_status).
     void startListener(bool bindLoopbackOnly);
     // Start / stop the embedded Tailscale node for Mode A.
     void startTunnel();
@@ -140,6 +140,10 @@ private:
     QTimer* m_reachTimer = nullptr;
     bool m_funnelReachable = false;       // last probe confirmed the public URL works
     bool m_probeInFlight = false;
+    // Bumped whenever probing (re)starts/stops; a probe reply carrying a stale
+    // generation is ignored so it can't flip status after disable/mode switch.
+    quint64 m_probeGeneration = 0;
+    int m_probeFailCount = 0;             // consecutive failed probes (for surfacing an error)
     QTimer* m_reaper = nullptr;
 
     Status m_status = Off;

--- a/src/mcp/mcptunnel_tsnet.cpp
+++ b/src/mcp/mcptunnel_tsnet.cpp
@@ -1,0 +1,178 @@
+#include "mcptunnel_tsnet.h"
+
+#include <QThread>
+#include <QDir>
+#include <QMetaObject>
+#include <QDebug>
+
+#ifdef DECENZA_ENABLE_TSNET
+extern "C" {
+#include "tailscale.h"
+}
+#endif
+
+McpTunnelTsnet::McpTunnelTsnet(QObject* parent)
+    : QObject(parent)
+{
+}
+
+McpTunnelTsnet::~McpTunnelTsnet()
+{
+    stop();
+}
+
+bool McpTunnelTsnet::isAvailable()
+{
+#ifdef DECENZA_ENABLE_TSNET
+    return true;
+#else
+    return false;
+#endif
+}
+
+void McpTunnelTsnet::applyUpdate(State state, const QString& authUrl,
+                                 const QString& certDomain, const QString& errorMsg)
+{
+    // Main thread.
+    if (!errorMsg.isEmpty())
+        m_lastError = errorMsg;
+    if (m_authUrl != authUrl) {
+        m_authUrl = authUrl;
+        emit authUrlChanged();
+    }
+    if (m_certDomain != certDomain) {
+        m_certDomain = certDomain;
+        emit certDomainChanged();
+    }
+    if (m_state != state) {
+        m_state = state;
+        emit stateChanged();
+    }
+}
+
+void McpTunnelTsnet::start(const QString& stateDir, const QString& hostname, quint16 localPort)
+{
+#ifndef DECENZA_ENABLE_TSNET
+    Q_UNUSED(stateDir)
+    Q_UNUSED(hostname)
+    Q_UNUSED(localPort)
+    applyUpdate(Error, QString(), QString(),
+                QStringLiteral("This build does not include Tailscale support (ENABLE_TSNET off)"));
+#else
+    if (m_worker)
+        return;  // already running — stop() first
+    m_stopRequested = false;
+    m_stateDir = stateDir;
+    applyUpdate(Starting, QString(), QString(), QString());
+
+    m_worker = QThread::create([this, stateDir, hostname, localPort]() {
+        runWorker(stateDir, hostname, localPort);
+    });
+    m_worker->setObjectName(QStringLiteral("tsnet-worker"));
+    m_worker->start();
+#endif
+}
+
+void McpTunnelTsnet::runWorker(QString stateDir, QString hostname, quint16 localPort)
+{
+#ifdef DECENZA_ENABLE_TSNET
+    auto post = [this](State st, const QString& au, const QString& cd, const QString& err) {
+        QMetaObject::invokeMethod(this, [this, st, au, cd, err]() {
+            applyUpdate(st, au, cd, err);
+        }, Qt::QueuedConnection);
+    };
+
+    QDir().mkpath(stateDir);
+
+    int sd = tailscale_new();
+    if (sd < 0) {
+        post(Error, QString(), QString(), QStringLiteral("tailscale_new failed"));
+        return;
+    }
+    m_handle = sd;
+
+    char buf[1024];
+    auto errmsg = [&]() -> QString {
+        return tailscale_errmsg(sd, buf, sizeof(buf)) == 0
+                   ? QString::fromUtf8(buf) : QStringLiteral("unknown error");
+    };
+    auto backendState = [&]() -> QString {
+        return tailscale_get_backend_state(sd, buf, sizeof(buf)) == 0
+                   ? QString::fromUtf8(buf) : QString();
+    };
+    auto authUrl = [&]() -> QString {
+        return tailscale_get_auth_url(sd, buf, sizeof(buf)) == 0
+                   ? QString::fromUtf8(buf) : QString();
+    };
+    auto certDomain = [&]() -> QString {
+        return tailscale_get_cert_domain(sd, buf, sizeof(buf)) == 0
+                   ? QString::fromUtf8(buf) : QString();
+    };
+
+    tailscale_set_logfd(sd, -1);  // discard tsnet's own logging
+    tailscale_set_dir(sd, stateDir.toUtf8().constData());
+    tailscale_set_hostname(sd, hostname.toUtf8().constData());
+
+    // Non-blocking bring-up so we can surface the login URL while it comes up.
+    if (tailscale_start(sd) != 0) {
+        post(Error, QString(), QString(), errmsg());
+        return;
+    }
+
+    bool funnelEnabled = false;
+    while (!m_stopRequested.load()) {
+        const QString state = backendState();
+        if (state == QLatin1String("Running")) {
+            if (!funnelEnabled) {
+                if (tailscale_enable_funnel_to_localhost_plaintext_http1(sd, localPort) != 0) {
+                    post(Error, QString(), QString(), errmsg());
+                    return;
+                }
+                funnelEnabled = true;
+            }
+            const QString domain = certDomain();
+            post(Running, QString(), domain, QString());
+            // Funnel provisions the cert lazily; once we have the FQDN we're done
+            // configuring and the node keeps running on its own goroutines.
+            if (!domain.isEmpty())
+                return;
+        } else if (state == QLatin1String("NeedsLogin")
+                   || state == QLatin1String("NeedsMachineAuth")) {
+            post(NeedsLogin, authUrl(), QString(), QString());
+        } else {
+            post(Starting, QString(), QString(), QString());
+        }
+        QThread::msleep(1000);
+    }
+#else
+    Q_UNUSED(stateDir)
+    Q_UNUSED(hostname)
+    Q_UNUSED(localPort)
+#endif
+}
+
+void McpTunnelTsnet::stop()
+{
+#ifdef DECENZA_ENABLE_TSNET
+    m_stopRequested = true;
+    if (m_worker) {
+        // The worker breaks out of its poll loop within one interval; wait a bit
+        // longer than that. (No event loop runs on it, so quit() is a no-op.)
+        m_worker->wait(6000);
+        delete m_worker;
+        m_worker = nullptr;
+    }
+    const int sd = m_handle.exchange(-1);
+    if (sd >= 0)
+        tailscale_close(sd);
+    applyUpdate(Stopped, QString(), QString(), QString());
+#endif
+}
+
+void McpTunnelTsnet::wipeState()
+{
+    const QString dir = m_stateDir;
+    stop();
+    if (!dir.isEmpty())
+        QDir(dir).removeRecursively();
+}

--- a/src/mcp/mcptunnel_tsnet.cpp
+++ b/src/mcp/mcptunnel_tsnet.cpp
@@ -119,7 +119,7 @@ void McpTunnelTsnet::runWorker(QString stateDir, QString hostname, quint16 local
         return;
     }
 
-    bool funnelEnabled = false;
+    bool funnelLogged = false;
     QString lastState;
     while (!m_stopRequested.load()) {
         const QString state = backendState();
@@ -131,28 +131,24 @@ void McpTunnelTsnet::runWorker(QString stateDir, QString hostname, quint16 local
         if (state == QLatin1String("Running")) {
             const QString domain = certDomain();
             if (domain.isEmpty()) {
-                // Node is authorized and up, but the tailnet hasn't issued a
-                // Funnel/HTTPS cert domain yet — HTTPS Certificates must be
-                // enabled and Funnel approved for this node in the admin console.
-                // Keep polling (do NOT return): the control plane pushes the new
-                // capability to the running node, so this recovers automatically
-                // once the user enables it, no restart needed.
-                post(Error, QString(), QString(),
-                     QStringLiteral("Tailscale node is up, but Funnel isn't available for this tailnet yet. "
-                                    "In the Tailscale admin console: enable HTTPS Certificates (DNS page) "
-                                    "and approve Funnel for this node."));
-            } else if (!funnelEnabled) {
-                if (tailscale_enable_funnel_to_localhost_plaintext_http1(sd, localPort) != 0) {
+                // Node up but no DNS/cert domain yet — keep waiting.
+                post(Starting, QString(), QString(), QString());
+            } else {
+                // (Re-)apply the Funnel serve config every cycle. SetServeConfig
+                // is idempotent, and re-applying is what lets a Funnel grant made
+                // WHILE the app is running take effect without a restart — the
+                // one-shot approach got permanently stuck if Funnel wasn't yet
+                // authorised when we first reached Running.
+                if (tailscale_enable_funnel_to_localhost_plaintext_http1(sd, localPort) != 0)
                     qWarning() << "McpTunnelTsnet: enable funnel failed:" << errmsg();
-                    post(Error, QString(), QString(), errmsg());
-                    // Keep polling — a transient/approval issue may clear.
-                } else {
-                    funnelEnabled = true;
-                    qInfo() << "McpTunnelTsnet: Funnel enabled for" << domain;
-                    post(Running, QString(), domain, QString());
-                    // Done configuring; the node keeps running on its goroutines.
-                    return;
+                if (!funnelLogged) {
+                    funnelLogged = true;
+                    qInfo() << "McpTunnelTsnet: Funnel configured for" << domain;
                 }
+                // Report the FQDN. This is NOT proof of public reachability —
+                // McpRemoteAccess probes the real Funnel URL before it surfaces
+                // the connector URL / "Active".
+                post(Running, QString(), domain, QString());
             }
         } else if (state == QLatin1String("NeedsLogin")
                    || state == QLatin1String("NeedsMachineAuth")) {
@@ -160,7 +156,8 @@ void McpTunnelTsnet::runWorker(QString stateDir, QString hostname, quint16 local
         } else {
             post(Starting, QString(), QString(), QString());
         }
-        QThread::msleep(1000);
+        // Poll faster while coming up; ease off (still re-applying funnel) once up.
+        QThread::msleep(state == QLatin1String("Running") ? 5000 : 1500);
     }
 #else
     Q_UNUSED(stateDir)

--- a/src/mcp/mcptunnel_tsnet.cpp
+++ b/src/mcp/mcptunnel_tsnet.cpp
@@ -120,22 +120,40 @@ void McpTunnelTsnet::runWorker(QString stateDir, QString hostname, quint16 local
     }
 
     bool funnelEnabled = false;
+    QString lastState;
     while (!m_stopRequested.load()) {
         const QString state = backendState();
+        if (state != lastState) {
+            qInfo() << "McpTunnelTsnet: backend state ->" << state;
+            lastState = state;
+        }
+
         if (state == QLatin1String("Running")) {
-            if (!funnelEnabled) {
+            const QString domain = certDomain();
+            if (domain.isEmpty()) {
+                // Node is authorized and up, but the tailnet hasn't issued a
+                // Funnel/HTTPS cert domain yet — HTTPS Certificates must be
+                // enabled and Funnel approved for this node in the admin console.
+                // Keep polling (do NOT return): the control plane pushes the new
+                // capability to the running node, so this recovers automatically
+                // once the user enables it, no restart needed.
+                post(Error, QString(), QString(),
+                     QStringLiteral("Tailscale node is up, but Funnel isn't available for this tailnet yet. "
+                                    "In the Tailscale admin console: enable HTTPS Certificates (DNS page) "
+                                    "and approve Funnel for this node."));
+            } else if (!funnelEnabled) {
                 if (tailscale_enable_funnel_to_localhost_plaintext_http1(sd, localPort) != 0) {
+                    qWarning() << "McpTunnelTsnet: enable funnel failed:" << errmsg();
                     post(Error, QString(), QString(), errmsg());
+                    // Keep polling — a transient/approval issue may clear.
+                } else {
+                    funnelEnabled = true;
+                    qInfo() << "McpTunnelTsnet: Funnel enabled for" << domain;
+                    post(Running, QString(), domain, QString());
+                    // Done configuring; the node keeps running on its goroutines.
                     return;
                 }
-                funnelEnabled = true;
             }
-            const QString domain = certDomain();
-            post(Running, QString(), domain, QString());
-            // Funnel provisions the cert lazily; once we have the FQDN we're done
-            // configuring and the node keeps running on its own goroutines.
-            if (!domain.isEmpty())
-                return;
         } else if (state == QLatin1String("NeedsLogin")
                    || state == QLatin1String("NeedsMachineAuth")) {
             post(NeedsLogin, authUrl(), QString(), QString());

--- a/src/mcp/mcptunnel_tsnet.cpp
+++ b/src/mcp/mcptunnel_tsnet.cpp
@@ -30,12 +30,18 @@ bool McpTunnelTsnet::isAvailable()
 #endif
 }
 
-void McpTunnelTsnet::applyUpdate(State state, const QString& authUrl,
+void McpTunnelTsnet::applyUpdate(quint64 epoch, State state, const QString& authUrl,
                                  const QString& certDomain, const QString& errorMsg)
 {
-    // Main thread.
+    Q_ASSERT(thread() == QThread::currentThread());  // main thread only
+    // Drop updates from a superseded worker generation (post-stop / restart).
+    if (epoch != m_epoch.load())
+        return;
+
     if (!errorMsg.isEmpty())
         m_lastError = errorMsg;
+    else if (state == Running || state == Stopped)
+        m_lastError.clear();  // don't leave a stale error after recovery
     if (m_authUrl != authUrl) {
         m_authUrl = authUrl;
         emit authUrlChanged();
@@ -56,35 +62,57 @@ void McpTunnelTsnet::start(const QString& stateDir, const QString& hostname, qui
     Q_UNUSED(stateDir)
     Q_UNUSED(hostname)
     Q_UNUSED(localPort)
-    applyUpdate(Error, QString(), QString(),
+    applyUpdate(m_epoch.load(), Error, QString(), QString(),
                 QStringLiteral("This build does not include Tailscale support (ENABLE_TSNET off)"));
 #else
-    if (m_worker)
-        return;  // already running — stop() first
+    // Reap a worker that has already exited (e.g. bring-up failed with Error) so
+    // a re-start is possible; only refuse if one is genuinely still running.
+    if (m_worker) {
+        if (m_worker->isFinished()) {
+            delete m_worker;
+            m_worker = nullptr;
+        } else {
+            return;
+        }
+    }
     m_stopRequested = false;
     m_stateDir = stateDir;
-    applyUpdate(Starting, QString(), QString(), QString());
+    const quint64 epoch = ++m_epoch;
+    applyUpdate(epoch, Starting, QString(), QString(), QString());
 
-    m_worker = QThread::create([this, stateDir, hostname, localPort]() {
-        runWorker(stateDir, hostname, localPort);
+    m_worker = QThread::create([this, epoch, stateDir, hostname, localPort]() {
+        runWorker(epoch, stateDir, hostname, localPort);
     });
     m_worker->setObjectName(QStringLiteral("tsnet-worker"));
     m_worker->start();
 #endif
 }
 
-void McpTunnelTsnet::runWorker(QString stateDir, QString hostname, quint16 localPort)
+void McpTunnelTsnet::runWorker(quint64 epoch, QString stateDir, QString hostname, quint16 localPort)
 {
 #ifdef DECENZA_ENABLE_TSNET
-    auto post = [this](State st, const QString& au, const QString& cd, const QString& err) {
-        QMetaObject::invokeMethod(this, [this, st, au, cd, err]() {
-            applyUpdate(st, au, cd, err);
+    auto post = [this, epoch](State st, const QString& au, const QString& cd, const QString& err) {
+        QMetaObject::invokeMethod(this, [this, epoch, st, au, cd, err]() {
+            applyUpdate(epoch, st, au, cd, err);
         }, Qt::QueuedConnection);
+    };
+    // Interruptible sleep so stop() (which sets m_stopRequested) is honoured
+    // within ~100 ms — the old single msleep(5000) could outrun stop()'s join
+    // timeout and get the still-running QThread deleted (a fatal abort).
+    auto sleepInterruptible = [this](int totalMs) {
+        for (int slept = 0; slept < totalMs && !m_stopRequested.load(); slept += 100)
+            QThread::msleep(100);
+    };
+    // The worker exclusively owns the libtailscale handle and closes it on exit.
+    auto closeHandle = [this]() {
+        const int h = m_handle.exchange(-1);
+        if (h >= 0)
+            tailscale_close(h);
     };
 
     QDir().mkpath(stateDir);
 
-    int sd = tailscale_new();
+    const int sd = tailscale_new();
     if (sd < 0) {
         post(Error, QString(), QString(), QStringLiteral("tailscale_new failed"));
         return;
@@ -109,13 +137,29 @@ void McpTunnelTsnet::runWorker(QString stateDir, QString hostname, quint16 local
                    ? QString::fromUtf8(buf) : QString();
     };
 
+    // Cancel bring-up if stop() arrived between tailscale_new and here.
+    if (m_stopRequested.load()) { closeHandle(); return; }
+
     tailscale_set_logfd(sd, -1);  // discard tsnet's own logging
-    tailscale_set_dir(sd, stateDir.toUtf8().constData());
-    tailscale_set_hostname(sd, hostname.toUtf8().constData());
+    // set_dir/set_hostname run once at bring-up; a failure here is always real
+    // (unwritable state dir, rejected hostname → wrong Funnel FQDN) — surface it.
+    if (tailscale_set_dir(sd, stateDir.toUtf8().constData()) != 0) {
+        post(Error, QString(), QString(),
+             QStringLiteral("Tailscale state dir rejected: ") + errmsg());
+        closeHandle();
+        return;
+    }
+    if (tailscale_set_hostname(sd, hostname.toUtf8().constData()) != 0) {
+        post(Error, QString(), QString(),
+             QStringLiteral("Tailscale hostname rejected: ") + errmsg());
+        closeHandle();
+        return;
+    }
 
     // Non-blocking bring-up so we can surface the login URL while it comes up.
     if (tailscale_start(sd) != 0) {
         post(Error, QString(), QString(), errmsg());
+        closeHandle();
         return;
     }
 
@@ -147,19 +191,30 @@ void McpTunnelTsnet::runWorker(QString stateDir, QString hostname, quint16 local
                 }
                 // Report the FQDN. This is NOT proof of public reachability —
                 // McpRemoteAccess probes the real Funnel URL before it surfaces
-                // the connector URL / "Active".
+                // the connector URL / "Active" (funnel may not be granted yet).
                 post(Running, QString(), domain, QString());
             }
         } else if (state == QLatin1String("NeedsLogin")
                    || state == QLatin1String("NeedsMachineAuth")) {
             post(NeedsLogin, authUrl(), QString(), QString());
+        } else if (state == QLatin1String("Stopped")
+                   || state == QLatin1String("InUseOtherUser")) {
+            // Non-transient: these won't advance on their own — surface, not "Starting".
+            post(Error, QString(), QString(),
+                 QStringLiteral("Tailscale backend state: ") + state);
         } else {
+            // NoState / Starting / empty (query error) — normal during bring-up.
             post(Starting, QString(), QString(), QString());
         }
         // Poll faster while coming up; ease off (still re-applying funnel) once up.
-        QThread::msleep(state == QLatin1String("Running") ? 5000 : 1500);
+        sleepInterruptible(state == QLatin1String("Running") ? 5000 : 1500);
     }
+
+    // Stop requested (or loop exited): the worker owns closing the handle so the
+    // main thread never races a tailscale_* call still running here.
+    closeHandle();
 #else
+    Q_UNUSED(epoch)
     Q_UNUSED(stateDir)
     Q_UNUSED(hostname)
     Q_UNUSED(localPort)
@@ -169,18 +224,22 @@ void McpTunnelTsnet::runWorker(QString stateDir, QString hostname, quint16 local
 void McpTunnelTsnet::stop()
 {
 #ifdef DECENZA_ENABLE_TSNET
+    // Invalidate any queued updates from the current worker before we tear down.
+    const quint64 epoch = ++m_epoch;
     m_stopRequested = true;
     if (m_worker) {
-        // The worker breaks out of its poll loop within one interval; wait a bit
-        // longer than that. (No event loop runs on it, so quit() is a no-op.)
-        m_worker->wait(6000);
-        delete m_worker;
-        m_worker = nullptr;
+        // The worker honours m_stopRequested within ~100 ms (interruptible sleep),
+        // then closes the handle and returns. Only delete once it has actually
+        // finished — deleting a still-running QThread is fatal. On the rare
+        // timeout (a libtailscale call stalled), leak the thread rather than crash.
+        if (m_worker->wait(12000)) {
+            delete m_worker;
+            m_worker = nullptr;
+        } else {
+            qWarning() << "McpTunnelTsnet: worker did not stop within timeout; leaking it";
+        }
     }
-    const int sd = m_handle.exchange(-1);
-    if (sd >= 0)
-        tailscale_close(sd);
-    applyUpdate(Stopped, QString(), QString(), QString());
+    applyUpdate(epoch, Stopped, QString(), QString(), QString());
 #endif
 }
 
@@ -188,6 +247,6 @@ void McpTunnelTsnet::wipeState()
 {
     const QString dir = m_stateDir;
     stop();
-    if (!dir.isEmpty())
-        QDir(dir).removeRecursively();
+    if (!dir.isEmpty() && !QDir(dir).removeRecursively())
+        qWarning() << "McpTunnelTsnet: failed to wipe tsnet state dir" << dir;
 }

--- a/src/mcp/mcptunnel_tsnet.h
+++ b/src/mcp/mcptunnel_tsnet.h
@@ -65,15 +65,20 @@ signals:
 
 private:
     // Applies a status update on the main thread (called via queued invocation
-    // from the worker). Emits the matching change signals.
-    void applyUpdate(State state, const QString& authUrl, const QString& certDomain,
-                     const QString& errorMsg);
+    // from the worker, or directly by stop()). Updates carrying a stale epoch —
+    // posted by a worker generation that has since been stopped/superseded — are
+    // dropped, so a late queued event can't clobber the current state.
+    void applyUpdate(quint64 epoch, State state, const QString& authUrl,
+                     const QString& certDomain, const QString& errorMsg);
 
-    void runWorker(QString stateDir, QString hostname, quint16 localPort);
+    void runWorker(quint64 epoch, QString stateDir, QString hostname, quint16 localPort);
 
     QThread* m_worker = nullptr;
-    std::atomic<int> m_handle{-1};   // libtailscale handle (int), -1 when none
+    std::atomic<int> m_handle{-1};   // libtailscale handle (int), -1 when none. Owned by the worker.
     std::atomic<bool> m_stopRequested{false};
+    // Bumped on every start()/stop(); a worker captures its epoch at launch so
+    // its queued updates are ignored once a newer generation begins.
+    std::atomic<quint64> m_epoch{0};
 
     State m_state = Stopped;
     QString m_authUrl;

--- a/src/mcp/mcptunnel_tsnet.h
+++ b/src/mcp/mcptunnel_tsnet.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <atomic>
+
+class QThread;
+
+// C++ wrapper around the (Decenza fork of) libtailscale C API. Embeds a
+// userspace Tailscale node and enables Funnel, giving a stable public HTTPS URL
+// (https://<host>.<tailnet>.ts.net) that proxies to Decenza's loopback MCP
+// listener. This is Mode A of the Remote MCP connector.
+//
+// Only does real work when the app is built with -DENABLE_TSNET=ON
+// (DECENZA_ENABLE_TSNET). Otherwise every call is a no-op and isAvailable()
+// returns false, so McpRemoteAccess can reference this class unconditionally and
+// simply report Mode A as unavailable.
+//
+// All blocking libtailscale calls run on a single worker thread (the C handle is
+// only ever touched from there); results are posted back to the main thread via
+// queued signals. Uses the non-blocking tailscale_start() + status polling so
+// the interactive login URL can be surfaced (as a QR/link) before the node is
+// authorized.
+class McpTunnelTsnet : public QObject {
+    Q_OBJECT
+public:
+    enum State {
+        Stopped,     // not started
+        Starting,    // backend coming up
+        NeedsLogin,  // waiting for the user to authorize (see authUrl())
+        Running,     // node up, Funnel active (see certDomain())
+        Error        // see lastError()
+    };
+    Q_ENUM(State)
+
+    explicit McpTunnelTsnet(QObject* parent = nullptr);
+    ~McpTunnelTsnet() override;
+
+    // Compiled with tsnet support? False in stock builds.
+    static bool isAvailable();
+
+    // Start the node and enable Funnel to 127.0.0.1:localPort (async).
+    // stateDir persists the tailnet identity across launches; hostname is the
+    // node name and becomes the Funnel subdomain. Safe to call once; call stop()
+    // before starting again.
+    void start(const QString& stateDir, const QString& hostname, quint16 localPort);
+
+    // Bring the node down and tear down the worker (async, then blocks briefly
+    // on join). Keeps the persisted state so the next start() reuses the identity.
+    void stop();
+
+    // "Forget this tailnet": stop(), then delete the state directory so the next
+    // start() logs in fresh.
+    void wipeState();
+
+    State state() const { return m_state; }
+    QString authUrl() const { return m_authUrl; }       // login URL (empty unless NeedsLogin)
+    QString certDomain() const { return m_certDomain; } // Funnel FQDN (empty until Running)
+    QString lastError() const { return m_lastError; }
+
+signals:
+    void stateChanged();
+    void authUrlChanged();
+    void certDomainChanged();
+
+private:
+    // Applies a status update on the main thread (called via queued invocation
+    // from the worker). Emits the matching change signals.
+    void applyUpdate(State state, const QString& authUrl, const QString& certDomain,
+                     const QString& errorMsg);
+
+    void runWorker(QString stateDir, QString hostname, quint16 localPort);
+
+    QThread* m_worker = nullptr;
+    std::atomic<int> m_handle{-1};   // libtailscale handle (int), -1 when none
+    std::atomic<bool> m_stopRequested{false};
+
+    State m_state = Stopped;
+    QString m_authUrl;
+    QString m_certDomain;
+    QString m_lastError;
+    QString m_stateDir;              // remembered for wipeState()
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -956,6 +956,8 @@ add_decenza_test(tst_mcpremoteaccess
     ${CMAKE_SOURCE_DIR}/src/mcp/mcpsession.h
     ${CMAKE_SOURCE_DIR}/src/mcp/mcpremoteaccess.cpp
     ${CMAKE_SOURCE_DIR}/src/mcp/mcpremoteaccess.h
+    ${CMAKE_SOURCE_DIR}/src/mcp/mcptunnel_tsnet.cpp
+    ${CMAKE_SOURCE_DIR}/src/mcp/mcptunnel_tsnet.h
     ${PROFILEMANAGER_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_internal.cpp


### PR DESCRIPTION
Adds **Mode A** of the Remote MCP connector — embedded Tailscale + Funnel — building on the merged Phase 1 (shared core + Mode C, #1480). Gives a stable public HTTPS URL with **no developer infrastructure and no Go toolchain in the app build**.

## How it works
- A **fork of libtailscale** ([skialpine/libtailscale](https://github.com/skialpine/libtailscale)) builds prebuilt artifacts for macOS/iOS/Android in CI and publishes them as a Release. That fork adds status accessors (`tailscale_get_cert_domain` / `_auth_url` / `_backend_state`), an Android build, a Funnel empty-cert-domain crash guard, and the release pipeline.
- **`cmake/tsnet.cmake`** (`-DENABLE_TSNET=ON`, default OFF) downloads + checksum-verifies + extracts + links the platform artifact. Normal builds are untouched.
- **`mcptunnel_tsnet.{h,cpp}`** wraps the libtailscale C API on a worker thread: non-blocking `tailscale_start()` + status polling surfaces the login URL (QR/link) before authorization; once `Running` it enables Funnel → `127.0.0.1:<remote port>`. Stub no-op when `ENABLE_TSNET` is off.
- **`McpRemoteAccess`** is now mode-aware: Mode A binds the tokenized listener to **loopback** (the node Funnels to it), composes `https://<funnel-fqdn>/mcp/<token>`, and exposes `loginUrl` + `tunnelAvailable`. Mode C is unchanged (LAN-routable bind for an off-box proxy).
- **Settings UI**: a reachability-mode selector (Custom URL / Tailscale — the latter greyed out when not compiled in) and a Tailscale login block (URL + QR) while authorization is pending.

## Verified
- Builds clean (ENABLE_TSNET off), 0 warnings; `tst_mcpremoteaccess` 17/17.
- Prebuilt macOS `.a` symbol analysis confirms it links with CoreFoundation + Security.
- Fork CI green; artifacts published + structure-verified (universal mac `.a`, iOS xcframework, Android 3-ABI `.so`).

## ⚠️ Needs on-tailnet QA before merge
The end-to-end Funnel flow can only be exercised on a real tailnet. To test:
1. Build with `-DENABLE_TSNET=ON` (macOS first).
2. Settings → AI → MCP → Remote Access → enable, pick **Tailscale**.
3. Scan/open the login URL, authorize the `decenza` node, approve **Funnel** in the Tailscale admin console.
4. Confirm `https://decenza.<tailnet>.ts.net/mcp/<token>` resolves and an MCP `initialize` succeeds through it.

Android/iOS packaging + the funnel-approval status surfacing are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)