### PR TITLE
Fix AI dialing conversation 400 (strip internal shotId from API requests)

### DIFF
--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -302,6 +302,26 @@ std::optional<QJsonObject> AIManager::parseStructuredNext(const QString& assista
     return doc.object();
 }
 
+QJsonArray AIManager::sanitizeApiMessages(const QJsonArray& messages)
+{
+    // AIConversation stores each turn as {role, content[, shotId][, structuredNext]}.
+    // shotId (issue #1053 shot latching) and structuredNext are Decenza-internal
+    // bookkeeping and must never reach a provider. The Anthropic Messages API
+    // rejects unknown per-message keys with HTTP 400 ("messages.N.shotId: Extra
+    // inputs are not permitted"), which killed every dial-in conversation request.
+    // Whitelist role + content only; content is copied verbatim (a plain string
+    // here — providers do their own cache-block wrapping downstream).
+    QJsonArray out;
+    for (const QJsonValue& v : messages) {
+        const QJsonObject msg = v.toObject();
+        QJsonObject clean;
+        clean["role"] = msg.value("role");
+        clean["content"] = msg.value("content");
+        out.append(clean);
+    }
+    return out;
+}
+
 // Heuristic for "the prior assistant message asked the user about
 // taste". Conservative: a false negative just means we don't auto-
 // persist — the user can still rate via the editor or the rating slider.
@@ -1559,7 +1579,9 @@ void AIManager::analyzeConversation(const QString& systemPrompt, const QJsonArra
     m_lastUserPrompt = QString("[Conversation with %1 messages]").arg(messages.size());
 
     logPrompt(selectedProvider(), systemPrompt, m_lastUserPrompt);
-    provider->analyzeConversation(systemPrompt, messages);
+    // Drop internal-only per-turn keys (shotId, structuredNext) before the
+    // payload reaches any provider — Anthropic 400s on unknown message fields.
+    provider->analyzeConversation(systemPrompt, sanitizeApiMessages(messages));
 }
 
 void AIManager::refreshOllamaModels()

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -1579,8 +1579,7 @@ void AIManager::analyzeConversation(const QString& systemPrompt, const QJsonArra
     m_lastUserPrompt = QString("[Conversation with %1 messages]").arg(messages.size());
 
     logPrompt(selectedProvider(), systemPrompt, m_lastUserPrompt);
-    // Drop internal-only per-turn keys (shotId, structuredNext) before the
-    // payload reaches any provider — Anthropic 400s on unknown message fields.
+    // Strip internal-only per-turn keys before the payload leaves the app.
     provider->analyzeConversation(systemPrompt, sanitizeApiMessages(messages));
 }
 

--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -209,6 +209,14 @@ public:
     // ai_advisor_invoke before the provider hop) can use it.
     static std::optional<QJsonObject> parseStructuredNext(const QString& assistantMessage);
 
+    // Strip Decenza-internal per-turn keys (shotId, structuredNext) from a
+    // stored conversation, leaving only the {role, content} pair every
+    // chat-completion provider accepts. Applied before dispatching to a
+    // provider so internal bookkeeping never leaks into the API request —
+    // the Anthropic Messages API 400s on unknown per-message fields. Pure /
+    // static so the test harness can assert the invariant directly.
+    static QJsonArray sanitizeApiMessages(const QJsonArray& messages);
+
     // Parsed numeric score + remaining notes from a user's conversational
     // reply (issue #1055 Layer 1). When the advisor asks "how did this
     // taste?" and the user answers with a number 1-100, we persist the

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -1435,9 +1435,19 @@ private slots:
         assistant["structuredNext"] = QJsonObject{{"grindDelta", -1}};
         messages.append(assistant);
 
+        // A future/unknown internal key must be stripped too. The sanitizer is
+        // a whitelist (rebuilds each object from role + content), so this guards
+        // against a later refactor to an explicit-blacklist approach that would
+        // silently leak any newly-stamped bookkeeping field.
+        QJsonObject withUnknownKey;
+        withUnknownKey["role"] = QStringLiteral("user");
+        withUnknownKey["content"] = QStringLiteral("Anything else?");
+        withUnknownKey["someFutureInternalKey"] = 42;
+        messages.append(withUnknownKey);
+
         const QJsonArray clean = AIManager::sanitizeApiMessages(messages);
 
-        QCOMPARE(clean.size(), 2);
+        QCOMPARE(clean.size(), 3);
         for (const QJsonValue& v : clean) {
             const QJsonObject msg = v.toObject();
             // Exactly the two API-legal keys — nothing else may survive.
@@ -1446,6 +1456,7 @@ private slots:
             QVERIFY(msg.contains(QStringLiteral("content")));
             QVERIFY(!msg.contains(QStringLiteral("shotId")));
             QVERIFY(!msg.contains(QStringLiteral("structuredNext")));
+            QVERIFY(!msg.contains(QStringLiteral("someFutureInternalKey")));
         }
         // Content and role are preserved verbatim.
         QCOMPARE(clean.at(0).toObject().value("role").toString(), QStringLiteral("user"));

--- a/tests/tst_aimanager.cpp
+++ b/tests/tst_aimanager.cpp
@@ -1412,6 +1412,48 @@ private slots:
         QCOMPARE(fields.grinder, QStringLiteral("Niche Zero with 63mm @ 4.0"));
     }
 
+    // Regression: AIConversation stamps internal per-turn keys (shotId from
+    // #1053 shot latching, structuredNext) onto stored message objects. Those
+    // are the same objects handed to the provider, and the Anthropic Messages
+    // API 400s on unknown per-message fields ("messages.0.shotId: Extra inputs
+    // are not permitted"), which broke every dial-in conversation request.
+    // sanitizeApiMessages must strip everything but role + content.
+    void sanitizeApiMessages_stripsInternalPerTurnKeys()
+    {
+        QJsonArray messages;
+
+        QJsonObject user;
+        user["role"] = QStringLiteral("user");
+        user["content"] = QStringLiteral("How did this shot taste?");
+        user["shotId"] = 1113.0;  // stored as double, per addUserMessage
+        messages.append(user);
+
+        QJsonObject assistant;
+        assistant["role"] = QStringLiteral("assistant");
+        assistant["content"] = QStringLiteral("Grind finer by one step.");
+        assistant["shotId"] = 1113.0;
+        assistant["structuredNext"] = QJsonObject{{"grindDelta", -1}};
+        messages.append(assistant);
+
+        const QJsonArray clean = AIManager::sanitizeApiMessages(messages);
+
+        QCOMPARE(clean.size(), 2);
+        for (const QJsonValue& v : clean) {
+            const QJsonObject msg = v.toObject();
+            // Exactly the two API-legal keys — nothing else may survive.
+            QCOMPARE(msg.keys().size(), 2);
+            QVERIFY(msg.contains(QStringLiteral("role")));
+            QVERIFY(msg.contains(QStringLiteral("content")));
+            QVERIFY(!msg.contains(QStringLiteral("shotId")));
+            QVERIFY(!msg.contains(QStringLiteral("structuredNext")));
+        }
+        // Content and role are preserved verbatim.
+        QCOMPARE(clean.at(0).toObject().value("role").toString(), QStringLiteral("user"));
+        QCOMPARE(clean.at(0).toObject().value("content").toString(),
+                 QStringLiteral("How did this shot taste?"));
+        QCOMPARE(clean.at(1).toObject().value("role").toString(), QStringLiteral("assistant"));
+    }
+
     void aiConversation_extractShotFields_detectorFlagsEchoFromShotAnalysisProse()
     {
         // Use the actual production-emitted strings from


### PR DESCRIPTION
## Problem

The AI Dialing Assistant was failing with a red banner:

> Anthropic error: messages.0.shotId: Extra inputs are not permitted

Every dial-in conversation request 400s. Root cause: `AIConversation` stores each turn as `{role, content[, shotId][, structuredNext]}` and hands those **exact objects** to the provider unchanged. `shotId` (per-turn shot latching) and `structuredNext` are Decenza-internal bookkeeping. The Anthropic Messages API strictly rejects unknown per-message keys, so the very first user turn — which carries a latched `shotId` in the normal advisor flow — fails at `messages.0`.

## Fix

Add `AIManager::sanitizeApiMessages()` (pure/static) which whitelists `role` + `content`, and apply it at the single provider-dispatch choke point in `analyzeConversation()`. All providers now receive clean messages regardless of their per-provider wrapping (Anthropic cache-block, OpenAI system-prepend, etc.).

## Regression source

Introduced by #1053, which began stamping `shotId` onto the stored message objects. The structured Anthropic conversation path that forwards them verbatim (`AnthropicProvider::analyzeConversation` → `requestBody["messages"]`) predates it, so #1053 is where the forbidden field first entered the objects flowing through it. Broken since 2026-05-01.

## Verification

Confirmed on a running local build through the **exact broken path**:
- Log shows `AIConversation: Sending request with 1 messages` (multi-turn send, `shotId`-latched `messages[0]`) → response received, conversation saved — **no 400**.
- The logged outgoing prompt contains **zero** `shotId` occurrences.
- New regression test `sanitizeApiMessages_stripsInternalPerTurnKeys` asserts only `role`/`content` survive and `shotId`/`structuredNext` are stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)