### PR TITLE
Fix invisible drink-type icons in recipe wizard on light theme

### DIFF
--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -2323,11 +2323,11 @@ Page {
                                 ColumnLayout {
                                     anchors.centerIn: parent
                                     spacing: Theme.spacingSmall
-                                    Image {
+                                    ThemedIcon {
                                         Layout.alignment: Qt.AlignHCenter
                                         source: wizardPage.drinkTypeIcon(modelData)
-                                        sourceSize.width: Theme.scaled(44)
-                                        sourceSize.height: Theme.scaled(44)
+                                        iconSize: Theme.scaled(44)
+                                        color: Theme.textColor
                                     }
                                     Label {
                                         Layout.alignment: Qt.AlignHCenter

--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -2328,6 +2328,7 @@ Page {
                                         source: wizardPage.drinkTypeIcon(modelData)
                                         iconSize: Theme.scaled(44)
                                         color: Theme.textColor
+                                        Accessible.ignored: true
                                     }
                                     Label {
                                         Layout.alignment: Qt.AlignHCenter


### PR DESCRIPTION
## Problem

On the recipe wizard's **"What are you making?"** step, the drink-type icons (Espresso, Latte/Cappuccino, Filter, Americano, Long black, Tea) were invisible in **light theme** — white icons on white cards.

The step rendered them with a plain `Image`, but the icon SVGs (`espresso.svg`, `water.svg`, `steam.svg`, `tea.svg`, `filter.svg`) all use hardcoded white fill/stroke.

## Fix

Render the icons through `ThemedIcon` so they follow `Theme.textColor`.

Used `ThemedIcon` rather than the `ColoredIcon` its sibling surfaces (recipe cards, shot detail, post-shot review) use, because `ColoredIcon` carries an absorbing `MouseArea` that would swallow taps on the icon — and the whole wizard card is meant to be tappable via its `AccessibleMouseArea`. `ThemedIcon` has no MouseArea.

Audited the other `DrinkType.icon()` consumers: they already tint via `ColoredIcon`/`iconColor`, so the wizard was the only offender.

QML-only change; builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)