### PR TITLE
Hold TypeScript at 5.x until the obsidian-plugin tsconfig is migrated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,25 @@ updates:
     directory: "/obsidian-plugin"
     schedule:
       interval: "weekly"
+    # TypeScript majors are held back deliberately. package.json pins "^5", but
+    # note that the range in the manifest does NOT hold Dependabot back on its
+    # own — for version updates it REWRITES the declared range rather than
+    # staying inside it. PR #1642 did exactly that, turning "^5.4.0" into
+    # "^7.0.2". This ignore rule is the part that actually works; the "^5" in
+    # package.json only documents the intent for a human reading it.
+    #
+    # Why hold it: TS 7 removed `baseUrl` and `moduleResolution: node10`, so it
+    # rejects obsidian-plugin/tsconfig.json outright (TS5102 / TS5108) before
+    # typechecking anything, and once the config is migrated it surfaces four
+    # further TS2550 errors in src/charts/ShotChart.ts that TS 5.9.3 does not
+    # report against that same config. That is a migration, not a bump.
+    #
+    # It would also land silently: `npm run build` is esbuild-only and never
+    # invokes tsc, and no workflow touches obsidian-plugin/, so a tsconfig the
+    # pinned compiler cannot parse would break nothing visible. (`tsc --noEmit`
+    # is in fact already failing on main — 12 errors — for the same reason.)
+    #
+    # Remove this rule as part of doing the migration, not before it.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]

--- a/obsidian-plugin/package-lock.json
+++ b/obsidian-plugin/package-lock.json
@@ -13,8 +13,8 @@
             "devDependencies": {
                 "@types/node": "^26.1.1",
                 "esbuild": "^0.28.1",
-                "obsidian": "*",
-                "typescript": "^5.4.0"
+                "obsidian": "latest",
+                "typescript": "^5"
             }
         },
         "node_modules/@codemirror/state": {

--- a/obsidian-plugin/package.json
+++ b/obsidian-plugin/package.json
@@ -11,7 +11,7 @@
         "@types/node": "^26.1.1",
         "esbuild": "^0.28.1",
         "obsidian": "latest",
-        "typescript": "^5.4.0"
+        "typescript": "^5"
     },
     "dependencies": {
         "chart.js": "^4.4.1"


### PR DESCRIPTION
Follow-up to closing #1642. Holds `typescript` at 5.x for `obsidian-plugin/` until someone takes the TS 7 migration on deliberately.

## Why not just merge the bump

TS 7 rejects `obsidian-plugin/tsconfig.json` before it typechecks a single file — both options were removed in 7.0:

```
tsconfig.json(3,9):   error TS5102: Option 'baseUrl' has been removed.
tsconfig.json(10,29): error TS5108: Option 'moduleResolution=node10' has been removed.
```

Migrating the config (drop `baseUrl`, `moduleResolution: "bundler"`) gets past that and then surfaces four more:

```
src/charts/ShotChart.ts(120,17): error TS2550: Property 'includes' does not exist on type 'string[]'.
src/charts/ShotChart.ts(146,17): error TS2550: ...
src/charts/ShotChart.ts(172,17): error TS2550: ...
src/charts/ShotChart.ts(185,17): error TS2550: ...
```

Those are TS7-specific — TS 5.9.3 against the *identical* patched tsconfig does not report them. So it needs a `lib` decision and a config review, not a dependency line change.

## Why the ignore rule and not just the manifest range

**The `"^5"` in `package.json` does not hold Dependabot back.** For version updates it rewrites the declared range rather than staying inside it — #1642's own diff turned `"^5.4.0"` into `"^7.0.2"`. Left to itself it would do the same to `"^5"`.

The `ignore` entry in `.github/dependabot.yml` is the part that works. The manifest range is there to document the intent for a human reading `package.json`, and the config comment says so explicitly so the next person doesn't assume the pin is load-bearing.

## What makes this worth a rule rather than a one-time close

It would land silently. `npm run build` is esbuild-only and never invokes `tsc`, and nothing in `.github/workflows/` touches `obsidian-plugin/` — a tsconfig the pinned compiler cannot parse breaks nothing observable. (Related, pre-existing, not addressed here: `tsc --noEmit` already fails on `main` with 12 errors — 8 × `TS2354` from `importHelpers: true` with no `tslib` dependency, 3 × `TS2420` inside `node_modules/obsidian/obsidian.d.ts`, and one real `TS2531` at `src/charts/ShotChart.ts:241`.)

## Verification

- `npm ci` resolves `typescript` to 5.9.3 — the pin holds.
- `npm run build` produces the same 178.3kb `main.js` as `main`.
- `dependabot.yml` parses; the `ignore` entry reads back as expected.
- No Qt/C++ test run: this touches only `dependabot.yml` and the plugin's npm manifest, neither of which the suite compiles or reads.

## Note on the lockfile diff

`npm install --package-lock-only` also normalized the recorded `obsidian` range from `"*"` to `"latest"` in the root `devDependencies` block. That is npm 11 writing a more faithful record of what `package.json` already says; reverting it by hand would just make the lock disagree with the tool. Semantically inert either way.

## Removing this later

Delete the `ignore` block as part of doing the migration, not before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
