### PR TITLE
Refresh Shot Plan grind when the active recipe is edited

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -872,8 +872,14 @@ void MainController::setupRecipeConnections() {
             m_pendingRecipeSelfWrites--;
             return;
         }
-        if (success)
+        if (success) {
+            // An external edit of the active recipe (wizard/MCP/web). Flag the
+            // re-read so recipeReady mirrors the new grind/rpm onto the live
+            // dial — the Shot Plan binds to Settings.dye, not the recipe cache,
+            // so without this the plan stays stale until re-activation.
+            m_refreshDialFromRecipeEdit = true;
             m_recipeStorage->requestRecipe(recipeId);
+        }
     });
 
     // Cache refresh + startup restore both land here.
@@ -881,6 +887,11 @@ void MainController::setupRecipeConnections() {
             [this](qint64 recipeId, const QVariantMap& recipe) {
         if (recipeId != m_settings->dye()->activeRecipeId())
             return;
+        // Consume the edit-refresh flag only for the active recipe's own
+        // re-read (a concurrent non-active read returns above without touching
+        // it, so it can't swallow a pending refresh).
+        const bool refreshDial = m_refreshDialFromRecipeEdit;
+        m_refreshDialFromRecipeEdit = false;
         if (recipe.isEmpty() || recipe.value("archived").toBool()) {
             // Row vanished or was archived out from under the selection.
             deactivateRecipe();
@@ -897,6 +908,23 @@ void MainController::setupRecipeConnections() {
         // the 5-9 minute warm-up means the hold must follow the cache.
         if (activeRecipeHasMilk() != hadMilk || activeRecipeHasMilk())
             applySteamSettings();
+        // Mirror an edited grind/rpm back onto the live dial so the Shot Plan
+        // refreshes without a re-activation (Flow-3 fix). Only on an actual
+        // edit re-read; same semantics as applyActivatedRecipe's grind push:
+        // grind-less drink types (tea) and an empty grind leave the dial
+        // untouched. The cache is already updated above, so the resulting
+        // dyeGrinderSettingChanged stamp hits stampActiveRecipe's equality
+        // guard and does NOT loop back into another write.
+        if (refreshDial
+            && DrinkTypes::hasGrind(m_activeRecipe.value(QStringLiteral("drinkType")).toString())) {
+            const QString grind = m_activeRecipe.value(QStringLiteral("grindPinned")).toString();
+            if (!grind.isEmpty()) {
+                m_settings->dye()->setDyeGrinderSetting(grind);
+                const qint64 rpm = m_activeRecipe.value(QStringLiteral("rpmPinned")).toLongLong();
+                if (rpm > 0)
+                    m_settings->dye()->setDyeGrinderRpm(static_cast<int>(rpm));
+            }
+        }
     });
 
     // --- Deactivate on ingredient swaps (tweaks refine the recipe; swapping
@@ -1202,6 +1230,10 @@ void MainController::applyActivatedRecipe(qint64 recipeId, const QVariantMap& re
     // echo arrived after the recipe was deactivated/switched never got a
     // chance to decrement) so it can't swallow this recipe's first edit.
     m_pendingRecipeSelfWrites = 0;
+    // Likewise drop a leaked edit-refresh flag: an edit re-read that never
+    // reached recipeReady before this switch must not push a stale grind onto
+    // the newly-active recipe's first read.
+    m_refreshDialFromRecipeEdit = false;
 
     if (!profileLess) {
         if (!filename.isEmpty()) {
@@ -1439,6 +1471,7 @@ void MainController::deactivateRecipe() {
     // Drop any in-flight self-write count with the recipe it belonged to —
     // its echo would otherwise land with no active recipe and leak the count.
     m_pendingRecipeSelfWrites = 0;
+    m_refreshDialFromRecipeEdit = false;
     if (m_settings) {
         m_settings->dye()->setActiveRecipeId(-1);
     }

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -481,6 +481,15 @@ private:
     // Outstanding write-through stamps whose recipeUpdated echo should not
     // trigger a cache re-read (mirrors SettingsDye::m_pendingSelfWrites).
     int m_pendingRecipeSelfWrites = 0;
+    // Set true immediately before the edit-triggered re-read of the ACTIVE
+    // recipe (the recipeUpdated → requestRecipe hop), so the recipeReady
+    // handler mirrors the refreshed grind/rpm back onto the live dial
+    // (Settings.dye). The Shot Plan widget binds to the dial, not the recipe
+    // cache, so an edit of the active recipe's grind (wizard/MCP/web) must
+    // re-push it or the plan goes stale until re-activation (the Flow-3 refresh
+    // bug). Left false on startup restore, relink refresh, and QML editor
+    // prefill reads — none of which should re-apply values to the live session.
+    bool m_refreshDialFromRecipeEdit = false;
     // Pure state machine behind selectedRecipeId + the deferred recipe-shot
     // start. MainController only wires it to Qt signals and the device; the
     // policy (lead/converge/rollback, arm/fire) lives in the header-only model


### PR DESCRIPTION
## Problem

Editing the **active** recipe's grind (Recipe wizard / MCP / web) updated the recipe row and `MainController`'s in-memory cache, but never re-applied grind to the live dial (`Settings.dye.dyeGrinderSetting`). The home **Shot Plan** widget binds to the dial, not the recipe cache — so the plan stayed **stale** until a full re-activation. Users had to *select a different recipe and re-select the edited one* to force the refresh.

This was traced as the "Flow 3" refresh bug: `Recipe → Shot Plan` grind propagation only ever happened at `applyActivatedRecipe` (activation), never on an in-place edit of the already-active recipe.

## Fix

Mirror an edited active recipe's `grindPinned`/`rpmPinned` back onto the dial from the `recipeReady` cache-refresh, using the **same push semantics** as `applyActivatedRecipe`:
- grind-less drink types (tea) and an empty grind leave the dial untouched;
- `rpm` is only pushed when `> 0`.

A new `m_refreshDialFromRecipeEdit` flag, set **only** on the edit-triggered re-read (`recipeUpdated → requestRecipe`), gates the push so the other `recipeReady` sources — **startup restore, relink refresh, and QML editor-prefill reads** — never re-apply values to the live session. The flag is consumed only for the active recipe's own read (a concurrent non-active read can't swallow it) and cleared on recipe switch/deactivate to prevent leaks.

**No write-loop:** the cache is updated before the push, so the resulting `dyeGrinderSettingChanged` stamp hits `stampActiveRecipe`'s equality guard and does not loop back into another DB write.

## Files
- `src/controllers/maincontroller.h` — new `m_refreshDialFromRecipeEdit` flag.
- `src/controllers/maincontroller.cpp` — set the flag on the edit re-read, consume it in `recipeReady` to push grind/rpm to the dial, clear it in `applyActivatedRecipe`/`deactivateRecipe`.

## Testing
- Builds clean on the macOS Qt 6.11.1 debug kit (0 errors, 0 warnings) including all test targets.
- **No automated regression test yet** — `MainController`'s recipe/dial wiring is async and has no test harness (recipe tests exercise `RecipeStorage` statics to avoid it). A follow-up OpenSpec covers building a real `tst_maincontroller` integration harness and moving proxy tests into it.

### Manual test plan
1. Activate a recipe with a grind (e.g. `4.5`); confirm the home Shot Plan shows it.
2. Edit that recipe's grind to `5.0` in the Recipe wizard (or via MCP `recipe_update` / web) **without** re-selecting the pill → **Shot Plan updates to `5.0` immediately.**
3. Edit an **inactive** recipe's grind → Shot Plan unchanged.
4. Restart the app with an active recipe → the live dial is **not** overwritten by the recipe's stored grind (startup restore doesn't re-apply).
5. Open the Recipe editor on the active recipe (no save) → dial unchanged.
6. Tea recipe (grind-less) edit → dial untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)