### PR TITLE
Add Recipe as a Shot Plan item

### DIFF
--- a/openspec/changes/archive/2026-07-23-add-recipe-to-shot-plan/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-23-add-recipe-to-shot-plan/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/archive/2026-07-23-add-recipe-to-shot-plan/design.md
+++ b/openspec/changes/archive/2026-07-23-add-recipe-to-shot-plan/design.md
@@ -1,0 +1,69 @@
+## Context
+
+The Shot Plan widget is rendered by `qml/components/ShotPlanText.qml` and configured through an ordered item-key list (`shotPlanItems`). The item list is resolved by the shared library `qml/components/layout/ShotPlanConfig.js` (`allKeys` + `itemsFor`), which is the single source of truth used by three surfaces:
+
+1. The widget itself (`ShotPlanItem.qml` → `ShotPlanText.qml`).
+2. The in-app chip editor (`ScreensaverEditorPopup.qml`, the "Shown"/"Available" rows in the screenshot).
+3. The ShotServer web layout editor, which re-implements the same rule in embedded JS (`src/network/shotserver_layout.cpp`: `SP_ALL_KEYS`, `SP_ITEM_LABELS`, `spItemsFromProps`).
+
+Today there are seven items (`doseYield`, `profile`, `temperature`, `roaster`, `coffee`, `grind`, `roastDate`). The active recipe (drink) name — the label many users now brew by — is not among them, even though `MainController.activeRecipe` (a `QVariantMap` with a `name` key, gated on `Settings.dye.activeRecipeId >= 0`) already exposes it, and the shot-detail / post-shot-review pages already resolve a per-shot recipe name via `recipeResolver.recipe.name`.
+
+`ShotPlanText` renders in three formats, all built by the one `_build(fmt, sep, blockSep)` function so the plain (a11y) and rich (display) strings can't drift: fragment list, profile-anchored sentence (+ trailing tail), and profile-less "recipe" sentence (+ trailing tail). Every property that varies per surface (dose, grind, temperature, beverage, override flags, baselines) is already an overridable `property` with a live-singleton default, so per-shot surfaces can inject frozen snapshot values.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `recipe` as an eighth, default-OFF Shot Plan item showing the active recipe name.
+- Place it correctly in all three formats (fragment order; trailing tail in both sentences).
+- Offer/label it in both the in-app and web editors, kept in sync.
+- Let the shot-detail and post-shot-review snapshot lines show the shot's frozen recipe name via an overridable property.
+
+**Non-Goals:**
+- No change to how recipes are selected, stored, or activated.
+- No new setting on the `Settings` façade or any domain object (the item list already lives in `shotPlanItems` on the widget instance).
+- Recipe reuses the **existing** "using {…}" scaffold slot — it never invents a new translated template. It anchors only when Profile is absent; otherwise it trails.
+- No legacy boolean (`shotPlanShowRecipe`) — default-OFF is achieved purely by absence from `allKeys`-driven defaults, exactly like a brand-new key.
+
+## Decisions
+
+### Recipe is a stand-in anchor for Profile in the "using {…}" slot
+The intended use is to **swap** Profile (and Roaster/Coffee) out for Recipe, so the recipe name must land where the profile name normally reads — the "using {…}" clause — not get buried in a trailing tail. Rather than invent a new sentence template, `recipe` fills the *existing* profile scaffold's anchor slot:
+
+- The "using {anchor}" anchor is filled by the profile name when the Profile item is present with a name; else by the active recipe name when the Recipe item is present and a recipe is active; else there is no anchor and the plan falls to the profile-less recipe sentence (roaster/coffee/dose based) as today.
+- When **both** Profile and Recipe are present with values, Profile keeps the anchor and Recipe trails as an ordinary tail item — Recipe never displaces a shown, available Profile. This gives a user who deliberately shows both the profile in its natural slot plus the recipe name after it, and keeps the anchor rule deterministic.
+
+Concretely, `ShotPlanText` computes an anchor string once (`_anchorStr` = `_profileStr` if non-empty, else `_recipeStr` when the Recipe item is present) and the four existing degradation templates ("Brew {yield} of {beverage}, using {anchor} at {temperature}", etc.) consume it in place of the current `_profileStr`. The profile-anchored branch's tail loop gains a `case "recipe":` that pushes the recipe name **only when it is not the current anchor** (i.e. only in the both-present case). Fragment mode gains a plain `case "recipe":` like any other segment. No new translated string is added for the sentence.
+
+- Alternative considered: a new "recipe" head template ("Brew {recipe}: …"). Rejected — heavier, needs new translated templates for all degradations, and collides with the existing profile-less "recipe" sentence that already owns that word for the beans-based fallback.
+- Alternative considered: keep recipe as a pure trailing tail item. Rejected by the user — it buries the recipe name when it is meant to headline the "using" clause in the swap case.
+
+### Default OFF via absence, no legacy boolean
+`roastDate` is the precedent: it is in `allKeys` but defaults off (the legacy derivation only pushes it when `shotPlanShowRoastDate === true`). For a brand-new key there is no legacy config to honor, so `recipe` simply is not pushed by any legacy-derivation branch and is absent from any pre-change `shotPlanItems` array. Adding it to `allKeys` makes it appear in the editors' "Available" row without altering any saved widget.
+
+- This means `ShotPlanConfig.itemsFor`, `spItemsFromProps`, and the legacy branches need **no** new derivation line — only `allKeys` / `SP_ALL_KEYS` / `SP_ITEM_LABELS` grow.
+
+### Recipe name is an overridable property, live by default
+Add `property string recipeName` to `ShotPlanText`, defaulting to the live active recipe name — e.g. `Settings.dye.activeRecipeId >= 0 ? (MainController.activeRecipe.name || "") : ""`. `_recipeStr` gates on `_has("recipe") && recipeName.length > 0`. The shot-detail and post-shot-review `ShotPlanText` instances set `recipeName:` to the shot's frozen recipe name (they already have `recipeResolver.recipe.name` in scope). This mirrors the existing override pattern (`grindSize`, `beverageType`, `isCleaning`, …) exactly.
+
+- Recipe cards (`RecipeDrinkCard.qml`) pin an explicit `itemOrder` without `recipe`, so they are unaffected; if a card ever wanted it, it would inject its own `recipeName`.
+
+### Emoji safety
+Recipe names are user-authored and the picker encourages emoji. `_recipeStr` flows through the same `fmt()` → `escapeHtml` → `replaceEmojiWithImg` path as the bean/recipe names already rendered in `_rich`, so a color emoji in a recipe name is rewritten to a bundled `<img>` and never reaches the macOS render thread. No new handling is required — just route the value through the existing tail formatting, not a raw `Text`.
+
+### Editor preview
+`ScreensaverEditorPopup.qml` renders a live `ShotPlanText` preview. Its `recipeName` defaults to the live value, so the preview shows the real active recipe when the user adds the Recipe chip — no extra wiring beyond the chip label case.
+
+## Risks / Trade-offs
+
+- [The two editors' item lists drift] → Add `recipe` to `allKeys` (JS) and `SP_ALL_KEYS` + `SP_ITEM_LABELS` (C++ embedded JS) in the same change; the existing `ShotPlanConfig.js` header comment already mandates keeping them in sync. A test/asserted parity check is out of scope, but the change is a single additive key in each.
+- [Recipe empty when no recipe active looks like a bug] → Spec'd behavior: the item contributes nothing, identical to Roaster/Coffee with no bean. Users who want it always-on will simply have a recipe active; this matches every other data-driven item.
+- [Frozen-shot line shows the wrong recipe if a page forgets to override] → Default is the live active recipe (a reasonable fallback), and both shot pages already resolve the shot's recipe name for their recipe card, so wiring `recipeName` there is a one-line addition next to existing code.
+- [Translations] → One new key (`shotPlanEditor.itemRecipe` "Recipe"); the web editor label is an English string in `SP_ITEM_LABELS` like its peers. Low risk.
+
+## Migration Plan
+
+Purely additive; no data migration. Existing `shotPlanItems` arrays remain valid and unchanged (they simply lack `recipe`). Rollback is a straight revert — no persisted state depends on the new key, and a saved layout that somehow contained `recipe` would just render an unknown key as nothing under the old code (the `switch` default), so forward/back compatibility is safe.
+
+## Open Questions
+
+- None blocking. (Confirmed during design: `settings_network.cpp` treats `shotPlan` as a single catalog widget and does not enumerate item keys or expose a per-item readout option schema, so no change is needed there.)

--- a/openspec/changes/archive/2026-07-23-add-recipe-to-shot-plan/proposal.md
+++ b/openspec/changes/archive/2026-07-23-add-recipe-to-shot-plan/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The Shot Plan widget lets users pick and order which brew facts it shows — Dose & yield, Profile, Temperature, Roaster, Coffee, Grind, Roast date — but not the one thing that now sits at the top of many users' workflow: the **active recipe (drink) name**. With recipes driving the brew (profile, yield, temperature, grind, bean link), a user who has "Morning Latte" or "Guji V60" selected can't surface that name on the idle screen, even though it's the label they think in.
+
+## What Changes
+
+- Add an **eighth Shot Plan display item, `recipe`**, that renders the active recipe's name (from `MainController.activeRecipe`, gated on `Settings.dye.activeRecipeId >= 0`). Like Roast date, it defaults **OFF**, so no existing widget configuration changes.
+- **Recipe is a stand-in anchor for Profile**, matching the intended use of swapping Profile (and Roaster/Coffee) out for Recipe: in sentence mode the "using {…}" slot is filled by the profile name when Profile is shown, or by the active recipe name when Profile is removed — "Brew 40.0g of Espresso, using Morning Latte at 92°C". When both Profile and Recipe are shown, Profile keeps the anchor and Recipe trails as a tail item. In fragment mode `recipe` joins in item-list order like any segment.
+- Add `recipe` to the in-app chip editor (Shot Plan Settings — the "Shown"/"Available" rows) with a translatable "Recipe" label, and to the ShotServer web layout editor's mirror (item catalog + labels), keeping the two in sync.
+- Make the recipe name overridable on `ShotPlanText` (a `recipeName` property) so the shot-detail and post-shot-review snapshot lines render the shot's **frozen** recipe name rather than the live active recipe — consistent with how those surfaces already override dose, grind, temperature, and beverage.
+- When no recipe is active the `recipe` item contributes nothing (empty segment), exactly like Roaster/Coffee with no bean set.
+- Update the wiki manual's Shot Plan documentation to list Recipe as a selectable item.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `plan-widgets`: the display-item set grows from seven items to eight — `recipe` (the active recipe/drink name) is added, with its content rule, its fragment/sentence/recipe-sentence placement, its default-OFF behavior, and its per-shot frozen-name override on the snapshot surfaces.
+
+## Impact
+
+- **QML**
+  - `qml/components/layout/ShotPlanConfig.js` — add `recipe` to `allKeys` (no legacy boolean; default OFF is achieved by absence).
+  - `qml/components/ShotPlanText.qml` — add `recipeName` property (default: live active recipe name), `_recipeStr` getter gated by `_has("recipe")`, and wire it into the fragment list, the profile-anchored sentence tail, and the profile-less recipe sentence tail.
+  - `qml/components/layout/ScreensaverEditorPopup.qml` — add the `recipe` chip label case and feed the editor preview the current recipe name.
+  - Per-shot surfaces (`qml/pages/ShotDetailPage.qml`, `qml/pages/PostShotReviewPage.qml`) — pass the shot's frozen recipe name into `ShotPlanText.recipeName` (these pages already resolve a recipe name via `recipeResolver.recipe.name`).
+- **C++ / web editor**
+  - `src/network/shotserver_layout.cpp` — add `recipe` to `SP_ALL_KEYS` and `SP_ITEM_LABELS` so the web layout editor offers and labels it.
+  - `src/core/settings_network.cpp` — widen the Shot Plan widget's readout/option surface only if the catalog or option schema enumerates the item keys (verify during design).
+- **Translations** — one new UI string (`shotPlanEditor` "Recipe" chip label); reuse existing keys where possible.
+- **Docs** — GitHub wiki Manual (Shot Plan section) lists Recipe as an item.
+- **No breaking changes**, no BLE/DB/settings-schema changes; `recipe` is additive and off by default, and the stored `shotPlanItems` array already accommodates arbitrary keys.

--- a/openspec/changes/archive/2026-07-23-add-recipe-to-shot-plan/specs/plan-widgets/spec.md
+++ b/openspec/changes/archive/2026-07-23-add-recipe-to-shot-plan/specs/plan-widgets/spec.md
@@ -1,8 +1,5 @@
-# plan-widgets Specification
+## MODIFIED Requirements
 
-## Purpose
-Defines the text-rendering rules for the `shotPlan` widget's shot-plan and steam-plan sentences: how the configured display-item list maps to sentence and fragment formats, override indicators for temperature and yield, the cleaning-profile warning, page-aware switching between shot and steam plans, and the wrap-before-elide overflow behavior.
-## Requirements
 ### Requirement: Shot plan sentence content follows the display toggles
 
 The Shot Plan text (used by the `shotPlan` widget) SHALL render the display items named by the instance's ordered item list (`shotPlanItems`), in list order, in one of two formats selected by the instance's Sentence style option (`shotPlanSentence`, default ON).
@@ -115,95 +112,7 @@ The plain (accessibility) text and the rich (displayed) text SHALL be produced b
 - **WHEN** the `grind` item is present and no RPM is recorded (dyeGrinderRpm = 0)
 - **THEN** the grind segment shows only the grinder setting, with no RPM placeholder
 
-### Requirement: Override indicators
-
-The Shot Plan text SHALL highlight only the individual overridden item(s), not the whole sentence: when a deliberate temperature override is active (the override differs from the surface's temperature baseline by more than 0.1°C) the temperature item SHALL render in the override-highlight color; when a deliberate yield override is active (the target differs from the surface's yield baseline by more than 0.1 g) the yield item SHALL render as "{baselineYield} → {target}g" in the override-highlight color. Every other part of the sentence, and the plan icon, SHALL remain the default text color. The override-highlight color SHALL be `Theme.highlightColor` — the same color the Brew Settings values use for an override — so the two surfaces read consistently. Natural drift between measured dose and profile dose SHALL NOT trigger either indicator.
-
-Because the highlight lives in the shared `ShotPlanText` component, it SHALL apply on **every** surface that renders the Shot Plan — the idle home widget, recipe cards, the shot-detail and post-shot-review snapshot lines, and the screensaver preview — not only the idle page. Each surface's highlight SHALL be driven by **that surface's own** override inputs: the live dial for the home widget, and the shot's frozen snapshot values for the shot-detail and post-shot-review lines. A frozen-shot surface SHALL NOT reflect the live dial's override state; if it does not render the temperature or yield item, that item simply shows no highlight (it does not borrow the live override).
-
-**Recipe cards have no override inputs of their own and SHALL render with no highlight**: a card shows a static recipe definition, not a live per-brew comparison, so neither its temperature nor its yield item ever carries the override-highlight color. The temperature segment SHALL still be resolved from the recipe's own (possibly not-currently-loaded) profile's frame temperatures, shifted by the recipe's stored `tempOffsetC`, and rendered as the resulting value only — see `recipe-quick-switch` for the full rendering rule. The yield segment SHALL render as the plain resulting value with no arrow.
-
-#### Scenario: Highlight appears on non-idle surfaces
-- **WHEN** a shot snapshot line renders a plan whose shot carries a yield or temperature override
-- **THEN** that overridden item is highlighted using the same per-item scheme as the idle widget, driven by the shot's own values
-
-#### Scenario: Recipe cards never highlight
-- **WHEN** a recipe card renders a recipe with `tempOffsetC` = −3 on a profile whose frames are 84 · 94°C, or a recipe whose stored yield differs from its profile's target
-- **THEN** the card's temperature and yield segments both render in the default text color — no tag, no arrow, no highlight
-
-#### Scenario: Frozen surfaces do not borrow the live override
-- **WHEN** a live temperature override is active and the user opens a historical shot whose snapshot had no override
-- **THEN** the shot-detail plan line shows no highlight (it reflects the shot's frozen state, not the live dial)
-
-#### Scenario: Temperature override highlights only the temperature item
-- **WHEN** a deliberate temperature override is active on the live dial or a shot snapshot
-- **THEN** that surface's temperature item renders in `Theme.highlightColor`
-- **AND** the rest of the sentence and the icon remain the default text color
-
-#### Scenario: Yield override shows the arrow, highlighted
-- **WHEN** the user dials a yield override of 40.0 g on a profile whose default yield is 36.0 g
-- **THEN** the plan shows "36.0 → 40.0g" and that yield fragment renders in `Theme.highlightColor`
-- **AND** the rest of the sentence remains the default text color
-
-#### Scenario: No override, no arrow, no highlight
-- **WHEN** no yield or temperature override is set
-- **THEN** the plan shows the single target weight with no arrow, and the whole sentence renders in the default text color
-
-#### Scenario: Natural dose drift does not highlight
-- **WHEN** the measured dose differs from the profile dose but no deliberate override flag is set
-- **THEN** no item is highlighted
-
-### Requirement: Steam plan sentence
-
-The Steam Plan text (the steam-context rendering of the `shotPlan` widget) SHALL summarise the next steam as "Steam {milk} of milk, using the {pitcher} pitcher for {duration}", degrading to a separator-joined list when a piece is missing, and SHALL render nothing when the selected pitcher preset is the disabled ("Off") preset. When the selected preset's name already contains the word "pitcher" (case-insensitive), the sentence SHALL NOT append another "pitcher", so a preset named "Large Pitcher" never renders "Large Pitcher pitcher". The displayed duration SHALL be the selected preset's effective steam time (scaled when weight-timed steaming has a measured/reference milk, else the preset's base duration), resolved by the single shared `SettingsBrew` helper — never the residue another code path wrote to `steamTimeout`.
-
-#### Scenario: Pitcher name containing "Pitcher"
-
-- **WHEN** the selected preset is named "Large Pitcher"
-- **THEN** the sentence reads "…using the Large Pitcher for 30s" (no duplicated word)
-
-#### Scenario: Duration reflects the selected preset
-
-- **WHEN** the user selects a pitcher preset without tapping it to start
-- **THEN** the displayed duration matches that preset's effective steam time, not a stale value from a previous session
-
-### Requirement: Page-aware steam mode of the Shot Plan widget
-
-The `shotPlan` widget SHALL display the Shot Plan text except in steam context — steam selected on the idle screen, the steam page active, or the machine actively steaming — where it SHALL display the Steam Plan text, unless the instance's Steam plan option (`shotPlanShowSteamPlan`, default ON) is off. Page/mode state SHALL be read from the app's single existing page-state source (the `Theme` singleton), not from a duplicate copy. Outside steam mode the widget SHALL be an activatable control that opens Brew Settings; in steam mode it SHALL be a read-only summary, and its accessibility role and name SHALL match the mode.
-
-#### Scenario: Switches to steam plan
-
-- **WHEN** the user selects steam on the idle screen and the instance's Steam plan option is on
-- **THEN** the widget shows the steam plan and is announced as a read-only "Steam plan"
-
-#### Scenario: Steam plan option off
-
-- **WHEN** the instance's Steam plan option is off and the machine is steaming
-- **THEN** the widget keeps showing the shot plan
-
-#### Scenario: Shot side opens Brew Settings
-
-- **WHEN** the widget is showing the shot plan and is tapped (or activated via a screen reader)
-- **THEN** Brew Settings opens
-
-### Requirement: Shot plan overflow wraps before eliding
-
-When the Shot Plan text is wider than the width available to the widget, it SHALL wrap onto a second line, and only content that does not fit within two lines SHALL be elided. The text SHALL NEVER be clipped mid-word at the widget or screen edge. Wrapping and eliding SHALL apply to both the sentence and fragment formats and preserve the rich-text styling (bolded live values).
-
-#### Scenario: Long plan wraps to a second line
-
-- **WHEN** the rendered plan's natural single-line width exceeds the width granted to the widget
-- **THEN** the text wraps onto a second line and all content remains readable
-
-#### Scenario: Extreme overflow elides, never clips
-
-- **WHEN** the rendered plan does not fit even within two lines at the granted width
-- **THEN** the text ends with an ellipsis at the end of the second line, with no characters cut off at the widget edge
-
-#### Scenario: Short plan stays on one line
-
-- **WHEN** the rendered plan fits the granted width on one line
-- **THEN** it renders on a single line, centered as today
+## ADDED Requirements
 
 ### Requirement: Recipe item defaults off and is offered by both layout editors
 
@@ -234,4 +143,3 @@ On the live idle widget the Recipe item SHALL render the currently active recipe
 
 - **WHEN** the Recipe item is shown on the shot-detail or post-shot-review snapshot line for a past shot, and a different recipe is now active live
 - **THEN** the line shows the recipe recorded for that shot, not the currently active recipe
-

--- a/openspec/changes/archive/2026-07-23-add-recipe-to-shot-plan/tasks.md
+++ b/openspec/changes/archive/2026-07-23-add-recipe-to-shot-plan/tasks.md
@@ -1,0 +1,39 @@
+## 1. Shared item catalog
+
+- [x] 1.1 Add `"recipe"` to `allKeys` in `qml/components/layout/ShotPlanConfig.js` (canonical order — place before `doseYield` or after `roastDate` consistently with the editor's label ordering); confirm no legacy-derivation line is needed since it defaults OFF.
+
+## 2. Renderer (ShotPlanText.qml)
+
+- [x] 2.1 Add `property string recipeName` defaulting to the live active recipe name (`Settings.dye.activeRecipeId >= 0 ? (MainController.activeRecipe.name || "") : ""`).
+- [x] 2.2 Add a `readonly property string _recipeStr` gated by `_has("recipe") && recipeName.length > 0`.
+- [x] 2.3 Introduce a single anchor string: `_anchorStr` = `_profileStr` when non-empty, else `_recipeStr`. In `_build`, drive the profile-anchored sentence scaffold (the four "using {anchor}" degradation templates) off `_anchorStr` in place of the current `_profileStr`, and gate entry to that branch on `_anchorStr !== ""` (not just `_profileStr !== ""`). Preserve the existing per-item override highlighting for temperature/yield unchanged.
+- [x] 2.4 In the profile-anchored sentence tail `switch`, add a `case "recipe":` that pushes the recipe name **only when it is not the current anchor** (i.e. only when a profile filled the anchor and recipe is also shown) — so recipe never both anchors and trails.
+- [x] 2.5 In the fragment `switch`, add a plain `case "recipe":` pushing `fmt(_recipeStr, true)` in item-list order. Do **not** add recipe to the profile-less recipe sentence tail (if recipe were active it would have anchored; an empty recipe contributes nothing).
+- [x] 2.6 Verify the value flows through the existing `fmt` → escape → `replaceEmojiWithImg` path (emoji-safe) and that the a11y `text` and rich `_rich` builders share the same code (no separate handling).
+
+## 3. In-app chip editor (ScreensaverEditorPopup.qml)
+
+- [x] 3.1 Add a `case "recipe": return TranslationManager.translate("shotPlanEditor.itemRecipe", "Recipe")` to the item-label function.
+- [x] 3.2 Confirm the live `ShotPlanText` preview shows the active recipe when the Recipe chip is added (its `recipeName` default already resolves the live value — no extra wiring expected; verify).
+
+## 4. Web layout editor (shotserver_layout.cpp)
+
+- [x] 4.1 Add `"recipe"` to `SP_ALL_KEYS` and `recipe: "Recipe"` to `SP_ITEM_LABELS` (matching canonical order in `ShotPlanConfig.js`).
+- [x] 4.2 Confirm `spItemsFromProps` needs no new derivation line (default OFF; no legacy boolean) and the web editor offers Recipe in Available items.
+
+## 5. Per-shot snapshot surfaces
+
+- [x] 5.1 In `qml/pages/ShotDetailPage.qml`, pass the shot's frozen recipe name into the snapshot `ShotPlanText` via `recipeName:` (reuse the page's existing `recipeResolver.recipe.name`).
+- [x] 5.2 In `qml/pages/PostShotReviewPage.qml`, do the same for its snapshot `ShotPlanText`.
+- [ ] 5.3 Verify a frozen-shot line shows the shot's own recipe, not the live active recipe, when a different recipe is active.
+
+## 6. Translations & docs
+
+- [x] 6.1 Add the `shotPlanEditor.itemRecipe` → "Recipe" string to the base translation source.
+- [x] 6.2 Update the GitHub wiki Manual (Shot Plan section) to list Recipe as a selectable item.
+
+## 7. Verification
+
+- [x] 7.1 Build via Qt Creator MCP (`mcp__qtcreator__build`) and run qmllint with `-I` on the build dir for the edited QML files; clear any new warnings/TypeErrors.
+- [x] 7.2 Run the full test suite via `mcp__qtcreator__run_tests` (scope `all`); if any plan-widgets/shot-plan test enumerates the item set, update it to include `recipe`.
+- [ ] 7.3 Manually verify in the running app: default layout unchanged (Recipe off); adding Recipe in Shot Plan Settings shows/reorders/removes correctly in fragment and both sentence modes; empty when no recipe active.

--- a/qml/components/ShotPlanText.qml
+++ b/qml/components/ShotPlanText.qml
@@ -33,8 +33,8 @@ Item {
     signal clicked()
 
     // Ordered display items. Keys: "doseYield", "profile", "temperature",
-    // "roaster", "coffee", "grind", "roastDate". Membership shows the item,
-    // position orders it (fragment list / sentence tail).
+    // "roaster", "coffee", "grind", "roastDate", "recipe". Membership shows the
+    // item, position orders it (fragment list / sentence tail).
     property var itemOrder: ["doseYield", "profile", "temperature", "roaster", "coffee", "grind"]
     // Sentence scaffold vs plain fragment list.
     property bool sentence: true
@@ -115,6 +115,13 @@ Item {
     property bool rpmCapable: Settings.dye.grinderRpmCapable(Settings.dye.dyeGrinderBrand, Settings.dye.dyeGrinderModel)
     property string beverageType: ProfileManager.currentProfileBeverageType
     property bool isCleaning: ProfileManager.currentProfileIsMaintenance
+    // The active recipe (drink) name — defaults to the LIVE active recipe so the
+    // home widget needs no wiring, but per-shot consumers (shot-detail /
+    // post-shot-review snapshot lines) override it with the shot's own FROZEN
+    // recipe name. Empty when no recipe is active; an empty recipe never fills
+    // the sentence anchor and contributes nothing as a fragment.
+    property string recipeName:
+        Settings.dye.activeRecipeId >= 0 ? (MainController.activeRecipe.name || "") : ""
 
     // Per-item override highlight (recipe-aware-brew-settings): only the
     // overridden segment(s) recolor — the temperature item on a temp override,
@@ -158,6 +165,15 @@ Item {
     // temperatureDisplay() follows the C/F display unit; its Settings.app.temperatureUnit
     // read is in C++, invisible to QML bindings, so read it here.
     readonly property string _profileStr: (_has("profile") && profileName) ? profileName : ""
+    // Recipe (drink) name — its own item gate. Shown as a fragment and, when it
+    // stands in for an absent profile, as the sentence anchor (see _anchorStr).
+    readonly property string _recipeStr: (_has("recipe") && recipeName.length > 0) ? recipeName : ""
+    // The "using {anchor}" slot: the profile name when the Profile item is shown
+    // with a name, else the active recipe name (add-recipe-to-shot-plan — Recipe
+    // is a stand-in anchor for Profile in the swap case). A shown, available
+    // profile always keeps the anchor; recipe fills it only when profile is
+    // absent. Empty => no anchor => the profile-less recipe sentence.
+    readonly property string _anchorStr: _profileStr !== "" ? _profileStr : _recipeStr
     readonly property string _tempStr: {
         void(Settings.app.temperatureUnit)
         if (!(_has("temperature") && profileTemp > 0)) return ""
@@ -236,24 +252,27 @@ Item {
         var temp = (_tempStr !== "") ? fmt(_tempStr, true, _tempOverride) : ""
         var order = itemOrder || []
 
-        // Sentence format needs the profile as its anchor; without it (item removed
-        // or no profile name) fall through to the fragment list. Word order inside
-        // the scaffold belongs to the translated template — the consumed items
-        // (doseYield's yield, profile, temperature) ignore their list positions.
-        if (sentence && _profileStr !== "") {
+        // Sentence format needs an anchor for its "using %" slot; without one
+        // (no profile name AND no active recipe to stand in) fall through to the
+        // profile-less recipe sentence. The anchor is the profile name, or the
+        // recipe name when the profile is absent (add-recipe-to-shot-plan). Word
+        // order inside the scaffold belongs to the translated template — the
+        // consumed items (doseYield's yield, the anchor, temperature) ignore
+        // their list positions.
+        if (sentence && _anchorStr !== "") {
             var s
             if (_yieldStr !== "" && _tempStr !== "")
                 s = TranslationManager.translate("shotplan.sentence", "Brew %1 of %2, using %3 at %4")
-                    .arg(fmt(_yieldStr, true, _yieldOverride)).arg(fmt(_beverage, false)).arg(fmt(_profileStr, true)).arg(temp)
+                    .arg(fmt(_yieldStr, true, _yieldOverride)).arg(fmt(_beverage, false)).arg(fmt(_anchorStr, true)).arg(temp)
             else if (_yieldStr === "" && _tempStr !== "")
                 s = TranslationManager.translate("shotplan.sentenceNoYield", "Brew %1, using %2 at %3")
-                    .arg(fmt(_beverage, false)).arg(fmt(_profileStr, true)).arg(temp)
+                    .arg(fmt(_beverage, false)).arg(fmt(_anchorStr, true)).arg(temp)
             else if (_yieldStr !== "")
                 s = TranslationManager.translate("shotplan.sentenceNoTemp", "Brew %1 of %2, using %3")
-                    .arg(fmt(_yieldStr, true, _yieldOverride)).arg(fmt(_beverage, false)).arg(fmt(_profileStr, true))
+                    .arg(fmt(_yieldStr, true, _yieldOverride)).arg(fmt(_beverage, false)).arg(fmt(_anchorStr, true))
             else
                 s = TranslationManager.translate("shotplan.sentenceNoYieldNoTemp", "Brew %1, using %2")
-                    .arg(fmt(_beverage, false)).arg(fmt(_profileStr, true))
+                    .arg(fmt(_beverage, false)).arg(fmt(_anchorStr, true))
             var tail = []
             for (var i = 0; i < order.length; i++) {
                 switch (order[i]) {
@@ -262,14 +281,22 @@ Item {
                 case "coffee":    if (_coffeeStr !== "") tail.push(fmt(_coffeeStr, true)); break
                 case "grind":     if (grind !== "") tail.push(grind); break
                 case "roastDate": if (roasted !== "") tail.push(roasted); break
+                // Recipe trails only when it is NOT the anchor — i.e. a profile
+                // filled the slot and recipe is also shown (the both-present
+                // case). When recipe IS the anchor, _profileStr is empty and it
+                // must not also trail.
+                case "recipe":    if (_recipeStr !== "" && _profileStr !== "") tail.push(fmt(_recipeStr, true)); break
                 }
             }
             return tail.length > 0 ? (s + blockSep + tail.join(sep)) : s
         }
 
-        // Recipe sentence — the profile-less anchor. Reached when Sentence is on
-        // but there's no profile anchor (item removed, or no profile name
-        // available), so the plan reads as the recipe itself: "Brew 40.0g of
+        // Beans sentence — the anchorless fallback. ("Recipe sentence" in the
+        // spec, but NOT the Recipe display item — this is the beans-anchored
+        // form reached when neither can fill the "using %" slot.) Reached when
+        // Sentence is on but there's no anchor at all: no profile name (item
+        // removed or none loaded) AND no active recipe to stand in for it
+        // (add-recipe-to-shot-plan). So the plan reads as the drink itself: "Brew 40.0g of
         // Espresso at 92°C from 18.0g of <Roaster> <Bean>". Dose, temperature,
         // roaster and coffee are CONSUMED into the sentence (they don't also
         // trail as fragments); only grind/roastDate trail after. Each piece
@@ -330,6 +357,7 @@ Item {
             case "coffee":      if (_coffeeStr !== "") parts.push(fmt(_coffeeStr, true)); break
             case "grind":       if (grind !== "") parts.push(grind); break
             case "roastDate":   if (roasted !== "") parts.push(roasted); break
+            case "recipe":      if (_recipeStr !== "") parts.push(fmt(_recipeStr, true)); break
             }
         }
         return parts.join(sep)

--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -54,6 +54,7 @@ Dialog {
         case "coffee":      return TranslationManager.translate("shotPlanEditor.showCoffee", "Coffee")
         case "grind":       return TranslationManager.translate("shotPlanEditor.showGrindRpm", "Grind")
         case "roastDate":   return TranslationManager.translate("shotPlanEditor.showRoastDate", "Roast date")
+        case "recipe":      return TranslationManager.translate("shotPlanEditor.itemRecipe", "Recipe")
         case "doseYield":   return TranslationManager.translate("shotPlanEditor.showDoseYield", "Dose & yield")
         }
         return key

--- a/qml/components/layout/ShotPlanConfig.js
+++ b/qml/components/layout/ShotPlanConfig.js
@@ -7,9 +7,11 @@
 // implementations in sync.
 
 // All item keys in canonical (default) order — the pre-configurable fragment
-// order. roastDate is the only item that defaults OFF, matching the legacy
-// shotPlanShowRoastDate default.
-var allKeys = ["doseYield", "profile", "temperature", "roaster", "coffee", "grind", "roastDate"]
+// order. roastDate and recipe are the items that default OFF: roastDate matches
+// the legacy shotPlanShowRoastDate default, and recipe is a new key with no
+// legacy boolean at all (default-OFF is achieved purely by absence from any
+// legacy-derivation branch below and from every pre-change stored list).
+var allKeys = ["doseYield", "profile", "temperature", "roaster", "coffee", "grind", "roastDate", "recipe"]
 
 // Resolve an instance's ordered display-item list: prefer the stored
 // `shotPlanItems` array — its PRESENCE is what matters, an empty array is a

--- a/qml/pages/PostShotReviewPage.qml
+++ b/qml/pages/PostShotReviewPage.qml
@@ -1253,6 +1253,10 @@ Page {
                 roasterBrand: editBeanBrand
                 coffeeName: editBeanType
                 roastDate: editRoastDate
+                // THIS shot's frozen recipe (resolved from editShotData.recipeId),
+                // never the live active recipe — same resolver the recipe card
+                // uses. Empty when the shot had no recipe.
+                recipeName: recipeResolver.recipe.name || ""
                 grindSize: editGrinderSetting
                 grindRpm: editRpm
                 // Only show RPM for grinders that actually report it (a Niche

--- a/qml/pages/ShotDetailPage.qml
+++ b/qml/pages/ShotDetailPage.qml
@@ -601,6 +601,10 @@ Page {
                 roasterBrand: shotData.beanBrand || ""
                 coffeeName: shotData.beanType || ""
                 roastDate: shotData.roastDate || ""
+                // THIS shot's frozen recipe (resolved from shotData.recipeId),
+                // never the live active recipe — same resolver the recipe card
+                // uses. Empty when the shot had no recipe.
+                recipeName: recipeResolver.recipe.name || ""
                 grindSize: shotData.grinderSetting || ""
                 grindRpm: shotData.rpm || 0
                 // Only show RPM for grinders that actually report it (a Niche

--- a/src/network/shotserver_layout.cpp
+++ b/src/network/shotserver_layout.cpp
@@ -3567,7 +3567,7 @@ QString ShotServer::generateLayoutPage() const
     // Mirrors qml/components/layout/ShotPlanConfig.js — keep the key set and
     // legacy-derivation rule in sync with it.
 
-    var SP_ALL_KEYS = ["doseYield", "profile", "temperature", "roaster", "coffee", "grind", "roastDate"];
+    var SP_ALL_KEYS = ["doseYield", "profile", "temperature", "roaster", "coffee", "grind", "roastDate", "recipe"];
     var SP_ITEM_LABELS = {
         doseYield: "Dose & yield",
         profile: "Profile",
@@ -3575,7 +3575,8 @@ QString ShotServer::generateLayoutPage() const
         roaster: "Roaster",
         coffee: "Coffee",
         grind: "Grind",
-        roastDate: "Roast date"
+        roastDate: "Roast date",
+        recipe: "Recipe"
     };
     var spItems = [];
 


### PR DESCRIPTION
## Why

The Shot Plan widget lets users pick and order which brew facts it shows — Dose & yield, Profile, Temperature, Roaster, Coffee, Grind, Roast date — but not the **active recipe (drink) name**, the label many users now brew by. This adds it.

## What changed

Adds an eighth, **default-OFF** Shot Plan display item, `recipe`, showing the active recipe name. It is a **stand-in anchor for Profile** (the intended use is swapping Profile/Roaster/Coffee out for Recipe):

| Config | Renders |
|---|---|
| Recipe shown, **Profile removed** | `Brew 40.0g of Espresso, using Morning Latte at 92°C` |
| **Both** Profile and Recipe shown | `Brew 40.0g of Espresso, using Default at 92°C · Morning Latte` — Profile keeps the anchor, Recipe trails |
| No profile, no active recipe | Today's beans-based recipe sentence, unchanged |
| Fragment mode | Recipe is a plain segment in list order |
| No recipe active | Contributes nothing |

**Rule:** the "using {…}" anchor = profile name if shown & available, else active recipe name; Recipe never displaces a shown profile, and never both anchors and trails.

### Files
- `ShotPlanConfig.js` — `recipe` in `allKeys` (no legacy boolean; default-OFF by absence)
- `ShotPlanText.qml` — `recipeName` property (live default, overridable), `_recipeStr`, shared `_anchorStr` driving the sentence scaffold
- `ScreensaverEditorPopup.qml` — "Recipe" chip label
- `shotserver_layout.cpp` — `recipe` in the web layout editor's `SP_ALL_KEYS` + `SP_ITEM_LABELS` (kept in sync with the QML)
- `ShotDetailPage.qml` / `PostShotReviewPage.qml` — snapshot lines pass the shot's **frozen** recipe name (`recipeResolver.recipe.name`), not the live active recipe

No breaking changes; existing widget configs are unaffected (recipe is absent from every pre-change `shotPlanItems` array).

## Testing
- ✅ Build clean, 0 warnings
- ✅ 92 tests pass, 0 warnings
- ✅ qmllint: no new unresolved-identifier errors
- ⏳ Manual UI check pending: adding Recipe in Shot Plan Settings; frozen-shot snapshot shows the shot's own recipe

## Docs
Wiki Manual (Shot Plan section) updated in the separate `Decenza.wiki` repo — **not yet pushed** (pushed separately since it's a different repo).

## Spec
OpenSpec change `add-recipe-to-shot-plan` archived in this branch; `plan-widgets` spec updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)