### PR TITLE
Fix the DiFluid weight parse; honour the R2's temperature unit; connect the Microbalance Ti

### DIFF
--- a/openspec/changes/expand-difluid-r2-protocol/.openspec.yaml
+++ b/openspec/changes/expand-difluid-r2-protocol/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/expand-difluid-r2-protocol/design.md
+++ b/openspec/changes/expand-difluid-r2-protocol/design.md
@@ -1,0 +1,84 @@
+## Context
+
+`src/ble/refractometers/difluidr2.cpp` implements the DF-DF framing, checksum, and a subset of the R2's command set. It handles Func 0 (device info, partially), Func 1 (temperature unit only, as of [#1656](https://github.com/Kulitorum/Decenza/pull/1656)), and Func 3 (device action). Result parsing is already complete for packs 0–4, including the averaged result in pack 3 and the averaged temperature/counter in pack 4 — code written against the spec but never exercised, because the driver only ever sends a single test.
+
+Two independent references exist for the parts we do not implement: DiFluid's `protocolR2.md`, and Beanconqueror's `difluidR2Refractometer.ts` + `diFluid/protocol.ts`, which are a working implementation of the same device with a full enum table. Where they agree, the behaviour is settled and no reverse engineering is needed.
+
+Constraints that shape this:
+
+- **`RefractometerDevice` is an abstraction over two devices.** `DiFluidR1` shares the interface and has no averaging. Anything added to the base class must have a sane refusal for R1.
+- **"Never use timers as guards" (CLAUDE.md).** The existing 15-second `m_measurementTimer` is a deliberate, documented exception — a device that goes silent emits no event, so no event-based mechanism can detect it. That justification covers a liveness watchdog; it does not cover using the same timer as a ceiling on run duration, which is what it currently is.
+- **The project's bias is against new user-facing settings.** Smarter defaults first.
+- **Field logs are consumed by AI assistants over MCP.** Log text is an interface, not decoration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Averaged readings available to users, with the measurement lifecycle correct for runs longer than a single test.
+- Status and error logging that identifies what the device is actually doing.
+- Serial number captured, as input to the unresolved Brix-vs-TDS variant question.
+- No change to what a default installation does when the user presses the existing TDS control.
+
+**Non-Goals:**
+
+- Calibration. The R2 supports it (Device Action Cmd 2); driving a calibration from the app is a separate, riskier feature with its own UX and failure modes.
+- Loop test. Statuses 7–9 are named for log readability, but the driver does not initiate loop tests.
+- Screen brightness, and the remaining device settings. Configuring someone's refractometer from Decenza is not a coffee problem.
+- Resolving Brix-vs-TDS. This change gathers the serial number; deciding what to do with a Brix variant stays with [#1386](https://github.com/Kulitorum/Decenza/pull/1386).
+
+## Decisions
+
+### The test count is a fixed default, not a setting
+
+Averaging exists to reduce scatter. Three tests captures most of that benefit; beyond that the user is waiting appreciably longer for diminishing returns. Rather than add a settings row and make every user decide, the averaged read uses a fixed count.
+
+*Alternative — a 1–10 setting (Beanconqueror exposes one):* rejected as the first move. It puts a number in front of the user that they have no basis to choose, in a project that explicitly prefers better defaults over more knobs. The driver still clamps to 1–10, so the setting can be added later without protocol work if anyone actually asks for it.
+
+*Alternative — always average, no single-test path:* rejected. It silently makes every existing TDS read several times slower, which is a behaviour change users did not ask for.
+
+### The watchdog becomes a liveness timer, restarted by device traffic
+
+Today `m_measurementTimer` is armed once at request time with a 15-second interval. For a single test that is indistinguishable from a liveness watchdog. For a 3-test average it is a hard ceiling that aborts a healthy device mid-run.
+
+The fix is to restart the interval on any packet indicating progress — pack 0 statuses 4, 5 and 10, and per-test result packets. Status 10 matters specifically: the R2 emits it *because* an individual test is running long, which is exactly when a fixed deadline would fire. Silence still recovers, which is the property the exception to the no-timers rule was granted for.
+
+*Alternative — a longer fixed interval scaled by test count:* rejected. It restores the same bug at a larger number, and picks a duration from guesswork rather than from what the device is telling us.
+
+### Averaging is a parameter on the existing request, not a second device mode
+
+`requestMeasurement()` gains an averaged variant rather than the driver holding a mode flag. A mode flag would be state that can disagree with what the user last pressed, and would have to be reconciled across disconnects. A parameter cannot drift.
+
+`RefractometerDevice` gains the averaged entry point with a base implementation that falls back to a single measurement, so `DiFluidR1` needs no change and any future device gets correct-if-unoptimised behaviour for free.
+
+### Status and error names live in one table, not scattered across the switch
+
+A single translation function per table, rather than string literals at each branch. The tables are the part most likely to be extended when DiFluid publishes more codes, and keeping them together is what makes the "unknown code still logged" requirement natural instead of an afterthought at every call site.
+
+### Serial number assembly indexes by part, and does not assume arrival order
+
+Beanconqueror splices by `part * 5` into a fixed-width buffer, which tolerates out-of-order arrival. Same approach here, plus explicit tracking of which parts have arrived so a partial serial is never logged as the device's identity. BLE notification ordering is not something to assume.
+
+### Auto Test is offered but not enabled by default
+
+Auto Test makes the R2 measure on its own when the prism temperature shifts. That is genuinely nicer — the reading is there when you load the sample. It also means readings arrive unprompted, which interacts with the active-page gating in `refractometer-tds-capture`: a reading during a temperature drift with the review page open would populate the field without the user asking.
+
+The existing gating already handles this correctly (device-initiated readings are an explicit scenario in that spec), so the capability is safe to add. Leaving it off by default keeps the change from altering behaviour for anyone who does not opt in.
+
+## Risks / Trade-offs
+
+**No R2 hardware is available to the author** → Every change is byte-level against two independent references, and covered by packet-level tests built from the spec's own worked examples. The averaged path in particular has never run against a device — it must be flagged as needing a hardware check before merge, not asserted as verified.
+
+**Averaged runs make the driver's stateful window much longer** → A disconnect or an app-side navigation mid-run is now a realistic case rather than a 2-second window. The measuring state must clear on disconnect, not only on result or timeout.
+
+**Restarting the watchdog on device traffic could mask a device that is emitting status but never finishing** → Bounded in practice: a device stuck emitting status 5 forever is a firmware fault the app cannot fix, and the user can navigate away. Accepting this is preferable to aborting healthy long runs, which is a certainty rather than a hypothetical.
+
+**Naming more error codes tempts surfacing more of them** → The existing division exists because the R2 emits benign class/code pairs around successful reads; the spec pins that division explicitly so a later reader does not "fix" the asymmetry and reintroduce error-dialog spam.
+
+**The serial number is device-identifying data** → It goes to the debug log, which users share when reporting problems. It identifies a refractometer, not a person, and the model and firmware strings are already logged the same way. No new class of data is being exposed.
+
+## Open Questions
+
+- Is a fixed count of 3 the right default, or should the averaged control offer a small explicit choice (e.g. 3 or 5) at the point of use rather than in settings? Point-of-use is not a settings row and may be the better compromise.
+- Does the review page need a distinct visual treatment for an averaged reading versus a single one — is "this number is an average of 3" worth showing after the fact, or only during?
+- Should Auto Test be surfaced in the UI at all in this change, or landed as driver capability plus MCP access only, with UI deferred until someone asks for it?

--- a/openspec/changes/expand-difluid-r2-protocol/proposal.md
+++ b/openspec/changes/expand-difluid-r2-protocol/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Decenza's DiFluid R2 driver implements roughly a third of the device's published protocol. It can request one single test, names 2 of 13 status codes, surfaces 2 of 4 error codes, and drops the serial number on the floor. Comparing it against DiFluid's own `protocolR2.md` and against [Beanconqueror's R2 driver](https://github.com/graphefruit/Beanconqueror/tree/master/src/classes/devices) — a second independent implementation of the same device — surfaced concrete, already-specified capability we are simply not using.
+
+The headline gap is **averaging**. A single refractometer reading on espresso carries meaningful run-to-run scatter; averaging several is standard practice, and the R2 does it in firmware. We already parse the averaged result packets (pack 3 and pack 4) — we have simply never sent the command that produces them. Users get the noisier number because of a missing request, not a missing capability.
+
+The rest is diagnosability. A user reporting "my R2 hangs" or "TDS looks like Brix" currently produces a log reading `Status: 5` and `R2 error: class=2 code=1`, which tells nobody anything.
+
+## What Changes
+
+- **Average Test**: request an averaged reading over N tests (Func 3 Cmd 1), with N settable 1–10 (Func 1 Cmd 3). Exposed as a user choice on the TDS capture affordance, defaulting to the current single-test behaviour.
+- **Measurement lifecycle becomes status-driven**: an average of 5 tests can exceed the driver's fixed 15-second measurement watchdog, which would abort a healthy measurement. The watchdog must be fed by the device's own progress packets — including status 10, which the R2 emits specifically to say "still working, this one is taking a while".
+- **Full status table (0–12)**: name every code — Calibration Started/Finished, Average Test Started/Ongoing/Finished, Loop Test Started/Ongoing/Finished — instead of only 0 and 11.
+- **Full error table**: name class-2 codes 1 (Test Error) and 2 (Calibration Failed) alongside the existing 3 (No Liquid) and 4 (Beyond Range), and class 3 (Hardware) with the code shown on the device screen.
+- **Serial number reassembly**: the SN arrives as 3 packets, `Data0` = part index, 5 bytes each. Capture and log it. This feeds the open Brix-vs-TDS variant identification work ([#1386](https://github.com/Kulitorum/Decenza/pull/1386)), where the model string alone has not been enough to tell a genuine Extract from a Brix rebrand.
+- **Auto Test** (Func 1 Cmd 1, optional): let the R2 start a measurement itself on a prism/tank temperature change, so TDS arrives when the sample is loaded with no button press.
+
+Not in scope — shipped separately in [#1656](https://github.com/Kulitorum/Decenza/pull/1656): temperature-unit (Data5) handling, set-to-Celsius on connect, and Microbalance Ti service `0x00DD` support.
+
+No breaking changes. Every addition is opt-in or log-only; the default measurement path stays a single test.
+
+## Capabilities
+
+### New Capabilities
+
+- `refractometer-averaged-measurement`: requesting an N-test averaged TDS reading, how the averaged result is distinguished from a single reading, and how the measuring lifecycle stays alive across a multi-test run without a fixed timer.
+- `refractometer-device-diagnostics`: what the driver records about device state and identity — the full status and error tables, and serial-number capture — so a field log is readable by a human or an AI triaging it.
+
+### Modified Capabilities
+
+<!-- None. `refractometer-tds-capture` governs which readings may populate the review
+     page; an averaged reading arrives through the same tdsChanged path under the same
+     gating, so its requirements are unchanged. -->
+
+## Impact
+
+- `src/ble/refractometers/difluidr2.{h,cpp}` — command construction, packet dispatch, measurement lifecycle. The bulk of the change.
+- `src/ble/refractometers/refractometerdevice.h` — the abstract interface gains averaged-measurement entry points; `DiFluidR1` must remain buildable (it has no averaging, so it declines).
+- QML TDS capture affordance on `PostShotReviewPage.qml` — a way to choose an averaged read.
+- `Settings` — if the test count is remembered, it belongs in an existing domain sub-object, never on `Settings` directly. Prefer no new setting at all if a sensible fixed count works (see `docs/CLAUDE_MD/SETTINGS.md` and the project's bias against new user-facing settings).
+- `tests/tst_difluidr2.cpp` — packet-level coverage for each new path.
+- Wiki manual (`Manual.md`, refractometer section) — averaging is user-visible and must be documented in the same change.
+- No BLE UUID, database, or migration impact.

--- a/openspec/changes/expand-difluid-r2-protocol/specs/refractometer-averaged-measurement/spec.md
+++ b/openspec/changes/expand-difluid-r2-protocol/specs/refractometer-averaged-measurement/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: The driver can request an averaged reading over multiple tests
+
+The DiFluid R2 driver SHALL be able to request an averaged measurement (Device Action, Cmd 1) carrying a test count, in addition to the existing single test (Device Action, Cmd 0). The test count SHALL be clamped to the device's supported range of 1–10 before transmission. The averaged result arrives as pack 3 and SHALL reach consumers through the same `tdsChanged` path, and the same out-of-range plausibility gate, as a single reading — averaging changes how a number was produced, not what is allowed to escape the driver.
+
+#### Scenario: Averaged measurement requested
+
+- **WHEN** an averaged measurement of 3 tests is requested
+- **THEN** the driver writes a Device Action Cmd 1 packet whose single data byte is 3, with a valid additive checksum
+- **AND** the driver enters the measuring state
+
+#### Scenario: Test count outside the device range is clamped
+
+- **WHEN** an averaged measurement is requested with a count of 0, or of 25
+- **THEN** the transmitted count is 1, or 10, respectively
+- **AND** no packet carrying an out-of-range count is ever written
+
+#### Scenario: Averaged result is gated identically to a single reading
+
+- **WHEN** a pack 3 averaged result arrives carrying a concentration above the plausible-TDS ceiling
+- **THEN** it is rejected and an error is surfaced, exactly as the same value in a pack 2 single result would be
+- **AND** no `tdsChanged` is emitted
+
+#### Scenario: Single test remains the default
+
+- **WHEN** a measurement is requested without specifying averaging
+- **THEN** the driver sends a single test (Device Action Cmd 0), preserving today's behaviour
+
+### Requirement: A multi-test run is kept alive by device progress, not by a fixed deadline
+
+The measurement liveness watchdog exists to recover from a device that stops responding entirely — a case that produces no event and so cannot be detected by events alone. It SHALL NOT double as a bound on how long a legitimate measurement may take. Any device packet indicating the measurement is still progressing — including status 5 (Average Test Ongoing) and status 10, which the R2 emits precisely to report that an individual test is taking a long time — SHALL restart the watchdog interval.
+
+#### Scenario: Long averaged run is not aborted
+
+- **WHEN** an averaged run of 5 tests is in progress
+- **AND** the device emits progress packets at intervals shorter than the watchdog interval
+- **AND** the total run exceeds the watchdog interval
+- **THEN** the measurement is not aborted
+- **AND** the measuring state remains true until the averaged result or a terminal status arrives
+
+#### Scenario: Slow-test status keeps the run alive
+
+- **WHEN** the device emits status 10 during an averaged run
+- **THEN** the watchdog is restarted
+- **AND** no timeout warning is logged
+- **AND** the measuring state is unchanged
+
+#### Scenario: Genuinely unresponsive device still recovers
+
+- **WHEN** a measurement has been requested
+- **AND** no packet of any kind arrives for longer than the watchdog interval
+- **THEN** the measuring state is cleared and a timeout is logged
+- **AND** the UI is not left waiting indefinitely
+
+#### Scenario: Terminal status ends the run
+
+- **WHEN** status 6 (Average Test Finished) arrives after the averaged result
+- **THEN** the watchdog is stopped
+- **AND** the measuring state is false
+
+### Requirement: The user can choose an averaged read
+
+The TDS capture affordance SHALL let the user take an averaged reading rather than a single one, and SHALL indicate while a multi-test run is in progress that more than one test is being taken. The choice SHALL default to the existing single-test behaviour, so an untouched installation behaves exactly as before.
+
+#### Scenario: Averaged read from the review page
+
+- **WHEN** the user chooses an averaged read on the post-shot review page
+- **THEN** an averaged measurement is requested
+- **AND** the resulting averaged TDS populates the review page's TDS field under the existing active-page and threshold gating
+
+#### Scenario: Progress is visible during a multi-test run
+
+- **WHEN** an averaged run of N tests is in progress and the device reports completing test M of N
+- **THEN** the interface reflects that a multi-test measurement is underway rather than appearing hung
+
+#### Scenario: Default is unchanged
+
+- **WHEN** a user who has never chosen averaging presses the TDS read control
+- **THEN** a single test is performed

--- a/openspec/changes/expand-difluid-r2-protocol/specs/refractometer-device-diagnostics/spec.md
+++ b/openspec/changes/expand-difluid-r2-protocol/specs/refractometer-device-diagnostics/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Every device status code is logged by name
+
+The driver SHALL log R2 test status codes by their documented meaning across the full range the device emits (0–12), not as bare integers. A status the driver does not recognise SHALL still be logged, with its numeric value, rather than silently discarded.
+
+This exists because field logs are read by people and by AI assistants triaging a user's problem through MCP. `Status: 5` communicates nothing; "Average Test Ongoing" tells the reader the device is healthy and working.
+
+#### Scenario: Averaging statuses are named
+
+- **WHEN** the device emits status 4, 5, 6, or 10 during a run
+- **THEN** each is logged as its documented meaning — Average Test Started, Average Test Ongoing, Average Test Finished, and the long-test variant of Average Test Ongoing respectively
+
+#### Scenario: Calibration statuses are named
+
+- **WHEN** the device emits status 12 and later status 1
+- **THEN** they are logged as Calibration Started and Calibration Finished
+
+#### Scenario: Unknown status is still reported
+
+- **WHEN** the device emits a status code the driver has no name for
+- **THEN** the numeric value is logged
+- **AND** no measurement state is changed on account of it
+
+### Requirement: Every documented error code is reported by name
+
+The driver SHALL name all documented R2 error codes: class 2 (General) codes 1 Test Error, 2 Calibration Failed, 3 No Liquid, and 4 Beyond Range; and class 3 (Hardware), whose code is the number shown on the device's own screen and SHALL be included in the message so a user can match it to what they are looking at.
+
+Naming a code is distinct from surfacing it to the user. The existing division SHALL be preserved: only user-actionable measurement failures raise a user-visible error; everything else is logged, because the R2 also emits benign class/code combinations around a successful read and surfacing those spams the error dialog with nothing useful.
+
+#### Scenario: Hardware error names the on-screen code
+
+- **WHEN** an error packet arrives with class 3 and code 7
+- **THEN** the log identifies it as a hardware error and states the code shown on the device screen is 7
+
+#### Scenario: Newly named codes do not become new dialogs
+
+- **WHEN** an error packet arrives with class 2 code 1 (Test Error)
+- **THEN** it is logged by name
+- **AND** whether a user-visible error is raised follows the existing user-actionable division, unchanged by this capability
+
+#### Scenario: Measurement state is cleared on any error
+
+- **WHEN** any error packet arrives while a measurement is in flight
+- **THEN** the measuring state is cleared so the interface does not hang
+
+### Requirement: The device serial number is reassembled and recorded
+
+The R2 transmits its serial number as three packets, each carrying a part index in Data0 followed by five bytes of serial data. The driver SHALL reassemble these into the complete serial number regardless of the order the packets arrive in, and record it alongside the model and firmware strings it already captures.
+
+This is identification data, not measurement data: it supports telling a genuine R2 Extract from a Brix-reporting variant or rebrand, where the model string alone has proven insufficient.
+
+#### Scenario: Serial number assembled from three packets
+
+- **WHEN** the three serial-number packets have all arrived
+- **THEN** the driver holds the complete serial number as a single string
+- **AND** logs it once complete
+
+#### Scenario: Packets arriving out of order
+
+- **WHEN** the part-index-2 packet arrives before the part-index-0 packet
+- **THEN** each part is placed at its indicated offset
+- **AND** the assembled serial number is identical to the in-order case
+
+#### Scenario: Incomplete serial number is not reported as complete
+
+- **WHEN** only some of the serial-number packets have arrived
+- **THEN** no partial serial number is logged as if it were the device's identity
+
+### Requirement: Device-initiated measurement can be enabled
+
+The driver SHALL be able to set the R2's Auto Test setting, which makes the device start a measurement on its own when it detects a prism or sample-tank temperature change — so a reading arrives when the sample is loaded, with no button press. Readings produced this way are device-initiated and SHALL be subject to exactly the same consumer-side gating as a button-initiated reading.
+
+#### Scenario: Auto Test enabled
+
+- **WHEN** Auto Test is enabled
+- **THEN** the driver writes the corresponding Device Settings command
+- **AND** the device's echoed confirmation of the setting is logged
+
+#### Scenario: Device-initiated reading is gated normally
+
+- **WHEN** Auto Test is on and the device starts and completes a measurement with no request from the app
+- **THEN** the resulting reading flows through the same plausibility gate and the same active-page gating as any other reading
+- **AND** it does not populate any field that a button-initiated reading would not

--- a/openspec/changes/expand-difluid-r2-protocol/tasks.md
+++ b/openspec/changes/expand-difluid-r2-protocol/tasks.md
@@ -1,0 +1,53 @@
+## 1. Diagnostics tables (no behaviour change, lands first)
+
+- [ ] 1.1 Add a status-code translation covering 0–12 in `difluidr2.cpp`, returning the numeric value for anything unrecognised
+- [ ] 1.2 Replace the two hardcoded status log branches (0 and 11) with the table
+- [ ] 1.3 Add an error-code translation for class 2 codes 1–4 and class 3 (Hardware), including the on-screen code in the hardware message
+- [ ] 1.4 Route the existing error handling through the table, leaving the user-actionable/log-only division exactly as it is
+- [ ] 1.5 Tests: every status code logs its name; unknown status logs its number; hardware error names the on-screen code; class 2 code 1 is named but raises no new user-visible error
+
+## 2. Serial number capture
+
+- [ ] 2.1 Add a fixed-width serial buffer plus per-part arrival tracking to `DiFluidR2`
+- [ ] 2.2 Handle Func 0 Cmd 0 packets — splice 5 bytes at `Data0 * 5`, order-independent
+- [ ] 2.3 Log the serial only once all three parts have arrived; never log a partial as the device identity
+- [ ] 2.4 Send the Get-SN query alongside the existing model/firmware queries in the connect handshake
+- [ ] 2.5 Tests: in-order assembly, out-of-order assembly produces the identical string, partial set logs no identity
+
+## 3. Measurement lifecycle
+
+- [ ] 3.1 Restart `m_measurementTimer` on pack 0 statuses 4, 5 and 10, and on per-test result packets
+- [ ] 3.2 Rewrite the timer's comment to say what it now is — a liveness watchdog fed by device traffic — and why that remains the documented exception to the no-timers-as-guards rule
+- [ ] 3.3 Clear the measuring state on transport disconnect, not only on result or timeout
+- [ ] 3.4 Tests: progress packets past the watchdog interval do not abort; status 10 restarts it silently; total silence still times out; status 6 stops it; disconnect mid-run clears measuring
+
+## 4. Averaged measurement
+
+- [ ] 4.1 Add an averaged-measurement entry point to `RefractometerDevice` with a base implementation that falls back to a single measurement (keeps `DiFluidR1` untouched)
+- [ ] 4.2 Implement it in `DiFluidR2` as Device Action Cmd 1 with a one-byte count, clamped to 1–10, checksum computed the same way as every other command
+- [ ] 4.3 Confirm pack 3 (averaged result) and pack 4 (averaged temps + M-of-N counter) parse correctly against the spec's worked example — this code has never run
+- [ ] 4.4 Surface the M-of-N progress from pack 4 as a signal the UI can bind to
+- [ ] 4.5 Tests: request bytes for count 3; clamping at 0 and 25; averaged result passes through the same plausibility gate as a single reading; single test remains the default path
+
+## 5. Auto Test
+
+- [ ] 5.1 Add the Auto Test set command (Device Settings Cmd 1) and log the device's echoed confirmation
+- [ ] 5.2 Confirm a device-initiated reading reaches consumers through the unchanged `tdsChanged` path with no extra side effects
+- [ ] 5.3 Tests: command bytes for on and off; echo logs the resulting state
+- [ ] 5.4 Decide from design's open question whether Auto Test gets UI in this change or driver + MCP access only
+
+## 6. User-facing capture
+
+- [ ] 6.1 Add an averaged-read affordance to the TDS control on `PostShotReviewPage.qml`, defaulting to single test
+- [ ] 6.2 Show multi-test progress while a run is in flight so the control does not read as hung
+- [ ] 6.3 Accessibility: `Accessible.role`/`name`/`focusable`/`onPressAction` on any new control, and fix any pre-existing violations in the files touched
+- [ ] 6.4 Internationalize all new visible text via `TranslationManager.translate` / `Tr`, reusing existing keys where they fit
+- [ ] 6.5 Resolve design's open question on whether an averaged reading is distinguished from a single one after the fact
+
+## 7. Documentation and verification
+
+- [ ] 7.1 Update the wiki manual's refractometer section for averaged reads (and Auto Test, if it ships with UI) — averaging is user-visible and the manual entry is part of this change, not a follow-up
+- [ ] 7.2 Note in `docs/CLAUDE_MD/BLE_PROTOCOL.md` which parts of the R2 command set are now implemented and which remain deliberately unimplemented (calibration, loop test, remaining settings)
+- [ ] 7.3 Run the full suite through the Qt Creator MCP (`run_tests`, scope `all`) and clear every warning
+- [ ] 7.4 Verify on physical R2 hardware: an averaged run completes, exceeds the old 15s ceiling without aborting, and reports a plausible averaged TDS. This has never run against a device — do not merge on test-suite green alone
+- [ ] 7.5 Archive this change with `openspec archive expand-difluid-r2-protocol` as the last commit on the feature branch

--- a/src/ble/protocol/de1characteristics.h
+++ b/src/ble/protocol/de1characteristics.h
@@ -255,9 +255,17 @@ namespace Generic {
     const QBluetoothUuid CMD(QString("0000FFF2-0000-1000-8000-00805F9B34FB"));
 }
 
-// DiFluid
+// DiFluid Microbalance / Microbalance Ti
+//
+// The Ti speaks the identical DF-DF command protocol on the identical AA01
+// characteristic, but advertises a *different* 16-bit service: the original
+// Microbalance uses 0x00EE, the Ti 0x00DD (DiFluid's protocolMicrobalance.md,
+// updated Dec 2024). Matching only 0x00EE means a Ti connects, finds no
+// recognised service, and silently never reports weight. Both are accepted;
+// DifluidScale remembers which one the connected device actually exposed.
 namespace DiFluid {
     const QBluetoothUuid SERVICE(QString("000000EE-0000-1000-8000-00805F9B34FB"));
+    const QBluetoothUuid SERVICE_TI(QString("000000DD-0000-1000-8000-00805F9B34FB"));
     const QBluetoothUuid CHARACTERISTIC(QString("0000AA01-0000-1000-8000-00805F9B34FB"));
 }
 

--- a/src/ble/protocol/de1characteristics.h
+++ b/src/ble/protocol/de1characteristics.h
@@ -257,12 +257,18 @@ namespace Generic {
 
 // DiFluid Microbalance / Microbalance Ti
 //
-// The Ti speaks the identical DF-DF command protocol on the identical AA01
-// characteristic, but advertises a *different* 16-bit service: the original
-// Microbalance uses 0x00EE, the Ti 0x00DD (DiFluid's protocolMicrobalance.md,
-// updated Dec 2024). Matching only 0x00EE means a Ti connects, finds no
-// recognised service, and silently never reports weight. Both are accepted;
-// DifluidScale remembers which one the connected device actually exposed.
+// The Ti speaks the same DF-DF command protocol but advertises a *different*
+// 16-bit service: the original Microbalance uses 0x00EE, the Ti 0x00DD
+// (protocolMicrobalance.md, updated Dec 2024). Matching only 0x00EE meant a Ti
+// reached service discovery, matched nothing, warned, and never became a
+// connected scale. Both are accepted; DifluidScale remembers which one the
+// connected device actually exposed.
+//
+// On the characteristic, the cited document is self-inconsistent: it lists AA01
+// for both models, then directs FF01 as the communication channel for the
+// original Microbalance and AA01 for the Ti. AA01 is what Beanconqueror uses for
+// both (difluidMicrobalance.ts, difluidMicrobalanceTi.ts) and what has shipped
+// here, so AA01 it is — but that is a working-practice claim, not a spec one.
 namespace DiFluid {
     const QBluetoothUuid SERVICE(QString("000000EE-0000-1000-8000-00805F9B34FB"));
     const QBluetoothUuid SERVICE_TI(QString("000000DD-0000-1000-8000-00805F9B34FB"));

--- a/src/ble/refractometers/difluidr2.cpp
+++ b/src/ble/refractometers/difluidr2.cpp
@@ -366,15 +366,33 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
             break;
         }
         case 1: {
-            // Temperature: Data1-2 = prism temp * 10, Data3-4 = tank temp * 10
+            // Temperature: Data1-2 = prism temp * 10, Data3-4 = tank temp * 10,
+            // Data5 = the unit those two are expressed in (0 = °C, 1 = °F).
+            //
+            // The unit is a device setting the user flips on the R2 itself, and it
+            // changes the wire values — DiFluid's own worked example in protocolR2.md
+            // is a °F packet (`... 03 17 03 14 01` = 79.1/78.8 °F). Ignoring Data5
+            // meant an R2 set to Fahrenheit reported 79.1 as if it were Celsius.
+            // RefractometerDevice::temperature() is Celsius (DiFluidR1 emits °C), so
+            // convert here rather than let a unit-tagged number escape the driver.
             if (dataLen < 5) return;
             uint16_t prismTemp = static_cast<uint16_t>(
                 (static_cast<uint8_t>(packet[6]) << 8) | static_cast<uint8_t>(packet[7]));
             uint16_t tankTemp = static_cast<uint16_t>(
                 (static_cast<uint8_t>(packet[8]) << 8) | static_cast<uint8_t>(packet[9]));
-            m_temperature = prismTemp / 10.0;
-            R2_LOG(QString("Temperature: prism=%1°C tank=%2°C")
-                .arg(prismTemp / 10.0, 0, 'f', 1).arg(tankTemp / 10.0, 0, 'f', 1));
+            // Firmware predating the unit byte sends dataLen 5; those packets are
+            // Celsius, which is what this driver assumed before Data5 was honoured.
+            const bool fahrenheit =
+                dataLen >= 6 && static_cast<uint8_t>(packet[10]) == 1;
+            const auto toCelsius = [fahrenheit](double t) {
+                return fahrenheit ? (t - 32.0) * 5.0 / 9.0 : t;
+            };
+            const double prismC = toCelsius(prismTemp / 10.0);
+            const double tankC = toCelsius(tankTemp / 10.0);
+            m_temperature = prismC;
+            R2_LOG(QString("Temperature: prism=%1°C tank=%2°C (device reporting in %3)")
+                .arg(prismC, 0, 'f', 1).arg(tankC, 0, 'f', 1)
+                .arg(fahrenheit ? QStringLiteral("°F") : QStringLiteral("°C")));
             emit temperatureChanged(m_temperature);
             break;
         }

--- a/src/ble/refractometers/difluidr2.cpp
+++ b/src/ble/refractometers/difluidr2.cpp
@@ -36,11 +36,17 @@ DiFluidR2::DiFluidR2(ScaleBleTransport* transport, QObject* parent)
     m_measurementTimer.setSingleShot(true);
     m_measurementTimer.setInterval(15000);
     connect(&m_measurementTimer, &QTimer::timeout, this, [this]() {
-        if (m_measuring) {
-            R2_WARN("Measurement timeout");
-            m_measuring = false;
-            emit measuringChanged();
-        }
+        if (!m_measuring) return;
+        // Every other failure in this driver reaches the error dialog. This is the
+        // most common real one — R2 out of range, asleep, or a write that never
+        // landed — and it used to stop the spinner with no message at all, leaving
+        // the user to conclude the button was broken.
+        R2_WARN(QString("Measurement timeout — no packet from the R2 for %1 ms")
+                    .arg(m_measurementTimer.interval()));
+        emit errorOccurred("The refractometer stopped responding. Check it is "
+                           "switched on and in range, then try again.");
+        m_measuring = false;
+        emit measuringChanged();
     });
 
     // BLE stack constraint: Qt's BLE layer (Android BluetoothLE + iOS CoreBluetooth)
@@ -316,7 +322,15 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
     // logging on its own line: if a reading ever looks unit-shifted, this says
     // whether the device was actually switched or the write went missing.
     if (func == 1 && cmd == 0) {
-        const uint8_t unit = dataLen >= 1 ? static_cast<uint8_t>(packet[5]) : 0;
+        // Absent data must not be printed as data: defaulting to 0 made a
+        // zero-length response log a confident "°C", and this line is exactly what
+        // someone will trust when diagnosing a unit-shifted reading.
+        if (dataLen < 1) {
+            R2_WARN(QString("Temperature-unit response carried no data byte: %1")
+                        .arg(QString(packet.toHex(' '))));
+            return;
+        }
+        const uint8_t unit = static_cast<uint8_t>(packet[5]);
         R2_LOG(QString("Temperature unit now: %1")
                    .arg(unit == 1 ? QStringLiteral("°F") : QStringLiteral("°C")));
         return;
@@ -329,9 +343,21 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
         R2_LOG(QString("Action packet raw: %1").arg(QString(packet.toHex(' '))));
 
         if (cmd == 254) {
-            // Error response
-            uint8_t errClass = dataLen > 0 ? static_cast<uint8_t>(packet[5]) : 0;
-            uint8_t errCode = dataLen > 1 ? static_cast<uint8_t>(packet[6]) : 0;
+            // Error response. class=0 code=0 is a real pair, so substituting zeros for
+            // absent bytes both fabricates a plausible code and skips the class-2
+            // branch below — a truncated "No liquid detected" would reach the user as
+            // nothing at all.
+            if (dataLen < 2) {
+                R2_WARN(QString("Error packet truncated (dataLen=%1, need 2): %2 — "
+                                "cannot classify, clearing the measurement")
+                            .arg(dataLen).arg(QString(packet.toHex(' '))));
+                m_measurementTimer.stop();
+                m_measuring = false;
+                emit measuringChanged();
+                return;
+            }
+            uint8_t errClass = static_cast<uint8_t>(packet[5]);
+            uint8_t errCode = static_cast<uint8_t>(packet[6]);
             R2_WARN(QString("R2 error: class=%1 code=%2").arg(errClass).arg(errCode));
             // Surface ONLY the user-actionable measurement failures. Class-2 are
             // the measurement errors; other class/code combos (notably 0/2) are
@@ -362,7 +388,14 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
         switch (packNo) {
         case 0: {
             // Status: Data1 = status code
-            uint8_t status = dataLen >= 2 ? static_cast<uint8_t>(packet[6]) : 0;
+            // Status 0 is "Test finished", so defaulting an absent byte to 0 turned a
+            // truncated packet into a confident claim that the measurement completed.
+            if (dataLen < 2) {
+                R2_WARN(QString("Status packet carried no status byte: %1")
+                            .arg(QString(packet.toHex(' '))));
+                return;
+            }
+            uint8_t status = static_cast<uint8_t>(packet[6]);
             R2_LOG(QString("Status: %1").arg(status));
             if (status == 0) {
                 R2_LOG("Test finished");
@@ -381,24 +414,47 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
             // meant an R2 set to Fahrenheit reported 79.1 as if it were Celsius.
             // RefractometerDevice::temperature() is Celsius (DiFluidR1 emits °C), so
             // convert here rather than let a unit-tagged number escape the driver.
-            if (dataLen < 5) return;
+            if (dataLen < 5) {
+                // Every neighbouring malformed-packet path warns; this one used to
+                // return in silence, so a framing change would show up as the
+                // temperature simply never updating against a clean log.
+                R2_WARN(QString("Temperature packet too short (dataLen=%1, need 5): %2")
+                            .arg(dataLen).arg(QString(packet.toHex(' '))));
+                return;
+            }
             uint16_t prismTemp = static_cast<uint16_t>(
                 (static_cast<uint8_t>(packet[6]) << 8) | static_cast<uint8_t>(packet[7]));
             uint16_t tankTemp = static_cast<uint16_t>(
                 (static_cast<uint8_t>(packet[8]) << 8) | static_cast<uint8_t>(packet[9]));
-            // Firmware predating the unit byte sends dataLen 5; those packets are
-            // Celsius, which is what this driver assumed before Data5 was honoured.
-            const bool fahrenheit =
-                dataLen >= 6 && static_cast<uint8_t>(packet[10]) == 1;
+
+            // Unit provenance matters as much as the unit. A packet with no Data5 and
+            // a packet that says "Celsius" used to log identically, so the one case
+            // where we know the unit and the one where we are guessing were
+            // indistinguishable in the only record that exists.
+            enum class Unit { Celsius, Fahrenheit, Unreported, Unrecognised };
+            Unit unit = Unit::Unreported;
+            if (dataLen >= 6) {
+                const uint8_t raw = static_cast<uint8_t>(packet[10]);
+                unit = raw == 0 ? Unit::Celsius
+                     : raw == 1 ? Unit::Fahrenheit
+                                : Unit::Unrecognised;
+                if (unit == Unit::Unrecognised)
+                    R2_WARN(QString("Unrecognised temperature unit byte 0x%1 — treating as °C")
+                                .arg(raw, 2, 16, QLatin1Char('0')));
+            }
+            const bool fahrenheit = (unit == Unit::Fahrenheit);
             const auto toCelsius = [fahrenheit](double t) {
                 return fahrenheit ? (t - 32.0) * 5.0 / 9.0 : t;
             };
             const double prismC = toCelsius(prismTemp / 10.0);
             const double tankC = toCelsius(tankTemp / 10.0);
             m_temperature = prismC;
-            R2_LOG(QString("Temperature: prism=%1°C tank=%2°C (device reporting in %3)")
+            R2_LOG(QString("Temperature: prism=%1°C tank=%2°C (unit: %3)")
                 .arg(prismC, 0, 'f', 1).arg(tankC, 0, 'f', 1)
-                .arg(fahrenheit ? QStringLiteral("°F") : QStringLiteral("°C")));
+                .arg(unit == Unit::Celsius      ? QStringLiteral("°C, reported by device")
+                   : unit == Unit::Fahrenheit   ? QStringLiteral("°F, converted")
+                   : unit == Unit::Unreported   ? QStringLiteral("not reported — assuming °C")
+                                                : QStringLiteral("unrecognised — assuming °C")));
             emit temperatureChanged(m_temperature);
             break;
         }
@@ -493,7 +549,17 @@ bool DiFluidR2::validateChecksum(const QByteArray& packet) const {
 }
 
 void DiFluidR2::sendCommand(const QByteArray& cmd) {
-    if (!m_transport || !m_characteristicsReady) return;
+    // Silence here is the empty-catch-block of BLE drivers: requestMeasurement()
+    // has already set the measuring state and armed the watchdog by this point, so
+    // a dropped write shows up as a spinner that runs to timeout with nothing in
+    // the log to say the request never left.
+    if (!m_transport || !m_characteristicsReady) {
+        R2_WARN(QString("Dropping command %1 — %2")
+                    .arg(QString(cmd.toHex(' ')),
+                         m_transport ? QStringLiteral("characteristics not ready")
+                                     : QStringLiteral("no transport")));
+        return;
+    }
     m_transport->writeCharacteristic(Refractometer::DiFluidR2::SERVICE,
                                      Refractometer::DiFluidR2::CHARACTERISTIC, cmd);
 }

--- a/src/ble/refractometers/difluidr2.cpp
+++ b/src/ble/refractometers/difluidr2.cpp
@@ -59,20 +59,15 @@ DiFluidR2::DiFluidR2(ScaleBleTransport* transport, QObject* parent)
         emit connectedChanged();
         R2_LOG("Connected and ready for measurements");
 
-        // Send "get temperature unit" as init handshake (Func=1, Cmd=0, DataLen=0)
-        // This benign query confirms the BLE link is working and may wake the R2
-        QByteArray initCmd;
-        initCmd.append(static_cast<char>(0xDF));
-        initCmd.append(static_cast<char>(0xDF));
-        initCmd.append(static_cast<char>(0x01));  // Func: Settings
-        initCmd.append(static_cast<char>(0x00));  // Cmd: Temperature Unit
-        initCmd.append(static_cast<char>(0x00));  // DataLen: 0 (query)
-        uint8_t checksum = 0;
-        for (qsizetype i = 0; i < initCmd.size(); ++i)
-            checksum += static_cast<uint8_t>(initCmd[i]);
-        initCmd.append(static_cast<char>(checksum));
-        R2_LOG(QString("Sending init query: %1").arg(QString(initCmd.toHex(' '))));
-        sendCommand(initCmd);
+        // Put the R2 into Celsius (Func=1 Settings, Cmd=0 Temperature Unit, Data=0).
+        // Doubles as the init handshake the connect path has always sent — it
+        // confirms the BLE link and may wake the R2 — but as a write rather than a
+        // query, so the device also stops reporting in whatever unit it was left in.
+        // Belt and braces with the pack-1 Data5 conversion below, which stays: the
+        // set is not instantaneous, packets from a device-initiated measurement can
+        // already be in flight, and Data5 is authoritative for the packet carrying it.
+        R2_LOG("Setting device temperature unit to Celsius");
+        sendCommand(QByteArray::fromHex("DFDF01000100C0"));  // Set Temperature Unit = °C
 
         // Instrumentation: identify the unit. Per DiFluid's official protocolR2.md, a
         // genuine R2 Extract (model "DFT-R102") transmits coffee *TDS* in pack 2, while
@@ -313,6 +308,17 @@ void DiFluidR2::handlePacket(const QByteArray& packet) {
             R2_LOG(QString("Device info response: Cmd=%1 data=%2")
                        .arg(cmd).arg(QString(data.toHex(' '))));
         }
+        return;
+    }
+
+    // Func 1 = Device Settings. The R2 echoes the setting back, so the response to
+    // the connect-time "set Celsius" write is the confirmation that it took. Worth
+    // logging on its own line: if a reading ever looks unit-shifted, this says
+    // whether the device was actually switched or the write went missing.
+    if (func == 1 && cmd == 0) {
+        const uint8_t unit = dataLen >= 1 ? static_cast<uint8_t>(packet[5]) : 0;
+        R2_LOG(QString("Temperature unit now: %1")
+                   .arg(unit == 1 ? QStringLiteral("°F") : QStringLiteral("°C")));
         return;
     }
 

--- a/src/ble/scales/difluidscale.cpp
+++ b/src/ble/scales/difluidscale.cpp
@@ -46,7 +46,7 @@ void DifluidScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     }
 
     m_name = device.name();
-    m_serviceFound = false;
+    m_service = QBluetoothUuid();
     m_characteristicsReady = false;
 
     DIFLUID_LOG(QString("Connecting to %1 (%2)")
@@ -73,23 +73,31 @@ void DifluidScale::onTransportError(const QString& message) {
 
 void DifluidScale::onServiceDiscovered(const QBluetoothUuid& uuid) {
     DIFLUID_LOG(QString("Service discovered: %1").arg(uuid.toString()));
+    // Microbalance (0x00EE) and Microbalance Ti (0x00DD) are the same protocol
+    // on different services — accept either and remember which.
     if (uuid == Scale::DiFluid::SERVICE) {
-        DIFLUID_LOG("Found DiFluid service");
-        m_serviceFound = true;
+        DIFLUID_LOG("Found DiFluid Microbalance service");
+        m_service = uuid;
+    } else if (uuid == Scale::DiFluid::SERVICE_TI) {
+        DIFLUID_LOG("Found DiFluid Microbalance Ti service");
+        m_service = uuid;
     }
 }
 
 void DifluidScale::onServicesDiscoveryFinished() {
-    DIFLUID_LOG(QString("Service discovery finished, service found: %1").arg(m_serviceFound));
-    if (!m_serviceFound) {
-        DIFLUID_WARN(QString("DiFluid service %1 not found!").arg(Scale::DiFluid::SERVICE.toString()));
+    DIFLUID_LOG(QString("Service discovery finished, service found: %1")
+                .arg(m_service.isNull() ? QStringLiteral("none") : m_service.toString()));
+    if (m_service.isNull()) {
+        DIFLUID_WARN(QString("Neither DiFluid service %1 nor %2 found!")
+                     .arg(Scale::DiFluid::SERVICE.toString(),
+                          Scale::DiFluid::SERVICE_TI.toString()));
         return;
     }
-    m_transport->discoverCharacteristics(Scale::DiFluid::SERVICE);
+    m_transport->discoverCharacteristics(m_service);
 }
 
 void DifluidScale::onCharacteristicsDiscoveryFinished(const QBluetoothUuid& serviceUuid) {
-    if (serviceUuid != Scale::DiFluid::SERVICE) return;
+    if (m_service.isNull() || serviceUuid != m_service) return;
     if (m_characteristicsReady) {
         DIFLUID_LOG("Characteristics already set up, ignoring duplicate callback");
         return;
@@ -104,7 +112,7 @@ void DifluidScale::onCharacteristicsDiscoveryFinished(const QBluetoothUuid& serv
     QTimer::singleShot(100, this, [this]() {
         if (!m_transport || !m_characteristicsReady) return;
         DIFLUID_LOG("Enabling notifications (100ms)");
-        m_transport->enableNotifications(Scale::DiFluid::SERVICE, Scale::DiFluid::CHARACTERISTIC);
+        m_transport->enableNotifications(m_service, Scale::DiFluid::CHARACTERISTIC);
 
         // Enable auto-notifications and set to grams
         DIFLUID_LOG("Sending enable notifications and set grams commands");
@@ -132,8 +140,8 @@ void DifluidScale::onCharacteristicChanged(const QBluetoothUuid& characteristicU
 }
 
 void DifluidScale::sendCommand(const QByteArray& cmd) {
-    if (!m_transport || !m_characteristicsReady) return;
-    m_transport->writeCharacteristic(Scale::DiFluid::SERVICE, Scale::DiFluid::CHARACTERISTIC, cmd);
+    if (!m_transport || !m_characteristicsReady || m_service.isNull()) return;
+    m_transport->writeCharacteristic(m_service, Scale::DiFluid::CHARACTERISTIC, cmd);
 }
 
 void DifluidScale::sendKeepAlive() {

--- a/src/ble/scales/difluidscale.cpp
+++ b/src/ble/scales/difluidscale.cpp
@@ -47,7 +47,6 @@ void DifluidScale::connectToDevice(const QBluetoothDeviceInfo& device) {
 
     m_name = device.name();
     resetLinkState();
-    m_discoveredServices.clear();
 
     DIFLUID_LOG(QString("Connecting to %1 (%2)")
                 .arg(device.name())
@@ -73,6 +72,7 @@ void DifluidScale::resetLinkState() {
     // subsequent tare/timer write goes to a torn-down transport.
     m_service = QBluetoothUuid();
     m_characteristicsReady = false;
+    m_discoveredServices.clear();
 }
 
 void DifluidScale::onTransportError(const QString& message) {
@@ -152,13 +152,9 @@ void DifluidScale::onCharacteristicsDiscoveryFinished(const QBluetoothUuid& serv
     // de1app uses 100ms delay for Difluid
     DIFLUID_LOG("Scheduling notification enable in 100ms (de1app timing)");
     QTimer::singleShot(100, this, [this]() {
+        // resetLinkState() clears m_characteristicsReady and m_service together, so
+        // this one check covers a link that dropped inside the 100ms window.
         if (!m_transport || !m_characteristicsReady) return;
-        // The link can drop inside this 100ms window, and resetLinkState() nulls
-        // m_service — without this guard we would enable notifications on a null UUID.
-        if (m_service.isNull()) {
-            DIFLUID_WARN("Notification enable aborted — link dropped during setup");
-            return;
-        }
         DIFLUID_LOG("Enabling notifications (100ms)");
         m_transport->enableNotifications(m_service, Scale::DiFluid::CHARACTERISTIC);
 
@@ -185,8 +181,17 @@ void DifluidScale::onCharacteristicChanged(const QBluetoothUuid& characteristicU
     // reached only when the weight was exactly zero, and then it was parsing the
     // timer bytes. The comment already said "bytes 5-8" (four bytes); the code
     // took a character count for a byte count.
+    // Sensor frames only. This characteristic also carries the device's echoes of our
+    // own settings writes (Func 1), which are 6-7 bytes — warning about those would
+    // describe healthy traffic as malformed, and at 5Hz a mismatched format would
+    // evict the whole 1000-entry scale log, destroying the artifact a diagnostician
+    // asks for. Anything that is not a sensor frame is logged quietly and dropped.
+    if (!value.startsWith(QByteArray::fromHex("dfdf0300"))) {
+        DIFLUID_LOG(QString("Non-sensor notification: %1").arg(QString(value.toHex(' '))));
+        return;
+    }
     if (value.size() < 19) {
-        DIFLUID_WARN(QString("Short notification (%1 bytes, need 19): %2")
+        DIFLUID_WARN(QString("Sensor frame too short (%1 bytes, need 19): %2")
                          .arg(value.size()).arg(QString(value.toHex(' '))));
         return;
     }
@@ -200,7 +205,7 @@ void DifluidScale::onCharacteristicChanged(const QBluetoothUuid& characteristicU
         | (static_cast<quint32>(static_cast<quint8>(value[7])) << 8)
         |  static_cast<quint32>(static_cast<quint8>(value[8])));
 
-    if (qAbs(weightRaw) >= 20000) {
+    if (weightRaw <= -20000 || weightRaw >= 20000) {
         DIFLUID_WARN(QString("Weight out of range: raw=%1 (%2 g) — ignoring")
                          .arg(weightRaw).arg(weightRaw / 10.0));
         return;

--- a/src/ble/scales/difluidscale.cpp
+++ b/src/ble/scales/difluidscale.cpp
@@ -46,8 +46,8 @@ void DifluidScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     }
 
     m_name = device.name();
-    m_service = QBluetoothUuid();
-    m_characteristicsReady = false;
+    resetLinkState();
+    m_discoveredServices.clear();
 
     DIFLUID_LOG(QString("Connecting to %1 (%2)")
                 .arg(device.name())
@@ -63,11 +63,21 @@ void DifluidScale::onTransportConnected() {
 
 void DifluidScale::onTransportDisconnected() {
     DIFLUID_LOG("Transport disconnected");
+    resetLinkState();
     setConnected(false);
+}
+
+void DifluidScale::resetLinkState() {
+    // Mirrors DiFluidR2's disconnect handling. Without this, m_characteristicsReady
+    // and m_service survive a drop, so sendCommand's guards pass and every
+    // subsequent tare/timer write goes to a torn-down transport.
+    m_service = QBluetoothUuid();
+    m_characteristicsReady = false;
 }
 
 void DifluidScale::onTransportError(const QString& message) {
     DIFLUID_WARN(QString("Transport error: %1").arg(message));
+    resetLinkState();
     setConnected(false);
 }
 
@@ -75,29 +85,61 @@ void DifluidScale::onServiceDiscovered(const QBluetoothUuid& uuid) {
     DIFLUID_LOG(QString("Service discovered: %1").arg(uuid.toString()));
     // Microbalance (0x00EE) and Microbalance Ti (0x00DD) are the same protocol
     // on different services — accept either and remember which.
-    if (uuid == Scale::DiFluid::SERVICE) {
-        DIFLUID_LOG("Found DiFluid Microbalance service");
-        m_service = uuid;
-    } else if (uuid == Scale::DiFluid::SERVICE_TI) {
-        DIFLUID_LOG("Found DiFluid Microbalance Ti service");
-        m_service = uuid;
+    if (uuid != Scale::DiFluid::SERVICE && uuid != Scale::DiFluid::SERVICE_TI) {
+        m_discoveredServices.append(uuid.toString());
+        return;
     }
+    // First match wins. A device could advertise both — a vendor keeping the old
+    // service for compatibility is exactly the shape of this change — and BLE
+    // discovery order is not guaranteed, so "last one seen" would be a coin toss.
+    if (!m_service.isNull()) {
+        DIFLUID_LOG(QString("Also advertises %1; staying on %2")
+                        .arg(uuid.toString(), m_service.toString()));
+        return;
+    }
+    // Bind the ternary to a local: SCALE_LOG concatenates its argument onto a
+    // prefix, so an unparenthesised ternary would bind as (prefix + cond) ? a : b.
+    const QString found = uuid == Scale::DiFluid::SERVICE_TI
+                              ? QStringLiteral("Found DiFluid Microbalance Ti service")
+                              : QStringLiteral("Found DiFluid Microbalance service");
+    DIFLUID_LOG(found);
+    m_service = uuid;
 }
 
 void DifluidScale::onServicesDiscoveryFinished() {
     DIFLUID_LOG(QString("Service discovery finished, service found: %1")
                 .arg(m_service.isNull() ? QStringLiteral("none") : m_service.toString()));
     if (m_service.isNull()) {
-        DIFLUID_WARN(QString("Neither DiFluid service %1 nor %2 found!")
-                     .arg(Scale::DiFluid::SERVICE.toString(),
-                          Scale::DiFluid::SERVICE_TI.toString()));
+        // Name what was actually there. Two bare UUIDs and a negative give a reader
+        // nothing to compare against — and this path is reachable for any device the
+        // name matcher pulled in that is not a DiFluid at all.
+        DIFLUID_WARN(QString("\"%1\" advertises neither DiFluid service "
+                             "(%2 Microbalance / %3 Ti). Services found: %4. "
+                             "This is probably not a DiFluid scale — check the scale "
+                             "type in Connections.")
+                         .arg(m_name,
+                              Scale::DiFluid::SERVICE.toString(),
+                              Scale::DiFluid::SERVICE_TI.toString(),
+                              m_discoveredServices.isEmpty()
+                                  ? QStringLiteral("none")
+                                  : m_discoveredServices.join(QStringLiteral(", "))));
+        emit errorOccurred(QString("%1 does not look like a DiFluid scale.").arg(m_name));
         return;
     }
     m_transport->discoverCharacteristics(m_service);
 }
 
 void DifluidScale::onCharacteristicsDiscoveryFinished(const QBluetoothUuid& serviceUuid) {
-    if (m_service.isNull() || serviceUuid != m_service) return;
+    if (m_service.isNull()) {
+        DIFLUID_WARN(QString("Characteristics discovered for %1 but no DiFluid service "
+                             "was adopted — ignoring").arg(serviceUuid.toString()));
+        return;
+    }
+    if (serviceUuid != m_service) {
+        DIFLUID_LOG(QString("Ignoring characteristics for unrelated service %1")
+                        .arg(serviceUuid.toString()));
+        return;
+    }
     if (m_characteristicsReady) {
         DIFLUID_LOG("Characteristics already set up, ignoring duplicate callback");
         return;
@@ -111,6 +153,12 @@ void DifluidScale::onCharacteristicsDiscoveryFinished(const QBluetoothUuid& serv
     DIFLUID_LOG("Scheduling notification enable in 100ms (de1app timing)");
     QTimer::singleShot(100, this, [this]() {
         if (!m_transport || !m_characteristicsReady) return;
+        // The link can drop inside this 100ms window, and resetLinkState() nulls
+        // m_service — without this guard we would enable notifications on a null UUID.
+        if (m_service.isNull()) {
+            DIFLUID_WARN("Notification enable aborted — link dropped during setup");
+            return;
+        }
         DIFLUID_LOG("Enabling notifications (100ms)");
         m_transport->enableNotifications(m_service, Scale::DiFluid::CHARACTERISTIC);
 
@@ -123,24 +171,55 @@ void DifluidScale::onCharacteristicsDiscoveryFinished(const QBluetoothUuid& serv
 
 void DifluidScale::onCharacteristicChanged(const QBluetoothUuid& characteristicUuid,
                                            const QByteArray& value) {
-    if (characteristicUuid == Scale::DiFluid::CHARACTERISTIC) {
-        // Difluid format: header bytes, then hex-encoded weight
-        if (value.size() >= 19) {
-            // Weight is in bytes 5-8 as hex-encoded integer
-            QString hexStr = value.mid(5, 8).toHex();
-            bool ok;
-            uint32_t weightRaw = hexStr.toUInt(&ok, 16);
+    if (characteristicUuid != Scale::DiFluid::CHARACTERISTIC) return;
 
-            if (ok && weightRaw < 20000) {
-                double weight = weightRaw / 10.0;
-                setWeight(weight);
-            }
-        }
+    // Sensor data notification: DF DF 03 00 <len> <weight:4> <timer:4> … , weight
+    // signed and scaled ×10 in grams. DiFluid's worked example in
+    // protocolMicrobalance.md is
+    //   DF DF 03 00 0D 00 00 02 F8 00 00 00 00 00 0A 27 B0 00 A9
+    // where bytes 5..8 = 0x000002F8 = 760 → 76.0 g.
+    //
+    // This used to read `value.mid(5, 8)` — eight bytes, not the four the field
+    // occupies — hex it to sixteen characters and parse that with toUInt(), which
+    // overflows and returns ok=false for any non-zero weight. So setWeight() was
+    // reached only when the weight was exactly zero, and then it was parsing the
+    // timer bytes. The comment already said "bytes 5-8" (four bytes); the code
+    // took a character count for a byte count.
+    if (value.size() < 19) {
+        DIFLUID_WARN(QString("Short notification (%1 bytes, need 19): %2")
+                         .arg(value.size()).arg(QString(value.toHex(' '))));
+        return;
     }
+
+    // Signed: the field goes negative after a tare drift, and reading it unsigned
+    // turned −0.5 g into 4294967291, which the range gate below then discarded —
+    // freezing the displayed weight at its last non-negative value.
+    const qint32 weightRaw = static_cast<qint32>(
+          (static_cast<quint32>(static_cast<quint8>(value[5])) << 24)
+        | (static_cast<quint32>(static_cast<quint8>(value[6])) << 16)
+        | (static_cast<quint32>(static_cast<quint8>(value[7])) << 8)
+        |  static_cast<quint32>(static_cast<quint8>(value[8])));
+
+    if (qAbs(weightRaw) >= 20000) {
+        DIFLUID_WARN(QString("Weight out of range: raw=%1 (%2 g) — ignoring")
+                         .arg(weightRaw).arg(weightRaw / 10.0));
+        return;
+    }
+    setWeight(weightRaw / 10.0);
 }
 
 void DifluidScale::sendCommand(const QByteArray& cmd) {
-    if (!m_transport || !m_characteristicsReady || m_service.isNull()) return;
+    // Every caller here is either a user action (tare, the timer buttons, and the
+    // MCP tools behind them) or a connect-handshake step. Dropping one silently
+    // means the MCP layer answers "Scale tared" for a write that never happened.
+    if (!m_transport || !m_characteristicsReady || m_service.isNull()) {
+        DIFLUID_WARN(QString("Dropping command %1 — transport=%2 characteristicsReady=%3 service=%4")
+                         .arg(QString(cmd.toHex(' ')),
+                              m_transport ? QStringLiteral("yes") : QStringLiteral("no"),
+                              m_characteristicsReady ? QStringLiteral("yes") : QStringLiteral("no"),
+                              m_service.isNull() ? QStringLiteral("none") : m_service.toString()));
+        return;
+    }
     m_transport->writeCharacteristic(m_service, Scale::DiFluid::CHARACTERISTIC, cmd);
 }
 

--- a/src/ble/scales/difluidscale.h
+++ b/src/ble/scales/difluidscale.h
@@ -3,6 +3,8 @@
 #include "../scaledevice.h"
 #include "../transport/scalebletransport.h"
 
+#include <QBluetoothUuid>
+
 class DifluidScale : public ScaleDevice {
     Q_OBJECT
 
@@ -38,6 +40,11 @@ private:
 
     ScaleBleTransport* m_transport = nullptr;
     QString m_name = "Difluid";
-    bool m_serviceFound = false;
+    // Which DiFluid service this device actually advertised — 0x00EE on the
+    // original Microbalance, 0x00DD on the Ti. Null until discovery finds one,
+    // so it doubles as the "service found" flag. Everything downstream
+    // (characteristic discovery, notifications, writes) uses this rather than a
+    // hard-coded constant, because the two models differ only here.
+    QBluetoothUuid m_service;
     bool m_characteristicsReady = false;
 };

--- a/src/ble/scales/difluidscale.h
+++ b/src/ble/scales/difluidscale.h
@@ -4,6 +4,7 @@
 #include "../transport/scalebletransport.h"
 
 #include <QBluetoothUuid>
+#include <QStringList>
 
 class DifluidScale : public ScaleDevice {
     Q_OBJECT
@@ -35,6 +36,9 @@ private slots:
 
 private:
     void sendCommand(const QByteArray& cmd);
+    // Clears the per-link state so a dropped connection cannot leave sendCommand's
+    // guards passing against a torn-down transport.
+    void resetLinkState();
     void enableNotifications();
     void setToGrams();
 
@@ -44,7 +48,10 @@ private:
     // original Microbalance, 0x00DD on the Ti. Null until discovery finds one,
     // so it doubles as the "service found" flag. Everything downstream
     // (characteristic discovery, notifications, writes) uses this rather than a
-    // hard-coded constant, because the two models differ only here.
+    // hard-coded constant, because that is where the two models differ.
     QBluetoothUuid m_service;
+    // Everything else the device advertised, so a "not a DiFluid" failure can say
+    // what it did find instead of only what it didn't.
+    QStringList m_discoveredServices;
     bool m_characteristicsReady = false;
 };

--- a/src/ble/scales/scalefactory.cpp
+++ b/src/ble/scales/scalefactory.cpp
@@ -241,8 +241,12 @@ bool ScaleFactory::isSmartChefScale(const QString& name) {
 bool ScaleFactory::isDifluidScale(const QString& name) {
     // Exclude R2 refractometer — it advertises with "difluid" in its name
     if (name.contains("r2")) return false;
+    // "mb ti" is the short form the Microbalance Ti can advertise under, which
+    // carries neither "difluid" nor "microbalance" (Beanconqueror matches the
+    // same two names). Without it a Ti is never routed to DifluidScale at all.
     return name.contains("difluid") ||
-           name.contains("microbalance");
+           name.contains("microbalance") ||
+           name.contains("mb ti");
 }
 
 bool ScaleFactory::isEurekaPrecisa(const QString& name) {

--- a/src/ble/scales/scalefactory.cpp
+++ b/src/ble/scales/scalefactory.cpp
@@ -241,9 +241,13 @@ bool ScaleFactory::isSmartChefScale(const QString& name) {
 bool ScaleFactory::isDifluidScale(const QString& name) {
     // Exclude R2 refractometer — it advertises with "difluid" in its name
     if (name.contains("r2")) return false;
-    // "mb ti" is the short form the Microbalance Ti can advertise under, which
-    // carries neither "difluid" nor "microbalance" (Beanconqueror matches the
-    // same two names). Without it a Ti is never routed to DifluidScale at all.
+    // "mb ti" is a short form the Microbalance Ti may advertise under, carrying
+    // neither "difluid" nor "microbalance". Beanconqueror's DifluidMicrobalanceTi
+    // matches "microbalance ti" and "mb ti", which is where this string comes from
+    // — neither DiFluid's docs nor ours records the Ti's actual advertised name, so
+    // it is unconfirmed against hardware. A Ti advertising the long form already
+    // matched via "microbalance"; this only adds the short one. NB: callers
+    // lowercase before calling, this function does not.
     return name.contains("difluid") ||
            name.contains("microbalance") ||
            name.contains("mb ti");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -796,12 +796,13 @@ add_decenza_test(tst_shotimportdedupe
 target_link_libraries(tst_shotimportdedupe PRIVATE decenza_shotlib)
 target_include_directories(tst_shotimportdedupe PRIVATE ${CMAKE_BINARY_DIR})
 
-# --- tst_scaleprotocol: Scale BLE packet parsing (Decent, Bookoo) ---
+# --- tst_scaleprotocol: Scale BLE packet parsing (Decent, Bookoo, DiFluid) ---
 add_decenza_test(tst_scaleprotocol
     tst_scaleprotocol.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/transport/scalebletransport.h
     ${CMAKE_SOURCE_DIR}/src/ble/scales/decentscale.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/scales/bookooscale.cpp
+    ${CMAKE_SOURCE_DIR}/src/ble/scales/difluidscale.cpp
 )
 
 # --- tst_decentscalewifi: WiFi scale driver (WebSocket protocol) ---

--- a/tests/tst_difluidr2.cpp
+++ b/tests/tst_difluidr2.cpp
@@ -366,6 +366,23 @@ private slots:
         QVERIFY(qAbs(r2.temperature() - 79.1) > 1.0);
     }
 
+    // The R2 echoes a settings write back (Func 1, Cmd 0 = temperature unit).
+    // That echo is log-only — it must not be mistaken for measurement data.
+    void settingsEchoIsNotTreatedAsMeasurement() {
+        DiFluidR2 r2(nullptr);
+        QSignalSpy tempSpy(&r2, &DiFluidR2::temperatureChanged);
+        QSignalSpy tdsSpy(&r2, &DiFluidR2::tdsChanged);
+
+        QByteArray data;
+        data.append(static_cast<char>(0x00));  // 0 = °C
+        r2.handlePacket(buildR2Packet(0x01, 0x00, data));
+
+        QCOMPARE(tempSpy.count(), 0);
+        QCOMPARE(tdsSpy.count(), 0);
+        QCOMPARE(r2.temperature(), 0.0);
+        QCOMPARE(r2.tds(), 0.0);
+    }
+
     // === Status packet parsing ===
 
     void parseStatusFinished() {

--- a/tests/tst_difluidr2.cpp
+++ b/tests/tst_difluidr2.cpp
@@ -79,15 +79,19 @@ private:
     }
 
     // Build a temperature packet: Func=3, Cmd=0, PackNo=1
-    // Prism temp = tempC * 10, tank temp = tempC * 10
-    static QByteArray buildTemperaturePacket(double tempC) {
-        uint16_t raw = static_cast<uint16_t>(qRound(tempC * 10.0));
+    // Prism temp = temp * 10, tank temp = temp * 10, both in the DEVICE's unit.
+    // unit: -1 omits Data5 entirely (firmware predating the unit byte, dataLen 5),
+    //        0 = °C, 1 = °F.
+    static QByteArray buildTemperaturePacket(double temp, int unit = -1) {
+        uint16_t raw = static_cast<uint16_t>(qRound(temp * 10.0));
         QByteArray data;
         data.append(static_cast<char>(0x01));  // PackNo = 1 (temperature)
         data.append(static_cast<char>((raw >> 8) & 0xFF));  // Prism temp high
         data.append(static_cast<char>(raw & 0xFF));          // Prism temp low
         data.append(static_cast<char>((raw >> 8) & 0xFF));  // Tank temp high
         data.append(static_cast<char>(raw & 0xFF));          // Tank temp low
+        if (unit >= 0)
+            data.append(static_cast<char>(unit));            // Data5: 0 = °C, 1 = °F
         return buildR2Packet(0x03, 0x00, data);
     }
 
@@ -331,6 +335,35 @@ private slots:
         // Temperature is prism temp / 10.0, encoded as tempC * 10
         QCOMPARE(spy.at(0).at(0).toDouble(), 23.50);
         QCOMPARE(r2.temperature(), 23.50);
+    }
+
+    // Data5 = 0: the device is already reporting Celsius, pass through unchanged.
+    void parseTemperaturePacketCelsiusUnit() {
+        DiFluidR2 r2(nullptr);
+        QSignalSpy spy(&r2, &DiFluidR2::temperatureChanged);
+
+        r2.handlePacket(buildTemperaturePacket(23.50, /*unit=*/0));
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toDouble(), 23.50);
+        QCOMPARE(r2.temperature(), 23.50);
+    }
+
+    // Data5 = 1: the device is reporting Fahrenheit and the driver must convert.
+    // Values are DiFluid's own worked example from protocolR2.md (79.1 °F prism).
+    // Before Data5 was honoured this surfaced as "79.1 °C".
+    void parseTemperaturePacketFahrenheitConverted() {
+        DiFluidR2 r2(nullptr);
+        QSignalSpy spy(&r2, &DiFluidR2::temperatureChanged);
+
+        r2.handlePacket(buildTemperaturePacket(79.1, /*unit=*/1));
+
+        QCOMPARE(spy.count(), 1);
+        const double expectedC = (79.1 - 32.0) * 5.0 / 9.0;  // ≈ 26.17
+        QVERIFY(qAbs(spy.at(0).at(0).toDouble() - expectedC) < 0.001);
+        QVERIFY(qAbs(r2.temperature() - expectedC) < 0.001);
+        // Guard the actual regression: never report the raw Fahrenheit number.
+        QVERIFY(qAbs(r2.temperature() - 79.1) > 1.0);
     }
 
     // === Status packet parsing ===

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -997,13 +997,46 @@ private slots:
         DifluidScale scale(transport);
         QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
 
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Short notification"));
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Sensor frame too short"));
         transport->fakeCharacteristicChanged(Scale::DiFluid::CHARACTERISTIC,
                                              QByteArray::fromHex("dfdf030001"));
 
         QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Weight out of range"));
         transport->fakeCharacteristicChanged(Scale::DiFluid::CHARACTERISTIC,
                                              difluidWeightFrame(999999));
+
+        QVERIFY(weightSpy.isEmpty());
+    }
+
+    void difluidIgnoresSettingsEchoesQuietly() {
+        // AA01 is also the characteristic the driver WRITES to, and the DF-DF family
+        // echoes settings back — so enableNotifications() and setToGrams() each drew a
+        // "too short" warning on every connect, calling healthy traffic malformed. At
+        // 5Hz a format mismatch would also evict the 1000-entry scale log, destroying
+        // the artifact someone would be asked to share.
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+
+        // Func 1 Cmd 0 echo — no warning, and failOnWarning() enforces that.
+        transport->fakeCharacteristicChanged(Scale::DiFluid::CHARACTERISTIC,
+                                             QByteArray::fromHex("dfdf01000101c1"));
+        QVERIFY(weightSpy.isEmpty());
+    }
+
+    void difluidExtremeWeightBytesDoNotTripUndefinedBehaviour() {
+        // 80 00 00 00 is INT32_MIN, the canonical "invalid reading" sentinel and the
+        // shape an unrecognised frame produces. qAbs() asserts on it in debug builds
+        // and is signed-overflow UB in release, so the range check must not use it.
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Weight out of range"));
+        transport->fakeCharacteristicChanged(
+            Scale::DiFluid::CHARACTERISTIC,
+            QByteArray::fromHex("dfdf03000d") + QByteArray::fromHex("80000000")
+                + QByteArray::fromHex("00000000000a27b000a9"));
 
         QVERIFY(weightSpy.isEmpty());
     }

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -42,12 +42,19 @@ public:
     void readCharacteristic(const QBluetoothUuid&, const QBluetoothUuid&) override {}
     bool isConnected() const override { return m_isConnected; }
 
-    // Drive the discovery handshake from a test (signals are protected on the base).
+    // Drive the discovery handshake from a test. Qt's `signals` macro expands to
+    // `public`, so these are not strictly necessary — they exist because
+    // `transport->fakeServiceDiscovered(x)` reads as "the transport reported x",
+    // which is the thing under test, rather than as a test emitting a signal.
     void fakeServiceDiscovered(const QBluetoothUuid& s) { emit serviceDiscovered(s); }
     void fakeServicesDiscoveryFinished() { emit servicesDiscoveryFinished(); }
     void fakeCharacteristicsDiscoveryFinished(const QBluetoothUuid& s) {
         emit characteristicsDiscoveryFinished(s);
     }
+    void fakeCharacteristicChanged(const QBluetoothUuid& c, const QByteArray& v) {
+        emit characteristicChanged(c, v);
+    }
+    void fakeDisconnected() { emit disconnected(); }
 
     int m_notifyEnableCount = 0;
     int m_disconnectCount = 0;
@@ -930,6 +937,130 @@ private slots:
         QVERIFY(transport->m_notifyEnableCount >= 1);
     }
 
+    // === DiFluid Microbalance / Microbalance Ti ===
+
+    // The service-selection tests below feed a constant in and assert the same
+    // constant comes out, and production compares that symbol to itself in between —
+    // so they cannot catch a wrong UUID. This is the assertion that ties the suite to
+    // the actual protocol fact the Ti support rests on.
+    void difluidServiceUuidsMatchTheProtocol() {
+        QCOMPARE(Scale::DiFluid::SERVICE.toString(),
+                 QString("{000000ee-0000-1000-8000-00805f9b34fb}"));
+        QCOMPARE(Scale::DiFluid::SERVICE_TI.toString(),
+                 QString("{000000dd-0000-1000-8000-00805f9b34fb}"));
+        QCOMPARE(Scale::DiFluid::CHARACTERISTIC.toString(),
+                 QString("{0000aa01-0000-1000-8000-00805f9b34fb}"));
+        QVERIFY2(Scale::DiFluid::SERVICE != Scale::DiFluid::SERVICE_TI,
+                 "the two models must not share a service, or Ti support is a no-op");
+    }
+
+    // DiFluid's worked example from protocolMicrobalance.md. Weight is bytes 5-8,
+    // signed, x10 grams: 0x000002F8 = 760 -> 76.0 g.
+    static QByteArray difluidWeightFrame(qint32 rawWeight) {
+        QByteArray f = QByteArray::fromHex("dfdf03000d");
+        f.append(static_cast<char>((rawWeight >> 24) & 0xFF));
+        f.append(static_cast<char>((rawWeight >> 16) & 0xFF));
+        f.append(static_cast<char>((rawWeight >> 8) & 0xFF));
+        f.append(static_cast<char>(rawWeight & 0xFF));
+        f.append(QByteArray::fromHex("00000000000a27b000a9"));  // timer + trailer
+        return f;
+    }
+
+    void difluidParsesTheDocumentedWeightFrame() {
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+
+        // Verbatim from the vendor doc, checksum byte included.
+        const QByteArray doc = QByteArray::fromHex(
+            "dfdf03000d000002f800000000000a27b000a9");
+        QCOMPARE(doc.size(), 19);
+        transport->fakeCharacteristicChanged(Scale::DiFluid::CHARACTERISTIC, doc);
+
+        QVERIFY2(!weightSpy.isEmpty(), "the vendor's own weight frame produced no reading");
+        QCOMPARE(scale.weight(), 76.0);
+    }
+
+    void difluidWeightGoesNegativeAfterTare() {
+        // The field is signed. Read unsigned, -0.5 g became 4294967291 and was
+        // discarded by the range gate, freezing the display at its last value.
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+
+        transport->fakeCharacteristicChanged(Scale::DiFluid::CHARACTERISTIC,
+                                             difluidWeightFrame(-5));
+        QCOMPARE(scale.weight(), -0.5);
+    }
+
+    void difluidRejectsImplausibleAndShortFrames() {
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Short notification"));
+        transport->fakeCharacteristicChanged(Scale::DiFluid::CHARACTERISTIC,
+                                             QByteArray::fromHex("dfdf030001"));
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Weight out of range"));
+        transport->fakeCharacteristicChanged(Scale::DiFluid::CHARACTERISTIC,
+                                             difluidWeightFrame(999999));
+
+        QVERIFY(weightSpy.isEmpty());
+    }
+
+    void difluidPrefersTheFirstServiceWhenBothAreAdvertised() {
+        // A vendor keeping the old service for compatibility is exactly the shape of
+        // this change, and BLE discovery order is not guaranteed — so this must not
+        // be a coin toss.
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+
+        transport->fakeServiceDiscovered(Scale::DiFluid::SERVICE);
+        transport->fakeServiceDiscovered(Scale::DiFluid::SERVICE_TI);
+        transport->fakeServicesDiscoveryFinished();
+
+        QCOMPARE(transport->m_characteristicDiscoveries.size(), 1);
+        QCOMPARE(transport->m_characteristicDiscoveries.at(0), Scale::DiFluid::SERVICE);
+    }
+
+    void difluidCommandsAreRefusedAndLoggedBeforeDiscovery() {
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Dropping command"));
+        scale.tare();
+
+        QVERIFY2(transport->m_writes.isEmpty(), "a command was written before any service was adopted");
+    }
+
+    void difluidDisconnectClearsLinkState() {
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+
+        transport->fakeServiceDiscovered(Scale::DiFluid::SERVICE_TI);
+        transport->fakeServicesDiscoveryFinished();
+        transport->fakeCharacteristicsDiscoveryFinished(Scale::DiFluid::SERVICE_TI);
+        QVERIFY(scale.isConnected());
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("DISCONNECTED"));
+        transport->fakeDisconnected();
+
+        // The 100ms notification-enable timer armed by characteristic discovery is
+        // still pending. It must not enable notifications on a dropped link — and it
+        // returns on the characteristicsReady check before reaching the m_service
+        // guard, so it does so silently. Let it fire to prove it stays quiet.
+        QTest::qWait(200);
+        QVERIFY2(transport->m_notifyEnableCount == 0,
+                 "notifications were enabled after the link dropped");
+
+        // Without the reset, sendCommand's guards still pass and every later write
+        // goes to a torn-down transport.
+        transport->m_writes.clear();
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Dropping command"));
+        scale.tare();
+        QVERIFY(transport->m_writes.isEmpty());
+    }
+
     // === DiFluid Microbalance / Microbalance Ti service selection ===
     //
     // The two models are the same protocol on different services (0x00EE vs
@@ -987,7 +1118,8 @@ private slots:
         // A Decent Scale service on a device we routed here by name must not be
         // mistaken for a DiFluid one.
         transport->fakeServiceDiscovered(Scale::Decent::SERVICE);
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Neither DiFluid service.*"));
+        QTest::ignoreMessage(QtWarningMsg,
+                             QRegularExpression("advertises neither DiFluid service"));
         transport->fakeServicesDiscoveryFinished();
 
         QVERIFY(transport->m_characteristicDiscoveries.isEmpty());

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -5,6 +5,7 @@
 
 #include "ble/scales/decentscale.h"
 #include "ble/scales/bookooscale.h"
+#include "ble/scales/difluidscale.h"
 #include "ble/transport/scalebletransport.h"
 #include "ble/protocol/de1characteristics.h"
 #include "ble/protocol/decentscaleprotocol.h"
@@ -26,19 +27,35 @@ public:
     void connectToDevice(const QString&, const QString&) override {}
     void disconnectFromDevice() override { m_disconnectCount++; }
     void discoverServices() override {}
-    void discoverCharacteristics(const QBluetoothUuid&) override {}
-    void enableNotifications(const QBluetoothUuid&, const QBluetoothUuid&) override { m_notifyEnableCount++; }
-    void writeCharacteristic(const QBluetoothUuid&, const QBluetoothUuid&,
+    void discoverCharacteristics(const QBluetoothUuid& service) override {
+        m_characteristicDiscoveries.append(service);
+    }
+    void enableNotifications(const QBluetoothUuid& service, const QBluetoothUuid&) override {
+        m_notifyEnableCount++;
+        m_lastNotifyService = service;
+    }
+    void writeCharacteristic(const QBluetoothUuid& service, const QBluetoothUuid&,
                              const QByteArray& value, WriteType = WriteType::WithResponse) override {
         m_writes.append(value);
+        m_lastWriteService = service;
     }
     void readCharacteristic(const QBluetoothUuid&, const QBluetoothUuid&) override {}
     bool isConnected() const override { return m_isConnected; }
+
+    // Drive the discovery handshake from a test (signals are protected on the base).
+    void fakeServiceDiscovered(const QBluetoothUuid& s) { emit serviceDiscovered(s); }
+    void fakeServicesDiscoveryFinished() { emit servicesDiscoveryFinished(); }
+    void fakeCharacteristicsDiscoveryFinished(const QBluetoothUuid& s) {
+        emit characteristicsDiscoveryFinished(s);
+    }
 
     int m_notifyEnableCount = 0;
     int m_disconnectCount = 0;
     bool m_isConnected = true;
     QList<QByteArray> m_writes;
+    QList<QBluetoothUuid> m_characteristicDiscoveries;
+    QBluetoothUuid m_lastNotifyService;
+    QBluetoothUuid m_lastWriteService;
 };
 
 class tst_ScaleProtocol : public QObject {
@@ -911,6 +928,70 @@ private slots:
 
         // Watchdog should have fired and re-enabled notifications
         QVERIFY(transport->m_notifyEnableCount >= 1);
+    }
+
+    // === DiFluid Microbalance / Microbalance Ti service selection ===
+    //
+    // The two models are the same protocol on different services (0x00EE vs
+    // 0x00DD). The driver must follow whichever the device advertised through
+    // characteristic discovery, notifications and writes — matching only 0x00EE
+    // left a Ti connected but permanently silent.
+
+    void difluidClassicServiceDrivesDiscovery() {
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+
+        transport->fakeServiceDiscovered(Scale::DiFluid::SERVICE);
+        transport->fakeServicesDiscoveryFinished();
+
+        QCOMPARE(transport->m_characteristicDiscoveries.size(), 1);
+        QCOMPARE(transport->m_characteristicDiscoveries.at(0), Scale::DiFluid::SERVICE);
+    }
+
+    void difluidTiServiceDrivesDiscovery() {
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+
+        transport->fakeServiceDiscovered(Scale::DiFluid::SERVICE_TI);
+        transport->fakeServicesDiscoveryFinished();
+
+        QCOMPARE(transport->m_characteristicDiscoveries.size(), 1);
+        QCOMPARE(transport->m_characteristicDiscoveries.at(0), Scale::DiFluid::SERVICE_TI);
+    }
+
+    void difluidTiCommandsUseTiService() {
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+
+        transport->fakeServiceDiscovered(Scale::DiFluid::SERVICE_TI);
+        transport->fakeServicesDiscoveryFinished();
+        transport->fakeCharacteristicsDiscoveryFinished(Scale::DiFluid::SERVICE_TI);
+
+        QVERIFY(scale.isConnected());
+
+        // Setup commands are sent from a 100ms singleShot after discovery.
+        QTest::qWait(200);
+        QVERIFY(!transport->m_writes.isEmpty());
+        QCOMPARE(transport->m_lastWriteService, Scale::DiFluid::SERVICE_TI);
+        QCOMPARE(transport->m_lastNotifyService, Scale::DiFluid::SERVICE_TI);
+
+        // And an explicit command after setup keeps using the Ti service.
+        scale.tare();
+        QCOMPARE(transport->m_lastWriteService, Scale::DiFluid::SERVICE_TI);
+    }
+
+    void difluidUnknownServiceIsNotAdopted() {
+        auto* transport = new MockScaleBleTransport;
+        DifluidScale scale(transport);
+
+        // A Decent Scale service on a device we routed here by name must not be
+        // mistaken for a DiFluid one.
+        transport->fakeServiceDiscovered(Scale::Decent::SERVICE);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(".*Neither DiFluid service.*"));
+        transport->fakeServicesDiscoveryFinished();
+
+        QVERIFY(transport->m_characteristicDiscoveries.isEmpty());
+        QVERIFY(!scale.isConnected());
     }
 };
 


### PR DESCRIPTION
Three DiFluid device-protocol fixes, found by diffing our drivers against DiFluid's published docs and [Beanconqueror's drivers](https://github.com/graphefruit/Beanconqueror/tree/master/src/classes/devices), then hardened over two review rounds.

## 1. DiFluid weight was never parsed

`onCharacteristicChanged` read `value.mid(5, 8)` — eight bytes where the field is four, and where the comment above it already said "bytes 5-8". Hexed that is sixteen characters, and `QString::toUInt` overflows and returns `ok=false` for any non-zero weight, so `setWeight()` was reached only when the weight was exactly zero — and then parsed the timer bytes.

DiFluid's own worked frame in `protocolMicrobalance.md` decodes to 76.0 g and produced nothing:

```
DF DF 03 00 0D  00 00 02 F8  ...     bytes 5-8 = 0x000002F8 = 760 → 76.0 g
```

The field is also **signed** — read unsigned, a post-tare −0.5 g became 4294967291 and was discarded by the range gate, freezing the display at its last non-negative value.

This matters for the Ti below: routing the service was necessary but not sufficient. A Ti owner would have got a scale that reports Connected, sits at 0.0 g all shot, and logs nothing.

## 2. R2 reported Fahrenheit readings as Celsius

Pack 1 carries `Data5` — the unit its temperatures are expressed in. We hardcoded the °C label, so an R2 switched to Fahrenheit reported **79.1 °C for a 26.2 °C prism**. DiFluid's own worked example is a Fahrenheit packet. Verified on hardware since (`Data5 = 0`, prism 25.1 °C).

The connect handshake also now *writes* Celsius rather than querying it. The per-packet conversion stays and is what actually guarantees correctness — the write is not instantaneous and packets can already be in flight.

## 3. Microbalance Ti could never connect

The Ti speaks the same protocol on service **`0x00DD`** where the original uses `0x00EE`. We matched only `0x00EE`, so a Ti reached service discovery, matched nothing, warned, and never became a connected scale. Both services are now accepted, first-match-wins (discovery order isn't guaranteed), with everything downstream following the one the device actually advertised. Also matches the short `MB Ti` advertising name.

## Silent failures closed

Every `sendCommand` refusal (the MCP layer answers "Scale tared" unconditionally, so a dropped write was reported to a field AI as success), short and out-of-range weight frames, characteristics discovered for an unadopted service, R2 dropped commands, runt packets, and absent status/error/unit bytes — a zero-length unit response used to log a confident "°C", and a truncated error packet logged `class=0 code=0` while skipping the class-2 branch, so a truncated "No liquid detected" reached the user as nothing at all.

`m_service` and `m_characteristicsReady` now reset on disconnect and transport error, matching `DiFluidR2`; without it the guards passed on a dead link.

## Fixed during review of the fixes

- `qAbs` on a value read straight off the wire is UB at `INT32_MIN` — Qt asserts on it in debug (ASan+UBSan here), and `80 00 00 00` is the canonical invalid-reading sentinel.
- The new short-frame warning fired on **healthy traffic**: `AA01` is also the characteristic we write to and the DF-DF family echoes settings back, so every connect drew two "malformed" warnings. At 5 Hz a format mismatch would evict the whole 1000-entry scale log in ~200 s — destroying the artifact a diagnostician asks for.

## Testing

Full suite: **102 passed, 0 failed, no warnings.**

The two Ti service tests originally fed a constant in and asserted the same constant came out — a typo'd UUID would have passed them and shipped a dead Ti. They now assert against the literal protocol strings. Added: the vendor's documented weight frame, negative weight, extreme bytes that would abort a debug build, settings echoes passing without a warning, both-services precedence, refusal-before-discovery, and disconnect state reset.

**Not verified on hardware** — no DiFluid scale available. The weight fix rests on the vendor's documented frame and de1app's equivalent parse (`string range $data 10 17` = 4 bytes at offset 5). Worth a Microbalance owner confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)