### PR TITLE
tsnet: adopt libtailscale decenza-v1.94.1-3 (Android netmon fix)

### DIFF
--- a/cmake/tsnet.cmake
+++ b/cmake/tsnet.cmake
@@ -10,20 +10,20 @@
 # The pinned release + per-artifact SHA-256 come from the release manifest.json.
 # Bump TSNET_TAG (and the hashes) to adopt a newer libtailscale build.
 
-set(TSNET_TAG "decenza-v1.94.1-1" CACHE STRING "libtailscale prebuilt release tag")
+set(TSNET_TAG "decenza-v1.94.1-3" CACHE STRING "libtailscale prebuilt release tag")
 set(TSNET_BASE_URL "https://github.com/skialpine/libtailscale/releases/download/${TSNET_TAG}")
 set(TSNET_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/tsnet-${TSNET_TAG}")
 
 # Per-platform artifact + expected SHA-256 (from manifest.json).
 if(IOS)
     set(_tsnet_zip "libtailscale-ios.zip")
-    set(_tsnet_sha "3edb45778be4117c8a034bae43da8f5b566c50f43596c197d0c4da983abdc427")
+    set(_tsnet_sha "b5916355d4c0df0bb6cf9a6c3848203c6fe8fb2614aaa6d7da741b10f3a93e21")
 elseif(ANDROID)
     set(_tsnet_zip "libtailscale-android.zip")
-    set(_tsnet_sha "e43497b13de23ccabd90487a9bb2c2d8dbc7f3d6d492ebfdbbf0965016505f4c")
+    set(_tsnet_sha "295190b8e96520fc2cfec172a04b9aaf4502cc7424d782988c3c6e53759bde55")
 elseif(APPLE)
     set(_tsnet_zip "libtailscale-macos.zip")
-    set(_tsnet_sha "b2a9041cb271af56dea6d9050927beb335d4eeff7427d44632c31c206f283f78")
+    set(_tsnet_sha "fa2f525411e30514663ee85203e856e5a34fb2228817cbd540a075519bcaa2b8")
 else()
     message(FATAL_ERROR "ENABLE_TSNET: no prebuilt libtailscale artifact for this platform yet "
                         "(supported: macOS, Android, iOS). Use Mode C (BYO URL) instead.")


### PR DESCRIPTION
Fixes Mode A (embedded Tailscale + Funnel) on **Android**, the key target platform.

## Problem
On Android API 30+, ordinary apps may not make the netlink `RTM_GETLINK`/`RTM_GETADDR` calls that Go's `net.Interfaces()` uses. tsnet hits this on a hard-fail path during bring-up: `tsnet.Server.Start()` → `netmon.New()` → interface enumeration → `net.Interfaces()`, which returns `route ip+net: netlinkrib: permission denied`. `Start()` propagates it, so the node never reaches `NeedsLogin` and no login URL is ever shown. macOS works because it has no such restriction; the shipped v2.0.0 beta APK was dead on Mode A.

Upstream: tailscale/tailscale#17311 (still open).

## Fix (in the fork)
The fork now ships a new `netmon_android.go` (guarded `//go:build android`, so macOS/iOS binaries don't include it and are behaviorally unchanged). It registers an interface getter via `netmon.RegisterInterfaceGetter()` — the exact mechanism Tailscale documents for SDK 30 — returning loopback plus the primary outbound v4/v6 source IP discovered with a UDP `connect` (`connect(2)`+`getsockname(2)` only; no netlink, no packets sent). That's enough for the userspace/netstack node to come up and expose the Funnel.

Fork PR: skialpine/libtailscale#1 · release `decenza-v1.94.1-3` (macOS/iOS/Android CI all green).

## Decenza change
Bumps `cmake/tsnet.cmake` `TSNET_TAG` → `decenza-v1.94.1-3` and all three artifact SHA-256s (verified against the release). No source changes on the Decenza side.

## Testing
Pending on-device verification on the SM-X210 tablet — the beta APK rebuilt from this branch should now reach the Tailscale login URL instead of erroring at start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)