### PR TITLE
Put Purge and Stop on one row on the live steam view

### DIFF
--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -1061,15 +1061,12 @@ Page {
 
                 Tr {
                     anchors.centerIn: parent
-                    key: "steam.label.purge"; fallback: "Purge"
+                    // Same key and same type treatment as steamStopButton beside it, so
+                    // the pair reads as one row.
+                    key: "steam.button.purge"; fallback: "PURGE"
                     color: Theme.primaryContrastColor
-                    // Matches steamStopButton: same box, same casing, so the pair reads
-                    // as one row. Capitalised at render time for the same reason it is
-                    // on that button — the key stays sentence-case and shared with the
-                    // settings-view Purge, and case-less scripts are left alone.
                     font.pixelSize: Theme.scaled(24)
                     font.weight: Font.Bold
-                    font.capitalization: Font.AllUppercase
                     Accessible.ignored: true
                 }
 
@@ -1119,21 +1116,16 @@ Page {
                 Text {
                     id: stopButtonText
                     anchors.centerIn: parent
-                    // Reuses steam.label.purge rather than minting a second purge key:
-                    // the registry maps key -> one English string, so the same key with a
-                    // different fallback would oscillate between whichever site rendered
-                    // last (see scripts/check_translation_key_conflicts.py).
+                    // steam.button.* carries the shouted label, matching espresso/flush/
+                    // hotwater/descaling/transport. The sentence-case steam.label.purge
+                    // stays on the settings-view Purge button — one key holds one English
+                    // string, so a shared key could not serve both casings.
                     text: (steamSoftStopped && Settings.hardware.steamTwoTapStop)
-                          ? TranslationManager.translate("steam.label.purge", "Purge")
-                          : TranslationManager.translate("steam.label.stop", "Stop")
+                          ? TranslationManager.translate("steam.button.purge", "PURGE")
+                          : TranslationManager.translate("steam.button.stop", "STOP")
                     color: Theme.primaryContrastColor
                     font.pixelSize: Theme.scaled(24)
                     font.weight: Font.Bold
-                    // The all-caps look is applied at render time, not baked into the
-                    // source strings. Translators supply natural case, scripts without a
-                    // case distinction are left alone, and the key stays shareable with
-                    // the sentence-case Purge button in the same row.
-                    font.capitalization: Font.AllUppercase
                     Accessible.ignored: true
                 }
 

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -1016,6 +1016,7 @@ Page {
             // at the shorter end of the supported aspect range. The row sits outside
             // the timer/chart view switch, so Purge is available in both views.
             RowLayout {
+                id: liveActionRow
                 Layout.alignment: Qt.AlignHCenter
                 // Mirrors the two children's own conditions rather than reading their
                 // .visible. A `visible` read returns EFFECTIVE visibility, so once this
@@ -1025,13 +1026,19 @@ Page {
                 visible: isSteaming || DE1Device.isHeadless
                 spacing: Theme.spacingMedium
 
+                // One source of truth for the button box, so the two can never drift
+                // apart again. They are peer actions in a shared row and read as
+                // mismatched the moment their boxes differ.
+                readonly property int buttonWidth: Theme.scaled(200)
+                readonly property int buttonHeight: Theme.scaled(60)
+
             // Purge button on the live steaming view — stops steam and triggers
             // the DE1 steam-wand purge.
             Rectangle {
                 id: livePurgeButton
                 visible: isSteaming
-                Layout.preferredWidth: Theme.scaled(150)
-                Layout.preferredHeight: Theme.scaled(60)  // matches steamStopButton so the row aligns
+                Layout.preferredWidth: liveActionRow.buttonWidth
+                Layout.preferredHeight: liveActionRow.buttonHeight
                 radius: Theme.buttonRadius
                 color: livePurgeMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
 
@@ -1055,7 +1062,14 @@ Page {
                 Tr {
                     anchors.centerIn: parent
                     key: "steam.label.purge"; fallback: "Purge"
-                    color: Theme.primaryContrastColor; font: Theme.bodyFont
+                    color: Theme.primaryContrastColor
+                    // Matches steamStopButton: same box, same casing, so the pair reads
+                    // as one row. Capitalised at render time for the same reason it is
+                    // on that button — the key stays sentence-case and shared with the
+                    // settings-view Purge, and case-less scripts are left alone.
+                    font.pixelSize: Theme.scaled(24)
+                    font.weight: Font.Bold
+                    font.capitalization: Font.AllUppercase
                     Accessible.ignored: true
                 }
 
@@ -1068,8 +1082,8 @@ Page {
             // When off, a single tap stops and triggers the hose purge.
             Rectangle {
                 id: steamStopButton
-                Layout.preferredWidth: Theme.scaled(200)
-                Layout.preferredHeight: Theme.scaled(60)
+                Layout.preferredWidth: liveActionRow.buttonWidth
+                Layout.preferredHeight: liveActionRow.buttonHeight
                 visible: DE1Device.isHeadless
                 radius: Theme.cardRadius
                 color: stopTapHandler.isPressed

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -1040,15 +1040,11 @@ Page {
                 Layout.preferredWidth: liveActionRow.buttonWidth
                 Layout.preferredHeight: liveActionRow.buttonHeight
                 radius: Theme.buttonRadius
-                color: livePurgeMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                color: livePurgeTap.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
 
                 activeFocusOnTab: true
-                Accessible.role: Accessible.Button
-                Accessible.name: TranslationManager.translate("steam.accessible.purge", "Purge the steam wand")
-                Accessible.focusable: true
-                Accessible.onPressAction: livePurgeMa.clicked(null)
-                Keys.onReturnPressed: { livePurgeMa.clicked(null); event.accepted = true }
-                Keys.onSpacePressed:  { livePurgeMa.clicked(null); event.accepted = true }
+                Keys.onReturnPressed: { livePurgeTap.accessibleClicked(); event.accepted = true }
+                Keys.onSpacePressed:  { livePurgeTap.accessibleClicked(); event.accepted = true }
                 KeyNavigation.tab: steamStopButton.visible ? steamStopButton
                                  : (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : livePurgeButton)
                 // The flow slider lives inside the timer-view subtree, so it is not a
@@ -1070,7 +1066,17 @@ Page {
                     Accessible.ignored: true
                 }
 
-                MouseArea { id: livePurgeMa; anchors.fill: parent; onClicked: DE1Device.requestIdle() }
+                // Using TapHandler for better touch responsiveness. Announce-first also
+                // matters more here than on a navigation control: this stops the steam
+                // and fires the wand purge, so a raw MouseArea would trigger it on the
+                // exploratory first touch instead of announcing itself.
+                AccessibleTapHandler {
+                    id: livePurgeTap
+                    anchors.fill: parent
+                    accessibleName: TranslationManager.translate("steam.accessible.purge", "Purge the steam wand")
+                    accessibleItem: livePurgeButton
+                    onAccessibleClicked: DE1Device.requestIdle()
+                }
             }
 
             // Stop button for headless machines.
@@ -1545,24 +1551,29 @@ Page {
                         visible: !steamPage.currentPitcherDisabled
                         Item { Layout.fillWidth: true }
                         Rectangle {
+                            id: settingsPurgeButton
                             Layout.preferredWidth: Theme.scaled(150)
                             Layout.preferredHeight: Theme.scaled(48)
                             radius: Theme.buttonRadius
-                            color: purgeMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                            color: purgeTap.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                             activeFocusOnTab: true
-                            Accessible.role: Accessible.Button
-                            Accessible.name: TranslationManager.translate("steam.accessible.purge", "Purge the steam wand")
-                            Accessible.focusable: true
-                            Accessible.onPressAction: purgeMa.clicked(null)
-                            Keys.onReturnPressed: { purgeMa.clicked(null); event.accepted = true }
-                            Keys.onSpacePressed:  { purgeMa.clicked(null); event.accepted = true }
+                            Keys.onReturnPressed: { purgeTap.accessibleClicked(); event.accepted = true }
+                            Keys.onSpacePressed:  { purgeTap.accessibleClicked(); event.accepted = true }
                             Tr {
                                 anchors.centerIn: parent
                                 key: "steam.label.purge"; fallback: "Purge"
                                 color: Theme.primaryContrastColor; font: Theme.bodyFont
                                 Accessible.ignored: true
                             }
-                            MouseArea { id: purgeMa; anchors.fill: parent; onClicked: DE1Device.requestIdle() }
+                            // Using TapHandler for better touch responsiveness. Announce-first
+                            // keeps an exploratory touch from firing the wand purge.
+                            AccessibleTapHandler {
+                                id: purgeTap
+                                anchors.fill: parent
+                                accessibleName: TranslationManager.translate("steam.accessible.purge", "Purge the steam wand")
+                                accessibleItem: settingsPurgeButton
+                                onAccessibleClicked: DE1Device.requestIdle()
+                            }
                         }
                     }
 

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -252,6 +252,24 @@ Page {
         }
     }
 
+    // --- Live-view action row focus targets ----------------------------------
+    // Purge and Stop share one row, and each appears independently: Purge only
+    // while steaming, Stop only on a headless machine. Every tab/backtab handler
+    // that enters the row has to pick the first/last button that is actually
+    // showing, so the choice lives here once instead of as a ternary repeated at
+    // each call site. Both return null when the row is empty; callers fall back.
+    function firstLiveActionButton() {
+        if (livePurgeButton.visible) return livePurgeButton
+        if (steamStopButton.visible) return steamStopButton
+        return null
+    }
+
+    function lastLiveActionButton() {
+        if (steamStopButton.visible) return steamStopButton
+        if (livePurgeButton.visible) return livePurgeButton
+        return null
+    }
+
     // --- Weight-scaled steaming (calibrated presets) -------------------------
     // Thin QML wrappers over the single source of truth in SettingsBrew, so the
     // scaling math, bounds, clamp, and the weight-timing toggle live in one place.
@@ -539,19 +557,21 @@ Page {
                                 event.accepted = true
                             }
                             Keys.onTabPressed: {
+                                var next = steamPage.firstLiveActionButton()
                                 if (index < livePresetRepeater.count - 1)
                                     livePresetRepeater.itemAt(index + 1).forceActiveFocus()
-                                else if (steamStopButton.visible)
-                                    steamStopButton.forceActiveFocus()
+                                else if (next)
+                                    next.forceActiveFocus()
                                 else
                                     livePresetRepeater.itemAt(0).forceActiveFocus()
                                 event.accepted = true
                             }
                             Keys.onBacktabPressed: {
+                                var prev = steamPage.lastLiveActionButton()
                                 if (index > 0)
                                     livePresetRepeater.itemAt(index - 1).forceActiveFocus()
-                                else if (steamStopButton.visible)
-                                    steamStopButton.forceActiveFocus()
+                                else if (prev)
+                                    prev.forceActiveFocus()
                                 else
                                     livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
                                 event.accepted = true
@@ -632,13 +652,15 @@ Page {
                     Keys.onReturnPressed: { viewToggleMa.accessibleClicked(); event.accepted = true }
                     Keys.onSpacePressed:  { viewToggleMa.accessibleClicked(); event.accepted = true }
                     Keys.onTabPressed: {
+                        var next = steamPage.firstLiveActionButton()
                         if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(0).forceActiveFocus()
-                        else if (steamStopButton.visible) steamStopButton.forceActiveFocus()
+                        else if (next) next.forceActiveFocus()
                         event.accepted = true
                     }
                     Keys.onBacktabPressed: {
+                        var prev = steamPage.lastLiveActionButton()
                         if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
-                        else if (steamStopButton.visible) steamStopButton.forceActiveFocus()
+                        else if (prev) prev.forceActiveFocus()
                         event.accepted = true
                     }
 
@@ -911,9 +933,8 @@ Page {
                     value: Settings.brew.steamFlow
                     displayText: flowToDisplay(value)
                     accessibleName: TranslationManager.translate("steam.label.steamFlow", "Steam Flow")
-                    KeyNavigation.tab: livePurgeButton.visible ? livePurgeButton
-                                     : (steamStopButton.visible ? steamStopButton
-                                     : (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : steamingFlowSlider))
+                    KeyNavigation.tab: steamPage.firstLiveActionButton()
+                                       ?? (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : steamingFlowSlider)
                     KeyNavigation.backtab: increaseTimeBtn
                     // BLE write deferred to commit (PR #782 pattern). The single
                     // commit-time MMR write is reliable because setSteamFlowImmediate
@@ -989,14 +1010,19 @@ Page {
                 }
             }
 
-            // Purge and Stop share one row. Both are terminal actions on the live
-            // steaming view, and stacking them cost a full button row of height on a
-            // page that already overflows its 600-unit reference budget. Sitting
-            // outside the timer/chart view switch, this row is also why Purge is now
-            // reachable from the chart view — it used to be timer-view only.
+            // Purge and Stop share one row. This view has no Flickable — the only one
+            // on the page wraps the settings editor — so content past the bottom edge
+            // clips instead of scrolling, and a second stacked button row did not fit
+            // at the shorter end of the supported aspect range. The row sits outside
+            // the timer/chart view switch, so Purge is available in both views.
             RowLayout {
                 Layout.alignment: Qt.AlignHCenter
-                visible: livePurgeButton.visible || steamStopButton.visible
+                // Mirrors the two children's own conditions rather than reading their
+                // .visible. A `visible` read returns EFFECTIVE visibility, so once this
+                // row hid itself both children would read false forever and the binding
+                // could never re-arm — the row would latch off permanently the first
+                // time the page existed while not steaming.
+                visible: isSteaming || DE1Device.isHeadless
                 spacing: Theme.spacingMedium
 
             // Purge button on the live steaming view — stops steam and triggers
@@ -1005,7 +1031,7 @@ Page {
                 id: livePurgeButton
                 visible: isSteaming
                 Layout.preferredWidth: Theme.scaled(150)
-                Layout.preferredHeight: Theme.scaled(60)
+                Layout.preferredHeight: Theme.scaled(60)  // matches steamStopButton so the row aligns
                 radius: Theme.buttonRadius
                 color: livePurgeMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
 
@@ -1018,7 +1044,13 @@ Page {
                 Keys.onSpacePressed:  { livePurgeMa.clicked(null); event.accepted = true }
                 KeyNavigation.tab: steamStopButton.visible ? steamStopButton
                                  : (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : livePurgeButton)
-                KeyNavigation.backtab: steamingFlowSlider
+                // The flow slider lives inside the timer-view subtree, so it is not a
+                // valid backtab target in chart view — fall back to the preset pills,
+                // which are shared by both views.
+                KeyNavigation.backtab: steamViewMode === "timer" ? steamingFlowSlider
+                                     : (livePresetRepeater.count > 0
+                                        ? livePresetRepeater.itemAt(livePresetRepeater.count - 1)
+                                        : livePurgeButton)
 
                 Tr {
                     anchors.centerIn: parent
@@ -1049,16 +1081,25 @@ Page {
                 activeFocusOnTab: true
                 Keys.onReturnPressed: { stopTapHandler.accessibleClicked(); event.accepted = true }
                 Keys.onSpacePressed:  { stopTapHandler.accessibleClicked(); event.accepted = true }
+                // Only swallow the key when there is somewhere to send focus. Accepting
+                // it unconditionally traps focus on this button when no preset pill
+                // exists to receive it.
                 Keys.onTabPressed: {
-                    if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(0).forceActiveFocus()
-                    event.accepted = true
+                    if (livePresetRepeater.count > 0) {
+                        livePresetRepeater.itemAt(0).forceActiveFocus()
+                        event.accepted = true
+                    }
                 }
                 Keys.onBacktabPressed: {
-                    // Purge now sits immediately to the left in the shared action row,
-                    // so it is the natural backtab target whenever it is showing.
-                    if (livePurgeButton.visible) livePurgeButton.forceActiveFocus()
-                    else if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
-                    event.accepted = true
+                    // Purge precedes Stop in the shared action row, so it is the backtab
+                    // target whenever it is showing.
+                    if (livePurgeButton.visible) {
+                        livePurgeButton.forceActiveFocus()
+                        event.accepted = true
+                    } else if (livePresetRepeater.count > 0) {
+                        livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
+                        event.accepted = true
+                    }
                 }
 
                 Text {

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -881,30 +881,6 @@ Page {
                     }
                 }
 
-                // Purge button on the live steaming view — stops steam and triggers
-                // the DE1 steam-wand purge.
-                Rectangle {
-                    visible: isSteaming
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    width: Theme.scaled(150)
-                    height: Theme.scaled(48)
-                    radius: Theme.buttonRadius
-                    color: livePurgeMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
-                    activeFocusOnTab: true
-                    Accessible.role: Accessible.Button
-                    Accessible.name: TranslationManager.translate("steam.accessible.purge", "Purge the steam wand")
-                    Accessible.focusable: true
-                    Accessible.onPressAction: livePurgeMa.clicked(null)
-                    Keys.onReturnPressed: { livePurgeMa.clicked(null); event.accepted = true }
-                    Keys.onSpacePressed:  { livePurgeMa.clicked(null); event.accepted = true }
-                    Tr {
-                        anchors.centerIn: parent
-                        key: "steam.label.purge"; fallback: "Purge"
-                        color: Theme.primaryContrastColor; font: Theme.bodyFont
-                        Accessible.ignored: true
-                    }
-                    MouseArea { id: livePurgeMa; anchors.fill: parent; onClicked: DE1Device.requestIdle() }
-                }
             }
 
             Item { Layout.fillHeight: true }
@@ -935,7 +911,9 @@ Page {
                     value: Settings.brew.steamFlow
                     displayText: flowToDisplay(value)
                     accessibleName: TranslationManager.translate("steam.label.steamFlow", "Steam Flow")
-                    KeyNavigation.tab: steamStopButton.visible ? steamStopButton : (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : steamingFlowSlider)
+                    KeyNavigation.tab: livePurgeButton.visible ? livePurgeButton
+                                     : (steamStopButton.visible ? steamStopButton
+                                     : (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : steamingFlowSlider))
                     KeyNavigation.backtab: increaseTimeBtn
                     // BLE write deferred to commit (PR #782 pattern). The single
                     // commit-time MMR write is reliable because setSteamFlowImmediate
@@ -1011,13 +989,53 @@ Page {
                 }
             }
 
+            // Purge and Stop share one row. Both are terminal actions on the live
+            // steaming view, and stacking them cost a full button row of height on a
+            // page that already overflows its 600-unit reference budget. Sitting
+            // outside the timer/chart view switch, this row is also why Purge is now
+            // reachable from the chart view — it used to be timer-view only.
+            RowLayout {
+                Layout.alignment: Qt.AlignHCenter
+                visible: livePurgeButton.visible || steamStopButton.visible
+                spacing: Theme.spacingMedium
+
+            // Purge button on the live steaming view — stops steam and triggers
+            // the DE1 steam-wand purge.
+            Rectangle {
+                id: livePurgeButton
+                visible: isSteaming
+                Layout.preferredWidth: Theme.scaled(150)
+                Layout.preferredHeight: Theme.scaled(60)
+                radius: Theme.buttonRadius
+                color: livePurgeMa.pressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+
+                activeFocusOnTab: true
+                Accessible.role: Accessible.Button
+                Accessible.name: TranslationManager.translate("steam.accessible.purge", "Purge the steam wand")
+                Accessible.focusable: true
+                Accessible.onPressAction: livePurgeMa.clicked(null)
+                Keys.onReturnPressed: { livePurgeMa.clicked(null); event.accepted = true }
+                Keys.onSpacePressed:  { livePurgeMa.clicked(null); event.accepted = true }
+                KeyNavigation.tab: steamStopButton.visible ? steamStopButton
+                                 : (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : livePurgeButton)
+                KeyNavigation.backtab: steamingFlowSlider
+
+                Tr {
+                    anchors.centerIn: parent
+                    key: "steam.label.purge"; fallback: "Purge"
+                    color: Theme.primaryContrastColor; font: Theme.bodyFont
+                    Accessible.ignored: true
+                }
+
+                MouseArea { id: livePurgeMa; anchors.fill: parent; onClicked: DE1Device.requestIdle() }
+            }
+
             // Stop button for headless machines.
             // When Settings.hardware.steamTwoTapStop is on (default off), behaves as a
             // two-stage button: first tap soft-stops, second tap purges.
             // When off, a single tap stops and triggers the hose purge.
             Rectangle {
                 id: steamStopButton
-                Layout.alignment: Qt.AlignHCenter
                 Layout.preferredWidth: Theme.scaled(200)
                 Layout.preferredHeight: Theme.scaled(60)
                 visible: DE1Device.isHeadless
@@ -1036,7 +1054,10 @@ Page {
                     event.accepted = true
                 }
                 Keys.onBacktabPressed: {
-                    if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
+                    // Purge now sits immediately to the left in the shared action row,
+                    // so it is the natural backtab target whenever it is showing.
+                    if (livePurgeButton.visible) livePurgeButton.forceActiveFocus()
+                    else if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
                     event.accepted = true
                 }
 
@@ -1075,6 +1096,8 @@ Page {
                     }
                 }
             }
+
+            } // end Purge + Stop action row
 
             Item { Layout.preferredHeight: Theme.scaled(20) }
         }

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -1120,12 +1120,14 @@ Page {
 
                 Tr {
                     anchors.centerIn: parent
-                    // Same key and same type treatment as steamStopButton beside it, so
-                    // the pair reads as one row.
-                    key: "steam.button.purge"; fallback: "PURGE"
+                    // Same key and same type treatment as steamStopButton beside it, so the
+                    // pair reads as one row. steam.label.purge, not steam.button.purge —
+                    // see the note on that button for why the latter is poisoned.
+                    key: "steam.label.purge"; fallback: "Purge"
                     color: Theme.primaryContrastColor
                     font.pixelSize: Theme.scaled(24)
                     font.weight: Font.Bold
+                    font.capitalization: Font.AllUppercase
                     Accessible.ignored: true
                 }
 
@@ -1190,16 +1192,23 @@ Page {
                 Text {
                     id: stopButtonText
                     anchors.centerIn: parent
-                    // steam.button.* carries the shouted label, matching espresso/flush/
-                    // hotwater/descaling/transport. The sentence-case steam.label.purge
-                    // stays on the settings-view Purge button — one key holds one English
-                    // string, so a shared key could not serve both casings.
+                    // DO NOT use steam.button.purge here. It labelled this button's
+                    // second-press state back when that state meant "stop", so the shipped
+                    // community translations for it literally say Stop — de "Stopp",
+                    // da "Stop", ar "إيقاف". Only steam.label.purge is translated as a
+                    // purge: de "Reinigen", fr "Purger", da "Rens", ar "تنظيف".
+                    // steam.button.stop is correct and matches espresso/flush/hotwater/
+                    // descaling/transport.
                     text: (steamSoftStopped && Settings.hardware.steamTwoTapStop)
-                          ? TranslationManager.translate("steam.button.purge", "PURGE")
+                          ? TranslationManager.translate("steam.label.purge", "Purge")
                           : TranslationManager.translate("steam.button.stop", "STOP")
                     color: Theme.primaryContrastColor
                     font.pixelSize: Theme.scaled(24)
                     font.weight: Font.Bold
+                    // The shouted look is applied here rather than baked into the source
+                    // strings, so one sentence-case purge key can serve this button and the
+                    // settings-view one. Case-less scripts (ar) are unaffected.
+                    font.capitalization: Font.AllUppercase
                     Accessible.ignored: true
                 }
 

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -1105,10 +1105,21 @@ Page {
                 Text {
                     id: stopButtonText
                     anchors.centerIn: parent
-                    text: (steamSoftStopped && Settings.hardware.steamTwoTapStop) ? "PURGE" : "STOP"
+                    // Reuses steam.label.purge rather than minting a second purge key:
+                    // the registry maps key -> one English string, so the same key with a
+                    // different fallback would oscillate between whichever site rendered
+                    // last (see scripts/check_translation_key_conflicts.py).
+                    text: (steamSoftStopped && Settings.hardware.steamTwoTapStop)
+                          ? TranslationManager.translate("steam.label.purge", "Purge")
+                          : TranslationManager.translate("steam.label.stop", "Stop")
                     color: Theme.primaryContrastColor
                     font.pixelSize: Theme.scaled(24)
                     font.weight: Font.Bold
+                    // The all-caps look is applied at render time, not baked into the
+                    // source strings. Translators supply natural case, scripts without a
+                    // case distinction are left alone, and the key stays shareable with
+                    // the sentence-case Purge button in the same row.
+                    font.capitalization: Font.AllUppercase
                     Accessible.ignored: true
                 }
 

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -270,6 +270,37 @@ Page {
         return null
     }
 
+    // An "Off" preset's pill is hidden while steaming, and KeyNavigation silently
+    // refuses to focus an invisible target — Tab then does nothing at all, because
+    // the pills navigate via Keys handlers and so offer no chain to fall through to.
+    // Never target a pill by raw index; ask for one that is actually showing.
+    function firstVisiblePresetPill() {
+        for (var i = 0; i < livePresetRepeater.count; i++) {
+            var pill = livePresetRepeater.itemAt(i)
+            if (pill && pill.visible) return pill
+        }
+        return null
+    }
+
+    function lastVisiblePresetPill() {
+        for (var i = livePresetRepeater.count - 1; i >= 0; i--) {
+            var pill = livePresetRepeater.itemAt(i)
+            if (pill && pill.visible) return pill
+        }
+        return null
+    }
+
+    // What follows the preset pills going forward. The timer view leads into the
+    // -5s/+5s pair (which hide during heating and puffing, leaving the flow slider
+    // as the first stop); the chart view has neither, so focus goes straight to the
+    // action row. Without this the pills jumped over the whole timer column and the
+    // -5s/+5s buttons were reachable only by Shift+Tab.
+    function firstLiveControlAfterPresets() {
+        if (steamViewMode === "timer")
+            return decreaseTimeBtn.visible ? decreaseTimeBtn : steamingFlowSlider
+        return firstLiveActionButton()
+    }
+
     // --- Weight-scaled steaming (calibrated presets) -------------------------
     // Thin QML wrappers over the single source of truth in SettingsBrew, so the
     // scaling math, bounds, clamp, and the weight-timing toggle live in one place.
@@ -548,33 +579,49 @@ Page {
 
                             Keys.onReturnPressed: { livePitcherMa.clicked(null); event.accepted = true }
                             Keys.onSpacePressed:  { livePitcherMa.clicked(null); event.accepted = true }
+                            // Step over hidden ("Off") pills the same way Tab does, rather
+                            // than parking focus on one the user cannot see.
                             Keys.onLeftPressed: {
-                                if (index > 0) livePresetRepeater.itemAt(index - 1).forceActiveFocus()
+                                for (var i = index - 1; i >= 0; i--) {
+                                    var prior = livePresetRepeater.itemAt(i)
+                                    if (prior && prior.visible) { prior.forceActiveFocus(); break }
+                                }
                                 event.accepted = true
                             }
                             Keys.onRightPressed: {
-                                if (index < livePresetRepeater.count - 1) livePresetRepeater.itemAt(index + 1).forceActiveFocus()
+                                for (var j = index + 1; j < livePresetRepeater.count; j++) {
+                                    var candidate = livePresetRepeater.itemAt(j)
+                                    if (candidate && candidate.visible) { candidate.forceActiveFocus(); break }
+                                }
                                 event.accepted = true
                             }
                             Keys.onTabPressed: {
-                                var next = steamPage.firstLiveActionButton()
-                                if (index < livePresetRepeater.count - 1)
-                                    livePresetRepeater.itemAt(index + 1).forceActiveFocus()
-                                else if (next)
-                                    next.forceActiveFocus()
-                                else
-                                    livePresetRepeater.itemAt(0).forceActiveFocus()
-                                event.accepted = true
+                                var nextPill = null
+                                for (var i = index + 1; i < livePresetRepeater.count && !nextPill; i++) {
+                                    var candidate = livePresetRepeater.itemAt(i)
+                                    if (candidate && candidate.visible) nextPill = candidate
+                                }
+                                var target = nextPill
+                                             ?? steamPage.firstLiveControlAfterPresets()
+                                             ?? steamPage.firstVisiblePresetPill()
+                                if (target) {
+                                    target.forceActiveFocus()
+                                    event.accepted = true
+                                }
                             }
                             Keys.onBacktabPressed: {
-                                var prev = steamPage.lastLiveActionButton()
-                                if (index > 0)
-                                    livePresetRepeater.itemAt(index - 1).forceActiveFocus()
-                                else if (prev)
-                                    prev.forceActiveFocus()
-                                else
-                                    livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
-                                event.accepted = true
+                                var prevPill = null
+                                for (var j = index - 1; j >= 0 && !prevPill; j--) {
+                                    var prior = livePresetRepeater.itemAt(j)
+                                    if (prior && prior.visible) prevPill = prior
+                                }
+                                var back = prevPill
+                                           ?? steamPage.lastLiveActionButton()
+                                           ?? steamPage.lastVisiblePresetPill()
+                                if (back) {
+                                    back.forceActiveFocus()
+                                    event.accepted = true
+                                }
                             }
 
                             Text {
@@ -652,16 +699,20 @@ Page {
                     Keys.onReturnPressed: { viewToggleMa.accessibleClicked(); event.accepted = true }
                     Keys.onSpacePressed:  { viewToggleMa.accessibleClicked(); event.accepted = true }
                     Keys.onTabPressed: {
-                        var next = steamPage.firstLiveActionButton()
-                        if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(0).forceActiveFocus()
-                        else if (next) next.forceActiveFocus()
-                        event.accepted = true
+                        var next = steamPage.firstVisiblePresetPill()
+                                   ?? steamPage.firstLiveControlAfterPresets()
+                        if (next) {
+                            next.forceActiveFocus()
+                            event.accepted = true
+                        }
                     }
                     Keys.onBacktabPressed: {
-                        var prev = steamPage.lastLiveActionButton()
-                        if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
-                        else if (prev) prev.forceActiveFocus()
-                        event.accepted = true
+                        var prev = steamPage.lastVisiblePresetPill()
+                                   ?? steamPage.lastLiveActionButton()
+                        if (prev) {
+                            prev.forceActiveFocus()
+                            event.accepted = true
+                        }
                     }
 
                     Image {
@@ -790,7 +841,10 @@ Page {
                         Keys.onReturnPressed: { decreaseMouseArea.clicked(null); event.accepted = true }
                         Keys.onSpacePressed:  { decreaseMouseArea.clicked(null); event.accepted = true }
                         KeyNavigation.tab: increaseTimeBtn
-                        KeyNavigation.backtab: steamingFlowSlider
+                        // Back to the pills, closing the loop. This used to point at the
+                        // flow slider, which sits AFTER this button going forward, so the
+                        // chain doubled back on itself and never reached the pills.
+                        KeyNavigation.backtab: steamPage.lastVisiblePresetPill() ?? steamingFlowSlider
 
                         Text {
                             anchors.centerIn: parent
@@ -934,8 +988,13 @@ Page {
                     displayText: flowToDisplay(value)
                     accessibleName: TranslationManager.translate("steam.label.steamFlow", "Steam Flow")
                     KeyNavigation.tab: steamPage.firstLiveActionButton()
-                                       ?? (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : steamingFlowSlider)
-                    KeyNavigation.backtab: increaseTimeBtn
+                                       ?? steamPage.firstVisiblePresetPill()
+                                       ?? steamingFlowSlider
+                    // +5s hides during heating and puffing; fall back to the pills rather
+                    // than at an invisible target, which KeyNavigation refuses to focus.
+                    KeyNavigation.backtab: increaseTimeBtn.visible
+                                           ? increaseTimeBtn
+                                           : (steamPage.lastVisiblePresetPill() ?? steamingFlowSlider)
                     // BLE write deferred to commit (PR #782 pattern). The single
                     // commit-time MMR write is reliable because setSteamFlowImmediate
                     // routes through writeMMRVerified — write, read-back, retry on
@@ -1026,9 +1085,10 @@ Page {
                 visible: isSteaming || DE1Device.isHeadless
                 spacing: Theme.spacingMedium
 
-                // One source of truth for the button box, so the two can never drift
-                // apart again. They are peer actions in a shared row and read as
-                // mismatched the moment their boxes differ.
+                // One source of truth for the button BOX, so the two cannot drift apart
+                // on size. Radius and border are deliberately not shared: Stop keeps the
+                // heavier cardRadius and its contrast border to stay visually dominant as
+                // the stop control, while Purge stays a plain secondary button.
                 readonly property int buttonWidth: Theme.scaled(200)
                 readonly property int buttonHeight: Theme.scaled(60)
 
@@ -1043,17 +1103,20 @@ Page {
                 color: livePurgeTap.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
 
                 activeFocusOnTab: true
+                // livePurgeTap carries role/name/focusable, so this Rectangle must step
+                // out of the accessibility tree rather than sit in it unnamed.
+                Accessible.ignored: true
                 Keys.onReturnPressed: { livePurgeTap.accessibleClicked(); event.accepted = true }
                 Keys.onSpacePressed:  { livePurgeTap.accessibleClicked(); event.accepted = true }
-                KeyNavigation.tab: steamStopButton.visible ? steamStopButton
-                                 : (livePresetRepeater.count > 0 ? livePresetRepeater.itemAt(0) : livePurgeButton)
+                KeyNavigation.tab: steamStopButton.visible
+                                   ? steamStopButton
+                                   : (steamPage.firstVisiblePresetPill() ?? livePurgeButton)
                 // The flow slider lives inside the timer-view subtree, so it is not a
                 // valid backtab target in chart view — fall back to the preset pills,
                 // which are shared by both views.
-                KeyNavigation.backtab: steamViewMode === "timer" ? steamingFlowSlider
-                                     : (livePresetRepeater.count > 0
-                                        ? livePresetRepeater.itemAt(livePresetRepeater.count - 1)
-                                        : livePurgeButton)
+                KeyNavigation.backtab: steamViewMode === "timer"
+                                       ? steamingFlowSlider
+                                       : (steamPage.lastVisiblePresetPill() ?? livePurgeButton)
 
                 Tr {
                     anchors.centerIn: parent
@@ -1066,10 +1129,12 @@ Page {
                     Accessible.ignored: true
                 }
 
-                // Using TapHandler for better touch responsiveness. Announce-first also
-                // matters more here than on a navigation control: this stops the steam
-                // and fires the wand purge, so a raw MouseArea would trigger it on the
-                // exploratory first touch instead of announcing itself.
+                // Using TapHandler for better touch responsiveness. It also brings
+                // announce-first, which matters more here than on a navigation control:
+                // this stops the steam and fires the wand purge. Under a screen reader
+                // (AccessibilityManager.enabled) a raw MouseArea would fire on the
+                // exploratory first touch, where this announces and waits for a
+                // confirming second tap. In normal mode both activate on release.
                 AccessibleTapHandler {
                     id: livePurgeTap
                     anchors.fill: parent
@@ -1096,25 +1161,28 @@ Page {
                 border.width: Theme.scaled(2)
 
                 activeFocusOnTab: true
+                // stopTapHandler carries role/name/focusable, so this Rectangle must step
+                // out of the accessibility tree rather than sit in it unnamed.
+                Accessible.ignored: true
                 Keys.onReturnPressed: { stopTapHandler.accessibleClicked(); event.accepted = true }
                 Keys.onSpacePressed:  { stopTapHandler.accessibleClicked(); event.accepted = true }
                 // Only swallow the key when there is somewhere to send focus. Accepting
                 // it unconditionally traps focus on this button when no preset pill
                 // exists to receive it.
                 Keys.onTabPressed: {
-                    if (livePresetRepeater.count > 0) {
-                        livePresetRepeater.itemAt(0).forceActiveFocus()
+                    var next = steamPage.firstVisiblePresetPill()
+                    if (next) {
+                        next.forceActiveFocus()
                         event.accepted = true
                     }
                 }
                 Keys.onBacktabPressed: {
                     // Purge precedes Stop in the shared action row, so it is the backtab
                     // target whenever it is showing.
-                    if (livePurgeButton.visible) {
-                        livePurgeButton.forceActiveFocus()
-                        event.accepted = true
-                    } else if (livePresetRepeater.count > 0) {
-                        livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
+                    var back = livePurgeButton.visible ? livePurgeButton
+                                                       : steamPage.lastVisiblePresetPill()
+                    if (back) {
+                        back.forceActiveFocus()
                         event.accepted = true
                     }
                 }
@@ -1468,7 +1536,11 @@ Page {
                             border.width: 1
 
                             activeFocusOnTab: true
-                            KeyNavigation.tab: durationSlider
+                            // Its AccessibleTapHandler carries role/name/focusable, so this
+                            // Rectangle must step out of the accessibility tree rather than
+                            // sit in it unnamed.
+                            Accessible.ignored: true
+                            KeyNavigation.tab: settingsPurgeButton.visible ? settingsPurgeButton : durationSlider
                             KeyNavigation.backtab: pitcherRepeater.count > 0
                                 ? pitcherRepeater.itemAt(pitcherRepeater.count - 1).focusTarget
                                 : durationSlider
@@ -1557,6 +1629,14 @@ Page {
                             radius: Theme.buttonRadius
                             color: purgeTap.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                             activeFocusOnTab: true
+                            // purgeTap carries role/name/focusable, so this Rectangle must
+                            // step out of the accessibility tree rather than sit in it unnamed.
+                            Accessible.ignored: true
+                            // Sits between the add-preset button and the duration slider in
+                            // reading order. It was previously in no tab chain at all — both
+                            // neighbours pointed straight at each other, past this button.
+                            KeyNavigation.tab: durationSlider
+                            KeyNavigation.backtab: addPitcherButton
                             Keys.onReturnPressed: { purgeTap.accessibleClicked(); event.accepted = true }
                             Keys.onSpacePressed:  { purgeTap.accessibleClicked(); event.accepted = true }
                             Tr {
@@ -1565,8 +1645,10 @@ Page {
                                 color: Theme.primaryContrastColor; font: Theme.bodyFont
                                 Accessible.ignored: true
                             }
-                            // Using TapHandler for better touch responsiveness. Announce-first
-                            // keeps an exploratory touch from firing the wand purge.
+                            // Using TapHandler for better touch responsiveness. Under a screen
+                            // reader it also announces on the first touch and waits for a
+                            // confirming second tap, rather than firing the wand purge on an
+                            // exploratory one. In normal mode both activate on release.
                             AccessibleTapHandler {
                                 id: purgeTap
                                 anchors.fill: parent
@@ -1606,7 +1688,7 @@ Page {
                             valueColor: Theme.primaryColor
                             accessibleName: TranslationManager.translate("steam.label.duration", "Duration")
                             KeyNavigation.tab: flowSlider
-                            KeyNavigation.backtab: addPitcherButton
+                            KeyNavigation.backtab: settingsPurgeButton.visible ? settingsPurgeButton : addPitcherButton
                             onValueModified: function(newValue) {
                                 durationSlider.value = newValue
                                 Settings.brew.steamTimeout = newValue


### PR DESCRIPTION
## The problem

The live steaming view overflowed the bottom of the screen and the STOP button was cut in half.

The page is a `ColumnLayout` with `anchors.fill: parent`, no `Flickable` and no clipping. Once its children's minimum heights exceed the parent, Qt lays out at minimum and the rest runs off the bottom. STOP is the last item, so STOP is what got lost — and on a headless machine that is the only in-app way to stop steaming.

Not a window-size bug: `Theme.scale = min(width/960, height/600)` scales everything uniformly, so the ratio of content to available height never changes. The page was simply over budget against its own 960x600 reference — roughly 536 units required against 440 available (600 less two 80-unit page margins). The two `Item { Layout.fillHeight: true }` spacers were already fully collapsed.

## The fix

Purge and Stop now share one row instead of stacking, reclaiming 56 units (a 48-unit button plus 8 of spacing).

The row sits where STOP already lived — a sibling of **both** the timer and chart views — rather than pulling STOP into the timer view, since gating it behind `steamViewMode === "timer"` would have removed the stop control from the chart view entirely.

**Behaviour change:** Purge is now reachable from the chart view, where it was previously timer-view only. This falls out of the row's placement. Documented in the wiki manual.

## What review turned up

Three rounds of review found problems worth recording, since none are visible in the final diff.

**A latch that would have shipped.** The row's first visibility guard read `livePurgeButton.visible || steamStopButton.visible`. A `.visible` read returns *effective* visibility, and `visibleChanged` does not fire when only the explicit value flips — so once the row hid itself, both children read `false` forever and it never came back, taking STOP with it. It only bites when the page instance predates the steam session, so a quick look while already steaming shows nothing wrong. Confirmed against the Qt 6.11.1 `qml` runtime with a reduced case, then fixed to mirror the children's own conditions.

**The keyboard chain was broken in four places.** Adding a focusable control left the loop open on a GHC machine; `decreaseTimeBtn` backtabbed to the flow slider, which sits *after* it, so the chain doubled back and never closed; the -5s/+5s pair was unreachable going forward; and several targets pointed at pills that hide when a preset is "Off" — `KeyNavigation` silently refuses an invisible target, so Tab did nothing at all. All targets now route through visibility-aware helpers.

**A German mistranslation, introduced and then removed here.** Mid-branch the Purge label was moved onto `steam.button.purge` on the reasoning that keys should unify on whatever the shipped translations were made from. Sound principle, but the data was never checked: that key labelled the Stop button's second-press state back in December, when the state meant "stop", so its community translations say exactly that — de "Stopp", da "Stop", ar "إيقاف". A German user would have seen two adjacent buttons both reading "Stopp". The correct translations were already under `steam.label.purge` (de "Reinigen", fr "Purger", da "Rens", ar "تنظيف"), which both purge labels now use; the poisoned key carries a comment so it is not reached for again.

`steam.button.stop` keeps its own key — its translations are correct and it matches the five sibling operation pages. It was hardcoded English before this branch, so translating it is a real gain.

**Accessibility.** Both Purge buttons moved from a raw `MouseArea` to `AccessibleTapHandler`, so under a screen reader an exploratory first touch announces instead of firing the wand purge. All four handler-owning parents on the page now set `Accessible.ignored: true`, the pattern ACCESSIBILITY.md documents and `viewToggleBtn` already used — this also fixes `steamStopButton` and `addPitcherButton`, which had the same gap. The settings-view Purge button was in no tab chain at all and is now wired between the add-preset button and the duration slider.

## Rendered labels

| | Purge | Stop |
|---|---|---|
| en | PURGE | STOP |
| de | REINIGEN | STOPP |
| fr | PURGER | ARRÊTER |
| da | RENS | STOP |
| ar | تنظيف | إيقاف |

Casing is applied with `font.capitalization` rather than baked into the source strings, so one sentence-case purge key can serve both this button and the settings-view one.

## Testing

Full suite 85/85, no warnings. `check_translation_key_conflicts.py` clean across 3271 keys. `qmllint` warnings net down across the branch with no new types. Layout, and the German labels, confirmed in the running app.

Verified by reading rather than on device: the keyboard tab order, and whether VoiceOver announces the four buttons whose accessibility semantics changed.

## Follow-up, deliberately not in this PR

The page is back inside the frame but not with much margin. `anchors.bottomMargin: Theme.pageTopMargin` reserves 80 units "for bottom bar", far more than the bar needs; halving it buys another 40. A user who raises `timerSize` (adjustable to 120) can still push the page out.

## Wiki

Manual and FAQ updated in `Decenza.wiki@362778d`: a new "Live Steaming Screen" section, plus four references to a setting that no longer exists — the docs told users to enable "Headless — Single press to stop & purge" to get behaviour that is now the default, under a name they cannot find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)