### PR TITLE
Name BLE service errors, and log the ones that reach the user

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -824,6 +824,7 @@ set(HEADERS
     src/ble/protocol/de1characteristics.h
     src/ble/protocol/decentscaleprotocol.h
     src/ble/blecapability.h
+    src/ble/bleserviceerror.h
     src/ble/blemanager.h
     src/ble/de1transport.h
     src/ble/de1device.h

--- a/src/ble/bleserviceerror.h
+++ b/src/ble/bleserviceerror.h
@@ -14,8 +14,10 @@
 // The scale transport already carried this mapping; this is that mapping made
 // shared, so both links describe the same failure the same way.
 //
-// No `default:` label on purpose: a new value in Qt's enum should fail the
-// -Wswitch build rather than silently fall through to a bare number.
+// No `default:` label on purpose: a new value in Qt's enum trips -Wswitch rather
+// than silently falling through to a bare number. That is an error on clang and
+// gcc, which build with -Werror; the MSVC arm is /W4 without /WX, so on Windows
+// it is a warning and the number-fallback below is what a new value would print.
 //
 // The return after the switch exists to satisfy control-flow analysis, not as
 // reachable behaviour, and is intentionally untested: producing a value outside

--- a/src/ble/bleserviceerror.h
+++ b/src/ble/bleserviceerror.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QLowEnergyService>
+#include <QString>
+
+// Human-readable name for a QLowEnergyService::ServiceError.
+//
+// Exists because the DE1 transport used to format the raw enum straight into a
+// user-facing dialog. A reporter hit "Service error: 5" and could not say what
+// it meant, and neither could the debug log they attached — that path emitted to
+// the UI without logging anything at all, so the one error they named was the
+// one thing the log could not show. 5 is CharacteristicReadError. See #1586.
+//
+// The scale transport already carried this mapping; this is that mapping made
+// shared, so both links describe the same failure the same way.
+//
+// No `default:` label on purpose: a new value in Qt's enum should fail the
+// -Wswitch build rather than silently fall through to a bare number.
+//
+// The return after the switch exists to satisfy control-flow analysis, not as
+// reachable behaviour, and is intentionally untested: producing a value outside
+// the enum is itself undefined behaviour (UBSan: "load of value N, which is not
+// a valid value for type QLowEnergyService::ServiceError"), so a test for it
+// passes under macOS's recovering-mode UBSan while failing the halting-mode
+// nightly Linux job.
+inline QString bleServiceErrorName(QLowEnergyService::ServiceError err) {
+    switch (err) {
+        case QLowEnergyService::NoError:
+            return QStringLiteral("NoError");
+        case QLowEnergyService::OperationError:
+            return QStringLiteral("OperationError");
+        case QLowEnergyService::CharacteristicWriteError:
+            return QStringLiteral("CharacteristicWriteError");
+        case QLowEnergyService::DescriptorWriteError:
+            return QStringLiteral("DescriptorWriteError");
+        case QLowEnergyService::UnknownError:
+            return QStringLiteral("UnknownError");
+        case QLowEnergyService::CharacteristicReadError:
+            return QStringLiteral("CharacteristicReadError");
+        case QLowEnergyService::DescriptorReadError:
+            return QStringLiteral("DescriptorReadError");
+    }
+    return QString::number(static_cast<int>(err));
+}

--- a/src/ble/bletransport.cpp
+++ b/src/ble/bletransport.cpp
@@ -1,5 +1,6 @@
 #include "bletransport.h"
 #include "blecapability.h"
+#include "bleserviceerror.h"
 #ifndef DECENZA_TESTING
 #include "blemanager.h"
 #endif
@@ -593,10 +594,17 @@ void BleTransport::onServiceDiscovered(const QBluetoothUuid& uuid) {
                                 emit queueDrained();
                         }
                     } else {
-                        emit errorOccurred(QString("Service error: %1").arg(error));
+                        // Log BEFORE emitting. This branch used to emit straight to
+                        // the UI with no log call at all, so a user could report
+                        // "Service error: 5" and the debug log they attached would
+                        // not contain it anywhere — the one error they named was
+                        // the one thing undiagnosable from the capture (#1586).
+                        const QString name = bleServiceErrorName(error);
+                        warn(QString("SERVICE ERROR: %1").arg(name));
+                        emit errorOccurred(QString("Service error: %1").arg(name));
                     }
                 } else {
-                    log(QString("Descriptor error (suppressed): %1").arg(static_cast<int>(error)));
+                    log(QString("Descriptor error (suppressed): %1").arg(bleServiceErrorName(error)));
                 }
             }, qc);
             log("Starting characteristic discovery for DE1 service");

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -51,9 +51,12 @@ void QtScaleBleTransport::log(const QString& message) {
 }
 
 void QtScaleBleTransport::warn(const QString& message) {
-    // Significant connection-priority events: WARN so they stand out in the
-    // user-attached debug.log (this feature is validated by reading those),
-    // and still flow to the scale log view via logMessage.
+    // Events a user-attached debug.log has to show: WARN so they stand out when
+    // that log is read after the fact (which is how this subsystem is
+    // validated), and still flow to the scale log view via logMessage.
+    // Originally scoped to connection-priority events; broadened when service
+    // errors joined it, since anything that reaches the user through error()
+    // needs to be findable in the log they send in (#1586).
     QString msg = QString("[BLE QtTransport] ") + message;
     qWarning().noquote() << msg;
     emit logMessage(msg);
@@ -722,9 +725,9 @@ void QtScaleBleTransport::onServiceError(QLowEnergyService::ServiceError err) {
     const QString errorName = bleServiceErrorName(err);
     // warn(), not log(): this reaches the user through error() the same way the
     // DE1 side reaches them through errorOccurred, and warn() is what makes an
-    // event visible in a user-attached debug.log (see the comment on warn()
-    // above). Leaving this at debug level would reproduce the #1586 defect on
-    // the scale link — a user-facing error absent from the log they send in.
+    // event visible in a user-attached debug.log. Leaving this at debug level
+    // would reproduce the #1586 defect on the scale link — a user-facing error
+    // absent from the log they send in.
     warn(QString("!!! SERVICE ERROR: %1 on %2 !!!").arg(errorName, serviceUuid));
     emit error(QString("Service error: %1").arg(errorName));
 }

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -1,5 +1,6 @@
 #include "qtscalebletransport.h"
 #include "../blecapability.h"
+#include "../bleserviceerror.h"
 #include "../blemanager.h"
 #include <QDateTime>
 #include <QDebug>
@@ -710,20 +711,15 @@ void QtScaleBleTransport::onServiceError(QLowEnergyService::ServiceError err) {
     QLowEnergyService* service = qobject_cast<QLowEnergyService*>(sender());
     QString serviceUuid = service ? service->serviceUuid().toString() : "unknown";
 
-    QString errorName;
-    switch (err) {
-        case QLowEnergyService::NoError: errorName = "NoError"; break;
-        case QLowEnergyService::OperationError: errorName = "OperationError"; break;
-        case QLowEnergyService::CharacteristicWriteError: errorName = "CharacteristicWriteError"; break;
-        case QLowEnergyService::DescriptorWriteError:
-            // CCCD write failures are non-fatal - some scales reject them but still notify
-            QT_TRANSPORT_LOG("DescriptorWriteError (non-fatal, scale may still send notifications)");
-            return;
-        case QLowEnergyService::UnknownError: errorName = "UnknownError"; break;
-        case QLowEnergyService::CharacteristicReadError: errorName = "CharacteristicReadError"; break;
-        case QLowEnergyService::DescriptorReadError: errorName = "DescriptorReadError"; break;
-        default: errorName = QString::number(static_cast<int>(err)); break;
+    if (err == QLowEnergyService::DescriptorWriteError) {
+        // CCCD write failures are non-fatal - some scales reject them but still notify
+        QT_TRANSPORT_LOG("DescriptorWriteError (non-fatal, scale may still send notifications)");
+        return;
     }
+
+    // Shared with the DE1 transport so both links name the same failure the same
+    // way (bleserviceerror.h, #1586).
+    const QString errorName = bleServiceErrorName(err);
     QT_TRANSPORT_LOG(QString("!!! SERVICE ERROR: %1 on %2 !!!").arg(errorName, serviceUuid));
     emit error(QString("Service error: %1").arg(errorName));
 }

--- a/src/ble/transport/qtscalebletransport.cpp
+++ b/src/ble/transport/qtscalebletransport.cpp
@@ -720,7 +720,12 @@ void QtScaleBleTransport::onServiceError(QLowEnergyService::ServiceError err) {
     // Shared with the DE1 transport so both links name the same failure the same
     // way (bleserviceerror.h, #1586).
     const QString errorName = bleServiceErrorName(err);
-    QT_TRANSPORT_LOG(QString("!!! SERVICE ERROR: %1 on %2 !!!").arg(errorName, serviceUuid));
+    // warn(), not log(): this reaches the user through error() the same way the
+    // DE1 side reaches them through errorOccurred, and warn() is what makes an
+    // event visible in a user-attached debug.log (see the comment on warn()
+    // above). Leaving this at debug level would reproduce the #1586 defect on
+    // the scale link — a user-facing error absent from the log they send in.
+    warn(QString("!!! SERVICE ERROR: %1 on %2 !!!").arg(errorName, serviceUuid));
     emit error(QString("Service error: %1").arg(errorName));
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -575,6 +575,11 @@ add_decenza_test(tst_profileupload
     mocks/MockTransport.h
 )
 
+# --- tst_bleserviceerror: QLowEnergyService::ServiceError name mapping (#1586) ---
+add_decenza_test(tst_bleserviceerror
+    tst_bleserviceerror.cpp
+)
+
 # --- tst_blefidelity: BLE encode round-trip for all built-in profiles ---
 add_decenza_test(tst_blefidelity
     tst_blefidelity.cpp

--- a/tests/tst_bleserviceerror.cpp
+++ b/tests/tst_bleserviceerror.cpp
@@ -1,0 +1,60 @@
+#include <QtTest>
+
+#include "ble/bleserviceerror.h"
+
+// Names for QLowEnergyService::ServiceError.
+//
+// The reason this is worth a test at all: a user reported "Service error: 5"
+// from the DE1 link and nobody — including the debug log they attached — could
+// say what 5 meant. The transport was formatting the raw enum into a dialog.
+// These cases pin the numeric values to their names so the mapping cannot drift
+// silently, and so the specific value from the report stays documented (#1586).
+class tst_BleServiceError : public QObject {
+    Q_OBJECT
+
+private slots:
+    void init() { QTest::failOnWarning(); }
+
+    void namesMatchQtEnumValues_data() {
+        QTest::addColumn<int>("rawValue");
+        QTest::addColumn<QString>("expectedName");
+
+        // Values are Qt's, asserted numerically on purpose: a user or a log only
+        // ever shows the number, so the number is what has to keep its meaning.
+        QTest::newRow("0 NoError") << 0 << "NoError";
+        QTest::newRow("1 OperationError") << 1 << "OperationError";
+        QTest::newRow("2 CharacteristicWriteError") << 2 << "CharacteristicWriteError";
+        QTest::newRow("3 DescriptorWriteError") << 3 << "DescriptorWriteError";
+        QTest::newRow("4 UnknownError") << 4 << "UnknownError";
+        QTest::newRow("5 CharacteristicReadError") << 5 << "CharacteristicReadError";
+        QTest::newRow("6 DescriptorReadError") << 6 << "DescriptorReadError";
+    }
+
+    void namesMatchQtEnumValues() {
+        QFETCH(int, rawValue);
+        QFETCH(QString, expectedName);
+        QCOMPARE(bleServiceErrorName(
+                     static_cast<QLowEnergyService::ServiceError>(rawValue)),
+                 expectedName);
+    }
+
+    // The value from issue #1586, called out separately so the report stays
+    // traceable to a name rather than living only in the data table above.
+    void reportedValueFiveIsCharacteristicReadError() {
+        QCOMPARE(bleServiceErrorName(QLowEnergyService::CharacteristicReadError),
+                 QStringLiteral("CharacteristicReadError"));
+        QCOMPARE(static_cast<int>(QLowEnergyService::CharacteristicReadError), 5);
+    }
+
+    // The number-fallback after the switch is deliberately NOT tested. Reaching
+    // it requires an out-of-range enum value, and merely loading one is
+    // undefined behaviour — UBSan flags it ("load of value 99, which is not a
+    // valid value for type QLowEnergyService::ServiceError"). macOS runs UBSan
+    // in recovering mode, so such a test passes locally and green-lights a
+    // change that would fail the halting-mode nightly Linux job. The fallback
+    // exists to satisfy the compiler's control-flow analysis, not as reachable
+    // behaviour; every value Qt can actually deliver is covered above.
+};
+
+QTEST_MAIN(tst_BleServiceError)
+#include "tst_bleserviceerror.moc"


### PR DESCRIPTION
Follow-up to the second complaint in #1586 (the first — the Equipment button resurrection — was #1591).

## What the reporter saw

> I also got Service Error 5 a few times, and the DE-1 would not connect to Decenza.

That message is ours, not the DE1's. `BleTransport` formatted the raw `QLowEnergyService::ServiceError` enum straight into a user-facing dialog, so it carried a number and nothing else. Per Qt's header, **5 is `CharacteristicReadError`** — a GATT read failed.

## Two defects, not one

**The error was invisible in the debug log.** Write errors log, descriptor errors log as suppressed — but this branch went straight to `errorOccurred` with no `log()` or `warn()` call at all. So the reporter saw it on screen, filed an issue, attached a debug log, and the one error they named was the one thing the capture could not show. I confirmed this the hard way: grepping their log for it returns nothing, and every conclusion I drew from that log was blind to it.

**It showed a raw integer.** The scale transport already mapped these values to names. The DE1 path was worse on both counts — opaque *and* unlogged.

## The change

- New `src/ble/bleserviceerror.h` — one shared enum-to-name mapping.
- `BleTransport` warns before emitting, and emits the name.
- `QtScaleBleTransport` drops its private copy of the switch; its non-fatal `DescriptorWriteError` early-return is hoisted above the mapping, unchanged.
- No `default:` label on purpose: a new value in Qt's enum should fail the `-Wswitch` build rather than silently degrade to a bare number, which is the failure this PR exists to fix.

## On the test

It pins each numeric value to its name, because the number is the only thing a user or a log ever shows, so the number is what has to keep its meaning.

The trailing number-fallback is deliberately **not** tested. Producing an out-of-range enum value is itself undefined behaviour, and I had written exactly that test — CTest reported **90/90 green** while the binary emitted:

```
runtime error: load of value 99, which is not a valid value for type
'QLowEnergyService::ServiceError'
```

macOS runs UBSan in recovering mode, so it passes locally; `nightly-sanitizers.yml` runs it halting on Linux, where it would have failed. Caught only because I ran the binary directly to check the cases were really executing. Same shape as the LSan gap `CLAUDE.md` already documents — a green local run not meaning what it appears to. Worth adding a line to `TESTING.md` about it separately.

## What this does not fix

Nothing about *why* the link failed. The log shows the DE1 refusing every connection with `ConnectionError` at exactly 5s while the scale connected fine on the same radio — consistent with a stale BLE slot on the machine side, which matches the reporter needing to power-cycle the DE1. This PR only makes the error say what it is, and makes it survive into the log so the next report is diagnosable.

Full suite 90/90 green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)