### PR TITLE
Capture profile-interop OpenSpec proposals (format + sync + recipe roundtrip)

### DIFF
--- a/openspec/changes/align-profile-json-with-reaprime/.openspec.yaml
+++ b/openspec/changes/align-profile-json-with-reaprime/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/align-profile-json-with-reaprime/design.md
+++ b/openspec/changes/align-profile-json-with-reaprime/design.md
@@ -1,0 +1,84 @@
+## Context
+
+**North star:** the Decent community needs a profile to make the same coffee in every app — import a profile into any DE1 app and get the identical extraction. That requires files that are *readable* everywhere (format) and content that is *equivalent* everywhere (sync). This change is the format half; `sync-builtin-profiles` (Change 2) is the content half.
+
+Today Decenza has **three profile serializations that have drifted**:
+
+| Path | Encoding | `tank_temperature` | `target_volume_count_start` | reaprime-readable |
+|---|---|---|---|---|
+| `Profile::toJson` (profile.cpp:364) — on-disk, export, share-code | numbers | ✗ (`tank_desired_water_temperature`) | ✗ (`number_of_preinfuse_frames`) | **✗ rejected** |
+| `buildVisualizerProfileJson` (visualizeruploader.cpp:1121) — upload | strings | ✓ aliased | ✓ aliased | ✓ |
+| Bundled `resources/profiles/*.json` | numbers | ✗ | ✗ | ✗ (+4 empty-`steps`) |
+
+reaprime's `Profile.fromJson` (`lib/src/models/data/profile.dart`) throws `ArgumentError` when `tank_temperature` or `target_volume_count_start` is absent, or when `steps` is empty; its `parseDouble` accepts both string- and number-encoded values. So the Visualizer builder — which already emits string values, both aliases, and the tablet metadata (`type`/`lang`/`hidden`/`reference_file`/`changes_since_last_espresso`) — is effectively the reaprime-faithful reference implementation. The general serializer simply never received those additions. **The drift is the bug.** `docs/CLAUDE_MD/VISUALIZER.md` already carries a standing warning that the live vs. history upload builders drifted the same way; this is a recurring failure mode in this code.
+
+Decenza's own re-parse is safe either way: `Profile::fromJson` reads values through `jsonToDouble` (profileframe.cpp:6), which parses strings and numbers.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Any profile Decenza emits is readable by reaprime (and any strict DE1 v2 parser) without loss.
+- A single canonical serializer; the Visualizer payload derives from it.
+- Canonical string encoding matching the rest of the ecosystem.
+- Every emitted file has a non-empty, runnable `steps` array — including simple `settings_2a/2b` profiles and bundled files.
+- The `profile_sync` dev tool regenerates the built-ins in the new format and lints them against reaprime's contract.
+
+**Non-Goals:**
+- Content reconciliation / dedup / A-Flow–D-Flow value differences (Change 2). This change makes files *parseable*, not *equivalent*.
+- The `recipe` round-trip through Visualizer (Change 3).
+- Any persisted-data migration. Encoding is backward-compatible on read; content migration belongs to Change 2.
+
+## Decisions
+
+### D1. Unify: `Profile::toJson` is the single source of truth; the Visualizer builder delegates
+The two writers independently re-walk the steps and re-list every key, which is exactly why they drifted. Make `Profile::toJson` the canonical serializer and reduce `buildVisualizerProfileJson` to `Profile::toJson` + Visualizer-only extras (multipart wrapping stays in the caller; the `recipe` block is Change 3). The string decision (D2) collapses the biggest difference between the two, which is what makes delegation low-risk now rather than a rewrite.
+
+*Alternative — parity only (add the keys to `Profile::toJson`, leave two functions):* rejected. It fixes this instance but leaves two sources of truth, so the next added key drifts again.
+
+*Guard:* a byte-parity test asserts the Visualizer upload payload is unchanged except for the intended additions, so delegation provably doesn't regress the tuned upload path.
+
+### D2. Canonical string encoding
+Emit numeric fields as strings in both `ProfileFrame::toJson` and `Profile::toJson`. reaprime reads numbers, but de1app / the tablet / Visualizer / reaprime all *write* strings, and matching them makes a Decenza file byte-shaped like every other app and robust to any strict parser. Import stays dual-tolerant via `jsonToDouble`.
+
+*Alternative — keep numbers:* lower churn and reaprime still reads them, but it leaves Decenza the lone number-encoder and risks a strict third-party parser. Rejected in favor of ecosystem uniformity.
+
+### D3. Reconcile the one behavioral difference between the writers deliberately
+`buildVisualizerProfileJson` emits `weight` always; `Profile::toJson` emits it only when `exitWeight > 0`. Keep the **omit-when-zero** behavior in the unified path — it matches reaprime's `parseOptionalDouble` (absent → null) and is the correct semantic. This is a conscious reconciliation, not an accident to preserve.
+
+### D4. Materialize simple-profile frames before emit
+`settings_2a/2b` profiles ship with `steps: []` and regenerate frames at activation (`regenerateSimpleFrames`). Any emit path must first materialize frames so the file has non-empty steps. `profile_sync` already has `normaliseSimpleProfile` doing exactly this for comparison; reuse that logic on the emit side. This makes even a raw bundled file a valid profile in any app.
+
+### D5. `profile_sync` is the regeneration + lint engine
+Its output already flows through `Profile::toJson`, so it emits the new format for free once the serializer changes. Re-run `--sync` to rewrite the built-ins. Add a reaprime-readability lint (required keys, non-empty steps, enum vocabulary) usable both in the tool and as a test, so a future built-in can't silently regress. (The 3-way de1app↔Decenza↔reaprime compare and the `settings_2a`-vs-stale-`advanced_shot` hardening are Change 2, not here.)
+
+### D6. Consumer audit for string tolerance
+Switching on-disk to strings changes the bytes of every profile Decenza writes, including user profiles on next re-save. `Profile::fromJson` is safe (`jsonToDouble`), but any other reader that does a bare `.toDouble()` / `parseFloat` on these fields would read 0. Audit `src/mcp/` profile tools, QML/JS profile readers, and golden-file tests; fix or update as found. This is a task, not a hope.
+
+## Risks / Trade-offs
+
+- **String encoding changes the bytes of every emitted profile, incl. existing saved user profiles on re-save** → backward-compatible on read (`jsonToDouble`); covered by the consumer audit (D6) and round-trip tests. It is a visible diff in exported files and golden data — expected, not a regression.
+- **Delegation could regress the tuned Visualizer upload** → byte-parity test on the upload payload (D1) is the gate; any diff beyond the intended additions fails the build.
+- **A hidden consumer assumes numbers** → the D6 audit; the readability lint and round-trip tests catch the profile side, but a non-profile reader (e.g. an MCP field) needs the explicit grep pass.
+- **Regenerating all built-ins is a large diff** → deterministic (tool-produced), reviewable as "format only"; content is asserted unchanged by `Profile::functionallyEqual` before/after in `profile_sync` compare mode.
+- **Scope creep into content sync** → hard line: this change only makes files parseable. Equivalence is Change 2, explicitly.
+
+## Migration Plan
+
+1. Switch `ProfileFrame::toJson` and `Profile::toJson` to strings + compat/standard keys + simple-frame materialization (D2, D4).
+2. Delegate `buildVisualizerProfileJson` to `Profile::toJson`; add the byte-parity test (D1).
+3. Run the consumer audit; fix any non-tolerant reader (D6).
+4. Add the reaprime-readability lint; regenerate built-ins via `profile_sync --sync` (D5).
+5. Update `VISUALIZER.md` / `RECIPE_PROFILES.md` with the canonical-format + single-serializer rule.
+
+Rollback is code-only (no persisted-data migration): revert the serializer and regenerated built-ins.
+
+## Open Questions
+
+- Exact home for the reaprime-readability lint: a mode inside `profile_sync` vs. a standalone unit test over `resources/profiles/`. Leaning toward both — a reusable checker called from a test.
+- Whether to also preserve unknown top-level keys through `Profile::fromJson`/`toJson` for passthrough friendliness (mirrors the reaprime concern in Change 3) — likely defer to Change 3.
+- Confirm no CI/release step consumes the bundled profile JSON expecting number encoding before regenerating.
+
+## Follow-on changes (recorded so they are not lost)
+
+- **Change 2 — `sync-builtin-profiles`** (Decenza + reaprime PRs): content reconciliation of the ~63 common built-ins, case-by-case (no blanket authority rule). Extend `profile_sync` to a 3-way compare (de1app-Tcl ↔ Decenza-JSON ↔ reaprime-JSON); harden the `settings_2a` path to prefer settings-derived frames over a stale `advanced_shot` (the lever-corruption lesson from reaprime's #242 curation). Ships Decenza content fixes + a user migration and upstream PRs where Decenza is the more faithful side (e.g. A-Flow 9-frame, which `profile_sync`'s plugin-canonical override already gets right).
+- **Change 3 — `preserve-recipe-visualizer-roundtrip`** (existing, 4 repos): carry the high-level `recipe` block through a Visualizer upload→download round-trip, building on this change's aligned format. Add a one-line correction to its `design.md`: reaprime currently *rejects* Decenza profiles (missing `tank_temperature`), not merely passthrough-strips unknown keys — this change is what makes the "passthrough" framing true.

--- a/openspec/changes/align-profile-json-with-reaprime/proposal.md
+++ b/openspec/changes/align-profile-json-with-reaprime/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The Decent community needs a profile to produce the **same espresso in every app** — a profile authored or shared in one DE1 app must run identically after import into another. That guarantee has two halves: the file must be *readable* everywhere (format), and its content must be *equivalent* everywhere (sync). This change delivers the first half; content sync (Change 2, below) delivers the second.
+
+reaprime (the Flutter DE1 app that, alongside de1app, defines the community "v2" profile format) **cannot read a Decenza-exported profile**. Its `Profile.fromJson` hard-rejects any profile missing `tank_temperature` or `target_volume_count_start`, or with an empty `steps` array — and Decenza emits none of the first two and ships four built-ins with empty steps. Separately, Decenza serializes profiles through **two independently hand-maintained writers** (`Profile::toJson` and `buildVisualizerProfileJson`) that have already drifted: the Visualizer path emits the compat keys and string-encoded values, the on-disk/export path does not. Aligning the format is the foundation for syncing built-in profiles and for the Visualizer recipe round-trip, so it goes first.
+
+## What Changes
+
+- **One canonical serializer.** `Profile::toJson` becomes the single source of truth for Decenza's profile JSON; `buildVisualizerProfileJson` delegates to it and layers only Visualizer-specific additions. This stops the two writers from drifting again (a repeat failure mode — see the standing `buildHistoryShotJson` drift warning in `docs/CLAUDE_MD/VISUALIZER.md`).
+- **Canonical string encoding.** Numeric step and profile fields serialize as strings (`"9.0"`, not `9.0`), matching de1app / the tablet / Visualizer / reaprime's own output. reaprime already *reads* numbers, but writing strings makes a Decenza file byte-shaped like every other DE1 app and safe against any strict parser in the ecosystem. **BREAKING** for byte-level consumers/golden tests (semantically compatible: our own `jsonToDouble` reads both).
+- **Emit the ecosystem-required and standard keys.** `tank_temperature` (alias of `tank_desired_water_temperature`) and `target_volume_count_start` (alias of `number_of_preinfuse_frames`) — both hard-required by reaprime — plus the tablet metadata `type`, `lang`, `hidden`, `reference_file`, `changes_since_last_espresso` that the Visualizer path already emits.
+- **Never emit an empty `steps` array.** Simple `settings_2a`/`settings_2b` profiles (which ship with `steps: []` and regenerate frames at activation) are expanded to explicit frames in any file Decenza emits, so even a raw exported/bundled file is a valid, runnable profile in any app. Preserve omit-`weight`-when-zero (matches reaprime's `parseOptionalDouble`, which reads absent as null).
+- **Leverage and update `tools/profile_sync.cpp`.** Its output flows through `Profile::toJson`, so it emits the new format for free once the serializer changes; re-run it (`--sync`) to regenerate all built-ins in reaprime-readable form. Add a **reaprime-readability lint** (required keys present, `steps` non-empty, enum values valid) as an acceptance gate so a future built-in can't regress.
+- **Audit internal consumers for string tolerance.** Every reader of profile JSON numeric fields (MCP profile tools, any QML/JS reader, golden-file tests) must tolerate string-encoded values. `Profile::fromJson` already does via `jsonToDouble`; the rest need a pass.
+- **NOT doing (recorded so it isn't lost):**
+  - **Change 2 — `sync-builtin-profiles`** (separate, follow-on): reconcile the *content* of the ~63 common built-ins with reaprime, case-by-case (no blanket authority rule), driven by an extended 3-way `profile_sync` (de1app-Tcl ↔ Decenza-JSON ↔ reaprime-JSON) plus a `settings_2a` hardening that prefers settings-derived frames over a stale `advanced_shot` (the lever-corruption lesson from reaprime's own curation pass). Produces Decenza content fixes + a user migration **and** upstream PRs to reaprime where Decenza is the more faithful side (e.g. A-Flow 9-frame).
+  - **Change 3 — `preserve-recipe-visualizer-roundtrip`** (existing change, follow-on): carry the high-level `recipe` block through a Visualizer upload→download round-trip. Builds on this change's aligned format. Its `design.md` should get a one-line correction: reaprime currently *rejects* Decenza profiles (not merely passthrough-strips unknown keys) — this change is what makes the "passthrough" framing true.
+  - Content reconciliation, dedup, and A-Flow/D-Flow value differences are **out of scope here** — this change only makes the built-ins *parseable* by reaprime, not *equivalent* in content.
+
+## Capabilities
+
+### New Capabilities
+- `profile-json-interchange`: The canonical serialization contract for Decenza profile JSON — single-serializer rule, string encoding, the required/standard key set, and the non-empty-`steps` guarantee — such that any profile Decenza emits is readable by reaprime and other DE1 v2 apps without loss.
+
+### Modified Capabilities
+<!-- None. visualizer-upload-persistence governs id write-back, not payload shape; its requirements are unchanged. The upload payload merely delegates to the new canonical serializer. -->
+
+## Impact
+
+- **Serializer:** `src/profile/profileframe.cpp` (`ProfileFrame::toJson` → strings) and `src/profile/profile.cpp` (`Profile::toJson` → strings, compat/standard keys, expand simple-profile steps).
+- **Visualizer upload:** `src/network/visualizeruploader.cpp` (`buildVisualizerProfileJson` delegates to `Profile::toJson`; Visualizer-only extras layered on top). Guarded by a byte-parity test so the upload payload is provably unchanged except for intended additions.
+- **Dev tool:** `tools/profile_sync.cpp` — regenerate built-ins in the new format; add reaprime-readability lint.
+- **Bundled data:** `resources/profiles/*.json` — regenerated; the four empty-`steps` `settings_2a` files gain explicit frames.
+- **Consumer audit:** `src/mcp/` profile tools, any QML/JS profile reader, golden-file tests — confirm string tolerance.
+- **Tests:** parse→emit→parse round-trip, Visualizer-payload byte-parity, and a "reaprime reads our export" fixture (reaprime's required-key + non-empty-steps contract).
+- **Docs:** `docs/CLAUDE_MD/VISUALIZER.md` and `docs/CLAUDE_MD/RECIPE_PROFILES.md` — document the canonical format and single-serializer rule.
+- **No persisted-data migration** in this change (encoding is backward-compatible on read). Content migration belongs to Change 2.

--- a/openspec/changes/align-profile-json-with-reaprime/specs/profile-json-interchange/spec.md
+++ b/openspec/changes/align-profile-json-with-reaprime/specs/profile-json-interchange/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Single canonical profile serializer
+
+Decenza SHALL serialize a profile to JSON through exactly one canonical code path (`Profile::toJson`). Any other producer of profile JSON — including the Visualizer upload payload — SHALL derive its output from that path rather than re-listing profile fields independently.
+
+#### Scenario: Visualizer upload delegates to the canonical serializer
+
+- **WHEN** the Visualizer upload payload for a shot is built
+- **THEN** the embedded `profile` object is produced by the canonical serializer plus only Visualizer-specific additions
+- **AND** no profile field is emitted by an independent second code path
+
+#### Scenario: A newly added profile field appears in every output
+
+- **WHEN** a new profile field is added to the canonical serializer
+- **THEN** it appears in both the on-disk/exported profile and the Visualizer upload payload without a separate edit to the upload builder
+
+### Requirement: Ecosystem-required keys are always present
+
+Every profile Decenza emits SHALL include `tank_temperature` and `target_volume_count_start`, in addition to Decenza's existing `tank_desired_water_temperature` and `number_of_preinfuse_frames`. Their values SHALL equal the corresponding existing keys.
+
+#### Scenario: Exported profile carries the required keys
+
+- **WHEN** a profile is exported, shared, or written to disk
+- **THEN** the JSON contains `tank_temperature` equal to `tank_desired_water_temperature`
+- **AND** the JSON contains `target_volume_count_start` equal to `number_of_preinfuse_frames`
+
+#### Scenario: reaprime accepts the exported profile
+
+- **WHEN** a Decenza-exported profile is parsed by reaprime's `Profile.fromJson`
+- **THEN** parsing succeeds without a missing-required-field error
+
+### Requirement: Standard DE1 metadata keys are emitted
+
+Every profile Decenza emits SHALL include the standard DE1 v2 metadata keys `type`, `lang`, `hidden`, `reference_file`, and `changes_since_last_espresso`, with `type` derived from the profile type (`settings_2a` → `pressure`, `settings_2b` → `flow`, otherwise `advanced`).
+
+#### Scenario: Metadata keys present with derived type
+
+- **WHEN** a `settings_2a` profile is serialized
+- **THEN** the JSON contains `"type": "pressure"` and the keys `lang`, `hidden`, `reference_file`, `changes_since_last_espresso`
+
+### Requirement: Numeric fields are string-encoded
+
+Decenza SHALL serialize numeric step fields and numeric profile-level fields as JSON strings (e.g. `"9.0"`), matching the de1app / tablet / Visualizer / reaprime convention. Decenza SHALL continue to parse both string- and number-encoded values on import.
+
+#### Scenario: Step values serialize as strings
+
+- **WHEN** a profile step with pressure 9.0 is serialized
+- **THEN** the JSON encodes `"pressure": "9.0"` rather than `"pressure": 9.0`
+
+#### Scenario: Round-trip is lossless in either encoding
+
+- **WHEN** a profile is serialized and re-parsed
+- **THEN** the re-parsed profile is functionally equal to the original
+- **AND** a profile authored with number-encoded values still parses correctly
+
+### Requirement: Emitted profiles always have a non-empty steps array
+
+Any profile file Decenza emits SHALL contain a non-empty `steps` array. Simple `settings_2a`/`settings_2b` profiles that carry no explicit frames SHALL have their frames materialized before serialization.
+
+#### Scenario: Simple profile is expanded on export
+
+- **WHEN** a `settings_2a` profile with no explicit steps is exported
+- **THEN** the emitted JSON contains explicit generated frames
+- **AND** reaprime parses it as a valid, runnable profile
+
+#### Scenario: Weight exit omitted when zero
+
+- **WHEN** a step has no weight-exit (weight 0)
+- **THEN** the `weight` key is omitted from that step rather than emitted as `"0.0"`
+
+### Requirement: Built-in profiles pass a reaprime-readability check
+
+The built-in profile set SHALL be regenerated in the canonical format, and a lint SHALL verify that every emitted built-in satisfies reaprime's contract: required keys present, `steps` non-empty, and enum-valued fields (`pump`, `sensor`, `transition`, exit `type`/`condition`) within reaprime's accepted vocabulary.
+
+#### Scenario: Lint fails on a non-conforming built-in
+
+- **WHEN** a built-in profile is missing `tank_temperature`, has empty `steps`, or uses an out-of-vocabulary enum value
+- **THEN** the readability lint reports it as a failure
+
+#### Scenario: Lint passes on the regenerated set
+
+- **WHEN** the lint runs over the regenerated built-in profiles
+- **THEN** every built-in passes

--- a/openspec/changes/align-profile-json-with-reaprime/tasks.md
+++ b/openspec/changes/align-profile-json-with-reaprime/tasks.md
@@ -1,0 +1,45 @@
+## 1. Canonical serializer — string encoding + non-empty steps
+
+- [ ] 1.1 Switch `ProfileFrame::toJson` (src/profile/profileframe.cpp) to string-encode numeric fields (`temperature`, `pressure`, `flow`, `seconds`, `volume`, exit `value`, limiter `value`/`range`); keep omit-`weight`-when-zero.
+- [ ] 1.2 Switch `Profile::toJson` (src/profile/profile.cpp) numeric profile-level fields to strings, matching the Visualizer builder's formatting precision.
+- [ ] 1.3 Materialize simple-profile frames before emit for `settings_2a`/`settings_2b` (reuse `regenerateSimpleFrames` / the `normaliseSimpleProfile` logic) so `steps` is never empty in an emitted file.
+- [ ] 1.4 Verify `Profile::fromJson` still round-trips string-encoded values (it uses `jsonToDouble`); add an explicit number-encoded-input parse test to prove dual tolerance.
+
+## 2. Ecosystem-required and standard keys
+
+- [ ] 2.1 Emit `tank_temperature` (= `tank_desired_water_temperature`) and `target_volume_count_start` (= `number_of_preinfuse_frames`) in `Profile::toJson`.
+- [ ] 2.2 Emit `type` (derived: `settings_2a`→`pressure`, `settings_2b`→`flow`, else `advanced`), `lang`, `hidden`, `reference_file`, `changes_since_last_espresso` in `Profile::toJson`.
+
+## 3. Unify the two writers
+
+- [ ] 3.1 Reduce `buildVisualizerProfileJson` (src/network/visualizeruploader.cpp) to `Profile::toJson` + Visualizer-only additions; remove the duplicated per-field/per-step re-listing.
+- [ ] 3.2 Reconcile the `weight`-always vs. omit-when-zero difference on the unified path in favor of omit-when-zero (D3).
+- [ ] 3.3 Add a byte-parity test asserting the Visualizer upload payload is unchanged except for the intended additions.
+
+## 4. Consumer audit (string tolerance)
+
+- [ ] 4.1 Grep every profile-JSON numeric reader for a bare `.toDouble()` / `toInt()` / `parseFloat` on step/profile fields (`src/mcp/` profile tools, QML/JS readers).
+- [ ] 4.2 Fix any non-tolerant reader to accept string-encoded values; update or regenerate golden-file test data that assumed number encoding.
+
+## 5. Tool + built-in regeneration
+
+- [ ] 5.1 Add a reaprime-readability checker (required keys present, `steps` non-empty, enum vocabulary for `pump`/`sensor`/`transition`/exit `type`+`condition`) reusable from both `tools/profile_sync.cpp` and a unit test.
+- [ ] 5.2 Regenerate `resources/profiles/*.json` via `profile_sync --sync`; confirm the four empty-`steps` `settings_2a` files now carry explicit frames.
+- [ ] 5.3 Confirm `profile_sync` compare mode reports the regenerated built-ins as functionally equal to before (format-only diff, no content change).
+
+## 6. Tests
+
+- [ ] 6.1 Round-trip test: parse → emit → parse yields a functionally-equal profile.
+- [ ] 6.2 Reaprime-contract test over every bundled built-in (required keys, non-empty steps, enum vocabulary) — the "reaprime reads our export" gate.
+- [ ] 6.3 Serialization-shape test: a sample profile emits string values, both compat aliases, and the standard metadata keys.
+- [ ] 6.4 Run the full suite via Qt Creator MCP (`run_tests`, scope all) before opening the PR.
+
+## 7. Docs
+
+- [ ] 7.1 Update `docs/CLAUDE_MD/VISUALIZER.md` and `docs/CLAUDE_MD/RECIPE_PROFILES.md` with the canonical-format contract and the single-serializer rule.
+- [ ] 7.2 Note in the docs that string encoding is the emitted form and `jsonToDouble` keeps import dual-tolerant.
+
+## 8. Follow-on hooks (record, do not implement here)
+
+- [ ] 8.1 Confirm `sync-builtin-profiles` (Change 2) is captured as the content-equivalence follow-on: 3-way `profile_sync` compare + `settings_2a`/stale-`advanced_shot` hardening + reaprime PRs.
+- [ ] 8.2 Confirm `preserve-recipe-visualizer-roundtrip` (Change 3) carries the one-line correction that reaprime currently *rejects* (not merely strips) Decenza profiles.

--- a/openspec/changes/preserve-recipe-visualizer-roundtrip/.openspec.yaml
+++ b/openspec/changes/preserve-recipe-visualizer-roundtrip/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/preserve-recipe-visualizer-roundtrip/design.md
+++ b/openspec/changes/preserve-recipe-visualizer-roundtrip/design.md
@@ -1,0 +1,94 @@
+## Context
+
+D-Flow (Damian Brakel) and A-Flow (Janek) are high-level espresso *recipe editors*: the user sets a handful of parameters (fill / infuse / pour pressures, flows, temperatures, times, plus A-Flow structural toggles) and the editor generates the low-level DE1 `advanced_shot` frames. They originated as **de1app plugins**; Decenza re-implements them as `RecipeParams` + `RecipeGenerator`.
+
+visualizer.coffee stores the entire uploaded `profile` object verbatim in `shot_informations.profile_fields["json"]`, but its readback (`json_profile` / `tcl_profile`) rebuilds the response from a fixed whitelist (`JSON_PROFILE_KEYS`, ~16 keys) and drops everything else. Neither Decenza nor de1app uploads a high-level recipe today — only the flattened frames survive the round-trip.
+
+Consequently, importing a D-Flow/A-Flow profile back from Visualizer produces a profile whose frames are correct but whose recipe editor is populated with **defaults** (the app tags it D-Flow/A-Flow from the title prefix, but has no parameters to load). The frames run correctly, yet the editor misrepresents the profile and saving from it regenerates default frames — silent corruption. This must be fixed for **arbitrary user-created** D-Flow/A-Flow profiles, and the downloaded profile file must be a working, faithful, editable profile in **any** DE1 app.
+
+Investigations informing this design:
+- **Visualizer** stores the uploaded `profile` verbatim; only the readback whitelist drops unknown keys (single-key fix in `app/models/shot_information/profile.rb`).
+- **de1app** D-Flow is a 3-frame editor; A-Flow a 9-frame editor with three structural toggles (`ramp_down_enabled`, `flow_extraction_up`, `2nd_fill_step`). Its high-level state is *not* stored as a structured object — only the frames plus a raw `::settings` dump reach Visualizer. Upload huddle is built in `profile.tcl:443-460` (`legacy_profile_to_v2`) / `shot.tcl:218-233`. A-Flow is identified by `::settings(profile_editor) == "A_Flow"`; D-Flow only by the `"D-Flow /"` title prefix.
+- **reaprime** (Flutter) has **no** recipe editor — only full frame-based v2 profiles. Its `Profile.fromJson`/`toJson` *drops* unknown keys, so a profile routed through it would strip a `recipe`. It is a passthrough concern, not a producer. **Correction (post-investigation):** reaprime does more than passthrough-strip — its `Profile.fromJson` *hard-rejects* any profile missing `tank_temperature` or `target_volume_count_start` (both of which Decenza's on-disk serializer omitted). So until `align-profile-json-with-reaprime` (Change 1) lands, reaprime cannot read a Decenza profile at all; the "passthrough" framing only becomes true once Change 1 ships. **This change depends on Change 1.**
+
+## Goals / Non-Goals
+
+**Goals:**
+- Faithful round-trip of arbitrary D-Flow/A-Flow (and simple pressure/flow) recipe parameters through Visualizer upload → download.
+- A single, additive, versioned `recipe` interchange object that any DE1 app can adopt.
+- The downloaded profile *file* (website "Download this profile") is a valid, working, editable profile importable into any app via the standard File/Tablet path.
+- Backward compatibility: apps that don't understand `recipe` still import a working profile from the authoritative frames.
+- Fix the `target_volume_count_start` → preinfuse-frame-count loss.
+
+**Non-Goals:**
+- Frame→recipe reconstruction (inferring recipe parameters from the frames). It cannot recover A-Flow toggles or distinguish editor variants; explicitly rejected.
+- Adding an editor-type field to the profile JSON — type stays carried by the name convention, preserving interchange-format compatibility.
+- Building a recipe editor in reaprime, or forcing de1app to *read* the recipe (its producer PR is in scope to propose; its reader side is optional).
+- Reconstructing recipe from de1app's raw `app.data.settings` dump.
+
+## Decisions
+
+### D1. Carry the recipe verbatim; do not reconstruct from frames
+The recipe parameters are not derivable from the name (name = editor type only) and not losslessly derivable from the frames (the rejected `RecipeAnalyzer` path never sets `editorType` and cannot recover A-Flow toggles). The only faithful mechanism is to **carry the actual parameters** as a `recipe` object in the profile JSON. Import already consumes it: `Profile::fromJson` (profile.cpp:556) reconstructs `RecipeParams` from a `recipe` block. So the happy path is: add the block on upload, let Visualizer return it, and existing import logic rebuilds the editor exactly.
+
+### D2. `recipe` is additive and backward-compatible; type stays in the name
+`recipe` is an extra key in an otherwise-standard profile JSON. Apps that don't understand it ignore it and still import a working profile from the frames (which stay authoritative). The editor **type** continues to come from the `"D-Flow /"` / `"A-Flow /"` title prefix — no `editorType` field is added (that would break the de1app/Visualizer interchange format). `RecipeParams::toJson` is therefore left as-is (it already omits `editorType`), and `Profile::fromJson` keeps deriving the type from the title.
+
+### D3. No recipe ⇒ import as advanced (never a default-filled editor)
+When a D-Flow/A-Flow-titled profile arrives with no `recipe` block (foreign upload, or pre-change Decenza upload), import it as an **advanced** profile using its frames. The current bug is that `editorType()` claims dflow/aflow from the title alone even with no backing parameters; the fix is that a recipe editor is only presented when a `recipe` block actually backs it. This removes the silent-corruption path entirely, with no guessing.
+
+### D4. Schema = Decenza `RecipeParams`, versioned, documented as the interchange contract
+`RecipeParams::toJson()` is the concrete schema (fill/infuse/pour, A-Flow toggles, simple pressure/flow params, per-step temps). Add a `version` marker inside the `recipe` object; an unrecognized version imports as advanced (D3) rather than risking a misread. Publish the schema as a short spec doc so de1app/reaprime can target the same shape. It is a **superset** of de1app's editors — e.g. de1app D-Flow fixes fill flow (8) / fill timeout (25) and *derives* fill exit-pressure from infuse pressure, whereas Decenza exposes `fillPressure`/`fillFlow`/`fillTimeout`. The schema carries the explicit values; a consumer maps the fields it exposes and applies its own editor's fixed/derived rules for the rest (documented in the mapping table below).
+
+### D5. Enable the round-trip in Visualizer: readback whitelist + a download-format option
+Because the uploaded `profile` (including `recipe`) is already stored verbatim, the in-app API path (`?format=json` → `json_profile`) needs only `recipe` added to `JSON_PROFILE_KEYS` in `app/models/shot_information/profile.rb`. No migration. Offer the maintainer the minimal one-key add, or the more future-proof variant (return the stored `profile_fields["json"]` merged with the notes-stamp instead of rebuilding from a whitelist, so any app's extra keys survive).
+
+The website **"Download this profile" file is TCL by default**, so covering the downloaded *file* means carrying `recipe` in the TCL serialization:
+- **`tcl_profile` embeds `recipe`** — as a nested Tcl dict, or a JSON-string value under a `recipe` key. Decenza's `Profile::loadFromTclFile` (used by `ProfileImporter` for `.tcl`; it already accepts both `.tcl` and `.json`) is taught to parse that key so the TCL download round-trips into a faithful editor. This keeps the downloaded file a working profile for any app: de1app reads its own TCL, Decenza reconstructs the recipe from the embedded key, and apps that don't understand it ignore the key and still import the frames.
+- **Deferred to a separate PR (out of scope here):** adding a JSON download-format *option* to the website (a JSON "Download this profile" variant). Decenza and reaprime are JSON-native and would benefit, but it is an independent enhancement and is intentionally not bundled into this change. This change relies on the JSON **API** readback (`?format=json`) for the in-app importers and TCL embedding for the file download.
+
+### D6. Cross-app roles
+- **Decenza** — producer + consumer: emit `recipe` on upload; reconstruct on import (both share-code and file paths, via `Profile::fromJson`).
+- **de1app** — proposed producer: build a `recipe` huddle from the plugin state and attach it at `profile.tcl:459` / `shot.tcl:233`. A-Flow toggles come from `::ramp_down_enabled`/`::flow_extraction_up`/`::2nd_fill_step`; D-Flow/A-Flow sliders from the `::Dflow_*`/`::Aflow_*` globals. Reading it back is optional/future.
+- **reaprime** — passthrough: stop dropping unknown keys in `Profile.fromJson`/`toJson` (`lib/src/models/data/profile.dart`) and the web import (`profile_handler.dart`) so a profile routed through reaprime keeps its `recipe`. No editor work needed.
+
+### de1app ↔ Decenza field mapping (for the schema doc)
+| Recipe field | de1app D-Flow | de1app A-Flow |
+|---|---|---|
+| fillTemperature | `Dflow_filling_temperature` | `Aflow_filling_temperature` |
+| fillPressure | derived from infuse pressure (fixed rule) | from `filling`/`ramp` frames |
+| fillFlow | fixed 8 | `Aflow_filling_flow` |
+| fillTimeout | fixed 25 | frame `filling(seconds)` |
+| infuseEnabled | always true | always true (frame present) |
+| infusePressure / infuseTime / infuseWeight / infuseVolume | `Dflow_soaking_*` | `Aflow_soaking_*` |
+| pourTemperature | `Dflow_pouring_temperature` | `Aflow_pouring_temperature` |
+| pourFlow | `Dflow_pouring_flow` | `Aflow_pouring_flow` |
+| pourPressure | `Dflow_pouring_pressure` | `Aflow_pouring_pressure` |
+| rampTime | fixed | `Aflow_ramp_updown_seconds` |
+| rampDownEnabled / flowExtractionUp / secondFillEnabled | n/a | `::ramp_down_enabled` / `::flow_extraction_up` / `::2nd_fill_step` |
+| targetWeight / targetVolume / dose | `final_desired_shot_weight_advanced` / `..volume..` / `grinder_dose_weight` | same |
+| preinfuse count | `final_desired_shot_volume_advanced_count_start` | same |
+
+## Risks / Trade-offs
+
+- **Visualizer PR must merge and deploy before the round-trip closes.** → Ship Decenza's upload first (recipes start being stored immediately, readable retroactively once the server change lands). Until then, Decenza→Decenza either waits or uses a notes-smuggle stopgap (ugly; not recommended as the destination).
+- **Schema divergence across apps** (de1app derives some fields Decenza stores explicitly). → The `version`-marked schema doc is the contract; consumers map exposed fields and apply their own fixed/derived rules for the rest. Round-trip within one app is always exact; cross-app is faithful for the fields both model.
+- **reaprime silently strips unknown keys today**, so routing a profile through it breaks the chain. → Passthrough PR to preserve unknown keys; until merged, document that reaprime is not recipe-preserving. (Separately, reaprime *rejects* Decenza profiles outright until Change 1 adds `tank_temperature`/`target_volume_count_start` — the `recipe` passthrough only matters once files are readable at all.)
+- **de1app-uploaded D-Flow/A-Flow profiles have no `recipe`** and (per D3) import as advanced in Decenza rather than reconstructing. → Accepted: consistent "no guessing" behavior; improves automatically once de1app adopts the producer PR.
+- **The website file download is TCL**, so the JSON whitelist fix alone does not cover it. → Embed `recipe` in `tcl_profile` and parse it in `Profile::loadFromTclFile`. (A JSON download option is deferred to a separate PR.)
+
+## Migration Plan
+
+1. Decenza: emit `recipe` (with `version`) on upload; add the no-recipe⇒advanced import guard; fix the preinfuse-count mapping. Ship — forward/backward compatible on its own.
+2. Publish the `recipe` schema doc; align with de1app plugin authors / Visualizer maintainer.
+3. Visualizer PR (readback whitelist). On deploy, Decenza→Decenza round-trip becomes exact (including retroactively-stored recipes).
+4. de1app producer PR; reaprime passthrough PR.
+Rollback: the upload key and import guard are independent and individually revertible; no persisted-data migration, so rollback is code-only.
+
+## Open Questions
+
+- TCL `recipe` encoding: nested Tcl dict vs a single JSON-string value under a `recipe` key — pick the one that's least invasive to Visualizer's `tcl_profile` and cleanest for `Profile::loadFromTclFile` to parse.
+- Final `recipe` schema `version` string and where it's documented (in-repo doc vs a shared community spec).
+- Scope/timing of the deferred JSON download-format option (separate PR) — track but do not implement here.
+- Should Decenza also preserve unknown top-level profile keys through `Profile::fromJson`/`toJson` for its own passthrough friendliness (mirrors the reaprime concern)?
+- Confirm byte-exact `JSON_PROFILE_KEYS` / `PROFILE_FIELDS` in Visualizer before drafting that PR (the source was read via a summarizing fetch).

--- a/openspec/changes/preserve-recipe-visualizer-roundtrip/proposal.md
+++ b/openspec/changes/preserve-recipe-visualizer-roundtrip/proposal.md
@@ -1,0 +1,32 @@
+> **Sequencing:** third in the profile-interop trilogy. Depends on `align-profile-json-with-reaprime` (Change 1 — format readability) and pairs with `sync-builtin-profiles` (Change 2 — content equivalence). This change carries the high-level `recipe` block through Visualizer; it assumes Change 1's aligned, reaprime-readable format is in place.
+
+## Why
+
+D-Flow and A-Flow profiles downloaded from visualizer.coffee do not come back as the profile that was uploaded. Visualizer stores only the flattened advanced frames, so on import the app re-labels the profile as D-Flow/A-Flow (from the title prefix) but has no recipe parameters to load — it fills the editor with **defaults**. The frames still run correctly, but the D-Flow/A-Flow editor shows wrong values (e.g. 88 °C / 3 bar / 20 s instead of 84 °C / 6 bar / 1 s), and opening the editor and saving regenerates frames from those defaults, silently destroying the profile. This must work for **arbitrary** user-created D-Flow/A-Flow profiles, not just the built-ins, and frame→recipe reconstruction is explicitly out of scope because it cannot be lossless (it cannot recover A-Flow structural toggles or the editor type).
+
+## What Changes
+
+- **Upload carries the recipe.** The Visualizer upload embeds a `recipe` object (the high-level editor parameters) inside the uploaded profile JSON. The editor *type* continues to be carried by the profile name convention ("D-Flow /…", "A-Flow /…"), not a JSON field — no new type key, no interchange-format break.
+- **Import reconstructs from the recipe, or falls back to advanced.** When a downloaded profile carries a `recipe` block, the app rebuilds the D-Flow/A-Flow editor exactly from it. When it does **not** (foreign uploads, or shots uploaded before this ships), the app imports it as an **advanced** profile — never a default-filled D-Flow/A-Flow editor. No guessing.
+- **The downloadable file is a complete, working profile for any app.** The profile file served by the Visualizer website's "Download this profile" link (not only Decenza's in-app share-code importer) carries the `recipe` and imports as a faithful, editable, immediately-usable profile through the standard File/Tablet import path — into **any** DE1 app. The `recipe` is an **additive, backward-compatible** key: an app that understands it reconstructs the exact D-Flow/A-Flow editor; an app that does not simply ignores it and still imports a fully working profile from the authoritative frames. This is why the frames stay authoritative and no editor-type field is added. Because Decenza's share-code importer and file importer share `Profile::fromJson`, one payload covers both Decenza paths; the recipe must be present in whichever serialization the download serves (JSON is primary; the TCL/`.tcl` download variant is a Visualizer-side consideration).
+- **Preinfuse-frame-count mapping fix.** On import, map Visualizer's `target_volume_count_start` to the preinfuse frame count so it stops silently resetting to 0.
+- **Shared `recipe` interchange schema.** Define and document a small, versioned `recipe` JSON schema (D-Flow, A-Flow, and the simple pressure/flow editors) so it is an ecosystem interchange format rather than a Decenza-private field.
+- **NOT doing:** frame→recipe reconstruction (lossy); adding an `editorType`/type field to the profile JSON (breaks compatibility).
+- **Coordinated, out-of-repo (tracked here for context, PRs land in their own repos):** a one-key readback-whitelist change in visualizer.coffee so the stored `recipe` is returned on download; and adoption of the same `recipe` block by de1app (D-Flow + A-Flow plugins via `visualizer_upload`) and reaprime, so profiles created in any app round-trip everywhere.
+
+## Capabilities
+
+### New Capabilities
+- `visualizer-recipe-roundtrip`: Preservation and reconstruction of the high-level D-Flow/A-Flow (and simple pressure/flow) recipe parameters across a visualizer.coffee upload→download round-trip, via a shared `recipe` block, with an advanced-profile fallback when no recipe is present.
+
+### Modified Capabilities
+<!-- No existing spec's requirements change; the import fallback and upload payload are introduced as new requirements under the new capability above. -->
+
+## Impact
+
+- **Upload:** `src/network/visualizeruploader.cpp` (`buildVisualizerProfileJson`) — emit the `recipe` object.
+- **Import:** `src/network/visualizerimporter.cpp` (`parseVisualizerProfile`) and `src/profile/profile.cpp` (`Profile::fromJson`) — consume `recipe` when present (already partially wired); when absent, import D-Flow/A-Flow-titled profiles as advanced; map `target_volume_count_start` → preinfuse frame count.
+- **Schema:** `src/profile/recipeparams.{h,cpp}` (`RecipeParams::toJson`/`fromJson`) is the serialization contract; a companion doc describes the interchange schema. No new Decenza-only field is added to the standard profile JSON.
+- **External repos (separate PRs):** miharekar/visualizer (readback whitelist), de1app D-Flow/A-Flow/`visualizer_upload` plugins, tadelv/reaprime — adopt the shared `recipe` block.
+- **Docs:** update `docs/CLAUDE_MD/VISUALIZER.md` (import/round-trip behavior) and the wiki manual entry for Visualizer import.
+- **Tests:** round-trip unit tests (D-Flow and A-Flow recipe → upload JSON → import → identical `RecipeParams`); no-recipe → advanced; preinfuse-count mapping.

--- a/openspec/changes/preserve-recipe-visualizer-roundtrip/specs/visualizer-recipe-roundtrip/spec.md
+++ b/openspec/changes/preserve-recipe-visualizer-roundtrip/specs/visualizer-recipe-roundtrip/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Upload embeds the recipe parameters
+
+The Visualizer upload SHALL embed a `recipe` object, containing the high-level editor parameters, inside the uploaded profile JSON for every recipe-based profile (D-Flow, A-Flow, and the simple pressure/flow editors). The `recipe` object SHALL carry a schema `version` marker. The editor type SHALL continue to be conveyed by the profile name convention ("D-Flow /…", "A-Flow /…") and SHALL NOT be added as a field to the profile JSON.
+
+#### Scenario: D-Flow profile upload includes recipe
+
+- **WHEN** a D-Flow profile is uploaded to visualizer.coffee
+- **THEN** the uploaded profile JSON contains a `recipe` object with the profile's fill, infuse, and pour parameters and a schema `version`
+- **AND** the profile JSON contains no editor-type field
+
+#### Scenario: A-Flow structural toggles are included
+
+- **WHEN** an A-Flow profile with structural options (e.g. split pressure ramp, second fill, flow-up extraction) is uploaded
+- **THEN** the `recipe` object records those toggle values so the exact frame structure can be reproduced
+
+#### Scenario: Advanced profile upload omits recipe
+
+- **WHEN** a hand-built advanced profile (not created by a recipe editor) is uploaded
+- **THEN** no `recipe` object is added and the upload is unchanged
+
+### Requirement: Import reconstructs the editor from the recipe
+
+When an imported profile carries a `recipe` object with a recognized schema `version`, the app SHALL reconstruct the D-Flow/A-Flow (or simple pressure/flow) editor exactly from those parameters, for arbitrary user-created profiles, without deriving parameters from the frames.
+
+#### Scenario: Faithful round-trip of a user D-Flow profile
+
+- **WHEN** a user-created D-Flow profile is uploaded and then imported back
+- **THEN** the reconstructed profile's recipe parameters equal the original's (fill/infuse/pour pressures, flows, temperatures, times, weights, and target weight/volume)
+- **AND** opening it in the D-Flow editor shows the original values, not defaults
+
+#### Scenario: Faithful round-trip of a user A-Flow profile
+
+- **WHEN** a user-created A-Flow profile with non-default structural toggles is uploaded and then imported back
+- **THEN** the reconstructed profile is A-Flow with the same toggles and parameters, and its generated frames match the original
+
+### Requirement: Missing recipe imports as an advanced profile
+
+When an imported profile has a D-Flow/A-Flow name but no `recipe` object (a foreign upload, or one predating this change), the app SHALL import it as an advanced profile using the profile's frames, and SHALL NOT present a recipe editor populated with default parameters. The app SHALL NOT attempt to reconstruct recipe parameters from the frames.
+
+#### Scenario: Foreign D-Flow-named profile without recipe
+
+- **WHEN** a profile titled "D-Flow / …" is imported and carries no `recipe` object
+- **THEN** it is imported as an advanced profile whose frames match the download
+- **AND** no default-filled D-Flow editor is shown for it
+
+#### Scenario: Unrecognized recipe version
+
+- **WHEN** an imported profile carries a `recipe` object whose schema `version` the app does not recognize
+- **THEN** the app imports it as an advanced profile rather than misreading the recipe
+
+### Requirement: Recipe survives the standard file-import path
+
+The recipe reconstruction SHALL apply to profiles imported from a downloaded profile file (the Visualizer website "Download this profile" file, imported via the standard File/Tablet import), not only to profiles fetched through the in-app share-code importer. A downloaded profile file SHALL be a valid, working profile importable into any DE1 app.
+
+#### Scenario: File import reconstructs the recipe
+
+- **WHEN** a profile file downloaded from visualizer.coffee that contains a `recipe` object is imported via File/Tablet import
+- **THEN** the app reconstructs the same D-Flow/A-Flow editor as the in-app share-code importer would
+
+#### Scenario: Recipe key is backward-compatible
+
+- **WHEN** the downloaded profile file is imported by an app that does not understand the `recipe` key
+- **THEN** the extra key is ignored and a fully working profile is imported from the frames
+
+### Requirement: Preinfuse frame count is preserved on import
+
+On import, the app SHALL derive the preinfuse frame count from the profile's `target_volume_count_start` field when present, rather than resetting it to zero.
+
+#### Scenario: Preinfuse count round-trips
+
+- **WHEN** a profile whose preinfuse frame count is 2 is uploaded and imported back
+- **THEN** the imported profile's preinfuse frame count is 2, not 0

--- a/openspec/changes/preserve-recipe-visualizer-roundtrip/tasks.md
+++ b/openspec/changes/preserve-recipe-visualizer-roundtrip/tasks.md
@@ -1,0 +1,50 @@
+## 1. Recipe interchange schema
+
+- [ ] 1.1 Add a `version` marker to the `recipe` object in `RecipeParams::toJson()` and read/validate it in `RecipeParams::fromJson()` (unrecognized version → signal "treat as absent").
+- [ ] 1.2 Write the `recipe` schema doc (fields, units, defaults, A-Flow toggles, version) — the interchange contract; include the de1app D-Flow/A-Flow ↔ recipe mapping table from design.md.
+
+## 2. Decenza upload (producer)
+
+- [ ] 2.1 In `VisualizerUploader::buildVisualizerProfileJson()` (visualizeruploader.cpp), emit `recipe = profile->recipeParams().toJson()` for recipe-based editors (dflow/aflow, and simple pressure/flow where recipe params are set). Do NOT add any editor-type field; type stays name-derived.
+- [ ] 2.2 Confirm no `recipe` is emitted for hand-built advanced profiles.
+
+## 3. Decenza import (consumer + fallback)
+
+- [ ] 3.1 Verify `Profile::fromJson` reconstructs `m_recipeParams` from a present `recipe` block (already wired at profile.cpp:556); add version handling so an unrecognized `recipe.version` is treated as absent.
+- [ ] 3.2 Implement the "no recipe ⇒ advanced" guard: a D-Flow/A-Flow-titled profile with no (valid) `recipe` block imports as an advanced profile — never a default-filled recipe editor. Ensure `editorType()` only resolves to dflow/aflow when a recipe actually backs it.
+- [ ] 3.3 Remove/avoid the frames→recipe path (`RecipeAnalyzer`) from the Visualizer import flow so no reconstruction-from-frames occurs on import.
+
+## 4. Preinfuse frame count fix
+
+- [ ] 4.1 In `Profile::fromJson`, map `target_volume_count_start` → `m_preinfuseFrameCount` (fall back to `number_of_preinfuse_frames`/`preinfuse_frame_count`/`countPreinfuseFrames` as today) so the count round-trips instead of resetting to 0.
+
+## 5. TCL file-download support (Decenza side)
+
+- [ ] 5.1 Teach `Profile::loadFromTclFile` to parse an embedded `recipe` key from a `.tcl` profile (matching the Visualizer TCL encoding chosen in the PR), so the website TCL download round-trips into a faithful editor via `ProfileImporter`.
+- [ ] 5.2 Confirm a `.tcl` download lacking `recipe` still imports as a working advanced profile (backward compatible).
+
+## 6. Tests
+
+- [ ] 6.1 Round-trip unit test: D-Flow `RecipeParams` → upload JSON (`buildVisualizerProfileJson`) → `Profile::fromJson` → identical `RecipeParams` (all fill/infuse/pour fields, targets).
+- [ ] 6.2 Round-trip unit test: A-Flow with non-default `rampDownEnabled`/`flowExtractionUp`/`secondFillEnabled` → identical toggles and generated frames.
+- [ ] 6.3 Test: D-Flow/A-Flow-titled profile with no `recipe` block imports as advanced (no default-filled editor).
+- [ ] 6.4 Test: unrecognized `recipe.version` imports as advanced.
+- [ ] 6.5 Test: preinfuse frame count of 2 survives upload→import (not 0).
+- [ ] 6.6 Test: TCL profile with embedded `recipe` reconstructs; TCL without it imports as working advanced.
+- [ ] 6.7 Run the full suite via `mcp__qtcreator__run_tests` (scope all) before PR.
+
+## 7. Documentation
+
+- [ ] 7.1 Update `docs/CLAUDE_MD/VISUALIZER.md` (round-trip behavior, recipe block, no-recipe⇒advanced, TCL embedding).
+- [ ] 7.2 Update the wiki manual Visualizer-import entry for the faithful D-Flow/A-Flow round-trip.
+
+## 8. External / ecosystem PRs (separate repos — coordinate, not landed in this repo)
+
+- [ ] 8.1 Visualizer (miharekar/visualizer): add `recipe` to `JSON_PROFILE_KEYS` in `app/models/shot_information/profile.rb`; embed `recipe` in `tcl_profile`. Confirm `JSON_PROFILE_KEYS`/`PROFILE_FIELDS` byte-exact from `base.rb`/`profile.rb` before drafting. (JSON download-format option is a SEPARATE, deferred PR — do not include.)
+- [ ] 8.2 de1app (producer): build a `recipe` huddle from D-Flow/A-Flow plugin state and attach it at `profile.tcl:459` / `shot.tcl:233`; source A-Flow toggles from `::ramp_down_enabled`/`::flow_extraction_up`/`::2nd_fill_step`, sliders from `::Dflow_*`/`::Aflow_*`. Coordinate schema with plugin authors.
+- [ ] 8.3 reaprime (passthrough): stop dropping unknown keys in `Profile.fromJson`/`toJson` (`lib/src/models/data/profile.dart`) and the web import (`profile_handler.dart`) so a `recipe` survives routing through reaprime.
+
+## 9. Verification
+
+- [ ] 9.1 End-to-end: upload a user D-Flow and a user A-Flow from Decenza, download via the in-app share-code importer, confirm reconstructed recipe equals the original (via `profiles_get_detail` / D-Flow editor).
+- [ ] 9.2 Clean up the throwaway `d_flow_q_vizimporttest` test profile created during investigation.

--- a/openspec/changes/sync-builtin-profiles/.openspec.yaml
+++ b/openspec/changes/sync-builtin-profiles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/sync-builtin-profiles/proposal.md
+++ b/openspec/changes/sync-builtin-profiles/proposal.md
@@ -1,0 +1,36 @@
+> **STATUS: STUB / follow-on.** Blocked on `align-profile-json-with-reaprime` (Change 1) landing first. This file records intent so it isn't lost; design.md, specs, and tasks are to be fleshed out once the aligned format ships and the case-by-case audit begins. Do not implement yet.
+
+## Why
+
+The Decent community needs a profile to make the **same coffee in every app**. Change 1 (`align-profile-json-with-reaprime`) makes Decenza's profiles *readable* by reaprime; this change makes the built-in profiles *equivalent* in content, so importing a shared profile yields the identical extraction regardless of which app authored it.
+
+The ~63 built-in profiles common to Decenza and reaprime are **not** identical today: ~14 differ in step count (e.g. A-Flow 6 vs 9 frames), and ~50 have real value differences, on top of encoding/omitted-zero noise. Neither side is automatically authoritative: reaprime's set was pulled from Visualizer + de1app copy-exports and is documented (their issue #242 curation) to have contained stale notes, duplicate collisions, and **lever-profile corruption** (importing de1app's stale `advanced_shot` instead of the `settings_2a` intent). Decenza is likely the more faithful side for several (A-Flow 9-frame matches de1app's editor; levers), while reaprime may be cleaner for others. So sync is **bidirectional and case-by-case**, not a one-way overwrite.
+
+## What Changes
+
+- **Extend `tools/profile_sync.cpp` to a 3-way compare** — de1app-Tcl ↔ Decenza-JSON ↔ reaprime `assets/defaultProfiles` (JSON) — to surface every divergence in one report and drive the audit.
+- **Harden the `settings_2a` path** to prefer settings-derived frames over a stale `advanced_shot` (the lever-corruption lesson from reaprime #242), in the parser/sync path (`src/profile/profile.cpp`).
+- **Per-profile audit doc** classifying each common profile keep / metadata-fix / content-fix / dedup / needs-decision. Divergent profiles are reviewed **case by case** with the user — no blanket "de1app wins" or "reaprime wins" rule. Suspect heuristic: any `settings_2a` profile carrying explicit frames is flagged until reviewed.
+- **Content + dedup fixes to Decenza built-ins** where warranted (`resources/profiles/*.json`), plus a check for the same collisions reaprime found (Sencha/Sensha, Chinese-green/white-tea, Bug-Bite/oolong-dark, milky=straight byte-copies).
+- **A one-time user migration** so users who imported a now-corrected built-in receive the fixed version (Decenza's equivalent of reaprime's M1 metadata-refresh / M2 retire-list).
+- **Upstream PRs to tadelv/reaprime** for profiles where Decenza is the more faithful side (A-Flow 9-frame; any lever/param corrections), updating their `assets/defaultProfiles/` + `manifest.json`.
+- **Sourcing dependency:** obtain Visualizer canonical JSON for genuinely-disputed profiles where neither app's frames are trustworthy (reaprime was blocked on this too — lever re-port, milky differentiation).
+- **NOT doing:** the serialization-format work (Change 1) and the `recipe` round-trip (Change 3, `preserve-recipe-visualizer-roundtrip`).
+
+## Capabilities
+
+### New Capabilities
+- `builtin-profile-sync`: Cross-app content equivalence of the bundled profile set — a tooling-driven, case-by-case reconciliation of Decenza's built-ins against reaprime (and de1app/Visualizer as references), with a user migration for corrected profiles and upstream PRs where Decenza is canonical.
+
+### Modified Capabilities
+<!-- TBD when fleshed out. Likely none at spec level; this is data + tooling. -->
+
+## Impact
+
+- **Tool:** `tools/profile_sync.cpp` (3-way compare, reaprime JSON input).
+- **Parser:** `src/profile/profile.cpp` (`settings_2a` prefer-regenerated-frames hardening).
+- **Bundled data:** `resources/profiles/*.json` (content/dedup fixes, regeneration).
+- **Migration:** profile-seeding path (retire/refresh corrected built-ins).
+- **External:** PRs to tadelv/reaprime (`assets/defaultProfiles/`, `manifest.json`); Visualizer canonical JSON sourcing.
+- **Docs:** the audit doc (in this change) + `docs/CLAUDE_MD/RECIPE_PROFILES.md`.
+- **Depends on:** `align-profile-json-with-reaprime` (Change 1) shipping first.

--- a/openspec/changes/sync-builtin-profiles/specs/builtin-profile-sync/spec.md
+++ b/openspec/changes/sync-builtin-profiles/specs/builtin-profile-sync/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Common built-in profiles are content-equivalent across apps
+
+The bundled profiles Decenza and reaprime share SHALL, after reconciliation, produce the same extraction — importing a shared profile into either app yields functionally-identical frames. Divergences SHALL be resolved case-by-case using de1app settings and Visualizer canonical JSON as references (never de1app's stale `advanced_shot` frames), with fixes flowing to whichever app is less faithful.
+
+> STUB: this requirement is a placeholder capturing the equivalence goal. Full requirements (audit method, 3-way tooling, migration, dedup rules) are to be authored once `align-profile-json-with-reaprime` lands and the case-by-case audit begins.
+
+#### Scenario: A reconciled shared profile makes the same coffee in either app
+
+- **WHEN** a built-in common to Decenza and reaprime has been reconciled
+- **THEN** the two apps' copies parse to functionally-equal frames
+- **AND** the divergence resolution is recorded in the audit with its chosen reference source
+
+#### Scenario: A settings_2a profile carrying stale advanced_shot frames is caught
+
+- **WHEN** a `settings_2a` profile is found carrying explicit frames that contradict its settings intent
+- **THEN** it is flagged for review and reconciled from the settings fields (or Visualizer canonical JSON), not from the stale `advanced_shot`


### PR DESCRIPTION
## Summary

Captures the three-change plan for **cross-app profile interoperability** — so a profile makes the same coffee in any DE1 app (Decenza, reaprime, de1app). Planning artifacts only; **no code changes**.

The community need: a profile authored or shared in one app must run identically after import into another. That has two halves — files must be *readable* everywhere (format) and content must be *equivalent* everywhere (sync). These proposals split the work accordingly.

## The three changes

| Change | Scope | State |
|---|---|---|
| **`align-profile-json-with-reaprime`** (Ch1) | Unify Decenza's profile serialization onto one canonical, string-encoded, reaprime-readable format — adds `tank_temperature` + `target_volume_count_start`, guarantees non-empty `steps`, single serializer (Visualizer path delegates). | Ready to implement |
| **`sync-builtin-profiles`** (Ch2) | Case-by-case content reconciliation of the ~63 shared built-ins via an extended 3-way `profile_sync`; `settings_2a`/stale-`advanced_shot` hardening; bidirectional reaprime PRs; user migration. | Stub — blocked on Ch1 |
| **`preserve-recipe-visualizer-roundtrip`** (Ch3) | Carry the high-level `recipe` block through a Visualizer upload→download round-trip. Cross-linked to depend on Ch1; corrected to note reaprime *hard-rejects* (not just strips) our profiles today. | Existing, now sequenced |

## Why now
Capturing the plan before implementing Ch1, so the follow-ons (content sync + recipe roundtrip) aren't lost and the sequencing is on record.

## Key findings behind the plan
- reaprime's `Profile.fromJson` rejects any profile missing `tank_temperature`/`target_volume_count_start` or with empty `steps` — Decenza's on-disk serializer emitted none of these, so reaprime can't read our exports today.
- Decenza already has two drifted serializers; the Visualizer one is the reaprime-faithful reference. Ch1 unifies them.
- Content sync is bidirectional: Decenza is more faithful for some (A-Flow 9-frame, levers), reaprime's set had documented stale/corrupt content (their #242 curation). de1app's `advanced_shot` is **not** a safe tiebreaker for `settings_2a` profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)