### PR TITLE
Clear four of five qmllint category exemptions, and the bugs they were hiding

### DIFF
--- a/docs/CLAUDE_MD/QML_GOTCHAS.md
+++ b/docs/CLAUDE_MD/QML_GOTCHAS.md
@@ -394,6 +394,32 @@ paired-line, not textual:
 Run over a whole branch diff that is a few seconds and it is exhaustive; it found this occurrence
 and confirmed there were no others.
 
+## Introducing an id? Verify every use falls inside that object's own block
+
+Giving a control an id to replace an untyped `parent.` hop is a good fix, and it is easy to bind
+the id to the WRONG object. An automated pass over
+`Button { background: Rectangle { color: parent.down ... } }` searched upward for the enclosing
+`background:`/`contentItem:` with no bound, found one hundreds of lines above, and attached six
+references to a button in a different part of the file:
+
+```qml
+// line 273
+AccessibleButton { id: createNewProfileButton; ... }
+// line 774, inside `trailingActionDelegate: Component { StyledIconButton { ... } }`
+icon.color: createNewProfileButton.selected ? ...   // WRONG: `parent` here is the delegate's row
+```
+
+It compiles, and both objects exist, so nothing complains — it simply reads the wrong object.
+
+The check that catches it is cheap and does not need a linter: **for every id you introduce, find
+its declaration line and its block's extent by indentation, then assert every `<id>.` use in the
+file falls inside that range.** Run over a 38-id pass this found exactly the 2 that were wrong.
+
+Note the ordinary gate does NOT catch this. It surfaced only because one file's `unqualified`
+ceiling ROSE (54 -> 60) and the tool refused to write a baseline that relaxes a ceiling — the
+rise was the symptom, not the defect. A gate that silently accepted the new number would have
+shipped it.
+
 ## `Window` is an attached property — do not write it through an id
 
 ```qml

--- a/qml-diagnostics-baseline.json
+++ b/qml-diagnostics-baseline.json
@@ -60,7 +60,6 @@
     "qml/components/layout/items/WeatherItem.qml": 32,
     "qml/components/library/LibraryItemCard.qml": 66,
     "qml/components/library/LibraryPanel.qml": 95,
-    "qml/main.qml": 110,
     "qml/pages/AutoFavoriteInfoPage.qml": 77,
     "qml/pages/AutoFavoritesPage.qml": 71,
     "qml/pages/BeanInfoPage.qml": 4,
@@ -211,6 +210,7 @@
     "qml/components/layout/items/TemperatureItem.qml",
     "qml/components/layout/items/WaterLevelItem.qml",
     "qml/components/qrcode.js",
+    "qml/main.qml",
     "qml/pages/AISettingsPage.qml",
     "qml/pages/FlowEditorPage.qml",
     "qml/pages/HotWaterPage.qml",
@@ -234,6 +234,6 @@
     "duplicate-property-binding": 2,
     "equality-type-coercion": 1,
     "missing-property": 146,
-    "unqualified": 2734
+    "unqualified": 2624
   }
 }

--- a/qml-diagnostics-baseline.json
+++ b/qml-diagnostics-baseline.json
@@ -50,7 +50,6 @@
     "qml/components/layout/ZoneOptionsPopup.qml": 4,
     "qml/components/layout/items/AutoFavoritesItem.qml": 1,
     "qml/components/layout/items/BeansItem.qml": 1,
-    "qml/components/layout/items/CustomItem.qml": 3,
     "qml/components/layout/items/EquipmentItem.qml": 1,
     "qml/components/layout/items/FlushItem.qml": 1,
     "qml/components/layout/items/HistoryItem.qml": 1,
@@ -61,7 +60,7 @@
     "qml/components/layout/items/WeatherItem.qml": 32,
     "qml/components/library/LibraryItemCard.qml": 66,
     "qml/components/library/LibraryPanel.qml": 95,
-    "qml/main.qml": 111,
+    "qml/main.qml": 110,
     "qml/pages/AutoFavoriteInfoPage.qml": 77,
     "qml/pages/AutoFavoritesPage.qml": 71,
     "qml/pages/BeanInfoPage.qml": 4,
@@ -188,6 +187,7 @@
     "qml/components/layout/WidgetColor.qml",
     "qml/components/layout/items/BatteryLevelItem.qml",
     "qml/components/layout/items/ClockItem.qml",
+    "qml/components/layout/items/CustomItem.qml",
     "qml/components/layout/items/DiscussItem.qml",
     "qml/components/layout/items/DoseWeightItem.qml",
     "qml/components/layout/items/EspressoItem.qml",
@@ -233,7 +233,7 @@
     "Quick.property-changes-parsed": 5,
     "duplicate-property-binding": 2,
     "equality-type-coercion": 1,
-    "missing-property": 145,
-    "unqualified": 2738
+    "missing-property": 146,
+    "unqualified": 2734
   }
 }

--- a/qml-diagnostics-baseline.json
+++ b/qml-diagnostics-baseline.json
@@ -229,7 +229,7 @@
     "qml/pages/settings/SettingsVisualizerTab.qml"
   ],
   "observed_categories": {
-    "missing-property": 150,
+    "missing-property": 92,
     "unqualified": 2327
   }
 }

--- a/qml-diagnostics-baseline.json
+++ b/qml-diagnostics-baseline.json
@@ -229,7 +229,7 @@
     "qml/pages/settings/SettingsVisualizerTab.qml"
   ],
   "observed_categories": {
-    "missing-property": 92,
+    "missing-property": 87,
     "unqualified": 2327
   }
 }

--- a/qml-diagnostics-baseline.json
+++ b/qml-diagnostics-baseline.json
@@ -229,10 +229,6 @@
     "qml/pages/settings/SettingsVisualizerTab.qml"
   ],
   "observed_categories": {
-    "Quick.layout-positioning": 20,
-    "Quick.property-changes-parsed": 5,
-    "duplicate-property-binding": 1,
-    "equality-type-coercion": 1,
     "missing-property": 150,
     "unqualified": 2327
   }

--- a/qml-diagnostics-baseline.json
+++ b/qml-diagnostics-baseline.json
@@ -69,7 +69,6 @@
     "qml/pages/EquipmentPage.qml": 3,
     "qml/pages/EspressoPage.qml": 23,
     "qml/pages/FlowCalibrationPage.qml": 1,
-    "qml/pages/FlushPage.qml": 117,
     "qml/pages/IdlePage.qml": 95,
     "qml/pages/ProfileImportPage.qml": 14,
     "qml/pages/ProfileInfoPage.qml": 32,
@@ -213,6 +212,7 @@
     "qml/main.qml",
     "qml/pages/AISettingsPage.qml",
     "qml/pages/FlowEditorPage.qml",
+    "qml/pages/FlushPage.qml",
     "qml/pages/HotWaterPage.qml",
     "qml/pages/PostShotReviewPage.qml",
     "qml/pages/PressureEditorPage.qml",
@@ -233,7 +233,7 @@
     "Quick.property-changes-parsed": 5,
     "duplicate-property-binding": 2,
     "equality-type-coercion": 1,
-    "missing-property": 146,
-    "unqualified": 2624
+    "missing-property": 150,
+    "unqualified": 2507
   }
 }

--- a/qml-diagnostics-baseline.json
+++ b/qml-diagnostics-baseline.json
@@ -69,14 +69,12 @@
     "qml/pages/EquipmentPage.qml": 3,
     "qml/pages/EspressoPage.qml": 23,
     "qml/pages/FlowCalibrationPage.qml": 1,
-    "qml/pages/IdlePage.qml": 95,
     "qml/pages/ProfileImportPage.qml": 14,
     "qml/pages/ProfileInfoPage.qml": 32,
     "qml/pages/ProfileSelectorPage.qml": 54,
     "qml/pages/RecipeEditorPage.qml": 99,
     "qml/pages/RecipeWizardPage.qml": 144,
     "qml/pages/RecipesPage.qml": 29,
-    "qml/pages/ScreensaverPage.qml": 85,
     "qml/pages/SettingsPage.qml": 4,
     "qml/pages/ShotComparisonPage.qml": 27,
     "qml/pages/TransportPage.qml": 21,
@@ -214,9 +212,11 @@
     "qml/pages/FlowEditorPage.qml",
     "qml/pages/FlushPage.qml",
     "qml/pages/HotWaterPage.qml",
+    "qml/pages/IdlePage.qml",
     "qml/pages/PostShotReviewPage.qml",
     "qml/pages/PressureEditorPage.qml",
     "qml/pages/ProfileEditorPage.qml",
+    "qml/pages/ScreensaverPage.qml",
     "qml/pages/ShotDetailPage.qml",
     "qml/pages/ShotHistoryPage.qml",
     "qml/pages/SimpleProfileEditorPage.qml",
@@ -229,11 +229,11 @@
     "qml/pages/settings/SettingsVisualizerTab.qml"
   ],
   "observed_categories": {
-    "Quick.layout-positioning": 21,
+    "Quick.layout-positioning": 20,
     "Quick.property-changes-parsed": 5,
-    "duplicate-property-binding": 2,
+    "duplicate-property-binding": 1,
     "equality-type-coercion": 1,
     "missing-property": 150,
-    "unqualified": 2507
+    "unqualified": 2327
   }
 }

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -500,6 +500,7 @@ Dialog {
 
                 // Clear all overrides
                 AccessibleButton {
+                    id: clearButton
                     Layout.preferredHeight: Theme.scaled(36)
                     text: TranslationManager.translate("brewDialog.clear", "Clear")
                     accessibleName: TranslationManager.translate("brewDialog.clearAllOverrides", "Clear all overrides")
@@ -548,7 +549,7 @@ Dialog {
                         border.color: Theme.warningColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: clearButton.text
                         font: Theme.bodyFont
                         color: Theme.warningColor
                         horizontalAlignment: Text.AlignHCenter
@@ -558,6 +559,7 @@ Dialog {
 
                 // Cancel
                 AccessibleButton {
+                    id: cancelButton
                     Layout.preferredHeight: Theme.scaled(36)
                     text: TranslationManager.translate("brewDialog.cancel", "Cancel")
                     accessibleName: TranslationManager.translate("brewDialog.cancelBrewSettings", "Cancel brew settings")
@@ -570,7 +572,7 @@ Dialog {
                         border.color: Theme.textSecondaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: cancelButton.text
                         font: Theme.bodyFont
                         color: Theme.textColor
                         horizontalAlignment: Text.AlignHCenter
@@ -580,6 +582,7 @@ Dialog {
 
                 // OK (primary)
                 AccessibleButton {
+                    id: okButton
                     Layout.preferredHeight: Theme.scaled(36)
                     text: TranslationManager.translate("brewDialog.ok", "OK")
                     accessibleName: TranslationManager.translate("brewDialog.confirmBrewSettings", "Confirm brew settings")
@@ -610,10 +613,10 @@ Dialog {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(36)
                         radius: Theme.buttonRadius
-                        color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: okButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: okButton.text
                         font: Theme.bodyFont
                         color: Theme.primaryContrastColor
                         horizontalAlignment: Text.AlignHCenter

--- a/qml/components/BrewDialog.qml
+++ b/qml/components/BrewDialog.qml
@@ -613,7 +613,7 @@ Dialog {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(36)
                         radius: Theme.buttonRadius
-                        color: okButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: okButton.down || okButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
                         text: okButton.text

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -1167,6 +1167,7 @@ Rectangle {
                 property real buttonHeight: Theme.scaled(50)
 
                 AccessibleButton {
+                    id: cancelButton
                     width: parent.buttonWidth
                     height: parent.buttonHeight
                     text: TranslationManager.translate("aiReport.cancel", "Cancel")
@@ -1180,7 +1181,7 @@ Rectangle {
                         border.color: Theme.textSecondaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: cancelButton.text
                         font: Theme.bodyFont
                         color: Theme.textColor
                         horizontalAlignment: Text.AlignHCenter
@@ -1189,6 +1190,7 @@ Rectangle {
                 }
 
                 AccessibleButton {
+                    id: openWebButton
                     width: parent.buttonWidth
                     height: parent.buttonHeight
                     enabled: MainController.shotServer && MainController.shotServer.running
@@ -1203,10 +1205,10 @@ Rectangle {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(60)
                         radius: Theme.buttonRadius
-                        color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: openWebButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: openWebButton.text
                         font: Theme.bodyFont
                         color: Theme.primaryContrastColor
                         horizontalAlignment: Text.AlignHCenter

--- a/qml/components/ConversationOverlay.qml
+++ b/qml/components/ConversationOverlay.qml
@@ -1205,7 +1205,7 @@ Rectangle {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(60)
                         radius: Theme.buttonRadius
-                        color: openWebButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: openWebButton.down || openWebButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
                         text: openWebButton.text

--- a/qml/components/CrashReportDialog.qml
+++ b/qml/components/CrashReportDialog.qml
@@ -279,7 +279,7 @@ Dialog {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(60)
                         radius: Theme.buttonRadius
-                        color: sendReportButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: sendReportButton.down || sendReportButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
                         text: sendReportButton.text
@@ -404,7 +404,7 @@ Dialog {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(60)
                         radius: Theme.buttonRadius
-                        color: okButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: okButton.down || okButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
                         text: okButton.text
@@ -528,7 +528,7 @@ Dialog {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(60)
                         radius: Theme.buttonRadius
-                        color: retryButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: retryButton.down || retryButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
                         text: retryButton.text

--- a/qml/components/CrashReportDialog.qml
+++ b/qml/components/CrashReportDialog.qml
@@ -239,6 +239,7 @@ Dialog {
                 property real buttonHeight: Theme.scaled(50)
 
                 AccessibleButton {
+                    id: dismissButton
                     width: parent.buttonWidth
                     height: parent.buttonHeight
                     text: TranslationManager.translate("crashReport.dismiss", "Dismiss")
@@ -255,7 +256,7 @@ Dialog {
                         border.color: Theme.textSecondaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: dismissButton.text
                         font: Theme.bodyFont
                         color: Theme.textColor
                         horizontalAlignment: Text.AlignHCenter
@@ -264,6 +265,7 @@ Dialog {
                 }
 
                 AccessibleButton {
+                    id: sendReportButton
                     width: parent.buttonWidth
                     height: parent.buttonHeight
                     text: TranslationManager.translate("crashReport.sendReport", "Send Report")
@@ -277,10 +279,10 @@ Dialog {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(60)
                         radius: Theme.buttonRadius
-                        color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: sendReportButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: sendReportButton.text
                         font: Theme.bodyFont
                         color: Theme.primaryContrastColor
                         horizontalAlignment: Text.AlignHCenter
@@ -389,6 +391,7 @@ Dialog {
                 Layout.margins: Theme.scaled(20)
 
                 AccessibleButton {
+                    id: okButton
                     anchors.right: parent.right
                     width: Theme.scaled(120)
                     height: parent.height
@@ -401,10 +404,10 @@ Dialog {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(60)
                         radius: Theme.buttonRadius
-                        color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: okButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: okButton.text
                         font: Theme.bodyFont
                         color: Theme.primaryContrastColor
                         horizontalAlignment: Text.AlignHCenter
@@ -485,6 +488,7 @@ Dialog {
                 property real buttonHeight: Theme.scaled(50)
 
                 AccessibleButton {
+                    id: dismissButton2
                     width: parent.buttonWidth
                     height: parent.buttonHeight
                     text: TranslationManager.translate("crashReport.dismiss", "Dismiss")
@@ -501,7 +505,7 @@ Dialog {
                         border.color: Theme.textSecondaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: dismissButton2.text
                         font: Theme.bodyFont
                         color: Theme.textColor
                         horizontalAlignment: Text.AlignHCenter
@@ -510,6 +514,7 @@ Dialog {
                 }
 
                 AccessibleButton {
+                    id: retryButton
                     width: parent.buttonWidth
                     height: parent.buttonHeight
                     text: TranslationManager.translate("crashReport.retry", "Retry")
@@ -523,10 +528,10 @@ Dialog {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(60)
                         radius: Theme.buttonRadius
-                        color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: retryButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: retryButton.text
                         font: Theme.bodyFont
                         color: Theme.primaryContrastColor
                         horizontalAlignment: Text.AlignHCenter

--- a/qml/components/CrtShaderEffect.qml
+++ b/qml/components/CrtShaderEffect.qml
@@ -7,7 +7,10 @@ import Decenza
 
 ShaderEffect {
     // Uniforms: time and resolution
-    property real time: 0
+    // No initialiser: `NumberAnimation on time` below is a value source, and a value source
+    // overrides an initial binding rather than starting from it. The `: 0` was dead. Removed
+    // rather than honoured, so the shader timing is unchanged.
+    property real time
     property real resWidth: width > 0 ? width : 960
     property real resHeight: height > 0 ? height : 600
 

--- a/qml/components/CrtShaderEffect.qml
+++ b/qml/components/CrtShaderEffect.qml
@@ -7,8 +7,10 @@ import Decenza
 
 ShaderEffect {
     // Uniforms: time and resolution
-    // No initialiser: `NumberAnimation on time` below is a value source, and a value source
-    // overrides an initial binding rather than starting from it. The `: 0` was dead. Removed
+    // No initialiser: `NumberAnimation on time` below is a value source WITH AN EXPLICIT `from`,
+    // so it starts there and the initialiser is discarded immediately. (A value source with
+    // no `from` DOES start from the property's current value — qquickanimation.cpp:1324.
+    // The rule is about the explicit `from`, not about value sources in general.) The `: 0` was dead. Removed
     // rather than honoured, so the shader timing is unchanged.
     property real time
     property real resWidth: width > 0 ? width : 960

--- a/qml/components/De1CommunicationErrorDialog.qml
+++ b/qml/components/De1CommunicationErrorDialog.qml
@@ -122,7 +122,7 @@ Dialog {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(50)
                     radius: Theme.buttonRadius
-                    color: okButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                    color: okButton.down || okButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                 }
                 contentItem: Text {
                     text: okButton.text

--- a/qml/components/De1CommunicationErrorDialog.qml
+++ b/qml/components/De1CommunicationErrorDialog.qml
@@ -108,6 +108,7 @@ Dialog {
             Layout.preferredHeight: Theme.scaled(50)
 
             AccessibleButton {
+                id: okButton
                 anchors.right: parent.right
                 width: Theme.scaled(140)
                 height: Theme.scaled(50)
@@ -121,10 +122,10 @@ Dialog {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(50)
                     radius: Theme.buttonRadius
-                    color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                    color: okButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                 }
                 contentItem: Text {
-                    text: parent.text
+                    text: okButton.text
                     font: Theme.bodyFont
                     color: Theme.primaryContrastColor
                     horizontalAlignment: Text.AlignHCenter

--- a/qml/components/McpConfirmDialog.qml
+++ b/qml/components/McpConfirmDialog.qml
@@ -160,7 +160,7 @@ Dialog {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(60)
                     radius: Theme.buttonRadius
-                    color: denyButton.down ? Qt.darker(Theme.errorColor, 1.2) : Theme.errorColor
+                    color: denyButton.down || denyButton.isPressed ? Qt.darker(Theme.errorColor, 1.2) : Theme.errorColor
                 }
                 contentItem: Text {
                     text: denyButton.text
@@ -187,7 +187,7 @@ Dialog {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(60)
                     radius: Theme.buttonRadius
-                    color: allowButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                    color: allowButton.down || allowButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                 }
                 contentItem: Text {
                     text: allowButton.text

--- a/qml/components/McpConfirmDialog.qml
+++ b/qml/components/McpConfirmDialog.qml
@@ -147,6 +147,7 @@ Dialog {
             property real buttonHeight: Theme.scaled(50)
 
             AccessibleButton {
+                id: denyButton
                 width: parent.buttonWidth
                 height: parent.buttonHeight
                 text: TranslationManager.translate("mcp.confirm.deny", "Deny")
@@ -159,10 +160,10 @@ Dialog {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(60)
                     radius: Theme.buttonRadius
-                    color: parent.down ? Qt.darker(Theme.errorColor, 1.2) : Theme.errorColor
+                    color: denyButton.down ? Qt.darker(Theme.errorColor, 1.2) : Theme.errorColor
                 }
                 contentItem: Text {
-                    text: parent.text
+                    text: denyButton.text
                     font: Theme.bodyFont
                     color: Theme.primaryContrastColor
                     horizontalAlignment: Text.AlignHCenter
@@ -172,6 +173,7 @@ Dialog {
             }
 
             AccessibleButton {
+                id: allowButton
                 width: parent.buttonWidth
                 height: parent.buttonHeight
                 text: TranslationManager.translate("mcp.confirm.allow", "Allow")
@@ -185,10 +187,10 @@ Dialog {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(60)
                     radius: Theme.buttonRadius
-                    color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                    color: allowButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                 }
                 contentItem: Text {
-                    text: parent.text
+                    text: allowButton.text
                     font: Theme.bodyFont
                     color: Theme.primaryContrastColor
                     horizontalAlignment: Text.AlignHCenter

--- a/qml/components/ShotMapScreensaver.qml
+++ b/qml/components/ShotMapScreensaver.qml
@@ -415,7 +415,7 @@ Item {
             interval: 1000
             running: showClock && root.visible
             repeat: true
-            // `parent`, not shotMapClock: Timer is a QObject with no parent of its own, so
+            // shotMapClock, not `parent`: Timer is a QObject with no parent of its own, so
             // unqualified `parent` resolved to the FILE root's parent and the clock never
             // ticked. Same defect as ScreensaverPage.qml.
             onTriggered: shotMapClock.currentTime = new Date()

--- a/qml/components/ShotMapScreensaver.qml
+++ b/qml/components/ShotMapScreensaver.qml
@@ -396,10 +396,12 @@ Item {
 
     // Clock display (top center)
     Text {
+        id: shotMapClock
+
         anchors.top: parent.top
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.topMargin: 30
-        text: Qt.formatTime(currentTime, Settings.app.use12HourTime ? "h:mmap" : "HH:mm")
+        text: Qt.formatTime(shotMapClock.currentTime, Settings.app.use12HourTime ? "h:mmap" : "HH:mm")
         color: mapTexture === "bright" ? "#ffffff" : "#aabbcc"
         font.pixelSize: Theme.scaled(48)
         font.bold: true
@@ -413,7 +415,10 @@ Item {
             interval: 1000
             running: showClock && root.visible
             repeat: true
-            onTriggered: parent.currentTime = new Date()
+            // `parent`, not shotMapClock: Timer is a QObject with no parent of its own, so
+            // unqualified `parent` resolved to the FILE root's parent and the clock never
+            // ticked. Same defect as ScreensaverPage.qml.
+            onTriggered: shotMapClock.currentTime = new Date()
         }
     }
 

--- a/qml/components/UnsavedChangesDialog.qml
+++ b/qml/components/UnsavedChangesDialog.qml
@@ -105,7 +105,7 @@ Dialog {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(60)
                     radius: Theme.buttonRadius
-                    color: discardButton.down ? Qt.darker(Theme.errorColor, 1.2) : Theme.errorColor
+                    color: discardButton.down || discardButton.isPressed ? Qt.darker(Theme.errorColor, 1.2) : Theme.errorColor
                 }
                 contentItem: Text {
                     text: discardButton.text
@@ -184,8 +184,8 @@ Dialog {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(60)
                     radius: Theme.buttonRadius
-                    color: parent.enabled
-                        ? (saveButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor)
+                    color: saveButton.enabled
+                        ? (saveButton.down || saveButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor)
                         : Theme.buttonDisabled
                 }
                 contentItem: Text {

--- a/qml/components/UnsavedChangesDialog.qml
+++ b/qml/components/UnsavedChangesDialog.qml
@@ -93,6 +93,7 @@ Dialog {
             property real buttonHeight: Theme.scaled(50)
 
             AccessibleButton {
+                id: discardButton
                 width: parent.buttonWidth
                 height: parent.buttonHeight
                 text: TranslationManager.translate("unsavedChanges.discard", "Discard")
@@ -104,10 +105,10 @@ Dialog {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(60)
                     radius: Theme.buttonRadius
-                    color: parent.down ? Qt.darker(Theme.errorColor, 1.2) : Theme.errorColor
+                    color: discardButton.down ? Qt.darker(Theme.errorColor, 1.2) : Theme.errorColor
                 }
                 contentItem: Text {
-                    text: parent.text
+                    text: discardButton.text
                     font: Theme.bodyFont
                     color: Theme.primaryContrastColor
                     horizontalAlignment: Text.AlignHCenter
@@ -116,6 +117,7 @@ Dialog {
             }
 
             AccessibleButton {
+                id: useUnsavedButton
                 visible: root.showTry
                 width: visible ? parent.buttonWidth : 0
                 height: visible ? parent.buttonHeight : 0
@@ -133,7 +135,7 @@ Dialog {
                     border.color: Theme.successColor
                 }
                 contentItem: Text {
-                    text: parent.text
+                    text: useUnsavedButton.text
                     font: Theme.bodyFont
                     color: Theme.successColor
                     horizontalAlignment: Text.AlignHCenter
@@ -142,6 +144,7 @@ Dialog {
             }
 
             AccessibleButton {
+                id: saveAsButton
                 visible: root.showSaveAs
                 width: visible ? parent.buttonWidth : 0
                 height: visible ? parent.buttonHeight : 0
@@ -159,7 +162,7 @@ Dialog {
                     border.color: Theme.primaryColor
                 }
                 contentItem: Text {
-                    text: parent.text
+                    text: saveAsButton.text
                     font: Theme.bodyFont
                     color: Theme.primaryColor
                     horizontalAlignment: Text.AlignHCenter
@@ -168,6 +171,7 @@ Dialog {
             }
 
             AccessibleButton {
+                id: saveButton
                 width: parent.buttonWidth
                 height: parent.buttonHeight
                 text: TranslationManager.translate("unsavedChanges.save", "Save")
@@ -181,11 +185,11 @@ Dialog {
                     implicitHeight: Theme.scaled(60)
                     radius: Theme.buttonRadius
                     color: parent.enabled
-                        ? (parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor)
+                        ? (saveButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor)
                         : Theme.buttonDisabled
                 }
                 contentItem: Text {
-                    text: parent.text
+                    text: saveButton.text
                     font: Theme.bodyFont
                     color: Theme.primaryContrastColor
                     horizontalAlignment: Text.AlignHCenter

--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -875,7 +875,7 @@ Item {
                                         text: root.displayText || (root.value.toFixed(root.decimals) + root.suffix)
                                         font.pixelSize: root.sc(30)
                                         font.bold: true
-                                        color: parent.parent.getContrastColor(root.valueColor)
+                                        color: parent.scrubberPopup.getContrastColor(root.valueColor)
                                     }
                                 }
 

--- a/qml/components/ValueInput.qml
+++ b/qml/components/ValueInput.qml
@@ -832,6 +832,8 @@ Item {
                         Loader {
                             active: popupDragArea.pressed
                             sourceComponent: Item {
+                                id: dragBubble
+
                                 parent: Overlay.overlay
                                 visible: popupDragArea.pressed
 
@@ -875,7 +877,7 @@ Item {
                                         text: root.displayText || (root.value.toFixed(root.decimals) + root.suffix)
                                         font.pixelSize: root.sc(30)
                                         font.bold: true
-                                        color: parent.scrubberPopup.getContrastColor(root.valueColor)
+                                        color: dragBubble.getContrastColor(root.valueColor)
                                     }
                                 }
 

--- a/qml/components/layout/items/CustomItem.qml
+++ b/qml/components/layout/items/CustomItem.qml
@@ -1,3 +1,8 @@
+// `layer.effect` declares an inline component, so ids from this file are not statically
+// resolvable inside it without this pragma. No Repeater/delegate in this file, so no
+// `required property` is needed — see PresetPillRow.qml for the case that does.
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Effects
@@ -183,7 +188,7 @@ Item {
     Timer {
         id: refreshTimer
         interval: 1000
-        running: content.indexOf("%TIME%") >= 0 || content.indexOf("%DATE%") >= 0
+        running: root.content.indexOf("%TIME%") >= 0 || root.content.indexOf("%DATE%") >= 0
         repeat: true
         onTriggered: root._refreshTick++
     }

--- a/qml/components/layout/items/SteamItem.qml
+++ b/qml/components/layout/items/SteamItem.qml
@@ -194,6 +194,8 @@ Item {
         }
 
         contentItem: Item {
+            id: popupContent
+
             implicitWidth: popupPillRow.implicitWidth
             implicitHeight: popupPillRow.implicitHeight
 
@@ -202,7 +204,7 @@ Item {
             Connections {
                 target: MachineState
                 function onScaleWeightChanged() {
-                    if (presetPopup.visible) popupPillRow.presetPopup.popupSuffixVersion++
+                    if (presetPopup.visible) popupContent.popupSuffixVersion++
                 }
             }
 

--- a/qml/components/layout/items/SteamItem.qml
+++ b/qml/components/layout/items/SteamItem.qml
@@ -202,7 +202,7 @@ Item {
             Connections {
                 target: MachineState
                 function onScaleWeightChanged() {
-                    if (presetPopup.visible) popupPillRow.parent.popupSuffixVersion++
+                    if (presetPopup.visible) popupPillRow.presetPopup.popupSuffixVersion++
                 }
             }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -400,7 +400,7 @@ ApplicationWindow {
     Timer {
         id: sleepCountdownTimer
         interval: 60 * 1000  // 1 minute
-        running: !screensaverActive && !root.operationActive && root.autoSleepMinutes > 0
+        running: !root.screensaverActive && !root.operationActive && root.autoSleepMinutes > 0
         repeat: true
         onTriggered: {
             if (root.sleepCountdownNormal > 0) root.sleepCountdownNormal--
@@ -413,7 +413,7 @@ ApplicationWindow {
                     console.log("[AutoSleep] Inactivity elapsed but inside scheduled stay-awake window — staying awake")
                 } else {
                     console.log("[AutoSleep] Inactivity elapsed, no stay-awake window — triggering sleep")
-                    triggerAutoSleep()
+                    root.triggerAutoSleep()
                 }
             }
         }
@@ -433,7 +433,7 @@ ApplicationWindow {
     Timer {
         id: autoLoadCountdownTimer
         interval: 60 * 1000  // 1 minute
-        running: root.autoLoadIdleCountdown > 0 && !screensaverActive && !root.operationActive
+        running: root.autoLoadIdleCountdown > 0 && !root.screensaverActive && !root.operationActive
         repeat: true
         onTriggered: {
             if (root.autoLoadIdleCountdown <= 0) return
@@ -544,7 +544,7 @@ ApplicationWindow {
     Connections {
         target: MachineState
         function onPhaseChanged() {
-            if (!screensaverActive && root.autoSleepMinutes > 0) {
+            if (!root.screensaverActive && root.autoSleepMinutes > 0) {
                 root.sleepCountdownNormal = root.autoSleepMinutes
                 console.log("[AutoSleep] Reset by phase change: normal=" + root.sleepCountdownNormal)
             }
@@ -630,7 +630,7 @@ ApplicationWindow {
                 // Navigate to SteamPage immediately so user sees heating progress
                 var currentPage = pageStack.currentItem ? pageStack.currentItem.objectName : ""
                 if (currentPage !== "steamPage" && !pageStack.busy) {
-                    saveReturnToPage(currentPage)
+                    root.saveReturnToPage(currentPage)
                     pageStack.replace(null, steamPage)
                 }
             }
@@ -658,7 +658,7 @@ ApplicationWindow {
                 var val = Settings.value("autoSleepMinutes", 60)
                 root.autoSleepMinutes = (val === undefined || val === null) ? 60 : parseInt(val)
                 // Update normal countdown to new value
-                if (!screensaverActive && root.autoSleepMinutes > 0) {
+                if (!root.screensaverActive && root.autoSleepMinutes > 0) {
                     root.sleepCountdownNormal = root.autoSleepMinutes
                 }
             } else if (key === "ui/configurePageScale") {
@@ -840,8 +840,8 @@ ApplicationWindow {
     onHeightChanged: updateScale()
     Connections {
         target: Theme
-        function onScaleMultiplierChanged() { updateScale() }
-        function onPageScaleMultiplierChanged() { updateScale() }
+        function onScaleMultiplierChanged() { root.updateScale() }
+        function onPageScaleMultiplierChanged() { root.updateScale() }
     }
     // Raise all application windows together when this window is activated.
     //
@@ -994,7 +994,7 @@ ApplicationWindow {
         }
 
         onPressed: function(mouse) {
-            var textItem = findTextAt(parent, mouse.x, mouse.y)
+            var textItem = root.findTextAt(parent, mouse.x, mouse.y)
             if (textItem && textItem.text && !isInsideInteractive(textItem)) {
                 AccessibilityManager.announceLabel(AccessibilityManager.cleanForSpeech(textItem.text))
             }
@@ -1090,10 +1090,10 @@ ApplicationWindow {
         target: pageStack
         function onBusyChanged() {
             if (!pageStack.busy) {
-                navigationInProgress = false
+                root.navigationInProgress = false
                 // Retry deferred disconnect navigation (#575)
-                if (pendingDisconnectNavigation) {
-                    pendingDisconnectNavigation = false
+                if (root.pendingDisconnectNavigation) {
+                    root.pendingDisconnectNavigation = false
                     console.log("Retrying deferred disconnect navigation to idle")
                     pageStack.replace(null, idlePage)
                     root.returnToPageName = ""
@@ -1171,7 +1171,7 @@ ApplicationWindow {
             if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
                 if (pageStack.depth > 1) {
                     event.accepted = true
-                    goBack()
+                    root.goBack()
                 }
             }
         }
@@ -1314,8 +1314,8 @@ ApplicationWindow {
     Connections {
         target: pageStack
         function onCurrentItemChanged() {
-            updateCurrentPageScale()
-            announceCurrentPage()
+            root.updateCurrentPageScale()
+            root.announceCurrentPage()
             pageColorTimer.restart()  // Detect colors after page settles
             // Reset the auto-load countdown: clears off-Idle, full value back on Idle
             root.autoLoadResetCountdown()
@@ -1326,7 +1326,7 @@ ApplicationWindow {
     Timer {
         id: pageColorTimer
         interval: 300
-        onTriggered: updatePageColors()
+        onTriggered: root.updatePageColors()
     }
 
     // Announce page name for accessibility when page changes
@@ -1431,7 +1431,7 @@ ApplicationWindow {
         id: initPageScaleTimer
         interval: 100
         onTriggered: {
-            updateCurrentPageScale()
+            root.updateCurrentPageScale()
         }
         Component.onCompleted: start()
     }
@@ -1552,8 +1552,8 @@ ApplicationWindow {
             var msg = isLocation
                 ? "Please enable Location services.\nAndroid requires Location for Bluetooth scanning."
                 : error
-            if (screensaverActive) {
-                queuePopup("bleError", {errorMessage: msg, isLocationError: isLocation, isBluetoothError: isBluetooth})
+            if (root.screensaverActive) {
+                root.queuePopup("bleError", {errorMessage: msg, isLocationError: isLocation, isBluetoothError: isBluetooth})
                 return
             }
             bleErrorDialog.isLocationError = isLocation
@@ -1574,8 +1574,8 @@ ApplicationWindow {
             // never-connected startup shows "No scale detected".
             var popupId = root.scaleDropPending ? "scaleDisconnected" : "flowScale"
             var dialog = root.scaleDropPending ? scaleDisconnectedDialog : flowScaleDialog
-            if (screensaverActive) { queuePopup(popupId); return }
-            if (AppShell.scaleDialogDeferred) { queuePopup(popupId); return }
+            if (root.screensaverActive) { root.queuePopup(popupId); return }
+            if (AppShell.scaleDialogDeferred) { root.queuePopup(popupId); return }
             dialog.open()
         }
         function onScaleDisconnected() {
@@ -1834,8 +1834,8 @@ ApplicationWindow {
         target: BatteryManager
 
         function onChargingMismatchDetected() {
-            if (screensaverActive) {
-                queuePopup("chargingMismatch")
+            if (root.screensaverActive) {
+                root.queuePopup("chargingMismatch")
                 return
             }
             chargingMismatchDialog.open()
@@ -1845,7 +1845,7 @@ ApplicationWindow {
             chargingMismatchDialog.close()
             // Remove any queued instance so it doesn't appear after screensaver wake
             // when the condition has already cleared.
-            pendingPopups = pendingPopups.filter(function(p) { return p.id !== "chargingMismatch" })
+            root.pendingPopups = root.pendingPopups.filter(function(p) { return p.id !== "chargingMismatch" })
         }
     }
 
@@ -1909,7 +1909,7 @@ ApplicationWindow {
         target: MachineState
         function onPhaseChanged() {
             if (MachineState.phase === MachineState.Phase.Refill) {
-                if (screensaverActive) { queuePopup("refill"); return }
+                if (root.screensaverActive) { root.queuePopup("refill"); return }
                 refillDialog.open()
             } else if (refillDialog.opened) {
                 refillDialog.close()
@@ -1991,7 +1991,7 @@ ApplicationWindow {
                             MainController.updateChecker.downloadAndInstall()
                         }
                         updateDialog.close()
-                        goToSettings("about")  // About tab has the update controls
+                        root.goToSettings("about")  // About tab has the update controls
 
                     }
                 }
@@ -2005,7 +2005,7 @@ ApplicationWindow {
         enabled: MainController.updateChecker !== null
 
         function onUpdatePromptRequested() {
-            if (screensaverActive) { queuePopup("update"); return }
+            if (root.screensaverActive) { root.queuePopup("update"); return }
             updateDialog.open()
         }
     }
@@ -2053,7 +2053,7 @@ ApplicationWindow {
 
             Text {
                 anchors.horizontalCenter: parent.horizontalCenter
-                text: completionMessage
+                text: root.completionMessage
                 color: Theme.textSecondaryColor
                 font: Theme.bodyFont
             }
@@ -2061,7 +2061,7 @@ ApplicationWindow {
             Text {
                 anchors.horizontalCenter: parent.horizontalCenter
                 text: {
-                    if (completionType === "hotwater") {
+                    if (root.completionType === "hotwater") {
                         return Math.max(0, MachineState.scaleWeight).toFixed(0) + "g"
                     } else {
                         return MachineState.shotTime.toFixed(1) + "s"
@@ -2092,8 +2092,8 @@ ApplicationWindow {
         id: completionTimer
         interval: 1500  // 1.5s: short enough not to feel slow (reduced from 3s per user feedback)
         onTriggered: {
-            if (_completionSuspendedForDialog) return
-            finishCompletion()
+            if (root._completionSuspendedForDialog) return
+            root.finishCompletion()
         }
     }
 
@@ -2184,8 +2184,8 @@ ApplicationWindow {
         radius: Theme.scaled(22)
         color: Theme.errorColor
 
-        visible: sawBypassedVisible || sawBypassedFadeOut.running
-        opacity: sawBypassedVisible ? 1 : 0
+        visible: root.sawBypassedVisible || sawBypassedFadeOut.running
+        opacity: root.sawBypassedVisible ? 1 : 0
         scale: 1.0
 
         SequentialAnimation {
@@ -2203,7 +2203,7 @@ ApplicationWindow {
         }
 
         Behavior on opacity {
-            enabled: sawBypassedVisible
+            enabled: root.sawBypassedVisible
             NumberAnimation { id: sawBypassedFadeOut; duration: 2000 }
         }
 
@@ -2224,7 +2224,7 @@ ApplicationWindow {
     Timer {
         id: sawBypassedTimer
         interval: 5000
-        onTriggered: sawBypassedVisible = false
+        onTriggered: root.sawBypassedVisible = false
     }
 
     // Espresso stop reason overlay (shown on top of any page)
@@ -2266,8 +2266,8 @@ ApplicationWindow {
         radius: Theme.scaled(22)
         color: Theme.warningColor
 
-        visible: stopOverlayVisible || fadeOutAnim.running
-        opacity: stopOverlayVisible ? 1 : 0
+        visible: root.stopOverlayVisible || fadeOutAnim.running
+        opacity: root.stopOverlayVisible ? 1 : 0
         scale: 1.0
 
         // Pop-in animation (punch effect: 100% → 110% → 100%)
@@ -2295,7 +2295,7 @@ ApplicationWindow {
 
         // Fade-out animation only (pop-in is instant)
         Behavior on opacity {
-            enabled: stopOverlayVisible  // Only animate when hiding
+            enabled: root.stopOverlayVisible  // Only animate when hiding
             NumberAnimation { id: fadeOutAnim; duration: 2000 }
         }
 
@@ -2306,7 +2306,7 @@ ApplicationWindow {
         Text {
             id: stopReasonText
             anchors.centerIn: parent
-            text: getStopReasonText()
+            text: root.getStopReasonText()
             color: "black"
             font: Theme.bodyFont
             Accessible.ignored: true
@@ -2317,28 +2317,28 @@ ApplicationWindow {
         id: stopOverlayTimer
         interval: 3000
         onTriggered: {
-            stopOverlayVisible = false
+            root.stopOverlayVisible = false
             if (root.pendingMetadataNavigation) {
                 root.pendingMetadataNavigation = false
                 // Settings.value() may return string on Windows (REG_SZ), coerce to Number
                 var timeout = Number(Settings.value("postShotReviewTimeout", 31))
                 if (timeout === 0) {
                     console.log("Post-shot review timeout is Instant, skipping review page")
-                    goToIdle()
+                    root.goToIdle()
                     return
                 }
                 if (root.pendingShotId > 0) {
-                    goToShotMetadata(root.pendingShotId)
+                    root.goToShotMetadata(root.pendingShotId)
                 } else {
                     console.warn("Post-shot navigation: no valid pendingShotId, going to idle")
-                    goToIdle()
+                    root.goToIdle()
                 }
             } else {
                 // pendingMetadataNavigation is set by onShotEndedShowMetadata only when
                 // the overlay was still visible at signal time. False here means either
                 // Edit After Shot is OFF, or the shot save arrived after the overlay
                 // expired (SAW settling outlasted 3s) and was handled directly.
-                goToIdle()
+                root.goToIdle()
             }
         }
     }
@@ -2383,7 +2383,7 @@ ApplicationWindow {
             root.stopOverlayVisible = true
             popInAnim.start()
             stopOverlayTimer.start()
-            console.log("Stop overlay:", getStopReasonText())
+            console.log("Stop overlay:", root.getStopReasonText())
 
             // Reset for next operation
             root.wasEspressoOperation = false
@@ -2399,14 +2399,14 @@ ApplicationWindow {
         onDismissed: {
             // Clear the crash log file
             MainController.clearCrashLog()
-            maybeShowLinuxBleCapabilityDialog()
-            maybeShowAutoRelaunchPrompt()
+            root.maybeShowLinuxBleCapabilityDialog()
+            root.maybeShowAutoRelaunchPrompt()
         }
         onReported: {
             // Clear the crash log file after successful report
             MainController.clearCrashLog()
-            maybeShowLinuxBleCapabilityDialog()
-            maybeShowAutoRelaunchPrompt()
+            root.maybeShowLinuxBleCapabilityDialog()
+            root.maybeShowAutoRelaunchPrompt()
         }
     }
 
@@ -2724,8 +2724,8 @@ ApplicationWindow {
                     // layout — never show the upgrade offer to them.
                     Settings.network.recipesUpgradeOffered = true
                     firstRunDialog.close()
-                    checkStorageSetup()
-                    maybeShowLinuxBleCapabilityDialog()
+                    root.checkStorageSetup()
+                    root.maybeShowLinuxBleCapabilityDialog()
                 }
             }
         }
@@ -2789,8 +2789,8 @@ ApplicationWindow {
                     onClicked: {
                         ProfileStorage.skipSetup()
                         storageSetupDialog.close()
-                        startBluetoothScan()
-                        maybeShowAutoRelaunchPrompt()
+                        root.startBluetoothScan()
+                        root.maybeShowAutoRelaunchPrompt()
                     }
                 }
 
@@ -3078,7 +3078,7 @@ ApplicationWindow {
             recipesUpgradeDialog.open()
         }
         function onRecipesUpgradeApplied(recipeName, starterRecipeFailed) {
-            recipesUpgradeToastText = starterRecipeFailed
+            root.recipesUpgradeToastText = starterRecipeFailed
                 ? trRecipesUpgradeToastRecipeFailed.text
                 : (recipeName.length > 0
                     ? trRecipesUpgradeToastWithRecipe.text.arg(recipeName)
@@ -3086,7 +3086,7 @@ ApplicationWindow {
             recipesUpgradeToast.opacity = 1
             recipesUpgradeToastTimer.restart()
             if (AccessibilityManager.enabled) {
-                AccessibilityManager.announce(recipesUpgradeToastText, starterRecipeFailed)
+                AccessibilityManager.announce(root.recipesUpgradeToastText, starterRecipeFailed)
             }
         }
     }
@@ -3131,7 +3131,7 @@ ApplicationWindow {
         Text {
             id: recipesUpgradeToastLabel
             anchors.centerIn: parent
-            text: recipesUpgradeToastText
+            text: root.recipesUpgradeToastText
             color: Theme.textColor
             font.pixelSize: Theme.scaled(13)
             Accessible.ignored: true
@@ -3154,13 +3154,13 @@ ApplicationWindow {
             // A bag with no roaster/coffee text would leave a dangling
             // "moved to " — fall back to a generic phrase.
             var bagName = targetBagName !== "" ? targetBagName : trRecipesRelinkBagFallback.text
-            recipesRelinkToastText = movedRecipeIds.length === 1
+            root.recipesRelinkToastText = movedRecipeIds.length === 1
                 ? trRecipesRelinkOne.text.arg(bagName)
                 : trRecipesRelinkMany.text.arg(movedRecipeIds.length).arg(bagName)
             recipesRelinkToast.opacity = 1
             recipesRelinkToastTimer.restart()
             if (AccessibilityManager.enabled)
-                AccessibilityManager.announce(recipesRelinkToastText)
+                AccessibilityManager.announce(root.recipesRelinkToastText)
         }
     }
     Tr {
@@ -3204,7 +3204,7 @@ ApplicationWindow {
         Text {
             id: recipesRelinkToastLabel
             anchors.centerIn: parent
-            text: recipesRelinkToastText
+            text: root.recipesRelinkToastText
             color: Theme.textColor
             font.pixelSize: Theme.scaled(13)
             Accessible.ignored: true
@@ -3244,8 +3244,8 @@ ApplicationWindow {
         function onFolderSelected(success) {
             if (storageSetupDialog.opened) {
                 storageSetupDialog.close()
-                checkFirstRunRestore()
-                maybeShowAutoRelaunchPrompt()
+                root.checkFirstRunRestore()
+                root.maybeShowAutoRelaunchPrompt()
             }
         }
     }
@@ -3274,7 +3274,7 @@ ApplicationWindow {
             if (shouldOffer) {
                 emptyDatabaseDialog.open();
             } else {
-                startBluetoothScan();
+                root.startBluetoothScan();
             }
         }
     }
@@ -3328,13 +3328,13 @@ ApplicationWindow {
                     if (!pageStack.busy) {
                         pageStack.replace(null, idlePage)
                     } else {
-                        pendingDisconnectNavigation = true
+                        root.pendingDisconnectNavigation = true
                     }
                 }
             } else {
                 // Clear deferred disconnect navigation on reconnect — machine is back,
                 // don't navigate away from whatever page the user is on now.
-                if (pendingDisconnectNavigation) pendingDisconnectNavigation = false
+                if (root.pendingDisconnectNavigation) root.pendingDisconnectNavigation = false
                 if (root.startupGracePeriod &&
                        phase !== MachineState.Phase.Sleep) {
                     root.startupGracePeriod = false
@@ -3382,9 +3382,9 @@ ApplicationWindow {
                 phase === MachineState.Phase.EspressoPreheating ||
                 phase === MachineState.Phase.Preinfusion ||
                 phase === MachineState.Phase.Pouring) {
-                if (completionPending) {
+                if (root.completionPending) {
                     console.log("Cancelling pending completion - new operation started (phase=" + phase + ")")
-                    completionPending = false
+                    root.completionPending = false
                     completionTimer.stop()
                     completionOverlay.opacity = 0
                 }
@@ -3402,9 +3402,9 @@ ApplicationWindow {
                     // If a real physical scale connected during warmup, discard queued scale popups
                     // (FlowScale is always "connected" so don't let it suppress dialogs)
                     if (ScaleDevice.connected && !ScaleDevice.isFlowScale) {
-                        removeQueuedScalePopups()
+                        root.removeQueuedScalePopups()
                     } else if (Settings.primaryScaleAddress !== "") {
-                        showNextPendingPopup()  // Show deferred dialog now
+                        root.showNextPendingPopup()  // Show deferred dialog now
                     }
                 } else if (phase === MachineState.Phase.Sleep) {
                     AppShell.scaleDialogDeferred = false
@@ -3421,17 +3421,17 @@ ApplicationWindow {
                 }
             } else if (phase === MachineState.Phase.Steaming) {
                 if (currentPage !== "steamPage" && !pageStack.busy) {
-                    saveReturnToPage(currentPage)
+                    root.saveReturnToPage(currentPage)
                     pageStack.replace(null, steamPage)
                 }
             } else if (phase === MachineState.Phase.HotWater) {
                 if (currentPage !== "hotWaterPage" && !pageStack.busy) {
-                    saveReturnToPage(currentPage)
+                    root.saveReturnToPage(currentPage)
                     pageStack.replace(null, hotWaterPage)
                 }
             } else if (phase === MachineState.Phase.Flushing) {
                 if (currentPage !== "flushPage" && !pageStack.busy) {
-                    saveReturnToPage(currentPage)
+                    root.saveReturnToPage(currentPage)
                     pageStack.replace(null, flushPage)
                 }
             } else if (phase === MachineState.Phase.Descaling) {
@@ -3449,10 +3449,10 @@ ApplicationWindow {
                 // Machine was put to sleep (e.g. via GHC stop button hold) - show screensaver
                 // Skip if machine has never been awake since connecting (initial connect reports
                 // Sleep before the wake command takes effect)
-                if (!screensaverActive && !root.startupGracePeriod && !root.shuttingDown) {
+                if (!root.screensaverActive && !root.startupGracePeriod && !root.shuttingDown) {
                     console.log("Machine entered Sleep - showing screensaver")
                     // Scale LCD disable is handled by C++ phaseChanged handler in main.cpp
-                    goToScreensaver()
+                    root.goToScreensaver()
                 }
             } else if (phase === MachineState.Phase.Idle || phase === MachineState.Phase.Ready) {
                 // DE1 went to idle - if we're on an operation page, show completion.
@@ -3461,14 +3461,14 @@ ApplicationWindow {
                 console.log("Phase Idle/Ready: currentPage=" + currentPage + " completionOverlay.opacity=" + completionOverlay.opacity)
 
                 if (currentPage === "steamPage") {
-                    showCompletion(trSteamComplete.text, "steam")
+                    root.showCompletion(trSteamComplete.text, "steam")
                 } else if (currentPage === "hotWaterPage") {
-                    showCompletion(trHotWaterComplete.text, "hotwater")
+                    root.showCompletion(trHotWaterComplete.text, "hotwater")
                 } else if (currentPage === "flushPage") {
                     if (AppShell.userExitedFlush) {
                         console.log("Phase Idle/Ready: flush exited by user, skipping completion overlay")
                     } else {
-                        showCompletion(trFlushComplete.text, "flush")
+                        root.showCompletion(trFlushComplete.text, "flush")
                     }
                 } else {
                     console.log("Phase Idle/Ready: NOT on operation page, no completion shown")
@@ -3973,7 +3973,7 @@ ApplicationWindow {
         onPressed: function(mouse) {
             // Reset the inactivity countdown on user touch (the scheduled
             // stay-awake window is independent of activity)
-            if (root.autoSleepMinutes > 0 && !screensaverActive) {
+            if (root.autoSleepMinutes > 0 && !root.screensaverActive) {
                 var prev = root.sleepCountdownNormal
                 root.sleepCountdownNormal = root.autoSleepMinutes
                 if (prev <= 5) console.log("[AutoSleep] Reset by touch: " + prev + " -> " + root.sleepCountdownNormal)
@@ -4076,7 +4076,7 @@ ApplicationWindow {
                 ScaleDevice.disableLcd()
             }
             DE1Device.goToSleep()
-            goToScreensaver()
+            root.goToScreensaver()
         }
     }
 
@@ -4109,11 +4109,14 @@ ApplicationWindow {
                 if (avgDeltaX < -100) {
                     // Two-finger swipe left = go back
                     AccessibilityManager.announce(trAnnounceGoingBack.text)
-                    if (stackView.depth > 1) {
-                        stackView.pop()
-                    } else {
-                        goToIdle()
-                    }
+                    // Was `stackView.depth`/`stackView.pop()` — no such id exists in this file
+                    // (the StackView is `pageStack`), so this threw a ReferenceError and took the
+                    // whole handler with it, else-branch included. The two-finger back gesture has
+                    // never worked, and it only runs with a screen reader active, which is why
+                    // nobody hit it. goBack() is the one owner of back navigation and adds the
+                    // re-entry guard this never had; the old else-branch was unreachable in
+                    // practice anyway, since depth 1 is `initialItem: idlePage`.
+                    root.goBack()
                 }
             }
             startPoints = []
@@ -4166,9 +4169,9 @@ ApplicationWindow {
                 var timeout = Number(Settings.value("postShotReviewTimeout", 31))
                 if (timeout === 0) {
                     console.log("Post-shot review: Instant timeout, going to idle")
-                    goToIdle()
+                    root.goToIdle()
                 } else if (root.pendingShotId > 0) {
-                    goToShotMetadata(root.pendingShotId)
+                    root.goToShotMetadata(root.pendingShotId)
                 } else {
                     console.warn("Post-shot navigation: no valid pendingShotId after overlay expired")
                 }
@@ -4182,8 +4185,8 @@ ApplicationWindow {
 
         function onAutoWakeTriggered() {
             console.log("[Main] Auto-wake triggered")
-            if (screensaverActive) {
-                goToIdleFromScreensaver()
+            if (root.screensaverActive) {
+                root.goToIdleFromScreensaver()
             }
             // No stay-awake arming here: the window is evaluated live from
             // the schedule by AutoWakeManager.isWithinStayAwakeWindow(), so
@@ -4193,18 +4196,18 @@ ApplicationWindow {
 
         function onRemoteSleepRequested() {
             console.log("[Main] Remote sleep requested via MQTT/REST API")
-            if (!screensaverActive) {
-                goToScreensaver()
+            if (!root.screensaverActive) {
+                root.goToScreensaver()
             }
         }
 
         function onFlowCalibrationAutoUpdated(profileTitle, oldValue, newValue) {
-            flowCalToastText = TranslationManager.translate("main.flowCalUpdated",
+            root.flowCalToastText = TranslationManager.translate("main.flowCalUpdated",
                 "Flow cal updated for %1: %2 → %3").arg(profileTitle).arg(oldValue.toFixed(2)).arg(newValue.toFixed(2))
             flowCalToast.opacity = 1
             flowCalToastTimer.restart()
             if (AccessibilityManager.enabled) {
-                AccessibilityManager.announce(flowCalToastText)
+                AccessibilityManager.announce(root.flowCalToastText)
             }
         }
 
@@ -4310,7 +4313,7 @@ ApplicationWindow {
         Text {
             id: flowCalToastLabel
             anchors.centerIn: parent
-            text: flowCalToastText
+            text: root.flowCalToastText
             color: Theme.textColor
             font.pixelSize: Theme.scaled(13)
             Accessible.ignored: true
@@ -4351,7 +4354,7 @@ ApplicationWindow {
         Text {
             id: shotExportToastLabel
             anchors.centerIn: parent
-            text: shotExportToastText
+            text: root.shotExportToastText
             color: Theme.textColor
             font.pixelSize: Theme.scaled(13)
             Accessible.ignored: true
@@ -4378,13 +4381,13 @@ ApplicationWindow {
         function onBagPushRejected(localBagId, bagName, message) {
             // Name the bag: a 422 can arrive from the retry drain long after
             // the edit, when a bare "the bag update" identifies nothing.
-            bagPushToastText = trBagPushRejected.text.arg(bagName).arg(message)
+            root.bagPushToastText = trBagPushRejected.text.arg(bagName).arg(message)
             bagPushToast.opacity = 1
             bagPushToastTimer.restart()
             if (AccessibilityManager.enabled) {
                 // Assertive: this is the only trace that the local and remote
                 // bags have permanently diverged.
-                AccessibilityManager.announce(bagPushToastText, true)
+                AccessibilityManager.announce(root.bagPushToastText, true)
             }
         }
     }
@@ -4411,7 +4414,7 @@ ApplicationWindow {
             id: bagPushToastLabel
             anchors.centerIn: parent
             width: Math.min(implicitWidth, bagPushToast.width - Theme.scaled(32))
-            text: bagPushToastText
+            text: root.bagPushToastText
             color: Theme.textColor
             font.pixelSize: Theme.scaled(13)
             wrapMode: Text.WordWrap
@@ -4589,18 +4592,18 @@ ApplicationWindow {
                 return
             }
             if (failed > 0) {
-                shotExportToastText = TranslationManager.translate(
+                root.shotExportToastText = TranslationManager.translate(
                     "main.toast.exportShotsPartial",
                     "Exported %1 shots; %2 failed").arg(written).arg(failed)
             } else {
-                shotExportToastText = TranslationManager.translate(
+                root.shotExportToastText = TranslationManager.translate(
                     "main.toast.exportShotsDone",
                     "Exported %1 shots").arg(written)
             }
             shotExportToast.opacity = 1
             shotExportToastTimer.restart()
             if (AccessibilityManager.enabled) {
-                AccessibilityManager.announce(shotExportToastText)
+                AccessibilityManager.announce(root.shotExportToastText)
             }
         }
     }
@@ -4723,7 +4726,7 @@ ApplicationWindow {
 
         function onConnectedChanged() {
             if (ScaleDevice.connected && !ScaleDevice.isFlowScale) {
-                removeQueuedScalePopups()
+                root.removeQueuedScalePopups()
             }
         }
     }
@@ -4733,7 +4736,7 @@ ApplicationWindow {
     // Uses scaledBase() to maintain consistent size regardless of current page scale
     Rectangle {
         id: pageScaleOverlay
-        visible: root.appInitialized && Theme.configurePageScaleEnabled && !screensaverActive && Theme.currentPageObjectName !== ""
+        visible: root.appInitialized && Theme.configurePageScaleEnabled && !root.screensaverActive && Theme.currentPageObjectName !== ""
         z: 800  // Above most content, below dialogs
 
 
@@ -4802,7 +4805,7 @@ ApplicationWindow {
     }
     Rectangle {
         id: globalHideKeyboardButton
-        visible: _textInputFocused && (Qt.platform.os === "android" || Qt.platform.os === "ios")
+        visible: root._textInputFocused && (Qt.platform.os === "android" || Qt.platform.os === "ios")
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.rightMargin: Theme.standardMargin
@@ -4891,10 +4894,10 @@ ApplicationWindow {
     Connections {
         target: WidgetLibrary
         function onEntryAdded(entryId) {
-            triggerLibraryThumbnailCapture(entryId)
+            root.triggerLibraryThumbnailCapture(entryId)
         }
         function onRequestThumbnailCapture(entryId) {
-            triggerLibraryThumbnailCapture(entryId)
+            root.triggerLibraryThumbnailCapture(entryId)
         }
     }
 
@@ -4960,7 +4963,7 @@ ApplicationWindow {
                     accessibleName: TranslationManager.translate("main.emptydb.skipAccessible", "Skip restore and start fresh")
                     onClicked: {
                         emptyDatabaseDialog.close();
-                        startBluetoothScan();
+                        root.startBluetoothScan();
                     }
                 }
 
@@ -4970,8 +4973,8 @@ ApplicationWindow {
                     accessibleName: TranslationManager.translate("main.emptydb.restoreAccessible", "Open restore settings")
                     onClicked: {
                         emptyDatabaseDialog.close();
-                        startBluetoothScan();
-                        goToSettings("historyData");  // History & Data tab has restore
+                        root.startBluetoothScan();
+                        root.goToSettings("historyData");  // History & Data tab has restore
                     }
                 }
             }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -4113,10 +4113,18 @@ ApplicationWindow {
                     // (the StackView is `pageStack`), so this threw a ReferenceError and took the
                     // whole handler with it, else-branch included. The two-finger back gesture has
                     // never worked, and it only runs with a screen reader active, which is why
-                    // nobody hit it. goBack() is the one owner of back navigation and adds the
-                    // re-entry guard this never had; the old else-branch was unreachable in
-                    // practice anyway, since depth 1 is `initialItem: idlePage`.
-                    root.goBack()
+                    // nobody hit it.
+                    //
+                    // Both branches are needed. `pageStack.replace(null, X)` CLEARS the stack, and
+                    // that is how every machine-driven page is entered (espresso, steam, hot water,
+                    // flush, descaling, transport) plus the screensaver — so those pages sit at
+                    // depth 1 with a non-idle currentItem, and goBack() alone would do nothing
+                    // there while the announcement above had already said it went back. This is the
+                    // same idiom onDismissRequested uses, for the same reason.
+                    if (pageStack.depth > 1)
+                        root.goBack()
+                    else
+                        root.goToIdle()
                 }
             }
             startPoints = []

--- a/qml/pages/FlushPage.qml
+++ b/qml/pages/FlushPage.qml
@@ -1,9 +1,15 @@
+// Delegates below declare their model roles with `required property`; the ids in this file
+// (livePresetRepeater, flowInput, presetsRow, ...) then resolve statically inside them.
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Decenza
 
 Page {
+    id: flushPage
+
     objectName: "flushPage"
     background: ThemedPageBackground {}
 
@@ -67,7 +73,7 @@ Page {
 
         // === FLUSHING VIEW ===
         ColumnLayout {
-            visible: isFlushing
+            visible: flushPage.isFlushing
             Layout.fillWidth: true
             Layout.fillHeight: true
             spacing: Theme.scaled(20)
@@ -82,6 +88,11 @@ Page {
                     model: Settings.brew.flushPresets
 
                     Rectangle {
+                        id: livePresetDelegate
+
+                        required property var modelData
+                        required property int index
+
                         width: livePresetText.implicitWidth + 24
                         height: Theme.scaled(36)
                         radius: Theme.scaled(18)
@@ -96,17 +107,17 @@ Page {
                         Accessible.focusable: true
                         Accessible.onPressAction: livePresetArea.clicked(null)
 
-                        Keys.onReturnPressed: { livePresetArea.clicked(null); event.accepted = true }
-                        Keys.onSpacePressed:  { livePresetArea.clicked(null); event.accepted = true }
-                        Keys.onLeftPressed: {
+                        Keys.onReturnPressed: function(event) { livePresetArea.clicked(null); event.accepted = true }
+                        Keys.onSpacePressed: function(event) { livePresetArea.clicked(null); event.accepted = true }
+                        Keys.onLeftPressed: function(event) {
                             if (index > 0) livePresetRepeater.itemAt(index - 1).forceActiveFocus()
                             event.accepted = true
                         }
-                        Keys.onRightPressed: {
+                        Keys.onRightPressed: function(event) {
                             if (index < livePresetRepeater.count - 1) livePresetRepeater.itemAt(index + 1).forceActiveFocus()
                             event.accepted = true
                         }
-                        Keys.onTabPressed: {
+                        Keys.onTabPressed: function(event) {
                             if (index < livePresetRepeater.count - 1)
                                 livePresetRepeater.itemAt(index + 1).forceActiveFocus()
                             else if (flushStopButton.visible)
@@ -115,7 +126,7 @@ Page {
                                 livePresetRepeater.itemAt(0).forceActiveFocus()
                             event.accepted = true
                         }
-                        Keys.onBacktabPressed: {
+                        Keys.onBacktabPressed: function(event) {
                             if (index > 0)
                                 livePresetRepeater.itemAt(index - 1).forceActiveFocus()
                             else if (flushStopButton.visible)
@@ -128,8 +139,8 @@ Page {
                         Text {
                             id: livePresetText
                             anchors.centerIn: parent
-                            text: modelData.name
-                            color: index === Settings.brew.selectedFlushPreset ? Theme.primaryContrastColor : Theme.textColor
+                            text: livePresetDelegate.modelData.name
+                            color: livePresetDelegate.index === Settings.brew.selectedFlushPreset ? Theme.primaryContrastColor : Theme.textColor
                             font: Theme.bodyFont
                             Accessible.ignored: true
                         }
@@ -138,9 +149,9 @@ Page {
                             id: livePresetArea
                             anchors.fill: parent
                             onClicked: {
-                                Settings.brew.selectedFlushPreset = index
-                                Settings.brew.flushFlow = modelData.flow
-                                Settings.brew.flushSeconds = modelData.seconds
+                                Settings.brew.selectedFlushPreset = livePresetDelegate.index
+                                Settings.brew.flushFlow = livePresetDelegate.modelData.flow
+                                Settings.brew.flushSeconds = livePresetDelegate.modelData.seconds
                                 MainController.applyFlushSettings()
                             }
                         }
@@ -200,13 +211,13 @@ Page {
                 border.width: Theme.scaled(2)
 
                 activeFocusOnTab: true
-                Keys.onReturnPressed: { AppShell.userExitedFlush = true; DE1Device.stopOperation(); AppShell.idleRequested(); event.accepted = true }
-                Keys.onSpacePressed:  { AppShell.userExitedFlush = true; DE1Device.stopOperation(); AppShell.idleRequested(); event.accepted = true }
-                Keys.onTabPressed: {
+                Keys.onReturnPressed: function(event) { AppShell.userExitedFlush = true; DE1Device.stopOperation(); AppShell.idleRequested(); event.accepted = true }
+                Keys.onSpacePressed: function(event) { AppShell.userExitedFlush = true; DE1Device.stopOperation(); AppShell.idleRequested(); event.accepted = true }
+                Keys.onTabPressed: function(event) {
                     if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(0).forceActiveFocus()
                     event.accepted = true
                 }
-                Keys.onBacktabPressed: {
+                Keys.onBacktabPressed: function(event) {
                     if (livePresetRepeater.count > 0) livePresetRepeater.itemAt(livePresetRepeater.count - 1).forceActiveFocus()
                     event.accepted = true
                 }
@@ -239,7 +250,7 @@ Page {
 
         // === SETTINGS VIEW ===
         ColumnLayout {
-            visible: !isFlushing
+            visible: !flushPage.isFlushing
             Layout.fillWidth: true
             Layout.fillHeight: true
             spacing: Theme.scaled(12)
@@ -276,6 +287,9 @@ Page {
 
                             Item {
                                 id: presetDelegate
+
+                                required property var modelData
+                                required property int index
                                 width: presetPill.width
                                 height: Theme.scaled(36)
 
@@ -294,56 +308,56 @@ Page {
 
                                     activeFocusOnTab: true
                                     Accessible.role: Accessible.Button
-                                    Accessible.name: modelData.name + " " + TranslationManager.translate("flush.accessibility.preset", "preset") +
+                                    Accessible.name: presetDelegate.modelData.name + " " + TranslationManager.translate("flush.accessibility.preset", "preset") +
                                                      (presetDelegate.presetIndex === Settings.brew.selectedFlushPreset ?
                                                       ", " + TranslationManager.translate("accessibility.selected", "selected") : "")
                                     Accessible.description: TranslationManager.translate("flush.accessibility.presetHint", "Double-tap or long-press to rename.")
                                     Accessible.focusable: true
                                     Accessible.onPressAction: {
                                         Settings.brew.selectedFlushPreset = presetDelegate.presetIndex
-                                        flowInput.value = modelData.flow
-                                        secondsInput.value = modelData.seconds
-                                        Settings.brew.flushFlow = modelData.flow
-                                        Settings.brew.flushSeconds = modelData.seconds
+                                        flowInput.value = presetDelegate.modelData.flow
+                                        secondsInput.value = presetDelegate.modelData.seconds
+                                        Settings.brew.flushFlow = presetDelegate.modelData.flow
+                                        Settings.brew.flushSeconds = presetDelegate.modelData.seconds
                                         MainController.applyFlushSettings()
                                     }
 
-                                    Keys.onReturnPressed: {
+                                    Keys.onReturnPressed: function(event) {
                                         Settings.brew.selectedFlushPreset = presetDelegate.presetIndex
-                                        flowInput.value = modelData.flow
-                                        secondsInput.value = modelData.seconds
-                                        Settings.brew.flushFlow = modelData.flow
-                                        Settings.brew.flushSeconds = modelData.seconds
+                                        flowInput.value = presetDelegate.modelData.flow
+                                        secondsInput.value = presetDelegate.modelData.seconds
+                                        Settings.brew.flushFlow = presetDelegate.modelData.flow
+                                        Settings.brew.flushSeconds = presetDelegate.modelData.seconds
                                         MainController.applyFlushSettings()
                                         event.accepted = true
                                     }
-                                    Keys.onSpacePressed: {
+                                    Keys.onSpacePressed: function(event) {
                                         Settings.brew.selectedFlushPreset = presetDelegate.presetIndex
-                                        flowInput.value = modelData.flow
-                                        secondsInput.value = modelData.seconds
-                                        Settings.brew.flushFlow = modelData.flow
-                                        Settings.brew.flushSeconds = modelData.seconds
+                                        flowInput.value = presetDelegate.modelData.flow
+                                        secondsInput.value = presetDelegate.modelData.seconds
+                                        Settings.brew.flushFlow = presetDelegate.modelData.flow
+                                        Settings.brew.flushSeconds = presetDelegate.modelData.seconds
                                         MainController.applyFlushSettings()
                                         event.accepted = true
                                     }
-                                    Keys.onLeftPressed: {
-                                        if (index > 0) presetRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
+                                    Keys.onLeftPressed: function(event) {
+                                        if (presetDelegate.index > 0) presetRepeater.itemAt(presetDelegate.index - 1).focusTarget.forceActiveFocus()
                                         event.accepted = true
                                     }
-                                    Keys.onRightPressed: {
-                                        if (index < presetRepeater.count - 1) presetRepeater.itemAt(index + 1).focusTarget.forceActiveFocus()
+                                    Keys.onRightPressed: function(event) {
+                                        if (presetDelegate.index < presetRepeater.count - 1) presetRepeater.itemAt(presetDelegate.index + 1).focusTarget.forceActiveFocus()
                                         event.accepted = true
                                     }
-                                    Keys.onTabPressed: {
-                                        if (index < presetRepeater.count - 1)
-                                            presetRepeater.itemAt(index + 1).focusTarget.forceActiveFocus()
+                                    Keys.onTabPressed: function(event) {
+                                        if (presetDelegate.index < presetRepeater.count - 1)
+                                            presetRepeater.itemAt(presetDelegate.index + 1).focusTarget.forceActiveFocus()
                                         else
                                             addPresetButton.forceActiveFocus()
                                         event.accepted = true
                                     }
-                                    Keys.onBacktabPressed: {
-                                        if (index > 0)
-                                            presetRepeater.itemAt(index - 1).focusTarget.forceActiveFocus()
+                                    Keys.onBacktabPressed: function(event) {
+                                        if (presetDelegate.index > 0)
+                                            presetRepeater.itemAt(presetDelegate.index - 1).focusTarget.forceActiveFocus()
                                         else
                                             flowInput.forceActiveFocus()
                                         event.accepted = true
@@ -363,7 +377,7 @@ Page {
                                     Text {
                                         id: presetText
                                         anchors.centerIn: parent
-                                        text: modelData.name
+                                        text: presetDelegate.modelData.name
                                         color: presetDelegate.presetIndex === Settings.brew.selectedFlushPreset ? Theme.primaryContrastColor : Theme.textColor
                                         font: Theme.bodyFont
                                         Accessible.ignored: true
@@ -389,10 +403,10 @@ Page {
                                             if (!moved && !held) {
                                                 // Simple click - select the preset
                                                 Settings.brew.selectedFlushPreset = presetDelegate.presetIndex
-                                                flowInput.value = modelData.flow
-                                                secondsInput.value = modelData.seconds
-                                                Settings.brew.flushFlow = modelData.flow
-                                                Settings.brew.flushSeconds = modelData.seconds
+                                                flowInput.value = presetDelegate.modelData.flow
+                                                secondsInput.value = presetDelegate.modelData.seconds
+                                                Settings.brew.flushFlow = presetDelegate.modelData.flow
+                                                Settings.brew.flushSeconds = presetDelegate.modelData.seconds
                                                 MainController.applyFlushSettings()
                                             }
                                             presetPill.Drag.drop()
@@ -409,8 +423,8 @@ Page {
                                         onDoubleClicked: {
                                             holdTimer.stop()
                                             held = true  // Prevent single-click selection on release
-                                            editingPresetIndex = presetDelegate.presetIndex
-                                            editPresetNameInput.text = modelData.name
+                                            flushPage.editingPresetIndex = presetDelegate.presetIndex
+                                            editPresetNameInput.text = presetDelegate.modelData.name
                                             editPresetPopup.open()
                                         }
 
@@ -420,8 +434,8 @@ Page {
                                             onTriggered: {
                                                 if (!dragArea.moved) {
                                                     dragArea.held = true
-                                                    editingPresetIndex = presetDelegate.presetIndex
-                                                    editPresetNameInput.text = modelData.name
+                                                    flushPage.editingPresetIndex = presetDelegate.presetIndex
+                                                    editPresetNameInput.text = presetDelegate.modelData.name
                                                     editPresetPopup.open()
                                                 }
                                             }
@@ -457,8 +471,8 @@ Page {
                             KeyNavigation.backtab: presetRepeater.count > 0
                                 ? presetRepeater.itemAt(presetRepeater.count - 1).focusTarget
                                 : secondsInput
-                            Keys.onReturnPressed: { addPresetDialog.open(); event.accepted = true }
-                            Keys.onSpacePressed:  { addPresetDialog.open(); event.accepted = true }
+                            Keys.onReturnPressed: function(event) { addPresetDialog.open(); event.accepted = true }
+                            Keys.onSpacePressed: function(event) { addPresetDialog.open(); event.accepted = true }
 
                             Text {
                                 anchors.centerIn: parent
@@ -518,7 +532,7 @@ Page {
                         ValueInput {
                             id: secondsInput
                             Layout.preferredWidth: Theme.scaled(180)
-                            value: getCurrentPresetSeconds()
+                            value: flushPage.getCurrentPresetSeconds()
                             from: 1
                             to: 45
                             stepSize: 0.5
@@ -534,7 +548,7 @@ Page {
                             onValueModified: function(newValue) {
                                 secondsInput.value = newValue
                                 Settings.brew.flushSeconds = newValue
-                                saveCurrentPreset(flowInput.value, newValue)
+                                flushPage.saveCurrentPreset(flowInput.value, newValue)
                             }
                             onValueCommitted: MainController.applyFlushSettings()
                         }
@@ -559,7 +573,7 @@ Page {
                         ValueInput {
                             id: flowInput
                             Layout.preferredWidth: Theme.scaled(180)
-                            value: getCurrentPresetFlow()
+                            value: flushPage.getCurrentPresetFlow()
                             from: 2
                             to: 10
                             stepSize: 0.5
@@ -576,7 +590,7 @@ Page {
                             onValueModified: function(newValue) {
                                 flowInput.value = newValue
                                 Settings.brew.flushFlow = newValue
-                                saveCurrentPreset(newValue, secondsInput.value)
+                                flushPage.saveCurrentPreset(newValue, secondsInput.value)
                             }
                             onValueCommitted: MainController.applyFlushSettings()
                         }
@@ -591,9 +605,9 @@ Page {
     // Always visible: back stays reachable during active flush. Chips collapse
     // during flush (live timer above shows state); back stops + suppresses overlay.
     BottomBar {
-        title: getCurrentPresetName() || pageTitle
+        title: flushPage.getCurrentPresetName() || flushPage.pageTitle
         onBackClicked: {
-            if (isFlushing) {
+            if (flushPage.isFlushing) {
                 AppShell.userExitedFlush = true
                 DE1Device.stopOperation()
             } else {
@@ -604,18 +618,18 @@ Page {
         }
 
         Text {
-            visible: !isFlushing
+            visible: !flushPage.isFlushing
             text: secondsInput.value.toFixed(1) + "s"
             color: Theme.primaryContrastColor
             font: Theme.bodyFont
             Accessible.ignored: true
         }
         Rectangle {
-            visible: !isFlushing
+            visible: !flushPage.isFlushing
             width: 1; height: Theme.scaled(30); color: Theme.primaryContrastColor; opacity: 0.3
         }
         Text {
-            visible: !isFlushing
+            visible: !flushPage.isFlushing
             text: flowInput.value.toFixed(1) + " mL/s"
             color: Theme.primaryContrastColor
             font: Theme.bodyFont
@@ -715,7 +729,7 @@ Page {
                     KeyNavigation.tab: cancelEditButton
                     KeyNavigation.backtab: editPresetNameInput
                     onClicked: {
-                        Settings.brew.removeFlushPreset(editingPresetIndex)
+                        Settings.brew.removeFlushPreset(flushPage.editingPresetIndex)
                         editPresetPopup.close()
                     }
                 }
@@ -740,8 +754,8 @@ Page {
                     KeyNavigation.backtab: cancelEditButton
                     onClicked: {
                         Keyboard.commit()
-                        var preset = Settings.brew.getFlushPreset(editingPresetIndex)
-                        Settings.brew.updateFlushPreset(editingPresetIndex, editPresetNameInput.text, preset.flow, preset.seconds)
+                        var preset = Settings.brew.getFlushPreset(flushPage.editingPresetIndex)
+                        Settings.brew.updateFlushPreset(flushPage.editingPresetIndex, editPresetNameInput.text, preset.flow, preset.seconds)
                         editPresetPopup.close()
                     }
                 }

--- a/qml/pages/IdlePage.qml
+++ b/qml/pages/IdlePage.qml
@@ -1,3 +1,8 @@
+// Loader/sourceComponent blocks below are nested components, so `idlePage` and the other ids
+// in this file are not statically resolvable inside them without this pragma. There is no
+// Repeater or delegate in this file, so no `required property` is needed.
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -826,9 +831,9 @@ Page {
     MouseArea {
         anchors.fill: parent
         z: -1
-        enabled: activePresetFunction !== "" &&
+        enabled: idlePage.activePresetFunction !== "" &&
                  !(typeof AccessibilityManager !== "undefined" && AccessibilityManager !== null && AccessibilityManager.enabled)
-        onClicked: activePresetFunction = ""
+        onClicked: idlePage.activePresetFunction = ""
     }
 
     // ============================================================
@@ -884,7 +889,14 @@ Page {
         // down for an upper-half one (restores to 0 on close).
         transform: Translate {
             y: -idlePage.bottomPanelClearance + idlePage.topPanelClearance
+            // qmllint disable Quick.layout-positioning
+            // False positive, verified: this `y` belongs to the Translate transform, not to the
+            // layout-managed item. A transform is precisely how you offset an item inside a layout
+            // WITHOUT fighting the layout — the alternative qmllint suggests (Layout.topMargin)
+            // would make the layout re-measure on every animation frame. The linter attributes the
+            // `y` to the enclosing item and cannot see the transform boundary.
             Behavior on y { NumberAnimation { duration: 200; easing.type: Easing.OutQuad } }
+            // qmllint enable Quick.layout-positioning
         }
 
         // Status readouts (temp, water level, connection)
@@ -914,7 +926,7 @@ Page {
         // Inline preset rows (for center-zone action buttons)
         Item {
             Layout.alignment: Qt.AlignHCenter
-            Layout.preferredHeight: activePresetFunction !== "" ? activePresetRow.implicitHeight : 0
+            Layout.preferredHeight: idlePage.activePresetFunction !== "" ? activePresetRow.implicitHeight : 0
             Layout.fillWidth: true
             Layout.maximumWidth: Theme.scaled(900)
             Layout.leftMargin: Theme.standardMargin
@@ -922,7 +934,7 @@ Page {
             clip: true
 
             property var activePresetRow: {
-                switch (activePresetFunction) {
+                switch (idlePage.activePresetFunction) {
                     case "steam": return steamPresetLoader
                     case "espresso": return espressoColumnLoader
                     case "hotwater": return hotWaterPresetLoader
@@ -942,7 +954,7 @@ Page {
                 id: steamPresetLoader
                 width: parent.width
                 anchors.horizontalCenter: parent.horizontalCenter
-                active: activePresetFunction === "steam"
+                active: idlePage.activePresetFunction === "steam"
                 visible: active
 
                 // Track scale weight changes and bump version to refresh the live
@@ -1079,7 +1091,7 @@ Page {
                 id: espressoColumnLoader
                 width: parent.width
                 anchors.horizontalCenter: parent.horizontalCenter
-                active: activePresetFunction === "espresso"
+                active: idlePage.activePresetFunction === "espresso"
                 visible: active
                 sourceComponent: Column {
                     width: parent ? parent.width : 0
@@ -1164,8 +1176,8 @@ Page {
                             Accessible.name: (ProfileManager.currentProfileName || "") + " " + TranslationManager.translate("idle.accessible.startespresso", "Start espresso")
                             Accessible.focusable: true
                             Accessible.onPressAction: idleNonFavMouseArea.clicked(null)
-                            Keys.onReturnPressed: { idleNonFavMouseArea.clicked(null); event.accepted = true }
-                            Keys.onSpacePressed:  { idleNonFavMouseArea.clicked(null); event.accepted = true }
+                            Keys.onReturnPressed: function(event) { idleNonFavMouseArea.clicked(null); event.accepted = true }
+                            Keys.onSpacePressed: function(event) { idleNonFavMouseArea.clicked(null); event.accepted = true }
 
                             Text {
                                 id: nonFavoriteProfileText
@@ -1256,7 +1268,7 @@ Page {
                 id: hotWaterPresetLoader
                 width: parent.width
                 anchors.horizontalCenter: parent.horizontalCenter
-                active: activePresetFunction === "hotwater"
+                active: idlePage.activePresetFunction === "hotwater"
                 visible: active
                 sourceComponent: PresetPillRow {
                     maxWidth: hotWaterPresetLoader.width
@@ -1303,7 +1315,7 @@ Page {
                 id: flushPresetLoader
                 width: parent.width
                 anchors.horizontalCenter: parent.horizontalCenter
-                active: activePresetFunction === "flush"
+                active: idlePage.activePresetFunction === "flush"
                 visible: active
                 sourceComponent: PresetPillRow {
                     maxWidth: flushPresetLoader.width
@@ -1351,7 +1363,7 @@ Page {
                 id: beanPresetLoader
                 width: parent.width
                 anchors.horizontalCenter: parent.horizontalCenter
-                active: activePresetFunction === "beans"
+                active: idlePage.activePresetFunction === "beans"
                 visible: active
                 sourceComponent: PresetPillRow {
                     id: inlineBeanPresetRow
@@ -1385,7 +1397,7 @@ Page {
                 id: equipmentPresetLoader
                 width: parent.width
                 anchors.horizontalCenter: parent.horizontalCenter
-                active: activePresetFunction === "equipment"
+                active: idlePage.activePresetFunction === "equipment"
                 visible: active
                 sourceComponent: PresetPillRow {
                     maxWidth: equipmentPresetLoader.width
@@ -1418,7 +1430,7 @@ Page {
                 id: recipePresetLoader
                 width: parent.width
                 anchors.horizontalCenter: parent.horizontalCenter
-                active: activePresetFunction === "recipes"
+                active: idlePage.activePresetFunction === "recipes"
                 visible: active
                 sourceComponent: PresetPillRow {
                     maxWidth: recipePresetLoader.width

--- a/qml/pages/ProfileEditorPage.qml
+++ b/qml/pages/ProfileEditorPage.qml
@@ -360,7 +360,7 @@ Page {
                             accessibleName: TranslationManager.translate("profileEditor.openProfileSettings", "Open profile settings")
                             onClicked: profileSettingsPopup.open()
                             background: Rectangle {
-                                color: openProfileSettingsButton.down ? Qt.darker(Theme.surfaceColor, 1.2) : Qt.rgba(1, 1, 1, 0.05)
+                                color: openProfileSettingsButton.down || openProfileSettingsButton.isPressed ? Qt.darker(Theme.surfaceColor, 1.2) : Qt.rgba(1, 1, 1, 0.05)
                                 radius: Theme.scaled(8)
                                 border.width: 1
                                 border.color: Theme.textSecondaryColor
@@ -389,7 +389,7 @@ Page {
                             accessibleName: TranslationManager.translate("profileEditor.openLimits", "Open limits settings")
                             onClicked: limitsPopup.open()
                             background: Rectangle {
-                                color: openLimitsButton.down ? Qt.darker(Theme.surfaceColor, 1.2) : Qt.rgba(1, 1, 1, 0.05)
+                                color: openLimitsButton.down || openLimitsButton.isPressed ? Qt.darker(Theme.surfaceColor, 1.2) : Qt.rgba(1, 1, 1, 0.05)
                                 radius: Theme.scaled(8)
                                 border.width: 1
                                 border.color: Theme.textSecondaryColor
@@ -555,7 +555,7 @@ Page {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(44)
                     radius: Theme.buttonRadius
-                    color: doneButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                    color: doneButton.down || doneButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                 }
                 contentItem: Text {
                     text: doneButton.text
@@ -804,7 +804,7 @@ Page {
                 implicitWidth: Math.max(Theme.scaled(80), doneText.implicitWidth + Theme.scaled(32))
                 implicitHeight: Theme.scaled(36)
                 radius: Theme.scaled(6)
-                color: doneButton2.down ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
+                color: doneButton2.down || doneButton2.isPressed ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
             }
             contentItem: Text {
                 id: doneText

--- a/qml/pages/ProfileEditorPage.qml
+++ b/qml/pages/ProfileEditorPage.qml
@@ -349,6 +349,7 @@ Page {
                         spacing: Theme.scaled(6)
 
                         AccessibleButton {
+                            id: openProfileSettingsButton
                             Layout.fillWidth: true
                             text: {
                                 profileEditorPage.stepVersion
@@ -359,13 +360,13 @@ Page {
                             accessibleName: TranslationManager.translate("profileEditor.openProfileSettings", "Open profile settings")
                             onClicked: profileSettingsPopup.open()
                             background: Rectangle {
-                                color: parent.down ? Qt.darker(Theme.surfaceColor, 1.2) : Qt.rgba(1, 1, 1, 0.05)
+                                color: openProfileSettingsButton.down ? Qt.darker(Theme.surfaceColor, 1.2) : Qt.rgba(1, 1, 1, 0.05)
                                 radius: Theme.scaled(8)
                                 border.width: 1
                                 border.color: Theme.textSecondaryColor
                             }
                             contentItem: Text {
-                                text: parent.text
+                                text: openProfileSettingsButton.text
                                 font: Theme.captionFont
                                 color: Theme.textColor
                                 horizontalAlignment: Text.AlignHCenter
@@ -374,6 +375,7 @@ Page {
                         }
 
                         AccessibleButton {
+                            id: openLimitsButton
                             Layout.fillWidth: true
                             text: {
                                 profileEditorPage.stepVersion
@@ -387,13 +389,13 @@ Page {
                             accessibleName: TranslationManager.translate("profileEditor.openLimits", "Open limits settings")
                             onClicked: limitsPopup.open()
                             background: Rectangle {
-                                color: parent.down ? Qt.darker(Theme.surfaceColor, 1.2) : Qt.rgba(1, 1, 1, 0.05)
+                                color: openLimitsButton.down ? Qt.darker(Theme.surfaceColor, 1.2) : Qt.rgba(1, 1, 1, 0.05)
                                 radius: Theme.scaled(8)
                                 border.width: 1
                                 border.color: Theme.textSecondaryColor
                             }
                             contentItem: Text {
-                                text: parent.text
+                                text: openLimitsButton.text
                                 font: Theme.captionFont
                                 color: Theme.textColor
                                 horizontalAlignment: Text.AlignHCenter
@@ -544,6 +546,7 @@ Page {
 
             // Close button
             AccessibleButton {
+                id: doneButton
                 Layout.fillWidth: true
                 Layout.topMargin: Theme.scaled(6)
                 text: TranslationManager.translate("profileEditor.done", "Done")
@@ -552,10 +555,10 @@ Page {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(44)
                     radius: Theme.buttonRadius
-                    color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                    color: doneButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                 }
                 contentItem: Text {
-                    text: parent.text
+                    text: doneButton.text
                     font: Theme.bodyFont
                     color: Theme.primaryContrastColor
                     horizontalAlignment: Text.AlignHCenter
@@ -785,6 +788,7 @@ Page {
             font: Theme.bodyFont
         }
         AccessibleButton {
+            id: doneButton2
             text: TranslationManager.translate("profileEditor.doneButton", "Done")
             accessibleName: TranslationManager.translate("profileEditor.finishEditing", "Finish editing profile")
             onClicked: {
@@ -800,11 +804,11 @@ Page {
                 implicitWidth: Math.max(Theme.scaled(80), doneText.implicitWidth + Theme.scaled(32))
                 implicitHeight: Theme.scaled(36)
                 radius: Theme.scaled(6)
-                color: parent.down ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
+                color: doneButton2.down ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
             }
             contentItem: Text {
                 id: doneText
-                text: parent.text
+                text: doneButton2.text
                 font.pixelSize: Theme.scaled(14)
                 font.family: Theme.bodyFont.family
                 color: Theme.primaryColor

--- a/qml/pages/ProfileImportPage.qml
+++ b/qml/pages/ProfileImportPage.qml
@@ -167,6 +167,7 @@ Page {
 
         // Progress bar (during scanning/importing, non-iOS only)
         ProgressBar {
+            id: progressBar
             Layout.fillWidth: true
             Layout.preferredHeight: Theme.scaled(4)
             visible: !profileImportPage.isIOS && (MainController.profileImporter.isScanning || MainController.profileImporter.isImporting)
@@ -179,7 +180,7 @@ Page {
                 radius: 2
             }
             contentItem: Rectangle {
-                width: parent.visualPosition * parent.width
+                width: progressBar.visualPosition * parent.width
                 height: parent.height
                 radius: 2
                 color: Theme.primaryColor

--- a/qml/pages/ProfileImportPage.qml
+++ b/qml/pages/ProfileImportPage.qml
@@ -16,7 +16,7 @@ Page {
         TranslationManager.translate("profileimport.title", "Import from Tablet")
 
     function rescan() {
-        if (customScanPath != "")
+        if (customScanPath !== "")
             MainController.profileImporter.scanProfilesFromUrl(customScanPath)
         else
             MainController.profileImporter.scanProfiles()

--- a/qml/pages/ProfileImportPage.qml
+++ b/qml/pages/ProfileImportPage.qml
@@ -16,7 +16,11 @@ Page {
         TranslationManager.translate("profileimport.title", "Import from Tablet")
 
     function rescan() {
-        if (customScanPath !== "")
+        // .toString(), not a bare compare: `customScanPath` is a `property url`, and QML exposes
+        // a url to JS as a UrlObject whose default virtualIsEqualTo returns false unconditionally
+        // (qv4managed.cpp). `!==` never coerces, so it was ALWAYS true and rescan() stopped
+        // falling back to auto-detect. `!=` coerced via ToPrimitive, which is why it worked.
+        if (customScanPath.toString() !== "")
             MainController.profileImporter.scanProfilesFromUrl(customScanPath)
         else
             MainController.profileImporter.scanProfiles()

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -270,7 +270,6 @@ Page {
                     }
 
                     AccessibleButton {
-                        id: createNewProfileButton
                         visible: viewFilter.currentIndex !== 1 && viewFilter.currentIndex !== 5
                         text: "+"
                         accessibleName: TranslationManager.translate("profileSelector.createNewProfile", "Create new profile")
@@ -771,13 +770,13 @@ Page {
                             icon.source: "qrc:/icons/edit.svg"
                             icon.width: Theme.scaled(18)
                             icon.height: Theme.scaled(18)
-                            icon.color: createNewProfileButton.selected ? Theme.primaryContrastColor : Theme.textColor
-                            accessibleName: createNewProfileButton.row ? (TranslationManager.translate("profileselector.accessible.edit", "Edit") + " " + AccessibilityManager.cleanForSpeech(createNewProfileButton.row.name)) : ""
+                            icon.color: parent.selected ? Theme.primaryContrastColor : Theme.textColor
+                            accessibleName: parent.row ? (TranslationManager.translate("profileselector.accessible.edit", "Edit") + " " + AccessibilityManager.cleanForSpeech(parent.row.name)) : ""
 
                             onClicked: {
-                                if (!createNewProfileButton.row) return
-                                Settings.app.selectedFavoriteProfile = createNewProfileButton.rowIndex
-                                ProfileManager.loadProfile(createNewProfileButton.row.filename)
+                                if (!parent.row) return
+                                Settings.app.selectedFavoriteProfile = parent.rowIndex
+                                ProfileManager.loadProfile(parent.row.filename)
                                 AppShell.profileEditorRequested()
                             }
                         }

--- a/qml/pages/ProfileSelectorPage.qml
+++ b/qml/pages/ProfileSelectorPage.qml
@@ -270,6 +270,7 @@ Page {
                     }
 
                     AccessibleButton {
+                        id: createNewProfileButton
                         visible: viewFilter.currentIndex !== 1 && viewFilter.currentIndex !== 5
                         text: "+"
                         accessibleName: TranslationManager.translate("profileSelector.createNewProfile", "Create new profile")
@@ -770,13 +771,13 @@ Page {
                             icon.source: "qrc:/icons/edit.svg"
                             icon.width: Theme.scaled(18)
                             icon.height: Theme.scaled(18)
-                            icon.color: parent.selected ? Theme.primaryContrastColor : Theme.textColor
-                            accessibleName: parent.row ? (TranslationManager.translate("profileselector.accessible.edit", "Edit") + " " + AccessibilityManager.cleanForSpeech(parent.row.name)) : ""
+                            icon.color: createNewProfileButton.selected ? Theme.primaryContrastColor : Theme.textColor
+                            accessibleName: createNewProfileButton.row ? (TranslationManager.translate("profileselector.accessible.edit", "Edit") + " " + AccessibilityManager.cleanForSpeech(createNewProfileButton.row.name)) : ""
 
                             onClicked: {
-                                if (!parent.row) return
-                                Settings.app.selectedFavoriteProfile = parent.rowIndex
-                                ProfileManager.loadProfile(parent.row.filename)
+                                if (!createNewProfileButton.row) return
+                                Settings.app.selectedFavoriteProfile = createNewProfileButton.rowIndex
+                                ProfileManager.loadProfile(createNewProfileButton.row.filename)
                                 AppShell.profileEditorRequested()
                             }
                         }

--- a/qml/pages/RecipeEditorPage.qml
+++ b/qml/pages/RecipeEditorPage.qml
@@ -602,6 +602,7 @@ Page {
         }
 
         AccessibleButton {
+            id: doneButton
             text: TranslationManager.translate("recipeEditor.done", "Done")
             accessibleName: TranslationManager.translate("recipeEditor.finishEditing", "Finish editing recipe")
             onClicked: {
@@ -617,11 +618,11 @@ Page {
                 implicitWidth: Math.max(Theme.scaled(80), recipeDoneText.implicitWidth + Theme.scaled(32))
                 implicitHeight: Theme.scaled(36)
                 radius: Theme.scaled(6)
-                color: parent.down ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
+                color: doneButton.down ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
             }
             contentItem: Text {
                 id: recipeDoneText
-                text: parent.text
+                text: doneButton.text
                 font.pixelSize: Theme.scaled(14)
                 font.family: Theme.bodyFont.family
                 color: Theme.primaryColor

--- a/qml/pages/RecipeEditorPage.qml
+++ b/qml/pages/RecipeEditorPage.qml
@@ -618,7 +618,7 @@ Page {
                 implicitWidth: Math.max(Theme.scaled(80), recipeDoneText.implicitWidth + Theme.scaled(32))
                 implicitHeight: Theme.scaled(36)
                 radius: Theme.scaled(6)
-                color: doneButton.down ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
+                color: doneButton.down || doneButton.isPressed ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
             }
             contentItem: Text {
                 id: recipeDoneText

--- a/qml/pages/ScreensaverPage.qml
+++ b/qml/pages/ScreensaverPage.qml
@@ -647,7 +647,7 @@ Page {
             interval: 1000
             running: clockDisplay.visible
             repeat: true
-            // `parent`, not clockDisplay: Timer is a QObject, not an Item, so it has no parent
+            // clockDisplay, not `parent`: Timer is a QObject, not an Item, so it has no parent
             // of its own. Unqualified `parent` walked past it to the document scope and resolved
             // to screensaverPage.parent — the StackView content item — so the write landed on an
             // object with no currentTime and the clock never ticked. qmllint does not flag this:

--- a/qml/pages/ScreensaverPage.qml
+++ b/qml/pages/ScreensaverPage.qml
@@ -644,7 +644,12 @@ Page {
             interval: 1000
             running: clockDisplay.visible
             repeat: true
-            onTriggered: parent.currentTime = new Date()
+            // `parent`, not clockDisplay: Timer is a QObject, not an Item, so it has no parent
+            // of its own. Unqualified `parent` walked past it to the document scope and resolved
+            // to screensaverPage.parent — the StackView content item — so the write landed on an
+            // object with no currentTime and the clock never ticked. qmllint does not flag this:
+            // `parent` is a known identifier, not an unqualified one.
+            onTriggered: clockDisplay.currentTime = new Date()
         }
     }
 

--- a/qml/pages/ScreensaverPage.qml
+++ b/qml/pages/ScreensaverPage.qml
@@ -549,8 +549,11 @@ Page {
         Rectangle {
             id: gradientRect
             anchors.fill: parent
-            // No initialiser: `NumberAnimation on gradientHue` below is a value source, and a value
-            // source overrides an initial binding rather than starting from it. The `: 0.6` that
+            // No initialiser: `NumberAnimation on gradientHue` below is a value source WITH AN EXPLICIT
+            // `from: 0`, so it starts there and the initialiser is discarded immediately.
+            // (A value source with no `from` DOES start from the property's current value —
+            // qquickanimation.cpp:1324. The rule is about the explicit `from`, not about
+            // value sources in general.) The `: 0.6` that
             // used to be here was dead — the gradient has always started at 0, not at 0.6. Removed
             // rather than honoured, so the rendering is unchanged; set the animation's `from` if a
             // different start hue is ever wanted.

--- a/qml/pages/ScreensaverPage.qml
+++ b/qml/pages/ScreensaverPage.qml
@@ -1,3 +1,8 @@
+// The video/image Loader sourceComponents below are nested components, so `screensaverPage`
+// and the other ids in this file are not statically resolvable inside them without this
+// pragma. No Repeater or delegate in this file, so no `required property` is needed.
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtMultimedia
@@ -123,35 +128,35 @@ Page {
         target: ScreensaverManager
         function onVideoReady(path) {
             // Media just finished downloading - try to play if we're showing fallback
-            if (!mediaPlaying) {
+            if (!screensaverPage.mediaPlaying) {
                 console.log("[Screensaver] New media ready, starting playback")
-                playNextMedia()
+                screensaverPage.playNextMedia()
             }
         }
         function onCatalogUpdated() {
             // Catalog loaded - try to play if we're showing fallback
-            if (!mediaPlaying && ScreensaverManager.itemCount > 0) {
+            if (!screensaverPage.mediaPlaying && ScreensaverManager.itemCount > 0) {
                 console.log("[Screensaver] Catalog updated, trying playback")
-                playNextMedia()
+                screensaverPage.playNextMedia()
             }
         }
         function onDimPercentChanged() {
-            if (isDisabledMode) return  // Disabled mode keeps brightness at minimum
+            if (screensaverPage.isDisabledMode) return  // Disabled mode keeps brightness at minimum
             if (ScreensaverManager.dimPercent === 0) {
                 dimTimer.stop()
                 dimOverlay.opacity = 0
                 ScreensaverManager.setScreenDimming(0)
             } else if (dimOverlay.opacity > 0) {
-                applyDim()
+                screensaverPage.applyDim()
             } else {
-                startDimming()
+                screensaverPage.startDimming()
             }
         }
         function onDimDelayMinutesChanged() {
             // Only restart if dim hasn't triggered yet
-            if (dimOverlay.opacity === 0 && ScreensaverManager.dimPercent > 0 && !isDisabledMode) {
+            if (dimOverlay.opacity === 0 && ScreensaverManager.dimPercent > 0 && !screensaverPage.isDisabledMode) {
                 dimTimer.stop()
-                startDimming()
+                screensaverPage.startDimming()
             }
         }
     }
@@ -186,7 +191,7 @@ Page {
                 console.log("[Screensaver] App suspended — pausing all rendering")
                 // Destroy video decoder to stop rendering to dead EGL surface
                 if (mediaPlayerLoader.active) {
-                    pendingVideoSource = ""
+                    screensaverPage.pendingVideoSource = ""
                     mediaPlayerLoader.active = false
                 }
                 imageDisplayTimer.stop()
@@ -194,19 +199,19 @@ Page {
             } else if (Qt.application.state === Qt.ApplicationActive && screensaverPage.appSuspended) {
                 screensaverPage.appSuspended = false
                 console.log("[Screensaver] App resumed — restarting media")
-                if (isVideosMode && ScreensaverManager.enabled) {
-                    playNextMedia()
+                if (screensaverPage.isVideosMode && ScreensaverManager.enabled) {
+                    screensaverPage.playNextMedia()
                     // playNextMedia() may call wake() which navigates away —
                     // don't touch animation state on a page being torn down
                     if (!screensaverPage.visible) return
                 }
                 // Restart gradient animation if in fallback mode (no playable media)
-                if (isVideosMode && !mediaPlaying) {
+                if (screensaverPage.isVideosMode && !screensaverPage.mediaPlaying) {
                     gradientAnimation.running = true
                 }
                 // Restart image rotation if an image was already loaded pre-suspend
                 // (onStatusChanged won't re-fire for an already-loaded source)
-                if (isVideosMode && isCurrentItemImage && mediaPlaying) {
+                if (screensaverPage.isVideosMode && screensaverPage.isCurrentItemImage && screensaverPage.mediaPlaying) {
                     imageDisplayTimer.restart()
                 }
             }
@@ -361,14 +366,14 @@ Page {
         repeat: false
         onTriggered: {
             // Mark current image as played for LRU tracking
-            if (currentImageSource.length > 0) {
-                ScreensaverManager.markVideoPlayed(currentImageSource)
+            if (screensaverPage.currentImageSource.length > 0) {
+                ScreensaverManager.markVideoPlayed(screensaverPage.currentImageSource)
             }
-            videoFailCount = 0
-            lastFailedSource = ""
+            screensaverPage.videoFailCount = 0
+            screensaverPage.lastFailedSource = ""
             // Toggle to other image for cross-fade effect
-            useFirstImage = !useFirstImage
-            playNextMedia()
+            screensaverPage.useFirstImage = !screensaverPage.useFirstImage
+            screensaverPage.playNextMedia()
         }
     }
 
@@ -384,7 +389,7 @@ Page {
         // Event-driven recreation: when the old component is destroyed (item
         // becomes null), re-activate the Loader to create a fresh decoder.
         onItemChanged: {
-            if (item === null && pendingVideoSource.length > 0) {
+            if (item === null && screensaverPage.pendingVideoSource.length > 0) {
                 mediaPlayerLoader.active = true
             }
         }
@@ -401,14 +406,14 @@ Page {
                 onMediaStatusChanged: {
                     if (mediaStatus === MediaPlayer.EndOfMedia) {
                         ScreensaverManager.markVideoPlayed(source.toString())
-                        videoFailCount = 0
-                        lastFailedSource = ""
-                        playNextMedia()
+                        screensaverPage.videoFailCount = 0
+                        screensaverPage.lastFailedSource = ""
+                        screensaverPage.playNextMedia()
                     } else if (mediaStatus === MediaPlayer.InvalidMedia) {
                         // InvalidMedia is the parser's verdict that the bytes
                         // aren't valid media — treat as a format error so the
                         // cached file gets evicted and re-fetched.
-                        handleVideoFailure(true)
+                        screensaverPage.handleVideoFailure(true)
                     }
                 }
 
@@ -417,13 +422,13 @@ Page {
                     // Only Qt's FormatError implies the on-disk bytes are
                     // bad. Other codes (ResourceError, NetworkError,
                     // AccessDeniedError) are transient — leave the file alone.
-                    handleVideoFailure(error === MediaPlayer.FormatError)
+                    screensaverPage.handleVideoFailure(error === MediaPlayer.FormatError)
                 }
 
                 onPlaybackStateChanged: {
                     if (playbackState === MediaPlayer.PlayingState) {
-                        videoFailCount = 0
-                        lastFailedSource = ""
+                        screensaverPage.videoFailCount = 0
+                        screensaverPage.lastFailedSource = ""
                     }
                 }
             }
@@ -432,13 +437,13 @@ Page {
                 id: videoOut
                 anchors.fill: parent
                 fillMode: VideoOutput.PreserveAspectCrop
-                visible: isVideosMode && mediaPlaying && !isCurrentItemImage
+                visible: screensaverPage.isVideosMode && screensaverPage.mediaPlaying && !screensaverPage.isCurrentItemImage
             }
         }
 
         onLoaded: {
             item.player.videoOutput = item.output
-            item.player.source = pendingVideoSource
+            item.player.source = screensaverPage.pendingVideoSource
             item.player.play()
         }
     }
@@ -447,7 +452,7 @@ Page {
     Item {
         id: imageContainer
         anchors.fill: parent
-        visible: isVideosMode && mediaPlaying && isCurrentItemImage
+        visible: screensaverPage.isVideosMode && screensaverPage.mediaPlaying && screensaverPage.isCurrentItemImage
 
         // Two images for cross-fade effect (2 second dissolve)
         Image {
@@ -455,14 +460,14 @@ Page {
             anchors.fill: parent
             fillMode: Image.PreserveAspectCrop
             asynchronous: true
-            opacity: useFirstImage ? 1.0 : 0.0
+            opacity: screensaverPage.useFirstImage ? 1.0 : 0.0
 
             Behavior on opacity {
                 NumberAnimation { duration: 2000; easing.type: Easing.InOutQuad }
             }
 
             onStatusChanged: {
-                if (status === Image.Ready && useFirstImage && source.toString().length > 0) {
+                if (status === Image.Ready && screensaverPage.useFirstImage && source.toString().length > 0) {
                     // Image loaded — only cycle if there are multiple items to show
                     if (ScreensaverManager.itemCount > 1 || ScreensaverManager.personalMediaCount > 1)
                         imageDisplayTimer.restart()
@@ -475,14 +480,14 @@ Page {
             anchors.fill: parent
             fillMode: Image.PreserveAspectCrop
             asynchronous: true
-            opacity: useFirstImage ? 0.0 : 1.0
+            opacity: screensaverPage.useFirstImage ? 0.0 : 1.0
 
             Behavior on opacity {
                 NumberAnimation { duration: 2000; easing.type: Easing.InOutQuad }
             }
 
             onStatusChanged: {
-                if (status === Image.Ready && !useFirstImage && source.toString().length > 0) {
+                if (status === Image.Ready && !screensaverPage.useFirstImage && source.toString().length > 0) {
                     if (ScreensaverManager.itemCount > 1 || ScreensaverManager.personalMediaCount > 1)
                         imageDisplayTimer.restart()
                 }
@@ -494,57 +499,62 @@ Page {
     Loader {
         id: pipesLoader
         anchors.fill: parent
-        active: Settings.app.hasQuick3D && isPipesMode && !appSuspended
-        visible: isPipesMode
+        active: Settings.app.hasQuick3D && screensaverPage.isPipesMode && !screensaverPage.appSuspended
+        visible: screensaverPage.isPipesMode
         z: 0
         source: "qrc:/qt/qml/Decenza/qml/components/PipesScreensaver.qml"
-        onLoaded: item.running = Qt.binding(function() { return isPipesMode && screensaverPage.visible && !appSuspended })
+        onLoaded: item.running = Qt.binding(function() { return screensaverPage.isPipesMode && screensaverPage.visible && !screensaverPage.appSuspended })
     }
 
     // Flip Clock screensaver
     Loader {
         id: flipClockLoader
         anchors.fill: parent
-        active: isFlipClockMode && !appSuspended
-        visible: isFlipClockMode
+        active: screensaverPage.isFlipClockMode && !screensaverPage.appSuspended
+        visible: screensaverPage.isFlipClockMode
         z: 0
         source: "qrc:/qt/qml/Decenza/qml/components/FlipClockScreensaver.qml"
-        onLoaded: item.running = Qt.binding(function() { return isFlipClockMode && screensaverPage.visible && !appSuspended })
+        onLoaded: item.running = Qt.binding(function() { return screensaverPage.isFlipClockMode && screensaverPage.visible && !screensaverPage.appSuspended })
     }
 
     // Strange Attractor screensaver
     Loader {
         id: attractorLoader
         anchors.fill: parent
-        active: isAttractorMode && !appSuspended
-        visible: isAttractorMode
+        active: screensaverPage.isAttractorMode && !screensaverPage.appSuspended
+        visible: screensaverPage.isAttractorMode
         z: 0
         source: "qrc:/qt/qml/Decenza/qml/components/StrangeAttractorScreensaver.qml"
-        onLoaded: item.running = Qt.binding(function() { return isAttractorMode && screensaverPage.visible && !appSuspended })
+        onLoaded: item.running = Qt.binding(function() { return screensaverPage.isAttractorMode && screensaverPage.visible && !screensaverPage.appSuspended })
     }
 
     // Shot Map screensaver (flat map works without Quick3D, globe loaded conditionally)
     Loader {
         id: shotMapLoader
         anchors.fill: parent
-        active: isShotMapMode && !appSuspended
-        visible: isShotMapMode
+        active: screensaverPage.isShotMapMode && !screensaverPage.appSuspended
+        visible: screensaverPage.isShotMapMode
         z: 0
         source: "qrc:/qt/qml/Decenza/qml/components/ShotMapScreensaver.qml"
-        onLoaded: item.running = Qt.binding(function() { return isShotMapMode && screensaverPage.visible && !appSuspended })
+        onLoaded: item.running = Qt.binding(function() { return screensaverPage.isShotMapMode && screensaverPage.visible && !screensaverPage.appSuspended })
     }
 
     // Fallback: show a subtle animation while no cached media (videos mode only)
     Rectangle {
         id: fallbackBackground
         anchors.fill: parent
-        visible: isVideosMode && (!mediaPlaying || (!isCurrentItemImage && (!mediaPlayerLoader.item || mediaPlayerLoader.item.player.playbackState !== MediaPlayer.PlayingState)))
+        visible: screensaverPage.isVideosMode && (!screensaverPage.mediaPlaying || (!screensaverPage.isCurrentItemImage && (!mediaPlayerLoader.item || mediaPlayerLoader.item.player.playbackState !== MediaPlayer.PlayingState)))
         z: 1
 
         Rectangle {
             id: gradientRect
             anchors.fill: parent
-            property real gradientHue: 0.6
+            // No initialiser: `NumberAnimation on gradientHue` below is a value source, and a value
+            // source overrides an initial binding rather than starting from it. The `: 0.6` that
+            // used to be here was dead — the gradient has always started at 0, not at 0.6. Removed
+            // rather than honoured, so the rendering is unchanged; set the animation's `from` if a
+            // different start hue is ever wanted.
+            property real gradientHue
 
             gradient: Gradient {
                 GradientStop {
@@ -581,10 +591,10 @@ Page {
                                ScreensaverManager.showDateOnPersonal &&
                                ScreensaverManager.currentMediaDate.length > 0
 
-        visible: isVideosMode &&
+        visible: screensaverPage.isVideosMode &&
                  (showDate || ScreensaverManager.currentVideoAuthor.length > 0) &&
                  ((mediaPlayerLoader.item && mediaPlayerLoader.item.player.playbackState === MediaPlayer.PlayingState) ||
-                  (isCurrentItemImage && mediaPlaying))
+                  (screensaverPage.isCurrentItemImage && screensaverPage.mediaPlaying))
 
         Text {
             anchors.centerIn: parent
@@ -595,7 +605,7 @@ Page {
                 var author = Theme.replaceEmojiWithImg(ScreensaverManager.currentVideoAuthor, Theme.scaled(14))
                 if (parent.showDate) {
                     return Theme.replaceEmojiWithImg(ScreensaverManager.currentMediaDate, Theme.scaled(14))
-                } else if (isCurrentItemImage) {
+                } else if (screensaverPage.isCurrentItemImage) {
                     return TranslationManager.translate("screensaver.photo_by", "Photo by %1 (Pexels)")
                            .arg(author)
                 } else {
@@ -615,13 +625,13 @@ Page {
         z: 2
         // Show clock based on screensaver type and user preference
         // Flip clock and disabled modes never show the clock
-        visible: (isVideosMode && ScreensaverManager.videosShowClock) ||
-                 (isPipesMode && ScreensaverManager.pipesShowClock) ||
-                 (isAttractorMode && ScreensaverManager.attractorShowClock)
+        visible: (screensaverPage.isVideosMode && ScreensaverManager.videosShowClock) ||
+                 (screensaverPage.isPipesMode && ScreensaverManager.pipesShowClock) ||
+                 (screensaverPage.isAttractorMode && ScreensaverManager.attractorShowClock)
         anchors.bottom: parent.bottom
         anchors.right: parent.right
-        anchors.rightMargin: Theme.scaled(50) + driftX
-        anchors.bottomMargin: Theme.chartMarginLarge + Theme.scaled(20) + driftY  // Above credits bar
+        anchors.rightMargin: Theme.scaled(50) + screensaverPage.driftX
+        anchors.bottomMargin: Theme.chartMarginLarge + Theme.scaled(20) + screensaverPage.driftY  // Above credits bar
         text: Qt.formatTime(currentTime, Settings.app.use12HourTime ? "h:mmap" : "HH:mm")
         color: Theme.primaryContrastColor
         opacity: 0.8
@@ -646,11 +656,11 @@ Page {
     Item {
         id: overlayReadoutRow
         z: 2
-        visible: !isDisabledMode && overlayRow.implicitWidth > 0
+        visible: !screensaverPage.isDisabledMode && overlayRow.implicitWidth > 0
         anchors.top: parent.top
         anchors.right: parent.right
-        anchors.topMargin: Theme.scaled(20) + driftY
-        anchors.rightMargin: Theme.scaled(50) + driftX
+        anchors.topMargin: Theme.scaled(20) + screensaverPage.driftY
+        anchors.rightMargin: Theme.scaled(50) + screensaverPage.driftX
         width: overlayRow.implicitWidth
         height: overlayRow.implicitHeight
 
@@ -689,7 +699,7 @@ Page {
     Rectangle {
         id: linkButton
         z: 4
-        visible: !isDisabledMode && ScreensaverManager.overlayLinkButtonEnabled
+        visible: !screensaverPage.isDisabledMode && ScreensaverManager.overlayLinkButtonEnabled
                  && ScreensaverManager.overlayLinkButtonLabel !== ""
         // Dims along with the rest of the screen, same as everything below the
         // dim overlay — otherwise it'd be the one static element that never
@@ -697,8 +707,8 @@ Page {
         opacity: 1.0 - dimOverlay.opacity
         anchors.left: parent.left
         anchors.bottom: parent.bottom
-        anchors.leftMargin: Theme.scaled(50) - driftX
-        anchors.bottomMargin: Theme.chartMarginLarge + Theme.scaled(20) + driftY
+        anchors.leftMargin: Theme.scaled(50) - screensaverPage.driftX
+        anchors.bottomMargin: Theme.chartMarginLarge + Theme.scaled(20) + screensaverPage.driftY
         radius: Theme.scaled(8)
         color: Qt.rgba(0, 0, 0, 0.5)
         border.color: Qt.rgba(1, 1, 1, 0.4)
@@ -731,7 +741,7 @@ Page {
         anchors.right: parent.right
         height: Theme.scaled(3)
         color: "transparent"
-        visible: isVideosMode && ScreensaverManager.isDownloading
+        visible: screensaverPage.isVideosMode && ScreensaverManager.isDownloading
 
         Rectangle {
             anchors.left: parent.left
@@ -753,7 +763,7 @@ Page {
         interval: Math.max(1, ScreensaverManager.dimDelayMinutes) * 60 * 1000
         repeat: false
         running: false
-        onTriggered: applyDim()
+        onTriggered: screensaverPage.applyDim()
     }
 
     // z:2.5 positions this above clock/credits (z:2) but below the touch MouseArea (z:3)
@@ -797,8 +807,8 @@ Page {
     MouseArea {
         z: 3
         anchors.fill: parent
-        onClicked: wake()
-        onPressed: wake()
+        onClicked: screensaverPage.wake()
+        onPressed: screensaverPage.wake()
     }
 
     // Also wake on key press

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -510,12 +510,15 @@ Page {
         states: State {
             name: "positioned"
             when: highlightOverlay.target !== null
+            // Explicit `highlightOverlay.<prop>:` form rather than `target:` plus bare property
+            // names. The old shape is custom-parsed by PropertyChanges, which means the bindings
+            // are not analysable — and `target` is doubly confusing here, since highlightOverlay
+            // has its OWN `target` property that these bindings read.
             PropertyChanges {
-                target: highlightOverlay
-                x: highlightOverlay.target ? highlightOverlay.target.x : 0
-                y: highlightOverlay.target ? highlightOverlay.target.y : 0
-                width: highlightOverlay.target ? highlightOverlay.target.width : 0
-                height: highlightOverlay.target ? highlightOverlay.target.height : 0
+                highlightOverlay.x: highlightOverlay.target ? highlightOverlay.target.x : 0
+                highlightOverlay.y: highlightOverlay.target ? highlightOverlay.target.y : 0
+                highlightOverlay.width: highlightOverlay.target ? highlightOverlay.target.width : 0
+                highlightOverlay.height: highlightOverlay.target ? highlightOverlay.target.height : 0
             }
         }
 

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -709,7 +709,11 @@ Page {
                                 source: "qrc:/icons/tick.svg"
                                 iconWidth: Theme.scaled(16)
                                 iconHeight: Theme.scaled(16)
-                                iconColor: Theme.primaryColor
+                                // primaryContrastColor, not primaryColor: the indicator's fill is
+                                // Theme.primaryColor when checked, so a primaryColor tick is drawn
+                                // blue-on-blue and cannot be seen. Same class as SettingsPage's
+                                // white-on-white search icon — visible only by looking at the app.
+                                iconColor: Theme.primaryContrastColor
                                 visible: checkBox.checked
                             }
                         }

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -710,7 +710,7 @@ Page {
                                 iconWidth: Theme.scaled(16)
                                 iconHeight: Theme.scaled(16)
                                 iconColor: Theme.primaryColor
-                                visible: parent.checkBox.checked
+                                visible: checkBox.checked
                             }
                         }
                     }

--- a/qml/pages/ShotHistoryPage.qml
+++ b/qml/pages/ShotHistoryPage.qml
@@ -688,6 +688,7 @@ Page {
 
                     // Selection checkbox
                     CheckBox {
+                        id: checkBox
                         checked: shotHistoryPage.isSelected(shotDelegate.model.id)
                         onClicked: shotHistoryPage.toggleSelection(shotDelegate.model.id)
                         Accessible.role: Accessible.CheckBox
@@ -699,8 +700,8 @@ Page {
                             implicitWidth: Theme.scaled(24)
                             implicitHeight: Theme.scaled(24)
                             radius: Theme.scaled(4)
-                            color: parent.checked ? Theme.primaryColor : "transparent"
-                            border.color: parent.checked ? Theme.primaryColor : Theme.borderColor
+                            color: checkBox.checked ? Theme.primaryColor : "transparent"
+                            border.color: checkBox.checked ? Theme.primaryColor : Theme.borderColor
                             border.width: 2
 
                             ColoredIcon {
@@ -709,7 +710,7 @@ Page {
                                 iconWidth: Theme.scaled(16)
                                 iconHeight: Theme.scaled(16)
                                 iconColor: Theme.primaryColor
-                                visible: parent.parent.checked
+                                visible: parent.checkBox.checked
                             }
                         }
                     }

--- a/qml/pages/SimpleProfileEditorPage.qml
+++ b/qml/pages/SimpleProfileEditorPage.qml
@@ -660,6 +660,7 @@ Page {
         }
 
         AccessibleButton {
+            id: accessibleButton
             text: editorPage.tr("done", "Done")
             accessibleName: editorPage.isFlow ? editorPage.tr("finishEditing", "Finish editing flow profile") : editorPage.tr("finishEditing", "Finish editing pressure profile")
             onClicked: {
@@ -674,11 +675,11 @@ Page {
                 implicitWidth: Math.max(Theme.scaled(80), doneText.implicitWidth + Theme.scaled(32))
                 implicitHeight: Theme.scaled(36)
                 radius: Theme.scaled(6)
-                color: parent.down ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
+                color: accessibleButton.down ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
             }
             contentItem: Text {
                 id: doneText
-                text: parent.text
+                text: accessibleButton.text
                 font.pixelSize: Theme.scaled(14)
                 font.family: Theme.bodyFont.family
                 color: Theme.primaryColor
@@ -818,6 +819,7 @@ Page {
                 }
 
                 AccessibleButton {
+                    id: doneButton
                     Layout.fillWidth: true
                     Layout.topMargin: Theme.scaled(6)
                     text: TranslationManager.translate("common.done", "Done")
@@ -826,10 +828,10 @@ Page {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(44)
                         radius: Theme.buttonRadius
-                        color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: doneButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: doneButton.text
                         font: Theme.bodyFont
                         color: Theme.primaryContrastColor
                         horizontalAlignment: Text.AlignHCenter
@@ -891,6 +893,7 @@ Page {
             }
 
             AccessibleButton {
+                id: okButton
                 Layout.fillWidth: true
                 Layout.leftMargin: Theme.scaled(20)
                 Layout.rightMargin: Theme.scaled(20)
@@ -901,10 +904,10 @@ Page {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(44)
                     radius: Theme.buttonRadius
-                    color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                    color: okButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                 }
                 contentItem: Text {
-                    text: parent.text
+                    text: okButton.text
                     font: Theme.bodyFont
                     color: Theme.primaryContrastColor
                     horizontalAlignment: Text.AlignHCenter
@@ -1022,6 +1025,7 @@ Page {
                     spacing: Theme.scaled(10)
 
                     AccessibleButton {
+                        id: cancelButton
                         Layout.fillWidth: true
                         text: TranslationManager.translate("common.cancel", "Cancel")
                         accessibleName: TranslationManager.translate("common.cancel", "Cancel")
@@ -1034,7 +1038,7 @@ Page {
                             border.color: Theme.textSecondaryColor
                         }
                         contentItem: Text {
-                            text: parent.text
+                            text: cancelButton.text
                             font: Theme.bodyFont
                             color: Theme.textColor
                             horizontalAlignment: Text.AlignHCenter
@@ -1043,6 +1047,7 @@ Page {
                     }
 
                     AccessibleButton {
+                        id: saveButton
                         Layout.fillWidth: true
                         text: TranslationManager.translate("common.save", "Save")
                         accessibleName: TranslationManager.translate("common.save", "Save")
@@ -1050,10 +1055,10 @@ Page {
                         background: Rectangle {
                             implicitHeight: Theme.scaled(44)
                             radius: Theme.buttonRadius
-                            color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                            color: saveButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                         }
                         contentItem: Text {
-                            text: parent.text
+                            text: saveButton.text
                             font: Theme.bodyFont
                             color: Theme.primaryContrastColor
                             horizontalAlignment: Text.AlignHCenter
@@ -1152,6 +1157,7 @@ Page {
                 spacing: Theme.scaled(10)
 
                 AccessibleButton {
+                    id: noButton
                     Layout.fillWidth: true
                     text: TranslationManager.translate("common.no", "No")
                     accessibleName: TranslationManager.translate("common.no", "No")
@@ -1164,7 +1170,7 @@ Page {
                         border.color: Theme.textSecondaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: noButton.text
                         font: Theme.bodyFont
                         color: Theme.textColor
                         horizontalAlignment: Text.AlignHCenter
@@ -1173,6 +1179,7 @@ Page {
                 }
 
                 AccessibleButton {
+                    id: yesButton
                     Layout.fillWidth: true
                     text: TranslationManager.translate("common.yes", "Yes")
                     accessibleName: TranslationManager.translate("common.yes", "Yes")
@@ -1187,10 +1194,10 @@ Page {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(44)
                         radius: Theme.buttonRadius
-                        color: parent.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: yesButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
-                        text: parent.text
+                        text: yesButton.text
                         font: Theme.bodyFont
                         color: Theme.primaryContrastColor
                         horizontalAlignment: Text.AlignHCenter

--- a/qml/pages/SimpleProfileEditorPage.qml
+++ b/qml/pages/SimpleProfileEditorPage.qml
@@ -675,7 +675,7 @@ Page {
                 implicitWidth: Math.max(Theme.scaled(80), doneText.implicitWidth + Theme.scaled(32))
                 implicitHeight: Theme.scaled(36)
                 radius: Theme.scaled(6)
-                color: accessibleButton.down ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
+                color: accessibleButton.down || accessibleButton.isPressed ? Qt.darker(Theme.primaryContrastColor, 1.1) : Theme.primaryContrastColor
             }
             contentItem: Text {
                 id: doneText
@@ -828,7 +828,7 @@ Page {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(44)
                         radius: Theme.buttonRadius
-                        color: doneButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: doneButton.down || doneButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
                         text: doneButton.text
@@ -904,7 +904,7 @@ Page {
                 background: Rectangle {
                     implicitHeight: Theme.scaled(44)
                     radius: Theme.buttonRadius
-                    color: okButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                    color: okButton.down || okButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                 }
                 contentItem: Text {
                     text: okButton.text
@@ -1055,7 +1055,7 @@ Page {
                         background: Rectangle {
                             implicitHeight: Theme.scaled(44)
                             radius: Theme.buttonRadius
-                            color: saveButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                            color: saveButton.down || saveButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                         }
                         contentItem: Text {
                             text: saveButton.text
@@ -1194,7 +1194,7 @@ Page {
                     background: Rectangle {
                         implicitHeight: Theme.scaled(44)
                         radius: Theme.buttonRadius
-                        color: yesButton.down ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
+                        color: yesButton.down || yesButton.isPressed ? Qt.darker(Theme.primaryColor, 1.2) : Theme.primaryColor
                     }
                     contentItem: Text {
                         text: yesButton.text

--- a/qml/pages/settings/SettingsConnectionsTab.qml
+++ b/qml/pages/settings/SettingsConnectionsTab.qml
@@ -771,13 +771,14 @@ Item {
                         model: BLEManager.discoveredDevices
 
                         delegate: ItemDelegate {
+                            id: delegate
                             width: ListView.view.width
                             contentItem: Text {
                                 text: modelData.name + " (" + modelData.address + ")"
                                 color: Theme.textColor
                             }
                             background: Rectangle {
-                                color: parent.hovered ? Theme.accentColor : "transparent"
+                                color: delegate.hovered ? Theme.accentColor : "transparent"
                                 radius: Theme.scaled(4)
                             }
                             onClicked: DE1Device.connectToDevice(modelData.address)
@@ -1699,6 +1700,7 @@ Item {
                         }
 
                         delegate: ItemDelegate {
+                            id: delegate2
                             width: ListView.view.width
 
                             Accessible.role: Accessible.Button
@@ -1743,7 +1745,7 @@ Item {
                                 }
                             }
                             background: Rectangle {
-                                color: parent.hovered ? Theme.accentColor : "transparent"
+                                color: delegate2.hovered ? Theme.accentColor : "transparent"
                                 radius: Theme.scaled(4)
                             }
                             onClicked: {

--- a/qml/pages/settings/SettingsDebugTab.qml
+++ b/qml/pages/settings/SettingsDebugTab.qml
@@ -339,7 +339,13 @@ Item {
                 modal: true
                 dim: true
                 closePolicy: Dialog.CloseOnEscape
+                // qmllint disable Quick.layout-positioning
+                // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+                // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+                // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+                // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
                 anchors.centerIn: Overlay.overlay
+                // qmllint enable Quick.layout-positioning
                 padding: Theme.scaled(24)
 
                 property string resultMessage: ""
@@ -485,7 +491,13 @@ Item {
                 modal: true
                 dim: true
                 closePolicy: Dialog.CloseOnEscape
+                // qmllint disable Quick.layout-positioning
+                // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+                // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+                // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+                // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
                 anchors.centerIn: Overlay.overlay
+                // qmllint enable Quick.layout-positioning
                 padding: Theme.scaled(24)
 
                 property string resultMessage: ""

--- a/qml/pages/settings/SettingsHistoryDataTab.qml
+++ b/qml/pages/settings/SettingsHistoryDataTab.qml
@@ -145,6 +145,7 @@ KeyboardAwareContainer {
                     }
 
                     ProgressBar {
+                        id: progressBar
                         Layout.fillWidth: true
                         from: 0
                         to: MainController.shotImporter ? MainController.shotImporter.totalFiles : 1
@@ -592,7 +593,7 @@ KeyboardAwareContainer {
                         Accessible.onPressAction: Qt.openUrlExternally(MainController.shotServer.url)
 
                         TapHandler {
-                            enabled: parent.parent.serverRunning
+                            enabled: parent.progressBar.serverRunning
                             onTapped: Qt.openUrlExternally(MainController.shotServer.url)
                         }
                     }

--- a/qml/pages/settings/SettingsHistoryDataTab.qml
+++ b/qml/pages/settings/SettingsHistoryDataTab.qml
@@ -145,7 +145,6 @@ KeyboardAwareContainer {
                     }
 
                     ProgressBar {
-                        id: progressBar
                         Layout.fillWidth: true
                         from: 0
                         to: MainController.shotImporter ? MainController.shotImporter.totalFiles : 1
@@ -593,7 +592,7 @@ KeyboardAwareContainer {
                         Accessible.onPressAction: Qt.openUrlExternally(MainController.shotServer.url)
 
                         TapHandler {
-                            enabled: parent.progressBar.serverRunning
+                            enabled: parent.parent.serverRunning
                             onTapped: Qt.openUrlExternally(MainController.shotServer.url)
                         }
                     }

--- a/qml/pages/settings/SettingsHistoryDataTab.qml
+++ b/qml/pages/settings/SettingsHistoryDataTab.qml
@@ -820,7 +820,13 @@ KeyboardAwareContainer {
             modal: true
             dim: true
             closePolicy: Dialog.NoAutoClose
+            // qmllint disable Quick.layout-positioning
+            // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+            // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+            // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+            // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
             anchors.centerIn: Overlay.overlay
+            // qmllint enable Quick.layout-positioning
             padding: Theme.scaled(24)
 
             background: Rectangle {
@@ -876,7 +882,13 @@ KeyboardAwareContainer {
             modal: true
             dim: true
             closePolicy: Dialog.CloseOnEscape
+            // qmllint disable Quick.layout-positioning
+            // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+            // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+            // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+            // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
             anchors.centerIn: Overlay.overlay
+            // qmllint enable Quick.layout-positioning
             padding: Theme.scaled(24)
 
             property string resultMessage: ""
@@ -986,9 +998,15 @@ KeyboardAwareContainer {
     Dialog {
         id: importCompletePopup
         parent: Overlay.overlay
+        // qmllint disable Quick.layout-positioning
+        // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+        // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+        // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+        // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
         anchors.centerIn: parent
         modal: true
         width: Theme.scaled(300)
+        // qmllint enable Quick.layout-positioning
         padding: Theme.scaled(20)
 
         property int settingsCount: 0
@@ -1161,15 +1179,27 @@ KeyboardAwareContainer {
         id: backupStatusBackground
         parent: Overlay.overlay
         visible: false
+        // qmllint disable Quick.layout-positioning
+        // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+        // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+        // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+        // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
         anchors.bottom: parent.bottom
+        // qmllint enable Quick.layout-positioning
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottomMargin: Theme.scaled(20)
         // NOT Layout.preferred*: this is reparented to Overlay.overlay and positioned with
         // anchors, so no Layout manages it and the attached properties would be inert — the
         // pill would collapse to 0x0 (Rectangle's implicit size). qmllint flags it as
         // layout-positioning because it is DECLARED inside one; that is a false positive.
+        // qmllint disable Quick.layout-positioning
+        // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+        // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+        // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+        // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
         width: backupStatusText.implicitWidth + Theme.scaled(20)
         height: backupStatusText.implicitHeight + Theme.scaled(20)
+        // qmllint enable Quick.layout-positioning
         color: Theme.surfaceColor
         radius: Theme.scaled(4)
         border.color: Theme.borderColor
@@ -1194,8 +1224,14 @@ KeyboardAwareContainer {
     Dialog {
         id: restoreConfirmDialog
         parent: Overlay.overlay
+        // qmllint disable Quick.layout-positioning
+        // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+        // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+        // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+        // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
         anchors.centerIn: parent
         width: Theme.scaled(400)
+        // qmllint enable Quick.layout-positioning
         padding: 0
         modal: true
 
@@ -1517,7 +1553,13 @@ KeyboardAwareContainer {
     Dialog {
         id: totpSetupDialog
         parent: Overlay.overlay
+        // qmllint disable Quick.layout-positioning
+        // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+        // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+        // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+        // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
         x: Math.round((parent.width - width) / 2)
+        // qmllint enable Quick.layout-positioning
         y: {
             if (totpCodeField.activeFocus) {
                 // Center in the visible area above the keyboard
@@ -1529,11 +1571,17 @@ KeyboardAwareContainer {
             }
             return Math.round((parent.height - height) / 2);
         }
+        // qmllint disable Quick.layout-positioning
+        // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+        // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+        // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+        // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
         width: Theme.scaled(380)
         padding: 0
         modal: true
 
         Behavior on y { NumberAnimation { duration: 250; easing.type: Easing.OutQuad } }
+        // qmllint enable Quick.layout-positioning
 
         property string totpSecret: ""
         property string totpUri: ""
@@ -1764,8 +1812,14 @@ KeyboardAwareContainer {
     Dialog {
         id: totpResetDialog
         parent: Overlay.overlay
+        // qmllint disable Quick.layout-positioning
+        // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+        // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+        // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+        // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
         anchors.centerIn: parent
         width: Theme.scaled(380)
+        // qmllint enable Quick.layout-positioning
         padding: 0
         modal: true
 
@@ -1849,8 +1903,14 @@ KeyboardAwareContainer {
     Dialog {
         id: factoryResetDialog1
         parent: Overlay.overlay
+        // qmllint disable Quick.layout-positioning
+        // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+        // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+        // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+        // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
         anchors.centerIn: parent
         width: Theme.scaled(400)
+        // qmllint enable Quick.layout-positioning
         padding: 0
         modal: true
 
@@ -1934,8 +1994,14 @@ KeyboardAwareContainer {
     Dialog {
         id: factoryResetDialog2
         parent: Overlay.overlay
+        // qmllint disable Quick.layout-positioning
+        // False positive, verified: qmllint's ForbiddenChildrenPropertyValidatorPass checks only
+        // whether an object is DECLARED lexically inside a Layout, never whether a Layout actually
+        // manages it. This object is not layout-managed — Dialog/Popup derive from QObject rather
+        // than Item, and anything with `parent: Overlay.overlay` is reparented out at runtime.
         anchors.centerIn: parent
         width: Theme.scaled(400)
+        // qmllint enable Quick.layout-positioning
         padding: 0
         modal: true
 

--- a/qml/pages/settings/SettingsLanguageTab.qml
+++ b/qml/pages/settings/SettingsLanguageTab.qml
@@ -263,6 +263,7 @@ Item {
                         }
 
                         ProgressBar {
+                            id: progressBar
                             Layout.fillWidth: true
                             from: 0
                             to: Math.max(1, TranslationManager.totalStringCount)
@@ -287,7 +288,7 @@ Item {
 
                             contentItem: Item {
                                 Rectangle {
-                                    width: parent.parent.visualPosition * parent.width
+                                    width: parent.progressBar.visualPosition * parent.width
                                     height: parent.height
                                     radius: Theme.scaled(3)
                                     color: Theme.successColor
@@ -755,6 +756,7 @@ Item {
         z: 100
 
         ProgressBar {
+            id: progressBar2
             anchors.centerIn: parent
             width: parent.width * 0.6
             from: 0
@@ -769,7 +771,7 @@ Item {
 
             contentItem: Item {
                 Rectangle {
-                    width: parent.parent.visualPosition * parent.width
+                    width: parent.progressBar2.visualPosition * parent.width
                     height: parent.height
                     radius: Theme.scaled(4)
                     color: Theme.primaryColor

--- a/qml/pages/settings/SettingsLanguageTab.qml
+++ b/qml/pages/settings/SettingsLanguageTab.qml
@@ -288,7 +288,7 @@ Item {
 
                             contentItem: Item {
                                 Rectangle {
-                                    width: parent.progressBar.visualPosition * parent.width
+                                    width: progressBar.visualPosition * parent.width
                                     height: parent.height
                                     radius: Theme.scaled(3)
                                     color: Theme.successColor
@@ -771,7 +771,7 @@ Item {
 
             contentItem: Item {
                 Rectangle {
-                    width: parent.progressBar2.visualPosition * parent.width
+                    width: progressBar2.visualPosition * parent.width
                     height: parent.height
                     radius: Theme.scaled(4)
                     color: Theme.primaryColor

--- a/qml/pages/settings/SettingsScreensaverTab.qml
+++ b/qml/pages/settings/SettingsScreensaverTab.qml
@@ -675,21 +675,22 @@ Item {
                         }
 
                         delegate: ItemDelegate {
+                            id: delegate
                             width: ListView.view ? ListView.view.width : 0
                             height: Theme.scaled(36)
                             highlighted: modelData && modelData.id === ScreensaverManager.selectedCategoryId
 
                             background: Rectangle {
-                                color: parent.highlighted ? Theme.primaryColor :
-                                       parent.hovered ? Qt.darker(Theme.insetBackgroundColor, 1.2) : Theme.insetBackgroundColor
+                                color: delegate.highlighted ? Theme.primaryColor :
+                                       delegate.hovered ? Qt.darker(Theme.insetBackgroundColor, 1.2) : Theme.insetBackgroundColor
                                 radius: Theme.scaled(6)
                             }
 
                             contentItem: Text {
                                 text: modelData ? modelData.name : ""
-                                color: parent.highlighted ? Theme.primaryContrastColor : Theme.textColor
+                                color: delegate.highlighted ? Theme.primaryContrastColor : Theme.textColor
                                 font.pixelSize: Theme.scaled(14)
-                                font.bold: parent.highlighted
+                                font.bold: delegate.highlighted
                                 verticalAlignment: Text.AlignVCenter
                                 leftPadding: Theme.scaled(10)
                             }

--- a/scripts/qml_qualify.py
+++ b/scripts/qml_qualify.py
@@ -9,7 +9,10 @@ decide is how you get this, from a real bulk pass:
     ValueInput.qml has `gear` on a delegate. The pass prefixed it with the component root,
     which has no such member, so every gear tap assigned `undefined`.
 
-qmllint already knows the answer and prints it. For an unqualified access it emits:
+qmllint already knows the answer and prints it. For an unqualified access it emits (this is real
+output from the PATCHED qmllint, taken AFTER the delegate gained `required property var modelData`
+— that matters: against an injected context property qmllint offers no id at all, because there is
+no id to offer. The suggestion appears once the role is a declared member of a delegate with an id):
 
     Warning: .../FlushPage.qml:142:35: Unqualified access [unqualified]
                                 text: modelData.name
@@ -40,6 +43,11 @@ Sites with no suggestion are reported, never guessed at. In practice they are:
     function instead: (event) => ...`, and the fix is the `function(event)` form, not a prefix
   * ids from outer components inside a nested component — Info says to set
     `pragma ComponentBehavior: Bound`, which is a semantic change and needs a delegate audit first
+
+It DOES now handle qmllint's glued-diagnostic bug (see GLUED_RE) — that one used to lose sites
+silently rather than report them, which is the worst possible behaviour for a tool whose entire
+claim is "never guesses". An accounting check in main() refuses to edit if the parsed count and
+qmllint's own count for the file disagree, so a future format change fails loudly instead.
 """
 
 from __future__ import annotations
@@ -53,6 +61,19 @@ from pathlib import Path
 
 WARN = re.compile(r"^Warning: (\S+?):(\d+):(\d+): Unqualified access \[unqualified\]$")
 QUALIFY_HINT = "qualify the access with its id"
+
+# qmllint 6.11.1 omits the trailing newline after some hint lines ("You first have to give the
+# element an id"), so the NEXT diagnostic is glued onto the end of that line and matches nothing.
+# Measured on this tree: RecipeWizardPage.qml has 144 unqualified sites and 20 of them vanish
+# without this split — not reported as unsuggested, silently absent. scripts/qmllint_report.py
+# carries the same regex for the same reason; it splits in memory and never writes the repaired
+# text back, so anything reading its --raw-out (i.e. this script) must split again itself.
+GLUED_RE = re.compile(r"(?<!^)(?=(?:Warning|Error|Info): )", re.MULTILINE)
+
+
+def read_raw(path: Path) -> list[str]:
+    """Split qmllint output into lines, repairing glued diagnostics first (see GLUED_RE)."""
+    return GLUED_RE.sub("\n", path.read_text(errors="replace")).split("\n")
 
 
 def collect(raw: list[str], target: str):
@@ -112,6 +133,12 @@ def verify(path: Path) -> int:
             while i < len(diff) and diff[i].startswith("+") and not diff[i].startswith("+++"):
                 plus.append(diff[i][1:])
                 i += 1
+            if len(minus) != len(plus):
+                # Unequal hunk: the paired comparison below cannot align lines, so it would
+                # silently check nothing. Say so rather than reporting a clean run.
+                print(f"  UNVERIFIED HUNK ({len(minus)} removed / {len(plus)} added) — "
+                      f"mid-chain check could not run here; inspect by hand.", file=sys.stderr)
+                bad += 1
             if len(minus) == len(plus):
                 for before, after in zip(minus, plus):
                     if before == after:
@@ -142,8 +169,19 @@ def main() -> int:
     args = ap.parse_args()
 
     path = Path(args.file)
-    raw = Path(args.raw).read_text(errors="replace").split("\n")
-    fixes, unsuggested = collect(raw, "/" + path.name)
+    raw = read_raw(Path(args.raw))
+    # Match on the full relative path, not the basename: two files can share a name.
+    fixes, unsuggested = collect(raw, "/" + str(path))
+
+    # Accounting, because the failure mode above is SILENT. Count the file's unqualified
+    # diagnostics independently of the parse and refuse to run if the two disagree.
+    reported = sum(1 for line in raw
+                   if (m := WARN.match(line)) and m.group(1).endswith("/" + path.name))
+    seen = sum(len(v) for v in fixes.values()) + len(unsuggested)
+    if seen != reported:
+        print(f"ACCOUNTING MISMATCH: parsed {seen} but qmllint reported {reported} for {path}. "
+              f"Refusing to edit — the parse is losing diagnostics.", file=sys.stderr)
+        return 1
 
     total = sum(len(v) for v in fixes.values())
     prefixes = Counter(p for v in fixes.values() for _, p in v)

--- a/scripts/qml_qualify.py
+++ b/scripts/qml_qualify.py
@@ -148,9 +148,29 @@ def verify(path: Path) -> int:
                         if chain in old:
                             continue
                         parts = chain.split(".")
+                        # (a) INSERTION: a segment was added into an existing chain.
+                        hit = False
                         for k in range(1, len(parts)):
                             if ".".join(parts[:k] + parts[k + 1:]) in old:
-                                print(f"  MID-CHAIN: {after.strip()}", file=sys.stderr)
+                                print(f"  MID-CHAIN INSERT: {after.strip()}", file=sys.stderr)
+                                bad += 1
+                                hit = True
+                                break
+                        if hit:
+                            continue
+                        # (b) SUBSTITUTION: same length, exactly one segment differs. This is what
+                        # replacing the seven characters `parent.` does to a `parent.parent.X`
+                        # chain — it rewrites the SECOND segment and leaves the first, so the
+                        # result reads a member off the wrong object. Five of those shipped past
+                        # the insertion check above, which cannot see them: nothing was added.
+                        for prev in old:
+                            pp = prev.split(".")
+                            if len(pp) != len(parts):
+                                continue
+                            diff = [i for i in range(len(pp)) if pp[i] != parts[i]]
+                            if len(diff) == 1 and diff[0] > 0:
+                                print(f"  MID-CHAIN SUBST: {prev.strip()} -> {chain}",
+                                      file=sys.stderr)
                                 bad += 1
                                 break
             minus = []

--- a/scripts/qml_qualify.py
+++ b/scripts/qml_qualify.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Apply qmllint's own suggested scope prefixes to unqualified accesses.
+
+WHY THIS EXISTS, AND WHY IT DOES NOT GUESS
+------------------------------------------
+Qualifying an identifier means deciding WHICH scope it belongs to. Reading indentation to
+decide is how you get this, from a real bulk pass:
+
+    ValueInput.qml has `gear` on a delegate. The pass prefixed it with the component root,
+    which has no such member, so every gear tap assigned `undefined`.
+
+qmllint already knows the answer and prints it. For an unqualified access it emits:
+
+    Warning: .../FlushPage.qml:142:35: Unqualified access [unqualified]
+                                text: modelData.name
+                                      ^^^^^^^^^
+    Info: modelData is a member of a parent element.
+          You can qualify the access with its id to avoid this warning.
+
+                                text: livePresetDelegate.modelData.name
+                                      ^^^^^^^^^^^^^^^^^^^
+
+That last block is the corrected line, with the RIGHT id — `livePresetDelegate`, not the page
+root, and not the other delegate in the same file. This script reads that suggestion and applies
+it. It never infers a prefix.
+
+THE OTHER RULE: INSERT RIGHT-TO-LEFT
+------------------------------------
+Two insertions on one line, applied left-to-right, put the second one in the wrong place because
+the first shifted every column after it. That is how `results.length` became
+`results.shotHistoryPage.length` — undefined, `+=` made it NaN, and Shot History pagination died.
+qmllint did not catch it: `results` is a signal-handler parameter typed `var`, so nothing checks
+that chain. Sorting by descending column is the whole fix, and --verify re-checks it anyway.
+
+WHAT IT DOES NOT HANDLE
+-----------------------
+Sites with no suggestion are reported, never guessed at. In practice they are:
+  * bare calls to the file's own functions — qmllint says "Unqualified access" with no Info block
+  * `event` in a `Keys.onXPressed: { ... }` handler — Info says `"event" is ambiguous. Use a
+    function instead: (event) => ...`, and the fix is the `function(event)` form, not a prefix
+  * ids from outer components inside a nested component — Info says to set
+    `pragma ComponentBehavior: Bound`, which is a semantic change and needs a delegate audit first
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+WARN = re.compile(r"^Warning: (\S+?):(\d+):(\d+): Unqualified access \[unqualified\]$")
+QUALIFY_HINT = "qualify the access with its id"
+
+
+def collect(raw: list[str], target: str):
+    """Return (fixes, unsuggested) for one file. fixes maps line -> [(col, prefix)]."""
+    fixes: dict[int, list[tuple[int, str]]] = defaultdict(list)
+    unsuggested: list[tuple[int, str, str]] = []
+    for i, line in enumerate(raw):
+        m = WARN.match(line)
+        if not m or not m.group(1).endswith(target):
+            continue
+        ln, col = int(m.group(2)), int(m.group(3))
+        src = raw[i + 1] if i + 1 < len(raw) else ""
+        if i + 4 < len(raw) and QUALIFY_HINT in raw[i + 4]:
+            # raw[i+6] is the corrected line; the prefix is what now sits at the same column.
+            prefix = re.match(r"([A-Za-z_]\w*)\.", raw[i + 6][col - 1:])
+            if prefix:
+                fixes[ln].append((col, prefix.group(1)))
+                continue
+        why = raw[i + 3].strip() if i + 3 < len(raw) else ""
+        unsuggested.append((ln, src.strip()[:70], why[:70]))
+    return fixes, unsuggested
+
+
+def apply(path: Path, fixes: dict[int, list[tuple[int, str]]]) -> int:
+    lines = path.read_text().split("\n")
+    applied = 0
+    for ln, items in fixes.items():
+        s = lines[ln - 1]
+        # RIGHT-TO-LEFT: every insertion shifts the columns after it.
+        for col, prefix in sorted(set(items), key=lambda x: -x[0]):
+            s = s[:col - 1] + prefix + "." + s[col - 1:]
+            applied += 1
+        lines[ln - 1] = s
+    path.write_text("\n".join(lines))
+    return applied
+
+
+def verify(path: Path) -> int:
+    """Re-check the diff for a prefix inserted INTO an existing dotted chain.
+
+    Paired-line, not textual: if dropping one segment from a new chain yields a chain that was
+    in the old line, the insertion landed mid-chain. This is the check that would have caught
+    results.shotHistoryPage.length, which no linter reported.
+    """
+    diff = subprocess.run(["git", "diff", "--", str(path)],
+                          capture_output=True, text=True).stdout.split("\n")
+    chains = lambda s: set(re.findall(r"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+", s))
+    bad, minus, i = 0, [], 0
+    while i < len(diff):
+        line = diff[i]
+        if line.startswith("-") and not line.startswith("---"):
+            minus.append(line[1:])
+            i += 1
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            plus = []
+            while i < len(diff) and diff[i].startswith("+") and not diff[i].startswith("+++"):
+                plus.append(diff[i][1:])
+                i += 1
+            if len(minus) == len(plus):
+                for before, after in zip(minus, plus):
+                    if before == after:
+                        continue
+                    old = chains(before)
+                    for chain in chains(after):
+                        if chain in old:
+                            continue
+                        parts = chain.split(".")
+                        for k in range(1, len(parts)):
+                            if ".".join(parts[:k] + parts[k + 1:]) in old:
+                                print(f"  MID-CHAIN: {after.strip()}", file=sys.stderr)
+                                bad += 1
+                                break
+            minus = []
+            continue
+        minus = []
+        i += 1
+    return bad
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("file", help="QML file to qualify, repo-relative")
+    ap.add_argument("--raw", required=True, help="saved qmllint output covering this file")
+    ap.add_argument("--apply", action="store_true", help="write changes (default: dry run)")
+    args = ap.parse_args()
+
+    path = Path(args.file)
+    raw = Path(args.raw).read_text(errors="replace").split("\n")
+    fixes, unsuggested = collect(raw, "/" + path.name)
+
+    total = sum(len(v) for v in fixes.values())
+    prefixes = Counter(p for v in fixes.values() for _, p in v)
+    print(f"{path}: {total} suggested across {len(fixes)} lines  {dict(prefixes)}")
+    if unsuggested:
+        print(f"  {len(unsuggested)} with NO suggestion — handle by hand, do not guess:")
+        for ln, src, why in unsuggested:
+            print(f"    L{ln}: {src}\n         {why}")
+    if not args.apply:
+        print("  (dry run; pass --apply to write)")
+        return 0
+
+    print(f"  applied {apply(path, fixes)}")
+    bad = verify(path)
+    print(f"  mid-chain insertions: {bad}")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/qmllint_report.py
+++ b/scripts/qmllint_report.py
@@ -112,23 +112,31 @@ CATEGORY_EXEMPTIONS: dict[str, int] = {
     # in-progress word is never committed). CLAUDE.md's "call commit() before reading
     # TextField.text" rule now has a home in code rather than being a convention.
     "missing-property": 145,
-    # All 21 remaining are qmllint FALSE POSITIVES and cannot be driven to zero from this side:
-    # it flags any child DECLARED lexically inside a Layout without checking that a Layout will
-    # actually manage it. Two shapes — objects that are not Items at all (Popup/Dialog derive
-    # from QObject; one Translate transform), and one Item reparented out of the layout at
-    # runtime (`parent: Overlay.overlay` + anchors, SettingsHistoryDataTab.qml). Verified in the
-    # Qt 6.11.1 source; see bugs-found.md. The real ones were fixed by moving to
-    # Layout.preferredWidth/Height — do not "clean up" these 21.
-    "Quick.layout-positioning": 21,
+    # No "Quick.layout-positioning" entry: CLEAR, and deliberately not by blanket exemption.
+    # All 21 were qmllint FALSE POSITIVES — its ForbiddenChildrenPropertyValidatorPass checks
+    # only whether an object is DECLARED lexically inside a Layout, never whether a Layout
+    # actually manages it. Three shapes: Dialog/Popup (derive from QObject, not Item), items
+    # reparented out at runtime via `parent: Overlay.overlay`, and one Translate transform.
+    #
+    # They are now suppressed AT EACH SITE with `qmllint disable/enable` and the reason
+    # inline, rather than exempted here. That is the whole point: a category exemption is
+    # global, so at 21 a genuine layout-positioning bug introduced anywhere in the tree was
+    # invisible. At 0 the category is enforced and the next real one fails the gate.
     # No "import" entry: the category is CLEAR. It went 23 -> 7 when the last runtime
     # qmlRegisterType<> calls became QML_ELEMENT, and 7 -> 0 when 106 redundant directory imports
     # were deleted — `import "../components"` and friends, which shadowed the module's own
     # registrations. Re-adding a directory import for a type the module already provides will
     # bring this category back.
-    "Quick.property-changes-parsed": 5,
-    "duplicate-property-binding": 2,
+    # No "Quick.property-changes-parsed" entry: CLEAR. The five were one PropertyChanges block
+    # in SettingsPage.qml using `target:` plus bare property names, which PropertyChanges
+    # custom-parses so the bindings are not analysable. Rephrased as explicit
+    # `highlightOverlay.<prop>:` bindings.
+    # No "duplicate-property-binding" entry: CLEAR. Both were `NumberAnimation on X` over a
+    # property that also had an initialiser (ScreensaverPage gradientHue, CrtShaderEffect
+    # time). A value source OVERRIDES an initial binding rather than starting from it, so in
+    # both cases the initialiser was dead and the code had never done what it read as.
     # No "unresolved-type" entry either — same cause, cleared the same way.
-    "equality-type-coercion": 1,
+    # No "equality-type-coercion" entry: CLEAR. One `!=` on a string in ProfileImportPage.
     # No "incompatible-type" entry. Its single finding was
     # StrangeAttractorScreensaver.qml:47 binding `target: renderer`, declared QObject and actually
     # a StrangeAttractorRenderer — unresolvable while that type was registered at runtime, and

--- a/scripts/qmllint_report.py
+++ b/scripts/qmllint_report.py
@@ -111,7 +111,13 @@ CATEGORY_EXEMPTIONS: dict[str, int] = {
     # indistinguishable from the correct spelling, and its failure mode is the silent one (the
     # in-progress word is never committed). CLAUDE.md's "call commit() before reading
     # TextField.text" rule now has a home in code rather than being a convention.
-    "missing-property": 145,
+    # No "missing-property" entry: NOT exempted. As of this change there are no approved
+    # category exemptions at all, and this dict is empty by intent.
+    #
+    # The category is NOT yet at zero — the gate is red on it, deliberately. A ceiling here
+    # would be global: at 145, a brand-new missing-property bug anywhere in the tree was
+    # invisible, which is what an exemption costs and why none of the five survived. Red and
+    # honest beats green and blind; the remaining sites are being worked to zero.
     # No "Quick.layout-positioning" entry: CLEAR, and deliberately not by blanket exemption.
     # All 21 were qmllint FALSE POSITIVES — its ForbiddenChildrenPropertyValidatorPass checks
     # only whether an object is DECLARED lexically inside a Layout, never whether a Layout

--- a/scripts/qmllint_report.py
+++ b/scripts/qmllint_report.py
@@ -142,7 +142,11 @@ CATEGORY_EXEMPTIONS: dict[str, int] = {
     # time). A value source OVERRIDES an initial binding rather than starting from it, so in
     # both cases the initialiser was dead and the code had never done what it read as.
     # No "unresolved-type" entry either — same cause, cleared the same way.
-    # No "equality-type-coercion" entry: CLEAR. One `!=` on a string in ProfileImportPage.
+    # No "equality-type-coercion" entry: CLEAR. One `!=` in ProfileImportPage — and the fix was
+    # NOT the obvious one. The operand is a `property url`, which QML hands to JS as a UrlObject
+    # whose default virtualIsEqualTo returns false unconditionally, so a bare `!==` is ALWAYS
+    # true and silently broke the rescan fallback. Compare `.toString()`. Lint-clean and wrong
+    # is worse than lint-dirty and right.
     # No "incompatible-type" entry. Its single finding was
     # StrangeAttractorScreensaver.qml:47 binding `target: renderer`, declared QObject and actually
     # a StrangeAttractorRenderer — unresolvable while that type was registered at runtime, and


### PR DESCRIPTION
Batch 1 of driving qmllint to zero. Tree goes **92 -> 131 of 219 clean**, and **`CATEGORY_EXEMPTIONS` is now empty**.

## Read this first: the nightly on `main` will be red

`missing-property` is at **92 and deliberately unexempted**. The qmllint gate does not run on PRs, but it does run in `nightly-sanitizers.yml` on `main`, so merging this turns the nightly red until batch 2 clears the remaining 92.

That is the intended trade. A category exemption is **global**: at `missing-property: 145` a brand-new missing-property bug anywhere in the tree was invisible. Red and honest beats green and blind — but it only stays defensible if batch 2 follows promptly.

## Exemptions deleted by fixing what they hid

| category | was | now |
|---|---|---|
| `equality-type-coercion` | 1 | **0** |
| `duplicate-property-binding` | 2 | **0** |
| `Quick.property-changes-parsed` | 5 | **0** |
| `Quick.layout-positioning` | 21 | **0** |
| `missing-property` | 145 | 92, unexempted |

`Quick.layout-positioning` were all genuine qmllint false positives — its check tests whether an object is *declared lexically* inside a Layout, never whether a Layout manages it, and `Dialog`/`Popup` derive from `QObject` while `parent: Overlay.overlay` reparents out at runtime. They are now suppressed **at each site** with the reason inline (13 suppressions), not behind one global number, so the category is enforced and the next real one fails.

## Bugs found, not lint noise

1. **The two-finger accessibility back gesture has never worked.** `main.qml` called `stackView.depth`/`stackView.pop()`; no such id exists (it is `pageStack`). ReferenceError killed the handler including its `else`. Now `depth > 1 ? goBack() : goToIdle()` — both branches needed, because `replace(null, X)` clears the stack and that is how every machine-driven page and the screensaver are entered, leaving them at depth 1.
2. **Two frozen clocks.** `Timer { onTriggered: parent.currentTime = ... }` in `ScreensaverPage` and `ShotMapScreensaver`. `Timer` is a `QObject` with no `parent`, so the write went to the file root's parent and the clock never ticked.
3. **Two dead initialisers.** `gradientHue: 0.6` and CrtShaderEffect's `time: 0`, both overridden by a `NumberAnimation` value source with an explicit `from`.
4. **`CustomItem.qml` had 3 diagnostics, not the 122 on record** — that number was never a measurement, because no run had ever completed on it. The patched qmllint does the whole tree in ~9s.

## scripts/qml_qualify.py

Encodes the rules that each cost a bug: never infer a prefix (qmllint prints the correct one), insert right-to-left, split qmllint's glued diagnostics, and refuse to edit when the parsed count disagrees with qmllint's own count for the file.

That last one is not hypothetical — the first version silently lost **20 of 144** sites in `RecipeWizardPage` to the glued-line bug and still reported a plausible number.

## What review caught, and how

Four review agents ran against this branch. Everything they found was mine and is fixed. Two are worth recording because of *how* they surfaced:

- The tool's 20 lost diagnostics printed a normal-looking report.
- Two of 38 inserted ids bound to the **wrong object** (a control 500 lines away, inside a delegate whose `parent` is the row). Nothing detected a wrong reference — the baseline writer **refused** because one file's ceiling rose 54 -> 60, and that refusal is the only reason anyone looked. Reverted; the containment check is now in `QML_GOTCHAS.md`.

Both failures still produced plausible numbers. That is the pattern to distrust.

## Verification

Build and full suite clean. `tst_decentscalewifi` failed once and passed on re-run; this branch contains no C++.

**`FlushPage` is the one thing wanting eyes rather than a compile** — its delegates now declare `modelData`/`index` with `required property`, the class that compiles and tests green while being broken. The preset pills and their arrow-key navigation should be looked at in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)