### PR TITLE
Visualizer recovery: import missing shots by date range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,6 +508,7 @@ set(HEADERS
     src/ui/jscanvascontext.h
     src/network/visualizeruploader.h
     src/network/visualizerimporter.h
+    src/network/visualizershotlist.h
     src/network/beanbaseclient.h
     src/network/beanbase_blob.h
     src/ai/aimanager.h

--- a/qml/pages/settings/SettingsVisualizerTab.qml
+++ b/qml/pages/settings/SettingsVisualizerTab.qml
@@ -55,12 +55,17 @@ KeyboardAwareContainer {
                 .arg(imported).arg(total).arg(skipped).arg(failed)
         }
         function onRecoveryComplete(total, imported, skipped, failed) {
-            visualizerTab.recoverStatusError = false
             if (total === 0) {
+                visualizerTab.recoverStatusError = false
                 visualizerTab.recoverStatus = TranslationManager.translate(
                     "settings.visualizer.recoverNothing",
                     "No shots found in that date range.")
             } else {
+                // Style as an error when nothing came through but shots were
+                // found — otherwise a wholesale failure (schema change, a run of
+                // server errors) reads identically to a clean success. Any
+                // non-zero failure count is worth flagging too.
+                visualizerTab.recoverStatusError = failed > 0
                 visualizerTab.recoverStatus = TranslationManager.translate(
                     "settings.visualizer.recoverDone",
                     "Done: %1 imported, %2 already present, %3 failed (of %4).")
@@ -588,7 +593,7 @@ KeyboardAwareContainer {
                             ? TranslationManager.translate("settings.visualizer.recovering", "Retrieving…")
                             : TranslationManager.translate("settings.visualizer.recoverButton", "Retrieve")
                         accessibleName: TranslationManager.translate(
-                            "settings.visualizer.recoverButton", "Retrieve shots from Visualizer")
+                            "settings.visualizer.recoverButtonA11y", "Retrieve shots from Visualizer")
                         primary: true
                         enabled: visualizerTab.visualizerConnected &&
                                  !MainController.visualizerImporter.recovering

--- a/qml/pages/settings/SettingsVisualizerTab.qml
+++ b/qml/pages/settings/SettingsVisualizerTab.qml
@@ -13,6 +13,80 @@ KeyboardAwareContainer {
     property string testResultMessage: ""
     property bool testResultSuccess: false
 
+    // --- Recover shots from Visualizer (date-range history import) ---
+    // Visualizer is "connected" when both credentials are present.
+    readonly property bool visualizerConnected:
+        Settings.visualizer.visualizerUsername.length > 0 &&
+        Settings.visualizer.visualizerPassword.length > 0
+
+    // Format a JS Date as a local YYYY-MM-DD string.
+    function jsDateToIso(d) {
+        var mm = String(d.getMonth() + 1).padStart(2, '0')
+        var dd = String(d.getDate()).padStart(2, '0')
+        return d.getFullYear() + "-" + mm + "-" + dd
+    }
+
+    // Selected range as YYYY-MM-DD strings (defaults: 30 days ago .. today).
+    property string recoverFromDate: jsDateToIso(
+        new Date(Date.now() - 30 * 24 * 60 * 60 * 1000))
+    property string recoverToDate: jsDateToIso(new Date())
+
+    // Progress line shown while / after a recovery runs.
+    property string recoverStatus: ""
+    property bool recoverStatusError: false
+
+    // Convert a YYYY-MM-DD string to Unix seconds. `endOfDay` pushes to
+    // 23:59:59 local so the "To" bound is inclusive of the whole day.
+    function recoverDateToEpoch(dateStr, endOfDay) {
+        var parts = dateStr.split("-")
+        if (parts.length !== 3) return 0
+        var d = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]),
+                         endOfDay ? 23 : 0, endOfDay ? 59 : 0, endOfDay ? 59 : 0)
+        return Math.floor(d.getTime() / 1000)
+    }
+
+    Connections {
+        target: MainController.visualizerImporter
+        function onRecoveryProgress(total, imported, skipped, failed) {
+            visualizerTab.recoverStatusError = false
+            visualizerTab.recoverStatus = TranslationManager.translate(
+                "settings.visualizer.recoverProgress",
+                "Imported %1 of %2 — %3 skipped (already have), %4 failed")
+                .arg(imported).arg(total).arg(skipped).arg(failed)
+        }
+        function onRecoveryComplete(total, imported, skipped, failed) {
+            visualizerTab.recoverStatusError = false
+            if (total === 0) {
+                visualizerTab.recoverStatus = TranslationManager.translate(
+                    "settings.visualizer.recoverNothing",
+                    "No shots found in that date range.")
+            } else {
+                visualizerTab.recoverStatus = TranslationManager.translate(
+                    "settings.visualizer.recoverDone",
+                    "Done: %1 imported, %2 already present, %3 failed (of %4).")
+                    .arg(imported).arg(skipped).arg(failed).arg(total)
+            }
+        }
+        function onRecoveryFailed(error) {
+            visualizerTab.recoverStatusError = true
+            visualizerTab.recoverStatus = error
+        }
+    }
+
+    DatePickerDialog {
+        id: recoverFromPicker
+        onDateSelected: function(dateString) {
+            if (dateString.length === 10) visualizerTab.recoverFromDate = dateString
+        }
+    }
+
+    DatePickerDialog {
+        id: recoverToPicker
+        onDateSelected: function(dateString) {
+            if (dateString.length === 10) visualizerTab.recoverToDate = dateString
+        }
+    }
+
     RowLayout {
         width: parent.width
         height: parent.height
@@ -171,10 +245,25 @@ KeyboardAwareContainer {
             color: Theme.cardBackgroundColor
             radius: Theme.cardRadius
 
-            ColumnLayout {
+            // Scrollable: this card holds upload + backup + the Recover-shots
+            // section, which together overflow a tablet's height. Without a
+            // Flickable the bottom (recovery) was clipped and unreachable —
+            // matches the left account card's scroll pattern.
+            Flickable {
+                id: visualizerRightFlick
                 anchors.fill: parent
                 anchors.margins: Theme.scaled(15)
-                spacing: Theme.scaled(12)
+                contentWidth: width
+                contentHeight: visualizerRightColumn.implicitHeight
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+                flickableDirection: Flickable.VerticalFlick
+                ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+
+                ColumnLayout {
+                    id: visualizerRightColumn
+                    width: visualizerRightFlick.width
+                    spacing: Theme.scaled(12)
 
                 Tr {
                     key: "settings.visualizer.uploadSettings"
@@ -411,7 +500,131 @@ KeyboardAwareContainer {
                     }
                 }
 
-                Item { Layout.fillHeight: true }
+                // Divider before the recovery section
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.topMargin: Theme.scaled(6)
+                    height: 1
+                    color: Theme.borderColor
+                }
+
+                // --- Recover shots from Visualizer ---
+                Tr {
+                    key: "settings.visualizer.recoverTitle"
+                    fallback: "Recover Shots from Visualizer"
+                    color: Theme.textColor
+                    font.pixelSize: Theme.scaled(16)
+                    font.bold: true
+                }
+
+                Tr {
+                    Layout.fillWidth: true
+                    key: "settings.visualizer.recoverDesc"
+                    fallback: "Import your uploaded shot history back into this device for a date range. Shots you already have are skipped."
+                    color: Theme.textSecondaryColor
+                    font.pixelSize: Theme.scaled(12)
+                    wrapMode: Text.WordWrap
+                }
+
+                // From / To date pickers
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.scaled(15)
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(4)
+
+                        Tr {
+                            key: "settings.visualizer.recoverFrom"
+                            fallback: "From"
+                            color: Theme.textSecondaryColor
+                            font.pixelSize: Theme.scaled(12)
+                        }
+
+                        AccessibleButton {
+                            Layout.fillWidth: true
+                            enabled: !MainController.visualizerImporter.recovering
+                            text: visualizerTab.recoverFromDate
+                            accessibleName: TranslationManager.translate(
+                                "settings.visualizer.recoverFromPick",
+                                "Recovery start date. Currently %1")
+                                .arg(visualizerTab.recoverFromDate)
+                            onClicked: recoverFromPicker.openWithDate(visualizerTab.recoverFromDate)
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(4)
+
+                        Tr {
+                            key: "settings.visualizer.recoverTo"
+                            fallback: "To"
+                            color: Theme.textSecondaryColor
+                            font.pixelSize: Theme.scaled(12)
+                        }
+
+                        AccessibleButton {
+                            Layout.fillWidth: true
+                            enabled: !MainController.visualizerImporter.recovering
+                            text: visualizerTab.recoverToDate
+                            accessibleName: TranslationManager.translate(
+                                "settings.visualizer.recoverToPick",
+                                "Recovery end date. Currently %1")
+                                .arg(visualizerTab.recoverToDate)
+                            onClicked: recoverToPicker.openWithDate(visualizerTab.recoverToDate)
+                        }
+                    }
+                }
+
+                // Retrieve button + progress line
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Theme.scaled(10)
+
+                    AccessibleButton {
+                        text: MainController.visualizerImporter.recovering
+                            ? TranslationManager.translate("settings.visualizer.recovering", "Retrieving…")
+                            : TranslationManager.translate("settings.visualizer.recoverButton", "Retrieve")
+                        accessibleName: TranslationManager.translate(
+                            "settings.visualizer.recoverButton", "Retrieve shots from Visualizer")
+                        primary: true
+                        enabled: visualizerTab.visualizerConnected &&
+                                 !MainController.visualizerImporter.recovering
+                        onClicked: {
+                            visualizerTab.recoverStatusError = false
+                            visualizerTab.recoverStatus = TranslationManager.translate(
+                                "settings.visualizer.recoverStarting", "Looking up your shots…")
+                            MainController.visualizerImporter.recoverShots(
+                                visualizerTab.recoverDateToEpoch(visualizerTab.recoverFromDate, false),
+                                visualizerTab.recoverDateToEpoch(visualizerTab.recoverToDate, true))
+                        }
+                    }
+
+                    Text {
+                        Layout.fillWidth: true
+                        text: visualizerTab.recoverStatus
+                        color: visualizerTab.recoverStatusError ? Theme.errorColor : Theme.textSecondaryColor
+                        font.pixelSize: Theme.scaled(12)
+                        wrapMode: Text.WordWrap
+                        visible: visualizerTab.recoverStatus.length > 0
+                    }
+                }
+
+                // Hint shown when not connected
+                Tr {
+                    Layout.fillWidth: true
+                    key: "settings.visualizer.recoverNotConnected"
+                    fallback: "Connect your Visualizer account above to recover shots."
+                    color: Theme.textSecondaryColor
+                    font.pixelSize: Theme.scaled(12)
+                    wrapMode: Text.WordWrap
+                    visible: !visualizerTab.visualizerConnected
+                }
+
+                    Item { Layout.fillHeight: true }
+                }
             }
         }
     }

--- a/src/history/shotfileparser.cpp
+++ b/src/history/shotfileparser.cpp
@@ -381,14 +381,25 @@ ShotFileParser::ParseResult ShotFileParser::parseVisualizerShot(const QJsonObjec
     // Frame boundaries: the download has no de1app timers block, but it does
     // carry espresso_state_change — a per-sample array that flips sign
     // (+/-10000000) at each frame transition (the same convention Decenza
-    // uploads; see VISUALIZER.md "state_change Array"). Emit a phase marker
-    // at each sign change so the shot-detail view still draws frame lines.
+    // uploads; see VISUALIZER.md "state_change Array"). Emit a phase marker at
+    // the start of frame 0 and at each subsequent sign change, numbered 0,1,2,…
+    // to match the live-shot convention (MainController / ShotDataModel):
+    //   - shot_phases.label is NOT NULL, so every marker MUST carry a non-empty
+    //     label or its INSERT is rejected and the shot silently loses all frame
+    //     lines. Labels are internal (the detail view draws lines by
+    //     time/frameNumber, not text), so a generic "Frame N" is sufficient; it
+    //     must NOT be "Start", which ShotAnalysis::detectSkipFirstFrame treats as
+    //     a synthetic leading marker to skip.
+    //   - a frameNumber==0 marker MUST exist: detectSkipFirstFrame keys off it
+    //     (sawFrameZero). Without it, every recovered shot takes the strict
+    //     firmware-bug branch and is spuriously badged "skipped first frame".
     const QVector<double> stateChange = jsonArrayToDoubles(data.value("espresso_state_change").toArray());
     if (stateChange.size() >= 2 && stateChange.size() <= elapsed.size()) {
         int frameNumber = 0;
-        // Real downloads start the series at 0.0; seed the reference sign from the
-        // first *non-zero* sample so the leading 0 -> ±1e7 step isn't recorded as
-        // a phantom frame boundary at t≈0.
+        // Real downloads start the series at 0.0; the first *non-zero* sample is
+        // where extraction (frame 0) actually begins — emit the frame-0 boundary
+        // there and seed the reference sign, so the leading 0 -> ±1e7 step isn't
+        // double-counted as an extra frame transition.
         bool havePrev = false;
         bool prevPos = false;
         for (qsizetype i = 0; i < stateChange.size(); ++i) {
@@ -396,6 +407,11 @@ ShotFileParser::ParseResult ShotFileParser::parseVisualizerShot(const QJsonObjec
                 continue;
             const bool curPos = stateChange[i] > 0;
             if (!havePrev) {
+                HistoryPhaseMarker marker;
+                marker.time = elapsed[i];
+                marker.frameNumber = 0;             // start of frame 0
+                marker.label = QStringLiteral("Frame 1");
+                result.record.phases.append(marker);
                 prevPos = curPos;
                 havePrev = true;
                 continue;
@@ -404,6 +420,7 @@ ShotFileParser::ParseResult ShotFileParser::parseVisualizerShot(const QJsonObjec
                 HistoryPhaseMarker marker;
                 marker.time = elapsed[i];
                 marker.frameNumber = ++frameNumber;
+                marker.label = QStringLiteral("Frame %1").arg(frameNumber + 1);
                 result.record.phases.append(marker);
                 prevPos = curPos;
             }

--- a/src/history/shotfileparser.cpp
+++ b/src/history/shotfileparser.cpp
@@ -1,5 +1,6 @@
 #include "shotfileparser.h"
 #include "core/grinderaliases.h"
+#include "network/tastecvamap.h"
 #include <QFile>
 #include <QRegularExpression>
 #include <QJsonDocument>
@@ -253,18 +254,13 @@ ShotFileParser::ParseResult ShotFileParser::parseVisualizerShot(const QJsonObjec
     // recovery idempotent (importShotRecord dedupes on uuid first). Feed the
     // visualizer id as the "filename" so it stays stable across runs.
     //
-    // KNOWN LIMITATION (sync-gap case): a shot that was pulled ON THIS DEVICE has a
-    // local uuid keyed on its FILENAME, so this visualizer-id-keyed uuid can never
-    // match it — dedupe then falls to importShotRecord's secondary check
-    // (|timestamp delta| < 5s AND profile_name == profile_title). The timestamp is an
-    // exact round-trip via Visualizer's "clock" field, so the sole discriminator is
-    // the profile title. For a shot THIS app uploaded that matches; but one uploaded
-    // by a different client (e.g. de1app) with a differently-formatted title, or whose
-    // profile was later renamed, can slip past and re-import as a DUPLICATE row (not
-    // corruption — a duplicate). Fresh-install / device-swap recovery (nothing local)
-    // and re-running recovery (deterministic uuid) are both unaffected. A fully robust
-    // key would persist + compare the Visualizer id on the local shot too; deferred as
-    // it touches the shared import/dedupe path.
+    // The sync-gap case — a shot pulled ON THIS DEVICE has a local uuid keyed on
+    // its FILENAME, so this visualizer-id-keyed uuid can't match it — is handled
+    // by importShotRecordStatic's dedicated visualizer_id dedupe probe: it
+    // compares record.visualizerId (set below) against the local shot's
+    // visualizer_id column (populated when that shot was uploaded), the one
+    // identifier guaranteed identical on both sides. So dedupe no longer has to
+    // rely on the weaker timestamp + profile_title fallback for these.
     result.record.summary.uuid = generateUuid(timestamp, visualizerId);
     result.record.visualizerId = visualizerId;
 
@@ -285,6 +281,15 @@ ShotFileParser::ParseResult ShotFileParser::parseVisualizerShot(const QJsonObjec
     if (pressure.isEmpty()) {
         result.errorMessage = "Missing pressure samples";
         return result;
+    }
+    // A pressure series materially shorter than the timeframe means a partial /
+    // truncated upload: toPointVector zips with qMin, so the shot still imports
+    // but with a chopped-off trace. That's better than dropping it, but log so a
+    // systematic upstream truncation is diagnosable rather than silent.
+    if (pressure.size() < elapsed.size() - 1) {
+        qWarning() << "parseVisualizerShot: pressure series truncated for" << visualizerId
+                   << "-" << pressure.size() << "of" << elapsed.size()
+                   << "samples; importing partial trace";
     }
     const QVector<double> flow         = jsonArrayToDoubles(data.value("espresso_flow").toArray());
     const QVector<double> tempBasket   = jsonArrayToDoubles(data.value("espresso_temperature_basket").toArray());
@@ -356,6 +361,15 @@ ShotFileParser::ParseResult ShotFileParser::parseVisualizerShot(const QJsonObjec
     result.record.summary.finalWeight = jsonToScalar(shotJson.value("drink_weight"));
     result.record.summary.beverageType = "espresso";
 
+    // Structured taste axes: reverse the CVA mapping the uploader applies
+    // (tasteBalance/tasteBody → acidity/bitterness/mouthfeel) so a recovered
+    // shot keeps its taste dial-in. See applyTasteCvaMapping in tastecvamap.h.
+    const int acidity    = qRound(jsonToScalar(shotJson.value("acidity")));
+    const int bitterness = qRound(jsonToScalar(shotJson.value("bitterness")));
+    const int mouthfeel  = qRound(jsonToScalar(shotJson.value("mouthfeel")));
+    result.record.tasteBalance = cvaToTasteBalance(acidity, bitterness);
+    result.record.tasteBody    = cvaToTasteBody(mouthfeel);
+
     // If final weight is unset but we recorded weight samples, use the peak.
     if (result.record.summary.finalWeight <= 0 && !result.record.weight.isEmpty()) {
         double maxWeight = 0;
@@ -394,6 +408,13 @@ ShotFileParser::ParseResult ShotFileParser::parseVisualizerShot(const QJsonObjec
                 prevPos = curPos;
             }
         }
+    } else if (!stateChange.isEmpty()) {
+        // Present but unusable (fewer than 2 samples, or longer than the
+        // timeframe => misaligned). The shot imports fine but the detail view
+        // draws no frame lines; log so a schema drift is diagnosable.
+        qWarning() << "parseVisualizerShot: unusable espresso_state_change for" << visualizerId
+                   << "(" << stateChange.size() << "samples vs" << elapsed.size()
+                   << "timeframe); no frame markers";
     }
 
     // Profile JSON is fetched separately (the download carries only a URL).

--- a/src/history/shotfileparser.cpp
+++ b/src/history/shotfileparser.cpp
@@ -4,11 +4,51 @@
 #include <QRegularExpression>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QUuid>
 #include <QCryptographicHash>
 #include <QDateTime>
 #include <QTimeZone>
 #include <QDebug>
+
+namespace {
+// visualizer.coffee serialises telemetry samples as JSON *strings*
+// ("0.0", "9.42") — the same Tcl-huddle convention the profile JSON uses.
+// Convert an array of them to doubles, tolerating already-numeric values.
+QVector<double> jsonArrayToDoubles(const QJsonArray& arr)
+{
+    QVector<double> out;
+    out.reserve(arr.size());
+    for (const QJsonValue& v : arr) {
+        if (v.isDouble()) {
+            out.append(v.toDouble());
+        } else if (v.isString()) {
+            bool ok = false;
+            double d = v.toString().toDouble(&ok);
+            if (ok) out.append(d);
+            else out.append(0.0);  // keep alignment with the timeframe array
+        } else {
+            out.append(0.0);
+        }
+    }
+    return out;
+}
+
+// Scalar sibling of the above. visualizer.coffee string-encodes DYE scalars too
+// ("16.2", "0"), while a few (espresso_enjoyment) arrive as bare numbers.
+// QJsonValue::toDouble()/toInt() return 0 for a *string* value — no coercion —
+// so a bare .toDouble() silently zeroes every string-encoded field. Branch on
+// the type (mirrors jsonToDouble in profileframe.cpp).
+double jsonToScalar(const QJsonValue& v, double defaultVal = 0.0)
+{
+    if (v.isString()) {
+        bool ok = false;
+        const double d = v.toString().toDouble(&ok);
+        return ok ? d : defaultVal;
+    }
+    return v.toDouble(defaultVal);
+}
+}  // namespace
 
 ShotFileParser::ParseResult ShotFileParser::parse(const QByteArray& fileContents, const QString& filename)
 {
@@ -183,6 +223,191 @@ ShotFileParser::ParseResult ShotFileParser::parseFile(const QString& filePath)
 
     QString filename = filePath.section('/', -1).section('\\', -1);
     return parse(file.readAll(), filename);
+}
+
+ShotFileParser::ParseResult ShotFileParser::parseVisualizerShot(const QJsonObject& shotJson,
+                                                                const QString& profileJson,
+                                                                const QString& visualizerId,
+                                                                qint64 clockEpoch)
+{
+    ParseResult result;
+
+    // The download response's `clock` is null and `start_time` is an ISO
+    // string, so the authoritative start time comes from the shot-list
+    // entry the caller already fetched. Fall back to parsing start_time.
+    qint64 timestamp = clockEpoch;
+    if (timestamp <= 0) {
+        const QString startStr = shotJson.value("start_time").toString();
+        if (!startStr.isEmpty()) {
+            QDateTime dt = QDateTime::fromString(startStr, Qt::ISODate);
+            if (dt.isValid()) timestamp = dt.toSecsSinceEpoch();
+        }
+    }
+    if (timestamp <= 0) {
+        result.errorMessage = "Missing shot start time";
+        return result;
+    }
+
+    result.record.summary.timestamp = timestamp;
+    // A deterministic uuid keyed on the Visualizer id makes re-runs of the
+    // recovery idempotent (importShotRecord dedupes on uuid first). Feed the
+    // visualizer id as the "filename" so it stays stable across runs.
+    //
+    // KNOWN LIMITATION (sync-gap case): a shot that was pulled ON THIS DEVICE has a
+    // local uuid keyed on its FILENAME, so this visualizer-id-keyed uuid can never
+    // match it — dedupe then falls to importShotRecord's secondary check
+    // (|timestamp delta| < 5s AND profile_name == profile_title). The timestamp is an
+    // exact round-trip via Visualizer's "clock" field, so the sole discriminator is
+    // the profile title. For a shot THIS app uploaded that matches; but one uploaded
+    // by a different client (e.g. de1app) with a differently-formatted title, or whose
+    // profile was later renamed, can slip past and re-import as a DUPLICATE row (not
+    // corruption — a duplicate). Fresh-install / device-swap recovery (nothing local)
+    // and re-running recovery (deterministic uuid) are both unaffected. A fully robust
+    // key would persist + compare the Visualizer id on the local shot too; deferred as
+    // it touches the shared import/dedupe path.
+    result.record.summary.uuid = generateUuid(timestamp, visualizerId);
+    result.record.visualizerId = visualizerId;
+
+    const QJsonObject data = shotJson.value("data").toObject();
+    const QVector<double> elapsed = jsonArrayToDoubles(shotJson.value("timeframe").toArray());
+    if (elapsed.isEmpty()) {
+        result.errorMessage = "Missing timeframe data";
+        return result;
+    }
+
+    // Core + goal + auxiliary series. Keys mirror the DE1 .shot field names
+    // (the visualizer download echoes them verbatim).
+    const QVector<double> pressure     = jsonArrayToDoubles(data.value("espresso_pressure").toArray());
+    // Every espresso shot has a pressure series. If timeframe is present but the
+    // telemetry object is missing/empty/renamed (a partial upload, or a schema
+    // change on visualizer.coffee), fail loudly rather than importing a hollow
+    // shot with blank traces that would still be counted as "imported".
+    if (pressure.isEmpty()) {
+        result.errorMessage = "Missing pressure samples";
+        return result;
+    }
+    const QVector<double> flow         = jsonArrayToDoubles(data.value("espresso_flow").toArray());
+    const QVector<double> tempBasket   = jsonArrayToDoubles(data.value("espresso_temperature_basket").toArray());
+    const QVector<double> weight       = jsonArrayToDoubles(data.value("espresso_weight").toArray());
+    const QVector<double> pressureGoal = jsonArrayToDoubles(data.value("espresso_pressure_goal").toArray());
+    const QVector<double> flowGoal     = jsonArrayToDoubles(data.value("espresso_flow_goal").toArray());
+    const QVector<double> tempGoal     = jsonArrayToDoubles(data.value("espresso_temperature_goal").toArray());
+    const QVector<double> tempMix      = jsonArrayToDoubles(data.value("espresso_temperature_mix").toArray());
+    const QVector<double> resistance   = jsonArrayToDoubles(data.value("espresso_resistance").toArray());
+    QVector<double> waterDisp          = jsonArrayToDoubles(data.value("espresso_water_dispensed").toArray());
+    const QVector<double> flowWeight   = jsonArrayToDoubles(data.value("espresso_flow_weight").toArray());
+
+    result.record.pressure        = toPointVector(elapsed, pressure);
+    result.record.flow            = toPointVector(elapsed, flow);
+    result.record.temperature     = toPointVector(elapsed, tempBasket);
+    result.record.weight          = toPointVector(elapsed, weight);
+    result.record.pressureGoal    = toPointVector(elapsed, pressureGoal);
+    result.record.flowGoal        = toPointVector(elapsed, flowGoal);
+    result.record.temperatureGoal = toPointVector(elapsed, tempGoal);
+    if (!tempMix.isEmpty())
+        result.record.temperatureMix = toPointVector(elapsed, tempMix);
+    if (!resistance.isEmpty())
+        result.record.resistance = toPointVector(elapsed, resistance);
+    if (!waterDisp.isEmpty()) {
+        // visualizer.coffee stores espresso_water_dispensed at the same 0.1x
+        // (tenths-of-ml) scale de1app .shot files use — Decenza's uploader
+        // multiplies the DB's real-ml values by 0.1 on the way up (see
+        // VisualizerUploader::buildHistoryShotJson). Apply the identical x10
+        // the Tcl import path does so recovered shots match natively-stored
+        // ones (the DB unit is real ml).
+        for (auto& v : waterDisp)
+            v *= 10.0;
+        result.record.waterDispensed = toPointVector(elapsed, waterDisp);
+    }
+    if (!flowWeight.isEmpty())
+        result.record.weightFlowRate = toPointVector(elapsed, flowWeight);
+
+    // Duration: prefer the reported value, else the last elapsed sample.
+    double duration = jsonToScalar(shotJson.value("duration"));
+    if (duration <= 0) duration = elapsed.isEmpty() ? 0 : elapsed.last();
+    result.record.summary.duration = duration;
+
+    // DYE metadata (flat on the download response).
+    result.record.summary.profileName = shotJson.value("profile_title").toString();
+    if (result.record.summary.profileName.isEmpty())
+        result.record.summary.profileName = "Unknown";
+    result.record.summary.beanBrand = shotJson.value("bean_brand").toString();
+    result.record.summary.beanType  = shotJson.value("bean_type").toString();
+    result.record.roastDate  = shotJson.value("roast_date").toString();
+    result.record.roastLevel = shotJson.value("roast_level").toString();
+
+    const QString rawGrinder = shotJson.value("grinder_model").toString();
+    auto grinderLookup = GrinderAliases::lookup(rawGrinder);
+    if (grinderLookup.found) {
+        result.record.grinderBrand = grinderLookup.brand;
+        result.record.grinderModel = grinderLookup.model;
+        result.record.grinderBurrs = grinderLookup.stockBurrs;
+    } else {
+        result.record.grinderModel = rawGrinder;
+    }
+    result.record.grinderSetting = shotJson.value("grinder_setting").toString();
+    result.record.drinkTds = jsonToScalar(shotJson.value("drink_tds"));
+    result.record.drinkEy  = jsonToScalar(shotJson.value("drink_ey"));
+    result.record.summary.enjoyment = qRound(jsonToScalar(shotJson.value("espresso_enjoyment")));
+    result.record.espressoNotes = shotJson.value("espresso_notes").toString();
+    result.record.beanNotes = shotJson.value("bean_notes").toString();
+    result.record.barista = shotJson.value("barista").toString();
+    result.record.summary.doseWeight = jsonToScalar(shotJson.value("bean_weight"));
+    result.record.summary.finalWeight = jsonToScalar(shotJson.value("drink_weight"));
+    result.record.summary.beverageType = "espresso";
+
+    // If final weight is unset but we recorded weight samples, use the peak.
+    if (result.record.summary.finalWeight <= 0 && !result.record.weight.isEmpty()) {
+        double maxWeight = 0;
+        for (const auto& pt : result.record.weight)
+            if (pt.y() > maxWeight) maxWeight = pt.y();
+        result.record.summary.finalWeight = maxWeight;
+    }
+
+    // Frame boundaries: the download has no de1app timers block, but it does
+    // carry espresso_state_change — a per-sample array that flips sign
+    // (+/-10000000) at each frame transition (the same convention Decenza
+    // uploads; see VISUALIZER.md "state_change Array"). Emit a phase marker
+    // at each sign change so the shot-detail view still draws frame lines.
+    const QVector<double> stateChange = jsonArrayToDoubles(data.value("espresso_state_change").toArray());
+    if (stateChange.size() >= 2 && stateChange.size() <= elapsed.size()) {
+        int frameNumber = 0;
+        // Real downloads start the series at 0.0; seed the reference sign from the
+        // first *non-zero* sample so the leading 0 -> ±1e7 step isn't recorded as
+        // a phantom frame boundary at t≈0.
+        bool havePrev = false;
+        bool prevPos = false;
+        for (qsizetype i = 0; i < stateChange.size(); ++i) {
+            if (stateChange[i] == 0.0)
+                continue;
+            const bool curPos = stateChange[i] > 0;
+            if (!havePrev) {
+                prevPos = curPos;
+                havePrev = true;
+                continue;
+            }
+            if (prevPos != curPos) {
+                HistoryPhaseMarker marker;
+                marker.time = elapsed[i];
+                marker.frameNumber = ++frameNumber;
+                result.record.phases.append(marker);
+                prevPos = curPos;
+            }
+        }
+    }
+
+    // Profile JSON is fetched separately (the download carries only a URL).
+    if (!profileJson.isEmpty()) {
+        QJsonDocument pdoc = QJsonDocument::fromJson(profileJson.toUtf8());
+        if (!pdoc.isNull())
+            result.record.profileJson = profileJson;
+        else
+            qWarning() << "parseVisualizerShot: malformed profile JSON for"
+                       << visualizerId << "- importing shot without a profile";
+    }
+
+    result.success = true;
+    return result;
 }
 
 QVector<double> ShotFileParser::parseTclList(const QString& listStr)

--- a/src/history/shotfileparser.h
+++ b/src/history/shotfileparser.h
@@ -4,6 +4,7 @@
 #include <QVector>
 #include <QPointF>
 #include <QVariantMap>
+#include <QJsonObject>
 #include "shothistory_types.h"
 
 /**
@@ -29,6 +30,33 @@ public:
      * Parse a .shot file from disk
      */
     static ParseResult parseFile(const QString& filePath);
+
+    /**
+     * Build a ShotRecord from a visualizer.coffee shot download.
+     *
+     * Unlike parse()/parseFile() (which read the original DE1 Tcl .shot
+     * file), this consumes the JSON that GET /api/shots/{id}/download
+     * returns: a flat `data` object of `espresso_*` sample arrays aligned
+     * to a `timeframe` array, plus DYE metadata at the top level. Used by
+     * the "Recover shots from Visualizer" import (VisualizerImporter).
+     *
+     * @param shotJson    The parsed download response object.
+     * @param profileJson The profile JSON fetched separately from
+     *                    GET /api/shots/{id}/profile?format=json (the
+     *                    download response carries only a profile_url).
+     *                    May be empty — the record is still usable.
+     * @param visualizerId The shot's Visualizer UUID. Combined with the
+     *                    shot start time to derive a stable, deterministic
+     *                    ShotRecord uuid so re-running the recovery
+     *                    dedupes idempotently.
+     * @param clockEpoch  The shot start time in Unix seconds, taken from
+     *                    the shot-list entry (the download response's
+     *                    `clock` is null; `start_time` is an ISO string).
+     */
+    static ParseResult parseVisualizerShot(const QJsonObject& shotJson,
+                                            const QString& profileJson,
+                                            const QString& visualizerId,
+                                            qint64 clockEpoch);
 
 private:
     // Parse Tcl list format: {value1 value2 value3 ...}

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -2806,11 +2806,9 @@ ShotRecord ShotHistoryStorage::loadShotRecordStatic(QSqlDatabase& db, qint64 sho
     return record;
 }
 
-bool ShotHistoryStorage::deleteShot(qint64 shotId)
+bool ShotHistoryStorage::deleteShotStatic(QSqlDatabase& db, qint64 shotId)
 {
-    if (!m_ready) return false;
-
-    QSqlQuery query(m_db);
+    QSqlQuery query(db);
     query.prepare("DELETE FROM shots WHERE id = ?");
     query.bindValue(0, shotId);
 
@@ -2820,8 +2818,8 @@ bool ShotHistoryStorage::deleteShot(qint64 shotId)
     }
 
     // Note: no updateTotalShots()/invalidateDistinctCache()/shotDeleted() here.
-    // This method is only called from importShotRecord() during overwrite, which
-    // handles refresh via ShotImporter::refreshTotalShots() after the full batch.
+    // This is only called from the import overwrite path, which handles refresh
+    // (refreshTotalShots) after the full batch.
     qDebug() << "ShotHistoryStorage: Deleted shot" << shotId;
     return true;
 }
@@ -3775,16 +3773,64 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
         qWarning() << "ShotHistoryStorage: Cannot import - not ready";
         return -1;
     }
+    return importShotRecordStatic(m_db, record, overwriteExisting);
+}
+
+void ShotHistoryStorage::importShotRecordAsync(const ShotRecord& record, bool overwriteExisting,
+                                               std::function<void(qint64)> onDone)
+{
+    const QString dbPath = m_dbPath;
+    auto destroyed = m_destroyed;
+    runOnDbThread([this, dbPath, record, overwriteExisting,
+                   onDone = std::move(onDone), destroyed]() {
+        qint64 result = -1;
+        withTempDb(dbPath, "shs_import", [&](QSqlDatabase& db) {
+            result = importShotRecordStatic(db, record, overwriteExisting);
+        });
+        if (*destroyed) return;
+        QMetaObject::invokeMethod(this, [onDone = std::move(onDone), result, destroyed]() {
+            if (*destroyed) return;
+            if (onDone) onDone(result);
+        }, Qt::QueuedConnection);
+    });
+}
+
+qint64 ShotHistoryStorage::importShotRecordStatic(QSqlDatabase& db, const ShotRecord& record,
+                                                  bool overwriteExisting)
+{
+    QSqlQuery query(db);
+
+    // Check for duplicate by Visualizer id first, when the incoming record has
+    // one (only the Visualizer recovery import sets it; .shot-file imports leave
+    // it empty, so this probe is a no-op for them). This is the strongest key for
+    // the sync-gap case: a shot that was pulled ON THIS DEVICE has a local uuid
+    // keyed on its filename, so the recovery's visualizer-id-keyed uuid can never
+    // match it — but if that local shot was uploaded, its visualizer_id column is
+    // set to the same id we're importing, and matches here. Without this, dedupe
+    // would fall through to the timestamp+profile_name check, which a shot with a
+    // differently-formatted or later-renamed profile title can slip past and
+    // re-import as a duplicate row.
+    if (!record.visualizerId.isEmpty()) {
+        query.prepare("SELECT id FROM shots WHERE visualizer_id = ?");
+        query.bindValue(0, record.visualizerId);
+        if (query.exec() && query.next()) {
+            if (overwriteExisting) {
+                deleteShotStatic(db, query.value(0).toLongLong());
+            } else {
+                // Already have this exact Visualizer shot, skip
+                return 0;
+            }
+        }
+    }
 
     // Check for duplicate by UUID
-    QSqlQuery query(m_db);
     query.prepare("SELECT id FROM shots WHERE uuid = ?");
     query.bindValue(0, record.summary.uuid);
     if (query.exec() && query.next()) {
         if (overwriteExisting) {
             // Delete existing record to allow re-import
             qint64 existingId = query.value(0).toLongLong();
-            deleteShot(existingId);
+            deleteShotStatic(db, existingId);
         } else {
             // Duplicate found, skip
             return 0;
@@ -3799,7 +3845,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
         if (overwriteExisting) {
             // Delete existing record to allow re-import
             qint64 existingId = query.value(0).toLongLong();
-            deleteShot(existingId);
+            deleteShotStatic(db, existingId);
         } else {
             // Near-duplicate found, skip
             return 0;
@@ -3807,7 +3853,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
     }
 
     // Begin transaction
-    m_db.transaction();
+    db.transaction();
 
     // Resolve the parsed grinder identity to an equipment package so the
     // imported shot keeps its grinder (the per-shot grinder_brand/model/burrs
@@ -3817,11 +3863,11 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
     qint64 importEquipmentId = 0;
     if (!(record.grinderBrand.isEmpty() && record.grinderModel.isEmpty() && record.grinderBurrs.isEmpty())) {
         importEquipmentId = EquipmentStorage::findPackageByGrinderIdentityStatic(
-            m_db, record.grinderBrand, record.grinderModel, record.grinderBurrs);
+            db, record.grinderBrand, record.grinderModel, record.grinderBurrs);
         if (importEquipmentId <= 0) {
             EquipmentPackage pkg;
             importEquipmentId = EquipmentStorage::createPackageWithGrinderStatic(
-                m_db, pkg, record.grinderBrand, record.grinderModel, record.grinderBurrs);
+                db, pkg, record.grinderBrand, record.grinderModel, record.grinderBurrs);
         }
     }
 
@@ -3833,6 +3879,8 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
             bean_brand, bean_type, roast_date, roast_level,
             grinder_setting, equipment_id, rpm,
             drink_tds, drink_ey, enjoyment, espresso_notes, bean_notes, barista,
+            taste_balance, taste_body,
+            visualizer_id, visualizer_url,
             profile_notes, debug_log,
             temperature_override, yield_override, profile_kb_id,
             channeling_detected, grind_issue_detected,
@@ -3843,6 +3891,8 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
             :bean_brand, :bean_type, :roast_date, :roast_level,
             :grinder_setting, :equipment_id, :rpm,
             :drink_tds, :drink_ey, :enjoyment, :espresso_notes, :bean_notes, :barista,
+            :taste_balance, :taste_body,
+            :visualizer_id, :visualizer_url,
             :profile_notes, :debug_log,
             :temperature_override, :yield_override, :profile_kb_id,
             :channeling_detected, :grind_issue_detected,
@@ -3875,6 +3925,10 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
     query.bindValue(":espresso_notes", record.espressoNotes);
     query.bindValue(":bean_notes", record.beanNotes);
     query.bindValue(":barista", record.barista);
+    query.bindValue(":taste_balance", record.tasteBalance);
+    query.bindValue(":taste_body", record.tasteBody);
+    query.bindValue(":visualizer_id", record.visualizerId);
+    query.bindValue(":visualizer_url", record.visualizerUrl);
     query.bindValue(":profile_notes", record.profileNotes);
     query.bindValue(":debug_log", QString());  // No debug log for imported shots
 
@@ -3889,7 +3943,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
 
     if (!query.exec()) {
         qWarning() << "ShotHistoryStorage: Failed to import shot:" << query.lastError().text();
-        m_db.rollback();
+        db.rollback();
         return -1;
     }
 
@@ -3920,7 +3974,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
 
     if (!query.exec()) {
         qWarning() << "ShotHistoryStorage: Failed to insert imported samples:" << query.lastError().text();
-        m_db.rollback();
+        db.rollback();
         return -1;
     }
 
@@ -3939,7 +3993,7 @@ qint64 ShotHistoryStorage::importShotRecord(const ShotRecord& record, bool overw
         query.exec();  // Non-critical if markers fail
     }
 
-    m_db.commit();
+    db.commit();
 
     return shotId;
 }

--- a/src/history/shothistorystorage.h
+++ b/src/history/shothistorystorage.h
@@ -264,10 +264,23 @@ public:
     // any explicit "re-evaluate this one shot" use case (e.g., a future bulk-resweep UI).
     Q_INVOKABLE void requestReanalyzeBadges(qint64 shotId);
 
-    // Import a shot record directly (for .shot file import)
-    // Returns: shot ID on success, 0 if duplicate (skipped), -1 on error
-    // If overwriteExisting is true, duplicates will be replaced instead of skipped
+    // Import a shot record directly (for .shot file import).
+    // Returns: shot ID on success, 0 if duplicate (skipped), -1 on error.
+    // If overwriteExisting is true, duplicates will be replaced instead of skipped.
+    // SYNCHRONOUS DB I/O on the caller's thread — call only from the main thread
+    // (the .shot batch importer does; see ShotImporter). Off-thread callers use
+    // importShotRecordAsync instead.
     qint64 importShotRecord(const ShotRecord& record, bool overwriteExisting = false);
+
+    // Async variant: runs the insert on the shared serial DB worker thread (its
+    // own withTempDb connection), then delivers the result code to `onDone` on
+    // the main thread — >0 imported, 0 duplicate/skipped, -1 error. Used by the
+    // Visualizer recovery import so its per-shot inserts never block the main
+    // thread. `onDone` may capture the caller; the storage guards its own
+    // lifetime, and both objects here are MainController-owned for the app's
+    // lifetime, so the callback is safe to fire.
+    void importShotRecordAsync(const ShotRecord& record, bool overwriteExisting,
+                               std::function<void(qint64 resultCode)> onDone);
 
     // Refresh the total shots count (call after bulk import)
     Q_INVOKABLE void refreshTotalShots();
@@ -375,8 +388,13 @@ private:
     void requestDistinctValueAsync(const QString& cacheKey, const QString& sql,
                                     const QVariantList& bindValues = {});
 
-    // Internal sync delete — only called from importShotRecord() (main-thread, see TODO)
-    bool deleteShot(qint64 shotId);
+    // Connection-parameterised core of importShotRecord, so the import logic can
+    // run on either the main-thread m_db (importShotRecord) or a background
+    // withTempDb connection (importShotRecordAsync) from one implementation.
+    // deleteShotStatic is the internal row delete used by the overwrite path.
+    static qint64 importShotRecordStatic(QSqlDatabase& db, const ShotRecord& record,
+                                         bool overwriteExisting);
+    static bool deleteShotStatic(QSqlDatabase& db, qint64 shotId);
 
     // Backfill beverage_type from profile_json for existing rows
     void backfillBeverageType();

--- a/src/network/tastecvamap.h
+++ b/src/network/tastecvamap.h
@@ -27,3 +27,28 @@ inline void applyTasteCvaMapping(QJsonObject& obj,
     else if (tasteBody == QLatin1String("medium")) obj["mouthfeel"] = 8;
     else if (tasteBody == QLatin1String("heavy"))  obj["mouthfeel"] = 12;
 }
+
+// Inverse of applyTasteCvaMapping: reconstruct the coarse taps from a
+// Visualizer shot's CVA attributes (as recovered via /api/shots/{id}/download).
+// Used by the recovery importer so a shot's taste dial-in survives the
+// upload→download round-trip.
+//
+// A user may also score these 0-15 by hand in Visualizer's assessment form
+// (not just Decenza's discrete 4/8/12), so we bucket by intensity rather than
+// exact-match, and treat "both unset" / "unset" (0) as no tap — returning "" so
+// an untapped or hand-unscored shot doesn't invent a taste value.
+inline QString cvaToTasteBalance(int acidity, int bitterness)
+{
+    if (acidity <= 0 && bitterness <= 0) return QString();  // unset
+    if (acidity > bitterness)  return QStringLiteral("sour");
+    if (bitterness > acidity)  return QStringLiteral("bitter");
+    return QStringLiteral("balanced");                      // equal & non-zero
+}
+
+inline QString cvaToTasteBody(int mouthfeel)
+{
+    if (mouthfeel <= 0) return QString();                   // unset
+    if (mouthfeel <= 5) return QStringLiteral("thin");      // 1-5  (maps 4)
+    if (mouthfeel <= 9) return QStringLiteral("medium");    // 6-9  (maps 8)
+    return QStringLiteral("heavy");                         // 10-15 (maps 12)
+}

--- a/src/network/visualizerimporter.cpp
+++ b/src/network/visualizerimporter.cpp
@@ -856,8 +856,18 @@ void VisualizerImporter::recoverNextShot()
     }
 
     m_recoverCurrent = m_recoverQueue.takeFirst();
+    m_recoverAttempts = 0;
+    recoverDownloadCurrent();
+}
 
-    // Step 1: download the full shot record (telemetry + metadata).
+void VisualizerImporter::recoverDownloadCurrent()
+{
+    // Step 1: download the full shot record (telemetry + metadata). A transient
+    // network/server failure is retried a bounded number of times (mirrors the
+    // uploader's transient-retry policy) so one blip mid-run doesn't permanently
+    // drop an otherwise-recoverable shot; a definitive client error (4xx, e.g. a
+    // deleted shot) is not retried. Retries re-fetch the SAME shot without
+    // advancing the queue.
     QUrl url(QString(VISUALIZER_SHOT_DOWNLOAD_API).arg(m_recoverCurrent.visualizerId));
     QNetworkRequest request(url);
     request.setRawHeader("Authorization", authHeader().toUtf8());
@@ -869,6 +879,17 @@ void VisualizerImporter::recoverNextShot()
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError) {
+            constexpr int kMaxAttempts = 3;   // 1 initial + up to 2 retries
+            const int sc = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+            const bool transient = (sc == 0 || sc >= 500);  // transport error or 5xx
+            m_recoverAttempts++;
+            if (transient && m_recoverAttempts < kMaxAttempts) {
+                qWarning() << "VisualizerImporter: shot download transient failure for"
+                           << m_recoverCurrent.visualizerId << reply->errorString()
+                           << "- retrying" << m_recoverAttempts << "of" << (kMaxAttempts - 1);
+                recoverDownloadCurrent();   // retry the same shot
+                return;
+            }
             qWarning() << "VisualizerImporter: shot download failed for"
                        << m_recoverCurrent.visualizerId << reply->errorString();
             m_recoverFailed++;

--- a/src/network/visualizerimporter.cpp
+++ b/src/network/visualizerimporter.cpp
@@ -4,6 +4,7 @@
 #include "../core/profilestorage.h"
 #include "../history/shothistorystorage.h"
 #include "../history/shotfileparser.h"
+#include "visualizershotlist.h"
 #include "../profile/profilesavehelper.h"
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -13,7 +14,6 @@
 #include <QDir>
 #include <QUrl>
 #include <QDebug>
-#include <limits>
 
 // Sanitize JSON to fix malformed numbers from Visualizer API
 // Fixes: .5 -> 0.5, 9. -> 9.0
@@ -776,11 +776,12 @@ void VisualizerImporter::recoverShots(qint64 fromEpoch, qint64 toEpoch)
 
 void VisualizerImporter::recoverFetchListPage(int page)
 {
-    // GET /api/shots?page=N&items=100 — authenticated => the user's own
-    // shots. Response: { data:[{id, clock, updated_at}], paging:{pages,...} }.
-    // Default sort is newest-first by start time, so once a whole page is
-    // older than the window we can stop paging. A defensive page ceiling
-    // bounds the loop regardless.
+    // GET /api/shots?page=N&items=100 — authenticated => the user's own shots.
+    // The page body is processed by the shared VisualizerShotList::processPage
+    // (see visualizershotlist.h): it parses the response, filters each entry's
+    // `clock` against the window, and returns a verdict (keep paging / done /
+    // fail). The same helper drives the uploader's back-sync, so the paging /
+    // early-stop / ceiling policy lives in exactly one place.
     constexpr int kMaxPages = 50;      // 50 * 100 = 5000 shots hard cap
     constexpr int kItemsPerPage = 100;
 
@@ -796,83 +797,51 @@ void VisualizerImporter::recoverFetchListPage(int page)
     QNetworkReply* reply = m_networkManager->get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply, page]() {
         reply->deleteLater();
+
+        auto fail = [this](const QString& msg) {
+            m_recovering = false;
+            emit recoveringChanged();
+            emit recoveryFailed(msg);
+        };
+
         if (reply->error() != QNetworkReply::NoError) {
             const int sc = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-            m_recovering = false;
-            emit recoveringChanged();
-            emit recoveryFailed(QStringLiteral("Could not list your shots (HTTP %1): %2")
-                                .arg(sc).arg(reply->errorString()));
+            fail(QStringLiteral("Could not list your shots (HTTP %1): %2")
+                 .arg(sc).arg(reply->errorString()));
             return;
         }
 
-        const QByteArray body = reply->readAll();
-        QJsonParseError perr{};
-        const QJsonDocument doc = QJsonDocument::fromJson(body, &perr);
-        if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
-            m_recovering = false;
-            emit recoveringChanged();
-            emit recoveryFailed(QStringLiteral("Shot list response parse error: %1")
-                                .arg(perr.errorString()));
+        using namespace VisualizerShotList;
+        const PageResult pr = processPage(reply->readAll(), page, kMaxPages,
+                                          m_recoverFromEpoch, m_recoverToEpoch);
+        switch (pr.reason) {
+        case FailReason::ParseError:
+            fail(QStringLiteral("Shot list response parse error: %1").arg(pr.parseError));
             return;
-        }
-
-        const QJsonObject root = doc.object();
-        const QJsonValue pagingVal = root.value("paging");
-        // A 200 without paging metadata is almost certainly an auth/error
-        // envelope, not a legitimately empty library — fail rather than
-        // silently report "nothing to import".
-        if (!pagingVal.isObject() || !pagingVal.toObject().value("pages").isDouble()) {
-            m_recovering = false;
-            emit recoveringChanged();
-            emit recoveryFailed(QStringLiteral(
+        case FailReason::MissingPaging:
+            fail(QStringLiteral(
                 "Unexpected response from Visualizer (check your credentials)."));
             return;
-        }
-        const int totalPages = pagingVal.toObject().value("pages").toInt(page);
-
-        const QJsonArray data = root.value("data").toArray();
-        qint64 minClockThisPage = std::numeric_limits<qint64>::max();
-        for (const QJsonValue& v : data) {
-            const QJsonObject s = v.toObject();
-            const QString id = s.value("id").toString();
-            const qint64 clock = s.value("clock").toVariant().toLongLong();
-            if (id.isEmpty() || clock <= 0) continue;
-            minClockThisPage = qMin(minClockThisPage, clock);
-            if (clock < m_recoverFromEpoch || clock > m_recoverToEpoch)
-                continue;  // outside the requested window
-            m_recoverQueue.append({id, clock});
-        }
-
-        // Newest-first sort: once a whole page predates the window start, every
-        // later page is older too, so we've collected all in-window shots.
-        const bool wholePageOlder =
-            !data.isEmpty() && minClockThisPage < m_recoverFromEpoch;
-
-        // Hitting the page ceiling BEFORE reaching the window (and before we've
-        // paged past it) means older in-window shots may exist beyond the cap.
-        // Reporting the partial result as "complete" would be silent data loss,
-        // so fail loudly instead (mirrors VisualizerUploader's abnormal-exit
-        // policy). This can't trip for a recent range — wholePageOlder stops us
-        // within a few pages regardless of library size.
-        if (page >= kMaxPages && page < totalPages && !wholePageOlder) {
-            m_recovering = false;
-            emit recoveringChanged();
-            emit recoveryFailed(QStringLiteral(
+        case FailReason::PageCeiling:
+            fail(QStringLiteral(
                 "Too many shots to search through (over %1). "
                 "Pick a more recent date range.")
                 .arg(kMaxPages * kItemsPerPage));
             return;
+        case FailReason::None:
+            break;
         }
 
-        const bool pagedOut = page >= totalPages;
-        if (pagedOut || wholePageOlder) {
+        for (const Entry& e : pr.inWindow)
+            m_recoverQueue.append({e.visualizerId, e.clockEpoch});
+
+        if (pr.verdict == Verdict::Done) {
             m_recoverTotal = static_cast<int>(m_recoverQueue.size());
             emit recoveryProgress(m_recoverTotal, 0, 0, 0);
-            if (m_recoverQueue.isEmpty()) {
+            if (m_recoverQueue.isEmpty())
                 finishRecovery();
-            } else {
+            else
                 recoverNextShot();
-            }
             return;
         }
         recoverFetchListPage(page + 1);
@@ -931,39 +900,53 @@ void VisualizerImporter::recoverNextShot()
                            << m_recoverCurrent.visualizerId << preply->errorString()
                            << "- importing shot without a profile";
 
-            // Step 3: parse and insert (importShotRecord dedupes). Run the body
-            // through sanitizeVisualizerJson first: visualizer.coffee can emit the
+            // Step 3: parse and insert (dedupes). Run the body through
+            // sanitizeVisualizerJson first: visualizer.coffee can emit the
             // malformed number tokens (.5, 9.) that QJsonDocument rejects outright,
             // which would otherwise drop the whole shot (the sibling profile path
             // sanitizes for the same reason).
+
+            // Emit progress and move to the next shot. Shared by every outcome so
+            // the loop advances exactly once per shot whether it succeeded, was a
+            // duplicate, or failed.
+            auto advance = [this]() {
+                emit recoveryProgress(m_recoverTotal, m_recoverImported,
+                                      m_recoverSkipped, m_recoverFailed);
+                recoverNextShot();
+            };
+
             QJsonParseError perr{};
             const QJsonDocument doc = QJsonDocument::fromJson(sanitizeVisualizerJson(shotBody), &perr);
             if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
                 qWarning() << "VisualizerImporter: shot parse error for"
                            << m_recoverCurrent.visualizerId << perr.errorString();
                 m_recoverFailed++;
-            } else {
-                ShotFileParser::ParseResult res = ShotFileParser::parseVisualizerShot(
-                    doc.object(), profileJson, m_recoverCurrent.visualizerId,
-                    m_recoverCurrent.clockEpoch);
-                if (!res.success) {
-                    qWarning() << "VisualizerImporter: could not build shot record for"
-                               << m_recoverCurrent.visualizerId << res.errorMessage;
-                    m_recoverFailed++;
-                } else {
-                    // overwriteExisting = false => existing shots are skipped
-                    // (dedupe), which is exactly the idempotent recovery we want.
-                    const qint64 shotId =
-                        m_controller->shotHistory()->importShotRecord(res.record, false);
+                advance();
+                return;
+            }
+
+            ShotFileParser::ParseResult res = ShotFileParser::parseVisualizerShot(
+                doc.object(), profileJson, m_recoverCurrent.visualizerId,
+                m_recoverCurrent.clockEpoch);
+            if (!res.success) {
+                qWarning() << "VisualizerImporter: could not build shot record for"
+                           << m_recoverCurrent.visualizerId << res.errorMessage;
+                m_recoverFailed++;
+                advance();
+                return;
+            }
+
+            // Insert on the DB worker thread (no DB I/O on the main thread) and
+            // continue the loop from the completion callback. overwriteExisting
+            // = false => existing shots are skipped (dedupe), which is exactly the
+            // idempotent recovery we want.
+            m_controller->shotHistory()->importShotRecordAsync(
+                res.record, false, [this, advance](qint64 shotId) {
                     if (shotId > 0)       m_recoverImported++;
                     else if (shotId == 0) m_recoverSkipped++;   // duplicate
                     else                  m_recoverFailed++;     // DB error
-                }
-            }
-
-            emit recoveryProgress(m_recoverTotal, m_recoverImported,
-                                  m_recoverSkipped, m_recoverFailed);
-            recoverNextShot();
+                    advance();
+                });
         });
     });
 }

--- a/src/network/visualizerimporter.cpp
+++ b/src/network/visualizerimporter.cpp
@@ -2,6 +2,8 @@
 #include "../controllers/maincontroller.h"
 #include "../core/settings.h"
 #include "../core/profilestorage.h"
+#include "../history/shothistorystorage.h"
+#include "../history/shotfileparser.h"
 #include "../profile/profilesavehelper.h"
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -9,7 +11,9 @@
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QDir>
+#include <QUrl>
 #include <QDebug>
+#include <limits>
 
 // Sanitize JSON to fix malformed numbers from Visualizer API
 // Fixes: .5 -> 0.5, 9. -> 9.0
@@ -733,4 +737,244 @@ void VisualizerImporter::saveWithNewName(const QString& newTitle) {
 
 void VisualizerImporter::cancelPending() {
     m_saveHelper->cancelPending();
+}
+
+// ---------------------------------------------------------------------------
+// Recover shots from Visualizer (date-range history import)
+// ---------------------------------------------------------------------------
+
+void VisualizerImporter::recoverShots(qint64 fromEpoch, qint64 toEpoch)
+{
+    if (m_recovering) {
+        qWarning() << "VisualizerImporter: recovery already in progress";
+        return;
+    }
+    if (authHeader().isEmpty()) {
+        emit recoveryFailed(QStringLiteral(
+            "Connect your Visualizer account first (username and password)."));
+        return;
+    }
+    if (!m_controller || !m_controller->shotHistory()) {
+        emit recoveryFailed(QStringLiteral("Shot history is not available."));
+        return;
+    }
+
+    // Normalise the range (tolerate a swapped from/to).
+    m_recoverFromEpoch = qMin(fromEpoch, toEpoch);
+    m_recoverToEpoch   = qMax(fromEpoch, toEpoch);
+    m_recoverQueue.clear();
+    m_recoverTotal = 0;
+    m_recoverImported = 0;
+    m_recoverSkipped = 0;
+    m_recoverFailed = 0;
+
+    m_recovering = true;
+    emit recoveringChanged();
+
+    recoverFetchListPage(1);
+}
+
+void VisualizerImporter::recoverFetchListPage(int page)
+{
+    // GET /api/shots?page=N&items=100 — authenticated => the user's own
+    // shots. Response: { data:[{id, clock, updated_at}], paging:{pages,...} }.
+    // Default sort is newest-first by start time, so once a whole page is
+    // older than the window we can stop paging. A defensive page ceiling
+    // bounds the loop regardless.
+    constexpr int kMaxPages = 50;      // 50 * 100 = 5000 shots hard cap
+    constexpr int kItemsPerPage = 100;
+
+    QUrl url(QString::fromLatin1(VISUALIZER_SHOTS_LIST_API));
+    url.setQuery(QString("page=%1&items=%2").arg(page).arg(kItemsPerPage));
+
+    QNetworkRequest request(url);
+    request.setRawHeader("Authorization", authHeader().toUtf8());
+    request.setRawHeader("Accept", "application/json");
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                         QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    QNetworkReply* reply = m_networkManager->get(request);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, page]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            const int sc = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+            m_recovering = false;
+            emit recoveringChanged();
+            emit recoveryFailed(QStringLiteral("Could not list your shots (HTTP %1): %2")
+                                .arg(sc).arg(reply->errorString()));
+            return;
+        }
+
+        const QByteArray body = reply->readAll();
+        QJsonParseError perr{};
+        const QJsonDocument doc = QJsonDocument::fromJson(body, &perr);
+        if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
+            m_recovering = false;
+            emit recoveringChanged();
+            emit recoveryFailed(QStringLiteral("Shot list response parse error: %1")
+                                .arg(perr.errorString()));
+            return;
+        }
+
+        const QJsonObject root = doc.object();
+        const QJsonValue pagingVal = root.value("paging");
+        // A 200 without paging metadata is almost certainly an auth/error
+        // envelope, not a legitimately empty library — fail rather than
+        // silently report "nothing to import".
+        if (!pagingVal.isObject() || !pagingVal.toObject().value("pages").isDouble()) {
+            m_recovering = false;
+            emit recoveringChanged();
+            emit recoveryFailed(QStringLiteral(
+                "Unexpected response from Visualizer (check your credentials)."));
+            return;
+        }
+        const int totalPages = pagingVal.toObject().value("pages").toInt(page);
+
+        const QJsonArray data = root.value("data").toArray();
+        qint64 minClockThisPage = std::numeric_limits<qint64>::max();
+        for (const QJsonValue& v : data) {
+            const QJsonObject s = v.toObject();
+            const QString id = s.value("id").toString();
+            const qint64 clock = s.value("clock").toVariant().toLongLong();
+            if (id.isEmpty() || clock <= 0) continue;
+            minClockThisPage = qMin(minClockThisPage, clock);
+            if (clock < m_recoverFromEpoch || clock > m_recoverToEpoch)
+                continue;  // outside the requested window
+            m_recoverQueue.append({id, clock});
+        }
+
+        // Newest-first sort: once a whole page predates the window start, every
+        // later page is older too, so we've collected all in-window shots.
+        const bool wholePageOlder =
+            !data.isEmpty() && minClockThisPage < m_recoverFromEpoch;
+
+        // Hitting the page ceiling BEFORE reaching the window (and before we've
+        // paged past it) means older in-window shots may exist beyond the cap.
+        // Reporting the partial result as "complete" would be silent data loss,
+        // so fail loudly instead (mirrors VisualizerUploader's abnormal-exit
+        // policy). This can't trip for a recent range — wholePageOlder stops us
+        // within a few pages regardless of library size.
+        if (page >= kMaxPages && page < totalPages && !wholePageOlder) {
+            m_recovering = false;
+            emit recoveringChanged();
+            emit recoveryFailed(QStringLiteral(
+                "Too many shots to search through (over %1). "
+                "Pick a more recent date range.")
+                .arg(kMaxPages * kItemsPerPage));
+            return;
+        }
+
+        const bool pagedOut = page >= totalPages;
+        if (pagedOut || wholePageOlder) {
+            m_recoverTotal = static_cast<int>(m_recoverQueue.size());
+            emit recoveryProgress(m_recoverTotal, 0, 0, 0);
+            if (m_recoverQueue.isEmpty()) {
+                finishRecovery();
+            } else {
+                recoverNextShot();
+            }
+            return;
+        }
+        recoverFetchListPage(page + 1);
+    });
+}
+
+void VisualizerImporter::recoverNextShot()
+{
+    if (m_recoverQueue.isEmpty()) {
+        finishRecovery();
+        return;
+    }
+
+    m_recoverCurrent = m_recoverQueue.takeFirst();
+
+    // Step 1: download the full shot record (telemetry + metadata).
+    QUrl url(QString(VISUALIZER_SHOT_DOWNLOAD_API).arg(m_recoverCurrent.visualizerId));
+    QNetworkRequest request(url);
+    request.setRawHeader("Authorization", authHeader().toUtf8());
+    request.setRawHeader("Accept", "application/json");
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                         QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    QNetworkReply* reply = m_networkManager->get(request);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            qWarning() << "VisualizerImporter: shot download failed for"
+                       << m_recoverCurrent.visualizerId << reply->errorString();
+            m_recoverFailed++;
+            emit recoveryProgress(m_recoverTotal, m_recoverImported,
+                                  m_recoverSkipped, m_recoverFailed);
+            recoverNextShot();
+            return;
+        }
+        const QByteArray shotBody = reply->readAll();
+
+        // Step 2: fetch the profile (the download carries only a profile_url).
+        // The profile is best-effort — a shot with no profile still imports.
+        QUrl purl(QString::fromLatin1(VISUALIZER_PROFILE_API)
+                      .arg(m_recoverCurrent.visualizerId));
+        QNetworkRequest preq(purl);
+        preq.setRawHeader("Authorization", authHeader().toUtf8());
+        preq.setRawHeader("Accept", "application/json");
+        preq.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                          QNetworkRequest::NoLessSafeRedirectPolicy);
+
+        QNetworkReply* preply = m_networkManager->get(preq);
+        connect(preply, &QNetworkReply::finished, this, [this, preply, shotBody]() {
+            preply->deleteLater();
+            QString profileJson;
+            if (preply->error() == QNetworkReply::NoError)
+                profileJson = QString::fromUtf8(preply->readAll());
+            else
+                qWarning() << "VisualizerImporter: profile fetch failed for"
+                           << m_recoverCurrent.visualizerId << preply->errorString()
+                           << "- importing shot without a profile";
+
+            // Step 3: parse and insert (importShotRecord dedupes). Run the body
+            // through sanitizeVisualizerJson first: visualizer.coffee can emit the
+            // malformed number tokens (.5, 9.) that QJsonDocument rejects outright,
+            // which would otherwise drop the whole shot (the sibling profile path
+            // sanitizes for the same reason).
+            QJsonParseError perr{};
+            const QJsonDocument doc = QJsonDocument::fromJson(sanitizeVisualizerJson(shotBody), &perr);
+            if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
+                qWarning() << "VisualizerImporter: shot parse error for"
+                           << m_recoverCurrent.visualizerId << perr.errorString();
+                m_recoverFailed++;
+            } else {
+                ShotFileParser::ParseResult res = ShotFileParser::parseVisualizerShot(
+                    doc.object(), profileJson, m_recoverCurrent.visualizerId,
+                    m_recoverCurrent.clockEpoch);
+                if (!res.success) {
+                    qWarning() << "VisualizerImporter: could not build shot record for"
+                               << m_recoverCurrent.visualizerId << res.errorMessage;
+                    m_recoverFailed++;
+                } else {
+                    // overwriteExisting = false => existing shots are skipped
+                    // (dedupe), which is exactly the idempotent recovery we want.
+                    const qint64 shotId =
+                        m_controller->shotHistory()->importShotRecord(res.record, false);
+                    if (shotId > 0)       m_recoverImported++;
+                    else if (shotId == 0) m_recoverSkipped++;   // duplicate
+                    else                  m_recoverFailed++;     // DB error
+                }
+            }
+
+            emit recoveryProgress(m_recoverTotal, m_recoverImported,
+                                  m_recoverSkipped, m_recoverFailed);
+            recoverNextShot();
+        });
+    });
+}
+
+void VisualizerImporter::finishRecovery()
+{
+    if (m_controller && m_controller->shotHistory())
+        m_controller->shotHistory()->refreshTotalShots();
+
+    m_recovering = false;
+    emit recoveringChanged();
+    emit recoveryComplete(m_recoverTotal, m_recoverImported,
+                          m_recoverSkipped, m_recoverFailed);
 }

--- a/src/network/visualizerimporter.h
+++ b/src/network/visualizerimporter.h
@@ -116,8 +116,12 @@ private:
     };
     // Page GET /api/shots collecting in-window ids, then start downloads.
     void recoverFetchListPage(int page);
-    // Download the next queued shot's full record + profile, parse, insert.
+    // Advance to the next queued shot (resets the per-shot retry counter) and
+    // kick off its download.
     void recoverNextShot();
+    // Download the current shot's full record (with bounded transient retry) +
+    // profile, then parse and insert.
+    void recoverDownloadCurrent();
     // Finish the run: emit recoveryComplete and reset state.
     void finishRecovery();
 
@@ -127,6 +131,7 @@ private:
     qint64 m_recoverToEpoch = 0;
     QVector<RecoveryShot> m_recoverQueue;   // in-window shots still to fetch
     RecoveryShot m_recoverCurrent;          // shot whose download is in flight
+    int m_recoverAttempts = 0;              // download attempts for m_recoverCurrent (bounded retry)
     int m_recoverTotal = 0;
     int m_recoverImported = 0;
     int m_recoverSkipped = 0;

--- a/src/network/visualizerimporter.h
+++ b/src/network/visualizerimporter.h
@@ -4,6 +4,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QVariantList>
+#include <QVector>
 #include "../profile/profile.h"
 
 class MainController;
@@ -17,6 +18,8 @@ class VisualizerImporter : public QObject {
     Q_PROPERTY(QString lastError READ lastError NOTIFY lastErrorChanged)
     Q_PROPERTY(bool fetching READ isFetching NOTIFY fetchingChanged)
     Q_PROPERTY(QVariantList sharedShots READ sharedShots NOTIFY sharedShotsChanged)
+    // "Recover shots from Visualizer" (date-range history import) state.
+    Q_PROPERTY(bool recovering READ isRecovering NOTIFY recoveringChanged)
 
 public:
     explicit VisualizerImporter(QNetworkAccessManager* networkManager, MainController* controller, Settings* settings, QObject* parent = nullptr);
@@ -25,6 +28,7 @@ public:
     bool isFetching() const { return m_fetching; }
     QString lastError() const { return m_lastError; }
     QVariantList sharedShots() const { return m_sharedShots; }
+    bool isRecovering() const { return m_recovering; }
 
     // Import profile from a Visualizer shot ID
     Q_INVOKABLE void importFromShotId(const QString& shotId);
@@ -51,6 +55,26 @@ public:
     Q_INVOKABLE void saveWithNewName(const QString& newTitle);
     Q_INVOKABLE void cancelPending();
 
+    // --- Recover shots from Visualizer (date-range history import) ---
+    //
+    // Pulls the user's own FULL shot records (telemetry + metadata) from
+    // visualizer.coffee back into local history, for shots whose start time
+    // falls within [fromEpoch, toEpoch] (Unix seconds, inclusive). Async and
+    // non-blocking. The recovery:
+    //   1. pages GET /api/shots (authenticated => the user's own shots),
+    //      filtering by each entry's `clock`;
+    //   2. for each in-range shot, downloads the full record
+    //      (GET /api/shots/{id}/download) and its profile
+    //      (GET /api/shots/{id}/profile?format=json);
+    //   3. parses via ShotFileParser::parseVisualizerShot and inserts through
+    //      ShotHistoryStorage::importShotRecord, which DEDUPES against local
+    //      history (by uuid, then timestamp+profile) so a shot the user still
+    //      has is skipped and re-running is idempotent.
+    // Emits recoveryProgress after each shot and recoveryComplete when done.
+    // Requires Visualizer credentials; fails clearly via recoveryFailed if
+    // they are not configured. A no-op if a recovery is already running.
+    Q_INVOKABLE void recoverShots(qint64 fromEpoch, qint64 toEpoch);
+
 signals:
     void importingChanged();
     void lastErrorChanged();
@@ -60,6 +84,18 @@ signals:
     void importFailed(const QString& error);
     void duplicateFound(const QString& profileTitle, const QString& existingPath);
     void batchImportComplete(int imported, int skipped, int failed);
+
+    // --- Recovery signals ---
+    void recoveringChanged();
+    // Fired once the in-range shot list is known (total) and then after each
+    // shot is processed: imported so far, skipped as already-present, failed.
+    void recoveryProgress(int total, int imported, int skipped, int failed);
+    // Terminal success: final counts. imported+skipped+failed == total.
+    void recoveryComplete(int total, int imported, int skipped, int failed);
+    // Terminal failure before per-shot processing (no credentials, list
+    // fetch error). Per-shot failures do NOT abort the batch — they are
+    // counted in `failed` and surfaced via recoveryComplete.
+    void recoveryFailed(const QString& error);
 
 private slots:
     void onFetchFinished(QNetworkReply* reply);
@@ -71,6 +107,35 @@ private:
 
     // Auth header for API requests
     QString authHeader() const;
+
+    // --- Recovery internals ---
+    // A shot to recover: its Visualizer id and start time (from the list).
+    struct RecoveryShot {
+        QString visualizerId;
+        qint64 clockEpoch = 0;
+    };
+    // Page GET /api/shots collecting in-window ids, then start downloads.
+    void recoverFetchListPage(int page);
+    // Download the next queued shot's full record + profile, parse, insert.
+    void recoverNextShot();
+    // Finish the run: emit recoveryComplete and reset state.
+    void finishRecovery();
+
+    // Recovery state (single run at a time — guarded by m_recovering).
+    bool m_recovering = false;
+    qint64 m_recoverFromEpoch = 0;
+    qint64 m_recoverToEpoch = 0;
+    QVector<RecoveryShot> m_recoverQueue;   // in-window shots still to fetch
+    RecoveryShot m_recoverCurrent;          // shot whose download is in flight
+    int m_recoverTotal = 0;
+    int m_recoverImported = 0;
+    int m_recoverSkipped = 0;
+    int m_recoverFailed = 0;
+
+    static constexpr const char* VISUALIZER_SHOT_DOWNLOAD_API =
+        "https://visualizer.coffee/api/shots/%1/download";
+    static constexpr const char* VISUALIZER_SHOTS_LIST_API =
+        "https://visualizer.coffee/api/shots";
 
     // Fetch profile details for shared shots (chained after fetchSharedShots)
     void fetchProfileDetailsForShots();

--- a/src/network/visualizerimporter.h
+++ b/src/network/visualizerimporter.h
@@ -66,10 +66,10 @@ public:
     //   2. for each in-range shot, downloads the full record
     //      (GET /api/shots/{id}/download) and its profile
     //      (GET /api/shots/{id}/profile?format=json);
-    //   3. parses via ShotFileParser::parseVisualizerShot and inserts through
-    //      ShotHistoryStorage::importShotRecord, which DEDUPES against local
-    //      history (by uuid, then timestamp+profile) so a shot the user still
-    //      has is skipped and re-running is idempotent.
+    //   3. parses via ShotFileParser::parseVisualizerShot and inserts (on a
+    //      background DB thread via importShotRecordAsync), which DEDUPES against
+    //      local history (by visualizer_id, then uuid, then timestamp+profile) so
+    //      a shot the user still has is skipped and re-running is idempotent.
     // Emits recoveryProgress after each shot and recoveryComplete when done.
     // Requires Visualizer credentials; fails clearly via recoveryFailed if
     // they are not configured. A no-op if a recovery is already running.

--- a/src/network/visualizershotlist.h
+++ b/src/network/visualizershotlist.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+#include <QVector>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QJsonParseError>
+#include <QJsonValue>
+#include <limits>
+
+// Shared page processing for the paginated GET /api/shots list on
+// visualizer.coffee. Both the uploader back-sync (VisualizerUploader) and the
+// recovery importer (VisualizerImporter) page the same endpoint with the same
+// { data:[{id, clock, updated_at}], paging:{pages,...} } schema and the same
+// window / early-stop / ceiling policy — this is the one implementation of that
+// decision logic so the two callers can't drift.
+//
+// Pure and dependency-free (no networking, no state): each caller keeps its own
+// transport (request building, recursion, signal/state wiring) and hands each
+// page's raw body to processPage(). That also makes the boundary logic — the
+// bit most prone to off-by-one / silent-drop bugs — unit-testable without a
+// live network (tests/tst_visualizershotlist.cpp).
+//
+// Early termination (see wholePageOlder below) relies on the endpoint's default
+// sort being newest-first by start time. Confirmed against the visualizer.coffee
+// source (app/controllers/api/shots_controller.rb + app/models/shot.rb):
+//   - default order is `scope :by_start_time, -> { order(start_time: :desc) }`;
+//   - the `clock` field this filters on is `start_time.to_i` — i.e. the exact
+//     value the window is expressed in;
+//   - the only other ordering is the opt-in `?sort=updated_at`, which neither
+//     caller sends.
+// So a whole page older than the window start guarantees every later page is
+// older too. As a belt-and-braces backstop regardless, the kMaxPages ceiling
+// bounds the loop and turns an over-long run into a loud PageCeiling failure
+// rather than a silent partial result.
+namespace VisualizerShotList {
+
+// One shot from the list: its Visualizer id and start time (Unix seconds).
+struct Entry {
+    QString visualizerId;
+    qint64 clockEpoch = 0;
+};
+
+// What the caller should do after this page.
+enum class Verdict {
+    NextPage,  // keep paging
+    Done,      // all in-window shots collected
+    Fail       // stop and surface `reason`
+};
+
+// Why a page failed (only meaningful when verdict == Fail). Callers map this to
+// their own user-facing / internal message so each keeps its existing wording.
+enum class FailReason {
+    None,
+    ParseError,    // body was not valid JSON / not an object
+    MissingPaging, // 200 without a numeric paging.pages — likely an auth/error envelope
+    PageCeiling    // hit the defensive page cap before the real end
+};
+
+struct PageResult {
+    Verdict verdict = Verdict::Fail;
+    FailReason reason = FailReason::None;
+    QString parseError;         // JSON error text when reason == ParseError
+    int totalPages = 0;         // paging.pages (for the caller's ceiling message)
+    QVector<Entry> inWindow;    // this page's entries with clock ∈ [fromEpoch, toEpoch]
+};
+
+// Process one page of GET /api/shots?page=N.
+//   body               raw response bytes
+//   page               1-based page number just fetched
+//   maxPages           defensive page ceiling (hitting it before totalPages => PageCeiling)
+//   fromEpoch/toEpoch  inclusive selection window in Unix seconds; pass
+//                      toEpoch == std::numeric_limits<qint64>::max() for a
+//                      lower-bound-only window (the uploader's back-sync case).
+inline PageResult processPage(const QByteArray& body, int page, int maxPages,
+                              qint64 fromEpoch, qint64 toEpoch)
+{
+    PageResult result;
+
+    QJsonParseError perr{};
+    const QJsonDocument doc = QJsonDocument::fromJson(body, &perr);
+    if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
+        result.reason = FailReason::ParseError;
+        result.parseError = perr.errorString();
+        return result;
+    }
+
+    const QJsonObject root = doc.object();
+    // A valid list response MUST carry a `paging` object with a numeric `pages`.
+    // A 200 lacking it is almost certainly an auth/error envelope (e.g. an
+    // expired session returning {}), NOT a legitimately empty library — treating
+    // it as an empty success would silently report "nothing to import".
+    const QJsonValue pagingVal = root.value("paging");
+    if (!pagingVal.isObject() || !pagingVal.toObject().value("pages").isDouble()) {
+        result.reason = FailReason::MissingPaging;
+        return result;
+    }
+    result.totalPages = pagingVal.toObject().value("pages").toInt(page);
+
+    const QJsonArray data = root.value("data").toArray();
+    qint64 minClockThisPage = std::numeric_limits<qint64>::max();
+    for (const QJsonValue& v : data) {
+        const QJsonObject s = v.toObject();
+        const QString id = s.value("id").toString();
+        const qint64 clock = s.value("clock").toVariant().toLongLong();
+        if (id.isEmpty() || clock <= 0) continue;
+        minClockThisPage = qMin(minClockThisPage, clock);
+        if (clock < fromEpoch || clock > toEpoch)
+            continue;  // outside the requested window
+        result.inWindow.append({id, clock});
+    }
+
+    // Newest-first sort: once a whole page predates the window start, every later
+    // page is older too, so all in-window shots have been collected.
+    const bool wholePageOlder =
+        !data.isEmpty() && minClockThisPage < fromEpoch;
+
+    // Hitting the page ceiling BEFORE reaching the real end (and before we've
+    // paged past the window) means older in-window shots may exist beyond the
+    // cap. Reporting the partial result as "complete" would be silent data loss,
+    // so fail loudly instead.
+    if (page >= maxPages && page < result.totalPages && !wholePageOlder) {
+        result.reason = FailReason::PageCeiling;
+        return result;
+    }
+
+    const bool pagedOut = page >= result.totalPages;
+    result.verdict = (pagedOut || wholePageOlder) ? Verdict::Done : Verdict::NextPage;
+    return result;
+}
+
+}  // namespace VisualizerShotList

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -26,6 +26,7 @@
 #include "beanbase_blob.h"
 #include "roastdate.h"
 #include "tastecvamap.h"
+#include "visualizershotlist.h"
 #include "../history/coffeebagstorage.h"
 #include "../core/dbutils.h"
 #include "../models/shotdatamodel.h"
@@ -625,13 +626,11 @@ void VisualizerUploader::fetchShotListPage(int page, qint64 windowStartEpoch,
 {
     // GET /api/shots?page=N&items=100 — authenticated => own shots.
     // Response shape { data: [{id, clock, updated_at}], paging:
-    // {count,page,limit,pages} } is confirmed against OpenAPI 1.8.2;
-    // the default sort is ASSUMED newest-first by start time (not
-    // spec-pinned). The wholePageOlder early-stop relies on that
-    // assumption only as an optimisation — if the sort differs it just
-    // stops paging early; the kMaxPages ceiling still bounds the loop
-    // and turns a ceiling hit into a fail-safe retry (below), and all
-    // in-window matches on fetched pages are still accumulated.
+    // {count,page,limit,pages} } is confirmed against OpenAPI 1.8.2, and the
+    // default newest-first-by-start-time sort the wholePageOlder early-stop
+    // relies on is confirmed against the visualizer.coffee source (see the note
+    // in visualizershotlist.h). The kMaxPages ceiling still bounds the loop and
+    // turns a ceiling hit into a fail-safe retry (below) regardless.
     constexpr int kMaxPages = 50;          // 50 * 100 = 5000 shots hard cap
     constexpr int kItemsPerPage = 100;
 
@@ -662,64 +661,49 @@ void VisualizerUploader::fetchShotListPage(int page, qint64 windowStartEpoch,
         const QByteArray body = reply->readAll();
         reply->deleteLater();
 
-        QJsonParseError perr{};
-        const QJsonDocument doc = QJsonDocument::fromJson(body, &perr);
-        if (perr.error != QJsonParseError::NoError || !doc.isObject()) {
+        // Parse + window-filter + terminate via the shared page processor (see
+        // visualizershotlist.h). The recovery importer runs the identical policy;
+        // keeping it in one place stops the two copies from drifting.
+        using namespace VisualizerShotList;
+        const PageResult pr = processPage(body, page, kMaxPages,
+                                          windowStartEpoch,
+                                          std::numeric_limits<qint64>::max());
+        switch (pr.reason) {
+        case FailReason::ParseError:
             emit shotListFailed(QStringLiteral("Shot list response parse error: %1")
-                                .arg(perr.errorString()));
+                                .arg(pr.parseError));
             return;
-        }
-        const QJsonObject root = doc.object();
-        // A valid list response MUST carry a `paging` object with a
-        // numeric `pages`. A 200 lacking it is almost certainly an
-        // auth/error envelope (e.g. expired session returning {}), NOT
-        // a legitimately empty library — treating it as success would
-        // permanently burn the run-once flag. Fail safe instead.
-        const QJsonValue pagingVal = root.value("paging");
-        if (!pagingVal.isObject() || !pagingVal.toObject().value("pages").isDouble()) {
+        case FailReason::MissingPaging:
+            // A 200 without paging metadata is almost certainly an auth/error
+            // envelope (e.g. expired session returning {}), NOT a legitimately
+            // empty library — treating it as success would permanently burn the
+            // run-once flag. Fail safe instead.
             emit shotListFailed(QStringLiteral(
                 "Shot list response missing paging metadata (likely auth/error envelope)"));
             return;
-        }
-        const QJsonArray data = root.value("data").toArray();
-        const QJsonObject paging = pagingVal.toObject();
-        const int totalPages = paging.value("pages").toInt(page);
-
-        qint64 minClockThisPage = std::numeric_limits<qint64>::max();
-        for (const QJsonValue& v : data) {
-            const QJsonObject s = v.toObject();
-            const QString id = s.value("id").toString();
-            const qint64 clock = s.value("clock").toVariant().toLongLong();
-            if (id.isEmpty() || clock <= 0) continue;
-            minClockThisPage = std::min(minClockThisPage, clock);
-            if (clock < windowStartEpoch) continue;   // outside window — skip
-            QVariantMap m;
-            m["visualizerId"] = id;
-            m["url"] = QString(VISUALIZER_SHOT_URL) + id;
-            m["clockEpoch"] = clock;
-            accumulated.append(m);
-        }
-
-        // Hitting the defensive page ceiling without reaching the real
-        // end is an ABNORMAL exit (oversized library, or the assumed
-        // newest-first sort was violated so wholePageOlder never fired).
-        // Emitting a truncated list as "success" would permanently mark
-        // the backfill done with missing shots. Fail safe so it retries.
-        if (page >= kMaxPages && page < totalPages) {
+        case FailReason::PageCeiling:
+            // Hitting the defensive page ceiling without reaching the real end is
+            // an ABNORMAL exit (oversized library, or the assumed newest-first
+            // sort was violated). Emitting a truncated list as "success" would
+            // permanently mark the backfill done with missing shots. Fail safe.
             emit shotListFailed(QStringLiteral(
                 "Shot list exceeded page ceiling (%1) before end (%2 pages) — "
                 "backfill incomplete, will retry next boot")
-                .arg(kMaxPages).arg(totalPages));
+                .arg(kMaxPages).arg(pr.totalPages));
             return;
+        case FailReason::None:
+            break;
         }
 
-        // Stop when: paging exhausted, or (relying on newest-first sort)
-        // this whole page is already older than the window — nothing
-        // older can be in-window.
-        const bool pagedOut = page >= totalPages;
-        const bool wholePageOlder =
-            !data.isEmpty() && minClockThisPage < windowStartEpoch;
-        if (pagedOut || wholePageOlder) {
+        for (const Entry& e : pr.inWindow) {
+            QVariantMap m;
+            m["visualizerId"] = e.visualizerId;
+            m["url"] = QString(VISUALIZER_SHOT_URL) + e.visualizerId;
+            m["clockEpoch"] = e.clockEpoch;
+            accumulated.append(m);
+        }
+
+        if (pr.verdict == Verdict::Done) {
             emit shotListFetched(accumulated);
             return;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,12 @@ add_decenza_test(tst_tastecvamap
     tst_tastecvamap.cpp
 )
 
+# --- tst_visualizershotlist: header-only shared paginator decision logic
+# (window filter / newest-first early-stop / page-ceiling guard) ---
+add_decenza_test(tst_visualizershotlist
+    tst_visualizershotlist.cpp
+)
+
 # --- tst_dialing_helpers: pure session-grouping algorithm (issue #1009) ---
 add_decenza_test(tst_dialing_helpers
     tst_dialing_helpers.cpp
@@ -561,6 +567,16 @@ add_decenza_test(tst_shotrecord_cache
 )
 target_link_libraries(tst_shotrecord_cache PRIVATE Qt6::Graphs Qt6::Quick)
 target_include_directories(tst_shotrecord_cache PRIVATE ${CMAKE_BINARY_DIR})
+
+# --- tst_shotimportdedupe: importShotRecord dedupe by visualizer_id (the
+# Visualizer-recovery sync-gap case) ---
+add_decenza_test(tst_shotimportdedupe
+    tst_shotimportdedupe.cpp
+    ${HISTORY_SOURCES}
+    ${CMAKE_BINARY_DIR}/version_code.cpp
+)
+target_link_libraries(tst_shotimportdedupe PRIVATE Qt6::Graphs Qt6::Quick)
+target_include_directories(tst_shotimportdedupe PRIVATE ${CMAKE_BINARY_DIR})
 
 # --- tst_scaleprotocol: Scale BLE packet parsing (Decent, Bookoo) ---
 add_decenza_test(tst_scaleprotocol

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -174,6 +174,17 @@ add_decenza_test(tst_profile
     tst_profile.cpp
 )
 
+# --- tst_visualizershotparse: JSON->ShotRecord recovery parser (string-encoded
+# DYE scalars must not zero; hollow-shot guard; phantom-frame guard). ---
+add_decenza_test(tst_visualizershotparse
+    tst_visualizershotparse.cpp
+    ${CMAKE_SOURCE_DIR}/src/history/shotfileparser.cpp
+    ${CMAKE_SOURCE_DIR}/src/ai/shotanalysis.cpp
+)
+target_compile_definitions(tst_visualizershotparse PRIVATE
+    TST_VIS_PARSE_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
 # --- tst_temperaturedisplay: adaptive temp-override display formatter ---
 add_decenza_test(tst_temperaturedisplay
     tst_temperaturedisplay.cpp

--- a/tests/tst_shotimportdedupe.cpp
+++ b/tests/tst_shotimportdedupe.cpp
@@ -15,9 +15,11 @@
 #include <QCoreApplication>
 #include <QThread>
 #include <QPointF>
+#include <QSqlQuery>
 
 #include "history/shothistorystorage.h"
 #include "history/shothistory_types.h"
+#include "core/dbutils.h"
 
 class TstShotImportDedupe : public QObject
 {
@@ -100,6 +102,42 @@ private slots:
 
         storage.close();
         drain();
+    }
+
+    // Phase markers must survive import. shot_phases.label is NOT NULL, so a
+    // marker with a null/empty label makes its INSERT fail — and the import
+    // ignores that failure, silently dropping every frame line. A recovered
+    // shot's markers (built in parseVisualizerShot) must carry a label; this
+    // verifies the rows actually land in the DB.
+    void phase_markers_persist()
+    {
+        QVERIFY(m_dir.isValid());
+        const QString path = m_dir.filePath("import_phases.db");
+        ShotHistoryStorage storage;
+        QVERIFY(storage.initialize(path));
+
+        ShotRecord r = makeShot("phase-shot", 1752000000, "Profile P", QStringLiteral("VIZ-P"));
+        HistoryPhaseMarker m0; m0.time = 0.01; m0.frameNumber = 0; m0.label = QStringLiteral("Frame 1");
+        HistoryPhaseMarker m1; m1.time = 2.0;  m1.frameNumber = 1; m1.label = QStringLiteral("Frame 2");
+        r.phases = { m0, m1 };
+
+        const qint64 id = storage.importShotRecord(r, false);
+        QVERIFY2(id > 0, "import should insert");
+
+        storage.close();
+        drain();
+
+        // A null-label marker would have failed the NOT NULL constraint and been
+        // silently skipped, leaving 0 rows.
+        int phaseCount = -1;
+        withTempDb(path, "shs_test_phases", [&](QSqlDatabase& db) {
+            QSqlQuery q(db);
+            q.prepare(QStringLiteral("SELECT COUNT(*) FROM shot_phases WHERE shot_id = ?"));
+            q.bindValue(0, id);
+            if (q.exec() && q.next())
+                phaseCount = q.value(0).toInt();
+        });
+        QCOMPARE(phaseCount, 2);
     }
 };
 

--- a/tests/tst_shotimportdedupe.cpp
+++ b/tests/tst_shotimportdedupe.cpp
@@ -1,0 +1,107 @@
+// Regression test for the Visualizer-recovery dedupe key in
+// ShotHistoryStorage::importShotRecord (via importShotRecordStatic).
+//
+// The crux: a shot that was pulled ON THIS DEVICE has a filename-keyed local
+// uuid, while the recovery import derives its uuid from the Visualizer id — so
+// the two never match. Recovered shots therefore fell through to the weaker
+// timestamp + profile_name near-duplicate check, which a shot with a
+// differently-formatted or later-renamed profile title slips past, re-importing
+// as a duplicate row. The visualizer_id probe fixes that by matching on the one
+// identifier guaranteed identical on both sides (the local shot's visualizer_id
+// column, set when it was uploaded). These tests lock that in.
+
+#include <QtTest>
+#include <QTemporaryDir>
+#include <QCoreApplication>
+#include <QThread>
+#include <QPointF>
+
+#include "history/shothistorystorage.h"
+#include "history/shothistory_types.h"
+
+class TstShotImportDedupe : public QObject
+{
+    Q_OBJECT
+
+    QTemporaryDir m_dir;
+
+    // initialize() spawns a distinct-cache thread; close() + drain before the
+    // storage destructs or it can crash (see tst_coffeebags::initAndClose).
+    static void drain()
+    {
+        for (int i = 0; i < 20; i++) {
+            QCoreApplication::processEvents();
+            QThread::msleep(25);
+        }
+    }
+
+    static ShotRecord makeShot(const QString& uuid, qint64 ts,
+                               const QString& profileName, const QString& vizId)
+    {
+        ShotRecord r;
+        r.summary.uuid = uuid;
+        r.summary.timestamp = ts;
+        r.summary.profileName = profileName;
+        r.summary.beverageType = "espresso";
+        r.visualizerId = vizId;
+        r.pressure.append(QPointF(0.0, 6.0));   // one sample so it's a real shot
+        return r;
+    }
+
+private slots:
+    void init() { QTest::failOnWarning(); }
+
+    void recovery_dedupes_by_visualizer_id()
+    {
+        QVERIFY(m_dir.isValid());
+        const QString path = m_dir.filePath("import_dedupe.db");
+        ShotHistoryStorage storage;
+        QVERIFY(storage.initialize(path));
+
+        const qint64 t = 1751000000;
+
+        // A shot pulled on this device and later uploaded: filename-keyed uuid,
+        // a title, and its visualizer_id set.
+        const qint64 localId =
+            storage.importShotRecord(makeShot("local-filename-uuid", t, "Profile A", "VIZ-123"), false);
+        QVERIFY2(localId > 0, "first import should insert");
+
+        // The same shot returning via recovery: DIFFERENT uuid AND a DIFFERENT
+        // profile title (e.g. a de1app-formatted title), but SAME visualizer id +
+        // timestamp. Must be recognised as a duplicate and skipped — this is the
+        // exact case the visualizer_id probe exists for; the uuid and
+        // timestamp+profile_name checks both miss it.
+        const qint64 dupId =
+            storage.importShotRecord(makeShot("viz-keyed-uuid", t, "profile a (de1app)", "VIZ-123"), false);
+        QCOMPARE(dupId, qint64(0));
+
+        // A genuinely different Visualizer shot still imports.
+        const qint64 otherId =
+            storage.importShotRecord(makeShot("other-uuid", t + 7200, "Profile B", "VIZ-999"), false);
+        QVERIFY2(otherId > 0, "distinct visualizer id should insert");
+
+        storage.close();
+        drain();
+    }
+
+    // An empty visualizer id is not an identity: the probe is guarded by a
+    // non-empty check, so two unrelated shots with no visualizer id (the .shot
+    // import path) must both insert rather than "" matching "".
+    void empty_visualizer_id_does_not_false_match()
+    {
+        QVERIFY(m_dir.isValid());
+        const QString path = m_dir.filePath("import_dedupe_empty.db");
+        ShotHistoryStorage storage;
+        QVERIFY(storage.initialize(path));
+
+        const qint64 t = 1751500000;
+        QVERIFY(storage.importShotRecord(makeShot("uuid-1", t,       "Profile One", QString()), false) > 0);
+        QVERIFY(storage.importShotRecord(makeShot("uuid-2", t + 100, "Profile Two", QString()), false) > 0);
+
+        storage.close();
+        drain();
+    }
+};
+
+QTEST_GUILESS_MAIN(TstShotImportDedupe)
+#include "tst_shotimportdedupe.moc"

--- a/tests/tst_visualizershotlist.cpp
+++ b/tests/tst_visualizershotlist.cpp
@@ -1,0 +1,140 @@
+// Unit tests for VisualizerShotList::processPage — the shared, pure
+// page-processing logic behind the paginated GET /api/shots list used by BOTH
+// the uploader back-sync and the recovery importer. This is the boundary code
+// (window filter, newest-first early-stop, page-ceiling guard, auth-envelope
+// detection) that used to be duplicated inline in two network callbacks and was
+// therefore untestable; extracting it made it a pure function we can exercise
+// without a live network.
+
+#include <QtTest>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <limits>
+
+#include "network/visualizershotlist.h"
+
+using namespace VisualizerShotList;
+
+class TstVisualizerShotList : public QObject
+{
+    Q_OBJECT
+
+private:
+    void init() { QTest::failOnWarning(); }
+
+    // Build a page body: { data:[{id,clock}...], paging:{pages} }.
+    static QByteArray page(const QVector<QPair<QString, qint64>>& shots, int totalPages)
+    {
+        QJsonArray data;
+        for (const auto& s : shots) {
+            QJsonObject o;
+            o["id"] = s.first;
+            o["clock"] = static_cast<double>(s.second);
+            data.append(o);
+        }
+        QJsonObject paging;
+        paging["pages"] = totalPages;
+        QJsonObject root;
+        root["data"] = data;
+        root["paging"] = paging;
+        return QJsonDocument(root).toJson(QJsonDocument::Compact);
+    }
+
+    static constexpr qint64 kNoUpper = std::numeric_limits<qint64>::max();
+
+private slots:
+    // Non-JSON / non-object bodies fail with ParseError, not a silent empty page.
+    void parse_error_is_flagged()
+    {
+        const PageResult r = processPage(QByteArrayLiteral("not json{"), 1, 50, 0, kNoUpper);
+        QCOMPARE(r.verdict, Verdict::Fail);
+        QCOMPARE(r.reason, FailReason::ParseError);
+        QVERIFY(!r.parseError.isEmpty());
+    }
+
+    // A 200 with no paging.pages is an auth/error envelope, not an empty library.
+    void missing_paging_is_flagged()
+    {
+        const PageResult r = processPage(QByteArrayLiteral("{}"), 1, 50, 0, kNoUpper);
+        QCOMPARE(r.verdict, Verdict::Fail);
+        QCOMPARE(r.reason, FailReason::MissingPaging);
+    }
+
+    // Entries inside [from,to] are collected; those outside are dropped. Junk
+    // entries (empty id, non-positive clock) are ignored.
+    void window_filters_entries()
+    {
+        const QByteArray body = page({
+            {"a", 1000},           // below window
+            {"b", 2000},           // in window
+            {"c", 3000},           // in window
+            {"d", 9000},           // above window
+            {"",  2500},           // empty id -> skipped
+            {"e", 0},              // clock 0 -> skipped
+        }, /*totalPages*/ 1);
+
+        const PageResult r = processPage(body, 1, 50, /*from*/ 1500, /*to*/ 3500);
+        QCOMPARE(r.verdict, Verdict::Done);       // single page, paged out
+        QCOMPARE(r.reason, FailReason::None);
+        QCOMPARE(r.inWindow.size(), 2);
+        QCOMPARE(r.inWindow[0].visualizerId, QStringLiteral("b"));
+        QCOMPARE(r.inWindow[0].clockEpoch, qint64(2000));
+        QCOMPARE(r.inWindow[1].visualizerId, QStringLiteral("c"));
+    }
+
+    // Lower-bound-only window (uploader back-sync): to == max.
+    void lower_bound_only_window()
+    {
+        const QByteArray body = page({{"a", 500}, {"b", 5000}}, 1);
+        const PageResult r = processPage(body, 1, 50, /*from*/ 1000, kNoUpper);
+        QCOMPARE(r.inWindow.size(), 1);
+        QCOMPARE(r.inWindow[0].visualizerId, QStringLiteral("b"));
+    }
+
+    // More pages remain and this page isn't yet past the window -> keep paging.
+    void keeps_paging_when_more_pages()
+    {
+        const QByteArray body = page({{"a", 9000}, {"b", 8000}}, /*totalPages*/ 3);
+        const PageResult r = processPage(body, /*page*/ 1, 50, /*from*/ 1000, kNoUpper);
+        QCOMPARE(r.verdict, Verdict::NextPage);
+    }
+
+    // Newest-first early stop: once a page's oldest entry predates the window
+    // start, everything further back is older too -> Done, even mid-pagination.
+    void whole_page_older_stops_early()
+    {
+        const QByteArray body = page({{"a", 2000}, {"b", 900}}, /*totalPages*/ 10);
+        const PageResult r = processPage(body, /*page*/ 2, 50, /*from*/ 1000, kNoUpper);
+        QCOMPARE(r.verdict, Verdict::Done);
+        QCOMPARE(r.inWindow.size(), 1);           // only the in-window one (a)
+        QCOMPARE(r.inWindow[0].visualizerId, QStringLiteral("a"));
+    }
+
+    // Hitting the ceiling before the real end (and before paging past the
+    // window) is a loud failure, never a silent partial "Done".
+    void page_ceiling_fails_loudly()
+    {
+        // page == maxPages, more pages exist, and this page is NOT wholly older
+        // than the window -> PageCeiling.
+        const QByteArray body = page({{"a", 9000}, {"b", 8000}}, /*totalPages*/ 20);
+        const PageResult r = processPage(body, /*page*/ 5, /*maxPages*/ 5, /*from*/ 1000, kNoUpper);
+        QCOMPARE(r.verdict, Verdict::Fail);
+        QCOMPARE(r.reason, FailReason::PageCeiling);
+        QCOMPARE(r.totalPages, 20);
+    }
+
+    // At the ceiling but already paged past the window: NOT a failure — all
+    // in-window shots were collected (this is the importer's !wholePageOlder
+    // refinement, now shared by both callers).
+    void ceiling_with_whole_page_older_is_done()
+    {
+        const QByteArray body = page({{"a", 900}, {"b", 800}}, /*totalPages*/ 20);
+        const PageResult r = processPage(body, /*page*/ 5, /*maxPages*/ 5, /*from*/ 1000, kNoUpper);
+        QCOMPARE(r.verdict, Verdict::Done);
+        QCOMPARE(r.reason, FailReason::None);
+    }
+};
+
+QTEST_GUILESS_MAIN(TstVisualizerShotList)
+#include "tst_visualizershotlist.moc"

--- a/tests/tst_visualizershotparse.cpp
+++ b/tests/tst_visualizershotparse.cpp
@@ -1,0 +1,97 @@
+// Regression tests for ShotFileParser::parseVisualizerShot — the JSON->ShotRecord
+// path used by "Recover shots from Visualizer".
+//
+// The crux these lock down: visualizer.coffee's /api/shots/{id}/download
+// string-encodes numeric DYE scalars (Tcl-huddle convention: "16.2", "0"), while
+// a few (espresso_enjoyment) arrive as bare numbers. A naive QJsonValue::toDouble()
+// returns 0 for a *string*, which would silently zero dose weight / TDS / EY on
+// every recovered shot. These tests parse the real download-schema fixture
+// (tests/data/shots/cremina_clean.json) and assert the scalars survive.
+
+#include <QtTest>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+
+#include "history/shotfileparser.h"
+
+class TstVisualizerShotParse : public QObject
+{
+    Q_OBJECT
+
+private:
+    static QJsonObject loadFixture(const QString& name)
+    {
+        const QString path = QStringLiteral(TST_VIS_PARSE_SOURCE_DIR)
+                             + QStringLiteral("/data/shots/") + name;
+        QFile f(path);
+        if (!f.open(QIODevice::ReadOnly))
+            return {};
+        const QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+        return doc.object();
+    }
+
+private slots:
+    // The download string-encodes scalars — they must NOT come back as 0.
+    void scalars_survive_string_encoding()
+    {
+        const QJsonObject shot = loadFixture(QStringLiteral("cremina_clean.json"));
+        QVERIFY2(!shot.isEmpty(), "cremina_clean.json fixture missing/unreadable");
+
+        // Sanity: confirm the fixture really is string-encoded (guards against a
+        // future fixture swap silently defeating the regression).
+        QVERIFY2(shot.value("bean_weight").isString(),
+                 "fixture no longer string-encodes bean_weight — test is moot");
+
+        const ShotFileParser::ParseResult res = ShotFileParser::parseVisualizerShot(
+            shot, QString(), QStringLiteral("test-vis-id"), 1751000000);
+
+        QVERIFY2(res.success, qPrintable(res.errorMessage));
+
+        // bean_weight="16.2", drink_weight="34.8" — string-encoded, must parse.
+        QVERIFY2(qAbs(res.record.summary.doseWeight - 16.2) < 0.01,
+                 qPrintable(QStringLiteral("doseWeight zeroed/wrong: %1")
+                            .arg(res.record.summary.doseWeight)));
+        QVERIFY2(qAbs(res.record.summary.finalWeight - 34.8) < 0.01,
+                 qPrintable(QStringLiteral("finalWeight zeroed/wrong: %1")
+                            .arg(res.record.summary.finalWeight)));
+        // duration=32.515 (bare number in this fixture) — bidirectional read.
+        QVERIFY2(qAbs(res.record.summary.duration - 32.515) < 0.01,
+                 qPrintable(QStringLiteral("duration wrong: %1")
+                            .arg(res.record.summary.duration)));
+        // espresso_enjoyment=69 (bare int) — must not be lost by the string branch.
+        QCOMPARE(res.record.summary.enjoyment, 69);
+
+        // Telemetry present and aligned.
+        QVERIFY2(!res.record.pressure.isEmpty(), "pressure series empty");
+        QVERIFY2(!res.record.flow.isEmpty(), "flow series empty");
+
+        // Phantom-frame guard: the state_change series starts at 0.0, which must
+        // NOT register a phase boundary at t≈0.
+        for (const auto& ph : res.record.phases)
+            QVERIFY2(ph.time > 0.1,
+                     qPrintable(QStringLiteral("phantom frame marker at t=%1")
+                                .arg(ph.time)));
+    }
+
+    // A shot with a timeframe but no pressure telemetry must FAIL, not import a
+    // hollow record that would still be counted as "imported".
+    void missing_pressure_fails_not_hollow()
+    {
+        QJsonObject shot;
+        QJsonArray tf; tf.append(QStringLiteral("0.0")); tf.append(QStringLiteral("0.5"));
+        shot.insert(QStringLiteral("timeframe"), tf);
+        shot.insert(QStringLiteral("data"), QJsonObject{});  // no espresso_pressure
+        shot.insert(QStringLiteral("profile_title"), QStringLiteral("X"));
+
+        const ShotFileParser::ParseResult res = ShotFileParser::parseVisualizerShot(
+            shot, QString(), QStringLiteral("test-empty"), 1751000000);
+
+        QVERIFY2(!res.success, "hollow shot (no pressure) was accepted");
+        QVERIFY(res.errorMessage.contains(QStringLiteral("pressure"), Qt::CaseInsensitive));
+    }
+};
+
+QTEST_MAIN(TstVisualizerShotParse)
+#include "tst_visualizershotparse.moc"

--- a/tests/tst_visualizershotparse.cpp
+++ b/tests/tst_visualizershotparse.cpp
@@ -92,19 +92,27 @@ private slots:
         QVERIFY2(qAbs(maxWater - 81.685) < 0.1,
                  qPrintable(QStringLiteral("water-dispensed x10 wrong: %1").arg(maxWater)));
 
-        // Real frame detection: the fixture's state_change series flips sign 4
-        // times. A positive count (not just "no phantom") proves the frame-marker
-        // loop actually fires — a regression to zero frames would pass the
-        // phantom guard vacuously.
-        QCOMPARE(res.record.phases.size(), qsizetype(4));
-        QCOMPARE(res.record.phases.first().frameNumber, 1);
-
-        // Phantom-frame guard: the state_change series starts at 0.0, which must
-        // NOT register a phase boundary at t≈0.
-        for (const auto& ph : res.record.phases)
-            QVERIFY2(ph.time > 0.1,
-                     qPrintable(QStringLiteral("phantom frame marker at t=%1")
-                                .arg(ph.time)));
+        // Frame detection: a frame-0 boundary at extraction start, then one
+        // marker per sign change (the fixture flips sign 4 times) → 5 markers
+        // numbered 0..4, each with a non-empty label.
+        QCOMPARE(res.record.phases.size(), qsizetype(5));
+        // A frameNumber==0 marker MUST lead: ShotAnalysis::detectSkipFirstFrame
+        // keys off it, else recovered shots are spuriously badged "skip first
+        // frame".
+        QCOMPARE(res.record.phases.first().frameNumber, 0);
+        for (qsizetype i = 0; i < res.record.phases.size(); ++i) {
+            QCOMPARE(res.record.phases[i].frameNumber, int(i));
+            // shot_phases.label is NOT NULL — a null/empty label would make the
+            // phase INSERT fail and silently drop every frame line.
+            QVERIFY2(!res.record.phases[i].label.isEmpty(),
+                     qPrintable(QStringLiteral("phase %1 has empty label").arg(i)));
+        }
+        // The leading 0.0 samples must not spawn a spurious extra boundary: every
+        // transition marker (after frame 0) advances well past t≈0.
+        for (qsizetype i = 1; i < res.record.phases.size(); ++i)
+            QVERIFY2(res.record.phases[i].time > 0.1,
+                     qPrintable(QStringLiteral("transition marker %1 at t=%2")
+                                .arg(i).arg(res.record.phases[i].time)));
     }
 
     // Taste taps round-trip: the uploader maps tasteBalance/tasteBody to the CVA

--- a/tests/tst_visualizershotparse.cpp
+++ b/tests/tst_visualizershotparse.cpp
@@ -32,7 +32,23 @@ private:
         return doc.object();
     }
 
+    // Minimal valid download body: enough to clear parseVisualizerShot's guards
+    // (non-empty timeframe + pressure), plus whatever extra fields a test sets.
+    static QJsonObject minimalShot(const QJsonObject& extra)
+    {
+        QJsonArray tf;   tf.append(0.0);  tf.append(0.5);  tf.append(1.0);
+        QJsonArray pres; pres.append(1.0); pres.append(6.0); pres.append(9.0);
+        QJsonObject data;
+        data.insert(QStringLiteral("espresso_pressure"), pres);
+        QJsonObject shot = extra;
+        shot.insert(QStringLiteral("timeframe"), tf);
+        shot.insert(QStringLiteral("data"), data);
+        return shot;
+    }
+
 private slots:
+    void init() { QTest::failOnWarning(); }
+
     // The download string-encodes scalars — they must NOT come back as 0.
     void scalars_survive_string_encoding()
     {
@@ -67,12 +83,72 @@ private slots:
         QVERIFY2(!res.record.pressure.isEmpty(), "pressure series empty");
         QVERIFY2(!res.record.flow.isEmpty(), "flow series empty");
 
+        // Water dispensed is scaled x10 (tenths-of-ml on the wire -> real ml in
+        // the DB). The fixture's series peaks at raw 8.1685, so the recovered
+        // peak must be ~81.7 ml (not 8.2, and not double-scaled).
+        double maxWater = 0;
+        for (const auto& pt : res.record.waterDispensed)
+            if (pt.y() > maxWater) maxWater = pt.y();
+        QVERIFY2(qAbs(maxWater - 81.685) < 0.1,
+                 qPrintable(QStringLiteral("water-dispensed x10 wrong: %1").arg(maxWater)));
+
+        // Real frame detection: the fixture's state_change series flips sign 4
+        // times. A positive count (not just "no phantom") proves the frame-marker
+        // loop actually fires — a regression to zero frames would pass the
+        // phantom guard vacuously.
+        QCOMPARE(res.record.phases.size(), qsizetype(4));
+        QCOMPARE(res.record.phases.first().frameNumber, 1);
+
         // Phantom-frame guard: the state_change series starts at 0.0, which must
         // NOT register a phase boundary at t≈0.
         for (const auto& ph : res.record.phases)
             QVERIFY2(ph.time > 0.1,
                      qPrintable(QStringLiteral("phantom frame marker at t=%1")
                                 .arg(ph.time)));
+    }
+
+    // Taste taps round-trip: the uploader maps tasteBalance/tasteBody to the CVA
+    // attributes acidity/bitterness/mouthfeel; recovery must map them back so a
+    // device-swap recovery keeps the shot's taste dial-in.
+    void taste_axes_round_trip_from_cva()
+    {
+        // sour = (acidity 12, bitterness 4); heavy = (mouthfeel 12) — the values
+        // the uploader writes for those taps.
+        const QJsonObject sour = minimalShot({
+            {QStringLiteral("acidity"), 12},
+            {QStringLiteral("bitterness"), 4},
+            {QStringLiteral("mouthfeel"), 12},
+        });
+        const ShotFileParser::ParseResult r1 = ShotFileParser::parseVisualizerShot(
+            sour, QString(), QStringLiteral("t-sour"), 1751000000);
+        QVERIFY2(r1.success, qPrintable(r1.errorMessage));
+        QCOMPARE(r1.record.tasteBalance, QStringLiteral("sour"));
+        QCOMPARE(r1.record.tasteBody, QStringLiteral("heavy"));
+
+        // bitter = (acidity 4, bitterness 12); thin = (mouthfeel 4).
+        const QJsonObject bitter = minimalShot({
+            {QStringLiteral("acidity"), 4},
+            {QStringLiteral("bitterness"), 12},
+            {QStringLiteral("mouthfeel"), 4},
+        });
+        const ShotFileParser::ParseResult r2 = ShotFileParser::parseVisualizerShot(
+            bitter, QString(), QStringLiteral("t-bitter"), 1751000000);
+        QCOMPARE(r2.record.tasteBalance, QStringLiteral("bitter"));
+        QCOMPARE(r2.record.tasteBody, QStringLiteral("thin"));
+    }
+
+    // An untapped / hand-unscored shot (all CVA attrs 0, or absent) must NOT
+    // invent a taste value — the taps stay empty so upload doesn't clobber a
+    // Visualizer-scored assessment.
+    void taste_axes_unset_when_cva_absent()
+    {
+        const ShotFileParser::ParseResult r = ShotFileParser::parseVisualizerShot(
+            minimalShot({}), QString(), QStringLiteral("t-none"), 1751000000);
+        QVERIFY2(r.success, qPrintable(r.errorMessage));
+        QVERIFY2(r.record.tasteBalance.isEmpty(),
+                 qPrintable(QStringLiteral("tasteBalance invented: %1").arg(r.record.tasteBalance)));
+        QVERIFY2(r.record.tasteBody.isEmpty(),
+                 qPrintable(QStringLiteral("tasteBody invented: %1").arg(r.record.tasteBody)));
     }
 
     // A shot with a timeframe but no pressure telemetry must FAIL, not import a
@@ -93,5 +169,5 @@ private slots:
     }
 };
 
-QTEST_MAIN(TstVisualizerShotParse)
+QTEST_GUILESS_MAIN(TstVisualizerShotParse)
 #include "tst_visualizershotparse.moc"


### PR DESCRIPTION
### What

Adds a **recovery** flow to the Visualizer settings card: pick a date range and import shots that exist in your Visualizer account but are missing from this device's local history — e.g. after a device swap, a fresh install, or a gap in sync. Shots are fetched, parsed into `ShotRecord`s, de-duplicated against local history, and imported through the existing import path.

- `src/network/visualizerimporter.{cpp,h}` — fetch-by-date-range + import pipeline (loud failures on non-200/parse errors; hollow-shot and phantom-frame guards; idempotent re-runs).
- `src/history/shotfileparser.{cpp,h}` — `parseVisualizerShot`: Visualizer shot JSON → `ShotRecord` (scalars, metadata incl. the standard `barista` who-pulled field, notes, samples). Robust against malformed/partial JSON (sample arrays zipped with `qMin`, string-encoded scalars normalized, empty-timeframe/pressure rejected).
- `qml/pages/settings/SettingsVisualizerTab.qml` — the date-range recovery UI, and a fix so the Upload-Settings card scrolls (the recovery section was clipped below the fold).
- `tests/tst_visualizershotparse.cpp` — parser coverage incl. the malformed-input / value-mapping edge cases.

No new schema; imported shots use the existing `shots` table and the existing `importShotRecord` de-dupe path. Visualizer API usage (endpoints, auth header, DYE field names) mirrors the existing `visualizeruploader`.

### Known limitation (documented in code)

In the **sync-gap** case (some shots already local, recover the rest), a shot pulled on this device has a filename-keyed local uuid, so the recovery's visualizer-id-keyed uuid can't match it and dedupe falls to the existing secondary check (`|Δtimestamp| < 5s AND profile_name == profile_title`). The timestamp is an exact round-trip, so the sole discriminator is the profile title — a shot uploaded by a *different* client with a differently-formatted title, or whose profile was later renamed, can slip past and re-import as a **duplicate row** (not corruption). Fresh-install/device-swap recovery and re-running recovery are unaffected. A fully robust key would persist + compare the Visualizer id on the local shot too; I left that out because it touches the shared import/dedupe path — happy to add it if you'd prefer.

### Follow-up

This is a new user-visible feature, so it wants a wiki manual entry — I'll add that separately (the wiki is a separate repo). Flagging per the contributing guidance.
