### PR TITLE
docs: TextMetrics-in-binding loop gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ just harder to scan.
   - Rule of thumb: colour picture in the emoji keyboard → emoji, fine. Line-drawing symbol in your text colour → font glyph, also fine now, but confirm coverage with the script. Toolbar/navigation affordance → neither; use a themed SVG.
 - **The bundled font covers Latin (incl. Extended), Greek and Cyrillic only.** In CJK, Arabic, Hebrew, Devanagari and Thai locales every glyph comes from a platform fallback, so the metric determinism the bundled font provides does **not** apply there. Layout tolerance (wrap/elide/content-driven sizing) is what keeps those UIs from clipping — never rely on a fixed width that only fits the design font.
 - **`elide` is dead on `Text.RichText`**: use `Text.StyledText` for HTML-ish labels (elide works, and it's lighter); RichText silently disables `elide` → mid-glyph clipping.
+- **Measuring text in a binding**: use `FontMetrics.advanceWidth(str)`, never a mutated `TextMetrics` (`.text=`/read `.width`) — the latter self-triggers a binding loop. Mutated `TextMetrics` is only safe in an imperative Timer/handler writing a plain property. Runtime-only; a clean build won't catch it.
 - **Accessibility on interactive elements**: every interactive element needs `Accessible.role`, `Accessible.name`, `Accessible.focusable: true`, and `Accessible.onPressAction`. Prefer `AccessibleButton` / `AccessibleMouseArea` over raw `Rectangle+MouseArea`. Full rules in `docs/CLAUDE_MD/ACCESSIBILITY.md`.
 
 ### MCP Tool Responses (`src/mcp/`)

--- a/docs/CLAUDE_MD/QML_GOTCHAS.md
+++ b/docs/CLAUDE_MD/QML_GOTCHAS.md
@@ -193,3 +193,34 @@ Rectangle {
     opacity: Settings.theme.backgroundImagePath.length > 0 ? 0.99 : 1.0
 }
 ```
+
+## Measuring text in a binding — `FontMetrics.advanceWidth()`, never a mutated `TextMetrics`
+
+To measure a string's width, the obvious reach is `TextMetrics`: set `.text`, read `.width`. Inside a **reactive binding** that is a self-triggering loop. Reading `.width` registers it as a dependency of the binding; assigning `.text` in the same binding invalidates `.width`; the invalidation re-runs the binding, which re-assigns `.text` — forever. Qt reports `WARN … Binding loop detected for property "<name>"`, and the property never settles. Sharing one `TextMetrics` across several bindings makes it worse: each binding's `.text` write re-triggers every other binding that reads `.width`.
+
+Use `FontMetrics.advanceWidth(str)` instead — a pure function that reads only the (static) font and mutates nothing, so it registers no self-dependency.
+
+```qml
+// BROKEN — mutates .text and reads .width in the same binding => binding loop
+TextMetrics { id: tm; font.pixelSize: Theme.scaled(16); font.bold: true }
+readonly property var pageSizes: {
+    var w = []
+    for (var i = 0; i < items.length; ++i) {
+        tm.text = items[i].name          // invalidates tm.width...
+        w.push(tm.width + Theme.scaled(40))  // ...which this binding depends on => loop
+    }
+    return packPages(w, availWidth)
+}
+
+// WORKS — advanceWidth() is a pure call, no mutated-property dependency
+FontMetrics { id: fm; font.pixelSize: Theme.scaled(16); font.bold: true }
+readonly property var pageSizes: {
+    var w = []
+    for (var i = 0; i < items.length; ++i)
+        w.push(fm.advanceWidth(items[i].name) + Theme.scaled(40))
+    return packPages(w, availWidth)
+}
+```
+
+The mutated-`TextMetrics` form is only safe when the measurement runs **imperatively** — inside a Timer/handler that writes a plain (non-`readonly`) property — not inside a binding. That is exactly what `PresetPillRow.measureTextWidth()` does (called from the timer-driven `calculateRows()`), which is why it never loops. Binding loops are **runtime-only**: a clean C++/qmlcache build will not catch them — check the running app's log (`debug_get_log`) after the change. (Bitten during `descriptive-recipe-names` computing idle pill-row page sizes; the shared `FontMetrics` is the font-mirroring measurement in `PillFit.js`'s callers.)
+


### PR DESCRIPTION
Documents the binding-loop gotcha found during #1562: measuring text in a reactive QML binding by setting `TextMetrics.text` and reading `.width` self-triggers a binding loop (reading `.width` is a dependency; writing `.text` invalidates it; the invalidation re-runs the binding). Use `FontMetrics.advanceWidth(str)` — a pure call with no mutated-property dependency — instead. The mutated-`TextMetrics` form is only safe imperatively (Timer/handler writing a plain property), which is why `PresetPillRow.measureTextWidth()` never loops.

- Full entry in `docs/CLAUDE_MD/QML_GOTCHAS.md` ("Measuring text in a binding").
- One-liner in the root `CLAUDE.md` gotchas index.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)