### PR TITLE
Fix two memory leaks the nightly found, and build only what it runs

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -213,10 +213,21 @@ jobs:
             -DBUILD_TESTS=ON \
             "$SANITIZER_FLAG"
 
+      # `build_tests`, not `all`. This job runs the ctest suite and nothing
+      # else, and `all` is dominated by targets it never executes: the Decenza
+      # app (385 C++ objects) and the tools (36) against the tests' 318.
+      # Measured with `ninja -t commands`: 1238 build steps for `all` vs 524
+      # for `build_tests` — 57.7% fewer, plus the app's link.
+      #
+      # No coverage is lost. Sanitizers report on code that RUNS, and nothing
+      # here runs the app; the src/ sources the tests exercise are compiled into
+      # decenza_testlib/decenza_shotlib and are still instrumented. App-only
+      # code (main.cpp, QML glue) is compiled several times a day by the
+      # platform builds anyway.
       - name: Build
         run: |
           cd build
-          ninja -j$(nproc)
+          ninja -j$(nproc) build_tests
 
       # Both option sets are exported unconditionally; each sanitizer reads only
       # its own variable, so the inactive one is inert. halt_on_error matters:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,18 @@ endif()
 #     "ERROR: AddressSanitizer: …" block naming the location. That is a bug to
 #     fix, not a reason to turn the sanitizer off.
 if(ENABLE_ASAN OR (NOT CMAKE_CONFIGURATION_TYPES AND CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT ANDROID))
+    # Reflect the auto-enable back into the option, as the UBSan block does.
+    # Without this, ASan is ACTIVE in every local Debug build while ENABLE_ASAN
+    # stays OFF — and tests/CMakeLists.txt registers asan_canary under
+    # `if(ENABLE_ASAN)`, so the canary silently did not exist in exactly the
+    # configuration developers run all day. ASan instrumented, nothing proving
+    # it: the precise hole the canary was written to close, reintroduced by
+    # copying the UBSan block's shape without noticing UBSan sets its flag here
+    # and ASan did not.
+    #
+    # Caught by a test count of 84 that contained sanitizer_canary and no
+    # asan_canary.
+    set(ENABLE_ASAN ON)
     if(MSVC)
         message(STATUS ">>> ASan ENABLED for debug build (MSVC) <<<")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fsanitize=address")

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -1771,7 +1771,31 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             const QString dbPath = shotHistory->databasePath();
 
             // Load the just-updated bag on a background thread and respond.
+            // Always create the reader thread ON THE MAIN THREAD.
+            //
+            // This lambda is invoked from two places: the storage-instance path
+            // (already on the main thread, via invokeMethod(qApp, ...)) and the
+            // headless fallback path — from INSIDE a QThread::create worker.
+            //
+            // In that second case the QThread built below inherited the
+            // WORKER's thread affinity, so deleteLater() on its finished()
+            // signal posted a DeferredDelete to the WORKER's event queue. A
+            // QThread::create thread never calls exec(), and has usually exited
+            // by then, so nothing ever processed that event: the QThread and
+            // its internals were never freed.
+            //
+            // Measured as 6,540 bytes / 70 allocations leaked in
+            // tst_mcptools_write. It survived a 250 ms drain of the MAIN
+            // thread's event queue — because the pending delete was never on
+            // the main thread's queue at all, which is what made two earlier
+            // explanations of this leak wrong. Confirmed by probe: on the
+            // fallback path this lambda reported
+            // currentThread() != qApp->thread() on every call.
+            //
+            // The hop makes affinity identical on both paths, so the deferred
+            // delete always lands on an event loop that actually runs.
             auto respondWithBag = [dbPath, bagId, bagToJson, respond]() {
+              QMetaObject::invokeMethod(qApp, [dbPath, bagId, bagToJson, respond]() {
                 QThread* t = QThread::create([dbPath, bagId, bagToJson, respond]() {
                     CoffeeBag updated;
                     withTempDb(dbPath, "mcp_bagupd_read", [&](QSqlDatabase& db) {
@@ -1791,6 +1815,7 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
                 });
                 QObject::connect(t, &QThread::finished, t, &QObject::deleteLater);
                 t->start();
+              }, Qt::QueuedConnection);
             };
 
             auto proceed = [dbPath, bagId, bagStorage, respondWithBag, respond](const QVariantMap& finalFields) {

--- a/src/mcp/mcptools_write.cpp
+++ b/src/mcp/mcptools_write.cpp
@@ -1773,9 +1773,11 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             // Load the just-updated bag on a background thread and respond.
             // Always create the reader thread ON THE MAIN THREAD.
             //
-            // This lambda is invoked from two places: the storage-instance path
-            // (already on the main thread, via invokeMethod(qApp, ...)) and the
-            // headless fallback path — from INSIDE a QThread::create worker.
+            // This lambda is invoked from THREE places: :1842 (bagUpdated
+            // handler, main thread), :1857 (the headless fallback path, from
+            // INSIDE a QThread::create worker — the leak), and :1969 (the
+            // idempotent-merge early return, main thread via invokeMethod).
+            // Only the middle one runs off the main thread.
             //
             // In that second case the QThread built below inherited the
             // WORKER's thread affinity, so deleteLater() on its finished()
@@ -1792,8 +1794,13 @@ void registerWriteTools(McpToolRegistry* registry, ProfileManager* profileManage
             // fallback path this lambda reported
             // currentThread() != qApp->thread() on every call.
             //
-            // The hop makes affinity identical on both paths, so the deferred
-            // delete always lands on an event loop that actually runs.
+            // The hop makes affinity identical on all three paths, so the
+            // deferred delete always lands on an event loop that actually runs.
+            //
+            // Confirmed, not assumed: the nightly Linux ASan job reported
+            // 6,540 bytes / 70 allocations here before this change and ZERO
+            // after (run 29707910438, 84/84, no LeakSanitizer reports).
+            // LeakSanitizer is Linux-only, so no local run could have shown it.
             auto respondWithBag = [dbPath, bagId, bagToJson, respond]() {
               QMetaObject::invokeMethod(qApp, [dbPath, bagId, bagToJson, respond]() {
                 QThread* t = QThread::create([dbPath, bagId, bagToJson, respond]() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,14 @@ set(CMAKE_AUTOMOC_PATH_PREFIX OFF)
 # Each test compiles only the source files it needs (no full app build).
 function(add_decenza_test name)
     add_executable(${name} ${ARGN})
+    # Record every test executable so `build_tests` below can depend on the set
+    # without anyone maintaining a second list by hand.
+    #
+    # A target declared with a bare add_executable + add_test does NOT pass
+    # through here and must append to DECENZA_TEST_TARGETS itself — see
+    # tst_shotcorpus. Forgetting that shows up as "(Not Run)" in a clean build,
+    # and ONLY in a clean build.
+    set_property(GLOBAL APPEND PROPERTY DECENZA_TEST_TARGETS ${name})
     set_target_properties(${name} PROPERTIES AUTOMOC_PATH_PREFIX OFF)
     target_compile_definitions(${name} PRIVATE DECENZA_TESTING)
     # Source-tree path, so a test can assert against shipped QML/assets rather than
@@ -490,6 +498,17 @@ if(NOT ANDROID AND NOT IOS)
     )
     add_dependencies(tst_shotcorpus shot_eval)
     add_test(NAME tst_shotcorpus COMMAND tst_shotcorpus)
+    # Registered by hand because this target is declared with add_executable
+    # rather than add_decenza_test, so the function that records test targets
+    # never sees it. Omitting it made `ninja build_tests` skip this binary and
+    # ctest report "40 - tst_shotcorpus (Not Run)" — caught only by building in
+    # a CLEAN tree, since an incremental build still had the binary lying around
+    # from a previous `ninja all`.
+    #
+    # This also pulls in shot_eval via add_dependencies above, which is correct:
+    # the test shells out to `shot_eval --validate`, so that tool IS needed even
+    # though the other three (saw_replay, saw_parity, profile_sync) are not.
+    set_property(GLOBAL APPEND PROPERTY DECENZA_TEST_TARGETS tst_shotcorpus)
 endif()
 
 # --- tst_shotsettings: ShotSettings BLE wire format ---
@@ -1020,3 +1039,34 @@ if(ENABLE_ASAN)
             -DEXPECT_ABORT=ON
             -P ${CMAKE_CURRENT_SOURCE_DIR}/run_sanitizer_canary.cmake)
 endif()
+
+# --- build_tests: everything ctest needs, and nothing it does not.
+#
+# `ninja` with no target builds `all`, which for this project is dominated by
+# things the test suite never executes. Measured on a nightly sanitizer build:
+# 385 C++ objects for the Decenza app and 36 for the tools (shot_eval,
+# saw_replay, saw_parity, profile_sync), against 318 for the tests themselves —
+# so roughly 56% of the compilation, plus the app's link, is work the job
+# throws away.
+#
+# Safe because no test target links or depends on the app: they link
+# decenza_testlib / decenza_shotlib, which compile the src/ sources they need
+# independently. Sanitizer coverage is unaffected — ASan and UBSan report on
+# code that RUNS, and this job runs only the suite.
+#
+# What this gives up, stated plainly: the nightly no longer compiles
+# app-exclusive code (main.cpp, QML glue) under sanitizer flags. That is not a
+# real loss — those files are already compiled several times a day by the
+# platform builds, and nothing here executed them.
+#
+# Use: `ninja build_tests` instead of `ninja`.
+get_property(_decenza_test_targets GLOBAL PROPERTY DECENZA_TEST_TARGETS)
+if(ENABLE_UBSAN)
+    list(APPEND _decenza_test_targets sanitizer_canary)
+endif()
+if(ENABLE_ASAN)
+    list(APPEND _decenza_test_targets asan_canary)
+endif()
+add_custom_target(build_tests DEPENDS ${_decenza_test_targets})
+list(LENGTH _decenza_test_targets _decenza_test_count)
+message(STATUS "build_tests target covers ${_decenza_test_count} test executables")

--- a/tests/mocks/McpTestFixture.h
+++ b/tests/mocks/McpTestFixture.h
@@ -7,6 +7,8 @@
 #include "controllers/profilemanager.h"
 #include "mcp/mcptoolregistry.h"
 
+#include <memory>
+
 // Shared test fixture for MCP tool tests.
 // Wires ProfileManager with a MockTransport so BLE writes can be verified.
 //
@@ -103,51 +105,65 @@ struct McpTestFixture {
     QJsonObject callAsyncTool(const QString& name, const QJsonObject& args, int accessLevel = 2)
     {
         QString error;
-        QJsonObject result;
-        bool responded = false;
+        // Shared state, NOT captures of this frame's locals.
+        //
+        // The callback outlives this function on the timeout path below: it
+        // returns after 5 s with queued work still in flight, and that work can
+        // fire during a LATER test's processEvents. Capturing &result/&responded
+        // by reference would then write into a destroyed stack frame — a
+        // stack-use-after-return, which is exactly what the ASan job this
+        // fixture feeds exists to catch. Pre-existing, but the window widened
+        // when bag_update gained a main-thread hop (one more event-loop cycle
+        // before it can respond), so it is fixed here rather than noted.
+        struct AsyncState { QJsonObject result; bool responded = false; };
+        auto state = std::make_shared<AsyncState>();
 
         registry.callAsyncTool(name, args, accessLevel, error,
-            [&result, &responded](const QJsonObject& r) {
-                result = r;
-                responded = true;
+            [state](const QJsonObject& r) {
+                state->result = r;
+                state->responded = true;
             });
 
         if (!error.isEmpty()) {
             qWarning() << "callAsyncTool error:" << error;
-            return result;
+            return state->result;
         }
 
         // Process events until the async handler responds
         QElapsedTimer timer;
         timer.start();
-        while (!responded && timer.elapsed() < 5000)
+        while (!state->responded && timer.elapsed() < 5000)
             QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
 
-        if (!responded)
+        if (!state->responded)
             qWarning() << "callAsyncTool timed out waiting for response";
 
-        // NOTE on a leak that is NOT explained by this loop.
+        // A leak that lived here, and the two wrong explanations for it.
         //
-        // tst_mcptools_write leaks 6540 bytes / 70 allocations under
-        // LeakSanitizer, with our frames at mcptools_write.cpp:1775, :1792,
-        // :1826, :1832, :1947 and :537 — the QThread::create sites in the
-        // headless static-fallback paths.
+        // tst_mcptools_write leaked 6,540 bytes / 70 allocations under
+        // LeakSanitizer, at the QThread::create sites in mcptools_write.cpp's
+        // headless static-fallback paths. RESOLVED — see the long note at
+        // src/mcp/mcptools_write.cpp:1774. Kept here because both failed
+        // diagnoses pointed at THIS function, and the record is what stops the
+        // next person re-deriving them:
         //
-        // Two explanations were proposed and BOTH are wrong, recorded so the
-        // next person does not spend the time again:
-        //
-        //   1. "There is no event loop, so deleteLater never runs." False —
-        //      the loop above is one.
+        //   1. "There is no event loop, so deleteLater never runs." Wrong about
+        //      this function — the loop above is one.
         //   2. "The loop returns the instant the response lands, before
         //      QThread::finished fires, so the queued deleteLater is never
-        //      delivered." Plausible, and tested: draining events for 250 ms
-        //      here plus an explicit sendPostedEvents(DeferredDelete) changed
-        //      the leak by exactly ZERO bytes. Reverted rather than kept, since
-        //      a fix that does nothing is worse than none — it looks handled.
+        //      delivered." Tested: draining events for 250 ms here plus an
+        //      explicit sendPostedEvents(DeferredDelete) changed the leak by
+        //      exactly ZERO bytes. Reverted rather than kept.
         //
-        // Still open. LeakSanitizer only runs on Linux (not macOS), so this is
-        // only reproducible in the nightly ASan job.
-        return result;
+        // The real cause was neither: respondWithBag() ran on a QThread::create
+        // WORKER, so the QThread it built inherited that worker's affinity and
+        // its deleteLater was posted to a queue nothing would ever pump. #2
+        // failed precisely because the pending delete was never on the main
+        // thread's queue — the thing this loop drains. Fixed by hopping to the
+        // main thread before creating that thread; nightly ASan now reports
+        // zero (run 29707910438).
+        //
+        return state->result;
     }
 
     // Helper: find BLE writes to a specific characteristic UUID

--- a/tests/mocks/McpTestFixture.h
+++ b/tests/mocks/McpTestFixture.h
@@ -125,6 +125,28 @@ struct McpTestFixture {
 
         if (!responded)
             qWarning() << "callAsyncTool timed out waiting for response";
+
+        // NOTE on a leak that is NOT explained by this loop.
+        //
+        // tst_mcptools_write leaks 6540 bytes / 70 allocations under
+        // LeakSanitizer, with our frames at mcptools_write.cpp:1775, :1792,
+        // :1826, :1832, :1947 and :537 — the QThread::create sites in the
+        // headless static-fallback paths.
+        //
+        // Two explanations were proposed and BOTH are wrong, recorded so the
+        // next person does not spend the time again:
+        //
+        //   1. "There is no event loop, so deleteLater never runs." False —
+        //      the loop above is one.
+        //   2. "The loop returns the instant the response lands, before
+        //      QThread::finished fires, so the queued deleteLater is never
+        //      delivered." Plausible, and tested: draining events for 250 ms
+        //      here plus an explicit sendPostedEvents(DeferredDelete) changed
+        //      the leak by exactly ZERO bytes. Reverted rather than kept, since
+        //      a fix that does nothing is worse than none — it looks handled.
+        //
+        // Still open. LeakSanitizer only runs on Linux (not macOS), so this is
+        // only reproducible in the nightly ASan job.
         return result;
     }
 

--- a/tests/tst_decentscalewifi.cpp
+++ b/tests/tst_decentscalewifi.cpp
@@ -24,6 +24,20 @@ public:
         connect(m_server, &QWebSocketServer::newConnection, this, [this]() {
             while (m_server->hasPendingConnections()) {
                 m_client = m_server->nextPendingConnection();
+                // QWebSocketServer does NOT take ownership of the socket it
+                // hands back — unlike QTcpServer, which parents it to itself.
+                // Qt's own docs: "It is up to the caller to delete the object
+                // explicitly ... otherwise a memory leak will occur."
+                //
+                // Leaving it unparented leaked one QWebSocket and its internals
+                // per connection: measured at 4,681 bytes / 49 allocations per
+                // connect-handshake-teardown cycle, scaling EXACTLY 20x between
+                // a 1-cycle and a 20-cycle run. It looked like harmless
+                // Qt-internal exit noise right up until it was measured.
+                //
+                // Reparenting to the fake server is enough — it dies with the
+                // server at end of scope.
+                m_client->setParent(this);
                 connect(m_client, &QWebSocket::textMessageReceived,
                         this, [this](const QString& msg) { m_received.append(msg); });
                 emit clientConnected();
@@ -123,6 +137,46 @@ private slots:
     // ==========================================
     // Snapshot frame parsing
     // ==========================================
+
+    // LEAK-SCALING PROBE. Repeats the full connect/handshake/teardown cycle N
+    // times in ONE process, where N comes from DECENZA_LEAK_SCALE (default 1,
+    // so an ordinary run is completely unaffected).
+    //
+    // The question this answers cannot be answered by reading a stack trace.
+    // The first nightly ASan run reported 131,068 bytes / 1,372 allocations
+    // leaked here, with every frame inside libQt6Core and none in our code —
+    // and, notably, ZERO "Direct leak" entries, only "Indirect". That is
+    // consistent with bounded state torn down at exit, and equally consistent
+    // with a real per-connection leak. The two need different responses
+    // (suppress vs fix), and only the growth curve tells them apart:
+    //
+    //   allocations stay ~1,372 as N rises  -> bounded, one-time, suppressible
+    //   allocations scale with N            -> real leak, fix it
+    //
+    // Symbolizing Qt would say WHERE memory was allocated; it would not say
+    // whether the total is bounded. Hence this, which needs no symbols at all.
+    void leakScalingProbe() {
+        bool ok = false;
+        const int n = qEnvironmentVariableIntValue("DECENZA_LEAK_SCALE", &ok);
+        const int iterations = (ok && n > 0) ? n : 1;
+        qInfo() << "[leak-probe] running" << iterations << "connect/teardown cycles";
+        for (int i = 0; i < iterations; ++i) {
+            // Each teardown emits one "[Scale] ... DISCONNECTED" warning, and
+            // failOnWarning turns any unignored warning into a failure.
+            // QTest::ignoreMessage consumes exactly ONE message, and init()
+            // queues exactly one — enough for a single-cycle test, one short
+            // per extra cycle here. Queue the rest.
+            if (i > 0)
+                QTest::ignoreMessage(QtWarningMsg,
+                                     QRegularExpression(".*DISCONNECTED.*"));
+            FakeHdsServer server;
+            DecentScaleWifi driver;
+            connectAndHandshake(driver, server);
+            driver.tare();
+            QTRY_VERIFY_WITH_TIMEOUT(server.received().size() >= 5, 2000);
+        }
+        QVERIFY(true);
+    }
 
     void weightSnapshotEmitsSetWeight() {
         FakeHdsServer server;


### PR DESCRIPTION
Two real memory leaks, found by the nightly ASan job on its first working run — and **verified fixed**, not asserted.

| Test | Before | After |
|---|---|---|
| `tst_decentscalewifi` | 131,068 bytes / 1,372 allocations | **0** |
| `tst_mcptools_write` | 6,540 bytes / 70 allocations | **0** |

Nightly ASan run `29707910438`: **84/84, zero LeakSanitizer reports, both canaries armed.** LeakSanitizer is Linux-only, so no local run could have shown this.

## Leak 1 — I nearly suppressed this one

I read the stacks, saw only Qt frames and zero `Direct` leaks, and was ready to call it bounded exit noise. Measuring instead:

```
N=1  ->  4,681 bytes /  49 allocations
N=20 -> 93,620 bytes / 980 allocations     exactly 20.00×
```

**Cause:** `QWebSocketServer::nextPendingConnection()` does *not* take ownership of the socket it returns — unlike `QTcpServer`, which parents it. `FakeHdsServer` assumed the familiar behaviour. Fixed by reparenting.

Test-only in scope: production has no `QWebSocketServer`; both `nextPendingConnection()` calls in `src/` are `QTcpServer`.

## Leak 2 — a real defect in `src/`

`respondWithBag()` is called from inside a `QThread::create` worker on the headless fallback path. The `QThread` it constructs therefore inherits the **worker's** thread affinity, so `deleteLater()` posts a `DeferredDelete` to the worker's queue — and `QThread::create` threads never call `exec()`, and have exited by then. Nothing ever processes it.

That is why draining the *main* thread's events for 250 ms changed the leak by **zero bytes**: the pending delete was never on the main thread's queue.

Verified by probe rather than reasoning — on every call:
```
[affinity-probe] respondWithBag on main? false  current= QThread(0x6030000eaaf0)
                                                main= QThread(0x602000002f70, "Qt mainThread")
```

Fixed by hopping to the main thread before creating the reader thread.

## `asan_canary` never registered in local Debug builds

The UBSan auto-enable does `set(ENABLE_UBSAN ON)`; the ASan one set no flag, and the canary is gated on `if(ENABLE_ASAN)`. So **every local Debug build ran ASan-instrumented with nothing proving it** — the exact hole the canary exists to close, reintroduced in the commit that added it. `ctest` now lists both.

## Nightly builds only what it runs

`ninja` with no target built `all`. Measured with `ninja -t commands`: **1238 steps for `all` vs 537 for the tests** — ~57% discarded, plus the app's link, which no compiler cache avoids. Adds a `build_tests` target; `add_decenza_test` records each executable so the set cannot drift.

Verified in a **clean build directory**, which mattered: my first check ran `ninja build_tests` in a tree where every binary already existed and then confirmed they existed — circular, and it hid a bug. A fresh tree failed with `40 - tst_shotcorpus (Not Run)`, because that target uses a bare `add_executable`. It now registers itself, and the recording function documents the requirement.

That also corrected a confident claim: the tools are **not** all unnecessary — `tst_shotcorpus` shells out to `shot_eval --validate`.

Final: 84 executables, cold build 537/537 in 2m44s, zero app binaries, clean-tree ctest 85/85.

## Review fixes (last commit)

1. `McpTestFixture.h` documented the second leak as "Still open" with both explanations marked wrong — written before the next commit found the cause. Rewritten to record the resolution while keeping the dead ends.
2. `callAsyncTool` captured `&result, &responded` — locals of a frame the callback can outlive on the 5 s timeout path, so a late callback writes into a destroyed stack frame. A stack-use-after-return in the fixture feeding the ASan job. Now `shared_ptr` state.
3. A comment claimed `respondWithBag` has "two" call sites; it has three (`:1842`, `:1857`, `:1969`). The thread analysis holds — only `:1857` is off-main.

## Verification

- Nightly ASan: **84/84, zero leaks**, both canaries passing
- Local: **85/85**
- Clean-tree build + ctest: **85/85**
