### PR TITLE
Fix Acaia battery level and the reconnect latch that needed a re-pair

### DIFF
--- a/src/ble/scales/acaiascale.cpp
+++ b/src/ble/scales/acaiascale.cpp
@@ -57,9 +57,25 @@ void AcaiaScale::connectToDevice(const QBluetoothDeviceInfo& device) {
         return;
     }
 
-    // Prevent duplicate connection attempts
-    if (m_isConnecting) {
-        ACAIA_LOG("Already connecting, ignoring duplicate request");
+    // Don't tear down an established link. A stray scaleDiscovered for a scale
+    // we're already talking to would otherwise run the reset below on a live
+    // connection — stopping the heartbeat and clearing m_characteristicsReady,
+    // which blocks every subsequent write.
+    //
+    // Note what this deliberately does NOT guard: a duplicate connect while the
+    // link is still coming up. That belongs to the transport, which debounces on
+    // the controller's live state (QtScaleBleTransport::connectToDevice) and so
+    // recovers correctly once the controller is gone. This used to be a latched
+    // m_isConnecting bool, set here and cleared only by onTransportDisconnected()
+    // — but BLEManager's direct-connect abort severs the controller's signals
+    // before deleting it, so that clear never ran. The flag stayed set for the
+    // life of the process and every later attempt was refused with "Already
+    // connecting, ignoring duplicate request", leaving the scale recoverable only
+    // by forgetting and re-pairing it (#1669). It predated the transport-level
+    // debounce and had been redundant since. reaprime guards the same way, on
+    // live transport state (acaia_scale.dart onConnect).
+    if (isConnected() || (m_transport && m_transport->isConnected())) {
+        ACAIA_LOG("Already connected, ignoring duplicate request");
         return;
     }
 
@@ -73,7 +89,6 @@ void AcaiaScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     m_characteristicsReady = false;
     m_receivingNotifications = false;
     m_weightReceived = false;
-    m_isConnecting = true;
     m_identRetryCount = 0;
     m_buffer.clear();
 
@@ -91,14 +106,12 @@ void AcaiaScale::onTransportDisconnected() {
     stopAllTimers();
     m_weightReceived = false;
     m_characteristicsReady = false;
-    m_isConnecting = false;
     setConnected(false);
 }
 
 void AcaiaScale::onTransportError(const QString& message) {
     ACAIA_WARN(QString("Transport error: %1").arg(message));
     stopAllTimers();
-    m_isConnecting = false;
     setConnected(false);
 }
 
@@ -191,7 +204,6 @@ void AcaiaScale::onInitTimer() {
     if (m_receivingNotifications) {
         ACAIA_LOG("Scale responded, stopping init sequence and starting heartbeat");
         m_initTimer->stop();
-        m_isConnecting = false;
 
         // Start heartbeat sequence
         sendConfig();
@@ -207,7 +219,6 @@ void AcaiaScale::onInitTimer() {
     if (m_identRetryCount >= MAX_IDENT_RETRIES) {
         ACAIA_WARN(QString("Init sequence failed after %1 retries").arg(MAX_IDENT_RETRIES));
         m_initTimer->stop();
-        m_isConnecting = false;
         return;
     }
 
@@ -298,66 +309,104 @@ void AcaiaScale::parseResponse(const QByteArray& data) {
     // Append to buffer
     m_buffer.append(data);
 
-    // Need at least 6 bytes for a valid message
-    if (m_buffer.size() < 6) return;
+    // One notification can carry several concatenated frames — commonly a weight
+    // frame with a 0x08 settings frame behind it. Decode every complete frame and
+    // keep the trailing partial for the next notification.
+    //
+    // This used to decode the first frame and then clear the whole buffer, which
+    // silently dropped whatever followed it. That is worse than de1app, which at
+    // least scans forward past uninteresting frames to reach a weight frame
+    // (bluetooth.tcl acaia_scan_buffer_for_msg). pyacaia and Beanconqueror both
+    // loop and carry the remainder (`bytes[messageEnd:]`); this matches them.
+    while (true) {
+        const uint8_t* buf = reinterpret_cast<const uint8_t*>(m_buffer.constData());
 
-    const uint8_t* buf = reinterpret_cast<const uint8_t*>(m_buffer.constData());
-
-    // Find message start (0xEF 0xDD)
-    int msgStart = -1;
-    for (int i = 0; i < m_buffer.size() - 1; i++) {
-        if (buf[i] == 0xEF && buf[i + 1] == 0xDD) {
-            msgStart = i;
-            break;
+        // Find message start (0xEF 0xDD)
+        int msgStart = -1;
+        for (qsizetype i = 0; i + 1 < m_buffer.size(); i++) {
+            if (buf[i] == 0xEF && buf[i + 1] == 0xDD) {
+                msgStart = static_cast<int>(i);
+                break;
+            }
         }
-    }
 
-    if (msgStart < 0) {
-        m_buffer.clear();
-        return;
-    }
-
-    // Skip bytes before message start
-    if (msgStart > 0) {
-        m_buffer = m_buffer.mid(msgStart);
-        buf = reinterpret_cast<const uint8_t*>(m_buffer.constData());
-    }
-
-    // Check if we have enough data for metadata
-    if (m_buffer.size() < ACAIA_METADATA_LEN + 1) return;
-
-    uint8_t msgType = buf[2];
-    uint8_t length = buf[3];
-    uint8_t eventType = buf[4];
-
-    // Mark that we're receiving notifications (not just info messages)
-    if (msgType != 7) {
-        m_receivingNotifications = true;
-    }
-
-    // Check if we have the complete message
-    int msgEnd = ACAIA_METADATA_LEN + length;
-    if (m_buffer.size() < msgEnd) return;
-
-    // Weight messages (msgType 0x0C, eventType 5 or 11)
-    if (msgType == 0x0C && (eventType == 5 || eventType == 11)) {
-        int payloadOffset = (eventType == 5) ? ACAIA_METADATA_LEN : ACAIA_METADATA_LEN + 3;
-        decodeWeight(m_buffer, payloadOffset);
-    }
-
-    // Settings response (msgType 0x08): contains battery level
-    // Unlike 0x0C event messages, 0x08 has no eventType byte — payload starts at buf[4]:
-    //   buf[4]=payload[0] (unknown), buf[5]=payload[1] (battery), buf[6]=payload[2] (units), ...
-    // Battery masked with 0x7F gives 0-100%
-    if (msgType == 0x08 && m_buffer.size() >= 6) {
-        int batteryLevel = buf[5] & 0x7F;
-        if (batteryLevel >= 0 && batteryLevel <= 100) {
-            setBatteryLevel(batteryLevel);
+        if (msgStart < 0) {
+            // No header in flight. A trailing 0xEF may be the first byte of a
+            // header split across two notifications, so hold it back.
+            if (!m_buffer.isEmpty() && static_cast<uint8_t>(m_buffer.back()) == 0xEF) {
+                m_buffer = m_buffer.right(1);
+            } else {
+                m_buffer.clear();
+            }
+            return;
         }
-    }
 
-    // Clear buffer after processing
-    m_buffer.clear();
+        // Skip bytes before message start
+        if (msgStart > 0) {
+            m_buffer = m_buffer.mid(msgStart);
+            buf = reinterpret_cast<const uint8_t*>(m_buffer.constData());
+        }
+
+        // Check if we have enough data for metadata
+        if (m_buffer.size() < ACAIA_METADATA_LEN + 1) return;
+
+        uint8_t msgType = buf[2];
+        uint8_t length = buf[3];
+        uint8_t eventType = buf[4];
+
+        // Mark that we're receiving notifications (not just info messages)
+        if (msgType != 7) {
+            m_receivingNotifications = true;
+        }
+
+        // A bogus length would park the buffer forever waiting on bytes that
+        // never arrive, now that the buffer survives across notifications.
+        // de1app gates on the same 64-byte ceiling; resync past this header.
+        if (length > MAX_ACAIA_PAYLOAD_LEN) {
+            m_buffer = m_buffer.mid(2);
+            continue;
+        }
+
+        // Check if we have the complete message
+        int msgEnd = ACAIA_METADATA_LEN + length;
+        if (m_buffer.size() < msgEnd) return;   // wait for the rest of the frame
+
+        // Weight messages (msgType 0x0C, eventType 5 or 11)
+        if (msgType == 0x0C && eventType == 5) {
+            decodeWeight(m_buffer, ACAIA_METADATA_LEN);
+        } else if (msgType == 0x0C && eventType == 11) {
+            // Heartbeat response. buf[7] (payload[2]) selects the body: 5 = weight,
+            // 7 = timer. de1app decodes the weight unconditionally here; a timer
+            // body decoded as a weight is garbage, so follow Beanconqueror and
+            // check the selector.
+            if (m_buffer.size() > 7 && buf[7] == 5) {
+                decodeWeight(m_buffer, ACAIA_METADATA_LEN + 3);
+            }
+        }
+
+        // Settings response (msgType 0x08): contains battery level.
+        // The payload starts right after msgType, at buf[3] — the same framing the
+        // weight path above relies on (length=buf[3], eventType=buf[4]):
+        //   buf[3]=payload[0] (unknown), buf[4]=payload[1] (battery),
+        //   buf[5]=payload[2] (units: 2=grams, 5=ounces)
+        // Battery masked with 0x7F gives 0-100%.
+        //
+        // This read buf[5] until issue #1670 — the units byte, so a scale set to
+        // grams reported a permanent "2%" battery (ounces would have read 5%).
+        // de1app never parses this frame at all, so there was no upstream to copy;
+        // pyacaia (`Settings(bytes[messageStart+3:])`) and Beanconqueror
+        // (`parseSettings(bytes.slice(messageStart+3))`) both put battery at
+        // payload[1].
+        if (msgType == 0x08) {
+            int batteryLevel = buf[4] & 0x7F;
+            if (batteryLevel <= 100) {
+                setBatteryLevel(batteryLevel);
+            }
+        }
+
+        // Consume the frame and look for the next one in the same buffer
+        m_buffer = m_buffer.mid(msgEnd);
+    }
 }
 
 void AcaiaScale::decodeWeight(const QByteArray& data, int payloadOffset) {

--- a/src/ble/scales/acaiascale.cpp
+++ b/src/ble/scales/acaiascale.cpp
@@ -63,19 +63,32 @@ void AcaiaScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     // which blocks every subsequent write.
     //
     // Note what this deliberately does NOT guard: a duplicate connect while the
-    // link is still coming up. That belongs to the transport, which debounces on
-    // the controller's live state (QtScaleBleTransport::connectToDevice) and so
-    // recovers correctly once the controller is gone. This used to be a latched
-    // m_isConnecting bool, set here and cleared only by onTransportDisconnected()
-    // — but BLEManager's direct-connect abort severs the controller's signals
-    // before deleting it, so that clear never ran. The flag stayed set for the
-    // life of the process and every later attempt was refused with "Already
-    // connecting, ignoring duplicate request", leaving the scale recoverable only
-    // by forgetting and re-pairing it (#1669). It predated the transport-level
-    // debounce and had been redundant since. reaprime guards the same way, on
-    // live transport state (acaia_scale.dart onConnect).
-    if (isConnected() || (m_transport && m_transport->isConnected())) {
+    // link is still coming up. QtScaleBleTransport::connectToDevice debounces
+    // that on the controller's live state, and unlike a flag here it recovers
+    // once the controller is gone. (CoreBluetoothScaleBleTransport has no such
+    // check — on iOS/macOS a duplicate mid-handshake still runs the reset below.)
+    //
+    // This was a latched m_isConnecting bool until #1669. It read live-ish state
+    // nowhere: it was cleared from the transport callbacks and the init timer,
+    // none of which run when BLEManager's direct-connect abort severs the
+    // controller's signals before deleting it — and startInitSequence() never
+    // armed that timer, because characteristics never became ready. So the flag
+    // stayed set for the life of the process and every later attempt was refused,
+    // leaving the scale reachable only by forgetting and re-pairing it. The bug
+    // was that it latched, not merely that it was redundant with the transport
+    // debounce that landed two weeks after it. reaprime guards on live transport
+    // state for the same reason (acaia_scale.dart onConnect).
+    if (isConnected()) {
         ACAIA_LOG("Already connected, ignoring duplicate request");
+        return;
+    }
+    if (m_transport && m_transport->isConnected()) {
+        // Linked but no weight has ever arrived, so the handshake is wedged
+        // rather than healthy. WARN, not LOG: a repeat here is the fingerprint of
+        // a scale that connects and stays mute, and "Already connected" at debug
+        // level reads as reassurance while the ladder spins.
+        ACAIA_WARN("Connect requested while the link is up but no weight has arrived; "
+                   "ignoring. Repeats here mean the handshake is wedged.");
         return;
     }
 
@@ -90,6 +103,9 @@ void AcaiaScale::connectToDevice(const QBluetoothDeviceInfo& device) {
     m_receivingNotifications = false;
     m_weightReceived = false;
     m_identRetryCount = 0;
+    m_infoFrameCount = 0;
+    m_resyncLogged = false;
+    m_badBatteryLogged = false;
     m_buffer.clear();
 
     m_name = device.name();
@@ -106,12 +122,26 @@ void AcaiaScale::onTransportDisconnected() {
     stopAllTimers();
     m_weightReceived = false;
     m_characteristicsReady = false;
+    m_buffer.clear();   // the buffer outlives a notification now; don't carry a
+                        // partial frame into the next session
     setConnected(false);
 }
 
 void AcaiaScale::onTransportError(const QString& message) {
     ACAIA_WARN(QString("Transport error: %1").arg(message));
     stopAllTimers();
+    m_buffer.clear();
+
+    // Drop the link, don't just mark ourselves disconnected. Both transports can
+    // emit error() with the link still up and their own m_connected still true —
+    // QtScaleBleTransport::onControllerError returns without touching it, and Qt
+    // does not backfill a disconnected() for an error in the Discovered state.
+    // Leaving that mismatch in place would strand connectToDevice()'s guard on a
+    // transport that claims to be connected while this driver knows it is not:
+    // the same permanent-refusal shape as #1669, just with a different flag.
+    if (m_transport) {
+        m_transport->disconnectFromDevice();
+    }
     setConnected(false);
 }
 
@@ -217,8 +247,28 @@ void AcaiaScale::onInitTimer() {
 
     // Check retry limit
     if (m_identRetryCount >= MAX_IDENT_RETRIES) {
-        ACAIA_WARN(QString("Init sequence failed after %1 retries").arg(MAX_IDENT_RETRIES));
+        // Drop the link on the way out. The scale is linked but has never
+        // answered, so leaving the transport connected strands us: this driver
+        // never reaches setConnected(true) (that waits on a first weight), while
+        // the transport still reports connected — and connectToDevice()'s guard
+        // then refuses every tick of the 60s reconnect ladder forever. The old
+        // m_isConnecting latch happened to clear itself here, so this exit has to
+        // do it explicitly now that the guard reads transport state instead.
+        //
+        // infoFrames distinguishes the two failures worth telling apart: a scale
+        // spamming msgType 7 is alive and rejecting our ident (wrong protocol or
+        // write characteristic), whereas zero frames means notifications never
+        // came up at all.
+        ACAIA_WARN(QString("Init sequence failed after %1 retries "
+                           "(infoFrames=%2, protocol=%3) — dropping the link so the "
+                           "reconnect ladder can retry")
+                       .arg(MAX_IDENT_RETRIES).arg(m_infoFrameCount)
+                       .arg(m_isPyxis ? "Pyxis" : "IPS"));
         m_initTimer->stop();
+        if (m_transport) {
+            m_transport->disconnectFromDevice();
+        }
+        setConnected(false);
         return;
     }
 
@@ -314,18 +364,20 @@ void AcaiaScale::parseResponse(const QByteArray& data) {
     // keep the trailing partial for the next notification.
     //
     // This used to decode the first frame and then clear the whole buffer, which
-    // silently dropped whatever followed it. That is worse than de1app, which at
-    // least scans forward past uninteresting frames to reach a weight frame
-    // (bluetooth.tcl acaia_scan_buffer_for_msg). pyacaia and Beanconqueror both
-    // loop and carry the remainder (`bytes[messageEnd:]`); this matches them.
+    // silently dropped whatever followed it. de1app scans forward past
+    // uninteresting frames to reach a weight frame, but then clears its buffer
+    // just the same (bluetooth.tcl acaia_scan_buffer_for_msg /
+    // acaia_parse_response) — it picks a better frame, it does not carry the
+    // rest. pyacaia (`bytes[messageEnd:]`), Beanconqueror (`bytes.slice(messageEnd)`)
+    // and reaprime (`sublist(msgLen)`) all carry the remainder; this matches them.
     while (true) {
         const uint8_t* buf = reinterpret_cast<const uint8_t*>(m_buffer.constData());
 
         // Find message start (0xEF 0xDD)
-        int msgStart = -1;
+        qsizetype msgStart = -1;
         for (qsizetype i = 0; i + 1 < m_buffer.size(); i++) {
             if (buf[i] == 0xEF && buf[i + 1] == 0xDD) {
-                msgStart = static_cast<int>(i);
+                msgStart = i;
                 break;
             }
         }
@@ -357,50 +409,89 @@ void AcaiaScale::parseResponse(const QByteArray& data) {
         // Mark that we're receiving notifications (not just info messages)
         if (msgType != 7) {
             m_receivingNotifications = true;
+        } else {
+            // Counted, never logged per-frame: the scale spams these hardest
+            // exactly when the handshake is failing, and the log ring drops on
+            // overflow. The count is what the init-failure warning reports.
+            m_infoFrameCount++;
         }
 
         // A bogus length would park the buffer forever waiting on bytes that
         // never arrive, now that the buffer survives across notifications.
-        // de1app gates on the same 64-byte ceiling; resync past this header.
+        // 64 is de1app's ceiling too (bluetooth.tcl acaia_scan_buffer_for_msg,
+        // whose own comment calls the threshold arbitrary), though it skips by
+        // the untrusted length where we resync by 2 — resyncing on a length we
+        // have just rejected is how one corrupt byte becomes a permanent desync.
+        //
+        // Worth a warning because this is the only desync-recovery path, and a
+        // sustained run of it presents to the user as "connects, no weight".
+        // One-shot: it sits inside the loop and could fire repeatedly per packet.
         if (length > MAX_ACAIA_PAYLOAD_LEN) {
+            if (!m_resyncLogged) {
+                m_resyncLogged = true;
+                ACAIA_WARN(QString("Frame resync: length %1 exceeds the %2-byte ceiling "
+                                   "(msgType=%3, buffered=%4)")
+                               .arg(length).arg(MAX_ACAIA_PAYLOAD_LEN)
+                               .arg(msgType).arg(m_buffer.size()));
+            }
             m_buffer = m_buffer.mid(2);
             continue;
         }
 
         // Check if we have the complete message
-        int msgEnd = ACAIA_METADATA_LEN + length;
+        const qsizetype msgEnd = ACAIA_METADATA_LEN + length;
         if (m_buffer.size() < msgEnd) return;   // wait for the rest of the frame
 
-        // Weight messages (msgType 0x0C, eventType 5 or 11)
+        // Everything below indexes within THIS frame, so bound reads by msgEnd and
+        // not by m_buffer.size(). The buffer now carries following frames, so a
+        // frame whose length byte is too short for the body it claims would
+        // otherwise read its neighbour's bytes and publish a garbage weight —
+        // which feeds stop-at-weight.
         if (msgType == 0x0C && eventType == 5) {
-            decodeWeight(m_buffer, ACAIA_METADATA_LEN);
+            if (msgEnd >= ACAIA_METADATA_LEN + 6) {
+                decodeWeight(m_buffer.left(msgEnd), ACAIA_METADATA_LEN);
+            }
         } else if (msgType == 0x0C && eventType == 11) {
-            // Heartbeat response. buf[7] (payload[2]) selects the body: 5 = weight,
-            // 7 = timer. de1app decodes the weight unconditionally here; a timer
-            // body decoded as a weight is garbage, so follow Beanconqueror and
-            // check the selector.
-            if (m_buffer.size() > 7 && buf[7] == 5) {
-                decodeWeight(m_buffer, ACAIA_METADATA_LEN + 3);
+            // Heartbeat response. buf[7] (payload[2] counting from buf[5], the
+            // base this file's weight path uses) selects the body: 5 = weight,
+            // 7 = timer. de1app and reaprime decode the weight unconditionally;
+            // pyacaia and Beanconqueror check the selector. A timer body decoded
+            // as a weight is garbage, so follow the stricter pair.
+            if (msgEnd > 7 && buf[7] == 5 && msgEnd >= ACAIA_METADATA_LEN + 3 + 6) {
+                decodeWeight(m_buffer.left(msgEnd), ACAIA_METADATA_LEN + 3);
             }
         }
 
         // Settings response (msgType 0x08): contains battery level.
-        // The payload starts right after msgType, at buf[3] — the same framing the
-        // weight path above relies on (length=buf[3], eventType=buf[4]):
-        //   buf[3]=payload[0] (unknown), buf[4]=payload[1] (battery),
-        //   buf[5]=payload[2] (units: 2=grams, 5=ounces)
-        // Battery masked with 0x7F gives 0-100%.
+        //
+        // Absolute offsets, because this block and the weight path above number
+        // their payloads from different bases — the weight path from buf[5]
+        // (ACAIA_METADATA_LEN), this one from buf[3] to match pyacaia's slice:
+        //   buf[3] = the frame length, already consumed as `length` above
+        //   buf[4] = battery
+        //   buf[5] = units (2 = grams, 5 = ounces)
         //
         // This read buf[5] until issue #1670 — the units byte, so a scale set to
         // grams reported a permanent "2%" battery (ounces would have read 5%).
-        // de1app never parses this frame at all, so there was no upstream to copy;
-        // pyacaia (`Settings(bytes[messageStart+3:])`) and Beanconqueror
-        // (`parseSettings(bytes.slice(messageStart+3))`) both put battery at
-        // payload[1].
+        // de1app parses no 0x08 frame at all, but three references land on buf[4]:
+        // pyacaia (`Settings(bytes[messageStart+3:])`, `payload[1] & 0x7F`),
+        // Beanconqueror (`parseSettings(bytes.slice(messageStart+3))`,
+        // `payload[1] & 127`) and reaprime (`_commandBuffer[4]`, unmasked).
         if (msgType == 0x08) {
-            int batteryLevel = buf[4] & 0x7F;
+            // 0x7F yields 0-127; the <= 100 test below is what bounds it to a
+            // percentage. Keep them separate — 101..127 means buf[4] is not a
+            // battery byte, i.e. the offset above is wrong for this model, and
+            // that is exactly the evidence #1670 lacked for months. One-shot so a
+            // wrong offset cannot flood the log.
+            const int batteryLevel = buf[4] & 0x7F;
             if (batteryLevel <= 100) {
                 setBatteryLevel(batteryLevel);
+            } else if (!m_badBatteryLogged) {
+                m_badBatteryLogged = true;
+                ACAIA_WARN(QString("Battery byte out of range: %1 (buf[3..5]=%2 %3 %4, "
+                                   "protocol=%5) — payload offset likely wrong for this model")
+                               .arg(batteryLevel).arg(buf[3]).arg(buf[4]).arg(buf[5])
+                               .arg(m_isPyxis ? "Pyxis" : "IPS"));
             }
         }
 

--- a/src/ble/scales/acaiascale.h
+++ b/src/ble/scales/acaiascale.h
@@ -54,6 +54,12 @@ private:
     bool m_characteristicsReady = false;
     bool m_receivingNotifications = false;
     bool m_weightReceived = false;  // Track if we've received weight data
+    // One-shot latches so a persistently malformed stream can't flood the log
+    // ring (AsyncLogger drops on overflow, so a flood destroys the evidence).
+    // All three are reset per connection attempt in connectToDevice().
+    bool m_resyncLogged = false;
+    bool m_badBatteryLogged = false;
+    int m_infoFrameCount = 0;  // msgType 7 frames — reported on init failure
 
     // Timers
     QTimer* m_heartbeatTimer = nullptr;

--- a/src/ble/scales/acaiascale.h
+++ b/src/ble/scales/acaiascale.h
@@ -54,7 +54,6 @@ private:
     bool m_characteristicsReady = false;
     bool m_receivingNotifications = false;
     bool m_weightReceived = false;  // Track if we've received weight data
-    bool m_isConnecting = false;  // Track if connection is in progress
 
     // Timers
     QTimer* m_heartbeatTimer = nullptr;
@@ -66,6 +65,7 @@ private:
 
     // Constants
     static constexpr int ACAIA_METADATA_LEN = 5;
+    static constexpr int MAX_ACAIA_PAYLOAD_LEN = 64;  // Sanity ceiling, same as de1app
     static constexpr int MAX_IDENT_RETRIES = 10;  // Same as de1app
     static constexpr int INIT_TIMER_INTERVAL_MS = 500;  // Ident + config every 500ms
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -820,13 +820,14 @@ add_decenza_test(tst_shotimportdedupe
 target_link_libraries(tst_shotimportdedupe PRIVATE decenza_shotlib)
 target_include_directories(tst_shotimportdedupe PRIVATE ${CMAKE_BINARY_DIR})
 
-# --- tst_scaleprotocol: Scale BLE packet parsing (Decent, Bookoo, DiFluid) ---
+# --- tst_scaleprotocol: Scale BLE packet parsing (Decent, Bookoo, DiFluid, Acaia) ---
 add_decenza_test(tst_scaleprotocol
     tst_scaleprotocol.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/transport/scalebletransport.h
     ${CMAKE_SOURCE_DIR}/src/ble/scales/decentscale.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/scales/bookooscale.cpp
     ${CMAKE_SOURCE_DIR}/src/ble/scales/difluidscale.cpp
+    ${CMAKE_SOURCE_DIR}/src/ble/scales/acaiascale.cpp
 )
 
 # --- tst_decentscalewifi: WiFi scale driver (WebSocket protocol) ---

--- a/tests/tst_scaleprotocol.cpp
+++ b/tests/tst_scaleprotocol.cpp
@@ -6,6 +6,7 @@
 #include "ble/scales/decentscale.h"
 #include "ble/scales/bookooscale.h"
 #include "ble/scales/difluidscale.h"
+#include "ble/scales/acaiascale.h"
 #include "ble/transport/scalebletransport.h"
 #include "ble/protocol/de1characteristics.h"
 #include "ble/protocol/decentscaleprotocol.h"
@@ -24,7 +25,7 @@ class MockScaleBleTransport : public ScaleBleTransport {
 public:
     explicit MockScaleBleTransport(QObject* parent = nullptr) : ScaleBleTransport(parent) {}
 
-    void connectToDevice(const QString&, const QString&) override {}
+    void connectToDevice(const QString&, const QString&) override { m_connectCount++; }
     void disconnectFromDevice() override { m_disconnectCount++; }
     void discoverServices() override {}
     void discoverCharacteristics(const QBluetoothUuid& service) override {
@@ -58,6 +59,7 @@ public:
 
     int m_notifyEnableCount = 0;
     int m_disconnectCount = 0;
+    int m_connectCount = 0;
     bool m_isConnected = true;
     QList<QByteArray> m_writes;
     QList<QBluetoothUuid> m_characteristicDiscoveries;
@@ -1157,6 +1159,240 @@ private slots:
 
         QVERIFY(transport->m_characteristicDiscoveries.isEmpty());
         QVERIFY(!scale.isConnected());
+    }
+
+    // --- Acaia (issues #1669, #1670) --------------------------------------
+    //
+    // Frames are `EF DD <msgType> <length> <payload…>`, length counting from the
+    // length byte itself, so a frame occupies ACAIA_METADATA_LEN(5) + length
+    // bytes. AcaiaScale defaults to the IPS protocol, so feeding
+    // Scale::AcaiaIPS::CHARACTERISTIC reaches parseResponse() with no discovery
+    // handshake.
+    //
+    // Byte layouts are asserted against pyacaia (decode/Settings), Beanconqueror
+    // (decoder.ts) and reaprime (acaia_scale.dart), which agree; de1app parses
+    // weight only and never reads a 0x08 settings frame.
+
+    // 0x08 settings frame. Battery is payload[1] = buf[4]; buf[5] is the units
+    // byte (2 = grams). Defaults are chosen to discriminate: reverting the fix to
+    // buf[5] yields 2 — the exact "always 2%" symptom reported in #1670.
+    static QByteArray buildAcaiaSettings(uint8_t battery, uint8_t units = 2) {
+        QByteArray pkt;
+        pkt.append(static_cast<char>(0xEF));
+        pkt.append(static_cast<char>(0xDD));
+        pkt.append(static_cast<char>(0x08));
+        pkt.append(static_cast<char>(0x0D));            // length
+        pkt.append(static_cast<char>(battery));         // buf[4]
+        pkt.append(static_cast<char>(units));           // buf[5]
+        pkt.append(QByteArray(12, '\0'));               // rest of the frame
+        return pkt.left(5 + 0x0D);
+    }
+
+    // 0x0C / eventType 5 weight frame. Body is 3-byte LE value, then a decimal
+    // exponent at payload[4] and a sign flag at payload[5].
+    static QByteArray buildAcaiaWeight(double grams) {
+        const uint32_t raw = static_cast<uint32_t>(qRound(qAbs(grams) * 10.0));
+        QByteArray pkt;
+        pkt.append(static_cast<char>(0xEF));
+        pkt.append(static_cast<char>(0xDD));
+        pkt.append(static_cast<char>(0x0C));
+        pkt.append(static_cast<char>(0x06));            // length
+        pkt.append(static_cast<char>(0x05));            // eventType
+        pkt.append(static_cast<char>(raw & 0xFF));
+        pkt.append(static_cast<char>((raw >> 8) & 0xFF));
+        pkt.append(static_cast<char>((raw >> 16) & 0xFF));
+        pkt.append(static_cast<char>(0x00));
+        pkt.append(static_cast<char>(0x01));            // one decimal place
+        pkt.append(static_cast<char>(grams < 0 ? 0x02 : 0x00));
+        return pkt;
+    }
+
+    static void feedAcaia(MockScaleBleTransport* t, const QByteArray& bytes) {
+        t->fakeCharacteristicChanged(Scale::AcaiaIPS::CHARACTERISTIC, bytes);
+    }
+
+    void acaiaBatteryComesFromPayloadByteOne() {
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+        QSignalSpy spy(&scale, &ScaleDevice::batteryLevelChanged);
+
+        feedAcaia(transport, buildAcaiaSettings(90));
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toInt(), 90);
+        QCOMPARE(scale.batteryLevel(), 90);
+    }
+
+    void acaiaBatteryIsNotTheUnitsByte() {
+        // The #1670 regression guard. Units is grams(2) here while the battery is
+        // 77, so reading the wrong byte cannot coincidentally pass.
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+
+        feedAcaia(transport, buildAcaiaSettings(77, /*units=*/2));
+
+        QCOMPARE(scale.batteryLevel(), 77);
+        QVERIFY(scale.batteryLevel() != 2);
+    }
+
+    void acaiaBatteryHighBitIsMasked() {
+        // pyacaia and Beanconqueror mask 0x80 off; reaprime does not. Masking
+        // keeps a set high bit from reading as an out-of-range battery.
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+
+        feedAcaia(transport, buildAcaiaSettings(0x80 | 64));
+
+        QCOMPARE(scale.batteryLevel(), 64);
+    }
+
+    void acaiaDecodesSecondFrameInSameNotification() {
+        // The frame-carrying fix: a settings frame followed by a weight frame in
+        // one notification. The old parser decoded the first and cleared the rest.
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+        QSignalSpy batterySpy(&scale, &ScaleDevice::batteryLevelChanged);
+
+        feedAcaia(transport, buildAcaiaSettings(90) + buildAcaiaWeight(100.0));
+
+        QCOMPARE(batterySpy.count(), 1);
+        QCOMPARE(batterySpy.at(0).at(0).toInt(), 90);
+        QCOMPARE(weightSpy.count(), 1);
+        QCOMPARE(weightSpy.at(0).at(0).toDouble(), 100.0);
+    }
+
+    void acaiaDecodesSettingsBehindWeight() {
+        // Reverse order — the comment in parseResponse claims this is the common
+        // shape on the wire, so pin both orderings.
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+        QSignalSpy batterySpy(&scale, &ScaleDevice::batteryLevelChanged);
+
+        feedAcaia(transport, buildAcaiaWeight(18.5) + buildAcaiaSettings(42));
+
+        QCOMPARE(weightSpy.count(), 1);
+        QCOMPARE(weightSpy.at(0).at(0).toDouble(), 18.5);
+        QCOMPARE(batterySpy.count(), 1);
+        QCOMPARE(batterySpy.at(0).at(0).toInt(), 42);
+    }
+
+    void acaiaShortFrameDoesNotReadIntoItsNeighbour() {
+        // A weight frame whose length byte is too short for its own body must be
+        // dropped, not completed from the following frame's bytes. Before the
+        // frame-bounded reads this decoded `AA BB EF DD 0C 06` as a weight with
+        // unit=12 and emitted a spurious sample ahead of the real one.
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+
+        QByteArray truncated = QByteArray::fromHex("EFDD0C0205AABB");
+        feedAcaia(transport, truncated + buildAcaiaWeight(100.0));
+
+        QCOMPARE(weightSpy.count(), 1);
+        QCOMPARE(weightSpy.at(0).at(0).toDouble(), 100.0);
+    }
+
+    void acaiaHeartbeatTimerBodyIsNotAWeight() {
+        // eventType 11 carries a selector at buf[7]: 5 = weight, 7 = timer.
+        // Decoding a timer body as a weight is what the selector check prevents.
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+
+        feedAcaia(transport, QByteArray::fromHex("EFDD0C090B000007123456789ABC"));
+        QCOMPARE(weightSpy.count(), 0);
+
+        // The weight-bodied variant of the same event still decodes.
+        feedAcaia(transport, QByteArray::fromHex("EFDD0C090B000005E80300000100"));
+        QCOMPARE(weightSpy.count(), 1);
+        QCOMPARE(weightSpy.at(0).at(0).toDouble(), 100.0);
+    }
+
+    void acaiaResyncsPastBogusLength() {
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Frame resync"));
+        feedAcaia(transport, QByteArray::fromHex("EFDD0CFF0500") + buildAcaiaWeight(100.0));
+
+        QCOMPARE(weightSpy.count(), 1);
+        QCOMPARE(weightSpy.at(0).at(0).toDouble(), 100.0);
+    }
+
+    void acaiaCarriesFrameSplitAcrossNotifications() {
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+
+        const QByteArray whole = buildAcaiaWeight(100.0);
+        feedAcaia(transport, whole.left(6));
+        QCOMPARE(weightSpy.count(), 0);
+        feedAcaia(transport, whole.mid(6));
+
+        QCOMPARE(weightSpy.count(), 1);
+        QCOMPARE(weightSpy.at(0).at(0).toDouble(), 100.0);
+    }
+
+    void acaiaCarriesHeaderSplitAcrossNotifications() {
+        // The trailing-0xEF hold-back. The old parser found no header, cleared
+        // the buffer, and the next notification then began with a stray 0xDD —
+        // losing the frame entirely.
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+        QSignalSpy weightSpy(&scale, &ScaleDevice::weightChanged);
+
+        const QByteArray whole = buildAcaiaWeight(100.0);
+        feedAcaia(transport, QByteArray::fromHex("1122") + whole.left(1));
+        feedAcaia(transport, whole.mid(1));
+
+        QCOMPARE(weightSpy.count(), 1);
+        QCOMPARE(weightSpy.at(0).at(0).toDouble(), 100.0);
+    }
+
+    void acaiaOutOfRangeBatteryIsReportedNotSwallowed() {
+        // 101..127 survives the 0x7F mask and means buf[4] is not a battery byte
+        // — the evidence #1670 lacked. It must warn rather than vanish, and the
+        // level must stay at the unknown sentinel.
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Battery byte out of range"));
+        feedAcaia(transport, buildAcaiaSettings(120));
+
+        QCOMPARE(scale.batteryLevel(), -1);
+    }
+
+    void acaiaReconnectIsNotRefusedAfterAFailedAttempt() {
+        // #1669. The first attempt dies without a disconnected() callback — the
+        // shape BLEManager's direct-connect abort produces by severing the
+        // controller's signals. The next ladder tick must still reach the
+        // transport; the old latched m_isConnecting swallowed it forever.
+        auto* transport = new MockScaleBleTransport;
+        transport->m_isConnected = false;   // mock defaults to connected
+        AcaiaScale scale(transport);
+
+        scale.connectToDevice(QBluetoothDeviceInfo());
+        QCOMPARE(transport->m_connectCount, 1);
+
+        scale.connectToDevice(QBluetoothDeviceInfo());
+        QCOMPARE(transport->m_connectCount, 2);
+    }
+
+    void acaiaConnectIsRefusedOnALiveLink() {
+        // The complement: a stray scaleDiscovered for a scale we are already
+        // talking to must not run the reset block, which would stop the heartbeat
+        // and clear m_characteristicsReady (blocking every later write).
+        auto* transport = new MockScaleBleTransport;
+        AcaiaScale scale(transport);
+        feedAcaia(transport, buildAcaiaWeight(12.0));   // first weight → connected
+        QVERIFY(scale.isConnected());
+
+        scale.connectToDevice(QBluetoothDeviceInfo());
+
+        QCOMPARE(transport->m_connectCount, 0);
     }
 };
 


### PR DESCRIPTION
Fixes #1670, fixes #1669.

## Battery always reads 2% (#1670)

`AcaiaScale::parseResponse` read the battery from `buf[5]` of the `0x08`
settings frame. That is the **units** byte. Grams is `2`, so every Acaia
reported a permanent "2%"; a scale set to ounces would have reported 5%.
Default `m_batteryLevel` is `-1`, so the reporter seeing `2` proves the frames
arrive and parse — just at the wrong index.

Acaia framing is `EF DD <msgType> <payload…>`, payload starting at `buf[3]`.
The weight path in this same function already relies on that (`length=buf[3]`,
`eventType=buf[4]`, weight body at `buf[5]`, `ACAIA_METADATA_LEN=5`). Battery
is `payload[1]` = **`buf[4]`**.

de1app never parses this frame at all — `acaia_parse_response` decodes weight
only and `bluetooth.tcl:1124` skips everything that is not msgType 12 — so
there was no upstream to copy from, which is how the offset came to be wrong.
The three implementations that do parse it agree:

| | dispatch | battery |
|---|---|---|
| pyacaia `decode()` | `Settings(bytes[messageStart+3:])` | `payload[1] & 0x7F` |
| Beanconqueror `decoder.ts` | `parseSettings(bytes.slice(messageStart+3))` | `payload[1] & 127` |
| reaprime `acaia_scale.dart` | — | `_commandBuffer[4]` |

Kept the `& 0x7F` mask (pyacaia logs `payload[1] & 0x80` as an unknown flag,
plausibly charging; reaprime reads the byte unmasked).

## Dropped frames

Decoded the first frame in the buffer, then cleared the whole thing — so a
settings frame bundled behind a weight frame in one notification was thrown
away. That is worse than de1app, which at least scans forward past
uninteresting frames to reach a weight frame. Now decodes every complete frame
and carries the remainder, matching pyacaia, Beanconqueror and reaprime.

Two guards come with it:

- **64-byte length ceiling** before waiting on a frame, so a bogus length
  cannot park the buffer forever now that it survives across notifications.
  de1app and reaprime gate on the same number.
- **eventType 11 selector.** `buf[7]` picks the heartbeat body: `5` = weight,
  `7` = timer. de1app and reaprime decode the weight unconditionally; pyacaia
  and Beanconqueror check first. A timer body decoded as a weight is garbage,
  so this follows the stricter pair.

## Scale unreachable until forget + re-pair (#1669)

Removes `m_isConnecting`. Reported as update-specific, but it is any startup
where the 4 s direct-connect misses — an update just guarantees a cold start.

From the reporter's log:

```
[   8.978] Direct wake: connecting to LUNAR-3885A5 at 60:8A:10:38:85:A5
[  12.950] Direct connect not established (~4s) — aborting, scan continues
[1165.528] Found scale: "LUNAR-3885A5" at 60:8A:10:38:85:A5
[1165.555] [BLE AcaiaScale] Already connecting, ignoring duplicate request
[1178.290] [BLE AcaiaScale] Already connecting, ignoring duplicate request
[1182.914] Disconnecting scale before scan        ← manual tap; device rebuilt
[1183.910] Controller connected!                  ← 0.24 s
```

`BLEManager::abortScaleDirectConnectIfPending` tears the parked controller down
via `transport->disconnectFromDevice()`, which calls `m_controller->disconnect()`
— severing the signals deliberately, so the teardown fires no spurious
`disconnected()` cascade. `AcaiaScale::onTransportDisconnected()` is therefore
never called, and it is the only place that path clears `m_isConnecting`. The
flag stayed set for the life of the process and every later attempt was refused.
The scale was present and connectable at t=1165 and connected in 0.24 s once a
manual re-pair rebuilt the device.

The flag was redundant anyway. `32d9c761` (2026-01-11) added it to dedupe the
then-new parallel direct-connect + scan; `76bdb591` (2026-01-26) added the
transport-level debounce at `qtscalebletransport.cpp:89`, which does the same
job against **live controller state** — ignore a duplicate to the same device
while Connecting/Connected/Discovering/Discovered, otherwise tear down and
reconnect. Being a latched bool rather than a state read is precisely why the
driver flag could not recover. reaprime guards the same way, on live transport
state (`acaia_scale.dart` `onConnect`), with no connecting flag at all.

The remaining guard reads live state and so cannot latch. It still stops a
stray `scaleDiscovered` on an established link from running the reset block —
which would stop the heartbeat and clear `m_characteristicsReady`, blocking
every subsequent write.

## Review follow-ups (second commit)

Four review agents ran over the first commit. Three findings were real defects, two of
them introduced by this PR:

- **Frame-bounded reads.** `decodeWeight()` and the eventType-11 selector byte were
  bounded by the whole buffer, not the frame. Harmless while the buffer was cleared
  every notification; a live defect once it carries concatenated frames, because a
  frame whose length byte is too short for its body then reads its neighbour's bytes
  and publishes a garbage weight into stop-at-weight.
- **Stale transport flag.** `connectToDevice()`'s guard reads
  `m_transport->isConnected()`, a cached flag.
  `QtScaleBleTransport::onControllerError` emits `error()` without clearing it, and Qt
  does not backfill a `disconnected()` for an error in the Discovered state — so the
  guard could latch on it, the same permanent-refusal shape as #1669 with a different
  flag. `onTransportError()` now drops the link so the two agree.
- **Init exhaustion.** Hitting `MAX_IDENT_RETRIES` left the link up while this driver
  stayed disconnected (it waits on a first weight), so the guard refused every tick of
  the 60 s reconnect ladder forever. The old `m_isConnecting` latch happened to clear
  itself on that exit; the guard reads transport state, so the exit now tears the
  transport down explicitly. This was a regression against the code being replaced.

Also: clear `m_buffer` on disconnect/error (it outlives a notification now); `qsizetype`
for buffer offsets per CLAUDE.md; one-shot warnings for the bogus-length resync and for
a battery byte of 101..127 — which means the payload offset is wrong for that model, and
is exactly the evidence #1670 lacked for months.

Several comment claims were wrong and are corrected: `m_isConnecting` was cleared at four
sites in three functions, not "only by `onTransportDisconnected()`"; the 0x08 block and
the weight path number their payloads from different bases, so the "same framing" claim
was self-contradictory; `buf[3]` is the frame length, not "unknown"; `0x7F` yields 0-127.
The eventType-11 note cited only Beanconqueror — de1app *and* reaprime decode
unconditionally, so it named just the reference that agreed.

Not done here, deliberately: `CoreBluetoothScaleBleTransport` has no duplicate-connect
debounce. Checked and it is not reachable — it sets `connected = true` in
`didConnectPeripheral`, so the new guard refuses duplicates from the moment the link is
up, which is the only window where `m_characteristicsReady` or an armed init timer exist.
Pre-link the reset block is a no-op and `connectPeripheral:` is idempotent.

## Testing

13 Acaia cases added to `tests/tst_scaleprotocol.cpp`, which already had a mock transport.
No `friend` hook needed — `m_isPyxis` defaults false, so IPS bytes reach `parseResponse`
with no discovery handshake.

Suite: **105 passed, 0 failed.** (The 3 QML-engine failures reported earlier were a local
`QML_DISK_CACHE` env var carrying a stray tab, unrelated to this change; they fail
identically on untouched `main` and are fixed outside the repo.)

Each production change was reverted in turn to confirm the tests discriminate, per
`TESTING.md`:

| Reverted | Tests that went red |
|---|---|
| battery `buf[4]` → `buf[5]` | 6, incl. `acaiaBatteryIsNotTheUnitsByte` |
| frame-bounded reads | `acaiaShortFrameDoesNotReadIntoItsNeighbour` |
| eventType-11 selector | `acaiaHeartbeatTimerBodyIsNotAWeight` |
| buffer carry → clear | `acaiaDecodesSecondFrameInSameNotification`, `acaiaDecodesSettingsBehindWeight`, `acaiaShortFrame…` |
| `m_isConnecting` latch restored | `acaiaReconnectIsNotRefusedAfterAFailedAttempt` |

No revert passed silently.

**Not hardware-verified — I have no Acaia.** The battery byte is agreed by pyacaia,
Beanconqueror and reaprime, but unconfirmed on a real Lunar 2021. Worth a beta check that
the battery tracks actual charge, and that a cold start with the scale switched off
recovers on its own once it is turned on, with no forget/re-pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
