### PR TITLE
Remove the default shot rating

### DIFF
--- a/docs/CLAUDE_MD/SETTINGS.md
+++ b/docs/CLAUDE_MD/SETTINGS.md
@@ -48,7 +48,7 @@ Never: `Settings.<property>` (flat, only valid for properties that remain on `Se
 // Right
 checked: Settings.mqtt.mqttEnabled
 text: Settings.theme.activeThemeName
-onValueModified: Settings.visualizer.defaultShotRating = newValue
+onValueModified: Settings.visualizer.visualizerMinDuration = newValue
 
 // Wrong — silently fails (Settings has no flat mqttEnabled property anymore)
 checked: Settings.mqttEnabled
@@ -100,12 +100,13 @@ Setters on a sub-object can't directly call methods on another domain (they only
 
 ```cpp
 // In Settings::Settings(), after all m_X members are constructed:
-connect(m_visualizer, &SettingsVisualizer::defaultShotRatingChanged, this, [this]() {
-    setDyeEspressoEnjoyment(m_visualizer->defaultShotRating());
+connect(m_calibration, &SettingsCalibration::sawLearningResetRequested, this, [this]() {
+    m_brew->setHotWaterSawOffset(2.0);  // Back to default
+    m_brew->setHotWaterSawSampleCount(0);
 });
 ```
 
-Don't try to inline the cross-call inside the sub-object's setter — `SettingsVisualizer::setDefaultShotRating` doesn't see `setDyeEspressoEnjoyment`, and adding the dependency would couple two domains that have no business knowing about each other.
+Don't try to inline the cross-call inside the sub-object's setter — `SettingsCalibration` doesn't see `SettingsBrew`'s setters, and adding the dependency would couple two domains that have no business knowing about each other.
 
 ### When `connect()` isn't enough: signal-out, then forward
 

--- a/docs/MCP_TEST_PLAN.md
+++ b/docs/MCP_TEST_PLAN.md
@@ -631,7 +631,7 @@ or pass `keys:["…"]` to bypass categories entirely.
 
 | Category | Notable keys |
 |---|---|
-| `machine` | `autoSleepMinutes`, `keepSteamHeaterOn`, `themeMode`, `darkThemeName`, `lightThemeName`, `screenBrightness`, `autoWakeEnabled`, `autoWakeStayAwakeEnabled`, `autoWakeStayAwakeMinutes`, `defaultShotRating`, `launcherMode`, `postShotReviewTimeout`, `refillKitOverride`, `steamAutoFlushSeconds`, `steamTwoTapStop`, `waterLevelDisplayUnit`, `waterRefillPoint` |
+| `machine` | `autoSleepMinutes`, `keepSteamHeaterOn`, `themeMode`, `darkThemeName`, `lightThemeName`, `screenBrightness`, `autoWakeEnabled`, `autoWakeStayAwakeEnabled`, `autoWakeStayAwakeMinutes`, `launcherMode`, `postShotReviewTimeout`, `refillKitOverride`, `steamAutoFlushSeconds`, `steamTwoTapStop`, `waterLevelDisplayUnit`, `waterRefillPoint` |
 | `calibration` | `autoFlowCalibration`, `flowCalibrationMultiplier`, `ignoreVolumeWithScale`, `useFlowScale` |
 | `connections` | `machineAddress`, `scaleAddress`, `scaleName`, `scaleType`, `showScaleDialogs`, `usbSerialEnabled` |
 | `screensaver` | `screensaverType`, `dimDelayMinutes`, `dimPercent`, `cacheEnabled`, `flipClockUse3D`, `imageDisplayDuration`, `pipesSpeed`, `pipesCameraSpeed`, `pipesShowClock`, `videosShowClock`, `attractorShowClock`, `showDateOnPersonal`, `shotMapShape`, `shotMapTexture`, `shotMapShowClock`, `shotMapShowProfiles`, `shotMapShowTerminator` |

--- a/qml/pages/settings/SettingsVisualizerTab.qml
+++ b/qml/pages/settings/SettingsVisualizerTab.qml
@@ -465,46 +465,6 @@ KeyboardAwareContainer {
                     }
                 }
 
-                // Default shot rating
-                RowLayout {
-                    Layout.fillWidth: true
-                    spacing: Theme.scaled(15)
-
-                    ColumnLayout {
-                        spacing: Theme.scaled(2)
-                        Layout.fillWidth: true
-
-                        Tr {
-                            key: "settings.visualizer.defaultRating"
-                            fallback: "Default Shot Rating"
-                            color: Theme.textColor
-                            font.pixelSize: Theme.scaled(14)
-                        }
-
-                        Tr {
-                            Layout.fillWidth: true
-                            key: "settings.visualizer.defaultRatingDesc"
-                            fallback: "Starting rating for new shots (0 = unrated)"
-                            color: Theme.textSecondaryColor
-                            font.pixelSize: Theme.scaled(12)
-                            wrapMode: Text.WordWrap
-                        }
-                    }
-
-                    RatingInput {
-                        id: defaultRatingInput
-                        Layout.preferredWidth: Theme.scaled(220)
-                        height: Theme.scaled(40)
-                        compact: true
-                        value: Settings.visualizer.defaultShotRating
-                        accessibleName: TranslationManager.translate("settings.visualizer.defaultRating", "Default Shot Rating")
-
-                        onValueModified: function(newValue) {
-                            Settings.visualizer.defaultShotRating = newValue
-                        }
-                    }
-                }
-
                 // Divider before the recovery section
                 Rectangle {
                     Layout.fillWidth: true

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -3355,8 +3355,11 @@ void MainController::onShotEnded() {
                     qDebug() << "[metadata] Set dyeDrinkWeight to:" << finalWeight;
 
                     // Reset shot-specific metadata for the next shot
-                    // Bean/grinder info persists (sticky), but per-shot fields reset
-                    m_settings->dye()->setDyeEspressoEnjoyment(m_settings->visualizer()->defaultShotRating());
+                    // Bean/grinder info persists (sticky), but per-shot fields reset.
+                    // Enjoyment resets to 0 (unrated): a shot that hasn't been tasted
+                    // is never auto-rated — the user rates it on the review page or
+                    // via the AI taste intake.
+                    m_settings->dye()->setDyeEspressoEnjoyment(0);
                     m_settings->dye()->setDyeShotNotes("");
                     m_settings->dye()->setDyeDrinkTds(0);
                     m_settings->dye()->setDyeDrinkEy(0);
@@ -3707,8 +3710,8 @@ void MainController::generateFakeShotData() {
                     // Update drink weight
                     m_settings->dye()->setDyeDrinkWeight(pendingFinalWeight);
 
-                    // Reset shot-specific metadata for next shot
-                    m_settings->dye()->setDyeEspressoEnjoyment(m_settings->visualizer()->defaultShotRating());
+                    // Reset shot-specific metadata for next shot (enjoyment 0 = unrated)
+                    m_settings->dye()->setDyeEspressoEnjoyment(0);
                     m_settings->dye()->setDyeShotNotes("");
                     m_settings->dye()->setDyeDrinkTds(0);
                     m_settings->dye()->setDyeDrinkEy(0);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -57,7 +57,7 @@ Settings::Settings(QObject* parent)
     , m_visualizer(new SettingsVisualizer(this))
     , m_mcp(new SettingsMcp(this))
     , m_brew(new SettingsBrew(this))
-    , m_dye(new SettingsDye(m_visualizer, this))
+    , m_dye(new SettingsDye(this))
     , m_network(new SettingsNetwork(this))
     , m_app(new SettingsApp(this))
     , m_calibration(new SettingsCalibration(this, this))
@@ -365,18 +365,6 @@ Settings::Settings(QObject* parent)
     if (m_settings.value("mcp/apiKey", "").toString().isEmpty()) {
         m_settings.setValue("mcp/apiKey", QUuid::createUuid().toString(QUuid::WithoutBraces));
     }
-
-    // Cross-domain wiring: when the user changes the default shot rating
-    // (Visualizer settings tab, MCP, settings import), also overwrite the
-    // persisted dye/espressoEnjoyment so the new value is reflected in the
-    // BrewDialog and on the next shot save — both in-progress and future
-    // shots see the change. Pre-split this was a side effect inside
-    // Settings::setDefaultShotRating(); it now lives here so any caller
-    // of SettingsVisualizer::setDefaultShotRating gets the same behaviour.
-    // Bean-modified tracking lives entirely inside SettingsDye now.
-    connect(m_visualizer, &SettingsVisualizer::defaultShotRatingChanged, this, [this]() {
-        m_dye->setDyeEspressoEnjoyment(m_visualizer->defaultShotRating());
-    });
 
     // Cross-domain wiring: SettingsCalibration::resetSawLearning() emits
     // sawLearningResetRequested so SettingsBrew can reset the hot-water SAW

--- a/src/core/settings_dye.cpp
+++ b/src/core/settings_dye.cpp
@@ -3,7 +3,6 @@
 #include "../history/bagid.h"
 #include "../history/coffeebagstorage.h"
 #include "../history/equipmentstorage.h"
-#include "settings_visualizer.h"
 #include "grinderaliases.h"
 #include "yieldspec.h"
 #include "basketaliases.h"
@@ -11,21 +10,14 @@
 #include <QtMath>
 #include <QDebug>
 
-SettingsDye::SettingsDye(SettingsVisualizer* visualizer, QObject* parent)
+SettingsDye::SettingsDye(QObject* parent)
     : QObject(parent)
 #ifdef DECENZA_TESTING
     , m_settings(Settings::testQSettingsPath(), QSettings::IniFormat)
 #else
     , m_settings("DecentEspresso", "DE1Qt")
 #endif
-    , m_visualizer(visualizer)
 {
-    // The visualizer pointer is required — dyeEspressoEnjoyment() falls back
-    // to defaultShotRating() when no per-shot value is persisted, and a null
-    // visualizer would crash the getter on first read. Settings::Settings()
-    // always passes a fully-constructed instance.
-    Q_ASSERT(m_visualizer);
-
     // NOTE: do NOT seed bean/presets here. The legacy preset array is
     // consumed by ShotHistoryStorage::importLegacyBeanPresets() — re-seeding
     // an empty array would just create churn for the import to retire.
@@ -520,7 +512,9 @@ void SettingsDye::setDyeDrinkEy(double value) {
 }
 
 int SettingsDye::dyeEspressoEnjoyment() const {
-    return m_settings.value("dye/espressoEnjoyment", m_visualizer->defaultShotRating()).toInt();
+    // 0 = unrated. Untasted shots are never auto-rated; the user rates on the
+    // post-shot review page or via the AI taste intake.
+    return m_settings.value("dye/espressoEnjoyment", 0).toInt();
 }
 
 void SettingsDye::setDyeEspressoEnjoyment(int value) {

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -6,14 +6,13 @@
 #include <QStringList>
 #include <QVariantMap>
 
-class SettingsVisualizer;
 class CoffeeBagStorage;
 class EquipmentStorage;
 
 // DYE (Describe Your Espresso) metadata. Split from Settings to keep
-// settings.h's transitive-include footprint small. Holds a non-owning
-// pointer to SettingsVisualizer so dyeEspressoEnjoyment can fall back to the
-// user-configured defaultShotRating when no per-shot value has been written.
+// settings.h's transitive-include footprint small. An unrated shot carries
+// enjoyment 0 ("unrated") — dyeEspressoEnjoyment defaults to 0 and resets to
+// 0 after each shot save, so untasted shots are never auto-rated.
 //
 // Bean model (bean-bag-inventory): the active coffee bag IS the bean state.
 // The dye/* QSettings keys act as a synchronous write-through cache of the
@@ -97,7 +96,7 @@ class SettingsDye : public QObject {
 
 public:
     // visualizer is non-owning and must outlive this object (Settings owns both).
-    explicit SettingsDye(SettingsVisualizer* visualizer, QObject* parent = nullptr);
+    explicit SettingsDye(QObject* parent = nullptr);
 
     // Non-owning; attached by main.cpp once ShotHistoryStorage has run the
     // migrations. Loads the active bag into the dye cache and subscribes to
@@ -319,7 +318,6 @@ private:
     void applyEquipmentIdentity(const QVariantMap& pkg);
 
     mutable QSettings m_settings;
-    SettingsVisualizer* m_visualizer = nullptr;  // Non-owning; for default-rating fallback.
     CoffeeBagStorage* m_bagStorage = nullptr;    // Non-owning; attached post-init.
     EquipmentStorage* m_equipmentStorage = nullptr; // Non-owning; attached post-init.
 

--- a/src/core/settings_dye.h
+++ b/src/core/settings_dye.h
@@ -95,7 +95,6 @@ class SettingsDye : public QObject {
     Q_PROPERTY(QString activeBagYieldMode READ activeBagYieldMode NOTIFY activeBagYieldSpecChanged)
 
 public:
-    // visualizer is non-owning and must outlive this object (Settings owns both).
     explicit SettingsDye(QObject* parent = nullptr);
 
     // Non-owning; attached by main.cpp once ShotHistoryStorage has run the

--- a/src/core/settings_visualizer.cpp
+++ b/src/core/settings_visualizer.cpp
@@ -98,17 +98,3 @@ void SettingsVisualizer::setVisualizerClearNotesOnStart(bool enabled) {
         emit visualizerClearNotesOnStartChanged();
     }
 }
-
-int SettingsVisualizer::defaultShotRating() const {
-    return m_settings.value("shot/defaultRating", 75).toInt();
-}
-
-void SettingsVisualizer::setDefaultShotRating(int rating) {
-    if (defaultShotRating() != rating) {
-        m_settings.setValue("shot/defaultRating", rating);
-        emit defaultShotRatingChanged();
-        // Cross-domain side effect (sync dye/espressoEnjoyment so the new default
-        // applies to the current shot) is wired in Settings::Settings() via
-        // connect(m_visualizer, &SettingsVisualizer::defaultShotRatingChanged, ...).
-    }
-}

--- a/src/core/settings_visualizer.h
+++ b/src/core/settings_visualizer.h
@@ -4,7 +4,7 @@
 #include <QSettings>
 #include <QString>
 
-// Visualizer (visualizer.coffee) upload settings + default shot rating.
+// Visualizer (visualizer.coffee) upload settings.
 class SettingsVisualizer : public QObject {
     Q_OBJECT
 
@@ -16,7 +16,6 @@ class SettingsVisualizer : public QObject {
     Q_PROPERTY(bool visualizerExtendedMetadata READ visualizerExtendedMetadata WRITE setVisualizerExtendedMetadata NOTIFY visualizerExtendedMetadataChanged)
     Q_PROPERTY(bool visualizerShowAfterShot READ visualizerShowAfterShot WRITE setVisualizerShowAfterShot NOTIFY visualizerShowAfterShotChanged)
     Q_PROPERTY(bool visualizerClearNotesOnStart READ visualizerClearNotesOnStart WRITE setVisualizerClearNotesOnStart NOTIFY visualizerClearNotesOnStartChanged)
-    Q_PROPERTY(int defaultShotRating READ defaultShotRating WRITE setDefaultShotRating NOTIFY defaultShotRatingChanged)
 
 public:
     explicit SettingsVisualizer(QObject* parent = nullptr);
@@ -45,9 +44,6 @@ public:
     bool visualizerClearNotesOnStart() const;
     void setVisualizerClearNotesOnStart(bool enabled);
 
-    int defaultShotRating() const;
-    void setDefaultShotRating(int rating);
-
 signals:
     void visualizerUsernameChanged();
     void visualizerPasswordChanged();
@@ -57,7 +53,6 @@ signals:
     void visualizerExtendedMetadataChanged();
     void visualizerShowAfterShotChanged();
     void visualizerClearNotesOnStartChanged();
-    void defaultShotRatingChanged();
 
 private:
     mutable QSettings m_settings;

--- a/src/core/settingsserializer.cpp
+++ b/src/core/settingsserializer.cpp
@@ -274,7 +274,6 @@ QJsonObject SettingsSerializer::exportToJson(Settings* settings, bool includeSen
     visualizer["extendedMetadata"] = settings->visualizer()->visualizerExtendedMetadata();
     visualizer["showAfterShot"] = settings->visualizer()->visualizerShowAfterShot();
     visualizer["clearNotesOnStart"] = settings->visualizer()->visualizerClearNotesOnStart();
-    visualizer["defaultShotRating"] = settings->visualizer()->defaultShotRating();
     root["visualizer"] = visualizer;
 
     // AI settings
@@ -760,7 +759,6 @@ bool SettingsSerializer::importFromJson(Settings* settings, const QJsonObject& j
         if (visualizer.contains("extendedMetadata")) settings->visualizer()->setVisualizerExtendedMetadata(visualizer["extendedMetadata"].toBool());
         if (visualizer.contains("showAfterShot")) settings->visualizer()->setVisualizerShowAfterShot(visualizer["showAfterShot"].toBool());
         if (visualizer.contains("clearNotesOnStart")) settings->visualizer()->setVisualizerClearNotesOnStart(visualizer["clearNotesOnStart"].toBool());
-        if (visualizer.contains("defaultShotRating")) settings->visualizer()->setDefaultShotRating(visualizer["defaultShotRating"].toInt());
     }
 
     // AI settings

--- a/src/history/shothistorystorage.cpp
+++ b/src/history/shothistorystorage.cpp
@@ -861,7 +861,9 @@ bool ShotHistoryStorage::runMigrations()
     //      MainController can re-PATCH them with the corrected rating.
     //   2) Reset every inferred row's enjoyment to the user's configured
     //      default rating (QSettings shot/defaultRating, fallback 75 —
-    //      matching SettingsVisualizer::defaultShotRating).
+    //      matching the former SettingsVisualizer::defaultShotRating default,
+    //      removed in the remove-default-shot-rating change; this frozen
+    //      migration still reads the raw legacy key for old DBs).
     if (currentVersion < 16) {
         qDebug() << "ShotHistoryStorage: Running migration to version 16 (drop enjoyment_source)";
 

--- a/src/mcp/mcptools_settings.cpp
+++ b/src/mcp/mcptools_settings.cpp
@@ -128,7 +128,6 @@ void registerSettingsReadTools(McpToolRegistry* registry, Settings* settings,
             if (include("waterRefillPoint", "machine")) result["waterRefillPoint"] = settings->app()->waterRefillPoint();
             if (include("waterLevelDisplayUnit", "machine")) result["waterLevelDisplayUnit"] = settings->app()->waterLevelDisplayUnit();
             if (include("screenBrightness", "machine")) result["screenBrightness"] = settings->theme()->screenBrightness();
-            if (include("defaultShotRating", "machine")) result["defaultShotRating"] = settings->visualizer()->defaultShotRating();
             if (include("launcherMode", "machine")) result["launcherMode"] = settings->app()->launcherMode();
             {
                 auto* aw = settings->autoWake();

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -536,7 +536,6 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 {"waterLevelDisplayUnit", QJsonObject{{"type", "string"}, {"description", "Water level display unit"}}},
                 {"useFlowScale", QJsonObject{{"type", "boolean"}, {"description", "Use virtual flow scale"}}},
                 {"screenBrightness", QJsonObject{{"type", "number"}, {"description", "Screen brightness 0.0-1.0"}}},
-                {"defaultShotRating", QJsonObject{{"type", "integer"}, {"description", "Default shot enjoyment rating 0-100"}}},
                 {"launcherMode", QJsonObject{{"type", "boolean"}, {"description", "Enable kiosk/launcher mode (Android only)"}}},
                 {"flowCalibrationMultiplier", QJsonObject{{"type", "number"}, {"description", "Flow calibration multiplier"}}},
                 {"autoFlowCalibration", QJsonObject{{"type", "boolean"}, {"description", "Enable automatic flow calibration"}}},
@@ -961,11 +960,6 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 double v = args["screenBrightness"].toDouble();
                 addSetter([settings, v]() { settings->theme()->setScreenBrightness(v); });
                 updated << "screenBrightness";
-            }
-            if (args.contains("defaultShotRating")) {
-                int v = qBound(0, args["defaultShotRating"].toInt(), 100);
-                addSetter([settings, v]() { settings->visualizer()->setDefaultShotRating(v); });
-                updated << "defaultShotRating";
             }
             if (args.contains("launcherMode")) {
                 bool v = args["launcherMode"].toBool();

--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -19,7 +19,6 @@
 #include "history/recipestorage.h"
 #include "history/unifiedbeansearchmodel.h"
 #include "core/settings_dye.h"
-#include "core/settings_visualizer.h"
 #include "network/visualizeruploader.h"
 
 using Tier = UnifiedBeanSearchModel::Tier;
@@ -1789,8 +1788,7 @@ private slots:
         });
         QVERIFY(bagRatio > 0 && bagPlain > 0);
 
-        SettingsVisualizer viz;
-        SettingsDye dye(&viz);
+        SettingsDye dye;
         dye.setBagStorage(&storage);
 
         // Selecting the anchored bag re-applies its spec and exposes it.
@@ -1867,7 +1865,7 @@ private slots:
 
         CoffeeBagStorage bagStorage; bagStorage.initialize(path);
         EquipmentStorage eqStorage; eqStorage.initialize(path);
-        SettingsVisualizer viz; SettingsDye dye(&viz);
+        SettingsDye dye;
         dye.setBagStorage(&bagStorage);
         dye.setEquipmentStorage(&eqStorage);
 
@@ -1940,7 +1938,7 @@ private slots:
         QVERIFY(bagId > 0);
 
         CoffeeBagStorage bagStorage; bagStorage.initialize(path);
-        SettingsVisualizer viz; SettingsDye dye(&viz);
+        SettingsDye dye;
         dye.setBagStorage(&bagStorage);
 
         dye.setActiveBagId(static_cast<int>(bagId));

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -91,7 +91,6 @@ private:
     double m_origSteamTemp;
     QString m_origScaleAddress;
     QString m_origThemeMode;
-    int m_origShotRating;
     bool m_origIgnoreVolume;
     bool m_origAutoUpdate;
     QString m_origDyeBeanBrand;
@@ -121,7 +120,6 @@ private slots:
         // a trailing reset inside each test — a trailing reset does not run when an
         // assertion fails mid-test, which is exactly when leaked state does most harm.
         m_origCustomFontSizes = m_settings.theme()->customFontSizes();
-        m_origShotRating = m_settings.visualizer()->defaultShotRating();
         m_origIgnoreVolume = m_settings.brew()->ignoreVolumeWithScale();
         m_origAutoUpdate = m_settings.visualizer()->visualizerAutoUpdate();
         m_origDyeBeanBrand = m_settings.dye()->dyeBeanBrand();
@@ -151,7 +149,6 @@ private slots:
         m_settings.brew()->setSteamTemperature(m_origSteamTemp);
         m_settings.setScaleAddress(m_origScaleAddress);
         m_settings.theme()->setThemeMode(m_origThemeMode);
-        m_settings.visualizer()->setDefaultShotRating(m_origShotRating);
         m_settings.brew()->setIgnoreVolumeWithScale(m_origIgnoreVolume);
         m_settings.visualizer()->setVisualizerAutoUpdate(m_origAutoUpdate);
         m_settings.dye()->setDyeBeanBrand(m_origDyeBeanBrand);
@@ -212,11 +209,6 @@ private slots:
     void themeModeRoundTrip() {
         m_settings.theme()->setThemeMode("light");
         QCOMPARE(m_settings.theme()->themeMode(), QString("light"));
-    }
-
-    void defaultShotRatingRoundTrip() {
-        m_settings.visualizer()->setDefaultShotRating(50);
-        QCOMPARE(m_settings.visualizer()->defaultShotRating(), 50);
     }
 
     void visualizerAutoUpdateDefaultIsTrue() {
@@ -321,23 +313,6 @@ private slots:
         QSignalSpy spy(m_settings.visualizer(), &SettingsVisualizer::visualizerAutoUpdateChanged);
         m_settings.visualizer()->setVisualizerAutoUpdate(!m_origAutoUpdate);
         QVERIFY(spy.count() >= 1);
-    }
-
-    // ==========================================
-    // Cross-domain wiring (Visualizer -> Dye)
-    // ==========================================
-
-    void defaultShotRatingPropagatesToDyeEnjoyment() {
-        // Settings::Settings() wires defaultShotRatingChanged -> setDyeEspressoEnjoyment
-        // so any caller of SettingsVisualizer::setDefaultShotRating sees the new
-        // value reflected in dye/espressoEnjoyment without going through Settings.
-        const int origEnjoyment = m_settings.dye()->dyeEspressoEnjoyment();
-        const int newRating = (m_origShotRating == 42) ? 43 : 42;
-        m_settings.visualizer()->setDefaultShotRating(newRating);
-        QCOMPARE(m_settings.dye()->dyeEspressoEnjoyment(), newRating);
-        // Restore (cleanup() also restores defaultShotRating, but enjoyment is
-        // a derived persisted value — leave it consistent for the next test).
-        m_settings.dye()->setDyeEspressoEnjoyment(origEnjoyment);
     }
 
     // ==========================================

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -325,6 +325,27 @@ private slots:
         QCOMPARE(m_settings.brew()->targetWeight(), 0.0);
     }
 
+    void dyeEspressoEnjoymentDefaultsToUnrated() {
+        // The default-shot-rating feature was removed: an untasted shot is never
+        // auto-rated. With no persisted per-shot value, enjoyment is 0 (unrated) —
+        // it must NOT fall back to any non-zero default. A fresh SettingsDye read
+        // against a store with the key removed proves the default in isolation
+        // (the shared suite store may carry a value from a prior test).
+        QSettings raw(Settings::testQSettingsPath(), QSettings::IniFormat);
+        const QVariant prior = raw.value("dye/espressoEnjoyment");
+        raw.remove("dye/espressoEnjoyment");
+        raw.sync();
+
+        SettingsDye fresh;  // reads the now-clean store
+        QCOMPARE(fresh.dyeEspressoEnjoyment(), 0);
+
+        // Restore so later tests see the store they expect.
+        if (prior.isValid()) {
+            raw.setValue("dye/espressoEnjoyment", prior);
+            raw.sync();
+        }
+    }
+
     void emptyScaleAddressIsValid() {
         m_settings.setScaleAddress("");
         QCOMPARE(m_settings.scaleAddress(), QString(""));


### PR DESCRIPTION
## Why

Clicking **AI Advice** on a fresh shot wasn't showing the "How did this shot taste?" intake. Root cause: the taste intake is gated on the shot having **no** saved feedback (`taste_balance` / `taste_body` / `enjoyment0to100`), but `MainController` reset `dyeEspressoEnjoyment` to `defaultShotRating()` after every save — so an untasted shot always carried a rating (50, in Jeff's case) and the gate suppressed the intake every time.

Rating a shot that hasn't been tasted isn't useful, and rating is now easy on the post-shot review page and via the taste intake. So we remove the default-shot-rating feature outright — settings and all.

## Behaviour change

An untasted shot now carries **enjoyment 0 (unrated)**. This is safe end-to-end:

- Visualizer auto-upload still fires immediately at shot save — **we do not wait for a rating.**
- The upload already omits the `espresso_enjoyment` field when enjoyment is 0 (`visualizeruploader.cpp`), so an unrated shot just uploads with no rating field.
- The moment the user rates the shot (review page or taste intake), the metadata-update path PATCHes Visualizer to fill it in.

So the only difference is that untasted shots are no longer branded with a fake rating.

## Removed

- `SettingsVisualizer::defaultShotRating` property/getter/setter/signal + the `shot/defaultRating` QSettings key
- `Settings::Settings()` cross-domain wiring that mirrored the default onto `dye/espressoEnjoyment`
- Visualizer settings-tab UI block
- MCP `settings_get` / `settings_set` entries
- Backup serialize/deserialize of `defaultShotRating`
- `SettingsDye`'s `SettingsVisualizer` dependency (it existed only for this fallback)

`dyeEspressoEnjoyment` now defaults to `0` and resets to `0` after each shot save. Migration 16 still reads the legacy `shot/defaultRating` key for old DBs — that frozen historical path is deliberately untouched.

## Tests / docs

- Removed the two now-obsolete `tst_settings` cases (`defaultShotRatingRoundTrip`, `defaultShotRatingPropagatesToDyeEnjoyment`) and their save/restore plumbing.
- Updated `docs/CLAUDE_MD/SETTINGS.md` (the cross-domain-wiring example used this removed connection) and `docs/MCP_TEST_PLAN.md`.
- **Wiki:** the Manual's Visualizer-settings section should drop the "Default Shot Rating" option — flagged for the usual held-for-release wiki pass.

Build + tests verified locally by Jeff (both clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)