### PR TITLE
Remove Read-TDS controls from Settings Connections tab

### DIFF
--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -1469,37 +1469,9 @@ Item {
                         }
                     }
 
-                    // Read TDS Now button (only when connected)
-                    AccessibleButton {
-                        Layout.fillWidth: true
-                        visible: BLEManager.refractometerConnected
-                        text: (typeof Refractometer !== "undefined" && Refractometer && Refractometer.measuring)
-                            ? TranslationManager.translate("settings.refractometer.measuring", "Measuring...")
-                            : TranslationManager.translate("settings.refractometer.readNow", "Read TDS Now")
-                        accessibleName: TranslationManager.translate("settings.refractometer.readTdsNow", "Read TDS from refractometer now")
-                        enabled: typeof Refractometer !== "undefined" && Refractometer && !Refractometer.measuring
-                        onClicked: {
-                            if (typeof Refractometer !== "undefined" && Refractometer)
-                                Refractometer.requestMeasurement()
-                        }
-                    }
-
-                    // Last TDS reading (only when connected and has reading)
-                    RowLayout {
-                        Layout.fillWidth: true
-                        visible: BLEManager.refractometerConnected && typeof Refractometer !== "undefined" && Refractometer && Refractometer.tds > 0
-
-                        Text {
-                            text: TranslationManager.translate("settings.refractometer.lastReading", "Last TDS:")
-                            color: Theme.textSecondaryColor
-                        }
-
-                        Text {
-                            text: (typeof Refractometer !== "undefined" && Refractometer) ? Refractometer.tds.toFixed(2) + "%" : ""
-                            color: Theme.textColor
-                            font: Theme.bodyFont
-                        }
-                    }
+                    // Reading TDS lives on the post-shot review page (where the
+                    // R2 is used); Settings only manages pairing (status + Forget
+                    // above) and discovery (list below), so no Read-TDS control here.
 
                     // Scale connection alert toggle
                     RowLayout {


### PR DESCRIPTION
## Why

The R2 refractometer is only used to capture TDS/EY on the post-shot review page. The **Read TDS Now** button and **Last TDS** readout on the Settings → Connections tab serve no purpose there — and since [#1618](https://github.com/Kulitorum/Decenza/pull/1618) scoped the R2's auto-reconnect to the review page, both controls (gated on `refractometerConnected`) never appeared in Settings anyway.

## What changed

- Removed the **Read TDS Now** button and the **Last TDS** readout from `qml/pages/settings/SettingsConnectionsTab.qml`.
- **Kept everything Connections is for:** the scan button, the discovered-devices list (scales + refractometers), the saved-refractometer status dot, and Forget — so the initial scan + connect (pairing) still works there. Reading TDS lives on the post-shot review page.

## Testing

Build via Qt Creator (Decenza): 0 errors, 0 warnings (QML compiles into the qmlcache). QML-only change; no unit-test harness for QML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)