### PR TITLE
fix(R2): stop benign refractometer status-errors spamming the error dialog

### DIFF
--- a/src/ble/refractometers/difluidr2.cpp
+++ b/src/ble/refractometers/difluidr2.cpp
@@ -327,17 +327,22 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
             uint8_t errClass = dataLen > 0 ? static_cast<uint8_t>(packet[5]) : 0;
             uint8_t errCode = dataLen > 1 ? static_cast<uint8_t>(packet[6]) : 0;
             R2_WARN(QString("R2 error: class=%1 code=%2").arg(errClass).arg(errCode));
+            // Surface ONLY the user-actionable measurement failures. Class-2 are
+            // the measurement errors; other class/code combos (notably 0/2) are
+            // benign device status the R2 also emits around a SUCCESSFUL read, so
+            // surfacing them spams the error dialog (they carry no useful info —
+            // the data already arrived). Log-only for those; still clear the
+            // measuring state so the UI doesn't hang.
             if (errClass == 2 && errCode == 3) emit errorOccurred("No liquid detected");
             else if (errClass == 2 && errCode == 4) emit errorOccurred("Beyond range");
-            else emit errorOccurred(QString("R2 error %1/%2").arg(errClass).arg(errCode));
             m_measurementTimer.stop();
             m_measuring = false;
             emit measuringChanged();
             return;
         }
         if (cmd == 255) {
+            // Non-actionable — log only (see the cmd==254 note above).
             R2_WARN("R2 unknown error");
-            emit errorOccurred("Unknown R2 error");
             m_measurementTimer.stop();
             m_measuring = false;
             emit measuringChanged();

--- a/tests/tst_difluidr2.cpp
+++ b/tests/tst_difluidr2.cpp
@@ -398,11 +398,16 @@ private slots:
         // class-2 measurement failures (no-liquid / beyond-range) surface.
         DiFluidR2 r2(nullptr);
         QSignalSpy errorSpy(&r2, &DiFluidR2::errorOccurred);
+        QSignalSpy measSpy(&r2, &DiFluidR2::measuringChanged);
 
         QTest::ignoreMessage(QtWarningMsg, QRegularExpression("R2 error: class=0 code=2"));
         r2.handlePacket(buildErrorPacket(0, 2));
 
         QCOMPARE(errorSpy.count(), 0);
+        // Not surfaced, but the measuring state is still cleared so the UI
+        // doesn't hang on a benign status error.
+        QCOMPARE(measSpy.count(), 1);
+        QVERIFY(!r2.isMeasuring());
     }
 
     // === Invalid packets ===

--- a/tests/tst_difluidr2.cpp
+++ b/tests/tst_difluidr2.cpp
@@ -378,14 +378,31 @@ private slots:
         QSignalSpy errorSpy(&r2, &DiFluidR2::errorOccurred);
         QSignalSpy measSpy(&r2, &DiFluidR2::measuringChanged);
 
-        // Cmd=255 = unknown error
+        // Cmd=255 = unknown error: non-actionable, so it is logged but NOT
+        // surfaced to the UI (errorOccurred is wired to the error dialog —
+        // surfacing unknown/benign device errors spams it). Measuring state is
+        // still cleared so the UI doesn't hang.
         QTest::ignoreMessage(QtWarningMsg, QRegularExpression("R2 unknown error"));
         r2.handlePacket(buildR2Packet(0x03, 0xFF, QByteArray()));
 
-        QCOMPARE(errorSpy.count(), 1);
-        QVERIFY(errorSpy.at(0).at(0).toString().contains("Unknown"));
+        QCOMPARE(errorSpy.count(), 0);
         QCOMPARE(measSpy.count(), 1);
         QVERIFY(!r2.isMeasuring());
+    }
+
+    void parseErrorNonActionableNotSurfaced() {
+        // Regression: the R2 emits a benign `class=0 code=2` error around a
+        // SUCCESSFUL read. It carries no useful info (the data already arrived),
+        // so it must be logged but NOT surfaced — before this gate it spammed
+        // the error dialog once errorOccurred was wired to the UI. Only the
+        // class-2 measurement failures (no-liquid / beyond-range) surface.
+        DiFluidR2 r2(nullptr);
+        QSignalSpy errorSpy(&r2, &DiFluidR2::errorOccurred);
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("R2 error: class=0 code=2"));
+        r2.handlePacket(buildErrorPacket(0, 2));
+
+        QCOMPARE(errorSpy.count(), 0);
     }
 
     // === Invalid packets ===


### PR DESCRIPTION
### Problem

Regression from #1528 (which wired `RefractometerDevice::errorOccurred` to the error dialog). After a shot, the DiFluid R2 reports TDS successfully, then emits a benign `class=0 code=2` "error" **repeatedly** (~every 3 s) while the sample is gone. Previously harmless (the signal had no consumer); now each one pops an unhelpful **"R2 error 0/2"** dialog even though the reading already came through.

Confirmed on real hardware (Samsung SM-X210) — debug log:
```
495.791  TDS: 9.40% (raw=940)            ← reading succeeds
500.163  TDS: 9.31% (raw=931)
504.526  TDS: 0.84% (raw=84)
508.290  WARN R2 error: class=0 code=2   ← benign, then repeats every ~3s
511.290  WARN R2 error: class=0 code=2
514.291  WARN R2 error: class=0 code=2
```

### Fix

In `DiFluidR2`'s error handler, surface only the **user-actionable class-2 measurement failures** — "No liquid detected" (2/3) and "Beyond range" (2/4). Every other class/code (notably `0/2`) and the `cmd=255` "unknown error" are logged (`R2_WARN`, unchanged) but no longer emit `errorOccurred`, so they don't reach the dialog. Measuring state is still cleared on all of them, so the UI never hangs. R1's single error ("out-of-range value") is genuinely actionable and unchanged.

### Tests

- `parseErrorUnknown` updated: unknown (`cmd=255`) errors are NOT surfaced (state still cleared).
- Added `parseErrorNonActionableNotSurfaced`: the exact `class=0 code=2` case asserts `errorOccurred` is not emitted.
- `parseErrorNoLiquid` / `parseErrorBeyondRange` still assert the class-2 errors DO surface.

Build clean (0 warnings); `tst_difluidr2`, `tst_difluidr1`, `failonwarning_lint` pass.

### Residual note

If the R2 is left streaming with an empty cup it could emit a class-2 "No liquid detected" repeatedly too; that's genuinely informative (unlike `0/2`) and wasn't the reported issue, but a general dedup/rate-limit on the error dialog would be a reasonable separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)