### PR TITLE
Fix Add Milk/Add Water navigating to Equipment page in recipe wizard

### DIFF
--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -3577,8 +3577,10 @@ Page {
                                 accessibleName: text
                                 onClicked: {
                                     wizardPage.fHasMilk = !wizardPage.fHasMilk
-                                    if (wizardPage.fHasMilk)
+                                    if (wizardPage.fHasMilk) {
+                                        wizardPage._detailsPage = "steam"
                                         wizardPage.openStep("details")
+                                    }
                                 }
                             }
                             AccessibleButton {
@@ -3588,8 +3590,10 @@ Page {
                                 accessibleName: text
                                 onClicked: {
                                     wizardPage.fHasWater = !wizardPage.fHasWater
-                                    if (wizardPage.fHasWater)
+                                    if (wizardPage.fHasWater) {
+                                        wizardPage._detailsPage = "water"
                                         wizardPage.openStep("details")
+                                    }
                                 }
                             }
                             Item { Layout.fillWidth: true }

--- a/qml/pages/settings/SettingsAITab.qml
+++ b/qml/pages/settings/SettingsAITab.qml
@@ -1144,7 +1144,7 @@ KeyboardAwareContainer {
                                 id: claudeConnectorsArea
                                 anchors.fill: parent
                                 cursorShape: Qt.PointingHandCursor
-                                onClicked: Qt.openUrlExternally("https://claude.ai/settings/connectors")
+                                onClicked: Qt.openUrlExternally("https://claude.ai/customize/connectors")
                             }
                             Accessible.onPressAction: claudeConnectorsArea.clicked(null)
                         }


### PR DESCRIPTION
## Summary
- Fixes #1601: in the recipe wizard, pressing **Add milk** or **Add hot water** navigated to the Equipment details page instead of the Steam/Water quantity page.
- Also fixes the "Open Connectors on claude.ai" link on the AI settings page, which pointed at the stale `/settings/connectors` path.

## Root cause
The Add Milk / Add Water buttons called the shared `openStep("details")` function without first setting `_detailsPage`, unlike every other navigation entry point (`SummaryRow`), so the details step opened whatever `_detailsPage` was last set to (defaulting to `"equipment"`).

## Fix
Set `wizardPage._detailsPage = "steam"` / `"water"` before calling `openStep("details")`, matching the pattern used by the Steam/Water `SummaryRow` entries.

## Test plan
- [x] Qt Creator build succeeded (both edited QML files recompiled)
- [x] Full test suite: 92 passed, 0 failed via `run_tests`
- [x] qmllint clean on changed lines (no new warnings introduced)
- [x] Manually verified in the running app: Add Milk → Steam quantity page, Add Water → Water quantity page, Connectors link opens the correct claude.ai page

🤖 Generated with [Claude Code](https://claude.com/claude-code)