### PR TITLE
Stop restating the one-time-injection contract in five places

### DIFF
--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -239,16 +239,15 @@ MainController::MainController(QNetworkAccessManager* networkManager,
     requestRecipeTempOffsetConversion();
     setupRecipeConnections();
 
-    // One-time idle-button injections, gated on the DB schema crossing that
-    // introduced each feature — the genuine once-ever signal, unlike the old
-    // "add it whenever the widget is absent" check that resurrected the button
-    // on every launch after a user removed it (issue #1586). crossedSchemaVersion
-    // is true only on the single launch whose migrations advanced the DB past
-    // that version, so a machine already upgraded (widget kept OR deliberately
-    // removed) is never touched again. Each inject is additionally a no-op if the
-    // widget is already present, so a fresh install's default layout — which
-    // ships both — does not double-add. Runs before the QML engine builds the
-    // idle page, so the layout is settled by first paint.
+    // One-time idle-button injections (issue #1586). What the gate means is
+    // documented on ShotHistoryStorage::crossedSchemaVersion; what the injections
+    // guarantee is documented on their declarations in settings_network.h.
+    //
+    // What is specific to THIS site is the ordering, which is why the calls live
+    // here and not somewhere more obvious: they must run after
+    // m_shotHistory->initialize() above (it is what computes the crossing) and
+    // before the QML engine is created in main.cpp (so the layout is settled by
+    // first paint, with no visible re-arrangement).
     if (m_shotHistory->crossedSchemaVersion(22))
         m_settings->network()->injectEquipmentButtonIfMissing();
     if (m_shotHistory->crossedSchemaVersion(25))

--- a/src/core/settings_network.cpp
+++ b/src/core/settings_network.cpp
@@ -1243,9 +1243,11 @@ void SettingsNetwork::injectEquipmentButtonIfMissing() {
     // Placement policy: immediately after the beans item, so an upgraded user
     // gets it in a sensible default place regardless of their custom layout;
     // append to bottomRight if beans was removed. Note the beans anchor is
-    // searched across ALL zones in key order, so a layout whose beans sits in
-    // centerTop (the current default) puts Equipment in the centre row, not the
-    // bottom bar. (Contract and gating: see the declaration.)
+    // searched across ALL zones in alphabetical key order (QJsonObject::keys()
+    // sorts; it is NOT the order the zones appear in the JSON), so a layout
+    // whose beans sits in centerTop — which the current default does — puts
+    // Equipment in the centre row, not the bottom bar. (Contract and gating:
+    // see the declaration.)
     QJsonObject layout = getLayoutObject();
     QJsonObject zones = layout["zones"].toObject();
     for (const QString& zoneName : zones.keys()) {

--- a/src/core/settings_network.cpp
+++ b/src/core/settings_network.cpp
@@ -1240,12 +1240,12 @@ bool SettingsNetwork::saveLayoutObjectVerified(const QJsonObject& layout, const 
 }
 
 void SettingsNetwork::injectEquipmentButtonIfMissing() {
-    // Add an Equipment idle button immediately after the beans item so an
-    // upgraded user gets it in a sensible default place regardless of their
-    // custom layout (fall back to appending to bottomRight if beans was
-    // removed). No-op when one already exists — a fresh install's default
-    // layout ships it, and the caller only invokes this on the one launch whose
-    // migrations crossed schema 22, so it never resurrects a removed button.
+    // Placement policy: immediately after the beans item, so an upgraded user
+    // gets it in a sensible default place regardless of their custom layout;
+    // append to bottomRight if beans was removed. Note the beans anchor is
+    // searched across ALL zones in key order, so a layout whose beans sits in
+    // centerTop (the current default) puts Equipment in the centre row, not the
+    // bottom bar. (Contract and gating: see the declaration.)
     QJsonObject layout = getLayoutObject();
     QJsonObject zones = layout["zones"].toObject();
     for (const QString& zoneName : zones.keys()) {
@@ -1282,10 +1282,10 @@ void SettingsNetwork::injectEquipmentButtonIfMissing() {
 }
 
 void SettingsNetwork::injectRecipesButtonIfMissing() {
-    // Add a Recipes idle button; default home is immediately LEFT of the
-    // espresso button, else beside equipment in the bottom row, else appended
-    // to bottomRight. Same one-time contract as the equipment button above:
-    // no-op if already placed, called only on the launch that crossed schema 25.
+    // Placement policy: immediately LEFT of the espresso button; else beside
+    // equipment in the bottom row; else appended to bottomRight. Same zone-order
+    // caveat as the equipment button above. (Contract and gating: see the
+    // declaration.)
     QJsonObject layout = getLayoutObject();
     QJsonObject zones = layout["zones"].toObject();
     for (const QString& zoneName : zones.keys()) {


### PR DESCRIPTION
Follow-up hygiene from #1591. Comments only, no behaviour change.

## The problem

The equipment/recipes one-time gate ended up documented at **six** sites. Three earn their keep and are untouched:

- the declarations in `settings_network.h` — the API contract, where a caller looks
- the `NOTE` in `getLayoutObject()` — a tombstone whose job is to stop someone re-adding the injection there
- `crossedSchemaVersion()` in `shothistorystorage.h` — the mechanism's own semantics

The other three paraphrased what those already own. That is three extra places to drift, and drift is not hypothetical here: **two of the six were already wrong before #1591 touched them**, and #1591 itself produced several more instances of a comment claiming something the code did not do. Each of the three now points at the authoritative site instead of restating it.

## What is kept

Whatever is genuinely local to each site, sharpened rather than trimmed:

- **`MainController`** — the *ordering*, which is the only reason the calls live in that constructor at all: after `initialize()` (which computes the crossing) and before `main.cpp` creates the QML engine, so the layout is settled by first paint.
- **The two injectors** — their *placement policy*, which is documented nowhere else.

## One thing added, not removed

The beans anchor is searched across **all** zones in key order, so a layout whose `beans` sits in `centerTop` — which the current default does — puts Equipment in the **centre row, not the bottom bar**. That surprised a reviewer during #1591 and was written down nowhere.

## Honest scope note

This is net **−1 line**. If you are looking for a visible cleanup, this is not it — the value is three fewer restatements that can rot, plus the zone-order caveat, and arguably the caveat is worth more than the consolidation. Reviewed on that basis rather than as a size reduction.

Full suite 89/89 green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)