### PR TITLE
Wait on the bag row, not on 50 ms, in the dose-ladder test

### DIFF
--- a/tests/tst_coffeebags.cpp
+++ b/tests/tst_coffeebags.cpp
@@ -1889,8 +1889,13 @@ private slots:
         // through to the profile, and the live dose is left alone (the bag
         // adopts it on the first edit; coffee-bag-model).
         dye.setActiveBagId(static_cast<int>(bagNoDose));
-        QTRY_COMPARE(dye.activeBagId(), static_cast<int>(bagNoDose));
-        QTRY_COMPARE(dye.doseOwner(), SettingsDye::DoseOwner::Profile);
+        QCOMPARE(dye.activeBagId(), static_cast<int>(bagNoDose));
+        // Let this bag's row land before reading the rung. Unresolved reads as
+        // "no dose" here, so a check taken mid-flight would pass for the wrong
+        // reason — and a row still in flight would land on top of the dose
+        // dialed just below, taking the rung back to empty.
+        QTRY_VERIFY(dye.doseLadderResolved());
+        QCOMPARE(dye.doseOwner(), SettingsDye::DoseOwner::Profile);
         QCOMPARE(dye.dyeBeanWeight(), 20.0);
 
         // Dialing a dose onto that bag makes it the owner: the write-through
@@ -1913,8 +1918,12 @@ private slots:
         // not merely the session value.
         dye.setDyeBeanWeight(19.0);              // the recipe's dose is live
         dye.setActiveBagId(static_cast<int>(bagWithDose));
-        QTRY_COMPARE(dye.activeBagId(), static_cast<int>(bagWithDose));
-        QTest::qWait(50);                        // let any queued apply land
+        QCOMPARE(dye.activeBagId(), static_cast<int>(bagWithDose));
+        // Wait on the ROW landing, not on a duration: the rung reports itself
+        // unresolved until bagReady arrives, so this is the event the queued
+        // apply is gated behind. A fixed wait passes locally and fails on a
+        // sanitizer runner where the storage worker takes longer than it.
+        QTRY_VERIFY(dye.doseLadderResolved());
         QCOMPARE(dye.dyeBeanWeight(), 19.0);     // NOT the bag's 20.0
         QCOMPARE(dye.doseOwner(), SettingsDye::DoseOwner::Recipe);
 


### PR DESCRIPTION
## What

The nightly ASan job failed `tst_CoffeeBags::settingsDyeDoseLadder()` on all three ctest attempts:

```
FAIL!  : tst_CoffeeBags::settingsDyeDoseLadder() Compared values are not the same
   Actual   (dye.doseOwner())            : Profile
   Expected (SettingsDye::DoseOwner::Bag): Bag
   Loc: [tests/tst_coffeebags.cpp(1923)]
```

Despite the job it surfaced in, this is not a sanitizer report — no ASan diagnostic was printed. It is a plain comparison failure that ASan's slowdown made deterministic.

## Why

The product code is correct. `SettingsDye::setActiveBagId()` drops the bag rung and marks it unresolved until `bagReady` arrives from the storage worker thread, so during that window `doseOwner()` returns `Profile` — an unresolved rung is indistinguishable from a bag that designs no dose, which is exactly what `doseLadderResolved()` exists to say.

The test bridged the window with `QTest::qWait(50)`. Under ASan on a CI runner the worker's DB round-trip takes longer than 50 ms, so clearing the recipe rung dropped to the profile instead of the bag. A fixed wait used as a guard is also what CLAUDE.md's design principles rule out.

## The fix

Wait on `doseLadderResolved()` — the event the queued apply is gated behind — so the assertion no longer depends on runner speed.

The same change goes on the earlier `bagNoDose` selection, which had the same shape and a nastier failure mode: the test dialed a dose while that bag's row was still in flight, and the stale row landing afterwards resets the cache to zero and takes `doseOwner()` back to `Profile`. It happened not to fire on CI, but it is the same race.

## Not in this PR

The nightly's **ubsan** job failed separately and never reached the tests — the QML diagnostics gate, which first ran in that nightly, reports `qml/simulator/GHCSimulatorWindow.qml` as not in the `qt_add_qml_module` list. On Linux that is correct: CMakeLists appends it only under `if(WIN32 OR (APPLE AND NOT IOS))`. Separately, the gate is red on macOS for three files whose counts rose after the baseline was set (`PresetPillRow.qml` 49 → 53, `HotWaterPage.qml` 135 → 137, `SteamPage.qml` 223 → 225). Both go on their own branch.

## Testing

Full suite via Qt Creator: 105 passed, 0 failed, 0 skipped, no test warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)