### PR TITLE
test: fail on unexpected qWarning (enforce the silence-on-stderr discipline)

### DIFF
--- a/docs/CLAUDE_MD/TESTING.md
+++ b/docs/CLAUDE_MD/TESTING.md
@@ -224,6 +224,8 @@ Run this after any changes to `src/mcp/`, `src/controllers/profilemanager.cpp`, 
 
 **Every `qWarning()` emitted during a test run must either be fixed at the source or explicitly marked as expected.** A noisy test suite hides real regressions: once you get used to seeing 50 WARN lines in green output, the 51st one — which is actually a new bug — blends in. Treat warnings as failures-in-waiting.
 
+**This is enforced, not just convention.** Every test class calls `QTest::failOnWarning()` in its `init()`, so an *unexpected* `qWarning`/`qCritical` during a test function **fails that test** — even under `ctest -j` or Qt Creator's CTest runner, which otherwise hide passing-test stderr. Warnings marked expected via `QTest::ignoreMessage()` are consumed before the check and do **not** fail. **New test classes must add `void init() { QTest::failOnWarning(); }`** (or prepend the call to an existing `init()`); without it the class silently opts out of the guard. Do **not** rely on `QT_FATAL_WARNINGS` — it aborts on `ignoreMessage()`-expected warnings too.
+
 There are three legitimate outcomes for any warning fired during a test:
 
 ### 1. It's the behaviour under test — mark it expected per-test

--- a/tests/tst_aborted_shot_classifier.cpp
+++ b/tests/tst_aborted_shot_classifier.cpp
@@ -17,6 +17,7 @@ class tst_AbortedShotClassifier : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // Real shots from Jeff's local DB that the classifier should drop.
     void corpusPositives_data() {

--- a/tests/tst_accessibility_announcements.cpp
+++ b/tests/tst_accessibility_announcements.cpp
@@ -91,7 +91,7 @@ private:
     QVariant m_origExtractionMode;
 
 private slots:
-    void init() {
+    void init() { QTest::failOnWarning();
         // Snapshot every key AccessibilityManager::saveSettings() touches so
         // setEnabled / setTtsEnabled writes during a test don't permanently
         // mutate the developer's real preferences.

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -127,6 +127,7 @@ class tst_AIManager : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     // parseBagExtraction: the "Get info" response contract — JSON possibly
     // wrapped in markdown fences, whitelisted to the blob vocabulary keys.
     void parseBagExtractionHandlesFencesWhitelistAndGarbage()

--- a/tests/tst_aiproviders.cpp
+++ b/tests/tst_aiproviders.cpp
@@ -91,6 +91,7 @@ class tst_AIProviders : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void openAiCatalogAndSelection()
     {
         QNetworkAccessManager nam;

--- a/tests/tst_autoflowcal.cpp
+++ b/tests/tst_autoflowcal.cpp
@@ -78,6 +78,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // D-Flow / Q: window sits entirely inside the Pouring flow frame.
     // isFlowProfile=true, target=1.8. No regression from today's behavior.

--- a/tests/tst_autowakewindow.cpp
+++ b/tests/tst_autowakewindow.cpp
@@ -87,7 +87,7 @@ private slots:
         m_settings.setAutoWakeStayAwakeMinutes(m_origStayMinutes);
     }
 
-    void init() {
+    void init() { QTest::failOnWarning();
         // Every test fully establishes the schedule/duration it needs in
         // its own body; this just guarantees a deterministic enabled flag
         // regardless of what the previous test left behind.

--- a/tests/tst_basketaliases.cpp
+++ b/tests/tst_basketaliases.cpp
@@ -20,6 +20,7 @@ class TstBasketAliases : public QObject
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     // Data integrity
     void everyEntry_is58mm();
     void everyEntry_hasSaneDoseRange();

--- a/tests/tst_beanbaseclient.cpp
+++ b/tests/tst_beanbaseclient.cpp
@@ -133,6 +133,7 @@ private:
     QNetworkAccessManager m_nam;
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     // ====================================================
     // search(): the canonical (Visualizer) path — keyless,
     // debounced (350 ms), session-cached, official /api JSON.

--- a/tests/tst_binarycodec.cpp
+++ b/tests/tst_binarycodec.cpp
@@ -10,6 +10,7 @@ class tst_BinaryCodec : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== U8P4: 4 fractional bits, range 0-15.9375 (de1app encode_U8P4) =====
 

--- a/tests/tst_blefidelity.cpp
+++ b/tests/tst_blefidelity.cpp
@@ -48,6 +48,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ==========================================
     // Verify profiles directory exists and has files

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -136,6 +136,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     void initTestCase() {
         QVERIFY(m_tempDir.isValid());

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -181,7 +181,7 @@ private slots:
 
     // Reset the migration fault-injection seam before every test so a one-shot
     // fault set by one test can never leak into the next.
-    void init() {
+    void init() { QTest::failOnWarning();
         ShotHistoryStorage::s_faultInjectMigration = 0;
     }
 

--- a/tests/tst_de1device_firmware.cpp
+++ b/tests/tst_de1device_firmware.cpp
@@ -30,6 +30,7 @@ private:
     };
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== writeFWMapRequest → A009 =====
 

--- a/tests/tst_de1device_headless.cpp
+++ b/tests/tst_de1device_headless.cpp
@@ -22,6 +22,7 @@ private:
     };
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void defaultsToHeadless() {
         // A freshly constructed device (no GHC read yet) must allow app starts.
         DE1Device device;

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -116,7 +116,7 @@ private slots:
     // Suppress the expected "[Scale] <name> DISCONNECTED" warning from
     // ScaleDevice::setConnected(false) that fires when the test's driver
     // is torn down at scope exit.
-    void init() {
+    void init() { QTest::failOnWarning();
         QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*DISCONNECTED.*"));
     }
 

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -225,6 +225,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void initTestCase()
     {
         QVERIFY(m_tempDir.isValid());

--- a/tests/tst_dialing_helpers.cpp
+++ b/tests/tst_dialing_helpers.cpp
@@ -8,6 +8,7 @@ class TstDialingHelpers : public QObject
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void emptyInput_returnsNoSessions();
     void singleShot_returnsOneSessionOfOne();
     void twoAdjacentShots_inSameSession();

--- a/tests/tst_difluidr1.cpp
+++ b/tests/tst_difluidr1.cpp
@@ -65,6 +65,7 @@ class tst_DiFluidR1 : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // === Pure helpers — captured vectors ===
 

--- a/tests/tst_difluidr2.cpp
+++ b/tests/tst_difluidr2.cpp
@@ -108,6 +108,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // === Device name matching ===
 

--- a/tests/tst_drinktypes.cpp
+++ b/tests/tst_drinktypes.cpp
@@ -8,6 +8,7 @@ class tst_DrinkTypes : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // Grind-bearing drink types (fix-recipe-grind-integrity): the tea family
     // stores no grind — a dial edit while a tea recipe is active must not

--- a/tests/tst_equipment.cpp
+++ b/tests/tst_equipment.cpp
@@ -53,6 +53,7 @@ private:
     QString freshDbPath() { return m_dir.filePath(QString("eq_%1.db").arg(++m_seq)); }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     // --- splitGrindAndRpm ---
     void splitGrindRpm_data() {
         QTest::addColumn<QString>("input");

--- a/tests/tst_firmwareassetcachehelpers.cpp
+++ b/tests/tst_firmwareassetcachehelpers.cpp
@@ -15,6 +15,7 @@ class tst_FirmwareAssetCacheHelpers : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== MetaJson round-trip =====
 

--- a/tests/tst_firmwareheader.cpp
+++ b/tests/tst_firmwareheader.cpp
@@ -67,6 +67,7 @@ class tst_FirmwareHeader : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== parseHeader: pure byte → struct =====
 

--- a/tests/tst_firmwarepackets.cpp
+++ b/tests/tst_firmwarepackets.cpp
@@ -13,6 +13,7 @@ class tst_FirmwarePackets : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== buildFWMapRequest: 7-byte packet written to A009 =====
     // Layout: [WindowIncrement(u16 BE)=0][FWToErase][FWToMap][FirstError×3]

--- a/tests/tst_firmwareupdater.cpp
+++ b/tests/tst_firmwareupdater.cpp
@@ -98,6 +98,7 @@ private:
     };
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== §4b: error paths =====
 

--- a/tests/tst_kb_schema.cpp
+++ b/tests/tst_kb_schema.cpp
@@ -112,6 +112,7 @@ class TstKbSchema : public QObject
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     // The precondition every corruption test leans on: the validator must
     // actually be runnable and must accept well-formed input. If this
     // fails, every "fails as expected" test below is meaningless (a

--- a/tests/tst_livesteamcoach.cpp
+++ b/tests/tst_livesteamcoach.cpp
@@ -92,7 +92,7 @@ private:
 
 private slots:
 
-    void init() {
+    void init() { QTest::failOnWarning();
         m_origCoachVisual  = m_realSettings.value("steam/steamCoachVisualEnabled");
         m_origCoachAudio   = m_realSettings.value("steam/steamCoachAudioEnabled");
         m_origSteamTimeout = m_realSettings.value("steam/timeout");

--- a/tests/tst_machinestate.cpp
+++ b/tests/tst_machinestate.cpp
@@ -35,6 +35,7 @@ private:
     };
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ==========================================
     // Phase Mapping (de1app update_de1_state)

--- a/tests/tst_machinestatussnapshot.cpp
+++ b/tests/tst_machinestatussnapshot.cpp
@@ -26,6 +26,7 @@ class tst_MachineStatusSnapshot : public QObject {
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void initTestCase() {
         // Keep snapshot writes out of the real app data dir, and guarantee
         // the desktop platformWrite path is writable so it never emits the

--- a/tests/tst_mcpremoteaccess.cpp
+++ b/tests/tst_mcpremoteaccess.cpp
@@ -252,6 +252,7 @@ private:
     QHash<QString, QVariant> m_savedSettings;
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void initTestCase()
     {
         // Best-effort isolation on platforms that honor test mode (Linux/CI).

--- a/tests/tst_mcpserver_protocol.cpp
+++ b/tests/tst_mcpserver_protocol.cpp
@@ -167,6 +167,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ─── Protocol version negotiation ──────────────────────────────────────
 

--- a/tests/tst_mcpserver_session.cpp
+++ b/tests/tst_mcpserver_session.cpp
@@ -124,6 +124,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void initTestCase()
     {
         // No setup needed — warnings from McpServer without full wiring are expected

--- a/tests/tst_mcptools_presets.cpp
+++ b/tests/tst_mcptools_presets.cpp
@@ -53,7 +53,7 @@ private slots:
         registerPresetsTools(&m_registry, &m_settings, nullptr, nullptr);
     }
 
-    void init() {
+    void init() { QTest::failOnWarning();
         QSettings raw(Settings::testQSettingsPath(), QSettings::IniFormat);
         m_origPitcherPresets = raw.value("steam/pitcherPresets").toByteArray();
         m_origVesselPresets = raw.value("water/vesselPresets").toByteArray();

--- a/tests/tst_mcptools_profiles.cpp
+++ b/tests/tst_mcptools_profiles.cpp
@@ -123,6 +123,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== profiles_list =====
 

--- a/tests/tst_mcptools_shots_helpers.cpp
+++ b/tests/tst_mcptools_shots_helpers.cpp
@@ -10,6 +10,7 @@ class TstMcpToolsShotsHelpers : public QObject
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void noDetectorResults_isNoOp();
     void cleanShot_pourEnvelope_peakPressureBarIsNull();
     void truncatedShot_pourEnvelope_peakPressureBarPopulated();

--- a/tests/tst_mcptools_write.cpp
+++ b/tests/tst_mcptools_write.cpp
@@ -156,6 +156,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== settings_set temperature triggers BLE upload =====
 

--- a/tests/tst_mmrwrite.cpp
+++ b/tests/tst_mmrwrite.cpp
@@ -26,6 +26,7 @@ private:
     };
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== Basic accept path =====
 

--- a/tests/tst_profile.cpp
+++ b/tests/tst_profile.cpp
@@ -88,6 +88,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ==========================================
     // JSON Round-Trip Tests

--- a/tests/tst_profileframe.cpp
+++ b/tests/tst_profileframe.cpp
@@ -31,6 +31,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ==========================================
     // JSON nested exit round-trip (de1app v2 format)

--- a/tests/tst_profilemanager.cpp
+++ b/tests/tst_profilemanager.cpp
@@ -107,6 +107,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // === Profile state after load ===
 

--- a/tests/tst_profileupload.cpp
+++ b/tests/tst_profileupload.cpp
@@ -54,6 +54,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== Happy path: all ACKs arrive, in order =====
 

--- a/tests/tst_recipegenerator.cpp
+++ b/tests/tst_recipegenerator.cpp
@@ -15,6 +15,7 @@ class tst_RecipeGenerator : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ==========================================
     // D-Flow frame structure

--- a/tests/tst_recipeparams.cpp
+++ b/tests/tst_recipeparams.cpp
@@ -12,6 +12,7 @@ class tst_RecipeParams : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ==========================================
     // JSON round-trip

--- a/tests/tst_recipepromotion.cpp
+++ b/tests/tst_recipepromotion.cpp
@@ -31,6 +31,7 @@ class tst_RecipePromotion : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // The shot's bag becomes the recipe's hard bag link (recipes link a
     // specific bag); a pre-bag shot (bagId <= 0) stores no link — the bean

--- a/tests/tst_recipeselectionmodel.cpp
+++ b/tests/tst_recipeselectionmodel.cpp
@@ -13,6 +13,7 @@ class tst_RecipeSelectionModel : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void defaultsToNone() {
         RecipeSelectionModel m;
         QCOMPARE(m.selected(), qint64(-1));

--- a/tests/tst_recipestorage.cpp
+++ b/tests/tst_recipestorage.cpp
@@ -91,6 +91,7 @@ private:
     QString freshDbPath() { return m_dir.filePath(QString("rec_%1.db").arg(++m_seq)); }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // --- variant map round-trip ---
 

--- a/tests/tst_roastdate.cpp
+++ b/tests/tst_roastdate.cpp
@@ -32,6 +32,7 @@ private:
 
 void TstRoastDate::init()
 {
+    QTest::failOnWarning();
     m_saved = QLocale();
     // Pin a month-first locale so non-locale tests are deterministic.
     QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));

--- a/tests/tst_sav.cpp
+++ b/tests/tst_sav.cpp
@@ -66,6 +66,7 @@ private:
     };
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== SAV fires when pourVolume >= targetVolume =====
 

--- a/tests/tst_saw.cpp
+++ b/tests/tst_saw.cpp
@@ -40,7 +40,7 @@ private:
 
 private slots:
 
-    void init() {
+    void init() { QTest::failOnWarning();
         m_fakeClock = 1000000;  // Reset for each test
     }
 

--- a/tests/tst_saw_settings.cpp
+++ b/tests/tst_saw_settings.cpp
@@ -49,7 +49,7 @@ private:
 
 private slots:
 
-    void init() {
+    void init() { QTest::failOnWarning();
         m_settings.calibration()->resetSawLearning();
     }
 

--- a/tests/tst_sawprediction.cpp
+++ b/tests/tst_sawprediction.cpp
@@ -19,6 +19,7 @@ class tst_SawPrediction : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== σ constant lock-in =====
 

--- a/tests/tst_scaleblepriority.cpp
+++ b/tests/tst_scaleblepriority.cpp
@@ -13,6 +13,7 @@ class tst_ScaleBlePriority : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void de1FaultClusterTriggersBackoff() {
         BlePriorityDetector d;
         d.armWindow(1000);

--- a/tests/tst_scalefeedliveness.cpp
+++ b/tests/tst_scalefeedliveness.cpp
@@ -36,7 +36,7 @@ class tst_ScaleFeedLiveness : public QObject {
 
 private slots:
 
-    void init() { m_clock = 1000000; }
+    void init() { QTest::failOnWarning(); m_clock = 1000000; }
 
     // The fix contract, at the ScaleDevice chokepoint: every accepted sample
     // emits weightSampleReceived; weightChanged stays deduped.

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -89,6 +89,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ==========================================
     // DecentScale: weight parsing

--- a/tests/tst_scaleskiphighlatch.cpp
+++ b/tests/tst_scaleskiphighlatch.cpp
@@ -22,6 +22,7 @@ class tst_ScaleSkipHighLatch : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void defaultIsUnlatchedAndEmpty() {
         BLEManager::ScaleSkipHighLatch l;
         QVERIFY(!l.latched);

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -107,7 +107,7 @@ private:
 
 private slots:
 
-    void init() {
+    void init() { QTest::failOnWarning();
         // Save all originals before each test
         m_origTargetWeight = m_settings.brew()->targetWeight();
         m_origDoseCupTare = m_settings.brew()->doseCupTareWeight();

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -32,6 +32,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== trimSettlingData() =====
 

--- a/tests/tst_shotanalysis.cpp
+++ b/tests/tst_shotanalysis.cpp
@@ -55,6 +55,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void skipFirstFrameDetection()
     {
         expectSkipDetection({}, -1, false);

--- a/tests/tst_shotcorpus.cpp
+++ b/tests/tst_shotcorpus.cpp
@@ -23,6 +23,7 @@ class TstShotCorpus : public QObject
 {
     Q_OBJECT
 private slots:
+    void init() { QTest::failOnWarning(); }
     void corpus_validates_against_manifest();
 };
 

--- a/tests/tst_shotprojection.cpp
+++ b/tests/tst_shotprojection.cpp
@@ -18,6 +18,7 @@ class TstShotProjection : public QObject
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     void coerce_gadgetVariant_passesThroughIntact();
     void coerce_plainMap_reconstructsValidProjection();
     void coerce_emptyVariant_yieldsInvalidProjection();

--- a/tests/tst_shotrecord_cache.cpp
+++ b/tests/tst_shotrecord_cache.cpp
@@ -95,6 +95,7 @@ class tst_ShotRecordCache : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     // Sentinel test: when cachedAnalysis is populated, convertShotRecord
     // MUST emit those exact lines without recomputing. The sentinel is a
     // string no real detector would produce — if recomputation fired, the

--- a/tests/tst_shotsettings.cpp
+++ b/tests/tst_shotsettings.cpp
@@ -42,6 +42,7 @@ private:
     };
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ===== Wire format length =====
 

--- a/tests/tst_shotsummarizer.cpp
+++ b/tests/tst_shotsummarizer.cpp
@@ -80,6 +80,7 @@ class tst_ShotSummarizer : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     // Puck-failure shape: peak pressure ~1.0 bar across the entire pour
     // window. Without the cascade, dC/dt and temp detectors on
     // ShotSummarizer's old code path would have read off the (nonexistent)

--- a/tests/tst_steamhealth.cpp
+++ b/tests/tst_steamhealth.cpp
@@ -24,7 +24,7 @@ private:
 
 private slots:
 
-    void init() {
+    void init() { QTest::failOnWarning();
         m_origHistory = m_settings.value("steam/sessionHistory").toByteArray();
         m_origLastWarned = m_settings.value("steam/lastWarnedSession");
         m_origLastFlow = m_settings.value("steam/lastTrackedFlow");

--- a/tests/tst_tclimport.cpp
+++ b/tests/tst_tclimport.cpp
@@ -29,6 +29,7 @@ private:
     }
 
 private slots:
+    void init() { QTest::failOnWarning(); }
 
     // ==========================================
     // Data-driven: one row per TCL profile

--- a/tests/tst_temperaturedisplay.cpp
+++ b/tests/tst_temperaturedisplay.cpp
@@ -15,6 +15,7 @@ class tst_TemperatureDisplay : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     // ----- distinctCount -----
     void distinctCount_data() {
         QTest::addColumn<QVector<double>>("temps");

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -65,7 +65,7 @@ private:
 
 private slots:
 
-    void init() {
+    void init() { QTest::failOnWarning();
         m_fakeClock = 1000000;  // Reset for each test
     }
 

--- a/tests/tst_wifiscalediscovery.cpp
+++ b/tests/tst_wifiscalediscovery.cpp
@@ -12,6 +12,7 @@ class tst_WifiScaleDiscovery : public QObject {
     Q_OBJECT
 
 private slots:
+    void init() { QTest::failOnWarning(); }
     // localhost resolves on every platform — exercises the success edge.
     void resolvedHostnameEmitsScaleFound() {
         WifiScaleDiscovery disc;


### PR DESCRIPTION
## Why
TESTING.md requires tests to be silent on stderr, but that was **visual-only**: a stray `qWarning()` printed a `QWARN` line yet the test still **passed**. Worse, `ctest -j` and Qt Creator's CTest runner (both now the recommended way to run the suite) capture and **hide** passing-test stderr — so a newly-introduced stray warning is invisible *and* non-failing.

## What
Arm `QTest::failOnWarning()` in every test class's `init()` (Qt 6.8+). An **unexpected** `qWarning`/`qCritical` during a test function now **fails that test** in any runner — plain `ctest`, `ctest -j`, and QC's CTest runner. Warnings marked expected via `QTest::ignoreMessage()` are consumed before the check and do not fail.

- 68 test classes: 13 had an `init()` (prepended the call), 55 got a one-line `init()`. `tst_roastdate`'s out-of-line `init()` handled specially.
- One-line addition per class; `docs/CLAUDE_MD/TESTING.md` documents the guard and that **new test classes must include it**.
- `QT_FATAL_WARNINGS` was evaluated and rejected — it aborts on `ignoreMessage()`-expected warnings too.

## Validation
- Audited first: the suite emits **0 unexpected `QWARN`** today, so nothing starts failing — this just locks it in.
- **68/68 pass** with enforcement armed, repeatedly under `ctest -j11` (~28 s).
- **Proven live** both ways: injecting a stray `qWarning` into an inserted-`init()` class and into the out-of-line-`init()` class made them fail with *"Received a warning that resulted in a failure"*; reverted.

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)