### PR TITLE
Document that LeakSanitizer does not exist on macOS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@ Read [`docs/SHOT_REVIEW.md`](https://github.com/Kulitorum/Decenza/blob/main/docs
 
 **Debug builds are sanitizer-instrumented automatically** — ASan *and* UBSan on every desktop platform including macOS, so a normal local test run already reports undefined behaviour and memory errors. UBSan is in recovering mode there (it reports and continues); an explicit `-DENABLE_UBSAN=ON` gives the halting mode CI uses. Release builds are untouched.
 
+**But LeakSanitizer does not exist on macOS, so a green local run says nothing about leaks.** `ASAN_OPTIONS=detect_leaks=1` is refused outright — `AddressSanitizer: detect_leaks is not supported on this platform`. LSan is Linux-only, so on a Mac ASan covers use-after-free, buffer overflow and double-free, and cannot see a leak at all. The nightly Linux ASan job is the only place leaks are detected; it found two the local suite had passed over for months. To chase a leak on macOS use `leaks <pid>` or `MallocStackLogging=1`, not ASan.
+
 ## Project Structure
 
 See `docs/CLAUDE_MD/PROJECT_STRUCTURE.md` for the full source tree, signal/slot flow, scale system, machine phases, AI/MCP overview, and profile pipeline. Top-level: `src/` (C++), `qml/` (UI), `resources/`, `shaders/`, `tests/`, `docs/`, `openspec/`, `android/`, `installer/`.

--- a/docs/CLAUDE_MD/TESTING.md
+++ b/docs/CLAUDE_MD/TESTING.md
@@ -52,6 +52,19 @@ UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
 
 **Debug builds instrument themselves.** A Debug configure turns on ASan *and* UBSan on every desktop platform including macOS (Android is excluded — its ASan needs `wrap.sh` packaging this project does not do). UBSan runs in **recovering** mode there: it prints a diagnostic and the app keeps going, so you are told about undefined behaviour without losing your session.
 
+**LeakSanitizer is Linux-only — your local run cannot detect leaks.** This is worth stating plainly because the natural inference from "ASan is on locally" is wrong, and it has already been drawn:
+
+```
+$ ASAN_OPTIONS=detect_leaks=1 ./tests/tst_mcptools_write
+==11353==AddressSanitizer: detect_leaks is not supported on this platform.
+```
+
+The runtime refuses the option; there is no flag that turns it on. On macOS, ASan covers use-after-free, heap-buffer-overflow, stack-use-after-return and double-free — a leak is invisible to it. So "84/84 passed under ASan" on a Mac means *no memory errors*, never *no leaks*.
+
+The nightly Linux ASan job (`ASAN_OPTIONS=detect_leaks=1`) is the only place leaks are caught. Its first run found two that the local suite had been passing over: `tst_decentscalewifi` (131,068 bytes / 1,372 allocations) and `tst_mcptools_write` (6,540 bytes / 70 allocations), byte-identical across all three retry attempts.
+
+To chase a leak on macOS, use the platform tools instead: `leaks <pid>`, or `MallocStackLogging=1` for allocation stacks.
+
 A **Release** build carries no instrumentation unless you ask. `-DENABLE_UBSAN=ON` gives the **halting** mode CI uses, where a finding aborts. `-DENABLE_ASAN=ON` does the same for memory errors, and the two combine. UBSan is not supported with MSVC (configure fails fast).
 
 **What the instrumented build turns on beyond plain UBSan**, and why each one is there:


### PR DESCRIPTION
## Why

Both `CLAUDE.md` and `TESTING.md` said Debug builds are ASan-instrumented on every desktop platform including macOS. True — and neither mentioned that the **leak-detection half is Linux-only**.

The natural inference is "ASan is on locally, so a green local suite means no leaks." That inference is wrong, and it was drawn in practice today: after the nightly found two leaks, the reasonable question was *"didn't we enable ASan for the dev test runs?"* We did. It just cannot see leaks on a Mac.

The runtime refuses the option outright — there is no flag that turns it on:

```
$ ASAN_OPTIONS=detect_leaks=1 ./tests/tst_mcptools_write
==11353==AddressSanitizer: detect_leaks is not supported on this platform.
```

So on macOS, ASan covers use-after-free, heap-buffer-overflow, stack-use-after-return and double-free. **"84/84 passed under ASan" means no memory _errors_, never no _leaks_.**

The nightly Linux ASan job is the only place leaks are detected. Its first run found two the local suite had been passing over for months:

| Test | Leak |
|---|---|
| `tst_decentscalewifi` | 131,068 bytes / 1,372 allocations |
| `tst_mcptools_write` | 6,540 bytes / 70 allocations |

Byte-identical across all three retry attempts — deterministic, not noise.

## Changes

Docs only. Adds the gap to both files, with the verbatim runtime message so it is recognisable, and points macOS leak-hunting at `leaks(1)` / `MallocStackLogging=1`, which do work.

This is the same shape as the rest of this week's work: a detector that is demonstrably running, but not covering what its presence implies.

## Not included

The two leaks themselves. They are pre-existing — ASan has never been able to see them until this week — and reading the stacks to decide between a code fix, a suppression file, or scoping `detect_leaks` is a separate change.