### PR TITLE
Bump tsnet to decenza-v1.94.1-4 (fixes ASan fork-safety crash)

### DIFF
--- a/cmake/tsnet.cmake
+++ b/cmake/tsnet.cmake
@@ -10,20 +10,20 @@
 # The pinned release + per-artifact SHA-256 come from the release manifest.json.
 # Bump TSNET_TAG (and the hashes) to adopt a newer libtailscale build.
 
-set(TSNET_TAG "decenza-v1.94.1-3" CACHE STRING "libtailscale prebuilt release tag")
+set(TSNET_TAG "decenza-v1.94.1-4" CACHE STRING "libtailscale prebuilt release tag")
 set(TSNET_BASE_URL "https://github.com/skialpine/libtailscale/releases/download/${TSNET_TAG}")
 set(TSNET_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/tsnet-${TSNET_TAG}")
 
 # Per-platform artifact + expected SHA-256 (from manifest.json).
 if(IOS)
     set(_tsnet_zip "libtailscale-ios.zip")
-    set(_tsnet_sha "b5916355d4c0df0bb6cf9a6c3848203c6fe8fb2614aaa6d7da741b10f3a93e21")
+    set(_tsnet_sha "f1c5477695563c9ef75b5e65ab14ed69675515861dc6766454bf6f0b4dde505b")
 elseif(ANDROID)
     set(_tsnet_zip "libtailscale-android.zip")
-    set(_tsnet_sha "295190b8e96520fc2cfec172a04b9aaf4502cc7424d782988c3c6e53759bde55")
+    set(_tsnet_sha "d345a7ef03854b9d5e1d6753c3dc463f27577e516492a3a144f406f217813bb1")
 elseif(APPLE)
     set(_tsnet_zip "libtailscale-macos.zip")
-    set(_tsnet_sha "fa2f525411e30514663ee85203e856e5a34fb2228817cbd540a075519bcaa2b8")
+    set(_tsnet_sha "642ed347483aded62b759419ff1740ec50d9d6c110fbebf51637caa41a146864")
 else()
     message(FATAL_ERROR "ENABLE_TSNET: no prebuilt libtailscale artifact for this platform yet "
                         "(supported: macOS, Android, iOS). Use Mode C (BYO URL) instead.")


### PR DESCRIPTION
## Summary
- Bumps `TSNET_TAG` in `cmake/tsnet.cmake` to `decenza-v1.94.1-4` and updates the three per-platform SHA-256 hashes.
- This release of the `libtailscale` fork adds `-tags ts_omit_ssh`, which fixes a real crash: `ipn/ipnlocal/ssh.go`'s `getSSHUsernames` shells out to `dscl` via `exec.Command`, wired up as a remotely-triggerable C2N handler (the Tailscale coordination server can invoke it at any time, independent of anything Decenza does locally). `fork()` without an immediate `exec()` inside a multithreaded, ASan-instrumented process — which local debug builds are by default — can corrupt ASan's allocator lock in the forked child. That produced exactly this crash: `EXC_BREAKPOINT`/`SIGKILL`, `"BUG IN CLIENT OF LIBPLATFORM: os_unfair_lock is corrupt"`, `"crashed on child side of fork pre-exec"`. Decenza never uses Tailscale SSH, so this tag removes the vulnerable path entirely (verified by diffing `strings` output of a build with vs. without the tag — the `"dscl"` string only appears without it).
- Also picks up 11 more `ts_omit_*` tags trimming tsnet features Decenza's Remote MCP connector (tsnet Mode A: embedded Tailscale + Funnel) never uses — identity federation, OAuth key resolution, DNS/MagicDNS, App Connectors, subnet routes, exit nodes, cloud-provider detection, the CLI update checker, the outbound proxy. Shrinks the macOS archive 55M → 49M unstripped.

Full rationale, what was investigated and ruled out (e.g. the `portlist`/`lsof` theory, which didn't hold up), and what must never be omitted (`ts_omit_serve` would break Funnel outright) is documented in the fork's new `CLAUDE.md` at `skialpine/libtailscale`.

## Test plan
- [x] Downloaded each of the three release artifacts (`libtailscale-macos.zip`, `libtailscale-ios.zip`, `libtailscale-android.zip`) and verified their SHA-256 matches the hash pinned in this diff.
- [x] Built `libtailscale.a` locally from the fork with the new tag set — compiles clean.
- [x] Confirmed via `strings` that the `dscl` exec call is present in an untagged build and absent with `ts_omit_ssh`.
- [ ] Build Decenza with this change (Qt Creator) and confirm the Remote MCP connector / Funnel still works end to end — flagging `ts_omit_dns` in particular as needing a real connect+Funnel runtime check per the fork's CLAUDE.md, since it touches real `net/dns/*` surface area architecturally verified as unused but not yet exercised live.