### PR TITLE
Fix Ratio/Grind pills showing a white capsule on non-accent zones

### DIFF
--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -534,6 +534,17 @@ QtObject {
     function zoneValueBold(style) {
         return style === "accentBar"
     }
+    // Fill for a small tappable value chip (the Ratio/Grind pills) sitting in a
+    // zone of the given style, chosen to contrast with that zone's OWN background
+    // (zoneBackgroundColor): a light capsule on the blue accentBar, a recessed
+    // inset chip on a surfaceColor zone, and a raised surface chip on the
+    // transparent standard zone (where a bare zoneTextColor fill would otherwise
+    // be a jarring white capsule in dark mode).
+    function zoneChipColor(style) {
+        if (style === "accentBar") return primaryContrastColor
+        if (style === "surface")   return insetBackgroundColor
+        return surfaceColor
+    }
 
     // Chart line colors
     property color pressureColor: _c("pressureColor", Settings.theme.customThemeColors.pressureColor || "#18c37e")

--- a/qml/components/layout/LayoutBarZone.qml
+++ b/qml/components/layout/LayoutBarZone.qml
@@ -68,6 +68,7 @@ Item {
                 itemSize: root.itemSize
                 zoneTextColor: Theme.zoneTextColor(root.zoneStyle)
                 zoneValueBold: Theme.zoneValueBold(root.zoneStyle)
+                zoneStyle: root.zoneStyle
                 // equalWidth/spaced: every item gets an equal share of the width,
                 // independent of content width. packed: only spacers grow.
                 Layout.fillWidth: modelData.type === "spacer" || root.fillWidthMode

--- a/qml/components/layout/LayoutCenterZone.qml
+++ b/qml/components/layout/LayoutCenterZone.qml
@@ -91,6 +91,7 @@ Item {
                 zoneName: root.zoneName
                 zoneTextColor: Theme.zoneTextColor(root.zoneStyle)
                 zoneValueBold: Theme.zoneValueBold(root.zoneStyle)
+                zoneStyle: root.zoneStyle
                 Layout.preferredWidth: {
                     // Flip clock: interpolate between buttonWidth and wide based on clockScale
                     if (modelData.type === "screensaverFlipClock") {

--- a/qml/components/layout/LayoutItemDelegate.qml
+++ b/qml/components/layout/LayoutItemDelegate.qml
@@ -12,6 +12,11 @@ Item {
     // it bind these, otherwise they keep their own theme colors.
     property color zoneTextColor: Theme.textColor
     property bool zoneValueBold: false
+    // The zone's style preset ("standard" | "surface" | "accentBar"). Widgets that
+    // render a filled chip (Ratio/Grind pills) key off this: the light-capsule +
+    // accent-text look only reads on an accentBar, so elsewhere they use a themed
+    // surface chip instead of a bare zoneTextColor fill (white in dark mode).
+    property string zoneStyle: "standard"
 
     readonly property string itemType: modelData.type || ""
     readonly property string itemId: modelData.id || ""
@@ -241,6 +246,8 @@ Item {
                 item.zoneTextColor = Qt.binding(function() { return root.zoneTextColor })
             if (typeof item.zoneValueBold !== "undefined")
                 item.zoneValueBold = Qt.binding(function() { return root.zoneValueBold })
+            if (typeof item.zoneStyle !== "undefined")
+                item.zoneStyle = Qt.binding(function() { return root.zoneStyle })
 
             if (root.isCompiled) {
                 // Compiled items: reactive binding merges original modelData with compiled properties

--- a/qml/components/layout/items/GrindQuickSelectItem.qml
+++ b/qml/components/layout/items/GrindQuickSelectItem.qml
@@ -33,6 +33,7 @@ Item {
     property var modelData: ({})
     property color zoneTextColor: Theme.textColor
     property bool zoneValueBold: false
+    property string zoneStyle: "standard"
 
     // Active grinder identity (both carry NOTIFY, so rpmCapable stays reactive
     // when the user switches equipment — mirrors BrewDialog.equipmentRpmCapable).
@@ -341,12 +342,14 @@ Item {
             radius: height / 2
             // Over a background image the solid capsule reads as an opaque white
             // chip on the photo; render it transparent so the value sits on the
-            // background like the Beans/Milk widgets. Without a background image
-            // keep the existing solid pill (zone-color fill, accent text).
+            // background like the Beans/Milk widgets. Otherwise use a zone-appropriate
+            // chip fill (Theme.zoneChipColor): a light capsule on the accentBar, a
+            // themed surface chip elsewhere so it isn't a white capsule in dark mode.
             readonly property bool hasBackgroundImage: Settings.theme.backgroundImagePath.length > 0
+            readonly property color pillFill: Theme.zoneChipColor(root.zoneStyle)
             color: hasBackgroundImage
                 ? "transparent"
-                : (grindMa.pressed ? Qt.darker(root.zoneTextColor, 1.15) : root.zoneTextColor)
+                : (grindMa.pressed ? Qt.darker(pillFill, 1.15) : pillFill)
 
             Accessible.role: Accessible.Button
             Accessible.name: root.labelText + " " + root.accessibleValue + ". "

--- a/qml/components/layout/items/RatioQuickSelectItem.qml
+++ b/qml/components/layout/items/RatioQuickSelectItem.qml
@@ -13,6 +13,7 @@ Item {
     property string itemId: ""
     property color zoneTextColor: Theme.textColor
     property bool zoneValueBold: false
+    property string zoneStyle: "standard"
 
     readonly property string labelText: TranslationManager.translate("idle.status.ratio", "Ratio")
     // The ACTUAL active ratio: the stored anchor when ratio-anchored, else
@@ -53,12 +54,14 @@ Item {
             radius: height / 2
             // Over a background image the solid capsule reads as an opaque chip on
             // the photo; render it transparent so the ratio sits on the background
-            // like the Beans/Milk widgets. Without a background image keep the
-            // existing solid pill (zone-color fill, accent text).
+            // like the Beans/Milk widgets. Otherwise use a zone-appropriate chip
+            // fill (Theme.zoneChipColor): a light capsule on the accentBar, a themed
+            // surface chip elsewhere so it isn't a white capsule in dark mode.
             readonly property bool hasBackgroundImage: Settings.theme.backgroundImagePath.length > 0
+            readonly property color pillFill: Theme.zoneChipColor(root.zoneStyle)
             color: hasBackgroundImage
                 ? "transparent"
-                : (ratioMa.pressed ? Qt.darker(root.zoneTextColor, 1.15) : root.zoneTextColor)
+                : (ratioMa.pressed ? Qt.darker(pillFill, 1.15) : pillFill)
 
             Accessible.role: Accessible.Button
             Accessible.name: root.labelText + " " + root.ratioText + ". "


### PR DESCRIPTION
## Problem

The Ratio and Grind quick-select pills fill their capsule with `zoneTextColor` and draw the value in accent blue. That look only reads on an **accentBar** zone, where `zoneTextColor` is the light contrast colour (a light capsule on the blue bar). On any other zone `zoneTextColor` is the plain page text colour — **white in dark mode** — so the capsule became a jarring white pill.

This is **pre-existing** (dates to #1368, 2026-06-21), not a regression from the recent background work — it just became obvious with the background image turned off in dark mode.

## Change

Add `Theme.zoneChipColor(style)` — a sibling of the existing `zoneBackgroundColor` / `zoneTextColor` / `zoneValueBold` family — returning a chip fill that contrasts with each zone style's **own** background:

| Zone style | Zone background | Chip fill |
|-----------|-----------------|-----------|
| `accentBar` | `primaryColor` (blue) | `primaryContrastColor` (light capsule) — unchanged |
| `surface` | `surfaceColor` | `insetBackgroundColor` (recessed chip) |
| `standard` | transparent (page) | `surfaceColor` (raised chip) |

Propagate the zone's `style` to widgets the same way `zoneTextColor` already is (`LayoutItemDelegate` + `LayoutBarZone` + `LayoutCenterZone`), and use the helper for both pills. The value text stays accent blue and reads on every fill.

**Accent-bar placements are visually unchanged** (`zoneChipColor("accentBar")` == the old `zoneTextColor` fill).

## Consistency audit

Reviewed every other layout item widget's filled shapes — popup/card backgrounds, `CustomItem`/`MiniGHC` fills, status dots, badges, dividers. All are already zone/background-aware or use semantic colours. **Only these two pills** rendered a contrast capsule keyed to the accent bar, so only they needed the fix.

## Testing

- Dark mode, no background image, plain zone: pills now render a raised surface chip with blue text instead of a white capsule.
- Accent-bar zone: unchanged.
- Surface zone: recessed chip (no longer invisible against the surface).
- Background image set: pills still render transparent (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)