### PR TITLE
i18n: localize VisualizerUploader and UpdateChecker error strings

### DIFF
--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -146,6 +146,8 @@ public:
     void setTranslationManager(TranslationManager* tm) {
         if (m_liveSteamCoach) m_liveSteamCoach->setTranslationManager(tm);
         if (m_visualizerImporter) m_visualizerImporter->setTranslationManager(tm);
+        if (m_visualizer) m_visualizer->setTranslationManager(tm);
+        if (m_updateChecker) m_updateChecker->setTranslationManager(tm);
     }
     void setAiManager(AIManager* aiManager) {
         m_aiManager = aiManager;

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -141,8 +141,9 @@ public:
     AIManager* aiManager() const { return m_aiManager; }
     LiveSteamCoach* liveSteamCoach() const { return m_liveSteamCoach; }
     // Injects the TranslationManager into the components that localize
-    // user-visible strings: the live steam coach (cue i18n) and the Visualizer
-    // importer (error messages).
+    // user-visible strings: the live steam coach (cue i18n), the Visualizer
+    // importer and uploader (error/status messages), and the update checker
+    // (update error messages).
     void setTranslationManager(TranslationManager* tm) {
         if (m_liveSteamCoach) m_liveSteamCoach->setTranslationManager(tm);
         if (m_visualizerImporter) m_visualizerImporter->setTranslationManager(tm);

--- a/src/core/updatechecker.cpp
+++ b/src/core/updatechecker.cpp
@@ -2,6 +2,7 @@
 #include "crashhandler.h"
 #include "settings.h"
 #include "settings_app.h"
+#include "translationmanager.h"
 #include "version.h"
 
 #include <algorithm>
@@ -206,6 +207,13 @@ UpdateChecker::UpdateChecker(QNetworkAccessManager* networkManager, Settings* se
     });
 }
 
+QString UpdateChecker::tr_(const char* key, const char* fallback) const {
+    if (m_translationManager)
+        return m_translationManager->translate(QString::fromUtf8(key),
+                                               QString::fromUtf8(fallback));
+    return QString::fromUtf8(fallback);
+}
+
 UpdateChecker::~UpdateChecker()
 {
     if (m_currentReply) {
@@ -232,7 +240,7 @@ void UpdateChecker::checkForUpdates()
 {
 #if defined(Q_OS_IOS)
     // iOS updates come from App Store only
-    m_errorMessage = "Updates are handled by the App Store";
+    m_errorMessage = tr_("update.error.appStore", "Updates are handled by the App Store");
     emit errorMessageChanged();
     return;
 #endif
@@ -261,7 +269,7 @@ void UpdateChecker::onReleaseInfoReceived()
     if (!m_currentReply) return;
 
     if (m_currentReply->error() != QNetworkReply::NoError) {
-        m_errorMessage = "Failed to check for updates: " + m_currentReply->errorString();
+        m_errorMessage = tr_("update.error.checkFailed", "Failed to check for updates: %1").arg(m_currentReply->errorString());
         emit errorMessageChanged();
         qWarning() << "UpdateChecker:" << m_errorMessage;
         m_currentReply->deleteLater();
@@ -280,7 +288,7 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
 {
     QJsonDocument doc = QJsonDocument::fromJson(data);
     if (!doc.isArray()) {
-        m_errorMessage = "Invalid response from GitHub";
+        m_errorMessage = tr_("update.error.invalidResponse", "Invalid response from GitHub");
         qWarning() << "UpdateChecker:" << m_errorMessage << "- response:" << data.left(200);
         emit errorMessageChanged();
         return;
@@ -303,7 +311,7 @@ void UpdateChecker::parseReleaseInfo(const QByteArray& data)
     }
 
     if (!found) {
-        m_errorMessage = "No releases found";
+        m_errorMessage = tr_("update.error.noReleases", "No releases found");
         emit errorMessageChanged();
         return;
     }
@@ -484,14 +492,15 @@ void UpdateChecker::downloadAndInstall()
         qWarning() << "UpdateChecker: downloadAndInstall called but no update available (current:"
                    << currentVersion() << "latest:" << m_latestVersion
                    << "downloadUrl:" << (m_downloadUrl.isEmpty() ? "<empty>" : m_downloadUrl) << ")";
-        m_errorMessage = "No update available";
+        m_errorMessage = tr_("update.error.noUpdate", "No update available");
         emit errorMessageChanged();
         return;
     }
     if (m_downloading || m_checking) return;
     if (m_installInFlight) {
-        m_errorMessage = "Install already in progress. If no confirmation dialog is visible, "
-                         "restart the app and try again.";
+        m_errorMessage = tr_("update.install.inProgress",
+                             "Install already in progress. If no confirmation dialog is visible, "
+                             "restart the app and try again.");
         emit errorMessageChanged();
         return;
     }
@@ -501,14 +510,15 @@ void UpdateChecker::downloadAndInstall()
     // rejected by ApkInstaller.install() at the end.
     if (QJniObject::callStaticMethod<jboolean>(
             "io/github/kulitorum/decenza_de1/ApkInstaller", "isInFlight", "()Z") == JNI_TRUE) {
-        m_errorMessage = "Install already in progress. If no confirmation dialog is visible, "
-                         "restart the app and try again.";
+        m_errorMessage = tr_("update.install.inProgress",
+                             "Install already in progress. If no confirmation dialog is visible, "
+                             "restart the app and try again.");
         emit errorMessageChanged();
         return;
     }
 #endif
     if (m_downloadUrl.isEmpty()) {
-        m_errorMessage = "No download available for this platform";
+        m_errorMessage = tr_("update.error.noDownload", "No download available for this platform");
         qWarning() << "UpdateChecker:" << m_errorMessage;
         emit errorMessageChanged();
         return;
@@ -563,7 +573,7 @@ void UpdateChecker::startDownload()
     savePath = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
 #endif
     if (!QDir().mkpath(savePath)) {
-        m_errorMessage = "Failed to create download directory: " + savePath;
+        m_errorMessage = tr_("update.error.createDir", "Failed to create download directory: %1").arg(savePath);
         qWarning() << "UpdateChecker:" << m_errorMessage;
         m_downloading = false;
         emit downloadingChanged();
@@ -576,7 +586,7 @@ void UpdateChecker::startDownload()
 
     m_downloadFile = new QFile(fullPath);
     if (!m_downloadFile->open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        m_errorMessage = "Failed to create download file: " + m_downloadFile->errorString();
+        m_errorMessage = tr_("update.error.createFile", "Failed to create download file: %1").arg(m_downloadFile->errorString());
         m_downloading = false;
         emit downloadingChanged();
         emit errorMessageChanged();
@@ -645,7 +655,7 @@ void UpdateChecker::startDownload()
             qWarning() << "UpdateChecker: Write failed during download:" << m_downloadFile->errorString();
             // Set the real error before aborting — abort() triggers onDownloadFinished
             // with OperationCanceledError, which would show a misleading message
-            m_errorMessage = "Download failed: could not write file (" + m_downloadFile->errorString() + ")";
+            m_errorMessage = tr_("update.error.writeFile", "Download failed: could not write file (%1)").arg(m_downloadFile->errorString());
             m_currentReply->abort();
         }
     });
@@ -681,7 +691,7 @@ void UpdateChecker::onDownloadFinished()
     if (!m_currentReply || !m_downloadFile) {
         qWarning() << "UpdateChecker: onDownloadFinished called with null reply or file"
                     << "reply=" << m_currentReply << "file=" << m_downloadFile;
-        m_errorMessage = "Download failed unexpectedly. Please try again.";
+        m_errorMessage = tr_("update.error.downloadUnexpected", "Download failed unexpectedly. Please try again.");
         emit errorMessageChanged();
         m_downloading = false;
         emit downloadingChanged();
@@ -693,7 +703,7 @@ void UpdateChecker::onDownloadFinished()
     if (!remaining.isEmpty()) {
         if (m_downloadFile->write(remaining) != remaining.size()) {
             qWarning() << "UpdateChecker: Final write failed:" << m_downloadFile->errorString();
-            m_errorMessage = "Download failed: could not write file (" + m_downloadFile->errorString() + ")";
+            m_errorMessage = tr_("update.error.writeFile", "Download failed: could not write file (%1)").arg(m_downloadFile->errorString());
             emit errorMessageChanged();
             const QString fileToRemove = m_downloadFile->fileName();
             const int capturedGen = s_downloadGeneration.loadAcquire();
@@ -749,8 +759,8 @@ void UpdateChecker::onDownloadFinished()
         if (m_errorMessage.isEmpty()) {
             const bool isTimeout = (m_currentReply->error() == QNetworkReply::TimeoutError);
             m_errorMessage = isTimeout
-                ? "Download timed out — check your network connection and tap Download & Install to try again."
-                : "Download failed: " + m_currentReply->errorString();
+                ? tr_("update.error.downloadTimeout", "Download timed out — check your network connection and tap Download & Install to try again.")
+                : tr_("update.error.downloadFailed", "Download failed: %1").arg(m_currentReply->errorString());
         }
         emit errorMessageChanged();
         {
@@ -775,7 +785,7 @@ void UpdateChecker::onDownloadFinished()
     // actualSize was captured from m_downloadFile->pos() before close() above.
     qint64 expectedSize = m_currentReply->header(QNetworkRequest::ContentLengthHeader).toLongLong();
     if (expectedSize > 0 && actualSize < expectedSize) {
-        m_errorMessage = QString("Download incomplete: got %1 of %2 bytes")
+        m_errorMessage = tr_("update.error.downloadIncomplete", "Download incomplete: got %1 of %2 bytes")
                              .arg(actualSize).arg(expectedSize);
         qWarning() << "UpdateChecker:" << m_errorMessage;
         emit errorMessageChanged();
@@ -801,7 +811,7 @@ void UpdateChecker::onDownloadFinished()
     // page from a failed redirect or severe truncation
     const qint64 MIN_APK_SIZE = 1024 * 1024;
     if (actualSize < MIN_APK_SIZE) {
-        m_errorMessage = QString("Downloaded file too small (%1 bytes) — download may have failed")
+        m_errorMessage = tr_("update.error.fileTooSmall", "Downloaded file too small (%1 bytes) — download may have failed")
                              .arg(actualSize);
         qWarning() << "UpdateChecker:" << m_errorMessage;
         emit errorMessageChanged();
@@ -976,7 +986,7 @@ bool UpdateChecker::installApk(const QString& apkPath)
 {
 #ifdef Q_OS_ANDROID
     if (s_nativeRegistrationFailed) {
-        m_errorMessage = "Install bridge failed to initialize. Please restart the app and try again.";
+        m_errorMessage = tr_("update.install.bridgeFailed", "Install bridge failed to initialize. Please restart the app and try again.");
         emit errorMessageChanged();
         return false;
     }
@@ -990,7 +1000,7 @@ bool UpdateChecker::installApk(const QString& apkPath)
 
     if (!activity.isValid()) {
         qWarning() << "UpdateChecker: Failed to get Android activity";
-        m_errorMessage = "Failed to get Android activity";
+        m_errorMessage = tr_("update.install.noActivity", "Failed to get Android activity");
         emit errorMessageChanged();
         return false;
     }
@@ -1027,11 +1037,13 @@ bool UpdateChecker::installApk(const QString& apkPath)
         jboolean inFlight = QJniObject::callStaticMethod<jboolean>(
             "io/github/kulitorum/decenza_de1/ApkInstaller", "isInFlight", "()Z");
         if (inFlight == JNI_TRUE) {
-            m_errorMessage = "Install already in progress. If no confirmation dialog is visible, "
-                             "restart the app and try again.";
+            m_errorMessage = tr_("update.install.inProgress",
+                                 "Install already in progress. If no confirmation dialog is visible, "
+                                 "restart the app and try again.");
         } else {
-            m_errorMessage = "Could not start install. If this is a first install, enable "
-                             "'Install Unknown Apps' for Decenza in Android Settings, then try again.";
+            m_errorMessage = tr_("update.install.couldNotStart",
+                                 "Could not start install. If this is a first install, enable "
+                                 "'Install Unknown Apps' for Decenza in Android Settings, then try again.");
         }
         emit errorMessageChanged();
         return false;
@@ -1043,7 +1055,7 @@ bool UpdateChecker::installApk(const QString& apkPath)
     return true;
 #else
     qDebug() << "UpdateChecker: APK installation only supported on Android. File saved to:" << apkPath;
-    m_errorMessage = "APK installation only supported on Android";
+    m_errorMessage = tr_("update.error.androidOnly", "APK installation only supported on Android");
     emit errorMessageChanged();
     return false;
 #endif
@@ -1123,35 +1135,36 @@ void UpdateChecker::onInstallStatus(int status, const QString& message)
             }
             return;
         case 2:  // STATUS_FAILURE_BLOCKED
-            userMessage = "Install blocked by device policy.";
+            userMessage = tr_("update.install.blocked", "Install blocked by device policy.");
             break;
         case 4:  // STATUS_FAILURE_INVALID
-            userMessage = "The downloaded APK is invalid. Please try again.";
+            userMessage = tr_("update.install.invalid", "The downloaded APK is invalid. Please try again.");
             break;
         case 5:  // STATUS_FAILURE_CONFLICT
-            userMessage = "Install conflicts with an existing app. Please uninstall and retry.";
+            userMessage = tr_("update.install.conflict", "Install conflicts with an existing app. Please uninstall and retry.");
             break;
         case 6:  // STATUS_FAILURE_STORAGE
-            userMessage = "Not enough storage to install the update.";
+            userMessage = tr_("update.install.storage", "Not enough storage to install the update.");
             break;
         case 7:  // STATUS_FAILURE_INCOMPATIBLE
-            userMessage = "Update is incompatible with this device.";
+            userMessage = tr_("update.install.incompatible", "Update is incompatible with this device.");
             break;
         case 8:  // STATUS_FAILURE_TIMEOUT
-            userMessage = "Install timed out. Please try again.";
+            userMessage = tr_("update.install.timeout", "Install timed out. Please try again.");
             break;
         case INTERNAL_STATUS_CREATE_FAILED:
-            userMessage = "Could not start install session. Check that 'Install Unknown Apps' "
-                          "is enabled for Decenza in Android Settings, then try again.";
+            userMessage = tr_("update.install.createSessionFailed",
+                              "Could not start install session. Check that 'Install Unknown Apps' "
+                              "is enabled for Decenza in Android Settings, then try again.");
             break;
         case INTERNAL_STATUS_WRITE_FAILED:
-            userMessage = "Failed to write the update package. Please try again.";
+            userMessage = tr_("update.install.writePackageFailed", "Failed to write the update package. Please try again.");
             break;
         case INTERNAL_STATUS_NO_CONFIRM_INTENT:
-            userMessage = "Install dialog could not be launched. Please try again.";
+            userMessage = tr_("update.install.noConfirmIntent", "Install dialog could not be launched. Please try again.");
             break;
         default:  // STATUS_FAILURE (1) and anything unexpected.
-            userMessage = "Install failed.";
+            userMessage = tr_("update.install.failed", "Install failed.");
             if (!message.isEmpty()) {
                 userMessage += " (" + message + ")";
             }

--- a/src/core/updatechecker.h
+++ b/src/core/updatechecker.h
@@ -8,6 +8,7 @@
 #include <QFileInfo>
 
 class Settings;
+class TranslationManager;
 
 class UpdateChecker : public QObject {
     Q_OBJECT
@@ -48,6 +49,12 @@ class UpdateChecker : public QObject {
 public:
     explicit UpdateChecker(QNetworkAccessManager* networkManager, Settings* settings, QObject* parent = nullptr);
     ~UpdateChecker();
+
+    // Inject the TranslationManager so user-visible error messages localize
+    // (mirrors VisualizerImporter/VisualizerUploader). Wired from
+    // MainController::setTranslationManager. Until injected, tr_() returns the
+    // English fallback.
+    void setTranslationManager(TranslationManager* tm) { m_translationManager = tm; }
 
     bool isChecking() const { return m_checking; }
     bool isDownloading() const { return m_downloading; }
@@ -141,7 +148,12 @@ private:
     int extractBuildNumber(const QString& version) const;
     bool isNewerVersion(const QString& latest, const QString& current) const;
 
+    // Translate a user-visible string via the injected TranslationManager,
+    // falling back to the English source when none is set.
+    QString tr_(const char* key, const char* fallback) const;
+
     Settings* m_settings = nullptr;
+    TranslationManager* m_translationManager = nullptr;
     QNetworkAccessManager* m_network = nullptr;
     QNetworkReply* m_currentReply = nullptr;
     QFile* m_downloadFile = nullptr;

--- a/src/network/visualizeruploader.cpp
+++ b/src/network/visualizeruploader.cpp
@@ -27,6 +27,7 @@
 #include "roastdate.h"
 #include "tastecvamap.h"
 #include "visualizershotlist.h"
+#include "../core/translationmanager.h"
 #include "../history/coffeebagstorage.h"
 #include "../core/dbutils.h"
 #include "../models/shotdatamodel.h"
@@ -75,6 +76,13 @@ VisualizerUploader::VisualizerUploader(QNetworkAccessManager* networkManager, Se
     , m_networkManager(networkManager)
 {
     Q_ASSERT(networkManager);
+}
+
+QString VisualizerUploader::tr_(const char* key, const char* fallback) const {
+    if (m_translationManager)
+        return m_translationManager->translate(QString::fromUtf8(key),
+                                               QString::fromUtf8(fallback));
+    return QString::fromUtf8(fallback);
 }
 
 // Helper: Interpolate goal data to match elapsed timestamps
@@ -159,7 +167,7 @@ void VisualizerUploader::uploadShot(ShotDataModel* shotData,
                                      qint64 dbShotId)
 {
     if (!shotData) {
-        emit uploadFailed("No shot data available");
+        emit uploadFailed(tr_("visualizer.upload.noShotData", "No shot data available"));
         return;
     }
 
@@ -176,7 +184,7 @@ void VisualizerUploader::uploadShot(ShotDataModel* shotData,
 void VisualizerUploader::uploadShotFromHistory(const ShotProjection& shotData)
 {
     if (!shotData.isValid()) {
-        emit uploadFailed("No shot data available");
+        emit uploadFailed(tr_("visualizer.upload.noShotData", "No shot data available"));
         return;
     }
 
@@ -203,7 +211,7 @@ void VisualizerUploader::uploadShotFromHistoryWithOverrides(
 {
     ShotProjection shot = ShotProjection::coerce(baseShot);
     if (!shot.isValid()) {
-        emit uploadFailed("No shot data available");
+        emit uploadFailed(tr_("visualizer.upload.noShotData", "No shot data available"));
         return;
     }
     auto applyStr    = [&](QString       ShotProjection::*f, const char* k) {
@@ -252,7 +260,7 @@ void VisualizerUploader::updateShotOnVisualizerWithOverrides(
     // catch a coerce miss here — otherwise a PATCH could go out with id=0 /
     // durationSec=0 / empty curves.
     if (!shot.isValid()) {
-        emit uploadFailed("No shot data available");
+        emit uploadFailed(tr_("visualizer.upload.noShotData", "No shot data available"));
         emit updateFailed(visualizerId, false, "No shot data available");
         return;
     }
@@ -295,7 +303,7 @@ void VisualizerUploader::updateShotOnVisualizerWithOverrides(
 void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, const ShotProjection& shotData)
 {
     if (visualizerId.isEmpty()) {
-        emit uploadFailed("No visualizer ID for update");
+        emit uploadFailed(tr_("visualizer.error.noVizId", "No visualizer ID for update"));
         emit updateFailed(visualizerId, false, "No visualizer ID for update");
         return;
     }
@@ -305,16 +313,16 @@ void VisualizerUploader::updateShotOnVisualizer(const QString& visualizerId, con
     QString password = m_settings->value("visualizer/password", "").toString();
 
     if (username.isEmpty() || password.isEmpty()) {
-        m_lastUploadStatus = "No credentials configured";
+        m_lastUploadStatus = tr_("visualizer.upload.noCredentials", "No credentials configured");
         emit lastUploadStatusChanged();
-        emit uploadFailed("Visualizer credentials not configured");
+        emit uploadFailed(tr_("visualizer.upload.credentialsMissing", "Visualizer credentials not configured"));
         emit updateFailed(visualizerId, false, "Visualizer credentials not configured");
         return;
     }
 
     m_uploading = true;
     emit uploadingChanged();
-    m_lastUploadStatus = "Updating...";
+    m_lastUploadStatus = tr_("visualizer.status.updating", "Updating...");
     emit lastUploadStatusChanged();
 
     // Build JSON body: {"shot": {"bean_brand": "...", ...}}
@@ -429,7 +437,7 @@ void VisualizerUploader::onUpdateFinished(QNetworkReply* reply, const QString& v
     QByteArray response = reply->readAll();
 
     if (reply->error() == QNetworkReply::NoError) {
-        m_lastUploadStatus = "Update successful";
+        m_lastUploadStatus = tr_("visualizer.status.updateSuccess", "Update successful");
         emit lastUploadStatusChanged();
         emit updateSuccess(visualizerId);
         qDebug() << "Visualizer: Update successful for shot" << visualizerId;
@@ -437,21 +445,21 @@ void VisualizerUploader::onUpdateFinished(QNetworkReply* reply, const QString& v
         QString errorMsg;
 
         if (statusCode == 401) {
-            errorMsg = "Invalid credentials";
+            errorMsg = tr_("visualizer.error.invalidCredentials", "Invalid credentials");
         } else if (statusCode == 404) {
-            errorMsg = "Shot not found on Visualizer";
+            errorMsg = tr_("visualizer.error.shotNotFound", "Shot not found on Visualizer");
         } else if (statusCode == 422) {
             QJsonDocument doc = QJsonDocument::fromJson(response);
             QJsonObject obj = doc.object();
             errorMsg = obj["error"].toString();
             if (errorMsg.isEmpty()) {
-                errorMsg = "Invalid data (422)";
+                errorMsg = tr_("visualizer.error.invalidData422", "Invalid data (422)");
             }
         } else {
-            errorMsg = QString("HTTP %1: %2").arg(statusCode).arg(reply->errorString());
+            errorMsg = tr_("visualizer.error.http", "HTTP %1: %2").arg(statusCode).arg(reply->errorString());
         }
 
-        m_lastUploadStatus = "Failed: " + errorMsg;
+        m_lastUploadStatus = tr_("visualizer.status.failed", "Failed: %1").arg(errorMsg);
         emit lastUploadStatusChanged();
         emit uploadFailed(errorMsg);
         // 404 is the one terminal outcome: the shot is gone from (or was
@@ -475,7 +483,7 @@ void VisualizerUploader::testConnection()
     QString password = m_settings->value("visualizer/password", "").toString();
 
     if (username.isEmpty() || password.isEmpty()) {
-        emit connectionTestResult(false, "Username or password not set");
+        emit connectionTestResult(false, tr_("visualizer.test.noUserPass", "Username or password not set"));
         return;
     }
 
@@ -519,7 +527,7 @@ void VisualizerUploader::onUploadFinished(QNetworkReply* reply)
         QString shotId = obj["id"].toString();
         if (!shotId.isEmpty()) {
             m_lastShotUrl = QString(VISUALIZER_SHOT_URL) + shotId;
-            m_lastUploadStatus = "Upload successful";
+            m_lastUploadStatus = tr_("visualizer.status.uploadSuccess", "Upload successful");
             emit lastShotUrlChanged();
             emit lastUploadStatusChanged();
             emit uploadSuccess(shotId, m_lastShotUrl);
@@ -537,7 +545,7 @@ void VisualizerUploader::onUploadFinished(QNetworkReply* reply)
             // local shot row never gets its visualizer_id and the bag sync
             // chain never runs. Surface it so the user sees an error and a
             // retry path, instead of a benign-looking "completed" status.
-            m_lastUploadStatus = "Upload returned no shot id (unexpected response)";
+            m_lastUploadStatus = tr_("visualizer.error.noShotIdReturned", "Upload returned no shot id (unexpected response)");
             emit lastUploadStatusChanged();
             qWarning() << "Visualizer: upload succeeded (HTTP" << statusCode
                        << ") but response had no shot id:" << response.left(200);
@@ -563,19 +571,19 @@ void VisualizerUploader::onUploadFinished(QNetworkReply* reply)
         QString errorMsg;
 
         if (statusCode == 401) {
-            errorMsg = "Invalid credentials";
+            errorMsg = tr_("visualizer.error.invalidCredentials", "Invalid credentials");
         } else if (statusCode == 422) {
             QJsonDocument doc = QJsonDocument::fromJson(response);
             QJsonObject obj = doc.object();
             errorMsg = obj["error"].toString();
             if (errorMsg.isEmpty()) {
-                errorMsg = "Invalid shot data (422)";
+                errorMsg = tr_("visualizer.error.invalidShotData422", "Invalid shot data (422)");
             }
         } else {
-            errorMsg = QString("HTTP %1: %2").arg(statusCode).arg(reply->errorString());
+            errorMsg = tr_("visualizer.error.http", "HTTP %1: %2").arg(statusCode).arg(reply->errorString());
         }
 
-        m_lastUploadStatus = "Failed: " + errorMsg;
+        m_lastUploadStatus = tr_("visualizer.status.failed", "Failed: %1").arg(errorMsg);
         emit lastUploadStatusChanged();
         emit uploadFailed(errorMsg);
         qDebug() << "Visualizer: Upload failed -" << errorMsg << "Response:" << response;
@@ -593,13 +601,13 @@ void VisualizerUploader::onUploadFinished(QNetworkReply* reply)
 void VisualizerUploader::onTestFinished(QNetworkReply* reply)
 {
     if (reply->error() == QNetworkReply::NoError) {
-        emit connectionTestResult(true, "Connection successful!");
+        emit connectionTestResult(true, tr_("visualizer.test.success", "Connection successful!"));
     } else {
         int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         QString errorMsg;
 
         if (statusCode == 401) {
-            errorMsg = "Invalid username or password";
+            errorMsg = tr_("visualizer.test.invalidUserPass", "Invalid username or password");
         } else {
             errorMsg = reply->errorString();
         }
@@ -1211,8 +1219,8 @@ bool VisualizerUploader::validateUpload(const QString& beverageType, double dura
 {
     // Skip maintenance profiles (shared tier — see Profile::isMaintenanceBeverageType)
     if (Profile::isMaintenanceBeverageType(beverageType)) {
-        const QString reason = QString("maintenance profile (%1)").arg(beverageType);
-        m_lastUploadStatus = QString("Skipped: %1").arg(reason);
+        const QString reason = tr_("visualizer.skip.maintenance", "maintenance profile (%1)").arg(beverageType);
+        m_lastUploadStatus = tr_("visualizer.status.skipped", "Skipped: %1").arg(reason);
         emit lastUploadStatusChanged();
         // Policy skip, not an error — uploadSkipped lets the page clear its
         // in-flight flags without surfacing a red error to UI listeners that
@@ -1228,17 +1236,17 @@ bool VisualizerUploader::validateUpload(const QString& beverageType, double dura
     QString username = m_settings->value("visualizer/username", "").toString();
     QString password = m_settings->value("visualizer/password", "").toString();
     if (username.isEmpty() || password.isEmpty()) {
-        m_lastUploadStatus = "No credentials configured";
+        m_lastUploadStatus = tr_("visualizer.upload.noCredentials", "No credentials configured");
         emit lastUploadStatusChanged();
-        emit uploadFailed("Visualizer credentials not configured");
+        emit uploadFailed(tr_("visualizer.upload.credentialsMissing", "Visualizer credentials not configured"));
         return false;
     }
 
     // Check minimum duration
     double minDuration = m_settings->value("visualizer/minDuration", 6.0).toDouble();
     if (duration < minDuration) {
-        const QString reason = QString("shot too short (%1s < %2s)").arg(duration, 0, 'f', 1).arg(minDuration, 0, 'f', 0);
-        m_lastUploadStatus = QString("Skipped: %1").arg(reason);
+        const QString reason = tr_("visualizer.skip.tooShort", "shot too short (%1s < %2s)").arg(duration, 0, 'f', 1).arg(minDuration, 0, 'f', 0);
+        m_lastUploadStatus = tr_("visualizer.status.skipped", "Skipped: %1").arg(reason);
         emit lastUploadStatusChanged();
         // Policy skip, not an error — see uploadSkipped rationale on the
         // maintenance branch above. Emit just the reason payload.
@@ -1249,7 +1257,7 @@ bool VisualizerUploader::validateUpload(const QString& beverageType, double dura
 
     m_uploading = true;
     emit uploadingChanged();
-    m_lastUploadStatus = "Uploading...";
+    m_lastUploadStatus = tr_("visualizer.status.uploading", "Uploading...");
     emit lastUploadStatusChanged();
     return true;
 }
@@ -2124,7 +2132,7 @@ void VisualizerUploader::patchRemoteBag(const QVariantMap& bag, const QString& r
             const QJsonObject err = QJsonDocument::fromJson(reply->readAll()).object();
             QString message = err.value(QStringLiteral("error")).toString();
             if (message.isEmpty())
-                message = QStringLiteral("Visualizer rejected the bag update");
+                message = tr_("visualizer.bag.rejected", "Visualizer rejected the bag update");
             emit bagPushRejected(localBagId, bagDisplayName, message);
             qDebug() << "Visualizer CM: bag update 422 for bag" << localBagId
                      << "(" << bagDisplayName << ") -" << message;

--- a/src/network/visualizeruploader.h
+++ b/src/network/visualizeruploader.h
@@ -12,6 +12,7 @@ class ShotDataModel;
 class Settings;
 class Profile;
 class DE1Device;
+class TranslationManager;
 
 // DYE (Describe Your Espresso) metadata for shot uploads
 struct ShotMetadata {
@@ -75,6 +76,12 @@ public:
     QString lastShotUrl() const { return m_lastShotUrl; }
 
     void setDevice(DE1Device* device) { m_device = device; }
+
+    // Inject the TranslationManager so user-visible upload/status/error strings
+    // localize (mirrors VisualizerImporter). Wired from
+    // MainController::setTranslationManager. Until injected, tr_() returns the
+    // English fallback.
+    void setTranslationManager(TranslationManager* tm) { m_translationManager = tm; }
 
     // Upload shot data to visualizer.coffee.
     // `dbShotId` is the local shots.id this upload is for, so a successful
@@ -226,6 +233,10 @@ private:
     QByteArray buildMultipartData(const QByteArray& jsonData, const QString& boundary);
     QString authHeader() const;
 
+    // Translate a user-visible string via the injected TranslationManager,
+    // falling back to the English source when none is set.
+    QString tr_(const char* key, const char* fallback) const;
+
     static QJsonObject buildAppInfoJson();
     static QJsonObject buildProfileSettings(const Profile* profile);
     bool validateUpload(const QString& beverageType, double duration);
@@ -298,6 +309,7 @@ private:
     Settings* m_settings;
     QNetworkAccessManager* m_networkManager;
     DE1Device* m_device = nullptr;
+    TranslationManager* m_translationManager = nullptr;
     bool m_uploading = false;
     QString m_lastUploadStatus;
     QString m_lastShotUrl;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,9 +96,10 @@ add_library(decenza_testlib STATIC
     ${CORE_SOURCES}
     ${CONTROLLER_SOURCES}
     ${SIMULATOR_SOURCES}
-    # TranslationManager is used by shared sources here (e.g. VisualizerUploader
-    # via HISTORY_SOURCES, LiveSteamCoach) that now route user-visible strings
-    # through translate(); provide it once instead of per-target.
+    # TranslationManager is needed by per-target sources that link this lib
+    # (VisualizerUploader via HISTORY_SOURCES; LiveSteamCoach) now that they
+    # route user-visible strings through translate(). Compiling it into the lib
+    # provides the symbol once instead of each target adding translationmanager.cpp.
     ${CMAKE_SOURCE_DIR}/src/core/translationmanager.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/de1transport.h
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,6 +96,10 @@ add_library(decenza_testlib STATIC
     ${CORE_SOURCES}
     ${CONTROLLER_SOURCES}
     ${SIMULATOR_SOURCES}
+    # TranslationManager is used by shared sources here (e.g. VisualizerUploader
+    # via HISTORY_SOURCES, LiveSteamCoach) that now route user-visible strings
+    # through translate(); provide it once instead of per-target.
+    ${CMAKE_SOURCE_DIR}/src/core/translationmanager.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/de1transport.h
 )
 set_target_properties(decenza_testlib PROPERTIES AUTOMOC ON AUTOMOC_PATH_PREFIX OFF)
@@ -217,7 +221,6 @@ add_decenza_test(tst_machinestate
 add_decenza_test(tst_livesteamcoach
     tst_livesteamcoach.cpp
     ${CMAKE_SOURCE_DIR}/src/ai/livesteamcoach.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/translationmanager.cpp
 )
 
 # --- tst_machinestatussnapshot: widget snapshot schema + temp coalescing ---
@@ -737,7 +740,6 @@ add_decenza_test(tst_mcptools_write
     ${PROFILEMANAGER_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/core/accessibilitymanager.cpp
     ${CMAKE_SOURCE_DIR}/src/screensaver/screensavervideomanager.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/translationmanager.cpp
     ${CMAKE_SOURCE_DIR}/src/core/batterymanager.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_internal.cpp
@@ -763,7 +765,6 @@ add_decenza_test(tst_mcptools_presets
     ${PROFILEMANAGER_SOURCES}
     ${CMAKE_SOURCE_DIR}/src/core/accessibilitymanager.cpp
     ${CMAKE_SOURCE_DIR}/src/screensaver/screensavervideomanager.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/translationmanager.cpp
     ${CMAKE_SOURCE_DIR}/src/core/batterymanager.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage.cpp
     ${CMAKE_SOURCE_DIR}/src/history/shothistorystorage_internal.cpp
@@ -873,7 +874,6 @@ find_package(Qt6 REQUIRED COMPONENTS TextToSpeech Multimedia Quick Network)
 add_decenza_test(tst_accessibility_announcements
     tst_accessibility_announcements.cpp
     ${CMAKE_SOURCE_DIR}/src/core/accessibilitymanager.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/translationmanager.cpp
 )
 target_link_libraries(tst_accessibility_announcements PRIVATE
     Qt6::TextToSpeech Qt6::Multimedia Qt6::Quick Qt6::Network


### PR DESCRIPTION
### What

Second batch of the C++ backend error-string i18n effort (follows #1523 which did `VisualizerImporter`). Routes the user-visible error/status strings in two more classes through `TranslationManager` instead of hardcoded English rendered in the UI.

- **`VisualizerUploader`** (~20 strings): upload/update/skip status, connection-test results, and bag-push rejection — shown on PostShotReviewPage, SettingsVisualizerTab, and toasts. The internal `shotListFailed` backfill strings (consumed only by the migration back-sync, never shown) and `qDebug` logs stay English.
- **`UpdateChecker`** (~20 strings): check/download/install error messages shown on SettingsUpdateTab, including the Android install-status block.

Both are MainController-owned, so injection is one line each in `MainController::setTranslationManager`; strings route through a `tr_(key, fallback)` helper with `%1`/`%2` args preserved on the dynamic ones.

### Test infrastructure

`TranslationManager` is now compiled once into the shared `decenza_testlib` (it's pulled in by shared sources like `VisualizerUploader` via `HISTORY_SOURCES`), replacing the ad-hoc per-target additions in `tst_livesteamcoach` / `tst_mcptools_write` / `tst_mcptools_presets` / `tst_accessibility_announcements`.

### Testing

Build clean (0 warnings). Ran the CMake-touched targets (`tst_livesteamcoach`, `tst_accessibility_announcements`, `tst_mcptools_write`, `tst_mcptools_presets`) plus a regression set (`tst_shotimportdedupe`, `tst_coffeebags`, `tst_dbmigration`, `tst_visualizershotparse`, `tst_aimanager`, `tst_profilemanager`) and `failonwarning_lint` — all pass. Behavior-preserving (additive `tr_` wrapper; returns English fallback when no translation loaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)