### PR TITLE
Fix taste intake: gate per-shot, not per-conversation

### DIFF
--- a/docs/CLAUDE_MD/AI_ADVISOR.md
+++ b/docs/CLAUDE_MD/AI_ADVISOR.md
@@ -19,12 +19,13 @@ When `Settings.ai.tasteIntakeOnAsk` is on (default), opening the advisor for a
 shot (`ConversationOverlay.openWithShot`) shows a fully text-free intake over the
 conversation — Extraction (`Sour`/`Balanced`/`Bitter` → `taste_balance`), Body
 (`Thin`/`Medium`/`Heavy` → `taste_body`), Overall (reused `RatingInput` →
-`enjoyment0to100`) — **unless there's already something to return to**: a saved
-conversation for the shot's context (`conversation.hasHistory`) or taste feedback
-already saved on the shot (any of `taste_balance` / `taste_body` /
-`enjoyment0to100`). So a new / cleared / backed-out-without-asking conversation
-re-shows the intake; once the user has asked the AI or recorded any taste it goes
-straight to the text conversation. **Ask** persists the taps via
+`enjoyment0to100`) — **whenever that shot has no taste feedback saved yet** (any of
+`taste_balance` / `taste_body` / `enjoyment0to100` set suppresses it). The gate is
+**per shot, independent of conversation history**: the conversation is keyed by
+bean+profile and shared across shots, so an ongoing conversation must NOT suppress
+the intake for a new, unrated shot — each new shot has its own qualities worth
+capturing. So a shot you've rated/tasted goes straight to the chat; a new or
+backed-out-without-entering shot re-shows the intake. **Ask** persists the taps via
 `requestUpdateShotMetadata`, composes a first-person question, and sends it with
 the shot attached; **Skip** drops into the normal text conversation.
 

--- a/openspec/specs/taste-intake/spec.md
+++ b/openspec/specs/taste-intake/spec.md
@@ -3,37 +3,39 @@
 ## Purpose
 TBD - created by archiving change add-ai-taste-intake. Update Purpose after archive.
 ## Requirements
-### Requirement: Tap-only taste intake for a fresh advisor session
+### Requirement: Tap-only taste intake, gated per shot
 
 When `Settings.ai.tasteIntakeOnAsk` is true, the system SHALL present a text-free,
-tap-only taste intake on opening the AI advisor for a shot **unless** there is
-already something to return to — namely a **saved conversation** for the shot's
-context (`conversation.hasHistory`) **or** taste feedback already saved on the
-shot (a non-empty `taste_balance`, `taste_body`, or a non-zero `enjoyment0to100`).
-When shown, the intake SHALL contain no free-text input of any kind and SHALL
-offer three rows — Extraction (`Sour` / `Balanced` / `Bitter`), Body (`Thin` /
-`Medium` / `Heavy`), and Overall (the existing `RatingInput`, values 25/50/75/100)
-— an "Ask" action, and a "Skip" action.
+tap-only taste intake on opening the AI advisor for a shot **whenever that shot has
+no taste feedback saved yet** — a non-empty `taste_balance`, `taste_body`, or a
+non-zero `enjoyment0to100` suppresses it; otherwise it is shown. The gate SHALL be
+**per shot and independent of conversation history**: the conversation is keyed by
+bean+profile and shared across many shots, so an ongoing conversation SHALL NOT
+suppress the intake for a new, unrated shot. When shown, the intake SHALL contain
+no free-text input of any kind and SHALL offer three rows — Extraction (`Sour` /
+`Balanced` / `Bitter`), Body (`Thin` / `Medium` / `Heavy`), and Overall (the
+existing `RatingInput`, values 25/50/75/100) — an "Ask" action, and a "Skip"
+action.
 
-#### Scenario: Fresh shot with no conversation and no feedback
-- **WHEN** the user opens the advisor for a shot with no saved conversation and no saved enjoyment/taste, with the setting ON
+#### Scenario: Fresh shot with no saved feedback
+- **WHEN** the user opens the advisor for a shot with no saved enjoyment/taste, with the setting ON
 - **THEN** the intake SHALL be shown with all three rows and an "Ask" button
 - **AND** no keyboard or text field SHALL be presented
+
+#### Scenario: New shot during an ongoing conversation still shows the intake
+- **WHEN** the user has an active bean+profile conversation with history, then opens the advisor for a NEW shot of the same bean+profile that has no saved taste feedback
+- **THEN** the intake SHALL still be shown — the shared conversation history SHALL NOT suppress it — so the new shot's qualities can be captured
 
 #### Scenario: Setting off
 - **WHEN** `Settings.ai.tasteIntakeOnAsk` is false
 - **THEN** opening the advisor SHALL go directly to the text conversation with the shot attached, with no intake shown
 
-#### Scenario: Empty conversation re-shows the intake
-- **WHEN** the user opened the advisor (intake shown), backed out without asking or cleared the conversation, so it has no history, and no taste feedback was saved
-- **THEN** re-opening the advisor SHALL show the intake again
-
-#### Scenario: Saved conversation suppresses the intake
-- **WHEN** the shot's conversation already has history (the user asked the AI before)
-- **THEN** opening the advisor SHALL go straight to the text conversation, with no intake
+#### Scenario: Backed out without entering anything re-shows the intake
+- **WHEN** the user opened the advisor (intake shown), backed out without tapping/asking, so the shot still has no saved taste feedback
+- **THEN** re-opening the advisor for that shot SHALL show the intake again
 
 #### Scenario: Saved taste feedback suppresses the intake
-- **WHEN** the shot already has a saved rating and/or taste axis (data entered and saved), even with no conversation
+- **WHEN** the shot already has a saved rating and/or taste axis (data entered and saved)
 - **THEN** opening the advisor SHALL go straight to the text conversation, with no intake
 
 ### Requirement: Ask composes a question from taps and attaches the shot

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -184,20 +184,20 @@ Rectangle {
         overlay.isMistakeShot = isMistake
         overlay.shotDebugLog = shotData.debugLog || ""
 
-        // Taste intake gate. Show the intake unless there's already something to
-        // go back to: a SAVED CONVERSATION for this shot's context, or taste
-        // feedback already entered + saved on the shot. So a new / cleared /
-        // backed-out-without-asking conversation (all empty) re-shows the intake
-        // next time; once the user has asked the AI or recorded any taste, it
-        // goes straight to the text conversation. (switchConversation ran above,
-        // so `conversation` reflects this shot's context.)
-        var conv = MainController.aiManager.conversation
-        var hasConversation = conv && conv.hasHistory
+        // Taste intake gate — per SHOT, not per conversation. Show the intake
+        // whenever THIS shot has no taste feedback saved yet, even if a
+        // conversation for this bean+profile is already going: the conversation
+        // is shared across many shots, so its history is not a per-shot signal,
+        // and each new shot has its own qualities worth capturing. Once this shot
+        // has any saved feedback (a rating or a taste axis), the intake is
+        // suppressed for it — so backing out without entering anything re-shows it
+        // next time, while a shot you've already rated/tasted goes straight to the
+        // text conversation.
         var hasSavedFeedback = ((shotData.tasteBalance || "").length > 0)
                             || ((shotData.tasteBody || "").length > 0)
                             || ((shotData.enjoyment0to100 || 0) > 0)
         var canIntake = Settings.ai.tasteIntakeOnAsk && !isMistake && shotId > 0
-                        && !hasConversation && !hasSavedFeedback
+                        && !hasSavedFeedback
         if (canIntake) {
             overlay.intakeTasteBalance = ""
             overlay.intakeTasteBody = ""


### PR DESCRIPTION
## Problem

Real-world testing found the taste intake failing to appear for a **new shot** when a conversation for the same bean+profile was already going.

The advisor conversation is keyed by **bean+profile** and shared across many shots, so gating on `conversation.hasHistory` suppressed the intake for a fresh, unrated shot just because an *earlier* shot of the same beans had been discussed — exactly when the new shot's (different) qualities are worth capturing.

## Fix

Gate purely on the **shot**: show the intake whenever *this* shot has no saved taste feedback (`taste_balance` / `taste_body` / `enjoyment0to100`), independent of conversation history.

- New / unrated shot → intake shows, **even mid-conversation**.
- Backed out without entering anything → shot still unrated → re-shows next time.
- Shot already rated/tasted → straight to the chat.

Updates the canonical `taste-intake` spec, `AI_ADVISOR.md`, and the wiki manual. Pure QML gate change (AOT-compiles clean); C++ untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)