### PR TITLE
i18n: localize AI provider/manager/conversation error strings

### DIFF
--- a/src/ai/aiconversation.cpp
+++ b/src/ai/aiconversation.cpp
@@ -1,6 +1,7 @@
 #include "aiconversation.h"
 #include "aimanager.h"
 #include "shotsummarizer.h"
+#include "../core/translationmanager.h"
 
 #include <QDateTime>
 #include <QDebug>
@@ -34,6 +35,14 @@ const QRegularExpression AIConversation::s_profileRe("\\*\\*Profile\\*\\*:\\s*(.
 const QRegularExpression AIConversation::s_scoreRe("\\*\\*Score\\*\\*:\\s*(\\d+)");
 const QRegularExpression AIConversation::s_notesRe("\\*\\*Notes\\*\\*:\\s*\"([^\"]+)\"");
 
+QString AIConversation::tr_(const char* key, const char* fallback) const
+{
+    if (m_translationManager)
+        return m_translationManager->translate(QString::fromUtf8(key),
+                                               QString::fromUtf8(fallback));
+    return QString::fromUtf8(fallback);
+}
+
 AIConversation::AIConversation(AIManager* aiManager, QObject* parent)
     : QObject(parent)
     , m_aiManager(aiManager)
@@ -65,7 +74,7 @@ void AIConversation::ask(const QString& systemPrompt, const QString& userMessage
 {
     if (!m_aiManager) {
         qWarning() << "AIConversation::ask called without AIManager";
-        m_errorMessage = "AI not available";
+        m_errorMessage = tr_("ai.error.notAvailable", "AI not available");
         emit errorOccurred(m_errorMessage);
         return;
     }
@@ -91,7 +100,7 @@ bool AIConversation::followUp(const QString& userMessage)
 {
     if (!m_aiManager) {
         qWarning() << "AIConversation::followUp called without AIManager";
-        m_errorMessage = "AI not available";
+        m_errorMessage = tr_("ai.error.notAvailable", "AI not available");
         emit errorOccurred(m_errorMessage);
         return false;
     }
@@ -101,7 +110,7 @@ bool AIConversation::followUp(const QString& userMessage)
     }
     if (m_systemPrompt.isEmpty()) {
         qWarning() << "AIConversation::followUp called without prior ask()";
-        m_errorMessage = "Please start a new conversation first";
+        m_errorMessage = tr_("ai.error.startNewFirst", "Please start a new conversation first");
         emit errorOccurred(m_errorMessage);
         return false;
     }
@@ -399,7 +408,7 @@ void AIConversation::dropTrailingFailedUserTurn()
 void AIConversation::sendRequest()
 {
     if (!m_aiManager || !m_aiManager->isConfigured()) {
-        m_errorMessage = "AI not configured";
+        m_errorMessage = tr_("ai.error.notConfigured", "AI not configured");
         emit errorOccurred(m_errorMessage);
         return;
     }
@@ -560,7 +569,7 @@ void AIConversation::addShotContext(const QString& shotSummary, const QString& s
 {
     if (m_busy) {
         qWarning() << "AIConversation::addShotContext ignored — already busy";
-        m_errorMessage = "Please wait for the current request to complete";
+        m_errorMessage = tr_("ai.error.waitForRequest", "Please wait for the current request to complete");
         emit errorOccurred(m_errorMessage);
         return;
     }
@@ -986,7 +995,7 @@ void AIConversation::loadFromStorage()
         if (parseError.error != QJsonParseError::NoError) {
             qWarning() << "AIConversation::loadFromStorage: JSON parse error for key" << m_storageKey
                         << ":" << parseError.errorString();
-            m_errorMessage = "Could not load conversation history";
+            m_errorMessage = tr_("ai.error.loadHistoryFailed", "Could not load conversation history");
             emit errorOccurred(m_errorMessage);
         } else if (doc.isArray()) {
             m_messages = doc.array();

--- a/src/ai/aiconversation.h
+++ b/src/ai/aiconversation.h
@@ -7,6 +7,7 @@
 #include <optional>
 
 class AIManager;
+class TranslationManager;
 
 /**
  * AIConversation - Manages a multi-turn conversation with an AI provider
@@ -41,6 +42,11 @@ class AIConversation : public QObject {
 
 public:
     explicit AIConversation(AIManager* aiManager, QObject* parent = nullptr);
+
+    // Inject the TranslationManager so user-visible error strings localize.
+    // Set by AIManager::setTranslationManager; until injected, tr_() returns
+    // the English fallback.
+    void setTranslationManager(TranslationManager* tm) { m_translationManager = tm; }
 
     bool isBusy() const { return m_busy; }
     bool hasHistory() const { return !m_messages.isEmpty(); }
@@ -252,6 +258,9 @@ private slots:
 
 private:
     void sendRequest();
+    // Translate a user-visible string via the injected TranslationManager,
+    // falling back to the English source when none is set.
+    QString tr_(const char* key, const char* fallback) const;
     // Drop a trailing unanswered user turn (a turn kept by onAnalysisFailed for
     // retry) before appending a new user message, so we never send two
     // consecutive user-role messages. No-op unless the last entry is a user turn.
@@ -315,6 +324,7 @@ private:
         s_grinderRe, s_profileRe, s_scoreRe, s_notesRe;
 
     AIManager* m_aiManager;
+    TranslationManager* m_translationManager = nullptr;
     QString m_systemPrompt;
     // Array of {role, content[, shotId?, structuredNext?]} objects.
     // shotId is the resolved shot id the advisor was asked about for

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -11,6 +11,7 @@
 #include "../profile/profile.h"
 #include "../network/visualizeruploader.h"
 #include "../history/shothistorystorage.h"
+#include "../core/translationmanager.h"
 
 #include <QNetworkAccessManager>
 #include <QStandardPaths>
@@ -142,6 +143,27 @@ void AIManager::createProviders()
     connect(ollama, &AIProvider::testResult, this, &AIManager::onTestResult);
     connect(ollama, &OllamaProvider::modelsRefreshed, this, &AIManager::onOllamaModelsRefreshed);
     m_ollamaProvider.reset(ollama);
+}
+
+void AIManager::setTranslationManager(TranslationManager* tm)
+{
+    m_translationManager = tm;
+    // Fan out to every owned provider (created in the ctor, before this runs)
+    // and the conversation, so their user-visible error strings localize too.
+    for (AIProvider* p : { m_openaiProvider.get(), m_anthropicProvider.get(),
+                           m_geminiProvider.get(), m_openrouterProvider.get(),
+                           m_ollamaProvider.get() }) {
+        if (p) p->setTranslationManager(tm);
+    }
+    if (m_conversation) m_conversation->setTranslationManager(tm);
+}
+
+QString AIManager::tr_(const char* key, const char* fallback) const
+{
+    if (m_translationManager)
+        return m_translationManager->translate(QString::fromUtf8(key),
+                                               QString::fromUtf8(fallback));
+    return QString::fromUtf8(fallback);
 }
 
 QString AIManager::selectedProvider() const
@@ -1239,7 +1261,7 @@ void AIManager::testConnection()
 {
     AIProvider* provider = currentProvider();
     if (!provider) {
-        m_lastTestResult = "No AI provider selected";
+        m_lastTestResult = tr_("ai.error.noProviderSelected", "No AI provider selected");
         m_lastTestSuccess = false;
         emit testResultChanged();
         return;
@@ -1251,20 +1273,20 @@ void AIManager::testConnection()
 void AIManager::analyze(const QString& systemPrompt, const QString& userPrompt)
 {
     if (m_analyzing) {
-        m_lastError = "Analysis already in progress";
+        m_lastError = tr_("ai.error.analysisInProgress", "Analysis already in progress");
         emit errorOccurred(m_lastError);
         return;
     }
 
     AIProvider* provider = currentProvider();
     if (!provider) {
-        m_lastError = "No AI provider configured";
+        m_lastError = tr_("ai.error.noProviderConfigured", "No AI provider configured");
         emit errorOccurred(m_lastError);
         return;
     }
 
     if (!isConfigured()) {
-        m_lastError = "AI provider not configured";
+        m_lastError = tr_("ai.error.providerNotConfigured", "AI provider not configured");
         emit errorOccurred(m_lastError);
         return;
     }
@@ -1489,19 +1511,19 @@ QVariantMap AIManager::parseBagExtraction(const QString& response, bool* ok)
 void AIManager::analyzeConversation(const QString& systemPrompt, const QJsonArray& messages)
 {
     if (m_analyzing) {
-        emit conversationErrorOccurred("Analysis already in progress");
+        emit conversationErrorOccurred(tr_("ai.error.analysisInProgress", "Analysis already in progress"));
         return;
     }
 
     AIProvider* provider = currentProvider();
     if (!provider) {
-        m_lastError = "No AI provider configured";
+        m_lastError = tr_("ai.error.noProviderConfigured", "No AI provider configured");
         emit conversationErrorOccurred(m_lastError);
         return;
     }
 
     if (!isConfigured()) {
-        m_lastError = "AI provider not configured";
+        m_lastError = tr_("ai.error.providerNotConfigured", "AI provider not configured");
         emit conversationErrorOccurred(m_lastError);
         return;
     }

--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -22,6 +22,7 @@ class ShotDataModel;
 class Profile;
 class Settings;
 class ShotHistoryStorage;
+class TranslationManager;
 class ProfileManager;
 
 class AIManager : public QObject {
@@ -138,6 +139,12 @@ public:
 
     // Shot history access for contextual recommendations
     void setShotHistoryStorage(ShotHistoryStorage* storage);
+
+    // Inject the TranslationManager so user-visible error strings localize.
+    // Forwards to every owned provider and the conversation. Wired directly in
+    // main.cpp (after MainController::setAiManager, since MainController's own
+    // setTranslationManager runs before the AIManager is attached).
+    void setTranslationManager(TranslationManager* tm);
     // ProfileManager hookup for the SAW prediction block (needs
     // baseProfileName + profile target metadata at user-prompt enrichment
     // time). Wired from MainController::setAiManager. Optional — falls
@@ -304,6 +311,9 @@ private slots:
 
 private:
     void createProviders();
+    // Translate a user-visible string via the injected TranslationManager,
+    // falling back to the English source when none is set.
+    QString tr_(const char* key, const char* fallback) const;
     AIProvider* providerById(const QString& providerId) const;
     AIProvider* currentProvider() const;
 
@@ -369,6 +379,7 @@ private:
 
     // Conversation for multi-turn interactions
     AIConversation* m_conversation = nullptr;
+    TranslationManager* m_translationManager = nullptr;
     QList<ConversationEntry> m_conversationIndex;
     bool m_isConversationRequest = false;
     bool m_isBagExtractionRequest = false;

--- a/src/ai/aiprovider.cpp
+++ b/src/ai/aiprovider.cpp
@@ -1,4 +1,5 @@
 #include "aiprovider.h"
+#include "../core/translationmanager.h"
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -25,22 +26,30 @@ void AIProvider::setStatus(Status status)
     }
 }
 
-QString AIProvider::friendlyNetworkError(QNetworkReply* reply)
+QString AIProvider::tr_(const char* key, const char* fallback) const
+{
+    if (m_translationManager)
+        return m_translationManager->translate(QString::fromUtf8(key),
+                                               QString::fromUtf8(fallback));
+    return QString::fromUtf8(fallback);
+}
+
+QString AIProvider::friendlyNetworkError(QNetworkReply* reply) const
 {
     switch (reply->error()) {
     case QNetworkReply::ConnectionRefusedError:
     case QNetworkReply::RemoteHostClosedError:
     case QNetworkReply::HostNotFoundError:
-        return "Could not connect to the AI service. Check your internet connection.";
+        return tr_("ai.error.noConnection", "Could not connect to the AI service. Check your internet connection.");
     case QNetworkReply::TimeoutError:
     case QNetworkReply::OperationCanceledError:
-        return "Request timed out. The AI service may be slow — please try again.";
+        return tr_("ai.error.timeout", "Request timed out. The AI service may be slow — please try again.");
     case QNetworkReply::AuthenticationRequiredError:
-        return "Authentication failed. Please check your API key in Settings.";
+        return tr_("ai.error.authFailed", "Authentication failed. Please check your API key in Settings.");
     case QNetworkReply::ContentAccessDenied:
-        return "Access denied. Your API key may not have permission for this model.";
+        return tr_("ai.error.accessDenied", "Access denied. Your API key may not have permission for this model.");
     default:
-        return "Request failed: " + reply->errorString();
+        return tr_("ai.error.requestFailed", "Request failed: %1").arg(reply->errorString());
     }
 }
 
@@ -207,7 +216,7 @@ void OpenAIProvider::sendRequest(const QJsonObject& requestBody)
 void OpenAIProvider::analyze(const QString& systemPrompt, const QString& userPrompt)
 {
     if (!isConfigured()) {
-        emit analysisFailed("OpenAI API key not configured");
+        emit analysisFailed(tr_("ai.openai.keyMissing", "OpenAI API key not configured"));
         return;
     }
 
@@ -249,7 +258,7 @@ void OpenAIProvider::analyze(const QString& systemPrompt, const QString& userPro
 void OpenAIProvider::analyzeUrl(const QString& systemPrompt, const QString& userPrompt)
 {
     if (!isConfigured()) {
-        emit analysisFailed("OpenAI API key not configured");
+        emit analysisFailed(tr_("ai.openai.keyMissing", "OpenAI API key not configured"));
         return;
     }
 
@@ -309,7 +318,7 @@ void OpenAIProvider::onResponsesReply(QNetworkReply* reply)
             if (!apiError.isEmpty()) {
                 int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
                 qWarning() << "OpenAI Responses API error" << status << "-" << apiError;
-                emit analysisFailed("OpenAI error: " + apiError);
+                emit analysisFailed(tr_("ai.openai.error", "OpenAI error: %1").arg(apiError));
                 return;
             }
             qWarning() << "AI request failed"
@@ -326,7 +335,7 @@ void OpenAIProvider::onResponsesReply(QNetworkReply* reply)
     if (root.contains("error") && root["error"].isObject()) {
         QString errorMsg = root["error"].toObject()["message"].toString();
         if (!errorMsg.isEmpty()) {
-            emit analysisFailed("OpenAI error: " + errorMsg);
+            emit analysisFailed(tr_("ai.openai.error", "OpenAI error: %1").arg(errorMsg));
             return;
         }
     }
@@ -349,7 +358,7 @@ void OpenAIProvider::onResponsesReply(QNetworkReply* reply)
     if (text.isEmpty()) {
         qWarning() << "OpenAI Responses: no output_text (status"
                    << root["status"].toString() << ")";
-        emit analysisFailed("OpenAI returned empty response content");
+        emit analysisFailed(tr_("ai.openai.emptyContent", "OpenAI returned empty response content"));
         return;
     }
     emit analysisComplete(text);
@@ -358,7 +367,7 @@ void OpenAIProvider::onResponsesReply(QNetworkReply* reply)
 void OpenAIProvider::analyzeConversation(const QString& systemPrompt, const QJsonArray& messages)
 {
     if (!isConfigured()) {
-        emit analysisFailed("OpenAI API key not configured");
+        emit analysisFailed(tr_("ai.openai.keyMissing", "OpenAI API key not configured"));
         return;
     }
 
@@ -389,7 +398,7 @@ void OpenAIProvider::onAnalysisReply(QNetworkReply* reply)
             if (!apiError.isEmpty()) {
                 int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
                 qWarning() << "OpenAI API error" << status << "-" << apiError;
-                emit analysisFailed("OpenAI error: " + apiError);
+                emit analysisFailed(tr_("ai.openai.error", "OpenAI error: %1").arg(apiError));
                 return;
             }
             qWarning() << "AI request failed"
@@ -405,19 +414,19 @@ void OpenAIProvider::onAnalysisReply(QNetworkReply* reply)
 
     if (root.contains("error")) {
         QString errorMsg = root["error"].toObject()["message"].toString();
-        emit analysisFailed("OpenAI error: " + errorMsg);
+        emit analysisFailed(tr_("ai.openai.error", "OpenAI error: %1").arg(errorMsg));
         return;
     }
 
     QJsonArray choices = root["choices"].toArray();
     if (choices.isEmpty()) {
-        emit analysisFailed("OpenAI returned no response");
+        emit analysisFailed(tr_("ai.openai.noResponse", "OpenAI returned no response"));
         return;
     }
 
     QString content = choices[0].toObject()["message"].toObject()["content"].toString();
     if (content.isEmpty()) {
-        emit analysisFailed("OpenAI returned empty response content");
+        emit analysisFailed(tr_("ai.openai.emptyContent", "OpenAI returned empty response content"));
         return;
     }
     emit analysisComplete(content);
@@ -426,7 +435,7 @@ void OpenAIProvider::onAnalysisReply(QNetworkReply* reply)
 void OpenAIProvider::testConnection()
 {
     if (!isConfigured()) {
-        emit testResult(false, "API key not configured");
+        emit testResult(false, tr_("ai.test.keyNotConfigured", "API key not configured"));
         return;
     }
 
@@ -462,11 +471,11 @@ void OpenAIProvider::onTestReply(QNetworkReply* reply)
             QJsonValue errVal = doc.object()["error"];
             QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
             if (!errorMsg.isEmpty()) {
-                emit testResult(false, "Authentication failed: " + errorMsg);
+                emit testResult(false, tr_("ai.test.authFailed", "Authentication failed: %1").arg(errorMsg));
                 return;
             }
         }
-        emit testResult(false, "Invalid API key");
+        emit testResult(false, tr_("ai.test.invalidKey", "Invalid API key"));
         return;
     }
 
@@ -476,11 +485,11 @@ void OpenAIProvider::onTestReply(QNetworkReply* reply)
             QJsonValue errVal = doc.object()["error"];
             QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
             if (!errorMsg.isEmpty()) {
-                emit testResult(false, "API error: " + errorMsg);
+                emit testResult(false, tr_("ai.test.apiError", "API error: %1").arg(errorMsg));
                 return;
             }
         }
-        emit testResult(false, "Connection failed: " + reply->errorString());
+        emit testResult(false, tr_("ai.test.connectionFailed", "Connection failed: %1").arg(reply->errorString()));
         return;
     }
 
@@ -489,12 +498,12 @@ void OpenAIProvider::onTestReply(QNetworkReply* reply)
         QJsonValue errVal = doc.object()["error"];
         QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
         if (errorMsg.isEmpty())
-            errorMsg = "Unknown API error";
-        emit testResult(false, "API error: " + errorMsg);
+            errorMsg = tr_("ai.test.unknownError", "Unknown API error");
+        emit testResult(false, tr_("ai.test.apiError", "API error: %1").arg(errorMsg));
         return;
     }
 
-    emit testResult(true, "Connected to OpenAI successfully");
+    emit testResult(true, tr_("ai.openai.connected", "Connected to OpenAI successfully"));
 }
 
 // ============================================================================
@@ -581,7 +590,7 @@ void AnthropicProvider::sendRequest(const QJsonObject& requestBody)
 void AnthropicProvider::analyze(const QString& systemPrompt, const QString& userPrompt)
 {
     if (!isConfigured()) {
-        emit analysisFailed("Anthropic API key not configured");
+        emit analysisFailed(tr_("ai.anthropic.keyMissing", "Anthropic API key not configured"));
         return;
     }
 
@@ -606,7 +615,7 @@ void AnthropicProvider::analyze(const QString& systemPrompt, const QString& user
 void AnthropicProvider::analyzeUrl(const QString& systemPrompt, const QString& userPrompt)
 {
     if (!isConfigured()) {
-        emit analysisFailed("Anthropic API key not configured");
+        emit analysisFailed(tr_("ai.anthropic.keyMissing", "Anthropic API key not configured"));
         return;
     }
 
@@ -641,7 +650,7 @@ void AnthropicProvider::analyzeUrl(const QString& systemPrompt, const QString& u
 void AnthropicProvider::analyzeConversation(const QString& systemPrompt, const QJsonArray& messages)
 {
     if (!isConfigured()) {
-        emit analysisFailed("Anthropic API key not configured");
+        emit analysisFailed(tr_("ai.anthropic.keyMissing", "Anthropic API key not configured"));
         return;
     }
 
@@ -729,7 +738,7 @@ void AnthropicProvider::onAnalysisReply(QNetworkReply* reply)
             if (!apiError.isEmpty()) {
                 int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
                 qWarning() << "Anthropic API error" << status << "-" << apiError;
-                emit analysisFailed("Anthropic error: " + apiError);
+                emit analysisFailed(tr_("ai.anthropic.error", "Anthropic error: %1").arg(apiError));
                 return;
             }
             qWarning() << "AI request failed"
@@ -745,13 +754,13 @@ void AnthropicProvider::onAnalysisReply(QNetworkReply* reply)
 
     if (root.contains("error")) {
         QString errorMsg = root["error"].toObject()["message"].toString();
-        emit analysisFailed("Anthropic error: " + errorMsg);
+        emit analysisFailed(tr_("ai.anthropic.error", "Anthropic error: %1").arg(errorMsg));
         return;
     }
 
     QJsonArray content = root["content"].toArray();
     if (content.isEmpty()) {
-        emit analysisFailed("Anthropic returned no response");
+        emit analysisFailed(tr_("ai.anthropic.noResponse", "Anthropic returned no response"));
         return;
     }
 
@@ -766,7 +775,7 @@ void AnthropicProvider::onAnalysisReply(QNetworkReply* reply)
             text += obj["text"].toString();
     }
     if (text.isEmpty()) {
-        emit analysisFailed("Anthropic returned empty response content");
+        emit analysisFailed(tr_("ai.anthropic.emptyContent", "Anthropic returned empty response content"));
         return;
     }
     emit analysisComplete(text);
@@ -775,7 +784,7 @@ void AnthropicProvider::onAnalysisReply(QNetworkReply* reply)
 void AnthropicProvider::testConnection()
 {
     if (!isConfigured()) {
-        emit testResult(false, "API key not configured");
+        emit testResult(false, tr_("ai.test.keyNotConfigured", "API key not configured"));
         return;
     }
 
@@ -824,11 +833,11 @@ void AnthropicProvider::onTestReply(QNetworkReply* reply)
             QJsonValue errVal = doc.object()["error"];
             QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
             if (!errorMsg.isEmpty()) {
-                emit testResult(false, "Authentication failed: " + errorMsg);
+                emit testResult(false, tr_("ai.test.authFailed", "Authentication failed: %1").arg(errorMsg));
                 return;
             }
         }
-        emit testResult(false, "Invalid API key");
+        emit testResult(false, tr_("ai.test.invalidKey", "Invalid API key"));
         return;
     }
 
@@ -838,11 +847,11 @@ void AnthropicProvider::onTestReply(QNetworkReply* reply)
             QJsonValue errVal = doc.object()["error"];
             QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
             if (!errorMsg.isEmpty()) {
-                emit testResult(false, "API error: " + errorMsg);
+                emit testResult(false, tr_("ai.test.apiError", "API error: %1").arg(errorMsg));
                 return;
             }
         }
-        emit testResult(false, "Connection failed: " + reply->errorString());
+        emit testResult(false, tr_("ai.test.connectionFailed", "Connection failed: %1").arg(reply->errorString()));
         return;
     }
 
@@ -851,12 +860,12 @@ void AnthropicProvider::onTestReply(QNetworkReply* reply)
         QJsonValue errVal = doc.object()["error"];
         QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
         if (errorMsg.isEmpty())
-            errorMsg = "Unknown API error";
-        emit testResult(false, "API error: " + errorMsg);
+            errorMsg = tr_("ai.test.unknownError", "Unknown API error");
+        emit testResult(false, tr_("ai.test.apiError", "API error: %1").arg(errorMsg));
         return;
     }
 
-    emit testResult(true, "Connected to Anthropic successfully");
+    emit testResult(true, tr_("ai.anthropic.connected", "Connected to Anthropic successfully"));
 }
 
 // ============================================================================
@@ -967,7 +976,7 @@ void GeminiProvider::sendRequest(const QJsonObject& requestBody)
 void GeminiProvider::analyze(const QString& systemPrompt, const QString& userPrompt)
 {
     if (!isConfigured()) {
-        emit analysisFailed("Gemini API key not configured");
+        emit analysisFailed(tr_("ai.gemini.keyMissing", "Gemini API key not configured"));
         return;
     }
 
@@ -1005,7 +1014,7 @@ void GeminiProvider::analyze(const QString& systemPrompt, const QString& userPro
 void GeminiProvider::analyzeUrl(const QString& systemPrompt, const QString& userPrompt)
 {
     if (!isConfigured()) {
-        emit analysisFailed("Gemini API key not configured");
+        emit analysisFailed(tr_("ai.gemini.keyMissing", "Gemini API key not configured"));
         return;
     }
 
@@ -1046,7 +1055,7 @@ void GeminiProvider::analyzeUrl(const QString& systemPrompt, const QString& user
 void GeminiProvider::analyzeConversation(const QString& systemPrompt, const QJsonArray& messages)
 {
     if (!isConfigured()) {
-        emit analysisFailed("Gemini API key not configured");
+        emit analysisFailed(tr_("ai.gemini.keyMissing", "Gemini API key not configured"));
         return;
     }
 
@@ -1102,7 +1111,7 @@ void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
             if (!apiError.isEmpty()) {
                 int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
                 qWarning() << "Gemini API error" << status << "-" << apiError;
-                emit analysisFailed("Gemini error: " + apiError);
+                emit analysisFailed(tr_("ai.gemini.error", "Gemini error: %1").arg(apiError));
                 return;
             }
             qWarning() << "AI request failed"
@@ -1118,7 +1127,7 @@ void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
 
     if (root.contains("error")) {
         QString errorMsg = root["error"].toObject()["message"].toString();
-        emit analysisFailed("Gemini error: " + errorMsg);
+        emit analysisFailed(tr_("ai.gemini.error", "Gemini error: %1").arg(errorMsg));
         return;
     }
 
@@ -1130,13 +1139,13 @@ void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
 
     QJsonArray candidates = root["candidates"].toArray();
     if (candidates.isEmpty()) {
-        emit analysisFailed("Gemini returned no response");
+        emit analysisFailed(tr_("ai.gemini.noResponse", "Gemini returned no response"));
         return;
     }
 
     QJsonArray parts = candidates[0].toObject()["content"].toObject()["parts"].toArray();
     if (parts.isEmpty()) {
-        emit analysisFailed("Gemini returned empty content");
+        emit analysisFailed(tr_("ai.gemini.emptyContent2", "Gemini returned empty content"));
         return;
     }
 
@@ -1151,7 +1160,7 @@ void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
         text += part["text"].toString();
     }
     if (text.isEmpty()) {
-        emit analysisFailed("Gemini returned empty response content");
+        emit analysisFailed(tr_("ai.gemini.emptyContent", "Gemini returned empty response content"));
         return;
     }
     emit analysisComplete(text);
@@ -1160,7 +1169,7 @@ void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
 void GeminiProvider::testConnection()
 {
     if (!isConfigured()) {
-        emit testResult(false, "API key not configured");
+        emit testResult(false, tr_("ai.test.keyNotConfigured", "API key not configured"));
         return;
     }
 
@@ -1207,11 +1216,11 @@ void GeminiProvider::onTestReply(QNetworkReply* reply)
             QJsonValue errVal = doc.object()["error"];
             QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
             if (!errorMsg.isEmpty()) {
-                emit testResult(false, "Authentication failed: " + errorMsg);
+                emit testResult(false, tr_("ai.test.authFailed", "Authentication failed: %1").arg(errorMsg));
                 return;
             }
         }
-        emit testResult(false, "Invalid API key");
+        emit testResult(false, tr_("ai.test.invalidKey", "Invalid API key"));
         return;
     }
 
@@ -1221,11 +1230,11 @@ void GeminiProvider::onTestReply(QNetworkReply* reply)
             QJsonValue errVal = doc.object()["error"];
             QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
             if (!errorMsg.isEmpty()) {
-                emit testResult(false, "API error: " + errorMsg);
+                emit testResult(false, tr_("ai.test.apiError", "API error: %1").arg(errorMsg));
                 return;
             }
         }
-        emit testResult(false, "Connection failed: " + reply->errorString());
+        emit testResult(false, tr_("ai.test.connectionFailed", "Connection failed: %1").arg(reply->errorString()));
         return;
     }
 
@@ -1234,12 +1243,12 @@ void GeminiProvider::onTestReply(QNetworkReply* reply)
         QJsonValue errVal = doc.object()["error"];
         QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
         if (errorMsg.isEmpty())
-            errorMsg = "Unknown API error";
-        emit testResult(false, "API error: " + errorMsg);
+            errorMsg = tr_("ai.test.unknownError", "Unknown API error");
+        emit testResult(false, tr_("ai.test.apiError", "API error: %1").arg(errorMsg));
         return;
     }
 
-    emit testResult(true, "Connected to Gemini successfully");
+    emit testResult(true, tr_("ai.gemini.connected", "Connected to Gemini successfully"));
 }
 
 // ============================================================================
@@ -1280,7 +1289,7 @@ void OpenRouterProvider::sendRequest(const QJsonObject& requestBody)
 void OpenRouterProvider::analyze(const QString& systemPrompt, const QString& userPrompt)
 {
     if (!isConfigured()) {
-        emit analysisFailed("OpenRouter API key or model not configured");
+        emit analysisFailed(tr_("ai.openrouter.keyOrModelMissing", "OpenRouter API key or model not configured"));
         return;
     }
 
@@ -1309,7 +1318,7 @@ void OpenRouterProvider::analyze(const QString& systemPrompt, const QString& use
 void OpenRouterProvider::analyzeConversation(const QString& systemPrompt, const QJsonArray& messages)
 {
     if (!isConfigured()) {
-        emit analysisFailed("OpenRouter API key or model not configured");
+        emit analysisFailed(tr_("ai.openrouter.keyOrModelMissing", "OpenRouter API key or model not configured"));
         return;
     }
 
@@ -1339,7 +1348,7 @@ void OpenRouterProvider::onAnalysisReply(QNetworkReply* reply)
             if (!apiError.isEmpty()) {
                 int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
                 qWarning() << "OpenRouter API error" << status << "-" << apiError;
-                emit analysisFailed("OpenRouter error: " + apiError);
+                emit analysisFailed(tr_("ai.openrouter.error", "OpenRouter error: %1").arg(apiError));
                 return;
             }
             qWarning() << "AI request failed"
@@ -1355,19 +1364,19 @@ void OpenRouterProvider::onAnalysisReply(QNetworkReply* reply)
 
     if (root.contains("error")) {
         QString errorMsg = root["error"].toObject()["message"].toString();
-        emit analysisFailed("OpenRouter error: " + errorMsg);
+        emit analysisFailed(tr_("ai.openrouter.error", "OpenRouter error: %1").arg(errorMsg));
         return;
     }
 
     QJsonArray choices = root["choices"].toArray();
     if (choices.isEmpty()) {
-        emit analysisFailed("OpenRouter returned no response");
+        emit analysisFailed(tr_("ai.openrouter.noResponse", "OpenRouter returned no response"));
         return;
     }
 
     QString content = choices[0].toObject()["message"].toObject()["content"].toString();
     if (content.isEmpty()) {
-        emit analysisFailed("OpenRouter returned empty response content");
+        emit analysisFailed(tr_("ai.openrouter.emptyContent", "OpenRouter returned empty response content"));
         return;
     }
     emit analysisComplete(content);
@@ -1376,7 +1385,7 @@ void OpenRouterProvider::onAnalysisReply(QNetworkReply* reply)
 void OpenRouterProvider::testConnection()
 {
     if (!isConfigured()) {
-        emit testResult(false, "API key or model not configured");
+        emit testResult(false, tr_("ai.openrouter.testKeyOrModel", "API key or model not configured"));
         return;
     }
 
@@ -1423,11 +1432,11 @@ void OpenRouterProvider::onTestReply(QNetworkReply* reply)
             QJsonValue errVal = doc.object()["error"];
             QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
             if (!errorMsg.isEmpty()) {
-                emit testResult(false, "Authentication failed: " + errorMsg);
+                emit testResult(false, tr_("ai.test.authFailed", "Authentication failed: %1").arg(errorMsg));
                 return;
             }
         }
-        emit testResult(false, "Invalid API key");
+        emit testResult(false, tr_("ai.test.invalidKey", "Invalid API key"));
         return;
     }
 
@@ -1437,11 +1446,11 @@ void OpenRouterProvider::onTestReply(QNetworkReply* reply)
             QJsonValue errVal = doc.object()["error"];
             QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
             if (!errorMsg.isEmpty()) {
-                emit testResult(false, "API error: " + errorMsg);
+                emit testResult(false, tr_("ai.test.apiError", "API error: %1").arg(errorMsg));
                 return;
             }
         }
-        emit testResult(false, "Connection failed: " + reply->errorString());
+        emit testResult(false, tr_("ai.test.connectionFailed", "Connection failed: %1").arg(reply->errorString()));
         return;
     }
 
@@ -1450,12 +1459,12 @@ void OpenRouterProvider::onTestReply(QNetworkReply* reply)
         QJsonValue errVal = doc.object()["error"];
         QString errorMsg = errVal.isObject() ? errVal.toObject()["message"].toString() : errVal.toString();
         if (errorMsg.isEmpty())
-            errorMsg = "Unknown API error";
-        emit testResult(false, "API error: " + errorMsg);
+            errorMsg = tr_("ai.test.unknownError", "Unknown API error");
+        emit testResult(false, tr_("ai.test.apiError", "API error: %1").arg(errorMsg));
         return;
     }
 
-    emit testResult(true, "Connected to OpenRouter successfully");
+    emit testResult(true, tr_("ai.openrouter.connected", "Connected to OpenRouter successfully"));
 }
 
 // ============================================================================
@@ -1491,7 +1500,7 @@ void OllamaProvider::sendRequest(const QUrl& url, const QJsonObject& requestBody
 void OllamaProvider::analyze(const QString& systemPrompt, const QString& userPrompt)
 {
     if (!isConfigured()) {
-        emit analysisFailed("Ollama not configured (need endpoint and model)");
+        emit analysisFailed(tr_("ai.ollama.notConfigured", "Ollama not configured (need endpoint and model)"));
         return;
     }
 
@@ -1515,7 +1524,7 @@ void OllamaProvider::analyze(const QString& systemPrompt, const QString& userPro
 void OllamaProvider::analyzeConversation(const QString& systemPrompt, const QJsonArray& messages)
 {
     if (!isConfigured()) {
-        emit analysisFailed("Ollama not configured (need endpoint and model)");
+        emit analysisFailed(tr_("ai.ollama.notConfigured", "Ollama not configured (need endpoint and model)"));
         return;
     }
 
@@ -1556,7 +1565,7 @@ void OllamaProvider::onAnalysisReply(QNetworkReply* reply)
     QJsonObject root = doc.object();
 
     if (root.contains("error")) {
-        emit analysisFailed("Ollama error: " + root["error"].toString());
+        emit analysisFailed(tr_("ai.ollama.error", "Ollama error: %1").arg(root["error"].toString()));
         return;
     }
 
@@ -1569,7 +1578,7 @@ void OllamaProvider::onAnalysisReply(QNetworkReply* reply)
         }
     }
     if (response.isEmpty()) {
-        emit analysisFailed("Ollama returned empty response");
+        emit analysisFailed(tr_("ai.ollama.emptyResponse", "Ollama returned empty response"));
         return;
     }
 
@@ -1579,7 +1588,7 @@ void OllamaProvider::onAnalysisReply(QNetworkReply* reply)
 void OllamaProvider::testConnection()
 {
     if (m_endpoint.isEmpty()) {
-        emit testResult(false, "Ollama endpoint not configured");
+        emit testResult(false, tr_("ai.ollama.endpointMissing", "Ollama endpoint not configured"));
         return;
     }
 
@@ -1592,11 +1601,11 @@ void OllamaProvider::onTestReply(QNetworkReply* reply)
     reply->deleteLater();
 
     if (reply->error() != QNetworkReply::NoError) {
-        emit testResult(false, "Cannot connect to Ollama: " + reply->errorString());
+        emit testResult(false, tr_("ai.ollama.cannotConnect", "Cannot connect to Ollama: %1").arg(reply->errorString()));
         return;
     }
 
-    emit testResult(true, "Connected to Ollama successfully");
+    emit testResult(true, tr_("ai.ollama.connected", "Connected to Ollama successfully"));
 }
 
 void OllamaProvider::refreshModels()
@@ -1620,7 +1629,7 @@ void OllamaProvider::onModelsReply(QNetworkReply* reply)
     reply->deleteLater();
 
     if (reply->error() != QNetworkReply::NoError) {
-        emit testResult(false, "Cannot list Ollama models: " + reply->errorString());
+        emit testResult(false, tr_("ai.ollama.cannotList", "Cannot list Ollama models: %1").arg(reply->errorString()));
         emit modelsRefreshed({});
         return;
     }
@@ -1636,8 +1645,8 @@ void OllamaProvider::onModelsReply(QNetworkReply* reply)
     emit modelsRefreshed(modelNames);
 
     if (!modelNames.isEmpty()) {
-        emit testResult(true, QString("Found %1 Ollama model(s)").arg(modelNames.size()));
+        emit testResult(true, tr_("ai.ollama.foundModels", "Found %1 Ollama model(s)").arg(modelNames.size()));
     } else {
-        emit testResult(false, "No models found. Run: ollama pull llama3.2");
+        emit testResult(false, tr_("ai.ollama.noModels", "No models found. Run: ollama pull llama3.2"));
     }
 }

--- a/src/ai/aiprovider.h
+++ b/src/ai/aiprovider.h
@@ -8,6 +8,8 @@
 #include <QNetworkReply>
 #include <functional>
 
+class TranslationManager;
+
 // Abstract base class for AI providers
 class AIProvider : public QObject {
     Q_OBJECT
@@ -25,6 +27,11 @@ public:
 
     explicit AIProvider(QNetworkAccessManager* networkManager, QObject* parent = nullptr);
     virtual ~AIProvider() = default;
+
+    // Inject the TranslationManager so user-visible error/status strings
+    // localize. Set by AIManager for every provider it owns; until injected,
+    // tr_() returns the English fallback.
+    void setTranslationManager(TranslationManager* tm) { m_translationManager = tm; }
 
     virtual QString name() const = 0;
     virtual QString id() const = 0;  // "openai", "anthropic", "gemini", "ollama"
@@ -63,7 +70,7 @@ public:
     virtual bool supportsUrlAnalysis() const { return false; }
     virtual void analyzeUrl(const QString& systemPrompt, const QString& userPrompt) {
         Q_UNUSED(systemPrompt); Q_UNUSED(userPrompt);
-        emit analysisFailed(QStringLiteral("URL analysis not supported by this provider"));
+        emit analysisFailed(tr_("ai.error.urlNotSupported", "URL analysis not supported by this provider"));
     }
 
     // Test connection
@@ -78,8 +85,12 @@ signals:
 protected:
     void setStatus(Status status);
 
-    // Map Qt network errors to user-friendly messages
-    static QString friendlyNetworkError(QNetworkReply* reply);
+    // Map Qt network errors to user-friendly messages (localized via tr_).
+    QString friendlyNetworkError(QNetworkReply* reply) const;
+
+    // Translate a user-visible string via the injected TranslationManager,
+    // falling back to the English source when none is set.
+    QString tr_(const char* key, const char* fallback) const;
 
     // Build OpenAI-compatible messages array: system message + conversation messages
     static QJsonArray buildOpenAIMessages(const QString& systemPrompt, const QJsonArray& messages);
@@ -92,6 +103,7 @@ protected:
     static constexpr int MAX_RETRIES = 3;                // max retries for 429/502/503/504
 
     QNetworkAccessManager* m_networkManager = nullptr;
+    TranslationManager* m_translationManager = nullptr;
     Status m_status = Status::Ready;
     std::function<void()> m_retryFn;  // set by each sendRequest() to re-send the pending request
     int m_retryCount = 0;             // reset to 0 before each new analyze() / analyzeConversation() call

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1077,6 +1077,10 @@ int main(int argc, char *argv[])
     // Create and wire AI Manager
     AIManager aiManager(&sharedNetworkManager, &settings);
     mainController.setAiManager(&aiManager);
+    // Localize AI error strings. Wired here (not via MainController's fan-out)
+    // because MainController::setTranslationManager already ran above, before
+    // the AIManager was attached. Forwards to every provider + the conversation.
+    aiManager.setTranslationManager(&translationManager);
 
     // Register the per-provider model-hint strings with the translation
     // registry. SettingsAITab.qml builds these keys dynamically


### PR DESCRIPTION
### What

Third batch of the C++ backend error-string i18n effort (follows #1523 VisualizerImporter and #1524 uploader/updatechecker). Routes the user-visible error/status strings in the AI cluster through `TranslationManager`.

- **`AIProvider`** (base + 5 providers, ~73 strings): `friendlyNetworkError`, per-provider "API key not configured" / "&lt;Provider&gt; error: %1" / "returned no/empty response" / "Connected to &lt;Provider&gt; successfully", the shared connection-test strings (deduped to single keys: invalid key, auth failed, API error, connection failed, unknown error), the Ollama specials, and the base `analyzeUrl` "URL analysis not supported" default. `friendlyNetworkError` becomes a non-static `const` member so it can localize.
- **`AIManager`**: the 4 dispatch-guard strings.
- **`AIConversation`**: 6 error messages.

### Injection

`AIManager` gets `setTranslationManager` (wired in `main.cpp` after `setAiManager`, because MainController's own fan-out runs before the manager is attached) and forwards to all five providers + the conversation via a shared `tr_(key, fallback)` helper.

### Important: prompts are NOT translated

The LLM prompt/context blocks and system prompts (`kCoffeePrompt`, recent-shot markdown, etc. — all in `aimanager.cpp`) are **model inputs, not UI**, and were deliberately left untouched. Only strings emitted to the UI via `analysisFailed`/`testResult`/`errorMessage` were wrapped.

### Testing

Build clean (0 warnings). `tst_aimanager`, `tst_aiproviders`, `tst_shotsummarizer`, `failonwarning_lint` pass. A review pass verified placeholder/`.arg()` integrity across all wraps, that no model-facing text was translated, injection ordering/null-safety, and no key/fallback collisions. Behavior-preserving (English fallback when no translation loaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)