### PR TITLE
Fix #1692: run the QML string scan off the main thread

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,11 @@ colour glyph reach the platform renderer, which **crashes the render thread on m
 - **When qualifying identifiers, go by qmllint's line and column, never by text search.** One name
   can be several things in a file (a function-local `var step` and a nested `property var step`),
   and only the flagged occurrences may move.
+- **A nested event loop reachable from a QML signal handler is a crash, not a slowdown.**
+  `processEvents()` / `exec()` below a handler delivers queued `DeferredDelete`s, so an object can
+  be destroyed mid-handler and Qt answers with `qFatal()` — shipped iOS 2.0.0 aborted this way
+  (#1692). Long work goes on a worker thread with results posted back queued, never pumped inline;
+  a progress bar is not a reason to pump. Full chain in `QML_GOTCHAS.md`.
 - **Font property conflict**: don't mix `font: Theme.bodyFont` with `font.bold: true` — assign sub-properties individually.
 - **Reserved names in JS model data**: `name`, `parent`, `children`, `data`, `state`, `enabled`, `visible`, `width`, `height`, `x`, `y`, `z`, `focus`, `clip` collide with QML properties — use `label` etc.
 - **IME last-word drop**: call `Keyboard.commit()` before reading any `TextField.text` from a button handler — otherwise the in-progress word is lost on mobile. (`Keyboard` is a compile-time singleton, `src/core/keyboard.h`. It replaced `Qt.inputMethod`, which qmllint types as a bare `QObject` — so a typo in the call was uncheckable, and its failure mode is silent.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,10 +147,12 @@ colour glyph reach the platform renderer, which **crashes the render thread on m
   can be several things in a file (a function-local `var step` and a nested `property var step`),
   and only the flagged occurrences may move.
 - **A nested event loop reachable from a QML signal handler is a crash, not a slowdown.**
-  `processEvents()` / `exec()` below a handler delivers queued `DeferredDelete`s, so an object can
-  be destroyed mid-handler and Qt answers with `qFatal()` — shipped iOS 2.0.0 aborted this way
+  `processEvents()` / `exec()` below a handler delivers queued events, and one that destroys an
+  object whose handler is still running makes Qt `qFatal()`
+  (`qtdeclarative/src/qml/qml/qqmlengine.cpp:1370-1396`) — shipped iOS 2.0.0 aborted this way
   (#1692). Long work goes on a worker thread with results posted back queued, never pumped inline;
-  a progress bar is not a reason to pump. Full chain in `QML_GOTCHAS.md`.
+  a progress bar is not a reason to pump. Which posted event did it is NOT established, and the
+  obvious guess (a `DeferredDelete`) is gated — see `QML_GOTCHAS.md` for the sources.
 - **Font property conflict**: don't mix `font: Theme.bodyFont` with `font.bold: true` — assign sub-properties individually.
 - **Reserved names in JS model data**: `name`, `parent`, `children`, `data`, `state`, `enabled`, `visible`, `width`, `height`, `x`, `y`, `z`, `focus`, `clip` collide with QML properties — use `label` etc.
 - **IME last-word drop**: call `Keyboard.commit()` before reading any `TextField.text` from a button handler — otherwise the in-progress word is lost on mobile. (`Keyboard` is a compile-time singleton, `src/core/keyboard.h`. It replaced `Qt.inputMethod`, which qmllint types as a bare `QObject` — so a typo in the call was uncheckable, and its failure mode is silent.)

--- a/docs/CLAUDE_MD/QML_GOTCHAS.md
+++ b/docs/CLAUDE_MD/QML_GOTCHAS.md
@@ -485,37 +485,60 @@ Debug, while working on exactly the two configurations it gets tested on.
 
 ## A nested event loop reachable from a QML signal handler is a crash, not a slowdown
 
-`QCoreApplication::processEvents()` (and anything that spins its own `QEventLoop` —
-`QDialog::exec()`, a blocking `QNetworkReply` wait) is not "the same work with the UI kept
-responsive". It delivers **queued events**, and one of those is `DeferredDelete`. If the call sits
-anywhere below a QML signal handler on the stack, an object that handler belongs to can be
-destroyed while the handler is still running. Qt does not limp on from that — `QQmlData::destroyed()`
-calls **`qFatal()`**:
+`QCoreApplication::processEvents()` (and anything that spins its own `QEventLoop` — a
+`QEventLoop::exec()` wrapped around a network reply, a `QThread::wait()` on the GUI thread) is not
+"the same work with the UI kept responsive". It delivers **queued events** while a QML signal
+handler is still on the stack, and if one of them destroys an object that handler belongs to, Qt
+does not limp on — `QQmlData::destroyed()` calls **`qFatal()`**
+(`qtdeclarative/src/qml/qml/qqmlengine.cpp:1370-1396`):
 
 ```
 Object 0x12a0fa680 destroyed while one of its QML signal handlers is in progress.
 Most likely the object was deleted synchronously (use QObject::deleteLater() instead), or the
-application is running a nested event loop. This behavior is NOT supported!
-qrc:/qt/qml/Decenza/qml/pages/SettingsPage.qml:106
+application is running a nested event loop.
+This behavior is NOT supported!
+qrc:/qt/qml/Decenza/qml/pages/SettingsPage.qml:106: function() { [native code] }
 ```
 
-That is issue #1692, on shipped iOS 2.0.0, as a **SIGABRT** — not the SIGSEGV every other crash
-report in the tracker is. The chain was five frames long and none of it looks dangerous in
+(abridged — Qt appends up to 96 characters of the handler's own source to the location line.)
+
+That is issue #1692, on shipped iOS 2.0.0, as a **SIGABRT** rather than the SIGSEGV most crash
+reports show. Symbolicated, the chain is five frames long and none of it looks dangerous in
 isolation:
 
 ```
 TabBar.onCurrentIndexChanged  ->  markTabLoaded() writes loadedTabs
-  -> Loader.active binding -> QQmlComponent::create (SYNCHRONOUS incubation)
+  -> Loader.active binding -> QQmlComponent::create  (SYNCHRONOUS: SettingsPage sets
+                                                      asynchronous: false on the tab Loaders)
     -> SettingsLanguageTab.Component.onCompleted -> TranslationManager::scanAllStrings()
-      -> processEvents()   <-- nested loop
-        -> queued DeferredDelete for the outgoing SettingsPage is delivered here
-          -> ~QQuickPage deletes its children, incl. the TabBar whose handler is still running
+      -> processEvents()   <-- nested pump
+        -> QCoreApplicationPrivate::sendPostedEvents -> QObject::event
+          -> ~QQmlElement<QQuickPage> deletes its children, incl. the TabBar still in its handler
 ```
 
-Note what the nested loop did **not** need: no dialog, no user interaction, no second thread. A
-page transition had already queued the `deleteLater`; the scan merely gave it a place to land.
+(`SettingsPage.qml:106` was `onCurrentIndexChanged` in v2.0.0; the handler is further down the
+file on main today. Go by the name, not the number.)
 
-Rules that follow:
+**What is established and what is not.** The stack proves an event delivered inside the pump
+destroyed the page — `QObject::event` deletes on `DeferredDelete` at `qobject.cpp:1463-1464`. It
+does **not** prove *which* posted event, and the obvious story is the one Qt guards against: a bare
+`processEvents()` normally will NOT deliver a queued `DeferredDelete`. `qcoreapplication.cpp:1858-1873`
+allows one through only when it was posted at a deeper loop+scope level than the pump, or before
+the outermost loop, or when `DeferredDelete` is passed explicitly; `qobject.cpp:2534-2557` records
+those levels specifically so that
+
+```cpp
+foo->deleteLater();
+qApp->processEvents();   // without passing QEvent::DeferredDelete
+```
+
+does not delete `foo`. So either one of those clauses held on the device, or the destroyer was a
+different queued event — a queued signal, a timer, a `Loader` status change — that deleted
+synchronously. Qt's own message lists "deleted synchronously" first for that reason. Do not repeat
+the tidier version of this story as fact; it is the version this file shipped with and it does not
+survive the sources.
+
+The rule survives the uncertainty, and it is the part that matters:
 
 - Long work reachable from QML goes on a **worker thread** with results posted back via
   `QMetaObject::invokeMethod(..., Qt::QueuedConnection)`, or is chunked across event-loop turns.
@@ -523,6 +546,7 @@ Rules that follow:
 - A progress bar is not a reason to pump. If the UI needs to animate during the work, that is
   precisely the case that needs the work off the calling stack.
 - This is invisible in the UI and in a normal test run — it needs a pending delete to coincide.
-  Pin the asynchrony with a test (`tests/tst_translationscan.cpp` asserts the call has NOT
-  completed when it returns), because "make it synchronous again, it's simpler" reads as a
+  Pin the asynchrony with a test (`tests/tst_translationscan.cpp` posts a sentinel queued event and
+  asserts it has NOT run when the call returns, which is an assertion about the event queue rather
+  than about when a signal arrives), because "make it synchronous again, it's simpler" reads as a
   harmless cleanup.

--- a/docs/CLAUDE_MD/QML_GOTCHAS.md
+++ b/docs/CLAUDE_MD/QML_GOTCHAS.md
@@ -482,3 +482,47 @@ affected while `GHCSimulator`'s were. `GHCSimulator` is registered wherever `DEC
 defined (every desktop config) but instanced only on a **debug** Windows/macOS build, so the broken
 guard passed — and threw on every window activation — on Linux, on Release desktop and on mobile
 Debug, while working on exactly the two configurations it gets tested on.
+
+## A nested event loop reachable from a QML signal handler is a crash, not a slowdown
+
+`QCoreApplication::processEvents()` (and anything that spins its own `QEventLoop` —
+`QDialog::exec()`, a blocking `QNetworkReply` wait) is not "the same work with the UI kept
+responsive". It delivers **queued events**, and one of those is `DeferredDelete`. If the call sits
+anywhere below a QML signal handler on the stack, an object that handler belongs to can be
+destroyed while the handler is still running. Qt does not limp on from that — `QQmlData::destroyed()`
+calls **`qFatal()`**:
+
+```
+Object 0x12a0fa680 destroyed while one of its QML signal handlers is in progress.
+Most likely the object was deleted synchronously (use QObject::deleteLater() instead), or the
+application is running a nested event loop. This behavior is NOT supported!
+qrc:/qt/qml/Decenza/qml/pages/SettingsPage.qml:106
+```
+
+That is issue #1692, on shipped iOS 2.0.0, as a **SIGABRT** — not the SIGSEGV every other crash
+report in the tracker is. The chain was five frames long and none of it looks dangerous in
+isolation:
+
+```
+TabBar.onCurrentIndexChanged  ->  markTabLoaded() writes loadedTabs
+  -> Loader.active binding -> QQmlComponent::create (SYNCHRONOUS incubation)
+    -> SettingsLanguageTab.Component.onCompleted -> TranslationManager::scanAllStrings()
+      -> processEvents()   <-- nested loop
+        -> queued DeferredDelete for the outgoing SettingsPage is delivered here
+          -> ~QQuickPage deletes its children, incl. the TabBar whose handler is still running
+```
+
+Note what the nested loop did **not** need: no dialog, no user interaction, no second thread. A
+page transition had already queued the `deleteLater`; the scan merely gave it a place to land.
+
+Rules that follow:
+
+- Long work reachable from QML goes on a **worker thread** with results posted back via
+  `QMetaObject::invokeMethod(..., Qt::QueuedConnection)`, or is chunked across event-loop turns.
+  Never pumped inline. `TranslationManager::scanAllStrings()` is the worked example.
+- A progress bar is not a reason to pump. If the UI needs to animate during the work, that is
+  precisely the case that needs the work off the calling stack.
+- This is invisible in the UI and in a normal test run — it needs a pending delete to coincide.
+  Pin the asynchrony with a test (`tests/tst_translationscan.cpp` asserts the call has NOT
+  completed when it returns), because "make it synchronous again, it's simpler" reads as a
+  harmless cleanup.

--- a/src/core/translationmanager.cpp
+++ b/src/core/translationmanager.cpp
@@ -163,8 +163,17 @@ TranslationManager::~TranslationManager()
     // The string-scan worker posts progress and its results back to this object, so it must not
     // outlive it. Nothing else waits on it — the scan is pure parsing over compiled-in qrc data,
     // so the worst case here is the parse of the remaining files, not a blocking I/O wait.
+    //
+    // The bounded wait is not belt-and-braces: wait() returns a bool that Qt does not annotate,
+    // so a dropped `false` would be invisible to -Werror=unused-result while leaving a thread
+    // about to post to an object entering ~QObject — the exact UB this line exists to prevent.
     if (m_scanThread && m_scanThread->isRunning()) {
-        m_scanThread->wait();
+        if (!m_scanThread->wait(10000)) {
+            qWarning() << "TranslationManager: the string-scan worker has not exited 10s into"
+                       << "destruction. Waiting on it regardless — the alternative is a thread"
+                       << "posting to a destroyed object.";
+            (void)m_scanThread->wait();
+        }
     }
 }
 
@@ -611,7 +620,12 @@ void TranslationManager::registerString(const QString& key, const QString& fallb
 // This runs when entering the Language settings page.
 void TranslationManager::scanAllStrings()
 {
+    // Not a refusal: the in-flight scan will emit scanFinished(), and that IS this caller's
+    // answer. The contract is that a caller connects BEFORE calling, never after — see
+    // translateAndUploadAllLanguages(), which parks on the signal first and only then asks for a
+    // scan. A caller that connects afterwards waits forever whenever it lost the race.
     if (m_scanning) {
+        qDebug() << "TranslationManager: string scan already running; joining the in-flight scan.";
         return;
     }
 
@@ -656,6 +670,7 @@ void TranslationManager::scanAllStrings()
     QThread* worker = QThread::create([this, qmlFiles]() {
         QList<ScannedString> found;
         QSet<QString> seenInQml;
+        QStringList unreadable;
         int filesDone = 0;
 
         for (const QString& filePath : qmlFiles) {
@@ -669,6 +684,11 @@ void TranslationManager::scanAllStrings()
                     seenInQml.insert(s.key);
                     found.append(s);
                 }
+            } else {
+                // A file we cannot read contributes nothing and would otherwise be indistinguishable
+                // from one that legitimately holds no strings — the scan would reach 100% and
+                // report success over a short registry, which is then AI-translated and uploaded.
+                unreadable << QStringLiteral("%1 (%2)").arg(filePath, file.errorString());
             }
 
             ++filesDone;
@@ -678,12 +698,29 @@ void TranslationManager::scanAllStrings()
             }, Qt::QueuedConnection);
         }
 
-        QMetaObject::invokeMethod(this, [this, found, seenInQml]() {
-            applyScanResults(found, seenInQml);
+        QMetaObject::invokeMethod(this, [this, found, seenInQml, unreadable]() {
+            applyScanResults(found, seenInQml, unreadable);
         }, Qt::QueuedConnection);
     });
 
     m_scanThread = worker;
+
+    // The results are posted before run() returns, so they are queued AHEAD of finished() on the
+    // main thread: reaching this slot with m_scanning still set means the worker died — or never
+    // started — without posting. Without it, m_scanning would stay true forever, the Language
+    // page's modal scanning overlay would never clear, every later scanAllStrings() would
+    // early-return, and anything parked on scanFinished() would wait for a signal that is not
+    // coming. QThread::start() can itself fail and only warns.
+    connect(worker, &QThread::finished, this, [this]() {
+        if (!m_scanning)
+            return;   // normal path: applyScanResults already ran
+        qWarning() << "TranslationManager: the string-scan worker exited without posting a result."
+                   << "The registry was not updated, so AI translation and community upload will"
+                   << "be working from an incomplete list.";
+        m_scanning = false;
+        emit scanningChanged();
+        emit scanFinished(0);   // release anything parked on it rather than hang
+    });
     connect(worker, &QThread::finished, worker, &QObject::deleteLater);
     worker->start();
 }
@@ -694,9 +731,11 @@ QList<TranslationManager::ScannedString> TranslationManager::parseTranslatableSt
 {
     QList<ScannedString> found;
 
-    // Built per call rather than kept static: this runs on the scan's worker thread, and a few
-    // microseconds of PCRE compile per file is not measurable against regexing the file itself.
-
+    // Built per call, not kept static: QRegularExpression is documented reentrant, not
+    // thread-safe (qtbase/src/corelib/text/qregularexpression.cpp:34), so a shared instance is a
+    // promise Qt does not make. A few microseconds of PCRE compile per file is not measurable
+    // against regexing the file itself.
+    //
     // Pattern 1: Direct translate() calls - translate("key", "fallback")
     QRegularExpression directCallRegex("translate\\s*\\(\\s*\"([^\"\\n]+)\"\\s*,\\s*\"([^\"\\n]+)\"\\s*\\)");
 
@@ -827,13 +866,14 @@ QList<TranslationManager::ScannedString> TranslationManager::parseTranslatableSt
     return found;
 }
 
-void TranslationManager::applyScanResults(const QList<ScannedString>& found, const QSet<QString>& seenInQml)
+void TranslationManager::applyScanResults(const QList<ScannedString>& found, const QSet<QString>& seenInQml,
+                                          const QStringList& unreadableFiles)
 {
     int stringsFound = 0;
     const qsizetype initialCount = m_stringRegistry.size();
 
-    // In file order, so a key used with two different fallbacks resolves the same way it did
-    // when this loop was interleaved with the parsing.
+    // In scan order (per file, then pattern 1, 2, 3), so a key used with two different fallbacks
+    // resolves the same way it did when this loop was interleaved with the parsing.
     for (const ScannedString& s : found) {
         if (noteSourceString(s.key, s.fallback)) {
             stringsFound++;
@@ -849,6 +889,20 @@ void TranslationManager::applyScanResults(const QList<ScannedString>& found, con
         emit totalStringCountChanged();
     }
 
+    // A file the scan could not read is not a cosmetic loss: the registry it feeds is what the AI
+    // translator is prompted with and what a community upload publishes, so a short scan spreads
+    // outward exactly the way the ":/qml" wrong-root bug did.
+    if (!unreadableFiles.isEmpty()) {
+        qWarning().noquote() << "TranslationManager: string scan could not read"
+                             << unreadableFiles.size() << "of" << m_scanTotal << "QML files. The"
+                             << "registry is INCOMPLETE — AI translation and community upload will"
+                             << "be working from a short list:"
+                             << "\n    " + unreadableFiles.join(QStringLiteral("\n    "));
+    }
+
+    // Both flags settle BEFORE the signal. translateAndUploadAllLanguages() re-enters from inside
+    // this emit and re-tests m_scanCompleted; set it afterwards and the batch re-parks, rescans,
+    // and loops scan -> translate -> scan forever. tst_translationscan pins the order.
     m_scanning = false;
     m_scanCompleted = true;
     emit scanningChanged();
@@ -3446,6 +3500,23 @@ void TranslationManager::translateAndUploadAllLanguages()
             m_batchAwaitingScan = true;
             connect(this, &TranslationManager::scanFinished, this, [this](int) {
                 m_batchAwaitingScan = false;
+
+                // The park opens a window the inline scan never had: an AI translation or an
+                // upload can start during it, and the re-entry would then hit the guard at the
+                // top of this function, qDebug, and return — with the single-shot connection
+                // already spent. The button press would evaporate with nothing on screen and no
+                // signal. Say so instead.
+                if (m_batchProcessing || m_autoTranslating || m_uploading) {
+                    m_lastError = QStringLiteral(
+                        "The batch translate and upload was waiting for the QML string scan to "
+                        "finish, but %1 started in the meantime. Wait for that to finish, then "
+                        "press the button again.")
+                        .arg(m_autoTranslating ? QStringLiteral("an AI translation")
+                                               : QStringLiteral("an upload"));
+                    emit lastErrorChanged();
+                    emit batchTranslateUploadFinished(false, m_lastError);
+                    return;
+                }
                 translateAndUploadAllLanguages();
             }, Qt::SingleShotConnection);
         }

--- a/src/core/translationmanager.cpp
+++ b/src/core/translationmanager.cpp
@@ -18,7 +18,7 @@
 #include <QNetworkInformation>
 #include <QSet>
 #include <QRegularExpression>
-#include <QCoreApplication>
+#include <QThread>
 #include <functional>
 #include <memory>
 
@@ -156,6 +156,16 @@ TranslationManager::TranslationManager(QNetworkAccessManager* networkManager, Se
              << "AI Translations:" << m_aiTranslations.size();
 
     scheduleLanguageUpdateCheck();
+}
+
+TranslationManager::~TranslationManager()
+{
+    // The string-scan worker posts progress and its results back to this object, so it must not
+    // outlive it. Nothing else waits on it — the scan is pure parsing over compiled-in qrc data,
+    // so the worst case here is the parse of the remaining files, not a blocking I/O wait.
+    if (m_scanThread && m_scanThread->isRunning()) {
+        m_scanThread->wait();
+    }
 }
 
 // Merge community translations for the active language, once per launch, as soon as there is
@@ -640,6 +650,53 @@ void TranslationManager::scanAllStrings()
     }
     qDebug() << "Scanning" << m_scanTotal << "QML files for translatable strings...";
 
+    // Parse off the main thread. The registry is NOT touched here — the worker only reads the
+    // (read-only, compiled-in) qrc files and returns pairs; noteSourceString() and everything
+    // else that mutates state runs in applyScanResults() back on the main thread.
+    QThread* worker = QThread::create([this, qmlFiles]() {
+        QList<ScannedString> found;
+        QSet<QString> seenInQml;
+        int filesDone = 0;
+
+        for (const QString& filePath : qmlFiles) {
+            QFile file(filePath);
+            if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                const QString content = QString::fromUtf8(file.readAll());
+                file.close();
+
+                const QList<ScannedString> inFile = parseTranslatableStrings(content);
+                for (const ScannedString& s : inFile) {
+                    seenInQml.insert(s.key);
+                    found.append(s);
+                }
+            }
+
+            ++filesDone;
+            QMetaObject::invokeMethod(this, [this, filesDone]() {
+                m_scanProgress = filesDone;
+                emit scanProgressChanged();
+            }, Qt::QueuedConnection);
+        }
+
+        QMetaObject::invokeMethod(this, [this, found, seenInQml]() {
+            applyScanResults(found, seenInQml);
+        }, Qt::QueuedConnection);
+    });
+
+    m_scanThread = worker;
+    connect(worker, &QThread::finished, worker, &QObject::deleteLater);
+    worker->start();
+}
+
+// Runs on the scan's worker thread. Touches no member, emits no signal, does no I/O — keep it
+// that way, or the crash this split was made to fix comes back by another route.
+QList<TranslationManager::ScannedString> TranslationManager::parseTranslatableStrings(const QString& content)
+{
+    QList<ScannedString> found;
+
+    // Built per call rather than kept static: this runs on the scan's worker thread, and a few
+    // microseconds of PCRE compile per file is not measurable against regexing the file itself.
+
     // Pattern 1: Direct translate() calls - translate("key", "fallback")
     QRegularExpression directCallRegex("translate\\s*\\(\\s*\"([^\"\\n]+)\"\\s*,\\s*\"([^\"\\n]+)\"\\s*\\)");
 
@@ -664,134 +721,123 @@ void TranslationManager::scanAllStrings()
     QRegularExpression trKeyRegex("\\bkey\\s*:\\s*\"([^\"\\n]+)\"");
     QRegularExpression trFallbackRegex("\\bfallback\\s*:\\s*\"([^\"\\n]+)\"");
 
-    int stringsFound = 0;
-    qsizetype initialCount = m_stringRegistry.size();
-    QSet<QString> seenInQml;
+    // Pattern 1: Direct translate() calls
+    QRegularExpressionMatchIterator matchIt = directCallRegex.globalMatch(content);
+    while (matchIt.hasNext()) {
+        QRegularExpressionMatch match = matchIt.next();
+        QString key = match.captured(1);
+        QString fallback = match.captured(2);
 
-    for (const QString& filePath : qmlFiles) {
-        QFile file(filePath);
-        if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-            QString content = QString::fromUtf8(file.readAll());
-            file.close();
+        // Unescape common escape sequences
+        key = unescapeQmlLiteral(key);
+        fallback = unescapeQmlLiteral(fallback);
 
-            // Pattern 1: Direct translate() calls
-            QRegularExpressionMatchIterator matchIt = directCallRegex.globalMatch(content);
-            while (matchIt.hasNext()) {
-                QRegularExpressionMatch match = matchIt.next();
-                QString key = match.captured(1);
-                QString fallback = match.captured(2);
+        if (!key.trimmed().isEmpty() && !fallback.trimmed().isEmpty()) {
+            found.append({key, fallback});
+        }
+    }
 
-                // Unescape common escape sequences
+    // Pattern 2: Property-based translations (translationKey + translationFallback pairs)
+    // Collect all keys and fallbacks, then match them by proximity in the file
+    QMap<qsizetype, QString> keyPositions;  // position -> key
+    QMap<qsizetype, QString> fallbackPositions;  // position -> fallback
+
+    QRegularExpressionMatchIterator keyIt = propKeyRegex.globalMatch(content);
+    while (keyIt.hasNext()) {
+        QRegularExpressionMatch match = keyIt.next();
+        keyPositions[match.capturedStart()] = match.captured(1);
+    }
+
+    QRegularExpressionMatchIterator fallbackIt = propFallbackRegex.globalMatch(content);
+    while (fallbackIt.hasNext()) {
+        QRegularExpressionMatch match = fallbackIt.next();
+        fallbackPositions[match.capturedStart()] = match.captured(1);
+    }
+
+    // Match keys with their nearest following fallback
+    for (auto posIt = keyPositions.constBegin(); posIt != keyPositions.constEnd(); ++posIt) {
+        qsizetype keyPos = posIt.key();
+        QString key = posIt.value();
+
+        // Find the nearest fallback after this key (within 200 chars)
+        for (auto fbIt = fallbackPositions.constBegin(); fbIt != fallbackPositions.constEnd(); ++fbIt) {
+            qsizetype fbPos = fbIt.key();
+            if (fbPos > keyPos && fbPos - keyPos < 200) {
+                QString fallback = fbIt.value();
+
+                // Unescape
                 key = unescapeQmlLiteral(key);
                 fallback = unescapeQmlLiteral(fallback);
 
                 if (!key.trimmed().isEmpty() && !fallback.trimmed().isEmpty()) {
-                    seenInQml.insert(key);
-                    if (noteSourceString(key, fallback)) {
-                        stringsFound++;
-                    }
+                    found.append({key, fallback});
                 }
+                break;  // Found the matching fallback
             }
+        }
+    }
 
-            // Pattern 2: Property-based translations (translationKey + translationFallback pairs)
-            // Collect all keys and fallbacks, then match them by proximity in the file
-            QMap<qsizetype, QString> keyPositions;  // position -> key
-            QMap<qsizetype, QString> fallbackPositions;  // position -> fallback
+    // Pattern 3: Tr component's key/fallback properties
+    QMap<qsizetype, QString> trKeyPositions;
+    QMap<qsizetype, QString> trFallbackPositions;
 
-            QRegularExpressionMatchIterator keyIt = propKeyRegex.globalMatch(content);
-            while (keyIt.hasNext()) {
-                QRegularExpressionMatch match = keyIt.next();
-                keyPositions[match.capturedStart()] = match.captured(1);
-            }
+    QRegularExpressionMatchIterator trKeyIt = trKeyRegex.globalMatch(content);
+    while (trKeyIt.hasNext()) {
+        QRegularExpressionMatch match = trKeyIt.next();
+        trKeyPositions[match.capturedStart()] = match.captured(1);
+    }
 
-            QRegularExpressionMatchIterator fallbackIt = propFallbackRegex.globalMatch(content);
-            while (fallbackIt.hasNext()) {
-                QRegularExpressionMatch match = fallbackIt.next();
-                fallbackPositions[match.capturedStart()] = match.captured(1);
-            }
+    QRegularExpressionMatchIterator trFallbackIt = trFallbackRegex.globalMatch(content);
+    while (trFallbackIt.hasNext()) {
+        QRegularExpressionMatch match = trFallbackIt.next();
+        trFallbackPositions[match.capturedStart()] = match.captured(1);
+    }
 
-            // Match keys with their nearest following fallback
-            for (auto posIt = keyPositions.constBegin(); posIt != keyPositions.constEnd(); ++posIt) {
-                qsizetype keyPos = posIt.key();
-                QString key = posIt.value();
+    // Match keys with their nearest fallback (within 200 chars, in either direction)
+    for (auto posIt = trKeyPositions.constBegin(); posIt != trKeyPositions.constEnd(); ++posIt) {
+        qsizetype keyPos = posIt.key();
+        QString key = posIt.value();
 
-                // Find the nearest fallback after this key (within 200 chars)
-                for (auto fbIt = fallbackPositions.constBegin(); fbIt != fallbackPositions.constEnd(); ++fbIt) {
-                    qsizetype fbPos = fbIt.key();
-                    if (fbPos > keyPos && fbPos - keyPos < 200) {
-                        QString fallback = fbIt.value();
+        // Find the nearest fallback (can be before or after the key)
+        QString fallback;
+        qsizetype minDistance = 200;
 
-                        // Unescape
-                        key = unescapeQmlLiteral(key);
-                        fallback = unescapeQmlLiteral(fallback);
-
-                        if (!key.trimmed().isEmpty() && !fallback.trimmed().isEmpty()) {
-                            seenInQml.insert(key);
-                            if (noteSourceString(key, fallback)) {
-                                stringsFound++;
-                            }
-                        }
-                        break;  // Found the matching fallback
-                    }
-                }
-            }
-
-            // Pattern 3: Tr component's key/fallback properties
-            QMap<qsizetype, QString> trKeyPositions;
-            QMap<qsizetype, QString> trFallbackPositions;
-
-            QRegularExpressionMatchIterator trKeyIt = trKeyRegex.globalMatch(content);
-            while (trKeyIt.hasNext()) {
-                QRegularExpressionMatch match = trKeyIt.next();
-                trKeyPositions[match.capturedStart()] = match.captured(1);
-            }
-
-            QRegularExpressionMatchIterator trFallbackIt = trFallbackRegex.globalMatch(content);
-            while (trFallbackIt.hasNext()) {
-                QRegularExpressionMatch match = trFallbackIt.next();
-                trFallbackPositions[match.capturedStart()] = match.captured(1);
-            }
-
-            // Match keys with their nearest fallback (within 200 chars, in either direction)
-            for (auto posIt = trKeyPositions.constBegin(); posIt != trKeyPositions.constEnd(); ++posIt) {
-                qsizetype keyPos = posIt.key();
-                QString key = posIt.value();
-
-                // Find the nearest fallback (can be before or after the key)
-                QString fallback;
-                qsizetype minDistance = 200;
-
-                for (auto fbIt = trFallbackPositions.constBegin(); fbIt != trFallbackPositions.constEnd(); ++fbIt) {
-                    qsizetype fbPos = fbIt.key();
-                    qsizetype distance = qAbs(fbPos - keyPos);
-                    if (distance < minDistance) {
-                        minDistance = distance;
-                        fallback = fbIt.value();
-                    }
-                }
-
-                if (!fallback.trimmed().isEmpty()) {
-                    // Unescape
-                    QString keyClean = key;
-                    QString fallbackClean = fallback;
-                    keyClean = unescapeQmlLiteral(keyClean);
-                    fallbackClean = unescapeQmlLiteral(fallbackClean);
-
-                    if (!keyClean.trimmed().isEmpty() && !fallbackClean.trimmed().isEmpty()) {
-                        seenInQml.insert(keyClean);
-                        if (noteSourceString(keyClean, fallbackClean)) {
-                            stringsFound++;
-                        }
-                    }
-                }
+        for (auto fbIt = trFallbackPositions.constBegin(); fbIt != trFallbackPositions.constEnd(); ++fbIt) {
+            qsizetype fbPos = fbIt.key();
+            qsizetype distance = qAbs(fbPos - keyPos);
+            if (distance < minDistance) {
+                minDistance = distance;
+                fallback = fbIt.value();
             }
         }
 
-        m_scanProgress++;
-        emit scanProgressChanged();
+        if (!fallback.trimmed().isEmpty()) {
+            // Unescape
+            QString keyClean = key;
+            QString fallbackClean = fallback;
+            keyClean = unescapeQmlLiteral(keyClean);
+            fallbackClean = unescapeQmlLiteral(fallbackClean);
 
-        // Process events to keep UI responsive
-        QCoreApplication::processEvents();
+            if (!keyClean.trimmed().isEmpty() && !fallbackClean.trimmed().isEmpty()) {
+                found.append({keyClean, fallbackClean});
+            }
+        }
+    }
+
+    return found;
+}
+
+void TranslationManager::applyScanResults(const QList<ScannedString>& found, const QSet<QString>& seenInQml)
+{
+    int stringsFound = 0;
+    const qsizetype initialCount = m_stringRegistry.size();
+
+    // In file order, so a key used with two different fallbacks resolves the same way it did
+    // when this loop was interleaved with the parsing.
+    for (const ScannedString& s : found) {
+        if (noteSourceString(s.key, s.fallback)) {
+            stringsFound++;
+        }
     }
 
     // Save the updated registry
@@ -804,6 +850,7 @@ void TranslationManager::scanAllStrings()
     }
 
     m_scanning = false;
+    m_scanCompleted = true;
     emit scanningChanged();
     emit scanFinished(static_cast<int>(m_stringRegistry.size() - initialCount));
 
@@ -3390,14 +3437,27 @@ void TranslationManager::translateAndUploadAllLanguages()
         return;
     }
 
+    // Ensure all strings are scanned first. The scan is asynchronous now (see scanAllStrings),
+    // so park the batch on scanFinished() and restart it from the top rather than proceeding
+    // with whatever the registry happened to hold — the whole point of the scan here is that the
+    // batch translates the COMPLETE string list, not just the screens this device has rendered.
+    if (!m_scanCompleted) {
+        if (!m_batchAwaitingScan) {
+            m_batchAwaitingScan = true;
+            connect(this, &TranslationManager::scanFinished, this, [this](int) {
+                m_batchAwaitingScan = false;
+                translateAndUploadAllLanguages();
+            }, Qt::SingleShotConnection);
+        }
+        if (!m_scanning) {
+            scanAllStrings();
+        }
+        return;
+    }
+
     // Save original provider AND language to restore later — the batch switches both.
     m_originalProvider = m_settings->ai()->aiProvider();
     m_originalLanguage = m_currentLanguage;
-
-    // Ensure all strings are scanned first
-    if (!m_scanning) {
-        scanAllStrings();
-    }
 
     // Build list of all local (non-remote, non-English) languages
     QStringList allLanguages;

--- a/src/core/translationmanager.h
+++ b/src/core/translationmanager.h
@@ -185,19 +185,34 @@ public:
 
     Q_INVOKABLE void registerString(const QString& key, const QString& fallback);
 
-    // Starts the scan and returns IMMEDIATELY — the parsing runs on a worker thread and the
-    // registry is written from a queued callback on the main thread. Watch `scanning` /
-    // `scanProgress`, or the scanFinished() signal, for completion.
+    // Returns without doing the parsing: it enumerates the qrc tree on the calling thread, hands
+    // the file list to a worker, and writes the registry from a queued callback on the main
+    // thread. Watch `scanning` / `scanProgress`, or the scanFinished() signal, for completion.
     //
     // It used to be synchronous, and pumped QCoreApplication::processEvents() once per file "to
-    // keep the UI responsive". That nested event loop crashed the app (#1692, SIGABRT): the scan
-    // is kicked off from SettingsLanguageTab's Component.onCompleted, which QML incubates
-    // synchronously while SettingsPage's TabBar.onCurrentIndexChanged handler is still on the
-    // stack. A DeferredDelete already queued for the outgoing SettingsPage was then delivered
-    // inside the nested loop, destroying the TabBar mid-handler, and Qt's QQmlData::destroyed()
-    // calls qFatal() for exactly that ("Object destroyed while one of its QML signal handlers is
-    // in progress"). Any nested event loop reachable from a QML signal handler can do this —
-    // do not reintroduce one here.
+    // keep the UI responsive". That nested pump crashed the app (#1692, SIGABRT): the scan is
+    // kicked off from SettingsLanguageTab's Component.onCompleted, which QML incubates
+    // synchronously (SettingsPage.qml sets `asynchronous: false` on the tab Loaders) while
+    // SettingsPage's TabBar.onCurrentIndexChanged handler is still on the stack. The symbolicated
+    // stack then shows QCoreApplicationPrivate::sendPostedEvents -> QObject::event ->
+    // ~QQmlElement<QQuickPage>, i.e. the outgoing page was destroyed inside the pump, taking its
+    // TabBar with it; QObject::event deletes on DeferredDelete at qobject.cpp:1463-1464. Qt turns
+    // a destroy-during-signal-handler into an abort, not a warning:
+    // qtdeclarative/src/qml/qml/qqmlengine.cpp:1370-1396 (QQmlData::destroyed() -> qFatal() when
+    // the handler isNotifying()).
+    //
+    // What is NOT established is which posted event did it. A bare processEvents() normally will
+    // NOT deliver a queued DeferredDelete — qcoreapplication.cpp:1858-1873 allows one through only
+    // when it was posted at a deeper loop+scope level, or was posted before the outermost loop, or
+    // when DeferredDelete was passed explicitly — and qobject.cpp:2534-2557 records those levels
+    // for exactly the `foo->deleteLater(); qApp->processEvents();` case. So one of those clauses
+    // held on the device, or the destroyer was some other queued event (a queued signal, a timer,
+    // a Loader status change) that deleted synchronously. Qt's own message lists "deleted
+    // synchronously" ahead of the nested loop for that reason.
+    //
+    // The rule survives the uncertainty: a nested pump under a QML signal handler delivers
+    // events that can destroy the object whose handler is running, and the failure is an abort.
+    // Do not reintroduce one here.
     Q_INVOKABLE void scanAllStrings();
 
     // One (key, English fallback) pair lifted out of QML source text by the scanner.
@@ -206,9 +221,11 @@ public:
         QString fallback;
     };
 
-    // Pure text → pairs, in file order, with the same last-write-wins ordering the registry
-    // relies on. Static and state-free so it can run on the scan's worker thread — and so a test
-    // can exercise the three patterns without an instance or the QML resource tree.
+    // Pure text → pairs, in SCAN order: all of pattern 1, then 2, then 3, each positional within
+    // itself. Not file order — do not "fix" it to positional, because that changes which fallback
+    // wins for a key used twice, and the old inline loop applied them in exactly this sequence.
+    // Static and state-free so it can run on the scan's worker thread — and so a test can
+    // exercise the three patterns without an instance or the QML resource tree.
     static QList<ScannedString> parseTranslatableStrings(const QString& qmlSource);
 
     // Public + static so tst_aiproviders can assert these stay equal to each provider's first
@@ -360,8 +377,12 @@ private:
     bool noteSourceString(const QString& key, const QString& fallback);
 
     // Main-thread tail of scanAllStrings(): writes what the worker parsed into the registry,
-    // saves, and reports. m_stringRegistry is only ever touched here, never on the worker.
-    void applyScanResults(const QList<ScannedString>& found, const QSet<QString>& seenInQml);
+    // saves, and reports. Nothing on the worker thread touches m_stringRegistry — the scan's
+    // writes all happen here. `unreadableFiles` are the QML files the worker could not open;
+    // they make the registry short, which matters because it is what gets AI-translated and
+    // published, so they are reported rather than swallowed.
+    void applyScanResults(const QList<ScannedString>& found, const QSet<QString>& seenInQml,
+                          const QStringList& unreadableFiles);
 
     void propagateTranslationsToAllKeys();
     void recalculateUntranslatedCount();
@@ -566,5 +587,10 @@ private:
     // `if (!openaiApiKey().isEmpty())` would leave the whole suite green while billing a user
     // on an account they did not choose. That is exactly how the retired-model bug survived.
     friend class TestTranslationSourceDrift;
+
+    // The scan's main-thread tail (applyScanResults) and the flags that order it. The ordering
+    // between m_scanCompleted and scanFinished() is what stops the parked bulk translator from
+    // re-parking forever; nothing enforces it but a test that reads both from inside the signal.
+    friend class TestTranslationScan;
 #endif
 };

--- a/src/core/translationmanager.h
+++ b/src/core/translationmanager.h
@@ -6,10 +6,13 @@
 #include <QNetworkReply>
 #include <QMap>
 #include <QVariantMap>
+#include <QPointer>
+#include <QSet>
 #include <QStringList>
 #include <QtQml/qqmlregistration.h>
 
 class QQmlEngine;
+class QThread;
 class Settings;
 
 class TranslationManager : public QObject {
@@ -81,6 +84,7 @@ class TranslationManager : public QObject {
 
 public:
     explicit TranslationManager(QNetworkAccessManager* networkManager, Settings* settings, QObject* parent = nullptr);
+    ~TranslationManager() override;
 
     // QML_SINGLETON hooks. The engine does NOT create this object: main.cpp owns it on the
     // stack and wires it into eight other subsystems (BLE, MCP, AI, backup, accessibility …)
@@ -180,7 +184,32 @@ public:
     static QString unescapeQmlLiteral(const QString& literal);
 
     Q_INVOKABLE void registerString(const QString& key, const QString& fallback);
+
+    // Starts the scan and returns IMMEDIATELY — the parsing runs on a worker thread and the
+    // registry is written from a queued callback on the main thread. Watch `scanning` /
+    // `scanProgress`, or the scanFinished() signal, for completion.
+    //
+    // It used to be synchronous, and pumped QCoreApplication::processEvents() once per file "to
+    // keep the UI responsive". That nested event loop crashed the app (#1692, SIGABRT): the scan
+    // is kicked off from SettingsLanguageTab's Component.onCompleted, which QML incubates
+    // synchronously while SettingsPage's TabBar.onCurrentIndexChanged handler is still on the
+    // stack. A DeferredDelete already queued for the outgoing SettingsPage was then delivered
+    // inside the nested loop, destroying the TabBar mid-handler, and Qt's QQmlData::destroyed()
+    // calls qFatal() for exactly that ("Object destroyed while one of its QML signal handlers is
+    // in progress"). Any nested event loop reachable from a QML signal handler can do this —
+    // do not reintroduce one here.
     Q_INVOKABLE void scanAllStrings();
+
+    // One (key, English fallback) pair lifted out of QML source text by the scanner.
+    struct ScannedString {
+        QString key;
+        QString fallback;
+    };
+
+    // Pure text → pairs, in file order, with the same last-write-wins ordering the registry
+    // relies on. Static and state-free so it can run on the scan's worker thread — and so a test
+    // can exercise the three patterns without an instance or the QML resource tree.
+    static QList<ScannedString> parseTranslatableStrings(const QString& qmlSource);
 
     // Public + static so tst_aiproviders can assert these stay equal to each provider's first
     // catalog entry in aiprovider.cpp. That test is what stops this list going stale again.
@@ -329,6 +358,11 @@ private:
     //
     // Returns true when the registry changed, so callers can decide whether to save.
     bool noteSourceString(const QString& key, const QString& fallback);
+
+    // Main-thread tail of scanAllStrings(): writes what the worker parsed into the registry,
+    // saves, and reports. m_stringRegistry is only ever touched here, never on the worker.
+    void applyScanResults(const QList<ScannedString>& found, const QSet<QString>& seenInQml);
+
     void propagateTranslationsToAllKeys();
     void recalculateUntranslatedCount();
     QString translationsDir() const;
@@ -366,6 +400,16 @@ private:
     bool m_scanning = false;
     int m_scanProgress = 0;
     int m_scanTotal = 0;
+
+    // A scan has finished at least once this session. The bulk translator needs the complete
+    // string list, which it used to get by calling the (then synchronous) scan inline; with an
+    // asynchronous scan it parks itself on scanFinished() instead.
+    bool m_scanCompleted = false;
+    bool m_batchAwaitingScan = false;
+
+    // Null once the worker has finished and deleteLater() has collected it. The destructor waits
+    // on it while it is alive, so a scan can never outlive the object it posts its results to.
+    QPointer<QThread> m_scanThread;
     QString m_lastError;
     QString m_retryStatus;
     QByteArray m_pendingUploadData;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -484,6 +484,16 @@ add_decenza_test(tst_translationsourcedrift
 )
 target_link_libraries(tst_translationsourcedrift PRIVATE Qt6::Qml)
 
+# --- tst_translationscan: the QML string scan, and that it stays off the calling stack ---
+# The scan is what feeds AI translation and community upload, so its three patterns are pinned
+# here. The asynchrony is pinned for a different reason: as a synchronous scan it pumped
+# processEvents() per file, and that nested event loop crashed shipped iOS 2.0.0 (#1692) by
+# letting a queued DeferredDelete destroy the settings TabBar inside its own signal handler.
+add_decenza_test(tst_translationscan
+    tst_translationscan.cpp
+)
+target_link_libraries(tst_translationscan PRIVATE Qt6::Qml)
+
 # --- tst_markdownrenderer: markdown -> HTML, incl. the raw-HTML security claim ---
 add_decenza_test(tst_markdownrenderer
     tst_markdownrenderer.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -487,10 +487,24 @@ target_link_libraries(tst_translationsourcedrift PRIVATE Qt6::Qml)
 # --- tst_translationscan: the QML string scan, and that it stays off the calling stack ---
 # The scan is what feeds AI translation and community upload, so its three patterns are pinned
 # here. The asynchrony is pinned for a different reason: as a synchronous scan it pumped
-# processEvents() per file, and that nested event loop crashed shipped iOS 2.0.0 (#1692) by
-# letting a queued DeferredDelete destroy the settings TabBar inside its own signal handler.
+# processEvents() per file, and that nested pump crashed shipped iOS 2.0.0 (#1692) — an event
+# delivered inside it destroyed the settings page while its TabBar handler was still running.
+#
+# The fixture resource is mounted at the SAME prefix the scanner hardcodes
+# (":/qt/qml/Decenza/qml", src/core/translationmanager.cpp). Without it the app's QML module —
+# which belongs to the Decenza target, not to this binary — is absent, the scan finds zero files,
+# and the worker loop, the file reads, the progress posts and the registry-writing tail all go
+# unexecuted while the tests still pass. This is resource DATA, not a QML harness: nothing here is
+# loaded or instantiated, the scanner reads it as text.
 add_decenza_test(tst_translationscan
     tst_translationscan.cpp
+)
+qt_add_resources(tst_translationscan "translationscan_fixtures"
+    PREFIX "/qt/qml/Decenza/qml"
+    BASE "${CMAKE_CURRENT_SOURCE_DIR}/data/qmlscan"
+    FILES
+        data/qmlscan/AlphaPage.qml
+        data/qmlscan/BetaPage.qml
 )
 target_link_libraries(tst_translationscan PRIVATE Qt6::Qml)
 

--- a/tests/data/qmlscan/AlphaPage.qml
+++ b/tests/data/qmlscan/AlphaPage.qml
@@ -1,0 +1,20 @@
+// Fixture for tst_translationscan. Never compiled or instantiated — the scanner reads QML as
+// TEXT, so this file exists only to be parsed. Keep it small; scale is not coverage.
+import QtQuick
+
+Item {
+    Text { text: TranslationManager.translate("fixture.alpha.title", "Alpha") }
+
+    ActionButton {
+        translationKey: "fixture.alpha.save"
+        translationFallback: "Save"
+    }
+
+    Tr { key: "fixture.alpha.idle"; fallback: "Idle" }
+
+    // One key, two fallbacks, in one file: pattern 1 sees "First", pattern 3 sees "Last". Scan
+    // order is pattern 1 then 3, so "Last" must win — independent of the order the worker
+    // happens to walk the files in.
+    Text { text: TranslationManager.translate("fixture.shared", "First") }
+    Tr { key: "fixture.shared"; fallback: "Last" }
+}

--- a/tests/data/qmlscan/BetaPage.qml
+++ b/tests/data/qmlscan/BetaPage.qml
@@ -1,0 +1,7 @@
+// Second fixture: proves the worker loops over more than one file rather than stopping at the
+// first. Same rules as AlphaPage.qml — text to be parsed, never loaded.
+import QtQuick
+
+Item {
+    Text { text: TranslationManager.translate("fixture.beta.title", "Beta") }
+}

--- a/tests/tst_translationscan.cpp
+++ b/tests/tst_translationscan.cpp
@@ -1,19 +1,22 @@
-// The QML string scan: what it extracts, and that it never runs inline.
+// The QML string scan: what it extracts, and that it never runs on the calling stack.
 //
-// The scan used to be synchronous and pumped QCoreApplication::processEvents() once per file
-// "to keep the UI responsive". That nested event loop is what crashed the shipped 2.0.0 iOS
-// build (issue #1692, SIGABRT): SettingsLanguageTab kicks the scan off from its
-// Component.onCompleted, QML incubates that component synchronously while SettingsPage's
-// TabBar.onCurrentIndexChanged handler is still on the stack, and a DeferredDelete already
-// queued for the outgoing SettingsPage was delivered inside the nested loop — destroying the
-// TabBar mid-handler, which Qt turns into a qFatal().
+// The scan used to be synchronous and pumped QCoreApplication::processEvents() once per file "to
+// keep the UI responsive". That nested pump is what crashed the shipped 2.0.0 iOS build (issue
+// #1692, SIGABRT): SettingsLanguageTab kicks the scan off from its Component.onCompleted, QML
+// incubates that component synchronously while SettingsPage's TabBar.onCurrentIndexChanged
+// handler is still on the stack, and an event delivered inside the pump destroyed the outgoing
+// SettingsPage — taking the TabBar with it, which Qt turns into a qFatal().
 //
-// So there are two things worth pinning here:
-//   * scanAllStrings() must RETURN before it has done any of the work. A future "just make it
-//     synchronous again, it's simpler" is the regression, and it is invisible in the UI.
-//   * the parsing itself, now that it has been lifted out into a static function, must still
-//     recognise all three patterns — including the two malformed-input cases that earlier bugs
-//     turned into garbage registry keys.
+// Three things worth pinning here:
+//   * scanAllStrings() must not pump the event queue. The sentinel test asserts that directly —
+//     a queued event posted before the call has still not run when it returns — rather than
+//     asserting the weaker "scanFinished arrived late", which a rewrite that keeps the parsing
+//     inline and defers only the tail would satisfy while reintroducing the crash.
+//   * m_scanCompleted and m_scanning must settle BEFORE scanFinished() is emitted, because the
+//     parked bulk translator re-enters from inside that emit.
+//   * the parsing itself, now lifted into a static function, must still recognise all three
+//     patterns — including the two malformed-input cases that earlier bugs turned into garbage
+//     registry keys, and the scan ordering that decides which fallback wins for a duplicate key.
 
 #include <QtTest>
 #include <QSignalSpy>
@@ -26,7 +29,8 @@
 
 namespace {
 
-// The scanner's output as a lookup, for tests that don't care about ordering.
+// The scanner's output as a lookup, for tests that don't care about ordering. Anything asserting
+// order or duplicates must use the QList directly — this helper discards exactly that.
 QMap<QString, QString> asMap(const QList<TranslationManager::ScannedString>& found)
 {
     QMap<QString, QString> out;
@@ -44,6 +48,11 @@ class TestTranslationScan : public QObject
 private:
     QNetworkAccessManager m_nam;
 
+    // Constructed in init(), BEFORE failOnWarning() is armed — Settings' own constructor may warn,
+    // and a warning from it inside a test function would fail that test pointing nowhere near the
+    // cause. Every test uses this one rather than building its own.
+    std::unique_ptr<Settings> m_settings;
+
 private slots:
     void initTestCase()
     {
@@ -56,13 +65,19 @@ private slots:
                             + QStringLiteral("/translations");
         QDir(dir).removeRecursively();
 
-        Settings settings;
-        settings.setValue(QStringLiteral("localization/language"), QStringLiteral("en"));
+        m_settings = std::make_unique<Settings>();
+        m_settings->setValue(QStringLiteral("localization/language"), QStringLiteral("en"));
 
-        // Armed last: Settings' own constructor may warn, and arming first would fail every
-        // test in this file with a message pointing nowhere near the cause.
+        // Armed last, after everything whose construction may warn.
         QTest::failOnWarning();
     }
+
+    void cleanup()
+    {
+        m_settings.reset();
+    }
+
+    // --- The parser -------------------------------------------------------------------------
 
     // Pattern 1: translate("key", "fallback").
     void directCallsAreExtracted()
@@ -77,8 +92,7 @@ private slots:
         QCOMPARE(found.value(QStringLiteral("units.grams")), QStringLiteral("g"));
     }
 
-    // Pattern 2: ActionButton's translationKey/translationFallback property pair, matched by
-    // proximity — the fallback has to FOLLOW the key, and within 200 characters.
+    // Pattern 2: ActionButton's translationKey/translationFallback pair, matched by proximity.
     void propertyPairsAreMatchedByProximity()
     {
         const QString qml = QStringLiteral(
@@ -89,6 +103,34 @@ private slots:
 
         const QMap<QString, QString> found = asMap(TranslationManager::parseTranslatableStrings(qml));
         QCOMPARE(found.value(QStringLiteral("common.button.ok")), QStringLiteral("OK"));
+    }
+
+    // The two proximity heuristics are NOT the same and must not be "unified for consistency":
+    // pattern 2 looks forward only, pattern 3 looks both ways by absolute distance. Which English
+    // string ends up attached to a key is what gets AI-translated and published, so the asymmetry
+    // is behaviour, not style.
+    void patternTwoLooksForwardOnlyAndPatternThreeLooksBothWays()
+    {
+        // Pattern 2, fallback BEFORE the key: not matched.
+        const QString backwards = QStringLiteral(
+            "ActionButton {\n"
+            "    translationFallback: \"Cancel\"\n"
+            "    translationKey: \"common.button.cancel\"\n"
+            "}\n");
+        QVERIFY(asMap(TranslationManager::parseTranslatableStrings(backwards))
+                    .value(QStringLiteral("common.button.cancel")).isEmpty());
+
+        // Pattern 3, fallback before the key: matched.
+        const QString trBackwards = QStringLiteral("Tr { fallback: \"Steaming\"; key: \"m.steaming\" }\n");
+        QCOMPARE(asMap(TranslationManager::parseTranslatableStrings(trBackwards))
+                     .value(QStringLiteral("m.steaming")), QStringLiteral("Steaming"));
+
+        // Pattern 2 beyond the 200-character window: not matched.
+        QString distant = QStringLiteral("ActionButton { translationKey: \"far.key\"\n");
+        distant += QStringLiteral("    // %1\n").arg(QString(240, QLatin1Char('x')));
+        distant += QStringLiteral("    translationFallback: \"Far\"\n}\n");
+        QVERIFY(asMap(TranslationManager::parseTranslatableStrings(distant))
+                    .value(QStringLiteral("far.key")).isEmpty());
     }
 
     // Pattern 3: the Tr component. Its fallback may sit on either side of the key.
@@ -104,10 +146,34 @@ private slots:
         QCOMPARE(found.value(QStringLiteral("machineStatus.steaming")), QStringLiteral("Steaming"));
     }
 
+    // Results come back in SCAN order — pattern 1, then 2, then 3 — not in position order. The
+    // registry applies them in that sequence and the last write wins, so 26 real keys that are
+    // used with two different fallbacks in the same build depend on this not being "tidied up".
+    void duplicateKeysComeBackInScanOrderNotPositionOrder()
+    {
+        const QString qml = QStringLiteral(
+            "Tr { key: \"dup.key\"; fallback: \"FromTr\" }\n"
+            "Text { text: TranslationManager.translate(\"dup.key\", \"FromTranslateCall\") }\n");
+
+        const QList<TranslationManager::ScannedString> found =
+            TranslationManager::parseTranslatableStrings(qml);
+
+        QList<QString> fallbacks;
+        for (const TranslationManager::ScannedString& s : found) {
+            if (s.key == QStringLiteral("dup.key"))
+                fallbacks << s.fallback;
+        }
+
+        // The Tr block comes FIRST in the text, but pattern 1 runs before pattern 3.
+        QCOMPARE(fallbacks.size(), 2);
+        QCOMPARE(fallbacks.at(0), QStringLiteral("FromTranslateCall"));
+        QCOMPARE(fallbacks.at(1), QStringLiteral("FromTr"));
+    }
+
     // A key must not be captured across a newline. Without the [^"\n] guard, `fallback: "How to
     // get an API key:"` matched at its own trailing `key:"` and swallowed 249 characters of QML
-    // source as a translation key — which was then AI-translated into every language and
-    // uploaded to the community server.
+    // source as a translation key — which was then AI-translated into every language and uploaded
+    // to the community server.
     void aFallbackEndingInKeyColonDoesNotBecomeAKey()
     {
         const QString qml = QStringLiteral(
@@ -129,6 +195,11 @@ private slots:
             QVERIFY2(!s.key.contains(QStringLiteral("Theme.")),
                      qPrintable(QStringLiteral("scanner captured QML source as a key: %1").arg(s.key)));
         }
+
+        // And the block is still scanned — a regex change that dropped it entirely would satisfy
+        // the assertions above.
+        QCOMPARE(asMap(found).value(QStringLiteral("ai.apiKeyHelp")),
+                 QStringLiteral("How to get an API key:"));
     }
 
     // The scanner reads QML as TEXT while the runtime sees the characters the escapes denote.
@@ -142,26 +213,118 @@ private slots:
         QCOMPARE(found.value(QStringLiteral("chart.mlPerSec")), QStringLiteral("ml·s⁻¹"));
     }
 
-    // The contract that keeps #1692 fixed: the call returns with the work not yet done, and the
-    // result arrives through the event loop.
-    void scanAllStringsIsAsynchronous()
-    {
-        Settings settings;
-        TranslationManager tm(&m_nam, &settings);
+    // --- The scan ---------------------------------------------------------------------------
 
-        // The QML module resource belongs to the app target, not to this test binary, so the
-        // scan legitimately finds no files here. That is the one warning expected.
-        QTest::ignoreMessage(QtWarningMsg,
-            QRegularExpression(QStringLiteral("string scan found NO QML files")));
+    // The contract that keeps #1692 fixed, asserted against the event queue itself: a queued call
+    // posted before scanAllStrings() must still be unrun when it returns. A scan that pumps —
+    // however briefly, however well-intentioned — runs it, and fails here.
+    void scanAllStringsDoesNotPumpTheEventQueue()
+    {
+        TranslationManager tm(&m_nam, m_settings.get());
+
+        QObject sentinel;
+        bool sentinelRan = false;
+        QMetaObject::invokeMethod(&sentinel, [&sentinelRan]() { sentinelRan = true; },
+                                  Qt::QueuedConnection);
+
+        tm.scanAllStrings();
+
+        QVERIFY2(!sentinelRan,
+                 "scanAllStrings() delivered a queued event before returning — it is pumping the "
+                 "event loop again, which is what aborted shipped iOS 2.0.0 (#1692)");
+        QVERIFY(tm.isScanning());
+    }
+
+    // The scan reaches the registry, over the fixture QML, off the calling stack.
+    void scanFindsFixtureStringsAndFinishesAsynchronously()
+    {
+        TranslationManager tm(&m_nam, m_settings.get());
 
         QSignalSpy finished(&tm, &TranslationManager::scanFinished);
         tm.scanAllStrings();
 
         QCOMPARE(finished.count(), 0);   // must NOT have completed inline
-        QVERIFY(tm.isScanning());
-
-        QVERIFY(finished.wait(5000));
+        QVERIFY(finished.wait(10000));
         QVERIFY(!tm.isScanning());
+
+        // Assert the REGISTRY, not translateString(): the registry is what the scan exists to
+        // fill and what AI translation and community upload are handed. translateString() with no
+        // translation loaded just echoes the fallback the caller passed, so it would pass this
+        // test whether or not the scan ever ran.
+        QCOMPARE(tm.m_stringRegistry.value(QStringLiteral("fixture.alpha.title")),
+                 QStringLiteral("Alpha"));
+        QCOMPARE(tm.m_stringRegistry.value(QStringLiteral("fixture.alpha.save")),
+                 QStringLiteral("Save"));
+        QCOMPARE(tm.m_stringRegistry.value(QStringLiteral("fixture.alpha.idle")),
+                 QStringLiteral("Idle"));
+        // Second file: the worker loops rather than stopping at the first.
+        QCOMPARE(tm.m_stringRegistry.value(QStringLiteral("fixture.beta.title")),
+                 QStringLiteral("Beta"));
+        // Last write wins, in scan order.
+        QCOMPARE(tm.m_stringRegistry.value(QStringLiteral("fixture.shared")),
+                 QStringLiteral("Last"));
+
+        // Progress is posted from the worker; a worker that never reported would leave the
+        // Language page's bar at zero for the whole scan and pass every other assertion here.
+        QVERIFY(tm.scanTotal() > 0);
+        QCOMPARE(tm.scanProgress(), tm.scanTotal());
+    }
+
+    // m_scanCompleted and m_scanning must be settled BEFORE scanFinished() is emitted: the parked
+    // bulk translator re-enters translateAndUploadAllLanguages() from inside this emit and
+    // re-tests m_scanCompleted. Emit first and it re-parks, rescans, and loops forever — with
+    // nothing in the suite noticing, because the loop only shows up via bulk translate.
+    void flagsAreSettledBeforeScanFinishedIsEmitted()
+    {
+        TranslationManager tm(&m_nam, m_settings.get());
+
+        bool sawCompleted = false;
+        bool sawStoppedScanning = false;
+        connect(&tm, &TranslationManager::scanFinished, &tm, [&](int) {
+            sawCompleted = tm.m_scanCompleted;
+            sawStoppedScanning = !tm.m_scanning;
+        });
+
+        QSignalSpy finished(&tm, &TranslationManager::scanFinished);
+        tm.scanAllStrings();
+        QVERIFY(finished.wait(10000));
+
+        QVERIFY2(sawCompleted, "m_scanCompleted was still false inside scanFinished() — a parked "
+                               "bulk translate would re-park and rescan forever");
+        QVERIFY2(sawStoppedScanning, "m_scanning was still true inside scanFinished()");
+    }
+
+    // Two calls in a row start one scan, not two, and emit one scanFinished. Both failure modes
+    // are silent.
+    void aSecondScanWhileOneIsRunningIsJoinedNotStarted()
+    {
+        TranslationManager tm(&m_nam, m_settings.get());
+
+        QSignalSpy finished(&tm, &TranslationManager::scanFinished);
+        tm.scanAllStrings();
+        tm.scanAllStrings();   // joins the in-flight scan
+
+        QVERIFY(finished.wait(10000));
+        QTest::qWait(50);      // any second worker's result would land in this window
+        QCOMPARE(finished.count(), 1);
+
+        // And a scan started after the first completed does run again.
+        tm.scanAllStrings();
+        QVERIFY(tm.isScanning());
+        QVERIFY(finished.wait(10000));
+        QCOMPARE(finished.count(), 2);
+    }
+
+    // The destructor exists so a worker cannot post to a destroyed object. Under the Debug
+    // build's automatic ASan this is a direct test of that.
+    void destroyingMidScanIsSafe()
+    {
+        {
+            TranslationManager tm(&m_nam, m_settings.get());
+            tm.scanAllStrings();
+            QVERIFY(tm.isScanning());
+        }
+        QTest::qWait(50);   // anything that escaped the destructor would land here
     }
 };
 

--- a/tests/tst_translationscan.cpp
+++ b/tests/tst_translationscan.cpp
@@ -1,0 +1,169 @@
+// The QML string scan: what it extracts, and that it never runs inline.
+//
+// The scan used to be synchronous and pumped QCoreApplication::processEvents() once per file
+// "to keep the UI responsive". That nested event loop is what crashed the shipped 2.0.0 iOS
+// build (issue #1692, SIGABRT): SettingsLanguageTab kicks the scan off from its
+// Component.onCompleted, QML incubates that component synchronously while SettingsPage's
+// TabBar.onCurrentIndexChanged handler is still on the stack, and a DeferredDelete already
+// queued for the outgoing SettingsPage was delivered inside the nested loop — destroying the
+// TabBar mid-handler, which Qt turns into a qFatal().
+//
+// So there are two things worth pinning here:
+//   * scanAllStrings() must RETURN before it has done any of the work. A future "just make it
+//     synchronous again, it's simpler" is the regression, and it is invisible in the UI.
+//   * the parsing itself, now that it has been lifted out into a static function, must still
+//     recognise all three patterns — including the two malformed-input cases that earlier bugs
+//     turned into garbage registry keys.
+
+#include <QtTest>
+#include <QSignalSpy>
+#include <QDir>
+#include <QNetworkAccessManager>
+#include <QRegularExpression>
+#include <QStandardPaths>
+#include "core/settings.h"
+#include "core/translationmanager.h"
+
+namespace {
+
+// The scanner's output as a lookup, for tests that don't care about ordering.
+QMap<QString, QString> asMap(const QList<TranslationManager::ScannedString>& found)
+{
+    QMap<QString, QString> out;
+    for (const TranslationManager::ScannedString& s : found)
+        out[s.key] = s.fallback;
+    return out;
+}
+
+} // namespace
+
+class TestTranslationScan : public QObject
+{
+    Q_OBJECT
+
+private:
+    QNetworkAccessManager m_nam;
+
+private slots:
+    void initTestCase()
+    {
+        QStandardPaths::setTestModeEnabled(true);
+    }
+
+    void init()
+    {
+        const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+                            + QStringLiteral("/translations");
+        QDir(dir).removeRecursively();
+
+        Settings settings;
+        settings.setValue(QStringLiteral("localization/language"), QStringLiteral("en"));
+
+        // Armed last: Settings' own constructor may warn, and arming first would fail every
+        // test in this file with a message pointing nowhere near the cause.
+        QTest::failOnWarning();
+    }
+
+    // Pattern 1: translate("key", "fallback").
+    void directCallsAreExtracted()
+    {
+        const QString qml = QStringLiteral(
+            "Text { text: TranslationManager.translate(\"settings.title\", \"Settings\") }\n"
+            "Text { text: TranslationManager.translate( \"units.grams\" , \"g\" ) }\n");
+
+        const QMap<QString, QString> found = asMap(TranslationManager::parseTranslatableStrings(qml));
+
+        QCOMPARE(found.value(QStringLiteral("settings.title")), QStringLiteral("Settings"));
+        QCOMPARE(found.value(QStringLiteral("units.grams")), QStringLiteral("g"));
+    }
+
+    // Pattern 2: ActionButton's translationKey/translationFallback property pair, matched by
+    // proximity — the fallback has to FOLLOW the key, and within 200 characters.
+    void propertyPairsAreMatchedByProximity()
+    {
+        const QString qml = QStringLiteral(
+            "ActionButton {\n"
+            "    translationKey: \"common.button.ok\"\n"
+            "    translationFallback: \"OK\"\n"
+            "}\n");
+
+        const QMap<QString, QString> found = asMap(TranslationManager::parseTranslatableStrings(qml));
+        QCOMPARE(found.value(QStringLiteral("common.button.ok")), QStringLiteral("OK"));
+    }
+
+    // Pattern 3: the Tr component. Its fallback may sit on either side of the key.
+    void trComponentPropertiesAreExtractedInEitherOrder()
+    {
+        const QString qml = QStringLiteral(
+            "Tr { key: \"machineStatus.idle\"; fallback: \"Idle\" }\n"
+            "Tr { fallback: \"Steaming\"; key: \"machineStatus.steaming\" }\n");
+
+        const QMap<QString, QString> found = asMap(TranslationManager::parseTranslatableStrings(qml));
+
+        QCOMPARE(found.value(QStringLiteral("machineStatus.idle")), QStringLiteral("Idle"));
+        QCOMPARE(found.value(QStringLiteral("machineStatus.steaming")), QStringLiteral("Steaming"));
+    }
+
+    // A key must not be captured across a newline. Without the [^"\n] guard, `fallback: "How to
+    // get an API key:"` matched at its own trailing `key:"` and swallowed 249 characters of QML
+    // source as a translation key — which was then AI-translated into every language and
+    // uploaded to the community server.
+    void aFallbackEndingInKeyColonDoesNotBecomeAKey()
+    {
+        const QString qml = QStringLiteral(
+            "Tr {\n"
+            "    key: \"ai.apiKeyHelp\"\n"
+            "    fallback: \"How to get an API key:\"\n"
+            "}\n"
+            "Text {\n"
+            "    color: Theme.textColor\n"
+            "    font: Theme.subtitleFont\n"
+            "}\n");
+
+        const QList<TranslationManager::ScannedString> found =
+            TranslationManager::parseTranslatableStrings(qml);
+
+        for (const TranslationManager::ScannedString& s : found) {
+            QVERIFY2(!s.key.contains(QLatin1Char('\n')),
+                     qPrintable(QStringLiteral("scanner captured QML source as a key: %1").arg(s.key)));
+            QVERIFY2(!s.key.contains(QStringLiteral("Theme.")),
+                     qPrintable(QStringLiteral("scanner captured QML source as a key: %1").arg(s.key)));
+        }
+    }
+
+    // The scanner reads QML as TEXT while the runtime sees the characters the escapes denote.
+    // Both write the registry, so they have to agree.
+    void escapesAreDecodedTheWayTheRuntimeSeesThem()
+    {
+        const QString qml = QStringLiteral(
+            "Text { text: TranslationManager.translate(\"chart.mlPerSec\", \"ml\\u00B7s\\u207B\\u00B9\") }\n");
+
+        const QMap<QString, QString> found = asMap(TranslationManager::parseTranslatableStrings(qml));
+        QCOMPARE(found.value(QStringLiteral("chart.mlPerSec")), QStringLiteral("ml·s⁻¹"));
+    }
+
+    // The contract that keeps #1692 fixed: the call returns with the work not yet done, and the
+    // result arrives through the event loop.
+    void scanAllStringsIsAsynchronous()
+    {
+        Settings settings;
+        TranslationManager tm(&m_nam, &settings);
+
+        // The QML module resource belongs to the app target, not to this test binary, so the
+        // scan legitimately finds no files here. That is the one warning expected.
+        QTest::ignoreMessage(QtWarningMsg,
+            QRegularExpression(QStringLiteral("string scan found NO QML files")));
+
+        QSignalSpy finished(&tm, &TranslationManager::scanFinished);
+        tm.scanAllStrings();
+
+        QCOMPARE(finished.count(), 0);   // must NOT have completed inline
+        QVERIFY(tm.isScanning());
+
+        QVERIFY(finished.wait(5000));
+        QVERIFY(!tm.isScanning());
+    }
+};
+
+QTEST_MAIN(TestTranslationScan)
+#include "tst_translationscan.moc"


### PR DESCRIPTION
Fixes #1692 — the first SIGABRT in the crash tracker (every other iOS crash report is SIGSEGV/SIGBUS), and the first with this message:

```
Object 0x12a0fa680 destroyed while one of its QML signal handlers is in progress.
Most likely the object was deleted synchronously (use QObject::deleteLater() instead), or the application is running a nested event loop.
qrc:/qt/qml/Decenza/qml/pages/SettingsPage.qml:106
```

## What it actually was

Symbolicated against the dSYM from the iOS release run that built the shipped 2.0.0 (slide `0x1F8000`). Note for the archive: the run tagged `v2.0.0` is **not** the one that shipped — the branch moved past the tag, and only the later build's dSYM lines up.

```
TabBar.onCurrentIndexChanged        SettingsPage.qml:106
  -> markTabLoaded() writes loadedTabs
  -> Loader.active binding -> QQmlComponent::create   (synchronous incubation)
  -> SettingsLanguageTab.Component.onCompleted
  -> TranslationManager::scanAllStrings()
  -> QCoreApplication::processEvents()                <-- nested event loop
  -> queued DeferredDelete for the outgoing SettingsPage delivered here
  -> ~QQuickPage deletes its children, incl. the TabBar whose handler is still running
  -> QQmlData::destroyed() -> qFatal() -> abort
```

The `processEvents()` ran once per scanned file, "to keep the UI responsive" while 212 QML files (4.6 MB) were regexed on the main thread. It needed no dialog, no user interaction and no second thread — a page transition had already queued the `deleteLater`, and the scan just gave it somewhere to land.

## The change

- Parsing moves to a `QThread::create()` worker. It is lifted into a static, state-free `parseTranslatableStrings()` that touches no member, emits no signal and does no I/O.
- Registry writes happen in `applyScanResults()`, from a queued callback on the main thread. `m_stringRegistry` is still only ever touched there, and pairs are applied in file order, so a key used with two different fallbacks resolves exactly as before.
- `scanAllStrings()` is therefore asynchronous. `translateAndUploadAllLanguages()` used to call it inline and read the registry on the next line, so it now parks on `scanFinished()` and restarts — the bulk translator's whole reason for scanning is that it gets the *complete* string list, not just the screens this device has rendered.
- Destructor waits on the worker, so a scan can never outlive the object it posts results to.

Side effect worth having: the Language page's progress bar can now actually animate. It was measuring work that blocked the thread painting it.

## Tests

`tests/tst_translationscan.cpp` — the three extraction patterns (including the two malformed-input cases earlier bugs turned into garbage registry keys), plus the contract that keeps this fixed: `scanAllStrings()` has **not** completed when it returns. Without that assertion, "make it synchronous again, it's simpler" reads as a harmless cleanup.

Full suite via Qt Creator: **107 passed, 0 failed, 0 warnings**.

## Docs

`QML_GOTCHAS.md` gains a section on nested event loops under QML signal handlers, with the full chain; `CLAUDE.md` gets the one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)