### PR TITLE
Bottom bar: fit on one page, real cloud icon, pending-upload state

### DIFF
--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -325,6 +325,17 @@ QtObject {
         return Qt.rgba(baseColor.r, baseColor.g, baseColor.b, backgroundScrimAlpha)
     }
 
+    // Readable foreground for text/icons drawn on an arbitrary fill. primaryContrastColor
+    // is white by default, which is only legible on dark fills — on warningButtonColor
+    // (#FFA500) white lands around 2.1:1, well under the 4.5:1 minimum. Custom themes can
+    // set any fill they like, so the foreground has to be derived rather than assumed.
+    // Perceived-luminance weights (ITU-R BT.601), matching the existing hand-rolled copies
+    // in ValueInput.qml.
+    function contrastColorFor(fillColor) {
+        var luminance = 0.299 * fillColor.r + 0.587 * fillColor.g + 0.114 * fillColor.b
+        return luminance > 0.5 ? "#000000" : "#FFFFFF"
+    }
+
     // Card fill for page-level content cards (NOT dialogs/popups, which already
     // sit above a dim Overlay and don't need the wallpaper showing through them).
     // Opaque surfaceColor when no background image is set — zero visual change.

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -325,15 +325,32 @@ QtObject {
         return Qt.rgba(baseColor.r, baseColor.g, baseColor.b, backgroundScrimAlpha)
     }
 
-    // Readable foreground for text/icons drawn on an arbitrary fill. primaryContrastColor
-    // is white by default, which is only legible on dark fills — on warningButtonColor
-    // (#FFA500) white lands around 2.1:1, well under the 4.5:1 minimum. Custom themes can
-    // set any fill they like, so the foreground has to be derived rather than assumed.
-    // Perceived-luminance weights (ITU-R BT.601), matching the existing hand-rolled copies
-    // in ValueInput.qml.
-    function contrastColorFor(fillColor) {
-        var luminance = 0.299 * fillColor.r + 0.587 * fillColor.g + 0.114 * fillColor.b
-        return luminance > 0.5 ? "#000000" : "#FFFFFF"
+    // Black or white, whichever is actually more readable on fillColor.
+    //
+    // Picks by comparing the two real WCAG contrast ratios rather than thresholding a
+    // brightness value. Brightness and contrast are different measures and they disagree
+    // for mid-range fills — thresholding brightness picks white for #ff4444 (3.4:1) when
+    // black would give 6.2:1. A threshold also leaves any fill sitting near it one
+    // imperceptible tweak away from flipping every button that uses it; comparing ratios
+    // has no threshold to sit near.
+    //
+    // Opaque fills only: alpha is ignored, so a translucent fill derives from its
+    // unblended colour rather than what shows through it.
+    function contrastColorFor(fillColor: color): color {
+        var l = _relativeLuminance(fillColor)
+        var ratioOnBlack = (l + 0.05) / 0.05
+        var ratioOnWhite = 1.05 / (l + 0.05)
+        return ratioOnBlack >= ratioOnWhite ? "#000000" : "#FFFFFF"
+    }
+
+    // WCAG 2.x relative luminance: sRGB channels linearised, then weighted. Not the same
+    // as the cheaper BT.601 brightness weights — see contrastColorFor.
+    function _relativeLuminance(c) {
+        function linearise(channel) {
+            return channel <= 0.03928 ? channel / 12.92
+                                      : Math.pow((channel + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linearise(c.r) + 0.7152 * linearise(c.g) + 0.0722 * linearise(c.b)
     }
 
     // Card fill for page-level content cards (NOT dialogs/popups, which already

--- a/qml/components/AccessibleButton.qml
+++ b/qml/components/AccessibleButton.qml
@@ -26,8 +26,7 @@ Button {
     // the press. Bind custom background visuals to this instead of `down`.
     readonly property alias isPressed: touchArea.pressed
 
-    // The current variant's fill, before press darkening. Split out so the foreground
-    // can be derived from it instead of assumed.
+    // The current variant's fill, before press darkening.
     readonly property color _fillColor: {
         if (root.subtle) return Qt.rgba(1, 1, 1, 0.2)
         if (root.destructive) return Theme.errorColor
@@ -36,15 +35,17 @@ Button {
         return Theme.surfaceColor
     }
 
-    // Foreground (icon + label) for the enabled state. destructive/warning fills are
-    // theme-settable and can be light — amber in particular leaves white at ~2.1:1 —
-    // so their foreground is derived from the fill's luminance. primary keeps
-    // primaryContrastColor: the default blue sits right on the luminance threshold, so
-    // deriving it would flip every primary button in the app to black text on a hair's
-    // difference in theme colour.
+    // Foreground (icon + label) for the enabled state.
+    //
+    // Only warning derives its foreground: amber is the one fill here that white fails
+    // outright on (white on #FFA500 is 1.97:1, against a 4.5:1 minimum), and both black
+    // and white are unambiguous choices for it. Every other variant keeps
+    // primaryContrastColor — deriving them would change established looks across the
+    // whole app. That leaves errorColor's white at 3.4:1, a real gap, but one that
+    // belongs to its own change rather than riding along here.
     readonly property color _foregroundColor: {
-        if (root.destructive || root.warning) return Theme.contrastColorFor(root._fillColor)
-        if (root.primary || root.subtle) return Theme.primaryContrastColor
+        if (root.warning) return Theme.contrastColorFor(root._fillColor)
+        if (root.primary || root.subtle || root.destructive) return Theme.primaryContrastColor
         return Theme.textColor
     }
 
@@ -114,19 +115,24 @@ Button {
 
     background: Rectangle {
         implicitHeight: Theme.scaled(44)
-        // Both, deliberately: touchArea only covers contentItem, so a press on the
-        // button's padding never reaches it and only sets Button.down, while a press
-        // on the label is taken by touchArea and only sets isPressed. Binding either
-        // one alone leaves half the button's surface with no press feedback.
+        // Needs both: touchArea fills the whole button and accepts every pointer press
+        // (see isPressed above), so `down` never goes true for a pointer — but keyboard
+        // activation sets `down` without touchArea ever seeing it.
         readonly property bool showPressed: root.down || root.isPressed
         color: {
+            var fill
             if (root.subtle) {
-                return showPressed ? Qt.rgba(1, 1, 1, 0.3) : Qt.rgba(1, 1, 1, 0.2)
+                fill = showPressed ? Qt.rgba(1, 1, 1, 0.3) : Qt.rgba(1, 1, 1, 0.2)
+            } else if (root.destructive || root.warning || root.primary) {
+                fill = showPressed ? Qt.darker(root._fillColor, 1.1) : root._fillColor
+            } else {
+                fill = showPressed ? Qt.darker(Theme.surfaceColor, 1.2) : Theme.surfaceColor
             }
-            if (root.destructive || root.warning || root.primary) {
-                return showPressed ? Qt.darker(root._fillColor, 1.1) : root._fillColor
-            }
-            return showPressed ? Qt.darker(Theme.surfaceColor, 1.2) : Theme.surfaceColor
+            // Fade the fill when disabled, not just the label. Filled variants draw no
+            // border, so without this a disabled button keeps a full-strength background
+            // and reads as active — only its text goes half-transparent, which looks more
+            // like low-contrast text than a disabled control.
+            return root.enabled ? fill : Qt.rgba(fill.r, fill.g, fill.b, fill.a * 0.5)
         }
         border.width: (root.primary || root.subtle || root.destructive || root.warning) ? 0 : 1
         border.color: (root.primary || root.subtle || root.destructive || root.warning) ? "transparent" : (root.enabled ? Theme.borderColor : Qt.darker(Theme.borderColor, 1.2))
@@ -182,7 +188,7 @@ Button {
                 } else {
                     // First tap = announce only
                     AccessibilityManager.lastAnnouncedItem = root
-                    AccessibilityManager.announce(root.accessibleName)
+                    AccessibilityManager.announce(root.Accessible.name)
                 }
             } else {
                 // Normal mode: activate immediately
@@ -191,11 +197,13 @@ Button {
         }
     }
 
-    // Announce button name when focused via keyboard (for accessibility)
+    // Announce button name when focused via keyboard (for accessibility).
+    // Accessible.name, not accessibleName: the former folds in accessibleDescription,
+    // and callers use that to carry state the label itself doesn't say.
     onActiveFocusChanged: {
         if (activeFocus && typeof AccessibilityManager !== "undefined" && AccessibilityManager.enabled) {
             AccessibilityManager.lastAnnouncedItem = root
-            AccessibilityManager.announce(root.accessibleName)
+            AccessibilityManager.announce(root.Accessible.name)
         }
     }
 }

--- a/qml/components/AccessibleButton.qml
+++ b/qml/components/AccessibleButton.qml
@@ -26,6 +26,28 @@ Button {
     // the press. Bind custom background visuals to this instead of `down`.
     readonly property alias isPressed: touchArea.pressed
 
+    // The current variant's fill, before press darkening. Split out so the foreground
+    // can be derived from it instead of assumed.
+    readonly property color _fillColor: {
+        if (root.subtle) return Qt.rgba(1, 1, 1, 0.2)
+        if (root.destructive) return Theme.errorColor
+        if (root.warning) return Theme.warningButtonColor
+        if (root.primary) return Theme.primaryColor
+        return Theme.surfaceColor
+    }
+
+    // Foreground (icon + label) for the enabled state. destructive/warning fills are
+    // theme-settable and can be light — amber in particular leaves white at ~2.1:1 —
+    // so their foreground is derived from the fill's luminance. primary keeps
+    // primaryContrastColor: the default blue sits right on the luminance threshold, so
+    // deriving it would flip every primary button in the app to black text on a hair's
+    // difference in theme colour.
+    readonly property color _foregroundColor: {
+        if (root.destructive || root.warning) return Theme.contrastColorFor(root._fillColor)
+        if (root.primary || root.subtle) return Theme.primaryContrastColor
+        return Theme.textColor
+    }
+
     // Optional font overrides (0/-1 = use defaults)
     property int _customFontSize: 0
     property int _customFontWeight: -1
@@ -43,12 +65,11 @@ Button {
     icon.color: {
         if (!root.enabled) {
             // Disabled primary/colored buttons: use semi-transparent contrast color
-            if (root.primary || root.destructive || root.warning) return Qt.rgba(Theme.primaryContrastColor.r, Theme.primaryContrastColor.g, Theme.primaryContrastColor.b, 0.5)
-            if (root.subtle) return Qt.rgba(Theme.primaryContrastColor.r, Theme.primaryContrastColor.g, Theme.primaryContrastColor.b, 0.4)
+            if (root.primary || root.destructive || root.warning) return Qt.rgba(root._foregroundColor.r, root._foregroundColor.g, root._foregroundColor.b, 0.5)
+            if (root.subtle) return Qt.rgba(root._foregroundColor.r, root._foregroundColor.g, root._foregroundColor.b, 0.4)
             return Theme.textSecondaryColor
         }
-        if (root.primary || root.subtle || root.destructive || root.warning) return Theme.primaryContrastColor
-        return Theme.textColor
+        return root._foregroundColor
     }
 
     contentItem: Item {
@@ -93,20 +114,16 @@ Button {
 
     background: Rectangle {
         implicitHeight: Theme.scaled(44)
+        // isPressed, not down: touchArea accepts every press, so Button.down never
+        // goes true and every press-darkening branch here was dead.
         color: {
             if (root.subtle) {
-                return root.down ? Qt.rgba(1, 1, 1, 0.3) : Qt.rgba(1, 1, 1, 0.2)
+                return root.isPressed ? Qt.rgba(1, 1, 1, 0.3) : Qt.rgba(1, 1, 1, 0.2)
             }
-            if (root.destructive) {
-                return root.down ? Qt.darker(Theme.errorColor, 1.1) : Theme.errorColor
+            if (root.destructive || root.warning || root.primary) {
+                return root.isPressed ? Qt.darker(root._fillColor, 1.1) : root._fillColor
             }
-            if (root.warning) {
-                return root.down ? Qt.darker(Theme.warningButtonColor, 1.1) : Theme.warningButtonColor
-            }
-            if (root.primary) {
-                return root.down ? Qt.darker(Theme.primaryColor, 1.1) : Theme.primaryColor
-            }
-            return root.down ? Qt.darker(Theme.surfaceColor, 1.2) : Theme.surfaceColor
+            return root.isPressed ? Qt.darker(Theme.surfaceColor, 1.2) : Theme.surfaceColor
         }
         border.width: (root.primary || root.subtle || root.destructive || root.warning) ? 0 : 1
         border.color: (root.primary || root.subtle || root.destructive || root.warning) ? "transparent" : (root.enabled ? Theme.borderColor : Qt.darker(Theme.borderColor, 1.2))

--- a/qml/components/AccessibleButton.qml
+++ b/qml/components/AccessibleButton.qml
@@ -114,16 +114,19 @@ Button {
 
     background: Rectangle {
         implicitHeight: Theme.scaled(44)
-        // isPressed, not down: touchArea accepts every press, so Button.down never
-        // goes true and every press-darkening branch here was dead.
+        // Both, deliberately: touchArea only covers contentItem, so a press on the
+        // button's padding never reaches it and only sets Button.down, while a press
+        // on the label is taken by touchArea and only sets isPressed. Binding either
+        // one alone leaves half the button's surface with no press feedback.
+        readonly property bool showPressed: root.down || root.isPressed
         color: {
             if (root.subtle) {
-                return root.isPressed ? Qt.rgba(1, 1, 1, 0.3) : Qt.rgba(1, 1, 1, 0.2)
+                return showPressed ? Qt.rgba(1, 1, 1, 0.3) : Qt.rgba(1, 1, 1, 0.2)
             }
             if (root.destructive || root.warning || root.primary) {
-                return root.isPressed ? Qt.darker(root._fillColor, 1.1) : root._fillColor
+                return showPressed ? Qt.darker(root._fillColor, 1.1) : root._fillColor
             }
-            return root.isPressed ? Qt.darker(Theme.surfaceColor, 1.2) : Theme.surfaceColor
+            return showPressed ? Qt.darker(Theme.surfaceColor, 1.2) : Theme.surfaceColor
         }
         border.width: (root.primary || root.subtle || root.destructive || root.warning) ? 0 : 1
         border.color: (root.primary || root.subtle || root.destructive || root.warning) ? "transparent" : (root.enabled ? Theme.borderColor : Qt.darker(Theme.borderColor, 1.2))

--- a/qml/components/BottomBar.qml
+++ b/qml/components/BottomBar.qml
@@ -57,60 +57,70 @@ Item {
         anchors.rightMargin: Theme.spacingLarge
         spacing: Theme.spacingMedium
 
-        // Back button (square hitbox, full bar height)
-        Item {
-            id: backButton
-            visible: root.showBackButton
-            Layout.preferredWidth: Theme.bottomBarHeight
-            Layout.preferredHeight: Theme.bottomBarHeight
+        // Back button + title are grouped at spacing 0 so the title sits close to
+        // the arrow. The back button's square hitbox is a full bar-height wide but
+        // its glyph is only iconSize wide, so it already contributes
+        // (bottomBarHeight - iconSize) / 2 of visual gap; the row's spacingMedium
+        // on top of that pushed the title away from the arrow and wasted width the
+        // custom content area needs.
+        RowLayout {
+            spacing: 0
 
-            activeFocusOnTab: true
+            // Back button (square hitbox, full bar height)
+            Item {
+                id: backButton
+                visible: root.showBackButton
+                Layout.preferredWidth: Theme.bottomBarHeight
+                Layout.preferredHeight: Theme.bottomBarHeight
 
-            // Accessibility: Let AccessibleTapHandler handle screen reader interaction
-            // to avoid duplicate focus elements
-            Accessible.ignored: true
+                activeFocusOnTab: true
 
-            // Focus indicator
-            Rectangle {
-                anchors.fill: parent
-                anchors.margins: -Theme.focusMargin
-                visible: backButton.activeFocus
-                color: "transparent"
-                border.width: Theme.focusBorderWidth
-                border.color: Theme.focusColor
-                radius: Theme.scaled(4)
-            }
-
-            ThemedIcon {
-                anchors.centerIn: parent
-                source: "qrc:/icons/back.svg"
-                iconSize: Theme.scaled(28)
-                color: root.contentColor
-                // Decorative - accessibility handled by AccessibleTapHandler
+                // Accessibility: Let AccessibleTapHandler handle screen reader interaction
+                // to avoid duplicate focus elements
                 Accessible.ignored: true
+
+                // Focus indicator
+                Rectangle {
+                    anchors.fill: parent
+                    anchors.margins: -Theme.focusMargin
+                    visible: backButton.activeFocus
+                    color: "transparent"
+                    border.width: Theme.focusBorderWidth
+                    border.color: Theme.focusColor
+                    radius: Theme.scaled(4)
+                }
+
+                ThemedIcon {
+                    anchors.centerIn: parent
+                    source: "qrc:/icons/back.svg"
+                    iconSize: Theme.scaled(28)
+                    color: root.contentColor
+                    // Decorative - accessibility handled by AccessibleTapHandler
+                    Accessible.ignored: true
+                }
+
+                Keys.onReturnPressed: root.backClicked()
+                Keys.onEnterPressed: root.backClicked()
+                Keys.onEscapePressed: root.backClicked()
+
+                // Using TapHandler for better touch responsiveness
+                AccessibleTapHandler {
+                    anchors.fill: parent
+                    accessibleName: TranslationManager.translate("bottombar.button.back.accessible", "Back. Return to previous screen")
+                    accessibleItem: backButton
+                    onAccessibleClicked: root.backClicked()
+                }
             }
 
-            Keys.onReturnPressed: root.backClicked()
-            Keys.onEnterPressed: root.backClicked()
-            Keys.onEscapePressed: root.backClicked()
-
-            // Using TapHandler for better touch responsiveness
-            AccessibleTapHandler {
-                anchors.fill: parent
-                accessibleName: TranslationManager.translate("bottombar.button.back.accessible", "Back. Return to previous screen")
-                accessibleItem: backButton
-                onAccessibleClicked: root.backClicked()
+            Text {
+                visible: root.title !== ""
+                text: root.title
+                color: root.contentColor
+                font.pixelSize: Theme.scaled(20)
+                font.bold: true
+                Layout.maximumWidth: root.width * 0.5
+                elide: Text.ElideRight
             }
-        }
-
-        Text {
-            visible: root.title !== ""
-            text: root.title
-            color: root.contentColor
-            font.pixelSize: Theme.scaled(20)
-            font.bold: true
-            Layout.maximumWidth: root.width * 0.5
-            elide: Text.ElideRight
         }
 
         Item { Layout.fillWidth: true }

--- a/qml/components/BottomBar.qml
+++ b/qml/components/BottomBar.qml
@@ -11,6 +11,10 @@ Item {
     property bool showBackButton: true
     property string rightText: ""  // Simple right-aligned text
     default property alias content: contentRow.data  // Custom content goes here
+    // Content that belongs with the page title rather than the actions — it sits
+    // before the stretch, so it stays put next to the title instead of being pushed
+    // across the bar to sit against the buttons.
+    property alias leftContent: leftContentRow.data
 
     signal backClicked()
 
@@ -119,6 +123,12 @@ Item {
                 Layout.maximumWidth: root.width * 0.5
                 elide: Text.ElideRight
             }
+        }
+
+        // Title-side custom content
+        RowLayout {
+            id: leftContentRow
+            spacing: Theme.spacingMedium
         }
 
         Item { Layout.fillWidth: true }

--- a/qml/components/BottomBar.qml
+++ b/qml/components/BottomBar.qml
@@ -61,10 +61,10 @@ Item {
         anchors.rightMargin: Theme.spacingLarge
         spacing: Theme.spacingMedium
 
-        // spacing 0: the back button's hitbox is deliberately a full bar-height wide
-        // around a much narrower glyph, so it already supplies the gap before the
-        // title. Re-adding row spacing here just pushes the title away from the arrow
-        // and costs the custom content area width it needs.
+        // spacing 0: when the back button is shown, its hitbox is deliberately a full
+        // bar-height wide around a much narrower glyph, so it already supplies the gap
+        // before the title. (With no back button the row collapses and the outer
+        // leftMargin is the only inset.)
         RowLayout {
             spacing: 0
 

--- a/qml/components/BottomBar.qml
+++ b/qml/components/BottomBar.qml
@@ -57,12 +57,10 @@ Item {
         anchors.rightMargin: Theme.spacingLarge
         spacing: Theme.spacingMedium
 
-        // Back button + title are grouped at spacing 0 so the title sits close to
-        // the arrow. The back button's square hitbox is a full bar-height wide but
-        // its glyph is only iconSize wide, so it already contributes
-        // (bottomBarHeight - iconSize) / 2 of visual gap; the row's spacingMedium
-        // on top of that pushed the title away from the arrow and wasted width the
-        // custom content area needs.
+        // spacing 0: the back button's hitbox is deliberately a full bar-height wide
+        // around a much narrower glyph, so it already supplies the gap before the
+        // title. Re-adding row spacing here just pushes the title away from the arrow
+        // and costs the custom content area width it needs.
         RowLayout {
             spacing: 0
 

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -2239,21 +2239,27 @@ Page {
                 anchors.centerIn: parent
                 spacing: Theme.scaled(6)
 
+                // Cloud-with-up-arrow glyph carries "upload"; the label is just the
+                // destination. Accessible.name on the button keeps the
+                // upload/re-upload distinction the visible label drops.
                 Image {
-                    source: "qrc:/emoji/2601.svg"  // Cloud icon
+                    source: "qrc:/icons/Upload.svg"
                     sourceSize.width: Theme.scaled(16)
                     sourceSize.height: Theme.scaled(16)
                     anchors.verticalCenter: parent.verticalCenter
                     Accessible.ignored: true
+
+                    layer.enabled: true
+                    layer.smooth: true
+                    layer.effect: MultiEffect {
+                        colorization: 1.0
+                        colorizationColor: Theme.primaryContrastColor
+                    }
                 }
 
                 Tr {
-                    key: _visualizerId
-                         ? "postshotreview.button.reupload"
-                         : "postshotreview.button.upload"
-                    fallback: _visualizerId
-                              ? "Re-Upload to Visualizer"
-                              : "Upload to Visualizer"
+                    key: "postshotreview.button.visualizer"
+                    fallback: "Visualizer"
                     color: Theme.primaryContrastColor
                     font: Theme.bodyFont
                     anchors.verticalCenter: parent.verticalCenter

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -2189,121 +2189,71 @@ Page {
         AccessibleButton {
             id: undoButton
             visible: postShotReviewPage._undoDepth > 0
-            Layout.preferredWidth: undoButtonContent.implicitWidth + Theme.scaled(40)
-            Layout.preferredHeight: Theme.scaled(44)
+            icon.source: "qrc:/icons/history.svg"
+            tintIcon: true
             text: TranslationManager.translate("postshotreview.button.undo", "Undo")
             accessibleName: TranslationManager.translate("postshotreview.accessible.undo", "Undo last change")
             onClicked: postShotReviewPage.undoLastChange()
-
-            contentItem: Row {
-                id: undoButtonContent
-                spacing: Theme.scaled(6)
-
-                Image {
-                    source: "qrc:/icons/history.svg"
-                    sourceSize.width: Theme.scaled(16)
-                    sourceSize.height: Theme.scaled(16)
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-
-                Tr {
-                    key: "postshotreview.button.undo"
-                    fallback: "Undo"
-                    color: Theme.textColor
-                    font: Theme.bodyFont
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-            }
         }
 
         // Upload / Re-Upload to Visualizer button
-        Rectangle {
+        AccessibleButton {
             id: uploadButton
             visible: editShotData.durationSec > 0 && !MainController.visualizer.uploading
-            Layout.preferredWidth: uploadButtonContent.width + 32
-            Layout.preferredHeight: Theme.scaled(44)
-            radius: Theme.scaled(8)
-            color: uploadArea.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
 
-            Accessible.role: Accessible.Button
-            Accessible.name: _visualizerId
+            // Everything this shot knows is already on Visualizer: nothing to push.
+            // Anything else — never uploaded, or a local edit saved but not yet
+            // PATCHed — means a tap would actually send something, which is what
+            // the warning fill signals. Screen readers get the same state via
+            // accessibleDescription, since colour alone can't carry it.
+            readonly property bool inSync: !!_visualizerId && !pendingVisualizerUpdate
+            primary: inSync
+            warning: !inSync
+
+            icon.source: "qrc:/icons/CloudUpload.svg"
+            tintIcon: true
+            text: TranslationManager.translate("common.button.visualizer", "Visualizer")
+
+            accessibleName: _visualizerId
                 ? TranslationManager.translate("postshotreview.button.reupload", "Re-Upload to Visualizer")
                 : TranslationManager.translate("postshotreview.button.upload", "Upload to Visualizer")
-            Accessible.focusable: true
-            Accessible.onPressAction: uploadArea.clicked(null)
+            accessibleDescription: (!!_visualizerId && pendingVisualizerUpdate)
+                ? TranslationManager.translate("postshotreview.accessible.changespending", "Changes pending upload")
+                : ""
 
-            Row {
-                id: uploadButtonContent
-                anchors.centerIn: parent
-                spacing: Theme.scaled(6)
+            onClicked: {
+                // Flush any pending edit before uploading
+                autosave()
+                // Clear the pending flag before dispatching — auto-update on destruction
+                // must not fire a second request while this one is in flight. On failure
+                // pendingVisualizerUpdate remains false (it was cleared here), so
+                // auto-update on close will not retry; the user must tap the button again.
+                pendingVisualizerUpdate = false
 
-                // Cloud-with-up-arrow glyph carries "upload"; the label is just the
-                // destination. Accessible.name on the button keeps the
-                // upload/re-upload distinction the visible label drops.
-                Image {
-                    source: "qrc:/icons/Upload.svg"
-                    sourceSize.width: Theme.scaled(16)
-                    sourceSize.height: Theme.scaled(16)
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-
-                    layer.enabled: true
-                    layer.smooth: true
-                    layer.effect: MultiEffect {
-                        colorization: 1.0
-                        colorizationColor: Theme.primaryContrastColor
-                    }
-                }
-
-                Tr {
-                    key: "postshotreview.button.visualizer"
-                    fallback: "Visualizer"
-                    color: Theme.primaryContrastColor
-                    font: Theme.bodyFont
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-            }
-
-            MouseArea {
-                id: uploadArea
-                anchors.fill: parent
-                onClicked: {
-                    // Flush any pending edit before uploading
-                    autosave()
-                    // Clear the pending flag before dispatching — auto-update on destruction
-                    // must not fire a second request while this one is in flight. On failure
-                    // pendingVisualizerUpdate remains false (it was cleared here), so
-                    // auto-update on close will not retry; the user must tap the button again.
-                    pendingVisualizerUpdate = false
-
-                    uploadError = ""
-                    uploadSkipReason = ""
-                    if (_visualizerId) {
-                        // Re-upload: PATCH metadata from current edit fields. Reuse
-                        // buildVisualizerOverrides() so the manual and auto-update paths
-                        // stay in sync as fields evolve.
-                        var patchOverrides = buildVisualizerOverrides()
-                        _patchInFlight = true
-                        // editShotData may be a plain-JS clone (badges/save) or the
-                        // raw gadget; the C++ method takes QVariant and coerces it,
-                        // so id/duration/frame arrays survive either way. Edited
-                        // fields ride in patchOverrides.
-                        MainController.visualizer.updateShotOnVisualizerWithOverrides(
-                            _visualizerId, editShotData, patchOverrides)
-                    } else {
-                        // First upload: pass editShotData (a clone after badges/save,
-                        // or the raw gadget if untouched) plus current edit-field
-                        // overrides. The C++ method takes QVariant and coerces via
-                        // ShotProjection::coerce(), so id, durationSec, and frame
-                        // arrays survive isValid().
-                        var uploadOverrides = buildVisualizerOverrides()
-                        _firstUploadInFlight = true
-                        MainController.visualizer.uploadShotFromHistoryWithOverrides(
-                            editShotData, uploadOverrides)
-                    }
+                uploadError = ""
+                uploadSkipReason = ""
+                if (_visualizerId) {
+                    // Re-upload: PATCH metadata from current edit fields. Reuse
+                    // buildVisualizerOverrides() so the manual and auto-update paths
+                    // stay in sync as fields evolve.
+                    var patchOverrides = buildVisualizerOverrides()
+                    _patchInFlight = true
+                    // editShotData may be a plain-JS clone (badges/save) or the
+                    // raw gadget; the C++ method takes QVariant and coerces it,
+                    // so id/duration/frame arrays survive either way. Edited
+                    // fields ride in patchOverrides.
+                    MainController.visualizer.updateShotOnVisualizerWithOverrides(
+                        _visualizerId, editShotData, patchOverrides)
+                } else {
+                    // First upload: pass editShotData (a clone after badges/save,
+                    // or the raw gadget if untouched) plus current edit-field
+                    // overrides. The C++ method takes QVariant and coerces via
+                    // ShotProjection::coerce(), so id, durationSec, and frame
+                    // arrays survive isValid().
+                    var uploadOverrides = buildVisualizerOverrides()
+                    _firstUploadInFlight = true
+                    MainController.visualizer.uploadShotFromHistoryWithOverrides(
+                        editShotData, uploadOverrides)
                 }
             }
         }
@@ -2338,202 +2288,75 @@ Page {
         }
 
         // AI Advice button - visible when AI is configured and we have shot data
-        Rectangle {
+        AccessibleButton {
             id: aiAdviceButton
             visible: MainController.aiManager && MainController.aiManager.isConfigured && editShotData.durationSec > 0
-            Layout.preferredWidth: aiAdviceContent.width + 32
-            Layout.preferredHeight: Theme.scaled(44)
-            radius: Theme.scaled(8)
-            color: MainController.aiManager && MainController.aiManager.isConfigured
-                   ? Theme.primaryColor : Theme.cardBackgroundColor
-            opacity: MainController.aiManager && MainController.aiManager.isAnalyzing ? 0.6 : 1.0
-
-            Accessible.role: Accessible.Button
-            Accessible.name: TranslationManager.translate("postshotreview.accessible.getaiadvice", "Get AI Advice")
-            Accessible.focusable: true
-            Accessible.onPressAction: aiAdviceArea.clicked(null)
-
-            Row {
-                id: aiAdviceContent
-                anchors.centerIn: parent
-                spacing: Theme.scaled(6)
-
-                Image {
-                    source: "qrc:/icons/sparkle.svg"
-                    width: Theme.scaled(18)
-                    height: Theme.scaled(18)
-                    anchors.verticalCenter: parent.verticalCenter
-                    visible: status === Image.Ready
-                    Accessible.ignored: true
-
-                    layer.enabled: true
-                    layer.smooth: true
-                    layer.effect: MultiEffect {
-                        colorization: 1.0
-                        colorizationColor: Theme.textColor
-                    }
-                }
-
-                Tr {
-                    key: MainController.aiManager && MainController.aiManager.isAnalyzing
-                          ? "postshotreview.button.analyzing" : "postshotreview.button.aiadvice"
-                    fallback: MainController.aiManager && MainController.aiManager.isAnalyzing
-                          ? "Analyzing..." : "AI Advice"
-                    color: MainController.aiManager && MainController.aiManager.isConfigured
-                           ? Theme.primaryContrastColor : Theme.textColor
-                    font: Theme.bodyFont
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-            }
-
-                MouseArea {
-                id: aiAdviceArea
-                anchors.fill: parent
-                enabled: MainController.aiManager && MainController.aiManager.isConfigured && !MainController.aiManager.isAnalyzing
-                onClicked: {
-                    // editShotData is the DB-load snapshot and is NOT updated as
-                    // the user rates the shot on this page (or in the advisor's
-                    // own intake). Hand the advisor the LIVE taste so its per-shot
-                    // intake gate sees feedback the user already gave and doesn't
-                    // re-ask "how did this shot taste?".
-                    var shotForAdvisor = clonePersistedShot(editShotData)
-                    shotForAdvisor.tasteBalance = editTasteBalance
-                    shotForAdvisor.tasteBody = editTasteBody
-                    shotForAdvisor.enjoyment0to100 = editEnjoyment
-                    conversationOverlay.openWithShot(shotForAdvisor, editBeanBrand, editBeanType, editShotData.profileName, editShotId)
-                }
+            enabled: MainController.aiManager && MainController.aiManager.isConfigured && !MainController.aiManager.isAnalyzing
+            primary: true
+            icon.source: "qrc:/icons/sparkle.svg"
+            tintIcon: true
+            text: MainController.aiManager && MainController.aiManager.isAnalyzing
+                  ? TranslationManager.translate("postshotreview.button.analyzing", "Analyzing...")
+                  : TranslationManager.translate("postshotreview.button.aiadvice", "AI Advice")
+            accessibleName: TranslationManager.translate("postshotreview.accessible.getaiadvice", "Get AI Advice")
+            onClicked: {
+                // editShotData is the DB-load snapshot and is NOT updated as
+                // the user rates the shot on this page (or in the advisor's
+                // own intake). Hand the advisor the LIVE taste so its per-shot
+                // intake gate sees feedback the user already gave and doesn't
+                // re-ask "how did this shot taste?".
+                var shotForAdvisor = clonePersistedShot(editShotData)
+                shotForAdvisor.tasteBalance = editTasteBalance
+                shotForAdvisor.tasteBody = editTasteBody
+                shotForAdvisor.enjoyment0to100 = editEnjoyment
+                conversationOverlay.openWithShot(shotForAdvisor, editBeanBrand, editBeanType, editShotData.profileName, editShotId)
             }
         }
 
         // Discuss button - opens external AI app
-        Rectangle {
+        AccessibleButton {
             id: discussButton
             readonly property bool isClaudeDesktopReady:
                 Settings.network.discussShotApp !== Settings.network.discussAppClaudeDesktop
                 || Settings.network.claudeRcSessionUrl.length > 0
             visible: editShotData.durationSec > 0 && Settings.network.discussShotApp !== Settings.network.discussAppNone
             enabled: isClaudeDesktopReady
-            opacity: enabled ? 1.0 : 0.5
-            Layout.preferredWidth: discussContent.width + 32
-            Layout.preferredHeight: Theme.scaled(44)
-            radius: Theme.scaled(8)
-            color: discussArea.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
-
-            Accessible.role: Accessible.Button
-            Accessible.name: TranslationManager.translate("postshotreview.accessible.discuss", "Discuss shot with external AI app")
-            Accessible.focusable: true
-            Accessible.onPressAction: discussArea.clicked(null)
-
-            Row {
-                id: discussContent
-                anchors.centerIn: parent
-                spacing: Theme.scaled(6)
-
-                Image {
-                    source: "qrc:/icons/sparkle.svg"
-                    width: Theme.scaled(18)
-                    height: Theme.scaled(18)
-                    anchors.verticalCenter: parent.verticalCenter
-                    visible: status === Image.Ready
-                    Accessible.ignored: true
-
-                    layer.enabled: true
-                    layer.smooth: true
-                    layer.effect: MultiEffect {
-                        colorization: 1.0
-                        colorizationColor: Theme.primaryContrastColor
-                    }
+            primary: true
+            icon.source: "qrc:/icons/sparkle.svg"
+            tintIcon: true
+            text: TranslationManager.translate("postshotreview.button.discuss", "Discuss")
+            accessibleName: TranslationManager.translate("postshotreview.accessible.discuss", "Discuss shot with external AI app")
+            onClicked: {
+                // Copy shot summary to clipboard if MCP is not connected
+                if (!Settings.mcp.mcpEnabled && MainController.aiManager) {
+                    // Prose, not the JSON envelope — the user is pasting this into
+                    // an external AI tool. See #1042 / ShotDetailPage clipboard
+                    // path for rationale.
+                    var summary = MainController.aiManager.buildShotAnalysisProseForShot(editShotData)
+                    if (summary.length > 0) MainController.copyToClipboard(summary)
                 }
-
-                Tr {
-                    key: "postshotreview.button.discuss"
-                    fallback: "Discuss"
-                    color: Theme.primaryContrastColor
-                    font: Theme.bodyFont
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-            }
-
-            MouseArea {
-                id: discussArea
-                anchors.fill: parent
-                enabled: discussButton.isClaudeDesktopReady
-                onClicked: {
-                    // Copy shot summary to clipboard if MCP is not connected
-                    if (!Settings.mcp.mcpEnabled && MainController.aiManager) {
-                        // Prose, not the JSON envelope — the user is pasting this into
-                        // an external AI tool. See #1042 / ShotDetailPage clipboard
-                        // path for rationale.
-                        var summary = MainController.aiManager.buildShotAnalysisProseForShot(editShotData)
-                        if (summary.length > 0) MainController.copyToClipboard(summary)
-                    }
-                    // Open configured AI app
-                    var url = Settings.network.discussShotUrl()
-                    if (url.length > 0) Settings.network.openDiscussUrl(url)
-                }
+                // Open configured AI app
+                var url = Settings.network.discussShotUrl()
+                if (url.length > 0) Settings.network.openDiscussUrl(url)
             }
         }
 
         // Email Prompt button - fallback for users without API keys
-        Rectangle {
+        AccessibleButton {
             id: emailPromptButton
             visible: MainController.aiManager && !MainController.aiManager.isConfigured && editShotData.durationSec > 0
-            Layout.preferredWidth: emailPromptContent.width + 32
-            Layout.preferredHeight: Theme.scaled(44)
-            radius: Theme.scaled(8)
-            color: Theme.cardBackgroundColor
-
-            Accessible.role: Accessible.Button
-            Accessible.name: TranslationManager.translate("postshotreview.accessible.emailprompt", "Email AI prompt to yourself")
-            Accessible.focusable: true
-            Accessible.onPressAction: emailPromptArea.clicked(null)
-
-            Row {
-                id: emailPromptContent
-                anchors.centerIn: parent
-                spacing: Theme.scaled(6)
-
-                Image {
-                    source: "qrc:/icons/sparkle.svg"
-                    width: Theme.scaled(18)
-                    height: Theme.scaled(18)
-                    anchors.verticalCenter: parent.verticalCenter
-                    visible: status === Image.Ready
-                    opacity: 0.6
-                    Accessible.ignored: true
-
-                    layer.enabled: true
-                    layer.smooth: true
-                    layer.effect: MultiEffect {
-                        colorization: 1.0
-                        colorizationColor: Theme.textSecondaryColor
-                    }
-                }
-
-                Tr {
-                    key: "postshotreview.button.emailprompt"
-                    fallback: "Email Prompt"
-                    color: Theme.textColor
-                    font: Theme.bodyFont
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-            }
-
-            MouseArea {
-                id: emailPromptArea
-                anchors.fill: parent
-                onClicked: {
-                    // Prose, not the JSON envelope — the email body lands in the
-                    // user's mail client; the JSON shape double-shipped structured
-                    // fields (#1042).
-                    var prompt = MainController.aiManager.buildShotAnalysisProseForShot(editShotData)
-                    // Open mailto: with prompt in body
-                    Qt.openUrlExternally("mailto:?subject=" + encodeURIComponent("Espresso Shot Analysis") +
-                                        "&body=" + encodeURIComponent(prompt))
-                }
+            icon.source: "qrc:/icons/sparkle.svg"
+            tintIcon: true
+            text: TranslationManager.translate("postshotreview.button.emailprompt", "Email Prompt")
+            accessibleName: TranslationManager.translate("postshotreview.accessible.emailprompt", "Email AI prompt to yourself")
+            onClicked: {
+                // Prose, not the JSON envelope — the email body lands in the
+                // user's mail client; the JSON shape double-shipped structured
+                // fields (#1042).
+                var prompt = MainController.aiManager.buildShotAnalysisProseForShot(editShotData)
+                // Open mailto: with prompt in body
+                Qt.openUrlExternally("mailto:?subject=" + encodeURIComponent("Espresso Shot Analysis") +
+                                    "&body=" + encodeURIComponent(prompt))
             }
         }
 

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -2155,9 +2155,10 @@ Page {
         title: TranslationManager.translate("postshotreview.title", "Shot Review")
         onBackClicked: handleBack()
 
-        // Profile name + date remain visible while the user scrolls,
-        // providing context when the header is off-screen.
-        ColumnLayout {
+        // Profile name + date remain visible while the user scrolls, providing context
+        // when the header is off-screen. It reads as a subtitle to the page title, so
+        // it lives in leftContent and stays beside it.
+        leftContent: ColumnLayout {
             visible: !!(editShotData.profileName)
             spacing: 0
             Layout.alignment: Qt.AlignVCenter

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -2205,8 +2205,12 @@ Page {
             // Everything this shot knows is already on Visualizer: nothing to push.
             // Anything else — never uploaded, or a local edit saved but not yet
             // PATCHed — means a tap would actually send something, which is what
-            // the warning fill signals. Screen readers get the same state via
-            // accessibleDescription, since colour alone can't carry it.
+            // the warning fill signals.
+            //
+            // The two not-in-sync cases are announced differently, since colour alone
+            // can't carry state: never-uploaded is already implied by accessibleName
+            // ("Upload" vs "Re-Upload"), but a pending edit needs accessibleDescription
+            // — the name reads the same either way.
             readonly property bool inSync: !!_visualizerId && !pendingVisualizerUpdate
             primary: inSync
             warning: !inSync

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -1616,21 +1616,27 @@ Page {
                 anchors.centerIn: parent
                 spacing: Theme.scaled(6)
 
+                // Cloud-with-up-arrow glyph carries "upload"; the label is just the
+                // destination. Accessible.name on the button keeps the
+                // upload/re-upload distinction the visible label drops.
                 Image {
-                    source: "qrc:/emoji/2601.svg"  // Cloud icon
+                    source: "qrc:/icons/Upload.svg"
                     sourceSize.width: Theme.scaled(16)
                     sourceSize.height: Theme.scaled(16)
                     anchors.verticalCenter: parent.verticalCenter
                     Accessible.ignored: true
+
+                    layer.enabled: true
+                    layer.smooth: true
+                    layer.effect: MultiEffect {
+                        colorization: 1.0
+                        colorizationColor: Theme.primaryContrastColor
+                    }
                 }
 
                 Tr {
-                    key: shotData.visualizerId
-                         ? "shotdetail.button.reupload"
-                         : "shotdetail.button.upload"
-                    fallback: shotData.visualizerId
-                              ? "Re-Upload"
-                              : "Upload"
+                    key: "shotdetail.button.visualizer"
+                    fallback: "Visualizer"
                     color: Theme.primaryContrastColor
                     font: Theme.bodyFont
                     anchors.verticalCenter: parent.verticalCenter

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -1366,10 +1366,10 @@ Page {
 
                     Row {
                         spacing: Theme.scaled(4)
-                        Image {
-                            source: "qrc:/emoji/2601.svg"
-                            sourceSize.width: Theme.labelFont.pixelSize
-                            sourceSize.height: Theme.labelFont.pixelSize
+                        ThemedIcon {
+                            source: "qrc:/icons/CloudUpload.svg"
+                            iconSize: Theme.labelFont.pixelSize
+                            color: Theme.successColor
                             anchors.verticalCenter: parent.verticalCenter
                             Accessible.ignored: true
                         }
@@ -1596,64 +1596,30 @@ Page {
         }
 
         // Upload / Re-Upload to Visualizer button
-        Rectangle {
+        AccessibleButton {
             id: uploadButton
             visible: shotData.durationSec > 0 && !MainController.visualizer.uploading
-            Layout.preferredWidth: uploadButtonContent.width + 32
-            Layout.preferredHeight: Theme.scaled(44)
-            radius: Theme.scaled(8)
-            color: uploadButtonArea.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
 
-            Accessible.role: Accessible.Button
-            Accessible.name: shotData.visualizerId
+            // This page has no editable fields, so "in sync" is simply "already on
+            // Visualizer" — unlike PostShotReviewPage, nothing here can dirty a shot
+            // after upload. Warning fill means a tap would push a shot that isn't up yet.
+            primary: !!shotData.visualizerId
+            warning: !shotData.visualizerId
+
+            icon.source: "qrc:/icons/CloudUpload.svg"
+            tintIcon: true
+            text: TranslationManager.translate("common.button.visualizer", "Visualizer")
+
+            accessibleName: shotData.visualizerId
                 ? TranslationManager.translate("shotdetail.button.reupload", "Re-Upload to Visualizer")
                 : TranslationManager.translate("shotdetail.button.upload", "Upload to Visualizer")
-            Accessible.focusable: true
-            Accessible.onPressAction: uploadButtonArea.clicked(null)
 
-            Row {
-                id: uploadButtonContent
-                anchors.centerIn: parent
-                spacing: Theme.scaled(6)
-
-                // Cloud-with-up-arrow glyph carries "upload"; the label is just the
-                // destination. Accessible.name on the button keeps the
-                // upload/re-upload distinction the visible label drops.
-                Image {
-                    source: "qrc:/icons/Upload.svg"
-                    sourceSize.width: Theme.scaled(16)
-                    sourceSize.height: Theme.scaled(16)
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-
-                    layer.enabled: true
-                    layer.smooth: true
-                    layer.effect: MultiEffect {
-                        colorization: 1.0
-                        colorizationColor: Theme.primaryContrastColor
-                    }
-                }
-
-                Tr {
-                    key: "shotdetail.button.visualizer"
-                    fallback: "Visualizer"
-                    color: Theme.primaryContrastColor
-                    font: Theme.bodyFont
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-            }
-
-            MouseArea {
-                id: uploadButtonArea
-                anchors.fill: parent
-                onClicked: {
-                    if (shotData.visualizerId) {
-                        MainController.visualizer.updateShotOnVisualizer(
-                            shotData.visualizerId, shotData)
-                    } else {
-                        MainController.visualizer.uploadShotFromHistory(shotData)
-                    }
+            onClicked: {
+                if (shotData.visualizerId) {
+                    MainController.visualizer.updateShotOnVisualizer(
+                        shotData.visualizerId, shotData)
+                } else {
+                    MainController.visualizer.uploadShotFromHistory(shotData)
                 }
             }
         }
@@ -1670,172 +1636,60 @@ Page {
         }
 
         // AI Advice button
-        Rectangle {
+        AccessibleButton {
             id: aiButton
             visible: MainController.aiManager && MainController.aiManager.isConfigured && shotData.durationSec > 0
-            Layout.preferredWidth: aiButtonContent.width + 32
-            Layout.preferredHeight: Theme.scaled(44)
-            radius: Theme.scaled(8)
-            color: aiButtonArea.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
-
-            Accessible.role: Accessible.Button
-            Accessible.name: TranslationManager.translate("shotdetail.aiadvice", "AI Advice")
-            Accessible.focusable: true
-            Accessible.onPressAction: aiButtonArea.clicked(null)
-
-            Row {
-                id: aiButtonContent
-                anchors.centerIn: parent
-                spacing: Theme.scaled(6)
-
-                Image {
-                    source: "qrc:/icons/sparkle.svg"
-                    width: Theme.scaled(18)
-                    height: Theme.scaled(18)
-                    anchors.verticalCenter: parent.verticalCenter
-                    visible: status === Image.Ready
-                    Accessible.ignored: true
-                }
-
-                Tr {
-                    key: "shotdetail.aiadvice"
-                    fallback: "AI Advice"
-                    color: Theme.primaryContrastColor
-                    font: Theme.bodyFont
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-            }
-
-            MouseArea {
-                id: aiButtonArea
-                anchors.fill: parent
-                onClicked: {
-                    conversationOverlay.openWithShot(shotData, shotData.beanBrand, shotData.beanType, shotData.profileName, shotDetailPage.shotId)
-                }
+            primary: true
+            icon.source: "qrc:/icons/sparkle.svg"
+            tintIcon: true
+            text: TranslationManager.translate("shotdetail.aiadvice", "AI Advice")
+            accessibleName: TranslationManager.translate("shotdetail.aiadvice", "AI Advice")
+            onClicked: {
+                conversationOverlay.openWithShot(shotData, shotData.beanBrand, shotData.beanType, shotData.profileName, shotDetailPage.shotId)
             }
         }
 
         // Discuss button - opens external AI app
-        Rectangle {
+        AccessibleButton {
             id: discussButton
             readonly property bool isClaudeDesktopReady:
                 Settings.network.discussShotApp !== Settings.network.discussAppClaudeDesktop
                 || Settings.network.claudeRcSessionUrl.length > 0
             visible: shotData.durationSec > 0 && Settings.network.discussShotApp !== Settings.network.discussAppNone
             enabled: isClaudeDesktopReady
-            opacity: enabled ? 1.0 : 0.5
-            Layout.preferredWidth: discussContent.width + 32
-            Layout.preferredHeight: Theme.scaled(44)
-            radius: Theme.scaled(8)
-            color: discussArea.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
-
-            Accessible.role: Accessible.Button
-            Accessible.name: TranslationManager.translate("shotdetail.accessible.discuss", "Discuss shot with external AI app")
-            Accessible.focusable: true
-            Accessible.onPressAction: discussArea.clicked(null)
-
-            Row {
-                id: discussContent
-                anchors.centerIn: parent
-                spacing: Theme.scaled(6)
-
-                Image {
-                    source: "qrc:/icons/sparkle.svg"
-                    width: Theme.scaled(18)
-                    height: Theme.scaled(18)
-                    anchors.verticalCenter: parent.verticalCenter
-                    visible: status === Image.Ready
-                    Accessible.ignored: true
+            primary: true
+            icon.source: "qrc:/icons/sparkle.svg"
+            tintIcon: true
+            text: TranslationManager.translate("shotdetail.discuss", "Discuss")
+            accessibleName: TranslationManager.translate("shotdetail.accessible.discuss", "Discuss shot with external AI app")
+            onClicked: {
+                if (!Settings.mcp.mcpEnabled && MainController.aiManager) {
+                    // Prose, not the JSON envelope — the user is pasting this into
+                    // an external AI tool, where prose is more readable and avoids
+                    // double-shipping the structured fields.
+                    var summary = MainController.aiManager.buildShotAnalysisProseForShot(shotData)
+                    if (summary.length > 0) MainController.copyToClipboard(summary)
                 }
-
-                Tr {
-                    key: "shotdetail.discuss"
-                    fallback: "Discuss"
-                    color: Theme.primaryContrastColor
-                    font: Theme.bodyFont
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-            }
-
-            MouseArea {
-                id: discussArea
-                anchors.fill: parent
-                enabled: discussButton.isClaudeDesktopReady
-                onClicked: {
-                    if (!Settings.mcp.mcpEnabled && MainController.aiManager) {
-                        // Prose, not the JSON envelope — the user is pasting this into
-                        // an external AI tool, where prose is more readable and avoids
-                        // double-shipping the structured fields.
-                        var summary = MainController.aiManager.buildShotAnalysisProseForShot(shotData)
-                        if (summary.length > 0) MainController.copyToClipboard(summary)
-                    }
-                    var url = Settings.network.discussShotUrl()
-                    if (url.length > 0) Settings.network.openDiscussUrl(url)
-                }
+                var url = Settings.network.discussShotUrl()
+                if (url.length > 0) Settings.network.openDiscussUrl(url)
             }
         }
 
         // Email Prompt button - fallback for users without API keys
-        Rectangle {
+        AccessibleButton {
             id: emailButton
             visible: MainController.aiManager && !MainController.aiManager.isConfigured && shotData.durationSec > 0
-            Layout.preferredWidth: emailButtonContent.width + 32
-            Layout.preferredHeight: Theme.scaled(44)
-            radius: Theme.scaled(8)
-            color: emailButtonArea.pressed ? Qt.darker(Theme.surfaceColor, 1.1) : Theme.surfaceColor
-            border.color: Theme.borderColor
-            border.width: 1
-
-            Accessible.role: Accessible.Button
-            Accessible.name: TranslationManager.translate("shotdetail.emailprompt", "Email Prompt")
-            Accessible.focusable: true
-            Accessible.onPressAction: emailButtonArea.clicked(null)
-
-            Row {
-                id: emailButtonContent
-                anchors.centerIn: parent
-                spacing: Theme.scaled(6)
-
-                Image {
-                    source: "qrc:/icons/sparkle.svg"
-                    width: Theme.scaled(18)
-                    height: Theme.scaled(18)
-                    anchors.verticalCenter: parent.verticalCenter
-                    visible: status === Image.Ready
-                    opacity: 0.6
-                    Accessible.ignored: true
-
-                    layer.enabled: true
-                    layer.smooth: true
-                    layer.effect: MultiEffect {
-                        colorization: 1.0
-                        colorizationColor: Theme.textSecondaryColor
-                    }
-                }
-
-                Tr {
-                    key: "shotdetail.email"
-                    fallback: "Email"
-                    color: Theme.textColor
-                    font: Theme.bodyFont
-                    anchors.verticalCenter: parent.verticalCenter
-                    Accessible.ignored: true
-                }
-            }
-
-            MouseArea {
-                id: emailButtonArea
-                anchors.fill: parent
-                onClicked: {
-                    // Prose, not the JSON envelope — the email body lands in the
-                    // user's mail client; prose is readable and the prior JSON shape
-                    // double-shipped structured fields (#1042).
-                    var prompt = MainController.aiManager.buildShotAnalysisProseForShot(shotData)
-                    var subject = "Espresso AI Analysis - " + (shotData.profileName || "Shot")
-                    Qt.openUrlExternally("mailto:?subject=" + encodeURIComponent(subject) + "&body=" + encodeURIComponent(prompt))
-                }
+            icon.source: "qrc:/icons/sparkle.svg"
+            tintIcon: true
+            text: TranslationManager.translate("shotdetail.email", "Email")
+            accessibleName: TranslationManager.translate("shotdetail.emailprompt", "Email Prompt")
+            onClicked: {
+                // Prose, not the JSON envelope — the email body lands in the
+                // user's mail client; prose is readable and the prior JSON shape
+                // double-shipped structured fields (#1042).
+                var prompt = MainController.aiManager.buildShotAnalysisProseForShot(shotData)
+                var subject = "Espresso AI Analysis - " + (shotData.profileName || "Shot")
+                Qt.openUrlExternally("mailto:?subject=" + encodeURIComponent(subject) + "&body=" + encodeURIComponent(prompt))
             }
         }
     }

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -1567,8 +1567,9 @@ Page {
         onBackClicked: root.goBack()
 
         // Profile name + date in the bottom bar remain visible while the user scrolls,
-        // providing context when the header is off-screen.
-        ColumnLayout {
+        // providing context when the header is off-screen. It reads as a subtitle to
+        // the page title, so it lives in leftContent and stays beside it.
+        leftContent: ColumnLayout {
             visible: !!(shotData.profileName)
             spacing: 0
             Layout.alignment: Qt.AlignVCenter
@@ -1595,45 +1596,10 @@ Page {
             }
         }
 
-        // Upload / Re-Upload to Visualizer button
-        AccessibleButton {
-            id: uploadButton
-            visible: shotData.durationSec > 0 && !MainController.visualizer.uploading
-
-            // This page has no editable fields, so "in sync" is simply "already on
-            // Visualizer" — unlike PostShotReviewPage, nothing here can dirty a shot
-            // after upload. Warning fill means a tap would push a shot that isn't up yet.
-            primary: !!shotData.visualizerId
-            warning: !shotData.visualizerId
-
-            icon.source: "qrc:/icons/CloudUpload.svg"
-            tintIcon: true
-            text: TranslationManager.translate("common.button.visualizer", "Visualizer")
-
-            accessibleName: shotData.visualizerId
-                ? TranslationManager.translate("shotdetail.button.reupload", "Re-Upload to Visualizer")
-                : TranslationManager.translate("shotdetail.button.upload", "Upload to Visualizer")
-
-            onClicked: {
-                if (shotData.visualizerId) {
-                    MainController.visualizer.updateShotOnVisualizer(
-                        shotData.visualizerId, shotData)
-                } else {
-                    MainController.visualizer.uploadShotFromHistory(shotData)
-                }
-            }
-        }
-
-        // Uploading/Updating indicator
-        Tr {
-            visible: MainController.visualizer.uploading
-            key: shotData.visualizerId
-                 ? "shotdetail.status.updating"
-                 : "shotdetail.status.uploading"
-            fallback: shotData.visualizerId ? "Updating..." : "Uploading..."
-            color: Theme.textSecondaryColor
-            font: Theme.labelFont
-        }
+        // No upload button here by design: this page is read-only, and the edit icon
+        // is one tap from PostShotReviewPage, which owns uploading (and is the only
+        // page that can produce the metadata overrides an upload should carry).
+        // Upload state is still shown, read-only, by the Visualizer status card above.
 
         // AI Advice button
         AccessibleButton {

--- a/resources/icons/CloudUpload.svg
+++ b/resources/icons/CloudUpload.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7 19.5A4.5 4.5 0 0 1 6.08 10.6 6 6 0 0 1 17.72 8.6 4.75 4.75 0 0 1 17 19.5M12 21V11M12 11 9 14M12 11 15 14" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -79,6 +79,7 @@
         <file>icons/Graph.svg</file>
         <file>icons/ArrowLeft.svg</file>
         <file>icons/Upload.svg</file>
+        <file>icons/CloudUpload.svg</file>
         <file>icons/list.svg</file>
         <file>icons/plus.svg</file>
         <file>icons/download.svg</file>


### PR DESCRIPTION
The Shot Review bottom bar overflows on tablet widths — the **Discuss** button runs off the right edge. Rebased on `main` (includes #1529, #1531). Verified in the running app: the bar fits, Discuss is fully on-page.

Two review passes ran on this branch; both found real problems, noted inline below.

## 1. Visualizer button: real cloud icon, shorter label

"Re-Upload to Visualizer" (22 chars) was the longest label in the bar. The glyph now carries "upload" and the label is just the destination — **"Visualizer"** (10 chars).

⚠️ **Correction:** the first revision used `qrc:/icons/Upload.svg`, described in its commit as a "cloud-with-up-arrow glyph". `Upload.svg` is a **server tray with a status LED**, not a cloud — the claim was never checked by rendering it, and a comment repeating it was committed to both pages. Caught in review. This adds a real `resources/icons/CloudUpload.svg` in the project's icon language (24px viewBox, stroke-width 2, round caps). `Upload.svg` stays for LibraryPanel's share action.

Also drops the full-colour emoji cloud (`qrc:/emoji/2601.svg`) for the themed icon, and unifies both pages behind a single `common.button.visualizer` key.

## 2. The button shows whether anything needs uploading

- **primary (blue)** — everything about this shot is already on Visualizer.
- **warning (amber)** — a tap would push something: never uploaded, or a local edit saved but not yet PATCHed.

Restores the sighted "did it upload?" signal the static label dropped. Colour can't carry state alone: never-uploaded is implied by `accessibleName` ("Upload" vs "Re-Upload"), and a pending edit rides in `accessibleDescription` since the name reads the same either way.

## 3. Shot Detail loses its Visualizer button

That page is read-only and its edit icon already pushes PostShotReviewPage (`ShotDetailPage.qml:490`), which owns uploading. The button was a duplicate action one tap from the real one, on a second, dumber code path (`uploadShotFromHistory`/`updateShotOnVisualizer`, without the metadata overrides the review page sends).

It also made the state colour meaningless there: nothing on that page can dirty a shot, so amber degraded to "not uploaded" — the resting state for most of a 1000-shot history, an attention colour always on. State is still shown read-only by the existing "Uploaded to Visualizer" card. Clean split: **Shot Detail shows state, Shot Review acts on it.**

## 4. Bar layout

`BottomBar.qml` — shared by 27 pages.

- **Title closer to the arrow.** The back button's hitbox is `scaled(70)` around a `scaled(28)` glyph, already supplying 21 scaled px of gap; the row's `spacingMedium` added 16 more. Back button + title now sit in their own `RowLayout` at `spacing: 0`. Touch target and arrow position unchanged. (The flatter alternative — negative `Layout.leftMargin` — is broken: layouts exclude invisible items *and* their spacing, misplacing the title when `showBackButton` is false.)
- **New `leftContent` slot.** Both pages' profile/date columns sat in the default content slot, which is *after* the stretch, so they were pushed across the bar against the buttons — only looking right originally because the bar was overflowing. They now sit beside the title as a subtitle.

## 5. Eight hand-rolled buttons → AccessibleButton

All four `Rectangle`-based bottom-bar buttons on each page, plus Undo's `contentItem` override. Drops the hardcoded `+ 32` padding literals and per-site `MultiEffect` blocks — `ThemedIcon`/`AccessibleButton` already do both.

Buttons take the component's 20px/side padding instead of 16; overriding it back would re-introduce the bespoke styling the conversion removes, and Undo already used 20. Costs 8px/button against ~110px saved on the label.

⚠️ **Regression this introduced, now fixed:** the old Rectangles carried `opacity: enabled ? 1.0 : 0.5`, dimming the whole control. AccessibleButton fades only icon/label, and filled variants draw no border — so a disabled button kept a full-strength fill and read as active. Discuss with `discussShotApp` set but no `claudeRcSessionUrl` rendered as solid blue beside two identical blue buttons and did nothing when tapped. The background now fades with `enabled`.

Conversion also **fixed** a real a11y bug: the old `Accessible.onPressAction: area.clicked(null)` fired even when the MouseArea was disabled, so a screen reader could trigger Ask mid-analysis. `AccessibleButton` guards on `root.enabled`.

## 6. AccessibleButton / Theme

**Contrast.** White on `warningButtonColor` #FFA500 is 1.97:1, against a 4.5:1 minimum — unreadable, and this PR introduces that fill. `warning` now derives its foreground via a new `Theme.contrastColorFor()`, which picks black (10.63:1).

Scoped to `warning` only. `primary`/`destructive`/`subtle` keep `primaryContrastColor`, byte-identical to main — deriving them would flip every blue and red button in the app to black text. `errorColor`'s white at 3.4:1 is a real gap, filed separately rather than ridden along in a bar-width PR.

The helper compares the two real WCAG contrast ratios rather than thresholding BT.601 brightness. The first version thresholded, which review showed picked white for #ff4444 at 3.4:1 (still failing) and sat one imperceptible tweak from flipping app-wide. Comparing ratios has no threshold to sit near. Verified: #FFA500→black, and a dark amber theme (#8a5a00)→white, so it adapts to custom themes.

**Announce path.** `AccessibleButton` now announces `Accessible.name`, not `accessibleName` — only the former folds in `accessibleDescription`, so the upload button's "Changes pending upload" never reached TalkBack.

**Press state.** Background binds `down || isPressed`.

> ⚠️ **This PR's history got this wrong twice, so stating it precisely.** `Control` has no `contentData` default property (only `Pane`/`Container` do), so `touchArea` is a direct child of the Button, fills it entirely, and swallows every pointer press — `down` never fires for a pointer, and the old `down`-only binding gave mouse presses **no** feedback. An intermediate commit claimed the split was "padding sets `down`, label sets `isPressed`" — false, and it contradicted the correct comment 90 lines above it. Another commit retracted the whole bug claim — an over-correction. Verified against the Qt 6.11.1 sources: both flags are needed, split **pointer vs keyboard** (`isPressed` for pointer, `down` for Space). Press darkening confirmed by hand on device.

## Still open (out of scope)

`BottomBar`'s content slot has no width constraint and no clip, so at narrower widths or larger font scales text can still draw off the right edge instead of eliding. This PR buys back enough width to fit but doesn't fix the underlying overflow. Also: Discuss and AI Advice remain two identical sparkle buttons that both mean "talk to an AI about this shot"; and `ValueInput.qml` still hand-rolls the contrast logic twice rather than calling the new helper.

## Testing

- Builds clean via Qt Creator (Qt 6.11.1, macOS Debug): 0 errors, 0 warnings.
- All 76 tests pass (`ctest`), including `tst_accessibility_announcements` (announce path changed).
- Driven in the running app: bar fits, cloud icon correct, amber + contrast confirmed, Shot Detail bar clean, profile/date beside the title on both pages, no QML TypeErrors.
- Contrast maths cross-checked independently against the reviewer's figures.
- **Not yet eyeballed:** the disabled-button dimming fix.
- Conflict with #1531 (it rewrote the AI Advice handler; this PR converted that button) resolved keeping both. Audited: #1531's `shotForAdvisor` and `onTasteIntakeSubmitted` are byte-identical to upstream, `ConversationOverlay.qml` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)