### PR TITLE
Make the wizard's Hot water window one-tap, like every other picker (#1671)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ This means:
 - **Qt Framework**: LGPL-3.0 / Commercial ([qt.io/licensing](https://www.qt.io/licensing))
 - **FFmpeg** (via Qt Multimedia): LGPL-2.1+
 - **Twemoji** (emoji graphics): CC-BY 4.0 ([github.com/twitter/twemoji](https://github.com/twitter/twemoji))
+- **Tabler Icons** (cup / mug / glass icons): MIT ([github.com/tabler/tabler-icons](https://github.com/tabler/tabler-icons)) — licence text in `resources/icons/MIT-TablerIcons.txt`
+- **Noto Sans Math** (symbol fallback font): SIL OFL 1.1 — licence text in `resources/fonts/OFL-NotoSansMath.txt`
 
 ### DE1 Protocol
 
@@ -232,6 +234,7 @@ This application implements the DE1 Bluetooth LE protocol based on publicly avai
 - The open-source coffee community for protocol documentation
 - [Pexels](https://pexels.com/) for screensaver videos
 - [Twemoji](https://github.com/twitter/twemoji) by Twitter/X for emoji graphics (CC-BY 4.0)
+- [Tabler Icons](https://github.com/tabler/tabler-icons) by Paweł Kuna for the drinkware icons (MIT)
 
 ## Disclaimer
 

--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -931,8 +931,16 @@ Page {
                     accessibleName: TranslationManager.translate("hotWater.saveVesselChanges", "Save changes to water vessel preset")
                     KeyNavigation.tab: editVesselNameInput
                     KeyNavigation.backtab: cancelEditVesselButton
+                    // A vessel is identified by its NAME everywhere it is used —
+                    // recipes snapshot it by name, and the recipe wizard matches
+                    // its tiles on it. Renaming one to blank therefore produces a
+                    // vessel nothing can refer to, so the empty name is rejected
+                    // here exactly as the Add dialog rejects it.
+                    enabled: editVesselNameInput.text.trim().length > 0
                     onClicked: {
                         Qt.inputMethod.commit()
+                        if (editVesselNameInput.text.trim().length === 0)
+                            return
                         var preset = Settings.brew.getWaterVesselPreset(editingVesselIndex)
                         Settings.brew.updateWaterVesselPreset(editingVesselIndex, editVesselNameInput.text, preset.volume, preset.mode || "weight", (preset.flowRate !== undefined) ? preset.flowRate : 40, (preset.temperature !== undefined) ? preset.temperature : Settings.brew.waterTemperature)
                         editVesselPopup.close()

--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -1106,13 +1106,26 @@ Page {
         fPitcherTemperatureC = preset.temperature || 0
     }
 
-    // The steam window's tile model: the enabled pitcher presets.
+    // The steam window's tile model: the enabled pitcher presets, plus the
+    // recipe's OWN pitcher when its preset has since been disabled, renamed or
+    // deleted — same rule as vesselTileModel() and equipmentTileModel(). The
+    // recipe carries a by-value snapshot, so the pitcher it names still exists
+    // as far as the recipe is concerned; only the preset list forgot it.
     function pitcherTileModel() {
         var arr = []
         var presets = Settings.brew.steamPitcherPresets
-        for (var i = 0; i < presets.length; ++i)
-            if (!presets[i].disabled)
-                arr.push(presets[i])
+        var found = false
+        for (var i = 0; i < presets.length; ++i) {
+            if (presets[i].disabled)
+                continue
+            arr.push(presets[i])
+            if ((presets[i].name || "") === fPitcherName)
+                found = true
+        }
+        if (!found && fPitcherName !== "") {
+            arr.push({ name: fPitcherName, duration: fPitcherDurationSec,
+                       flow: fPitcherFlow, temperature: fPitcherTemperatureC })
+        }
         return arr
     }
 
@@ -1127,27 +1140,76 @@ Page {
     }
 
     // Snapshot the chosen water vessel preset onto the recipe BY VALUE (never a
-    // preset index). Shared by the hot-water window's tiles.
+    // preset index): presets can be renamed, reordered or deleted after the
+    // recipe is saved, and an index would then silently point at someone else's
+    // vessel. Called by the hot-water window's tiles.
     function selectVessel(preset) {
         fVesselName = preset.name || ""
         fVesselVolume = preset.volume || 0
         fVesselMode = preset.mode || "weight"
-        fVesselFlowRate = preset.flowRate || 40
+        // `!== undefined`, not `|| 40`: a preset really set to 0 must survive
+        // rather than being silently rewritten to the default (the same idiom
+        // HotWaterPage uses when reading these presets).
+        fVesselFlowRate = preset.flowRate !== undefined ? preset.flowRate : 40
         fVesselTemperatureC = preset.temperature || 0
     }
 
-    // Tile artwork for a water vessel, chosen by how much it holds: a cup for
-    // an espresso-sized pour, a mug for a normal one, a tall glass above that.
-    // The thresholds are deliberately coarse — this is a glance-level cue, and
-    // the name and amount underneath carry the actual information.
-    function vesselTileIcon(preset) {
-        var v = preset.volume || 0
-        if (v > 0 && v <= 120) return "qrc:/icons/cup.svg"
-        if (v > 320) return "qrc:/icons/glass-full.svg"
-        return "qrc:/icons/mug.svg"
+    // Set the water order, keeping the drink TYPE honest with it. Americano and
+    // long black are the same drink with the water on the other side of the
+    // shot, and the order tiles say so in their own labels — so flipping the
+    // order has to flip the type, or the recipe saves as "Americano" while
+    // DrinkType.fromRecipe() reads its blocks and calls it a long black. Any
+    // other type (a tea, a milk drink that also takes water) keeps its type.
+    function setWaterOrder(order) {
+        fWaterOrder = order
+        if (fDrinkType === "americano" || fDrinkType === "long_black")
+            fDrinkType = order === "before" ? "long_black" : "americano"
     }
 
-    // Compact "220ml · 96°C" metadata line for a water vessel preset tile.
+    // The hot-water window's tile model: the saved vessel presets, plus the
+    // recipe's OWN vessel when its preset has since been renamed or deleted.
+    // Without that last tile the window shows nothing selected and no trace of
+    // what the recipe actually holds — the same reason equipmentTileModel()
+    // keeps a retired package. The snapshot on the recipe stays authoritative
+    // either way; this only decides what the window can show.
+    function vesselTileModel() {
+        var presets = Settings.brew.waterVesselPresets
+        var arr = []
+        var found = false
+        for (var i = 0; i < presets.length; ++i) {
+            arr.push(presets[i])
+            if ((presets[i].name || "") === fVesselName)
+                found = true
+        }
+        if (!found && fVesselName !== "") {
+            arr.push({ name: fVesselName, volume: fVesselVolume, mode: fVesselMode,
+                       flowRate: fVesselFlowRate, temperature: fVesselTemperatureC })
+        }
+        return arr
+    }
+
+    // Tile artwork for a water vessel, banded by how much it holds. The bands
+    // are set around the presets the app SEEDS — "Cup" at 200 and "Mug" at 350
+    // (settings_brew.cpp) — so the artwork agrees with the name on a fresh
+    // install; an earlier split at 120/320 gave the shipped Cup a mug and the
+    // shipped Mug a glass, which is worse than no icon at all.
+    //
+    // Volume and weight presets are compared with one set of numbers because
+    // water is ~1 g/ml. A preset with no usable volume gets NO icon rather than
+    // the middle one: absent artwork reads as "unknown", whereas a mug on a
+    // 0-volume preset reads as a normal vessel and hides the problem.
+    function vesselTileIcon(preset) {
+        var v = preset.volume || 0
+        if (v <= 0) return ""
+        if (v <= 250) return "qrc:/icons/cup.svg"
+        if (v <= 400) return "qrc:/icons/mug.svg"
+        return "qrc:/icons/glass-full.svg"
+    }
+
+    // The tile's metadata line: the amount in the preset's OWN mode (ml or g)
+    // and the temperature, e.g. "200g · 96°C" — never name-only, because two
+    // vessels can share a name and the numbers are what tell them apart.
+    // Temperature renders in the user's unit via Theme.formatTemperature.
     function vesselTileMeta(preset) {
         var parts = []
         if ((preset.volume || 0) > 0)
@@ -2036,8 +2098,10 @@ Page {
         }
     }
 
-    // A tap-to-select tile used by the equipment and steam windows: title +
-    // optional metadata line, highlighted when selected, emits chosen() on tap.
+    // The wizard's tap-to-select tile, used by every picker window: optional
+    // leading icon + title + optional metadata line, highlighted when selected,
+    // emits chosen() on tap. Deliberately not enumerating the call sites here —
+    // that list has been wrong once already.
     component ChoiceTile: Rectangle {
         id: choiceTile
         property string title: ""
@@ -2067,34 +2131,43 @@ Page {
             ThemedIcon {
                 visible: choiceTile.iconSource !== ""
                 Layout.alignment: Qt.AlignVCenter
+                // A bare Item publishes no implicit minimum, so without these
+                // the layout is free to shrink the icon to nothing when a long
+                // title over-constrains the row — and since the Image inside
+                // draws at a fixed sourceSize and the tile does not clip, the
+                // artwork would keep drawing at full size over the title.
+                Layout.preferredWidth: iconSize
+                Layout.minimumWidth: iconSize
                 source: choiceTile.iconSource
                 iconSize: Theme.scaled(26)
-                // Tinted with the selection colour so the artwork tracks the
-                // tile's state instead of sitting at a fixed grey.
+                // Takes the selection colour when chosen; otherwise the same
+                // Theme.iconColor every other icon uses, which on its own gives
+                // no hint of the tile's state.
                 color: choiceTile.selected ? Theme.primaryColor : Theme.iconColor
+                Accessible.ignored: true
             }
             ColumnLayout {
-            Layout.fillWidth: true
-            spacing: Theme.scaled(2)
-            Label {
                 Layout.fillWidth: true
-                text: choiceTile.title
-                font: Theme.bodyFont
-                color: Theme.textColor
-                wrapMode: Text.WordWrap
-                maximumLineCount: 2
-                elide: Text.ElideRight
-                Accessible.ignored: true
-            }
-            Label {
-                visible: choiceTile.meta !== ""
-                Layout.fillWidth: true
-                text: choiceTile.meta
-                font: Theme.captionFont
-                color: Theme.textSecondaryColor
-                elide: Text.ElideRight
-                Accessible.ignored: true
-            }
+                spacing: Theme.scaled(2)
+                Label {
+                    Layout.fillWidth: true
+                    text: choiceTile.title
+                    font: Theme.bodyFont
+                    color: Theme.textColor
+                    wrapMode: Text.WordWrap
+                    maximumLineCount: 2
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
+                Label {
+                    visible: choiceTile.meta !== ""
+                    Layout.fillWidth: true
+                    text: choiceTile.meta
+                    font: Theme.captionFont
+                    color: Theme.textSecondaryColor
+                    elide: Text.ElideRight
+                    Accessible.ignored: true
+                }
             }
         }
         AccessibleMouseArea {
@@ -3327,7 +3400,8 @@ Page {
                                         title: modelData.name || ""
                                         meta: wizardPage.pitcherTileMeta(modelData)
                                         iconSource: "qrc:/icons/pitcher.svg"
-                                        selected: (modelData.name || "") === wizardPage.fPitcherName
+                                        selected: wizardPage.fPitcherName !== ""
+                                            && (modelData.name || "") === wizardPage.fPitcherName
                                         onChosen: {
                                             wizardPage.selectPitcher(modelData)
                                             wizardPage.detailsContinue()
@@ -3345,13 +3419,19 @@ Page {
                             title: TranslationManager.translate("recipes.composer.sectionHotWater", "Hot water")
                             // Order BEFORE the vessel: the vessel tile is the
                             // terminal choice and moves on by itself, so the
-                            // order (a modifier, template-defaulted) has to be
-                            // settled first.
+                            // order — a modifier that arrives template-defaulted
+                            // — is offered first, while the user is still here.
+                            // Nothing forces that sequence; both orders are
+                            // valid whenever this block is shown.
                             ColumnLayout {
-                                // Latte + Water fixes the order (water before the
-                                // espresso) — no order choice is offered for it.
+                                // A drink carrying BOTH milk and water pours the
+                                // water first, so it gets no order choice. Gated
+                                // on the blocks rather than on fDrinkType: the
+                                // summary's "Add milk" button adds the milk block
+                                // without rewriting the type, so an americano can
+                                // reach this window with milk on it.
                                 visible: !wizardPage.isHotWaterTea
-                                    && wizardPage.fDrinkType !== "latte_hotwater"
+                                    && !(wizardPage.fHasMilk && wizardPage.fHasWater)
                                 Layout.fillWidth: true
                                 spacing: Theme.spacingSmall
                                 Label {
@@ -3366,12 +3446,12 @@ Page {
                                     ChoiceTile {
                                         title: TranslationManager.translate("recipes.composer.waterAfter", "After espresso (Americano)")
                                         selected: wizardPage.fWaterOrder !== "before"
-                                        onChosen: wizardPage.fWaterOrder = "after"
+                                        onChosen: wizardPage.setWaterOrder("after")
                                     }
                                     ChoiceTile {
                                         title: TranslationManager.translate("recipes.composer.waterBefore", "Before espresso (long black)")
                                         selected: wizardPage.fWaterOrder === "before"
-                                        onChosen: wizardPage.fWaterOrder = "before"
+                                        onChosen: wizardPage.setWaterOrder("before")
                                     }
                                 }
                             }
@@ -3383,6 +3463,8 @@ Page {
                                 font: Theme.captionFont
                                 color: Theme.textSecondaryColor
                                 wrapMode: Text.WordWrap
+                                Accessible.role: Accessible.StaticText
+                                Accessible.name: text
                             }
                             // The vessel presets as inline, tap-to-select tiles
                             // (like the pitchers on the steam window): the chosen
@@ -3391,12 +3473,17 @@ Page {
                                 Layout.fillWidth: true
                                 spacing: Theme.spacingMedium
                                 Repeater {
-                                    model: Settings.brew.waterVesselPresets
+                                    model: wizardPage.vesselTileModel()
                                     delegate: ChoiceTile {
                                         title: modelData.name || ""
                                         meta: wizardPage.vesselTileMeta(modelData)
                                         iconSource: wizardPage.vesselTileIcon(modelData)
-                                        selected: (modelData.name || "") === wizardPage.fVesselName
+                                        // The empty-name test matters: a preset
+                                        // saved with a blank name would otherwise
+                                        // match the wizard's own empty default and
+                                        // show as chosen before anything is tapped.
+                                        selected: wizardPage.fVesselName !== ""
+                                            && (modelData.name || "") === wizardPage.fVesselName
                                         onChosen: {
                                             wizardPage.selectVessel(modelData)
                                             wizardPage.detailsContinue()

--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -1136,6 +1136,17 @@ Page {
         fVesselTemperatureC = preset.temperature || 0
     }
 
+    // Tile artwork for a water vessel, chosen by how much it holds: a cup for
+    // an espresso-sized pour, a mug for a normal one, a tall glass above that.
+    // The thresholds are deliberately coarse — this is a glance-level cue, and
+    // the name and amount underneath carry the actual information.
+    function vesselTileIcon(preset) {
+        var v = preset.volume || 0
+        if (v > 0 && v <= 120) return "qrc:/icons/cup.svg"
+        if (v > 320) return "qrc:/icons/glass-full.svg"
+        return "qrc:/icons/mug.svg"
+    }
+
     // Compact "220ml · 96°C" metadata line for a water vessel preset tile.
     function vesselTileMeta(preset) {
         var parts = []
@@ -2032,21 +2043,38 @@ Page {
         property string title: ""
         property string meta: ""
         property bool selected: false
+        // Optional leading artwork (a qrc:/icons/… SVG). Purely a visual aid:
+        // the title carries the meaning, and the accessible name below is built
+        // from the text alone, so a tile with no icon loses nothing.
+        property string iconSource: ""
         signal chosen()
         width: Math.min(Theme.scaled(240),
             (parent && parent.width > 0) ? parent.width : Theme.scaled(240))
-        implicitHeight: choiceTileCol.implicitHeight + 2 * Theme.spacingMedium
+        implicitHeight: Math.max(choiceTileRow.implicitHeight, Theme.scaled(30))
+            + 2 * Theme.spacingMedium
         radius: Theme.cardRadius
         color: selected ? Qt.alpha(Theme.primaryColor, 0.12) : Theme.cardBackgroundColor
         border.color: selected ? Theme.primaryColor : Theme.borderColor
         border.width: selected ? 2 : 1
-        ColumnLayout {
-            id: choiceTileCol
+        RowLayout {
+            id: choiceTileRow
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             anchors.leftMargin: Theme.spacingMedium
             anchors.rightMargin: Theme.spacingMedium
+            spacing: Theme.spacingSmall
+            ThemedIcon {
+                visible: choiceTile.iconSource !== ""
+                Layout.alignment: Qt.AlignVCenter
+                source: choiceTile.iconSource
+                iconSize: Theme.scaled(26)
+                // Tinted with the selection colour so the artwork tracks the
+                // tile's state instead of sitting at a fixed grey.
+                color: choiceTile.selected ? Theme.primaryColor : Theme.iconColor
+            }
+            ColumnLayout {
+            Layout.fillWidth: true
             spacing: Theme.scaled(2)
             Label {
                 Layout.fillWidth: true
@@ -2066,6 +2094,7 @@ Page {
                 color: Theme.textSecondaryColor
                 elide: Text.ElideRight
                 Accessible.ignored: true
+            }
             }
         }
         AccessibleMouseArea {
@@ -3297,6 +3326,7 @@ Page {
                                     delegate: ChoiceTile {
                                         title: modelData.name || ""
                                         meta: wizardPage.pitcherTileMeta(modelData)
+                                        iconSource: "qrc:/icons/pitcher.svg"
                                         selected: (modelData.name || "") === wizardPage.fPitcherName
                                         onChosen: {
                                             wizardPage.selectPitcher(modelData)
@@ -3365,6 +3395,7 @@ Page {
                                     delegate: ChoiceTile {
                                         title: modelData.name || ""
                                         meta: wizardPage.vesselTileMeta(modelData)
+                                        iconSource: wizardPage.vesselTileIcon(modelData)
                                         selected: (modelData.name || "") === wizardPage.fVesselName
                                         onChosen: {
                                             wizardPage.selectVessel(modelData)

--- a/qml/pages/RecipeWizardPage.qml
+++ b/qml/pages/RecipeWizardPage.qml
@@ -1126,6 +1126,26 @@ Page {
         return parts.join(" · ")
     }
 
+    // Snapshot the chosen water vessel preset onto the recipe BY VALUE (never a
+    // preset index). Shared by the hot-water window's tiles.
+    function selectVessel(preset) {
+        fVesselName = preset.name || ""
+        fVesselVolume = preset.volume || 0
+        fVesselMode = preset.mode || "weight"
+        fVesselFlowRate = preset.flowRate || 40
+        fVesselTemperatureC = preset.temperature || 0
+    }
+
+    // Compact "220ml · 96°C" metadata line for a water vessel preset tile.
+    function vesselTileMeta(preset) {
+        var parts = []
+        if ((preset.volume || 0) > 0)
+            parts.push(preset.volume + (preset.mode === "volume" ? "ml" : "g"))
+        if ((preset.temperature || 0) > 0)
+            parts.push(Theme.formatTemperature(preset.temperature, 0))
+        return parts.join(" · ")
+    }
+
     // --- details prefill (history → tea bag data → profile defaults) -------
 
     // Absolute tea temperature (vendor numbers are steeping temps; the tea
@@ -1903,56 +1923,6 @@ Page {
     Tr { id: trJustHotWater; key: "recipes.wizard.justHotWater"; fallback: "Just hot water — no profile"; visible: false }
 
     // --- Reusable pieces (composer idiom) -----------------------------------
-
-    component PickerField: ColumnLayout {
-        id: pickerField
-        property string label: ""
-        property string value: ""
-        property string placeholder: ""
-        signal activated()
-        spacing: Theme.scaled(4)
-        Label {
-            text: pickerField.label
-            font: Theme.captionFont
-            color: Theme.textSecondaryColor
-            Accessible.ignored: true
-        }
-        Rectangle {
-            Layout.fillWidth: true
-            implicitHeight: Theme.scaled(44)
-            radius: Theme.scaled(8)
-            color: Theme.cardBackgroundColor
-            border.color: Theme.borderColor
-            border.width: 1
-            RowLayout {
-                anchors.fill: parent
-                anchors.leftMargin: Theme.spacingMedium
-                anchors.rightMargin: Theme.spacingMedium
-                spacing: Theme.spacingSmall
-                Label {
-                    Layout.fillWidth: true
-                    text: pickerField.value !== "" ? pickerField.value : pickerField.placeholder
-                    font: Theme.bodyFont
-                    color: pickerField.value !== "" ? Theme.textColor : Theme.textSecondaryColor
-                    elide: Text.ElideRight
-                    Accessible.ignored: true
-                }
-                Label {
-                    text: "→"
-                    font: Theme.bodyFont
-                    color: Theme.textSecondaryColor
-                    Accessible.ignored: true
-                }
-            }
-            AccessibleMouseArea {
-                anchors.fill: parent
-                accessibleName: pickerField.label + ", "
-                    + (pickerField.value !== "" ? pickerField.value : pickerField.placeholder)
-                accessibleItem: parent
-                onAccessibleClicked: pickerField.activated()
-            }
-        }
-    }
 
     component NumberField: ColumnLayout {
         id: numberField
@@ -3343,13 +3313,10 @@ Page {
                             // The hot-water window.
                             visible: wizardPage.fHasWater && wizardPage._detailsPage === "water"
                             title: TranslationManager.translate("recipes.composer.sectionHotWater", "Hot water")
-                            PickerField {
-                                Layout.fillWidth: true
-                                label: TranslationManager.translate("recipes.composer.waterVessel", "Water vessel")
-                                value: wizardPage.fVesselName
-                                placeholder: TranslationManager.translate("recipes.composer.chooseVessel", "Choose vessel…")
-                                onActivated: vesselPicker.open()
-                            }
+                            // Order BEFORE the vessel: the vessel tile is the
+                            // terminal choice and moves on by itself, so the
+                            // order (a modifier, template-defaulted) has to be
+                            // settled first.
                             ColumnLayout {
                                 // Latte + Water fixes the order (water before the
                                 // espresso) — no order choice is offered for it.
@@ -3363,18 +3330,60 @@ Page {
                                     color: Theme.textSecondaryColor
                                     Accessible.ignored: true
                                 }
-                                StyledComboBox {
+                                Flow {
                                     Layout.fillWidth: true
-                                    accessibleLabel: TranslationManager.translate("recipes.composer.waterOrder", "When to add the water")
-                                    model: [
-                                        TranslationManager.translate("recipes.composer.waterAfter", "After espresso (Americano)"),
-                                        TranslationManager.translate("recipes.composer.waterBefore", "Before espresso (long black)")
-                                    ]
-                                    currentIndex: wizardPage.fWaterOrder === "before" ? 1 : 0
-                                    onActivated: function(index) {
-                                        wizardPage.fWaterOrder = index === 1 ? "before" : "after"
+                                    spacing: Theme.spacingMedium
+                                    ChoiceTile {
+                                        title: TranslationManager.translate("recipes.composer.waterAfter", "After espresso (Americano)")
+                                        selected: wizardPage.fWaterOrder !== "before"
+                                        onChosen: wizardPage.fWaterOrder = "after"
+                                    }
+                                    ChoiceTile {
+                                        title: TranslationManager.translate("recipes.composer.waterBefore", "Before espresso (long black)")
+                                        selected: wizardPage.fWaterOrder === "before"
+                                        onChosen: wizardPage.fWaterOrder = "before"
                                     }
                                 }
+                            }
+                            Label {
+                                Layout.fillWidth: true
+                                text: TranslationManager.translate("recipes.wizard.vesselHint",
+                                      "Pick the vessel this drink is poured into — its preset sets the "
+                                      + "water amount and temperature.")
+                                font: Theme.captionFont
+                                color: Theme.textSecondaryColor
+                                wrapMode: Text.WordWrap
+                            }
+                            // The vessel presets as inline, tap-to-select tiles
+                            // (like the pitchers on the steam window): the chosen
+                            // one is highlighted, and picking one moves on.
+                            Flow {
+                                Layout.fillWidth: true
+                                spacing: Theme.spacingMedium
+                                Repeater {
+                                    model: Settings.brew.waterVesselPresets
+                                    delegate: ChoiceTile {
+                                        title: modelData.name || ""
+                                        meta: wizardPage.vesselTileMeta(modelData)
+                                        selected: (modelData.name || "") === wizardPage.fVesselName
+                                        onChosen: {
+                                            wizardPage.selectVessel(modelData)
+                                            wizardPage.detailsContinue()
+                                        }
+                                    }
+                                }
+                            }
+                            Label {
+                                visible: Settings.brew.waterVesselPresets.length === 0
+                                Layout.fillWidth: true
+                                text: TranslationManager.translate("recipes.wizard.noVessels",
+                                      "No water vessels saved yet — add one on the Hot Water page "
+                                      + "and it will show up here.")
+                                font: Theme.captionFont
+                                color: Theme.textSecondaryColor
+                                wrapMode: Text.WordWrap
+                                Accessible.role: Accessible.StaticText
+                                Accessible.name: text
                             }
                         }
 
@@ -3702,69 +3711,6 @@ Page {
             basketBrand: wizardPage._selectedPackage.basketBrand || ""
             basketModel: wizardPage._selectedPackage.basketModel || ""
             puckPrepCanonical: wizardPage._selectedPackage.puckPrepCanonical || ""
-        }
-    }
-
-    // --- Pickers (selection-only dialogs, composer idiom) -------------------
-
-    component PickerDialog: Dialog {
-        modal: true
-        anchors.centerIn: parent
-        width: Math.min(Theme.scaled(520), parent.width - Theme.scaled(40))
-        height: Math.min(Theme.scaled(620), parent.height - Theme.scaled(80))
-        background: Rectangle { color: Theme.surfaceColor; radius: Theme.cardRadius; border.color: Theme.borderColor; border.width: 1 }
-    }
-
-
-
-    PickerDialog {
-        id: vesselPicker
-        height: Math.min(Theme.scaled(420), parent.height - Theme.scaled(80))
-        contentItem: ListView {
-            clip: true
-            model: Settings.brew.waterVesselPresets
-            delegate: ItemDelegate {
-                width: ListView.view.width
-                // Preset metadata on the row: amount (per its mode) and
-                // temperature — "220ml · 96°C", never name-only.
-                readonly property string rowMeta: {
-                    var parts = []
-                    if ((modelData.volume || 0) > 0)
-                        parts.push(modelData.volume + (modelData.mode === "volume" ? "ml" : "g"))
-                    if ((modelData.temperature || 0) > 0)
-                        parts.push(Theme.formatTemperature(modelData.temperature, 0))
-                    return parts.join(" · ")
-                }
-                contentItem: ColumnLayout {
-                    spacing: 0
-                    Label {
-                        Layout.fillWidth: true
-                        text: modelData.name || ""
-                        font: Theme.bodyFont
-                        color: Theme.textColor
-                        elide: Text.ElideRight
-                    }
-                    Label {
-                        visible: rowMeta !== ""
-                        Layout.fillWidth: true
-                        text: rowMeta
-                        font: Theme.captionFont
-                        color: Theme.textSecondaryColor
-                        elide: Text.ElideRight
-                    }
-                }
-                Accessible.role: Accessible.Button
-                Accessible.name: (modelData.name || "") + (rowMeta !== "" ? ", " + rowMeta : "")
-                onClicked: {
-                    // Snapshot BY VALUE (never a preset index).
-                    wizardPage.fVesselName = modelData.name || ""
-                    wizardPage.fVesselVolume = modelData.volume || 0
-                    wizardPage.fVesselMode = modelData.mode || "weight"
-                    wizardPage.fVesselFlowRate = modelData.flowRate || 40
-                    wizardPage.fVesselTemperatureC = modelData.temperature || 0
-                    vesselPicker.close()
-                }
-            }
         }
     }
 

--- a/resources/icons/MIT-TablerIcons.txt
+++ b/resources/icons/MIT-TablerIcons.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2026 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/resources/icons/cup.svg
+++ b/resources/icons/cup.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 11h14V8H5zm12.5 0L16 21H8L6.5 11M6 8V7a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v1m-3-3V3"/></svg>

--- a/resources/icons/glass-full.svg
+++ b/resources/icons/glass-full.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M8 21h8m-4-6v6m5-18l1 7c0 3.012-2.686 5-6 5s-6-1.988-6-5l1-7z"/><path d="M6 10a5 5 0 0 1 6 0a5 5 0 0 0 6 0"/></g></svg>

--- a/resources/icons/mug.svg
+++ b/resources/icons/mug.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" stroke="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.083 5h10.834A1.08 1.08 0 0 1 16 6.077v8.615C16 17.072 14.06 19 11.667 19H7.333C4.94 19 3 17.071 3 14.692V6.077A1.08 1.08 0 0 1 4.083 5M16 8h2.5c1.38 0 2.5 1.045 2.5 2.333v2.334C21 13.955 19.88 15 18.5 15H16"/></svg>

--- a/resources/icons/pitcher.svg
+++ b/resources/icons/pitcher.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5.6 7 L16 8.2 L14.5 19.2a1.1 1.1 0 0 1 -1.1 1H10.2a1.1 1.1 0 0 1 -1.1 -1L7.5 9 Z"/>
+  <path d="M16 8.6h1.2a3.6 3.6 0 0 1 0 7.2H15"/>
+</svg>

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -38,6 +38,15 @@
         <file alias="icons/espresso.svg">icons/espresso 8mm.svg</file>
         <file>icons/steam.svg</file>
         <file>icons/water.svg</file>
+        <!-- Drinkware, on the recipe wizard's steam and hot-water tiles.
+             pitcher.svg is drawn for this project; cup/mug/glass-full come
+             from Tabler Icons (MIT) — licence text in
+             icons/MIT-TablerIcons.txt, credited in the README. All four
+             are 24-unit, stroke-width 2, matching the stroked icons above. -->
+        <file>icons/pitcher.svg</file>
+        <file>icons/cup.svg</file>
+        <file>icons/mug.svg</file>
+        <file>icons/glass-full.svg</file>
         <file alias="icons/flush.svg">icons/flush 8mm.svg</file>
         <file>icons/settings.svg</file>
         <file>icons/back.svg</file>

--- a/src/mcp/mcptools_presets.cpp
+++ b/src/mcp/mcptools_presets.cpp
@@ -337,7 +337,12 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
             const QVariantList list = settings->brew()->waterVesselPresets();
             if (!indexInRange(index, list.size())) { result["error"] = "index out of range"; return result; }
             const QVariantMap existing = settings->brew()->getWaterVesselPreset(index);
-            const QString name = args.contains("name") ? args.value("name").toString() : existing.value("name").toString();
+            // A blank name is rejected here for the same reason water_vessel_add
+            // rejects it: recipes snapshot the vessel BY NAME, so a nameless
+            // preset is one nothing can refer to afterwards.
+            const QString name = args.contains("name") ? args.value("name").toString().trimmed()
+                                                       : existing.value("name").toString();
+            if (name.isEmpty()) { result["error"] = "name cannot be empty"; return result; }
             const int volume = args.contains("volumeMl") ? args.value("volumeMl").toInt() : existing.value("volume").toInt();
             const QString mode = args.contains("mode") ? args.value("mode").toString()
                 : (existing.contains("mode") ? existing.value("mode").toString() : QStringLiteral("weight"));


### PR DESCRIPTION
Closes [#1671](https://github.com/Kulitorum/Decenza/issues/1671).

## The complaint

Every picker window in the recipe wizard is tap-to-choose-and-move-on — drink type, bean, profile, equipment, steam pitcher. **Hot water was the one exception**: it opened a modal list to pick the vessel, dropped you back on the window, and then wanted a second tap on Continue. That is what the video in #1671 shows.

I audited the rest of the walk before changing anything; hot water was the only place left. The other multi-tap spots are the dose/yield/temp/grind fields, which are typed numbers rather than a choice.

## The change

The vessel presets are now inline `ChoiceTile`s, rendered exactly the way the steam window renders pitchers — current one highlighted, each tile showing its amount and temperature (`220ml · 96°C`). Tapping one snapshots the preset **by value** (never a preset index, same as before) and moves on.

The water-order combo becomes two tiles as well, and sits **above** the vessels: it is a modifier with a template-supplied default, so the terminal choice — the one that advances — has to come last. Latte + Water still offers no order choice; it always pours the water first.

An empty preset list previously still rendered "Choose vessel…"; it now says where vessels are added rather than showing a blank card.

Removing the modal took the last users of the `PickerField` and `PickerDialog` components with it, so both are deleted.

## Manual

Wiki manual step 6 (Steam / Hot water) updated to describe the tiles. Held locally pending the usual release-timing call — say the word and I'll push it.

## Verification

- Qt Creator build: succeeded, 0 errors, 0 warnings.
- Full suite via `run_tests` scope `all`: **105 passed, 0 failed, 0 skipped**.
- All four `scripts/check_*.py` text invariants clean (glyph coverage reports only its pre-existing AddLanguagePage exemptions).
- QML behaviour itself is manual-test-only per project convention — not yet exercised on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)