### PR TITLE
Fetch model list from custom endpoints (#1598 follow-up)

### DIFF
--- a/qml/pages/settings/SettingsAITab.qml
+++ b/qml/pages/settings/SettingsAITab.qml
@@ -246,6 +246,7 @@ KeyboardAwareContainer {
                 // Model selection (providers exposing a fixed catalog of >1 model).
                 // Generic: any provider whose availableModels() returns multiple
                 // entries lights this up automatically — no per-provider wiring.
+                // Hidden when a custom endpoint is set (dynamic picker shown instead).
                 ColumnLayout {
                     id: modelSelect
                     // Re-evaluated when the active provider changes (the binding
@@ -254,7 +255,14 @@ KeyboardAwareContainer {
                         ? MainController.aiManager.availableModels(Settings.ai.aiProvider)
                         : []
                     property string currentProvider: Settings.ai.aiProvider
-                    visible: options.length > 1
+                    property bool hasCustomEndpoint: {
+                        switch(Settings.ai.aiProvider) {
+                            case "openai": return Settings.ai.openaiEndpoint !== ""
+                            case "anthropic": return Settings.ai.anthropicEndpoint !== ""
+                            default: return false
+                        }
+                    }
+                    visible: options.length > 1 && !hasCustomEndpoint
                     Layout.fillWidth: true
                     spacing: Theme.scaled(8)
 
@@ -320,6 +328,50 @@ KeyboardAwareContainer {
                         font.pixelSize: Theme.scaled(11)
                         wrapMode: Text.Wrap
                         Layout.fillWidth: true
+                    }
+                }
+
+                // Dynamic model picker for custom endpoints (OpenAI/Anthropic with custom base URL)
+                ColumnLayout {
+                    visible: modelSelect.hasCustomEndpoint
+                    Layout.fillWidth: true
+                    spacing: Theme.scaled(8)
+
+                    Tr {
+                        key: "settings.ai.model"
+                        fallback: "Model"
+                        color: Theme.textColor
+                        font.pixelSize: Theme.scaled(14)
+                        font.bold: true
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Theme.scaled(8)
+
+                        StyledComboBox {
+                            id: customEndpointModelCombo
+                            Layout.fillWidth: true
+                            model: MainController.aiManager ? MainController.aiManager.customEndpointModels : []
+                            currentIndex: {
+                                var models = MainController.aiManager ? MainController.aiManager.customEndpointModels : []
+                                var stored = Settings.ai.providerModel(Settings.ai.aiProvider)
+                                return Math.max(0, models.indexOf(stored))
+                            }
+                            onActivated: function(index) {
+                                var models = MainController.aiManager ? MainController.aiManager.customEndpointModels : []
+                                if (index >= 0 && index < models.length) {
+                                    Settings.ai.setProviderModel(Settings.ai.aiProvider, models[index])
+                                }
+                            }
+                            accessibleLabel: TranslationManager.translate("settings.ai.modelAccessible", "AI model")
+                        }
+
+                        AccessibleButton {
+                            text: TranslationManager.translate("settings.ai.refresh", "Refresh")
+                            accessibleName: TranslationManager.translate("settings.ai.refreshEndpointModels", "Refresh list of available models from custom endpoint")
+                            onClicked: MainController.aiManager?.refreshCustomEndpointModels()
+                        }
                     }
                 }
 

--- a/src/ai/aimanager.cpp
+++ b/src/ai/aimanager.cpp
@@ -106,6 +106,7 @@ void AIManager::createProviders()
     connect(openai, &AIProvider::analysisComplete, this, &AIManager::onAnalysisComplete);
     connect(openai, &AIProvider::analysisFailed, this, &AIManager::onAnalysisFailed);
     connect(openai, &AIProvider::testResult, this, &AIManager::onTestResult);
+    connect(openai, &OpenAIProvider::modelsRefreshed, this, &AIManager::onCustomEndpointModelsRefreshed);
     m_openaiProvider.reset(openai);
 
     // Create Anthropic provider
@@ -116,6 +117,7 @@ void AIManager::createProviders()
     connect(anthropic, &AIProvider::analysisComplete, this, &AIManager::onAnalysisComplete);
     connect(anthropic, &AIProvider::analysisFailed, this, &AIManager::onAnalysisFailed);
     connect(anthropic, &AIProvider::testResult, this, &AIManager::onTestResult);
+    connect(anthropic, &AnthropicProvider::modelsRefreshed, this, &AIManager::onCustomEndpointModelsRefreshed);
     m_anthropicProvider.reset(anthropic);
 
     // Create Gemini provider
@@ -1658,6 +1660,26 @@ void AIManager::onOllamaModelsRefreshed(const QStringList& models)
     emit ollamaModelsChanged();
 }
 
+void AIManager::refreshCustomEndpointModels()
+{
+    const QString provider = m_settings->ai()->aiProvider();
+    if (provider == QLatin1String("openai")) {
+        auto* openai = dynamic_cast<OpenAIProvider*>(m_openaiProvider.get());
+        if (openai && openai->hasCustomEndpoint())
+            openai->refreshModels();
+    } else if (provider == QLatin1String("anthropic")) {
+        auto* anthropic = dynamic_cast<AnthropicProvider*>(m_anthropicProvider.get());
+        if (anthropic && anthropic->hasCustomEndpoint())
+            anthropic->refreshModels();
+    }
+}
+
+void AIManager::onCustomEndpointModelsRefreshed(const QStringList& models)
+{
+    m_customEndpointModels = models;
+    emit customEndpointModelsChanged();
+}
+
 void AIManager::onSettingsChanged()
 {
     // Update providers with new settings
@@ -1674,6 +1696,10 @@ void AIManager::onSettingsChanged()
         anthropic->setModel(m_settings->ai()->providerModel("anthropic"));  // empty → keeps default
         anthropic->setBaseUrl(m_settings->ai()->anthropicEndpoint());
     }
+
+    // Refresh custom endpoint model list when either provider has a custom base URL
+    if ((openai && openai->hasCustomEndpoint()) || (anthropic && anthropic->hasCustomEndpoint()))
+        refreshCustomEndpointModels();
 
     auto* gemini = dynamic_cast<GeminiProvider*>(m_geminiProvider.get());
     if (gemini) {

--- a/src/ai/aimanager.h
+++ b/src/ai/aimanager.h
@@ -37,6 +37,7 @@ class AIManager : public QObject {
     Q_PROPERTY(QString lastTestResult READ lastTestResult NOTIFY testResultChanged)
     Q_PROPERTY(bool lastTestSuccess READ lastTestSuccess NOTIFY testResultChanged)
     Q_PROPERTY(QStringList ollamaModels READ ollamaModels NOTIFY ollamaModelsChanged)
+    Q_PROPERTY(QStringList customEndpointModels READ customEndpointModels NOTIFY customEndpointModelsChanged)
     Q_PROPERTY(QString currentModelName READ currentModelName NOTIFY providerChanged)
     Q_PROPERTY(AIConversation* conversation READ conversation CONSTANT)
     Q_PROPERTY(bool hasAnyConversation READ hasAnyConversation NOTIFY conversationIndexChanged)
@@ -69,6 +70,7 @@ public:
     QString lastTestResult() const { return m_lastTestResult; }
     bool lastTestSuccess() const { return m_lastTestSuccess; }
     QStringList ollamaModels() const { return m_ollamaModels; }
+    QStringList customEndpointModels() const { return m_customEndpointModels; }
     QString currentModelName() const;
     Q_INVOKABLE QString modelDisplayName(const QString& providerId) const;
     // Selectable models for a provider as a list of { "id", "name" } maps, in UI
@@ -292,6 +294,8 @@ public:
 
     // Ollama-specific
     Q_INVOKABLE void refreshOllamaModels();
+    // Custom endpoint model fetch (OpenAI/Anthropic with custom base URL)
+    Q_INVOKABLE void refreshCustomEndpointModels();
 
 signals:
     void providerChanged();
@@ -305,6 +309,7 @@ signals:
     void bagDetailsExtractionFailed(const QString& requestToken, const QString& error);
     void testResultChanged();
     void ollamaModelsChanged();
+    void customEndpointModelsChanged();
     void conversationIndexChanged();
     void recentShotContextReady(const QString& context);
     void conversationResponseReceived(const QString& response);
@@ -315,6 +320,7 @@ private slots:
     void onAnalysisFailed(const QString& error);
     void onTestResult(bool success, const QString& message);
     void onOllamaModelsRefreshed(const QStringList& models);
+    void onCustomEndpointModelsRefreshed(const QStringList& models);
     void onSettingsChanged();
 
 private:
@@ -350,6 +356,7 @@ private:
     QString m_lastTestResult;
     bool m_lastTestSuccess = false;
     QStringList m_ollamaModels;
+    QStringList m_customEndpointModels;
 
     // For logging - store last prompts to pair with response
     QString m_lastSystemPrompt;

--- a/src/ai/aiprovider.cpp
+++ b/src/ai/aiprovider.cpp
@@ -177,6 +177,10 @@ void OpenAIProvider::setModel(const QString& modelId)
 {
     if (modelId.isEmpty())
         return;  // unset → keep the current default
+    if (hasCustomEndpoint()) {
+        m_model = modelId;
+        return;
+    }
     for (const ModelOption& opt : availableModels()) {
         if (opt.id == modelId) {
             m_model = modelId;
@@ -515,6 +519,53 @@ void OpenAIProvider::onTestReply(QNetworkReply* reply)
     emit testResult(true, tr_("ai.openai.connected", "Connected to OpenAI successfully"));
 }
 
+void OpenAIProvider::refreshModels()
+{
+    if (!hasCustomEndpoint()) return;
+
+    QString urlStr = m_baseUrl + QStringLiteral("/v1/models");
+    QUrl url(urlStr);
+    QNetworkRequest req;
+    req.setUrl(url);
+    req.setRawHeader("Authorization", ("Bearer " + m_apiKey).toUtf8());
+    req.setTransferTimeout(TEST_TIMEOUT_MS);
+    req.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
+
+    QNetworkReply* reply = m_networkManager->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        onModelsReply(reply);
+    });
+}
+
+void OpenAIProvider::onModelsReply(QNetworkReply* reply)
+{
+    reply->deleteLater();
+
+    if (reply->error() != QNetworkReply::NoError) {
+        emit testResult(false, tr_("ai.openai.cannotListModels", "Cannot list models: %1").arg(reply->errorString()));
+        emit modelsRefreshed({});
+        return;
+    }
+
+    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+    QJsonArray data = doc.object()["data"].toArray();
+
+    QStringList modelIds;
+    for (const auto& entry : data) {
+        QString id = entry.toObject()["id"].toString();
+        if (!id.isEmpty())
+            modelIds.append(id);
+    }
+
+    emit modelsRefreshed(modelIds);
+
+    if (!modelIds.isEmpty()) {
+        emit testResult(true, tr_("ai.openai.foundModels", "Connected — found %1 model(s)").arg(modelIds.size()));
+    } else {
+        emit testResult(false, tr_("ai.openai.noModels", "Connected but no models found"));
+    }
+}
+
 // ============================================================================
 // Anthropic Provider
 // ============================================================================
@@ -554,6 +605,10 @@ void AnthropicProvider::setModel(const QString& modelId)
 {
     if (modelId.isEmpty())
         return;  // unset → keep the current default
+    if (hasCustomEndpoint()) {
+        m_model = modelId;
+        return;
+    }
     for (const ModelOption& opt : availableModels()) {
         if (opt.id == modelId) {
             m_model = modelId;
@@ -881,6 +936,54 @@ void AnthropicProvider::onTestReply(QNetworkReply* reply)
     }
 
     emit testResult(true, tr_("ai.anthropic.connected", "Connected to Anthropic successfully"));
+}
+
+void AnthropicProvider::refreshModels()
+{
+    if (!hasCustomEndpoint()) return;
+
+    QString urlStr = m_baseUrl + QStringLiteral("/v1/models");
+    QUrl url(urlStr);
+    QNetworkRequest req;
+    req.setUrl(url);
+    req.setRawHeader("x-api-key", m_apiKey.toUtf8());
+    req.setRawHeader("Authorization", ("Bearer " + m_apiKey).toUtf8());
+    req.setTransferTimeout(TEST_TIMEOUT_MS);
+    req.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
+
+    QNetworkReply* reply = m_networkManager->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        onModelsReply(reply);
+    });
+}
+
+void AnthropicProvider::onModelsReply(QNetworkReply* reply)
+{
+    reply->deleteLater();
+
+    if (reply->error() != QNetworkReply::NoError) {
+        emit testResult(false, tr_("ai.anthropic.cannotListModels", "Cannot list models: %1").arg(reply->errorString()));
+        emit modelsRefreshed({});
+        return;
+    }
+
+    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+    QJsonArray data = doc.object()["data"].toArray();
+
+    QStringList modelIds;
+    for (const auto& entry : data) {
+        QString id = entry.toObject()["id"].toString();
+        if (!id.isEmpty())
+            modelIds.append(id);
+    }
+
+    emit modelsRefreshed(modelIds);
+
+    if (!modelIds.isEmpty()) {
+        emit testResult(true, tr_("ai.anthropic.foundModels", "Connected — found %1 model(s)").arg(modelIds.size()));
+    } else {
+        emit testResult(false, tr_("ai.anthropic.noModels", "Connected but no models found"));
+    }
 }
 
 // ============================================================================

--- a/src/ai/aiprovider.h
+++ b/src/ai/aiprovider.h
@@ -134,9 +134,10 @@ public:
     void setApiKey(const QString& key) { m_apiKey = key; }
     // empty → keeps default upstream URL
     void setBaseUrl(const QString& url) { m_baseUrl = url.endsWith(QLatin1Char('/')) ? url.chopped(1) : url; }
+    bool hasCustomEndpoint() const { return !m_baseUrl.isEmpty(); }
     // Select the wire model. Ignores empty (keeps current default) and any id
     // not in availableModels(), so a stale/unknown stored value can't break the
-    // request.
+    // request. Skips validation when a custom endpoint is set.
     void setModel(const QString& modelId);
 
     void analyze(const QString& systemPrompt, const QString& userPrompt) override;
@@ -149,11 +150,16 @@ public:
     bool supportsUrlAnalysis() const override { return true; }
     void analyzeUrl(const QString& systemPrompt, const QString& userPrompt) override;
     void testConnection() override;
+    void refreshModels();
+
+signals:
+    void modelsRefreshed(const QStringList& models);
 
 private slots:
     void onAnalysisReply(QNetworkReply* reply);
     void onResponsesReply(QNetworkReply* reply);
     void onTestReply(QNetworkReply* reply);
+    void onModelsReply(QNetworkReply* reply);
 
 private:
     void sendRequest(const QJsonObject& requestBody);
@@ -189,9 +195,10 @@ public:
     void setApiKey(const QString& key) { m_apiKey = key; }
     // empty → keeps default upstream URL
     void setBaseUrl(const QString& url) { m_baseUrl = url.endsWith(QLatin1Char('/')) ? url.chopped(1) : url; }
+    bool hasCustomEndpoint() const { return !m_baseUrl.isEmpty(); }
     // Select the wire model. Ignores empty (keeps current default) and any id
     // not in availableModels(), so a stale/unknown stored value can't break the
-    // request.
+    // request. Skips validation when a custom endpoint is set.
     void setModel(const QString& modelId);
 
     void analyze(const QString& systemPrompt, const QString& userPrompt) override;
@@ -203,10 +210,15 @@ public:
     bool supportsUrlAnalysis() const override { return true; }
     void analyzeUrl(const QString& systemPrompt, const QString& userPrompt) override;
     void testConnection() override;
+    void refreshModels();
+
+signals:
+    void modelsRefreshed(const QStringList& models);
 
 private slots:
     void onAnalysisReply(QNetworkReply* reply);
     void onTestReply(QNetworkReply* reply);
+    void onModelsReply(QNetworkReply* reply);
 
 private:
     void sendRequest(const QJsonObject& requestBody);


### PR DESCRIPTION
## Summary

Follow-up to #1598 (custom endpoint URLs). When a custom endpoint is configured, the hardcoded model catalogs (e.g. `claude-sonnet-4-6`, `gpt-5.4`) might not match what the endpoint serves. This adds dynamic model fetching via `/v1/models`, replicating the existing Ollama pattern.

- OpenAI/Anthropic providers gain `refreshModels()` that GETs `/v1/models` and emits the model list
- `setModel()` skips catalog validation when a custom endpoint is set (accepts any model string)
- AIManager exposes `customEndpointModels` Q_PROPERTY, auto-refreshes on endpoint change
- QML shows a ComboBox + Refresh button (like the Ollama picker) when a custom endpoint is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)