### PR TITLE
fix: stop "fi" ligature dropping during window resize (#1537)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -409,21 +409,28 @@ int main(int argc, char *argv[])
         }
     }
 
-#ifdef Q_OS_MACOS
-    // Workaround for macOS crash in Apple Color Emoji bitmap rendering.
-    // PNGReadPlugin::InitializePluginData crashes on QSGRenderThread when CoreText
-    // tries to decode emoji bitmaps from the sbix font table via CTFontDrawGlyphs →
-    // CopyEmojiImage → CGImageSourceCreateImageAtIndex.
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN) || defined(Q_OS_LINUX)
+    // Use CurveTextRendering (Qt 6.7+) on all resizable desktop platforms. It
+    // renders every glyph as bezier curves on the GPU, so it needs neither the
+    // distance-field glyph cache nor the native bitmap path. Two problems it avoids:
     //
-    // QtTextRendering (distance fields) was tried first, but Qt 6.x STILL falls back
-    // to native rendering when QGlyphRun contains color font glyphs — if CoreText's
-    // font shaping assigns ANY character to Apple Color Emoji (a color font), Qt uses
-    // QSGTextMaskMaterial (bitmap path) for that glyph run, triggering the crash.
+    //   * Windows/Linux "fi" ligature glitch (#1537): Qt's default QtTextRendering
+    //     (distance fields) re-caches glyphs while the window is resized, and at
+    //     certain widths the "fi" ligature drops — "Profile" briefly reads
+    //     "Proule", "Profiles" reads "Proules" — then snaps back on the next size.
+    //     CurveTextRendering has no distance-field cache, so the ligature is stable.
     //
-    // CurveTextRendering (Qt 6.7+) renders ALL glyphs as bezier curves on the GPU,
-    // never calling QCoreTextFontEngine::imageForGlyph, completely avoiding the
-    // CopyEmojiImage crash path. This app renders emoji as SVG images
-    // (Theme.emojiToImage), so bitmap emoji glyphs are not needed.
+    //   * macOS Apple Color Emoji crash: QtTextRendering STILL falls back to native
+    //     bitmap rendering (QSGTextMaskMaterial) when a glyph run contains color-font
+    //     glyphs. If CoreText shapes ANY character to Apple Color Emoji, that bitmap
+    //     path hits PNGReadPlugin::InitializePluginData → CopyEmojiImage and crashes
+    //     on QSGRenderThread. CurveTextRendering never calls imageForGlyph, so the
+    //     crash path is gone. This app draws emoji as SVG images (Theme.emojiToImage),
+    //     so bitmap emoji glyphs are never needed anyway.
+    //
+    // Mobile (Android/iOS) keeps Qt's default: those windows are fullscreen and
+    // don't resize, so the ligature glitch can't occur, and the default avoids the
+    // extra GPU cost of curve rendering on constrained devices.
     QQuickWindow::setTextRenderType(QQuickWindow::CurveTextRendering);
     {
         auto actual = QQuickWindow::textRenderType();
@@ -432,6 +439,9 @@ int main(int argc, char *argv[])
                      actual == QQuickWindow::QtTextRendering ? "QtText" : "Native")
                  << "(" << static_cast<int>(actual) << ")";
     }
+#endif
+
+#ifdef Q_OS_MACOS
     // Probe which characters CoreText routes to Apple Color Emoji — diagnostic
     // for the CopyEmojiImage crash. If any non-emoji chars use the emoji font,
     // it explains why Qt fell back to native rendering despite QtTextRendering.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -430,7 +430,9 @@ int main(int argc, char *argv[])
     //
     // Mobile (Android/iOS) keeps Qt's default: those windows are fullscreen and
     // don't resize, so the ligature glitch can't occur, and the default avoids the
-    // extra GPU cost of curve rendering on constrained devices.
+    // extra GPU cost of curve rendering on constrained devices. iOS shares macOS's
+    // CoreText/Apple Color Emoji stack, but the CopyEmojiImage crash has only ever
+    // been observed on macOS, so iOS is intentionally left on the default too.
     QQuickWindow::setTextRenderType(QQuickWindow::CurveTextRendering);
     {
         auto actual = QQuickWindow::textRenderType();


### PR DESCRIPTION
## Problem

Resizing the desktop window makes bottom-bar labels briefly corrupt at certain widths — **"Profile Edit" → "Proule Edit"** and **"Profiles" → "Proules"** — then snap back when resized further (issue #1537, Windows 11). It's the **"fi" ligature** being dropped: "Pro**fi**le" → "Proule".

## Root cause

Qt's default `QtTextRendering` uses a distance-field glyph cache that re-caches glyphs while the window resizes; at certain intermediate widths the "fi" ligature glyph is mis-rendered. Decenza only opted out of distance fields on macOS (`src/main.cpp`, inside `#ifdef Q_OS_MACOS`), so Windows and Linux fell back to the default and hit the bug. macOS was immune precisely because it already uses `CurveTextRendering`. Mobile never resizes (fullscreen), so it can't reproduce it.

## Fix

Extend `QQuickWindow::setTextRenderType(CurveTextRendering)` to all resizable desktop platforms (macOS + Windows + Linux). `CurveTextRendering` (Qt 6.7+) renders glyphs as GPU bezier curves with no distance-field cache, so the ligature stays stable during resize. Mobile keeps Qt's default to avoid the extra GPU cost on constrained devices.

The macOS-only Apple Color Emoji probe is split into its own `#ifdef Q_OS_MACOS` block so it stays macOS-only.

## Verification

The bug only reproduces on Windows/Linux (macOS already used `CurveTextRendering`). macOS behaviour is unchanged. Needs confirmation on a Windows build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)