### PR TITLE
Fix TypeError when reordering shot-plan chips by drag

### DIFF
--- a/qml/components/layout/ScreensaverEditorPopup.qml
+++ b/qml/components/layout/ScreensaverEditorPopup.qml
@@ -565,13 +565,18 @@ Dialog {
                                                 if (drag.active) popup._planDragging = true
                                             }
                                             onReleased: {
-                                                if (popup._planDragging) {
-                                                    var endIndex = planChip.liveIndex
-                                                    if (_startIndex >= 0 && endIndex !== _startIndex)
-                                                        popup.planMoveItem(_startIndex, endIndex)
-                                                }
+                                                // Read state out of the delegate context and reset
+                                                // BEFORE the move: planMoveItem() reassigns
+                                                // shotPlanItems, which rebuilds the DelegateModel and
+                                                // destroys this delegate — so it must be the last
+                                                // statement, or the trailing lines run in a torn-down
+                                                // context where `popup` no longer resolves.
+                                                var from = _startIndex
+                                                var to = popup._planDragging ? planChip.liveIndex : -1
                                                 popup._planDragging = false
                                                 _startIndex = -1
+                                                if (from >= 0 && to >= 0 && to !== from)
+                                                    popup.planMoveItem(from, to)
                                             }
                                             onCanceled: {
                                                 // Roll back any live swaps so the DelegateModel


### PR DESCRIPTION
## Problem

Dragging a shot-plan chip to reorder it logged:

```
ScreensaverEditorPopup.qml:573: TypeError: Value is undefined and could not be converted to an object
```

## Cause

The drag `onReleased` handler called `popup.planMoveItem(...)` **before** resetting `_planDragging`. `planMoveItem()` reassigns `shotPlanItems`, which is the model behind the `DelegateModel` (`planVisualModel`). Reassigning it synchronously rebuilds every chip delegate — including the one that owns this `MouseArea`. With the delegate torn down mid-handler, the trailing `popup._planDragging = false` could no longer resolve the `popup` id through the dead delegate context, throwing the TypeError.

## Fix

Read the drag state out of the delegate context and reset the flag first, so the delegate-destroying `planMoveItem()` call is the handler's **last** statement — nothing touches `popup` or the delegate after the model mutation.

## Testing

QML change, verified manually (no QML test harness). Dragging a shot-plan chip to reorder no longer logs the TypeError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)