### PR TITLE
openspec: propose add-maincontroller-test-harness

### DIFF
--- a/openspec/changes/add-maincontroller-test-harness/.openspec.yaml
+++ b/openspec/changes/add-maincontroller-test-harness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/add-maincontroller-test-harness/design.md
+++ b/openspec/changes/add-maincontroller-test-harness/design.md
@@ -1,0 +1,75 @@
+## Context
+
+`MainController` is the hub for recipe activation and the dial/bag/recipe write-through wiring. Today it is impossible to unit-test because:
+
+- It constructs `RecipeStorage`, `ShotHistoryStorage`, and `CoffeeBagStorage` internally (`maincontroller.cpp` ~L196/206/226), each resolving the shared shot-history DB path — so a test would read/write the real user DB.
+- Its constructor eagerly builds `ProfileManager`, `VisualizerUploader`, `BeanBaseClient`, `AIManager`, and `LiveSteamCoach`.
+
+The recipe tests (`tst_recipestorage`, `tst_recipeselectionmodel`, etc.) deliberately exercise `RecipeStorage` **static** methods and the header-only `RecipeSelectionModel` to sidestep this. That leaves the actual `MainController` signal wiring — `recipeUpdated → requestRecipe → recipeReady`, the `m_pendingRecipeSelfWrites` echo-guard, `deactivateRecipe` watchers, same-id re-activation, and the Flow-3 grind refresh from [#1483](https://github.com/Kulitorum/Decenza/pull/1483) — with no coverage.
+
+The DB layer already provides isolation primitives: `withTempDb()` (`src/core/dbutils.h`) and the storages' `SerialDbWorker`. The gap is purely that `MainController` doesn't let a test point those storages at a temp DB.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `MainController` constructible in a headless test against a throwaway DB.
+- Add `tst_maincontroller` that drives the real async recipe-wiring chain and asserts the Flow-3 contract plus the surrounding invariants.
+- Migrate proxy/fake recipe-wiring assertions into the harness and delete the proxies.
+- Keep the production construction path byte-for-byte behaviorally identical by default.
+
+**Non-Goals:**
+- Changing any production recipe-wiring behavior (including the recorded rpm-clear limitation — the test pins it, a fix is a separate change).
+- Building a full end-to-end harness for BLE/profile-upload/AI/visualizer paths. Only the recipe/dial/bag wiring is in scope; unrelated collaborators may stay as real inert objects or be left unexercised.
+- Refactoring `MainController` into a fully dependency-injected object. Only the minimal seams needed for this coverage.
+
+## Decisions
+
+### D1: DB isolation via `QStandardPaths` test mode first, explicit seam only if needed
+
+**Decision:** In the test's `initTestCase`, call `QStandardPaths::setTestModeEnabled(true)` and set `HOME`/`AppDataLocation` to a `QTemporaryDir`. First verify the three storages resolve their DB path through `QStandardPaths::writableLocation(...)`; if they do, no production code changes for isolation. Only if a storage hard-codes a path do we add a minimal static DB-path override (test-only setter) — the smallest possible seam.
+
+**Why over alternatives:** Test-mode is the idiomatic Qt approach and touches zero production logic. A blanket "inject a DB path everywhere" refactor is larger and riskier. Injecting the storages (D2) also solves it, but test-mode keeps the internal-create path — the one that actually ships — under test, which is more valuable than only ever testing injected doubles.
+
+### D2: Optional constructor injection, defaulting to internal create
+
+**Decision:** Add trailing optional parameters to the `MainController` constructor (or a dedicated test-only overload guarded appropriately) for the three storages, defaulting to `nullptr`. When null, construct internally exactly as today. This gives tests a second lever (inject temp-DB-backed storages) and makes intent explicit, without changing the production call site.
+
+**Why:** Preserves the shipped path as the default (D1 keeps it isolated), while allowing a test to supply pre-seeded storages when that is simpler than driving inserts through the async API. Trailing-optional-with-nullptr is the least invasive signature change and mirrors the existing `profileStorage = nullptr` parameter already on the constructor.
+
+### D3: `QTRY_VERIFY`/`QTRY_COMPARE`, never `qWait`
+
+**Decision:** All async assertions poll with `QTRY_*` (default 5s timeout) on the observable end-state (`Settings.dye.dyeGrinderSetting`, `activeRecipeId`, etc.). No fixed `qWait`/sleep anywhere.
+
+**Why:** The wiring hops across the `SerialDbWorker` thread and back via queued signals; timing is nondeterministic. `QTRY_*` waits exactly as long as needed and fails fast on regressions, avoiding both flakiness and wasted wall-clock — and honors the repo's "no timers as guards" ethos in test code too.
+
+### D4: Assert observable settings/state, not private members
+
+**Decision:** Tests assert on public observables (`Settings` values, `activeRecipeId`, emitted signals via `QSignalSpy`) rather than reaching into `m_refreshDialFromRecipeEdit` or `m_pendingRecipeSelfWrites`. The flag/counter behaviors are verified through their effects (no stale push, no loop, no swallowed edit).
+
+**Why:** Keeps tests robust to internal refactors and avoids needing `friend`/`#ifdef DECENZA_TESTING` access. If a specific invariant can only be observed privately, use the existing `friend class ... #ifdef DECENZA_TESTING` pattern rather than widening the public API.
+
+### D5: Proxy-test audit is explicit and subtractive
+
+**Decision:** Enumerate current recipe tests, classify each assertion as "genuine `RecipeStorage`/model unit test" (keep) vs "proxy for `MainController` wiring" (migrate + delete). Land the migration in the same change so coverage never regresses in between.
+
+## Risks / Trade-offs
+
+- **[Storage path is not `QStandardPaths`-derived]** → then D1 alone won't isolate; mitigation is the minimal test-only DB-path override seam (D2's sibling). Confirm before writing tests.
+- **[Constructor builds heavy collaborators with side effects]** (network, file I/O) → mitigation: those collaborators must be inert without a connected device/network in a headless run; if any performs I/O on construction, guard it behind the same test-mode/temp-dir isolation or make its creation lazy. Investigate during implementation; expand the seam only as forced.
+- **[Async test flakiness]** → mitigated by D3 (`QTRY_*`, generous timeout) and by asserting end-state rather than intermediate ordering.
+- **[Injection signature churn]** → mitigated by trailing-optional-nullptr params; the single production call site is unchanged.
+- **[Over-scoping into a general MainController harness]** → mitigated by the Non-Goals: only recipe/dial/bag wiring; other subsystems stay unexercised.
+
+## Migration Plan
+
+1. Confirm storage DB-path resolution; add the DB-path override seam only if `QStandardPaths` test mode is insufficient.
+2. Add optional storage-injection params (default `nullptr`).
+3. Create `tests/tst_maincontroller.cpp` + `tests/CMakeLists.txt` target; get one green async assertion (active-recipe grind edit → dial) end-to-end first to prove the harness.
+4. Fill in the remaining scenarios from the spec.
+5. Audit + migrate proxy assertions; delete proxies.
+6. Build all test targets; confirm no coverage regression.
+
+## Open Questions
+
+- Do `RecipeStorage`/`ShotHistoryStorage`/`CoffeeBagStorage` resolve their DB path via `QStandardPaths` (D1 sufficient) or a hard-coded/derived path (needs the D2-sibling seam)? Resolve in step 1.
+- Which existing recipe tests, if any, actually qualify as proxies to migrate vs. legitimate storage/model unit tests to keep? Resolve in the step-5 audit.

--- a/openspec/changes/add-maincontroller-test-harness/proposal.md
+++ b/openspec/changes/add-maincontroller-test-harness/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+`MainController`'s recipe/dial/bag write-through wiring is some of the most intricate logic in the app — deactivate-on-ingredient-swap, the `m_pendingRecipeSelfWrites` stamp echo-guard, same-id re-activation, and the just-merged Flow-3 grind-refresh ([#1483](https://github.com/Kulitorum/Decenza/pull/1483)) — yet it has **zero automated regression coverage**. It is untestable today: `MainController` creates its `RecipeStorage`/`ShotHistoryStorage`/`CoffeeBagStorage` internally against the real app DB, and its constructor eagerly builds `ProfileManager`/`VisualizerUploader`/`BeanBaseClient`/`AIManager`/`LiveSteamCoach`. So every author who has touched this wiring has skipped the test or tested a static-method proxy that does not exercise the signal flow. This change makes the wiring testable and locks the behavior down.
+
+## What Changes
+
+- Add **test seams** to `MainController` so it can be constructed in isolation:
+  - Isolate the internally-created storages from the real app DB via `QStandardPaths` test mode + a temp data dir (confirm the storages resolve their path through `QStandardPaths`; if not, add a minimal DB-path override seam).
+  - **Optional constructor injection** of the three storages, defaulting to `nullptr` → create-internally, so **production behavior is unchanged**.
+- Add `tests/tst_maincontroller.cpp` (registered in `tests/CMakeLists.txt`), driving the **real** `recipeUpdated → requestRecipe → recipeReady` chain with `QTRY_VERIFY` (polling, not `qWait`, to avoid flakiness).
+- Cover the recipe-wiring contract, at minimum:
+  - editing the **active** recipe's grind pushes to `Settings.dye.dyeGrinderSetting`;
+  - editing an **inactive** recipe does **not**;
+  - **startup restore** does not re-apply grind to the live dial;
+  - **relink refresh** and **QML editor-prefill** reads do not push;
+  - recipe **switch/deactivate** clears `m_refreshDialFromRecipeEdit`;
+  - the dial→recipe stamp **echo-guard does not loop**;
+  - **deactivate-on-ingredient-swap** fires on a profile/bag/equipment change.
+  - Recorded known-limitation case: an edit that **zeroes `rpmPinned`** does not clear a stale RPM on the dial (parity with `applyActivatedRecipe`) — asserted as current behavior so a future fix is a deliberate, visible change.
+- **Audit and migrate proxy tests**: find existing recipe tests whose assertions only stand in for `MainController` signal-wiring behavior (e.g. `RecipeStorage`-static or pure-helper checks used as a substitute for the live wiring), move those assertions into the harness, and delete the proxies.
+
+Non-goal / **not** changing: any production recipe-wiring behavior. The seams are additive and default to today's behavior.
+
+## Capabilities
+
+### New Capabilities
+- `maincontroller-test-coverage`: `MainController` exposes test seams (DB isolation + optional storage injection) and a `tst_maincontroller` harness that regression-covers the recipe/dial/bag write-through wiring through the real async signal chain.
+
+### Modified Capabilities
+<!-- None. Production behavior is unchanged; the injection seam defaults to the existing internal-create path. -->
+
+## Impact
+
+- **Code**: `src/controllers/maincontroller.{h,cpp}` (additive constructor param + DB-path seam only); `tests/tst_maincontroller.cpp` (new); `tests/CMakeLists.txt` (new target).
+- **Tests**: proxy/fake recipe-wiring tests removed and re-expressed in the harness (net coverage increase; no loss).
+- **Build/CI**: one new test executable; runs headless like the existing `tst_*` targets. No production-binary impact.
+- **Risk**: low — production construction path is the default (no injection, no test-mode); the seam is inert unless a test opts in.

--- a/openspec/changes/add-maincontroller-test-harness/specs/maincontroller-test-coverage/spec.md
+++ b/openspec/changes/add-maincontroller-test-harness/specs/maincontroller-test-coverage/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: MainController is constructible in isolation for tests
+
+`MainController` SHALL provide test seams that let a unit test construct it without touching the real application database or requiring live hardware, while leaving the production construction path unchanged by default.
+
+#### Scenario: Storages isolated from the real app DB
+
+- **WHEN** a test constructs `MainController` under `QStandardPaths` test mode with a temporary data directory
+- **THEN** the internally-created `RecipeStorage`, `ShotHistoryStorage`, and `CoffeeBagStorage` operate against a throwaway DB under the temp dir and never read or write the user's real app database
+
+#### Scenario: Optional storage injection defaults to production behavior
+
+- **WHEN** `MainController` is constructed without any injected storages (the production call)
+- **THEN** it creates its storages internally exactly as before the change, with no behavioral difference
+
+#### Scenario: Injected storages are used when provided
+
+- **WHEN** a test constructs `MainController` passing temp-DB-backed storages
+- **THEN** `MainController` uses the injected instances instead of creating its own
+
+### Requirement: Active-recipe grind edits refresh the live dial
+
+The harness SHALL assert that an in-place edit of the active recipe's grind reaches `Settings.dye.dyeGrinderSetting` through the real async `recipeUpdated → requestRecipe → recipeReady` chain, and that non-edit reads do not.
+
+#### Scenario: Editing the active recipe's grind pushes to the dial
+
+- **WHEN** the active recipe's `grindPinned` is updated via `requestUpdateRecipe`
+- **THEN** `Settings.dye.dyeGrinderSetting` eventually equals the new grind (awaited with `QTRY_VERIFY`)
+
+#### Scenario: Editing an inactive recipe does not touch the dial
+
+- **WHEN** a recipe that is not the active recipe is updated
+- **THEN** `Settings.dye.dyeGrinderSetting` is unchanged
+
+#### Scenario: Startup restore does not re-apply grind
+
+- **WHEN** the active recipe is restored on startup (`requestRecipe` without an edit)
+- **THEN** the live dial is not overwritten by the recipe's stored grind
+
+#### Scenario: Relink refresh and editor-prefill reads do not push
+
+- **WHEN** the active recipe is re-read due to a bag relink or a QML editor-prefill (not an edit)
+- **THEN** `Settings.dye.dyeGrinderSetting` is unchanged
+
+#### Scenario: Grind-less drink type and empty grind leave the dial untouched
+
+- **WHEN** the active recipe is a grind-less drink type (tea) or its `grindPinned` is empty and it is edited
+- **THEN** the live dial is not modified
+
+#### Scenario: Zeroing rpmPinned does not clear the dial RPM (recorded limitation)
+
+- **WHEN** the active recipe is edited to set `rpmPinned` to 0
+- **THEN** `Settings.dye.dyeGrinderRpm` retains its prior value (documented parity with `applyActivatedRecipe`; the test pins current behavior so a future fix is a deliberate change)
+
+### Requirement: Recipe-wiring invariants are regression-covered
+
+The harness SHALL cover the surrounding recipe-wiring invariants so a regression in the shared machinery is caught.
+
+#### Scenario: The refresh flag is cleared on recipe switch and deactivate
+
+- **WHEN** an edit sets `m_refreshDialFromRecipeEdit` and the user then switches or deactivates the recipe before the re-read lands
+- **THEN** the flag does not leak a stale grind onto the newly-active recipe's first read
+
+#### Scenario: The dial→recipe stamp echo-guard does not loop
+
+- **WHEN** an active-recipe edit refreshes the dial, which re-emits `dyeGrinderSettingChanged`
+- **THEN** the resulting stamp hits the equality guard and issues no further recipe write (no infinite loop, no `m_pendingRecipeSelfWrites` drift)
+
+#### Scenario: Deactivate-on-ingredient-swap fires
+
+- **WHEN** the live profile, bag, or equipment is changed to something other than the active recipe's own ingredient
+- **THEN** the active recipe deactivates
+
+### Requirement: Proxy tests are migrated into the harness
+
+Existing tests whose assertions only stand in for `MainController` signal-wiring behavior SHALL be re-expressed against the real harness and the proxies removed.
+
+#### Scenario: No proxy remains for covered wiring
+
+- **WHEN** the audit identifies a recipe test that uses `RecipeStorage` statics or a pure helper as a substitute for live `MainController` wiring already covered by the harness
+- **THEN** its assertions are moved into `tst_maincontroller` and the proxy test is deleted, with no net loss of coverage

--- a/openspec/changes/add-maincontroller-test-harness/tasks.md
+++ b/openspec/changes/add-maincontroller-test-harness/tasks.md
@@ -1,0 +1,37 @@
+## 1. Investigate seams
+
+- [ ] 1.1 Confirm how `RecipeStorage`, `ShotHistoryStorage`, and `CoffeeBagStorage` resolve their DB path (via `QStandardPaths` vs hard-coded/derived) — determines whether `QStandardPaths` test mode alone isolates them.
+- [ ] 1.2 Audit the `MainController` constructor for collaborators that perform network or file I/O on construction (ProfileManager/Visualizer/BeanBase/AIManager/LiveSteamCoach); confirm they are inert headless or note what must be guarded.
+
+## 2. Add test seams to MainController
+
+- [ ] 2.1 If 1.1 shows the storages are `QStandardPaths`-derived, add nothing for isolation; otherwise add a minimal test-only DB-path override seam (smallest change that isolates the temp DB).
+- [ ] 2.2 Add optional trailing constructor parameters to inject `RecipeStorage`/`ShotHistoryStorage`/`CoffeeBagStorage`, defaulting to `nullptr` → create-internally (mirrors the existing `profileStorage = nullptr` param).
+- [ ] 2.3 Verify the single production call site compiles unchanged and the default path constructs storages exactly as before.
+
+## 3. Stand up the harness
+
+- [ ] 3.1 Create `tests/tst_maincontroller.cpp` with `initTestCase` enabling `QStandardPaths` test mode + a `QTemporaryDir` data dir; construct `MainController` with headless collaborators.
+- [ ] 3.2 Register the `tst_maincontroller` target in `tests/CMakeLists.txt` alongside the existing `tst_*` targets.
+- [ ] 3.3 Prove the harness end-to-end: one `QTRY_VERIFY` test that editing the active recipe's grind reaches `Settings.dye.dyeGrinderSetting`.
+
+## 4. Cover the recipe-wiring contract
+
+- [ ] 4.1 Active-recipe grind edit pushes to the dial; inactive-recipe edit does not.
+- [ ] 4.2 Startup restore does NOT re-apply grind to the live dial.
+- [ ] 4.3 Relink refresh and QML editor-prefill reads do NOT push.
+- [ ] 4.4 Grind-less drink type (tea) and empty `grindPinned` leave the dial untouched.
+- [ ] 4.5 Recipe switch/deactivate before the re-read lands does not leak a stale grind (flag cleared).
+- [ ] 4.6 Dial→recipe stamp echo-guard does not loop and does not drift `m_pendingRecipeSelfWrites` (assert via observable effects / `QSignalSpy`).
+- [ ] 4.7 Deactivate-on-ingredient-swap fires on a profile/bag/equipment change to a non-recipe value.
+- [ ] 4.8 Recorded limitation: editing the active recipe to zero `rpmPinned` leaves `Settings.dye.dyeGrinderRpm` unchanged (pin current parity behavior).
+
+## 5. Migrate proxy tests
+
+- [ ] 5.1 Enumerate existing recipe tests and classify each assertion: genuine `RecipeStorage`/model unit test (keep) vs proxy for `MainController` wiring (migrate).
+- [ ] 5.2 Move proxy assertions into `tst_maincontroller` and delete the proxy tests, ensuring no net coverage loss.
+
+## 6. Verify
+
+- [ ] 6.1 Build all test targets (`--target all`) and run `tst_maincontroller` + the touched recipe tests; confirm green and non-flaky (repeat runs).
+- [ ] 6.2 Confirm the production `Decenza` target builds unchanged and the constructor default path is behaviorally identical.


### PR DESCRIPTION
OpenSpec **proposal** (planning artifacts only — no production code) for a real `tst_maincontroller` integration harness.

## Why
`MainController`'s recipe/dial/bag write-through wiring — deactivate-on-ingredient-swap, the `m_pendingRecipeSelfWrites` stamp echo-guard, same-id re-activation, and the just-merged Flow-3 grind refresh ([#1483](https://github.com/Kulitorum/Decenza/pull/1483)) — has **zero regression coverage**, because `MainController` is untestable today (creates its storages against the real app DB; constructor eagerly builds ProfileManager/Visualizer/BeanBase/AIManager/LiveSteamCoach). Recipe tests exercise `RecipeStorage` statics as a proxy, which never touches the live wiring.

## What this change proposes
- **Test seams** (additive, default = today's behavior): `QStandardPaths` test-mode DB isolation, plus optional constructor injection of the three storages defaulting to `nullptr` → create-internally.
- **`tests/tst_maincontroller.cpp`** driving the real async `recipeUpdated → recipeReady` chain with `QTRY_VERIFY` (no `qWait`).
- **Coverage** of the recipe-wiring contract (active-edit → dial; inactive edit → no push; startup/relink/editor-prefill → no push; flag cleared on switch; echo-guard no-loop; deactivate-on-swap; plus the recorded rpm-clear parity limitation).
- **Proxy-test migration**: move fake/proxy recipe-wiring assertions into the harness and delete the proxies.

Explicit non-goal: changing any production recipe-wiring behavior.

## Artifacts
- `proposal.md`, `design.md`, `specs/maincontroller-test-coverage/spec.md`, `tasks.md`
- Validated: `openspec validate add-maincontroller-test-harness` → valid.

Implementation lands later via `/opsx:apply` (archive inside that implementation PR per project convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)