### PR TITLE
Fix #1691: Anthropic thinking off explicitly; stop silently truncating every provider

### DIFF
--- a/src/ai/aiprovider.cpp
+++ b/src/ai/aiprovider.cpp
@@ -4,6 +4,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QNetworkRequest>
+#include <QStringList>
 #include <QTimer>
 #include <QUrl>
 #include <QVariant>
@@ -32,6 +33,13 @@ QString AIProvider::tr_(const char* key, const char* fallback) const
         return m_translationManager->translateString(QString::fromUtf8(key),
                                                QString::fromUtf8(fallback));
     return QString::fromUtf8(fallback);
+}
+
+QString AIProvider::truncatedResponseError() const
+{
+    return tr_("ai.error.truncated",
+               "The AI's reply was cut off before it finished. Please try again, "
+               "or ask a more specific question.");
 }
 
 QString AIProvider::friendlyNetworkError(QNetworkReply* reply) const
@@ -243,9 +251,9 @@ void OpenAIProvider::analyze(const QString& systemPrompt, const QString& userPro
     // chat/completions ("Unsupported parameter") — max_completion_tokens is
     // the accepted cap. Live-caught July 2026: stage-1 extraction and the
     // advisor both 400'd on gpt-5.4/gpt-5.4-mini.
-    requestBody["max_completion_tokens"] = 1024;
+    requestBody["max_completion_tokens"] = MAX_OUTPUT_TOKENS;
     // GPT-5 family are reasoning models; keep reasoning off so hidden
-    // reasoning tokens don't count against the 1024-token output cap (which would
+    // reasoning tokens don't count against the output cap (which would
     // risk truncating the trailing nextShot JSON block) and to keep latency/cost
     // low. Dial-in advice needs little chain-of-thought. Mirrors Gemini's
     // thinking=off. The 5.4 generation REPLACED the value "minimal" with "none"
@@ -284,7 +292,7 @@ void OpenAIProvider::analyzeUrl(const QString& systemPrompt, const QString& user
     QJsonObject reasoning;
     reasoning["effort"] = QString("low");
     requestBody["reasoning"] = reasoning;
-    requestBody["max_output_tokens"] = 2048;
+    requestBody["max_output_tokens"] = MAX_OUTPUT_TOKENS;
 
     sendResponsesRequest(requestBody);
 }
@@ -361,10 +369,21 @@ void OpenAIProvider::onResponsesReply(QNetworkReply* reply)
                 text += part["text"].toString();
         }
     }
-    if (text.isEmpty()) {
-        qWarning() << "OpenAI Responses: no output_text (status"
-                   << root["status"].toString() << ")";
-        emit analysisFailed(tr_("ai.openai.emptyContent", "OpenAI returned empty response content"));
+    // "incomplete" + reason "max_output_tokens" means the cap cut the answer
+    // short. Report it either way: an empty text is a failure, and a partial
+    // one is worse than a failure if returned as if complete — it silently
+    // drops the trailing nextShot JSON block.
+    const bool truncated = root["status"].toString() == QLatin1String("incomplete")
+        && root["incomplete_details"].toObject()["reason"].toString()
+               == QLatin1String("max_output_tokens");
+    if (text.isEmpty() || truncated) {
+        qWarning() << "OpenAI Responses: status" << root["status"].toString()
+                   << "incomplete_reason"
+                   << root["incomplete_details"].toObject()["reason"].toString()
+                   << "text chars" << text.size();
+        emit analysisFailed(truncated
+            ? truncatedResponseError()
+            : tr_("ai.openai.emptyContent", "OpenAI returned empty response content"));
         return;
     }
     emit analysisComplete(text);
@@ -384,7 +403,7 @@ void OpenAIProvider::analyzeConversation(const QString& systemPrompt, const QJso
     QJsonObject requestBody;
     requestBody["model"] = m_model;
     requestBody["messages"] = buildOpenAIMessages(systemPrompt, messages);
-    requestBody["max_completion_tokens"] = 1024;
+    requestBody["max_completion_tokens"] = MAX_OUTPUT_TOKENS;
     requestBody["reasoning_effort"] = "none";  // see analyze(): 5.4 generation dropped "minimal"
 
     sendRequest(requestBody);
@@ -430,9 +449,16 @@ void OpenAIProvider::onAnalysisReply(QNetworkReply* reply)
         return;
     }
 
+    const QString finishReason = choices[0].toObject()["finish_reason"].toString();
     QString content = choices[0].toObject()["message"].toObject()["content"].toString();
-    if (content.isEmpty()) {
-        emit analysisFailed(tr_("ai.openai.emptyContent", "OpenAI returned empty response content"));
+    // finish_reason "length" = the answer hit max_completion_tokens. Never emit
+    // a truncated reply as if complete (see MAX_OUTPUT_TOKENS).
+    if (content.isEmpty() || finishReason == QLatin1String("length")) {
+        qWarning() << "OpenAI: finish_reason" << finishReason
+                   << "content chars" << content.size();
+        emit analysisFailed(finishReason == QLatin1String("length")
+            ? truncatedResponseError()
+            : tr_("ai.openai.emptyContent", "OpenAI returned empty response content"));
         return;
     }
     emit analysisComplete(content);
@@ -518,6 +544,27 @@ void OpenAIProvider::onTestReply(QNetworkReply* reply)
 // ============================================================================
 // Anthropic Provider
 // ============================================================================
+
+// Turn extended thinking OFF, explicitly, on every request.
+//
+// This has to be explicit because the default is NOT stable across models:
+// claude-sonnet-4-6 runs without thinking when the field is omitted, while
+// claude-sonnet-5 runs ADAPTIVE thinking when the field is omitted. Since
+// max_tokens caps thinking + response text together, omitting the field on
+// Sonnet 5 let thinking consume the entire budget — the reply came back HTTP
+// 200 with a thinking block and no text block at all, which is #1691's
+// "Anthropic returned empty response content" for every request the user sent.
+//
+// Off (not merely bounded) is the right setting here for the same reason the
+// OpenAI and Gemini paths force reasoning/thinking off: dial-in advice needs
+// little chain-of-thought, and hidden thinking tokens are billed at the output
+// rate. Both selectable models accept the "disabled" form.
+static void disableAnthropicThinking(QJsonObject& requestBody)
+{
+    QJsonObject thinking;
+    thinking["type"] = QStringLiteral("disabled");
+    requestBody["thinking"] = thinking;
+}
 
 AnthropicProvider::AnthropicProvider(QNetworkAccessManager* networkManager,
                                      const QString& apiKey,
@@ -612,7 +659,8 @@ void AnthropicProvider::analyze(const QString& systemPrompt, const QString& user
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
-    requestBody["max_tokens"] = 1024;
+    requestBody["max_tokens"] = MAX_OUTPUT_TOKENS;
+    disableAnthropicThinking(requestBody);
     requestBody["system"] = buildCachedSystemPrompt(systemPrompt);
     QJsonArray messages;
     QJsonObject userMsg;
@@ -637,7 +685,8 @@ void AnthropicProvider::analyzeUrl(const QString& systemPrompt, const QString& u
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
-    requestBody["max_tokens"] = 1024;
+    requestBody["max_tokens"] = MAX_OUTPUT_TOKENS;
+    disableAnthropicThinking(requestBody);
     requestBody["system"] = buildCachedSystemPrompt(systemPrompt);
     QJsonArray messages;
     QJsonObject userMsg;
@@ -672,7 +721,8 @@ void AnthropicProvider::analyzeConversation(const QString& systemPrompt, const Q
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
-    requestBody["max_tokens"] = 1024;
+    requestBody["max_tokens"] = MAX_OUTPUT_TOKENS;
+    disableAnthropicThinking(requestBody);
     requestBody["system"] = buildCachedSystemPrompt(systemPrompt);
     requestBody["messages"] = messagesWithCachedFirstUser(messages);
 
@@ -786,8 +836,24 @@ void AnthropicProvider::onAnalysisReply(QNetworkReply* reply)
         if (obj["type"].toString() == QLatin1String("text"))
             text += obj["text"].toString();
     }
-    if (text.isEmpty()) {
-        emit analysisFailed(tr_("ai.anthropic.emptyContent", "Anthropic returned empty response content"));
+    // stop_reason "max_tokens" = the answer hit the cap. Report it rather than
+    // emitting a half-written reply whose trailing nextShot JSON block is gone.
+    // Log the block types on any text-less reply: content can be non-empty
+    // while carrying no text block at all (a thinking-only reply — #1691), and
+    // the generic message alone made that indistinguishable from a real
+    // refusal for three days of user reports.
+    const QString stopReason = root["stop_reason"].toString();
+    const bool truncated = stopReason == QLatin1String("max_tokens");
+    if (text.isEmpty() || truncated) {
+        QStringList blockTypes;
+        for (const QJsonValue& block : content)
+            blockTypes << block.toObject()["type"].toString();
+        qWarning() << "Anthropic: stop_reason" << stopReason
+                   << "block types" << blockTypes
+                   << "text chars" << text.size();
+        emit analysisFailed(truncated
+            ? truncatedResponseError()
+            : tr_("ai.anthropic.emptyContent", "Anthropic returned empty response content"));
         return;
     }
     emit analysisComplete(text);
@@ -800,10 +866,15 @@ void AnthropicProvider::testConnection()
         return;
     }
 
-    // Send a minimal request to test the API key
+    // Send a minimal request to test the API key. Thinking off for the same
+    // reason as the analysis paths — with thinking on, a 10-token budget
+    // produces a reply with no text block. This check only looks for an error,
+    // so it PASSED while every real request failed (#1691): the user's key
+    // tested fine and the advisor was unusable.
     QJsonObject requestBody;
     requestBody["model"] = m_model;
     requestBody["max_tokens"] = 10;
+    disableAnthropicThinking(requestBody);
     QJsonArray messages;
     QJsonObject userMsg;
     userMsg["role"] = QString("user");
@@ -976,7 +1047,7 @@ void GeminiProvider::sendRequest(const QJsonObject& requestBody)
     }
     QJsonObject generationConfig;
     generationConfig["thinkingConfig"] = thinkingConfig;
-    generationConfig["maxOutputTokens"] = 1024;  // also bounds thinking tokens; matches other providers
+    generationConfig["maxOutputTokens"] = MAX_OUTPUT_TOKENS;  // also bounds thinking tokens; matches other providers
     bodyWithConfig["generationConfig"] = generationConfig;
 
     m_retryFn = [this, requestBody]() { sendRequest(requestBody); };
@@ -1174,8 +1245,16 @@ void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
             continue;
         text += part["text"].toString();
     }
-    if (text.isEmpty()) {
-        emit analysisFailed(tr_("ai.gemini.emptyContent", "Gemini returned empty response content"));
+    // finishReason "MAX_TOKENS" = the answer hit maxOutputTokens; don't emit a
+    // truncated reply as if complete (see MAX_OUTPUT_TOKENS).
+    const QString finishReason = candidates[0].toObject()["finishReason"].toString();
+    const bool truncated = finishReason == QLatin1String("MAX_TOKENS");
+    if (text.isEmpty() || truncated) {
+        qWarning() << "Gemini: finishReason" << finishReason
+                   << "parts" << parts.size() << "text chars" << text.size();
+        emit analysisFailed(truncated
+            ? truncatedResponseError()
+            : tr_("ai.gemini.emptyContent", "Gemini returned empty response content"));
         return;
     }
     emit analysisComplete(text);
@@ -1325,7 +1404,7 @@ void OpenRouterProvider::analyze(const QString& systemPrompt, const QString& use
     userMsg["content"] = userPrompt;
     messages.append(userMsg);
     requestBody["messages"] = messages;
-    requestBody["max_tokens"] = 1024;
+    requestBody["max_tokens"] = MAX_OUTPUT_TOKENS;
 
     sendRequest(requestBody);
 }
@@ -1344,7 +1423,7 @@ void OpenRouterProvider::analyzeConversation(const QString& systemPrompt, const 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
     requestBody["messages"] = buildOpenAIMessages(systemPrompt, messages);
-    requestBody["max_tokens"] = 1024;
+    requestBody["max_tokens"] = MAX_OUTPUT_TOKENS;
 
     sendRequest(requestBody);
 }
@@ -1389,9 +1468,17 @@ void OpenRouterProvider::onAnalysisReply(QNetworkReply* reply)
         return;
     }
 
+    // finish_reason "length" = the answer hit max_tokens. This matters most on
+    // OpenRouter: the model is a free-text user string, so it can point at a
+    // reasoning model whose hidden tokens eat the cap the way #1691's did.
+    const QString finishReason = choices[0].toObject()["finish_reason"].toString();
     QString content = choices[0].toObject()["message"].toObject()["content"].toString();
-    if (content.isEmpty()) {
-        emit analysisFailed(tr_("ai.openrouter.emptyContent", "OpenRouter returned empty response content"));
+    if (content.isEmpty() || finishReason == QLatin1String("length")) {
+        qWarning() << "OpenRouter: model" << m_model << "finish_reason" << finishReason
+                   << "content chars" << content.size();
+        emit analysisFailed(finishReason == QLatin1String("length")
+            ? truncatedResponseError()
+            : tr_("ai.openrouter.emptyContent", "OpenRouter returned empty response content"));
         return;
     }
     emit analysisComplete(content);

--- a/src/ai/aiprovider.cpp
+++ b/src/ai/aiprovider.cpp
@@ -37,9 +37,45 @@ QString AIProvider::tr_(const char* key, const char* fallback) const
 
 QString AIProvider::truncatedResponseError() const
 {
+    // Deliberately does NOT say "ask a more specific question": analyzeUrl() is
+    // the recipe-wizard URL extraction, where there is no question to narrow —
+    // the user pasted a link. Keep the remedy true on every path.
     return tr_("ai.error.truncated",
-               "The AI's reply was cut off before it finished. Please try again, "
-               "or ask a more specific question.");
+               "The AI's reply was cut off before it finished. Please try again.");
+}
+
+QString AIProvider::truncationNotice() const
+{
+    return QStringLiteral("\n\n_") +
+           tr_("ai.notice.truncated", "This reply was cut off before it finished.") +
+           QStringLiteral("_");
+}
+
+bool AIProvider::dispatchTruncatedOrEmpty(const QString& text, bool truncated,
+                                          const QString& emptyMessage)
+{
+    if (!truncated && !text.isEmpty())
+        return false;  // ordinary reply — caller emits it
+
+    if (truncated && !text.isEmpty() && m_truncationPolicy == TruncationPolicy::ShowPartial) {
+        emit analysisComplete(text + truncationNotice());
+        return true;
+    }
+    emit analysisFailed(truncated ? truncatedResponseError() : emptyMessage);
+    return true;
+}
+
+QString AIProvider::logSafeErrorBody(const QByteArray& body)
+{
+    // Prefer the machine-readable classification, which never carries request
+    // content. Fall back to a bounded prefix when the body isn't the shape we
+    // expect (an HTML error page from a proxy, say).
+    const QJsonObject error = QJsonDocument::fromJson(body).object()["error"].toObject();
+    const QString type = error["type"].toString();
+    const QString code = error["code"].toString();
+    if (!type.isEmpty() || !code.isEmpty())
+        return QStringLiteral("type=%1 code=%2").arg(type, code);
+    return QString::fromUtf8(body.left(LOG_BODY_LIMIT));
 }
 
 QString AIProvider::friendlyNetworkError(QNetworkReply* reply) const
@@ -108,7 +144,8 @@ bool AIProvider::tryScheduleRetry(QNetworkReply* reply)
     const int delay = computeRetryDelayMs(++m_retryCount, reply);
     const QByteArray body = reply->readAll();
     qWarning() << name() << "HTTP" << status << "- retry" << m_retryCount
-               << "in" << delay << "ms" << (body.isEmpty() ? QByteArray() : ("- " + body.left(200)));
+               << "in" << delay << "ms"
+               << (body.isEmpty() ? QString() : QStringLiteral("- ") + logSafeErrorBody(body));
     // QTimer::singleShot is intentional: the server signalled a transient error and we must
     // wait before retrying (rate-limit or overload backoff). This is a server-driven delay,
     // not a heuristic guard. The generation counter prevents stale timers from firing if a
@@ -234,6 +271,7 @@ void OpenAIProvider::analyze(const QString& systemPrompt, const QString& userPro
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -276,6 +314,7 @@ void OpenAIProvider::analyzeUrl(const QString& systemPrompt, const QString& user
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
 
     // The web_search tool lives on the Responses API, not chat/completions.
     // Its open_page action lets the model retrieve the specific URL named in
@@ -335,9 +374,10 @@ void OpenAIProvider::onResponsesReply(QNetworkReply* reply)
                 emit analysisFailed(tr_("ai.openai.error", "OpenAI error: %1").arg(apiError));
                 return;
             }
+            // Bounded/classified, never the raw body — see logSafeErrorBody().
             qWarning() << "AI request failed"
                        << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt()
-                       << "-" << body;
+                       << "-" << logSafeErrorBody(body);
         }
         emit analysisFailed(friendlyNetworkError(reply));
         return;
@@ -356,7 +396,11 @@ void OpenAIProvider::onResponsesReply(QNetworkReply* reply)
 
     // The Responses output array interleaves reasoning/web_search_call items
     // with message items; the answer is the message items' output_text parts.
+    // Collect the part types too: when the answer is missing, WHAT came back
+    // instead is the whole diagnosis (#1691's lesson — log shape, not content).
     QString text;
+    QString refusal;
+    QStringList partTypes;
     const QJsonArray output = root["output"].toArray();
     for (const QJsonValue& itemVal : output) {
         const QJsonObject item = itemVal.toObject();
@@ -365,26 +409,34 @@ void OpenAIProvider::onResponsesReply(QNetworkReply* reply)
         const QJsonArray content = item["content"].toArray();
         for (const QJsonValue& partVal : content) {
             const QJsonObject part = partVal.toObject();
-            if (part["type"].toString() == QLatin1String("output_text"))
+            const QString partType = part["type"].toString();
+            partTypes << partType;
+            if (partType == QLatin1String("output_text"))
                 text += part["text"].toString();
+            else if (partType == QLatin1String("refusal"))
+                refusal = part["refusal"].toString();
         }
     }
-    // "incomplete" + reason "max_output_tokens" means the cap cut the answer
-    // short. Report it either way: an empty text is a failure, and a partial
-    // one is worse than a failure if returned as if complete — it silently
-    // drops the trailing nextShot JSON block.
-    const bool truncated = root["status"].toString() == QLatin1String("incomplete")
-        && root["incomplete_details"].toObject()["reason"].toString()
-               == QLatin1String("max_output_tokens");
+
+    // Gate on completion, not on one reason. `incomplete_details.reason` is
+    // also "content_filter", and status can be "failed"/"cancelled" — anything
+    // other than "completed" means the text in hand is not the whole answer.
+    const QString status = root["status"].toString();
+    const QString incompleteReason = root["incomplete_details"].toObject()["reason"].toString();
+    const bool truncated = status != QLatin1String("completed");
     if (text.isEmpty() || truncated) {
-        qWarning() << "OpenAI Responses: status" << root["status"].toString()
-                   << "incomplete_reason"
-                   << root["incomplete_details"].toObject()["reason"].toString()
-                   << "text chars" << text.size();
-        emit analysisFailed(truncated
-            ? truncatedResponseError()
-            : tr_("ai.openai.emptyContent", "OpenAI returned empty response content"));
-        return;
+        qWarning() << "OpenAI Responses: model" << m_model << "status" << status
+                   << "incomplete_reason" << incompleteReason
+                   << "part types" << partTypes << "text chars" << text.size();
+        // A refusal explains itself; surfacing it beats the generic message,
+        // which is the failure #1691 took three days to place.
+        if (text.isEmpty() && !refusal.isEmpty()) {
+            emit analysisFailed(tr_("ai.openai.refused", "OpenAI declined the request: %1").arg(refusal));
+            return;
+        }
+        if (dispatchTruncatedOrEmpty(text, truncated,
+                tr_("ai.openai.emptyContent", "OpenAI returned empty response content")))
+            return;
     }
     emit analysisComplete(text);
 }
@@ -399,6 +451,12 @@ void OpenAIProvider::analyzeConversation(const QString& systemPrompt, const QJso
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
+    // A conversation turn is prose the user reads, so a cut-off reply still has
+    // value — show it with a notice rather than discarding it (see
+    // TruncationPolicy). The one-shot analyze()/analyzeUrl() paths keep Fail:
+    // their result is machine-parsed.
+    m_truncationPolicy = TruncationPolicy::ShowPartial;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -426,9 +484,10 @@ void OpenAIProvider::onAnalysisReply(QNetworkReply* reply)
                 emit analysisFailed(tr_("ai.openai.error", "OpenAI error: %1").arg(apiError));
                 return;
             }
+            // Bounded/classified, never the raw body — see logSafeErrorBody().
             qWarning() << "AI request failed"
                        << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt()
-                       << "-" << body;
+                       << "-" << logSafeErrorBody(body);
         }
         emit analysisFailed(friendlyNetworkError(reply));
         return;
@@ -449,17 +508,30 @@ void OpenAIProvider::onAnalysisReply(QNetworkReply* reply)
         return;
     }
 
-    const QString finishReason = choices[0].toObject()["finish_reason"].toString();
-    QString content = choices[0].toObject()["message"].toObject()["content"].toString();
-    // finish_reason "length" = the answer hit max_completion_tokens. Never emit
-    // a truncated reply as if complete (see MAX_OUTPUT_TOKENS).
-    if (content.isEmpty() || finishReason == QLatin1String("length")) {
-        qWarning() << "OpenAI: finish_reason" << finishReason
-                   << "content chars" << content.size();
-        emit analysisFailed(finishReason == QLatin1String("length")
-            ? truncatedResponseError()
-            : tr_("ai.openai.emptyContent", "OpenAI returned empty response content"));
-        return;
+    const QJsonObject choice = choices[0].toObject();
+    const QString finishReason = choice["finish_reason"].toString();
+    const QJsonObject message = choice["message"].toObject();
+    QString content = message["content"].toString();
+    // "length" = hit max_completion_tokens; "content_filter" = moderation cut
+    // it short. Either way the text in hand is not the whole answer.
+    const bool truncated = finishReason == QLatin1String("length")
+                        || finishReason == QLatin1String("content_filter");
+    if (content.isEmpty() || truncated) {
+        qWarning() << "OpenAI: model" << m_model << "finish_reason" << finishReason
+                   << "content chars" << content.size()
+                   << "reasoning tokens"
+                   << root["usage"].toObject()["completion_tokens_details"]
+                          .toObject()["reasoning_tokens"].toInt();
+        // `message.refusal` carries the model's own stated reason; without this
+        // it reads as a bare "empty response content".
+        const QString refusal = message["refusal"].toString();
+        if (content.isEmpty() && !refusal.isEmpty()) {
+            emit analysisFailed(tr_("ai.openai.refused", "OpenAI declined the request: %1").arg(refusal));
+            return;
+        }
+        if (dispatchTruncatedOrEmpty(content, truncated,
+                tr_("ai.openai.emptyContent", "OpenAI returned empty response content")))
+            return;
     }
     emit analysisComplete(content);
 }
@@ -547,18 +619,32 @@ void OpenAIProvider::onTestReply(QNetworkReply* reply)
 
 // Turn extended thinking OFF, explicitly, on every request.
 //
-// This has to be explicit because the default is NOT stable across models:
-// claude-sonnet-4-6 runs without thinking when the field is omitted, while
-// claude-sonnet-5 runs ADAPTIVE thinking when the field is omitted. Since
-// max_tokens caps thinking + response text together, omitting the field on
-// Sonnet 5 let thinking consume the entire budget — the reply came back HTTP
-// 200 with a thinking block and no text block at all, which is #1691's
-// "Anthropic returned empty response content" for every request the user sent.
+// This has to be explicit because the default is NOT stable across models.
+// Per Anthropic's thinking documentation (checked 2026-07-29): omitting the
+// `thinking` field runs NO thinking on claude-sonnet-4-6, but runs ADAPTIVE
+// thinking on claude-sonnet-5. Since max_tokens caps thinking + response text
+// together, omitting it on Sonnet 5 lets thinking consume the entire budget
+// and the reply carries no text block at all.
+//
+// That is the mechanism behind #1691, whose user-visible symptom was
+// "Anthropic returned empty response content" on every request. Note the issue
+// itself reports only the symptom — it names no model and carries no wire
+// capture, and the block-type logging that would show a thinking-only reply is
+// added by this same change. The mechanism is inferred from the documented
+// defaults, not observed in that report; the logging exists so the next one
+// can be settled from the log instead.
 //
 // Off (not merely bounded) is the right setting here for the same reason the
 // OpenAI and Gemini paths force reasoning/thinking off: dial-in advice needs
 // little chain-of-thought, and hidden thinking tokens are billed at the output
-// rate. Both selectable models accept the "disabled" form.
+// rate.
+//
+// INVARIANT: assumes every availableModels() entry accepts thinking type
+// "disabled" — guard/branch here if the catalog ever gains one that doesn't.
+// This is not theoretical: newer Anthropic models reject the disabled form
+// outright (thinking is always on, omit the field instead) or accept it only
+// at or below a given effort level. Adding such a model to the catalog would
+// turn EVERY Anthropic request into a 400, which is a worse #1691 than #1691.
 static void disableAnthropicThinking(QJsonObject& requestBody)
 {
     QJsonObject thinking;
@@ -656,6 +742,7 @@ void AnthropicProvider::analyze(const QString& systemPrompt, const QString& user
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -682,6 +769,7 @@ void AnthropicProvider::analyzeUrl(const QString& systemPrompt, const QString& u
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -718,6 +806,12 @@ void AnthropicProvider::analyzeConversation(const QString& systemPrompt, const Q
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
+    // A conversation turn is prose the user reads, so a cut-off reply still has
+    // value — show it with a notice rather than discarding it (see
+    // TruncationPolicy). The one-shot analyze()/analyzeUrl() paths keep Fail:
+    // their result is machine-parsed.
+    m_truncationPolicy = TruncationPolicy::ShowPartial;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -803,9 +897,10 @@ void AnthropicProvider::onAnalysisReply(QNetworkReply* reply)
                 emit analysisFailed(tr_("ai.anthropic.error", "Anthropic error: %1").arg(apiError));
                 return;
             }
+            // Bounded/classified, never the raw body — see logSafeErrorBody().
             qWarning() << "AI request failed"
                        << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt()
-                       << "-" << body;
+                       << "-" << logSafeErrorBody(body);
         }
         emit analysisFailed(friendlyNetworkError(reply));
         return;
@@ -820,9 +915,18 @@ void AnthropicProvider::onAnalysisReply(QNetworkReply* reply)
         return;
     }
 
+    // Read stop_reason BEFORE any content gate. An early return above it makes
+    // the truncation branch unreachable for exactly the case that matters —
+    // the reply that stopped with nothing to show. That ordering bug shipped
+    // in this file's Gemini handler and is fixed there too.
+    const QString stopReason = root["stop_reason"].toString();
+
     QJsonArray content = root["content"].toArray();
     if (content.isEmpty()) {
-        emit analysisFailed(tr_("ai.anthropic.noResponse", "Anthropic returned no response"));
+        qWarning() << "Anthropic: model" << m_model << "no content blocks, stop_reason" << stopReason;
+        emit analysisFailed(stopReason == QLatin1String("max_tokens")
+            ? truncatedResponseError()
+            : tr_("ai.anthropic.noResponse", "Anthropic returned no response"));
         return;
     }
 
@@ -836,25 +940,31 @@ void AnthropicProvider::onAnalysisReply(QNetworkReply* reply)
         if (obj["type"].toString() == QLatin1String("text"))
             text += obj["text"].toString();
     }
-    // stop_reason "max_tokens" = the answer hit the cap. Report it rather than
-    // emitting a half-written reply whose trailing nextShot JSON block is gone.
-    // Log the block types on any text-less reply: content can be non-empty
-    // while carrying no text block at all (a thinking-only reply — #1691), and
-    // the generic message alone made that indistinguishable from a real
-    // refusal for three days of user reports.
-    const QString stopReason = root["stop_reason"].toString();
-    const bool truncated = stopReason == QLatin1String("max_tokens");
-    if (text.isEmpty() || truncated) {
+    // Treat anything that is not a natural end as an unfinished turn, rather
+    // than listing the bad reasons. "pause_turn" is the one that forced this:
+    // it means the API paused a long-running server-tool turn and the response
+    // must be fed back to continue, so its text is partial by definition — and
+    // analyzeUrl() attaches the web_fetch server tool, so this path can reach
+    // it. "refusal" and "model_context_window_exceeded" are likewise not
+    // answers. Allow-listing the two good reasons fails safe as Anthropic adds
+    // more; enumerating the bad ones does not.
+    const bool unfinished = stopReason != QLatin1String("end_turn")
+                         && stopReason != QLatin1String("stop_sequence");
+    if (text.isEmpty() || unfinished) {
+        // Log the block types on any text-less reply: content can be non-empty
+        // while carrying no text block at all (a thinking-only reply — #1691),
+        // and the generic message alone made that indistinguishable from a
+        // refusal. The model matters too: the #1691 root cause was that the
+        // thinking default differs BETWEEN models.
         QStringList blockTypes;
         for (const QJsonValue& block : content)
             blockTypes << block.toObject()["type"].toString();
-        qWarning() << "Anthropic: stop_reason" << stopReason
-                   << "block types" << blockTypes
-                   << "text chars" << text.size();
-        emit analysisFailed(truncated
-            ? truncatedResponseError()
-            : tr_("ai.anthropic.emptyContent", "Anthropic returned empty response content"));
-        return;
+        qWarning() << "Anthropic: model" << m_model << "stop_reason" << stopReason
+                   << "block types" << blockTypes << "text chars" << text.size()
+                   << "output tokens" << root["usage"].toObject()["output_tokens"].toInt();
+        if (dispatchTruncatedOrEmpty(text, unfinished,
+                tr_("ai.anthropic.emptyContent", "Anthropic returned empty response content")))
+            return;
     }
     emit analysisComplete(text);
 }
@@ -1016,8 +1126,10 @@ QString GeminiProvider::shortModelName() const
 QString GeminiProvider::apiUrl() const
 {
     // Use URL without key - key is passed via header for better security
-    return QString("https://generativelanguage.googleapis.com/v1beta/models/%1:generateContent")
-        .arg(m_model);
+    const QString host = m_baseUrl.isEmpty()
+        ? QStringLiteral("https://generativelanguage.googleapis.com")
+        : m_baseUrl;
+    return host + QStringLiteral("/v1beta/models/%1:generateContent").arg(m_model);
 }
 
 void GeminiProvider::sendRequest(const QJsonObject& requestBody)
@@ -1069,6 +1181,7 @@ void GeminiProvider::analyze(const QString& systemPrompt, const QString& userPro
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
 
     // Gemini uses a different format
     QJsonObject requestBody;
@@ -1107,6 +1220,7 @@ void GeminiProvider::analyzeUrl(const QString& systemPrompt, const QString& user
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
 
     // Same body as analyze() plus the url_context server tool: the API
     // fetches the URL named in the user prompt during generateContent
@@ -1148,6 +1262,12 @@ void GeminiProvider::analyzeConversation(const QString& systemPrompt, const QJso
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
+    // A conversation turn is prose the user reads, so a cut-off reply still has
+    // value — show it with a notice rather than discarding it (see
+    // TruncationPolicy). The one-shot analyze()/analyzeUrl() paths keep Fail:
+    // their result is machine-parsed.
+    m_truncationPolicy = TruncationPolicy::ShowPartial;
 
     QJsonObject requestBody;
 
@@ -1200,9 +1320,10 @@ void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
                 emit analysisFailed(tr_("ai.gemini.error", "Gemini error: %1").arg(apiError));
                 return;
             }
+            // Bounded/classified, never the raw body — see logSafeErrorBody().
             qWarning() << "AI request failed"
                        << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt()
-                       << "-" << body;
+                       << "-" << logSafeErrorBody(body);
         }
         emit analysisFailed(friendlyNetworkError(reply));
         return;
@@ -1225,19 +1346,32 @@ void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
 
     QJsonArray candidates = root["candidates"].toArray();
     if (candidates.isEmpty()) {
-        emit analysisFailed(tr_("ai.gemini.noResponse", "Gemini returned no response"));
+        // A prompt-level block returns promptFeedback.blockReason and no
+        // candidates. That reason IS the explanation; discarding it left the
+        // user with five generic words and the log with nothing.
+        const QString blockReason = root["promptFeedback"].toObject()["blockReason"].toString();
+        qWarning() << "Gemini: model" << m_model << "no candidates, blockReason" << blockReason;
+        emit analysisFailed(blockReason.isEmpty()
+            ? tr_("ai.gemini.noResponse", "Gemini returned no response")
+            : tr_("ai.gemini.blocked", "Gemini refused the request (%1).").arg(blockReason));
         return;
     }
 
-    QJsonArray parts = candidates[0].toObject()["content"].toObject()["parts"].toArray();
-    if (parts.isEmpty()) {
-        emit analysisFailed(tr_("ai.gemini.emptyContent2", "Gemini returned empty content"));
-        return;
-    }
+    // Read finishReason BEFORE the parts gate. When Gemini stops on MAX_TOKENS
+    // *while still thinking* — and gemini-3.5-flash runs thinkingLevel
+    // "minimal", which is on, not off — the candidate comes back carrying a
+    // finishReason and NO content key at all. Reading it after an
+    // `parts.isEmpty()` early return made this branch unreachable for exactly
+    // the #1691-shaped failure it exists to catch: budget eaten by hidden
+    // reasoning, no text, opaque error. SAFETY/RECITATION/PROHIBITED_CONTENT
+    // arrive the same way.
+    const QString finishReason = candidates[0].toObject()["finishReason"].toString();
+    const bool truncated = finishReason == QLatin1String("MAX_TOKENS");
 
     // Join every non-thought text part: plain replies have exactly one, but
     // a url_context response (analyzeUrl) may split the answer across parts;
     // thought parts are hidden reasoning and must not leak into the answer.
+    const QJsonArray parts = candidates[0].toObject()["content"].toObject()["parts"].toArray();
     QString text;
     for (const QJsonValue& partVal : parts) {
         const QJsonObject part = partVal.toObject();
@@ -1245,17 +1379,21 @@ void GeminiProvider::onAnalysisReply(QNetworkReply* reply)
             continue;
         text += part["text"].toString();
     }
-    // finishReason "MAX_TOKENS" = the answer hit maxOutputTokens; don't emit a
-    // truncated reply as if complete (see MAX_OUTPUT_TOKENS).
-    const QString finishReason = candidates[0].toObject()["finishReason"].toString();
-    const bool truncated = finishReason == QLatin1String("MAX_TOKENS");
+
     if (text.isEmpty() || truncated) {
-        qWarning() << "Gemini: finishReason" << finishReason
-                   << "parts" << parts.size() << "text chars" << text.size();
-        emit analysisFailed(truncated
-            ? truncatedResponseError()
-            : tr_("ai.gemini.emptyContent", "Gemini returned empty response content"));
-        return;
+        // thoughtsTokenCount is the field that names a thinking-ate-the-budget
+        // failure on sight, so log it next to the reason rather than only in
+        // the qInfo line above.
+        qWarning() << "Gemini: model" << m_model << "finishReason" << finishReason
+                   << "parts" << parts.size() << "text chars" << text.size()
+                   << "thought tokens" << usage["thoughtsTokenCount"].toInt()
+                   << "output tokens" << usage["candidatesTokenCount"].toInt();
+        // One message for both empty cases. There used to be two strings one
+        // word apart ("empty content" vs "empty response content"), only one of
+        // which logged — a user reporting either could not say which they hit.
+        if (dispatchTruncatedOrEmpty(text, truncated,
+                tr_("ai.gemini.emptyContent", "Gemini returned empty response content")))
+            return;
     }
     emit analysisComplete(text);
 }
@@ -1361,7 +1499,9 @@ OpenRouterProvider::OpenRouterProvider(QNetworkAccessManager* networkManager,
 
 void OpenRouterProvider::sendRequest(const QJsonObject& requestBody)
 {
-    QUrl url(QString::fromLatin1(API_URL));
+    QUrl url(m_baseUrl.isEmpty()
+        ? QString::fromLatin1(API_URL)
+        : m_baseUrl + QStringLiteral("/api/v1/chat/completions"));
     QNetworkRequest req;
     req.setUrl(url);
     req.setHeader(QNetworkRequest::ContentTypeHeader, QVariant(QString("application/json")));
@@ -1390,6 +1530,7 @@ void OpenRouterProvider::analyze(const QString& systemPrompt, const QString& use
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
 
     // OpenRouter uses OpenAI-compatible format
     QJsonObject requestBody;
@@ -1419,6 +1560,12 @@ void OpenRouterProvider::analyzeConversation(const QString& systemPrompt, const 
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
+    // A conversation turn is prose the user reads, so a cut-off reply still has
+    // value — show it with a notice rather than discarding it (see
+    // TruncationPolicy). The one-shot analyze()/analyzeUrl() paths keep Fail:
+    // their result is machine-parsed.
+    m_truncationPolicy = TruncationPolicy::ShowPartial;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -1445,9 +1592,10 @@ void OpenRouterProvider::onAnalysisReply(QNetworkReply* reply)
                 emit analysisFailed(tr_("ai.openrouter.error", "OpenRouter error: %1").arg(apiError));
                 return;
             }
+            // Bounded/classified, never the raw body — see logSafeErrorBody().
             qWarning() << "AI request failed"
                        << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt()
-                       << "-" << body;
+                       << "-" << logSafeErrorBody(body);
         }
         emit analysisFailed(friendlyNetworkError(reply));
         return;
@@ -1468,18 +1616,44 @@ void OpenRouterProvider::onAnalysisReply(QNetworkReply* reply)
         return;
     }
 
+    const QJsonObject choice = choices[0].toObject();
+
+    // OpenRouter reports an upstream provider failure as a 200 carrying an
+    // error object on the CHOICE, which the top-level root["error"] check above
+    // does not see.
+    const QJsonObject choiceError = choice["error"].toObject();
+    if (!choiceError.isEmpty()) {
+        const QString message = choiceError["message"].toString();
+        qWarning() << "OpenRouter: model" << m_model << "upstream error"
+                   << choiceError["code"].toVariant() << "-" << message;
+        emit analysisFailed(tr_("ai.openrouter.error", "OpenRouter error: %1")
+            .arg(message.isEmpty() ? tr_("ai.error.unknown", "unknown error") : message));
+        return;
+    }
+
     // finish_reason "length" = the answer hit max_tokens. This matters most on
     // OpenRouter: the model is a free-text user string, so it can point at a
     // reasoning model whose hidden tokens eat the cap the way #1691's did.
-    const QString finishReason = choices[0].toObject()["finish_reason"].toString();
-    QString content = choices[0].toObject()["message"].toObject()["content"].toString();
-    if (content.isEmpty() || finishReason == QLatin1String("length")) {
+    // "content_filter" and "error" likewise mean the text in hand is not the
+    // whole answer.
+    const QString finishReason = choice["finish_reason"].toString();
+    const QJsonObject message = choice["message"].toObject();
+    QString content = message["content"].toString();
+    const bool truncated = finishReason == QLatin1String("length")
+                        || finishReason == QLatin1String("content_filter")
+                        || finishReason == QLatin1String("error");
+    if (content.isEmpty() || truncated) {
         qWarning() << "OpenRouter: model" << m_model << "finish_reason" << finishReason
                    << "content chars" << content.size();
-        emit analysisFailed(finishReason == QLatin1String("length")
-            ? truncatedResponseError()
-            : tr_("ai.openrouter.emptyContent", "OpenRouter returned empty response content"));
-        return;
+        const QString refusal = message["refusal"].toString();
+        if (content.isEmpty() && !refusal.isEmpty()) {
+            emit analysisFailed(tr_("ai.openrouter.refused",
+                                    "OpenRouter's model declined the request: %1").arg(refusal));
+            return;
+        }
+        if (dispatchTruncatedOrEmpty(content, truncated,
+                tr_("ai.openrouter.emptyContent", "OpenRouter returned empty response content")))
+            return;
     }
     emit analysisComplete(content);
 }
@@ -1609,6 +1783,7 @@ void OllamaProvider::analyze(const QString& systemPrompt, const QString& userPro
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
 
     QJsonObject requestBody;
     requestBody["model"] = m_model;
@@ -1633,6 +1808,12 @@ void OllamaProvider::analyzeConversation(const QString& systemPrompt, const QJso
     setStatus(Status::Busy);
     m_retryCount = 0;
     ++m_reqGen;
+    m_truncationPolicy = TruncationPolicy::Fail;
+    // A conversation turn is prose the user reads, so a cut-off reply still has
+    // value — show it with a notice rather than discarding it (see
+    // TruncationPolicy). The one-shot analyze()/analyzeUrl() paths keep Fail:
+    // their result is machine-parsed.
+    m_truncationPolicy = TruncationPolicy::ShowPartial;
 
     // Use /api/chat which supports messages array natively
     QJsonObject requestBody;
@@ -1658,7 +1839,7 @@ void OllamaProvider::onAnalysisReply(QNetworkReply* reply)
         if (!body.isEmpty())
             qWarning() << "Ollama request failed"
                        << reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt()
-                       << "-" << body;
+                       << "-" << logSafeErrorBody(body);
         emit analysisFailed(friendlyNetworkError(reply));
         return;
     }
@@ -1672,16 +1853,40 @@ void OllamaProvider::onAnalysisReply(QNetworkReply* reply)
     }
 
     // Support both /api/chat (message.content) and /api/generate (response) formats
-    QString response = root["message"].toObject()["content"].toString();
+    const QJsonObject message = root["message"].toObject();
+    QString response = message["content"].toString();
     if (response.isEmpty()) {
         response = root["response"].toString();
-        if (!response.isEmpty()) {
-            qDebug() << "OllamaProvider: Used /api/generate response format (fallback)";
-        }
+        // Warn, not qDebug: taking the /api/generate shape off what may have
+        // been an /api/chat request means one of the two assumptions is wrong,
+        // and this fallback otherwise masks a legitimately-empty chat reply
+        // (truncation, refusal, thinking-only) behind a shape probe.
+        if (!response.isEmpty())
+            qWarning() << "OllamaProvider: /api/chat message.content was empty; "
+                          "fell back to the /api/generate response field";
     }
-    if (response.isEmpty()) {
-        emit analysisFailed(tr_("ai.ollama.emptyResponse", "Ollama returned empty response"));
-        return;
+
+    // This app sets no token cap for Ollama, but that is not the same as "it
+    // cannot truncate": num_predict and num_ctx live in the USER's Modelfile
+    // and server config, and Ollama reports done_reason "length" when either
+    // one stops generation. Without this check a locally-truncated reply was
+    // emitted as complete — the same defect this change fixes on the four
+    // cloud providers, on the fifth.
+    const QString doneReason = root["done_reason"].toString();
+    const bool truncated = doneReason == QLatin1String("length");
+
+    if (response.isEmpty() || truncated) {
+        // Thinking models (deepseek-r1, qwen3) return reasoning in
+        // message.thinking with a possibly-empty message.content — literally
+        // #1691's shape, on a local model. Say so rather than logging nothing,
+        // which is what this branch did.
+        qWarning() << "Ollama: model" << m_model << "done_reason" << doneReason
+                   << "content chars" << response.size()
+                   << "thinking chars" << message["thinking"].toString().size()
+                   << "eval_count" << root["eval_count"].toInt();
+        if (dispatchTruncatedOrEmpty(response, truncated,
+                tr_("ai.ollama.emptyResponse", "Ollama returned empty response")))
+            return;
     }
 
     emit analysisComplete(response);

--- a/src/ai/aiprovider.h
+++ b/src/ai/aiprovider.h
@@ -98,9 +98,29 @@ protected:
     // Retry support: each sendRequest() assigns m_retryFn; each onAnalysisReply() calls tryScheduleRetry()
     bool tryScheduleRetry(QNetworkReply* reply);  // returns true if retry was scheduled
 
+    // User-visible error for a reply that hit MAX_OUTPUT_TOKENS. Shared across
+    // providers: every one of them can truncate, and the user's remedy is the
+    // same regardless of which API produced it.
+    QString truncatedResponseError() const;
+
     static constexpr int ANALYSIS_TIMEOUT_MS = 60000;   // 60s for cloud AI analysis
     static constexpr int TEST_TIMEOUT_MS = 15000;        // 15s for connection tests
     static constexpr int MAX_RETRIES = 3;                // max retries for 429/502/503/504
+
+    // Output cap for every analysis request, on every provider.
+    //
+    // Was 1024, which was too tight for the job: a dial-in reply plus the
+    // trailing fenced `nextShot` JSON block (#1054) lands right at that edge,
+    // and NO provider inspected its stop/finish reason — so a capped reply was
+    // emitted as if complete, silently missing the JSON block. #1691 was the
+    // acute form: Anthropic sends no `thinking` field, and claude-sonnet-5
+    // runs adaptive thinking by DEFAULT (claude-sonnet-4-6 does not), so the
+    // whole 1024 went to a thinking block and the reply carried no text block
+    // at all — a hard "empty response content" error on every request.
+    //
+    // Raising the cap is close to free: it is a ceiling, not a reservation —
+    // billing is on tokens actually produced.
+    static constexpr int MAX_OUTPUT_TOKENS = 4096;
 
     QNetworkAccessManager* m_networkManager = nullptr;
     TranslationManager* m_translationManager = nullptr;

--- a/src/ai/aiprovider.h
+++ b/src/ai/aiprovider.h
@@ -98,25 +98,63 @@ protected:
     // Retry support: each sendRequest() assigns m_retryFn; each onAnalysisReply() calls tryScheduleRetry()
     bool tryScheduleRetry(QNetworkReply* reply);  // returns true if retry was scheduled
 
+    // What to do when a reply stops because it hit the output cap.
+    //
+    // A one-shot analysis (analyze/analyzeUrl) is parsed by machine: the caller
+    // reads a trailing fenced `nextShot` JSON block (#1054, parsed by
+    // AIManager::parseStructuredNext), which a cut-off reply has lost. A
+    // half-parsed result is worse than no result, so those paths fail.
+    //
+    // A conversation turn (analyzeConversation) is prose the user reads, so
+    // several thousand useful tokens beat an error — show them with a notice
+    // appended. Each analyze*() sets the policy before sending; the shared
+    // reply handler reads it.
+    enum class TruncationPolicy { Fail, ShowPartial };
+    TruncationPolicy m_truncationPolicy = TruncationPolicy::Fail;
+
     // User-visible error for a reply that hit MAX_OUTPUT_TOKENS. Shared across
     // providers: every one of them can truncate, and the user's remedy is the
     // same regardless of which API produced it.
     QString truncatedResponseError() const;
 
+    // Notice appended to a partial reply under TruncationPolicy::ShowPartial.
+    QString truncationNotice() const;
+
+    // Shared exit for "the reply is empty, or was cut off, or both". Returns
+    // true when it has emitted (analysisComplete for an allowed partial,
+    // analysisFailed otherwise) and the caller must return; false when the
+    // reply is fine and the caller should carry on to emit it.
+    //
+    // Factored out because all five providers need identical policy on top of
+    // five different vendor spellings of "why I stopped" — the divergence
+    // belongs in each handler's parsing, not in what we do about it.
+    bool dispatchTruncatedOrEmpty(const QString& text, bool truncated,
+                                  const QString& emptyMessage);
+
+    // Bound an untrusted provider error body before it reaches the log.
+    //
+    // These logs get attached to public GitHub issues, and a provider's 4xx
+    // body echoes fragments of the request back: Anthropic quotes the offending
+    // field and its value, OpenAI's moderation errors quote the flagged prompt
+    // text. Our prompts carry the user's shot history, bean names and tasting
+    // notes (AIManager::sanitizeApiMessages). Log the machine-readable type and
+    // a bounded prefix, never the whole body.
+    static QString logSafeErrorBody(const QByteArray& body);
+
     static constexpr int ANALYSIS_TIMEOUT_MS = 60000;   // 60s for cloud AI analysis
     static constexpr int TEST_TIMEOUT_MS = 15000;        // 15s for connection tests
     static constexpr int MAX_RETRIES = 3;                // max retries for 429/502/503/504
+    static constexpr int LOG_BODY_LIMIT = 200;           // chars of a provider error body we log
 
     // Output cap for every analysis request, on every provider.
     //
     // Was 1024, which was too tight for the job: a dial-in reply plus the
     // trailing fenced `nextShot` JSON block (#1054) lands right at that edge,
-    // and NO provider inspected its stop/finish reason — so a capped reply was
-    // emitted as if complete, silently missing the JSON block. #1691 was the
-    // acute form: Anthropic sends no `thinking` field, and claude-sonnet-5
-    // runs adaptive thinking by DEFAULT (claude-sonnet-4-6 does not), so the
-    // whole 1024 went to a thinking block and the reply carried no text block
-    // at all — a hard "empty response content" error on every request.
+    // and no provider inspected its stop/finish reason — so a capped reply was
+    // emitted as if complete, silently missing the JSON block.
+    //
+    // #1691 was the acute form, on Anthropic; the mechanism is recorded once at
+    // disableAnthropicThinking() in aiprovider.cpp rather than restated here.
     //
     // Raising the cap is close to free: it is a ceiling, not a reservation —
     // billing is on tokens actually produced.
@@ -266,6 +304,10 @@ public:
     QString modelHint() const override;
 
     void setApiKey(const QString& key) { m_apiKey = key; }
+    // empty → keeps default upstream URL. Matches OpenAI/Anthropic; exists so
+    // the truncation/finish-reason handling is reachable from a test against a
+    // canned-response server (the branch shipped untested and was broken).
+    void setBaseUrl(const QString& url) { m_baseUrl = url.endsWith(QLatin1Char('/')) ? url.chopped(1) : url; }
     // Select the wire model. Ignores empty (keeps current default) and any id
     // not in availableModels(), so a stale/unknown stored value can't break the
     // request URL.
@@ -288,6 +330,7 @@ private:
     void sendRequest(const QJsonObject& requestBody);
 
     QString m_apiKey;
+    QString m_baseUrl;
     // Selected wire model. Defaulted in the constructor to the first
     // availableModels() entry (the recommended default), so the C++ default and
     // the UI's "unset → index 0" fallback reference the same fact and can't drift.
@@ -313,6 +356,9 @@ public:
 
     void setApiKey(const QString& key) { m_apiKey = key; }
     void setModel(const QString& model) { m_model = model; }
+    // empty → keeps default upstream URL. See GeminiProvider::setBaseUrl for
+    // why this exists.
+    void setBaseUrl(const QString& url) { m_baseUrl = url.endsWith(QLatin1Char('/')) ? url.chopped(1) : url; }
 
     void analyze(const QString& systemPrompt, const QString& userPrompt) override;
     void analyzeConversation(const QString& systemPrompt, const QJsonArray& messages) override;
@@ -326,6 +372,7 @@ private:
     void sendRequest(const QJsonObject& requestBody);
 
     QString m_apiKey;
+    QString m_baseUrl;
     QString m_model;
     static constexpr const char* API_URL = "https://openrouter.ai/api/v1/chat/completions";
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -668,8 +668,10 @@ target_include_directories(tst_aimanager PRIVATE ${CMAKE_BINARY_DIR})
 # Pins availableModels()/setModel()/shortModelName()/modelName() for the
 # user-selectable providers (OpenAI, Anthropic, Gemini): catalog order,
 # constructor default = first entry, and the empty/unknown/valid setModel
-# branches that AIManager drives from Settings.ai.providerModel(). Pure logic,
-# so the target only needs aiprovider.cpp (no network/mocking).
+# branches that AIManager drives from Settings.ai.providerModel(). Also pins the
+# request shape and the stop/finish-reason handling for all five providers,
+# which needs a canned-response server (FakeProviderServer) on loopback —
+# Qt6::Network comes in via add_decenza_test.
 add_decenza_test(tst_aiproviders
     tst_aiproviders.cpp
     ${CMAKE_SOURCE_DIR}/src/ai/aiprovider.cpp

--- a/tests/tst_aiproviders.cpp
+++ b/tests/tst_aiproviders.cpp
@@ -13,19 +13,98 @@
 //   - construction  → default to availableModels().first().id
 //   - modelHint()   → non-empty and mentions every catalog entry by name
 //
-// These methods are pure (no network I/O) and public, so no mocking or
+// Those catalog methods are pure (no network I/O) and public, so no mocking or
 // friend-class access is needed. Gemini is covered too — it shipped the
 // pattern this test also guards, previously untested.
+//
+// The suite also pins the Anthropic REQUEST SHAPE (#1691), which does need a
+// canned-response server: what broke there was an absent field in the posted
+// JSON, not anything a pure method exposes. See FakeAnthropicServer below.
 
 #include <QtTest>
+#include <QHostAddress>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QNetworkAccessManager>
 #include <QRegularExpression>
+#include <QSignalSpy>
+#include <QTcpServer>
+#include <QTcpSocket>
 #include <QList>
 #include <QPair>
 #include <QString>
 
 #include "ai/aiprovider.h"
 #include "core/translationmanager.h"
+
+// Canned-response HTTP server for the Anthropic request/reply contract below.
+// Records the request BODY (not just the request line) because what these
+// tests assert is what we send in the JSON — the #1691 regression was an
+// absent field, invisible from the URL. Same shape as FakeBeanBaseServer in
+// tst_beanbaseclient.cpp.
+//
+// NOTE: no raw string literals anywhere in this file — moc miscounts the
+// braces inside "..." and silently drops every class declared after one.
+class FakeAnthropicServer : public QObject {
+    Q_OBJECT
+public:
+    FakeAnthropicServer() {
+        connect(&m_server, &QTcpServer::newConnection, this, [this]() {
+            while (m_server.hasPendingConnections()) {
+                QTcpSocket* sock = m_server.nextPendingConnection();
+                auto* buf = new QByteArray;
+                connect(sock, &QTcpSocket::readyRead, this, [this, sock, buf]() {
+                    buf->append(sock->readAll());
+                    // Wait for the whole body: a POST can arrive in several
+                    // chunks, and a half-read body parses as invalid JSON.
+                    const qsizetype headerEnd = buf->indexOf("\r\n\r\n");
+                    if (headerEnd < 0) return;
+                    const QByteArray headers = buf->left(headerEnd);
+                    const qsizetype clPos = headers.indexOf("Content-Length: ");
+                    if (clPos < 0) return;
+                    const qsizetype expected = headers.mid(clPos + 16).split('\r').first().toLongLong();
+                    const QByteArray body = buf->mid(headerEnd + 4);
+                    if (body.size() < expected) return;
+
+                    m_requestBodies.append(body);
+                    const QByteArray resp =
+                        "HTTP/1.1 200 OK\r\n"
+                        "Content-Type: application/json\r\n"
+                        "Content-Length: " + QByteArray::number(m_responseBody.size()) + "\r\n"
+                        "Connection: close\r\n"
+                        "\r\n" + m_responseBody;
+                    sock->write(resp);
+                    sock->disconnectFromHost();
+                });
+                connect(sock, &QTcpSocket::disconnected, sock, [sock, buf]() {
+                    delete buf;
+                    sock->deleteLater();
+                });
+            }
+        });
+        const bool ok = m_server.listen(QHostAddress::LocalHost, 0);
+        Q_ASSERT(ok);
+    }
+
+    QString baseUrl() const {
+        return QStringLiteral("http://127.0.0.1:%1").arg(m_server.serverPort());
+    }
+
+    void respondWith(const QByteArray& body) { m_responseBody = body; }
+
+    // Body of the last request the provider actually sent, parsed as JSON.
+    QJsonObject lastRequest() const {
+        if (m_requestBodies.isEmpty()) return {};
+        return QJsonDocument::fromJson(m_requestBodies.last()).object();
+    }
+    qsizetype requestCount() const { return m_requestBodies.size(); }
+
+private:
+    QTcpServer m_server;
+    QByteArray m_responseBody = "{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}],\"stop_reason\":\"end_turn\"}";
+    QList<QByteArray> m_requestBodies;
+};
 
 namespace {
 
@@ -169,6 +248,90 @@ private slots:
         QVERIFY(GeminiProvider(&nam, "key").supportsUrlAnalysis());
         QVERIFY(!OpenRouterProvider(&nam, "key", "model").supportsUrlAnalysis());
         QVERIFY(!OllamaProvider(&nam, "http://localhost:11434", "model").supportsUrlAnalysis());
+    }
+
+    // #1691: every Anthropic request must turn thinking OFF explicitly.
+    //
+    // The default is not stable across models — claude-sonnet-4-6 runs without
+    // thinking when the field is omitted, claude-sonnet-5 runs adaptive. Since
+    // max_tokens bounds thinking + text together, an omitted field on Sonnet 5
+    // let thinking eat the whole budget and the reply carried no text block at
+    // all, failing 100% of the time. Nothing in the request URL shows this, so
+    // the assertion has to be on the posted JSON.
+    void anthropicRequestsDisableThinkingAndUseTheRaisedCap()
+    {
+        QNetworkAccessManager nam;
+        FakeAnthropicServer server;
+        AnthropicProvider p(&nam, QStringLiteral("key"));
+        p.setBaseUrl(server.baseUrl());
+
+        QSignalSpy complete(&p, &AIProvider::analysisComplete);
+
+        p.analyze(QStringLiteral("system"), QStringLiteral("user"));
+        QVERIFY(complete.wait(5000));
+        QCOMPARE(server.requestCount(), 1);
+
+        QJsonObject body = server.lastRequest();
+        QCOMPARE(body["thinking"].toObject()["type"].toString(), QStringLiteral("disabled"));
+        QCOMPARE(body["max_tokens"].toInt(), 4096);
+
+        // analyzeConversation() is the path the in-app advisor actually uses
+        // (AIConversation::sendRequest) and is where #1691 was reported.
+        QJsonArray messages;
+        QJsonObject userMsg;
+        userMsg["role"] = QStringLiteral("user");
+        userMsg["content"] = QStringLiteral("how did this shot taste?");
+        messages.append(userMsg);
+        p.analyzeConversation(QStringLiteral("system"), messages);
+        QVERIFY(complete.wait(5000));
+        QCOMPARE(server.requestCount(), 2);
+
+        body = server.lastRequest();
+        QCOMPARE(body["thinking"].toObject()["type"].toString(), QStringLiteral("disabled"));
+        QCOMPARE(body["max_tokens"].toInt(), 4096);
+    }
+
+    // A 200 whose content holds blocks but no TEXT block is what #1691 looked
+    // like on the wire. Belt and braces for the fix above: if thinking ever
+    // returns (a new model default, a future feature), the user must get the
+    // truncation message and the log must name the block types — the old
+    // generic "empty response content" was indistinguishable from a refusal
+    // and cost three days of user reports to place.
+    void anthropicReportsAThinkingOnlyReplyAsTruncated()
+    {
+        QNetworkAccessManager nam;
+        FakeAnthropicServer server;
+        server.respondWith(
+            "{\"content\":[{\"type\":\"thinking\",\"thinking\":\"\"}],\"stop_reason\":\"max_tokens\"}");
+        AnthropicProvider p(&nam, QStringLiteral("key"));
+        p.setBaseUrl(server.baseUrl());
+
+        QSignalSpy failed(&p, &AIProvider::analysisFailed);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Anthropic: stop_reason"));
+
+        p.analyze(QStringLiteral("system"), QStringLiteral("user"));
+        QVERIFY(failed.wait(5000));
+        QCOMPARE(failed.size(), 1);
+        const QString message = failed.first().first().toString();
+        QVERIFY2(message.contains(QStringLiteral("cut off")),
+                 qPrintable(QStringLiteral("expected the truncation message, got: ") + message));
+    }
+
+    // The truncation branch must not swallow good replies: stop_reason
+    // "end_turn" with real text still completes.
+    void anthropicCompleteReplyStillSucceeds()
+    {
+        QNetworkAccessManager nam;
+        FakeAnthropicServer server;
+        server.respondWith(
+            "{\"content\":[{\"type\":\"text\",\"text\":\"Grind finer.\"}],\"stop_reason\":\"end_turn\"}");
+        AnthropicProvider p(&nam, QStringLiteral("key"));
+        p.setBaseUrl(server.baseUrl());
+
+        QSignalSpy complete(&p, &AIProvider::analysisComplete);
+        p.analyze(QStringLiteral("system"), QStringLiteral("user"));
+        QVERIFY(complete.wait(5000));
+        QCOMPARE(complete.first().first().toString(), QStringLiteral("Grind finer."));
     }
 };
 

--- a/tests/tst_aiproviders.cpp
+++ b/tests/tst_aiproviders.cpp
@@ -19,7 +19,7 @@
 //
 // The suite also pins the Anthropic REQUEST SHAPE (#1691), which does need a
 // canned-response server: what broke there was an absent field in the posted
-// JSON, not anything a pure method exposes. See FakeAnthropicServer below.
+// JSON, not anything a pure method exposes. See FakeProviderServer below.
 
 #include <QtTest>
 #include <QHostAddress>
@@ -35,38 +35,67 @@
 #include <QPair>
 #include <QString>
 
+#include <memory>
+
 #include "ai/aiprovider.h"
 #include "core/translationmanager.h"
 
-// Canned-response HTTP server for the Anthropic request/reply contract below.
+// Canned-response HTTP server for the provider request/reply contracts below.
 // Records the request BODY (not just the request line) because what these
 // tests assert is what we send in the JSON — the #1691 regression was an
 // absent field, invisible from the URL. Same shape as FakeBeanBaseServer in
-// tst_beanbaseclient.cpp.
+// tst_beanbaseclient.cpp, which handles GETs and so needed no body
+// accumulation.
 //
-// NOTE: no raw string literals anywhere in this file — moc miscounts the
-// braces inside "..." and silently drops every class declared after one.
-class FakeAnthropicServer : public QObject {
+// Provider-agnostic: every provider here speaks JSON over POST, so only the
+// canned response body differs.
+//
+// NOTE: no RAW string literals (R"(...)") in this file. Ordinary escaped
+// literals are fine and are used throughout — including brace-heavy JSON in
+// the canned bodies below, which is why the rule has to name the raw form
+// specifically rather than "string literals".
+class FakeProviderServer : public QObject {
     Q_OBJECT
 public:
-    FakeAnthropicServer() {
+    FakeProviderServer() {
         connect(&m_server, &QTcpServer::newConnection, this, [this]() {
             while (m_server.hasPendingConnections()) {
                 QTcpSocket* sock = m_server.nextPendingConnection();
-                auto* buf = new QByteArray;
-                connect(sock, &QTcpSocket::readyRead, this, [this, sock, buf]() {
+                // shared_ptr, captured BY VALUE in both lambdas: a raw
+                // new/delete pair split across readyRead and disconnected is
+                // both a use-after-free (readyRead can fire after disconnected
+                // for data already in the read buffer) and a leak (QTcpServer
+                // parents its sockets, so server destruction can reap the
+                // socket before disconnected is ever delivered). The leak half
+                // is invisible on macOS — no LSan — and would surface only in
+                // the nightly Linux ASan job.
+                auto buf = std::make_shared<QByteArray>();
+                auto responded = std::make_shared<bool>(false);
+                connect(sock, &QTcpSocket::readyRead, this, [this, sock, buf, responded]() {
+                    if (*responded) return;  // one response per connection
                     buf->append(sock->readAll());
                     // Wait for the whole body: a POST can arrive in several
                     // chunks, and a half-read body parses as invalid JSON.
                     const qsizetype headerEnd = buf->indexOf("\r\n\r\n");
                     if (headerEnd < 0) return;
                     const QByteArray headers = buf->left(headerEnd);
-                    const qsizetype clPos = headers.indexOf("Content-Length: ");
+                    // Header names are case-insensitive by spec. Qt title-cases
+                    // them at serialization (qhttpnetworkrequest.cpp), so the
+                    // exact spelling is stable today — but matching on a
+                    // lowered copy costs nothing and won't hang every test here
+                    // for 5s if that ever changes. (QByteArray::indexOf has no
+                    // case-insensitive overload, hence the copy; toLower() is
+                    // length-preserving for ASCII so the offset still applies
+                    // to the original.)
+                    static const QByteArray kContentLength = "content-length: ";
+                    const qsizetype clPos = headers.toLower().indexOf(kContentLength);
                     if (clPos < 0) return;
-                    const qsizetype expected = headers.mid(clPos + 16).split('\r').first().toLongLong();
+                    const qsizetype expected =
+                        headers.mid(clPos + kContentLength.size()).split('\r').first().toLongLong();
                     const QByteArray body = buf->mid(headerEnd + 4);
                     if (body.size() < expected) return;
 
+                    *responded = true;
                     m_requestBodies.append(body);
                     const QByteArray resp =
                         "HTTP/1.1 200 OK\r\n"
@@ -77,14 +106,16 @@ public:
                     sock->write(resp);
                     sock->disconnectFromHost();
                 });
-                connect(sock, &QTcpSocket::disconnected, sock, [sock, buf]() {
-                    delete buf;
-                    sock->deleteLater();
-                });
+                connect(sock, &QTcpSocket::disconnected, sock, &QObject::deleteLater);
             }
         });
-        const bool ok = m_server.listen(QHostAddress::LocalHost, 0);
-        Q_ASSERT(ok);
+        // Not Q_ASSERT: tests are also built in Release for the tag-push
+        // linux-release job, where it compiles out — a failed listen() would
+        // then point baseUrl() at port 0 and every test here would fail on a
+        // 5s timeout with no clue why.
+        if (!m_server.listen(QHostAddress::LocalHost, 0))
+            qFatal("FakeProviderServer: listen() failed: %s",
+                   qPrintable(m_server.errorString()));
     }
 
     QString baseUrl() const {
@@ -250,7 +281,7 @@ private slots:
         QVERIFY(!OllamaProvider(&nam, "http://localhost:11434", "model").supportsUrlAnalysis());
     }
 
-    // #1691: every Anthropic request must turn thinking OFF explicitly.
+    // #1691: EVERY Anthropic request must turn thinking OFF explicitly.
     //
     // The default is not stable across models — claude-sonnet-4-6 runs without
     // thinking when the field is omitted, claude-sonnet-5 runs adaptive. Since
@@ -258,10 +289,13 @@ private slots:
     // let thinking eat the whole budget and the reply carried no text block at
     // all, failing 100% of the time. Nothing in the request URL shows this, so
     // the assertion has to be on the posted JSON.
+    //
+    // All four request paths, not just the reported one: deleting the call from
+    // any single builder must fail this test.
     void anthropicRequestsDisableThinkingAndUseTheRaisedCap()
     {
         QNetworkAccessManager nam;
-        FakeAnthropicServer server;
+        FakeProviderServer server;
         AnthropicProvider p(&nam, QStringLiteral("key"));
         p.setBaseUrl(server.baseUrl());
 
@@ -270,13 +304,12 @@ private slots:
         p.analyze(QStringLiteral("system"), QStringLiteral("user"));
         QVERIFY(complete.wait(5000));
         QCOMPARE(server.requestCount(), 1);
-
         QJsonObject body = server.lastRequest();
         QCOMPARE(body["thinking"].toObject()["type"].toString(), QStringLiteral("disabled"));
         QCOMPARE(body["max_tokens"].toInt(), 4096);
 
-        // analyzeConversation() is the path the in-app advisor actually uses
-        // (AIConversation::sendRequest) and is where #1691 was reported.
+        // analyzeConversation() is the path the in-app advisor uses
+        // (AIConversation::sendRequest).
         QJsonArray messages;
         QJsonObject userMsg;
         userMsg["role"] = QStringLiteral("user");
@@ -285,36 +318,140 @@ private slots:
         p.analyzeConversation(QStringLiteral("system"), messages);
         QVERIFY(complete.wait(5000));
         QCOMPARE(server.requestCount(), 2);
+        body = server.lastRequest();
+        QCOMPARE(body["thinking"].toObject()["type"].toString(), QStringLiteral("disabled"));
+        QCOMPARE(body["max_tokens"].toInt(), 4096);
 
+        // analyzeUrl() — the recipe-wizard stage-2 extraction path.
+        p.analyzeUrl(QStringLiteral("system"), QStringLiteral("https://example.com/bag"));
+        QVERIFY(complete.wait(5000));
+        QCOMPARE(server.requestCount(), 3);
         body = server.lastRequest();
         QCOMPARE(body["thinking"].toObject()["type"].toString(), QStringLiteral("disabled"));
         QCOMPARE(body["max_tokens"].toInt(), 4096);
     }
 
-    // A 200 whose content holds blocks but no TEXT block is what #1691 looked
-    // like on the wire. Belt and braces for the fix above: if thinking ever
-    // returns (a new model default, a future feature), the user must get the
-    // truncation message and the log must name the block types — the old
-    // generic "empty response content" was indistinguishable from a refusal
-    // and cost three days of user reports to place.
-    void anthropicReportsAThinkingOnlyReplyAsTruncated()
+    // testConnection() is the diagnostic that LIED during #1691: it only checks
+    // for an HTTP error, so it passed while every analysis request failed — the
+    // user's key tested fine and the advisor was unusable. It also uses the
+    // tightest budget in the file (10 tokens), so it is the first request to
+    // break if thinking is ever re-enabled by accident.
+    void anthropicTestConnectionAlsoDisablesThinking()
     {
         QNetworkAccessManager nam;
-        FakeAnthropicServer server;
+        FakeProviderServer server;
+        AnthropicProvider p(&nam, QStringLiteral("key"));
+        p.setBaseUrl(server.baseUrl());
+
+        QSignalSpy tested(&p, &AIProvider::testResult);
+        p.testConnection();
+        QVERIFY(tested.wait(5000));
+
+        const QJsonObject body = server.lastRequest();
+        QCOMPARE(body["thinking"].toObject()["type"].toString(), QStringLiteral("disabled"));
+        QCOMPARE(body["max_tokens"].toInt(), 10);
+    }
+
+    // The branch that matters: a reply that DID produce text but was cut off.
+    //
+    // This is the case the empty-text test cannot reach, and it is the
+    // dangerous one — before the fix it was emitted as if complete, silently
+    // missing the trailing nextShot JSON block (#1054) that
+    // AIManager::parseStructuredNext reads. Reducing the production guard to
+    // `if (text.isEmpty())` must fail HERE; it does not fail the empty case,
+    // whose fixture satisfies both halves of the condition at once.
+    void anthropicReportsAPartialReplyAsTruncated()
+    {
+        QNetworkAccessManager nam;
+        FakeProviderServer server;
+        server.respondWith("{\"content\":[{\"type\":\"text\",\"text\":\"Grind fine\"}],"
+                           "\"stop_reason\":\"max_tokens\"}");
+        AnthropicProvider p(&nam, QStringLiteral("key"));
+        p.setBaseUrl(server.baseUrl());
+
+        QSignalSpy failed(&p, &AIProvider::analysisFailed);
+        QSignalSpy complete(&p, &AIProvider::analysisComplete);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Anthropic: model"));
+
+        // analyze() is machine-parsed, so its policy is Fail.
+        p.analyze(QStringLiteral("system"), QStringLiteral("user"));
+        QVERIFY(failed.wait(5000));
+        QCOMPARE(failed.size(), 1);
+        QVERIFY(failed.first().first().toString().contains(QStringLiteral("cut off")));
+        QCOMPARE(complete.size(), 0);  // must not ALSO emit the partial
+    }
+
+    // ...but the same truncated reply on the conversation path is prose the
+    // user reads, so it is shown with a notice instead of discarded.
+    void anthropicShowsAPartialConversationReply()
+    {
+        QNetworkAccessManager nam;
+        FakeProviderServer server;
+        server.respondWith("{\"content\":[{\"type\":\"text\",\"text\":\"Grind fine\"}],"
+                           "\"stop_reason\":\"max_tokens\"}");
+        AnthropicProvider p(&nam, QStringLiteral("key"));
+        p.setBaseUrl(server.baseUrl());
+
+        QSignalSpy failed(&p, &AIProvider::analysisFailed);
+        QSignalSpy complete(&p, &AIProvider::analysisComplete);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Anthropic: model"));
+
+        QJsonArray messages;
+        QJsonObject userMsg;
+        userMsg["role"] = QStringLiteral("user");
+        userMsg["content"] = QStringLiteral("why is it sour?");
+        messages.append(userMsg);
+        p.analyzeConversation(QStringLiteral("system"), messages);
+
+        QVERIFY(complete.wait(5000));
+        const QString shown = complete.first().first().toString();
+        QVERIFY2(shown.startsWith(QStringLiteral("Grind fine")), qPrintable(shown));
+        QVERIFY2(shown.contains(QStringLiteral("cut off")), qPrintable(shown));
+        QCOMPARE(failed.size(), 0);
+    }
+
+    // A 200 whose content holds blocks but NO text block is what #1691 looked
+    // like on the wire. Guards the block-type logging that makes such a reply
+    // placeable from the log rather than indistinguishable from a refusal.
+    void anthropicReportsATextlessReply()
+    {
+        QNetworkAccessManager nam;
+        FakeProviderServer server;
         server.respondWith(
             "{\"content\":[{\"type\":\"thinking\",\"thinking\":\"\"}],\"stop_reason\":\"max_tokens\"}");
         AnthropicProvider p(&nam, QStringLiteral("key"));
         p.setBaseUrl(server.baseUrl());
 
         QSignalSpy failed(&p, &AIProvider::analysisFailed);
-        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Anthropic: stop_reason"));
+        QSignalSpy complete(&p, &AIProvider::analysisComplete);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Anthropic: model"));
 
         p.analyze(QStringLiteral("system"), QStringLiteral("user"));
         QVERIFY(failed.wait(5000));
         QCOMPARE(failed.size(), 1);
-        const QString message = failed.first().first().toString();
-        QVERIFY2(message.contains(QStringLiteral("cut off")),
-                 qPrintable(QStringLiteral("expected the truncation message, got: ") + message));
+        QVERIFY(failed.first().first().toString().contains(QStringLiteral("cut off")));
+        QCOMPARE(complete.size(), 0);
+    }
+
+    // stop_reason "pause_turn" means the API paused a server-tool turn and the
+    // response must be fed back to continue — its text is partial by
+    // definition. analyzeUrl() attaches web_fetch, so this path can reach it.
+    void anthropicTreatsPauseTurnAsUnfinished()
+    {
+        QNetworkAccessManager nam;
+        FakeProviderServer server;
+        server.respondWith("{\"content\":[{\"type\":\"text\",\"text\":\"Fetching...\"}],"
+                           "\"stop_reason\":\"pause_turn\"}");
+        AnthropicProvider p(&nam, QStringLiteral("key"));
+        p.setBaseUrl(server.baseUrl());
+
+        QSignalSpy failed(&p, &AIProvider::analysisFailed);
+        QSignalSpy complete(&p, &AIProvider::analysisComplete);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression("Anthropic: model"));
+
+        p.analyzeUrl(QStringLiteral("system"), QStringLiteral("https://example.com/bag"));
+        QVERIFY(failed.wait(5000));
+        QCOMPARE(complete.size(), 0);
     }
 
     // The truncation branch must not swallow good replies: stop_reason
@@ -322,16 +459,110 @@ private slots:
     void anthropicCompleteReplyStillSucceeds()
     {
         QNetworkAccessManager nam;
-        FakeAnthropicServer server;
+        FakeProviderServer server;
         server.respondWith(
             "{\"content\":[{\"type\":\"text\",\"text\":\"Grind finer.\"}],\"stop_reason\":\"end_turn\"}");
         AnthropicProvider p(&nam, QStringLiteral("key"));
         p.setBaseUrl(server.baseUrl());
 
         QSignalSpy complete(&p, &AIProvider::analysisComplete);
+        QSignalSpy failed(&p, &AIProvider::analysisFailed);
         p.analyze(QStringLiteral("system"), QStringLiteral("user"));
         QVERIFY(complete.wait(5000));
         QCOMPARE(complete.first().first().toString(), QStringLiteral("Grind finer."));
+        QCOMPARE(failed.size(), 0);
+    }
+
+    // The other four providers' truncation detection, which shipped untested —
+    // and on Gemini, broken: its finishReason was read AFTER an
+    // `parts.isEmpty()` early return, so a candidate that stopped with nothing
+    // to show never reached the check. Each predicate is a bare string compare
+    // against a different vendor spelling, with no compiler or linter signal if
+    // it is wrong.
+    void otherProvidersReportTruncation_data()
+    {
+        QTest::addColumn<QString>("provider");
+        QTest::addColumn<QByteArray>("truncatedBody");
+        QTest::addColumn<QByteArray>("goodBody");
+        QTest::addColumn<QString>("warningPrefix");
+
+        QTest::newRow("openai-chat")
+            << QStringLiteral("openai")
+            << QByteArray("{\"choices\":[{\"finish_reason\":\"length\","
+                          "\"message\":{\"content\":\"Grind fine\"}}]}")
+            << QByteArray("{\"choices\":[{\"finish_reason\":\"stop\","
+                          "\"message\":{\"content\":\"Grind finer.\"}}]}")
+            << QStringLiteral("OpenAI: model");
+
+        // No content key at all — the shape that made this branch unreachable.
+        QTest::newRow("gemini-thinking-ate-the-budget")
+            << QStringLiteral("gemini")
+            << QByteArray("{\"candidates\":[{\"finishReason\":\"MAX_TOKENS\"}]}")
+            << QByteArray("{\"candidates\":[{\"finishReason\":\"STOP\",\"content\":"
+                          "{\"parts\":[{\"text\":\"Grind finer.\"}]}}]}")
+            << QStringLiteral("Gemini: model");
+
+        QTest::newRow("openrouter")
+            << QStringLiteral("openrouter")
+            << QByteArray("{\"choices\":[{\"finish_reason\":\"length\","
+                          "\"message\":{\"content\":\"Grind fine\"}}]}")
+            << QByteArray("{\"choices\":[{\"finish_reason\":\"stop\","
+                          "\"message\":{\"content\":\"Grind finer.\"}}]}")
+            << QStringLiteral("OpenRouter: model");
+
+        QTest::newRow("ollama")
+            << QStringLiteral("ollama")
+            << QByteArray("{\"done_reason\":\"length\",\"message\":{\"content\":\"Grind fine\"}}")
+            << QByteArray("{\"done_reason\":\"stop\",\"message\":{\"content\":\"Grind finer.\"}}")
+            << QStringLiteral("Ollama: model");
+    }
+
+    void otherProvidersReportTruncation()
+    {
+        QFETCH(QString, provider);
+        QFETCH(QByteArray, truncatedBody);
+        QFETCH(QByteArray, goodBody);
+        QFETCH(QString, warningPrefix);
+
+        QNetworkAccessManager nam;
+        FakeProviderServer server;
+
+        // Ollama takes its endpoint as a constructor arg; the rest use setBaseUrl.
+        std::unique_ptr<AIProvider> p;
+        if (provider == QLatin1String("openai")) {
+            auto* o = new OpenAIProvider(&nam, QStringLiteral("key"));
+            o->setBaseUrl(server.baseUrl());
+            p.reset(o);
+        } else if (provider == QLatin1String("gemini")) {
+            auto* g = new GeminiProvider(&nam, QStringLiteral("key"));
+            g->setBaseUrl(server.baseUrl());
+            p.reset(g);
+        } else if (provider == QLatin1String("openrouter")) {
+            auto* r = new OpenRouterProvider(&nam, QStringLiteral("key"), QStringLiteral("some/model"));
+            r->setBaseUrl(server.baseUrl());
+            p.reset(r);
+        } else {
+            p.reset(new OllamaProvider(&nam, server.baseUrl(), QStringLiteral("llama3")));
+        }
+
+        // Truncated → failure on the machine-parsed analyze() path.
+        server.respondWith(truncatedBody);
+        QSignalSpy failed(p.get(), &AIProvider::analysisFailed);
+        QSignalSpy complete(p.get(), &AIProvider::analysisComplete);
+        QTest::ignoreMessage(QtWarningMsg, QRegularExpression(warningPrefix));
+        p->analyze(QStringLiteral("system"), QStringLiteral("user"));
+        QVERIFY(failed.wait(5000));
+        QVERIFY2(failed.first().first().toString().contains(QStringLiteral("cut off")),
+                 qPrintable(failed.first().first().toString()));
+        QCOMPARE(complete.size(), 0);
+
+        // ...and a complete reply is still emitted, so the new guard can't
+        // start swallowing good answers unnoticed.
+        server.respondWith(goodBody);
+        p->analyze(QStringLiteral("system"), QStringLiteral("user"));
+        QVERIFY(complete.wait(5000));
+        QCOMPARE(complete.first().first().toString(), QStringLiteral("Grind finer."));
+        QCOMPARE(failed.size(), 1);  // still just the first one
     }
 };
 


### PR DESCRIPTION
Fixes #1691.

## The bug

`AnthropicProvider` sends `max_tokens` with **no `thinking` field**. That default is not stable across models:

| model | `thinking` omitted |
|---|---|
| `claude-sonnet-4-6` | no thinking |
| `claude-sonnet-5` | **adaptive thinking** |

`max_tokens` bounds thinking *and* response text together, so on Sonnet 5 the whole 1024-token budget went to a thinking block. The reply came back **HTTP 200, `content` non-empty, `stop_reason: "max_tokens"`, zero `text` blocks** — landing on the `Anthropic returned empty response content` path.

Every request failed, for every user who picked Sonnet 5 (added in #1445). Sonnet 4.6 users were unaffected, which is why it took a user report to surface.

The reporter's log shows 12–15 s between request and failure across three separate days — tokens *were* generated, just not as text.

`testConnection()` has the same gap and only checks for an HTTP error, so **it passed while every real request failed** — the key tested fine and the advisor was unusable.

## Changes

**1. Turn thinking off explicitly** on all three Anthropic request builders plus `testConnection()`. Same reason the OpenAI and Gemini paths already force reasoning/thinking off: dial-in advice needs little chain-of-thought, and hidden thinking tokens bill at the output rate. Anthropic was the one that never got the equivalent, then Sonnet 5 flipped the default under it.

**2. Raise the output cap 1024 → 4096** across all providers (shared `AIProvider::MAX_OUTPUT_TOKENS`). 1024 was too tight regardless of thinking — a dial-in reply plus the trailing fenced `nextShot` JSON block (#1054) lands right at that edge. The cap is a ceiling, not a reservation, so this costs nothing unless the model actually writes more.

**3. Report truncation instead of hiding it.** No provider inspected its stop/finish reason, so a capped reply was emitted *as if complete* — silently dropping the `nextShot` block with nothing in the log. All four cloud providers now check (Anthropic `stop_reason`, OpenAI `finish_reason` + `incomplete_details`, Gemini `finishReason`, OpenRouter `finish_reason`) and surface a shared message. This matters most on OpenRouter, whose model is a free-text user string and can point at a reasoning model that eats the cap the same way.

The Anthropic path also logs the **block types** on any text-less reply: `content` can be non-empty while carrying no text block, and the generic message alone made that indistinguishable from a refusal.

## Tests

`tst_aiproviders` gains a canned-response server (same shape as `FakeBeanBaseServer`) that captures the posted **body** — an absent field in the request JSON is invisible to the existing pure catalog tests.

- request shape: `thinking.type == "disabled"` and `max_tokens == 4096` on both `analyze()` and `analyzeConversation()` (the path the in-app advisor actually uses)
- a thinking-only reply is reported as truncated, not as the generic empty-content error
- a complete reply still succeeds — the truncation branch doesn't swallow good replies

Full suite via Qt Creator: **108 passed, 0 failed, 0 skipped, no warnings**. Build clean, 0 warnings.

Note `get_test_details` reports per-CTest-binary, not per-function, so the three new functions don't resolve by name — they ran inside `tst_aiproviders`, which rebuilt after the edits and passed.

## Not covered

Ollama sets no cap at all (unbounded) and is left alone.

No user-visible feature change, so no wiki manual edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)