### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(Decenza VERSION 2.0.0 LANGUAGES CXX)
+project(Decenza VERSION 2.0.1 LANGUAGES CXX)
 
 message(STATUS "Developer note: executable target is now 'Decenza'. If Qt Creator shows 'No executable specified', re-run CMake and select the 'Decenza' Run configuration.")
 


### PR DESCRIPTION
Display version bump for the v2.0.1 pre-release. `CMakeLists.txt` line 2 only.

`versioncode.txt` is deliberately untouched — CI bumps it on tag push and the Android workflow commits the new value back to `main` (see [CI_CD.md](docs/CLAUDE_MD/CI_CD.md)).

Release notes and the tag follow this merge, in that order: the GitHub Release must exist before the tag is pushed, or Android/Linux auto-create a non-prerelease with generated notes while macOS/Windows silently skip their uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)