### PR TITLE
Fix dead pen icon on recipe wizard summary rows (#1606)

### DIFF
--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -2185,11 +2185,17 @@ Page {
                         Layout.alignment: Qt.AlignVCenter
                         sourceComponent: summaryRow.headerActions
                     }
-                    ColoredIcon {
+                    // Decorative edit glyph. Must be mouse-transparent: the
+                    // card's tap target sits at z:-1 (so header-action buttons
+                    // win), so a click-absorbing ColoredIcon here would swallow
+                    // taps that land on the pencil and never open the step —
+                    // the whole card was tappable EXCEPT the pencil (#1606).
+                    // ThemedIcon draws the tinted SVG without grabbing clicks,
+                    // so a tap on the pencil falls through to the card handler.
+                    ThemedIcon {
                         source: "qrc:/icons/edit.svg"
-                        iconWidth: Theme.scaled(16)
-                        iconHeight: Theme.scaled(16)
-                        iconColor: Theme.textSecondaryColor
+                        iconSize: Theme.scaled(16)
+                        color: Theme.textSecondaryColor
                         Accessible.ignored: true
                     }
                 }


### PR DESCRIPTION
## Problem

On the recipe editor's summary step (where "Edit Recipe" lands), the whole card was tappable to open a parameter for editing — **except the pen icon itself**. Tapping directly on the pencil did nothing; you had to tap elsewhere on the card. This happened on macOS, Windows and Android (not a keyboard/platform issue).

Fixes #1606.

## Root cause

The summary cards (`SummaryRow`) put their card-wide tap target at `z:-1` on purpose, so the Profile card's header-action buttons (ⓘ / keyboard) win their own taps. The edit pencil was rendered with `ColoredIcon`, which is a **click-absorbing `Button`** (it has an internal `MouseArea` specifically to swallow clicks). Sitting on top of the `z:-1` handler, it ate any tap that landed on the pencil, so that one spot was a dead zone while the rest of the card fell through to the handler.

`SectionCard` and the Ratio control were unaffected — they declare their tap handler *on top*, so it catches the pencil too.

## Fix

Swap the decorative pencil to `ThemedIcon` — a plain `Item` + tinted `Image` with no `MouseArea`. It renders identically (same 16px, `textSecondaryColor`) but doesn't grab clicks, so a tap on the pencil now falls through to the card's existing handler and opens the **same** step as tapping anywhere else on the card. One change in the `SummaryRow` definition fixes every summary row, and it adds no second accessibility target.

## Testing

Build clean, full test suite passes, verified in-app that tapping the pen icon now opens the corresponding editor.