### PR TITLE
Recipe wizard: one-press save in edit mode + unsaved-changes guard

### DIFF
--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -1997,9 +1997,9 @@ Page {
                                 ? TranslationManager.translate("recipes.wizard.detailsOptionalEdit",
                                       "Everything here is optional. "
                                       + "Tap a section to adjust it, then Save.")
-                                : TranslationManager.translate("recipes.wizard.detailsOptional",
+                                : TranslationManager.translate("recipes.wizard.detailsOptionalReview",
                                       "Everything here is optional — it's prefilled and ready to save. "
-                                      + "Tap a section to adjust it, then Continue.")
+                                      + "Tap a section to adjust it, then Review.")
                             font: Theme.captionFont
                             color: Theme.textSecondaryColor
                             wrapMode: Text.WordWrap
@@ -2026,8 +2026,11 @@ Page {
                             visible: !wizardPage._enteredAtSummary
                             Layout.alignment: Qt.AlignVCenter
                             primary: true
-                            text: TranslationManager.translate("recipes.wizard.continue", "Continue")
-                            accessibleName: TranslationManager.translate("recipes.wizard.accessible.continue", "Continue to the summary")
+                            // "Review", not "Continue": the next stop is the
+                            // named, WYSIWYG summary with the Save button —
+                            // a label that reads like a commit loses saves.
+                            text: TranslationManager.translate("recipes.wizard.review", "Review")
+                            accessibleName: TranslationManager.translate("recipes.wizard.accessible.review", "Review the recipe before saving")
                             onClicked: { wizardPage._fromSummary = false; wizardPage.currentStep = "summary" }
                         }
                     }

--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -522,6 +522,11 @@ Page {
     }
 
     function save() {
+        // Re-entry guard: a second tap while the async create/update is in
+        // flight would submit twice (create mode would duplicate the recipe —
+        // the token guard silently discards the first reply).
+        if (_submitting)
+            return
         Qt.inputMethod.commit()  // IME: flush the in-progress word first
         errorMessage = ""
         var name = nameField.text.trim()

--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -34,6 +34,17 @@ Page {
     property var prefill: ({})
     property real promoteShotId: 0
 
+    // Intercept the Android system back button / Escape key (Main.qml pops
+    // the page directly otherwise): step back like the bottom-bar arrow, so
+    // leaving the wizard always funnels through the unsaved-changes guard.
+    focus: true
+    Keys.onReleased: function(event) {
+        if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+            event.accepted = true
+            goBackOneStep()
+        }
+    }
+
     // --- step machine ----------------------------------------------------
     // "drink" | "bean" | "profile" | "details" | "summary". Creation walks
     // them in order; edit/clone/promote start at "summary". A step opened
@@ -467,9 +478,10 @@ Page {
             MainController.bagStorage.requestInventory()
     }
 
-    // The exact map save() persists — also the dirty check's comparison
-    // basis, so "unsaved changes" means precisely "save() would store
-    // something different from what was loaded".
+    // The exact map save() persists (plus a create-only requestToken) — also
+    // the dirty check's comparison basis, so "unsaved changes" means
+    // precisely "save() would store something different from what was
+    // loaded".
     function buildSaveMap() {
         var map = {
             name: nameField.text.trim(),
@@ -547,24 +559,42 @@ Page {
         _baselineJson = JSON.stringify(buildSaveMap())
     }
     function hasUnsavedChanges() {
-        // No baseline yet (an edit/promote load still in flight) — nothing
-        // the user typed can have landed either; never block the exit.
+        // No baseline yet (an edit/promote load still in flight): anything
+        // typed this early would be overwritten by applyRecipeMap when the
+        // reply lands anyway — never block the exit.
         if (_baselineJson === "")
             return false
         Qt.inputMethod.commit()  // IME: flush the in-progress word first
         return JSON.stringify(buildSaveMap()) !== _baselineJson
     }
 
-    // Every path that LEAVES the wizard funnels through here: with unsaved
-    // changes the exit dialog intercepts (Discard / Save); otherwise leave
-    // directly. During a creation walk a half-built draft that could not be
-    // saved anyway (no name/profile yet) exits silently — the dialog would
-    // only offer a disabled Save.
+    // Every cancel/back path out of the wizard funnels through here (the
+    // save-success pops and the deleted-recipe bail are deliberately not
+    // intercepted): with unsaved changes the exit dialog intercepts
+    // (Discard / Save); otherwise leave directly. The early creation-walk
+    // steps exit silently when nothing saveable exists yet (abandoning a
+    // couple of taps must not nag); from the details/summary steps — where
+    // typed content lives — any unsaved change prompts, even an unsaveable
+    // one (e.g. the name cleared for a retype): Discard plus a disabled
+    // Save beats a silent discard.
     function requestExit() {
-        if (hasUnsavedChanges() && (canSave || _enteredAtSummary))
+        var earlyWalk = !_enteredAtSummary
+            && currentStep !== "summary" && currentStep !== "details"
+        if (hasUnsavedChanges() && (canSave || !earlyWalk))
             exitDialog.open()
         else
             root.goBack()
+    }
+
+    // A failed save must be SEEN: the pinned error label exists only on the
+    // summary and details steps, but the exit dialog's Save can fire from a
+    // walk step (backing out of a create). Land on the summary, where the
+    // error, the name field, and Save sit together.
+    function showSaveError() {
+        if (currentStep !== "summary" && currentStep !== "details") {
+            _fromSummary = false
+            _enterStep("summary")
+        }
     }
 
     // --- wizard step actions -----------------------------------------------
@@ -1106,22 +1136,26 @@ Page {
             if (wizardPage.mode !== "edit" && wizardPage._submitting) {
                 wizardPage._submitting = false
                 wizardPage._createToken = ""
-                if (recipeId > 0)
+                if (recipeId > 0) {
                     pageStack.pop()
-                else
+                } else {
                     wizardPage.errorMessage =
                         TranslationManager.translate("recipes.wizard.errorSave", "Could not save the recipe")
+                    wizardPage.showSaveError()
+                }
             }
         }
         function onRecipeUpdated(recipeId, success) {
             if (wizardPage.mode === "edit" && recipeId === wizardPage.editRecipeId
                 && wizardPage._submitting) {
                 wizardPage._submitting = false
-                if (success)
+                if (success) {
                     pageStack.pop()
-                else
+                } else {
                     wizardPage.errorMessage =
                         TranslationManager.translate("recipes.wizard.errorSave", "Could not save the recipe")
+                    wizardPage.showSaveError()
+                }
             }
         }
         function onLastEquipmentForDrinkTypeReady(drinkType, equipmentId) {
@@ -2007,6 +2041,8 @@ Page {
                         font: Theme.bodyFont
                         color: Theme.errorColor
                         wrapMode: Text.WordWrap
+                        Accessible.role: Accessible.StaticText
+                        Accessible.name: text
                     }
 
                     Flickable {
@@ -2354,6 +2390,8 @@ Page {
                         font: Theme.bodyFont
                         color: Theme.errorColor
                         wrapMode: Text.WordWrap
+                        Accessible.role: Accessible.StaticText
+                        Accessible.name: text
                     }
 
                     Flickable {

--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -76,7 +76,7 @@ Page {
         }
         switch (currentStep) {
         case "drink":
-            root.goBack()
+            requestExit()
             break
         case "bean":
             _enterStep("drink")
@@ -98,12 +98,12 @@ Page {
             break
         case "summary":
             if (_enteredAtSummary)
-                root.goBack()
+                requestExit()
             else
                 _enterStep("details")
             break
         default:
-            root.goBack()
+            requestExit()
         }
     }
 
@@ -253,8 +253,10 @@ Page {
             applyRecipeMap(prefill)
             nameField.forceActiveFocus()
             nameField.selectAll()
+            captureBaseline()
         } else {
             currentStep = "drink"
+            captureBaseline()
         }
     }
 
@@ -437,6 +439,7 @@ Page {
         var bean = ((shot.beanBrand || "") + " " + (shot.beanType || "")).trim()
         nameField.text = bean !== "" ? bean : (shot.profileName || "")
         nameField.selectAll()
+        captureBaseline()
     }
 
     // Resolve the selected profile's base temperature (for the offset
@@ -464,21 +467,12 @@ Page {
             MainController.bagStorage.requestInventory()
     }
 
-    function save() {
-        Qt.inputMethod.commit()  // IME: flush the in-progress word first
-        errorMessage = ""
-        var name = nameField.text.trim()
-        if (name === "") {
-            errorMessage = TranslationManager.translate("recipes.wizard.errorNoName", "A recipe needs a name")
-            return
-        }
-        if (!MainController.recipeStorage.isSaveValid(name, fProfileTitle, buildHotWaterJson())) {
-            errorMessage = TranslationManager.translate("recipes.wizard.errorNoProfile",
-                "A recipe needs a profile (unless it is a hot-water drink)")
-            return
-        }
+    // The exact map save() persists — also the dirty check's comparison
+    // basis, so "unsaved changes" means precisely "save() would store
+    // something different from what was loaded".
+    function buildSaveMap() {
         var map = {
-            name: name,
+            name: nameField.text.trim(),
             drinkType: fDrinkType !== "" ? fDrinkType : deriveDrinkType(),
             profileTitle: fProfileTitle,
             profileJson: fProfileJson,
@@ -512,6 +506,23 @@ Page {
             map.createdFromShotId = prefill.createdFromShotId
         if (prefill && prefill.clonedFromRecipeId)
             map.clonedFromRecipeId = prefill.clonedFromRecipeId
+        return map
+    }
+
+    function save() {
+        Qt.inputMethod.commit()  // IME: flush the in-progress word first
+        errorMessage = ""
+        var name = nameField.text.trim()
+        if (name === "") {
+            errorMessage = TranslationManager.translate("recipes.wizard.errorNoName", "A recipe needs a name")
+            return
+        }
+        if (!MainController.recipeStorage.isSaveValid(name, fProfileTitle, buildHotWaterJson())) {
+            errorMessage = TranslationManager.translate("recipes.wizard.errorNoProfile",
+                "A recipe needs a profile (unless it is a hot-water drink)")
+            return
+        }
+        var map = buildSaveMap()
         _submitting = true
         if (mode === "edit" && editRecipeId > 0) {
             MainController.recipeStorage.requestUpdateRecipe(editRecipeId, map)
@@ -525,6 +536,36 @@ Page {
         }
     }
     property string _createToken: ""
+
+    // --- unsaved-changes guard ----------------------------------------------
+    // Snapshot of buildSaveMap() at load time; "dirty" is a comparison
+    // against it, so every field, block toggle, and picker choice is covered
+    // without per-control bookkeeping. Captured once the entry state is fully
+    // in hand (after applyRecipeMap / prefillFromShot / a blank start).
+    property string _baselineJson: ""
+    function captureBaseline() {
+        _baselineJson = JSON.stringify(buildSaveMap())
+    }
+    function hasUnsavedChanges() {
+        // No baseline yet (an edit/promote load still in flight) — nothing
+        // the user typed can have landed either; never block the exit.
+        if (_baselineJson === "")
+            return false
+        Qt.inputMethod.commit()  // IME: flush the in-progress word first
+        return JSON.stringify(buildSaveMap()) !== _baselineJson
+    }
+
+    // Every path that LEAVES the wizard funnels through here: with unsaved
+    // changes the exit dialog intercepts (Discard / Save); otherwise leave
+    // directly. During a creation walk a half-built draft that could not be
+    // saved anyway (no name/profile yet) exits silently — the dialog would
+    // only offer a disabled Save.
+    function requestExit() {
+        if (hasUnsavedChanges() && (canSave || _enteredAtSummary))
+            exitDialog.open()
+        else
+            root.goBack()
+    }
 
     // --- wizard step actions -----------------------------------------------
 
@@ -1046,6 +1087,7 @@ Page {
                 return
             if (Object.keys(recipe).length > 0) {
                 wizardPage.applyRecipeMap(recipe)
+                wizardPage.captureBaseline()
             } else {
                 // The recipe was deleted between opening the list and the load
                 // landing — don't leave a blank "edit" form the user fills in
@@ -1914,9 +1956,16 @@ Page {
                         spacing: Theme.spacingMedium
                         Label {
                             Layout.fillWidth: true
-                            text: TranslationManager.translate("recipes.wizard.detailsOptional",
-                                  "Everything here is optional — it's prefilled and ready to save. "
-                                  + "Tap a section to adjust it, then Continue.")
+                            // Edit/clone/promote (entered at the summary):
+                            // this step commits directly — never send the
+                            // user hunting for a second Save press.
+                            text: wizardPage._enteredAtSummary
+                                ? TranslationManager.translate("recipes.wizard.detailsOptionalEdit",
+                                      "Everything here is optional. "
+                                      + "Tap a section to adjust it, then Save.")
+                                : TranslationManager.translate("recipes.wizard.detailsOptional",
+                                      "Everything here is optional — it's prefilled and ready to save. "
+                                      + "Tap a section to adjust it, then Continue.")
                             font: Theme.captionFont
                             color: Theme.textSecondaryColor
                             wrapMode: Text.WordWrap
@@ -1924,12 +1973,40 @@ Page {
                             Accessible.name: text
                         }
                         AccessibleButton {
+                            visible: wizardPage._enteredAtSummary
+                            Layout.alignment: Qt.AlignVCenter
+                            text: TranslationManager.translate("common.cancel", "Cancel")
+                            accessibleName: TranslationManager.translate("recipes.composer.accessible.cancel", "Cancel recipe editing")
+                            onClicked: wizardPage.requestExit()
+                        }
+                        AccessibleButton {
+                            visible: wizardPage._enteredAtSummary
+                            Layout.alignment: Qt.AlignVCenter
+                            primary: true
+                            enabled: wizardPage.canSave
+                            text: TranslationManager.translate("common.save", "Save")
+                            accessibleName: TranslationManager.translate("recipes.composer.accessible.save", "Save the recipe")
+                            onClicked: wizardPage.save()
+                        }
+                        AccessibleButton {
+                            visible: !wizardPage._enteredAtSummary
                             Layout.alignment: Qt.AlignVCenter
                             primary: true
                             text: TranslationManager.translate("recipes.wizard.continue", "Continue")
                             accessibleName: TranslationManager.translate("recipes.wizard.accessible.continue", "Continue to the summary")
                             onClicked: { wizardPage._fromSummary = false; wizardPage.currentStep = "summary" }
                         }
+                    }
+
+                    // Pinned with the header (matching the summary step) so a
+                    // save failure from the details step is never hidden.
+                    Label {
+                        visible: wizardPage.errorMessage !== ""
+                        Layout.fillWidth: true
+                        text: wizardPage.errorMessage
+                        font: Theme.bodyFont
+                        color: Theme.errorColor
+                        wrapMode: Text.WordWrap
                     }
 
                     Flickable {
@@ -2256,7 +2333,7 @@ Page {
                             Layout.alignment: Qt.AlignBottom
                             text: TranslationManager.translate("common.cancel", "Cancel")
                             accessibleName: TranslationManager.translate("recipes.composer.accessible.cancel", "Cancel recipe editing")
-                            onClicked: pageStack.pop()
+                            onClicked: wizardPage.requestExit()
                         }
                         AccessibleButton {
                             Layout.alignment: Qt.AlignBottom
@@ -2615,6 +2692,17 @@ Page {
                 }
             }
         }
+    }
+
+    // Unsaved-changes intercept (requestExit): leaving with edits offers
+    // Save / Discard — closing the dialog (Esc / tap outside) keeps editing.
+    UnsavedChangesDialog {
+        id: exitDialog
+        itemType: "recipe"
+        showSaveAs: false
+        canSave: wizardPage.canSave
+        onDiscardClicked: root.goBack()
+        onSaveClicked: wizardPage.save()
     }
 
     BottomBar {


### PR DESCRIPTION
## Problem

Editing a recipe required pressing **Continue** (details step) and then **Save** (summary) — two commits for one edit. Worse, every exit path (Cancel, back arrow) silently discarded edits, and after Continue the summary's WYSIWYG hero card already showed the new values, so backing out read as "saved" while losing everything. Reported after many lost edits; reproduced live on macOS (grind edit → Continue → back → change gone, no warning).

## Changes (all in `RecipeWizardPage.qml`)

- **Details step entered from the summary (edit / clone / promote) now shows Cancel / Save instead of Continue**, and Save commits directly — no second press. The creation walk keeps Continue → summary review, which is where that review has value.
- **Unsaved-changes guard on every exit path.** A baseline snapshot of the exact save map is captured at load (`buildSaveMap()` extracted from `save()`); any exit with a differing map opens the existing `UnsavedChangesDialog` (Discard / Save, Esc keeps editing). Covers summary Cancel, details Cancel, and both back-arrow exits. A half-built creation draft that isn't saveable yet still exits silently.
- The pinned error label now also renders on the details step so a save failure there is never hidden below the scroll.

## Verification (live, macOS build)

- Edit → Details now shows Cancel/Save with "…then Save." caption ✔
- Grind 12→13 saved with one press from the details step, persisted to the list ✔
- Dirty exit (clone, grind changed, back-arrow) intercepted by Unsaved Changes dialog; Discard leaves nothing behind ✔
- Clean exit (no edits) leaves without any prompt ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)