### PR TITLE
Give Ratio/Grind pills a button chip over a background image

### DIFF
--- a/qml/components/layout/items/GrindQuickSelectItem.qml
+++ b/qml/components/layout/items/GrindQuickSelectItem.qml
@@ -340,16 +340,15 @@ Item {
                                    + Theme.spacingMedium * 2
             Layout.preferredHeight: Theme.scaled(32)
             radius: height / 2
-            // Over a background image the solid capsule reads as an opaque white
-            // chip on the photo; render it transparent so the value sits on the
-            // background like the Beans/Milk widgets. Otherwise use a zone-appropriate
-            // chip fill (Theme.zoneChipColor): a light capsule on the accentBar, a
-            // themed surface chip elsewhere so it isn't a white capsule in dark mode.
+            // Always a visible chip: this pill is tappable (opens the grind chooser),
+            // so it must read as a button — not a plain readout like Beans/Milk. Over
+            // a background image use the same neutral glass scrim as the Sleep/Quit
+            // buttons (Theme.actionButtonFill); otherwise a zone-appropriate solid
+            // chip (Theme.zoneChipColor): a light capsule on the accentBar, a themed
+            // surface chip elsewhere so it isn't a white capsule in dark mode.
             readonly property bool hasBackgroundImage: Settings.theme.backgroundImagePath.length > 0
-            readonly property color pillFill: Theme.zoneChipColor(root.zoneStyle)
-            color: hasBackgroundImage
-                ? "transparent"
-                : (grindMa.pressed ? Qt.darker(pillFill, 1.15) : pillFill)
+            readonly property color pillFill: Theme.actionButtonFill(Theme.zoneChipColor(root.zoneStyle))
+            color: grindMa.pressed ? Qt.darker(pillFill, 1.15) : pillFill
 
             Accessible.role: Accessible.Button
             Accessible.name: root.labelText + " " + root.accessibleValue + ". "
@@ -370,9 +369,9 @@ Item {
                 id: grindValue
                 anchors.centerIn: parent
                 text: root.valueText
-                // Accent text reads on the solid pill; over a background image the
-                // pill is transparent, so the value uses the zone text color to
-                // read against the photo (matching Beans/Milk).
+                // Accent-blue value reads on the solid chip; over a background image
+                // the chip is the neutral glass scrim, so the value uses the light
+                // zone text color (like the Sleep/Quit labels on their glass).
                 color: parent.hasBackgroundImage ? root.zoneTextColor : Theme.primaryColor
                 font.pixelSize: Theme.scaled(20)
                 font.bold: true

--- a/qml/components/layout/items/RatioQuickSelectItem.qml
+++ b/qml/components/layout/items/RatioQuickSelectItem.qml
@@ -52,16 +52,15 @@ Item {
             Layout.preferredWidth: ratioValue.implicitWidth + Theme.spacingMedium * 2
             Layout.preferredHeight: Theme.scaled(32)
             radius: height / 2
-            // Over a background image the solid capsule reads as an opaque chip on
-            // the photo; render it transparent so the ratio sits on the background
-            // like the Beans/Milk widgets. Otherwise use a zone-appropriate chip
-            // fill (Theme.zoneChipColor): a light capsule on the accentBar, a themed
+            // Always a visible chip: this pill is tappable (opens the ratio chooser),
+            // so it must read as a button — not a plain readout like Beans/Milk. Over
+            // a background image use the same neutral glass scrim as the Sleep/Quit
+            // buttons (Theme.actionButtonFill); otherwise a zone-appropriate solid
+            // chip (Theme.zoneChipColor): a light capsule on the accentBar, a themed
             // surface chip elsewhere so it isn't a white capsule in dark mode.
             readonly property bool hasBackgroundImage: Settings.theme.backgroundImagePath.length > 0
-            readonly property color pillFill: Theme.zoneChipColor(root.zoneStyle)
-            color: hasBackgroundImage
-                ? "transparent"
-                : (ratioMa.pressed ? Qt.darker(pillFill, 1.15) : pillFill)
+            readonly property color pillFill: Theme.actionButtonFill(Theme.zoneChipColor(root.zoneStyle))
+            color: ratioMa.pressed ? Qt.darker(pillFill, 1.15) : pillFill
 
             Accessible.role: Accessible.Button
             Accessible.name: root.labelText + " " + root.ratioText + ". "
@@ -73,10 +72,9 @@ Item {
                 id: ratioValue
                 anchors.centerIn: parent
                 text: root.ratioText
-                // Pill fill is the zone text color (light on an accentBar zone);
-                // accent-colored text reads against it in the intended placements.
-                // Over a background image the pill is transparent, so the base
-                // color becomes the zone text color to read against the photo.
+                // Accent-blue value reads against the solid chip; over a background
+                // image the chip is the neutral glass scrim, so the value uses the
+                // light zone text color (like the Sleep/Quit labels on their glass).
                 // Override-highlight when the session deviates from the active
                 // recipe's/bag's stored spec — consistent with the Brew Settings
                 // rows and the Shot Plan — and wins in both modes.


### PR DESCRIPTION
## Problem

Over a background image, the Ratio/Grind quick-select pills rendered fully **transparent**, so these *tappable* pills (they open a ratio/grind chooser) looked identical to the non-interactive Beans/Milk readouts sitting beside them — nothing signalled they could be clicked.

## Change

Render the pills as a button chip in **every** case:

| State | Fill |
|-------|------|
| Background image on | neutral glass scrim — the same `Theme.actionButtonFill` used by the Sleep/Quit buttons |
| No image, standard zone | raised `surfaceColor` chip |
| No image, surface zone | recessed inset chip |
| No image, accentBar zone | light capsule (unchanged) |

Implemented as `Theme.actionButtonFill(Theme.zoneChipColor(zoneStyle))` — reusing both helpers already in the codebase, so the pills match the Sleep/Quit glass over a photo and the zone-appropriate chip otherwise. The value text stays accent blue on the solid chip and light on the glass (mirroring the Sleep/Quit labels), so it reads as a button rather than a readout.

## Context

Follow-up to #1552. Also audited the other layout widgets for the same "looks like a readout but is tappable" confusion: the brew-info row (Ratio/Grind vs the Beans/Dose/Milk/Profile readouts) was the genuine case. Feature buttons already have icons/tiles; the temperature/water/battery readouts only carry an undiscoverable bonus tap (e.g. tap-to-tare) and correctly look like readouts. No other widget needed this treatment.

## Testing

- Background image on: pills now show the glass chip with light value text (was transparent).
- No image, dark mode: raised surface chip, blue value (unchanged from #1552).
- Accent-bar / surface zones: unchanged.
- Pressed state darkens the chip in all cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)