### PR TITLE
fix(advisor): flow taste-intake taps back to the review page immediately

### DIFF
--- a/docs/CLAUDE_MD/AI_ADVISOR.md
+++ b/docs/CLAUDE_MD/AI_ADVISOR.md
@@ -29,6 +29,16 @@ backed-out-without-entering shot re-shows the intake. **Ask** persists the taps 
 `requestUpdateShotMetadata`, composes a first-person question, and sends it with
 the shot attached; **Skip** drops into the normal text conversation.
 
+The overlay reads only the host page's shot *snapshot* for the gate, and
+`PostShotReviewPage` deliberately does not reload that snapshot on metadata save
+(it would clobber in-progress edits). So on Ask the overlay also emits
+`tasteIntakeSubmitted(tasteBalance, tasteBody, overall)`; the review page mirrors
+those axes into its live `editTaste*` / `editEnjoyment` fields (via
+`applyEditState`, advancing the baseline rather than re-saving) so the rating
+slider and taste chips update at once and the next Ask sees the feedback — the
+review page's AI-Advice click passes the *live* taste, not the stale snapshot, to
+`openWithShot`.
+
 The taps are structured shot columns (`taste_balance`/`taste_body`, migration 33),
 not free text — so the same picker also appears on the post-shot review page (no
 parallel UI), the values flow into the advisor prompt and the dial-in history

--- a/docs/CLAUDE_MD/AI_ADVISOR.md
+++ b/docs/CLAUDE_MD/AI_ADVISOR.md
@@ -34,8 +34,12 @@ The overlay reads only the host page's shot *snapshot* for the gate, and
 (it would clobber in-progress edits). So on Ask the overlay also emits
 `tasteIntakeSubmitted(tasteBalance, tasteBody, overall)`; the review page mirrors
 those axes into its live `editTaste*` / `editEnjoyment` fields (via
-`applyEditState`, advancing the baseline rather than re-saving) so the rating
-slider and taste chips update at once and the next Ask sees the feedback — the
+`applyEditState`) and advances **both** review-page baselines — `editShotData`
+(what `hasUnsavedChanges` compares against) and `_committedState` (the undo
+baseline) — mirroring the `ChangeBeansDialog.onBagSelected` external-flow
+pattern, so no redundant re-save/Visualizer PATCH or phantom undo frame fires on
+the next flush. The rating slider and taste chips update at once and the next
+Ask sees the feedback — the
 review page's AI-Advice click passes the *live* taste, not the stale snapshot, to
 `openWithShot`.
 

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -82,6 +82,11 @@ Rectangle {
         if (overlay.shotId > 0 && Object.keys(meta).length > 0 && MainController.shotHistory)
             MainController.shotHistory.requestUpdateShotMetadata(overlay.shotId, meta)
 
+        // Reflect the taps back to the host page right away so its rating slider
+        // and taste chips update, and its per-shot intake gate sees the feedback
+        // on the next Ask (the overlay only ever reads the host's shot snapshot).
+        overlay.tasteIntakeSubmitted(intakeTasteBalance, intakeTasteBody, intakeOverall)
+
         // Send first, then dismiss only if it actually went through. Dismissing
         // up front would, on mobile (where conversationInput is hidden), silently
         // discard the composed question if the send were refused.
@@ -94,6 +99,13 @@ Rectangle {
     // Emitted when the overlay clears pendingShotSummary (parent must handle)
     signal pendingShotSummaryCleared()
     signal closed()
+
+    // Emitted when the tap-only intake is submitted, carrying the tapped axes so
+    // the host page (e.g. PostShotReviewPage) can mirror them into its live edit
+    // fields immediately — the overlay has already persisted them to the DB, so
+    // the host advances its baseline rather than re-saving. Empty string / 0
+    // means "not tapped" and should be left untouched by the host.
+    signal tasteIntakeSubmitted(string tasteBalance, string tasteBody, int overall)
 
     property bool isMobile: Qt.platform.os === "android" || Qt.platform.os === "ios"
 

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -2386,7 +2386,16 @@ Page {
                 anchors.fill: parent
                 enabled: MainController.aiManager && MainController.aiManager.isConfigured && !MainController.aiManager.isAnalyzing
                 onClicked: {
-                    conversationOverlay.openWithShot(editShotData, editBeanBrand, editBeanType, editShotData.profileName, editShotId)
+                    // editShotData is the DB-load snapshot and is NOT updated as
+                    // the user rates the shot on this page (or in the advisor's
+                    // own intake). Hand the advisor the LIVE taste so its per-shot
+                    // intake gate sees feedback the user already gave and doesn't
+                    // re-ask "how did this shot taste?".
+                    var shotForAdvisor = clonePersistedShot(editShotData)
+                    shotForAdvisor.tasteBalance = editTasteBalance
+                    shotForAdvisor.tasteBody = editTasteBody
+                    shotForAdvisor.enjoyment0to100 = editEnjoyment
+                    conversationOverlay.openWithShot(shotForAdvisor, editBeanBrand, editBeanType, editShotData.profileName, editShotId)
                 }
             }
         }
@@ -2534,6 +2543,19 @@ Page {
         id: conversationOverlay
         anchors.fill: parent
         overlayTitle: TranslationManager.translate("postshotreview.conversation.title", "Dialing Conversation")
+
+        // Taste tapped in the advisor's intake flows back to this page at once so
+        // the rating slider + taste chips reflect it. The overlay already
+        // persisted the taps to the DB, so advance the baseline via applyEditState
+        // rather than triggering another autosave. Empty axes are left untouched.
+        onTasteIntakeSubmitted: function(tasteBalance, tasteBody, overall) {
+            var s = captureEditState()
+            if (tasteBalance.length > 0) s.tasteBalance = tasteBalance
+            if (tasteBody.length > 0) s.tasteBody = tasteBody
+            if (overall > 0) s.enjoyment = overall
+            applyEditState(s)
+            _committedState = captureEditState()
+        }
     }
 
 }

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -2546,14 +2546,27 @@ Page {
 
         // Taste tapped in the advisor's intake flows back to this page at once so
         // the rating slider + taste chips reflect it. The overlay already
-        // persisted the taps to the DB, so advance the baseline via applyEditState
-        // rather than triggering another autosave. Empty axes are left untouched.
+        // persisted the taps to the DB (and synced Visualizer via
+        // requestUpdateShotMetadata), so mirror them in without re-saving — the
+        // same external-flow pattern as ChangeBeansDialog.onBagSelected. That
+        // means advancing BOTH baselines: editShotData (what hasUnsavedChanges
+        // compares against) as well as _committedState (the undo baseline). If we
+        // only advanced _committedState, hasUnsavedChanges would stay stuck true
+        // and the next lifecycle flush (backing out) would redundantly re-save,
+        // re-PATCH Visualizer, and push a phantom undo frame. No
+        // pendingVisualizerUpdate here — the overlay already synced. Empty axes
+        // are left untouched.
         onTasteIntakeSubmitted: function(tasteBalance, tasteBody, overall) {
             var s = captureEditState()
             if (tasteBalance.length > 0) s.tasteBalance = tasteBalance
             if (tasteBody.length > 0) s.tasteBody = tasteBody
             if (overall > 0) s.enjoyment = overall
             applyEditState(s)
+            var nb = clonePersistedShot(editShotData)
+            nb.tasteBalance = editTasteBalance
+            nb.tasteBody = editTasteBody
+            nb.enjoyment0to100 = editEnjoyment
+            editShotData = nb
             _committedState = captureEditState()
         }
     }


### PR DESCRIPTION
## Problem

On Android/DE1: make a shot → tap the AI Advisor → tap taste/body + **Ask** → the AI replies. Go back to the shot review page (e.g. to update TDS) → tap AI Advisor again → it re-shows the **"how did this shot taste?"** intake page instead of resuming the conversation.

## Root cause

The advisor's per-shot taste-intake gate (`ConversationOverlay.openWithShot`) decides whether to show the intake by reading the taste fields off the **shot snapshot the caller hands it**. On `PostShotReviewPage` that snapshot is `editShotData` — the DB-load copy, which is **never refreshed on save** (the page deliberately skips reload to avoid clobbering in-progress edits).

So the taps were persisted to the DB but not mirrored into the snapshot → on reopen the gate read stale-empty taste → intake re-shown. (Shot Detail is immune: it reloads its snapshot on metadata save.)

## Fix

- `ConversationOverlay` emits `tasteIntakeSubmitted(tasteBalance, tasteBody, overall)` on **Ask**, after persisting the taps.
- `PostShotReviewPage`'s AI-Advice click now passes the **live** taste (`editTaste*`/`editEnjoyment`) to `openWithShot`, not the stale snapshot. This also fixes the sibling bug where rating via the page's own taste picker and *then* clicking AI Advice re-asked for taste.
- The page mirrors the emitted taps into its live edit fields via `applyEditState` (re-establishing the rating-slider/chip bindings) and advances the committed baseline instead of re-saving — so **selections in the advisor flow back to the review page immediately** (rating slider + taste chips update) and the next Ask sees the feedback.

## Testing

- Built in Qt Creator: succeeded, 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)