### PR TITLE
Fix BeanBaseSearchBar teardown TypeError on _setInputText

### DIFF
--- a/qml/components/BeanBaseSearchBar.qml
+++ b/qml/components/BeanBaseSearchBar.qml
@@ -79,7 +79,13 @@ Item {
         MainController.beanbase.search(t)
     }
 
+    // These change handlers can fire while the object is being destroyed
+    // (this bar lives in ChangeBeansDialog on StackView pages; popping the page
+    // re-evaluates the `linked` binding as `root` unwinds). During teardown the
+    // component's JS method table is already gone, so calling _setInputText
+    // throws "is not a function" — guard on it before the call.
     onLinkedChanged: {
+        if (typeof _setInputText !== "function") return  // teardown
         if (linked) {
             resultsPopup.close()
             _setInputText(linkedLabel)
@@ -87,7 +93,7 @@ Item {
             _setInputText("")
         }
     }
-    onLinkedLabelChanged: if (linked) _setInputText(linkedLabel)
+    onLinkedLabelChanged: if (linked && typeof _setInputText === "function") _setInputText(linkedLabel)
     Component.onCompleted: if (linked) _setInputText(linkedLabel)
     onVisibleChanged: if (!visible) resultsPopup.close()
 


### PR DESCRIPTION
## What

Guards the `onLinkedChanged` / `onLinkedLabelChanged` handlers in `BeanBaseSearchBar.qml` against a teardown-time `TypeError`.

## Root cause

The bar lives inside `ChangeBeansDialog`, hosted on StackView pages (`PostShotReviewPage`, `RecipeWizardPage`). When such a page is popped, the dialog's `root` unwinds and the `linked: root.fBeanBaseId.length > 0` binding re-evaluates to `false`, firing `onLinkedChanged` **during destruction**. By then the component's JS method table is gone, so `_setInputText("")` throws:

```
qrc:/…/BeanBaseSearchBar.qml:87: TypeError: Property '_setInputText'
of object BeanBaseSearchBar_QMLTYPE_266 is not a function
```

Found while triaging the DE1 debug log. Fired twice in a single ~19h device session (build 3484), each time immediately preceded by `DelegateModel::cancel: index out range` and followed by a mass QObject teardown (`-611 QQuickAccessibleAttached, -285 QQuickLayoutAttached, …`; total QObjects 13143 → 9085) — confirming the destruction-time trigger.

## Impact

Cosmetic/benign — the text field is being destroyed anyway, so failing to clear its text has no user-visible effect. But it is an app-code QML `TypeError`, so it's worth clearing. Not a recent regression — original to the Bean Base integration (#1322).

## Fix

Guard both change handlers with `typeof _setInputText === "function"` so they no-op once the method is gone. The throw is at the *call site*, so guarding inside `_setInputText` wouldn't help. `Component.onCompleted` can't fire during teardown, so it needs no guard.

## Verification

- Builds clean via Qt Creator (0 errors, 0 warnings); QML cache for `BeanBaseSearchBar` recompiled without complaint.
- Manual check to do on device: open/close the Change Beans dialog from the post-shot review page a few times and confirm the TypeError no longer appears in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)