### PR TITLE
Fix stale NDK fallback version in Android CI workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -86,9 +86,9 @@ jobs:
             fi
           done
 
-          # Fallback to known-good version for Qt 6.11.x
+          # Fallback to known-good version for Qt 6.11.x (matches local dev NDK)
           if [ -z "$QT_NDK_VERSION" ]; then
-            QT_NDK_VERSION="27.1.12297006"
+            QT_NDK_VERSION="27.2.12479018"
           fi
 
           echo "NDK version needed: $QT_NDK_VERSION"


### PR DESCRIPTION
## Summary
- The CI workflow's NDK auto-detect fallback pointed to `27.1.12297006`, a revision that doesn't correspond to what Qt 6.11.1 actually needs, and doesn't match the NDK version used for local dev (`27.2.12479018`).
- Primary detection (parsing `ANDROID_NDK_REVISION` out of Qt's own toolchain file) is unaffected and already matches dev — this only fixes the fallback path used if that detection fails.

## Test plan
- [x] Diff reviewed — single string literal change, no logic changes
- [ ] Next Android CI run should show correct NDK version regardless of whether auto-detect succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)