### PR TITLE
test: lint that every test file arms QTest::failOnWarning()

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -880,3 +880,13 @@ target_compile_definitions(tst_kb_schema PRIVATE
     VALIDATE_KB_SCRIPT="${CMAKE_SOURCE_DIR}/tools/validate_kb.py"
     VALIDATE_KB_REAL_JSON="${CMAKE_SOURCE_DIR}/resources/ai/profile_knowledge.json"
 )
+
+# --- failonwarning_lint: guard that every QTEST_*MAIN test file arms
+# QTest::failOnWarning() (see tests/lint_failonwarning.cmake and the Handling
+# Warnings section of docs/CLAUDE_MD/TESTING.md). A pure cmake -P check — no
+# build, no extra dependency — that re-globs on each run, so a newly-added
+# test file that forgets the guard fails `ctest` without a reconfigure.
+add_test(NAME failonwarning_lint
+    COMMAND ${CMAKE_COMMAND}
+        -DLINT_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/lint_failonwarning.cmake)

--- a/tests/lint_failonwarning.cmake
+++ b/tests/lint_failonwarning.cmake
@@ -1,0 +1,30 @@
+# Guard: every test executable must arm QTest::failOnWarning() so an unexpected
+# qWarning/qCritical fails the test (see docs/CLAUDE_MD/TESTING.md). A new
+# tst_*.cpp that forgets it would silently opt out of the discipline — this lint
+# catches that. Run as a CTest entry (cmake -P), so it re-globs on every run and
+# needs no reconfigure when a test file is added.
+#
+# Invoked with -DLINT_DIR=<tests source dir>.
+
+file(GLOB test_files "${LINT_DIR}/tst_*.cpp")
+set(offenders "")
+foreach(f ${test_files})
+    file(READ "${f}" content)
+    # Only files that actually declare a test executable need the guard.
+    if(content MATCHES "QTEST_[A-Z_]*MAIN" AND NOT content MATCHES "failOnWarning")
+        get_filename_component(name "${f}" NAME)
+        list(APPEND offenders "${name}")
+    endif()
+endforeach()
+
+if(offenders)
+    string(REPLACE ";" "\n  " offlist "${offenders}")
+    message(FATAL_ERROR
+        "These test files declare a QTEST_*MAIN executable but do not call "
+        "QTest::failOnWarning():\n  ${offlist}\n"
+        "Add `void init() { QTest::failOnWarning(); }` to the test class (or "
+        "prepend the call to an existing init()). See the Handling Warnings "
+        "section of docs/CLAUDE_MD/TESTING.md.")
+endif()
+
+message(STATUS "failOnWarning lint: all test executables guarded")


### PR DESCRIPTION
## Why
#1504 made an unexpected `qWarning`/`qCritical` fail the test — but only for classes that call `QTest::failOnWarning()` in `init()`. That's per-test-class, so a future `tst_*.cpp` that forgets the line silently opts out of the discipline. This makes the "every test file must arm it" rule airtight instead of convention.

## What
A CTest entry `failonwarning_lint` (pure `cmake -P`, no build step, no extra dependency) that globs `tests/tst_*.cpp` and fails — **naming the offender** — if any file declaring a `QTEST_*MAIN` executable lacks a `failOnWarning` call. It re-globs on every run, so a newly-added test file is caught without a reconfigure. Runs anywhere the suite runs: plain `ctest`, `ctest -j`, CI, and Qt Creator's CTest runner.

## Validation
- Passes today (all 68 test files guarded).
- **Proven to fail**: temporarily stripped `failOnWarning` from `tst_saw.cpp` → lint failed with *"These test files declare a QTEST_*MAIN executable but do not call QTest::failOnWarning(): tst_saw.cpp"*; restored → passes again.

No production code changes; adds one CTest check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)