### PR TITLE
Fix three tablet-log faults; resolve the SAW scale key once; make MQTT reconnect survivable

### DIFF
--- a/qml/pages/settings/SettingsCalibrationTab.qml
+++ b/qml/pages/settings/SettingsCalibrationTab.qml
@@ -152,7 +152,10 @@ Item {
                                 // makes the binding depend on sawLearnedLagChanged so that
                                 // commits/rejects/resets trigger a re-evaluation.
                                 property string _profile: ProfileManager.baseProfileName
-                                property string _scale: Settings.scaleType
+                                // The scale SERVING, not the saved primary — this must match the
+                                // key the shot engine learns under, or the tab shows one pool
+                                // while shots train another (WiFi primary, BLE actually serving).
+                                property string _scale: MachineState.activeScaleType
                                 property double _lagDep: Settings.calibration.sawLearnedLag
                                 text: { void(_lagDep);
                                     return Settings.calibration.sawLearnedLagFor(_profile, _scale).toFixed(2)
@@ -168,7 +171,7 @@ Item {
                             Layout.fillWidth: true
                             property double _modelDep: Settings.calibration.sawLearnedLag  // dep tracker for rebind
                             property string _modelSource: { void(_modelDep);
-                                return Settings.calibration.sawModelSource(ProfileManager.baseProfileName, Settings.scaleType); }
+                                return Settings.calibration.sawModelSource(ProfileManager.baseProfileName, MachineState.activeScaleType); }
                             property string _sourceSuffix: {
                                 if (_modelSource === "perProfile")
                                     return " " + TranslationManager.translate("settings.preferences.sawPerProfile", "(per-profile)");
@@ -182,7 +185,7 @@ Item {
                             Text {
                                 // Show the human-readable scale name, not scaleType — the latter
                                 // is now a canonical id ("decent", "bookoo"), not a display label.
-                                text: (Settings.scaleName || TranslationManager.translate("settings.options.none", "none"))
+                                text: (MachineState.activeScaleName || TranslationManager.translate("settings.options.none", "none"))
                                       + sawSourceRow._sourceSuffix
                                       + " · "
                                       + TranslationManager.translate("settings.options.autoLearns", "learns when to stop so your cup hits target weight")
@@ -206,7 +209,7 @@ Item {
                                     anchors.margins: -Theme.scaled(4)
                                     accessibleName: TranslationManager.translate("settings.calibration.resetWeightStopTimingProfile", "Reset weight stop timing for current profile")
                                     accessibleItem: resetThisProfileText
-                                    onAccessibleClicked: Settings.calibration.resetSawLearningForProfile(ProfileManager.baseProfileName, Settings.scaleType)
+                                    onAccessibleClicked: Settings.calibration.resetSawLearningForProfile(ProfileManager.baseProfileName, MachineState.activeScaleType)
                                 }
                             }
 

--- a/src/ai/dialing_blocks.cpp
+++ b/src/ai/dialing_blocks.cpp
@@ -505,7 +505,12 @@ QJsonObject buildSawPredictionBlock(Settings* settings,
 
     if (!settings || !profileManager) return QJsonObject();
 
-    const QString scaleType = settings->scaleType();
+    // Deliberately NOT settings->scaleType(). That is the saved primary, which is not
+    // necessarily the scale serving the shot path, and reading it here made the advisor
+    // report drip/tier/sample-count for a pool the learner was not training — invisible
+    // from the advisor's own output. Empty asks SettingsCalibration to resolve, which is
+    // the same answer the learner, the Calibration tab and the MCP reset tool all get.
+    const QString scaleType = settings->calibration()->currentScaleType();
     const QString profileFilename = profileManager->baseProfileName();
     if (scaleType.isEmpty() || profileFilename.isEmpty()) return QJsonObject();
 

--- a/src/ble/scales/scaletypeids.cpp
+++ b/src/ble/scales/scaletypeids.cpp
@@ -49,9 +49,14 @@ QString scaleTypeName(ScaleType type) {
 }
 
 namespace {
-// All real (non-Unknown) scale types. Shared by normalizeScaleTypeId() and
-// isCanonicalScaleTypeId() so the two can never disagree about what counts as a
-// real scale — duplicating this list is how they would drift.
+// All real (non-Unknown) scale types. Shared by normalizeScaleTypeId(),
+// isCanonicalScaleTypeId() and scaleTypeNameForId() so they cannot drift apart as
+// types are added — duplicating this list is how that would happen.
+//
+// Note the three do NOT accept the same inputs: normalizeScaleTypeId() also maps
+// legacy DISPLAY NAMES to ids, while the other two match ids only. That is
+// deliberate (an id is a key; a display name is not), so "agree on the type list"
+// is the invariant here, not "accept the same strings".
 constexpr ScaleType kAll[] = {
     ScaleType::DecentScale, ScaleType::DecentScaleWifi, ScaleType::DecentScaleUsb,
     ScaleType::Acaia, ScaleType::AcaiaPyxis, ScaleType::Felicita, ScaleType::Skale,
@@ -73,10 +78,10 @@ QString normalizeScaleTypeId(const QString& typeOrName) {
     return typeOrName;
 }
 
-bool isCanonicalScaleTypeId(const QString& typeOrName) {
-    if (typeOrName.isEmpty()) return false;
+bool isCanonicalScaleTypeId(const QString& typeId) {
+    if (typeId.isEmpty()) return false;
     for (ScaleType t : kAll) {
-        if (typeOrName == scaleTypeId(t)) return true;
+        if (typeId == scaleTypeId(t)) return true;
     }
     return false;  // "flow" (FlowScale), "" (ScaleDevice base), or anything unrecognized
 }

--- a/src/ble/scales/scaletypeids.cpp
+++ b/src/ble/scales/scaletypeids.cpp
@@ -48,17 +48,21 @@ QString scaleTypeName(ScaleType type) {
     return QStringLiteral("Unknown");
 }
 
+namespace {
+// All real (non-Unknown) scale types. Shared by normalizeScaleTypeId() and
+// isCanonicalScaleTypeId() so the two can never disagree about what counts as a
+// real scale — duplicating this list is how they would drift.
+constexpr ScaleType kAll[] = {
+    ScaleType::DecentScale, ScaleType::DecentScaleWifi, ScaleType::DecentScaleUsb,
+    ScaleType::Acaia, ScaleType::AcaiaPyxis, ScaleType::Felicita, ScaleType::Skale,
+    ScaleType::HiroiaJimmy, ScaleType::Bookoo, ScaleType::SmartChef,
+    ScaleType::Difluid, ScaleType::EurekaPrecisa, ScaleType::SoloBarista,
+    ScaleType::AtomheartEclair, ScaleType::VariaAku, ScaleType::Timemore,
+};
+}  // namespace
+
 QString normalizeScaleTypeId(const QString& typeOrName) {
     if (typeOrName.isEmpty()) return typeOrName;
-
-    // All real (non-Unknown) scale types, for inverse lookup.
-    static const ScaleType kAll[] = {
-        ScaleType::DecentScale, ScaleType::DecentScaleWifi, ScaleType::DecentScaleUsb,
-        ScaleType::Acaia, ScaleType::AcaiaPyxis, ScaleType::Felicita, ScaleType::Skale,
-        ScaleType::HiroiaJimmy, ScaleType::Bookoo, ScaleType::SmartChef,
-        ScaleType::Difluid, ScaleType::EurekaPrecisa, ScaleType::SoloBarista,
-        ScaleType::AtomheartEclair, ScaleType::VariaAku, ScaleType::Timemore,
-    };
 
     for (ScaleType t : kAll) {
         if (typeOrName == scaleTypeId(t)) return typeOrName;        // already a canonical id
@@ -67,6 +71,21 @@ QString normalizeScaleTypeId(const QString& typeOrName) {
 
     // Unrecognized (e.g. a future custom value) — return unchanged so nothing is destroyed.
     return typeOrName;
+}
+
+bool isCanonicalScaleTypeId(const QString& typeOrName) {
+    if (typeOrName.isEmpty()) return false;
+    for (ScaleType t : kAll) {
+        if (typeOrName == scaleTypeId(t)) return true;
+    }
+    return false;  // "flow" (FlowScale), "" (ScaleDevice base), or anything unrecognized
+}
+
+QString scaleTypeNameForId(const QString& typeId) {
+    for (ScaleType t : kAll) {
+        if (typeId == scaleTypeId(t)) return scaleTypeName(t);
+    }
+    return QString();
 }
 
 }  // namespace ScaleTypeIds

--- a/src/ble/scales/scaletypeids.h
+++ b/src/ble/scales/scaletypeids.h
@@ -50,8 +50,10 @@ QString scaleTypeName(ScaleType type);
 // unchanged so no data is ever destroyed.
 QString normalizeScaleTypeId(const QString& typeOrName);
 
-// True only for a string that maps to a real ScaleType — i.e. a physical scale
-// whose per-transport state is worth keying on.
+// True only for a CANONICAL ID that maps to a real ScaleType — i.e. a physical
+// scale whose per-transport state is worth keying on. A legacy display name is
+// NOT accepted ("Decent Scale" -> false, "decent" -> true); normalize first if the
+// caller might hold one.
 //
 // Deliberately FALSE for the virtual scales: FlowScale reports "flow" (a raw
 // string, not a scaleTypeId), and ScaleDevice's base type() returns "". Callers
@@ -60,7 +62,7 @@ QString normalizeScaleTypeId(const QString& typeOrName);
 // inventing a pool for a scale that has no transport latency to learn.
 // normalizeScaleTypeId() deliberately passes unknown strings through unchanged,
 // so it cannot answer this question on its own.
-bool isCanonicalScaleTypeId(const QString& typeOrName);
+bool isCanonicalScaleTypeId(const QString& typeId);
 
 // Canonical id -> display name, without the caller needing the enum. Returns an
 // empty string for anything isCanonicalScaleTypeId() rejects, so a caller cannot

--- a/src/ble/scales/scaletypeids.h
+++ b/src/ble/scales/scaletypeids.h
@@ -25,7 +25,15 @@ enum class ScaleType {
     SoloBarista,
     AtomheartEclair,
     VariaAku,
-    Timemore
+    // ADDING A TYPE? Three places, and only the first two are compiler-checked:
+    //   1. scaleTypeId() / scaleTypeName() switches — enforced by -Wswitch (no default:).
+    //   2. kAll in scaletypeids.cpp — NOT enforced by anything. Miss it and
+    //      isCanonicalScaleTypeId() rejects the new scale, so SAW silently keys its
+    //      shots on the saved primary and corrupts another scale's learned pool.
+    //   3. If you add AFTER Timemore, move the loop bound in
+    //      tst_saw_settings::everyScaleTypeIsInTheCanonicalVocabulary, which is what
+    //      catches (2). It iterates Unknown+1 .. Timemore and cannot see past the end.
+    Timemore  // keep last, or update the test bound above
 };
 
 // Canonical scale type-id / display-name mapping and normalization.

--- a/src/ble/scales/scaletypeids.h
+++ b/src/ble/scales/scaletypeids.h
@@ -50,4 +50,21 @@ QString scaleTypeName(ScaleType type);
 // unchanged so no data is ever destroyed.
 QString normalizeScaleTypeId(const QString& typeOrName);
 
+// True only for a string that maps to a real ScaleType — i.e. a physical scale
+// whose per-transport state is worth keying on.
+//
+// Deliberately FALSE for the virtual scales: FlowScale reports "flow" (a raw
+// string, not a scaleTypeId), and ScaleDevice's base type() returns "". Callers
+// that key persistent per-scale state — SAW learning above all — use this to
+// decide whether the serving scale is one they should key on at all, rather than
+// inventing a pool for a scale that has no transport latency to learn.
+// normalizeScaleTypeId() deliberately passes unknown strings through unchanged,
+// so it cannot answer this question on its own.
+bool isCanonicalScaleTypeId(const QString& typeOrName);
+
+// Canonical id -> display name, without the caller needing the enum. Returns an
+// empty string for anything isCanonicalScaleTypeId() rejects, so a caller cannot
+// accidentally render "Unknown" for a virtual scale.
+QString scaleTypeNameForId(const QString& typeId);
+
 }  // namespace ScaleTypeIds

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -615,18 +615,31 @@ void ShotTimingController::onSettlingComplete()
     // passing and learning proceeded on a flow-integral ESTIMATE, writing a
     // fabricated drip into the real scale's pool.
     //
-    // Without a physical scale there is no observation of what actually landed in
-    // the cup, so there is nothing for SAW to learn FROM — and the number it did
-    // learn was not merely noisy, it was structurally zero. Drip is measured over
-    // the settling window as m_weight - m_weightAtStop, but m_weight only advances
-    // on a scale sample, and FlowScale only emits while MachineState::isFlowing().
-    // The SAW stop ends the pour, isFlowing() goes false, FlowScale falls silent,
-    // and m_weight stays pinned at m_weightAtStop for the whole window. drip == 0
-    // clears every validation gate below and lands in the SAVED scale's pool
-    // (activeScaleType() falls back to it for a virtual scale), dragging that
-    // model toward "no drip" — so SAW then stops late and overshoots once the
-    // user reconnects the real scale. FlowScale still SERVES SAW; it just must
-    // never train it.
+    // Without a physical scale there is no OBSERVATION of what landed in the cup, so
+    // there is nothing for SAW to learn from — the estimate and the thing it would be
+    // corrected against are the same number.
+    //
+    // Concretely, drip is what arrives after the stop command: m_weight - m_weightAtStop,
+    // where m_weightAtStop is captured in onSawTriggered() when SAW FIRES and m_weight
+    // keeps advancing until endShot() starts settling. On a real scale that spans two
+    // physical contributions — flow still leaving the group during the DE1's stop
+    // latency, AND the gravity drip off the puck afterwards. FlowScale can only ever
+    // see the first: MachineState::onFlowSample() is gated on isFlowing(), so the
+    // moment the pour ends FlowScale goes silent and every gram that drips after it is
+    // invisible. Its drip is therefore a real number but a systematically LOW one, and
+    // it is an integral of the DE1's own flow model rather than a measurement.
+    //
+    // That biased value used to land in the SAVED scale's pool (currentScaleType()
+    // falls back to it for a virtual scale), pulling a physical scale's learned drip
+    // down so SAW stops late and overshoots once the user reconnects it.
+    //
+    // (An earlier revision of this comment claimed the learned drip was structurally
+    // ZERO, reasoning that FlowScale falls silent at the stop. It does — but not until
+    // endShot(), which is well after onSawTriggered() captured m_weightAtStop, so the
+    // stop-latency flow is still integrated. Recorded because the wrong version is
+    // more memorable than the right one, and the conclusion is unchanged either way.)
+    //
+    // FlowScale still SERVES SAW; it just must never train it.
     if (!m_scale || !m_scale->isConnected() || m_scale->isFlowScale()) {
         qWarning() << "[SAW] No physical scale at settling (scale="
                    << (m_scale ? m_scale->type() : QStringLiteral("none"))

--- a/src/controllers/shottimingcontroller.cpp
+++ b/src/controllers/shottimingcontroller.cpp
@@ -608,9 +608,29 @@ void ShotTimingController::onSettlingComplete()
     // the ordering.
     auto deferProcessing = qScopeGuard([this] { emit shotProcessingReady(); });
 
-    // Check scale is still connected
-    if (!m_scale || !m_scale->isConnected()) {
-        qWarning() << "[SAW] Scale disconnected, skipping learning";
+    // Check a REAL scale is still serving. isConnected() alone cannot fail the way
+    // this guard intends: every path that drops a physical scale installs FlowScale
+    // in its place, and FlowScale's constructor calls setConnected(true) — it is
+    // permanently "connected". So a USB or BLE scale lost mid-pour left this check
+    // passing and learning proceeded on a flow-integral ESTIMATE, writing a
+    // fabricated drip into the real scale's pool.
+    //
+    // Without a physical scale there is no observation of what actually landed in
+    // the cup, so there is nothing for SAW to learn FROM — and the number it did
+    // learn was not merely noisy, it was structurally zero. Drip is measured over
+    // the settling window as m_weight - m_weightAtStop, but m_weight only advances
+    // on a scale sample, and FlowScale only emits while MachineState::isFlowing().
+    // The SAW stop ends the pour, isFlowing() goes false, FlowScale falls silent,
+    // and m_weight stays pinned at m_weightAtStop for the whole window. drip == 0
+    // clears every validation gate below and lands in the SAVED scale's pool
+    // (activeScaleType() falls back to it for a virtual scale), dragging that
+    // model toward "no drip" — so SAW then stops late and overshoots once the
+    // user reconnects the real scale. FlowScale still SERVES SAW; it just must
+    // never train it.
+    if (!m_scale || !m_scale->isConnected() || m_scale->isFlowScale()) {
+        qWarning() << "[SAW] No physical scale at settling (scale="
+                   << (m_scale ? m_scale->type() : QStringLiteral("none"))
+                   << "), skipping learning";
         return;
     }
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -483,6 +483,18 @@ void Settings::setScaleType(const QString& type) {
     // The pool is also orphaned the moment a scale is paired again. Fall back to the
     // same default scaleType() would have used.
     if (id.isEmpty()) {
+        // Logged because this SUBSTITUTES a specific scale the user may not own for a
+        // genuinely-unknown state. Without it a support log shows scale/type = "decent"
+        // with no way to tell whether the user owns a Decent scale or whether this
+        // branch invented one.
+        //
+        // qDebug, not qWarning: setPrimaryScale(QString()) reaches here on a perfectly
+        // ordinary path (clearing the primary, e.g. removing the last known scale), so
+        // a warning would flag routine behaviour — and did fail three tests exercising
+        // exactly that. The substitution is still worth a line in the log.
+        qDebug() << "[Settings] setScaleType() called with an empty/unrecognized type"
+                 << type << "- falling back to \"decent\". An empty key would orphan"
+                 << "the SAW pool; see removeKnownScale()'s auto-promote.";
         id = QStringLiteral("decent");
     }
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -472,7 +472,20 @@ QString Settings::scaleType() const {
 void Settings::setScaleType(const QString& type) {
     // Persist the canonical type-id, never a display name — scaleType is a
     // rename-stable key for SAW learning / sensorLag / known scales.
-    const QString id = ScaleTypeIds::normalizeScaleTypeId(type);
+    QString id = ScaleTypeIds::normalizeScaleTypeId(type);
+
+    // Never persist an EMPTY id. removeKnownScale()'s auto-promote reaches here with
+    // "" when the removed scale was primary and nothing is left to promote, and once
+    // stored, the "decent" default below stops applying — scaleType() returns the
+    // stored empty string. Everything downstream then keys on it: SAW pools become
+    // "<profile>::" and sensorLag("") warns on every single shot with an empty value
+    // in the message, which reads as a logging bug rather than the data bug it is.
+    // The pool is also orphaned the moment a scale is paired again. Fall back to the
+    // same default scaleType() would have used.
+    if (id.isEmpty()) {
+        id = QStringLiteral("decent");
+    }
+
     if (scaleType() != id) {
         m_settings.setValue("scale/type", id);
         emit scaleTypeChanged();

--- a/src/core/settings_calibration.cpp
+++ b/src/core/settings_calibration.cpp
@@ -45,10 +45,31 @@ SettingsCalibration::SettingsCalibration(Settings* owner, QObject* parent)
 {
 }
 
+void SettingsCalibration::setServingScaleTypeProvider(std::function<QString()> provider) {
+    m_servingScaleType = std::move(provider);
+}
+
 QString SettingsCalibration::currentScaleType() const {
+    // Prefer the scale actually serving the shot path. Keying on the SAVED type
+    // instead is how BLE-served shots came to be written into the "decent-wifi"
+    // pool: the WiFi scale stays the saved primary while every weight sample
+    // arrives over BLE. Four consecutive BLE shots logged scale="decent-wifi"
+    // on-device before this was resolved centrally.
+    const QString serving = m_servingScaleType ? m_servingScaleType() : QString();
+    if (!serving.isEmpty() && ScaleTypeIds::isCanonicalScaleTypeId(serving))
+        return serving;
     // Normalize defensively — scaleType is stored as a canonical id, but this keeps
     // SAW keying correct even if a legacy display name slips through pre-migration.
     return ScaleTypeIds::normalizeScaleTypeId(m_owner ? m_owner->scaleType() : QStringLiteral("decent"));
+}
+
+QString SettingsCalibration::resolveScaleKey(const QString& explicitKey) const {
+    if (explicitKey.isEmpty())
+        return currentScaleType();
+    // Normalize an explicit key too. A caller holding a legacy display name would
+    // otherwise open a second pool alongside the canonical one under a different
+    // spelling of the same scale — the split this resolution exists to close.
+    return ScaleTypeIds::normalizeScaleTypeId(explicitKey);
 }
 
 void SettingsCalibration::invalidateCache() {
@@ -675,7 +696,8 @@ void SettingsCalibration::savePerProfileSawBatchMap(const QJsonObject& map) {
 }
 
 QJsonArray SettingsCalibration::perProfileSawHistory(const QString& profileFilename, const QString& scaleType) const {
-    return loadPerProfileSawHistoryMap().value(sawPairKey(profileFilename, scaleType)).toArray();
+    return loadPerProfileSawHistoryMap()
+        .value(sawPairKey(profileFilename, resolveScaleKey(scaleType))).toArray();
 }
 
 QJsonObject SettingsCalibration::allPerProfileSawHistory() const {
@@ -683,7 +705,8 @@ QJsonObject SettingsCalibration::allPerProfileSawHistory() const {
 }
 
 QJsonArray SettingsCalibration::sawPendingBatch(const QString& profileFilename, const QString& scaleType) const {
-    return loadPerProfileSawBatchMap().value(sawPairKey(profileFilename, scaleType)).toArray();
+    return loadPerProfileSawBatchMap()
+        .value(sawPairKey(profileFilename, resolveScaleKey(scaleType))).toArray();
 }
 
 double SettingsCalibration::globalSawBootstrapLag(const QString& scaleType) const {
@@ -699,7 +722,7 @@ void SettingsCalibration::setGlobalSawBootstrapLag(const QString& scaleType, dou
 // ---- per-(profile, scale) read path ----
 
 QString SettingsCalibration::sawModelSource(const QString& profileFilename, QString scaleType) const {
-    scaleType = ScaleTypeIds::normalizeScaleTypeId(scaleType);
+    scaleType = resolveScaleKey(scaleType);
     if (!profileFilename.isEmpty()) {
         QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
         if (pairHistory.size() >= kSawMinMediansForGraduation) return QStringLiteral("perProfile");
@@ -715,9 +738,10 @@ QString SettingsCalibration::sawModelSource(const QString& profileFilename, QStr
 QList<QPair<double, double>> SettingsCalibration::sawLearningEntriesFor(const QString& profileFilename,
                                                                        const QString& scaleType,
                                                                        int maxEntries) const {
+    const QString scale = resolveScaleKey(scaleType);
     QList<QPair<double, double>> result;
     if (!profileFilename.isEmpty()) {
-        QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
+        QJsonArray pairHistory = perProfileSawHistory(profileFilename, scale);
         if (pairHistory.size() >= kSawMinMediansForGraduation) {
             for (qsizetype i = pairHistory.size() - 1; i >= 0 && result.size() < maxEntries; --i) {
                 QJsonObject obj = pairHistory[i].toObject();
@@ -728,12 +752,13 @@ QList<QPair<double, double>> SettingsCalibration::sawLearningEntriesFor(const QS
             if (!result.isEmpty()) return result;
         }
     }
-    return sawLearningEntries(scaleType, maxEntries);
+    return sawLearningEntries(scale, maxEntries);
 }
 
 double SettingsCalibration::sawLearnedLagFor(const QString& profileFilename, const QString& scaleType) const {
+    const QString scale = resolveScaleKey(scaleType);
     if (!profileFilename.isEmpty()) {
-        QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
+        QJsonArray pairHistory = perProfileSawHistory(profileFilename, scale);
         if (pairHistory.size() >= kSawMinMediansForGraduation) {
             double sumLag = 0;
             qsizetype count = 0;
@@ -749,7 +774,7 @@ double SettingsCalibration::sawLearnedLagFor(const QString& profileFilename, con
             if (count > 0) return sumLag / count;
         }
     }
-    double bootstrap = globalSawBootstrapLag(scaleType);
+    double bootstrap = globalSawBootstrapLag(scale);
     if (bootstrap > 0.0) return bootstrap;
     return sawLearnedLag();
 }
@@ -757,8 +782,9 @@ double SettingsCalibration::sawLearnedLagFor(const QString& profileFilename, con
 double SettingsCalibration::getExpectedDripFor(const QString& profileFilename,
                                                const QString& scaleType,
                                                double currentFlowRate) const {
+    const QString scale = resolveScaleKey(scaleType);
     if (!profileFilename.isEmpty()) {
-        QJsonArray pairHistory = perProfileSawHistory(profileFilename, scaleType);
+        QJsonArray pairHistory = perProfileSawHistory(profileFilename, scale);
         if (pairHistory.size() >= kSawMinMediansForGraduation) {
             // Same flow-similarity kernel as the global getExpectedDrip(), but
             // recencyMin is fixed at 3.0 — per-pair history only kicks in after
@@ -787,11 +813,11 @@ double SettingsCalibration::getExpectedDripFor(const QString& profileFilename,
             }
         }
     }
-    double bootstrap = globalSawBootstrapLag(scaleType);
+    double bootstrap = globalSawBootstrapLag(scale);
     if (bootstrap > 0.0) {
         return qMin(currentFlowRate * bootstrap, 8.0);
     }
-    return qMin(currentFlowRate * (sensorLag(scaleType) + 0.1), 8.0);
+    return qMin(currentFlowRate * (sensorLag(scale) + 0.1), 8.0);
 }
 
 // ---- per-pair batch accumulator + commit ----

--- a/src/core/settings_calibration.cpp
+++ b/src/core/settings_calibration.cpp
@@ -58,6 +58,23 @@ QString SettingsCalibration::currentScaleType() const {
     const QString serving = m_servingScaleType ? m_servingScaleType() : QString();
     if (!serving.isEmpty() && ScaleTypeIds::isCanonicalScaleTypeId(serving))
         return serving;
+
+    // A non-canonical id here is EXPECTED for the virtual scale ("flow") and for test
+    // doubles. For a real scale driver whose id was never added to ScaleTypeIds::kAll it
+    // is a silent correctness bug: nothing downstream rejects it — the isFlowScale()
+    // guard in onSettlingComplete() only catches the virtual scale — so a genuine scale
+    // trains the SAVED primary's pool with its own transport latency, undetectably.
+    // Logged once per distinct id: this runs on every SAW read, and the compile-time
+    // guard is the test over the enum (everyScaleTypeIsInTheCanonicalVocabulary); this
+    // is only so a field log can show it. qDebug not qWarning because serving a
+    // non-canonical type is legitimate in tests running under failOnWarning().
+    if (!serving.isEmpty() && serving != QLatin1String("flow")
+        && serving != m_warnedNonCanonicalScale) {
+        m_warnedNonCanonicalScale = serving;
+        qDebug() << "SettingsCalibration: serving scale reports non-canonical type-id"
+                 << serving << "- SAW will key on the saved primary instead."
+                 << "If this is a real scale, add it to ScaleTypeIds::kAll.";
+    }
     // Normalize defensively — scaleType is stored as a canonical id, but this keeps
     // SAW keying correct even if a legacy display name slips through pre-migration.
     return ScaleTypeIds::normalizeScaleTypeId(m_owner ? m_owner->scaleType() : QStringLiteral("decent"));
@@ -66,12 +83,16 @@ QString SettingsCalibration::currentScaleType() const {
 QString SettingsCalibration::resolveScaleKey(const QString& explicitKey) const {
     if (explicitKey.isEmpty())
         return currentScaleType();
-    // Normalizing an explicit key is belt-and-braces, not load-bearing: every
-    // downstream already does it (sawPairKey, globalSawBootstrapLag, sensorLag,
-    // sawLearningEntries), so a legacy display name cannot open a second pool today
-    // whether or not this line exists. It is here so the value this function RETURNS
-    // is canonical for any future consumer that uses it as a key or compares it,
-    // rather than depending on each one remembering to normalize again.
+    // Load-bearing, and specifically for sawModelSource(): it compares the key RAW
+    // against the stored "scale" field of each global-pool entry, so an un-normalized
+    // legacy display name there returns "scaleDefault" where the truth is "globalPool"
+    // — a wrong model tier shown in the Calibration tab and reported to the AI advisor.
+    //
+    // The key-derived paths (sawPairKey, globalSawBootstrapLag, sensorLag,
+    // sawLearningEntries) each normalize again, so for those it is belt-and-braces.
+    // Do NOT reason from that subset that the line can go: this comment previously
+    // claimed exactly that, having enumerated the normalizing consumers and missed the
+    // one comparing consumer.
     return ScaleTypeIds::normalizeScaleTypeId(explicitKey);
 }
 
@@ -452,7 +473,27 @@ double SettingsCalibration::sensorLag(const QString& scaleType)
     if (id == "skale")            return 0.38;
     if (id == "decent-wifi")      return 0.38;  // WiFi transport of the Half Decent Scale
     if (id == "decent-usb")       return 0.38;  // USB transport of the Half Decent Scale
-    qWarning() << "[SAW] Unknown scale type for sensorLag:" << scaleType << "- using default 0.38s";
+    // Two different situations reach here and they are not equally interesting.
+    //
+    // A CANONICAL id with no entry above is simply a supported scale whose BLE latency
+    // nobody has measured yet — six of the sixteen are in that position (difluid,
+    // eureka_precisa, smartchef, solo_barista, timemore, varia_aku). The de1app default
+    // is the correct answer for them and adaptive learning replaces it within a few
+    // shots. Warning here fired on EVERY SAW read for those users, naming their
+    // perfectly-supported scale as "unknown" — a log full of alarming lines describing
+    // normal operation, which is how genuinely alarming lines get ignored.
+    //
+    // A non-canonical string is the one worth flagging: it means a type-id reached SAW
+    // that ScaleTypeIds does not know, so it is also missing from kAll and keys its own
+    // orphan pool.
+    if (ScaleTypeIds::isCanonicalScaleTypeId(id)) {
+        qDebug() << "[SAW] No measured sensor lag for" << id
+                 << "- using the 0.38s default until learning has data";
+    } else {
+        qWarning() << "[SAW] Unknown scale type for sensorLag:" << scaleType
+                   << "- using default 0.38s. If this is a real scale, add it to"
+                   << "ScaleTypeIds::kAll.";
+    }
     return 0.38;  // de1app default for unknown/unlisted scales
 }
 

--- a/src/core/settings_calibration.cpp
+++ b/src/core/settings_calibration.cpp
@@ -66,9 +66,12 @@ QString SettingsCalibration::currentScaleType() const {
 QString SettingsCalibration::resolveScaleKey(const QString& explicitKey) const {
     if (explicitKey.isEmpty())
         return currentScaleType();
-    // Normalize an explicit key too. A caller holding a legacy display name would
-    // otherwise open a second pool alongside the canonical one under a different
-    // spelling of the same scale — the split this resolution exists to close.
+    // Normalizing an explicit key is belt-and-braces, not load-bearing: every
+    // downstream already does it (sawPairKey, globalSawBootstrapLag, sensorLag,
+    // sawLearningEntries), so a legacy display name cannot open a second pool today
+    // whether or not this line exists. It is here so the value this function RETURNS
+    // is canonical for any future consumer that uses it as a key or compares it,
+    // rather than depending on each one remembering to normalize again.
     return ScaleTypeIds::normalizeScaleTypeId(explicitKey);
 }
 

--- a/src/core/settings_calibration.h
+++ b/src/core/settings_calibration.h
@@ -22,13 +22,27 @@ class Settings;
 //
 // SCALE KEY RESOLUTION — read this before adding a SAW call site.
 //
-// Every per-scale SAW read takes an OPTIONAL scaleType. Leave it empty and the
-// class resolves it itself, via currentScaleType(); that is the correct answer
-// and the one every other consumer gets. Pass a value only when you genuinely
-// mean a specific pool, which is true in exactly two places: the learning path
-// (main.cpp latches the key at shot start so a scale swapped mid-shot still
-// learns under the key that made the prediction) and the MCP
-// reset_saw_learning_for_profile tool (the user names a scale).
+// The per-(profile, scale) reads take an OPTIONAL scaleType: sawLearnedLagFor,
+// getExpectedDripFor, sawLearningEntriesFor, sawModelSource, perProfileSawHistory and
+// sawPendingBatch. Leave it empty and the class resolves it via currentScaleType();
+// that is the correct answer and the one every other consumer gets.
+//
+// Pass a value when you genuinely mean a SPECIFIC pool rather than the current one.
+// The case that must never be converted to resolution is the learning path: main.cpp
+// latches the key at shot start and passes it back ~40 s later, so a scale swapped
+// mid-shot still trains the pool that made the prediction. (Other callers pass an
+// explicit key today simply because they already hold the resolved value — that is
+// harmless, not a second rule. Deliberately not enumerated: an exhaustive list of call
+// sites in a comment is falsified by the next commit, and this file has already had
+// three such lists go stale.)
+//
+// The rule is NOT applied to the per-scale-only entry points — globalSawBootstrapLag,
+// setGlobalSawBootstrapLag, sensorLag, isSawConverged, sawLearningEntries. They keep a
+// required key, so `isSawConverged("")` still silently means the empty pool while
+// `sawLearnedLagFor(p)` resolves. That asymmetry is a wart, stated here rather than
+// papered over: those five are internal/bootstrap paths whose callers always have a
+// concrete key in hand, and sensorLag is static so it has no instance to resolve from.
+// If you add a NEW caller of one of them, pass currentScaleType() explicitly.
 //
 // This is deliberately the inverse of the older design, where the key was a
 // required parameter every caller derived for itself. Four consumers derived it
@@ -198,6 +212,10 @@ private:
 
     Settings* m_owner = nullptr;  // Non-owning; used ONLY for currentScaleType() lookup.
     std::function<QString()> m_servingScaleType;  // See setServingScaleTypeProvider().
+    // Last non-canonical serving id already reported, so the diagnostic in
+    // currentScaleType() logs once per distinct scale rather than on every SAW read.
+    // mutable: currentScaleType() is const and this is pure log-throttling state.
+    mutable QString m_warnedNonCanonicalScale;
     mutable AppSettings m_settings;
 
     // SAW learning history cache (avoids re-parsing JSON from QSettings on every weight sample)

--- a/src/core/settings_calibration.h
+++ b/src/core/settings_calibration.h
@@ -9,6 +9,7 @@
 #include <QPair>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <functional>
 
 class Settings;
 
@@ -18,6 +19,24 @@ class Settings;
 // current scaleType() without a public-API change. The owner pointer is used
 // ONLY for that single lookup — no other Settings surface is reached through
 // it.
+//
+// SCALE KEY RESOLUTION — read this before adding a SAW call site.
+//
+// Every per-scale SAW read takes an OPTIONAL scaleType. Leave it empty and the
+// class resolves it itself, via currentScaleType(); that is the correct answer
+// and the one every other consumer gets. Pass a value only when you genuinely
+// mean a specific pool, which is true in exactly two places: the learning path
+// (main.cpp latches the key at shot start so a scale swapped mid-shot still
+// learns under the key that made the prediction) and the MCP
+// reset_saw_learning_for_profile tool (the user names a scale).
+//
+// This is deliberately the inverse of the older design, where the key was a
+// required parameter every caller derived for itself. Four consumers derived it
+// three different ways: the learner wrote one pool while the Calibration tab
+// displayed another and the AI advisor reported a third, each invisible from the
+// others. Making the resolved answer the DEFAULT means a new call site is right
+// by omission, and an explicit key now reads as a deliberate choice rather than
+// as boilerplate.
 class SettingsCalibration : public QObject {
     Q_OBJECT
 
@@ -60,14 +79,23 @@ public:
 
     // Per-(profile, scale) variant of sawLearnedLag — falls back to global bootstrap /
     // per-scale data when the pair has not yet graduated. Pass empty profile for the
-    // legacy global-pool path.
-    Q_INVOKABLE double sawLearnedLagFor(const QString& profileFilename, const QString& scaleType) const;
-    double getExpectedDripFor(const QString& profileFilename, const QString& scaleType, double currentFlowRate) const;
-    QList<QPair<double, double>> sawLearningEntriesFor(const QString& profileFilename, const QString& scaleType, int maxEntries) const;
+    // legacy global-pool path. Empty scaleType = resolve it (see class comment).
+    Q_INVOKABLE double sawLearnedLagFor(const QString& profileFilename,
+                                        const QString& scaleType = QString()) const;
+    double getExpectedDripFor(const QString& profileFilename, const QString& scaleType,
+                              double currentFlowRate) const;
+    QList<QPair<double, double>> sawLearningEntriesFor(const QString& profileFilename,
+                                                       const QString& scaleType,
+                                                       int maxEntries) const;
 
     // Reports which model the read path uses for (profile, scale).
-    Q_INVOKABLE QString sawModelSource(const QString& profileFilename, QString scaleType) const;
+    Q_INVOKABLE QString sawModelSource(const QString& profileFilename,
+                                       QString scaleType = QString()) const;
 
+    // Learning is the one path that must NOT resolve: main.cpp latches the key at
+    // shot start and passes it here ~40 s later, so that a scale swapped mid-shot
+    // still trains the pool that made the prediction. Resolving live here would
+    // reintroduce exactly that bug, so scaleType stays required.
     void addSawLearningPoint(double drip, double flowRate, QString scaleType, double overshoot,
                              const QString& profileFilename = QString());
     Q_INVOKABLE void resetSawLearning();
@@ -81,11 +109,13 @@ public:
     void sawLearningImport(const QJsonObject& o);
 
     // Per-pair committed history (storage helpers; mostly for tests + bootstrap recompute).
-    QJsonArray perProfileSawHistory(const QString& profileFilename, const QString& scaleType) const;
+    QJsonArray perProfileSawHistory(const QString& profileFilename,
+                                    const QString& scaleType = QString()) const;
     QJsonObject allPerProfileSawHistory() const;
 
     // Per-pair pending batch accumulator (5 entries before committing the batch median).
-    QJsonArray sawPendingBatch(const QString& profileFilename, const QString& scaleType) const;
+    QJsonArray sawPendingBatch(const QString& profileFilename,
+                               const QString& scaleType = QString()) const;
 
     // Global bootstrap lag for new (profile, scale) pairs without graduated history.
     double globalSawBootstrapLag(const QString& scaleType) const;
@@ -110,6 +140,30 @@ public:
     // Returns SAW learning entries filtered by scale type (most recent first).
     // Used by WeightProcessor to snapshot learning data at shot start.
     QList<QPair<double, double>> sawLearningEntries(QString scaleType, int maxEntries) const;
+
+    // Reports the type-id of the scale currently wired into the shot path, or an
+    // empty string when none is connected. Installed once by MachineState, which is
+    // the only object that tracks the serving scale.
+    //
+    // A PULL provider rather than a pushed value on purpose: the serving scale
+    // changes on device events at a dozen call sites and its connected state changes
+    // independently of that, so anything pushed would need re-pushing from both and
+    // would go stale the first time one was missed. A closure reading live state
+    // cannot be stale. It returns raw device identity only — the canonical-vocabulary
+    // test and the saved-scale fallback are POLICY and stay here, so there is exactly
+    // one implementation of the SAW key rule.
+    //
+    // The provider must not outlive its captured object; MachineState clears it in
+    // its destructor.
+    void setServingScaleTypeProvider(std::function<QString()> provider);
+
+    // The SAW pool key for right now: the serving scale when it is real (connected
+    // AND in the canonical ScaleTypeIds vocabulary), otherwise the saved primary,
+    // normalized. FlowScale reports "flow" and is permanently isConnected(), so the
+    // vocabulary check is what stops every scale-less shot opening a "flow" pool and
+    // making sensorLag() warn about an unknown type on every cycle. Public because
+    // MachineState::activeScaleType() forwards here for the QML property.
+    QString currentScaleType() const;
 
 signals:
     void flowCalibrationMultiplierChanged();
@@ -137,9 +191,13 @@ private:
                             double overshoot, const QString& profileFilename);
     void recomputeGlobalSawBootstrap(const QString& scaleType);
 
-    QString currentScaleType() const;
+    // Every optional-scaleType entry point funnels through here: an explicit key is
+    // normalized and used as given, an empty one resolves. One helper so "empty means
+    // resolve" cannot be implemented three subtly different ways.
+    QString resolveScaleKey(const QString& explicitKey) const;
 
     Settings* m_owner = nullptr;  // Non-owning; used ONLY for currentScaleType() lookup.
+    std::function<QString()> m_servingScaleType;  // See setServingScaleTypeProvider().
     mutable AppSettings m_settings;
 
     // SAW learning history cache (avoids re-parsing JSON from QSettings on every weight sample)

--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -3,6 +3,8 @@
 #include "../ble/scaledevice.h"
 #include "../ble/scales/scaletypeids.h"
 #include "../core/settings.h"
+#include "../core/settings_calibration.h"  // currentScaleType()/setServingScale() — settings.h
+                                           // only forward-declares the domain sub-objects
 #include "../core/settings_brew.h"
 #include "../controllers/shottimingcontroller.h"
 #include <QDateTime>
@@ -48,6 +50,15 @@ MachineState::MachineState(DE1Device* device, QObject* parent)
         // connected before MachineState was constructed, e.g. simulator mode)
         updatePhase();
     }
+}
+
+MachineState::~MachineState() {
+    // The provider installed in syncServingScale() captures `this`. Settings is not
+    // owned by MachineState and outlives it in the tests that build both on the stack,
+    // so leaving a dangling closure behind would turn any later currentScaleType()
+    // into a use-after-free.
+    if (m_settings && m_settings->calibration())
+        m_settings->calibration()->setServingScaleTypeProvider(nullptr);
 }
 
 bool MachineState::isFlowing() const {
@@ -158,28 +169,39 @@ void MachineState::setScale(ScaleDevice* scale) {
     emit activeScaleTypeChanged();
 }
 
+void MachineState::syncServingScale() {
+    // SettingsCalibration resolves the SAW pool key for every consumer, so it needs to
+    // know which scale is serving. Hand it a closure over m_scale rather than the value:
+    // main.cpp swaps the serving scale at a dozen device-event sites and connectedChanged
+    // fires independently of those, so a pushed value would need re-pushing from both
+    // and would be wrong the first time one was missed. Reading live state cannot go
+    // stale, so this only has to be installed once.
+    //
+    // Raw identity only — empty when nothing real is connected. The canonical-vocabulary
+    // test and the saved-scale fallback belong to SettingsCalibration, and duplicating
+    // either here would recreate the second implementation this refactor removed.
+    if (!m_settings || !m_settings->calibration())
+        return;
+    m_settings->calibration()->setServingScaleTypeProvider([this]() -> QString {
+        return m_scale && m_scale->isConnected() ? m_scale->type() : QString();
+    });
+}
+
 QString MachineState::activeScaleType() const {
-    // Only a scale in the canonical vocabulary is worth keying persistent per-scale
-    // state on. FlowScale reports "flow" and is permanently isConnected(), so without
-    // the vocabulary check every scale-less shot would open a "flow" pool and make
-    // SettingsCalibration::sensorLag() warn about an unknown type on every cycle.
-    // Falling back to the saved type for virtual scales preserves the long-standing
-    // behaviour there exactly. Note this fallback is only safe for the PREDICTION
-    // read: flow-derived shots must not feed SAW learning at all, which is enforced
-    // upstream by the isFlowScale() guard in ShotTimingController::onSettlingComplete()
-    // — see the reasoning there. Were that guard removed, this fallback is the exact
-    // mechanism by which a scale-less shot would write into a physical scale's pool.
-    if (m_scale && m_scale->isConnected()
-        && ScaleTypeIds::isCanonicalScaleTypeId(m_scale->type())) {
-        return m_scale->type();
-    }
-    // Normalized, not raw. Settings::scaleType() returns whatever is stored, and
-    // SettingsCalibration::currentScaleType() already normalizes defensively against a
-    // legacy display name surviving migration — so "Decent Scale" can reach here. This
-    // property is documented as returning a type-ID, and a caller keying a SAW pool on
-    // "Decent Scale" while the global path reads "decent" is the same split this whole
-    // mechanism exists to close.
-    return m_settings ? ScaleTypeIds::normalizeScaleTypeId(m_settings->scaleType()) : QString();
+    // Forwarder. The resolution itself lives on SettingsCalibration, which owns the
+    // SAW pools and which every consumer already holds a pointer to — so a call site
+    // that needs the key does NOT need a MachineState. This property exists purely to
+    // expose it to QML (the Calibration tab) with a notify signal; it is not a second
+    // implementation, and must never become one.
+    //
+    // The fallback to the saved type when the serving scale is virtual is only safe
+    // for the PREDICTION read: flow-derived shots must not feed SAW learning at all,
+    // which is enforced upstream by the isFlowScale() guard in
+    // ShotTimingController::onSettlingComplete() — see the reasoning there. Were that
+    // guard removed, this fallback is the exact mechanism by which a scale-less shot
+    // would write into a physical scale's pool.
+    return m_settings && m_settings->calibration()
+               ? m_settings->calibration()->currentScaleType() : QString();
 }
 
 QString MachineState::activeScaleName() const {
@@ -221,6 +243,7 @@ void MachineState::setSettings(Settings* settings) {
                 this, &MachineState::activeScaleTypeChanged);
     }
 
+    syncServingScale();
     emit activeScaleTypeChanged();
 }
 

--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -170,7 +170,13 @@ QString MachineState::activeScaleType() const {
         && ScaleTypeIds::isCanonicalScaleTypeId(m_scale->type())) {
         return m_scale->type();
     }
-    return m_settings ? m_settings->scaleType() : QString();
+    // Normalized, not raw. Settings::scaleType() returns whatever is stored, and
+    // SettingsCalibration::currentScaleType() already normalizes defensively against a
+    // legacy display name surviving migration — so "Decent Scale" can reach here. This
+    // property is documented as returning a type-ID, and a caller keying a SAW pool on
+    // "Decent Scale" while the global path reads "decent" is the same split this whole
+    // mechanism exists to close.
+    return m_settings ? ScaleTypeIds::normalizeScaleTypeId(m_settings->scaleType()) : QString();
 }
 
 QString MachineState::activeScaleName() const {
@@ -191,7 +197,28 @@ QString MachineState::activeScaleName() const {
 
 
 void MachineState::setSettings(Settings* settings) {
+    if (m_settings == settings) return;
+    if (m_settings) disconnect(m_settings, nullptr, this, nullptr);
+
     m_settings = settings;
+
+    // activeScaleType()/activeScaleName() fall back to the SAVED scale whenever the
+    // serving one is virtual or disconnected — which is the common case, since the app
+    // starts on FlowScale. Without these, changing the primary scale (Connections tab,
+    // removing a known scale, a settings restore) would move the answer while every
+    // QML binding on it kept the old value. The Calibration tab would then show one
+    // pool's lag and model tier while its reset button — an imperative read, not a
+    // binding — cleared a different pool. That read/write divergence is precisely what
+    // activeScaleType exists to prevent, so leaving it unwired would have reintroduced
+    // the bug one layer up.
+    if (m_settings) {
+        connect(m_settings, &Settings::scaleTypeChanged,
+                this, &MachineState::activeScaleTypeChanged);
+        connect(m_settings, &Settings::scaleNameChanged,
+                this, &MachineState::activeScaleTypeChanged);
+    }
+
+    emit activeScaleTypeChanged();
 }
 
 void MachineState::setTimingController(ShotTimingController* controller) {

--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -164,8 +164,11 @@ QString MachineState::activeScaleType() const {
     // the vocabulary check every scale-less shot would open a "flow" pool and make
     // SettingsCalibration::sensorLag() warn about an unknown type on every cycle.
     // Falling back to the saved type for virtual scales preserves the long-standing
-    // behaviour there exactly; whether flow-derived shots should feed SAW learning at
-    // all is a separate question, deliberately not decided here.
+    // behaviour there exactly. Note this fallback is only safe for the PREDICTION
+    // read: flow-derived shots must not feed SAW learning at all, which is enforced
+    // upstream by the isFlowScale() guard in ShotTimingController::onSettlingComplete()
+    // — see the reasoning there. Were that guard removed, this fallback is the exact
+    // mechanism by which a scale-less shot would write into a physical scale's pool.
     if (m_scale && m_scale->isConnected()
         && ScaleTypeIds::isCanonicalScaleTypeId(m_scale->type())) {
         return m_scale->type();

--- a/src/machine/machinestate.cpp
+++ b/src/machine/machinestate.cpp
@@ -1,6 +1,7 @@
 #include "machinestate.h"
 #include "../ble/de1device.h"
 #include "../ble/scaledevice.h"
+#include "../ble/scales/scaletypeids.h"
 #include "../core/settings.h"
 #include "../core/settings_brew.h"
 #include "../controllers/shottimingcontroller.h"
@@ -144,10 +145,48 @@ void MachineState::setScale(ScaleDevice* scale) {
                 m_weightTrailingTimer->start();
             }
         });
+        // activeScaleType() answers differently once the link comes up or drops, and
+        // nothing else would tell QML. Same connection lifetime as the weight relays
+        // above (disconnected wholesale on the next swap).
+        connect(m_scale, &ScaleDevice::connectedChanged,
+                this, &MachineState::activeScaleTypeChanged);
         // Emit immediately so QML picks up current weight
         emit scaleWeightChanged();
         emit scaleFlowRateChanged();
     }
+
+    emit activeScaleTypeChanged();
+}
+
+QString MachineState::activeScaleType() const {
+    // Only a scale in the canonical vocabulary is worth keying persistent per-scale
+    // state on. FlowScale reports "flow" and is permanently isConnected(), so without
+    // the vocabulary check every scale-less shot would open a "flow" pool and make
+    // SettingsCalibration::sensorLag() warn about an unknown type on every cycle.
+    // Falling back to the saved type for virtual scales preserves the long-standing
+    // behaviour there exactly; whether flow-derived shots should feed SAW learning at
+    // all is a separate question, deliberately not decided here.
+    if (m_scale && m_scale->isConnected()
+        && ScaleTypeIds::isCanonicalScaleTypeId(m_scale->type())) {
+        return m_scale->type();
+    }
+    return m_settings ? m_settings->scaleType() : QString();
+}
+
+QString MachineState::activeScaleName() const {
+    const QString saved = m_settings ? m_settings->scaleType() : QString();
+    const QString active = activeScaleType();
+
+    // Normal case: the serving scale IS the saved primary, so the user's own label
+    // (which may be a custom name) is both correct and the friendlier answer.
+    if (active == saved)
+        return m_settings ? m_settings->scaleName() : QString();
+
+    // Diverged — the saved label names a scale that is not serving. Report the
+    // canonical name of the one that is; a stale label next to a live model is
+    // exactly the confusion activeScaleType exists to remove.
+    const QString name = ScaleTypeIds::scaleTypeNameForId(active);
+    return name.isEmpty() ? (m_settings ? m_settings->scaleName() : QString()) : name;
 }
 
 

--- a/src/machine/machinestate.h
+++ b/src/machine/machinestate.h
@@ -155,9 +155,12 @@ private slots:
     void onTimingControllerTareComplete();
 
 private:
-    // Push the serving scale down to SettingsCalibration, which resolves the SAW pool
-    // key for every consumer. Called from setScale() and setSettings() — they arrive
-    // in either order at startup, and both must leave the resolver current.
+    // Install the serving-scale provider on SettingsCalibration, which resolves the SAW
+    // pool key for every consumer. Called from setSettings() ONLY, and once is enough:
+    // the provider is a closure over m_scale, so it follows every later setScale() and
+    // every connectedChanged without being reinstalled. (An earlier revision called it
+    // from setScale() too, which was the right shape for a pushed VALUE and pointless
+    // for a pull provider.)
     void syncServingScale();
 
     void updatePhase();

--- a/src/machine/machinestate.h
+++ b/src/machine/machinestate.h
@@ -22,6 +22,16 @@ class MachineState : public QObject {
     Q_PROPERTY(double shotTime READ shotTime NOTIFY shotTimeChanged)
     Q_PROPERTY(double targetWeight READ targetWeight WRITE setTargetWeight NOTIFY targetWeightChanged)
     Q_PROPERTY(double targetVolume READ targetVolume WRITE setTargetVolume NOTIFY targetVolumeChanged)
+    // The type-id of the scale ACTUALLY serving, which is not always the saved primary:
+    // the WiFi→BLE fallback preserves the WiFi primary on purpose, and a USB scale never
+    // occupies main()'s physicalScale at all. Everything that keys persistent per-scale
+    // state on "which scale is this?" — SAW learning, the Calibration tab's model/reset —
+    // must read THIS, so the pool being written is the pool being shown and reset.
+    // See SettingsCalibration and docs/CLAUDE_MD/SAW_LEARNING.md.
+    Q_PROPERTY(QString activeScaleType READ activeScaleType NOTIFY activeScaleTypeChanged)
+    // Display label matching activeScaleType, so a UI showing the two together cannot
+    // name one scale while reporting the other's learned model.
+    Q_PROPERTY(QString activeScaleName READ activeScaleName NOTIFY activeScaleTypeChanged)
     Q_PROPERTY(double scaleWeight READ scaleWeight NOTIFY scaleWeightChanged)
     Q_PROPERTY(double scaleFlowRate READ scaleFlowRate NOTIFY scaleFlowRateChanged)
     Q_PROPERTY(double smoothedScaleFlowRate READ smoothedScaleFlowRate NOTIFY scaleFlowRateChanged)
@@ -64,6 +74,8 @@ public:
     double pourVolume() const { return m_pourVolume; }
     ScaleDevice* scale() const;
     void setScale(ScaleDevice* scale);
+    QString activeScaleType() const;
+    QString activeScaleName() const;
     void setSettings(Settings* settings);
     void setTimingController(ShotTimingController* controller);
     void setTargetWeight(double weight);
@@ -100,6 +112,7 @@ signals:
     void preinfusionVolumeChanged();
     void pourVolumeChanged();
     void scaleWeightChanged();
+    void activeScaleTypeChanged();
     void scaleFlowRateChanged();
     void espressoCycleStarted();  // When entering espresso preheating (clear graph here)
     // The PAIR of espressoCycleStarted: fires when the espresso cycle is left,

--- a/src/machine/machinestate.h
+++ b/src/machine/machinestate.h
@@ -60,6 +60,9 @@ public:
     Q_ENUM(Phase)
 
     explicit MachineState(DE1Device* device, QObject* parent = nullptr);
+    // Clears the SAW scale-type provider it installed on SettingsCalibration, which
+    // captures `this` — see syncServingScale().
+    ~MachineState() override;
 
     Phase phase() const { return m_phase; }
     QString phaseString() const;
@@ -152,6 +155,11 @@ private slots:
     void onTimingControllerTareComplete();
 
 private:
+    // Push the serving scale down to SettingsCalibration, which resolves the SAW pool
+    // key for every consumer. Called from setScale() and setSettings() — they arrive
+    // in either order at startup, and both must leave the resolver current.
+    void syncServingScale();
+
     void updatePhase();
     void startShotTimer();
     void stopShotTimer();

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -56,11 +56,32 @@ void WeightProcessor::processWeight(double weight)
     // whole shot. That is the deliberate trade (see the comment there); it is a much
     // smaller surface than leaving the spike filter itself off.
     if (m_active && m_hasLastWeight && qAbs(weight - m_lastRawWeight) > 100.0) {
-        if (m_awaitingTare && qAbs(weight) <= kTareLandedThresholdG) {
-            // The tare landing. Accept it and stop expecting it.
+        if (m_awaitingTare && qAbs(weight) <= kTareLandedThresholdG
+            && ++m_tareLandedSamples >= kTareLandedConfirmations) {
+            // The tare landing, CONFIRMED. One packet is deliberately not enough.
+            //
+            // To be clear about the evidence: the observed "weight= 0 last= 364.6"
+            // above was the REAL tare being wrongly rejected, not corruption — it is
+            // not evidence that spurious zeros occur. The reason to require a second
+            // sample is that single-packet corruption is the documented failure mode
+            // this whole filter exists for (#610, a Felicita reporting 1649 g instead
+            // of ~10 g), and Decenza supports sixteen scale types whose behaviour
+            // around a tare we have no data on. Believing one spurious near-zero
+            // would consume the exemption, leave the real tare step to be rejected
+            // three times and escape-hatched, and open the per-frame weight exit on a
+            // full pre-tare reading — firing exactly the skipFrame the gate below
+            // exists to prevent. Same shape as the oscillation detector's settle
+            // count, and it costs ~200 ms of preheat.
             m_awaitingTare = false;
+            m_tareLandedSamples = 0;
             m_consecutiveRejections = 0;
+        } else if (m_awaitingTare && qAbs(weight) <= kTareLandedThresholdG) {
+            // Near zero but unconfirmed. Hold it: do NOT let it become the baseline,
+            // or a spurious zero still displaces a real pre-tare reading.
+            m_lastWallClockMs = wallClock;  // keep de-jitter timing accurate
+            return;
         } else if (++m_consecutiveRejections < 3) {
+            m_tareLandedSamples = 0;  // not near zero — any run of them is broken
             m_lastWallClockMs = wallClock;  // Keep de-jitter timing accurate
             qWarning() << "[SAW-Worker] Spike rejected: weight=" << weight
                        << "last=" << m_lastRawWeight;
@@ -73,9 +94,16 @@ void WeightProcessor::processWeight(double weight)
         }
     } else {
         // A near-zero reading with no big step (the common case — the scale was already
-        // at zero) still satisfies the tare we were waiting for.
-        if (m_awaitingTare && qAbs(weight) <= kTareLandedThresholdG)
-            m_awaitingTare = false;
+        // at zero) still satisfies the tare we were waiting for, and is confirmed the
+        // same way. Samples here are accepted normally either way; only the flag waits.
+        if (m_awaitingTare && qAbs(weight) <= kTareLandedThresholdG) {
+            if (++m_tareLandedSamples >= kTareLandedConfirmations) {
+                m_awaitingTare = false;
+                m_tareLandedSamples = 0;
+            }
+        } else {
+            m_tareLandedSamples = 0;
+        }
         m_consecutiveRejections = 0;
     }
     // Captured before the overwrite below: pre-#1176, a sample equal to the
@@ -525,6 +553,7 @@ void WeightProcessor::startExtraction()
     m_hasLastWeight = false;
     m_consecutiveRejections = 0;
     m_awaitingTare = true;  // Cleared when the scale is seen to reach zero
+    m_tareLandedSamples = 0;
     m_currentFrame = -1;
     m_tareComplete = false;
     m_oscillationDetected = false;
@@ -548,6 +577,15 @@ void WeightProcessor::markExtractionStart()
     // Flow has begun, so whatever the scale reads now is its post-tare zero even if
     // it never passed through the near-zero window (an untared cup left on the
     // platter, say). Arm the spike filter unconditionally here.
+    //
+    // Deliberately NOT warned about. An earlier revision logged when m_awaitingTare
+    // was still set here, on the theory that reaching flow without an observed tare is
+    // abnormal. There is no evidence for that theory and good reason to doubt it: the
+    // near-zero window is 5 g, and across the sixteen supported scale types any scale
+    // that settles a little above it after a tare would warn on every single shot. The
+    // condition is also already surfaced properly — untaredCupDetected() carries it to
+    // the UI — and by the next line the app has recovered, so per-frame exits work from
+    // flow start regardless. A log line here would be noise on a handled path.
     //
     // The SAW stop of #610 cannot fire before this point regardless — it requires
     // extractionElapsed > 5 s, and extractionElapsed is 0 while m_extractionStartTime
@@ -601,6 +639,7 @@ void WeightProcessor::resetForRetare()
     m_hasLastWeight = false;
     m_consecutiveRejections = 0;
     m_awaitingTare = true;  // Retare moves the zero point again — same reasoning
+    m_tareLandedSamples = 0;
     m_extractionStartTime = 0;  // Will be set when extraction actually starts
     m_stopTriggered = false;
     m_frameWeightSkipSent.clear();

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -33,34 +33,42 @@ void WeightProcessor::processWeight(double weight)
     // and polluting the debug log. The filter is reset by startExtraction()
     // before each shot and by resetForRetare() on mid-preheat retare.
     //
-    // Held off until the tare lands. startExtraction() clears the baseline, but
-    // the tare is asynchronous AT THE SCALE: the first samples after it arrive
-    // still carrying the loaded portafilter's weight, one of which becomes the
-    // new baseline — so the drop to zero that follows reads as a >100g spike and
-    // the filter rejects the app's own tare. Observed every shot on-device:
-    // "Spike rejected: weight= 0 last= 364.6" twice, then the 3-rejection escape
-    // hatch accepting the baseline it should never have questioned. Nothing broke,
-    // because this all happens during EspressoPreheating, but the filter spent the
-    // window blind and each shot's log carried two warnings for normal operation.
-    if (m_awaitingTare) {
-        // A near-zero reading is the tare landing. Until then every sample simply
-        // re-baselines below, which is the correct treatment for a signal whose
-        // zero point we have just deliberately moved.
-        if (qAbs(weight) <= kTareLandedThresholdG) {
+    // ONE step is exempt: the tare. startExtraction() clears the baseline, but the tare
+    // is asynchronous AT THE SCALE — the samples arriving just after it still carry the
+    // loaded portafilter's weight, and one of them becomes the new baseline. The drop to
+    // zero that follows then reads as a >100 g spike, so the filter rejected the app's
+    // own tare. Observed every shot on-device: "Spike rejected: weight= 0 last= 364.6"
+    // twice, then the 3-rejection escape hatch accepting the baseline it should never
+    // have questioned.
+    //
+    // The exemption is deliberately DIRECTIONAL: only a large step DOWN to near zero,
+    // and only while awaiting a tare. Corruption of the #610 kind travels upward (1649 g
+    // instead of 10 g), so nothing about that case needs the filter relaxed — and an
+    // exemption for large steps in general would leave a window with no filter at all,
+    // whose end depended on events that might never arrive (a scale that never reads
+    // near zero, a shot where flow never starts). There is no such window now: every
+    // sample that is not the tare step is filtered exactly as before.
+    if (m_active && m_hasLastWeight && qAbs(weight - m_lastRawWeight) > 100.0) {
+        if (m_awaitingTare && qAbs(weight) <= kTareLandedThresholdG) {
+            // The tare landing. Accept it and stop expecting it.
             m_awaitingTare = false;
-        }
-    } else if (m_active && m_hasLastWeight && qAbs(weight - m_lastRawWeight) > 100.0) {
-        if (++m_consecutiveRejections < 3) {
+            m_consecutiveRejections = 0;
+        } else if (++m_consecutiveRejections < 3) {
             m_lastWallClockMs = wallClock;  // Keep de-jitter timing accurate
             qWarning() << "[SAW-Worker] Spike rejected: weight=" << weight
                        << "last=" << m_lastRawWeight;
             return;
+        } else {
+            qWarning() << "[SAW-Worker] Spike filter reset after"
+                       << m_consecutiveRejections << "consecutive rejections"
+                       << "— accepting new baseline:" << weight;
+            m_consecutiveRejections = 0;
         }
-        qWarning() << "[SAW-Worker] Spike filter reset after"
-                   << m_consecutiveRejections << "consecutive rejections"
-                   << "— accepting new baseline:" << weight;
-        m_consecutiveRejections = 0;
     } else {
+        // A near-zero reading with no big step (the common case — the scale was already
+        // at zero) still satisfies the tare we were waiting for.
+        if (m_awaitingTare && qAbs(weight) <= kTareLandedThresholdG)
+            m_awaitingTare = false;
         m_consecutiveRejections = 0;
     }
     // Captured before the overwrite below: pre-#1176, a sample equal to the
@@ -324,8 +332,18 @@ void WeightProcessor::processWeight(double weight)
         }
     }
 
-    // Per-frame weight exit check
-    if (m_currentFrame >= 0 && m_currentFrame < m_frameExitWeights.size()) {
+    // Per-frame weight exit check.
+    //
+    // Gated on the tare having landed. This check compares an ABSOLUTE weight against
+    // a threshold, and while m_awaitingTare holds, absolute weight is meaningless — the
+    // zero point is mid-move. A pre-tare reading (a loaded portafilter, ~360 g) clears
+    // any plausible exitWeight outright, so acting on it would skip a frame on the
+    // strength of a number we have already decided not to trust. That was reachable
+    // before this gate for the first post-startExtraction sample, which bypasses the
+    // spike filter to establish the baseline; the tare hold-off would have widened it
+    // to every pre-tare sample. Unlike the SAW stop below, this branch has no
+    // extractionElapsed > 5 s guard of its own, so it needs its own.
+    if (!m_awaitingTare && m_currentFrame >= 0 && m_currentFrame < m_frameExitWeights.size()) {
         double exitWeight = m_frameExitWeights[m_currentFrame];
         if (exitWeight > 0 && weight >= exitWeight && !m_frameWeightSkipSent.contains(m_currentFrame)) {
             // On a mixed frame (weight exit + firmware exit), the firmware can
@@ -522,9 +540,12 @@ void WeightProcessor::markExtractionStart()
     m_extractionStartTime = m_wallClock();
     // Flow has begun, so whatever the scale reads now is its post-tare zero even if
     // it never passed through the near-zero window (an untared cup left on the
-    // platter, say). Arm the spike filter unconditionally: the pour is the only
-    // window where a corrupt packet can cause the false SAW stop of #610, and it
-    // starts here.
+    // platter, say). Arm the spike filter unconditionally here.
+    //
+    // The SAW stop of #610 cannot fire before this point regardless — it requires
+    // extractionElapsed > 5 s, and extractionElapsed is 0 while m_extractionStartTime
+    // is 0 — so the hold-off costs nothing there. It is the per-frame weight exit that
+    // needed protecting in the meantime, and that has its own !m_awaitingTare gate.
     m_awaitingTare = false;
 }
 

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -32,7 +32,24 @@ void WeightProcessor::processWeight(double weight)
     // 100g+ swings that the filter would reject, freezing the flow rate display
     // and polluting the debug log. The filter is reset by startExtraction()
     // before each shot and by resetForRetare() on mid-preheat retare.
-    if (m_active && m_hasLastWeight && qAbs(weight - m_lastRawWeight) > 100.0) {
+    //
+    // Held off until the tare lands. startExtraction() clears the baseline, but
+    // the tare is asynchronous AT THE SCALE: the first samples after it arrive
+    // still carrying the loaded portafilter's weight, one of which becomes the
+    // new baseline — so the drop to zero that follows reads as a >100g spike and
+    // the filter rejects the app's own tare. Observed every shot on-device:
+    // "Spike rejected: weight= 0 last= 364.6" twice, then the 3-rejection escape
+    // hatch accepting the baseline it should never have questioned. Nothing broke,
+    // because this all happens during EspressoPreheating, but the filter spent the
+    // window blind and each shot's log carried two warnings for normal operation.
+    if (m_awaitingTare) {
+        // A near-zero reading is the tare landing. Until then every sample simply
+        // re-baselines below, which is the correct treatment for a signal whose
+        // zero point we have just deliberately moved.
+        if (qAbs(weight) <= kTareLandedThresholdG) {
+            m_awaitingTare = false;
+        }
+    } else if (m_active && m_hasLastWeight && qAbs(weight - m_lastRawWeight) > 100.0) {
         if (++m_consecutiveRejections < 3) {
             m_lastWallClockMs = wallClock;  // Keep de-jitter timing accurate
             qWarning() << "[SAW-Worker] Spike rejected: weight=" << weight
@@ -482,6 +499,7 @@ void WeightProcessor::startExtraction()
     m_lastRawWeight = 0;
     m_hasLastWeight = false;
     m_consecutiveRejections = 0;
+    m_awaitingTare = true;  // Cleared when the scale is seen to reach zero
     m_currentFrame = -1;
     m_tareComplete = false;
     m_oscillationDetected = false;
@@ -502,6 +520,12 @@ void WeightProcessor::markExtractionStart()
 {
     if (!m_active || m_extractionStartTime != 0) return;
     m_extractionStartTime = m_wallClock();
+    // Flow has begun, so whatever the scale reads now is its post-tare zero even if
+    // it never passed through the near-zero window (an untared cup left on the
+    // platter, say). Arm the spike filter unconditionally: the pour is the only
+    // window where a corrupt packet can cause the false SAW stop of #610, and it
+    // starts here.
+    m_awaitingTare = false;
 }
 
 void WeightProcessor::endShotCycle()
@@ -548,6 +572,7 @@ void WeightProcessor::resetForRetare()
     m_lastRawWeight = 0;
     m_hasLastWeight = false;
     m_consecutiveRejections = 0;
+    m_awaitingTare = true;  // Retare moves the zero point again — same reasoning
     m_extractionStartTime = 0;  // Will be set when extraction actually starts
     m_stopTriggered = false;
     m_frameWeightSkipSent.clear();

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -25,7 +25,8 @@ void WeightProcessor::processWeight(double weight)
     // A Felicita scale was observed sending 1649g instead of ~10g, causing a
     // false SAW stop. Any reading that jumps more than 100g from the previous
     // sample is rejected. Auto-resets after 3 consecutive rejections to handle
-    // legitimate shifts (cup removal, tare, scale reconnect at different offset).
+    // legitimate shifts (cup removal, scale reconnect at different offset). The tare
+    // used to rely on that hatch too; it is handled up front now — see below.
     //
     // Only active during extraction — between shots, cup placement/removal,
     // tare drift, and scale reconnect at different offset produce legitimate
@@ -46,8 +47,14 @@ void WeightProcessor::processWeight(double weight)
     // instead of 10 g), so nothing about that case needs the filter relaxed — and an
     // exemption for large steps in general would leave a window with no filter at all,
     // whose end depended on events that might never arrive (a scale that never reads
-    // near zero, a shot where flow never starts). There is no such window now: every
-    // sample that is not the tare step is filtered exactly as before.
+    // near zero, a shot where flow never starts). Every sample the SPIKE FILTER sees
+    // other than the tare step is therefore filtered exactly as before.
+    //
+    // The m_awaitingTare window is not gone, though — it still gates the per-frame
+    // weight exit at the bottom of this function, and on an untared cup that never
+    // reads near zero in a shot where flow never starts, that gate stays shut for the
+    // whole shot. That is the deliberate trade (see the comment there); it is a much
+    // smaller surface than leaving the spike filter itself off.
     if (m_active && m_hasLastWeight && qAbs(weight - m_lastRawWeight) > 100.0) {
         if (m_awaitingTare && qAbs(weight) <= kTareLandedThresholdG) {
             // The tare landing. Accept it and stop expecting it.

--- a/src/machine/weightprocessor.cpp
+++ b/src/machine/weightprocessor.cpp
@@ -78,6 +78,24 @@ void WeightProcessor::processWeight(double weight)
         } else if (m_awaitingTare && qAbs(weight) <= kTareLandedThresholdG) {
             // Near zero but unconfirmed. Hold it: do NOT let it become the baseline,
             // or a spurious zero still displaces a real pre-tare reading.
+            //
+            // Logged because this DISCARDS a sample, and its sibling branch below logs
+            // every sample it drops — a silent drop on a path that runs every shot is
+            // the one you cannot diagnose from a field log. qDebug, not qWarning:
+            // holding the first near-zero is the NORMAL case (the confirmation needs a
+            // second one), so a warning would fire on every shot and fail the suite
+            // under failOnWarning().
+            //
+            // Repeated lines here with no "tare confirmed" following them is the
+            // signature of a scale alternating a loaded reading with a near-zero one
+            // (e.g. 200, 0, 200, 0): each zero holds and is discarded without updating
+            // m_lastRawWeight, each 200 is a 0 g step that resets the confirmation
+            // count, so m_awaitingTare never clears for the whole preheat. Bounded —
+            // markExtractionStart() arms unconditionally at flow start — but worth
+            // seeing rather than guessing at.
+            qDebug() << "[SAW-Worker] Tare candidate held (unconfirmed): weight=" << weight
+                     << "last=" << m_lastRawWeight
+                     << "confirmations=" << m_tareLandedSamples << "/" << kTareLandedConfirmations;
             m_lastWallClockMs = wallClock;  // keep de-jitter timing accurate
             return;
         } else if (++m_consecutiveRejections < 3) {

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -139,6 +139,12 @@ private:
     // A tared scale reads within a gram or two of zero; 5 g leaves room for drift
     // and a wet basket without being wide enough to swallow a real cup.
     static constexpr double kTareLandedThresholdG = 5.0;
+    // Consecutive near-zero samples required before the tare is believed. Single-packet
+    // corruption is the documented failure mode this filter exists for (#610), and we
+    // support sixteen scale types whose behaviour around a tare is unmeasured — so one
+    // packet must not be able to consume the exemption. Costs ~200 ms during preheat.
+    static constexpr int kTareLandedConfirmations = 2;
+    int m_tareLandedSamples = 0;
 
     // Scale-feed liveness (in-shot backstop). Evaluated on the DE1 tick so a
     // fully-silent scale is still detected. 2000ms mirrors the de-jitter

--- a/src/machine/weightprocessor.h
+++ b/src/machine/weightprocessor.h
@@ -131,6 +131,14 @@ private:
     double m_lastRawWeight = 0;
     bool m_hasLastWeight = false;
     int m_consecutiveRejections = 0;
+    // Held from startExtraction()/resetForRetare() until the tare is observed to
+    // have landed at the scale. The step from a loaded portafilter to zero is the
+    // app's own doing, not corruption — see processWeight(). Cleared by a near-zero
+    // sample or, at the latest, by markExtractionStart().
+    bool m_awaitingTare = false;
+    // A tared scale reads within a gram or two of zero; 5 g leaves room for drift
+    // and a wet basket without being wide enough to swallow a real cup.
+    static constexpr double kTareLandedThresholdG = 5.0;
 
     // Scale-feed liveness (in-shot backstop). Evaluated on the DE1 tick so a
     // fully-silent scale is still detected. 2000ms mirrors the de-jitter

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1253,14 +1253,36 @@ int main(int argc, char *argv[])
     // those in sync matters as much as the key itself: a write path that diverges from the
     // read path is worse than a consistently wrong key, because nothing on screen reveals it.
 
+    // The SAW key is resolved at shot START (to pick the prediction model and sensor
+    // lag) and again ~40 s later at learning time (to pick the pool to write). Those
+    // are two reads of live state with a whole shot in between, and main() swaps the
+    // serving scale on device events at a dozen call sites — a USB cable knocked loose
+    // mid-pour is enough. Latch it once, alongside ProfileManager::latchForShot(),
+    // and learn under the key that actually made the prediction.
+    QString sawScaleKeyForShot;
+
     // Connect SAW learning signal to settings persistence.
     // Logs the predicted-vs-actual drip ("accuracy" line) before persisting, so any single
     // shot's debug log records whether SAW hit its target. addSawLearningPoint then routes
     // the entry through the per-(profile, scale) batch accumulator and emits the
     // "accumulated"/"committed"/"batch rejected" qDebug line that ShotDebugLogger captures.
     QObject::connect(&timingController, &ShotTimingController::sawLearningComplete,
-                     [&settings, &mainController, &machineState](double drip, double flowAtStop, double overshoot) {
-                         const QString scaleType = machineState.activeScaleType();
+                     [&settings, &mainController, &machineState, &sawScaleKeyForShot](
+                             double drip, double flowAtStop, double overshoot) {
+                         // Prefer the latched key. Empty only if learning somehow fires
+                         // without a cycle start, in which case live state is all there is.
+                         const QString liveScaleType = machineState.activeScaleType();
+                         const QString scaleType = sawScaleKeyForShot.isEmpty()
+                                                       ? liveScaleType : sawScaleKeyForShot;
+                         if (!sawScaleKeyForShot.isEmpty() && liveScaleType != sawScaleKeyForShot) {
+                             // Not fatal — the latched key is the correct one to learn
+                             // under — but it means the serving scale changed mid-shot,
+                             // which is worth seeing in the shot log rather than inferring
+                             // later from a pool that drifted.
+                             qWarning() << "[SAW] scale changed mid-shot: predicted with"
+                                        << sawScaleKeyForShot << "but now serving"
+                                        << liveScaleType << "- learning under the former";
+                         }
                          const QString profileFilename = mainController.profileManager()->baseProfileName();
                          const double predictedDrip = settings.calibration()->getExpectedDripFor(profileFilename, scaleType, flowAtStop);
                          qDebug() << "[SAW] accuracy: predictedDrip=" << predictedDrip
@@ -1374,7 +1396,8 @@ int main(int argc, char *argv[])
     // connection would race: its queued setTareComplete(true) arrives on the worker BEFORE
     // startExtraction() (which resets m_tareComplete=false), causing tare to be lost.
     QObject::connect(&machineState, &MachineState::espressoCycleStarted,
-                     [&weightProcessor, &machineState, &settings, &mainController, &timingController]() {
+                     [&weightProcessor, &machineState, &settings, &mainController, &timingController,
+                      &sawScaleKeyForShot]() {
                          // Freeze the resolved target + dose for the duration
                          // of the shot (add-yield-ratio-anchor Decision 9),
                          // alongside the SAW model snapshot below so the two
@@ -1395,6 +1418,7 @@ int main(int argc, char *argv[])
                          // is driving this shot's predictions for later accuracy analysis.
                          double targetWeight = machineState.targetWeight();
                          QString scaleType = machineState.activeScaleType();
+                         sawScaleKeyForShot = scaleType;  // latched for the learning path
                          QString profileFilename = mainController.profileManager()->baseProfileName();
                          bool converged = settings.calibration()->isSawConverged(scaleType);
                          int maxEntries = converged ? 12 : 8;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1230,21 +1230,28 @@ int main(int argc, char *argv[])
     // SAW learning is keyed per (profile, scale) — and "scale" has to mean the scale that
     // actually served the shot, not the one nominated as primary in Settings. The two
     // diverge whenever the WiFi-primary Half Decent Scale is unreachable and the app falls
-    // back to its BLE transport: that path deliberately preserves the saved WiFi primary
-    // ("Scale connected via WiFi-to-BLE fallback — preserving saved WiFi primary"), so
-    // settings.scaleType() keeps answering "decent-wifi" while every weight sample arrives
-    // over BLE. Reading and writing the WiFi bucket from BLE shots trains one transport's
-    // lag model on the other's timing — the two transports are separate keys precisely
-    // because their latency differs. Observed on-device: four consecutive BLE-served shots
-    // logged scale="decent-wifi" and committed into that pool.
+    // back to its BLE transport: that path deliberately skips setPrimaryScale() (see
+    // isFallbackConnect in the scaleFound handler), so settings.scaleType() keeps answering
+    // "decent-wifi" while every weight sample arrives over BLE. Writing BLE-served shots
+    // into the WiFi pool corrupts a learned model the user cannot see or reset separately.
+    // Observed on-device: four consecutive BLE-served shots logged scale="decent-wifi".
     //
-    // Falls back to the saved type only when nothing is connected, which no live shot can
-    // observe — it exists so the expression is total, not as a real code path.
-    auto sawScaleType = [&physicalScale, &settings]() -> QString {
-        if (physicalScale && physicalScale->isConnected())
-            return physicalScale->type();
-        return settings.scaleType();
-    };
+    // Note the SEED defaults in SettingsCalibration::sensorLag() are identical for "decent"
+    // and "decent-wifi" today (both 0.38), so the first-shot prediction would not differ —
+    // it is the accumulated per-key pools that this protects, and that argument survives a
+    // future edit to the seed table.
+    //
+    // Resolved by MachineState::activeScaleType(), which keys on the scale actually wired
+    // into the shot path. Deliberately NOT main()'s physicalScale: a USB scale never
+    // occupies it (the USB discovery handler calls physicalScale.reset() and installs
+    // usbScale directly), so keying on physicalScale would leave USB shots on the saved
+    // type — correct today only because the USB path always calls setPrimaryScale(), i.e.
+    // by the same luck the WiFi→BLE fallback removes.
+    //
+    // The Calibration tab and the reset_saw_learning_for_profile MCP tool read the same
+    // property, so the pool being trained is the pool the user sees and can clear. Keeping
+    // those in sync matters as much as the key itself: a write path that diverges from the
+    // read path is worse than a consistently wrong key, because nothing on screen reveals it.
 
     // Connect SAW learning signal to settings persistence.
     // Logs the predicted-vs-actual drip ("accuracy" line) before persisting, so any single
@@ -1252,8 +1259,8 @@ int main(int argc, char *argv[])
     // the entry through the per-(profile, scale) batch accumulator and emits the
     // "accumulated"/"committed"/"batch rejected" qDebug line that ShotDebugLogger captures.
     QObject::connect(&timingController, &ShotTimingController::sawLearningComplete,
-                     [&settings, &mainController, sawScaleType](double drip, double flowAtStop, double overshoot) {
-                         const QString scaleType = sawScaleType();
+                     [&settings, &mainController, &machineState](double drip, double flowAtStop, double overshoot) {
+                         const QString scaleType = machineState.activeScaleType();
                          const QString profileFilename = mainController.profileManager()->baseProfileName();
                          const double predictedDrip = settings.calibration()->getExpectedDripFor(profileFilename, scaleType, flowAtStop);
                          qDebug() << "[SAW] accuracy: predictedDrip=" << predictedDrip
@@ -1367,8 +1374,7 @@ int main(int argc, char *argv[])
     // connection would race: its queued setTareComplete(true) arrives on the worker BEFORE
     // startExtraction() (which resets m_tareComplete=false), causing tare to be lost.
     QObject::connect(&machineState, &MachineState::espressoCycleStarted,
-                     [&weightProcessor, &machineState, &settings, &mainController, &timingController,
-                      sawScaleType]() {
+                     [&weightProcessor, &machineState, &settings, &mainController, &timingController]() {
                          // Freeze the resolved target + dose for the duration
                          // of the shot (add-yield-ratio-anchor Decision 9),
                          // alongside the SAW model snapshot below so the two
@@ -1388,7 +1394,7 @@ int main(int argc, char *argv[])
                          // committed batches). The "model:" log line records which source
                          // is driving this shot's predictions for later accuracy analysis.
                          double targetWeight = machineState.targetWeight();
-                         QString scaleType = sawScaleType();
+                         QString scaleType = machineState.activeScaleType();
                          QString profileFilename = mainController.profileManager()->baseProfileName();
                          bool converged = settings.calibration()->isSawConverged(scaleType);
                          int maxEntries = converged ? 12 : 8;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1227,14 +1227,33 @@ int main(int argc, char *argv[])
     // WeightProcessor signals (stopNow, skipFrame) wired below.
     // ShotTimingController::stopAtWeightReached and perFrameWeightReached are no longer emitted.
 
+    // SAW learning is keyed per (profile, scale) — and "scale" has to mean the scale that
+    // actually served the shot, not the one nominated as primary in Settings. The two
+    // diverge whenever the WiFi-primary Half Decent Scale is unreachable and the app falls
+    // back to its BLE transport: that path deliberately preserves the saved WiFi primary
+    // ("Scale connected via WiFi-to-BLE fallback — preserving saved WiFi primary"), so
+    // settings.scaleType() keeps answering "decent-wifi" while every weight sample arrives
+    // over BLE. Reading and writing the WiFi bucket from BLE shots trains one transport's
+    // lag model on the other's timing — the two transports are separate keys precisely
+    // because their latency differs. Observed on-device: four consecutive BLE-served shots
+    // logged scale="decent-wifi" and committed into that pool.
+    //
+    // Falls back to the saved type only when nothing is connected, which no live shot can
+    // observe — it exists so the expression is total, not as a real code path.
+    auto sawScaleType = [&physicalScale, &settings]() -> QString {
+        if (physicalScale && physicalScale->isConnected())
+            return physicalScale->type();
+        return settings.scaleType();
+    };
+
     // Connect SAW learning signal to settings persistence.
     // Logs the predicted-vs-actual drip ("accuracy" line) before persisting, so any single
     // shot's debug log records whether SAW hit its target. addSawLearningPoint then routes
     // the entry through the per-(profile, scale) batch accumulator and emits the
     // "accumulated"/"committed"/"batch rejected" qDebug line that ShotDebugLogger captures.
     QObject::connect(&timingController, &ShotTimingController::sawLearningComplete,
-                     [&settings, &mainController](double drip, double flowAtStop, double overshoot) {
-                         const QString scaleType = settings.scaleType();
+                     [&settings, &mainController, sawScaleType](double drip, double flowAtStop, double overshoot) {
+                         const QString scaleType = sawScaleType();
                          const QString profileFilename = mainController.profileManager()->baseProfileName();
                          const double predictedDrip = settings.calibration()->getExpectedDripFor(profileFilename, scaleType, flowAtStop);
                          qDebug() << "[SAW] accuracy: predictedDrip=" << predictedDrip
@@ -1348,7 +1367,8 @@ int main(int argc, char *argv[])
     // connection would race: its queued setTareComplete(true) arrives on the worker BEFORE
     // startExtraction() (which resets m_tareComplete=false), causing tare to be lost.
     QObject::connect(&machineState, &MachineState::espressoCycleStarted,
-                     [&weightProcessor, &machineState, &settings, &mainController, &timingController]() {
+                     [&weightProcessor, &machineState, &settings, &mainController, &timingController,
+                      sawScaleType]() {
                          // Freeze the resolved target + dose for the duration
                          // of the shot (add-yield-ratio-anchor Decision 9),
                          // alongside the SAW model snapshot below so the two
@@ -1368,7 +1388,7 @@ int main(int argc, char *argv[])
                          // committed batches). The "model:" log line records which source
                          // is driving this shot's predictions for later accuracy analysis.
                          double targetWeight = machineState.targetWeight();
-                         QString scaleType = settings.scaleType();
+                         QString scaleType = sawScaleType();
                          QString profileFilename = mainController.profileManager()->baseProfileName();
                          bool converged = settings.calibration()->isSawConverged(scaleType);
                          int maxEntries = converged ? 12 : 8;

--- a/src/mcp/mcptools_control.cpp
+++ b/src/mcp/mcptools_control.cpp
@@ -336,13 +336,13 @@ void registerControlTools(McpToolRegistry* registry, DE1Device* device, MachineS
         "reset_saw_learning_for_profile",
         "Reset stop-at-weight learning for a single (profile, scale) pair only. Other pairs "
         "and the global bootstrap are preserved. Defaults to the active profile and the "
-        "configured scale type when arguments are omitted.",
+        "scale currently serving shots when arguments are omitted.",
         QJsonObject{{"type", "object"}, {"properties", QJsonObject{
             {"profileFilename", QJsonObject{{"type", "string"}, {"description", "Profile filename (defaults to active profile)"}}},
-            {"scaleType", QJsonObject{{"type", "string"}, {"description", "Scale type (defaults to configured scaleType)"}}},
+            {"scaleType", QJsonObject{{"type", "string"}, {"description", "Scale type (defaults to the scale currently serving shots, which is not always the saved primary)"}}},
             {"confirmed", QJsonObject{{"type", "boolean"}, {"description", "Set to true after user confirms this action in chat"}}}
         }}},
-        [settings, profileManager](const QJsonObject& args) -> QJsonObject {
+        [settings, profileManager, machineState](const QJsonObject& args) -> QJsonObject {
             QJsonObject result;
             if (!settings) {
                 result["error"] = "Settings not available";
@@ -357,6 +357,10 @@ void registerControlTools(McpToolRegistry* registry, DE1Device* device, MachineS
                 return result;
             }
             QString scale = args["scaleType"].toString();
+            // Default to the scale actually serving, matching what the shot engine
+            // learns under and what the Calibration tab shows. Defaulting to the saved
+            // primary would silently clear a pool the user is not using.
+            if (scale.isEmpty() && machineState) scale = machineState->activeScaleType();
             if (scale.isEmpty()) scale = settings->scaleType();
             settings->calibration()->resetSawLearningForProfile(filename, scale);
             result["success"] = true;

--- a/src/mcp/mcptools_control.cpp
+++ b/src/mcp/mcptools_control.cpp
@@ -342,7 +342,7 @@ void registerControlTools(McpToolRegistry* registry, DE1Device* device, MachineS
             {"scaleType", QJsonObject{{"type", "string"}, {"description", "Scale type (defaults to the scale currently serving shots, which is not always the saved primary)"}}},
             {"confirmed", QJsonObject{{"type", "boolean"}, {"description", "Set to true after user confirms this action in chat"}}}
         }}},
-        [settings, profileManager, machineState](const QJsonObject& args) -> QJsonObject {
+        [settings, profileManager](const QJsonObject& args) -> QJsonObject {
             QJsonObject result;
             if (!settings) {
                 result["error"] = "Settings not available";
@@ -357,11 +357,17 @@ void registerControlTools(McpToolRegistry* registry, DE1Device* device, MachineS
                 return result;
             }
             QString scale = args["scaleType"].toString();
-            // Default to the scale actually serving, matching what the shot engine
-            // learns under and what the Calibration tab shows. Defaulting to the saved
-            // primary would silently clear a pool the user is not using.
-            if (scale.isEmpty() && machineState) scale = machineState->activeScaleType();
-            if (scale.isEmpty()) scale = settings->scaleType();
+            // Default to the scale actually serving, matching what the shot engine learns
+            // under and what the Calibration tab shows. Defaulting to the saved primary
+            // would silently clear a pool the user is not using.
+            //
+            // Ask SettingsCalibration directly rather than rehydrating the rule here.
+            // This used to be two hand-rolled fallbacks, and the second one —
+            // settings->scaleType() — did NOT normalize, so a legacy display name
+            // surviving migration would clear "<profile>::Decent Scale" while the learner
+            // writes "<profile>::decent", reporting success having cleared nothing. It
+            // was also echoed verbatim to the model in result["scaleType"] below.
+            if (scale.isEmpty()) scale = settings->calibration()->currentScaleType();
             settings->calibration()->resetSawLearningForProfile(filename, scale);
             result["success"] = true;
             result["profileFilename"] = filename;

--- a/src/network/mqttclient.cpp
+++ b/src/network/mqttclient.cpp
@@ -70,11 +70,16 @@ MqttClient::MqttClient(DE1Device* device, MachineState* machineState,
 
     // The reconnect budget is for "the broker is not answering us", not for "this
     // device has no network" — a connect attempt against a down interface tells us
-    // nothing about the broker, and MAX_RECONNECT_ATTEMPTS is terminal: once it is
-    // reached neither failure handler re-arms the timer, so MQTT stays dead until
-    // the app restarts. Observed on-device 2026-07-25: a ~7 min Wi-Fi drop consumed
-    // 9 of the 10 attempts and the 10th happened to land 12 s after the network came
-    // back. A slightly longer outage would have killed Home Assistant for the day.
+    // nothing about the broker, and hitting MAX_RECONNECT_ATTEMPTS ends automatic
+    // recovery: neither failure handler re-arms the timer past the cap, so nothing
+    // retries on its own. Recovery then needs a deliberate act — the Connect button,
+    // an MQTT settings change, or the mqtt_connect MCP tool — none of which a user
+    // has any reason to perform, because the failure is silent.
+    //
+    // Observed on-device 2026-07-25: a Wi-Fi drop consumed the budget down to the
+    // last attempt, which happened to land seconds after the network returned. A
+    // slightly longer outage would have left Home Assistant dark until someone
+    // noticed and intervened.
     //
     // So: watch reachability, don't spend attempts while it is positively down, and
     // treat the return of the network as a fresh budget. Only "Disconnected" counts
@@ -227,6 +232,17 @@ void MqttClient::connectToBroker()
             QString resolved = MdnsResolver::resolveHostname(host);
             QMetaObject::invokeMethod(guard.data(), [guard, resolved, host]() {
                 if (!guard) return;
+                // The resolve takes up to 2 s and conditions can change inside it —
+                // newly relevant now that connectToBroker() also fires on a reachability
+                // edge rather than only on user action. A flapping AP would otherwise
+                // land here with the network down again, overwrite the accurate
+                // "Waiting for network..." status, and dial a dead interface.
+                if (guard->m_networkDown || !guard->m_settingsMqtt
+                    || !guard->m_settingsMqtt->mqttEnabled()) {
+                    qDebug() << "MqttClient: mDNS resolve finished but conditions changed"
+                             << "(networkDown=" << guard->m_networkDown << ") - not connecting";
+                    return;
+                }
                 if (!resolved.isEmpty()) {
                     qDebug() << "MqttClient: Resolved" << host << "to" << resolved << "via mDNS";
                     guard->connectWithHost(resolved);
@@ -452,6 +468,19 @@ void MqttClient::onInternalConnectionFailed(const QString& error)
         int delay = reconnectDelayMs();
         qDebug() << "MqttClient: Retrying in" << delay / 1000 << "seconds";
         m_reconnectTimer.start(delay);
+    } else if (m_settingsMqtt && m_settingsMqtt->mqttEnabled()) {
+        // Budget exhausted against a reachable network — so this is the BROKER refusing
+        // or absent, not connectivity, and the reachability up-edge that rescues the
+        // offline case will never fire. Automatic recovery ends here. This branch used
+        // to be absent entirely: the client went quiet with the last log line being a
+        // "Retrying in 60 seconds" that was never honoured, which is precisely the shape
+        // of failure that hides a bad credential or a broker that moved.
+        qWarning() << "MqttClient: giving up after" << m_reconnectAttempts
+                   << "attempts - no further automatic reconnects. Last error:" << error
+                   << "- recovery needs Connect, an MQTT settings change, or the network"
+                      " dropping and returning.";
+        m_status = "Disconnected - max retries reached";
+        emit statusChanged();
     }
 }
 
@@ -610,12 +639,23 @@ void MqttClient::onNetworkReachabilityChanged(bool reachable)
 
     qDebug() << "MqttClient: network back - resuming reconnect";
 
+    // Clear the waiting-for-network status BEFORE any early return. It describes a
+    // condition that has just ended, so leaving it in place on the disabled/connected
+    // paths would strand the Home Automation tab reading "Waiting for network..." with
+    // the network up and, if the user disabled MQTT while it showed, nothing left that
+    // would ever rewrite it.
+    if (m_status == QLatin1String("Waiting for network...")) {
+        m_status = "Disconnected";
+        emit statusChanged();
+    }
+
     if (!m_settingsMqtt || !m_settingsMqtt->mqttEnabled() || isConnected())
         return;
 
     // A network we just regained is a different proposition from the one we lost:
-    // give it a full budget. This is also the only path that clears a latched
-    // "max retries reached", which nothing else in the class can undo.
+    // give it a full budget. This is the only path that does so WITHOUT user or
+    // settings action — disconnectFromBroker() and connectWithHost() also zero the
+    // count, but both need someone to ask.
     m_reconnectAttempts = 0;
     emit reconnectAttemptsChanged();
     m_reconnectTimer.stop();

--- a/src/network/mqttclient.cpp
+++ b/src/network/mqttclient.cpp
@@ -76,10 +76,12 @@ MqttClient::MqttClient(DE1Device* device, MachineState* machineState,
     // Observed on-device 2026-07-25: a Wi-Fi drop consumed the budget down to the last
     // attempt, which happened to land seconds after the network returned. At the time
     // that budget was TERMINAL, so a slightly longer outage would have left Home
-    // Assistant dark until someone noticed and intervened. It is no longer terminal —
-    // every failure path now routes through scheduleReconnect(), which always re-arms —
-    // but exhausting it still means a 15-minute hole in the fast path, which
-    // reachability avoids entirely.
+    // Assistant dark until someone noticed and intervened. It is no longer terminal:
+    // the connect-failure paths route through scheduleReconnect(), which re-arms at the
+    // slow cadence rather than stopping. (Not "every path" — connectToBroker()'s two
+    // configuration guards deliberately do not, and scheduleReconnect() itself does not
+    // re-arm while MQTT is disabled; both are documented at those sites.) Exhausting the
+    // fast budget still means a 15-minute hole, which reachability avoids entirely.
     //
     // (The ~7 min figure is the sum of the backoff delays. Wall-clock is longer against
     // a blackholed host: Paho's connectTimeout defaults to 30 s and is not overridden,
@@ -99,6 +101,12 @@ MqttClient::MqttClient(DE1Device* device, MachineState* machineState,
                         onNetworkReachabilityChanged(
                             reachability != QNetworkInformation::Reachability::Disconnected);
                     });
+        } else {
+            // Same reasoning as the else below, and it was missing here: a backend that
+            // loads but yields no instance leaves the whole feature inert while the log
+            // looks exactly like a healthy install.
+            qInfo() << "MqttClient: QNetworkInformation backend loaded but no instance - "
+                       "reconnect attempts will be spent while offline";
         }
     }
     else {
@@ -217,6 +225,17 @@ void MqttClient::onSubscribeFailure(void* context, MQTTAsync_failureData* respon
 
 void MqttClient::connectToBroker()
 {
+    // Second, independent guard on the same latch. Setting the flag only on the
+    // callback-producing branch of disconnectFromBroker() closes the reachable case,
+    // but not this one: onSettingsChanged() disconnects and immediately reconnects, and
+    // connectWithHost() calls MQTTAsync_destroy() on the client whose disconnect
+    // callback is still in flight. Whether Paho still delivers onDisconnectSuccess
+    // after a destroy is not something to depend on — and every mqtt* setter fires
+    // onSettingsChanged() synchronously, so one settings save runs that race several
+    // times. A user-requested disconnect only ever describes the connection it ended;
+    // once we are dialling again it is meaningless, so clear it unconditionally here.
+    m_userRequestedDisconnect = false;
+
     if (!m_settingsMqtt) {
         m_status = "Error: No settings";
         emit statusChanged();
@@ -244,7 +263,7 @@ void MqttClient::connectToBroker()
                 if (!guard) return;
                 // The resolve takes up to 2 s and conditions can change inside it —
                 // newly relevant now that connectToBroker() also fires on a reachability
-                // edge rather than only on user action. A flapping AP would otherwise
+                // edge, one of several non-user callers. A flapping AP would otherwise
                 // land here with the network down again, overwrite the accurate
                 // "Waiting for network..." status, and dial a dead interface.
                 if (guard->m_networkDown || !guard->m_settingsMqtt
@@ -285,7 +304,7 @@ void MqttClient::connectWithHost(const QString& host)
 
     if (!m_isReconnecting) {
         m_reconnectAttempts = 0;
-        m_slowRetryAnnounced = false;  // fresh budget → announce again if it happens again
+        m_slowRetryAnnounced = false;
         emit reconnectAttemptsChanged();
     }
     m_isReconnecting = false;
@@ -356,28 +375,47 @@ void MqttClient::connectWithHost(const QString& host)
     if (rc != MQTTASYNC_SUCCESS) {
         MQTTAsync_destroy(&m_client);
         m_client = nullptr;
-        // Synchronous refusal — Paho validated the request and rejected it without
-        // ever dialing, so NO onConnectFailure callback will follow. Before this,
-        // these three exits returned with no timer armed and no callback pending,
-        // which is the terminal death the slow-retry change was supposed to end:
-        // a typo'd broker host (`tcp://tcp://host` -> MQTTASYNC_BAD_PROTOCOL) killed
-        // MQTT until the app restarted, with only a status string to show for it.
+        // Synchronous refusal — Paho validated the request and rejected it without ever
+        // dialing, so NO onConnectFailure callback will follow (verified in MQTTAsync.c:
+        // every synchronous error exit is a bare validation `goto exit`, and
+        // m->connect.onFailure is assigned only after all of them). Before this, the
+        // synchronous exits returned with no timer armed and no callback pending, which
+        // is the terminal death the slow-retry change exists to end — MQTT stayed dead
+        // until the app restarted, with only a status string to show for it.
+        //
+        // No worked example here on purpose: an earlier version claimed a `tcp://tcp://`
+        // host typo produced MQTTASYNC_BAD_PROTOCOL on this line. Both halves were wrong
+        // — that code comes from the create call above, and the URI is always built as
+        // "tcp://%1:%2" so the scheme prefix check cannot fail. The structural point
+        // stands regardless of which rc gets us here.
         scheduleReconnect(QString("Connect failed (%1)").arg(rc));
     }
 }
 
 void MqttClient::disconnectFromBroker()
 {
-    // Consumed by onInternalDisconnected() so Paho's disconnect callback does not
-    // read as a fault and re-arm the retry loop.
-    m_userRequestedDisconnect = true;
     m_reconnectTimer.stop();
     m_publishTimer.stop();
     m_reconnectAttempts = 0;
-    m_slowRetryAnnounced = false;  // fresh budget → announce again if it happens again
+    m_slowRetryAnnounced = false;
     emit reconnectAttemptsChanged();
 
     if (m_client && m_connected) {
+        // Set ONLY here. The flag is consumed by onInternalDisconnected(), and this is
+        // the one branch that causes that callback to run — so arming it is safe only
+        // on this path. Setting it unconditionally (as this did) latched it forever
+        // whenever the user disconnected while ALREADY disconnected: the else branch
+        // below returns without any callback, nothing clears the flag, and the next
+        // GENUINE broker drop is then misread as user-requested, stops the timer and
+        // arms nothing. That is precisely the terminal reconnect death this change set
+        // exists to remove, reintroduced by the flag added to remove it.
+        //
+        // Reachable from two unguarded callers: the Home Automation tab's Disconnect
+        // button (SettingsHomeAutomationTab.qml) and ShotServer::handleMqttDisconnect —
+        // neither checks isConnected() first, and tapping Disconnect while the status
+        // reads "reconnecting (3/10)…" is the obvious thing a user does.
+        m_userRequestedDisconnect = true;
+
         publishAvailability(false);
 
         MQTTAsync_disconnectOptions opts = MQTTAsync_disconnectOptions_initializer;
@@ -409,7 +447,7 @@ void MqttClient::onInternalConnected()
     emit connectedChanged();
 
     m_reconnectAttempts = 0;
-    m_slowRetryAnnounced = false;  // fresh budget → announce again if it happens again
+    m_slowRetryAnnounced = false;
     emit reconnectAttemptsChanged();
 
     // Publish availability
@@ -498,14 +536,31 @@ void MqttClient::onInternalConnectionFailed(const QString& error)
     scheduleReconnect(error);
 }
 
-// Single arming point for every failure that should be retried. Every path that ends
-// a connect attempt without success must come through here — the bug this consolidates
-// away was three synchronous exits in connectWithHost() that armed no timer and had no
-// Paho callback coming, so they simply stopped forever.
+// Single arming point for every failure that should be RETRIED, and the only place the
+// three synchronous exits in connectWithHost() report at all — they used to set their own
+// "Error: …" status and this consolidation removed it, so anything that returns from here
+// without writing a status leaves the tab reading "Connecting..." forever.
+//
+// Not universal, deliberately: connectToBroker()'s two configuration guards (null settings,
+// empty host) end a connect attempt without coming through here. Both set an accurate,
+// actionable status and are recovered by onSettingsChanged() when the user fixes the
+// setting, so arming a retry against an unfixable config would only produce log spam.
 void MqttClient::scheduleReconnect(const QString& reason)
 {
-    if (!m_settingsMqtt || !m_settingsMqtt->mqttEnabled())
+    if (!m_settingsMqtt || !m_settingsMqtt->mqttEnabled()) {
+        // Do NOT retry — but do not swallow the failure either. A connect can be
+        // initiated while MQTT is disabled: the Home Automation tab's Connect button
+        // gates only on host-non-empty, and neither the mqtt_connect MCP tool nor the
+        // ShotServer endpoint checks mqttEnabled(). Returning silently here left the
+        // status latched at "Connecting...", discarded the Paho rc, and turned a precise
+        // BAD_PROTOCOL (the tcp://tcp:// typo) into the ShotServer poller's generic
+        // "Connection timed out" — pointing the user at their network instead of the typo.
+        qWarning() << "MqttClient: connect attempt failed while MQTT is disabled -"
+                   << "not retrying. Reason:" << reason;
+        m_status = "Error: " + reason;
+        emit statusChanged();
         return;
+    }
 
     const int delay = reconnectDelayMs();
     if (m_reconnectAttempts >= MAX_FAST_RECONNECT_ATTEMPTS && !m_slowRetryAnnounced) {
@@ -524,7 +579,8 @@ void MqttClient::scheduleReconnect(const QString& reason)
     // Keep the broker's own words. The caller has usually just set an "Error: …"
     // status, and both assignments land in one event-loop turn, so a bare
     // reconnectStatusText() would erase "Bad user name or password" before it could
-    // ever be painted — and the Home Automation tab's status line is the ONLY place
+    // ever be painted — and the status line (Home Automation tab, and the ShotServer
+    // settings page which mirrors it) is the main place
     // that reason reaches the user. With retries no longer stopping, there would be
     // no later moment when anything more specific appeared: the tab would read
     // "reconnecting (1/10)..." forever while the real problem sat in a log nobody opens.
@@ -698,20 +754,29 @@ void MqttClient::onNetworkReachabilityChanged(bool reachable)
         // a keepalive (60 s), and in the meantime publish() silently drops every
         // update the user's Home Assistant automations depend on, behind a green dot
         // reading "Connected". The app knows at t=0; there is no reason to hide it.
-        m_status = isConnected() ? "Connected - network unreachable" : kWaitingForNetwork;
+        m_status = isConnected() ? kConnectedNetworkUnreachable : kWaitingForNetwork;
         emit statusChanged();
         return;
     }
 
     qDebug() << "MqttClient: network back - resuming reconnect";
 
-    // Clear the waiting-for-network status BEFORE any early return. It describes a
-    // condition that has just ended, so leaving it in place on the disabled/connected
-    // paths would strand the Home Automation tab reading "Waiting for network..." with
-    // the network up and, if the user disabled MQTT while it showed, nothing left that
-    // would ever rewrite it.
+    // Clear BOTH statuses the down-edge can write, BEFORE any early return. They describe
+    // a condition that has just ended, so leaving either in place strands the Home
+    // Automation tab describing a network problem that is over.
+    //
+    // Covering only kWaitingForNetwork — as this did — missed the connected case
+    // entirely, and that one is the worse of the two: a brief reachability blip the TCP
+    // session survives (well inside the 60 s keepalive) leaves "Connected - network
+    // unreachable" on screen INDEFINITELY, because the isConnected() early return below
+    // means nothing else ever rewrites it while the session holds. Publishing works fine
+    // the whole time. This is the same fixed-for-one-string-and-not-the-others mistake
+    // called out in onSettingsChanged(), made in the very comment warning about it.
     if (m_status == QLatin1String(kWaitingForNetwork)) {
         m_status = "Disconnected";
+        emit statusChanged();
+    } else if (m_status == QLatin1String(kConnectedNetworkUnreachable)) {
+        m_status = isConnected() ? "Connected" : "Disconnected";
         emit statusChanged();
     }
 
@@ -722,13 +787,14 @@ void MqttClient::onNetworkReachabilityChanged(bool reachable)
     // give it a full FAST budget rather than leaving it on the 15-minute cadence,
     // and reconnect now instead of waiting out the current slow interval.
     //
-    // Four sites zero m_reconnectAttempts: onInternalConnected() (success — the budget
-    // is moot), disconnectFromBroker() (user or settings action), connectWithHost()
-    // (only when !m_isReconnecting, which is precisely what stops the reconnect tick
-    // from refunding its own budget), and this one. This is the only one that refunds a
-    // LIVE budget and reconnects on its own, with nobody asking.
+    // Several sites zero m_reconnectAttempts — success, user/settings action, a fresh
+    // user-initiated connect (connectWithHost only when !m_isReconnecting, which is
+    // precisely what stops the reconnect tick from refunding its own budget). What is
+    // specific to THIS one, and the reason it is worth a comment: it refunds a LIVE
+    // budget and reconnects on its own, with nobody asking. (No count here on purpose —
+    // an earlier version said "four sites" and was wrong within its own commit.)
     m_reconnectAttempts = 0;
-    m_slowRetryAnnounced = false;  // fresh budget → announce again if it happens again
+    m_slowRetryAnnounced = false;
     emit reconnectAttemptsChanged();
     m_reconnectTimer.stop();
     m_isReconnecting = false;

--- a/src/network/mqttclient.cpp
+++ b/src/network/mqttclient.cpp
@@ -101,8 +101,13 @@ MqttClient::MqttClient(DE1Device* device, MachineState* machineState,
                     });
         }
     }
-    // No backend on this platform leaves m_networkDown false forever, which is
-    // exactly the pre-existing behaviour: every tick spends an attempt.
+    else {
+        // Not an error — but without it a field debug log cannot distinguish "the
+        // network was fine" from "we had no way to tell", which matters when the
+        // whole reachability feature is inert.
+        qInfo() << "MqttClient: no QNetworkInformation backend - reconnect attempts "
+                   "will be spent while offline (pre-existing behaviour)";
+    }
 
     m_status = "Disconnected";
 }
@@ -363,6 +368,9 @@ void MqttClient::connectWithHost(const QString& host)
 
 void MqttClient::disconnectFromBroker()
 {
+    // Consumed by onInternalDisconnected() so Paho's disconnect callback does not
+    // read as a fault and re-arm the retry loop.
+    m_userRequestedDisconnect = true;
     m_reconnectTimer.stop();
     m_publishTimer.stop();
     m_reconnectAttempts = 0;
@@ -445,15 +453,33 @@ void MqttClient::onInternalDisconnected()
     m_publishTimer.stop();
     emit connectedChanged();
 
-    // Always keep trying while MQTT is enabled — only the cadence changes.
-    if (m_settingsMqtt && m_settingsMqtt->mqttEnabled()) {
-        m_status = reconnectStatusText();
-        emit statusChanged();
-        m_reconnectTimer.start(reconnectDelayMs());
-    } else {
+    // A disconnect the USER asked for is not a fault to recover from. Without this,
+    // tapping Disconnect (or calling the mqtt_disconnect MCP tool, or the web
+    // endpoint) immediately re-armed the timer and dialled back 5 s later — the
+    // status would read "reconnecting (1/10)..." while the tool that just returned
+    // {"success": true, "message": "MQTT disconnected"} was already being undone.
+    // Bounded to 10 attempts before; unbounded once retries stopped being terminal.
+    if (m_userRequestedDisconnect) {
+        m_userRequestedDisconnect = false;
+        m_reconnectTimer.stop();
         m_status = "Disconnected";
         emit statusChanged();
+        return;
     }
+
+    // Otherwise keep trying while MQTT is enabled — only the cadence changes.
+    // Routed through the shared helper so this path announces the fast→slow
+    // transition too: a broker that accepts TCP then drops the session (a stale
+    // ACL, or a duplicate client-id from a second install) only ever reaches here,
+    // never onInternalConnectionFailed, and used to loop every 15 minutes forever
+    // with one qDebug line per cycle and no warning at all.
+    if (m_settingsMqtt && m_settingsMqtt->mqttEnabled()) {
+        scheduleReconnect(QStringLiteral("broker closed the connection"));
+        return;
+    }
+
+    m_status = "Disconnected";
+    emit statusChanged();
 }
 
 void MqttClient::onInternalConnectionFailed(const QString& error)
@@ -636,7 +662,7 @@ void MqttClient::onReconnectTimerTick()
     if (m_networkDown) {
         qDebug() << "MqttClient: reconnect deferred - no network (attempt"
                  << (m_reconnectAttempts + 1) << "not spent)";
-        m_status = "Waiting for network...";
+        m_status = kWaitingForNetwork;
         emit statusChanged();
         return;
     }
@@ -668,10 +694,12 @@ void MqttClient::onNetworkReachabilityChanged(bool reachable)
         // Cancel a pending tick rather than let it fire and log a deferral. The
         // flag is cleared by the reachable event below, not by waiting this out.
         m_reconnectTimer.stop();
-        if (!isConnected()) {
-            m_status = "Waiting for network...";
-            emit statusChanged();
-        }
+        // Say so even while still nominally connected. Paho will not notice for up to
+        // a keepalive (60 s), and in the meantime publish() silently drops every
+        // update the user's Home Assistant automations depend on, behind a green dot
+        // reading "Connected". The app knows at t=0; there is no reason to hide it.
+        m_status = isConnected() ? "Connected - network unreachable" : kWaitingForNetwork;
+        emit statusChanged();
         return;
     }
 
@@ -682,7 +710,7 @@ void MqttClient::onNetworkReachabilityChanged(bool reachable)
     // paths would strand the Home Automation tab reading "Waiting for network..." with
     // the network up and, if the user disabled MQTT while it showed, nothing left that
     // would ever rewrite it.
-    if (m_status == QLatin1String("Waiting for network...")) {
+    if (m_status == QLatin1String(kWaitingForNetwork)) {
         m_status = "Disconnected";
         emit statusChanged();
     }
@@ -716,7 +744,21 @@ void MqttClient::onSettingsChanged()
 
     if (m_settingsMqtt && m_settingsMqtt->mqttEnabled()) {
         connectToBroker();
+        return;
     }
+
+    // MQTT switched off. Nothing below runs otherwise, and the retry timer would
+    // survive: onReconnectTimerTick() early-returns on !mqttEnabled() WITHOUT
+    // touching the status, so whatever string was showing — "retrying every 15 min",
+    // or kWaitingForNetwork — stayed on the Home Automation tab forever, describing
+    // a loop that is no longer running. Same permanently-latched status this branch
+    // was already fixed for once; it was fixed for one string and not the others.
+    m_reconnectTimer.stop();
+    m_reconnectAttempts = 0;
+    m_slowRetryAnnounced = false;
+    emit reconnectAttemptsChanged();
+    m_status = "Disabled";
+    emit statusChanged();
 }
 
 QString MqttClient::topicPath(const QString& subtopic) const

--- a/src/network/mqttclient.cpp
+++ b/src/network/mqttclient.cpp
@@ -11,6 +11,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QHostInfo>
+#include <QNetworkInformation>
 #include <QUuid>
 #include <QMutexLocker>
 #ifdef Q_OS_ANDROID
@@ -66,6 +67,32 @@ MqttClient::MqttClient(DE1Device* device, MachineState* machineState,
     // Reconnect timer
     m_reconnectTimer.setSingleShot(true);
     connect(&m_reconnectTimer, &QTimer::timeout, this, &MqttClient::onReconnectTimerTick);
+
+    // The reconnect budget is for "the broker is not answering us", not for "this
+    // device has no network" — a connect attempt against a down interface tells us
+    // nothing about the broker, and MAX_RECONNECT_ATTEMPTS is terminal: once it is
+    // reached neither failure handler re-arms the timer, so MQTT stays dead until
+    // the app restarts. Observed on-device 2026-07-25: a ~7 min Wi-Fi drop consumed
+    // 9 of the 10 attempts and the 10th happened to land 12 s after the network came
+    // back. A slightly longer outage would have killed Home Assistant for the day.
+    //
+    // So: watch reachability, don't spend attempts while it is positively down, and
+    // treat the return of the network as a fresh budget. Only "Disconnected" counts
+    // as down — Unknown is what a backend reports when it cannot tell (macOS does
+    // exactly this at startup), and treating it as offline would stall a client that
+    // can in fact reach its broker. Same rule as scheduleLanguageUpdateCheck().
+    if (QNetworkInformation::loadDefaultBackend()) {
+        if (auto* info = QNetworkInformation::instance()) {
+            m_networkDown = (info->reachability() == QNetworkInformation::Reachability::Disconnected);
+            connect(info, &QNetworkInformation::reachabilityChanged, this,
+                    [this](QNetworkInformation::Reachability reachability) {
+                        onNetworkReachabilityChanged(
+                            reachability != QNetworkInformation::Reachability::Disconnected);
+                    });
+        }
+    }
+    // No backend on this platform leaves m_networkDown false forever, which is
+    // exactly the pre-existing behaviour: every tick spends an attempt.
 
     m_status = "Disconnected";
 }
@@ -540,6 +567,18 @@ void MqttClient::onReconnectTimerTick()
         return;
     }
 
+    // No network: the attempt would fail on the interface, not at the broker, so
+    // don't charge it to the budget. Deliberately does NOT re-arm the timer —
+    // onNetworkReachabilityChanged() resumes on the event, rather than polling a
+    // condition we are already told about.
+    if (m_networkDown) {
+        qDebug() << "MqttClient: reconnect deferred - no network (attempt"
+                 << (m_reconnectAttempts + 1) << "not spent)";
+        m_status = "Waiting for network...";
+        emit statusChanged();
+        return;
+    }
+
     m_reconnectAttempts++;
     emit reconnectAttemptsChanged();
 
@@ -547,6 +586,40 @@ void MqttClient::onReconnectTimerTick()
 
     // Flag preserved until connectWithHost() checks it (may be async on Android)
     m_isReconnecting = true;
+    connectToBroker();
+}
+
+void MqttClient::onNetworkReachabilityChanged(bool reachable)
+{
+    const bool nowDown = !reachable;
+    if (m_networkDown == nowDown)
+        return;
+    m_networkDown = nowDown;
+
+    if (m_networkDown) {
+        qDebug() << "MqttClient: network down - reconnect attempts suspended";
+        // Cancel a pending tick rather than let it fire and log a deferral. The
+        // flag is cleared by the reachable event below, not by waiting this out.
+        m_reconnectTimer.stop();
+        if (!isConnected()) {
+            m_status = "Waiting for network...";
+            emit statusChanged();
+        }
+        return;
+    }
+
+    qDebug() << "MqttClient: network back - resuming reconnect";
+
+    if (!m_settingsMqtt || !m_settingsMqtt->mqttEnabled() || isConnected())
+        return;
+
+    // A network we just regained is a different proposition from the one we lost:
+    // give it a full budget. This is also the only path that clears a latched
+    // "max retries reached", which nothing else in the class can undo.
+    m_reconnectAttempts = 0;
+    emit reconnectAttemptsChanged();
+    m_reconnectTimer.stop();
+    m_isReconnecting = false;
     connectToBroker();
 }
 

--- a/src/network/mqttclient.cpp
+++ b/src/network/mqttclient.cpp
@@ -68,18 +68,17 @@ MqttClient::MqttClient(DE1Device* device, MachineState* machineState,
     m_reconnectTimer.setSingleShot(true);
     connect(&m_reconnectTimer, &QTimer::timeout, this, &MqttClient::onReconnectTimerTick);
 
-    // The reconnect budget is for "the broker is not answering us", not for "this
+    // The FAST reconnect budget is for "the broker is not answering us", not for "this
     // device has no network" — a connect attempt against a down interface tells us
-    // nothing about the broker, and hitting MAX_RECONNECT_ATTEMPTS ends automatic
-    // recovery: neither failure handler re-arms the timer past the cap, so nothing
-    // retries on its own. Recovery then needs a deliberate act — the Connect button,
-    // an MQTT settings change, or the mqtt_connect MCP tool — none of which a user
-    // has any reason to perform, because the failure is silent.
+    // nothing about the broker, so spending the budget on an outage just burns through
+    // the responsive phase while nothing could have worked anyway.
     //
-    // Observed on-device 2026-07-25: a Wi-Fi drop consumed the budget down to the
-    // last attempt, which happened to land seconds after the network returned. A
-    // slightly longer outage would have left Home Assistant dark until someone
-    // noticed and intervened.
+    // Observed on-device 2026-07-25: a Wi-Fi drop consumed the budget down to the last
+    // attempt, which happened to land seconds after the network returned. At the time
+    // that budget was TERMINAL, so a slightly longer outage would have left Home
+    // Assistant dark until someone noticed and intervened. It is no longer terminal —
+    // retries continue every IDLE_RECONNECT_DELAY_MS forever — but exhausting it still
+    // means a 15-minute hole in the fast path, which reachability avoids entirely.
     //
     // So: watch reachability, don't spend attempts while it is positively down, and
     // treat the return of the network as a fresh budget. Only "Disconnected" counts
@@ -275,6 +274,7 @@ void MqttClient::connectWithHost(const QString& host)
 
     if (!m_isReconnecting) {
         m_reconnectAttempts = 0;
+        m_slowRetryAnnounced = false;  // fresh budget → announce again if it happens again
         emit reconnectAttemptsChanged();
     }
     m_isReconnecting = false;
@@ -357,6 +357,7 @@ void MqttClient::disconnectFromBroker()
     m_reconnectTimer.stop();
     m_publishTimer.stop();
     m_reconnectAttempts = 0;
+    m_slowRetryAnnounced = false;  // fresh budget → announce again if it happens again
     emit reconnectAttemptsChanged();
 
     if (m_client && m_connected) {
@@ -391,6 +392,7 @@ void MqttClient::onInternalConnected()
     emit connectedChanged();
 
     m_reconnectAttempts = 0;
+    m_slowRetryAnnounced = false;  // fresh budget → announce again if it happens again
     emit reconnectAttemptsChanged();
 
     // Publish availability
@@ -434,16 +436,11 @@ void MqttClient::onInternalDisconnected()
     m_publishTimer.stop();
     emit connectedChanged();
 
-    // Attempt reconnection with exponential backoff if MQTT is still enabled
-    if (m_settingsMqtt && m_settingsMqtt->mqttEnabled() && m_reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
-        m_status = QString("Disconnected - reconnecting (%1/%2)...")
-            .arg(m_reconnectAttempts + 1)
-            .arg(MAX_RECONNECT_ATTEMPTS);
+    // Always keep trying while MQTT is enabled — only the cadence changes.
+    if (m_settingsMqtt && m_settingsMqtt->mqttEnabled()) {
+        m_status = reconnectStatusText();
         emit statusChanged();
         m_reconnectTimer.start(reconnectDelayMs());
-    } else if (m_reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
-        m_status = "Disconnected - max retries reached";
-        emit statusChanged();
     } else {
         m_status = "Disconnected";
         emit statusChanged();
@@ -463,25 +460,35 @@ void MqttClient::onInternalConnectionFailed(const QString& error)
     emit statusChanged();
     emit connectedChanged();
 
-    // Attempt reconnection with exponential backoff
-    if (m_settingsMqtt && m_settingsMqtt->mqttEnabled() && m_reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
-        int delay = reconnectDelayMs();
+    // Keep trying indefinitely while MQTT is enabled; only the cadence changes.
+    if (m_settingsMqtt && m_settingsMqtt->mqttEnabled()) {
+        const int delay = reconnectDelayMs();
+        if (m_reconnectAttempts >= MAX_FAST_RECONNECT_ATTEMPTS && !m_slowRetryAnnounced) {
+            // Announce the transition ONCE. Past this point the fast budget is spent
+            // against a network that is up, so this is the broker refusing or absent —
+            // a bad credential, a broker that moved, a container still restarting. Worth
+            // one warning naming the cause; not worth one every 15 minutes thereafter.
+            m_slowRetryAnnounced = true;
+            qWarning() << "MqttClient: broker unreachable after" << m_reconnectAttempts
+                       << "attempts - backing off to one retry every" << delay / 60000
+                       << "min. Last error:" << error;
+        }
         qDebug() << "MqttClient: Retrying in" << delay / 1000 << "seconds";
         m_reconnectTimer.start(delay);
-    } else if (m_settingsMqtt && m_settingsMqtt->mqttEnabled()) {
-        // Budget exhausted against a reachable network — so this is the BROKER refusing
-        // or absent, not connectivity, and the reachability up-edge that rescues the
-        // offline case will never fire. Automatic recovery ends here. This branch used
-        // to be absent entirely: the client went quiet with the last log line being a
-        // "Retrying in 60 seconds" that was never honoured, which is precisely the shape
-        // of failure that hides a bad credential or a broker that moved.
-        qWarning() << "MqttClient: giving up after" << m_reconnectAttempts
-                   << "attempts - no further automatic reconnects. Last error:" << error
-                   << "- recovery needs Connect, an MQTT settings change, or the network"
-                      " dropping and returning.";
-        m_status = "Disconnected - max retries reached";
+        m_status = reconnectStatusText();
         emit statusChanged();
     }
+}
+
+QString MqttClient::reconnectStatusText() const
+{
+    if (m_reconnectAttempts >= MAX_FAST_RECONNECT_ATTEMPTS) {
+        return QString("Disconnected - retrying every %1 min")
+            .arg(IDLE_RECONNECT_DELAY_MS / 60000);
+    }
+    return QString("Disconnected - reconnecting (%1/%2)...")
+        .arg(m_reconnectAttempts + 1)
+        .arg(MAX_FAST_RECONNECT_ATTEMPTS);
 }
 
 void MqttClient::onInternalMessageReceived(const QString& topic, const QString& payload)
@@ -611,7 +618,12 @@ void MqttClient::onReconnectTimerTick()
     m_reconnectAttempts++;
     emit reconnectAttemptsChanged();
 
-    qDebug() << "MqttClient: Reconnection attempt" << m_reconnectAttempts << "of" << MAX_RECONNECT_ATTEMPTS;
+    if (m_reconnectAttempts > MAX_FAST_RECONNECT_ATTEMPTS) {
+        qDebug() << "MqttClient: Reconnection attempt" << m_reconnectAttempts << "(slow retry)";
+    } else {
+        qDebug() << "MqttClient: Reconnection attempt" << m_reconnectAttempts
+                 << "of" << MAX_FAST_RECONNECT_ATTEMPTS << "before backing off";
+    }
 
     // Flag preserved until connectWithHost() checks it (may be async on Android)
     m_isReconnecting = true;
@@ -653,10 +665,12 @@ void MqttClient::onNetworkReachabilityChanged(bool reachable)
         return;
 
     // A network we just regained is a different proposition from the one we lost:
-    // give it a full budget. This is the only path that does so WITHOUT user or
-    // settings action — disconnectFromBroker() and connectWithHost() also zero the
-    // count, but both need someone to ask.
+    // give it a full FAST budget rather than leaving it on the 15-minute cadence,
+    // and reconnect now instead of waiting out the current slow interval. This is the
+    // only path that does so without user or settings action — disconnectFromBroker()
+    // and connectWithHost() also zero the count, but both need someone to ask.
     m_reconnectAttempts = 0;
+    m_slowRetryAnnounced = false;  // fresh budget → announce again if it happens again
     emit reconnectAttemptsChanged();
     m_reconnectTimer.stop();
     m_isReconnecting = false;

--- a/src/network/mqttclient.cpp
+++ b/src/network/mqttclient.cpp
@@ -77,8 +77,14 @@ MqttClient::MqttClient(DE1Device* device, MachineState* machineState,
     // attempt, which happened to land seconds after the network returned. At the time
     // that budget was TERMINAL, so a slightly longer outage would have left Home
     // Assistant dark until someone noticed and intervened. It is no longer terminal —
-    // retries continue every IDLE_RECONNECT_DELAY_MS forever — but exhausting it still
-    // means a 15-minute hole in the fast path, which reachability avoids entirely.
+    // every failure path now routes through scheduleReconnect(), which always re-arms —
+    // but exhausting it still means a 15-minute hole in the fast path, which
+    // reachability avoids entirely.
+    //
+    // (The ~7 min figure is the sum of the backoff delays. Wall-clock is longer against
+    // a blackholed host: Paho's connectTimeout defaults to 30 s and is not overridden,
+    // so ten attempts can take ~12 min. It is ~7 min only when the broker actively
+    // refuses.)
     //
     // So: watch reachability, don't spend attempts while it is positively down, and
     // treat the return of the network as a fresh budget. Only "Disconnected" counts
@@ -292,18 +298,16 @@ void MqttClient::connectWithHost(const QString& host)
     int rc = MQTTAsync_create(&m_client, serverUriBytes.constData(), clientIdBytes.constData(),
                               MQTTCLIENT_PERSISTENCE_NONE, nullptr);
     if (rc != MQTTASYNC_SUCCESS) {
-        m_status = QString("Error: Failed to create client (%1)").arg(rc);
-        emit statusChanged();
+        scheduleReconnect(QString("Failed to create client (%1)").arg(rc));
         return;
     }
 
     // Set callbacks
     rc = MQTTAsync_setCallbacks(m_client, this, onConnectionLost, onMessageArrived, nullptr);
     if (rc != MQTTASYNC_SUCCESS) {
-        m_status = QString("Error: Failed to set callbacks (%1)").arg(rc);
-        emit statusChanged();
         MQTTAsync_destroy(&m_client);
         m_client = nullptr;
+        scheduleReconnect(QString("Failed to set callbacks (%1)").arg(rc));
         return;
     }
 
@@ -345,10 +349,15 @@ void MqttClient::connectWithHost(const QString& host)
 
     rc = MQTTAsync_connect(m_client, &connOpts);
     if (rc != MQTTASYNC_SUCCESS) {
-        m_status = QString("Error: Connect failed (%1)").arg(rc);
-        emit statusChanged();
         MQTTAsync_destroy(&m_client);
         m_client = nullptr;
+        // Synchronous refusal — Paho validated the request and rejected it without
+        // ever dialing, so NO onConnectFailure callback will follow. Before this,
+        // these three exits returned with no timer armed and no callback pending,
+        // which is the terminal death the slow-retry change was supposed to end:
+        // a typo'd broker host (`tcp://tcp://host` -> MQTTASYNC_BAD_PROTOCOL) killed
+        // MQTT until the app restarted, with only a status string to show for it.
+        scheduleReconnect(QString("Connect failed (%1)").arg(rc));
     }
 }
 
@@ -460,24 +469,41 @@ void MqttClient::onInternalConnectionFailed(const QString& error)
     emit statusChanged();
     emit connectedChanged();
 
-    // Keep trying indefinitely while MQTT is enabled; only the cadence changes.
-    if (m_settingsMqtt && m_settingsMqtt->mqttEnabled()) {
-        const int delay = reconnectDelayMs();
-        if (m_reconnectAttempts >= MAX_FAST_RECONNECT_ATTEMPTS && !m_slowRetryAnnounced) {
-            // Announce the transition ONCE. Past this point the fast budget is spent
-            // against a network that is up, so this is the broker refusing or absent —
-            // a bad credential, a broker that moved, a container still restarting. Worth
-            // one warning naming the cause; not worth one every 15 minutes thereafter.
-            m_slowRetryAnnounced = true;
-            qWarning() << "MqttClient: broker unreachable after" << m_reconnectAttempts
-                       << "attempts - backing off to one retry every" << delay / 60000
-                       << "min. Last error:" << error;
-        }
-        qDebug() << "MqttClient: Retrying in" << delay / 1000 << "seconds";
-        m_reconnectTimer.start(delay);
-        m_status = reconnectStatusText();
-        emit statusChanged();
+    scheduleReconnect(error);
+}
+
+// Single arming point for every failure that should be retried. Every path that ends
+// a connect attempt without success must come through here — the bug this consolidates
+// away was three synchronous exits in connectWithHost() that armed no timer and had no
+// Paho callback coming, so they simply stopped forever.
+void MqttClient::scheduleReconnect(const QString& reason)
+{
+    if (!m_settingsMqtt || !m_settingsMqtt->mqttEnabled())
+        return;
+
+    const int delay = reconnectDelayMs();
+    if (m_reconnectAttempts >= MAX_FAST_RECONNECT_ATTEMPTS && !m_slowRetryAnnounced) {
+        // Announce the transition ONCE. Past this point the fast budget is spent
+        // against a network that is up, so this is the broker refusing or absent —
+        // a bad credential, a broker that moved, a container still restarting. Worth
+        // one warning naming the cause; not worth one every 15 minutes thereafter.
+        m_slowRetryAnnounced = true;
+        qWarning() << "MqttClient: broker unreachable after" << m_reconnectAttempts
+                   << "attempts - backing off to one retry every" << delay / 60000
+                   << "min. Reason:" << reason;
     }
+    qDebug() << "MqttClient: Retrying in" << delay / 1000 << "seconds -" << reason;
+    m_reconnectTimer.start(delay);
+
+    // Keep the broker's own words. The caller has usually just set an "Error: …"
+    // status, and both assignments land in one event-loop turn, so a bare
+    // reconnectStatusText() would erase "Bad user name or password" before it could
+    // ever be painted — and the Home Automation tab's status line is the ONLY place
+    // that reason reaches the user. With retries no longer stopping, there would be
+    // no later moment when anything more specific appeared: the tab would read
+    // "reconnecting (1/10)..." forever while the real problem sat in a log nobody opens.
+    m_status = reconnectStatusText() + " (" + reason + ")";
+    emit statusChanged();
 }
 
 QString MqttClient::reconnectStatusText() const
@@ -666,9 +692,13 @@ void MqttClient::onNetworkReachabilityChanged(bool reachable)
 
     // A network we just regained is a different proposition from the one we lost:
     // give it a full FAST budget rather than leaving it on the 15-minute cadence,
-    // and reconnect now instead of waiting out the current slow interval. This is the
-    // only path that does so without user or settings action — disconnectFromBroker()
-    // and connectWithHost() also zero the count, but both need someone to ask.
+    // and reconnect now instead of waiting out the current slow interval.
+    //
+    // Four sites zero m_reconnectAttempts: onInternalConnected() (success — the budget
+    // is moot), disconnectFromBroker() (user or settings action), connectWithHost()
+    // (only when !m_isReconnecting, which is precisely what stops the reconnect tick
+    // from refunding its own budget), and this one. This is the only one that refunds a
+    // LIVE budget and reconnects on its own, with nobody asking.
     m_reconnectAttempts = 0;
     m_slowRetryAnnounced = false;  // fresh budget → announce again if it happens again
     emit reconnectAttemptsChanged();

--- a/src/network/mqttclient.h
+++ b/src/network/mqttclient.h
@@ -96,6 +96,7 @@ private:
     QString generateClientId();
     void onNetworkReachabilityChanged(bool reachable);
     QString reconnectStatusText() const;
+    void scheduleReconnect(const QString& reason);
 
     // Paho callbacks (static, call instance methods via context)
     static void onConnectSuccess(void* context, MQTTAsync_successData* response);

--- a/src/network/mqttclient.h
+++ b/src/network/mqttclient.h
@@ -94,6 +94,7 @@ private:
     void publish(const QString& topic, const QString& payload, bool retain = true);
     void publishAvailability(bool online);
     QString generateClientId();
+    void onNetworkReachabilityChanged(bool reachable);
 
     // Paho callbacks (static, call instance methods via context)
     static void onConnectSuccess(void* context, MQTTAsync_successData* response);
@@ -115,6 +116,10 @@ private:
     QTimer m_reconnectTimer;
     int m_reconnectAttempts = 0;
     bool m_isReconnecting = false;
+    // True only while QNetworkInformation positively reports Disconnected (Unknown is
+    // NOT offline — see the constructor). Reconnect attempts are not spent while it
+    // holds, and the transition back to reachable is what resumes them.
+    bool m_networkDown = false;
     static constexpr int MAX_RECONNECT_ATTEMPTS = 10;
     static constexpr int INITIAL_RECONNECT_DELAY_MS = 5000;
     static constexpr int MAX_RECONNECT_DELAY_MS = 60000;

--- a/src/network/mqttclient.h
+++ b/src/network/mqttclient.h
@@ -145,6 +145,14 @@ private:
     // Latches when the slow cadence is announced, so the transition is logged once
     // rather than every 15 minutes for as long as the broker stays away.
     bool m_slowRetryAnnounced = false;
+    // Set by disconnectFromBroker(), consumed by onInternalDisconnected(), so a stop
+    // the user asked for is not treated as a fault and immediately undone.
+    bool m_userRequestedDisconnect = false;
+    // One definition for a string that is both WRITTEN and COMPARED. It had three
+    // copies; editing any one of them would have silently stopped the clear-on-resume
+    // from matching, re-creating the permanently-latched status it exists to prevent,
+    // with no compiler help.
+    static constexpr auto kWaitingForNetwork = "Waiting for network...";
 
     QString m_status;
     bool m_connected = false;

--- a/src/network/mqttclient.h
+++ b/src/network/mqttclient.h
@@ -95,6 +95,7 @@ private:
     void publishAvailability(bool online);
     QString generateClientId();
     void onNetworkReachabilityChanged(bool reachable);
+    QString reconnectStatusText() const;
 
     // Paho callbacks (static, call instance methods via context)
     static void onConnectSuccess(void* context, MQTTAsync_successData* response);
@@ -120,11 +121,29 @@ private:
     // NOT offline — see the constructor). Reconnect attempts are not spent while it
     // holds, and the transition back to reachable is what resumes them.
     bool m_networkDown = false;
-    static constexpr int MAX_RECONNECT_ATTEMPTS = 10;
+    // Attempts spent at the FAST cadence before dropping to the slow one. Not a
+    // stopping point: retries continue indefinitely, just rarely. It used to be
+    // terminal, which meant a broker outage longer than the budget (~7 min) killed
+    // MQTT until someone intervened — a Home Assistant restart or a broker redeploy
+    // was enough, and nothing about that is the user's fault or their job to notice.
+    static constexpr int MAX_FAST_RECONNECT_ATTEMPTS = 10;
     static constexpr int INITIAL_RECONNECT_DELAY_MS = 5000;
     static constexpr int MAX_RECONNECT_DELAY_MS = 60000;
-    // Exponential backoff: 5s, 10s, 20s, 40s, 60s, 60s, ... (capped at 60s)
-    int reconnectDelayMs() const { return std::min(INITIAL_RECONNECT_DELAY_MS * (1 << std::min(m_reconnectAttempts, 20)), MAX_RECONNECT_DELAY_MS); }
+    // Slow cadence once the fast budget is spent. A TCP connect to a LAN broker is
+    // negligible, so this is about log noise and not looking frantic, not cost —
+    // 15 min recovers an unattended broker restart well within the time it takes
+    // anyone to notice Home Assistant went quiet.
+    static constexpr int IDLE_RECONNECT_DELAY_MS = 15 * 60 * 1000;
+    // Exponential backoff: 5s, 10s, 20s, 40s, 60s, 60s… then every 15 min forever.
+    int reconnectDelayMs() const {
+        if (m_reconnectAttempts >= MAX_FAST_RECONNECT_ATTEMPTS)
+            return IDLE_RECONNECT_DELAY_MS;
+        return std::min(INITIAL_RECONNECT_DELAY_MS * (1 << std::min(m_reconnectAttempts, 20)),
+                        MAX_RECONNECT_DELAY_MS);
+    }
+    // Latches when the slow cadence is announced, so the transition is logged once
+    // rather than every 15 minutes for as long as the broker stays away.
+    bool m_slowRetryAnnounced = false;
 
     QString m_status;
     bool m_connected = false;

--- a/src/network/mqttclient.h
+++ b/src/network/mqttclient.h
@@ -61,6 +61,16 @@ signals:
     void internalConnectionFailed(const QString& error);
     void internalMessageReceived(const QString& topic, const QString& payload);
 
+#ifdef DECENZA_TESTING
+    // The reconnect state machine is pure logic over a QTimer and a handful of flags,
+    // and every one of its inputs is a private slot. Exposing it to the test is what
+    // lets tst_mqttclient assert on timer state directly, with no broker and no waiting.
+    // Added after a latched m_userRequestedDisconnect shipped in a change whose entire
+    // purpose was to stop reconnection from dying — this file was in no test target at
+    // all, so nothing could have caught it.
+    friend class tst_MqttClient;
+#endif
+
 private slots:
     void onInternalConnected();
     void onInternalDisconnected();
@@ -145,14 +155,25 @@ private:
     // Latches when the slow cadence is announced, so the transition is logged once
     // rather than every 15 minutes for as long as the broker stays away.
     bool m_slowRetryAnnounced = false;
-    // Set by disconnectFromBroker(), consumed by onInternalDisconnected(), so a stop
-    // the user asked for is not treated as a fault and immediately undone.
+    // A stop the user asked for is not a fault, so it must not re-arm the retry loop.
+    //
+    // INVARIANT: this may only be true while a disconnect callback is actually pending.
+    // It is set in the ONE branch of disconnectFromBroker() that triggers that callback,
+    // consumed by onInternalDisconnected(), and cleared again in connectToBroker() so a
+    // callback lost to MQTTAsync_destroy() cannot strand it. A latched true is not a
+    // cosmetic bug: the next genuine broker drop reads as user-requested, stops the
+    // timer, and leaves MQTT dead until the app restarts — the exact terminal death the
+    // slow-retry cadence was written to end.
     bool m_userRequestedDisconnect = false;
     // One definition for a string that is both WRITTEN and COMPARED. It had three
     // copies; editing any one of them would have silently stopped the clear-on-resume
     // from matching, re-creating the permanently-latched status it exists to prevent,
     // with no compiler help.
     static constexpr auto kWaitingForNetwork = "Waiting for network...";
+    // Same reasoning, same trap: the down-edge WRITES this and the up-edge COMPARES it.
+    // Two copies of the literal is how the connected case came to be left latched on
+    // screen forever while kWaitingForNetwork was handled correctly beside it.
+    static constexpr auto kConnectedNetworkUnreachable = "Connected - network unreachable";
 
     QString m_status;
     bool m_connected = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -903,6 +903,19 @@ add_decenza_test(tst_sampleblobseries
 target_link_libraries(tst_sampleblobseries PRIVATE decenza_shotlib)
 target_include_directories(tst_sampleblobseries PRIVATE ${CMAKE_BINARY_DIR})
 
+# --- tst_mqttclient: reconnect state machine (backoff cadence, reachability, user-disconnect) ---
+# mqttclient.cpp was in no test target at all until a latched m_userRequestedDisconnect
+# shipped in the change meant to STOP reconnection dying permanently. Drives the private
+# slots via the DECENZA_TESTING friend and asserts on timer state — no broker, no waiting.
+add_decenza_test(tst_mqttclient
+    tst_mqttclient.cpp
+    ${CMAKE_SOURCE_DIR}/src/network/mqttclient.cpp
+    ${CMAKE_BINARY_DIR}/version_code.cpp
+)
+target_link_libraries(tst_mqttclient PRIVATE paho-mqtt3a-static)
+# mqttclient.cpp includes the generated version.h (sw_version in the HA discovery payload).
+target_include_directories(tst_mqttclient PRIVATE ${CMAKE_BINARY_DIR})
+
 # --- tst_settling: SAW settling trimSettlingData(), m_sawSettling flag, shot save ordering ---
 find_package(Qt6 REQUIRED COMPONENTS Graphs Quick)
 add_decenza_test(tst_settling

--- a/tests/mocks/MockScaleDevice.h
+++ b/tests/mocks/MockScaleDevice.h
@@ -16,7 +16,7 @@ public:
     // Configurable behavior
     bool isFlowScale() const override { return m_isFlowScale; }
     QString name() const override { return QStringLiteral("MockScale"); }
-    QString type() const override { return QStringLiteral("mock"); }
+    QString type() const override { return m_type; }
 
     // Test helpers — expose protected setters
     void mockSetConnected(bool connected) { setConnected(connected); }
@@ -24,7 +24,12 @@ public:
 
     // Test configuration
     void setIsFlowScale(bool flow) { m_isFlowScale = flow; }
+    // Default stays "mock" — deliberately NOT a canonical ScaleTypeIds id, so the
+    // existing tests keep exercising the non-canonical path. Set a real id (e.g.
+    // "decent") to test callers that distinguish real scales from virtual ones.
+    void setType(const QString& type) { m_type = type; }
 
 private:
     bool m_isFlowScale = false;
+    QString m_type = QStringLiteral("mock");
 };

--- a/tests/tst_machinestate.cpp
+++ b/tests/tst_machinestate.cpp
@@ -470,6 +470,105 @@ private slots:
         f.setDE1State(DE1::State::Idle, DE1::SubState::Ready);
         QCOMPARE(spy.count(), 0);
     }
+
+    // ==========================================
+    // activeScaleType / activeScaleName
+    //
+    // The authority for "which scale is serving", used to key SAW learning, the
+    // Calibration tab's model display, and the reset_saw_learning_for_profile MCP
+    // default. Its failure mode is a corrupted persisted learning pool that no
+    // screen reveals, so it is asserted here rather than trusted to on-device use:
+    // the WiFi→BLE fallback that triggers it is rare and its symptom is a slightly
+    // wrong SAW stop weeks later.
+    // ==========================================
+
+    void activeScaleTypePrefersConnectedScaleOverSavedPrimary() {
+        // The bug this exists to fix: WiFi primary preserved on purpose by the
+        // WiFi→BLE fallback, BLE actually delivering every weight sample. Four
+        // consecutive shots on-device logged scale="decent-wifi" while served by BLE.
+        TestFixture f;
+        f.settings.setScaleType("decent-wifi");
+        f.settings.setScaleName("Half Decent Scale (WiFi)");
+        f.scale.setType("decent");
+        f.scale.mockSetConnected(true);
+
+        QCOMPARE(f.state.activeScaleType(), QStringLiteral("decent"));
+        // Canonical name of the scale actually serving — NOT the stale saved label,
+        // which would name one scale beside another's learned model.
+        QCOMPARE(f.state.activeScaleName(), QStringLiteral("Decent Scale"));
+    }
+
+    void activeScaleNameKeepsUserLabelWhenServingScaleIsThePrimary() {
+        TestFixture f;
+        f.settings.setScaleType("decent");
+        f.settings.setScaleName("Kitchen scale");  // user's own label
+        f.scale.setType("decent");
+        f.scale.mockSetConnected(true);
+
+        QCOMPARE(f.state.activeScaleType(), QStringLiteral("decent"));
+        QCOMPARE(f.state.activeScaleName(), QStringLiteral("Kitchen scale"));
+    }
+
+    void activeScaleTypeFallsBackForNonCanonicalScale() {
+        // FlowScale reports "flow" and is permanently isConnected(). Keying on it
+        // would open a "flow" pool and make SettingsCalibration::sensorLag() warn
+        // about an unknown type on every espresso cycle — which, under
+        // QTest::failOnWarning(), would surface as failures elsewhere in the suite.
+        TestFixture f;
+        f.settings.setScaleType("decent");
+        f.scale.setType("flow");
+        f.scale.mockSetConnected(true);
+        QCOMPARE(f.state.activeScaleType(), QStringLiteral("decent"));
+
+        // Base ScaleDevice::type() returns "" — an empty key would write learning
+        // entries into a pool nothing ever reads.
+        f.scale.setType(QString());
+        QCOMPARE(f.state.activeScaleType(), QStringLiteral("decent"));
+    }
+
+    void activeScaleTypeFallsBackWhenNotConnectedOrAbsent() {
+        TestFixture f;
+        f.settings.setScaleType("decent-wifi");
+        f.scale.setType("decent");
+
+        f.scale.mockSetConnected(false);
+        QCOMPARE(f.state.activeScaleType(), QStringLiteral("decent-wifi"));
+
+        f.state.setScale(nullptr);
+        QCOMPARE(f.state.activeScaleType(), QStringLiteral("decent-wifi"));
+    }
+
+    void activeScaleTypeNotifiesOnEverySourceThatCanChangeIt() {
+        // Each of these is a one-line wiring that, if dropped, leaves the Calibration
+        // tab bound to a stale value while its reset button — an imperative read, not
+        // a binding — clears a different pool. Silent, and exactly the read/write
+        // divergence activeScaleType exists to prevent.
+        TestFixture f;
+        f.settings.setScaleType("decent-wifi");
+        QSignalSpy spy(&f.state, &MachineState::activeScaleTypeChanged);
+
+        f.scale.setType("decent");
+        f.scale.mockSetConnected(true);           // ScaleDevice::connectedChanged
+        QVERIFY2(spy.count() >= 1, "connect/disconnect must notify");
+
+        spy.clear();
+        MockScaleDevice other;
+        other.setType("bookoo");
+        f.state.setScale(&other);                  // setScale()
+        QVERIFY2(spy.count() >= 1, "swapping the serving scale must notify");
+
+        spy.clear();
+        f.state.setScale(nullptr);                 // now on the saved-primary fallback
+        spy.clear();
+        f.settings.setScaleType("acaia");          // Settings::scaleTypeChanged
+        QVERIFY2(spy.count() >= 1,
+                 "changing the saved primary must notify while on the fallback path");
+        QCOMPARE(f.state.activeScaleType(), QStringLiteral("acaia"));
+
+        spy.clear();
+        f.settings.setScaleName("Renamed");        // Settings::scaleNameChanged
+        QVERIFY2(spy.count() >= 1, "renaming the saved scale must notify activeScaleName");
+    }
 };
 
 QTEST_GUILESS_MAIN(tst_MachineState)

--- a/tests/tst_mqttclient.cpp
+++ b/tests/tst_mqttclient.cpp
@@ -1,0 +1,263 @@
+#include <QtTest>
+#include <QSignalSpy>
+
+#include "core/settings.h"
+#include "core/settings_mqtt.h"
+#include "network/mqttclient.h"
+
+// Reconnect state machine for MqttClient.
+//
+// Why this file exists: mqttclient.cpp was in NO test target at all, and a change whose
+// entire purpose was to stop MQTT reconnection from dying permanently shipped a latched
+// m_userRequestedDisconnect that reintroduced exactly that death — silently, with no
+// warning and no status change. Nothing in a 101-test suite could have caught it.
+//
+// Everything here drives the private slots directly through the DECENZA_TESTING friend
+// declaration and asserts on QTimer state. No broker, no sockets, no waiting: the state
+// machine is pure logic over a timer and a handful of flags, and the Paho callbacks it
+// reacts to are already marshalled onto these slots via queued connections.
+class tst_MqttClient : public QObject {
+    Q_OBJECT
+
+private:
+    // device and machineState are only used to wire telemetry signals; the reconnect
+    // machine touches neither, so nullptr keeps the fixture to Settings alone.
+    static MqttClient* makeClient(Settings& settings) {
+        return new MqttClient(nullptr, nullptr, &settings, settings.mqtt());
+    }
+
+    // Put the client in the state the app is in with MQTT switched on and a host set,
+    // which is what every reconnect path assumes.
+    static void enableMqtt(Settings& settings) {
+        settings.mqtt()->setMqttEnabled(true);
+        settings.mqtt()->setMqttBrokerHost(QStringLiteral("192.0.2.1"));  // TEST-NET-1
+    }
+
+private slots:
+    void init() { QTest::failOnWarning(); }
+
+    // ===== The regression this file was created for =====
+
+    void disconnectWhileNotConnectedDoesNotStrandTheNextRealDrop() {
+        // THE bug. disconnectFromBroker() used to set m_userRequestedDisconnect
+        // unconditionally, but only the connected branch produces the callback that
+        // consumes it. Disconnecting while already disconnected therefore latched the
+        // flag forever, and the next GENUINE broker drop was read as user-requested:
+        // timer stopped, nothing armed, MQTT dead until app restart.
+        //
+        // Reachable from the Home Automation tab's Disconnect button and from
+        // ShotServer::handleMqttDisconnect, neither of which checks isConnected() —
+        // and tapping Disconnect while the status reads "reconnecting (3/10)..." is
+        // the obvious thing to do.
+        Settings settings;
+        enableMqtt(settings);
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        QVERIFY2(!c->isConnected(), "precondition: never connected");
+        c->disconnectFromBroker();          // the else branch — no Paho callback follows
+        QVERIFY2(!c->m_reconnectTimer.isActive(), "an explicit disconnect must not retry");
+
+        // Now a real broker-initiated drop, exactly as Paho would deliver it.
+        c->onInternalDisconnected();
+
+        QVERIFY2(c->m_reconnectTimer.isActive(),
+                 "a genuine broker drop after a no-op disconnect must still re-arm — "
+                 "this is the terminal death the slow-retry change exists to remove");
+    }
+
+    void userDisconnectIsConsumedExactlyOnce() {
+        // The flag must suppress the disconnect the user asked for and nothing after it.
+        //
+        // Set directly rather than via disconnectFromBroker(): that only arms the flag on
+        // the `m_client && m_connected` branch, and m_client is null here because there is
+        // no broker to have created one. Faking a non-null m_client would hand a garbage
+        // pointer to MQTTAsync_disconnect(). So this covers the CONSUMER's contract, and
+        // disconnectWhileNotConnectedDoesNotStrandTheNextRealDrop above covers the
+        // producer's — together they pin both halves of the bug.
+        Settings settings;
+        enableMqtt(settings);
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        c->m_userRequestedDisconnect = true;
+        c->onInternalDisconnected();        // the callback the user's disconnect caused
+        QVERIFY2(!c->m_reconnectTimer.isActive(), "user disconnect must not re-arm");
+        QCOMPARE(c->status(), QStringLiteral("Disconnected"));
+
+        c->onInternalDisconnected();        // a later, genuine drop
+        QVERIFY2(c->m_reconnectTimer.isActive(), "flag must be one-shot, not sticky");
+    }
+
+    void reconnectingClearsAStrandedUserDisconnectFlag() {
+        // Second, independent guard: onSettingsChanged() disconnects then immediately
+        // reconnects, and connectWithHost() destroys the client whose disconnect callback
+        // is still in flight (opts.onFailure is never set, so Paho's teardown loses it).
+        // connectToBroker() clears the flag unconditionally so that cannot strand it.
+        Settings settings;
+        enableMqtt(settings);
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        // Set directly for the same reason as above — and note this test was vacuous
+        // when it went through disconnectFromBroker(): with m_client null the flag was
+        // never armed, so the "must be cleared" assertion passed without testing anything.
+        c->m_userRequestedDisconnect = true;   // as if the callback never arrived
+        c->connectToBroker();                  // must clear it
+        QVERIFY2(!c->m_userRequestedDisconnect,
+                 "a new connect attempt means the prior user-disconnect is meaningless");
+
+        c->onInternalDisconnected();
+        QVERIFY2(c->m_reconnectTimer.isActive(),
+                 "a drop after reconnecting must re-arm, not read as user-requested");
+    }
+
+    // ===== Backoff cadence =====
+
+    void backoffWalksUpThenSettlesOnTheSlowCadence() {
+        // The point of the change: the fast budget stops being terminal. After it is
+        // spent the client keeps trying forever, just rarely.
+        Settings settings;
+        enableMqtt(settings);
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        QList<int> intervals;
+        for (int i = 0; i < MqttClient::MAX_FAST_RECONNECT_ATTEMPTS; ++i) {
+            c->m_reconnectAttempts = i;
+            intervals << c->reconnectDelayMs();
+        }
+        // Monotonic non-decreasing, capped.
+        for (int i = 1; i < intervals.size(); ++i)
+            QVERIFY2(intervals[i] >= intervals[i - 1], "backoff must not go backwards");
+        QCOMPARE(intervals.first(), MqttClient::INITIAL_RECONNECT_DELAY_MS);
+        QVERIFY(intervals.last() <= MqttClient::MAX_RECONNECT_DELAY_MS);
+
+        // Past the budget: the slow cadence, forever.
+        c->m_reconnectAttempts = MqttClient::MAX_FAST_RECONNECT_ATTEMPTS;
+        QCOMPARE(c->reconnectDelayMs(), MqttClient::IDLE_RECONNECT_DELAY_MS);
+        c->m_reconnectAttempts = MqttClient::MAX_FAST_RECONNECT_ATTEMPTS + 500;
+        QCOMPARE(c->reconnectDelayMs(), MqttClient::IDLE_RECONNECT_DELAY_MS);
+    }
+
+    void slowCadenceIsAnnouncedOnceNotEveryCycle() {
+        // A warning every 15 minutes forever is log spam that hides real faults; none at
+        // all leaves a silent 15-minute-cadence loop nobody can see. Exactly one.
+        Settings settings;
+        enableMqtt(settings);
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        c->m_reconnectAttempts = MqttClient::MAX_FAST_RECONNECT_ATTEMPTS;
+        QTest::ignoreMessage(QtWarningMsg,
+                             QRegularExpression("broker unreachable after"));
+        c->scheduleReconnect(QStringLiteral("test"));
+
+        // A second pass must be silent — init()'s failOnWarning() is the assertion.
+        c->scheduleReconnect(QStringLiteral("test"));
+        QVERIFY(c->m_reconnectTimer.isActive());
+    }
+
+    // ===== Network reachability =====
+
+    void networkDownSuspendsRetriesAndComingBackRefundsTheBudget() {
+        Settings settings;
+        enableMqtt(settings);
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        c->m_reconnectAttempts = 4;
+        c->scheduleReconnect(QStringLiteral("test"));
+        QVERIFY(c->m_reconnectTimer.isActive());
+
+        c->onNetworkReachabilityChanged(false);
+        QVERIFY2(!c->m_reconnectTimer.isActive(), "no point dialling a down interface");
+        QCOMPARE(c->status(), QStringLiteral("Waiting for network..."));
+
+        c->onNetworkReachabilityChanged(true);
+        QCOMPARE(c->m_reconnectAttempts, 0);   // a regained network gets a fresh budget
+        QVERIFY2(c->status() != QStringLiteral("Waiting for network..."),
+                 "the waiting status describes a condition that has ended");
+    }
+
+    void aDeferredTickDoesNotSpendAnAttempt() {
+        // The whole reason reachability is watched: an outage must not burn the fast
+        // budget, because an attempt against a down interface says nothing about the
+        // broker. Observed on-device 2026-07-25.
+        Settings settings;
+        enableMqtt(settings);
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        c->m_networkDown = true;
+        const int before = c->m_reconnectAttempts;
+        c->onReconnectTimerTick();
+        QCOMPARE(c->m_reconnectAttempts, before);
+    }
+
+    void connectedNetworkUnreachableStatusDoesNotLatch() {
+        // A reachability blip the TCP session survives (well inside the 60 s keepalive)
+        // used to leave "Connected - network unreachable" on the Home Automation tab
+        // indefinitely: the resume path cleared only the waiting-for-network string and
+        // then early-returned on isConnected(), so nothing ever rewrote it.
+        Settings settings;
+        enableMqtt(settings);
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        c->m_connected = true;
+        c->onNetworkReachabilityChanged(false);
+        QCOMPARE(c->status(), QStringLiteral("Connected - network unreachable"));
+
+        c->onNetworkReachabilityChanged(true);
+        QVERIFY2(c->status() != QStringLiteral("Connected - network unreachable"),
+                 "status must not outlive the condition it describes");
+    }
+
+    // ===== Enable/disable =====
+
+    void disablingMqttStopsTheLoopAndSaysSo() {
+        Settings settings;
+        enableMqtt(settings);
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        c->scheduleReconnect(QStringLiteral("test"));
+        QVERIFY(c->m_reconnectTimer.isActive());
+
+        settings.mqtt()->setMqttEnabled(false);   // fires onSettingsChanged()
+        QVERIFY2(!c->m_reconnectTimer.isActive(), "a disabled feature must not retry");
+        QCOMPARE(c->status(), QStringLiteral("Disabled"));
+    }
+
+    void failureWhileDisabledIsReportedRatherThanSwallowed() {
+        // scheduleReconnect() returns early when MQTT is off — correctly, it must not
+        // retry. But the three synchronous connectWithHost() exits lost their own
+        // "Error: …" status when they were consolidated here, so returning silently left
+        // the tab reading "Connecting..." forever with the Paho rc discarded. A connect
+        // CAN be initiated while disabled: the Connect button gates only on host-non-empty.
+        Settings settings;
+        settings.mqtt()->setMqttEnabled(false);
+        settings.mqtt()->setMqttBrokerHost(QStringLiteral("192.0.2.1"));
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             QRegularExpression("connect attempt failed while MQTT is disabled"));
+        c->scheduleReconnect(QStringLiteral("Connect failed (-3)"));
+
+        QVERIFY2(!c->m_reconnectTimer.isActive(), "still must not retry while disabled");
+        QVERIFY2(c->status().contains(QStringLiteral("Connect failed (-3)")),
+                 "the broker's own reason must survive to the UI, not be discarded");
+    }
+
+    // ===== Status text =====
+
+    void brokerReasonSurvivesIntoTheStatus() {
+        // "Bad user name or password" is the whole diagnosis; a bare
+        // "reconnecting (3/10)..." that overwrites it makes the fault unfindable.
+        Settings settings;
+        enableMqtt(settings);
+        QScopedPointer<MqttClient> c(makeClient(settings));
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Connection failed"));
+        c->onInternalConnectionFailed(QStringLiteral("Bad user name or password"));
+
+        QVERIFY2(c->status().contains(QStringLiteral("Bad user name or password")),
+                 "the broker's reason must reach the Home Automation tab");
+        QVERIFY(c->m_reconnectTimer.isActive());
+    }
+};
+
+QTEST_MAIN(tst_MqttClient)
+#include "tst_mqttclient.moc"

--- a/tests/tst_saw_settings.cpp
+++ b/tests/tst_saw_settings.cpp
@@ -57,6 +57,88 @@ private slots:
         m_settings.calibration()->resetSawLearning();
     }
 
+    // ===== Scale-key resolution (omitted scaleType) =====
+    //
+    // The whole point of the optional parameter: a call site that omits the scale
+    // gets the SAME key the learner writes under. Four consumers previously derived
+    // it three ways, so these pin the resolution itself rather than any one caller.
+
+    void omittedScaleTypeResolvesToTheServingScale() {
+        // Saved primary is one scale, a different one is actually serving. Learning
+        // under the serving scale must be readable by a caller that names nothing —
+        // this is the decent-wifi/BLE split that started all of this.
+        m_settings.setScaleType(QStringLiteral("decent-wifi"));
+        m_settings.calibration()->setServingScaleTypeProvider(
+            []() { return QStringLiteral("bookoo"); });
+
+        for (int i = 0; i < 3; ++i)
+            m_settings.calibration()->addSawLearningPoint(3.0, 1.5, QStringLiteral("bookoo"),
+                                                          0.0, kProfileA);
+        for (int i = 0; i < 3; ++i)
+            m_settings.calibration()->addSawLearningPoint(3.0, 1.5, QStringLiteral("bookoo"),
+                                                          0.0, kProfileA);
+
+        const double resolved = m_settings.calibration()->sawLearnedLagFor(kProfileA);
+        const double explicitBookoo =
+            m_settings.calibration()->sawLearnedLagFor(kProfileA, QStringLiteral("bookoo"));
+        QCOMPARE(resolved, explicitBookoo);
+        QVERIFY2(resolved > 1.8, "omitting the scale must reach the serving scale's pool");
+
+        m_settings.calibration()->setServingScaleTypeProvider(nullptr);
+    }
+
+    void omittedScaleTypeFallsBackToSavedWhenNothingIsServing() {
+        // No physical scale connected — the provider reports empty. The saved primary
+        // is the only answer left, and it must be NORMALIZED: "Decent Scale" and
+        // "decent" keying different pools is the same split under another spelling.
+        m_settings.setScaleType(QStringLiteral("Decent Scale"));
+        m_settings.calibration()->setServingScaleTypeProvider([]() { return QString(); });
+
+        QCOMPARE(m_settings.calibration()->currentScaleType(), QStringLiteral("decent"));
+
+        m_settings.calibration()->setServingScaleTypeProvider(nullptr);
+    }
+
+    void nonCanonicalServingScaleFallsBackToSaved() {
+        // FlowScale reports "flow" and is permanently connected. Without the canonical
+        // check every scale-less shot would open a "flow" pool and make sensorLag()
+        // warn about an unknown type on every cycle (init()'s failOnWarning would
+        // catch that here).
+        m_settings.setScaleType(QStringLiteral("bookoo"));
+        m_settings.calibration()->setServingScaleTypeProvider(
+            []() { return QStringLiteral("flow"); });
+
+        QCOMPARE(m_settings.calibration()->currentScaleType(), QStringLiteral("bookoo"));
+
+        m_settings.calibration()->setServingScaleTypeProvider(nullptr);
+    }
+
+    void explicitScaleTypeOverridesTheServingScale() {
+        // The learning path latches the key at shot start and passes it ~40 s later,
+        // so a scale swapped mid-shot still trains the pool that made the prediction.
+        // An explicit key must therefore beat live resolution, not be overridden by it.
+        m_settings.setScaleType(QStringLiteral("decent"));
+        m_settings.calibration()->setServingScaleTypeProvider(
+            []() { return QStringLiteral("bookoo"); });
+
+        for (int i = 0; i < 3; ++i)
+            m_settings.calibration()->addSawLearningPoint(0.6, 1.5, QStringLiteral("acaia"),
+                                                          0.0, kProfileA);
+        for (int i = 0; i < 3; ++i)
+            m_settings.calibration()->addSawLearningPoint(0.6, 1.5, QStringLiteral("acaia"),
+                                                          0.0, kProfileA);
+
+        // acaia's pool has the graduated data; bookoo (resolved) does not.
+        QVERIFY2(m_settings.calibration()
+                     ->perProfileSawHistory(kProfileA, QStringLiteral("acaia")).size() > 0,
+                 "precondition: explicit-key learning landed in acaia's pool");
+        QCOMPARE(m_settings.calibration()
+                     ->perProfileSawHistory(kProfileA, QStringLiteral("bookoo")).size(),
+                 qsizetype(0));
+
+        m_settings.calibration()->setServingScaleTypeProvider(nullptr);
+    }
+
     // ===== Per-pair isolation =====
 
     void perPairIsolatesFromOtherProfile() {

--- a/tests/tst_saw_settings.cpp
+++ b/tests/tst_saw_settings.cpp
@@ -55,6 +55,48 @@ private slots:
 
     void cleanup() {
         m_settings.calibration()->resetSawLearning();
+        // Must be here, not at the end of each test that installs one. Settings is a
+        // class member, so a provider left installed leaks into every later test in the
+        // file — and a test that installs one then fails a QCOMPARE returns from the
+        // slot without reaching its own teardown, burying the real failure under
+        // cascading ones.
+        m_settings.calibration()->setServingScaleTypeProvider(nullptr);
+    }
+
+    // ===== ScaleTypeIds::kAll completeness =====
+
+    void everyScaleTypeIsInTheCanonicalVocabulary() {
+        // kAll is a hand-maintained array and gets NO compiler help. The switches in
+        // scaleTypeId()/scaleTypeName() have no `default:`, so -Wswitch (with -Werror)
+        // forces a new enumerator to be handled there — but nothing forces it into kAll.
+        //
+        // Miss it and the failure is silent and expensive: isCanonicalScaleTypeId()
+        // returns false for the new scale, SettingsCalibration::currentScaleType() falls
+        // through to the SAVED primary, and that scale's shots train another scale's SAW
+        // pool. Identical to the decent-wifi/BLE corruption this whole change set exists
+        // to fix, for a scale nobody is looking at yet.
+        //
+        // Bound: iterates the real types, Unknown excluded (it has no id by design).
+        // NOTE this catches "added an enumerator, forgot kAll" — the likely mistake —
+        // but not "added an enumerator AFTER Timemore", which also needs this bound
+        // moved. See the note on the enum's last entry in scaletypeids.h.
+        // ScaleType is at global scope; only the helper functions are namespaced.
+        int checked = 0;
+        for (int t = int(ScaleType::Unknown) + 1; t <= int(ScaleType::Timemore); ++t) {
+            const ScaleType type = static_cast<ScaleType>(t);
+            const QString id = ScaleTypeIds::scaleTypeId(type);
+            QVERIFY2(!id.isEmpty(),
+                     qPrintable(QString("ScaleType %1 has no canonical id").arg(t)));
+            QVERIFY2(ScaleTypeIds::isCanonicalScaleTypeId(id),
+                     qPrintable(QString("id '%1' (ScaleType %2) is missing from kAll — SAW "
+                                        "would key its shots on the saved primary").arg(id).arg(t)));
+            // The round trips the three kAll consumers rely on.
+            QCOMPARE(ScaleTypeIds::normalizeScaleTypeId(id), id);
+            QCOMPARE(ScaleTypeIds::normalizeScaleTypeId(ScaleTypeIds::scaleTypeName(type)), id);
+            QCOMPARE(ScaleTypeIds::scaleTypeNameForId(id), ScaleTypeIds::scaleTypeName(type));
+            ++checked;
+        }
+        QVERIFY2(checked >= 16, "enum shrank unexpectedly — is the bound still right?");
     }
 
     // ===== Scale-key resolution (omitted scaleType) =====
@@ -71,20 +113,46 @@ private slots:
         m_settings.calibration()->setServingScaleTypeProvider(
             []() { return QStringLiteral("bookoo"); });
 
-        for (int i = 0; i < 3; ++i)
-            m_settings.calibration()->addSawLearningPoint(3.0, 1.5, QStringLiteral("bookoo"),
-                                                          0.0, kProfileA);
+        // One batch of 3 graduates the pair (kSawMinMediansForGraduation == 1).
         for (int i = 0; i < 3; ++i)
             m_settings.calibration()->addSawLearningPoint(3.0, 1.5, QStringLiteral("bookoo"),
                                                           0.0, kProfileA);
 
-        const double resolved = m_settings.calibration()->sawLearnedLagFor(kProfileA);
-        const double explicitBookoo =
-            m_settings.calibration()->sawLearnedLagFor(kProfileA, QStringLiteral("bookoo"));
-        QCOMPARE(resolved, explicitBookoo);
-        QVERIFY2(resolved > 1.8, "omitting the scale must reach the serving scale's pool");
+        // Cover ALL FOUR optional-key entry points, not just one. Dropping the
+        // resolveScaleKey() call from any single reader must fail this — sawModelSource()
+        // especially, since that is the Q_INVOKABLE the Calibration tab reads, so its
+        // mutation is literally "the tab reports a pool the learner is not training".
+        //
+        // Each assertion is two-sided: the omitted-key answer must MATCH the serving
+        // scale's explicit answer and DIFFER from the saved primary's. The second half is
+        // what makes it discriminating — matching alone would also pass if both pools
+        // happened to be empty.
+        auto* cal = m_settings.calibration();
+        const QString kServing = QStringLiteral("bookoo");
+        const QString kSaved = QStringLiteral("decent-wifi");
 
-        m_settings.calibration()->setServingScaleTypeProvider(nullptr);
+        // Match-the-serving-scale holds for every reader.
+        QCOMPARE(cal->sawLearnedLagFor(kProfileA), cal->sawLearnedLagFor(kProfileA, kServing));
+        QCOMPARE(cal->sawModelSource(kProfileA), cal->sawModelSource(kProfileA, kServing));
+        QCOMPARE(cal->perProfileSawHistory(kProfileA).size(),
+                 cal->perProfileSawHistory(kProfileA, kServing).size());
+        QCOMPARE(cal->sawPendingBatch(kProfileA).size(),
+                 cal->sawPendingBatch(kProfileA, kServing).size());
+
+        // Differ-from-the-saved-primary is asserted on the DIRECT pool reads only.
+        // sawLearnedLagFor/sawModelSource deliberately fall back (per-pair → global
+        // bootstrap → global pool) when a pair has not graduated, and with only one
+        // scale's data present those fallbacks land on the same number — so "must
+        // differ" is not a property of those readers and asserting it there fails for
+        // a reason that has nothing to do with key resolution. perProfileSawHistory
+        // reads one pool with no fallback, which is what makes it discriminating.
+        QVERIFY2(cal->perProfileSawHistory(kProfileA).size()
+                     != cal->perProfileSawHistory(kProfileA, kSaved).size(),
+                 "resolved key must not reach the saved primary's pool");
+        QCOMPARE(cal->perProfileSawHistory(kProfileA, kSaved).size(), qsizetype(0));
+
+        QVERIFY2(cal->sawLearnedLagFor(kProfileA) > 1.8,
+                 "omitting the scale must reach the serving scale's pool");
     }
 
     void omittedScaleTypeFallsBackToSavedWhenNothingIsServing() {
@@ -96,7 +164,6 @@ private slots:
 
         QCOMPARE(m_settings.calibration()->currentScaleType(), QStringLiteral("decent"));
 
-        m_settings.calibration()->setServingScaleTypeProvider(nullptr);
     }
 
     void nonCanonicalServingScaleFallsBackToSaved() {
@@ -110,7 +177,6 @@ private slots:
 
         QCOMPARE(m_settings.calibration()->currentScaleType(), QStringLiteral("bookoo"));
 
-        m_settings.calibration()->setServingScaleTypeProvider(nullptr);
     }
 
     void explicitScaleTypeOverridesTheServingScale() {
@@ -136,7 +202,6 @@ private slots:
                      ->perProfileSawHistory(kProfileA, QStringLiteral("bookoo")).size(),
                  qsizetype(0));
 
-        m_settings.calibration()->setServingScaleTypeProvider(nullptr);
     }
 
     // ===== Per-pair isolation =====

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -533,11 +533,48 @@ private slots:
         QSignalSpy sawSpy(&tc, &ShotTimingController::sawLearningComplete);
         QSignalSpy readySpy(&tc, &ShotTimingController::shotProcessingReady);
 
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Scale disconnected"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("No physical scale at settling"));
         tc.onSettlingComplete();
 
         QCOMPARE(sawSpy.count(), 0);   // learning skipped
         QCOMPARE(readySpy.count(), 1); // but shot still saves
+    }
+
+    void flowScaleServesSawButNeverTrainsIt() {
+        // A virtual scale is permanently isConnected(), so the connection check alone
+        // lets it through. Without the isFlowScale() clause a scale-less shot learns
+        // from a flow-integral estimate — and specifically learns drip == 0, because
+        // FlowScale stops emitting the moment the SAW stop ends the pour, leaving
+        // m_weight pinned at m_weightAtStop for the whole settling window. That zero
+        // lands in the SAVED physical scale's pool and drags it toward "no drip", so
+        // SAW stops late and overshoots once the real scale is reconnected.
+        //
+        // State below is byte-for-byte the passing case in
+        // sawLearningCompleteEmittedBeforeShotProcessingReady above, so the ONLY
+        // difference is isFlowScale() — deleting that clause flips this test red
+        // while the positive test stays green.
+        DE1Device device;
+        ShotTimingController tc(&device);
+
+        MockScaleDevice scale;
+        scale.mockSetConnected(true);
+        scale.setIsFlowScale(true);
+        tc.setScale(&scale);
+
+        tc.m_weightAtStop = 35.0;
+        tc.m_flowRateAtStop = 1.5;
+        tc.m_targetWeightAtStop = 36.0;
+        tc.m_weight = 36.5;
+        tc.m_sawSettling = true;
+
+        QSignalSpy sawSpy(&tc, &ShotTimingController::sawLearningComplete);
+        QSignalSpy readySpy(&tc, &ShotTimingController::shotProcessingReady);
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("No physical scale at settling"));
+        tc.onSettlingComplete();
+
+        QCOMPARE(sawSpy.count(), 0);    // never trains the physical scale's pool
+        QCOMPARE(readySpy.count(), 1);  // but the scale-less shot still saves
     }
 
     void startShotCancelsSettlingAndEmitsReady() {
@@ -575,7 +612,7 @@ private slots:
         tc.onSawTriggered(35.0, 2.0, 36.0);
         QVERIFY(tc.wasSawTriggered());
         tc.m_sawSettling = true;
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Scale disconnected"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("No physical scale at settling"));
         tc.onSettlingComplete();  // clears m_sawTriggeredThisShot internally
         QVERIFY2(tc.wasSawTriggered(),
                  "#1161: SAW must still read true after settling — "

--- a/tests/tst_settling.cpp
+++ b/tests/tst_settling.cpp
@@ -542,17 +542,18 @@ private slots:
 
     void flowScaleServesSawButNeverTrainsIt() {
         // A virtual scale is permanently isConnected(), so the connection check alone
-        // lets it through. Without the isFlowScale() clause a scale-less shot learns
-        // from a flow-integral estimate — and specifically learns drip == 0, because
-        // FlowScale stops emitting the moment the SAW stop ends the pour, leaving
-        // m_weight pinned at m_weightAtStop for the whole settling window. That zero
-        // lands in the SAVED physical scale's pool and drags it toward "no drip", so
-        // SAW stops late and overshoots once the real scale is reconnected.
+        // lets it through. Without the isFlowScale() clause a scale-less shot trains a
+        // physical scale's pool from a flow-integral ESTIMATE — and a biased one: the
+        // gravity drip off the puck lands after the pour ends, which is exactly when
+        // FlowScale goes silent, so its drip is systematically low and drags the saved
+        // scale's learned model down. SAW then stops late and overshoots once the real
+        // scale is reconnected. See the reasoning at the guard itself.
         //
         // State below is byte-for-byte the passing case in
-        // sawLearningCompleteEmittedBeforeShotProcessingReady above, so the ONLY
+        // sawLearningCompleteFiresBeforeShotProcessingReady above, so the ONLY
         // difference is isFlowScale() — deleting that clause flips this test red
-        // while the positive test stays green.
+        // while the positive test stays green. (Note the fixture's drip is 1.5 g, not
+        // zero; the guard does not depend on the value, only on the source.)
         DE1Device device;
         ShotTimingController tc(&device);
 

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -697,6 +697,33 @@ private slots:
         QCOMPARE(flowSpy.count(), countBeforeTare + 1);  // accepted, not rejected
     }
 
+    void tareLandsWithoutABigStep() {
+        // The common case, and the one the >100 g branch never sees: the scale was
+        // already at (or returned to) about zero, so the tare arrives as an ordinary
+        // sample. The exemption must still be consumed — otherwise it stays armed all
+        // preheat, keeping the per-frame weight exit gated off and handing a free pass
+        // to a genuine large drop later.
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
+
+        wp.startExtraction();
+        wp.processWeight(0.4);  m_fakeClock += 200;  // realistic post-tare residual,
+                                                     // not exactly 0 — the threshold
+                                                     // is a band, not an equality
+        // Climb in sub-100 g steps so nothing here is itself a spike.
+        wp.processWeight(60.0);  m_fakeClock += 200;
+        wp.processWeight(120.0); m_fakeClock += 200;
+        wp.processWeight(150.0); m_fakeClock += 200;
+        const qsizetype countBefore = flowSpy.count();
+
+        // Exemption already spent by the 0.4 g sample, so this is a spike.
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected: weight= 0 "));
+        wp.processWeight(0.0); m_fakeClock += 200;
+
+        QCOMPARE(flowSpy.count(), countBefore);
+    }
+
     void tareExemptionIsDirectional() {
         // The exemption is for a step DOWN to near zero, nothing else. #610 corruption
         // travels upward (1649 g instead of 10 g), so an upward spike must still be
@@ -714,6 +741,13 @@ private slots:
         wp.processWeight(1649.0); m_fakeClock += 200;
 
         QCOMPARE(flowSpy.count(), countBefore);  // rejected despite awaiting the tare
+
+        // ...and DOWN is not enough either — the destination has to be near zero.
+        // A large downward step that lands somewhere else is a cup lift or garbage,
+        // not the tare we are waiting for.
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected: weight= 250 "));
+        wp.processWeight(250.0); m_fakeClock += 200;
+        QCOMPARE(flowSpy.count(), countBefore);
     }
 
     void tareExemptionIsConsumedOnce() {
@@ -735,7 +769,7 @@ private slots:
         wp.processWeight(150.0); m_fakeClock += 200;
         const qsizetype countBefore = flowSpy.count();
 
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected.*0"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected: weight= 0 "));
         wp.processWeight(0.0); m_fakeClock += 200;
 
         QCOMPARE(flowSpy.count(), countBefore);  // rejected — no second free pass
@@ -755,7 +789,7 @@ private slots:
         feedRising(wp, 150.0, 2.0, 4);
         const qsizetype countBefore = flowSpy.count();
 
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected.*0"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected: weight= 0 "));
         wp.processWeight(0.0); m_fakeClock += 200;
 
         QCOMPARE(flowSpy.count(), countBefore);

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -622,7 +622,11 @@ private slots:
         WeightProcessor wp;
         installFakeClock(wp);
         QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
-        wp.startExtraction();  // Spike filter only active during extraction
+        wp.startExtraction();      // Spike filter only active during extraction
+        wp.markExtractionStart();  // ...and only once the tare has landed / flow began.
+                                   // This test's baseline starts at 8 g and never passes
+                                   // through zero, so without this the filter would still
+                                   // be holding off for the tare — see tareStepIsNotASpike.
 
         // Establish baseline at ~10g
         feedRising(wp, 8.0, 2.0, 5);
@@ -669,6 +673,94 @@ private slots:
         QVERIFY2(qAbs(flowAfter - flowBefore) < 1.5,
                  qPrintable(QString("Flow should be stable after spike rejection: before=%1 after=%2")
                             .arg(flowBefore).arg(flowAfter)));
+    }
+
+    void tareStepIsNotASpike() {
+        // The drop from a loaded portafilter to zero is the app's own tare, not BLE
+        // corruption. startExtraction() clears the baseline, but the tare is async at
+        // the scale: pre-tare samples keep arriving and one of them re-establishes the
+        // baseline, so the step to zero used to read as a >100 g spike. Observed every
+        // shot on-device: "Spike rejected: weight= 0 last= 364.6", twice.
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
+
+        wp.startExtraction();  // Preheat begins; tare command sent by the caller
+
+        // Scale is still reporting the loaded portafilter — these land AFTER
+        // startExtraction() cleared the baseline, which is what made the old filter
+        // latch onto a pre-tare value.
+        wp.processWeight(364.6); m_fakeClock += 200;
+        wp.processWeight(364.6); m_fakeClock += 200;
+        const qsizetype countBeforeTare = flowSpy.count();
+
+        // Tare lands. No warning may be emitted — a stray qWarning here fails the
+        // suite under the project's warning policy, so absence is enforced, not assumed.
+        wp.processWeight(0.0); m_fakeClock += 200;
+
+        QCOMPARE(flowSpy.count(), countBeforeTare + 1);  // accepted, not rejected
+    }
+
+    void spikeFilterArmsAfterTareLands() {
+        // The hold-off must not disable #610 protection for the rest of the shot:
+        // once a near-zero sample proves the tare landed, corruption is rejected again.
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
+
+        wp.startExtraction();
+        wp.processWeight(364.6); m_fakeClock += 200;  // pre-tare
+        wp.processWeight(0.0);   m_fakeClock += 200;  // tare lands → filter arms
+
+        feedRising(wp, 0.0, 2.0, 5);
+        const qsizetype countBefore = flowSpy.count();
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected.*1649"));
+        wp.processWeight(1649.0); m_fakeClock += 200;
+
+        QCOMPARE(flowSpy.count(), countBefore);  // rejected — no signal
+    }
+
+    void spikeFilterArmsAtFlowStartWithoutNearZeroSample() {
+        // Backstop for a scale that never reads near zero (untared cup left on the
+        // platter): flow starting is the point past which the pour — the only window
+        // where a corrupt packet can cause a false SAW stop — must be protected.
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
+
+        wp.startExtraction();
+        wp.processWeight(120.0); m_fakeClock += 200;  // never passes through zero
+        wp.markExtractionStart();                     // flow begins → arm regardless
+
+        feedRising(wp, 120.0, 2.0, 4);
+        const qsizetype countBefore = flowSpy.count();
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected.*1649"));
+        wp.processWeight(1649.0); m_fakeClock += 200;
+
+        QCOMPARE(flowSpy.count(), countBefore);
+    }
+
+    void retareStepIsNotASpike() {
+        // resetForRetare() moves the zero point mid-preheat for exactly the same
+        // reason, so it re-enters the same hold-off.
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
+
+        wp.startExtraction();
+        wp.processWeight(0.0);   m_fakeClock += 200;  // first tare landed
+        feedRising(wp, 0.0, 2.0, 3);
+
+        QTest::ignoreMessage(QtDebugMsg, QRegularExpression("Reset for auto-retare"));
+        wp.resetForRetare();
+
+        wp.processWeight(364.6); m_fakeClock += 200;  // scale still pre-retare
+        const qsizetype countBefore = flowSpy.count();
+        wp.processWeight(0.0);   m_fakeClock += 200;  // retare lands
+
+        QCOMPARE(flowSpy.count(), countBefore + 1);
     }
 
     void spikeBypassedWhenInactive() {

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -690,10 +690,13 @@ private slots:
         wp.processWeight(364.6); m_fakeClock += 200;
         const qsizetype countBeforeTare = flowSpy.count();
 
-        // Tare lands. No warning may be emitted — init() calls QTest::failOnWarning(),
-        // so absence is enforced, not assumed.
+        // First near-zero sample is HELD, not believed — one packet is not proof.
         wp.processWeight(0.0); m_fakeClock += 200;
+        QCOMPARE(flowSpy.count(), countBeforeTare);
 
+        // Second confirms it. No warning may be emitted — init() calls
+        // QTest::failOnWarning(), so absence is enforced, not assumed.
+        wp.processWeight(0.0); m_fakeClock += 200;
         QCOMPARE(flowSpy.count(), countBeforeTare + 1);  // accepted, not rejected
     }
 
@@ -708,9 +711,10 @@ private slots:
         QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
 
         wp.startExtraction();
-        wp.processWeight(0.4);  m_fakeClock += 200;  // realistic post-tare residual,
-                                                     // not exactly 0 — the threshold
-                                                     // is a band, not an equality
+        // Realistic post-tare residual, not exactly 0 — the threshold is a band, not
+        // an equality. Two of them, because one is never enough.
+        wp.processWeight(0.4);  m_fakeClock += 200;
+        wp.processWeight(0.3);  m_fakeClock += 200;
         // Climb in sub-100 g steps so nothing here is itself a spike.
         wp.processWeight(60.0);  m_fakeClock += 200;
         wp.processWeight(120.0); m_fakeClock += 200;
@@ -759,7 +763,8 @@ private slots:
 
         wp.startExtraction();
         wp.processWeight(364.6); m_fakeClock += 200;
-        wp.processWeight(0.0);   m_fakeClock += 200;  // tare lands, exemption consumed
+        wp.processWeight(0.0);   m_fakeClock += 200;  // held
+        wp.processWeight(0.0);   m_fakeClock += 200;  // confirmed — exemption consumed
 
         // Climb to a large-drink weight in steps under the 100 g spike threshold —
         // a single jump to 150 g would itself be rejected as a spike, which is the
@@ -822,11 +827,44 @@ private slots:
         wp.processWeight(364.6); m_fakeClock += 200;
         QCOMPARE(skipSpy.count(), 0);  // must NOT skip on an untared weight
 
-        // Tare lands, then a genuine 25 g crosses the exit for real.
+        // Tare lands (confirmed), then a genuine 25 g crosses the exit for real.
+        wp.processWeight(0.0);  m_fakeClock += 200;
         wp.processWeight(0.0);  m_fakeClock += 200;
         QCOMPARE(skipSpy.count(), 0);
         wp.processWeight(25.0); m_fakeClock += 200;
         QCOMPARE(skipSpy.count(), 1);  // ...and the gate does not block a real exit
+    }
+
+    void singleSpuriousZeroDoesNotOpenFrameExit() {
+        // Regression for the hole the confirmation requirement closes. Zero is a
+        // demonstrated spurious reading on this hardware. Believing one would consume
+        // the exemption, leaving the REAL pre-tare weights to be rejected three times
+        // and then escape-hatched — at which point the per-frame exit is open and a
+        // 364 g portafilter reading clears any plausible exit weight, firing exactly
+        // the spurious skipFrame the gate exists to prevent.
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy skipSpy(&wp, &WeightProcessor::skipFrame);
+
+        QVector<double> weights = {20.0, 0.0};  // frame 0 exits at 20 g
+        QVector<FrameExitCondition> conds = {{}, {}};
+        configureEspresso(wp, 0, 0, weights, conds);
+        wp.startExtraction();
+        wp.setTareComplete(true);
+        wp.setCurrentFrame(0);
+
+        wp.processWeight(364.6); m_fakeClock += 200;  // real pre-tare baseline
+        wp.processWeight(0.0);   m_fakeClock += 200;  // ONE spurious zero — held
+        wp.processWeight(364.6); m_fakeClock += 200;  // real weight resumes
+        wp.processWeight(364.6); m_fakeClock += 200;
+
+        QCOMPARE(skipSpy.count(), 0);  // gate must still be shut
+
+        // The real tare, confirmed, then a genuine crossing.
+        wp.processWeight(0.0);  m_fakeClock += 200;
+        wp.processWeight(0.0);  m_fakeClock += 200;
+        wp.processWeight(25.0); m_fakeClock += 200;
+        QCOMPARE(skipSpy.count(), 1);
     }
 
     void retareStepIsNotASpike() {
@@ -845,7 +883,8 @@ private slots:
 
         wp.processWeight(364.6); m_fakeClock += 200;  // scale still pre-retare
         const qsizetype countBefore = flowSpy.count();
-        wp.processWeight(0.0);   m_fakeClock += 200;  // retare lands
+        wp.processWeight(0.0);   m_fakeClock += 200;  // held
+        wp.processWeight(0.0);   m_fakeClock += 200;  // retare confirmed
 
         QCOMPARE(flowSpy.count(), countBefore + 1);
     }

--- a/tests/tst_weightprocessor.cpp
+++ b/tests/tst_weightprocessor.cpp
@@ -622,11 +622,7 @@ private slots:
         WeightProcessor wp;
         installFakeClock(wp);
         QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
-        wp.startExtraction();      // Spike filter only active during extraction
-        wp.markExtractionStart();  // ...and only once the tare has landed / flow began.
-                                   // This test's baseline starts at 8 g and never passes
-                                   // through zero, so without this the filter would still
-                                   // be holding off for the tare — see tareStepIsNotASpike.
+        wp.startExtraction();  // Spike filter only active during extraction
 
         // Establish baseline at ~10g
         feedRising(wp, 8.0, 2.0, 5);
@@ -694,57 +690,114 @@ private slots:
         wp.processWeight(364.6); m_fakeClock += 200;
         const qsizetype countBeforeTare = flowSpy.count();
 
-        // Tare lands. No warning may be emitted — a stray qWarning here fails the
-        // suite under the project's warning policy, so absence is enforced, not assumed.
+        // Tare lands. No warning may be emitted — init() calls QTest::failOnWarning(),
+        // so absence is enforced, not assumed.
         wp.processWeight(0.0); m_fakeClock += 200;
 
         QCOMPARE(flowSpy.count(), countBeforeTare + 1);  // accepted, not rejected
     }
 
-    void spikeFilterArmsAfterTareLands() {
-        // The hold-off must not disable #610 protection for the rest of the shot:
-        // once a near-zero sample proves the tare landed, corruption is rejected again.
+    void tareExemptionIsDirectional() {
+        // The exemption is for a step DOWN to near zero, nothing else. #610 corruption
+        // travels upward (1649 g instead of 10 g), so an upward spike must still be
+        // rejected even while the tare is outstanding — otherwise the hold-off would be
+        // a window with no filter at all.
         WeightProcessor wp;
         installFakeClock(wp);
         QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
 
         wp.startExtraction();
-        wp.processWeight(364.6); m_fakeClock += 200;  // pre-tare
-        wp.processWeight(0.0);   m_fakeClock += 200;  // tare lands → filter arms
-
-        feedRising(wp, 0.0, 2.0, 5);
+        wp.processWeight(364.6); m_fakeClock += 200;  // pre-tare baseline, tare still pending
         const qsizetype countBefore = flowSpy.count();
 
         QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected.*1649"));
         wp.processWeight(1649.0); m_fakeClock += 200;
 
-        QCOMPARE(flowSpy.count(), countBefore);  // rejected — no signal
+        QCOMPARE(flowSpy.count(), countBefore);  // rejected despite awaiting the tare
     }
 
-    void spikeFilterArmsAtFlowStartWithoutNearZeroSample() {
-        // Backstop for a scale that never reads near zero (untared cup left on the
-        // platter): flow starting is the point past which the pour — the only window
-        // where a corrupt packet can cause a false SAW stop — must be protected.
+    void tareExemptionIsConsumedOnce() {
+        // Once the tare has landed the exemption is spent: a second large drop to zero
+        // is a cup lift or a corrupt packet, not a tare, and must be filtered.
         WeightProcessor wp;
         installFakeClock(wp);
         QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
 
         wp.startExtraction();
-        wp.processWeight(120.0); m_fakeClock += 200;  // never passes through zero
-        wp.markExtractionStart();                     // flow begins → arm regardless
+        wp.processWeight(364.6); m_fakeClock += 200;
+        wp.processWeight(0.0);   m_fakeClock += 200;  // tare lands, exemption consumed
 
-        feedRising(wp, 120.0, 2.0, 4);
+        // Climb to a large-drink weight in steps under the 100 g spike threshold —
+        // a single jump to 150 g would itself be rejected as a spike, which is the
+        // filter working, not the thing under test.
+        wp.processWeight(60.0);  m_fakeClock += 200;
+        wp.processWeight(120.0); m_fakeClock += 200;
+        wp.processWeight(150.0); m_fakeClock += 200;
         const qsizetype countBefore = flowSpy.count();
 
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected.*1649"));
-        wp.processWeight(1649.0); m_fakeClock += 200;
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected.*0"));
+        wp.processWeight(0.0); m_fakeClock += 200;
+
+        QCOMPARE(flowSpy.count(), countBefore);  // rejected — no second free pass
+    }
+
+    void flowStartConsumesTareExemption() {
+        // Backstop for a scale that never reads near zero (an untared cup left on the
+        // platter): once flow begins there is no tare still to come, so a later drop to
+        // zero must be filtered rather than mistaken for one.
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);
+
+        wp.startExtraction();
+        wp.processWeight(150.0); m_fakeClock += 200;  // never passes through zero
+        wp.markExtractionStart();                     // flow begins → exemption spent
+        feedRising(wp, 150.0, 2.0, 4);
+        const qsizetype countBefore = flowSpy.count();
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Spike rejected.*0"));
+        wp.processWeight(0.0); m_fakeClock += 200;
 
         QCOMPARE(flowSpy.count(), countBefore);
     }
 
+    void preTareWeightDoesNotTriggerFrameExit() {
+        // The per-frame weight exit compares an ABSOLUTE weight to a threshold, and a
+        // pre-tare reading (loaded portafilter, ~364 g) clears any plausible exitWeight
+        // outright. Acting on it would skip a frame on a number the app has already
+        // decided not to trust — the zero point is mid-move. Unlike the SAW stop, this
+        // branch has no extractionElapsed guard, so it carries its own !m_awaitingTare.
+        WeightProcessor wp;
+        installFakeClock(wp);
+        QSignalSpy skipSpy(&wp, &WeightProcessor::skipFrame);
+
+        QVector<double> weights = {20.0, 0.0};  // frame 0 exits at 20 g
+        QVector<FrameExitCondition> conds = {{}, {}};
+        configureEspresso(wp, 0, 0, weights, conds);
+        wp.startExtraction();
+        // Mirrors production ordering: setTareComplete(true) rides in the SAME queued
+        // invocation as startExtraction() (see the comment at main.cpp's
+        // espressoCycleStarted handler), so it is already true while the scale is still
+        // reporting pre-tare weights. That is exactly why this window needs its own
+        // gate — the m_tareComplete check at the top of processWeight() does not cover it.
+        wp.setTareComplete(true);
+        wp.setCurrentFrame(0);
+
+        // Scale still reporting the loaded portafilter — way past the 20 g exit.
+        wp.processWeight(364.6); m_fakeClock += 200;
+        wp.processWeight(364.6); m_fakeClock += 200;
+        QCOMPARE(skipSpy.count(), 0);  // must NOT skip on an untared weight
+
+        // Tare lands, then a genuine 25 g crosses the exit for real.
+        wp.processWeight(0.0);  m_fakeClock += 200;
+        QCOMPARE(skipSpy.count(), 0);
+        wp.processWeight(25.0); m_fakeClock += 200;
+        QCOMPARE(skipSpy.count(), 1);  // ...and the gate does not block a real exit
+    }
+
     void retareStepIsNotASpike() {
         // resetForRetare() moves the zero point mid-preheat for exactly the same
-        // reason, so it re-enters the same hold-off.
+        // reason, so it re-arms the same one-shot exemption.
         WeightProcessor wp;
         installFakeClock(wp);
         QSignalSpy flowSpy(&wp, &WeightProcessor::flowRatesReady);


### PR DESCRIPTION
Three independent bugs found by reading 50 h of on-device debug log from the SM-X210 (app 2.0.0). None had visibly broken a shot yet — one came within about a minute of taking down Home Assistant for the day.

## 1. MQTT reconnect budget was spent on network outages, and running out was terminal

On 2026-07-25 the tablet lost Wi-Fi for ~7 minutes:

```
[25343.434] [Network] reachability changed -> Disconnected
[25343.561] [MdnsResolver] socket open FAILED ... errno= 19     ← ENODEV, no interface
[25343.556] MqttClient: Reconnection attempt 1 of 10
...
[25762.315] [Network] reachability changed -> Online
[25774.550] MqttClient: Reconnection attempt 10 of 10           ← connected, 12 s to spare
```

Attempts 1–9 were spent against an interface that could not route. Attempt **10 of 10** happened to land just after the network came back. One minute more and `MqttClient` would have latched `"max retries reached"` — and past the cap neither [`onInternalDisconnected`](src/network/mqttclient.cpp) nor `onInternalConnectionFailed` re-arms the timer, so nothing short of an app restart would have revived it.

`MqttClient` now watches `QNetworkInformation`:
- attempts are **not charged** while reachability is positively `Disconnected`
- regaining the network **resets the budget and reconnects** — the only path that can clear a latched cap
- only `Disconnected` counts as down; `Unknown` is treated as reachable, matching the reasoning already written down in `TranslationManager::scheduleLanguageUpdateCheck()`

The reachability signal already existed in `main.cpp` — it was logging-only, nobody consumed it. Where no backend is available the flag stays false forever and behaviour is exactly as before.

## 2. SAW learning was keyed to the saved scale, not the connected one

Both SAW sites read `settings.scaleType()` — the *nominated primary*. When the WiFi-primary Half Decent Scale is unreachable the app falls back to BLE and **deliberately preserves** the WiFi primary:

```
[69.144] Scale connected via WiFi-to-BLE fallback — preserving saved WiFi primary "wifi:hds.local"
```

So every BLE-served shot read and wrote the `decent-wifi` bucket. Four consecutive shots in this log did exactly that, committing into a pool now at a learned lag of 0.916 s against a 0.38 s default. The two transports are separate keys precisely *because* their latency differs, so this trains one transport's model on the other's timing.

Both sites now resolve the scale that actually served the shot.

## 3. The spike filter rejected the app's own tare

Every single shot:

```
[SAW-Worker] Spike rejected: weight= 0 last= 364.6      (×2)
[SAW-Worker] Spike filter reset after 3 consecutive rejections — accepting new baseline: -0.1
```

`startExtraction()` clears the baseline, but the tare is asynchronous **at the scale**: a pre-tare sample lands afterwards and becomes the new baseline, so the step to zero reads as a >100 g spike. The 3-rejection escape hatch then accepts the baseline it should never have questioned.

Nothing broke — this all happens during `EspressoPreheating` — but the filter spent that window blind and warned on the completely normal path.

The filter now holds off until the tare is observed to land (a near-zero sample) or, at the latest, until flow begins. The pour is the only window where a corrupt packet can cause the false SAW stop of #610, so that protection is unchanged where it actually matters.

## Testing

Full suite: **101 passed, 0 failed, 0 warnings.**

Four new cases in `tst_weightprocessor` cover the tare hold-off, both re-arming paths, and retare. **Verified by mutation** — reverting the production fix makes them fail with exactly the expected diagnostic, so they genuinely bite rather than merely passing.

`consecutiveRejectionsAutoReset` gains a `markExtractionStart()` call: its baseline starts at 8 g and never passes through zero, so it now models the in-extraction scenario it already claimed to test — matching its sibling `singleSpikeRejectedByRateFilter`.

**Fixes 1 and 2 have no unit coverage.** One depends on the `QNetworkInformation` singleton, the other lives in `main()`'s wiring lambdas; neither has an injection seam, and adding one is a production refactor beyond the scope of these fixes. Flagging that explicitly rather than implying the whole PR is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# What review added after the original three

Three review rounds followed, and each found something the previous one had introduced. Recorded here because the pattern is the point.

## 4. The MQTT fix's own flag caused the death it was written to prevent

Fix #1 above added `m_userRequestedDisconnect` so tapping Disconnect wouldn't immediately re-arm the retry loop. It was set **unconditionally** in `disconnectFromBroker()`, but only the `m_client && m_connected` branch produces the Paho callback that consumes it.

Disconnecting while *already* disconnected therefore latched it forever — and that is the obvious user action when the status reads `"Disconnected - reconnecting (3/10)..."`. Both the Home Automation button and `ShotServer::handleMqttDisconnect` call it unguarded. The next genuine broker drop then read as user-requested: timer stopped, nothing armed, MQTT dead until restart, **with no log at all** — quieter than the `"max retries reached"` it replaced.

Fixed on both failure paths: set the flag only on the branch that produces the callback, and clear it in `connectToBroker()` so a callback lost to `MQTTAsync_destroy()` can't strand it either.

**Root cause: `mqttclient.cpp` was in zero test targets.** Adds `tests/tst_mqttclient.cpp` — 11 tests driving the private slots through a `DECENZA_TESTING` friend, asserting on `QTimer` state with no broker and no waiting.

## 5. FlowScale may serve stop-at-weight, but must never train it

A virtual scale is permanently `isConnected()`, so the settling guard let it through and a scale-less shot trained the *saved physical scale's* pool from a flow-integral estimate.

FlowScale goes silent exactly when the gravity drip off the puck lands (`isFlowing()` is false by then), so it misses that contribution entirely and biases the pool **low** — SAW then stops late and overshoots once the real scale is reconnected.

## 6. The scale key is resolved once, in the class that owns the pools

Fix #2 corrected three of four SAW consumers but left the key a *required parameter*, so the fourth still had to know to ask. `SettingsCalibration` now resolves it, and the parameter is optional — omit it and a new call site is correct by default. `MachineState::activeScaleType()` becomes a forwarder for the QML property, not a second implementation.

This turned an 8-file change threading `MachineState*` through `AIManager` and `McpServer` into a one-line change in `dialing_blocks.cpp`, with neither touched.

## 7. Two pre-existing bugs

- **`sensorLag()` warned on every SAW read for six supported scales** — `difluid`, `eureka_precisa`, `smartchef`, `solo_barista`, `timemore`, `varia_aku` are canonical but unmeasured, so they were named "unknown" on every shot.
- **`reset_saw_learning_for_profile` could report success having cleared nothing** — it fell back to `settings->scaleType()` raw, so a legacy display name cleared `"<profile>::Decent Scale"` while the learner writes `"<profile>::decent"`, and echoed the un-normalized value back to the model.

## Verification

- Full suite **102 passed, 0 failed, 0 warnings**, rebased onto `e6d4a8c2` and re-run.
- Mutation-tested the two guards this rests on: removing `|| isFlowScale()` fails exactly one test; making `currentScaleType()` ignore the serving scale fails both the new resolution test and the pre-existing `activeScaleTypePrefersConnectedScaleOverSavedPrimary`.
- `everyScaleTypeIsInTheCanonicalVocabulary` guards `ScaleTypeIds::kAll`, which had no compiler help — a scale missing from it silently trains the saved primary's pool.

## One correction on the record

An earlier revision claimed FlowScale's learned drip was *structurally zero*. It isn't. `m_weightAtStop` is captured when SAW fires, but settling only begins at `endShot()`, so the stop-latency flow is still integrated. The conclusion was right and the reasoning was wrong; both the comment and commit message now carry the mechanism in §5.
