### PR TITLE
Fix broken bean-link section on Shot Review; add lightweight Bean Base link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -808,6 +808,7 @@ set(QML_FILES
     qml/components/BeanBaseDetailsPopup.qml
     qml/components/BeanBaseDetailsRow.qml
     qml/components/BeanSummary.qml
+    qml/components/LinkBeanBaseDialog.qml
     qml/components/ChangeBeansDialog.qml
     qml/components/BagCard.qml
     qml/components/SwitchEquipmentDialog.qml

--- a/qml/components/BeanBaseDetailsRow.qml
+++ b/qml/components/BeanBaseDetailsRow.qml
@@ -35,6 +35,10 @@ Item {
         id: rowLayout
         anchors.fill: parent
         spacing: Theme.scaled(10)
+        // Intrinsically tied to hasData, not just the root's `visible`: a host
+        // may override root.visible (e.g. a recipe-gate), and without this the
+        // fallback text would paint into the zero-height (!hasData) box.
+        visible: root.hasData
 
         // Bag thumbnail — collapses when missing or failing to load
         Image {
@@ -76,6 +80,7 @@ Item {
 
     AccessibleMouseArea {
         anchors.fill: parent
+        enabled: root.hasData   // no dead tap target when there's nothing to open
         accessibleName: TranslationManager.translate("beanbase.row.accessible", "Bean details from Bean Base. Opens details dialog")
         accessibleItem: root
         onAccessibleClicked: detailsPopup.open()

--- a/qml/components/BeanSummary.qml
+++ b/qml/components/BeanSummary.qml
@@ -21,6 +21,13 @@ Item {
 
     // false = read live Settings.dye state; true = use the shot-mode properties below
     property bool useShotData: false
+
+    // When true, the "Link to Bean Base" nudge becomes a tappable link that emits
+    // linkRequested() — hosts wire it to their bean-linking flow (e.g. the Change
+    // Beans dialog). Default false keeps the nudge a passive hint on read-only
+    // surfaces (idle/brew, shot detail) where there's no link action to take.
+    property bool linkable: false
+    signal linkRequested()
     property string roasterName: ""
     property string coffeeName: ""
     property string roastDate: ""
@@ -177,14 +184,37 @@ Item {
             }
         }
 
-        // Subtle nudge for non-canonical beans
-        Tr {
+        // Subtle nudge for non-canonical beans. When `linkable`, it reads as a
+        // tappable link (primary colour + underline) that emits linkRequested();
+        // otherwise it's a passive secondary-colour hint.
+        Item {
+            id: linkNudge
             visible: root.hasBeans && !root.canonical
-            key: "beans.summary.linkNudge"
-            fallback: "Link to Bean Base"
-            font: Theme.captionFont
-            color: Theme.textSecondaryColor
-            Accessible.ignored: true
+            Layout.fillWidth: true
+            implicitHeight: nudgeText.implicitHeight
+            implicitWidth: nudgeText.implicitWidth
+
+            Tr {
+                id: nudgeText
+                key: "beans.summary.linkNudge"
+                fallback: "Link to Bean Base"
+                // Sub-properties assigned individually (font: + font.underline mix
+                // is a known QML conflict — see CLAUDE.md QML Gotchas).
+                font.family: Theme.captionFont.family
+                font.pixelSize: Theme.captionFont.pixelSize
+                font.underline: root.linkable
+                color: root.linkable ? Theme.primaryColor : Theme.textSecondaryColor
+                Accessible.ignored: true
+            }
+
+            AccessibleMouseArea {
+                anchors.fill: parent
+                enabled: root.linkable
+                visible: root.linkable
+                accessibleName: nudgeText.text
+                accessibleItem: linkNudge
+                onAccessibleClicked: root.linkRequested()
+            }
         }
     }
 }

--- a/qml/components/LinkBeanBaseDialog.qml
+++ b/qml/components/LinkBeanBaseDialog.qml
@@ -1,0 +1,122 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Decenza
+
+// Lightweight "Link to Bean Base" for a SINGLE shot: search the canonical
+// database, pick the matching coffee, and hand the entry back to the caller —
+// which writes only that shot's bean-base snapshot. Unlike ChangeBeansDialog
+// this creates no inventory bag and never touches the active bag; it is the
+// metadata-enrichment path for a (historical) shot whose bean simply isn't
+// linked to Bean Base yet. The heavyweight Change Beans dialog remains the
+// path for actually creating or re-pointing a bag.
+Dialog {
+    id: root
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+    width: Math.min(Theme.scaled(520), parent ? parent.width * 0.95 : Theme.scaled(520))
+    modal: true
+    closePolicy: Dialog.CloseOnEscape
+    padding: 0
+
+    // Emitted with the picked canonical entry (Bean Base blob-shaped keys).
+    signal entryPicked(var entry)
+
+    // Seed query (roaster + coffee) prefilled into the search line on open.
+    property string seedQuery: ""
+
+    function openWith(query) {
+        root.seedQuery = query
+        root.open()
+    }
+
+    onOpened: {
+        // Prefill the search line with the shot's coffee and run it, so the
+        // matching results are one tap away — the user shouldn't have to type
+        // a name the shot already knows.
+        linkBar.prefillAndSearch(root.seedQuery)
+    }
+
+    background: Rectangle {
+        color: Theme.surfaceColor
+        radius: Theme.cardRadius
+        border.width: 1
+        border.color: Theme.borderColor
+    }
+
+    contentItem: KeyboardAwareContainer {
+        id: keyboardContainer
+        inOverlay: true
+        implicitWidth: root.width
+        implicitHeight: mainColumn.implicitHeight
+        textFields: [linkBar.textField]
+
+        ColumnLayout {
+            id: mainColumn
+            width: keyboardContainer.width
+            spacing: Theme.scaled(14)
+
+            Accessible.role: Accessible.Dialog
+            Accessible.name: trLinkTitle.text
+
+            // Header: title + Cancel
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: Theme.scaled(16)
+                Layout.leftMargin: Theme.scaled(20)
+                Layout.rightMargin: Theme.scaled(12)
+                spacing: Theme.scaled(8)
+
+                Tr {
+                    id: trLinkTitle
+                    Layout.fillWidth: true
+                    key: "beanbase.link.title"
+                    fallback: "Link to Bean Base"
+                    font: Theme.titleFont
+                    color: Theme.textColor
+                    Accessible.ignored: true  // announced via the dialog name
+                }
+
+                HideKeyboardButton {
+                    Layout.alignment: Qt.AlignVCenter
+                }
+
+                AccessibleButton {
+                    Layout.alignment: Qt.AlignVCenter
+                    height: Theme.scaled(38)
+                    leftPadding: Theme.scaled(14)
+                    rightPadding: Theme.scaled(14)
+                    text: TranslationManager.translate("common.cancel", "Cancel")
+                    accessibleName: TranslationManager.translate("common.button.cancel", "Cancel")
+                    onClicked: root.close()
+                }
+            }
+
+            // Subtitle: make the "no bag created" contract explicit so this
+            // never surprises the way the full Change Beans flow did.
+            Tr {
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.scaled(20)
+                Layout.rightMargin: Theme.scaled(20)
+                key: "beanbase.link.subtitle"
+                fallback: "Attach the coffee's Bean Base record to this shot. Only this shot is updated — no bag is created."
+                font: Theme.captionFont
+                color: Theme.textSecondaryColor
+                wrapMode: Text.Wrap
+                Accessible.ignored: true
+            }
+
+            BeanBaseSearchBar {
+                id: linkBar
+                Layout.fillWidth: true
+                Layout.leftMargin: Theme.scaled(20)
+                Layout.rightMargin: Theme.scaled(20)
+                Layout.bottomMargin: Theme.scaled(20)
+                onEntrySelected: function(entry) {
+                    root.entryPicked(entry)
+                    root.close()
+                }
+            }
+        }
+    }
+}

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -2144,8 +2144,9 @@ Page {
         if (entry.roasterName) editBeanBrand = String(entry.roasterName)
         if (entry.roastName) editBeanType = String(entry.roastName)
         if (entry.degree) editRoastLevel = String(entry.degree)
+        // autosave() -> saveEditedShot() persists the snapshot and already sets
+        // pendingVisualizerUpdate, so the enriched bean info pushes to Visualizer.
         autosave("beanBase", true)
-        pendingVisualizerUpdate = true
         // Best-effort attribute enrichment (origin/variety/process/...): the
         // onCanonicalDetails handler above merges it into editBeanBaseJson and
         // re-saves when it arrives.

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -779,7 +779,13 @@ Page {
             "drinkEy": editDrinkEy,
             "espressoNotes": editNotes,
             "beverageType": editBeverageType,
-            "beanBaseJson": editBeanBaseJson
+            "beanBaseJson": editBeanBaseJson,
+            // Keep the indexed canonical id in lockstep with the blob — the
+            // backend does NOT derive beanbase_id from beanbase_json on a
+            // metadata update (updateShotMetadataStatic), so a link made here
+            // (e.g. the lightweight LinkBeanBaseDialog path) would otherwise
+            // leave beanbase_id stale and break the history search lane.
+            "beanBaseId": beanBaseLinked ? String(activeBeanBase.id) : ""
         }
         metadata["enjoyment"] = editEnjoyment
         metadata["tasteBalance"] = editTasteBalance
@@ -1753,6 +1759,8 @@ Page {
                     roastDate: editRoastDate
                     roastLevel: editRoastLevel
                     beanBaseData: editBeanBaseJson
+                    linkable: true
+                    onLinkRequested: postShotReviewPage.requestBeanLink()
                 }
 
                 AccessibleButton {
@@ -1768,7 +1776,13 @@ Page {
 
             BeanBaseDetailsRow {
                 Layout.fillWidth: true
-                visible: (editShotData.recipeId || -1) <= 0
+                // Recipe-gate AND the bean-linked gate. This override replaces the
+                // component's own `visible: hasData`, so without beanBaseLinked an
+                // unlinked no-recipe shot forces the row visible: it then paints its
+                // "Linked to Bean Base / Tap for bean details" fallback into a
+                // zero-height box (implicitHeight is 0 when !hasData), overlapping
+                // the Barista field below with a dead tap target.
+                visible: (editShotData.recipeId || -1) <= 0 && postShotReviewPage.beanBaseLinked
                 beanBaseJson: postShotReviewPage.editBeanBaseJson
             }
 
@@ -1952,6 +1966,8 @@ Page {
                                     roastDate: editRoastDate
                                     roastLevel: editRoastLevel
                                     beanBaseData: editBeanBaseJson
+                                    linkable: true
+                                    onLinkRequested: postShotReviewPage.requestBeanLink()
                                 }
                                 AccessibleButton {
                                     Layout.preferredHeight: Theme.scaled(44)
@@ -2107,6 +2123,40 @@ Page {
     // Change Beans + Change Equipment — page-scoped so both the recipe card and
     // the standalone bean/equipment rows share one instance regardless of which
     // is visible.
+    // "Link to Bean Base" nudge action. A historical shot (anything but the
+    // just-pulled one) links lightweight — attach the canonical record to THIS
+    // shot only, no bag created. The most-recent shot keeps the full Change
+    // Beans path, where linking the active bag is the intended "wrong bag" fix.
+    function requestBeanLink() {
+        if (editShotId === MainController.lastSavedShotId) {
+            reviewChangeBeansDialog.open()
+        } else {
+            reviewLinkBeanBaseDialog.openWith(
+                [editBeanBrand, editBeanType].filter(function(s) { return s && s.length > 0 }).join(" "))
+        }
+    }
+
+    // Apply a canonical Bean Base pick to this shot's snapshot only. Mirrors
+    // the fields ChangeBeansDialog.onBagSelected writes (so the linked shot
+    // looks identical) MINUS any bag: no inventory bag, activeBagId untouched.
+    function applyCanonicalLinkToShot(entry) {
+        editBeanBaseJson = JSON.stringify(entry)
+        if (entry.roasterName) editBeanBrand = String(entry.roasterName)
+        if (entry.roastName) editBeanType = String(entry.roastName)
+        if (entry.degree) editRoastLevel = String(entry.degree)
+        autosave("beanBase", true)
+        pendingVisualizerUpdate = true
+        // Best-effort attribute enrichment (origin/variety/process/...): the
+        // onCanonicalDetails handler above merges it into editBeanBaseJson and
+        // re-saves when it arrives.
+        MainController.beanbase.fetchCanonicalDetails(entry)
+    }
+
+    LinkBeanBaseDialog {
+        id: reviewLinkBeanBaseDialog
+        onEntryPicked: function(entry) { postShotReviewPage.applyCanonicalLinkToShot(entry) }
+    }
+
     ChangeBeansDialog {
         id: reviewChangeBeansDialog
         // Only the most recent shot is the "post-shot" fix path (sets


### PR DESCRIPTION
## Problem

On the Post-Shot Review page, the bean section just above the Barista field was visually broken for a no-recipe shot with an unlinked bean: three link-like lines (`Link to Bean Base`, `Linked to Bean Base`, `Tap for bean details`) overlapping each other and the Barista field, none of which did anything when tapped.

<img width="1080" src="https://github.com/user-attachments/assets/placeholder" alt="before"/>

## Root causes & fixes

**1. Overlap + dead tap target.** The standalone `BeanBaseDetailsRow` had its `visible` overridden by a recipe-only gate (`recipeId <= 0`) that *replaced* the component's own `visible: hasData`. For an unlinked no-recipe shot this force-showed the row while `hasData` was false, so it painted its fallback text into a zero-height box (`implicitHeight` is 0 when `!hasData`) — overlapping the Barista field, with a collapsed (dead) `AccessibleMouseArea`.
- Gate the override on `beanBaseLinked` too.
- Defensively tie the component's content `RowLayout` and tap area to `hasData`, so a host `visible` override can never reintroduce the ghost.

**2. Dead "Link to Bean Base" nudge.** It looked like a link but had no handler. `BeanSummary` now exposes opt-in `linkable` + `linkRequested()`; when `linkable` the nudge renders as a real link (primary colour + underline) and emits the signal. Read-only surfaces (idle/brew, Shot Detail) keep it a passive hint — no dead link.

**3. Surprise inventory-bag creation.** Linking a >1-year-old shot ran the full Change Beans flow and created a real inventory bag just to hold the identity. New lightweight `LinkBeanBaseDialog`: the search line is prefilled with the shot's coffee and auto-run, and picking a result writes **only that shot's bean-base snapshot** — no inventory bag, active bag untouched. Scoped to historical shots; the just-pulled shot keeps the full Change Beans path (where linking the active bag is the intended "wrong bag" fix). The `Change Beans` button is unchanged.

**Latent gap closed.** `saveEditedShot` persisted `beanbase_json` but not the indexed `beanbase_id` (the backend does not derive it on a metadata update), so a link made via autosave left the history-search index stale. They now stay in lockstep.

## Files
- `qml/components/BeanBaseDetailsRow.qml` — content/tap-area gated on `hasData`
- `qml/components/BeanSummary.qml` — opt-in `linkable` link + `linkRequested()`
- `qml/components/LinkBeanBaseDialog.qml` — new lightweight link dialog (+ CMakeLists)
- `qml/pages/PostShotReviewPage.qml` — `visible` gate fix, link wiring, lightweight-link handlers, `beanBaseId` persistence

## Testing
Built clean (Qt 6.11.1, macOS Debug), 0 warnings. Verified against real data on the running app: shot 38 (no-recipe, unlinked) reproduced the overlap; after the fix the section is clean and "Link to Bean Base" opens the prefilled lightweight search that links the shot without creating a bag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)