### PR TITLE
Bean freshness follow-up: non-frozen storage lifecycle + AI reasoning (#1032)

### DIFF
--- a/openspec/changes/bean-freshness-followup/specs/dialing-context-payload/spec.md
+++ b/openspec/changes/bean-freshness-followup/specs/dialing-context-payload/spec.md
@@ -46,22 +46,30 @@ The session's `shotCount`, `sessionStart`, `sessionEnd`, and `shots[]` array SHA
 - `frozenDate` / `defrostDate` — surfaced verbatim when set.
 - `storageHint` / `openedDate` — surfaced verbatim when set (the non-frozen analogue of `frozenDate`/`defrostDate`; `storageHint` never has a "frozen" value — see `bag-freeze-lifecycle`).
 - `freshnessKnown` — boolean. `true` when at least one of `frozenDate`, `defrostDate`, or `openedDate` is set; `false` otherwise (no storage history recorded at all).
-- `instruction` — one of two fixed strings selected by `freshnessKnown`:
-  - When `false`: an imperative telling the AI calendar age from `roastDate` is NOT freshness (many users freeze/thaw or rotate portions) and to ASK the user about storage before applying any bean-aging guidance.
+- `instruction` — selected by `freshnessKnown` and the presence of a `storageHint`, in three states:
+  - When `false` and no `storageHint`: an imperative teaching the freshness ASYMMETRY — `roastDate` is the UPPER BOUND on staleness because freezing/airtight/vacuum storage only pauses staling, so beans are never older than their calendar age since roast, only fresher. Therefore the AI SHALL treat a *recent* roast as fresh WITHOUT asking about storage (nothing storage could reveal makes recently-roasted beans stale), and SHALL ask about storage ONLY when the roast date is old (the sole case where freshness is genuinely ambiguous: frozen-since-roast-and-fresh vs left-out-and-stale). The AI judges "recent vs old" itself — the block ships no day count.
+  - When `false` and a `storageHint` IS set: the same upper-bound imperative PLUS a clause stating the storage TYPE is already known (naming the hint). The AI SHALL NOT re-ask how the beans are stored; at most — and only when the roast is old — it SHALL ask solely for the aging-start date. `freshnessKnown` stays `false` because a hint without a date is not a precise aging anchor.
   - When `true`: an imperative telling the AI storage history is known — do NOT ask about it — and to age the beans from the most recent of `defrostDate`/`openedDate` (whichever is set), not from `roastDate`. This instruction SHALL also teach the reverse-direction case: a *recent* `defrostDate`/`openedDate` can mean the portion is under-rested/gassy (chokes, runs long, over-extracts, may want a coarser grind that settles back over the following days), not merely "less stale" — the AI SHALL NOT treat a recent thaw/open date as unconditionally meaning "fresher is better."
 
 The block SHALL be omitted entirely when `roastDate` is empty AND no lifecycle field (`frozenDate`, `defrostDate`, `storageHint`, `openedDate`) is set. The block SHALL NOT contain a precomputed day count under any field name; the AI MUST do the subtraction itself, in front of the user, to make the assumption visible.
 
 The `shotAnalysis` prose SHALL NOT contain the parenthetical "(N days since roast, not necessarily freshness — ask about storage)" that previously rendered next to the bean name. It is replaced by the lighter "(roasted YYYY-MM-DD; ask user about storage before reasoning about age)" — same caveat, no day count. (This prose clause is unchanged by this delta; it is carried forward verbatim from the baseline requirement for continuity with the later PR-2-scope requirements in this file that govern whether/where that clause still renders.)
 
-#### Scenario: beanFreshness emits with freshnessKnown false and the ask-about-storage instruction
+#### Scenario: beanFreshness emits with freshnessKnown false and the upper-bound instruction
 - **GIVEN** a resolved shot with `roastDate = "2026-04-15"` and no `frozenDate`/`defrostDate`/`storageHint`/`openedDate`
 - **WHEN** the response is built
 - **THEN** `currentBean.beanFreshness.roastDate` SHALL be `"2026-04-15"`
 - **AND** `currentBean.beanFreshness.freshnessKnown` SHALL be `false`
-- **AND** `currentBean.beanFreshness.instruction` SHALL match the ask-about-storage imperative
+- **AND** `currentBean.beanFreshness.instruction` SHALL frame `roastDate` as the staleness upper bound, carve out recent-roast-is-fresh (no storage question), and gate the ASK on an OLD roast
 - **AND** `currentBean` SHALL NOT contain `daysSinceRoast` or `daysSinceRoastNote` under any spelling
 - **AND** `currentBean.beanFreshness` SHALL NOT contain a `daysSinceRoast`, `calendarDaysSinceRoast`, `effectiveAgeDays`, or any other precomputed-day-count field
+
+#### Scenario: beanFreshness with a storageHint but no date does not re-ask storage
+- **GIVEN** a resolved shot with `roastDate` set, `storageHint = "vacuum-sealed"`, and no `frozenDate`/`defrostDate`/`openedDate`
+- **WHEN** the response is built
+- **THEN** `currentBean.beanFreshness.freshnessKnown` SHALL be `false` (a hint without a date is not a precise aging anchor)
+- **AND** `currentBean.beanFreshness.storageHint` SHALL be `"vacuum-sealed"`
+- **AND** the instruction SHALL name the known storage type and direct the AI NOT to re-ask how the beans are stored — asking, at most, only for the aging-start date and only when the roast is old
 
 #### Scenario: beanFreshness emits with freshnessKnown true from frozen/defrost dates
 - **GIVEN** a resolved shot with `frozenDate` and `defrostDate` set

--- a/openspec/changes/bean-freshness-followup/tasks.md
+++ b/openspec/changes/bean-freshness-followup/tasks.md
@@ -1,57 +1,57 @@
 ## 1. Data model & migration — coffee_bags
 
-- [ ] 1.1 Add `storageHint` (QString) and `openedDate` (QString, ISO date) fields to `CoffeeBag` in `src/history/coffeebagstorage.h`
-- [ ] 1.2 Add the next sequential migration in `src/history/shothistorystorage.cpp` adding nullable `storage_hint` TEXT and `opened_date` TEXT columns to `coffee_bags`; bump `kCols`/column-list constants used by `updateBagFieldsStatic`/`bagFromQueryRow`
-- [ ] 1.3 Update `CoffeeBag::toVariantMap()`/`fromVariantMap()` in `coffeebagstorage.cpp` to round-trip the two new fields
-- [ ] 1.4 Confirm `CoffeeBagStorage::importBagsStatic` (device transfer / backup restore) copies the two new `coffee_bags` columns via its existing generic column path; add explicit coverage if it uses an allowlist instead
-- [ ] 1.5 Confirm `touchesVisualizerFields()` correctly excludes `storageHint`/`openedDate` (local-only, same as `frozenDate`/`defrostDate`)
+- [x] 1.1 Add `storageHint` (QString) and `openedDate` (QString, ISO date) fields to `CoffeeBag` in `src/history/coffeebagstorage.h`
+- [x] 1.2 Add the next sequential migration in `src/history/shothistorystorage.cpp` adding nullable `storage_hint` TEXT and `opened_date` TEXT columns to `coffee_bags`; bump `kCols`/column-list constants used by `updateBagFieldsStatic`/`bagFromQueryRow`
+- [x] 1.3 Update `CoffeeBag::toVariantMap()`/`fromVariantMap()` in `coffeebagstorage.cpp` to round-trip the two new fields
+- [x] 1.4 Confirm `CoffeeBagStorage::importBagsStatic` (device transfer / backup restore) copies the two new `coffee_bags` columns via its existing generic column path; add explicit coverage if it uses an allowlist instead
+- [x] 1.5 Confirm `touchesVisualizerFields()` correctly excludes `storageHint`/`openedDate` (local-only, same as `frozenDate`/`defrostDate`)
 
 ## 2. Data model & migration — shots (blocking: gap 3 cannot work without this)
 
 `frozen_date`/`defrost_date` are dedicated `shots`-table columns, not just `coffee_bags` columns — the same migration/plumbing must be mirrored for `storage_hint`/`opened_date`, or the shot-snapshot requirements in `coffee-bag-model`/`bag-freeze-lifecycle` are unsatisfiable and gap 3's per-shot lifecycle data has nothing to read from on historical shots.
 
-- [ ] 2.1 In the same migration as task 1.2 (or a paired one), `ALTER TABLE shots ADD COLUMN storage_hint TEXT` and `ALTER TABLE shots ADD COLUMN opened_date TEXT`, mirroring `shothistorystorage.cpp:1038-1041`'s `frozen_date`/`defrost_date` pattern
-- [ ] 2.2 Add `storage_hint`/`opened_date` to the shot-save `INSERT` column list and bound parameters (mirror `shothistorystorage.cpp:1896`/`1910`/`1957-1958`)
-- [ ] 2.3 Add `storage_hint`/`opened_date` to the shot-read `SELECT` column list and the `ShotRecord`/metadata field mapping (mirror `shothistorystorage.cpp:2482`/`2542-2543`, and the `data.frozenDate = metadata.frozenDate` style assignment around `1719-1720`)
-- [ ] 2.4 Add `storage_hint`/`opened_date` to the device-transfer/backup-restore `INSERT` column list, including the source-column-presence index resolution used for older source databases that predate the columns (mirror `shothistorystorage.cpp:3371-3372` `idxFrozenDate`/`idxDefrostDate` and the `srcValueOrNull(idx)` binding at `3412`)
-- [ ] 2.5 Add `storageHint`/`openedDate` fields to `ShotProjection` (`src/history/shotprojection.h/.cpp`) and `src/history/shothistory_types.h`, following the existing `frozenDate`/`defrostDate` pattern
-- [ ] 2.6 Snapshot the active bag's `storageHint`/`openedDate` onto the shot record at save time (same call site that stamps `frozenDate`/`defrostDate` today)
-- [ ] 2.7 Add `storageHint`/`openedDate` to `CurrentBeanBlockInputs` and `beanInputsFromProjection()` in `src/ai/dialing_blocks.h`
-- [ ] 2.8 Add a migration test asserting an existing database gains both `shots` columns (NULL on existing rows) and a device-transfer test asserting a source DB predating the migration imports cleanly with both columns NULL (no per-row "unknown field" warning)
+- [x] 2.1 In the same migration as task 1.2 (or a paired one), `ALTER TABLE shots ADD COLUMN storage_hint TEXT` and `ALTER TABLE shots ADD COLUMN opened_date TEXT`, mirroring `shothistorystorage.cpp:1038-1041`'s `frozen_date`/`defrost_date` pattern
+- [x] 2.2 Add `storage_hint`/`opened_date` to the shot-save `INSERT` column list and bound parameters (mirror `shothistorystorage.cpp:1896`/`1910`/`1957-1958`)
+- [x] 2.3 Add `storage_hint`/`opened_date` to the shot-read `SELECT` column list and the `ShotRecord`/metadata field mapping (mirror `shothistorystorage.cpp:2482`/`2542-2543`, and the `data.frozenDate = metadata.frozenDate` style assignment around `1719-1720`)
+- [x] 2.4 Add `storage_hint`/`opened_date` to the device-transfer/backup-restore `INSERT` column list, including the source-column-presence index resolution used for older source databases that predate the columns (mirror `shothistorystorage.cpp:3371-3372` `idxFrozenDate`/`idxDefrostDate` and the `srcValueOrNull(idx)` binding at `3412`)
+- [x] 2.5 Add `storageHint`/`openedDate` fields to `ShotProjection` (`src/history/shotprojection.h/.cpp`) and `src/history/shothistory_types.h`, following the existing `frozenDate`/`defrostDate` pattern
+- [x] 2.6 Snapshot the active bag's `storageHint`/`openedDate` onto the shot record at save time (same call site that stamps `frozenDate`/`defrostDate` today)
+- [x] 2.7 Add `storageHint`/`openedDate` to `CurrentBeanBlockInputs` and `beanInputsFromProjection()` in `src/ai/dialing_blocks.h`
+- [x] 2.8 Add a migration test asserting an existing database gains both `shots` columns (NULL on existing rows) and a device-transfer test asserting a source DB predating the migration imports cleanly with both columns NULL (no per-row "unknown field" warning)
 
 ## 4. AI reasoning — beanFreshness block
 
-- [ ] 4.1 Extend `DialingHelpers::buildBeanFreshness()` (`src/ai/dialing_helpers.h`) to accept `storageHint`/`openedDate`, compute `freshnessKnown` from `frozenDate || defrostDate || openedDate`, and surface `storageHint`/`openedDate` in the JSON block when set
-- [ ] 4.2 Rewrite `kBeanFreshnessKnownInstruction` to add the reverse-direction guidance: a recent `defrostDate`/`openedDate` may mean the portion is under-rested/gassy (chokes, runs long, over-extracts, may want a coarser grind that settles over the following days), not merely "fresher"
-- [ ] 4.3 Update the aging-anchor logic to use whichever of `defrostDate`/`openedDate` is most recent when both are present
-- [ ] 4.4 Update `src/ai/shotsummarizer.cpp`'s `currentBean.beanFreshness` guidance (around lines 1003-1012) and the "Your beans are old/stale" forbidden-simplification note (around lines 1605-1613) to reflect the two-direction reasoning and the `openedDate`/`storageHint` fields
-- [ ] 4.5 Add/update unit tests for `buildBeanFreshness()` covering: frozen+defrost known, never-frozen+opened known, neither set (unknown), both defrost and opened set (most-recent-wins anchor)
+- [x] 4.1 Extend `DialingHelpers::buildBeanFreshness()` (`src/ai/dialing_helpers.h`) to accept `storageHint`/`openedDate`, compute `freshnessKnown` from `frozenDate || defrostDate || openedDate`, and surface `storageHint`/`openedDate` in the JSON block when set
+- [x] 4.2 Rewrite `kBeanFreshnessKnownInstruction` to add the reverse-direction guidance: a recent `defrostDate`/`openedDate` may mean the portion is under-rested/gassy (chokes, runs long, over-extracts, may want a coarser grind that settles over the following days), not merely "fresher"
+- [x] 4.3 Update the aging-anchor logic to use whichever of `defrostDate`/`openedDate` is most recent when both are present
+- [x] 4.4 Update `src/ai/shotsummarizer.cpp`'s `currentBean.beanFreshness` guidance (around lines 1003-1012) and the "Your beans are old/stale" forbidden-simplification note (around lines 1605-1613) to reflect the two-direction reasoning and the `openedDate`/`storageHint` fields
+- [x] 4.5 Add/update unit tests for `buildBeanFreshness()` covering: frozen+defrost known, never-frozen+opened known, neither set (unknown), both defrost and opened set (most-recent-wins anchor)
 
 ## 5. AI reasoning — cross-portion lifecycle visibility
 
-- [ ] 5.1 Extend the `dialInSessions[].context`/per-shot hoisting in `src/ai/dialing_blocks.cpp` to include `frozenDate`/`defrostDate`/`storageHint`/`openedDate` alongside the existing identity fields (only emit per-shot when it differs from the session/resolved value) — this is a MODIFIED requirement on the existing hoisting logic, not new machinery
-- [ ] 5.2 Extend `buildBestRecentShotBlock()` to carry the candidate shot's lifecycle fields directly (no hoisting — it's a single object, not a session list) for comparison against the resolved shot's `currentBean.beanFreshness`
-- [ ] 5.3 No new system-prompt instruction for this (see design.md decision) — data exposure is the whole fix. Do NOT add discounting guidance here
-- [ ] 5.4 Add tests asserting the data is visible: a `bestRecentShot` candidate with an older `defrostDate` than the resolved shot shows both dates distinctly in the payload; a `dialInSessions` session spanning a thaw event correctly hoists the shared value and overrides on the differing shot
+- [x] 5.1 Extend the `dialInSessions[].context`/per-shot hoisting in `src/ai/dialing_blocks.cpp` to include `frozenDate`/`defrostDate`/`storageHint`/`openedDate` alongside the existing identity fields (only emit per-shot when it differs from the session/resolved value) — this is a MODIFIED requirement on the existing hoisting logic, not new machinery
+- [x] 5.2 Extend `buildBestRecentShotBlock()` to carry the candidate shot's lifecycle fields directly (no hoisting — it's a single object, not a session list) for comparison against the resolved shot's `currentBean.beanFreshness`
+- [x] 5.3 No new system-prompt instruction for this (see design.md decision) — data exposure is the whole fix. Do NOT add discounting guidance here
+- [x] 5.4 Add tests asserting the data is visible: a `bestRecentShot` candidate with an older `defrostDate` than the resolved shot shows both dates distinctly in the payload; a `dialInSessions` session spanning a thaw event correctly hoists the shared value and overrides on the differing shot
 - [ ] 5.5 Before shipping, replay a synthetic lifecycle-mismatch payload (shaped like the #1032 follow-up's shot-937 session) through the actual system prompt in a one-off eval to see whether the model's response flags the mismatch without any new instruction — this is a cheap sanity check before committing to "no instruction needed," not a substitute for the post-ship spot-check below
 - [ ] 5.6 After shipping, spot-check a few real dial-in transcripts for a lifecycle-mismatch case to see whether the AI actually acts on the exposed dates without further prompting — only add instruction text later if this check (or 5.5) shows it's needed
 
 ## 6. MCP surface
 
-- [ ] 6.1 Update the `bag_update` MCP tool schema/description in `src/mcp/mcptools_write.cpp` to document `storageHint`/`openedDate`
-- [ ] 6.2 Verify `bag_create`/`bag_update` MCP handlers accept and persist the two new fields
+- [x] 6.1 Update the `bag_update` MCP tool schema/description in `src/mcp/mcptools_write.cpp` to document `storageHint`/`openedDate`
+- [x] 6.2 Verify `bag_create`/`bag_update` MCP handlers accept and persist the two new fields
 
 ## 7. UI — Change Beans dialog & bag cards
 
-- [ ] 7.1 Add a `storageHint` dropdown (Counter / Airtight container / Vacuum-sealed / Fridge — no "Frozen" value) to the bag form in `qml/components/ChangeBeansDialog.qml`, visible only while the freeze toggle is OFF; clear `storageHint` to null when the freeze toggle is turned on
-- [ ] 7.2 Add an `openedDate` `BeanDateField` to the form (edit-mode only, mirroring the existing `defrostDateField` at `ChangeBeansDialog.qml:1667-1676` — "only directly editable in edit mode, the quick action on the bag card is the everyday path")
-- [ ] 7.3 Add a "Mark Opened" action to `qml/components/BagCard.qml` for non-frozen bags, mirroring the existing "Thaw" `AccessibleButton` (`BagCard.qml:415-424`), with its own `DatePickerDialog` instance (`openedDatePicker`)
-- [ ] 7.4 Change the existing "Thaw" button's `onClicked` (`BagCard.qml:423`, currently `thawDatePicker.openWithDate(card.defrostDate)`) to `thawDatePicker.openWithDate("")` — always default the picker to today instead of the bag's existing `defrostDate`. Wire the new "Mark Opened" button's `onClicked` to `openedDatePicker.openWithDate("")` the same way (never pre-filled with the existing `openedDate`)
-- [ ] 7.5 Update `BagCard.qml`'s `_metaParts` (`BagCard.qml:161-175`) to render the absolute date alongside the day count — "Thawed {date} ({N}d)" / "Opened {date} ({N}d)" — reusing the existing `formatRoastDate()`-style locale formatting; update `qml/components/BeanSummary.qml`'s equivalent freeze/open line the same way
+- [x] 7.1 Add a `storageHint` dropdown (Counter / Airtight container / Vacuum-sealed / Fridge — no "Frozen" value) to the bag form in `qml/components/ChangeBeansDialog.qml`, visible only while the freeze toggle is OFF; clear `storageHint` to null when the freeze toggle is turned on
+- [x] 7.2 Add an `openedDate` `BeanDateField` to the form (edit-mode only, mirroring the existing `defrostDateField` at `ChangeBeansDialog.qml:1667-1676` — "only directly editable in edit mode, the quick action on the bag card is the everyday path")
+- [x] 7.3 Add a "Mark Opened" action to `qml/components/BagCard.qml` for non-frozen bags, mirroring the existing "Thaw" `AccessibleButton` (`BagCard.qml:415-424`), with its own `DatePickerDialog` instance (`openedDatePicker`)
+- [x] 7.4 Change the existing "Thaw" button's `onClicked` (`BagCard.qml:423`, currently `thawDatePicker.openWithDate(card.defrostDate)`) to `thawDatePicker.openWithDate("")` — always default the picker to today instead of the bag's existing `defrostDate`. Wire the new "Mark Opened" button's `onClicked` to `openedDatePicker.openWithDate("")` the same way (never pre-filled with the existing `openedDate`)
+- [x] 7.5 Update `BagCard.qml`'s `_metaParts` (`BagCard.qml:161-175`) to render the absolute date alongside the day count — "Thawed {date} ({N}d)" / "Opened {date} ({N}d)" — reusing the existing `formatRoastDate()`-style locale formatting; update `qml/components/BeanSummary.qml`'s equivalent freeze/open line the same way
 
 ## 8. Manual & issue cleanup
 
-- [ ] 8.1 Update the GitHub wiki manual (bean/bag section) to document the storage-hint dropdown and "Mark Opened" action
+- [x] 8.1 Update the GitHub wiki manual (bean/bag section) to document the storage-hint dropdown and "Mark Opened" action
 - [ ] 8.2 Close GitHub issue #1032, referencing this change as covering its remaining gaps (storage-hint field, under-rested/gassy direction guidance, cross-portion lifecycle visibility)
 
 ## 9. Verification

--- a/qml/components/BagCard.qml
+++ b/qml/components/BagCard.qml
@@ -27,6 +27,9 @@ Rectangle {
     readonly property bool hasCanonical: bag && bag.beanBaseId !== undefined && String(bag.beanBaseId).length > 0
     readonly property bool isFrozen: bag && bag.frozenDate !== undefined && String(bag.frozenDate).length > 0
     readonly property string defrostDate: bag && bag.defrostDate !== undefined ? String(bag.defrostDate) : ""
+    // Non-frozen storage lifecycle (bean-freshness-followup): the "Mark Opened"
+    // quick action mirrors "Thaw" and shows only on non-frozen bags.
+    readonly property string openedDate: bag && bag.openedDate !== undefined ? String(bag.openedDate) : ""
 
     readonly property var beanBase: {
         if (!bag || !bag.beanBaseData || String(bag.beanBaseData).length === 0) return ({})
@@ -155,9 +158,10 @@ Rectangle {
         return Qt.formatDate(d, Qt.locale().dateFormat(Locale.ShortFormat))
     }
 
-    // Roast date · freeze state line (omits anything unknown — no
-    // placeholders). The user freezes beans, so the actual roast date is more
-    // meaningful than days-since-roast.
+    // Roast date · freeze/open state line (omits anything unknown — no
+    // placeholders). The user freezes beans, so the actual roast/thaw/open
+    // date is more meaningful than a bare day count — show both (the absolute
+    // date and the at-a-glance age), matching the roast-date convention.
     readonly property var _metaParts: {
         var _ = TranslationManager.translationVersion
         var parts = []
@@ -167,9 +171,17 @@ Rectangle {
         if (defrostDate.length > 0) {
             var defAge = daysSince(defrostDate)
             if (defAge >= 0)
-                parts.push(TranslationManager.translate("beans.summary.defrostDays", "Def %1d").arg(defAge))
+                parts.push(TranslationManager.translate("beans.summary.thawedDate", "Thawed %1 (%2d)")
+                    .arg(formatRoastDate(defrostDate)).arg(defAge))
         } else if (isFrozen) {
             parts.push(TranslationManager.translate("beans.summary.frozen", "Frozen"))
+        } else if (openedDate.length > 0) {
+            // Non-frozen bags: show the opened date/age the same way (only when
+            // not frozen — a frozen bag's lifecycle is the thaw date above).
+            var openAge = daysSince(openedDate)
+            if (openAge >= 0)
+                parts.push(TranslationManager.translate("beans.summary.openedDate", "Opened %1 (%2d)")
+                    .arg(formatRoastDate(openedDate)).arg(openAge))
         }
         return parts
     }
@@ -205,6 +217,15 @@ Rectangle {
         id: thawDatePicker
         onDateSelected: function(dateString) {
             MainController.bagStorage.requestUpdateBag(card.bag.id, { "defrostDate": dateString })
+        }
+    }
+
+    // "Mark Opened" quick action for non-frozen bags (bean-freshness-followup),
+    // the non-frozen analogue of thawDatePicker.
+    DatePickerDialog {
+        id: openedDatePicker
+        onDateSelected: function(dateString) {
+            MainController.bagStorage.requestUpdateBag(card.bag.id, { "openedDate": dateString })
         }
     }
 
@@ -411,7 +432,10 @@ Rectangle {
             }
 
             // Frozen bag: "Thaw" records the latest portion leaving the
-            // freezer — calendar picker, defaulting to today.
+            // freezer — calendar picker, always defaulting to today (a new
+            // thaw event happening today is overwhelmingly the common case;
+            // pass "" so the picker's "default to today" branch wins over any
+            // stored defrostDate).
             AccessibleButton {
                 visible: card.isFrozen
                 height: Theme.scaled(36)
@@ -420,7 +444,21 @@ Rectangle {
                 rightPadding: Theme.scaled(10)
                 text: TranslationManager.translate("bagcard.thaw", "Thaw")
                 accessibleName: TranslationManager.translate("bagcard.accessible.thaw", "Thaw: pick the date the latest portion left the freezer")
-                onClicked: thawDatePicker.openWithDate(card.defrostDate)
+                onClicked: thawDatePicker.openWithDate("")
+            }
+
+            // Non-frozen bag: "Mark Opened" is the equivalent quick action —
+            // records when the current portion started being used. Same picker
+            // pattern as Thaw, always defaulting to today.
+            AccessibleButton {
+                visible: !card.isFrozen
+                height: Theme.scaled(36)
+                _customFontSize: Theme.captionFont.pixelSize
+                leftPadding: Theme.scaled(10)
+                rightPadding: Theme.scaled(10)
+                text: TranslationManager.translate("bagcard.markOpened", "Mark Opened")
+                accessibleName: TranslationManager.translate("bagcard.accessible.markOpened", "Mark opened: pick the date this bag was opened")
+                onClicked: openedDatePicker.openWithDate("")
             }
 
             // No shots yet: the bag is a mistaken creation — offer delete

--- a/qml/components/BeanSummary.qml
+++ b/qml/components/BeanSummary.qml
@@ -3,15 +3,16 @@ import QtQuick.Layouts
 import Decenza
 
 // Read-only adaptive one-line bean summary ("show less when more is known"):
-//   canonical-linked  ->  "{coffee} · {origin} · {process} · Roasted <date> [· Def Md | Frozen]"
+//   canonical-linked  ->  "{coffee} · {origin} · {process} · Roasted <date> [· Thawed <date> (Md) | Frozen | Opened <date> (Md)]"
 //                         with a small verified badge
-//   history only      ->  "{roaster} {coffee} · Roasted <date> [· Def Md | Frozen]"
+//   history only      ->  "{roaster} {coffee} · Roasted <date> [· Thawed <date> (Md) | Frozen | Opened <date> (Md)]"
 //                         + "Link to Bean Base" nudge
 //   no roast date     ->  roast-date portion silently omitted (no placeholder)
 //   no bag selected   ->  "No beans selected"
 //
 // Roast shows the actual date (the user freezes beans, so days-since-roast is
-// misleading); defrost shows days-out-of-freezer (a real freshness clock).
+// misleading); the thaw/open line shows the absolute date plus days-since (a
+// real freshness clock for the current portion).
 //
 // Two data sources: live DYE state (default — brew/idle contexts) or
 // explicitly set shot-snapshot properties (useShotData: true — detail pages).
@@ -27,6 +28,9 @@ Item {
     property string beanBaseData: ""
     property string frozenDate: ""
     property string defrostDate: ""
+    // Non-frozen storage lifecycle (bean-freshness-followup): opened date, the
+    // non-frozen analogue of the defrost date.
+    property string openedDate: ""
 
     // Effective values for the active mode
     readonly property string effRoaster: useShotData ? roasterName : Settings.dye.dyeBeanBrand
@@ -35,6 +39,7 @@ Item {
     readonly property string effBeanBaseData: useShotData ? beanBaseData : Settings.dye.dyeBeanBaseData
     readonly property string effFrozenDate: useShotData ? frozenDate : Settings.dye.activeBagFrozenDate
     readonly property string effDefrostDate: useShotData ? defrostDate : Settings.dye.activeBagDefrostDate
+    readonly property string effOpenedDate: useShotData ? openedDate : Settings.dye.activeBagOpenedDate
 
     readonly property var beanBase: {
         if (!effBeanBaseData || effBeanBaseData.length === 0) return ({})
@@ -99,9 +104,15 @@ Item {
         if (effDefrostDate.length > 0) {
             var defAge = daysSince(effDefrostDate)
             if (defAge >= 0)
-                parts.push(TranslationManager.translate("beans.summary.defrostDays", "Def %1d").arg(defAge))
+                parts.push(TranslationManager.translate("beans.summary.thawedDate", "Thawed %1 (%2d)")
+                    .arg(formatRoastDate(effDefrostDate)).arg(defAge))
         } else if (effFrozenDate.length > 0) {
             parts.push(TranslationManager.translate("beans.summary.frozen", "Frozen"))
+        } else if (effOpenedDate.length > 0) {
+            var openAge = daysSince(effOpenedDate)
+            if (openAge >= 0)
+                parts.push(TranslationManager.translate("beans.summary.openedDate", "Opened %1 (%2d)")
+                    .arg(formatRoastDate(effOpenedDate)).arg(openAge))
         }
         return parts
     }

--- a/qml/components/ChangeBeansDialog.qml
+++ b/qml/components/ChangeBeansDialog.qml
@@ -82,6 +82,11 @@ Dialog {
     property bool fFreeze: false
     property string fFrozenDate: ""
     property string fDefrostDate: ""
+    // Non-frozen storage lifecycle (bean-freshness-followup). storageHint is a
+    // category tag ("" = unset); openedDate is the non-frozen analogue of the
+    // defrost date. Both apply only while the freeze toggle is OFF.
+    property string fStorageHint: ""
+    property string fOpenedDate: ""
 
     // Bean details (add-bag-detail-editing): the descriptive working keys of
     // the beanBaseData blob, editable for linked and manual bags alike. A
@@ -349,6 +354,7 @@ Dialog {
         fRpm = ""
         fDose = ""; fYield = ""; fNotes = ""
         fFreeze = false; fFrozenDate = ""; fDefrostDate = ""
+        fStorageHint = ""; fOpenedDate = ""
         syncDetailFieldsFromBlob()   // blob is empty: clears every detail field
         detailsExpanded = false
         _openedLink = ""
@@ -431,6 +437,8 @@ Dialog {
         fFrozenDate = bag.frozenDate || ""
         fDefrostDate = bag.defrostDate || ""
         fFreeze = fFrozenDate.length > 0
+        fStorageHint = bag.storageHint || ""
+        fOpenedDate = bag.openedDate || ""
         mode = "form"
         _armedForm = true
         open()
@@ -470,7 +478,9 @@ Dialog {
             "beanBaseId": bag.beanBaseId ? String(bag.beanBaseId) : "",
             "bagId": bagId,
             "frozenDate": bag.frozenDate || "",
-            "defrostDate": bag.defrostDate || ""
+            "defrostDate": bag.defrostDate || "",
+            "storageHint": bag.storageHint || "",
+            "openedDate": bag.openedDate || ""
         })
     }
 
@@ -543,7 +553,10 @@ Dialog {
             "doseWeightG": parseWeight(fDose),
             "yieldOverrideG": parseWeight(fYield),
             "notes": fNotes,
-            "frozenDate": fFreeze ? (fFrozenDate.length === 10 ? fFrozenDate : todayIso()) : ""
+            "frozenDate": fFreeze ? (fFrozenDate.length === 10 ? fFrozenDate : todayIso()) : "",
+            // Non-frozen storage hint: cleared to "" whenever the bag is frozen
+            // (the dropdown is hidden, not merely disabled with a stale value).
+            "storageHint": fFreeze ? "" : fStorageHint
         }
         // kind is stamped at creation only (immutable identity; the edit
         // path never writes it).
@@ -551,6 +564,10 @@ Dialog {
             fields["kind"] = bagKind
         if (formMode === "edit") {
             fields["defrostDate"] = fFreeze ? (fDefrostDate.length === 10 ? fDefrostDate : "") : ""
+            // openedDate is the non-frozen analogue of defrostDate — edit-mode
+            // only (the "Mark Opened" quick action on the bag card is the
+            // everyday path), and cleared when the bag is frozen.
+            fields["openedDate"] = fFreeze ? "" : (fOpenedDate.length === 10 ? fOpenedDate : "")
             // Re-point the bag's equipment package (<=0 -> NULL via the column hook).
             fields["equipmentId"] = fEquipmentId
             // A link change fixes the whole bag: propagate the (new or
@@ -742,6 +759,7 @@ Dialog {
         textFields: [searchField, roasterInput.textField, coffeeInput.textField, roastDateField.textField,
                      grindSettingInput, doseInput, yieldInput,
                      notesInput, frozenDateField.textField, defrostDateField.textField,
+                     openedDateField.textField,
                      originField.textField, regionField.textField, farmField.textField,
                      producerField.textField, varietyField.textField, elevationField.textField,
                      processField.textField, harvestField.textField, qualityScoreField.textField,
@@ -1673,6 +1691,48 @@ Dialog {
                         fieldAccessibleName: TranslationManager.translate("changebeans.form.defrostDate.accessible", "Defrost date, optional.")
                         calendarAccessibleName: TranslationManager.translate("changebeans.form.defrostDate.openCalendar", "Open calendar to pick defrost date")
                         onValueEdited: function(dateString) { root.fDefrostDate = dateString }
+                    }
+
+                    // --- Non-frozen storage (bean-freshness-followup): only
+                    // meaningful while NOT frozen, so both hide once the freeze
+                    // toggle is on (frozen state is fully expressed by the
+                    // freeze toggle + frozen date). storageHint has no "frozen"
+                    // value by design. ---
+                    FieldRow {
+                        visible: !root.fFreeze
+                        labelKey: "changebeans.form.storageHint"
+                        labelFallback: "Storage:"
+
+                        StyledComboBox {
+                            id: storageHintCombo
+                            Layout.fillWidth: true
+                            // Canonical enum values (index-aligned with model);
+                            // index 0 = unset ("").
+                            readonly property var hintValues: ["", "counter", "airtight", "vacuum-sealed", "fridge"]
+                            accessibleLabel: TranslationManager.translate("changebeans.form.storageHint.accessible", "Storage type")
+                            model: [
+                                TranslationManager.translate("changebeans.form.storageHint.unset", "Not specified"),
+                                TranslationManager.translate("changebeans.form.storageHint.counter", "Counter"),
+                                TranslationManager.translate("changebeans.form.storageHint.airtight", "Airtight container"),
+                                TranslationManager.translate("changebeans.form.storageHint.vacuum", "Vacuum-sealed"),
+                                TranslationManager.translate("changebeans.form.storageHint.fridge", "Fridge")]
+                            currentIndex: Math.max(0, hintValues.indexOf(root.fStorageHint))
+                            onActivated: root.fStorageHint = currentIndex > 0 ? hintValues[currentIndex] : ""
+                        }
+                    }
+
+                    // Opened date is only directly editable in edit mode
+                    // ("Mark Opened" on the bag card is the everyday path),
+                    // mirroring the defrost field above.
+                    BeanDateField {
+                        id: openedDateField
+                        visible: !root.fFreeze && root.formMode === "edit"
+                        labelKey: "changebeans.form.openedDate"
+                        labelFallback: "Opened:"
+                        value: root.fOpenedDate
+                        fieldAccessibleName: TranslationManager.translate("changebeans.form.openedDate.accessible", "Opened date, optional.")
+                        calendarAccessibleName: TranslationManager.translate("changebeans.form.openedDate.openCalendar", "Open calendar to pick opened date")
+                        onValueEdited: function(dateString) { root.fOpenedDate = dateString }
                     }
 
                     // --- Grinder setting + dose (the per-bag dial-in fields).

--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -74,10 +74,10 @@ double effectiveTargetWeightG(const ShotProjection& shot)
     return twVal > 0 ? twVal : 0.0;
 }
 
-// Per-shot serializer for dialInSessions. Identity overrides come from
-// the per-session `hoistSessionContext` output; per-shot entries emit
-// the five identity fields only when they differ from the session
-// context (otherwise the field is hoisted and absent here).
+// Per-shot serializer for dialInSessions. Identity/lifecycle overrides come
+// from the per-session `hoistSessionContext` output; per-shot entries emit
+// the identity and storage-lifecycle fields only when they differ from the
+// session context (otherwise the field is hoisted and absent here).
 QJsonObject shotToJson(const ShotProjection& shot,
                        const DialingHelpers::ShotIdentity& override)
 {
@@ -110,6 +110,18 @@ QJsonObject shotToJson(const ShotProjection& shot,
         h["beanBrand"] = override.beanBrand;
     if (!override.beanType.isEmpty())
         h["beanType"] = override.beanType;
+    // Bean storage lifecycle (bean-freshness-followup): emitted per-shot only
+    // when it differs from the session context (e.g. a session spanning a thaw
+    // or open event), so the AI can tell a best-rated anchor came from a
+    // different, longer-rested portion. Hoisted to context otherwise.
+    if (!override.frozenDate.isEmpty())
+        h["frozenDate"] = override.frozenDate;
+    if (!override.defrostDate.isEmpty())
+        h["defrostDate"] = override.defrostDate;
+    if (!override.storageHint.isEmpty())
+        h["storageHint"] = override.storageHint;
+    if (!override.openedDate.isEmpty())
+        h["openedDate"] = override.openedDate;
     h["notes"] = shot.espressoNotes;
     // #1161: why the shot ended. stoppedBy varies shot-to-shot (a session
     // can mix a SAW shot and a manually-aborted one), so it is NOT hoisted
@@ -168,6 +180,10 @@ QJsonArray buildDialInSessionsBlock(QSqlDatabase& db,
             id.grinderBurrs = s.grinderBurrs;
             id.beanBrand = s.beanBrand;
             id.beanType = s.beanType;
+            id.frozenDate = s.frozenDate;
+            id.defrostDate = s.defrostDate;
+            id.storageHint = s.storageHint;
+            id.openedDate = s.openedDate;
             identities.append(id);
         }
         const DialingHelpers::HoistedSession hoisted =
@@ -251,6 +267,17 @@ QJsonArray buildDialInSessionsBlock(QSqlDatabase& db,
             contextObj["beanBrand"] = hoisted.context.beanBrand;
         if (!hoisted.context.beanType.isEmpty())
             contextObj["beanType"] = hoisted.context.beanType;
+        // Bean storage lifecycle (bean-freshness-followup): hoisted to the
+        // session context when shared across every shot, overridden per-shot
+        // when a session spans a thaw/open event (see shotToJson).
+        if (!hoisted.context.frozenDate.isEmpty())
+            contextObj["frozenDate"] = hoisted.context.frozenDate;
+        if (!hoisted.context.defrostDate.isEmpty())
+            contextObj["defrostDate"] = hoisted.context.defrostDate;
+        if (!hoisted.context.storageHint.isEmpty())
+            contextObj["storageHint"] = hoisted.context.storageHint;
+        if (!hoisted.context.openedDate.isEmpty())
+            contextObj["openedDate"] = hoisted.context.openedDate;
         // Issue #1158: hoisted pour control mode — one field for the
         // whole session instead of repeating it on every shot.
         if (pourControlUniform)
@@ -341,6 +368,21 @@ QJsonObject buildBestRecentShotBlock(QSqlDatabase& db,
     b["grinderModel"] = best.grinderModel;
     b["beanBrand"] = best.beanBrand;
     b["beanType"] = best.beanType;
+    // Bean storage lifecycle (bean-freshness-followup): carry the anchor shot's
+    // own snapshotted dates directly (no hoisting — this is a single object).
+    // When they differ from the resolved shot's currentBean.beanFreshness, the
+    // AI has the raw data to notice the anchor came from a different, longer-
+    // rested portion — no precomputed "different portion" flag, the dates are
+    // the whole signal. Sparse-emit: legacy shots with no lifecycle recorded
+    // carry nothing, same as today.
+    if (!best.frozenDate.isEmpty())
+        b["frozenDate"] = best.frozenDate;
+    if (!best.defrostDate.isEmpty())
+        b["defrostDate"] = best.defrostDate;
+    if (!best.storageHint.isEmpty())
+        b["storageHint"] = best.storageHint;
+    if (!best.openedDate.isEmpty())
+        b["openedDate"] = best.openedDate;
     b["notes"] = best.espressoNotes;
     if (best.doseWeightG > 0)
         b["ratio"] = QString("1:%1").arg(best.finalWeightG / best.doseWeightG, 0, 'f', 2);

--- a/src/ai/dialing_blocks.h
+++ b/src/ai/dialing_blocks.h
@@ -187,11 +187,15 @@ struct CurrentBeanBlockInputs {
     QString roastLevel;
     QString roastDate;
     // Bean storage lifecycle (bean-bag-inventory), snapshotted at shot time.
-    // When either is set, buildBeanFreshness reports storage as KNOWN and ages
-    // the beans from the thaw date instead of asking the user. Empty = no
-    // freeze history recorded for this shot.
+    // When any is set, buildBeanFreshness reports storage as KNOWN and ages
+    // the beans from the most recent thaw/open date instead of asking the
+    // user. Empty = no storage history recorded for this shot.
+    // storageHint/openedDate (bean-freshness-followup) are the non-frozen
+    // analogues of frozenDate/defrostDate.
     QString frozenDate;
     QString defrostDate;
+    QString storageHint;
+    QString openedDate;
     QString grinderBrand;
     QString grinderModel;
     QString grinderBurrs;
@@ -233,6 +237,8 @@ inline CurrentBeanBlockInputs beanInputsFromProjection(const ShotProjection& sd)
     in.roastDate = sd.roastDate;
     in.frozenDate = sd.frozenDate;
     in.defrostDate = sd.defrostDate;
+    in.storageHint = sd.storageHint;
+    in.openedDate = sd.openedDate;
     in.grinderBrand = sd.grinderBrand;
     in.grinderModel = sd.grinderModel;
     in.grinderBurrs = sd.grinderBurrs;
@@ -302,7 +308,7 @@ inline QJsonObject buildCurrentBeanBlock(const CurrentBeanBlockInputs& in)
     }
 
     const QJsonObject freshness = DialingHelpers::buildBeanFreshness(
-        in.roastDate, in.frozenDate, in.defrostDate);
+        in.roastDate, in.frozenDate, in.defrostDate, in.storageHint, in.openedDate);
     if (!freshness.isEmpty())
         bean["beanFreshness"] = freshness;
 

--- a/src/ai/dialing_helpers.h
+++ b/src/ai/dialing_helpers.h
@@ -215,7 +215,8 @@ inline constexpr const char* kBeanFreshnessKnownInstruction =
 // Build the `currentBean.beanFreshness` block. Replaces the deprecated
 // `daysSinceRoast` + `daysSinceRoastNote` fields. Returns an empty object
 // (caller suppresses the parent assignment) only when there is nothing to say
-// — no `roastDate` AND no freeze/thaw dates.
+// — no `roastDate`, no freeze/thaw/open date, AND no `storageHint` (a lone
+// `storageHint` still emits the block; see state 2 below).
 //
 // `freshnessKnown` is `true` when the bag carries a `frozenDate`, `defrostDate`,
 // and/or `openedDate` — a precise aging-anchor date exists, so the AI ages the

--- a/src/ai/dialing_helpers.h
+++ b/src/ai/dialing_helpers.h
@@ -50,18 +50,29 @@ inline QList<QList<qsizetype>> groupSessions(const QList<qint64>& timestampsDesc
     return sessions;
 }
 
-// The five shot-identity fields hoistable to a session-level `context`
-// object. These describe the user's *setup* (which grinder, which bean) —
-// shot-INVARIANT across a single dial-in session in the typical case.
-// Shot-VARIABLE fields (`grinderSetting`, `doseWeightG`, `finalWeightG`,
-// `durationSec`, `enjoyment0to100`, `notes`) are NOT hoisted; they are
-// what the user is iterating on.
+// The shot-identity fields hoistable to a session-level `context` object.
+// These describe the user's *setup* (which grinder, which bean) plus the bean
+// storage lifecycle — shot-INVARIANT across a single dial-in session in the
+// typical case. Shot-VARIABLE fields (`grinderSetting`, `doseWeightG`,
+// `finalWeightG`, `durationSec`, `enjoyment0to100`, `notes`) are NOT hoisted;
+// they are what the user is iterating on.
 struct ShotIdentity {
     QString grinderBrand;
     QString grinderModel;
     QString grinderBurrs;
     QString beanBrand;
     QString beanType;
+    // Bean storage lifecycle (bean-freshness-followup). Hoisted with the same
+    // "shared → context, differing → per-shot override" discipline as the
+    // identity fields: a session that spans a thaw/open event carries the
+    // shared date in `context` and the differing shot overrides it, giving the
+    // AI the raw data to notice a best-rated anchor came from a different,
+    // longer-rested portion. No precomputed "different portion" flag — the raw
+    // dates are the whole signal.
+    QString frozenDate;
+    QString defrostDate;
+    QString storageHint;
+    QString openedDate;
 };
 
 // Output of `hoistSessionContext`: the field values that go on the
@@ -126,59 +137,135 @@ inline HoistedSession hoistSessionContext(const QList<ShotIdentity>& shots)
     fillField([](const ShotIdentity& s) { return s.beanType; },
               [](ShotIdentity& c, const QString& v) { c.beanType = v; },
               [](ShotIdentity& o, const QString& v) { o.beanType = v; });
+    fillField([](const ShotIdentity& s) { return s.frozenDate; },
+              [](ShotIdentity& c, const QString& v) { c.frozenDate = v; },
+              [](ShotIdentity& o, const QString& v) { o.frozenDate = v; });
+    fillField([](const ShotIdentity& s) { return s.defrostDate; },
+              [](ShotIdentity& c, const QString& v) { c.defrostDate = v; },
+              [](ShotIdentity& o, const QString& v) { o.defrostDate = v; });
+    fillField([](const ShotIdentity& s) { return s.storageHint; },
+              [](ShotIdentity& c, const QString& v) { c.storageHint = v; },
+              [](ShotIdentity& o, const QString& v) { o.storageHint = v; });
+    fillField([](const ShotIdentity& s) { return s.openedDate; },
+              [](ShotIdentity& c, const QString& v) { c.openedDate = v; },
+              [](ShotIdentity& o, const QString& v) { o.openedDate = v; });
 
     return out;
 }
 
-// Instruction shipped when the bag's storage history is UNKNOWN (no freeze
-// or thaw dates recorded). Reads as imperative, not advisory — calendar age
-// is a category-mistake against actual bean freshness when storage history is
-// unknown (frozen, thawed weekly, vacuum-sealed, etc.). The previous advisory
-// note was demonstrably skimmed past; this one tells the AI explicitly to ASK
-// before quoting age.
+// Instruction shipped when no aging-anchor date (frozen/defrost/opened) is
+// recorded. The key teaching is the ASYMMETRY: roastDate is the UPPER BOUND on
+// staleness — freezing / airtight / vacuum storage only PAUSE staling, so beans
+// are never OLDER than their calendar age since roast, only fresher. That makes
+// the ask conditional, not automatic:
+//   - Recent roast  → the beans are fresh no matter how they were stored (the
+//     ceiling is low). Do NOT ask about storage; there's nothing storage could
+//     reveal that changes "fresh."
+//   - Old roast     → genuinely ambiguous (frozen-since-roast and still fresh,
+//     vs left out and stale). ONLY here is the storage/aging question worth
+//     asking. The AI judges "recent vs old" itself — we ship no day count
+//     (same no-precompute rule as the rest of the block).
+// buildBeanFreshness appends a storageHint clause when the storage TYPE is known
+// but no date is: then the AI must not re-ask how the beans are stored (it was
+// told), only — and only if the roast is old — when the current portion started
+// aging.
 inline constexpr const char* kBeanFreshnessInstruction =
-    "Calendar age from roastDate is NOT freshness — many users freeze and "
-    "thaw weekly. ASK the user about storage before applying any "
-    "bean-aging guidance.";
+    "roastDate is the UPPER BOUND on staleness: freezing and airtight/vacuum "
+    "storage only pause staling, so these beans can never be older than their "
+    "calendar age since roast — only fresher. So if the roast date is recent, "
+    "treat the beans as fresh and do NOT ask about storage; nothing storage "
+    "could reveal would make recently-roasted beans stale. ONLY when the roast "
+    "date is old is freshness ambiguous (frozen since roast and still fresh, vs "
+    "left out and staled) — only then ASK how the beans have been stored and "
+    "when this portion started being used, before reasoning about age.";
 
-// Instruction shipped when the bag DOES carry storage history (a frozenDate
-// and/or defrostDate is present). Storage is no longer a missing variable, so
-// the AI must NOT ask about it — and must not treat calendar days from
-// roastDate as staleness. Freezing pauses staling, so the aging clock runs
-// from defrostDate (the thaw), not roastDate: beans frozen since roast and
-// recently thawed are fresh regardless of calendar age.
+// Appended to kBeanFreshnessInstruction (the no-date case) when a storageHint
+// IS known: the storage TYPE is no longer a missing variable, so the AI must
+// not re-ask it. %1 is the storage hint (e.g. "vacuum-sealed").
+inline constexpr const char* kBeanFreshnessStorageHintClause =
+    " The user already told you the storage type (%1), which pauses staling — "
+    "do NOT ask how they store the beans. If the roast is recent, they are "
+    "fresh; only if the roast is old, ask solely when this portion started "
+    "being used (its aging-start date), nothing else.";
+
+// Instruction shipped when the bag DOES carry storage history (a frozenDate,
+// defrostDate, and/or openedDate is present). Storage is no longer a missing
+// variable, so the AI must NOT ask about it — and must not treat calendar days
+// from roastDate as staleness. Freezing/sealing pauses staling, so the aging
+// clock runs from the most recent thaw/open date, not roastDate: beans frozen
+// since roast and recently thawed are fresh regardless of calendar age.
+//
+// It ALSO teaches the reverse direction (bean-freshness-followup): a *recent*
+// thaw/open date does NOT unconditionally mean "fresher is better." Freshly
+// thawed or just-opened beans are often UNDER-RESTED and gassy — they choke the
+// puck, run long, and over-extract, and typically want a COARSER grind that
+// settles back over the following few days as the CO2 degasses. Recent ≠
+// simply better; it can cut in either direction.
 inline constexpr const char* kBeanFreshnessKnownInstruction =
     "Storage history is known from the dates below — do NOT ask the user "
-    "about storage. Freezing pauses staling: count bean age from defrostDate "
-    "(the thaw), not roastDate. Beans frozen since roast and recently thawed "
-    "are fresh regardless of how many calendar days have passed since roast.";
+    "about storage. Freezing (and airtight/vacuum storage) pauses staling: "
+    "count bean age from the most recent of defrostDate/openedDate, not "
+    "roastDate. Beans frozen since roast and recently thawed are fresh "
+    "regardless of how many calendar days have passed since roast. But a "
+    "recent thaw/open cuts BOTH ways: freshly thawed or just-opened beans are "
+    "often under-rested and gassy (they choke the puck, run long, over-extract) "
+    "and usually want a COARSER grind that settles back over the next few days "
+    "as they degas — do NOT assume a recent date just means 'fresher is better.'";
 
 // Build the `currentBean.beanFreshness` block. Replaces the deprecated
 // `daysSinceRoast` + `daysSinceRoastNote` fields. Returns an empty object
 // (caller suppresses the parent assignment) only when there is nothing to say
 // — no `roastDate` AND no freeze/thaw dates.
 //
-// `freshnessKnown` is `true` when the bag carries a `frozenDate` and/or
-// `defrostDate`: that storage history is the variable whose absence the
-// unknown-case instruction asks the user to supply, so its presence flips the
-// guidance from "ASK about storage" to "age from the thaw date." The block
-// still contains NO precomputed day count under any field name — the AI does
-// the subtraction itself (from `defrostDate` when freshness is known).
+// `freshnessKnown` is `true` when the bag carries a `frozenDate`, `defrostDate`,
+// and/or `openedDate` — a precise aging-anchor date exists, so the AI ages the
+// beans from the most recent thaw/open date rather than asking. `openedDate`
+// (bean-freshness-followup) is the non-frozen analogue of `defrostDate` — a
+// never-frozen bag that has simply been opened reports KNOWN too, so the common
+// non-freezer user isn't asked about storage forever.
+//
+// The instruction has THREE states, not two:
+//   1. No date, no storageHint → upper-bound instruction: roastDate caps
+//      staleness (storage only preserves), so ask about storage ONLY when the
+//      roast is old; recent roast = fresh, no question needed.
+//   2. No date, storageHint set → (1) plus a clause telling the AI the storage
+//      TYPE is already known (don't re-ask it) — at most ask for the aging-start
+//      date, and only if the roast is old. `freshnessKnown` stays false: a hint
+//      without a date is not a precise anchor.
+//   3. A date is set → the known-storage instruction (age from the thaw/open
+//      date, with the under-rested/gassy reverse-direction guidance).
+// `storageHint` is surfaced verbatim whenever set. The block still contains NO
+// precomputed day count under any field name — the AI judges "recent vs old"
+// and does the subtraction itself.
 //
 // Pure function: easy to unit-test, no DB / Settings dependency.
 inline QJsonObject buildBeanFreshness(const QString& roastDate,
                                       const QString& frozenDate = QString(),
-                                      const QString& defrostDate = QString())
+                                      const QString& defrostDate = QString(),
+                                      const QString& storageHint = QString(),
+                                      const QString& openedDate = QString())
 {
-    const bool known = !frozenDate.isEmpty() || !defrostDate.isEmpty();
-    if (roastDate.isEmpty() && !known) return QJsonObject();
+    const bool known = !frozenDate.isEmpty() || !defrostDate.isEmpty()
+                       || !openedDate.isEmpty();
+    if (roastDate.isEmpty() && !known && storageHint.isEmpty()) return QJsonObject();
     QJsonObject block;
     if (!roastDate.isEmpty()) block["roastDate"] = roastDate;
     if (!frozenDate.isEmpty()) block["frozenDate"] = frozenDate;
     if (!defrostDate.isEmpty()) block["defrostDate"] = defrostDate;
+    if (!storageHint.isEmpty()) block["storageHint"] = storageHint;
+    if (!openedDate.isEmpty()) block["openedDate"] = openedDate;
     block["freshnessKnown"] = known;
-    block["instruction"] = QString::fromUtf8(
-        known ? kBeanFreshnessKnownInstruction : kBeanFreshnessInstruction);
+    if (known) {
+        block["instruction"] = QString::fromUtf8(kBeanFreshnessKnownInstruction);
+    } else {
+        // No aging-anchor date. Teach the upper-bound asymmetry (ask only when
+        // the roast is old); when the storage TYPE is known but the date isn't,
+        // append the clause that tells the AI not to re-ask the storage method.
+        QString instruction = QString::fromUtf8(kBeanFreshnessInstruction);
+        if (!storageHint.isEmpty())
+            instruction += QString::fromUtf8(kBeanFreshnessStorageHintClause).arg(storageHint);
+        block["instruction"] = instruction;
+    }
     return block;
 }
 

--- a/src/ai/shotsummarizer.cpp
+++ b/src/ai/shotsummarizer.cpp
@@ -1002,17 +1002,30 @@ QString ShotSummarizer::shotAnalysisSystemPrompt(const QString& beverageType, co
         "the single-shot rule above, it extends it to a run of untasted shots.\n\n"
         "**`currentBean.beanFreshness`**: carries an optional `roastDate`, a\n"
         "`freshnessKnown` flag, and an `instruction`. When `freshnessKnown` is\n"
-        "`false`, storage is\n"
-        "unknown — NEVER quote calendar age; ASK the user about storage first\n"
-        "(many users freeze beans and thaw weekly, so calendar days from\n"
-        "`roastDate` are not freshness without storage context). When\n"
-        "`freshnessKnown` is `true`, the block also carries `frozenDate` and/or\n"
-        "`defrostDate`: storage IS known, so do NOT ask — freezing pauses\n"
-        "staling, so age the beans from `defrostDate` (the thaw), not `roastDate`.\n"
-        "Always follow the block's `instruction` field.\n\n"
+        "`false`, no precise aging-anchor date is recorded — but `roastDate` is\n"
+        "the UPPER BOUND on staleness: freezing/airtight/vacuum storage only\n"
+        "pauses staling, so beans are never older than their calendar age since\n"
+        "roast, only fresher. So a RECENT roast means fresh regardless of storage\n"
+        "— do NOT ask about storage. Only when the roast is OLD is freshness\n"
+        "ambiguous (frozen-and-fresh vs left-out-and-stale); only then ask. If a\n"
+        "`storageHint` is present the storage type is already known — never\n"
+        "re-ask it; at most ask (when the roast is old) for the aging-start date.\n"
+        "When\n"
+        "`freshnessKnown` is `true`, the block also carries a `frozenDate`,\n"
+        "`defrostDate`, and/or `openedDate` (and an optional `storageHint` such\n"
+        "as `airtight`/`vacuum-sealed`): storage IS known, so do NOT ask — age\n"
+        "the beans from the most recent of `defrostDate`/`openedDate`, not\n"
+        "`roastDate`. But a RECENT thaw/open cuts both ways: freshly thawed or\n"
+        "just-opened beans are often under-rested and gassy — they choke the\n"
+        "puck, run long, and over-extract, and usually want a COARSER grind that\n"
+        "settles back over the next few days as they degas. Do NOT read a recent\n"
+        "date as simply 'fresher is better.' Always follow the block's\n"
+        "`instruction` field.\n\n"
         "**`dialInSessions[].context`**: hoists shot-identity fields shared across\n"
         "an iteration session (`grinderBrand`, `grinderModel`, `grinderBurrs`,\n"
-        "`beanBrand`, `beanType`). When a per-shot entry under `shots[]` omits\n"
+        "`beanBrand`, `beanType`, and the bean storage-lifecycle dates\n"
+        "`frozenDate`/`defrostDate`/`storageHint`/`openedDate`). When a per-shot\n"
+        "entry under `shots[]` omits\n"
         "one of these fields, that shot uses the session's `context` value.\n"
         "When a per-shot entry carries the field directly, it overrides the\n"
         "context for that shot only. CAVEAT: a hoisted context value reflects\n"
@@ -1609,7 +1622,7 @@ QString ShotSummarizer::sharedForbiddenSimplifications()
 Never give these generic responses without evidence from the data AND checking profile intent:
 - **"Grind finer/coarser"** without supporting evidence (flow rate, shot time, or taste) OR checking if it contradicts the profile intent — state what you observed and why it suggests a grind change.
 - **"Pressure/Time/Ratio should be X"** — the DE1 uses intentional profiles where "non-standard" values are often the goal.
-- **"Your beans are old/stale"** — roast date alone does not indicate staleness. Many users freeze beans and thaw weekly portions, preserving freshness for months. If roast date seems old, ask about storage conditions before assuming degradation.
+- **"Your beans are old/stale"** — roast date alone does not indicate staleness. Many users freeze beans and thaw weekly portions, or keep them airtight/vacuum-sealed, preserving freshness for months. If roast date seems old and storage is unknown (`freshnessKnown: false`), ask about storage before assuming degradation. And do not assume the opposite either: when a `defrostDate`/`openedDate` is recent, the beans may be UNDER-rested and gassy (choking the puck, running long) rather than "fresher" — a recent storage date can call for a coarser grind that settles over the following days, not a finer one.
 )");
 }
 

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -3027,6 +3027,8 @@ void MainController::onShotEnded() {
     metadata.bagId = m_settings->dye()->activeBagId();
     metadata.frozenDate = m_settings->dye()->activeBagFrozenDate();
     metadata.defrostDate = m_settings->dye()->activeBagDefrostDate();
+    metadata.storageHint = m_settings->dye()->activeBagStorageHint();
+    metadata.openedDate = m_settings->dye()->activeBagOpenedDate();
     // Recipe provenance (add-recipes): the recipe active at shot time and
     // the steam spec in effect, so promote-from-shot round-trips the drink.
     metadata.recipeId = m_settings->dye()->activeRecipeId();
@@ -3284,6 +3286,8 @@ void MainController::uploadPendingShot() {
     metadata.bagId = m_settings->dye()->activeBagId();
     metadata.frozenDate = m_settings->dye()->activeBagFrozenDate();
     metadata.defrostDate = m_settings->dye()->activeBagDefrostDate();
+    metadata.storageHint = m_settings->dye()->activeBagStorageHint();
+    metadata.openedDate = m_settings->dye()->activeBagOpenedDate();
     // Recipe provenance (add-recipes): the recipe active at shot time and
     // the steam spec in effect, so promote-from-shot round-trips the drink.
     metadata.recipeId = m_settings->dye()->activeRecipeId();
@@ -3446,6 +3450,8 @@ void MainController::generateFakeShotData() {
             metadata.bagId = m_settings->dye()->activeBagId();
             metadata.frozenDate = m_settings->dye()->activeBagFrozenDate();
             metadata.defrostDate = m_settings->dye()->activeBagDefrostDate();
+            metadata.storageHint = m_settings->dye()->activeBagStorageHint();
+            metadata.openedDate = m_settings->dye()->activeBagOpenedDate();
             metadata.recipeId = m_settings->dye()->activeRecipeId();
             metadata.steamJson = currentSteamSpecJson();
             metadata.hotWaterJson = currentHotWaterSpecJson();

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -74,9 +74,14 @@ void SettingsDye::setBagStorage(CoffeeBagStorage* storage)
                     m_keepFieldsOnNextApply = false;
                     const QString frozen = bag.value("frozenDate").toString();
                     const QString defrost = bag.value("defrostDate").toString();
-                    if (frozen != m_activeBagFrozenDate || defrost != m_activeBagDefrostDate) {
+                    const QString storageHint = bag.value("storageHint").toString();
+                    const QString opened = bag.value("openedDate").toString();
+                    if (frozen != m_activeBagFrozenDate || defrost != m_activeBagDefrostDate
+                        || storageHint != m_activeBagStorageHint || opened != m_activeBagOpenedDate) {
                         m_activeBagFrozenDate = frozen;
                         m_activeBagDefrostDate = defrost;
+                        m_activeBagStorageHint = storageHint;
+                        m_activeBagOpenedDate = opened;
                         emit activeBagChanged();
                     }
                     return;
@@ -627,6 +632,8 @@ void SettingsDye::setActiveBagId(int bagId) {
         m_applyingBag = false;
         m_activeBagFrozenDate.clear();
         m_activeBagDefrostDate.clear();
+        m_activeBagStorageHint.clear();
+        m_activeBagOpenedDate.clear();
         m_activeBagYieldOverrideG = 0;  // no bag → no override
         emit activeBagChanged();
         return;
@@ -648,6 +655,8 @@ void SettingsDye::setActiveBagKeepFields(int bagId)
         m_settings.setValue("dye/activeBagId", -1);
         m_activeBagFrozenDate.clear();
         m_activeBagDefrostDate.clear();
+        m_activeBagStorageHint.clear();
+        m_activeBagOpenedDate.clear();
         emit activeBagIdChanged();
         emit activeBagChanged();
         return;
@@ -696,9 +705,14 @@ void SettingsDye::applyActiveBag(const QVariantMap& bag)
 
     const QString frozen = bag.value("frozenDate").toString();
     const QString defrost = bag.value("defrostDate").toString();
-    if (frozen != m_activeBagFrozenDate || defrost != m_activeBagDefrostDate) {
+    const QString storageHint = bag.value("storageHint").toString();
+    const QString opened = bag.value("openedDate").toString();
+    if (frozen != m_activeBagFrozenDate || defrost != m_activeBagDefrostDate
+        || storageHint != m_activeBagStorageHint || opened != m_activeBagOpenedDate) {
         m_activeBagFrozenDate = frozen;
         m_activeBagDefrostDate = defrost;
+        m_activeBagStorageHint = storageHint;
+        m_activeBagOpenedDate = opened;
         emit activeBagChanged();
     }
 

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -84,6 +84,10 @@ class SettingsDye : public QObject {
     // shot snapshot (read-only here; edited via CoffeeBagStorage).
     Q_PROPERTY(QString activeBagFrozenDate READ activeBagFrozenDate NOTIFY activeBagChanged)
     Q_PROPERTY(QString activeBagDefrostDate READ activeBagDefrostDate NOTIFY activeBagChanged)
+    // Non-frozen storage lifecycle (bean-freshness-followup): storage category
+    // and opened date of the active bag.
+    Q_PROPERTY(QString activeBagStorageHint READ activeBagStorageHint NOTIFY activeBagChanged)
+    Q_PROPERTY(QString activeBagOpenedDate READ activeBagOpenedDate NOTIFY activeBagChanged)
 
 public:
     // visualizer is non-owning and must outlive this object (Settings owns both).
@@ -229,6 +233,8 @@ public:
     Q_INVOKABLE void setActiveBagKeepFields(int bagId);
     QString activeBagFrozenDate() const { return m_activeBagFrozenDate; }
     QString activeBagDefrostDate() const { return m_activeBagDefrostDate; }
+    QString activeBagStorageHint() const { return m_activeBagStorageHint; }
+    QString activeBagOpenedDate() const { return m_activeBagOpenedDate; }
 
     // Active recipe (add-recipes). Persisted id only — see the Q_PROPERTY note.
     int activeRecipeId() const;
@@ -315,6 +321,8 @@ private:
     int m_pendingSelfWrites = 0; // Outstanding write-throughs whose bagUpdated echo to skip
     QString m_activeBagFrozenDate;
     QString m_activeBagDefrostDate;
+    QString m_activeBagStorageHint;
+    QString m_activeBagOpenedDate;
     double m_activeBagYieldOverrideG = 0;  // active bag's yield override (0 = none)
 
     // Cached DYE values (avoid QSettings::value() → CFPreferences on every QML binding read)

--- a/src/history/coffeebagstorage.cpp
+++ b/src/history/coffeebagstorage.cpp
@@ -254,6 +254,26 @@ TeaBrewingData CoffeeBag::teaBrewingFromBlob(const QString& beanBaseData)
     return data;
 }
 
+// static
+const QStringList& CoffeeBag::storageHintValues()
+{
+    // Mirror in QML: ChangeBeansDialog `hintValues`. No "frozen" — frozen state
+    // is defined solely by frozenDate (bean-freshness-followup design).
+    static const QStringList values = {
+        QStringLiteral("counter"),
+        QStringLiteral("airtight"),
+        QStringLiteral("vacuum-sealed"),
+        QStringLiteral("fridge"),
+    };
+    return values;
+}
+
+// static
+bool CoffeeBag::isValidStorageHint(const QString& hint)
+{
+    return hint.isEmpty() || storageHintValues().contains(hint);
+}
+
 CoffeeBagStorage::CoffeeBagStorage(QObject* parent)
     : QObject(parent)
 {

--- a/src/history/coffeebagstorage.cpp
+++ b/src/history/coffeebagstorage.cpp
@@ -132,6 +132,14 @@ const BagCol kCols[] = {
     COL_STR  ("beanbase_json",         beanBaseData,        true),
     COL_STR  ("frozen_date",           frozenDate,          true),
     COL_STR  ("defrost_date",          defrostDate,         true),
+    // Non-frozen storage lifecycle (bean-freshness-followup). Local-only
+    // (visualizer=false): the AI reads them, but Visualizer's coffee-bag
+    // record has no equivalent field, so an edit touching only these two
+    // must NOT trigger a bag PATCH (touchesVisualizerFields stays false).
+    // Unlike frozen_date/defrost_date above (visualizer=true — they map to
+    // Visualizer's frozen_date/defrosted_date), these have no remote home.
+    COL_STR  ("storage_hint",          storageHint,         false),
+    COL_STR  ("opened_date",           openedDate,          false),
     COL_STR  ("notes",                 notes,               true),
     COL_DBL  ("start_weight_g",        startWeightG),
     COL_BOOL ("in_inventory",          inInventory),
@@ -454,6 +462,8 @@ bool CoffeeBagStorage::ensureTableStatic(QSqlDatabase& db)
             beanbase_json TEXT,
             frozen_date TEXT,
             defrost_date TEXT,
+            storage_hint TEXT,
+            opened_date TEXT,
             notes TEXT,
             start_weight_g REAL,
             in_inventory INTEGER NOT NULL DEFAULT 1,

--- a/src/history/coffeebagstorage.h
+++ b/src/history/coffeebagstorage.h
@@ -53,10 +53,17 @@ struct CoffeeBag {
     // brewTempC, leafGramsPer100Ml, …) live in the beanBaseData blob.
     QString kind = QStringLiteral("coffee");
 
-    // Lifecycle. frozenDate/defrostDate describe the CURRENT portion only —
-    // the defrost history lives in per-shot snapshots.
+    // Lifecycle. frozenDate/defrostDate/storageHint/openedDate describe the
+    // CURRENT portion only — the full history lives in per-shot snapshots.
+    // storageHint is a non-frozen storage category (counter / airtight /
+    // vacuum-sealed / fridge — never "frozen"; frozen state is defined solely
+    // by frozenDate being set). openedDate is the non-frozen analogue of
+    // defrostDate: when the current portion started being actively used at
+    // room temperature. Both are local-only (never synced to Visualizer).
     QString frozenDate;
     QString defrostDate;
+    QString storageHint;
+    QString openedDate;
     QString notes;
     double startWeightG = 0; // 0 = unset; local-only, never synced to Visualizer
     bool inInventory = true;

--- a/src/history/coffeebagstorage.h
+++ b/src/history/coffeebagstorage.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QHash>
 #include <QString>
+#include <QStringList>
 #include <QVariantList>
 #include <QVariantMap>
 #include <QVector>
@@ -108,6 +109,17 @@ struct CoffeeBag {
     // Parse the tea brewing keys out of a beanBaseData blob string. Tolerant:
     // empty/invalid JSON or absent keys land on the struct defaults.
     static TeaBrewingData teaBrewingFromBlob(const QString& beanBaseData);
+
+    // Canonical non-frozen storageHint values (bean-freshness-followup). The
+    // single C++ source of truth for the enum; the QML dropdown
+    // (ChangeBeansDialog `hintValues`) must mirror it. "frozen" is deliberately
+    // NOT a value — frozen state is defined solely by `frozenDate` being set,
+    // so the two can never disagree.
+    static const QStringList& storageHintValues();
+    // Accepts "" (unset) or any canonical value; rejects "frozen" and junk.
+    // The write boundary uses this so an off-list value from an MCP client
+    // can't reach the DB (and thence the AI freshness block) unvalidated.
+    static bool isValidStorageHint(const QString& hint);
 };
 
 // An inventory row: a bag plus its shot count. The count is NOT a CoffeeBag

--- a/src/history/shothistory_types.h
+++ b/src/history/shothistory_types.h
@@ -88,6 +88,11 @@ struct ShotRecord {
     qint64 bagId = -1;
     QString frozenDate;
     QString defrostDate;
+    // Non-frozen storage lifecycle snapshot (bean-freshness-followup,
+    // migration 32): the bag's storage_hint / opened_date at shot time, the
+    // non-frozen analogue of frozenDate/defrostDate. "" = unset.
+    QString storageHint;
+    QString openedDate;
 
     // Recipe provenance (add-recipes, migration 25): the recipe active at
     // shot start (<= 0 = none / pre-recipe shot) and the steam-spec snapshot
@@ -282,6 +287,10 @@ struct ShotSaveData {
     qint64 bagId = -1;
     QString frozenDate;
     QString defrostDate;
+    // Non-frozen storage lifecycle snapshot (bean-freshness-followup): see
+    // ShotRecord. "" = unset.
+    QString storageHint;
+    QString openedDate;
 
     // Recipe provenance (add-recipes): see ShotRecord. <= 0 = none.
     qint64 recipeId = -1;

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1547,6 +1547,42 @@ bool ShotHistoryStorage::runMigrations()
         }
     }
 
+    // Migration 32: non-frozen storage lifecycle (bean-freshness-followup).
+    // storage_hint (a non-frozen storage category) and opened_date (the
+    // non-frozen analogue of defrost_date) join the existing freeze-lifecycle
+    // fields on BOTH tables: coffee_bags (the current-portion state) AND shots
+    // (the per-shot snapshot, so historical shots record which storage regime
+    // they were pulled under). The shots columns mirror frozen_date/defrost_date
+    // added by migration 19 — the shot-save INSERT, shot-read SELECT, and
+    // device-transfer INSERT all name them. Additive with NULL defaults, no
+    // backfill (existing bags/shots simply have both unset). Fresh DBs get the
+    // coffee_bags columns from ensureTableStatic and the shots columns here (the
+    // shots CREATE TABLE omits the lifecycle columns, same as frozen_date). The
+    // hasColumn guards make both paths converge. Idempotent, gated
+    // ">= 31 && < 32", mirroring migration 31. Whitespace before the open-paren
+    // dodges the QSqlQuery permission-hook false-positive; do not auto-format.
+    if (currentVersion >= 31 && currentVersion < 32) {
+        qDebug() << "ShotHistoryStorage: Running migration to version 32 (storage hint + opened date)";
+
+        if (!hasColumn("coffee_bags", "storage_hint"))
+            query.exec ("ALTER TABLE coffee_bags ADD COLUMN storage_hint TEXT");
+        if (!hasColumn("coffee_bags", "opened_date"))
+            query.exec ("ALTER TABLE coffee_bags ADD COLUMN opened_date TEXT");
+        if (!hasColumn("shots", "storage_hint"))
+            query.exec ("ALTER TABLE shots ADD COLUMN storage_hint TEXT");
+        if (!hasColumn("shots", "opened_date"))
+            query.exec ("ALTER TABLE shots ADD COLUMN opened_date TEXT");
+
+        if (hasColumn("coffee_bags", "storage_hint") && hasColumn("coffee_bags", "opened_date")
+            && hasColumn("shots", "storage_hint") && hasColumn("shots", "opened_date")) {
+            query.exec ("DELETE FROM schema_version");
+            query.exec ("INSERT INTO schema_version (version) VALUES (32)");
+            currentVersion = 32;
+        } else {
+            qWarning() << "ShotHistoryStorage: migration 32 incomplete - will retry next launch";
+        }
+    }
+
     m_schemaVersion = currentVersion;
     return true;
 }
@@ -1718,6 +1754,8 @@ qint64 ShotHistoryStorage::saveShot(ShotDataModel* shotData,
     data.bagId = metadata.bagId;
     data.frozenDate = metadata.frozenDate;
     data.defrostDate = metadata.defrostDate;
+    data.storageHint = metadata.storageHint;
+    data.openedDate = metadata.openedDate;
     data.recipeId = metadata.recipeId;
     data.steamJson = metadata.steamJson;
     data.hotWaterJson = metadata.hotWaterJson;
@@ -1893,7 +1931,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     channeling_detected, grind_issue_detected,
                     skip_first_frame_detected, pour_truncated_detected,
                     stopped_by, beanbase_json, beanbase_id,
-                    bag_id, frozen_date, defrost_date,
+                    bag_id, frozen_date, defrost_date, storage_hint, opened_date,
                     recipe_id, steam_json, hot_water_json
                 ) VALUES (
                     :uuid, :timestamp, :profile_name, :profile_json, :beverage_type,
@@ -1907,7 +1945,7 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
                     :channeling_detected, :grind_issue_detected,
                     :skip_first_frame_detected, :pour_truncated_detected,
                     :stopped_by, :beanbase_json, :beanbase_id,
-                    :bag_id, :frozen_date, :defrost_date,
+                    :bag_id, :frozen_date, :defrost_date, :storage_hint, :opened_date,
                     :recipe_id, :steam_json, :hot_water_json
                 )
             )");
@@ -1956,6 +1994,8 @@ qint64 ShotHistoryStorage::saveShotStatic(const QString& dbPath, const ShotSaveD
             query.bindValue(":bag_id", bagIdIsSet(data.bagId) ? QVariant(data.bagId) : QVariant());
             query.bindValue(":frozen_date", data.frozenDate.isEmpty() ? QVariant() : data.frozenDate);
             query.bindValue(":defrost_date", data.defrostDate.isEmpty() ? QVariant() : data.defrostDate);
+            query.bindValue(":storage_hint", data.storageHint.isEmpty() ? QVariant() : data.storageHint);
+            query.bindValue(":opened_date", data.openedDate.isEmpty() ? QVariant() : data.openedDate);
             query.bindValue(":recipe_id", data.recipeId > 0 ? QVariant(data.recipeId) : QVariant());
             query.bindValue(":steam_json", data.steamJson.isEmpty() ? QVariant() : data.steamJson);
             query.bindValue(":hot_water_json", data.hotWaterJson.isEmpty() ? QVariant() : data.hotWaterJson);
@@ -2484,7 +2524,8 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
                ep.in_inventory, ep.superseded_by, ep.name,
                eb.brand, eb.model,
                epp.model,
-               s.recipe_id, s.steam_json, s.hot_water_json
+               s.recipe_id, s.steam_json, s.hot_water_json,
+               s.storage_hint, s.opened_date
         FROM shots s
         LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder'
         LEFT JOIN equipment_items eb ON eb.package_id = s.equipment_id AND eb.kind = 'basket'
@@ -2574,6 +2615,11 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     record.recipeId = query.value(47).isNull() ? -1 : query.value(47).toLongLong();
     record.steamJson = query.value(48).toString();
     record.hotWaterJson = query.value(49).toString();
+    // Non-frozen storage lifecycle snapshot (cols 50/51, bean-freshness-
+    // followup): the non-frozen analogue of frozen_date/defrost_date. Appended
+    // at the end of the SELECT so existing positional reads keep their indices.
+    record.storageHint = query.value(50).toString();
+    record.openedDate = query.value(51).toString();
     record.summary.hasVisualizerUpload = !record.visualizerId.isEmpty();
 
     // Snapshot stored badge values before the recompute block overwrites them, so
@@ -2862,6 +2908,8 @@ bool ShotHistoryStorage::updateShotMetadataStatic(QSqlDatabase& db, qint64 shotI
         {"bagId",           "bag_id"},
         {"frozenDate",      "frozen_date"},
         {"defrostDate",     "defrost_date"},
+        {"storageHint",     "storage_hint"},
+        {"openedDate",      "opened_date"},
     };
 
     // Build SET clause from only the keys present in the metadata.
@@ -3370,6 +3418,12 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
             const int idxBagId = srcRecord.indexOf("bag_id");
             const int idxFrozenDate = srcRecord.indexOf("frozen_date");
             const int idxDefrostDate = srcRecord.indexOf("defrost_date");
+            // Non-frozen storage lifecycle (bean-freshness-followup): carried
+            // verbatim like frozen_date/defrost_date. Present only on
+            // post-migration-32 sources → NULL on older ones (idx == -1),
+            // so a pre-32 source imports cleanly rather than failing per row.
+            const int idxStorageHint = srcRecord.indexOf("storage_hint");
+            const int idxOpenedDate = srcRecord.indexOf("opened_date");
             // equipment_id (a source package row id, remapped) + rpm exist only
             // on post-migration-22 sources (add-equipment-packages). Older
             // sources lack both — they resolve to NULL.
@@ -3409,9 +3463,9 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                         channeling_detected, grind_issue_detected,
                         skip_first_frame_detected, pour_truncated_detected,
                         stopped_by, beanbase_json, beanbase_id,
-                        bag_id, frozen_date, defrost_date,
+                        bag_id, frozen_date, defrost_date, storage_hint, opened_date,
                         recipe_id, steam_json, hot_water_json)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 )");
 
                 insert.addBindValue(uuid);
@@ -3470,6 +3524,8 @@ bool ShotHistoryStorage::importDatabaseStatic(const QString& destDbPath, const Q
                 }
                 insert.addBindValue(srcValueOrNull(idxFrozenDate));
                 insert.addBindValue(srcValueOrNull(idxDefrostDate));
+                insert.addBindValue(srcValueOrNull(idxStorageHint));
+                insert.addBindValue(srcValueOrNull(idxOpenedDate));
                 // recipe_id is a row id in the SOURCE database — remap to the
                 // imported recipe's new id, or NULL when the recipe wasn't
                 // imported (so provenance never dangles). steam_json and

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -1564,14 +1564,22 @@ bool ShotHistoryStorage::runMigrations()
     if (currentVersion >= 31 && currentVersion < 32) {
         qDebug() << "ShotHistoryStorage: Running migration to version 32 (storage hint + opened date)";
 
-        if (!hasColumn("coffee_bags", "storage_hint"))
-            query.exec ("ALTER TABLE coffee_bags ADD COLUMN storage_hint TEXT");
-        if (!hasColumn("coffee_bags", "opened_date"))
-            query.exec ("ALTER TABLE coffee_bags ADD COLUMN opened_date TEXT");
-        if (!hasColumn("shots", "storage_hint"))
-            query.exec ("ALTER TABLE shots ADD COLUMN storage_hint TEXT");
-        if (!hasColumn("shots", "opened_date"))
-            query.exec ("ALTER TABLE shots ADD COLUMN opened_date TEXT");
+        if (!hasColumn("coffee_bags", "storage_hint")
+            && !query.exec ("ALTER TABLE coffee_bags ADD COLUMN storage_hint TEXT"))
+            qWarning() << "ShotHistoryStorage: migration 32 add coffee_bags.storage_hint failed -"
+                       << query.lastError().text();
+        if (!hasColumn("coffee_bags", "opened_date")
+            && !query.exec ("ALTER TABLE coffee_bags ADD COLUMN opened_date TEXT"))
+            qWarning() << "ShotHistoryStorage: migration 32 add coffee_bags.opened_date failed -"
+                       << query.lastError().text();
+        if (!hasColumn("shots", "storage_hint")
+            && !query.exec ("ALTER TABLE shots ADD COLUMN storage_hint TEXT"))
+            qWarning() << "ShotHistoryStorage: migration 32 add shots.storage_hint failed -"
+                       << query.lastError().text();
+        if (!hasColumn("shots", "opened_date")
+            && !query.exec ("ALTER TABLE shots ADD COLUMN opened_date TEXT"))
+            qWarning() << "ShotHistoryStorage: migration 32 add shots.opened_date failed -"
+                       << query.lastError().text();
 
         if (hasColumn("coffee_bags", "storage_hint") && hasColumn("coffee_bags", "opened_date")
             && hasColumn("shots", "storage_hint") && hasColumn("shots", "opened_date")) {

--- a/src/history/shothistorystorage_queries.cpp
+++ b/src/history/shothistorystorage_queries.cpp
@@ -557,7 +557,8 @@ QVariantList ShotHistoryStorage::loadRecentShotsByKbIdStatic(QSqlDatabase& db, c
                json_extract(eg.attrs, '$.burrs') AS grinder_burrs,
                s.grinder_setting, s.drink_tds, s.drink_ey, s.enjoyment,
                s.espresso_notes, s.roast_date, s.temperature_override, s.yield_override, s.profile_json, s.beverage_type,
-               s.stopped_by
+               s.stopped_by,
+               s.frozen_date, s.defrost_date, s.storage_hint, s.opened_date
         FROM shots s
         LEFT JOIN equipment_items eg ON eg.package_id = s.equipment_id AND eg.kind = 'grinder'
         WHERE s.profile_kb_id = ?
@@ -604,6 +605,20 @@ QVariantList ShotHistoryStorage::loadRecentShotsByKbIdStatic(QSqlDatabase& db, c
             shot["targetWeightG"] = query.value("yield_override").toDouble();
             shot["profileJson"] = query.value("profile_json").toString();
             shot["beverageType"] = query.value("beverage_type").toString();
+            // Bean storage lifecycle (bean-freshness-followup): needed for the
+            // dialInSessions per-shot hoist/override. Sparse-emit so an unset
+            // field stays absent from the map (ShotProjection::fromVariantMap
+            // defaults it empty), matching the toVariantMap sparse convention.
+            {
+                const QString fd = query.value("frozen_date").toString();
+                if (!fd.isEmpty()) shot["frozenDate"] = fd;
+                const QString dd = query.value("defrost_date").toString();
+                if (!dd.isEmpty()) shot["defrostDate"] = dd;
+                const QString sh = query.value("storage_hint").toString();
+                if (!sh.isEmpty()) shot["storageHint"] = sh;
+                const QString od = query.value("opened_date").toString();
+                if (!od.isEmpty()) shot["openedDate"] = od;
+            }
             // #1161: sparse-emit (see ShotProjection::toVariantMap) so a
             // future consumer of this map can't surface "profileEnd"/"".
             {

--- a/src/history/shothistorystorage_serialize.cpp
+++ b/src/history/shothistorystorage_serialize.cpp
@@ -86,6 +86,8 @@ ShotProjection ShotHistoryStorage::convertShotRecord(const ShotRecord& record)
     p.bagId = record.bagId;
     p.frozenDate = record.frozenDate;
     p.defrostDate = record.defrostDate;
+    p.storageHint = record.storageHint;
+    p.openedDate = record.openedDate;
     p.recipeId = record.recipeId;
     p.steamJson = record.steamJson;
     p.hotWaterJson = record.hotWaterJson;

--- a/src/history/shotprojection.cpp
+++ b/src/history/shotprojection.cpp
@@ -63,6 +63,10 @@ QVariantMap ShotProjection::toVariantMap() const
         m["frozenDate"] = frozenDate;
     if (!defrostDate.isEmpty())
         m["defrostDate"] = defrostDate;
+    if (!storageHint.isEmpty())
+        m["storageHint"] = storageHint;
+    if (!openedDate.isEmpty())
+        m["openedDate"] = openedDate;
     // Recipe provenance (add-recipes) — sparse-emit like the bag snapshot.
     if (recipeId > 0)
         m["recipeId"] = recipeId;
@@ -160,6 +164,8 @@ ShotProjection ShotProjection::fromVariantMap(const QVariantMap& m)
     p.bagId = m.value("bagId", -1).toLongLong();
     p.frozenDate = m.value("frozenDate").toString();
     p.defrostDate = m.value("defrostDate").toString();
+    p.storageHint = m.value("storageHint").toString();
+    p.openedDate = m.value("openedDate").toString();
     p.recipeId = m.value("recipeId", -1).toLongLong();
     p.steamJson = m.value("steamJson").toString();
     p.hotWaterJson = m.value("hotWaterJson").toString();

--- a/src/history/shotprojection.h
+++ b/src/history/shotprojection.h
@@ -90,6 +90,10 @@ class ShotProjection {
     Q_PROPERTY(qint64 bagId MEMBER bagId)
     Q_PROPERTY(QString frozenDate MEMBER frozenDate)
     Q_PROPERTY(QString defrostDate MEMBER defrostDate)
+    // Non-frozen storage lifecycle snapshot (bean-freshness-followup): storage
+    // category + opened date at shot time (ISO date, "" = unset).
+    Q_PROPERTY(QString storageHint MEMBER storageHint)
+    Q_PROPERTY(QString openedDate MEMBER openedDate)
     // Recipe provenance (add-recipes): the recipe active at shot time
     // (<= 0 = none) and the steam-spec snapshot — the composer's
     // promote-from-shot prefill reads these.
@@ -178,6 +182,8 @@ public:
     QString steamJson;
     QString hotWaterJson;
     QString defrostDate;
+    QString storageHint;
+    QString openedDate;
 
     bool channelingDetected = false;
     bool grindIssueDetected = false;

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -1668,6 +1668,19 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 respond(QJsonObject{{"error", "Valid bagId is required"}});
                 return;
             }
+            // Reject an off-list storageHint loudly rather than writing junk the
+            // AI freshness block would then surface verbatim. "" clears it;
+            // "frozen" is intentionally invalid (freeze state = frozenDate).
+            if (args.contains("storageHint")) {
+                const QString hint = args["storageHint"].toString();
+                if (!CoffeeBag::isValidStorageHint(hint)) {
+                    respond(QJsonObject{{"error",
+                        QStringLiteral("storageHint must be one of %1 (or '' to clear); "
+                                       "there is no 'frozen' value — set frozenDate instead")
+                            .arg(CoffeeBag::storageHintValues().join(QStringLiteral(", ")))}});
+                    return;
+                }
+            }
             QVariantMap fields;
             static const QStringList kEditable = {
                 "roasterName", "coffeeName", "roastDate", "roastLevel",

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -1532,6 +1532,8 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
         if (!bag.roastLevel.isEmpty()) obj["roastLevel"] = bag.roastLevel;
         if (!bag.frozenDate.isEmpty()) obj["frozenDate"] = bag.frozenDate;
         if (!bag.defrostDate.isEmpty()) obj["defrostDate"] = bag.defrostDate;
+        if (!bag.storageHint.isEmpty()) obj["storageHint"] = bag.storageHint;
+        if (!bag.openedDate.isEmpty()) obj["openedDate"] = bag.openedDate;
         if (!bag.notes.isEmpty()) obj["notes"] = bag.notes;
         obj["inInventory"] = bag.inInventory;
         if (!bag.grinderBrand.isEmpty()) obj["grinderBrand"] = bag.grinderBrand;
@@ -1604,8 +1606,10 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
         "origin/variety/process/tasting notes/product URL). Only provided fields change. Pass an "
         "empty string to clear a text/date field. Setting inInventory=false marks the bag empty "
         "(removes it from the inventory view; shots keep their snapshots). Setting defrostDate "
-        "records a thaw (the latest portion leaving the freezer). Bean-detail edits keep a "
-        "canonical Bean Base link intact and sync to the user's Visualizer bag when one is linked.",
+        "records a thaw (the latest portion leaving the freezer); openedDate is the non-frozen "
+        "analogue (when a never-frozen portion started being used). storageHint is the non-frozen "
+        "storage type (counter/airtight/vacuum-sealed/fridge — never 'frozen'). Bean-detail edits "
+        "keep a canonical Bean Base link intact and sync to the user's Visualizer bag when linked.",
         QJsonObject{
             {"type", "object"},
             {"properties", QJsonObject{
@@ -1616,6 +1620,10 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 {"roastLevel", QJsonObject{{"type", "string"}}},
                 {"frozenDate", QJsonObject{{"type", "string"}, {"description", "YYYY-MM-DD, '' to clear"}}},
                 {"defrostDate", QJsonObject{{"type", "string"}, {"description", "YYYY-MM-DD, '' to clear"}}},
+                {"storageHint", QJsonObject{{"type", "string"},
+                    {"description", "Non-frozen storage: counter/airtight/vacuum-sealed/fridge, '' to clear"}}},
+                {"openedDate", QJsonObject{{"type", "string"},
+                    {"description", "YYYY-MM-DD the non-frozen portion was opened, '' to clear"}}},
                 {"notes", QJsonObject{{"type", "string"}}},
                 {"grinderBrand", QJsonObject{{"type", "string"}}},
                 {"grinderModel", QJsonObject{{"type", "string"}}},
@@ -1663,7 +1671,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             QVariantMap fields;
             static const QStringList kEditable = {
                 "roasterName", "coffeeName", "roastDate", "roastLevel",
-                "frozenDate", "defrostDate", "notes",
+                "frozenDate", "defrostDate", "storageHint", "openedDate", "notes",
                 "grinderBrand", "grinderModel", "grinderBurrs", "grinderSetting",
                 "doseWeightG", "yieldOverrideG", "inInventory"};
             for (const QString& key : kEditable) {

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -45,6 +45,11 @@ struct ShotMetadata {
     qint64 bagId = -1;
     QString frozenDate;   // ISO yyyy-MM-dd, "" = not frozen
     QString defrostDate;  // ISO yyyy-MM-dd, "" = not defrosted
+    // Non-frozen storage lifecycle (bean-freshness-followup): the bag's
+    // storage category and opened date at shot time. Local history only —
+    // not part of the Visualizer upload payload.
+    QString storageHint;  // counter/airtight/vacuum-sealed/fridge, "" = unset
+    QString openedDate;   // ISO yyyy-MM-dd, "" = not opened
 
     // Recipe provenance (add-recipes): the recipe active at shot start
     // (<= 0 = none) and compact-JSON snapshots of the steam and hot-water specs

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -620,14 +620,18 @@ private slots:
             bag.roasterName = "Transfer";
             bag.coffeeName = "Roast";
             bag.frozenDate = "2026-06-01";
+            bag.storageHint = "airtight";       // bean-freshness-followup
+            bag.openedDate = "2026-06-05";
             srcBagId = CoffeeBagStorage::insertBagStatic(db, bag);
             QVERIFY(srcBagId > 0);
-            // Shot linked to the bag, carrying the once-dropped columns.
+            // Shot linked to the bag, carrying the once-dropped columns plus the
+            // non-frozen storage lifecycle snapshot (bean-freshness-followup).
             QSqlQuery q(db);
             q.prepare("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds, "
-                      "bean_brand, bean_type, bag_id, stopped_by, beanbase_json, frozen_date) "
+                      "bean_brand, bean_type, bag_id, stopped_by, beanbase_json, frozen_date, "
+                      "storage_hint, opened_date) "
                       "VALUES ('src-uuid-1', 2000, 'P', 30, 'Transfer', 'Roast', :bag, 'weight', "
-                      "'{\"id\":\"canon-9\"}', '2026-06-01')");
+                      "'{\"id\":\"canon-9\"}', '2026-06-01', 'airtight', '2026-06-05')");
             q.bindValue(":bag", srcBagId);
             QVERIFY(q.exec());
         });
@@ -646,7 +650,8 @@ private slots:
         withRawDb(destPath, "imp_check", [&](QSqlDatabase& db) {
             QSqlQuery q(db);
             QVERIFY(q.exec("SELECT s.bag_id, s.stopped_by, s.beanbase_json, s.beanbase_id, s.frozen_date, "
-                           "b.roaster_name FROM shots s JOIN coffee_bags b ON b.id = s.bag_id "
+                           "b.roaster_name, s.storage_hint, s.opened_date, b.storage_hint, b.opened_date "
+                           "FROM shots s JOIN coffee_bags b ON b.id = s.bag_id "
                            "WHERE s.uuid = 'src-uuid-1'"));
             QVERIFY(q.next());
             QVERIFY(q.value(0).toLongLong() != srcBagId);          // remapped
@@ -655,6 +660,10 @@ private slots:
             QCOMPARE(q.value(3).toString(), QString("canon-9"));    // beanbase_id backfilled
             QCOMPARE(q.value(4).toString(), QString("2026-06-01")); // frozen_date carried
             QCOMPARE(q.value(5).toString(), QString("Transfer"));   // joined to the imported bag
+            QCOMPARE(q.value(6).toString(), QString("airtight"));   // shot storage_hint carried
+            QCOMPARE(q.value(7).toString(), QString("2026-06-05")); // shot opened_date carried
+            QCOMPARE(q.value(8).toString(), QString("airtight"));   // bag storage_hint carried
+            QCOMPARE(q.value(9).toString(), QString("2026-06-05")); // bag opened_date carried
         });
     }
 
@@ -867,7 +876,7 @@ private slots:
             QCOMPARE(q.value(0).toInt(), 0);  // existing rows default to 0
             QVERIFY(q.exec("SELECT version FROM schema_version"));
             QVERIFY(q.next());
-            QCOMPARE(q.value(0).toInt(), 31);  // chain runs on to the latest (recipe temp offset)
+            QCOMPARE(q.value(0).toInt(), 32);  // chain runs on to the latest (storage hint + opened date)
         });
     }
 
@@ -892,6 +901,15 @@ private slots:
             // source column reads as "" and must normalize at bind time
             // (bindKind), not blow up the INSERT with an explicit NULL.
             QVERIFY(q.exec("ALTER TABLE coffee_bags DROP COLUMN kind"));
+            // Non-frozen storage lifecycle (migration 32): a pre-32 source has
+            // neither column on shots or coffee_bags. The shots-side transfer
+            // path resolves the missing columns to NULL via source-column-index
+            // lookup (idx == -1), so the per-row INSERT must NOT warn — the
+            // armed QTest::failOnWarning() in init() catches any "unknown field".
+            QVERIFY(q.exec("ALTER TABLE shots DROP COLUMN storage_hint"));
+            QVERIFY(q.exec("ALTER TABLE shots DROP COLUMN opened_date"));
+            QVERIFY(q.exec("ALTER TABLE coffee_bags DROP COLUMN storage_hint"));
+            QVERIFY(q.exec("ALTER TABLE coffee_bags DROP COLUMN opened_date"));
         });
 
         QVERIFY(ShotHistoryStorage::importDatabaseStatic(destPath, srcPath, /*merge=*/true));
@@ -903,6 +921,15 @@ private slots:
             QVERIFY(!bags.first().bag.visualizerSyncPending);
             QCOMPARE(bags.first().bag.equipmentId, qint64(0));
             QCOMPARE(bags.first().bag.kind, QString("coffee"));
+            // The new lifecycle fields land on their empty defaults.
+            QVERIFY(bags.first().bag.storageHint.isEmpty());
+            QVERIFY(bags.first().bag.openedDate.isEmpty());
+            // The shot imported cleanly (no per-row warning) with both columns NULL.
+            QSqlQuery q(db);
+            QVERIFY(q.exec("SELECT storage_hint, opened_date FROM shots LIMIT 1"));
+            QVERIFY(q.next());
+            QVERIFY(q.value(0).isNull());
+            QVERIFY(q.value(1).isNull());
         });
     }
 
@@ -1148,7 +1175,7 @@ private slots:
             QSqlQuery q(db);
             QVERIFY(q.exec("SELECT version FROM schema_version"));
             QVERIFY(q.next());
-            QCOMPARE(q.value(0).toInt(), 31);  // chain runs on to the latest (recipe temp offset)
+            QCOMPARE(q.value(0).toInt(), 32);  // chain runs on to the latest (storage hint + opened date)
         });
     }
 
@@ -1181,7 +1208,7 @@ private slots:
             QSqlQuery q(db);
             QVERIFY(q.exec("SELECT version FROM schema_version"));
             QVERIFY(q.next());
-            QCOMPARE(q.value(0).toInt(), 31);  // chain runs on to the latest (recipe temp offset)
+            QCOMPARE(q.value(0).toInt(), 32);  // chain runs on to the latest (storage hint + opened date)
             // The repaired table is writable — insertRecipeStatic binds
             // rpm_pinned unconditionally, so it would fail wholesale if the
             // ALTER hadn't landed.

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -933,6 +933,21 @@ private slots:
         });
     }
 
+    // bean-freshness-followup: the canonical storageHint set is the single
+    // C++ source of truth the MCP write boundary validates against. "" (unset)
+    // is valid; "frozen" is deliberately NOT — freeze state is frozenDate.
+    void storageHintValidation() {
+        QVERIFY(CoffeeBag::isValidStorageHint(QString()));           // unset
+        QVERIFY(CoffeeBag::isValidStorageHint(QStringLiteral("counter")));
+        QVERIFY(CoffeeBag::isValidStorageHint(QStringLiteral("airtight")));
+        QVERIFY(CoffeeBag::isValidStorageHint(QStringLiteral("vacuum-sealed")));
+        QVERIFY(CoffeeBag::isValidStorageHint(QStringLiteral("fridge")));
+        QVERIFY2(!CoffeeBag::isValidStorageHint(QStringLiteral("frozen")),
+                 "'frozen' must be rejected — freeze state is defined by frozenDate");
+        QVERIFY(!CoffeeBag::isValidStorageHint(QStringLiteral("Fridge")));   // case-sensitive
+        QVERIFY(!CoffeeBag::isValidStorageHint(QStringLiteral("junk")));
+    }
+
     void rankedProfilesForBean() {
         const QString path = freshDb();
         withRawDb(path, "ranked", [&](QSqlDatabase& db) {

--- a/tests/tst_dbmigration.cpp
+++ b/tests/tst_dbmigration.cpp
@@ -200,7 +200,7 @@ private slots:
             QVERIFY(hasTable(db, "shot_phases"));
             QVERIFY(hasTable(db, "schema_version"));
             QVERIFY(hasTable(db, "recipes"));  // migration 25 (add-recipes)
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
         });
     }
 
@@ -239,6 +239,12 @@ private slots:
             QVERIFY(hasColumn(db, "recipes", "rpm_pinned"));   // migration 26 (add-recipes)
             QVERIFY(hasColumn(db, "recipes", "bag_id"));       // migration 29 (recipes-bag-links)
             QVERIFY(hasColumn(db, "shot_phases", "transition_reason"));
+            // Non-frozen storage lifecycle (migration 32, bean-freshness-followup):
+            // added to BOTH shots and coffee_bags.
+            QVERIFY(hasColumn(db, "shots", "storage_hint"));
+            QVERIFY(hasColumn(db, "shots", "opened_date"));
+            QVERIFY(hasColumn(db, "coffee_bags", "storage_hint"));
+            QVERIFY(hasColumn(db, "coffee_bags", "opened_date"));
         });
     }
 
@@ -279,7 +285,7 @@ private slots:
         initAndClose(path, storage);
 
         withRawDb(path, "v1_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
             QVERIFY(hasColumn(db, "shots", "temperature_override"));
             QVERIFY(hasColumn(db, "shots", "yield_override"));
             QVERIFY(hasColumn(db, "shots", "beverage_type"));
@@ -303,6 +309,12 @@ private slots:
             QVERIFY(hasColumn(db, "recipes", "rpm_pinned"));   // migration 26 (add-recipes)
             QVERIFY(hasColumn(db, "recipes", "bag_id"));       // migration 29 (recipes-bag-links)
             QVERIFY(hasColumn(db, "shot_phases", "transition_reason"));
+            // Non-frozen storage lifecycle (migration 32, bean-freshness-followup):
+            // added to BOTH shots and coffee_bags.
+            QVERIFY(hasColumn(db, "shots", "storage_hint"));
+            QVERIFY(hasColumn(db, "shots", "opened_date"));
+            QVERIFY(hasColumn(db, "coffee_bags", "storage_hint"));
+            QVERIFY(hasColumn(db, "coffee_bags", "opened_date"));
         });
     }
 
@@ -398,7 +410,7 @@ private slots:
         withRawDb(path, "v9_verify", [](QSqlDatabase& db) {
             QVERIFY(hasColumn(db, "shots", "profile_kb_id"));
             QVERIFY(hasIndex(db, "idx_shots_profile_kb_id"));
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
         });
     }
 
@@ -412,7 +424,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "idempotent", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
         });
     }
 
@@ -444,7 +456,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }  // runs migration 30
 
         withRawDb(path, "v29_verify30", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
             QSqlQuery q(db);
             QVERIFY(q.exec(QString("SELECT grind_pinned, rpm_pinned FROM recipes "
                                    "WHERE id = %1").arg(recipeId)));
@@ -479,13 +491,61 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }  // runs migration 31
 
         withRawDb(path, "v30_verify31", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
             QSqlQuery q(db);
             QVERIFY(q.exec(QString("SELECT temp_offset_c, temp_override_c FROM recipes "
                                    "WHERE id = %1").arg(recipeId)));
             QVERIFY(q.next());
             QVERIFY(q.value(0).isNull());              // unconverted marker intact
             QCOMPARE(q.value(1).toDouble(), 87.0);     // legacy absolute untouched
+        });
+    }
+
+    // Migration 32 (bean-freshness-followup) adds storage_hint/opened_date to
+    // BOTH shots and coffee_bags. Existing rows must gain the columns as NULL
+    // (no backfill), on both tables.
+    void v31ToV32AddsStorageHintAndOpenedDate() {
+        QString path = freshDbPath();
+        { ShotHistoryStorage s; initAndClose(path, s); }  // full chain -> latest
+
+        qint64 shotId = 0, bagId = 0;
+        withRawDb(path, "v31_seed", [&](QSqlDatabase& db) {
+            // Rewind to 31 and drop the new columns, simulating a DB that
+            // upgraded to 31 before this migration shipped.
+            QSqlQuery q(db);
+            QVERIFY(q.exec("DELETE FROM schema_version"));
+            QVERIFY(q.exec("INSERT INTO schema_version (version) VALUES (31)"));
+            QVERIFY(q.exec("ALTER TABLE shots DROP COLUMN storage_hint"));
+            QVERIFY(q.exec("ALTER TABLE shots DROP COLUMN opened_date"));
+            QVERIFY(q.exec("ALTER TABLE coffee_bags DROP COLUMN storage_hint"));
+            QVERIFY(q.exec("ALTER TABLE coffee_bags DROP COLUMN opened_date"));
+            QVERIFY(q.exec("INSERT INTO shots (uuid, timestamp, profile_name, duration_seconds) "
+                           "VALUES ('m32-shot', 1000, 'P', 25.0)"));
+            shotId = q.lastInsertId().toLongLong();
+            QVERIFY(q.exec("INSERT INTO coffee_bags (roaster_name, coffee_name) "
+                           "VALUES ('R', 'C')"));
+            bagId = q.lastInsertId().toLongLong();
+        });
+        QVERIFY(shotId > 0);
+        QVERIFY(bagId > 0);
+
+        { ShotHistoryStorage s; initAndClose(path, s); }  // runs migration 32
+
+        withRawDb(path, "v31_verify32", [&](QSqlDatabase& db) {
+            QCOMPARE(getSchemaVersion(db), 32);
+            QVERIFY(hasColumn(db, "shots", "storage_hint"));
+            QVERIFY(hasColumn(db, "shots", "opened_date"));
+            QVERIFY(hasColumn(db, "coffee_bags", "storage_hint"));
+            QVERIFY(hasColumn(db, "coffee_bags", "opened_date"));
+            QSqlQuery q(db);
+            QVERIFY(q.exec(QString("SELECT storage_hint, opened_date FROM shots WHERE id = %1").arg(shotId)));
+            QVERIFY(q.next());
+            QVERIFY2(q.value(0).isNull(), "existing shot row must have NULL storage_hint");
+            QVERIFY2(q.value(1).isNull(), "existing shot row must have NULL opened_date");
+            QVERIFY(q.exec(QString("SELECT storage_hint, opened_date FROM coffee_bags WHERE id = %1").arg(bagId)));
+            QVERIFY(q.next());
+            QVERIFY2(q.value(0).isNull(), "existing bag row must have NULL storage_hint");
+            QVERIFY2(q.value(1).isNull(), "existing bag row must have NULL opened_date");
         });
     }
 
@@ -504,7 +564,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "empty_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
         });
     }
 
@@ -526,7 +586,7 @@ private slots:
         QCoreApplication::processEvents();
 
         withRawDb(path, "null_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
             QSqlQuery q(db);
             // grinder_brand was dropped in migration 23; grinder_setting (the
             // surviving per-shot dial-in) exercises the same NULL-tolerance path.
@@ -706,7 +766,7 @@ private slots:
                 }
             }
         });
-        QCOMPARE(versionFound, 31);  // latest after full chain (recipe temp offset)
+        QCOMPARE(versionFound, 32);  // latest after full chain (storage hint + opened date)
         QVERIFY2(!hasEnjoymentSource,
                  "enjoyment_source column must be absent after migration 16");
     }
@@ -808,7 +868,7 @@ private slots:
             }
         });
 
-        QCOMPARE(versionFound, 31);  // latest after full chain (recipe temp offset)
+        QCOMPARE(versionFound, 32);  // latest after full chain (storage hint + opened date)
         QVERIFY2(columnGone, "enjoyment_source column must be dropped");
         QCOMPARE(enjoy1, 50);
         QCOMPARE(enjoy2, 50);
@@ -1142,7 +1202,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v21_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
             QVERIFY(!hasColumn(db, "coffee_bags", "yield_target_g"));
             QSqlQuery q(db);
@@ -1176,7 +1236,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v28_verify", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
             QVERIFY(hasColumn(db, "recipes", "drink_type"));
             QVERIFY(hasColumn(db, "coffee_bags", "kind"));
             QSqlQuery q(db);
@@ -1256,7 +1316,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v20_after_retry", [&](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
             // The retry ran the WHOLE deferred chain, not just migration 20:
             // migration 21's rename landed too (post-condition column present).
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
@@ -1302,7 +1362,7 @@ private slots:
         { ShotHistoryStorage s; initAndClose(path, s); }
 
         withRawDb(path, "v21_after_retry", [](QSqlDatabase& db) {
-            QCOMPARE(getSchemaVersion(db), 31);
+            QCOMPARE(getSchemaVersion(db), 32);
             QVERIFY(hasColumn(db, "coffee_bags", "yield_override_g"));
             QVERIFY(!hasColumn(db, "coffee_bags", "yield_target_g"));
             QSqlQuery q(db);
@@ -1369,7 +1429,7 @@ private slots:
         };
 
         { ShotHistoryStorage s; initAndClose(path, s); }
-        withRawDb(path, "v22_ver", [](QSqlDatabase& db) { QCOMPARE(getSchemaVersion(db), 31); });
+        withRawDb(path, "v22_ver", [](QSqlDatabase& db) { QCOMPARE(getSchemaVersion(db), 32); });
         QCOMPARE(packageCount(), 1);             // default package created from current settings
         { ShotHistoryStorage s; initAndClose(path, s); }
         QCOMPARE(packageCount(), 1);             // gate prevented a duplicate on re-init

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -71,6 +71,13 @@ struct ShotRow {
     // #1161: why the shot ended → shots.stopped_by. "" by default so
     // existing fixtures are unaffected (sparse-omitted from the blocks).
     QString stoppedBy;
+    // Bean storage lifecycle snapshot (bean-freshness-followup) → shots
+    // frozen_date/defrost_date/storage_hint/opened_date. "" by default so
+    // existing fixtures are unaffected (sparse-omitted from the blocks).
+    QString frozenDate;
+    QString defrostDate;
+    QString storageHint;
+    QString openedDate;
 };
 
 // Run work with a scoped raw SQLite connection on `path`. Same pattern
@@ -115,14 +122,16 @@ qint64 insertShot(QSqlDatabase& db, const ShotRow& r)
             bean_brand, bean_type, roast_level,
             grinder_setting, equipment_id,
             enjoyment, espresso_notes, profile_kb_id,
-            profile_json, yield_override, temperature_override, stopped_by
+            profile_json, yield_override, temperature_override, stopped_by,
+            frozen_date, defrost_date, storage_hint, opened_date
         ) VALUES (
             :uuid, :timestamp, :profile_name, :beverage_type,
             :duration, :final_weight, :dose_weight,
             :bean_brand, :bean_type, :roast_level,
             :grinder_setting, :equipment_id,
             :enjoyment, :espresso_notes, :profile_kb_id,
-            :profile_json, :yield_override, :temperature_override, :stopped_by
+            :profile_json, :yield_override, :temperature_override, :stopped_by,
+            :frozen_date, :defrost_date, :storage_hint, :opened_date
         )
     )"));
     q.bindValue(":uuid", r.uuid);
@@ -144,6 +153,10 @@ qint64 insertShot(QSqlDatabase& db, const ShotRow& r)
     q.bindValue(":yield_override", r.targetWeight);
     q.bindValue(":temperature_override", r.temperatureOverride);
     q.bindValue(":stopped_by", r.stoppedBy);
+    q.bindValue(":frozen_date", r.frozenDate.isEmpty() ? QVariant() : r.frozenDate);
+    q.bindValue(":defrost_date", r.defrostDate.isEmpty() ? QVariant() : r.defrostDate);
+    q.bindValue(":storage_hint", r.storageHint.isEmpty() ? QVariant() : r.storageHint);
+    q.bindValue(":opened_date", r.openedDate.isEmpty() ? QVariant() : r.openedDate);
     if (!q.exec ()) {
         qWarning() << "insertShot failed:" << q.lastError().text();
         return -1;
@@ -291,6 +304,26 @@ private slots:
         QCOMPARE(fresh[QStringLiteral("freshnessKnown")].toBool(), true);
         QCOMPARE(fresh[QStringLiteral("frozenDate")].toString(), QStringLiteral("2026-04-16"));
         QCOMPARE(fresh[QStringLiteral("defrostDate")].toString(), QStringLiteral("2026-06-20"));
+    }
+
+    // bean-freshness-followup: the non-frozen storage lifecycle (storageHint +
+    // openedDate) flows through the same mapper for a never-frozen bag.
+    void beanInputsFromProjection_carriesNonFrozenStorage()
+    {
+        ShotProjection sd;
+        sd.beanBrand = QStringLiteral("Sey");
+        sd.roastDate = QStringLiteral("2026-06-01");
+        sd.storageHint = QStringLiteral("airtight");
+        sd.openedDate = QStringLiteral("2026-06-25");
+
+        const QJsonObject bean = DialingBlocks::buildCurrentBeanBlock(
+            DialingBlocks::beanInputsFromProjection(sd));
+        const QJsonObject fresh = bean[QStringLiteral("beanFreshness")].toObject();
+        QCOMPARE(fresh[QStringLiteral("freshnessKnown")].toBool(), true);
+        QCOMPARE(fresh[QStringLiteral("storageHint")].toString(), QStringLiteral("airtight"));
+        QCOMPARE(fresh[QStringLiteral("openedDate")].toString(), QStringLiteral("2026-06-25"));
+        QVERIFY2(!fresh.contains(QStringLiteral("frozenDate")),
+                 "never-frozen bag must omit frozenDate");
     }
 
     // -------------------------------------------------------------------
@@ -472,6 +505,57 @@ private slots:
             QVERIFY2(!diff.isEmpty(), "changeFromBest must capture grind/yield/duration shifts");
             QCOMPARE(diff.value(QStringLiteral("grinderSetting")).toString(),
                      QStringLiteral("4.0 -> 4.4"));
+        });
+    }
+
+    // -------------------------------------------------------------------
+    // bean-freshness-followup: the best-recent-shot anchor carries its OWN
+    // snapshotted lifecycle dates directly, distinct from the resolved shot —
+    // the raw data the AI needs to notice the anchor came from a different,
+    // longer-rested portion of the same bag. No hoisting, no derived flag.
+    // -------------------------------------------------------------------
+    void bestRecentShotBlock_carriesOwnLifecycleDates()
+    {
+        const QString path = freshDbPath();
+        initAndClose(path);
+
+        const qint64 now = QDateTime::currentSecsSinceEpoch();
+
+        withRawDb(path, QStringLiteral("best_lifecycle"), [&](QSqlDatabase& db) {
+            // Best anchor: an older, longer-rested thaw.
+            ShotRow best;
+            best.uuid = QStringLiteral("uuid-best-lc");
+            best.profileName = QStringLiteral("80's Espresso");
+            best.profileKbId = QStringLiteral("kb-lc");
+            best.beanBrand = QStringLiteral("Northbound");
+            best.timestamp = now - 14 * kSecPerDay;
+            best.doseWeight = 18.0;
+            best.finalWeight = 38.0;
+            best.duration = 30.0;
+            best.enjoyment = 92;
+            best.defrostDate = QStringLiteral("2026-05-01");
+            const qint64 bestId = insertShot(db, best);
+            QVERIFY(bestId > 0);
+
+            // Current shot: a newer thaw (different portion).
+            ShotRow current = best;
+            current.uuid = QStringLiteral("uuid-current-lc");
+            current.timestamp = now - kSecPerDay;
+            current.enjoyment = 70;
+            current.defrostDate = QStringLiteral("2026-05-13");
+            const qint64 currentId = insertShot(db, current);
+            QVERIFY(currentId > 0);
+
+            const ShotProjection currentProj = projectionForShot(db, currentId);
+            const QJsonObject best_ = DialingBlocks::buildBestRecentShotBlock(
+                db, QStringLiteral("kb-lc"), currentId, currentProj);
+
+            QVERIFY(!best_.isEmpty());
+            // The anchor carries its own defrostDate, distinct from the current
+            // shot's 2026-05-13 — the mismatch signal is now visible.
+            QCOMPARE(best_.value(QStringLiteral("defrostDate")).toString(),
+                     QStringLiteral("2026-05-01"));
+            QCOMPARE(currentProj.defrostDate, QStringLiteral("2026-05-13"));
         });
     }
 

--- a/tests/tst_dialing_blocks.cpp
+++ b/tests/tst_dialing_blocks.cpp
@@ -429,6 +429,69 @@ private slots:
     }
 
     // -------------------------------------------------------------------
+    // dialInSessionsBlock — bean-freshness-followup: the storage-lifecycle
+    // fields hoist/override through the REAL block builder, not just the pure
+    // hoistSessionContext helper. Exercises the projection->ShotIdentity copy
+    // (dialing_blocks.cpp), the context emission, and the per-shot override in
+    // shotToJson — the three segments the pure-function test can't reach.
+    // -------------------------------------------------------------------
+    void dialInSessionsBlock_hoistsLifecycleAndOverridesOnThaw()
+    {
+        const QString path = freshDbPath();
+        initAndClose(path);
+        const qint64 now = QDateTime::currentSecsSinceEpoch();
+        const qint64 base = now - 2 * kSecPerDay;
+
+        withRawDb(path, QStringLiteral("dial_lifecycle"), [&](QSqlDatabase& db) {
+            // One session, three shots within ~30 min. All share a storageHint
+            // (should hoist to context); shots 1-2 share a defrostDate and shot
+            // 3 was pulled after a new thaw (should override per-shot).
+            ShotRow b;
+            b.profileName = QStringLiteral("80's Espresso");
+            b.profileKbId = QStringLiteral("kb-lc2");
+            b.beanBrand = QStringLiteral("Northbound");
+            b.grinderModel = QStringLiteral("Zero");
+            b.storageHint = QStringLiteral("airtight");
+
+            ShotRow s1 = b; s1.uuid = QStringLiteral("lc-s1");
+            s1.timestamp = base - 30 * 60; s1.defrostDate = QStringLiteral("2026-05-01");
+            QVERIFY(insertShot(db, s1) > 0);
+            ShotRow s2 = b; s2.uuid = QStringLiteral("lc-s2");
+            s2.timestamp = base - 15 * 60; s2.defrostDate = QStringLiteral("2026-05-01");
+            QVERIFY(insertShot(db, s2) > 0);
+            ShotRow s3 = b; s3.uuid = QStringLiteral("lc-s3");
+            s3.timestamp = base; s3.defrostDate = QStringLiteral("2026-05-13");
+            QVERIFY(insertShot(db, s3) > 0);
+
+            const QJsonArray sessions = DialingBlocks::buildDialInSessionsBlock(
+                db, QStringLiteral("kb-lc2"), -1, 10);
+            QCOMPARE(sessions.size(), 1);
+            const QJsonObject session = sessions[0].toObject();
+            const QJsonObject context = session.value(QStringLiteral("context")).toObject();
+            const QJsonArray shots = session.value(QStringLiteral("shots")).toArray();
+            QCOMPARE(shots.size(), 3);
+
+            // storageHint is uniform -> hoisted to context, absent per-shot.
+            QCOMPARE(context.value(QStringLiteral("storageHint")).toString(),
+                     QStringLiteral("airtight"));
+            for (const QJsonValue& v : shots)
+                QVERIFY2(!v.toObject().contains(QStringLiteral("storageHint")),
+                         "uniform storageHint must hoist to context");
+
+            // defrostDate: shared value hoists; the differing (newest) shot
+            // overrides. Shots are ASC (oldest first): [0]=s1,[1]=s2,[2]=s3.
+            QCOMPARE(context.value(QStringLiteral("defrostDate")).toString(),
+                     QStringLiteral("2026-05-01"));
+            QVERIFY2(!shots[0].toObject().contains(QStringLiteral("defrostDate")),
+                     "shot matching context must not carry an override");
+            QVERIFY2(!shots[1].toObject().contains(QStringLiteral("defrostDate")),
+                     "shot matching context must not carry an override");
+            QCOMPARE(shots[2].toObject().value(QStringLiteral("defrostDate")).toString(),
+                     QStringLiteral("2026-05-13"));
+        });
+    }
+
+    // -------------------------------------------------------------------
     // dialInSessionsBlock — empty when no rows.
     // -------------------------------------------------------------------
     void dialInSessionsBlock_emptyWhenNoRows()
@@ -534,6 +597,12 @@ private slots:
             best.duration = 30.0;
             best.enjoyment = 92;
             best.defrostDate = QStringLiteral("2026-05-01");
+            // Also set the non-frozen lifecycle fields so the appended
+            // positional read (cols 50/51 in loadShotRecordStatic) and the
+            // block-emission branch are both exercised across a real DB read,
+            // not just defrostDate.
+            best.storageHint = QStringLiteral("airtight");
+            best.openedDate = QStringLiteral("2026-05-02");
             const qint64 bestId = insertShot(db, best);
             QVERIFY(bestId > 0);
 
@@ -556,6 +625,14 @@ private slots:
             QCOMPARE(best_.value(QStringLiteral("defrostDate")).toString(),
                      QStringLiteral("2026-05-01"));
             QCOMPARE(currentProj.defrostDate, QStringLiteral("2026-05-13"));
+            // storageHint/openedDate survive the DB read (cols 50/51) and reach
+            // both the projection and the emitted block.
+            QCOMPARE(best_.value(QStringLiteral("storageHint")).toString(),
+                     QStringLiteral("airtight"));
+            QCOMPARE(best_.value(QStringLiteral("openedDate")).toString(),
+                     QStringLiteral("2026-05-02"));
+            QCOMPARE(currentProj.storageHint, QStringLiteral("airtight"));
+            QCOMPARE(currentProj.openedDate, QStringLiteral("2026-05-02"));
         });
     }
 

--- a/tests/tst_dialing_helpers.cpp
+++ b/tests/tst_dialing_helpers.cpp
@@ -26,6 +26,12 @@ private slots:
     void buildBeanFreshness_freezeDates_setKnownAndUseThawInstruction();
     void buildBeanFreshness_emptyRoastButFrozen_stillEmitsKnownBlock();
     void buildBeanFreshness_defrostOnly_isKnown();
+    // bean-freshness-followup
+    void buildBeanFreshness_openedDate_isKnownWithoutFreeze();
+    void buildBeanFreshness_storageHintOnly_surfacedButNotKnown();
+    void buildBeanFreshness_unknownInstruction_teachesUpperBound();
+    void buildBeanFreshness_defrostAndOpened_bothSurfaced();
+    void buildBeanFreshness_knownInstruction_carriesUnderRestedGuidance();
 
     // hoistSessionContext (openspec optimize-dialing-context-payload, task 1)
     void hoistSessionContext_emptySession_returnsEmpty();
@@ -34,6 +40,8 @@ private slots:
     void hoistSessionContext_singleShotSession_contextCarriesIdentity();
     void hoistSessionContext_firstShotEmptyForField_fallsBackToFirstNonEmpty();
     void hoistSessionContext_allShotsEmptyForField_contextOmitsField();
+    // bean-freshness-followup: lifecycle fields hoist like identity fields
+    void hoistSessionContext_sessionSpansThaw_differingShotOverridesDefrost();
 
     // buildShotChangeDiff (issue #1020 — also drives changeFromPrev)
     void buildShotChangeDiff_identicalShots_emptyDiff();
@@ -236,6 +244,111 @@ void TstDialingHelpers::buildBeanFreshness_defrostOnly_isKnown()
     QCOMPARE(block["defrostDate"].toString(), QStringLiteral("2026-06-20"));
 }
 
+// ---- bean-freshness-followup ----
+
+void TstDialingHelpers::buildBeanFreshness_openedDate_isKnownWithoutFreeze()
+{
+    // A never-frozen bag that carries an openedDate (with an airtight storage
+    // hint) reports storage as KNOWN — the common non-freezer user must not be
+    // asked about storage forever. openedDate is the non-frozen analogue of
+    // defrostDate.
+    const QJsonObject block = buildBeanFreshness(QStringLiteral("2026-04-15"),
+                                                 QString(), QString(),
+                                                 QStringLiteral("airtight"),
+                                                 QStringLiteral("2026-06-20"));
+    QCOMPARE(block["freshnessKnown"].toBool(), true);
+    QCOMPARE(block["storageHint"].toString(), QStringLiteral("airtight"));
+    QCOMPARE(block["openedDate"].toString(), QStringLiteral("2026-06-20"));
+    QVERIFY2(!block.contains(QStringLiteral("frozenDate")),
+             "frozenDate must be omitted for a never-frozen bag");
+    QVERIFY2(!block.contains(QStringLiteral("defrostDate")),
+             "defrostDate must be omitted for a never-frozen bag");
+    const QString instruction = block["instruction"].toString();
+    QVERIFY2(!instruction.contains(QStringLiteral("ASK")),
+             "known-storage instruction must NOT ask the user about storage");
+    QVERIFY2(instruction.contains(QStringLiteral("openedDate")),
+             "known instruction must anchor aging on openedDate when present");
+}
+
+void TstDialingHelpers::buildBeanFreshness_storageHintOnly_surfacedButNotKnown()
+{
+    // A storageHint with no dates is surfaced (advisory context) and keeps the
+    // block alive, but does NOT by itself flip freshnessKnown — only a
+    // frozen/defrost/opened DATE anchors the aging clock.
+    const QJsonObject block = buildBeanFreshness(QStringLiteral("2026-07-01"),
+                                                 QString(), QString(),
+                                                 QStringLiteral("vacuum-sealed"),
+                                                 QString());
+    QVERIFY2(!block.isEmpty(),
+             "storageHint alone must keep the block (not omitted)");
+    QCOMPARE(block["storageHint"].toString(), QStringLiteral("vacuum-sealed"));
+    QCOMPARE(block["freshnessKnown"].toBool(), false);
+    // When the storage TYPE is known (but no date), the instruction must NOT
+    // tell the AI to re-ask how the beans are stored — it must name the hint
+    // and, at most, ask only for the aging-start date and only if roast is old.
+    const QString instruction = block["instruction"].toString();
+    QVERIFY2(instruction.contains(QStringLiteral("vacuum-sealed")),
+             "instruction must name the known storage type so the AI doesn't re-ask it");
+    QVERIFY2(instruction.contains(QStringLiteral("do NOT ask how")),
+             "instruction must tell the AI not to re-ask the storage method");
+}
+
+void TstDialingHelpers::buildBeanFreshness_unknownInstruction_teachesUpperBound()
+{
+    // The no-date instruction must teach the asymmetry: roastDate caps
+    // staleness (storage only preserves), so the ask is conditional on the
+    // roast being OLD — recent-roast beans are fresh regardless of storage.
+    const QJsonObject block = buildBeanFreshness(QStringLiteral("2026-07-01"));
+    QCOMPARE(block["freshnessKnown"].toBool(), false);
+    const QString instruction = block["instruction"].toString();
+    QVERIFY2(instruction.contains(QStringLiteral("UPPER BOUND"))
+             || instruction.contains(QStringLiteral("upper bound")),
+             "unknown instruction must frame roastDate as the staleness ceiling");
+    QVERIFY2(instruction.contains(QStringLiteral("recent")),
+             "unknown instruction must carve out the recent-roast = fresh case");
+    QVERIFY2(instruction.contains(QStringLiteral("old")),
+             "unknown instruction must gate the ask on an OLD roast");
+    // A bare storageHint-free block must NOT carry the storage-hint clause.
+    QVERIFY2(!instruction.contains(QStringLiteral("already told you")),
+             "no-hint block must not claim a known storage type");
+}
+
+void TstDialingHelpers::buildBeanFreshness_defrostAndOpened_bothSurfaced()
+{
+    // When both a defrostDate and an openedDate are present (frozen, thawed,
+    // later moved to a jar), both are surfaced distinctly — the AI picks the
+    // most recent as the aging anchor (no precomputed anchor field).
+    const QJsonObject block = buildBeanFreshness(QStringLiteral("2026-04-15"),
+                                                 QStringLiteral("2026-04-16"),
+                                                 QStringLiteral("2026-06-01"),
+                                                 QStringLiteral("counter"),
+                                                 QStringLiteral("2026-06-20"));
+    QCOMPARE(block["freshnessKnown"].toBool(), true);
+    QCOMPARE(block["defrostDate"].toString(), QStringLiteral("2026-06-01"));
+    QCOMPARE(block["openedDate"].toString(), QStringLiteral("2026-06-20"));
+    QCOMPARE(block["storageHint"].toString(), QStringLiteral("counter"));
+    // Still no precomputed day count anywhere.
+    for (const QString& key : block.keys())
+        QVERIFY2(!key.contains(QStringLiteral("Day")),
+                 qPrintable(QString("unexpected day-related key: %1").arg(key)));
+}
+
+void TstDialingHelpers::buildBeanFreshness_knownInstruction_carriesUnderRestedGuidance()
+{
+    // The known-storage instruction must teach the REVERSE direction: a recent
+    // thaw/open can mean under-rested/gassy (coarser grind), not just "fresher."
+    const QJsonObject block = buildBeanFreshness(QStringLiteral("2026-04-15"),
+                                                 QString(),
+                                                 QStringLiteral("2026-06-20"));
+    const QString instruction = block["instruction"].toString();
+    QVERIFY2(instruction.contains(QStringLiteral("gassy"))
+             || instruction.contains(QStringLiteral("under-rested")),
+             "known instruction must warn a recent date can mean under-rested/gassy");
+    QVERIFY2(instruction.contains(QStringLiteral("COARSER"))
+             || instruction.contains(QStringLiteral("coarser")),
+             "known instruction must mention the coarser-grind direction");
+}
+
 // ---- hoistSessionContext (openspec optimize-dialing-context-payload, task 1) ----
 //
 // Empirical anchor: the Northbound 80's Espresso conversation has a 4-shot
@@ -394,6 +507,35 @@ void TstDialingHelpers::hoistSessionContext_allShotsEmptyForField_contextOmitsFi
     for (const auto& override : out.perShotOverrides) {
         QVERIFY(override.grinderBurrs.isEmpty());
     }
+}
+
+void TstDialingHelpers::hoistSessionContext_sessionSpansThaw_differingShotOverridesDefrost()
+{
+    // bean-freshness-followup: a 3-shot session where shots 1-2 were pulled on
+    // one thaw and shot 3 after a new thaw. defrostDate hoists to the shared
+    // value (first shot + majority) and only the differing shot overrides it —
+    // the same mechanism beanBrand/grinderBrand already use, giving the AI the
+    // raw signal that shot 3 came from a different portion.
+    auto withDefrost = [](const QString& defrost) {
+        DialingHelpers::ShotIdentity id;
+        id.grinderBrand = QStringLiteral("Niche");
+        id.beanBrand = QStringLiteral("Northbound");
+        id.defrostDate = defrost;
+        return id;
+    };
+    const QList<DialingHelpers::ShotIdentity> shots{
+        withDefrost(QStringLiteral("2026-05-01")),
+        withDefrost(QStringLiteral("2026-05-01")),
+        withDefrost(QStringLiteral("2026-05-13"))};
+
+    const auto out = hoistSessionContext(shots);
+
+    QCOMPARE(out.context.defrostDate, QStringLiteral("2026-05-01"));
+    QVERIFY2(out.perShotOverrides[0].defrostDate.isEmpty(),
+             "shot 0 matches the context → no override");
+    QVERIFY2(out.perShotOverrides[1].defrostDate.isEmpty(),
+             "shot 1 matches the context → no override");
+    QCOMPARE(out.perShotOverrides[2].defrostDate, QStringLiteral("2026-05-13"));
 }
 
 // ---- buildShotChangeDiff (issue #1020) ----


### PR DESCRIPTION
Closes the three remaining gaps from #1032 after the bean-bag-inventory work (#1327/#1370): the headline `freshnessKnown` bug was already fixed, but a never-frozen bag always reported storage as unknown, the AI only knew one direction of the freshness clock, and historical shots carried no per-shot lifecycle data.

## What changed

**Non-frozen storage lifecycle** — new `storageHint` (counter / airtight / vacuum-sealed / fridge — never "frozen") and `openedDate` on the bag, the non-frozen analogue of `frozenDate`/`defrostDate`. Snapshotted onto every shot (both `coffee_bags` and `shots` gain the columns via migration 32).

**AI reasoning is now correct in both directions:**
- `freshnessKnown` flips on `openedDate` too, so the common non-freezer user isn't asked about storage forever.
- **Three-state instruction.** The key insight (thanks to review discussion): `roastDate` is the *upper bound* on staleness — freezing/vacuum/airtight only *pause* staling, so beans are never older than their calendar age, only fresher. So:
  1. No date, no hint → teach that asymmetry; ask about storage **only when the roast is old** (recent roast = fresh, no question).
  2. Hint but no date → don't re-ask *how* they store it (they told us); at most ask for the aging-start date, and only if the roast is old.
  3. A thaw/open date → age from the most recent of `defrostDate`/`openedDate`, **plus** reverse-direction guidance: a *recent* thaw/open can mean under-rested/gassy (choke, run long) and want a **coarser** grind, not just "fresher."
- Per-shot lifecycle is hoisted in `dialInSessions` and carried on `bestRecentShot`, so the AI can notice a best-rated anchor came from a different, longer-rested portion. No precomputed day counts — the AI does the subtraction.

**MCP** — `bag_update` accepts/documents both fields; `bag_list` emits them.

**UI** — storage-hint dropdown (hidden when frozen) + opened-date field in Change Beans; **Mark Opened** quick action on non-frozen cards mirroring **Thaw**; both pickers default to today; cards show `Thawed/Opened {date} ({N}d)`.

**Manual** — documented (held for release push).

## Verified live
Against the running macOS build via the `decenza` MCP: `bag_update` round-trips `storageHint`/`openedDate`; `dialing_get_context` returns the new three-state instruction (including the upper-bound + "don't re-ask storage" clause for a vacuum-sealed, recently-roasted, no-date bag).

## Tests
Full suite green. New/updated: migration 32; device-transfer round-trip + pre-32 clean import (no per-row warning); `buildBeanFreshness` (opened-only, hint-only, upper-bound, reverse-direction); hoist-across-thaw; bestRecentShot-carries-lifecycle. Stale schema-version-31 "chain runs to latest" assertions bumped to 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)