### PR TITLE
Add temporary diagnostics for Android-only opaque bottom bar

### DIFF
--- a/qml/components/StatusBar.qml
+++ b/qml/components/StatusBar.qml
@@ -27,6 +27,14 @@ Rectangle {
            ? Theme.scrimColor(_opaqueColor)
            : _opaqueColor
 
+    // TEMPORARY diagnostic for the Android-only opaque-bottom-bar report
+    // (add-custom-background follow-up) — remove once root-caused.
+    onColorChanged: console.log("[statusBar-diag] pathLen=" + Settings.theme.backgroundImagePath.length
+        + " opaqueColor=" + _opaqueColor + " a=" + _opaqueColor.a
+        + " scrimResult=" + Theme.scrimColor(_opaqueColor) + " a=" + Theme.scrimColor(_opaqueColor).a
+        + " finalColor=" + color + " a=" + color.a + " itemOpacity=" + opacity + " itemZ=" + z)
+    Component.onCompleted: colorChanged()
+
     LayoutBarZone {
         anchors.fill: parent
         anchors.leftMargin: Theme.chartMarginSmall

--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -518,6 +518,7 @@ Item {
         implicitHeight: root.hasEmoji ? Theme.scaled(120) : (fullText.implicitHeight + Theme.scaled(16) + (root.hasAction ? Theme.scaled(8) : 0))
 
         Rectangle {
+            id: fullBgRect
             visible: !root.hideBackground && (root.hasAction || root.hasEmoji)
             anchors.fill: parent
             color: fullTap.isPressed ? Qt.darker(root._effectiveBackground, 1.2) : root._effectiveBackground
@@ -525,6 +526,13 @@ Item {
             opacity: root.hasAction && typeof DE1Device !== "undefined" && !DE1Device.guiEnabled ? 0.5 : 1.0
             border.width: root.isActive ? Theme.scaled(3) : 0
             border.color: root._activeRingColor
+
+            // TEMPORARY diagnostic for the Android-only opaque-bottom-bar report
+            // (add-custom-background follow-up) — remove once root-caused.
+            onColorChanged: console.log("[customItem-diag] label=\"" + root.content + "\" pathLen=" + Settings.theme.backgroundImagePath.length
+                + " effectiveBackground=" + root._effectiveBackground + " a=" + root._effectiveBackground.a
+                + " finalColor=" + color + " a=" + color.a + " itemOpacity=" + opacity)
+            Component.onCompleted: colorChanged()
         }
 
         // Layout with emoji: icon above text (like ActionButton)

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -1164,6 +1164,18 @@ Page {
                ? Theme.scrimColor(Theme.bottomBarColor)
                : Theme.bottomBarColor
 
+        // TEMPORARY diagnostic for the Android-only opaque-bottom-bar report
+        // (add-custom-background follow-up) — remove once root-caused.
+        onColorChanged: console.log("[bottomBar-diag] pathLen=" + Settings.theme.backgroundImagePath.length
+            + " bottomBarColor=" + Theme.bottomBarColor + " a=" + Theme.bottomBarColor.a
+            + " scrimResult=" + Theme.scrimColor(Theme.bottomBarColor) + " a=" + Theme.scrimColor(Theme.bottomBarColor).a
+            + " finalColor=" + color + " a=" + color.a + " itemOpacity=" + opacity + " itemZ=" + z)
+        Component.onCompleted: {
+            colorChanged()
+            console.log("[gfx-diag] api=" + GraphicsInfo.api + " shaderType=" + GraphicsInfo.shaderType
+                + " shaderCompilationType=" + GraphicsInfo.shaderCompilationType + " renderableType=" + GraphicsInfo.renderableType)
+        }
+
         RowLayout {
             anchors.fill: parent
             anchors.leftMargin: Theme.spacingMedium


### PR DESCRIPTION
## Summary
- Diagnostic-only change to root-cause a user-reported bug: on Android, `IdlePage`'s bottom bar (Sleep/Flush/History/Equipment/Profiles) renders fully opaque when a custom background image is active, while the top status bar and idle-screen action tiles correctly show the translucent scrim.
- Ruled out: stale build (device log confirms build 3481, which chronologically includes the fix), stale QML cache (survived a full cold app relaunch), and code-level logic error (this file's binding is byte-for-byte the same pattern as the working `StatusBar.qml`).
- Adds `console.log` diagnostics at three comparison points that all call the same `Theme.scrimColor()` helper — `StatusBar.qml` (48 lines, confirmed working), `CustomItem.qml` (593 lines, idle action tiles), and `IdlePage.qml`'s own bottom bar (inline binding inside a 1205-line file — the one reported broken) — logging the base color, scrim result, and final rendered color with alpha at each point, plus item opacity/z.
- Also logs `GraphicsInfo.api`/`shaderType`/`shaderCompilationType`/`renderableType` once at startup to fingerprint the RHI backend (confirmed Metal/`api=6` on macOS locally) for comparison against Android's.
- Verified on macOS: all three diagnostics report the correct `alpha=0.4` scrim consistently — confirming both the logic and the logging work correctly there. Needed on-device on Android to see where it actually diverges.

**This is temporary.** Once the Android log data reveals the root cause, a follow-up PR will apply the real fix and revert these diagnostics.

## Test plan
- [x] Build succeeds cleanly (`Decenza-Desktop`, 0 errors/warnings)
- [x] Verified diagnostic output on macOS desktop — all three points log `alpha=0.4` as expected
- [ ] Deploy to Android, reproduce the report, pull `debug_get_log` via the `de1` MCP tools to compare

🤖 Generated with [Claude Code](https://claude.com/claude-code)