### PR TITLE
Watch the Obsidian plugin's npm dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,21 @@ updates:
     directory: "/.github/actions/setup-compiler-cache"
     schedule:
       interval: "daily"
+
+  # obsidian-plugin/ is the repo's only npm manifest, and nothing here watched
+  # it until an esbuild advisory (arbitrary file read via the dev server on
+  # Windows, low) surfaced as a Dependabot *alert* with no PR behind it. Alerts
+  # do not open pull requests — they sit in the Security tab until someone
+  # looks. Only an entry here, or the repo's separate security-updates toggle,
+  # produces one.
+  #
+  # Same rule as the composite actions above: `directory` names the folder
+  # holding the manifest, and there is no glob. A second npm package would need
+  # its own entry.
+  #
+  # Weekly rather than daily: this is build-only tooling for a plugin that
+  # changes rarely, so a daily cadence would be noise without being safer.
+  - package-ecosystem: "npm"
+    directory: "/obsidian-plugin"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Why

`obsidian-plugin/` is the repo's only npm manifest, and nothing was watching it — `.github/dependabot.yml` covered `github-actions` only (the `/` workflows entry plus the `setup-compiler-cache` composite action).

The gap surfaced concretely: an **esbuild advisory** (arbitrary file read via the dev server on Windows, *low*) is sitting as a Dependabot **alert** with no PR behind it. Alerts don't open pull requests — they stay in the Security tab until someone looks, which is how this went unnoticed. Every Dependabot PR this repo has ever had (#1575, #1566, #1565) was a GitHub Actions bump, because that's all the config watched.

## What changes

One `npm` entry for `/obsidian-plugin`. No other files touched.

- **Weekly, not daily** — build-only tooling for a plugin that changes rarely, so a daily cadence would be noise without being safer. (The actions entries stay daily.)
- The comment follows the file's existing "there is no glob, each manifest needs its own entry" convention, so a future second npm package isn't silently unwatched.

## Notes

- esbuild is pinned `^0.27.3` and the fix is `0.28.1`, so the caret range won't pick it up on its own — Dependabot now has standing permission to propose that bump.
- This does **not** enable *Dependabot security updates* (the repo toggle that auto-opens PRs for alerts across all ecosystems). That's a repo setting, deliberately left alone here.
- Verified: `obsidian-plugin/` is the only npm manifest outside `node_modules/`/build dirs, and the YAML parses with all three entries intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)