### PR TITLE
Ship the simulator in non-debug builds (fixes nightly + the next release build)

### DIFF
--- a/src/ble/de1device.cpp
+++ b/src/ble/de1device.cpp
@@ -6,9 +6,7 @@
 #include "profile/profile.h"
 #include "../core/settings_hardware.h"
 
-#ifdef QT_DEBUG
 #include "../simulator/de1simulator.h"
-#endif
 #include <QBluetoothAddress>
 #include <QDateTime>
 #include <cmath>
@@ -867,7 +865,6 @@ void DE1Device::parseMMRResponse(const QByteArray& data) {
 // -- Machine control methods (delegate through transport) --
 
 void DE1Device::requestState(DE1::State state) {
-#ifdef QT_DEBUG
     if (m_simulationMode && m_simulator) {
         switch (state) {
         case DE1::State::Espresso:
@@ -909,7 +906,6 @@ void DE1Device::requestState(DE1::State state) {
         }
         return;
     }
-#endif
 
     if (!m_transport) return;
     if (dropDeviceWriteIfFirmwareFlash("requestState")) return;
@@ -1029,12 +1025,10 @@ void DE1Device::customEvent(QEvent* event) {
 }
 
 void DE1Device::stopOperationUrgent(qint64 sawTriggerMs) {
-#ifdef QT_DEBUG
     if (m_simulationMode && m_simulator) {
         m_simulator->stop();
         return;
     }
-#endif
     if (!m_transport) return;
     if (dropDeviceWriteIfFirmwareFlash("stopOperationUrgent")) return;
     clearCommandQueue();
@@ -1060,12 +1054,10 @@ void DE1Device::skipToNextFrame() {
 }
 
 void DE1Device::goToSleep() {
-#ifdef QT_DEBUG
     if (m_simulationMode && m_simulator) {
         m_simulator->goToSleep();
         return;
     }
-#endif
 
     // Never send sleep during a firmware flash: writing to REQUESTED_STATE
     // mid-flash can disrupt the bootloader and risk bricking. The MMR-write
@@ -1127,11 +1119,9 @@ void DE1Device::clearCommandQueue() {
 }
 
 void DE1Device::uploadProfile(const Profile& profile) {
-#ifdef QT_DEBUG
     if (m_simulationMode && m_simulator) {
         m_simulator->setProfile(profile);
     }
-#endif
 
     if (!m_transport) return;
     if (dropDeviceWriteIfFirmwareFlash("uploadProfile")) {
@@ -1730,11 +1720,6 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
     // read-back verification are all skipped. m_lastShotSettingsPayload is
     // intentionally left untouched — drift detection only runs against real
     // DE1 indications, which never fire in sim mode.
-    //
-    // Guarded by QT_DEBUG because m_simulator and setSimulator() are only
-    // compiled in debug builds (see de1device.h). Release builds have no
-    // simulator at all, so this branch is dead code there.
-#ifdef QT_DEBUG
     if (m_simulationMode && m_simulator) {
         m_simulator->setTargetSteamTemp(steamTemp);
         m_commandedSteamTargetC = steamTemp;
@@ -1744,7 +1729,6 @@ void DE1Device::setShotSettings(double steamTemp, int steamDuration,
         m_commandedGroupTargetC = groupTemp;
         return;
     }
-#endif
     if (!m_transport) return;
     if (dropDeviceWriteIfFirmwareFlash("setShotSettings")) return;
     QByteArray data(9, 0);

--- a/src/ble/de1device.h
+++ b/src/ble/de1device.h
@@ -36,9 +36,7 @@ class SettingsHardware;
 class DE1Transport;
 class BleTransport;
 
-#ifdef QT_DEBUG
 class DE1Simulator;
-#endif
 
 struct ShotSample {
     qint64 timestamp = 0;
@@ -172,9 +170,11 @@ public:
     // app commands a new steam target via setShotSettings). Emits a minimal
     // shot sample so QML bindings on DE1Device.steamTemperature re-evaluate.
     void setSimulatedIdleSteamTemp(double steamTempC);
-#ifdef QT_DEBUG
+    // Simulation mode is a shipped user setting (Settings -> Machine), not a
+    // debug-only affordance, so the simulator seam is compiled into every
+    // build. Every branch that uses it is gated on `m_simulationMode &&
+    // m_simulator` at runtime, so it stays inert until main.cpp wires one up.
     void setSimulator(DE1Simulator* simulator) { m_simulator = simulator; }
-#endif
 
     // Hardware settings (heater calibration sent to firmware)
     void setSettings(SettingsHardware* settings);
@@ -509,9 +509,7 @@ private:
     bool m_connecting = false;
     bool m_simulationMode = false;
     bool m_firmwareFlashInProgress = false;
-#ifdef QT_DEBUG
     DE1Simulator* m_simulator = nullptr;  // For simulation mode
-#endif
     SettingsHardware* m_settings = nullptr;  // Heater calibration sent to firmware
     bool m_profileUploadInProgress = false;  // True while profile header+frames are being sent
     bool m_sleepPendingAfterUpload = false;  // Sleep requested during profile upload

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,13 +194,11 @@ extern "C" const char* __ubsan_default_options()
 #include "weather/weathermanager.h"
 #include "models/flowcalibrationmodel.h"
 
-// Simulator engine (all debug builds) and GHC window (desktop debug only)
-#ifdef QT_DEBUG
+// Simulator engine (every build) and GHC window (desktop debug only)
 #include "simulator/de1simulator.h"
 #include "simulator/simulatedscale.h"
-#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
+#if (defined(Q_OS_WIN) || defined(Q_OS_MACOS)) && defined(QT_DEBUG)
 #include "simulator/ghcsimulator.h"
-#endif
 #endif
 
 using namespace Qt::StringLiterals;
@@ -1139,7 +1137,6 @@ int main(int argc, char *argv[])
     // no way back: the Settings row is `visible: Settings.app.simulationMode`,
     // so the switch is hidden in exactly that state. "A simulated scale owns
     // the weight stream" is only true when a simulated scale actually exists.
-#ifdef QT_DEBUG
     const auto applyScaleSimulated = [&bleManager, &settings]() {
         bleManager.setScaleSimulated(settings.app()->simulationMode()
                                      && settings.app()->simulatedScaleEnabled());
@@ -1152,7 +1149,6 @@ int main(int argc, char *argv[])
     // too — otherwise turning the DE1 simulator off leaves the scale blocked.
     QObject::connect(settings.app(), &SettingsApp::simulationModeChanged,
                      &bleManager, applyScaleSimulated);
-#endif
 
     DE1Device de1Device;
     de1Device.setSettings(settings.hardware());  // Heater calibration sent to firmware
@@ -3441,14 +3437,14 @@ int main(int argc, char *argv[])
         }
     }
 
-    // Simulator engine (all debug builds) and GHC window (desktop debug only)
+    // Simulator engine (every build — Simulation Mode is a shipped user setting
+    // in Settings -> Machine) and GHC window (desktop debug only).
     // NOTE: These must be declared outside the if-block so they survive through
     // app.exec(). Otherwise the if-block scope destroys them before the event
     // loop starts, and signal connections become dangling references (use-after-free).
-#ifdef QT_DEBUG
     std::unique_ptr<DE1Simulator> de1SimulatorPtr;
     std::unique_ptr<SimulatedScale> simulatedScalePtr;
-#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
+#if (defined(Q_OS_WIN) || defined(Q_OS_MACOS)) && defined(QT_DEBUG)
     std::unique_ptr<QQmlApplicationEngine> ghcEnginePtr;
 #endif
 
@@ -3595,10 +3591,9 @@ int main(int argc, char *argv[])
         ghcEngine.load(ghcUrl);
 #endif // desktop GHC window
     }
-#endif // QT_DEBUG
 
     // Purge the simulated-scale entry when not running in simulation mode, so a
-    // prior debug session's placeholder doesn't leak into the real connection UI.
+    // prior simulation session's placeholder doesn't leak into the real connection UI.
     if (!settings.app()->simulationMode()) {
         settings.removeKnownScale(QStringLiteral("sim:00:00:00:00:00:00"));
     }


### PR DESCRIPTION
## What broke

Nightly sanitizers [#536](https://github.com/Kulitorum/Decenza/actions/runs/30192207389) failed at **Build**, not on a sanitizer finding. Both the asan and ubsan jobs died identically:

```
tests/tst_simulatedscale.cpp:80:20: error: 'class DE1Device' has no member named
  'setSimulator'; did you mean 'setSimulationMode'?
```

`DE1Device::setSimulator()` was `#ifdef QT_DEBUG`. The nightly configures `-DCMAKE_BUILD_TYPE=RelWithDebInfo`, so `NDEBUG` is set, `QT_DEBUG` is not, and the member does not exist. Local Debug builds define it, which is why the pre-PR suite passed.

**The same PR broke release builds of the app itself.** #1629 also added an unguarded `de1Device.setSimulator(nullptr)` teardown call in `main.cpp`, outside the `#ifdef QT_DEBUG` block that ends 640 lines earlier. Every release workflow builds `-DCMAKE_BUILD_TYPE=Release`; the last release build ran 2026-07-24, before #1629 landed, so the next tag push would have failed to compile.

## Why the guard was wrong in the first place

Simulation Mode is not a debug affordance — it is a shipped user feature. Only its wiring was debug-only:

| Piece | In a release build? |
|---|---|
| `DE1Simulator` + `SimulatedScale` compiled and linked | **Yes** — unconditional, `CMakeLists.txt:767` |
| `developer/simulationMode` setting | **Yes** — `QT_DEBUG` only changes the *default* |
| "Simulation Mode" card in Settings → Machine | **Yes** — no guard, translated title/description, "Restart required" note |
| Ctrl+D shortcut | **Yes** — no guard |
| SIMULATION MODE badge, `canStartOperations`, status "Simulation" | **Yes** |
| `setSimulator` / `m_simulator` / every sim branch in `DE1Device` | **No** |
| `main.cpp` block that constructs the simulator | **No** |

So a user on a shipped build could enable Simulation Mode, be told to restart, restart, see the SIMULATION MODE badge and enabled Espresso/Steam/Flush buttons — and have every button do nothing, because `requestState()`'s simulator branch was compiled away and it fell through to `if (!m_transport) return;`.

## The fix

Remove the guards so the code that ships matches the UI that ships:

- **`de1device.h` / `de1device.cpp`** — the `DE1Simulator` forward declaration, the include, `setSimulator()`, `m_simulator`, and the five `m_simulationMode && m_simulator` branches (`requestState`, `stopOperationUrgent`, `goToSleep`, `uploadProfile`, `setShotSettings`). Every one is already runtime-gated on a non-null `m_simulator`, so they stay inert until `main.cpp` wires one up. Also drops a comment that claimed "Release builds have no simulator at all".
- **`main.cpp`** — the simulator includes and the construction/wiring block, which is already inside `if (settings.app()->simulationMode())`. The GHC simulator window (a desktop `QWidget` dev window) stays `(Q_OS_WIN || Q_OS_MACOS) && QT_DEBUG`.
- **`main.cpp`** — the `BLEManager` gate that disables DE1 BLE in simulation mode. Without it a release user in Simulation Mode would keep scanning for a real machine.

No binary-size cost: the simulator was already being linked into every build.

## Testing

- Full local suite via Qt Creator: **101 passed, 0 failed, 0 skipped, no warnings**.
- Debug builds only prove the path that already worked, so the nightly-sanitizers workflow was dispatched against this branch to compile and run the exact RelWithDebInfo configuration that failed. Result linked in a comment below.

## Follow-up for the maintainer

Now that Simulation Mode actually functions for end users, the wiki manual may want an entry for it. Not done here — flagging per the CLAUDE.md rule rather than pushing wiki edits unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)