### PR TITLE
Ship Mode A: enable ENABLE_TSNET in macOS/iOS/Android release builds

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -211,6 +211,7 @@ jobs:
           mkdir -p build
           cd build
           $QT_ROOT_DIR/bin/qt-cmake .. -G Ninja \
+            -DENABLE_TSNET=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -172,6 +172,7 @@ jobs:
           # drops -ivfsstatcache and other Apple-internal flags). Compen-
           # sate by setting -lc++ -lc++abi in OTHER_LDFLAGS explicitly.
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
+            -DENABLE_TSNET=ON \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_XCODE_ATTRIBUTE_CC="$CCACHE_LAUNCH_C" \

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -175,6 +175,7 @@ jobs:
           mkdir -p build/macos
           cd build/macos
           $QT_ROOT_DIR/bin/qt-cmake ../.. -G Xcode \
+            -DENABLE_TSNET=ON \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
             -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \

--- a/cmake/tsnet.cmake
+++ b/cmake/tsnet.cmake
@@ -93,11 +93,13 @@ elseif(ANDROID)
     if(NOT EXISTS "${_tsnet_so}")
         message(FATAL_ERROR "tsnet: no Android .so for ABI ${CMAKE_ANDROID_ARCH_ABI}")
     endif()
-    # Bundle the .so into the APK for the active ABI so androiddeployqt ships it.
-    set(ANDROID_EXTRA_LIBS "${ANDROID_EXTRA_LIBS};${_tsnet_so}" CACHE STRING "" FORCE)
     function(decenza_link_tsnet tgt)
         target_include_directories(${tgt} PRIVATE "${TSNET_INCLUDE_DIR}")
         target_link_libraries(${tgt} PRIVATE "${_tsnet_so}")
+        # Bundle the .so into the APK for the active ABI. The QT_ANDROID_EXTRA_LIBS
+        # target property is the Qt6-idiomatic way (more reliable than the legacy
+        # ANDROID_EXTRA_LIBS variable) — androiddeployqt copies it into the APK.
+        set_property(TARGET ${tgt} APPEND PROPERTY QT_ANDROID_EXTRA_LIBS "${_tsnet_so}")
     endfunction()
 endif()
 


### PR DESCRIPTION
Mode A (embedded Tailscale + Funnel, merged in #1481) is gated behind `ENABLE_TSNET` (default OFF), so it **never ships in release builds** — the "Tailscale (built-in)" option is greyed out in the App Store IPA / release APK / DMG, and only Mode C works. This flips it on for the three platforms the fork builds prebuilt libtailscale artifacts for.

## Changes
- **`macos` / `ios` / `android-release.yml`**: add `-DENABLE_TSNET=ON` to the `qt-cmake` configure step.
- **`cmake/tsnet.cmake`**: bundle the Android `.so` via the Qt6 `QT_ANDROID_EXTRA_LIBS` target property (more reliable than the legacy `ANDROID_EXTRA_LIBS` variable).
- **Windows / Linux stay OFF** — the fork has no prebuilt libtailscale for them (`cmake/tsnet.cmake` would `FATAL_ERROR`); Mode C / a user-run tunnel still works there.

## Size impact (measured, not estimated)
Stripped shipped binary: baseline 52.3 MB → **72.4 MB (+20.1 MB)** of Go/Tailscale machine code. In the compressed `.dmg` (~144 MB) that's roughly **+7–8%**; same order on iOS/Android (arm64-only APK, so one `.so`). Verified `-ldflags "-s -w"` is a **no-op** for the `c-archive` (byte-identical `.a` and binary), so the fork stays unstripped — the ~20 MB is irreducible machine code.

## Verified
- macOS `ENABLE_TSNET=ON` builds + links + runs; Funnel path proven end-to-end over a real tailnet (public `initialize` → 200).
- `tst_mcpremoteaccess` 17/17.

## ⚠️ Needs a CI/device smoke-test after the first tagged build
- CI now **downloads** the ~30 MB fork artifact at configure time — confirm the macOS/iOS/Android release jobs still go green on the next tag.
- **Android**: confirm the bundled `libtailscale.so` is actually in the APK and loads on a device (the build succeeds regardless; the `QT_ANDROID_EXTRA_LIBS` bundling is the untested part).

🤖 Generated with [Claude Code](https://claude.com/claude-code)