### PR TITLE
Remote Control page: add the missing tablet debugging setup

### DIFF
--- a/src/network/webtemplates/remote_page.h
+++ b/src/network/webtemplates/remote_page.h
@@ -242,22 +242,60 @@ inline constexpr const char* WEB_REMOTE_PAGE = R"HTML(
             </div>
         </div>
 
-        <h2>Step 2: Connect to the tablet</h2>
+        <h2>Step 2: Prepare the tablet</h2>
+
+        <p>Android does not accept debugging connections over WiFi until you turn that on and authorise your computer. Until you do, <code>adb connect</code> fails with <em>"connection refused"</em> &mdash; port 5555 simply is not open. This is a one-time setup per computer.</p>
 
         <div class="step">
             <span class="step-number">2</span>
+            <span class="step-title">Enable wireless debugging (one time)</span>
+            <div class="step-content">
+                <p><strong>a. Turn on Developer options</strong></p>
+                <p>On the tablet, open <strong>Settings</strong> &rarr; <strong>About tablet</strong>, find <strong>Build number</strong> and tap it seven times. Enter your PIN if asked &mdash; you will see "You are now a developer!".</p>
+
+                <p><strong>b. Turn on debugging</strong></p>
+                <p>Go to <strong>Settings</strong> &rarr; <strong>System</strong> &rarr; <strong>Developer options</strong> and turn on <strong>USB debugging</strong>. On Android 11 and newer, also turn on <strong>Wireless debugging</strong>.</p>
+
+                <p><strong>c. Authorise your computer</strong> &mdash; either method works:</p>
+
+                <p><em>With a USB cable (any Android version)</em></p>
+                <p>Plug the tablet into the computer and unlock its screen. An <strong>"Allow USB debugging?"</strong> prompt appears with a key fingerprint &mdash; tick <strong>Always allow from this computer</strong> and tap <strong>Allow</strong>. Then run:</p>
+                <pre><code id="tcpipCmd">adb tcpip 5555</code></pre>
+                <button class="copy-btn" onclick="copyCommand('tcpipCmd')">Copy</button>
+                <p style="margin-top: 1rem;">Unplug the cable &mdash; the tablet is now listening on port 5555.</p>
+
+                <p style="margin-top: 1rem;"><em>Wireless pairing (Android 11 and newer)</em></p>
+                <p>Tap the words <strong>Wireless debugging</strong> (not the toggle) to open its screen, then <strong>Pair device with pairing code</strong>. It shows a six-digit code and an address with its own port number. On the computer run <code>adb pair</code> with that address, and type the code when prompted:</p>
+                <pre><code>adb pair 192.168.x.x:37123</code></pre>
+                <p>Use the exact port shown on the tablet &mdash; it is not 5555, and it is different every time.</p>
+            </div>
+        </div>
+
+        <div class="note">
+            <strong>If the prompt never appeared:</strong> the tablet screen must be unlocked to show it. If it flashed past and timed out, unplug and replug the cable to get it back.
+        </div>
+
+        <h2>Step 3: Connect to the tablet</h2>
+
+        <div class="step">
+            <span class="step-number">3</span>
             <span class="step-title">Connect via WiFi</span>
             <div class="step-content">
                 <p>Make sure your computer is on the same WiFi network as the tablet, then run:</p>
                 <pre><code id="connectCmd">adb connect <span id="connectIp">192.168.x.x</span>:5555</code></pre>
                 <button class="copy-btn" onclick="copyCommand('connectCmd')">Copy</button>
+                <p style="margin-top: 1rem;">If you paired wirelessly instead of using a cable, use the port from the tablet's <strong>Wireless debugging</strong> screen in place of 5555 &mdash; the pairing port and the connect port are two different numbers.</p>
             </div>
         </div>
 
-        <h2>Step 3: Start remote control</h2>
+        <div class="note">
+            <strong>After a tablet reboot:</strong> <code>adb tcpip 5555</code> does not survive a restart, so repeat the cable step if the connection stops working. Wireless pairing does survive, but the port changes &mdash; check the <strong>Wireless debugging</strong> screen for the current one.
+        </div>
+
+        <h2>Step 4: Start remote control</h2>
 
         <div class="step">
-            <span class="step-number">3</span>
+            <span class="step-number">4</span>
             <span class="step-title">Launch scrcpy</span>
             <div class="step-content">
                 <p>Once connected, start the remote view:</p>


### PR DESCRIPTION
## Problem

[#1637](https://github.com/Kulitorum/Decenza/issues/1637) — the web app's **Remote Control** page (`/remote`) goes straight from "install scrcpy" to `adb connect <ip>:5555`. On a stock tablet that always fails with `No connection could be made because the target machine actively refused it. (10061)`, because Android does not listen on 5555 until you enable developer options, turn on debugging, and authorise the computer's key. The page never said so, so the reporter went looking for a missing permission — and eventually got the answer from Gemini instead of from us.

## Change

- New **Step 2: Prepare the tablet** — developer options (7 taps on Build number), USB/Wireless debugging, and authorising the computer either by cable (`adb tcpip 5555`) or by pairing code (`adb pair`).
- Connect and launch renumbered to Steps 3 and 4.
- Two notes for the things that bite afterwards: `adb tcpip 5555` does not survive a tablet reboot, and wireless pairing uses a different (and changing) port than the 5555 the connect step shows.

Copy-buttons and the auto-filled device IP work the same as before.

## Wiki

Updated in the same pass (separate repo, pushed directly):

- New **Remote Control (screen mirroring)** section under Web Server with the same prerequisites.
- Corrected the burger-menu table, which described Remote Control as "Control the DE1 from the browser" — it is a scrcpy setup guide, the web UI has no start/stop controls. Added the missing Recipes / Beans / Equipment rows while there.
- Same correction in the headless-machines paragraph and in the FAQ.

## Testing

Header compiles; page HTML verified well-formed (tag balance) after the edit.

Closes #1637