### PR TITLE
Fix missing accessibleName on custom-endpoint dialog buttons

### DIFF
--- a/qml/pages/settings/SettingsAITab.qml
+++ b/qml/pages/settings/SettingsAITab.qml
@@ -1430,11 +1430,13 @@ KeyboardAwareContainer {
                 Item { Layout.fillWidth: true }
                 AccessibleButton {
                     text: TranslationManager.translate("common.button.cancel", "Cancel")
+                    accessibleName: TranslationManager.translate("common.button.cancel", "Cancel")
                     onClicked: advancedEndpointDialog.close()
                 }
                 AccessibleButton {
                     primary: true
                     text: TranslationManager.translate("common.button.save", "Save")
+                    accessibleName: TranslationManager.translate("settings.ai.saveEndpointAccessible", "Save custom endpoint")
                     onClicked: {
                         Qt.inputMethod.commit()
                         switch(Settings.ai.aiProvider) {


### PR DESCRIPTION
## Summary
- `AccessibleButton` requires `accessibleName`, and the Cancel/Save buttons in the new custom-endpoint "Advanced" dialog (added in #1598) didn't set it.
- This threw `Required property accessibleName was not initialized` at runtime and broke the whole AI settings tab (`SettingsPage: tab load error ai`).
- Fixed by adding `accessibleName` to both buttons, matching the convention used by the other dialogs in the same file (e.g. `rotateTokenDialog`, `tailscaleSignoutDialog`).

## Test plan
- [ ] Open Settings > AI tab, select OpenAI or Anthropic, confirm the tab loads without error
- [ ] Click "Advanced", confirm the dialog opens and Cancel/Save buttons work