### PR TITLE
Stop the docs telling assistants to build and test from a shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,11 @@ Read [`docs/SHOT_REVIEW.md`](https://github.com/Kulitorum/Decenza/blob/main/docs
 
 ## Building
 
-**Don't build automatically** — let the user build in Qt Creator (~50× faster than CLI). Only run CLI builds when the user explicitly asks. CLI commands for Windows/macOS/iOS live in `docs/CLAUDE_MD/PLATFORM_BUILD.md`.
+**An assistant builds and runs tests through the Qt Creator MCP tools — `mcp__qtcreator__build` and `mcp__qtcreator__run_tests` — and through nothing else.** Not `cmake --build`, not `ctest`, not a `./tests/tst_*` binary, from any shell. That holds for the full pre-PR suite, for a single target, and when an MCP call times out (the call's wait can abort while Qt Creator keeps building — poll `get_build_status`, don't shell out). If the MCP path is blocked — wrong startup project, app holding the binary, tool unavailable — **stop and ask**. Qt Creator is also ~50× faster than a CLI build, and it is the environment the maintainer is watching while you work.
 
-**There is no pull-request CI gate — run the full suite locally before opening a PR.** That is the gate. `nightly-sanitizers.yml` re-runs the suite on `main` each night under UBSan and ASan. Platform-guarded code (`#ifdef Q_OS_IOS` etc.) is compiled only by the tag-push release workflows, so verify platform-specific changes with a CI test build of that platform (see `docs/CLAUDE_MD/CI_CD.md`).
+The `cmake`/`ctest` invocations in `docs/CLAUDE_MD/TESTING.md` and `docs/CLAUDE_MD/PLATFORM_BUILD.md` are **reference for humans and CI**, not instructions for an assistant. Run their equivalent through the MCP.
+
+**There is no pull-request CI gate — run the full suite locally before opening a PR.** That is the gate — via `mcp__qtcreator__run_tests` (scope `all`). `nightly-sanitizers.yml` re-runs the suite on `main` each night under UBSan and ASan. Platform-guarded code (`#ifdef Q_OS_IOS` etc.) is compiled only by the tag-push release workflows, so verify platform-specific changes with a CI test build of that platform (see `docs/CLAUDE_MD/CI_CD.md`).
 
 **Debug builds are sanitizer-instrumented automatically** — ASan *and* UBSan on every desktop platform including macOS, so a normal local test run already reports undefined behaviour and memory errors. UBSan is in recovering mode there (it reports and continues); an explicit `-DENABLE_UBSAN=ON` gives the halting mode CI uses. Release builds are untouched.
 

--- a/docs/CLAUDE_MD/PLATFORM_BUILD.md
+++ b/docs/CLAUDE_MD/PLATFORM_BUILD.md
@@ -1,6 +1,9 @@
-## Command Line Build (for Claude sessions)
+## Command Line Build (human / CI reference)
 
-> **Don't build automatically** — let the user build in Qt Creator (~50× faster than CLI). Only use these commands if the user explicitly asks for a CLI build.
+> **Not for assistant use.** An assistant builds and tests through the Qt Creator MCP
+> (`mcp__qtcreator__build`, `mcp__qtcreator__run_tests`) and nothing else — see the Building
+> section of the root `CLAUDE.md`. These commands are here for humans building by hand and for
+> reproducing what CI does. If the MCP path is blocked, stop and ask rather than running them.
 
 ### Windows (MSVC)
 

--- a/docs/CLAUDE_MD/TESTING.md
+++ b/docs/CLAUDE_MD/TESTING.md
@@ -6,6 +6,13 @@ Qt Test (QTest) — ships with Qt, no external dependencies, integrates with CMa
 
 ## Building and Running
 
+> **Assistants: use the Qt Creator MCP, not the commands below.** `mcp__qtcreator__run_tests`
+> (`scope: "all"`, or `scope: "named"` for one test) builds and runs, and returns a pass/fail
+> summary; `mcp__qtcreator__build` is the build half. The `cmake`/`ctest`/`./tests/tst_*` lines
+> in this file are reference for **humans and CI**. Never run them from a shell — including for
+> the full pre-PR suite, a single target, or after an MCP call times out. If the MCP path is
+> blocked, stop and ask. See the Building section of the root `CLAUDE.md`.
+
 Tests are **auto-enabled in Debug builds** (single-config generators like Ninja/Make) and **in Linux CI releases**. Multi-config generators (Visual Studio, Xcode) require `-DBUILD_TESTS=ON` explicitly since `CMAKE_BUILD_TYPE` is empty at configure time.
 
 ```bash
@@ -274,7 +281,7 @@ Run this after any changes to `src/mcp/`, `src/controllers/profilemanager.cpp`, 
 1. Create `tests/tst_yourtest.cpp` with `QTEST_GUILESS_MAIN(tst_YourTest)` and `#include "tst_yourtest.moc"`
 2. Add to `tests/CMakeLists.txt` using `add_decenza_test(tst_yourtest tst_yourtest.cpp ...source files...)`
 3. If accessing private members, add `friend class tst_YourTest;` behind `#ifdef DECENZA_TESTING` in the production header
-4. Run `ctest` to verify
+4. Run `mcp__qtcreator__run_tests` to verify (`scope: "named"`, `names: ["tst_YourTest"]`; if a freshly added target isn't in the Autotest model yet, just retry — it re-parses)
 
 ## Handling Warnings
 


### PR DESCRIPTION
The project rule is that an assistant builds and runs tests through the Qt Creator MCP (`mcp__qtcreator__build`, `mcp__qtcreator__run_tests`). Three checked-in instructions said otherwise — and they are the ones actually loaded into an assistant's context, so they won.

| Where | Said |
|---|---|
| `CLAUDE.md` Building | "let **the user** build in Qt Creator … Only run CLI builds when the user explicitly asks" — reads as: the user builds, the CLI is the assistant's path |
| `CLAUDE.md` + `TESTING.md` | "run the full suite locally before opening a PR. **That is the gate**", with `ctest --output-on-failure -j… --repeat until-pass:3` as the documented how |
| `PLATFORM_BUILD.md` | section titled **"Command Line Build (for Claude sessions)"** |

After this:

- `CLAUDE.md` names the MCP tools as the only route, covers the cases that tempt a fallback (full suite, single target, MCP call timing out — poll `get_build_status` instead), and says to stop and ask when the MCP path is blocked.
- `TESTING.md` carries the same note directly above its command block, and its add-a-test checklist step 4 says `run_tests` rather than `ctest`.
- `PLATFORM_BUILD.md` is retitled "human / CI reference" and marked not-for-assistant-use.

Docs only — no code, no behaviour change.

Context: I broke this rule repeatedly in the #1592 session, including running the exact `ctest` line `TESTING.md` documents, and the maintainer pointed out the docs were pulling one way while he was telling me the other. Fixing the source rather than only my own notes.