### PR TITLE
Glassy dialog backgrounds over a custom wallpaper

### DIFF
--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -454,10 +454,21 @@ QtObject {
         return 0.2126 * linearise(c.r) + 0.7152 * linearise(c.g) + 0.0722 * linearise(c.b)
     }
 
-    // Card fill for page-level content cards (NOT dialogs/popups, which already
-    // sit above a dim Overlay and don't need the wallpaper showing through them).
+    // Card fill for page-level content cards. Dialogs/popups use
+    // dialogBackgroundColor below (same value, separately documented).
     // Opaque surfaceColor when no background image is set — zero visual change.
     readonly property color cardBackgroundColor: Settings.theme.backgroundImagePath.length > 0
+        ? scrimColor(surfaceColor)
+        : surfaceColor
+
+    // Frame fill for content dialogs/popups (Brew Settings, Grind Setting, Brew
+    // Ratio, etc.). When a custom background image is active these use the same
+    // tinted-glass scrim as the idle action tiles (Steam/Recipes/Beans) so the
+    // wallpaper shows through and the dialog matches the rest of the chrome
+    // rather than reading as an out-of-place opaque slab; opaque surfaceColor
+    // otherwise, so nothing changes with no background set. The modal Overlay
+    // dim behind the dialog keeps the glass legible over busy photos.
+    readonly property color dialogBackgroundColor: Settings.theme.backgroundImagePath.length > 0
         ? scrimColor(surfaceColor)
         : surfaceColor
 

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -444,7 +444,7 @@ Dialog {
     }
 
     background: Rectangle {
-        color: Theme.surfaceColor
+        color: Theme.dialogBackgroundColor
         radius: Theme.cardRadius
         border.width: 1
         border.color: Theme.borderColor

--- a/qml/components/GrindPickerDialog.qml
+++ b/qml/components/GrindPickerDialog.qml
@@ -73,7 +73,7 @@ Dialog {
     }
 
     background: Rectangle {
-        color: Theme.surfaceColor
+        color: Theme.dialogBackgroundColor
         radius: Theme.cardRadius
         border.width: 1
         border.color: Theme.borderColor

--- a/qml/components/RatioPresetDialog.qml
+++ b/qml/components/RatioPresetDialog.qml
@@ -97,7 +97,7 @@ Dialog {
     }
 
     background: Rectangle {
-        color: Theme.surfaceColor
+        color: Theme.dialogBackgroundColor
         radius: Theme.cardRadius
         border.width: 1
         border.color: Theme.borderColor


### PR DESCRIPTION
## What

The Brew Settings, Grind Setting, and Brew Ratio dialogs used an opaque `Theme.surfaceColor` frame. Once a custom background image is active, that reads as an out-of-place black slab — while the idle action tiles (Steam/Recipes/Beans) already show the wallpaper through a tinted-glass scrim.

This makes the three dialogs match that glass.

## How

- **`Theme.qml`** — add `dialogBackgroundColor`: `scrimColor(surfaceColor)` (0.4-alpha tinted glass, same as the idle tiles) when a background image is set, opaque `surfaceColor` otherwise → **zero visual change with no wallpaper**. Reconcile the `cardBackgroundColor` comment which previously claimed dialogs were excluded.
- **`BrewDialog.qml`, `GrindPickerDialog.qml`, `RatioPresetDialog.qml`** — frame `color` → `Theme.dialogBackgroundColor`.

The modal Overlay dim behind each dialog keeps the glass legible over busy photos. Inner cards/buttons stay opaque `surfaceColor`, so they read as raised surfaces on the glass — same layering the idle screen uses.

## Testing

Manual (QML has no test harness). Verified the app runtime log is clean — no color-binding errors, no binding loops referencing the new property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)