### PR TITLE
Fix two background-source defects: the shot chart's scrim, and a stored key that never converges

### DIFF
--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -544,9 +544,24 @@ QtObject {
     // (it has no parameter), so on a fresh install with no shots the source says shot while
     // BackgroundSurface paints a flat colour — and scrimming chrome over a flat colour is
     // the exact elevation-cancelling failure chromeFill()'s own comment documents.
+    //
+    // That fact is PUSHED in by LastShotChartSource rather than read from it. Everything
+    // else this file reads — Settings, TemperatureDisplay, EmojiAssets — is a context
+    // property, visible everywhere without an import; LastShotChartSource is a QML singleton
+    // in qml/components/, and a file in qml/ cannot see a type from another directory. This
+    // condition used to reference it directly, which compiled clean and threw
+    // "ReferenceError: LastShotChartSource is not defined" on every evaluation, pinning
+    // hasBackgroundImage to false for the whole shot case: the chart drew, and all ~70 call
+    // sites below painted chrome opaque over it — the exact inverse of the intent.
+    //
+    // Keep it a push. Theme is the lowest-level singleton in the app and deliberately
+    // depends on nothing but context properties; importing the module here to reach one
+    // component would trade a runtime error for a dependency cycle waiting to happen.
+    property bool shotChartRendered: false
+
     readonly property bool hasBackgroundImage: Settings.theme.backgroundSource === "image"
                                                || (Settings.theme.backgroundSource === "shot"
-                                                   && LastShotChartSource.imageSource.length > 0)
+                                                   && shotChartRendered)
 
     // The fill a piece of chrome should actually paint.
     //

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -545,23 +545,25 @@ QtObject {
     // BackgroundSurface paints a flat colour — and scrimming chrome over a flat colour is
     // the exact elevation-cancelling failure chromeFill()'s own comment documents.
     //
-    // That fact is PUSHED in by LastShotChartSource rather than read from it. Everything
-    // else this file reads — Settings, TemperatureDisplay, EmojiAssets — is a context
-    // property, visible everywhere without an import; LastShotChartSource is a QML singleton
-    // in qml/components/, and a file in qml/ cannot see a type from another directory. This
-    // condition used to reference it directly, which compiled clean and threw
-    // "ReferenceError: LastShotChartSource is not defined" on every evaluation, pinning
-    // hasBackgroundImage to false for the whole shot case: the chart drew, and all ~70 call
-    // sites below painted chrome opaque over it — the exact inverse of the intent.
+    // Set by main.qml from the background of the page on TOP of the stack — see the note
+    // there. Not read from LastShotChartSource: that singleton lives in qml/components/ and
+    // a file in qml/ cannot see a type from another directory, so referencing it here
+    // compiled clean and threw "ReferenceError: LastShotChartSource is not defined" on
+    // every evaluation, pinning hasBackgroundImage false for the whole shot case. Theme is
+    // also the lowest-level singleton in the app and deliberately depends on nothing but
+    // context properties; importing the module here to reach one component would trade a
+    // runtime error for a dependency cycle waiting to happen.
     //
-    // Keep it a push. Theme is the lowest-level singleton in the app and deliberately
-    // depends on nothing but context properties; importing the module here to reach one
-    // component would trade a runtime error for a dependency cycle waiting to happen.
-    property bool shotChartRendered: false
+    // Per-PAGE, unlike the image below, because the chart is the one background a page can
+    // refuse: ThemedPageBackground.suppressShotChart turns it off wherever the page draws a
+    // graph of its own, and those pages then paint a flat colour. A global "a render
+    // exists" answer would claim a picture is behind the chrome there too — which is the
+    // elevation-cancelling failure chromeFill() documents below, and which collapses
+    // insetBackgroundColor onto backgroundColor so the control disappears entirely.
+    property bool shotChartOnCurrentPage: false
 
     readonly property bool hasBackgroundImage: Settings.theme.backgroundSource === "image"
-                                               || (Settings.theme.backgroundSource === "shot"
-                                                   && shotChartRendered)
+                                               || shotChartOnCurrentPage
 
     // The fill a piece of chrome should actually paint.
     //

--- a/qml/components/BackgroundSurface.qml
+++ b/qml/components/BackgroundSurface.qml
@@ -61,6 +61,17 @@ Item {
     readonly property bool _hasPattern: _pattern.id !== undefined && !_hasShotChart
     readonly property bool _hasImage: !_hasPreset && (_hasShotChart || imagePath.length > 0)
 
+    // The same fact under a public name, because one reader outside this file needs it and
+    // reaching for an underscore across a file boundary is how a private becomes an API
+    // nobody meant to publish. main.qml binds Theme.shotChartOnCurrentPage to this for the
+    // page on top of the stack — see the note there for why the app-wide glass chrome has
+    // to ask a PAGE whether a chart is behind it, rather than asking the setting.
+    //
+    // Deliberately the drawn state and not the stored one: it is false while the render is
+    // still pending, false when a preset overrides, and false on a page that suppresses the
+    // chart. Those are exactly the cases where the chrome must stay opaque.
+    readonly property bool paintsShotChart: _hasShotChart
+
     // The flat colour actually being painted, and the ink that will read on it.
     //
     // Derived per instance, NOT taken from Theme.textColor. Theme's value follows the

--- a/qml/components/LastShotChartSource.qml
+++ b/qml/components/LastShotChartSource.qml
@@ -27,6 +27,16 @@ QtObject {
     // straight into the same Image path a background photo takes.
     readonly property string imageSource: _renderedUrl
 
+    // Theme.hasBackgroundImage needs to know whether a render exists, and cannot read it
+    // from here: Theme lives in qml/ and imports nothing from the module, so this type is
+    // simply not in scope there. Pushed from the side that CAN see Theme.
+    //
+    // Not a Binding in main.qml, which can see both: reading imageSource from there would
+    // instantiate this singleton at startup for every user, which is what the load guard on
+    // shotBackgroundSelected below exists to avoid. Pushing costs nothing when the feature
+    // is off, because then nothing creates this object and false is the right answer anyway.
+    onImageSourceChanged: Theme.shotChartRendered = imageSource.length > 0
+
     // Distinguishes "no shot exists" from "not fetched yet", so the fallback does not flash
     // on a cold start: nothing is drawn until we know there is nothing to draw.
     readonly property bool ready: _loadState !== "loading"

--- a/qml/components/LastShotChartSource.qml
+++ b/qml/components/LastShotChartSource.qml
@@ -27,16 +27,6 @@ QtObject {
     // straight into the same Image path a background photo takes.
     readonly property string imageSource: _renderedUrl
 
-    // Theme.hasBackgroundImage needs to know whether a render exists, and cannot read it
-    // from here: Theme lives in qml/ and imports nothing from the module, so this type is
-    // simply not in scope there. Pushed from the side that CAN see Theme.
-    //
-    // Not a Binding in main.qml, which can see both: reading imageSource from there would
-    // instantiate this singleton at startup for every user, which is what the load guard on
-    // shotBackgroundSelected below exists to avoid. Pushing costs nothing when the feature
-    // is off, because then nothing creates this object and false is the right answer anyway.
-    onImageSourceChanged: Theme.shotChartRendered = imageSource.length > 0
-
     // Distinguishes "no shot exists" from "not fetched yet", so the fallback does not flash
     // on a cold start: nothing is drawn until we know there is nothing to draw.
     readonly property bool ready: _loadState !== "loading"

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1136,6 +1136,32 @@ ApplicationWindow {
         source: "components/LastShotChartRenderer.qml"
     }
 
+    // Whether the page on TOP of the stack is actually drawing the last shot's chart.
+    //
+    // Theme.hasBackgroundImage gates the app-wide glass chrome, and for a photo that is a
+    // fair app-wide question — every page shows it. The chart is not: ThemedPageBackground
+    // .suppressShotChart turns it off on the pages that draw a graph of their own, which
+    // then paint a flat colour. Answering "a render exists" app-wide told the chrome a
+    // picture was behind it on those pages too, and chrome scrimmed over a flat colour is
+    // the elevation-cancelling failure chromeFill() documents — insetBackgroundColor in
+    // particular becomes 40% of backgroundColor over itself, which is backgroundColor, and
+    // text fields and switch tracks drawn straight on the page vanish.
+    //
+    // A binding rather than a push from the surface: several ThemedPageBackgrounds are
+    // alive at once in the stack, so whichever one wrote last would win regardless of which
+    // page you are looking at. currentItem answers for the one on top, and re-evaluates
+    // both on navigation and when a late render lands. It costs no extra work either —
+    // paintsShotChart is the surface's own drawing state, which it computes anyway, and its
+    // `shotChart &&` short-circuits before touching LastShotChartSource when this
+    // background is not selected, so the singleton's load guard still holds.
+    Binding {
+        target: Theme
+        property: "shotChartOnCurrentPage"
+        value: !!(pageStack.currentItem
+                  && pageStack.currentItem.background
+                  && pageStack.currentItem.background.paintsShotChart)
+    }
+
     // Page stack for navigation
     StackView {
         id: pageStack

--- a/src/core/settings_theme.cpp
+++ b/src/core/settings_theme.cpp
@@ -79,6 +79,13 @@ void SettingsTheme::setBackgroundImagePath(const QString& path) {
     } else if (storedBackgroundSource() == kBackgroundSourceImage) {
         // Clearing the path the stored source NAMES. Without this the key kept pointing at
         // an image that is gone — see the note in setBackgroundPreset.
+        //
+        // Reading the key is what makes this safe, and it depends on the ORDER above: every
+        // caller that switches source stores the new kind BEFORE clearing the old
+        // parameter, so by the time a nested clear reaches here the key already says
+        // "colour" or "shot" and this branch declines. Move the store after the clear and
+        // this silently releases a source that was just selected — clearingOneSourceDoes
+        // NotDisturbAnother is the test that would catch it.
         storeBackgroundSource(QString::fromLatin1(kBackgroundSourceNone));
     }
     notifyBackgroundSourceChanged(before);
@@ -141,6 +148,10 @@ void SettingsTheme::setBackgroundPreset(const QString& id) {
         // This is the write path recording the user's own action, not the read path
         // rewriting stored data — backgroundSource() still derives and still rewrites
         // nothing, which is what keeps an install predating the key working.
+        //
+        // Same ordering dependency as the branch in setBackgroundImagePath: this is safe
+        // only because a caller switching source stores the new kind before clearing the
+        // old parameter, so a nested clear finds a key that no longer names it.
         storeBackgroundSource(QString::fromLatin1(kBackgroundSourceNone));
     }
     notifyBackgroundSourceChanged(before);

--- a/src/core/settings_theme.cpp
+++ b/src/core/settings_theme.cpp
@@ -76,6 +76,10 @@ void SettingsTheme::setBackgroundImagePath(const QString& path) {
     if (!path.isEmpty()) {
         storeBackgroundSource(kBackgroundSourceImage);
         clearBackgroundPreset("a background image was chosen instead");
+    } else if (storedBackgroundSource() == kBackgroundSourceImage) {
+        // Clearing the path the stored source NAMES. Without this the key kept pointing at
+        // an image that is gone — see the note in setBackgroundPreset.
+        storeBackgroundSource(QString::fromLatin1(kBackgroundSourceNone));
     }
     notifyBackgroundSourceChanged(before);
 }
@@ -123,6 +127,21 @@ void SettingsTheme::setBackgroundPreset(const QString& id) {
     if (!id.isEmpty()) {
         storeBackgroundSource(kBackgroundSourceColour);
         setBackgroundImagePath(QString());
+    } else if (storedBackgroundSource() == kBackgroundSourceColour) {
+        // Clearing the colour the stored source NAMES, so the key has to move with it.
+        //
+        // Without this the pair went permanently inconsistent — source "colour", preset
+        // empty — and stayed that way, because the guard above only ever wrote the key when
+        // a colour was SET. backgroundSource() derived "none" correctly so nothing looked
+        // wrong on screen, but it logged "not backed by a value this build can draw" on
+        // every launch for the life of the install: 152 times in one dev machine's log.
+        // That message exists to make an override diagnosable; one that fires forever on a
+        // state that can never resolve trains the reader to skip it.
+        //
+        // This is the write path recording the user's own action, not the read path
+        // rewriting stored data — backgroundSource() still derives and still rewrites
+        // nothing, which is what keeps an install predating the key working.
+        storeBackgroundSource(QString::fromLatin1(kBackgroundSourceNone));
     }
     notifyBackgroundSourceChanged(before);
 }
@@ -137,8 +156,12 @@ void SettingsTheme::setBackgroundPreset(const QString& id) {
 //
 // Nothing is rewritten on read. The derivation is unambiguous, and rewriting stored
 // user-set values is a thing this project deliberately does not do.
+QString SettingsTheme::storedBackgroundSource() const {
+    return m_settings.value("theme/backgroundSource", "").toString();
+}
+
 QString SettingsTheme::backgroundSource() const {
-    const QString stored = m_settings.value("theme/backgroundSource", "").toString();
+    const QString stored = storedBackgroundSource();
     if (stored == kBackgroundSourceShot)
         return stored;
     if (stored == kBackgroundSourceColour && !backgroundPreset().isEmpty())

--- a/src/core/settings_theme.h
+++ b/src/core/settings_theme.h
@@ -302,6 +302,10 @@ private:
     void clearBackgroundPreset(const char* reason);
     // The ONE place the stored source key is written; emits nothing.
     void storeBackgroundSource(const QString& source);
+    // The raw stored source, WITHOUT the backing-value derivation backgroundSource()
+    // applies. The write paths need to know what is on disk — asking the public getter
+    // there is useless, because it has already derived the inconsistency away.
+    QString storedBackgroundSource() const;
     // The other half: emit iff the DERIVED source differs from `before`. Split because the
     // stored key and the derived value move independently — see the definition.
     void notifyBackgroundSourceChanged(const QString& before);

--- a/tests/tst_backgroundpresets.cpp
+++ b/tests/tst_backgroundpresets.cpp
@@ -503,6 +503,40 @@ private slots:
         }
     }
 
+    void releasingAParameterOnItsOwnMovesTheStoredKey() {
+        // Clearing a colour WITHOUT going through clearBackground() — which is what the
+        // chooser's "no colour" does, and what clearBackgroundPreset() does on behalf of
+        // other actions. clearBackground() writes the key explicitly as its last step, so
+        // clearingReturnsToNone() passed while this path left the pair inconsistent for
+        // good: source "colour", preset empty.
+        //
+        // Nothing looked wrong, which is why it survived a release — backgroundSource()
+        // derives "none" and the right background draws. But the stored key never
+        // converged, so every launch logged "not backed by a value this build can draw":
+        // 152 times in one machine's log. Asserting the DERIVED getter here would pass
+        // against the bug; the stored key is the thing that was broken.
+        {
+            SettingsTheme theme;
+            theme.setBackgroundPreset("walnut");
+            theme.setBackgroundPreset(QString());
+            QSettings raw(Settings::testQSettingsPath(), QSettings::IniFormat);
+            QCOMPARE(raw.value("theme/backgroundSource").toString(), QString("none"));
+        }
+        {
+            // Same store across blocks, so start clean — see the note in
+            // anInstallPredatingTheSourceKeepsItsBackground().
+            QSettings wipe(Settings::testQSettingsPath(), QSettings::IniFormat);
+            wipe.remove("theme");
+            wipe.sync();
+
+            SettingsTheme theme;
+            theme.setBackgroundImagePath("/tmp/a-photo.jpg");
+            theme.setBackgroundImagePath(QString());
+            QSettings raw(Settings::testQSettingsPath(), QSettings::IniFormat);
+            QCOMPARE(raw.value("theme/backgroundSource").toString(), QString("none"));
+        }
+    }
+
     void clearingOneSourceDoesNotDisturbAnother() {
         // Choosing an image clears the colour as a SIDE EFFECT, and that clear arrives
         // after the source is already "image". If releasing a source were unconditional


### PR DESCRIPTION
Three defects in the background-source code, found by reading a tablet debug log and then a macOS one. All are invisible on screen in the sense that nothing looks obviously broken, which is why they shipped.

---

## 1. The shot-chart background never scrimmed the chrome over it

`Theme.hasBackgroundImage` read `LastShotChartSource.imageSource` directly. That singleton lives in `qml/components/`; `Theme.qml` lives in `qml/` and imports nothing from the module, so the type was never in scope there. The binding compiled clean and threw at runtime on **every** evaluation:

```
qrc:/qt/qml/Decenza/qml/Theme.qml:549:
ReferenceError: LastShotChartSource is not defined
```

A throwing binding leaves the property at its default, so `hasBackgroundImage` was pinned `false` for the entire `"shot"` case — the chart drew as wallpaper and all ~70 call sites reading it painted their chrome **opaque** over the picture, the inverse of the intent.

Introduced by #1585, released in 2.0.1.

## 2. ...and once it evaluated, it was asking the wrong question

Making the arm evaluate exposed that it was app-wide, while the shot chart is the one background a **page** can refuse. `ThemedPageBackground.suppressShotChart` turns it off on the eleven pages that draw a graph of their own — `EspressoPage`, `SteamPage`, `PostShotReviewPage`, `ShotDetailPage`, `ShotComparisonPage`, `FlowCalibrationPage`, `RecipeEditorPage`, `SimpleProfileEditorPage`, `ProfileEditorPage`, `ProfileInfoPage`, `AutoFavoriteInfoPage` — and those pages then paint a flat colour.

So "a render exists" told the chrome a picture was behind it where there was none. `glassChrome` went true, `chromeFill()` scrimmed over a flat page (the elevation-cancelling failure its own comment documents), and `insetBackgroundColor` took the `scrimColor(backgroundColor)` branch — 40% of a colour composited over itself, which is that colour exactly. Text-field boxes, switch tracks and unselected pills drawn straight on those pages disappeared, and the `_flatInsetTint` branch written for this case was skipped.

**Fix:** bind to what the surface is actually *drawing*. `BackgroundSurface` publishes `paintsShotChart` (its existing `_hasShotChart` under a public name), and `main.qml` binds `Theme.shotChartOnCurrentPage` to it for the item on top of the stack. That is false while a render is pending, false under a preset, and false on a suppressing page — the three cases where chrome must stay opaque.

A binding rather than a push from the surface: several `ThemedPageBackground`s are alive at once in the stack, so whichever wrote last would win regardless of which page you were looking at. It costs nothing extra either — `paintsShotChart` is state the surface computes anyway, and its `shotChart &&` short-circuits before touching `LastShotChartSource`, so the singleton's startup load guard still holds.

## 3. The stored background source never converged after a parameter was released

`setBackgroundPreset("")` — what the chooser's "no colour" does, and what `clearBackgroundPreset()` does on behalf of other actions such as `ScreensaverVideoManager` deleting a backing file — wrote `theme/backgroundPreset` but left `theme/backgroundSource` at `"colour"`. The guard only ever wrote the key when a colour was **set**, so the pair went inconsistent and stayed that way.

Nothing looked wrong — `backgroundSource()` derives `"none"` from the values actually set, so the right background drew. But the stored key never converged, and the derivation logs when it overrides a stored value, so every launch reported:

```
[Theme] Stored background source "colour" is not backed by a value this build can draw - using "none"
```

**152 times in one machine's log.** That message exists to make an override diagnosable; one that fires forever on a state that can never resolve trains the reader to skip it.

`setBackgroundImagePath("")` had the identical defect, leaving `"image"` pointing at a path that is gone. Fixed both.

Fixed at the write site, not the read site: `backgroundSource()` still derives and still rewrites nothing, which is what keeps an install predating the key working. Both new branches release the key only when it still names the parameter being cleared, and both document the ordering they depend on — every caller stores the new source kind *before* clearing the old parameter, so a nested clear finds a key that no longer names it.

### Test

`clearBackground()` already wrote the key explicitly as its last step, which is why `clearingReturnsToNone()` passed throughout — the gap was clearing a parameter *without* going through it. The new case asserts the **stored** key after releasing a parameter on its own; asserting the derived getter would pass against the bug.

Defect 2 has no automated test: the failure is QML-runtime-only and the suite is C++.

---

## On the guard that didn't catch #1

`qmllint` **did** flag that line — as one of 88 identical `Unqualified access` warnings in `Theme.qml`. The other 87 are context-property false positives, so the one real error was indistinguishable from the noise. Worth a separate think about declaring context properties to qmllint so that signal becomes usable; not attempted here.

## Verification

- Build: 0 errors, 0 warnings.
- Full suite via Qt Creator: **104 passed, 0 failed, 0 skipped, 0 with warnings.**
- Defect 1 confirmed fixed against a running app (chart grab logged, no ReferenceError); defect 3 covered by the new test case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)