### PR TITLE
tsnet: use device model for Android node name, not 'localhost'

### DIFF
--- a/src/mcp/mcpremoteaccess.cpp
+++ b/src/mcp/mcpremoteaccess.cpp
@@ -15,6 +15,9 @@
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QNetworkReply>
+#ifdef Q_OS_ANDROID
+#include <QJniObject>
+#endif
 
 McpRemoteAccess::McpRemoteAccess(QObject* parent)
     : QObject(parent)
@@ -225,9 +228,9 @@ void McpRemoteAccess::startTunnel()
     }
     const QString stateDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
                              + QStringLiteral("/tsnet");
-    // Node name → Funnel subdomain. Include the machine hostname so multiple
-    // Decenza instances on one tailnet get distinct, recognisable node names
-    // (and distinct Funnel URLs). Tailscale node names allow only [a-z0-9-];
+    // Node name → Funnel subdomain. Include the device name so multiple Decenza
+    // instances on one tailnet get distinct, recognisable node names (and
+    // distinct Funnel URLs). Tailscale node names allow only [a-z0-9-];
     // sanitise the host and trim stray hyphens.
     QString host = QSysInfo::machineHostName().toLower();
     // Drop any domain suffix (e.g. macOS returns "name.local") — keep just the
@@ -235,6 +238,18 @@ void McpRemoteAccess::startTunnel()
     const qsizetype dot = host.indexOf('.');
     if (dot > 0)
         host = host.left(dot);
+#ifdef Q_OS_ANDROID
+    // Android doesn't expose a device hostname to apps — machineHostName()
+    // returns "localhost", which would make every Android node "decenza-localhost".
+    // Use the marketing model name (Build.MODEL, e.g. "SM-X210") instead so the
+    // node is recognisable and distinct.
+    if (host.isEmpty() || host == QLatin1String("localhost")) {
+        const QJniObject model = QJniObject::getStaticObjectField<jstring>(
+            "android/os/Build", "MODEL");
+        if (model.isValid())
+            host = model.toString().toLower();
+    }
+#endif
     for (QChar& c : host) {
         if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-'))
             c = '-';


### PR DESCRIPTION
Follow-up to the Android Mode A fix (#1488). With tsnet now reaching **Running** on Android, the node registered with a **strange name: `decenza-localhost`**.

## Cause
`QSysInfo::machineHostName()` returns `"localhost"` on Android — Android doesn't expose a device hostname to apps — so the node name `decenza-<host>` became `decenza-localhost`. macOS/iOS return their real hostnames, so this only affects Android.

Beyond being ugly and non-unique (every Android device would be `decenza-localhost`), **`localhost` is an RFC 6761 reserved name**, so the Funnel DNS label derived from it may never be published publicly — a likely contributor to the observed `decenza-localhost.<tailnet>.ts.net not found` reachability failure on-device.

## Fix
On Android, when the hostname is empty or `localhost`, fall back to the marketing model name via JNI (`android/os/Build.MODEL`, e.g. `SM-X210`) — the same source `app_get_info` already uses — yielding names like `decenza-sm-x210`. The existing sanitiser lowercases and strips to `[a-z0-9-]`. The tsnet state dir persists node identity, so this simply **renames** the existing node on next start rather than creating a new one. Android-only; macOS/iOS are untouched.

## Testing
Confirmed on the SM-X210 that #1488 got tsnet to `Running` + Funnel-configured (the netlink blocker is gone). This PR should make the node appear as `decenza-sm-x210`, and — if the reserved-name theory holds — resolve the public Funnel URL. Pending on-device re-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)