### PR TITLE
Scrim idle action buttons over a custom background image

### DIFF
--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -376,14 +376,16 @@ QtObject {
         ? surfaceColor
         : primaryColor
 
-    // Fill for idle-screen full-mode action buttons that render their OWN
-    // ActionButton/Rectangle (Sleep/Quit/History/Favorites/Discuss) instead of
-    // compiling to the scrimmed CustomItem tile. Over a custom background image
-    // they scrim to the same neutral glass as those tiles — so they read as
-    // buttons like Steam/Hot Water rather than an opaque colour slab — while
-    // keeping their given accent/grey fill when no image is set (zero change).
+    // Fill for idle-screen action buttons that render their OWN ActionButton/
+    // Rectangle (Sleep/Quit/History/Favorites/Discuss) rather than as a scrimmed
+    // CustomItem tile (Recipes/Beans/Steam). Over a custom background image they
+    // scrim to the same neutral glass as those tiles — so they read as buttons
+    // like Steam/Hot Water rather than an opaque colour slab — while keeping
+    // their given accent/grey fill when no image is set (zero change). Applies to
+    // both the full-mode ActionButton and the compact-mode Rectangle (Sleep/Quit).
+    // The image-case fill equals cardBackgroundColor (scrimColor(surfaceColor)).
     function actionButtonFill(baseColor: color): color {
-        return Settings.theme.backgroundImagePath.length > 0 ? scrimColor(surfaceColor) : baseColor
+        return Settings.theme.backgroundImagePath.length > 0 ? cardBackgroundColor : baseColor
     }
     property color secondaryColor: _c("secondaryColor", Settings.theme.customThemeColors.secondaryColor || "#c0c5e3")
     property color textColor: _c("textColor", Settings.theme.customThemeColors.textColor || "#ffffff")

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -375,6 +375,16 @@ QtObject {
     readonly property color actionTileColor: Settings.theme.backgroundImagePath.length > 0
         ? surfaceColor
         : primaryColor
+
+    // Fill for idle-screen full-mode action buttons that render their OWN
+    // ActionButton/Rectangle (Sleep/Quit/History/Favorites/Discuss) instead of
+    // compiling to the scrimmed CustomItem tile. Over a custom background image
+    // they scrim to the same neutral glass as those tiles — so they read as
+    // buttons like Steam/Hot Water rather than an opaque colour slab — while
+    // keeping their given accent/grey fill when no image is set (zero change).
+    function actionButtonFill(baseColor: color): color {
+        return Settings.theme.backgroundImagePath.length > 0 ? scrimColor(surfaceColor) : baseColor
+    }
     property color secondaryColor: _c("secondaryColor", Settings.theme.customThemeColors.secondaryColor || "#c0c5e3")
     property color textColor: _c("textColor", Settings.theme.customThemeColors.textColor || "#ffffff")
     // Brightened whenever a background image is active. Originally tried scoping

--- a/qml/components/layout/items/AutoFavoritesItem.qml
+++ b/qml/components/layout/items/AutoFavoritesItem.qml
@@ -73,7 +73,7 @@ Item {
             translationFallback: "Favorites"
             iconSource: "qrc:/icons/star.svg"
             iconSize: Theme.scaled(43)
-            backgroundColor: Theme.primaryColor
+            backgroundColor: Theme.actionButtonFill(Theme.primaryColor)
             onClicked: root.goToAutoFavorites()
         }
     }

--- a/qml/components/layout/items/DiscussItem.qml
+++ b/qml/components/layout/items/DiscussItem.qml
@@ -85,7 +85,7 @@ Item {
             translationFallback: "Discuss"
             iconSource: "qrc:/icons/discuss.svg"
             iconSize: Theme.scaled(43)
-            backgroundColor: Theme.primaryColor
+            backgroundColor: Theme.actionButtonFill(Theme.primaryColor)
             enabled: root.isClaudeDesktopReady
             onClicked: root.openDiscuss()
         }

--- a/qml/components/layout/items/HistoryItem.qml
+++ b/qml/components/layout/items/HistoryItem.qml
@@ -74,7 +74,7 @@ Item {
             translationFallback: "History"
             iconSource: "qrc:/icons/history.svg"
             iconSize: Theme.scaled(43)
-            backgroundColor: Theme.primaryColor
+            backgroundColor: Theme.actionButtonFill(Theme.primaryColor)
             onClicked: root.goToHistory()
         }
     }

--- a/qml/components/layout/items/LastShotItem.qml
+++ b/qml/components/layout/items/LastShotItem.qml
@@ -122,7 +122,7 @@ Item {
 
         Rectangle {
             anchors.fill: parent
-            color: Theme.surfaceColor
+            color: Theme.cardBackgroundColor
             radius: Theme.cardRadius
         }
 

--- a/qml/components/layout/items/QuitItem.qml
+++ b/qml/components/layout/items/QuitItem.qml
@@ -24,7 +24,10 @@ Item {
             anchors.fill: parent
             anchors.topMargin: Theme.spacingSmall
             anchors.bottomMargin: Theme.spacingSmall
-            color: quitCompactTap.isPressed ? Qt.darker("#555555", 1.2) : "#555555"
+            color: {
+                var base = Theme.actionButtonFill("#555555")
+                return quitCompactTap.isPressed ? Qt.darker(base, 1.2) : base
+            }
             radius: Theme.cardRadius
         }
 
@@ -76,7 +79,7 @@ Item {
             translationKey: "idle.button.quit"
             translationFallback: "Quit"
             iconSource: "qrc:/icons/quit.svg"
-            backgroundColor: "#555555"
+            backgroundColor: Theme.actionButtonFill("#555555")
             onClicked: Qt.quit()
         }
     }

--- a/qml/components/layout/items/SleepItem.qml
+++ b/qml/components/layout/items/SleepItem.qml
@@ -49,7 +49,10 @@ Item {
             anchors.fill: parent
             anchors.topMargin: Theme.spacingSmall
             anchors.bottomMargin: Theme.spacingSmall
-            color: sleepCompactTap.isPressed ? Qt.darker(Theme.buttonDisabled, 1.2) : Theme.buttonDisabled
+            color: {
+                var base = Theme.actionButtonFill(Theme.buttonDisabled)
+                return sleepCompactTap.isPressed ? Qt.darker(base, 1.2) : base
+            }
             radius: Theme.cardRadius
             opacity: 1.0
         }
@@ -107,7 +110,7 @@ Item {
             translationKey: "idle.button.sleep"
             translationFallback: "Sleep"
             iconSource: root.showIcon ? "qrc:/icons/sleep.svg" : ""
-            backgroundColor: Theme.buttonDisabled
+            backgroundColor: Theme.actionButtonFill(Theme.buttonDisabled)
             onClicked: root.doSleep()
             onPressAndHold: if (root.allowQuit) Qt.quit()
 


### PR DESCRIPTION
## Problem

Over a custom background image, the mode tiles (Recipes/Beans/Steam/Hot Water) scrim to a translucent "glass" fill via `CustomItem`, but several idle buttons render their **own** opaque `ActionButton`/`Rectangle` and never got that treatment — so they sat as solid slabs. Sleep and Quit's `#555555` grey reads as brown over the green wallpaper; the accent buttons would show as opaque blue slabs.

| Before | After |
|--------|-------|
| Sleep/Quit opaque grey ("brown") slabs | translucent glass matching Steam/Hot Water |

## Change

New shared helper `Theme.actionButtonFill(baseColor)`:
- **Over a background image** → returns the same neutral glass (`scrimColor(surfaceColor)`) as the compiled tiles.
- **No background image** → returns the given colour unchanged (zero visual change to the default look).

Applied to every idle button that self-renders its background:

- `QuitItem.qml` (compact + full)
- `SleepItem.qml` (compact + full)
- `HistoryItem.qml`, `AutoFavoritesItem.qml`, `DiscussItem.qml` (blue accent → neutral glass over image)
- `LastShotItem.qml` — switched to the existing `Theme.cardBackgroundColor`, which already scrims over an image

Press-state darkening is preserved. `MiniGHCItem` already scrimmed itself and was left alone. `IdlePage` renders Sleep/Quit only through these layout items, so nothing else needed touching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)