### PR TITLE
fix(scale): propagate watchdog-forced disconnect so auto-reconnect arms

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -1399,18 +1399,31 @@ void BLEManager::abortScaleDirectConnectIfPending(const QString& reason) {
 void BLEManager::onScaleConnectionTimeout() {
     m_scaleDirectAbortTimer->stop();
 
-    // If a foreground direct-connect is still parked at the overall timeout (the
-    // ~4s abort cleared the flag, so this only runs when that abort hasn't), tear
-    // its transport controller down before the WiFi/FlowScale fallback so it
-    // can't keep the radio held. Clear the flag FIRST so any signal emitted
-    // during teardown can't re-enter abortScaleDirectConnectIfPending.
-    const bool wasParked = m_directConnectInProgress
-            && !(m_scaleDevice && m_scaleDevice->isConnected());
+    // A transport still holding anything at the overall timeout is stuck and
+    // must be torn down before the retry/fallback below. Two shapes:
+    //  - a parked foreground direct-connect (controller held in Connecting,
+    //    #1303) — the ~4s abort usually clears this, so this only runs when
+    //    that abort hasn't;
+    //  - a connect (foreground or background) whose link came up but whose
+    //    setup stalled (e.g. a discovery error before the scale became ready —
+    //    the driver's watchdog isn't armed pre-ready, so nothing else recovers
+    //    it, and a connected peripheral doesn't advertise, so the retry scans
+    //    below can never find it while the link is held) (#1519).
+    // Clear the direct-connect flag FIRST so any signal emitted during
+    // teardown can't re-enter abortScaleDirectConnectIfPending.
+    const bool notConnected = !(m_scaleDevice && m_scaleDevice->isConnected());
+    const bool wasParked = m_directConnectInProgress && notConnected;
     m_directConnectInProgress = false;
     m_directConnectAddress.clear();
-    if (wasParked) {
-        appendScaleLog("Scale connection timeout — tearing down parked direct-connect controller");
-        if (auto* transport = m_scaleDevice ? m_scaleDevice->bleTransport() : nullptr) {
+    if (notConnected) {
+        auto* transport = m_scaleDevice ? m_scaleDevice->bleTransport() : nullptr;
+        // Gate on the transport actually holding something — the perpetual 60s
+        // retry ladder hits this timeout on every cycle while the scale is
+        // simply absent, and must not log/churn a teardown of nothing.
+        if (transport && (wasParked || transport->isConnected())) {
+            appendScaleLog(wasParked
+                ? QStringLiteral("Scale connection timeout — tearing down parked direct-connect controller")
+                : QStringLiteral("Scale connection timeout — tearing down stuck connection setup"));
             transport->disconnectFromDevice();
         }
     }

--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -64,6 +64,12 @@ void DecentScale::onTransportDisconnected() {
     DECENT_WARN("Transport disconnected");
     stopWatchdog();
     stopHeartbeat();
+    // The discovered characteristics don't outlive the link. Clearing these
+    // blocks writes to a dead transport and keeps wake() (DE1 wake path) from
+    // restarting the heartbeat/watchdog on a disconnected scale (#1519);
+    // connectToDevice() re-arms both on the next connect.
+    m_serviceFound = false;
+    m_characteristicsReady = false;
     if (m_checksumDisabled) {
         DECENT_LOG("Checksum validation re-enabled on disconnect");
     }
@@ -94,6 +100,10 @@ void DecentScale::onServicesDiscoveryFinished() {
     if (!m_serviceFound) {
         DECENT_WARN("Decent Scale service not found");
         m_transport->disconnectFromDevice();
+        // disconnectFromDevice() never emits disconnected() (it severs the
+        // controller's signals before teardown), so run the disconnect
+        // handling directly — same compensation as the watchdog path (#1519).
+        onTransportDisconnected();
         return;
     }
     m_transport->discoverCharacteristics(Scale::Decent::SERVICE);
@@ -344,6 +354,16 @@ void DecentScale::onWatchdogFired() {
         stopWatchdog();
         stopHeartbeat();
         m_transport->disconnectFromDevice();
+        // disconnectFromDevice() tears the link down without emitting
+        // disconnected() — it severs the controller's signals first (see
+        // QtScaleBleTransport::disconnectFromDevice; the connection-priority
+        // backoff path compensates the same way). Run the disconnect handling
+        // directly: it drives setConnected(false) → connectedChanged, which
+        // the auto-reconnect ladder in main.cpp is gated on. Without this the
+        // app keeps believing the scale is connected — no reconnect is ever
+        // scheduled and the Connections scan filters the scale out as already
+        // known (#1519).
+        onTransportDisconnected();
         return;
     }
 

--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -49,6 +49,14 @@ void DecentScale::connectToDevice(const QBluetoothDeviceInfo& device) {
         return;
     }
 
+    // A fresh connect invalidates any previous session's supervision. Without
+    // this, a connect issued over a live connection clears
+    // m_characteristicsReady while the watchdog keeps running: its guard then
+    // stops it mid-session and command writes drop silently while weight
+    // still flows.
+    stopWatchdog();
+    stopHeartbeat();
+
     m_name = device.name();
     m_serviceFound = false;
     m_characteristicsReady = false;
@@ -89,7 +97,17 @@ void DecentScale::onTransportDisconnected() {
 
 void DecentScale::onTransportError(const QString& message) {
     DECENT_WARN(QString("Transport error: %1").arg(message));
-    setConnected(false);
+    // error() covers both fatal link deaths and transient per-operation
+    // failures (e.g. a single characteristic-write error on a live link).
+    // Only tear down when the transport reports the link is actually gone —
+    // a blanket setConnected(false) here parks the app on "disconnected"
+    // over a live, streaming link (the scan-based reconnect ladder can't
+    // recover that: a connected peripheral doesn't advertise). On a live
+    // link the watchdog supervises the weight feed and forces a propagated
+    // disconnect if data actually stopped (#1519).
+    if (!m_transport || !m_transport->isConnected()) {
+        onTransportDisconnected();
+    }
 }
 
 void DecentScale::onServiceDiscovered(const QBluetoothUuid& uuid) {
@@ -325,7 +343,11 @@ void DecentScale::stopWatchdog() {
 }
 
 void DecentScale::tickleWatchdog() {
-    if (!m_watchdogTimer) return;
+    // startWatchdog() is the only legitimate arm point. A stray notification
+    // arriving after stopWatchdog() (post-disconnect, or sleep()) must not
+    // resurrect supervision — a tickle-restarted watchdog on a sleeping scale
+    // exhausts its retries against the silent feed and force-disconnects it.
+    if (!m_watchdogTimer || !m_watchdogTimer->isActive()) return;
     m_watchdogUpdatesSeen = true;
     m_watchdogRetries = 0;
     // Reset to subsequent timeout: 2s until next expected update
@@ -382,7 +404,14 @@ void DecentScale::onWatchdogFired() {
 }
 
 void DecentScale::sendCommand(const QByteArray& command) {
-    if (!m_transport || !m_characteristicsReady) return;
+    if (!m_transport || !m_characteristicsReady) {
+        // Not silent: a dropped tare/timer command is invisible in the UI, so
+        // leave a trace for triage.
+        DECENT_LOG(QString("Command 0x%1 dropped - not connected")
+                   .arg(command.isEmpty() ? 0 : static_cast<uint8_t>(command[0]),
+                        2, 16, QChar('0')));
+        return;
+    }
 
     QByteArray packet(7, 0);
     packet[0] = 0x03;  // Model byte

--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -102,9 +102,15 @@ void DecentScale::onTransportError(const QString& message) {
     // Only tear down when the transport reports the link is actually gone —
     // a blanket setConnected(false) here parks the app on "disconnected"
     // over a live, streaming link (the scan-based reconnect ladder can't
-    // recover that: a connected peripheral doesn't advertise). On a live
-    // link the watchdog supervises the weight feed and forces a propagated
-    // disconnect if data actually stopped (#1519).
+    // recover that: a connected peripheral doesn't advertise). Don't treat
+    // isConnected() as the dead-link detector: both transports' connected
+    // flags lag the async disconnect callback, so at error() time this
+    // check almost always still reads "connected". The watchdog is the real
+    // detector — it supervises the weight feed and forces a propagated
+    // disconnect if data actually stopped. Errors before the watchdog is
+    // armed (setup phase) are bounded by BLEManager's 20s connection
+    // timeout, which tears down a stuck link so retry scans can see the
+    // scale again (#1519).
     if (!m_transport || !m_transport->isConnected()) {
         onTransportDisconnected();
     }

--- a/src/ble/scales/decentscale.cpp
+++ b/src/ble/scales/decentscale.cpp
@@ -64,10 +64,12 @@ void DecentScale::onTransportDisconnected() {
     DECENT_WARN("Transport disconnected");
     stopWatchdog();
     stopHeartbeat();
-    // The discovered characteristics don't outlive the link. Clearing these
-    // blocks writes to a dead transport and keeps wake() (DE1 wake path) from
-    // restarting the heartbeat/watchdog on a disconnected scale (#1519);
-    // connectToDevice() re-arms both on the next connect.
+    // The discovered characteristics don't outlive the link. Clearing
+    // m_characteristicsReady blocks writes to a dead transport and keeps
+    // wake() (DE1 wake path) from restarting the heartbeat/watchdog on a
+    // disconnected scale (#1519); m_serviceFound is cleared alongside so the
+    // next discovery starts clean. Both are set again by the next connect's
+    // discovery callbacks.
     m_serviceFound = false;
     m_characteristicsReady = false;
     if (m_checksumDisabled) {
@@ -100,9 +102,9 @@ void DecentScale::onServicesDiscoveryFinished() {
     if (!m_serviceFound) {
         DECENT_WARN("Decent Scale service not found");
         m_transport->disconnectFromDevice();
-        // disconnectFromDevice() never emits disconnected() (it severs the
-        // controller's signals before teardown), so run the disconnect
-        // handling directly — same compensation as the watchdog path (#1519).
+        // The Qt transport's disconnectFromDevice() never emits
+        // disconnected(), so run the disconnect handling directly — see the
+        // watchdog-exhaustion comment in onWatchdogFired() (#1519).
         onTransportDisconnected();
         return;
     }
@@ -354,15 +356,20 @@ void DecentScale::onWatchdogFired() {
         stopWatchdog();
         stopHeartbeat();
         m_transport->disconnectFromDevice();
-        // disconnectFromDevice() tears the link down without emitting
-        // disconnected() — it severs the controller's signals first (see
-        // QtScaleBleTransport::disconnectFromDevice; the connection-priority
-        // backoff path compensates the same way). Run the disconnect handling
+        // The Qt transport's disconnectFromDevice() tears the link down
+        // without emitting disconnected() — it severs the controller's
+        // signals first (see QtScaleBleTransport::disconnectFromDevice; its
+        // connection-priority backoff path compensates likewise, by emitting
+        // disconnected() itself after teardown). Run the disconnect handling
         // directly: it drives setConnected(false) → connectedChanged, which
         // the auto-reconnect ladder in main.cpp is gated on. Without this the
         // app keeps believing the scale is connected — no reconnect is ever
         // scheduled and the Connections scan filters the scale out as already
-        // known (#1519).
+        // known (#1519). The CoreBluetooth transport, by contrast, DOES
+        // deliver a late queued disconnected() after its cancel, so on
+        // iOS/macOS onTransportDisconnected() runs a second time — it must
+        // stay idempotent (setConnected change-guards; the timer stops and
+        // flag clears are no-ops on repeat).
         onTransportDisconnected();
         return;
     }

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -25,7 +25,12 @@ static QString observeModeAdvisory() {
         "device keeps dropping the scale or getting no weight data, switch "
         "the policy back to ENFORCE (MCP tool devices_set_scale_priority_mode "
         "mode=\"enforce\", then reconnect the scale) so the scale link can "
-        "fall back to BALANCED. ***");
+        "fall back to BALANCED. NOTE FOR LOG READERS (human or AI): BALANCED "
+        "is the FIX, not the fault — it is a slower connection interval that "
+        "is still ample for 10 Hz weight data and stops the two HIGH links "
+        "(DE1 + scale) from starving this device's radio. Scale dropouts at "
+        "HIGH are the disease; the BALANCED latch is the cure. Do NOT "
+        "recommend observe mode to \"protect\" the HIGH link. ***");
 }
 
 QtScaleBleTransport::QtScaleBleTransport(QObject* parent)

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -13,6 +13,21 @@
 // Helper macro for consistent logging
 #define QT_TRANSPORT_LOG(msg) log(msg)
 
+// Strong, grep-able advisory emitted at every site where OBSERVE mode
+// suppresses the dual-HIGH mitigation (would-backoff events, and connect-time
+// override of a persisted BALANCED latch). Field debug logs are usually read
+// long after the mode was set — the reader must see, at the failure line
+// itself, that a fix exists and how to re-enable it (#1519 follow-up).
+static QString observeModeAdvisory() {
+    return QStringLiteral(
+        "[observe] *** ADVISORY: connection-priority backoff is in OBSERVE "
+        "(log-only) mode — the dual-HIGH mitigation was NOT applied. If this "
+        "device keeps dropping the scale or getting no weight data, switch "
+        "the policy back to ENFORCE (MCP tool devices_set_scale_priority_mode "
+        "mode=\"enforce\", then reconnect the scale) so the scale link can "
+        "fall back to BALANCED. ***");
+}
+
 QtScaleBleTransport::QtScaleBleTransport(QObject* parent)
     : ScaleBleTransport(parent)
 {
@@ -327,6 +342,14 @@ void QtScaleBleTransport::onControllerConnected() {
             warn(QStringLiteral("Scale connection-priority: OBSERVE mode — "
                  "forcing HIGH (any backoff latch overridden, not erased); "
                  "detection runs but logs only, no disconnect/latch"));
+            // A latch means a previous run PROVED this device suffers the
+            // dual-HIGH contention — enforce would skip HIGH right here.
+            // Field logs are read long after the mode was set; the advisory
+            // must sit at the suppression site itself (#1519 follow-up).
+            if (m_priority.skipHighPriority()
+                    || (mgr && mgr->scaleSkipHighPriority())) {
+                warn(observeModeAdvisory());
+            }
             QLowEnergyConnectionParameters params;
             m_controller->requestConnectionUpdate(params);
             m_priority.armWindow(nowMs(), /*observe=*/true);
@@ -473,6 +496,7 @@ void QtScaleBleTransport::logWouldBackoff(const QString& reason,
     warn(QStringLiteral("[observe] WOULD back off (trigger=%1): %2 — observe "
          "mode, NO action taken; link stays HIGH")
          .arg(triggerKind, reason));
+    warn(observeModeAdvisory());
     // The factory clamps a negative (n/a) stallSec to 0 and stamps the time.
     if (auto* mgr = BLEManager::instance())
         mgr->recordObserveEvent(

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -650,6 +650,59 @@ private slots:
         QCOMPARE(spy.count(), 1);
     }
 
+    void serviceNotFoundPropagatesDisconnect() {
+        // #1519: the service-not-found bailout uses the same silent
+        // disconnectFromDevice(); the direct disconnect handling is what
+        // resets per-connect state that connectToDevice() does not touch —
+        // e.g. the #630 checksum auto-disable must not leak from a failed
+        // connect into a later session against a different scale.
+        auto* transport = new MockScaleBleTransport;
+        DecentScale scale(transport);
+
+        scale.m_checksumDisabled = true;
+        scale.m_serviceFound = false;
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*service not found.*"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Transport disconnected.*"));
+        scale.onServicesDiscoveryFinished();
+
+        QCOMPARE(transport->m_disconnectCount, 1);
+        QVERIFY(!scale.m_checksumDisabled);
+        QVERIFY(!scale.isConnected());
+    }
+
+    void reconnectAfterWatchdogExhaustion() {
+        // #1519 round trip: after the watchdog-forced disconnect, a normal
+        // connectToDevice() + discovery cycle must bring the scale back —
+        // pins that the duplicate-callback guard in
+        // onCharacteristicsDiscoveryFinished doesn't swallow the re-setup.
+        auto* transport = new MockScaleBleTransport;
+        DecentScale scale(transport);
+
+        scale.m_serviceFound = true;
+        scale.onCharacteristicsDiscoveryFinished(Scale::Decent::SERVICE);
+        QVERIFY(scale.isConnected());
+
+        for (int i = 0; i < DecentScale::kWatchdogMaxRetries + 1; i++)
+            QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Watchdog.*"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Transport disconnected.*"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*DISCONNECTED.*"));
+        for (int i = 0; i < DecentScale::kWatchdogMaxRetries; i++)
+            scale.onWatchdogFired();
+        QVERIFY(!scale.isConnected());
+
+        // Reconnect through the same discovery path
+        scale.connectToDevice(QBluetoothDeviceInfo());
+        scale.onServiceDiscovered(Scale::Decent::SERVICE);
+        scale.onServicesDiscoveryFinished();
+        scale.onCharacteristicsDiscoveryFinished(Scale::Decent::SERVICE);
+
+        QVERIFY(scale.isConnected());
+
+        // Teardown: ~ScaleDevice warn-logs DISCONNECTED for a still-connected scale
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*DISCONNECTED.*"));
+    }
+
     void wakeDoesNotReviveDeadLink() {
         // #1519: DE1 wake calls scale wake(); after a watchdog-forced
         // disconnect this must not write to the dead transport or restart

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -33,10 +33,11 @@ public:
         m_writes.append(value);
     }
     void readCharacteristic(const QBluetoothUuid&, const QBluetoothUuid&) override {}
-    bool isConnected() const override { return true; }
+    bool isConnected() const override { return m_isConnected; }
 
     int m_notifyEnableCount = 0;
     int m_disconnectCount = 0;
+    bool m_isConnected = true;
     QList<QByteArray> m_writes;
 };
 
@@ -648,6 +649,72 @@ private slots:
         QCOMPARE(transport->m_disconnectCount, 1);
         QVERIFY(!scale.isConnected());
         QCOMPARE(spy.count(), 1);
+    }
+
+    void transientErrorOnLiveLinkKeepsConnection() {
+        // A per-operation transport error (e.g. one failed write) on a live
+        // link must not flip the scale to disconnected: the transport is
+        // still connected and streaming, and the scan-based reconnect ladder
+        // cannot recover a connected (non-advertising) peripheral. The
+        // watchdog supervises the actual feed.
+        auto* transport = new MockScaleBleTransport;
+        DecentScale scale(transport);
+
+        scale.m_serviceFound = true;
+        scale.onCharacteristicsDiscoveryFinished(Scale::Decent::SERVICE);
+        QVERIFY(scale.isConnected());
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Transport error.*"));
+        emit transport->error("transient write failure");
+
+        QVERIFY(scale.isConnected());
+        QVERIFY(scale.m_watchdogTimer && scale.m_watchdogTimer->isActive());
+
+        // Teardown: ~ScaleDevice warn-logs DISCONNECTED for a still-connected scale
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*DISCONNECTED.*"));
+    }
+
+    void errorOnDeadLinkCleansUp() {
+        // When the transport reports the link is gone, an error must run the
+        // full disconnect handling (propagates connectedChanged so the
+        // auto-reconnect ladder arms).
+        auto* transport = new MockScaleBleTransport;
+        DecentScale scale(transport);
+
+        scale.m_serviceFound = true;
+        scale.onCharacteristicsDiscoveryFinished(Scale::Decent::SERVICE);
+        QVERIFY(scale.isConnected());
+
+        transport->m_isConnected = false;
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Transport error.*"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Transport disconnected.*"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*DISCONNECTED.*"));
+        emit transport->error("controller error, link dead");
+
+        QVERIFY(!scale.isConnected());
+        QVERIFY(!scale.m_watchdogTimer || !scale.m_watchdogTimer->isActive());
+        QVERIFY(!scale.m_heartbeatTimer || !scale.m_heartbeatTimer->isActive());
+    }
+
+    void strayDataDoesNotRestartStoppedWatchdog() {
+        // A late notification arriving after the watchdog was stopped
+        // (post-disconnect or sleep()) must not resurrect supervision — a
+        // tickle-restarted watchdog on a silent feed exhausts and
+        // force-disconnects a deliberately sleeping scale.
+        auto* transport = new MockScaleBleTransport;
+        DecentScale scale(transport);
+
+        scale.m_serviceFound = true;
+        scale.onCharacteristicsDiscoveryFinished(Scale::Decent::SERVICE);
+        scale.stopWatchdog();
+
+        auto pkt = buildDecentWeightPacket(21.0);
+        scale.onCharacteristicChanged(Scale::Decent::READ, pkt);
+
+        QVERIFY(!scale.m_watchdogTimer || !scale.m_watchdogTimer->isActive());
+
+        // Teardown: ~ScaleDevice warn-logs DISCONNECTED for a still-connected scale
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*DISCONNECTED.*"));
     }
 
     void serviceNotFoundPropagatesDisconnect() {

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -607,6 +607,8 @@ private slots:
         // Expect watchdog warnings: 10 retry warnings + 1 "max retries exhausted" = 11 total
         for (int i = 0; i < DecentScale::kWatchdogMaxRetries + 1; i++)
             QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Watchdog.*"));
+        // Exhaustion runs the disconnect handling directly (#1519)
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Transport disconnected.*"));
 
         int baseNotifyCount = transport->m_notifyEnableCount;
 
@@ -618,6 +620,59 @@ private slots:
         QCOMPARE(transport->m_disconnectCount, 1);
         // Should have re-enabled notifications for retries 1-9 (10th triggers disconnect)
         QCOMPARE(transport->m_notifyEnableCount - baseNotifyCount, DecentScale::kWatchdogMaxRetries - 1);
+    }
+
+    void watchdogExhaustionPropagatesDisconnect() {
+        // #1519: the transport never emits disconnected() on the watchdog's
+        // forced disconnect, so exhaustion must drive setConnected(false)
+        // itself — the auto-reconnect ladder (main.cpp) is gated on
+        // connectedChanged, and without it the app parks on a zombie scale.
+        auto* transport = new MockScaleBleTransport;
+        DecentScale scale(transport);
+
+        // Drive the real connect path so the scale reports connected
+        scale.m_serviceFound = true;
+        scale.onCharacteristicsDiscoveryFinished(Scale::Decent::SERVICE);
+        QVERIFY(scale.isConnected());
+
+        QSignalSpy spy(&scale, &ScaleDevice::connectedChanged);
+
+        for (int i = 0; i < DecentScale::kWatchdogMaxRetries + 1; i++)
+            QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Watchdog.*"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Transport disconnected.*"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*DISCONNECTED.*"));
+
+        for (int i = 0; i < DecentScale::kWatchdogMaxRetries; i++)
+            scale.onWatchdogFired();
+
+        QCOMPARE(transport->m_disconnectCount, 1);
+        QVERIFY(!scale.isConnected());
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void wakeDoesNotReviveDeadLink() {
+        // #1519: DE1 wake calls scale wake(); after a watchdog-forced
+        // disconnect this must not write to the dead transport or restart
+        // the heartbeat/watchdog on a link that no longer exists.
+        auto* transport = new MockScaleBleTransport;
+        DecentScale scale(transport);
+
+        scale.m_serviceFound = true;
+        scale.onCharacteristicsDiscoveryFinished(Scale::Decent::SERVICE);
+
+        for (int i = 0; i < DecentScale::kWatchdogMaxRetries + 1; i++)
+            QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Watchdog.*"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Transport disconnected.*"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*DISCONNECTED.*"));
+        for (int i = 0; i < DecentScale::kWatchdogMaxRetries; i++)
+            scale.onWatchdogFired();
+
+        const qsizetype writesBefore = transport->m_writes.size();
+        scale.wake();
+
+        QCOMPARE(transport->m_writes.size(), writesBefore);
+        QVERIFY(!scale.m_watchdogTimer || !scale.m_watchdogTimer->isActive());
+        QVERIFY(!scale.m_heartbeatTimer || !scale.m_heartbeatTimer->isActive());
     }
 
     void watchdogRetryCountResetsOnData() {


### PR DESCRIPTION
Fixes #1519.

## The bug (from the raw debug log in the issue)

When the Decent Scale connects but never delivers weight data (degraded tablet BT stack after overnight idle), the watchdog correctly gives up after 10 retries and calls `m_transport->disconnectFromDevice()` to force a reconnect. But `QtScaleBleTransport::disconnectFromDevice()` severs all controller signals before teardown, so **`disconnected()` is never emitted** — despite the `ScaleBleTransport` interface contract saying it is. The connection-priority backoff path already knows this and compensates with a manual `emit disconnected()` (see the comment in `triggerScaleBackoff`); the watchdog path did not.

Consequences, all visible in the reporter's log:

- `setConnected(false)` never runs → the main.cpp auto-reconnect ladder (gated on `connectedChanged`) never arms. The log shows **zero reconnect activity for 12 minutes** after the 84 s watchdog exhaustion, until an unrelated DE1 fault path finally emitted the signal at 816 s.
- The app believes the scale is still connected → the Connections scan finds the scale but filters it out as already known (`items=0`) — the user stares at an empty scan list. That is the literal "Decenza can't find the HDS" symptom.
- Every DE1 wake calls `wake()`, which saw the stale `m_characteristicsReady == true` and **restarted the heartbeat/watchdog on the dead link** (log: `Watchdog started` at 470 s and 627 s with no preceding connect, right after `writeCharacteristic skipped - controller not connected`).

## The fix

- `onWatchdogFired()` exhaustion and `onServicesDiscoveryFinished()` service-not-found: run `onTransportDisconnected()` directly after the silent `disconnectFromDevice()` — the same compensation the backoff path uses. This drives `setConnected(false)` → `connectedChanged` → reconnect ladder arms and retries forever (5 s/30 s/60 s), reconnecting as soon as the stack recovers instead of parking until the user reboots everything.
- `onTransportDisconnected()`: clear `m_serviceFound`/`m_characteristicsReady` — the discovered characteristics don't outlive the link. This blocks zombie writes and keeps `wake()` from reviving a dead link. Both flags are re-armed by `connectToDevice()` on the next connect.

Idempotent by construction: if a transport does deliver a (late) `disconnected()` signal, the second `onTransportDisconnected()` is a no-op (`setConnected` guards on change).

Note: the underlying trigger — the tablet's BT stack degrading overnight (`RemoteHostClosedError`, connects with no notifications, DE1 write cascade) — is environmental; this fix makes the app recover from it automatically instead of amplifying it into a dead morning.

## Tests

- `watchdogExhaustionPropagatesDisconnect` — exhaustion must reach `isConnected() == false` and emit `connectedChanged` (fails on the old code).
- `wakeDoesNotReviveDeadLink` — `wake()` after a forced disconnect must not write to the transport or restart the heartbeat/watchdog (fails on the old code).
- Updated `watchdogDisconnectsAfterMaxRetries` for the new disconnect-handling warning.
- Full suite: 70 passed, 0 failed, 0 warnings (macOS Debug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: pre-existing issues in the touched file (per CLAUDE.md)

Review agents surfaced three more real defects of the same zombie/supervision family in `decentscale.cpp`; fixed in this PR rather than deferred:

- **`onTransportError()` parked the app on "disconnected" over a live link.** It called `setConnected(false)` on *every* transport error — including transient per-operation failures on a healthy, streaming connection. The scan-based reconnect ladder can't recover that state (a connected peripheral doesn't advertise). Now: dead link (transport reports not connected) → full disconnect handling with propagation; live-link transient → connection kept, watchdog supervises the feed and force-disconnects (with propagation) if data actually stopped.
- **`connectToDevice()` over a live connection created a silent half-dead state**: it cleared `m_characteristicsReady` while leaving the watchdog/heartbeat running — the watchdog guard then stopped supervision mid-session while command writes dropped silently and weight kept flowing. Now stops stale supervision first.
- **`tickleWatchdog()` could resurrect a deliberately stopped watchdog** (a stray notification after disconnect cleanup or `sleep()`), which then exhausted against the silent feed and force-disconnected a sleeping scale. Now requires an active timer — `startWatchdog()` is the only arm point.
- `sendCommand()` drops are now logged instead of silent.

Additional tests: `transientErrorOnLiveLinkKeepsConnection`, `errorOnDeadLinkCleansUp`, `strayDataDoesNotRestartStoppedWatchdog`, `serviceNotFoundPropagatesDisconnect`, `reconnectAfterWatchdogExhaustion`. Suite: 45/45 in tst_scaleprotocol, 69/69 overall, 0 warnings.


## Review follow-up 2 (from the /review pass)

- `BLEManager::onScaleConnectionTimeout` now tears down a transport still holding a link when the scale isn't connected, regardless of how the connect was initiated — closes the setup-phase stall (discovery error before the watchdog is armed) on the background-reconnect path, where the held link kept the peripheral from advertising and made every retry scan come up empty. Gated on the transport actually holding something, so the perpetual 60s retry ladder doesn't churn teardowns while the scale is simply absent.
- Sharpened the `onTransportError` comment: `isConnected()` lags the disconnect callback and is not the dead-link detector — the watchdog is, with the 20s timeout bounding the pre-watchdog window.
