### PR TITLE
Harden the water-vessel and steam-pitcher preset store

### DIFF
--- a/qml/pages/HotWaterPage.qml
+++ b/qml/pages/HotWaterPage.qml
@@ -933,13 +933,17 @@ Page {
                     KeyNavigation.backtab: cancelEditVesselButton
                     // A vessel is identified by its NAME everywhere it is used —
                     // recipes snapshot it by name, and the recipe wizard matches
-                    // its tiles on it. Renaming one to blank therefore produces a
-                    // vessel nothing can refer to, so the empty name is rejected
-                    // here exactly as the Add dialog rejects it.
+                    // its tiles on it. So a blank name (nothing can refer to it)
+                    // and a name another vessel already holds (two vessels that
+                    // cannot be told apart) are both refused, as in the Add
+                    // dialog. ignoreIndex is this preset: keeping its own name is
+                    // not a clash.
                     enabled: editVesselNameInput.text.trim().length > 0
+                        && !Settings.brew.waterVesselNameTaken(editVesselNameInput.text, editingVesselIndex)
                     onClicked: {
                         Qt.inputMethod.commit()
-                        if (editVesselNameInput.text.trim().length === 0)
+                        if (editVesselNameInput.text.trim().length === 0
+                                || Settings.brew.waterVesselNameTaken(editVesselNameInput.text, editingVesselIndex))
                             return
                         var preset = Settings.brew.getWaterVesselPreset(editingVesselIndex)
                         Settings.brew.updateWaterVesselPreset(editingVesselIndex, editVesselNameInput.text, preset.volume, preset.mode || "weight", (preset.flowRate !== undefined) ? preset.flowRate : 40, (preset.temperature !== undefined) ? preset.temperature : Settings.brew.waterTemperature)
@@ -1031,6 +1035,22 @@ Page {
                 }
             }
 
+            // Two vessels sharing a name are indistinguishable everywhere they
+            // are used — recipes snapshot the vessel BY NAME — so the clash is
+            // named here rather than letting the setter drop the write silently.
+            Label {
+                visible: newVesselNameInput.text.trim().length > 0
+                    && Settings.brew.waterVesselNameTaken(newVesselNameInput.text, -1)
+                Layout.fillWidth: true
+                text: TranslationManager.translate("hotwater.vesselNameInUse",
+                          "That name is already used by another vessel — choose a different one.")
+                font: Theme.captionFont
+                color: Theme.warningColor
+                wrapMode: Text.WordWrap
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
+            }
+
             RowLayout {
                 spacing: Theme.scaled(10)
 
@@ -1050,6 +1070,8 @@ Page {
                     primary: true
                     text: TranslationManager.translate("hotwater.button.add", "Add")
                     accessibleName: TranslationManager.translate("hotWater.addNewVessel", "Add new water vessel with entered name")
+                    enabled: newVesselNameInput.text.trim().length > 0
+                        && !Settings.brew.waterVesselNameTaken(newVesselNameInput.text, -1)
                     KeyNavigation.tab: newVesselNameInput
                     KeyNavigation.backtab: cancelAddVesselButton
                     onClicked: {

--- a/qml/pages/SteamPage.qml
+++ b/qml/pages/SteamPage.qml
@@ -2478,10 +2478,19 @@ Page {
                     primary: true
                     text: saveButtonText.text
                     accessibleName: TranslationManager.translate("steam.savePitcherChanges", "Save changes to pitcher preset")
+                    // Recipes snapshot the pitcher BY NAME, so a blank name is
+                    // one nothing can refer to and a duplicate makes two
+                    // pitchers indistinguishable. ignoreIndex is this preset —
+                    // keeping its own name is not a clash.
+                    enabled: editPitcherNameInput.text.trim().length > 0
+                        && !Settings.brew.steamPitcherNameTaken(editPitcherNameInput.text, editingPitcherIndex)
                     KeyNavigation.tab: editPitcherNameInput
                     KeyNavigation.backtab: editCancelButton
                     onClicked: {
                         Qt.inputMethod.commit()
+                        if (editPitcherNameInput.text.trim().length === 0
+                                || Settings.brew.steamPitcherNameTaken(editPitcherNameInput.text, editingPitcherIndex))
+                            return
                         var preset = Settings.brew.getSteamPitcherPreset(editingPitcherIndex)
                         Settings.brew.updateSteamPitcherPreset(editingPitcherIndex, editPitcherNameInput.text, preset.duration, preset.flow)
                         editPitcherPopup.close()
@@ -2594,6 +2603,8 @@ Page {
                     id: addPitcherOffButton
                     text: addOffButtonText.text
                     accessibleName: TranslationManager.translate("steam.addNewPitcherOff", "Add new preset that turns the steam heater off")
+                    enabled: newPitcherName.text.trim().length > 0
+                        && !Settings.brew.steamPitcherNameTaken(newPitcherName.text, -1)
                     KeyNavigation.tab: addPitcherConfirmButton
                     KeyNavigation.backtab: addCancelPitcherButton
                     onClicked: {
@@ -2613,6 +2624,8 @@ Page {
                     primary: true
                     text: addButtonText.text
                     accessibleName: TranslationManager.translate("steam.addNewPitcher", "Add new pitcher preset with entered name")
+                    enabled: newPitcherName.text.trim().length > 0
+                        && !Settings.brew.steamPitcherNameTaken(newPitcherName.text, -1)
                     KeyNavigation.tab: newPitcherName
                     KeyNavigation.backtab: addPitcherOffButton
                     onClicked: {

--- a/src/controllers/maincontroller.cpp
+++ b/src/controllers/maincontroller.cpp
@@ -1734,22 +1734,37 @@ void MainController::applyActivatedRecipe(qint64 recipeId, const QVariantMap& re
                     qDebug() << "applyActivatedRecipe: recreated deleted water vessel" << vesselName;
                 } else if (!blockHasValues) {
                     // Name-only block (web): adopt the live vessel's values.
+                    // Each field is adopted only when the preset actually
+                    // carries it: presets predating these keys exist (the Hot
+                    // Water page reads them with the same `undefined`
+                    // fallbacks), and an absent key resolves to 0 — which would
+                    // silently discard the defaults applied above and push a
+                    // 0 mL/s, 0 °C target to the machine.
                     const QVariantMap p = brew->getWaterVesselPreset(index);
                     volume = p.value("volume").toInt();
                     const QString pMode = p.value("mode").toString();
                     if (!pMode.isEmpty()) mode = pMode;
-                    flowRate = p.value("flowRate").toInt();
-                    tempC = p.value("temperature").toDouble();
+                    if (p.contains("flowRate")) flowRate = p.value("flowRate").toInt();
+                    if (p.contains("temperature")) tempC = p.value("temperature").toDouble();
                 }
                 brew->setSelectedWaterCup(index);
             }
             // Push the vessel's values into the live hot-water settings and send
             // (the non-UI equivalent of selecting the vessel on the brew screen).
-            brew->setWaterVolume(volume);
-            brew->setWaterVolumeMode(mode);
-            m_settings->hardware()->setHotWaterFlowRate(flowRate);
-            brew->setWaterTemperature(tempC);
-            applyHotWaterSettings();
+            // A vessel that resolved to no usable volume is treated like the
+            // missing-vessel case above — say so and leave the live settings at
+            // the user's baseline, rather than pouring to a 0 target.
+            if (volume <= 0) {
+                qWarning() << "applyActivatedRecipe: hot-water vessel" << vesselName
+                           << "resolved to no usable volume — leaving the live hot-water"
+                           << "settings untouched";
+            } else {
+                brew->setWaterVolume(volume);
+                brew->setWaterVolumeMode(mode);
+                m_settings->hardware()->setHotWaterFlowRate(flowRate);
+                brew->setWaterTemperature(tempC);
+                applyHotWaterSettings();
+            }
         }
 
         // Selection state last, so the watchers above never see a half-

--- a/src/core/settings_brew.cpp
+++ b/src/core/settings_brew.cpp
@@ -249,13 +249,61 @@ void SettingsBrew::calibrateSteamFromReference(double milkG, double timeSec) {
     setMilkAutoCaptureEnabled(true);
 }
 
+bool SettingsBrew::nameTakenIn(const QJsonArray& arr, const QString& name, int ignoreIndex) {
+    const QString wanted = name.trimmed();
+    if (wanted.isEmpty()) return false;   // emptiness is rejected by the callers, separately
+    for (int i = 0; i < arr.size(); ++i) {
+        if (i == ignoreIndex) continue;   // renaming a preset to its own name is not a clash
+        if (arr.at(i).toObject().value("name").toString().trimmed()
+                .compare(wanted, Qt::CaseInsensitive) == 0)
+            return true;
+    }
+    return false;
+}
+
+bool SettingsBrew::waterVesselNameTaken(const QString& name, int ignoreIndex) const {
+    return nameTakenIn(readPresetArray(QStringLiteral("water/vesselPresets")), name, ignoreIndex);
+}
+
+bool SettingsBrew::steamPitcherNameTaken(const QString& name, int ignoreIndex) const {
+    return nameTakenIn(readPresetArray(QStringLiteral("steam/pitcherPresets")), name, ignoreIndex);
+}
+
+QJsonArray SettingsBrew::readPresetArray(const QString& key, bool* parseFailed) const {
+    if (parseFailed) *parseFailed = false;
+    const QByteArray data = m_settings.value(key).toByteArray();
+    // Genuinely unset (or explicitly emptied) — not a failure, just no presets.
+    if (data.isEmpty()) return QJsonArray();
+
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(data, &err);
+    if (err.error != QJsonParseError::NoError) {
+        if (parseFailed) *parseFailed = true;
+        // noquote so the key reads as a settings path rather than "a/b" — this
+        // line is the only notice a user or a bug report ever gets that their
+        // presets became unreadable.
+        qWarning().noquote() << "SettingsBrew: could not parse" << key << "-" << err.errorString()
+                             << "at offset" << err.offset
+                             << "- reporting no presets and refusing to overwrite the stored value";
+        return QJsonArray();
+    }
+    // Valid JSON that is not an array is equally unusable, and equally must not
+    // be written over.
+    if (!doc.isArray()) {
+        if (parseFailed) *parseFailed = true;
+        qWarning().noquote() << "SettingsBrew:" << key << "holds valid JSON that is not an array"
+                             << "- reporting no presets and refusing to overwrite the stored value";
+        return QJsonArray();
+    }
+    return doc.array();
+}
+
 double SettingsBrew::deriveSteamRateFromLegacyPresets() const {
     // Recover a global seconds-per-gram rate from the pre-migration per-pitcher
     // (calibMilkG, duration): the first preset carrying both wins. Returns 0 when no
     // preset was calibrated. Shared by the one-time ctor migration and the backup-
     // import re-seed so both derive the rate identically.
-    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-    QJsonArray arr = QJsonDocument::fromJson(data).array();
+    const QJsonArray arr = readPresetArray(QStringLiteral("steam/pitcherPresets"));
     for (const QJsonValue& v : arr) {
         QJsonObject preset = v.toObject();
         double calibMilk = preset.value("calibMilkG").toDouble(0.0);
@@ -353,9 +401,7 @@ void SettingsBrew::setSteamAutoFlushSeconds(int seconds) {
 // Steam pitcher presets
 
 QVariantList SettingsBrew::steamPitcherPresets() const {
-    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    QJsonArray arr = readPresetArray(QStringLiteral("steam/pitcherPresets"));
 
     QVariantList result;
     for (const QJsonValue& v : arr) {
@@ -376,9 +422,24 @@ void SettingsBrew::setSelectedSteamCup(int index) {
 }
 
 void SettingsBrew::addSteamPitcherPreset(const QString& name, int duration, int flow, double temperature) {
-    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("steam/pitcherPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
+
+    // A preset is addressed BY NAME by everything downstream — recipes snapshot
+    // the vessel/pitcher by name and re-select it on activation, and the recipe
+    // wizard matches its tiles on it. Two presets sharing a name therefore both
+    // light up in the wizard and activation resolves to whichever comes first,
+    // so the clash is refused at the setter, where every caller inherits it.
+    // Existing duplicates already in storage are left alone: this rejects new
+    // ones, it does not delete anyone's data.
+    if (nameTakenIn(arr, name, -1)) {
+        qWarning() << "SettingsBrew: refusing a duplicate steam pitcher named" << name
+                   << "- that name is already in use";
+        return;
+    }
 
     QJsonObject preset;
     preset["name"] = name;
@@ -392,9 +453,24 @@ void SettingsBrew::addSteamPitcherPreset(const QString& name, int duration, int 
 }
 
 void SettingsBrew::addSteamPitcherPresetDisabled(const QString& name) {
-    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("steam/pitcherPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
+
+    // A preset is addressed BY NAME by everything downstream — recipes snapshot
+    // the vessel/pitcher by name and re-select it on activation, and the recipe
+    // wizard matches its tiles on it. Two presets sharing a name therefore both
+    // light up in the wizard and activation resolves to whichever comes first,
+    // so the clash is refused at the setter, where every caller inherits it.
+    // Existing duplicates already in storage are left alone: this rejects new
+    // ones, it does not delete anyone's data.
+    if (nameTakenIn(arr, name, -1)) {
+        qWarning() << "SettingsBrew: refusing a duplicate steam pitcher named" << name
+                   << "- that name is already in use";
+        return;
+    }
 
     QJsonObject preset;
     preset["name"] = name;
@@ -406,9 +482,24 @@ void SettingsBrew::addSteamPitcherPresetDisabled(const QString& name) {
 }
 
 void SettingsBrew::updateSteamPitcherPreset(int index, const QString& name, int duration, int flow, double temperature) {
-    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("steam/pitcherPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
+
+    // A preset is addressed BY NAME by everything downstream — recipes snapshot
+    // the vessel/pitcher by name and re-select it on activation, and the recipe
+    // wizard matches its tiles on it. Two presets sharing a name therefore both
+    // light up in the wizard and activation resolves to whichever comes first,
+    // so the clash is refused at the setter, where every caller inherits it.
+    // Existing duplicates already in storage are left alone: this rejects new
+    // ones, it does not delete anyone's data.
+    if (nameTakenIn(arr, name, index)) {
+        qWarning() << "SettingsBrew: refusing a duplicate steam pitcher named" << name
+                   << "- that name is already in use";
+        return;
+    }
 
     if (index >= 0 && index < static_cast<int>(arr.size())) {
         QJsonObject preset = arr[index].toObject();  // Read existing to preserve pitcherWeightG / calibMilkG
@@ -424,9 +515,11 @@ void SettingsBrew::updateSteamPitcherPreset(int index, const QString& name, int 
 }
 
 void SettingsBrew::removeSteamPitcherPreset(int index) {
-    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("steam/pitcherPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
 
     if (index >= 0 && index < arr.size()) {
         arr.removeAt(index);
@@ -442,9 +535,11 @@ void SettingsBrew::removeSteamPitcherPreset(int index) {
 }
 
 void SettingsBrew::moveSteamPitcherPreset(int from, int to) {
-    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("steam/pitcherPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
 
     if (from >= 0 && from < arr.size() && to >= 0 && to < arr.size() && from != to) {
         QJsonValue item = arr[from];
@@ -466,9 +561,11 @@ void SettingsBrew::moveSteamPitcherPreset(int from, int to) {
 }
 
 void SettingsBrew::setSteamPitcherWeight(int index, double weightG) {
-    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("steam/pitcherPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
 
     if (index >= 0 && index < static_cast<int>(arr.size())) {
         QJsonObject preset = arr[index].toObject();
@@ -480,9 +577,11 @@ void SettingsBrew::setSteamPitcherWeight(int index, double weightG) {
 }
 
 void SettingsBrew::setSteamPitcherCalibration(int index, double calibMilkG) {
-    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("steam/pitcherPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
 
     if (index >= 0 && index < static_cast<int>(arr.size())) {
         QJsonObject preset = arr[index].toObject();
@@ -548,9 +647,7 @@ int SettingsBrew::effectiveSteamDurationSec(int index, double milkG) const {
 }
 
 QVariantMap SettingsBrew::getSteamPitcherPreset(int index) const {
-    QByteArray data = m_settings.value("steam/pitcherPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    QJsonArray arr = readPresetArray(QStringLiteral("steam/pitcherPresets"));
 
     if (index >= 0 && index < arr.size()) {
         return arr[index].toObject().toVariantMap();
@@ -623,9 +720,7 @@ void SettingsBrew::setHotWaterSawSampleCount(int count) {
 // Hot water vessel presets
 
 QVariantList SettingsBrew::waterVesselPresets() const {
-    QByteArray data = m_settings.value("water/vesselPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    QJsonArray arr = readPresetArray(QStringLiteral("water/vesselPresets"));
 
     QVariantList result;
     for (const QJsonValue& v : arr) {
@@ -646,9 +741,24 @@ void SettingsBrew::setSelectedWaterCup(int index) {
 }
 
 void SettingsBrew::addWaterVesselPreset(const QString& name, int volume, const QString& mode, int flowRate, double temperature) {
-    QByteArray data = m_settings.value("water/vesselPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("water/vesselPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
+
+    // A preset is addressed BY NAME by everything downstream — recipes snapshot
+    // the vessel/pitcher by name and re-select it on activation, and the recipe
+    // wizard matches its tiles on it. Two presets sharing a name therefore both
+    // light up in the wizard and activation resolves to whichever comes first,
+    // so the clash is refused at the setter, where every caller inherits it.
+    // Existing duplicates already in storage are left alone: this rejects new
+    // ones, it does not delete anyone's data.
+    if (nameTakenIn(arr, name, -1)) {
+        qWarning() << "SettingsBrew: refusing a duplicate water vessel named" << name
+                   << "- that name is already in use";
+        return;
+    }
 
     QJsonObject preset;
     preset["name"] = name;
@@ -663,9 +773,24 @@ void SettingsBrew::addWaterVesselPreset(const QString& name, int volume, const Q
 }
 
 void SettingsBrew::updateWaterVesselPreset(int index, const QString& name, int volume, const QString& mode, int flowRate, double temperature) {
-    QByteArray data = m_settings.value("water/vesselPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("water/vesselPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
+
+    // A preset is addressed BY NAME by everything downstream — recipes snapshot
+    // the vessel/pitcher by name and re-select it on activation, and the recipe
+    // wizard matches its tiles on it. Two presets sharing a name therefore both
+    // light up in the wizard and activation resolves to whichever comes first,
+    // so the clash is refused at the setter, where every caller inherits it.
+    // Existing duplicates already in storage are left alone: this rejects new
+    // ones, it does not delete anyone's data.
+    if (nameTakenIn(arr, name, index)) {
+        qWarning() << "SettingsBrew: refusing a duplicate water vessel named" << name
+                   << "- that name is already in use";
+        return;
+    }
 
     if (index >= 0 && index < arr.size()) {
         QJsonObject preset;
@@ -682,9 +807,11 @@ void SettingsBrew::updateWaterVesselPreset(int index, const QString& name, int v
 }
 
 void SettingsBrew::removeWaterVesselPreset(int index) {
-    QByteArray data = m_settings.value("water/vesselPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("water/vesselPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
 
     if (index >= 0 && index < arr.size()) {
         arr.removeAt(index);
@@ -700,9 +827,11 @@ void SettingsBrew::removeWaterVesselPreset(int index) {
 }
 
 void SettingsBrew::moveWaterVesselPreset(int from, int to) {
-    QByteArray data = m_settings.value("water/vesselPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("water/vesselPresets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
 
     if (from >= 0 && from < arr.size() && to >= 0 && to < arr.size() && from != to) {
         QJsonValue item = arr[from];
@@ -724,9 +853,7 @@ void SettingsBrew::moveWaterVesselPreset(int from, int to) {
 }
 
 QVariantMap SettingsBrew::getWaterVesselPreset(int index) const {
-    QByteArray data = m_settings.value("water/vesselPresets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    QJsonArray arr = readPresetArray(QStringLiteral("water/vesselPresets"));
 
     if (index >= 0 && index < arr.size()) {
         return arr[index].toObject().toVariantMap();
@@ -737,9 +864,7 @@ QVariantMap SettingsBrew::getWaterVesselPreset(int index) const {
 // Flush
 
 QVariantList SettingsBrew::flushPresets() const {
-    QByteArray data = m_settings.value("flush/presets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    QJsonArray arr = readPresetArray(QStringLiteral("flush/presets"));
 
     QVariantList result;
     for (const QJsonValue& v : arr) {
@@ -782,9 +907,11 @@ void SettingsBrew::setFlushSeconds(double seconds) {
 }
 
 void SettingsBrew::addFlushPreset(const QString& name, double flow, double seconds) {
-    QByteArray data = m_settings.value("flush/presets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("flush/presets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
 
     QJsonObject preset;
     preset["name"] = name;
@@ -797,9 +924,11 @@ void SettingsBrew::addFlushPreset(const QString& name, double flow, double secon
 }
 
 void SettingsBrew::updateFlushPreset(int index, const QString& name, double flow, double seconds) {
-    QByteArray data = m_settings.value("flush/presets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("flush/presets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
 
     if (index >= 0 && index < arr.size()) {
         QJsonObject preset;
@@ -814,9 +943,11 @@ void SettingsBrew::updateFlushPreset(int index, const QString& name, double flow
 }
 
 void SettingsBrew::removeFlushPreset(int index) {
-    QByteArray data = m_settings.value("flush/presets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("flush/presets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
 
     if (index >= 0 && index < arr.size()) {
         arr.removeAt(index);
@@ -832,9 +963,11 @@ void SettingsBrew::removeFlushPreset(int index) {
 }
 
 void SettingsBrew::moveFlushPreset(int from, int to) {
-    QByteArray data = m_settings.value("flush/presets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    bool parseFailed = false;
+    QJsonArray arr = readPresetArray(QStringLiteral("flush/presets"), &parseFailed);
+    // Refuse to append to an array we could not read: writing back would
+    // save an empty list over the user's unreadable presets.
+    if (parseFailed) return;
 
     if (from >= 0 && from < arr.size() && to >= 0 && to < arr.size() && from != to) {
         QJsonValue item = arr[from];
@@ -856,9 +989,7 @@ void SettingsBrew::moveFlushPreset(int from, int to) {
 }
 
 QVariantMap SettingsBrew::getFlushPreset(int index) const {
-    QByteArray data = m_settings.value("flush/presets").toByteArray();
-    QJsonDocument doc = QJsonDocument::fromJson(data);
-    QJsonArray arr = doc.array();
+    QJsonArray arr = readPresetArray(QStringLiteral("flush/presets"));
 
     if (index >= 0 && index < arr.size()) {
         return arr[index].toObject().toVariantMap();

--- a/src/core/settings_brew.h
+++ b/src/core/settings_brew.h
@@ -6,6 +6,10 @@
 #include <QVariantList>
 #include <QVariantMap>
 
+// Forward-declared rather than included: only the private preset-array helper
+// below needs it, and settings.h now includes this header (see CLAUDE.md).
+class QJsonArray;
+
 // Brew-domain settings: espresso, steam, hot water, flush, presets, and
 // session-only brew/temperature overrides. Split from Settings to keep
 // settings.h's transitive-include footprint small.
@@ -167,6 +171,8 @@ public:
     Q_INVOKABLE void removeSteamPitcherPreset(int index);
     Q_INVOKABLE void moveSteamPitcherPreset(int from, int to);
     Q_INVOKABLE QVariantMap getSteamPitcherPreset(int index) const;
+    // As waterVesselNameTaken: for a dialog to check before it calls a setter.
+    Q_INVOKABLE bool steamPitcherNameTaken(const QString& name, int ignoreIndex = -1) const;
     Q_INVOKABLE void setSteamPitcherWeight(int index, double weightG);
     // Weight-scaled steaming: pair a reference milk weight with this preset's
     // duration. At steam time the duration is scaled by the actual milk weight.
@@ -224,6 +230,10 @@ public:
     Q_INVOKABLE void removeWaterVesselPreset(int index);
     Q_INVOKABLE void moveWaterVesselPreset(int from, int to);
     Q_INVOKABLE QVariantMap getWaterVesselPreset(int index) const;
+    // Lets a dialog block Save and explain itself BEFORE calling the setters
+    // above, which reject a clash silently (they return void). ignoreIndex is
+    // the preset being renamed; pass -1 when adding.
+    Q_INVOKABLE bool waterVesselNameTaken(const QString& name, int ignoreIndex = -1) const;
 
     // Flush
     QVariantList flushPresets() const;
@@ -325,4 +335,24 @@ private:
     // Shared write path for the session anchor: normalizes + clamps, updates
     // the cache and QSettings, emits brewOverridesChanged once.
     void writeBrewYieldAnchor(double value, const QString& mode);
+
+    // Every preset list (steam pitchers, water vessels, flushes) is stored as a
+    // JSON array in one settings key and read back through here.
+    //
+    // The point of the helper is the `parseFailed` out-parameter. Reading with
+    // the no-error overload of QJsonDocument::fromJson makes unreadable bytes
+    // indistinguishable from an absent key — both yield an empty array — so a
+    // reader reports "you have no presets" and the next writer appends to that
+    // empty array and SAVES IT OVER the bytes it could not read. The user is
+    // told their presets are gone and then handed the action that makes it
+    // true. Mutators therefore check the flag and refuse to write.
+    //
+    // Pass nullptr when a caller genuinely cannot act on the distinction; the
+    // warning is still logged.
+    QJsonArray readPresetArray(const QString& key, bool* parseFailed = nullptr) const;
+
+    // Case-insensitive, whitespace-trimmed name search. ignoreIndex is the entry
+    // being renamed (so renaming a preset to its own name is not a clash); pass
+    // -1 when adding.
+    static bool nameTakenIn(const QJsonArray& arr, const QString& name, int ignoreIndex);
 };

--- a/src/mcp/mcptools_presets.cpp
+++ b/src/mcp/mcptools_presets.cpp
@@ -154,6 +154,13 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
             if (!settings) { result["error"] = "Settings unavailable"; return result; }
             const QString name = args.value("name").toString().trimmed();
             if (name.isEmpty()) { result["error"] = "name is required"; return result; }
+            // Presets are addressed by name downstream (recipes snapshot the
+            // pitcher by name), so a duplicate is refused here with a message
+            // rather than silently dropped by the setter, which returns void.
+            if (settings->brew()->steamPitcherNameTaken(name)) {
+                result["error"] = "a steam pitcher named \"" + name + "\" already exists";
+                return result;
+            }
             if (args.value("disabled").toBool()) {
                 settings->brew()->addSteamPitcherPresetDisabled(name);
             } else {
@@ -206,6 +213,10 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
                 ? args.value("temperatureC").toDouble()
                 : (existing.contains("temperature") ? existing.value("temperature").toDouble()
                                                      : settings->brew()->steamTemperature());
+            if (settings->brew()->steamPitcherNameTaken(name, index)) {
+                result["error"] = "a steam pitcher named \"" + name + "\" already exists";
+                return result;
+            }
             settings->brew()->updateSteamPitcherPreset(index, name, duration, flow, temp);
             // If we edited the active pitcher, re-apply so the live steam settings
             // (and the machine) reflect the change immediately.
@@ -301,6 +312,10 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
             if (!settings) { result["error"] = "Settings unavailable"; return result; }
             const QString name = args.value("name").toString().trimmed();
             if (name.isEmpty()) { result["error"] = "name is required"; return result; }
+            if (settings->brew()->waterVesselNameTaken(name)) {
+                result["error"] = "a water vessel named \"" + name + "\" already exists";
+                return result;
+            }
             const int volume = args.contains("volumeMl") ? args.value("volumeMl").toInt() : 200;
             const QString mode = args.contains("mode") ? args.value("mode").toString() : QStringLiteral("weight");
             const int flowRate = args.contains("flowMlPerSec")
@@ -353,6 +368,10 @@ void registerPresetsTools(McpToolRegistry* registry, Settings* settings, MainCon
                 ? args.value("temperatureC").toDouble()
                 : (existing.contains("temperature") ? existing.value("temperature").toDouble()
                                                      : settings->brew()->waterTemperature());
+            if (settings->brew()->waterVesselNameTaken(name, index)) {
+                result["error"] = "a water vessel named \"" + name + "\" already exists";
+                return result;
+            }
             settings->brew()->updateWaterVesselPreset(index, name, volume, mode, flowRate, temp);
             // If we edited the active vessel, re-apply so the live hot water settings
             // (and the machine) reflect the change immediately.

--- a/tests/tst_settings.cpp
+++ b/tests/tst_settings.cpp
@@ -656,6 +656,76 @@ private slots:
         QCOMPARE(m_settings.brew()->getWaterVesselPreset(idx)["temperature"].toDouble(), 92.0);
     }
 
+    void duplicatePresetNamesAreRejected() {
+        // Presets are addressed BY NAME downstream (recipes snapshot the vessel or
+        // pitcher and re-select it by name on activation), so two sharing a name
+        // are indistinguishable — the setter refuses the second one.
+        const qsizetype before = m_settings.brew()->waterVesselPresets().size();
+        m_settings.brew()->addWaterVesselPreset("Duplicate Test", 250);
+        QCOMPARE(m_settings.brew()->waterVesselPresets().size(), before + 1);
+
+        // Same name, and the case-insensitive/whitespace variants of it.
+        for (const QString& clash : {QStringLiteral("Duplicate Test"),
+                                     QStringLiteral("duplicate test"),
+                                     QStringLiteral("  Duplicate Test  ")}) {
+            QTest::ignoreMessage(QtWarningMsg,
+                QRegularExpression(QStringLiteral("refusing a duplicate water vessel named")));
+            m_settings.brew()->addWaterVesselPreset(clash, 300);
+        }
+        QCOMPARE(m_settings.brew()->waterVesselPresets().size(), before + 1);
+        QVERIFY(m_settings.brew()->waterVesselNameTaken("DUPLICATE TEST"));
+        QVERIFY(!m_settings.brew()->waterVesselNameTaken("Something Else"));
+
+        // Renaming a preset to the name it already holds is not a clash.
+        const int idx = static_cast<int>(before);
+        QVERIFY(!m_settings.brew()->waterVesselNameTaken("Duplicate Test", idx));
+        m_settings.brew()->updateWaterVesselPreset(idx, "Duplicate Test", 275);
+        QCOMPARE(m_settings.brew()->getWaterVesselPreset(idx)["volume"].toInt(), 275);
+
+        // The pitcher list carries the identical contract.
+        const qsizetype pitchersBefore = m_settings.brew()->steamPitcherPresets().size();
+        m_settings.brew()->addSteamPitcherPreset("Duplicate Pitcher", 30, 150, 150.0);
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(QStringLiteral("refusing a duplicate steam pitcher named")));
+        m_settings.brew()->addSteamPitcherPreset("duplicate pitcher", 45, 150, 150.0);
+        QCOMPARE(m_settings.brew()->steamPitcherPresets().size(), pitchersBefore + 1);
+    }
+
+    void unreadablePresetBlobIsNotOverwritten() {
+        // A corrupt preset blob used to be indistinguishable from an absent key:
+        // both parsed to an empty array, so the app reported "no presets" and the
+        // next add saved that empty array OVER the bytes it could not read. The
+        // read must warn, and every writer must refuse rather than destroy it.
+        QSettings raw(Settings::testQSettingsPath(), QSettings::IniFormat);
+        const QByteArray corrupt = QByteArrayLiteral("{ this is not json");
+        raw.setValue("water/vesselPresets", corrupt);
+        raw.sync();
+
+        // Read through a FRESH Settings, as visualizerAutoUpdateDefault does: the
+        // shared m_settings holds its own QSettings instance and need not observe
+        // another instance's write.
+        {
+            Settings fresh;
+            QTest::ignoreMessage(QtWarningMsg,
+                QRegularExpression(QStringLiteral("SettingsBrew: could not parse water/vesselPresets")));
+            QVERIFY(fresh.brew()->waterVesselPresets().isEmpty());
+
+            // The add is refused — it warns again on its own read — and the
+            // stored bytes survive untouched.
+            QTest::ignoreMessage(QtWarningMsg,
+                QRegularExpression(QStringLiteral("SettingsBrew: could not parse water/vesselPresets")));
+            fresh.brew()->addWaterVesselPreset("Should not be written", 200);
+        }
+
+        raw.sync();
+        QCOMPARE(raw.value("water/vesselPresets").toByteArray(), corrupt);
+
+        // Restore a readable list; cleanupTestCase puts the original back, but
+        // the tests that follow in this class read presets through m_settings.
+        raw.setValue("water/vesselPresets", QByteArrayLiteral("[]"));
+        raw.sync();
+    }
+
     void temperatureUnitRoundTrip() {
         // The display temperature unit must survive an export -> import cycle. The
         // serializer's export/import key strings are hand-mirrored, so a typo on


### PR DESCRIPTION
Three defects the review of [#1679](https://github.com/Kulitorum/Decenza/pull/1679) turned up in the storage layer underneath the wizard's new tile windows. All pre-existing; none is a regression from that PR.

> **Stacked on `fix-wizard-hot-water-one-tap`**, because it touches files #1679 also modifies. **Retarget this to `main` before #1679 merges**, or GitHub closes it and it can't be reopened.

## 1. Activation could push zeros to the machine

`applyActivatedRecipe` reads the recipe's `flowRate`/`temperature` *with* defaults (40, the global water temperature). The adopt-from-preset branch below it — taken when the block carries no volume, which is what the web form's name-only block stores — re-read the same fields with a bare `toInt()`/`toDouble()`, so an absent key resolved to 0 and discarded those defaults.

Presets predating those keys demonstrably exist: `HotWaterPage.qml` reads them with explicit `!== undefined` fallbacks for exactly that reason. Such a preset reached `setHotWaterFlowRate(0)` and `setWaterTemperature(0)`, and `applyHotWaterSettings()` pushed both to the DE1 with nothing logged.

Each field is now adopted only when the preset carries it, and a vessel still resolving to no usable volume is handled like the missing-vessel case the guard above already covers — warn, and leave the live settings at the user's baseline.

## 2. Writes destroyed data they could not read

Every preset list is a JSON array in one settings key, read at **22 sites** with the no-error overload of `QJsonDocument::fromJson`. That makes corrupt bytes indistinguishable from an absent key — both parse to an empty array — so the app reported "no presets" and the next add appended to that empty array and saved it **over the bytes it could not read**. The user was told their presets were gone and then handed the action that made it true.

All 22 go through one `readPresetArray()` now: it reports the failure through an out-parameter, warns with the error string and offset, and also rejects valid JSON that isn't an array. The **15 mutators** bail on that flag instead of writing.

## 3. Duplicate names were accepted

Nothing enforced uniqueness, yet every consumer resolves a vessel or pitcher **by name** — recipes snapshot by value and re-select by name on activation (`RECIPES.md`), and the wizard's tiles match on it. Two presets sharing a name both light up as selected, and activation resolves to whichever comes first, which needn't be the one tapped.

Rejected at the setter so every caller inherits it: case-insensitive, whitespace-trimmed, with an `ignoreIndex` so renaming a preset to its own name isn't a clash. **Duplicates already in storage are left alone** — this refuses new ones, it doesn't delete anyone's data. Since the setters return `void`, new `waterVesselNameTaken`/`steamPitcherNameTaken` let the Add and Edit dialogs on both pages disable Save and say why, and the four MCP write paths return a real error rather than silently doing nothing.

## Verification

- Build: 0 errors, 0 warnings
- **105 passed, 0 failed, 0 skipped**
- Text invariants clean
- Two new cases in `tst_settings.cpp`: a corrupt blob survives an attempted add, and duplicate rejection across case/whitespace variants for both vessels and pitchers

The QML dialog changes are manual-test-only per project convention — not yet exercised on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)