### PR TITLE
Stop the R2 teardown from dispatching through a destroyed vtable

### DIFF
--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -1834,6 +1834,12 @@ void BLEManager::clearSavedRefractometer() {
     // this call (main.cpp disconnects it, then destroys it), and was harmless
     // only because clearing the saved address above happens to make the stale
     // handler's re-kick no-op. It also emits refractometerConnectedChanged.
+    //
+    // This MUST stay ahead of disconnectRefractometerRequested: that emission
+    // is what arms the reconnect timer, and the handler's unconditional
+    // stop() — which runs first thing — is what tears it down again. Emitting
+    // the request first would stop the timer before this armed it, leaving a
+    // reconnect running for the device the user just forgot.
     setRefractometerDevice(nullptr);
     emit disconnectRefractometerRequested();
 }
@@ -1844,11 +1850,14 @@ void BLEManager::setRefractometerDevice(RefractometerDevice* device) {
                                     : QStringLiteral("none"),
              device ? QString::number(reinterpret_cast<quintptr>(device), 16)
                      : QStringLiteral("none"));
-    if (m_refractometerDevice) {
-        disconnect(m_refractometerDevice, nullptr, this, nullptr);
-    }
+    // Sever exactly the two handlers we installed — see the note on the
+    // Connection members. Disconnecting an already-severed or default
+    // Connection is a no-op, so this needs no null guard.
+    QObject::disconnect(m_refractometerConnectedConn);
+    QObject::disconnect(m_refractometerDestroyedConn);
     m_refractometerDevice = device;
     if (m_refractometerDevice) {
+        m_refractometerConnectedConn =
         connect(m_refractometerDevice, &RefractometerDevice::connectedChanged,
                 this, [this]() {
             emit refractometerConnectedChanged();
@@ -1872,9 +1881,12 @@ void BLEManager::setRefractometerDevice(RefractometerDevice* device) {
         // before the device dies, so in practice this only fires at app exit —
         // hence qDebug, not qWarning. A future path that forgets gets a log line
         // instead of a silently stale "connected".
+        m_refractometerDestroyedConn =
         connect(m_refractometerDevice, &QObject::destroyed, this, [this]() {
-            qDebug().noquote() << "[R2-diag] refractometer destroyed while still held "
-                                  "— reporting disconnected";
+            qDebug().noquote() << "[R2-diag] refractometer destroyed with the holder "
+                                  "still set — reporting disconnected. Expected at app "
+                                  "exit; anywhere else means a path skipped "
+                                  "setRefractometerDevice(nullptr).";
             emit refractometerConnectedChanged();
         });
     }

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -1798,6 +1798,8 @@ QVariantList BLEManager::discoveredRefractometers() const {
 }
 
 bool BLEManager::isRefractometerConnected() const {
+    // m_refractometerDevice is a QPointer on purpose — this line is the one a
+    // raw pointer crashes on during teardown. See its declaration.
     return m_refractometerDevice && m_refractometerDevice->isConnected();
 }
 
@@ -1826,8 +1828,13 @@ void BLEManager::setSavedRefractometerAddress(const QString& address, const QStr
 void BLEManager::clearSavedRefractometer() {
     m_savedRefractometerAddress.clear();
     m_savedRefractometerName.clear();
-    m_refractometerDevice = nullptr;
-    emit refractometerConnectedChanged();
+    // Through the setter, not a bare assignment: the setter is what severs the
+    // connectedChanged/destroyed handlers installed alongside the pointer. The
+    // bare assignment this replaced left them live on a device that outlives
+    // this call (main.cpp disconnects it, then destroys it), and was harmless
+    // only because clearing the saved address above happens to make the stale
+    // handler's re-kick no-op. It also emits refractometerConnectedChanged.
+    setRefractometerDevice(nullptr);
     emit disconnectRefractometerRequested();
 }
 
@@ -1852,6 +1859,23 @@ void BLEManager::setRefractometerDevice(RefractometerDevice* device) {
                 qDebug().noquote() << "[R2-diag] R2 dropped while hunting — re-kicking scan";
                 tryDirectConnectToRefractometer();
             }
+        });
+        // Own the "device went away" invariant rather than borrowing QML's. The
+        // QPointer above self-nulls, but nothing tells our observers — today the
+        // UI only stays correct because QQmlContext::setContextProperty quietly
+        // connects to destroyed() too, and its dropDestroyedQObject pokes the
+        // context notify, which re-runs the binding that reads us. That is
+        // load-bearing, invisible, and rests on a registration Qt's own source
+        // discourages; move `Refractometer` to a singleton some day and it
+        // vanishes silently. Emitting here means our property is right on our
+        // own terms. Every non-teardown path calls setRefractometerDevice(nullptr)
+        // before the device dies, so in practice this only fires at app exit —
+        // hence qDebug, not qWarning. A future path that forgets gets a log line
+        // instead of a silently stale "connected".
+        connect(m_refractometerDevice, &QObject::destroyed, this, [this]() {
+            qDebug().noquote() << "[R2-diag] refractometer destroyed while still held "
+                                  "— reporting disconnected";
+            emit refractometerConnectedChanged();
         });
     }
     emit refractometerConnectedChanged();

--- a/src/ble/blemanager.cpp
+++ b/src/ble/blemanager.cpp
@@ -1833,7 +1833,7 @@ void BLEManager::clearSavedRefractometer() {
 
 void BLEManager::setRefractometerDevice(RefractometerDevice* device) {
     qDebug().noquote() << QString("[R2-diag] setRefractometerDevice old=%1 new=%2")
-        .arg(m_refractometerDevice ? QString::number(reinterpret_cast<quintptr>(m_refractometerDevice), 16)
+        .arg(m_refractometerDevice ? QString::number(reinterpret_cast<quintptr>(m_refractometerDevice.data()), 16)
                                     : QStringLiteral("none"),
              device ? QString::number(reinterpret_cast<quintptr>(device), 16)
                      : QStringLiteral("none"));

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -12,6 +12,7 @@
 #include <QFile>
 #include <QDateTime>
 #include <QMutex>
+#include <QPointer>
 #include <atomic>
 
 #include "blecapability.h"
@@ -858,7 +859,18 @@ private:
     QList<QBluetoothDeviceInfo> m_refractometerDevices;
     QString m_savedRefractometerAddress;
     QString m_savedRefractometerName;
-    RefractometerDevice* m_refractometerDevice = nullptr;
+    // QPointer, not a raw pointer: main() owns the device in a unique_ptr declared
+    // AFTER the QML engine, so at teardown it dies while the engine — and every
+    // binding reading `BLEManager.refractometerConnected` — is still live. Its
+    // ~QObject emits destroyed(), QML drops the `Refractometer` context property,
+    // and the resulting binding re-evaluation calls isRefractometerConnected() on
+    // an object whose derived part is already gone. Through a raw pointer that is
+    // a pure-virtual dispatch on a rewound vptr: it indexes past QObject's vtable
+    // into adjacent data and jumps there (SIGBUS, instruction-abort). QObject's
+    // destructor zeroes the shared refcount *before* emitting destroyed()
+    // (qobject.cpp:1073 vs 1079), so a QPointer already reads null at that point
+    // and the getter simply reports "not connected".
+    QPointer<RefractometerDevice> m_refractometerDevice;
 
     // Scale debug log
     QStringList m_scaleLogMessages;

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -863,13 +863,18 @@ private:
     // die. Same reason MachineState::m_scale and ShotTimingController::m_scale
     // are QPointer (noted at the end of main()) — house style, not a one-off.
     //
-    // What made it necessary: main() declares its `refractometer` unique_ptr
-    // AFTER the QML engine, breaking the convention stated at the engine's own
-    // declaration in main.cpp ("declared before the engine ... so it outlives
-    // the engine at scope unwind"). Treat that as a defect that has not been
-    // fixed yet, not as a fact of life. At scope unwind the device therefore
-    // dies while the engine and every binding reading
-    // `BLEManager.refractometerConnected` are still live: ~QObject emits
+    // What made it necessary: main() used to declare its `refractometer`
+    // unique_ptr AFTER the QML engine, breaking the convention stated at the
+    // engine's own declaration ("declared before the engine ... so it outlives
+    // the engine at scope unwind"). That has since been fixed — the declaration
+    // now sits above the engine — so the specific crash below is no longer
+    // reachable at app exit. This stays because it is the second line of
+    // defence, and because it still covers the runtime recreate path (a new
+    // device discovered while one is live) that ordering does nothing for.
+    //
+    // What the ordering bug looked like, so nobody reintroduces it: the device
+    // died while the engine and every binding reading
+    // `BLEManager.refractometerConnected` were still live: ~QObject emits
     // destroyed(), QML drops the `Refractometer` context property, and the
     // resulting binding re-evaluation lands in isRefractometerConnected() on an
     // object whose derived part is already gone. Through a raw pointer, that

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -859,17 +859,37 @@ private:
     QList<QBluetoothDeviceInfo> m_refractometerDevices;
     QString m_savedRefractometerAddress;
     QString m_savedRefractometerName;
-    // QPointer, not a raw pointer: main() owns the device in a unique_ptr declared
-    // AFTER the QML engine, so at teardown it dies while the engine — and every
-    // binding reading `BLEManager.refractometerConnected` — is still live. Its
-    // ~QObject emits destroyed(), QML drops the `Refractometer` context property,
-    // and the resulting binding re-evaluation calls isRefractometerConnected() on
-    // an object whose derived part is already gone. Through a raw pointer that is
-    // a pure-virtual dispatch on a rewound vptr: it indexes past QObject's vtable
-    // into adjacent data and jumps there (SIGBUS, instruction-abort). QObject's
-    // destructor zeroes the shared refcount *before* emitting destroyed()
-    // (qobject.cpp:1073 vs 1079), so a QPointer already reads null at that point
-    // and the getter simply reports "not connected".
+    // QPointer, not a raw pointer: we do not own this device and cannot see it
+    // die. Same reason MachineState::m_scale and ShotTimingController::m_scale
+    // are QPointer (noted at the end of main()) — house style, not a one-off.
+    //
+    // What made it necessary: main() declares its `refractometer` unique_ptr
+    // AFTER the QML engine, breaking the convention stated at the engine's own
+    // declaration in main.cpp ("declared before the engine ... so it outlives
+    // the engine at scope unwind"). Treat that as a defect that has not been
+    // fixed yet, not as a fact of life. At scope unwind the device therefore
+    // dies while the engine and every binding reading
+    // `BLEManager.refractometerConnected` are still live: ~QObject emits
+    // destroyed(), QML drops the `Refractometer` context property, and the
+    // resulting binding re-evaluation lands in isRefractometerConnected() on an
+    // object whose derived part is already gone. Through a raw pointer, that
+    // call is a pure-virtual dispatch on a vptr already rewound to QObject's:
+    // it indexes past the end of QObject's vtable into adjacent data and jumps
+    // there. On macOS/arm64 that was a SIGBUS instruction-abort with the PC
+    // inside QtCore's non-executable __DATA; other platforms may land on a
+    // plausible-looking pointer and not trap at all, so "no crash here" is not
+    // evidence the fault is gone.
+    //
+    // Why QPointer answers it: ~QObject stores 0 into sharedRefcount->strongref
+    // before the `emit destroyed(this)` a few lines below (qtbase qobject.cpp,
+    // verified against Qt 6.11.1), so the pointer already reads null when that
+    // binding runs and the getter just reports "not connected".
+    //
+    // Bound worth knowing: this only covers the window from ~QObject onward. A
+    // signal emitted from a concrete driver's OWN destructor body would still
+    // find a non-null QPointer and a half-destroyed object. That window is
+    // empty today — neither transport emits synchronously from
+    // disconnectFromDevice() — but it is not something QPointer protects.
     QPointer<RefractometerDevice> m_refractometerDevice;
 
     // Scale debug log

--- a/src/ble/blemanager.h
+++ b/src/ble/blemanager.h
@@ -897,6 +897,18 @@ private:
     // disconnectFromDevice() — but it is not something QPointer protects.
     QPointer<RefractometerDevice> m_refractometerDevice;
 
+    // Handles for the two connections setRefractometerDevice() installs, so it
+    // can sever exactly those. It must NOT use a blanket
+    // disconnect(device, nullptr, this, nullptr): main.cpp also connects the
+    // device's logMessage to appendScaleLog and errorOccurred to our
+    // errorOccurred, and those have to survive until the device is actually
+    // destroyed. Forget nulls the holder BEFORE disconnecting the device (that
+    // order is load-bearing — see the timer-stop note on
+    // disconnectRefractometerRequested in main.cpp), so a blanket disconnect
+    // there silently swallowed every log line the disconnect itself produced.
+    QMetaObject::Connection m_refractometerConnectedConn;
+    QMetaObject::Connection m_refractometerDestroyedConn;
+
     // Scale debug log
     QStringList m_scaleLogMessages;
     QString m_scaleLogFilePath;

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -34,7 +34,6 @@
 #include "../ble/blemanager.h"
 #include "../ble/scaledevice.h"
 #include "../ble/scales/flowscale.h"
-#include "../ble/refractometers/refractometerdevice.h"
 #include <QGuiApplication>
 #include <QClipboard>
 #include <cmath>
@@ -4431,21 +4430,6 @@ void MainController::processVisualizerReconciliation()
     qDebug() << "MainController: starting one-time Visualizer reconciliation (window"
              << kReconcileWindowDays << "days)";
     m_visualizer->fetchShotListSince(windowStartEpoch);
-}
-
-void MainController::setRefractometer(RefractometerDevice* refractometer) {
-    // Disconnect old signal chain before connecting new one
-    if (m_refractometer) {
-        disconnect(m_refractometer, nullptr, this, nullptr);
-    }
-    m_refractometer = refractometer;
-    if (!m_refractometer) return;
-
-    // Non-mutating log only. PostShotReviewPage owns context-gated capture; do
-    // not write to Settings here — device-initiated readings would leak forward.
-    connect(m_refractometer, &RefractometerDevice::tdsChanged, this, [](double tds) {
-        qDebug() << "[Refractometer] tdsChanged" << tds;
-    });
 }
 
 

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -4433,6 +4433,10 @@ void MainController::processVisualizerReconciliation()
     m_visualizer->fetchShotListSince(windowStartEpoch);
 }
 
+RefractometerDevice* MainController::refractometer() const {
+    return m_refractometer.data();
+}
+
 void MainController::setRefractometer(RefractometerDevice* refractometer) {
     // Disconnect old signal chain before connecting new one
     if (m_refractometer) {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -4433,10 +4433,6 @@ void MainController::processVisualizerReconciliation()
     m_visualizer->fetchShotListSince(windowStartEpoch);
 }
 
-RefractometerDevice* MainController::refractometer() const {
-    return m_refractometer.data();
-}
-
 void MainController::setRefractometer(RefractometerDevice* refractometer) {
     // Disconnect old signal chain before connecting new one
     if (m_refractometer) {

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QVariantList>
 #include <QMap>
+#include <QPointer>
 #include <QTimer>
 #include "profilemanager.h"
 #include "recipeselectionmodel.h"
@@ -170,7 +171,10 @@ public:
     void setBLEManager(BLEManager* bleManager) { m_bleManager = bleManager; }
     void setFlowScale(FlowScale* flowScale) { m_flowScale = flowScale; }
     void setRefractometer(RefractometerDevice* refractometer);
-    RefractometerDevice* refractometer() const { return m_refractometer; }
+    // Out-of-line: m_refractometer is a QPointer and RefractometerDevice is only
+    // forward-declared here. Resolving the QPointer inline would need the full
+    // type in this header, which every translation unit including it would pay for.
+    RefractometerDevice* refractometer() const;
     void setTimingController(ShotTimingController* controller) { m_timingController = controller; }
     void setBackupManager(DatabaseBackupManager* backupManager) { m_backupManager = backupManager; }
     ShotDataModel* shotDataModel() const { return m_shotDataModel; }
@@ -477,7 +481,10 @@ private:
     ShotTimingController* m_timingController = nullptr;
     BLEManager* m_bleManager = nullptr;
     FlowScale* m_flowScale = nullptr;  // Shadow FlowScale for comparison logging
-    RefractometerDevice* m_refractometer = nullptr;
+    // QPointer for the same teardown reason as BLEManager::m_refractometerDevice —
+    // main() destroys the device while the QML engine is still live. See the
+    // comment there for the full chain.
+    QPointer<RefractometerDevice> m_refractometer;
 
     SteamDataModel* m_steamDataModel = nullptr;
     SteamHealthTracker* m_steamHealthTracker = nullptr;

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -3,7 +3,6 @@
 #include <QObject>
 #include <QVariantList>
 #include <QMap>
-#include <QPointer>
 #include <QTimer>
 #include "profilemanager.h"
 #include "recipeselectionmodel.h"
@@ -41,7 +40,6 @@ class DE1Device;
 class MachineState;
 class BLEManager;
 class FlowScale;
-class RefractometerDevice;
 class ProfileStorage;
 class ShotDebugLogger;
 class LocationProvider;
@@ -170,7 +168,6 @@ public:
     }
     void setBLEManager(BLEManager* bleManager) { m_bleManager = bleManager; }
     void setFlowScale(FlowScale* flowScale) { m_flowScale = flowScale; }
-    void setRefractometer(RefractometerDevice* refractometer);
     void setTimingController(ShotTimingController* controller) { m_timingController = controller; }
     void setBackupManager(DatabaseBackupManager* backupManager) { m_backupManager = backupManager; }
     ShotDataModel* shotDataModel() const { return m_shotDataModel; }
@@ -477,12 +474,6 @@ private:
     ShotTimingController* m_timingController = nullptr;
     BLEManager* m_bleManager = nullptr;
     FlowScale* m_flowScale = nullptr;  // Shadow FlowScale for comparison logging
-    // QPointer for symmetry with BLEManager::m_refractometerDevice: same
-    // ownership shape (main() destroys the device at scope unwind while we still
-    // hold it), so this can dangle the same way. Not the same fault, though —
-    // no QML binding reaches this member, so it has no path to the crash
-    // documented over there. Defensive, not load-bearing.
-    QPointer<RefractometerDevice> m_refractometer;
 
     SteamDataModel* m_steamDataModel = nullptr;
     SteamHealthTracker* m_steamHealthTracker = nullptr;

--- a/src/controllers/maincontroller.h
+++ b/src/controllers/maincontroller.h
@@ -171,10 +171,6 @@ public:
     void setBLEManager(BLEManager* bleManager) { m_bleManager = bleManager; }
     void setFlowScale(FlowScale* flowScale) { m_flowScale = flowScale; }
     void setRefractometer(RefractometerDevice* refractometer);
-    // Out-of-line: m_refractometer is a QPointer and RefractometerDevice is only
-    // forward-declared here. Resolving the QPointer inline would need the full
-    // type in this header, which every translation unit including it would pay for.
-    RefractometerDevice* refractometer() const;
     void setTimingController(ShotTimingController* controller) { m_timingController = controller; }
     void setBackupManager(DatabaseBackupManager* backupManager) { m_backupManager = backupManager; }
     ShotDataModel* shotDataModel() const { return m_shotDataModel; }
@@ -481,9 +477,11 @@ private:
     ShotTimingController* m_timingController = nullptr;
     BLEManager* m_bleManager = nullptr;
     FlowScale* m_flowScale = nullptr;  // Shadow FlowScale for comparison logging
-    // QPointer for the same teardown reason as BLEManager::m_refractometerDevice —
-    // main() destroys the device while the QML engine is still live. See the
-    // comment there for the full chain.
+    // QPointer for symmetry with BLEManager::m_refractometerDevice: same
+    // ownership shape (main() destroys the device at scope unwind while we still
+    // hold it), so this can dangle the same way. Not the same fault, though —
+    // no QML binding reaches this member, so it has no path to the crash
+    // documented over there. Defensive, not load-bearing.
     QPointer<RefractometerDevice> m_refractometer;
 
     SteamDataModel* m_steamDataModel = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1933,6 +1933,16 @@ int main(int argc, char *argv[])
     // so it outlives the engine at scope unwind.
     TemperatureDisplayBridge temperatureDisplayBridge;
 
+    // Same rule, and this one was learned the hard way. The refractometer is
+    // wired up ~950 lines below, next to the rest of its BLE handling, but the
+    // unique_ptr lives HERE so the device outlives the engine. Declared down
+    // there it was destroyed first, and ~QObject's destroyed() reached a live
+    // QML binding on BLEManager.refractometerConnected, which dispatched a pure
+    // virtual on the half-destroyed object — a SIGBUS on quit. Keep the
+    // declaration above `engine`; the QPointer in BLEManager is the second
+    // line of defence, not a licence to move this back down.
+    std::unique_ptr<RefractometerDevice> refractometer;
+
     // Set up QML engine
     QQmlApplicationEngine engine;
     checkpoint("QML engine created");
@@ -2066,8 +2076,8 @@ int main(int argc, char *argv[])
     // by reference.
     //
     // Stack objects destruct in reverse declaration order, so everything declared
-    // after `engine` (the reconnect state just above, `refractometer` further
-    // down) is destroyed BEFORE `engine` is. The senders those handlers hang off
+    // after `engine` (the reconnect state just above) is destroyed BEFORE
+    // `engine` is. The senders those handlers hang off
     // — app, bleManager, machineState, screensaverManager, the scale — are all
     // declared above `engine` and so outlive the very locals their handlers write
     // to. A signal emitted during teardown then runs a lambda over dead stack.
@@ -2081,7 +2091,7 @@ int main(int argc, char *argv[])
     // when it dies. The explicit reset() after app.exec() is what does the work
     // and must not be dropped: it runs ahead of every local's destructor, whereas
     // this unique_ptr's own destructor fires at THIS declaration point and so
-    // would already be too late for anything declared below it (`refractometer`).
+    // would already be too late for anything declared below it.
     //
     // Handlers whose sender IS one of these locals (the reconnect timers) need no
     // guard — the connection already dies with the sender.
@@ -2873,14 +2883,8 @@ int main(int argc, char *argv[])
     });
 
     // === Refractometer (DiFluid R1 / R2) ===
-    // NOTE: declared AFTER `engine`, unlike the other context-property backing
-    // objects (see the convention stated at the engine's declaration). It is
-    // therefore destroyed while the engine and its bindings are still live, and
-    // BLEManager/MainController hold it via QPointer for exactly that reason —
-    // see BLEManager::m_refractometerDevice. Moving this above `engine` would
-    // remove the hazard at the source; until then, do not add a raw-pointer
-    // holder for this device.
-    std::unique_ptr<RefractometerDevice> refractometer;
+    // The `refractometer` unique_ptr itself is declared up with the engine —
+    // see the note there for why the order matters.
     engine.rootContext()->setContextProperty("Refractometer", nullptr);
 
     // Restore saved refractometer address for auto-reconnect
@@ -4261,18 +4265,21 @@ int main(int argc, char *argv[])
             physicalScale->disconnectFromScale();
         }
 
-        // Note: no need to null context properties here — but NOT because every
-        // C++ object outlives the engine. Most are declared before it and do;
-        // the exceptions (`refractometer` below, `de1SimulatorPtr` — see the
-        // note after app.exec()) are declared after it and die FIRST, while
-        // bindings that read them are still live. This comment used to claim
-        // the blanket guarantee, and a refractometer teardown crash proved it
-        // wrong. What makes nulling unnecessary is narrower: QML drops a
-        // context property itself when its object emits destroyed(), and the
-        // C++ side holds those objects via QPointer (see
-        // BLEManager::m_refractometerDevice) so it self-nulls at the same
-        // moment. A new context-property object held by a raw pointer would
-        // need one of those two, not this comment's blessing.
+        // Note: no need to null context properties here — but NOT because of a
+        // blanket "everything is declared before the engine" guarantee. This
+        // comment used to claim exactly that, and a refractometer teardown
+        // crash proved it wrong: the device was declared AFTER the engine, so
+        // it died first, while bindings reading it were still live.
+        //
+        // What actually holds: most context-property backing objects are
+        // declared above `engine` and so outlive it (`refractometer` now among
+        // them). Where that is not true — `de1SimulatorPtr`, see the note after
+        // app.exec(); also GHCSimulator and FlowCalibrationModel further down —
+        // safety comes from QML dropping a context property itself when its
+        // object emits destroyed(), plus the C++ side holding it via QPointer
+        // so it self-nulls at the same moment (BLEManager::m_refractometerDevice
+        // is the worked example). A new context-property object declared after
+        // the engine and held by a raw pointer has neither, and would need one.
 
         // Disable Qt's accessibility bridge before window destruction
         // This prevents iOS crash (SIGBUS) where the accessibility system tries to

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2873,6 +2873,13 @@ int main(int argc, char *argv[])
     });
 
     // === Refractometer (DiFluid R1 / R2) ===
+    // NOTE: declared AFTER `engine`, unlike the other context-property backing
+    // objects (see the convention stated at the engine's declaration). It is
+    // therefore destroyed while the engine and its bindings are still live, and
+    // BLEManager/MainController hold it via QPointer for exactly that reason —
+    // see BLEManager::m_refractometerDevice. Moving this above `engine` would
+    // remove the hazard at the source; until then, do not add a raw-pointer
+    // holder for this device.
     std::unique_ptr<RefractometerDevice> refractometer;
     engine.rootContext()->setContextProperty("Refractometer", nullptr);
 
@@ -4259,9 +4266,18 @@ int main(int argc, char *argv[])
             physicalScale->disconnectFromScale();
         }
 
-        // Note: No need to null context properties here. All C++ objects are
-        // stack-allocated before the QML engine, so reverse destruction order
-        // guarantees the engine (and all QML items) is destroyed first.
+        // Note: no need to null context properties here — but NOT because every
+        // C++ object outlives the engine. Most are declared before it and do;
+        // the exceptions (`refractometer` below, `de1SimulatorPtr` — see the
+        // note after app.exec()) are declared after it and die FIRST, while
+        // bindings that read them are still live. This comment used to claim
+        // the blanket guarantee, and a refractometer teardown crash proved it
+        // wrong. What makes nulling unnecessary is narrower: QML drops a
+        // context property itself when its object emits destroyed(), and the
+        // C++ side holds those objects via QPointer (see
+        // BLEManager::m_refractometerDevice) so it self-nulls at the same
+        // moment. A new context-property object held by a raw pointer would
+        // need one of those two, not this comment's blessing.
 
         // Disable Qt's accessibility bridge before window destruction
         // This prevents iOS crash (SIGBUS) where the accessibility system tries to

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2972,13 +2972,6 @@ int main(int argc, char *argv[])
     QObject::connect(&bleManager, &BLEManager::disconnectRefractometerRequested, handlerScope.get(),
                      [&refractometer, &engine, &bleManager,
                       &refractometerReconnectTimer, &refractometerReconnectAttempt]() {
-        // Stop any pending/persistent reconnect — the user forgot this device.
-        // Unconditional (mirrors the scale's disconnectScaleRequested) so a
-        // timer armed by the clearSavedRefractometer → refractometerConnected-
-        // Changed emission is torn down deterministically rather than relying
-        // on the next-tick saved-address guard.
-        refractometerReconnectTimer.stop();
-        refractometerReconnectAttempt = 0;
         if (refractometer) {
             qDebug() << "[Refractometer] Forget requested, disconnecting";
             refractometer->disconnectFromDevice();
@@ -2986,6 +2979,23 @@ int main(int argc, char *argv[])
             engine.rootContext()->setContextProperty("Refractometer", nullptr);
             refractometer.reset();
         }
+        // Stop any pending/persistent reconnect — the user forgot this device.
+        // Unconditional (mirrors the scale's disconnectScaleRequested).
+        //
+        // LAST, not first. Everything above emits refractometerConnectedChanged
+        // — disconnectFromDevice() via the device's own connectedChanged, and
+        // setRefractometerDevice(nullptr) directly — and each of those re-arms
+        // this tick through the connectedChanged handler below. Stopping first
+        // therefore stopped a timer that was immediately re-armed: the debug log
+        // showed "scheduled first retry in 5000 ms" on both sides of the stop,
+        // with the tick surviving Forget and only self-cancelling ~5 s later on
+        // the next-tick saved-address guard. This comment used to claim the stop
+        // made teardown deterministic "rather than relying on the next-tick
+        // saved-address guard"; it relied on it. Stopping here makes the claim
+        // true — clearSavedRefractometer() emits this request last, so nothing
+        // runs after us to re-arm.
+        refractometerReconnectTimer.stop();
+        refractometerReconnectAttempt = 0;
     });
 
     QObject::connect(&refractometerReconnectTimer, &QTimer::timeout,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2890,7 +2890,7 @@ int main(int argc, char *argv[])
     }
 
     QObject::connect(&bleManager, &BLEManager::refractometerDiscovered, handlerScope.get(),
-                     [&refractometer, &mainController, &engine, &bleManager, &settings](const QBluetoothDeviceInfo& device) {
+                     [&refractometer, &engine, &bleManager, &settings](const QBluetoothDeviceInfo& device) {
         qDebug().noquote() << QString("[R2-diag] refractometerDiscovered dev=%1 existingInstance=%2 existingConnected=%3")
             .arg(getDeviceIdentifier(device),
                  refractometer ? QString::number(reinterpret_cast<quintptr>(refractometer.get()), 16)
@@ -2912,7 +2912,6 @@ int main(int argc, char *argv[])
                 .arg(QString::number(reinterpret_cast<quintptr>(refractometer.get()), 16),
                      refractometer->isConnected() ? QStringLiteral("true") : QStringLiteral("false"));
             refractometer->disconnectFromDevice();
-            mainController.setRefractometer(nullptr);
             bleManager.setRefractometerDevice(nullptr);
             engine.rootContext()->setContextProperty("Refractometer", nullptr);
         }
@@ -2938,9 +2937,6 @@ int main(int argc, char *argv[])
         // the scale connection-priority / feed-stall machinery off this link.
         transport->setConnectionPriorityManaged(false);
         refractometer->connectToDevice(device);
-
-        // Wire to MainController for TDS → Settings pipeline
-        mainController.setRefractometer(refractometer.get());
 
         // Tell BLEManager about the live device (for isRefractometerConnected property)
         bleManager.setRefractometerDevice(refractometer.get());
@@ -2970,7 +2966,7 @@ int main(int argc, char *argv[])
 
     // Handle Forget Refractometer — disconnect and clean up
     QObject::connect(&bleManager, &BLEManager::disconnectRefractometerRequested, handlerScope.get(),
-                     [&refractometer, &mainController, &engine, &bleManager,
+                     [&refractometer, &engine, &bleManager,
                       &refractometerReconnectTimer, &refractometerReconnectAttempt]() {
         // Stop any pending/persistent reconnect — the user forgot this device.
         // Unconditional (mirrors the scale's disconnectScaleRequested) so a
@@ -2982,7 +2978,6 @@ int main(int argc, char *argv[])
         if (refractometer) {
             qDebug() << "[Refractometer] Forget requested, disconnecting";
             refractometer->disconnectFromDevice();
-            mainController.setRefractometer(nullptr);
             bleManager.setRefractometerDevice(nullptr);
             engine.rootContext()->setContextProperty("Refractometer", nullptr);
             refractometer.reset();


### PR DESCRIPTION
## The crash

Quitting the app with a DiFluid R2 connected and the post-shot review page open crashed on exit:

```
Exception Type:  EXC_BAD_ACCESS (SIGBUS)
Exception Subtype: KERN_PROTECTION_FAILURE at 0x000000011e8b1a68
esr: 0x8200000f (Instruction Abort) Permission fault

--->  __DATA   11e8ac000-11e8b8000  rw-/rw-  .../QtCore.framework/Versions/A/QtCore
```

The PC is inside QtCore's `__DATA` segment, which is not executable — the CPU tried to *execute* data. Frame #0's symbol (`QMetaTypeInterfaceWrapper<QString>::metaType`) is meaningless; it is just the nearest preceding symbol to a garbage address.

## Why

```
~unique_ptr<RefractometerDevice>              <- `refractometer`, declared AFTER `engine`
  ~DiFluidR2 -> ~RefractometerDevice -> ~QObject
    emit destroyed(this)                       qobject.cpp:1079
      QQmlContextPrivate::dropDestroyedQObject <- the `Refractometer` context property
        QQmlBinding::update -> QV4 ... getterQObject
          BLEManager::isRefractometerConnected()
            m_refractometerDevice->isConnected()   <- pure virtual, raw pointer
```

Reverse destruction order killed the device while the engine and every binding reading `BLEManager.refractometerConnected` were still live. `isConnected()` is pure virtual on `RefractometerDevice`; by the time `~QObject` runs the derived parts are gone and the vptr points at `QObject`'s vtable — much shorter — so the dispatch indexes off the end of it into adjacent data and jumps there.

The binding is [`PostShotReviewPage.qml:470`](../blob/main/qml/pages/PostShotReviewPage.qml#L470), a `Connections.target` that reads both `Refractometer` and `BLEManager.refractometerConnected`.

## The fix, in layers

**1. Fix the ordering at its source.** The `refractometer` unique_ptr now sits above `QQmlApplicationEngine engine`, with the other context-property backing objects — matching the convention already stated at the engine's own declaration, and already obeyed by `physicalScale`. That is precisely why the scale, which has the identical raw-pointer/virtual-dispatch shape in `BLEManager::m_scaleDevice`, has never produced this crash. Only the declaration moves; the wiring stays with the rest of the BLE handling, and a default-constructed null `unique_ptr` makes the move inert.

**2. Keep a QPointer in BLEManager.** Second line of defence at exit, but still the *first* for the runtime recreate path — a new device discovered while one is live — which ordering does nothing for. `~QObject` zeroes `sharedRefcount->strongref` before the `emit destroyed(this)` a few lines below (verified against Qt 6.11.1), so the pointer reads null when that binding runs and the getter reports "not connected".

**3. Make BLEManager report the dangle itself.** `setRefractometerDevice()` now connects to the device's `destroyed()` and emits `refractometerConnectedChanged`. Previously the UI stayed correct only because `QQmlContext::setContextProperty` quietly connects to `destroyed()` too and pokes the context notify — load-bearing, invisible, and tied to a registration Qt's own source discourages. Every non-teardown path nulls the holder first, so this fires only at exit; `qDebug`, not `qWarning`, and a future path that forgets gets a log line instead of a silently stale "connected".

**4. Route `clearSavedRefractometer()` through its own setter** instead of bare-assigning the member, so the handlers installed alongside the pointer actually get severed.

**5. Delete `MainController`'s refractometer entirely.** The device is needed in exactly two places and neither goes through `MainController`: the Connections settings tab discovers and pairs it via `BLEManager`, and the review page reads it via the `Refractometer` context property. Its whole involvement was a member, a setter, a forward declaration and three call sites in `main()`, existing to install one debug line on `tdsChanged` — which both drivers already log at the right layer with more context ([`difluidr1.cpp:406`](../blob/main/src/ble/refractometers/difluidr1.cpp#L406) logs temperature, Brix, RI and raw; [`difluidr2.cpp:436`](../blob/main/src/ble/refractometers/difluidr2.cpp#L436) logs value and raw).

## Comments corrected, not left stale

- The `aboutToQuit` note claimed every C++ object is declared before the engine and so outlives it. This crash disproved it, and the file already contradicted itself 20 lines below re: `de1SimulatorPtr`. It now names the exceptions that actually remain.
- `blemanager.h` describes the ordering bug in the past tense and says why the QPointer stays.
- The `handlerScope` comment no longer lists `refractometer` among the locals declared below the engine.

## Relationship to #1634

Found while checking whether [#1634](https://github.com/Kulitorum/Decenza/issues/1634) still reproduces. **It does not** — the `handlerScope` guard held, and ASan reported no use-after-scope. That report predates the guard landing on `main` in 5a1bc68a. This is a distinct fault the same repro surfaced, fixed here on its own terms. #1634 is closed.

## Testing

- Full local suite via Qt Creator: **102 passed, 0 failed, 0 skipped**, no warnings.
- Debug build is ASan/UBSan-instrumented; clean with 0 warnings.
- **Confirmed on hardware at the final commit**, four scenarios, all pass:
  1. Original repro — R2 connected, post-shot review page open, quit. No crash. This is the path the reorder changed most: the device now outlives the engine, so `Component.onDestruction` calls `disconnectFromDevice()` on a live object, which never happened before.
  2. Forget (Settings → Connections). Disconnects and clears normally; no reconnect attempted afterwards.
  3. Re-pair after Forget, reading taken. Log shows a clean instance swap — old `60d0003d3bd0` released, new `60d000e69bb0` connected — with no dangling holder.
  4. R2 powered off mid-session with the review page open; hunt re-kicks the scan chain.

## Review

Reviewed by four agents (code, comments, silent-failure, test-coverage). No blockers. Findings on dead code, comment rot, and the borrowed QML invariant are folded in above. No regression test: the pre-fix failure is UB that may or may not trap, and `-fsanitize=vptr` is disabled project-wide (see `TESTING.md`), so a test could not be relied on to fail — the "test that cannot fail" the testing doc warns about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

